### PR TITLE
Hotfix: fix /skills count fallback runtime on Convex

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -48,6 +48,7 @@ import type * as lib_githubImport from "../lib/githubImport.js";
 import type * as lib_githubProfileSync from "../lib/githubProfileSync.js";
 import type * as lib_githubRestoreHelpers from "../lib/githubRestoreHelpers.js";
 import type * as lib_githubSoulBackup from "../lib/githubSoulBackup.js";
+import type * as lib_globalStats from "../lib/globalStats.js";
 import type * as lib_httpHeaders from "../lib/httpHeaders.js";
 import type * as lib_httpRateLimit from "../lib/httpRateLimit.js";
 import type * as lib_leaderboards from "../lib/leaderboards.js";
@@ -137,6 +138,7 @@ declare const fullApi: ApiFromModules<{
   "lib/githubProfileSync": typeof lib_githubProfileSync;
   "lib/githubRestoreHelpers": typeof lib_githubRestoreHelpers;
   "lib/githubSoulBackup": typeof lib_githubSoulBackup;
+  "lib/globalStats": typeof lib_globalStats;
   "lib/httpHeaders": typeof lib_httpHeaders;
   "lib/httpRateLimit": typeof lib_httpRateLimit;
   "lib/leaderboards": typeof lib_leaderboards;

--- a/convex/lib/public.ts
+++ b/convex/lib/public.ts
@@ -53,6 +53,7 @@ export function toPublicUser(user: Doc<'users'> | null | undefined): PublicUser 
 }
 
 export function toPublicSkill(skill: Doc<'skills'> | null | undefined): PublicSkill | null {
+  if (!skill) return null
   if (!isPublicSkillDoc(skill)) return null
   const stats = {
     downloads:

--- a/convex/skills.countPublicSkills.test.ts
+++ b/convex/skills.countPublicSkills.test.ts
@@ -14,18 +14,7 @@ function makeSkillsQuery(skills: Array<{ softDeletedAt?: number; moderationStatu
     withIndex: (name: string) => {
       if (name !== 'by_active_updated') throw new Error(`unexpected skills index ${name}`)
       return {
-        order: (dir: string) => {
-          if (dir !== 'asc') throw new Error(`unexpected skills order ${dir}`)
-          return {
-            paginate: async () => ({
-              page: skills,
-              isDone: true,
-              continueCursor: null,
-              pageStatus: null,
-              splitCursor: null,
-            }),
-          }
-        },
+        collect: async () => skills,
       }
     },
   }


### PR DESCRIPTION
Follow-up hotfix after re-landing #76.

## Issue
`skills.countPublicSkills` fallback used repeated paginated queries, which Convex disallows inside one function.

## Fix
- Switch fallback counting to a single `collect()` query in `convex/lib/globalStats.ts`.
- Keep type-narrowing explicit in `toPublicSkill`.
- Update fallback tests.
- Regenerate `convex/_generated/api.d.ts`.

## Verification
- `bun run lint`
- `bun run test`
- `bunx convex deploy -y`
- `bunx convex run --deployment-name wry-manatee-359 statsMaintenance:updateGlobalStatsInternal`
- `bunx convex run --deployment-name wry-manatee-359 skills:countPublicSkills` (returned `7774`)
