### PR TITLE
fix: sanitize public skill version queries

### DIFF
--- a/convex/downloads.ts
+++ b/convex/downloads.ts
@@ -71,17 +71,21 @@ export const downloadZip = httpAction(async (ctx, request) => {
   }
 
   const skill = skillResult.skill
-  let version = skillResult.latestVersion
+  let version = skill.latestVersionId
+    ? await ctx.runQuery(internal.skills.getVersionByIdInternal, {
+        versionId: skill.latestVersionId,
+      })
+    : null
 
   if (versionParam) {
-    version = await ctx.runQuery(api.skills.getVersionBySkillAndVersion, {
+    version = await ctx.runQuery(internal.skills.getVersionBySkillAndVersionInternal, {
       skillId: skill._id,
       version: versionParam,
     })
   } else if (tagParam) {
     const versionId = skill.tags[tagParam]
     if (versionId) {
-      version = await ctx.runQuery(api.skills.getVersionById, { versionId })
+      version = await ctx.runQuery(internal.skills.getVersionByIdInternal, { versionId })
     }
   }
 

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -1444,7 +1444,7 @@ describe('httpApiV1 handlers', () => {
   })
 
   it('returns raw file content', async () => {
-    const version = {
+    const internalVersion = {
       version: '1.0.0',
       createdAt: 1,
       changelog: 'c',
@@ -1459,19 +1459,28 @@ describe('httpApiV1 handlers', () => {
       ],
       softDeletedAt: undefined,
     }
-    const runQuery = vi.fn().mockResolvedValue({
-      skill: {
-        _id: 'skills:1',
-        slug: 'demo',
-        displayName: 'Demo',
-        summary: 's',
-        tags: {},
-        stats: {},
-        createdAt: 1,
-        updatedAt: 2,
-      },
-      latestVersion: version,
-      owner: null,
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ('slug' in args) {
+        return {
+          skill: {
+            _id: 'skills:1',
+            slug: 'demo',
+            displayName: 'Demo',
+            summary: 's',
+            tags: {},
+            stats: {},
+            createdAt: 1,
+            updatedAt: 2,
+            latestVersionId: 'skillVersions:1',
+          },
+          latestVersion: { _id: 'skillVersions:1', version: '1.0.0' },
+          owner: null,
+        }
+      }
+      if ('versionId' in args) {
+        return internalVersion
+      }
+      return null
     })
     const runMutation = vi.fn().mockResolvedValue(okRate())
     const storage = {
@@ -1487,7 +1496,7 @@ describe('httpApiV1 handlers', () => {
   })
 
   it('returns 413 when raw file too large', async () => {
-    const version = {
+    const internalVersion = {
       version: '1.0.0',
       createdAt: 1,
       changelog: 'c',
@@ -1502,19 +1511,28 @@ describe('httpApiV1 handlers', () => {
       ],
       softDeletedAt: undefined,
     }
-    const runQuery = vi.fn().mockResolvedValue({
-      skill: {
-        _id: 'skills:1',
-        slug: 'demo',
-        displayName: 'Demo',
-        summary: 's',
-        tags: {},
-        stats: {},
-        createdAt: 1,
-        updatedAt: 2,
-      },
-      latestVersion: version,
-      owner: null,
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ('slug' in args) {
+        return {
+          skill: {
+            _id: 'skills:1',
+            slug: 'demo',
+            displayName: 'Demo',
+            summary: 's',
+            tags: {},
+            stats: {},
+            createdAt: 1,
+            updatedAt: 2,
+            latestVersionId: 'skillVersions:1',
+          },
+          latestVersion: { _id: 'skillVersions:1', version: '1.0.0' },
+          owner: null,
+        }
+      }
+      if ('versionId' in args) {
+        return internalVersion
+      }
+      return null
     })
     const runMutation = vi.fn().mockResolvedValue(okRate())
     const response = await __handlers.skillsGetRouterV1Handler(

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -90,8 +90,18 @@ type GetBySlugResult = {
     stats: unknown
     createdAt: number
     updatedAt: number
+    latestVersionId?: Id<'skillVersions'>
   } | null
-  latestVersion: Doc<'skillVersions'> | null
+  latestVersion: {
+    _id: Id<'skillVersions'>
+    version: string
+    createdAt?: number
+    changelog?: string
+    parsed?: {
+      license?: 'MIT-0'
+      clawdis?: { os?: string[]; nix?: { plugin?: boolean; systems?: string[] } }
+    }
+  } | null
   owner: { _id: Id<'users'>; handle?: string; displayName?: string; image?: string } | null
   moderationInfo?: {
     isPendingScan: boolean
@@ -792,16 +802,20 @@ export async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request)
     const skillResult = (await ctx.runQuery(api.skills.getBySlug, { slug })) as GetBySlugResult
     if (!skillResult?.skill) return text('Skill not found', 404, rate.headers)
 
-    let version = skillResult.latestVersion
+    let version = skillResult.skill.latestVersionId
+      ? await ctx.runQuery(internal.skills.getVersionByIdInternal, {
+          versionId: skillResult.skill.latestVersionId,
+        })
+      : null
     if (versionParam) {
-      version = await ctx.runQuery(api.skills.getVersionBySkillAndVersion, {
+      version = await ctx.runQuery(internal.skills.getVersionBySkillAndVersionInternal, {
         skillId: skillResult.skill._id,
         version: versionParam,
       })
     } else if (tagParam) {
       const versionId = skillResult.skill.tags[tagParam]
       if (versionId) {
-        version = await ctx.runQuery(api.skills.getVersionById, { versionId })
+        version = await ctx.runQuery(internal.skills.getVersionByIdInternal, { versionId })
       }
     }
 

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -78,6 +78,8 @@ type PublicSkillVersionResponse = {
   files: PublicSkillVersionFile[]
   parsed?: PublicSkillVersionParsed
   softDeletedAt?: number
+  sha256hash?: string
+  vtAnalysis?: Doc<'skillVersions'>['vtAnalysis']
   llmAnalysis?: Doc<'skillVersions'>['llmAnalysis']
 }
 
@@ -114,10 +116,7 @@ type GetBySlugResult = {
     updatedAt: number
     latestVersionId?: Id<'skillVersions'>
   } | null
-  latestVersion: Pick<
-    PublicSkillVersionResponse,
-    '_id' | 'version' | 'createdAt' | 'changelog' | 'parsed'
-  > | null
+  latestVersion: PublicSkillVersionResponse | null
   owner: { _id: Id<'users'>; handle?: string; displayName?: string; image?: string } | null
   moderationInfo?: {
     isPendingScan: boolean
@@ -271,7 +270,12 @@ function hasLlmDimensionWarnings(
   })
 }
 
-function buildSkillSecuritySnapshot(version: Doc<'skillVersions'>): SkillSecuritySnapshot | null {
+function buildSkillSecuritySnapshot(
+  version: Pick<
+    PublicSkillVersionResponse,
+    'sha256hash' | 'vtAnalysis' | 'llmAnalysis'
+  >,
+): SkillSecuritySnapshot | null {
   const sha256hash = version.sha256hash ?? null
   const vt = version.vtAnalysis
   const llm = version.llmAnalysis

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -57,7 +57,29 @@ type ListSkillsResult = {
   nextCursor: string | null
 }
 
-type SkillFile = Doc<'skillVersions'>['files'][number]
+type PublicSkillVersionFile = {
+  path: string
+  size: number
+  sha256: string
+  contentType?: string
+}
+
+type PublicSkillVersionParsed = {
+  license?: 'MIT-0'
+  clawdis?: { os?: string[]; nix?: { plugin?: boolean; systems?: string[] } }
+}
+
+type PublicSkillVersionResponse = {
+  _id: Id<'skillVersions'>
+  version: string
+  createdAt?: number
+  changelog?: string
+  changelogSource?: 'auto' | 'user'
+  files: PublicSkillVersionFile[]
+  parsed?: PublicSkillVersionParsed
+  softDeletedAt?: number
+  llmAnalysis?: Doc<'skillVersions'>['llmAnalysis']
+}
 
 type ModerationEvidence = {
   code: string
@@ -92,16 +114,10 @@ type GetBySlugResult = {
     updatedAt: number
     latestVersionId?: Id<'skillVersions'>
   } | null
-  latestVersion: {
-    _id: Id<'skillVersions'>
-    version: string
-    createdAt?: number
-    changelog?: string
-    parsed?: {
-      license?: 'MIT-0'
-      clawdis?: { os?: string[]; nix?: { plugin?: boolean; systems?: string[] } }
-    }
-  } | null
+  latestVersion: Pick<
+    PublicSkillVersionResponse,
+    '_id' | 'version' | 'createdAt' | 'changelog' | 'parsed'
+  > | null
   owner: { _id: Id<'users'>; handle?: string; displayName?: string; image?: string } | null
   moderationInfo?: {
     isPendingScan: boolean
@@ -119,20 +135,7 @@ type GetBySlugResult = {
 } | null
 
 type ListVersionsResult = {
-  items: Array<{
-    version: string
-    createdAt: number
-    changelog: string
-    changelogSource?: 'auto' | 'user'
-    files: Array<{
-      path: string
-      size: number
-      storageId: Id<'_storage'>
-      sha256: string
-      contentType?: string
-    }>
-    softDeletedAt?: number
-  }>
+  items: PublicSkillVersionResponse[]
   nextCursor: string | null
 }
 
@@ -691,10 +694,10 @@ export async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request)
     const skillResult = (await ctx.runQuery(api.skills.getBySlug, { slug })) as GetBySlugResult
     if (!skillResult?.skill) return text('Skill not found', 404, rate.headers)
 
-    const version = await ctx.runQuery(api.skills.getVersionBySkillAndVersion, {
+    const version = (await ctx.runQuery(api.skills.getVersionBySkillAndVersion, {
       skillId: skillResult.skill._id,
       version: third,
-    })
+    })) as PublicSkillVersionResponse | null
     if (!version) return text('Version not found', 404, rate.headers)
     if (version.softDeletedAt) return text('Version not available', 410, rate.headers)
     const security = buildSkillSecuritySnapshot(version)
@@ -708,7 +711,7 @@ export async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request)
           changelog: version.changelog,
           changelogSource: version.changelogSource ?? null,
           license: version.parsed?.license ?? null,
-          files: version.files.map((file: SkillFile) => ({
+          files: version.files.map((file) => ({
             path: file.path,
             size: file.size,
             sha256: file.sha256,
@@ -802,7 +805,7 @@ export async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request)
     const skillResult = (await ctx.runQuery(api.skills.getBySlug, { slug })) as GetBySlugResult
     if (!skillResult?.skill) return text('Skill not found', 404, rate.headers)
 
-    let version = skillResult.skill.latestVersionId
+    let version: Doc<'skillVersions'> | null = skillResult.skill.latestVersionId
       ? await ctx.runQuery(internal.skills.getVersionByIdInternal, {
           versionId: skillResult.skill.latestVersionId,
         })

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -1030,15 +1030,55 @@ type PublicSkillListVersion = Pick<
   | 'changelog'
   | 'changelogSource'
 > & {
-  parsed?: {
-    license?: typeof PLATFORM_SKILL_LICENSE
-    clawdis?: {
-      os?: string[]
-      nix?: {
-        plugin?: boolean
-        systems?: string[]
-      }
+  parsed?: PublicSkillVersionParsed
+}
+
+type PublicSkillVersionParsed = {
+  license?: typeof PLATFORM_SKILL_LICENSE
+  clawdis?: {
+    os?: string[]
+    nix?: {
+      plugin?: boolean
+      systems?: string[]
     }
+  }
+}
+
+type PublicSkillVersion = {
+  _id: Id<'skillVersions'>
+  _creationTime?: number
+  skillId?: Id<'skills'>
+  version: string
+  fingerprint?: string
+  changelog?: string
+  changelogSource?: Doc<'skillVersions'>['changelogSource']
+  files: Array<{
+    path: string
+    size: number
+    sha256: string
+    contentType?: string
+  }>
+  parsed?: PublicSkillVersionParsed
+  createdBy?: Id<'users'>
+  createdAt?: number
+  softDeletedAt?: number
+  sha256hash?: string
+  vtAnalysis?: Doc<'skillVersions'>['vtAnalysis']
+  llmAnalysis?: Doc<'skillVersions'>['llmAnalysis']
+  staticScan?: {
+    status: NonNullable<Doc<'skillVersions'>['staticScan']>['status']
+    reasonCodes: NonNullable<Doc<'skillVersions'>['staticScan']>['reasonCodes']
+    findings: Array<{
+      code: string
+      severity: 'info' | 'warn' | 'critical'
+      file: string
+      line: number
+      message: string
+      evidence: string
+    }>
+    summary: NonNullable<Doc<'skillVersions'>['staticScan']>['summary']
+    engineVersion: NonNullable<Doc<'skillVersions'>['staticScan']>['engineVersion']
+    checkedAt: NonNullable<Doc<'skillVersions'>['staticScan']>['checkedAt']
   }
 }
 
@@ -1178,7 +1218,7 @@ function toPublicSkillListVersion(
 
 function toPublicSkillVersion(
   version: Doc<'skillVersions'> | null | undefined,
-): Doc<'skillVersions'> | null {
+): PublicSkillVersion | null {
   if (!version) return null
   return {
     _id: version._id,
@@ -1188,7 +1228,7 @@ function toPublicSkillVersion(
     fingerprint: version.fingerprint,
     changelog: version.changelog,
     changelogSource: version.changelogSource,
-    files: version.files.map((file) => ({
+    files: (version.files ?? []).map((file) => ({
       path: file.path,
       size: file.size,
       sha256: file.sha256,
@@ -1210,7 +1250,7 @@ function toPublicSkillVersion(
       ? {
           status: version.staticScan.status,
           reasonCodes: version.staticScan.reasonCodes,
-          findings: version.staticScan.findings.map((finding) => ({
+          findings: (version.staticScan.findings ?? []).map((finding) => ({
             code: finding.code,
             severity: finding.severity,
             file: finding.file,
@@ -1223,7 +1263,7 @@ function toPublicSkillVersion(
           checkedAt: version.staticScan.checkedAt,
         }
       : undefined,
-  } as Doc<'skillVersions'>
+  }
 }
 
 function toPublicSkillListVersionFromSummary(
@@ -2785,6 +2825,18 @@ export const getVersionsByIdsInternal = internalQuery({
 export const getVersionByIdInternal = internalQuery({
   args: { versionId: v.id('skillVersions') },
   handler: async (ctx, args) => ctx.db.get(args.versionId),
+})
+
+export const getVersionBySkillAndVersionInternal = internalQuery({
+  args: { skillId: v.id('skills'), version: v.string() },
+  handler: async (ctx, args) => {
+    return ctx.db
+      .query('skillVersions')
+      .withIndex('by_skill_version', (q) =>
+        q.eq('skillId', args.skillId).eq('version', args.version),
+      )
+      .unique()
+  },
 })
 
 export const getSkillByIdInternal = internalQuery({

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -1176,6 +1176,56 @@ function toPublicSkillListVersion(
   }
 }
 
+function toPublicSkillVersion(
+  version: Doc<'skillVersions'> | null | undefined,
+): Doc<'skillVersions'> | null {
+  if (!version) return null
+  return {
+    _id: version._id,
+    _creationTime: version._creationTime,
+    skillId: version.skillId,
+    version: version.version,
+    fingerprint: version.fingerprint,
+    changelog: version.changelog,
+    changelogSource: version.changelogSource,
+    files: version.files.map((file) => ({
+      path: file.path,
+      size: file.size,
+      sha256: file.sha256,
+      contentType: file.contentType,
+    })),
+    parsed: version.parsed
+      ? {
+          license: version.parsed.license,
+          clawdis: version.parsed.clawdis,
+        }
+      : undefined,
+    createdBy: version.createdBy,
+    createdAt: version.createdAt,
+    softDeletedAt: version.softDeletedAt,
+    sha256hash: version.sha256hash,
+    vtAnalysis: version.vtAnalysis,
+    llmAnalysis: version.llmAnalysis,
+    staticScan: version.staticScan
+      ? {
+          status: version.staticScan.status,
+          reasonCodes: version.staticScan.reasonCodes,
+          findings: version.staticScan.findings.map((finding) => ({
+            code: finding.code,
+            severity: finding.severity,
+            file: finding.file,
+            line: finding.line,
+            message: finding.message,
+            evidence: '',
+          })),
+          summary: version.staticScan.summary,
+          engineVersion: version.staticScan.engineVersion,
+          checkedAt: version.staticScan.checkedAt,
+        }
+      : undefined,
+  } as Doc<'skillVersions'>
+}
+
 function toPublicSkillListVersionFromSummary(
   summary: NonNullable<Doc<'skills'>['latestVersionSummary']>,
   latestVersionId: Id<'skillVersions'> | undefined,
@@ -1322,9 +1372,9 @@ export const getBySlug = query({
     const userId = await getAuthUserId(ctx)
     const isOwner = Boolean(userId && userId === skill.ownerUserId)
 
-    const latestVersion = skill.latestVersionId
-      ? await ctx.db.get(skill.latestVersionId)
-      : null
+    const latestVersion = toPublicSkillVersion(
+      skill.latestVersionId ? await ctx.db.get(skill.latestVersionId) : null,
+    )
     const owner = toPublicUser(await ctx.db.get(skill.ownerUserId))
     if (!owner) return null
     const badges = await getSkillBadgeMap(ctx, skill._id)
@@ -2133,9 +2183,9 @@ export const listWithLatest = query({
     const items = await Promise.all(
       limited.map(async (skill) => ({
         skill: toPublicSkill(skill),
-        latestVersion: skill.latestVersionId
-          ? await ctx.db.get(skill.latestVersionId)
-          : null,
+        latestVersion: toPublicSkillVersion(
+          skill.latestVersionId ? await ctx.db.get(skill.latestVersionId) : null,
+        ),
       })),
     )
     return items.filter(
@@ -2688,11 +2738,12 @@ export const listVersions = query({
   args: { skillId: v.id('skills'), limit: v.optional(v.number()) },
   handler: async (ctx, args) => {
     const limit = args.limit ?? 20
-    return ctx.db
+    const versions = await ctx.db
       .query('skillVersions')
       .withIndex('by_skill', (q) => q.eq('skillId', args.skillId))
       .order('desc')
       .take(limit)
+    return versions.map((version) => toPublicSkillVersion(version)!)
   },
 })
 
@@ -2709,14 +2760,16 @@ export const listVersionsPage = query({
       .withIndex('by_skill', (q) => q.eq('skillId', args.skillId))
       .order('desc')
       .paginate({ cursor: args.cursor ?? null, numItems: limit })
-    const items = page.filter((version) => !version.softDeletedAt)
+    const items = page
+      .filter((version) => !version.softDeletedAt)
+      .map((version) => toPublicSkillVersion(version)!)
     return { items, nextCursor: isDone ? null : continueCursor }
   },
 })
 
 export const getVersionById = query({
   args: { versionId: v.id('skillVersions') },
-  handler: async (ctx, args) => ctx.db.get(args.versionId),
+  handler: async (ctx, args) => toPublicSkillVersion(await ctx.db.get(args.versionId)),
 })
 
 export const getVersionsByIdsInternal = internalQuery({
@@ -4086,12 +4139,13 @@ export const escalateByVtInternal = internalMutation({
 export const getVersionBySkillAndVersion = query({
   args: { skillId: v.id('skills'), version: v.string() },
   handler: async (ctx, args) => {
-    return ctx.db
+    const version = await ctx.db
       .query('skillVersions')
       .withIndex('by_skill_version', (q) =>
         q.eq('skillId', args.skillId).eq('version', args.version),
       )
       .unique()
+    return toPublicSkillVersion(version)
   },
 })
 

--- a/convex/skills.versions.public.test.ts
+++ b/convex/skills.versions.public.test.ts
@@ -1,0 +1,244 @@
+/* @vitest-environment node */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@convex-dev/auth/server', () => ({
+  getAuthUserId: vi.fn(),
+}))
+
+vi.mock('./lib/badges', () => ({
+  getSkillBadgeMap: vi.fn(),
+  getSkillBadgeMaps: vi.fn(),
+  isSkillHighlighted: vi.fn(),
+}))
+
+const { getAuthUserId } = await import('@convex-dev/auth/server')
+const { getSkillBadgeMap, getSkillBadgeMaps } = await import('./lib/badges')
+const { getBySlug, getVersionById, getVersionBySkillAndVersion, listVersions, listWithLatest } =
+  await import('./skills')
+
+function makeVersion() {
+  return {
+    _id: 'skillVersions:1',
+    _creationTime: 1,
+    skillId: 'skills:1',
+    version: '1.0.0',
+    fingerprint: 'fp',
+    changelog: 'Initial release',
+    changelogSource: 'auto',
+    files: [
+      {
+        path: 'SKILL.md',
+        size: 10,
+        storageId: '_storage:1',
+        sha256: 'abc123',
+        contentType: 'text/markdown',
+      },
+    ],
+    parsed: {
+      frontmatter: { secret: 'value' },
+      metadata: { hidden: true },
+      clawdis: { os: ['macos'] },
+      moltbot: { prompt: 'hidden' },
+      license: 'MIT-0',
+    },
+    createdBy: 'users:1',
+    createdAt: 100,
+    softDeletedAt: undefined,
+    sha256hash: 'deadbeef',
+    vtAnalysis: {
+      status: 'clean',
+      verdict: 'clean',
+      analysis: 'safe',
+      source: 'code_insight',
+      checkedAt: 1,
+    },
+    llmAnalysis: {
+      status: 'clean',
+      verdict: 'benign',
+      confidence: 'high',
+      summary: 'Looks safe',
+      dimensions: [],
+      guidance: 'ok',
+      findings: 'none',
+      model: 'gpt',
+      checkedAt: 1,
+    },
+    staticScan: {
+      status: 'suspicious',
+      reasonCodes: ['scanner.example'],
+      findings: [
+        {
+          code: 'scanner.example',
+          severity: 'warn',
+          file: 'SKILL.md',
+          line: 1,
+          message: 'Example finding',
+          evidence: 'SECRET_SNIPPET',
+        },
+      ],
+      summary: 'Something matched',
+      engineVersion: '1',
+      checkedAt: 1,
+    },
+  }
+}
+
+describe('public skill version queries', () => {
+  beforeEach(() => {
+    vi.mocked(getAuthUserId).mockReset()
+    vi.mocked(getSkillBadgeMap).mockReset()
+    vi.mocked(getSkillBadgeMaps).mockReset()
+    vi.mocked(getAuthUserId).mockResolvedValue(null as never)
+    vi.mocked(getSkillBadgeMap).mockResolvedValue({} as never)
+    vi.mocked(getSkillBadgeMaps).mockResolvedValue(new Map() as never)
+  })
+
+  it('sanitizes latestVersion returned by getBySlug', async () => {
+    const version = makeVersion()
+    const ctx = {
+      db: {
+        query: vi.fn((table: string) => {
+          if (table !== 'skills') throw new Error(`Unexpected table ${table}`)
+          return {
+            withIndex: vi.fn(() => ({
+              unique: vi.fn().mockResolvedValue({
+                _id: 'skills:1',
+                _creationTime: 1,
+                slug: 'demo',
+                displayName: 'Demo',
+                summary: 'Summary',
+                ownerUserId: 'users:1',
+                canonicalSkillId: undefined,
+                forkOf: undefined,
+                latestVersionId: version._id,
+                tags: {},
+                stats: {
+                  downloads: 1,
+                  installsCurrent: 1,
+                  installsAllTime: 1,
+                  stars: 1,
+                  versions: 1,
+                  comments: 0,
+                },
+                createdAt: 1,
+                updatedAt: 2,
+                moderationStatus: 'active',
+                moderationFlags: undefined,
+                moderationReason: undefined,
+                softDeletedAt: undefined,
+              }),
+            })),
+          }
+        }),
+        get: vi.fn(async (id: string) => {
+          if (id === version._id) return version
+          if (id === 'users:1') {
+            return {
+              _id: 'users:1',
+              _creationTime: 1,
+              handle: 'demo',
+              name: 'demo',
+              displayName: 'Demo',
+              image: null,
+              bio: null,
+            }
+          }
+          return null
+        }),
+      },
+    } as never
+
+    const result = await getBySlug._handler(ctx, { slug: 'demo' } as never)
+
+    expect(result?.latestVersion?.files[0]).not.toHaveProperty('storageId')
+    expect(result?.latestVersion?.parsed).toEqual({
+      clawdis: { os: ['macos'] },
+      license: 'MIT-0',
+    })
+    expect(result?.latestVersion?.staticScan?.findings[0]?.evidence).toBe('')
+  })
+
+  it('sanitizes direct public version queries', async () => {
+    const version = makeVersion()
+    const unique = vi.fn().mockResolvedValue(version)
+    const take = vi.fn().mockResolvedValue([version])
+    const ctx = {
+      db: {
+        get: vi.fn().mockResolvedValue(version),
+        query: vi.fn((table: string) => {
+          if (table !== 'skillVersions') throw new Error(`Unexpected table ${table}`)
+          return {
+            withIndex: vi.fn(() => ({
+              unique,
+              order: vi.fn(() => ({ take })),
+            })),
+          }
+        }),
+      },
+    } as never
+
+    const byId = await getVersionById._handler(ctx, { versionId: version._id } as never)
+    const byVersion = await getVersionBySkillAndVersion._handler(
+      ctx,
+      { skillId: 'skills:1', version: '1.0.0' } as never,
+    )
+    const list = await listVersions._handler(ctx, { skillId: 'skills:1', limit: 5 } as never)
+
+    for (const result of [byId, byVersion, list[0]]) {
+      expect(result?.files[0]).not.toHaveProperty('storageId')
+      expect(result?.parsed).not.toHaveProperty('frontmatter')
+      expect(result?.parsed).not.toHaveProperty('metadata')
+      expect(result?.parsed).not.toHaveProperty('moltbot')
+      expect(result?.staticScan?.findings[0]?.evidence).toBe('')
+    }
+  })
+
+  it('sanitizes latestVersion in listWithLatest', async () => {
+    const version = makeVersion()
+    const ctx = {
+      db: {
+        query: vi.fn((table: string) => {
+          if (table !== 'skills') throw new Error(`Unexpected table ${table}`)
+          return {
+            order: vi.fn(() => ({
+              take: vi.fn().mockResolvedValue([
+                {
+                  _id: 'skills:1',
+                  _creationTime: 1,
+                  slug: 'demo',
+                  displayName: 'Demo',
+                  summary: 'Summary',
+                  ownerUserId: 'users:1',
+                  canonicalSkillId: undefined,
+                  forkOf: undefined,
+                  latestVersionId: version._id,
+                  tags: {},
+                  badges: undefined,
+                  stats: {
+                    downloads: 1,
+                    installsCurrent: 1,
+                    installsAllTime: 1,
+                    stars: 1,
+                    versions: 1,
+                    comments: 0,
+                  },
+                  createdAt: 1,
+                  updatedAt: 2,
+                  softDeletedAt: undefined,
+                  moderationStatus: 'active',
+                  moderationFlags: undefined,
+                  moderationReason: undefined,
+                },
+              ]),
+            })),
+          }
+        }),
+        get: vi.fn().mockResolvedValue(version),
+      },
+    } as never
+
+    const result = await listWithLatest._handler(ctx, { limit: 1 } as never)
+    expect(result[0]?.latestVersion?.files[0]).not.toHaveProperty('storageId')
+    expect(result[0]?.latestVersion?.parsed).not.toHaveProperty('frontmatter')
+  })
+})

--- a/convex/skills.versions.public.test.ts
+++ b/convex/skills.versions.public.test.ts
@@ -16,6 +16,42 @@ const { getSkillBadgeMap, getSkillBadgeMaps } = await import('./lib/badges')
 const { getBySlug, getVersionById, getVersionBySkillAndVersion, listVersions, listWithLatest } =
   await import('./skills')
 
+type WrappedHandler<TArgs, TResult = unknown> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>
+}
+
+const getBySlugHandler = (
+  getBySlug as unknown as WrappedHandler<{
+    slug: string
+  }>
+)._handler
+
+const getVersionByIdHandler = (
+  getVersionById as unknown as WrappedHandler<{
+    versionId: string
+  }>
+)._handler
+
+const getVersionBySkillAndVersionHandler = (
+  getVersionBySkillAndVersion as unknown as WrappedHandler<{
+    skillId: string
+    version: string
+  }>
+)._handler
+
+const listVersionsHandler = (
+  listVersions as unknown as WrappedHandler<{
+    skillId: string
+    limit?: number
+  }>
+)._handler
+
+const listWithLatestHandler = (
+  listWithLatest as unknown as WrappedHandler<{
+    limit?: number
+  }>
+)._handler
+
 function makeVersion() {
   return {
     _id: 'skillVersions:1',
@@ -148,14 +184,20 @@ describe('public skill version queries', () => {
       },
     } as never
 
-    const result = await getBySlug._handler(ctx, { slug: 'demo' } as never)
+    const result = (await getBySlugHandler(ctx, { slug: 'demo' } as never)) as {
+      latestVersion?: {
+        files: Array<Record<string, unknown>>
+        parsed?: Record<string, unknown>
+        staticScan?: { findings?: Array<{ evidence?: string }> }
+      } | null
+    } | null
 
     expect(result?.latestVersion?.files[0]).not.toHaveProperty('storageId')
     expect(result?.latestVersion?.parsed).toEqual({
       clawdis: { os: ['macos'] },
       license: 'MIT-0',
     })
-    expect(result?.latestVersion?.staticScan?.findings[0]?.evidence).toBe('')
+    expect(result?.latestVersion?.staticScan?.findings?.[0]?.evidence).toBe('')
   })
 
   it('sanitizes direct public version queries', async () => {
@@ -177,19 +219,40 @@ describe('public skill version queries', () => {
       },
     } as never
 
-    const byId = await getVersionById._handler(ctx, { versionId: version._id } as never)
-    const byVersion = await getVersionBySkillAndVersion._handler(
+    const byId = (await getVersionByIdHandler(ctx, {
+      versionId: version._id,
+    } as never)) as
+      | {
+          files: Array<Record<string, unknown>>
+          parsed?: Record<string, unknown>
+          staticScan?: { findings?: Array<{ evidence?: string }> }
+        }
+      | null
+    const byVersion = (await getVersionBySkillAndVersionHandler(
       ctx,
       { skillId: 'skills:1', version: '1.0.0' } as never,
-    )
-    const list = await listVersions._handler(ctx, { skillId: 'skills:1', limit: 5 } as never)
+    )) as
+      | {
+          files: Array<Record<string, unknown>>
+          parsed?: Record<string, unknown>
+          staticScan?: { findings?: Array<{ evidence?: string }> }
+        }
+      | null
+    const list = (await listVersionsHandler(ctx, {
+      skillId: 'skills:1',
+      limit: 5,
+    } as never)) as Array<{
+      files: Array<Record<string, unknown>>
+      parsed?: Record<string, unknown>
+      staticScan?: { findings?: Array<{ evidence?: string }> }
+    }>
 
     for (const result of [byId, byVersion, list[0]]) {
       expect(result?.files[0]).not.toHaveProperty('storageId')
       expect(result?.parsed).not.toHaveProperty('frontmatter')
       expect(result?.parsed).not.toHaveProperty('metadata')
       expect(result?.parsed).not.toHaveProperty('moltbot')
-      expect(result?.staticScan?.findings[0]?.evidence).toBe('')
+      expect(result?.staticScan?.findings?.[0]?.evidence).toBe('')
     }
   })
 
@@ -237,7 +300,12 @@ describe('public skill version queries', () => {
       },
     } as never
 
-    const result = await listWithLatest._handler(ctx, { limit: 1 } as never)
+    const result = (await listWithLatestHandler(ctx, { limit: 1 } as never)) as Array<{
+      latestVersion?: {
+        files: Array<Record<string, unknown>>
+        parsed?: Record<string, unknown>
+      } | null
+    }>
     expect(result[0]?.latestVersion?.files[0]).not.toHaveProperty('storageId')
     expect(result[0]?.latestVersion?.parsed).not.toHaveProperty('frontmatter')
   })


### PR DESCRIPTION
## Summary
- sanitize public skill version query responses instead of returning raw `skillVersions` docs
- strip internal-only fields like `storageId`, raw parsed frontmatter/metadata, and static finding evidence
- add regression coverage for `getBySlug`, direct version lookups, and `listWithLatest`

## Why
Follow-up to #763 and #793. The HTTP handlers already projected safe fields, but direct public Convex queries still exposed raw version docs.

## Testing
- `bunx vitest run convex/skills.versions.public.test.ts`
- `bun run lint`
