### PR TITLE
Fix direct skill prefix recall when vector search misses

### DIFF
--- a/convex/lib/skillSearchDigest.test.ts
+++ b/convex/lib/skillSearchDigest.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment node */
 
 import { describe, expect, it } from "vitest";
-import { extractDigestFields, digestToOwnerInfo } from "./skillSearchDigest";
+import { digestToOwnerInfo, extractDigestFields } from "./skillSearchDigest";
 
 function makeSkillDoc(overrides: Record<string, unknown> = {}) {
   return {
@@ -69,7 +69,9 @@ describe("extractDigestFields", () => {
 
     expect(digest.skillId).toBe("skills:abc");
     expect(digest.slug).toBe("test-skill");
+    expect(digest.normalizedSlug).toBe("test-skill");
     expect(digest.displayName).toBe("Test Skill");
+    expect(digest.normalizedDisplayName).toBe("test skill");
     expect(digest.summary).toBe("A test skill summary");
     expect(digest.ownerUserId).toBe("users:owner");
     expect(digest.statsDownloads).toBe(42);
@@ -125,6 +127,17 @@ describe("extractDigestFields", () => {
     expect(digest).not.toHaveProperty("ownerName");
     expect(digest).not.toHaveProperty("ownerDisplayName");
     expect(digest).not.toHaveProperty("ownerImage");
+  });
+
+  it("normalizes lexical fields for indexed prefix search", () => {
+    const skill = makeSkillDoc({
+      slug: "Midscene-Computer-Automation",
+      displayName: "  Midscene   Automations Skills  ",
+    });
+    const digest = extractDigestFields(skill as never);
+
+    expect(digest.normalizedSlug).toBe("midscene-computer-automation");
+    expect(digest.normalizedDisplayName).toBe("midscene automations skills");
   });
 
   it("produces a digest that works with toPublicSkill when shaped as Doc<skills>", () => {

--- a/convex/lib/skillSearchDigest.ts
+++ b/convex/lib/skillSearchDigest.ts
@@ -39,6 +39,8 @@ const SHARED_KEYS = [
 /** Fields stored in the skillSearchDigest table. */
 export type SkillSearchDigestFields = Pick<Doc<"skills">, (typeof SHARED_KEYS)[number]> & {
   skillId: Id<"skills">;
+  normalizedSlug: string;
+  normalizedDisplayName: string;
   isSuspicious?: boolean;
   ownerHandle?: string;
   ownerKind?: "user" | "org";
@@ -47,11 +49,17 @@ export type SkillSearchDigestFields = Pick<Doc<"skills">, (typeof SHARED_KEYS)[n
   ownerImage?: string;
 };
 
+export function normalizeSkillSearchText(value: string) {
+  return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
 /** Pick the subset of fields from a full skill doc needed for the digest. */
 export function extractDigestFields(skill: Doc<"skills">): SkillSearchDigestFields {
   return {
     ...pick(skill, [...SHARED_KEYS]),
     skillId: skill._id,
+    normalizedSlug: normalizeSkillSearchText(skill.slug),
+    normalizedDisplayName: normalizeSkillSearchText(skill.displayName),
     isSuspicious: skill.isSuspicious,
   };
 }

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -1641,14 +1641,28 @@ export const backfillSkillSearchDigestInternal = internalMutation({
       .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
 
     let inserted = 0;
+    let updated = 0;
     for (const skill of page) {
+      const fields = extractDigestFields(skill);
       const existing = await ctx.db
         .query("skillSearchDigest")
         .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
         .unique();
       if (!existing) {
-        await ctx.db.insert("skillSearchDigest", extractDigestFields(skill));
+        await ctx.db.insert("skillSearchDigest", fields);
         inserted++;
+        continue;
+      }
+
+      if (
+        existing.normalizedSlug !== fields.normalizedSlug ||
+        existing.normalizedDisplayName !== fields.normalizedDisplayName
+      ) {
+        await ctx.db.patch(existing._id, {
+          normalizedSlug: fields.normalizedSlug,
+          normalizedDisplayName: fields.normalizedDisplayName,
+        });
+        updated++;
       }
     }
 
@@ -1659,7 +1673,7 @@ export const backfillSkillSearchDigestInternal = internalMutation({
       });
     }
 
-    return { inserted, isDone, scanned: page.length };
+    return { inserted, updated, isDone, scanned: page.length };
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -544,7 +544,9 @@ const embeddingSkillMap = defineTable({
 const skillSearchDigest = defineTable({
   skillId: v.id("skills"),
   slug: v.string(),
+  normalizedSlug: v.optional(v.string()),
   displayName: v.string(),
+  normalizedDisplayName: v.optional(v.string()),
   summary: v.optional(v.string()),
   ownerUserId: v.id("users"),
   ownerPublisherId: v.optional(v.id("publishers")),
@@ -584,6 +586,12 @@ const skillSearchDigest = defineTable({
   .index("by_active_updated", ["softDeletedAt", "updatedAt"])
   .index("by_active_created", ["softDeletedAt", "createdAt"])
   .index("by_active_name", ["softDeletedAt", "displayName"])
+  .index("by_active_normalized_slug", ["softDeletedAt", "normalizedSlug", "updatedAt"])
+  .index("by_active_normalized_display_name", [
+    "softDeletedAt",
+    "normalizedDisplayName",
+    "updatedAt",
+  ])
   .index("by_active_stats_downloads", ["softDeletedAt", "statsDownloads", "updatedAt"])
   .index("by_active_stats_stars", ["softDeletedAt", "statsStars", "updatedAt"])
   .index("by_active_stats_installs_all_time", [
@@ -594,6 +602,18 @@ const skillSearchDigest = defineTable({
   .index("by_nonsuspicious_updated", ["softDeletedAt", "isSuspicious", "updatedAt"])
   .index("by_nonsuspicious_created", ["softDeletedAt", "isSuspicious", "createdAt"])
   .index("by_nonsuspicious_name", ["softDeletedAt", "isSuspicious", "displayName"])
+  .index("by_nonsuspicious_normalized_slug", [
+    "softDeletedAt",
+    "isSuspicious",
+    "normalizedSlug",
+    "updatedAt",
+  ])
+  .index("by_nonsuspicious_normalized_display_name", [
+    "softDeletedAt",
+    "isSuspicious",
+    "normalizedDisplayName",
+    "updatedAt",
+  ])
   .index("by_nonsuspicious_downloads", [
     "softDeletedAt",
     "isSuspicious",

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -125,10 +125,12 @@ describe("search helpers", () => {
     const result = await directLexicalSkillsHandler(
       makeDirectLexicalCtx({
         displayNameDigests: [],
-        legacyDisplayNameDigests: [digest],
+        legacyDisplayNameDigestsByPrefix: {
+          Midscene: [digest],
+        },
         slugDigests: [],
       }),
-      { query: "Midscene", limit: 10 },
+      { query: "midscene", limit: 10 },
     );
 
     expect(result).toHaveLength(1);
@@ -164,6 +166,36 @@ describe("search helpers", () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].skill.slug).toBe("midscene-computer-automation");
+  });
+
+  it("skips direct lexical lookup when vector exact matches already satisfy the limit", async () => {
+    generateEmbeddingMock.mockResolvedValueOnce([0, 1, 2]);
+    const vectorEntries = [
+      {
+        embeddingId: "skillEmbeddings:midscene",
+        skill: makePublicSkill({
+          id: "skills:midscene",
+          slug: "midscene-computer-automation",
+          displayName: "Midscene Automations Skills for Computer",
+        }),
+        version: null,
+        ownerHandle: "quanru",
+        owner: null,
+      },
+    ];
+    const runQuery = vi.fn().mockResolvedValueOnce(vectorEntries); // hydrateResults
+
+    const result = await searchSkillsHandler(
+      {
+        vectorSearch: vi.fn().mockResolvedValue([{ _id: "skillEmbeddings:midscene", _score: 0.95 }]),
+        runQuery,
+      },
+      { query: "Midscene", limit: 1 },
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].skill.slug).toBe("midscene-computer-automation");
+    expect(runQuery).toHaveBeenCalledTimes(1);
   });
 
   it("applies highlightedOnly filtering in lexical fallback", async () => {
@@ -1014,6 +1046,7 @@ function makeLexicalCtx(params: {
 function makeDirectLexicalCtx(params: {
   displayNameDigests: DigestRow[];
   legacyDisplayNameDigests?: DigestRow[];
+  legacyDisplayNameDigestsByPrefix?: Record<string, DigestRow[]>;
   slugDigests: DigestRow[];
 }) {
   return {
@@ -1021,18 +1054,46 @@ function makeDirectLexicalCtx(params: {
       query: vi.fn((table: string) => {
         if (table !== "skillSearchDigest") throw new Error(`Unexpected table ${table}`);
         return {
-          withIndex: (index: string) => {
+          withIndex: (index: string, buildRange?: (q: LegacyRangeBuilder) => LegacyRangeBuilder) => {
+            const range = buildLegacyRange(buildRange);
             if (index === "by_active_normalized_display_name") {
+              return {
+                take: vi.fn().mockResolvedValue(params.displayNameDigests),
+              };
+            }
+            if (index === "by_nonsuspicious_normalized_display_name") {
               return {
                 take: vi.fn().mockResolvedValue(params.displayNameDigests),
               };
             }
             if (index === "by_active_name") {
               return {
-                take: vi.fn().mockResolvedValue(params.legacyDisplayNameDigests ?? []),
+                take: vi
+                  .fn()
+                  .mockResolvedValue(
+                    params.legacyDisplayNameDigestsByPrefix?.[range.gteValue ?? ""] ??
+                      params.legacyDisplayNameDigests ??
+                      [],
+                  ),
+              };
+            }
+            if (index === "by_nonsuspicious_name") {
+              return {
+                take: vi
+                  .fn()
+                  .mockResolvedValue(
+                    params.legacyDisplayNameDigestsByPrefix?.[range.gteValue ?? ""] ??
+                      params.legacyDisplayNameDigests ??
+                      [],
+                  ),
               };
             }
             if (index === "by_active_normalized_slug") {
+              return {
+                take: vi.fn().mockResolvedValue(params.slugDigests),
+              };
+            }
+            if (index === "by_nonsuspicious_normalized_slug") {
               return {
                 take: vi.fn().mockResolvedValue(params.slugDigests),
               };
@@ -1048,6 +1109,28 @@ function makeDirectLexicalCtx(params: {
       }),
     },
   };
+}
+
+type LegacyRangeBuilder = {
+  eq: (field: string, value: unknown) => LegacyRangeBuilder;
+  gte: (field: string, value: string) => LegacyRangeBuilder;
+  lt: (field: string, value: string) => LegacyRangeBuilder;
+};
+
+function buildLegacyRange(
+  buildRange?: (q: LegacyRangeBuilder) => LegacyRangeBuilder,
+) {
+  const state: { gteValue?: string } = {};
+  const range: LegacyRangeBuilder = {
+    eq: () => range,
+    gte: (_field, value) => {
+      state.gteValue = value;
+      return range;
+    },
+    lt: () => range,
+  };
+  buildRange?.(range);
+  return state;
 }
 
 function makeDigestRow(skill: ReturnType<typeof makeSkillDoc>) {

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -2,7 +2,13 @@
 
 import { describe, expect, it, vi } from "vitest";
 import { tokenize } from "./lib/searchText";
-import { __test, hydrateResults, lexicalFallbackSkills, searchSkills } from "./search";
+import {
+  __test,
+  directLexicalSkills,
+  hydrateResults,
+  lexicalFallbackSkills,
+  searchSkills,
+} from "./search";
 
 const { generateEmbeddingMock } = vi.hoisted(() => ({
   generateEmbeddingMock: vi.fn(),
@@ -25,6 +31,14 @@ type WrappedHandler = {
 };
 
 const searchSkillsHandler = (searchSkills as unknown as WrappedHandler)._handler;
+const directLexicalSkillsHandler = (
+  directLexicalSkills as unknown as {
+    _handler: (
+      ctx: unknown,
+      args: unknown,
+    ) => Promise<Array<{ skill: { slug: string; _id: string } }>>;
+  }
+)._handler;
 const lexicalFallbackSkillsHandler = (lexicalFallbackSkills as unknown as WrappedHandler)._handler;
 const hydrateResultsHandler = (
   hydrateResults as unknown as {
@@ -34,6 +48,10 @@ const hydrateResultsHandler = (
     ) => Promise<Array<{ skill: { slug: string; _id: string }; ownerHandle: string | null }>>;
   }
 )._handler;
+type DigestRow = Omit<ReturnType<typeof makeDigestRow>, "normalizedSlug" | "normalizedDisplayName"> & {
+  normalizedSlug?: string;
+  normalizedDisplayName?: string;
+};
 
 describe("search helpers", () => {
   it("returns fallback results when vector candidates are empty", async () => {
@@ -46,8 +64,12 @@ describe("search helpers", () => {
         owner: null,
       },
     ];
-    // Slug-like queries now do an indexed exact-slug lookup before lexical fallback.
-    const runQuery = vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(fallback);
+    // Slug-like queries do exact-slug lookup, then directLexicalSkills, then lexical fallback.
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce(null) // getExactSkillSlugMatch
+      .mockResolvedValueOnce([]) // directLexicalSkills
+      .mockResolvedValueOnce(fallback); // lexicalFallbackSkills
 
     const result = await searchSkillsHandler(
       {
@@ -59,10 +81,89 @@ describe("search helpers", () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].skill.slug).toBe("orf");
-    expect(runQuery).toHaveBeenCalledWith(
+    expect(runQuery).toHaveBeenNthCalledWith(
+      3,
       expect.anything(),
       expect.objectContaining({ query: "orf", queryTokens: ["orf"] }),
     );
+  });
+
+  it("returns direct lexical prefix matches when vector recall misses them (#1254)", async () => {
+    const digest = makeDigestRow(
+      makeSkillDoc({
+        id: "skills:midscene",
+        slug: "midscene-computer-automation",
+        displayName: "Midscene Automations Skills for Computer",
+      }),
+    );
+
+    const result = await directLexicalSkillsHandler(
+      makeDirectLexicalCtx({
+        displayNameDigests: [digest],
+        slugDigests: [digest],
+      }),
+      { query: "Midscene", limit: 10 },
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].skill.slug).toBe("midscene-computer-automation");
+  });
+
+  it("returns direct lexical matches from legacy display-name indexes before digest backfill", async () => {
+    const digest = {
+      ...makeDigestRow(
+        makeSkillDoc({
+          id: "skills:midscene",
+          slug: "midscene-computer-automation",
+          displayName: "Midscene Automations Skills for Computer",
+        }),
+      ),
+      normalizedSlug: undefined,
+      normalizedDisplayName: undefined,
+    };
+
+    const result = await directLexicalSkillsHandler(
+      makeDirectLexicalCtx({
+        displayNameDigests: [],
+        legacyDisplayNameDigests: [digest],
+        slugDigests: [],
+      }),
+      { query: "Midscene", limit: 10 },
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].skill.slug).toBe("midscene-computer-automation");
+  });
+
+  it("merges direct lexical matches into search results when vector recall misses them", async () => {
+    generateEmbeddingMock.mockResolvedValueOnce([0, 1, 2]);
+    const direct = [
+      {
+        skill: makePublicSkill({
+          id: "skills:midscene",
+          slug: "midscene-computer-automation",
+          displayName: "Midscene Automations Skills for Computer",
+        }),
+        version: null,
+        ownerHandle: "quanru",
+        owner: null,
+      },
+    ];
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce(direct) // directLexicalSkills
+      .mockResolvedValueOnce([]); // lexicalFallbackSkills
+
+    const result = await searchSkillsHandler(
+      {
+        vectorSearch: vi.fn().mockResolvedValue([]),
+        runQuery,
+      },
+      { query: "Midscene", limit: 10 },
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].skill.slug).toBe("midscene-computer-automation");
   });
 
   it("applies highlightedOnly filtering in lexical fallback", async () => {
@@ -185,6 +286,7 @@ describe("search helpers", () => {
       .fn()
       .mockResolvedValueOnce(null) // getExactSkillSlugMatch
       .mockResolvedValueOnce(vectorEntries) // hydrateResults
+      .mockResolvedValueOnce([]) // directLexicalSkills
       .mockResolvedValueOnce(fallbackEntries); // lexicalFallbackSkills
 
     const result = await searchSkillsHandler(
@@ -868,14 +970,7 @@ function makeLexicalCtx(params: {
   recentSkills: Array<ReturnType<typeof makeSkillDoc>>;
 }) {
   // Convert skill docs to digest-shaped rows (add skillId + owner fields).
-  const digestRows = params.recentSkills.map((skill) => ({
-    ...skill,
-    skillId: skill._id,
-    ownerHandle: "owner",
-    ownerName: "Owner",
-    ownerDisplayName: "Owner",
-    ownerImage: undefined,
-  }));
+  const digestRows = params.recentSkills.map((skill) => makeDigestRow(skill));
   return {
     db: {
       query: vi.fn((table: string) => {
@@ -913,5 +1008,57 @@ function makeLexicalCtx(params: {
         return null;
       }),
     },
+  };
+}
+
+function makeDirectLexicalCtx(params: {
+  displayNameDigests: DigestRow[];
+  legacyDisplayNameDigests?: DigestRow[];
+  slugDigests: DigestRow[];
+}) {
+  return {
+    db: {
+      query: vi.fn((table: string) => {
+        if (table !== "skillSearchDigest") throw new Error(`Unexpected table ${table}`);
+        return {
+          withIndex: (index: string) => {
+            if (index === "by_active_normalized_display_name") {
+              return {
+                take: vi.fn().mockResolvedValue(params.displayNameDigests),
+              };
+            }
+            if (index === "by_active_name") {
+              return {
+                take: vi.fn().mockResolvedValue(params.legacyDisplayNameDigests ?? []),
+              };
+            }
+            if (index === "by_active_normalized_slug") {
+              return {
+                take: vi.fn().mockResolvedValue(params.slugDigests),
+              };
+            }
+            throw new Error(`Unexpected digest index ${index}`);
+          },
+        };
+      }),
+      get: vi.fn(async (id: string) => {
+        if (id.startsWith("users:")) return { _id: id, handle: "owner" };
+        if (id.startsWith("skillVersions:")) return { _id: id, version: "1.0.0" };
+        return null;
+      }),
+    },
+  };
+}
+
+function makeDigestRow(skill: ReturnType<typeof makeSkillDoc>) {
+  return {
+    ...skill,
+    skillId: skill._id,
+    normalizedSlug: skill.slug.trim().toLowerCase(),
+    normalizedDisplayName: skill.displayName.trim().toLowerCase().replace(/\s+/g, " "),
+    ownerHandle: "owner",
+    ownerName: "Owner",
+    ownerDisplayName: "Owner",
+    ownerImage: undefined,
   };
 }

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -71,6 +71,15 @@ function slugPrefixForQuery(query: string) {
   return tokens.length > 0 ? tokens.join("-") : "";
 }
 
+function legacyDisplayNamePrefixes(query: string) {
+  const normalized = normalizeSkillSearchText(query);
+  if (!normalized) return [];
+
+  const raw = query.trim().replace(/\s+/g, " ");
+  const titleCase = normalized.replace(/\b[a-z]/g, (char) => char.toUpperCase());
+  return [...new Set([raw, normalized, titleCase].filter(Boolean))];
+}
+
 function matchesAllTokens(
   queryTokens: string[],
   candidateTokens: string[],
@@ -221,12 +230,15 @@ export const searchSkills: ReturnType<typeof action> = action({
       candidateLimit = nextLimit;
     }
 
-    const directMatches = (await ctx.runQuery(internal.search.directLexicalSkills, {
-      query,
-      limit: Math.min(Math.max(limit * 4, 20), DIRECT_LEXICAL_SCAN_LIMIT),
-      highlightedOnly: args.highlightedOnly,
-      nonSuspiciousOnly: args.nonSuspiciousOnly,
-    })) as SkillSearchEntry[];
+    const directMatches =
+      exactMatches.length >= limit
+        ? []
+        : ((await ctx.runQuery(internal.search.directLexicalSkills, {
+            query,
+            limit: Math.min(Math.max(limit * 4, 20), DIRECT_LEXICAL_SCAN_LIMIT),
+            highlightedOnly: args.highlightedOnly,
+            nonSuspiciousOnly: args.nonSuspiciousOnly,
+          })) as SkillSearchEntry[]);
 
     const primaryMatches = mergeUniqueBySkillId(
       exactSlugMatch
@@ -357,10 +369,10 @@ export const directLexicalSkills = internalQuery({
   },
   handler: async (ctx, args): Promise<SkillSearchEntry[]> => {
     const limit = Math.min(Math.max(args.limit ?? 20, 10), DIRECT_LEXICAL_SCAN_LIMIT);
-    const rawDisplayNamePrefix = args.query.trim();
     const displayNamePrefix = normalizeSkillSearchText(args.query);
+    const legacyNamePrefixes = legacyDisplayNamePrefixes(args.query);
     const slugPrefix = slugPrefixForQuery(args.query);
-    if (!rawDisplayNamePrefix && !displayNamePrefix && !slugPrefix) return [];
+    if (!displayNamePrefix && legacyNamePrefixes.length === 0 && !slugPrefix) return [];
 
     const [slugDigests, displayNameDigests, legacyDisplayNameDigests] = args.nonSuspiciousOnly
       ? await Promise.all([
@@ -386,16 +398,20 @@ export const directLexicalSkills = internalQuery({
                 )
                 .take(limit)
             : Promise.resolve([]),
-          rawDisplayNamePrefix
-            ? ctx.db
-                .query("skillSearchDigest")
-                .withIndex("by_nonsuspicious_name", (q) =>
-                  q.eq("softDeletedAt", undefined)
-                    .eq("isSuspicious", false)
-                    .gte("displayName", rawDisplayNamePrefix)
-                    .lt("displayName", prefixUpperBound(rawDisplayNamePrefix)),
-                )
-                .take(limit)
+          legacyNamePrefixes.length > 0
+            ? Promise.all(
+                legacyNamePrefixes.map((prefix) =>
+                  ctx.db
+                    .query("skillSearchDigest")
+                    .withIndex("by_nonsuspicious_name", (q) =>
+                      q.eq("softDeletedAt", undefined)
+                        .eq("isSuspicious", false)
+                        .gte("displayName", prefix)
+                        .lt("displayName", prefixUpperBound(prefix)),
+                    )
+                    .take(limit),
+                ),
+              ).then((pages) => pages.flat())
             : Promise.resolve([]),
         ])
       : await Promise.all([
@@ -419,15 +435,19 @@ export const directLexicalSkills = internalQuery({
                 )
                 .take(limit)
             : Promise.resolve([]),
-          rawDisplayNamePrefix
-            ? ctx.db
-                .query("skillSearchDigest")
-                .withIndex("by_active_name", (q) =>
-                  q.eq("softDeletedAt", undefined)
-                    .gte("displayName", rawDisplayNamePrefix)
-                    .lt("displayName", prefixUpperBound(rawDisplayNamePrefix)),
-                )
-                .take(limit)
+          legacyNamePrefixes.length > 0
+            ? Promise.all(
+                legacyNamePrefixes.map((prefix) =>
+                  ctx.db
+                    .query("skillSearchDigest")
+                    .withIndex("by_active_name", (q) =>
+                      q.eq("softDeletedAt", undefined)
+                        .gte("displayName", prefix)
+                        .lt("displayName", prefixUpperBound(prefix)),
+                    )
+                    .take(limit),
+                ),
+              ).then((pages) => pages.flat())
             : Promise.resolve([]),
         ]);
 

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -10,7 +10,11 @@ import { toPublicPublisher, toPublicSkill, toPublicSoul } from "./lib/public";
 import { getOwnerPublisher } from "./lib/publishers";
 import { matchesExactTokens, tokenize } from "./lib/searchText";
 import { isSkillSuspicious } from "./lib/skillSafety";
-import { digestToHydratableSkill, digestToOwnerInfo } from "./lib/skillSearchDigest";
+import {
+  digestToHydratableSkill,
+  digestToOwnerInfo,
+  normalizeSkillSearchText,
+} from "./lib/skillSearchDigest";
 
 type OwnerInfo = { ownerHandle: string | null; owner: PublicPublisher | null };
 
@@ -51,10 +55,20 @@ const NAME_EXACT_BOOST = 1.1;
 const NAME_PREFIX_BOOST = 0.6;
 const POPULARITY_WEIGHT = 0.08;
 const FALLBACK_SCAN_LIMIT = 500;
+const DIRECT_LEXICAL_SCAN_LIMIT = 100;
 
 function getNextCandidateLimit(current: number, max: number) {
   const next = Math.min(current * 2, max);
   return next > current ? next : null;
+}
+
+function prefixUpperBound(value: string) {
+  return `${value}\uffff`;
+}
+
+function slugPrefixForQuery(query: string) {
+  const tokens = tokenize(query);
+  return tokens.length > 0 ? tokens.join("-") : "";
 }
 
 function matchesAllTokens(
@@ -207,9 +221,19 @@ export const searchSkills: ReturnType<typeof action> = action({
       candidateLimit = nextLimit;
     }
 
-    const primaryMatches = exactSlugMatch
-      ? mergeUniqueBySkillId([exactSlugMatch], exactMatches)
-      : exactMatches;
+    const directMatches = (await ctx.runQuery(internal.search.directLexicalSkills, {
+      query,
+      limit: Math.min(Math.max(limit * 4, 20), DIRECT_LEXICAL_SCAN_LIMIT),
+      highlightedOnly: args.highlightedOnly,
+      nonSuspiciousOnly: args.nonSuspiciousOnly,
+    })) as SkillSearchEntry[];
+
+    const primaryMatches = mergeUniqueBySkillId(
+      exactSlugMatch
+        ? mergeUniqueBySkillId([exactSlugMatch], exactMatches)
+        : exactMatches,
+      directMatches,
+    );
 
     const fallbackMatches =
       primaryMatches.length >= limit
@@ -321,6 +345,127 @@ export const hydrateResults = internalQuery({
     );
 
     return entries.filter((entry): entry is SkillSearchEntry => entry !== null);
+  },
+});
+
+export const directLexicalSkills = internalQuery({
+  args: {
+    query: v.string(),
+    limit: v.optional(v.number()),
+    highlightedOnly: v.optional(v.boolean()),
+    nonSuspiciousOnly: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args): Promise<SkillSearchEntry[]> => {
+    const limit = Math.min(Math.max(args.limit ?? 20, 10), DIRECT_LEXICAL_SCAN_LIMIT);
+    const rawDisplayNamePrefix = args.query.trim();
+    const displayNamePrefix = normalizeSkillSearchText(args.query);
+    const slugPrefix = slugPrefixForQuery(args.query);
+    if (!rawDisplayNamePrefix && !displayNamePrefix && !slugPrefix) return [];
+
+    const [slugDigests, displayNameDigests, legacyDisplayNameDigests] = args.nonSuspiciousOnly
+      ? await Promise.all([
+          slugPrefix
+            ? ctx.db
+                .query("skillSearchDigest")
+                .withIndex("by_nonsuspicious_normalized_slug", (q) =>
+                  q.eq("softDeletedAt", undefined)
+                    .eq("isSuspicious", false)
+                    .gte("normalizedSlug", slugPrefix)
+                    .lt("normalizedSlug", prefixUpperBound(slugPrefix)),
+                )
+                .take(limit)
+            : Promise.resolve([]),
+          displayNamePrefix
+            ? ctx.db
+                .query("skillSearchDigest")
+                .withIndex("by_nonsuspicious_normalized_display_name", (q) =>
+                  q.eq("softDeletedAt", undefined)
+                    .eq("isSuspicious", false)
+                    .gte("normalizedDisplayName", displayNamePrefix)
+                    .lt("normalizedDisplayName", prefixUpperBound(displayNamePrefix)),
+                )
+                .take(limit)
+            : Promise.resolve([]),
+          rawDisplayNamePrefix
+            ? ctx.db
+                .query("skillSearchDigest")
+                .withIndex("by_nonsuspicious_name", (q) =>
+                  q.eq("softDeletedAt", undefined)
+                    .eq("isSuspicious", false)
+                    .gte("displayName", rawDisplayNamePrefix)
+                    .lt("displayName", prefixUpperBound(rawDisplayNamePrefix)),
+                )
+                .take(limit)
+            : Promise.resolve([]),
+        ])
+      : await Promise.all([
+          slugPrefix
+            ? ctx.db
+                .query("skillSearchDigest")
+                .withIndex("by_active_normalized_slug", (q) =>
+                  q.eq("softDeletedAt", undefined)
+                    .gte("normalizedSlug", slugPrefix)
+                    .lt("normalizedSlug", prefixUpperBound(slugPrefix)),
+                )
+                .take(limit)
+            : Promise.resolve([]),
+          displayNamePrefix
+            ? ctx.db
+                .query("skillSearchDigest")
+                .withIndex("by_active_normalized_display_name", (q) =>
+                  q.eq("softDeletedAt", undefined)
+                    .gte("normalizedDisplayName", displayNamePrefix)
+                    .lt("normalizedDisplayName", prefixUpperBound(displayNamePrefix)),
+                )
+                .take(limit)
+            : Promise.resolve([]),
+          rawDisplayNamePrefix
+            ? ctx.db
+                .query("skillSearchDigest")
+                .withIndex("by_active_name", (q) =>
+                  q.eq("softDeletedAt", undefined)
+                    .gte("displayName", rawDisplayNamePrefix)
+                    .lt("displayName", prefixUpperBound(rawDisplayNamePrefix)),
+                )
+                .take(limit)
+            : Promise.resolve([]),
+        ]);
+
+    const uniqueDigests = [...slugDigests, ...displayNameDigests, ...legacyDisplayNameDigests]
+      .filter(
+        (digest, index, all) =>
+          all.findIndex((candidate) => candidate.skillId === digest.skillId) === index,
+      )
+      .sort((a, b) => b.updatedAt - a.updatedAt || a.slug.localeCompare(b.slug))
+      .slice(0, limit);
+
+    if (uniqueDigests.length === 0) return [];
+
+    const getOwnerInfo = makeOwnerInfoGetter(ctx);
+    const entries = await Promise.all(
+      uniqueDigests.map(async (digest) => {
+        const skill = digestToHydratableSkill(digest);
+        const preResolved = digestToOwnerInfo(digest);
+        const resolved = preResolved?.owner
+          ? preResolved
+          : await getOwnerInfo(skill.ownerUserId, skill.ownerPublisherId);
+        const publicSkill = toPublicSkill(skill);
+        if (!publicSkill || !resolved.owner) return null;
+        return {
+          skill: publicSkill,
+          version: null as Doc<"skillVersions"> | null,
+          ownerHandle: resolved.ownerHandle,
+          owner: resolved.owner,
+        };
+      }),
+    );
+    const validEntries = entries.filter(Boolean) as SkillSearchEntry[];
+    if (validEntries.length === 0) return [];
+
+    const filtered = args.highlightedOnly
+      ? validEntries.filter((entry) => isSkillHighlighted(entry.skill))
+      : validEntries;
+    return filtered.slice(0, limit);
   },
 });
 


### PR DESCRIPTION
## Summary
- add a direct lexical prefix lookup path for skill search using normalized slug and display-name digest indexes
- merge direct lexical matches before the recent-digest fallback so specific queries still surface when vector recall returns nothing
- keep the fix effective before backfill by also checking the existing case-sensitive display-name prefix indexes
- backfill normalized digest fields for existing rows and add regression tests for issue #1254

Closes #1254.

## Testing
- `bun /Users/bytedance/personal/clawhub-search-fix/node_modules/vitest/vitest.mjs run convex/search.test.ts convex/lib/skillSearchDigest.test.ts`
- `bun run lint`
- `bunx tsc --noEmit`

## Notes
- `bunx convex codegen` requires a configured `CONVEX_DEPLOYMENT`; this local clone does not have one, so I validated with tests, lint, and TypeScript instead.