### PR TITLE
fix(convex): schedule skill digest pagination to avoid dual-paginate + TDZ

### DIFF
--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -220,7 +220,7 @@ export async function syncSkillSearchDigestsPageForOwnerPublisherId(
   ownerPublisherId: Id<"publishers"> | null | undefined,
   cursor: string | null = null,
 ) {
-  if (!ownerPublisherId) return;
+  if (!ownerPublisherId) return null;
   try {
     const page = await ctx.db
       .query("skills")
@@ -364,11 +364,9 @@ triggers.register("users", async (ctx, change) => {
 triggers.register("publishers", async (ctx, change) => {
   const ownerPublisherId = change.operation === "delete" ? change.id : change.newDoc._id;
   await syncPackageSearchDigestsForOwnerPublisherId(ctx, ownerPublisherId);
-  if (ownerPublisherId) {
-    await ctx.scheduler.runAfter(0, internal.functions.syncSkillSearchDigestsForOwnerPublisherIdInternal, {
-      ownerPublisherId,
-    });
-  }
+  await ctx.scheduler.runAfter(0, internal.functions.syncSkillSearchDigestsForOwnerPublisherIdInternal, {
+    ownerPublisherId,
+  });
 });
 
 export const mutation = customMutation(rawMutation, customCtx(triggers.wrapDB));


### PR DESCRIPTION
## Summary
Fix Convex multi-pagination publish failures without regressing scalability.

## Problem
The `publishers` trigger in `convex/functions.ts` could execute two paginated queries in one function run:
- package digest sync (paginated)
- skill digest sync (paginated)

Convex allows only one paginated query per function execution, causing publish failures.

## Correct fix
- Keep package digest sync as-is in the trigger.
- Move skill digest sync into a scheduled internal worker mutation.
- Worker paginates one page at a time and re-schedules itself with `continueCursor`.
- Declare worker with `rawInternalMutation(...)` to avoid TDZ at module init.

## Why this is better
- Respects Convex one-paginated-query rule per execution.
- Preserves scalability (no full `.collect()` over all skills).
- Avoids module initialization error from early `internalMutation` reference.

## Files changed
- `convex/functions.ts`

## Notes
This closes the publish-path failure mode while keeping large publisher/org datasets safe from collect-size limits.
