### PR TITLE
feat(dashboard): add skill pagination

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -421,6 +421,12 @@ const skills = defineTable({
   .index("by_slug", ["slug"])
   .index("by_owner", ["ownerUserId"])
   .index("by_owner_publisher", ["ownerPublisherId"])
+  .index("by_owner_active_updated", ["ownerUserId", "softDeletedAt", "updatedAt"])
+  .index("by_owner_publisher_active_updated", [
+    "ownerPublisherId",
+    "softDeletedAt",
+    "updatedAt",
+  ])
   .index("by_updated", ["updatedAt"])
   .index("by_stats_downloads", ["statsDownloads", "updatedAt"])
   .index("by_stats_stars", ["statsStars", "updatedAt"])

--- a/convex/skills.dashboard.test.ts
+++ b/convex/skills.dashboard.test.ts
@@ -1,0 +1,198 @@
+import { getAuthUserId } from "@convex-dev/auth/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@convex-dev/auth/server", () => ({
+  getAuthUserId: vi.fn(),
+  authTables: {},
+}));
+
+import { listDashboardPaginated } from "./skills";
+
+type WrappedHandler<TArgs, TResult = unknown> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
+};
+
+const handler = (
+  listDashboardPaginated as unknown as WrappedHandler<
+    {
+      ownerUserId?: string;
+      ownerPublisherId?: string;
+      paginationOpts: { cursor: string | null; numItems: number };
+    },
+    { page: Array<{ slug: string }>; isDone: boolean; continueCursor: string }
+  >
+)._handler;
+
+function makeSkill(slug: string, overrides: Record<string, unknown> = {}) {
+  return {
+    _id: `skills:${slug}`,
+    _creationTime: 1,
+    slug,
+    displayName: slug.charAt(0).toUpperCase() + slug.slice(1),
+    summary: `${slug} integration.`,
+    ownerUserId: "users:owner",
+    ownerPublisherId: undefined,
+    canonicalSkillId: undefined,
+    forkOf: undefined,
+    latestVersionId: undefined,
+    tags: {},
+    capabilityTags: [],
+    badges: undefined,
+    stats: {
+      downloads: 0,
+      installsCurrent: 0,
+      installsAllTime: 0,
+      stars: 0,
+      versions: 1,
+      comments: 0,
+    },
+    statsDownloads: 0,
+    statsInstallsCurrent: 0,
+    statsInstallsAllTime: 0,
+    statsStars: 0,
+    createdAt: 1,
+    updatedAt: 2,
+    softDeletedAt: undefined,
+    moderationStatus: "active",
+    moderationFlags: [],
+    moderationReason: undefined,
+    isSuspicious: false,
+    ...overrides,
+  };
+}
+
+function makeCtx(indexPages: Record<string, ReturnType<typeof makeSkill>[]>) {
+  const indexCalls: string[] = [];
+  const ctx = {
+    db: {
+      get: vi.fn(async (id: string) => {
+        if (id === "users:owner") {
+          return { _id: "users:owner", _creationTime: 1, handle: "owner", displayName: "Owner" };
+        }
+        if (id === "publishers:self") {
+          return {
+            _id: "publishers:self",
+            _creationTime: 1,
+            kind: "user",
+            handle: "owner",
+            displayName: "Owner",
+            linkedUserId: "users:owner",
+          };
+        }
+        if (id === "publishers:org") {
+          return {
+            _id: "publishers:org",
+            _creationTime: 1,
+            kind: "org",
+            handle: "team",
+            displayName: "Team",
+          };
+        }
+        return null;
+      }),
+      query: vi.fn((table: string) => {
+        if (table === "publisherMembers") {
+          return {
+            withIndex: vi.fn(() => ({
+              unique: vi.fn().mockResolvedValue(null),
+            })),
+          };
+        }
+        if (table === "skillBadges") {
+          return {
+            withIndex: vi.fn(() => ({
+              take: vi.fn().mockResolvedValue([]),
+            })),
+          };
+        }
+        if (table === "skills") {
+          return {
+            withIndex: vi.fn((indexName: string) => {
+              indexCalls.push(indexName);
+              return {
+                order: vi.fn(() => ({
+                  paginate: vi.fn().mockResolvedValue({
+                    page: indexPages[indexName] ?? [],
+                    isDone: true,
+                    continueCursor: "",
+                  }),
+                })),
+              };
+            }),
+          };
+        }
+        throw new Error(`unexpected table ${table}`);
+      }),
+    },
+  };
+  return { ctx, indexCalls };
+}
+
+const paginationOpts = { cursor: null, numItems: 50 };
+
+describe("skills.listDashboardPaginated", () => {
+  it("paginates user dashboard skills through an active owner index", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:owner" as never);
+    const { ctx, indexCalls } = makeCtx({
+      by_owner_active_updated: [makeSkill("slack")],
+    });
+
+    const result = await handler(ctx as never, {
+      ownerUserId: "users:owner",
+      paginationOpts,
+    } as never);
+
+    expect(indexCalls).toContain("by_owner_active_updated");
+    expect(result.page).toEqual([expect.objectContaining({ slug: "slack" })]);
+  });
+
+  it("includes linked-user legacy skills when paginating a personal publisher", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:owner" as never);
+    const { ctx, indexCalls } = makeCtx({
+      by_owner_active_updated: [makeSkill("legacy-skill")],
+    });
+
+    const result = await handler(ctx as never, {
+      ownerPublisherId: "publishers:self",
+      paginationOpts,
+    } as never);
+
+    expect(indexCalls).toContain("by_owner_active_updated");
+    expect(result.page).toEqual([expect.objectContaining({ slug: "legacy-skill" })]);
+  });
+
+  it("keeps non-owner personal publisher reads scoped to publisher-owned skills", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:other" as never);
+    const { ctx, indexCalls } = makeCtx({
+      by_owner_publisher_active_updated: [
+        makeSkill("published-skill", { ownerPublisherId: "publishers:self" }),
+      ],
+    });
+
+    const result = await handler(ctx as never, {
+      ownerPublisherId: "publishers:self",
+      paginationOpts,
+    } as never);
+
+    expect(indexCalls).toContain("by_owner_publisher_active_updated");
+    expect(indexCalls).not.toContain("by_owner_active_updated");
+    expect(result.page).toEqual([expect.objectContaining({ slug: "published-skill" })]);
+  });
+
+  it("paginates org publisher skills through an active publisher index", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:owner" as never);
+    const { ctx, indexCalls } = makeCtx({
+      by_owner_publisher_active_updated: [
+        makeSkill("team-skill", { ownerPublisherId: "publishers:org" }),
+      ],
+    });
+
+    const result = await handler(ctx as never, {
+      ownerPublisherId: "publishers:org",
+      paginationOpts,
+    } as never);
+
+    expect(indexCalls).toContain("by_owner_publisher_active_updated");
+    expect(result.page).toEqual([expect.objectContaining({ slug: "team-skill" })]);
+  });
+});

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -2344,6 +2344,88 @@ export const list = query({
   },
 });
 
