### PR TITLE
feat: Add waves-claim skill for SURF Waves Cards

### DIFF
--- a/skills/waves-claim/SKILL.md
+++ b/skills/waves-claim/SKILL.md
@@ -7,7 +7,7 @@ metadata:
     emoji: "🎴"
     category: "web3"
     requires:
-      bins: ["cast"]
+      bins: ["cast", "jq"]
 ---
 
 # Waves Claim Skill

--- a/skills/waves-claim/install.sh
+++ b/skills/waves-claim/install.sh
@@ -7,30 +7,43 @@ set -e
 SKILL_DIR="${OPENCLAW_SKILLS:-$HOME/.openclaw/skills}/waves-claim"
 REPO_URL="https://raw.githubusercontent.com/openclaw/clawhub/main/skills/waves-claim"
 
-echo "🎴 Installing SURF Waves Cards claim skill..."
+echo "🎴 Installing SURF Waves Claim Skill..."
 
-# Create skill directory
+# Create directories
 mkdir -p "$SKILL_DIR/scripts"
 
-# Download skill files
+# Download files with error checking
+download_file() {
+  local url="$1"
+  local dest="$2"
+  local http_code
+  
+  http_code=$(curl -sL -w "%{http_code}" -o "$dest" "$url")
+  
+  if [ "$http_code" != "200" ]; then
+    echo "❌ Failed to download $url (HTTP $http_code)"
+    rm -f "$dest"
+    return 1
+  fi
+}
+
 echo "📥 Downloading skill files..."
-curl -sL "$REPO_URL/SKILL.md" > "$SKILL_DIR/SKILL.md"
-curl -sL "$REPO_URL/scripts/check-claim.sh" > "$SKILL_DIR/scripts/check-claim.sh"
-curl -sL "$REPO_URL/scripts/claim.sh" > "$SKILL_DIR/scripts/claim.sh"
+
+download_file "$REPO_URL/SKILL.md" "$SKILL_DIR/SKILL.md" || exit 1
+download_file "$REPO_URL/scripts/check-claim.sh" "$SKILL_DIR/scripts/check-claim.sh" || exit 1
+download_file "$REPO_URL/scripts/claim.sh" "$SKILL_DIR/scripts/claim.sh" || exit 1
 
 # Make scripts executable
 chmod +x "$SKILL_DIR/scripts/"*.sh
 
 echo ""
-echo "✅ Skill installed to: $SKILL_DIR"
+echo "✅ Installed to: $SKILL_DIR"
 echo ""
-echo "📋 Usage:"
-echo "  Check eligibility: $SKILL_DIR/scripts/check-claim.sh"
-echo "  Claim a card:      $SKILL_DIR/scripts/claim.sh"
+echo "📋 Prerequisites:"
+echo "   - Foundry cast: curl -L https://foundry.paradigm.xyz | bash"
+echo "   - jq: sudo apt install jq (or brew install jq)"
+echo "   - ETH on Base for gas (~0.0001 ETH)"
 echo ""
-echo "🔧 Requirements:"
-echo "  - Foundry (cast CLI)"
-echo "  - PRIVATE_KEY env var or ~/.config/clawtasks/credentials.json"
-echo "  - Base ETH for gas"
-echo ""
-echo "🌊 Happy claiming!"
+echo "🚀 Usage:"
+echo "   Check status:  $SKILL_DIR/scripts/check-claim.sh <wallet>"
+echo "   Claim card:    PRIVATE_KEY=0x... $SKILL_DIR/scripts/claim.sh"

--- a/skills/waves-claim/scripts/claim.sh
+++ b/skills/waves-claim/scripts/claim.sh
@@ -1,64 +1,96 @@
 #!/bin/bash
 # Claim a free SURF Waves Card NFT
+# Usage: PRIVATE_KEY=0x... ./claim.sh
 
