### PR TITLE
fix: remove display grid class from tab-body

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -4,2973 +4,3022 @@
 @import "@fontsource/ibm-plex-mono/latin.css";
 
 :root {
-  color-scheme: light dark;
-  --bg: #f8f5ef;
-  --bg-soft: #fdfaf4;
-  --bg-glow-1: #fff1d8;
-  --bg-glow-2: #ffe8e0;
-  --surface: #ffffff;
-  --surface-muted: #fff6f1;
-  --nav-bg: rgba(248, 245, 239, 0.85);
-  --ink: #1d1a17;
-  --ink-soft: #4c463f;
-  --accent: #ff6b4a;
-  --accent-deep: #e54f31;
-  --seafoam: #2bc6a4;
-  --gold: #f0c46a;
-  --line: rgba(29, 26, 23, 0.12);
-  --shadow: 0 24px 60px rgba(29, 26, 23, 0.1);
-  --radius-lg: 28px;
-  --radius-md: 18px;
-  --radius-sm: 12px;
-  --font-display: "Bricolage Grotesque", "Manrope", sans-serif;
-  --font-body: "Manrope", "Bricolage Grotesque", sans-serif;
-  --font-mono:
-    "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
-    "Courier New", monospace;
+    color-scheme: light dark;
+    --bg: #f8f5ef;
+    --bg-soft: #fdfaf4;
+    --bg-glow-1: #fff1d8;
+    --bg-glow-2: #ffe8e0;
+    --surface: #ffffff;
+    --surface-muted: #fff6f1;
+    --nav-bg: rgba(248, 245, 239, 0.85);
+    --ink: #1d1a17;
+    --ink-soft: #4c463f;
+    --accent: #ff6b4a;
+    --accent-deep: #e54f31;
+    --seafoam: #2bc6a4;
+    --gold: #f0c46a;
+    --line: rgba(29, 26, 23, 0.12);
+    --shadow: 0 24px 60px rgba(29, 26, 23, 0.1);
+    --radius-lg: 28px;
+    --radius-md: 18px;
+    --radius-sm: 12px;
+    --font-display: "Bricolage Grotesque", "Manrope", sans-serif;
+    --font-body: "Manrope", "Bricolage Grotesque", sans-serif;
+    --font-mono:
+        "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+        "Liberation Mono", "Courier New", monospace;
 }
 
 [data-theme="dark"] {
-  color-scheme: dark;
-  --bg: #14110f;
-  --bg-soft: #1d1916;
-  --bg-glow-1: #2b1a15;
-  --bg-glow-2: #231713;
-  --surface: #201b18;
-  --surface-muted: #241f1b;
-  --nav-bg: rgba(20, 17, 15, 0.85);
-  --ink: #f6efe4;
-  --ink-soft: #c6b8a8;
-  --accent: #e86a47;
-  --accent-deep: #c24a2f;
-  --seafoam: #4ad8b7;
-  --gold: #f3c97a;
-  --line: rgba(255, 255, 255, 0.12);
-  --shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+    color-scheme: dark;
+    --bg: #14110f;
+    --bg-soft: #1d1916;
+    --bg-glow-1: #2b1a15;
+    --bg-glow-2: #231713;
+    --surface: #201b18;
+    --surface-muted: #241f1b;
+    --nav-bg: rgba(20, 17, 15, 0.85);
+    --ink: #f6efe4;
+    --ink-soft: #c6b8a8;
+    --accent: #e86a47;
+    --accent-deep: #c24a2f;
+    --seafoam: #4ad8b7;
+    --gold: #f3c97a;
+    --line: rgba(255, 255, 255, 0.12);
+    --shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
 }
 
 * {
-  box-sizing: border-box;
+    box-sizing: border-box;
 }
 
 body {
-  margin: 0;
-  font-family: var(--font-body);
-  color: var(--ink);
-  background:
-    radial-gradient(1200px 800px at 20% -10%, var(--bg-glow-1) 0%, transparent 60%),
-    radial-gradient(900px 600px at 90% 10%, var(--bg-glow-2) 0%, transparent 60%), var(--bg);
-  min-height: 100vh;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+    margin: 0;
+    font-family: var(--font-body);
+    color: var(--ink);
+    background:
+        radial-gradient(
+            1200px 800px at 20% -10%,
+            var(--bg-glow-1) 0%,
+            transparent 60%
+        ),
+        radial-gradient(
+            900px 600px at 90% 10%,
+            var(--bg-glow-2) 0%,
+            transparent 60%
+        ),
+        var(--bg);
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 a {
-  color: inherit;
-  text-decoration: none;
+    color: inherit;
+    text-decoration: none;
 }
 
 code {
-  font-family: var(--font-mono);
+    font-family: var(--font-mono);
 }
 
 .app-shell {
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
 }
 
 .app-shell main {
-  flex: 1;
+    flex: 1;
 }
 
 .site-footer {
-  padding: 0 24px 40px;
+    padding: 0 24px 40px;
 }
 
 .site-footer-inner {
-  max-width: 1200px;
-  margin: 0 auto;
+    max-width: 1200px;
+    margin: 0 auto;
 }
 
 .site-footer-divider {
-  height: 1px;
-  background: var(--line);
-  opacity: 0.6;
-  margin: 18px 0 16px;
+    height: 1px;
+    background: var(--line);
+    opacity: 0.6;
+    margin: 18px 0 16px;
 }
 
 .site-footer-row {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
 }
 
 .site-footer-copy {
-  font-size: 0.85rem;
-  color: var(--ink-soft);
-  opacity: 0.72;
-  text-align: center;
-  max-width: 720px;
+    font-size: 0.85rem;
+    color: var(--ink-soft);
+    opacity: 0.72;
+    text-align: center;
+    max-width: 720px;
 }
 
 .site-footer-copy a {
-  color: inherit;
-  text-decoration: underline;
-  text-decoration-color: rgba(255, 107, 74, 0.32);
-  text-underline-offset: 3px;
-  transition:
-    color 0.2s ease,
-    text-decoration-color 0.2s ease;
+    color: inherit;
+    text-decoration: underline;
+    text-decoration-color: rgba(255, 107, 74, 0.32);
+    text-underline-offset: 3px;
+    transition:
+        color 0.2s ease,
+        text-decoration-color 0.2s ease;
 }
 
 .site-footer-copy a:hover {
-  color: var(--ink);
-  text-decoration-color: rgba(255, 107, 74, 0.6);
+    color: var(--ink);
+    text-decoration-color: rgba(255, 107, 74, 0.6);
 }
 
 .section-cta {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 18px;
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 18px;
 }
 
 .navbar {
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  background: var(--nav-bg);
-  backdrop-filter: blur(18px);
-  border-bottom: 1px solid var(--line);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: var(--nav-bg);
+    backdrop-filter: blur(18px);
+    border-bottom: 1px solid var(--line);
 }
 
 .navbar-inner {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 20px 24px;
-  display: flex;
-  align-items: center;
-  gap: 20px;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px 24px;
+    display: flex;
+    align-items: center;
+    gap: 20px;
 }
 
 .brand {
-  font-family: var(--font-display);
-  font-size: 1.4rem;
-  letter-spacing: -0.03em;
-  display: flex;
-  align-items: center;
-  gap: 10px;
+    font-family: var(--font-display);
+    font-size: 1.4rem;
+    letter-spacing: -0.03em;
+    display: flex;
+    align-items: center;
+    gap: 10px;
 }
 
 .brand-name {
-  display: inline-flex;
+    display: inline-flex;
 }
 
 .brand-mark {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  background: radial-gradient(circle at 30% 30%, #ffd3c2 0%, #ff6b4a 60%, #d1492f 100%);
-  box-shadow: inset 0 0 0 4px rgba(255, 255, 255, 0.5);
-  display: grid;
-  place-items: center;
-  overflow: hidden;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: radial-gradient(
+        circle at 30% 30%,
+        #ffd3c2 0%,
+        #ff6b4a 60%,
+        #d1492f 100%
+    );
+    box-shadow: inset 0 0 0 4px rgba(255, 255, 255, 0.5);
+    display: grid;
+    place-items: center;
+    overflow: hidden;
 }
 
 .brand-mark img {
-  width: 70%;
-  height: 70%;
-  object-fit: cover;
-  border-radius: 50%;
+    width: 70%;
+    height: 70%;
+    object-fit: cover;
+    border-radius: 50%;
 }
 
 .nav-links {
-  display: flex;
-  gap: 16px;
-  font-size: 0.95rem;
-  color: var(--ink-soft);
+    display: flex;
+    gap: 16px;
+    font-size: 0.95rem;
+    color: var(--ink-soft);
 }
 
 .nav-mobile {
-  display: none;
+    display: none;
 }
 
 .nav-mobile-trigger {
-  width: 40px;
-  height: 40px;
-  border-radius: 999px;
-  border: 1px solid var(--line);
-  background: var(--surface);
-  display: grid;
-  place-items: center;
-  cursor: pointer;
-  transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease;
+    width: 40px;
+    height: 40px;
+    border-radius: 999px;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    transition:
+        transform 0.2s ease,
+        box-shadow 0.2s ease;
 }
 
 .nav-mobile-trigger:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 18px rgba(255, 107, 74, 0.18);
+    transform: translateY(-1px);
+    box-shadow: 0 10px 18px rgba(255, 107, 74, 0.18);
 }
 
 .nav-mobile-trigger:focus-visible {
-  outline: 3px solid rgba(255, 107, 74, 0.35);
-  outline-offset: 3px;
+    outline: 3px solid rgba(255, 107, 74, 0.35);
+    outline-offset: 3px;
 }
 
 .nav-actions {
-  margin-left: auto;
-  display: flex;
-  gap: 12px;
-  align-items: center;
+    margin-left: auto;
+    display: flex;
+    gap: 12px;
+    align-items: center;
 }
 
 .theme-toggle {
-  display: inline-flex;
+    display: inline-flex;
 }
 
 .user-trigger {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  border: 1px solid var(--line);
-  background: var(--surface);
-  padding: 6px 12px 6px 6px;
-  border-radius: 999px;
-  cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    padding: 6px 12px 6px 6px;
+    border-radius: 999px;
+    cursor: pointer;
 }
 
 .user-trigger img,
 .user-menu-fallback {
-  width: 34px;
-  height: 34px;
-  border-radius: 50%;
-  display: grid;
-  place-items: center;
-  background: rgba(255, 107, 74, 0.2);
-  color: var(--accent-deep);
-  font-weight: 700;
-  font-size: 0.9rem;
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    background: rgba(255, 107, 74, 0.2);
+    color: var(--accent-deep);
+    font-weight: 700;
+    font-size: 0.9rem;
 }
 
 .user-menu-chevron {
-  font-size: 0.8rem;
-  color: var(--ink-soft);
+    font-size: 0.8rem;
+    color: var(--ink-soft);
 }
 
 .btn {
-  border: 1px solid var(--line);
-  padding: 10px 16px;
-  border-radius: 999px;
-  background: var(--surface);
-  font-weight: 600;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease,
-    border 0.2s ease;
+    border: 1px solid var(--line);
+    padding: 10px 16px;
+    border-radius: 999px;
+    background: var(--surface);
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    transition:
+        transform 0.2s ease,
+        box-shadow 0.2s ease,
+        border 0.2s ease;
 }
 
 .btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 20px rgba(29, 26, 23, 0.12);
+    transform: translateY(-1px);
+    box-shadow: 0 10px 20px rgba(29, 26, 23, 0.12);
 }
 
 .btn:disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
-  box-shadow: none;
-  transform: none;
+    cursor: not-allowed;
+    opacity: 0.6;
+    box-shadow: none;
+    transform: none;
 }
 
 .btn-primary {
-  background: linear-gradient(135deg, var(--accent), var(--accent-deep));
-  color: white;
-  border: none;
+    background: linear-gradient(135deg, var(--accent), var(--accent-deep));
+    color: white;
+    border: none;
 }
 
 .hero {
-  position: relative;
-  overflow: hidden;
-  padding: 80px 24px 60px;
+    position: relative;
+    overflow: hidden;
+    padding: 80px 24px 60px;
 }
 
 .hero-inner {
-  max-width: 1200px;
-  margin: 0 auto;
-  display: grid;
-  grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr);
-  gap: 40px;
-  align-items: center;
-  transition:
-    grid-template-columns 0.45s cubic-bezier(0.2, 0.9, 0.2, 1),
-    gap 0.45s cubic-bezier(0.2, 0.9, 0.2, 1);
+    max-width: 1200px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr);
+    gap: 40px;
+    align-items: center;
+    transition:
+        grid-template-columns 0.45s cubic-bezier(0.2, 0.9, 0.2, 1),
+        gap 0.45s cubic-bezier(0.2, 0.9, 0.2, 1);
 }
 
 .hero-copy {
-  max-height: 640px;
-  overflow: hidden;
-  min-width: 0;
-  transition:
-    opacity 0.35s ease,
-    transform 0.35s ease,
-    max-height 0.35s ease;
+    max-height: 640px;
+    overflow: hidden;
+    min-width: 0;
+    transition:
+        opacity 0.35s ease,
+        transform 0.35s ease,
+        max-height 0.35s ease;
 }
 
 .hero.search-mode .hero-inner {
-  grid-template-columns: 0fr minmax(0, 1fr);
-  gap: 0px;
+    grid-template-columns: 0fr minmax(0, 1fr);
+    gap: 0px;
 }
 
 .hero.search-mode .hero-copy {
-  opacity: 0;
-  transform: translateY(-12px);
-  max-height: 0;
-  pointer-events: none;
+    opacity: 0;
+    transform: translateY(-12px);
+    max-height: 0;
+    pointer-events: none;
 }
 
 .hero-title {
-  font-family: var(--font-display);
-  font-size: clamp(2.6rem, 4vw, 4rem);
-  letter-spacing: -0.03em;
-  margin-bottom: 16px;
+    font-family: var(--font-display);
+    font-size: clamp(2.6rem, 4vw, 4rem);
+    letter-spacing: -0.03em;
+    margin-bottom: 16px;
 }
 
 .hero-subtitle {
-  font-size: 1.1rem;
-  color: var(--ink-soft);
-  line-height: 1.6;
+    font-size: 1.1rem;
+    color: var(--ink-soft);
+    line-height: 1.6;
 }
 
 .hero-card {
-  background: var(--bg-soft);
-  border-radius: var(--radius-lg);
-  padding: 28px;
-  box-shadow: var(--shadow);
-  border: 1px solid rgba(255, 107, 74, 0.15);
+    background: var(--bg-soft);
+    border-radius: var(--radius-lg);
+    padding: 28px;
+    box-shadow: var(--shadow);
+    border: 1px solid rgba(255, 107, 74, 0.15);
 }
 
 .hero-search-card {
-  transition:
-    transform 0.35s ease,
-    box-shadow 0.35s ease;
+    transition:
+        transform 0.35s ease,
+        box-shadow 0.35s ease;
 }
 
 .hero.search-mode .hero-search-card {
-  transform: scale(1.01);
-  box-shadow: 0 22px 46px rgba(29, 26, 23, 0.16);
+    transform: scale(1.01);
+    box-shadow: 0 22px 46px rgba(29, 26, 23, 0.16);
 }
 
 .hero-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  background: rgba(255, 107, 74, 0.12);
