### PR TITLE
fix: add lexical fallback, scoring boost, and incremental hydration for soul search

### DIFF
--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -2,7 +2,15 @@
 
 import { describe, expect, it, vi } from "vitest";
 import { tokenize } from "./lib/searchText";
-import { __test, hydrateResults, lexicalFallbackSkills, searchSkills } from "./search";
+import {
+  __test,
+  hydrateResults,
+  hydrateSoulResults,
+  lexicalFallbackSkills,
+  lexicalFallbackSouls,
+  searchSkills,
+  searchSouls,
+} from "./search";
 
 const { generateEmbeddingMock } = vi.hoisted(() => ({
   generateEmbeddingMock: vi.fn(),
@@ -25,7 +33,17 @@ type WrappedHandler = {
 };
 
 const searchSkillsHandler = (searchSkills as unknown as WrappedHandler)._handler;
+const searchSoulsHandler = (searchSouls as unknown as WrappedHandler)._handler;
 const lexicalFallbackSkillsHandler = (lexicalFallbackSkills as unknown as WrappedHandler)._handler;
+const lexicalFallbackSoulsHandler = (lexicalFallbackSouls as unknown as WrappedHandler)._handler;
+const hydrateSoulResultsHandler = (
+  hydrateSoulResults as unknown as {
+    _handler: (
+      ctx: unknown,
+      args: unknown,
+    ) => Promise<Array<{ soul: { slug: string; _id: string }; embeddingId: string }>>;
+  }
+)._handler;
 const hydrateResultsHandler = (
   hydrateResults as unknown as {
     _handler: (
@@ -354,21 +372,21 @@ describe("search helpers", () => {
 
   it("boosts exact slug/name matches over loose matches", () => {
     const queryTokens = tokenize("notion");
-    const exactScore = __test.scoreSkillResult(queryTokens, 0.4, "Notion Sync", "notion-sync", 5);
-    const looseScore = __test.scoreSkillResult(queryTokens, 0.6, "Notes Sync", "notes-sync", 500);
+    const exactScore = __test.scoreSearchResult(queryTokens, 0.4, "Notion Sync", "notion-sync", 5);
+    const looseScore = __test.scoreSearchResult(queryTokens, 0.6, "Notes Sync", "notes-sync", 500);
     expect(exactScore).toBeGreaterThan(looseScore);
   });
 
   it("adds a popularity prior for equally relevant matches", () => {
     const queryTokens = tokenize("notion");
-    const lowDownloads = __test.scoreSkillResult(
+    const lowDownloads = __test.scoreSearchResult(
       queryTokens,
       0.5,
       "Notion Helper",
       "notion-helper",
       0,
     );
-    const highDownloads = __test.scoreSkillResult(
+    const highDownloads = __test.scoreSearchResult(
       queryTokens,
       0.5,
       "Notion Helper",
@@ -581,6 +599,186 @@ describe("search helpers", () => {
   });
 });
 
+describe("soul search", () => {
+  it("returns fallback results when vector candidates are empty", async () => {
+    generateEmbeddingMock.mockResolvedValueOnce([0, 1, 2]);
+    const fallback = [
+      {
+        soul: makePublicSoul({ id: "souls:1", slug: "helper", displayName: "Helper" }),
+        version: null,
+      },
+    ];
+    const runQuery = vi.fn().mockResolvedValueOnce(fallback); // lexicalFallbackSouls
+
+    const result = await searchSoulsHandler(
+      {
+        vectorSearch: vi.fn().mockResolvedValue([]),
+        runQuery,
+      },
+      { query: "helper", limit: 10 },
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].soul.slug).toBe("helper");
+    expect(runQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ query: "helper", queryTokens: ["helper"] }),
+    );
+  });
+
+  it("applies lexical boost and popularity scoring to soul results", async () => {
+    generateEmbeddingMock.mockResolvedValueOnce([0, 1, 2]);
+    const vectorEntries = [
+      {
+        embeddingId: "soulEmbeddings:a",
+        soul: makePublicSoul({
+          id: "souls:a",
+          slug: "notion-soul",
+          displayName: "Notion Soul",
+          downloads: 100,
+        }),
+        version: null,
+      },
+      {
+        embeddingId: "soulEmbeddings:b",
+        soul: makePublicSoul({
+          id: "souls:b",
+          slug: "notes-soul",
+          displayName: "Notes Soul",
+          downloads: 0,
+        }),
+        version: null,
+      },
+    ];
+
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce(vectorEntries) // hydrateSoulResults
+      .mockResolvedValueOnce([]); // lexicalFallbackSouls
+
+    const result = await searchSoulsHandler(
+      {
+        vectorSearch: vi.fn().mockResolvedValue([
+          { _id: "soulEmbeddings:a", _score: 0.5 },
+          { _id: "soulEmbeddings:b", _score: 0.8 },
+        ]),
+        runQuery,
+      },
+      { query: "notion soul", limit: 10 },
+    );
+
+    expect(result).toHaveLength(2);
+    // "notion-soul" should rank higher due to lexical boost despite lower vector score
+    expect(result[0].soul.slug).toBe("notion-soul");
+    expect(result[0].score).toBeGreaterThan(result[1].score);
+  });
+
+  it("includes exact slug match from lexicalFallbackSouls", async () => {
+    const exactSlugSoul = makeSoulDoc({ id: "souls:1", slug: "helper", displayName: "Helper" });
+    const ctx = makeSoulLexicalCtx({
+      exactSlugSoul,
+      recentSouls: [],
+    });
+
+    const result = await lexicalFallbackSoulsHandler(ctx, {
+      query: "helper",
+      queryTokens: ["helper"],
+      limit: 10,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].soul.slug).toBe("helper");
+  });
+
+  it("excludes soft-deleted souls from lexical fallback", async () => {
+    const deletedSoul = makeSoulDoc({
+      id: "souls:1",
+      slug: "helper",
+      displayName: "Helper",
+      softDeletedAt: 1700000000000,
+    });
+    const ctx = makeSoulLexicalCtx({
+      exactSlugSoul: deletedSoul,
+      recentSouls: [],
+    });
+
+    const result = await lexicalFallbackSoulsHandler(ctx, {
+      query: "helper",
+      queryTokens: ["helper"],
+      limit: 10,
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("merges fallback matches without duplicate soul ids", () => {
+    const primary = [
+      { embeddingId: "soulEmbeddings:1", soul: { _id: "souls:1" } },
+    ] as unknown as Parameters<typeof __test.mergeUniqueBySoulId>[0];
+    const fallback = [
+      { soul: { _id: "souls:1" } },
+      { soul: { _id: "souls:2" } },
+    ] as unknown as Parameters<typeof __test.mergeUniqueBySoulId>[1];
+
+    const merged = __test.mergeUniqueBySoulId(primary, fallback);
+    expect(merged).toHaveLength(2);
+    expect(merged.map((entry) => entry.soul._id)).toEqual(["souls:1", "souls:2"]);
+  });
+
+  it("uses incremental hydration for soul search", async () => {
+    generateEmbeddingMock.mockResolvedValueOnce([0, 1, 2]);
+
+    const firstBatch = Array.from({ length: 50 }, (_, i) => ({
+      _id: `soulEmbeddings:e${i}`,
+      _score: 0.5 - i * 0.001,
+    }));
+    const secondBatch = [
+      ...firstBatch,
+      ...Array.from({ length: 10 }, (_, i) => ({
+        _id: `soulEmbeddings:n${i}`,
+        _score: 0.3 - i * 0.001,
+      })),
+    ];
+
+    const vectorSearchMock = vi
+      .fn()
+      .mockResolvedValueOnce(firstBatch)
+      .mockResolvedValueOnce(secondBatch);
+
+    const hydrateCalls: string[][] = [];
+    const runQuery = vi.fn(
+      async (_ref: unknown, args: { embeddingIds?: string[]; query?: string }) => {
+        if (args.embeddingIds) {
+          hydrateCalls.push(args.embeddingIds);
+          return args.embeddingIds.map((embeddingId: string) => ({
+            embeddingId,
+            soul: makePublicSoul({
+              id: `souls:${embeddingId.split(":")[1]}`,
+              slug: `soul-${embeddingId.split(":")[1]}`,
+              displayName: `Soul ${embeddingId.split(":")[1]}`,
+            }),
+            version: null,
+          }));
+        }
+        return []; // lexicalFallbackSouls
+      },
+    );
+
+    await searchSoulsHandler(
+      { vectorSearch: vectorSearchMock, runQuery },
+      { query: "test", limit: 10 },
+    );
+
+    // Should have been called twice, but second call should only have new IDs
+    expect(hydrateCalls).toHaveLength(2);
+    expect(hydrateCalls[0]).toHaveLength(50);
+    expect(hydrateCalls[1]).toHaveLength(10);
+    const firstSet = new Set(hydrateCalls[0]);
+    const overlap = hydrateCalls[1].filter((id) => firstSet.has(id));
+    expect(overlap).toHaveLength(0);
+  });
+});
+
 function makePublicSkill(params: {
   id: string;
   slug: string;
@@ -678,6 +876,77 @@ function makeLexicalCtx(params: {
         if (id.startsWith("users:")) return { _id: id, handle: "owner" };
         if (id.startsWith("skillVersions:")) return { _id: id, version: "1.0.0" };
         return null;
+      }),
+    },
+  };
+}
+
+function makePublicSoul(params: {
+  id: string;
+  slug: string;
+  displayName: string;
+  downloads?: number;
+}) {
+  return {
+    _id: params.id,
+    _creationTime: 1,
+    slug: params.slug,
+    displayName: params.displayName,
+    summary: `${params.displayName} summary`,
+    ownerUserId: "users:owner",
+    ownerPublisherId: undefined,
+    latestVersionId: "soulVersions:1",
+    tags: {},
+    stats: {
+      downloads: params.downloads ?? 0,
+      stars: 0,
+      versions: 1,
+      comments: 0,
+    },
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function makeSoulDoc(params: {
+  id: string;
+  slug: string;
+  displayName: string;
+  softDeletedAt?: number;
+}) {
+  return {
+    ...makePublicSoul(params),
+    softDeletedAt: params.softDeletedAt as number | undefined,
+  };
+}
+
+function makeSoulLexicalCtx(params: {
+  exactSlugSoul: ReturnType<typeof makeSoulDoc> | null;
+  recentSouls: Array<ReturnType<typeof makeSoulDoc>>;
+}) {
+  return {
+    db: {
+      query: vi.fn((table: string) => {
+        if (table === "souls") {
+          return {
+            withIndex: (index: string) => {
+              if (index === "by_slug") {
+                return {
+                  unique: vi.fn().mockResolvedValue(params.exactSlugSoul),
+                };
+              }
+              if (index === "by_updated") {
+                return {
+                  order: () => ({
+                    take: vi.fn().mockResolvedValue(params.recentSouls),
+                  }),
+                };
+              }
+              throw new Error(`Unexpected souls index ${index}`);
+            },
+          };
+        }
+        throw new Error(`Unexpected table ${table}`);
       }),
     },
   };

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -92,7 +92,7 @@ function getLexicalBoost(queryTokens: string[], displayName: string, slug: strin
   return boost;
 }
 
-function scoreSkillResult(
+function scoreSearchResult(
   queryTokens: string[],
   vectorScore: number,
   displayName: string,
@@ -210,7 +210,7 @@ export const searchSkills: ReturnType<typeof action> = action({
         const vectorScore = entry.embeddingId ? (scoreById.get(entry.embeddingId) ?? 0) : 0;
         return {
           ...entry,
-          score: scoreSkillResult(
+          score: scoreSearchResult(
             queryTokens,
             vectorScore,
             entry.skill.displayName,
@@ -366,12 +366,24 @@ export const lexicalFallbackSkills = internalQuery({
 });
 
 type HydratedSoulEntry = {
-  embeddingId: Id<"soulEmbeddings">;
+  embeddingId?: Id<"soulEmbeddings">;
   soul: NonNullable<ReturnType<typeof toPublicSoul>>;
   version: Doc<"soulVersions"> | null;
 };
 
 type SoulSearchResult = HydratedSoulEntry & { score: number };
+
+function mergeUniqueBySoulId(primary: HydratedSoulEntry[], fallback: HydratedSoulEntry[]) {
+  if (fallback.length === 0) return primary;
+  const out = [...primary];
+  const seen = new Set(primary.map((entry) => entry.soul._id));
+  for (const entry of fallback) {
+    if (seen.has(entry.soul._id)) continue;
+    seen.add(entry.soul._id);
+    out.push(entry);
+  }
+  return out;
+}
 
 export const searchSouls: ReturnType<typeof action> = action({
   args: {
@@ -395,6 +407,7 @@ export const searchSouls: ReturnType<typeof action> = action({
     const maxCandidate = Math.min(Math.max(limit * 10, 200), 256);
     let candidateLimit = Math.min(Math.max(limit * 3, 50), 256);
     let hydrated: HydratedSoulEntry[] = [];
+    const seenEmbeddingIds = new Set<Id<"soulEmbeddings">>();
     let scoreById = new Map<Id<"soulEmbeddings">, number>();
     let exactMatches: HydratedSoulEntry[] = [];
 
@@ -405,9 +418,16 @@ export const searchSouls: ReturnType<typeof action> = action({
         filter: (q) => q.or(q.eq("visibility", "latest"), q.eq("visibility", "latest-approved")),
       });
 
-      hydrated = (await ctx.runQuery(internal.search.hydrateSoulResults, {
-        embeddingIds: results.map((result) => result._id),
-      })) as HydratedSoulEntry[];
+      // Only hydrate embedding IDs we haven't seen yet (incremental).
+      const newEmbeddingIds = results.map((r) => r._id).filter((id) => !seenEmbeddingIds.has(id));
+      for (const id of newEmbeddingIds) seenEmbeddingIds.add(id);
+
+      if (newEmbeddingIds.length > 0) {
+        const newEntries = (await ctx.runQuery(internal.search.hydrateSoulResults, {
+          embeddingIds: newEmbeddingIds,
+        })) as HydratedSoulEntry[];
+        hydrated = [...hydrated, ...newEntries];
+      }
 
       scoreById = new Map<Id<"soulEmbeddings">, number>(
         results.map((result) => [result._id, result._score]),
@@ -430,12 +450,33 @@ export const searchSouls: ReturnType<typeof action> = action({
       candidateLimit = nextLimit;
     }
 
-    return exactMatches
-      .map((entry) => ({
-        ...entry,
-        score: scoreById.get(entry.embeddingId) ?? 0,
-      }))
+    const fallbackMatches =
+      exactMatches.length >= limit
+        ? []
+        : ((await ctx.runQuery(internal.search.lexicalFallbackSouls, {
+            query,
+            queryTokens,
+            limit: Math.min(Math.max(limit * 4, 200), FALLBACK_SCAN_LIMIT),
+          })) as HydratedSoulEntry[]);
+
+    const mergedMatches = mergeUniqueBySoulId(exactMatches, fallbackMatches);
+
+    return mergedMatches
+      .map((entry) => {
+        const vectorScore = entry.embeddingId ? (scoreById.get(entry.embeddingId) ?? 0) : 0;
+        return {
+          ...entry,
+          score: scoreSearchResult(
+            queryTokens,
+            vectorScore,
+            entry.soul.displayName,
+            entry.soul.slug,
+            entry.soul.stats.downloads,
+          ),
+        };
+      })
       .filter((entry) => entry.soul)
+      .sort((a, b) => b.score - a.score || b.soul.stats.downloads - a.soul.stats.downloads)
       .slice(0, limit);
   },
 });
@@ -460,10 +501,67 @@ export const hydrateSoulResults = internalQuery({
   },
 });
 
+export const lexicalFallbackSouls = internalQuery({
+  args: {
+    query: v.string(),
+    queryTokens: v.array(v.string()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<HydratedSoulEntry[]> => {
+    const limit = Math.min(Math.max(args.limit ?? 200, 10), FALLBACK_SCAN_LIMIT);
+    const seenSoulIds = new Set<Id<"souls">>();
+    const candidates: Doc<"souls">[] = [];
+
+    // Exact slug match via the souls table (only one row, cheap).
+    const slugQuery = args.query.trim().toLowerCase();
+    if (/^[a-z0-9][a-z0-9-]*$/.test(slugQuery)) {
+      const exactSlugSoul = await ctx.db
+        .query("souls")
+        .withIndex("by_slug", (q) => q.eq("slug", slugQuery))
+        .unique();
+      if (exactSlugSoul && !exactSlugSoul.softDeletedAt) {
+        seenSoulIds.add(exactSlugSoul._id);
+        candidates.push(exactSlugSoul);
+      }
+    }
+
+    // Scan recent active souls by updatedAt.
+    const recentSouls = await ctx.db
+      .query("souls")
+      .withIndex("by_updated")
+      .order("desc")
+      .take(FALLBACK_SCAN_LIMIT);
+
+    for (const soul of recentSouls) {
+      if (seenSoulIds.has(soul._id)) continue;
+      if (soul.softDeletedAt) continue;
+      seenSoulIds.add(soul._id);
+      candidates.push(soul);
+    }
+
+    const matched = candidates.filter((soul) =>
+      matchesExactTokens(args.queryTokens, [soul.displayName, soul.slug, soul.summary]),
+    );
+    if (matched.length === 0) return [];
+
+    const entries = matched.map((soul) => {
+      const publicSoul = toPublicSoul(soul);
+      if (!publicSoul) return null;
+      return {
+        soul: publicSoul,
+        version: null as Doc<"soulVersions"> | null,
+      };
+    });
+
+    return entries.filter(Boolean).slice(0, limit) as HydratedSoulEntry[];
+  },
+});
+
 export const __test = {
   getNextCandidateLimit,
   matchesAllTokens,
   getLexicalBoost,
-  scoreSkillResult,
+  scoreSearchResult,
   mergeUniqueBySkillId,
+  mergeUniqueBySoulId,
 };

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -526,15 +526,17 @@ export const lexicalFallbackSouls = internalQuery({
     }
 
     // Scan recent active souls by updatedAt.
+    // Filter out soft-deleted rows before truncating so that deleted souls
+    // don't consume slots in the FALLBACK_SCAN_LIMIT budget.
     const recentSouls = await ctx.db
       .query("souls")
       .withIndex("by_updated")
       .order("desc")
+      .filter((q) => q.eq(q.field("softDeletedAt"), undefined))
       .take(FALLBACK_SCAN_LIMIT);
 
     for (const soul of recentSouls) {
       if (seenSoulIds.has(soul._id)) continue;
-      if (soul.softDeletedAt) continue;
       seenSoulIds.add(soul._id);
       candidates.push(soul);
     }


### PR DESCRIPTION
## Problem

`searchSouls` was missing several features that `searchSkills` already had, causing 
inconsistent search quality:

1. No lexical fallback — searching by exact name could return 0 results
2. No scoring boost — slug/name matches weren't prioritized over vector similarity
3. No incremental hydration — all embeddings were re-hydrated on each loop iteration
4. No merge/dedup — vector and fallback results weren't combined

## Solution

1. **Lexical fallback**: Added `lexicalFallbackSouls` that scans recent souls via 
   `by_updated` index and matches by exact slug + token matching on displayName/slug/summary
2. **Scoring boost**: Soul results now use `scoreSearchResult()` (renamed from 
   `scoreSkillResult` for reuse) combining vector score + lexical boost + popularity boost
3. **Incremental hydration**: Vector search loop tracks seen embedding IDs and only 
   hydrates new ones
4. **Merge + dedup**: Added `mergeUniqueBySoulId` to combine vector and lexical results

## Changes

- `convex/search.ts`: Added `lexicalFallbackSouls`, `mergeUniqueBySoulId`, incremental 
  hydration, and scoring to `searchSouls`. Renamed `scoreSkillResult` → `scoreSearchResult`.
- `convex/search.test.ts`: Added 6 new test cases for soul search

All 22 tests pass (16 existing + 6 new).