### PR TITLE
fix: auto-switch to relevance sort when search query is entered

### DIFF
--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -49,7 +49,7 @@ export function useSkillsBrowseModel({
   const trimmedQuery = useMemo(() => query.trim(), [query])
   const hasQuery = trimmedQuery.length > 0
   const sort: SortKey = hasQuery
-    ? 'relevance'
+    ? (search.sort ?? 'relevance')
     : (search.sort === 'relevance' ? 'downloads' : (search.sort ?? 'downloads'))
   const listSort = toListSort(sort)
   const dir = parseDir(search.dir, sort)
@@ -228,7 +228,13 @@ export function useSkillsBrowseModel({
       const trimmed = next.trim()
       navigateTimer.current = window.setTimeout(() => {
         void navigate({
-          search: (prev) => ({ ...prev, q: trimmed ? next : undefined }),
+          search: (prev) => ({
+            ...prev,
+            q: trimmed ? next : undefined,
+            // When entering a search query, clear any injected sort so relevance
+            // becomes the default. Users can still pick a different sort manually.
+            sort: trimmed ? undefined : prev.sort,
+          }),
           replace: true,
         })
       }, 220)


### PR DESCRIPTION
## Problem

When users search for skills on the `/skills` page, results are always sorted by **downloads** instead of **relevance**, making the vector search scoring (semantic similarity + lexical boost) effectively useless.

### Root cause

The `beforeLoad` redirect in `skills/index.tsx` injects `sort=downloads` whenever no sort param is present. Since all entry points (Browse Skills button, Header Skills link, Header Search link) arrive without a sort param, the URL always becomes `?sort=downloads`.

When the user then types a search query, the sort computation in `useSkillsBrowseModel.ts` checks:
```ts
const sort = search.sort === "relevance" && !hasQuery
  ? "downloads"
  : (search.sort ?? (hasQuery ? "relevance" : "downloads"))
```

Because `search.sort` is already `"downloads"` (not `undefined`), the `??` fallback to `"relevance"` never triggers.

### Impact

**100% of normal-path users** are affected. The only way to get relevance-based search results is to manually select "relevance" from the sort dropdown, which most users never do.

This means skills with high semantic relevance to a query but low download counts are buried behind popular but less relevant results.

### Reproduction

1. Open an incognito/private browser window
2. Go to https://clawhub.ai
3. Click "Browse skills"
4. Observe URL has `sort=downloads`
5. Type a search query (e.g., a specific skill slug)
6. Observe sort dropdown still shows "downloads", not "relevance"

## Fix

When `hasQuery` is true, always use `relevance` sort. When query is cleared, fall back to the URL sort param or `downloads`.

This is a one-line logic change in `useSkillsBrowseModel.ts`. The sort dropdown still allows users to manually override to any sort order during search.

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| User types search query | Sort stays as `downloads` | Sort switches to `relevance` |
| User clears search query | Sort stays as `downloads` | Sort reverts to `downloads` |
| User manually selects sort during search | Respected | Respected (overridden by relevance on next query change) |
