### PR TITLE
fix: avoid double JSON encoding in transfer, rename, and merge requests

### DIFF
--- a/packages/clawdhub/src/cli/commands/ownership.test.ts
+++ b/packages/clawdhub/src/cli/commands/ownership.test.ts
@@ -67,8 +67,8 @@ describe("ownership commands", () => {
       }),
       expect.anything(),
     );
-    const requestArgs = mockApiRequest.mock.calls[0]?.[1] as { body?: string };
-    expect(requestArgs.body).toContain('"newSlug":"demo-new"');
+    const requestArgs = mockApiRequest.mock.calls[0]?.[1] as { body?: unknown };
+    expect(requestArgs.body).toEqual({ newSlug: "demo-new" });
   });
 
   it("merge calls merge endpoint", async () => {
@@ -88,7 +88,7 @@ describe("ownership commands", () => {
       }),
       expect.anything(),
     );
-    const requestArgs = mockApiRequest.mock.calls[0]?.[1] as { body?: string };
-    expect(requestArgs.body).toContain('"targetSlug":"demo"');
+    const requestArgs = mockApiRequest.mock.calls[0]?.[1] as { body?: unknown };
+    expect(requestArgs.body).toEqual({ targetSlug: "demo" });
   });
 });

--- a/packages/clawdhub/src/cli/commands/ownership.ts
+++ b/packages/clawdhub/src/cli/commands/ownership.ts
@@ -57,7 +57,7 @@ export async function cmdRenameSkill(
         method: "POST",
         path: `${ApiRoutes.skills}/${encodeURIComponent(slug)}/rename`,
         token,
-        body: JSON.stringify({ newSlug }),
+        body: { newSlug },
       },
       ApiV1SkillRenameResponseSchema,
     );
@@ -99,7 +99,7 @@ export async function cmdMergeSkill(
         method: "POST",
         path: `${ApiRoutes.skills}/${encodeURIComponent(sourceSlug)}/merge`,
         token,
-        body: JSON.stringify({ targetSlug }),
+        body: { targetSlug },
       },
       ApiV1SkillMergeResponseSchema,
     );

--- a/packages/clawdhub/src/cli/commands/transfer.test.ts
+++ b/packages/clawdhub/src/cli/commands/transfer.test.ts
@@ -82,8 +82,11 @@ describe("transfer commands", () => {
       }),
       expect.anything(),
     );
-    const requestArgs = mockApiRequest.mock.calls[0]?.[1] as { body?: string };
-    expect(requestArgs.body).toContain('"toUserHandle":"alice"');
+    const requestArgs = mockApiRequest.mock.calls[0]?.[1] as { body?: unknown };
+    expect(requestArgs.body).toEqual({
+      toUserHandle: "alice",
+      message: "Please take over",
+    });
   });
 
   it("list calls incoming transfers endpoint", async () => {

--- a/packages/clawdhub/src/cli/commands/transfer.ts
+++ b/packages/clawdhub/src/cli/commands/transfer.ts
@@ -88,10 +88,10 @@ export async function cmdTransferRequest(
         method: "POST",
         path: `${ApiRoutes.skills}/${encodeURIComponent(slug)}/transfer`,
         token,
-        body: JSON.stringify({
+        body: {
           toUserHandle: toHandle,
           message: options.message,
-        }),
+        },
       },
       ApiV1TransferRequestResponseSchema,
     );

--- a/packages/clawdhub/src/http.test.ts
+++ b/packages/clawdhub/src/http.test.ts
@@ -145,6 +145,23 @@ describe("apiRequest", () => {
     vi.unstubAllGlobals();
   });
 
+  it("passes through pre-serialized json body without double-encoding", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await apiRequest("https://example.com", {
+      method: "POST",
+      path: "/x",
+      body: '{"a":1}',
+    });
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(init.body).toBe('{"a":1}');
+    expect((init.headers as Record<string, string>)["Content-Type"]).toBe("application/json");
+    vi.unstubAllGlobals();
+  });
+
   it("throws text body on non-200", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: false,

--- a/packages/clawdhub/src/http.ts
+++ b/packages/clawdhub/src/http.ts
@@ -70,7 +70,11 @@ type RateLimitInfo = {
 };
 
 function serializeJsonBody(body: unknown): string {
-  return typeof body === "string" ? body : JSON.stringify(body ?? {});
+  if (typeof body === "string") {
+    // Assume already-serialized JSON; skip re-encoding to avoid double-encoding.
+    return body;
+  }
+  return JSON.stringify(body ?? {});
 }
 
 class HttpStatusError extends Error {

--- a/packages/clawdhub/src/http.ts
+++ b/packages/clawdhub/src/http.ts
@@ -69,6 +69,10 @@ type RateLimitInfo = {
   retryAfterSeconds?: number;
 };
 
+function serializeJsonBody(body: unknown): string {
+  return typeof body === "string" ? body : JSON.stringify(body ?? {});
+}
+
 class HttpStatusError extends Error {
   readonly status: number;
   readonly rateLimit: RateLimitInfo;
@@ -103,7 +107,7 @@ export async function apiRequest<T>(
     let body: string | undefined;
     if (args.method === "POST") {
       headers["Content-Type"] = "application/json";
-      body = JSON.stringify(args.body ?? {});
+      body = serializeJsonBody(args.body);
     }
     const response = await fetchWithTimeout(url, {
       method: args.method,
@@ -403,7 +407,7 @@ async function fetchJsonViaCurl(url: string, args: RequestArgs) {
   ];
   if (args.method === "POST") {
     curlArgs.push("-H", "Content-Type: application/json");
-    curlArgs.push("--data-binary", JSON.stringify(args.body ?? {}));
+    curlArgs.push("--data-binary", serializeJsonBody(args.body));
   }
 
   const result = spawnSync("curl", curlArgs, { encoding: "utf8" });


### PR DESCRIPTION
 ## Summary

  This fixes a CLI bug where some `POST` requests were JSON-encoded twice before being sent.

  I hit this while trying to transfer an existing skill:

  ```bash
  clawhub transfer request <skill name> <github handle>
 ```

  The CLI showed the confirmation prompt correctly, but the server returned:

  toUserHandle required

  ## Root Cause

  Some command handlers were doing:

  ```ts
  body: JSON.stringify(...)

  before passing the payload to apiRequest().

  But apiRequest() already serializes args.body for JSON POST requests.

  That meant the server received a JSON string literal instead of a JSON object.

  ## Changes

  - Update transfer requests to pass plain objects to apiRequest()
  - Update rename requests to pass plain objects to apiRequest()
  - Update merge requests to pass plain objects to apiRequest()
  - Make http.ts tolerate already-serialized string bodies to avoid double-encoding regressions
  - Update command tests to assert object payloads instead of pre-stringified bodies
  - Add an http.ts test covering pre-serialized JSON passthrough

  ## Why this approach

  Fixing only transfer would leave the same bug pattern in other command handlers.

  This change fixes the affected call sites and also hardens the shared HTTP layer so accidental pre-
  serialized bodies are not double-encoded in the future.

  ## Validation

  Ran:

  bunx vitest run \
    packages/clawdhub/src/cli/commands/transfer.test.ts \
    packages/clawdhub/src/cli/commands/ownership.test.ts \
    packages/clawdhub/src/http.test.ts

  Result:

  - 3 test files passed
  - 31 tests passed

  ## User impact

  This fixes broken CLI flows for requests that expect JSON object bodies, including:

  - skill transfer requests
  - skill rename requests
  - skill merge requests