### PR TITLE
fix: handle shorthand hex colors in SkillDiffCard

### DIFF
--- a/src/components/SkillDiffCard.tsx
+++ b/src/components/SkillDiffCard.tsx
@@ -461,8 +461,11 @@ function applyMonacoTheme(monaco: NonNullable<ReturnType<typeof useMonaco>>) {
 }
 
 function normalizeHex(value: string) {
-  if (value.startsWith('#')) return value
-  return '#000000'
+  if (!value.startsWith('#')) return '#000000'
+  if (value.length === 4) {
+    return `#${value[1]}${value[1]}${value[2]}${value[2]}${value[3]}${value[3]}`
+  }
+  return value
 }
 
 function toRgba(color: string, alpha: number) {


### PR DESCRIPTION
Fixes 'Illegal value for token color' error by correctly expanding 3-digit hex codes (e.g. #fff) to 6-digit hex codes before passing them to Monaco Editor.