### PR TITLE
fix: add CSP headers and Content-Disposition to prevent SVG XSS 🚨

### DIFF
--- a/convex/httpApiV1.ts
+++ b/convex/httpApiV1.ts
@@ -375,6 +375,7 @@ async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request) {
     if (!blob) return text('File missing in storage', 410, rate.headers)
     const textContent = await blob.text()
 
+    const isSvg = file.contentType?.toLowerCase().includes('svg')
     const headers = mergeHeaders(rate.headers, {
       'Content-Type': file.contentType
         ? `${file.contentType}; charset=utf-8`
@@ -383,6 +384,9 @@ async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request) {
       ETag: file.sha256,
       'X-Content-SHA256': file.sha256,
       'X-Content-Size': String(file.size),
+      'X-Content-Type-Options': 'nosniff',
+      'Content-Security-Policy': "default-src 'none'; style-src 'unsafe-inline'; img-src * data:; media-src *",
+      ...(isSvg ? { 'Content-Disposition': 'attachment' } : {}),
     })
     return new Response(textContent, { status: 200, headers })
   }
@@ -984,6 +988,7 @@ async function soulsGetRouterV1Handler(ctx: ActionCtx, request: Request) {
 
     void ctx.runMutation(api.soulDownloads.increment, { soulId: soulResult.soul._id })
 
+    const isSvg = file.contentType?.toLowerCase().includes('svg')
     const headers = mergeHeaders(rate.headers, {
       'Content-Type': file.contentType
         ? `${file.contentType}; charset=utf-8`
@@ -992,6 +997,9 @@ async function soulsGetRouterV1Handler(ctx: ActionCtx, request: Request) {
       ETag: file.sha256,
       'X-Content-SHA256': file.sha256,
       'X-Content-Size': String(file.size),
+      'X-Content-Type-Options': 'nosniff',
+      'Content-Security-Policy': "default-src 'none'; style-src 'unsafe-inline'; img-src * data:; media-src *",
+      ...(isSvg ? { 'Content-Disposition': 'attachment' } : {}),
     })
     return new Response(textContent, { status: 200, headers })
   }


### PR DESCRIPTION
                                                                                                             
  ## Summary                                                                                                  
                                                                                                              
  SVG files served through the skills and souls file endpoints (`/api/v1/skills/:name/file` and               
  `/api/v1/souls/:name/file`) execute arbitrary JavaScript via `<foreignObject>`. Because these files are     
  served from the main `clawdhub.com` origin with no Content-Security-Policy or Content-Disposition headers,  
  any script in an SVG runs with full same-origin access to `localStorage`, including Convex auth JWTs and    
  refresh tokens.                                                                                             
                                                                                                              
  An attacker can publish a skill containing a malicious SVG, then link to it from their skill's README.      
  Anyone who clicks the link while logged in has their session tokens exposed. Refresh tokens mean the        
  attacker maintains access even after the JWT expires.                                                       
                                                                                                              
  **PoC (open while logged in to ClawdHub):** https://clawdhub.com/api/v1/skills/red-pill/file?path=icon.svg  
                                                                                                              
  ## What this patch does                                                                                     
                                                                                                              
  Adds three layers of defense to both file-serving endpoints in `convex/httpApiV1.ts`:                       
                                                                                                              
  - **`Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; img-src * data:; media-src *`**
   -- blocks all script execution while still allowing static SVG rendering with inline styles and images     
  - **`X-Content-Type-Options: nosniff`** -- prevents the browser from reinterpreting content types           
  - **`Content-Disposition: attachment`** on SVG files specifically -- forces download instead of inline      
  rendering as a belt-and-suspenders measure                                                                  
                                                                                                              
  ## Affected endpoints                                                                                       
                                                                                                              
  - `skillsGetRouterV1Handler` (line ~378)                                                                    
  - `soulsGetRouterV1Handler` (line ~987)                                                                     
                                                                                                              
  ## Test plan                                                                                                
                                                                                                              
  - [ ] Open the PoC SVG link above after deploying -- should download instead of rendering inline            
  - [ ] Verify non-SVG files (`.js`, `.md`, `.json`) still serve normally with correct content types          
  - [ ] Confirm CSP header is present on all file responses via browser dev tools                             
  - [ ] Confirm `X-Content-Type-Options: nosniff` is present on all file responses 