### PR TITLE
fix: make /search mode-aware

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -84,7 +84,7 @@ export default function Header() {
             Upload
           </Link>
           {isSoulMode ? null : <Link to="/import">Import</Link>}
-          <Link to="/" search={{ q: undefined, highlighted: undefined, search: true }}>
+          <Link to="/search" search={{ q: undefined, highlighted: undefined }}>
             Search
           </Link>
           {me ? <Link to="/stars">Stars</Link> : null}
@@ -138,7 +138,7 @@ export default function Header() {
                   </DropdownMenuItem>
                 )}
                 <DropdownMenuItem asChild>
-                  <Link to="/" search={{ q: undefined, highlighted: undefined, search: true }}>
+                  <Link to="/search" search={{ q: undefined, highlighted: undefined }}>
                     Search
                   </Link>
                 </DropdownMenuItem>

--- a/src/routes/search.tsx
+++ b/src/routes/search.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
+import { getSiteMode } from '../lib/site'
 
 export const Route = createFileRoute('/search')({
   validateSearch: (search) => ({
@@ -6,13 +7,37 @@ export const Route = createFileRoute('/search')({
     highlighted: search.highlighted === '1' || search.highlighted === 'true' ? true : undefined,
   }),
   beforeLoad: ({ search }) => {
-    throw redirect({
-      to: '/skills',
-      search: {
-        q: search.q || undefined,
-        highlighted: search.highlighted || undefined,
-      },
-      replace: true,
-    })
+    const mode = getSiteMode()
+    switch (mode) {
+      case 'souls':
+        throw redirect({
+          to: '/',
+          search: {
+            q: search.q || undefined,
+            highlighted: undefined,
+            search: search.q ? undefined : true,
+          },
+          replace: true,
+        })
+      case 'skills':
+        throw redirect({
+          to: '/skills',
+          search: {
+            q: search.q || undefined,
+            highlighted: search.highlighted || undefined,
+          },
+          replace: true,
+        })
+      default:
+        throw redirect({
+          to: '/',
+          search: {
+            q: search.q || undefined,
+            highlighted: undefined,
+            search: search.q ? undefined : true,
+          },
+          replace: true,
+        })
+    }
   },
 })


### PR DESCRIPTION
## Summary
- make /search mode-aware with a default redirect
- point header Search link to /search

## Rationale
- Standardizing on `/search` gives us stable, shareable URLs across deployments. It lets us map search to the right mode today while keeping a single bookmarkable entry point that we can rewire later without breaking links.

## Heads-up
- Quick check: do our SSR deploy envs always set the intended mode (e.g., via VITE_SITE_MODE)? If not, `/search` could resolve to the wrong mode when VITE_SOULHUB_SITE_URL is set. src/routes/search.tsx:9-31

## Testing
- bun run lint (pass)
- bun run test (fail: src/lib/site.test.ts; src/__tests__/search-route.test.ts; src/__tests__/upload.route.test.tsx)
- bun run test:e2e (fail: 3 tests in e2e/clawdhub.e2e.test.ts)
- bun run coverage (fail: same as bun run test)
- bun run test:pw (fail: preview server couldn’t start; build required)
