### PR TITLE
fix: my skills dashboard style

### DIFF
--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { useQuery } from 'convex/react'
-import { Clock, Package, Plus, Upload } from 'lucide-react'
+import { Clock, Layers3, Package, Plus, Star, Upload } from 'lucide-react'
 import { api } from '../../convex/_generated/api'
 import type { Doc } from '../../convex/_generated/dataModel'
 import { formatCompactStat } from '../lib/numberFormat'
@@ -85,11 +85,18 @@ function SkillCard({ skill, ownerHandle }: { skill: DashboardSkill; ownerHandle:
         </div>
         {skill.summary && <p className="dashboard-skill-description">{skill.summary}</p>}
         <div className="dashboard-skill-stats">
-          <span>
-            <Package size={13} aria-hidden="true" /> {formatCompactStat(skill.stats.downloads)}
+          <span className="dashboard-skill-stat">
+            <Package className="dashboard-skill-stat-icon" size={13} aria-hidden="true" />
+            <span>{formatCompactStat(skill.stats.downloads)}</span>
           </span>
-          <span>★ {formatCompactStat(skill.stats.stars)}</span>
-          <span>{skill.stats.versions} v</span>
+          <span className="dashboard-skill-stat">
+            <Star className="dashboard-skill-stat-icon" size={13} aria-hidden="true" />
+            <span>{formatCompactStat(skill.stats.stars)}</span>
+          </span>
+          <span className="dashboard-skill-stat">
+            <Layers3 className="dashboard-skill-stat-icon" size={13} aria-hidden="true" />
+            <span>{skill.stats.versions} v</span>
+          </span>
         </div>
       </div>
       <div className="dashboard-skill-actions">

--- a/src/styles.css
+++ b/src/styles.css
@@ -3449,10 +3449,28 @@ html.theme-transition::view-transition-new(theme) {
 
 .dashboard-skill-stats {
   display: flex;
-  gap: 12px;
-  margin-top: 8px;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.dashboard-skill-stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, var(--surface) 82%, var(--bg-glow-1));
+  color: var(--ink-soft);
   font-size: 0.8rem;
-  color: var(--color-muted);
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.dashboard-skill-stat-icon {
+  flex: 0 0 auto;
+  color: var(--accent);
 }
 
 .dashboard-skill-actions {


### PR DESCRIPTION
## Summary

Refactors the “My Skills” dashboard cards to improve stat readability and visual hierarchy.

## What Changed

- Updated [src/routes/dashboard.tsx](/Users/geoffrey/Desktop/AI/clawhub/src/routes/dashboard.tsx) to render downloads, stars, and version count as structured stat items with icons.
- Added pill-style metric styling in [src/styles.css](/Users/geoffrey/Desktop/AI/clawhub/src/styles.css) for the dashboard skill stats.
- Kept the existing card layout and actions intact while improving the lower stat row presentation.

before
<img width="2428" height="498" alt="image" src="https://github.com/user-attachments/assets/93409511-fcca-483c-9bb6-5c1ff2ac243b" />
<img width="2268" height="232" alt="image" src="https://github.com/user-attachments/assets/fe9c796c-1915-4f1a-944e-6fd22d06e441" />

after
<img width="2442" height="432" alt="image" src="https://github.com/user-attachments/assets/5cf2b428-bbd4-43bd-b751-9f242f8a313a" />
<img width="2380" height="424" alt="image" src="https://github.com/user-attachments/assets/0713b573-a239-42c5-9ddd-c300a5846928" />


## Why

The previous stat row was loose inline text, which made the lower part of each card feel uneven and harder to scan. Converting those values into compact icon + value pills gives the cards a cleaner rhythm and makes downloads, stars, and versions easier to compare at a glance.
