### PR TITLE
Improve error handling in GitHub import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - CLI: preserve registry base paths when composing API URLs for search/inspect/moderation commands (#486) (thanks @Liknox).
 - API tests: lock `Retry-After` behavior to relative-delay semantics for v1 search 429s (#421) (thanks @apoorvdarshan).
 - CLI tests: assert 5xx HTTP responses still perform retry attempts before surfacing final error (#457) (thanks @YonghaoZhao722).
+- GitHub import: improve storage/publish failure errors with actionable context; add regression tests for error formatting (#512) (thanks @vassiliylakhonin).
 
 ## 0.6.1 - 2026-02-13
 

--- a/convex/githubImport.test.ts
+++ b/convex/githubImport.test.ts
@@ -4,6 +4,20 @@ import { __test } from './githubImport'
 import { buildGitHubZipForTests } from './lib/githubImport'
 
 describe('githubImport', () => {
+  it('formats storage failure message with file context', () => {
+    const message = __test.buildStoreFailureMessage('skill/SKILL.md', 123, new Error('disk full'))
+    expect(message).toBe('Failed to store file "skill/SKILL.md" (123 bytes). disk full')
+  })
+
+  it('formats publish failure message with fallback text', () => {
+    expect(__test.buildPublishFailureMessage(new Error('slug exists'))).toBe(
+      'Import failed during publish: slug exists. Check skill format, slug availability, and try again.',
+    )
+    expect(__test.buildPublishFailureMessage('unexpected')).toBe(
+      'Import failed during publish: unexpected. Check skill format, slug availability, and try again.',
+    )
+  })
+
   it('filters mac junk files while unzipping archive entries', () => {
     const zip = buildGitHubZipForTests({
       'demo-repo/skill/SKILL.md': '# Demo',

--- a/convex/githubImport.ts
+++ b/convex/githubImport.ts
@@ -196,10 +196,7 @@ export const importGitHubSkill = action({
       try {
         storageId = await ctx.storage.store(new Blob([safeBytes], { type: 'text/plain' }))
       } catch (error) {
-        const errorMsg = error instanceof Error ? error.message : String(error)
-        throw new ConvexError(
-          `Failed to store file "${sanitized}" (${bytes.byteLength} bytes). ${errorMsg}`,
-        )
+        throw new ConvexError(buildStoreFailureMessage(sanitized, bytes.byteLength, error))
       }
       storedFiles.push({
         path: sanitized,
@@ -241,10 +238,7 @@ export const importGitHubSkill = action({
         },
       })
     } catch (error) {
-      const errorMsg = error instanceof Error ? error.message : String(error)
-      throw new ConvexError(
-        `Import failed during publish: ${errorMsg}. Check skill format, slug availability, and try again.`,
-      )
+      throw new ConvexError(buildPublishFailureMessage(error))
     }
 
     return { ok: true, slug: slugBase, version, ...result }
@@ -324,6 +318,20 @@ function normalizeZipPath(path: string) {
   return normalized
 }
 
+function toErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function buildStoreFailureMessage(path: string, sizeBytes: number, error: unknown) {
+  return `Failed to store file "${path}" (${sizeBytes} bytes). ${toErrorMessage(error)}`
+}
+
+function buildPublishFailureMessage(error: unknown) {
+  return `Import failed during publish: ${toErrorMessage(error)}. Check skill format, slug availability, and try again.`
+}
+
 export const __test = {
+  buildPublishFailureMessage,
+  buildStoreFailureMessage,
   unzipToEntries,
 }


### PR DESCRIPTION
## What this fixes

Addresses issues #491 and #477 where users receive generic "Server Error" when importing skills via GitHub.

## Changes

- **Storage errors**: Now include file path and size in error messages
- **Publish errors**: Wrapped in try/catch with helpful context about skill format and slug availability
- **User guidance**: Error messages now suggest concrete next steps

## Before

```
Server Error Called by Client
```

## After

```
Failed to store file "SKILL.md" (1024 bytes). [specific error]
Import failed during publish: [specific error]. Check skill format, slug availability, and try again.
```

## Testing

- Import flow with invalid files should show specific error
- Import flow with duplicate slug should suggest trying a different name
- Import flow with formatting issues should surface the actual validation error

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wraps two critical operations in the GitHub import flow with try-catch blocks to provide more specific error messages:

- **Storage errors** (lines 196-203): When `ctx.storage.store()` fails, the error now includes the file name and size to help debug storage issues
- **Publish errors** (lines 225-247): When `publishVersionForUser()` fails, the error message now suggests checking skill format and slug availability

The changes directly address issues #491 and #477 where users were receiving generic "Server Error" messages during GitHub imports.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are focused error handling improvements that wrap existing operations without changing core logic. The try-catch blocks properly re-throw errors with enhanced context, making debugging easier without introducing new failure modes.
- No files require special attention

<sub>Last reviewed commit: 3180109</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->