### PR TITLE
fix: remove double JSON.stringify in transfer request

### DIFF
--- a/packages/clawdhub/src/cli/commands/transfer.test.ts
+++ b/packages/clawdhub/src/cli/commands/transfer.test.ts
@@ -82,8 +82,8 @@ describe("transfer commands", () => {
       }),
       expect.anything(),
     );
-    const requestArgs = mockApiRequest.mock.calls[0]?.[1] as { body?: string };
-    expect(requestArgs.body).toContain('"toUserHandle":"alice"');
+    const requestArgs = mockApiRequest.mock.calls[0]?.[1] as { body?: unknown };
+    expect(requestArgs.body).toEqual({ toUserHandle: "alice", message: "Please take over" });
   });
 
   it("list calls incoming transfers endpoint", async () => {

--- a/packages/clawdhub/src/cli/commands/transfer.ts
+++ b/packages/clawdhub/src/cli/commands/transfer.ts
@@ -88,10 +88,10 @@ export async function cmdTransferRequest(
         method: "POST",
         path: `${ApiRoutes.skills}/${encodeURIComponent(slug)}/transfer`,
         token,
-        body: JSON.stringify({
+        body: {
           toUserHandle: toHandle,
           message: options.message,
-        }),
+        },
       },
       ApiV1TransferRequestResponseSchema,
     );


### PR DESCRIPTION
## Summary

`clawhub transfer request <slug> <handle>` always fails with `toUserHandle required` because the request body is double-stringified.

In `transfer.ts`, `cmdTransferRequest` wraps the body in `JSON.stringify()` before passing it to `apiRequest`. But `apiRequest` in `http.ts` also calls `JSON.stringify(args.body)` for POST requests (line 74). The server receives a JSON string containing a string instead of an object, so it can't extract `toUserHandle`.

## Fix

Remove the redundant `JSON.stringify()` in `transfer.ts` so the body is passed as a plain object, matching the contract of `apiRequest` (and matching how other POST callers like `apiRequestForm` work).

## Reproduction

```bash
clawhub transfer request my-skill @someuser --yes
# Error: toUserHandle required
```

## Test plan

- [x] Updated existing test to assert on the raw object instead of a pre-stringified string
- [ ] CI passes