### PR TITLE
perf: lazy-load diff viewer (Monaco)

### DIFF
--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -1,7 +1,7 @@
 import { Link, useNavigate } from '@tanstack/react-router'
 import type { ClawdisSkillMetadata, SkillInstallSpec } from 'clawhub-schema'
 import { useAction, useMutation, useQuery } from 'convex/react'
-import { useEffect, useMemo, useState } from 'react'
+import { Suspense, lazy, useEffect, useMemo, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { api } from '../../convex/_generated/api'
@@ -10,7 +10,7 @@ import { getSkillBadges } from '../lib/badges'
 import type { PublicSkill, PublicUser } from '../lib/publicUser'
 import { canManageSkill, isModerator } from '../lib/roles'
 import { useAuthStatus } from '../lib/useAuthStatus'
-import { SkillDiffCard } from './SkillDiffCard'
+const SkillDiffCard = lazy(() => import('./SkillDiffCard').then((m) => ({ default: m.SkillDiffCard })))
 
 type VtAnalysis = {
   status: string
@@ -1002,7 +1002,9 @@ export function SkillDetailPage({
           ) : null}
           {activeTab === 'compare' && skill ? (
             <div className="tab-body">
-              <SkillDiffCard skill={skill} versions={diffVersions ?? []} variant="embedded" />
+              <Suspense fallback={<div className="stat">Loading diff viewer…</div>}>
+                <SkillDiffCard skill={skill} versions={diffVersions ?? []} variant="embedded" />
+              </Suspense>
             </div>
           ) : null}
           {activeTab === 'versions' ? (

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -1,7 +1,7 @@
 import { Link, useNavigate } from '@tanstack/react-router'
 import type { ClawdisSkillMetadata, SkillInstallSpec } from 'clawhub-schema'
 import { useAction, useMutation, useQuery } from 'convex/react'
-import { Suspense, lazy, useEffect, useMemo, useState } from 'react'
+import { lazy, Suspense, useEffect, useMemo, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { api } from '../../convex/_generated/api'
@@ -10,7 +10,10 @@ import { getSkillBadges } from '../lib/badges'
 import type { PublicSkill, PublicUser } from '../lib/publicUser'
 import { canManageSkill, isModerator } from '../lib/roles'
 import { useAuthStatus } from '../lib/useAuthStatus'
-const SkillDiffCard = lazy(() => import('./SkillDiffCard').then((m) => ({ default: m.SkillDiffCard })))
+
+const SkillDiffCard = lazy(() =>
+  import('./SkillDiffCard').then((m) => ({ default: m.SkillDiffCard })),
+)
 
 type VtAnalysis = {
   status: string
@@ -580,7 +583,11 @@ export function SkillDetailPage({
               {canManage ? (
                 <p className="pending-banner-appeal">
                   If you believe this skill has been incorrectly flagged, please{' '}
-                  <a href="https://github.com/openclaw/clawhub/issues" target="_blank" rel="noopener noreferrer">
+                  <a
+                    href="https://github.com/openclaw/clawhub/issues"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     submit an issue on GitHub
                   </a>{' '}
                   and we'll break down why it was flagged and what you can do.


### PR DESCRIPTION
Lazy-load the SkillDiffCard chunk so Monaco is only downloaded when the user opens the Compare tab.

- Uses React.lazy + Suspense around SkillDiffCard
- No behavior changes outside Compare tab
- Verified: bun run build

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Implemented lazy-loading for the `SkillDiffCard` component using `React.lazy` and `Suspense` to defer Monaco editor bundle download until the Compare tab is opened. The implementation correctly transforms the named export to a default export for lazy loading, adds appropriate loading fallback UI, and maintains existing functionality without behavior changes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows React best practices for code splitting, correctly handles the named-to-default export transformation, includes proper loading states, and is a performance optimization with no logical changes to functionality
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->