### PR TITLE
fix(ui): align publish-skill header with publish-plugin and remove custom background

### DIFF
--- a/src/routes/publish-skill.tsx
+++ b/src/routes/publish-skill.tsx
@@ -432,17 +432,17 @@ export function Upload() {
   }
 
   return (
-    <main className="section upload-page">
-      <header className="upload-page-header">
-        <div>
-          <h1 className="upload-page-title">Publish a {contentLabel}</h1>
-          <p className="upload-page-subtitle">
-            Drop a folder with {requiredFileLabel} and text files. We will handle the rest.
-          </p>
-        </div>
+    <main className="section">
+      <header className="skills-header-top">
+        <h1 className="section-title" style={{ marginBottom: 8 }}>
+          Publish a {contentLabel}
+        </h1>
+        <p className="section-subtitle" style={{ marginBottom: 0 }}>
+          Drop a folder with {requiredFileLabel} and text files. We will handle the rest.
+        </p>
       </header>
 
-      <form onSubmit={handleSubmit} className="upload-grid">
+      <form onSubmit={handleSubmit} className="upload-grid publish-skill-grid">
         <div className="card upload-panel">
           <label className="form-label" htmlFor="slug">
             Slug

--- a/src/styles.css
+++ b/src/styles.css
@@ -440,44 +440,7 @@ code {
   position: relative;
 }
 
-.upload-page {
-  position: relative;
-}
-
-.upload-page::before {
-  content: "";
-  position: absolute;
-  inset: -80px 0 auto;
-  height: 220px;
-  pointer-events: none;
-  background:
-    radial-gradient(circle at 22% 40%, rgba(255, 118, 84, 0.14), transparent 58%),
-    radial-gradient(circle at 78% 0%, rgba(255, 177, 136, 0.08), transparent 45%);
-}
-
-.upload-page-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  gap: 16px;
-  margin-bottom: 18px;
-}
-
-.upload-page-title {
-  margin: 0;
-  font-family: var(--font-display);
-  font-size: clamp(1.9rem, 3.2vw, 2.7rem);
-  letter-spacing: -0.03em;
-}
-
-.upload-page-subtitle {
-  margin: 8px 0 0;
-  max-width: 640px;
-  color: var(--ink-soft);
-  line-height: 1.6;
-}
-
-.upload-page .upload-grid {
+.publish-skill-grid {
   grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
   gap: 18px;
 }
@@ -3437,7 +3400,7 @@ code {
     grid-template-columns: 1fr;
   }
 
-  .upload-page .upload-grid {
+  .publish-skill-grid {
     gap: 14px;
   }
 


### PR DESCRIPTION
## Why

The `/publish-skill` page had a custom square background that felt visually off, especially compared with the cleaner and more restrained header on `/publish-plugin`.

## What changed

- removed the custom publish-skill hero/background treatment
- switched the page header to the same simple title/subtitle structure used on the plugin publishing page
- kept the existing two-column form layout by scoping the grid override to a dedicated `publish-skill-grid` class

## Before
<img width="1307" height="473" alt="image" src="https://github.com/user-attachments/assets/8a25f359-a68f-4499-9310-b091d1f1db64" />


- the page showed a long tinted rectangle-like background behind the title area
- the top section felt heavier and visually inconsistent with the plugin publishing flow

## After
<img width="1331" height="320" alt="image" src="https://github.com/user-attachments/assets/5d243149-009b-4759-8d78-a0d40cba90cb" />


- the odd colored header block is gone
- the page now uses a plain title + subtitle header, matching the plugin page more closely
- the form and upload interaction remain unchanged

## Verification

- `bunx vitest run src/__tests__/upload.route.test.tsx`
- `bun run build`
- `bun run lint`
