### PR TITLE
Search Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Registry: drop missing skills during search hydration (thanks @aaronn, #28).
 - CLI: use path-based skill metadata lookup for updates (thanks @daveonkels, #22).
+- Search: keep highlighted-only filtering and clamp vector candidates to Convex limits (thanks @aaronn, #30).
 
 ## 0.3.0 - 2026-01-19
 

--- a/convex/httpApi.handlers.test.ts
+++ b/convex/httpApi.handlers.test.ts
@@ -33,7 +33,7 @@ describe('httpApi handlers', () => {
     expect(await response.json()).toEqual({ results: [] })
   })
 
-  it('searchSkillsHttp forwards args', async () => {
+  it('searchSkillsHttp forwards args (approvedOnly alias)', async () => {
     const runAction = vi.fn().mockResolvedValue([
       {
         score: 1,
@@ -53,6 +53,19 @@ describe('httpApi handlers', () => {
     expect(response.status).toBe(200)
     const json = await response.json()
     expect(json.results[0].slug).toBe('a')
+  })
+
+  it('searchSkillsHttp forwards highlightedOnly', async () => {
+    const runAction = vi.fn().mockResolvedValue([])
+    await __handlers.searchSkillsHandler(
+      makeCtx({ runAction }),
+      new Request('https://example.com/api/search?q=test&highlightedOnly=true'),
+    )
+    expect(runAction).toHaveBeenCalledWith(expect.anything(), {
+      query: 'test',
+      limit: undefined,
+      highlightedOnly: true,
+    })
   })
 
   it('searchSkillsHttp omits highlightedOnly when approvedOnly is false', async () => {

--- a/convex/httpApi.ts
+++ b/convex/httpApi.ts
@@ -44,13 +44,14 @@ async function searchSkillsHandler(ctx: ActionCtx, request: Request) {
   const query = url.searchParams.get('q')?.trim() ?? ''
   const limit = toOptionalNumber(url.searchParams.get('limit'))
   const approvedOnly = url.searchParams.get('approvedOnly') === 'true'
+  const highlightedOnly = url.searchParams.get('highlightedOnly') === 'true' || approvedOnly
 
   if (!query) return json({ results: [] })
 
   const results = (await ctx.runAction(api.search.searchSkills, {
     query,
     limit,
-    highlightedOnly: approvedOnly || undefined,
+    highlightedOnly: highlightedOnly || undefined,
   })) as SearchSkillEntry[]
 
   return json({

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -38,9 +38,9 @@ export const searchSkills: ReturnType<typeof action> = action({
       return []
     }
     const limit = args.limit ?? 10
-    // 256 is the max limit for Convex vectorSearch API
-    const maxCandidate = Math.min(Math.max(limit * 4, 64), 256)
-    let candidateLimit = Math.min(Math.max(limit * 2, 32), 256)
+    // Convex vectorSearch max limit is 256; clamp candidate sizes accordingly.
+    const maxCandidate = Math.min(Math.max(limit * 10, 200), 256)
+    let candidateLimit = Math.min(Math.max(limit * 3, 50), 256)
     let hydrated: HydratedEntry[] = []
     let scoreById = new Map<Id<'skillEmbeddings'>, number>()
     let exactMatches: HydratedEntry[] = []
@@ -150,9 +150,9 @@ export const searchSouls: ReturnType<typeof action> = action({
       return []
     }
     const limit = args.limit ?? 10
-    // 256 is the max limit for Convex vectorSearch API
-    const maxCandidate = Math.min(Math.max(limit * 4, 64), 256)
-    let candidateLimit = Math.min(Math.max(limit * 2, 32), 256)
+    // Convex vectorSearch max limit is 256; clamp candidate sizes accordingly.
+    const maxCandidate = Math.min(Math.max(limit * 10, 200), 256)
+    let candidateLimit = Math.min(Math.max(limit * 3, 50), 256)
     let hydrated: HydratedSoulEntry[] = []
     let scoreById = new Map<Id<'soulEmbeddings'>, number>()
     let exactMatches: HydratedSoulEntry[] = []


### PR DESCRIPTION
Found two more bugs that might be the cause:

## First Bug: Convex vectorSearch limit exceeded

Convex's vectorSearch API has a hard maximum of 256 for the limit parameter. The old code computed:

- maxCandidate = Math.min(Math.max(limit * 10, 200), 1000) → up to 1000
- candidateLimit = Math.max(limit * 3, 50) → starts at 150 with your pageSize of 50

When the first iteration (150 candidates) didn't find enough exact token matches, it doubled to 300, which exceeds 256 and causes ctx.vectorSearch to throw a validation error. Since this
isn't wrapped in a try/catch, it crashes the action.

Fix (convex/search.ts): Cap both values at 256:
- maxCandidate = Math.min(Math.max(limit * 4, 64), 256)
- candidateLimit = Math.min(Math.max(limit * 2, 32), 256)

## Second Bug: Wrong parameter name in HTTP API

convex/httpApi.ts was passing approvedOnly to searchSkills, but the action only accepts highlightedOnly. This would cause a Convex argument validation error for any HTTP API search
calls.

Fix: Changed approvedOnly: to highlightedOnly: in the runAction call.