### PR TITLE
fix: scroll bar in the fie view under light theme

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -4,7 +4,7 @@
 @import "@fontsource/ibm-plex-mono/latin.css";
 
 :root {
-  color-scheme: light dark;
+  color-scheme: light;
   --bg: #f8f2ed;
   --bg-soft: #fdf7f2;
   --bg-glow-1: #ffe1d4;
@@ -17,6 +17,7 @@
   --accent: #e65c46;
   --accent-deep: #bf3f30;
   --seafoam: #209e92;
+  --file-browser-pane-max-height: 360px;
   --gold: #e7bb67;
   --line: rgba(42, 31, 25, 0.14);
   --border-ui: rgba(191, 63, 48, 0.28);
@@ -2332,7 +2333,7 @@ code {
 .file-list-body {
   display: grid;
   gap: 8px;
-  max-height: 260px;
+  max-height: var(--file-browser-pane-max-height);
   max-width: 100%;
   overflow: auto;
   padding-right: 4px;
@@ -2385,7 +2386,7 @@ code {
 }
 
 .file-viewer-body {
-  max-height: 320px;
+  max-height: var(--file-browser-pane-max-height);
   overflow: auto;
   padding-right: 4px;
 }


### PR DESCRIPTION
## Summary

This PR fixes two UI issues in the skill file viewer:

- corrects native scrollbar rendering in light theme
- aligns the file list and file preview panes to use the same max height

## Changes

- set the light theme `color-scheme` to `light` so browsers do not render dark native scrollbars while the app is in light mode
- keep dark mode controlled by the existing `[data-theme="dark"]` override
- introduce a shared file browser pane max-height token in `src/styles.css`
- apply that shared max height to both the left file list and the right file preview pane
- remove the redundant dark-theme override for the shared pane height token

before
<img width="2280" height="876" alt="image" src="https://github.com/user-attachments/assets/5656621c-e419-4758-9173-71515a18b602" />

after
<img width="2318" height="920" alt="image" src="https://github.com/user-attachments/assets/c000265c-910b-43c8-87d1-0e4aeebdc696" />


## Files changed

- `src/styles.css`

## Notes

- no component logic changes included
- this is CSS-only
