### PR TITLE
fix: remove global stats full-table scan and shard rate limit counters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ bunx convex run --no-push devSeed:seedNixSkills
 bunx convex run --no-push devSeedExtra:seedExtraSkillsInternal
 
 # Refresh the cached skills count (required after seeding)
-bunx convex run --no-push statsMaintenance:updateGlobalStatsInternal
+bunx convex run --no-push statsMaintenance:updateGlobalStatsAction
 ```
 
 To reset and re-seed:

--- a/convex/lib/globalStats.ts
+++ b/convex/lib/globalStats.ts
@@ -52,18 +52,6 @@ export function isGlobalStatsStorageNotReadyError(error: unknown) {
   )
 }
 
-export async function countPublicSkillsForGlobalStats(ctx: GlobalStatsReadCtx) {
-  const digests = await ctx.db
-    .query('skillSearchDigest')
-    .withIndex('by_active_updated', (q) => q.eq('softDeletedAt', undefined))
-    .collect()
-  let count = 0
-  for (const digest of digests) {
-    if (isPublicSkillDoc(digest)) count += 1
-  }
-  return count
-}
-
 export async function setGlobalPublicSkillsCount(
   ctx: GlobalStatsWriteCtx,
   count: number,
@@ -117,9 +105,8 @@ export async function adjustGlobalPublicSkillsCount(
   }
 
   if (!existing) {
-    // No baseline yet (e.g. fresh deploy). Initialize via full recount once.
-    const count = await countPublicSkillsForGlobalStats(ctx)
-    await setGlobalPublicSkillsCount(ctx, count, now)
+    // No baseline yet — initialize with delta (clamped to 0). The daily cron reconciles.
+    await setGlobalPublicSkillsCount(ctx, Math.max(0, normalizedDelta), now)
     return
   }
 

--- a/convex/lib/httpRateLimit.ts
+++ b/convex/lib/httpRateLimit.ts
@@ -152,7 +152,9 @@ async function checkRateLimit(
 
   return {
     allowed: result.allowed,
-    remaining: result.remaining,
+    // Use the query's cross-shard total (accurate) minus 1 for the token we just consumed.
+    // The mutation's remaining is per-shard and would be misleading in response headers.
+    remaining: Math.max(0, status.remaining - 1),
     limit: status.limit,
     resetAt: status.resetAt,
   }

--- a/convex/rateLimits.ts
+++ b/convex/rateLimits.ts
@@ -1,9 +1,12 @@
 import { v } from 'convex/values'
 import { internalMutation, internalQuery } from './functions'
 
+const SHARD_COUNT = 8
+
 /**
  * Read-only rate limit check. Returns current status without writing anything.
- * This eliminates write conflicts for denied requests entirely.
+ * Reads all shards + legacy unsharded key and sums counts.
+ * As a query (not mutation), this doesn't participate in OCC.
  */
 export const getRateLimitStatusInternal = internalQuery({
   args: {
@@ -19,12 +22,26 @@ export const getRateLimitStatusInternal = internalQuery({
       return { allowed: false, remaining: 0, limit: args.limit, resetAt }
     }
 
-    const existing = await ctx.db
-      .query('rateLimits')
-      .withIndex('by_key_window', (q) => q.eq('key', args.key).eq('windowStart', windowStart))
-      .unique()
+    // Read all shards + legacy unsharded key in parallel
+    const keys = [
+      args.key, // legacy unsharded key
+      ...Array.from({ length: SHARD_COUNT }, (_, i) => `${args.key}:s${i}`),
+    ]
 
-    const count = existing?.count ?? 0
+    const docs = await Promise.all(
+      keys.map((k) =>
+        ctx.db
+          .query('rateLimits')
+          .withIndex('by_key_window', (q) => q.eq('key', k).eq('windowStart', windowStart))
+          .unique(),
+      ),
+    )
+
+    let count = 0
+    for (const doc of docs) {
+      if (doc) count += doc.count
+    }
+
     const allowed = count < args.limit
     return {
       allowed,
@@ -37,8 +54,8 @@ export const getRateLimitStatusInternal = internalQuery({
 
 /**
  * Consume one rate limit token. Only call this after getRateLimitStatusInternal
- * returns allowed=true. Includes a double-check to handle races between the
- * query and this mutation.
+ * returns allowed=true. Writes to a random shard to reduce OCC contention —
+ * two concurrent mutations only conflict if they land on the same shard (1/8).
  */
 export const consumeRateLimitInternal = internalMutation({
   args: {
@@ -49,27 +66,23 @@ export const consumeRateLimitInternal = internalMutation({
   handler: async (ctx, args) => {
     const now = Date.now()
     const windowStart = Math.floor(now / args.windowMs) * args.windowMs
+    const shard = Math.floor(Math.random() * SHARD_COUNT)
+    const shardKey = `${args.key}:s${shard}`
 
     const existing = await ctx.db
       .query('rateLimits')
-      .withIndex('by_key_window', (q) => q.eq('key', args.key).eq('windowStart', windowStart))
+      .withIndex('by_key_window', (q) => q.eq('key', shardKey).eq('windowStart', windowStart))
       .unique()
-
-    // Double-check: another request may have consumed the last token
-    // between our query and this mutation
-    if (existing && existing.count >= args.limit) {
-      return { allowed: false, remaining: 0 }
-    }
 
     if (!existing) {
       await ctx.db.insert('rateLimits', {
-        key: args.key,
+        key: shardKey,
         windowStart,
         count: 1,
         limit: args.limit,
         updatedAt: now,
       })
-      return { allowed: true, remaining: Math.max(0, args.limit - 1) }
+      return { allowed: true, remaining: args.limit - 1 }
     }
 
     await ctx.db.patch(existing._id, {

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -32,7 +32,6 @@ import {
 } from './lib/githubIdentity'
 import {
   adjustGlobalPublicSkillsCount,
-  countPublicSkillsForGlobalStats,
   getPublicSkillVisibilityDelta,
   isPublicSkillDoc,
   readGlobalPublicSkillsCount,
@@ -2750,9 +2749,8 @@ export const countPublicSkills = query({
   args: {},
   handler: async (ctx) => {
     const statsCount = await readGlobalPublicSkillsCount(ctx)
-    if (typeof statsCount === 'number') return statsCount
-    // Fallback for uninitialized/missing globalStats storage.
-    return countPublicSkillsForGlobalStats(ctx)
+    // Daily cron ensures globalStats is always populated. Return 0 if missing.
+    return statsCount ?? 0
   },
 })
 

--- a/convex/statsMaintenance.ts
+++ b/convex/statsMaintenance.ts
@@ -4,7 +4,6 @@ import type { Doc } from './_generated/dataModel'
 import type { ActionCtx } from './_generated/server'
 import { internalAction, internalMutation, internalQuery } from './functions'
 import {
-  countPublicSkillsForGlobalStats,
   isPublicSkillDoc,
   setGlobalPublicSkillsCount,
 } from './lib/globalStats'
@@ -364,14 +363,3 @@ export const updateGlobalStatsAction = internalAction({
   },
 })
 
-/**
- * @deprecated Use updateGlobalStatsAction instead.
- * Kept as a manual emergency fallback only — do not re-add to crons.
- */
-export const updateGlobalStatsInternal = internalMutation({
-  args: {},
-  handler: async (ctx) => {
-    const count = await countPublicSkillsForGlobalStats(ctx)
-    await setGlobalPublicSkillsCount(ctx, count)
-  },
-})


### PR DESCRIPTION
## Summary

- **Remove `countPublicSkillsForGlobalStats`** which scanned all 19K `skillSearchDigest` rows (17MB) in a single mutation, exceeding the bytes-read limit. The `adjustGlobalPublicSkillsCount` fallback now initializes with `Math.max(0, delta)` — the daily cron reconciles within 24h.
- **Shard rate limit writes across 8 keys** to reduce OCC contention (3M retries / 43K permanent failures in 72h). The read-only query sums all shards + legacy key; the mutation writes to a random shard, reducing collision probability to 1/8.
- **Delete deprecated `updateGlobalStatsInternal`** mutation to prevent accidental manual invocations of the full-table scan.

## Test plan

- [x] `npx convex dev --once` — typechecks pass
- [ ] Deploy to prod: `npx convex deploy --yes`
- [ ] After deploy: `npx convex insights --prod --details` — verify OCC retries drop ~8×, no new errors
- [ ] Verify rate limiting still works (API requests not incorrectly rejected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)