### PR TITLE
fix: typecheck error in listPublicPageV2 test

### DIFF
--- a/convex/skills.listPublicPageV2.test.ts
+++ b/convex/skills.listPublicPageV2.test.ts
@@ -366,7 +366,7 @@ describe('skills.listPublicPageV2', () => {
     expect(result.page).toHaveLength(1)
     expect(result.page[0]?.skill.slug).toBe('old')
     // No db.get fallback — latestVersion is null when summary is absent
-    expect(result.page[0]?.latestVersion).toBeNull()
+    expect((result.page[0] as Record<string, unknown>)?.latestVersion).toBeNull()
     expect(ctx.db.get).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
## Summary

- Fixes CI typecheck failure introduced in #947
- `result.page[0]?.latestVersion` doesn't compile because the handler's return type narrows page items to `{ skill: { slug: string } }`
- Cast to `Record<string, unknown>` to access `latestVersion`

## Test plan

- [x] `bun run test -- convex/skills.listPublicPageV2.test.ts` — 11/11 pass
- [x] `bunx tsc --noEmit` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)