### PR TITLE
Fix deploy workflow failing due to secrets in if condition

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,11 +85,11 @@ jobs:
         run: bunx playwright install --with-deps chromium
 
       - name: Write authenticated storage state
-        if: ${{ secrets.PLAYWRIGHT_AUTH_STORAGE_STATE_JSON != '' }}
+        if: env.PLAYWRIGHT_AUTH_STORAGE_STATE_JSON != ''
+        env:
+          PLAYWRIGHT_AUTH_STORAGE_STATE_JSON: ${{ secrets.PLAYWRIGHT_AUTH_STORAGE_STATE_JSON }}
         run: |
-          cat > "$RUNNER_TEMP/playwright-auth.json" <<'EOF'
-          ${{ secrets.PLAYWRIGHT_AUTH_STORAGE_STATE_JSON }}
-          EOF
+          echo "$PLAYWRIGHT_AUTH_STORAGE_STATE_JSON" > "$RUNNER_TEMP/playwright-auth.json"
           echo "PLAYWRIGHT_AUTH_STORAGE_STATE=$RUNNER_TEMP/playwright-auth.json" >> "$GITHUB_ENV"
 
       - name: Smoke test production


### PR DESCRIPTION
Fix GitHub Actions deploy workflow failing due to an if condition referencing secrets

GitHub Actions does not allow secrets to be referenced in YAML `if` conditions, so the workflow https://github.com/openclaw/clawhub/actions/runs/22830800173/workflow failed to load
Because the workflow never ran `APP_BUILD_SHA` and `APP_DEPLOYED_AT` were never stamped in Convex

This PR updates `deploy.yml` so the workflow can execute properly without referencing secrets in the if condition

Once the workflow runs:
- Deployment metadata (`APP_BUILD_SHA`, `APP_DEPLOYED_AT`) will be stamped
- Convex functions will deploy
- Runtime environment variables will be present