### PR TITLE
feat: check OS requirements when clawdhub install

### DIFF
--- a/packages/clawhub/src/cli.ts
+++ b/packages/clawhub/src/cli.ts
@@ -203,7 +203,7 @@ program
   .description("Install into <dir>/<slug>")
   .argument("<slug>", "Skill slug")
   .option("--version <version>", "Version to install")
-  .option("--force", "Overwrite existing folder")
+  .option("--force", "Overwrite existing folder, bypass OS mismatch, and allow suspicious skills")
   .action(async (slug, options) => {
     const opts = await resolveGlobalOpts();
     await cmdInstall(opts, slug, options.version, options.force);

--- a/packages/clawhub/src/cli/commands/skills.ts
+++ b/packages/clawhub/src/cli/commands/skills.ts
@@ -1,5 +1,6 @@
 import { mkdir, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
+import { platform } from "node:os";
 import semver from "semver";
 import { apiRequest, downloadZip, registryUrl } from "../../http.js";
 import {
@@ -95,6 +96,13 @@ export async function cmdInstall(
       { method: "GET", path: `${ApiRoutes.skills}/${encodeURIComponent(trimmed)}`, token },
       ApiV1SkillResponseSchema,
     );
+
+    // Check system requirements before proceeding
+    const currentPlatform = platform();
+    if (skillMeta.metadata?.os && !skillMeta.metadata.os.includes(currentPlatform) && !force) {
+      spinner.fail(`Incompatible system: ${trimmed} is not supported on ${currentPlatform}`);
+      fail("This skill is not compatible with your system.");
+    }
 
     // Check moderation status before proceeding
     if (skillMeta.moderation?.isMalwareBlocked) {

--- a/packages/clawhub/src/schema/schemas.ts
+++ b/packages/clawhub/src/schema/schemas.ts
@@ -199,6 +199,10 @@ export const ApiV1SkillResponseSchema = type({
     displayName: "string|null?",
     image: "string|null?",
   }).or("null"),
+  metadata: type({
+    os:"string[]|null",
+    systems:"string[]|null",
+  }).or("null"),
   moderation: type({
     isSuspicious: "boolean",
     isMalwareBlocked: "boolean",


### PR DESCRIPTION
## Description

Add an OS requirements check during `clawdhub install {slug}` to ensure the user’s system is included in the `metadata.os` list.

## Changes

[packages/clawdhub/src/cli/commands/skills.ts](https://github.com/AdairLi2504/clawhub/commit/00c210bf93e1c0d5dd3ac48ec563675331b17fb3)
Add check OS logic
[packages/clawdhub/src/schema/schemas.ts](https://github.com/AdairLi2504/clawhub/commit/c8e21b6f0e4a0b674cbf08cfe912d61af6206bd3)
Add the metadata type so that it can be parse

## Additional Information

I have not added the check for `metadata.systems`, because it is related to the NIX feature whose maintenance status is unknown.

