### PR TITLE
feat(capabilities): Skill capability badges and declaration visibility in UI

### DIFF
--- a/src/components/SkillInstallCard.tsx
+++ b/src/components/SkillInstallCard.tsx
@@ -58,15 +58,7 @@ export function SkillInstallCard({ clawdis, osLabels }: SkillInstallCardProps) {
               ))}
             </div>
           </div>
-        ) : (
-          <div className="skill-panel">
-            <div className="skill-panel-body">
-              <div className="stat" style={{ color: 'var(--ink-soft)' }}>
-                <span>No capabilities declared</span>
-              </div>
-            </div>
-          </div>
-        )}
+        ) : null}
         {hasRuntimeRequirements ? (
           <div className="skill-panel">
             <h3 className="section-title" style={{ fontSize: '1rem', margin: 0 }}>


### PR DESCRIPTION
## Summary

- Problem:
  - Users/authors need capability visibility before enforcement is enabled.
- Why it matters:
  - Visibility-first rollout reduces breakage and guides migration.
- What changed:
  - Added capability extraction utilities for skill detail surfaces.
  - Updated install card rendering to show declared capabilities and visibility cues.
- What did NOT change (scope boundary):
  - No browse-page refactor.
  - No report/comments/versions panel rewrites.
  - No publish-time blocking.

## Testing

- [ ] `bun run lint`
- [ ] `bun run test`
- [ ] `bun run build`

## Related

- https://github.com/openclaw/clawhub/pull/545
- https://github.com/openclaw/openclaw/pull/28966
- https://github.com/openclaw/openclaw/pull/28968
