### PR TITLE
fix(ui): persist folder upload input across page refresh

### DIFF
--- a/src/routes/upload.tsx
+++ b/src/routes/upload.tsx
@@ -76,6 +76,13 @@ export function Upload() {
   const [error, setError] = useState<string | null>(null)
   const [isDragging, setIsDragging] = useState(false)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const setFileInputRef = (node: HTMLInputElement | null) => {
+    fileInputRef.current = node
+    if (node) {
+      node.setAttribute('webkitdirectory', '')
+      node.setAttribute('directory', '')
+    }
+  }
   const validationRef = useRef<HTMLDivElement | null>(null)
   const navigate = useNavigate()
   const maxBytes = 50 * 1024 * 1024
@@ -244,11 +251,8 @@ export function Upload() {
     requiredFileLabel,
   ])
 
-  useEffect(() => {
-    if (!fileInputRef.current) return
-    fileInputRef.current.setAttribute('webkitdirectory', '')
-    fileInputRef.current.setAttribute('directory', '')
-  }, [])
+  // webkitdirectory/directory attributes are set via the ref callback (setFileInputRef)
+  // to ensure they persist across hydration and re-renders (#58)
 
   if (!isAuthenticated) {
     return (
@@ -416,15 +420,12 @@ export function Upload() {
             }}
           >
             <input
-              ref={fileInputRef}
+              ref={setFileInputRef}
               className="upload-file-input"
               id="upload-files"
               data-testid="upload-input"
               type="file"
               multiple
-              // @ts-expect-error - non-standard attribute to allow folder selection
-              webkitdirectory=""
-              directory=""
               onChange={(event) => {
                 const picked = Array.from(event.target.files ?? [])
                 void applyExpandedFiles(picked)


### PR DESCRIPTION
## Summary

Fixes #58

After a page refresh on `/upload`, the file input lost its `webkitdirectory` attribute and switched from folder selection mode to individual file mode. This made it impossible to upload multi-file skills via the browser after refreshing.

### Root cause

The `webkitdirectory` and `directory` attributes were set via:
1. Non-standard JSX props (`@ts-expect-error`) — React may strip these during hydration
2. A `useEffect([], ...)` fallback — doesn't re-fire when React hydrates (rather than fresh-mounts) the component after a page refresh

### Fix

Replaced both approaches with a **ref callback** that imperatively sets `webkitdirectory` and `directory` every time the input element is attached to the DOM. This is reliable across initial render, hydration, and re-renders.

## Test plan

- [x] `bun run test -- src/__tests__/upload.route.test.tsx` — 8/8 pass (existing test `marks the input for folder uploads` still passes)
- [x] `bun run lint` — 0 warnings, 0 errors