### PR TITLE
feat: add deploy workflow targets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,16 @@ name: Deploy
 
 on:
   workflow_dispatch:
+    inputs:
+      target:
+        description: "What to deploy"
+        required: true
+        default: full
+        type: choice
+        options:
+          - full
+          - backend
+          - frontend
 
 concurrency:
   group: deploy-production
@@ -11,6 +21,11 @@ jobs:
   validate-deploy-request:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    outputs:
+      deploy_backend: ${{ steps.mode.outputs.deploy_backend }}
+      deploy_frontend: ${{ steps.mode.outputs.deploy_frontend }}
+      run_smoke: ${{ steps.mode.outputs.run_smoke }}
+      target: ${{ steps.mode.outputs.target }}
     steps:
       - name: Require main ref for production deploy
         run: |
@@ -19,6 +34,34 @@ jobs:
             echo "Production deploys must run from main."
             exit 1
           fi
+
+      - name: Resolve deploy mode
+        id: mode
+        run: |
+          set -euo pipefail
+          target="${{ inputs.target }}"
+          case "$target" in
+            full)
+              echo "deploy_backend=true" >> "$GITHUB_OUTPUT"
+              echo "deploy_frontend=true" >> "$GITHUB_OUTPUT"
+              echo "run_smoke=true" >> "$GITHUB_OUTPUT"
+              ;;
+            backend)
+              echo "deploy_backend=true" >> "$GITHUB_OUTPUT"
+              echo "deploy_frontend=false" >> "$GITHUB_OUTPUT"
+              echo "run_smoke=true" >> "$GITHUB_OUTPUT"
+              ;;
+            frontend)
+              echo "deploy_backend=false" >> "$GITHUB_OUTPUT"
+              echo "deploy_frontend=true" >> "$GITHUB_OUTPUT"
+              echo "run_smoke=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unsupported deploy target: $target" >&2
+              exit 1
+              ;;
+          esac
+          echo "target=$target" >> "$GITHUB_OUTPUT"
 
   deploy-production:
     runs-on: ubuntu-latest
@@ -32,12 +75,12 @@ jobs:
       PLAYWRIGHT_AUTH_STORAGE_STATE_JSON: ${{ secrets.PLAYWRIGHT_AUTH_STORAGE_STATE_JSON }}
       PLAYWRIGHT_BASE_URL: https://clawhub.ai
     steps:
-      - name: Check deploy secrets
+      - name: Check deploy configuration
         run: |
           set -euo pipefail
           missing=()
 
-          if [[ -z "$CONVEX_DEPLOY_KEY" ]]; then
+          if [[ "${{ needs.validate-deploy-request.outputs.deploy_backend }}" == "true" && -z "$CONVEX_DEPLOY_KEY" ]]; then
             missing+=("CONVEX_DEPLOY_KEY")
           fi
 
@@ -45,6 +88,8 @@ jobs:
             echo "::error::Missing required production environment secrets: ${missing[*]}"
             exit 1
           fi
+
+          echo "Deploy target: ${{ needs.validate-deploy-request.outputs.target }}"
 
           if [[ -z "$PLAYWRIGHT_AUTH_STORAGE_STATE_JSON" ]]; then
             echo "PLAYWRIGHT_AUTH_STORAGE_STATE_JSON not set; authenticated smoke will be skipped."
@@ -60,18 +105,23 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Stamp Convex build SHA
+        if: needs.validate-deploy-request.outputs.deploy_backend == 'true'
         run: bunx convex env set APP_BUILD_SHA "${GITHUB_SHA}" --prod
 
       - name: Stamp Convex deploy time
+        if: needs.validate-deploy-request.outputs.deploy_backend == 'true'
         run: bunx convex env set APP_DEPLOYED_AT "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" --prod
 
       - name: Deploy Convex
+        if: needs.validate-deploy-request.outputs.deploy_backend == 'true'
         run: bun run convex:deploy
 
       - name: Verify Convex contract
+        if: needs.validate-deploy-request.outputs.deploy_backend == 'true'
         run: bun run verify:convex-contract -- --prod
 
       - name: Wait for Vercel production deployment
+        if: needs.validate-deploy-request.outputs.deploy_frontend == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -112,13 +162,15 @@ jobs:
           exit 1
 
       - name: Install Playwright browser
+        if: needs.validate-deploy-request.outputs.run_smoke == 'true'
         run: bunx playwright install --with-deps chromium
 
       - name: Write authenticated storage state
-        if: env.PLAYWRIGHT_AUTH_STORAGE_STATE_JSON != ''
+        if: needs.validate-deploy-request.outputs.run_smoke == 'true' && env.PLAYWRIGHT_AUTH_STORAGE_STATE_JSON != ''
         run: |
           echo "$PLAYWRIGHT_AUTH_STORAGE_STATE_JSON" > "$RUNNER_TEMP/playwright-auth.json"
           echo "PLAYWRIGHT_AUTH_STORAGE_STATE=$RUNNER_TEMP/playwright-auth.json" >> "$GITHUB_ENV"
 
       - name: Smoke test production