-  color: var(--accent-deep);
-  border-radius: 999px;
-  padding: 6px 14px;
-  font-weight: 600;
-  font-size: 0.85rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: rgba(255, 107, 74, 0.12);
+    color: var(--accent-deep);
+    border-radius: 999px;
+    padding: 6px 14px;
+    font-weight: 600;
+    font-size: 0.85rem;
 }
 
 .section {
-  width: 100%;
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 32px 24px 72px;
-  box-sizing: border-box;
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 32px 24px 72px;
+    box-sizing: border-box;
 }
 
 .upload-shell {
-  position: relative;
+    position: relative;
 }
 
 .upload-header {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 24px;
-  margin-bottom: 28px;
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 24px;
+    margin-bottom: 28px;
 }
 
 .upload-kicker {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  font-weight: 600;
-  color: var(--accent-deep);
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-  font-size: 0.7rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 600;
+    color: var(--accent-deep);
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    font-size: 0.7rem;
 }
 
 .upload-title {
-  font-family: var(--font-display);
-  font-size: clamp(2.2rem, 3.5vw, 3rem);
-  letter-spacing: -0.03em;
-  margin: 8px 0 10px;
+    font-family: var(--font-display);
+    font-size: clamp(2.2rem, 3.5vw, 3rem);
+    letter-spacing: -0.03em;
+    margin: 8px 0 10px;
 }
 
 .upload-subtitle {
-  color: var(--ink-soft);
-  max-width: 560px;
-  line-height: 1.6;
-  margin: 0;
+    color: var(--ink-soft);
+    max-width: 560px;
+    line-height: 1.6;
+    margin: 0;
 }
 
 .upload-badge {
-  background: linear-gradient(140deg, #ffddc9, #ffe9df);
-  color: #9a3a24;
-  border-radius: 999px;
-  padding: 12px 18px;
-  font-weight: 700;
-  box-shadow: 0 12px 24px rgba(255, 107, 74, 0.18);
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+    background: linear-gradient(140deg, #ffddc9, #ffe9df);
+    color: #9a3a24;
+    border-radius: 999px;
+    padding: 12px 18px;
+    font-weight: 700;
+    box-shadow: 0 12px 24px rgba(255, 107, 74, 0.18);
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
 }
 
 .upload-badge-sub {
-  font-size: 0.7rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
 }
 
 .upload-card {
-  background: linear-gradient(180deg, var(--surface) 0%, var(--surface-muted) 100%);
-  border-radius: calc(var(--radius-lg) + 6px);
-  border: 1px solid rgba(255, 107, 74, 0.18);
-  padding: 28px;
-  box-shadow: 0 24px 60px rgba(29, 26, 23, 0.12);
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
+    background: linear-gradient(
+        180deg,
+        var(--surface) 0%,
+        var(--surface-muted) 100%
+    );
+    border-radius: calc(var(--radius-lg) + 6px);
+    border: 1px solid rgba(255, 107, 74, 0.18);
+    padding: 28px;
+    box-shadow: 0 24px 60px rgba(29, 26, 23, 0.12);
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
 }
 
 .upload-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1.1fr) minmax(260px, 0.7fr);
-  gap: 28px;
+    display: grid;
+    grid-template-columns: minmax(0, 1.1fr) minmax(260px, 0.7fr);
+    gap: 28px;
 }
 
 .upload-fields {
-  display: grid;
-  gap: 14px;
+    display: grid;
+    gap: 14px;
 }
 
 .upload-field {
-  display: grid;
-  gap: 10px;
-  font-weight: 600;
+    display: grid;
+    gap: 10px;
+    font-weight: 600;
 }
 
 .upload-field-header {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 12px;
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
 }
 
 .upload-field span {
-  font-size: 0.9rem;
-  color: var(--ink-soft);
+    font-size: 0.9rem;
+    color: var(--ink-soft);
 }
 
 .upload-field-hint {
-  font-size: 0.82rem;
-  color: rgba(92, 85, 78, 0.8);
-  font-weight: 500;
+    font-size: 0.82rem;
+    color: rgba(92, 85, 78, 0.8);
+    font-weight: 500;
 }
 
 [data-theme="dark"] .upload-field-hint {
-  color: rgba(198, 184, 168, 0.72);
+    color: rgba(198, 184, 168, 0.72);
 }
 
 .upload-input {
-  border: 1px solid rgba(29, 26, 23, 0.18);
-  border-radius: 14px;
-  padding: 12px 14px;
-  background: #fffdf9;
-  box-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.85),
-    inset 0 1px 6px rgba(255, 107, 74, 0.08);
+    border: 1px solid rgba(29, 26, 23, 0.18);
+    border-radius: 14px;
+    padding: 12px 14px;
+    background: #fffdf9;
+    box-shadow:
+        inset 0 0 0 1px rgba(255, 255, 255, 0.85),
+        inset 0 1px 6px rgba(255, 107, 74, 0.08);
 }
 
 [data-theme="dark"] .upload-input {
-  background: rgba(28, 23, 20, 0.95);
-  border-color: rgba(255, 255, 255, 0.12);
-  color: var(--ink);
-  box-shadow:
-    inset 0 0 0 1px rgba(255, 255, 255, 0.05),
-    inset 0 1px 6px rgba(0, 0, 0, 0.2);
+    background: rgba(28, 23, 20, 0.95);
+    border-color: rgba(255, 255, 255, 0.12);
+    color: var(--ink);
+    box-shadow:
+        inset 0 0 0 1px rgba(255, 255, 255, 0.05),
+        inset 0 1px 6px rgba(0, 0, 0, 0.2);
 }
 
 [data-theme="dark"] .upload-input::placeholder {
-  color: rgba(198, 184, 168, 0.7);
+    color: rgba(198, 184, 168, 0.7);
 }
 
 .upload-input:focus {
-  border-color: rgba(255, 107, 74, 0.6);
-  box-shadow:
-    0 0 0 2px rgba(255, 107, 74, 0.2),
-    inset 0 0 0 1px rgba(255, 255, 255, 0.8);
+    border-color: rgba(255, 107, 74, 0.6);
+    box-shadow:
+        0 0 0 2px rgba(255, 107, 74, 0.2),
+        inset 0 0 0 1px rgba(255, 255, 255, 0.8);
 }
 
 .upload-row {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 16px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 16px;
 }
 
 .upload-side {
-  display: grid;
-  gap: 16px;
-  align-content: start;
+    display: grid;
+    gap: 16px;
+    align-content: start;
 }
 
 .dropzone {
-  border: 2px dashed rgba(255, 107, 74, 0.5);
-  border-radius: 24px;
-  padding: 20px;
-  background: radial-gradient(circle at top, #fff3ec 0%, #ffffff 65%);
-  display: grid;
-  gap: 12px;
-  text-align: center;
-  cursor: pointer;
-  transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease,
-    border-color 0.2s ease;
+    border: 2px dashed rgba(255, 107, 74, 0.5);
+    border-radius: 24px;
+    padding: 20px;
+    background: radial-gradient(circle at top, #fff3ec 0%, #ffffff 65%);
+    display: grid;
+    gap: 12px;
+    text-align: center;
+    cursor: pointer;
+    transition:
+        transform 0.2s ease,
+        box-shadow 0.2s ease,
+        border-color 0.2s ease;
 }
 
 [data-theme="dark"] .dropzone {
-  background: radial-gradient(circle at top, rgba(35, 26, 22, 0.9) 0%, rgba(20, 17, 15, 0.9) 70%);
-  border-color: rgba(255, 131, 95, 0.5);
-  color: var(--ink);
+    background: radial-gradient(
+        circle at top,
+        rgba(35, 26, 22, 0.9) 0%,
+        rgba(20, 17, 15, 0.9) 70%
+    );
+    border-color: rgba(255, 131, 95, 0.5);
+    color: var(--ink);
 }
 
 .dropzone:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 18px 30px rgba(255, 107, 74, 0.15);
+    transform: translateY(-2px);
+    box-shadow: 0 18px 30px rgba(255, 107, 74, 0.15);
 }
 
 [data-theme="dark"] .dropzone:hover {
-  box-shadow: 0 20px 36px rgba(0, 0, 0, 0.45);
+    box-shadow: 0 20px 36px rgba(0, 0, 0, 0.45);
 }
 
 .dropzone.is-dragging {
-  border-color: var(--accent);
-  box-shadow: 0 20px 40px rgba(255, 107, 74, 0.25);
-  background: radial-gradient(circle at top, #ffe1d3 0%, #fff6f1 70%);
+    border-color: var(--accent);
+    box-shadow: 0 20px 40px rgba(255, 107, 74, 0.25);
+    background: radial-gradient(circle at top, #ffe1d3 0%, #fff6f1 70%);
 }
 
 [data-theme="dark"] .dropzone.is-dragging {
-  box-shadow: 0 20px 40px rgba(255, 131, 95, 0.25);
-  background: radial-gradient(circle at top, rgba(66, 35, 28, 0.9) 0%, rgba(24, 19, 16, 0.9) 70%);
+    box-shadow: 0 20px 40px rgba(255, 131, 95, 0.25);
+    background: radial-gradient(
+        circle at top,
+        rgba(66, 35, 28, 0.9) 0%,
+        rgba(24, 19, 16, 0.9) 70%
+    );
 }
 
 .dropzone-icon {
-  width: 54px;
-  height: 54px;
-  border-radius: 16px;
-  margin: 0 auto;
-  display: grid;
-  place-items: center;
-  font-size: 1.4rem;
-  background: linear-gradient(160deg, #ff6b4a, #f08b5f);
-  color: white;
-  box-shadow: inset 0 0 0 3px rgba(255, 255, 255, 0.4);
+    width: 54px;
+    height: 54px;
+    border-radius: 16px;
+    margin: 0 auto;
+    display: grid;
+    place-items: center;
+    font-size: 1.4rem;
+    background: linear-gradient(160deg, #ff6b4a, #f08b5f);
+    color: white;
+    box-shadow: inset 0 0 0 3px rgba(255, 255, 255, 0.4);
 }
 
 [data-theme="dark"] .dropzone-icon {
-  box-shadow: inset 0 0 0 3px rgba(255, 255, 255, 0.12);
+    box-shadow: inset 0 0 0 3px rgba(255, 255, 255, 0.12);
 }
 
 .dropzone-input {
-  display: none;
+    display: none;
 }
 
 .dropzone-button {
-  all: unset;
-  display: grid;
-  gap: 12px;
-  text-align: center;
-  cursor: pointer;
-  width: 100%;
-  height: 100%;
+    all: unset;
+    display: grid;
+    gap: 12px;
+    text-align: center;
+    cursor: pointer;
+    width: 100%;
+    height: 100%;
 }
 
 .dropzone-button:focus-visible {
-  outline: 3px solid rgba(255, 107, 74, 0.35);
-  outline-offset: 6px;
-  border-radius: 18px;
+    outline: 3px solid rgba(255, 107, 74, 0.35);
+    outline-offset: 6px;
+    border-radius: 18px;
 }
 
 .upload-summary {
-  border-radius: 20px;
-  background: rgba(255, 255, 255, 0.7);
-  border: 1px solid rgba(29, 26, 23, 0.08);
-  padding: 16px;
-  display: grid;
-  gap: 10px;
-  font-size: 0.9rem;
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.7);
+    border: 1px solid rgba(29, 26, 23, 0.08);
+    padding: 16px;
+    display: grid;
+    gap: 10px;
+    font-size: 0.9rem;
 }
 
 [data-theme="dark"] .upload-summary {
-  background: rgba(20, 17, 15, 0.7);
-  border-color: rgba(255, 255, 255, 0.08);
+    background: rgba(20, 17, 15, 0.7);
+    border-color: rgba(255, 255, 255, 0.08);
 }
 
 .upload-requirement {
-  padding: 6px 12px;
-  border-radius: 999px;
-  background: rgba(255, 107, 74, 0.12);
-  color: #9a3a24;
-  font-weight: 600;
-  width: fit-content;
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: rgba(255, 107, 74, 0.12);
+    color: #9a3a24;
+    font-weight: 600;
+    width: fit-content;
 }
 
 .upload-requirement.ok {
-  background: rgba(43, 198, 164, 0.18);
-  color: #1a6b5b;
+    background: rgba(43, 198, 164, 0.18);
+    color: #1a6b5b;
 }
 
 .upload-filelist {
-  display: grid;
-  gap: 6px;
-  max-height: 220px;
-  overflow: auto;
+    display: grid;
+    gap: 6px;
+    max-height: 220px;
+    overflow: auto;
 }
 
 .upload-filelist .upload-file {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  font-size: 0.85rem;
-  color: var(--ink-soft);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 0.85rem;
+    color: var(--ink-soft);
 }
 
 .upload-file span:first-child {
-  flex: 1;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .upload-remove {
-  border: none;
-  background: transparent;
-  color: var(--accent-deep);
-  font-weight: 600;
-  cursor: pointer;
+    border: none;
+    background: transparent;
+    color: var(--accent-deep);
+    font-weight: 600;
+    cursor: pointer;
 }
 
 .upload-remove:hover {
-  text-decoration: underline;
+    text-decoration: underline;
 }
 
 .upload-more {
-  font-size: 0.8rem;
-  color: var(--ink-soft);
+    font-size: 0.8rem;
+    color: var(--ink-soft);
 }
 
 .upload-muted {
-  color: var(--ink-soft);
-  margin: 0;
+    color: var(--ink-soft);
+    margin: 0;
 }
 
 .upload-notes {
-  background: #fff8f3;
-  border: 1px solid rgba(255, 107, 74, 0.12);
-  border-radius: 18px;
-  padding: 16px;
-  font-size: 0.85rem;
-  color: var(--ink-soft);
+    background: #fff8f3;
+    border: 1px solid rgba(255, 107, 74, 0.12);
+    border-radius: 18px;
+    padding: 16px;
+    font-size: 0.85rem;
+    color: var(--ink-soft);
 }
 
 [data-theme="dark"] .upload-notes {
-  background: rgba(32, 27, 24, 0.6);
+    background: rgba(32, 27, 24, 0.6);
 }
 
 .upload-notes ul {
-  padding-left: 18px;
-  margin: 8px 0 0;
-  display: grid;
-  gap: 6px;
+    padding-left: 18px;
+    margin: 8px 0 0;
+    display: grid;
+    gap: 6px;
 }
 
 .upload-footer {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
 }
 
 .upload-validation {
-  display: grid;
-  gap: 6px;
-  font-size: 0.85rem;
-  color: #9a3a24;
+    display: grid;
+    gap: 6px;
+    font-size: 0.85rem;
+    color: #9a3a24;
 }
 
 .upload-validation-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
 }
 
 .upload-validation-item::before {
-  content: "•";
+    content: "•";
 }
 
 .upload-ready {
-  font-size: 0.9rem;
-  font-weight: 600;
-  color: #1a6b5b;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #1a6b5b;
 }
 
 .upload-error {
-  color: #b84a3a;
+    color: #b84a3a;
 }
 
 .section-title {
-  font-family: var(--font-display);
-  font-size: 1.8rem;
-  letter-spacing: -0.02em;
-  margin-bottom: 10px;
+    font-family: var(--font-display);
+    font-size: 1.8rem;
+    letter-spacing: -0.02em;
+    margin-bottom: 10px;
 }
 
 .section-subtitle {
-  color: var(--ink-soft);
-  margin-bottom: 24px;
+    color: var(--ink-soft);
+    margin-bottom: 24px;
 }
 
 .grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 20px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 20px;
 }
 
 .skills-header {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 14px;
-  flex-wrap: wrap;
-  margin-bottom: 22px;
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 14px;
+    flex-wrap: wrap;
+    margin-bottom: 22px;
 }
 
 .skills-toolbar {
-  display: grid;
-  gap: 10px;
-  padding: 14px 16px;
-  border-radius: 18px;
-  border: 1px solid rgba(255, 107, 74, 0.18);
-  background: linear-gradient(135deg, var(--surface), var(--surface-muted));
-  min-width: min(520px, 100%);
+    display: grid;
+    gap: 10px;
+    padding: 14px 16px;
+    border-radius: 18px;
+    border: 1px solid rgba(255, 107, 74, 0.18);
+    background: linear-gradient(135deg, var(--surface), var(--surface-muted));
+    min-width: min(520px, 100%);
 }
 
 .skills-search {
-  display: flex;
-  align-items: center;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 107, 74, 0.2);
-  background: rgba(255, 255, 255, 0.45);
-  padding: 10px 14px;
+    display: flex;
+    align-items: center;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 107, 74, 0.2);
+    background: rgba(255, 255, 255, 0.45);
+    padding: 10px 14px;
 }
 
 [data-theme="dark"] .skills-search {
-  background: rgba(24, 19, 16, 0.55);
-  border-color: rgba(255, 131, 95, 0.35);
+    background: rgba(24, 19, 16, 0.55);
+    border-color: rgba(255, 131, 95, 0.35);
 }
 
 .skills-search-input {
-  border: none;
-  outline: none;
-  width: 100%;
-  font-size: 0.95rem;
-  background: transparent;
+    border: none;
+    outline: none;
+    width: 100%;
+    font-size: 0.95rem;
+    background: transparent;
 }
 
 .skills-toolbar-row {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 10px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 10px;
+    flex-wrap: wrap;
 }
 
 .skills-sort {
-  appearance: none;
-  border: 1px solid rgba(255, 107, 74, 0.2);
-  border-radius: 999px;
-  padding: 10px 14px;
-  background: rgba(255, 255, 255, 0.45);
-  color: var(--ink);
-  font-weight: 650;
-  font-size: 0.9rem;
-  cursor: pointer;
+    appearance: none;
+    border: 1px solid rgba(255, 107, 74, 0.2);
+    border-radius: 999px;
+    padding: 10px 14px;
+    background: rgba(255, 255, 255, 0.45);
+    color: var(--ink);
+    font-weight: 650;
+    font-size: 0.9rem;
+    cursor: pointer;
 }
 
 [data-theme="dark"] .skills-sort {
-  background: rgba(24, 19, 16, 0.55);
-  border-color: rgba(255, 131, 95, 0.35);
+    background: rgba(24, 19, 16, 0.55);
+    border-color: rgba(255, 131, 95, 0.35);
 }
 
 .skills-dir,
 .skills-view {
-  border: 1px solid rgba(255, 107, 74, 0.2);
-  border-radius: 999px;
-  padding: 10px 12px;
-  background: rgba(255, 255, 255, 0.45);
-  color: var(--ink);
-  font-weight: 700;
-  cursor: pointer;
+    border: 1px solid rgba(255, 107, 74, 0.2);
+    border-radius: 999px;
+    padding: 10px 12px;
+    background: rgba(255, 255, 255, 0.45);
+    color: var(--ink);
+    font-weight: 700;
+    cursor: pointer;
 }
 
 [data-theme="dark"] .skills-dir,
 [data-theme="dark"] .skills-view {
-  background: rgba(24, 19, 16, 0.55);
-  border-color: rgba(255, 131, 95, 0.35);
+    background: rgba(24, 19, 16, 0.55);
+    border-color: rgba(255, 131, 95, 0.35);
 }
 
 .skills-view.is-active {
-  background: rgba(255, 107, 74, 0.16);
-  border-color: rgba(255, 107, 74, 0.32);
-  color: var(--accent-deep);
+    background: rgba(255, 107, 74, 0.16);
+    border-color: rgba(255, 107, 74, 0.32);
+    color: var(--accent-deep);
 }
 
 .skills-list {
-  display: grid;
-  gap: 0;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--line);
-  overflow: hidden;
-  background: var(--surface);
+    display: grid;
+    gap: 0;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--line);
+    overflow: hidden;
+    background: var(--surface);
 }
 
 .skills-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 14px;
