### PR TITLE
UI: allow copying OpenClaw scan summary text

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -3604,7 +3604,7 @@ html.theme-transition::view-transition-new(theme) {
   gap: 12px;
   padding: 10px 14px;
   cursor: pointer;
-  user-select: none;
+  user-select: text;
   border-radius: 12px;
   transition: background 0.15s ease;
 }
@@ -3625,6 +3625,7 @@ html.theme-transition::view-transition-new(theme) {
   align-items: center;
   gap: 4px;
   white-space: nowrap;
+  user-select: none;
 }
 
 .analysis-detail-toggle .chevron {


### PR DESCRIPTION
The OpenClaw scan summary (the bordered message above the “Details” dropdown) is currently not copyable because `.analysis-detail-header` has `user-select: none`.

This PR makes the summary text selectable/copyable (useful for sharing scan results, reporting issues, and audits) while keeping the “Details” toggle non-selectable.

Change: `src/styles.css`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed `.analysis-detail-header` from `user-select: none` to `user-select: text` to allow copying the OpenClaw scan summary text, while adding `user-select: none` to `.analysis-detail-toggle` to keep the "Details" button non-selectable.

- Enables text selection for the summary message (useful for sharing scan results and reporting issues)
- Prevents accidental selection of the "Details" toggle button
- Clean, targeted fix that maintains the intended UX

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, focused, and correct. The implementation properly addresses the stated goal by making the summary text selectable while keeping the toggle button non-selectable. This is a CSS-only change with no logic modifications.
- No files require special attention

<sub>Last reviewed commit: 9e33607</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->