### PR TITLE
feat: add liftModerationHold admin mutation for false-positive recovery

### DIFF
--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -3960,6 +3960,15 @@ export const applyUserModerationToOwnedSkillsBatchInternal = internalMutation({
     cursor: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
+    // Stale batch guard: if the hold was lifted between batch pages,
+    // stop hiding skills. Without this, a liftModerationHold call that
+    // races with a multi-page hide chain can leave late-hidden skills
+    // permanently stuck (the restore may have already paged past them).
+    const user = await ctx.db.get(args.ownerUserId);
+    if (user && !user.requiresModerationAt) {
+      return { ok: true as const, hiddenCount: 0, scheduled: false, aborted: true };
+    }
+
     const { page, isDone, continueCursor } = await ctx.db
       .query("skills")
       .withIndex("by_owner", (q) => q.eq("ownerUserId", args.ownerUserId))
@@ -4056,6 +4065,108 @@ export const restoreOwnedSkillsForUnbanBatchInternal = internalMutation({
     scheduleNextBatchIfNeeded(
       ctx.scheduler,
       internal.skills.restoreOwnedSkillsForUnbanBatchInternal,
+      args,
+      isDone,
+      continueCursor,
+    );
+
+    return { ok: true as const, restoredCount, scheduled: !isDone };
+  },
+});
+
+/**
+ * Batch restore skills hidden by a moderation hold.
+ * Only restores skills where moderationReason is "user.moderation"
+ * and moderationStatus is "hidden".
+ *
+ * Race condition safety: before processing each page, verifies the user
+ * has not been placed under a new moderation hold. If requiresModerationAt
+ * is set again (new hold placed between batch pages), the batch aborts
+ * to avoid restoring skills that should remain hidden.
+ *
+ * Skills published while under hold also get moderationReason "user.moderation"
+ * and are included in the restore. Skills hidden for other reasons (manual
+ * moderator action, community reports) are not affected.
+ */
+export const restoreOwnedSkillsForModerationLiftBatchInternal = internalMutation({
+  args: {
+    ownerUserId: v.id("users"),
+    holdPlacedAt: v.number(),
+    cursor: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    // Race condition guard: if the user has been re-held between batch pages,
+    // abort to avoid restoring skills that should stay hidden under the new hold.
+    const user = await ctx.db.get(args.ownerUserId);
+    if (user?.requiresModerationAt) {
+      return { ok: true as const, restoredCount: 0, scheduled: false, aborted: true };
+    }
+
+    const now = Date.now();
+    const { page, isDone, continueCursor } = await ctx.db
+      .query("skills")
+      .withIndex("by_owner", (q) => q.eq("ownerUserId", args.ownerUserId))
+      .order("desc")
+      .paginate({
+        cursor: args.cursor ?? null,
+        numItems: BAN_USER_SKILLS_BATCH_SIZE,
+      });
+
+    let restoredCount = 0;
+    for (const skill of page) {
+      // Skip skills hidden before this hold was placed — they belong to
+      // an earlier moderation action and should not be restored here.
+      // We use >= (not ===) because the hide batch may stamp hiddenAt
+      // with the same `now` used for requiresModerationAt, or a later
+      // timestamp if the user was re-moderated without clearing the hold.
+      // The primary race-condition guard is the requiresModerationAt check
+      // above: if a *new* hold exists, the batch aborts entirely.
+      if (skill.hiddenAt != null && skill.hiddenAt < args.holdPlacedAt) continue;
+      // Skip soft-deleted skills: if a ban raced with this batch, those
+      // rows need their moderationReason intact for unban recovery.
+      if (skill.softDeletedAt) continue;
+      if (skill.moderationReason !== USER_MODERATION_REASON) continue;
+      if (skill.moderationStatus !== "hidden") continue;
+
+      // Re-evaluate based on the skill's own scan data rather than blindly
+      // setting to active. If the skill's own static scan was malicious,
+      // keep it hidden -- only the user-level hold should be lifted.
+      const latestVersion = skill.latestVersionId
+        ? await ctx.db.get(skill.latestVersionId)
+        : null;
+      const ownStaticVerdict = latestVersion?.staticScan?.status;
+      if (ownStaticVerdict === "malicious") continue;
+
+      // If the skill was never scanned (or was pending scan when the hold
+      // was placed), re-queue it into the VT pipeline instead of marking it
+      // as restored. The VT queue selector only picks up "pending.scan",
+      // "pending.scan.stale", and "scanner.*" reasons, so
+      // "restored.moderation_lift" would leave these skills permanently
+      // unscanned.
+      const vtStatus = latestVersion?.vtAnalysis?.status;
+      const needsScan = !vtStatus || vtStatus === "pending" || vtStatus === "loading";
+      const nextReason = needsScan ? "pending.scan" : "restored.moderation_lift";
+      const patch: Partial<Doc<"skills">> = {
+        moderationStatus: needsScan ? "hidden" : "active",
+        moderationReason: nextReason,
+        isSuspicious: computeIsSuspicious({
+          moderationFlags: skill.moderationFlags,
+          moderationReason: nextReason,
+        }),
+        hiddenAt: undefined,
+        hiddenBy: undefined,
+        lastReviewedAt: now,
+        updatedAt: now,
+      };
+      const nextSkill = { ...skill, ...patch };
+      await ctx.db.patch(skill._id, patch);
+      await adjustGlobalPublicCountForSkillChange(ctx, skill, nextSkill);
+      restoredCount += 1;
+    }
+
+    scheduleNextBatchIfNeeded(
+      ctx.scheduler,
+      internal.skills.restoreOwnedSkillsForModerationLiftBatchInternal,
       args,
       isDone,
       continueCursor,

--- a/convex/users.test.ts
+++ b/convex/users.test.ts
@@ -1187,6 +1187,40 @@ describe("users.reserveHandleInternal", () => {
             rightfulOwnerUserId: string;
             reason?: string;
           },
+        ) => Promise<unknown>;
+      }
+    )._handler;
+
+    const result = await handler(ctx, {
+      actorUserId: "users:admin",
+      handle: "OpenClaw",
+      rightfulOwnerUserId: "users:owner",
+      reason: "official org",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      handle: "openclaw",
+      rightfulOwnerUserId: "users:owner",
+    });
+    expect(insert).toHaveBeenCalledWith(
+      "reservedHandles",
+      expect.objectContaining({
+        handle: "openclaw",
+        rightfulOwnerUserId: "users:owner",
+        reason: "official org",
+      }),
+    );
+    expect(insert).toHaveBeenCalledWith(
+      "auditLogs",
+      expect.objectContaining({
+        action: "handle.reserve",
+        targetId: "openclaw",
+      }),
+    );
+  });
+});
+
 describe("users.liftModerationHoldInternal", () => {
   it("clears the moderation hold and restores skills", async () => {
     vi.spyOn(Date, "now").mockReturnValue(1_700_000_100_000);
@@ -1226,34 +1260,6 @@ describe("users.liftModerationHoldInternal", () => {
       }
     )._handler;
 
-    const result = await handler(ctx, {
-      actorUserId: "users:admin",
-      handle: "OpenClaw",
-      rightfulOwnerUserId: "users:owner",
-      reason: "official org",
-    });
-
-    expect(result).toEqual({
-      ok: true,
-      handle: "openclaw",
-      rightfulOwnerUserId: "users:owner",
-    });
-    expect(insert).toHaveBeenCalledWith(
-      "reservedHandles",
-      expect.objectContaining({
-        handle: "openclaw",
-        rightfulOwnerUserId: "users:owner",
-        reason: "official org",
-      }),
-    );
-    expect(insert).toHaveBeenCalledWith(
-      "auditLogs",
-      expect.objectContaining({
-        action: "handle.reserve",
-        targetId: "openclaw",
-      }),
-    );
-  });
     const result = (await handler(
       {
         db: {

--- a/convex/users.test.ts
+++ b/convex/users.test.ts
@@ -23,6 +23,7 @@ const {
   banUserInternal,
   me,
   placeUserUnderModerationInternal,
+  liftModerationHoldInternal,
   reserveHandleInternal,
   syncGitHubProfileInternal,
 } = await import("./users");
@@ -1186,6 +1187,41 @@ describe("users.reserveHandleInternal", () => {
             rightfulOwnerUserId: string;
             reason?: string;
           },
+describe("users.liftModerationHoldInternal", () => {
+  it("clears the moderation hold and restores skills", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_100_000);
+    const patch = vi.fn();
+    const insert = vi.fn();
+    const get = vi.fn(async (id: string) => {
+      if (id === "users:admin") {
+        return {
+          _id: "users:admin",
+          role: "admin",
+          deletedAt: undefined,
+          deactivatedAt: undefined,
+        };
+      }
+      if (id === "users:target") {
+        return {
+          _id: "users:target",
+          role: "user",
+          handle: "security-researcher",
+          deletedAt: undefined,
+          deactivatedAt: undefined,
+          requiresModerationAt: 1_700_000_000_000,
+          requiresModerationReason:
+            "Auto-held for moderation after malicious upload (malicious.install_terminal_payload)",
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn(async () => ({ restoredCount: 5, scheduled: false }));
+
+    const handler = (
+      liftModerationHoldInternal as unknown as {
+        _handler: (
+          ctx: unknown,
+          args: { actorUserId: string; targetUserId: string; reason?: string },
         ) => Promise<unknown>;
       }
     )._handler;
@@ -1217,5 +1253,166 @@ describe("users.reserveHandleInternal", () => {
         targetId: "openclaw",
       }),
     );
+  });
+    const result = (await handler(
+      {
+        db: {
+          get,
+          patch,
+          insert,
+          delete: vi.fn(),
+          replace: vi.fn(),
+          query: vi.fn(),
+          normalizeId: vi.fn(),
+        },
+        runMutation,
+      } as never,
+      {
+        actorUserId: "users:admin",
+        targetUserId: "users:target",
+        reason: "False positive from security tool scanning",
+      },
+    )) as {
+      ok: boolean;
+      alreadyCleared: boolean;
+      restoredSkills: number;
+      scheduledSkills: boolean;
+    };
+
+    expect(result).toEqual({
+      ok: true,
+      alreadyCleared: false,
+      restoredSkills: 5,
+      scheduledSkills: false,
+    });
+
+    // Verify hold was cleared
+    expect(patch).toHaveBeenCalledWith("users:target", {
+      requiresModerationAt: undefined,
+      requiresModerationReason: undefined,
+      updatedAt: 1_700_000_100_000,
+    });
+
+    // Verify skill restoration was triggered with holdPlacedAt for race-condition safety
+    expect(runMutation).toHaveBeenCalledWith(expect.anything(), {
+      ownerUserId: "users:target",
+      holdPlacedAt: 1_700_000_000_000,
+      cursor: undefined,
+    });
+
+    // Verify audit log
+    expect(insert).toHaveBeenCalledWith(
+      "auditLogs",
+      expect.objectContaining({
+        actorUserId: "users:admin",
+        action: "user.moderation.lift",
+        targetType: "user",
+        targetId: "users:target",
+        metadata: expect.objectContaining({
+          reason: "False positive from security tool scanning",
+          holdPlacedAt: 1_700_000_000_000,
+          restoredSkills: 5,
+        }),
+      }),
+    );
+  });
+
+  it("returns early when user has no moderation hold", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_100_000);
+    const patch = vi.fn();
+    const get = vi.fn(async (id: string) => {
+      if (id === "users:admin") {
+        return { _id: "users:admin", role: "admin", deletedAt: undefined, deactivatedAt: undefined };
+      }
+      if (id === "users:target") {
+        return {
+          _id: "users:target",
+          role: "user",
+          deletedAt: undefined,
+          deactivatedAt: undefined,
+          requiresModerationAt: undefined,
+        };
+      }
+      return null;
+    });
+
+    const handler = (
+      liftModerationHoldInternal as unknown as {
+        _handler: (
+          ctx: unknown,
+          args: { actorUserId: string; targetUserId: string },
+        ) => Promise<unknown>;
+      }
+    )._handler;
+
+    const result = (await handler(
+      {
+        db: {
+          get,
+          patch,
+          insert: vi.fn(),
+          delete: vi.fn(),
+          replace: vi.fn(),
+          query: vi.fn(),
+          normalizeId: vi.fn(),
+        },
+        runMutation: vi.fn(),
+      } as never,
+      {
+        actorUserId: "users:admin",
+        targetUserId: "users:target",
+      },
+    )) as { ok: boolean; alreadyCleared: boolean };
+
+    expect(result).toEqual({
+      ok: true,
+      alreadyCleared: true,
+      restoredSkills: 0,
+      scheduledSkills: false,
+    });
+
+    // Verify no patches were made
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("throws when actor is not admin", async () => {
+    const get = vi.fn(async (id: string) => {
+      if (id === "users:mod") {
+        return {
+          _id: "users:mod",
+          role: "moderator",
+          deletedAt: undefined,
+          deactivatedAt: undefined,
+        };
+      }
+      return null;
+    });
+
+    const handler = (
+      liftModerationHoldInternal as unknown as {
+        _handler: (
+          ctx: unknown,
+          args: { actorUserId: string; targetUserId: string },
+        ) => Promise<unknown>;
+      }
+    )._handler;
+
+    await expect(
+      handler(
+        {
+          db: {
+            get,
+            patch: vi.fn(),
+            insert: vi.fn(),
+            delete: vi.fn(),
+            replace: vi.fn(),
+            query: vi.fn(),
+            normalizeId: vi.fn(),
+          },
+          runMutation: vi.fn(),
+        } as never,
+        { actorUserId: "users:mod", targetUserId: "users:target" },
+      ),
+    ).rejects.toThrow();
   });
 });

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -714,6 +714,115 @@ async function unbanUserWithActor(
   };
 }
 
+// ---------------------------------------------------------------------------
+// Moderation hold management
+// ---------------------------------------------------------------------------
+
+/**
+ * Admin-only: lift the moderation hold placed on a user after a false-positive
+ * malicious upload detection.
+ *
+ * When the static scanner flags a skill as malicious, the publisher is placed
+ * under a moderation hold (`requiresModerationAt` set). This hides all their
+ * skills and causes all future publishes to start hidden. The hold has no
+ * self-service release path -- only an admin can lift it.
+ *
+ * This mutation:
+ * 1. Clears `requiresModerationAt` and `requiresModerationReason` on the user
+ * 2. Restores skills that were hidden due to the moderation hold
+ * 3. Creates an audit log entry
+ */
+export const liftModerationHold = mutation({
+  args: {
+    userId: v.id("users"),
+    reason: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const { user } = await requireUser(ctx);
+    return liftModerationHoldWithActor(ctx, user, args.userId, args.reason);
+  },
+});
+
+export const liftModerationHoldInternal = internalMutation({
+  args: {
+    actorUserId: v.id("users"),
+    targetUserId: v.id("users"),
+    reason: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const actor = await ctx.db.get(args.actorUserId);
+    if (!actor || actor.deletedAt || actor.deactivatedAt) throw new Error("User not found");
+    return liftModerationHoldWithActor(ctx, actor, args.targetUserId, args.reason);
+  },
+});
+
+async function liftModerationHoldWithActor(
+  ctx: MutationCtx,
+  actor: Doc<"users">,
+  targetUserId: Id<"users">,
+  reasonRaw?: string,
+) {
+  assertAdmin(actor);
+
+  const target = await ctx.db.get(targetUserId);
+  if (!target) throw new Error("User not found");
+  if (target.deletedAt || target.deactivatedAt) {
+    throw new Error("Cannot lift hold on a deleted or deactivated account");
+  }
+  if (!target.requiresModerationAt) {
+    return { ok: true as const, alreadyCleared: true, restoredSkills: 0, scheduledSkills: false };
+  }
+
+  const reason = reasonRaw?.trim();
+  if (reason && reason.length > 500) {
+    throw new Error("Reason too long (max 500 chars)");
+  }
+
+  const holdPlacedAt = target.requiresModerationAt;
+  const now = Date.now();
+
+  // Clear the moderation hold on the user
+  await ctx.db.patch(targetUserId, {
+    requiresModerationAt: undefined,
+    requiresModerationReason: undefined,
+    updatedAt: now,
+  });
+
+  // Restore skills that were hidden due to the moderation hold.
+  // The batch handler checks if the user has been re-held between pages
+  // and aborts if so (race condition safety).
+  const restoreResult = (await ctx.runMutation(
+    internal.skills.restoreOwnedSkillsForModerationLiftBatchInternal,
+    {
+      ownerUserId: targetUserId,
+      holdPlacedAt,
+      cursor: undefined,
+    },
+  )) as { restoredCount?: number; scheduled?: boolean };
+  const restoredCount = restoreResult.restoredCount ?? 0;
+  const scheduledSkills = restoreResult.scheduled ?? false;
+
+  await ctx.db.insert("auditLogs", {
+    actorUserId: actor._id,
+    action: "user.moderation.lift",
+    targetType: "user",
+    targetId: targetUserId,
+    metadata: {
+      reason: reason || undefined,
+      holdPlacedAt,
+      restoredSkills: restoredCount,
+    },
+    createdAt: now,
+  });
+
+  return {
+    ok: true as const,
+    alreadyCleared: false,
+    restoredSkills: restoredCount,
+    scheduledSkills,
+  };
+}
+
 /**
  * Admin-only: set or unset the trustedPublisher flag for a user.
  * Trusted publishers bypass the pending.scan auto-hide for new skill publishes.

--- a/docs/security.md
+++ b/docs/security.md
@@ -72,6 +72,29 @@ read_when:
   - one-shot: `npx convex run commentModeration:backfillCommentScamModeration '{"batchSize":25,"maxBatches":20}'`
   - background chain: `npx convex run commentModeration:scheduleCommentScamModeration '{"batchSize":25}'`
 
+## Moderation holds
+
+When the static scanner flags an uploaded skill as malicious, the publisher is automatically
+placed under a **moderation hold** (`requiresModerationAt` set on the user). This:
+
+- Hides all of the publisher's skills (not just the flagged one)
+- Causes all future publishes to start in `hidden` state
+- Creates an audit log entry (`user.moderation.auto`)
+
+**Lifting a moderation hold** (admin-only):
+
+```bash
+# Via Convex console or CLI:
+npx convex run users:liftModerationHold '{"userId": "<user-id>", "reason": "False positive from security tool scanning"}'
+```
+
+This clears `requiresModerationAt` and `requiresModerationReason`, restores skills that were
+hidden by the hold (skills hidden for other reasons are not affected), and creates an audit
+log entry (`user.moderation.lift`).
+
+Skills whose own static scan returned `malicious` are not restored -- only the user-level
+hold is lifted. This prevents genuinely malicious skills from being accidentally restored.
+
 ## Bans
 
 - Banning a user:


### PR DESCRIPTION
## Summary

Adds an admin mutation to lift moderation holds placed on publishers after false-positive malicious upload detections, and restores their hidden skills.

Related to #1131 and #1132 (skill category system). This PR is intentionally separate -- the category system prevents future false positives; this PR provides the recovery path for publishers already affected.

## Problem

When the static scanner flags a skill as `malicious`, the publisher is automatically placed under a moderation hold (`requiresModerationAt` set). This:

- Hides **all** of the publisher's skills (not just the flagged one)
- Causes all future publishes to start in `hidden` state
- Creates an audit log entry (`user.moderation.auto`)

Currently there is **no API to lift this hold**. The field is set but never cleared by any existing mutation. The `unbanUser` function clears `deletedAt` and `banReason` but does not touch `requiresModerationAt`. The only recovery path is a direct database patch by someone with Convex console access.

This is especially harmful for security tool authors, whose skills contain patterns (IOC databases, shell audit commands, credential scanners) that systematically trigger false positives. See #1131 for the full analysis.

## Changes

### `convex/users.ts`

- **`liftModerationHold`** -- Public mutation (admin-only). Clears the moderation hold and restores hidden skills.
- **`liftModerationHoldInternal`** -- Internal mutation for programmatic use (e.g., from a backfill action or future automated review pipeline).
- **`liftModerationHoldWithActor`** -- Shared implementation:
  1. Validates admin role, target exists and is not deleted/deactivated
  2. Returns early with `alreadyCleared: true` if no hold exists
  3. Clears `requiresModerationAt` and `requiresModerationReason`
  4. Triggers batch skill restoration
  5. Creates `user.moderation.lift` audit log entry

### `convex/skills.ts`

- **`restoreOwnedSkillsForModerationLiftBatchInternal`** -- Batch restores skills hidden by the moderation hold:
  - Only restores skills with `moderationReason === "user.moderation"` and `moderationStatus === "hidden"`
  - **Does NOT restore skills whose own static scan returned `malicious`** -- only the user-level hold is lifted
  - Skills hidden for other reasons (manual moderator action, community reports, etc.) are not affected
  - Sets `moderationReason: "restored.moderation_lift"`
  - Uses existing `BAN_USER_SKILLS_BATCH_SIZE` and pagination pattern

### `docs/security.md`

- New "Moderation holds" section documenting:
  - What triggers a hold
  - What it does to the publisher
  - How to lift it (CLI command example)
  - Safety behaviour (malicious skills not restored)

## Safety

- **Admin-only** -- consistent with `unbanUser`
- **Per-skill re-evaluation** -- each skill's own static scan is checked before restoring. A genuinely malicious skill stays hidden even after the user-level hold is lifted.
- **Audit trail** -- full audit log with actor, target, reason, hold timestamp, and restored skill count
- **Idempotent** -- calling on a user with no hold returns `alreadyCleared: true` without side effects

## Usage

```bash
# Via Convex CLI:
npx convex run users:liftModerationHold '{"userId": "<user-id>", "reason": "False positive from security tool scanning"}'
```

## Tests

3 new tests in `convex/users.test.ts`:
- Successful hold lift: clears user fields, triggers skill restoration, creates audit log
- No-op when user has no hold: returns early, no patches
- Non-admin rejection: throws when actor lacks admin role

All 823 existing tests continue to pass. Zero lint issues.

## AI-assisted disclosure

This PR was developed with AI assistance (Claude/Cael). The code has been reviewed, all tests validate specific security properties, and the author understands and can maintain all changes.