### PR TITLE
fix: prevent loading state flicker on skills page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - CLI: validate skill slugs used for filesystem operations (prevents path traversal) (#241) (thanks @superlowburn).
 - Skills: keep global sorting across pagination on `/skills` (thanks @CodeBBakGoSu, #98).
 - Skills: allow updating skill description/summary from frontmatter on subsequent publishes (#312) (thanks @ianalloway).
+- Skills/Web: prevent filtered pagination dead-ends and loading-state flicker on `/skills`; move highlighted browse filtering into server list query (#339) (thanks @Marvae).
 
 ## 0.6.1 - 2026-02-13
 

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -1563,6 +1563,7 @@ export const listPublicPageV2 = query({
       ),
     ),
     dir: v.optional(v.union(v.literal('asc'), v.literal('desc'))),
+    highlightedOnly: v.optional(v.boolean()),
     nonSuspiciousOnly: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
@@ -1581,9 +1582,14 @@ export const listPublicPageV2 = query({
       .order(dir)
       .paginate(paginationOpts)
 
-    const filteredPage = args.nonSuspiciousOnly
-      ? result.page.filter((skill) => !isSkillSuspicious(skill))
-      : result.page
+    const filteredPage =
+      args.nonSuspiciousOnly || args.highlightedOnly
+        ? result.page.filter((skill) => {
+            if (args.nonSuspiciousOnly && isSkillSuspicious(skill)) return false
+            if (args.highlightedOnly && !isSkillHighlighted(skill)) return false
+            return true
+          })
+        : result.page
 
     // Build the public skill entries (fetch latestVersion + ownerHandle)
     const items = await buildPublicSkillEntries(ctx, filteredPage)

--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -49,7 +49,7 @@ describe('SkillsIndex', () => {
     // usePaginatedQuery should be called with the API endpoint and sort/dir args
     expect(usePaginatedQueryMock).toHaveBeenCalledWith(
       expect.anything(),
-      { sort: 'downloads', dir: 'desc', nonSuspiciousOnly: false },
+      { sort: 'downloads', dir: 'desc', highlightedOnly: false, nonSuspiciousOnly: false },
       { initialNumItems: 25 },
     )
   })
@@ -71,15 +71,14 @@ describe('SkillsIndex', () => {
     expect(screen.queryByText('No skills match that filter.')).toBeNull()
   })
 
-  it('does not show scroll to load more when results are empty', () => {
-    // Even if canLoadMore is true, don't show "Scroll to load more" with no results
+  it('keeps load-more reachable when results are empty but pagination can continue', () => {
     usePaginatedQueryMock.mockReturnValue({
       results: [],
       status: 'CanLoadMore',
       loadMore: vi.fn(),
     })
     render(<SkillsIndex />)
-    expect(screen.queryByText('Scroll to load more')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Load more' })).toBeTruthy()
   })
 
   it('shows loading indicator during pagination instead of hiding load more', () => {
@@ -116,8 +115,8 @@ describe('SkillsIndex', () => {
     // Should show loading message, not "No skills match"
     expect(screen.getByText('Loading skills…')).toBeTruthy()
     expect(screen.queryByText('No skills match that filter.')).toBeNull()
-    // Load more should be hidden when no results
-    expect(screen.queryByText('Loading…')).toBeNull()
+    // Keep the pagination control mounted so loading can continue.
+    expect(screen.getByText('Loading…')).toBeTruthy()
   })
 
   it('shows empty state immediately when search returns no results', async () => {
@@ -261,7 +260,18 @@ describe('SkillsIndex', () => {
 
     expect(usePaginatedQueryMock).toHaveBeenCalledWith(
       expect.anything(),
-      { sort: 'downloads', dir: 'desc', nonSuspiciousOnly: true },
+      { sort: 'downloads', dir: 'desc', highlightedOnly: false, nonSuspiciousOnly: true },
+      { initialNumItems: 25 },
+    )
+  })
+
+  it('passes highlightedOnly to list query when filter is active', () => {
+    searchMock = { highlighted: true }
+    render(<SkillsIndex />)
+
+    expect(usePaginatedQueryMock).toHaveBeenCalledWith(
+      expect.anything(),
+      { sort: 'downloads', dir: 'desc', highlightedOnly: true, nonSuspiciousOnly: false },
       { initialNumItems: 25 },
     )
   })


### PR DESCRIPTION
## Problem

Skills page briefly shows "No skills match that filter" before results load, and "Scroll to load more" flickers when results are empty.


![Screen Recording 2026-02-16 at 9 23 08 AM](https://github.com/user-attachments/assets/a3e10cf1-bd44-4f5e-aad4-fd8158bf36cd)

## Solution

- Only show empty state when `paginationStatus === 'Exhausted'`
- Hide "Scroll to load more" when results array is empty


## Changes

- `src/routes/skills/index.tsx`: +6/-2 (logic fix)
- `src/__tests__/skills-index.test.tsx`: +23 (2 new test cases)

## Testing

All 9 tests pass ✅

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a UI flicker on the skills page where "No skills match that filter" briefly appeared before results loaded, and "Scroll to load more" flickered with empty results. The fix gates the empty-state message on `paginationStatus === 'Exhausted'` and adds a `sorted.length > 0` guard to the load-more element.

- The browse (paginated) path is correctly fixed — the empty state now only shows after pagination is fully exhausted.
- The `sorted.length > 0` guard on the "Scroll to load more" element is a clean, correct fix.
- **Regression in search mode**: When the user searches (`hasQuery` is true), `usePaginatedQuery` is called with `'skip'`, so `paginationStatus` remains `'LoadingFirstPage'` and never reaches `'Exhausted'`. A search returning zero results will now show "Loading skills…" indefinitely instead of the expected "No skills match that filter." The condition should also account for the `hasQuery` case (e.g., `paginationStatus === 'Exhausted' || hasQuery`).
- Two new tests are added and cover the intended fix well, but the default test mock (`status: 'Exhausted'`) doesn't match what Convex returns for a skipped query, which masks the search-mode regression.

<h3>Confidence Score: 2/5 **Already Fixed. Not sure how to re-trigger this**</h3> 

- This PR introduces a regression in search mode where empty search results show an infinite loading state.
- The browse/pagination fix is correct, but the `paginationStatus === 'Exhausted'` check doesn't account for search mode where the paginated query is skipped and the status never reaches 'Exhausted'. This causes a user-visible regression: searching with no results shows "Loading skills…" forever instead of "No skills match that filter."
- `src/routes/skills/index.tsx` — the empty-state condition at line 456 needs to handle the search mode case.

<sub>Last reviewed commit: 5ee6fb9</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a1d58d20-b4dd-4cbb-973a-9fd7824e1921))

<!-- /greptile_comment -->