### PR TITLE
fix: sanitize public skill owners

### DIFF
--- a/convex/skills.public.test.ts
+++ b/convex/skills.public.test.ts
@@ -1,0 +1,106 @@
+/* @vitest-environment node */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@convex-dev/auth/server', () => ({
+  getAuthUserId: vi.fn(),
+}))
+
+vi.mock('./lib/badges', () => ({
+  getSkillBadgeMap: vi.fn(),
+  getSkillBadgeMaps: vi.fn(),
+  isSkillHighlighted: vi.fn(),
+}))
+
+const { getAuthUserId } = await import('@convex-dev/auth/server')
+const { getSkillBadgeMap } = await import('./lib/badges')
+const { getBySlug } = await import('./skills')
+
+function makeCtx(args: {
+  skill: Record<string, unknown> | null
+  owner: Record<string, unknown> | null
+  latestVersion?: Record<string, unknown> | null
+}) {
+  const unique = vi.fn().mockResolvedValue(args.skill)
+  const withIndex = vi.fn(() => ({ unique }))
+  const query = vi.fn((table: string) => {
+    if (table !== 'skills') throw new Error(`Unexpected query table: ${table}`)
+    return { withIndex }
+  })
+  const get = vi.fn(async (id: string) => {
+    if (!args.skill) return null
+    if (id === args.skill.ownerUserId) return args.owner
+    if (id === args.skill.latestVersionId) return args.latestVersion ?? null
+    return null
+  })
+  return { db: { query, get } } as never
+}
+
+describe('skills.getBySlug', () => {
+  beforeEach(() => {
+    vi.mocked(getAuthUserId).mockReset()
+    vi.mocked(getSkillBadgeMap).mockReset()
+    vi.mocked(getAuthUserId).mockResolvedValue(null as never)
+    vi.mocked(getSkillBadgeMap).mockResolvedValue({} as never)
+  })
+
+  it('sanitizes owner fields in the public response', async () => {
+    const ctx = makeCtx({
+      skill: {
+        _id: 'skills:1',
+        _creationTime: 1,
+        slug: 'demo',
+        displayName: 'Demo',
+        summary: 'Public demo skill',
+        ownerUserId: 'users:1',
+        canonicalSkillId: undefined,
+        forkOf: undefined,
+        latestVersionId: null,
+        tags: {},
+        stats: {
+          downloads: 10,
+          installsCurrent: 2,
+          installsAllTime: 5,
+          stars: 3,
+          versions: 1,
+          comments: 0,
+        },
+        createdAt: 1,
+        updatedAt: 2,
+        moderationStatus: 'active',
+        moderationFlags: undefined,
+        softDeletedAt: undefined,
+      },
+      owner: {
+        _id: 'users:1',
+        _creationTime: 1,
+        handle: 'demo-owner',
+        name: 'Demo Owner',
+        displayName: 'Demo Owner',
+        image: null,
+        bio: 'Ships demo skills',
+        email: 'owner@example.com',
+        emailVerificationTime: 123,
+        githubCreatedAt: 456,
+        githubFetchedAt: 789,
+        githubProfileSyncedAt: 999,
+      },
+    })
+
+    const result = await getBySlug._handler(ctx, { slug: 'demo' } as never)
+
+    expect(result?.owner).toEqual({
+      _id: 'users:1',
+      _creationTime: 1,
+      handle: 'demo-owner',
+      name: 'Demo Owner',
+      displayName: 'Demo Owner',
+      image: null,
+      bio: 'Ships demo skills',
+    })
+    expect(result?.owner).not.toHaveProperty('email')
+    expect(result?.owner).not.toHaveProperty('emailVerificationTime')
+    expect(result?.owner).not.toHaveProperty('githubCreatedAt')
+    expect(result?.owner).not.toHaveProperty('githubFetchedAt')
+    expect(result?.owner).not.toHaveProperty('githubProfileSyncedAt')
+  })
+})

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -1157,7 +1157,7 @@ export const getBySlug = query({
     const latestVersion = skill.latestVersionId
       ? await ctx.db.get(skill.latestVersionId)
       : null
-    const owner = await ctx.db.get(skill.ownerUserId)
+    const owner = toPublicUser(await ctx.db.get(skill.ownerUserId))
     const badges = await getSkillBadgeMap(ctx, skill._id)
 
     const forkOfSkill = skill.forkOf?.skillId


### PR DESCRIPTION
## Summary
- sanitize the public `skills.getBySlug` owner payload with `toPublicUser` so public Convex query responses no longer expose private account metadata
- add a regression test that fails if fields like `email`, `emailVerificationTime`, or GitHub sync timestamps leak through the public owner object again
- fix for the security report in #763

## Test plan
- [x] `bun install`
- [x] `bun run lint`
- [x] `bun run test -- convex/skills.public.test.ts convex/httpApi.handlers.test.ts convex/httpApiV1.handlers.test.ts`
- [x] `bun run test`
- [x] `bun run build`

## AI assistance
- This PR was prepared with AI assistance, then reviewed and validated locally with the commands above.

Made with [Cursor](https://cursor.com)