### PR TITLE
fix: re-enable theme switching

### DIFF
--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -1,9 +1,18 @@
 /* @vitest-environment jsdom */
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import Header from "../components/Header";
+
+const { applyThemeMock, setModeMock, startThemeTransitionMock } = vi.hoisted(() => ({
+  applyThemeMock: vi.fn(),
+  setModeMock: vi.fn(),
+  startThemeTransitionMock: vi.fn(
+    ({ setTheme, nextTheme }: { setTheme: (value: string) => void; nextTheme: string }) =>
+      setTheme(nextTheme),
+  ),
+}));
 
 vi.mock("@tanstack/react-router", () => ({
   Link: (props: { children: ReactNode }) => <a href="/">{props.children}</a>,
@@ -25,16 +34,15 @@ vi.mock("../lib/useAuthStatus", () => ({
 }));
 
 vi.mock("../lib/theme", () => ({
-  applyTheme: vi.fn(),
+  applyTheme: applyThemeMock,
   useThemeMode: () => ({
     mode: "system",
-    setMode: vi.fn(),
+    setMode: setModeMock,
   }),
 }));
 
 vi.mock("../lib/theme-transition", () => ({
-  startThemeTransition: ({ setTheme, nextTheme }: { setTheme: (value: string) => void; nextTheme: string }) =>
-    setTheme(nextTheme),
+  startThemeTransition: startThemeTransitionMock,
 }));
 
 vi.mock("../lib/useAuthError", () => ({
@@ -71,15 +79,113 @@ vi.mock("../components/ui/dropdown-menu", () => ({
   DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
 
-vi.mock("../components/ui/toggle-group", () => ({
-  ToggleGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  ToggleGroupItem: ({ children }: { children: ReactNode }) => <button type="button">{children}</button>,
-}));
+vi.mock("../components/ui/toggle-group", async () => {
+  const React = await import("react");
+
+  type ToggleGroupProps = {
+    children: ReactNode;
+    value?: string;
+    onValueChange?: (value: string) => void;
+    "aria-label"?: string;
+  };
+
+  type ToggleGroupItemProps = {
+    children: ReactNode;
+    value: string;
+    onClick?: () => void;
+    "aria-label"?: string;
+    currentValue?: string;
+    onValueChange?: (value: string) => void;
+  };
+
+  const values = ["system", "light", "dark"] as const;
+
+  return {
+    ToggleGroup: ({ children, value, onValueChange, ...props }: ToggleGroupProps) => (
+      <div role="group" {...props}>
+        {React.Children.map(children, (child) =>
+          React.isValidElement<ToggleGroupItemProps>(child)
+            ? React.cloneElement(child, { currentValue: value, onValueChange })
+            : child,
+        )}
+      </div>
+    ),
+    ToggleGroupItem: ({
+      children,
+      value,
+      onClick,
+      currentValue,
+      onValueChange,
+      ...props
+    }: ToggleGroupItemProps) => (
+      <button
+        type="button"
+        role="radio"
+        data-state={currentValue === value ? "on" : "off"}
+        aria-checked={currentValue === value}
+        onClick={onClick}
+        onKeyDown={(event) => {
+          if (!onValueChange || !currentValue) return;
+          const currentIndex = values.indexOf(currentValue as (typeof values)[number]);
+          if (event.key === "ArrowRight" && currentIndex >= 0 && currentIndex < values.length - 1) {
+            onValueChange(values[currentIndex + 1]);
+          }
+          if (event.key === "ArrowLeft" && currentIndex > 0) {
+            onValueChange(values[currentIndex - 1]);
+          }
+        }}
+        {...props}
+      >
+        {children}
+      </button>
+    ),
+  };
+});
 
 describe("Header", () => {
+  beforeEach(() => {
+    applyThemeMock.mockClear();
+    setModeMock.mockClear();
+    startThemeTransitionMock.mockClear();
+  });
+
   it("hides Packages navigation in soul mode on mobile and desktop", () => {
     render(<Header />);
 
     expect(screen.queryByText("Packages")).toBeNull();
+  });
+
+  it("switches theme from the desktop theme buttons", () => {
+    render(<Header />);
+
+    fireEvent.click(screen.getByRole("radio", { name: "Dark theme" }));
+
+    expect(startThemeTransitionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentTheme: "system",
+        nextTheme: "dark",
+      }),
+    );
+    expect(applyThemeMock).toHaveBeenCalledWith("dark");
+    expect(setModeMock).toHaveBeenCalledWith("dark");
+  });
+
+  it("switches theme from keyboard navigation on the desktop toggle", () => {
+    render(<Header />);
+
+    const systemTheme = screen.getByRole("radio", { name: "System theme" });
+    systemTheme.focus();
+    fireEvent.keyDown(systemTheme, { key: "ArrowRight" });
+
+    return waitFor(() => {
+      expect(startThemeTransitionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          currentTheme: "system",
+          nextTheme: "light",
+        }),
+      );
+      expect(applyThemeMock).toHaveBeenCalledWith("light");
+      expect(setModeMock).toHaveBeenCalledWith("light");
+    });
   });
 });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -24,6 +24,7 @@ export default function Header() {
   const { signIn, signOut } = useAuthActions();
   const { mode, setMode } = useThemeMode();
   const toggleRef = useRef<HTMLDivElement | null>(null);
+  const pointerThemeRef = useRef<"system" | "light" | "dark" | null>(null);
   const siteMode = getSiteMode();
   const siteName = useMemo(() => getSiteName(siteMode), [siteMode]);
   const isSoulMode = siteMode === "souls";
@@ -47,6 +48,21 @@ export default function Header() {
       },
       context: { element: toggleRef.current },
     });
+  };
+
+  const handlePointerThemeChange = (next: "system" | "light" | "dark") => {
+    pointerThemeRef.current = next;
+    setTheme(next);
+  };
+
+  const handleThemeValueChange = (value: string) => {
+    if (value !== "system" && value !== "light" && value !== "dark") return;
+    if (pointerThemeRef.current === value) {
+      pointerThemeRef.current = null;
+      return;
+    }
+    pointerThemeRef.current = null;
+    setTheme(value);
   };
 
   return (
@@ -239,21 +255,30 @@ export default function Header() {
             <ToggleGroup
               type="single"
               value={mode}
-              onValueChange={(value) => {
-                if (!value) return;
-                setTheme(value as "system" | "light" | "dark");
-              }}
               aria-label="Theme mode"
+              onValueChange={handleThemeValueChange}
             >
-              <ToggleGroupItem value="system" aria-label="System theme">
+              <ToggleGroupItem
+                value="system"
+                aria-label="System theme"
+                onClick={() => handlePointerThemeChange("system")}
+              >
                 <Monitor className="h-4 w-4" aria-hidden="true" />
                 <span className="sr-only">System</span>
               </ToggleGroupItem>
-              <ToggleGroupItem value="light" aria-label="Light theme">
+              <ToggleGroupItem
+                value="light"
+                aria-label="Light theme"
+                onClick={() => handlePointerThemeChange("light")}
+              >
                 <Sun className="h-4 w-4" aria-hidden="true" />
                 <span className="sr-only">Light</span>
               </ToggleGroupItem>
-              <ToggleGroupItem value="dark" aria-label="Dark theme">
+              <ToggleGroupItem
+                value="dark"
+                aria-label="Dark theme"
+                onClick={() => handlePointerThemeChange("dark")}
+              >
                 <Moon className="h-4 w-4" aria-hidden="true" />
                 <span className="sr-only">Dark</span>
               </ToggleGroupItem>

--- a/src/lib/theme.test.tsx
+++ b/src/lib/theme.test.tsx
@@ -49,8 +49,11 @@ describe("theme", () => {
     expect(getStoredTheme()).toBe("dark");
     window.localStorage.setItem("clawhub-theme", "nope");
     expect(getStoredTheme()).toBe("system");
+  });
+
+  it("ignores the legacy ClawDHUB theme key", () => {
     window.localStorage.setItem("clawdhub-theme", "dark");
-    expect(getStoredTheme()).toBe("dark");
+    expect(getStoredTheme()).toBe("system");
   });
 
   it("applies theme and toggles dark class", () => {

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -3,14 +3,11 @@ import { useEffect, useState } from "react";
 export type ThemeMode = "system" | "light" | "dark";
 
 const THEME_KEY = "clawhub-theme";
-const LEGACY_THEME_KEY = "clawdhub-theme";
 
 export function getStoredTheme(): ThemeMode {
   if (typeof window === "undefined") return "system";
   const stored = window.localStorage.getItem(THEME_KEY);
   if (stored === "light" || stored === "dark" || stored === "system") return stored;
-  const legacy = window.localStorage.getItem(LEGACY_THEME_KEY);
-  if (legacy === "light" || legacy === "dark" || legacy === "system") return legacy;
   return "system";
 }
 


### PR DESCRIPTION
Closes #1228

## Summary
- re-enable switching between system, light, and dark themes from the top-right header control
- keep the original Radix `ToggleGroup` pill UI and restore both click and keyboard-driven theme changes
- default first-time ClawHub visits to `system` by ignoring the old `clawdhub-theme` storage key
- add regressions covering desktop theme switching, keyboard navigation, and the first-visit `system` default

## Why this approach
This keeps the original desktop theme toggle structure and active-state styling, restores the broken interaction path, preserves keyboard accessibility on the controlled `ToggleGroup`, and removes the legacy storage fallback that could incorrectly preselect `dark` on a first ClawHub visit.

## Testing
- `bun run lint`
- `bun run test`
- `bun run build`

## AI assistance
- AI-assisted change
- Human verified locally by running the commands above

## Screenshot
- Local visual verification completed for the header theme toggle update
<img width="370" height="70" alt="Bildschirmfoto 2026-03-24 um 12 42 01" src="https://github.com/user-attachments/assets/67f4d765-fda8-4d38-ae2b-fdefd98261da" /> 
<img width="339" height="57" alt="Bildschirmfoto 2026-03-24 um 13 23 14" src="https://github.com/user-attachments/assets/f82d4b79-d9e6-44f1-87fe-21ab26b1c3a8" />

