### PR TITLE
feat: add bartrd skill

### DIFF
--- a/skills/getbartrd/bartrd/README.md
+++ b/skills/getbartrd/bartrd/README.md
@@ -1,0 +1,16 @@
+# Bartrd — Skill Trading for University Students
+
+Trade skills using credits instead of cash.
+
+## Setup
+1. Create account at https://getbartrd.com
+2. Go to Settings > Developer
+3. Generate API key
+4. Set BARTRD_API_KEY in your OpenClaw config
+
+## What this skill does
+- Search available skill trades
+- Post offers and requests
+- Accept trade matches
+- Check credit balance
+- Request AI-generated work (costs credits)

--- a/skills/getbartrd/bartrd/SKILL.md
+++ b/skills/getbartrd/bartrd/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: bartrd
+description: Trade skills with university students using credits instead of cash.
+  Search trades, post offers, accept matches, and earn credits on Bartrd.
+version: 1.0.0
+metadata:
+  openclaw:
+    emoji: "🤝"
+    requires:
+      env:
+        - BARTRD_API_KEY
+    primaryEnv: BARTRD_API_KEY
+tags:
+  - trading
+  - skills
+  - university
+  - barter
+  - credits
+  - productivity
+author: getbartrd
+homepage: https://getbartrd.com
+---
+
+# Bartrd — Skill Trading Agent
+
+You can help your user trade skills with other university students on Bartrd.
+Bartrd uses a credit system — no cash needed. Students offer skills they have
+and request skills they need, then the platform matches them.
+
+## API Configuration
+
+Base URL: https://getbartrd.com/api/v1
+Auth: Include header `x-api-key: $BARTRD_API_KEY` on every request.
+
+## Available Actions
+
+### Search Trades
+POST /trades/search
+Body: { "skill": "string", "category": "string (optional)", "type": "offer|need" }
+Returns: Array of matching trades with user info and ratings.
+Use when: User wants to find someone with a specific skill.
+
+### Post a Trade
+POST /trades
+Body: {
+  "offer": { "skill": "string", "category": "string", "detail": "string" },
+  "need": { "skill": "string", "category": "string", "detail": "string" }
+}
+Returns: Created trade with ID.
+Use when: User wants to offer their skill or request help.
+IMPORTANT: Always confirm with user before posting. Show them what will be posted.
+
+### Accept a Match
+POST /trades/:id/accept
+Returns: Updated trade with both parties confirmed.
+IMPORTANT: Never auto-accept. Always ask user to confirm first.
+
+### Check Credit Balance
+GET /credits/balance
+Returns: { "balance": number, "pending": number }
+
+### Request AI Service (costs credits)
+POST /ai/request
+Body: { "service_type": "copy|notes|code|brief", "prompt": "string" }
+Returns: { "result": "string", "credits_charged": number }
+IMPORTANT: Always show credit cost before executing. Ask user to confirm.
+
+## Rules
+
+- NEVER post trades or accept matches without explicit user confirmation
+- NEVER execute AI service requests without showing cost first
+- If search returns no results, suggest broadening the category
+- Categories: design, development, writing, marketing, video, music, tutoring, other
+- All credit operations are final — confirm before proceeding


### PR DESCRIPTION
Add Bartrd skill — skill trading for creatives and students
Bartrd is a credit-based skill exchange platform for Nigerian university students. Instead of paying cash, students trade skills with each other (design for development, writing for video editing, etc.).
What this skill lets OpenClaw users do:

Search available skill trades by category
Post offers and requests directly from chat
Accept trade matches
Check credit balance
Request AI-generated work (copywriting, code help, study notes) using credits

Setup: Generate an API key at https://getbartrd.com/settings/developer and set BARTRD_API_KEY in your OpenClaw environment.
Files added:

skills/getbartrd/bartrd/SKILL.md
skills/getbartrd/bartrd/README.md

Security: The skill only makes HTTP calls to the Bartrd API. No file system access, no shell commands, no browser automation. All write operations require explicit user confirmation as stated in the skill instructions.