### PR TITLE
ops: make production deploy manual only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,6 @@
 name: Deploy
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- stop auto-starting the Deploy workflow on pushes to `main`
- keep production deploys available through `workflow_dispatch` only
- keep the existing `Production` environment approval gate in place

## Why
The previous workflow PR correctly gated production, but merging it still started a waiting deploy run on every push to `main`. This follow-up makes production deploys manual only.

## Result
After this merges, production deploys will require:
1. manually starting the `Deploy` workflow from `main`
2. approval from the `Production` environment reviewers
