### PR TITLE
fix(api): allow legacy cli publish payloads

### DIFF
--- a/convex/httpApi.handlers.test.ts
+++ b/convex/httpApi.handlers.test.ts
@@ -377,6 +377,47 @@ describe('httpApi handlers', () => {
     expect(json.skillId).toBe('s')
   })
 
+  it('cliPublishHttp accepts legacy clients that omit license terms', async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValueOnce({ userId: 'user1' } as never)
+    vi.mocked(publishVersionForUser).mockResolvedValueOnce({
+      skillId: 's',
+      versionId: 'v',
+      embeddingId: 'e',
+    } as never)
+    const request = new Request('https://x/api/cli/publish', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        slug: 'cool-skill',
+        displayName: 'Cool Skill',
+        version: '1.2.3',
+        changelog: 'c',
+        files: [{ path: 'SKILL.md', size: 1, storageId: 'id', sha256: 'a' }],
+      }),
+    })
+    const response = await __handlers.cliPublishHandler(makeCtx({}), request)
+    expect(response.status).toBe(200)
+  })
+
+  it('cliPublishHttp rejects explicit license refusal', async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValueOnce({ userId: 'user1' } as never)
+    const request = new Request('https://x/api/cli/publish', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        slug: 'cool-skill',
+        displayName: 'Cool Skill',
+        version: '1.2.3',
+        changelog: 'c',
+        acceptLicenseTerms: false,
+        files: [{ path: 'SKILL.md', size: 1, storageId: 'id', sha256: 'a' }],
+      }),
+    })
+    const response = await __handlers.cliPublishHandler(makeCtx({}), request)
+    expect(response.status).toBe(400)
+    expect(await response.text()).toMatch(/license terms must be accepted/i)
+  })
+
   it('cliSkillDeleteHandler returns 401 when unauthorized', async () => {
     vi.mocked(requireApiTokenUser).mockRejectedValueOnce(new Error('Unauthorized'))
     const request = new Request('https://x/api/cli/skill/delete', {

--- a/convex/httpApi.ts
+++ b/convex/httpApi.ts
@@ -163,7 +163,7 @@ async function cliPublishHandler(ctx: ActionCtx, request: Request) {
   try {
     const { userId } = await requireApiTokenUser(ctx, request)
     const args = parsePublishBody(body)
-    if (args.acceptLicenseTerms !== true) {
+    if (!hasAcceptedLegacyLicenseTerms(args.acceptLicenseTerms)) {
       return text('MIT-0 license terms must be accepted to publish skills', 400)
     }
     const result = await publishVersionForUser(ctx, userId, args)
@@ -173,6 +173,10 @@ async function cliPublishHandler(ctx: ActionCtx, request: Request) {
     if (message.toLowerCase().includes('unauthorized')) return text('Unauthorized', 401)
     return text(message, 400)
   }
+}
+
+function hasAcceptedLegacyLicenseTerms(acceptLicenseTerms: boolean | undefined) {
+  return acceptLicenseTerms !== false
 }
 
 export const cliPublishHttp = httpAction(cliPublishHandler)

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -1030,6 +1030,43 @@ describe('httpApiV1 handlers', () => {
     expect(publishVersionForUser).toHaveBeenCalled()
   })
 
+  it('publish json accepts legacy clients that omit license terms', async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValueOnce({
+      userId: 'users:1',
+      user: { handle: 'p' },
+    } as never)
+    vi.mocked(publishVersionForUser).mockResolvedValueOnce({
+      skillId: 's',
+      versionId: 'v',
+      embeddingId: 'e',
+    } as never)
+    const runMutation = vi.fn().mockResolvedValue(okRate())
+    const body = JSON.stringify({
+      slug: 'demo',
+      displayName: 'Demo',
+      version: '1.0.0',
+      changelog: 'c',
+      files: [
+        {
+          path: 'SKILL.md',
+          size: 1,
+          storageId: 'storage:1',
+          sha256: 'abc',
+          contentType: 'text/plain',
+        },
+      ],
+    })
+    const response = await __handlers.publishSkillV1Handler(
+      makeCtx({ runMutation }),
+      new Request('https://example.com/api/v1/skills', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer clh_test' },
+        body,
+      }),
+    )
+    expect(response.status).toBe(200)
+  })
+
   it('publish multipart succeeds', async () => {
     vi.mocked(requireApiTokenUser).mockResolvedValueOnce({
       userId: 'users:1',
@@ -1065,6 +1102,74 @@ describe('httpApiV1 handlers', () => {
     if (response.status !== 200) {
       throw new Error(await response.text())
     }
+  })
+
+  it('publish multipart accepts legacy clients that omit license terms', async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValueOnce({
+      userId: 'users:1',
+      user: { handle: 'p' },
+    } as never)
+    vi.mocked(publishVersionForUser).mockResolvedValueOnce({
+      skillId: 's',
+      versionId: 'v',
+      embeddingId: 'e',
+    } as never)
+    const runMutation = vi.fn().mockResolvedValue(okRate())
+    const form = new FormData()
+    form.set(
+      'payload',
+      JSON.stringify({
+        slug: 'demo',
+        displayName: 'Demo',
+        version: '1.0.0',
+        changelog: '',
+        tags: ['latest'],
+      }),
+    )
+    form.append('files', new Blob(['hello'], { type: 'text/plain' }), 'SKILL.md')
+    const response = await __handlers.publishSkillV1Handler(
+      makeCtx({ runMutation, storage: { store: vi.fn().mockResolvedValue('storage:1') } }),
+      new Request('https://example.com/api/v1/skills', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer clh_test' },
+        body: form,
+      }),
+    )
+    expect(response.status).toBe(200)
+  })
+
+  it('publish rejects explicit license refusal', async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValueOnce({
+      userId: 'users:1',
+      user: { handle: 'p' },
+    } as never)
+    const runMutation = vi.fn().mockResolvedValue(okRate())
+    const body = JSON.stringify({
+      slug: 'demo',
+      displayName: 'Demo',
+      version: '1.0.0',
+      changelog: 'c',
+      acceptLicenseTerms: false,
+      files: [
+        {
+          path: 'SKILL.md',
+          size: 1,
+          storageId: 'storage:1',
+          sha256: 'abc',
+          contentType: 'text/plain',
+        },
+      ],
+    })
+    const response = await __handlers.publishSkillV1Handler(
+      makeCtx({ runMutation }),
+      new Request('https://example.com/api/v1/skills', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer clh_test' },
+        body,
+      }),
+    )
+    expect(response.status).toBe(400)
+    expect(await response.text()).toMatch(/license terms must be accepted/i)
   })
 
   it('publish multipart ignores mac junk files', async () => {

--- a/convex/httpApiV1/shared.ts
+++ b/convex/httpApiV1/shared.ts
@@ -271,13 +271,13 @@ export async function parseMultipartPublish(
   }
 
   const forkOf = payload.forkOf && typeof payload.forkOf === 'object' ? payload.forkOf : undefined
+  const hasAcceptLicenseTerms = Object.prototype.hasOwnProperty.call(payload, 'acceptLicenseTerms')
   const body = {
     slug: payload.slug,
     displayName: payload.displayName,
     version: payload.version,
     changelog: typeof payload.changelog === 'string' ? payload.changelog : '',
-    acceptLicenseTerms:
-      typeof payload.acceptLicenseTerms === 'boolean' ? payload.acceptLicenseTerms : undefined,
+    ...(hasAcceptLicenseTerms ? { acceptLicenseTerms: payload.acceptLicenseTerms } : {}),
     tags: Array.isArray(payload.tags) ? payload.tags : undefined,
     ...(payload.source ? { source: payload.source } : {}),
     files,

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -651,7 +651,7 @@ export async function publishSkillV1Handler(ctx: ActionCtx, request: Request) {
     if (contentType.includes('application/json')) {
       const body = await request.json()
       const payload = parsePublishBody(body)
-      if (payload.acceptLicenseTerms !== true) {
+      if (!hasAcceptedLegacyLicenseTerms(payload.acceptLicenseTerms)) {
         return text('MIT-0 license terms must be accepted to publish skills', 400, rate.headers)
       }
       const result = await publishVersionForUser(ctx, userId, payload)
@@ -660,7 +660,7 @@ export async function publishSkillV1Handler(ctx: ActionCtx, request: Request) {
 
     if (contentType.includes('multipart/form-data')) {
       const payload = await parseMultipartPublish(ctx, request)
-      if (payload.acceptLicenseTerms !== true) {
+      if (!hasAcceptedLegacyLicenseTerms(payload.acceptLicenseTerms)) {
         return text('MIT-0 license terms must be accepted to publish skills', 400, rate.headers)
       }
       const result = await publishVersionForUser(ctx, userId, payload)
@@ -672,6 +672,10 @@ export async function publishSkillV1Handler(ctx: ActionCtx, request: Request) {
   }
 
   return text('Unsupported content type', 415, rate.headers)
+}
+
+function hasAcceptedLegacyLicenseTerms(acceptLicenseTerms: boolean | undefined) {
+  return acceptLicenseTerms !== false
 }
 
 type TransferDecisionAction = 'accept' | 'reject' | 'cancel'


### PR DESCRIPTION
## Summary
- allow token-auth publish endpoints to accept legacy CLI payloads that omit `acceptLicenseTerms`
- continue rejecting explicit `acceptLicenseTerms: false`
- add regression tests for legacy JSON and multipart publish requests

## Testing
- bunx vitest run convex/httpApi.handlers.test.ts
- bunx vitest run convex/httpApiV1.handlers.test.ts
