### PR TITLE
fix(vt): sync scan status from AV engines when Code Insight unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Comments: hide entries authored by deleted/deactivated users in `comments:listBySkill`.
 - Admin API: `POST /api/v1/users/reclaim` now performs non-destructive root-slug owner transfer
   (preserves existing skill versions/stats/metadata) and clears active slug reservations.
+- VirusTotal: use shared AV-engine fallback verdict mapping for pending/backfill flows and keep undetected-only results pending (#591) (thanks @Shuai-DaiDai).
 - CLI publish: use a longer multipart upload timeout and normalize abort rejections into proper Errors (#550) (thanks @MunemHashmi).
 - CLI: forward optional auth tokens for `search` and `explore` against authenticated registries (#608) (thanks @artdaal).
 - Skill metadata: parse top-level `requires.*`, `primaryEnv`, and homepage fallbacks for security review accuracy (#548) (thanks @MunemHashmi).

--- a/convex/vt.test.ts
+++ b/convex/vt.test.ts
@@ -58,3 +58,45 @@ describe('vt activation fallback', () => {
     ).toBe(false)
   })
 })
+
+describe('vt AV engine fallback verdicts', () => {
+  it('maps engine verdicts in severity order', () => {
+    expect(
+      __test.statusFromAvStats({
+        malicious: 1,
+        suspicious: 2,
+        harmless: 10,
+        undetected: 40,
+      }),
+    ).toBe('malicious')
+
+    expect(
+      __test.statusFromAvStats({
+        malicious: 0,
+        suspicious: 1,
+        harmless: 10,
+        undetected: 40,
+      }),
+    ).toBe('suspicious')
+
+    expect(
+      __test.statusFromAvStats({
+        malicious: 0,
+        suspicious: 0,
+        harmless: 1,
+        undetected: 40,
+      }),
+    ).toBe('clean')
+  })
+
+  it('keeps undetected-only results pending', () => {
+    expect(
+      __test.statusFromAvStats({
+        malicious: 0,
+        suspicious: 0,
+        harmless: 0,
+        undetected: 40,
+      }),
+    ).toBeNull()
+  })
+})

--- a/convex/vt.ts
+++ b/convex/vt.ts
@@ -122,6 +122,8 @@ type VTFileResponse = {
   }
 }
 
