### PR TITLE
chore: add repository field to clawhub CLI package.json

### DIFF
--- a/packages/clawdhub/package.json
+++ b/packages/clawdhub/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/openclaw/clawhub.git",
+    "url": "git+https://github.com/openclaw/clawhub.git",
     "directory": "packages/clawdhub"
   },
   "bin": {

--- a/packages/clawdhub/package.json
+++ b/packages/clawdhub/package.json
@@ -3,6 +3,11 @@
   "version": "0.9.0",
   "description": "ClawHub CLI \\u2014 install, update, search, and publish skills plus OpenClaw packages.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/openclaw/clawhub.git",
+    "directory": "packages/clawdhub"
+  },
   "bin": {
     "clawdhub": "bin/clawdhub.js",
     "clawhub": "bin/clawdhub.js"


### PR DESCRIPTION
This will help claude figure out the repo and easier for people to find issues:

Example, current behaviour

Me: 

```
!which clawhub
```

Claude:

```
/Users/yuchen/.nvm/versions/node/v24.14.0/bin/clawhub
```

Me:

```
which git repo is clawhub command implemented?
```

Claude:

```
The package.json has no repository field, and the README says to run it from "this repo" but doesn't name the repo. The git remote in that directory traces back to nvm-sh/nvm (an artifact of nvm's directory structure, not the actual source).

Do you know where the source repo lives locally? I can look for it if you give me a hint (e.g., a folder name or GitHub org).
```