### PR TITLE
feat: list manually installed skills in `clawhub list`

### DIFF
--- a/packages/clawdhub/src/cli.ts
+++ b/packages/clawdhub/src/cli.ts
@@ -230,7 +230,7 @@ program
 
 program
   .command("list")
-  .description("List installed skills (from lockfile)")
+  .description("List installed skills (tracked and manually installed)")
   .action(async () => {
     const opts = await resolveGlobalOpts();
     await cmdList(opts);

--- a/packages/clawdhub/src/cli/commands/skills.ts
+++ b/packages/clawdhub/src/cli/commands/skills.ts
@@ -13,6 +13,7 @@ import {
 import {
   extractZipToDir,
   hashSkillFiles,
+  listManualSkills,
   listTextFiles,
   readLockfile,
   readSkillOrigin,
@@ -317,12 +318,30 @@ export async function cmdUpdate(
 export async function cmdList(opts: GlobalOpts) {
   const lock = await readLockfile(opts.workdir);
   const entries = Object.entries(lock.skills);
-  if (entries.length === 0) {
+
+  // Get manually installed skills (those in skills dir but not in lockfile)
+  const lockedSlugs = new Set(Object.keys(lock.skills));
+  const manualSkills = await listManualSkills(opts.dir, lockedSlugs);
+
+  if (entries.length === 0 && manualSkills.length === 0) {
     console.log("No installed skills.");
     return;
   }
+
+  // Display tracked skills (from lockfile)
   for (const [slug, entry] of entries) {
     console.log(`${slug}  ${entry.version ?? "latest"}`);
+  }
+
+  // Display manually installed skills
+  if (manualSkills.length > 0) {
+    if (entries.length > 0) {
+      console.log(); // Empty line separator
+    }
+    console.log("Manually installed (not tracked by clawhub):");
+    for (const slug of manualSkills) {
+      console.log(`  ${slug}`);
+    }
   }
 }
 

--- a/packages/clawdhub/src/skills.test.ts
+++ b/packages/clawdhub/src/skills.test.ts
@@ -10,6 +10,7 @@ import {
   extractZipToDir,
   hashSkillFiles,
   hashSkillZip,
+  listManualSkills,
   listTextFiles,
   readLockfile,
   readSkillOrigin,
@@ -190,5 +191,124 @@ describe("skills", () => {
     };
     await writeSkillOrigin(workdir, origin);
     expect(await readSkillOrigin(workdir)).toEqual(origin);
+  });
+
+  describe("listManualSkills", () => {
+    it("lists manual skills not in lockfile", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "clawhub-manual-"));
+      const skillDir = join(dir, "my-skill");
+      await mkdir(skillDir);
+      await writeFile(join(skillDir, "SKILL.md"), "# My Skill", "utf8");
+
+      const result = await listManualSkills(dir, new Set());
+      expect(result).toEqual(["my-skill"]);
+    });
+
+    it("excludes skills that are in the lockfile", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "clawhub-manual-locked-"));
+      const skillDir = join(dir, "tracked-skill");
+      await mkdir(skillDir);
+      await writeFile(join(skillDir, "SKILL.md"), "# Tracked", "utf8");
+
+      const result = await listManualSkills(dir, new Set(["tracked-skill"]));
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array when skills dir does not exist", async () => {
+      const result = await listManualSkills("/nonexistent/path", new Set());
+      expect(result).toEqual([]);
+    });
+
+    it("recognizes skills with .clawhub/origin.json", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "clawhub-origin-skill-"));
+      const skillDir = join(dir, "origin-skill");
+      await mkdir(skillDir);
+      await mkdir(join(skillDir, ".clawhub"));
+      await writeFile(
+        join(skillDir, ".clawhub", "origin.json"),
+        JSON.stringify({
+          version: 1,
+          registry: "https://example.com",
+          slug: "origin-skill",
+          installedVersion: "1.0.0",
+          installedAt: Date.now(),
+        }),
+        "utf8",
+      );
+
+      const result = await listManualSkills(dir, new Set());
+      expect(result).toEqual(["origin-skill"]);
+    });
+
+    it("recognizes skills with legacy .clawdhub/origin.json", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "clawhub-legacy-skill-"));
+      const skillDir = join(dir, "legacy-skill");
+      await mkdir(skillDir);
+      await mkdir(join(skillDir, ".clawdhub"));
+      await writeFile(
+        join(skillDir, ".clawdhub", "origin.json"),
+        JSON.stringify({
+          version: 1,
+          registry: "https://example.com",
+          slug: "legacy-skill",
+          installedVersion: "1.0.0",
+          installedAt: Date.now(),
+        }),
+        "utf8",
+      );
+
+      const result = await listManualSkills(dir, new Set());
+      expect(result).toEqual(["legacy-skill"]);
+    });
+
+    it("skips directories without skill metadata", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "clawhub-no-metadata-"));
+      const skillDir = join(dir, "not-a-skill");
+      await mkdir(skillDir);
+      await writeFile(join(skillDir, "readme.txt"), "just a folder", "utf8");
+
+      const result = await listManualSkills(dir, new Set());
+      expect(result).toEqual([]);
+    });
+
+    it("skips dotfile directories", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "clawhub-dotfiles-"));
+      const visibleSkillDir = join(dir, "visible-skill");
+      await mkdir(visibleSkillDir);
+      await writeFile(join(visibleSkillDir, "SKILL.md"), "# Visible", "utf8");
+
+      const hiddenSkillDir = join(dir, ".hidden-skill");
+      await mkdir(hiddenSkillDir);
+      await writeFile(join(hiddenSkillDir, "SKILL.md"), "# Hidden", "utf8");
+
+      const result = await listManualSkills(dir, new Set());
+      expect(result).toEqual(["visible-skill"]);
+    });
+
+    it("returns sorted list of skills", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "clawhub-sort-"));
+      await mkdir(join(dir, "z-skill"));
+      await writeFile(join(dir, "z-skill", "SKILL.md"), "# Z", "utf8");
+      await mkdir(join(dir, "a-skill"));
+      await writeFile(join(dir, "a-skill", "SKILL.md"), "# A", "utf8");
+      await mkdir(join(dir, "m-skill"));
+      await writeFile(join(dir, "m-skill", "SKILL.md"), "# M", "utf8");
+
+      const result = await listManualSkills(dir, new Set());
+      expect(result).toEqual(["a-skill", "m-skill", "z-skill"]);
+    });
+
+    it("handles mixed tracked and manual skills correctly", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "clawhub-mixed-"));
+      await mkdir(join(dir, "tracked-skill"));
+      await writeFile(join(dir, "tracked-skill", "SKILL.md"), "# Tracked", "utf8");
+      await mkdir(join(dir, "manual-skill"));
+      await writeFile(join(dir, "manual-skill", "SKILL.md"), "# Manual", "utf8");
+      await mkdir(join(dir, "another-manual"));
+      await writeFile(join(dir, "another-manual", "SKILL.md"), "# Another", "utf8");
+
+      const result = await listManualSkills(dir, new Set(["tracked-skill"]));
+      expect(result).toEqual(["another-manual", "manual-skill"]);
+    });
   });
 });

