### PR TITLE
ops: gate production deploys behind environment approval

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,7 +82,13 @@ jobs:
         run: |
           set -euo pipefail
           for attempt in {1..90}; do
-            state="$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/status"               --jq '.statuses[] | select(.context == env.VERCEL_STATUS_CONTEXT) | .state'               2>/dev/null | head -n1)"
+            if ! state="$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/status" \
+              --jq '.statuses[] | select(.context == env.VERCEL_STATUS_CONTEXT) | .state' \
+              2>/dev/null | head -n1)"; then
+              echo "GitHub status check failed for $GITHUB_SHA; retrying..."
+              sleep 10
+              continue
+            fi
 
             case "$state" in
               success)


### PR DESCRIPTION
## Summary
- gate production deploys behind the existing GitHub `Production` environment
- require deploy runs to come from `main` before they can reach the gated job
- keep deploy, Vercel wait, and production smoke inside one gated job so approval happens once

## Why
Merges to `main` currently deploy to prod immediately. This changes prod deploys to a release-manager approval flow, similar to the gated release jobs in `openclaw`.

## GitHub follow-up
- open the existing `Production` environment in this repo
- add the OpenClaw release managers team as required reviewers
- move `CONVEX_DEPLOY_KEY` into that environment
- optionally move `PLAYWRIGHT_AUTH_STORAGE_STATE_JSON` there too
- restrict the environment to `main` if you want an extra UI-level guard
