### PR TITLE
Fix tests due to missing mock version in skills.test.ts

### DIFF
--- a/packages/clawdhub/src/cli/commands/skills.test.ts
+++ b/packages/clawdhub/src/cli/commands/skills.test.ts
@@ -170,6 +170,7 @@ describe('cmdUpdate', () => {
     mockApiRequest.mockResolvedValue({ latestVersion: { version: '1.0.0' } })
     mockDownloadZip.mockResolvedValue(new Uint8Array([1, 2, 3]))
     vi.mocked(readLockfile).mockResolvedValue({
+      version: 1,
       skills: { demo: { version: '0.1.0', installedAt: 123 } },
     })
     vi.mocked(writeLockfile).mockResolvedValue()


### PR DESCRIPTION
Commit d7a017e1c3d6f8dff0261d18dd373aaa730a31d5 broke CI.

The mock for readLockfile is missing the top-level version property that the type now requires.This adds it to fix tests.