### PR TITLE
fix: use www.clawhub.ai as default registry to prevent auth header stripping on redirect

### DIFF
--- a/e2e/clawdhub.e2e.test.ts
+++ b/e2e/clawdhub.e2e.test.ts
@@ -38,13 +38,13 @@ function getRegistry() {
   return (
     process.env.CLAWHUB_REGISTRY?.trim() ||
     process.env.CLAWDHUB_REGISTRY?.trim() ||
-    'https://clawhub.ai'
+    'https://www.clawhub.ai'
   )
 }
 
 function getSite() {
   return (
-    process.env.CLAWHUB_SITE?.trim() || process.env.CLAWDHUB_SITE?.trim() || 'https://clawhub.ai'
+    process.env.CLAWHUB_SITE?.trim() || process.env.CLAWDHUB_SITE?.trim() || 'https://www.clawhub.ai'
   )
 }
 

--- a/packages/clawdhub/src/cli/commands/delete.test.ts
+++ b/packages/clawdhub/src/cli/commands/delete.test.ts
@@ -4,11 +4,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { GlobalOpts } from '../types'
 
 vi.mock('../../config.js', () => ({
-  readGlobalConfig: vi.fn(async () => ({ registry: 'https://clawhub.ai', token: 'tkn' })),
+  readGlobalConfig: vi.fn(async () => ({ registry: 'https://www.clawhub.ai', token: 'tkn' })),
 }))
 
 vi.mock('../registry.js', () => ({
-  getRegistry: vi.fn(async () => 'https://clawhub.ai'),
+  getRegistry: vi.fn(async () => 'https://www.clawhub.ai'),
 }))
 
 const mockApiRequest = vi.fn()
@@ -35,8 +35,8 @@ function makeOpts(): GlobalOpts {
   return {
     workdir: '/work',
     dir: '/work/skills',
-    site: 'https://clawhub.ai',
-    registry: 'https://clawhub.ai',
+    site: 'https://www.clawhub.ai',
+    registry: 'https://www.clawhub.ai',
     registrySource: 'default',
   }
 }

--- a/packages/clawdhub/src/cli/commands/inspect.test.ts
+++ b/packages/clawdhub/src/cli/commands/inspect.test.ts
@@ -11,7 +11,7 @@ vi.mock('../../http.js', () => ({
   fetchText: (...args: unknown[]) => mockFetchText(...args),
 }))
 
-const mockGetRegistry = vi.fn(async () => 'https://clawhub.ai')
+const mockGetRegistry = vi.fn(async () => 'https://www.clawhub.ai')
 vi.mock('../registry.js', () => ({
   getRegistry: () => mockGetRegistry(),
 }))
@@ -41,8 +41,8 @@ function makeOpts(): GlobalOpts {
   return {
     workdir: '/work',
     dir: '/work/skills',
-    site: 'https://clawhub.ai',
-    registry: 'https://clawhub.ai',
+    site: 'https://www.clawhub.ai',
+    registry: 'https://www.clawhub.ai',
     registrySource: 'default',
   }
 }

--- a/packages/clawdhub/src/cli/commands/moderation.test.ts
+++ b/packages/clawdhub/src/cli/commands/moderation.test.ts
@@ -4,11 +4,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { GlobalOpts } from '../types'
 
 vi.mock('../../config.js', () => ({
-  readGlobalConfig: vi.fn(async () => ({ registry: 'https://clawhub.ai', token: 'tkn' })),
+  readGlobalConfig: vi.fn(async () => ({ registry: 'https://www.clawhub.ai', token: 'tkn' })),
 }))
 
 vi.mock('../registry.js', () => ({
-  getRegistry: vi.fn(async () => 'https://clawhub.ai'),
+  getRegistry: vi.fn(async () => 'https://www.clawhub.ai'),
 }))
 
 const mockApiRequest = vi.fn()
@@ -33,8 +33,8 @@ function makeOpts(): GlobalOpts {
   return {
     workdir: '/work',
     dir: '/work/skills',
-    site: 'https://clawhub.ai',
-    registry: 'https://clawhub.ai',
+    site: 'https://www.clawhub.ai',
+    registry: 'https://www.clawhub.ai',
     registrySource: 'default',
   }
 }

--- a/packages/clawdhub/src/cli/commands/publish.test.ts
+++ b/packages/clawdhub/src/cli/commands/publish.test.ts
@@ -7,10 +7,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { GlobalOpts } from '../types'
 
 vi.mock('../../config.js', () => ({
-  readGlobalConfig: vi.fn(async () => ({ registry: 'https://clawhub.ai', token: 'tkn' })),
+  readGlobalConfig: vi.fn(async () => ({ registry: 'https://www.clawhub.ai', token: 'tkn' })),
 }))
 
