### PR TITLE
feat: add public skills list endpoint

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -10,6 +10,7 @@ import {
   cliUploadUrlHttp,
   cliWhoamiHttp,
   getSkillHttp,
+  listSkillsHttp,
   resolveSkillVersionHttp,
   searchSkillsHttp,
 } from './httpApi'
@@ -28,6 +29,12 @@ http.route({
   path: ApiRoutes.search,
   method: 'GET',
   handler: searchSkillsHttp,
+})
+
+http.route({
+  path: ApiRoutes.skillsList,
+  method: 'GET',
+  handler: listSkillsHttp,
 })
 
 http.route({

--- a/convex/httpApi.ts
+++ b/convex/httpApi.ts
@@ -67,6 +67,42 @@ async function searchSkillsHandler(ctx: ActionCtx, request: Request) {
 
 export const searchSkillsHttp = httpAction(searchSkillsHandler)
 
+async function listSkillsHandler(ctx: ActionCtx, request: Request) {
+  const url = new URL(request.url)
+  const batchParam = url.searchParams.get('batch')?.trim()
+  const batch = batchParam && batchParam.length > 0 ? batchParam : undefined
+  const limit = toOptionalNumber(url.searchParams.get('limit'))
+
+  const skills = (await ctx.runQuery(api.skills.list, {
+    batch,
+    limit,
+  })) as Array<{
+    slug: string
+    displayName: string
+    summary?: string | null
+    tags: Record<string, string>
+    stats: unknown
+    batch?: string | null
+    createdAt: number
+    updatedAt: number
+  }>
+
+  return json({
+    skills: skills.map((skill) => ({
+      slug: skill.slug,
+      displayName: skill.displayName,
+      summary: skill.summary ?? null,
+      tags: skill.tags,
+      stats: skill.stats,
+      batch: skill.batch ?? null,
+      createdAt: skill.createdAt,
+      updatedAt: skill.updatedAt,
+    })),
+  })
+}
+
+export const listSkillsHttp = httpAction(listSkillsHandler)
+
 async function getSkillHandler(ctx: ActionCtx, request: Request) {
   const url = new URL(request.url)
   const slug = url.searchParams.get('slug')?.trim().toLowerCase()
@@ -293,6 +329,7 @@ export const __test = {
 
 export const __handlers = {
   searchSkillsHandler,
+  listSkillsHandler,
   getSkillHandler,
   resolveSkillVersionHandler,
   cliWhoamiHandler,

--- a/packages/clawdhub/src/http.ts
+++ b/packages/clawdhub/src/http.ts
@@ -63,3 +63,13 @@ export async function downloadZip(registry: string, args: { slug: string; versio
     { retries: 2 },
   )
 }
+
+export async function listSkills(
+  registry: string,
+  args?: { batch?: string; limit?: number },
+) {
+  const url = new URL(ApiRoutes.skillsList, registry)
+  if (args?.batch) url.searchParams.set('batch', args.batch)
+  if (args?.limit) url.searchParams.set('limit', String(args.limit))
+  return apiRequest(registry, { method: 'GET', url: url.toString() })
+}

--- a/packages/schema/src/routes.ts
+++ b/packages/schema/src/routes.ts
@@ -1,5 +1,6 @@
 export const ApiRoutes = {
   download: '/api/download',
+  skillsList: '/api/skills',
   search: '/api/search',
   skill: '/api/skill',
   skillResolve: '/api/skill/resolve',

--- a/packages/schema/src/schemas.ts
+++ b/packages/schema/src/schemas.ts
@@ -43,6 +43,19 @@ export const ApiSearchResponseSchema = type({
   }).array(),
 })
 
+export const ApiSkillListResponseSchema = type({
+  skills: type({
+    slug: 'string',
+    displayName: 'string',
+    summary: 'string|null?',
+    tags: 'unknown',
+    stats: 'unknown',
+    batch: 'string|null?',
+    createdAt: 'number',
+    updatedAt: 'number',
+  }).array(),
+})
+
 export const ApiSkillMetaResponseSchema = type({
   latestVersion: type({
     version: 'string',


### PR DESCRIPTION
Adds a public /api/skills endpoint (batch + limit) for highlighted/latest lists and exposes it via the schema routes.

Notes:
- Uses the existing skills.list query and returns lightweight fields for browsing.
- Schema dist artifacts were not regenerated in this PR.