### PR TITLE
docs: remove production approval step from deploy docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,9 +47,8 @@
 - Production deploys are manual-only. Merging to `main` does **not** deploy.
 - To release production, start the GitHub Actions `Deploy` workflow from `main`:
   `gh workflow run deploy.yml --repo openclaw/clawhub --ref main`
-- The workflow pauses at the GitHub `Production` environment. A member of the `openclaw-release-managers` team must approve it before any real deploy step runs.
+- The workflow uses the GitHub `Production` environment for deploy secrets, but it does not require a separate approval step.
 - Prod deploy secrets live on the `Production` environment, not as ordinary repo secrets. Required: `CONVEX_DEPLOY_KEY`. Optional: `PLAYWRIGHT_AUTH_STORAGE_STATE_JSON`.
-- If you are not in `openclaw-release-managers`, do not treat a started workflow as shipped. Ask that team to approve the pending deployment.
 - CLI npm releases are also manual-only and tag-based. Stable tags only: `vX.Y.Z`. Start `ClawHub CLI NPM Release` from `main`, first with `preflight_only=true`, then rerun it with the same tag and the successful `preflight_run_id`.
 - Real CLI publishes wait at the GitHub `npm-release` environment and use npm trusted publishing. Required npm trusted publisher settings: repository `openclaw/clawhub`, workflow `clawhub-cli-npm-release.yml`, environment `npm-release`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@
 
 - Production deploys are manual-only. Merging to `main` does **not** deploy.
 - Start the GitHub Actions `Deploy` workflow from `main` with `gh workflow run deploy.yml --repo openclaw/clawhub --ref main`.
-- The workflow waits at the `Production` environment until `openclaw-release-managers` approves it.
+- The workflow uses the `Production` environment for deploy secrets, but it does not wait for a separate approval.
 - Required prod secret: `CONVEX_DEPLOY_KEY` on the `Production` environment. Optional smoke secret: `PLAYWRIGHT_AUTH_STORAGE_STATE_JSON`.
 - CLI npm releases are manual-only and tag-based through `ClawHub CLI NPM Release`. Stable tags only: `vX.Y.Z`. Run a `preflight_only=true` pass first, then rerun with the same tag plus `preflight_run_id` for the real publish.
 - Real CLI publishes wait at `npm-release` and rely on npm trusted publishing for `openclaw/clawhub` + `clawhub-cli-npm-release.yml` + `npm-release`.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -32,7 +32,7 @@ Production deploy notes:
 
 - `deploy.yml` is manual-only (`workflow_dispatch`). Merging to `main` does not deploy.
 - The workflow must be started from `main`.
-- The real deploy job waits at the GitHub `Production` environment. A member of `openclaw-release-managers` must approve it before deploy continues.
+- The real deploy job uses the GitHub `Production` environment for deploy secrets, but it does not wait for a separate approval.
 - Required `Production` environment secret: `CONVEX_DEPLOY_KEY`.
 - Optional `Production` environment secret: `PLAYWRIGHT_AUTH_STORAGE_STATE_JSON` for authenticated smoke coverage.
 


### PR DESCRIPTION
## Summary
- remove the stale release-manager approval wording from ClawHub deploy docs
- clarify that the Production environment now only holds deploy secrets

## Verification
- GitHub Production environment no longer has required reviewers
- git diff --check