+        if: needs.validate-deploy-request.outputs.run_smoke == 'true'
         run: bunx playwright test e2e/menu-smoke.pw.test.ts e2e/upload-auth-smoke.pw.test.ts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@
 - Production deploys are manual-only. Merging to `main` does **not** deploy.
 - To release production, start the GitHub Actions `Deploy` workflow from `main`:
   `gh workflow run deploy.yml --repo openclaw/clawhub --ref main`
+- The workflow supports `full`, `backend`, and `frontend` targets.
+- `frontend` currently means: wait for the Vercel production deploy for the selected `main` SHA, then run production smoke checks. It does not call `vercel deploy` directly yet.
 - The workflow uses the GitHub `Production` environment for deploy secrets, but it does not require a separate approval step.
 - Prod deploy secrets live on the `Production` environment, not as ordinary repo secrets. Required: `CONVEX_DEPLOY_KEY`. Optional: `PLAYWRIGHT_AUTH_STORAGE_STATE_JSON`.
 - CLI npm releases are also manual-only and tag-based. Stable tags only: `vX.Y.Z`. Start `ClawHub CLI NPM Release` from `main`, first with `preflight_only=true`, then rerun it with the same tag and the successful `preflight_run_id`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,8 @@
 
 - Production deploys are manual-only. Merging to `main` does **not** deploy.
 - Start the GitHub Actions `Deploy` workflow from `main` with `gh workflow run deploy.yml --repo openclaw/clawhub --ref main`.
+- The workflow supports `full`, `backend`, and `frontend` targets.
+- `frontend` currently waits for the Vercel production deploy on the selected `main` SHA and then runs smoke checks. It does not trigger Vercel directly yet.
 - The workflow uses the `Production` environment for deploy secrets, but it does not wait for a separate approval.
 - Required prod secret: `CONVEX_DEPLOY_KEY` on the `Production` environment. Optional smoke secret: `PLAYWRIGHT_AUTH_STORAGE_STATE_JSON`.
 - CLI npm releases are manual-only and tag-based through `ClawHub CLI NPM Release`. Stable tags only: `vX.Y.Z`. Run a `preflight_only=true` pass first, then rerun with the same tag plus `preflight_run_id` for the real publish.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -32,6 +32,11 @@ Production deploy notes:
 
 - `deploy.yml` is manual-only (`workflow_dispatch`). Merging to `main` does not deploy.
 - The workflow must be started from `main`.
+- Deploy targets:
+  - `full`: deploy Convex, verify contract, wait for the matching Vercel production deploy, then run smoke tests
+  - `backend`: deploy Convex, verify contract, then run smoke tests against current production
+  - `frontend`: wait for the Vercel production deploy for the selected `main` SHA, then run smoke tests
+- `frontend` does not call `vercel deploy` directly yet. It relies on the existing Vercel Git-based production deploy for that SHA.
 - The real deploy job uses the GitHub `Production` environment for deploy secrets, but it does not wait for a separate approval.
 - Required `Production` environment secret: `CONVEX_DEPLOY_KEY`.
 - Optional `Production` environment secret: `PLAYWRIGHT_AUTH_STORAGE_STATE_JSON` for authenticated smoke coverage.
@@ -65,9 +70,9 @@ CLI release notes:
 - npm trusted publisher must be configured for package `clawhub` with repository `openclaw/clawhub`, workflow `clawhub-cli-npm-release.yml`, and environment `npm-release`.
 
 That workflow assumes Vercel Git integration is enabled for this repo. It does
-not run `vercel deploy` directly; instead it waits for the GitHub commit status
-`Vercel – clawhub` for the selected SHA, then runs smoke tests against
-production.
+not run `vercel deploy` directly; frontend-related steps wait for the GitHub
+commit status `Vercel – clawhub` for the selected SHA, then run smoke tests
+against production.
 
 Ensure Convex env is set (auth + embeddings):
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -86,9 +86,8 @@ clawhub sync --root /path/to/skills
 
 ## `deploy.yml` fails before deploy or smoke runs
 
-- Ensure GitHub Actions secrets exist for the repo:
+- Ensure GitHub Actions secrets exist on the `Production` environment:
   - `CONVEX_DEPLOY_KEY`
-  - `VERCEL_TOKEN`
   - Optional: `PLAYWRIGHT_AUTH_STORAGE_STATE_JSON`
 - Missing required deploy secrets now fails the preflight job immediately.
 - If the optional Playwright auth secret is missing, authenticated smoke canaries will skip; deploy should still proceed.


### PR DESCRIPTION
## Summary
- add `full`, `backend`, and `frontend` targets to the manual ClawHub deploy workflow
- make backend-only runs skip the Vercel wait while frontend/full runs still validate Vercel
- update deploy docs to explain the new targets and the current Vercel limitation

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy.yml")'\n- git diff --check