### PR TITLE
fix: fallback to lexical search when embedding generation fails

### DIFF
--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -65,6 +65,36 @@ describe("search helpers", () => {
     );
   });
 
+  it("falls back to lexical search when embedding generation fails", async () => {
+    generateEmbeddingMock.mockRejectedValueOnce(new Error("API unavailable"));
+    const fallback = [
+      {
+        skill: makePublicSkill({ id: "skills:orf", slug: "orf", displayName: "ORF" }),
+        version: null,
+        ownerHandle: "steipete",
+        owner: null,
+      },
+    ];
+    const runQuery = vi.fn().mockResolvedValueOnce(fallback); // lexicalFallbackSkills
+
+    const result = await searchSkillsHandler(
+      {
+        vectorSearch: vi.fn().mockRejectedValue(new Error("should not be called")),
+        runQuery,
+      },
+      { query: "orf", limit: 10 },
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].skill.slug).toBe("orf");
+    // vectorSearch should never be called when embedding fails
+    expect(runQuery).toHaveBeenCalledTimes(1);
+    expect(runQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ query: "orf", queryTokens: ["orf"] }),
+    );
+  });
+
   it("applies highlightedOnly filtering in lexical fallback", async () => {
     const highlighted = {
       ...makeSkillDoc({

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -387,7 +387,7 @@ export const searchSouls: ReturnType<typeof action> = action({
     try {
       vector = await generateEmbedding(query);
     } catch (error) {
-      console.warn("Search embedding generation failed, falling back to lexical search", error);
+      console.warn("Search embedding generation failed, returning empty results", error);
       vector = null;
     }
     const limit = args.limit ?? 10;

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -128,12 +128,12 @@ export const searchSkills: ReturnType<typeof action> = action({
     if (!query) return [];
     const queryTokens = tokenize(query);
     if (queryTokens.length === 0) return [];
-    let vector: number[];
+    let vector: number[] | null;
     try {
       vector = await generateEmbedding(query);
     } catch (error) {
-      console.warn("Search embedding generation failed", error);
-      return [];
+      console.warn("Search embedding generation failed, falling back to lexical search", error);
+      vector = null;
     }
     const limit = args.limit ?? 10;
     // Convex vectorSearch max limit is 256; clamp candidate sizes accordingly.
@@ -144,7 +144,7 @@ export const searchSkills: ReturnType<typeof action> = action({
     let scoreById = new Map<Id<"skillEmbeddings">, number>();
     let exactMatches: SkillSearchEntry[] = [];
 
-    while (candidateLimit <= maxCandidate) {
+    while (vector && candidateLimit <= maxCandidate) {
       const results = await ctx.vectorSearch("skillEmbeddings", "by_embedding", {
         vector,
         limit: candidateLimit,
@@ -383,12 +383,12 @@ export const searchSouls: ReturnType<typeof action> = action({
     if (!query) return [];
     const queryTokens = tokenize(query);
     if (queryTokens.length === 0) return [];
-    let vector: number[];
+    let vector: number[] | null;
     try {
       vector = await generateEmbedding(query);
     } catch (error) {
-      console.warn("Search embedding generation failed", error);
-      return [];
+      console.warn("Search embedding generation failed, falling back to lexical search", error);
+      vector = null;
     }
     const limit = args.limit ?? 10;
     // Convex vectorSearch max limit is 256; clamp candidate sizes accordingly.
@@ -398,7 +398,7 @@ export const searchSouls: ReturnType<typeof action> = action({
     let scoreById = new Map<Id<"soulEmbeddings">, number>();
     let exactMatches: HydratedSoulEntry[] = [];
 
-    while (candidateLimit <= maxCandidate) {
+    while (vector && candidateLimit <= maxCandidate) {
       const results = await ctx.vectorSearch("soulEmbeddings", "by_embedding", {
         vector,
         limit: candidateLimit,


### PR DESCRIPTION
## Problem

When `generateEmbedding()` throws (e.g. embedding API unavailable), both `searchSkills` and 
`searchSouls` immediately return an empty array. However, the lexical fallback path 
(`lexicalFallbackSkills`) does not depend on embeddings — it uses token matching against 
skill slugs, names, and summaries.

## Solution

- Changed `vector` from `number[]` to `number[] | null`
- The vector search `while` loop is now guarded by `vector &&`, so it is skipped when 
  embedding is unavailable
- For `searchSkills`, this naturally falls through to `lexicalFallbackSkills`
- For `searchSouls`, the vector loop is similarly skipped

## Changes

- `convex/search.ts`: Modified `searchSkills` and `searchSouls` to gracefully handle 
  embedding failures
- `convex/search.test.ts`: Added test case verifying lexical fallback is invoked when 
  embedding generation fails

All 17 tests pass.