+set -e
+
+# Contract addresses
 CLAIM_VAULT="${CLAIM_VAULT:-0xAF1906B749339adaE38A1cba9740fffA168897c2}"
 RPC_URL="${RPC_URL:-https://mainnet.base.org}"
 
+# Check dependencies
+if ! command -v cast &> /dev/null; then
+  echo "❌ Foundry 'cast' not found. Install: curl -L https://foundry.paradigm.xyz | bash"
+  exit 1
+fi
+
+if ! command -v jq &> /dev/null; then
+  echo "❌ 'jq' not found. Install: sudo apt install jq"
+  exit 1
+fi
+
 # Get private key
 if [ -z "$PRIVATE_KEY" ]; then
-  if [ -f ~/.config/clawtasks/credentials.json ]; then
-    PRIVATE_KEY=$(jq -r '.private_key' ~/.config/clawtasks/credentials.json)
-  fi
-fi
-
-if [ -z "$PRIVATE_KEY" ]; then
-  echo "❌ Set PRIVATE_KEY env variable"
+  echo "❌ PRIVATE_KEY environment variable required"
+  echo "Usage: PRIVATE_KEY=0x... ./claim.sh"
   exit 1
 fi
 
-WALLET=$(cast wallet address --private-key "$PRIVATE_KEY" 2>/dev/null)
+# Derive wallet address
+WALLET=$(cast wallet address "$PRIVATE_KEY" 2>&1) || {
+  echo "❌ Invalid private key: $WALLET"
+  exit 1
+}
 
-echo "🎴 SURF Waves Cards - Claiming..."
+echo "🎴 SURF Waves Card Claim"
 echo "   Wallet: $WALLET"
-echo "   Vault:  $CLAIM_VAULT"
 echo ""
 
-# Check if can claim first
-CAN_CLAIM=$(cast call "$CLAIM_VAULT" "canClaim(address)(bool)" "$WALLET" --rpc-url "$RPC_URL" 2>/dev/null)
+# Check if can claim (convert hex to decimal for comparison)
+CAN_CLAIM=$(cast call "$CLAIM_VAULT" "canClaim(address)(bool)" "$WALLET" --rpc-url "$RPC_URL" 2>&1) || {
+  echo "❌ RPC error checking canClaim: $CAN_CLAIM"
+  exit 1
+}
 
 if [ "$CAN_CLAIM" != "true" ]; then
-  TIME_LEFT=$(cast call "$CLAIM_VAULT" "timeUntilClaim(address)(uint256)" "$WALLET" --rpc-url "$RPC_URL" 2>/dev/null)
+  TIME_HEX=$(cast call "$CLAIM_VAULT" "timeUntilClaim(address)(uint256)" "$WALLET" --rpc-url "$RPC_URL" 2>&1) || {
+    echo "❌ RPC error: $TIME_HEX"
+    exit 1
+  }
+  TIME_LEFT=$(cast to-dec "$TIME_HEX" 2>/dev/null || echo "0")
   MINUTES=$((TIME_LEFT / 60))
-  echo "⏳ Cannot claim yet. Cooldown: ${MINUTES} minutes remaining"
+  echo "⏳ Cooldown active. Try again in ${MINUTES} minutes."
   exit 1
 fi
 
-# Check available
-AVAILABLE=$(cast call "$CLAIM_VAULT" "availableCount()(uint256)" --rpc-url "$RPC_URL" 2>/dev/null)
+# Check available cards
+AVAILABLE_HEX=$(cast call "$CLAIM_VAULT" "availableCount()(uint256)" --rpc-url "$RPC_URL" 2>&1) || {
+  echo "❌ RPC error: $AVAILABLE_HEX"
+  exit 1
+}
+AVAILABLE=$(cast to-dec "$AVAILABLE_HEX" 2>/dev/null || echo "0")
+
 if [ "$AVAILABLE" = "0" ]; then
-  echo "❌ No NFTs available in vault"
+  echo "❌ No cards available in vault"
   exit 1
 fi
 
