### PR TITLE
fix: increase upload timeout and wrap non-Error abort rejections

### DIFF
--- a/packages/clawdhub/src/http.ts
+++ b/packages/clawdhub/src/http.ts
@@ -9,6 +9,8 @@ import { ApiRoutes, parseArk } from './schema/index.js'
 
 const REQUEST_TIMEOUT_MS = 15_000
 const REQUEST_TIMEOUT_SECONDS = Math.ceil(REQUEST_TIMEOUT_MS / 1000)
+const UPLOAD_TIMEOUT_MS = 120_000
+const UPLOAD_TIMEOUT_SECONDS = Math.ceil(UPLOAD_TIMEOUT_MS / 1000)
 const RETRY_COUNT = 2
 const RETRY_BACKOFF_BASE_MS = 300
 const RETRY_BACKOFF_MAX_MS = 5_000
@@ -143,11 +145,11 @@ export async function apiRequestForm<T>(
 
       const headers: Record<string, string> = { Accept: 'application/json' }
       if (args.token) headers.Authorization = `Bearer ${args.token}`
-      const response = await fetchWithTimeout(url, {
-        method: args.method,
-        headers,
-        body: args.form,
-      })
+      const response = await fetchWithTimeout(
+        url,
+        { method: args.method, headers, body: args.form },
+        UPLOAD_TIMEOUT_MS,
+      )
       if (!response.ok) {
         throwHttpStatusError(response.status, await readResponseTextSafe(response), response.headers)
       }
@@ -205,11 +207,24 @@ export async function downloadZip(
   )
 }
 
-async function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number = REQUEST_TIMEOUT_MS,
+): Promise<Response> {
   const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(new Error('Timeout')), REQUEST_TIMEOUT_MS)
+  const timeout = setTimeout(() => {
+    // Ensure we always throw a proper Error instance. Some Node/undici versions
+    // propagate the abort reason as-is; if it is not an Error, pRetry will
+    // surface "Non-error was thrown" instead of a meaningful message.
+    controller.abort(new Error(`Request timed out after ${timeoutMs}ms`))
+  }, timeoutMs)
   try {
     return await fetch(url, { ...init, signal: controller.signal })
+  } catch (err) {
+    // Re-wrap non-Error rejections so pRetry always receives an Error instance.
+    if (err instanceof Error) throw err
+    throw new Error(String(err))
   } finally {
     clearTimeout(timeout)
   }
@@ -425,7 +440,7 @@ async function fetchJsonFormViaCurl(url: string, args: FormRequestArgs) {
       '--show-error',
       '--location',
       '--max-time',
-      String(REQUEST_TIMEOUT_SECONDS),
+      String(UPLOAD_TIMEOUT_SECONDS),
       '--write-out',
       CURL_WRITE_OUT_FORMAT,
       '-X',


### PR DESCRIPTION
## Problem

Fixes #533

`clawhub publish` consistently times out with:
```
✖ Non-error was thrown: "Timeout". You should only throw errors.
```

Two root causes:

### 1. Timeout too short for form uploads
`REQUEST_TIMEOUT_MS` (15s) is applied uniformly to all requests including multipart form uploads in `apiRequestForm`. Uploading skill files to the server can easily exceed 15s depending on skill size and server-side processing time.

### 2. Non-Error abort rejections not re-wrapped
In some Node.js/undici versions, `controller.abort(reason)` causes `fetch` to reject with the raw reason value rather than wrapping it. If the reason is not an `Error` instance (or gets lost in propagation), `pRetry` surfaces the unhelpful `Non-error was thrown` message instead of the underlying cause.

## Fix

1. Added `UPLOAD_TIMEOUT_MS = 120_000` (2 min) and applied it to both the Node `fetchWithTimeout` path and the Bun/curl `--max-time` path in `apiRequestForm` / `fetchJsonFormViaCurl`.
2. In `fetchWithTimeout`, wrap any non-Error rejection in a new `Error` so `pRetry` always receives a proper `Error` instance.
3. Updated the abort reason message to include the timeout duration for easier debugging.

## Testing
Verified locally that `clawhub whoami` still works and the timeout constants are wired correctly.