### PR TITLE
fix(convex): avoid multiple paginated queries in publisher digest sync

### DIFF
--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -232,7 +232,7 @@ export async function syncSkillSearchDigestsForOwnerPublisherId(
   }
 }
 
-export const syncSkillSearchDigestsForOwnerPublisherIdInternal = internalMutation({
+export const syncSkillSearchDigestsForOwnerPublisherIdInternal = rawInternalMutation({
   args: {
     ownerPublisherId: v.id("publishers"),
     cursor: v.optional(v.string()),


### PR DESCRIPTION
## Summary
This patch prevents a single Convex function execution from running two paginated queries in the publisher-triggered digest sync path.

## Root cause
When publisher records are inserted/updated (e.g. during skill publish), the `publishers` trigger in `convex/functions.ts` executes:
- `syncPackageSearchDigestsForOwnerPublisherId` (uses `.paginate()`)
- `syncSkillSearchDigestsForOwnerPublisherId` (also used `.paginate()`)

Convex allows only one paginated query per function execution, which can throw:
`This query or mutation function ran multiple paginated queries`.

## Change
- Refactor `syncSkillSearchDigestsForOwnerPublisherId` to use a non-paginated indexed `.collect()` query.
- Keep package digest sync paginated.
- Result: the publisher-triggered path executes only one paginated query.

## Why this is safe
- Scope is limited to skill digest sync by owner publisher.
- Maintains existing behavior of syncing all matching skills.
- Avoids the publish-time backend failure path seen in production.

## Repro this addresses
Publishing a skill can fail with stack frames including:
- `syncSkillSearchDigestsForOwnerPublisherId`
- `ensurePersonalPublisherForUser`

and error:
`Convex only supports a single paginated query in each function.`
