### PR TITLE
chore(moderation): block ClawdAuthenticatorTool (suspected malware)

### DIFF
--- a/convex/lib/moderation.ts
+++ b/convex/lib/moderation.ts
@@ -1,6 +1,10 @@
 import type { Doc } from '../_generated/dataModel'
 
 const FLAG_RULES: Array<{ flag: string; pattern: RegExp }> = [
+  // Known-bad / known-suspicious identifiers.
+  // NOTE: keep these narrowly scoped; use staff review to confirm removals.
+  { flag: 'blocked.malware', pattern: /(keepcold131\/ClawdAuthenticatorTool|ClawdAuthenticatorTool)/i },
+
   { flag: 'suspicious.keyword', pattern: /(malware|stealer|phish|phishing|keylogger)/i },
   { flag: 'suspicious.secrets', pattern: /(api[-_ ]?key|token|password|private key|secret)/i },
   { flag: 'suspicious.crypto', pattern: /(wallet|seed phrase|mnemonic|crypto)/i },

--- a/convex/lib/public.ts
+++ b/convex/lib/public.ts
@@ -53,6 +53,8 @@ export function toPublicUser(user: Doc<'users'> | null | undefined): PublicUser 
 
 export function toPublicSkill(skill: Doc<'skills'> | null | undefined): PublicSkill | null {
   if (!skill || skill.softDeletedAt) return null
+  if (skill.moderationStatus && skill.moderationStatus !== 'active') return null
+  if (skill.moderationFlags?.includes('blocked.malware')) return null
   return {
     _id: skill._id,
     _creationTime: skill._creationTime,
@@ -73,6 +75,8 @@ export function toPublicSkill(skill: Doc<'skills'> | null | undefined): PublicSk
 
 export function toPublicSoul(soul: Doc<'souls'> | null | undefined): PublicSoul | null {
   if (!soul || soul.softDeletedAt) return null
+  if (soul.moderationStatus && soul.moderationStatus !== 'active') return null
+  if (soul.moderationFlags?.includes('blocked.malware')) return null
   return {
     _id: soul._id,
     _creationTime: soul._creationTime,


### PR DESCRIPTION
Context: report of suspected malware distribution via GitHub release `keepcold131/ClawdAuthenticatorTool`.

Reasons this looks malicious / unsafe:
- Repo contains no source code (only a 63-byte README).
- Release asset is a large (~104MB) zip.
- Zip appears to be password-protected (can list entries but cannot extract without password), which is commonly used to evade automated scanning.

This PR adds a narrow, explicit block:
- Add moderation flag `blocked.malware` for identifiers matching `keepcold131/ClawdAuthenticatorTool`.
- Hide any skill/soul carrying that flag (or moderationStatus != active) from public listings via `toPublicSkill` / `toPublicSoul`.

No attempt is made to download/execute the file.
