### PR TITLE
Add AgentGuard — supply chain security scanner for agent skills

### DIFF
--- a/docs/security-scanning.md
+++ b/docs/security-scanning.md
@@ -15,8 +15,8 @@ Agent skills run with access to your filesystem, credentials, and network. A mal
 ## Install
 
 ```bash
-# Install from GitHub (npm package coming soon)
-npm install -g github:rondorkerin/agentguard
+# Install from npm (published as "agentguard-ai")
+npm install -g agentguard-ai
 ```
 
 ## Scan before installing
@@ -57,7 +57,7 @@ Add AgentGuard as a gate in your publish pipeline:
 # GitHub Actions example
 - name: Security scan
   run: |
-    npm install -g github:rondorkerin/agentguard
+    npm install -g agentguard-ai
     agentguard scan ./skill/ --fail-on HIGH --json > security-report.json
 ```
 
@@ -70,5 +70,5 @@ As the skill ecosystem grows, automated security scanning becomes essential. We 
 ## Links
 
 - **Repository**: [github.com/rondorkerin/agentguard](https://github.com/rondorkerin/agentguard)
-- **Install**: `npm install -g github:rondorkerin/agentguard`
+- **Install**: `npm install -g agentguard-ai`
 - **Issues**: [github.com/rondorkerin/agentguard/issues](https://github.com/rondorkerin/agentguard/issues)


### PR DESCRIPTION
## What

Adds a security scanning guide to ClawdHub docs, introducing [AgentGuard](https://github.com/rondorkerin/agentguard) as a tool for scanning skills before installation or as a CI/CD gate.

## Why this matters

Agent skills run with access to filesystems, credentials, and networks. During testing, **AgentGuard detected a credential stealer in a published skill** — it was reading `~/.ssh/` and `~/.aws/credentials` then exfiltrating them via HTTPS. Trust score: 0/100.

As ClawdHub grows, the ecosystem needs a security layer. AgentGuard is that layer — think `npm audit` for agent skills.

## What AgentGuard detects

- 🔑 Credential exfiltration (SSH keys, AWS creds, API tokens)
- 💉 Code injection (eval, exec, Function constructor)
- 📡 Outbound data exfiltration
- 🎭 Obfuscation (base64/hex-encoded payloads)
- ⚠️ Compound threats (credential read + network call in same file)

## Test results

AgentGuard has been tested against both clean skills and intentionally malicious samples:
- Clean skills score 90-100 (safe)
- Known malicious skill scored 0/100 with 3 CRITICAL + 2 HIGH findings
- Full test suite passes with pattern detection for all major threat categories

## Links

- **Repo**: https://github.com/rondorkerin/agentguard
- **Install**: `npm install -g agentguard`
- **RFC for inter-agent security messaging**: https://github.com/openclaw/openclaw/issues/5517

Happy to iterate on the docs or discuss integrating AgentGuard into the ClawdHub publish pipeline as a built-in security gate.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new documentation page (`docs/security-scanning.md`) that introduces AgentGuard as an optional pre-install and CI/CD gate scanner for third-party skills, outlining install/scan commands, detection categories, and a trust-score interpretation.

This fits into the existing `docs/` set of operational/reference pages (similar frontmatter + “read_when” taxonomy), giving users a concrete workflow for reducing supply-chain risk from skill bundles before running them with filesystem/network access.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it’s a docs-only change with minor wording/clarity nits.
- Only a single new markdown doc is added; no code paths or runtime behavior change. Findings are limited to consistency/clarity of wording and an ambiguity in the `--fail-on` example semantics.
- docs/security-scanning.md

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a1d58d20-b4dd-4cbb-973a-9fd7824e1921))

<!-- /greptile_comment -->