### PR TITLE
Fix Convex env access in appMeta:getDeploymentInfo

### DIFF
--- a/convex/appMeta.ts
+++ b/convex/appMeta.ts
@@ -5,10 +5,17 @@ function normalizeEnv(value: string | undefined) {
   return normalized ? normalized : null
 }
 
+function readEnv(key: string): string | undefined {
+  // Convex functions don't always run in a Node.js environment.
+  // Accessing `process.env` directly can throw `ReferenceError: process is not defined`.
+  const env = (globalThis as any)?.process?.env as Record<string, string | undefined> | undefined
+  return env?.[key]
+}
+
 export const getDeploymentInfo = query({
   args: {},
   handler: async () => ({
-    appBuildSha: normalizeEnv(process.env.APP_BUILD_SHA),
-    deployedAt: normalizeEnv(process.env.APP_DEPLOYED_AT),
+    appBuildSha: normalizeEnv(readEnv('APP_BUILD_SHA')),
+    deployedAt: normalizeEnv(readEnv('APP_DEPLOYED_AT')),
   }),
 })


### PR DESCRIPTION
Fixes server error on ClawHub due to `process` being undefined in Convex query runtime. Uses safe env read via globalThis.process?.env.