### PR TITLE
feat: add publish skill CTA to skills toolbar

### DIFF
--- a/src/__tests__/skills-index-load-more.test.tsx
+++ b/src/__tests__/skills-index-load-more.test.tsx
@@ -19,7 +19,11 @@ vi.mock("@tanstack/react-router", () => ({
     useSearch: () => searchMock,
   }),
   redirect: (options: unknown) => ({ redirect: options }),
-  Link: (props: { children: ReactNode }) => <a href="/">{props.children}</a>,
+  Link: (props: { children: ReactNode; className?: string }) => (
+    <a href="/" className={props.className}>
+      {props.children}
+    </a>
+  ),
 }));
 
 vi.mock("convex/react", () => ({

--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -19,7 +19,11 @@ vi.mock("@tanstack/react-router", () => ({
     useSearch: () => searchMock,
   }),
   redirect: (options: unknown) => ({ redirect: options }),
-  Link: (props: { children: ReactNode }) => <a href="/">{props.children}</a>,
+  Link: (props: { children: ReactNode; className?: string }) => (
+    <a href="/" className={props.className}>
+      {props.children}
+    </a>
+  ),
 }));
 
 vi.mock("convex/react", () => ({
@@ -67,6 +71,13 @@ describe("SkillsIndex", () => {
     render(<SkillsIndex />);
     await act(async () => {});
     expect(screen.getByText("No skills match that filter.")).toBeTruthy();
+  });
+
+  it("shows a publish skill action in the toolbar", async () => {
+    render(<SkillsIndex />);
+    await act(async () => {});
+
+    expect(screen.getByRole("link", { name: "Publish Skill" })).toBeTruthy();
   });
 
   it("shows loading state before fetch completes", async () => {
@@ -229,10 +240,10 @@ describe("SkillsIndex", () => {
       await vi.runAllTimersAsync();
     });
 
-    const links = screen.getAllByRole("link");
-    expect(links[0]?.textContent).toContain("Skill B");
-    expect(links[1]?.textContent).toContain("Skill A");
-    expect(links[2]?.textContent).toContain("Skill C");
+    const resultRows = Array.from(document.querySelectorAll(".skills-table-row"));
+    expect(resultRows[0]?.textContent).toContain("Skill B");
+    expect(resultRows[1]?.textContent).toContain("Skill A");
+    expect(resultRows[2]?.textContent).toContain("Skill C");
   });
 
   it("uses relevance as default sort when searching", async () => {

--- a/src/routes/skills/-SkillsToolbar.tsx
+++ b/src/routes/skills/-SkillsToolbar.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@tanstack/react-router";
 import type { RefObject } from "react";
 import { type SortDir, type SortKey } from "./-params";
 
@@ -91,6 +92,13 @@ export function SkillsToolbar({
         >
           {view === "cards" ? "List" : "Cards"}
         </button>
+        <Link
+          className="btn btn-primary"
+          to="/publish-skill"
+          search={{ updateSlug: undefined }}
+        >
+          Publish Skill
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Add a `Publish Skill` CTA to the `/skills` browse toolbar so the skills page matches the plugin catalog and homepage entry points.

## Why

The skills index page currently lets users browse, search, filter, and sort skills, but it does not expose a direct publishing action.

That creates an inconsistency in the product:
- the homepage already has a `Publish Skill` button
- the plugins page already has a `Publish Plugin` button in the toolbar
- the skills page is missing the equivalent CTA

Adding the button makes publishing easier to discover for users who land directly on the skills catalog.

## What Changed

- Added a `Publish Skill` button to the right side of the skills toolbar
- Reused the existing `/publish-skill` route and existing `btn btn-primary` styling
- Kept the layout consistent with the current toolbar structure and the plugins page CTA placement
- Added a regression test to verify the publish action is rendered on the skills page
- Updated the related test `Link` mocks to preserve `className`
- Tightened one existing sorting test so it asserts against skill result rows instead of assuming the first page link is a result item

## Before
<img width="1844" height="430" alt="image" src="https://github.com/user-attachments/assets/04a0f725-abdc-4168-a1c6-a4873ba6c487" />
<img width="1977" height="454" alt="image" src="https://github.com/user-attachments/assets/6fd7a4e4-a78a-4855-85b4-26ffd88a3449" />


- `/skills` had search/filter/sort controls only
- users browsing the skills catalog had no direct publish CTA on that page

## After

<img width="1790" height="444" alt="image" src="https://github.com/user-attachments/assets/929e905d-205c-4ca5-b738-26ee0ca7b094" />


- `/skills` shows a `Publish Skill` button in the toolbar
- clicking the button navigates to `/publish-skill`

## Testing

- `bun run test -- src/__tests__/skills-index.test.tsx src/__tests__/skills-index-load-more.test.tsx`
- `bun x oxlint src/routes/skills/-SkillsToolbar.tsx src/__tests__/skills-index.test.tsx src/__tests__/skills-index-load-more.test.tsx`
- `bun run build`

## Verification

- Ran the app locally
- Verified `http://localhost:3000/skills?sort=downloads` shows the new `Publish Skill` CTA in the toolbar
- Verified clicking the button navigates to `/publish-skill`

## AI Usage

This PR was made by Codex, with local verification applied before submission.
