### PR TITLE
fix: responsible size for upload skill page

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -3182,6 +3182,7 @@ code {
   }
 
   .upload-page .upload-grid {
+    grid-template-columns: 1fr;
     gap: 14px;
   }
 


### PR DESCRIPTION
## Summary

Improves the upload page on small screens by making the upload layout collapse to a single column at mobile/tablet widths.

## What Changed

- Updated [src/styles.css](/Users/geoffrey/Desktop/AI/clawhub/src/styles.css) so the `max-width: 900px` responsive rule applies directly to `.upload-page .upload-grid`.
- Ensured the upload form panels stack vertically instead of staying in a cramped two-column layout on smaller viewports.

## Why

The upload page was still rendering side-by-side panels at smaller sizes because the base `.upload-page .upload-grid` selector was more specific than the generic mobile override. This caused the form, file picker, validation panel, and license panel to feel compressed and hard to read.

Applying the responsive override to the same selector fixes that specificity issue and gives the upload flow a cleaner one-column layout on smaller screens.

## Verification
before

<img width="860" height="1782" alt="image" src="https://github.com/user-attachments/assets/770595d9-715a-4263-bfdd-5ea9950fcf0d" />


after
<img width="778" height="1618" alt="image" src="https://github.com/user-attachments/assets/d800a78f-d2e0-4401-ac3e-4909b830fefa" />
