### PR TITLE
docs: document undici dependency fix in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Registry: drop missing skills during search hydration (thanks @aaronn, #28).
 - CLI: use path-based skill metadata lookup for updates (thanks @daveonkels, #22).
 - Search: keep highlighted-only filtering and clamp vector candidates to Convex limits (thanks @aaronn, #30).
+- CLI: add missing `undici` dependency to package.json (fixes #23).
 
 ## 0.3.0 - 2026-01-19
 


### PR DESCRIPTION
## Summary
This PR documents the undici dependency fix in the CHANGELOG under the "Unreleased" section.

## Background
Issue #23 reported that `clawdhub v0.3.0` fails with `ERR_MODULE_NOT_FOUND` for the `undici` package when installed from npm.

## What happened
- The fix (adding `undici` to `package.json`) was already committed to the main branch
- However, v0.3.0 was published to npm **before** this fix was committed
- The fix was not documented in the CHANGELOG

## This PR
- ✅ Adds a CHANGELOG entry documenting that the `undici` dependency has been added
- ✅ References issue #23 for tracking
- ✅ Prepares the CHANGELOG for the next patch release (v0.3.1)

## Impact
This ensures users understand the fix will be available in the next npm release and maintainers have proper release notes when publishing v0.3.1.

Fixes #23

---
Co-Authored-By: Warp <agent@warp.dev>