### PR TITLE
bugfix: #170 Sign-in broken after GitHub username change

### DIFF
--- a/convex/users.ts
+++ b/convex/users.ts
@@ -90,7 +90,8 @@ export const ensure = mutation({
       if (normalizedHandle) updates.displayName = normalizedHandle
     }
     if (!user.role) {
-      updates.role = handle === ADMIN_HANDLE ? 'admin' : DEFAULT_ROLE
+      const roleHandle = normalizedHandle ?? user.handle?.trim()
+      updates.role = roleHandle === ADMIN_HANDLE ? 'admin' : DEFAULT_ROLE
     }
     if (!user.createdAt) updates.createdAt = user._creationTime
     updates.updatedAt = now


### PR DESCRIPTION
fix #170 Sign-in broken after GitHub username change

Updated user bootstrap to sync the app handle/display name with the current GitHub login on each sign-in, so username changes update the stored handle instead of leaving the old one. This keeps profile lookups and GitHub-related flows (like account age checks) aligned after a rename; change lives in convex/users.ts.

convex/users.ts: refreshes handle when user.name changes; updates displayName only when it was still the auto-generated handle.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change updates the `ensure` mutation in `convex/users.ts` to resync a user’s stored `handle` with the current GitHub `user.name` (falling back to email prefix) on each sign-in, and to update `displayName` only when it’s unset or still equal to the auto-generated handle. The intent is to keep profile lookups and GitHub-dependent logic aligned after a GitHub username rename.

Main behavior change is that an existing `user.handle` will now be overwritten when `user.name` differs, instead of only being set once at bootstrap.

<h3>Confidence Score: 4/5</h3>

- This PR is likely safe to merge after fixing a small logic inconsistency in admin role assignment.
- The change is narrowly scoped to user bootstrap logic and appears to address the rename issue, but it introduces an inconsistency where role assignment uses the non-normalized handle while handle/displayName updates use the normalized value, which can cause incorrect role selection in edge cases.
- convex/users.ts

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->