### PR TITLE
fix: add missing undici dependency

### DIFF
--- a/packages/clawdhub/package.json
+++ b/packages/clawdhub/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.11.0",
+    "undici": "^7.0.0",
     "arktype": "^2.1.29",
     "commander": "^14.0.2",
     "fflate": "^0.8.2",


### PR DESCRIPTION
## Summary
- Add `undici` to dependencies in `packages/clawdhub/package.json`

The CLI imports `undici` for HTTP/2 support but it was not listed in dependencies, causing `ERR_MODULE_NOT_FOUND` when running via `npx`.

Fixes #23

## Test plan
- [ ] Run `npx clawdhub@latest --help` after publishing new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)