### PR TITLE
fix(cli): avoid double skills dir on install when workdir already poi…

### DIFF
--- a/packages/clawdhub/src/cli.ts
+++ b/packages/clawdhub/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { stat } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
+import { basename, isAbsolute, join, resolve } from 'node:path'
 import { Command } from 'commander'
 import { getCliBuildLabel, getCliVersion } from './cli/buildInfo.js'
 import { resolveClawdbotDefaultWorkspace } from './cli/clawdbotConfig.js'
@@ -65,7 +65,7 @@ configureCommanderHelp(program)
 async function resolveGlobalOpts(): Promise<GlobalOpts> {
   const raw = program.opts<{ workdir?: string; dir?: string; site?: string; registry?: string }>()
   const workdir = await resolveWorkdir(raw.workdir)
-  const dir = resolve(workdir, raw.dir ?? 'skills')
+  const dir = resolveSkillsDir(workdir, raw.dir ?? 'skills')
   const site = raw.site ?? process.env.CLAWHUB_SITE ?? process.env.CLAWDHUB_SITE ?? DEFAULT_SITE
   const registrySource = raw.registry
     ? 'cli'
@@ -78,6 +78,14 @@ async function resolveGlobalOpts(): Promise<GlobalOpts> {
     process.env.CLAWDHUB_REGISTRY ??
     DEFAULT_REGISTRY
   return { workdir, dir, site, registry, registrySource }
+}
+
+function resolveSkillsDir(workdir: string, dirInput: string) {
+  const trimmed = dirInput.trim()
+  if (!trimmed) return resolve(workdir, 'skills')
+  if (isAbsolute(trimmed)) return resolve(trimmed)
+  if (basename(workdir) === trimmed) return workdir
+  return resolve(workdir, trimmed)
 }
 
 function isInputAllowed() {


### PR DESCRIPTION
- **Description:** Fix `clawhub install` path resolution when the working directory already points to the skills folder. Previously, the CLI would resolve `--dir skills` relative to a `workdir` that ends with `skills`, producing `skills/skills/<slug>`.  
- **Reproduction:**  
  1. `mkdir -p /tmp/demo/skills`  
  2. `clawhub --workdir /tmp/demo/skills install demo`  
  3. Actual: `/tmp/demo/skills/skills/demo`  
     Expected: `/tmp/demo/skills/demo`  
- **Fix:** If `workdir` already ends with the same directory name as `--dir` (default `skills`), treat `workdir` as the skills root and avoid appending the extra segment.