### PR TITLE
feat: add third party service flag for skills

### DIFF
--- a/convex/lib/public.ts
+++ b/convex/lib/public.ts
@@ -13,6 +13,7 @@ export type PublicSkill = Pick<
   | 'displayName'
   | 'summary'
   | 'ownerUserId'
+  | 'thirdPartyServiceOverride'
   | 'canonicalSkillId'
   | 'forkOf'
   | 'latestVersionId'
@@ -62,6 +63,7 @@ export function toPublicSkill(skill: Doc<'skills'> | null | undefined): PublicSk
     displayName: skill.displayName,
     summary: skill.summary,
     ownerUserId: skill.ownerUserId,
+    thirdPartyServiceOverride: skill.thirdPartyServiceOverride,
     canonicalSkillId: skill.canonicalSkillId,
     forkOf: skill.forkOf,
     latestVersionId: skill.latestVersionId,

--- a/convex/lib/skillPublish.ts
+++ b/convex/lib/skillPublish.ts
@@ -35,6 +35,7 @@ export type PublishVersionArgs = {
   changelog: string
   tags?: string[]
   forkOf?: { slug: string; version?: string }
+  thirdPartyService?: boolean
   source?: {
     kind: 'github'
     url: string
@@ -103,6 +104,7 @@ export async function publishVersionForUser(
   const frontmatter = parseFrontmatter(readmeText)
   const clawdis = parseClawdisMetadata(frontmatter)
   const metadata = mergeSourceIntoMetadata(getFrontmatterMetadata(frontmatter), args.source)
+  const thirdPartyService = resolveThirdPartyService(frontmatter, args.thirdPartyService)
 
   const otherFiles = [] as Array<{ path: string; content: string }>
   for (const file of safeFiles) {
@@ -167,6 +169,7 @@ export async function publishVersionForUser(
       metadata,
       clawdis,
     },
+    thirdPartyService,
     embedding,
   })) as PublishResult
 
@@ -203,6 +206,19 @@ export async function publishVersionForUser(
   })
 
   return publishResult
