### PR TITLE
Revert: display total skills count (fixes #357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@
 - Skills: keep global sorting across pagination on `/skills` (thanks @CodeBBakGoSu, #98).
 - Skills: allow updating skill description/summary from frontmatter on subsequent publishes (#312) (thanks @ianalloway).
 - Skills/Web: prevent filtered pagination dead-ends and loading-state flicker on `/skills`; move highlighted browse filtering into server list query (#339) (thanks @Marvae).
-- Web: align `/skills` total count with public visibility and format header count (thanks @rknoche6, #76).
 
 ## 0.6.1 - 2026-02-13
 

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -31,13 +31,6 @@ crons.interval(
   {},
 )
 
-crons.interval(
-  'global-stats-update',
-  { minutes: 60 },
-  internal.statsMaintenance.updateGlobalStatsInternal,
-  {},
-)
-
 crons.interval('vt-pending-scans', { minutes: 5 }, internal.vt.pollPendingScans, { batchSize: 100 })
 
 crons.interval('vt-cache-backfill', { minutes: 30 }, internal.vt.backfillActiveSkillsVTCache, {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -342,12 +342,6 @@ const skillStatBackfillState = defineTable({
   updatedAt: v.number(),
 }).index('by_key', ['key'])
 
-const globalStats = defineTable({
-  key: v.string(),
-  activeSkillsCount: v.number(),
-  updatedAt: v.number(),
-}).index('by_key', ['key'])
-
 const skillStatEvents = defineTable({
   skillId: v.id('skills'),
   kind: v.union(
@@ -580,7 +574,6 @@ export default defineSchema({
   skillDailyStats,
   skillLeaderboards,
   skillStatBackfillState,
-  globalStats,
   skillStatEvents,
   skillStatUpdateCursors,
   comments,

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -1632,18 +1632,6 @@ function isCursorParseError(error: unknown) {
   return false
 }
 
-export const countPublicSkills = query({
-  args: {},
-  handler: async (ctx) => {
-    const stats = await ctx.db
-      .query('globalStats')
-      .withIndex('by_key', (q) => q.eq('key', 'default'))
-      .unique()
-    // Null means global stats haven't been initialized yet.
-    return stats?.activeSkillsCount ?? null
-  },
-})
-
 function sortToIndex(
   sort: 'downloads' | 'stars' | 'installsCurrent' | 'installsAllTime',
 ):

--- a/convex/statsMaintenance.ts
+++ b/convex/statsMaintenance.ts
@@ -3,14 +3,12 @@ import { internal } from './_generated/api'
 import type { Doc } from './_generated/dataModel'
 import type { ActionCtx } from './_generated/server'
 import { internalAction, internalMutation, internalQuery } from './_generated/server'
-import { toPublicSkill } from './lib/public'
 
 const DEFAULT_BATCH_SIZE = 200
 const MAX_BATCH_SIZE = 1000
 const DEFAULT_MAX_BATCHES = 5
 const MAX_MAX_BATCHES = 50
 const BACKFILL_STATE_KEY = 'default'
-const GLOBAL_STATS_PAGE_SIZE = 500
 
 export const backfillSkillStatFieldsInternal = internalMutation({
   args: {
@@ -301,44 +299,3 @@ export const runReconcileSkillStarCountsInternal = internalAction({
 function clampInt(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max)
 }
-
-export const updateGlobalStatsInternal = internalMutation({
-  args: {},
-  handler: async (ctx) => {
-    let count = 0
-    let cursor: string | null = null
-
-    while (true) {
-      const { page, isDone, continueCursor } = await ctx.db
-        .query('skills')
-        .withIndex('by_active_updated', (q) => q.eq('softDeletedAt', undefined))
-        .order('asc')
-        .paginate({ cursor, numItems: GLOBAL_STATS_PAGE_SIZE })
-
-      for (const skill of page) {
-        if (toPublicSkill(skill)) {
-          count += 1
-        }
-      }
-
-      if (isDone) break
-      cursor = continueCursor
-    }
-
-    const now = Date.now()
-    const existing = await ctx.db
-      .query('globalStats')
-      .withIndex('by_key', (q) => q.eq('key', 'default'))
-      .unique()
-
-    if (existing) {
-      await ctx.db.patch(existing._id, { activeSkillsCount: count, updatedAt: now })
-    } else {
-      await ctx.db.insert('globalStats', {
-        key: 'default',
-        activeSkillsCount: count,
-        updatedAt: now,
-      })
-    }
-  },
-})

--- a/src/__tests__/skills-index-load-more.test.tsx
+++ b/src/__tests__/skills-index-load-more.test.tsx
@@ -7,7 +7,6 @@ import { SkillsIndex } from '../routes/skills/index'
 
 const navigateMock = vi.fn()
 const useActionMock = vi.fn()
-const useQueryMock = vi.fn()
 const usePaginatedQueryMock = vi.fn()
 let searchMock: Record<string, unknown> = {}
 
@@ -22,7 +21,6 @@ vi.mock('@tanstack/react-router', () => ({
 
 vi.mock('convex/react', () => ({
   useAction: (...args: unknown[]) => useActionMock(...args),
-  useQuery: (...args: unknown[]) => useQueryMock(...args),
   usePaginatedQuery: (...args: unknown[]) => usePaginatedQueryMock(...args),
 }))
 
@@ -30,11 +28,9 @@ describe('SkillsIndex load-more observer', () => {
   beforeEach(() => {
     usePaginatedQueryMock.mockReset()
     useActionMock.mockReset()
-    useQueryMock.mockReset()
     navigateMock.mockReset()
     searchMock = {}
     useActionMock.mockReturnValue(() => Promise.resolve([]))
-    useQueryMock.mockReturnValue(null)
   })
 
   afterEach(() => {

--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -7,7 +7,6 @@ import { SkillsIndex } from '../routes/skills/index'
 
 const navigateMock = vi.fn()
 const useActionMock = vi.fn()
-const useQueryMock = vi.fn()
 const usePaginatedQueryMock = vi.fn()
 let searchMock: Record<string, unknown> = {}
 
@@ -22,7 +21,6 @@ vi.mock('@tanstack/react-router', () => ({
 
 vi.mock('convex/react', () => ({
   useAction: (...args: unknown[]) => useActionMock(...args),
-  useQuery: (...args: unknown[]) => useQueryMock(...args),
   usePaginatedQuery: (...args: unknown[]) => usePaginatedQueryMock(...args),
 }))
 
@@ -30,11 +28,9 @@ describe('SkillsIndex', () => {
   beforeEach(() => {
     usePaginatedQueryMock.mockReset()
     useActionMock.mockReset()
-    useQueryMock.mockReset()
     navigateMock.mockReset()
     searchMock = {}
     useActionMock.mockReturnValue(() => Promise.resolve([]))
-    useQueryMock.mockReturnValue(null)
     // Default: return empty results with Exhausted status
     usePaginatedQueryMock.mockReturnValue({
       results: [],

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -1,7 +1,5 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
-import { useQuery } from 'convex/react'
 import { useRef } from 'react'
-import { api } from '../../../convex/_generated/api'
 import { parseSort } from './-params'
 import { SkillsResults } from './-SkillsResults'
 import { SkillsToolbar } from './-SkillsToolbar'
@@ -51,9 +49,6 @@ export function SkillsIndex() {
   const navigate = Route.useNavigate()
   const search = Route.useSearch()
   const searchInputRef = useRef<HTMLInputElement>(null)
-  const totalSkills = useQuery(api.skills.countPublicSkills)
-  const totalSkillsText =
-    typeof totalSkills === 'number' ? totalSkills.toLocaleString('en-US') : null
 
   const model = useSkillsBrowseModel({
     navigate,
@@ -66,7 +61,6 @@ export function SkillsIndex() {
       <header className="skills-header-top">
         <h1 className="section-title" style={{ marginBottom: 8 }}>
           Skills
-          {totalSkillsText && <span style={{ opacity: 0.55 }}>{` (${totalSkillsText})`}</span>}
         </h1>
         <p className="section-subtitle" style={{ marginBottom: 0 }}>
           {model.isLoadingSkills


### PR DESCRIPTION
Reverts commit 8993395 which broke the /skills page with a Convex server error on `countPublicSkills`.

The `globalStats` table/cron was added but likely hasn't been properly initialized in the Convex deployment, causing a server error when querying it.

Fixes #357

cc @rknoche6 — happy to help you re-land this properly once the schema migration is sorted.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Clean revert of commit 8993395 ("display total skills count on /skills page (#76)") to fix a Convex server error on the `/skills` page (#357). The original commit added a `globalStats` table, a `countPublicSkills` query, a cron job to update global stats, and UI to display the total count in the page header. Since the `globalStats` table was never properly initialized in the Convex deployment, the `countPublicSkills` query caused a server error.

- Removes the `globalStats` table definition from `convex/schema.ts`
- Removes the `countPublicSkills` query from `convex/skills.ts`
- Removes the `updateGlobalStatsInternal` mutation and its hourly cron from `convex/statsMaintenance.ts` and `convex/crons.ts`
- Reverts the `/skills` page UI to no longer display the total skills count
- Cleans up test mocks for `useQuery` that were added for the feature
- Removes the corresponding CHANGELOG entry

Verified this is a byte-for-byte clean revert — the resulting files are identical to the state before the original feature commit.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a clean, complete revert restoring the codebase to a known-good state.
- The revert produces zero diff against the pre-feature commit (e352309), confirming it is an exact rollback. The feature being reverted was merged but broken in production due to an uninitialized table. No new code is introduced, no partial changes remain, and tests are updated to match.
- No files require special attention.

<sub>Last reviewed commit: 87dd677</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a1d58d20-b4dd-4cbb-973a-9fd7824e1921))

<!-- /greptile_comment -->