### PR TITLE
chore: add listPublicPageV3 to identify stale-tab websocket traffic

### DIFF
--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -2710,6 +2710,92 @@ export const listPublicPageV2 = query({
   },
 })
 
+/** Identical to listPublicPageV2 — used to distinguish new client traffic from stale tabs. */
+export const listPublicPageV3 = query({
+  args: {
+    paginationOpts: paginationOptsValidator,
+    sort: v.optional(
+      v.union(
+        v.literal('newest'),
+        v.literal('updated'),
+        v.literal('downloads'),
+        v.literal('installs'),
+        v.literal('stars'),
+        v.literal('name'),
+      ),
+    ),
+    dir: v.optional(v.union(v.literal('asc'), v.literal('desc'))),
+    highlightedOnly: v.optional(v.boolean()),
+    nonSuspiciousOnly: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const sort = args.sort ?? 'newest'
+    const dir = args.dir ?? (sort === 'name' ? 'asc' : 'desc')
+    const { numItems, cursor: initialCursor } = normalizePublicListPagination(
+      args.paginationOpts,
+    )
+
+    const runPaginateBase = (cursor: string | null) =>
+      ctx.db
+        .query('skillSearchDigest')
+        .withIndex(SORT_INDEXES[sort], (q) => q.eq('softDeletedAt', undefined))
+        .order(dir)
+        .paginate({ cursor, numItems })
+
+    const runPaginateCompound = (cursor: string | null) =>
+      ctx.db
+        .query('skillSearchDigest')
+        .withIndex(NONSUSPICIOUS_SORT_INDEXES[sort], (q) =>
+          q.eq('softDeletedAt', undefined).eq('isSuspicious', false),
+        )
+        .order(dir)
+        .paginate({ cursor, numItems })
+
+    let result = await paginateWithStaleCursorRecovery(
+      args.nonSuspiciousOnly ? runPaginateCompound : runPaginateBase,
+      initialCursor,
+    )
+
+    if (
+      args.nonSuspiciousOnly &&
+      initialCursor === null &&
+      result.page.length === 0 &&
+      !result.isDone
+    ) {
+      result = await paginateWithStaleCursorRecovery(runPaginateBase, null)
+    }
+
+    const filteredPage = filterPublicSkillPage(
+      result.page.map(digestToHydratableSkill),
+      args,
+    )
+
+    const filteredMap = new Map(filteredPage.map((s) => [s._id, s]))
+    const items: PublicSkillEntry[] = []
+    for (const digest of result.page) {
+      const hydratable = filteredMap.get(digest.skillId)
+      if (!hydratable) continue
+      const publicSkill = toPublicSkill(hydratable)
+      if (!publicSkill) continue
+      const ownerInfo = digestToOwnerInfo(digest)
+      if (!ownerInfo?.owner) continue
+      const latestVersion = digest.latestVersionSummary
+        ? toPublicSkillListVersionFromSummary(
+            digest.latestVersionSummary,
+            digest.latestVersionId,
+          )
+        : null
+      items.push({
+        skill: publicSkill,
+        latestVersion,
+        ownerHandle: ownerInfo.ownerHandle,
+        owner: ownerInfo.owner,
+      })
+    }
+    return { ...result, page: items }
+  },
+})
+
 function filterPublicSkillPage(
   page: HydratableSkill[],
   args: { highlightedOnly?: boolean; nonSuspiciousOnly?: boolean },

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -40,7 +40,7 @@ function SkillsHome() {
       .then((r) => { if (!cancelled) setHighlighted(r as SkillPageEntry[]) })
       .catch(() => {})
     convexHttp
-      .query(api.skills.listPublicPageV2, {
+      .query(api.skills.listPublicPageV3, {
         paginationOpts: { cursor: null, numItems: 12 },
         sort: 'downloads',
         dir: 'desc',

--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -70,7 +70,7 @@ export function useSkillsBrowseModel({
   const fetchPage = useCallback(
     async (cursor: string | null, generation: number) => {
       try {
-        const result = await convexHttp.query(api.skills.listPublicPageV2, {
+        const result = await convexHttp.query(api.skills.listPublicPageV3, {
           paginationOpts: { cursor, numItems: pageSize },
           sort: listSort,
           dir,


### PR DESCRIPTION
## Summary

- Duplicates `listPublicPageV2` as `listPublicPageV3` (separate Convex function)
- Switches both frontend callers (homepage + browse page) to V3
- Any `listPublicPageV2` calls remaining in the dashboard after deploy are confirmed stale browser tabs

This is a diagnostic change to determine whether the 25% websocket calls to `listPublicPageV2` are from old client bundles.

## Test plan

- [ ] Deploy, check dashboard — V2 calls = stale tabs, V3 calls = current clients
- [ ] Once confirmed, can delete V3 and rename back if desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)