### PR TITLE
fix: verified filter on /plugins crashes with server error

### DIFF
--- a/src/routes/plugins/index.tsx
+++ b/src/routes/plugins/index.tsx
@@ -44,7 +44,7 @@ export const Route = createFileRoute("/plugins/")({
       family: deps.family,
       isOfficial: deps.verified,
       executesCode: deps.executesCode,
-      limit: 50,
+      limit: deps.verified ? 10 : 50,
     });
     const allItems = "results" in data ? data.results.map((entry) => entry.package) : data.items;
     const items = allItems.filter((item) => item.family !== "skill");


### PR DESCRIPTION
Clicking "Verified only" on /plugins (also reachable via /packages redirect) triggers a Convex server error because the isOfficial query path can't handle limit=50. Lowering the limit to 10 when the verified filter is active works around this — there are currently only 2 verified plugins.

Repro:
1. Go to https://clawhub.ai/plugins
2. Click "Verified only"
3. Server error

Fix: `limit: deps.verified ? 10 : 50`