### PR TITLE
fix: clear stale suspicious flag when VT verdict improves

### DIFF
--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -2611,8 +2611,8 @@ export const approveSkillByHashInternal = internalMutation({
       if (isMalicious || alreadyBlocked) {
         // Malicious from ANY scanner → blocked.malware (upgrade from suspicious)
         newFlags = ['blocked.malware']
-      } else if ((isSuspicious || alreadyFlagged) && !bypassSuspicious) {
-        // Suspicious from ANY scanner → flagged.suspicious
+      } else if (isSuspicious && !bypassSuspicious) {
+        // Suspicious from this scanner → flagged.suspicious
         newFlags = ['flagged.suspicious']
       } else if (isClean) {
         // Clean from this scanner — only clear if no other scanner has flagged

--- a/convex/vt.ts
+++ b/convex/vt.ts
@@ -834,7 +834,7 @@ export const rescanActiveSkills = internalAction({
             status,
           })
           accUpdated++
-        } else if (wasFlagged) {
+        } else if (wasFlagged && status === 'clean') {
           // Verdict improved from suspicious → clean: clear the stale moderation flag
           console.log(`[vt:rescan] ${slug}: verdict improved to clean, clearing suspicious flag`)
           await ctx.runMutation(internal.skills.approveSkillByHashInternal, {


### PR DESCRIPTION
## Summary

- The daily VT rescan (`rescanActiveSkills`) updates `vtAnalysis` on the version when a verdict changes, but only called `escalateByVtInternal` for suspicious/malicious verdicts
- When a verdict **improved** from suspicious to clean, the version's `vtAnalysis.status` was updated to `"clean"` (website shows "Benign") but the skill's `moderationFlags` kept the stale `"flagged.suspicious"` entry (CLI warns "suspicious", website shows warning banner)
- Now the rescan calls `approveSkillByHashInternal` to clear the flag when a previously-flagged skill's verdict improves to clean

Reported via https://clawhub.ai/pskoett/self-improving-agent — both scanners say Benign but the skill is still flagged.

## Test plan

- [ ] Verify `rescanActiveSkills` clears `flagged.suspicious` for skills whose VT verdict improved to clean
- [ ] Verify skills that are still suspicious/malicious are unaffected
- [ ] Verify clean skills that were never flagged remain counted as `accUnchanged`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where the daily VT rescan would update a version's `vtAnalysis.status` to `"clean"` when the verdict improved, but left a stale `flagged.suspicious` entry in the skill's `moderationFlags`. This caused the CLI to warn "suspicious" and the website to show a warning banner even after VT declared the skill benign.

- **`convex/skills.ts`**: Adds a `wasFlagged` boolean to the rescan batch query, indicating whether the skill currently has `flagged.suspicious` in its `moderationFlags`.
- **`convex/vt.ts`**: Uses `wasFlagged` in the rescan loop to call `approveSkillByHashInternal` when a previously-flagged skill's verdict improves, clearing the stale moderation flag.
- The cross-scanner protection in `approveSkillByHashInternal` ensures that if another scanner (e.g., LLM) has independently flagged the skill, the flag is preserved.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor edge case to consider around unrecognized VT verdicts.
- The fix is well-scoped and addresses the reported bug correctly. The cross-scanner protection in `approveSkillByHashInternal` handles multi-scanner scenarios properly. One minor logic concern: the `else if (wasFlagged)` branch doesn't guard against `status === 'pending'`, which could clear a suspicious flag on an inconclusive verdict. In practice this edge case is unlikely given VT's current verdict categories, but adding `&& status === 'clean'` would be more defensive.
- `convex/vt.ts` — the `else if (wasFlagged)` condition at line 837 could be tightened to only trigger on `status === 'clean'`.

<sub>Last reviewed commit: a17d333</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=a1d58d20-b4dd-4cbb-973a-9fd7824e1921))

<!-- /greptile_comment -->