### PR TITLE
fix: preserve local skill directory when install --force checks fail

### DIFF
--- a/packages/clawdhub/src/cli/commands/skills.ts
+++ b/packages/clawdhub/src/cli/commands/skills.ts
@@ -81,12 +81,6 @@ export async function cmdInstall(
   const registry = await getRegistry(opts, { cache: true })
   await mkdir(opts.dir, { recursive: true })
   const target = join(opts.dir, trimmed)
-  if (!force) {
-    const exists = await fileExists(target)
-    if (exists) fail(`Already installed: ${target} (use --force)`)
-  } else {
-    await rm(target, { recursive: true, force: true })
-  }
 
   const spinner = createSpinner(`Resolving ${trimmed}`)
   try {
@@ -121,6 +115,14 @@ export async function cmdInstall(
 
     const resolvedVersion = versionFlag ?? skillMeta.latestVersion?.version ?? null
     if (!resolvedVersion) fail('Could not resolve latest version')
+
+    // All checks passed. Now safe to remove existing directory (if --force)
+    if (force) {
+      await rm(target, { recursive: true, force: true })
+    } else {
+      const exists = await fileExists(target)
+      if (exists) fail(`Already installed: ${target} (use --force)`)
+    }
 
     spinner.text = `Downloading ${trimmed}@${resolvedVersion}`
     const zip = await downloadZip(registry, { slug: trimmed, version: resolvedVersion, token })

--- a/test-force-install-fix.sh
+++ b/test-force-install-fix.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Test script for issue #825
+# Verifies that `clawhub install --force` preserves local directory when checks fail
+
+set -e
+
+SKILLS_DIR="./test-skills"
+TEST_SKILL="not-a-real-skill"
+
+echo "🧪 Testing fix for issue #825..."
+echo ""
+
+# Cleanup from previous runs
+rm -rf "$SKILLS_DIR"
+mkdir -p "$SKILLS_DIR"
+
+# Create a local skill directory to simulate an existing install
+echo "📁 Creating test skill directory with precious data..."
+mkdir -p "$SKILLS_DIR/$TEST_SKILL"
+echo "PRECIOUS_DATA" > "$SKILLS_DIR/$TEST_SKILL/MARKER.txt"
+
+# Verify the file exists
+if [ ! -f "$SKILLS_DIR/$TEST_SKILL/MARKER.txt" ]; then
+  echo "❌ Test setup failed: MARKER.txt not created"
+  exit 1
+fi
+
+echo "✅ Test setup complete. MARKER.txt exists."
+echo ""
+
+# Try to force install a nonexistent slug
+echo "🔨 Running: clawhub install $TEST_SKILL --force (expecting failure)..."
+echo ""
+
+# Run the install command (should fail because skill doesn't exist)
+# Note: This will fail, but we're testing that the directory is NOT deleted
+if ./packages/clawdhub/dist/cli.js install "$TEST_SKILL" --force --dir "$SKILLS_DIR" 2>&1; then
+  echo "⚠️  Install succeeded unexpectedly (skill may exist now)"
+else
+  echo ""
+  echo "✅ Install failed as expected (skill not found)"
+fi
+
+echo ""
+echo "🔍 Checking if MARKER.txt still exists..."
+
+# Check if the file still exists
+if [ -f "$SKILLS_DIR/$TEST_SKILL/MARKER.txt" ]; then
+  echo "✅ SUCCESS! MARKER.txt preserved. Fix is working correctly."
+  echo ""
+  echo "📄 Content of MARKER.txt:"
+  cat "$SKILLS_DIR/$TEST_SKILL/MARKER.txt"
+  echo ""
+  exit 0
+else
+  echo "❌ FAILURE! MARKER.txt was deleted. The bug still exists."
+  exit 1
+fi
+
+# Cleanup
+rm -rf "$SKILLS_DIR"


### PR DESCRIPTION
## Summary

This PR fixes issue #825 where \clawhub install --force\ deletes the local skill directory **before** running pre-install checks. If any check fails (skill not found, malware-blocked, etc.), the user's existing skill files are lost with no replacement.

## Changes

- **Moved directory deletion** to after all pre-install checks pass (malware check, suspicious check, version resolution)
- **Aligns behavior** with \cmdUpdate\, which already follows the correct pattern (checks before delete)
- **Added test script** (\	est-force-install-fix.sh\) to verify the fix

## Testing

The test script simulates the bug scenario:
1. Creates a local skill directory with a marker file
2. Attempts to \install --force\ a non-existent skill
3. Verifies the marker file still exists after the failed install

## Before (buggy behavior)

\\\	ypescript
// Delete first, then check
if (force) {
  await rm(target, { recursive: true, force: true })
}
// ... checks that might fail
\\\

## After (fixed behavior)

\\\	ypescript
// Check first, then delete only if all checks pass
// ... all checks
if (force) {
  await rm(target, { recursive: true, force: true })
}
// ... download and extract
\\\

Fixes #825