### PR TITLE
feat: add hover effect to skill and plugin cards

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1642,6 +1642,29 @@ code {
 .skill-card {
   min-height: 176px;
   box-shadow: 0 1px 3px rgba(42, 31, 25, 0.08);
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    border-color 0.2s ease,
+    background 0.2s ease;
+}
+
+.skill-card:hover,
+.skill-card:focus-within {
+  border-color: var(--border-ui-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(29, 26, 23, 0.12);
+}
+
+.skill-card:focus-visible {
+  outline: 3px solid rgba(255, 107, 74, 0.3);
+  outline-offset: 3px;
+}
+
+[data-theme="dark"] .skill-card:hover,
+[data-theme="dark"] .skill-card:focus-within {
+  border-color: var(--border-ui-hover);
+  box-shadow: 0 14px 28px rgba(7, 15, 20, 0.36);
 }
 
 .skill-card-tags {


### PR DESCRIPTION
## Summary

This PR adds button-style hover feedback to all cards that use the shared `.skill-card` styling, including skill and plugin cards across the site.

![chrome-capture-2026-03-28](https://github.com/user-attachments/assets/c6b6130c-5cb3-4a17-8d37-d350873afca9)


## Why

Interactive buttons on ClawHub already provide clear hover feedback, but skill/plugin cards remained visually static. That made the UI feel a bit inconsistent and reduced the sense that these cards are interactive.

This change makes card interactions feel more intentional and aligned with the rest of the product.

## What Changed

### Before

- Skill and plugin cards did not visibly change on hover
- Buttons had stronger interactive feedback than cards
- Card interactions felt less consistent across pages

### After

- Skill and plugin cards now respond on hover/focus with:
  - border highlight
  - slight upward movement
  - stronger shadow
- Card interactions now feel more consistent with existing button hover behavior

## Verification

- `bun run lint`
- `bun run build`
- Verified in browser that card hover now shows visible feedback consistent with existing button interactions
