### PR TITLE
perf: reduce stat sync cache invalidations from ~200 to ~6

### DIFF
--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -34,13 +34,13 @@ crons.interval(
 )
 
 // Syncs accumulated stat deltas to skill documents every 6 hours.
-// Runs infrequently to avoid thundering-herd reactive query invalidation.
-// Uses processedAt field to track progress (independent of the action cursor).
+// Uses action pattern: reads via queries (no cache impact), then applies
+// all skill doc patches in chunks of 500 (~6 invalidations instead of ~200).
 crons.interval(
   'skill-doc-stat-sync',
   { hours: 6 },
-  internal.skillStatEvents.processSkillStatEventsInternal,
-  { batchSize: 500 },
+  internal.skillStatEvents.syncSkillDocStatsAction,
+  {},
 )
 
 crons.interval(

--- a/convex/skillStatEvents.ts
+++ b/convex/skillStatEvents.ts
@@ -552,3 +552,174 @@ export const processSkillStatEventsAction = internalAction({
     }
   },
 })
+
+// ============================================================================
+// Skill doc stat sync — action-based to minimize cache invalidation
+// ============================================================================
+
+const SKILL_DOC_SYNC_CHUNK_SIZE = 500
+
+/** Read a batch of events where processedAt is undefined. */
+export const getUnprocessedStatEventsBatch = internalQuery({
+  args: { limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    return ctx.db
+      .query('skillStatEvents')
+      .withIndex('by_unprocessed', (q) => q.eq('processedAt', undefined))
+      .take(args.limit ?? 500)
+  },
+})
+
+const skillDocDeltaValidator = v.object({
+  skillId: v.id('skills'),
+  downloads: v.number(),
+  stars: v.number(),
+  comments: v.number(),
+  installsAllTime: v.number(),
+  installsCurrent: v.number(),
+})
+
+/**
+ * Patch skill documents with aggregated stat deltas.
+ * Each call = one transaction = one cache invalidation for skillSearchDigest.
+ * Chunk size of 500 keeps reads well under the 8 MB limit (~1.4 MB).
+ */
+export const applySkillDocStatDeltas = internalMutation({
+  args: { skillDeltas: v.array(skillDocDeltaValidator) },
+  handler: async (ctx, args) => {
+    let patched = 0
+    for (const delta of args.skillDeltas) {
+      if (
+        delta.downloads === 0 &&
+        delta.stars === 0 &&
+        delta.comments === 0 &&
+        delta.installsAllTime === 0 &&
+        delta.installsCurrent === 0
+      ) {
+        continue
+      }
+      const skill = await ctx.db.get(delta.skillId)
+      if (!skill) continue
+      const patch = applySkillStatDeltas(skill, {
+        downloads: delta.downloads,
+        stars: delta.stars,
+        comments: delta.comments,
+        installsAllTime: delta.installsAllTime,
+        installsCurrent: delta.installsCurrent,
+      })
+      await ctx.db.patch(skill._id, patch)
+      patched += 1
+    }
+    return { patched }
+  },
+})
+
+/**
+ * Mark events as processed. No subscribers on skillStatEvents, so this
+ * causes zero cache invalidation regardless of batch size.
+ */
+export const markEventsProcessed = internalMutation({
+  args: { eventIds: v.array(v.id('skillStatEvents')) },
+  handler: async (ctx, args) => {
+    const now = Date.now()
+    for (const id of args.eventIds) {
+      await ctx.db.patch(id, { processedAt: now })
+    }
+    return { marked: args.eventIds.length }
+  },
+})
+
+/**
+ * Action-based skill doc stat sync. Replaces processSkillStatEventsInternal.
+ *
+ * Reads ALL unprocessed events via queries (no cache impact), aggregates
+ * deltas in memory, then applies to skill docs in chunks of 500 skills.
+ * Each chunk = one mutation = one cache invalidation.
+ *
+ * For ~3000 skills this produces ~6 invalidations instead of ~200.
+ */
+export const syncSkillDocStatsAction = internalAction({
+  args: { batchSize: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const queryBatchSize = args.batchSize ?? 500
+
+    // Phase 1: Read all unprocessed events and aggregate in memory.
+    // We mark events processed in batches as we read them so subsequent
+    // query calls return the next page of unprocessed events.
+    const aggregatedBySkill = new Map<
+      Id<'skills'>,
+      { downloads: number; stars: number; comments: number; installsAllTime: number; installsCurrent: number }
+    >()
+    let totalEvents = 0
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const events = (await ctx.runQuery(
+        internal.skillStatEvents.getUnprocessedStatEventsBatch,
+        { limit: queryBatchSize },
+      )) as Doc<'skillStatEvents'>[]
+
+      if (events.length === 0) break
+
+      // Mark this batch as processed immediately so the next query
+      // returns the next page. This writes to skillStatEvents only
+      // (no subscribers = zero cache invalidation).
+      const eventIds = events.map((e) => e._id)
+      await ctx.runMutation(internal.skillStatEvents.markEventsProcessed, {
+        eventIds,
+      })
+
+      for (const event of events) {
+        const deltas = aggregateEvents([event])
+        let existing = aggregatedBySkill.get(event.skillId)
+        if (!existing) {
+          existing = { downloads: 0, stars: 0, comments: 0, installsAllTime: 0, installsCurrent: 0 }
+          aggregatedBySkill.set(event.skillId, existing)
+        }
+        existing.downloads += deltas.downloads
+        existing.stars += deltas.stars
+        existing.comments += deltas.comments
+        existing.installsAllTime += deltas.installsAllTime
+        existing.installsCurrent += deltas.installsCurrent
+      }
+
+      totalEvents += events.length
+
+      // If we got fewer than requested, we've exhausted unprocessed events
+      if (events.length < queryBatchSize) break
+    }
+
+    if (totalEvents === 0) {
+      console.log('[SKILL-DOC-SYNC] No unprocessed events')
+      return { totalEvents: 0, uniqueSkills: 0, chunks: 0 }
+    }
+
+    console.log(
+      `[SKILL-DOC-SYNC] Aggregated ${totalEvents} events across ${aggregatedBySkill.size} skills`,
+    )
+
+    // Phase 2: Apply skill doc patches in chunks (each chunk = one invalidation)
+    const allDeltas = Array.from(aggregatedBySkill.entries()).map(([skillId, d]) => ({
+      skillId,
+      ...d,
+    }))
+
+    let chunks = 0
+    for (let i = 0; i < allDeltas.length; i += SKILL_DOC_SYNC_CHUNK_SIZE) {
+      const chunk = allDeltas.slice(i, i + SKILL_DOC_SYNC_CHUNK_SIZE)
+      await ctx.runMutation(internal.skillStatEvents.applySkillDocStatDeltas, {
+        skillDeltas: chunk,
+      })
+      chunks += 1
+      console.log(
+        `[SKILL-DOC-SYNC] Applied chunk ${chunks} (${chunk.length} skills)`,
+      )
+    }
+
+    console.log(
+      `[SKILL-DOC-SYNC] Done: ${totalEvents} events, ${aggregatedBySkill.size} skills, ${chunks} chunks`,
+    )
+
+    return { totalEvents, uniqueSkills: aggregatedBySkill.size, chunks }
+  },
+})

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -2681,17 +2681,31 @@ export const listPublicPageV2 = query({
       args,
     )
 
-    // Build a map from skillId → pre-resolved owner info from digest rows
-    const preResolvedOwners = new Map<
-      Id<'skills'>,
-      { ownerHandle: string | null; owner: ReturnType<typeof toPublicUser> | null }
-    >()
+    // Build response directly from digest — no extra table reads.
+    // This keeps the query's read set to skillSearchDigest only, so writes
+    // to skills/users/skillVersions never invalidate the cache.
+    const filteredIds = new Set(filteredPage.map((s) => s._id))
+    const items: PublicSkillEntry[] = []
     for (const digest of result.page) {
-      const info = digestToOwnerInfo(digest)
-      if (info) preResolvedOwners.set(digest.skillId, info)
+      if (!filteredIds.has(digest.skillId)) continue
+      const hydratable = digestToHydratableSkill(digest)
+      const publicSkill = toPublicSkill(hydratable)
+      if (!publicSkill) continue
+      const ownerInfo = digestToOwnerInfo(digest)
+      if (!ownerInfo?.owner) continue
+      const latestVersion = digest.latestVersionSummary
+        ? toPublicSkillListVersionFromSummary(
+            digest.latestVersionSummary,
+            digest.latestVersionId,
+          )
+        : null
+      items.push({
+        skill: publicSkill,
+        latestVersion,
+        ownerHandle: ownerInfo.ownerHandle,
+        owner: ownerInfo.owner,
+      })
     }
-
-    const items = await buildPublicSkillEntries(ctx, filteredPage, { preResolvedOwners })
     return { ...result, page: items }
   },
 })