-  padding: 14px 18px;
-  text-decoration: none;
-  color: inherit;
-  border-bottom: 1px solid var(--line);
-  transition: background 0.15s ease;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 14px;
+    padding: 14px 18px;
+    text-decoration: none;
+    color: inherit;
+    border-bottom: 1px solid var(--line);
+    transition: background 0.15s ease;
 }
 
 .skills-row:last-child {
-  border-bottom: none;
+    border-bottom: none;
 }
 
 .skills-row:hover {
-  background: rgba(255, 107, 74, 0.07);
+    background: rgba(255, 107, 74, 0.07);
 }
 
 [data-theme="dark"] .skills-row:hover {
-  background: rgba(232, 106, 71, 0.11);
+    background: rgba(232, 106, 71, 0.11);
 }
 
 .skills-row-main {
-  display: grid;
-  gap: 6px;
-  min-width: 0;
+    display: grid;
+    gap: 6px;
+    min-width: 0;
 }
 
 .skills-row-title {
-  display: flex;
-  align-items: baseline;
-  gap: 10px;
-  flex-wrap: wrap;
-  font-family: var(--font-display);
-  font-size: 1.1rem;
-  letter-spacing: -0.02em;
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    flex-wrap: wrap;
+    font-family: var(--font-display);
+    font-size: 1.1rem;
+    letter-spacing: -0.02em;
 }
 
 .skills-row-slug {
-  font-family: var(--font-mono);
-  font-size: 0.85rem;
-  color: var(--ink-soft);
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    color: var(--ink-soft);
 }
 
 .skills-row-summary {
-  color: var(--ink-soft);
-  font-size: 0.95rem;
-  line-height: 1.45;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
+    color: var(--ink-soft);
+    font-size: 0.95rem;
+    line-height: 1.45;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
 }
 
 .skills-row-metrics {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 14px;
-  font-family: var(--font-mono);
-  font-size: 0.85rem;
-  color: var(--ink-soft);
-  white-space: nowrap;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 14px;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    color: var(--ink-soft);
+    white-space: nowrap;
 }
 
 .skills-row-metrics span {
-  display: inline-flex;
-  gap: 6px;
-  align-items: center;
+    display: inline-flex;
+    gap: 6px;
+    align-items: center;
 }
 
 .card {
-  width: 100%;
-  background: var(--surface);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--line);
-  padding: 20px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  box-sizing: border-box;
-  transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease;
+    width: 100%;
+    background: var(--surface);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--line);
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    box-sizing: border-box;
+    transition:
+        transform 0.2s ease,
+        box-shadow 0.2s ease;
 }
 
 .loading-indicator {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  font-weight: 650;
-  color: var(--ink-soft);
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 650;
+    color: var(--ink-soft);
 }
 
 .loading-indicator::before {
-  content: "";
-  width: 14px;
-  height: 14px;
-  border-radius: 999px;
-  border: 2px solid rgba(255, 107, 74, 0.25);
-  border-top-color: var(--accent);
-  animation: spin 0.9s linear infinite;
+    content: "";
+    width: 14px;
+    height: 14px;
+    border-radius: 999px;
+    border: 2px solid rgba(255, 107, 74, 0.25);
+    border-top-color: var(--accent);
+    animation: spin 0.9s linear infinite;
 }
 
 .skill-card {
-  min-height: 176px;
+    min-height: 176px;
 }
 
 .skill-card-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
 }
 
 .tag-compact {
-  padding: 3px 10px;
-  font-size: 0.72rem;
+    padding: 3px 10px;
+    font-size: 0.72rem;
 }
 
 .skills-row-meta {
-  font-size: 0.82rem;
-  color: var(--ink-soft);
+    font-size: 0.82rem;
+    color: var(--ink-soft);
 }
 
 .skill-card-title {
-  font-family: var(--font-display);
-  font-size: 1.2rem;
-  letter-spacing: -0.02em;
-  margin: 0;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+    font-family: var(--font-display);
+    font-size: 1.2rem;
+    letter-spacing: -0.02em;
+    margin: 0;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
 }
 
 .skill-card-summary {
-  margin: 0;
-  color: var(--ink-soft);
-  font-size: 0.95rem;
-  line-height: 1.45;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+    margin: 0;
+    color: var(--ink-soft);
+    font-size: 0.95rem;
+    line-height: 1.45;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
 }
 
 .skill-card-footer {
-  margin-top: auto;
+    margin-top: auto;
 }
 
 .skill-card-footer-inline {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
 }
 
 .hero-install {
-  display: grid;
-  gap: 10px;
+    display: grid;
+    gap: 10px;
 }
 
 .install-switcher {
-  display: grid;
-  gap: 10px;
+    display: grid;
+    gap: 10px;
 }
 
 .install-switcher-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 14px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 14px;
