### PR TITLE
fix: replace paginate with collect in publisher trigger sync functions

### DIFF
--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -146,18 +146,13 @@ export async function syncPackageSearchDigestsForOwnerUserId(
   ownerUserId: Id<"users"> | null | undefined,
 ) {
   if (!ownerUserId) return;
-  let cursor: string | null = null;
   try {
-    while (true) {
-      const page = await ctx.db
-        .query("packages")
-        .withIndex("by_owner", (q) => q.eq("ownerUserId", ownerUserId))
-        .paginate({ cursor, numItems: 100 });
-      for (const pkg of page.page) {
-        await syncPackageSearchDigest(ctx, pkg);
-      }
-      if (page.isDone) break;
-      cursor = page.continueCursor;
+    const packages = await ctx.db
+      .query("packages")
+      .withIndex("by_owner", (q) => q.eq("ownerUserId", ownerUserId))
+      .collect();
+    for (const pkg of packages) {
+      await syncPackageSearchDigest(ctx, pkg);
     }
   } catch (error) {
     if (isMissingTableError(error, "packages")) return;
@@ -170,18 +165,13 @@ export async function syncPackageSearchDigestsForOwnerPublisherId(
   ownerPublisherId: Id<"publishers"> | null | undefined,
 ) {
   if (!ownerPublisherId) return;
-  let cursor: string | null = null;
   try {
-    while (true) {
-      const page = await ctx.db
-        .query("packages")
-        .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", ownerPublisherId))
-        .paginate({ cursor, numItems: 100 });
-      for (const pkg of page.page) {
-        await syncPackageSearchDigest(ctx, pkg);
-      }
-      if (page.isDone) break;
-      cursor = page.continueCursor;
+    const packages = await ctx.db
+      .query("packages")
+      .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", ownerPublisherId))
+      .collect();
+    for (const pkg of packages) {
+      await syncPackageSearchDigest(ctx, pkg);
     }
   } catch (error) {
     if (isMissingTableError(error, "packages")) return;
@@ -214,18 +204,13 @@ export async function syncSkillSearchDigestsForOwnerPublisherId(
   ownerPublisherId: Id<"publishers"> | null | undefined,
 ) {
   if (!ownerPublisherId) return;
-  let cursor: string | null = null;
   try {
-    while (true) {
-      const page = await ctx.db
-        .query("skills")
-        .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", ownerPublisherId))
-        .paginate({ cursor, numItems: 100 });
-      for (const skill of page.page) {
-        await syncSkillSearchDigestForSkill(ctx, skill);
-      }
-      if (page.isDone) break;
-      cursor = page.continueCursor;
+    const skills = await ctx.db
+      .query("skills")
+      .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", ownerPublisherId))
+      .collect();
+    for (const skill of skills) {
+      await syncSkillSearchDigestForSkill(ctx, skill);
     }
   } catch (error) {
     if (isMissingTableError(error, "skills")) return;


### PR DESCRIPTION
## Problem

The `publishers` trigger in `convex/functions.ts` calls both `syncPackageSearchDigestsForOwnerPublisherId` and `syncSkillSearchDigestsForOwnerPublisherId` sequentially. Each used a `.paginate()` while-loop, causing Convex to reject the mutation with:

```
Uncaught Error: This query or mutation function ran multiple paginated queries.
Convex only supports a single paginated query in each function.
```

This breaks:
- `clawhub publish` — fails when `ensurePersonalPublisherForUser` inserts a new publisher record
- `clawhub` sync — same error
- Web publishing — results in 'Personal publisher not found' since the publisher record is never created

## Fix

Replace `.paginate()` loops with `.collect()` in all three sync-by-owner functions:
- `syncPackageSearchDigestsForOwnerUserId`
- `syncPackageSearchDigestsForOwnerPublisherId`
- `syncSkillSearchDigestsForOwnerPublisherId`

`.collect()` does not count against Convex's single-pagination-per-mutation limit, so the `publishers` trigger can call multiple sync functions without error.

## Testing

The `getPreferredFallbackPackageRelease` function retains `.paginate()` since it's only called from the `packageReleases` trigger (no multi-pagination conflict).