-const mockGetRegistry = vi.fn(async (_opts: unknown, _params?: unknown) => 'https://clawhub.ai')
+const mockGetRegistry = vi.fn(async (_opts: unknown, _params?: unknown) => 'https://www.clawhub.ai')
 vi.mock('../registry.js', () => ({
   getRegistry: (opts: unknown, params?: unknown) => mockGetRegistry(opts, params),
 }))
@@ -42,8 +42,8 @@ function makeOpts(workdir: string): GlobalOpts {
   return {
     workdir,
     dir: join(workdir, 'skills'),
-    site: 'https://clawhub.ai',
-    registry: 'https://clawhub.ai',
+    site: 'https://www.clawhub.ai',
+    registry: 'https://www.clawhub.ai',
     registrySource: 'default',
   }
 }

--- a/packages/clawdhub/src/cli/commands/skills.test.ts
+++ b/packages/clawdhub/src/cli/commands/skills.test.ts
@@ -11,7 +11,7 @@ vi.mock('../../http.js', () => ({
   downloadZip: (...args: unknown[]) => mockDownloadZip(...args),
 }))
 
-const mockGetRegistry = vi.fn(async () => 'https://clawhub.ai')
+const mockGetRegistry = vi.fn(async () => 'https://www.clawhub.ai')
 vi.mock('../registry.js', () => ({
   getRegistry: () => mockGetRegistry(),
 }))
@@ -68,8 +68,8 @@ function makeOpts(): GlobalOpts {
   return {
     workdir: '/work',
     dir: '/work/skills',
-    site: 'https://clawhub.ai',
-    registry: 'https://clawhub.ai',
+    site: 'https://www.clawhub.ai',
+    registry: 'https://www.clawhub.ai',
     registrySource: 'default',
   }
 }

--- a/packages/clawdhub/src/cli/commands/sync.test.ts
+++ b/packages/clawdhub/src/cli/commands/sync.test.ts
@@ -27,10 +27,10 @@ vi.mock('@clack/prompts', () => ({
 }))
 
 vi.mock('../../config.js', () => ({
-  readGlobalConfig: vi.fn(async () => ({ registry: 'https://clawhub.ai', token: 'tkn' })),
+  readGlobalConfig: vi.fn(async () => ({ registry: 'https://www.clawhub.ai', token: 'tkn' })),
 }))
 
-const mockGetRegistry = vi.fn(async () => 'https://clawhub.ai')
+const mockGetRegistry = vi.fn(async () => 'https://www.clawhub.ai')
 vi.mock('../registry.js', () => ({
   getRegistry: () => mockGetRegistry(),
 }))
@@ -89,8 +89,8 @@ function makeOpts(): GlobalOpts {
   return {
     workdir: '/work',
     dir: '/work/skills',
-    site: 'https://clawhub.ai',
-    registry: 'https://clawhub.ai',
+    site: 'https://www.clawhub.ai',
+    registry: 'https://www.clawhub.ai',
     registrySource: 'default',
   }
 }

