### PR TITLE
fix(cli): use www.clawhub.ai as default registry

### DIFF
--- a/packages/clawdhub/src/cli/registry.ts
+++ b/packages/clawdhub/src/cli/registry.ts
@@ -2,8 +2,8 @@ import { readGlobalConfig, writeGlobalConfig } from '../config.js'
 import { discoverRegistryFromSite } from '../discovery.js'
 import type { GlobalOpts } from './types.js'
 
-export const DEFAULT_SITE = 'https://clawhub.ai'
-export const DEFAULT_REGISTRY = 'https://clawhub.ai'
+export const DEFAULT_SITE = 'https://www.clawhub.ai'
+export const DEFAULT_REGISTRY = 'https://www.clawhub.ai'
 const LEGACY_REGISTRY_HOSTS = new Set(['auth.clawdhub.com', 'auth.clawhub.com', 'auth.clawhub.ai'])
 
 export async function resolveRegistry(opts: GlobalOpts) {


### PR DESCRIPTION
## Summary
The CLI defaults to `https://clawhub.ai` but the API only responds at `https://www.clawhub.ai` (with www subdomain).

This causes token verification to fail with 'Unauthorized' even for valid tokens created via the web UI.

## Changes
- Updated `DEFAULT_SITE` and `DEFAULT_REGISTRY` to include `www.` subdomain

## Testing
- Confirmed tokens work when manually specifying `--registry https://www.clawhub.ai`
- Successfully published a skill after this workaround

Fixes #72