### PR TITLE
fix(web): clarify account deletion is reversible

### DIFF
--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -56,7 +56,10 @@ function Settings() {
   }
 
   async function onDelete() {
-    const ok = window.confirm('Soft delete your account? This cannot be undone.')
+    const ok = window.confirm(
+      'Delete your account? Your published skills will remain public.\n\n' +
+        'You can restore your account by logging in again within 30 days.',
+    )
     if (!ok) return
     await deleteAccount()
   }
@@ -185,7 +188,10 @@ function Settings() {
 
       <div className="card danger-card">
         <h2 className="section-title danger-title">Danger zone</h2>
-        <p className="section-subtitle">Soft delete your account. Skills remain public.</p>
+        <p className="section-subtitle">
+          Delete your account. Published skills remain public. Log in again within 30 days to
+          restore.
+        </p>
         <button className="btn btn-danger" type="button" onClick={() => void onDelete()}>
           Delete account
         </button>


### PR DESCRIPTION
## Problem

The account deletion dialog says 'This cannot be undone' but accounts ARE actually restorable by logging in again. This:
- Is factually incorrect
- Creates unnecessary user anxiety
- Erodes trust when users discover the truth

## Solution

Update messaging to accurately describe what happens:
- Skills remain public
- Account can be restored within 30 days by logging in again

## Changes

- `src/routes/settings.tsx`: Update confirm dialog and subtitle text

## Before/After

**Before:**
> Soft delete your account? This cannot be undone.

**After:**
> Delete your account? Your published skills will remain public.
> You can restore your account by logging in again within 30 days.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Settings “Danger zone” copy and the account-deletion confirm dialog to clarify that deletion is a soft-delete: published skills remain public and the account can be restored by logging in again within 30 days. Changes are confined to the web route `src/routes/settings.tsx`, adjusting user-facing strings only and leaving the underlying `api.users.deleteAccount` mutation behavior unchanged.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The diff only changes user-facing text in a confirm dialog and subtitle; there are no behavioral or API changes, and the updated strings remain syntactically valid TypeScript/JSX.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a1d58d20-b4dd-4cbb-973a-9fd7824e1921))

<!-- /greptile_comment -->