### PR TITLE
fix: align transferred skill publisher ownership

### DIFF
--- a/convex/skillTransfers.test.ts
+++ b/convex/skillTransfers.test.ts
@@ -102,6 +102,147 @@ describe("skillTransfers", () => {
     );
   });
 
+  it("acceptTransferInternal updates skill and alias ownership to the recipient publisher", async () => {
+    const patch = vi.fn(async () => {});
+    const insert = vi.fn(async () => "auditLogs:1");
+    const newPublisher = {
+      _id: "publishers:alice",
+      handle: "alice",
+      displayName: "Alice",
+      linkedUserId: "users:2",
+      trustedPublisher: false,
+    };
+    const existingMember = {
+      _id: "publisherMembers:1",
+      publisherId: "publishers:alice",
+      userId: "users:2",
+      role: "owner",
+    };
+    const aliases = [
+      {
+        _id: "skillSlugAliases:1",
+        slug: "demo-old",
+        skillId: "skills:1",
+        ownerUserId: "users:1",
+        ownerPublisherId: "publishers:owner",
+      },
+      {
+        _id: "skillSlugAliases:2",
+        slug: "demo-legacy",
+        skillId: "skills:1",
+        ownerUserId: "users:1",
+        ownerPublisherId: "publishers:owner",
+      },
+    ];
+
+    const result = (await acceptTransferInternalHandler(
+      {
+        db: {
+          normalizeId: vi.fn(),
+          get: vi.fn(async (id: string) => {
+            if (id === "users:2") {
+              return {
+                _id: "users:2",
+                handle: "alice",
+                personalPublisherId: "publishers:alice",
+                trustedPublisher: false,
+              };
+            }
+            if (id === "skillOwnershipTransfers:1") {
+              return {
+                _id: "skillOwnershipTransfers:1",
+                skillId: "skills:1",
+                fromUserId: "users:1",
+                toUserId: "users:2",
+                status: "pending",
+                requestedAt: Date.now() - 1_000,
+                expiresAt: Date.now() + 10_000,
+              };
+            }
+            if (id === "skills:1") {
+              return {
+                _id: "skills:1",
+                slug: "demo",
+                ownerUserId: "users:1",
+                ownerPublisherId: "publishers:owner",
+              };
+            }
+            if (id === "publishers:alice") {
+              return newPublisher;
+            }
+            return null;
+          }),
+          query: vi.fn((table: string) => {
+            if (table === "skillSlugAliases") {
+              return {
+                withIndex: (indexName: string) => {
+                  expect(indexName).toBe("by_skill");
+                  return {
+                    collect: async () => aliases,
+                  };
+                },
+              };
+            }
+            if (table === "publishers") {
+              return {
+                withIndex: (indexName: string) => {
+                  expect(indexName).toBe("by_handle");
+                  return {
+                    unique: async () => newPublisher,
+                  };
+                },
+              };
+            }
+            if (table === "publisherMembers") {
+              return {
+                withIndex: (indexName: string) => {
+                  expect(indexName).toBe("by_publisher_user");
+                  return {
+                    unique: async () => existingMember,
+                  };
+                },
+              };
+            }
+            throw new Error(`unexpected table ${table}`);
+          }),
+          patch,
+          insert,
+        },
+      } as never,
+      {
+        actorUserId: "users:2",
+        transferId: "skillOwnershipTransfers:1",
+      } as never,
+    )) as { ok: boolean; skillSlug: string };
+
+    expect(result).toEqual({ ok: true, skillSlug: "demo" });
+    expect(patch).toHaveBeenCalledWith(
+      "skills:1",
+      expect.objectContaining({
+        ownerUserId: "users:2",
+        ownerPublisherId: "publishers:alice",
+      }),
+    );
+    expect(patch).toHaveBeenCalledWith(
+      "skillSlugAliases:1",
+      expect.objectContaining({
+        ownerUserId: "users:2",
+        ownerPublisherId: "publishers:alice",
+      }),
+    );
+    expect(patch).toHaveBeenCalledWith(
+      "skillSlugAliases:2",
+      expect.objectContaining({
+        ownerUserId: "users:2",
+        ownerPublisherId: "publishers:alice",
+      }),
+    );
+    expect(patch).toHaveBeenCalledWith(
+      "skillOwnershipTransfers:1",
+      expect.objectContaining({ status: "accepted" }),
+    );
+  });
+
   it("acceptTransferInternal cancels stale transfer when ownership changed", async () => {
     const patch = vi.fn(async () => {});
 

--- a/convex/skillTransfers.ts
+++ b/convex/skillTransfers.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import type { Doc, Id } from "./_generated/dataModel";
 import { internalMutation, internalQuery } from "./functions";
+import { ensurePersonalPublisherForUser } from "./lib/publishers";
 const TRANSFER_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
 
 type TransferDoc = Doc<"skillOwnershipTransfers">;
@@ -157,7 +158,7 @@ export const acceptTransferInternal = internalMutation({
   },
   handler: async (ctx, args) => {
     const now = Date.now();
-    await requireActiveUserById(ctx, args.actorUserId);
+    const newOwner = await requireActiveUserById(ctx, args.actorUserId);
 
     const transfer = await validatePendingTransferForActor(ctx, {
       transferId: args.transferId,
@@ -173,10 +174,27 @@ export const acceptTransferInternal = internalMutation({
       throw new Error("Transfer is no longer valid");
     }
 
+    const newPublisher = await ensurePersonalPublisherForUser(ctx, newOwner);
+    if (!newPublisher) throw new Error("Failed to resolve publisher for new owner");
+
     await ctx.db.patch(skill._id, {
       ownerUserId: args.actorUserId,
+      ownerPublisherId: newPublisher._id,
       updatedAt: now,
     });
+
+    const aliases = await ctx.db
+      .query("skillSlugAliases")
+      .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
+      .collect();
+    for (const alias of aliases) {
+      await ctx.db.patch(alias._id, {
+        ownerUserId: args.actorUserId,
+        ownerPublisherId: newPublisher._id,
+        updatedAt: now,
+      });
+    }
+
     await ctx.db.patch(transfer._id, { status: "accepted", respondedAt: now });
 
     await ctx.db.insert("auditLogs", {


### PR DESCRIPTION
## Summary
- update accepted skill transfers to move both `ownerUserId` and `ownerPublisherId`
- repoint `skillSlugAliases` rows for the transferred skill to the recipient publisher
- add a regression test covering the successful accept-transfer path

## Why
After the publisher migration, canonical ownership resolution prefers `ownerPublisherId`. The transfer accept path only updated `ownerUserId`, which left some transferred skills resolving under the old owner even after acceptance.

Fixes #1303.
References #1304.

## Verification
- `bunx vitest run convex/skillTransfers.test.ts packages/clawdhub/src/cli/commands/transfer.test.ts`
- `bunx vitest run convex/httpApiV1.handlers.test.ts -t transfer`
- `bunx tsc -p tsconfig.json --noEmit`
- `bunx oxlint --type-aware --tsconfig ./tsconfig.oxlint.json convex/skillTransfers.ts convex/skillTransfers.test.ts`