### PR TITLE
feat(moderation): add manual override audit tools

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -56,6 +56,7 @@ import type * as lib_globalStats from "../lib/globalStats.js";
 import type * as lib_httpHeaders from "../lib/httpHeaders.js";
 import type * as lib_httpRateLimit from "../lib/httpRateLimit.js";
 import type * as lib_leaderboards from "../lib/leaderboards.js";
+import type * as lib_manualOverrides from "../lib/manualOverrides.js";
 import type * as lib_moderation from "../lib/moderation.js";
 import type * as lib_moderationEngine from "../lib/moderationEngine.js";
 import type * as lib_moderationReasonCodes from "../lib/moderationReasonCodes.js";
@@ -155,6 +156,7 @@ declare const fullApi: ApiFromModules<{
   "lib/httpHeaders": typeof lib_httpHeaders;
   "lib/httpRateLimit": typeof lib_httpRateLimit;
   "lib/leaderboards": typeof lib_leaderboards;
+  "lib/manualOverrides": typeof lib_manualOverrides;
   "lib/moderation": typeof lib_moderation;
   "lib/moderationEngine": typeof lib_moderationEngine;
   "lib/moderationReasonCodes": typeof lib_moderationReasonCodes;

--- a/convex/lib/manualOverrides.test.ts
+++ b/convex/lib/manualOverrides.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import type { Id } from '../_generated/dataModel'
+import {
+  applyManualOverrideToSkillPatch,
+  isManualOverrideReason,
+} from './manualOverrides'
+
+function userId(value: string) {
+  return value as Id<'users'>
+}
+
+describe('manualOverrides', () => {
+  it('detects manual override reasons', () => {
+    expect(isManualOverrideReason('manual.override.clean')).toBe(true)
+    expect(isManualOverrideReason('scanner.vt.suspicious')).toBe(false)
+    expect(isManualOverrideReason(undefined)).toBe(false)
+  })
+
+  it('applies a clean override as non-suspicious active skill state', () => {
+    const now = 1_700_000_000_000
+    const patch = applyManualOverrideToSkillPatch({
+      basePatch: {
+        moderationReasonCodes: ['suspicious.dynamic_code_execution'],
+      },
+      override: {
+        verdict: 'clean',
+        note: 'security tool false positive',
+        reviewerUserId: userId('users:reviewer'),
+        updatedAt: now,
+      },
+      now,
+    })
+
+    expect(patch).toMatchObject({
+      moderationStatus: 'active',
+      moderationReason: 'manual.override.clean',
+      moderationVerdict: 'clean',
+      moderationFlags: undefined,
+      moderationSummary: 'Manual override (clean): security tool false positive',
+      moderationEvaluatedAt: now,
+      isSuspicious: false,
+      updatedAt: now,
+    })
+    expect(patch.moderationReasonCodes).toEqual(['suspicious.dynamic_code_execution'])
+  })
+
+  it('preserves malicious scanner state over a clean override', () => {
+    const now = 1_700_000_100_000
+    const patch = applyManualOverrideToSkillPatch({
+      basePatch: {
+        moderationStatus: 'hidden',
+        moderationReason: 'scanner.vt.malicious',
+        moderationVerdict: 'malicious',
+        moderationFlags: ['blocked.malware'],
+        moderationSummary: 'Detected: malicious.known_blocked_signature',
+        hiddenAt: now,
+        hiddenBy: undefined,
+        lastReviewedAt: now,
+        updatedAt: now,
+      },
+      override: {
+        verdict: 'clean',
+        note: 'earlier false positive review',
+        reviewerUserId: userId('users:reviewer'),
+        updatedAt: now,
+      },
+      now,
+    })
+
+    expect(patch).toMatchObject({
+      moderationStatus: 'hidden',
+      moderationReason: 'scanner.vt.malicious',
+      moderationVerdict: 'malicious',
+      moderationFlags: ['blocked.malware'],
+      hiddenAt: now,
+      lastReviewedAt: now,
+      updatedAt: now,
+    })
+  })
+})

--- a/convex/lib/manualOverrides.test.ts
+++ b/convex/lib/manualOverrides.test.ts
@@ -77,4 +77,33 @@ describe('manualOverrides', () => {
       updatedAt: now,
     })
   })
+
+  it('preserves non-scanner hidden locks over a clean override', () => {
+    const now = 1_700_000_200_000
+    const patch = applyManualOverrideToSkillPatch({
+      basePatch: {
+        moderationStatus: 'hidden',
+        moderationReason: 'quality.low',
+        moderationVerdict: 'clean',
+        moderationFlags: undefined,
+        moderationSummary: 'Auto-quarantined by quality gate.',
+        updatedAt: now,
+      },
+      override: {
+        verdict: 'clean',
+        note: 'older suspicious finding was reviewed',
+        reviewerUserId: userId('users:reviewer'),
+        updatedAt: now,
+      },
+      now,
+    })
+
+    expect(patch).toMatchObject({
+      moderationStatus: 'hidden',
+      moderationReason: 'quality.low',
+      moderationVerdict: 'clean',
+      moderationSummary: 'Auto-quarantined by quality gate.',
+      updatedAt: now,
+    })
+  })
 })

--- a/convex/lib/manualOverrides.ts
+++ b/convex/lib/manualOverrides.ts
@@ -1,0 +1,79 @@
+import type { Doc, Id } from '../_generated/dataModel'
+import { type ModerationVerdict, legacyFlagsFromVerdict } from './moderationReasonCodes'
+import { computeIsSuspicious } from './skillSafety'
+
+export type ManualOverrideVerdict = Extract<ModerationVerdict, 'clean'>
+
+export type ManualModerationOverride = {
+  verdict: ManualOverrideVerdict
+  note: string
+  reviewerUserId: Id<'users'>
+  updatedAt: number
+}
+
+type SkillModerationPatch = Partial<
+  Pick<
+    Doc<'skills'>,
+    | 'moderationStatus'
+    | 'moderationReason'
+    | 'moderationFlags'
+    | 'moderationVerdict'
+    | 'moderationReasonCodes'
+    | 'moderationEvidence'
+    | 'moderationSummary'
+    | 'moderationEngineVersion'
+    | 'moderationEvaluatedAt'
+    | 'moderationSourceVersionId'
+    | 'isSuspicious'
+    | 'hiddenAt'
+    | 'hiddenBy'
+    | 'lastReviewedAt'
+    | 'updatedAt'
+  >
+>
+
+export function isManualOverrideReason(reason: string | undefined) {
+  return typeof reason === 'string' && reason.startsWith('manual.override.')
+}
+
+export function buildManualOverrideReason(verdict: ManualOverrideVerdict) {
+  return `manual.override.${verdict}`
+}
+
+export function formatManualOverrideSummary(override: ManualModerationOverride) {
+  return `Manual override (${override.verdict}): ${override.note}`
+}
+
+export function applyManualOverrideToSkillPatch(params: {
+  basePatch?: SkillModerationPatch
+  override: ManualModerationOverride
+  now: number
+}): SkillModerationPatch {
+  if (
+    params.basePatch?.moderationVerdict === 'malicious' ||
+    params.basePatch?.moderationFlags?.includes('blocked.malware')
+  ) {
+    return params.basePatch
+  }
+
+  const moderationFlags = legacyFlagsFromVerdict(params.override.verdict)
+  const moderationReason = buildManualOverrideReason(params.override.verdict)
+
+  return {
+    ...params.basePatch,
+    moderationStatus: 'active',
+    moderationFlags,
+    moderationReason,
+    moderationVerdict: params.override.verdict,
+    moderationSummary: formatManualOverrideSummary(params.override),
+    moderationEvaluatedAt: params.override.updatedAt,
+    hiddenAt: undefined,
+    hiddenBy: undefined,
+    lastReviewedAt: params.override.updatedAt,
+    isSuspicious: computeIsSuspicious({
+      moderationFlags,
+      moderationReason,
+    }),
+    updatedAt: params.now,
+  }
+}

--- a/convex/lib/manualOverrides.ts
+++ b/convex/lib/manualOverrides.ts
@@ -44,15 +44,34 @@ export function formatManualOverrideSummary(override: ManualModerationOverride) 
   return `Manual override (${override.verdict}): ${override.note}`
 }
 
