### PR TITLE
fix: sanitize public soul version queries

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -586,6 +586,56 @@ describe('httpApiV1 handlers', () => {
     expect(json.soul.tags.latest).toBe('1.0.0')
   })
 
+  it('souls file download loads storage from internal version docs', async () => {
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ('slug' in args) {
+        return {
+          _id: 'souls:1',
+          slug: 'demo-soul',
+          displayName: 'Demo Soul',
+          tags: { latest: 'soulVersions:1' },
+          latestVersionId: 'soulVersions:1',
+          softDeletedAt: undefined,
+        }
+      }
+      if ('versionId' in args) {
+        return {
+          _id: 'soulVersions:1',
+          version: '1.0.0',
+          createdAt: 3,
+          changelog: 'c',
+          files: [
+            {
+              path: 'SOUL.md',
+              size: 5,
+              storageId: '_storage:1',
+              sha256: 'abc123',
+              contentType: 'text/markdown',
+            },
+          ],
+          softDeletedAt: undefined,
+        }
+      }
+      return null
+    })
+    const runMutation = vi.fn().mockResolvedValue(okRate())
+    const storageGet = vi.fn().mockResolvedValue({
+      text: vi.fn().mockResolvedValue('hello'),
+    })
+    const response = await __handlers.soulsGetRouterV1Handler(
+      makeCtx({
+        runQuery,
+        runMutation,
+        storage: { get: storageGet },
+      }),
+      new Request('https://example.com/api/v1/souls/demo-soul/file?path=SOUL.md'),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe('hello')
+    expect(storageGet).toHaveBeenCalledWith('_storage:1')
+  })
+
   it('lists skills supports sort aliases', async () => {
     const checks: Array<[string, string]> = [
       ['rating', 'stars'],

--- a/convex/httpApiV1/soulsV1.ts
+++ b/convex/httpApiV1/soulsV1.ts
@@ -46,29 +46,40 @@ type GetSoulBySlugResult = {
     createdAt: number
     updatedAt: number
   } | null
-  latestVersion: Doc<'soulVersions'> | null
+  latestVersion: PublicSoulVersion | null
   owner: { handle?: string; displayName?: string; image?: string } | null
 } | null
 
 type ListSoulVersionsResult = {
-  items: Array<{
-    version: string
-    createdAt: number
-    changelog: string
-    changelogSource?: 'auto' | 'user'
-    files: Array<{
-      path: string
-      size: number
-      storageId: Id<'_storage'>
-      sha256: string
-      contentType?: string
-    }>
-    softDeletedAt?: number
-  }>
+  items: PublicSoulVersion[]
   nextCursor: string | null
 }
 
-type SoulFile = Doc<'soulVersions'>['files'][number]
+type PublicSoulVersion = Pick<
+  Doc<'soulVersions'>,
+  | '_id'
+  | '_creationTime'
+  | 'soulId'
+  | 'version'
+  | 'fingerprint'
+  | 'changelog'
+  | 'changelogSource'
+  | 'createdBy'
+  | 'createdAt'
+  | 'softDeletedAt'
+> & {
+  files: Array<{
+    path: string
+    size: number
+    sha256: string
+    contentType?: string
+  }>
+  parsed?: {
+    clawdis?: Doc<'soulVersions'>['parsed']['clawdis']
+  }
+}
+
+type SoulFile = PublicSoulVersion['files'][number]
 
 export async function listSoulsV1Handler(ctx: ActionCtx, request: Request) {
   const rate = await applyRateLimit(ctx, request, 'read')
@@ -219,19 +230,23 @@ export async function soulsGetRouterV1Handler(ctx: ActionCtx, request: Request) 
     const versionParam = url.searchParams.get('version')?.trim()
     const tagParam = url.searchParams.get('tag')?.trim()
 
-    const soulResult = (await ctx.runQuery(api.souls.getBySlug, { slug })) as GetSoulBySlugResult
-    if (!soulResult?.soul) return text('Soul not found', 404, rate.headers)
+    const soul = await ctx.runQuery(internal.souls.getSoulBySlugInternal, { slug })
+    if (!soul || soul.softDeletedAt) return text('Soul not found', 404, rate.headers)
 
-    let version = soulResult.latestVersion
+    let version = soul.latestVersionId
+      ? await ctx.runQuery(internal.souls.getVersionByIdInternal, {
+          versionId: soul.latestVersionId,
+        })
+      : null
     if (versionParam) {
-      version = await ctx.runQuery(api.souls.getVersionBySoulAndVersion, {
-        soulId: soulResult.soul._id,
+      version = await ctx.runQuery(internal.souls.getVersionBySoulAndVersionInternal, {
+        soulId: soul._id,
         version: versionParam,
       })
     } else if (tagParam) {
-      const versionId = soulResult.soul.tags[tagParam]
+      const versionId = soul.tags[tagParam]
       if (versionId) {
-        version = await ctx.runQuery(api.souls.getVersionById, { versionId })
+        version = await ctx.runQuery(internal.souls.getVersionByIdInternal, { versionId })
       }
     }
 
@@ -250,7 +265,7 @@ export async function soulsGetRouterV1Handler(ctx: ActionCtx, request: Request) 
     if (!blob) return text('File missing in storage', 410, rate.headers)
     const textContent = await blob.text()
 
-    void ctx.runMutation(api.soulDownloads.increment, { soulId: soulResult.soul._id })
+    void ctx.runMutation(api.soulDownloads.increment, { soulId: soul._id })
     return safeTextFileResponse({
       textContent,
       path: file.path,

--- a/convex/souls.public.test.ts
+++ b/convex/souls.public.test.ts
@@ -4,6 +4,50 @@ import { describe, expect, it, vi } from 'vitest'
 const { getBySlug, getVersionById, getVersionBySoulAndVersion, listVersions } =
   await import('./souls')
 
+type WrappedHandler<TArgs, TResult = unknown> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>
+}
+
+type PublicSoulVersionResult = {
+  files: Array<{
+    path: string
+    size: number
+    sha256: string
+    contentType?: string
+  }>
+  parsed?: {
+    clawdis?: unknown
+  }
+}
+
+const getBySlugHandler = (
+  getBySlug as unknown as WrappedHandler<{
+    slug: string
+  }, {
+    latestVersion: PublicSoulVersionResult | null
+  } | null>
+)._handler
+
+const getVersionByIdHandler = (
+  getVersionById as unknown as WrappedHandler<{
+    versionId: string
+  }, PublicSoulVersionResult | null>
+)._handler
+
+const getVersionBySoulAndVersionHandler = (
+  getVersionBySoulAndVersion as unknown as WrappedHandler<{
+    soulId: string
+    version: string
+  }, PublicSoulVersionResult | null>
+)._handler
+
+const listVersionsHandler = (
+  listVersions as unknown as WrappedHandler<{
+    soulId: string
+    limit?: number
+  }, PublicSoulVersionResult[]>
+)._handler
+
 function makeVersion() {
   return {
     _id: 'soulVersions:1',
@@ -87,7 +131,7 @@ describe('public soul version queries', () => {
       },
     } as never
 
-    const result = await getBySlug._handler(ctx, { slug: 'demo-soul' } as never)
+    const result = await getBySlugHandler(ctx, { slug: 'demo-soul' } as never)
 
     expect(result?.latestVersion?.files[0]).not.toHaveProperty('storageId')
     expect(result?.latestVersion?.parsed).toEqual({
@@ -114,12 +158,12 @@ describe('public soul version queries', () => {
       },
     } as never
 
-    const byId = await getVersionById._handler(ctx, { versionId: version._id } as never)
-    const byVersion = await getVersionBySoulAndVersion._handler(
+    const byId = await getVersionByIdHandler(ctx, { versionId: version._id } as never)
+    const byVersion = await getVersionBySoulAndVersionHandler(
       ctx,
       { soulId: 'souls:1', version: '1.0.0' } as never,
     )
-    const list = await listVersions._handler(ctx, { soulId: 'souls:1', limit: 5 } as never)
+    const list = await listVersionsHandler(ctx, { soulId: 'souls:1', limit: 5 } as never)
 
     for (const result of [byId, byVersion, list[0]]) {
       expect(result?.files[0]).not.toHaveProperty('storageId')

--- a/convex/souls.ts
+++ b/convex/souls.ts
@@ -18,9 +18,30 @@ type FileTextResult = { path: string; text: string; size: number; sha256: string
 const MAX_DIFF_FILE_BYTES = 200 * 1024
 const MAX_LIST_LIMIT = 50
 
+type PublicSoulVersion = Pick<
+  Doc<'soulVersions'>,
+  | '_id'
+  | '_creationTime'
+  | 'soulId'
+  | 'version'
+  | 'fingerprint'
+  | 'changelog'
+  | 'changelogSource'
+  | 'createdBy'
+  | 'createdAt'
+  | 'softDeletedAt'
+> & {
+  files: Array<
+    Pick<Doc<'soulVersions'>['files'][number], 'path' | 'size' | 'sha256' | 'contentType'>
+  >
+  parsed?: {
+    clawdis?: Doc<'soulVersions'>['parsed']['clawdis']
+  }
+}
+
 function toPublicSoulVersion(
   version: Doc<'soulVersions'> | null | undefined,
-): Doc<'soulVersions'> | null {
+): PublicSoulVersion | null {
   if (!version) return null
   return {
     _id: version._id,
@@ -44,7 +65,7 @@ function toPublicSoulVersion(
     createdBy: version.createdBy,
     createdAt: version.createdAt,
     softDeletedAt: version.softDeletedAt,
-  } as Doc<'soulVersions'>
+  }
 }
 
 export const getBySlug = query({
@@ -127,7 +148,7 @@ export const listPublicPage = query({
 
     const items: Array<{
       soul: NonNullable<ReturnType<typeof toPublicSoul>>
-      latestVersion: Doc<'soulVersions'> | null
+      latestVersion: PublicSoulVersion | null
     }> = []
 
     for (const soul of page) {
@@ -193,6 +214,15 @@ export const getVersionsByIdsInternal = internalQuery({
 export const getVersionByIdInternal = internalQuery({
   args: { versionId: v.id('soulVersions') },
   handler: async (ctx, args) => ctx.db.get(args.versionId),
+})
+
+export const getVersionBySoulAndVersionInternal = internalQuery({
+  args: { soulId: v.id('souls'), version: v.string() },
+  handler: async (ctx, args) =>
+    ctx.db
+      .query('soulVersions')
+      .withIndex('by_soul_version', (q) => q.eq('soulId', args.soulId).eq('version', args.version))
+      .unique(),
 })
 
 export const getVersionBySoulAndVersion = query({

--- a/src/components/SoulDetailPage.tsx
+++ b/src/components/SoulDetailPage.tsx
@@ -14,9 +14,33 @@ type SoulDetailPageProps = {
   slug: string
 }
 
+type PublicSoulVersion = Pick<
+  Doc<'soulVersions'>,
+  | '_id'
+  | '_creationTime'
+  | 'soulId'
+  | 'version'
+  | 'fingerprint'
+  | 'changelog'
+  | 'changelogSource'
+  | 'createdBy'
+  | 'createdAt'
+  | 'softDeletedAt'
+> & {
+  files: Array<{
+    path: string
+    size: number
+    sha256: string
+    contentType?: string
+  }>
+  parsed?: {
+    clawdis?: Doc<'soulVersions'>['parsed']['clawdis']
+  }
+}
+
 type SoulBySlugResult = {
   soul: PublicSoul
-  latestVersion: Doc<'soulVersions'> | null
+  latestVersion: PublicSoulVersion | null
   owner: PublicUser | null
 } | null
 
@@ -40,7 +64,7 @@ export function SoulDetailPage({ slug }: SoulDetailPageProps) {
   const versions = useQuery(
     api.souls.listVersions,
     soul ? { soulId: soul._id, limit: 50 } : 'skip',
-  ) as Doc<'soulVersions'>[] | undefined
+  ) as PublicSoulVersion[] | undefined
 
   const isStarred = useQuery(
     api.soulStars.isStarred,


### PR DESCRIPTION
## Summary
- sanitize public soul version query responses instead of returning raw `soulVersions` docs
- strip internal-only fields like `storageId` and raw parsed frontmatter/metadata
- add regression coverage for `getBySlug` and direct public version lookups

## Why
Follow-up to #763 and #793. Public HTTP routes were already narrowing version fields, but direct public Convex queries still exposed raw soul version docs.

## Testing
- `bunx vitest run convex/souls.public.test.ts`
- `bun run lint`
