### PR TITLE
fix: remove multi-paginate loop in listPublicPageV2

### DIFF
--- a/convex/skills.listPublicPageV2.test.ts
+++ b/convex/skills.listPublicPageV2.test.ts
@@ -98,25 +98,15 @@ describe('skills.listPublicPageV2', () => {
     expect(paginateMock).toHaveBeenCalledWith({ cursor: null, numItems: 25 })
   })
 
-  it('skips fully filtered pages until it finds matching skills', async () => {
+  it('returns empty filtered page without multi-paginate when no rows match', async () => {
     const plain = makeSkill('skills:plain', 'plain', 'users:1', 'skillVersions:1')
-    const highlightedClean = makeSkill('skills:hl-clean', 'hl-clean', 'users:2', 'skillVersions:2')
-    const paginateMock = vi
-      .fn()
-      .mockResolvedValueOnce({
-        page: [plain],
-        continueCursor: 'next-cursor',
-        isDone: false,
-        pageStatus: null,
-        splitCursor: null,
-      })
-      .mockResolvedValueOnce({
-        page: [highlightedClean],
-        continueCursor: 'after-highlighted',
-        isDone: false,
-        pageStatus: null,
-        splitCursor: null,
-      })
+    const paginateMock = vi.fn().mockResolvedValueOnce({
+      page: [plain],
+      continueCursor: 'next-cursor',
+      isDone: false,
+      pageStatus: null,
+      splitCursor: null,
+    })
     const ctx = {
       db: {
         query: vi.fn(() => ({
@@ -124,11 +114,7 @@ describe('skills.listPublicPageV2', () => {
             order: vi.fn(() => ({ paginate: paginateMock })),
           })),
         })),
-        get: vi.fn(async (id: string) => {
-          if (id.startsWith('users:')) return makeUser(id)
-          if (id.startsWith('skillVersions:')) return makeVersion(id)
-          return null
-        }),
+        get: vi.fn(),
       },
     }
 
@@ -140,13 +126,10 @@ describe('skills.listPublicPageV2', () => {
       nonSuspiciousOnly: false,
     })
 
-    expect(result.page).toHaveLength(1)
-    expect(result.page[0]?.skill.slug).toBe('hl-clean')
-    expect(result.continueCursor).toBe('after-highlighted')
+    expect(result.page).toEqual([])
+    expect(result.continueCursor).toBe('next-cursor')
     expect(result.isDone).toBe(false)
-    expect(paginateMock).toHaveBeenCalledTimes(2)
-    expect(paginateMock).toHaveBeenNthCalledWith(1, { cursor: null, numItems: 25 })
-    expect(paginateMock).toHaveBeenNthCalledWith(2, { cursor: 'next-cursor', numItems: 25 })
+    expect(paginateMock).toHaveBeenCalledTimes(1)
   })
 
   it('returns exhausted when filtered pages remain empty to the end', async () => {
@@ -232,18 +215,10 @@ describe('skills.listPublicPageV2', () => {
     expect(paginateMock).toHaveBeenCalledTimes(1)
   })
 
-  it('restarts pagination from first page when cursor is stale', async () => {
-    const plain = makeSkill('skills:plain', 'plain', 'users:1', 'skillVersions:1')
+  it('returns empty isDone page when cursor is stale', async () => {
     const paginateMock = vi
       .fn()
       .mockRejectedValueOnce(new Error('Failed to parse cursor'))
-      .mockResolvedValueOnce({
-        page: [plain],
-        continueCursor: 'next-cursor',
-        isDone: false,
-        pageStatus: null,
-        splitCursor: null,
-      })
     const ctx = {
       db: {
         query: vi.fn(() => ({
@@ -251,11 +226,7 @@ describe('skills.listPublicPageV2', () => {
             order: vi.fn(() => ({ paginate: paginateMock })),
           })),
         })),
-        get: vi.fn(async (id: string) => {
-          if (id.startsWith('users:')) return makeUser(id)
-          if (id.startsWith('skillVersions:')) return makeVersion(id)
-          return null
-        }),
+        get: vi.fn(),
       },
     }
 
@@ -267,17 +238,11 @@ describe('skills.listPublicPageV2', () => {
       nonSuspiciousOnly: false,
     })
 
-    expect(result.page).toHaveLength(1)
-    expect(result.page[0]?.skill.slug).toBe('plain')
-    expect(result.continueCursor).toBe('next-cursor')
-    expect(result.isDone).toBe(false)
-    expect(paginateMock).toHaveBeenNthCalledWith(1, { cursor: 'stale-cursor', numItems: 25 })
-    expect(paginateMock).toHaveBeenNthCalledWith(2, { cursor: null, numItems: 25 })
-    expect(paginateMock).not.toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: expect.any(Number),
-      }),
-    )
+    expect(result.page).toEqual([])
+    expect(result.isDone).toBe(true)
+    expect(result.continueCursor).toBe('')
+    expect(paginateMock).toHaveBeenCalledTimes(1)
+    expect(paginateMock).toHaveBeenCalledWith({ cursor: 'stale-cursor', numItems: 25 })
   })
 
   it('drops pagination id from client options on first-page queries', async () => {

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -2344,27 +2344,14 @@ export const listPublicPageV2 = query({
 
     // Use the lightweight skillSearchDigest table (~800 bytes/row vs ~1.9KB)
     // to avoid Bytes Read Limit errors on the full skills table.
-    // When post-pagination filters are active, skip empty filtered pages so clients
-    // don't bounce between CanLoadMore/LoadingMore with no visible new rows.
-    let result = await paginateWithStaleCursorRecovery(
+    const result = await paginateWithStaleCursorRecovery(
       runPaginate,
       initialCursor,
     )
-    let filteredPage = filterPublicSkillPage(
+    const filteredPage = filterPublicSkillPage(
       result.page.map(digestToHydratableSkill),
       args,
     )
-    while (
-      (args.nonSuspiciousOnly || args.highlightedOnly) &&
-      filteredPage.length === 0 &&
-      !result.isDone
-    ) {
-      result = await runPaginate(result.continueCursor)
-      filteredPage = filterPublicSkillPage(
-        result.page.map(digestToHydratableSkill),
-        args,
-      )
-    }
 
     const items = await buildPublicSkillEntries(ctx, filteredPage)
     return { ...result, page: items }
@@ -2396,30 +2383,29 @@ function normalizePublicListPagination(paginationOpts: {
 }
 
 async function paginateWithStaleCursorRecovery<T>(
-  runPaginate: (cursor: string | null) => Promise<T>,
+  runPaginate: (cursor: string | null) => Promise<{ page: T[]; isDone: boolean; continueCursor: string }>,
   initialCursor: string | null,
 ) {
   try {
     return await runPaginate(initialCursor)
   } catch (error) {
-    // Some clients may send stale cursors after index/query argument changes.
-    // Recover by restarting from the first page instead of surfacing a 500.
-    if (!initialCursor || !isCursorParseError(error)) {
-      throw error
+    if (initialCursor && isStaleCursorError(error)) {
+      // Return a synthetic empty page so usePaginatedQuery restarts cleanly.
+      return { page: [] as T[], isDone: true, continueCursor: '' }
     }
-    return runPaginate(null)
+    throw error
   }
 }
 
-function isCursorParseError(error: unknown) {
-  if (typeof error === 'string') return error.includes('Failed to parse cursor')
-  if (error && typeof error === 'object' && 'message' in error) {
-    const message = (error as { message?: unknown }).message
-    return (
-      typeof message === 'string' && message.includes('Failed to parse cursor')
-    )
-  }
-  return false
+function isStaleCursorError(error: unknown) {
+  const patterns = ['Failed to parse cursor', 'cursor is from a different query']
+  const msg =
+    typeof error === 'string'
+      ? error
+      : error && typeof error === 'object' && 'message' in error
+        ? String((error as { message?: unknown }).message)
+        : ''
+  return patterns.some((p) => msg.includes(p))
 }
 
 export const countPublicSkills = query({


### PR DESCRIPTION
## Summary

- **Hotfix** — already deployed to prod
- `listPublicPageV2` had a `while` loop that called `.paginate()` multiple times in a single query function, which Convex doesn't allow (limit of one paginated query per function)
- This caused `"ran multiple paginated queries"` errors on prod after the leaderboard deploy pushed all of `main`
- Removed the loop — clients handle empty filtered pages by requesting the next page via `continueCursor`

## Test plan

- [x] Deployed to prod, errors stopped
- [ ] Verify filtered listing (highlighted/non-suspicious) still works correctly with client-side pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)