### PR TITLE
feat: add listPublicPageV4 backend query (frontend stays on V3)

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -40,8 +40,8 @@ function SkillsHome() {
       .then((r) => { if (!cancelled) setHighlighted(r as SkillPageEntry[]) })
       .catch(() => {})
     convexHttp
-      .query(api.skills.listPublicPageV4, {
-        numItems: 12,
+      .query(api.skills.listPublicPageV3, {
+        paginationOpts: { cursor: null, numItems: 12 },
         sort: 'downloads',
         dir: 'desc',
         nonSuspiciousOnly: true,

--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -70,9 +70,8 @@ export function useSkillsBrowseModel({
   const fetchPage = useCallback(
     async (cursor: string | null, generation: number) => {
       try {
-        const result = await convexHttp.query(api.skills.listPublicPageV4, {
-          cursor: cursor ?? undefined,
-          numItems: pageSize,
+        const result = await convexHttp.query(api.skills.listPublicPageV3, {
+          paginationOpts: { cursor, numItems: pageSize },
           sort: listSort,
           dir,
           highlightedOnly,
@@ -80,8 +79,8 @@ export function useSkillsBrowseModel({
         })
         if (generation !== fetchGeneration.current) return
         setListResults((prev) => (cursor ? [...prev, ...result.page] : result.page))
-        setListCursor(!result.hasMore ? null : result.nextCursor)
-        setListStatus(!result.hasMore ? 'done' : 'idle')
+        setListCursor(result.isDone ? null : result.continueCursor)
+        setListStatus(result.isDone ? 'done' : 'idle')
       } catch (err) {
         if (generation !== fetchGeneration.current) return
         console.error('Failed to fetch skills page:', err)


### PR DESCRIPTION
## Summary
- **Add `listPublicPageV4` query** using `convex-helpers` `getPage()` for deterministic index-key cursors. Enables shared query caching across all users.
- **Gut V1 (`listPublicPage`) and V2 (`listPublicPageV2`)** — return empty results with zero DB reads.
- **Keep V3 intact** — frontend still uses V3. V4 is deployed but not wired up on the frontend yet (V4 was failing in production, needs investigation before frontend switchover).

## Context
V4 was deployed and wired up in PR #950 but failed in production. This PR ships just the backend query so it can be tested via the dashboard/API before switching the frontend over in a follow-up PR.

## Test plan
- [x] `npx convex dev --once` typechecks pass
- [x] CI passes (lint, test, typecheck, build)
- [ ] Test V4 query via Convex dashboard before frontend switchover
- [ ] Frontend switchover in a separate PR after V4 is verified in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)