+    flex-wrap: wrap;
 }
 
 .install-switcher-toggle {
-  display: inline-flex;
-  border-radius: 999px;
-  padding: 4px;
-  border: 1px solid rgba(255, 107, 74, 0.22);
-  background: rgba(255, 107, 74, 0.06);
+    display: inline-flex;
+    border-radius: 999px;
+    padding: 4px;
+    border: 1px solid rgba(255, 107, 74, 0.22);
+    background: rgba(255, 107, 74, 0.06);
 }
 
 [data-theme="dark"] .install-switcher-toggle {
-  border-color: rgba(232, 106, 71, 0.32);
-  background: rgba(232, 106, 71, 0.12);
+    border-color: rgba(232, 106, 71, 0.32);
+    background: rgba(232, 106, 71, 0.12);
 }
 
 .install-switcher-pill {
-  appearance: none;
-  border: none;
-  background: transparent;
-  color: var(--ink-soft);
-  font: inherit;
-  font-weight: 650;
-  font-size: 0.85rem;
-  padding: 6px 10px;
-  border-radius: 999px;
-  cursor: pointer;
-  transition:
-    background 0.18s ease,
-    color 0.18s ease,
-    transform 0.18s ease;
+    appearance: none;
+    border: none;
+    background: transparent;
+    color: var(--ink-soft);
+    font: inherit;
+    font-weight: 650;
+    font-size: 0.85rem;
+    padding: 6px 10px;
+    border-radius: 999px;
+    cursor: pointer;
+    transition:
+        background 0.18s ease,
+        color 0.18s ease,
+        transform 0.18s ease;
 }
 
 .install-switcher-pill:hover {
-  color: var(--ink);
-  transform: translateY(-1px);
+    color: var(--ink);
+    transform: translateY(-1px);
 }
 
 .install-switcher-pill.is-active {
-  background: rgba(255, 107, 74, 0.18);
-  color: var(--accent-deep);
+    background: rgba(255, 107, 74, 0.18);
+    color: var(--accent-deep);
 }
 
 [data-theme="dark"] .install-switcher-pill.is-active {
-  background: rgba(232, 106, 71, 0.22);
-  color: #ffd0bf;
+    background: rgba(232, 106, 71, 0.22);
+    color: #ffd0bf;
 }
 
 .hero-install-code {
-  border: 1px solid rgba(255, 107, 74, 0.2);
-  border-left: 3px solid var(--accent-deep);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(255, 250, 247, 0.9));
-  border-radius: 12px;
-  padding: 12px 14px;
-  font-size: 0.9rem;
-  line-height: 1.55;
-  color: var(--ink);
-  font-family: var(--font-mono);
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  margin: 0;
-  text-align: left;
-  font-variant-ligatures: none;
-  font-feature-settings:
-    "liga" 0,
-    "calt" 0;
-  white-space: pre;
-  tab-size: 2;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+    border: 1px solid rgba(255, 107, 74, 0.2);
+    border-left: 3px solid var(--accent-deep);
+    background: linear-gradient(
+        180deg,
+        rgba(255, 255, 255, 0.92),
+        rgba(255, 250, 247, 0.9)
+    );
+    border-radius: 12px;
+    padding: 12px 14px;
+    font-size: 0.9rem;
+    line-height: 1.55;
+    color: var(--ink);
+    font-family: var(--font-mono);
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    margin: 0;
+    text-align: left;
+    font-variant-ligatures: none;
+    font-feature-settings:
+        "liga" 0,
+        "calt" 0;
+    white-space: pre;
+    tab-size: 2;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
 
 [data-theme="dark"] .hero-install-code {
-  border-color: rgba(232, 106, 71, 0.35);
-  background: linear-gradient(180deg, rgba(26, 20, 18, 0.9), rgba(20, 16, 14, 0.85));
-  color: #f5e9e3;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    border-color: rgba(232, 106, 71, 0.35);
+    background: linear-gradient(
+        180deg,
+        rgba(26, 20, 18, 0.9),
+        rgba(20, 16, 14, 0.85)
+    );
+    color: #f5e9e3;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 .tag {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 12px;
-  border-radius: 999px;
-  background: rgba(43, 198, 164, 0.16);
-  color: #1a6b5b;
-  font-size: 0.8rem;
-  font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px;
+    border-radius: 999px;
+    background: rgba(43, 198, 164, 0.16);
+    color: #1a6b5b;
+    font-size: 0.8rem;
+    font-weight: 600;
 }
 
 [data-theme="dark"] .tag {
-  background: rgba(232, 106, 71, 0.2);
-  color: #ffd0bf;
+    background: rgba(232, 106, 71, 0.2);
+    color: #ffd0bf;
 }
 
 .skill-actions {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
-  align-items: center;
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    align-items: center;
 }
 
 .star-toggle {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  border: 1px solid rgba(255, 107, 74, 0.35);
-  background: rgba(255, 107, 74, 0.12);
-  color: var(--accent-deep);
-  display: grid;
-  place-items: center;
-  cursor: pointer;
-  transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease,
-    background 0.2s ease;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 107, 74, 0.35);
+    background: rgba(255, 107, 74, 0.12);
+    color: var(--accent-deep);
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    transition:
+        transform 0.2s ease,
+        box-shadow 0.2s ease,
+        background 0.2s ease;
 }
 
 .star-toggle span {
-  font-size: 1.1rem;
+    font-size: 1.1rem;
 }
 
 .star-toggle:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 18px rgba(255, 107, 74, 0.2);
+    transform: translateY(-1px);
+    box-shadow: 0 10px 18px rgba(255, 107, 74, 0.2);
 }
 
 .star-toggle.is-active {
-  background: var(--accent);
-  color: white;
-  border-color: var(--accent-deep);
+    background: var(--accent);
+    color: white;
+    border-color: var(--accent-deep);
 }
 
 .star-toggle:focus-visible {
-  outline: 3px solid rgba(255, 107, 74, 0.35);
-  outline-offset: 3px;
+    outline: 3px solid rgba(255, 107, 74, 0.35);
+    outline-offset: 3px;
 }
 
 [data-theme="dark"] .star-toggle {
-  border-color: rgba(232, 106, 71, 0.45);
-  background: rgba(232, 106, 71, 0.16);
-  color: #ffd0bf;
+    border-color: rgba(232, 106, 71, 0.45);
+    background: rgba(232, 106, 71, 0.16);
+    color: #ffd0bf;
 }
 
 .highlight-toggle {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  border: 1px solid rgba(43, 198, 164, 0.45);
-  background: rgba(43, 198, 164, 0.14);
-  color: #1a6b5b;
-  display: grid;
-  place-items: center;
-  cursor: pointer;
-  transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease,
-    background 0.2s ease;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    border: 1px solid rgba(43, 198, 164, 0.45);
+    background: rgba(43, 198, 164, 0.14);
+    color: #1a6b5b;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    transition:
+        transform 0.2s ease,
+        box-shadow 0.2s ease,
+        background 0.2s ease;
 }
 
 .highlight-toggle span {
-  font-size: 1.05rem;
+    font-size: 1.05rem;
 }
 
 .highlight-toggle:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 18px rgba(43, 198, 164, 0.2);
+    transform: translateY(-1px);
+    box-shadow: 0 10px 18px rgba(43, 198, 164, 0.2);
 }
 
 .highlight-toggle.is-active {
-  background: rgba(43, 198, 164, 0.28);
-  border-color: rgba(43, 198, 164, 0.7);
+    background: rgba(43, 198, 164, 0.28);
+    border-color: rgba(43, 198, 164, 0.7);
 }
 
 .highlight-toggle:focus-visible {
-  outline: 3px solid rgba(43, 198, 164, 0.3);
-  outline-offset: 3px;
+    outline: 3px solid rgba(43, 198, 164, 0.3);
+    outline-offset: 3px;
 }
 
 [data-theme="dark"] .highlight-toggle {
-  border-color: rgba(255, 131, 95, 0.45);
-  background: rgba(255, 131, 95, 0.12);
-  color: #ffd0bf;
+    border-color: rgba(255, 131, 95, 0.45);
+    background: rgba(255, 131, 95, 0.12);
+    color: #ffd0bf;
 }
 
 [data-theme="dark"] .highlight-toggle.is-active {
-  background: rgba(255, 131, 95, 0.22);
-  border-color: rgba(255, 131, 95, 0.55);
+    background: rgba(255, 131, 95, 0.22);
+    border-color: rgba(255, 131, 95, 0.55);
 }
 
 .stat {
-  display: flex;
-  gap: 10px;
-  align-items: center;
-  font-size: 0.9rem;
-  color: var(--ink-soft);
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    font-size: 0.9rem;
+    color: var(--ink-soft);
 }
 
 .search-bar {
-  display: flex;
-  gap: 12px;
-  padding: 14px 16px;
-  border-radius: 16px;
-  border: 1px solid var(--line);
-  background: var(--surface);
-  align-items: center;
+    display: flex;
+    gap: 12px;
+    padding: 14px 16px;
+    border-radius: 16px;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    align-items: center;
 }
 
 .hero.search-mode .search-bar {
-  padding: 18px 20px;
+    padding: 18px 20px;
 }
 
 .hero.search-mode .search-input {
-  font-size: 1.1rem;
+    font-size: 1.1rem;
 }
 
 @media (max-width: 860px) {
-  .hero-inner {
-    grid-template-columns: 1fr;
-    transition: none;
-  }
+    .hero-inner {
+        grid-template-columns: 1fr;
+        transition: none;
+    }
 
-  .hero.search-mode .hero-inner {
-    grid-template-columns: 1fr;
-    gap: 24px;
-  }
+    .hero.search-mode .hero-inner {
+        grid-template-columns: 1fr;
+        gap: 24px;
+    }
 }
 
 .skill-detail-stack {
-  display: grid;
-  gap: 16px;
+    display: grid;
+    gap: 16px;
 }
 
 .skill-hero {
-  gap: 14px;
+    gap: 14px;
 }
 
 .skill-hero-header {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 24px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 24px;
 }
 
 @media (max-width: 960px) {
-  .skill-hero-top.has-plugin {
-    grid-template-columns: 1fr;
-  }
+    .skill-hero-top.has-plugin {
+        grid-template-columns: 1fr;
+    }
 }
 
 .skill-hero-title {
-  display: grid;
-  gap: 10px;
-  min-width: min(100%, 320px);
-  flex: 1 1 360px;
+    display: grid;
+    gap: 10px;
+    min-width: min(100%, 320px);
+    flex: 1 1 360px;
 }
 
 .skill-hero-title-row {
-  display: flex;
-  align-items: baseline;
-  gap: 12px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    flex-wrap: wrap;
 }
 
 .skill-hero-note {
-  font-size: 0.9rem;
-  color: var(--ink);
-  max-width: 560px;
-  padding: 8px 12px;
-  border-radius: 12px;
-  background: rgba(255, 107, 74, 0.08);
-  border: 1px solid rgba(255, 107, 74, 0.18);
+    font-size: 0.9rem;
+    color: var(--ink);
+    max-width: 560px;
+    padding: 8px 12px;
+    border-radius: 12px;
+    background: rgba(255, 107, 74, 0.08);
+    border: 1px solid rgba(255, 107, 74, 0.18);
 }
 
 [data-theme="dark"] .skill-hero-note {
-  background: rgba(232, 106, 71, 0.16);
-  border-color: rgba(232, 106, 71, 0.3);
+    background: rgba(232, 106, 71, 0.16);
+    border-color: rgba(232, 106, 71, 0.3);
 }
 
 .tag-accent {
-  background: rgba(255, 107, 74, 0.16);
-  color: var(--accent-deep);
+    background: rgba(255, 107, 74, 0.16);
+    color: var(--accent-deep);
 }
 
 .skill-hero-top {
-  display: grid;
-  gap: 16px;
+    display: grid;
+    gap: 16px;
 }
 
 .skill-hero-top.has-plugin {
-  grid-template-columns: minmax(0, 1fr) minmax(320px, 420px);
-  align-items: start;
+    grid-template-columns: minmax(0, 1fr) minmax(320px, 420px);
+    align-items: start;
 }
 
 .skill-hero-content {
-  display: grid;
-  gap: 16px;
+    display: grid;
+    gap: 16px;
 }
 
 .bundle-card {
-  border: 1px solid rgba(255, 107, 74, 0.35);
-  border-radius: 18px;
-  padding: 18px;
-  background: linear-gradient(135deg, rgba(255, 107, 74, 0.1), rgba(255, 255, 255, 0.7));
-  box-shadow: 0 18px 30px rgba(37, 31, 26, 0.08);
+    border: 1px solid rgba(255, 107, 74, 0.35);
+    border-radius: 18px;
+    padding: 18px;
+    background: linear-gradient(
+        135deg,
+        rgba(255, 107, 74, 0.1),
+        rgba(255, 255, 255, 0.7)
+    );
+    box-shadow: 0 18px 30px rgba(37, 31, 26, 0.08);
 }
 
 [data-theme="dark"] .bundle-card {
-  background: linear-gradient(135deg, rgba(232, 106, 71, 0.2), rgba(24, 19, 16, 0.7));
-  border-color: rgba(232, 106, 71, 0.5);
-  box-shadow: 0 18px 30px rgba(0, 0, 0, 0.35);
+    background: linear-gradient(
+        135deg,
+        rgba(232, 106, 71, 0.2),
+        rgba(24, 19, 16, 0.7)
+    );
+    border-color: rgba(232, 106, 71, 0.5);
+    box-shadow: 0 18px 30px rgba(0, 0, 0, 0.35);
 }
 
 [data-theme="dark"] .tag-accent {
-  background: rgba(232, 106, 71, 0.24);
-  color: #ffd0bf;
+    background: rgba(232, 106, 71, 0.24);
+    color: #ffd0bf;
 }
 
 .bundle-header {
-  display: grid;
-  gap: 6px;
+    display: grid;
+    gap: 6px;
 }
 
 .bundle-title {
-  font-family: var(--font-display);
-  font-size: 1.05rem;
-  letter-spacing: -0.015em;
+    font-family: var(--font-display);
+    font-size: 1.05rem;
+    letter-spacing: -0.015em;
 }
 
 .bundle-subtitle {
-  font-size: 0.88rem;
-  color: var(--ink-soft);
+    font-size: 0.88rem;
+    color: var(--ink-soft);
 }
 
 .bundle-includes {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
 }
 
 .bundle-includes span {
-  padding: 6px 12px;
-  border-radius: 999px;
-  background: rgba(255, 107, 74, 0.16);
-  color: var(--accent-deep);
-  font-size: 0.76rem;
-  font-weight: 650;
-  letter-spacing: 0.01em;
+    padding: 6px 12px;
+    border-radius: 999px;
+    background: rgba(255, 107, 74, 0.16);
+    color: var(--accent-deep);
+    font-size: 0.76rem;
+    font-weight: 650;
+    letter-spacing: 0.01em;
 }
 
 [data-theme="dark"] .bundle-includes span {
-  background: rgba(232, 106, 71, 0.22);
-  color: #ffd0bf;
+    background: rgba(232, 106, 71, 0.22);
+    color: #ffd0bf;
 }
 
 .bundle-section {
-  display: grid;
-  gap: 8px;
-  padding: 10px 12px;
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.6);
-  border: 1px solid rgba(255, 107, 74, 0.12);
+    display: grid;
+    gap: 8px;
+    padding: 10px 12px;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.6);
+    border: 1px solid rgba(255, 107, 74, 0.12);
 }
 
 .bundle-card .hero-install-code {
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-  text-align: left;
-  font-variant-ligatures: none;
-  font-feature-settings:
-    "liga" 0,
-    "calt" 0;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    text-align: left;
+    font-variant-ligatures: none;
+    font-feature-settings:
+        "liga" 0,
+        "calt" 0;
 }
 
 [data-theme="dark"] .bundle-section {
-  background: rgba(30, 24, 20, 0.6);
-  border-color: rgba(232, 106, 71, 0.2);
+    background: rgba(30, 24, 20, 0.6);
+    border-color: rgba(232, 106, 71, 0.2);
 }
 
 .bundle-section-title {
-  font-size: 0.9rem;
-  font-weight: 650;
+    font-size: 0.9rem;
+    font-weight: 650;
 }
 
 .bundle-meta {
-  display: grid;
-  gap: 6px;
+    display: grid;
+    gap: 6px;
 }
 
 .bundle-details summary {
-  cursor: pointer;
-  font-weight: 650;
-  list-style: none;
+    cursor: pointer;
+    font-weight: 650;
+    list-style: none;
 }
 
 .bundle-details summary::-webkit-details-marker {
-  display: none;
+    display: none;
 }
 
 .bundle-details summary::before {
-  content: "▸";
-  display: inline-block;
-  margin-right: 8px;
-  color: var(--accent-deep);
+    content: "▸";
+    display: inline-block;
+    margin-right: 8px;
+    color: var(--accent-deep);
 }
 
 .bundle-details[open] summary::before {
-  content: "▾";
+    content: "▾";
 }
 
 .skill-hero-cta {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
-  gap: 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 10px;
 }
 
 .skill-version-pill {
-  display: grid;
-  gap: 4px;
-  padding: 10px 14px;
-  border-radius: 16px;
-  border: 1px solid var(--line);
-  background: var(--surface-muted);
-  text-align: right;
-  min-width: 150px;
+    display: grid;
+    gap: 4px;
+    padding: 10px 14px;
+    border-radius: 16px;
+    border: 1px solid var(--line);
+    background: var(--surface-muted);
+    text-align: right;
+    min-width: 150px;
 }
 
 .skill-version-label {
-  font-size: 0.68rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--ink-soft);
+    font-size: 0.68rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--ink-soft);
 }
 
 .skill-tag-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
 }
 
 .tag-meta {
-  font-size: 0.72rem;
-  font-weight: 600;
-  color: inherit;
-  opacity: 0.7;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: inherit;
+    opacity: 0.7;
 }
 
 .tag-form {
-  display: grid;
-  grid-template-columns: minmax(140px, 1fr) minmax(160px, 1fr) auto;
-  gap: 10px;
-  align-items: center;
+    display: grid;
+    grid-template-columns: minmax(140px, 1fr) minmax(160px, 1fr) auto;
+    gap: 10px;
+    align-items: center;
 }
 
 .skill-hero-panels {
-  display: grid;
-  gap: 14px;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    display: grid;
+    gap: 14px;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
 .skill-panel {
-  display: grid;
-  gap: 10px;
-  padding: 14px;
-  border-radius: 16px;
-  border: 1px solid var(--line);
-  background: var(--surface-muted);
+    display: grid;
+    gap: 10px;
+    padding: 14px;
+    border-radius: 16px;
+    border: 1px solid var(--line);
+    background: var(--surface-muted);
 }
 
 .skill-panel-body {
-  display: grid;
-  gap: 8px;
+    display: grid;
+    gap: 8px;
 }
 
 .diff-card {
-  gap: 16px;
+    gap: 16px;
 }
 
 .diff-card-embedded {
-  padding: 0;
-  background: transparent;
-  border: none;
+    padding: 0;
+    background: transparent;
+    border: none;
 }
 
 .diff-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 16px;
-  flex-wrap: wrap;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    flex-wrap: wrap;
 }
 
 .diff-toggle-group {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px;
-  border-radius: 999px;
-  border: 1px solid var(--line);
-  background: var(--surface-muted);
-  margin: 0;
-  min-inline-size: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px;
+    border-radius: 999px;
+    border: 1px solid var(--line);
+    background: var(--surface-muted);
+    margin: 0;
+    min-inline-size: 0;
 }
 
 .diff-toggle {
-  border: none;
-  background: transparent;
-  padding: 8px 14px;
-  border-radius: 999px;
-  font-weight: 600;
-  color: var(--ink-soft);
-  cursor: pointer;
+    border: none;
+    background: transparent;
+    padding: 8px 14px;
+    border-radius: 999px;
+    font-weight: 600;
+    color: var(--ink-soft);
+    cursor: pointer;
 }
 
 .diff-toggle.is-active {
-  background: var(--surface);
-  color: var(--ink);
-  box-shadow: 0 8px 18px rgba(29, 26, 23, 0.12);
+    background: var(--surface);
+    color: var(--ink);
+    box-shadow: 0 8px 18px rgba(29, 26, 23, 0.12);
 }
 
 .diff-controls {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
-  gap: 12px;
-  align-items: end;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    gap: 12px;
+    align-items: end;
 }
 
 .diff-select {
-  display: grid;
-  gap: 6px;
+    display: grid;
+    gap: 6px;
 }
 
 .diff-select label {
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--ink-soft);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--ink-soft);
 }
 
 .diff-swap {
-  align-self: end;
+    align-self: end;
 }
 
 .diff-meta {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  color: var(--ink-soft);
-  font-size: 0.85rem;
-  flex-wrap: wrap;
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    color: var(--ink-soft);
+    font-size: 0.85rem;
+    flex-wrap: wrap;
 }
 
 .diff-layout {
-  display: grid;
-  grid-template-columns: minmax(180px, 240px) minmax(0, 1fr);
-  gap: 16px;
-  align-items: start;
+    display: grid;
+    grid-template-columns: minmax(180px, 240px) minmax(0, 1fr);
+    gap: 16px;
+    align-items: start;
 }
 
 .diff-files {
-  display: grid;
-  gap: 8px;
-  max-height: 420px;
-  overflow: auto;
-  padding-right: 4px;
+    display: grid;
+    gap: 8px;
+    max-height: 420px;
+    overflow: auto;
+    padding-right: 4px;
 }
 
 .diff-file {
-  border: 1px solid var(--line);
-  background: var(--surface-muted);
-  border-radius: 14px;
-  padding: 10px 12px;
-  text-align: left;
-  display: grid;
-  gap: 6px;
-  transition:
-    transform 0.2s ease,
-    box-shadow 0.2s ease,
-    border 0.2s ease;
+    border: 1px solid var(--line);
+    background: var(--surface-muted);
+    border-radius: 14px;
+    padding: 10px 12px;
+    text-align: left;
+    display: grid;
+    gap: 6px;
+    transition:
+        transform 0.2s ease,
+        box-shadow 0.2s ease,
+        border 0.2s ease;
 }
 
 .diff-file:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 20px rgba(29, 26, 23, 0.12);
