### PR TITLE
fix: dedupe download metrics hourly by user-or-ip identity

### DIFF
--- a/convex/downloads.test.ts
+++ b/convex/downloads.test.ts
@@ -1,12 +1,43 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { __test } from './downloads'
 
 describe('downloads helpers', () => {
-  it('calculates day start boundaries', () => {
-    const day = 86_400_000
-    expect(__test.getDayStart(0)).toBe(0)
-    expect(__test.getDayStart(day - 1)).toBe(0)
-    expect(__test.getDayStart(day)).toBe(day)
-    expect(__test.getDayStart(day + 1)).toBe(day)
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('calculates hour start boundaries', () => {
+    const hour = 3_600_000
+    expect(__test.getHourStart(0)).toBe(0)
+    expect(__test.getHourStart(hour - 1)).toBe(0)
+    expect(__test.getHourStart(hour)).toBe(hour)
+    expect(__test.getHourStart(hour + 1)).toBe(hour)
+  })
+
+  it('prefers user identity when token user exists', () => {
+    const request = new Request('https://example.com', {
+      headers: { 'cf-connecting-ip': '1.2.3.4' },
+    })
+    expect(__test.getDownloadIdentityValue(request, 'users_123')).toBe('user:users_123')
+  })
+
+  it('uses cf-connecting-ip for anonymous identity', () => {
+    const request = new Request('https://example.com', {
+      headers: { 'cf-connecting-ip': '1.2.3.4' },
+    })
+    expect(__test.getDownloadIdentityValue(request, null)).toBe('ip:1.2.3.4')
+  })
+
+  it('falls back to forwarded ip when explicitly enabled', () => {
+    vi.stubEnv('TRUST_FORWARDED_IPS', 'true')
+    const request = new Request('https://example.com', {
+      headers: { 'x-forwarded-for': '10.0.0.1, 10.0.0.2' },
+    })
+    expect(__test.getDownloadIdentityValue(request, null)).toBe('ip:10.0.0.1')
+  })
+
+  it('returns null when user and ip are missing', () => {
+    const request = new Request('https://example.com')
+    expect(__test.getDownloadIdentityValue(request, null)).toBeNull()
   })
 })

--- a/convex/lib/apiTokenAuth.test.ts
+++ b/convex/lib/apiTokenAuth.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getOptionalApiTokenUserId } from './apiTokenAuth'
+import { hashToken } from './tokens'
+
+describe('getOptionalApiTokenUserId', () => {
+  it('returns null when auth header is missing', async () => {
+    const ctx = {
+      runQuery: vi.fn(),
+    }
+    const request = new Request('https://example.com')
+
+    const userId = await getOptionalApiTokenUserId(ctx as never, request)
+
+    expect(userId).toBeNull()
+    expect(ctx.runQuery).not.toHaveBeenCalled()
+  })
+
+  it('returns null for unknown token', async () => {
+    const ctx = {
+      runQuery: vi.fn().mockResolvedValue(null),
+    }
+    const request = new Request('https://example.com', {
+      headers: { authorization: 'Bearer token-1' },
+    })
+
+    const userId = await getOptionalApiTokenUserId(ctx as never, request)
+
+    expect(userId).toBeNull()
+    expect(ctx.runQuery).toHaveBeenCalledTimes(1)
+    expect(ctx.runQuery.mock.calls[0]?.[1]).toEqual({
+      tokenHash: await hashToken('token-1'),
+    })
+  })
+
+  it('returns user id when token and user are valid', async () => {
+    const tokenId = 'apiTokens_1'
+    const expectedUserId = 'users_1'
+    const ctx = {
+      runQuery: vi
+        .fn()
+        .mockImplementation(async (_fn, args: { tokenHash?: string; tokenId?: string }) => {
+          if (args.tokenHash) {
+            return { _id: tokenId, revokedAt: undefined }
+          }
+          if (args.tokenId) {
+            return { _id: expectedUserId, deletedAt: undefined }
+          }
+          return null
+        }),
+    }
+    const request = new Request('https://example.com', {
+      headers: { authorization: 'Bearer token-2' },
+    })
+
+    const userId = await getOptionalApiTokenUserId(ctx as never, request)
+
+    expect(userId).toBe(expectedUserId)
+    expect(ctx.runQuery).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns null when user is deleted', async () => {
+    const tokenId = 'apiTokens_2'
+    const ctx = {
+      runQuery: vi
+        .fn()
+        .mockImplementation(async (_fn, args: { tokenHash?: string; tokenId?: string }) => {
+          if (args.tokenHash) {
+            return { _id: tokenId, revokedAt: undefined }
+          }
+          if (args.tokenId) {
+            return { _id: 'users_deleted', deletedAt: Date.now() }
+          }
+          return null
+        }),
+    }
+    const request = new Request('https://example.com', {
+      headers: { authorization: 'Bearer token-3' },
+    })
+
+    const userId = await getOptionalApiTokenUserId(ctx as never, request)
+
+    expect(userId).toBeNull()
+    expect(ctx.runQuery).toHaveBeenCalledTimes(2)
+  })
+})

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -492,12 +492,12 @@ const rateLimits = defineTable({
 
 const downloadDedupes = defineTable({
   skillId: v.id('skills'),
-  ipHash: v.string(),
-  dayStart: v.number(),
+  identityHash: v.string(),
+  hourStart: v.number(),
   createdAt: v.number(),
 })
-  .index('by_skill_ip_day', ['skillId', 'ipHash', 'dayStart'])
-  .index('by_day', ['dayStart'])
+  .index('by_skill_identity_hour', ['skillId', 'identityHash', 'hourStart'])
+  .index('by_hour', ['hourStart'])
 
 const githubBackupSyncState = defineTable({
   key: v.string(),

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -131,6 +131,7 @@ Notes:
 
 - If neither `version` nor `tag` is provided, the latest version is used.
 - Soft-deleted versions return `410`.
+- Download stats are counted as unique identities per hour (`userId` when API token is valid, otherwise IP).
 
 ## Auth endpoints (Bearer token)
 


### PR DESCRIPTION
## Summary
- count download stats as unique identities per hour instead of per day
- prefer API-token user identity for dedupe keys, then fall back to IP when anonymous
- keep metric path best-effort and prune dedupe rows after 7 days
- add regression tests for hourly bucket/identity selection and optional token-user lookup
- document `/api/v1/download` counting semantics

## Verification
- bun run lint
- bun run test
- bun run build

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR changes download metric deduplication from per-day/per-IP to per-hour using an identity key that prefers an authenticated API-token user and falls back to client IP for anonymous callers. It updates the `downloadDedupes` schema and pruning logic (7-day retention), adds unit tests for hour bucketing and identity selection, adds tests for optional API token user lookup, and documents the new `/api/v1/download` counting semantics.

The implementation fits into the existing Convex HTTP download flow by computing an identity (token user id or IP) in `convex/downloads.ts`, hashing it, and using an indexed `downloadDedupes` lookup to enforce uniqueness per hour before emitting a `skillStatEvent`.

<h3>Confidence Score: 4/5</h3>

- This PR is largely safe to merge, but has a behavioral regression in API token usage tracking for download requests.
- Core schema/index updates and dedupe logic look consistent, tests cover the new bucketing/identity behavior, and the metric path remains best-effort. The main issue is that optional token auth used for downloads does not update `lastUsedAt`, which is a real behavioral change compared to other token-authenticated endpoints.
- convex/lib/apiTokenAuth.ts

<sub>Last reviewed commit: df472b3</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a1d58d20-b4dd-4cbb-973a-9fd7824e1921))

<!-- /greptile_comment -->