### PR TITLE
feat: add AIVI Lead Engagement skill

### DIFF
--- a/skills/aivi-engagement/SKILL.md
+++ b/skills/aivi-engagement/SKILL.md
@@ -24,6 +24,12 @@ Complete one-time setup (15-30 minutes):
 app.aivi.io → Profile → Settings → API Keys → Generate API Key
 Copy it — shown once only.
 
+### Pro Tip — Save your API key permanently
+Tell your AI agent once:
+"Remember my AIVI API key is aivi_sk_xxxxx"
+
+Claude will remember it across all future conversations. You will never need to type it again.
+
 ### Step 3 — Connect to your AI agent
 
 Claude Code:
@@ -72,6 +78,27 @@ If skill returns invalid_api_key:
 
 If skill returns insufficient_funds:
 > "Add credits at app.aivi.io → Billing. Minimum $100 to activate campaigns"
+
+---
+
+## Quick Start Prompts
+
+Copy and paste to get started immediately:
+
+1. Save your key (one time only):
+   "Remember my AIVI API key is aivi_sk_xxxxx"
+
+2. Score a lead:
+   "Score the lead at +12065551234"
+
+3. Launch a sequence:
+   "Launch a 3-day sequence for +12065551234"
+
+4. Check what happened:
+   "What happened on the last call with +12065551234?"
+
+5. Get ML recommendation:
+   "What should I do next with +12065551234?"
 
 ---
 


### PR DESCRIPTION
## Summary
- AIVI Lead Engagement skill for ClawHub
- Score leads using ML bandit + RRDB enrichment
- Launch AI voice + SMS outreach sequences
- Supports real estate, debt collection, healthcare, home services

## MCP Endpoint
`https://mcp.aivi.io/mcp`

## Skills
| Skill | Cost | Description |
|-------|------|-------------|
| score_lead | $0.75 | ML scoring + phone validation + RRDB enrichment |
| launch_sequence | $1-3 | AI voice + SMS sequence (1/3/12 day) |
| decide_next_action | Free | ML bandit next action recommendation |
| get_outcome | Free | Post-call intelligence and topics |
| onboard_organization | Free | Create org + agent + API key |

## Test plan
- [x] score_lead returns score=80 tier_1 with real call history
- [x] launch_sequence fired Supercharged 1 Day Journey
- [x] decide_next_action returns wait_next_morning_sms
- [x] get_outcome returns topics, sentiment, outcome
- [x] MCP endpoint live at mcp.aivi.io
- [x] Health check passing
- [x] All 4 skills tested live in Claude Desktop

## Note on CI
The Vercel deployment check fails because the fork doesn't have Vercel authorization — this is expected for external PRs. The skill files are markdown only (no build needed).