### PR TITLE
fix: allow pending-scan skills to appear in search results

### DIFF
--- a/convex/lib/public.ts
+++ b/convex/lib/public.ts
@@ -53,7 +53,8 @@ export function toPublicUser(user: Doc<'users'> | null | undefined): PublicUser 
 
 export function toPublicSkill(skill: Doc<'skills'> | null | undefined): PublicSkill | null {
   if (!skill || skill.softDeletedAt) return null
-  if (skill.moderationStatus && skill.moderationStatus !== 'active') return null
+  const isPendingScan = skill.moderationStatus === 'hidden' && skill.moderationReason === 'pending.scan'
+  if (skill.moderationStatus && skill.moderationStatus !== 'active' && !isPendingScan) return null
   if (skill.moderationFlags?.includes('blocked.malware')) return null
   return {
     _id: skill._id,


### PR DESCRIPTION
## Summary

- Published skills with `moderationStatus: 'hidden'` and `moderationReason: 'pending.scan'` were invisible in search results
- `toPublicSkill()` filtered out all non-active skills, including those being actively scanned
- Now allows pending-scan skills to hydrate in search while still filtering manually hidden/malicious skills

Fixes #139

## Root Cause

When a skill is published, it gets `moderationStatus: 'hidden'` with `moderationReason: 'pending.scan'`. The embedding is created and indexed correctly, but `toPublicSkill()` returns `null` for any skill where `moderationStatus !== 'active'`, making newly published skills invisible until a moderator manually approves them.

On second publish (new version), the old version's embedding is archived (unsearchable) and the new one is still filtered — making the skill completely unfindable.

## Changes

- Modified `toPublicSkill()` in `convex/lib/public.ts` to allow skills with `moderationStatus: 'hidden'` AND `moderationReason: 'pending.scan'` to pass through the visibility filter
- Skills hidden for other reasons (manually moderated, flagged as malicious) remain filtered

## Test plan

- [ ] Publish a new skill → verify it appears in search within seconds
- [ ] Publish a second version → verify skill remains searchable
- [ ] Manually hidden skills should NOT appear in search
- [ ] Skills flagged by VT/LLM scan should NOT appear in search

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes `toPublicSkill()` (`convex/lib/public.ts`) so skills in the temporary moderation state `moderationStatus: 'hidden'` with `moderationReason: 'pending.scan'` are treated as public for hydration/search results.

This integrates cleanly with the existing public-skill filtering pattern: search hydration (`convex/search.ts`) and public listing endpoints (`convex/skills.ts`, `convex/stars.ts`) already centralize visibility decisions via `toPublicSkill()`. The change remains narrow (only the `hidden + pending.scan` case is allowed) and the existing malware block (`moderationFlags` including `blocked.malware`) remains enforced.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, explicit adjustment to the central public-skill filter (`toPublicSkill`) and is consistent with how search/listing code paths already rely on that function. It preserves existing exclusion rules for other non-active moderation states and continues to block malware-flagged skills.
- No files require special attention

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a1d58d20-b4dd-4cbb-973a-9fd7824e1921))

<!-- /greptile_comment -->