### PR TITLE
fix: tolerate stale auth on public package reads

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -2345,6 +2345,27 @@ describe("httpApiV1 handlers", () => {
     );
   });
 
+  it("packages list falls back to anonymous when cookie auth resolution fails", async () => {
+    vi.mocked(getAuthUserId).mockRejectedValue(new Error("stale session"));
+    const runQuery = vi.fn().mockResolvedValue({ page: [], isDone: true, continueCursor: "" });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.listPackagesV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/packages?isOfficial=true&limit=7"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        isOfficial: true,
+        viewerUserId: undefined,
+        paginationOpts: { cursor: null, numItems: 7 },
+      }),
+    );
+  });
+
   it("packages detail falls back to public skills", async () => {
     const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
       if ("name" in args) return null;

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -58,6 +58,17 @@ async function runActionRef<T>(ctx: ActionCtx, ref: unknown, args: unknown): Pro
   return (await ctx.runAction(ref as never, args as never)) as T;
 }
 
+async function getOptionalViewerUserIdForRequest(ctx: ActionCtx, request: Request) {
+  const apiTokenUserId = await getOptionalApiTokenUserId(ctx, request);
+  if (apiTokenUserId) return apiTokenUserId;
+  try {
+    return (await getAuthUserId(ctx)) ?? null;
+  } catch {
+    // Public package reads should degrade to anonymous when cookie-backed auth is stale.
+    return null;
+  }
+}
+
 type PackageListQueryArgs = {
   family?: "skill" | "code-plugin" | "bundle-plugin";
   channel?: "official" | "community" | "private";
@@ -408,7 +419,7 @@ async function listPackages(ctx: ActionCtx, request: Request, family?: PackageLi
   if (!rate.ok) return rate.response;
 
   const url = new URL(request.url);
-  const viewerUserId = (await getOptionalApiTokenUserId(ctx, request)) ?? (await getAuthUserId(ctx));
+  const viewerUserId = await getOptionalViewerUserIdForRequest(ctx, request);
   const limit = Math.max(1, Math.min(toOptionalNumber(url.searchParams.get("limit")) ?? 25, 100));
   const cursor = url.searchParams.get("cursor");
   const familyRaw = url.searchParams.get("family");
@@ -693,7 +704,7 @@ export async function packagesGetRouterV1Handler(ctx: ActionCtx, request: Reques
 
   if (segments[0] === "search" && new URL(request.url).searchParams.has("q")) {
     const url = new URL(request.url);
-    const viewerUserId = (await getOptionalApiTokenUserId(ctx, request)) ?? (await getAuthUserId(ctx));
+    const viewerUserId = await getOptionalViewerUserIdForRequest(ctx, request);
     const queryText = url.searchParams.get("q")?.trim() ?? "";
     const limit = Math.max(1, Math.min(toOptionalNumber(url.searchParams.get("limit")) ?? 20, 100));
     const familyRaw = url.searchParams.get("family");
@@ -775,7 +786,7 @@ export async function packagesGetRouterV1Handler(ctx: ActionCtx, request: Reques
   }
 
   const packageName = segments[0] ?? "";
-  const viewerUserId = (await getOptionalApiTokenUserId(ctx, request)) ?? (await getAuthUserId(ctx));
+  const viewerUserId = await getOptionalViewerUserIdForRequest(ctx, request);
   const detail = (await runQueryRef(
     ctx,
     internalRefs.packages.getByNameForViewerInternal,

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -1017,6 +1017,19 @@ describe("packages public queries", () => {
     expect(version?.version.version).toBe("1.0.0");
   });
 
+  it("treats auth resolution failures as anonymous for public package detail", async () => {
+    vi.mocked(getAuthUserId).mockRejectedValue(new Error("stale session"));
+    const { ctx } = makePackageCtx({
+      pkg: makePackageDoc({ channel: "community" }),
+    });
+
+    const detail = await getByNameHandler(ctx, {
+      name: "demo-plugin",
+    });
+
+    expect(detail?.package.name).toBe("demo-plugin");
+  });
+
   it("does not expose a soft-deleted latest release as latestVersion", async () => {
     const { ctx } = makePackageCtx({
       latestRelease: makeReleaseDoc({ softDeletedAt: 10 }),

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -222,6 +222,15 @@ function decodePublicPageCursor(raw: string | null | undefined): PublicPageCurso
   }
 }
 
+async function getOptionalViewerUserId(ctx: Parameters<typeof getAuthUserId>[0]) {
+  try {
+    return (await getAuthUserId(ctx)) ?? undefined;
+  } catch {
+    // Public package reads should degrade to anonymous when session resolution fails.
+    return undefined;
+  }
+}
+
 function packageSearchScore(digest: PackageDigestLike, queryText: string) {
   const needle = queryText.toLowerCase();
   const normalized = digest.normalizedName.toLowerCase();
@@ -485,7 +494,7 @@ async function getReadablePackageByName(
 export const getByName = query({
   args: { name: v.string() },
   handler: async (ctx, args) => {
-    const viewerUserId = (await getAuthUserId(ctx)) ?? undefined;
+    const viewerUserId = await getOptionalViewerUserId(ctx);
     const pkg = await getReadablePackageByName(ctx, args.name, viewerUserId);
     if (!pkg) return null;
     const latestRelease = pkg.latestReleaseId ? await ctx.db.get(pkg.latestReleaseId) : null;
@@ -526,7 +535,7 @@ export const listVersions = query({
     paginationOpts: paginationOptsValidator,
   },
   handler: async (ctx, args) => {
-    const viewerUserId = (await getAuthUserId(ctx)) ?? undefined;
+    const viewerUserId = await getOptionalViewerUserId(ctx);
     const pkg = await getReadablePackageByName(ctx, args.name, viewerUserId);
     if (!pkg) return { page: [], isDone: true, continueCursor: "" };
     return await ctx.db
@@ -564,7 +573,7 @@ export const getVersionByName = query({
     version: v.string(),
   },
   handler: async (ctx, args) => {
-    const viewerUserId = (await getAuthUserId(ctx)) ?? undefined;
+    const viewerUserId = await getOptionalViewerUserId(ctx);
     const pkg = await getReadablePackageByName(ctx, args.name, viewerUserId);
     if (!pkg) return null;
     const publicPackage = toPublicPackage(pkg);

--- a/convex/users.test.ts
+++ b/convex/users.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("@convex-dev/auth/server", () => ({
+  getAuthUserId: vi.fn(),
+}));
+
 vi.mock("./lib/access", async () => {
   const actual = await vi.importActual<typeof import("./lib/access")>("./lib/access");
   return { ...actual, requireUser: vi.fn() };
@@ -10,16 +14,24 @@ vi.mock("./skillStatEvents", () => ({
 }));
 
 const { requireUser } = await import("./lib/access");
+const { getAuthUserId } = await import("@convex-dev/auth/server");
 const { insertStatEvent } = await import("./skillStatEvents");
 const {
   ensureHandler,
   list,
   searchInternal,
   banUserInternal,
+  me,
   placeUserUnderModerationInternal,
   reserveHandleInternal,
   syncGitHubProfileInternal,
 } = await import("./users");
+
+type WrappedHandler<TArgs, TResult> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
+};
+
+const meHandler = (me as unknown as WrappedHandler<Record<string, never>, unknown>)._handler;
 
 function makeCtx() {
   const patch = vi.fn();
@@ -116,6 +128,7 @@ function makeBanCtx() {
 describe("ensureHandler", () => {
   afterEach(() => {
     vi.mocked(requireUser).mockReset();
+    vi.mocked(getAuthUserId).mockReset();
   });
 
   it("updates handle and display name when GitHub login changes", async () => {
@@ -309,6 +322,22 @@ describe("ensureHandler", () => {
     await ensureHandler(ctx);
 
     expect(patch).not.toHaveBeenCalled();
+  });
+});
+
+describe("me", () => {
+  afterEach(() => {
+    vi.mocked(getAuthUserId).mockReset();
+  });
+
+  it("returns null when auth resolution throws", async () => {
+    vi.mocked(getAuthUserId).mockRejectedValue(new Error("stale session"));
+    const get = vi.fn();
+
+    const result = await meHandler({ db: { get } } as never, {});
+
+    expect(result).toBeNull();
+    expect(get).not.toHaveBeenCalled();
   });
 });
 

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -151,7 +151,13 @@ export const syncGitHubProfileAction = internalAction({
 export const me = query({
   args: {},
   handler: async (ctx) => {
-    const userId = await getAuthUserId(ctx);
+    let userId: Awaited<ReturnType<typeof getAuthUserId>>;
+    try {
+      userId = await getAuthUserId(ctx);
+    } catch {
+      // Public pages should treat broken/stale auth as anonymous instead of crashing SSR.
+      return null;
+    }
     if (!userId) return null;
     const user = await ctx.db.get(userId);
     if (!user || user.deletedAt || user.deactivatedAt) return null;


### PR DESCRIPTION
## Summary
- treat stale or broken auth resolution as anonymous for public package reads
- harden package HTTP handlers and public package queries against optional auth failures
- add regression coverage for public package listing/detail paths and `users.me`

## Testing
- `npx vitest run convex/users.test.ts convex/packages.public.test.ts convex/httpApiV1.handlers.test.ts src/lib/packageApi.test.ts src/__tests__/packages-route.test.tsx`
