### PR TITLE
fix(http): add exponential backoff for rate limiting (429 errors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - CLI: respect `HTTPS_PROXY`/`HTTP_PROXY`/`NO_PROXY` env vars for outbound registry requests, with troubleshooting docs (#363) (thanks @kerrypotter).
 - CLI: preserve registry base paths when composing API URLs for search/inspect/moderation commands (#486) (thanks @Liknox).
 - API tests: lock `Retry-After` behavior to relative-delay semantics for v1 search 429s (#421) (thanks @apoorvdarshan).
+- CLI tests: assert 5xx HTTP responses still perform retry attempts before surfacing final error (#457) (thanks @YonghaoZhao722).
 
 ## 0.6.1 - 2026-02-13
 

--- a/packages/clawdhub/src/http.test.ts
+++ b/packages/clawdhub/src/http.test.ts
@@ -203,6 +203,7 @@ describe('apiRequest', () => {
   })
 
   it('falls back to HTTP status when body is empty', async () => {
+    mockImmediateTimeouts()
     const fetchMock = vi.fn().mockResolvedValue({
       ok: false,
       status: 500,
@@ -212,6 +213,7 @@ describe('apiRequest', () => {
     await expect(
       apiRequest('https://example.com', { method: 'GET', url: 'https://example.com/x' }),
     ).rejects.toThrow('HTTP 500')
+    expect(fetchMock).toHaveBeenCalledTimes(3)
     vi.unstubAllGlobals()
   })
 


### PR DESCRIPTION
## Problem

The current pRetry configuration only specifies `{ retries: 2 }` with no delay between attempts. When the server returns a 429 (rate limit) or 5xx error, the client immediately retries twice without backoff, causing repeated failures.

## Solution

Add exponential backoff with jitter to all pRetry calls:

- `minTimeout: 1000` - Initial delay of 1 second
- `maxTimeout: 8000` - Max delay capped at 8 seconds  
- `factor: 2` - Exponential multiplier (1s → 2s → 4s...)
- `randomize: true` - Adds jitter to prevent thundering herd
- `onFailedAttempt` - Logs retry attempts for debugging

## Changes

Modified `packages/clawdhub/src/http.ts`:
- Added `createRetryOptions()` helper function
- Replaced all `{ retries: 2 }` with backoff configuration
- Each operation has a descriptive name for logging

## Backwards Compatibility

Non-retryable errors (4xx except 429) still abort immediately via `AbortError`. Only 429 and 5xx errors trigger the backoff retry.

---

Co-authored-by: Claude <claude@anthropic.com>
Co-authored-by: Clawdbot <clawdbot@openclaw.ai>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added exponential backoff configuration to all HTTP retry operations to handle rate limiting (429) and server errors (5xx) more gracefully. The implementation introduces a `createRetryOptions()` helper that configures p-retry with 1-8 second delays, exponential factor of 2, randomized jitter, and debug logging for retry attempts.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is well-scoped, adds proper exponential backoff to handle rate limiting gracefully, maintains existing error handling behavior (non-retryable errors still abort immediately), and has comprehensive test coverage that validates retry behavior for 429 errors and timeouts
- No files require special attention

<sub>Last reviewed commit: 2d93733</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->