### PR TITLE
fix(search): boost exact slug match over containing slug

### DIFF
--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -359,6 +359,26 @@ describe("search helpers", () => {
     expect(exactScore).toBeGreaterThan(looseScore);
   });
 
+  it("boosts exact full slug over slug that merely contains all query tokens", () => {
+    const queryTokens = tokenize("self-improving-agent");
+    const exactScore = __test.scoreSkillResult(
+      queryTokens,
+      0.5,
+      "Self Improving Agent",
+      "self-improving-agent",
+      10,
+    );
+    const containingScore = __test.scoreSkillResult(
+      queryTokens,
+      0.6,
+      "Self Improving Agent",
+      "xiucheng-self-improving-agent",
+      100,
+    );
+    // Exact slug should beat a longer slug even with lower vector score and fewer downloads
+    expect(exactScore).toBeGreaterThan(containingScore);
+  });
+
   it("adds a popularity prior for equally relevant matches", () => {
     const queryTokens = tokenize("notion");
     const lowDownloads = __test.scoreSkillResult(

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -40,7 +40,8 @@ type SkillSearchEntry = {
 
 type SearchResult = SkillSearchEntry & { score: number };
 
-const SLUG_EXACT_BOOST = 1.4;
+const EXACT_SLUG_BOOST = 2.5;
+const SLUG_TOKEN_BOOST = 1.4;
 const SLUG_PREFIX_BOOST = 0.8;
 const NAME_EXACT_BOOST = 1.1;
 const NAME_PREFIX_BOOST = 0.6;
@@ -68,8 +69,15 @@ function getLexicalBoost(queryTokens: string[], displayName: string, slug: strin
   const nameTokens = tokenize(displayName);
 
   let boost = 0;
-  if (matchesAllTokens(queryTokens, slugTokens, (candidate, query) => candidate === query)) {
-    boost += SLUG_EXACT_BOOST;
+
+  // Exact slug match: "self-improving-agent" query → "self-improving-agent" slug
+  // Must be checked before token-based matching to distinguish from
+  // slugs that merely contain all query tokens (e.g., "xiucheng-self-improving-agent")
+  const normalizedQuery = queryTokens.join("-");
+  if (normalizedQuery === slug) {
+    boost += EXACT_SLUG_BOOST;
+  } else if (matchesAllTokens(queryTokens, slugTokens, (candidate, query) => candidate === query)) {
+    boost += SLUG_TOKEN_BOOST;
   } else if (
     matchesAllTokens(queryTokens, slugTokens, (candidate, query) => candidate.startsWith(query))
   ) {


### PR DESCRIPTION
## Bug

When searching for `self-improving-agent`, the exact match does not rank #1. Instead, longer slugs like `xiucheng-self-improving-agent` appear first.

## Root Cause

`getLexicalBoost()` uses `matchesAllTokens()` to check if every query token appears in the slug tokens. For query "self-improving-agent" (tokens: `["self", "improving", "agent"]`), both:
- `self-improving-agent` → tokens match → **1.4 boost**
- `xiucheng-self-improving-agent` → tokens match → **1.4 boost**

Both get the same `SLUG_EXACT_BOOST`, so the vector similarity score (which favors the longer, more "semantically similar" slug) determines ranking.

## Fix

Added `EXACT_SLUG_BOOST = 2.5` that fires when the entire normalized query equals the slug exactly. This gives exact matches a decisive scoring edge.

```typescript
const normalizedQuery = queryTokens.join("-");
if (normalizedQuery === slug) {
  boost += EXACT_SLUG_BOOST;  // 2.5 — highest possible lexical boost
} else if (matchesAllTokens(...)) {
  boost += SLUG_EXACT_BOOST;  // 1.4 — tokens match but slug is longer
}
```

## Testing

- All 17 tests pass (16 existing + 1 new)
- New test: `boosts exact full slug over slug that merely contains all query tokens`

## Files Changed

- `convex/search.ts` — Add `EXACT_SLUG_BOOST` constant and exact slug check in `getLexicalBoost()`
- `convex/search.test.ts` — Add regression test

Fixes #52034