+    transform: translateY(-1px);
+    box-shadow: 0 10px 20px rgba(29, 26, 23, 0.12);
 }
 
 .diff-file.is-active {
-  border-color: rgba(255, 107, 74, 0.45);
-  box-shadow: 0 12px 24px rgba(255, 107, 74, 0.2);
+    border-color: rgba(255, 107, 74, 0.45);
+    box-shadow: 0 12px 24px rgba(255, 107, 74, 0.2);
 }
 
 .diff-file-name {
-  font-size: 0.9rem;
-  color: var(--ink);
-  font-family: var(--font-mono);
-  word-break: break-all;
+    font-size: 0.9rem;
+    color: var(--ink);
+    font-family: var(--font-mono);
+    word-break: break-all;
 }
 
 .diff-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 0.7rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-weight: 700;
-  padding: 4px 8px;
-  border-radius: 999px;
-  align-self: start;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 700;
+    padding: 4px 8px;
+    border-radius: 999px;
+    align-self: start;
 }
 
 .diff-pill-added {
-  background: rgba(43, 198, 164, 0.18);
-  color: #0b6b58;
+    background: rgba(43, 198, 164, 0.18);
+    color: #0b6b58;
 }
 
 .diff-pill-removed {
-  background: rgba(255, 107, 74, 0.18);
-  color: #9b3a25;
+    background: rgba(255, 107, 74, 0.18);
+    color: #9b3a25;
 }
 
 .diff-pill-changed {
-  background: rgba(240, 196, 106, 0.22);
-  color: #8a5b14;
+    background: rgba(240, 196, 106, 0.22);
+    color: #8a5b14;
 }
 
 .diff-pill-same {
-  background: rgba(29, 26, 23, 0.08);
-  color: var(--ink-soft);
+    background: rgba(29, 26, 23, 0.08);
+    color: var(--ink-soft);
 }
 
 .diff-view {
-  position: relative;
-  min-height: 360px;
+    position: relative;
+    min-height: 360px;
 }
 
 .diff-monaco {
-  height: 420px;
-  border-radius: 18px;
-  border: 1px solid var(--line);
-  overflow: hidden;
-  background: var(--surface);
+    height: 420px;
+    border-radius: 18px;
+    border: 1px solid var(--line);
+    overflow: hidden;
+    background: var(--surface);
 }
 
 .diff-empty {
-  border-radius: 16px;
-  border: 1px dashed var(--line);
-  padding: 20px;
-  color: var(--ink-soft);
-  background: var(--surface-muted);
-  font-size: 0.9rem;
+    border-radius: 16px;
+    border: 1px dashed var(--line);
+    padding: 20px;
+    color: var(--ink-soft);
+    background: var(--surface-muted);
+    font-size: 0.9rem;
 }
 
 .diff-loading {
-  position: absolute;
-  bottom: 12px;
-  right: 16px;
-  font-size: 0.8rem;
-  color: var(--ink-soft);
-  background: rgba(255, 255, 255, 0.8);
-  border-radius: 999px;
-  padding: 6px 10px;
-  border: 1px solid var(--line);
+    position: absolute;
+    bottom: 12px;
+    right: 16px;
+    font-size: 0.8rem;
+    color: var(--ink-soft);
+    background: rgba(255, 255, 255, 0.8);
+    border-radius: 999px;
+    padding: 6px 10px;
+    border: 1px solid var(--line);
 }
 
 .tab-card {
-  gap: 14px;
+    gap: 14px;
 }
 
 .tab-header {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px;
-  border-radius: 999px;
-  border: 1px solid var(--line);
-  background: var(--surface-muted);
-  align-self: flex-start;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px;
+    border-radius: 999px;
+    border: 1px solid var(--line);
+    background: var(--surface-muted);
+    align-self: flex-start;
 }
 
 .tab-button {
-  border: none;
-  background: transparent;
-  padding: 8px 16px;
-  border-radius: 999px;
-  font-weight: 650;
-  color: var(--ink-soft);
-  cursor: pointer;
+    border: none;
+    background: transparent;
+    padding: 8px 16px;
+    border-radius: 999px;
+    font-weight: 650;
+    color: var(--ink-soft);
+    cursor: pointer;
 }
 
 .tab-button.is-active {
-  background: var(--surface);
-  color: var(--ink);
-  box-shadow: 0 8px 18px rgba(29, 26, 23, 0.12);
-}
-
-.tab-body {
-  display: grid;
-  gap: 20px;
+    background: var(--surface);
+    color: var(--ink);
+    box-shadow: 0 8px 18px rgba(29, 26, 23, 0.12);
 }
 
 .file-list {
-  display: grid;
-  gap: 12px;
-  padding-top: 8px;
-  border-top: 1px solid var(--line);
+    display: grid;
+    gap: 12px;
+    padding-top: 8px;
+    border-top: 1px solid var(--line);
 }
 
 .file-list-header {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 10px;
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 10px;
 }
 
 .file-list-body {
-  display: grid;
-  gap: 8px;
-  max-height: 260px;
-  overflow: auto;
-  padding-right: 4px;
+    display: grid;
+    gap: 8px;
+    max-height: 260px;
+    overflow: auto;
+    padding-right: 4px;
 }
 
 .version-scroll {
-  max-height: 320px;
-  overflow: auto;
-  padding-right: 4px;
+    max-height: 320px;
+    overflow: auto;
+    padding-right: 4px;
 }
 
 .file-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 10px 12px;
-  border-radius: 12px;
-  border: 1px solid var(--line);
-  background: var(--surface-muted);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 10px 12px;
+    border-radius: 12px;
+    border: 1px solid var(--line);
+    background: var(--surface-muted);
 }
 
 .file-path {
-  font-family: var(--font-mono);
-  font-size: 0.9rem;
-  color: var(--ink);
-  word-break: break-all;
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    color: var(--ink);
+    word-break: break-all;
 }
 
 .file-meta {
-  font-size: 0.8rem;
-  color: var(--ink-soft);
-  white-space: nowrap;
+    font-size: 0.8rem;
+    color: var(--ink-soft);
+    white-space: nowrap;
 }
 
 .comment-form {
-  display: grid;
-  gap: 12px;
-  margin-top: 12px;
+    display: grid;
+    gap: 12px;
+    margin-top: 12px;
 }
 
 .comment-input {
-  border-radius: 16px;
-  border: 1px solid var(--line);
-  padding: 14px 16px;
-  font-size: 1rem;
-  background: var(--surface-muted);
-  color: var(--ink);
-  font-family: var(--font-body);
-  min-height: 120px;
-  resize: vertical;
+    border-radius: 16px;
+    border: 1px solid var(--line);
+    padding: 14px 16px;
+    font-size: 1rem;
+    background: var(--surface-muted);
+    color: var(--ink);
+    font-family: var(--font-body);
+    min-height: 120px;
+    resize: vertical;
 }
 
 .comment-input:focus-visible {
-  outline: 3px solid rgba(255, 107, 74, 0.25);
-  outline-offset: 3px;
+    outline: 3px solid rgba(255, 107, 74, 0.25);
+    outline-offset: 3px;
 }
 
 .comment-submit {
-  justify-self: start;
-  padding: 8px 14px;
-  font-size: 0.9rem;
+    justify-self: start;
+    padding: 8px 14px;
+    font-size: 0.9rem;
 }
 
 .sidebar-card {
-  gap: 20px;
+    gap: 20px;
 }
 
 .sidebar-section {
-  display: grid;
-  gap: 12px;
+    display: grid;
+    gap: 12px;
 }
 
 .sidebar-stack {
-  display: grid;
-  gap: 8px;
+    display: grid;
+    gap: 8px;
 }
 
 .sidebar-divider {
-  height: 1px;
-  background: var(--line);
-  opacity: 0.6;
+    height: 1px;
+    background: var(--line);
+    opacity: 0.6;
 }
 
 .sidebar-scroll {
-  max-height: 260px;
-  overflow: auto;
-  padding-right: 4px;
+    max-height: 260px;
+    overflow: auto;
+    padding-right: 4px;
 }
 
 .sidebar-form {
-  display: grid;
-  gap: 10px;
-  margin-top: 12px;
+    display: grid;
+    gap: 10px;
+    margin-top: 12px;
 }
 
 .version-list {
-  display: grid;
-  gap: 14px;
+    display: grid;
+    gap: 14px;
 }
 
 .version-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 16px;
