### PR TITLE
docs: changelog credit + v1 delete status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 - Users: sync handle on ensure when GitHub login changes (#293) (thanks @christianhpoe).
 - Upload gate: fetch GitHub account age by immutable account ID (prevents username swaps) (#116) (thanks @mkrokosz).
+- API: return proper status codes for delete/undelete errors (#35) (thanks @sergical).
 - API: for owners, return clearer status/messages for hidden/soft-deleted skills instead of a generic 404.
 - HTTP/CORS: add preflight handler + include CORS headers on API/download errors; CLI: include auth token for owner-visible installs/updates (#146) (thanks @Grenghis-Khan).
 - Skills: keep global sorting across pagination on `/skills` (thanks @CodeBBakGoSu, #98).

--- a/convex/lib/httpRateLimit.ts
+++ b/convex/lib/httpRateLimit.ts
@@ -147,9 +147,10 @@ function shouldTrustForwardedIps() {
   const value = String(process.env.TRUST_FORWARDED_IPS ?? '')
     .trim()
     .toLowerCase()
-  if (!value) return true
+  // Hardening default: CF-only. Forwarded headers are trivial to spoof unless you
+  // control the trusted proxy layer.
+  if (!value) return false
   if (value === '1' || value === 'true' || value === 'yes') return true
-  if (value === '0' || value === 'false' || value === 'no') return false
   return false
 }
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -156,6 +156,14 @@ Publishes a new version.
 
 Soft-delete / restore a skill (moderator/admin only).
 
+Status codes:
+
+- `200`: ok
+- `401`: unauthorized
+- `403`: forbidden
+- `404`: skill/user not found
+- `500`: internal server error
+
 ### `POST /api/v1/users/ban`
 
 Ban a user and hard-delete owned skills (moderator/admin only).

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -27,8 +27,8 @@ Headers:
 
 IP source:
 
-- Uses `cf-connecting-ip` first, then falls back to `x-real-ip`, `x-forwarded-for`, or `fly-client-ip`.
-- Set `TRUST_FORWARDED_IPS=false` to disable forwarded-header fallback.
+- Uses `cf-connecting-ip` (Cloudflare) for client IP by default.
+- Set `TRUST_FORWARDED_IPS=true` to opt in to `x-real-ip`, `x-forwarded-for`, or `fly-client-ip` (non-Cloudflare deployments).
 
 ## Public endpoints (no auth)
 


### PR DESCRIPTION
- Add Unreleased changelog credit for #35 (thanks @sergical)\n- Document v1 skill delete/undelete status codes\n- Include pending main commit: CF-only client IP parsing default\n\nTests: bun run lint; bun run test

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR makes three documentation improvements:
- Adds changelog credit for PR #35 (`@sergical`) which fixed delete/undelete error handling
- Documents the v1 API status codes (200, 401, 403, 404, 500) for skill delete/undelete endpoints
- Updates IP parsing documentation to reflect the security hardening change that defaults to Cloudflare-only client IP detection

The `httpRateLimit.ts` change improves security by defaulting to CF-only IP parsing (requiring explicit opt-in via `TRUST_FORWARDED_IPS=true` for other forwarded headers), preventing IP spoofing attacks. Tests were properly updated to reflect the new behavior with correct environment variable cleanup.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All changes are documentation updates and a security hardening improvement (CF-only IP default). The code change is well-tested with proper environment cleanup in tests. The documented status codes accurately match the `softDeleteErrorToResponse` implementation in `convex/httpApiV1.ts`.
- No files require special attention

<sub>Last reviewed commit: a85faf7</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->