### PR TITLE
fix(upload): ignore macOS junk files during publish

### DIFF
--- a/convex/githubImport.test.ts
+++ b/convex/githubImport.test.ts
@@ -1,0 +1,22 @@
+/* @vitest-environment node */
+import { describe, expect, it } from 'vitest'
+import { __test } from './githubImport'
+import { buildGitHubZipForTests } from './lib/githubImport'
+
+describe('githubImport', () => {
+  it('filters mac junk files while unzipping archive entries', () => {
+    const zip = buildGitHubZipForTests({
+      'demo-repo/skill/SKILL.md': '# Demo',
+      'demo-repo/skill/notes.md': 'notes',
+      'demo-repo/skill/.DS_Store': 'junk',
+      'demo-repo/skill/._notes.md': 'junk',
+      'demo-repo/__MACOSX/._SKILL.md': 'junk',
+    })
+
+    const entries = __test.unzipToEntries(zip)
+    expect(Object.keys(entries).sort()).toEqual([
+      'demo-repo/skill/SKILL.md',
+      'demo-repo/skill/notes.md',
+    ])
+  })
+})

--- a/convex/githubImport.ts
+++ b/convex/githubImport.ts
@@ -20,7 +20,7 @@ import {
   suggestVersion,
 } from './lib/githubImport'
 import { publishVersionForUser } from './lib/skillPublish'
-import { sanitizePath } from './lib/skills'
+import { isMacJunkPath, sanitizePath } from './lib/skills'
 
 const MAX_SELECTED_BYTES = 50 * 1024 * 1024
 const MAX_UNZIPPED_BYTES = 80 * 1024 * 1024
