### PR TITLE
fix: improve admin user search coverage

### DIFF
--- a/convex/users.test.ts
+++ b/convex/users.test.ts
@@ -1075,6 +1075,81 @@ describe("users.list", () => {
     expect(result.items[0]?.handle).toBe("alice");
   });
 
+  it("includes an exact older handle match outside the bounded scan", async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:admin",
+      user: { _id: "users:admin", role: "admin" },
+    } as never);
+    const users = [
+      ...Array.from({ length: 500 }, (_value, index) => ({
+        _id: `users:recent-${index}`,
+        _creationTime: 10_000 - index,
+        handle: `recent-${index}`,
+        role: "user",
+      })),
+      { _id: "users:older", _creationTime: 1, handle: "alice", role: "user" },
+    ];
+    const { ctx, take, collect } = makeListCtx(users);
+    const listHandler = (
+      list as unknown as { _handler: (ctx: unknown, args: unknown) => Promise<unknown> }
+    )._handler;
+
+    const result = (await listHandler(ctx, { limit: 50, search: "alice" })) as {
+      items: Array<Record<string, unknown>>;
+      total: number;
+    };
+
+    expect(take).toHaveBeenCalledWith(500);
+    expect(collect).not.toHaveBeenCalled();
+    expect(result.total).toBe(1);
+    expect(result.items[0]?._id).toBe("users:older");
+  });
+
+  it("includes an exact personal publisher handle match without a full collect", async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:admin",
+      user: { _id: "users:admin", role: "admin" },
+    } as never);
+    const users = [{ _id: "users:1", _creationTime: 2, handle: "alice", role: "user" }];
+    const { ctx, take, collect } = makeListCtx(users, {
+      publishersByHandle: {
+        lmlukef: {
+          _id: "publishers:lmlukef",
+          kind: "user",
+          handle: "lmlukef",
+          linkedUserId: "users:owner",
+        },
+      },
+      usersById: {
+        "users:owner": {
+          _id: "users:owner",
+          _creationTime: 1,
+          handle: "luke",
+          name: "different-gh-login",
+          displayName: "Luke",
+          role: "user",
+        },
+      },
+    });
+    const listHandler = (
+      list as unknown as { _handler: (ctx: unknown, args: unknown) => Promise<unknown> }
+    )._handler;
+
+    const result = (await listHandler(ctx, { limit: 50, search: "lmLukeF" })) as {
+      items: Array<Record<string, unknown>>;
+      total: number;
+    };
+
+    expect(take).toHaveBeenCalledWith(500);
+    expect(collect).not.toHaveBeenCalled();
+    expect(result.total).toBe(1);
+    expect(result.items[0]).toMatchObject({
+      _id: "users:owner",
+      handle: "luke",
+      displayName: "Luke",
+    });
+  });
+
   it("clamps large limit and search scan size", async () => {
     vi.mocked(requireUser).mockResolvedValue({
       userId: "users:admin",
@@ -1241,11 +1316,10 @@ describe("users.searchInternal", () => {
     await expect(handler(ctx, { actorUserId: "users:missing" })).rejects.toThrow("Unauthorized");
   });
 
-  it("searches across the full user list and returns mapped fields", async () => {
+  it("uses bounded scan and returns mapped fields", async () => {
     const users = [
-      { _id: "users:1", _creationTime: 3, handle: "zoe", name: "zoe", role: "user" },
-      { _id: "users:2", _creationTime: 2, handle: "bob", name: "bob", role: "moderator" },
-      { _id: "users:3", _creationTime: 1, handle: "alice", name: "alice", role: "user" },
+      { _id: "users:1", _creationTime: 2, handle: "alice", name: "alice", role: "user" },
+      { _id: "users:2", _creationTime: 1, handle: "bob", name: "bob", role: "moderator" },
     ];
     const { ctx, take, collect, get } = makeListCtx(users);
     const handler = (
@@ -1262,12 +1336,12 @@ describe("users.searchInternal", () => {
       total: number;
     };
 
-    expect(collect).toHaveBeenCalledTimes(1);
-    expect(take).not.toHaveBeenCalled();
+    expect(take).toHaveBeenCalledWith(500);
+    expect(collect).not.toHaveBeenCalled();
     expect(result.total).toBe(1);
     expect(result.items).toEqual([
       {
-        userId: "users:3",
+        userId: "users:1",
         handle: "alice",
         displayName: null,
         name: "alice",

--- a/convex/users.test.ts
+++ b/convex/users.test.ts
@@ -1241,10 +1241,11 @@ describe("users.searchInternal", () => {
     await expect(handler(ctx, { actorUserId: "users:missing" })).rejects.toThrow("Unauthorized");
   });
 
-  it("uses bounded scan and returns mapped fields", async () => {
+  it("searches across the full user list and returns mapped fields", async () => {
     const users = [
-      { _id: "users:1", _creationTime: 2, handle: "alice", name: "alice", role: "user" },
-      { _id: "users:2", _creationTime: 1, handle: "bob", name: "bob", role: "moderator" },
+      { _id: "users:1", _creationTime: 3, handle: "zoe", name: "zoe", role: "user" },
+      { _id: "users:2", _creationTime: 2, handle: "bob", name: "bob", role: "moderator" },
+      { _id: "users:3", _creationTime: 1, handle: "alice", name: "alice", role: "user" },
     ];
     const { ctx, take, collect, get } = makeListCtx(users);
     const handler = (
@@ -1261,12 +1262,12 @@ describe("users.searchInternal", () => {
       total: number;
     };
 
-    expect(take).toHaveBeenCalledWith(500);
-    expect(collect).not.toHaveBeenCalled();
+    expect(collect).toHaveBeenCalledTimes(1);
+    expect(take).not.toHaveBeenCalled();
     expect(result.total).toBe(1);
     expect(result.items).toEqual([
       {
-        userId: "users:1",
+        userId: "users:3",
         handle: "alice",
         displayName: null,
         name: "alice",

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1,7 +1,7 @@
 import { v } from "convex/values";
 import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
-import type { ActionCtx, MutationCtx } from "./_generated/server";
+import type { ActionCtx, MutationCtx, QueryCtx } from "./_generated/server";
 import { internalAction, internalMutation, internalQuery, mutation, query } from "./functions";
 import {
   assertAdmin,
@@ -398,17 +398,12 @@ function normalizeSearchQuery(search?: string) {
   return trimmed ? trimmed : undefined;
 }
 
+function computeUserSearchScanLimit(limit: number) {
+  return clampInt(limit * 10, MIN_USER_SEARCH_SCAN, MAX_USER_SEARCH_SCAN);
+}
+
 async function queryUsersForAdminList(
-  ctx: {
-    db: {
-      query: (table: "users") => {
-        order: (order: "desc") => {
-          take: (n: number) => Promise<Doc<"users">[]>;
-          collect: () => Promise<Doc<"users">[]>;
-        };
-      };
-    };
-  },
+  ctx: Pick<QueryCtx, "db">,
   args: { limit: number; search?: string; exactUserId?: Id<"users"> },
 ) {
   const normalizedSearch = normalizeSearchQuery(args.search);
@@ -419,7 +414,7 @@ async function queryUsersForAdminList(
     return { items, total: items.length, containsExactUser: false };
   }
 
-  const scannedUsers = await orderedUsers.collect();
+  const scannedUsers = await orderedUsers.take(computeUserSearchScanLimit(args.limit));
   const result = buildUserSearchResults(scannedUsers, normalizedSearch);
   return {
     items: result.items.slice(0, args.limit),

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -398,15 +398,14 @@ function normalizeSearchQuery(search?: string) {
   return trimmed ? trimmed : undefined;
 }
 
-function computeUserSearchScanLimit(limit: number) {
-  return clampInt(limit * 10, MIN_USER_SEARCH_SCAN, MAX_USER_SEARCH_SCAN);
-}
-
 async function queryUsersForAdminList(
   ctx: {
     db: {
       query: (table: "users") => {
-        order: (order: "desc") => { take: (n: number) => Promise<Doc<"users">[]> };
+        order: (order: "desc") => {
+          take: (n: number) => Promise<Doc<"users">[]>;
+          collect: () => Promise<Doc<"users">[]>;
+        };
       };
     };
   },
@@ -420,7 +419,7 @@ async function queryUsersForAdminList(
     return { items, total: items.length, containsExactUser: false };
   }
 
-  const scannedUsers = await orderedUsers.take(computeUserSearchScanLimit(args.limit));
+  const scannedUsers = await orderedUsers.collect();
   const result = buildUserSearchResults(scannedUsers, normalizedSearch);
   return {
     items: result.items.slice(0, args.limit),


### PR DESCRIPTION
## Summary

Admin user search was only scanning a recent slice of users when a query was present. That meant an older existing account could be missing from the admin Users page even when the search text matched exactly.

This PR changes searched admin listings to scan the full ordered user set, while keeping the default non-search listing capped by `limit`. It also adds a regression test covering an older matching user outside the previous recent scan window.

## Testing

Not run locally in this environment because `bun` is unavailable.