### PR TITLE
fix: use www.clawhub.ai in well-known discovery config

### DIFF
--- a/public/.well-known/clawdhub.json
+++ b/public/.well-known/clawdhub.json
@@ -1,6 +1,6 @@
 {
-  "apiBase": "https://clawhub.ai",
-  "authBase": "https://clawhub.ai",
+  "apiBase": "https://www.clawhub.ai",
+  "authBase": "https://www.clawhub.ai",
   "minCliVersion": "0.1.0",
-  "registry": "https://clawhub.ai"
+  "registry": "https://www.clawhub.ai"
 }

--- a/public/.well-known/clawhub.json
+++ b/public/.well-known/clawhub.json
@@ -1,6 +1,6 @@
 {
-  "apiBase": "https://clawhub.ai",
-  "authBase": "https://clawhub.ai",
+  "apiBase": "https://www.clawhub.ai",
+  "authBase": "https://www.clawhub.ai",
   "minCliVersion": "0.1.0",
-  "registry": "https://clawhub.ai"
+  "registry": "https://www.clawhub.ai"
 }


### PR DESCRIPTION
## Problem

`clawhub login` fails with `Unauthorized` for all users.

**Root cause:** The `.well-known/clawhub.json` discovery config advertises `https://clawhub.ai` as the `apiBase`, but `clawhub.ai` 307-redirects to `www.clawhub.ai` (Vercel hosting).

Node.js's `fetch()` strips the `Authorization` header on cross-origin redirects per HTTP spec (`clawhub.ai` → `www.clawhub.ai` is considered cross-origin). The CLI sends the auth token to `clawhub.ai`, gets redirected, and the token is dropped before reaching `www.clawhub.ai`.

This affects:
- `clawhub login` (browser flow callback validation)
- `clawhub login --no-browser --token`
- `clawhub whoami`
- `clawhub publish`
- Any authenticated API call

## Fix

Update `apiBase`, `authBase`, and `registry` in both `.well-known/clawhub.json` and `.well-known/clawdhub.json` to use `https://www.clawhub.ai` directly, bypassing the redirect.

## Repro

```bash
# Shows the 307 redirect
curl -sI https://clawhub.ai/api/v1/whoami
# HTTP/2 307
# location: https://www.clawhub.ai/api/v1/whoami

# Direct to www works fine
curl -s -H 'Authorization: Bearer <token>' https://www.clawhub.ai/api/v1/whoami
```

## Files Changed
- `public/.well-known/clawhub.json`
- `public/.well-known/clawdhub.json`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the CLI discovery configuration served from `public/.well-known/*.json` so the CLI uses `https://www.clawhub.ai` directly, avoiding the `clawhub.ai` → `www.clawhub.ai` redirect that causes Node’s `fetch()` to drop `Authorization` headers on cross-origin redirects.

The change fits into the codebase as static discovery metadata (served via the web app’s `public/` assets) that the CLI reads to determine `apiBase`, `authBase`, and `registry` locations for authenticated operations.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge, but verify the discovery JSON actually reflects the intended www endpoints.
- The change is limited to static JSON config, but the current file contents indicate `authBase` and `registry` may still point at `https://clawhub.ai`, which would undercut the stated fix and likely keep auth flows broken for some calls.
- public/.well-known/clawhub.json, public/.well-known/clawdhub.json

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a1d58d20-b4dd-4cbb-973a-9fd7824e1921))

<!-- /greptile_comment -->