### PR TITLE
fix: preserve exact skill slug matches in search

### DIFF
--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -236,8 +236,7 @@ describe("search helpers", () => {
     const runQuery = vi
       .fn()
       .mockResolvedValueOnce(exactSlugEntry)
-      .mockResolvedValueOnce(vectorEntries)
-      .mockResolvedValueOnce([]);
+      .mockResolvedValueOnce(vectorEntries);
 
     const result = await searchSkillsHandler(
       {
@@ -251,6 +250,7 @@ describe("search helpers", () => {
 
     expect(result).toHaveLength(10);
     expect(result[0].skill.slug).toBe("skill-downloader");
+    expect(runQuery).toHaveBeenCalledTimes(2);
   });
 
   it("omits exact slug injection when nonSuspiciousOnly excludes it", async () => {
@@ -287,6 +287,151 @@ describe("search helpers", () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].skill.slug).toBe("downloader-1");
+  });
+
+  it("omits exact slug injection when highlightedOnly excludes it", async () => {
+    generateEmbeddingMock.mockResolvedValueOnce([0, 1, 2]);
+
+    const exactSlugEntry = {
+      skill: makePublicSkill({
+        id: "skills:exact",
+        slug: "skill-downloader",
+        displayName: "Skill Downloader",
+        downloads: 1,
+      }),
+      version: null,
+      ownerHandle: "yyang100",
+      owner: null,
+    };
+
+    const vectorEntries = [
+      {
+        embeddingId: "skillEmbeddings:1",
+        skill: {
+          ...makePublicSkill({
+            id: "skills:1",
+            slug: "downloader-1",
+            displayName: "Downloader 1",
+            downloads: 50,
+          }),
+          badges: { highlighted: { byUserId: "users:mod", at: 1 } },
+        },
+        version: null,
+        ownerHandle: "owner",
+        owner: null,
+      },
+    ];
+
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce(exactSlugEntry)
+      .mockResolvedValueOnce(vectorEntries)
+      .mockResolvedValueOnce([]);
+
+    const result = await searchSkillsHandler(
+      {
+        vectorSearch: vi.fn().mockResolvedValue([{ _id: "skillEmbeddings:1", _score: 0.9 }]),
+        runQuery,
+      },
+      { query: "skill-downloader", limit: 10, highlightedOnly: true },
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].skill.slug).toBe("downloader-1");
+  });
+
+  it("deduplicates exact slug injection against vector exact matches", async () => {
+    generateEmbeddingMock.mockResolvedValueOnce([0, 1, 2]);
+
+    const sharedSkill = makePublicSkill({
+      id: "skills:exact",
+      slug: "skill-downloader",
+      displayName: "Skill Downloader",
+      downloads: 100,
+    });
+    const exactSlugEntry = {
+      skill: sharedSkill,
+      version: null,
+      ownerHandle: "yyang100",
+      owner: null,
+    };
+    const vectorEntries = [
+      {
+        embeddingId: "skillEmbeddings:exact",
+        skill: sharedSkill,
+        version: null,
+        ownerHandle: "yyang100",
+        owner: null,
+      },
+      {
+        embeddingId: "skillEmbeddings:other",
+        skill: makePublicSkill({
+          id: "skills:other",
+          slug: "downloader-2",
+          displayName: "Downloader 2",
+          downloads: 50,
+        }),
+        version: null,
+        ownerHandle: "owner",
+        owner: null,
+      },
+    ];
+
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce(exactSlugEntry)
+      .mockResolvedValueOnce(vectorEntries)
+      .mockResolvedValueOnce([]);
+
+    const result = await searchSkillsHandler(
+      {
+        vectorSearch: vi.fn().mockResolvedValue([
+          { _id: "skillEmbeddings:exact", _score: 0.95 },
+          { _id: "skillEmbeddings:other", _score: 0.8 },
+        ]),
+        runQuery,
+      },
+      { query: "skill-downloader", limit: 10 },
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result.filter((entry) => entry.skill._id === "skills:exact")).toHaveLength(1);
+  });
+
+  it("skips duplicate slug lookup inside lexical fallback when search action already did it", async () => {
+    generateEmbeddingMock.mockResolvedValueOnce([0, 1, 2]);
+
+    const fallbackEntries = [
+      {
+        skill: makePublicSkill({
+          id: "skills:orf",
+          slug: "orf",
+          displayName: "ORF",
+        }),
+        version: null,
+        ownerHandle: "steipete",
+        owner: null,
+      },
+    ];
+
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockImplementationOnce(async (_ref: unknown, args: { skipExactSlugLookup?: boolean }) => {
+        expect(args.skipExactSlugLookup).toBe(true);
+        return fallbackEntries;
+      });
+
+    const result = await searchSkillsHandler(
+      {
+        vectorSearch: vi.fn().mockResolvedValue([]),
+        runQuery,
+      },
+      { query: "orf", limit: 10 },
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].skill.slug).toBe("orf");
   });
 
   it("filters suspicious vector results in hydrateResults when requested", async () => {

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -132,12 +132,16 @@ export const searchSkills: ReturnType<typeof action> = action({
     if (!query) return [];
     const queryTokens = tokenize(query);
     if (queryTokens.length === 0) return [];
-    const exactSlugMatch =
+    const rawExactSlugMatch =
       isSlugLikeQuery(query)
         ? ((await ctx.runQuery(internal.search.getExactSkillSlugMatch, {
             slug: query.toLowerCase(),
             nonSuspiciousOnly: args.nonSuspiciousOnly,
           })) as SkillSearchEntry | null)
+        : null;
+    const exactSlugMatch =
+      rawExactSlugMatch && (!args.highlightedOnly || isSkillHighlighted(rawExactSlugMatch.skill))
+        ? rawExactSlugMatch
         : null;
     let vector: number[];
     try {
@@ -203,8 +207,12 @@ export const searchSkills: ReturnType<typeof action> = action({
       candidateLimit = nextLimit;
     }
 
+    const primaryMatches = exactSlugMatch
+      ? mergeUniqueBySkillId([exactSlugMatch], exactMatches)
+      : exactMatches;
+
     const fallbackMatches =
-      exactMatches.length >= limit && !exactSlugMatch
+      primaryMatches.length >= limit
         ? []
         : ((await ctx.runQuery(internal.search.lexicalFallbackSkills, {
             query,
@@ -212,12 +220,9 @@ export const searchSkills: ReturnType<typeof action> = action({
             limit: Math.min(Math.max(limit * 4, 200), FALLBACK_SCAN_LIMIT),
             highlightedOnly: args.highlightedOnly,
             nonSuspiciousOnly: args.nonSuspiciousOnly,
+            skipExactSlugLookup: true,
           })) as SkillSearchEntry[]);
-
-    const mergedMatches = mergeUniqueBySkillId(
-      exactSlugMatch ? [exactSlugMatch, ...exactMatches] : exactMatches,
-      fallbackMatches,
-    );
+    const mergedMatches = mergeUniqueBySkillId(primaryMatches, fallbackMatches);
 
     return mergedMatches
       .map((entry) => {
@@ -326,6 +331,7 @@ export const lexicalFallbackSkills = internalQuery({
     limit: v.optional(v.number()),
     highlightedOnly: v.optional(v.boolean()),
     nonSuspiciousOnly: v.optional(v.boolean()),
+    skipExactSlugLookup: v.optional(v.boolean()),
   },
   handler: async (ctx, args): Promise<SkillSearchEntry[]> => {
     const limit = Math.min(Math.max(args.limit ?? 200, 10), FALLBACK_SCAN_LIMIT);
@@ -339,7 +345,7 @@ export const lexicalFallbackSkills = internalQuery({
 
     // Exact slug match via the skills table (only one row, cheap).
     const slugQuery = args.query.trim().toLowerCase();
-    if (/^[a-z0-9][a-z0-9-]*$/.test(slugQuery)) {
+    if (!args.skipExactSlugLookup && /^[a-z0-9][a-z0-9-]*$/.test(slugQuery)) {
       const exactSlugSkill = await ctx.db
         .query("skills")
         .withIndex("by_slug", (q) => q.eq("slug", slugQuery))


### PR DESCRIPTION
## Summary
- preserve exact public skill slug matches in search results even when vector-ranked matches fill the limit
- use a cheap indexed `by_slug` lookup for slug-like queries and respect `nonSuspiciousOnly`
- add regression tests for exact slug injection and filtering behavior

## Verification
- `bun run test convex/search.test.ts`
- `bun run test`
- `bun run lint`
- `bun run build`

## Notes
- Addresses the exact-slug discoverability bug from #1322 without changing suspicious-skill policy.
- Owner-handle search semantics are intentionally unchanged in this patch.
