### PR TITLE
fix(cli): secure config file permissions

### DIFF
--- a/packages/clawdhub/src/config.test.ts
+++ b/packages/clawdhub/src/config.test.ts
@@ -1,0 +1,73 @@
+/* @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const chmodMock = vi.fn()
+const mkdirMock = vi.fn()
+const readFileMock = vi.fn()
+const writeFileMock = vi.fn()
+
+vi.mock('node:fs/promises', () => ({
+  chmod: (...args: unknown[]) => chmodMock(...args),
+  mkdir: (...args: unknown[]) => mkdirMock(...args),
+  readFile: (...args: unknown[]) => readFileMock(...args),
+  writeFile: (...args: unknown[]) => writeFileMock(...args),
+}))
+
+const { writeGlobalConfig } = await import('./config')
+
+const originalPlatform = process.platform
+const testConfigPath = '/tmp/clawhub-config-test/config.json'
+
+function makeErr(code: string): NodeJS.ErrnoException {
+  const error = new Error(code) as NodeJS.ErrnoException
+  error.code = code
+  return error
+}
+
+beforeEach(() => {
+  vi.stubEnv('CLAWHUB_CONFIG_PATH', testConfigPath)
+  Object.defineProperty(process, 'platform', { value: 'linux' })
+  chmodMock.mockResolvedValue(undefined)
+  mkdirMock.mockResolvedValue(undefined)
+  readFileMock.mockResolvedValue('')
+  writeFileMock.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', { value: originalPlatform })
+  vi.unstubAllEnvs()
+  vi.clearAllMocks()
+})
+
+describe('writeGlobalConfig', () => {
+  it('writes config with restricted modes', async () => {
+    await writeGlobalConfig({ registry: 'https://example.com', token: 'clh_test' })
+
+    expect(mkdirMock).toHaveBeenCalledWith('/tmp/clawhub-config-test', {
+      recursive: true,
+      mode: 0o700,
+    })
+    expect(writeFileMock).toHaveBeenCalledWith(
+      testConfigPath,
+      expect.stringContaining('"token": "clh_test"'),
+      {
+        encoding: 'utf8',
+        mode: 0o600,
+      },
+    )
+    expect(chmodMock).toHaveBeenCalledWith(testConfigPath, 0o600)
+  })
+
+  it('ignores non-fatal chmod errors', async () => {
+    chmodMock.mockRejectedValueOnce(makeErr('ENOTSUP'))
+
+    await expect(writeGlobalConfig({ registry: 'https://example.com' })).resolves.toBeUndefined()
+  })
+
+  it('rethrows unexpected chmod errors', async () => {
+    chmodMock.mockRejectedValueOnce(new Error('boom'))
+
+    await expect(writeGlobalConfig({ registry: 'https://example.com' })).rejects.toThrow('boom')
+  })
+})


### PR DESCRIPTION
## Problem

Config files containing API tokens are created with default permissions (often 0644), making them readable by other users on shared systems.

## Solution

1. **Security:** Set restrictive file permissions
   - Config files: `0600` (owner read/write only)
   - Config directories: `0700` (owner only)
   - Explicit `chmod` call for existing files

2. **Maintainability:** Extract `resolveConfigPath()` helper
   - Reduces duplicate 5-line blocks (4x → 1x)
   - Same legacy fallback logic in one place

## Changes

- `packages/clawdhub/src/config.ts`: Add chmod import, extract helper, secure writeGlobalConfig

## Testing

```bash
clawhub login
ls -la ~/.config/clawhub/
# Should show: -rw------- config.json (0600)
```

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the CLI global config handling in `packages/clawdhub/src/config.ts` by (1) centralizing the legacy `clawdhub`→`clawhub` fallback logic into `resolveConfigPath()`, and (2) attempting to harden config persistence by creating the config directory with `0o700`, writing the config file with `0o600`, and `chmod`-ing the file on non-Windows platforms after write.

Overall, it aligns config path resolution across macOS/XDG/Windows/default locations and improves token file protection, but the directory-permission hardening is not fully enforced for pre-existing directories.

<h3>Confidence Score: 4/5</h3>

- This PR is mostly safe to merge, but directory permission hardening is incomplete for existing config directories.
- The file-permission changes are straightforward and scoped, and path-resolution refactor is equivalent to the prior logic. The main concern is that directory permissions are only set on creation (and can be affected by umask), so the PR’s stated security guarantees aren’t met when the directory already exists with broader permissions.
- packages/clawdhub/src/config.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->