### PR TITLE
feat: add skill ownership transfer

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -28,6 +28,7 @@ import {
   soulsPostRouterV1Http,
   starsDeleteRouterV1Http,
   starsPostRouterV1Http,
+  transfersGetRouterV1Http,
   usersListV1Http,
   usersPostRouterV1Http,
   whoamiV1Http,
@@ -113,6 +114,12 @@ http.route({
   path: ApiRoutes.users,
   method: 'GET',
   handler: usersListV1Http,
+})
+
+http.route({
+  pathPrefix: '/api/v1/transfers/',
+  method: 'GET',
+  handler: transfersGetRouterV1Http,
 })
 
 http.route({

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -454,6 +454,28 @@ const userSkillRootInstalls = defineTable({
   .index('by_user_skill', ['userId', 'skillId'])
   .index('by_skill', ['skillId'])
 
+const skillOwnershipTransfers = defineTable({
+  skillId: v.id('skills'),
+  fromUserId: v.id('users'),
+  toUserId: v.id('users'),
+  status: v.union(
+    v.literal('pending'),
+    v.literal('accepted'),
+    v.literal('rejected'),
+    v.literal('cancelled'),
+    v.literal('expired'),
+  ),
+  message: v.optional(v.string()),
+  requestedAt: v.number(),
+  respondedAt: v.optional(v.number()),
+  expiresAt: v.number(),
+})
+  .index('by_skill', ['skillId'])
+  .index('by_from_user', ['fromUserId'])
+  .index('by_to_user', ['toUserId'])
+  .index('by_to_user_status', ['toUserId', 'status'])
+  .index('by_skill_status', ['skillId', 'status'])
+
 export default defineSchema({
   ...authSchema,
   users,
@@ -483,4 +505,5 @@ export default defineSchema({
   userSyncRoots,
   userSkillInstalls,
   userSkillRootInstalls,
+  skillOwnershipTransfers,
 })

--- a/convex/skillTransfers.ts
+++ b/convex/skillTransfers.ts
@@ -1,0 +1,384 @@
+import { v } from 'convex/values'
+import { internal } from './_generated/api'
+import type { Doc, Id } from './_generated/dataModel'
+import { internalMutation, internalQuery, mutation, query } from './_generated/server'
+import { requireUser } from './lib/access'
+
+/** Transfer request expires after 7 days */
+const TRANSFER_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000
+
+/**
+ * Request to transfer a skill to another user.
+ * The recipient must accept the transfer for it to complete.
+ */
+export const requestTransfer = mutation({
+  args: {
+    skillId: v.id('skills'),
+    toUserHandle: v.string(),
+    message: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const { userId, user } = await requireUser(ctx)
+    const now = Date.now()
+
+    // Get the skill
+    const skill = await ctx.db.get(args.skillId)
+    if (!skill) throw new Error('Skill not found')
+    if (skill.softDeletedAt) throw new Error('Cannot transfer deleted skill')
+    if (skill.ownerUserId !== userId) {
+      throw new Error('You can only transfer skills you own')
+    }
+
+    // Find the recipient by handle
+    const toUser = await ctx.db
+      .query('users')
+      .withIndex('handle', (q) => q.eq('handle', args.toUserHandle.toLowerCase()))
+      .first()
+    if (!toUser) throw new Error(`User @${args.toUserHandle} not found`)
+    if (toUser.deletedAt) throw new Error(`User @${args.toUserHandle} has deleted their account`)
+    if (toUser._id === userId) throw new Error('Cannot transfer skill to yourself')
+
+    // Check for existing pending transfer for this skill
+    const existing = await ctx.db
+      .query('skillOwnershipTransfers')
+      .withIndex('by_skill_status', (q) => q.eq('skillId', args.skillId).eq('status', 'pending'))
+      .first()
+    if (existing) {
+      throw new Error('A transfer is already pending for this skill. Cancel it first.')
+    }
+
+    // Create the transfer request
+    const transferId = await ctx.db.insert('skillOwnershipTransfers', {
+      skillId: args.skillId,
+      fromUserId: userId,
+      toUserId: toUser._id,
+      status: 'pending',
+      message: args.message,
+      requestedAt: now,
+      expiresAt: now + TRANSFER_EXPIRY_MS,
+    })
+
+    // Log the action
+    await ctx.db.insert('auditLogs', {
+      actorUserId: userId,
+      action: 'skill.transfer.request',
+      targetType: 'skill',
+      targetId: skill._id,
+      metadata: {
+        transferId,
+        toUserId: toUser._id,
+        toUserHandle: toUser.handle,
+      },
+      createdAt: now,
+    })
+
+    return { transferId, toUserHandle: toUser.handle }
+  },
+})
+
+/**
+ * Accept a pending transfer request.
+ */
+export const acceptTransfer = mutation({
+  args: {
+    transferId: v.id('skillOwnershipTransfers'),
+  },
+  handler: async (ctx, args) => {
+    const { userId } = await requireUser(ctx)
+    const now = Date.now()
+
+    const transfer = await ctx.db.get(args.transferId)
+    if (!transfer) throw new Error('Transfer not found')
+    if (transfer.toUserId !== userId) {
+      throw new Error('This transfer is not addressed to you')
+    }
+    if (transfer.status !== 'pending') {
+      throw new Error(`Transfer is ${transfer.status}, not pending`)
+    }
+    if (transfer.expiresAt < now) {
+      await ctx.db.patch(args.transferId, { status: 'expired', respondedAt: now })
+      throw new Error('Transfer has expired')
+    }
+
+    const skill = await ctx.db.get(transfer.skillId)
+    if (!skill) throw new Error('Skill not found')
+
+    // Transfer ownership
+    await ctx.db.patch(transfer.skillId, {
+      ownerUserId: userId,
+      updatedAt: now,
+    })
+
+    // Mark transfer as accepted
+    await ctx.db.patch(args.transferId, {
+      status: 'accepted',
+      respondedAt: now,
+    })
+
+    // Log the action
+    await ctx.db.insert('auditLogs', {
+      actorUserId: userId,
+      action: 'skill.transfer.accept',
+      targetType: 'skill',
+      targetId: skill._id,
+      metadata: {
+        transferId: args.transferId,
+        fromUserId: transfer.fromUserId,
+      },
+      createdAt: now,
+    })
+
+    return { skillSlug: skill.slug }
+  },
+})
+
+/**
+ * Reject a pending transfer request.
+ */
+export const rejectTransfer = mutation({
+  args: {
+    transferId: v.id('skillOwnershipTransfers'),
+  },
+  handler: async (ctx, args) => {
+    const { userId } = await requireUser(ctx)
+    const now = Date.now()
+
+    const transfer = await ctx.db.get(args.transferId)
+    if (!transfer) throw new Error('Transfer not found')
+    if (transfer.toUserId !== userId) {
+      throw new Error('This transfer is not addressed to you')
+    }
+    if (transfer.status !== 'pending') {
+      throw new Error(`Transfer is ${transfer.status}, not pending`)
+    }
+
+    await ctx.db.patch(args.transferId, {
+      status: 'rejected',
+      respondedAt: now,
+    })
+
+    // Log the action
+    await ctx.db.insert('auditLogs', {
+      actorUserId: userId,
+      action: 'skill.transfer.reject',
+      targetType: 'skill',
+      targetId: transfer.skillId,
+      metadata: { transferId: args.transferId },
+      createdAt: now,
+    })
+
+    return { ok: true }
+  },
+})
+
+/**
+ * Cancel a pending transfer request (by the sender).
+ */
+export const cancelTransfer = mutation({
+  args: {
+    transferId: v.id('skillOwnershipTransfers'),
+  },
+  handler: async (ctx, args) => {
+    const { userId } = await requireUser(ctx)
+    const now = Date.now()
+
+    const transfer = await ctx.db.get(args.transferId)
+    if (!transfer) throw new Error('Transfer not found')
+    if (transfer.fromUserId !== userId) {
+      throw new Error('Only the sender can cancel a transfer')
+    }
+    if (transfer.status !== 'pending') {
+      throw new Error(`Transfer is ${transfer.status}, not pending`)
+    }
+
+    await ctx.db.patch(args.transferId, {
+      status: 'cancelled',
+      respondedAt: now,
+    })
+
+    return { ok: true }
+  },
+})
+
+/**
+ * Get pending incoming transfers for the current user.
+ */
+export const listIncoming = query({
+  args: {},
+  handler: async (ctx) => {
+    const { userId } = await requireUser(ctx)
+    const now = Date.now()
+
+    const transfers = await ctx.db
+      .query('skillOwnershipTransfers')
+      .withIndex('by_to_user_status', (q) => q.eq('toUserId', userId).eq('status', 'pending'))
+      .collect()
+
+    // Filter out expired and enrich with skill/user info
+    const results = []
+    for (const transfer of transfers) {
+      if (transfer.expiresAt < now) continue
+
+      const skill = await ctx.db.get(transfer.skillId)
+      const fromUser = await ctx.db.get(transfer.fromUserId)
+      if (!skill || !fromUser) continue
+
+      results.push({
+        _id: transfer._id,
+        skill: {
+          _id: skill._id,
+          slug: skill.slug,
+          displayName: skill.displayName,
+        },
+        fromUser: {
+          _id: fromUser._id,
+          handle: fromUser.handle,
+          displayName: fromUser.displayName,
+        },
+        message: transfer.message,
+        requestedAt: transfer.requestedAt,
+        expiresAt: transfer.expiresAt,
+      })
+    }
+
+    return results
+  },
+})
+
+/**
+ * Get pending outgoing transfers for the current user.
+ */
+export const listOutgoing = query({
+  args: {},
+  handler: async (ctx) => {
+    const { userId } = await requireUser(ctx)
+    const now = Date.now()
+
+    const transfers = await ctx.db
+      .query('skillOwnershipTransfers')
+      .withIndex('by_from_user', (q) => q.eq('fromUserId', userId))
+      .filter((q) => q.eq(q.field('status'), 'pending'))
+      .collect()
+
+    const results = []
+    for (const transfer of transfers) {
+      if (transfer.expiresAt < now) continue
+
+      const skill = await ctx.db.get(transfer.skillId)
+      const toUser = await ctx.db.get(transfer.toUserId)
+      if (!skill || !toUser) continue
+
+      results.push({
+        _id: transfer._id,
+        skill: {
+          _id: skill._id,
+          slug: skill.slug,
+          displayName: skill.displayName,
+        },
+        toUser: {
+          _id: toUser._id,
+          handle: toUser.handle,
+          displayName: toUser.displayName,
+        },
+        message: transfer.message,
+        requestedAt: transfer.requestedAt,
+        expiresAt: transfer.expiresAt,
+      })
+    }
+
+    return results
+  },
+})
+
+/**
+ * Get transfer history for a skill (for skill detail page).
+ */
+export const getSkillTransferHistory = query({
+  args: { skillId: v.id('skills') },
+  handler: async (ctx, args) => {
+    const transfers = await ctx.db
+      .query('skillOwnershipTransfers')
+      .withIndex('by_skill', (q) => q.eq('skillId', args.skillId))
+      .order('desc')
+      .take(20)
+
+    const results = []
+    for (const transfer of transfers) {
+      const fromUser = await ctx.db.get(transfer.fromUserId)
+      const toUser = await ctx.db.get(transfer.toUserId)
+
+      results.push({
+        _id: transfer._id,
+        status: transfer.status,
+        fromUser: fromUser ? { handle: fromUser.handle } : null,
+        toUser: toUser ? { handle: toUser.handle } : null,
+        requestedAt: transfer.requestedAt,
+        respondedAt: transfer.respondedAt,
+      })
+    }
+
+    return results
+  },
+})
+
+/**
+ * Count pending incoming transfers (for notification badge).
+ */
+export const countIncoming = query({
+  args: {},
+  handler: async (ctx) => {
+    const { userId } = await requireUser(ctx)
+    const now = Date.now()
+
+    const transfers = await ctx.db
+      .query('skillOwnershipTransfers')
+      .withIndex('by_to_user_status', (q) => q.eq('toUserId', userId).eq('status', 'pending'))
+      .collect()
+
+    return transfers.filter((t) => t.expiresAt >= now).length
+  },
+})
+
+/**
+ * Internal: Get pending transfer for a skill to a specific user.
+ * Used by HTTP API handlers.
+ */
+export const getPendingTransferBySkillAndUser = internalQuery({
+  args: {
+    skillId: v.id('skills'),
+    toUserId: v.id('users'),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now()
+    const transfer = await ctx.db
+      .query('skillOwnershipTransfers')
+      .withIndex('by_skill_status', (q) => q.eq('skillId', args.skillId).eq('status', 'pending'))
+      .filter((q) => q.eq(q.field('toUserId'), args.toUserId))
+      .first()
+
+    if (!transfer || transfer.expiresAt < now) return null
+    return transfer
+  },
+})
+
+/**
+ * Internal: Get pending transfer for a skill from a specific user.
+ * Used by HTTP API handlers for cancel.
+ */
+export const getPendingTransferBySkillAndFromUser = internalQuery({
+  args: {
+    skillId: v.id('skills'),
+    fromUserId: v.id('users'),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now()
+    const transfer = await ctx.db
+      .query('skillOwnershipTransfers')
+      .withIndex('by_skill_status', (q) => q.eq('skillId', args.skillId).eq('status', 'pending'))
+      .filter((q) => q.eq(q.field('fromUserId'), args.fromUserId))
+      .first()
+
+    if (!transfer || transfer.expiresAt < now) return null
+    return transfer
+  },
+})

--- a/packages/clawdhub/src/cli.ts
+++ b/packages/clawdhub/src/cli.ts
@@ -17,6 +17,13 @@ import { cmdPublish } from './cli/commands/publish.js'
 import { cmdExplore, cmdInstall, cmdList, cmdSearch, cmdUpdate } from './cli/commands/skills.js'
 import { cmdStarSkill } from './cli/commands/star.js'
 import { cmdSync } from './cli/commands/sync.js'
+import {
+  cmdTransfer,
+  cmdTransferAccept,
+  cmdTransferCancel,
+  cmdTransferList,
+  cmdTransferReject,
+} from './cli/commands/transfer.js'
 import { cmdUnstarSkill } from './cli/commands/unstar.js'
 import { configureCommanderHelp, styleEnvBlock, styleTitle } from './cli/helpStyle.js'
 import { DEFAULT_REGISTRY, DEFAULT_SITE } from './cli/registry.js'
@@ -374,6 +381,62 @@ program
       },
       isInputAllowed(),
     )
+  })
+
+// Transfer commands
+const transferCmd = program
+  .command('transfer')
+  .description('Transfer skill ownership to another user')
+
+transferCmd
+  .command('request')
+  .description('Request to transfer a skill to another user')
+  .argument('<slug>', 'Skill slug')
+  .argument('<handle>', 'Recipient handle (e.g., @username)')
+  .option('--message <text>', 'Optional message to recipient')
+  .option('--yes', 'Skip confirmation')
+  .action(async (slug, handle, options) => {
+    const opts = await resolveGlobalOpts()
+    await cmdTransfer(opts, slug, handle, options, isInputAllowed())
+  })
+
+transferCmd
+  .command('list')
+  .description('List pending transfer requests')
+  .option('--outgoing', 'Show outgoing requests instead of incoming')
+  .action(async (options) => {
+    const opts = await resolveGlobalOpts()
+    await cmdTransferList(opts, options)
+  })
+
+transferCmd
+  .command('accept')
+  .description('Accept an incoming transfer request')
+  .argument('<slug>', 'Skill slug')
+  .option('--yes', 'Skip confirmation')
+  .action(async (slug, options) => {
+    const opts = await resolveGlobalOpts()
+    await cmdTransferAccept(opts, slug, options, isInputAllowed())
+  })
+
+transferCmd
+  .command('reject')
+  .description('Reject an incoming transfer request')
+  .argument('<slug>', 'Skill slug')
+  .option('--yes', 'Skip confirmation')
+  .action(async (slug, options) => {
+    const opts = await resolveGlobalOpts()
+    await cmdTransferReject(opts, slug, options, isInputAllowed())
+  })
+
+transferCmd
+  .command('cancel')
+  .description('Cancel an outgoing transfer request')
+  .argument('<slug>', 'Skill slug')
+  .option('--yes', 'Skip confirmation')
+  .action(async (slug, options) => {
+    const opts = await resolveGlobalOpts()
+    await cmdTransferCancel(opts, slug, options, isInputAllowed())
   })
 
 program.action(async () => {

--- a/packages/clawdhub/src/cli/commands/transfer.ts
+++ b/packages/clawdhub/src/cli/commands/transfer.ts
@@ -1,0 +1,231 @@
+import { readGlobalConfig } from '../../config.js'
+import { apiRequest } from '../../http.js'
+import { ApiRoutes } from '../../schema/index.js'
+import { getRegistry } from '../registry.js'
+import type { GlobalOpts } from '../types.js'
+import { createSpinner, fail, formatError, isInteractive, promptConfirm } from '../ui.js'
+
+async function requireToken() {
+  const cfg = await readGlobalConfig()
+  const token = cfg?.token
+  if (!token) fail('Not logged in. Run: clawhub login')
+  return token
+}
+
+/**
+ * Request to transfer a skill to another user.
+ */
+export async function cmdTransfer(
+  opts: GlobalOpts,
+  slugArg: string,
+  toHandleArg: string,
+  options: { message?: string; yes?: boolean },
+  inputAllowed: boolean,
+) {
+  const slug = slugArg.trim().toLowerCase()
+  const toHandle = toHandleArg.trim().toLowerCase().replace(/^@/, '')
+
+  if (!slug) fail('Skill slug required')
+  if (!toHandle) fail('Recipient handle required (e.g., @username)')
+
+  const allowPrompt = isInteractive() && inputAllowed !== false
+
+  if (!options.yes) {
+    if (!allowPrompt) fail('Pass --yes (no input)')
+    const ok = await promptConfirm(
+      `Transfer ${slug} to @${toHandle}? They will need to accept.`,
+    )
+    if (!ok) return
+  }
+
+  const token = await requireToken()
+  const registry = await getRegistry(opts, { cache: true })
+  const spinner = createSpinner(`Requesting transfer of ${slug} to @${toHandle}`)
+
+  try {
+    const result = await apiRequest(
+      registry,
+      {
+        method: 'POST',
+        path: `${ApiRoutes.skills}/${encodeURIComponent(slug)}/transfer`,
+        token,
+        body: JSON.stringify({
+          toUserHandle: toHandle,
+          message: options.message,
+        }),
+      },
+      undefined, // No schema validation for now
+    )
+    spinner.succeed(`Transfer requested. @${toHandle} must accept at clawhub.io/settings`)
+  } catch (error) {
+    spinner.fail(formatError(error))
+    throw error
+  }
+}
+
+/**
+ * List incoming transfer requests.
+ */
+export async function cmdTransferList(opts: GlobalOpts, options: { outgoing?: boolean }) {
+  const token = await requireToken()
+  const registry = await getRegistry(opts, { cache: true })
+  const spinner = createSpinner('Fetching transfers')
+
+  try {
+    const path = options.outgoing
+      ? '/api/v1/transfers/outgoing'
+      : '/api/v1/transfers/incoming'
+
+    const result = await apiRequest(
+      registry,
+      { method: 'GET', path, token },
+      undefined,
+    ) as { transfers: Array<{
+      skill: { slug: string }
+      fromUser?: { handle: string }
+      toUser?: { handle: string }
+      requestedAt: number
+      expiresAt: number
+    }> }
+
+    spinner.stop()
+
+    if (!result.transfers?.length) {
+      console.log(options.outgoing ? 'No outgoing transfers.' : 'No incoming transfers.')
+      return
+    }
+
+    console.log(options.outgoing ? 'Outgoing transfers:' : 'Incoming transfers:')
+    for (const t of result.transfers) {
+      const other = options.outgoing ? t.toUser?.handle : t.fromUser?.handle
+      const expiresIn = Math.ceil((t.expiresAt - Date.now()) / (24 * 60 * 60 * 1000))
+      console.log(`  ${t.skill.slug} → @${other} (expires in ${expiresIn}d)`)
+    }
+  } catch (error) {
+    spinner.fail(formatError(error))
+    throw error
+  }
+}
+
+/**
+ * Accept an incoming transfer.
+ */
+export async function cmdTransferAccept(
+  opts: GlobalOpts,
+  slugArg: string,
+  options: { yes?: boolean },
+  inputAllowed: boolean,
+) {
+  const slug = slugArg.trim().toLowerCase()
+  if (!slug) fail('Skill slug required')
+
+  const allowPrompt = isInteractive() && inputAllowed !== false
+
+  if (!options.yes) {
+    if (!allowPrompt) fail('Pass --yes (no input)')
+    const ok = await promptConfirm(`Accept transfer of ${slug}? You will become the owner.`)
+    if (!ok) return
+  }
+
+  const token = await requireToken()
+  const registry = await getRegistry(opts, { cache: true })
+  const spinner = createSpinner(`Accepting transfer of ${slug}`)
+
+  try {
+    await apiRequest(
+      registry,
+      {
+        method: 'POST',
+        path: `${ApiRoutes.skills}/${encodeURIComponent(slug)}/transfer/accept`,
+        token,
+      },
+      undefined,
+    )
+    spinner.succeed(`You are now the owner of ${slug}`)
+  } catch (error) {
+    spinner.fail(formatError(error))
+    throw error
+  }
+}
+
+/**
+ * Reject an incoming transfer.
+ */
+export async function cmdTransferReject(
+  opts: GlobalOpts,
+  slugArg: string,
+  options: { yes?: boolean },
+  inputAllowed: boolean,
+) {
+  const slug = slugArg.trim().toLowerCase()
+  if (!slug) fail('Skill slug required')
+
+  const allowPrompt = isInteractive() && inputAllowed !== false
+
+  if (!options.yes) {
+    if (!allowPrompt) fail('Pass --yes (no input)')
+    const ok = await promptConfirm(`Reject transfer of ${slug}?`)
+    if (!ok) return
+  }
+
+  const token = await requireToken()
+  const registry = await getRegistry(opts, { cache: true })
+  const spinner = createSpinner(`Rejecting transfer of ${slug}`)
+
+  try {
+    await apiRequest(
+      registry,
+      {
+        method: 'POST',
+        path: `${ApiRoutes.skills}/${encodeURIComponent(slug)}/transfer/reject`,
+        token,
+      },
+      undefined,
+    )
+    spinner.succeed(`Transfer of ${slug} rejected`)
+  } catch (error) {
+    spinner.fail(formatError(error))
+    throw error
+  }
+}
+
+/**
+ * Cancel an outgoing transfer.
+ */
+export async function cmdTransferCancel(
+  opts: GlobalOpts,
+  slugArg: string,
+  options: { yes?: boolean },
+  inputAllowed: boolean,
+) {
+  const slug = slugArg.trim().toLowerCase()
+  if (!slug) fail('Skill slug required')
+
+  const allowPrompt = isInteractive() && inputAllowed !== false
+
+  if (!options.yes) {
+    if (!allowPrompt) fail('Pass --yes (no input)')
+    const ok = await promptConfirm(`Cancel transfer of ${slug}?`)
+    if (!ok) return
+  }
+
+  const token = await requireToken()
+  const registry = await getRegistry(opts, { cache: true })
+  const spinner = createSpinner(`Cancelling transfer of ${slug}`)
+
+  try {
+    await apiRequest(
+      registry,
+      {
+        method: 'POST',
+        path: `${ApiRoutes.skills}/${encodeURIComponent(slug)}/transfer/cancel`,
+        token,
+      },
+      undefined,
+    )
+    spinner.succeed(`Transfer of ${slug} cancelled`)
+  } catch (error) {
+    spinner.fail(formatError(error))
+    throw error
+  }
+}


### PR DESCRIPTION
## Summary

Implements **Phase 1** of the [ownership architecture improvements](https://github.com/openclaw/clawhub/issues/167): skill ownership transfer.

## What This Adds

### Schema
- New `skillOwnershipTransfers` table tracking transfer requests
- Status: pending → accepted/rejected/cancelled/expired
- 7-day expiry on transfer requests

### Backend (`convex/skillTransfers.ts`)
| Mutation | Description |
|----------|-------------|
| `requestTransfer` | Owner requests transfer to another user |
| `acceptTransfer` | Recipient accepts, becomes new owner |
| `rejectTransfer` | Recipient declines |
| `cancelTransfer` | Owner cancels pending request |

| Query | Description |
|-------|-------------|
| `listIncoming` | Pending transfers to current user |
| `listOutgoing` | Pending transfers from current user |
| `countIncoming` | Count for notification badge |

### API Routes
```
POST /api/v1/skills/{slug}/transfer         - Request transfer
POST /api/v1/skills/{slug}/transfer/accept  - Accept transfer
POST /api/v1/skills/{slug}/transfer/reject  - Reject transfer
POST /api/v1/skills/{slug}/transfer/cancel  - Cancel transfer
GET  /api/v1/transfers/incoming             - List incoming
GET  /api/v1/transfers/outgoing             - List outgoing
```

### CLI
```bash
clawhub transfer request cool-skill @newowner --message "Taking over!"
clawhub transfer list                    # Show incoming requests
clawhub transfer list --outgoing         # Show outgoing requests
clawhub transfer accept cool-skill       # Accept incoming transfer
clawhub transfer reject cool-skill       # Reject incoming transfer
clawhub transfer cancel cool-skill       # Cancel outgoing transfer
```

## Audit Trail

All transfer actions are logged to `auditLogs` table:
- `skill.transfer.request`
- `skill.transfer.accept`
- `skill.transfer.reject`

## What's NOT Included (Future Phases)

- [ ] Web UI for transfers (Phase 1.5)
- [ ] Collaborators/maintainers (Phase 2)
- [ ] Fallback owners / orphan handling (Phase 3)
- [ ] Organizations (Phase 4)

## Testing

```bash
# Request transfer
clawhub transfer request my-skill @friend

# Recipient accepts
clawhub transfer accept my-skill

# Verify new owner
clawhub inspect my-skill
```

Closes #167 (Phase 1)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds Phase 1 of skill ownership transfers.

- **Data model:** introduces a new `skillOwnershipTransfers` table (pending → accepted/rejected/cancelled/expired) with timestamps and expiry.
- **Backend:** adds Convex mutations/queries to request/accept/reject/cancel transfers, plus helper internal queries for the HTTP layer.
- **HTTP API:** extends the v1 skills POST router with `/skills/{slug}/transfer[/accept|reject|cancel]` and adds a new GET router under `/api/v1/transfers/{incoming|outgoing}`.
- **CLI:** adds a `clawhub transfer` command group to request/list/accept/reject/cancel transfers via the new endpoints.


<h3>Confidence Score: 3/5</h3>

- This PR is close to mergeable but has a correctness issue in transfer acceptance that can overwrite ownership in edge cases.
- Core flow is implemented end-to-end (schema, Convex functions, HTTP routes, CLI), but `acceptTransfer` does not revalidate the skill’s current owner or deletion state at acceptance time, which can lead to incorrect ownership changes if the skill changed after the request. Minor CLI output robustness issue also present.
- convex/skillTransfers.ts, packages/clawdhub/src/cli/commands/transfer.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->