### PR TITLE
fix: split publisher digest sync scheduling

### DIFF
--- a/convex/functions.test.ts
+++ b/convex/functions.test.ts
@@ -9,8 +9,6 @@ import {
   syncPackageSearchDigestsForOwnerUserId,
 } from "./functions";
 
-type InternalFunctionRef = unknown;
-
 describe("package digest sync", () => {
   it("clears latestVersion when the current package release is soft-deleted", async () => {
     const pkg = {
@@ -508,12 +506,6 @@ describe("package digest sync", () => {
 
 describe("publisher digest scheduling", () => {
   it("schedules package and skill digest sync in separate background mutations", async () => {
-    const ownerPublisherDigestSyncInternal = internal as unknown as {
-      functions: {
-        syncPackageSearchDigestsForOwnerPublisherIdInternal: InternalFunctionRef;
-        syncSkillSearchDigestsForOwnerPublisherIdInternal: InternalFunctionRef;
-      };
-    };
     const ctx = {
       scheduler: {
         runAfter: vi.fn().mockResolvedValue(undefined),
@@ -526,13 +518,13 @@ describe("publisher digest scheduling", () => {
     expect(ctx.scheduler.runAfter).toHaveBeenNthCalledWith(
       1,
       0,
-      ownerPublisherDigestSyncInternal.functions.syncPackageSearchDigestsForOwnerPublisherIdInternal,
+      internal.functions.syncPackageSearchDigestsForOwnerPublisherIdInternal,
       { ownerPublisherId: "publishers:demo" },
     );
     expect(ctx.scheduler.runAfter).toHaveBeenNthCalledWith(
       2,
       0,
-      ownerPublisherDigestSyncInternal.functions.syncSkillSearchDigestsForOwnerPublisherIdInternal,
+      internal.functions.syncSkillSearchDigestsForOwnerPublisherIdInternal,
       { ownerPublisherId: "publishers:demo" },
     );
   });

--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -33,7 +33,6 @@ function isMissingTableError(error: unknown, table: string) {
 
 type PackageDigestSyncCtx = Pick<MutationCtx, "db">;
 type OwnerPublisherDigestScheduleCtx = Pick<MutationCtx, "scheduler">;
-type ScheduledMutationRef = Parameters<MutationCtx["scheduler"]["runAfter"]>[1];
 type LatestPackageRelease = Pick<
   Doc<"packageReleases">,
   | "_id"
@@ -242,20 +241,14 @@ export async function scheduleOwnerPublisherDigestSync(
   ownerPublisherId: Id<"publishers"> | null | undefined,
 ) {
   if (!ownerPublisherId) return;
-  const ownerPublisherDigestSyncInternal = internal as unknown as {
-    functions: {
-      syncPackageSearchDigestsForOwnerPublisherIdInternal: ScheduledMutationRef;
-      syncSkillSearchDigestsForOwnerPublisherIdInternal: ScheduledMutationRef;
-    };
-  };
   await ctx.scheduler.runAfter(
     0,
-    ownerPublisherDigestSyncInternal.functions.syncPackageSearchDigestsForOwnerPublisherIdInternal,
+    internal.functions.syncPackageSearchDigestsForOwnerPublisherIdInternal,
     { ownerPublisherId },
   );
   await ctx.scheduler.runAfter(
     0,
-    ownerPublisherDigestSyncInternal.functions.syncSkillSearchDigestsForOwnerPublisherIdInternal,
+    internal.functions.syncSkillSearchDigestsForOwnerPublisherIdInternal,
     { ownerPublisherId },
   );
 }


### PR DESCRIPTION
## Summary
- split publisher-owned digest sync into two scheduled internal mutations instead of running two paginated loops in one trigger mutation
- add regression coverage for the publisher digest scheduling path
- preserve current digest backfill behavior while unblocking first-time package publish for users missing a personal publisher row

## Repro
1. Log into `clawhub` CLI as a user without an existing `personalPublisherId`
2. Run `clawhub package publish <plugin-dir> --source-repo ... --source-commit ...`
3. Observe Convex fail inside `ensurePersonalPublisherForUser` with:
   `This query or mutation function ran multiple paginated queries. Convex only supports a single paginated query in each function.`

## Testing
- `bun run lint`
- `bunx vitest run convex/functions.test.ts convex/publishers.test.ts`
- `bunx tsc --noEmit`
