### PR TITLE
fix(cli-auth): ensure fallback token renders before redirect on Windows/Chrome

### DIFF
--- a/src/routes/cli/-auth.test.tsx
+++ b/src/routes/cli/-auth.test.tsx
@@ -1,0 +1,113 @@
+/* @vitest-environment jsdom */
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const createTokenMock = vi.fn();
+const clearAuthErrorMock = vi.fn();
+let mockSearch: {
+  redirect_uri?: string;
+  label?: string;
+  label_b64?: string;
+  state?: string;
+} = {};
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (config: { component: unknown }) => ({
+    ...config,
+    useSearch: () => mockSearch,
+  }),
+}));
+
+vi.mock("convex/react", () => ({
+  useMutation: () => createTokenMock,
+}));
+
+vi.mock("../../../convex/_generated/api", () => ({
+  api: {
+    tokens: {
+      create: "tokens.create",
+    },
+  },
+}));
+
+vi.mock("../../lib/useAuthStatus", () => ({
+  useAuthStatus: () => ({
+    isAuthenticated: true,
+    isLoading: false,
+    me: { _id: "user_123" },
+  }),
+}));
+
+vi.mock("../../lib/useAuthError", () => ({
+  useAuthError: () => ({
+    error: null,
+    clear: clearAuthErrorMock,
+  }),
+}));
+
+vi.mock("../../lib/site", () => ({
+  getClawHubSiteUrl: () => "https://clawhub.ai",
+  normalizeClawHubSiteOrigin: () => "https://clawhub.ai",
+}));
+
+vi.mock("../../components/layout/Container", () => ({
+  Container: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../components/SignInButton", () => ({
+  SignInButton: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}));
+
+vi.mock("../../components/ui/card", () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardTitle: ({ children }: { children: React.ReactNode }) => <h1>{children}</h1>,
+}));
+
+const { CliAuth } = await import("./auth");
+
+describe("CliAuth", () => {
+  const assignSpy = vi.fn();
+
+  beforeEach(() => {
+    createTokenMock.mockReset();
+    clearAuthErrorMock.mockReset();
+    assignSpy.mockReset();
+    mockSearch = {
+      redirect_uri: "http://127.0.0.1:43110/callback",
+      state: "state_123",
+      label: "CLI token",
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the fallback token and retry link before attempting redirect", async () => {
+    createTokenMock.mockResolvedValue({ token: "clh_test_token" });
+
+    render(<CliAuth navigate={assignSpy} />);
+
+    await waitFor(() => {
+      expect(createTokenMock).toHaveBeenCalledWith({ label: "CLI token" });
+    });
+
+    await waitFor(() => {
+      expect(assignSpy).toHaveBeenCalledWith(
+        "http://127.0.0.1:43110/callback#token=clh_test_token&registry=https%3A%2F%2Fclawhub.ai&state=state_123",
+      );
+    });
+
+    expect(screen.getByText(/copy this token and run/i)).toBeTruthy();
+    expect(screen.getByText("clh_test_token")).toBeTruthy();
+    expect(screen.getByText(/Redirecting to CLI/i)).toBeTruthy();
+    expect(screen.getByRole("link", { name: /Retry redirect to CLI/i }).getAttribute("href")).toBe(
+      "http://127.0.0.1:43110/callback#token=clh_test_token&registry=https%3A%2F%2Fclawhub.ai&state=state_123",
+    );
+  });
+});

--- a/src/routes/cli/auth.tsx
+++ b/src/routes/cli/auth.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useMutation } from "convex/react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import { api } from "../../../convex/_generated/api";
 import { Container } from "../../components/layout/Container";
 import { SignInButton } from "../../components/SignInButton";
@@ -26,6 +27,7 @@ function CliAuth() {
   };
   const [status, setStatus] = useState<string>("Preparing...");
   const [token, setToken] = useState<string | null>(null);
+  const [callbackUrl, setCallbackUrl] = useState<string | null>(null);
   const hasRun = useRef(false);
 
   const redirectUri = search.redirect_uri ?? "";