+function isScannerManagedReason(reason: string | undefined) {
+  if (!reason) return false
+  return (
+    reason === 'pending.scan' ||
+    reason === 'pending.scan.stale' ||
+    reason.startsWith('scanner.')
+  )
+}
+
+function shouldPreserveExistingLock(basePatch: SkillModerationPatch | undefined) {
+  if (!basePatch) return false
+  if (
+    basePatch.moderationVerdict === 'malicious' ||
+    basePatch.moderationFlags?.includes('blocked.malware')
+  ) {
+    return true
+  }
+  if (basePatch.moderationStatus !== 'hidden') return false
+  if (isManualOverrideReason(basePatch.moderationReason)) return false
+  return !isScannerManagedReason(basePatch.moderationReason)
+}
+
 export function applyManualOverrideToSkillPatch(params: {
   basePatch?: SkillModerationPatch
   override: ManualModerationOverride
   now: number
 }): SkillModerationPatch {
-  if (
-    params.basePatch?.moderationVerdict === 'malicious' ||
-    params.basePatch?.moderationFlags?.includes('blocked.malware')
-  ) {
+  if (shouldPreserveExistingLock(params.basePatch)) {
     return params.basePatch
   }
 

--- a/convex/lib/moderationEngine.ts
+++ b/convex/lib/moderationEngine.ts
@@ -5,6 +5,7 @@ import {
   normalizeReasonCodes,
   type ModerationFinding,
   REASON_CODES,
+  type ScannerModerationVerdict,
   summarizeReasonCodes,
   type ModerationVerdict,
   verdictFromCodes,
@@ -23,7 +24,7 @@ export type StaticScanInput = {
 }
 
 export type StaticScanResult = {
-  status: ModerationVerdict
+  status: ScannerModerationVerdict
   reasonCodes: string[]
   findings: ModerationFinding[]
   summary: string
@@ -32,7 +33,7 @@ export type StaticScanResult = {
 }
 
 export type ModerationSnapshot = {
-  verdict: ModerationVerdict
+  verdict: ScannerModerationVerdict
   reasonCodes: string[]
   evidence: ModerationFinding[]
   summary: string

--- a/convex/lib/moderationReasonCodes.ts
+++ b/convex/lib/moderationReasonCodes.ts
@@ -1,4 +1,5 @@
 export type ModerationVerdict = 'clean' | 'suspicious' | 'malicious'
+export type ScannerModerationVerdict = ModerationVerdict
 
 export type ModerationFindingSeverity = 'info' | 'warn' | 'critical'
 
@@ -44,7 +45,7 @@ export function summarizeReasonCodes(codes: string[]) {
   return `Detected: ${top}${extra}`
 }
 
-export function verdictFromCodes(codes: string[]): ModerationVerdict {
+export function verdictFromCodes(codes: string[]): ScannerModerationVerdict {
   const normalized = normalizeReasonCodes(codes)
   if (normalized.some((code) => MALICIOUS_CODES.has(code) || code.startsWith('malicious.'))) {
     return 'malicious'

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -5,6 +5,13 @@ import { EMBEDDING_DIMENSIONS } from './lib/embeddings'
 
 const PLATFORM_SKILL_LICENSE = 'MIT-0' as const
 
+const manualModerationOverride = v.object({
+  verdict: v.literal('clean'),
+  note: v.string(),
+  reviewerUserId: v.id('users'),
+  updatedAt: v.number(),
+})
+
 const users = defineTable({
   name: v.optional(v.string()),
   image: v.optional(v.string()),
@@ -16,7 +23,9 @@ const users = defineTable({
   handle: v.optional(v.string()),
   displayName: v.optional(v.string()),
   bio: v.optional(v.string()),
-  role: v.optional(v.union(v.literal('admin'), v.literal('moderator'), v.literal('user'))),
+  role: v.optional(
+    v.union(v.literal('admin'), v.literal('moderator'), v.literal('user')),
+  ),
   githubCreatedAt: v.optional(v.number()),
   githubFetchedAt: v.optional(v.number()),
   githubProfileSyncedAt: v.optional(v.number()),
@@ -53,7 +62,9 @@ const skills = defineTable({
       version: v.string(),
       createdAt: v.number(),
       changelog: v.string(),
-      changelogSource: v.optional(v.union(v.literal('auto'), v.literal('user'))),
+      changelogSource: v.optional(
+        v.union(v.literal('auto'), v.literal('user')),
+      ),
       clawdis: v.optional(v.any()),
     }),
   ),
@@ -93,14 +104,22 @@ const skills = defineTable({
   moderationNotes: v.optional(v.string()),
   moderationReason: v.optional(v.string()),
   moderationVerdict: v.optional(
-    v.union(v.literal('clean'), v.literal('suspicious'), v.literal('malicious')),
+    v.union(
+      v.literal('clean'),
+      v.literal('suspicious'),
+      v.literal('malicious'),
+    ),
   ),
   moderationReasonCodes: v.optional(v.array(v.string())),
   moderationEvidence: v.optional(
     v.array(
       v.object({
         code: v.string(),
-        severity: v.union(v.literal('info'), v.literal('warn'), v.literal('critical')),
+        severity: v.union(
+          v.literal('info'),
+          v.literal('warn'),
+          v.literal('critical'),
+        ),
         file: v.string(),
         line: v.number(),
         message: v.string(),
@@ -112,11 +131,20 @@ const skills = defineTable({
   moderationEngineVersion: v.optional(v.string()),
   moderationEvaluatedAt: v.optional(v.number()),
   moderationSourceVersionId: v.optional(v.id('skillVersions')),
+  manualOverride: v.optional(manualModerationOverride),
   quality: v.optional(
     v.object({
       score: v.number(),
-      decision: v.union(v.literal('pass'), v.literal('quarantine'), v.literal('reject')),
-      trustTier: v.union(v.literal('low'), v.literal('medium'), v.literal('trusted')),
+      decision: v.union(
+        v.literal('pass'),
+        v.literal('quarantine'),
+        v.literal('reject'),
+      ),
+      trustTier: v.union(
+        v.literal('low'),
+        v.literal('medium'),
+        v.literal('trusted'),
+      ),
       similarRecentCount: v.number(),
       reason: v.string(),
       signals: v.object({
@@ -169,7 +197,11 @@ const skills = defineTable({
   .index('by_active_updated', ['softDeletedAt', 'updatedAt'])
   .index('by_active_created', ['softDeletedAt', 'createdAt'])
   .index('by_active_name', ['softDeletedAt', 'displayName'])
-  .index('by_active_stats_downloads', ['softDeletedAt', 'statsDownloads', 'updatedAt'])
+  .index('by_active_stats_downloads', [
+    'softDeletedAt',
+    'statsDownloads',
+    'updatedAt',
+  ])
   .index('by_active_stats_stars', ['softDeletedAt', 'statsStars', 'updatedAt'])
   .index('by_active_stats_installs_all_time', [
     'softDeletedAt',
@@ -179,16 +211,33 @@ const skills = defineTable({
   .index('by_canonical', ['canonicalSkillId'])
   .index('by_fork_of', ['forkOf.skillId'])
   .index('by_moderation', ['moderationStatus', 'moderationReason'])
-  .index('by_nonsuspicious_updated', ['softDeletedAt', 'isSuspicious', 'updatedAt'])
-  .index('by_nonsuspicious_created', ['softDeletedAt', 'isSuspicious', 'createdAt'])
-  .index('by_nonsuspicious_name', ['softDeletedAt', 'isSuspicious', 'displayName'])
+  .index('by_nonsuspicious_updated', [
+    'softDeletedAt',
+    'isSuspicious',
+    'updatedAt',
+  ])
+  .index('by_nonsuspicious_created', [
+    'softDeletedAt',
+    'isSuspicious',
+    'createdAt',
+  ])
+  .index('by_nonsuspicious_name', [
+    'softDeletedAt',
+    'isSuspicious',
+    'displayName',
+  ])
   .index('by_nonsuspicious_downloads', [
     'softDeletedAt',
     'isSuspicious',
     'statsDownloads',
     'updatedAt',
   ])
-  .index('by_nonsuspicious_stars', ['softDeletedAt', 'isSuspicious', 'statsStars', 'updatedAt'])
+  .index('by_nonsuspicious_stars', [
+    'softDeletedAt',
+    'isSuspicious',
+    'statsStars',
+    'updatedAt',
+  ])
   .index('by_nonsuspicious_installs', [
     'softDeletedAt',
     'isSuspicious',
@@ -276,12 +325,20 @@ const skillVersions = defineTable({
   ),
   staticScan: v.optional(
     v.object({
-      status: v.union(v.literal('clean'), v.literal('suspicious'), v.literal('malicious')),
+      status: v.union(
+        v.literal('clean'),
+        v.literal('suspicious'),
+        v.literal('malicious'),
+      ),
       reasonCodes: v.array(v.string()),
       findings: v.array(
         v.object({
           code: v.string(),
-          severity: v.union(v.literal('info'), v.literal('warn'), v.literal('critical')),
+          severity: v.union(
+            v.literal('info'),
+            v.literal('warn'),
+            v.literal('critical'),
+          ),
           file: v.string(),
           line: v.number(),
           message: v.string(),
@@ -481,9 +538,15 @@ const comments = defineTable({
   reportCount: v.optional(v.number()),
   lastReportedAt: v.optional(v.number()),
   scamScanVerdict: v.optional(
-    v.union(v.literal('not_scam'), v.literal('likely_scam'), v.literal('certain_scam')),
+    v.union(
+      v.literal('not_scam'),
+      v.literal('likely_scam'),
+      v.literal('certain_scam'),
+    ),
   ),
-  scamScanConfidence: v.optional(v.union(v.literal('low'), v.literal('medium'), v.literal('high'))),
+  scamScanConfidence: v.optional(
+    v.union(v.literal('low'), v.literal('medium'), v.literal('high')),
+  ),
   scamScanExplanation: v.optional(v.string()),
   scamScanEvidence: v.optional(v.array(v.string())),
   scamScanModel: v.optional(v.string()),
@@ -560,9 +623,14 @@ const auditLogs = defineTable({
 })
   .index('by_actor', ['actorUserId'])
   .index('by_target', ['targetType', 'targetId'])
+  .index('by_target_createdAt', ['targetType', 'targetId', 'createdAt'])
 
 const vtScanLogs = defineTable({
-  type: v.union(v.literal('daily_rescan'), v.literal('backfill'), v.literal('pending_poll')),
+  type: v.union(
+    v.literal('daily_rescan'),
+    v.literal('backfill'),
+    v.literal('pending_poll'),
+  ),
   total: v.number(),
   updated: v.number(),
   unchanged: v.number(),

--- a/convex/skills.listPublicPageV2.test.ts
+++ b/convex/skills.listPublicPageV2.test.ts
@@ -48,8 +48,8 @@ describe('skills.listPublicPageV2', () => {
   })
 
   it('applies highlightedOnly and nonSuspiciousOnly together', async () => {
-    // With both flags, the nonsuspicious index handles isSuspicious at DB level,
-    // and highlightedOnly is applied as a JS filter on top.
+    // Keep pagination on the base sort index and apply both filters in JS while
+    // `isSuspicious` is still being backfilled on existing rows.
     const highlightedClean = makeSkill('skills:hl-clean', 'hl-clean', 'users:1', 'skillVersions:1')
     const plainClean = makeSkill('skills:plain', 'plain', 'users:2', 'skillVersions:2')
 
@@ -93,7 +93,7 @@ describe('skills.listPublicPageV2', () => {
     expect(result.page[0]?.skill.slug).toBe('hl-clean')
     expect(result.continueCursor).toBe('next-cursor')
     expect(result.isDone).toBe(false)
-    expect(withIndexMock).toHaveBeenCalledWith('by_nonsuspicious_downloads', expect.any(Function))
+    expect(withIndexMock).toHaveBeenCalledWith('by_active_stats_downloads', expect.any(Function))
     expect(orderMock).toHaveBeenCalledWith('desc')
     expect(paginateMock).toHaveBeenCalledWith({ cursor: null, numItems: 25 })
   })
@@ -183,10 +183,17 @@ describe('skills.listPublicPageV2', () => {
     expect(paginateMock).toHaveBeenCalledTimes(1)
   })
 
-  it('uses nonsuspicious index when nonSuspiciousOnly is true', async () => {
+  it('uses the base index and filters suspicious rows in JS when nonSuspiciousOnly is true', async () => {
     const clean = makeSkill('skills:clean', 'clean', 'users:1', 'skillVersions:1')
+    const suspicious = makeSkill(
+      'skills:suspicious',
+      'suspicious',
+      'users:2',
+      'skillVersions:2',
+      ['flagged.suspicious'],
+    )
     const paginateMock = vi.fn().mockResolvedValueOnce({
-      page: [clean],
+      page: [suspicious, clean],
       continueCursor: 'after-clean',
       isDone: false,
       pageStatus: null,
@@ -221,7 +228,7 @@ describe('skills.listPublicPageV2', () => {
     expect(result.continueCursor).toBe('after-clean')
     expect(result.isDone).toBe(false)
     expect(withIndexMock).toHaveBeenCalledTimes(1)
-    expect(withIndexMock).toHaveBeenCalledWith('by_nonsuspicious_downloads', expect.any(Function))
+    expect(withIndexMock).toHaveBeenCalledWith('by_active_stats_downloads', expect.any(Function))
     expect(paginateMock).toHaveBeenCalledTimes(1)
   })
 

--- a/convex/skills.manualOverrides.test.ts
+++ b/convex/skills.manualOverrides.test.ts
@@ -9,7 +9,11 @@ vi.mock('./lib/access', async () => {
 })
 
 const { requireUser } = await import('./lib/access')
-const { setSkillManualOverride, clearSkillManualOverride } = await import('./skills')
+const {
+  setSkillManualOverride,
+  clearSkillManualOverride,
+  updateVersionLlmAnalysisInternal,
+} = await import('./skills')
 
 type WrappedHandler<TArgs, TResult = unknown> = {
   _handler: (ctx: unknown, args: TArgs) => Promise<TResult>
@@ -26,6 +30,13 @@ const clearSkillManualOverrideHandler = (
   clearSkillManualOverride as unknown as WrappedHandler<{
     skillId: string
     note: string
+  }>
+)._handler
+
+const updateVersionLlmAnalysisInternalHandler = (
+  updateVersionLlmAnalysisInternal as unknown as WrappedHandler<{
+    versionId: string
+    llmAnalysis: Record<string, unknown>
   }>
 )._handler
 
@@ -310,5 +321,113 @@ describe('skills manual overrides', () => {
     ).rejects.toThrow('Audit note must be at most 1200 characters.')
     expect(patch).not.toHaveBeenCalled()
     expect(insert).not.toHaveBeenCalled()
+  })
+
+  it('rejects manual overrides for malware-blocked skills', async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: 'users:moderator',
+      user: { _id: 'users:moderator', role: 'moderator' },
+    } as never)
+
+    const skill = {
+      _id: 'skills:1',
+      latestVersionId: 'skillVersions:1',
+      softDeletedAt: undefined,
+      moderationStatus: 'hidden',
+      moderationReason: 'manual.override.clean',
+      moderationVerdict: 'malicious',
+      moderationFlags: ['blocked.malware'],
+    }
+
+    const { ctx, patch, insert } = makeCtx({ skill })
+
+    await expect(
+      setSkillManualOverrideHandler(ctx, {
+        skillId: 'skills:1',
+        note: 'trying to reactivate blocked malware',
+      }),
+    ).rejects.toThrow('Skill is not currently suspicious.')
+    expect(patch).not.toHaveBeenCalled()
+    expect(insert).not.toHaveBeenCalled()
+  })
+
+  it('does not let llm scan sync clear an existing quality quarantine', async () => {
+    vi.mocked(requireUser).mockReset()
+
+    const skill = {
+      _id: 'skills:1',
+      ownerUserId: 'users:owner',
+      latestVersionId: 'skillVersions:7',
+      moderationStatus: 'hidden',
+      moderationReason: 'quality.low',
+      moderationVerdict: 'clean',
+      moderationFlags: undefined,
+    }
+    const version = {
+      _id: 'skillVersions:7',
+      skillId: 'skills:1',
+      staticScan: undefined,
+      vtAnalysis: { status: 'clean', checkedAt: 100 },
+      llmAnalysis: undefined,
+    }
+
+    const { ctx, patch } = makeCtx({ skill, version })
+
+    await updateVersionLlmAnalysisInternalHandler(ctx, {
+      versionId: 'skillVersions:7',
+      llmAnalysis: {
+        status: 'clean',
+        checkedAt: 200,
+      },
+    })
+
+    expect(patch).toHaveBeenCalledTimes(1)
+    expect(patch).toHaveBeenCalledWith('skillVersions:7', {
+      llmAnalysis: {
+        status: 'clean',
+        checkedAt: 200,
+      },
+    })
+  })
+
+  it('updates global public count when llm scan sync restores a skill to active', async () => {
+    const now = 1_700_000_300_000
+    vi.spyOn(Date, 'now').mockReturnValue(now)
+
+    const skill = {
+      _id: 'skills:1',
+      ownerUserId: 'users:owner',
+      latestVersionId: 'skillVersions:8',
+      softDeletedAt: undefined,
+      moderationStatus: 'hidden',
+      moderationReason: 'scanner.llm.suspicious',
+      moderationVerdict: 'suspicious',
+      moderationFlags: ['flagged.suspicious'],
+    }
+    const version = {
+      _id: 'skillVersions:8',
+      skillId: 'skills:1',
+      staticScan: undefined,
+      vtAnalysis: undefined,
+      llmAnalysis: { status: 'suspicious', checkedAt: now - 100 },
+    }
+
+    const { ctx, patch } = makeCtx({ skill, version })
+
+    await updateVersionLlmAnalysisInternalHandler(ctx, {
+      versionId: 'skillVersions:8',
+      llmAnalysis: {
+        status: 'clean',
+        checkedAt: now,
+      },
+    })
+
+    expect(patch).toHaveBeenCalledWith(
+      'globalStats:1',
+      expect.objectContaining({
+        activeSkillsCount: 2,
+        updatedAt: now,
+      }),
+    )
   })
 })

--- a/convex/skills.manualOverrides.test.ts
+++ b/convex/skills.manualOverrides.test.ts
@@ -1,0 +1,314 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./lib/access', async () => {
+  const actual = await vi.importActual<typeof import('./lib/access')>('./lib/access')
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  }
+})
+
+const { requireUser } = await import('./lib/access')
+const { setSkillManualOverride, clearSkillManualOverride } = await import('./skills')
+
+type WrappedHandler<TArgs, TResult = unknown> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>
+}
+
+const setSkillManualOverrideHandler = (
+  setSkillManualOverride as unknown as WrappedHandler<{
+    skillId: string
+    note: string
+  }>
+)._handler
+
+const clearSkillManualOverrideHandler = (
+  clearSkillManualOverride as unknown as WrappedHandler<{
+    skillId: string
+    note: string
+  }>
+)._handler
+
+function makeCtx(params: {
+  skill: Record<string, unknown>
+  version?: Record<string, unknown>
+}) {
+  const patch = vi.fn(async () => {})
+  const insert = vi.fn(async () => 'auditLogs:1')
+  const query = vi.fn((table: string) => {
+    if (table === 'globalStats') {
+      return {
+        withIndex: vi.fn(() => ({
+          unique: vi.fn(async () => ({ _id: 'globalStats:1', activeSkillsCount: 1 })),
+        })),
+      }
+    }
+
+    if (table === 'skills') {
+      return {
+        withIndex: vi.fn(() => ({
+          collect: vi.fn(async () => [params.skill]),
+        })),
+      }
+    }
+
+    throw new Error(`Unexpected query table: ${table}`)
+  })
+  const get = vi.fn(async (id: string) => {
+    if (id === params.skill._id) return params.skill
+    if (params.version && id === params.version._id) return params.version
+    if (params.version && id === params.skill.latestVersionId) return params.version
+    return null
+  })
+
+  return {
+    ctx: {
+      db: { get, patch, insert, query },
+    } as never,
+    patch,
+    insert,
+    get,
+    query,
+  }
+}
+
+describe('skills manual overrides', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.mocked(requireUser).mockReset()
+  })
+
+  it('applies a skill-level override and preserves scan metadata', async () => {
+    const now = 1_700_000_000_000
+    vi.spyOn(Date, 'now').mockReturnValue(now)
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: 'users:moderator',
+      user: { _id: 'users:moderator', role: 'moderator' },
+    } as never)
+
+    const skill = {
+      _id: 'skills:1',
+      latestVersionId: 'skillVersions:1',
+      softDeletedAt: undefined,
+      moderationStatus: 'active',
+      moderationReason: 'scanner.vt.suspicious',
+      moderationVerdict: 'suspicious',
+      moderationFlags: ['flagged.suspicious'],
+      moderationReasonCodes: ['suspicious.vt_suspicious'],
+      moderationEvidence: [{ code: 'x', severity: 'warn', file: 'SKILL.md', line: 1, message: 'x', evidence: 'x' }],
+      moderationEngineVersion: 'v2.0.0',
+      moderationSourceVersionId: 'skillVersions:1',
+    }
+
+    const { ctx, patch, insert } = makeCtx({ skill })
+
+    await setSkillManualOverrideHandler(ctx, {
+      skillId: 'skills:1',
+      note: 'reviewed locally',
+    })
+
+    expect(patch).toHaveBeenCalledWith(
+      'skills:1',
+      expect.objectContaining({
+        manualOverride: expect.objectContaining({
+          verdict: 'clean',
+          note: 'reviewed locally',
+          reviewerUserId: 'users:moderator',
+          updatedAt: now,
+        }),
+        moderationReason: 'manual.override.clean',
+        moderationVerdict: 'clean',
+        moderationFlags: undefined,
+        moderationReasonCodes: ['suspicious.vt_suspicious'],
+        moderationEngineVersion: 'v2.0.0',
+        isSuspicious: false,
+      }),
+    )
+    expect(insert).toHaveBeenCalledWith(
+      'auditLogs',
+      expect.objectContaining({
+        action: 'skill.manual_override.set',
+        targetType: 'skill',
+        targetId: 'skills:1',
+      }),
+    )
+  })
+
+  it('increments global public count when an override restores a hidden skill', async () => {
+    const now = 1_700_000_050_000
+    vi.spyOn(Date, 'now').mockReturnValue(now)
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: 'users:moderator',
+      user: { _id: 'users:moderator', role: 'moderator' },
+    } as never)
+
+    const skill = {
+      _id: 'skills:1',
+      latestVersionId: 'skillVersions:1',
+      softDeletedAt: undefined,
+      moderationStatus: 'hidden',
+      moderationReason: 'scanner.vt.suspicious',
+      moderationVerdict: 'suspicious',
+      moderationFlags: ['flagged.suspicious'],
+      moderationReasonCodes: ['suspicious.vt_suspicious'],
+      moderationSourceVersionId: 'skillVersions:1',
+    }
+
+    const { ctx, patch } = makeCtx({ skill })
+
+    await setSkillManualOverrideHandler(ctx, {
+      skillId: 'skills:1',
+      note: 'reviewed and okay to list',
+    })
+
+    expect(patch).toHaveBeenCalledWith(
+      'globalStats:1',
+      expect.objectContaining({
+        activeSkillsCount: 2,
+        updatedAt: now,
+      }),
+    )
+  })
+
+  it('clears a skill-level override and restores scanner-derived suspicious state', async () => {
+    const now = 1_700_000_100_000
+    vi.spyOn(Date, 'now').mockReturnValue(now)
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: 'users:moderator',
+      user: { _id: 'users:moderator', role: 'moderator' },
+    } as never)
+
+    const skill = {
+      _id: 'skills:1',
+      latestVersionId: 'skillVersions:3',
+      moderationReason: 'manual.override.clean',
+      moderationVerdict: 'clean',
+      moderationFlags: undefined,
+      manualOverride: {
+        verdict: 'clean',
+        note: 'reviewed locally',
+        reviewerUserId: 'users:moderator',
+        updatedAt: now - 10_000,
+      },
+    }
+    const version = {
+      _id: 'skillVersions:3',
+      skillId: 'skills:1',
+      staticScan: undefined,
+      vtAnalysis: { status: 'suspicious', checkedAt: now - 1000 },
+      llmAnalysis: undefined,
+    }
+
+    const { ctx, patch, insert } = makeCtx({ skill, version })
+
+    await clearSkillManualOverrideHandler(ctx, {
+      skillId: 'skills:1',
+      note: 'scanner is fixed now',
+    })
+
+    expect(patch).toHaveBeenCalledWith(
+      'skills:1',
+      expect.objectContaining({
+        manualOverride: undefined,
+        updatedAt: now,
+      }),
+    )
+    expect(patch).toHaveBeenCalledWith(
+      'skills:1',
+      expect.objectContaining({
+        moderationReason: 'scanner.vt.suspicious',
+        moderationVerdict: 'suspicious',
+        moderationFlags: ['flagged.suspicious'],
+        isSuspicious: true,
+      }),
+    )
+    expect(insert).toHaveBeenCalledWith(
+      'auditLogs',
+      expect.objectContaining({
+        action: 'skill.manual_override.clear',
+        targetType: 'skill',
+        targetId: 'skills:1',
+      }),
+    )
+  })
+
+  it('clears a skill-level override and restores hidden malicious state', async () => {
+    const now = 1_700_000_200_000
+    vi.spyOn(Date, 'now').mockReturnValue(now)
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: 'users:moderator',
+      user: { _id: 'users:moderator', role: 'moderator' },
+    } as never)
+
+    const skill = {
+      _id: 'skills:1',
+      ownerUserId: 'users:owner',
+      latestVersionId: 'skillVersions:4',
+      moderationStatus: 'active',
+      moderationReason: 'manual.override.clean',
+      moderationVerdict: 'clean',
+      moderationFlags: undefined,
+      manualOverride: {
+        verdict: 'clean',
+        note: 'reviewed locally',
+        reviewerUserId: 'users:moderator',
+        updatedAt: now - 10_000,
+      },
+    }
+    const version = {
+      _id: 'skillVersions:4',
+      skillId: 'skills:1',
+      staticScan: undefined,
+      vtAnalysis: { status: 'malicious', checkedAt: now - 1000 },
+      llmAnalysis: undefined,
+    }
+
+    const { ctx, patch } = makeCtx({ skill, version })
+
+    await clearSkillManualOverrideHandler(ctx, {
+      skillId: 'skills:1',
+      note: 'restoring scanner verdict',
+    })
+
+    expect(patch).toHaveBeenCalledWith(
+      'skills:1',
+      expect.objectContaining({
+        moderationStatus: 'hidden',
+        moderationReason: 'scanner.vt.malicious',
+        moderationVerdict: 'malicious',
+        moderationFlags: ['blocked.malware'],
+        hiddenAt: now,
+        lastReviewedAt: now,
+        isSuspicious: false,
+      }),
+    )
+  })
+
+  it('rejects override notes longer than the max length', async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: 'users:moderator',
+      user: { _id: 'users:moderator', role: 'moderator' },
+    } as never)
+
+    const skill = {
+      _id: 'skills:1',
+      latestVersionId: 'skillVersions:1',
+      softDeletedAt: undefined,
+      moderationStatus: 'active',
+      moderationReason: 'scanner.vt.suspicious',
+      moderationVerdict: 'suspicious',
+      moderationFlags: ['flagged.suspicious'],
+    }
+
+    const { ctx, patch, insert } = makeCtx({ skill })
+
+    await expect(
+      setSkillManualOverrideHandler(ctx, {
+        skillId: 'skills:1',
+        note: 'x'.repeat(1201),
+      }),
+    ).rejects.toThrow('Audit note must be at most 1200 characters.')
+    expect(patch).not.toHaveBeenCalled()
+    expect(insert).not.toHaveBeenCalled()
+  })
+})

--- a/convex/skills.publicModeration.test.ts
+++ b/convex/skills.publicModeration.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@convex-dev/auth/server', () => ({
+  getAuthUserId: vi.fn(),
+}))
+
+vi.mock('./lib/badges', async () => {
+  const actual =
+    await vi.importActual<typeof import('./lib/badges')>('./lib/badges')
+  return {
+    ...actual,
+    getSkillBadgeMap: vi.fn(async () => ({})),
+  }
+})
+
+const { getAuthUserId } = await import('@convex-dev/auth/server')
+const { getBySlug } = await import('./skills')
+
+type WrappedHandler<TArgs, TResult = unknown> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>
+}
+
+const getBySlugHandler = (
+  getBySlug as unknown as WrappedHandler<{
+    slug: string
+  }>
+)._handler
+
+function makeCtx() {
+  const skill = {
+    _id: 'skills:1',
+    _creationTime: 1,
+    slug: 'padel',
+    displayName: 'Padel',
+    summary: 'A test skill',
+    ownerUserId: 'users:owner',
+    canonicalSkillId: undefined,
+    forkOf: undefined,
+    latestVersionId: 'skillVersions:1',
+    tags: { latest: '0.1.0' },
+    badges: {},
+    stats: {
+      downloads: 0,
+      stars: 0,
+      installsCurrent: 0,
+      installsAllTime: 0,
+      versions: 1,
+      comments: 0,
+    },
+    createdAt: 10,
+    updatedAt: 20,
+    softDeletedAt: undefined,
+    moderationStatus: 'active',
+    moderationReason: 'manual.override.clean',
+    moderationVerdict: 'clean',
+    moderationFlags: undefined,
+    moderationReasonCodes: ['suspicious.dynamic_code_execution'],
+    moderationSummary: 'Manual override (clean): internal staff note',
+    moderationEngineVersion: 'v2.0.0',
+    moderationEvaluatedAt: 30,
+    manualOverride: {
+      verdict: 'clean',
+      note: 'internal staff note',
+      reviewerUserId: 'users:moderator',
+      updatedAt: 30,
+    },
+  }
+
+  const latestVersion = {
+    _id: 'skillVersions:1',
+    version: '0.1.0',
+  }
+
+  const owner = {
+    _id: 'users:owner',
+    _creationTime: 2,
+    handle: 'local',
+    name: 'Local Dev',
+    displayName: 'Local Dev',
+    deletedAt: undefined,
+    deactivatedAt: undefined,
+  }
+
+  const query = vi.fn((table: string) => {
+    if (table === 'skills') {
+      return {
+        withIndex: vi.fn(() => ({
+          unique: vi.fn(async () => skill),
+        })),
+      }
+    }
+    throw new Error(`Unexpected query table: ${table}`)
+  })
+
+  const get = vi.fn(async (id: string) => {
+    if (id === 'skillVersions:1') return latestVersion
+    if (id === 'users:owner') return owner
+    return null
+  })
+
+  return {
+    ctx: {
+      db: { query, get },
+    } as never,
+  }
+}
+
+describe('getBySlug public moderation info', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.mocked(getAuthUserId).mockReset()
+  })
+
+  it('does not expose manual override notes to non-owners', async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue(null)
+
+    const { ctx } = makeCtx()
+    const result = (await getBySlugHandler(ctx, {
+      slug: 'padel',
+    })) as {
+      moderationInfo: {
+        overrideActive: boolean
+        summary: string | null
+      } | null
+    }
+
+    expect(result.moderationInfo?.overrideActive).toBe(true)
+    expect(result.moderationInfo?.summary).toBe(
+      'Security findings were reviewed by staff and cleared for public use.',
+    )
+  })
+})

--- a/convex/skills.staffAuditLogs.test.ts
+++ b/convex/skills.staffAuditLogs.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./lib/access', async () => {
+  const actual =
+    await vi.importActual<typeof import('./lib/access')>('./lib/access')
+  return {
+    ...actual,
+    requireUser: vi.fn(),
+  }
+})
+
+vi.mock('./lib/badges', async () => {
+  const actual =
+    await vi.importActual<typeof import('./lib/badges')>('./lib/badges')
+  return {
+    ...actual,
+    getSkillBadgeMap: vi.fn(async () => ({})),
+  }
+})
+
+const { requireUser } = await import('./lib/access')
+const { getSkillBadgeMap } = await import('./lib/badges')
+const { getBySlugForStaff } = await import('./skills')
+
+type WrappedHandler<TArgs, TResult = unknown> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>
+}
+
+const getBySlugForStaffHandler = (
+  getBySlugForStaff as unknown as WrappedHandler<{
+    slug: string
+    auditLogLimit?: number
+  }>
+)._handler
+
+function makeCtx() {
+  const skill = {
+    _id: 'skills:1',
+    slug: 'padel',
+    displayName: 'Padel',
+    ownerUserId: 'users:owner',
+    latestVersionId: 'skillVersions:1',
+    manualOverride: {
+      verdict: 'clean',
+      note: 'reviewed locally',
+      reviewerUserId: 'users:moderator',
+      updatedAt: 200,
+    },
+    tags: {},
+  }
+
+  const latestVersion = {
+    _id: 'skillVersions:1',
+    version: '0.1.0',
+    createdAt: 100,
+    changelog: 'seeded',
+  }
+
+  const auditLogs = [
+    {
+      _id: 'auditLogs:1',
+      actorUserId: 'users:moderator',
+      action: 'skill.manual_override.set',
+      targetType: 'skill',
+      targetId: 'skills:1',
+      metadata: { verdict: 'clean', note: 'reviewed locally' },
+      createdAt: 200,
+    },
+    {
+      _id: 'auditLogs:2',
+      actorUserId: 'users:admin',
+      action: 'skill.owner.change',
+      targetType: 'skill',
+      targetId: 'skills:1',
+      metadata: { from: 'users:owner', to: 'users:next-owner' },
+      createdAt: 150,
+    },
+  ]
+
+  const auditTake = vi.fn(async (limit: number) => auditLogs.slice(0, limit))
+  const skillUnique = vi.fn(async () => skill)
+  const query = vi.fn((table: string) => {
+    if (table === 'skills') {
+      return {
+        withIndex: vi.fn(() => ({
+          unique: skillUnique,
+        })),
+      }
+    }
+
+    if (table === 'auditLogs') {
+      return {
+        withIndex: vi.fn(() => ({
+          order: vi.fn(() => ({
+            take: auditTake,
+          })),
+        })),
+      }
+    }
+
+    throw new Error(`Unexpected query table: ${table}`)
+  })
+
+  const get = vi.fn(async (id: string) => {
+    switch (id) {
+      case 'skillVersions:1':
+        return latestVersion
+      case 'users:owner':
+        return {
+          _id: 'users:owner',
+          _creationTime: 1,
+          handle: 'local',
+          name: 'Local Dev',
+          displayName: 'Local Dev',
+          role: 'user',
+        }
+      case 'users:moderator':
+        return {
+          _id: 'users:moderator',
+          _creationTime: 2,
+          handle: 'moddy',
+          name: 'Moddy',
+          displayName: 'Moddy',
+          role: 'moderator',
+        }
+      case 'users:admin':
+        return {
+          _id: 'users:admin',
+          _creationTime: 3,
+          handle: 'chief',
+          name: 'Chief',
+          displayName: 'Chief',
+          role: 'admin',
+        }
+      default:
+        return null
+    }
+  })
+
+  return {
+    ctx: {
+      db: { query, get },
+    } as never,
+    auditTake,
+    get,
+  }
+}
+
+describe('getBySlugForStaff audit logs', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.mocked(requireUser).mockReset()
+  })
+
+  it('returns reviewer info and recent audit logs with actor handles', async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: 'users:moderator',
+      user: { _id: 'users:moderator', role: 'moderator' },
+    } as never)
+
+    const { ctx, auditTake } = makeCtx()
+
+    const result = (await getBySlugForStaffHandler(ctx, {
+      slug: 'padel',
+      auditLogLimit: 5,
+    })) as {
+      overrideReviewer: { handle?: string | null } | null
+      auditLogs: Array<{
+        actor: { handle?: string | null } | null
+        action: string
+      }>
+    }
+
+    expect(getSkillBadgeMap).toHaveBeenCalled()
+    expect(auditTake).toHaveBeenCalledWith(5)
+    expect(result.overrideReviewer?.handle).toBe('moddy')
+    expect(result.auditLogs).toHaveLength(2)
+    expect(result.auditLogs[0]?.action).toBe('skill.manual_override.set')
+    expect(result.auditLogs[0]?.actor?.handle).toBe('moddy')
+    expect(result.auditLogs[1]?.actor?.handle).toBe('chief')
+  })
+})

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -1,9 +1,9 @@
 import { getAuthUserId } from '@convex-dev/auth/server'
 import { paginationOptsValidator } from 'convex/server'
 import { ConvexError, v } from 'convex/values'
-import { internal } from './_generated/api'
 import type { Doc, Id } from './_generated/dataModel'
 import type { MutationCtx, QueryCtx } from './_generated/server'
+import { internal } from './_generated/api'
 import {
   action,
   internalAction,
@@ -12,13 +12,20 @@ import {
   mutation,
   query,
 } from './_generated/server'
-import { assertAdmin, assertModerator, requireUser, requireUserFromAction } from './lib/access'
+import {
+  assertAdmin,
+  assertModerator,
+  requireUser,
+  requireUserFromAction,
+} from './lib/access'
 import {
   getSkillBadgeMap,
   getSkillBadgeMaps,
   isSkillHighlighted,
 } from './lib/badges'
+import { scheduleNextBatchIfNeeded } from './lib/batching'
 import { generateChangelogPreview as buildChangelogPreview } from './lib/changelog'
+import { embeddingVisibilityFor } from './lib/embeddingVisibility'
 import {
   canHealSkillOwnershipByGitHubProviderAccountId,
   getGitHubProviderAccountId,
@@ -31,8 +38,13 @@ import {
   readGlobalPublicSkillsCount,
 } from './lib/globalStats'
 import { buildTrendingLeaderboard } from './lib/leaderboards'
-import { buildModerationSnapshot } from './lib/moderationEngine'
+import {
+  applyManualOverrideToSkillPatch,
+  isManualOverrideReason,
+  type ManualModerationOverride,
+} from './lib/manualOverrides'
 import { deriveModerationFlags } from './lib/moderation'
+import { buildModerationSnapshot } from './lib/moderationEngine'
 import {
   legacyFlagsFromVerdict,
   summarizeReasonCodes,
@@ -44,8 +56,6 @@ import {
   MAX_ACTIVE_REPORTS_PER_USER,
   MAX_REPORT_REASON_LENGTH,
 } from './lib/reporting'
-import { embeddingVisibilityFor } from './lib/embeddingVisibility'
-import { scheduleNextBatchIfNeeded } from './lib/batching'
 import {
   enforceReservedSlugCooldownForNewSkill,
   formatReservedSlugCooldownMessage,
@@ -60,13 +70,18 @@ import {
   publishVersionForUser,
   queueHighlightedWebhook,
 } from './lib/skillPublish'
-import { computeIsSuspicious, isSkillSuspicious } from './lib/skillSafety'
 import { getFrontmatterValue, hashSkillFiles } from './lib/skills'
+import { computeIsSuspicious, isSkillSuspicious } from './lib/skillSafety'
 
 export { publishVersionForUser } from './lib/skillPublish'
 
 type ReadmeResult = { path: string; text: string }
-type FileTextResult = { path: string; text: string; size: number; sha256: string }
+type FileTextResult = {
+  path: string
+  text: string
+  size: number
+  sha256: string
+}
 const PLATFORM_SKILL_LICENSE = 'MIT-0' as const
 
 const MAX_DIFF_FILE_BYTES = 200 * 1024
@@ -84,6 +99,9 @@ const RATE_LIMIT_DAY_MS = 24 * RATE_LIMIT_HOUR_MS
 const SLUG_RESERVATION_DAYS = 90
 const SLUG_RESERVATION_MS = SLUG_RESERVATION_DAYS * RATE_LIMIT_DAY_MS
 const LOW_TRUST_ACCOUNT_AGE_MS = 30 * RATE_LIMIT_DAY_MS
+const MAX_MANUAL_OVERRIDE_NOTE_LENGTH = 1200
+const DEFAULT_STAFF_AUDIT_LOG_LIMIT = 10
+const MAX_STAFF_AUDIT_LOG_LIMIT = 50
 
 function buildStructuredModerationPatch(params: {
   staticScan?: Doc<'skillVersions'>['staticScan']
@@ -109,8 +127,12 @@ function buildStructuredModerationPatch(params: {
 
   return {
     moderationVerdict: snapshot.verdict,
-    moderationReasonCodes: snapshot.reasonCodes.length ? snapshot.reasonCodes : undefined,
-    moderationEvidence: snapshot.evidence.length ? snapshot.evidence : undefined,
+    moderationReasonCodes: snapshot.reasonCodes.length
+      ? snapshot.reasonCodes
+      : undefined,
+    moderationEvidence: snapshot.evidence.length
+      ? snapshot.evidence
+      : undefined,
     moderationSummary: snapshot.summary,
     moderationEngineVersion: snapshot.engineVersion,
     moderationEvaluatedAt: snapshot.evaluatedAt,
@@ -118,21 +140,161 @@ function buildStructuredModerationPatch(params: {
   }
 }
 
+type SkillModerationPatch = Partial<Doc<'skills'>>
+
+function trimManualOverrideNote(note: string) {
+  const trimmed = note.trim()
+  if (!trimmed) {
+    throw new ConvexError('Audit note is required.')
+  }
+  if (trimmed.length > MAX_MANUAL_OVERRIDE_NOTE_LENGTH) {
+    throw new ConvexError(
+      `Audit note must be at most ${MAX_MANUAL_OVERRIDE_NOTE_LENGTH} characters.`,
+    )
+  }
+  return trimmed
+}
+
+function normalizeAnalysisStatus(status: string | undefined) {
+  return status?.trim().toLowerCase()
+}
+
+function resolveScannerModerationReason(params: {
+  vtStatus?: string
+  llmStatus?: string
+  verdict?: Doc<'skills'>['moderationVerdict']
+}) {
+  const vtStatus = normalizeAnalysisStatus(params.vtStatus)
+  const llmStatus = normalizeAnalysisStatus(params.llmStatus)
+
+  if (vtStatus === 'malicious') return 'scanner.vt.malicious'
+  if (llmStatus === 'malicious') return 'scanner.llm.malicious'
+  if (vtStatus === 'suspicious') return 'scanner.vt.suspicious'
+  if (llmStatus === 'suspicious') return 'scanner.llm.suspicious'
+  if (
+    vtStatus === 'pending' ||
+    vtStatus === 'loading' ||
+    vtStatus === 'not_found'
+  ) {
+    return 'scanner.vt.pending'
+  }
+  if (llmStatus === 'pending' || llmStatus === 'loading')
+    return 'scanner.llm.pending'
+  if (vtStatus === 'clean') return 'scanner.vt.clean'
+  if (llmStatus === 'clean') return 'scanner.llm.clean'
+  if (params.verdict === 'malicious') return 'scanner.aggregate.malicious'
+  if (params.verdict === 'suspicious') return 'scanner.aggregate.suspicious'
+  return 'scanner.aggregate.clean'
+}
+
+function buildScannerModerationPatchFromVersion(params: {
+  owner: Doc<'users'> | null | undefined
+  version: Pick<
+    Doc<'skillVersions'>,
+    '_id' | 'staticScan' | 'vtAnalysis' | 'llmAnalysis'
+  >
+  now: number
+}): SkillModerationPatch {
+  const structuredPatch = buildStructuredModerationPatch({
+    staticScan: params.version.staticScan,
+    vtStatus: params.version.vtAnalysis?.status,
+    llmStatus: params.version.llmAnalysis?.status,
+    sourceVersionId: params.version._id,
+  })
+
+  const sourceReasonCodes = structuredPatch.moderationReasonCodes ?? []
+  const sourceReason = resolveScannerModerationReason({
+    vtStatus: params.version.vtAnalysis?.status,
+    llmStatus: params.version.llmAnalysis?.status,
+    verdict: structuredPatch.moderationVerdict,
+  })
+  const bypassSuspicious =
+    structuredPatch.moderationVerdict === 'suspicious' &&
+    isPrivilegedOwnerForSuspiciousBypass(params.owner)
+  const moderationReasonCodes = bypassSuspicious
+    ? sourceReasonCodes.filter((code) => !code.startsWith('suspicious.'))
+    : sourceReasonCodes
+  const moderationVerdict = verdictFromCodes(moderationReasonCodes)
+  const moderationFlags = legacyFlagsFromVerdict(moderationVerdict)
+  const moderationReason = bypassSuspicious
+    ? normalizeScannerSuspiciousReason(sourceReason)
+    : sourceReason
+  const moderationStatus =
+    moderationVerdict === 'malicious' ? 'hidden' : 'active'
+
+  return {
+    moderationStatus,
+    moderationReason,
+    moderationFlags,
+    moderationVerdict,
+    moderationReasonCodes: moderationReasonCodes.length
+      ? moderationReasonCodes
+      : undefined,
+    moderationEvidence: structuredPatch.moderationEvidence,
+    moderationSummary: summarizeReasonCodes(moderationReasonCodes),
+    moderationEngineVersion: structuredPatch.moderationEngineVersion,
+    moderationEvaluatedAt: structuredPatch.moderationEvaluatedAt,
+    moderationSourceVersionId: structuredPatch.moderationSourceVersionId,
+    moderationNotes: undefined,
+    isSuspicious: computeIsSuspicious({
+      moderationFlags,
+      moderationReason,
+    }),
+    hiddenAt: moderationStatus === 'hidden' ? params.now : undefined,
+    hiddenBy: undefined,
+    lastReviewedAt: moderationStatus === 'hidden' ? params.now : undefined,
+    updatedAt: params.now,
+  }
+}
+
+function buildPreservedSkillModerationPatch(
+  skill: Doc<'skills'>,
+): SkillModerationPatch {
+  return {
+    moderationReasonCodes: skill.moderationReasonCodes,
+    moderationEvidence: skill.moderationEvidence,
+    moderationEngineVersion: skill.moderationEngineVersion,
+    moderationSourceVersionId: skill.moderationSourceVersionId,
+  }
+}
+
+function applySkillManualOverrideToSkillPatch(params: {
+  skill: Pick<Doc<'skills'>, 'manualOverride'>
+  basePatch: SkillModerationPatch
+  now: number
+}) {
+  if (!params.skill.manualOverride) return params.basePatch
+  return applyManualOverrideToSkillPatch({
+    basePatch: params.basePatch,
+    override: params.skill.manualOverride,
+    now: params.now,
+  })
+}
+
 async function patchStructuredModerationFromVersion(
   ctx: MutationCtx,
   skill: Doc<'skills'>,
-  version: Pick<Doc<'skillVersions'>, '_id' | 'staticScan' | 'vtAnalysis' | 'llmAnalysis'>,
+  version: Pick<
+    Doc<'skillVersions'>,
+    '_id' | 'staticScan' | 'vtAnalysis' | 'llmAnalysis'
+  >,
 ) {
-  const patch = buildStructuredModerationPatch({
-    staticScan: version.staticScan,
-    vtStatus: version.vtAnalysis?.status,
-    llmStatus: version.llmAnalysis?.status,
-    sourceVersionId: version._id,
+  const now = Date.now()
+  const owner = skill.ownerUserId ? await ctx.db.get(skill.ownerUserId) : null
+  const basePatch = buildScannerModerationPatchFromVersion({
+    owner,
+    version,
+    now,
+  })
+  const patch = applySkillManualOverrideToSkillPatch({
+    skill,
+    basePatch,
+    now,
   })
 
   await ctx.db.patch(skill._id, {
     ...patch,
-    updatedAt: Date.now(),
+    updatedAt: now,
   })
 }
 const TRUSTED_PUBLISHER_SKILL_THRESHOLD = 10
@@ -152,15 +314,6 @@ const SORT_INDEXES = {
   installs: 'by_active_stats_installs_all_time',
 } as const
 
-const NONSUSPICIOUS_SORT_INDEXES = {
-  newest: 'by_nonsuspicious_created',
-  updated: 'by_nonsuspicious_updated',
-  name: 'by_nonsuspicious_name',
-  downloads: 'by_nonsuspicious_downloads',
-  stars: 'by_nonsuspicious_stars',
-  installs: 'by_nonsuspicious_installs',
-} as const
-
 function isSkillVersionId(
   value: Id<'skillVersions'> | null | undefined,
 ): value is Id<'skillVersions'> {
@@ -177,7 +330,9 @@ type OwnerTrustSignals = {
   skillsLastDay: number
 }
 
-function isPrivilegedOwnerForSuspiciousBypass(owner: Doc<'users'> | null | undefined) {
+function isPrivilegedOwnerForSuspiciousBypass(
+  owner: Doc<'users'> | null | undefined,
+) {
   if (!owner) return false
   return owner.role === 'admin' || owner.role === 'moderator'
 }
@@ -188,14 +343,114 @@ function stripSuspiciousFlag(flags: string[] | undefined) {
   return next.length ? next : undefined
 }
 
-function buildConflictingSkillUrl(skill: Doc<'skills'>, owner: Doc<'users'> | null | undefined) {
-  if (!owner || owner.deletedAt || owner.deactivatedAt || !isPublicSkillDoc(skill)) return null
+function buildManualOverrideRecord(params: {
+  note: string
+  reviewerUserId: Id<'users'>
+  updatedAt: number
+}): ManualModerationOverride {
+  return {
+    verdict: 'clean',
+    note: trimManualOverrideNote(params.note),
+    reviewerUserId: params.reviewerUserId,
+    updatedAt: params.updatedAt,
+  }
+}
+
+function canApplySkillManualOverride(
+  skill: Pick<Doc<'skills'>, 'moderationReason' | 'moderationFlags'>,
+) {
+  return (
+    isSkillSuspicious(skill) || isManualOverrideReason(skill.moderationReason)
+  )
+}
+
+function shouldSyncModerationFromLatestVersion(
+  skill: Pick<
+    Doc<'skills'>,
+    'manualOverride' | 'moderationStatus' | 'moderationReason' | 'softDeletedAt'
+  >,
+) {
+  if (skill.softDeletedAt) return false
+  if (skill.manualOverride) return true
+  if (skill.moderationStatus === 'active') return true
+  if (skill.moderationStatus === 'removed') return false
+  if (
+    skill.moderationReason === 'pending.scan' ||
+    skill.moderationReason === 'pending.scan.stale'
+  ) {
+    return true
+  }
+  return (
+    typeof skill.moderationReason === 'string' &&
+    skill.moderationReason.startsWith('scanner.')
+  )
+}
+
+async function syncSkillModerationFromLatestVersion(
+  ctx: MutationCtx,
+  skill: Doc<'skills'>,
+  now: number,
+) {
+  const owner = skill.ownerUserId ? await ctx.db.get(skill.ownerUserId) : null
+  const latestVersion = skill.latestVersionId
+    ? await ctx.db.get(skill.latestVersionId)
+    : null
+  const basePatch: SkillModerationPatch = latestVersion
+    ? buildScannerModerationPatchFromVersion({
+        owner,
+        version: latestVersion,
+        now,
+      })
+    : {
+        moderationStatus: 'active',
+        moderationReason: undefined,
+        moderationNotes: undefined,
+        moderationFlags: undefined,
+        moderationVerdict: 'clean',
+        moderationReasonCodes: undefined,
+        moderationEvidence: undefined,
+        moderationSummary: 'No suspicious patterns detected.',
+        moderationEngineVersion: undefined,
+        moderationEvaluatedAt: now,
+        moderationSourceVersionId: undefined,
+        isSuspicious: false,
+        hiddenAt: undefined,
+        hiddenBy: undefined,
+        lastReviewedAt: undefined,
+        updatedAt: now,
+      }
+
+  const patch = applySkillManualOverrideToSkillPatch({
+    skill,
+    basePatch,
+    now,
+  })
+
+  const nextSkill = { ...skill, ...patch }
+  await ctx.db.patch(skill._id, patch)
+  await adjustGlobalPublicCountForSkillChange(ctx, skill, nextSkill)
+}
+
+function buildConflictingSkillUrl(
+  skill: Doc<'skills'>,
+  owner: Doc<'users'> | null | undefined,
+) {
+  if (
+    !owner ||
+    owner.deletedAt ||
+    owner.deactivatedAt ||
+    !isPublicSkillDoc(skill)
+  )
+    return null
   const ownerParam = owner.handle?.trim() || String(owner._id)
   if (!ownerParam) return null
   return `/${encodeURIComponent(ownerParam)}/${encodeURIComponent(skill.slug)}`
 }
 
-function buildSlugTakenErrorMessage(skill: Doc<'skills'>, owner: Doc<'users'> | null | undefined) {
+function buildSlugTakenErrorMessage(
+  skill: Doc<'skills'>,
+  owner: Doc<'users'> | null | undefined,
+) {
   const base = 'Slug is already taken. Choose a different slug.'
   const url = buildConflictingSkillUrl(skill, owner)
   if (!url) return base
@@ -204,7 +459,8 @@ function buildSlugTakenErrorMessage(skill: Doc<'skills'>, owner: Doc<'users'> | 
 
 function normalizeScannerSuspiciousReason(reason: string | undefined) {
   if (!reason) return reason
-  if (!reason.startsWith('scanner.') || !reason.endsWith('.suspicious')) return reason
+  if (!reason.startsWith('scanner.') || !reason.endsWith('.suspicious'))
+    return reason
   return `${reason.slice(0, -'.suspicious'.length)}.clean`
 }
 
@@ -254,7 +510,9 @@ async function getOwnerTrustSignals(
 }
 
 function enforceNewSkillRateLimit(signals: OwnerTrustSignals) {
-  const limits = signals.isLowTrust ? NEW_SKILL_RATE_LIMITS.lowTrust : NEW_SKILL_RATE_LIMITS.trusted
+  const limits = signals.isLowTrust
+    ? NEW_SKILL_RATE_LIMITS.lowTrust
+    : NEW_SKILL_RATE_LIMITS.trusted
   if (signals.skillsLastHour >= limits.perHour) {
     throw new ConvexError(
       `Rate limit: max ${limits.perHour} new skills per hour. Please wait before publishing more.`,
@@ -288,7 +546,9 @@ const HARD_DELETE_PHASES = [
 
 type HardDeletePhase = (typeof HARD_DELETE_PHASES)[number]
 
-function isHardDeletePhase(value: string | undefined): value is HardDeletePhase {
+function isHardDeletePhase(
+  value: string | undefined,
+): value is HardDeletePhase {
   if (!value) return false
   return (HARD_DELETE_PHASES as readonly string[]).includes(value)
 }
@@ -512,7 +772,9 @@ async function hardDeleteSkillStep(
         .query('skillLeaderboards')
         .take(HARD_DELETE_LEADERBOARD_BATCH_SIZE)
       for (const leaderboard of leaderboards) {
-        const items = leaderboard.items.filter((item) => item.skillId !== skill._id)
+        const items = leaderboard.items.filter(
+          (item) => item.skillId !== skill._id,
+        )
         if (items.length !== leaderboard.items.length) {
           await ctx.db.patch(leaderboard._id, { items })
         }
@@ -589,9 +851,18 @@ type PublicSkillEntry = {
   owner: ReturnType<typeof toPublicUser> | null
 }
 
+type StaffSkillAuditLogEntry = Doc<'auditLogs'> & {
+  actor: ReturnType<typeof toPublicUser> | null
+}
+
 type PublicSkillListVersion = Pick<
   Doc<'skillVersions'>,
-  '_id' | '_creationTime' | 'version' | 'createdAt' | 'changelog' | 'changelogSource'
+  | '_id'
+  | '_creationTime'
+  | 'version'
+  | 'createdAt'
+  | 'changelog'
+  | 'changelogSource'
 > & {
   parsed?: {
     license?: typeof PLATFORM_SKILL_LICENSE
@@ -621,7 +892,10 @@ async function buildPublicSkillEntries(
   const includeVersion = opts?.includeVersion ?? true
   const ownerInfoCache = new Map<
     Id<'users'>,
-    Promise<{ ownerHandle: string | null; owner: ReturnType<typeof toPublicUser> | null }>
+    Promise<{
+      ownerHandle: string | null
+      owner: ReturnType<typeof toPublicUser> | null
+    }>
   >()
 
   const getOwnerInfo = (ownerUserId: Id<'users'>) => {
@@ -632,7 +906,8 @@ async function buildPublicSkillEntries(
         return { ownerHandle: null, owner: null }
       }
       return {
-        ownerHandle: ownerDoc.handle ?? (ownerDoc._id ? String(ownerDoc._id) : null),
+        ownerHandle:
+          ownerDoc.handle ?? (ownerDoc._id ? String(ownerDoc._id) : null),
         owner: toPublicUser(ownerDoc),
       }
     })
@@ -653,7 +928,10 @@ async function buildPublicSkillEntries(
       const publicSkill = toPublicSkill(skill)
       if (!publicSkill) return null
       const latestVersion = hasSummary
-        ? toPublicSkillListVersionFromSummary(skill.latestVersionSummary!, skill.latestVersionId)
+        ? toPublicSkillListVersionFromSummary(
+            skill.latestVersionSummary!,
+            skill.latestVersionId,
+          )
         : toPublicSkillListVersion(latestVersionDoc)
       return {
         skill: publicSkill,
@@ -681,8 +959,12 @@ function toPublicSkillListVersion(
     parsed:
       version.parsed?.clawdis || version.parsed?.license
         ? {
-            ...(version.parsed?.license ? { license: version.parsed.license } : {}),
-            ...(version.parsed?.clawdis ? { clawdis: version.parsed.clawdis } : {}),
+            ...(version.parsed?.license
+              ? { license: version.parsed.license }
+              : {}),
+            ...(version.parsed?.clawdis
+              ? { clawdis: version.parsed.clawdis }
+              : {}),
           }
         : undefined,
   }
@@ -705,7 +987,10 @@ function toPublicSkillListVersionFromSummary(
   }
 }
 
-async function buildManagementSkillEntries(ctx: QueryCtx, skills: Doc<'skills'>[]) {
+async function buildManagementSkillEntries(
+  ctx: QueryCtx,
+  skills: Doc<'skills'>[],
+) {
   const ownerCache = new Map<Id<'users'>, Promise<Doc<'users'> | null>>()
   const badgeMapBySkillId = await getSkillBadgeMaps(
     ctx,
@@ -770,7 +1055,9 @@ async function upsertSkillBadge(
 ) {
   const existing = await ctx.db
     .query('skillBadges')
-    .withIndex('by_skill_kind', (q) => q.eq('skillId', skillId).eq('kind', kind))
+    .withIndex('by_skill_kind', (q) =>
+      q.eq('skillId', skillId).eq('kind', kind),
+    )
     .unique()
   if (existing) {
     await ctx.db.patch(existing._id, { byUserId: userId, at })
@@ -794,10 +1081,16 @@ async function upsertSkillBadge(
   }
 }
 
-async function removeSkillBadge(ctx: MutationCtx, skillId: Id<'skills'>, kind: BadgeKind) {
+async function removeSkillBadge(
+  ctx: MutationCtx,
+  skillId: Id<'skills'>,
+  kind: BadgeKind,
+) {
   const existing = await ctx.db
     .query('skillBadges')
-    .withIndex('by_skill_kind', (q) => q.eq('skillId', skillId).eq('kind', kind))
+    .withIndex('by_skill_kind', (q) =>
+      q.eq('skillId', skillId).eq('kind', kind),
+    )
     .unique()
   if (existing) {
     await ctx.db.delete(existing._id)
@@ -805,7 +1098,10 @@ async function removeSkillBadge(ctx: MutationCtx, skillId: Id<'skills'>, kind: B
   // Keep denormalized badges field on skill doc in sync
   const skill = await ctx.db.get(skillId)
   if (skill) {
-    const { [kind]: _, ...remainingBadges } = (skill.badges ?? {}) as Record<string, unknown>
+    const { [kind]: _, ...remainingBadges } = (skill.badges ?? {}) as Record<
+      string,
+      unknown
+    >
     await ctx.db.patch(skillId, { badges: remainingBadges })
   }
 }
@@ -822,24 +1118,39 @@ export const getBySlug = query({
     const userId = await getAuthUserId(ctx)
     const isOwner = Boolean(userId && userId === skill.ownerUserId)
 
-    const latestVersion = skill.latestVersionId ? await ctx.db.get(skill.latestVersionId) : null
+    const latestVersion = skill.latestVersionId
+      ? await ctx.db.get(skill.latestVersionId)
+      : null
     const owner = await ctx.db.get(skill.ownerUserId)
     const badges = await getSkillBadgeMap(ctx, skill._id)
 
-    const forkOfSkill = skill.forkOf?.skillId ? await ctx.db.get(skill.forkOf.skillId) : null
-    const forkOfOwner = forkOfSkill ? await ctx.db.get(forkOfSkill.ownerUserId) : null
+    const forkOfSkill = skill.forkOf?.skillId
+      ? await ctx.db.get(skill.forkOf.skillId)
+      : null
+    const forkOfOwner = forkOfSkill
+      ? await ctx.db.get(forkOfSkill.ownerUserId)
+      : null
 
-    const canonicalSkill = skill.canonicalSkillId ? await ctx.db.get(skill.canonicalSkillId) : null
-    const canonicalOwner = canonicalSkill ? await ctx.db.get(canonicalSkill.ownerUserId) : null
+    const canonicalSkill = skill.canonicalSkillId
+      ? await ctx.db.get(skill.canonicalSkillId)
+      : null
+    const canonicalOwner = canonicalSkill
+      ? await ctx.db.get(canonicalSkill.ownerUserId)
+      : null
 
     const publicSkill = toPublicSkill({ ...skill, badges })
 
     // Determine moderation state
+    const overrideActive = Boolean(skill.manualOverride)
     const isPendingScan =
-      skill.moderationStatus === 'hidden' && skill.moderationReason === 'pending.scan'
-    const isMalwareBlocked = skill.moderationFlags?.includes('blocked.malware') ?? false
-    const isSuspicious = skill.moderationFlags?.includes('flagged.suspicious') ?? false
-    const isHiddenByMod = skill.moderationStatus === 'hidden' && !isPendingScan && !isMalwareBlocked
+      skill.moderationStatus === 'hidden' &&
+      skill.moderationReason === 'pending.scan'
+    const isMalwareBlocked =
+      skill.moderationFlags?.includes('blocked.malware') ?? false
+    const isSuspicious =
+      skill.moderationFlags?.includes('flagged.suspicious') ?? false
+    const isHiddenByMod =
+      skill.moderationStatus === 'hidden' && !isPendingScan && !isMalwareBlocked
     const isRemoved = skill.moderationStatus === 'removed'
 
     // Non-owners can see malware-blocked skills (transparency), but not other hidden states
@@ -865,7 +1176,8 @@ export const getBySlug = query({
     }
 
     // Moderation info - visible to owners for all states, or anyone for flagged skills (transparency)
-    const showModerationInfo = isOwner || isMalwareBlocked || isSuspicious
+    const showModerationInfo =
+      isOwner || isMalwareBlocked || isSuspicious || overrideActive
     const moderationInfo = showModerationInfo
       ? {
           isPendingScan,
@@ -873,6 +1185,7 @@ export const getBySlug = query({
           isSuspicious,
           isHiddenByMod,
           isRemoved,
+          overrideActive,
           verdict: skill.moderationVerdict,
           reasonCodes: skill.moderationReasonCodes,
           summary: skill.moderationSummary,
@@ -947,7 +1260,10 @@ export const checkSlugAvailability = query({
         return {
           available: false,
           reason: 'reserved' as const,
-          message: formatReservedSlugCooldownMessage(slug, reservation.expiresAt),
+          message: formatReservedSlugCooldownMessage(
+            slug,
+            reservation.expiresAt,
+          ),
           url: null,
         }
       }
@@ -982,10 +1298,11 @@ export const checkSlugAvailability = query({
     }
 
     if (userId) {
-      const [ownerProviderAccountId, callerProviderAccountId] = await Promise.all([
-        getGitHubProviderAccountId(ctx, skill.ownerUserId),
-        getGitHubProviderAccountId(ctx, userId),
-      ])
+      const [ownerProviderAccountId, callerProviderAccountId] =
+        await Promise.all([
+          getGitHubProviderAccountId(ctx, skill.ownerUserId),
+          getGitHubProviderAccountId(ctx, userId),
+        ])
 
       if (
         canHealSkillOwnershipByGitHubProviderAccountId(
@@ -1012,10 +1329,15 @@ export const checkSlugAvailability = query({
 })
 
 export const getBySlugForStaff = query({
-  args: { slug: v.string() },
+  args: {
+    slug: v.string(),
+    auditLogLimit: v.optional(v.number()),
+  },
   handler: async (ctx, args) => {
     const { user } = await requireUser(ctx)
     assertModerator(user)
+
+    const auditLogLimit = clampStaffAuditLogLimit(args.auditLogLimit)
 
     const skill = await ctx.db
       .query('skills')
@@ -1023,20 +1345,55 @@ export const getBySlugForStaff = query({
       .unique()
     if (!skill) return null
 
-    const latestVersion = skill.latestVersionId ? await ctx.db.get(skill.latestVersionId) : null
+    const latestVersion = skill.latestVersionId
+      ? await ctx.db.get(skill.latestVersionId)
+      : null
     const owner = toPublicUser(await ctx.db.get(skill.ownerUserId))
     const badges = await getSkillBadgeMap(ctx, skill._id)
+    const rawAuditLogs = await ctx.db
+      .query('auditLogs')
+      .withIndex('by_target_createdAt', (q) =>
+        q.eq('targetType', 'skill').eq('targetId', skill._id),
+      )
+      .order('desc')
+      .take(auditLogLimit)
 
-    const forkOfSkill = skill.forkOf?.skillId ? await ctx.db.get(skill.forkOf.skillId) : null
-    const forkOfOwner = forkOfSkill ? await ctx.db.get(forkOfSkill.ownerUserId) : null
+    const staffUserIds = new Set<Id<'users'>>()
+    if (skill.manualOverride?.reviewerUserId) {
+      staffUserIds.add(skill.manualOverride.reviewerUserId)
+    }
+    for (const log of rawAuditLogs) {
+      staffUserIds.add(log.actorUserId)
+    }
+    const publicUsers = await loadPublicUsersById(ctx, [...staffUserIds])
+    const overrideReviewer = skill.manualOverride?.reviewerUserId
+      ? (publicUsers.get(skill.manualOverride.reviewerUserId) ?? null)
+      : null
+    const auditLogs: StaffSkillAuditLogEntry[] = rawAuditLogs.map((log) => ({
+      ...log,
+      actor: publicUsers.get(log.actorUserId) ?? null,
+    }))
 
-    const canonicalSkill = skill.canonicalSkillId ? await ctx.db.get(skill.canonicalSkillId) : null
-    const canonicalOwner = canonicalSkill ? await ctx.db.get(canonicalSkill.ownerUserId) : null
+    const forkOfSkill = skill.forkOf?.skillId
+      ? await ctx.db.get(skill.forkOf.skillId)
+      : null
+    const forkOfOwner = forkOfSkill
+      ? await ctx.db.get(forkOfSkill.ownerUserId)
+      : null
+
+    const canonicalSkill = skill.canonicalSkillId
+      ? await ctx.db.get(skill.canonicalSkillId)
+      : null
+    const canonicalOwner = canonicalSkill
+      ? await ctx.db.get(canonicalSkill.ownerUserId)
+      : null
 
     return {
       skill: { ...skill, badges },
       latestVersion,
       owner,
+      overrideReviewer,
+      auditLogs,
       forkOf: forkOfSkill
         ? {
             kind: skill.forkOf?.kind ?? 'fork',
@@ -1066,6 +1423,28 @@ export const getBySlugForStaff = query({
     }
   },
 })
+
+function clampStaffAuditLogLimit(limit?: number) {
+  if (!Number.isFinite(limit)) return DEFAULT_STAFF_AUDIT_LOG_LIMIT
+  return Math.min(
+    Math.max(Math.trunc(limit ?? DEFAULT_STAFF_AUDIT_LOG_LIMIT), 1),
+    MAX_STAFF_AUDIT_LOG_LIMIT,
+  )
+}
+
+async function loadPublicUsersById(
+  ctx: Pick<QueryCtx, 'db'>,
+  userIds: Id<'users'>[],
+) {
+  const uniqueUserIds = [...new Set(userIds)]
+  const entries = await Promise.all(
+    uniqueUserIds.map(
+      async (userId) =>
+        [userId, toPublicUser(await ctx.db.get(userId))] as const,
+    ),
+  )
+  return new Map(entries)
+}
 
 export const getReservedSlugInternal = internalQuery({
   args: { slug: v.string() },
@@ -1113,9 +1492,14 @@ export const clearOwnerSuspiciousFlagsInternal = internalMutation({
   },
   handler: async (ctx, args) => {
     const owner = await ctx.db.get(args.ownerUserId)
-    if (!owner || owner.deletedAt || owner.deactivatedAt) throw new Error('Owner not found')
+    if (!owner || owner.deletedAt || owner.deactivatedAt)
+      throw new Error('Owner not found')
     if (!isPrivilegedOwnerForSuspiciousBypass(owner)) {
-      return { inspected: 0, updated: 0, skipped: 'owner_not_privileged' as const }
+      return {
+        inspected: 0,
+        updated: 0,
+        skipped: 'owner_not_privileged' as const,
+      }
     }
 
     const limit = clampInt(args.limit ?? 500, 1, 5000)
@@ -1129,7 +1513,8 @@ export const clearOwnerSuspiciousFlagsInternal = internalMutation({
     const now = Date.now()
 
     for (const skill of skills) {
-      const existingFlags: string[] = (skill.moderationFlags as string[] | undefined) ?? []
+      const existingFlags: string[] =
+        (skill.moderationFlags as string[] | undefined) ?? []
       const hasSuspiciousFlag = existingFlags.includes('flagged.suspicious')
       const hasSuspiciousReason =
         skill.moderationReason?.startsWith('scanner.') &&
@@ -1139,7 +1524,9 @@ export const clearOwnerSuspiciousFlagsInternal = internalMutation({
       const patch: Partial<Doc<'skills'>> = { updatedAt: now }
       patch.moderationFlags = stripSuspiciousFlag(existingFlags)
       if (hasSuspiciousReason) {
-        patch.moderationReason = normalizeScannerSuspiciousReason(skill.moderationReason)
+        patch.moderationReason = normalizeScannerSuspiciousReason(
+          skill.moderationReason,
+        )
       }
       if (
         (skill.moderationStatus ?? 'active') === 'hidden' &&
@@ -1150,7 +1537,9 @@ export const clearOwnerSuspiciousFlagsInternal = internalMutation({
       }
       patch.isSuspicious = computeIsSuspicious({
         moderationFlags: patch.moderationFlags,
-        moderationReason: (patch.moderationReason ?? skill.moderationReason) as string | undefined,
+        moderationReason: (patch.moderationReason ?? skill.moderationReason) as
+          | string
+          | undefined,
       })
 
       const nextSkill = { ...skill, ...patch }
@@ -1180,7 +1569,8 @@ export const getQuickStatsInternal = internalQuery({
       byStatus[status] = (byStatus[status] ?? 0) + 1
 
       if (skill.moderationReason) {
-        byReason[skill.moderationReason] = (byReason[skill.moderationReason] ?? 0) + 1
+        byReason[skill.moderationReason] =
+          (byReason[skill.moderationReason] ?? 0) + 1
       }
     }
 
@@ -1211,7 +1601,13 @@ export const getStatsPageInternal = internalQuery({
     const byStatus: Record<string, number> = {}
     const byReason: Record<string, number> = {}
     const byFlags: Record<string, number> = {}
-    const vtStats = { clean: 0, suspicious: 0, malicious: 0, pending: 0, noAnalysis: 0 }
+    const vtStats = {
+      clean: 0,
+      suspicious: 0,
+      malicious: 0,
+      pending: 0,
+      noAnalysis: 0,
+    }
 
     for (const skill of page) {
       if (skill.softDeletedAt) continue
@@ -1221,7 +1617,8 @@ export const getStatsPageInternal = internalQuery({
       byStatus[status] = (byStatus[status] ?? 0) + 1
 
       if (skill.moderationReason) {
-        byReason[skill.moderationReason] = (byReason[skill.moderationReason] ?? 0) + 1
+        byReason[skill.moderationReason] =
+          (byReason[skill.moderationReason] ?? 0) + 1
       }
 
       for (const flag of skill.moderationFlags ?? []) {
@@ -1238,7 +1635,10 @@ export const getStatsPageInternal = internalQuery({
           vtStats.malicious++
         } else if (reason === 'scanner.vt.suspicious') {
           vtStats.suspicious++
-        } else if (reason === 'scanner.vt.pending' || reason === 'pending.scan') {
+        } else if (
+          reason === 'scanner.vt.pending' ||
+          reason === 'pending.scan'
+        ) {
           vtStats.pending++
         } else if (reason.startsWith('scanner.vt-rescan.')) {
           const suffix = reason.slice('scanner.vt-rescan.'.length)
@@ -1252,7 +1652,8 @@ export const getStatsPageInternal = internalQuery({
       }
     }
 
-    const nextCursor = page.length > 0 ? page[page.length - 1]._creationTime : null
+    const nextCursor =
+      page.length > 0 ? page[page.length - 1]._creationTime : null
     const done = page.length < PAGE_SIZE
 
     return { total, byStatus, byReason, byFlags, vtStats, nextCursor, done }
@@ -1296,7 +1697,13 @@ export const getStatsInternal = internalAction({
     const byStatus: Record<string, number> = {}
     const byReason: Record<string, number> = {}
     const byFlags: Record<string, number> = {}
-    const vtStats = { clean: 0, suspicious: 0, malicious: 0, pending: 0, noAnalysis: 0 }
+    const vtStats = {
+      clean: 0,
+      suspicious: 0,
+      malicious: 0,
+      pending: 0,
+      noAnalysis: 0,
+    }
 
     let cursor: number | undefined
     let done = false
@@ -1340,7 +1747,10 @@ export const getStatsInternal = internalAction({
       }
     }
 
-    const highlighted: number = await ctx.runQuery(internal.skills.getHighlightedCountInternal, {})
+    const highlighted: number = await ctx.runQuery(
+      internal.skills.getHighlightedCountInternal,
+      {},
+    )
 
     return { total, highlighted, byStatus, byReason, byFlags, vtStats }
   },
@@ -1368,7 +1778,9 @@ export const list = query({
         .withIndex('by_batch', (q) => q.eq('batch', args.batch))
         .order('desc')
         .take(takeLimit)
-      const filtered = entries.filter((skill) => !skill.softDeletedAt).slice(0, limit)
+      const filtered = entries
+        .filter((skill) => !skill.softDeletedAt)
+        .slice(0, limit)
       const withBadges = await attachBadgesToSkills(ctx, filtered)
       return withBadges
         .map((skill) => toPublicSkill(skill))
@@ -1383,7 +1795,9 @@ export const list = query({
         .withIndex('by_owner', (q) => q.eq('ownerUserId', ownerUserId))
         .order('desc')
         .take(takeLimit)
-      const filtered = entries.filter((skill) => !skill.softDeletedAt).slice(0, limit)
+      const filtered = entries
+        .filter((skill) => !skill.softDeletedAt)
+        .slice(0, limit)
       const withBadges = await attachBadgesToSkills(ctx, filtered)
 
       if (isOwnDashboard) {
@@ -1394,7 +1808,8 @@ export const list = query({
             if (publicSkill) return publicSkill
             // Include pending skills for owner
             const isPending =
-              skill.moderationStatus === 'hidden' && skill.moderationReason === 'pending.scan'
+              skill.moderationStatus === 'hidden' &&
+              skill.moderationReason === 'pending.scan'
             if (isPending) {
               // Use computed badges from attachBadgesToSkills, not stored skill.badges
               const { badges } = skill
@@ -1426,7 +1841,9 @@ export const list = query({
         .filter((skill): skill is NonNullable<typeof skill> => Boolean(skill))
     }
     const entries = await ctx.db.query('skills').order('desc').take(takeLimit)
-    const filtered = entries.filter((skill) => !skill.softDeletedAt).slice(0, limit)
+    const filtered = entries
+      .filter((skill) => !skill.softDeletedAt)
+      .slice(0, limit)
     const withBadges = await attachBadgesToSkills(ctx, filtered)
     return withBadges
       .map((skill) => toPublicSkill(skill))
@@ -1470,14 +1887,18 @@ export const listWithLatest = query({
     const ordered =
       args.batch === 'highlighted'
         ? [...withBadges].sort(
-            (a, b) => (b.badges?.highlighted?.at ?? 0) - (a.badges?.highlighted?.at ?? 0),
+            (a, b) =>
+              (b.badges?.highlighted?.at ?? 0) -
+              (a.badges?.highlighted?.at ?? 0),
           )
         : withBadges
     const limited = ordered.slice(0, limit)
     const items = await Promise.all(
       limited.map(async (skill) => ({
         skill: toPublicSkill(skill),
-        latestVersion: skill.latestVersionId ? await ctx.db.get(skill.latestVersionId) : null,
+        latestVersion: skill.latestVersionId
+          ? await ctx.db.get(skill.latestVersionId)
+          : null,
       })),
     )
     return items.filter(
@@ -1512,7 +1933,9 @@ export const listForManagement = query({
     const takeLimit = Math.min(limit * 5, MAX_LIST_TAKE)
     const entries = await ctx.db.query('skills').order('desc').take(takeLimit)
     const filtered = (
-      args.includeDeleted ? entries : entries.filter((skill) => !skill.softDeletedAt)
+      args.includeDeleted
+        ? entries
+        : entries.filter((skill) => !skill.softDeletedAt)
     ).slice(0, limit)
     return buildManagementSkillEntries(ctx, filtered)
   },
@@ -1528,7 +1951,9 @@ export const listRecentVersions = query({
       .query('skillVersions')
       .order('desc')
       .take(limit * 2)
-    const entries = versions.filter((version) => !version.softDeletedAt).slice(0, limit)
+    const entries = versions
+      .filter((version) => !version.softDeletedAt)
+      .slice(0, limit)
 
     const results: Array<{
       version: Doc<'skillVersions'>
@@ -1577,7 +2002,9 @@ export const listReportedSkills = query({
       managementEntries.map(async (entry) => {
         const reports = await ctx.db
           .query('skillReports')
-          .withIndex('by_skill_createdAt', (q) => q.eq('skillId', entry.skill._id))
+          .withIndex('by_skill_createdAt', (q) =>
+            q.eq('skillId', entry.skill._id),
+          )
           .order('desc')
           .take(MAX_REPORT_REASON_SAMPLE)
         const reportEntries = await Promise.all(
@@ -1585,7 +2012,8 @@ export const listReportedSkills = query({
             const reporter = await getReporter(report.userId)
             const reason = report.reason?.trim()
             return {
-              reason: reason && reason.length > 0 ? reason : 'No reason provided.',
+              reason:
+                reason && reason.length > 0 ? reason : 'No reason provided.',
               createdAt: report.createdAt,
               reporterHandle: reporter?.handle ?? reporter?.name ?? null,
               reporterId: report.userId,
@@ -1606,7 +2034,9 @@ export const listDuplicateCandidates = query({
     const limit = clampInt(args.limit ?? 20, 1, MAX_LIST_BULK_LIMIT)
     const takeLimit = Math.min(limit * 5, MAX_LIST_TAKE)
     const skills = await ctx.db.query('skills').order('desc').take(takeLimit)
-    const entries = skills.filter((skill) => !skill.softDeletedAt).slice(0, limit)
+    const entries = skills
+      .filter((skill) => !skill.softDeletedAt)
+      .slice(0, limit)
 
     const results: Array<{
       skill: Doc<'skills'>
@@ -1630,11 +2060,17 @@ export const listDuplicateCandidates = query({
           .withIndex('by_fingerprint', (q) => q.eq('fingerprint', fingerprint))
           .take(10)
       } catch (error) {
-        console.error('listDuplicateCandidates: fingerprint lookup failed', error)
+        console.error(
+          'listDuplicateCandidates: fingerprint lookup failed',
+          error,
+        )
         continue
       }
 
-      const matchEntries: Array<{ skill: Doc<'skills'>; owner: Doc<'users'> | null }> = []
+      const matchEntries: Array<{
+        skill: Doc<'skills'>
+        owner: Doc<'users'> | null
+      }> = []
       for (const match of matchedFingerprints) {
         if (match.skillId === skill._id) continue
         const matchSkill = await ctx.db.get(match.skillId)
@@ -1645,7 +2081,9 @@ export const listDuplicateCandidates = query({
 
       if (matchEntries.length === 0) continue
 
-      const owner = isUserId(skill.ownerUserId) ? await ctx.db.get(skill.ownerUserId) : null
+      const owner = isUserId(skill.ownerUserId)
+        ? await ctx.db.get(skill.ownerUserId)
+        : null
       results.push({
         skill,
         latestVersion,
@@ -1659,7 +2097,10 @@ export const listDuplicateCandidates = query({
   },
 })
 
-async function countActiveReportsForUser(ctx: MutationCtx, userId: Id<'users'>) {
+async function countActiveReportsForUser(
+  ctx: MutationCtx,
+  userId: Id<'users'>,
+) {
   const reports = await ctx.db
     .query('skillReports')
     .withIndex('by_user', (q) => q.eq('userId', userId))
@@ -1695,13 +2136,18 @@ export const report = mutation({
 
     const existing = await ctx.db
       .query('skillReports')
-      .withIndex('by_skill_user', (q) => q.eq('skillId', args.skillId).eq('userId', userId))
+      .withIndex('by_skill_user', (q) =>
+        q.eq('skillId', args.skillId).eq('userId', userId),
+      )
       .unique()
-    if (existing) return { ok: true as const, reported: false, alreadyReported: true }
+    if (existing)
+      return { ok: true as const, reported: false, alreadyReported: true }
 
     const activeReports = await countActiveReportsForUser(ctx, userId)
     if (activeReports >= MAX_ACTIVE_REPORTS_PER_USER) {
-      throw new Error('Report limit reached. Please wait for moderation before reporting more.')
+      throw new Error(
+        'Report limit reached. Please wait for moderation before reporting more.',
+      )
     }
 
     const now = Date.now()
@@ -1713,7 +2159,8 @@ export const report = mutation({
     })
 
     const nextReportCount = (skill.reportCount ?? 0) + 1
-    const shouldAutoHide = nextReportCount > AUTO_HIDE_REPORT_THRESHOLD && !skill.softDeletedAt
+    const shouldAutoHide =
+      nextReportCount > AUTO_HIDE_REPORT_THRESHOLD && !skill.softDeletedAt
     const updates: Partial<Doc<'skills'>> = {
       reportCount: nextReportCount,
       lastReportedAt: now,
@@ -1843,20 +2290,11 @@ export const listPublicPageV2 = query({
   handler: async (ctx, args) => {
     const sort = args.sort ?? 'newest'
     const dir = args.dir ?? (sort === 'name' ? 'asc' : 'desc')
-    const { numItems, cursor: initialCursor } = normalizePublicListPagination(args.paginationOpts)
-
-    const useNonsuspiciousIndex = !!args.nonSuspiciousOnly
+    const { numItems, cursor: initialCursor } = normalizePublicListPagination(
+      args.paginationOpts,
+    )
 
     const runPaginate = (cursor: string | null) => {
-      if (useNonsuspiciousIndex) {
-        return ctx.db
-          .query('skills')
-          .withIndex(NONSUSPICIOUS_SORT_INDEXES[sort], (q) =>
-            q.eq('softDeletedAt', undefined).eq('isSuspicious', false),
-          )
-          .order(dir)
-          .paginate({ cursor, numItems })
-      }
       return ctx.db
         .query('skills')
         .withIndex(SORT_INDEXES[sort], (q) => q.eq('softDeletedAt', undefined))
@@ -1864,18 +2302,25 @@ export const listPublicPageV2 = query({
         .paginate({ cursor, numItems })
     }
 
-    let result = await paginateWithStaleCursorRecovery(runPaginate, initialCursor)
-    // When using the nonsuspicious index, isSuspicious is already filtered at the DB level,
-    // so only apply highlightedOnly in JS. Otherwise apply both filters.
-    const filterArgs = useNonsuspiciousIndex
-      ? { highlightedOnly: args.highlightedOnly }
-      : args
-    let filteredPage = filterPublicSkillPage(result.page, filterArgs)
-
-    // When post-filters are active, skip empty filtered pages so clients don't bounce.
-    while (filteredPage.length < result.page.length && filteredPage.length === 0 && !result.isDone) {
+    // Use the index to filter out soft-deleted skills at query time.
+    // softDeletedAt === undefined means active (non-deleted) skills only.
+    // When post-pagination filters are active, skip empty filtered pages so clients
+    // don't bounce between CanLoadMore/LoadingMore with no visible new rows.
+    // `isSuspicious` is still backfilled on existing rows, so mixing cursor families
+    // (`by_nonsuspicious_*` vs base sort indexes) can skip rows or duplicate pages.
+    // Stay on the base sort index and filter in JS until the backfill is complete.
+    let result = await paginateWithStaleCursorRecovery(
+      runPaginate,
+      initialCursor,
+    )
+    let filteredPage = filterPublicSkillPage(result.page, args)
+    while (
+      (args.nonSuspiciousOnly || args.highlightedOnly) &&
+      filteredPage.length === 0 &&
+      !result.isDone
+    ) {
       result = await runPaginate(result.continueCursor)
-      filteredPage = filterPublicSkillPage(result.page, filterArgs)
+      filteredPage = filterPublicSkillPage(result.page, args)
     }
 
     const items = await buildPublicSkillEntries(ctx, filteredPage)
@@ -1927,7 +2372,9 @@ function isCursorParseError(error: unknown) {
   if (typeof error === 'string') return error.includes('Failed to parse cursor')
   if (error && typeof error === 'object' && 'message' in error) {
     const message = (error as { message?: unknown }).message
-    return typeof message === 'string' && message.includes('Failed to parse cursor')
+    return (
+      typeof message === 'string' && message.includes('Failed to parse cursor')
+    )
   }
   return false
 }
@@ -1975,7 +2422,10 @@ async function getTrendingEntries(ctx: QueryCtx, limit: number) {
   }
 
   // No leaderboard exists yet (cold start) - compute on the fly
-  const fallback = await buildTrendingLeaderboard(ctx, { limit, now: Date.now() })
+  const fallback = await buildTrendingLeaderboard(ctx, {
+    limit,
+    now: Date.now(),
+  })
   return fallback.items
 }
 
@@ -2017,7 +2467,9 @@ export const getVersionById = query({
 export const getVersionsByIdsInternal = internalQuery({
   args: { versionIds: v.array(v.id('skillVersions')) },
   handler: async (ctx, args) => {
-    const versions = await Promise.all(args.versionIds.map((id) => ctx.db.get(id)))
+    const versions = await Promise.all(
+      args.versionIds.map((id) => ctx.db.get(id)),
+    )
     return versions.filter((v): v is NonNullable<typeof v> => v !== null)
   },
 })
@@ -2040,7 +2492,9 @@ export const getPendingScanSkillsInternal = internalQuery({
   },
   handler: async (ctx, args) => {
     const exhaustive = args.exhaustive ?? false
-    const limit = exhaustive ? Math.max(1, Math.floor(args.limit ?? 10000)) : clampInt(args.limit ?? 10, 1, 100)
+    const limit = exhaustive
+      ? Math.max(1, Math.floor(args.limit ?? 10000))
+      : clampInt(args.limit ?? 10, 1, 100)
     const skipRecentMinutes = exhaustive ? 0 : (args.skipRecentMinutes ?? 60)
     const skipThreshold = Date.now() - skipRecentMinutes * 60 * 1000
 
@@ -2058,12 +2512,16 @@ export const getPendingScanSkillsInternal = internalQuery({
       const [recentSkills, oldestSkills] = await Promise.all([
         ctx.db
           .query('skills')
-          .withIndex('by_active_updated', (q) => q.eq('softDeletedAt', undefined))
+          .withIndex('by_active_updated', (q) =>
+            q.eq('softDeletedAt', undefined),
+          )
           .order('desc')
           .take(poolSize),
         ctx.db
           .query('skills')
-          .withIndex('by_active_created', (q) => q.eq('softDeletedAt', undefined))
+          .withIndex('by_active_created', (q) =>
+            q.eq('softDeletedAt', undefined),
+          )
           .order('asc')
           .take(poolSize),
       ])
@@ -2077,10 +2535,17 @@ export const getPendingScanSkillsInternal = internalQuery({
 
     const candidates = allSkills.filter((skill) => {
       const reason = skill.moderationReason
-      if (skill.moderationStatus === 'hidden' && reason === 'pending.scan') return true
-      if (skill.moderationStatus === 'hidden' && reason === 'quality.low') return true
-      if (skill.moderationStatus === 'active' && reason === 'pending.scan') return true
-      if (skill.moderationStatus === 'active' && reason === 'scanner.vt.pending') return true
+      if (skill.moderationStatus === 'hidden' && reason === 'pending.scan')
+        return true
+      if (skill.moderationStatus === 'hidden' && reason === 'quality.low')
+        return true
+      if (skill.moderationStatus === 'active' && reason === 'pending.scan')
+        return true
+      if (
+        skill.moderationStatus === 'active' &&
+        reason === 'scanner.vt.pending'
+      )
+        return true
       return (
         reason === 'scanner.llm.clean' ||
         reason === 'scanner.llm.suspicious' ||
@@ -2092,7 +2557,9 @@ export const getPendingScanSkillsInternal = internalQuery({
     const skills =
       skipRecentMinutes <= 0
         ? candidates
-        : candidates.filter((s) => !s.scanLastCheckedAt || s.scanLastCheckedAt < skipThreshold)
+        : candidates.filter(
+            (s) => !s.scanLastCheckedAt || s.scanLastCheckedAt < skipThreshold,
+          )
 
     // Shuffle and take the requested limit (Fisher-Yates)
     for (let i = skills.length - 1; i > 0; i--) {
@@ -2110,7 +2577,9 @@ export const getPendingScanSkillsInternal = internalQuery({
 
     const FINAL_VT_STATUSES = new Set(['clean', 'malicious', 'suspicious'])
     for (const skill of selected) {
-      const version = skill.latestVersionId ? await ctx.db.get(skill.latestVersionId) : null
+      const version = skill.latestVersionId
+        ? await ctx.db.get(skill.latestVersionId)
+        : null
       if (!version?.sha256hash) continue
       const vtStatus = version.vtAnalysis?.status?.trim().toLowerCase()
       // Keep retrying unresolved VT results (pending/stale/error), but skip finalized outcomes.
@@ -2136,7 +2605,9 @@ export const getScanQueueHealthInternal = internalQuery({
     const pending = await ctx.db
       .query('skills')
       .withIndex('by_moderation', (q) =>
-        q.eq('moderationStatus', 'hidden').eq('moderationReason', 'pending.scan'),
+        q
+          .eq('moderationStatus', 'hidden')
+          .eq('moderationReason', 'pending.scan'),
       )
       .collect()
 
@@ -2179,26 +2650,34 @@ export const getActiveSkillsMissingVTCacheInternal = internalQuery({
     const vtPending = await ctx.db
       .query('skills')
       .withIndex('by_moderation', (q) =>
-        q.eq('moderationStatus', 'active').eq('moderationReason', 'scanner.vt.pending'),
+        q
+          .eq('moderationStatus', 'active')
+          .eq('moderationReason', 'scanner.vt.pending'),
       )
       .take(poolSize)
     const [llmClean, llmSuspicious, llmMalicious] = await Promise.all([
       ctx.db
         .query('skills')
         .withIndex('by_moderation', (q) =>
-          q.eq('moderationStatus', 'active').eq('moderationReason', 'scanner.llm.clean'),
+          q
+            .eq('moderationStatus', 'active')
+            .eq('moderationReason', 'scanner.llm.clean'),
         )
         .take(poolSize),
       ctx.db
         .query('skills')
         .withIndex('by_moderation', (q) =>
-          q.eq('moderationStatus', 'active').eq('moderationReason', 'scanner.llm.suspicious'),
+          q
+            .eq('moderationStatus', 'active')
+            .eq('moderationReason', 'scanner.llm.suspicious'),
         )
         .take(poolSize),
       ctx.db
         .query('skills')
         .withIndex('by_moderation', (q) =>
-          q.eq('moderationStatus', 'active').eq('moderationReason', 'scanner.llm.malicious'),
+          q
+            .eq('moderationStatus', 'active')
+            .eq('moderationReason', 'scanner.llm.malicious'),
         )
         .take(poolSize),
     ])
@@ -2323,7 +2802,9 @@ export const getActiveSkillBatchForRescanInternal = internalQuery({
         sha256hash: version.sha256hash,
         slug: skill.slug,
         wasFlagged:
-          (skill.moderationFlags as string[] | undefined)?.includes('flagged.suspicious') ?? false,
+          (skill.moderationFlags as string[] | undefined)?.includes(
+            'flagged.suspicious',
+          ) ?? false,
       })
     }
 
@@ -2403,13 +2884,17 @@ export const getSkillsWithStaleModerationReasonInternal = internalQuery({
       ctx.db
         .query('skills')
         .withIndex('by_moderation', (q) =>
-          q.eq('moderationStatus', 'active').eq('moderationReason', 'scanner.vt.pending'),
+          q
+            .eq('moderationStatus', 'active')
+            .eq('moderationReason', 'scanner.vt.pending'),
         )
         .take(poolSize),
       ctx.db
         .query('skills')
         .withIndex('by_moderation', (q) =>
-          q.eq('moderationStatus', 'active').eq('moderationReason', 'pending.scan'),
+          q
+            .eq('moderationStatus', 'active')
+            .eq('moderationReason', 'pending.scan'),
         )
         .take(poolSize),
     ])
@@ -2455,7 +2940,9 @@ export const getPendingVTSkillsInternal = internalQuery({
     const skills = await ctx.db
       .query('skills')
       .withIndex('by_moderation', (q) =>
-        q.eq('moderationStatus', 'active').eq('moderationReason', 'scanner.vt.pending'),
+        q
+          .eq('moderationStatus', 'active')
+          .eq('moderationReason', 'scanner.vt.pending'),
       )
       .take(limit)
 
@@ -2544,14 +3031,21 @@ export const setSkillModerationStatusActiveInternal = internalMutation({
   },
 })
 
-async function listSkillEmbeddingsForSkill(ctx: MutationCtx, skillId: Id<'skills'>) {
+async function listSkillEmbeddingsForSkill(
+  ctx: MutationCtx,
+  skillId: Id<'skills'>,
+) {
   return ctx.db
     .query('skillEmbeddings')
     .withIndex('by_skill', (q) => q.eq('skillId', skillId))
     .collect()
 }
 
-async function markSkillEmbeddingsDeleted(ctx: MutationCtx, skillId: Id<'skills'>, now: number) {
+async function markSkillEmbeddingsDeleted(
+  ctx: MutationCtx,
+  skillId: Id<'skills'>,
+  now: number,
+) {
   const embeddings = await listSkillEmbeddingsForSkill(ctx, skillId)
   for (const embedding of embeddings) {
     if (embedding.visibility === 'deleted') continue
@@ -2559,10 +3053,17 @@ async function markSkillEmbeddingsDeleted(ctx: MutationCtx, skillId: Id<'skills'
   }
 }
 
-async function restoreSkillEmbeddingsVisibility(ctx: MutationCtx, skillId: Id<'skills'>, now: number) {
+async function restoreSkillEmbeddingsVisibility(
+  ctx: MutationCtx,
+  skillId: Id<'skills'>,
+  now: number,
+) {
   const embeddings = await listSkillEmbeddingsForSkill(ctx, skillId)
   for (const embedding of embeddings) {
-    const visibility = embeddingVisibilityFor(embedding.isLatest, embedding.isApproved)
+    const visibility = embeddingVisibilityFor(
+      embedding.isLatest,
+      embedding.isApproved,
+    )
     await ctx.db.patch(embedding._id, { visibility, updatedAt: now })
   }
 }
@@ -2626,7 +3127,10 @@ export const applyBanToOwnedSkillsBatchInternal = internalMutation({
       .query('skills')
       .withIndex('by_owner', (q) => q.eq('ownerUserId', args.ownerUserId))
       .order('desc')
-      .paginate({ cursor: args.cursor ?? null, numItems: BAN_USER_SKILLS_BATCH_SIZE })
+      .paginate({
+        cursor: args.cursor ?? null,
+        numItems: BAN_USER_SKILLS_BATCH_SIZE,
+      })
 
     let hiddenCount = 0
     for (const skill of page) {
@@ -2634,9 +3138,13 @@ export const applyBanToOwnedSkillsBatchInternal = internalMutation({
 
       // Only overwrite moderation fields for active skills. Keep existing hidden/removed
       // moderation reasons intact.
-      const shouldMarkModeration = (skill.moderationStatus ?? 'active') === 'active'
+      const shouldMarkModeration =
+        (skill.moderationStatus ?? 'active') === 'active'
 
-      const patch: Partial<Doc<'skills'>> = { softDeletedAt: args.bannedAt, updatedAt: args.bannedAt }
+      const patch: Partial<Doc<'skills'>> = {
+        softDeletedAt: args.bannedAt,
+        updatedAt: args.bannedAt,
+      }
       if (shouldMarkModeration) {
         patch.moderationStatus = 'hidden'
         patch.moderationReason = 'user.banned'
@@ -2680,7 +3188,10 @@ export const restoreOwnedSkillsForUnbanBatchInternal = internalMutation({
       .query('skills')
       .withIndex('by_owner', (q) => q.eq('ownerUserId', args.ownerUserId))
       .order('desc')
-      .paginate({ cursor: args.cursor ?? null, numItems: BAN_USER_SKILLS_BATCH_SIZE })
+      .paginate({
+        cursor: args.cursor ?? null,
+        numItems: BAN_USER_SKILLS_BATCH_SIZE,
+      })
 
     let restoredCount = 0
     for (const skill of page) {
@@ -2736,7 +3247,9 @@ export const getLegacyPendingScanSkillsInternal = internalQuery({
     const skills = await ctx.db
       .query('skills')
       .withIndex('by_moderation', (q) =>
-        q.eq('moderationStatus', 'active').eq('moderationReason', 'pending.scan'),
+        q
+          .eq('moderationStatus', 'active')
+          .eq('moderationReason', 'pending.scan'),
       )
       .take(limit)
 
@@ -2917,7 +3430,9 @@ export const approveSkillByHashInternal = internalMutation({
     sha256hash: v.string(),
     scanner: v.string(),
     status: v.string(),
-    moderationStatus: v.optional(v.union(v.literal('active'), v.literal('hidden'))),
+    moderationStatus: v.optional(
+      v.union(v.literal('active'), v.literal('hidden')),
+    ),
   },
   handler: async (ctx, args) => {
     const version = await ctx.db
@@ -2930,18 +3445,25 @@ export const approveSkillByHashInternal = internalMutation({
     // Update the skill's moderation status based on scan result
     const skill = await ctx.db.get(version.skillId)
     if (skill) {
-      const owner = skill.ownerUserId ? await ctx.db.get(skill.ownerUserId) : null
+      const owner = skill.ownerUserId
+        ? await ctx.db.get(skill.ownerUserId)
+        : null
       const isMalicious = args.status === 'malicious'
       const isSuspicious = args.status === 'suspicious'
       const isClean = !isMalicious && !isSuspicious
 
       // Defense-in-depth: read existing flags to merge scanner results.
       // The stricter verdict always wins across scanners.
-      const existingFlags: string[] = (skill.moderationFlags as string[] | undefined) ?? []
-      const existingReason: string | undefined = skill.moderationReason as string | undefined
+      const existingFlags: string[] =
+        (skill.moderationFlags as string[] | undefined) ?? []
+      const existingReason: string | undefined = skill.moderationReason as
+        | string
+        | undefined
       const alreadyBlocked = existingFlags.includes('blocked.malware')
       const bypassSuspicious =
-        isSuspicious && !alreadyBlocked && isPrivilegedOwnerForSuspiciousBypass(owner)
+        isSuspicious &&
+        !alreadyBlocked &&
+        isPrivilegedOwnerForSuspiciousBypass(owner)
 
       // Determine new flags based on multi-scanner merge
       let newFlags: string[] | undefined
@@ -2965,7 +3487,8 @@ export const approveSkillByHashInternal = internalMutation({
       }
 
       const now = Date.now()
-      const qualityLocked = skill.moderationReason === 'quality.low' && !isMalicious
+      const qualityLocked =
+        skill.moderationReason === 'quality.low' && !isMalicious
       const nextModerationStatus = qualityLocked ? 'hidden' : 'active'
       const nextModerationReason = qualityLocked
         ? 'quality.low'
@@ -2980,30 +3503,39 @@ export const approveSkillByHashInternal = internalMutation({
       const snapshot = buildModerationSnapshot({
         staticScan: version.staticScan,
         vtStatus: scanner === 'vt' ? args.status : version.vtAnalysis?.status,
-        llmStatus: scanner === 'llm' ? args.status : version.llmAnalysis?.status,
+        llmStatus:
+          scanner === 'llm' ? args.status : version.llmAnalysis?.status,
         sourceVersionId: version._id,
       })
       const nextReasonCodes =
         bypassSuspicious && !isMalicious
-          ? snapshot.reasonCodes.filter((code) => !code.startsWith('suspicious.'))
+          ? snapshot.reasonCodes.filter(
+              (code) => !code.startsWith('suspicious.'),
+            )
           : snapshot.reasonCodes
       const nextVerdict = verdictFromCodes(nextReasonCodes)
       const nextLegacyFlags = legacyFlagsFromVerdict(nextVerdict)
 
-      const patch: Partial<Doc<'skills'>> = {
+      const basePatch: SkillModerationPatch = {
         moderationStatus: nextModerationStatus,
         moderationReason: nextModerationReason,
         moderationFlags: newFlags ?? nextLegacyFlags,
         moderationVerdict: nextVerdict,
-        moderationReasonCodes: nextReasonCodes.length ? nextReasonCodes : undefined,
-        moderationEvidence: snapshot.evidence.length ? snapshot.evidence : undefined,
+        moderationReasonCodes: nextReasonCodes.length
+          ? nextReasonCodes
+          : undefined,
+        moderationEvidence: snapshot.evidence.length
+          ? snapshot.evidence
+          : undefined,
         moderationSummary: summarizeReasonCodes(nextReasonCodes),
         moderationEngineVersion: snapshot.engineVersion,
         moderationEvaluatedAt: snapshot.evaluatedAt,
         moderationSourceVersionId: version._id,
         moderationNotes: nextModerationNotes,
         isSuspicious: computeIsSuspicious({
-          moderationFlags: (newFlags ?? nextLegacyFlags) as string[] | undefined,
+          moderationFlags: (newFlags ?? nextLegacyFlags) as
+            | string[]
+            | undefined,
           moderationReason: nextModerationReason,
         }),
         hiddenAt: nextModerationStatus === 'hidden' ? now : undefined,
@@ -3011,17 +3543,26 @@ export const approveSkillByHashInternal = internalMutation({
         lastReviewedAt: nextModerationStatus === 'hidden' ? now : undefined,
         updatedAt: now,
       }
+      const patch = applySkillManualOverrideToSkillPatch({
+        skill,
+        basePatch,
+        now,
+      })
       const nextSkill = { ...skill, ...patch }
       await ctx.db.patch(skill._id, patch)
       await adjustGlobalPublicCountForSkillChange(ctx, skill, nextSkill)
 
       // Auto-ban authors of malicious skills (skips moderators/admins)
       if (isMalicious && skill.ownerUserId) {
-        await ctx.scheduler.runAfter(0, internal.users.autobanMalwareAuthorInternal, {
-          ownerUserId: skill.ownerUserId,
-          sha256hash: args.sha256hash,
-          slug: skill.slug,
-        })
+        await ctx.scheduler.runAfter(
+          0,
+          internal.users.autobanMalwareAuthorInternal,
+          {
+            ownerUserId: skill.ownerUserId,
+            sha256hash: args.sha256hash,
+            slug: skill.slug,
+          },
+        )
       }
     }
 
@@ -3050,11 +3591,14 @@ export const escalateByVtInternal = internalMutation({
     if (!skill) return
 
     const isMalicious = args.status === 'malicious'
-    const existingFlags: string[] = (skill.moderationFlags as string[] | undefined) ?? []
+    const existingFlags: string[] =
+      (skill.moderationFlags as string[] | undefined) ?? []
     const alreadyBlocked = existingFlags.includes('blocked.malware')
     const owner = skill.ownerUserId ? await ctx.db.get(skill.ownerUserId) : null
     const bypassSuspicious =
-      !isMalicious && !alreadyBlocked && isPrivilegedOwnerForSuspiciousBypass(owner)
+      !isMalicious &&
+      !alreadyBlocked &&
+      isPrivilegedOwnerForSuspiciousBypass(owner)
 
     // Determine new flags — stricter verdict always wins
     let newFlags: string[]
@@ -3078,44 +3622,59 @@ export const escalateByVtInternal = internalMutation({
         ? snapshot.reasonCodes.filter((code) => !code.startsWith('suspicious.'))
         : snapshot.reasonCodes
     const nextVerdict = verdictFromCodes(nextReasonCodes)
-    const patch: Partial<Doc<'skills'>> = {
+    const now = Date.now()
+    const basePatch: SkillModerationPatch = {
       moderationFlags: nextModerationFlags,
       moderationVerdict: nextVerdict,
-      moderationReasonCodes: nextReasonCodes.length ? nextReasonCodes : undefined,
-      moderationEvidence: snapshot.evidence.length ? snapshot.evidence : undefined,
+      moderationReasonCodes: nextReasonCodes.length
+        ? nextReasonCodes
+        : undefined,
+      moderationEvidence: snapshot.evidence.length
+        ? snapshot.evidence
+        : undefined,
       moderationSummary: summarizeReasonCodes(nextReasonCodes),
       moderationEngineVersion: snapshot.engineVersion,
       moderationEvaluatedAt: snapshot.evaluatedAt,
       moderationSourceVersionId: version._id,
-      updatedAt: Date.now(),
+      updatedAt: now,
     }
     if (bypassSuspicious) {
-      patch.moderationReason = normalizeScannerSuspiciousReason(
+      basePatch.moderationReason = normalizeScannerSuspiciousReason(
         skill.moderationReason as string | undefined,
       )
     }
 
     // Only hide for malicious — suspicious stays visible with a flag
     if (isMalicious) {
-      patch.moderationStatus = 'hidden'
+      basePatch.moderationStatus = 'hidden'
     }
 
-    patch.isSuspicious = computeIsSuspicious({
+    basePatch.isSuspicious = computeIsSuspicious({
       moderationFlags: nextModerationFlags,
-      moderationReason: (patch.moderationReason ?? skill.moderationReason) as string | undefined,
+      moderationReason: (basePatch.moderationReason ??
+        skill.moderationReason) as string | undefined,
     })
 
+    const patch = applySkillManualOverrideToSkillPatch({
+      skill,
+      basePatch,
+      now,
+    })
     const nextSkill = { ...skill, ...patch }
     await ctx.db.patch(skill._id, patch)
     await adjustGlobalPublicCountForSkillChange(ctx, skill, nextSkill)
 
     // Auto-ban authors of malicious skills
     if (isMalicious && skill.ownerUserId) {
-      await ctx.scheduler.runAfter(0, internal.users.autobanMalwareAuthorInternal, {
-        ownerUserId: skill.ownerUserId,
-        sha256hash: args.sha256hash,
-        slug: skill.slug,
-      })
+      await ctx.scheduler.runAfter(
+        0,
+        internal.users.autobanMalwareAuthorInternal,
+        {
+          ownerUserId: skill.ownerUserId,
+          sha256hash: args.sha256hash,
+          slug: skill.slug,
+        },
+      )
     }
 
     return { ok: true, skillId: version.skillId, versionId: version._id }
@@ -3160,7 +3719,9 @@ export const publishVersion: ReturnType<typeof action> = action({
   },
   handler: async (ctx, args): Promise<PublishResult> => {
     if (args.acceptLicenseTerms !== true) {
-      throw new ConvexError('MIT-0 license terms must be accepted to publish skills')
+      throw new ConvexError(
+        'MIT-0 license terms must be accepted to publish skills',
+      )
     }
     const { userId } = await requireUserFromAction(ctx)
     return publishVersionForUser(ctx, userId, args)
@@ -3189,12 +3750,17 @@ export const generateChangelogPreview = action({
 export const getReadme: ReturnType<typeof action> = action({
   args: { versionId: v.id('skillVersions') },
   handler: async (ctx, args): Promise<ReadmeResult> => {
-    const version = (await ctx.runQuery(internal.skills.getVersionByIdInternal, {
-      versionId: args.versionId,
-    })) as Doc<'skillVersions'> | null
+    const version = (await ctx.runQuery(
+      internal.skills.getVersionByIdInternal,
+      {
+        versionId: args.versionId,
+      },
+    )) as Doc<'skillVersions'> | null
     if (!version) throw new ConvexError('Version not found')
     const readmeFile = version.files.find(
-      (file) => file.path.toLowerCase() === 'skill.md' || file.path.toLowerCase() === 'skills.md',
+      (file) =>
+        file.path.toLowerCase() === 'skill.md' ||
+        file.path.toLowerCase() === 'skills.md',
     )
     if (!readmeFile) throw new ConvexError('SKILL.md not found')
     const text = await fetchText(ctx, readmeFile.storageId)
@@ -3205,16 +3771,21 @@ export const getReadme: ReturnType<typeof action> = action({
 export const getFileText: ReturnType<typeof action> = action({
   args: { versionId: v.id('skillVersions'), path: v.string() },
   handler: async (ctx, args): Promise<FileTextResult> => {
-    const version = (await ctx.runQuery(internal.skills.getVersionByIdInternal, {
-      versionId: args.versionId,
-    })) as Doc<'skillVersions'> | null
+    const version = (await ctx.runQuery(
+      internal.skills.getVersionByIdInternal,
+      {
+        versionId: args.versionId,
+      },
+    )) as Doc<'skillVersions'> | null
     if (!version) throw new ConvexError('Version not found')
 
     const normalizedPath = args.path.trim()
     const normalizedLower = normalizedPath.toLowerCase()
     const file =
       version.files.find((entry) => entry.path === normalizedPath) ??
-      version.files.find((entry) => entry.path.toLowerCase() === normalizedLower)
+      version.files.find(
+        (entry) => entry.path.toLowerCase() === normalizedLower,
+      )
     if (!file) throw new ConvexError('File not found')
     if (file.size > MAX_DIFF_FILE_BYTES) {
       throw new ConvexError('File exceeds 200KB limit')
@@ -3238,11 +3809,15 @@ export const resolveVersionByHash = query({
       .unique()
     if (!skill || skill.softDeletedAt) return null
 
-    const latestVersion = skill.latestVersionId ? await ctx.db.get(skill.latestVersionId) : null
+    const latestVersion = skill.latestVersionId
+      ? await ctx.db.get(skill.latestVersionId)
+      : null
 
     const fingerprintMatches = await ctx.db
       .query('skillVersionFingerprints')
-      .withIndex('by_skill_fingerprint', (q) => q.eq('skillId', skill._id).eq('fingerprint', hash))
+      .withIndex('by_skill_fingerprint', (q) =>
+        q.eq('skillId', skill._id).eq('fingerprint', hash),
+      )
       .take(25)
 
     let match: { version: string } | null = null
@@ -3266,13 +3841,19 @@ export const resolveVersionByHash = query({
 
       for (const version of versions) {
         if (version.softDeletedAt) continue
-        if (typeof version.fingerprint === 'string' && version.fingerprint === hash) {
+        if (
+          typeof version.fingerprint === 'string' &&
+          version.fingerprint === hash
+        ) {
           match = { version: version.version }
           break
         }
 
         const fingerprint = await hashSkillFiles(
-          version.files.map((file) => ({ path: file.path, sha256: file.sha256 })),
+          version.files.map((file) => ({
+            path: file.path,
+            sha256: file.sha256,
+          })),
         )
         if (fingerprint === hash) {
           match = { version: version.version }
@@ -3291,7 +3872,9 @@ export const resolveVersionByHash = query({
 export const updateTags = mutation({
   args: {
     skillId: v.id('skills'),
-    tags: v.array(v.object({ tag: v.string(), versionId: v.id('skillVersions') })),
+    tags: v.array(
+      v.object({ tag: v.string(), versionId: v.id('skillVersions') }),
+    ),
   },
   handler: async (ctx, args) => {
     const { user } = await requireUser(ctx)
@@ -3310,7 +3893,9 @@ export const updateTags = mutation({
     const now = Date.now()
     const patch: Partial<Doc<'skills'>> = {
       tags: nextTags,
-      latestVersionId: latestEntry ? latestEntry.versionId : skill.latestVersionId,
+      latestVersionId: latestEntry
+        ? latestEntry.versionId
+        : skill.latestVersionId,
       updatedAt: now,
     }
 
@@ -3330,8 +3915,25 @@ export const updateTags = mutation({
 
     await ctx.db.patch(skill._id, patch)
 
+    if (
+      latestEntry &&
+      latestEntry.versionId !== skill.latestVersionId &&
+      shouldSyncModerationFromLatestVersion(skill)
+    ) {
+      await syncSkillModerationFromLatestVersion(
+        ctx,
+        { ...skill, latestVersionId: latestEntry.versionId },
+        now,
+      )
+    }
+
     if (latestEntry) {
-      await setSkillEmbeddingsLatestVersion(ctx, skill._id, latestEntry.versionId, now)
+      await setSkillEmbeddingsLatestVersion(
+        ctx,
+        skill._id,
+        latestEntry.versionId,
+        now,
+      )
     }
   },
 })
@@ -3405,6 +4007,111 @@ export const setBatch = mutation({
     if (nextHighlighted && !previousHighlighted) {
       void queueHighlightedWebhook(ctx, skill._id)
     }
+  },
+})
+
+export const setSkillManualOverride = mutation({
+  args: {
+    skillId: v.id('skills'),
+    note: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const { user } = await requireUser(ctx)
+    assertModerator(user)
+
+    const skill = await ctx.db.get(args.skillId)
+    if (!skill) throw new ConvexError('Skill not found')
+    if (skill.softDeletedAt || skill.moderationStatus === 'removed') {
+      throw new ConvexError('Removed skills cannot be manually unflagged.')
+    }
+    if (!canApplySkillManualOverride(skill)) {
+      throw new ConvexError('Skill is not currently suspicious.')
+    }
+
+    const now = Date.now()
+    const manualOverride = buildManualOverrideRecord({
+      note: args.note,
+      reviewerUserId: user._id,
+      updatedAt: now,
+    })
+
+    const patch = applyManualOverrideToSkillPatch({
+      basePatch: buildPreservedSkillModerationPatch(skill),
+      override: manualOverride,
+      now,
+    })
+
+    await ctx.db.patch(skill._id, {
+      manualOverride,
+      ...patch,
+    })
+    const nextSkill = { ...skill, manualOverride, ...patch }
+    await adjustGlobalPublicCountForSkillChange(ctx, skill, nextSkill)
+
+    await ctx.db.insert('auditLogs', {
+      actorUserId: user._id,
+      action: 'skill.manual_override.set',
+      targetType: 'skill',
+      targetId: skill._id,
+      metadata: {
+        verdict: manualOverride.verdict,
+        note: manualOverride.note,
+        previousReason: skill.moderationReason ?? null,
+        previousVerdict: skill.moderationVerdict ?? null,
+      },
+      createdAt: now,
+    })
+
+    return { ok: true, manualOverride }
+  },
+})
+
+export const clearSkillManualOverride = mutation({
+  args: {
+    skillId: v.id('skills'),
+    note: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const { user } = await requireUser(ctx)
+    assertModerator(user)
+
+    const skill = await ctx.db.get(args.skillId)
+    if (!skill) throw new ConvexError('Skill not found')
+    if (!skill.manualOverride) {
+      throw new ConvexError('Skill does not have a manual override.')
+    }
+
+    const now = Date.now()
+    const note = trimManualOverrideNote(args.note)
+    const previousOverride = skill.manualOverride
+
+    await ctx.db.patch(skill._id, {
+      manualOverride: undefined,
+      updatedAt: now,
+    })
+
+    await ctx.db.insert('auditLogs', {
+      actorUserId: user._id,
+      action: 'skill.manual_override.clear',
+      targetType: 'skill',
+      targetId: skill._id,
+      metadata: {
+        note,
+        previousVerdict: previousOverride.verdict,
+        previousNote: previousOverride.note,
+        previousReviewerUserId: previousOverride.reviewerUserId,
+        previousUpdatedAt: previousOverride.updatedAt,
+      },
+      createdAt: now,
+    })
+
+    await syncSkillModerationFromLatestVersion(
+      ctx,
+      { ...skill, manualOverride: undefined },
+      now,
+    )
+
+    return { ok: true }
   },
 })
 
@@ -3507,7 +4214,11 @@ async function transferSkillOwnershipAndEmbeddings(
   }
 }
 
-async function releaseActiveReservationsForSlug(ctx: MutationCtx, slug: string, releasedAt: number) {
+async function releaseActiveReservationsForSlug(
+  ctx: MutationCtx,
+  slug: string,
+  releasedAt: number,
+) {
   const active = await listActiveReservedSlugsForSlug(ctx, slug)
   for (const reservation of active) {
     await ctx.db.patch(reservation._id, { releasedAt })
@@ -3596,7 +4307,8 @@ export const reclaimSlugInternal = internalMutation({
   },
   handler: async (ctx, args) => {
     const actor = await ctx.db.get(args.actorUserId)
-    if (!actor || actor.deletedAt || actor.deactivatedAt) throw new Error('User not found')
+    if (!actor || actor.deletedAt || actor.deactivatedAt)
+      throw new Error('User not found')
     assertAdmin(actor)
 
     const slug = args.slug.trim().toLowerCase()
@@ -3606,7 +4318,11 @@ export const reclaimSlugInternal = internalMutation({
     const transferRootSlugOnly = args.transferRootSlugOnly === true
 
     const rightfulOwner = await ctx.db.get(args.rightfulOwnerUserId)
-    if (!rightfulOwner || rightfulOwner.deletedAt || rightfulOwner.deactivatedAt) {
+    if (
+      !rightfulOwner ||
+      rightfulOwner.deletedAt ||
+      rightfulOwner.deactivatedAt
+    ) {
       throw new Error('Rightful owner not found')
     }
 
@@ -3679,7 +4395,10 @@ export const reclaimSlugInternal = internalMutation({
       return { ok: true as const, action: 'ownership_transferred' as const }
     }
 
-    if (existingSkill && existingSkill.ownerUserId !== args.rightfulOwnerUserId) {
+    if (
+      existingSkill &&
+      existingSkill.ownerUserId !== args.rightfulOwnerUserId
+    ) {
       await ctx.scheduler.runAfter(0, internal.skills.hardDeleteInternal, {
         skillId: existingSkill._id,
         actorUserId: args.actorUserId,
@@ -3702,7 +4421,10 @@ export const reclaimSlugInternal = internalMutation({
       metadata: {
         slug,
         rightfulOwnerUserId: args.rightfulOwnerUserId,
-        hadSquatter: Boolean(existingSkill && existingSkill.ownerUserId !== args.rightfulOwnerUserId),
+        hadSquatter: Boolean(
+          existingSkill &&
+          existingSkill.ownerUserId !== args.rightfulOwnerUserId,
+        ),
         reason: args.reason || undefined,
       },
       createdAt: now,
@@ -3746,7 +4468,8 @@ export const setDuplicate = mutation({
       .withIndex('by_slug', (q) => q.eq('slug', canonicalSlug))
       .unique()
     if (!canonical) throw new Error('Canonical skill not found')
-    if (canonical._id === skill._id) throw new Error('Cannot duplicate a skill onto itself')
+    if (canonical._id === skill._id)
+      throw new Error('Cannot duplicate a skill onto itself')
 
     const canonicalVersion = canonical.latestVersionId
       ? await ctx.db.get(canonical.latestVersionId)
@@ -3828,7 +4551,9 @@ export const setDeprecatedBadge = mutation({
 
     await ctx.db.insert('auditLogs', {
       actorUserId: user._id,
-      action: args.deprecated ? 'badge.deprecated.set' : 'badge.deprecated.unset',
+      action: args.deprecated
+        ? 'badge.deprecated.set'
+        : 'badge.deprecated.unset',
       targetType: 'skill',
       targetId: skill._id,
       metadata: { deprecated: args.deprecated },
@@ -3849,10 +4574,15 @@ export const hardDelete = mutation({
 })
 
 export const hardDeleteInternal = internalMutation({
-  args: { skillId: v.id('skills'), actorUserId: v.id('users'), phase: v.optional(v.string()) },
+  args: {
+    skillId: v.id('skills'),
+    actorUserId: v.id('users'),
+    phase: v.optional(v.string()),
+  },
   handler: async (ctx, args) => {
     const actor = await ctx.db.get(args.actorUserId)
-    if (!actor || actor.deletedAt || actor.deactivatedAt) throw new Error('User not found')
+    if (!actor || actor.deletedAt || actor.deactivatedAt)
+      throw new Error('User not found')
     assertAdmin(actor)
     const skill = await ctx.db.get(args.skillId)
     if (!skill) return
@@ -3896,10 +4626,18 @@ export const insertVersion = internalMutation({
     summary: v.optional(v.string()),
     qualityAssessment: v.optional(
       v.object({
-        decision: v.union(v.literal('pass'), v.literal('quarantine'), v.literal('reject')),
+        decision: v.union(
+          v.literal('pass'),
+          v.literal('quarantine'),
+          v.literal('reject'),
+        ),
         score: v.number(),
         reason: v.string(),
-        trustTier: v.union(v.literal('low'), v.literal('medium'), v.literal('trusted')),
+        trustTier: v.union(
+          v.literal('low'),
+          v.literal('medium'),
+          v.literal('trusted'),
+        ),
         similarRecentCount: v.number(),
         signals: v.object({
           bodyChars: v.number(),
@@ -3914,12 +4652,20 @@ export const insertVersion = internalMutation({
       }),
     ),
     staticScan: v.object({
-      status: v.union(v.literal('clean'), v.literal('suspicious'), v.literal('malicious')),
+      status: v.union(
+        v.literal('clean'),
+        v.literal('suspicious'),
+        v.literal('malicious'),
+      ),
       reasonCodes: v.array(v.string()),
       findings: v.array(
         v.object({
           code: v.string(),
-          severity: v.union(v.literal('info'), v.literal('warn'), v.literal('critical')),
+          severity: v.union(
+            v.literal('info'),
+            v.literal('warn'),
+            v.literal('critical'),
+          ),
           file: v.string(),
           line: v.number(),
           message: v.string(),
@@ -3935,7 +4681,8 @@ export const insertVersion = internalMutation({
   handler: async (ctx, args) => {
     const userId = args.userId
     const user = await ctx.db.get(userId)
-    if (!user || user.deletedAt || user.deactivatedAt) throw new Error('User not found')
+    if (!user || user.deletedAt || user.deactivatedAt)
+      throw new Error('User not found')
 
     const now = Date.now()
 
@@ -3953,10 +4700,11 @@ export const insertVersion = internalMutation({
         throw new ConvexError(slugTakenMessage)
       }
 
-      const [ownerProviderAccountId, callerProviderAccountId] = await Promise.all([
-        getGitHubProviderAccountId(ctx, skill.ownerUserId),
-        getGitHubProviderAccountId(ctx, userId),
-      ])
+      const [ownerProviderAccountId, callerProviderAccountId] =
+        await Promise.all([
+          getGitHubProviderAccountId(ctx, skill.ownerUserId),
+          getGitHubProviderAccountId(ctx, userId),
+        ])
 
       // Deny healing when GitHub identity isn't present/consistent.
       if (
@@ -3978,16 +4726,22 @@ export const insertVersion = internalMutation({
     // Trusted publishers (and moderators/admins) bypass auto-hide for pending scans.
     // Keep moderationReason as pending.scan so the VT poller keeps working.
     const isTrustedPublisher = Boolean(
-      user.trustedPublisher || user.role === 'admin' || user.role === 'moderator',
+      user.trustedPublisher ||
+      user.role === 'admin' ||
+      user.role === 'moderator',
     )
     const initialModerationStatus =
       isTrustedPublisher && !isQualityQuarantine ? 'active' : 'hidden'
 
-    const moderationReason = isQualityQuarantine ? 'quality.low' : 'pending.scan'
+    const moderationReason = isQualityQuarantine
+      ? 'quality.low'
+      : 'pending.scan'
     const moderationNotes = isQualityQuarantine
       ? `Auto-quarantined by quality gate (score=${qualityAssessment.score}, tier=${qualityAssessment.trustTier}, similar=${qualityAssessment.similarRecentCount}).`
       : undefined
-    const staticSnapshot = buildModerationSnapshot({ staticScan: args.staticScan })
+    const staticSnapshot = buildModerationSnapshot({
+      staticScan: args.staticScan,
+    })
 
     const qualityRecord = qualityAssessment
       ? {
@@ -4003,7 +4757,11 @@ export const insertVersion = internalMutation({
 
     if (!skill) {
       // Anti-squatting: enforce reserved slug cooldown.
-      await enforceReservedSlugCooldownForNewSkill(ctx, { slug: args.slug, userId, now })
+      await enforceReservedSlugCooldownForNewSkill(ctx, {
+        slug: args.slug,
+        userId,
+        now,
+      })
 
       if (!args.bypassNewSkillRateLimit) {
         const ownerTrustSignals = await getOwnerTrustSignals(ctx, user, now)
@@ -4028,7 +4786,8 @@ export const insertVersion = internalMutation({
           .query('skills')
           .withIndex('by_slug', (q) => q.eq('slug', forkOfSlug))
           .unique()
-        if (!upstream || upstream.softDeletedAt) throw new Error('Upstream skill not found')
+        if (!upstream || upstream.softDeletedAt)
+          throw new Error('Upstream skill not found')
         canonicalSkillId = upstream.canonicalSkillId ?? upstream._id
         forkOf = {
           skillId: upstream._id,
@@ -4037,7 +4796,10 @@ export const insertVersion = internalMutation({
           at: now,
         }
       } else {
-        const match = await findCanonicalSkillForFingerprint(ctx, args.fingerprint)
+        const match = await findCanonicalSkillForFingerprint(
+          ctx,
+          args.fingerprint,
+        )
         if (match) {
           canonicalSkillId = match.canonicalSkillId ?? match._id
           forkOf = {
@@ -4048,15 +4810,24 @@ export const insertVersion = internalMutation({
         }
       }
 
-      const summary = args.summary ?? getFrontmatterValue(args.parsed.frontmatter, 'description')
+      const summary =
+        args.summary ??
+        getFrontmatterValue(args.parsed.frontmatter, 'description')
       const summaryValue = summary ?? undefined
       const derivedFlags = deriveModerationFlags({
-        skill: { slug: args.slug, displayName: args.displayName, summary: summaryValue },
+        skill: {
+          slug: args.slug,
+          displayName: args.displayName,
+          summary: summaryValue,
+        },
         parsed: args.parsed,
         files: args.files,
       })
       const newSkillFlags = Array.from(
-        new Set([...(derivedFlags ?? []), ...(staticSnapshot.legacyFlags ?? [])]),
+        new Set([
+          ...(derivedFlags ?? []),
+          ...(staticSnapshot.legacyFlags ?? []),
+        ]),
       )
       const skillId = await ctx.db.insert('skills', {
         slug: args.slug,
@@ -4081,7 +4852,9 @@ export const insertVersion = internalMutation({
         moderationReasonCodes: staticSnapshot.reasonCodes.length
           ? staticSnapshot.reasonCodes
           : undefined,
-        moderationEvidence: staticSnapshot.evidence.length ? staticSnapshot.evidence : undefined,
+        moderationEvidence: staticSnapshot.evidence.length
+          ? staticSnapshot.evidence
+          : undefined,
         moderationSummary: staticSnapshot.summary,
         moderationEngineVersion: staticSnapshot.engineVersion,
         moderationEvaluatedAt: staticSnapshot.evaluatedAt,
@@ -4119,7 +4892,9 @@ export const insertVersion = internalMutation({
 
     const existingVersion = await ctx.db
       .query('skillVersions')
-      .withIndex('by_skill_version', (q) => q.eq('skillId', skill._id).eq('version', args.version))
+      .withIndex('by_skill_version', (q) =>
+        q.eq('skillId', skill._id).eq('version', args.version),
+      )
       .unique()
     if (existingVersion) {
       throw new ConvexError('Version already exists')
@@ -4148,9 +4923,15 @@ export const insertVersion = internalMutation({
     const latestBefore = skill.latestVersionId
 
     const nextSummary =
-      args.summary ?? getFrontmatterValue(args.parsed.frontmatter, 'description') ?? skill.summary
+      args.summary ??
+      getFrontmatterValue(args.parsed.frontmatter, 'description') ??
+      skill.summary
     const derivedFlags = deriveModerationFlags({
-      skill: { slug: skill.slug, displayName: args.displayName, summary: nextSummary ?? undefined },
+      skill: {
+        slug: skill.slug,
+        displayName: args.displayName,
+        summary: nextSummary ?? undefined,
+      },
       parsed: args.parsed,
       files: args.files,
     })
@@ -4159,9 +4940,12 @@ export const insertVersion = internalMutation({
       sourceVersionId: versionId,
     })
     const nextFlags = Array.from(
-      new Set([...(derivedFlags ?? []), ...(moderationSnapshot.legacyFlags ?? [])]),
+      new Set([
+        ...(derivedFlags ?? []),
+        ...(moderationSnapshot.legacyFlags ?? []),
+      ]),
     )
-    const patch: Partial<Doc<'skills'>> = {
+    const basePatch: SkillModerationPatch = {
       displayName: args.displayName,
       summary: nextSummary ?? undefined,
       latestVersionId: versionId,
@@ -4197,6 +4981,11 @@ export const insertVersion = internalMutation({
       }),
       updatedAt: now,
     }
+    const patch = applySkillManualOverrideToSkillPatch({
+      skill,
+      basePatch,
+      now,
+    })
     const nextSkill = { ...skill, ...patch }
     await ctx.db.patch(skill._id, patch)
     await adjustGlobalPublicCountForSkillChange(ctx, skill, nextSkill)
@@ -4215,7 +5004,10 @@ export const insertVersion = internalMutation({
       updatedAt: now,
     })
     // Lightweight lookup so search hydration can skip reading the 12KB embedding doc
-    await ctx.db.insert('embeddingSkillMap', { embeddingId, skillId: skill._id })
+    await ctx.db.insert('embeddingSkillMap', {
+      embeddingId,
+      skillId: skill._id,
+    })
 
     if (latestBefore) {
       const previousEmbedding = await ctx.db
@@ -4225,7 +5017,10 @@ export const insertVersion = internalMutation({
       if (previousEmbedding) {
         await ctx.db.patch(previousEmbedding._id, {
           isLatest: false,
-          visibility: embeddingVisibilityFor(false, previousEmbedding.isApproved),
+          visibility: embeddingVisibilityFor(
+            false,
+            previousEmbedding.isApproved,
+          ),
           updatedAt: now,
         })
       }
@@ -4250,7 +5045,8 @@ export const setSkillSoftDeletedInternal = internalMutation({
   },
   handler: async (ctx, args) => {
     const user = await ctx.db.get(args.userId)
-    if (!user || user.deletedAt || user.deactivatedAt) throw new Error('User not found')
+    if (!user || user.deletedAt || user.deactivatedAt)
+      throw new Error('User not found')
 
     const slug = args.slug.trim().toLowerCase()
     if (!slug) throw new Error('Slug required')

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -279,6 +279,8 @@ async function patchStructuredModerationFromVersion(
     '_id' | 'staticScan' | 'vtAnalysis' | 'llmAnalysis'
   >,
 ) {
+  if (shouldPreserveExistingModerationLock(skill)) return
+
   const now = Date.now()
   const owner = skill.ownerUserId ? await ctx.db.get(skill.ownerUserId) : null
   const basePatch = buildScannerModerationPatchFromVersion({
@@ -292,10 +294,12 @@ async function patchStructuredModerationFromVersion(
     now,
   })
 
+  const nextSkill = { ...skill, ...patch }
   await ctx.db.patch(skill._id, {
     ...patch,
     updatedAt: now,
   })
+  await adjustGlobalPublicCountForSkillChange(ctx, skill, nextSkill)
 }
 const TRUSTED_PUBLISHER_SKILL_THRESHOLD = 10
 const LOW_TRUST_BURST_THRESHOLD_PER_HOUR = 8
@@ -343,6 +347,27 @@ function stripSuspiciousFlag(flags: string[] | undefined) {
   return next.length ? next : undefined
 }
 
+function hasMalwareBlock(flags: string[] | undefined) {
+  return flags?.includes('blocked.malware') ?? false
+}
+
+function isScannerManagedReason(reason: string | undefined) {
+  if (!reason) return false
+  return (
+    reason === 'pending.scan' ||
+    reason === 'pending.scan.stale' ||
+    reason.startsWith('scanner.')
+  )
+}
+
+function shouldPreserveExistingModerationLock(
+  skill: Pick<Doc<'skills'>, 'moderationStatus' | 'moderationReason'>,
+) {
+  if (skill.moderationStatus !== 'hidden') return false
+  if (isManualOverrideReason(skill.moderationReason)) return false
+  return !isScannerManagedReason(skill.moderationReason)
+}
+
 function buildManualOverrideRecord(params: {
   note: string
   reviewerUserId: Id<'users'>
@@ -357,8 +382,13 @@ function buildManualOverrideRecord(params: {
 }
 
 function canApplySkillManualOverride(
-  skill: Pick<Doc<'skills'>, 'moderationReason' | 'moderationFlags'>,
+  skill: Pick<
+    Doc<'skills'>,
+    'moderationStatus' | 'moderationReason' | 'moderationFlags'
+  >,
 ) {
+  if (hasMalwareBlock(skill.moderationFlags)) return false
+  if (shouldPreserveExistingModerationLock(skill)) return false
   return (
     isSkillSuspicious(skill) || isManualOverrideReason(skill.moderationReason)
   )
@@ -1178,6 +1208,10 @@ export const getBySlug = query({
     // Moderation info - visible to owners for all states, or anyone for flagged skills (transparency)
     const showModerationInfo =
       isOwner || isMalwareBlocked || isSuspicious || overrideActive
+    const publicModerationSummary =
+      !isOwner && overrideActive && !isMalwareBlocked && !isSuspicious
+        ? 'Security findings were reviewed by staff and cleared for public use.'
+        : skill.moderationSummary
     const moderationInfo = showModerationInfo
       ? {
           isPendingScan,
@@ -1188,7 +1222,7 @@ export const getBySlug = query({
           overrideActive,
           verdict: skill.moderationVerdict,
           reasonCodes: skill.moderationReasonCodes,
-          summary: skill.moderationSummary,
+          summary: publicModerationSummary,
           engineVersion: skill.moderationEngineVersion,
           updatedAt: skill.moderationEvaluatedAt,
           reason: isOwner ? skill.moderationReason : undefined,

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -139,6 +139,12 @@ export function SkillDetailPage({
   const forkOf = result?.forkOf ?? null
   const canonical = result?.canonical ?? null
   const modInfo = result?.moderationInfo ?? null
+  const suppressVersionScanResults =
+    !isStaff && Boolean(modInfo?.overrideActive) && !modInfo?.isMalwareBlocked && !modInfo?.isSuspicious
+  const scanResultsSuppressedMessage =
+    suppressVersionScanResults
+      ? 'Security findings on these releases were reviewed by staff and cleared for public use.'
+      : null
   const forkOfLabel = forkOf?.kind === 'duplicate' ? 'duplicate of' : 'fork of'
   const forkOfOwnerHandle = forkOf?.owner?.handle ?? null
   const forkOfOwnerId = forkOf?.owner?.userId ?? null
@@ -384,6 +390,8 @@ export function SkillDetailPage({
           diffVersions={diffVersions}
           versions={versions}
           nixPlugin={Boolean(nixPlugin)}
+          suppressVersionScanResults={suppressVersionScanResults}
+          scanResultsSuppressedMessage={scanResultsSuppressedMessage}
         />
 
         <SkillCommentsPanel skillId={skill._id} isAuthenticated={isAuthenticated} me={me ?? null} />

--- a/src/components/SkillDetailTabs.tsx
+++ b/src/components/SkillDetailTabs.tsx
@@ -24,6 +24,8 @@ type SkillDetailTabsProps = {
   diffVersions: Doc<'skillVersions'>[] | undefined
   versions: Doc<'skillVersions'>[] | undefined
   nixPlugin: boolean
+  suppressVersionScanResults: boolean
+  scanResultsSuppressedMessage: string | null
 }
 
 export function SkillDetailTabs({
@@ -38,6 +40,8 @@ export function SkillDetailTabs({
   diffVersions,
   versions,
   nixPlugin,
+  suppressVersionScanResults,
+  scanResultsSuppressedMessage,
 }: SkillDetailTabsProps) {
   return (
     <div className="card tab-card">
@@ -93,7 +97,13 @@ export function SkillDetailTabs({
       ) : null}
 
       {activeTab === 'versions' ? (
-        <SkillVersionsPanel versions={versions} nixPlugin={nixPlugin} skillSlug={skill.slug} />
+        <SkillVersionsPanel
+          versions={versions}
+          nixPlugin={nixPlugin}
+          skillSlug={skill.slug}
+          suppressScanResults={suppressVersionScanResults}
+          suppressedMessage={scanResultsSuppressedMessage}
+        />
       ) : null}
     </div>
   )

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -19,6 +19,8 @@ export type SkillModerationInfo = {
   isSuspicious: boolean
   isHiddenByMod: boolean
   isRemoved: boolean
+  overrideActive?: boolean
+  verdict?: 'clean' | 'suspicious' | 'malicious'
   reason?: string
 }
 
@@ -112,6 +114,15 @@ export function SkillHeader({
   osLabels,
 }: SkillHeaderProps) {
   const formattedStats = formatSkillStatsTriplet(skill.stats)
+  const suppressScanResults =
+    !isStaff &&
+    Boolean(modInfo?.overrideActive) &&
+    !modInfo?.isMalwareBlocked &&
+    !modInfo?.isSuspicious
+  const overrideScanMessage =
+    suppressScanResults
+      ? 'Security findings were reviewed by staff and cleared for public use.'
+      : null
 
   return (
     <>
@@ -255,12 +266,16 @@ export function SkillHeader({
                   </Link>
                 ) : null}
               </div>
-              <SecurityScanResults
-                sha256hash={latestVersion?.sha256hash}
-                vtAnalysis={latestVersion?.vtAnalysis}
-                llmAnalysis={latestVersion?.llmAnalysis as LlmAnalysis | undefined}
-              />
-              {latestVersion?.sha256hash || latestVersion?.llmAnalysis ? (
+              {suppressScanResults ? (
+                <div className="skill-hero-note">{overrideScanMessage}</div>
+              ) : latestVersion?.sha256hash || latestVersion?.llmAnalysis ? (
+                <SecurityScanResults
+                  sha256hash={latestVersion?.sha256hash}
+                  vtAnalysis={latestVersion?.vtAnalysis}
+                  llmAnalysis={latestVersion?.llmAnalysis as LlmAnalysis | undefined}
+                />
+              ) : null}
+              {!suppressScanResults && (latestVersion?.sha256hash || latestVersion?.llmAnalysis) ? (
                 <p className="scan-disclaimer">
                   Like a lobster shell, security has layers — review code before you run it.
                 </p>

--- a/src/components/SkillVersionsPanel.tsx
+++ b/src/components/SkillVersionsPanel.tsx
@@ -5,9 +5,17 @@ type SkillVersionsPanelProps = {
   versions: Doc<'skillVersions'>[] | undefined
   nixPlugin: boolean
   skillSlug: string
+  suppressScanResults: boolean
+  suppressedMessage: string | null
 }
 
-export function SkillVersionsPanel({ versions, nixPlugin, skillSlug }: SkillVersionsPanelProps) {
+export function SkillVersionsPanel({
+  versions,
+  nixPlugin,
+  skillSlug,
+  suppressScanResults,
+  suppressedMessage,
+}: SkillVersionsPanelProps) {
   return (
     <div className="tab-body">
       <div>
@@ -19,6 +27,7 @@ export function SkillVersionsPanel({ versions, nixPlugin, skillSlug }: SkillVers
             ? 'Review release history and changelog.'
             : 'Download older releases or scan the changelog.'}
         </p>
+        {suppressedMessage ? <p className="section-subtitle">{suppressedMessage}</p> : null}
       </div>
       <div className="version-scroll">
         <div className="version-list">
@@ -33,7 +42,7 @@ export function SkillVersionsPanel({ versions, nixPlugin, skillSlug }: SkillVers
                 </div>
                 <div style={{ color: '#5c554e', whiteSpace: 'pre-wrap' }}>{version.changelog}</div>
                 <div className="version-scan-results">
-                  {version.sha256hash || version.llmAnalysis ? (
+                  {!suppressScanResults && (version.sha256hash || version.llmAnalysis) ? (
                     <SecurityScanResults
                       sha256hash={version.sha256hash}
                       vtAnalysis={version.vtAnalysis}

--- a/src/routes/management.tsx
+++ b/src/routes/management.tsx
@@ -1,8 +1,8 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useMutation, useQuery } from 'convex/react'
 import { useEffect, useState } from 'react'
-import { api } from '../../convex/_generated/api'
 import type { Doc, Id } from '../../convex/_generated/dataModel'
+import { api } from '../../convex/_generated/api'
 import {
   getSkillBadges,
   isSkillDeprecated,
@@ -11,6 +11,23 @@ import {
 } from '../lib/badges'
 import { isAdmin, isModerator } from '../lib/roles'
 import { useAuthStatus } from '../lib/useAuthStatus'
+
+const SKILL_AUDIT_LOG_LIMIT = 10
+
+type ManagementUserSummary = {
+  _id: Id<'users'>
+  handle?: string | null
+  name?: string | null
+  displayName?: string | null
+}
+
+type SkillAuditLogEntry = {
+  _id: Id<'auditLogs'>
+  action: string
+  metadata?: unknown
+  createdAt: number
+  actor: ManagementUserSummary | null
+}
 
 type ManagementSkillEntry = {
   skill: Doc<'skills'>
@@ -47,13 +64,18 @@ type SkillBySlugResult = {
   skill: Doc<'skills'>
   latestVersion: Doc<'skillVersions'> | null
   owner: Doc<'users'> | null
+  overrideReviewer: ManagementUserSummary | null
+  auditLogs: SkillAuditLogEntry[]
   canonical: {
     skill: { slug: string; displayName: string }
     owner: { handle: string | null; userId: Id<'users'> | null }
   } | null
 } | null
 
-function resolveOwnerParam(handle: string | null | undefined, ownerId?: Id<'users'>) {
+function resolveOwnerParam(
+  handle: string | null | undefined,
+  ownerId?: Id<'users'>,
+) {
   return handle?.trim() || (ownerId ? String(ownerId) : 'unknown')
 }
 
@@ -66,7 +88,10 @@ function promptBanReason(label: string) {
 
 export const Route = createFileRoute('/management')({
   validateSearch: (search) => ({
-    skill: typeof search.skill === 'string' && search.skill.trim() ? search.skill : undefined,
+    skill:
+      typeof search.skill === 'string' && search.skill.trim()
+        ? search.skill
+        : undefined,
   }),
   component: Management,
 })
@@ -80,14 +105,19 @@ function Management() {
   const selectedSlug = search.skill?.trim()
   const selectedSkill = useQuery(
     api.skills.getBySlugForStaff,
-    staff && selectedSlug ? { slug: selectedSlug } : 'skip',
+    staff && selectedSlug
+      ? { slug: selectedSlug, auditLogLimit: SKILL_AUDIT_LOG_LIMIT }
+      : 'skip',
   ) as SkillBySlugResult | undefined
-  const recentVersions = useQuery(api.skills.listRecentVersions, staff ? { limit: 20 } : 'skip') as
-    | RecentVersionEntry[]
-    | undefined
-  const reportedSkills = useQuery(api.skills.listReportedSkills, staff ? { limit: 25 } : 'skip') as
-    | ReportedSkillEntry[]
-    | undefined
+  const selectedSkillId = selectedSkill?.skill?._id ?? null
+  const recentVersions = useQuery(
+    api.skills.listRecentVersions,
+    staff ? { limit: 20 } : 'skip',
+  ) as RecentVersionEntry[] | undefined
+  const reportedSkills = useQuery(
+    api.skills.listReportedSkills,
+    staff ? { limit: 25 } : 'skip',
+  ) as ReportedSkillEntry[] | undefined
   const duplicateCandidates = useQuery(
     api.skills.listDuplicateCandidates,
     staff ? { limit: 20 } : 'skip',
@@ -102,6 +132,10 @@ function Management() {
   const setDuplicate = useMutation(api.skills.setDuplicate)
   const setOfficialBadge = useMutation(api.skills.setOfficialBadge)
   const setDeprecatedBadge = useMutation(api.skills.setDeprecatedBadge)
+  const setSkillManualOverride = useMutation(api.skills.setSkillManualOverride)
+  const clearSkillManualOverride = useMutation(
+    api.skills.clearSkillManualOverride,
+  )
 
   const [selectedDuplicate, setSelectedDuplicate] = useState('')
   const [selectedOwner, setSelectedOwner] = useState('')
@@ -109,6 +143,7 @@ function Management() {
   const [reportSearchDebounced, setReportSearchDebounced] = useState('')
   const [userSearch, setUserSearch] = useState('')
   const [userSearchDebounced, setUserSearchDebounced] = useState('')
+  const [skillOverrideNote, setSkillOverrideNote] = useState('')
 
   const userQuery = userSearchDebounced.trim()
   const userResult = useQuery(
@@ -116,7 +151,6 @@ function Management() {
     admin ? { limit: 200, search: userQuery || undefined } : 'skip',
   ) as { items: Doc<'users'>[]; total: number } | undefined
 
-  const selectedSkillId = selectedSkill?.skill?._id ?? null
   const selectedOwnerUserId = selectedSkill?.skill?.ownerUserId ?? null
   const selectedCanonicalSlug = selectedSkill?.canonical?.skill?.slug ?? ''
 
@@ -125,6 +159,10 @@ function Management() {
     setSelectedDuplicate(selectedCanonicalSlug)
     setSelectedOwner(String(selectedOwnerUserId))
   }, [selectedCanonicalSlug, selectedOwnerUserId, selectedSkillId])
+
+  useEffect(() => {
+    setSkillOverrideNote('')
+  }, [selectedSkillId])
 
   useEffect(() => {
     const handle = setTimeout(() => setReportSearchDebounced(reportSearch), 250)
@@ -155,7 +193,9 @@ function Management() {
   const reportQuery = reportSearchDebounced.trim().toLowerCase()
   const filteredReportedSkills = reportQuery
     ? reportedSkills.filter((entry) => {
-        const reportReasons = (entry.reports ?? []).map((report) => report.reason).join(' ')
+        const reportReasons = (entry.reports ?? [])
+          .map((report) => report.reason)
+          .join(' ')
         const reporterHandles = (entry.reports ?? [])
           .map((report) => report.reporterHandle)
           .filter(Boolean)
@@ -193,10 +233,36 @@ function Management() {
       : ''
     : 'Loading users…'
 
+  const applySkillOverride = () => {
+    if (!selectedSkill?.skill) return
+    void setSkillManualOverride({
+      skillId: selectedSkill.skill._id,
+      note: skillOverrideNote,
+    })
+      .then(() => {
+        setSkillOverrideNote('')
+      })
+      .catch((error) => window.alert(formatMutationError(error)))
+  }
+
+  const clearSkillOverride = () => {
+    if (!selectedSkill?.skill?.manualOverride) return
+    void clearSkillManualOverride({
+      skillId: selectedSkill.skill._id,
+      note: skillOverrideNote,
+    })
+      .then(() => {
+        setSkillOverrideNote('')
+      })
+      .catch((error) => window.alert(formatMutationError(error)))
+  }
+
   return (
     <main className="section">
       <h1 className="section-title">Management console</h1>
-      <p className="section-subtitle">Moderation, curation, and ownership tools.</p>
+      <p className="section-subtitle">
+        Moderation, curation, and ownership tools.
+      </p>
 
       <div className="card">
         <h2 className="section-title" style={{ fontSize: '1.2rem', margin: 0 }}>
@@ -228,12 +294,16 @@ function Management() {
               return (
                 <div key={skill._id} className="management-item">
                   <div className="management-item-main">
-                    <Link to="/$owner/$slug" params={{ owner: ownerParam, slug: skill.slug }}>
+                    <Link
+                      to="/$owner/$slug"
+                      params={{ owner: ownerParam, slug: skill.slug }}
+                    >
                       {skill.displayName}
                     </Link>
                     <div className="section-subtitle" style={{ margin: 0 }}>
-                      @{owner?.handle ?? owner?.name ?? 'user'} · v{latestVersion?.version ?? '—'} ·
-                      {skill.reportCount ?? 0} report{(skill.reportCount ?? 0) === 1 ? '' : 's'}
+                      @{owner?.handle ?? owner?.name ?? 'user'} · v
+                      {latestVersion?.version ?? '—'} ·{skill.reportCount ?? 0}{' '}
+                      report{(skill.reportCount ?? 0) === 1 ? '' : 's'}
                       {skill.lastReportedAt
                         ? ` · last ${formatTimestamp(skill.lastReportedAt)}`
                         : ''}
@@ -247,7 +317,9 @@ function Management() {
                           >
                             <span className="management-report-meta">
                               {formatTimestamp(report.createdAt)}
-                              {report.reporterHandle ? ` · @${report.reporterHandle}` : ''}
+                              {report.reporterHandle
+                                ? ` · @${report.reporterHandle}`
+                                : ''}
                             </span>
                             <span>{report.reason}</span>
                           </div>
@@ -260,11 +332,21 @@ function Management() {
                     )}
                   </div>
                   <div className="management-actions">
+                    <Link
+                      className="btn"
+                      to="/management"
+                      search={{ skill: skill.slug }}
+                    >
+                      Manage
+                    </Link>
                     <button
                       className="btn"
                       type="button"
                       onClick={() =>
-                        void setSoftDeleted({ skillId: skill._id, deleted: !skill.softDeletedAt })
+                        void setSoftDeleted({
+                          skillId: skill._id,
+                          deleted: !skill.softDeletedAt,
+                        })
                       }
                     >
                       {skill.softDeletedAt ? 'Restore' : 'Hide'}
@@ -274,7 +356,10 @@ function Management() {
                         className="btn"
                         type="button"
                         onClick={() => {
-                          if (!window.confirm(`Hard delete ${skill.displayName}?`)) return
+                          if (
+                            !window.confirm(`Hard delete ${skill.displayName}?`)
+                          )
+                            return
                           void hardDelete({ skillId: skill._id })
                         }}
                       >
@@ -303,20 +388,30 @@ function Management() {
         ) : null}
         <div className="management-list">
           {!selectedSlug ? (
-            <div className="stat">Use the Manage button on a skill to open tooling here.</div>
+            <div className="stat">
+              Use the Manage button on a skill to open tooling here.
+            </div>
           ) : selectedSkill === undefined ? (
             <div className="stat">Loading skill…</div>
           ) : !selectedSkill?.skill ? (
             <div className="stat">No skill found for "{selectedSlug}".</div>
           ) : (
             (() => {
-              const { skill, latestVersion, owner, canonical } = selectedSkill
+              const {
+                skill,
+                latestVersion,
+                owner,
+                canonical,
+                overrideReviewer,
+                auditLogs,
+              } = selectedSkill
               const ownerParam = resolveOwnerParam(
                 owner?.handle ?? null,
                 owner?._id ?? skill.ownerUserId,
               )
               const moderationStatus =
-                skill.moderationStatus ?? (skill.softDeletedAt ? 'hidden' : 'active')
+                skill.moderationStatus ??
+                (skill.softDeletedAt ? 'hidden' : 'active')
               const isHighlighted = isSkillHighlighted(skill)
               const isOfficial = isSkillOfficial(skill)
               const isDeprecated = isSkillDeprecated(skill)
@@ -325,18 +420,30 @@ function Management() {
               const ownerHandle = owner?.handle ?? owner?.name ?? 'user'
               const isOwnerAdmin = owner?.role === 'admin'
               const canBanOwner =
-                staff && ownerUserId && ownerUserId !== me?._id && (admin || !isOwnerAdmin)
+                staff &&
+                ownerUserId &&
+                ownerUserId !== me?._id &&
+                (admin || !isOwnerAdmin)
 
               return (
-                <div key={skill._id} className="management-item">
+                <div
+                  key={skill._id}
+                  className="management-item management-item-detail"
+                >
                   <div className="management-item-main">
-                    <Link to="/$owner/$slug" params={{ owner: ownerParam, slug: skill.slug }}>
+                    <Link
+                      to="/$owner/$slug"
+                      params={{ owner: ownerParam, slug: skill.slug }}
+                    >
                       {skill.displayName}
                     </Link>
                     <div className="section-subtitle" style={{ margin: 0 }}>
-                      @{owner?.handle ?? owner?.name ?? 'user'} · v{latestVersion?.version ?? '—'} ·
-                      updated {formatTimestamp(skill.updatedAt)} · {moderationStatus}
-                      {badges.length ? ` · ${badges.join(', ').toLowerCase()}` : ''}
+                      @{owner?.handle ?? owner?.name ?? 'user'} · v
+                      {latestVersion?.version ?? '—'} · updated{' '}
+                      {formatTimestamp(skill.updatedAt)} · {moderationStatus}
+                      {badges.length
+                        ? ` · ${badges.join(', ').toLowerCase()}`
+                        : ''}
                     </div>
                     {skill.moderationFlags?.length ? (
                       <div className="management-tags">
@@ -347,76 +454,234 @@ function Management() {
                         ))}
                       </div>
                     ) : null}
-                    <div className="management-controls">
-                      <label className="management-control">
+                    <div className="management-sublist">
+                      <div className="section-subtitle" style={{ margin: 0 }}>
+                        Manual overrides
+                      </div>
+                      <section className="management-override-panel">
+                        <div className="management-report-item">
+                          <span className="management-report-meta">
+                            Current override
+                          </span>
+                          <span>
+                            {formatManualOverrideState(
+                              skill.manualOverride,
+                              overrideReviewer,
+                            )}
+                          </span>
+                        </div>
+                        <div className="management-report-item">
+                          <span className="management-report-meta">
+                            Latest version
+                          </span>
+                          <span>
+                            {latestVersion
+                              ? `v${latestVersion.version}`
+                              : 'No published version.'}
+                          </span>
+                        </div>
+                        <div className="management-report-item">
+                          <span className="management-report-meta">
+                            Behavior
+                          </span>
+                          <span>
+                            Applies to the full skill until a moderator clears
+                            it.
+                          </span>
+                        </div>
+                        <textarea
+                          className="form-input management-textarea"
+                          rows={4}
+                          placeholder={
+                            skill.manualOverride
+                              ? 'Audit note required to update or clear the okay override'
+                              : 'Audit note required to mark this skill okay'
+                          }
+                          value={skillOverrideNote}
+                          onChange={(event) =>
+                            setSkillOverrideNote(event.target.value)
+                          }
+                        />
+                        <div className="management-actions management-actions-start">
+                          <button
+                            className="btn management-action-btn"
+                            type="button"
+                            disabled={!skillOverrideNote.trim()}
+                            onClick={applySkillOverride}
+                          >
+                            {skill.manualOverride
+                              ? 'Update okay override'
+                              : 'Mark skill okay'}
+                          </button>
+                          {skill.manualOverride ? (
+                            <button
+                              className="btn management-action-btn"
+                              type="button"
+                              disabled={!skillOverrideNote.trim()}
+                              onClick={clearSkillOverride}
+                            >
+                              Clear skill override
+                            </button>
+                          ) : null}
+                        </div>
+                      </section>
+                    </div>
+                    <div className="management-sublist">
+                      <div className="section-subtitle" style={{ margin: 0 }}>
+                        Recent audit activity
+                      </div>
+                      <section className="management-override-panel management-audit-panel">
+                        <div className="management-report-item">
+                          <span className="management-report-meta">Window</span>
+                          <span>
+                            Last {SKILL_AUDIT_LOG_LIMIT} entries for this skill.
+                          </span>
+                        </div>
+                        {auditLogs.length === 0 ? (
+                          <div
+                            className="section-subtitle"
+                            style={{ margin: 0 }}
+                          >
+                            No audit activity yet.
+                          </div>
+                        ) : (
+                          <div className="management-audit-list">
+                            {auditLogs.map((entry) => {
+                              const auditSummary = formatAuditMetadataSummary(
+                                entry.action,
+                                entry.metadata,
+                              )
+                              return (
+                                <div
+                                  key={entry._id}
+                                  className="management-audit-item"
+                                >
+                                  <div className="management-report-item">
+                                    <span className="management-report-meta">
+                                      {formatTimestamp(entry.createdAt)} ·{' '}
+                                      {formatManagementUserLabel(entry.actor)}
+                                    </span>
+                                    <span>
+                                      {formatAuditActionLabel(
+                                        entry.action,
+                                        entry.metadata,
+                                      )}
+                                    </span>
+                                  </div>
+                                  {auditSummary ? (
+                                    <div className="section-subtitle management-audit-summary">
+                                      {auditSummary}
+                                    </div>
+                                  ) : null}
+                                  {entry.metadata ? (
+                                    <details className="management-audit-details">
+                                      <summary>metadata</summary>
+                                      <pre className="management-audit-json">
+                                        {JSON.stringify(
+                                          entry.metadata,
+                                          null,
+                                          2,
+                                        )}
+                                      </pre>
+                                    </details>
+                                  ) : null}
+                                </div>
+                              )
+                            })}
+                          </div>
+                        )}
+                      </section>
+                    </div>
+                    <div className="management-tool-grid">
+                      <label className="management-control management-control-stack">
                         <span className="mono">duplicate of</span>
                         <input
-                          className="search-input"
+                          className="management-field"
                           value={selectedDuplicate}
-                          onChange={(event) => setSelectedDuplicate(event.target.value)}
-                          placeholder={canonical?.skill?.slug ?? 'canonical slug'}
+                          onChange={(event) =>
+                            setSelectedDuplicate(event.target.value)
+                          }
+                          placeholder={
+                            canonical?.skill?.slug ?? 'canonical slug'
+                          }
                         />
                       </label>
-                      <button
-                        className="btn"
-                        type="button"
-                        onClick={() =>
-                          void setDuplicate({
-                            skillId: skill._id,
-                            canonicalSlug: selectedDuplicate.trim() || undefined,
-                          })
-                        }
-                      >
-                        Set duplicate
-                      </button>
+                      <div className="management-control management-control-stack">
+                        <span className="mono">duplicate action</span>
+                        <button
+                          className="btn management-action-btn"
+                          type="button"
+                          onClick={() =>
+                            void setDuplicate({
+                              skillId: skill._id,
+                              canonicalSlug:
+                                selectedDuplicate.trim() || undefined,
+                            })
+                          }
+                        >
+                          Set duplicate
+                        </button>
+                      </div>
                       {admin ? (
-                        <label className="management-control">
-                          <span className="mono">owner</span>
-                          <select
-                            value={selectedOwner}
-                            onChange={(event) => setSelectedOwner(event.target.value)}
-                          >
-                            {filteredUsers.map((user) => (
-                              <option key={user._id} value={user._id}>
-                                @{user.handle ?? user.name ?? 'user'}
-                              </option>
-                            ))}
-                          </select>
-                          <button
-                            className="btn"
-                            type="button"
-                            onClick={() =>
-                              void changeOwner({
-                                skillId: skill._id,
-                                ownerUserId: selectedOwner as Doc<'users'>['_id'],
-                              })
-                            }
-                          >
-                            Change owner
-                          </button>
-                        </label>
+                        <>
+                          <label className="management-control management-control-stack">
+                            <span className="mono">owner</span>
+                            <select
+                              className="management-field"
+                              value={selectedOwner}
+                              onChange={(event) =>
+                                setSelectedOwner(event.target.value)
+                              }
+                            >
+                              {filteredUsers.map((user) => (
+                                <option key={user._id} value={user._id}>
+                                  @{user.handle ?? user.name ?? 'user'}
+                                </option>
+                              ))}
+                            </select>
+                          </label>
+                          <div className="management-control management-control-stack">
+                            <span className="mono">owner action</span>
+                            <button
+                              className="btn management-action-btn"
+                              type="button"
+                              onClick={() =>
+                                void changeOwner({
+                                  skillId: skill._id,
+                                  ownerUserId:
+                                    selectedOwner as Doc<'users'>['_id'],
+                                })
+                              }
+                            >
+                              Change owner
+                            </button>
+                          </div>
+                        </>
                       ) : null}
                     </div>
                   </div>
-                  <div className="management-actions">
+                  <div className="management-actions management-action-grid">
                     <Link
-                      className="btn"
+                      className="btn management-action-btn"
                       to="/$owner/$slug"
                       params={{ owner: ownerParam, slug: skill.slug }}
                     >
                       View
                     </Link>
                     <button
-                      className="btn"
+                      className="btn management-action-btn"
                       type="button"
                       onClick={() =>
-                        void setSoftDeleted({ skillId: skill._id, deleted: !skill.softDeletedAt })
+                        void setSoftDeleted({
+                          skillId: skill._id,
+                          deleted: !skill.softDeletedAt,
+                        })
                       }
                     >
                       {skill.softDeletedAt ? 'Restore' : 'Hide'}
                     </button>
                     <button
-                      className="btn"
+                      className="btn management-action-btn"
                       type="button"
                       onClick={() =>
                         void setBatch({
@@ -429,10 +694,13 @@ function Management() {
                     </button>
                     {admin ? (
                       <button
-                        className="btn"
+                        className="btn management-action-btn"
                         type="button"
                         onClick={() => {
-                          if (!window.confirm(`Hard delete ${skill.displayName}?`)) return
+                          if (
+                            !window.confirm(`Hard delete ${skill.displayName}?`)
+                          )
+                            return
                           void hardDelete({ skillId: skill._id })
                         }}
                       >
@@ -441,12 +709,16 @@ function Management() {
                     ) : null}
                     {staff ? (
                       <button
-                        className="btn"
+                        className="btn management-action-btn"
                         type="button"
                         disabled={!canBanOwner}
                         onClick={() => {
                           if (!ownerUserId || ownerUserId === me?._id) return
-                          if (!window.confirm(`Ban @${ownerHandle} and delete their skills?`)) {
+                          if (
+                            !window.confirm(
+                              `Ban @${ownerHandle} and delete their skills?`,
+                            )
+                          ) {
                             return
                           }
                           const reason = promptBanReason(`@${ownerHandle}`)
@@ -460,7 +732,7 @@ function Management() {
                     {admin ? (
                       <>
                         <button
-                          className="btn"
+                          className="btn management-action-btn"
                           type="button"
                           onClick={() =>
                             void setOfficialBadge({
@@ -472,7 +744,7 @@ function Management() {
                           {isOfficial ? 'Remove official' : 'Mark official'}
                         </button>
                         <button
-                          className="btn"
+                          className="btn management-action-btn"
                           type="button"
                           onClick={() =>
                             void setDeprecatedBadge({
@@ -481,7 +753,9 @@ function Management() {
                             })
                           }
                         >
-                          {isDeprecated ? 'Remove deprecated' : 'Mark deprecated'}
+                          {isDeprecated
+                            ? 'Remove deprecated'
+                            : 'Mark deprecated'}
                         </button>
                       </>
                     ) : null}
@@ -526,9 +800,13 @@ function Management() {
                       <div key={match.skill._id} className="management-subitem">
                         <div>
                           <strong>{match.skill.displayName}</strong>
-                          <div className="section-subtitle" style={{ margin: 0 }}>
-                            @{match.owner?.handle ?? match.owner?.name ?? 'user'} ·{' '}
-                            {match.skill.slug}
+                          <div
+                            className="section-subtitle"
+                            style={{ margin: 0 }}
+                          >
+                            @
+                            {match.owner?.handle ?? match.owner?.name ?? 'user'}{' '}
+                            · {match.skill.slug}
                           </div>
                         </div>
                         <div className="management-actions">
@@ -596,10 +874,20 @@ function Management() {
                 <div className="management-item-main">
                   <strong>{entry.skill?.displayName ?? 'Unknown skill'}</strong>
                   <div className="section-subtitle" style={{ margin: 0 }}>
-                    v{entry.version.version} · @{entry.owner?.handle ?? entry.owner?.name ?? 'user'}
+                    v{entry.version.version} · @
+                    {entry.owner?.handle ?? entry.owner?.name ?? 'user'}
                   </div>
                 </div>
                 <div className="management-actions">
+                  {entry.skill ? (
+                    <Link
+                      className="btn"
+                      to="/management"
+                      search={{ skill: entry.skill.slug }}
+                    >
+                      Manage
+                    </Link>
+                  ) : null}
                   {entry.skill ? (
                     <Link
                       className="btn"
@@ -624,7 +912,10 @@ function Management() {
 
       {admin ? (
         <div className="card" style={{ marginTop: 20 }}>
-          <h2 className="section-title" style={{ fontSize: '1.2rem', margin: 0 }}>
+          <h2
+            className="section-title"
+            style={{ fontSize: '1.2rem', margin: 0 }}
+          >
             Users
           </h2>
           <div className="management-controls">
@@ -646,7 +937,9 @@ function Management() {
               filteredUsers.map((user) => (
                 <div key={user._id} className="management-item">
                   <div className="management-item-main">
-                    <span className="mono">@{user.handle ?? user.name ?? 'user'}</span>
+                    <span className="mono">
+                      @{user.handle ?? user.name ?? 'user'}
+                    </span>
                     {user.deletedAt || user.deactivatedAt ? (
                       <div className="section-subtitle" style={{ margin: 0 }}>
                         {user.banReason && user.deletedAt
@@ -660,7 +953,11 @@ function Management() {
                       value={user.role ?? 'user'}
                       onChange={(event) => {
                         const value = event.target.value
-                        if (value === 'admin' || value === 'moderator' || value === 'user') {
+                        if (
+                          value === 'admin' ||
+                          value === 'moderator' ||
+                          value === 'user'
+                        ) {
                           void setRole({ userId: user._id, role: value })
                         }
                       }}
@@ -703,4 +1000,148 @@ function Management() {
 
 function formatTimestamp(value: number) {
   return new Date(value).toLocaleString()
+}
+
+function formatMutationError(error: unknown) {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message.trim()
+  }
+  return 'Request failed.'
+}
+
+function formatManualOverrideState(
+  override:
+    | {
+        verdict: string
+        note: string
+        reviewerUserId: string
+        updatedAt: number
+      }
+    | null
+    | undefined,
+  reviewer?: ManagementUserSummary | null,
+) {
+  if (!override) return 'No override.'
+  return `${formatVerdictLabel(override.verdict)} · reviewer ${formatManagementUserLabel(reviewer, override.reviewerUserId)} · updated ${formatTimestamp(
+    override.updatedAt,
+  )} · ${override.note}`
+}
+
+function formatManagementUserLabel(
+  user: ManagementUserSummary | null | undefined,
+  fallbackId?: string | null,
+) {
+  if (user?.handle?.trim()) return `@${user.handle.trim()}`
+  if (user?.displayName?.trim()) return user.displayName.trim()
+  if (user?.name?.trim()) return user.name.trim()
+  if (fallbackId?.trim()) return fallbackId.trim()
+  return 'unknown user'
+}
+
+function formatAuditActionLabel(action: string, metadata?: unknown) {
+  const record = asAuditMetadataRecord(metadata)
+  if (action === 'skill.manual_override.set') {
+    const verdict =
+      typeof record?.verdict === 'string' ? record.verdict : 'unknown'
+    return `Override set to ${formatVerdictLabel(verdict)}`
+  }
+  if (action === 'skill.manual_override.clear') {
+    return 'Override cleared'
+  }
+  if (action === 'skill.owner.change') {
+    return 'Owner changed'
+  }
+  if (action === 'skill.duplicate.set') {
+    return 'Duplicate target set'
+  }
+  if (action === 'skill.duplicate.clear') {
+    return 'Duplicate target cleared'
+  }
+  if (action === 'skill.auto_hide') {
+    return 'Skill auto-hidden'
+  }
+  if (action === 'skill.hard_delete') {
+    return 'Skill hard-deleted'
+  }
+  if (action.startsWith('skill.transfer.')) {
+    return `Transfer ${action.slice('skill.transfer.'.length).replaceAll('_', ' ')}`
+  }
+  if (action.startsWith('skill.')) {
+    return action
+      .slice('skill.'.length)
+      .replaceAll('.', ' ')
+      .replaceAll('_', ' ')
+  }
+  return action.replaceAll('.', ' ').replaceAll('_', ' ')
+}
+
+function formatAuditMetadataSummary(action: string, metadata?: unknown) {
+  const record = asAuditMetadataRecord(metadata)
+  if (!record) return null
+
+  if (action === 'skill.manual_override.set') {
+    const note = typeof record.note === 'string' ? record.note.trim() : ''
+    if (note) return note
+    const previousVerdict =
+      typeof record.previousVerdict === 'string' ? record.previousVerdict : null
+    return previousVerdict
+      ? `Previous verdict: ${formatVerdictLabel(previousVerdict)}`
+      : null
+  }
+
+  if (action === 'skill.manual_override.clear') {
+    const note = typeof record.note === 'string' ? record.note.trim() : ''
+    if (note) return note
+    const previousVerdict =
+      typeof record.previousVerdict === 'string' ? record.previousVerdict : null
+    return previousVerdict
+      ? `Previous override verdict: ${formatVerdictLabel(previousVerdict)}`
+      : null
+  }
+
+  if (action === 'skill.owner.change') {
+    const from = typeof record.from === 'string' ? record.from : null
+    const to = typeof record.to === 'string' ? record.to : null
+    if (from || to) return `from ${from ?? 'unknown'} to ${to ?? 'unknown'}`
+  }
+
+  if (action === 'skill.duplicate.set') {
+    return typeof record.canonicalSlug === 'string'
+      ? `Canonical skill: ${record.canonicalSlug}`
+      : null
+  }
+
+  if (action === 'skill.duplicate.clear') {
+    return 'Canonical skill cleared.'
+  }
+
+  if (action === 'skill.auto_hide') {
+    return typeof record.reportCount === 'number'
+      ? `${record.reportCount} active reports`
+      : null
+  }
+
+  if (action === 'skill.hard_delete') {
+    return typeof record.slug === 'string'
+      ? `Deleted slug: ${record.slug}`
+      : null
+  }
+
+  if (typeof record.note === 'string' && record.note.trim()) {
+    return record.note.trim()
+  }
+  if (typeof record.reason === 'string' && record.reason.trim()) {
+    return record.reason.trim()
+  }
+  return null
+}
+
+function asAuditMetadataRecord(metadata: unknown) {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata))
+    return null
+  return metadata as Record<string, unknown>
+}
+
+function formatVerdictLabel(verdict: string) {
+  return verdict === 'clean' ? 'okay' : verdict
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -3404,6 +3404,10 @@ html.theme-transition::view-transition-new(theme) {
   align-items: start;
 }
 
+.management-item-detail {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .management-item-main {
   display: grid;
   gap: 6px;
@@ -3437,13 +3441,27 @@ html.theme-transition::view-transition-new(theme) {
   align-items: center;
 }
 
+.management-control-stack {
+  display: grid;
+  gap: 6px;
+  align-items: stretch;
+  min-width: 0;
+}
+
 .management-control .mono {
   font-size: 12px;
   color: var(--ink-soft);
 }
 
-.management-control input {
+.management-control input,
+.management-control select {
   min-width: 180px;
+}
+
+.management-control-stack input,
+.management-control-stack select {
+  width: 100%;
+  min-width: 0;
 }
 
 .management-search input {
@@ -3461,6 +3479,120 @@ html.theme-transition::view-transition-new(theme) {
   margin-top: 10px;
   padding-left: 12px;
   border-left: 1px solid var(--line);
+}
+
+.management-override-panel {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  padding: 14px;
+  border-radius: 14px;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, var(--surface) 72%, transparent);
+}
+
+.management-audit-panel {
+  gap: 10px;
+}
+
+.management-audit-list {
+  display: grid;
+  gap: 10px;
+}
+
+.management-audit-item {
+  display: grid;
+  gap: 8px;
+  padding-top: 10px;
+  border-top: 1px solid color-mix(in srgb, var(--line) 78%, transparent);
+}
+
+.management-audit-item:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.management-audit-summary {
+  margin: 0;
+}
+
+.management-audit-details {
+  color: var(--ink-soft);
+}
+
+.management-audit-details summary {
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.management-audit-json {
+  margin: 8px 0 0;
+  padding: 10px 12px;
+  overflow-x: auto;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, var(--surface) 82%, black 4%);
+  color: var(--ink);
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+
+.management-tool-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  align-items: end;
+}
+
+.management-field {
+  width: 100%;
+  min-width: 0;
+  min-height: 44px;
+  box-sizing: border-box;
+  border: 1px solid rgba(29, 59, 78, 0.22);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  color: var(--ink);
+  background: rgba(255, 255, 255, 0.94);
+}
+
+.management-field:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent) 70%, white);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.management-action-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  justify-content: stretch;
+}
+
+.management-action-btn {
+  justify-content: center;
+  min-height: 42px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.management-textarea {
+  min-height: 104px;
+  resize: vertical;
+}
+
+.management-actions-start {
+  justify-content: flex-start;
+}
+
+[data-theme="dark"] .management-field {
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(14, 28, 37, 0.84);
+}
+
+[data-theme="dark"] .management-field:focus {
+  border-color: rgba(255, 131, 95, 0.75);
+  box-shadow: 0 0 0 3px rgba(255, 131, 95, 0.2);
 }
 
 .management-subitem {


### PR DESCRIPTION
## Summary
- implement Phase 1 moderator override tooling for suspicious skills with auditable skill-level manual overrides
- add management console support for applying/clearing overrides and showing recent audit activity with reviewer/actor handles
- preserve scanner evidence under overrides and suppress raw public suspicious scan cards when staff has explicitly cleared the skill

## Validation
- `bunx convex codegen --typecheck=disable`
- `bun run lint`
- `bun run test -- convex/skills.manualOverrides.test.ts convex/skills.staffAuditLogs.test.ts convex/lib/manualOverrides.test.ts`
- `bun run build`

## Notes
- verified locally against the local Convex deployment only
- did not touch production deployment or use `--prod`
