### PR TITLE
fix: install card text overflow style

### DIFF
--- a/src/components/SkillInstallCard.tsx
+++ b/src/components/SkillInstallCard.tsx
@@ -160,15 +160,15 @@ export function SkillInstallCard({ clawdis, osLabels }: SkillInstallCardProps) {
               {installSpecs.map((spec, index) => {
                 const command = formatInstallCommand(spec)
                 return (
-                  <div key={`${spec.id ?? spec.kind}-${index}`} className="stat">
-                    <div>
+                  <div key={`${spec.id ?? spec.kind}-${index}`} className="skill-install-entry">
+                    <div className="skill-install-entry-body">
                       <strong>{spec.label ?? formatInstallLabel(spec)}</strong>
                       {spec.bins?.length ? (
-                        <div style={{ color: 'var(--ink-soft)', fontSize: '0.85rem' }}>
+                        <div className="skill-install-meta">
                           Bins: {spec.bins.join(', ')}
                         </div>
                       ) : null}
-                      {command ? <code>{command}</code> : null}
+                      {command ? <code className="skill-install-command">{command}</code> : null}
                     </div>
                   </div>
                 )

--- a/src/styles.css
+++ b/src/styles.css
@@ -2071,6 +2071,7 @@ code {
 
 .skill-panel {
   display: grid;
+  align-content: start;
   gap: 10px;
   padding: 14px;
   border-radius: 16px;
@@ -2081,6 +2082,43 @@ code {
 .skill-panel-body {
   display: grid;
   gap: 8px;
+  align-content: start;
+}
+
+.skill-install-entry {
+  min-width: 0;
+}
+
+.skill-install-entry-body {
+  color: var(--ink-soft);
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+  width: 100%;
+  font-size: 0.9rem;
+}
+
+.skill-install-entry-body strong {
+  color: inherit;
+  font-size: inherit;
+  line-height: 1.45;
+}
+
+.skill-install-meta {
+  color: var(--ink-soft);
+  font-size: inherit;
+}
+
+.skill-install-command {
+  display: block;
+  max-width: 100%;
+  color: var(--ink-soft);
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  white-space: pre-wrap;
+  font-size: inherit;
+  line-height: 1.55;
+  font-family: var(--font-mono);
 }
 
 .diff-card {


### PR DESCRIPTION
## Summary

Fixes the install card layout on skill detail pages.

## Changes

- replace generic install entry markup with dedicated install-card structure
- improve spacing and typography for install entries
- make install commands wrap cleanly inside the card
- keep install metadata styling consistent with the surrounding panels

before
<img width="1176" height="202" alt="PixPin_2026-03-17_20-06-16" src="https://github.com/user-attachments/assets/fa8c8238-9d44-420e-9006-e2c921f9d321" />

after
<img width="1145" height="236" alt="PixPin_2026-03-17_20-07-52" src="https://github.com/user-attachments/assets/69d97cac-d619-4ff3-9398-1d2e59cb908c" />



## Files changed

- `src/components/SkillInstallCard.tsx`
- `src/styles.css`

## Notes

- style-only change
- no backend or behavior changes
