### PR TITLE
fix: align security scan summary text

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -3866,9 +3866,11 @@ html.theme-transition::view-transition-new(theme) {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  width: 100%;
   padding: 10px 14px;
   cursor: pointer;
   user-select: text;
+  text-align: left;
   border-radius: 12px;
   transition: background 0.15s ease;
 }
@@ -3907,6 +3909,7 @@ html.theme-transition::view-transition-new(theme) {
   flex: 1;
   cursor: text;
   user-select: text;
+  text-align: left;
 }
 
 .analysis-body {


### PR DESCRIPTION
## Summary

Fix the security scan summary text alignment in the skill detail page.

## What Changed

- set the expandable security scan header to use full width
- left-align the header content
- left-align the wrapped summary text inside the OpenClaw analysis row

## Why

The security scan description could appear centered when the summary wrapped across multiple lines, which made the panel harder to scan and visually inconsistent with the rest of the detail page. This change keeps the description left-aligned without changing the interaction or adding truncation behavior.

## Files Changed

- `src/styles.css`

before:
<img width="2330" height="1596" alt="image" src="https://github.com/user-attachments/assets/6753a882-eb28-4d42-86b0-a387e107e54d" />

after:
<img width="2042" height="1002" alt="image" src="https://github.com/user-attachments/assets/3771700d-40e4-447a-9c32-fae726747944" />

