### PR TITLE
[fix] show moderation status on plain clawhub inspect

### DIFF
--- a/packages/clawhub/src/cli/commands/inspect.test.ts
+++ b/packages/clawhub/src/cli/commands/inspect.test.ts
@@ -218,6 +218,36 @@ describe("cmdInspect", () => {
     expect(securityCalls).toHaveLength(0);
   });
 
+  it("falls back to boolean flags when verdict is absent", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      skill: {
+        slug: "demo",
+        displayName: "Demo",
+        summary: null,
+        tags: { latest: "1.0.0" },
+        stats: {},
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      latestVersion: { version: "1.0.0", createdAt: 3, changelog: "init", license: null },
+      owner: null,
+      moderation: {
+        isSuspicious: true,
+        isMalwareBlocked: false,
+        // verdict intentionally absent
+        reasonCodes: [],
+        updatedAt: null,
+        engineVersion: null,
+        summary: null,
+      },
+    });
+
+    await cmdInspect(makeGlobalOpts(), "demo");
+
+    expect(mockLog).toHaveBeenCalledWith("Security: SUSPICIOUS");
+    expect(mockLog).toHaveBeenCalledWith("Suspicious: yes");
+  });
+
   it("rejects when both version and tag are provided", async () => {
     await expect(
       cmdInspect(makeGlobalOpts(), "demo", { version: "1.0.0", tag: "latest" }),

--- a/packages/clawhub/src/cli/commands/inspect.test.ts
+++ b/packages/clawhub/src/cli/commands/inspect.test.ts
@@ -132,6 +132,92 @@ describe("cmdInspect", () => {
     expect(mockLog).toHaveBeenCalledWith("Model: gpt-5.2");
   });
 
+  it("prints skill-level moderation status on plain inspect (no version flags)", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      skill: {
+        slug: "demo",
+        displayName: "Demo",
+        summary: null,
+        tags: { latest: "1.0.0" },
+        stats: {},
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      latestVersion: { version: "1.0.0", createdAt: 3, changelog: "init", license: null },
+      owner: null,
+      moderation: {
+        isSuspicious: true,
+        isMalwareBlocked: false,
+        verdict: "suspicious",
+        reasonCodes: ["env-leak"],
+        updatedAt: 1_700_000_000_000,
+        engineVersion: "v2",
+        summary: null,
+      },
+    });
+
+    await cmdInspect(makeGlobalOpts(), "demo");
+
+    expect(mockLog).toHaveBeenCalledWith("Security: SUSPICIOUS");
+    expect(mockLog).toHaveBeenCalledWith("Suspicious: yes");
+    expect(mockLog).toHaveBeenCalledWith("Checked: 2023-11-14T22:13:20.000Z");
+    expect(mockLog).toHaveBeenCalledWith("Engine: v2");
+  });
+
+  it("shows Security: CLEAN for a clean skill on plain inspect", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      skill: {
+        slug: "demo",
+        displayName: "Demo",
+        summary: null,
+        tags: { latest: "1.0.0" },
+        stats: {},
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      latestVersion: { version: "1.0.0", createdAt: 3, changelog: "init", license: null },
+      owner: null,
+      moderation: {
+        isSuspicious: false,
+        isMalwareBlocked: false,
+        verdict: "clean",
+        reasonCodes: [],
+        updatedAt: null,
+        engineVersion: null,
+        summary: null,
+      },
+    });
+
+    await cmdInspect(makeGlobalOpts(), "demo");
+
+    expect(mockLog).toHaveBeenCalledWith("Security: CLEAN");
+    expect(mockLog).not.toHaveBeenCalledWith("Suspicious: yes");
+    expect(mockLog).not.toHaveBeenCalledWith("Malware: blocked");
+  });
+
+  it("skips security block when moderation is absent", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      skill: {
+        slug: "demo",
+        displayName: "Demo",
+        summary: null,
+        tags: { latest: "1.0.0" },
+        stats: {},
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      latestVersion: { version: "1.0.0", createdAt: 3, changelog: "init", license: null },
+      owner: null,
+    });
+
+    await cmdInspect(makeGlobalOpts(), "demo");
+
+    const securityCalls = mockLog.mock.calls.filter((args) =>
+      String(args[0]).startsWith("Security:"),
+    );
+    expect(securityCalls).toHaveLength(0);
+  });
+
   it("rejects when both version and tag are provided", async () => {
     await expect(
       cmdInspect(makeGlobalOpts(), "demo", { version: "1.0.0", tag: "latest" }),

--- a/packages/clawhub/src/cli/commands/inspect.ts
+++ b/packages/clawhub/src/cli/commands/inspect.ts
@@ -145,6 +145,8 @@ export async function cmdInspect(opts: GlobalOpts, slug: string, options: Inspec
     if (shouldPrintMeta && versionResult?.version) {
       printVersionSummary(versionResult.version);
       printSecuritySummary(versionResult.version);
+    } else if (shouldPrintMeta) {
+      printModerationSummary(skillResult.moderation ?? null);
     }
 
     if (versionsList?.items && Array.isArray(versionsList.items)) {
@@ -295,6 +297,31 @@ function printSecuritySummary(version: unknown) {
   }
   if (sec.model) {
     console.log(`Model: ${sec.model}`);
+  }
+}
+
+function printModerationSummary(
+  moderation: {
+    isSuspicious?: boolean;
+    isMalwareBlocked?: boolean;
+    verdict?: string | null;
+    updatedAt?: number | null;
+    engineVersion?: string | null;
+  } | null,
+) {
+  if (!moderation) return;
+  const verdict = moderation.verdict ?? "clean";
+  console.log(`Security: ${verdict.toUpperCase()}`);
+  if (moderation.isMalwareBlocked) {
+    console.log("Malware: blocked");
+  } else if (moderation.isSuspicious) {
+    console.log("Suspicious: yes");
+  }
+  if (typeof moderation.updatedAt === "number") {
+    console.log(`Checked: ${formatTimestamp(moderation.updatedAt)}`);
+  }
+  if (moderation.engineVersion) {
+    console.log(`Engine: ${moderation.engineVersion}`);
   }
 }
 

--- a/packages/clawhub/src/cli/commands/inspect.ts
+++ b/packages/clawhub/src/cli/commands/inspect.ts
@@ -310,7 +310,9 @@ function printModerationSummary(
   } | null,
 ) {
   if (!moderation) return;
-  const verdict = moderation.verdict ?? "clean";
+  const verdict =
+    moderation.verdict ??
+    (moderation.isMalwareBlocked ? "malicious" : moderation.isSuspicious ? "suspicious" : "clean");
   console.log(`Security: ${verdict.toUpperCase()}`);
   if (moderation.isMalwareBlocked) {
     console.log("Malware: blocked");


### PR DESCRIPTION
## What's the problem?

Running `clawhub inspect <skill>` without any flags never shows the security status, even though the API always returns it.

If you try with `--version 1.2.3` you'll see the security block — but that requires knowing a version number upfront. For a quick sanity check, you shouldn't have to do that.

Related to #1483.

## Why does it happen?

The existing `printSecuritySummary` call is gated behind `versionResult?.version`:

```ts
if (shouldPrintMeta && versionResult?.version) {
  printVersionSummary(versionResult.version);
  printSecuritySummary(versionResult.version);   // never runs on plain inspect
}
```

`versionResult` is only populated when `--version`, `--tag`, `--files`, or `--file` is passed. Without those flags it stays `null`, and the skill's `moderation` object — which the API always returns — is fetched but never displayed.

## What I changed

Added a `printModerationSummary` function that reads the skill-level `moderation` object (`verdict`, `isSuspicious`, `isMalwareBlocked`, `updatedAt`, `engineVersion`) and prints it in the `else if (shouldPrintMeta)` branch, so the security line is always visible on a basic inspect:

```
$ clawhub inspect some-skill
some-skill  Some Skill
Owner: someone
...
Security: SUSPICIOUS
Suspicious: yes
Checked: 2024-01-15T10:30:00.000Z
Engine: v2
```

When no moderation data comes back from the API the block is a no-op, so existing behaviour for older responses is unchanged.

## How I verified it

- Added three unit tests to `inspect.test.ts`:
  1. Suspicious skill with full moderation data → all fields printed correctly
  2. Clean skill → `Security: CLEAN`, no suspicious/malware lines
  3. No moderation field in response → security block not printed at all
- Ran the full clawdhub test suite: **176/176 passed**