### PR TITLE
fix: align skills page width with site layout

### DIFF
--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -63,6 +63,13 @@ describe("SkillsIndex", () => {
     );
   });
 
+  it("does not wrap the skills page content in a narrow width container", async () => {
+    render(<SkillsIndex />);
+    await act(async () => {});
+
+    expect(document.querySelector(".skills-container")).toBeNull();
+  });
+
   it("renders an empty state when no skills are returned", async () => {
     render(<SkillsIndex />);
     await act(async () => {});

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -74,36 +74,34 @@ export function SkillsIndex() {
             : `Browse the skill library${model.activeFilters.length ? ` (${model.activeFilters.join(", ")})` : ""}.`}
         </p>
       </header>
-      <div className="skills-container">
-        <SkillsToolbar
-          searchInputRef={searchInputRef}
-          query={model.query}
-          hasQuery={model.hasQuery}
-          sort={model.sort}
-          dir={model.dir}
-          view={model.view}
-          highlightedOnly={model.highlightedOnly}
-          nonSuspiciousOnly={model.nonSuspiciousOnly}
-          onQueryChange={model.onQueryChange}
-          onToggleHighlighted={model.onToggleHighlighted}
-          onToggleNonSuspicious={model.onToggleNonSuspicious}
-          onSortChange={model.onSortChange}
-          onToggleDir={model.onToggleDir}
-          onToggleView={model.onToggleView}
-        />
-        <SkillsResults
-          isLoadingSkills={model.isLoadingSkills}
-          sorted={model.sorted}
-          view={model.view}
-          listDoneLoading={!model.isLoadingSkills && !model.canLoadMore && !model.isLoadingMore}
-          hasQuery={model.hasQuery}
-          canLoadMore={model.canLoadMore}
-          isLoadingMore={model.isLoadingMore}
-          canAutoLoad={model.canAutoLoad}
-          loadMoreRef={model.loadMoreRef}
-          loadMore={model.loadMore}
-        />
-      </div>
+      <SkillsToolbar
+        searchInputRef={searchInputRef}
+        query={model.query}
+        hasQuery={model.hasQuery}
+        sort={model.sort}
+        dir={model.dir}
+        view={model.view}
+        highlightedOnly={model.highlightedOnly}
+        nonSuspiciousOnly={model.nonSuspiciousOnly}
+        onQueryChange={model.onQueryChange}
+        onToggleHighlighted={model.onToggleHighlighted}
+        onToggleNonSuspicious={model.onToggleNonSuspicious}
+        onSortChange={model.onSortChange}
+        onToggleDir={model.onToggleDir}
+        onToggleView={model.onToggleView}
+      />
+      <SkillsResults
+        isLoadingSkills={model.isLoadingSkills}
+        sorted={model.sorted}
+        view={model.view}
+        listDoneLoading={!model.isLoadingSkills && !model.canLoadMore && !model.isLoadingMore}
+        hasQuery={model.hasQuery}
+        canLoadMore={model.canLoadMore}
+        isLoadingMore={model.isLoadingMore}
+        canAutoLoad={model.canAutoLoad}
+        loadMoreRef={model.loadMoreRef}
+        loadMore={model.loadMore}
+      />
     </main>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1299,11 +1299,6 @@ code {
   margin-bottom: 22px;
 }
 
-.skills-container {
-  max-width: 900px;
-  margin: 0 auto;
-}
-
 .skills-header {
   display: flex;
   align-items: flex-end;


### PR DESCRIPTION
## Summary

Fix the `Skills` page so it uses the same content width as other top-level pages like `About` and `Plugins`.

## Why

The `Skills` page was visibly narrower than other pages because it wrapped the toolbar and results in a page-specific `.skills-container` with `max-width: 900px`.

Other top-level pages already rely on the shared `.section` layout width, so the extra wrapper made `/skills` look inconsistent.

## What Changed

- Removed the extra `.skills-container` wrapper from the skills index page
- Removed the page-specific `max-width: 900px` CSS constraint
- Added a regression test to ensure the skills page is not wrapped in the narrow container again

## Before
<img width="2057" height="840" alt="image" src="https://github.com/user-attachments/assets/3ac0d8eb-7aee-4a58-96a3-7918f1b233b0" />


- `/skills` content was constrained to a narrower width than `/about`
- The toolbar and results table looked more compressed than the rest of the site

## After
<img width="2100" height="819" alt="image" src="https://github.com/user-attachments/assets/157ebd4e-d04a-49c8-954f-2a42b5c5988a" />


- `/skills` now uses the shared page width from the main section layout
- The toolbar and results align with the same width system used elsewhere

## Verification

- `bun run test -- src/__tests__/skills-index.test.tsx`
- `bun run build`
- Ran the app locally and verified the updated `/skills` layout in the browser
- Verified locally with Playwright that `/skills` and `/about` now share the same main content width

## AI Assistance

This PR was prepared with Codex and manually verified locally.
