### PR TITLE
fix: update ownerPublisherId and slug aliases on skill transfer

### DIFF
--- a/convex/skillTransfers.ts
+++ b/convex/skillTransfers.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import type { Doc, Id } from "./_generated/dataModel";
 import { internalMutation, internalQuery } from "./functions";
+import { ensurePersonalPublisherForUser } from "./lib/publishers";
 const TRANSFER_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
 
 type TransferDoc = Doc<"skillOwnershipTransfers">;
@@ -157,7 +158,7 @@ export const acceptTransferInternal = internalMutation({
   },
   handler: async (ctx, args) => {
     const now = Date.now();
-    await requireActiveUserById(ctx, args.actorUserId);
+    const newOwner = await requireActiveUserById(ctx, args.actorUserId);
 
     const transfer = await validatePendingTransferForActor(ctx, {
       transferId: args.transferId,
@@ -173,11 +174,27 @@ export const acceptTransferInternal = internalMutation({
       throw new Error("Transfer is no longer valid");
     }
 
+    const newPublisher = await ensurePersonalPublisherForUser(ctx, newOwner as Doc<"users">);
+
     await ctx.db.patch(skill._id, {
       ownerUserId: args.actorUserId,
+      ownerPublisherId: newPublisher._id,
       updatedAt: now,
     });
     await ctx.db.patch(transfer._id, { status: "accepted", respondedAt: now });
+
+    // Update slug aliases to point to the new owner
+    const aliases = await ctx.db
+      .query("skillSlugAliases")
+      .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
+      .collect();
+    for (const alias of aliases) {
+      await ctx.db.patch(alias._id, {
+        ownerUserId: args.actorUserId,
+        ownerPublisherId: newPublisher._id,
+        updatedAt: now,
+      });
+    }
 
     await ctx.db.insert("auditLogs", {
       actorUserId: args.actorUserId,

--- a/convex/skillTransfers.ts
+++ b/convex/skillTransfers.ts
@@ -175,6 +175,7 @@ export const acceptTransferInternal = internalMutation({
     }
 
     const newPublisher = await ensurePersonalPublisherForUser(ctx, newOwner as Doc<"users">);
+    if (!newPublisher) throw new Error("Failed to resolve publisher for new owner");
 
     await ctx.db.patch(skill._id, {
       ownerUserId: args.actorUserId,


### PR DESCRIPTION
Fixes: https://github.com/openclaw/clawhub/issues/1303

## Summary

- **Bug:** After accepting a skill transfer, visiting the skill URL still redirects to the old owner's profile (e.g. 
- **Root cause:** `acceptTransferInternal` only updates `ownerUserId`, but since the publisher migration (`f6ce8f9`) all read paths (`getOwnerPublisher`) resolve ownership via `ownerPublisherId` first — which still pointed to the old owner's publisher
- **Fix:** The transfer now also sets `ownerPublisherId` to the new owner's personal publisher and updates any `skillSlugAliases` rows for the transferred skill

## Test plan

- [ ] Transfer a skill between two users
- [ ] Verify the skill page resolves to the new owner's handle in the URL
- [ ] Verify slug aliases (if any) also redirect to the new owner
- [ ] Verify the skill still appears in the new owner's dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)