### PR TITLE
[Issue #26] Search fix.

### DIFF
--- a/convex/search.ts
+++ b/convex/search.ts
@@ -108,7 +108,7 @@ export const hydrateResults = internalQuery({
         const embedding = await ctx.db.get(embeddingId)
         if (!embedding) return null
         const skill = await ctx.db.get(embedding.skillId)
-        if (skill?.softDeletedAt) return null
+        if (!skill || skill.softDeletedAt) return null
         const [version, ownerHandle] = await Promise.all([
           ctx.db.get(embedding.versionId),
           getOwnerHandle(skill.ownerUserId),


### PR DESCRIPTION
I noticed search results weren't returning on web yesterday and Claude Code identified the following problem:

```
  const skill = await ctx.db.get(embedding.skillId)
  if (skill?.softDeletedAt) return null
  const [version, ownerHandle] = await Promise.all([
    ctx.db.get(embedding.versionId),
    getOwnerHandle(skill.ownerUserId),  // ← Here
  ])
```

The bug: The code checks if (skill?.softDeletedAt) return null, but this only returns early if the skill exists AND is soft-deleted. If skill is null or undefined (which can happen if the skill was deleted from the database), the check passes through because null?.softDeletedAt evaluates to undefined (falsy).

Then on the next line, it tries to access skill.ownerUserId, which will throw an error if skill is null/undefined.

## Future Tests?
While full integration tests require a bit more infrastructure, in the future it might be worth having one endpoint test that returns a known result and doesn't return a soft-deleted result. I have filed this as an issue: https://github.com/clawdbot/clawdhub/issues/29