### PR TITLE
fix: repair auth sign-in typecheck

### DIFF
--- a/convex/auth.test.ts
+++ b/convex/auth.test.ts
@@ -10,7 +10,14 @@ function makeCtx({
   user,
   banRecords,
 }: {
-  user: { deletedAt?: number; deactivatedAt?: number; purgedAt?: number } | null;
+  user:
+    | {
+        deletedAt?: number;
+        deactivatedAt?: number;
+        purgedAt?: number;
+        banReason?: string;
+      }
+    | null;
   banRecords?: Array<Record<string, unknown>>;
 }) {
   const query = {

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -1,4 +1,3 @@
-import { getAuthUserId } from "@convex-dev/auth/server";
 import { paginationOptsValidator } from "convex/server";
 import { ConvexError, v } from "convex/values";
 import {
@@ -498,7 +497,7 @@ function decodePublicPageCursor(raw: string | null | undefined): PublicPageCurso
   }
 }
 
-async function getOptionalViewerUserId(ctx: Parameters<typeof getAuthUserId>[0]) {
+async function getOptionalViewerUserId(ctx: QueryCtx | MutationCtx) {
   return await getOptionalActiveAuthUserId(ctx);
 }
 

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -254,15 +254,16 @@ async function computeEnsureUpdates(ctx: MutationCtx, user: Doc<"users">) {
       : undefined;
   if (!derivedHandle && (!existingHandle || !existingHandleClaimable)) {
     const emailFallback = normalizeHandle(user.email?.split("@")[0]);
+    const emailFallbackHandle =
+      emailFallback && emailFallback !== requestedHandle
+        ? await resolveAvailableHandle(ctx, emailFallback, user._id)
+        : undefined;
     derivedHandle =
       (await resolveAvailableHandle(
         ctx,
         requestedHandle ?? existingHandle ?? githubLogin ?? emailFallback,
         user._id,
-      )) ||
-      (emailFallback &&
-        emailFallback !== requestedHandle &&
-        (await resolveAvailableHandle(ctx, emailFallback, user._id)));
+      )) ?? emailFallbackHandle;
   }
   const baseHandle = derivedHandle ?? (existingHandleClaimable ? existingHandle : undefined);
 


### PR DESCRIPTION
## Summary
- widen the auth sign-in test fixture to include `banReason`
- align the package viewer helper with the active-auth ctx type it actually accepts
- keep derived handle fallback typed as `string | undefined`

## Testing
- bunx tsc --noEmit
- bun run test convex/auth.test.ts
- bun run lint