### PR TITLE
fix: fix types in tests for bun convex dev

### DIFF
--- a/convex/lib/moderation.test.ts
+++ b/convex/lib/moderation.test.ts
@@ -231,7 +231,7 @@ describe('deriveModerationFlags', () => {
         summary: 'Normal description',
       },
       parsed: { frontmatter: {} },
-      files: [{ path: 'install-malware.sh', size: 100, storageId: mockStorageId }],
+      files: [{ path: 'install-malware.sh', size: 100, storageId: mockStorageId, sha256: 'abc' }],
     })
     expect(flags).toContain('suspicious.keyword')
   })
@@ -244,7 +244,7 @@ describe('deriveModerationFlags', () => {
         summary: 'Get weather data from wttr.in',
       },
       parsed: { frontmatter: {} },
-      files: [{ path: 'SKILL.md', size: 100, storageId: mockStorageId }],
+      files: [{ path: 'SKILL.md', size: 100, storageId: mockStorageId, sha256: 'abc' }],
     })
     expect(flags.length).toBe(0)
   })

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -390,7 +390,7 @@ function makeSkillDoc(params: {
     moderationStatus: 'active',
     moderationFlags: params.moderationFlags ?? [],
     moderationReason: params.moderationReason,
-    softDeletedAt: undefined,
+    softDeletedAt: undefined as number | undefined,
   }
 }
 


### PR DESCRIPTION
This is just fixing types when running `bun convex dev` without `--typecheck=disable`

Before:

```
✖ TypeScript typecheck via `tsc` failed.
To ignore failing typecheck, use `--typecheck=disable`.
convex/lib/moderation.test.ts:234:15 - error TS2741: Property 'sha256' is missing in type '{ path: string; size: number; storageId: Id<"_storage">; }' but required in type '{ contentType?: string | undefined; path: string; size: number; storageId: Id<"_storage">; sha256: string; }'.

234       files: [{ path: 'install-malware.sh', size: 100, storageId: mockStorageId }],
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
convex/lib/moderation.test.ts:247:15 - error TS2741: Property 'sha256' is missing in type '{ path: string; size: number; storageId: Id<"_storage">; }' but required in type '{ contentType?: string | undefined; path: string; size: number; storageId: Id<"_storage">; sha256: string; }'.

247       files: [{ path: 'SKILL.md', size: 100, storageId: mockStorageId }],
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

convex/search.test.ts:282:7 - error TS2322: Type '{ softDeletedAt: number; _creationTime: number; moderationStatus: string; moderationFlags: string[]; moderationReason: string | undefined; _id: string; slug: string; displayName: string; summary: string; ... 8 more ...; updatedAt: number; }' is not assignable to type '{ _creationTime: number; moderationStatus: string; moderationFlags: string[]; moderationReason: string | undefined; softDeletedAt: undefined; _id: string; slug: string; displayName: string; ... 9 more ...; updatedAt: number; }'.
  Types of property 'softDeletedAt' are incompatible.
    Type 'number' is not assignable to type 'undefined'.

282       exactSlugSkill: deletedSkill,
          ~~~~~~~~~~~~~~

  convex/search.test.ts:398:3
    398   exactSlugSkill: ReturnType<typeof makeSkillDoc> | null
          ~~~~~~~~~~~~~~
    The expected type comes from property 'exactSlugSkill' which is declared here on type '{ exactSlugSkill: { _creationTime: number; moderationStatus: string; moderationFlags: string[]; moderationReason: string | undefined; softDeletedAt: undefined; _id: string; slug: string; ... 10 more ...; updatedAt: number; } | null; recentSkills: { ...; }[]; }'

Found 3 errors in 2 files.

Errors  Files
     2  convex/lib/moderation.test.ts:234
     1  convex/search.test.ts:282
```

After:
```
✔ Started running a deployment locally at http://127.0.0.1:3210 and saved its name as CONVEX_DEPLOYMENT to .env.local
Run `npx convex login` at any time to create an account and link this deployment.

Write your Convex functions in convex
Give us feedback at https://convex.dev/community or support@convex.dev
View the Convex dashboard at http://127.0.0.1:6790/?d=anonymous-clawhub

A minor update is available for Convex (1.31.7 → 1.32.0)
Changelog: https://github.com/get-convex/convex-js/blob/main/CHANGELOG.md#changelog
✔ 23:10:05 Convex functions ready! (5.12s)
```