### PR TITLE
perf: batch tag resolution to reduce action→query round-trips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 - Quality gate: language-aware word counting (`Intl.Segmenter`) and new `cjkChars` signal to reduce false rejects for non-Latin docs.
 - Jobs: run skill stat event processing every 5 minutes (was 15).
+- API performance: batch resolve skill/soul tags in v1 list/get endpoints (fewer action->query round-trips) (#112) (thanks @mkrokosz).
 
 ### Fixed
 - Users: sync handle on ensure when GitHub login changes (#293) (thanks @christianhpoe).

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -1623,7 +1623,7 @@ export const getVersionById = query({
   handler: async (ctx, args) => ctx.db.get(args.versionId),
 })
 
-export const getVersionsByIds = query({
+export const getVersionsByIdsInternal = internalQuery({
   args: { versionIds: v.array(v.id('skillVersions')) },
   handler: async (ctx, args) => {
     const versions = await Promise.all(args.versionIds.map((id) => ctx.db.get(id)))

--- a/convex/souls.ts
+++ b/convex/souls.ts
@@ -145,7 +145,7 @@ export const getVersionById = query({
   handler: async (ctx, args) => ctx.db.get(args.versionId),
 })
 
-export const getVersionsByIds = query({
+export const getVersionsByIdsInternal = internalQuery({
   args: { versionIds: v.array(v.id('soulVersions')) },
   handler: async (ctx, args) => {
     const versions = await Promise.all(args.versionIds.map((id) => ctx.db.get(id)))


### PR DESCRIPTION
## Summary
- Batch version tag resolution in list endpoints to reduce N sequential `ctx.runQuery()` calls to 1
- Applies to both skills and souls list/get endpoints

## Problem
The `resolveTags` function was called per-item in list responses, with each call making sequential `ctx.runQuery()` calls for each tag. For a list of 20 skills with 5 tags each, this resulted in 100 separate action→query round-trips.

## Solution
- Add `getVersionsByIds` batch query to `skills.ts` and `souls.ts`
- Replace per-item tag resolution with batch resolution that:
  1. Collects all version IDs from all items
  2. Fetches all versions in a single query
  3. Maps results back to each item

## Performance Impact
| Scenario | Before | After |
|----------|--------|-------|
| List 20 skills, 5 tags each | 100 action→query round-trips | 1 round-trip |
| Single skill detail, 5 tags | 5 round-trips | 1 round-trip |

## Changes
- `convex/skills.ts`: Add `getVersionsByIds` query
- `convex/souls.ts`: Add `getVersionsByIds` query  
- `convex/httpApiV1.ts`: Replace `resolveTags`/`resolveSoulTags` with batch versions
- `convex/httpApiV1.handlers.test.ts`: Update tests to verify batch behavior

## API Impact
None - response format is unchanged.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR batches version-tag resolution for skills and souls in the v1 HTTP API handlers. Instead of resolving each tag via repeated `ctx.runQuery()` calls per item, handlers now collect all version IDs from the response, fetch the corresponding versions via a single `getVersionsByIds` query, and map the resolved version strings back onto each item.

The approach fits the existing Convex pattern of keeping list endpoints cacheable/efficient while doing additional enrichment in the HTTP layer.

One correctness issue to address: the new batch resolvers assume the batch query always returns an array, and can throw when there are no tags / the query returns `null`.

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is due to a crash in the new batch tag resolution path when the batch query returns null/undefined.
- Score is reduced because the new `resolveTagsBatch`/`resolveSoulTagsBatch` assume the batch query returns an iterable array and will throw if it returns `null` (observed in tests when listing skills with no tags / when `runQuery` mock returns null). The remaining changes are straightforward and localized, and the performance intent is sound.
- convex/httpApiV1.ts (batch tag resolver helpers); also review the new batch queries in convex/skills.ts and convex/souls.ts for expected input sizes/limits.

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a1d58d20-b4dd-4cbb-973a-9fd7824e1921))

<!-- /greptile_comment -->