### PR TITLE
fix(search): improve lexical fallback coverage for recently published skills (#1185)

### DIFF
--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -576,6 +576,51 @@ describe("search helpers", () => {
     expect(result).toHaveLength(0);
   });
 
+  it("finds recently created skill missed by updatedAt scan via createdAt scan (#1185)", async () => {
+    // Skill was recently created but not recently updated — only appears in by_active_created.
+    const newSkill = makeSkillDoc({
+      id: "skills:new",
+      slug: "ai-clipping",
+      displayName: "AI Clipping",
+    });
+    const ctx = makeLexicalCtx({
+      exactSlugSkill: null,
+      recentSkills: [], // updatedAt scan returns nothing
+      recentByCreated: [newSkill], // createdAt scan finds it
+    });
+
+    const result = await lexicalFallbackSkillsHandler(ctx, {
+      query: "clipping",
+      queryTokens: ["clipping"],
+      limit: 10,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].skill.slug).toBe("ai-clipping");
+  });
+
+  it("deduplicates skills found by both updatedAt and createdAt scans", async () => {
+    const skill = makeSkillDoc({
+      id: "skills:dup",
+      slug: "orf-dup",
+      displayName: "ORF Dup",
+    });
+    const ctx = makeLexicalCtx({
+      exactSlugSkill: null,
+      recentSkills: [skill],
+      recentByCreated: [skill], // same skill in both scans
+    });
+
+    const result = await lexicalFallbackSkillsHandler(ctx, {
+      query: "orf",
+      queryTokens: ["orf"],
+      limit: 10,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].skill.slug).toBe("orf-dup");
+  });
+
   it("advances candidate limit until max", () => {
     expect(__test.getNextCandidateLimit(50, 1000)).toBe(100);
     expect(__test.getNextCandidateLimit(800, 1000)).toBe(1000);
@@ -866,16 +911,20 @@ function makeSkillDoc(params: {
 function makeLexicalCtx(params: {
   exactSlugSkill: ReturnType<typeof makeSkillDoc> | null;
   recentSkills: Array<ReturnType<typeof makeSkillDoc>>;
+  recentByCreated?: Array<ReturnType<typeof makeSkillDoc>>;
 }) {
   // Convert skill docs to digest-shaped rows (add skillId + owner fields).
-  const digestRows = params.recentSkills.map((skill) => ({
-    ...skill,
-    skillId: skill._id,
-    ownerHandle: "owner",
-    ownerName: "Owner",
-    ownerDisplayName: "Owner",
-    ownerImage: undefined,
-  }));
+  const toDigestRows = (skills: Array<ReturnType<typeof makeSkillDoc>>) =>
+    skills.map((skill) => ({
+      ...skill,
+      skillId: skill._id,
+      ownerHandle: "owner",
+      ownerName: "Owner",
+      ownerDisplayName: "Owner",
+      ownerImage: undefined,
+    }));
+  const digestByUpdated = toDigestRows(params.recentSkills);
+  const digestByCreated = toDigestRows(params.recentByCreated ?? []);
   return {
     db: {
       query: vi.fn((table: string) => {
@@ -897,7 +946,14 @@ function makeLexicalCtx(params: {
               if (index === "by_active_updated") {
                 return {
                   order: () => ({
-                    take: vi.fn().mockResolvedValue(digestRows),
+                    take: vi.fn().mockResolvedValue(digestByUpdated),
+                  }),
+                };
+              }
+              if (index === "by_active_created") {
+                return {
+                  order: () => ({
+                    take: vi.fn().mockResolvedValue(digestByCreated),
                   }),
                 };
               }

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -50,7 +50,7 @@ const SLUG_PREFIX_BOOST = 0.8;
 const NAME_EXACT_BOOST = 1.1;
 const NAME_PREFIX_BOOST = 0.6;
 const POPULARITY_WEIGHT = 0.08;
-const FALLBACK_SCAN_LIMIT = 500;
+const FALLBACK_SCAN_LIMIT = 2000;
 
 function getNextCandidateLimit(current: number, max: number) {
   const next = Math.min(current * 2, max);
@@ -361,13 +361,22 @@ export const lexicalFallbackSkills = internalQuery({
     }
 
     // Scan recent active digests (~800 bytes each) instead of full skill docs (~3-5KB).
-    const recentDigests = await ctx.db
-      .query("skillSearchDigest")
-      .withIndex("by_active_updated", (q) => q.eq("softDeletedAt", undefined))
-      .order("desc")
-      .take(FALLBACK_SCAN_LIMIT);
+    // Use two scan windows (updatedAt + createdAt) to cover both recently modified
+    // and recently published skills that may not overlap in the top N entries.
+    const [recentByUpdated, recentByCreated] = await Promise.all([
+      ctx.db
+        .query("skillSearchDigest")
+        .withIndex("by_active_updated", (q) => q.eq("softDeletedAt", undefined))
+        .order("desc")
+        .take(FALLBACK_SCAN_LIMIT),
+      ctx.db
+        .query("skillSearchDigest")
+        .withIndex("by_active_created", (q) => q.eq("softDeletedAt", undefined))
+        .order("desc")
+        .take(FALLBACK_SCAN_LIMIT),
+    ]);
 
-    for (const digest of recentDigests) {
+    for (const digest of [...recentByUpdated, ...recentByCreated]) {
       if (seenSkillIds.has(digest.skillId)) continue;
       const skill = digestToHydratableSkill(digest);
       if (args.nonSuspiciousOnly && isSkillSuspicious(skill)) continue;


### PR DESCRIPTION
## Summary
- Raise `FALLBACK_SCAN_LIMIT` from 500 to 2000 to cover more skills in the lexical fallback
- Add a secondary scan by `createdAt` alongside the existing `updatedAt` scan, so recently published skills are found even if not recently updated
- Deduplicate results across both scan windows

## Problem
Published skills can be invisible in search when their embedding has low vector similarity AND the skill falls outside the 500 most recently updated digests in the lexical fallback scan. This was reported in #1185 where a published skill was accessible via direct URL but didn't appear in any search queries.

## How it works
The lexical fallback previously only scanned `skillSearchDigest` by `by_active_updated` (descending). On an active registry, a newly published skill that hasn't been modified since publication could fall outside the top 500, making it invisible to the fallback path.

This PR:
1. Raises the scan limit from 500 → 2000 (~1.6MB at ~800 bytes/digest, within Convex's 8MB limit)
2. Adds a parallel scan by `by_active_created` to catch recently created skills missed by the `updatedAt` window
3. Deduplicates across both scans using the existing `seenSkillIds` set

## Test plan
- [x] Added test: skill found only via `createdAt` scan is included in results
- [x] Added test: skills appearing in both scans are deduplicated
- [x] All 18 existing + new search tests pass
