### PR TITLE
feat(cli): add explore command to browse latest updated skills

### DIFF
--- a/packages/clawdhub/src/cli.ts
+++ b/packages/clawdhub/src/cli.ts
@@ -7,7 +7,7 @@ import { resolveClawdbotDefaultWorkspace } from './cli/clawdbotConfig.js'
 import { cmdLoginFlow, cmdLogout, cmdWhoami } from './cli/commands/auth.js'
 import { cmdDeleteSkill, cmdUndeleteSkill } from './cli/commands/delete.js'
 import { cmdPublish } from './cli/commands/publish.js'
-import { cmdInstall, cmdList, cmdSearch, cmdUpdate } from './cli/commands/skills.js'
+import { cmdExplore, cmdInstall, cmdList, cmdSearch, cmdUpdate } from './cli/commands/skills.js'
 import { cmdSync } from './cli/commands/sync.js'
 import { configureCommanderHelp, styleEnvBlock, styleTitle } from './cli/helpStyle.js'
 import { DEFAULT_REGISTRY, DEFAULT_SITE } from './cli/registry.js'
@@ -181,6 +181,16 @@ program
   .action(async () => {
     const opts = await resolveGlobalOpts()
     await cmdList(opts)
+  })
+
+program
+  .command('explore')
+  .description('Browse latest updated skills from the registry')
+  .option('--limit <n>', 'Number of skills to show (max 50)', '25')
+  .action(async (options) => {
+    const opts = await resolveGlobalOpts()
+    const limit = Number.parseInt(options.limit, 10) || 25
+    await cmdExplore(opts, limit)
   })
 
 program


### PR DESCRIPTION
## Summary

Adds a new `clawdhub explore` command that fetches the most recently updated skills from the registry, sorted by `updatedAt` descending.

## Usage

```bash
clawdhub explore              # Show latest 25 skills
clawdhub explore --limit 10   # Show latest 10 skills
```

## Output

```
gog  v1.2.3  2h ago  Google Workspace CLI for Gmail, Calendar, Drive...
github  v2.0.0  5h ago  Interact with GitHub using the gh CLI...
weather  v1.0.1  1d ago  Get current weather and forecasts...
```

## Implementation

- Uses the existing `GET /api/v1/skills` endpoint which already returns skills sorted by `updatedAt` DESC
- Reuses existing `ApiV1SkillListResponseSchema` for response validation
- Includes relative time formatting and summary truncation for clean output

## Context

The API and data already existed (the `skills` table has `createdAt`/`updatedAt` fields with a `by_updated` index), but there was no CLI command to expose the "latest updated skills" feed.

---
*Implemented by Thufir Hawat 🧮*