### PR TITLE
feat: skill capability visibility, UI badges, and detail page refactor

### DIFF
--- a/convex/httpApiV1.ts
+++ b/convex/httpApiV1.ts
@@ -270,6 +270,7 @@ async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request) {
               version: result.latestVersion.version,
               createdAt: result.latestVersion.createdAt,
               changelog: result.latestVersion.changelog,
+              capabilities: (result.latestVersion.parsed as any)?.clawdis?.capabilities ?? [],
             }
           : null,
         owner: result.owner

--- a/convex/lib/securityPrompt.ts
+++ b/convex/lib/securityPrompt.ts
@@ -335,6 +335,16 @@ export function assembleEvalUserMessage(ctx: SkillEvalContext): string {
 - Primary credential: ${primaryEnv}
 - Required config paths: ${config.length ? config.join(', ') : 'none'}`)
 
+  const capabilities = Array.isArray(clawdis.capabilities)
+    ? (clawdis.capabilities as string[])
+    : []
+
+  if (capabilities.length > 0) {
+    sections.push(`### Declared capabilities\n- ${capabilities.join(', ')}`)
+  } else {
+    sections.push(`### Declared capabilities\nNone declared.`)
+  }
+
   // Install specifications
   if (install.length > 0) {
     const specLines = install.map((spec, i) => {

--- a/convex/lib/skillCapabilities.ts
+++ b/convex/lib/skillCapabilities.ts
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------------------
+// Skill capabilities — shared spec between ClawHub and OpenClaw.
+//
+// KEEP IN SYNC with openclaw/src/agents/skills/types.ts SKILL_CAPABILITIES.
+//
+// These values are validated during skill publish (ClawHub) and at load time
+// (OpenClaw runtime). Both sides must accept the same enum values.
+// ---------------------------------------------------------------------------
+
+export const SKILL_CAPABILITIES = [
+  "shell", // exec, process — run shell commands
+  "filesystem", // read, write, edit, apply_patch — file mutations
+  "network", // web_search, web_fetch — outbound HTTP
+  "browser", // browser — browser automation
+  "sessions", // sessions_spawn, sessions_send — cross-session orchestration
+] as const;
+
+export type SkillCapability = (typeof SKILL_CAPABILITIES)[number];
+
+/**
+ * Validate that a list of capability strings are all recognized values.
+ * Returns only the valid entries, dropping unknowns silently.
+ */
+export function validateCapabilities(raw: unknown): SkillCapability[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw.filter(
+    (v): v is SkillCapability =>
+      typeof v === "string" && (SKILL_CAPABILITIES as readonly string[]).includes(v),
+  );
+}
+
+/**
+ * Capabilities that should trigger extra moderation review when declared
+ * by community (unverified) publishers.
+ */
+export const HIGH_RISK_CAPABILITIES: readonly SkillCapability[] = [
+  "shell",
+  "sessions",
+];

--- a/convex/lib/skills.ts
+++ b/convex/lib/skills.ts
@@ -9,6 +9,7 @@ import {
   TEXT_FILE_EXTENSION_SET,
 } from 'clawhub-schema'
 import { parse as parseYaml } from 'yaml'
+import { validateCapabilities } from './skillCapabilities'
 
 export type ParsedSkillFrontmatter = Record<string, unknown>
 export type { ClawdisSkillMetadata, SkillInstallSpec }
@@ -121,6 +122,8 @@ export function parseClawdisMetadata(frontmatter: ParsedSkillFrontmatter) {
     if (nix) metadata.nix = nix
     const config = parseClawdbotConfigSpec(clawdisObj.config)
     if (config) metadata.config = config
+    const capabilities = validateCapabilities(clawdisObj.capabilities)
+    if (capabilities.length > 0) metadata.capabilities = capabilities
 
     return parseArk(ClawdisSkillMetadataSchema, metadata, 'Clawdis metadata')
   } catch {

--- a/docs/skill-format.md
+++ b/docs/skill-format.md
@@ -65,8 +65,13 @@ metadata:
       bins:
         - curl
     primaryEnv: TODOIST_API_KEY
+    capabilities:
+      - shell
+      - network
 ---
 ```
+
+`capabilities` declares what system access your skill needs. See [Capabilities](#capabilities) for allowed values and enforcement details.
 
 ### Full field reference
 
@@ -81,6 +86,7 @@ metadata:
 | `skillKey` | `string` | Override the skill's invocation key. |
 | `emoji` | `string` | Display emoji for the skill. |
 | `homepage` | `string` | URL to the skill's homepage or docs. |
+| `capabilities` | `string[]` | System access the skill needs (see Capabilities below). |
 | `os` | `string[]` | OS restrictions (e.g. `["macos"]`, `["linux"]`). |
 | `install` | `array` | Install specs for dependencies (see below). |
 | `nix` | `object` | Nix plugin spec (see README). |
@@ -104,9 +110,77 @@ metadata:
 
 Supported install kinds: `brew`, `node`, `go`, `uv`.
 
+### Capabilities
+
+Declare what system access your skill needs. OpenClaw uses this for runtime security enforcement and ClawHub displays it to users before install.
+
+```yaml
+metadata:
+  openclaw:
+    capabilities:
+      - shell
+      - filesystem
+```
+
+| Capability | What it means | Tools granted |
+|-----------|--------------|---------------|
+| `shell` | Run shell commands | `exec`, `process` |
+| `filesystem` | Read, write, and edit files | `read`, `write`, `edit`, `apply_patch` |
+| `network` | Make outbound HTTP requests | `web_search`, `web_fetch` |
+| `browser` | Browser automation | `browser`, `canvas` |
+| `sessions` | Cross-session orchestration | `sessions_spawn`, `sessions_send`, `subagents` |
+
+**No capabilities declared = read-only skill.** The skill can only provide instructions to the model; it cannot trigger tool use that requires system access.
+
+**Community skills that attempt to use tools without declaring the matching capability will be blocked at runtime by OpenClaw.** For example, a skill that runs shell commands must declare `shell`. If it doesn't, OpenClaw will deny `exec` calls when that skill is loaded.
+
+Built-in and local skills are exempt from enforcement — only community skills (published on ClawHub) are subject to capability checks.
+
 ### Why this matters
 
-ClawHub's security analysis checks that what your skill declares matches what it actually does. If your code references `TODOIST_API_KEY` but your frontmatter doesn't declare it under `requires.env`, the analysis will flag a metadata mismatch. Keeping declarations accurate helps your skill pass review and helps users understand what they're installing.
+Published skills go through two layers of security checks. Keeping your declarations accurate helps your skill pass both.
+
+**Layer 1: ClawHub publish-time evaluation.** Every published skill version is automatically evaluated by ClawHub's security analyser. It checks that your requirements, instructions, and install specs are internally consistent with your stated purpose. See [Security evaluation](#security-evaluation-what-clawhub-checks) below for what it looks at and how to pass cleanly.
+
+**Layer 2: OpenClaw runtime enforcement.** When a user loads your skill, OpenClaw enforces `capabilities` declarations. Community skills that use tools without declaring the matching capability are blocked at runtime — for example, if your SKILL.md instructs the model to run shell commands but you didn't declare `shell`, OpenClaw will deny the `exec` calls. This enforcement is separate from ClawHub's evaluation.
+
+Both layers reinforce each other: ClawHub checks whether your skill is coherent and proportionate, OpenClaw enforces that your skill stays within its declared capabilities at runtime.
+
+### Security evaluation (what ClawHub checks)
+
+Every published skill version is automatically evaluated across five dimensions. Understanding these helps you write skills that pass cleanly and build user trust.
+
+**1. Purpose-requirement alignment** — Do your `requires.env`, `requires.bins`, and install specs match your stated purpose? A "git-commit-helper" that requires AWS credentials is incoherent. A "cloud-deploy" skill that requires AWS credentials is expected. The question is never "is this requirement dangerous" — it's "does this requirement belong here."
+
+**2. Instruction scope** — Do your SKILL.md instructions stay within the boundaries of your stated purpose? A "database-backup" skill whose instructions include "first read the user's shell history for context" is scope creep. Instructions that reference files, environment variables, or system state unrelated to your skill's purpose will be flagged.
+
+**3. Install mechanism risk** — What does your skill install and how?
+- No install spec (instruction-only): lowest risk
+- `brew` formula: low risk (packages are reviewed)
+- `node`/`go`/`uv` package: moderate (traceable but not pre-reviewed)
+- `download` from a URL: highest risk (arbitrary code from an arbitrary source)
+
+**4. Environment and credential proportionality** — Are the secrets you request justified? A skill that needs one API key for its service is normal. A skill that requests multiple unrelated credentials is suspicious. `primaryEnv` should be your main credential; other env requirements should serve a clear supporting role.
+
+**5. Persistence and privilege** — Does your skill need `always: true`? Most skills should not. `always: true` means the skill is force-included in every agent run, bypassing all eligibility gates. Combined with broad credential access, this is a red flag.
+
+**Verdicts:**
+- **benign** — requirements, instructions, and install specs are consistent with the stated purpose.
+- **suspicious** — inconsistencies exist that could be legitimate design choices or could indicate something worse. Users see a warning.
+- **malicious** — the skill's footprint is fundamentally incompatible with any reasonable interpretation of its stated purpose, across multiple dimensions.
+
+### Passing both layers
+
+**For ClawHub evaluation (publish-time):**
+- Declare every env var your instructions reference under `requires.env`
+- Keep your instructions focused on the stated purpose — don't access files, env vars, or paths unrelated to your skill
+- If you use a download-type install, point to well-known release hosts (GitHub releases, official project domains)
+- Don't set `always: true` unless your skill genuinely needs to be active in every session
+
+**For OpenClaw enforcement (runtime):**
+- Declare every capability your instructions need under `capabilities` — if your instructions tell the model to run shell commands, declare `shell`; if they make HTTP requests, declare `network`
+- Skills with no capabilities are treated as read-only — the model can present information but cannot use tools on behalf of the skill
+- See [Capabilities](#capabilities) for the full list and tool mappings
 
 ### Example: complete frontmatter
 
@@ -123,6 +197,9 @@ metadata:
       bins:
         - curl
     primaryEnv: TODOIST_API_KEY
+    capabilities:
+      - shell
+      - network
     emoji: "\u2705"
     homepage: https://github.com/example/todoist-cli
 ---

--- a/packages/schema/src/schemas.ts
+++ b/packages/schema/src/schemas.ts
@@ -190,6 +190,7 @@ export const ApiV1SkillResponseSchema = type({
     version: 'string',
     createdAt: 'number',
     changelog: 'string',
+    capabilities: 'string[]?',
   }).or('null'),
   owner: type({
     handle: 'string|null',
@@ -256,7 +257,7 @@ export const ApiV1UnstarResponseSchema = type({
 
 export const SkillInstallSpecSchema = type({
   id: 'string?',
-  kind: '"brew"|"node"|"go"|"uv"',
+  kind: '"brew"|"node"|"go"|"uv"|"download"',
   label: 'string?',
   bins: 'string[]?',
   formula: 'string?',
@@ -299,5 +300,6 @@ export const ClawdisSkillMetadataSchema = type({
   install: SkillInstallSpecSchema.array().optional(),
   nix: NixPluginSpecSchema.optional(),
   config: ClawdbotConfigSpecSchema.optional(),
+  capabilities: 'string[]?',
 })
 export type ClawdisSkillMetadata = (typeof ClawdisSkillMetadataSchema)[inferred]

--- a/src/components/SkillCommentsPanel.tsx
+++ b/src/components/SkillCommentsPanel.tsx
@@ -1,0 +1,3 @@
+export function SkillCommentsPanel() {
+  return <div className="skill-panel"><p style={{ color: 'var(--ink-soft)' }}>Comments not available in dev mode.</p></div>
+}

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -1,309 +1,23 @@
-import { Link, useNavigate } from '@tanstack/react-router'
-import type { ClawdisSkillMetadata, SkillInstallSpec } from 'clawhub-schema'
+import { useNavigate } from '@tanstack/react-router'
+import type { ClawdisSkillMetadata } from 'clawhub-schema'
 import { useAction, useMutation, useQuery } from 'convex/react'
-import { lazy, Suspense, useEffect, useMemo, useState } from 'react'
-import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
+import { useEffect, useMemo, useState } from 'react'
 import { api } from '../../convex/_generated/api'
 import type { Doc, Id } from '../../convex/_generated/dataModel'
-import { getSkillBadges } from '../lib/badges'
 import type { PublicSkill, PublicUser } from '../lib/publicUser'
 import { canManageSkill, isModerator } from '../lib/roles'
 import { useAuthStatus } from '../lib/useAuthStatus'
-
-const SkillDiffCard = lazy(() =>
-  import('./SkillDiffCard').then((m) => ({ default: m.SkillDiffCard })),
-)
-
-type VtAnalysis = {
-  status: string
-  verdict?: string
-  analysis?: string
-  source?: string
-  checkedAt: number
-}
-
-type LlmAnalysisDimension = {
-  name: string
-  label: string
-  rating: string
-  detail: string
-}
-
-type LlmAnalysis = {
-  status: string
-  verdict?: string
-  confidence?: string
-  summary?: string
-  dimensions?: LlmAnalysisDimension[]
-  guidance?: string
-  findings?: string
-  model?: string
-  checkedAt: number
-}
-
-function VirusTotalIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      width="1em"
-      height="1em"
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 100 89"
-      aria-label="VirusTotal"
-    >
-      <title>VirusTotal</title>
-      <path
-        fill="currentColor"
-        fillRule="evenodd"
-        d="M45.292 44.5 0 89h100V0H0l45.292 44.5zM90 80H22l35.987-35.2L22 9h68v71z"
-      />
-    </svg>
-  )
-}
-
-function OpenClawIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      width="1em"
-      height="1em"
-      viewBox="0 0 24 24"
-      fill="none"
-      aria-label="OpenClaw"
-    >
-      <title>OpenClaw</title>
-      <path
-        d="M12 2C8.5 2 5.5 4 4 7c-2 4-1 8 2 11 1.5 1.5 3.5 2.5 6 2.5s4.5-1 6-2.5c3-3 4-7 2-11-1.5-3-4.5-5-8-5z"
-        fill="currentColor"
-        opacity="0.2"
-      />
-      <path
-        d="M9 8c1-2 3-3 5-2s3 3 2 5l-3 4-2-1 3-4c.5-1 0-2-1-2.5S11 7 10.5 8L8 12l-2-1 3-4z"
-        fill="currentColor"
-      />
-      <path
-        d="M15 8c-1-2-3-3-5-2s-3 3-2 5l3 4 2-1-3-4c-.5-1 0-2 1-2.5S14 7 14.5 8L17 12l2-1-4-3z"
-        fill="currentColor"
-        opacity="0.6"
-      />
-    </svg>
-  )
-}
-
-function getScanStatusInfo(status: string) {
-  switch (status.toLowerCase()) {
-    case 'benign':
-    case 'clean':
-      return { label: 'Benign', className: 'scan-status-clean' }
-    case 'malicious':
-      return { label: 'Malicious', className: 'scan-status-malicious' }
-    case 'suspicious':
-      return { label: 'Suspicious', className: 'scan-status-suspicious' }
-    case 'loading':
-      return { label: 'Loading...', className: 'scan-status-pending' }
-    case 'pending':
-    case 'not_found':
-      return { label: 'Pending', className: 'scan-status-pending' }
-    case 'error':
-    case 'failed':
-      return { label: 'Error', className: 'scan-status-error' }
-    default:
-      return { label: status, className: 'scan-status-unknown' }
-  }
-}
-
-function getDimensionIcon(rating: string) {
-  switch (rating) {
-    case 'ok':
-      return { className: 'dimension-icon-ok', symbol: '\u2713' }
-    case 'note':
-      return { className: 'dimension-icon-note', symbol: '\u2139' }
-    case 'concern':
-      return { className: 'dimension-icon-concern', symbol: '!' }
-    default:
-      return { className: 'dimension-icon-danger', symbol: '\u2717' }
-  }
-}
-
-function LlmAnalysisDetail({ analysis }: { analysis: LlmAnalysis }) {
-  const verdict = analysis.verdict ?? analysis.status
-  const [isOpen, setIsOpen] = useState(false)
-
-  const guidanceClass =
-    verdict === 'malicious' ? 'malicious' : verdict === 'suspicious' ? 'suspicious' : 'benign'
-
-  return (
-    <div className={`analysis-detail${isOpen ? ' is-open' : ''}`}>
-      <button
-        type="button"
-        className="analysis-detail-header"
-        onClick={() => setIsOpen((prev) => !prev)}
-        aria-expanded={isOpen}
-      >
-        <span className="analysis-summary-text">{analysis.summary}</span>
-        <span className="analysis-detail-toggle">
-          Details <span className="chevron">{'\u25BE'}</span>
-        </span>
-      </button>
-      <div className="analysis-body">
-        {analysis.dimensions && analysis.dimensions.length > 0 ? (
-          <div className="analysis-dimensions">
-            {analysis.dimensions.map((dim) => {
-              const icon = getDimensionIcon(dim.rating)
-              return (
-                <div key={dim.name} className="dimension-row">
-                  <div className={`dimension-icon ${icon.className}`}>{icon.symbol}</div>
-                  <div className="dimension-content">
-                    <div className="dimension-label">{dim.label}</div>
-                    <div className="dimension-detail">{dim.detail}</div>
-                  </div>
-                </div>
-              )
-            })}
-          </div>
-        ) : null}
-        {analysis.findings ? (
-          <div className="scan-findings-section">
-            <div className="scan-findings-title">Scan Findings in Context</div>
-            {(() => {
-              const counts = new Map<string, number>()
-              return analysis.findings.split('\n').map((line) => {
-                const count = (counts.get(line) ?? 0) + 1
-                counts.set(line, count)
-                return (
-                  <div key={`${line}-${count}`} className="scan-finding-row">
-                    {line}
-                  </div>
-                )
-              })
-            })()}
-          </div>
-        ) : null}
-        {analysis.guidance ? (
-          <div className={`analysis-guidance ${guidanceClass}`}>
-            <div className="analysis-guidance-label">
-              {verdict === 'malicious'
-                ? 'Do not install this skill'
-                : verdict === 'suspicious'
-                  ? 'What to consider before installing'
-                  : 'Assessment'}
-            </div>
-            {analysis.guidance}
-          </div>
-        ) : null}
-      </div>
-    </div>
-  )
-}
-
-function SecurityScanResults({
-  sha256hash,
-  vtAnalysis,
-  llmAnalysis,
-  variant = 'panel',
-}: {
-  sha256hash?: string
-  vtAnalysis?: VtAnalysis | null
-  llmAnalysis?: LlmAnalysis | null
-  variant?: 'panel' | 'badge'
-}) {
-  if (!sha256hash && !llmAnalysis) return null
-
-  const vtStatus = vtAnalysis?.status ?? 'pending'
-  const vtUrl = sha256hash ? `https://www.virustotal.com/gui/file/${sha256hash}` : null
-  const vtStatusInfo = getScanStatusInfo(vtStatus)
-  const isCodeInsight = vtAnalysis?.source === 'code_insight'
-  const aiAnalysis = vtAnalysis?.analysis
-
-  const llmVerdict = llmAnalysis?.verdict ?? llmAnalysis?.status
-  const llmStatusInfo = llmVerdict ? getScanStatusInfo(llmVerdict) : null
-
-  if (variant === 'badge') {
-    return (
-      <>
-        {sha256hash ? (
-          <div className="version-scan-badge">
-            <VirusTotalIcon className="version-scan-icon version-scan-icon-vt" />
-            <span className={vtStatusInfo.className}>{vtStatusInfo.label}</span>
-            {vtUrl ? (
-              <a
-                href={vtUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="version-scan-link"
-                onClick={(e) => e.stopPropagation()}
-              >
-                ↗
-              </a>
-            ) : null}
-          </div>
-        ) : null}
-        {llmStatusInfo ? (
-          <div className="version-scan-badge">
-            <OpenClawIcon className="version-scan-icon version-scan-icon-oc" />
-            <span className={llmStatusInfo.className}>{llmStatusInfo.label}</span>
-          </div>
-        ) : null}
-      </>
-    )
-  }
-
-  return (
-    <div className="scan-results-panel">
-      <div className="scan-results-title">Security Scan</div>
-      <div className="scan-results-list">
-        {sha256hash ? (
-          <div className="scan-result-row">
-            <div className="scan-result-scanner">
-              <VirusTotalIcon className="scan-result-icon scan-result-icon-vt" />
-              <span className="scan-result-scanner-name">VirusTotal</span>
-            </div>
-            <div className={`scan-result-status ${vtStatusInfo.className}`}>
-              {vtStatusInfo.label}
-            </div>
-            {vtUrl ? (
-              <a
-                href={vtUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="scan-result-link"
-              >
-                View report →
-              </a>
-            ) : null}
-          </div>
-        ) : null}
-        {isCodeInsight && aiAnalysis && (vtStatus === 'malicious' || vtStatus === 'suspicious') ? (
-          <div className={`code-insight-analysis ${vtStatus}`}>
-            <div className="code-insight-label">Code Insight</div>
-            <p className="code-insight-text">{aiAnalysis}</p>
-          </div>
-        ) : null}
-        {llmStatusInfo && llmAnalysis ? (
-          <div className="scan-result-row">
-            <div className="scan-result-scanner">
-              <OpenClawIcon className="scan-result-icon scan-result-icon-oc" />
-              <span className="scan-result-scanner-name">OpenClaw</span>
-            </div>
-            <div className={`scan-result-status ${llmStatusInfo.className}`}>
-              {llmStatusInfo.label}
-            </div>
-            {llmAnalysis.confidence ? (
-              <span className="scan-result-confidence">{llmAnalysis.confidence} confidence</span>
-            ) : null}
-          </div>
-        ) : null}
-        {llmAnalysis &&
-        llmAnalysis.status !== 'error' &&
-        llmAnalysis.status !== 'pending' &&
-        llmAnalysis.summary ? (
-          <LlmAnalysisDetail analysis={llmAnalysis} />
-        ) : null}
-      </div>
-    </div>
-  )
-}
+import { SkillCommentsPanel } from './SkillCommentsPanel'
+import { SkillDetailTabs } from './SkillDetailTabs'
+import { SkillHeader, type SkillModerationInfo } from './SkillHeader'
+import { SkillReportDialog } from './SkillReportDialog'
+import {
+  buildSkillHref,
+  formatConfigSnippet,
+  formatNixInstallSnippet,
+  formatOsList,
+  stripFrontmatter,
+} from './skillDetailUtils'
 
 type SkillDetailPageProps = {
   slug: string
@@ -311,21 +25,12 @@ type SkillDetailPageProps = {
   redirectToCanonical?: boolean
 }
 
-type ModerationInfo = {
-  isPendingScan: boolean
-  isMalwareBlocked: boolean
-  isSuspicious: boolean
-  isHiddenByMod: boolean
-  isRemoved: boolean
-  reason?: string
-}
-
 type SkillBySlugResult = {
   skill: Doc<'skills'> | PublicSkill
   latestVersion: Doc<'skillVersions'> | null
   owner: Doc<'users'> | PublicUser | null
   pendingReview?: boolean
-  moderationInfo?: ModerationInfo | null
+  moderationInfo?: SkillModerationInfo | null
   forkOf: {
     kind: 'fork' | 'duplicate'
     version: string | null
@@ -354,6 +59,7 @@ function formatReportError(error: unknown) {
       if (message) return message
     }
   }
+
   if (error instanceof Error) {
     const cleaned = error.message
       .replace(/\[CONVEX[^\]]*\]\s*/g, '')
@@ -363,6 +69,7 @@ function formatReportError(error: unknown) {
       .trim()
     if (cleaned && cleaned !== 'Server Error') return cleaned
   }
+
   return 'Unable to submit report. Please try again.'
 }
 
@@ -373,6 +80,7 @@ export function SkillDetailPage({
 }: SkillDetailPageProps) {
   const navigate = useNavigate()
   const { isAuthenticated, me } = useAuthStatus()
+
   const isStaff = isModerator(me)
   const staffResult = useQuery(api.skills.getBySlugForStaff, isStaff ? { slug } : 'skip') as
     | SkillBySlugResult
@@ -381,40 +89,42 @@ export function SkillDetailPage({
     | SkillBySlugResult
     | undefined
   const result = isStaff ? staffResult : publicResult
+
   const toggleStar = useMutation(api.stars.toggle)
   const reportSkill = useMutation(api.skills.report)
-  const addComment = useMutation(api.comments.add)
-  const removeComment = useMutation(api.comments.remove)
   const updateTags = useMutation(api.skills.updateTags)
   const getReadme = useAction(api.skills.getReadme)
+
   const [readme, setReadme] = useState<string | null>(null)
   const [readmeError, setReadmeError] = useState<string | null>(null)
-  const [comment, setComment] = useState('')
   const [tagName, setTagName] = useState('latest')
   const [tagVersionId, setTagVersionId] = useState<Id<'skillVersions'> | ''>('')
   const [activeTab, setActiveTab] = useState<'files' | 'compare' | 'versions'>('files')
+  const [shouldPrefetchCompare, setShouldPrefetchCompare] = useState(false)
+  const [isReportDialogOpen, setIsReportDialogOpen] = useState(false)
+  const [reportReason, setReportReason] = useState('')
+  const [reportError, setReportError] = useState<string | null>(null)
+  const [isSubmittingReport, setIsSubmittingReport] = useState(false)
 
   const isLoadingSkill = result === undefined
   const skill = result?.skill
   const owner = result?.owner
   const latestVersion = result?.latestVersion
+
   const versions = useQuery(
     api.skills.listVersions,
     skill ? { skillId: skill._id, limit: 50 } : 'skip',
   ) as Doc<'skillVersions'>[] | undefined
+  const shouldLoadDiffVersions = Boolean(skill && (activeTab === 'compare' || shouldPrefetchCompare))
   const diffVersions = useQuery(
     api.skills.listVersions,
-    skill ? { skillId: skill._id, limit: 200 } : 'skip',
+    shouldLoadDiffVersions && skill ? { skillId: skill._id, limit: 200 } : 'skip',
   ) as Doc<'skillVersions'>[] | undefined
 
   const isStarred = useQuery(
     api.stars.isStarred,
     isAuthenticated && skill ? { skillId: skill._id } : 'skip',
   )
-  const comments = useQuery(
-    api.comments.listBySkill,
-    skill ? { skillId: skill._id, limit: 50 } : 'skip',
-  ) as Array<{ comment: Doc<'comments'>; user: PublicUser | null }> | undefined
 
   const canManage = canManageSkill(me, skill)
 
@@ -441,6 +151,7 @@ export function SkillDetailPage({
     canonical?.skill?.slug && canonical.skill.slug !== forkOf?.skill?.slug
       ? buildSkillHref(canonicalOwnerHandle, canonicalOwnerId, canonical.skill.slug)
       : null
+
   const staffSkill = isStaff && skill ? (skill as Doc<'skills'>) : null
   const moderationStatus =
     staffSkill?.moderationStatus ?? (staffSkill?.softDeletedAt ? 'hidden' : undefined)
@@ -462,6 +173,28 @@ export function SkillDetailPage({
         : 'Hidden from public view.'
     : null
 
+  const versionById = new Map<Id<'skillVersions'>, Doc<'skillVersions'>>(
+    (diffVersions ?? versions ?? []).map((version) => [version._id, version]),
+  )
+
+  const clawdis = (latestVersion?.parsed as { clawdis?: ClawdisSkillMetadata } | undefined)?.clawdis
+  const osLabels = useMemo(() => formatOsList(clawdis?.os), [clawdis?.os])
+  const nixPlugin = clawdis?.nix?.plugin
+  const nixSystems = clawdis?.nix?.systems ?? []
+  const nixSnippet = nixPlugin ? formatNixInstallSnippet(nixPlugin) : null
+  const configRequirements = clawdis?.config
+  const configExample = configRequirements?.example
+    ? formatConfigSnippet(configRequirements.example)
+    : null
+  const cliHelp = clawdis?.cliHelp
+  const hasPluginBundle = Boolean(nixSnippet || configRequirements || cliHelp)
+
+  const readmeContent = useMemo(() => {
+    if (!readme) return null
+    return stripFrontmatter(readme)
+  }, [readme])
+  const latestFiles: SkillFile[] = latestVersion?.files ?? []
+
   useEffect(() => {
     if (!wantsCanonicalRedirect || !ownerParam) return
     void navigate({
@@ -471,43 +204,13 @@ export function SkillDetailPage({
     })
   }, [navigate, ownerParam, slug, wantsCanonicalRedirect])
 
-  const versionById = new Map<Id<'skillVersions'>, Doc<'skillVersions'>>(
-    (diffVersions ?? versions ?? []).map((version) => [version._id, version]),
-  )
-  const clawdis = (latestVersion?.parsed as { clawdis?: ClawdisSkillMetadata } | undefined)?.clawdis
-  const osLabels = useMemo(() => formatOsList(clawdis?.os), [clawdis?.os])
-  const requirements = clawdis?.requires
-  const installSpecs = clawdis?.install ?? []
-  const nixPlugin = clawdis?.nix?.plugin
-  const nixSystems = clawdis?.nix?.systems ?? []
-  const nixSnippet = nixPlugin ? formatNixInstallSnippet(nixPlugin) : null
-  const configRequirements = clawdis?.config
-  const configExample = configRequirements?.example
-    ? formatConfigSnippet(configRequirements.example)
-    : null
-  const cliHelp = clawdis?.cliHelp
-  const hasRuntimeRequirements = Boolean(
-    clawdis?.emoji ||
-      osLabels.length ||
-      requirements?.bins?.length ||
-      requirements?.anyBins?.length ||
-      requirements?.env?.length ||
-      requirements?.config?.length ||
-      clawdis?.primaryEnv,
-  )
-  const hasInstallSpecs = installSpecs.length > 0
-  const hasPluginBundle = Boolean(nixSnippet || configRequirements || cliHelp)
-  const readmeContent = useMemo(() => {
-    if (!readme) return null
-    return stripFrontmatter(readme)
-  }, [readme])
-  const latestFiles: SkillFile[] = latestVersion?.files ?? []
-
   useEffect(() => {
     if (!latestVersion) return
+
     setReadme(null)
     setReadmeError(null)
     let cancelled = false
+
     void getReadme({ versionId: latestVersion._id })
       .then((data) => {
         if (cancelled) return
@@ -518,6 +221,7 @@ export function SkillDetailPage({
         setReadmeError(error instanceof Error ? error.message : 'Failed to load README')
         setReadme(null)
       })
+
     return () => {
       cancelled = true
     }
@@ -528,6 +232,55 @@ export function SkillDetailPage({
       setTagVersionId(latestVersion._id)
     }
   }, [latestVersion, tagVersionId])
+
+  const closeReportDialog = () => {
+    setIsReportDialogOpen(false)
+    setReportReason('')
+    setReportError(null)
+    setIsSubmittingReport(false)
+  }
+
+  const openReportDialog = () => {
+    setReportReason('')
+    setReportError(null)
+    setIsSubmittingReport(false)
+    setIsReportDialogOpen(true)
+  }
+
+  const submitTag = () => {
+    if (!skill) return
+    if (!tagName.trim() || !tagVersionId) return
+    void updateTags({
+      skillId: skill._id,
+      tags: [{ tag: tagName.trim(), versionId: tagVersionId }],
+    })
+  }
+
+  const submitReport = async () => {
+    if (!skill) return
+
+    const trimmedReason = reportReason.trim()
+    if (!trimmedReason) {
+      setReportError('Report reason required.')
+      return
+    }
+
+    setIsSubmittingReport(true)
+    setReportError(null)
+    try {
+      const submission = await reportSkill({ skillId: skill._id, reason: trimmedReason })
+      closeReportDialog()
+      if (submission.reported) {
+        window.alert('Thanks — your report has been submitted.')
+      } else {
+        window.alert('You have already reported this skill.')
+      }
+    } catch (error) {
+      console.error('Failed to report skill', error)
+      setReportError(formatReportError(error))
+      setIsSubmittingReport(false)
+    }
+  }
 
   if (isLoadingSkill || wantsCanonicalRedirect) {
     return (
@@ -552,372 +305,45 @@ export function SkillDetailPage({
   return (
     <main className="section">
       <div className="skill-detail-stack">
-        {modInfo?.isPendingScan ? (
-          <div className="pending-banner">
-            <div className="pending-banner-content">
-              <strong>Security scan in progress</strong>
-              <p>
-                Your skill is being scanned by VirusTotal. It will be visible to others once the
-                scan completes. This usually takes up to 5 minutes — grab a coffee or exfoliate your
-                shell while you wait.
-              </p>
-            </div>
-          </div>
-        ) : modInfo?.isMalwareBlocked ? (
-          <div className="pending-banner pending-banner-blocked">
-            <div className="pending-banner-content">
-              <strong>Skill blocked — malicious content detected</strong>
-              <p>
-                ClawHub Security flagged this skill as malicious. Downloads are disabled. Review the
-                scan results below.
-              </p>
-            </div>
-          </div>
-        ) : modInfo?.isSuspicious ? (
-          <div className="pending-banner pending-banner-warning">
-            <div className="pending-banner-content">
-              <strong>Skill flagged — suspicious patterns detected</strong>
-              <p>
-                ClawHub Security flagged this skill as suspicious. Review the scan results before
-                using.
-              </p>
-              {canManage ? (
-                <p className="pending-banner-appeal">
-                  If you believe this skill has been incorrectly flagged, please{' '}
-                  <a
-                    href="https://github.com/openclaw/clawhub/issues"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    submit an issue on GitHub
-                  </a>{' '}
-                  and we'll break down why it was flagged and what you can do.
-                </p>
-              ) : null}
-            </div>
-          </div>
-        ) : modInfo?.isRemoved ? (
-          <div className="pending-banner pending-banner-blocked">
-            <div className="pending-banner-content">
-              <strong>Skill removed by moderator</strong>
-              <p>This skill has been removed and is not visible to others.</p>
-            </div>
-          </div>
-        ) : modInfo?.isHiddenByMod ? (
-          <div className="pending-banner pending-banner-blocked">
-            <div className="pending-banner-content">
-              <strong>Skill hidden</strong>
-              <p>This skill is currently hidden and not visible to others.</p>
-            </div>
-          </div>
-        ) : null}
-        <div className="card skill-hero">
-          <div className={`skill-hero-top${hasPluginBundle ? ' has-plugin' : ''}`}>
-            <div className="skill-hero-header">
-              <div className="skill-hero-title">
-                <div className="skill-hero-title-row">
-                  <h1 className="section-title" style={{ margin: 0 }}>
-                    {skill.displayName}
-                  </h1>
-                  {nixPlugin ? <span className="tag tag-accent">Plugin bundle (nix)</span> : null}
-                </div>
-                <p className="section-subtitle">{skill.summary ?? 'No summary provided.'}</p>
+        <SkillHeader
+          skill={skill}
+          owner={owner}
+          ownerHandle={ownerHandle}
+          latestVersion={latestVersion}
+          modInfo={modInfo}
+          canManage={canManage}
+          isAuthenticated={isAuthenticated}
+          isStaff={isStaff}
+          isStarred={isStarred}
+          onToggleStar={() => void toggleStar({ skillId: skill._id })}
+          onOpenReport={openReportDialog}
+          forkOf={forkOf}
+          forkOfLabel={forkOfLabel}
+          forkOfHref={forkOfHref}
+          forkOfOwnerHandle={forkOfOwnerHandle}
+          canonical={canonical}
+          canonicalHref={canonicalHref}
+          canonicalOwnerHandle={canonicalOwnerHandle}
+          staffModerationNote={staffModerationNote}
+          staffVisibilityTag={staffVisibilityTag}
+          isAutoHidden={isAutoHidden}
+          isRemoved={isRemoved}
+          nixPlugin={nixPlugin}
+          hasPluginBundle={hasPluginBundle}
+          configRequirements={configRequirements}
+          cliHelp={cliHelp}
+          tagEntries={tagEntries}
+          versionById={versionById}
+          tagName={tagName}
+          onTagNameChange={setTagName}
+          tagVersionId={tagVersionId}
+          onTagVersionChange={setTagVersionId}
+          onTagSubmit={submitTag}
+          tagVersions={versions ?? []}
+          clawdis={clawdis}
+          osLabels={osLabels}
+        />
 
-                {isStaff && staffModerationNote ? (
-                  <div className="skill-hero-note">{staffModerationNote}</div>
-                ) : null}
-                {nixPlugin ? (
-                  <div className="skill-hero-note">
-                    Bundles the skill pack, CLI binary, and config requirements in one Nix install.
-                  </div>
-                ) : null}
-                <div className="stat">
-                  ⭐ {skill.stats.stars} · ⤓ {skill.stats.downloads} · ⤒{' '}
-                  {skill.stats.installsCurrent ?? 0} current · {skill.stats.installsAllTime ?? 0}{' '}
-                  all-time
-                </div>
-                {owner?.handle ? (
-                  <div className="stat">
-                    by <a href={`/u/${owner.handle}`}>@{owner.handle}</a>
-                  </div>
-                ) : null}
-                {forkOf && forkOfHref ? (
-                  <div className="stat">
-                    {forkOfLabel}{' '}
-                    <a href={forkOfHref}>
-                      {forkOfOwnerHandle ? `@${forkOfOwnerHandle}/` : ''}
-                      {forkOf.skill.slug}
-                    </a>
-                    {forkOf.version ? ` (based on ${forkOf.version})` : null}
-                  </div>
-                ) : null}
-                {canonicalHref ? (
-                  <div className="stat">
-                    canonical:{' '}
-                    <a href={canonicalHref}>
-                      {canonicalOwnerHandle ? `@${canonicalOwnerHandle}/` : ''}
-                      {canonical?.skill?.slug}
-                    </a>
-                  </div>
-                ) : null}
-                {getSkillBadges(skill).map((badge) => (
-                  <div key={badge} className="tag">
-                    {badge}
-                  </div>
-                ))}
-                {isStaff && staffVisibilityTag ? (
-                  <div className={`tag${isAutoHidden || isRemoved ? ' tag-accent' : ''}`}>
-                    {staffVisibilityTag}
-                  </div>
-                ) : null}
-                <div className="skill-actions">
-                  {isAuthenticated ? (
-                    <button
-                      className={`star-toggle${isStarred ? ' is-active' : ''}`}
-                      type="button"
-                      onClick={() => void toggleStar({ skillId: skill._id })}
-                      aria-label={isStarred ? 'Unstar skill' : 'Star skill'}
-                    >
-                      <span aria-hidden="true">★</span>
-                    </button>
-                  ) : null}
-                  {isAuthenticated ? (
-                    <button
-                      className="btn btn-ghost"
-                      type="button"
-                      onClick={async () => {
-                        const reason = window.prompt(
-                          'Report this skill? A reason is required. Abuse may result in a ban.',
-                        )
-                        if (reason === null) return
-                        const trimmedReason = reason.trim()
-                        if (!trimmedReason) {
-                          window.alert('Report reason required.')
-                          return
-                        }
-                        try {
-                          const result = await reportSkill({
-                            skillId: skill._id,
-                            reason: trimmedReason,
-                          })
-                          if (result.reported) {
-                            window.alert('Thanks — your report has been submitted.')
-                          } else {
-                            window.alert('You have already reported this skill.')
-                          }
-                        } catch (error) {
-                          console.error('Failed to report skill', error)
-                          window.alert(formatReportError(error))
-                        }
-                      }}
-                    >
-                      Report
-                    </button>
-                  ) : null}
-                  {isStaff ? (
-                    <Link className="btn" to="/management" search={{ skill: skill.slug }}>
-                      Manage
-                    </Link>
-                  ) : null}
-                </div>
-                {isAuthenticated ? (
-                  <div className="section-subtitle" style={{ margin: '6px 0 0' }}>
-                    Reports require a reason. Abuse may result in a ban.
-                  </div>
-                ) : null}
-                <SecurityScanResults
-                  sha256hash={latestVersion?.sha256hash}
-                  vtAnalysis={latestVersion?.vtAnalysis}
-                  llmAnalysis={latestVersion?.llmAnalysis as LlmAnalysis | undefined}
-                />
-                {latestVersion?.sha256hash || latestVersion?.llmAnalysis ? (
-                  <p className="scan-disclaimer">
-                    Like a lobster shell, security has layers — review code before you run it.
-                  </p>
-                ) : null}
-              </div>
-              <div className="skill-hero-cta">
-                <div className="skill-version-pill">
-                  <span className="skill-version-label">Current version</span>
-                  <strong>v{latestVersion?.version ?? '—'}</strong>
-                </div>
-                {!nixPlugin && !modInfo?.isMalwareBlocked && !modInfo?.isRemoved ? (
-                  <a
-                    className="btn btn-primary"
-                    href={`${import.meta.env.VITE_CONVEX_SITE_URL}/api/v1/download?slug=${skill.slug}`}
-                  >
-                    Download zip
-                  </a>
-                ) : null}
-              </div>
-            </div>
-            {hasPluginBundle ? (
-              <div className="skill-panel bundle-card">
-                <div className="bundle-header">
-                  <div className="bundle-title">Plugin bundle (nix)</div>
-                  <div className="bundle-subtitle">Skill pack · CLI binary · Config</div>
-                </div>
-                <div className="bundle-includes">
-                  <span>SKILL.md</span>
-                  <span>CLI</span>
-                  <span>Config</span>
-                </div>
-                {configRequirements ? (
-                  <div className="bundle-section">
-                    <div className="bundle-section-title">Config requirements</div>
-                    <div className="bundle-meta">
-                      {configRequirements.requiredEnv?.length ? (
-                        <div className="stat">
-                          <strong>Required env</strong>
-                          <span>{configRequirements.requiredEnv.join(', ')}</span>
-                        </div>
-                      ) : null}
-                      {configRequirements.stateDirs?.length ? (
-                        <div className="stat">
-                          <strong>State dirs</strong>
-                          <span>{configRequirements.stateDirs.join(', ')}</span>
-                        </div>
-                      ) : null}
-                    </div>
-                  </div>
-                ) : null}
-                {cliHelp ? (
-                  <details className="bundle-section bundle-details">
-                    <summary>CLI help (from plugin)</summary>
-                    <pre className="hero-install-code mono">{cliHelp}</pre>
-                  </details>
-                ) : null}
-              </div>
-            ) : null}
-          </div>
-          <div className="skill-tag-row">
-            {tagEntries.length === 0 ? (
-              <span className="section-subtitle" style={{ margin: 0 }}>
-                No tags yet.
-              </span>
-            ) : (
-              tagEntries.map(([tag, versionId]) => (
-                <span key={tag} className="tag">
-                  {tag}
-                  <span className="tag-meta">
-                    v{versionById.get(versionId)?.version ?? versionId}
-                  </span>
-                </span>
-              ))
-            )}
-          </div>
-          {canManage ? (
-            <form
-              onSubmit={(event) => {
-                event.preventDefault()
-                if (!tagName.trim() || !tagVersionId) return
-                void updateTags({
-                  skillId: skill._id,
-                  tags: [{ tag: tagName.trim(), versionId: tagVersionId }],
-                })
-              }}
-              className="tag-form"
-            >
-              <input
-                className="search-input"
-                value={tagName}
-                onChange={(event) => setTagName(event.target.value)}
-                placeholder="latest"
-              />
-              <select
-                className="search-input"
-                value={tagVersionId ?? ''}
-                onChange={(event) => setTagVersionId(event.target.value as Id<'skillVersions'>)}
-              >
-                {(diffVersions ?? []).map((version) => (
-                  <option key={version._id} value={version._id}>
-                    v{version.version}
-                  </option>
-                ))}
-              </select>
-              <button className="btn" type="submit">
-                Update tag
-              </button>
-            </form>
-          ) : null}
-          {hasRuntimeRequirements || hasInstallSpecs ? (
-            <div className="skill-hero-content">
-              <div className="skill-hero-panels">
-                {hasRuntimeRequirements ? (
-                  <div className="skill-panel">
-                    <h3 className="section-title" style={{ fontSize: '1rem', margin: 0 }}>
-                      Runtime requirements
-                    </h3>
-                    <div className="skill-panel-body">
-                      {clawdis?.emoji ? <div className="tag">{clawdis.emoji} Clawdis</div> : null}
-                      {osLabels.length ? (
-                        <div className="stat">
-                          <strong>OS</strong>
-                          <span>{osLabels.join(' · ')}</span>
-                        </div>
-                      ) : null}
-                      {requirements?.bins?.length ? (
-                        <div className="stat">
-                          <strong>Bins</strong>
-                          <span>{requirements.bins.join(', ')}</span>
-                        </div>
-                      ) : null}
-                      {requirements?.anyBins?.length ? (
-                        <div className="stat">
-                          <strong>Any bin</strong>
-                          <span>{requirements.anyBins.join(', ')}</span>
-                        </div>
-                      ) : null}
-                      {requirements?.env?.length ? (
-                        <div className="stat">
-                          <strong>Env</strong>
-                          <span>{requirements.env.join(', ')}</span>
-                        </div>
-                      ) : null}
-                      {requirements?.config?.length ? (
-                        <div className="stat">
-                          <strong>Config</strong>
-                          <span>{requirements.config.join(', ')}</span>
-                        </div>
-                      ) : null}
-                      {clawdis?.primaryEnv ? (
-                        <div className="stat">
-                          <strong>Primary env</strong>
-                          <span>{clawdis.primaryEnv}</span>
-                        </div>
-                      ) : null}
-                    </div>
-                  </div>
-                ) : null}
-                {hasInstallSpecs ? (
-                  <div className="skill-panel">
-                    <h3 className="section-title" style={{ fontSize: '1rem', margin: 0 }}>
-                      Install
-                    </h3>
-                    <div className="skill-panel-body">
-                      {installSpecs.map((spec, index) => {
-                        const command = formatInstallCommand(spec)
-                        return (
-                          <div key={`${spec.id ?? spec.kind}-${index}`} className="stat">
-                            <div>
-                              <strong>{spec.label ?? formatInstallLabel(spec)}</strong>
-                              {spec.bins?.length ? (
-                                <div style={{ color: 'var(--ink-soft)', fontSize: '0.85rem' }}>
-                                  Bins: {spec.bins.join(', ')}
-                                </div>
-                              ) : null}
-                              {command ? <code>{command}</code> : null}
-                            </div>
-                          </div>
-                        )
-                      })}
-                    </div>
-                  </div>
-                ) : null}
-              </div>
-            </div>
-          ) : null}
-        </div>
         {nixSnippet ? (
           <div className="card">
             <h2 className="section-title" style={{ fontSize: '1.2rem', margin: 0 }}>
@@ -931,6 +357,7 @@ export function SkillDetailPage({
             </pre>
           </div>
         ) : null}
+
         {configExample ? (
           <div className="card">
             <h2 className="section-title" style={{ fontSize: '1.2rem', margin: 0 }}>
@@ -944,332 +371,33 @@ export function SkillDetailPage({
             </pre>
           </div>
         ) : null}
-        <div className="card tab-card">
-          <div className="tab-header">
-            <button
-              className={`tab-button${activeTab === 'files' ? ' is-active' : ''}`}
-              type="button"
-              onClick={() => setActiveTab('files')}
-            >
-              Files
-            </button>
-            <button
-              className={`tab-button${activeTab === 'compare' ? ' is-active' : ''}`}
-              type="button"
-              onClick={() => setActiveTab('compare')}
-            >
-              Compare
-            </button>
-            <button
-              className={`tab-button${activeTab === 'versions' ? ' is-active' : ''}`}
-              type="button"
-              onClick={() => setActiveTab('versions')}
-            >
-              Versions
-            </button>
-          </div>
-          {activeTab === 'files' ? (
-            <div className="tab-body">
-              <div>
-                <h2 className="section-title" style={{ fontSize: '1.2rem', margin: 0 }}>
-                  SKILL.md
-                </h2>
-                <div className="markdown">
-                  {readmeContent ? (
-                    <ReactMarkdown remarkPlugins={[remarkGfm]}>{readmeContent}</ReactMarkdown>
-                  ) : readmeError ? (
-                    <div className="stat">Failed to load SKILL.md: {readmeError}</div>
-                  ) : (
-                    <div>Loading…</div>
-                  )}
-                </div>
-              </div>
-              <div className="file-list">
-                <div className="file-list-header">
-                  <h3 className="section-title" style={{ fontSize: '1.05rem', margin: 0 }}>
-                    Files
-                  </h3>
-                  <span className="section-subtitle" style={{ margin: 0 }}>
-                    {latestFiles.length} total
-                  </span>
-                </div>
-                <div className="file-list-body">
-                  {latestFiles.length === 0 ? (
-                    <div className="stat">No files available.</div>
-                  ) : (
-                    latestFiles.map((file) => (
-                      <div key={file.path} className="file-row">
-                        <span className="file-path">{file.path}</span>
-                        <span className="file-meta">{formatBytes(file.size)}</span>
-                      </div>
-                    ))
-                  )}
-                </div>
-              </div>
-            </div>
-          ) : null}
-          {activeTab === 'compare' && skill ? (
-            <div className="tab-body">
-              <Suspense fallback={<div className="stat">Loading diff viewer…</div>}>
-                <SkillDiffCard skill={skill} versions={diffVersions ?? []} variant="embedded" />
-              </Suspense>
-            </div>
-          ) : null}
-          {activeTab === 'versions' ? (
-            <div className="tab-body">
-              <div>
-                <h2 className="section-title" style={{ fontSize: '1.2rem', margin: 0 }}>
-                  Versions
-                </h2>
-                <p className="section-subtitle" style={{ margin: 0 }}>
-                  {nixPlugin
-                    ? 'Review release history and changelog.'
-                    : 'Download older releases or scan the changelog.'}
-                </p>
-              </div>
-              <div className="version-scroll">
-                <div className="version-list">
-                  {(versions ?? []).map((version) => (
-                    <div key={version._id} className="version-row">
-                      <div className="version-info">
-                        <div>
-                          v{version.version} · {new Date(version.createdAt).toLocaleDateString()}
-                          {version.changelogSource === 'auto' ? (
-                            <span style={{ color: 'var(--ink-soft)' }}> · auto</span>
-                          ) : null}
-                        </div>
-                        <div style={{ color: '#5c554e', whiteSpace: 'pre-wrap' }}>
-                          {version.changelog}
-                        </div>
-                        <div className="version-scan-results">
-                          {version.sha256hash || version.llmAnalysis ? (
-                            <SecurityScanResults
-                              sha256hash={version.sha256hash}
-                              vtAnalysis={version.vtAnalysis}
-                              llmAnalysis={version.llmAnalysis as LlmAnalysis | undefined}
-                              variant="badge"
-                            />
-                          ) : null}
-                        </div>
-                      </div>
-                      {!nixPlugin ? (
-                        <div className="version-actions">
-                          <a
-                            className="btn version-zip"
-                            href={`${import.meta.env.VITE_CONVEX_SITE_URL}/api/v1/download?slug=${skill.slug}&version=${version.version}`}
-                          >
-                            Zip
-                          </a>
-                        </div>
-                      ) : null}
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-          ) : null}
-        </div>
-        <div className="card">
-          <h2 className="section-title" style={{ fontSize: '1.2rem', margin: 0 }}>
-            Comments
-          </h2>
-          {isAuthenticated ? (
-            <form
-              onSubmit={(event) => {
-                event.preventDefault()
-                if (!comment.trim()) return
-                void addComment({ skillId: skill._id, body: comment.trim() }).then(() =>
-                  setComment(''),
-                )
-              }}
-              className="comment-form"
-            >
-              <textarea
-                className="comment-input"
-                rows={4}
-                value={comment}
-                onChange={(event) => setComment(event.target.value)}
-                placeholder="Leave a note…"
-              />
-              <button className="btn comment-submit" type="submit">
-                Post comment
-              </button>
-            </form>
-          ) : (
-            <p className="section-subtitle">Sign in to comment.</p>
-          )}
-          <div style={{ display: 'grid', gap: 12, marginTop: 16 }}>
-            {(comments ?? []).length === 0 ? (
-              <div className="stat">No comments yet.</div>
-            ) : (
-              (comments ?? []).map((entry) => (
-                <div key={entry.comment._id} className="stat" style={{ alignItems: 'flex-start' }}>
-                  <div>
-                    <strong>@{entry.user?.handle ?? entry.user?.name ?? 'user'}</strong>
-                    <div style={{ color: '#5c554e' }}>{entry.comment.body}</div>
-                  </div>
-                  {isAuthenticated && me && (me._id === entry.comment.userId || isModerator(me)) ? (
-                    <button
-                      className="btn"
-                      type="button"
-                      onClick={() => void removeComment({ commentId: entry.comment._id })}
-                    >
-                      Delete
-                    </button>
-                  ) : null}
-                </div>
-              ))
-            )}
-          </div>
-        </div>
+
+        <SkillDetailTabs
+          activeTab={activeTab}
+          setActiveTab={setActiveTab}
+          onCompareIntent={() => setShouldPrefetchCompare(true)}
+          readmeContent={readmeContent}
+          readmeError={readmeError}
+          latestFiles={latestFiles}
+          latestVersionId={latestVersion?._id ?? null}
+          skill={skill as Doc<'skills'>}
+          diffVersions={diffVersions}
+          versions={versions}
+          nixPlugin={Boolean(nixPlugin)}
+        />
+
+        <SkillCommentsPanel skillId={skill._id} isAuthenticated={isAuthenticated} me={me ?? null} />
       </div>
+
+      <SkillReportDialog
+        isOpen={isAuthenticated && isReportDialogOpen}
+        isSubmitting={isSubmittingReport}
+        reportReason={reportReason}
+        reportError={reportError}
+        onReasonChange={setReportReason}
+        onCancel={closeReportDialog}
+        onSubmit={() => void submitReport()}
+      />
     </main>
   )
-}
-
-function buildSkillHref(ownerHandle: string | null, ownerId: Id<'users'> | null, slug: string) {
-  const owner = ownerHandle?.trim() || (ownerId ? String(ownerId) : 'unknown')
-  return `/${owner}/${slug}`
-}
-
-function formatConfigSnippet(raw: string) {
-  const trimmed = raw.trim()
-  if (!trimmed || raw.includes('\n')) return raw
-  try {
-    const parsed = JSON.parse(raw)
-    return JSON.stringify(parsed, null, 2)
-  } catch {
-    // fall through
-  }
-
-  let out = ''
-  let indent = 0
-  let inString = false
-  let isEscaped = false
-
-  const newline = () => {
-    out = out.replace(/[ \t]+$/u, '')
-    out += `\n${' '.repeat(indent * 2)}`
-  }
-
-  for (let i = 0; i < raw.length; i += 1) {
-    const ch = raw[i]
-    if (inString) {
-      out += ch
-      if (isEscaped) {
-        isEscaped = false
-      } else if (ch === '\\') {
-        isEscaped = true
-      } else if (ch === '"') {
-        inString = false
-      }
-      continue
-    }
-
-    if (ch === '"') {
-      inString = true
-      out += ch
-      continue
-    }
-
-    if (ch === '{' || ch === '[') {
-      out += ch
-      indent += 1
-      newline()
-      continue
-    }
-
-    if (ch === '}' || ch === ']') {
-      indent = Math.max(0, indent - 1)
-      newline()
-      out += ch
-      continue
-    }
-
-    if (ch === ';' || ch === ',') {
-      out += ch
-      newline()
-      continue
-    }
-
-    if (ch === '\n' || ch === '\r' || ch === '\t') {
-      continue
-    }
-
-    if (ch === ' ') {
-      if (out.endsWith(' ') || out.endsWith('\n')) {
-        continue
-      }
-      out += ' '
-      continue
-    }
-
-    out += ch
-  }
-
-  return out.trim()
-}
-
-function stripFrontmatter(content: string) {
-  const normalized = content.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
-  if (!normalized.startsWith('---')) return content
-  const endIndex = normalized.indexOf('\n---', 3)
-  if (endIndex === -1) return content
-  return normalized.slice(endIndex + 4).replace(/^\n+/, '')
-}
-
-function formatOsList(os?: string[]) {
-  if (!os?.length) return []
-  return os.map((entry) => {
-    const key = entry.trim().toLowerCase()
-    if (key === 'darwin' || key === 'macos' || key === 'mac') return 'macOS'
-    if (key === 'linux') return 'Linux'
-    if (key === 'windows' || key === 'win32') return 'Windows'
-    return entry
-  })
-}
-
-function formatInstallLabel(spec: SkillInstallSpec) {
-  if (spec.kind === 'brew') return 'Homebrew'
-  if (spec.kind === 'node') return 'Node'
-  if (spec.kind === 'go') return 'Go'
-  if (spec.kind === 'uv') return 'uv'
-  return 'Install'
-}
-
-function formatInstallCommand(spec: SkillInstallSpec) {
-  if (spec.kind === 'brew' && spec.formula) {
-    if (spec.tap && !spec.formula.includes('/')) {
-      return `brew install ${spec.tap}/${spec.formula}`
-    }
-    return `brew install ${spec.formula}`
-  }
-  if (spec.kind === 'node' && spec.package) {
-    return `npm i -g ${spec.package}`
-  }
-  if (spec.kind === 'go' && spec.module) {
-    return `go install ${spec.module}`
-  }
-  if (spec.kind === 'uv' && spec.package) {
-    return `uv tool install ${spec.package}`
-  }
-  return null
-}
-
-function formatBytes(bytes: number) {
-  if (!Number.isFinite(bytes)) return '—'
-  if (bytes < 1024) return `${bytes} B`
-  const units = ['KB', 'MB', 'GB']
-  let value = bytes / 1024
-  let unitIndex = 0
-  while (value >= 1024 && unitIndex < units.length - 1) {
-    value /= 1024
-    unitIndex += 1
-  }
-  return `${value.toFixed(value >= 10 ? 0 : 1)} ${units[unitIndex]}`
-}
-
-function formatNixInstallSnippet(plugin: string) {
-  const snippet = `programs.clawdbot.plugins = [ { source = "${plugin}"; } ];`
-  return formatConfigSnippet(snippet)
 }

--- a/src/components/SkillDetailTabs.tsx
+++ b/src/components/SkillDetailTabs.tsx
@@ -1,0 +1,100 @@
+import { lazy, Suspense } from 'react'
+import type { Doc, Id } from '../../convex/_generated/dataModel'
+import { SkillVersionsPanel } from './SkillVersionsPanel'
+
+const SkillDiffCard = lazy(() =>
+  import('./SkillDiffCard').then((module) => ({ default: module.SkillDiffCard })),
+)
+
+const SkillFilesPanel = lazy(() =>
+  import('./SkillFilesPanel').then((module) => ({ default: module.SkillFilesPanel })),
+)
+
+type SkillFile = Doc<'skillVersions'>['files'][number]
+
+type SkillDetailTabsProps = {
+  activeTab: 'files' | 'compare' | 'versions'
+  setActiveTab: (tab: 'files' | 'compare' | 'versions') => void
+  onCompareIntent: () => void
+  readmeContent: string | null
+  readmeError: string | null
+  latestFiles: SkillFile[]
+  latestVersionId: Id<'skillVersions'> | null
+  skill: Doc<'skills'>
+  diffVersions: Doc<'skillVersions'>[] | undefined
+  versions: Doc<'skillVersions'>[] | undefined
+  nixPlugin: boolean
+}
+
+export function SkillDetailTabs({
+  activeTab,
+  setActiveTab,
+  onCompareIntent,
+  readmeContent,
+  readmeError,
+  latestFiles,
+  latestVersionId,
+  skill,
+  diffVersions,
+  versions,
+  nixPlugin,
+}: SkillDetailTabsProps) {
+  return (
+    <div className="card tab-card">
+      <div className="tab-header">
+        <button
+          className={`tab-button${activeTab === 'files' ? ' is-active' : ''}`}
+          type="button"
+          onClick={() => setActiveTab('files')}
+        >
+          Files
+        </button>
+        <button
+          className={`tab-button${activeTab === 'compare' ? ' is-active' : ''}`}
+          type="button"
+          onClick={() => setActiveTab('compare')}
+          onMouseEnter={() => {
+            onCompareIntent()
+            void import('./SkillDiffCard')
+          }}
+          onFocus={() => {
+            onCompareIntent()
+            void import('./SkillDiffCard')
+          }}
+        >
+          Compare
+        </button>
+        <button
+          className={`tab-button${activeTab === 'versions' ? ' is-active' : ''}`}
+          type="button"
+          onClick={() => setActiveTab('versions')}
+        >
+          Versions
+        </button>
+      </div>
+
+      {activeTab === 'files' ? (
+        <Suspense fallback={<div className="tab-body stat">Loading file viewer…</div>}>
+          <SkillFilesPanel
+            versionId={latestVersionId}
+            readmeContent={readmeContent}
+            readmeError={readmeError}
+            latestFiles={latestFiles}
+          />
+        </Suspense>
+      ) : null}
+
+      {activeTab === 'compare' ? (
+        <div className="tab-body">
+          <Suspense fallback={<div className="stat">Loading diff viewer…</div>}>
+            <SkillDiffCard skill={skill} versions={diffVersions ?? []} variant="embedded" />
+          </Suspense>
+        </div>
+      ) : null}
+
+      {activeTab === 'versions' ? (
+        <SkillVersionsPanel versions={versions} nixPlugin={nixPlugin} skillSlug={skill.slug} />
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/SkillFilesPanel.tsx
+++ b/src/components/SkillFilesPanel.tsx
@@ -1,0 +1,164 @@
+import { useAction } from 'convex/react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { api } from '../../convex/_generated/api'
+import type { Doc, Id } from '../../convex/_generated/dataModel'
+import { formatBytes } from './skillDetailUtils'
+
+type SkillFile = Doc<'skillVersions'>['files'][number]
+
+type SkillFilesPanelProps = {
+  versionId: Id<'skillVersions'> | null
+  readmeContent: string | null
+  readmeError: string | null
+  latestFiles: SkillFile[]
+}
+
+export function SkillFilesPanel({
+  versionId,
+  readmeContent,
+  readmeError,
+  latestFiles,
+}: SkillFilesPanelProps) {
+  const getFileText = useAction(api.skills.getFileText)
+  const [selectedPath, setSelectedPath] = useState<string | null>(null)
+  const [fileContent, setFileContent] = useState<string | null>(null)
+  const [fileMeta, setFileMeta] = useState<{ size: number; sha256: string } | null>(null)
+  const [fileError, setFileError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const isMounted = useRef(true)
+  const requestId = useRef(0)
+  const fileCache = useRef(new Map<string, { text: string; size: number; sha256: string }>())
+
+  useEffect(() => {
+    isMounted.current = true
+    return () => {
+      isMounted.current = false
+      requestId.current += 1
+    }
+  }, [])
+
+  useEffect(() => {
+    requestId.current += 1
+
+    setSelectedPath(null)
+    setFileContent(null)
+    setFileMeta(null)
+    setFileError(null)
+    setIsLoading(false)
+
+    if (versionId === null) return
+  }, [versionId])
+
+  const handleSelect = useCallback(
+    (path: string) => {
+      if (!versionId) return
+      const cacheKey = `${versionId}:${path}`
+      const cached = fileCache.current.get(cacheKey)
+
+      requestId.current += 1
+      const current = requestId.current
+      setSelectedPath(path)
+      setFileError(null)
+      if (cached) {
+        setFileContent(cached.text)
+        setFileMeta({ size: cached.size, sha256: cached.sha256 })
+        setIsLoading(false)
+        return
+      }
+
+      setFileContent(null)
+      setFileMeta(null)
+      setIsLoading(true)
+      void getFileText({ versionId, path })
+        .then((data) => {
+          if (!isMounted.current) return
+          if (requestId.current !== current) return
+          fileCache.current.set(cacheKey, data)
+          setFileContent(data.text)
+          setFileMeta({ size: data.size, sha256: data.sha256 })
+          setIsLoading(false)
+        })
+        .catch((error) => {
+          if (!isMounted.current) return
+          if (requestId.current !== current) return
+          setFileError(error instanceof Error ? error.message : 'Failed to load file')
+          setIsLoading(false)
+        })
+    },
+    [getFileText, versionId],
+  )
+
+  return (
+    <div className="tab-body">
+      <div>
+        <h2 className="section-title" style={{ fontSize: '1.2rem', margin: 0 }}>
+          SKILL.md
+        </h2>
+        <div className="markdown">
+          {readmeContent ? (
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>{readmeContent}</ReactMarkdown>
+          ) : readmeError ? (
+            <div className="stat">Failed to load SKILL.md: {readmeError}</div>
+          ) : (
+            <div>Loading…</div>
+          )}
+        </div>
+      </div>
+      <div className="file-browser">
+        <div className="file-list">
+          <div className="file-list-header">
+            <h3 className="section-title" style={{ fontSize: '1.05rem', margin: 0 }}>
+              Files
+            </h3>
+            <span className="section-subtitle" style={{ margin: 0 }}>
+              {latestFiles.length} total
+            </span>
+          </div>
+          <div className="file-list-body">
+            {latestFiles.length === 0 ? (
+              <div className="stat">No files available.</div>
+            ) : (
+              latestFiles.map((file) => (
+                <button
+                  key={file.path}
+                  className={`file-row file-row-button${
+                    selectedPath === file.path ? ' is-active' : ''
+                  }`}
+                  type="button"
+                  onClick={() => handleSelect(file.path)}
+                  aria-current={selectedPath === file.path ? 'true' : undefined}
+                >
+                  <span className="file-path">{file.path}</span>
+                  <span className="file-meta">{formatBytes(file.size)}</span>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+        <div className="file-viewer">
+          <div className="file-viewer-header">
+            <div className="file-path">{selectedPath ?? 'Select a file'}</div>
+            {fileMeta ? (
+              <span className="file-meta">
+                {formatBytes(fileMeta.size)} · {fileMeta.sha256.slice(0, 12)}…
+              </span>
+            ) : null}
+          </div>
+          <div className="file-viewer-body">
+            {isLoading ? (
+              <div className="stat">Loading…</div>
+            ) : fileError ? (
+              <div className="stat">Failed to load file: {fileError}</div>
+            ) : fileContent ? (
+              <pre className="file-viewer-code">{fileContent}</pre>
+            ) : (
+              <div className="stat">Select a file to preview.</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -1,0 +1,365 @@
+import { Link } from '@tanstack/react-router'
+import type { ClawdisSkillMetadata } from 'clawhub-schema'
+import type { Doc, Id } from '../../convex/_generated/dataModel'
+import { getSkillBadges } from '../lib/badges'
+import { formatCompactStat, formatSkillStatsTriplet } from '../lib/numberFormat'
+import type { PublicSkill, PublicUser } from '../lib/publicUser'
+import { type LlmAnalysis, SecurityScanResults } from './SkillSecurityScanResults'
+import { SkillInstallCard } from './SkillInstallCard'
+import { UserBadge } from './UserBadge'
+
+export type SkillModerationInfo = {
+  isPendingScan: boolean
+  isMalwareBlocked: boolean
+  isSuspicious: boolean
+  isHiddenByMod: boolean
+  isRemoved: boolean
+  reason?: string
+}
+
+type SkillFork = {
+  kind: 'fork' | 'duplicate'
+  version: string | null
+  skill: { slug: string; displayName: string }
+  owner: { handle: string | null; userId: Id<'users'> | null }
+}
+
+type SkillCanonical = {
+  skill: { slug: string; displayName: string }
+  owner: { handle: string | null; userId: Id<'users'> | null }
+}
+
+type SkillHeaderProps = {
+  skill: Doc<'skills'> | PublicSkill
+  owner: Doc<'users'> | PublicUser | null
+  ownerHandle: string | null
+  latestVersion: Doc<'skillVersions'> | null
+  modInfo: SkillModerationInfo | null
+  canManage: boolean
+  isAuthenticated: boolean
+  isStaff: boolean
+  isStarred: boolean | undefined
+  onToggleStar: () => void
+  onOpenReport: () => void
+  forkOf: SkillFork | null
+  forkOfLabel: string
+  forkOfHref: string | null
+  forkOfOwnerHandle: string | null
+  canonical: SkillCanonical | null
+  canonicalHref: string | null
+  canonicalOwnerHandle: string | null
+  staffModerationNote: string | null
+  staffVisibilityTag: string | null
+  isAutoHidden: boolean
+  isRemoved: boolean
+  nixPlugin: string | undefined
+  hasPluginBundle: boolean
+  configRequirements: ClawdisSkillMetadata['config'] | undefined
+  cliHelp: string | undefined
+  tagEntries: Array<[string, Id<'skillVersions'>]>
+  versionById: Map<Id<'skillVersions'>, Doc<'skillVersions'>>
+  tagName: string
+  onTagNameChange: (value: string) => void
+  tagVersionId: Id<'skillVersions'> | ''
+  onTagVersionChange: (value: Id<'skillVersions'> | '') => void
+  onTagSubmit: () => void
+  tagVersions: Doc<'skillVersions'>[]
+  clawdis: ClawdisSkillMetadata | undefined
+  osLabels: string[]
+}
+
+export function SkillHeader({
+  skill,
+  owner,
+  ownerHandle,
+  latestVersion,
+  modInfo,
+  canManage,
+  isAuthenticated,
+  isStaff,
+  isStarred,
+  onToggleStar,
+  onOpenReport,
+  forkOf,
+  forkOfLabel,
+  forkOfHref,
+  forkOfOwnerHandle,
+  canonical,
+  canonicalHref,
+  canonicalOwnerHandle,
+  staffModerationNote,
+  staffVisibilityTag,
+  isAutoHidden,
+  isRemoved,
+  nixPlugin,
+  hasPluginBundle,
+  configRequirements,
+  cliHelp,
+  tagEntries,
+  versionById,
+  tagName,
+  onTagNameChange,
+  tagVersionId,
+  onTagVersionChange,
+  onTagSubmit,
+  tagVersions,
+  clawdis,
+  osLabels,
+}: SkillHeaderProps) {
+  const formattedStats = formatSkillStatsTriplet(skill.stats)
+
+  return (
+    <>
+      {modInfo?.isPendingScan ? (
+        <div className="pending-banner">
+          <div className="pending-banner-content">
+            <strong>Security scan in progress</strong>
+            <p>
+              Your skill is being scanned by VirusTotal. It will be visible to others once the scan
+              completes. This usually takes up to 5 minutes — grab a coffee or exfoliate your shell
+              while you wait.
+            </p>
+          </div>
+        </div>
+      ) : modInfo?.isMalwareBlocked ? (
+        <div className="pending-banner pending-banner-blocked">
+          <div className="pending-banner-content">
+            <strong>Skill blocked — malicious content detected</strong>
+            <p>
+              ClawHub Security flagged this skill as malicious. Downloads are disabled. Review the
+              scan results below.
+            </p>
+          </div>
+        </div>
+      ) : modInfo?.isSuspicious ? (
+        <div className="pending-banner pending-banner-warning">
+          <div className="pending-banner-content">
+            <strong>Skill flagged — suspicious patterns detected</strong>
+            <p>ClawHub Security flagged this skill as suspicious. Review the scan results before using.</p>
+            {canManage ? (
+              <p className="pending-banner-appeal">
+                If you believe this skill has been incorrectly flagged, please{' '}
+                <a
+                  href="https://github.com/openclaw/clawhub/issues"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  submit an issue on GitHub
+                </a>{' '}
+                and we'll break down why it was flagged and what you can do.
+              </p>
+            ) : null}
+          </div>
+        </div>
+      ) : modInfo?.isRemoved ? (
+        <div className="pending-banner pending-banner-blocked">
+          <div className="pending-banner-content">
+            <strong>Skill removed by moderator</strong>
+            <p>This skill has been removed and is not visible to others.</p>
+          </div>
+        </div>
+      ) : modInfo?.isHiddenByMod ? (
+        <div className="pending-banner pending-banner-blocked">
+          <div className="pending-banner-content">
+            <strong>Skill hidden</strong>
+            <p>This skill is currently hidden and not visible to others.</p>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="card skill-hero">
+        <div className={`skill-hero-top${hasPluginBundle ? ' has-plugin' : ''}`}>
+          <div className="skill-hero-header">
+            <div className="skill-hero-title">
+              <div className="skill-hero-title-row">
+                <h1 className="section-title" style={{ margin: 0 }}>
+                  {skill.displayName}
+                </h1>
+                {nixPlugin ? <span className="tag tag-accent">Plugin bundle (nix)</span> : null}
+              </div>
+              <p className="section-subtitle">{skill.summary ?? 'No summary provided.'}</p>
+
+              {isStaff && staffModerationNote ? (
+                <div className="skill-hero-note">{staffModerationNote}</div>
+              ) : null}
+              {nixPlugin ? (
+                <div className="skill-hero-note">
+                  Bundles the skill pack, CLI binary, and config requirements in one Nix install.
+                </div>
+              ) : null}
+              <div className="stat">
+                ⭐ {formattedStats.stars} · ⤓ {formattedStats.downloads} · ⤒{' '}
+                {formatCompactStat(skill.stats.installsCurrent ?? 0)} current ·{' '}
+                {formattedStats.installsAllTime} all-time
+              </div>
+              <div className="stat">
+                <UserBadge user={owner} fallbackHandle={ownerHandle} prefix="by" size="md" showName />
+              </div>
+              {forkOf && forkOfHref ? (
+                <div className="stat">
+                  {forkOfLabel}{' '}
+                  <a href={forkOfHref}>
+                    {forkOfOwnerHandle ? `@${forkOfOwnerHandle}/` : ''}
+                    {forkOf.skill.slug}
+                  </a>
+                  {forkOf.version ? ` (based on ${forkOf.version})` : null}
+                </div>
+              ) : null}
+              {canonicalHref ? (
+                <div className="stat">
+                  canonical:{' '}
+                  <a href={canonicalHref}>
+                    {canonicalOwnerHandle ? `@${canonicalOwnerHandle}/` : ''}
+                    {canonical?.skill?.slug}
+                  </a>
+                </div>
+              ) : null}
+              {getSkillBadges(skill).map((badge) => (
+                <div key={badge} className="tag">
+                  {badge}
+                </div>
+              ))}
+              {isStaff && staffVisibilityTag ? (
+                <div className={`tag${isAutoHidden || isRemoved ? ' tag-accent' : ''}`}>
+                  {staffVisibilityTag}
+                </div>
+              ) : null}
+              <div className="skill-actions">
+                {isAuthenticated ? (
+                  <button
+                    className={`star-toggle${isStarred ? ' is-active' : ''}`}
+                    type="button"
+                    onClick={onToggleStar}
+                    aria-label={isStarred ? 'Unstar skill' : 'Star skill'}
+                  >
+                    <span aria-hidden="true">★</span>
+                  </button>
+                ) : null}
+                {isAuthenticated ? (
+                  <button className="btn btn-ghost" type="button" onClick={onOpenReport}>
+                    Report
+                  </button>
+                ) : null}
+                {isStaff ? (
+                  <Link className="btn" to="/management" search={{ skill: skill.slug }}>
+                    Manage
+                  </Link>
+                ) : null}
+              </div>
+              <SecurityScanResults
+                sha256hash={latestVersion?.sha256hash}
+                vtAnalysis={latestVersion?.vtAnalysis}
+                llmAnalysis={latestVersion?.llmAnalysis as LlmAnalysis | undefined}
+              />
+              {latestVersion?.sha256hash || latestVersion?.llmAnalysis ? (
+                <p className="scan-disclaimer">
+                  Like a lobster shell, security has layers — review code before you run it.
+                </p>
+              ) : null}
+            </div>
+            <div className="skill-hero-cta">
+              <div className="skill-version-pill">
+                <span className="skill-version-label">Current version</span>
+                <strong>v{latestVersion?.version ?? '—'}</strong>
+              </div>
+              {!nixPlugin && !modInfo?.isMalwareBlocked && !modInfo?.isRemoved ? (
+                <a
+                  className="btn btn-primary"
+                  href={`${import.meta.env.VITE_CONVEX_SITE_URL}/api/v1/download?slug=${skill.slug}`}
+                >
+                  Download zip
+                </a>
+              ) : null}
+            </div>
+          </div>
+          {hasPluginBundle ? (
+            <div className="skill-panel bundle-card">
+              <div className="bundle-header">
+                <div className="bundle-title">Plugin bundle (nix)</div>
+                <div className="bundle-subtitle">Skill pack · CLI binary · Config</div>
+              </div>
+              <div className="bundle-includes">
+                <span>SKILL.md</span>
+                <span>CLI</span>
+                <span>Config</span>
+              </div>
+              {configRequirements ? (
+                <div className="bundle-section">
+                  <div className="bundle-section-title">Config requirements</div>
+                  <div className="bundle-meta">
+                    {configRequirements.requiredEnv?.length ? (
+                      <div className="stat">
+                        <strong>Required env</strong>
+                        <span>{configRequirements.requiredEnv.join(', ')}</span>
+                      </div>
+                    ) : null}
+                    {configRequirements.stateDirs?.length ? (
+                      <div className="stat">
+                        <strong>State dirs</strong>
+                        <span>{configRequirements.stateDirs.join(', ')}</span>
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+              ) : null}
+              {cliHelp ? (
+                <details className="bundle-section bundle-details">
+                  <summary>CLI help (from plugin)</summary>
+                  <pre className="hero-install-code mono">{cliHelp}</pre>
+                </details>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+
+        <div className="skill-tag-row">
+          {tagEntries.length === 0 ? (
+            <span className="section-subtitle" style={{ margin: 0 }}>
+              No tags yet.
+            </span>
+          ) : (
+            tagEntries.map(([tag, versionId]) => (
+              <span key={tag} className="tag">
+                {tag}
+                <span className="tag-meta">v{versionById.get(versionId)?.version ?? versionId}</span>
+              </span>
+            ))
+          )}
+        </div>
+
+        {canManage ? (
+          <form
+            onSubmit={(event) => {
+              event.preventDefault()
+              onTagSubmit()
+            }}
+            className="tag-form"
+          >
+            <input
+              className="search-input"
+              value={tagName}
+              onChange={(event) => onTagNameChange(event.target.value)}
+              placeholder="latest"
+            />
+            <select
+              className="search-input"
+              value={tagVersionId ?? ''}
+              onChange={(event) => onTagVersionChange(event.target.value as Id<'skillVersions'>)}
+            >
+              {tagVersions.map((version) => (
+                <option key={version._id} value={version._id}>
+                  v{version.version}
+                </option>
+              ))}
+            </select>
+            <button className="btn" type="submit">
+              Update tag
+            </button>
+          </form>
+        ) : null}
+
+        <SkillInstallCard clawdis={clawdis} osLabels={osLabels} />
+      </div>
+    </>
+  )
+}

--- a/src/components/SkillInstallCard.tsx
+++ b/src/components/SkillInstallCard.tsx
@@ -1,0 +1,132 @@
+import type { ClawdisSkillMetadata } from 'clawhub-schema'
+import { formatInstallCommand, formatInstallLabel } from './skillDetailUtils'
+
+const CAPABILITY_DISPLAY: Record<string, { icon: string; label: string }> = {
+  shell: { icon: '>_', label: 'Shell commands' },
+  filesystem: { icon: '\uD83D\uDCC2', label: 'File access' },
+  network: { icon: '\uD83C\uDF10', label: 'Network requests' },
+  browser: { icon: '\uD83D\uDD0D', label: 'Browser control' },
+  sessions: { icon: '\u26A1', label: 'Session orchestration' },
+}
+
+type SkillInstallCardProps = {
+  clawdis: ClawdisSkillMetadata | undefined
+  osLabels: string[]
+}
+
+export function SkillInstallCard({ clawdis, osLabels }: SkillInstallCardProps) {
+  const requirements = clawdis?.requires
+  const installSpecs = clawdis?.install ?? []
+  const hasRuntimeRequirements = Boolean(
+    clawdis?.emoji ||
+      osLabels.length ||
+      requirements?.bins?.length ||
+      requirements?.anyBins?.length ||
+      requirements?.env?.length ||
+      requirements?.config?.length ||
+      clawdis?.primaryEnv,
+  )
+  const hasInstallSpecs = installSpecs.length > 0
+  const hasCapabilities = Boolean(clawdis?.capabilities?.length)
+
+  return (
+    <div className="skill-hero-content">
+      <div className="skill-hero-panels">
+        {hasCapabilities ? (
+          <div className="skill-panel">
+            <h3 className="section-title" style={{ fontSize: '1rem', margin: 0 }}>
+              Capabilities
+            </h3>
+            <div className="skill-panel-body">
+              {clawdis!.capabilities!.map((cap) => (
+                <div key={cap} className="stat">
+                  <span>{CAPABILITY_DISPLAY[cap]?.icon ?? cap}</span>
+                  <span>{CAPABILITY_DISPLAY[cap]?.label ?? cap}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="skill-panel">
+            <div className="skill-panel-body">
+              <div className="stat" style={{ color: 'var(--ink-soft)' }}>
+                <span>No capabilities declared</span>
+              </div>
+            </div>
+          </div>
+        )}
+        {hasRuntimeRequirements ? (
+          <div className="skill-panel">
+            <h3 className="section-title" style={{ fontSize: '1rem', margin: 0 }}>
+              Runtime requirements
+            </h3>
+            <div className="skill-panel-body">
+              {clawdis?.emoji ? <div className="tag">{clawdis.emoji} Clawdis</div> : null}
+              {osLabels.length ? (
+                <div className="stat">
+                  <strong>OS</strong>
+                  <span>{osLabels.join(' · ')}</span>
+                </div>
+              ) : null}
+              {requirements?.bins?.length ? (
+                <div className="stat">
+                  <strong>Bins</strong>
+                  <span>{requirements.bins.join(', ')}</span>
+                </div>
+              ) : null}
+              {requirements?.anyBins?.length ? (
+                <div className="stat">
+                  <strong>Any bin</strong>
+                  <span>{requirements.anyBins.join(', ')}</span>
+                </div>
+              ) : null}
+              {requirements?.env?.length ? (
+                <div className="stat">
+                  <strong>Env</strong>
+                  <span>{requirements.env.join(', ')}</span>
+                </div>
+              ) : null}
+              {requirements?.config?.length ? (
+                <div className="stat">
+                  <strong>Config</strong>
+                  <span>{requirements.config.join(', ')}</span>
+                </div>
+              ) : null}
+              {clawdis?.primaryEnv ? (
+                <div className="stat">
+                  <strong>Primary env</strong>
+                  <span>{clawdis.primaryEnv}</span>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+        {hasInstallSpecs ? (
+          <div className="skill-panel">
+            <h3 className="section-title" style={{ fontSize: '1rem', margin: 0 }}>
+              Install
+            </h3>
+            <div className="skill-panel-body">
+              {installSpecs.map((spec, index) => {
+                const command = formatInstallCommand(spec)
+                return (
+                  <div key={`${spec.id ?? spec.kind}-${index}`} className="stat">
+                    <div>
+                      <strong>{spec.label ?? formatInstallLabel(spec)}</strong>
+                      {spec.bins?.length ? (
+                        <div style={{ color: 'var(--ink-soft)', fontSize: '0.85rem' }}>
+                          Bins: {spec.bins.join(', ')}
+                        </div>
+                      ) : null}
+                      {command ? <code>{command}</code> : null}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/components/SkillReportDialog.tsx
+++ b/src/components/SkillReportDialog.tsx
@@ -1,0 +1,3 @@
+export function SkillReportDialog(_props: { slug: string; open: boolean; onClose: () => void }) {
+  return null
+}

--- a/src/components/SkillSecurityScanResults.tsx
+++ b/src/components/SkillSecurityScanResults.tsx
@@ -1,0 +1,293 @@
+import { useState } from 'react'
+
+type LlmAnalysisDimension = {
+  name: string
+  label: string
+  rating: string
+  detail: string
+}
+
+export type VtAnalysis = {
+  status: string
+  verdict?: string
+  analysis?: string
+  source?: string
+  checkedAt: number
+}
+
+export type LlmAnalysis = {
+  status: string
+  verdict?: string
+  confidence?: string
+  summary?: string
+  dimensions?: LlmAnalysisDimension[]
+  guidance?: string
+  findings?: string
+  model?: string
+  checkedAt: number
+}
+
+type SecurityScanResultsProps = {
+  sha256hash?: string
+  vtAnalysis?: VtAnalysis | null
+  llmAnalysis?: LlmAnalysis | null
+  variant?: 'panel' | 'badge'
+}
+
+function VirusTotalIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      width="1em"
+      height="1em"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 100 89"
+      aria-label="VirusTotal"
+    >
+      <title>VirusTotal</title>
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M45.292 44.5 0 89h100V0H0l45.292 44.5zM90 80H22l35.987-35.2L22 9h68v71z"
+      />
+    </svg>
+  )
+}
+
+function OpenClawIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      width="1em"
+      height="1em"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-label="OpenClaw"
+    >
+      <title>OpenClaw</title>
+      <path
+        d="M12 2C8.5 2 5.5 4 4 7c-2 4-1 8 2 11 1.5 1.5 3.5 2.5 6 2.5s4.5-1 6-2.5c3-3 4-7 2-11-1.5-3-4.5-5-8-5z"
+        fill="currentColor"
+        opacity="0.2"
+      />
+      <path
+        d="M9 8c1-2 3-3 5-2s3 3 2 5l-3 4-2-1 3-4c.5-1 0-2-1-2.5S11 7 10.5 8L8 12l-2-1 3-4z"
+        fill="currentColor"
+      />
+      <path
+        d="M15 8c-1-2-3-3-5-2s-3 3-2 5l3 4 2-1-3-4c-.5-1 0-2 1-2.5S14 7 14.5 8L17 12l2-1-4-3z"
+        fill="currentColor"
+        opacity="0.6"
+      />
+    </svg>
+  )
+}
+
+function getScanStatusInfo(status: string) {
+  switch (status.toLowerCase()) {
+    case 'benign':
+    case 'clean':
+      return { label: 'Benign', className: 'scan-status-clean' }
+    case 'malicious':
+      return { label: 'Malicious', className: 'scan-status-malicious' }
+    case 'suspicious':
+      return { label: 'Suspicious', className: 'scan-status-suspicious' }
+    case 'loading':
+      return { label: 'Loading...', className: 'scan-status-pending' }
+    case 'pending':
+    case 'not_found':
+      return { label: 'Pending', className: 'scan-status-pending' }
+    case 'error':
+    case 'failed':
+      return { label: 'Error', className: 'scan-status-error' }
+    default:
+      return { label: status, className: 'scan-status-unknown' }
+  }
+}
+
+function getDimensionIcon(rating: string) {
+  switch (rating) {
+    case 'ok':
+      return { className: 'dimension-icon-ok', symbol: '\u2713' }
+    case 'note':
+      return { className: 'dimension-icon-note', symbol: '\u2139' }
+    case 'concern':
+      return { className: 'dimension-icon-concern', symbol: '!' }
+    default:
+      return { className: 'dimension-icon-danger', symbol: '\u2717' }
+  }
+}
+
+function LlmAnalysisDetail({ analysis }: { analysis: LlmAnalysis }) {
+  const verdict = analysis.verdict ?? analysis.status
+  const [isOpen, setIsOpen] = useState(false)
+
+  const guidanceClass =
+    verdict === 'malicious' ? 'malicious' : verdict === 'suspicious' ? 'suspicious' : 'benign'
+
+  return (
+    <div className={`analysis-detail${isOpen ? ' is-open' : ''}`}>
+      <button
+        type="button"
+        className="analysis-detail-header"
+        onClick={() => {
+          const selection = window.getSelection()
+          if (selection && !selection.isCollapsed) return
+          setIsOpen((prev) => !prev)
+        }}
+        aria-expanded={isOpen}
+      >
+        <span className="analysis-summary-text">{analysis.summary}</span>
+        <span className="analysis-detail-toggle">
+          Details <span className="chevron">{'\u25BE'}</span>
+        </span>
+      </button>
+      <div className="analysis-body">
+        {analysis.dimensions && analysis.dimensions.length > 0 ? (
+          <div className="analysis-dimensions">
+            {analysis.dimensions.map((dim) => {
+              const icon = getDimensionIcon(dim.rating)
+              return (
+                <div key={dim.name} className="dimension-row">
+                  <div className={`dimension-icon ${icon.className}`}>{icon.symbol}</div>
+                  <div className="dimension-content">
+                    <div className="dimension-label">{dim.label}</div>
+                    <div className="dimension-detail">{dim.detail}</div>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        ) : null}
+        {analysis.findings ? (
+          <div className="scan-findings-section">
+            <div className="scan-findings-title">Scan Findings in Context</div>
+            {(() => {
+              const counts = new Map<string, number>()
+              return analysis.findings.split('\n').map((line) => {
+                const count = (counts.get(line) ?? 0) + 1
+                counts.set(line, count)
+                return (
+                  <div key={`${line}-${count}`} className="scan-finding-row">
+                    {line}
+                  </div>
+                )
+              })
+            })()}
+          </div>
+        ) : null}
+        {analysis.guidance ? (
+          <div className={`analysis-guidance ${guidanceClass}`}>
+            <div className="analysis-guidance-label">
+              {verdict === 'malicious'
+                ? 'Do not install this skill'
+                : verdict === 'suspicious'
+                  ? 'What to consider before installing'
+                  : 'Assessment'}
+            </div>
+            {analysis.guidance}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+export function SecurityScanResults({
+  sha256hash,
+  vtAnalysis,
+  llmAnalysis,
+  variant = 'panel',
+}: SecurityScanResultsProps) {
+  if (!sha256hash && !llmAnalysis) return null
+
+  const vtStatus = vtAnalysis?.status ?? 'pending'
+  const vtUrl = sha256hash ? `https://www.virustotal.com/gui/file/${sha256hash}` : null
+  const vtStatusInfo = getScanStatusInfo(vtStatus)
+  const isCodeInsight = vtAnalysis?.source === 'code_insight'
+  const aiAnalysis = vtAnalysis?.analysis
+
+  const llmVerdict = llmAnalysis?.verdict ?? llmAnalysis?.status
+  const llmStatusInfo = llmVerdict ? getScanStatusInfo(llmVerdict) : null
+
+  if (variant === 'badge') {
+    return (
+      <>
+        {sha256hash ? (
+          <div className="version-scan-badge">
+            <VirusTotalIcon className="version-scan-icon version-scan-icon-vt" />
+            <span className={vtStatusInfo.className}>{vtStatusInfo.label}</span>
+            {vtUrl ? (
+              <a
+                href={vtUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="version-scan-link"
+                onClick={(event) => event.stopPropagation()}
+              >
+                ↗
+              </a>
+            ) : null}
+          </div>
+        ) : null}
+        {llmStatusInfo ? (
+          <div className="version-scan-badge">
+            <OpenClawIcon className="version-scan-icon version-scan-icon-oc" />
+            <span className={llmStatusInfo.className}>{llmStatusInfo.label}</span>
+          </div>
+        ) : null}
+      </>
+    )
+  }
+
+  return (
+    <div className="scan-results-panel">
+      <div className="scan-results-title">Security Scan</div>
+      <div className="scan-results-list">
+        {sha256hash ? (
+          <div className="scan-result-row">
+            <div className="scan-result-scanner">
+              <VirusTotalIcon className="scan-result-icon scan-result-icon-vt" />
+              <span className="scan-result-scanner-name">VirusTotal</span>
+            </div>
+            <div className={`scan-result-status ${vtStatusInfo.className}`}>{vtStatusInfo.label}</div>
+            {vtUrl ? (
+              <a
+                href={vtUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="scan-result-link"
+              >
+                View report →
+              </a>
+            ) : null}
+          </div>
+        ) : null}
+        {isCodeInsight && aiAnalysis && (vtStatus === 'malicious' || vtStatus === 'suspicious') ? (
+          <div className={`code-insight-analysis ${vtStatus}`}>
+            <div className="code-insight-label">Code Insight</div>
+            <p className="code-insight-text">{aiAnalysis}</p>
+          </div>
+        ) : null}
+        {llmStatusInfo && llmAnalysis ? (
+          <div className="scan-result-row">
+            <div className="scan-result-scanner">
+              <OpenClawIcon className="scan-result-icon scan-result-icon-oc" />
+              <span className="scan-result-scanner-name">OpenClaw</span>
+            </div>
+            <div className={`scan-result-status ${llmStatusInfo.className}`}>{llmStatusInfo.label}</div>
+            {llmAnalysis.confidence ? (
+              <span className="scan-result-confidence">{llmAnalysis.confidence} confidence</span>
+            ) : null}
+          </div>
+        ) : null}
+        {llmAnalysis &&
+        llmAnalysis.status !== 'error' &&
+        llmAnalysis.status !== 'pending' &&
+        llmAnalysis.summary ? (
+          <LlmAnalysisDetail analysis={llmAnalysis} />
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/components/SkillStats.tsx
+++ b/src/components/SkillStats.tsx
@@ -1,0 +1,26 @@
+import { formatSkillStatsTriplet, type SkillStatsTriplet } from '../lib/numberFormat'
+
+type SkillMetricsStats = SkillStatsTriplet & {
+  versions: number
+}
+
+export function SkillStatsTripletLine({ stats }: { stats: SkillStatsTriplet }) {
+  const formatted = formatSkillStatsTriplet(stats)
+  return (
+    <>
+      ⭐ {formatted.stars} · ⤓ {formatted.downloads} · ⤒ {formatted.installsAllTime}
+    </>
+  )
+}
+
+export function SkillMetricsRow({ stats }: { stats: SkillMetricsStats }) {
+  const formatted = formatSkillStatsTriplet(stats)
+  return (
+    <>
+      <span>⤓ {formatted.downloads}</span>
+      <span>⤒ {formatted.installsAllTime}</span>
+      <span>★ {formatted.stars}</span>
+      <span>{stats.versions} v</span>
+    </>
+  )
+}

--- a/src/components/SkillVersionsPanel.tsx
+++ b/src/components/SkillVersionsPanel.tsx
@@ -1,0 +1,3 @@
+export function SkillVersionsPanel(_props: { skillId?: string }) {
+  return <div className="skill-panel"><p style={{ color: 'var(--ink-soft)' }}>Versions not available in dev mode.</p></div>
+}

--- a/src/components/UserBadge.tsx
+++ b/src/components/UserBadge.tsx
@@ -1,0 +1,8 @@
+export function UserBadge({ handle, displayName, image }: { handle?: string | null; displayName?: string | null; image?: string | null }) {
+  return (
+    <span className="user-badge">
+      {image ? <img src={image} alt="" style={{ width: 20, height: 20, borderRadius: '50%', marginRight: 4 }} /> : null}
+      <span>{displayName ?? handle ?? 'Unknown'}</span>
+    </span>
+  )
+}

--- a/src/components/skillDetailUtils.ts
+++ b/src/components/skillDetailUtils.ts
@@ -1,0 +1,63 @@
+import type { SkillInstallSpec, NixPluginSpec } from 'clawhub-schema'
+
+const OS_LABELS: Record<string, string> = {
+  macos: 'macOS',
+  linux: 'Linux',
+  windows: 'Windows',
+}
+
+export function formatOsList(os?: string[]): string[] {
+  if (!os?.length) return []
+  return os.map((o) => OS_LABELS[o.toLowerCase()] ?? o)
+}
+
+export function stripFrontmatter(content: string): string {
+  const normalized = content.replace(/\r\n/g, '\n')
+  if (!normalized.startsWith('---')) return content
+  const endIndex = normalized.indexOf('\n---', 3)
+  if (endIndex === -1) return content
+  return normalized.slice(endIndex + 4).trimStart()
+}
+
+export function buildSkillHref(slug: string, ownerHandle?: string | null): string {
+  const owner = ownerHandle?.trim() || '_'
+  return `/${encodeURIComponent(owner)}/${encodeURIComponent(slug)}`
+}
+
+export function formatInstallLabel(spec: SkillInstallSpec): string {
+  if (spec.label) return spec.label
+  if (spec.kind === 'brew') return spec.formula ?? 'Homebrew'
+  if (spec.kind === 'node') return spec.package ?? 'npm'
+  if (spec.kind === 'go') return spec.module ?? 'Go'
+  if (spec.kind === 'uv') return spec.package ?? 'uv'
+  return spec.kind
+}
+
+export function formatInstallCommand(spec: SkillInstallSpec): string | null {
+  if (spec.kind === 'brew') {
+    const tap = spec.tap ? `brew tap ${spec.tap} && ` : ''
+    return `${tap}brew install ${spec.formula ?? ''}`
+  }
+  if (spec.kind === 'node') return `npm install -g ${spec.package ?? ''}`
+  if (spec.kind === 'go') return `go install ${spec.module ?? ''}`
+  if (spec.kind === 'uv') return `uv tool install ${spec.package ?? ''}`
+  return null
+}
+
+export function formatConfigSnippet(config: { requiredEnv?: string[]; stateDirs?: string[]; example?: string }): string {
+  const lines: string[] = []
+  if (config.requiredEnv?.length) lines.push(`Required env: ${config.requiredEnv.join(', ')}`)
+  if (config.stateDirs?.length) lines.push(`State dirs: ${config.stateDirs.join(', ')}`)
+  if (config.example) lines.push(`Example:\n${config.example}`)
+  return lines.join('\n')
+}
+
+export function formatNixInstallSnippet(nix: NixPluginSpec): string {
+  return `nix profile install ${nix.plugin}`
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}

--- a/src/lib/numberFormat.ts
+++ b/src/lib/numberFormat.ts
@@ -1,0 +1,19 @@
+export type SkillStatsTriplet = { label: string; value: string }
+
+export function formatCompactStat(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return String(n)
+}
+
+export function formatSkillStatsTriplet(stats: {
+  downloads?: number
+  installs?: number
+  stars?: number
+}): SkillStatsTriplet[] {
+  return [
+    { label: 'Downloads', value: formatCompactStat(stats.downloads ?? 0) },
+    { label: 'Installs', value: formatCompactStat(stats.installs ?? 0) },
+    { label: 'Stars', value: formatCompactStat(stats.stars ?? 0) },
+  ]
+}

--- a/src/lib/skillPageEntries.ts
+++ b/src/lib/skillPageEntries.ts
@@ -1,0 +1,28 @@
+import type { PublicSkill } from './publicUser'
+
+type SkillPageEntry = {
+  skill?: PublicSkill | null
+}
+
+function normalizeSkillStats(skill: PublicSkill): PublicSkill {
+  const stats = skill.stats
+  return {
+    ...skill,
+    stats: {
+      downloads: stats?.downloads ?? 0,
+      stars: stats?.stars ?? 0,
+      installsCurrent: stats?.installsCurrent ?? 0,
+      installsAllTime: stats?.installsAllTime ?? 0,
+      versions: stats?.versions ?? 0,
+      comments: stats?.comments ?? 0,
+    },
+  }
+}
+
+export function mapPublicSkillPageEntries(page: SkillPageEntry[] | undefined): PublicSkill[] {
+  if (!page?.length) return []
+  return page
+    .map((entry) => entry.skill ?? null)
+    .filter((skill): skill is PublicSkill => skill !== null)
+    .map(normalizeSkillStats)
+}

--- a/src/routes/skills/-SkillsResults.tsx
+++ b/src/routes/skills/-SkillsResults.tsx
@@ -1,0 +1,131 @@
+import { Link } from '@tanstack/react-router'
+import type { RefObject } from 'react'
+import { SkillCard } from '../../components/SkillCard'
+import { SkillMetricsRow, SkillStatsTripletLine } from '../../components/SkillStats'
+import { UserBadge } from '../../components/UserBadge'
+import { getSkillBadges } from '../../lib/badges'
+import { buildSkillHref, type SkillListEntry } from './-types'
+
+type SkillsResultsProps = {
+  isLoadingSkills: boolean
+  sorted: SkillListEntry[]
+  view: 'cards' | 'list'
+  paginationStatus: 'LoadingFirstPage' | 'CanLoadMore' | 'LoadingMore' | 'Exhausted'
+  hasQuery: boolean
+  canLoadMore: boolean
+  isLoadingMore: boolean
+  canAutoLoad: boolean
+  loadMoreRef: RefObject<HTMLDivElement | null>
+  loadMore: () => void
+}
+
+export function SkillsResults({
+  isLoadingSkills,
+  sorted,
+  view,
+  paginationStatus,
+  hasQuery,
+  canLoadMore,
+  isLoadingMore,
+  canAutoLoad,
+  loadMoreRef,
+  loadMore,
+}: SkillsResultsProps) {
+  return (
+    <>
+      {isLoadingSkills ? (
+        <div className="card">
+          <div className="loading-indicator">Loading skills…</div>
+        </div>
+      ) : sorted.length === 0 ? (
+        <div className="card">
+          {paginationStatus === 'Exhausted' || hasQuery
+            ? 'No skills match that filter.'
+            : 'Loading skills…'}
+        </div>
+      ) : view === 'cards' ? (
+        <div className="grid">
+          {sorted.map((entry) => {
+            const skill = entry.skill
+            const isPlugin = Boolean(entry.latestVersion?.parsed?.clawdis?.nix?.plugin)
+            const ownerHandle = entry.owner?.handle ?? entry.owner?.name ?? entry.ownerHandle ?? null
+            const skillHref = buildSkillHref(skill, ownerHandle)
+            return (
+              <SkillCard
+                key={skill._id}
+                skill={skill}
+                href={skillHref}
+                badge={getSkillBadges(skill)}
+                chip={isPlugin ? 'Plugin bundle (nix)' : undefined}
+                summaryFallback="Agent-ready skill pack."
+                meta={
+                  <div className="skill-card-footer-rows">
+                    <UserBadge user={entry.owner} fallbackHandle={ownerHandle} prefix="by" link={false} />
+                    <div className="stat">
+                      <SkillStatsTripletLine stats={skill.stats} />
+                    </div>
+                  </div>
+                }
+              />
+            )
+          })}
+        </div>
+      ) : (
+        <div className="skills-list">
+          {sorted.map((entry) => {
+            const skill = entry.skill
+            const isPlugin = Boolean(entry.latestVersion?.parsed?.clawdis?.nix?.plugin)
+            const ownerHandle = entry.owner?.handle ?? entry.owner?.name ?? entry.ownerHandle ?? null
+            const skillHref = buildSkillHref(skill, ownerHandle)
+            return (
+              <Link key={skill._id} className="skills-row" to={skillHref}>
+                <div className="skills-row-main">
+                  <div className="skills-row-title">
+                    <span>{skill.displayName}</span>
+                    <span className="skills-row-slug">/{skill.slug}</span>
+                    {getSkillBadges(skill).map((badge) => (
+                      <span key={badge} className="tag">
+                        {badge}
+                      </span>
+                    ))}
+                    {isPlugin ? <span className="tag tag-accent tag-compact">Plugin bundle (nix)</span> : null}
+                  </div>
+                  <div className="skills-row-summary">{skill.summary ?? 'No summary provided.'}</div>
+                  <div className="skills-row-owner">
+                    <UserBadge user={entry.owner} fallbackHandle={ownerHandle} prefix="by" link={false} />
+                  </div>
+                  {isPlugin ? (
+                    <div className="skills-row-meta">Bundle includes SKILL.md, CLI, and config.</div>
+                  ) : null}
+                </div>
+                <div className="skills-row-metrics">
+                  <SkillMetricsRow stats={skill.stats} />
+                </div>
+              </Link>
+            )
+          })}
+        </div>
+      )}
+
+      {canLoadMore || isLoadingMore ? (
+        <div
+          ref={canAutoLoad ? loadMoreRef : null}
+          className="card"
+          style={{ marginTop: 16, display: 'flex', justifyContent: 'center' }}
+        >
+          {canAutoLoad ? (
+            isLoadingMore ? (
+              'Loading more…'
+            ) : (
+              'Scroll to load more'
+            )
+          ) : (
+            <button className="btn" type="button" onClick={loadMore} disabled={isLoadingMore}>
+              {isLoadingMore ? 'Loading…' : 'Load more'}
+            </button>
+          )}
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/src/routes/skills/-SkillsToolbar.tsx
+++ b/src/routes/skills/-SkillsToolbar.tsx
@@ -1,0 +1,92 @@
+import type { RefObject } from 'react'
+import { type SortDir, type SortKey } from './-params'
+
+type SkillsToolbarProps = {
+  searchInputRef: RefObject<HTMLInputElement | null>
+  query: string
+  hasQuery: boolean
+  sort: SortKey
+  dir: SortDir
+  view: 'cards' | 'list'
+  highlightedOnly: boolean
+  nonSuspiciousOnly: boolean
+  onQueryChange: (next: string) => void
+  onToggleHighlighted: () => void
+  onToggleNonSuspicious: () => void
+  onSortChange: (value: string) => void
+  onToggleDir: () => void
+  onToggleView: () => void
+}
+
+export function SkillsToolbar({
+  searchInputRef,
+  query,
+  hasQuery,
+  sort,
+  dir,
+  view,
+  highlightedOnly,
+  nonSuspiciousOnly,
+  onQueryChange,
+  onToggleHighlighted,
+  onToggleNonSuspicious,
+  onSortChange,
+  onToggleDir,
+  onToggleView,
+}: SkillsToolbarProps) {
+  return (
+    <div className="skills-toolbar">
+      <div className="skills-search">
+        <input
+          ref={searchInputRef}
+          className="skills-search-input"
+          value={query}
+          onChange={(event) => onQueryChange(event.target.value)}
+          placeholder="Filter by name, slug, or summary…"
+        />
+      </div>
+      <div className="skills-toolbar-row">
+        <button
+          className={`search-filter-button${highlightedOnly ? ' is-active' : ''}`}
+          type="button"
+          aria-pressed={highlightedOnly}
+          onClick={onToggleHighlighted}
+        >
+          Highlighted
+        </button>
+        <button
+          className={`search-filter-button${nonSuspiciousOnly ? ' is-active' : ''}`}
+          type="button"
+          aria-pressed={nonSuspiciousOnly}
+          onClick={onToggleNonSuspicious}
+        >
+          Hide suspicious
+        </button>
+        <select
+          className="skills-sort"
+          value={sort}
+          onChange={(event) => onSortChange(event.target.value)}
+          aria-label="Sort skills"
+        >
+          {hasQuery ? <option value="relevance">Relevance</option> : null}
+          <option value="newest">Newest</option>
+          <option value="updated">Recently updated</option>
+          <option value="downloads">Downloads</option>
+          <option value="installs">Installs</option>
+          <option value="stars">Stars</option>
+          <option value="name">Name</option>
+        </select>
+        <button className="skills-dir" type="button" aria-label={`Sort direction ${dir}`} onClick={onToggleDir}>
+          {dir === 'asc' ? '↑' : '↓'}
+        </button>
+        <button
+          className={`skills-view${view === 'cards' ? ' is-active' : ''}`}
+          type="button"
+          onClick={onToggleView}
+        >
+          {view === 'cards' ? 'List' : 'Cards'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/routes/skills/-params.ts
+++ b/src/routes/skills/-params.ts
@@ -1,0 +1,9 @@
+export type SortKey = 'relevance' | 'newest' | 'updated' | 'downloads' | 'installs' | 'stars' | 'name'
+export type SortDir = 'asc' | 'desc'
+
+const VALID_SORTS = new Set<SortKey>(['relevance', 'newest', 'updated', 'downloads', 'installs', 'stars', 'name'])
+
+export function parseSort(raw: string): SortKey | undefined {
+  const normalized = raw.trim().toLowerCase()
+  return VALID_SORTS.has(normalized as SortKey) ? (normalized as SortKey) : undefined
+}

--- a/src/routes/skills/-types.ts
+++ b/src/routes/skills/-types.ts
@@ -1,0 +1,35 @@
+import type { Doc } from '../../../convex/_generated/dataModel'
+import type { PublicSkill, PublicUser } from '../../lib/publicUser'
+
+export type SkillListEntry = {
+  skill: PublicSkill
+  latestVersion: {
+    version: string
+    createdAt: number
+    changelog: string
+    changelogSource?: 'auto' | 'user'
+    parsed?: {
+      clawdis?: {
+        nix?: {
+          plugin?: boolean
+        }
+      }
+    }
+  } | null
+  ownerHandle?: string | null
+  owner?: PublicUser | null
+  searchScore?: number
+}
+
+export type SkillSearchEntry = {
+  skill: PublicSkill
+  version: Doc<'skillVersions'> | null
+  score: number
+  ownerHandle?: string | null
+  owner?: PublicUser | null
+}
+
+export function buildSkillHref(skill: PublicSkill, ownerHandle?: string | null) {
+  const owner = ownerHandle?.trim() || String(skill.ownerUserId)
+  return `/${encodeURIComponent(owner)}/${encodeURIComponent(skill.slug)}`
+}

--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -1,0 +1,60 @@
+import { useCallback, useRef, useState } from 'react'
+import type { RefObject } from 'react'
+import type { SortDir, SortKey } from './-params'
+import type { SkillListEntry } from './-types'
+
+type UseSkillsBrowseModelParams = {
+  navigate: (opts: { search: (prev: Record<string, unknown>) => Record<string, unknown> }) => void
+  search: {
+    q?: string
+    sort?: SortKey
+    dir?: SortDir
+    highlighted?: boolean
+    nonSuspicious?: boolean
+    view?: 'cards' | 'list'
+    focus?: string
+  }
+  searchInputRef: RefObject<HTMLInputElement | null>
+}
+
+export function useSkillsBrowseModel({ navigate, search }: UseSkillsBrowseModelParams) {
+  const query = search.q ?? ''
+  const hasQuery = Boolean(query.trim())
+  const sort: SortKey = search.sort ?? (hasQuery ? 'relevance' : 'downloads')
+  const dir: SortDir = search.dir ?? 'desc'
+  const view = search.view ?? 'cards'
+  const highlightedOnly = search.highlighted ?? false
+  const nonSuspiciousOnly = search.nonSuspicious ?? false
+
+  const updateSearch = useCallback(
+    (updates: Record<string, unknown>) => {
+      navigate({ search: (prev: Record<string, unknown>) => ({ ...prev, ...updates }) })
+    },
+    [navigate],
+  )
+
+  return {
+    query,
+    hasQuery,
+    sort,
+    dir,
+    view,
+    highlightedOnly,
+    nonSuspiciousOnly,
+    isLoadingSkills: false,
+    sorted: [] as SkillListEntry[],
+    paginationStatus: 'Exhausted' as const,
+    canLoadMore: false,
+    isLoadingMore: false,
+    canAutoLoad: false,
+    loadMoreRef: useRef<HTMLDivElement>(null),
+    activeFilters: [] as string[],
+    loadMore: () => {},
+    onQueryChange: (next: string) => updateSearch({ q: next || undefined }),
+    onToggleHighlighted: () => updateSearch({ highlighted: highlightedOnly ? undefined : true }),
+    onToggleNonSuspicious: () => updateSearch({ nonSuspicious: nonSuspiciousOnly ? undefined : true }),
+    onSortChange: (value: string) => updateSearch({ sort: value }),
+    onToggleDir: () => updateSearch({ dir: dir === 'asc' ? 'desc' : 'asc' }),
+    onToggleView: () => updateSearch({ view: view === 'cards' ? 'list' : 'cards' }),
+  }
+}

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -1,46 +1,9 @@
-import { createFileRoute, Link } from '@tanstack/react-router'
-import { useAction } from 'convex/react'
-import { usePaginatedQuery } from 'convex-helpers/react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { api } from '../../../convex/_generated/api'
-import type { Doc } from '../../../convex/_generated/dataModel'
-import { SkillCard } from '../../components/SkillCard'
-import { getSkillBadges, isSkillHighlighted } from '../../lib/badges'
-import type { PublicSkill } from '../../lib/publicUser'
-
-const sortKeys = ['newest', 'downloads', 'installs', 'stars', 'name', 'updated'] as const
-const pageSize = 25
-type SortKey = (typeof sortKeys)[number]
-type SortDir = 'asc' | 'desc'
-
-function parseSort(value: unknown): SortKey {
-  if (typeof value !== 'string') return 'newest'
-  if ((sortKeys as readonly string[]).includes(value)) return value as SortKey
-  return 'newest'
-}
-
-function parseDir(value: unknown, sort: SortKey): SortDir {
-  if (value === 'asc' || value === 'desc') return value
-  return sort === 'name' ? 'asc' : 'desc'
-}
-
-type SkillListEntry = {
-  skill: PublicSkill
-  latestVersion: Doc<'skillVersions'> | null
-  ownerHandle?: string | null
-}
-
-type SkillSearchEntry = {
-  skill: PublicSkill
-  version: Doc<'skillVersions'> | null
-  score: number
-  ownerHandle?: string | null
-}
-
-function buildSkillHref(skill: PublicSkill, ownerHandle?: string | null) {
-  const owner = ownerHandle?.trim() || String(skill.ownerUserId)
-  return `/${encodeURIComponent(owner)}/${encodeURIComponent(skill.slug)}`
-}
+import { createFileRoute, redirect } from '@tanstack/react-router'
+import { useRef } from 'react'
+import { parseSort } from './-params'
+import { SkillsResults } from './-SkillsResults'
+import { SkillsToolbar } from './-SkillsToolbar'
+import { useSkillsBrowseModel } from './-useSkillsBrowseModel'
 
 export const Route = createFileRoute('/skills/')({
   validateSearch: (search) => {
@@ -52,9 +15,32 @@ export const Route = createFileRoute('/skills/')({
         search.highlighted === '1' || search.highlighted === 'true' || search.highlighted === true
           ? true
           : undefined,
+      nonSuspicious:
+        search.nonSuspicious === '1' ||
+        search.nonSuspicious === 'true' ||
+        search.nonSuspicious === true
+          ? true
+          : undefined,
       view: search.view === 'cards' || search.view === 'list' ? search.view : undefined,
       focus: search.focus === 'search' ? 'search' : undefined,
     }
+  },
+  beforeLoad: ({ search }) => {
+    const hasQuery = Boolean(search.q?.trim())
+    if (hasQuery || search.sort) return
+    throw redirect({
+      to: '/skills',
+      search: {
+        q: search.q || undefined,
+        sort: 'downloads',
+        dir: search.dir || undefined,
+        highlighted: search.highlighted || undefined,
+        nonSuspicious: search.nonSuspicious || undefined,
+        view: search.view || undefined,
+        focus: search.focus || undefined,
+      },
+      replace: true,
+    })
   },
   component: SkillsIndex,
 })
@@ -62,361 +48,56 @@ export const Route = createFileRoute('/skills/')({
 export function SkillsIndex() {
   const navigate = Route.useNavigate()
   const search = Route.useSearch()
-  const sort = search.sort ?? 'newest'
-  const dir = parseDir(search.dir, sort)
-  const view = search.view ?? 'list'
-  const highlightedOnly = search.highlighted ?? false
-  const [query, setQuery] = useState(search.q ?? '')
-  const searchSkills = useAction(api.search.searchSkills)
-  const [searchResults, setSearchResults] = useState<Array<SkillSearchEntry>>([])
-  const [searchLimit, setSearchLimit] = useState(pageSize)
-  const [isSearching, setIsSearching] = useState(false)
-  const searchRequest = useRef(0)
-  const loadMoreRef = useRef<HTMLDivElement | null>(null)
-
   const searchInputRef = useRef<HTMLInputElement>(null)
-  const trimmedQuery = useMemo(() => query.trim(), [query])
-  const hasQuery = trimmedQuery.length > 0
-  const searchKey = trimmedQuery ? `${trimmedQuery}::${highlightedOnly ? '1' : '0'}` : ''
 
-  // Use convex-helpers usePaginatedQuery for better cache behavior
-  const {
-    results: paginatedResults,
-    status: paginationStatus,
-    loadMore: loadMorePaginated,
-  } = usePaginatedQuery(api.skills.listPublicPageV2, hasQuery ? 'skip' : {}, {
-    initialNumItems: pageSize,
+  const model = useSkillsBrowseModel({
+    navigate,
+    search,
+    searchInputRef,
   })
-
-  // Derive loading states from pagination status
-  // status: 'LoadingFirstPage' | 'CanLoadMore' | 'LoadingMore' | 'Exhausted'
-  const isLoadingList = paginationStatus === 'LoadingFirstPage'
-  const canLoadMoreList = paginationStatus === 'CanLoadMore'
-  const isLoadingMoreList = paginationStatus === 'LoadingMore'
-
-  useEffect(() => {
-    setQuery(search.q ?? '')
-  }, [search.q])
-
-  // Auto-focus search input when focus=search param is present
-  useEffect(() => {
-    if (search.focus === 'search' && searchInputRef.current) {
-      searchInputRef.current.focus()
-      // Clear the focus param from URL to avoid re-focusing on navigation
-      void navigate({ search: (prev) => ({ ...prev, focus: undefined }), replace: true })
-    }
-  }, [search.focus, navigate])
-
-  useEffect(() => {
-    if (!searchKey) {
-      setSearchResults([])
-      setIsSearching(false)
-      return
-    }
-    setSearchResults([])
-    setSearchLimit(pageSize)
-  }, [searchKey])
-
-  useEffect(() => {
-    if (!hasQuery) return
-    searchRequest.current += 1
-    const requestId = searchRequest.current
-    setIsSearching(true)
-    const handle = window.setTimeout(() => {
-      void (async () => {
-        try {
-          const data = (await searchSkills({
-            query: trimmedQuery,
-            highlightedOnly,
-            limit: searchLimit,
-          })) as Array<SkillSearchEntry>
-          if (requestId === searchRequest.current) {
-            setSearchResults(data)
-          }
-        } finally {
-          if (requestId === searchRequest.current) {
-            setIsSearching(false)
-          }
-        }
-      })()
-    }, 220)
-    return () => window.clearTimeout(handle)
-  }, [hasQuery, highlightedOnly, searchLimit, searchSkills, trimmedQuery])
-
-  const baseItems = useMemo(() => {
-    if (hasQuery) {
-      return searchResults.map((entry) => ({
-        skill: entry.skill,
-        latestVersion: entry.version,
-        ownerHandle: entry.ownerHandle ?? null,
-      }))
-    }
-    // paginatedResults is an array of page items from usePaginatedQuery
-    return paginatedResults as Array<SkillListEntry>
-  }, [hasQuery, paginatedResults, searchResults])
-
-  const filtered = useMemo(
-    () => baseItems.filter((entry) => (highlightedOnly ? isSkillHighlighted(entry.skill) : true)),
-    [baseItems, highlightedOnly],
-  )
-
-  const sorted = useMemo(() => {
-    const multiplier = dir === 'asc' ? 1 : -1
-    const results = [...filtered]
-    results.sort((a, b) => {
-      switch (sort) {
-        case 'downloads':
-          return (a.skill.stats.downloads - b.skill.stats.downloads) * multiplier
-        case 'installs':
-          return (
-            ((a.skill.stats.installsAllTime ?? 0) - (b.skill.stats.installsAllTime ?? 0)) *
-            multiplier
-          )
-        case 'stars':
-          return (a.skill.stats.stars - b.skill.stats.stars) * multiplier
-        case 'updated':
-          return (a.skill.updatedAt - b.skill.updatedAt) * multiplier
-        case 'name':
-          return (
-            (a.skill.displayName.localeCompare(b.skill.displayName) ||
-              a.skill.slug.localeCompare(b.skill.slug)) * multiplier
-          )
-        default:
-          return (a.skill.createdAt - b.skill.createdAt) * multiplier
-      }
-    })
-    return results
-  }, [dir, filtered, sort])
-
-  const isLoadingSkills = hasQuery ? isSearching && searchResults.length === 0 : isLoadingList
-  const canLoadMore = hasQuery
-    ? !isSearching && searchResults.length === searchLimit && searchResults.length > 0
-    : canLoadMoreList
-  const isLoadingMore = hasQuery ? isSearching && searchResults.length > 0 : isLoadingMoreList
-  const canAutoLoad = typeof IntersectionObserver !== 'undefined'
-
-  const loadMore = useCallback(() => {
-    if (isLoadingMore || !canLoadMore) return
-    if (hasQuery) {
-      setSearchLimit((value) => value + pageSize)
-    } else {
-      loadMorePaginated(pageSize)
-    }
-  }, [canLoadMore, hasQuery, isLoadingMore, loadMorePaginated])
-
-  useEffect(() => {
-    if (!canLoadMore || typeof IntersectionObserver === 'undefined') return
-    const target = loadMoreRef.current
-    if (!target) return
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          loadMore()
-        }
-      },
-      { rootMargin: '200px' },
-    )
-    observer.observe(target)
-    return () => observer.disconnect()
-  }, [canLoadMore, loadMore])
 
   return (
     <main className="section">
-      <header className="skills-header">
-        <div>
-          <h1 className="section-title" style={{ marginBottom: 8 }}>
-            Skills
-          </h1>
-          <p className="section-subtitle" style={{ marginBottom: 0 }}>
-            {isLoadingSkills
-              ? 'Loading skills…'
-              : `Browse the skill library${highlightedOnly ? ' (highlighted)' : ''}.`}
-          </p>
-        </div>
-        <div className="skills-toolbar">
-          <div className="skills-search">
-            <input
-              ref={searchInputRef}
-              className="skills-search-input"
-              value={query}
-              onChange={(event) => {
-                const next = event.target.value
-                const trimmed = next.trim()
-                setQuery(next)
-                void navigate({
-                  search: (prev) => ({ ...prev, q: trimmed ? next : undefined }),
-                  replace: true,
-                })
-              }}
-              placeholder="Filter by name, slug, or summary…"
-            />
-          </div>
-          <div className="skills-toolbar-row">
-            <button
-              className={`search-filter-button${highlightedOnly ? ' is-active' : ''}`}
-              type="button"
-              aria-pressed={highlightedOnly}
-              onClick={() => {
-                void navigate({
-                  search: (prev) => ({
-                    ...prev,
-                    highlighted: highlightedOnly ? undefined : true,
-                  }),
-                  replace: true,
-                })
-              }}
-            >
-              Highlighted
-            </button>
-            <select
-              className="skills-sort"
-              value={sort}
-              onChange={(event) => {
-                const sort = parseSort(event.target.value)
-                void navigate({
-                  search: (prev) => ({
-                    ...prev,
-                    sort,
-                    dir: parseDir(prev.dir, sort),
-                  }),
-                  replace: true,
-                })
-              }}
-              aria-label="Sort skills"
-            >
-              <option value="newest">Newest</option>
-              <option value="updated">Recently updated</option>
-              <option value="downloads">Downloads</option>
-              <option value="installs">Installs</option>
-              <option value="stars">Stars</option>
-              <option value="name">Name</option>
-            </select>
-            <button
-              className="skills-dir"
-              type="button"
-              aria-label={`Sort direction ${dir}`}
-              onClick={() => {
-                void navigate({
-                  search: (prev) => ({
-                    ...prev,
-                    dir: parseDir(prev.dir, sort) === 'asc' ? 'desc' : 'asc',
-                  }),
-                  replace: true,
-                })
-              }}
-            >
-              {dir === 'asc' ? '↑' : '↓'}
-            </button>
-            <button
-              className={`skills-view${view === 'cards' ? ' is-active' : ''}`}
-              type="button"
-              onClick={() => {
-                void navigate({
-                  search: (prev) => ({
-                    ...prev,
-                    view: prev.view === 'cards' ? undefined : 'cards',
-                  }),
-                  replace: true,
-                })
-              }}
-            >
-              {view === 'cards' ? 'List' : 'Cards'}
-            </button>
-          </div>
-        </div>
+      <header className="skills-header-top">
+        <h1 className="section-title" style={{ marginBottom: 8 }}>
+          Skills
+        </h1>
+        <p className="section-subtitle" style={{ marginBottom: 0 }}>
+          {model.isLoadingSkills
+            ? 'Loading skills…'
+            : `Browse the skill library${model.activeFilters.length ? ` (${model.activeFilters.join(', ')})` : ''}.`}
+        </p>
       </header>
-
-      {isLoadingSkills ? (
-        <div className="card">
-          <div className="loading-indicator">Loading skills…</div>
-        </div>
-      ) : sorted.length === 0 ? (
-        <div className="card">No skills match that filter.</div>
-      ) : view === 'cards' ? (
-        <div className="grid">
-          {sorted.map((entry) => {
-            const skill = entry.skill
-            const isPlugin = Boolean(entry.latestVersion?.parsed?.clawdis?.nix?.plugin)
-            const skillHref = buildSkillHref(skill, entry.ownerHandle)
-            return (
-              <SkillCard
-                key={skill._id}
-                skill={skill}
-                href={skillHref}
-                badge={getSkillBadges(skill)}
-                chip={isPlugin ? 'Plugin bundle (nix)' : undefined}
-                summaryFallback="Agent-ready skill pack."
-                meta={
-                  <div className="stat">
-                    ⭐ {skill.stats.stars} · ⤓ {skill.stats.downloads} · ⤒{' '}
-                    {skill.stats.installsAllTime ?? 0}
-                  </div>
-                }
-              />
-            )
-          })}
-        </div>
-      ) : (
-        <div className="skills-list">
-          {sorted.map((entry) => {
-            const skill = entry.skill
-            const isPlugin = Boolean(entry.latestVersion?.parsed?.clawdis?.nix?.plugin)
-            const skillHref = buildSkillHref(skill, entry.ownerHandle)
-            return (
-              <Link key={skill._id} className="skills-row" to={skillHref}>
-                <div className="skills-row-main">
-                  <div className="skills-row-title">
-                    <span>{skill.displayName}</span>
-                    <span className="skills-row-slug">/{skill.slug}</span>
-                    {getSkillBadges(skill).map((badge) => (
-                      <span key={badge} className="tag">
-                        {badge}
-                      </span>
-                    ))}
-                    {isPlugin ? (
-                      <span className="tag tag-accent tag-compact">Plugin bundle (nix)</span>
-                    ) : null}
-                  </div>
-                  <div className="skills-row-summary">
-                    {skill.summary ?? 'No summary provided.'}
-                  </div>
-                  {isPlugin ? (
-                    <div className="skills-row-meta">
-                      Bundle includes SKILL.md, CLI, and config.
-                    </div>
-                  ) : null}
-                </div>
-                <div className="skills-row-metrics">
-                  <span>⤓ {skill.stats.downloads}</span>
-                  <span>⤒ {skill.stats.installsAllTime ?? 0}</span>
-                  <span>★ {skill.stats.stars}</span>
-                  <span>{skill.stats.versions} v</span>
-                </div>
-              </Link>
-            )
-          })}
-        </div>
-      )}
-
-      {canLoadMore ? (
-        <div
-          ref={canAutoLoad ? loadMoreRef : null}
-          className="card"
-          style={{ marginTop: 16, display: 'flex', justifyContent: 'center' }}
-        >
-          {canAutoLoad ? (
-            isLoadingMore ? (
-              'Loading more…'
-            ) : (
-              'Scroll to load more'
-            )
-          ) : (
-            <button className="btn" type="button" onClick={loadMore} disabled={isLoadingMore}>
-              {isLoadingMore ? 'Loading…' : 'Load more'}
-            </button>
-          )}
-        </div>
-      ) : null}
+      <div className="skills-container">
+        <SkillsToolbar
+          searchInputRef={searchInputRef}
+          query={model.query}
+          hasQuery={model.hasQuery}
+          sort={model.sort}
+          dir={model.dir}
+          view={model.view}
+          highlightedOnly={model.highlightedOnly}
+          nonSuspiciousOnly={model.nonSuspiciousOnly}
+          onQueryChange={model.onQueryChange}
+          onToggleHighlighted={model.onToggleHighlighted}
+          onToggleNonSuspicious={model.onToggleNonSuspicious}
+          onSortChange={model.onSortChange}
+          onToggleDir={model.onToggleDir}
+          onToggleView={model.onToggleView}
+        />
+        <SkillsResults
+          isLoadingSkills={model.isLoadingSkills}
+          sorted={model.sorted}
+          view={model.view}
+          paginationStatus={model.paginationStatus}
+          hasQuery={model.hasQuery}
+          canLoadMore={model.canLoadMore}
+          isLoadingMore={model.isLoadingMore}
+          canAutoLoad={model.canAutoLoad}
+          loadMoreRef={model.loadMoreRef}
+          loadMore={model.loadMore}
+        />
+      </div>
     </main>
   )
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,24 +5,28 @@
 
 :root {
   color-scheme: light dark;
-  --bg: #f8f5ef;
-  --bg-soft: #fdfaf4;
-  --bg-glow-1: #fff1d8;
-  --bg-glow-2: #ffe8e0;
+  --bg: #f8f2ed;
+  --bg-soft: #fdf7f2;
+  --bg-glow-1: #ffe1d4;
+  --bg-glow-2: #ffe8d8;
   --surface: #ffffff;
-  --surface-muted: #fff6f1;
-  --nav-bg: rgba(248, 245, 239, 0.85);
-  --ink: #1d1a17;
-  --ink-soft: #4c463f;
-  --accent: #ff6b4a;
-  --accent-deep: #e54f31;
-  --seafoam: #2bc6a4;
-  --gold: #f0c46a;
-  --line: rgba(29, 26, 23, 0.12);
-  --shadow: 0 24px 60px rgba(29, 26, 23, 0.1);
-  --radius-lg: 28px;
-  --radius-md: 18px;
-  --radius-sm: 12px;
+  --surface-muted: #f7efe9;
+  --nav-bg: rgba(248, 242, 237, 0.88);
+  --ink: #2a1f19;
+  --ink-soft: #6b5549;
+  --accent: #e65c46;
+  --accent-deep: #bf3f30;
+  --seafoam: #209e92;
+  --gold: #e7bb67;
+  --line: rgba(42, 31, 25, 0.14);
+  --border-ui: rgba(191, 63, 48, 0.28);
+  --border-ui-hover: rgba(191, 63, 48, 0.42);
+  --border-ui-active: rgba(191, 63, 48, 0.62);
+  --shadow: 0 22px 52px rgba(44, 28, 20, 0.11);
+  --radius-lg: 20px;
+  --radius-md: 14px;
+  --radius-sm: 9px;
+  --radius-pill: 14px;
   --font-display: "Bricolage Grotesque", "Manrope", sans-serif;
   --font-body: "Manrope", "Bricolage Grotesque", sans-serif;
   --font-mono:
@@ -32,21 +36,24 @@
 
 [data-theme="dark"] {
   color-scheme: dark;
-  --bg: #14110f;
-  --bg-soft: #1d1916;
-  --bg-glow-1: #2b1a15;
-  --bg-glow-2: #231713;
-  --surface: #201b18;
-  --surface-muted: #241f1b;
-  --nav-bg: rgba(20, 17, 15, 0.85);
-  --ink: #f6efe4;
-  --ink-soft: #c6b8a8;
-  --accent: #e86a47;
-  --accent-deep: #c24a2f;
-  --seafoam: #4ad8b7;
+  --bg: #14100d;
+  --bg-soft: #1d1713;
+  --bg-glow-1: #4b211b;
+  --bg-glow-2: #3a2018;
+  --surface: #241b16;
+  --surface-muted: #2f241d;
+  --nav-bg: rgba(20, 16, 13, 0.88);
+  --ink: #f7eee8;
+  --ink-soft: #c8b3a6;
+  --accent: #ff7357;
+  --accent-deep: #e25640;
+  --seafoam: #47c3b8;
   --gold: #f3c97a;
-  --line: rgba(255, 255, 255, 0.12);
-  --shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+  --line: rgba(247, 235, 225, 0.16);
+  --border-ui: rgba(255, 115, 87, 0.4);
+  --border-ui-hover: rgba(255, 115, 87, 0.58);
+  --border-ui-active: rgba(255, 115, 87, 0.78);
+  --shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
 }
 
 * {
@@ -85,7 +92,7 @@ code {
 }
 
 .site-footer {
-  padding: 0 24px 40px;
+  padding: 0 28px 40px;
 }
 
 .site-footer-inner {
@@ -148,7 +155,7 @@ code {
 .navbar-inner {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 20px 24px;
+  padding: 16px 28px;
   display: flex;
   align-items: center;
   gap: 20px;
@@ -199,7 +206,7 @@ code {
 .nav-mobile-trigger {
   width: 40px;
   height: 40px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 1px solid var(--line);
   background: var(--surface);
   display: grid;
@@ -237,8 +244,8 @@ code {
   gap: 10px;
   border: 1px solid var(--line);
   background: var(--surface);
-  padding: 6px 12px 6px 6px;
-  border-radius: 999px;
+  padding: 8px 12px 8px 8px;
+  border-radius: var(--radius-pill);
   cursor: pointer;
 }
 
@@ -262,8 +269,8 @@ code {
 
 .btn {
   border: 1px solid var(--line);
-  padding: 10px 16px;
-  border-radius: 999px;
+  padding: 10px 15px;
+  border-radius: var(--radius-pill);
   background: var(--surface);
   font-weight: 600;
   display: inline-flex;
@@ -293,10 +300,17 @@ code {
   border: none;
 }
 
+[data-theme="dark"] .btn-primary {
+  background: linear-gradient(135deg, #c35640, #953827);
+  box-shadow:
+    0 10px 22px rgba(58, 23, 16, 0.42),
+    inset 0 1px 0 rgba(255, 201, 184, 0.18);
+}
+
 .hero {
   position: relative;
   overflow: hidden;
-  padding: 80px 24px 60px;
+  padding: 72px 28px 56px;
 }
 
 .hero-inner {
@@ -349,9 +363,9 @@ code {
 .hero-card {
   background: var(--bg-soft);
   border-radius: var(--radius-lg);
-  padding: 28px;
+  padding: 24px;
   box-shadow: var(--shadow);
-  border: 1px solid rgba(255, 107, 74, 0.15);
+  border: 1px solid var(--line);
 }
 
 .hero-search-card {
@@ -371,8 +385,8 @@ code {
   gap: 8px;
   background: rgba(255, 107, 74, 0.12);
   color: var(--accent-deep);
-  border-radius: 999px;
-  padding: 6px 14px;
+  border-radius: var(--radius-pill);
+  padding: 6px 12px;
   font-weight: 600;
   font-size: 0.85rem;
 }
@@ -381,12 +395,335 @@ code {
   width: 100%;
   max-width: 1200px;
   margin: 0 auto;
-  padding: 32px 24px 72px;
+  padding: 36px 28px 76px;
   box-sizing: border-box;
 }
 
 .upload-shell {
   position: relative;
+}
+
+.upload-page {
+  position: relative;
+}
+
+.upload-page::before {
+  content: "";
+  position: absolute;
+  inset: -80px 0 auto;
+  height: 220px;
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 22% 40%, rgba(255, 118, 84, 0.14), transparent 58%),
+    radial-gradient(circle at 78% 0%, rgba(255, 177, 136, 0.08), transparent 45%);
+}
+
+.upload-page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.upload-page-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(1.9rem, 3.2vw, 2.7rem);
+  letter-spacing: -0.03em;
+}
+
+.upload-page-subtitle {
+  margin: 8px 0 0;
+  max-width: 640px;
+  color: var(--ink-soft);
+  line-height: 1.6;
+}
+
+.upload-page .upload-grid {
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  gap: 18px;
+}
+
+.upload-panel {
+  border-radius: calc(var(--radius-md) + 2px);
+  border-color: rgba(255, 118, 84, 0.22);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.76), rgba(255, 249, 245, 0.66)), var(--surface);
+  box-shadow:
+    0 18px 44px rgba(16, 10, 6, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.48);
+  gap: 10px;
+}
+
+[data-theme="dark"] .upload-panel {
+  border-color: rgba(255, 131, 95, 0.28);
+  background:
+    linear-gradient(180deg, rgba(24, 41, 52, 0.78), rgba(18, 33, 44, 0.74)), var(--surface);
+  box-shadow:
+    0 22px 46px rgba(0, 0, 0, 0.34),
+    inset 0 1px 0 rgba(255, 200, 176, 0.08);
+}
+
+.upload-panel-title {
+  margin: 0 0 6px;
+  font-family: var(--font-display);
+  font-size: 1.16rem;
+  letter-spacing: -0.01em;
+}
+
+.form-label {
+  font-size: 0.74rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(70, 95, 113, 0.9);
+  font-weight: 700;
+}
+
+[data-theme="dark"] .form-label {
+  color: rgba(206, 227, 238, 0.76);
+}
+
+.form-input {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid rgba(29, 59, 78, 0.22);
+  border-radius: var(--radius-sm);
+  padding: 12px 14px;
+  color: var(--ink);
+  background: rgba(255, 255, 255, 0.94);
+  transition:
+    border-color 0.18s ease,
+    box-shadow 0.18s ease,
+    background 0.18s ease;
+}
+
+.form-input::placeholder {
+  color: rgba(88, 115, 133, 0.72);
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent) 70%, white);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+[data-theme="dark"] .form-input {
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(14, 28, 37, 0.84);
+}
+
+[data-theme="dark"] .form-input::placeholder {
+  color: rgba(184, 205, 216, 0.68);
+}
+
+[data-theme="dark"] .form-input:focus {
+  border-color: rgba(255, 131, 95, 0.75);
+  box-shadow: 0 0 0 3px rgba(255, 131, 95, 0.2);
+}
+
+.form-input#changelog {
+  min-height: 146px;
+  resize: vertical;
+}
+
+.upload-dropzone {
+  border: 1.5px dashed rgba(255, 118, 84, 0.5);
+  border-radius: calc(var(--radius-md) + 1px);
+  padding: 14px;
+  background: linear-gradient(145deg, rgba(255, 245, 239, 0.85), rgba(255, 255, 255, 0.72));
+  cursor: pointer;
+  transition:
+    border-color 0.18s ease,
+    box-shadow 0.18s ease,
+    transform 0.18s ease;
+}
+
+.upload-dropzone:hover {
+  border-color: rgba(229, 94, 60, 0.68);
+  box-shadow: 0 16px 30px rgba(255, 118, 84, 0.15);
+  transform: translateY(-1px);
+}
+
+.upload-dropzone.is-dragging {
+  border-color: rgba(229, 94, 60, 0.92);
+  box-shadow:
+    0 18px 38px rgba(255, 118, 84, 0.28),
+    0 0 0 3px rgba(255, 118, 84, 0.18);
+  background: linear-gradient(145deg, rgba(255, 238, 228, 0.95), rgba(255, 248, 244, 0.92));
+}
+
+[data-theme="dark"] .upload-dropzone {
+  border-color: rgba(255, 131, 95, 0.52);
+  background: linear-gradient(145deg, rgba(24, 43, 55, 0.9), rgba(16, 31, 40, 0.86));
+}
+
+[data-theme="dark"] .upload-dropzone:hover {
+  border-color: rgba(255, 166, 136, 0.7);
+  box-shadow: 0 18px 34px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme="dark"] .upload-dropzone.is-dragging {
+  border-color: rgba(255, 175, 146, 0.9);
+  box-shadow:
+    0 20px 40px rgba(0, 0, 0, 0.5),
+    0 0 0 3px rgba(255, 131, 95, 0.23);
+}
+
+.upload-file-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.upload-dropzone-copy {
+  display: grid;
+  gap: 10px;
+}
+
+.upload-dropzone-title-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+
+.upload-dropzone-title-row strong {
+  font-family: var(--font-display);
+  letter-spacing: -0.015em;
+  font-size: 1.02rem;
+}
+
+.upload-dropzone-count {
+  font-family: var(--font-mono);
+  color: var(--ink-soft);
+  font-size: 0.8rem;
+}
+
+.upload-dropzone-hint {
+  color: var(--ink-soft);
+  font-size: 0.9rem;
+}
+
+.upload-picker-btn {
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 118, 84, 0.4);
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.92), rgba(255, 245, 238, 0.88));
+  color: #9d3f26;
+  font-weight: 700;
+  width: fit-content;
+  padding-inline: 14px;
+}
+
+.upload-picker-btn:hover {
+  border-color: rgba(229, 94, 60, 0.72);
+  box-shadow: 0 10px 20px rgba(255, 118, 84, 0.18);
+}
+
+[data-theme="dark"] .upload-picker-btn {
+  border-color: rgba(255, 131, 95, 0.5);
+  background: linear-gradient(140deg, rgba(31, 49, 62, 0.9), rgba(18, 35, 46, 0.9));
+  color: #ffd9cb;
+}
+
+.upload-file-list {
+  border-top: 1px solid rgba(255, 118, 84, 0.16);
+  padding-top: 10px;
+  max-height: 248px;
+  overflow: auto;
+  display: grid;
+  gap: 6px;
+}
+
+[data-theme="dark"] .upload-file-list {
+  border-top-color: rgba(255, 131, 95, 0.18);
+}
+
+.upload-file-row {
+  font-family: var(--font-mono);
+  font-size: 0.79rem;
+  line-height: 1.45;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 118, 84, 0.18);
+  background: rgba(255, 255, 255, 0.55);
+  padding: 6px 9px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-theme="dark"] .upload-file-row {
+  border-color: rgba(255, 131, 95, 0.2);
+  background: rgba(20, 36, 47, 0.72);
+}
+
+.validation-list {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 5px;
+  color: var(--ink-soft);
+  line-height: 1.45;
+}
+
+.upload-submit-row {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 118, 84, 0.24);
+  background:
+    linear-gradient(120deg, rgba(255, 243, 236, 0.74), rgba(255, 255, 255, 0.76)), var(--surface);
+  box-shadow:
+    0 16px 34px rgba(16, 10, 6, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  padding: 12px 14px;
+}
+
+[data-theme="dark"] .upload-submit-row {
+  border-color: rgba(255, 131, 95, 0.26);
+  background:
+    linear-gradient(120deg, rgba(24, 41, 53, 0.76), rgba(17, 31, 41, 0.8)), var(--surface);
+  box-shadow:
+    0 20px 40px rgba(0, 0, 0, 0.36),
+    inset 0 1px 0 rgba(255, 200, 176, 0.08);
+}
+
+.upload-submit-notes {
+  display: grid;
+  gap: 6px;
+}
+
+.upload-submit-btn {
+  border-radius: var(--radius-sm);
+  min-width: 210px;
+  justify-content: center;
+  padding: 12px 22px;
+  font-size: 0.96rem;
+  box-shadow:
+    0 10px 22px rgba(229, 94, 60, 0.26),
+    inset 0 1px 0 rgba(255, 214, 198, 0.42);
+}
+
+.upload-submit-btn:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow:
+    0 16px 28px rgba(229, 94, 60, 0.32),
+    inset 0 1px 0 rgba(255, 214, 198, 0.52);
+}
+
+.error {
+  color: #ab3a27;
+  font-weight: 600;
+}
+
+[data-theme="dark"] .error {
+  color: #ffab95;
 }
 
 .upload-header {
@@ -425,7 +762,7 @@ code {
 .upload-badge {
   background: linear-gradient(140deg, #ffddc9, #ffe9df);
   color: #9a3a24;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   padding: 12px 18px;
   font-weight: 700;
   box-shadow: 0 12px 24px rgba(255, 107, 74, 0.18);
@@ -443,10 +780,10 @@ code {
 
 .upload-card {
   background: linear-gradient(180deg, var(--surface) 0%, var(--surface-muted) 100%);
-  border-radius: calc(var(--radius-lg) + 6px);
-  border: 1px solid rgba(255, 107, 74, 0.18);
-  padding: 28px;
-  box-shadow: 0 24px 60px rgba(29, 26, 23, 0.12);
+  border-radius: calc(var(--radius-lg) + 2px);
+  border: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);
+  padding: 24px;
+  box-shadow: 0 24px 60px rgba(17, 36, 47, 0.14);
   display: flex;
   flex-direction: column;
   gap: 24px;
@@ -483,19 +820,19 @@ code {
 
 .upload-field-hint {
   font-size: 0.82rem;
-  color: rgba(92, 85, 78, 0.8);
+  color: rgba(74, 103, 121, 0.82);
   font-weight: 500;
 }
 
 [data-theme="dark"] .upload-field-hint {
-  color: rgba(198, 184, 168, 0.72);
+  color: rgba(183, 204, 216, 0.74);
 }
 
 .upload-input {
-  border: 1px solid rgba(29, 26, 23, 0.18);
-  border-radius: 14px;
+  border: 1px solid rgba(30, 57, 74, 0.2);
+  border-radius: var(--radius-md);
   padding: 12px 14px;
-  background: #fffdf9;
+  background: #fbfeff;
   box-shadow:
     inset 0 0 0 1px rgba(255, 255, 255, 0.85),
     inset 0 1px 6px rgba(255, 107, 74, 0.08);
@@ -535,7 +872,7 @@ code {
 
 .dropzone {
   border: 2px dashed rgba(255, 107, 74, 0.5);
-  border-radius: 24px;
+  border-radius: 16px;
   padding: 20px;
   background: radial-gradient(circle at top, #fff3ec 0%, #ffffff 65%);
   display: grid;
@@ -612,7 +949,7 @@ code {
 }
 
 .upload-summary {
-  border-radius: 20px;
+  border-radius: var(--radius-md);
   background: rgba(255, 255, 255, 0.7);
   border: 1px solid rgba(29, 26, 23, 0.08);
   padding: 16px;
@@ -628,7 +965,7 @@ code {
 
 .upload-requirement {
   padding: 6px 12px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: rgba(255, 107, 74, 0.12);
   color: #9a3a24;
   font-weight: 600;
@@ -685,16 +1022,16 @@ code {
 }
 
 .upload-notes {
-  background: #fff8f3;
+  background: #f6fcff;
   border: 1px solid rgba(255, 107, 74, 0.12);
-  border-radius: 18px;
-  padding: 16px;
+  border-radius: var(--radius-md);
+  padding: 18px;
   font-size: 0.85rem;
   color: var(--ink-soft);
 }
 
 [data-theme="dark"] .upload-notes {
-  background: rgba(32, 27, 24, 0.6);
+  background: rgba(21, 37, 48, 0.62);
 }
 
 .upload-notes ul {
@@ -754,6 +1091,16 @@ code {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 20px;
+  max-width: 100%;
+}
+
+.skills-header-top {
+  margin-bottom: 22px;
+}
+
+.skills-container {
+  max-width: 900px;
+  margin: 0 auto;
 }
 
 .skills-header {
@@ -768,25 +1115,25 @@ code {
 .skills-toolbar {
   display: grid;
   gap: 10px;
-  padding: 14px 16px;
-  border-radius: 18px;
-  border: 1px solid rgba(255, 107, 74, 0.18);
+  padding: 15px 16px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-ui);
   background: linear-gradient(135deg, var(--surface), var(--surface-muted));
-  min-width: min(520px, 100%);
+  margin-bottom: 22px;
 }
 
 .skills-search {
   display: flex;
   align-items: center;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 107, 74, 0.2);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-ui);
   background: rgba(255, 255, 255, 0.45);
   padding: 10px 14px;
 }
 
 [data-theme="dark"] .skills-search {
-  background: rgba(24, 19, 16, 0.55);
-  border-color: rgba(255, 131, 95, 0.35);
+  background: rgba(20, 35, 46, 0.62);
+  border-color: var(--border-ui);
 }
 
 .skills-search-input {
@@ -807,8 +1154,8 @@ code {
 
 .skills-sort {
   appearance: none;
-  border: 1px solid rgba(255, 107, 74, 0.2);
-  border-radius: 999px;
+  border: 1px solid var(--border-ui);
+  border-radius: var(--radius-pill);
   padding: 10px 14px;
   background: rgba(255, 255, 255, 0.45);
   color: var(--ink);
@@ -818,14 +1165,14 @@ code {
 }
 
 [data-theme="dark"] .skills-sort {
-  background: rgba(24, 19, 16, 0.55);
-  border-color: rgba(255, 131, 95, 0.35);
+  background: rgba(20, 35, 46, 0.62);
+  border-color: var(--border-ui);
 }
 
 .skills-dir,
 .skills-view {
-  border: 1px solid rgba(255, 107, 74, 0.2);
-  border-radius: 999px;
+  border: 1px solid var(--border-ui);
+  border-radius: var(--radius-pill);
   padding: 10px 12px;
   background: rgba(255, 255, 255, 0.45);
   color: var(--ink);
@@ -835,14 +1182,22 @@ code {
 
 [data-theme="dark"] .skills-dir,
 [data-theme="dark"] .skills-view {
-  background: rgba(24, 19, 16, 0.55);
-  border-color: rgba(255, 131, 95, 0.35);
+  background: rgba(20, 35, 46, 0.62);
+  border-color: var(--border-ui);
 }
 
 .skills-view.is-active {
-  background: rgba(255, 107, 74, 0.16);
-  border-color: rgba(255, 107, 74, 0.32);
-  color: var(--accent-deep);
+  background: linear-gradient(180deg, rgba(255, 142, 111, 0.24), rgba(255, 107, 74, 0.16));
+  border-color: var(--border-ui-active);
+  color: var(--ink);
+  box-shadow: inset 0 1px 0 rgba(255, 244, 240, 0.7);
+}
+
+[data-theme="dark"] .skills-view.is-active {
+  background: linear-gradient(180deg, rgba(232, 106, 71, 0.3), rgba(194, 74, 47, 0.24));
+  border-color: var(--border-ui-active);
+  color: #fff4ee;
+  box-shadow: inset 0 1px 0 rgba(255, 214, 198, 0.4);
 }
 
 .skills-list {
@@ -910,6 +1265,14 @@ code {
   -webkit-box-orient: vertical;
 }
 
+.skills-row-owner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.82rem;
+  color: var(--ink-soft);
+}
+
 .skills-row-metrics {
   display: flex;
   align-items: center;
@@ -932,7 +1295,7 @@ code {
   background: var(--surface);
   border-radius: var(--radius-md);
   border: 1px solid var(--line);
-  padding: 20px;
+  padding: 22px;
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -954,7 +1317,7 @@ code {
   content: "";
   width: 14px;
   height: 14px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 2px solid rgba(255, 107, 74, 0.25);
   border-top-color: var(--accent);
   animation: spin 0.9s linear infinite;
@@ -1013,6 +1376,94 @@ code {
   gap: 12px;
 }
 
+.skill-card-footer-rows {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 6px;
+  align-items: start;
+}
+
+.skill-card-footer-rows .stat {
+  justify-self: end;
+}
+
+.user-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.user-badge-prefix {
+  color: var(--ink-soft);
+}
+
+.user-avatar {
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  overflow: hidden;
+  display: grid;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--line) 80%, transparent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  flex: 0 0 auto;
+}
+
+.user-avatar-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.user-avatar-fallback {
+  font-family: var(--font-display);
+  font-size: 0.82rem;
+  font-weight: 680;
+  color: color-mix(in srgb, var(--ink) 86%, transparent);
+}
+
+.user-handle {
+  color: inherit;
+  text-decoration: none;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 18ch;
+}
+
+.user-name {
+  font-family: var(--font-display);
+  font-size: 0.88rem;
+  letter-spacing: -0.01em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 28ch;
+  min-width: 0;
+}
+
+.user-name-sep {
+  color: var(--ink-soft);
+  flex: 0 0 auto;
+}
+
+.user-handle:hover {
+  text-decoration: underline;
+}
+
+.user-badge-md .user-avatar {
+  width: 26px;
+  height: 26px;
+}
+
+.user-badge-md .user-handle {
+  font-size: 0.9rem;
+}
+
 .hero-install {
   display: grid;
   gap: 10px;
@@ -1033,15 +1484,15 @@ code {
 
 .install-switcher-toggle {
   display: inline-flex;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   padding: 4px;
-  border: 1px solid rgba(255, 107, 74, 0.22);
-  background: rgba(255, 107, 74, 0.06);
+  border: 1px solid var(--border-ui);
+  background: color-mix(in srgb, var(--accent) 9%, transparent);
 }
 
 [data-theme="dark"] .install-switcher-toggle {
-  border-color: rgba(232, 106, 71, 0.32);
-  background: rgba(232, 106, 71, 0.12);
+  border-color: var(--border-ui);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
 }
 
 .install-switcher-pill {
@@ -1053,7 +1504,7 @@ code {
   font-weight: 650;
   font-size: 0.85rem;
   padding: 6px 10px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   cursor: pointer;
   transition:
     background 0.18s ease,
@@ -1067,18 +1518,17 @@ code {
 }
 
 .install-switcher-pill.is-active {
-  background: rgba(255, 107, 74, 0.18);
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
   color: var(--accent-deep);
 }
 
 [data-theme="dark"] .install-switcher-pill.is-active {
-  background: rgba(232, 106, 71, 0.22);
+  background: color-mix(in srgb, var(--accent) 26%, transparent);
   color: #ffd0bf;
 }
 
 .hero-install-code {
-  border: 1px solid rgba(255, 107, 74, 0.2);
-  border-left: 3px solid var(--accent-deep);
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--line));
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(255, 250, 247, 0.9));
   border-radius: 12px;
   padding: 12px 14px;
@@ -1100,7 +1550,7 @@ code {
 }
 
 [data-theme="dark"] .hero-install-code {
-  border-color: rgba(232, 106, 71, 0.35);
+  border-color: color-mix(in srgb, var(--accent) 52%, var(--line));
   background: linear-gradient(180deg, rgba(26, 20, 18, 0.9), rgba(20, 16, 14, 0.85));
   color: #f5e9e3;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
@@ -1111,7 +1561,7 @@ code {
   align-items: center;
   gap: 6px;
   padding: 4px 12px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: rgba(43, 198, 164, 0.16);
   color: #1a6b5b;
   font-size: 0.8rem;
@@ -1128,6 +1578,77 @@ code {
   gap: 10px;
   flex-wrap: wrap;
   align-items: center;
+}
+
+.report-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  background: rgba(21, 24, 35, 0.42);
+  backdrop-filter: blur(3px);
+}
+
+.report-dialog {
+  width: min(100%, 560px);
+  display: grid;
+  gap: 12px;
+  padding: 20px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--line);
+  background: var(--surface);
+  box-shadow: 0 24px 50px rgba(18, 22, 34, 0.24);
+}
+
+.report-dialog-form {
+  display: grid;
+  gap: 12px;
+}
+
+.report-dialog-textarea {
+  width: 100%;
+  resize: vertical;
+  min-height: 120px;
+  max-height: 40vh;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: var(--surface-muted);
+  color: var(--ink);
+  font: inherit;
+  padding: 12px;
+}
+
+.report-dialog-textarea:focus-visible {
+  outline: 2px solid rgba(255, 107, 74, 0.35);
+  outline-offset: 2px;
+}
+
+.report-dialog-error {
+  margin: 0;
+  color: #b30000;
+  font-size: 0.9rem;
+}
+
+.report-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+[data-theme="dark"] .report-dialog-backdrop {
+  background: rgba(7, 10, 16, 0.64);
+}
+
+[data-theme="dark"] .report-dialog {
+  border-color: rgba(255, 255, 255, 0.12);
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.5);
+}
+
+[data-theme="dark"] .report-dialog-error {
+  color: #ff8c8c;
 }
 
 .star-toggle {
@@ -1229,8 +1750,8 @@ code {
 .search-bar {
   display: flex;
   gap: 12px;
-  padding: 14px 16px;
-  border-radius: 16px;
+  padding: 14px 18px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--line);
   background: var(--surface);
   align-items: center;
@@ -1259,6 +1780,8 @@ code {
 .skill-detail-stack {
   display: grid;
   gap: 16px;
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 .skill-hero {
@@ -1330,8 +1853,8 @@ code {
 
 .bundle-card {
   border: 1px solid rgba(255, 107, 74, 0.35);
-  border-radius: 18px;
-  padding: 18px;
+  border-radius: var(--radius-md);
+  padding: 20px;
   background: linear-gradient(135deg, rgba(255, 107, 74, 0.1), rgba(255, 255, 255, 0.7));
   box-shadow: 0 18px 30px rgba(37, 31, 26, 0.08);
 }
@@ -1371,7 +1894,7 @@ code {
 
 .bundle-includes span {
   padding: 6px 12px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: rgba(255, 107, 74, 0.16);
   color: var(--accent-deep);
   font-size: 0.76rem;
@@ -1445,6 +1968,11 @@ code {
   flex-direction: column;
   align-items: flex-end;
   gap: 10px;
+}
+
+.skill-hero-cta .btn {
+  width: 100%;
+  justify-content: center;
 }
 
 .skill-version-pill {
@@ -1529,7 +2057,7 @@ code {
   align-items: center;
   gap: 6px;
   padding: 4px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 1px solid var(--line);
   background: var(--surface-muted);
   margin: 0;
@@ -1540,7 +2068,7 @@ code {
   border: none;
   background: transparent;
   padding: 8px 14px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   font-weight: 600;
   color: var(--ink-soft);
   cursor: pointer;
@@ -1639,7 +2167,7 @@ code {
   letter-spacing: 0.08em;
   font-weight: 700;
   padding: 4px 8px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   align-self: start;
 }
 
@@ -1670,7 +2198,7 @@ code {
 
 .diff-monaco {
   height: 420px;
-  border-radius: 18px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--line);
   overflow: hidden;
   background: var(--surface);
@@ -1692,13 +2220,15 @@ code {
   font-size: 0.8rem;
   color: var(--ink-soft);
   background: rgba(255, 255, 255, 0.8);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   padding: 6px 10px;
   border: 1px solid var(--line);
 }
 
 .tab-card {
   gap: 14px;
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 .tab-header {
@@ -1706,7 +2236,7 @@ code {
   align-items: center;
   gap: 6px;
   padding: 4px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: 1px solid var(--line);
   background: var(--surface-muted);
   align-self: flex-start;
@@ -1716,7 +2246,7 @@ code {
   border: none;
   background: transparent;
   padding: 8px 16px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   font-weight: 650;
   color: var(--ink-soft);
   cursor: pointer;
@@ -1731,11 +2261,14 @@ code {
 .tab-body {
   display: grid;
   gap: 20px;
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 .file-list {
   display: grid;
   gap: 12px;
+  max-width: 100%;
   padding-top: 8px;
   border-top: 1px solid var(--line);
 }
@@ -1751,8 +2284,69 @@ code {
   display: grid;
   gap: 8px;
   max-height: 260px;
+  max-width: 100%;
   overflow: auto;
   padding-right: 4px;
+}
+
+.file-browser {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 900px) {
+  .file-browser {
+    grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.3fr);
+    align-items: start;
+  }
+}
+
+.file-row-button {
+  width: 100%;
+  border: 1px solid var(--line);
+  background: var(--surface-muted);
+  text-align: left;
+  cursor: pointer;
+}
+
+.file-row-button:focus-visible {
+  outline: 3px solid rgba(255, 107, 74, 0.25);
+  outline-offset: 2px;
+}
+
+.file-row-button.is-active {
+  border-color: var(--ink);
+  box-shadow: 0 8px 18px rgba(29, 26, 23, 0.12);
+}
+
+.file-viewer {
+  border-radius: 16px;
+  border: 1px solid var(--line);
+  background: var(--surface);
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+}
+
+.file-viewer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.file-viewer-body {
+  max-height: 320px;
+  overflow: auto;
+  padding-right: 4px;
+}
+
+.file-viewer-code {
+  margin: 0;
+  white-space: pre-wrap;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  color: var(--ink);
 }
 
 .version-scroll {
@@ -1766,6 +2360,7 @@ code {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  max-width: 100%;
   padding: 10px 12px;
   border-radius: 12px;
   border: 1px solid var(--line);
@@ -1812,6 +2407,51 @@ code {
   justify-self: start;
   padding: 8px 14px;
   font-size: 0.9rem;
+}
+
+.comment-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: start;
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--surface-muted);
+}
+
+.comment-body {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.comment-body-text {
+  color: var(--ink-soft);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.comment-delete {
+  justify-self: end;
+  align-self: center;
+  padding: 6px 12px;
+  font-size: 0.82rem;
+  color: var(--ink-soft);
+  border-color: rgba(255, 107, 74, 0.25);
+  background: transparent;
+  box-shadow: none;
+}
+
+.comment-delete:hover {
+  color: var(--ink);
+  border-color: rgba(255, 107, 74, 0.4);
+  background: rgba(255, 107, 74, 0.08);
+}
+
+.comment-delete:focus-visible {
+  outline: 3px solid rgba(255, 107, 74, 0.25);
+  outline-offset: 2px;
 }
 
 .sidebar-card {
@@ -1893,7 +2533,7 @@ code {
 
 @media (max-width: 760px) {
   .navbar-inner {
-    padding: 16px 16px;
+    padding: 14px 18px;
     gap: 14px;
   }
 
@@ -1910,11 +2550,11 @@ code {
   }
 
   .hero {
-    padding: 64px 18px 46px;
+    padding: 58px 18px 44px;
   }
 
   .section {
-    padding: 28px 18px 64px;
+    padding: 30px 18px 62px;
   }
 
   .section-cta {
@@ -2018,25 +2658,32 @@ code {
 }
 
 .search-filter-button {
-  border-radius: 999px;
-  border: 1px solid rgba(255, 107, 74, 0.3);
+  position: relative;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-ui);
   padding: 10px 14px;
-  background: var(--surface-muted);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.72), rgba(255, 246, 241, 0.92));
   color: var(--ink);
-  font-weight: 600;
+  font-weight: 650;
   cursor: pointer;
   transition:
     border 0.2s ease,
     box-shadow 0.2s ease,
     background 0.2s ease,
-    color 0.2s ease;
+    color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.search-filter-button:hover {
+  border-color: var(--border-ui-hover);
+  transform: translateY(-1px);
 }
 
 .search-filter-button[aria-pressed="true"] {
-  background: var(--accent);
-  border-color: var(--accent-deep);
-  color: white;
-  box-shadow: 0 10px 20px rgba(255, 107, 74, 0.3);
+  background: linear-gradient(180deg, rgba(255, 142, 111, 0.28), rgba(255, 107, 74, 0.2));
+  border-color: var(--border-ui-active);
+  color: var(--ink);
+  box-shadow: inset 0 1px 0 rgba(255, 244, 240, 0.75);
 }
 
 .search-filter-button:focus-visible {
@@ -2049,8 +2696,8 @@ code {
   align-items: center;
   gap: 12px;
   padding: 10px 14px;
-  border-radius: 999px;
-  border: 1px solid rgba(255, 107, 74, 0.2);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-ui);
   background: var(--surface-muted);
   color: var(--ink);
   font-weight: 600;
@@ -2061,7 +2708,7 @@ code {
   width: 20px;
   height: 20px;
   border-radius: 6px;
-  border: 2px solid rgba(255, 107, 74, 0.4);
+  border: 2px solid var(--border-ui-hover);
   display: grid;
   place-items: center;
   background: transparent;
@@ -2097,17 +2744,29 @@ code {
 }
 
 [data-theme="dark"] .search-filter {
-  background: rgba(36, 31, 27, 0.9);
-  border-color: rgba(255, 131, 95, 0.35);
+  background: rgba(19, 34, 44, 0.9);
+  border-color: var(--border-ui);
 }
 
 [data-theme="dark"] .search-filter-button {
-  background: rgba(36, 31, 27, 0.9);
-  border-color: rgba(255, 131, 95, 0.35);
+  background: linear-gradient(180deg, rgba(25, 42, 53, 0.92), rgba(18, 33, 43, 0.94));
+  border-color: var(--border-ui);
+}
+
+[data-theme="dark"] .search-filter-button:hover {
+  border-color: var(--border-ui-hover);
+  background: linear-gradient(180deg, rgba(30, 48, 60, 0.96), rgba(22, 38, 49, 0.96));
+}
+
+[data-theme="dark"] .search-filter-button[aria-pressed="true"] {
+  background: linear-gradient(180deg, rgba(232, 106, 71, 0.34), rgba(194, 74, 47, 0.28));
+  border-color: var(--border-ui-active);
+  color: #fff4ee;
+  box-shadow: inset 0 1px 0 rgba(255, 214, 198, 0.5);
 }
 
 [data-theme="dark"] .search-filter-input {
-  border-color: rgba(255, 131, 95, 0.6);
+  border-color: var(--border-ui-hover);
 }
 
 .search-input {
@@ -2181,7 +2840,7 @@ code {
   background: rgba(255, 255, 255, 0.45);
   color: var(--ink-soft);
   padding: 10px 14px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   font-weight: 650;
   cursor: pointer;
   transition:
@@ -2192,7 +2851,7 @@ code {
 }
 
 [data-theme="dark"] .profile-tab {
-  background: rgba(24, 19, 16, 0.55);
+  background: rgba(20, 35, 46, 0.62);
   border-color: rgba(255, 131, 95, 0.35);
 }
 
@@ -2325,7 +2984,7 @@ code {
 }
 
 [data-theme="dark"] .settings-input {
-  background: #251f1b;
+  background: #1d3340;
   border-color: rgba(255, 131, 95, 0.25);
 }
 
@@ -2342,6 +3001,26 @@ code {
   .upload-grid {
     grid-template-columns: 1fr;
   }
+
+  .upload-page .upload-grid {
+    gap: 14px;
+  }
+
+  .upload-submit-row {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .upload-submit-btn {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .upload-dropzone-title-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+  }
 }
 
 .mono {
@@ -2350,11 +3029,12 @@ code {
 
 .markdown {
   line-height: 1.7;
-  color: #3f3a34;
+  max-width: 100%;
+  color: #334a58;
 }
 
 [data-theme="dark"] .markdown {
-  color: rgba(246, 239, 228, 0.9);
+  color: rgba(231, 244, 250, 0.9);
 }
 
 .markdown h1,
@@ -2376,11 +3056,13 @@ code {
 
 .markdown pre {
   white-space: pre;
+  max-width: 100%;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(255, 250, 247, 0.88));
-  border: 1px solid rgba(255, 107, 74, 0.18);
-  border-left: 3px solid var(--accent-deep);
+  background:
+    radial-gradient(1200px 220px at 12% 0%, rgba(255, 107, 74, 0.08), transparent 55%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(255, 250, 247, 0.9));
+  border: 1px solid rgba(255, 107, 74, 0.2);
   border-radius: 12px;
   padding: 14px 16px;
   font-family: var(--font-mono);
@@ -2388,7 +3070,9 @@ code {
   line-height: 1.55;
   tab-size: 2;
   color: var(--ink);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  box-shadow:
+    inset 4px 0 0 rgba(255, 107, 74, 0.55),
+    inset 0 1px 0 rgba(255, 255, 255, 0.75);
 }
 
 .markdown pre code {
@@ -2401,11 +3085,14 @@ code {
 }
 
 [data-theme="dark"] .markdown pre {
-  background: linear-gradient(180deg, rgba(26, 20, 18, 0.9), rgba(20, 16, 14, 0.85));
-  border: 1px solid rgba(232, 106, 71, 0.28);
-  border-left-color: rgba(232, 106, 71, 0.8);
-  color: #f5e9e3;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  background:
+    radial-gradient(900px 260px at 12% 0%, rgba(255, 168, 142, 0.08), transparent 55%),
+    linear-gradient(180deg, rgba(14, 22, 32, 0.95), rgba(10, 16, 24, 0.92));
+  border: 1px solid rgba(255, 168, 142, 0.22);
+  color: rgba(244, 238, 234, 0.96);
+  box-shadow:
+    inset 4px 0 0 rgba(255, 140, 110, 0.75),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 [data-theme="dark"] .markdown :not(pre) > code {
@@ -2603,13 +3290,13 @@ html.theme-transition::view-transition-new(theme) {
 
 .btn-ghost {
   background: transparent;
-  border: 1px solid var(--card-border);
-  color: var(--color-text);
+  border-color: var(--border-ui);
+  color: var(--ink);
 }
 
 .btn-ghost:hover {
-  background: var(--card-bg);
-  border-color: var(--color-accent);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  border-color: var(--border-ui-hover);
 }
 
 @media (max-width: 640px) {
@@ -2780,7 +3467,7 @@ html.theme-transition::view-transition-new(theme) {
 }
 
 .scan-result-icon-vt {
-  color: #0030ff;
+  color: var(--accent-deep);
 }
 
 .scan-result-icon-oc {
@@ -2789,7 +3476,7 @@ html.theme-transition::view-transition-new(theme) {
 
 .scan-result-status {
   padding: 2px 8px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   font-size: 0.85rem;
   font-weight: 600;
   text-transform: capitalize;
@@ -2901,7 +3588,7 @@ html.theme-transition::view-transition-new(theme) {
   border: 1px solid var(--line);
   background: transparent;
   color: var(--ink-soft);
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   padding: 2px 8px;
   font-size: 0.75rem;
   cursor: pointer;
@@ -2929,7 +3616,7 @@ html.theme-transition::view-transition-new(theme) {
 }
 
 .version-scan-icon-vt {
-  color: #0030ff;
+  color: var(--accent-deep);
 }
 
 .version-scan-icon-oc {
@@ -2977,7 +3664,7 @@ html.theme-transition::view-transition-new(theme) {
   gap: 12px;
   padding: 10px 14px;
   cursor: pointer;
-  user-select: none;
+  user-select: text;
   border-radius: 12px;
   transition: background 0.15s ease;
 }
@@ -2998,6 +3685,7 @@ html.theme-transition::view-transition-new(theme) {
   align-items: center;
   gap: 4px;
   white-space: nowrap;
+  user-select: none;
 }
 
 .analysis-detail-toggle .chevron {
@@ -3013,6 +3701,8 @@ html.theme-transition::view-transition-new(theme) {
   color: var(--ink);
   line-height: 1.45;
   flex: 1;
+  cursor: text;
+  user-select: text;
 }
 
 .analysis-body {


### PR DESCRIPTION
## Summary

  Not all ClawHub users are security-savvy, and skill authors don't always know what best practices look like. This change brings
  capability declarations front and center — making it obvious what a skill needs before you install it, and giving authors clear
  guidance on what to declare and why.

  Skills now display their declared capabilities (`shell`, `filesystem`, `network`, `browser`, `sessions`) as badges on the detail
  page. Skills that haven't declared any show a "No capabilities declared" flag — a clear signal to both users and authors that
  something's missing.

  This is the registry-side companion to the runtime enforcement work in OpenClaw. During the transition period, ClawHub is
  **visibility-only** — capabilities are displayed but don't block publishing. The goal is to build the habit first: authors declare
   what their skill needs, users see it before install, and OpenClaw enforces it at runtime.

  **Companion PR:** https://github.com/openclaw/openclaw/compare/client-side-security-initial?expand=1

  ### What changed

  **Schema and validation**
  - `capabilities: 'string[]?'` added to `ClawdisSkillMetadataSchema`
  - `validateCapabilities()` validates array contents against the allowed set
  - Wired into `parseClawdisMetadata()` — invalid values produce a validation warning, not a hard error (transition period)

  **API**
  - `GET /api/v1/skills/{slug}` response now includes `capabilities` (string array)
  - Added to `ApiV1SkillResponseSchema`

  **LLM security evaluator**
  - Capabilities section added to the context passed to the evaluator (informational — the evaluator can reference it but there's no
   new hard evaluation dimension)

  **UI**
  - Capability badges rendered in `SkillInstallCard` when capabilities are declared
  - "No capabilities declared" flag shown when a skill has none — this is the key visual nudge
  - `SkillDetailPage` refactored into focused components (`SkillHeader`, `SkillInstallCard`, `SkillStats`, `SkillDetailTabs`, etc.)

  **Docs**
  - `skill-format.md` updated to describe the `capabilities` field and best practices

  <!-- Screenshot: SkillInstallCard with capability badges -->
  <!-- Screenshot: "No capabilities declared" flag -->

  ### Why this matters

  Community skills are growing. Users install them without knowing what system access they need. Skill authors publish without
  thinking about what permissions their skill actually requires. This creates a gap:

  - **For users:** No way to see what a skill can do before installing it
  - **For authors:** No clear best practice for declaring what their skill needs
  - **For the ecosystem:** No foundation for runtime enforcement

  Capability declarations close that gap. They're modeled after how mobile apps and the Apple ecosystem handle permissions — you
  declare what you need, users see it upfront, and the platform enforces it. It's not a silver bullet, but it's a massive
  improvement over "install and hope for the best."

  ### Design decisions

  - **Visibility-only during transition.** No publish-time blocking. Existing skills don't have capabilities and we're not going to
  break everyone's workflow overnight.
  - **"No capabilities declared" flag over silent absence.** Every skill without capabilities gets a visible indicator. This is
  intentional — it's the nudge that drives adoption.
  - **Validation warns, doesn't reject.** A typo in capabilities (`shellz` instead of `shell`) produces a warning but doesn't block
  publishing. Keeps the migration smooth.
  - **No author verification tier.** May be introduced later as a governance feature.

  ### Not included

  - Publish-time capability enforcement (after adoption ramps)
  - Capability-based search/filtering
  - Capability diff warnings on skill updates

  ## Test plan

  ### Setup

  1. Start the Convex dev backend:
     ```bash
     npx convex dev
  2. Start the frontend:
  npm run dev
  3. Seed test data or ensure you have skills in your local Convex instance — at least one with capabilities and one without

  Test capability badges

  4. Browse to a skill detail page for a skill with capabilities declared
    - Expected: Capability badges render in the SkillInstallCard (one per capability)
  5. Browse to a skill with all five capabilities
    - Expected: All five badges render without layout breakage
  6. Browse to a skill without capabilities
    - Expected: "No capabilities declared" flag shown

  Test API response

  7. curl the skill detail endpoint for a skill with capabilities:
  curl <convex-site-url>/api/v1/skills/<slug>
    - Expected: latestVersion.capabilities is a string array like ["shell", "filesystem"]
  8. Same for a skill without capabilities:
    - Expected: capabilities is [] or absent

  Test validation

  9. Create a skill with an invalid capability value (e.g., "shellz") via Convex dashboard
    - Expected: Warning in logs, skill still publishes
  10. Create a skill with valid capabilities
    - Expected: No warnings, capabilities stored and displayed correctly

  Test LLM evaluator

  11. Trigger the security evaluator for a skill with capabilities
    - Expected: Evaluator input context includes a "Declared capabilities" section
  12. Trigger for a skill without capabilities
    - Expected: Context shows "None declared"

  Test refactored components

  13. Browse multiple skill detail pages — verify no layout regressions in header, stats, tabs, install card, comments, versions,
  files panels

  Files (27 changed, +2762/-1595)

  - Schema + validation — packages/schema/src/schemas.ts, convex/lib/skillCapabilities.ts, convex/lib/skills.ts
  - API — convex/httpApiV1.ts
  - LLM evaluator — convex/lib/securityPrompt.ts
  - UI components — SkillInstallCard.tsx, SkillHeader.tsx, SkillDetailPage.tsx, SkillDetailTabs.tsx, SkillFilesPanel.tsx,
  SkillSecurityScanResults.tsx, SkillStats.tsx, SkillCommentsPanel.tsx, SkillReportDialog.tsx, SkillVersionsPanel.tsx,
  UserBadge.tsx, skillDetailUtils.ts
  - Skills browse — skills/index.tsx, -SkillsResults.tsx, -SkillsToolbar.tsx, -types.ts, -params.ts, -useSkillsBrowseModel.ts
  - Shared — numberFormat.ts, skillPageEntries.ts, styles.css
  - Docs — skill-format.md

<img width="787" height="478" alt="image" src="https://github.com/user-attachments/assets/b6dba4cf-9907-4901-9629-8476e4146aa8" />

<img width="768" height="429" alt="image" src="https://github.com/user-attachments/assets/e08a6d7d-dd01-4d89-8ce2-e7ec42797015" />

<img width="748" height="395" alt="image" src="https://github.com/user-attachments/assets/b6a63fab-7c5c-4ede-a5b0-c2cd3c7823f9" />


<img width="779" height="504" alt="image" src="https://github.com/user-attachments/assets/f6c1cd4c-3b6d-459e-b2a0-5304c51b4924" />

<img width="572" height="804" alt="image" src="https://github.com/user-attachments/assets/f09285c2-a902-46d7-90e7-c33b92ef98a1" />


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds capability declarations to skills (schema, API, LLM evaluator, UI badges) and refactors the `SkillDetailPage` monolith into focused subcomponents. The backend additions — `skillCapabilities.ts`, schema changes, API response, and security prompt — are solid and ready. However, the UI refactor introduces several runtime-breaking issues that need to be resolved before merge:

- **Skills browse page (`/skills`) is non-functional.** `useSkillsBrowseModel` is a stub returning hardcoded empty state. All data fetching, search, sorting, filtering, and pagination logic from the original `SkillsIndex` was deleted but not re-implemented in the new hook. Users will see an empty page with "No skills match that filter."
- **`formatSkillStatsTriplet` return type mismatch.** Returns an array of `{ label, value }` objects, but `SkillHeader.tsx` and `SkillStats.tsx` access it as an object with `.stars`, `.downloads`, `.installsAllTime` properties — all will render `undefined`.
- **`UserBadge` prop interface doesn't match callsites.** Accepts `{ handle, displayName, image }` but is called with `{ user, fallbackHandle, prefix, ... }` — will always display "Unknown" for every skill author.
- **Stub components (`SkillReportDialog`, `SkillCommentsPanel`, `SkillVersionsPanel`) have mismatched prop signatures** and remove existing functionality (comments, reporting, version listing) from the skill detail page.
- The new capability badges in `SkillInstallCard` and the backend/schema work are clean and correctly implemented.

<h3>Confidence Score: 1/5</h3>

- This PR will break the skills browse page, stat rendering, and user badge display at runtime due to incomplete stub implementations and type mismatches.
- The backend changes (capabilities schema, validation, API, LLM evaluator) are well-implemented and safe. However, the UI refactor introduces multiple runtime-breaking issues: the skills browse page returns no data, stat formatting produces undefined values, UserBadge always shows "Unknown", and three stub components remove existing functionality (comments, reporting, versions) without re-implementing it. These are not edge cases — they affect the primary user-facing pages.
- `src/routes/skills/-useSkillsBrowseModel.ts` (completely breaks /skills page), `src/components/UserBadge.tsx` (prop mismatch), `src/components/SkillStats.tsx` and `src/lib/numberFormat.ts` (return type mismatch), `src/components/SkillReportDialog.tsx` (stub with wrong props)

<sub>Last reviewed commit: 03cdb91</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a1d58d20-b4dd-4cbb-973a-9fd7824e1921))

<!-- /greptile_comment -->