-  align-items: center;
-  padding: 6px 0;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 16px;
+    align-items: center;
+    padding: 6px 0;
 }
 
 .version-info {
-  display: grid;
-  gap: 6px;
-  color: var(--ink-soft);
-  font-size: 0.9rem;
+    display: grid;
+    gap: 6px;
+    color: var(--ink-soft);
+    font-size: 0.9rem;
 }
 
 .version-actions {
-  display: grid;
-  align-items: center;
+    display: grid;
+    align-items: center;
 }
 
 .version-zip {
-  justify-self: end;
+    justify-self: end;
 }
 
 [data-theme="dark"] .diff-pill-added {
-  color: #72f0d3;
+    color: #72f0d3;
 }
 
 [data-theme="dark"] .diff-pill-removed {
-  color: #ffc1b1;
+    color: #ffc1b1;
 }
 
 [data-theme="dark"] .diff-pill-changed {
-  color: #ffd494;
+    color: #ffd494;
 }
 
 [data-theme="dark"] .diff-loading {
-  background: rgba(32, 27, 24, 0.85);
+    background: rgba(32, 27, 24, 0.85);
 }
 
 @media (max-width: 760px) {
-  .navbar-inner {
-    padding: 16px 16px;
-    gap: 14px;
-  }
+    .navbar-inner {
+        padding: 16px 16px;
+        gap: 14px;
+    }
 
-  .nav-links {
-    display: none;
-  }
+    .nav-links {
+        display: none;
+    }
 
-  .nav-mobile {
-    display: inline-flex;
-  }
+    .nav-mobile {
+        display: inline-flex;
+    }
 
-  .theme-toggle {
-    display: none;
-  }
+    .theme-toggle {
+        display: none;
+    }
 
-  .hero {
-    padding: 64px 18px 46px;
-  }
+    .hero {
+        padding: 64px 18px 46px;
+    }
 
-  .section {
-    padding: 28px 18px 64px;
-  }
+    .section {
+        padding: 28px 18px 64px;
+    }
 
-  .section-cta {
-    justify-content: flex-start;
-  }
+    .section-cta {
+        justify-content: flex-start;
+    }
 
-  .skill-hero-header {
-    flex-direction: column;
-    align-items: stretch;
-  }
+    .skill-hero-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
 
-  .skill-hero-cta {
-    align-items: flex-start;
-  }
+    .skill-hero-cta {
+        align-items: flex-start;
+    }
 
-  .tag-form {
-    grid-template-columns: 1fr;
-    align-items: stretch;
-  }
+    .tag-form {
+        grid-template-columns: 1fr;
+        align-items: stretch;
+    }
 
-  .diff-controls {
-    grid-template-columns: 1fr;
-  }
+    .diff-controls {
+        grid-template-columns: 1fr;
+    }
 
-  .diff-layout {
-    grid-template-columns: 1fr;
-  }
+    .diff-layout {
+        grid-template-columns: 1fr;
+    }
 
-  .diff-files {
-    grid-auto-flow: column;
-    grid-auto-columns: minmax(180px, 1fr);
-    overflow-x: auto;
-    padding-bottom: 6px;
-    max-height: none;
-  }
+    .diff-files {
+        grid-auto-flow: column;
+        grid-auto-columns: minmax(180px, 1fr);
+        overflow-x: auto;
+        padding-bottom: 6px;
+        max-height: none;
+    }
 
-  .skills-row {
-    grid-template-columns: 1fr;
-    gap: 10px;
-  }
+    .skills-row {
+        grid-template-columns: 1fr;
+        gap: 10px;
+    }
 
-  .skills-row-metrics {
-    justify-content: flex-start;
-    white-space: normal;
-    flex-wrap: wrap;
-    row-gap: 8px;
-  }
+    .skills-row-metrics {
+        justify-content: flex-start;
+        white-space: normal;
+        flex-wrap: wrap;
+        row-gap: 8px;
+    }
 }
 
 @media (max-width: 520px) {
-  .brand {
-    font-size: 1.25rem;
-  }
+    .brand {
+        font-size: 1.25rem;
+    }
 
-  .nav-actions {
-    gap: 10px;
-  }
+    .nav-actions {
+        gap: 10px;
+    }
 
-  .navbar .btn {
-    padding: 9px 12px;
-    font-size: 0.95rem;
-  }
+    .navbar .btn {
+        padding: 9px 12px;
+        font-size: 0.95rem;
+    }
 
-  .sign-in-provider {
-    display: none;
-  }
+    .sign-in-provider {
+        display: none;
+    }
 
-  .user-trigger .mono,
-  .user-menu-chevron {
-    display: none;
-  }
+    .user-trigger .mono,
+    .user-menu-chevron {
+        display: none;
+    }
 
-  .search-bar {
-    flex-wrap: wrap;
-    gap: 10px;
-  }
+    .search-bar {
+        flex-wrap: wrap;
+        gap: 10px;
+    }
 
-  .search-bar > .mono {
-    display: none;
-  }
+    .search-bar > .mono {
+        display: none;
+    }
 
-  .search-input {
-    flex: 1 1 180px;
-    min-width: 0;
-  }
+    .search-input {
+        flex: 1 1 180px;
+        min-width: 0;
+    }
 
-  .search-filter-button {
-    width: 100%;
-    justify-content: center;
-  }
+    .search-filter-button {
+        width: 100%;
+        justify-content: center;
+    }
 
-  .install-switcher-row {
-    align-items: flex-start;
-    flex-direction: column;
-    gap: 10px;
-  }
+    .install-switcher-row {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 10px;
+    }
 
-  .site-footer {
-    padding: 0 18px 36px;
-  }
+    .site-footer {
+        padding: 0 18px 36px;
+    }
 }
 
 .search-filter-button {
-  border-radius: 999px;
-  border: 1px solid rgba(255, 107, 74, 0.3);
-  padding: 10px 14px;
-  background: var(--surface-muted);
-  color: var(--ink);
-  font-weight: 600;
-  cursor: pointer;
-  transition:
-    border 0.2s ease,
-    box-shadow 0.2s ease,
-    background 0.2s ease,
-    color 0.2s ease;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 107, 74, 0.3);
+    padding: 10px 14px;
+    background: var(--surface-muted);
+    color: var(--ink);
+    font-weight: 600;
+    cursor: pointer;
+    transition:
+        border 0.2s ease,
+        box-shadow 0.2s ease,
+        background 0.2s ease,
+        color 0.2s ease;
 }
 
 .search-filter-button[aria-pressed="true"] {
-  background: var(--accent);
-  border-color: var(--accent-deep);
-  color: white;
-  box-shadow: 0 10px 20px rgba(255, 107, 74, 0.3);
+    background: var(--accent);
+    border-color: var(--accent-deep);
+    color: white;
+    box-shadow: 0 10px 20px rgba(255, 107, 74, 0.3);
 }
 
 .search-filter-button:focus-visible {
-  outline: 3px solid rgba(255, 107, 74, 0.3);
-  outline-offset: 3px;
+    outline: 3px solid rgba(255, 107, 74, 0.3);
+    outline-offset: 3px;
 }
 
 .search-filter {
-  display: inline-flex;
-  align-items: center;
-  gap: 12px;
-  padding: 10px 14px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 107, 74, 0.2);
-  background: var(--surface-muted);
-  color: var(--ink);
-  font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 14px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 107, 74, 0.2);
+    background: var(--surface-muted);
+    color: var(--ink);
+    font-weight: 600;
 }
 
 .search-filter-input {
-  appearance: none;
-  width: 20px;
-  height: 20px;
-  border-radius: 6px;
-  border: 2px solid rgba(255, 107, 74, 0.4);
-  display: grid;
-  place-items: center;
-  background: transparent;
-  transition:
-    border 0.2s ease,
-    box-shadow 0.2s ease,
-    background 0.2s ease;
+    appearance: none;
+    width: 20px;
+    height: 20px;
+    border-radius: 6px;
+    border: 2px solid rgba(255, 107, 74, 0.4);
+    display: grid;
+    place-items: center;
+    background: transparent;
+    transition:
+        border 0.2s ease,
+        box-shadow 0.2s ease,
+        background 0.2s ease;
 }
 
 .search-filter-input::after {
-  content: "";
-  width: 10px;
-  height: 10px;
-  border-radius: 3px;
-  background: white;
-  transform: scale(0);
-  transition: transform 0.15s ease;
+    content: "";
+    width: 10px;
+    height: 10px;
+    border-radius: 3px;
+    background: white;
+    transform: scale(0);
+    transition: transform 0.15s ease;
 }
 
 .search-filter-input:checked {
-  background: var(--accent);
-  border-color: var(--accent-deep);
-  box-shadow: 0 8px 16px rgba(255, 107, 74, 0.3);
+    background: var(--accent);
+    border-color: var(--accent-deep);
+    box-shadow: 0 8px 16px rgba(255, 107, 74, 0.3);
 }
 
 .search-filter-input:checked::after {
-  transform: scale(1);
+    transform: scale(1);
 }
 
 .search-filter-input:focus-visible {
-  outline: 3px solid rgba(255, 107, 74, 0.3);
-  outline-offset: 3px;
+    outline: 3px solid rgba(255, 107, 74, 0.3);
+    outline-offset: 3px;
 }
 
 [data-theme="dark"] .search-filter {
-  background: rgba(36, 31, 27, 0.9);
-  border-color: rgba(255, 131, 95, 0.35);
+    background: rgba(36, 31, 27, 0.9);
+    border-color: rgba(255, 131, 95, 0.35);
 }
 
 [data-theme="dark"] .search-filter-button {
-  background: rgba(36, 31, 27, 0.9);
-  border-color: rgba(255, 131, 95, 0.35);
+    background: rgba(36, 31, 27, 0.9);
+    border-color: rgba(255, 131, 95, 0.35);
 }
 
 [data-theme="dark"] .search-filter-input {
-  border-color: rgba(255, 131, 95, 0.6);
+    border-color: rgba(255, 131, 95, 0.6);
 }
 
 .search-input {
-  border: none;
-  outline: none;
-  flex: 1;
-  font-size: 1rem;
-  background: transparent;
+    border: none;
+    outline: none;
+    flex: 1;
+    font-size: 1rem;
+    background: transparent;
 }
 
 .settings-shell {
-  display: grid;
-  gap: 20px;
+    display: grid;
+    gap: 20px;
 }
 
 .settings-profile {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  background: linear-gradient(135deg, var(--surface), var(--surface-muted));
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    background: linear-gradient(135deg, var(--surface), var(--surface-muted));
 }
 
 .settings-avatar {
-  width: 72px;
-  height: 72px;
-  border-radius: 22px;
-  background: rgba(255, 107, 74, 0.14);
-  border: 1px solid rgba(255, 107, 74, 0.3);
-  display: grid;
-  place-items: center;
-  font-weight: 700;
-  color: var(--accent-deep);
-  overflow: hidden;
+    width: 72px;
+    height: 72px;
+    border-radius: 22px;
+    background: rgba(255, 107, 74, 0.14);
+    border: 1px solid rgba(255, 107, 74, 0.3);
+    display: grid;
+    place-items: center;
+    font-weight: 700;
+    color: var(--accent-deep);
+    overflow: hidden;
 }
 
 .settings-avatar img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
 }
 
 .settings-profile-body {
-  display: grid;
-  gap: 4px;
+    display: grid;
+    gap: 4px;
 }
 
 .settings-name {
-  font-size: 1.25rem;
-  font-weight: 700;
+    font-size: 1.25rem;
+    font-weight: 700;
 }
 
 .settings-handle {
-  color: var(--ink-soft);
+    color: var(--ink-soft);
 }
 
 .settings-email {
-  font-size: 0.95rem;
-  color: var(--ink-soft);
+    font-size: 0.95rem;
+    color: var(--ink-soft);
 }
 
 .profile-tabs {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-  margin: 0 0 18px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    margin: 0 0 18px;
 }
 
 .profile-tab {
-  border: 1px solid rgba(255, 107, 74, 0.2);
-  background: rgba(255, 255, 255, 0.45);
-  color: var(--ink-soft);
-  padding: 10px 14px;
-  border-radius: 999px;
-  font-weight: 650;
-  cursor: pointer;
-  transition:
-    transform 0.18s ease,
-    background 0.18s ease,
-    border-color 0.18s ease,
-    color 0.18s ease;
+    border: 1px solid rgba(255, 107, 74, 0.2);
+    background: rgba(255, 255, 255, 0.45);
+    color: var(--ink-soft);
+    padding: 10px 14px;
+    border-radius: 999px;
+    font-weight: 650;
+    cursor: pointer;
+    transition:
+        transform 0.18s ease,
+        background 0.18s ease,
+        border-color 0.18s ease,
+        color 0.18s ease;
 }
 
 [data-theme="dark"] .profile-tab {
-  background: rgba(24, 19, 16, 0.55);
-  border-color: rgba(255, 131, 95, 0.35);
+    background: rgba(24, 19, 16, 0.55);
+    border-color: rgba(255, 131, 95, 0.35);
 }
 
 .profile-tab:hover {
-  transform: translateY(-1px);
-  color: var(--ink);
+    transform: translateY(-1px);
+    color: var(--ink);
 }
 
 .profile-tab.is-active {
-  background: rgba(255, 107, 74, 0.16);
-  border-color: rgba(255, 107, 74, 0.32);
-  color: var(--accent-deep);
+    background: rgba(255, 107, 74, 0.16);
+    border-color: rgba(255, 107, 74, 0.32);
+    color: var(--accent-deep);
 }
 
 .profile-actions {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-  margin-bottom: 18px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    margin-bottom: 18px;
 }
 
 .telemetry-root-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
 }
 
 .telemetry-root-title {
-  font-weight: 750;
-  letter-spacing: -0.01em;
+    font-weight: 750;
+    letter-spacing: -0.01em;
 }
 
 .telemetry-root-meta {
-  font-size: 0.9rem;
-  color: var(--ink-soft);
-  margin-top: 4px;
+    font-size: 0.9rem;
+    color: var(--ink-soft);
+    margin-top: 4px;
 }
 
 .telemetry-skill-list {
-  display: grid;
-  gap: 10px;
-  margin-top: 10px;
+    display: grid;
+    gap: 10px;
+    margin-top: 10px;
 }
 
 .telemetry-skill-row {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 12px;
-  flex-wrap: wrap;
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
 }
 
 .telemetry-skill-link {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 10px;
-  min-width: 0;
+    display: inline-flex;
+    align-items: baseline;
+    gap: 10px;
+    min-width: 0;
 }
 
 .telemetry-skill-slug {
-  font-family: var(--font-mono);
-  font-size: 0.85rem;
-  color: var(--ink-soft);
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    color: var(--ink-soft);
 }
 
 .telemetry-skill-meta {
-  color: var(--ink-soft);
-  white-space: nowrap;
+    color: var(--ink-soft);
+    white-space: nowrap;
 }
 
 .settings-card {
-  display: grid;
-  gap: 16px;
+    display: grid;
+    gap: 16px;
 }
 
 .settings-field {
-  display: grid;
-  gap: 8px;
-  font-weight: 600;
-  color: var(--ink);
+    display: grid;
+    gap: 8px;
+    font-weight: 600;
+    color: var(--ink);
 }
 
 .settings-input {
-  width: 100%;
-  border-radius: 14px;
-  border: 1px solid rgba(255, 107, 74, 0.2);
-  background: var(--surface-muted);
-  padding: 12px 14px;
-  font-size: 1rem;
-  color: var(--ink);
-  outline: none;
-  transition:
-    border 0.2s ease,
-    box-shadow 0.2s ease;
+    width: 100%;
+    border-radius: 14px;
+    border: 1px solid rgba(255, 107, 74, 0.2);
+    background: var(--surface-muted);
+    padding: 12px 14px;
+    font-size: 1rem;
+    color: var(--ink);
+    outline: none;
+    transition:
+        border 0.2s ease,
+        box-shadow 0.2s ease;
 }
 
 .settings-input:focus {
-  border-color: rgba(255, 107, 74, 0.5);
-  box-shadow: 0 0 0 3px rgba(255, 107, 74, 0.15);
+    border-color: rgba(255, 107, 74, 0.5);
+    box-shadow: 0 0 0 3px rgba(255, 107, 74, 0.15);
 }
 
 .settings-actions {
-  display: flex;
-  align-items: center;
-  gap: 12px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
 }
 
 .settings-save {
-  padding: 10px 22px;
+    padding: 10px 22px;
 }
 
 .danger-card {
-  margin-top: 8px;
-  border: 1px solid rgba(255, 107, 74, 0.28);
-  background: linear-gradient(135deg, rgba(255, 107, 74, 0.08), transparent);
+    margin-top: 8px;
+    border: 1px solid rgba(255, 107, 74, 0.28);
+    background: linear-gradient(135deg, rgba(255, 107, 74, 0.08), transparent);
 }
 
 .danger-title {
-  margin: 0 0 6px;
-  font-size: 1.2rem;
+    margin: 0 0 6px;
+    font-size: 1.2rem;
 }
 
 .btn-danger {
-  background: linear-gradient(135deg, #ff5b5b, #d62a2a);
-  border: none;
-  color: #fff;
+    background: linear-gradient(135deg, #ff5b5b, #d62a2a);
+    border: none;
+    color: #fff;
 }
 
 [data-theme="dark"] .settings-input {
-  background: #251f1b;
-  border-color: rgba(255, 131, 95, 0.25);
+    background: #251f1b;
+    border-color: rgba(255, 131, 95, 0.25);
 }
 
 [data-theme="dark"] .settings-input:focus {
-  box-shadow: 0 0 0 3px rgba(255, 131, 95, 0.2);
+    box-shadow: 0 0 0 3px rgba(255, 131, 95, 0.2);
 }
 
 @media (max-width: 900px) {
-  .upload-header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
+    .upload-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
 
-  .upload-grid {
-    grid-template-columns: 1fr;
-  }
+    .upload-grid {
+        grid-template-columns: 1fr;
+    }
 }
 
 .mono {
-  font-family: var(--font-mono);
+    font-family: var(--font-mono);
 }
 
 .markdown {
-  line-height: 1.7;
-  color: #3f3a34;
+    line-height: 1.7;
+    color: #3f3a34;
 }
 
 [data-theme="dark"] .markdown {
-  color: rgba(246, 239, 228, 0.9);
+    color: rgba(246, 239, 228, 0.9);
 }
 
 .markdown h1,
 .markdown h2,
 .markdown h3 {
-  font-family: var(--font-display);
-  margin-top: 1.4rem;
+    font-family: var(--font-display);
+    margin-top: 1.4rem;
 }
 
 .markdown a {
-  color: var(--accent-deep);
+    color: var(--accent-deep);
 }
 
 .markdown :not(pre) > code {
-  background: rgba(255, 107, 74, 0.12);
-  padding: 2px 6px;
-  border-radius: 8px;
+    background: rgba(255, 107, 74, 0.12);
+    padding: 2px 6px;
+    border-radius: 8px;
 }
 
 .markdown pre {
-  white-space: pre;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(255, 250, 247, 0.88));
-  border: 1px solid rgba(255, 107, 74, 0.18);
-  border-left: 3px solid var(--accent-deep);
-  border-radius: 12px;
-  padding: 14px 16px;
-  font-family: var(--font-mono);
-  font-size: 0.9rem;
-  line-height: 1.55;
-  tab-size: 2;
-  color: var(--ink);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+    white-space: pre;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    background: linear-gradient(
+        180deg,
+        rgba(255, 255, 255, 0.9),
+        rgba(255, 250, 247, 0.88)
+    );
+    border: 1px solid rgba(255, 107, 74, 0.18);
+    border-left: 3px solid var(--accent-deep);
+    border-radius: 12px;
+    padding: 14px 16px;
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    line-height: 1.55;
+    tab-size: 2;
+    color: var(--ink);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
 
 .markdown pre code {
-  background: transparent;
-  padding: 0;
-  border-radius: 0;
-  white-space: inherit;
-  font-family: inherit;
-  color: inherit;
+    background: transparent;
+    padding: 0;
+    border-radius: 0;
+    white-space: inherit;
+    font-family: inherit;
+    color: inherit;
 }
 
 [data-theme="dark"] .markdown pre {
-  background: linear-gradient(180deg, rgba(26, 20, 18, 0.9), rgba(20, 16, 14, 0.85));
-  border: 1px solid rgba(232, 106, 71, 0.28);
-  border-left-color: rgba(232, 106, 71, 0.8);
-  color: #f5e9e3;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    background: linear-gradient(
+        180deg,
+        rgba(26, 20, 18, 0.9),
+        rgba(20, 16, 14, 0.85)
+    );
+    border: 1px solid rgba(232, 106, 71, 0.28);
+    border-left-color: rgba(232, 106, 71, 0.8);
+    color: #f5e9e3;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 [data-theme="dark"] .markdown :not(pre) > code {
-  background: rgba(255, 131, 95, 0.2);
-  color: #ffe9de;
+    background: rgba(255, 131, 95, 0.2);
+    color: #ffe9de;
 }
 
 [data-theme="dark"] .markdown pre code {
-  background: transparent;
-  color: inherit;
+    background: transparent;
+    color: inherit;
 }
 
 .fade-up {
-  animation: fadeUp 0.6s ease forwards;
-  opacity: 0;
-  transform: translateY(12px);
+    animation: fadeUp 0.6s ease forwards;
+    opacity: 0;
+    transform: translateY(12px);
 }
 
 .fade-up[data-delay="1"] {
-  animation-delay: 0.1s;
+    animation-delay: 0.1s;
 }
 
 .fade-up[data-delay="2"] {
-  animation-delay: 0.2s;
+    animation-delay: 0.2s;
 }
 
 .fade-up[data-delay="3"] {
-  animation-delay: 0.3s;
+    animation-delay: 0.3s;
 }
 
 @keyframes fadeUp {
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 @keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 @keyframes theme-circle-transition {
-  0% {
-    clip-path: circle(0% at var(--theme-switch-x, 50%) var(--theme-switch-y, 50%));
-  }
-  100% {
-    clip-path: circle(150% at var(--theme-switch-x, 50%) var(--theme-switch-y, 50%));
-  }
+    0% {
+        clip-path: circle(
+            0% at var(--theme-switch-x, 50%) var(--theme-switch-y, 50%)
+        );
+    }
+    100% {
+        clip-path: circle(
+            150% at var(--theme-switch-x, 50%) var(--theme-switch-y, 50%)
+        );
+    }
 }
 
 html.theme-transition {
-  view-transition-name: theme;
+    view-transition-name: theme;
 }
 
 /* biome-ignore lint/correctness/noUnknownTypeSelector: Custom view-transition pseudo-element for theme switch. */
 html.theme-transition::view-transition-old(theme) {
-  mix-blend-mode: normal;
-  animation: none;
-  z-index: 1;
+    mix-blend-mode: normal;
+    animation: none;
+    z-index: 1;
 }
 
 /* biome-ignore lint/correctness/noUnknownTypeSelector: Custom view-transition pseudo-element for theme switch. */
 html.theme-transition::view-transition-new(theme) {
-  mix-blend-mode: normal;
-  z-index: 2;
-  animation: theme-circle-transition 0.45s ease-out forwards;
+    mix-blend-mode: normal;
+    z-index: 2;
+    animation: theme-circle-transition 0.45s ease-out forwards;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  /* biome-ignore lint/correctness/noUnknownTypeSelector: Custom view-transition pseudo-element for theme switch. */
-  html.theme-transition::view-transition-old(theme) {
-    /* biome-ignore lint/complexity/noImportantStyles: reduce-motion override */
-    animation: none !important;
-  }
+    /* biome-ignore lint/correctness/noUnknownTypeSelector: Custom view-transition pseudo-element for theme switch. */
+    html.theme-transition::view-transition-old(theme) {
+        /* biome-ignore lint/complexity/noImportantStyles: reduce-motion override */
+        animation: none !important;
+    }
 
-  /* biome-ignore lint/correctness/noUnknownTypeSelector: Custom view-transition pseudo-element for theme switch. */
-  html.theme-transition::view-transition-new(theme) {
-    /* biome-ignore lint/complexity/noImportantStyles: reduce-motion override */
-    animation: none !important;
-  }
+    /* biome-ignore lint/correctness/noUnknownTypeSelector: Custom view-transition pseudo-element for theme switch. */
+    html.theme-transition::view-transition-new(theme) {
+        /* biome-ignore lint/complexity/noImportantStyles: reduce-motion override */
+        animation: none !important;
+    }
 }
 
 /* Dashboard styles */
 .dashboard-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 24px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 24px;
 }
 
 .dashboard-header h1 {
-  font-size: 1.5rem;
-  font-weight: 600;
-  margin: 0;
+    font-size: 1.5rem;
+    font-weight: 600;
+    margin: 0;
 }
 
 .dashboard-empty {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  padding: 48px 24px;
-  gap: 16px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 48px 24px;
+    gap: 16px;
 }
 
 .dashboard-empty h2 {
-  font-size: 1.25rem;
-  font-weight: 600;
-  margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0;
 }
 
 .dashboard-empty p {
-  color: var(--color-muted);
-  margin: 0;
+    color: var(--color-muted);
+    margin: 0;
 }
 
 .dashboard-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
 }
 
 .dashboard-skill-card {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 16px;
-  padding: 16px 20px;
-  background: var(--card-bg);
-  border: 1px solid var(--card-border);
-  border-radius: 12px;
-  transition: border-color 0.15s ease;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+    padding: 16px 20px;
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 12px;
+    transition: border-color 0.15s ease;
 }
 
 .dashboard-skill-card:hover {
-  border-color: var(--color-accent);
+    border-color: var(--color-accent);
 }
 
 .dashboard-skill-info {
-  flex: 1;
-  min-width: 0;
+    flex: 1;
+    min-width: 0;
 }
 
 .dashboard-skill-name {
-  font-weight: 600;
-  font-size: 1.1rem;
-  color: var(--color-text);
-  text-decoration: none;
+    font-weight: 600;
+    font-size: 1.1rem;
+    color: var(--color-text);
+    text-decoration: none;
 }
 
 .dashboard-skill-name:hover {
-  color: var(--color-accent);
+    color: var(--color-accent);
 }
 
 .dashboard-skill-slug {
-  font-family: var(--font-mono);
-  font-size: 0.85rem;
-  color: var(--color-muted);
-  margin-left: 8px;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    color: var(--color-muted);
+    margin-left: 8px;
 }
 
 .dashboard-skill-description {
-  font-size: 0.9rem;
-  color: var(--color-muted);
-  margin: 8px 0 0;
-  line-height: 1.4;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+    font-size: 0.9rem;
+    color: var(--color-muted);
+    margin: 8px 0 0;
+    line-height: 1.4;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
 }
 
 .dashboard-skill-stats {
-  display: flex;
-  gap: 12px;
-  margin-top: 8px;
-  font-size: 0.8rem;
-  color: var(--color-muted);
+    display: flex;
+    gap: 12px;
+    margin-top: 8px;
+    font-size: 0.8rem;
+    color: var(--color-muted);
 }
 
 .dashboard-skill-actions {
-  display: flex;
-  gap: 8px;
-  flex-shrink: 0;
+    display: flex;
+    gap: 8px;
+    flex-shrink: 0;
 }
 
 .btn-sm {
-  padding: 6px 12px;
-  font-size: 0.85rem;
-  gap: 4px;
+    padding: 6px 12px;
+    font-size: 0.85rem;
+    gap: 4px;
 }
 
 .btn-ghost {
-  background: transparent;
-  border: 1px solid var(--card-border);
-  color: var(--color-text);
+    background: transparent;
+    border: 1px solid var(--card-border);
+    color: var(--color-text);
 }
 
 .btn-ghost:hover {
-  background: var(--card-bg);
-  border-color: var(--color-accent);
+    background: var(--card-bg);
+    border-color: var(--color-accent);
 }
 
 @media (max-width: 640px) {
-  .dashboard-skill-card {
-    flex-direction: column;
-    gap: 12px;
-  }
+    .dashboard-skill-card {
+        flex-direction: column;
+        gap: 12px;
+    }
 
-  .dashboard-skill-actions {
-    width: 100%;
-  }
+    .dashboard-skill-actions {
+        width: 100%;
+    }
 
-  .dashboard-skill-actions .btn {
-    flex: 1;
-    justify-content: center;
-  }
+    .dashboard-skill-actions .btn {
+        flex: 1;
+        justify-content: center;
+    }
 }
 
 .management-list {
-  display: grid;
-  gap: 16px;
-  margin-top: 12px;
+    display: grid;
+    gap: 16px;
+    margin-top: 12px;
 }
 
 .management-item {
-  display: grid;
-  gap: 16px;
-  padding: 16px;
-  border-radius: 16px;
-  border: 1px solid var(--line);
-  background: var(--surface);
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: start;
+    display: grid;
+    gap: 16px;
+    padding: 16px;
+    border-radius: 16px;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
 }
 
 .management-item-main {
-  display: grid;
-  gap: 6px;
-  min-width: 0;
+    display: grid;
+    gap: 6px;
+    min-width: 0;
 }
 
 .management-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  justify-content: flex-end;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    justify-content: flex-end;
 }
 
 .management-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
 }
 
 .management-controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
 }
 
 .management-control {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
 }
 
 .management-control .mono {
-  font-size: 12px;
-  color: var(--ink-soft);
+    font-size: 12px;
+    color: var(--ink-soft);
 }
 
 .management-control input {
-  min-width: 180px;
+    min-width: 180px;
 }
 
 .management-search input {
-  min-width: 240px;
+    min-width: 240px;
 }
 
 .management-count {
-  font-size: 0.85rem;
-  color: var(--ink-soft);
+    font-size: 0.85rem;
+    color: var(--ink-soft);
 }
 
 .management-sublist {
-  display: grid;
-  gap: 8px;
-  margin-top: 10px;
-  padding-left: 12px;
-  border-left: 1px solid var(--line);
+    display: grid;
+    gap: 8px;
+    margin-top: 10px;
+    padding-left: 12px;
+    border-left: 1px solid var(--line);
 }
 
 .management-subitem {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  align-items: center;
-  justify-content: space-between;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    align-items: center;
+    justify-content: space-between;
 }
 
 .management-report-item {
-  display: grid;
-  gap: 4px;
-  font-size: 0.95rem;
-  color: var(--ink);
+    display: grid;
+    gap: 4px;
+    font-size: 0.95rem;
+    color: var(--ink);
 }
 
 .management-report-meta {
-  font-size: 0.8rem;
-  color: var(--ink-soft);
+    font-size: 0.8rem;
+    color: var(--ink-soft);
 }
 
 @media (max-width: 900px) {
-  .management-item {
-    grid-template-columns: 1fr;
-  }
+    .management-item {
+        grid-template-columns: 1fr;
+    }
 
-  .management-actions {
-    justify-content: flex-start;
-  }
+    .management-actions {
+        justify-content: flex-start;
+    }
 
-  .management-subitem {
-    justify-content: flex-start;
-  }
+    .management-subitem {
+        justify-content: flex-start;
+    }
 }
 
 /* Security Scan Results */
 .scan-results-panel {
-  margin-top: 16px;
-  padding: 12px;
-  border-radius: 12px;
-  border: 1px solid var(--line);
-  background: rgba(0, 0, 0, 0.02);
-  width: fit-content;
+    margin-top: 16px;
+    padding: 12px;
+    border-radius: 12px;
+    border: 1px solid var(--line);
+    background: rgba(0, 0, 0, 0.02);
+    width: fit-content;
 }
 
 .scan-results-title {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--ink-soft);
