### PR TITLE
fix: point plugin metadata help link to OpenClaw docs

### DIFF
--- a/src/__tests__/packages-publish-route.test.tsx
+++ b/src/__tests__/packages-publish-route.test.tsx
@@ -276,9 +276,12 @@ describe("plugins publish route", () => {
 
     expect(screen.getByText(/openclaw\.compat\.pluginApi/i)).toBeTruthy();
     expect(screen.getByText(/openclaw\.build\.openclawVersion/i)).toBeTruthy();
-    expect(screen.getByRole("link", { name: /Plugin Setup and Config/i }).getAttribute("href")).toBe(
+    const docsLink = screen.getByRole("link", { name: /Plugin Setup and Config/i });
+    expect(docsLink.getAttribute("href")).toBe(
       "https://docs.openclaw.ai/plugins/sdk-setup#package-metadata",
     );
+    expect(docsLink.getAttribute("target")).toBe("_blank");
+    expect(docsLink.getAttribute("rel")).toBe("noopener noreferrer");
     expect(screen.getByRole("button", { name: "Publish" }).getAttribute("disabled")).not.toBeNull();
     expect(publishRelease).not.toHaveBeenCalled();
   });

--- a/src/__tests__/packages-publish-route.test.tsx
+++ b/src/__tests__/packages-publish-route.test.tsx
@@ -276,6 +276,9 @@ describe("plugins publish route", () => {
 
     expect(screen.getByText(/openclaw\.compat\.pluginApi/i)).toBeTruthy();
     expect(screen.getByText(/openclaw\.build\.openclawVersion/i)).toBeTruthy();
+    expect(screen.getByRole("link", { name: /Plugin Setup and Config/i }).getAttribute("href")).toBe(
+      "https://docs.openclaw.ai/plugins/sdk-setup#package-metadata",
+    );
     expect(screen.getByRole("button", { name: "Publish" }).getAttribute("disabled")).not.toBeNull();
     expect(publishRelease).not.toHaveBeenCalled();
   });

--- a/src/components/PackageSourceChooser.tsx
+++ b/src/components/PackageSourceChooser.tsx
@@ -8,6 +8,9 @@ import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import { Card } from "./ui/card";
 
+const OPENCLAW_PLUGIN_PACKAGE_METADATA_DOCS_URL =
+  'https://docs.openclaw.ai/plugins/sdk-setup#package-metadata';
+
 export function PackageSourceChooser(props: {
   files: File[];
   totalBytes: number;
@@ -155,7 +158,7 @@ export function PackageSourceChooser(props: {
         <Badge variant="accent">
           Missing required OpenClaw package metadata: {props.codePluginFieldIssues.join(", ")}. Add
           these fields to <code>package.json</code> before publishing. See{" "}
-          <a href="/plugins/sdk-setup#package-metadata" className="underline">
+          <a href={OPENCLAW_PLUGIN_PACKAGE_METADATA_DOCS_URL} className="underline">
             Plugin Setup and Config
           </a>
           .

--- a/src/components/PackageSourceChooser.tsx
+++ b/src/components/PackageSourceChooser.tsx
@@ -158,7 +158,12 @@ export function PackageSourceChooser(props: {
         <Badge variant="accent">
           Missing required OpenClaw package metadata: {props.codePluginFieldIssues.join(", ")}. Add
           these fields to <code>package.json</code> before publishing. See{" "}
-          <a href={OPENCLAW_PLUGIN_PACKAGE_METADATA_DOCS_URL} className="underline">
+          <a
+            href={OPENCLAW_PLUGIN_PACKAGE_METADATA_DOCS_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
             Plugin Setup and Config
           </a>
           .


### PR DESCRIPTION
## Summary

- point the plugin package metadata help link to the public OpenClaw docs page
- add a route test assertion so the help link does not regress back to the broken in-app path

## Why

The publish UI currently tells users to see `/plugins/sdk-setup#package-metadata`, but ClawHub does not expose that route. The result is a broken/empty help page right when users hit required metadata errors for:

- `openclaw.compat.pluginApi`
- `openclaw.build.openclawVersion`

This PR keeps the existing validation behavior and only fixes the user guidance by linking directly to:

- `https://docs.openclaw.ai/plugins/sdk-setup#package-metadata`

## Testing

- Not run in this environment: `bun` is not installed, so I could not execute the repo's Vitest / TypeScript checks locally.
