### PR TITLE
fix(web): default compare diff to inline on narrow screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Visibility/API: prevent skills owned by deleted/banned users from showing up in public detail pages, browse/search results, or version API routes.
+- Skills/Web: keep Monaco compare layout toggles reliable while defaulting narrow screens to inline mode (#828) (thanks @geoffrey-xiao).
 
 ## 0.8.0 - 2026-03-13
 

--- a/src/components/SkillDiffCard.test.tsx
+++ b/src/components/SkillDiffCard.test.tsx
@@ -1,0 +1,105 @@
+/* @vitest-environment jsdom */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Doc, Id } from '../../convex/_generated/dataModel'
+import { SkillDiffCard } from './SkillDiffCard'
+
+const getFileTextMock = vi.fn()
+
+vi.mock('convex/react', () => ({
+  useAction: () => getFileTextMock,
+}))
+
+vi.mock('@monaco-editor/react', () => ({
+  DiffEditor: ({
+    className,
+    options,
+  }: {
+    className?: string
+    options?: { renderSideBySide?: boolean; useInlineViewWhenSpaceIsLimited?: boolean }
+  }) => (
+    <div
+      className={className}
+      data-inline-fallback={String(options?.useInlineViewWhenSpaceIsLimited)}
+      data-side-by-side={String(options?.renderSideBySide)}
+      data-testid="diff-editor"
+    />
+  ),
+  useMonaco: () => null,
+}))
+
+function installMatchMedia(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockImplementation(() => ({
+      matches,
+      media: '(max-width: 860px)',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+}
+
+function makeVersion(id: string, version: string): Doc<'skillVersions'> {
+  return {
+    _id: id as Id<'skillVersions'>,
+    version,
+    files: [{ path: 'SKILL.md', size: 10 }],
+  } as unknown as Doc<'skillVersions'>
+}
+
+const skill = {
+  _id: 'skills:1',
+  slug: 'diagram-tools',
+  displayName: 'Diagram Tools',
+  tags: {},
+  stats: { stars: 0, downloads: 0 },
+} as unknown as Doc<'skills'>
+
+describe('SkillDiffCard', () => {
+  beforeEach(() => {
+    getFileTextMock.mockReset()
+    getFileTextMock.mockResolvedValue({ text: 'content' })
+  })
+
+  it('defaults to inline mode on narrow screens', async () => {
+    installMatchMedia(true)
+
+    render(
+      <SkillDiffCard
+        skill={skill}
+        versions={[makeVersion('skillVersions:1', '1.0.1'), makeVersion('skillVersions:2', '1.0.2')]}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('diff-editor').getAttribute('data-side-by-side')).toBe('false')
+    })
+    expect(screen.getByRole('button', { name: 'Inline' }).className).toContain('is-active')
+    expect(screen.getByTestId('diff-editor').getAttribute('data-inline-fallback')).toBe('false')
+  })
+
+  it('keeps explicit split mode when selected on narrow screens', async () => {
+    installMatchMedia(true)
+
+    render(
+      <SkillDiffCard
+        skill={skill}
+        versions={[makeVersion('skillVersions:1', '1.0.1'), makeVersion('skillVersions:2', '1.0.2')]}
+      />,
+    )
+
+    await screen.findByTestId('diff-editor')
+    fireEvent.click(screen.getByRole('button', { name: 'Side-by-side' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('diff-editor').getAttribute('data-side-by-side')).toBe('true')
+    })
+    expect(screen.getByRole('button', { name: 'Side-by-side' }).className).toContain('is-active')
+  })
+})

--- a/src/components/SkillDiffCard.tsx
+++ b/src/components/SkillDiffCard.tsx
@@ -36,11 +36,19 @@ type SizeWarning = {
 }
 
 const EMPTY_DIFF_TEXT = ''
+const MOBILE_DIFF_BREAKPOINT = 860
+
+function getDefaultViewMode() {
+  if (typeof window === 'undefined') return 'split'
+  return window.matchMedia(`(max-width: ${MOBILE_DIFF_BREAKPOINT}px)`).matches
+    ? 'inline'
+    : 'split'
+}
 
 export function SkillDiffCard({ skill, versions, variant = 'card' }: SkillDiffCardProps) {
   const getFileText = useAction(api.skills.getFileText)
   const monaco = useMonaco()
-  const [viewMode, setViewMode] = useState<'split' | 'inline'>('split')
+  const [viewMode, setViewMode] = useState<'split' | 'inline'>(getDefaultViewMode)
   const [leftVersionId, setLeftVersionId] = useState<Id<'skillVersions'> | null>(null)
   const [rightVersionId, setRightVersionId] = useState<Id<'skillVersions'> | null>(null)
   const [selectedPath, setSelectedPath] = useState<string | null>(null)
@@ -50,6 +58,7 @@ export function SkillDiffCard({ skill, versions, variant = 'card' }: SkillDiffCa
   const [error, setError] = useState<string | null>(null)
   const [sizeWarning, setSizeWarning] = useState<SizeWarning | null>(null)
   const cacheRef = useRef(new Map<string, string>())
+  const userSelectedViewModeRef = useRef(false)
 
   const versionEntries = useMemo(
     () => versions.map((entry) => ({ id: entry._id, version: entry.version })),
@@ -235,6 +244,29 @@ export function SkillDiffCard({ skill, versions, variant = 'card' }: SkillDiffCa
     return () => observer.disconnect()
   }, [monaco])
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const mediaQuery = window.matchMedia(`(max-width: ${MOBILE_DIFF_BREAKPOINT}px)`)
+    const syncViewMode = () => {
+      if (!userSelectedViewModeRef.current) {
+        setViewMode(mediaQuery.matches ? 'inline' : 'split')
+      }
+    }
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', syncViewMode)
+      return () => mediaQuery.removeEventListener('change', syncViewMode)
+    }
+
+    mediaQuery.addListener(syncViewMode)
+    return () => mediaQuery.removeListener(syncViewMode)
+  }, [])
+
+  function updateViewMode(nextViewMode: 'split' | 'inline') {
+    userSelectedViewModeRef.current = true
+    setViewMode(nextViewMode)
+  }
+
   const leftLabel = leftVersion ? `v${leftVersion.version}` : '—'
   const rightLabel = rightVersion ? `v${rightVersion.version}` : '—'
   const diffUnavailable = versions.length < 2
