### PR TITLE
feat: Add SPIRIT skill to devSeed

### DIFF
--- a/convex/devSeed.ts
+++ b/convex/devSeed.ts
@@ -261,6 +261,7 @@ xuezh audio process-voice --file ./utterance.wav
 name: spirit
 description: Resurrect your AI agent anywhere. Preserves identity, memory, and projects so when your server dies or you migrate, your agent is always you. Use when (1) Session ending, (2) User asks to backup/preserve state, (3) Setting up SPIRIT, or (4) Restoring on a new server.
 ---
+
 # SPIRIT Skill
 
 Preserves AI agent state (identity, memory, projects) using SPIRIT CLI.


### PR DESCRIPTION
- Resurrect your AI agent anywhere
- Preserves identity, memory, projects across sessions/servers
- Auto-installs latest via install.sh
- Triggers: checkpoint, backup, preserve, session-end
- Security: requires PRIVATE repositories

Installs on-demand via OpenClaw when 'spirit' binary needed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `SPIRIT` skill seed entry to `convex/devSeed.ts`. SPIRIT is a CLI tool for preserving and restoring AI agent state (identity, memory, projects) across sessions and servers via a git-backed mechanism.

The skill spec uses `kind: 'brew'` for its install entry, which is a valid install kind per `packages/schema/src/schemas.ts:259`. The `openclaw` metadata namespace is correctly handled by `parseClawdisMetadata` in `convex/lib/skills.ts:78`. Several previously flagged issues (code fences around shell commands, `install.sh` reference removal) have been addressed across the fix commits.

Key remaining issues:
- A trailing stray `'` character at the end of the `rawSkillMd` template literal (line 303) has persisted through all four fix commits and will appear as a literal apostrophe at the end of the rendered Markdown document.
- The `# SPIRIT Skill` heading follows the closing frontmatter `---` without a blank line, inconsistent with all other skills in the file.
- The previously flagged duplicate `metadata:` key concern (from thread at line 260) and `kind: exec` install spec issues (from thread) were addressed in earlier fix commits and no longer apply to the current HEAD.

<h3>Confidence Score: 3/5</h3>

- This PR is low-risk for the application but has minor unresolved content defects in the skill Markdown.
- The core install spec is valid (`kind: 'brew'`) and the `openclaw` metadata namespace is properly parsed. The stray trailing quote is a cosmetic Markdown content bug that won't break parsing or runtime behavior, and the missing blank line after frontmatter is a style inconsistency. No runtime errors or security issues are introduced by the current state of the code.
- convex/devSeed.ts — specifically line 303 (trailing stray quote) and line 264 (missing blank line after frontmatter)

<sub>Last reviewed commit: 786922e</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a1d58d20-b4dd-4cbb-973a-9fd7824e1921))

<!-- /greptile_comment -->