### PR TITLE
feat: Display maintainer in clawhub search results

### DIFF
--- a/packages/clawdhub/src/cli/commands/skills.ts
+++ b/packages/clawdhub/src/cli/commands/skills.ts
@@ -61,7 +61,8 @@ export async function cmdSearch(opts: GlobalOpts, query: string, limit?: number)
       const slug = entry.slug ?? 'unknown'
       const name = entry.displayName ?? slug
       const version = entry.version ? ` v${entry.version}` : ''
-      console.log(`${slug}${version}  ${name}  (${entry.score.toFixed(3)})`)
+      const maintainer = entry.owner?.handle ?? 'N/A'
+      console.log(`${slug}${version}  ${name} by ${maintainer} (${entry.score.toFixed(3)})`)
     }
   } catch (error) {
     spinner.fail(formatError(error))

--- a/packages/clawdhub/src/schema/schemas.ts
+++ b/packages/clawdhub/src/schema/schemas.ts
@@ -145,6 +145,9 @@ export const ApiV1SearchResponseSchema = type({
     version: 'string|null?',
     score: 'number',
     updatedAt: 'number?',
+    owner: type({
+      handle: 'string|null',
+    }).or('null').optional(),
   }).array(),
 })
 


### PR DESCRIPTION
This PR enhances the  command by including the maintainer's name/username in the search results. This addresses the problem of non-technical users not being able to easily identify which skill belongs to which maintainer and assess trustworthiness. I have also updated the relevant API schema to include the owner's handle in the search results.