@@ -260,14 +292,14 @@ export function SkillDiffCard({ skill, versions, variant = 'card' }: SkillDiffCa
           <button
             className={`diff-toggle${viewMode === 'split' ? ' is-active' : ''}`}
             type="button"
-            onClick={() => setViewMode('split')}
+            onClick={() => updateViewMode('split')}
           >
             Side-by-side
           </button>
           <button
             className={`diff-toggle${viewMode === 'inline' ? ' is-active' : ''}`}
             type="button"
-            onClick={() => setViewMode('inline')}
+            onClick={() => updateViewMode('inline')}
           >
             Inline
           </button>
@@ -359,7 +391,7 @@ export function SkillDiffCard({ skill, versions, variant = 'card' }: SkillDiffCa
             <ClientOnly fallback={<div className="diff-empty">Preparing diff…</div>}>
               <DiffEditor
                 key={`diff-${viewMode}`}
-                className="diff-monaco"
+                className={`diff-monaco diff-monaco-${viewMode}`}
                 original={leftText}
                 modified={rightText}
                 theme={getMonacoThemeName()}

--- a/src/styles.css
+++ b/src/styles.css
@@ -2754,12 +2754,20 @@ code {
     grid-template-columns: 1fr;
   }
 
+  .diff-view {
+    overflow-x: auto;
+  }
+
   .diff-files {
     grid-auto-flow: column;
     grid-auto-columns: minmax(180px, 1fr);
     overflow-x: auto;
     padding-bottom: 6px;
     max-height: none;
+  }
+
+  .diff-monaco.diff-monaco-split {
+    min-width: 560px;
   }
 
   .skills-row {


### PR DESCRIPTION
## Summary
- replace #828 with the same Monaco toggle/remount fix plus a mobile-safe default
- preserve the original work from @geoffrey-xiao and acknowledge it in the changelog entry
- keep explicit side-by-side usable on narrow screens by allowing horizontal overflow instead of cramped panes

## What changed
- default the compare view to `inline` below the existing narrow-screen breakpoint
- keep syncing that default on resize until the user explicitly chooses a view mode
- preserve the PR #828 `DiffEditor` remount and `useInlineViewWhenSpaceIsLimited: false` behavior so the toggle remains authoritative
- add a regression test for narrow-screen default and explicit split selection

## Verification
- `bun run check:peers`
- `bun run lint`
- `bun run test`
- `bun run coverage`
- `bunx tsc --noEmit`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawdhub/tsconfig.json --noEmit`
- `bun run build`
- phone-sized browser verification at `390x844` on the local dev server:
  - default compare mode is `Inline` with Monaco not side-by-side
  - selecting `Side-by-side` keeps Monaco in split mode and the diff area scrolls horizontally instead of compressing both panes
