### PR TITLE
chore: bump version to 0.7.1 for npm release (fixes acceptLicenseTerms error)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.1 - 2026-03-11
+
+### Fixed
+- CLI: include `acceptLicenseTerms: true` in publish payload to fix "acceptLicenseTerms: invalid value" error (fixes #644, #660, #671, #672). The server now requires this field for all skill publishes. The fix was already in commit 2687d67, but npm v0.7.0 was published before that commit.
+
 ## Unreleased
 
 ### Added

--- a/packages/clawdhub/package.json
+++ b/packages/clawdhub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawhub",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "ClawHub CLI \\u2014 install, update, search, and publish agent skills.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

This PR bumps the CLI version to 0.7.1 to prepare for an npm release that includes the `acceptLicenseTerms: true` fix.

## Problem

`clawhub publish` and `clawhub sync` currently fail with:
```
Publish payload: acceptLicenseTerms: invalid value
```

This affects all users trying to publish skills (see #644, #660, #671, #672).

## Root Cause

- Server API now requires `acceptLicenseTerms: true` (added in commit 2687d67)
- npm v0.7.0 was published on 2026-02-16, before this commit (2026-03-07)
- The fix is already on `main`, just needs a new npm release

## Changes

- Bump version from 0.7.0 to 0.7.1
- Add CHANGELOG entry documenting the fix

## Verification

The fix is already in `packages/clawdhub/src/cli/commands/publish.ts` line 71:
```ts
acceptLicenseTerms: true,
```

## Next Steps

After merging:
```bash
cd packages/clawdhub
npm publish --access public
```

## Workaround for Users

Until this is released, users can manually patch their CLI:
```bash
# Find publish.js in global node_modules
PUBLISH_JS=$(npm root -g)/clawhub/dist/cli/commands/publish.js

# Add acceptLicenseTerms: true to payload
sed -i '' 's/changelog,/changelog,\n            acceptLicenseTerms: true,/' "$PUBLISH_JS"
```

Fixes #644, #660, #671, #672