### PR TITLE
fix(convex): replace paginate with collect to fix multi-pagination error

### DIFF
--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -170,18 +170,13 @@ export async function syncPackageSearchDigestsForOwnerPublisherId(
   ownerPublisherId: Id<"publishers"> | null | undefined,
 ) {
   if (!ownerPublisherId) return;
-  let cursor: string | null = null;
   try {
-    while (true) {
-      const page = await ctx.db
-        .query("packages")
-        .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", ownerPublisherId))
-        .paginate({ cursor, numItems: 100 });
-      for (const pkg of page.page) {
-        await syncPackageSearchDigest(ctx, pkg);
-      }
-      if (page.isDone) break;
-      cursor = page.continueCursor;
+    const packages = await ctx.db
+      .query("packages")
+      .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", ownerPublisherId))
+      .collect();
+    for (const pkg of packages) {
+      await syncPackageSearchDigest(ctx, pkg);
     }
   } catch (error) {
     if (isMissingTableError(error, "packages")) return;
@@ -214,18 +209,13 @@ export async function syncSkillSearchDigestsForOwnerPublisherId(
   ownerPublisherId: Id<"publishers"> | null | undefined,
 ) {
   if (!ownerPublisherId) return;
-  let cursor: string | null = null;
   try {
-    while (true) {
-      const page = await ctx.db
-        .query("skills")
-        .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", ownerPublisherId))
-        .paginate({ cursor, numItems: 100 });
-      for (const skill of page.page) {
-        await syncSkillSearchDigestForSkill(ctx, skill);
-      }
-      if (page.isDone) break;
-      cursor = page.continueCursor;
+    const skills = await ctx.db
+      .query("skills")
+      .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", ownerPublisherId))
+      .collect();
+    for (const skill of skills) {
+      await syncSkillSearchDigestForSkill(ctx, skill);
     }
   } catch (error) {
     if (isMissingTableError(error, "skills")) return;


### PR DESCRIPTION
## Problem

All publish operations fail with:

```
Error: This query or mutation function ran multiple paginated queries.
Convex only supports a single paginated query in each function.
```

The `publishers` trigger in `convex/functions.ts` (line 337-340) calls both:
1. `syncPackageSearchDigestsForOwnerPublisherId` — uses `paginate()`
2. `syncSkillSearchDigestsForOwnerPublisherId` — uses `paginate()`

Convex only allows **one** paginated query per mutation, so the second call always fails.

## Solution

Replace `paginate()` loops with `collect()` in both functions. This is safe because:
- A single publisher's packages/skills are bounded (typically <100)
- `collect()` stays well within Convex's document limits for this use case
- No behavioral change — same documents are processed, just fetched in one call instead of pages

## Changes

- `convex/functions.ts`: Replace paginate loops with collect in both `syncPackageSearchDigestsForOwnerPublisherId` and `syncSkillSearchDigestsForOwnerPublisherId`

## Testing

- Manually verified the logic change is equivalent (same index, same iteration)
- The fix resolves the root cause for all 7 related issues

Fixes #1170, #1171, #1173, #1175, #1176, #1179, #1182