@@ -244,7 +244,7 @@ function unzipToEntries(zipBytes: Uint8Array) {
   for (const [rawPath, bytes] of Object.entries(entries)) {
     const normalizedPath = normalizeZipPath(rawPath)
     if (!normalizedPath) continue
-    if (isJunkPath(normalizedPath)) continue
+    if (isMacJunkPath(normalizedPath)) continue
     if (!bytes) continue
     if (bytes.byteLength > MAX_SINGLE_FILE_BYTES) continue
     totalBytes += bytes.byteLength
@@ -308,10 +308,6 @@ function normalizeZipPath(path: string) {
   return normalized
 }
 
-function isJunkPath(path: string) {
-  const normalized = path.toLowerCase()
-  if (normalized.startsWith('__macosx/')) return true
-  if (normalized.endsWith('/.ds_store')) return true
-  if (normalized === '.ds_store') return true
-  return false
+export const __test = {
+  unzipToEntries,
 }

--- a/convex/httpApiV1/shared.ts
+++ b/convex/httpApiV1/shared.ts
@@ -5,6 +5,7 @@ import type { ActionCtx } from '../_generated/server'
 import { assertAdmin } from '../lib/access'
 import { requireApiTokenUser } from '../lib/apiTokenAuth'
 import { corsHeaders, mergeHeaders } from '../lib/httpHeaders'
+import { isMacJunkPath } from '../lib/skills'
 
 export const MAX_RAW_FILE_BYTES = 200 * 1024
 
@@ -259,6 +260,7 @@ export async function parseMultipartPublish(
     const file = toFileLike(entry)
     if (!file) continue
     const path = file.name
+    if (isMacJunkPath(path)) continue
     const size = file.size
     const contentType = file.type || undefined
     const buffer = new Uint8Array(await file.arrayBuffer())

--- a/convex/lib/skills.test.ts
+++ b/convex/lib/skills.test.ts
@@ -4,6 +4,7 @@ import {
   getFrontmatterMetadata,
   getFrontmatterValue,
   hashSkillFiles,
+  isMacJunkPath,
   isTextFile,
   parseClawdisMetadata,
   parseFrontmatter,
@@ -150,6 +151,15 @@ describe('skills utils', () => {
     expect(isTextFile('note.txt', 'text/plain')).toBe(true)
     expect(isTextFile('data.any', 'application/json')).toBe(true)
     expect(isTextFile('data.json')).toBe(true)
+  })
+
+  it('detects mac junk paths', () => {
+    expect(isMacJunkPath('.DS_Store')).toBe(true)
+    expect(isMacJunkPath('folder/.DS_Store')).toBe(true)
+    expect(isMacJunkPath('folder/._config.md')).toBe(true)
+    expect(isMacJunkPath('__MACOSX/._SKILL.md')).toBe(true)
+    expect(isMacJunkPath('docs/SKILL.md')).toBe(false)
+    expect(isMacJunkPath('notes.md')).toBe(false)
   })
 
   it('builds embedding text', () => {

--- a/convex/lib/skills.ts
+++ b/convex/lib/skills.ts
@@ -140,6 +140,22 @@ export function isTextFile(path: string, contentType?: string | null) {
   return false
 }
 
+export function isMacJunkPath(path: string) {
+  const normalized = path
+    .trim()
+    .replaceAll('\\', '/')
+    .replace(/^\/+/, '')
+    .toLowerCase()
+  if (!normalized) return false
+  const segments = normalized.split('/').filter(Boolean)
+  if (segments.length === 0) return false
+  if (segments.includes('__macosx')) return true
+  const basename = segments.at(-1) ?? ''
+  if (basename === '.ds_store') return true
+  if (basename.startsWith('._')) return true
+  return false
+}
+
 export function sanitizePath(path: string) {
   const trimmed = path.trim().replace(/^\/+/, '')
   if (!trimmed || trimmed.includes('..') || trimmed.includes('\\')) {

--- a/src/lib/uploadFiles.jsdom.test.ts
+++ b/src/lib/uploadFiles.jsdom.test.ts
@@ -1,7 +1,7 @@
 import { strToU8, unzipSync, zipSync } from 'fflate'
 import { describe, expect, it } from 'vitest'
 
-import { expandDroppedItems, expandFiles } from './uploadFiles'
+import { expandDroppedItems, expandFiles, expandFilesWithReport } from './uploadFiles'
 
 function readWithFileReader(blob: Blob) {
   return new Promise<ArrayBuffer>((resolve, reject) => {
@@ -33,6 +33,16 @@ describe('expandFiles (jsdom)', () => {
 
     const expanded = await expandFiles([zipFile])
     expect(expanded.map((file) => file.name)).toEqual(['SKILL.md', 'notes.txt'])
+  })
+
+  it('filters mac junk files and returns ignored paths', async () => {
+    const report = await expandFilesWithReport([
+      new File(['hello'], 'SKILL.md', { type: 'text/markdown' }),
+      new File(['junk'], '.DS_Store', { type: 'application/octet-stream' }),
+    ])
+
+    expect(report.files.map((file) => file.name)).toEqual(['SKILL.md'])
+    expect(report.ignoredMacJunkPaths).toEqual(['.DS_Store'])
   })
 })
 


### PR DESCRIPTION
## Summary
- Automatically ignore macOS junk files during upload/publish (`.DS_Store`, `__MACOSX/*`, `._*`).
- Apply filtering consistently across frontend ingestion and backend publish paths (skills + souls + multipart API + GitHub import).
- Add a small upload UI note when junk files are ignored.
- Expand tests for frontend upload expansion, upload route behavior, backend multipart handling, and GitHub import filtering.

## What Changed
- Frontend
  - Added `expandFilesWithReport` in `src/lib/uploadFiles.ts` and kept `expandFiles` as compatibility wrapper.
  - Filtered macOS junk for direct files and archive-expanded files.
  - Updated upload route to surface an informational ignored-files note.
- Backend
  - Added canonical `isMacJunkPath` helper in `convex/lib/skills.ts`.
  - Applied filtering in:
    - `convex/lib/skillPublish.ts`
    - `convex/lib/soulPublish.ts`
    - `convex/httpApiV1/shared.ts` (multipart parser skips junk before storage)
    - `convex/githubImport.ts`
- Tests
  - Added/updated tests in:
    - `src/lib/uploadFiles.test.ts`
    - `src/lib/uploadFiles.jsdom.test.ts`
    - `src/__tests__/upload.route.test.tsx`
    - `convex/lib/skills.test.ts`
    - `convex/httpApiV1.handlers.test.ts`
    - `convex/githubImport.test.ts` (new)

## Test Commands Run
- `bun run test -- src/lib/uploadFiles.test.ts src/lib/uploadFiles.jsdom.test.ts src/__tests__/upload.route.test.tsx convex/lib/skills.test.ts convex/httpApiV1.handlers.test.ts convex/githubImport.test.ts`
- `bun run lint:oxlint`

## Notes
- No endpoint contract changes; behavior hardening only.
