### PR TITLE
fix: reduce skill stat processing interval from 15m to 1m

### DIFF
--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -24,9 +24,9 @@ crons.interval(
   { batchSize: 200, maxBatches: 5 },
 )
 
-crons.schedule(
+crons.interval(
   'skill-stat-events',
-  '*/1 * * * *',
+  { minutes: 1 },
   internal.skillStatEvents.processSkillStatEventsAction,
   {},
 )


### PR DESCRIPTION
This improves the responsiveness of download and star metrics on the website, addressing user feedback that these metrics were not updating in a timely manner (Issue #156).

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Convex cron schedule for skill-stat processing to run much more frequently (from 15 minutes to 1 minute) to make download/star metrics update more responsively on the site (Issue #156). The change is localized to the Convex cron configuration (`convex/crons.ts`).

<h3>Confidence Score: 3/5</h3>

- This PR is low-risk if the cron syntax is correct, but as written it likely won’t run at all.
- Only one file changes and the intent is straightforward, but the new schedule string appears to use a non-cron duration format that typical Convex cron scheduling won’t accept, which would prevent the job from registering/executing.
- convex/crons.ts

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a1d58d20-b4dd-4cbb-973a-9fd7824e1921))

<!-- /greptile_comment -->