### PR TITLE
fix(cli): align delete command wording with owner permissions

### DIFF
--- a/packages/clawdhub/src/cli.ts
+++ b/packages/clawdhub/src/cli.ts
@@ -278,7 +278,7 @@ program
 
 program
   .command('delete')
-  .description('Soft-delete a skill (moderator/admin only)')
+  .description('Soft-delete a skill (owner, moderator, or admin)')
   .argument('<slug>', 'Skill slug')
   .option('--yes', 'Skip confirmation')
   .action(async (slug, options) => {
@@ -288,7 +288,7 @@ program
 
 program
   .command('hide')
-  .description('Hide a skill (moderator/admin only)')
+  .description('Hide a skill (owner, moderator, or admin)')
   .argument('<slug>', 'Skill slug')
   .option('--yes', 'Skip confirmation')
   .action(async (slug, options) => {
@@ -298,7 +298,7 @@ program
 
 program
   .command('undelete')
-  .description('Restore a hidden skill (moderator/admin only)')
+  .description('Restore a hidden skill (owner, moderator, or admin)')
   .argument('<slug>', 'Skill slug')
   .option('--yes', 'Skip confirmation')
   .action(async (slug, options) => {
@@ -308,7 +308,7 @@ program
 
 program
   .command('unhide')
-  .description('Unhide a skill (moderator/admin only)')
+  .description('Unhide a skill (owner, moderator, or admin)')
   .argument('<slug>', 'Skill slug')
   .option('--yes', 'Skip confirmation')
   .action(async (slug, options) => {

--- a/packages/clawdhub/src/cli/commands/delete.ts
+++ b/packages/clawdhub/src/cli/commands/delete.ts
@@ -16,28 +16,28 @@ const deleteLabels: SkillActionLabels = {
   verb: 'Delete',
   progress: 'Deleting',
   past: 'Deleted',
-  promptSuffix: 'soft delete, requires moderator/admin',
+  promptSuffix: 'soft delete, owner/moderator/admin',
 }
 
 const undeleteLabels: SkillActionLabels = {
   verb: 'Undelete',
   progress: 'Undeleting',
   past: 'Undeleted',
-  promptSuffix: 'requires moderator/admin',
+  promptSuffix: 'owner/moderator/admin',
 }
 
 const hideLabels: SkillActionLabels = {
   verb: 'Hide',
   progress: 'Hiding',
   past: 'Hidden',
-  promptSuffix: 'requires moderator/admin',
+  promptSuffix: 'owner/moderator/admin',
 }
 
 const unhideLabels: SkillActionLabels = {
   verb: 'Unhide',
   progress: 'Unhiding',
   past: 'Unhidden',
-  promptSuffix: 'requires moderator/admin',
+  promptSuffix: 'owner/moderator/admin',
 }
 
 export async function cmdDeleteSkill(


### PR DESCRIPTION
## Summary
- update `clawhub delete|hide|undelete|unhide` command descriptions to state owner/moderator/admin access
- update delete command confirmation suffix text to match the same permission model

## Rationale
Backend soft-delete already allows owners to manage their own skills, and only requires moderator/admin for non-owners (`convex/skills.ts`, `setSkillSoftDeletedInternal`). CLI wording was stale and implied owners were blocked.

## Testing
- `bunx vitest run packages/clawdhub/src/cli/commands/delete.test.ts`
- `bun run lint`

Refs #413

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated CLI command descriptions and confirmation prompts to correctly reflect that skill owners can manage their own skills' soft-delete status without requiring moderator/admin privileges. The backend logic in `convex/skills.ts` (`setSkillSoftDeletedInternal`) already implements this permission model: it allows owners to manage their own skills and only requires moderator/admin access for non-owners.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - straightforward text-only documentation fix
- Changes are purely textual updates to CLI help strings that align with existing backend implementation, no logic changes, and tests pass
- No files require special attention

<sub>Last reviewed commit: b2e4144</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->