### PR TITLE
Re-land #76 safely: resilient /skills count + globalStats fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Skills: keep global sorting across pagination on `/skills` (thanks @CodeBBakGoSu, #98).
 - Skills: allow updating skill description/summary from frontmatter on subsequent publishes (#312) (thanks @ianalloway).
 - Skills/Web: prevent filtered pagination dead-ends and loading-state flicker on `/skills`; move highlighted browse filtering into server list query (#339) (thanks @Marvae).
+- Web: align `/skills` total count with public visibility and format header count (thanks @rknoche6, #76).
 
 ## 0.6.1 - 2026-02-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Skills: allow updating skill description/summary from frontmatter on subsequent publishes (#312) (thanks @ianalloway).
 - Skills/Web: prevent filtered pagination dead-ends and loading-state flicker on `/skills`; move highlighted browse filtering into server list query (#339) (thanks @Marvae).
 - Web: align `/skills` total count with public visibility and format header count (thanks @rknoche6, #76).
+- Skills/Web: centralize public visibility checks and keep `globalStats` skill counts in sync incrementally; remove duplicate `/skills` default-sort fallback and share browse test mocks (thanks @rknoche6, #76).
 
 ## 0.6.1 - 2026-02-13
 

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -31,6 +31,13 @@ crons.interval(
   {},
 )
 
+crons.interval(
+  'global-stats-update',
+  { minutes: 60 },
+  internal.statsMaintenance.updateGlobalStatsInternal,
+  {},
+)
+
 crons.interval('vt-pending-scans', { minutes: 5 }, internal.vt.pollPendingScans, { batchSize: 100 })
 
 crons.interval('vt-cache-backfill', { minutes: 30 }, internal.vt.backfillActiveSkillsVTCache, {

--- a/convex/lib/globalStats.ts
+++ b/convex/lib/globalStats.ts
@@ -1,5 +1,5 @@
 import type { Doc } from '../_generated/dataModel'
-import type { MutationCtx } from '../_generated/server'
+import type { MutationCtx, QueryCtx } from '../_generated/server'
 
 export const GLOBAL_STATS_KEY = 'default'
 const GLOBAL_STATS_PAGE_SIZE = 500
@@ -8,6 +8,8 @@ type SkillVisibilityFields = Pick<
   Doc<'skills'>,
   'softDeletedAt' | 'moderationStatus' | 'moderationFlags'
 >
+
+type DbCtx = Pick<MutationCtx | QueryCtx, 'db'>
 
 export function isPublicSkillDoc(skill: SkillVisibilityFields | null | undefined) {
   if (!skill || skill.softDeletedAt) return false
@@ -26,7 +28,31 @@ export function getPublicSkillVisibilityDelta(
   return afterPublic ? 1 : -1
 }
 
-export async function countPublicSkillsForGlobalStats(ctx: Pick<MutationCtx, 'db'>) {
+function getErrorMessage(error: unknown) {
+  if (typeof error === 'string') return error
+  if (error && typeof error === 'object' && 'message' in error) {
+    const message = (error as { message?: unknown }).message
+    if (typeof message === 'string') return message
+  }
+  return ''
+}
+
+export function isGlobalStatsStorageNotReadyError(error: unknown) {
+  const message = getErrorMessage(error).toLowerCase()
+  if (!message) return false
+  const referencesGlobalStats = message.includes('globalstats') || message.includes('by_key')
+  if (!referencesGlobalStats) return false
+  return (
+    message.includes('table') ||
+    message.includes('index') ||
+    message.includes('schema') ||
+    message.includes('not found') ||
+    message.includes('does not exist') ||
+    message.includes('unknown')
+  )
+}
+
+export async function countPublicSkillsForGlobalStats(ctx: DbCtx) {
   let count = 0
   let cursor: string | null = null
 
@@ -51,39 +77,56 @@ export async function countPublicSkillsForGlobalStats(ctx: Pick<MutationCtx, 'db
 }
 
 export async function setGlobalPublicSkillsCount(
-  ctx: Pick<MutationCtx, 'db'>,
+  ctx: DbCtx,
   count: number,
   now = Date.now(),
 ) {
   const normalizedCount = Math.max(0, Math.trunc(Number.isFinite(count) ? count : 0))
-  const existing = await ctx.db
-    .query('globalStats')
-    .withIndex('by_key', (q) => q.eq('key', GLOBAL_STATS_KEY))
-    .unique()
+  try {
+    const existing = await ctx.db
+      .query('globalStats')
+      .withIndex('by_key', (q) => q.eq('key', GLOBAL_STATS_KEY))
+      .unique()
 
-  if (existing) {
-    await ctx.db.patch(existing._id, { activeSkillsCount: normalizedCount, updatedAt: now })
-  } else {
-    await ctx.db.insert('globalStats', {
-      key: GLOBAL_STATS_KEY,
-      activeSkillsCount: normalizedCount,
-      updatedAt: now,
-    })
+    if (existing) {
+      await ctx.db.patch(existing._id, { activeSkillsCount: normalizedCount, updatedAt: now })
+    } else {
+      await ctx.db.insert('globalStats', {
+        key: GLOBAL_STATS_KEY,
+        activeSkillsCount: normalizedCount,
+        updatedAt: now,
+      })
+    }
+  } catch (error) {
+    if (isGlobalStatsStorageNotReadyError(error)) return
+    throw error
   }
 }
 
 export async function adjustGlobalPublicSkillsCount(
-  ctx: Pick<MutationCtx, 'db'>,
+  ctx: DbCtx,
   delta: number,
   now = Date.now(),
 ) {
   const normalizedDelta = Math.trunc(Number.isFinite(delta) ? delta : 0)
   if (normalizedDelta === 0) return
 
-  const existing = await ctx.db
-    .query('globalStats')
-    .withIndex('by_key', (q) => q.eq('key', GLOBAL_STATS_KEY))
-    .unique()
+  let existing:
+    | {
+        _id: Doc<'globalStats'>['_id']
+        activeSkillsCount: number
+      }
+    | null
+    | undefined
+  try {
+    existing = await ctx.db
+      .query('globalStats')
+      .withIndex('by_key', (q) => q.eq('key', GLOBAL_STATS_KEY))
+      .unique()
+  } catch (error) {
+    if (isGlobalStatsStorageNotReadyError(error)) return
+    throw error
+  }
 
   if (!existing) {
     // No baseline yet (e.g. fresh deploy). Initialize via full recount once.
@@ -94,4 +137,17 @@ export async function adjustGlobalPublicSkillsCount(
 
   const nextCount = Math.max(0, existing.activeSkillsCount + normalizedDelta)
   await ctx.db.patch(existing._id, { activeSkillsCount: nextCount, updatedAt: now })
+}
+
+export async function readGlobalPublicSkillsCount(ctx: DbCtx) {
+  try {
+    const stats = await ctx.db
+      .query('globalStats')
+      .withIndex('by_key', (q) => q.eq('key', GLOBAL_STATS_KEY))
+      .unique()
+    return stats?.activeSkillsCount ?? null
+  } catch (error) {
+    if (isGlobalStatsStorageNotReadyError(error)) return null
+    throw error
+  }
 }

--- a/convex/lib/globalStats.ts
+++ b/convex/lib/globalStats.ts
@@ -1,0 +1,97 @@
+import type { Doc } from '../_generated/dataModel'
+import type { MutationCtx } from '../_generated/server'
+
+export const GLOBAL_STATS_KEY = 'default'
+const GLOBAL_STATS_PAGE_SIZE = 500
+
+type SkillVisibilityFields = Pick<
+  Doc<'skills'>,
+  'softDeletedAt' | 'moderationStatus' | 'moderationFlags'
+>
+
+export function isPublicSkillDoc(skill: SkillVisibilityFields | null | undefined) {
+  if (!skill || skill.softDeletedAt) return false
+  if (skill.moderationStatus && skill.moderationStatus !== 'active') return false
+  if (skill.moderationFlags?.includes('blocked.malware')) return false
+  return true
+}
+
+export function getPublicSkillVisibilityDelta(
+  before: SkillVisibilityFields | null | undefined,
+  after: SkillVisibilityFields | null | undefined,
+) {
+  const beforePublic = isPublicSkillDoc(before)
+  const afterPublic = isPublicSkillDoc(after)
+  if (beforePublic === afterPublic) return 0
+  return afterPublic ? 1 : -1
+}
+
+export async function countPublicSkillsForGlobalStats(ctx: Pick<MutationCtx, 'db'>) {
+  let count = 0
+  let cursor: string | null = null
+
+  while (true) {
+    const { page, isDone, continueCursor } = await ctx.db
+      .query('skills')
+      .withIndex('by_active_updated', (q) => q.eq('softDeletedAt', undefined))
+      .order('asc')
+      .paginate({ cursor, numItems: GLOBAL_STATS_PAGE_SIZE })
+
+    for (const skill of page) {
+      if (isPublicSkillDoc(skill)) {
+        count += 1
+      }
+    }
+
+    if (isDone) break
+    cursor = continueCursor
+  }
+
+  return count
+}
+
+export async function setGlobalPublicSkillsCount(
+  ctx: Pick<MutationCtx, 'db'>,
+  count: number,
+  now = Date.now(),
+) {
+  const normalizedCount = Math.max(0, Math.trunc(Number.isFinite(count) ? count : 0))
+  const existing = await ctx.db
+    .query('globalStats')
+    .withIndex('by_key', (q) => q.eq('key', GLOBAL_STATS_KEY))
+    .unique()
+
+  if (existing) {
+    await ctx.db.patch(existing._id, { activeSkillsCount: normalizedCount, updatedAt: now })
+  } else {
+    await ctx.db.insert('globalStats', {
+      key: GLOBAL_STATS_KEY,
+      activeSkillsCount: normalizedCount,
+      updatedAt: now,
+    })
+  }
+}
+
+export async function adjustGlobalPublicSkillsCount(
+  ctx: Pick<MutationCtx, 'db'>,
+  delta: number,
+  now = Date.now(),
+) {
+  const normalizedDelta = Math.trunc(Number.isFinite(delta) ? delta : 0)
+  if (normalizedDelta === 0) return
+
+  const existing = await ctx.db
+    .query('globalStats')
+    .withIndex('by_key', (q) => q.eq('key', GLOBAL_STATS_KEY))
+    .unique()
+
+  if (!existing) {
+    // No baseline yet (e.g. fresh deploy). Initialize via full recount once.
+    const count = await countPublicSkillsForGlobalStats(ctx)
+    await setGlobalPublicSkillsCount(ctx, count, now)
+    return
+  }
+
+  const nextCount = Math.max(0, existing.activeSkillsCount + normalizedDelta)
+  await ctx.db.patch(existing._id, { activeSkillsCount: nextCount, updatedAt: now })
+}

--- a/convex/lib/public.ts
+++ b/convex/lib/public.ts
@@ -1,4 +1,5 @@
 import type { Doc } from '../_generated/dataModel'
+import { isPublicSkillDoc } from './globalStats'
 
 export type PublicUser = Pick<
   Doc<'users'>,
@@ -52,9 +53,7 @@ export function toPublicUser(user: Doc<'users'> | null | undefined): PublicUser 
 }
 
 export function toPublicSkill(skill: Doc<'skills'> | null | undefined): PublicSkill | null {
-  if (!skill || skill.softDeletedAt) return null
-  if (skill.moderationStatus && skill.moderationStatus !== 'active') return null
-  if (skill.moderationFlags?.includes('blocked.malware')) return null
+  if (!isPublicSkillDoc(skill)) return null
   const stats = {
     downloads:
       typeof skill.statsDownloads === 'number'

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -342,6 +342,12 @@ const skillStatBackfillState = defineTable({
   updatedAt: v.number(),
 }).index('by_key', ['key'])
 
+const globalStats = defineTable({
+  key: v.string(),
+  activeSkillsCount: v.number(),
+  updatedAt: v.number(),
+}).index('by_key', ['key'])
+
 const skillStatEvents = defineTable({
   skillId: v.id('skills'),
   kind: v.union(
@@ -574,6 +580,7 @@ export default defineSchema({
   skillDailyStats,
   skillLeaderboards,
   skillStatBackfillState,
+  globalStats,
   skillStatEvents,
   skillStatUpdateCursors,
   comments,

--- a/convex/skills.countPublicSkills.test.ts
+++ b/convex/skills.countPublicSkills.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest'
+import { countPublicSkills } from './skills'
+
+type WrappedHandler<TArgs, TResult> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>
+}
+
+const countPublicSkillsHandler = (
+  countPublicSkills as unknown as WrappedHandler<Record<string, never>, number>
+)._handler
+
+function makeSkillsQuery(skills: Array<{ softDeletedAt?: number; moderationStatus?: string | null }>) {
+  return {
+    withIndex: (name: string) => {
+      if (name !== 'by_active_updated') throw new Error(`unexpected skills index ${name}`)
+      return {
+        order: (dir: string) => {
+          if (dir !== 'asc') throw new Error(`unexpected skills order ${dir}`)
+          return {
+            paginate: async () => ({
+              page: skills,
+              isDone: true,
+              continueCursor: null,
+              pageStatus: null,
+              splitCursor: null,
+            }),
+          }
+        },
+      }
+    },
+  }
+}
+
+describe('skills.countPublicSkills', () => {
+  it('returns precomputed global stats count when available', async () => {
+    const ctx = {
+      db: {
+        query: vi.fn((table: string) => {
+          if (table === 'globalStats') {
+            return {
+              withIndex: () => ({
+                unique: async () => ({ _id: 'globalStats:1', activeSkillsCount: 123 }),
+              }),
+            }
+          }
+          if (table === 'skills') {
+            return makeSkillsQuery([])
+          }
+          throw new Error(`unexpected table ${table}`)
+        }),
+      },
+    }
+
+    const result = await countPublicSkillsHandler(ctx, {})
+    expect(result).toBe(123)
+  })
+
+  it('falls back to live count when global stats row is missing', async () => {
+    const ctx = {
+      db: {
+        query: vi.fn((table: string) => {
+          if (table === 'globalStats') {
+            return {
+              withIndex: () => ({
+                unique: async () => null,
+              }),
+            }
+          }
+          if (table === 'skills') {
+            return makeSkillsQuery([
+              { softDeletedAt: undefined, moderationStatus: 'active' },
+              { softDeletedAt: undefined, moderationStatus: 'hidden' },
+              { softDeletedAt: undefined, moderationStatus: 'active' },
+            ])
+          }
+          throw new Error(`unexpected table ${table}`)
+        }),
+      },
+    }
+
+    const result = await countPublicSkillsHandler(ctx, {})
+    expect(result).toBe(2)
+  })
+
+  it('falls back to live count when globalStats table is unavailable', async () => {
+    const ctx = {
+      db: {
+        query: vi.fn((table: string) => {
+          if (table === 'globalStats') {
+            throw new Error('unexpected table globalStats')
+          }
+          if (table === 'skills') {
+            return makeSkillsQuery([
+              { softDeletedAt: undefined, moderationStatus: 'active' },
+              { softDeletedAt: undefined, moderationStatus: 'active' },
+            ])
+          }
+          throw new Error(`unexpected table ${table}`)
+        }),
+      },
+    }
+
+    const result = await countPublicSkillsHandler(ctx, {})
+    expect(result).toBe(2)
+  })
+})

--- a/convex/skills.rateLimit.test.ts
+++ b/convex/skills.rateLimit.test.ts
@@ -22,6 +22,21 @@ const clearOwnerSuspiciousFlagsHandler = (
   clearOwnerSuspiciousFlagsInternal as unknown as WrappedHandler<Record<string, unknown>>
 )._handler
 
+function buildGlobalStatsQuery(table: string) {
+  if (table !== 'globalStats') return null
+  return {
+    withIndex: (name: string) => {
+      if (name !== 'by_key') throw new Error(`unexpected globalStats index ${name}`)
+      return {
+        unique: async () => ({
+          _id: 'globalStats:1',
+          activeSkillsCount: 100,
+        }),
+      }
+    },
+  }
+}
+
 function createPublishArgs(overrides?: Partial<Record<string, unknown>>) {
   return {
     userId: 'users:owner',
@@ -67,6 +82,8 @@ describe('skills anti-spam guards', () => {
         deletedAt: undefined,
       })),
       query: vi.fn((table: string) => {
+        const globalStatsQuery = buildGlobalStatsQuery(table)
+        if (globalStatsQuery) return globalStatsQuery
         if (table === 'skills') {
           return {
             withIndex: (name: string) => {
@@ -127,6 +144,8 @@ describe('skills anti-spam guards', () => {
         return null
       }),
       query: vi.fn((table: string) => {
+        const globalStatsQuery = buildGlobalStatsQuery(table)
+        if (globalStatsQuery) return globalStatsQuery
         if (table === 'skillVersions') {
           return {
             withIndex: () => ({
@@ -197,6 +216,8 @@ describe('skills anti-spam guards', () => {
         return null
       }),
       query: vi.fn((table: string) => {
+        const globalStatsQuery = buildGlobalStatsQuery(table)
+        if (globalStatsQuery) return globalStatsQuery
         if (table === 'skillVersions') {
           return {
             withIndex: () => ({
@@ -265,6 +286,8 @@ describe('skills anti-spam guards', () => {
         return null
       }),
       query: vi.fn((table: string) => {
+        const globalStatsQuery = buildGlobalStatsQuery(table)
+        if (globalStatsQuery) return globalStatsQuery
         if (table === 'skillVersions') {
           return {
             withIndex: () => ({
@@ -324,6 +347,8 @@ describe('skills anti-spam guards', () => {
         return null
       }),
       query: vi.fn((table: string) => {
+        const globalStatsQuery = buildGlobalStatsQuery(table)
+        if (globalStatsQuery) return globalStatsQuery
         if (table === 'skills') {
           return {
             withIndex: (name: string) => {

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -1632,6 +1632,18 @@ function isCursorParseError(error: unknown) {
   return false
 }
 
+export const countPublicSkills = query({
+  args: {},
+  handler: async (ctx) => {
+    const stats = await ctx.db
+      .query('globalStats')
+      .withIndex('by_key', (q) => q.eq('key', 'default'))
+      .unique()
+    // Null means global stats haven't been initialized yet.
+    return stats?.activeSkillsCount ?? null
+  },
+})
+
 function sortToIndex(
   sort: 'downloads' | 'stars' | 'installsCurrent' | 'installsAllTime',
 ):

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -26,7 +26,9 @@ import {
 } from './lib/githubIdentity'
 import {
   adjustGlobalPublicSkillsCount,
+  countPublicSkillsForGlobalStats,
   getPublicSkillVisibilityDelta,
+  readGlobalPublicSkillsCount,
 } from './lib/globalStats'
 import { buildTrendingLeaderboard } from './lib/leaderboards'
 import { deriveModerationFlags } from './lib/moderation'
@@ -1655,12 +1657,10 @@ function isCursorParseError(error: unknown) {
 export const countPublicSkills = query({
   args: {},
   handler: async (ctx) => {
-    const stats = await ctx.db
-      .query('globalStats')
-      .withIndex('by_key', (q) => q.eq('key', 'default'))
-      .unique()
-    // Null means global stats haven't been initialized yet.
-    return stats?.activeSkillsCount ?? null
+    const statsCount = await readGlobalPublicSkillsCount(ctx)
+    if (typeof statsCount === 'number') return statsCount
+    // Fallback for uninitialized/missing globalStats storage.
+    return countPublicSkillsForGlobalStats(ctx)
   },
 })
 

--- a/convex/statsMaintenance.ts
+++ b/convex/statsMaintenance.ts
@@ -3,12 +3,14 @@ import { internal } from './_generated/api'
 import type { Doc } from './_generated/dataModel'
 import type { ActionCtx } from './_generated/server'
 import { internalAction, internalMutation, internalQuery } from './_generated/server'
+import { toPublicSkill } from './lib/public'
 
 const DEFAULT_BATCH_SIZE = 200
 const MAX_BATCH_SIZE = 1000
 const DEFAULT_MAX_BATCHES = 5
 const MAX_MAX_BATCHES = 50
 const BACKFILL_STATE_KEY = 'default'
+const GLOBAL_STATS_PAGE_SIZE = 500
 
 export const backfillSkillStatFieldsInternal = internalMutation({
   args: {
@@ -299,3 +301,44 @@ export const runReconcileSkillStarCountsInternal = internalAction({
 function clampInt(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max)
 }
+
+export const updateGlobalStatsInternal = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    let count = 0
+    let cursor: string | null = null
+
+    while (true) {
+      const { page, isDone, continueCursor } = await ctx.db
+        .query('skills')
+        .withIndex('by_active_updated', (q) => q.eq('softDeletedAt', undefined))
+        .order('asc')
+        .paginate({ cursor, numItems: GLOBAL_STATS_PAGE_SIZE })
+
+      for (const skill of page) {
+        if (toPublicSkill(skill)) {
+          count += 1
+        }
+      }
+
+      if (isDone) break
+      cursor = continueCursor
+    }
+
+    const now = Date.now()
+    const existing = await ctx.db
+      .query('globalStats')
+      .withIndex('by_key', (q) => q.eq('key', 'default'))
+      .unique()
+
+    if (existing) {
+      await ctx.db.patch(existing._id, { activeSkillsCount: count, updatedAt: now })
+    } else {
+      await ctx.db.insert('globalStats', {
+        key: 'default',
+        activeSkillsCount: count,
+        updatedAt: now,
+      })
+    }
+  },
+})

--- a/src/__tests__/helpers/convexReactMocks.ts
+++ b/src/__tests__/helpers/convexReactMocks.ts
@@ -1,0 +1,18 @@
+import { vi } from 'vitest'
+
+export const convexReactMocks = {
+  useAction: vi.fn(),
+  useQuery: vi.fn(),
+  usePaginatedQuery: vi.fn(),
+}
+
+export function resetConvexReactMocks() {
+  convexReactMocks.useAction.mockReset()
+  convexReactMocks.useQuery.mockReset()
+  convexReactMocks.usePaginatedQuery.mockReset()
+}
+
+export function setupDefaultConvexReactMocks() {
+  convexReactMocks.useAction.mockReturnValue(() => Promise.resolve([]))
+  convexReactMocks.useQuery.mockReturnValue(null)
+}

--- a/src/__tests__/skills-index-load-more.test.tsx
+++ b/src/__tests__/skills-index-load-more.test.tsx
@@ -7,6 +7,7 @@ import { SkillsIndex } from '../routes/skills/index'
 
 const navigateMock = vi.fn()
 const useActionMock = vi.fn()
+const useQueryMock = vi.fn()
 const usePaginatedQueryMock = vi.fn()
 let searchMock: Record<string, unknown> = {}
 
@@ -21,6 +22,7 @@ vi.mock('@tanstack/react-router', () => ({
 
 vi.mock('convex/react', () => ({
   useAction: (...args: unknown[]) => useActionMock(...args),
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
   usePaginatedQuery: (...args: unknown[]) => usePaginatedQueryMock(...args),
 }))
 
@@ -28,9 +30,11 @@ describe('SkillsIndex load-more observer', () => {
   beforeEach(() => {
     usePaginatedQueryMock.mockReset()
     useActionMock.mockReset()
+    useQueryMock.mockReset()
     navigateMock.mockReset()
     searchMock = {}
     useActionMock.mockReturnValue(() => Promise.resolve([]))
+    useQueryMock.mockReturnValue(null)
   })
 
   afterEach(() => {

--- a/src/__tests__/skills-index-load-more.test.tsx
+++ b/src/__tests__/skills-index-load-more.test.tsx
@@ -2,13 +2,15 @@
 import { act, render } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  convexReactMocks,
+  resetConvexReactMocks,
+  setupDefaultConvexReactMocks,
+} from './helpers/convexReactMocks'
 
 import { SkillsIndex } from '../routes/skills/index'
 
 const navigateMock = vi.fn()
-const useActionMock = vi.fn()
-const useQueryMock = vi.fn()
-const usePaginatedQueryMock = vi.fn()
 let searchMock: Record<string, unknown> = {}
 
 vi.mock('@tanstack/react-router', () => ({
@@ -21,20 +23,17 @@ vi.mock('@tanstack/react-router', () => ({
 }))
 
 vi.mock('convex/react', () => ({
-  useAction: (...args: unknown[]) => useActionMock(...args),
-  useQuery: (...args: unknown[]) => useQueryMock(...args),
-  usePaginatedQuery: (...args: unknown[]) => usePaginatedQueryMock(...args),
+  useAction: (...args: unknown[]) => convexReactMocks.useAction(...args),
+  useQuery: (...args: unknown[]) => convexReactMocks.useQuery(...args),
+  usePaginatedQuery: (...args: unknown[]) => convexReactMocks.usePaginatedQuery(...args),
 }))
 
 describe('SkillsIndex load-more observer', () => {
   beforeEach(() => {
-    usePaginatedQueryMock.mockReset()
-    useActionMock.mockReset()
-    useQueryMock.mockReset()
+    resetConvexReactMocks()
     navigateMock.mockReset()
     searchMock = {}
-    useActionMock.mockReturnValue(() => Promise.resolve([]))
-    useQueryMock.mockReturnValue(null)
+    setupDefaultConvexReactMocks()
   })
 
   afterEach(() => {
@@ -43,7 +42,7 @@ describe('SkillsIndex load-more observer', () => {
 
   it('triggers one request for repeated intersection callbacks', async () => {
     const loadMorePaginated = vi.fn()
-    usePaginatedQueryMock.mockReturnValue({
+    convexReactMocks.usePaginatedQuery.mockReturnValue({
       results: [makeListResult('skill-0', 'Skill 0')],
       status: 'CanLoadMore',
       loadMore: loadMorePaginated,

--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -7,6 +7,7 @@ import { SkillsIndex } from '../routes/skills/index'
 
 const navigateMock = vi.fn()
 const useActionMock = vi.fn()
+const useQueryMock = vi.fn()
 const usePaginatedQueryMock = vi.fn()
 let searchMock: Record<string, unknown> = {}
 
@@ -21,6 +22,7 @@ vi.mock('@tanstack/react-router', () => ({
 
 vi.mock('convex/react', () => ({
   useAction: (...args: unknown[]) => useActionMock(...args),
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
   usePaginatedQuery: (...args: unknown[]) => usePaginatedQueryMock(...args),
 }))
 
@@ -28,9 +30,11 @@ describe('SkillsIndex', () => {
   beforeEach(() => {
     usePaginatedQueryMock.mockReset()
     useActionMock.mockReset()
+    useQueryMock.mockReset()
     navigateMock.mockReset()
     searchMock = {}
     useActionMock.mockReturnValue(() => Promise.resolve([]))
+    useQueryMock.mockReturnValue(null)
     // Default: return empty results with Exhausted status
     usePaginatedQueryMock.mockReturnValue({
       results: [],

--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -78,17 +78,6 @@ export function useSkillsBrowseModel({
   }, [search.q])
 
   useEffect(() => {
-    if (hasQuery || search.sort) return
-    void navigate({
-      search: (prev) => ({
-        ...prev,
-        sort: 'downloads',
-      }),
-      replace: true,
-    })
-  }, [hasQuery, navigate, search.sort])
-
-  useEffect(() => {
     if (search.focus === 'search' && searchInputRef.current) {
       searchInputRef.current.focus()
       void navigate({ search: (prev) => ({ ...prev, focus: undefined }), replace: true })

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -1,5 +1,7 @@
 import { createFileRoute, redirect } from '@tanstack/react-router'
+import { useQuery } from 'convex/react'
 import { useRef } from 'react'
+import { api } from '../../../convex/_generated/api'
 import { parseSort } from './-params'
 import { SkillsResults } from './-SkillsResults'
 import { SkillsToolbar } from './-SkillsToolbar'
@@ -49,6 +51,9 @@ export function SkillsIndex() {
   const navigate = Route.useNavigate()
   const search = Route.useSearch()
   const searchInputRef = useRef<HTMLInputElement>(null)
+  const totalSkills = useQuery(api.skills.countPublicSkills)
+  const totalSkillsText =
+    typeof totalSkills === 'number' ? totalSkills.toLocaleString('en-US') : null
 
   const model = useSkillsBrowseModel({
     navigate,
@@ -61,6 +66,7 @@ export function SkillsIndex() {
       <header className="skills-header-top">
         <h1 className="section-title" style={{ marginBottom: 8 }}>
           Skills
+          {totalSkillsText && <span style={{ opacity: 0.55 }}>{` (${totalSkillsText})`}</span>}
         </h1>
         <p className="section-subtitle" style={{ marginBottom: 0 }}>
           {model.isLoadingSkills


### PR DESCRIPTION
Re-lands the #76 skills-count feature that was reverted in #359, with migration-safe behavior.

## What changed
- Re-applies the original `/skills` total count UI + `globalStats` table/cron.
- Re-applies follow-up refactors for public-visibility/count consistency.
- Adds hard fallbacks so `/skills` never errors if `globalStats` table/index/row is missing:
  - `skills.countPublicSkills` returns precomputed count when available.
  - If global stats storage is unavailable or uninitialized, it falls back to a live public-skill count.
- Guards `globalStats` write paths so missing storage does not fail unrelated skill mutations.
- Adds regression tests for `countPublicSkills` fallback paths.

## Verification
- `bun run lint`
- `bun run build`
- `bun run test`

Fixes #357

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Re-lands the #76 skills-count feature (reverted in #359) with migration-safe fallbacks. Adds a `globalStats` table with an hourly cron for full reconciliation, incremental count adjustments on every skill mutation path, and a `countPublicSkills` query that prefers precomputed counts but falls back to a live scan if the table isn't ready. Centralizes public-visibility checks from `toPublicSkill` into a reusable `isPublicSkillDoc` function, removes a redundant client-side default-sort `useEffect`, and shares Convex React test mocks across the skills test suite.

- The `globalStats` error-detection heuristic (`isGlobalStatsStorageNotReadyError`) is string-based, which is pragmatic for migration safety but may need updating if Convex changes its error message format.
- All skill mutation sites consistently apply the `{...skill, ...patch}` pattern to compute before/after visibility deltas — no double-counting was found in the `insertVersion` flow.
- The live-count fallback in the `countPublicSkills` query paginates through all skills, which could be expensive on large datasets, but this only triggers when `globalStats` hasn't been initialized yet and is quickly resolved by the hourly cron.
- Test coverage is solid: three fallback scenarios for `countPublicSkills` and updated rate-limit tests to handle the new `globalStats` queries.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — all mutation paths are properly guarded with fallbacks, and the feature degrades gracefully if the new table isn't deployed yet.
- Score of 5 reflects: (1) consistent and thorough integration of count adjustments at all skill mutation sites, (2) robust error handling that prevents the new feature from breaking existing functionality even during migration, (3) proper test coverage for all fallback paths, (4) clean code organization with centralized visibility logic, and (5) no logical errors or security issues found after thorough review.
- No files require special attention.

<sub>Last reviewed commit: 89129a5</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a1d58d20-b4dd-4cbb-973a-9fd7824e1921))

<!-- /greptile_comment -->