### PR TITLE
fix: Restore soft-deleted users on re-authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Web: show pending-scan skills to owners without 404 (thanks @orlyjamie, #136).
 - Users: backfill empty handles from name/email in ensure (thanks @adlai88, #158).
 - Web: update footer branding to OpenClaw (thanks @jontsai, #122).
+- Auth: restore soft-deleted users on reauth, block banned users (thanks @mkrokosz, #106).
 
 ## 0.5.1 - TBD
 

--- a/convex/auth.test.ts
+++ b/convex/auth.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Id } from './_generated/dataModel'
+import { BANNED_REAUTH_MESSAGE, handleSoftDeletedUserReauth } from './auth'
+
+function makeCtx({
+  user,
+  banRecord,
+}: {
+  user: { deletedAt?: number } | null
+  banRecord?: Record<string, unknown> | null
+}) {
+  const query = {
+    withIndex: vi.fn().mockReturnValue({
+      filter: vi.fn().mockReturnValue({
+        first: vi.fn().mockResolvedValue(banRecord ?? null),
+      }),
+    }),
+  }
+  const ctx = {
+    db: {
+      get: vi.fn().mockResolvedValue(user),
+      patch: vi.fn().mockResolvedValue(null),
+      query: vi.fn().mockReturnValue(query),
+    },
+  }
+  return { ctx, query }
+}
+
+describe('handleSoftDeletedUserReauth', () => {
+  const userId = 'users:1' as Id<'users'>
+
+  it('skips when no existing user', async () => {
+    const { ctx } = makeCtx({ user: null })
+
+    await handleSoftDeletedUserReauth(ctx as never, { userId, existingUserId: null })
+
+    expect(ctx.db.get).not.toHaveBeenCalled()
+  })
+
+  it('skips active users', async () => {
+    const { ctx } = makeCtx({ user: { deletedAt: undefined } })
+
+    await handleSoftDeletedUserReauth(ctx as never, { userId, existingUserId: userId })
+
+    expect(ctx.db.query).not.toHaveBeenCalled()
+    expect(ctx.db.patch).not.toHaveBeenCalled()
+  })
+
+  it('restores soft-deleted users when not banned', async () => {
+    const { ctx } = makeCtx({ user: { deletedAt: 123 }, banRecord: null })
+
+    await handleSoftDeletedUserReauth(ctx as never, { userId, existingUserId: userId })
+
+    expect(ctx.db.patch).toHaveBeenCalledWith(userId, {
+      deletedAt: undefined,
+      updatedAt: expect.any(Number),
+    })
+  })
+
+  it('blocks banned users with a custom message', async () => {
+    const { ctx } = makeCtx({ user: { deletedAt: 123 }, banRecord: { action: 'user.ban' } })
+
+    await expect(
+      handleSoftDeletedUserReauth(ctx as never, { userId, existingUserId: userId }),
+    ).rejects.toThrow(BANNED_REAUTH_MESSAGE)
+
+    expect(ctx.db.patch).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Users who deleted their ClawHub account cannot sign in again with the same GitHub account. This PR fixes that by restoring self-deleted accounts on re-authentication.

## The Problem

When a user deletes their account:
1. `deletedAt` timestamp is set (soft-delete)
2. User record remains in database with GitHub ID

When they try to sign in again:
1. Convex Auth finds existing user by GitHub ID
2. Session is created
3. But `me` query filters deleted users: `if (!user || user.deletedAt) return null`
4. Frontend sees "not logged in", shows sign-in button
5. User is stuck - can never log in, no error message

## The Fix

Adds a `createOrUpdateUser` callback in `convex/auth.ts` that:
1. Detects soft-deleted users during OAuth
2. Checks audit logs to determine if user was **banned** vs **self-deleted**
3. If banned → throws error "This account has been suspended"
4. If self-deleted → clears `deletedAt` to restore account

## Security Consideration

Both `deleteAccount` and `banUser` set the same `deletedAt` field. This fix ensures **banned users cannot restore their accounts** by re-authenticating - only self-deleted users can restore.

## Performance

The callback runs on every OAuth sign-in, but:

| User State | Extra Queries | Notes |
|------------|---------------|-------|
| New user | 0 | Returns `null` immediately |
| Active user | 0 | Single `if` check on already-loaded field |
| Soft-deleted user | 1 | Indexed query on `auditLogs.by_target` |

**For 99% of logins (active users), there is zero performance impact.** The audit log query only runs for soft-deleted users attempting to sign in, and uses the existing `by_target` index.

## Testing

1. Create account → Delete account → Try to sign in again → Should restore and log in
2. Create account → Get banned by moderator → Try to sign in → Should see "suspended" error
3. Normal active user signs in → No change in behavior

---

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a `callbacks.createOrUpdateUser` hook in `convex/auth.ts` to restore soft-deleted user records when the same GitHub account re-authenticates. The callback:
- Lets Convex Auth create brand-new users (returns `null` when there is no `existingUserId`).
- For existing, active users, returns early without extra queries.
- For soft-deleted users, checks the `auditLogs.by_target` index for a `user.ban` record and blocks login with a suspension error if present; otherwise it clears `deletedAt` and updates `updatedAt` to restore the account.

This aligns the auth flow with the existing `me`/`requireUser` behavior that filters out `deletedAt` users, while preserving bans by treating ban audit logs as the source of truth.

<h3>Confidence Score: 4/5</h3>

- This PR looks safe to merge and addresses the soft-delete re-login bug with minimal behavioral surface area.
- The change is localized to the Convex Auth callback, follows existing ban semantics (via `user.ban` audit logs), and avoids extra queries for normal logins. The main concern is a minor schema/type mismatch (`auditLogs.targetId` is `string` while code compares against an `Id<'users'>`), which could make the ban check brittle depending on how IDs are serialized in practice.
- convex/auth.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a1d58d20-b4dd-4cbb-973a-9fd7824e1921))

<!-- /greptile_comment -->