### PR TITLE
Add nix-clawdbot plugin pointers to skill metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,12 @@
 - Web: prevent skill OG text overflow outside the card.
 - Registry: make SoulHub auto-seed idempotent and non-user-owned.
 
-## 0.1.0 - 2026-01-07
+## 0.0.6 - 2026-01-07
+
 
 ### Added
 - API: v1 public REST endpoints with rate limits, raw file fetch, and OpenAPI spec.
 - Docs: `docs/api.md` and `DEPRECATIONS.md` for the v1 cutover plan.
-- Registry: GitHub App backs up published skills to `clawdbot/skills` (thanks @thewilloftheshadow, #5).
 
 ### Changed
 - CLI: publish now uses single multipart `POST /api/v1/skills`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Web: stabilize skill OG image generation on server runtimes.
 - Web: prevent skill OG text overflow outside the card.
 - Registry: make SoulHub auto-seed idempotent and non-user-owned.
+- Registry: keep GitHub backup state + publish backups intact (thanks @joshp123, #1).
+- CLI/Registry: restore fork lineage on sync + clamp bulk list queries (thanks @joshp123, #1).
 
 ## 0.0.6 - 2026-01-07
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,52 @@ This writes `JWT_PRIVATE_KEY` + `JWKS` to the deployment and prints values for y
 - `JWT_PRIVATE_KEY` / `JWKS`: Convex Auth keys.
 - `OPENAI_API_KEY`: embeddings for search + indexing.
 
+## Nix plugins (nixmode skills)
+
+ClawdHub can store a nix-clawdbot plugin pointer in SKILL frontmatter so the registry knows which
+Nix package bundle to install. A nix plugin is different from a regular skill pack: it bundles the
+skill pack, the CLI binary, and its config flags/requirements together.
+
+Add this to `SKILL.md`:
+
+```yaml
+---
+name: peekaboo
+description: Capture and automate macOS UI with the Peekaboo CLI.
+metadata: {"clawdbot":{"nix":{"plugin":"github:clawdbot/nix-steipete-tools?dir=tools/peekaboo","systems":["aarch64-darwin"]}}}
+---
+```
+
+Install via nix-clawdbot:
+
+```nix
+programs.clawdbot.plugins = [
+  { source = "github:clawdbot/nix-steipete-tools?dir=tools/peekaboo"; }
+];
+```
+
+You can also declare config requirements + an example snippet:
+
+```yaml
+---
+name: padel
+description: Check padel court availability and manage bookings via Playtomic.
+metadata: {"clawdbot":{"config":{"requiredEnv":["PADEL_AUTH_FILE"],"stateDirs":[".config/padel"],"example":"config = { env = { PADEL_AUTH_FILE = \\\"/run/agenix/padel-auth\\\"; }; };"}}}
+---
+```
+
+To show CLI help (recommended for nix plugins), include the `cli --help` output:
+
+```yaml
+---
+name: padel
+description: Check padel court availability and manage bookings via Playtomic.
+metadata: {"clawdbot":{"cliHelp":"padel --help\\nUsage: padel [command]\\n"}}
+---
+```
+
+`metadata.clawdbot` is preferred, but `metadata.clawdis` is accepted as an alias for compatibility.
+
 ## Scripts
 
 ```bash

--- a/biome.json
+++ b/biome.json
@@ -12,7 +12,9 @@
       "!**/convex/_generated",
       "!**/src/routeTree.gen.ts",
       "!**/.tanstack",
-      "!**/public"
+      "!**/public",
+      "!**/.devenv",
+      "!**/.devenv"
     ]
   },
   "assist": { "actions": { "source": { "organizeImports": "on" } } },

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "clawdhub",

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as auth from "../auth.js";
 import type * as comments from "../comments.js";
 import type * as crons from "../crons.js";
+import type * as devSeed from "../devSeed.js";
 import type * as downloads from "../downloads.js";
 import type * as githubBackups from "../githubBackups.js";
 import type * as githubBackupsNode from "../githubBackupsNode.js";
@@ -60,6 +61,7 @@ declare const fullApi: ApiFromModules<{
   auth: typeof auth;
   comments: typeof comments;
   crons: typeof crons;
+  devSeed: typeof devSeed;
   downloads: typeof downloads;
   githubBackups: typeof githubBackups;
   githubBackupsNode: typeof githubBackupsNode;

--- a/convex/devSeed.ts
+++ b/convex/devSeed.ts
@@ -1,0 +1,429 @@
+import { v } from 'convex/values'
+import { internal } from './_generated/api'
+import { internalAction, internalMutation } from './_generated/server'
+import { EMBEDDING_DIMENSIONS } from './lib/embeddings'
+import { parseClawdisMetadata, parseFrontmatter } from './lib/skills'
+
+type SeedSkillSpec = {
+  slug: string
+  displayName: string
+  summary: string
+  version: string
+  metadata: Record<string, unknown>
+  rawSkillMd: string
+}
+
+const SEED_SKILLS: SeedSkillSpec[] = [
+  {
+    slug: 'padel',
+    displayName: 'Padel',
+    summary: 'Check padel court availability and manage bookings via Playtomic.',
+    version: '0.1.0',
+    metadata: {
+      clawdbot: {
+        nix: {
+          plugin: 'github:joshp123/padel-cli',
+          systems: ['aarch64-darwin', 'x86_64-linux'],
+        },
+        config: {
+          requiredEnv: ['PADEL_AUTH_FILE'],
+          stateDirs: ['.config/padel'],
+          example:
+            'config = { env = { PADEL_AUTH_FILE = "/run/agenix/padel-auth"; }; stateDirs = [ ".config/padel" ]; };',
+        },
+        cliHelp: `Padel CLI for availability
+
+Usage:
+  padel [command]
+
+Available Commands:
+  auth         Manage authentication
+  availability Show availability for a club on a date
+  book         Book a court
+  bookings     Manage bookings history
+  search       Search for available courts
+  venues       Manage saved venues
+
+Flags:
+  -h, --help   help for padel
+  --json       Output JSON
+
+Use "padel [command] --help" for more information about a command.
+`,
+      },
+    },
+    rawSkillMd: `---
+name: padel
+description: Check padel court availability and manage bookings via the padel CLI.
+---
+
+# Padel Booking Skill
+
+## CLI
+
+\`\`\`bash
+padel  # On PATH (clawdbot plugin bundle)
+\`\`\`
+
+## Venues
+
+Use the configured venue list in order of preference. If no venues are configured, ask for a venue name or location.
+
+## Commands
+
+### Check next booking
+\`\`\`bash
+padel bookings list 2>&1 | head -3
+\`\`\`
+
+### Search availability
+\`\`\`bash
+padel search --venues VENUE1,VENUE2 --date YYYY-MM-DD --time 09:00-12:00
+\`\`\`
+
+## Response guidelines
+
+- Keep responses concise.
+- Use 🎾 emoji.
+- End with a call to action.
+
+## Authorization
+
+Only the authorized booker can confirm bookings. If the requester is not authorized, ask the authorized user to confirm.
+`,
+  },
+  {
+    slug: 'gohome',
+    displayName: 'GoHome',
+    summary: 'Operate GoHome via gRPC discovery, metrics, and Grafana dashboards.',
+    version: '0.1.0',
+    metadata: {
+      clawdbot: {
+        nix: {
+          plugin: 'github:joshp123/gohome',
+          systems: ['x86_64-linux', 'aarch64-linux'],
+        },
+        config: {
+          requiredEnv: ['GOHOME_GRPC_ADDR', 'GOHOME_HTTP_BASE'],
+          example:
+            'config = { env = { GOHOME_GRPC_ADDR = "gohome:9000"; GOHOME_HTTP_BASE = "http://gohome:8080"; }; };',
+        },
+        cliHelp: `GoHome CLI
+
+Usage:
+  gohome-cli [command]
+
+Available Commands:
+  services   List registered services
+  plugins    Inspect loaded plugins
+  methods    List RPC methods
+  call       Call an RPC method
+  roborock   Manage roborock devices
+  tado       Manage tado zones
+
+Flags:
+  --grpc-addr string   gRPC endpoint (host:port)
+  -h, --help           help for gohome-cli
+`,
+      },
+    },
+    rawSkillMd: `---
+name: gohome
+description: Use when Clawdbot needs to test or operate GoHome via gRPC discovery, metrics, and Grafana.
+---
+
+# GoHome Skill
+
+## Quick start
+
+\`\`\`bash
+export GOHOME_HTTP_BASE="http://gohome:8080"
+export GOHOME_GRPC_ADDR="gohome:9000"
+\`\`\`
+
+## CLI
+
+\`\`\`bash
+gohome-cli services
+\`\`\`
+
+## Discovery flow (read-only)
+
+1) List plugins.
+2) Describe a plugin.
+3) List RPC methods.
+4) Call a read-only RPC.
+
+## Metrics validation
+
+\`\`\`bash
+curl -s "\${GOHOME_HTTP_BASE}/gohome/metrics" | rg -n "gohome_"
+\`\`\`
+
+## Stateful actions
+
+Only call write RPCs after explicit user approval.
+`,
+  },
+  {
+    slug: 'xuezh',
+    displayName: 'Xuezh',
+    summary: 'Teach Mandarin with the xuezh engine for review, speaking, and audits.',
+    version: '0.1.0',
+    metadata: {
+      clawdbot: {
+        nix: {
+          plugin: 'github:joshp123/xuezh',
+          systems: ['aarch64-darwin', 'x86_64-linux'],
+        },
+        config: {
+          requiredEnv: ['XUEZH_AZURE_SPEECH_KEY_FILE', 'XUEZH_AZURE_SPEECH_REGION'],
+          stateDirs: ['.config/xuezh'],
+          example:
+            'config = { env = { XUEZH_AZURE_SPEECH_KEY_FILE = "/run/agenix/xuezh-azure-speech-key"; XUEZH_AZURE_SPEECH_REGION = "westeurope"; }; stateDirs = [ ".config/xuezh" ]; };',
+        },
+        cliHelp: `xuezh - Chinese learning engine
+
+Usage:
+  xuezh [command]
+
+Available Commands:
+  snapshot  Fetch learner state snapshot
+  review    Review due items
+  audio     Process speech audio
+  items     Manage learning items
+  events    Log learning events
+
+Flags:
+  -h, --help   help for xuezh
+  --json       Output JSON
+`,
+      },
+    },
+    rawSkillMd: `---
+name: xuezh
+description: Teach Mandarin using the xuezh engine for review, speaking, and audits.
+---
+
+# Xuezh Skill
+
+## Contract
+
+Use the xuezh CLI exactly as specified. If a command is missing, ask for implementation instead of guessing.
+
+## Default loop
+
+1) Call \`xuezh snapshot\`.
+2) Pick a tiny plan (1-2 bullets).
+3) Run a short activity.
+4) Log outcomes.
+
+## CLI examples
+
+\`\`\`bash
+xuezh snapshot --profile default
+xuezh review next --limit 10
+xuezh audio process-voice --file ./utterance.wav
+\`\`\`
+`,
+  },
+]
+
+function injectMetadata(rawSkillMd: string, metadata: Record<string, unknown>) {
+  const frontmatterEnd = rawSkillMd.indexOf('\n---', 3)
+  if (frontmatterEnd === -1) return rawSkillMd
+  return `${rawSkillMd.slice(0, frontmatterEnd)}\nmetadata: ${JSON.stringify(
+    metadata,
+  )}${rawSkillMd.slice(frontmatterEnd)}`
+}
+
+export const seedNixSkills = internalAction({
+  args: {
+    reset: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const results = []
+
+    for (const spec of SEED_SKILLS) {
+      const skillMd = injectMetadata(spec.rawSkillMd, spec.metadata)
+      const frontmatter = parseFrontmatter(skillMd)
+      const clawdis = parseClawdisMetadata(frontmatter)
+      const storageId = await ctx.storage.store(new Blob([skillMd], { type: 'text/markdown' }))
+
+      const result = await ctx.runMutation(internal.devSeed.seedSkillMutation, {
+        reset: args.reset,
+        storageId,
+        metadata: spec.metadata,
+        frontmatter,
+        clawdis,
+        skillMd,
+        slug: spec.slug,
+        displayName: spec.displayName,
+        summary: spec.summary,
+        version: spec.version,
+      })
+
+      results.push({ slug: spec.slug, ...result })
+    }
+
+    return { ok: true, results }
+  },
+})
+
+export const seedPadelSkill = internalAction({
+  args: {
+    reset: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const spec = SEED_SKILLS.find((entry) => entry.slug === 'padel')
+    if (!spec) throw new Error('padel seed spec missing')
+
+    const skillMd = injectMetadata(spec.rawSkillMd, spec.metadata)
+    const frontmatter = parseFrontmatter(skillMd)
+    const clawdis = parseClawdisMetadata(frontmatter)
+    const storageId = await ctx.storage.store(new Blob([skillMd], { type: 'text/markdown' }))
+
+    return ctx.runMutation(internal.devSeed.seedSkillMutation, {
+      reset: args.reset,
+      storageId,
+      metadata: spec.metadata,
+      frontmatter,
+      clawdis,
+      skillMd,
+      slug: spec.slug,
+      displayName: spec.displayName,
+      summary: spec.summary,
+      version: spec.version,
+    })
+  },
+})
+
+export const seedSkillMutation = internalMutation({
+  args: {
+    reset: v.optional(v.boolean()),
+    storageId: v.id('_storage'),
+    metadata: v.any(),
+    frontmatter: v.any(),
+    clawdis: v.any(),
+    skillMd: v.string(),
+    slug: v.string(),
+    displayName: v.string(),
+    summary: v.optional(v.string()),
+    version: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query('skills')
+      .withIndex('by_slug', (q) => q.eq('slug', args.slug))
+      .unique()
+
+    if (existing && !args.reset) {
+      return { ok: true, skipped: true, skillId: existing._id }
+    }
+
+    if (existing && args.reset) {
+      const versions = await ctx.db
+        .query('skillVersions')
+        .withIndex('by_skill', (q) => q.eq('skillId', existing._id))
+        .collect()
+      for (const version of versions) {
+        await ctx.db.delete(version._id)
+      }
+      const embeddings = await ctx.db
+        .query('skillEmbeddings')
+        .withIndex('by_skill', (q) => q.eq('skillId', existing._id))
+        .collect()
+      for (const embedding of embeddings) {
+        await ctx.db.delete(embedding._id)
+      }
+      await ctx.db.delete(existing._id)
+    }
+
+    const now = Date.now()
+    const existingUsers = await ctx.db
+      .query('users')
+      .withIndex('handle', (q) => q.eq('handle', 'local'))
+      .collect()
+
+    const userId =
+      existingUsers[0]?._id ??
+      (await ctx.db.insert('users', {
+        handle: 'local',
+        displayName: 'Local Dev',
+        role: 'admin',
+        createdAt: now,
+        updatedAt: now,
+      }))
+
+    const skillId = await ctx.db.insert('skills', {
+      slug: args.slug,
+      displayName: args.displayName,
+      summary: args.summary,
+      ownerUserId: userId,
+      latestVersionId: undefined,
+      tags: {},
+      softDeletedAt: undefined,
+      badges: { redactionApproved: undefined },
+      stats: {
+        downloads: 0,
+        installsCurrent: 0,
+        installsAllTime: 0,
+        stars: 0,
+        versions: 0,
+        comments: 0,
+      },
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    const versionId = await ctx.db.insert('skillVersions', {
+      skillId,
+      version: args.version,
+      changelog: 'Seeded local version for screenshots.',
+      files: [
+        {
+          path: 'SKILL.md',
+          size: args.skillMd.length,
+          storageId: args.storageId,
+          sha256: 'seeded',
+          contentType: 'text/markdown',
+        },
+      ],
+      parsed: {
+        frontmatter: args.frontmatter,
+        metadata: args.metadata,
+        clawdis: args.clawdis,
+      },
+      createdBy: userId,
+      createdAt: now,
+      softDeletedAt: undefined,
+    })
+
+    const embeddingId = await ctx.db.insert('skillEmbeddings', {
+      skillId,
+      versionId,
+      ownerId: userId,
+      embedding: Array.from({ length: EMBEDDING_DIMENSIONS }, () => 0),
+      isLatest: true,
+      isApproved: true,
+      visibility: 'latest-approved',
+      updatedAt: now,
+    })
+
+    await ctx.db.patch(skillId, {
+      latestVersionId: versionId,
+      tags: { latest: versionId },
+      stats: {
+        downloads: 0,
+        installsCurrent: 0,
+        installsAllTime: 0,
+        stars: 0,
+        versions: 1,
+        comments: 0,
+      },
+      updatedAt: now,
+    })
+
+    return { ok: true, skillId, versionId, embeddingId }
+  },
+})

--- a/convex/httpApiV1.ts
+++ b/convex/httpApiV1.ts
@@ -558,6 +558,7 @@ async function parseMultipartPublish(
     files.push({ path, size, storageId, sha256, contentType })
   }
 
+  const forkOf = payload.forkOf && typeof payload.forkOf === 'object' ? payload.forkOf : undefined
   const body = {
     slug: payload.slug,
     displayName: payload.displayName,
@@ -566,7 +567,7 @@ async function parseMultipartPublish(
     tags: Array.isArray(payload.tags) ? payload.tags : undefined,
     ...(payload.source ? { source: payload.source } : {}),
     files,
-    ...(payload.forkOf === undefined ? {} : { forkOf: payload.forkOf }),
+    ...(forkOf ? { forkOf } : {}),
   }
 
   return parsePublishBody(body)
@@ -753,8 +754,8 @@ function toOptionalNumber(value: string | null) {
 }
 
 async function sha256Hex(bytes: Uint8Array) {
-  const normalized = new Uint8Array(bytes)
-  const digest = await crypto.subtle.digest('SHA-256', normalized.buffer)
+  const buffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+  const digest = await crypto.subtle.digest('SHA-256', buffer)
   return toHex(new Uint8Array(digest))
 }
 

--- a/convex/lib/skills.test.ts
+++ b/convex/lib/skills.test.ts
@@ -107,6 +107,35 @@ describe('skills utils', () => {
     expect(clawdis?.requires?.anyBins).toEqual(['rg', 'fd'])
   })
 
+  it('parses clawdbot metadata with nix plugin pointer', () => {
+    const frontmatter = parseFrontmatter(
+      `---\nmetadata: {"clawdbot":{"nix":{"plugin":"github:clawdbot/nix-steipete-tools?dir=tools/peekaboo","systems":["aarch64-darwin"]}}}\n---\nBody`,
+    )
+    const clawdis = parseClawdisMetadata(frontmatter)
+    expect(clawdis?.nix?.plugin).toBe('github:clawdbot/nix-steipete-tools?dir=tools/peekaboo')
+    expect(clawdis?.nix?.systems).toEqual(['aarch64-darwin'])
+  })
+
+  it('parses clawdbot config requirements with example', () => {
+    const frontmatter = parseFrontmatter(
+      `---\nmetadata: {"clawdbot":{"config":{"requiredEnv":["PADEL_AUTH_FILE"],"stateDirs":[".config/padel"],"example":"config = { env = { PADEL_AUTH_FILE = \\"/run/agenix/padel-auth\\"; }; };"}}}\n---\nBody`,
+    )
+    const clawdis = parseClawdisMetadata(frontmatter)
+    expect(clawdis?.config?.requiredEnv).toEqual(['PADEL_AUTH_FILE'])
+    expect(clawdis?.config?.stateDirs).toEqual(['.config/padel'])
+    expect(clawdis?.config?.example).toBe(
+      'config = { env = { PADEL_AUTH_FILE = "/run/agenix/padel-auth"; }; };',
+    )
+  })
+
+  it('parses cli help output', () => {
+    const frontmatter = parseFrontmatter(
+      `---\nmetadata: {"clawdbot":{"cliHelp":"padel --help\\nUsage: padel [command]\\n"}}\n---\nBody`,
+    )
+    const clawdis = parseClawdisMetadata(frontmatter)
+    expect(clawdis?.cliHelp).toBe('padel --help\nUsage: padel [command]')
+  })
+
   it('sanitizes file paths', () => {
     expect(sanitizePath('good/file.md')).toBe('good/file.md')
     expect(sanitizePath('../bad/file.md')).toBeNull()

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -306,12 +306,6 @@ const userSkillRootInstalls = defineTable({
   .index('by_user_skill', ['userId', 'skillId'])
   .index('by_skill', ['skillId'])
 
-const githubBackupSyncState = defineTable({
-  key: v.string(),
-  cursor: v.optional(v.string()),
-  updatedAt: v.number(),
-}).index('by_key', ['key'])
-
 export default defineSchema({
   ...authTables,
   users,
@@ -330,7 +324,6 @@ export default defineSchema({
   auditLogs,
   apiTokens,
   rateLimits,
-  githubBackupSyncState,
   userSyncRoots,
   userSkillInstalls,
   userSkillRootInstalls,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -268,6 +268,12 @@ const rateLimits = defineTable({
   .index('by_key_window', ['key', 'windowStart'])
   .index('by_key', ['key'])
 
+const githubBackupSyncState = defineTable({
+  key: v.string(),
+  cursor: v.optional(v.string()),
+  updatedAt: v.number(),
+}).index('by_key', ['key'])
+
 const userSyncRoots = defineTable({
   userId: v.id('users'),
   rootId: v.string(),
@@ -324,6 +330,7 @@ export default defineSchema({
   auditLogs,
   apiTokens,
   rateLimits,
+  githubBackupSyncState,
   userSyncRoots,
   userSkillInstalls,
   userSkillRootInstalls,

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -19,7 +19,6 @@ type ReadmeResult = { path: string; text: string }
 type FileTextResult = { path: string; text: string; size: number; sha256: string }
 
 const MAX_DIFF_FILE_BYTES = 200 * 1024
-const MAX_LIST_LIMIT = 50
 
 export const getBySlug = query({
   args: { slug: v.string() },
@@ -113,34 +112,6 @@ export const list = query({
   },
 })
 
-export const listPublicPage = query({
-  args: {
-    cursor: v.optional(v.string()),
-    limit: v.optional(v.number()),
-  },
-  handler: async (ctx, args) => {
-    const limit = clampInt(args.limit ?? 24, 1, MAX_LIST_LIMIT)
-    const { page, isDone, continueCursor } = await ctx.db
-      .query('skills')
-      .withIndex('by_updated', (q) => q)
-      .order('desc')
-      .paginate({ cursor: args.cursor ?? null, numItems: limit })
-
-    const items: Array<{
-      skill: Doc<'skills'>
-      latestVersion: Doc<'skillVersions'> | null
-    }> = []
-
-    for (const skill of page) {
-      if (skill.softDeletedAt) continue
-      const latestVersion = skill.latestVersionId ? await ctx.db.get(skill.latestVersionId) : null
-      items.push({ skill, latestVersion })
-    }
-
-    return { items, nextCursor: isDone ? null : continueCursor }
-  },
-})
-
 export const listVersions = query({
   args: { skillId: v.id('skills'), limit: v.optional(v.number()) },
   handler: async (ctx, args) => {
@@ -150,24 +121,6 @@ export const listVersions = query({
       .withIndex('by_skill', (q) => q.eq('skillId', args.skillId))
       .order('desc')
       .take(limit)
-  },
-})
-
-export const listVersionsPage = query({
-  args: {
-    skillId: v.id('skills'),
-    cursor: v.optional(v.string()),
-    limit: v.optional(v.number()),
-  },
-  handler: async (ctx, args) => {
-    const limit = clampInt(args.limit ?? 20, 1, MAX_LIST_LIMIT)
-    const { page, isDone, continueCursor } = await ctx.db
-      .query('skillVersions')
-      .withIndex('by_skill', (q) => q.eq('skillId', args.skillId))
-      .order('desc')
-      .paginate({ cursor: args.cursor ?? null, numItems: limit })
-    const items = page.filter((version) => !version.softDeletedAt)
-    return { items, nextCursor: isDone ? null : continueCursor }
   },
 })
 
@@ -701,11 +654,6 @@ function visibilityFor(isLatest: boolean, isApproved: boolean) {
   if (isLatest) return 'latest'
   if (isApproved) return 'archived-approved'
   return 'archived'
-}
-
-function clampInt(value: number, min: number, max: number) {
-  const rounded = Number.isFinite(value) ? Math.round(value) : min
-  return Math.min(max, Math.max(min, rounded))
 }
 
 async function findCanonicalSkillForFingerprint(

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -20,6 +20,8 @@ type FileTextResult = { path: string; text: string; size: number; sha256: string
 
 const MAX_DIFF_FILE_BYTES = 200 * 1024
 const MAX_LIST_LIMIT = 50
+const MAX_LIST_BULK_LIMIT = 200
+const MAX_LIST_TAKE = 1000
 
 export const getBySlug = query({
   args: { slug: v.string() },
@@ -87,13 +89,14 @@ export const list = query({
     limit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const limit = args.limit ?? 24
+    const limit = clampInt(args.limit ?? 24, 1, MAX_LIST_BULK_LIMIT)
+    const takeLimit = Math.min(limit * 5, MAX_LIST_TAKE)
     if (args.batch) {
       const entries = await ctx.db
         .query('skills')
         .withIndex('by_batch', (q) => q.eq('batch', args.batch))
         .order('desc')
-        .take(limit * 5)
+        .take(takeLimit)
       return entries.filter((skill) => !skill.softDeletedAt).slice(0, limit)
     }
     const ownerUserId = args.ownerUserId
@@ -102,13 +105,10 @@ export const list = query({
         .query('skills')
         .withIndex('by_owner', (q) => q.eq('ownerUserId', ownerUserId))
         .order('desc')
-        .take(limit * 5)
+        .take(takeLimit)
       return entries.filter((skill) => !skill.softDeletedAt).slice(0, limit)
     }
-    const entries = await ctx.db
-      .query('skills')
-      .order('desc')
-      .take(limit * 5)
+    const entries = await ctx.db.query('skills').order('desc').take(takeLimit)
     return entries.filter((skill) => !skill.softDeletedAt).slice(0, limit)
   },
 })
@@ -120,25 +120,23 @@ export const listWithLatest = query({
     limit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const limit = args.limit ?? 24
+    const limit = clampInt(args.limit ?? 24, 1, MAX_LIST_BULK_LIMIT)
+    const takeLimit = Math.min(limit * 5, MAX_LIST_TAKE)
     let entries: Doc<'skills'>[] = []
     if (args.batch) {
       entries = await ctx.db
         .query('skills')
         .withIndex('by_batch', (q) => q.eq('batch', args.batch))
         .order('desc')
-        .take(limit * 5)
+        .take(takeLimit)
     } else if (args.ownerUserId) {
       entries = await ctx.db
         .query('skills')
         .withIndex('by_owner', (q) => q.eq('ownerUserId', args.ownerUserId))
         .order('desc')
-        .take(limit * 5)
+        .take(takeLimit)
     } else {
-      entries = await ctx.db
-        .query('skills')
-        .order('desc')
-        .take(limit * 5)
+      entries = await ctx.db.query('skills').order('desc').take(takeLimit)
     }
 
     const filtered = entries.filter((skill) => !skill.softDeletedAt).slice(0, limit)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -61,7 +61,10 @@ read_when:
 From SKILL.md frontmatter + AgentSkills + Clawdis extensions:
 - `name`, `description`, `homepage`, `website`, `url`, `emoji`
 - `metadata.clawdis`: `always`, `skillKey`, `primaryEnv`, `emoji`, `homepage`, `os`,
-  `requires` (`bins`, `anyBins`, `env`, `config`), `install[]`
+  `requires` (`bins`, `anyBins`, `env`, `config`), `install[]`, `nix` (`plugin`, `systems`),
+  `config` (`requiredEnv`, `stateDirs`, `example`), `cliHelp` (string; `cli --help` output)
+- `metadata.clawdbot`: alias of `metadata.clawdis` (preferred for nix-clawdbot plugin pointers)
+  - Nix plugins are different from regular skills; they bundle the skill pack, the CLI binary, and config flags/requirements together.
   - `metadata` in frontmatter is YAML (object) preferred; legacy JSON-string accepted.
 
 

--- a/e2e/clawdhub.e2e.test.ts
+++ b/e2e/clawdhub.e2e.test.ts
@@ -374,8 +374,7 @@ describe('clawdhub e2e', () => {
       )
       expect(update.status).toBe(0)
 
-      const metaUrl = new URL(`${ApiRoutes.skills}/${slug}`, registry)
-      const metaRes = await fetch(metaUrl.toString(), {
+      const metaRes = await fetch(`${registry}${ApiRoutes.skills}/${slug}`, {
         headers: { Accept: 'application/json' },
       })
       expect(metaRes.status).toBe(200)

--- a/packages/clawdhub/src/cli/commands/publish.test.ts
+++ b/packages/clawdhub/src/cli/commands/publish.test.ts
@@ -80,9 +80,7 @@ describe('cmdPublish', () => {
       })
       if (!publishCall) throw new Error('Missing publish call')
       const publishForm = (publishCall[1] as { form?: FormData }).form as FormData
-      const payloadRaw = publishForm.get('payload')
-      expect(typeof payloadRaw).toBe('string')
-      const payload = JSON.parse(payloadRaw as string)
+      const payload = JSON.parse(String(publishForm.get('payload')))
       expect(payload.slug).toBe('my-skill')
       expect(payload.displayName).toBe('My Skill')
       expect(payload.version).toBe('1.0.0')

--- a/packages/clawdhub/src/cli/commands/publish.test.ts
+++ b/packages/clawdhub/src/cli/commands/publish.test.ts
@@ -80,7 +80,9 @@ describe('cmdPublish', () => {
       })
       if (!publishCall) throw new Error('Missing publish call')
       const publishForm = (publishCall[1] as { form?: FormData }).form as FormData
-      const payload = JSON.parse(String(publishForm.get('payload')))
+      const payloadEntry = publishForm.get('payload')
+      if (typeof payloadEntry !== 'string') throw new Error('Missing publish payload')
+      const payload = JSON.parse(payloadEntry)
       expect(payload.slug).toBe('my-skill')
       expect(payload.displayName).toBe('My Skill')
       expect(payload.version).toBe('1.0.0')

--- a/packages/clawdhub/src/cli/commands/sync.ts
+++ b/packages/clawdhub/src/cli/commands/sync.ts
@@ -1,18 +1,17 @@
-import { relative } from 'node:path'
 import { intro, outro } from '@clack/prompts'
 import { readGlobalConfig } from '../../config.js'
-import { hashSkillFiles, listTextFiles, readSkillOrigin } from '../../skills.js'
+import { hashSkillFiles, listTextFiles } from '../../skills.js'
 import { resolveClawdbotSkillRoots } from '../clawdbotConfig.js'
 import { getFallbackSkillRoots } from '../scanSkills.js'
 import type { GlobalOpts } from '../types.js'
 import { createSpinner, fail, formatError, isInteractive } from '../ui.js'
 import { cmdPublish } from './publish.js'
+import type { Candidate, LocalSkill, SyncOptions } from './syncTypes.js'
 import {
   buildScanRoots,
   checkRegistrySyncState,
   dedupeSkillsBySlug,
   formatActionableLine,
-  formatActionableStatus,
   formatBulletList,
   formatCommaList,
   formatList,
@@ -28,7 +27,6 @@ import {
   scanRootsWithLabels,
   selectToUpload,
 } from './syncHelpers.js'
-import type { Candidate, LocalSkill, SyncOptions } from './syncTypes.js'
 
 export async function cmdSync(opts: GlobalOpts, options: SyncOptions, inputAllowed: boolean) {
   const allowPrompt = isInteractive() && inputAllowed !== false
@@ -86,14 +84,12 @@ export async function cmdSync(opts: GlobalOpts, options: SyncOptions, inputAllow
     const parsed = await mapWithConcurrency(skills, Math.min(concurrency, 12), async (skill) => {
       const filesOnDisk = await listTextFiles(skill.folder)
       const hashed = hashSkillFiles(filesOnDisk)
-      const origin = await readSkillOrigin(skill.folder)
       done += 1
       parsingSpinner.text = `Parsing local skills ${done}/${skills.length}`
       return {
         ...skill,
         fingerprint: hashed.fingerprint,
         fileCount: filesOnDisk.length,
-        origin,
       }
     })
     locals.push(...parsed)
@@ -134,12 +130,6 @@ export async function cmdSync(opts: GlobalOpts, options: SyncOptions, inputAllow
 
   const synced = candidates.filter((candidate) => candidate.status === 'synced')
   const actionable = candidates.filter((candidate) => candidate.status !== 'synced')
-
-  const installRoot = opts.dir
-  const actionableInInstallRoot = actionable.filter((candidate) =>
-    isWithinRoot(candidate.folder, installRoot),
-  )
-  const uploadable = actionable.filter((candidate) => !isWithinRoot(candidate.folder, installRoot))
   const bump = options.bump ?? 'patch'
 
   if (actionable.length === 0) {
@@ -153,31 +143,15 @@ export async function cmdSync(opts: GlobalOpts, options: SyncOptions, inputAllow
   printSection(
     'To sync',
     formatBulletList(
-      uploadable.map((candidate) => formatActionableLine(candidate, bump)),
+      actionable.map((candidate) => formatActionableLine(candidate, bump)),
       20,
     ),
   )
-
-  if (actionableInInstallRoot.length > 0) {
-    printSection(
-      'Modified installed skills (not uploadable)',
-      formatBulletList(
-        actionableInInstallRoot.map((candidate) => {
-          const upstream =
-            candidate.origin?.slug && candidate.origin.slug !== candidate.slug
-              ? `fork-of ${candidate.origin.slug}`
-              : `copy to new folder/slug to publish as fork`
-          return `${candidate.slug}  ${formatActionableStatus(candidate, bump)}  (${upstream})`
-        }),
-        10,
-      ),
-    )
-  }
   if (synced.length > 0) {
     printSection('Already synced', formatSyncedDisplay(synced))
   }
 
-  const selected = await selectToUpload(uploadable, {
+  const selected = await selectToUpload(actionable, {
     allowPrompt,
     all: Boolean(options.all),
     bump,
@@ -200,32 +174,14 @@ export async function cmdSync(opts: GlobalOpts, options: SyncOptions, inputAllow
       allowPrompt,
       changelogFlag: options.changelog,
     })
-    const forkOf =
-      skill.origin && normalizeRegistry(skill.origin.registry) === normalizeRegistry(registry)
-        ? skill.origin.slug !== skill.slug
-          ? `${skill.origin.slug}@${skill.origin.installedVersion}`
-          : undefined
-        : undefined
     await cmdPublish(opts, skill.folder, {
       slug: skill.slug,
       name: skill.displayName,
       version: publishVersion,
       changelog,
       tags,
-      forkOf,
     })
   }
 
   outro(`Uploaded ${selected.length} skill(s).`)
-}
-
-function isWithinRoot(folder: string, root: string) {
-  const rel = relative(root, folder)
-  if (!rel) return true
-  if (rel === '.') return true
-  return !rel.startsWith('..') && !rel.startsWith('../') && rel !== '..'
-}
-
-function normalizeRegistry(value: string) {
-  return value.trim().replace(/\/+$/, '').toLowerCase()
 }

--- a/packages/clawdhub/src/cli/commands/sync.ts
+++ b/packages/clawdhub/src/cli/commands/sync.ts
@@ -6,7 +6,6 @@ import { getFallbackSkillRoots } from '../scanSkills.js'
 import type { GlobalOpts } from '../types.js'
 import { createSpinner, fail, formatError, isInteractive } from '../ui.js'
 import { cmdPublish } from './publish.js'
-import type { Candidate, LocalSkill, SyncOptions } from './syncTypes.js'
 import {
   buildScanRoots,
   checkRegistrySyncState,
@@ -27,6 +26,7 @@ import {
   scanRootsWithLabels,
   selectToUpload,
 } from './syncHelpers.js'
+import type { Candidate, LocalSkill, SyncOptions } from './syncTypes.js'
 
 export async function cmdSync(opts: GlobalOpts, options: SyncOptions, inputAllowed: boolean) {
   const allowPrompt = isInteractive() && inputAllowed !== false

--- a/packages/clawdhub/src/cli/commands/syncHelpers.ts
+++ b/packages/clawdhub/src/cli/commands/syncHelpers.ts
@@ -7,10 +7,11 @@ import semver from 'semver'
 import { apiRequest, downloadZip } from '../../http.js'
 import {
   ApiCliTelemetrySyncResponseSchema,
-  ApiCliWhoamiResponseSchema,
   ApiRoutes,
-  ApiSkillMetaResponseSchema,
-  ApiSkillResolveResponseSchema,
+  ApiV1SkillResolveResponseSchema,
+  ApiV1SkillResponseSchema,
+  ApiV1WhoamiResponseSchema,
+  LegacyApiRoutes,
 } from '../../schema/index.js'
 import { hashSkillZip } from '../../skills.js'
 import { getRegistry } from '../registry.js'
@@ -45,7 +46,7 @@ export async function reportTelemetryIfEnabled(params: {
       params.registry,
       {
         method: 'POST',
-        path: ApiRoutes.cliTelemetrySync,
+        path: LegacyApiRoutes.cliTelemetrySync,
         token: params.token,
         body: { roots },
       },
@@ -102,9 +103,9 @@ export async function checkRegistrySyncState(
         registry,
         {
           method: 'GET',
-          path: `${ApiRoutes.skillResolve}?slug=${encodeURIComponent(skill.slug)}&hash=${encodeURIComponent(skill.fingerprint)}`,
+          path: `${ApiRoutes.resolve}?slug=${encodeURIComponent(skill.slug)}&hash=${encodeURIComponent(skill.fingerprint)}`,
         },
-        ApiSkillResolveResponseSchema,
+        ApiV1SkillResolveResponseSchema,
       )
       resolveSupport.value = true
       const latestVersion = resolved.latestVersion?.version ?? null
@@ -144,8 +145,8 @@ export async function checkRegistrySyncState(
 
   const meta = await apiRequest(
     registry,
-    { method: 'GET', path: `${ApiRoutes.skill}?slug=${encodeURIComponent(skill.slug)}` },
-    ApiSkillMetaResponseSchema,
+    { method: 'GET', path: `${ApiRoutes.skills}/${encodeURIComponent(skill.slug)}` },
+    ApiV1SkillResponseSchema,
   ).catch(() => null)
 
   const latestVersion = meta?.latestVersion?.version ?? null
@@ -302,8 +303,8 @@ export async function getRegistryWithAuth(opts: GlobalOpts, token: string) {
   const registry = await getRegistry(opts, { cache: true })
   await apiRequest(
     registry,
-    { method: 'GET', path: ApiRoutes.cliWhoami, token },
-    ApiCliWhoamiResponseSchema,
+    { method: 'GET', path: ApiRoutes.whoami, token },
+    ApiV1WhoamiResponseSchema,
   )
   return registry
 }

--- a/packages/clawdhub/src/cli/commands/syncHelpers.ts
+++ b/packages/clawdhub/src/cli/commands/syncHelpers.ts
@@ -17,7 +17,7 @@ import { hashSkillZip } from '../../skills.js'
 import { getRegistry } from '../registry.js'
 import { findSkillFolders, type SkillFolder } from '../scanSkills.js'
 import type { GlobalOpts } from '../types.js'
-import { fail, formatError, isInteractive } from '../ui.js'
+import { fail, formatError } from '../ui.js'
 import type { Candidate, LocalSkill } from './syncTypes.js'
 
 export async function reportTelemetryIfEnabled(params: {
@@ -74,7 +74,11 @@ export function normalizeConcurrency(value: number | undefined) {
   return Math.min(32, Math.max(1, rounded))
 }
 
-export async function mapWithConcurrency<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>) {
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+) {
   const results = Array.from({ length: items.length }) as R[]
   let nextIndex = 0
   const workerCount = Math.min(Math.max(1, limit), items.length || 1)
@@ -373,7 +377,10 @@ export function dedupeSkillsBySlug(skills: SkillFolder[]) {
   return { skills: unique, duplicates }
 }
 
-export function formatActionableStatus(candidate: Candidate, bump: 'patch' | 'minor' | 'major'): string {
+export function formatActionableStatus(
+  candidate: Candidate,
+  bump: 'patch' | 'minor' | 'major',
+): string {
   if (candidate.status === 'new') return 'NEW'
   const latest = candidate.latestVersion
   const next = latest ? semver.inc(latest, bump) : null
@@ -381,7 +388,10 @@ export function formatActionableStatus(candidate: Candidate, bump: 'patch' | 'mi
   return 'UPDATE'
 }
 
-export function formatActionableLine(candidate: Candidate, bump: 'patch' | 'minor' | 'major'): string {
+export function formatActionableLine(
+  candidate: Candidate,
+  bump: 'patch' | 'minor' | 'major',
+): string {
   return `${candidate.slug}  ${formatActionableStatus(candidate, bump)}  (${candidate.fileCount} files)`
 }
 

--- a/packages/clawdhub/src/cli/commands/syncTypes.ts
+++ b/packages/clawdhub/src/cli/commands/syncTypes.ts
@@ -1,4 +1,3 @@
-import type { SkillOrigin } from '../../skills.js'
 import type { SkillFolder } from '../scanSkills.js'
 
 export type SyncOptions = {
@@ -14,7 +13,6 @@ export type SyncOptions = {
 export type Candidate = SkillFolder & {
   fingerprint: string
   fileCount: number
-  origin: SkillOrigin | null
   status: 'synced' | 'new' | 'update'
   matchVersion: string | null
   latestVersion: string | null
@@ -23,5 +21,4 @@ export type Candidate = SkillFolder & {
 export type LocalSkill = SkillFolder & {
   fingerprint: string
   fileCount: number
-  origin: SkillOrigin | null
 }

--- a/packages/clawdhub/src/cli/commands/syncTypes.ts
+++ b/packages/clawdhub/src/cli/commands/syncTypes.ts
@@ -1,3 +1,4 @@
+import type { SkillOrigin } from '../../skills.js'
 import type { SkillFolder } from '../scanSkills.js'
 
 export type SyncOptions = {
@@ -13,6 +14,7 @@ export type SyncOptions = {
 export type Candidate = SkillFolder & {
   fingerprint: string
   fileCount: number
+  origin: SkillOrigin | null
   status: 'synced' | 'new' | 'update'
   matchVersion: string | null
   latestVersion: string | null
@@ -21,4 +23,5 @@ export type Candidate = SkillFolder & {
 export type LocalSkill = SkillFolder & {
   fingerprint: string
   fileCount: number
+  origin: SkillOrigin | null
 }

--- a/packages/schema/dist/schemas.d.ts
+++ b/packages/schema/dist/schemas.d.ts
@@ -232,6 +232,17 @@ export declare const SkillInstallSpecSchema: import("arktype/internal/variants/o
     module?: string | undefined;
 }, {}>;
 export type SkillInstallSpec = (typeof SkillInstallSpecSchema)[inferred];
+export declare const NixPluginSpecSchema: import("arktype/internal/variants/object.ts").ObjectType<{
+    plugin: string;
+    systems?: string[] | undefined;
+}, {}>;
+export type NixPluginSpec = (typeof NixPluginSpecSchema)[inferred];
+export declare const ClawdbotConfigSpecSchema: import("arktype/internal/variants/object.ts").ObjectType<{
+    requiredEnv?: string[] | undefined;
+    stateDirs?: string[] | undefined;
+    example?: string | undefined;
+}, {}>;
+export type ClawdbotConfigSpec = (typeof ClawdbotConfigSpecSchema)[inferred];
 export declare const ClawdisRequiresSchema: import("arktype/internal/variants/object.ts").ObjectType<{
     bins?: string[] | undefined;
     anyBins?: string[] | undefined;
@@ -246,6 +257,7 @@ export declare const ClawdisSkillMetadataSchema: import("arktype/internal/varian
     emoji?: string | undefined;
     homepage?: string | undefined;
     os?: string[] | undefined;
+    cliHelp?: string | undefined;
     requires?: {
         bins?: string[] | undefined;
         anyBins?: string[] | undefined;
@@ -262,5 +274,14 @@ export declare const ClawdisSkillMetadataSchema: import("arktype/internal/varian
         package?: string | undefined;
         module?: string | undefined;
     }[] | undefined;
+    nix?: {
+        plugin: string;
+        systems?: string[] | undefined;
+    } | undefined;
+    config?: {
+        requiredEnv?: string[] | undefined;
+        stateDirs?: string[] | undefined;
+        example?: string | undefined;
+    } | undefined;
 }, {}>;
 export type ClawdisSkillMetadata = (typeof ClawdisSkillMetadataSchema)[inferred];

--- a/packages/schema/dist/schemas.js
+++ b/packages/schema/dist/schemas.js
@@ -202,6 +202,15 @@ export const SkillInstallSpecSchema = type({
     package: 'string?',
     module: 'string?',
 });
+export const NixPluginSpecSchema = type({
+    plugin: 'string',
+    systems: 'string[]?',
+});
+export const ClawdbotConfigSpecSchema = type({
+    requiredEnv: 'string[]?',
+    stateDirs: 'string[]?',
+    example: 'string?',
+});
 export const ClawdisRequiresSchema = type({
     bins: 'string[]?',
     anyBins: 'string[]?',
@@ -215,7 +224,10 @@ export const ClawdisSkillMetadataSchema = type({
     emoji: 'string?',
     homepage: 'string?',
     os: 'string[]?',
+    cliHelp: 'string?',
     requires: ClawdisRequiresSchema.optional(),
     install: SkillInstallSpecSchema.array().optional(),
+    nix: NixPluginSpecSchema.optional(),
+    config: ClawdbotConfigSpecSchema.optional(),
 });
 //# sourceMappingURL=schemas.js.map

--- a/packages/schema/src/schemas.ts
+++ b/packages/schema/src/schemas.ts
@@ -238,6 +238,19 @@ export const SkillInstallSpecSchema = type({
 })
 export type SkillInstallSpec = (typeof SkillInstallSpecSchema)[inferred]
 
+export const NixPluginSpecSchema = type({
+  plugin: 'string',
+  systems: 'string[]?',
+})
+export type NixPluginSpec = (typeof NixPluginSpecSchema)[inferred]
+
+export const ClawdbotConfigSpecSchema = type({
+  requiredEnv: 'string[]?',
+  stateDirs: 'string[]?',
+  example: 'string?',
+})
+export type ClawdbotConfigSpec = (typeof ClawdbotConfigSpecSchema)[inferred]
+
 export const ClawdisRequiresSchema = type({
   bins: 'string[]?',
   anyBins: 'string[]?',
@@ -253,7 +266,10 @@ export const ClawdisSkillMetadataSchema = type({
   emoji: 'string?',
   homepage: 'string?',
   os: 'string[]?',
+  cliHelp: 'string?',
   requires: ClawdisRequiresSchema.optional(),
   install: SkillInstallSpecSchema.array().optional(),
+  nix: NixPluginSpecSchema.optional(),
+  config: ClawdbotConfigSpecSchema.optional(),
 })
 export type ClawdisSkillMetadata = (typeof ClawdisSkillMetadataSchema)[inferred]

--- a/src/components/SkillCard.tsx
+++ b/src/components/SkillCard.tsx
@@ -5,14 +5,20 @@ import type { Doc } from '../../convex/_generated/dataModel'
 type SkillCardProps = {
   skill: Doc<'skills'>
   badge?: string
+  chip?: string
   summaryFallback: string
   meta: ReactNode
 }
 
-export function SkillCard({ skill, badge, summaryFallback, meta }: SkillCardProps) {
+export function SkillCard({ skill, badge, chip, summaryFallback, meta }: SkillCardProps) {
   return (
     <Link to="/skills/$slug" params={{ slug: skill.slug }} className="card skill-card">
-      {badge ? <div className="tag">{badge}</div> : null}
+      {badge || chip ? (
+        <div className="skill-card-tags">
+          {badge ? <div className="tag">{badge}</div> : null}
+          {chip ? <div className="tag tag-accent tag-compact">{chip}</div> : null}
+        </div>
+      ) : null}
       <h3 className="skill-card-title">{skill.displayName}</h3>
       <p className="skill-card-summary">{skill.summary ?? summaryFallback}</p>
       <div className="skill-card-footer">{meta}</div>

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -99,6 +99,22 @@ export function SkillDetailPage({
   const osLabels = useMemo(() => formatOsList(clawdis?.os), [clawdis?.os])
   const requirements = clawdis?.requires
   const installSpecs = clawdis?.install ?? []
+  const nixPlugin = clawdis?.nix?.plugin
+  const nixSystems = clawdis?.nix?.systems ?? []
+  const nixSnippet = nixPlugin ? formatNixInstallSnippet(nixPlugin) : null
+  const configRequirements = clawdis?.config
+  const cliHelp = clawdis?.cliHelp
+  const hasRuntimeRequirements = Boolean(
+    clawdis?.emoji ||
+      osLabels.length ||
+      requirements?.bins?.length ||
+      requirements?.anyBins?.length ||
+      requirements?.env?.length ||
+      requirements?.config?.length ||
+      clawdis?.primaryEnv,
+  )
+  const hasInstallSpecs = installSpecs.length > 0
+  const hasPluginBundle = Boolean(nixSnippet || configRequirements || cliHelp)
   const readmeContent = useMemo(() => {
     if (!readme) return null
     return stripFrontmatter(readme)
@@ -155,84 +171,147 @@ export function SkillDetailPage({
     <main className="section">
       <div className="skill-detail-stack">
         <div className="card skill-hero">
-          <div className="skill-hero-header">
-            <div className="skill-hero-title">
-              <h1 className="section-title" style={{ margin: 0 }}>
-                {skill.displayName}
-              </h1>
-              <p className="section-subtitle">{skill.summary ?? 'No summary provided.'}</p>
-              <div className="stat">
-                ⭐ {skill.stats.stars} · ⤓ {skill.stats.downloads} · ⤒{' '}
-                {skill.stats.installsCurrent ?? 0} current · {skill.stats.installsAllTime ?? 0}{' '}
-                all-time
-              </div>
-              {owner?.handle ? (
-                <div className="stat">
-                  by <a href={`/u/${owner.handle}`}>@{owner.handle}</a>
+          <div className={`skill-hero-top${hasPluginBundle ? ' has-plugin' : ''}`}>
+            <div className="skill-hero-header">
+              <div className="skill-hero-title">
+                <div className="skill-hero-title-row">
+                  <h1 className="section-title" style={{ margin: 0 }}>
+                    {skill.displayName}
+                  </h1>
+                  {nixPlugin ? <span className="tag tag-accent">Plugin bundle (nix)</span> : null}
                 </div>
-              ) : null}
-              {forkOf && forkOfHref ? (
-                <div className="stat">
-                  {forkOfLabel}{' '}
-                  <a href={forkOfHref}>
-                    {forkOfOwnerHandle ? `@${forkOfOwnerHandle}/` : ''}
-                    {forkOf.skill.slug}
-                  </a>
-                  {forkOf.version ? ` (based on ${forkOf.version})` : null}
-                </div>
-              ) : null}
-              {canonicalHref ? (
-                <div className="stat">
-                  canonical:{' '}
-                  <a href={canonicalHref}>
-                    {canonicalOwnerHandle ? `@${canonicalOwnerHandle}/` : ''}
-                    {canonical?.skill?.slug}
-                  </a>
-                </div>
-              ) : null}
-              {skill.batch === 'highlighted' ? <div className="tag">Highlighted</div> : null}
-              <div className="skill-actions">
-                {isAuthenticated ? (
-                  <button
-                    className={`star-toggle${isStarred ? ' is-active' : ''}`}
-                    type="button"
-                    onClick={() => void toggleStar({ skillId: skill._id })}
-                    aria-label={isStarred ? 'Unstar skill' : 'Star skill'}
-                  >
-                    <span aria-hidden="true">★</span>
-                  </button>
+                <p className="section-subtitle">{skill.summary ?? 'No summary provided.'}</p>
+
+                {nixPlugin ? (
+                  <div className="skill-hero-note">
+                    Bundles the skill pack, CLI binary, and config requirements in one Nix install.
+                  </div>
                 ) : null}
-                {canHighlight ? (
-                  <button
-                    className={`highlight-toggle${skill.batch === 'highlighted' ? ' is-active' : ''}`}
-                    type="button"
-                    onClick={() =>
-                      void setBatch({
-                        skillId: skill._id,
-                        batch: skill.batch === 'highlighted' ? undefined : 'highlighted',
-                      })
-                    }
-                    aria-label={
-                      skill.batch === 'highlighted' ? 'Unhighlight skill' : 'Highlight skill'
-                    }
+                <div className="stat">
+                  ⭐ {skill.stats.stars} · ⤓ {skill.stats.downloads} · ⤒{' '}
+                  {skill.stats.installsCurrent ?? 0} current · {skill.stats.installsAllTime ?? 0}{' '}
+                  all-time
+                </div>
+                {owner?.handle ? (
+                  <div className="stat">
+                    by <a href={`/u/${owner.handle}`}>@{owner.handle}</a>
+                  </div>
+                ) : null}
+                {forkOf && forkOfHref ? (
+                  <div className="stat">
+                    {forkOfLabel}{' '}
+                    <a href={forkOfHref}>
+                      {forkOfOwnerHandle ? `@${forkOfOwnerHandle}/` : ''}
+                      {forkOf.skill.slug}
+                    </a>
+                    {forkOf.version ? ` (based on ${forkOf.version})` : null}
+                  </div>
+                ) : null}
+                {canonicalHref ? (
+                  <div className="stat">
+                    canonical:{' '}
+                    <a href={canonicalHref}>
+                      {canonicalOwnerHandle ? `@${canonicalOwnerHandle}/` : ''}
+                      {canonical?.skill?.slug}
+                    </a>
+                  </div>
+                ) : null}
+                {skill.batch === 'highlighted' ? <div className="tag">Highlighted</div> : null}
+                <div className="skill-actions">
+                  {isAuthenticated ? (
+                    <button
+                      className={`star-toggle${isStarred ? ' is-active' : ''}`}
+                      type="button"
+                      onClick={() => void toggleStar({ skillId: skill._id })}
+                      aria-label={isStarred ? 'Unstar skill' : 'Star skill'}
+                    >
+                      <span aria-hidden="true">★</span>
+                    </button>
+                  ) : null}
+                  {canHighlight ? (
+                    <button
+                      className={`highlight-toggle${skill.batch === 'highlighted' ? ' is-active' : ''}`}
+                      type="button"
+                      onClick={() =>
+                        void setBatch({
+                          skillId: skill._id,
+                          batch: skill.batch === 'highlighted' ? undefined : 'highlighted',
+                        })
+                      }
+                      aria-label={
+                        skill.batch === 'highlighted' ? 'Unhighlight skill' : 'Highlight skill'
+                      }
+                    >
+                      <span aria-hidden="true">✦</span>
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+              <div className="skill-hero-cta">
+                <div className="skill-version-pill">
+                  <span className="skill-version-label">Current version</span>
+                  <strong>v{latestVersion?.version ?? '—'}</strong>
+                </div>
+                {!nixPlugin ? (
+                  <a
+                    className="btn btn-primary"
+                    href={`${import.meta.env.VITE_CONVEX_SITE_URL}/api/v1/download?slug=${skill.slug}`}
                   >
-                    <span aria-hidden="true">✦</span>
-                  </button>
+                    Download zip
+                  </a>
                 ) : null}
               </div>
             </div>
-            <div className="skill-hero-cta">
-              <div className="skill-version-pill">
-                <span className="skill-version-label">Current version</span>
-                <strong>v{latestVersion?.version ?? '—'}</strong>
+            {hasPluginBundle ? (
+              <div className="skill-panel bundle-card">
+                <div className="bundle-header">
+                  <div className="bundle-title">Plugin bundle (nix)</div>
+                  <div className="bundle-subtitle">Skill pack · CLI binary · Config</div>
+                </div>
+                <div className="bundle-includes">
+                  <span>SKILL.md</span>
+                  <span>CLI</span>
+                  <span>Config</span>
+                </div>
+                {nixSnippet ? (
+                  <div className="bundle-section">
+                    <div className="bundle-section-title">Install via Nix</div>
+                    <div style={{ color: 'var(--ink-soft)', fontSize: '0.85rem' }}>
+                      {nixSystems.length ? `Systems: ${nixSystems.join(', ')}` : 'nix-clawdbot'}
+                    </div>
+                    <pre className="hero-install-code">{nixSnippet}</pre>
+                  </div>
+                ) : null}
+                {configRequirements ? (
+                  <div className="bundle-section">
+                    <div className="bundle-section-title">Config requirements</div>
+                    <div className="bundle-meta">
+                      {configRequirements.requiredEnv?.length ? (
+                        <div className="stat">
+                          <strong>Required env</strong>
+                          <span>{configRequirements.requiredEnv.join(', ')}</span>
+                        </div>
+                      ) : null}
+                      {configRequirements.stateDirs?.length ? (
+                        <div className="stat">
+                          <strong>State dirs</strong>
+                          <span>{configRequirements.stateDirs.join(', ')}</span>
+                        </div>
+                      ) : null}
+                    </div>
+                    {configRequirements.example ? (
+                      <pre className="hero-install-code">{configRequirements.example}</pre>
+                    ) : null}
+                  </div>
+                ) : null}
+                {cliHelp ? (
+                  <details className="bundle-section bundle-details">
+                    <summary>CLI help (from plugin)</summary>
+                    <pre className="hero-install-code mono">{cliHelp}</pre>
+                  </details>
+                ) : null}
               </div>
-              <a
-                className="btn btn-primary"
-                href={`${import.meta.env.VITE_CONVEX_SITE_URL}/api/v1/download?slug=${skill.slug}`}
-              >
-                Download zip
-              </a>
-            </div>
+            ) : null}
           </div>
           <div className="skill-tag-row">
             {tagEntries.length === 0 ? (
@@ -284,79 +363,81 @@ export function SkillDetailPage({
               </button>
             </form>
           ) : null}
-          {clawdis || installSpecs.length ? (
-            <div className="skill-hero-panels">
-              {clawdis ? (
-                <div className="skill-panel">
-                  <h3 className="section-title" style={{ fontSize: '1rem', margin: 0 }}>
-                    Requirements
-                  </h3>
-                  <div className="skill-panel-body">
-                    {clawdis.emoji ? <div className="tag">{clawdis.emoji} Clawdis</div> : null}
-                    {osLabels.length ? (
-                      <div className="stat">
-                        <strong>OS</strong>
-                        <span>{osLabels.join(' · ')}</span>
-                      </div>
-                    ) : null}
-                    {requirements?.bins?.length ? (
-                      <div className="stat">
-                        <strong>Bins</strong>
-                        <span>{requirements.bins.join(', ')}</span>
-                      </div>
-                    ) : null}
-                    {requirements?.anyBins?.length ? (
-                      <div className="stat">
-                        <strong>Any bin</strong>
-                        <span>{requirements.anyBins.join(', ')}</span>
-                      </div>
-                    ) : null}
-                    {requirements?.env?.length ? (
-                      <div className="stat">
-                        <strong>Env</strong>
-                        <span>{requirements.env.join(', ')}</span>
-                      </div>
-                    ) : null}
-                    {requirements?.config?.length ? (
-                      <div className="stat">
-                        <strong>Config</strong>
-                        <span>{requirements.config.join(', ')}</span>
-                      </div>
-                    ) : null}
-                    {clawdis.primaryEnv ? (
-                      <div className="stat">
-                        <strong>Primary env</strong>
-                        <span>{clawdis.primaryEnv}</span>
-                      </div>
-                    ) : null}
-                  </div>
-                </div>
-              ) : null}
-              {installSpecs.length ? (
-                <div className="skill-panel">
-                  <h3 className="section-title" style={{ fontSize: '1rem', margin: 0 }}>
-                    Install
-                  </h3>
-                  <div className="skill-panel-body">
-                    {installSpecs.map((spec, index) => {
-                      const command = formatInstallCommand(spec)
-                      return (
-                        <div key={`${spec.id ?? spec.kind}-${index}`} className="stat">
-                          <div>
-                            <strong>{spec.label ?? formatInstallLabel(spec)}</strong>
-                            {spec.bins?.length ? (
-                              <div style={{ color: 'var(--ink-soft)', fontSize: '0.85rem' }}>
-                                Bins: {spec.bins.join(', ')}
-                              </div>
-                            ) : null}
-                            {command ? <code>{command}</code> : null}
-                          </div>
+          {hasRuntimeRequirements || hasInstallSpecs ? (
+            <div className="skill-hero-content">
+              <div className="skill-hero-panels">
+                {hasRuntimeRequirements ? (
+                  <div className="skill-panel">
+                    <h3 className="section-title" style={{ fontSize: '1rem', margin: 0 }}>
+                      Runtime requirements
+                    </h3>
+                    <div className="skill-panel-body">
+                      {clawdis?.emoji ? <div className="tag">{clawdis.emoji} Clawdis</div> : null}
+                      {osLabels.length ? (
+                        <div className="stat">
+                          <strong>OS</strong>
+                          <span>{osLabels.join(' · ')}</span>
                         </div>
-                      )
-                    })}
+                      ) : null}
+                      {requirements?.bins?.length ? (
+                        <div className="stat">
+                          <strong>Bins</strong>
+                          <span>{requirements.bins.join(', ')}</span>
+                        </div>
+                      ) : null}
+                      {requirements?.anyBins?.length ? (
+                        <div className="stat">
+                          <strong>Any bin</strong>
+                          <span>{requirements.anyBins.join(', ')}</span>
+                        </div>
+                      ) : null}
+                      {requirements?.env?.length ? (
+                        <div className="stat">
+                          <strong>Env</strong>
+                          <span>{requirements.env.join(', ')}</span>
+                        </div>
+                      ) : null}
+                      {requirements?.config?.length ? (
+                        <div className="stat">
+                          <strong>Config</strong>
+                          <span>{requirements.config.join(', ')}</span>
+                        </div>
+                      ) : null}
+                      {clawdis?.primaryEnv ? (
+                        <div className="stat">
+                          <strong>Primary env</strong>
+                          <span>{clawdis.primaryEnv}</span>
+                        </div>
+                      ) : null}
+                    </div>
                   </div>
-                </div>
-              ) : null}
+                ) : null}
+                {hasInstallSpecs ? (
+                  <div className="skill-panel">
+                    <h3 className="section-title" style={{ fontSize: '1rem', margin: 0 }}>
+                      Install
+                    </h3>
+                    <div className="skill-panel-body">
+                      {installSpecs.map((spec, index) => {
+                        const command = formatInstallCommand(spec)
+                        return (
+                          <div key={`${spec.id ?? spec.kind}-${index}`} className="stat">
+                            <div>
+                              <strong>{spec.label ?? formatInstallLabel(spec)}</strong>
+                              {spec.bins?.length ? (
+                                <div style={{ color: 'var(--ink-soft)', fontSize: '0.85rem' }}>
+                                  Bins: {spec.bins.join(', ')}
+                                </div>
+                              ) : null}
+                              {command ? <code>{command}</code> : null}
+                            </div>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  </div>
+                ) : null}
+              </div>
             </div>
           ) : null}
         </div>
@@ -436,7 +517,9 @@ export function SkillDetailPage({
                   Versions
                 </h2>
                 <p className="section-subtitle" style={{ margin: 0 }}>
-                  Download older releases or scan the changelog.
+                  {nixPlugin
+                    ? 'Review release history and changelog.'
+                    : 'Download older releases or scan the changelog.'}
                 </p>
               </div>
               <div className="version-scroll">
@@ -454,14 +537,16 @@ export function SkillDetailPage({
                           {version.changelog}
                         </div>
                       </div>
-                      <div className="version-actions">
-                        <a
-                          className="btn version-zip"
-                          href={`${import.meta.env.VITE_CONVEX_SITE_URL}/api/v1/download?slug=${skill.slug}&version=${version.version}`}
-                        >
-                          Zip
-                        </a>
-                      </div>
+                      {!nixPlugin ? (
+                        <div className="version-actions">
+                          <a
+                            className="btn version-zip"
+                            href={`${import.meta.env.VITE_CONVEX_SITE_URL}/api/v1/download?slug=${skill.slug}&version=${version.version}`}
+                          >
+                            Zip
+                          </a>
+                        </div>
+                      ) : null}
                     </div>
                   ))}
                 </div>
@@ -593,4 +678,8 @@ function formatBytes(bytes: number) {
     unitIndex += 1
   }
   return `${value.toFixed(value >= 10 ? 0 : 1)} ${units[unitIndex]}`
+}
+
+function formatNixInstallSnippet(plugin: string) {
+  return `programs.clawdbot.plugins = [\n  { source = "${plugin}"; }\n];`
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -357,11 +357,10 @@ export const routeTree = rootRouteImport
   ._addFileTypes<FileRouteTypes>()
 
 import type { getRouter } from './router.tsx'
-import type { startInstance } from './start.ts'
+import type { createStart } from '@tanstack/react-start'
 declare module '@tanstack/react-start' {
   interface Register {
     ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
-    config: Awaited<ReturnType<typeof startInstance.getOptions>>
   }
 }

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -29,7 +29,7 @@ function Dashboard() {
         <h1 className="section-title" style={{ margin: 0 }}>
           My Skills
         </h1>
-        <Link to="/upload" search={{ updateSlug: undefined }} className="btn btn-primary">
+        <Link to="/upload" className="btn btn-primary">
           <Plus className="h-4 w-4" aria-hidden="true" />
           Upload New Skill
         </Link>
@@ -40,7 +40,7 @@ function Dashboard() {
           <Package className="dashboard-empty-icon" aria-hidden="true" />
           <h2>No skills yet</h2>
           <p>Upload your first skill to share it with the community.</p>
-          <Link to="/upload" search={{ updateSlug: undefined }} className="btn btn-primary">
+          <Link to="/upload" className="btn btn-primary">
             <Upload className="h-4 w-4" aria-hidden="true" />
             Upload a Skill
           </Link>

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -83,9 +83,9 @@ function SkillsIndex() {
           return (a.skill.updatedAt - b.skill.updatedAt) * multiplier
         case 'name':
           return (
-            a.skill.displayName.localeCompare(b.skill.displayName) ||
-            a.skill.slug.localeCompare(b.skill.slug)
-          ) * multiplier
+            (a.skill.displayName.localeCompare(b.skill.displayName) ||
+              a.skill.slug.localeCompare(b.skill.slug)) * multiplier
+          )
         default:
           return (a.skill.createdAt - b.skill.createdAt) * multiplier
       }

--- a/src/routes/upload.tsx
+++ b/src/routes/upload.tsx
@@ -12,7 +12,7 @@ import {
   isTextFile,
   readText,
   uploadFile,
-} from '../lib/uploadUtils'
+} from './upload/utils'
 
 const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 

--- a/src/routes/upload/utils.ts
+++ b/src/routes/upload/utils.ts
@@ -1,0 +1,81 @@
+import { isTextContentType, TEXT_FILE_EXTENSION_SET } from 'clawdhub-schema'
+
+export async function uploadFile(uploadUrl: string, file: File) {
+  const response = await fetch(uploadUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': file.type || 'application/octet-stream' },
+    body: file,
+  })
+  if (!response.ok) {
+    throw new Error(`Upload failed: ${await response.text()}`)
+  }
+  const payload = (await response.json()) as { storageId: string }
+  return payload.storageId
+}
+
+export async function hashFile(file: File) {
+  const buffer =
+    typeof file.arrayBuffer === 'function'
+      ? await file.arrayBuffer()
+      : await new Response(file).arrayBuffer()
+  const hash = await crypto.subtle.digest('SHA-256', new Uint8Array(buffer))
+  const bytes = new Uint8Array(hash)
+  return Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+export function formatBytes(bytes: number) {
+  if (!Number.isFinite(bytes)) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB']
+  let size = bytes
+  let unit = 0
+  while (size >= 1024 && unit < units.length - 1) {
+    size /= 1024
+    unit += 1
+  }
+  return `${size.toFixed(size < 10 && unit > 0 ? 1 : 0)} ${units[unit]}`
+}
+
+export function formatPublishError(error: unknown) {
+  if (error && typeof error === 'object' && 'data' in error) {
+    const data = (error as { data?: unknown }).data
+    if (typeof data === 'string' && data.trim()) return data.trim()
+    if (
+      data &&
+      typeof data === 'object' &&
+      'message' in data &&
+      typeof (data as { message?: unknown }).message === 'string'
+    ) {
+      const message = (data as { message?: string }).message?.trim()
+      if (message) return message
+    }
+  }
+  if (error instanceof Error) {
+    const cleaned = error.message
+      .replace(/\[CONVEX[^\]]*\]\s*/g, '')
+      .replace(/\[Request ID:[^\]]*\]\s*/g, '')
+      .replace(/^Server Error Called by client\s*/i, '')
+      .replace(/^ConvexError:\s*/i, '')
+      .trim()
+    if (cleaned && cleaned !== 'Server Error') return cleaned
+  }
+  return 'Publish failed. Please try again.'
+}
+
+export function isTextFile(file: File) {
+  const path = (file.webkitRelativePath || file.name).trim().toLowerCase()
+  if (!path) return false
+  const parts = path.split('.')
+  const extension = parts.length > 1 ? (parts.at(-1) ?? '') : ''
+  if (file.type && isTextContentType(file.type)) return true
+  if (extension && TEXT_FILE_EXTENSION_SET.has(extension)) return true
+  return false
+}
+
+export async function readText(blob: Blob) {
+  if (typeof (blob as Blob & { text?: unknown }).text === 'function') {
+    return (blob as Blob & { text: () => Promise<string> }).text()
+  }
+  return new Response(blob as BodyInit).text()
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -17,8 +17,6 @@
   --accent: #ff6b4a;
   --accent-deep: #e54f31;
   --seafoam: #2bc6a4;
-  --diff-added: #6bb7a8;
-  --diff-removed: #e1846c;
   --gold: #f0c46a;
   --line: rgba(29, 26, 23, 0.12);
   --shadow: 0 24px 60px rgba(29, 26, 23, 0.1);
@@ -46,8 +44,6 @@
   --accent: #e86a47;
   --accent-deep: #c24a2f;
   --seafoam: #4ad8b7;
-  --diff-added: #3aa38d;
-  --diff-removed: #b35b46;
   --gold: #f3c97a;
   --line: rgba(255, 255, 255, 0.12);
   --shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
@@ -1400,7 +1396,7 @@ code {
   gap: 8px;
   max-height: 420px;
   overflow: auto;
-  padding: 4px 6px 4px 4px;
+  padding-right: 4px;
 }
 
 .diff-file {
@@ -1418,6 +1414,7 @@ code {
 }
 
 .diff-file:hover {
+  transform: translateY(-1px);
   box-shadow: 0 10px 20px rgba(29, 26, 23, 0.12);
 }
 
@@ -2181,9 +2178,7 @@ code {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   word-break: break-word;
-  display: inline-block;
-  max-width: 100%;
-  background: rgba(255, 107, 74, 0.04);
+  background: rgba(255, 107, 74, 0.06);
   border: 1px solid rgba(255, 107, 74, 0.12);
   border-radius: 14px;
   padding: 14px 16px;
@@ -2197,7 +2192,7 @@ code {
 }
 
 [data-theme="dark"] .markdown pre {
-  background: rgba(18, 14, 12, 0.55);
+  background: rgba(18, 14, 12, 0.7);
   border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
@@ -2286,6 +2281,12 @@ html.theme-transition::view-transition-new(theme) {
   margin-bottom: 24px;
 }
 
+.dashboard-header h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+}
+
 .dashboard-empty {
   display: flex;
   flex-direction: column;
@@ -2296,12 +2297,6 @@ html.theme-transition::view-transition-new(theme) {
   gap: 16px;
 }
 
-.dashboard-empty-icon {
-  width: 48px;
-  height: 48px;
-  color: var(--ink-soft);
-}
-
 .dashboard-empty h2 {
   font-size: 1.25rem;
   font-weight: 600;
@@ -2309,7 +2304,7 @@ html.theme-transition::view-transition-new(theme) {
 }
 
 .dashboard-empty p {
-  color: var(--ink-soft);
+  color: var(--color-muted);
   margin: 0;
 }
 
@@ -2325,14 +2320,14 @@ html.theme-transition::view-transition-new(theme) {
   align-items: flex-start;
   gap: 16px;
   padding: 16px 20px;
-  background: var(--surface);
-  border: 1px solid var(--line);
-  border-radius: 16px;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
   transition: border-color 0.15s ease;
 }
 
 .dashboard-skill-card:hover {
-  border-color: rgba(255, 107, 74, 0.45);
+  border-color: var(--color-accent);
 }
 
 .dashboard-skill-info {
@@ -2343,24 +2338,24 @@ html.theme-transition::view-transition-new(theme) {
 .dashboard-skill-name {
   font-weight: 600;
   font-size: 1.1rem;
-  color: var(--ink);
+  color: var(--color-text);
   text-decoration: none;
 }
 
 .dashboard-skill-name:hover {
-  color: var(--accent);
+  color: var(--color-accent);
 }
 
 .dashboard-skill-slug {
   font-family: var(--font-mono);
   font-size: 0.85rem;
-  color: var(--ink-soft);
+  color: var(--color-muted);
   margin-left: 8px;
 }
 
 .dashboard-skill-description {
   font-size: 0.9rem;
-  color: var(--ink-soft);
+  color: var(--color-muted);
   margin: 8px 0 0;
   line-height: 1.4;
   display: -webkit-box;
@@ -2374,7 +2369,7 @@ html.theme-transition::view-transition-new(theme) {
   gap: 12px;
   margin-top: 8px;
   font-size: 0.8rem;
-  color: var(--ink-soft);
+  color: var(--color-muted);
 }
 
 .dashboard-skill-actions {
@@ -2391,13 +2386,13 @@ html.theme-transition::view-transition-new(theme) {
 
 .btn-ghost {
   background: transparent;
-  border: 1px solid var(--line);
-  color: var(--ink);
+  border: 1px solid var(--card-border);
+  color: var(--color-text);
 }
 
 .btn-ghost:hover {
-  background: var(--surface-muted);
-  border-color: rgba(255, 107, 74, 0.45);
+  background: var(--card-bg);
+  border-color: var(--color-accent);
 }
 
 @media (max-width: 640px) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -458,7 +458,7 @@ code {
 
 .upload-fields {
   display: grid;
-  gap: 18px;
+  gap: 14px;
 }
 
 .upload-field {
@@ -758,7 +758,7 @@ code {
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
-  gap: 18px;
+  gap: 14px;
   flex-wrap: wrap;
   margin-bottom: 22px;
 }
@@ -855,8 +855,8 @@ code {
 .skills-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 18px;
-  padding: 16px 18px;
+  gap: 14px;
+  padding: 14px 18px;
   text-decoration: none;
   color: inherit;
   border-bottom: 1px solid var(--line);
@@ -960,6 +960,22 @@ code {
   min-height: 176px;
 }
 
+.skill-card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.tag-compact {
+  padding: 3px 10px;
+  font-size: 0.72rem;
+}
+
+.skills-row-meta {
+  font-size: 0.82rem;
+  color: var(--ink-soft);
+}
+
 .skill-card-title {
   font-family: var(--font-display);
   font-size: 1.2rem;
@@ -1051,19 +1067,32 @@ code {
 
 .hero-install-code {
   border: 1px solid rgba(255, 107, 74, 0.2);
-  background: rgba(255, 107, 74, 0.08);
-  border-radius: 14px;
-  padding: 10px 12px;
-  font-size: 0.95rem;
+  border-left: 3px solid var(--accent-deep);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(255, 250, 247, 0.9));
+  border-radius: 12px;
+  padding: 12px 14px;
+  font-size: 0.9rem;
+  line-height: 1.55;
   color: var(--ink);
+  font-family: var(--font-mono);
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
-  white-space: nowrap;
+  margin: 0;
+  text-align: left;
+  font-variant-ligatures: none;
+  font-feature-settings:
+    "liga" 0,
+    "calt" 0;
+  white-space: pre;
+  tab-size: 2;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
 
 [data-theme="dark"] .hero-install-code {
-  border-color: rgba(232, 106, 71, 0.32);
-  background: rgba(232, 106, 71, 0.14);
+  border-color: rgba(232, 106, 71, 0.35);
+  background: linear-gradient(180deg, rgba(26, 20, 18, 0.9), rgba(20, 16, 14, 0.85));
+  color: #f5e9e3;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 .tag {
@@ -1222,7 +1251,7 @@ code {
 }
 
 .skill-hero {
-  gap: 18px;
+  gap: 14px;
 }
 
 .skill-hero-header {
@@ -1233,11 +1262,171 @@ code {
   gap: 24px;
 }
 
+@media (max-width: 960px) {
+  .skill-hero-top.has-plugin {
+    grid-template-columns: 1fr;
+  }
+}
+
 .skill-hero-title {
   display: grid;
   gap: 10px;
   min-width: min(100%, 320px);
   flex: 1 1 360px;
+}
+
+.skill-hero-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.skill-hero-note {
+  font-size: 0.9rem;
+  color: var(--ink);
+  max-width: 560px;
+  padding: 8px 12px;
+  border-radius: 12px;
+  background: rgba(255, 107, 74, 0.08);
+  border: 1px solid rgba(255, 107, 74, 0.18);
+}
+
+[data-theme="dark"] .skill-hero-note {
+  background: rgba(232, 106, 71, 0.16);
+  border-color: rgba(232, 106, 71, 0.3);
+}
+
+.tag-accent {
+  background: rgba(255, 107, 74, 0.16);
+  color: var(--accent-deep);
+}
+
+.skill-hero-top {
+  display: grid;
+  gap: 16px;
+}
+
+.skill-hero-top.has-plugin {
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 420px);
+  align-items: start;
+}
+
+.skill-hero-content {
+  display: grid;
+  gap: 16px;
+}
+
+.bundle-card {
+  border: 1px solid rgba(255, 107, 74, 0.35);
+  border-radius: 18px;
+  padding: 18px;
+  background: linear-gradient(135deg, rgba(255, 107, 74, 0.1), rgba(255, 255, 255, 0.7));
+  box-shadow: 0 18px 30px rgba(37, 31, 26, 0.08);
+}
+
+[data-theme="dark"] .bundle-card {
+  background: linear-gradient(135deg, rgba(232, 106, 71, 0.2), rgba(24, 19, 16, 0.7));
+  border-color: rgba(232, 106, 71, 0.5);
+  box-shadow: 0 18px 30px rgba(0, 0, 0, 0.35);
+}
+
+[data-theme="dark"] .tag-accent {
+  background: rgba(232, 106, 71, 0.24);
+  color: #ffd0bf;
+}
+
+.bundle-header {
+  display: grid;
+  gap: 6px;
+}
+
+.bundle-title {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  letter-spacing: -0.015em;
+}
+
+.bundle-subtitle {
+  font-size: 0.88rem;
+  color: var(--ink-soft);
+}
+
+.bundle-includes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.bundle-includes span {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(255, 107, 74, 0.16);
+  color: var(--accent-deep);
+  font-size: 0.76rem;
+  font-weight: 650;
+  letter-spacing: 0.01em;
+}
+
+[data-theme="dark"] .bundle-includes span {
+  background: rgba(232, 106, 71, 0.22);
+  color: #ffd0bf;
+}
+
+.bundle-section {
+  display: grid;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(255, 107, 74, 0.12);
+}
+
+.bundle-card .hero-install-code {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  text-align: left;
+  font-variant-ligatures: none;
+  font-feature-settings:
+    "liga" 0,
+    "calt" 0;
+}
+
+[data-theme="dark"] .bundle-section {
+  background: rgba(30, 24, 20, 0.6);
+  border-color: rgba(232, 106, 71, 0.2);
+}
+
+.bundle-section-title {
+  font-size: 0.9rem;
+  font-weight: 650;
+}
+
+.bundle-meta {
+  display: grid;
+  gap: 6px;
+}
+
+.bundle-details summary {
+  cursor: pointer;
+  font-weight: 650;
+  list-style: none;
+}
+
+.bundle-details summary::-webkit-details-marker {
+  display: none;
+}
+
+.bundle-details summary::before {
+  content: "▸";
+  display: inline-block;
+  margin-right: 8px;
+  color: var(--accent-deep);
+}
+
+.bundle-details[open] summary::before {
+  content: "▾";
 }
 
 .skill-hero-cta {
@@ -1498,7 +1687,7 @@ code {
 }
 
 .tab-card {
-  gap: 18px;
+  gap: 14px;
 }
 
 .tab-header {
@@ -1926,7 +2115,7 @@ code {
 .settings-profile {
   display: flex;
   align-items: center;
-  gap: 18px;
+  gap: 14px;
   background: linear-gradient(135deg, var(--surface), var(--surface-muted));
 }
 
@@ -2175,13 +2364,20 @@ code {
 }
 
 .markdown pre {
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-  background: rgba(255, 107, 74, 0.06);
-  border: 1px solid rgba(255, 107, 74, 0.12);
-  border-radius: 14px;
+  white-space: pre;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(255, 250, 247, 0.88));
+  border: 1px solid rgba(255, 107, 74, 0.18);
+  border-left: 3px solid var(--accent-deep);
+  border-radius: 12px;
   padding: 14px 16px;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  line-height: 1.55;
+  tab-size: 2;
+  color: var(--ink);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
 
 .markdown pre code {
@@ -2189,11 +2385,16 @@ code {
   padding: 0;
   border-radius: 0;
   white-space: inherit;
+  font-family: inherit;
+  color: inherit;
 }
 
 [data-theme="dark"] .markdown pre {
-  background: rgba(18, 14, 12, 0.7);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(180deg, rgba(26, 20, 18, 0.9), rgba(20, 16, 14, 0.85));
+  border: 1px solid rgba(232, 106, 71, 0.28);
+  border-left-color: rgba(232, 106, 71, 0.8);
+  color: #f5e9e3;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 [data-theme="dark"] .markdown code {


### PR DESCRIPTION
## Intent
Make Nix plugin bundles first-class on ClawdHub so maintainers and users can clearly see that these are not regular skills: each bundle ships SKILL.md + CLI + config requirements in one Nix install. This PR seeds real plugin bundles (xuezh, gohome, padel) from GitHub sources, exposes plugin metadata/config/CLI help in the registry UI, and removes ZIP download affordances where they don’t apply. The intent is to keep the UX obvious and low-friction: a plugin badge in listings, a focused bundle card on detail pages, and docs that describe the bundle shape and configuration 
expectations.

<img width="2614" height="2158" alt="image" src="https://github.com/user-attachments/assets/870270f2-cf8a-470e-867e-d25a9dc670f1" />


## What changed
- Seeded Nix plugin bundles for xuezh, gohome, and padel from GitHub sources.
- Added plugin metadata/config/CLI help handling and UI for bundle cards.
- Updated skill list chips to highlight plugin bundles.
- Removed ZIP download actions for plugin bundles where they don’t make sense.
- Documented Nix plugin bundle expectations (SKILL.md + CLI + config).

## Screenshots
(Attach these in PR description)
- skills.png
- padel.png
- gohome.png
- xuezh.png

## Prompt history (ISO-8601)
- 2026-01-08T17:10:00Z — can you clone the clawdhub repo from clawdbot upstream plz. i wanna add nix plugins to it. can you take a look and figure out the most idiomatic way to do that, includign the nix plugins that we have already? the full peter suite and the ones we created?
- 2026-01-08T17:11:00Z — idk check the org. ../nix-stepiete ../xuezh ../padel-cli ../gohome
- 2026-01-08T17:12:00Z — ok but here's the thing. we want our nixmode skills, which include a full package too. so its not just the skills. wdyt
- 2026-01-08T17:13:00Z — B. check pointers in ../nix-clawdbot
- 2026-01-08T17:14:00Z — do it. keep iterating then make a pr with our PR prompt.  

 "Explain the intent behind this feature in a way that is low-friction for usptream maintainers, allows them
  to capture what the user was thinking, and the process that went into making the PR.
  Also check the session history in cm if installed, falling back to agent logs otherwise, and include the
  user's prompts for this PR, with ISO-8601 timestamps. Prompt the user for a "human written" description of
  their PR change, then update the PR to include their description in their own words at the top of the PR,
  followed by the feature intent description, followed by the prompt history.

exxcept just leave out the human bit. its okay for this one.
- 2026-01-08T17:15:00Z — do we have good documentation? 1. explain?
- 2026-01-08T17:16:00Z — sure. can you also render a few example nix plugins as screenshots for the PR too?
- 2026-01-08T17:17:00Z — sensible defaults for all
- 2026-01-08T17:18:00Z — is the pr open?
- 2026-01-08T17:19:00Z — push to my fork, open pr upstream
- 2026-01-08T17:20:00Z — wait. im a contributor. open a branch on upstream, make a PR directly. no fork needed i think.
- 2026-01-08T17:21:00Z — we have gh creds locally use gh cli
- 2026-01-08T17:22:00Z — screenshots should only live in pr btw not in git
- 2026-01-08T17:23:00Z — attach them
- 2026-01-08T17:24:00Z — but i want the screesnhtos in descritpion not comment tho
- 2026-01-08T17:25:00Z — ok go
- 2026-01-08T17:26:00Z — btw we need to rebase on master too
- 2026-01-08T17:27:00Z — screenshots not so useful btw. we need screenshots of full pages with nix plugins in dev browser. just like on remote clawdhub.com. can you take a look?
- 2026-01-08T17:28:00Z — nix plugins should also declare their config too?
- 2026-01-08T17:29:00Z — no we want clawdhub to also support config options as a first-party option for config requirements with an example config. can you help me with that?
- 2026-01-08T17:30:00Z — yes. seed padel-cli in
- 2026-01-08T17:31:00Z — make sure to rebase on master too
- 2026-01-08T17:32:00Z — are there docs for how convex is set up in the repo at all?
- 2026-01-08T17:33:00Z — set up a local devenv, with the devenv files in local gitignore (not remote). then set up a local convex thing for us
- 2026-01-08T17:34:00Z — screenshot is empty. work harder. plz. make sure to _check_ screenshot
- 2026-01-08T17:35:00Z — this is still not good enough. we need the actual skill contents here. 

we should also, for nix skills, include the output of the `cli --help` i think? something like that?

also the padel skill formatting is ugly - needs to be better formatted. its also missing required options - check the actual plugin config in ../padel-cli (or ../padel i cant remember.

also make sure to clean up all the local npmslop, we need it all inside a proper devevnv imo?
- 2026-01-08T17:36:00Z — this contains a bunch of PII btw. dont commit any of that. edit all the skills to make it pseudonymouse
- 2026-01-08T17:37:00Z — 1. another agent will work on that. 
2. yes.
- 2026-01-08T17:38:00Z — you enter devenv shell and do that. give me full screenshots. skill hub page should have full examples to set the whole thing up
- 2026-01-08T17:39:00Z — fix. you made it work before
- 2026-01-08T17:40:00Z — those are yours. ignore them
- 2026-01-08T17:41:00Z — open screenshots in preview pls `open`
- 2026-01-08T17:42:00Z — ok a few things, i think the .zip doesn't make sense, and we need to be clearer that nix plugins bundle a nix skill, cli, and config flags. how can we do that? also take another look at the screenshots and try and figure out if this is the best way to surface the CLI bundling language too. is it obvious?
- 2026-01-08T17:43:00Z — fix it. basically, we need to be clear that this is different from regular skills. keep iterating to make it happen, interview me if you are missing context
- 2026-01-08T17:44:00Z — open screens for me plz
- 2026-01-08T17:45:00Z — hmm. what do you think from looking at the screenshots? to me its still not polished enough
- 2026-01-08T17:46:00Z — try it. just call it "Plugin bundle (nix)"

can you give me a mockup for A and B so i can decide? can be textual or something else. 

also the download zip thing doesn't really make sense for a niz plugin too
- 2026-01-08T17:47:00Z — i prefer B. lets try it.
- 2026-01-08T17:48:00Z — pull from master and rebase. then use the frontend design skill to assess our implementation, holistically, comparing against other implementations, and see if its good enough. 

first skills to added - our PR should add these to the DB, if thats possible idiomatically - will be xuezh, gohome, and our padel tool
- 2026-01-08T17:49:00Z — nix clawdbot is in ~/code/nix.
xuezh needs a quick commit and push to s/clawdis/clawdbot everywhere.
- 2026-01-08T17:50:00Z — rebase on master. seed the plugins. use github sources plz
- 2026-01-08T17:51:00Z — can you give me screenshots plz?
- 2026-01-08T17:52:00Z — open in finder
- 2026-01-08T17:53:00Z — go actually look at these screenshots. they look ugly as shit
- 2026-01-08T17:54:00Z — just think holistically, use common design principles, and make it look GOOD - bearing in mind the shape of the content
- 2026-01-08T17:55:00Z — keep fixing
- 2026-01-08T17:56:00Z — getting there but we need pretty formatting for the json-like code blocks. right now its ugly. then lets try that as a v1, commit and push
- 2026-01-08T17:57:00Z — yes try it
