### PR TITLE
fix: Overhaul search relevance — prioritize exact matches, eliminate false positives

### DIFF
--- a/convex/lib/searchText.test.ts
+++ b/convex/lib/searchText.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment node */
 
 import { describe, expect, it } from 'vitest'
-import { __test, matchesExactTokens, tokenize } from './searchText'
+import { __test, matchesExactTokens, scoreTokenMatch, tokenize } from './searchText'
 
 describe('searchText', () => {
   it('tokenize lowercases and splits on punctuation', () => {
@@ -13,15 +13,18 @@ describe('searchText', () => {
     ])
   })
 
-  it('matchesExactTokens requires at least one query token to prefix-match', () => {
+  it('matchesExactTokens requires ALL query tokens to prefix-match', () => {
     const queryTokens = tokenize('Remind Me')
+    // Both "remind" and "me" match
     expect(matchesExactTokens(queryTokens, ['Remind Me', '/remind-me', 'Short summary'])).toBe(true)
-    // "Reminder" starts with "remind", so it matches with prefix matching
+    // "reminder" starts with "remind", but no "me" token
     expect(matchesExactTokens(queryTokens, ['Reminder tool', '/reminder', 'Short summary'])).toBe(
-      true,
+      false,
     )
-    // Matches because "remind" token is present
-    expect(matchesExactTokens(queryTokens, ['Remind tool', '/remind', 'Short summary'])).toBe(true)
+    // "remind" matches but no "me" token either
+    expect(matchesExactTokens(queryTokens, ['Remind tool', '/remind', 'Short summary'])).toBe(false)
+    // "remind" + "me" present in summary
+    expect(matchesExactTokens(queryTokens, ['Remind tool', '/remind', 'Reminds me of things'])).toBe(true)
     // No matching tokens at all
     expect(matchesExactTokens(queryTokens, ['Other tool', '/other', 'Short summary'])).toBe(false)
   })
@@ -35,6 +38,20 @@ describe('searchText', () => {
     expect(matchesExactTokens(['xyz'], ['GoHome', '/gohome', 'Navigate home'])).toBe(false)
     // "notion" should not match "annotations" (substring only)
     expect(matchesExactTokens(['notion'], ['Annotations helper', '/annotations'])).toBe(false)
+  })
+
+  it('scoreTokenMatch returns higher scores for better matches', () => {
+    const queryTokens = tokenize('Remind Me')
+    // Exact match on both tokens
+    expect(scoreTokenMatch(queryTokens, ['Remind Me'])).toBeGreaterThan(0)
+    // Only one token matches — below threshold for 2-token query
+    expect(scoreTokenMatch(queryTokens, ['Other tool with me'])).toBe(0)
+    // Both match (prefix)
+    const bothMatch = scoreTokenMatch(queryTokens, ['Reminder mechanism'])
+    expect(bothMatch).toBeGreaterThan(0)
+    // Exact > prefix
+    const exactBoth = scoreTokenMatch(queryTokens, ['remind me'])
+    expect(exactBoth).toBeGreaterThan(bothMatch)
   })
 
   it('matchesExactTokens ignores empty inputs', () => {

--- a/convex/lib/searchText.ts
+++ b/convex/lib/searchText.ts
@@ -9,6 +9,59 @@ export function tokenize(value: string): string[] {
   return normalize(value).match(WORD_RE) ?? []
 }
 
+/**
+ * Returns a match score (0 = no match, higher = better) based on how well
+ * the query tokens match the candidate text parts.
+ *
+ * Scoring:
+ *  - Each query token that exactly matches a text token: +2
+ *  - Each query token that prefix-matches a text token: +1
+ *  - Bonus if ALL query tokens match: +3
+ *
+ * Returns 0 if fewer than half the query tokens match (for single-token queries, must match).
+ */
+export function scoreTokenMatch(
+  queryTokens: string[],
+  parts: Array<string | null | undefined>,
+): number {
+  if (queryTokens.length === 0) return 0
+  const text = parts.filter((part) => Boolean(part?.trim())).join(' ')
+  if (!text) return 0
+  const textTokens = tokenize(text)
+  if (textTokens.length === 0) return 0
+
+  let score = 0
+  let matched = 0
+
+  for (const queryToken of queryTokens) {
+    const hasExact = textTokens.some((t) => t === queryToken)
+    if (hasExact) {
+      score += 2
+      matched++
+    } else {
+      const hasPrefix = textTokens.some((t) => t.startsWith(queryToken))
+      if (hasPrefix) {
+        score += 1
+        matched++
+      }
+    }
+  }
+
+  // Require majority of query tokens to match (all for 1-2 token queries)
+  const minRequired = queryTokens.length <= 2 ? queryTokens.length : Math.ceil(queryTokens.length * 0.6)
+  if (matched < minRequired) return 0
+
+  // Bonus for all tokens matching
+  if (matched === queryTokens.length) score += 3
+
+  return score
+}
+
+/**
+ * Legacy boolean check — returns true if ALL query tokens prefix-match
+ * at least one text token. This is stricter than the old behavior
+ * (which only required ONE token) to prevent false positives.
+ */
 export function matchesExactTokens(
   queryTokens: string[],
   parts: Array<string | null | undefined>,
@@ -18,10 +71,11 @@ export function matchesExactTokens(
   if (!text) return false
   const textTokens = tokenize(text)
   if (textTokens.length === 0) return false
-  // Require at least one token to prefix-match, allowing vector similarity to determine relevance
-  return queryTokens.some((queryToken) =>
+  // Require ALL query tokens to prefix-match at least one text token.
+  // This prevents "Remind Me" from matching skills that only contain "me".
+  return queryTokens.every((queryToken) =>
     textTokens.some((textToken) => textToken.startsWith(queryToken)),
   )
 }
 
-export const __test = { normalize, tokenize, matchesExactTokens }
+export const __test = { normalize, tokenize, matchesExactTokens, scoreTokenMatch }


### PR DESCRIPTION
## Problem

Searching for a skill by its exact name returns it far down the results list. For example, searching **"Remind Me"** shows the actual "Remind Me" skill at position **#71** — the #1 result doesn't even mention "Remind Me" anywhere in its name or description.

Reported in #15.

### Root Cause

Three compounding issues in the search pipeline:

1. **`matchesExactTokens` only required ONE query token to match** — so `"Remind Me"` matched *any* skill containing the word "me" (or any word starting with "me"). Since "me" is extremely common, nearly every skill passed the "exact match" filter, defeating its purpose entirely.

2. **Lexical boosts were too weak relative to vector similarity scores** — even when a skill's name exactly matched the query, the boost was only +1.1 to +1.4. This was easily overwhelmed by high vector cosine similarity scores from semantically-adjacent but differently-named skills.

3. **Summary/description text wasn't factored into lexical scoring** — only `displayName` and `slug` were checked for lexical boosts, missing cases where the query terms appear prominently in the skill's summary.

---

## Changes

### `convex/lib/searchText.ts` — Core matching logic

#### `matchesExactTokens` — now requires ALL tokens (was: any one)
```diff
- // Require at least one token to prefix-match
- return queryTokens.some((queryToken) =>
+ // Require ALL query tokens to prefix-match at least one text token
+ return queryTokens.every((queryToken) =>
    textTokens.some((textToken) => textToken.startsWith(queryToken)),
  )
```

**Before:** `"Remind Me"` → matches anything with "remind" OR "me"  
**After:** `"Remind Me"` → only matches skills containing BOTH "remind" AND "me"

This single change eliminates the vast majority of false positives.

#### New: `scoreTokenMatch` — granular lexical scoring
A new scoring function that returns a numeric relevance score instead of a boolean:
- **Exact token match:** +2 per token (e.g., query "remind" matches text token "remind")
- **Prefix match:** +1 per token (e.g., query "remind" matches text token "reminder")
- **All-tokens bonus:** +3 when every query token matches
- **Threshold:** For 1-2 token queries, ALL tokens must match. For 3+ tokens, 60% must match.

This enables ranked results within the set of matching skills.

### `convex/search.ts` — Search scoring weights

#### Lexical boost weights increased ~2x
| Boost | Before | After |
|-------|--------|-------|
| Slug exact match | 1.4 | **3.0** |
| Slug prefix match | 0.8 | **1.5** |
| Name exact match | 1.1 | **2.5** |
| Name prefix match | 0.6 | **1.2** |

These higher weights ensure that a skill literally named "Remind Me" will rank above a skill that's merely semantically similar (e.g., a "Notifications" skill with high vector similarity but no lexical match).

#### New: Summary text matching
Added `SUMMARY_MATCH_WEIGHT = 0.3` — the skill's summary is now scored using `scoreTokenMatch` and contributes to the final ranking. This helps surface skills where the query terms appear in the description even if the name/slug don't match exactly.

### `convex/lib/searchText.test.ts` — Updated tests

- Updated `matchesExactTokens` tests to verify ALL-token matching behavior
- Added `scoreTokenMatch` tests verifying exact > prefix scoring and threshold behavior

### `convex/search.test.ts` — All existing tests pass unchanged

The `scoreSkillResult` function's new `summary` parameter is optional, so all 10 existing search tests continue to pass without modification.

---

## Impact

### Before (searching "Remind Me")
1. ❌ Unrelated skill (matched on "me" alone, high vector score)
2. ❌ Another unrelated skill
3. ...
71. ✅ Actual "Remind Me" skill

### After
1. ✅ "Remind Me" skill (exact name match: +2.5 name boost + summary score)
2. Skills with "remind" and "me" in their text
3. Semantically similar skills via vector search

---

## Test Results

```
Test Files  58 passed (58)
     Tests  393 passed (393)
  Duration  7.47s
```

All 393 tests pass, including 16 search-specific tests.

---

Fixes #15

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR tightens lexical matching and rebalances scoring so exact-name queries rank as expected.

- Updates `matchesExactTokens` to require *all* query tokens to prefix-match across a skill’s `displayName`/`slug`/`summary`, reducing false positives for common tokens.
- Introduces `scoreTokenMatch` for graded lexical scoring and uses it in `searchSkills` as an additional (lightweight) summary-based boost.
- Increases slug/name lexical boost weights so literal matches can outrank purely semantic (vector) similarity.
- Updates unit tests in `convex/lib/searchText.test.ts` to reflect the stricter token matching and validate `scoreTokenMatch` behavior.

No functional regressions or runtime errors were found in the changed code paths; existing search tests remain compatible with the optional `summary` parameter in `scoreSkillResult`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized to search tokenization/matching and scoring; updated tests cover the stricter matching behavior, and the search scoring update is additive (optional summary) without breaking existing call sites.
- No files require special attention

<sub>Last reviewed commit: 025f665</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->