### PR TITLE
perf: listPublicPageV2 reads only from digest, no extra table joins

### DIFF
--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -2684,11 +2684,11 @@ export const listPublicPageV2 = query({
     // Build response directly from digest — no extra table reads.
     // This keeps the query's read set to skillSearchDigest only, so writes
     // to skills/users/skillVersions never invalidate the cache.
-    const filteredIds = new Set(filteredPage.map((s) => s._id))
+    const filteredMap = new Map(filteredPage.map((s) => [s._id, s]))
     const items: PublicSkillEntry[] = []
     for (const digest of result.page) {
-      if (!filteredIds.has(digest.skillId)) continue
-      const hydratable = digestToHydratableSkill(digest)
+      const hydratable = filteredMap.get(digest.skillId)
+      if (!hydratable) continue
       const publicSkill = toPublicSkill(hydratable)
       if (!publicSkill) continue
       const ownerInfo = digestToOwnerInfo(digest)


### PR DESCRIPTION
## Summary

- Build `listPublicPageV2` response directly from `skillSearchDigest` rows instead of calling `buildPublicSkillEntries`
- Eliminates all `ctx.db.get()` calls for owners and versions — the query's read set now touches **only** `skillSearchDigest`
- Writes to `skills`, `users`, or `skillVersions` no longer invalidate the query cache for this endpoint

This is possible now that digest rows have `ownerHandle`/`ownerName`/`ownerDisplayName`/`ownerImage` and `latestVersionSummary` backfilled.

## Test plan

- [x] `npx convex dev --once` typechecks pass
- [ ] Deploy, confirm browse page still renders all skill cards with owner + version info
- [ ] Verify `listPublicPageV2` stays cached (2-4ms) even during writes to `skills`/`users` tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)