### PR TITLE
Fix reusable package publish workflow

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -102,8 +102,8 @@ jobs:
           from pathlib import Path
           from urllib.request import Request, urlopen
 
-          request_token = os.environ["ACTIONS_ID_TOKEN_REQUEST_TOKEN"].strip()
-          request_url = os.environ["ACTIONS_ID_TOKEN_REQUEST_URL"].strip()
+          request_token = os.environ.get("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "").strip()
+          request_url = os.environ.get("ACTIONS_ID_TOKEN_REQUEST_URL", "").strip()
           if not request_token or not request_url:
               raise SystemExit("GitHub OIDC token request env vars are missing; id-token: write is required.")
 


### PR DESCRIPTION
## Summary
- resolve the called reusable workflow source from GitHub OIDC `job_workflow_ref` / `job_workflow_sha`
- run the checked-out ClawHub CLI via an absolute path and fail clearly if the entrypoint is missing
- preserve real publish failures by enabling `pipefail` in the publish step

## Why
The shared `package-publish.yml` workflow was using the caller workflow context, so it checked out the caller repo instead of `openclaw/clawhub`. That made the GitHub Actions publish path fail before the CLI could actually run.

After these fixes, the same test publish reached the real backend error for an already-published version:
- `Version 0.0.2 already exists`
- run: https://github.com/onutc/onutc-test-package/actions/runs/23946020015

## Testing
- triggered `Package Publish` from `onutc/onutc-test-package`
- confirmed the reusable workflow now checks out `openclaw/clawhub`
- confirmed the publish step now surfaces the real duplicate-version error instead of wrapper failures