### PR TITLE
chore: add Vercel attribution in footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -12,7 +12,11 @@ export function Footer() {
             <a href="https://openclaw.ai" target="_blank" rel="noreferrer">
               OpenClaw
             </a>{' '}
-            project · Powered by{' '}
+            project · Deployed on{' '}
+            <a href="https://vercel.com" target="_blank" rel="noreferrer">
+              Vercel
+            </a>{' '}
+            · Powered by{' '}
             <a href="https://www.convex.dev" target="_blank" rel="noreferrer">
               Convex
             </a>{' '}


### PR DESCRIPTION
## Summary
- Adds "Deployed on Vercel" attribution link to the site footer
- Placed between "An OpenClaw project" and "Powered by Convex"
- Links to https://vercel.com

## Test plan
- [x] `bun run lint:oxlint` passes (0 warnings, 0 errors)
- [x] `bun run test` passes (85 test files, 604 tests)
- [x] Visually confirm footer reads: "ClawHub · An OpenClaw project · Deployed on Vercel · Powered by Convex · Open source (MIT) · Peter Steinberger."

🤖 Generated with [Claude Code](https://claude.com/claude-code)