+type VTAnalysisStats = NonNullable<VTFileResponse['data']['attributes']['last_analysis_stats']>
+
 type ScanQueueHealth = {
   queueSize: number
   staleCount: number
@@ -246,6 +248,15 @@ function shouldActivateWhenVtUnavailable(skill: SkillActivationCandidate | null 
   return typeof reason === 'string' && VT_PENDING_REASONS.has(reason)
 }
 
+function statusFromAvStats(stats?: VTAnalysisStats | null): 'malicious' | 'suspicious' | 'clean' | null {
+  if (!stats) return null
+  if (stats.malicious > 0) return 'malicious'
+  if (stats.suspicious > 0) return 'suspicious'
+  // Keep this aligned with fetchResults: undetected-only should stay pending.
+  if (stats.harmless > 0) return 'clean'
+  return null
+}
+
 async function activateSkillWhenVtUnavailable(ctx: ActionCtx, skillId: Id<'skills'>) {
   const skill = await ctx.runQuery(internal.skills.getSkillByIdInternal, { skillId })
   if (!shouldActivateWhenVtUnavailable(skill)) return
@@ -294,15 +305,8 @@ export const fetchResults = action({
       if (aiResult?.verdict) {
         // Prioritize AI Analysis (Code Insight)
         status = verdictToStatus(normalizeVerdict(aiResult.verdict))
-      } else if (stats) {
-        // Fallback to AV engines
-        if (stats.malicious > 0) {
-          status = 'malicious'
-        } else if (stats.suspicious > 0) {
-          status = 'suspicious'
-        } else if (stats.harmless > 0) {
-          status = 'clean'
-        }
+      } else {
+        status = statusFromAvStats(stats) ?? 'pending'
       }
 
       return {
@@ -568,19 +572,8 @@ export const pollPendingScans = internalAction({
         if (!aiResult) {
           // No Code Insight - check AV engine stats as fallback
           const stats = vtResult.data.attributes.last_analysis_stats
-          let status: string | null = null
+          const status = statusFromAvStats(stats)
           let source = 'engines'
-
-          if (stats) {
-            if (stats.malicious > 0) {
-              status = 'malicious'
-            } else if (stats.suspicious > 0) {
-              status = 'suspicious'
-            } else if (stats.harmless > 0 || stats.undetected > 0) {
-              // No detections and some harmless/undetected engines = clean
-              status = 'clean'
-            }
-          }
 
           if (status) {
             // We have a verdict from AV engines - update the skill
@@ -726,6 +719,7 @@ async function requestRescan(apiKey: string, sha256hash: string): Promise<boolea
 }
 
 export const __test = {
+  statusFromAvStats,
   shouldActivateWhenVtUnavailable,
 }
 
@@ -785,18 +779,7 @@ export const backfillPendingScans = internalAction({
         if (!aiResult) {
           // No Code Insight - check AV engine stats as fallback
           const stats = vtResult.data.attributes.last_analysis_stats
-          let status: string | null = null
-
-          if (stats) {
-            if (stats.malicious > 0) {
-              status = 'malicious'
-            } else if (stats.suspicious > 0) {
-              status = 'suspicious'
-            } else if (stats.harmless > 0 || stats.undetected > 0) {
-              // No detections and some harmless/undetected engines = clean
-              status = 'clean'
-            }
-          }
+          const status = statusFromAvStats(stats)
 
           if (status) {
             // We have a verdict from AV engines - update the skill
@@ -913,19 +896,8 @@ export const rescanActiveSkills = internalAction({
         if (!aiResult) {
           // No Code Insight - check AV engine stats as fallback
           const stats = vtResult.data.attributes.last_analysis_stats
-          let status: string | null = null
+          const status = statusFromAvStats(stats)
           let source = 'engines'
-
-          if (stats) {
-            if (stats.malicious > 0) {
-              status = 'malicious'
-            } else if (stats.suspicious > 0) {
-              status = 'suspicious'
-            } else if (stats.harmless > 0 || stats.undetected > 0) {
-              // No detections and some harmless/undetected engines = clean
-              status = 'clean'
-            }
-          }
 
           if (!status) {
             // No verdict from engines either - keep as pending
@@ -1247,19 +1219,8 @@ export const backfillActiveSkillsVTCache = internalAction({
         if (!aiResult) {
           // No Code Insight - check AV engine stats as fallback
           const stats = vtResult.data.attributes.last_analysis_stats
-          let status: string | null = null
+          const status = statusFromAvStats(stats)
           let source = 'engines'
-
-          if (stats) {
-            if (stats.malicious > 0) {
-              status = 'malicious'
-            } else if (stats.suspicious > 0) {
-              status = 'suspicious'
-            } else if (stats.harmless > 0 || stats.undetected > 0) {
-              // No detections and some harmless/undetected engines = clean
-              status = 'clean'
-            }
-          }
 
           if (!status) {
             console.log(`[vt:backfillActive] ${slug}: no Code Insight or engine stats yet`)


### PR DESCRIPTION
## Problem

When VirusTotal scan completes with AV engine results (e.g., 0/64 detections, "Benign") but Code Insight AI analysis is not yet available, skill scan status was stuck on "Pending" indefinitely.

Fixes #33435

## Root Cause

The VT polling functions only checked for "code_insight" AI analysis results and ignored the "last_analysis_stats" AV engine scan results:

- \"pollPendingScans\" - would request rescan instead of using engine stats
- \"backfillPendingScans\" - would skip skills with no Code Insight
- \"rescanActiveSkills\" - would mark as pending instead of using engine stats  
- \"backfillActiveSkillsVTCache\" - would skip skills with no Code Insight

## Solution

Added fallback logic to check \"last_analysis_stats\" when Code Insight is unavailable:

- If \"malicious > 0\" → status = \"malicious\"
- If \"suspicious > 0\" → status = \"suspicious\"
- If \"harmless > 0 || undetected > 0\" → status = \"clean\"

This matches the existing logic in \"fetchResults\" function.

## Testing

- [ ] Test with skill that has engine stats but no Code Insight
- [ ] Verify status updates to clean/malicious/suspicious correctly
- [ ] Confirm pending skills are processed faster