### PR TITLE
fix(cli): validate forced install version before rm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - API: accept legacy CLI publish payloads during the v1 migration (#815).
 - Auth/UI: surface OAuth callback failures in the web UI instead of swallowing them (#688).
 - Skills: allow ownership healing when the previous owner was deleted/banned, and sanitize owner data in public payloads (#689, #793).
+- CLI: validate explicit `install --force --version` targets before removing an existing local skill, preventing data loss when the requested version does not exist (#825) (thanks @jonathandeamer).
 - Skills/Web: debounce search URL updates on `/skills` to keep typing responsive, and cancel stale pending navigations on external query changes (#587) (thanks @neeravmakwana).
 - Upload: keep folder-picking enabled after page refresh by reapplying `webkitdirectory`/`directory` on the file input ref (#551) (thanks @MunemHashmi).
 - CLI publish: use a longer multipart upload timeout and normalize abort rejections into proper Errors (#550) (thanks @MunemHashmi).

--- a/packages/clawdhub/src/cli/commands/skills.test.ts
+++ b/packages/clawdhub/src/cli/commands/skills.test.ts
@@ -274,6 +274,73 @@ describe('cmdInstall', () => {
     expect(rm).not.toHaveBeenCalled()
   })
 
+  it('does not rm local directory when requested version lookup fails (--force)', async () => {
+    vi.mocked(stat).mockResolvedValue({} as unknown as Awaited<ReturnType<typeof stat>>) // target exists
+    mockApiRequest
+      .mockResolvedValueOnce({
+        skill: { slug: 'demo', displayName: 'Demo', summary: null, tags: {}, stats: {}, createdAt: 0, updatedAt: 0 },
+        latestVersion: { version: '1.0.0' },
+        owner: null,
+        moderation: null,
+      })
+      .mockRejectedValueOnce(new Error('Version not found'))
+
+    await expect(cmdInstall(makeOpts(), 'demo', '9.9.9', true)).rejects.toThrow(
+      /version not found/i,
+    )
+
+    expect(rm).not.toHaveBeenCalled()
+    expect(mockApiRequest).toHaveBeenNthCalledWith(
+      2,
+      'https://clawhub.ai',
+      expect.objectContaining({
+        path: `${ApiRoutes.skills}/${encodeURIComponent('demo')}/versions/${encodeURIComponent('9.9.9')}`,
+      }),
+      expect.anything(),
+    )
+  })
+
+  it('validates requested version before rm when all checks pass (--force)', async () => {
+    vi.mocked(stat).mockResolvedValue({} as unknown as Awaited<ReturnType<typeof stat>>) // target exists
+    mockApiRequest
+      .mockResolvedValueOnce({
+        skill: { slug: 'demo', displayName: 'Demo', summary: null, tags: {}, stats: {}, createdAt: 0, updatedAt: 0 },
+        latestVersion: { version: '1.0.0' },
+        owner: null,
+        moderation: null,
+      })
+      .mockResolvedValueOnce({
+        version: {
+          version: '9.9.9',
+          createdAt: 0,
+          changelog: '',
+          changelogSource: null,
+          license: null,
+          files: [],
+        },
+        skill: { slug: 'demo', displayName: 'Demo' },
+      })
+    mockDownloadZip.mockResolvedValue(new Uint8Array([1, 2, 3]))
+    vi.mocked(readLockfile).mockResolvedValue({ version: 1, skills: {} })
+    vi.mocked(writeLockfile).mockResolvedValue()
+    vi.mocked(writeSkillOrigin).mockResolvedValue()
+    vi.mocked(extractZipToDir).mockResolvedValue()
+    vi.mocked(rm).mockResolvedValue()
+
+    await cmdInstall(makeOpts(), 'demo', '9.9.9', true)
+
+    expect(rm).toHaveBeenCalledWith('/work/skills/demo', { recursive: true, force: true })
+    expect(mockDownloadZip).toHaveBeenCalledWith(
+      'https://clawhub.ai',
+      expect.objectContaining({ slug: 'demo', version: '9.9.9' }),
+    )
+    const versionLookupOrder = mockApiRequest.mock.invocationCallOrder[1]
+    const rmOrder = vi.mocked(rm).mock.invocationCallOrder[0]
+    const downloadOrder = mockDownloadZip.mock.invocationCallOrder[0]
+    expect(versionLookupOrder).toBeLessThan(rmOrder)
+    expect(rmOrder).toBeLessThan(downloadOrder)
+  })
+
   it('calls rm before download when all checks pass (--force)', async () => {
     vi.mocked(stat).mockResolvedValue({} as unknown as Awaited<ReturnType<typeof stat>>) // target exists
     mockApiRequest.mockResolvedValue({

--- a/packages/clawdhub/src/cli/commands/skills.ts
+++ b/packages/clawdhub/src/cli/commands/skills.ts
@@ -8,6 +8,7 @@ import {
   ApiV1SkillListResponseSchema,
   ApiV1SkillResolveResponseSchema,
   ApiV1SkillResponseSchema,
+  ApiV1SkillVersionResponseSchema,
 } from '../../schema/index.js'
 import {
   extractZipToDir,
@@ -119,6 +120,20 @@ export async function cmdInstall(
 
     const resolvedVersion = versionFlag ?? skillMeta.latestVersion?.version ?? null
     if (!resolvedVersion) fail('Could not resolve latest version')
+
+    if (versionFlag) {
+      await apiRequest(
+        registry,
+        {
+          method: 'GET',
+          path: `${ApiRoutes.skills}/${encodeURIComponent(trimmed)}/versions/${encodeURIComponent(
+            resolvedVersion,
+          )}`,
+          token,
+        },
+        ApiV1SkillVersionResponseSchema,
+      )
+    }
 
     if (force) {
       await rm(target, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- keep the `#826` fix that delays `rm` until after pre-download checks pass
- validate explicit `--version` installs before removing the existing local skill directory
- add regression tests for the missing-version failure path and explicit-version happy path
- document the CLI fix in `CHANGELOG.md`

## Why
`#826` fixed the data-loss window for metadata and moderation failures, but `clawhub install <slug> --force --version <missing>` still trusted the requested version, deleted the local skill directory, and only then failed on the download 404. This replacement PR closes that remaining data-loss path.

## Testing
- `bun run lint`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawdhub/tsconfig.json --noEmit`
- `bun run test`
- `bun run build`

Fixes #825.
Supersedes #826.
