### PR TITLE
fix(convex): schedule skill digest pagination to avoid dual-paginate + TDZ

### DIFF
--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -211,7 +211,11 @@ async function syncSkillSearchDigestForSkill(
   });
 }
 
-export async function syncSkillSearchDigestsForOwnerPublisherId(
+/**
+ * Sync exactly one page of skill digests for a publisher and return pagination state.
+ * Callers that need full coverage must continue via continueCursor (see internal worker below).
+ */
+export async function syncSkillSearchDigestsPageForOwnerPublisherId(
   ctx: PackageDigestSyncCtx,
   ownerPublisherId: Id<"publishers"> | null | undefined,
   cursor: string | null = null,
@@ -236,6 +240,26 @@ export async function syncSkillSearchDigestsForOwnerPublisherId(
 // Temporal Dead Zone: the custom wrapper (line ~366) is declared after this const.
 // skillSearchDigest has no registered triggers so wrapDB is not needed here.
 export const syncSkillSearchDigestsForOwnerPublisherIdInternal = rawInternalMutation({
+  args: {
+    ownerPublisherId: v.id("publishers"),
+    cursor: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const page = await syncSkillSearchDigestsPageForOwnerPublisherId(
+      ctx,
+      args.ownerPublisherId,
+      args.cursor ?? null,
+    );
+    if (!page || page.isDone) return { done: true as const };
+    // Continue via scheduler so each execution performs only one paginated query
+    // (Convex enforces one paginated query per function execution).
+    await ctx.scheduler.runAfter(0, internal.functions.syncSkillSearchDigestsForOwnerPublisherIdInternal, {
+      ownerPublisherId: args.ownerPublisherId,
+      cursor: page.continueCursor,
+    });
+    return { done: false as const, cursor: page.continueCursor };
+  },
+});
 
 export async function repointPackageLatestRelease(
   ctx: PackageDigestSyncCtx,


### PR DESCRIPTION
## Summary
Fix Convex multi-pagination publish failures without regressing scalability.

## Problem
The `publishers` trigger in `convex/functions.ts` could execute two paginated queries in one function run:
- package digest sync (paginated)
- skill digest sync (paginated)

Convex allows only one paginated query per function execution, causing publish failures.

## Correct fix
- Keep package digest sync as-is in the trigger.
- Move skill digest sync into a scheduled internal worker mutation.
- Worker paginates one page at a time and re-schedules itself with `continueCursor`.
- Declare worker with `rawInternalMutation(...)` to avoid TDZ at module init.

## Why this is better
- Respects Convex one-paginated-query rule per execution.
- Preserves scalability (no full `.collect()` over all skills).
- Avoids module initialization error from early `internalMutation` reference.

## Files changed
- `convex/functions.ts`

## Notes
This closes the publish-path failure mode while keeping large publisher/org datasets safe from collect-size limits.
