### PR TITLE
fix: show pointer cursor on report button

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -312,6 +312,7 @@ code {
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  cursor: pointer;
   white-space: nowrap;
   transition:
     transform 0.2s ease,


### PR DESCRIPTION
## Why
<img width="407" height="249" alt="image" src="https://github.com/user-attachments/assets/67c2d6ac-212e-40e5-bf2c-216723d2d424" />

The skill detail page renders the authenticated `Report` action as a shared `.btn.btn-ghost` button, but the base `.btn` styles did not set a pointer cursor.

That made the `Report` button show the default arrow on hover instead of the expected hand cursor, which felt broken/inconsistent compared with other interactive controls.

The same issue applies to other places whenever `.btn` is used

## What Changed

- Added `cursor: pointer` to the shared `.btn` base style in `src/styles.css`

## Before

- Hovering the `Report` button on the skill detail page showed the default arrow cursor

## After

- Hovering the `Report` button shows the pointer cursor
- Other non-disabled buttons that use the shared `.btn` base style now also consistently show a pointer cursor
- Disabled buttons still use the existing `cursor: not-allowed` rule

## Testing

- `bun run test -- src/__tests__/skill-detail-page.test.tsx`
- `bun run build`

## Verification

- Ran the app locally and checked the skill page in the browser
- Verified via Playwright that the computed cursor for a shared `.btn` button resolves to `"pointer"`
- Confirmed the `Report` button uses the same shared `.btn` styling path on the skill detail page