--- a/packages/clawdhub/src/cli/registry.test.ts
+++ b/packages/clawdhub/src/cli/registry.test.ts
@@ -22,7 +22,7 @@ function makeOpts(overrides: Partial<GlobalOpts> = {}): GlobalOpts {
   return {
     workdir: '/work',
     dir: '/work/skills',
-    site: 'https://clawhub.ai',
+    site: 'https://www.clawhub.ai',
     registry: DEFAULT_REGISTRY,
     registrySource: 'default',
     ...overrides,
@@ -38,7 +38,7 @@ beforeEach(() => {
 describe('registry resolution', () => {
   it('prefers explicit registry over discovery/cache', async () => {
     readGlobalConfig.mockResolvedValue({ registry: 'https://auth.clawdhub.com' })
-    discoverRegistryFromSite.mockResolvedValue({ apiBase: 'https://clawhub.ai' })
+    discoverRegistryFromSite.mockResolvedValue({ apiBase: 'https://www.clawhub.ai' })
 
     const registry = await resolveRegistry(
       makeOpts({ registry: 'https://custom.example', registrySource: 'cli' }),
@@ -50,13 +50,13 @@ describe('registry resolution', () => {
 
   it('ignores legacy registry and updates cache from discovery', async () => {
     readGlobalConfig.mockResolvedValue({ registry: 'https://auth.clawdhub.com', token: 'tkn' })
-    discoverRegistryFromSite.mockResolvedValue({ apiBase: 'https://clawhub.ai' })
+    discoverRegistryFromSite.mockResolvedValue({ apiBase: 'https://www.clawhub.ai' })
 
     const registry = await getRegistry(makeOpts(), { cache: true })
 
-    expect(registry).toBe('https://clawhub.ai')
+    expect(registry).toBe('https://www.clawhub.ai')
     expect(writeGlobalConfig).toHaveBeenCalledWith({
-      registry: 'https://clawhub.ai',
+      registry: 'https://www.clawhub.ai',
       token: 'tkn',
     })
   })

--- a/packages/clawdhub/src/cli/registry.ts
+++ b/packages/clawdhub/src/cli/registry.ts
@@ -2,8 +2,8 @@ import { readGlobalConfig, writeGlobalConfig } from '../config.js'
 import { discoverRegistryFromSite } from '../discovery.js'
 import type { GlobalOpts } from './types.js'
 
-export const DEFAULT_SITE = 'https://clawhub.ai'
-export const DEFAULT_REGISTRY = 'https://clawhub.ai'
+export const DEFAULT_SITE = 'https://www.clawhub.ai'
+export const DEFAULT_REGISTRY = 'https://www.clawhub.ai'
 const LEGACY_REGISTRY_HOSTS = new Set(['auth.clawdhub.com', 'auth.clawhub.com', 'auth.clawhub.ai'])
 
 export async function resolveRegistry(opts: GlobalOpts) {

--- a/public/.well-known/clawhub.json
+++ b/public/.well-known/clawhub.json
@@ -1,6 +1,6 @@
 {
-  "apiBase": "https://clawhub.ai",
-  "authBase": "https://clawhub.ai",
+  "apiBase": "https://www.clawhub.ai",
+  "authBase": "https://www.clawhub.ai",
   "minCliVersion": "0.1.0",
-  "registry": "https://clawhub.ai"
+  "registry": "https://www.clawhub.ai"
 }


### PR DESCRIPTION
## Summary

`clawhub.ai` returns a **307 redirect** to `www.clawhub.ai`. Per standard HTTP security rules, the `Authorization` header is **stripped on cross-origin redirects**. This causes all authenticated CLI commands (`publish`, `whoami`, `sync`, `delete`, etc.) to fail with **"Unauthorized"** unless the user manually passes `--registry https://www.clawhub.ai`.

## Root Cause

- `DEFAULT_SITE` and `DEFAULT_REGISTRY` in `packages/clawdhub/src/cli/registry.ts` point to `https://clawhub.ai` (without `www`)
- `.well-known/clawhub.json` discovery file also returns non-www URLs
- CLI sends authenticated requests to `https://clawhub.ai`
- Server responds with 307 redirect to `https://www.clawhub.ai`
- Browser/fetch follows redirect but strips `Authorization` header (cross-origin security)
- Request arrives at `www.clawhub.ai` without auth → **"Unauthorized"**

## Fix

- Update `DEFAULT_SITE` and `DEFAULT_REGISTRY` to `https://www.clawhub.ai`
- Update `public/.well-known/clawhub.json` to use `www.clawhub.ai` for all endpoints
- Update all CLI test mocks and e2e test fallbacks to match

## Testing

- All 305 unit tests pass (46 test files)
- The fix is a minimal, targeted URL change — no logic modifications

## Related Issues

Fixes #100
Also fixes #41, #72, #99

All of these report the same symptom: CLI returns "Unauthorized" after successful login, which is caused by the auth header being stripped during the non-www → www redirect.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the CLI’s default `site`/`registry` URLs and the `.well-known/clawhub.json` discovery document to use `https://www.clawhub.ai` instead of `https://clawhub.ai`, avoiding a cross-origin 307 redirect that strips `Authorization` headers and breaks authenticated commands. Test fixtures and e2e defaults were updated accordingly.

One inconsistency remains: the Convex Discord webhook helper still defaults `SITE_URL` to the non-www domain, so webhook-generated links may continue pointing at the redirecting host instead of the new canonical URL.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk; it’s mostly a targeted URL change with one missed default outside the CLI.
- The production change is limited to switching default site/registry constants and the discovery document, and tests were updated to match. The primary concern is an inconsistent default URL in `convex/lib/webhooks.ts` that still points to the redirecting non-www domain, which could lead to inconsistent links.
- convex/lib/webhooks.ts (and its tests) for URL consistency

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a1d58d20-b4dd-4cbb-973a-9fd7824e1921))

<!-- /greptile_comment -->