### PR TITLE
Add owner skill delete flow

### DIFF
--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -4911,6 +4911,16 @@ export const mergeOwnedSkillIntoCanonical = mutation({
   },
 })
 
+export const deleteOwnedSkill = mutation({
+  args: {
+    slug: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const { user } = await requireUser(ctx)
+    return setSkillSoftDeletedByActor(ctx, user._id, args.slug, true)
+  },
+})
+
 export const renameOwnedSkillInternal = internalMutation({
   args: {
     actorUserId: v.id('users'),
@@ -6072,50 +6082,66 @@ export const setSkillSoftDeletedInternal = internalMutation({
     deleted: v.boolean(),
   },
   handler: async (ctx, args) => {
-    const user = await ctx.db.get(args.userId)
-    if (!user || user.deletedAt || user.deactivatedAt)
-      throw new Error('User not found')
-
-    const slug = args.slug.trim().toLowerCase()
-    if (!slug) throw new Error('Slug required')
-
-    const skill = await ctx.db
-      .query('skills')
-      .withIndex('by_slug', (q) => q.eq('slug', slug))
-      .unique()
-    if (!skill) throw new Error('Skill not found')
-
-    if (skill.ownerUserId !== args.userId) {
-      assertModerator(user)
-    }
-
-    const now = Date.now()
-    const patch: Partial<Doc<'skills'>> = {
-      softDeletedAt: args.deleted ? now : undefined,
-      moderationStatus: args.deleted ? 'hidden' : 'active',
-      hiddenAt: args.deleted ? now : undefined,
-      hiddenBy: args.deleted ? args.userId : undefined,
-      lastReviewedAt: now,
-      updatedAt: now,
-    }
-    const nextSkill = { ...skill, ...patch }
-    await ctx.db.patch(skill._id, patch)
-    await adjustGlobalPublicCountForSkillChange(ctx, skill, nextSkill)
-
-    await setSkillEmbeddingsSoftDeleted(ctx, skill._id, args.deleted, now)
-
-    await ctx.db.insert('auditLogs', {
-      actorUserId: args.userId,
-      action: args.deleted ? 'skill.delete' : 'skill.undelete',
-      targetType: 'skill',
-      targetId: skill._id,
-      metadata: { slug, softDeletedAt: args.deleted ? now : null },
-      createdAt: now,
+    return setSkillSoftDeletedByActor(ctx, args.userId, args.slug, args.deleted, {
+      allowModerator: true,
     })
-
-    return { ok: true as const }
   },
 })
+
+async function setSkillSoftDeletedByActor(
+  ctx: MutationCtx,
+  actorUserId: Id<'users'>,
+  slugArg: string,
+  deleted: boolean,
+  options?: { allowModerator?: boolean },
+) {
+  const user = await ctx.db.get(actorUserId)
+  if (!user || user.deletedAt || user.deactivatedAt) {
+    throw new ConvexError('Forbidden')
+  }
+
+  const slug = slugArg.trim().toLowerCase()
+  if (!slug) throw new ConvexError('Slug required')
+
+  const skill = await ctx.db
+    .query('skills')
+    .withIndex('by_slug', (q) => q.eq('slug', slug))
+    .unique()
+  if (!skill) throw new ConvexError('Skill not found')
+
+  if (skill.ownerUserId !== actorUserId) {
+    if (!options?.allowModerator) {
+      throw new ConvexError('Forbidden')
+    }
+    assertModerator(user)
+  }
+
+  const now = Date.now()
+  const patch: Partial<Doc<'skills'>> = {
+    softDeletedAt: deleted ? now : undefined,
+    moderationStatus: deleted ? 'hidden' : 'active',
+    hiddenAt: deleted ? now : undefined,
+    hiddenBy: deleted ? actorUserId : undefined,
+    lastReviewedAt: now,
+    updatedAt: now,
+  }
+  const nextSkill = { ...skill, ...patch }
+  await ctx.db.patch(skill._id, patch)
+  await adjustGlobalPublicCountForSkillChange(ctx, skill, nextSkill)
+
+  await setSkillEmbeddingsSoftDeleted(ctx, skill._id, deleted, now)
+
+  await ctx.db.insert('auditLogs', {
+    actorUserId,
+    action: deleted ? 'skill.delete' : 'skill.undelete',
+    targetType: 'skill',
+    targetId: skill._id,
+    metadata: { slug, softDeletedAt: deleted ? now : null },
+    createdAt: now,
+  })
+
+  return { ok: true as const }
+}
 
 function clampInt(value: number, min: number, max: number) {
   const rounded = Number.isFinite(value) ? Math.round(value) : min

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -5,6 +5,7 @@ import { SkillDetailPage } from '../components/SkillDetailPage'
 
 const navigateMock = vi.fn()
 const useAuthStatusMock = vi.fn()
+const mutationFnMock = vi.fn()
 
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => navigateMock,
@@ -15,7 +16,7 @@ const getReadmeMock = vi.fn()
 
 vi.mock('convex/react', () => ({
   useQuery: (...args: unknown[]) => useQueryMock(...args),
-  useMutation: () => vi.fn(),
+  useMutation: () => mutationFnMock,
   useAction: () => getReadmeMock,
 }))
 
@@ -34,6 +35,7 @@ describe('SkillDetailPage', () => {
     getReadmeMock.mockReset()
     navigateMock.mockReset()
     useAuthStatusMock.mockReset()
+    mutationFnMock.mockReset()
     getReadmeMock.mockResolvedValue({ text: '' })
     useAuthStatusMock.mockReturnValue({
       isAuthenticated: false,
@@ -325,6 +327,26 @@ describe('SkillDetailPage', () => {
     expect(await screen.findByText(/Owner tools/i)).toBeTruthy()
     expect(screen.getByRole('button', { name: /Rename and redirect/i })).toBeTruthy()
     expect(screen.getByRole('button', { name: /Merge into target/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Delete skill/i })).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /Delete skill/i }))
+
+    const confirmButton = screen.getByRole('button', { name: /Confirm delete/i }) as HTMLButtonElement
+    expect(confirmButton.disabled).toBe(true)
+
+    fireEvent.change(screen.getByPlaceholderText(/type "delete"/i), {
+      target: { value: 'delete' },
+    })
+    expect(confirmButton.disabled).toBe(false)
+
+    fireEvent.click(confirmButton)
+
+    await waitFor(() => {
+      expect(mutationFnMock).toHaveBeenCalledWith({ slug: 'weather' })
+    })
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith({ to: '/dashboard' })
+    })
   })
 
   it('defers compare version query until compare tab is requested', async () => {

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -345,7 +345,7 @@ describe('SkillDetailPage', () => {
       expect(mutationFnMock).toHaveBeenCalledWith({ slug: 'weather' })
     })
     await waitFor(() => {
-      expect(navigateMock).toHaveBeenCalledWith({ to: '/dashboard' })
+      expect(navigateMock).toHaveBeenCalledWith({ to: '/dashboard', replace: true })
     })
   })
 

--- a/src/components/SkillOwnershipPanel.tsx
+++ b/src/components/SkillOwnershipPanel.tsx
@@ -41,13 +41,17 @@ export function SkillOwnershipPanel({
   const navigate = useNavigate()
   const renameOwnedSkill = useMutation(api.skills.renameOwnedSkill)
   const mergeOwnedSkillIntoCanonical = useMutation(api.skills.mergeOwnedSkillIntoCanonical)
+  const deleteOwnedSkill = useMutation(api.skills.deleteOwnedSkill)
 
   const [renameSlug, setRenameSlug] = useState(slug)
   const [mergeTargetSlug, setMergeTargetSlug] = useState(ownedSkills[0]?.slug ?? '')
+  const [deleteConfirmation, setDeleteConfirmation] = useState('')
+  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const ownerHref = (nextSlug: string) => buildSkillHref(ownerHandle, ownerId, nextSlug)
+  const isDeleteConfirmed = deleteConfirmation.trim().toLowerCase() === 'delete'
 
   const handleRename = async () => {
     const nextSlug = renameSlug.trim().toLowerCase()
@@ -104,14 +108,28 @@ export function SkillOwnershipPanel({
     }
   }
 
+  const handleDelete = async () => {
+    if (!isDeleteConfirmed) return
+    setIsSubmitting(true)
+    setError(null)
+    try {
+      await deleteOwnedSkill({ slug })
+      await navigate({ to: '/dashboard' })
+    } catch (deleteError) {
+      setError(formatMutationError(deleteError))
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
   return (
     <div className="card skill-owner-tools" data-skill-id={skillId}>
       <h2 className="section-title" style={{ marginTop: 0 }}>
         Owner tools
       </h2>
       <p className="section-subtitle">
-        Rename the canonical slug or fold this listing into another one you own. Old slugs stay as
-        redirects and stop polluting search/list views.
+        Rename the canonical slug, fold this listing into another one you own, or remove it from
+        public listings. Old slugs stay as redirects and stop polluting search/list views.
       </p>
 
       <div className="skill-owner-tools-grid">
@@ -165,12 +183,74 @@ export function SkillOwnershipPanel({
             Merge into target
           </button>
         </div>
+        <div className="management-control management-control-stack skill-owner-delete-panel">
+          <span className="mono">delete skill</span>
+          <span className="section-subtitle">
+            Soft delete hides this skill from public view. Type <span className="mono">delete</span>{' '}
+            before confirming.
+          </span>
+          {showDeleteConfirmation ? (
+            <input
+              className="management-field"
+              value={deleteConfirmation}
+              onChange={(event) => setDeleteConfirmation(event.target.value)}
+              placeholder='type "delete"'
+              autoComplete="off"
+              spellCheck={false}
+              disabled={isSubmitting}
+            />
+          ) : (
+            <span className="section-subtitle">
+              This removes the current skill listing and returns you to your dashboard.
+            </span>
+          )}
+        </div>
+        <div className="management-control management-control-stack">
+          <span className="mono">delete action</span>
+          {showDeleteConfirmation ? (
+            <div className="skill-owner-delete-actions">
+              <button
+                className="btn btn-ghost"
+                type="button"
+                onClick={() => {
+                  if (isSubmitting) return
+                  setDeleteConfirmation('')
+                  setShowDeleteConfirmation(false)
+                }}
+                disabled={isSubmitting}
+              >
+                Cancel
+              </button>
+              <button
+                className="btn btn-danger management-action-btn"
+                type="button"
+                onClick={() => void handleDelete()}
+                disabled={isSubmitting || !isDeleteConfirmed}
+              >
+                {isSubmitting ? 'Deleting…' : 'Confirm delete'}
+              </button>
+            </div>
+          ) : (
+            <button
+              className="btn btn-danger management-action-btn"
+              type="button"
+              onClick={() => {
+                setDeleteConfirmation('')
+                setShowDeleteConfirmation(true)
+                setError(null)
+              }}
+              disabled={isSubmitting}
+            >
+              Delete skill
+            </button>
+          )}
+        </div>
       </div>
 
       {error ? <div className="stat" style={{ color: 'var(--danger)' }}>{error}</div> : null}
       <div className="section-subtitle">
-        Merge keeps the target live and hides this row. Versions and stats stay on the original
-        records for now.
+        Merge keeps the target live and hides this row. Delete is a soft delete and restore remains
+        CLI-only for now.
       </div>
     </div>
   )

--- a/src/components/SkillOwnershipPanel.tsx
+++ b/src/components/SkillOwnershipPanel.tsx
@@ -114,7 +114,7 @@ export function SkillOwnershipPanel({
     setError(null)
     try {
       await deleteOwnedSkill({ slug })
-      await navigate({ to: '/dashboard' })
+      await navigate({ to: '/dashboard', replace: true })
     } catch (deleteError) {
       setError(formatMutationError(deleteError))
     } finally {
@@ -213,7 +213,6 @@ export function SkillOwnershipPanel({
                 className="btn btn-ghost"
                 type="button"
                 onClick={() => {
-                  if (isSubmitting) return
                   setDeleteConfirmation('')
                   setShowDeleteConfirmation(false)
                 }}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1856,6 +1856,15 @@ code {
   grid-template-columns: minmax(0, 2fr) minmax(220px, 1fr);
 }
 
+.skill-owner-delete-panel {
+  align-self: stretch;
+}
+
+.skill-owner-delete-actions {
+  display: grid;
+  gap: 10px;
+}
+
 @media (max-width: 820px) {
   .skill-owner-tools-grid {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- add an owner-facing soft-delete action to the existing skill owner tools panel
- require users to click delete first, then type `delete` before enabling the destructive confirm action
- reuse the existing Convex soft-delete behavior on the backend and cover the new UI flow with a focused test

## Test plan
- [x] `bun run test src/__tests__/skill-detail-page.test.tsx`
- [x] `bun run lint`
- [ ] Sign in as the skill owner on a deployed preview and verify `Delete skill` appears under owner tools
- [ ] Click `Delete skill`, confirm the text box only appears after the click, and verify `Confirm delete` stays disabled until `delete` is entered
- [ ] Confirm the skill is removed from the dashboard/listing after deletion


Made with [Cursor](https://cursor.com)