### PR TITLE
refactor: v1 raw file response + embeddings helpers

### DIFF
--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -3,7 +3,6 @@ import type { Doc, Id } from '../_generated/dataModel'
 import type { ActionCtx } from '../_generated/server'
 import { getOptionalApiTokenUserId, requireApiTokenUser } from '../lib/apiTokenAuth'
 import { applyRateLimit, parseBearerToken } from '../lib/httpRateLimit'
-import { corsHeaders, mergeHeaders } from '../lib/httpHeaders'
 import { publishVersionForUser } from '../skills'
 import {
   MAX_RAW_FILE_BYTES,
@@ -12,6 +11,7 @@ import {
   parseMultipartPublish,
   parsePublishBody,
   resolveTagsBatch,
+  safeTextFileResponse,
   softDeleteErrorToResponse,
   text,
   toOptionalNumber,
@@ -406,32 +406,14 @@ export async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request)
     const blob = await ctx.storage.get(file.storageId)
     if (!blob) return text('File missing in storage', 410, rate.headers)
     const textContent = await blob.text()
-
-    const isSvg =
-      file.contentType?.toLowerCase().includes('svg') || file.path.toLowerCase().endsWith('.svg')
-
-    const headers = mergeHeaders(
-      rate.headers,
-      {
-        'Content-Type': file.contentType
-          ? `${file.contentType}; charset=utf-8`
-          : 'text/plain; charset=utf-8',
-        'Cache-Control': 'private, max-age=60',
-        ETag: file.sha256,
-        'X-Content-SHA256': file.sha256,
-        'X-Content-Size': String(file.size),
-        'X-Content-Type-Options': 'nosniff',
-        'X-Frame-Options': 'DENY',
-        // For any text response that a browser might try to render, lock it down.
-        // In particular, this prevents SVG <foreignObject> script execution from
-        // reading localStorage tokens on this origin.
-        'Content-Security-Policy':
-          "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'",
-        ...(isSvg ? { 'Content-Disposition': 'attachment' } : {}),
-      },
-      corsHeaders(),
-    )
-    return new Response(textContent, { status: 200, headers })
+    return safeTextFileResponse({
+      textContent,
+      path: file.path,
+      contentType: file.contentType ?? undefined,
+      sha256: file.sha256,
+      size: file.size,
+      headers: rate.headers,
+    })
   }
 
   return text('Not found', 404, rate.headers)


### PR DESCRIPTION
Small followup refactors.

- httpApiV1: centralize safe raw text-file response headers/CSP in shared helper
- skills: centralize skillEmbeddings visibility loops (soft-delete, ban/unban restore, approvals, latest tag)

Gate:
- bun run lint
- bun run build
- bun run test

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR successfully extracts duplicate code into reusable helpers, improving maintainability without changing functionality.

**HTTP API Changes:**
- Centralized safe text-file response headers and CSP (Content Security Policy) into `safeTextFileResponse()` helper in `convex/httpApiV1/shared.ts:18`
- Applied to both skills and souls file serving endpoints, eliminating ~20 lines of duplicated header logic in each handler

**Skills Embedding Updates:**
- Consolidated 5 separate patterns of updating `skillEmbeddings` visibility into 4 focused helper functions:
  - `listSkillEmbeddingsForSkill()` - query helper
  - `setSkillEmbeddingsSoftDeleted()` - handles soft delete/restore flow
  - `setSkillEmbeddingsLatestVersion()` - updates latest tag visibility
  - `setSkillEmbeddingsApproved()` - updates approval visibility
- Removes ~60 lines of repetitive embedding query/update loops across 6 call sites
- Maintains exact same visibility logic via `embeddingVisibilityFor()` helper

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk - it's a pure refactoring that extracts duplicate code into helpers
- The changes are mechanical refactorings that consolidate duplicate code patterns without modifying logic. All security headers, CSP policies, and embedding visibility rules remain identical. The new helpers make the code more maintainable and reduce the risk of divergence between similar operations.
- No files require special attention

<sub>Last reviewed commit: 14de4cb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->