### PR TITLE
docs: document CLI config paths across platforms

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -62,6 +62,9 @@ When no proxy variable is set, behavior is unchanged (direct connections).
 Stores your API token + cached registry URL.
 
 - macOS: `~/Library/Application Support/clawhub/config.json`
+- Linux/XDG: `$XDG_CONFIG_HOME/clawhub/config.json` or `~/.config/clawhub/config.json`
+- Windows: `%APPDATA%\\clawhub\\config.json`
+- Legacy fallback: if `clawdhub/config.json` exists in the same config base directory, the CLI reuses it
 - override: `CLAWHUB_CONFIG_PATH` (legacy `CLAWDHUB_CONFIG_PATH`)
 
 ## Commands

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -64,7 +64,7 @@ Stores your API token + cached registry URL.
 - macOS: `~/Library/Application Support/clawhub/config.json`
 - Linux/XDG: `$XDG_CONFIG_HOME/clawhub/config.json` or `~/.config/clawhub/config.json`
 - Windows: `%APPDATA%\\clawhub\\config.json`
-- Legacy fallback: if `clawdhub/config.json` exists in the same config base directory, the CLI reuses it
+- Legacy fallback: if `clawhub/config.json` does not exist yet but `clawdhub/config.json` does, the CLI reuses the legacy path
 - override: `CLAWHUB_CONFIG_PATH` (legacy `CLAWDHUB_CONFIG_PATH`)
 
 ## Commands

--- a/packages/clawhub/README.md
+++ b/packages/clawhub/README.md
@@ -27,7 +27,12 @@ clawhub login --token clh_...
 Notes:
 
 - Browser login opens `https://clawhub.ai/cli/auth` and completes via a loopback callback.
-- Token stored in `~/Library/Application Support/clawhub/config.json` on macOS (override via `CLAWHUB_CONFIG_PATH`, legacy `CLAWDHUB_CONFIG_PATH`).
+- Default config path:
+  - macOS: `~/Library/Application Support/clawhub/config.json`
+  - Linux/XDG: `$XDG_CONFIG_HOME/clawhub/config.json` or `~/.config/clawhub/config.json`
+  - Windows: `%APPDATA%\\clawhub\\config.json`
+- Legacy fallback: if `clawdhub/config.json` exists in the same config base directory, the CLI reuses it.
+- Override via `CLAWHUB_CONFIG_PATH` (legacy `CLAWDHUB_CONFIG_PATH`).
 
 ## Examples
 

--- a/packages/clawhub/README.md
+++ b/packages/clawhub/README.md
@@ -31,7 +31,7 @@ Notes:
   - macOS: `~/Library/Application Support/clawhub/config.json`
   - Linux/XDG: `$XDG_CONFIG_HOME/clawhub/config.json` or `~/.config/clawhub/config.json`
   - Windows: `%APPDATA%\\clawhub\\config.json`
-- Legacy fallback: if `clawdhub/config.json` exists in the same config base directory, the CLI reuses it.
+- Legacy fallback: if `clawhub/config.json` does not exist yet but `clawdhub/config.json` does, the CLI reuses the legacy path.
 - Override via `CLAWHUB_CONFIG_PATH` (legacy `CLAWDHUB_CONFIG_PATH`).
 
 ## Examples


### PR DESCRIPTION
## Summary

Document the actual CLI config file locations across macOS, Linux/XDG, and Windows.

## What changed

- update `docs/cli.md` to include Linux/XDG and Windows config paths
- update `packages/clawdhub/README.md` with the same cross-platform config path details
- document the legacy fallback to `clawdhub/config.json` when it already exists

## Why

The docs only mentioned the macOS config path, but the CLI also supports:
- `$XDG_CONFIG_HOME/clawhub/config.json` or `~/.config/clawhub/config.json`
- `%APPDATA%\\clawhub\\config.json`
- legacy fallback to `clawdhub/config.json`

This change aligns the docs with the current implementation in `packages/clawdhub/src/config.ts`.

## Testing

Docs-only change. Verified against the current config path resolution logic in `packages/clawdhub/src/config.ts`.

## AI assistance

AI-assisted docs change; reviewed and verified against the current implementation before submission.
