### PR TITLE
Fxing an issue removal of the registry path

### DIFF
--- a/packages/clawdhub/src/cli/commands/inspect.ts
+++ b/packages/clawdhub/src/cli/commands/inspect.ts
@@ -1,4 +1,4 @@
-import { apiRequest, fetchText } from '../../http.js'
+import { apiRequest, fetchText, registryUrl } from '../../http.js'
 import {
   ApiRoutes,
   ApiV1SkillResponseSchema,
@@ -78,7 +78,7 @@ export async function cmdInspect(opts: GlobalOpts, slug: string, options: Inspec
     let versionsList: { items?: unknown[]; nextCursor?: string | null } | null = null
     if (options.versions) {
       const limit = clampLimit(options.limit ?? 25, 25)
-      const url = new URL(`${ApiRoutes.skills}/${encodeURIComponent(trimmed)}/versions`, registry)
+      const url = registryUrl(`${ApiRoutes.skills}/${encodeURIComponent(trimmed)}/versions`, registry)
       url.searchParams.set('limit', String(limit))
       spinner.text = `Fetching versions (${limit})`
       versionsList = await apiRequest(
@@ -90,7 +90,7 @@ export async function cmdInspect(opts: GlobalOpts, slug: string, options: Inspec
 
     let fileContent: string | null = null
     if (options.file) {
-      const url = new URL(`${ApiRoutes.skills}/${encodeURIComponent(trimmed)}/file`, registry)
+      const url = registryUrl(`${ApiRoutes.skills}/${encodeURIComponent(trimmed)}/file`, registry)
       url.searchParams.set('path', options.file)
       if (options.version) {
         url.searchParams.set('version', options.version)

--- a/packages/clawdhub/src/cli/commands/moderation.ts
+++ b/packages/clawdhub/src/cli/commands/moderation.ts
@@ -1,5 +1,5 @@
 import { isCancel, select } from '@clack/prompts'
-import { apiRequest } from '../../http.js'
+import { apiRequest, registryUrl } from '../../http.js'
 import {
   ApiRoutes,
   ApiV1BanUserResponseSchema,
@@ -192,12 +192,12 @@ async function resolveUserIdentifier(
 }
 
 async function searchUsers(registry: string, token: string, query: string) {
-  const url = new URL(ApiRoutes.users, registry)
+  const url = registryUrl(ApiRoutes.users, registry)
   url.searchParams.set('q', query.trim())
   url.searchParams.set('limit', '10')
   const result = await apiRequest(
     registry,
-    { method: 'GET', path: `${url.pathname}?${url.searchParams.toString()}`, token },
+    { method: 'GET', url: url.toString(), token },
     ApiV1UserSearchResponseSchema,
   )
   return parseArk(ApiV1UserSearchResponseSchema, result, 'User search response')

--- a/packages/clawdhub/src/cli/commands/skills.ts
+++ b/packages/clawdhub/src/cli/commands/skills.ts
@@ -1,7 +1,7 @@
 import { mkdir, rm, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import semver from 'semver'
-import { apiRequest, downloadZip } from '../../http.js'
+import { apiRequest, downloadZip, registryUrl } from '../../http.js'
 import {
   ApiRoutes,
   ApiV1SearchResponseSchema,
@@ -43,7 +43,7 @@ export async function cmdSearch(opts: GlobalOpts, query: string, limit?: number)
   const registry = await getRegistry(opts, { cache: true })
   const spinner = createSpinner('Searching')
   try {
-    const url = new URL(ApiRoutes.search, registry)
+    const url = registryUrl(ApiRoutes.search, registry)
     url.searchParams.set('q', query)
     if (typeof limit === 'number' && Number.isFinite(limit)) {
       url.searchParams.set('limit', String(limit))
@@ -363,7 +363,7 @@ export async function cmdExplore(
   const registry = await getRegistry(opts, { cache: true })
   const spinner = createSpinner('Fetching latest skills')
   try {
-    const url = new URL(ApiRoutes.skills, registry)
+    const url = registryUrl(ApiRoutes.skills, registry)
     const boundedLimit = clampLimit(options.limit ?? 25)
     const { apiSort } = resolveExploreSort(options.sort)
     url.searchParams.set('limit', String(boundedLimit))
@@ -465,7 +465,7 @@ function resolveExploreSort(raw?: string): { sort: ExploreSort; apiSort: ApiExpl
 }
 
 async function resolveSkillVersion(registry: string, slug: string, hash: string, token?: string) {
-  const url = new URL(ApiRoutes.resolve, registry)
+  const url = registryUrl(ApiRoutes.resolve, registry)
   url.searchParams.set('slug', slug)
   url.searchParams.set('hash', hash)
   return apiRequest(


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed URL construction to preserve registry base paths when the registry is hosted at a non-root path (e.g., `http://host/custom/registry/path`). Previously, `new URL('/api/v1/skills', 'http://host/base')` would discard `/base` because absolute paths override the base URL's path component. The new `registryUrl()` helper normalizes both arguments to construct relative URLs, ensuring `http://host/base/api/v1/skills`.

- Introduced `registryUrl()` helper function in `http.ts` with proper path normalization
- Updated all URL construction sites across `inspect.ts`, `moderation.ts`, and `skills.ts` to use the new helper
- Added comprehensive test coverage in `http.test.ts` covering plain origins, custom base paths, trailing slashes, and encoded segments
- Fixed `moderation.ts` to pass complete URLs instead of pathname-only strings to maintain base path context

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix addresses a clear bug with proper encapsulation through a helper function, includes comprehensive test coverage for edge cases, and consistently applies the fix across all affected call sites. The implementation is straightforward with no complex logic or side effects.
- No files require special attention

<sub>Last reviewed commit: 8401d0d</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->