### PR TITLE
refactor: skill card with tag

### DIFF
--- a/src/components/SkillCard.tsx
+++ b/src/components/SkillCard.tsx
@@ -20,6 +20,7 @@ export function SkillCard({ skill, badge, chip, platformLabels, summaryFallback,
 
   return (
     <Link to={link} className="card skill-card">
+      <h3 className="skill-card-title">{skill.displayName}</h3>
       {hasTags ? (
         <div className="skill-card-tags">
           {badges.map((label) => (
@@ -33,7 +34,6 @@ export function SkillCard({ skill, badge, chip, platformLabels, summaryFallback,
           ))}
         </div>
       ) : null}
-      <h3 className="skill-card-title">{skill.displayName}</h3>
       <p className="skill-card-summary">{skill.summary ?? summaryFallback}</p>
       <div className="skill-card-footer">{meta}</div>
     </Link>


### PR DESCRIPTION
## Summary

Moves skill card tags below the title to improve card hierarchy and readability in the skills grid.

## What Changed

- Updated [src/components/SkillCard.tsx](/Users/geoffrey/Desktop/AI/clawhub/src/components/SkillCard.tsx) so the skill title renders before the tag row.
- Kept the existing tag styling and behavior unchanged; this is a layout-only refactor.

before
<img width="1844" height="1146" alt="image" src="https://github.com/user-attachments/assets/7cc91069-09a8-493f-93ee-672e4bc733ec" />

after
<img width="1834" height="1180" alt="image" src="https://github.com/user-attachments/assets/164c86c3-f1e0-4e6f-ae0f-2c7966cdacde" />


## Why

The previous layout put badges/platform tags above the title, which made card scanning less natural. Rendering the title first gives the card a clearer reading order:

1. title
2. tags
3. summary
4. owner/stats

This works better for both promotional badges like `Highlighted` and technical tags like OS labels.

