### PR TITLE
fix: use path instead of url for skill metadata API call

### DIFF
--- a/packages/clawdhub/src/cli/commands/skills.ts
+++ b/packages/clawdhub/src/cli/commands/skills.ts
@@ -153,7 +153,7 @@ export async function cmdUpdate(
       } else {
         const meta = await apiRequest(
           registry,
-          { method: 'GET', url: `${ApiRoutes.skills}/${encodeURIComponent(entry)}` },
+          { method: 'GET', path: `${ApiRoutes.skills}/${encodeURIComponent(entry)}` },
           ApiV1SkillResponseSchema,
         )
         resolveResult = { match: null, latestVersion: meta.latestVersion ?? null }


### PR DESCRIPTION
## Summary
- Fixed URL parsing error in `cmdUpdate` when updating skills without local fingerprint match

## Problem
Running `clawdhub update --all` fails with:
```
✖ Failed to parse URL from /api/v1/skills/clawd-docs-v2
Error: Failed to parse URL from /api/v1/skills/clawd-docs-v2
```

## Cause
In `skills.ts:156`, the `apiRequest` call was using `url:` with a relative path:
```typescript
{ method: 'GET', url: `${ApiRoutes.skills}/${encodeURIComponent(entry)}` }
```

The `apiRequest` function in `http.ts` handles `url` and `path` differently:
```typescript
const url = 'url' in args ? args.url : new URL(args.path, registry).toString();
```

When `url` is provided, it's used as-is without combining with the registry base URL, causing URL parsing to fail on a relative path.

## Fix
Changed `url:` to `path:` so the relative path is properly combined with the registry base URL.

## Test plan
- [x] Tested locally with `clawdhub update --all` - now works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)