### PR TITLE
fix: disable nonsuspicious index queries until backfill

### DIFF
--- a/convex/skills.listPublicPageV2.test.ts
+++ b/convex/skills.listPublicPageV2.test.ts
@@ -93,7 +93,7 @@ describe('skills.listPublicPageV2', () => {
     expect(result.page[0]?.skill.slug).toBe('hl-clean')
     expect(result.continueCursor).toBe('next-cursor')
     expect(result.isDone).toBe(false)
-    expect(withIndexMock).toHaveBeenCalledWith('by_nonsuspicious_downloads', expect.any(Function))
+    expect(withIndexMock).toHaveBeenCalledWith('by_active_stats_downloads', expect.any(Function))
     expect(orderMock).toHaveBeenCalledWith('desc')
     expect(paginateMock).toHaveBeenCalledWith({ cursor: null, numItems: 25 })
   })
@@ -211,7 +211,7 @@ describe('skills.listPublicPageV2', () => {
     expect(result.continueCursor).toBe('after-clean')
     expect(result.isDone).toBe(false)
     expect(withIndexMock).toHaveBeenCalledTimes(1)
-    expect(withIndexMock).toHaveBeenCalledWith('by_nonsuspicious_downloads', expect.any(Function))
+    expect(withIndexMock).toHaveBeenCalledWith('by_active_stats_downloads', expect.any(Function))
     expect(paginateMock).toHaveBeenCalledTimes(1)
   })
 

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -2343,17 +2343,13 @@ export const listPublicPageV2 = query({
       args.paginationOpts,
     )
 
-    const useNonsuspiciousIndex = Boolean(args.nonSuspiciousOnly)
-    const indexMap = useNonsuspiciousIndex ? NONSUSPICIOUS_SORT_INDEXES : SORT_INDEXES
-
+    // NOTE: by_nonsuspicious_* indexes exist but isSuspicious is undefined
+    // (not false) on most digest rows until backfilled. Use regular indexes
+    // with JS filtering for now.
     const runPaginate = (cursor: string | null) => {
       return ctx.db
         .query('skillSearchDigest')
-        .withIndex(indexMap[sort], (q) =>
-          useNonsuspiciousIndex
-            ? q.eq('softDeletedAt', undefined).eq('isSuspicious', false)
-            : q.eq('softDeletedAt', undefined),
-        )
+        .withIndex(SORT_INDEXES[sort], (q) => q.eq('softDeletedAt', undefined))
         .order(dir)
         .paginate({ cursor, numItems })
     }


### PR DESCRIPTION
## Summary
- `by_nonsuspicious_*` indexes on `skillSearchDigest` use `.eq('isSuspicious', false)` but most rows have `isSuspicious: undefined` (not `false`), returning zero results
- Reverts to regular `SORT_INDEXES` with JS filtering until `isSuspicious` is backfilled on all digest rows
- Already deployed to prod as hotfix

## Test plan
- [x] `vitest run convex/skills.listPublicPageV2.test.ts` — 7/7 pass
- [x] Verified /skills page loads with Highlighted + Hide suspicious filters active

🤖 Generated with [Claude Code](https://claude.com/claude-code)