### PR TITLE
chore(convex): upgrade convex to 1.32.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
         "@vercel/analytics": "^1.6.1",
         "clawhub-schema": "workspace:*",
         "clsx": "^2.1.1",
-        "convex": "^1.31.7",
+        "convex": "^1.32.0",
         "convex-helpers": "^0.1.114",
         "fflate": "^0.8.2",
         "h3": "2.0.1-rc.11",
@@ -789,7 +789,7 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "convex": ["convex@1.31.7", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-PtNMe1mAIOvA8Yz100QTOaIdgt2rIuWqencVXrb4McdhxBHZ8IJ1eXTnrgCC9HydyilGT1pOn+KNqT14mqn9fQ=="],
+    "convex": ["convex@1.32.0", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.18.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-5FlajdLpW75pdLS+/CgGH5H6yeRuA+ru50AKJEYbJpmyILUS+7fdTvsdTaQ7ZFXMv0gE8mX4S+S3AtJ94k0mfw=="],
 
     "convex-helpers": ["convex-helpers@0.1.114", "", { "peerDependencies": { "@standard-schema/spec": "^1.0.0", "convex": "^1.32.0", "hono": "^4.0.5", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "typescript": "^5.5", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["@standard-schema/spec", "hono", "react", "typescript", "zod"], "bin": { "convex-helpers": "bin.cjs" } }, "sha512-elEdh+gG6BDv2dWIWVvBeJPbHnDQS5+WexUuwlGVJXz1EbMkXz/UIQwFIfLMZIXUwW6ot4JYf/1JJKNStrE6lg=="],
 
@@ -1381,7 +1381,7 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
-    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
@@ -1416,6 +1416,8 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tanstack/devtools-event-bus/ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "@tanstack/start-plugin-core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -319,15 +319,6 @@ const SORT_INDEXES = {
   installs: 'by_active_stats_installs_all_time',
 } as const
 
-const NONSUSPICIOUS_SORT_INDEXES = {
-  newest: 'by_nonsuspicious_created',
-  updated: 'by_nonsuspicious_updated',
-  name: 'by_nonsuspicious_name',
-  downloads: 'by_nonsuspicious_downloads',
-  stars: 'by_nonsuspicious_stars',
-  installs: 'by_nonsuspicious_installs',
-} as const
-
 function isSkillVersionId(
   value: Id<'skillVersions'> | null | undefined,
 ): value is Id<'skillVersions'> {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@vercel/analytics": "^1.6.1",
     "clawhub-schema": "workspace:*",
     "clsx": "^2.1.1",
-    "convex": "^1.31.7",
+    "convex": "^1.32.0",
     "convex-helpers": "^0.1.114",
     "fflate": "^0.8.2",
     "h3": "2.0.1-rc.11",

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -5,6 +5,11 @@ const DEFAULT_ONLYCRABS_SITE_URL = 'https://onlycrabs.ai'
 const DEFAULT_ONLYCRABS_HOST = 'onlycrabs.ai'
 const LEGACY_CLAWDHUB_HOSTS = new Set(['clawdhub.com', 'www.clawdhub.com', 'auth.clawdhub.com'])
 
+function readMetaEnv(value?: string | null) {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
+}
+
 export function normalizeClawHubSiteOrigin(value?: string | null) {
   if (!value) return null
   try {
@@ -19,14 +24,14 @@ export function normalizeClawHubSiteOrigin(value?: string | null) {
 }
 
 export function getClawHubSiteUrl() {
-  return normalizeClawHubSiteOrigin(import.meta.env.VITE_SITE_URL) ?? DEFAULT_CLAWHUB_SITE_URL
+  return normalizeClawHubSiteOrigin(readMetaEnv(import.meta.env.VITE_SITE_URL)) ?? DEFAULT_CLAWHUB_SITE_URL
 }
 
 export function getOnlyCrabsSiteUrl() {
-  const explicit = import.meta.env.VITE_SOULHUB_SITE_URL
+  const explicit = readMetaEnv(import.meta.env.VITE_SOULHUB_SITE_URL)
   if (explicit) return explicit
 
-  const siteUrl = import.meta.env.VITE_SITE_URL
+  const siteUrl = readMetaEnv(import.meta.env.VITE_SITE_URL)
   if (siteUrl) {
     try {
       const url = new URL(siteUrl)
@@ -46,7 +51,7 @@ export function getOnlyCrabsSiteUrl() {
 }
 
 export function getOnlyCrabsHost() {
-  return import.meta.env.VITE_SOULHUB_HOST ?? DEFAULT_ONLYCRABS_HOST
+  return readMetaEnv(import.meta.env.VITE_SOULHUB_HOST) ?? DEFAULT_ONLYCRABS_HOST
 }
 
 export function detectSiteMode(host?: string | null): SiteMode {
@@ -71,13 +76,13 @@ export function getSiteMode(): SiteMode {
   if (typeof window !== 'undefined') {
     return detectSiteMode(window.location.hostname)
   }
-  const forced = import.meta.env.VITE_SITE_MODE
+  const forced = readMetaEnv(import.meta.env.VITE_SITE_MODE)
   if (forced === 'souls' || forced === 'skills') return forced
 
-  const onlyCrabsSite = import.meta.env.VITE_SOULHUB_SITE_URL
+  const onlyCrabsSite = readMetaEnv(import.meta.env.VITE_SOULHUB_SITE_URL)
   if (onlyCrabsSite) return detectSiteModeFromUrl(onlyCrabsSite)
 
-  const siteUrl = import.meta.env.VITE_SITE_URL ?? process.env.SITE_URL
+  const siteUrl = readMetaEnv(import.meta.env.VITE_SITE_URL) ?? process.env.SITE_URL
   if (siteUrl) return detectSiteModeFromUrl(siteUrl)
 
   return 'skills'


### PR DESCRIPTION
## Summary
- upgrade `convex` to `1.32.0`
- refresh `bun.lock` for the new Convex release
- normalize blank `VITE_SOULHUB_*` env values and remove an unused constant so the repo stays green after the bump

## Validation
- `bun run lint`
- `bunx tsc --noEmit`
- `bun run test`
