### PR TITLE
fix: add nonsuspicious indexes to skillSearchDigest

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -478,6 +478,22 @@ const skillSearchDigest = defineTable({
     'statsInstallsAllTime',
     'updatedAt',
   ])
+  .index('by_nonsuspicious_updated', ['softDeletedAt', 'isSuspicious', 'updatedAt'])
+  .index('by_nonsuspicious_created', ['softDeletedAt', 'isSuspicious', 'createdAt'])
+  .index('by_nonsuspicious_name', ['softDeletedAt', 'isSuspicious', 'displayName'])
+  .index('by_nonsuspicious_downloads', [
+    'softDeletedAt',
+    'isSuspicious',
+    'statsDownloads',
+    'updatedAt',
+  ])
+  .index('by_nonsuspicious_stars', ['softDeletedAt', 'isSuspicious', 'statsStars', 'updatedAt'])
+  .index('by_nonsuspicious_installs', [
+    'softDeletedAt',
+    'isSuspicious',
+    'statsInstallsAllTime',
+    'updatedAt',
+  ])
 
 const skillDailyStats = defineTable({
   skillId: v.id('skills'),

--- a/convex/skills.listPublicPageV2.test.ts
+++ b/convex/skills.listPublicPageV2.test.ts
@@ -93,7 +93,7 @@ describe('skills.listPublicPageV2', () => {
     expect(result.page[0]?.skill.slug).toBe('hl-clean')
     expect(result.continueCursor).toBe('next-cursor')
     expect(result.isDone).toBe(false)
-    expect(withIndexMock).toHaveBeenCalledWith('by_active_stats_downloads', expect.any(Function))
+    expect(withIndexMock).toHaveBeenCalledWith('by_nonsuspicious_downloads', expect.any(Function))
     expect(orderMock).toHaveBeenCalledWith('desc')
     expect(paginateMock).toHaveBeenCalledWith({ cursor: null, numItems: 25 })
   })
@@ -211,7 +211,7 @@ describe('skills.listPublicPageV2', () => {
     expect(result.continueCursor).toBe('after-clean')
     expect(result.isDone).toBe(false)
     expect(withIndexMock).toHaveBeenCalledTimes(1)
-    expect(withIndexMock).toHaveBeenCalledWith('by_active_stats_downloads', expect.any(Function))
+    expect(withIndexMock).toHaveBeenCalledWith('by_nonsuspicious_downloads', expect.any(Function))
     expect(paginateMock).toHaveBeenCalledTimes(1)
   })
 

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -319,6 +319,15 @@ const SORT_INDEXES = {
   installs: 'by_active_stats_installs_all_time',
 } as const
 
+const NONSUSPICIOUS_SORT_INDEXES = {
+  newest: 'by_nonsuspicious_created',
+  updated: 'by_nonsuspicious_updated',
+  name: 'by_nonsuspicious_name',
+  downloads: 'by_nonsuspicious_downloads',
+  stars: 'by_nonsuspicious_stars',
+  installs: 'by_nonsuspicious_installs',
+} as const
+
 function isSkillVersionId(
   value: Id<'skillVersions'> | null | undefined,
 ): value is Id<'skillVersions'> {
@@ -2334,10 +2343,17 @@ export const listPublicPageV2 = query({
       args.paginationOpts,
     )
 
+    const useNonsuspiciousIndex = Boolean(args.nonSuspiciousOnly)
+    const indexMap = useNonsuspiciousIndex ? NONSUSPICIOUS_SORT_INDEXES : SORT_INDEXES
+
     const runPaginate = (cursor: string | null) => {
       return ctx.db
         .query('skillSearchDigest')
-        .withIndex(SORT_INDEXES[sort], (q) => q.eq('softDeletedAt', undefined))
+        .withIndex(indexMap[sort], (q) =>
+          useNonsuspiciousIndex
+            ? q.eq('softDeletedAt', undefined).eq('isSuspicious', false)
+            : q.eq('softDeletedAt', undefined),
+        )
         .order(dir)
         .paginate({ cursor, numItems })
     }
@@ -2348,6 +2364,7 @@ export const listPublicPageV2 = query({
       runPaginate,
       initialCursor,
     )
+    // highlightedOnly is still filtered in JS (rare enough that empty pages are unlikely)
     const filteredPage = filterPublicSkillPage(
       result.page.map(digestToHydratableSkill),
       args,


### PR DESCRIPTION
## Summary

- Add 6 `by_nonsuspicious_*` indexes to `skillSearchDigest` (matching the ones already on `skills`)
- `listPublicPageV2` now uses these indexes when `nonSuspiciousOnly` is set, filtering at the DB level instead of in JS
- Eliminates empty filtered pages that broke the browse UI after the multi-paginate loop was removed
- Already deployed to prod

## Follow-up

- Once stable, remove the `by_nonsuspicious_*` indexes from the `skills` table (no longer queried by `listPublicPageV2`)

## Test plan

- [x] `npx convex typecheck` passes
- [x] All tests pass
- [x] Deployed to prod, filtered browse works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)