-  margin-bottom: 8px;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--ink-soft);
+    margin-bottom: 8px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
 }
 
 .scan-result-row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
 }
 
 .scan-result-scanner {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 500;
 }
 
 .scan-result-icon {
-  font-size: 1.1rem;
+    font-size: 1.1rem;
 }
 
 .scan-result-icon-vt {
-  color: #0030ff;
+    color: #0030ff;
 }
 
 .scan-result-status {
-  padding: 2px 8px;
-  border-radius: 999px;
-  font-size: 0.85rem;
-  font-weight: 600;
-  text-transform: capitalize;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-transform: capitalize;
 }
 
 .scan-status-clean {
-  background: rgba(34, 197, 94, 0.1);
-  color: #16a34a;
+    background: rgba(34, 197, 94, 0.1);
+    color: #16a34a;
 }
 
 .scan-status-malicious {
-  background: rgba(239, 68, 68, 0.1);
-  color: #dc2626;
+    background: rgba(239, 68, 68, 0.1);
+    color: #dc2626;
 }
 
 .scan-status-suspicious {
-  background: rgba(245, 158, 11, 0.1);
-  color: #f59e0b;
+    background: rgba(245, 158, 11, 0.1);
+    color: #f59e0b;
 }
 
 .scan-status-pending {
-  background: rgba(107, 114, 128, 0.1);
-  color: #4b5563;
+    background: rgba(107, 114, 128, 0.1);
+    color: #4b5563;
 }
 
 .scan-status-error {
-  background: rgba(239, 68, 68, 0.1);
-  color: #dc2626;
+    background: rgba(239, 68, 68, 0.1);
+    color: #dc2626;
 }
 
 .scan-result-link {
-  font-size: 0.85rem;
-  color: var(--accent);
-  text-decoration: none;
+    font-size: 0.85rem;
+    color: var(--accent);
+    text-decoration: none;
 }
 
 .scan-result-link:hover {
-  text-decoration: underline;
+    text-decoration: underline;
 }
 
 /* Code Insight Analysis */
 .code-insight-analysis {
-  margin-top: 12px;
-  padding: 10px 12px;
-  border-radius: 8px;
-  background: rgba(239, 68, 68, 0.06);
-  border-left: 3px solid #dc2626;
+    margin-top: 12px;
+    padding: 10px 12px;
+    border-radius: 8px;
+    background: rgba(239, 68, 68, 0.06);
+    border-left: 3px solid #dc2626;
 }
 
 .code-insight-label {
-  font-size: 0.7rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #dc2626;
-  margin-bottom: 6px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #dc2626;
+    margin-bottom: 6px;
 }
 
 .code-insight-text {
-  font-size: 0.82rem;
-  line-height: 1.5;
-  color: var(--ink);
-  margin: 0;
+    font-size: 0.82rem;
+    line-height: 1.5;
+    color: var(--ink);
+    margin: 0;
 }
 
 .code-insight-text code {
-  font-family: var(--font-mono);
-  font-size: 0.78rem;
-  background: rgba(0, 0, 0, 0.06);
-  padding: 2px 5px;
-  border-radius: 4px;
-  word-break: break-all;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    background: rgba(0, 0, 0, 0.06);
+    padding: 2px 5px;
+    border-radius: 4px;
+    word-break: break-all;
 }
 
 [data-theme="dark"] .code-insight-analysis {
-  background: rgba(239, 68, 68, 0.12);
+    background: rgba(239, 68, 68, 0.12);
 }
 
 [data-theme="dark"] .code-insight-text code {
-  background: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.1);
 }
 
 .version-scan-results {
-  display: flex;
-  gap: 8px;
-  margin-top: 4px;
+    display: flex;
+    gap: 8px;
+    margin-top: 4px;
 }
 
 .version-scan-toggle {
-  border: 1px solid var(--line);
-  background: transparent;
-  color: var(--ink-soft);
-  border-radius: 999px;
-  padding: 2px 8px;
-  font-size: 0.75rem;
-  cursor: pointer;
+    border: 1px solid var(--line);
+    background: transparent;
+    color: var(--ink-soft);
+    border-radius: 999px;
+    padding: 2px 8px;
+    font-size: 0.75rem;
+    cursor: pointer;
 }
 
 .version-scan-toggle:hover {
-  color: var(--accent);
-  border-color: var(--accent);
+    color: var(--accent);
+    border-color: var(--accent);
 }
 
 .version-scan-badge {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 0.75rem;
 }
 
 .version-scan-badge .scan-result-status {
-  padding: 1px 6px;
-  font-size: 0.7rem;
+    padding: 1px 6px;
+    font-size: 0.7rem;
 }
 
 .version-scan-icon {
-  font-size: 0.9rem;
+    font-size: 0.9rem;
 }
 
 .version-scan-icon-vt {
-  color: #0030ff;
+    color: #0030ff;
 }
 
 .version-scan-link {
-  color: var(--ink-soft);
-  text-decoration: none;
+    color: var(--ink-soft);
+    text-decoration: none;
 }
 
 .version-scan-link:hover {
-  color: var(--accent);
+    color: var(--accent);
 }
 
 .scan-disclaimer {
-  font-size: 0.8rem;
-  color: var(--ink-soft);
-  opacity: 0.8;
-  margin: 8px 0 0;
-  font-style: italic;
+    font-size: 0.8rem;
+    color: var(--ink-soft);
+    opacity: 0.8;
+    margin: 8px 0 0;
+    font-style: italic;
 }
 
 /* Pending Review Banner */
 .pending-banner {
-  font-size: 0.9rem;
-  color: var(--ink);
-  padding: 12px 16px;
-  border-radius: 12px;
-  background: rgba(240, 196, 106, 0.15);
-  border: 1px solid rgba(240, 196, 106, 0.4);
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
+    font-size: 0.9rem;
+    color: var(--ink);
+    padding: 12px 16px;
+    border-radius: 12px;
+    background: rgba(240, 196, 106, 0.15);
+    border: 1px solid rgba(240, 196, 106, 0.4);
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
 }
 
 [data-theme="dark"] .pending-banner {
-  background: rgba(243, 201, 122, 0.12);
-  border-color: rgba(243, 201, 122, 0.35);
+    background: rgba(243, 201, 122, 0.12);
+    border-color: rgba(243, 201, 122, 0.35);
 }
 
 .pending-banner-content strong {
-  display: block;
-  font-weight: 650;
-  margin-bottom: 2px;
+    display: block;
+    font-weight: 650;
+    margin-bottom: 2px;
 }
 
 .pending-banner-content p {
-  color: var(--ink-soft);
-  font-size: 0.85rem;
-  line-height: 1.5;
-  margin: 0;
+    color: var(--ink-soft);
+    font-size: 0.85rem;
+    line-height: 1.5;
+    margin: 0;
 }
 
 /* Blocked/removed banner variant */
 .pending-banner-blocked {
-  background: rgba(239, 68, 68, 0.12);
-  border-color: rgba(239, 68, 68, 0.4);
+    background: rgba(239, 68, 68, 0.12);
+    border-color: rgba(239, 68, 68, 0.4);
 }
 
 [data-theme="dark"] .pending-banner-blocked {
-  background: rgba(239, 68, 68, 0.15);
-  border-color: rgba(239, 68, 68, 0.35);
+    background: rgba(239, 68, 68, 0.15);
+    border-color: rgba(239, 68, 68, 0.35);
 }
 
 /* Pending tag for dashboard */
 .tag-pending {
-  background: rgba(240, 196, 106, 0.2);
-  color: #8a6914;
-  gap: 4px;
+    background: rgba(240, 196, 106, 0.2);
+    color: #8a6914;
+    gap: 4px;
 }
 
 [data-theme="dark"] .tag-pending {
-  background: rgba(243, 201, 122, 0.18);
-  color: #f3c97a;
+    background: rgba(243, 201, 122, 0.18);
+    color: #f3c97a;
 }


