### PR TITLE
Add a GH action to scan for potential leaked secrets in pull requests

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: TruffleHog OSS
         id: trufflehog
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@e64309e4514a601c7d23f336688782a229a4a754 # Pin to current stable
         with:
           path: ./
           base: ${{ github.event.pull_request.base.sha }} # scope it to the committed files


### PR DESCRIPTION
# Add a GH action to scan for potential leaked secrets in pull requests

This PR adds a GH action to ensure that any PR's containing *Live*, *Validated* known credential patterns immediately error the build out. This uses a trufflehog action to scan for and validate the existence of authentication tokens and credentials like GH OAuth tokens, etc.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a GitHub Actions workflow to scan pull requests for verified secrets using TruffleHog. The workflow runs on PRs targeting `main` or `master` branches and will fail the build if live, validated credentials are detected.

- Implements security scanning using TruffleHog OSS action
- Scopes scan to PR changes only (`base` to `head` SHA)
- Uses `--only-verified` flag to minimize false positives
- Provides clear error messaging when secrets are found
- Contains a typo in the failure notification message ("removel" instead of "removal")

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk after fixing the typo
- The workflow adds important security scanning without modifying any application code. The implementation follows GitHub Actions best practices with appropriate permissions and scoping. Only issue is a minor typo in the error message and a style suggestion about version pinning.
- No files require special attention beyond fixing the typo in `secret-scan.yml`

<sub>Last reviewed commit: 397c17e</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->