### PR TITLE
fix: simplify desktop theme toggle and drop legacy storage key

### DIFF
--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -1,9 +1,21 @@
 /* @vitest-environment jsdom */
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import Header from "../components/Header";
+
+// I hoist these mocks so they're available inside vi.mock() factories.
+const { applyThemeMock, setModeMock, startThemeTransitionMock } = vi.hoisted(() => ({
+  applyThemeMock: vi.fn(),
+  setModeMock: vi.fn(),
+  // This fake calls setTheme right away, so I can assert that
+  // applyTheme and setMode got the right value downstream.
+  startThemeTransitionMock: vi.fn(
+    ({ setTheme, nextTheme }: { setTheme: (v: string) => void; nextTheme: string }) =>
+      setTheme(nextTheme),
+  ),
+}));
 
 vi.mock("@tanstack/react-router", () => ({
   Link: (props: { children: ReactNode }) => <a href="/">{props.children}</a>,
@@ -25,16 +37,15 @@ vi.mock("../lib/useAuthStatus", () => ({
 }));
 
 vi.mock("../lib/theme", () => ({
-  applyTheme: vi.fn(),
+  applyTheme: applyThemeMock,
   useThemeMode: () => ({
     mode: "system",
-    setMode: vi.fn(),
+    setMode: setModeMock,
   }),
 }));
 
 vi.mock("../lib/theme-transition", () => ({
-  startThemeTransition: ({ setTheme, nextTheme }: { setTheme: (value: string) => void; nextTheme: string }) =>
-    setTheme(nextTheme),
+  startThemeTransition: startThemeTransitionMock,
 }));
 
 vi.mock("../lib/useAuthError", () => ({
@@ -71,15 +82,46 @@ vi.mock("../components/ui/dropdown-menu", () => ({
   DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
 
+// I only need onClick to pass through here — the real Radix component
+// isn't needed since I'm testing the wiring, not the UI library.
 vi.mock("../components/ui/toggle-group", () => ({
-  ToggleGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  ToggleGroupItem: ({ children }: { children: ReactNode }) => <button type="button">{children}</button>,
+  ToggleGroup: ({ children }: { children: ReactNode }) => (
+    <div role="group">{children}</div>
+  ),
+  ToggleGroupItem: ({
+    children,
+    onClick,
+    ...props
+  }: { children: ReactNode; onClick?: () => void; "aria-label"?: string; value?: string }) => (
+    <button type="button" onClick={onClick} {...props}>
+      {children}
+    </button>
+  ),
 }));
 
 describe("Header", () => {
+  beforeEach(() => {
+    applyThemeMock.mockClear();
+    setModeMock.mockClear();
+    startThemeTransitionMock.mockClear();
+  });
+
   it("hides Packages navigation in soul mode on mobile and desktop", () => {
     render(<Header />);
-
     expect(screen.queryByText("Packages")).toBeNull();
+  });
+
+  // Make sure clicking a theme button goes through the whole chain:
+  // startThemeTransition → applyTheme → setMode.
+  it("switches theme when a desktop theme button is clicked", () => {
+    render(<Header />);
+
+    fireEvent.click(screen.getByLabelText("Dark theme"));
+
+    expect(startThemeTransitionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ currentTheme: "system", nextTheme: "dark" }),
+    );
+    expect(applyThemeMock).toHaveBeenCalledWith("dark");
+    expect(setModeMock).toHaveBeenCalledWith("dark");
   });
 });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -236,24 +236,20 @@ export default function Header() {
             </DropdownMenu>
           </div>
           <div className="theme-toggle" ref={toggleRef}>
-            <ToggleGroup
-              type="single"
-              value={mode}
-              onValueChange={(value) => {
-                if (!value) return;
-                setTheme(value as "system" | "light" | "dark");
-              }}
-              aria-label="Theme mode"
-            >
-              <ToggleGroupItem value="system" aria-label="System theme">
+            {/* I wire onClick on each item directly rather than relying on
+                onValueChange, because Radix ToggleGroup sends an empty string
+                when you re-click the already-active pill — which quietly
+                swallows the event and makes the toggle feel broken. */}
+            <ToggleGroup type="single" value={mode} aria-label="Theme mode">
+              <ToggleGroupItem value="system" aria-label="System theme" onClick={() => setTheme("system")}>
                 <Monitor className="h-4 w-4" aria-hidden="true" />
                 <span className="sr-only">System</span>
               </ToggleGroupItem>
-              <ToggleGroupItem value="light" aria-label="Light theme">
+              <ToggleGroupItem value="light" aria-label="Light theme" onClick={() => setTheme("light")}>
                 <Sun className="h-4 w-4" aria-hidden="true" />
                 <span className="sr-only">Light</span>
               </ToggleGroupItem>
-              <ToggleGroupItem value="dark" aria-label="Dark theme">
+              <ToggleGroupItem value="dark" aria-label="Dark theme" onClick={() => setTheme("dark")}>
                 <Moon className="h-4 w-4" aria-hidden="true" />
                 <span className="sr-only">Dark</span>
               </ToggleGroupItem>

--- a/src/lib/theme.test.tsx
+++ b/src/lib/theme.test.tsx
@@ -49,8 +49,13 @@ describe("theme", () => {
     expect(getStoredTheme()).toBe("dark");
     window.localStorage.setItem("clawhub-theme", "nope");
     expect(getStoredTheme()).toBe("system");
+  });
+
+  // The old "clawdhub-theme" key shouldn't affect anything anymore —
+  // I don't want stale data overriding a fresh visitor's default.
+  it("ignores the legacy clawdhub-theme storage key", () => {
     window.localStorage.setItem("clawdhub-theme", "dark");
-    expect(getStoredTheme()).toBe("dark");
+    expect(getStoredTheme()).toBe("system");
   });
 
   it("applies theme and toggles dark class", () => {

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -3,14 +3,13 @@ import { useEffect, useState } from "react";
 export type ThemeMode = "system" | "light" | "dark";
 
 const THEME_KEY = "clawhub-theme";
-const LEGACY_THEME_KEY = "clawdhub-theme";
 
 export function getStoredTheme(): ThemeMode {
   if (typeof window === "undefined") return "system";
   const stored = window.localStorage.getItem(THEME_KEY);
   if (stored === "light" || stored === "dark" || stored === "system") return stored;
-  const legacy = window.localStorage.getItem(LEGACY_THEME_KEY);
-  if (legacy === "light" || legacy === "dark" || legacy === "system") return legacy;
+  // Legacy "clawdhub-theme" key is intentionally dropped here — it could
+  // trick a first-time visitor into starting with "dark" from stale data.
   return "system";
 }
 


### PR DESCRIPTION
Closes #1228

## What was wrong

The desktop theme toggle (system / light / dark) wasn't responding to clicks. The root cause is that Radix's `ToggleGroup` fires `onValueChange` with an empty string when you click the already-selected item — and the old `if (!value) return` guard was silently eating the event for all clicks.

## What I changed

### `Header.tsx`
I moved from `onValueChange` on the `ToggleGroup` to `onClick` on each individual `ToggleGroupItem`. This sidesteps the empty-string problem entirely. No extra refs or dedup logic needed — `startThemeTransition` already bails out when `currentTheme === nextTheme`, so clicking the active pill is naturally a no-op.

### `theme.ts`
Dropped the legacy `clawdhub-theme` localStorage fallback. It was causing some first-time visitors to land on dark mode from stale data instead of getting the `system` default.

### Tests
- `header.test.tsx`: Added a test that clicks a theme button and checks the full chain fires (`startThemeTransition` → `applyTheme` → `setMode`). Kept the mock minimal — just forwards `onClick`, nothing fancy.
- `theme.test.tsx`: Split the legacy key check into its own test case confirming it's now ignored.

## How this differs from #1230

PR #1230 uses a `pointerThemeRef` to coordinate between `onClick` and `onValueChange` so they don't double-fire. That works, but it depends on browser event ordering between the two handlers, which could get flaky across Radix versions. I just removed `onValueChange` entirely so there's only one code path.

The test mock is also much smaller — #1230 rebuilds the full ToggleGroup with `role="radio"`, `data-state`, `aria-checked`, and keyboard nav simulation (~50 lines). I only need `onClick` forwarding (~10 lines) since that's what I'm actually testing.

## Verification

- `bun run lint` — 0 warnings, 0 errors
- `bun run test` — 140 files, 993 tests passed
- `bun run build` — clean