### PR TITLE
UI: don't toggle Details when selecting scan summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Upload gate: fetch GitHub account age by immutable account ID (prevents username swaps) (#116) (thanks @mkrokosz).
 - API: return proper status codes for delete/undelete errors (#35) (thanks @sergical).
 - API: for owners, return clearer status/messages for hidden/soft-deleted skills instead of a generic 404.
+- Web: allow copying OpenClaw scan summary text (thanks @borisolver, #322).
 - HTTP/CORS: add preflight handler + include CORS headers on API/download errors; CLI: include auth token for owner-visible installs/updates (#146) (thanks @Grenghis-Khan).
 - CLI: clarify `logout` only removes the local token; token remains valid until revoked in the web UI (#166) (thanks @aronchick).
 - Skills: keep global sorting across pagination on `/skills` (thanks @CodeBBakGoSu, #98).

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -139,7 +139,12 @@ function LlmAnalysisDetail({ analysis }: { analysis: LlmAnalysis }) {
       <button
         type="button"
         className="analysis-detail-header"
-        onClick={() => setIsOpen((prev) => !prev)}
+        onClick={() => {
+          // Drag-select to copy summary text should not toggle open/closed.
+          const selection = window.getSelection()
+          if (selection && !selection.isCollapsed) return
+          setIsOpen((prev) => !prev)
+        }}
         aria-expanded={isOpen}
       >
         <span className="analysis-summary-text">{analysis.summary}</span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -3641,6 +3641,8 @@ html.theme-transition::view-transition-new(theme) {
   color: var(--ink);
   line-height: 1.45;
   flex: 1;
+  cursor: text;
+  user-select: text;
 }
 
 .analysis-body {


### PR DESCRIPTION
Follow-up to #322.

- Prevent toggle click when user is selecting text (copy/paste)
- Make summary cursor indicate selectable text
- Add changelog thanks for @borisolver

Local: bun run lint; bun run test

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves UX by preventing the Details section from toggling when users select the security scan summary text. The implementation checks for an active text selection before toggling, and updates CSS to show a text cursor and enable text selection on the summary.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are minimal, well-targeted, and use standard browser APIs correctly. The `window.getSelection()` API is widely supported and the `isCollapsed` check is a standard way to detect active text selection. CSS changes are purely cosmetic and properly scoped.
- No files require special attention

<sub>Last reviewed commit: 786af96</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->