### PR TITLE
Fixes Monaco editor instantiation in Light mode

### DIFF
--- a/src/components/SkillDiffCard.tsx
+++ b/src/components/SkillDiffCard.tsx
@@ -418,7 +418,7 @@ function buildDiffOptions(viewMode: 'split' | 'inline'): DiffEditorProps['option
 
 function applyMonacoTheme(monaco: NonNullable<ReturnType<typeof useMonaco>>) {
   const styles = getComputedStyle(document.documentElement)
-  const surface = styles.getPropertyValue('--surface').trim() || '#ffffff'
+  const surface = normalizeHex(styles.getPropertyValue('--surface').trim() || '#ffffff')
   const surfaceMuted = styles.getPropertyValue('--surface-muted').trim() || '#f6f1ec'
   const ink = styles.getPropertyValue('--ink').trim() || '#1d1a17'
   const inkSoft = styles.getPropertyValue('--ink-soft').trim() || '#4c463f'


### PR DESCRIPTION
Currently the skills page is crashing when clicking compare (in light mode only).

`Uncaught Error: Illegal value for token color: #fff`

The Monaco Editor expects full hex codes in it's theming, and whilst it is being set as "#ffffff" in the styles.css, some part of the build process (likely the Vite CSS minifier) is converting it to "#fff" in the live site.

This is a pretty hacky fix, but seems to solve the problem.

Fixes #9