### PR DESCRIPTION
Removed the 'display: grid' class that was causing layout issues in the tab-body component.

<img width="2491" height="1623" alt="image" src="https://github.com/user-attachments/assets/158d2a39-42e1-403c-9fed-9287dfd20a31" />
<img width="2165" height="1635" alt="image" src="https://github.com/user-attachments/assets/c58a0b1b-2fb6-4cca-90f7-359f2c36a6c6" />

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR aims to fix a tab layout issue by removing a `display: grid` class from the tab body styling.

On the code side, the only changed file is `src/styles.css`, and the actual functional change appears to be the removal of `.tab-body { display: grid; }` (or equivalent), so that the `SkillDetailPage` tabs (`<div className="tab-body">` in `src/components/SkillDetailPage.tsx:824` etc.) no longer force a grid layout.

However, the diff also includes a large repo-wide formatting churn within `src/styles.css` (indentation changes across many unrelated selectors), which makes the PR much noisier than necessary and increases merge/conflict risk. It would be better to keep this PR scoped to the `.tab-body` rule change only.

<h3>Confidence Score: 3/5</h3>

- Moderately safe, but the change set is noisy and obscures the intended fix.
- The intended CSS behavior change looks small, but the PR introduces large, unrelated formatting churn in a shared stylesheet, which increases merge/conflict risk and makes review of the real behavioral change harder.
- src/styles.css

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a1d58d20-b4dd-4cbb-973a-9fd7824e1921))

<!-- /greptile_comment -->