### PR TITLE
fix: remove duplicate search navigation item

### DIFF
--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -2,8 +2,10 @@
 
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import Header from "../components/Header";
+
+let mockSiteMode: "souls" | "skills" = "souls";
 
 vi.mock("@tanstack/react-router", () => ({
   Link: (props: { children: ReactNode }) => <a href="/">{props.children}</a>,
@@ -51,8 +53,8 @@ vi.mock("../lib/roles", () => ({
 
 vi.mock("../lib/site", () => ({
   getClawHubSiteUrl: () => "https://clawhub.ai",
-  getSiteMode: () => "souls",
-  getSiteName: () => "OnlyCrabs",
+  getSiteMode: () => mockSiteMode,
+  getSiteName: () => (mockSiteMode === "souls" ? "OnlyCrabs" : "ClawHub"),
 }));
 
 vi.mock("../lib/convexError", () => ({
@@ -77,9 +79,21 @@ vi.mock("../components/ui/toggle-group", () => ({
 }));
 
 describe("Header", () => {
+  beforeEach(() => {
+    mockSiteMode = "souls";
+  });
+
   it("hides Packages navigation in soul mode on mobile and desktop", () => {
     render(<Header />);
 
     expect(screen.queryByText("Packages")).toBeNull();
+  });
+
+  it("does not render a separate Search navigation item in skills mode", () => {
+    mockSiteMode = "skills";
+
+    render(<Header />);
+
+    expect(screen.queryByText("Search")).toBeNull();
   });
 });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -94,30 +94,6 @@ export default function Header() {
             </Link>
           )}
           {isSoulMode ? null : <Link to="/plugins">Plugins</Link>}
-          <Link
-            to={isSoulMode ? "/souls" : "/skills"}
-            search={
-              isSoulMode
-                ? {
-                    q: undefined,
-                    sort: undefined,
-                    dir: undefined,
-                    view: undefined,
-                    focus: "search",
-                  }
-                : {
-                    q: undefined,
-                    sort: undefined,
-                    dir: undefined,
-                    highlighted: undefined,
-                    nonSuspicious: undefined,
-                    view: undefined,
-                    focus: "search",
-                  }
-            }
-          >
-            Search
-          </Link>
           {isSoulMode ? null : <Link to="/about">About</Link>}
           {me ? <Link to="/stars">Stars</Link> : null}
           {isStaff ? (
@@ -176,32 +152,6 @@ export default function Header() {
                     <Link to="/plugins">Plugins</Link>
                   </DropdownMenuItem>
                 )}
-                <DropdownMenuItem asChild>
-                  <Link
-                    to={isSoulMode ? "/souls" : "/skills"}
-                    search={
-                      isSoulMode
-                        ? {
-                            q: undefined,
-                            sort: undefined,
-                            dir: undefined,
-                            view: undefined,
-                            focus: "search",
-                          }
-                        : {
-                            q: undefined,
-                            sort: undefined,
-                            dir: undefined,
-                            highlighted: undefined,
-                            nonSuspicious: undefined,
-                            view: undefined,
-                            focus: "search",
-                          }
-                    }
-                  >
-                    Search
-                  </Link>
-                </DropdownMenuItem>
                 {isSoulMode ? null : (
                   <DropdownMenuItem asChild>
                     <Link to="/about">About</Link>


### PR DESCRIPTION
## Summary

Removes the duplicate `Search` navigation item from the header.

The current `Search` nav entry routes users back into the same skills browse flow, so it appears redundant with `Skills`.

## Testing

Before:
<img width="1058" height="463" alt="image" src="https://github.com/user-attachments/assets/40cf0ddb-b0c9-4bed-b4a0-40c7a6036258" />


After:
<img width="1003" height="457" alt="image" src="https://github.com/user-attachments/assets/a4aa3b59-8f1a-489c-93ed-4aa9b8cfb140" />


- `bun run test -- src/__tests__/header.test.tsx src/__tests__/search-route.test.ts`
- `bunx oxlint --type-aware --tsconfig ./tsconfig.oxlint.json src/components/Header.tsx src/__tests__/header.test.tsx`
- `bun run build`
- `bun run check:peers`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawdhub/tsconfig.json --noEmit`

## Notes

- `bun run lint` fails locally due to an existing repo issue referencing missing `convex/lib/moderationEngine.test.ts`
- `bun run test` has existing Windows-specific failures in `packages/clawdhub`