-echo "📦 Available: $AVAILABLE NFTs"
-echo "🔨 Sending claim transaction..."
+echo "📦 Cards available: $AVAILABLE"
+echo "🚀 Claiming..."
 
-# Claim
-TX=$(cast send "$CLAIM_VAULT" "claim()" \
+# Execute claim transaction
+TX_OUTPUT=$(cast send "$CLAIM_VAULT" "claim()" \
   --private-key "$PRIVATE_KEY" \
   --rpc-url "$RPC_URL" \
-  --json 2>/dev/null)
+  --json 2>&1)
 
-if [ $? -eq 0 ]; then
-  TX_HASH=$(echo "$TX" | jq -r '.transactionHash')
-  echo ""
-  echo "✅ Claimed successfully!"
-  echo "   TX: https://basescan.org/tx/$TX_HASH"
-  echo ""
-  echo "🎴 Check your new card on OpenSea:"
-  echo "   https://opensea.io/collection/surf-waves-cards"
-else
-  echo "❌ Claim failed"
-  echo "$TX"
+TX_STATUS=$?
+if [ $TX_STATUS -ne 0 ]; then
+  echo "❌ Transaction failed: $TX_OUTPUT"
   exit 1
 fi
+
+# Extract transaction hash
+TX_HASH=$(echo "$TX_OUTPUT" | jq -r '.transactionHash // empty')
+
+if [ -z "$TX_HASH" ] || [ "$TX_HASH" = "null" ]; then
+  echo "❌ Failed to get transaction hash"
+  echo "Raw output: $TX_OUTPUT"
+  exit 1
+fi
+
+echo ""
+echo "✅ Claim successful!"
+echo "🔗 TX: https://basescan.org/tx/$TX_HASH"
+echo ""
+echo "View your cards: https://opensea.io/account"


### PR DESCRIPTION
## Summary

Adds the `waves-claim` skill for claiming free SURF Waves Card NFTs on Base.

## What's included

- `SKILL.md` - Skill documentation with contract info and usage
- `install.sh` - One-click installer
- `scripts/check-claim.sh` - Check claim eligibility
- `scripts/claim.sh` - Claim a card

## Contract Details

| Property | Value |
|----------|-------|
| **ClaimVault** | `0xAF1906B749339adaE38A1cba9740fffA168897c2` |
| **NFT Contract** | `0xcc2d6ba8564541e6e51fe5522e26d4f4bbdd458b` |
| **Network** | Base (Chain ID: 8453) |
| **Cooldown** | 2 hours |
| **Available** | 259 cards |

## Usage

```bash
clawhub install waves-claim
./scripts/claim.sh
```

## Links

- [OpenSea Collection](https://opensea.io/collection/surf-waves-cards)
- [ClaimVault on BaseScan](https://basescan.org/address/0xAF1906B749339adaE38A1cba9740fffA168897c2)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a new `waves-claim` skill under `skills/waves-claim/` with documentation (`SKILL.md`), an installer (`install.sh`), and two helper scripts to check eligibility and submit a claim transaction via Foundry `cast`.

Main things to double-check are the shell scripts’ handling of `cast call` return values and exit codes; currently several values are treated as decimals even though `cast` returns hex by default, and the claim script’s success/failure detection can misbehave due to checking `$?` after command substitution.

<h3>Confidence Score: 3/5</h3>

- Reasonably safe to merge, but the claim/check scripts have a few logic bugs that can cause incorrect eligibility/availability reporting and unreliable error handling.
- The changes are isolated to a new skill and don’t affect existing runtime code paths, but the scripts as written may mis-handle `cast` outputs (hex vs decimal) and may proceed when the vault is empty or mis-report cooldown, which undermines the feature’s correctness.
- skills/waves-claim/scripts/claim.sh; skills/waves-claim/scripts/check-claim.sh

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a1d58d20-b4dd-4cbb-973a-9fd7824e1921))

<!-- /greptile_comment -->