### PR TITLE
fix: debounce URL navigation in skills search to reduce input lag

### DIFF
--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -39,6 +39,7 @@ export function useSkillsBrowseModel({
   const searchRequest = useRef(0)
   const loadMoreRef = useRef<HTMLDivElement | null>(null)
   const loadMoreInFlightRef = useRef(false)
+  const navigateTimer = useRef<number>(0)
 
   const view: SkillsView = search.view ?? 'list'
   const highlightedOnly = search.highlighted ?? false
@@ -74,6 +75,7 @@ export function useSkillsBrowseModel({
   const isLoadingMoreList = paginationStatus === 'LoadingMore'
 
   useEffect(() => {
+    window.clearTimeout(navigateTimer.current)
     setQuery(search.q ?? '')
   }, [search.q])
 
@@ -216,14 +218,21 @@ export function useSkillsBrowseModel({
     return () => observer.disconnect()
   }, [canLoadMore, loadMore])
 
+  useEffect(() => {
+    return () => window.clearTimeout(navigateTimer.current)
+  }, [])
+
   const onQueryChange = useCallback(
     (next: string) => {
-      const trimmed = next.trim()
       setQuery(next)
-      void navigate({
-        search: (prev) => ({ ...prev, q: trimmed ? next : undefined }),
-        replace: true,
-      })
+      window.clearTimeout(navigateTimer.current)
+      const trimmed = next.trim()
+      navigateTimer.current = window.setTimeout(() => {
+        void navigate({
+          search: (prev) => ({ ...prev, q: trimmed ? next : undefined }),
+          replace: true,
+        })
+      }, 220)
     },
     [navigate],
   )


### PR DESCRIPTION
## Summary

- Debounce the `navigate()` call in `onQueryChange` (skills browse page) so the URL is not updated on every keystroke
- `setQuery()` remains immediate so the controlled input stays responsive
- Uses 220 ms delay, matching the existing search-action debounce in the same `useEffect`

## Problem

Typing in the skills search input on `/skills` causes noticeable lag. Each keystroke calls `navigate({ search: … })` synchronously, which triggers `history.replaceState`, TanStack Router re-evaluation, and `useSearch()` invalidation — resulting in multiple React re-render cycles per keystroke on top of the `setQuery` render.

The Convex search action was already debounced at 220 ms, but the `navigate` call was not.

## Test plan

- [ ] Type rapidly in the skills search input — input should feel responsive with no lag
- [ ] After typing stops, URL `?q=` param updates within ~220 ms
- [ ] Clearing the input removes the `?q` param from the URL
- [ ] Sharing/bookmarking a URL with `?q=term` still pre-populates the search on load
- [ ] Browser back/forward with different `?q` values still syncs the input
- [ ] `bun run lint` — 0 warnings, 0 errors
- [ ] `bun run test` — 604 tests pass

Made with [Cursor](https://cursor.com)