### PR TITLE
Issue #660 Add --accept-license-terms flag to publish and sync 

### DIFF
--- a/packages/clawdhub/src/cli.ts
+++ b/packages/clawdhub/src/cli.ts
@@ -278,6 +278,7 @@ program
   .option('--fork-of <slug[@version]>', 'Mark as a fork of an existing skill')
   .option('--changelog <text>', 'Changelog text')
   .option('--tags <tags>', 'Comma-separated tags', 'latest')
+  .option('--accept-license-terms', 'Accept the license terms')
   .action(async (folder, options) => {
     const opts = await resolveGlobalOpts()
     await cmdPublish(opts, folder, options)
@@ -432,6 +433,7 @@ program
   .option('--changelog <text>', 'Changelog to use for updates (non-interactive)')
   .option('--tags <tags>', 'Comma-separated tags', 'latest')
   .option('--concurrency <n>', 'Concurrent registry checks (default: 4)', '4')
+  .option('--accept-license-terms', 'Accept the license terms')
   .action(async (options) => {
     const opts = await resolveGlobalOpts()
     const bump = String(options.bump ?? 'patch') as 'patch' | 'minor' | 'major'
@@ -449,6 +451,7 @@ program
         changelog: options.changelog,
         tags: options.tags,
         concurrency,
+        acceptLicenseTerms: options.acceptLicenseTerms,
       },
       isInputAllowed(),
     )

--- a/packages/clawdhub/src/cli/commands/publish.ts
+++ b/packages/clawdhub/src/cli/commands/publish.ts
@@ -20,6 +20,7 @@ export async function cmdPublish(
     changelog?: string
     tags?: string
     forkOf?: string
+    acceptLicenseTerms?: boolean
   },
 ) {
   const folder = folderArg ? resolve(opts.workdir, folderArg) : null
@@ -68,7 +69,7 @@ export async function cmdPublish(
         displayName,
         version,
         changelog,
-        acceptLicenseTerms: true,
+        acceptLicenseTerms: options.acceptLicenseTerms === true,
         tags,
         ...(forkOf ? { forkOf } : {}),
       }),

--- a/packages/clawdhub/src/cli/commands/sync.ts
+++ b/packages/clawdhub/src/cli/commands/sync.ts
@@ -187,6 +187,7 @@ export async function cmdSync(opts: GlobalOpts, options: SyncOptions, inputAllow
       changelog,
       tags,
       forkOf,
+      acceptLicenseTerms: options.acceptLicenseTerms,
     })
   }
 

--- a/packages/clawdhub/src/cli/commands/syncTypes.ts
+++ b/packages/clawdhub/src/cli/commands/syncTypes.ts
@@ -9,6 +9,7 @@ export type SyncOptions = {
   changelog?: string
   tags?: string
   concurrency?: number
+  acceptLicenseTerms?: boolean
 }
 
 export type Candidate = SkillFolder & {


### PR DESCRIPTION
Fix for  issue #660 

##  Summary
- Adds --accept-license-terms flag to the publish and sync CLI commands
- When the flag is set, acceptLicenseTerms: true is sent in the JSON payload; otherwise false
- Replaces the previously hardcoded acceptLicenseTerms: true in cmdPublish

## Changes

- cli.ts: Added --accept-license-terms option to publish and sync command definitions; sync passes the flag value through to cmdSync
- syncTypes.ts: Added acceptLicenseTerms?: boolean to SyncOptions
- sync.ts: Forwards options.acceptLicenseTerms to cmdPublish
- publish.ts: Added acceptLicenseTerms?: boolean to options type; replaced hardcoded true with options.acceptLicenseTerms === true

## Test plan

- clawhub publish <path> --accept-license-terms sends acceptLicenseTerms: true in payload
- clawhub publish <path> (without flag) sends acceptLicenseTerms: false
- clawhub sync --accept-license-terms propagates true to each cmdPublish call
- clawhub sync (without flag) propagates false to each cmdPublish call
- clawhub publish --help and clawhub sync --help show the new flag