### PR TITLE
fix: normalize github sign-in button spacing and fix cursor 

### DIFF
--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -33,8 +33,13 @@ vi.mock("../lib/theme", () => ({
 }));
 
 vi.mock("../lib/theme-transition", () => ({
-  startThemeTransition: ({ setTheme, nextTheme }: { setTheme: (value: string) => void; nextTheme: string }) =>
-    setTheme(nextTheme),
+  startThemeTransition: ({
+    setTheme,
+    nextTheme,
+  }: {
+    setTheme: (value: string) => void;
+    nextTheme: string;
+  }) => setTheme(nextTheme),
 }));
 
 vi.mock("../lib/useAuthError", () => ({
@@ -73,7 +78,9 @@ vi.mock("../components/ui/dropdown-menu", () => ({
 
 vi.mock("../components/ui/toggle-group", () => ({
   ToggleGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  ToggleGroupItem: ({ children }: { children: ReactNode }) => <button type="button">{children}</button>,
+  ToggleGroupItem: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
 }));
 
 describe("Header", () => {
@@ -81,5 +88,13 @@ describe("Header", () => {
     render(<Header />);
 
     expect(screen.queryByText("Packages")).toBeNull();
+  });
+
+  it("renders the GitHub sign-in button with the dedicated spacing class", () => {
+    render(<Header />);
+
+    const button = screen.getByRole("button", { name: /Sign in/ });
+    expect(button.className).toContain("sign-in-button");
+    expect(screen.getByText("with GitHub")).toBeTruthy();
   });
 });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -305,7 +305,7 @@ export default function Header() {
                 </div>
               ) : null}
               <button
-                className="btn btn-primary"
+                className="btn btn-primary sign-in-button"
                 type="button"
                 disabled={isLoading}
                 onClick={() => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -313,6 +313,7 @@ code {
   align-items: center;
   gap: 8px;
   white-space: nowrap;
+  cursor: pointer;
   transition:
     transform 0.2s ease,
     box-shadow 0.2s ease,
@@ -335,6 +336,10 @@ code {
   background: linear-gradient(135deg, var(--accent), var(--accent-deep));
   color: white;
   border: none;
+}
+
+.sign-in-button {
+  gap: 0.28em;
 }
 
 [data-theme="dark"] .btn-primary {
@@ -1358,7 +1363,9 @@ code {
   border: 1px solid var(--border-ui);
   border-radius: var(--radius-pill);
   padding: 10px 20px 10px 14px;
-  background: rgba(255, 255, 255, 0.45) url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%236b5549' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E") no-repeat right 7px center;
+  background: rgba(255, 255, 255, 0.45)
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%236b5549' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E")
+    no-repeat right 7px center;
   background-size: 10px;
   color: var(--ink);
   font-weight: 650;


### PR DESCRIPTION
## Why

The header GitHub sign-in CTA was rendered as two separate text spans, so the spacing between `Sign in` and `with GitHub` came from the shared button flex gap instead of normal text spacing.

That created two small but visible UI issues:
- the space between `in` and `with` looked wider than the rest of the label
- hovering the button showed the default arrow cursor instead of a pointer

## What Changed

- added a dedicated `sign-in-button` class to the header auth CTA
- tuned the spacing between the two text spans so the label reads like normal text again
- added `cursor: pointer` to the shared `.btn` base style so button hover behavior matches expectations
- added a focused header test covering the sign-in button structure

## Before
<img width="561" height="148" alt="image" src="https://github.com/user-attachments/assets/e83afe71-4c80-46d4-abf1-96f6b9fcf271" />


- `Sign in` and `with GitHub` were separated by the shared flex gap, which looked too wide for plain text
- the sign-in button did not show a pointer cursor on hover

## After
<img width="532" height="133" alt="image" src="https://github.com/user-attachments/assets/859a7f00-3e0c-41d2-b267-aa53e58d4ad3" />


- `Sign in with GitHub` reads with natural-looking spacing
- the sign-in button shows a pointer cursor on hover
- the header test locks in the dedicated sign-in button structure

## Verification

Passed:
- `bunx vitest run src/__tests__/header.test.tsx`
- `bunx oxfmt --check src/components/Header.tsx src/__tests__/header.test.tsx src/styles.css`
- `bun run build`
- `bun run lint`

