### PR TITLE
feat: add mdnew skill

### DIFF
--- a/packages/schema/skills/mdnew/SKILL.md
+++ b/packages/schema/skills/mdnew/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: mdnew
+description: Fetch clean, agent-optimized Markdown from any URL using the markdown.new service. Use when web_fetch or browser fails to provide clean content, or when you need a token-efficient version of a web page for deep analysis.
+---
+
+# mdnew
+
+Fetch clean Markdown from any URL using the `markdown.new` three-tier conversion pipeline (Header Negotiation -> Workers AI -> Browser Rendering).
+
+## Usage
+
+Run the script with a target URL:
+
+```bash
+python3 scripts/mdnew.py <url>
+```
+
+## Why use mdnew?
+
+1. **Token Efficiency**: Reduces content size by up to 80% compared to raw HTML.
+2. **Clean Data**: Strips boilerplate, ads, and nav menus, leaving only core content.
+3. **JS Execution**: Automatically handles JS-heavy pages via Cloudflare Browser Rendering fallback.
+4. **Agent-First**: Includes `x-markdown-tokens` tracking to help manage context windows.

--- a/packages/schema/skills/mdnew/scripts/mdnew.py
+++ b/packages/schema/skills/mdnew/scripts/mdnew.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+import sys
+import urllib.request
+import urllib.parse
+
+def fetch_markdown(url):
+    # Construct the markdown.new URL
+    md_new_url = f"https://markdown.new/{url}"
+    
+    # Request headers to match the tool's optimized behavior
+    headers = {
+        "Accept": "text/markdown, text/html",
+        "User-Agent": "OpenClaw-MDNew-Skill/1.0"
+    }
+    
+    try:
+        req = urllib.request.Request(md_new_url, headers=headers)
+        with urllib.request.urlopen(req, timeout=30) as response:
+            content = response.read().decode('utf-8')
+            # Extract custom headers if needed (e.g., token count)
+            tokens = response.getheader('x-markdown-tokens')
+            return content, tokens
+    except Exception as e:
+        return f"Error: {str(e)}", None
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: mdnew <url>")
+        sys.exit(1)
+    
+    target_url = sys.argv[1]
+    markdown, token_count = fetch_markdown(target_url)
+    
+    if token_count:
+        print(f"--- Estimated Tokens: {token_count} ---")
+    print(markdown)


### PR DESCRIPTION
Add mdnew skill that uses markdown.new for clean markdown fetching from any URL.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a new `mdnew` skill that fetches clean, agent-optimized Markdown from URLs using the markdown.new service. The skill includes a Python script that makes HTTP requests to the markdown.new API and returns formatted content.

Key changes:
- Added `SKILL.md` with frontmatter metadata and documentation explaining the skill's purpose, usage, and benefits (token efficiency, clean data extraction, JS execution support)
- Implemented `mdnew.py` script that constructs API requests to `https://markdown.new/{url}`, handles responses with 30-second timeout, and extracts the `x-markdown-tokens` header for token count estimation
- The script follows standard Python practices with proper error handling and UTF-8 decoding

The implementation is straightforward and follows expected patterns for skill scripts. One minor optimization: the unused `urllib.parse` import can be removed.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-contained, introducing a simple new skill with clear documentation. The Python script uses standard library functions with appropriate error handling and timeout. The only issue found is a minor unused import that doesn't affect functionality. The SKILL.md follows the expected format with proper frontmatter metadata. No security concerns, logical errors, or breaking changes identified.
- No files require special attention

<sub>Last reviewed commit: 9d735bb</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->