--- a/packages/clawdhub/src/skills.ts
+++ b/packages/clawdhub/src/skills.ts
@@ -192,3 +192,59 @@ async function addIgnoreFile(ig: ReturnType<typeof ignore>, path: string) {
     // optional
   }
 }
+
+/**
+ * List manually installed skills (those in skills dir but not in lockfile).
+ * Returns an array of skill directory names.
+ */
+export async function listManualSkills(
+  skillsDir: string,
+  lockedSlugs: Set<string>,
+): Promise<string[]> {
+  const manual: string[] = [];
+  try {
+    const entries = await readdir(skillsDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name.startsWith(".")) continue;
+      // Skip skills that are in the lockfile (already tracked by clawhub)
+      if (lockedSlugs.has(entry.name)) continue;
+      // Check if this is a valid skill directory (has SKILL.md or .clawhub/origin.json)
+      const skillPath = join(skillsDir, entry.name);
+      const hasSkillFile = await hasSkillMetadata(skillPath);
+      if (hasSkillFile) {
+        manual.push(entry.name);
+      }
+    }
+  } catch {
+    // Skills directory might not exist yet
+  }
+  return manual.sort();
+}
+
+/**
+ * Check if a directory looks like a skill by checking for common indicators.
+ */
+async function hasSkillMetadata(skillDir: string): Promise<boolean> {
+  // Check for SKILL.md
+  try {
+    await readFile(join(skillDir, "SKILL.md"), "utf8");
+    return true;
+  } catch {
+    // Check for .clawhub/origin.json or .clawdhub/origin.json
+    const originPath = join(skillDir, DOT_DIR, "origin.json");
+    try {
+      await readFile(originPath, "utf8");
+      return true;
+    } catch {
+      // Check legacy path
+      const legacyOriginPath = join(skillDir, LEGACY_DOT_DIR, "origin.json");
+      try {
+        await readFile(legacyOriginPath, "utf8");
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+}

--- a/packages/clawdhub/src/skills.ts
+++ b/packages/clawdhub/src/skills.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { access, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, relative, resolve, sep } from "node:path";
 import { unzipSync } from "fflate";
 import ignore from "ignore";
@@ -226,25 +226,24 @@ export async function listManualSkills(
  * Check if a directory looks like a skill by checking for common indicators.
  */
 async function hasSkillMetadata(skillDir: string): Promise<boolean> {
-  // Check for SKILL.md
-  try {
-    await readFile(join(skillDir, "SKILL.md"), "utf8");
-    return true;
-  } catch {
-    // Check for .clawhub/origin.json or .clawdhub/origin.json
-    const originPath = join(skillDir, DOT_DIR, "origin.json");
+  const candidates = [
+    join(skillDir, "SKILL.md"),
+    join(skillDir, DOT_DIR, "origin.json"),
+    join(skillDir, LEGACY_DOT_DIR, "origin.json"),
+  ];
+  for (const p of candidates) {
     try {
-      await readFile(originPath, "utf8");
+      await access(p);
       return true;
-    } catch {
-      // Check legacy path
-      const legacyOriginPath = join(skillDir, LEGACY_DOT_DIR, "origin.json");
-      try {
-        await readFile(legacyOriginPath, "utf8");
-        return true;
-      } catch {
-        return false;
+    } catch (err) {
+      // Re-throw unexpected errors (only ENOENT and ENOTDIR are expected)
+      if (
+        (err as NodeJS.ErrnoException).code !== "ENOENT" &&
+        (err as NodeJS.ErrnoException).code !== "ENOTDIR"
+      ) {
+        throw err;
       }
     }
   }
+  return false;
 }


### PR DESCRIPTION
## 📋 Problem Summary

`clawhub list` only displays skills that were installed via `clawhub install` (i.e., skills tracked in the lockfile). Skills that were manually installed by copying them directly to `~/.claude/skills/` are not shown, even though they are valid and functional skills.

### Example scenario:
```bash
$ clawhub list
senior-data-engineer  2.1.1
spark-engineer  1.0.0

# But I also have these manually installed skills that don't show:
# - excel-xlsx
# - pdf-smart-tool-cn  
# - powerpoint-pptx
# - word-docx
```

## ✨ Solution

Add functionality to detect and display manually installed skills alongside tracked skills.

### Changes made:

1. **`packages/clawdhub/src/skills.ts`**
   - Added `listManualSkills()` function to scan skills directory for untracked skills
   - Added `hasSkillMetadata()` helper to identify valid skill directories

2. **`packages/clawdhub/src/cli/commands/skills.ts`**
   - Modified `cmdList()` to call `listManualSkills()`
   - Display manual skills in a separate section with clear labeling

### New output format:
```
$ clawhub list
senior-data-engineer  2.1.1
spark-engineer  1.0.0

Manually installed (not tracked by clawhub):
  excel-xlsx
  pdf-smart-tool-cn
  powerpoint-pptx
  word-docx
```

## 🔍 Implementation Details

A skill is considered "manually installed" if:
- It exists in the skills directory
- It is NOT in the lockfile (not tracked by clawhub)
- It has skill metadata (either `SKILL.md` or `.clawhub/origin.json`)

This approach:
- ✅ Preserves backward compatibility
- ✅ Clearly distinguishes between tracked and manual skills
- ✅ Helps users understand their skill inventory
- ✅ No changes to existing workflows

## 🧪 Testing

Tested manually with mixed installation methods:
- Skills installed via `clawhub install` show with version
- Manually copied skills show in separate section
- Empty skills directory shows "No installed skills."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>