### PR TITLE
fix: use esbuild minification for safari builds

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -70,6 +70,8 @@ const config = defineConfig({
     viteReact(),
   ],
   build: {
+    // Oxc currently emits Safari-hostile minified syntax for this app bundle.
+    minify: "esbuild",
     chunkSizeWarningLimit: 900,
     rollupOptions: {
       onwarn: handleRollupWarning,


### PR DESCRIPTION
This fixes #1141.

What I changed
- Pinned the production Vite minifier to `esbuild` so the generated bundle no longer hits Safari/WebKit with the `Unexpected keyword 'in'` parse error.
- Kept the change scoped to the build config.

How to verify
- `bun run lint`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawdhub/tsconfig.json --noEmit`
- `$env:VITE_CONVEX_URL='https://example.invalid'; $env:VITE_CONVEX_SITE_URL='https://example.invalid'; bun run build`
- `bun --bun vite preview --host 127.0.0.1 --port 4173 --strictPort`
- Open `http://127.0.0.1:4173/` in WebKit and confirm the app loads without the parse error.

Notes
- `bun run test` still fails in this Windows environment on existing `packages/clawdhub` path separator assertions outside this patch.