+async function mapDashboardSkillPage(
+  ctx: QueryCtx,
+  skills: Doc<"skills">[],
+  isOwnDashboard: boolean,
+) {
+  const withBadges = await attachBadgesToSkills(ctx, skills);
+
+  if (isOwnDashboard) {
+    return await Promise.all(
+      withBadges.map(async (skill) => await toDashboardSkillListItem(ctx, skill)),
+    );
+  }
+
+  const visibleSkills = await filterSkillsByActiveOwner(ctx, withBadges);
+  return visibleSkills
+    .map((skill) => toPublicSkill(skill))
+    .filter((skill): skill is NonNullable<typeof skill> => Boolean(skill));
+}
+
+export const listDashboardPaginated = query({
+  args: {
+    ownerUserId: v.optional(v.id("users")),
+    ownerPublisherId: v.optional(v.id("publishers")),
+    paginationOpts: paginationOptsValidator,
+  },
+  handler: async (ctx, args) => {
+    const ownerPublisherId = args.ownerPublisherId;
+    if (ownerPublisherId) {
+      const userId = await getOptionalActiveAuthUserId(ctx);
+      const ownerPublisher = await ctx.db.get(ownerPublisherId);
+      const membership =
+        userId &&
+        (await ctx.db
+          .query("publisherMembers")
+          .withIndex("by_publisher_user", (q) =>
+            q.eq("publisherId", ownerPublisherId).eq("userId", userId),
+          )
+          .unique());
+      const isOwnDashboard = Boolean(
+        membership ||
+        (userId && ownerPublisher?.kind === "user" && ownerPublisher.linkedUserId === userId),
+      );
+
+      const result =
+        isOwnDashboard && ownerPublisher?.kind === "user" && ownerPublisher.linkedUserId
+          ? await ctx.db
+              .query("skills")
+              .withIndex("by_owner_active_updated", (q) =>
+                q.eq("ownerUserId", ownerPublisher.linkedUserId!).eq("softDeletedAt", undefined),
+              )
+              .order("desc")
+              .paginate(args.paginationOpts)
+          : await ctx.db
+              .query("skills")
+              .withIndex("by_owner_publisher_active_updated", (q) =>
+                q.eq("ownerPublisherId", ownerPublisherId).eq("softDeletedAt", undefined),
+              )
+              .order("desc")
+              .paginate(args.paginationOpts);
+      const page = await mapDashboardSkillPage(ctx, result.page, isOwnDashboard);
+      return { ...result, page };
+    }
+
+    const ownerUserId = args.ownerUserId;
+    if (ownerUserId) {
+      const userId = await getOptionalActiveAuthUserId(ctx);
+      const isOwnDashboard = Boolean(userId && userId === ownerUserId);
+      const result = await ctx.db
+        .query("skills")
+        .withIndex("by_owner_active_updated", (q) =>
+          q.eq("ownerUserId", ownerUserId).eq("softDeletedAt", undefined),
+        )
+        .order("desc")
+        .paginate(args.paginationOpts);
+      const page = await mapDashboardSkillPage(ctx, result.page, isOwnDashboard);
+      return { ...result, page };
+    }
+
+    return { page: [], isDone: true as const, continueCursor: "" };
+  },
+});
+
 export const listWithLatest = query({
   args: {
     batch: v.optional(v.string()),

--- a/src/routes/-dashboard.test.tsx
+++ b/src/routes/-dashboard.test.tsx
@@ -8,6 +8,7 @@ import { Dashboard } from "./dashboard";
 
 const mocks = vi.hoisted(() => ({
   useQuery: vi.fn(),
+  usePaginatedQuery: vi.fn(),
   useMutation: vi.fn(),
   toastSuccess: vi.fn(),
   toastError: vi.fn(),
@@ -15,6 +16,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("convex/react", () => ({
   useQuery: (...args: unknown[]) => mocks.useQuery(...args),
+  usePaginatedQuery: (...args: unknown[]) => mocks.usePaginatedQuery(...args),
   useMutation: (...args: unknown[]) => mocks.useMutation(...args),
 }));
 
@@ -200,15 +202,18 @@ function arrangeDashboard({
   packages?: TestPackage[];
 }) {
   let unscopedQueryCount = 0;
-  let scopedQueryCount = 0;
+  mocks.usePaginatedQuery.mockReturnValue({
+    results: skills,
+    status: "Exhausted",
+    loadMore: vi.fn(),
+  });
   mocks.useQuery.mockImplementation((_fn: unknown, args: unknown) => {
     if (args === "skip") return undefined;
     if (args === undefined) {
       unscopedQueryCount += 1;
       return unscopedQueryCount % 2 === 1 ? me : publishers;
     }
-    scopedQueryCount += 1;
-    return scopedQueryCount % 2 === 1 ? skills : packages;
+    return packages;
   });
 }
 
@@ -223,6 +228,12 @@ function renderDashboard() {
 describe("Dashboard minimal rows", () => {
   beforeEach(() => {
     mocks.useQuery.mockReset();
+    mocks.usePaginatedQuery.mockReset();
+    mocks.usePaginatedQuery.mockReturnValue({
+      results: [],
+      status: "LoadingFirstPage",
+      loadMore: vi.fn(),
+    });
     mocks.useMutation.mockReset();
     mocks.useMutation.mockReturnValue(vi.fn().mockResolvedValue({}));
     mocks.toastSuccess.mockReset();

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useMutation, useQuery } from "convex/react";
-import { Clock, Info, MoreVertical, Plus, RotateCw, Settings } from "lucide-react";
+import { useMutation, usePaginatedQuery, useQuery } from "convex/react";
+import { Clock, Info, Loader2, MoreVertical, Plus, RotateCw, Settings } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { api } from "../../convex/_generated/api";
@@ -137,16 +137,22 @@ export function Dashboard() {
   const selectedPublisher =
     publishers?.find((entry) => entry.publisher._id === selectedPublisherId) ?? null;
 
-  const mySkills = useQuery(
-    api.skills.list,
+  const skillsQueryArgs =
     selectedPublisher?.publisher.kind === "user" && me?._id
-      ? { ownerUserId: me._id, limit: 100 }
+      ? { ownerUserId: me._id }
       : selectedPublisherId
-        ? { ownerPublisherId: selectedPublisherId as Doc<"publishers">["_id"], limit: 100 }
+        ? { ownerPublisherId: selectedPublisherId as Doc<"publishers">["_id"] }
         : me?._id
-          ? { ownerUserId: me._id, limit: 100 }
-          : "skip",
-  ) as DashboardSkill[] | undefined;
+          ? { ownerUserId: me._id }
+          : "skip";
+  const {
+    results: paginatedSkills,
+    status: skillsStatus,
+    loadMore,
+  } = usePaginatedQuery(api.skills.listDashboardPaginated, skillsQueryArgs, {
+    initialNumItems: 50,
+  });
+  const mySkills = paginatedSkills as DashboardSkill[] | undefined;
   const myPackages = useQuery(
     api.packages.list,
     selectedPublisherId
@@ -179,7 +185,7 @@ export function Dashboard() {
 
   const skills = mySkills ?? [];
   const packages = myPackages ?? [];
-  const isLoading = mySkills === undefined;
+  const isLoading = skillsStatus === "LoadingFirstPage";
   const ownerHandle =
     selectedPublisher?.publisher.handle ?? me.handle ?? me.name ?? me.displayName ?? me._id;
 
@@ -256,6 +262,17 @@ export function Dashboard() {
                 {skills.map((skill) => (
                   <SkillRow key={skill._id} skill={skill} ownerHandle={ownerHandle} />
                 ))}
+              </div>
+            )}
+            {skills.length > 0 && skillsStatus === "CanLoadMore" && (
+              <div className="mt-4 flex justify-center">
+                <Button onClick={() => loadMore(50)}>Load More</Button>
+              </div>
+            )}
+            {skillsStatus === "LoadingMore" && (
+              <div className="mt-4 flex items-center justify-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                <span>Loading more skills...</span>
               </div>
             )}
           </section>


### PR DESCRIPTION
## Summary
 - Added  "Load More" for Skills list on /dashboard page via "Load More" 
 - Extended .gitignore

https://github.com/user-attachments/assets/40860ecf-82d4-45c6-b39d-b172095bd38b

(AI Assisted)

## Changes

  - Add `listDashboardPaginated` query using Convex `.paginate()` for incremental loading of publisher skills
  - Update dashboard UI with "Load More" button

 ## Test plan

  - [ ] Open `/dashboard` with a publisher that has many skills — initial load shows 50, "Load More" fetches more
  - [ ] Verify "Load More" disappears when all skills are loaded