### PR TITLE
fix: handle GitHub API rate limits in account age check

### DIFF
--- a/convex/lib/githubAccount.test.ts
+++ b/convex/lib/githubAccount.test.ts
@@ -1,5 +1,5 @@
 /* @vitest-environment node */
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { internal } from '../_generated/api'
 import { requireGitHubAccountAge } from './githubAccount'
@@ -18,6 +18,11 @@ const ONE_DAY_MS = 24 * 60 * 60 * 1000
 describe('requireGitHubAccountAge', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
   })
 
   it('uses cached githubCreatedAt when fresh', async () => {
@@ -86,7 +91,9 @@ describe('requireGitHubAccountAge', () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       'https://api.github.com/users/steipete',
-      expect.objectContaining({ headers: { 'User-Agent': 'clawhub' } }),
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'User-Agent': 'clawhub' }),
+      }),
     )
     expect(runMutation).toHaveBeenCalledWith(internal.users.updateGithubMetaInternal, {
       userId: 'users:1',

--- a/convex/lib/githubAccount.ts
+++ b/convex/lib/githubAccount.ts
@@ -27,7 +27,7 @@ export async function requireGitHubAccountAge(ctx: ActionCtx, userId: Id<'users'
     const headers: Record<string, string> = { 'User-Agent': 'clawhub' }
     const token = process.env.GITHUB_TOKEN
     if (token) {
-      headers['Authorization'] = `Bearer ${token}`
+      headers.Authorization = `Bearer ${token}`
     }
 
     const response = await fetch(`${GITHUB_API}/users/${encodeURIComponent(handle)}`, {
@@ -35,9 +35,7 @@ export async function requireGitHubAccountAge(ctx: ActionCtx, userId: Id<'users'
     })
     if (!response.ok) {
       if (response.status === 403 || response.status === 429) {
-        throw new ConvexError(
-          'GitHub API rate limit exceeded — please try again in a few minutes',
-        )
+        throw new ConvexError('GitHub API rate limit exceeded — please try again in a few minutes')
       }
       throw new ConvexError('GitHub account lookup failed')
     }

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -30,6 +30,7 @@ Ensure Convex env is set (auth + embeddings):
 - `OPENAI_API_KEY`
 - `SITE_URL` (your web app URL)
 - Optional webhook env (see `docs/webhook.md`)
+- Optional: `GITHUB_TOKEN` (recommended; raises GitHub account lookup limit used by publish gate)
 
 ## 2) Deploy web app (Vercel)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -49,3 +49,7 @@ read_when:
   - `githubFetchedAt` (fetch timestamp)
 - Cache TTL: 24 hours.
 - Gate applies to web uploads, CLI publish, and GitHub import.
+- If GitHub responds `403` or `429`, publish fails with:
+  - `GitHub API rate limit exceeded — please try again in a few minutes`
+- To reduce rate-limit failures, set `GITHUB_TOKEN` in Convex env for authenticated
+  GitHub API requests.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -23,6 +23,12 @@ read_when:
 - Set `OPENAI_API_KEY` in the Convex environment (not only locally).
 - Re-run `bunx convex dev` / `bunx convex deploy` after setting env.
 
+## `publish` fails with `GitHub API rate limit exceeded`
+
+- This is the GitHub account-age gate lookup hitting unauthenticated limits.
+- Set `GITHUB_TOKEN` in Convex environment to use authenticated GitHub API limits.
+- Retry publish after a short wait if the limit was already exhausted.
+
 ## `sync` says “No skills found”
 
 - `sync` looks for folders containing `SKILL.md` (or `skill.md`).


### PR DESCRIPTION
## Summary

- `requireGitHubAccountAge` makes unauthenticated GitHub API requests (60 req/hr per IP). Since this runs server-side in Convex, all users share the same server IP and quickly exhaust the rate limit, causing "GitHub account lookup failed" errors during skill publish.
- Detect 403/429 responses and throw a clear "rate limit exceeded" error instead of the generic "GitHub account lookup failed"
- Support an optional `GITHUB_TOKEN` env var for authenticated requests (5,000 req/hr), avoiding the shared rate limit entirely

## Test plan

- [x] All 7 existing + new unit tests pass (`vitest run convex/lib/githubAccount.test.ts`)
- [x] New tests cover: 403 rate limit, 429 rate limit, and `GITHUB_TOKEN` auth header inclusion
- [x] Existing test updated to be explicit about HTTP status code
- [ ] Deploy and verify `GITHUB_TOKEN` env var resolves the rate limit for production traffic

Fixes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates the Convex-side `requireGitHubAccountAge` check to (1) optionally use an authenticated GitHub API request when `GITHUB_TOKEN` is set and (2) surface a clearer error message when GitHub responds with rate-limiting statuses (403/429). Unit tests were updated/added to assert 404 lookup failure behavior, rate-limit handling, and Authorization header inclusion.

These changes live in `convex/lib/githubAccount.ts` and are consumed by publish flows (e.g., `convex/lib/skillPublish.ts` / `convex/lib/soulPublish.ts`) to gate publishing based on GitHub account age.

<h3>Confidence Score: 4/5</h3>

- This PR is close to merge-ready, with one test isolation issue to address.
- Core logic change is small and covered by new unit tests, but the new env-stubbing test can leak `GITHUB_TOKEN` into later tests in the same worker process, making the suite order-dependent.
- convex/lib/githubAccount.test.ts

<sub>Last reviewed commit: 4e644ad</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a1d58d20-b4dd-4cbb-973a-9fd7824e1921))

<!-- /greptile_comment -->