+}
+
+function resolveThirdPartyService(
+  frontmatter: Record<string, unknown>,
+  supplied?: boolean,
+): boolean | undefined {
+  if (typeof supplied === 'boolean') return supplied
+  const raw =
+    frontmatter.thirdPartyService ??
+    frontmatter.thirdpartyservice ??
+    frontmatter['third-party-service'] ??
+    frontmatter['third_party_service']
+  return typeof raw === 'boolean' ? raw : undefined
 }
 
 function mergeSourceIntoMetadata(metadata: unknown, source: PublishVersionArgs['source']) {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -34,6 +34,7 @@ const skills = defineTable({
   summary: v.optional(v.string()),
   resourceId: v.optional(v.string()),
   ownerUserId: v.id('users'),
+  thirdPartyServiceOverride: v.optional(v.boolean()),
   canonicalSkillId: v.optional(v.id('skills')),
   forkOf: v.optional(
     v.object({
@@ -143,6 +144,7 @@ const skillVersions = defineTable({
   fingerprint: v.optional(v.string()),
   changelog: v.string(),
   changelogSource: v.optional(v.union(v.literal('auto'), v.literal('user'))),
+  thirdPartyService: v.optional(v.boolean()),
   files: v.array(
     v.object({
       path: v.string(),

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -528,6 +528,7 @@ export const getBySlug = query({
       displayName: skill.displayName,
       summary: skill.summary,
       ownerUserId: skill.ownerUserId,
+      thirdPartyServiceOverride: skill.thirdPartyServiceOverride,
       canonicalSkillId: skill.canonicalSkillId,
       forkOf: skill.forkOf,
       latestVersionId: skill.latestVersionId,
@@ -2112,6 +2113,7 @@ export const publishVersion: ReturnType<typeof action> = action({
         version: v.optional(v.string()),
       }),
     ),
+    thirdPartyService: v.optional(v.boolean()),
     files: v.array(
       v.object({
         path: v.string(),
@@ -2331,6 +2333,22 @@ export const setRedactionApproved = mutation({
       targetId: skill._id,
       metadata: { badge: 'redactionApproved', approved: args.approved },
       createdAt: now,
+    })
+  },
+})
+
+export const setThirdPartyServiceOverride = mutation({
+  args: { skillId: v.id('skills'), enabled: v.boolean() },
+  handler: async (ctx, args) => {
+    const { user } = await requireUser(ctx)
+    assertModerator(user)
+
+    const skill = await ctx.db.get(args.skillId)
+    if (!skill) throw new Error('Skill not found')
+
+    await ctx.db.patch(skill._id, {
+      thirdPartyServiceOverride: args.enabled,
+      updatedAt: Date.now(),
     })
   },
 })
@@ -2622,6 +2640,7 @@ export const insertVersion = internalMutation({
         version: v.optional(v.string()),
       }),
     ),
+    thirdPartyService: v.optional(v.boolean()),
     files: v.array(
       v.object({
         path: v.string(),
@@ -2754,6 +2773,7 @@ export const insertVersion = internalMutation({
       fingerprint: args.fingerprint,
       changelog: args.changelog,
       changelogSource: args.changelogSource,
+      thirdPartyService: args.thirdPartyService,
       files: args.files,
       parsed: args.parsed,
       createdBy: userId,

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -382,6 +382,7 @@ export function SkillDetailPage({
   const addComment = useMutation(api.comments.add)
   const removeComment = useMutation(api.comments.remove)
   const updateTags = useMutation(api.skills.updateTags)
+  const setThirdPartyServiceOverride = useMutation(api.skills.setThirdPartyServiceOverride)
   const getReadme = useAction(api.skills.getReadme)
   const [readme, setReadme] = useState<string | null>(null)
   const [readmeError, setReadmeError] = useState<string | null>(null)
@@ -544,6 +545,9 @@ export function SkillDetailPage({
   }
 
   const tagEntries = Object.entries(skill.tags ?? {}) as Array<[string, Id<'skillVersions'>]>
+  const isThirdPartyService = Boolean(latestVersion?.thirdPartyService)
+  const isThirdPartyOverride = Boolean(skill.thirdPartyServiceOverride)
+  const showThirdPartyWarning = isThirdPartyService || isThirdPartyOverride
 
   return (
     <main className="section">
@@ -600,6 +604,17 @@ export function SkillDetailPage({
             <div className="pending-banner-content">
               <strong>Skill hidden</strong>
               <p>This skill is currently hidden and not visible to others.</p>
+            </div>
+          </div>
+        ) : null}
+        {showThirdPartyWarning ? (
+          <div className="pending-banner pending-banner-warning">
+            <div className="pending-banner-content">
+              <strong>Warning — This skill uses a third-party service</strong>
+              <p>
+                By using this skill, you are interacting with a third-party service to facilitate its functionality. Consider
+                what data and permissions you are granting to that third-party.
+              </p>
             </div>
           </div>
         ) : null}
@@ -661,6 +676,25 @@ export function SkillDetailPage({
                   <div className={`tag${isAutoHidden || isRemoved ? ' tag-accent' : ''}`}>
                     {staffVisibilityTag}
                   </div>
+                ) : null}
+                {isStaff ? (
+                  <label
+                    className="form-checkbox warning-override-toggle"
+                    htmlFor="third-party-override"
+                  >
+                    <input
+                      id="third-party-override"
+                      type="checkbox"
+                      checked={isThirdPartyOverride}
+                      onChange={(event) => {
+                        void setThirdPartyServiceOverride({
+                          skillId: skill._id,
+                          enabled: event.target.checked,
+                        })
+                      }}
+                    />
+                    <span>Force third-party service warning</span>
+                  </label>
                 ) : null}
                 <div className="skill-actions">
                   {isAuthenticated ? (

--- a/src/lib/publicUser.ts
+++ b/src/lib/publicUser.ts
@@ -13,6 +13,7 @@ export type PublicSkill = Pick<
   | 'displayName'
   | 'summary'
   | 'ownerUserId'
+  | 'thirdPartyServiceOverride'
   | 'canonicalSkillId'
   | 'forkOf'
   | 'latestVersionId'

--- a/src/routes/upload.tsx
+++ b/src/routes/upload.tsx
@@ -62,6 +62,7 @@ export function Upload() {
   const [displayName, setDisplayName] = useState('')
   const [version, setVersion] = useState('1.0.0')
   const [tags, setTags] = useState('latest')
+  const [thirdPartyService, setThirdPartyService] = useState(false)
   const [changelog, setChangelog] = useState('')
   const [changelogStatus, setChangelogStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>(
     'idle',
@@ -302,6 +303,7 @@ export function Upload() {
         version,
         changelog: trimmedChangelog,
         tags: parsedTags,
+        ...(isSoulMode ? {} : { thirdPartyService }),
         files: uploaded,
       })
       setStatus(null)
@@ -373,6 +375,24 @@ export function Upload() {
             onChange={(event) => setTags(event.target.value)}
             placeholder="latest, stable"
           />
+          {!isSoulMode ? (
+            <label className="form-checkbox" htmlFor="thirdPartyService">
+              <input
+                id="thirdPartyService"
+                type="checkbox"
+                checked={thirdPartyService}
+                onChange={(event) => setThirdPartyService(event.target.checked)}
+              />
+              <span>
+                This skill uses a third-party service to fetch data for its intended source.
+              </span>
+            </label>
+          ) : null}
+          {!isSoulMode ? (
+            <div className="form-helper">
+              A warning banner will be displayed so users understand how their data is transmitted.
+            </div>
+          ) : null}
         </div>
 
         <div className="card">

--- a/src/styles.css
+++ b/src/styles.css
@@ -458,6 +458,76 @@ code {
   gap: 28px;
 }
 
+.form-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+  color: var(--ink-soft);
+}
+
+.form-input {
+  border-radius: 14px;
+  border: 1px solid rgba(255, 107, 74, 0.2);
+  background: var(--surface-muted);
+  padding: 12px 14px;
+  font-size: 1rem;
+  color: var(--ink);
+  outline: none;
+  transition:
+    border 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.form-input:focus {
+  border-color: rgba(255, 107, 74, 0.5);
+  box-shadow: 0 0 0 3px rgba(255, 107, 74, 0.15);
+}
+
+[data-theme="dark"] .form-input {
+  background: #251f1b;
+  border-color: rgba(255, 131, 95, 0.25);
+  color: var(--ink);
+}
+
+[data-theme="dark"] .form-input:focus {
+  border-color: rgba(255, 131, 95, 0.5);
+  box-shadow: 0 0 0 3px rgba(255, 131, 95, 0.2);
+}
+
+.form-checkbox {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  font-size: 0.92rem;
+  color: var(--ink);
+}
+
+.form-checkbox input {
+  margin-top: 2px;
+  width: 16px;
+  height: 16px;
+}
+
+.form-helper {
+  font-size: 0.82rem;
+  color: var(--ink-soft);
+  margin-left: 26px;
+}
+
+.warning-override-toggle {
+  margin-top: 8px;
+  background: rgba(255, 107, 74, 0.08);
+  border: 1px solid rgba(255, 107, 74, 0.25);
+  border-radius: 12px;
+  padding: 8px 12px;
+}
+
+[data-theme="dark"] .warning-override-toggle {
+  background: rgba(255, 131, 95, 0.12);
+  border-color: rgba(255, 131, 95, 0.35);
+}
+
 .upload-fields {
   display: grid;
   gap: 14px;


### PR DESCRIPTION
This feature adds the ability for publishers to declare they use a third party service to enable the skills, this is used to inform the users of the skills of the implications of using third parties.
If skill publishers do not self nominate there is an ability for moderators to enable the warning banner

The reason this is required is because of skills like https://clawhub.ai/byungkyu/github-api which appear easy to use but have big security implications in giving third parties like maton.ai full access to your account

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds a third-party service warning system to help users understand when skills interact with external services. Publishers can self-declare by checking a box on the upload form or adding `thirdPartyService: true` in their SKILL.md frontmatter (supports multiple naming conventions: `thirdPartyService`, `thirdpartyservice`, `third-party-service`, `third_party_service`). When enabled, a warning banner appears on the skill detail page informing users about data sharing implications. Moderators can force-enable the warning via `thirdPartyServiceOverride` on any skill using a checkbox toggle visible only to staff, allowing them to flag skills that don't self-nominate but should display the warning.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns in the codebase (similar to badge management), includes proper moderator permission checks via `assertModerator`, handles multiple frontmatter naming conventions for flexibility, and adds both user self-nomination and moderator override capabilities. The schema changes are optional fields, ensuring backward compatibility. The UI changes are isolated and straightforward.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a1d58d20-b4dd-4cbb-973a-9fd7824e1921))

<!-- /greptile_comment -->