### PR TITLE
chore: add github repo banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
 </p>
 
-![GitHub Repo Banner](https://ghrb.waren.build/banner?header=%F0%9F%A6%9EClawHub&subheader=Skill+Directory+for+OpenClaw&bg=00000000&color=ffffff&support=true)<!-- Created with GitHub Repo Banner by Waren Gonzaga: https://ghrb.waren.build -->
+![GitHub Repo Banner](https://ghrb.waren.build/banner?header=%F0%9F%A6%9EClawHub&subheader=Skill+Directory+for+OpenClaw&bg=00000000&color=ffffff&support=true)
+<!-- Created with GitHub Repo Banner by Waren Gonzaga: https://ghrb.waren.build -->
 
 ClawHub is the **public skill registry for Clawdbot**: publish, version, and search text-based agent skills (a `SKILL.md` plus supporting files).
 It’s designed for fast browsing + a CLI-friendly API, with moderation hooks and vector search.


### PR DESCRIPTION
This pull request adds a visual improvement to the project documentation by including a GitHub repository banner in the `README.md` file.

Documentation update:

* Added a GitHub Repo Banner image at the top of `README.md` to enhance the project's visual presentation.

---

The banner is made using this tool: https://ghrb.waren.build/ (I made it)
Wondering if we can add this to this project to have some good visuals. (Just launched today, yey)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates project documentation by adding a GitHub README banner image near the top of `README.md` (under the existing badges) to improve visual presentation.

The change is isolated to documentation and does not affect runtime code paths or application behavior.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it’s a documentation-only change with low blast radius.
- The only change is adding a README banner image. Main considerations are long-term reliability/maintainability of a remote, dynamically generated asset and minor markdown rendering portability.
- README.md (banner hosting/format choice)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a1d58d20-b4dd-4cbb-973a-9fd7824e1921))

<!-- /greptile_comment -->