@@ -51,13 +53,21 @@ function CliAuth() {
     const run = async () => {
       setStatus("Creating token...");
       const result = await createToken({ label });
-      setToken(result.token);
-      setStatus("Redirecting to CLI...");
       const hash = new URLSearchParams();
       hash.set("token", result.token);
       hash.set("registry", registry);
       hash.set("state", state);
-      window.location.assign(`${redirectUri}#${hash.toString()}`);
+      const callbackUrl = `${redirectUri}#${hash.toString()}`;
+      // Render the fallback token before attempting navigation so it is
+      // always visible if the browser blocks or fails the http:// redirect
+      // (e.g. ERR_CONNECTION_REFUSED when the CLI server has already shut
+      // down, or Chrome's HTTPS-first mode interfering with localhost).
+      flushSync(() => {
+        setToken(result.token);
+        setCallbackUrl(callbackUrl);
+        setStatus("Redirecting to CLI…");
+      });
+      window.location.assign(callbackUrl);
     };
 
     void run().catch((error) => {
@@ -159,8 +169,16 @@ function CliAuth() {
             <p className="text-sm text-[color:var(--ink-soft)]">{status}</p>
             {token ? (
               <div className="text-sm text-[color:var(--ink-soft)] overflow-x-auto">
-                <div className="mb-2">If redirect fails, copy this token:</div>
+                <div className="mb-2">
+              If the redirect did not complete, copy this token and run{" "}
+              <code>clawhub login --token &lt;token&gt;</code>:
+            </div>
                 <code className="font-mono text-xs">{token}</code>
+                {callbackUrl ? (
+                  <div className="mt-2">
+                    <a href={callbackUrl}>Retry redirect to CLI</a>
+                  </div>
+                ) : null}
               </div>
             ) : null}
           </CardContent>

--- a/src/routes/cli/auth.tsx
+++ b/src/routes/cli/auth.tsx
@@ -14,7 +14,11 @@ export const Route = createFileRoute("/cli/auth")({
   component: CliAuth,
 });
 
-function CliAuth() {
+type CliAuthProps = {
+  navigate?: (url: string) => void;
+};
+
+export function CliAuth({ navigate = (url: string) => window.location.assign(url) }: CliAuthProps = {}) {
   const { isAuthenticated, isLoading, me } = useAuthStatus();
   const { error: authError, clear: clearAuthError } = useAuthError();
   const createToken = useMutation(api.tokens.create);
@@ -67,7 +71,7 @@ function CliAuth() {
         setCallbackUrl(callbackUrl);
         setStatus("Redirecting to CLI…");
       });
-      window.location.assign(callbackUrl);
+      navigate(callbackUrl);
     };
 
     void run().catch((error) => {
@@ -75,7 +79,7 @@ function CliAuth() {
       setStatus(message);
       setToken(null);
     });
-  }, [createToken, isAuthenticated, label, me, redirectUri, registry, safeRedirect, state]);
+  }, [createToken, isAuthenticated, label, me, navigate, redirectUri, registry, safeRedirect, state]);
 
   if (!safeRedirect) {
     return (


### PR DESCRIPTION
## Summary

Fixes #1469 — CLI login callback does not complete after GitHub sign-in on Windows/Chrome.

**Root cause**: `setToken()` (a React state update, batched/async) and `window.location.assign()` (synchronous navigation) were called back-to-back in the same microtask. React's batching meant the fallback token UI was never rendered before the navigation fired.

On Windows/Chrome, when `window.location.assign("http://127.0.0.1:PORT/…")` fails — for example because the CLI's local server already shut down (`ERR_CONNECTION_REFUSED`) or Chrome's HTTPS-first mode interferes — Chrome replaces the current page with an error screen. Since the token had not rendered yet, users were left on Chrome's error page with no way to recover.

**Fix**:
- Use `flushSync()` from `react-dom` to render the token and callback URL synchronously before calling `window.location.assign()`. The token is guaranteed to be on screen before any navigation attempt.
- Add a `callbackUrl` state so the rendered fallback also includes a **"Retry redirect to CLI"** link — useful if the user navigates back to the page or the auto-redirect was silently swallowed.
- Improve the fallback copy instructions to mention `clawhub login --token <token>`.

## Test plan

- [ ] Normal flow (CLI server still running): sign in with GitHub, CLI receives token automatically — no visible change.
- [ ] Failed redirect flow (CLI server shut down): token and "Retry redirect to CLI" link are visible on screen before Chrome shows any error. User can copy the token manually.
- [ ] Retry link: clicking "Retry redirect to CLI" re-attempts the localhost redirect.
- [ ] Existing `AppProviders` tests still pass (`bun run test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)