### PR TITLE
fix: sync handle on user ensure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Users: sync handle on ensure when GitHub login changes (#293) (thanks @christianhpoe).
+
 ## 0.6.1 - 2026-02-13
 
 ### Added

--- a/convex/users.test.ts
+++ b/convex/users.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('./lib/access', () => ({
-  requireUser: vi.fn(),
-}))
+vi.mock('./lib/access', async () => {
+  const actual = await vi.importActual<typeof import('./lib/access')>('./lib/access')
+  return { ...actual, requireUser: vi.fn() }
+})
 
 const { requireUser } = await import('./lib/access')
 const { ensureHandler } = await import('./users')

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -84,7 +84,9 @@ export async function ensureHandler(ctx: MutationCtx) {
   const existingHandle = user.handle?.trim() || undefined
   const nameHandle = user.name?.trim() || undefined
   const emailHandle = user.email?.split('@')[0]?.trim() || undefined
-  const derivedHandle = nameHandle || emailHandle
+  // `user.name` is the GitHub login (see convex/auth.ts profile mapping).
+  // Only fall back to deriving from email if we don't already have a handle.
+  const derivedHandle = nameHandle || (!existingHandle ? emailHandle : undefined)
   const baseHandle = derivedHandle ?? existingHandle
 
   if (derivedHandle && (!existingHandle || existingHandle !== derivedHandle)) {

--- a/packages/clawdhub/src/skills.test.ts
+++ b/packages/clawdhub/src/skills.test.ts
@@ -20,15 +20,18 @@ import {
 
 describe('skills', () => {
   it('extracts zip into directory and skips traversal', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'clawhub-'))
+    const parent = await mkdtemp(join(tmpdir(), 'clawhub-zip-'))
+    const dir = join(parent, 'dir')
+    await mkdir(dir)
+    const evilName = `evil-${parent.split('/').pop() ?? 'file'}.txt`
     const zip = zipSync({
       'SKILL.md': strToU8('hello'),
-      '../evil.txt': strToU8('nope'),
+      [`../${evilName}`]: strToU8('nope'),
     })
     await extractZipToDir(new Uint8Array(zip), dir)
 
     expect((await readFile(join(dir, 'SKILL.md'), 'utf8')).trim()).toBe('hello')
-    await expect(stat(join(dir, '..', 'evil.txt'))).rejects.toBeTruthy()
+    await expect(stat(join(parent, evilName))).rejects.toBeTruthy()
   })
 
   it('writes and reads lockfile', async () => {


### PR DESCRIPTION
## Summary
- sync user handle to latest GitHub login during ensure
- keep auto-derived display names in sync while preserving custom ones
- add regression tests for handle sync behavior

Fixes #187

## Testing
- bun run test -- convex/users.test.ts