### PR TITLE
chore: drop convex-helpers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,6 @@
         "clawhub-schema": "workspace:*",
         "clsx": "^2.1.1",
         "convex": "^1.31.7",
-        "convex-helpers": "^0.1.111",
         "fflate": "^0.8.2",
         "h3": "2.0.1-rc.11",
         "lucide-react": "^0.563.0",
@@ -790,8 +789,6 @@
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "convex": ["convex@1.31.7", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-PtNMe1mAIOvA8Yz100QTOaIdgt2rIuWqencVXrb4McdhxBHZ8IJ1eXTnrgCC9HydyilGT1pOn+KNqT14mqn9fQ=="],
-
-    "convex-helpers": ["convex-helpers@0.1.111", "", { "peerDependencies": { "@standard-schema/spec": "^1.0.0", "convex": "^1.25.4", "hono": "^4.0.5", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "typescript": "^5.5", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["@standard-schema/spec", "hono", "react", "typescript", "zod"], "bin": { "convex-helpers": "bin.cjs" } }, "sha512-0O59Ohi8HVc3+KULxSC6JHsw8cQJyc8gZ7OAfNRVX7T5Wy6LhPx3l8veYN9avKg7UiPlO7m1eBiQMHKclIyXyQ=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "clawhub-schema": "workspace:*",
     "clsx": "^2.1.1",
     "convex": "^1.31.7",
-    "convex-helpers": "^0.1.111",
     "fflate": "^0.8.2",
     "h3": "2.0.1-rc.11",
     "lucide-react": "^0.563.0",


### PR DESCRIPTION
Remove unused convex-helpers dependency (repo uses core Convex hooks/pagination).

Gate: bun run lint && bun run test && bun run build && bun run docs:list

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Removes the unused `convex-helpers` dependency from `package.json` and `bun.lock`. A codebase-wide search confirms zero remaining imports or references to the package — the project relies solely on core Convex hooks and pagination.

- Removed `convex-helpers` (`^0.1.111`) from `dependencies` in `package.json`
- Removed corresponding entry and integrity hash from `bun.lock`
- No code changes required; no remaining usage found anywhere in the codebase

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only removes an unused dependency with no remaining references in the codebase.
- The change is minimal and purely subtractive: a single unused dependency is removed from package.json and bun.lock. A full codebase search confirms zero imports or references to convex-helpers. The PR author confirmed lint, test, build, and docs:list all pass.
- No files require special attention.

<sub>Last reviewed commit: b4525cf</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a1d58d20-b4dd-4cbb-973a-9fd7824e1921))

<!-- /greptile_comment -->