### PR TITLE
feat(cli): support CLAWDHUB_DIR env var and config.json for skills directory

### DIFF
--- a/packages/clawdhub/README.md
+++ b/packages/clawdhub/README.md
@@ -54,4 +54,4 @@ clawdhub sync --root ../clawdis/skills --all --dry-run
 - Site: `https://clawdhub.com` (override via `--site` or `CLAWDHUB_SITE`)
 - Registry: discovered from `/.well-known/clawdhub.json` on the site (override via `--registry` or `CLAWDHUB_REGISTRY`)
 - Workdir: current directory (falls back to Clawdbot workspace if configured; override via `--workdir` or `CLAWDHUB_WORKDIR`)
-- Install dir: `./skills` under workdir (override via `--dir`)
+- Install dir: `./skills` under workdir (override via `--dir`, `CLAWDHUB_DIR`, or `dir` in config.json)

--- a/packages/clawdhub/src/cli.ts
+++ b/packages/clawdhub/src/cli.ts
@@ -34,7 +34,7 @@ const program = new Command()
   .showSuggestionAfterError()
   .addHelpText(
     'after',
-    styleEnvBlock('\nEnv:\n  CLAWDHUB_SITE\n  CLAWDHUB_REGISTRY\n  CLAWDHUB_WORKDIR\n'),
+    styleEnvBlock('\nEnv:\n  CLAWDHUB_SITE\n  CLAWDHUB_REGISTRY\n  CLAWDHUB_WORKDIR\n  CLAWDHUB_DIR\n'),
   )
 
 configureCommanderHelp(program)
@@ -42,7 +42,9 @@ configureCommanderHelp(program)
 async function resolveGlobalOpts(): Promise<GlobalOpts> {
   const raw = program.opts<{ workdir?: string; dir?: string; site?: string; registry?: string }>()
   const workdir = await resolveWorkdir(raw.workdir)
-  const dir = resolve(workdir, raw.dir ?? 'skills')
+  const config = await readGlobalConfig()
+  const dirRel = raw.dir ?? process.env.CLAWDHUB_DIR ?? config?.dir ?? 'skills'
+  const dir = resolve(workdir, dirRel)
   const site = raw.site ?? process.env.CLAWDHUB_SITE ?? DEFAULT_SITE
   const registrySource = raw.registry ? 'cli' : process.env.CLAWDHUB_REGISTRY ? 'env' : 'default'
   const registry = raw.registry ?? process.env.CLAWDHUB_REGISTRY ?? DEFAULT_REGISTRY

--- a/packages/clawdhub/src/schema/schemas.ts
+++ b/packages/clawdhub/src/schema/schemas.ts
@@ -3,6 +3,7 @@ import { type inferred, type } from 'arktype'
 export const GlobalConfigSchema = type({
   registry: 'string',
   token: 'string?',
+  dir: 'string?',
 })
 export type GlobalConfig = (typeof GlobalConfigSchema)[inferred]
 


### PR DESCRIPTION
## Summary

Add support for configuring the skills install directory via:
- `CLAWDHUB_DIR` environment variable
- `dir` field in `config.json`

**Priority order**: CLI flag (`--dir`) > ENV > config > default (`skills`)

## Motivation

The current default of `skills/` conflicts with hand-written local skills. Users can set `dir: ".clawdhub/skills"` in their config to keep installed skills alongside the lockfile, making it easy to gitignore the entire `.clawdhub/` directory.

## Changes

- `src/schema/schemas.ts`: Add optional `dir` field to GlobalConfigSchema
- `src/cli.ts`: Check env var and config when resolving skills directory
- `README.md`: Document the new options