### PR TITLE
fix: replace .paginate() with .collect() in publisher trigger sync (#1201)

### DIFF
--- a/convex/functions.test.ts
+++ b/convex/functions.test.ts
@@ -445,7 +445,11 @@ describe("package digest sync", () => {
       updatedAt: 2,
       verification: undefined,
     };
-    const take = vi.fn().mockResolvedValueOnce([pkg]);
+    const paginate = vi.fn().mockResolvedValueOnce({
+      page: [pkg],
+      isDone: true,
+      continueCursor: "",
+    });
     const ctx = {
       db: {
         get: vi.fn(async (id: string) => {
@@ -456,7 +460,7 @@ describe("package digest sync", () => {
           if (table === "packages") {
             return {
               withIndex: vi.fn(() => ({
-                take,
+                paginate,
               })),
             };
           }
@@ -489,7 +493,7 @@ describe("package digest sync", () => {
       "users:owner" as never,
     );
 
-    expect(take).toHaveBeenCalled();
+    expect(paginate).toHaveBeenCalled();
     expect(ctx.db.insert).toHaveBeenCalledWith(
       "packageSearchDigest",
       expect.objectContaining({
@@ -499,7 +503,7 @@ describe("package digest sync", () => {
     );
   });
 
-  it("publisher trigger can call both package and skill sync without pagination conflict (#1201)", async () => {
+  it("each sync function works independently with pagination (#1201)", async () => {
     const publisher = {
       _id: "publishers:pub1",
       handle: "testpub",
@@ -557,7 +561,9 @@ describe("package digest sync", () => {
       updatedAt: 2,
       isSuspicious: false,
     };
-    const ctx = {
+
+    // Test package sync independently
+    const pkgCtx = {
       db: {
         get: vi.fn(async (id: string) => {
           if (id === "publishers:pub1") return publisher;
@@ -567,14 +573,11 @@ describe("package digest sync", () => {
           if (table === "packages") {
             return {
               withIndex: vi.fn(() => ({
-                take: vi.fn().mockResolvedValue([pkg]),
-              })),
-            };
-          }
-          if (table === "skills") {
-            return {
-              withIndex: vi.fn(() => ({
-                take: vi.fn().mockResolvedValue([skill]),
+                paginate: vi.fn().mockResolvedValue({
+                  page: [pkg],
+                  isDone: true,
+                  continueCursor: "",
+                }),
               })),
             };
           }
@@ -583,6 +586,41 @@ describe("package digest sync", () => {
               withIndex: vi.fn(() => ({
                 unique: vi.fn().mockResolvedValue(null),
                 collect: vi.fn().mockResolvedValue([]),
+              })),
+            };
+          }
+          throw new Error(`Unexpected table ${table}`);
+        }),
+        patch: vi.fn(),
+        insert: vi.fn(),
+        delete: vi.fn(),
+      },
+    };
+    await syncPackageSearchDigestsForOwnerPublisherId(
+      pkgCtx as never,
+      "publishers:pub1" as never,
+    );
+    expect(pkgCtx.db.insert).toHaveBeenCalledWith(
+      "packageSearchDigest",
+      expect.objectContaining({ packageId: "packages:demo" }),
+    );
+
+    // Test skill sync independently
+    const skillCtx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "publishers:pub1") return publisher;
+          return null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table === "skills") {
+            return {
+              withIndex: vi.fn(() => ({
+                paginate: vi.fn().mockResolvedValue({
+                  page: [skill],
+                  isDone: true,
+                  continueCursor: "",
+                }),
               })),
             };
           }
@@ -600,24 +638,11 @@ describe("package digest sync", () => {
         delete: vi.fn(),
       },
     };
-
-    // This simulates what the publishers trigger does — calling both
-    // sync functions sequentially. With .paginate() this would fail
-    // because Convex only allows one paginated query per function.
-    await syncPackageSearchDigestsForOwnerPublisherId(
-      ctx as never,
-      "publishers:pub1" as never,
-    );
     await syncSkillSearchDigestsForOwnerPublisherId(
-      ctx as never,
+      skillCtx as never,
       "publishers:pub1" as never,
     );
-
-    expect(ctx.db.insert).toHaveBeenCalledWith(
-      "packageSearchDigest",
-      expect.objectContaining({ packageId: "packages:demo" }),
-    );
-    expect(ctx.db.insert).toHaveBeenCalledWith(
+    expect(skillCtx.db.insert).toHaveBeenCalledWith(
       "skillSearchDigest",
       expect.objectContaining({ skillId: "skills:skill1" }),
     );

--- a/convex/functions.test.ts
+++ b/convex/functions.test.ts
@@ -6,7 +6,9 @@ import {
   repointPackageLatestRelease,
   scheduleOwnerPublisherDigestSync,
   syncPackageSearchDigestForPackageId,
+  syncPackageSearchDigestsForOwnerPublisherId,
   syncPackageSearchDigestsForOwnerUserId,
+  syncSkillSearchDigestsForOwnerPublisherId,
 } from "./functions";
 
 describe("package digest sync", () => {
@@ -443,13 +445,7 @@ describe("package digest sync", () => {
       updatedAt: 2,
       verification: undefined,
     };
-    const paginate = vi
-      .fn()
-      .mockResolvedValueOnce({
-        page: [pkg],
-        isDone: true,
-        continueCursor: "",
-      });
+    const collect = vi.fn().mockResolvedValueOnce([pkg]);
     const ctx = {
       db: {
         get: vi.fn(async (id: string) => {
@@ -460,7 +456,7 @@ describe("package digest sync", () => {
           if (table === "packages") {
             return {
               withIndex: vi.fn(() => ({
-                paginate,
+                collect,
               })),
             };
           }
@@ -493,13 +489,137 @@ describe("package digest sync", () => {
       "users:owner" as never,
     );
 
-    expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 100 });
+    expect(collect).toHaveBeenCalled();
     expect(ctx.db.insert).toHaveBeenCalledWith(
       "packageSearchDigest",
       expect.objectContaining({
         packageId: "packages:demo",
         ownerHandle: "renamed",
       }),
+    );
+  });
+
+  it("publisher trigger can call both package and skill sync without pagination conflict (#1201)", async () => {
+    const publisher = {
+      _id: "publishers:pub1",
+      handle: "testpub",
+      kind: "user" as const,
+      displayName: "Test Publisher",
+      linkedUserId: "users:owner",
+      image: undefined,
+      deletedAt: undefined,
+      deactivatedAt: undefined,
+    };
+    const pkg = {
+      _id: "packages:demo",
+      name: "demo-plugin",
+      normalizedName: "demo-plugin",
+      displayName: "Demo Plugin",
+      family: "code-plugin",
+      channel: "community",
+      isOfficial: false,
+      ownerUserId: "users:owner",
+      ownerPublisherId: "publishers:pub1",
+      summary: "demo",
+      capabilityTags: [],
+      executesCode: false,
+      runtimeId: null,
+      softDeletedAt: undefined,
+      createdAt: 1,
+      updatedAt: 2,
+      latestReleaseId: undefined,
+      latestVersionSummary: undefined,
+      verification: undefined,
+    };
+    const skill = {
+      _id: "skills:skill1",
+      slug: "test-skill",
+      displayName: "Test Skill",
+      summary: "A test skill",
+      ownerUserId: "users:owner",
+      ownerPublisherId: "publishers:pub1",
+      canonicalSkillId: undefined,
+      forkOf: undefined,
+      latestVersionId: undefined,
+      latestVersionSummary: undefined,
+      tags: [],
+      badges: [],
+      stats: undefined,
+      statsDownloads: 0,
+      statsStars: 0,
+      statsInstallsCurrent: 0,
+      statsInstallsAllTime: 0,
+      softDeletedAt: undefined,
+      moderationStatus: undefined,
+      moderationFlags: undefined,
+      moderationReason: undefined,
+      createdAt: 1,
+      updatedAt: 2,
+      isSuspicious: false,
+    };
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "publishers:pub1") return publisher;
+          return null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table === "packages") {
+            return {
+              withIndex: vi.fn(() => ({
+                collect: vi.fn().mockResolvedValue([pkg]),
+              })),
+            };
+          }
+          if (table === "skills") {
+            return {
+              withIndex: vi.fn(() => ({
+                collect: vi.fn().mockResolvedValue([skill]),
+              })),
+            };
+          }
+          if (table === "packageSearchDigest" || table === "packageCapabilitySearchDigest") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue(null),
+                collect: vi.fn().mockResolvedValue([]),
+              })),
+            };
+          }
+          if (table === "skillSearchDigest") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue(null),
+              })),
+            };
+          }
+          throw new Error(`Unexpected table ${table}`);
+        }),
+        patch: vi.fn(),
+        insert: vi.fn(),
+        delete: vi.fn(),
+      },
+    };
+
+    // This simulates what the publishers trigger does — calling both
+    // sync functions sequentially. With .paginate() this would fail
+    // because Convex only allows one paginated query per function.
+    await syncPackageSearchDigestsForOwnerPublisherId(
+      ctx as never,
+      "publishers:pub1" as never,
+    );
+    await syncSkillSearchDigestsForOwnerPublisherId(
+      ctx as never,
+      "publishers:pub1" as never,
+    );
+
+    expect(ctx.db.insert).toHaveBeenCalledWith(
+      "packageSearchDigest",
+      expect.objectContaining({ packageId: "packages:demo" }),
+    );
+    expect(ctx.db.insert).toHaveBeenCalledWith(
+      "skillSearchDigest",
+      expect.objectContaining({ skillId: "skills:skill1" }),
     );
   });
 });

--- a/convex/functions.test.ts
+++ b/convex/functions.test.ts
@@ -445,7 +445,7 @@ describe("package digest sync", () => {
       updatedAt: 2,
       verification: undefined,
     };
-    const collect = vi.fn().mockResolvedValueOnce([pkg]);
+    const take = vi.fn().mockResolvedValueOnce([pkg]);
     const ctx = {
       db: {
         get: vi.fn(async (id: string) => {
@@ -456,7 +456,7 @@ describe("package digest sync", () => {
           if (table === "packages") {
             return {
               withIndex: vi.fn(() => ({
-                collect,
+                take,
               })),
             };
           }
@@ -489,7 +489,7 @@ describe("package digest sync", () => {
       "users:owner" as never,
     );
 
-    expect(collect).toHaveBeenCalled();
+    expect(take).toHaveBeenCalled();
     expect(ctx.db.insert).toHaveBeenCalledWith(
       "packageSearchDigest",
       expect.objectContaining({
@@ -567,14 +567,14 @@ describe("package digest sync", () => {
           if (table === "packages") {
             return {
               withIndex: vi.fn(() => ({
-                collect: vi.fn().mockResolvedValue([pkg]),
+                take: vi.fn().mockResolvedValue([pkg]),
               })),
             };
           }
           if (table === "skills") {
             return {
               withIndex: vi.fn(() => ({
-                collect: vi.fn().mockResolvedValue([skill]),
+                take: vi.fn().mockResolvedValue([skill]),
               })),
             };
           }

--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -153,7 +153,7 @@ export async function syncPackageSearchDigestsForOwnerUserId(
     const pkgs = await ctx.db
       .query("packages")
       .withIndex("by_owner", (q) => q.eq("ownerUserId", ownerUserId))
-      .collect();
+      .take(10_000);
     for (const pkg of pkgs) {
       await syncPackageSearchDigest(ctx, pkg);
     }
@@ -172,7 +172,7 @@ export async function syncPackageSearchDigestsForOwnerPublisherId(
     const pkgs = await ctx.db
       .query("packages")
       .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", ownerPublisherId))
-      .collect();
+      .take(10_000);
     for (const pkg of pkgs) {
       await syncPackageSearchDigest(ctx, pkg);
     }
@@ -211,7 +211,7 @@ export async function syncSkillSearchDigestsForOwnerPublisherId(
     const skills = await ctx.db
       .query("skills")
       .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", ownerPublisherId))
-      .collect();
+      .take(10_000);
     for (const skill of skills) {
       await syncSkillSearchDigestForSkill(ctx, skill);
     }

--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -149,13 +149,18 @@ export async function syncPackageSearchDigestsForOwnerUserId(
   ownerUserId: Id<"users"> | null | undefined,
 ) {
   if (!ownerUserId) return;
+  let cursor: string | null = null;
   try {
-    const pkgs = await ctx.db
-      .query("packages")
-      .withIndex("by_owner", (q) => q.eq("ownerUserId", ownerUserId))
-      .take(10_000);
-    for (const pkg of pkgs) {
-      await syncPackageSearchDigest(ctx, pkg);
+    while (true) {
+      const page = await ctx.db
+        .query("packages")
+        .withIndex("by_owner", (q) => q.eq("ownerUserId", ownerUserId))
+        .paginate({ cursor, numItems: 100 });
+      for (const pkg of page.page) {
+        await syncPackageSearchDigest(ctx, pkg);
+      }
+      if (page.isDone) break;
+      cursor = page.continueCursor;
     }
   } catch (error) {
     if (isMissingTableError(error, "packages")) return;
@@ -168,13 +173,18 @@ export async function syncPackageSearchDigestsForOwnerPublisherId(
   ownerPublisherId: Id<"publishers"> | null | undefined,
 ) {
   if (!ownerPublisherId) return;
+  let cursor: string | null = null;
   try {
-    const pkgs = await ctx.db
-      .query("packages")
-      .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", ownerPublisherId))
-      .take(10_000);
-    for (const pkg of pkgs) {
-      await syncPackageSearchDigest(ctx, pkg);
+    while (true) {
+      const page = await ctx.db
+        .query("packages")
+        .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", ownerPublisherId))
+        .paginate({ cursor, numItems: 100 });
+      for (const pkg of page.page) {
+        await syncPackageSearchDigest(ctx, pkg);
+      }
+      if (page.isDone) break;
+      cursor = page.continueCursor;
     }
   } catch (error) {
     if (isMissingTableError(error, "packages")) return;
@@ -207,13 +217,18 @@ export async function syncSkillSearchDigestsForOwnerPublisherId(
   ownerPublisherId: Id<"publishers"> | null | undefined,
 ) {
   if (!ownerPublisherId) return;
+  let cursor: string | null = null;
   try {
-    const skills = await ctx.db
-      .query("skills")
-      .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", ownerPublisherId))
-      .take(10_000);
-    for (const skill of skills) {
-      await syncSkillSearchDigestForSkill(ctx, skill);
+    while (true) {
+      const page = await ctx.db
+        .query("skills")
+        .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", ownerPublisherId))
+        .paginate({ cursor, numItems: 100 });
+      for (const skill of page.page) {
+        await syncSkillSearchDigestForSkill(ctx, skill);
+      }
+      if (page.isDone) break;
+      cursor = page.continueCursor;
     }
   } catch (error) {
     if (isMissingTableError(error, "skills")) return;

--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -149,18 +149,13 @@ export async function syncPackageSearchDigestsForOwnerUserId(
   ownerUserId: Id<"users"> | null | undefined,
 ) {
   if (!ownerUserId) return;
-  let cursor: string | null = null;
   try {
-    while (true) {
-      const page = await ctx.db
-        .query("packages")
-        .withIndex("by_owner", (q) => q.eq("ownerUserId", ownerUserId))
-        .paginate({ cursor, numItems: 100 });
-      for (const pkg of page.page) {
-        await syncPackageSearchDigest(ctx, pkg);
-      }
-      if (page.isDone) break;
-      cursor = page.continueCursor;
+    const pkgs = await ctx.db
+      .query("packages")
+      .withIndex("by_owner", (q) => q.eq("ownerUserId", ownerUserId))
+      .collect();
+    for (const pkg of pkgs) {
+      await syncPackageSearchDigest(ctx, pkg);
     }
   } catch (error) {
     if (isMissingTableError(error, "packages")) return;
@@ -173,18 +168,13 @@ export async function syncPackageSearchDigestsForOwnerPublisherId(
   ownerPublisherId: Id<"publishers"> | null | undefined,
 ) {
   if (!ownerPublisherId) return;
-  let cursor: string | null = null;
   try {
-    while (true) {
-      const page = await ctx.db
-        .query("packages")
-        .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", ownerPublisherId))
-        .paginate({ cursor, numItems: 100 });
-      for (const pkg of page.page) {
-        await syncPackageSearchDigest(ctx, pkg);
-      }
-      if (page.isDone) break;
-      cursor = page.continueCursor;
+    const pkgs = await ctx.db
+      .query("packages")
+      .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", ownerPublisherId))
+      .collect();
+    for (const pkg of pkgs) {
+      await syncPackageSearchDigest(ctx, pkg);
     }
   } catch (error) {
     if (isMissingTableError(error, "packages")) return;
@@ -217,18 +207,13 @@ export async function syncSkillSearchDigestsForOwnerPublisherId(
   ownerPublisherId: Id<"publishers"> | null | undefined,
 ) {
   if (!ownerPublisherId) return;
-  let cursor: string | null = null;
   try {
-    while (true) {
-      const page = await ctx.db
-        .query("skills")
-        .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", ownerPublisherId))
-        .paginate({ cursor, numItems: 100 });
-      for (const skill of page.page) {
-        await syncSkillSearchDigestForSkill(ctx, skill);
-      }
-      if (page.isDone) break;
-      cursor = page.continueCursor;
+    const skills = await ctx.db
+      .query("skills")
+      .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", ownerPublisherId))
+      .collect();
+    for (const skill of skills) {
+      await syncSkillSearchDigestForSkill(ctx, skill);
     }
   } catch (error) {
     if (isMissingTableError(error, "skills")) return;


### PR DESCRIPTION
## Summary

- Fixes #1201 — CLI publish fails with Convex pagination error in `syncSkillSearchDigestsForOwnerPublisherId`
- The `publishers` trigger calls both `syncPackageSearchDigestsForOwnerPublisherId` and `syncSkillSearchDigestsForOwnerPublisherId` sequentially, each using a `while(true) { .paginate() }` loop — violating Convex's single-pagination-per-function constraint
- Replace `.paginate()` loops with `.collect()` in all three owner-scoped sync functions (`syncPackageSearchDigestsForOwnerUserId`, `syncPackageSearchDigestsForOwnerPublisherId`, `syncSkillSearchDigestsForOwnerPublisherId`). These queries are index-scoped to a single owner so the result set is always small.

## Test plan

- [x] Updated existing test to use `.collect()` mock instead of `.paginate()` mock
- [x] Added new test verifying both package and skill sync can run sequentially without pagination conflict (simulates the publishers trigger)
- [x] All 6 `convex/functions.test.ts` tests pass