### PR DESCRIPTION
## Summary

- **Stat sync cron**: Replace the old `processSkillStatEventsInternal` (which fired ~200 back-to-back mutations via `runAfter(0)`) with `syncSkillDocStatsAction` — an action that reads all unprocessed events via queries, aggregates deltas in memory, then applies patches in chunks of 500 skills per mutation. This reduces cache invalidations from ~200 to ~6 per cron run.
- **listPublicPageV2**: Build response directly from `skillSearchDigest` rows instead of calling `buildPublicSkillEntries` (which fell back to `ctx.db.get()` for owners/versions). The query now touches only `skillSearchDigest` — writes to `skills`, `users`, or `skillVersions` no longer invalidate its cache.

### Before
During the 6-hour cron, `listPublicPageV2` latency spiked from 2-4ms to 450-680ms for the entire duration (~200 sequential cache busts). At ~80 concurrent queries/sec this caused massive bandwidth spikes.

### After
- ~6 invalidations instead of ~200 (one per 500-skill chunk)
- `listPublicPageV2` read set limited to `skillSearchDigest` only — immune to writes on other tables

## Test plan

- [x] `npx convex dev --once` typechecks pass
- [ ] Deploy to prod, trigger `syncSkillDocStatsAction` manually, verify logs show chunked application
- [ ] Confirm `listPublicPageV2` latency stays at 2-4ms during cron run
- [ ] Check `npx convex insights --prod` for reduced bandwidth after one cron cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)