### PR TITLE
feat: add --dry-run flag to package publish command

### DIFF
--- a/packages/clawdhub/src/cli.ts
+++ b/packages/clawdhub/src/cli.ts
@@ -387,6 +387,7 @@ packageCmd
   .option("--source-commit <sha>", "Git commit SHA")
   .option("--source-ref <ref>", "Git ref/tag/branch")
   .option("--source-path <path>", "Repo subpath", ".")
+  .option("--dry-run", "List files that would be uploaded without publishing")
   .action(async (folder, options) => {
     const opts = await resolveGlobalOpts();
     await cmdPublishPackage(opts, folder, options);

--- a/packages/clawdhub/src/cli/commands/packages.ts
+++ b/packages/clawdhub/src/cli/commands/packages.ts
@@ -60,6 +60,7 @@ type PackagePublishOptions = {
   sourceCommit?: string;
   sourceRef?: string;
   sourcePath?: string;
+  dryRun?: boolean;
 };
 
 type PackageFile = {
@@ -326,6 +327,14 @@ export async function cmdPublishPackage(
     if (!fileSet.has("openclaw.bundle.json") && hostTargets.length === 0) {
       fail("Bundle plugins need openclaw.bundle.json or --host-targets");
     }
+  }
+
+  if (options.dryRun) {
+    console.log(`Would publish ${name}@${version} (${filesOnDisk.length} files):`);
+    for (const file of filesOnDisk) {
+      console.log(`  ${file.relPath}`);
+    }
+    return;
   }
 
   const spinner = createSpinner(`Preparing ${name}@${version}`);


### PR DESCRIPTION
Lets users inspect which files would be uploaded without actually publishing. Useful for debugging timeouts caused by accidentally included large or unwanted files — iterate with .clawhubignore until the file list looks right, then publish.

Testing output:

```
npx tsx /Users/yuchen/Projects/clawhub/packages/clawdhub/src/cli.ts package publish ~/Projects/AgentZero --family bundle-plugin --name agent-zero --version 0.1.0 --source-repo yzhong52/AgentZero --source-commit b473731794a3102a263b1fffbb8aa710923ab01b --host-targets claude --dry-run 2>&1

Would publish agent-zero@0.1.0 (137 files):
  .DS_Store
  .clawhubignore
  .gitignore
  CLAUDE.md
  Cargo.lock
  Cargo.toml
  README.md
  SKILL.md
  backend/.DS_Store
  backend/Cargo.lock
  backend/Cargo.toml
...
```