### PR TITLE
Format codebase with consistent linting and import ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## 0.10.0 - 2026-04-05
+
+### Added
+
+- Design system: introduce a shared UI component library (`src/components/ui/`) built on Radix UI primitives — Button, Card, Badge, Tabs, Dialog, Input, Textarea, Label, Select, Avatar, Separator, Tooltip, ScrollArea, Sheet, Skeleton, and Table — following the shadcn/ui pattern with `cn()` + Tailwind utilities.
+- Design system: `Button` supports `asChild` via Radix Slot for polymorphic rendering (e.g., wrapping `<Link>` without extra DOM).
+- Layout: add `Container` component with `narrow` / `default` / `wide` size presets and `Breadcrumb` component for hierarchical navigation.
+- Loading: add skeleton loading states (`SkillCardSkeleton`, `SkillDetailSkeleton`, `DashboardSkeleton`) replacing text-based "Loading..." indicators with animated placeholders.
+- Errors: add `ErrorBoundary` with `resetKey` prop that auto-resets on route changes, wired into the root layout.
+- Errors: surface fallback messages from Convex API error payloads in mutation/action error toasts.
+- UX: add `EmptyState` component with icon, headline, description, and optional CTA action used across dashboard, stars, profile, and publish pages.
+- UX: add confirmation dialogs for destructive skill ownership actions (transfer, abandon).
+- Markdown: add `MarkdownPreview` component with `react-markdown`, `remark-gfm`, and `react-syntax-highlighter` for rich rendering of skill/plugin READMEs with syntax-highlighted code blocks, GFM tables, and task lists.
+- Markdown: render tables with the new `Table` UI primitive for consistent styling across skill docs.
+- Navigation: replace DropdownMenu-based mobile nav with a slide-out `Sheet` panel.
+- Validation: add Zod schemas (`src/lib/schemas.ts`) for publish-skill, settings, report, and org forms.
+- Management: restore capability-tags UI (crypto, requires-wallet, can-make-purchases, etc.) that was silently removed during the initial refactor.
+- Management: add `.catch()` error handling with toast feedback on `setSoftDeleted` calls; prompt for hide/restore reasons.
+
+### Changed
+
+- CSS: migrate from a monolithic 5,161-line `styles.css` to Tailwind utilities on components, pruning CSS to ~1,000 lines (81% reduction). Dark mode now uses Tailwind `dark:` variants via a `@variant dark` directive bridging existing CSS custom properties.
+- Tailwind: add `@theme` block mapping all CSS design tokens (`--bg`, `--surface`, `--ink`, `--accent`, `--line`, `--radius-*`, etc.) into first-class Tailwind utilities.
+- Pages: modernize all route pages (home, skills browse, skill detail, dashboard, settings, publish-skill, publish-plugin, import, about, CLI auth, stars, souls, user profile, org profile, management, plugins browse, plugin detail) from CSS class selectors to Tailwind + UI primitives.
+- Skills browse: widen container to `wide` (1400px) for better use of screen space on desktop; same for plugins browse.
+- Skills browse: replace text-based filter toggles with pill chips and modernize toolbar layout.
+- Skill detail: migrate tab controls from CSS-styled buttons to Radix `Tabs` primitive with proper `role="tab"` accessibility.
+- Skill detail: replace inline CSS class-based install card with `SkillInstallCard` using Card + Button primitives.
+- Header/Footer: migrate from CSS classes to Tailwind utilities with responsive Sheet-based mobile navigation.
+- Dashboard: replace CSS table layout with `Table` UI primitive; add metric cards and skeleton loading.
+- Settings: modernize form inputs with `Input`/`Textarea`/`Label` primitives and structured layout.
+- Publish: use `Dialog` primitive for modals; inline validation indicators; modernized file list display.
+
+### Fixed
+
+- Auth: `EmptyState` "Sign in" button on publish page now triggers GitHub OAuth via `useAuthActions` instead of linking to non-existent `/signin` route.
+- API: fix plugins page dev-mode `{"error":"Only HTML requests are supported here"}` by routing SSR and localhost API fetches directly to the Convex site URL instead of through TanStack Start's request pipeline.
+- API: fix CORS error when `credentials: "include"` conflicts with `Access-Control-Allow-Origin: *` by making credentials conditional on same-origin requests.
+- API: fix SSR `packageApiUrl` to always use `VITE_CONVEX_SITE_URL` directly, avoiding `getRequestUrl()` failures when SSR request context is unavailable.
+- Management: restore `setSoftDeleted` reason parameter for hide/restore actions.
+- Tests: rename `settings.test.tsx` to `-settings.test.tsx` to exclude from TanStack Router's file-based route discovery.
+- Tests: add `@convex-dev/auth/react` mock for `useAuthActions` in upload route tests.
+- Tests: update skill detail tests for Radix tab roles (`role="tab"` instead of `role="button"`), skeleton loading classes (`animate-pulse`), and capability tag data.
+- Tests: update skills index tests for refreshed UI copy (placeholder text, empty state wording, loading indicator patterns).
+- Tests: update SkillDiffCard tests for Tailwind active-tab class (`shadow-sm` replacing `.is-active`).
+- Tests: update packages publish route tests for Tailwind border classes.
+- Tests: update packageApi tests for conditional credentials and SSR URL resolution.
+
 ## 0.9.0 - 2026-03-23
 
 ### Added

--- a/convex/auth.test.ts
+++ b/convex/auth.test.ts
@@ -10,14 +10,12 @@ function makeCtx({
   user,
   banRecords,
 }: {
-  user:
-    | {
-        deletedAt?: number;
-        deactivatedAt?: number;
-        purgedAt?: number;
-        banReason?: string;
-      }
-    | null;
+  user: {
+    deletedAt?: number;
+    deactivatedAt?: number;
+    purgedAt?: number;
+    banReason?: string;
+  } | null;
   banRecords?: Array<Record<string, unknown>>;
 }) {
   const query = {

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -24,9 +24,12 @@ function getBannedReauthMessage(reason: string | undefined) {
 export async function handleDeletedUserSignIn(
   ctx: GenericMutationCtx<DataModel>,
   args: { userId: Id<"users">; existingUserId: Id<"users"> | null },
-  userOverride?:
-    | { deletedAt?: number; deactivatedAt?: number; purgedAt?: number; banReason?: string }
-    | null,
+  userOverride?: {
+    deletedAt?: number;
+    deactivatedAt?: number;
+    purgedAt?: number;
+    banReason?: string;
+  } | null,
 ) {
   const user = userOverride !== undefined ? userOverride : await ctx.db.get(args.userId);
   if (!user?.deletedAt && !user?.deactivatedAt) return;

--- a/convex/functions.test.ts
+++ b/convex/functions.test.ts
@@ -62,10 +62,7 @@ describe("package digest sync", () => {
       },
     };
 
-    await syncPackageSearchDigestForPackageId(
-      ctx as never,
-      "packages:demo" as never,
-    );
+    await syncPackageSearchDigestForPackageId(ctx as never, "packages:demo" as never);
 
     expect(ctx.db.insert).toHaveBeenCalledWith(
       "packageSearchDigest",
@@ -128,10 +125,7 @@ describe("package digest sync", () => {
       },
     };
 
-    await syncPackageSearchDigestForPackageId(
-      ctx as never,
-      "packages:demo" as never,
-    );
+    await syncPackageSearchDigestForPackageId(ctx as never, "packages:demo" as never);
 
     expect(ctx.db.insert).toHaveBeenCalledWith(
       "packageSearchDigest",
@@ -443,13 +437,11 @@ describe("package digest sync", () => {
       updatedAt: 2,
       verification: undefined,
     };
-    const paginate = vi
-      .fn()
-      .mockResolvedValueOnce({
-        page: [pkg],
-        isDone: true,
-        continueCursor: "",
-      });
+    const paginate = vi.fn().mockResolvedValueOnce({
+      page: [pkg],
+      isDone: true,
+      continueCursor: "",
+    });
     const ctx = {
       db: {
         get: vi.fn(async (id: string) => {
@@ -488,10 +480,7 @@ describe("package digest sync", () => {
       },
     };
 
-    await syncPackageSearchDigestsForOwnerUserId(
-      ctx as never,
-      "users:owner" as never,
-    );
+    await syncPackageSearchDigestsForOwnerUserId(ctx as never, "users:owner" as never);
 
     expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 100 });
     expect(ctx.db.insert).toHaveBeenCalledWith(

--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -128,7 +128,8 @@ async function syncPackageSearchDigest(
   });
   await upsertPackageSearchDigest(ctx, {
     ...fields,
-    latestVersion: latestRelease && !latestRelease.softDeletedAt ? latestRelease.version : undefined,
+    latestVersion:
+      latestRelease && !latestRelease.softDeletedAt ? latestRelease.version : undefined,
     ownerHandle: owner?.handle ?? "",
     ownerKind: owner?.kind,
   });
@@ -344,13 +345,15 @@ triggers.register("packages", async (ctx, change) => {
 
 triggers.register("packageReleases", async (ctx, change) => {
   if (change.operation === "insert") return;
-  if (change.operation === "update" && change.oldDoc.softDeletedAt === change.newDoc.softDeletedAt) {
+  if (
+    change.operation === "update" &&
+    change.oldDoc.softDeletedAt === change.newDoc.softDeletedAt
+  ) {
     return;
   }
   const packageId =
     change.operation === "delete" ? change.oldDoc.packageId : change.newDoc.packageId;
-  const affectedReleaseId =
-    change.operation === "delete" ? change.oldDoc._id : change.newDoc._id;
+  const affectedReleaseId = change.operation === "delete" ? change.oldDoc._id : change.newDoc._id;
   if (change.operation === "delete" || change.newDoc.softDeletedAt) {
     await repointPackageLatestRelease(ctx, packageId, affectedReleaseId);
     return;

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -24,12 +24,10 @@ vi.mock("./skills", () => ({
 }));
 
 const { getAuthUserId } = await import("@convex-dev/auth/server");
-const { getOptionalApiTokenUserId, requireApiTokenUser, requirePackagePublishAuth } = await import(
-  "./lib/apiTokenAuth"
-);
-const { fetchGitHubRepositoryIdentity, verifyGitHubActionsTrustedPublishJwt } = await import(
-  "./lib/githubActionsOidc"
-);
+const { getOptionalApiTokenUserId, requireApiTokenUser, requirePackagePublishAuth } =
+  await import("./lib/apiTokenAuth");
+const { fetchGitHubRepositoryIdentity, verifyGitHubActionsTrustedPublishJwt } =
+  await import("./lib/githubActionsOidc");
 const { publishVersionForUser } = await import("./skills");
 const { __handlers } = await import("./httpApiV1");
 
@@ -3090,7 +3088,10 @@ describe("httpApiV1 handlers", () => {
     );
 
     const zipEntries = unzipSync(new Uint8Array(await response.arrayBuffer()));
-    expect(Object.keys(zipEntries).sort()).toEqual(["package/dist/index.js", "package/package.json"]);
+    expect(Object.keys(zipEntries).sort()).toEqual([
+      "package/dist/index.js",
+      "package/package.json",
+    ]);
     expect(zipEntries["_meta.json"]).toBeUndefined();
   });
 
@@ -3365,7 +3366,9 @@ describe("httpApiV1 handlers", () => {
 
     const fileResponse = await __handlers.packagesGetRouterV1Handler(
       makeCtx({ runQuery, runMutation, storage: { get: vi.fn() } }),
-      new Request("https://example.com/api/v1/packages/demo-plugin/file?version=1.0.0&path=README.md"),
+      new Request(
+        "https://example.com/api/v1/packages/demo-plugin/file?version=1.0.0&path=README.md",
+      ),
     );
     const downloadResponse = await __handlers.packagesGetRouterV1Handler(
       makeCtx({ runQuery, runMutation, storage: { get: vi.fn() } }),
@@ -3386,7 +3389,9 @@ describe("httpApiV1 handlers", () => {
       user: { _id: "users:1", handle: "p" },
     } as never);
     const runMutation = vi.fn().mockResolvedValue(okRate());
-    const runAction = vi.fn().mockResolvedValue({ ok: true, packageId: "pkg:1", releaseId: "rel:1" });
+    const runAction = vi
+      .fn()
+      .mockResolvedValue({ ok: true, packageId: "pkg:1", releaseId: "rel:1" });
 
     const response = await __handlers.publishPackageV1Handler(
       makeCtx({ runAction, runMutation }),
@@ -3438,7 +3443,9 @@ describe("httpApiV1 handlers", () => {
       user: { _id: "users:1", handle: "p" },
     } as never);
     const runMutation = vi.fn().mockResolvedValue(okRate());
-    const runAction = vi.fn().mockResolvedValue({ ok: true, packageId: "pkg:1", releaseId: "rel:1" });
+    const runAction = vi
+      .fn()
+      .mockResolvedValue({ ok: true, packageId: "pkg:1", releaseId: "rel:1" });
     const form = new FormData();
     form.set(
       "payload",
@@ -3451,10 +3458,7 @@ describe("httpApiV1 handlers", () => {
       }),
     );
     form.append("files", new File(["{}"], ".DS_Store", { type: "application/octet-stream" }));
-    form.append(
-      "files",
-      new File(["{}"], "openclaw.bundle.json", { type: "application/json" }),
-    );
+    form.append("files", new File(["{}"], "openclaw.bundle.json", { type: "application/json" }));
 
     const response = await __handlers.publishPackageV1Handler(
       makeCtx({
@@ -3493,7 +3497,9 @@ describe("httpApiV1 handlers", () => {
       publishToken: { _id: "packagePublishTokens:1" },
     } as never);
     const runMutation = vi.fn().mockResolvedValue(okRate());
-    const runAction = vi.fn().mockResolvedValue({ ok: true, packageId: "pkg:1", releaseId: "rel:1" });
+    const runAction = vi
+      .fn()
+      .mockResolvedValue({ ok: true, packageId: "pkg:1", releaseId: "rel:1" });
 
     const response = await __handlers.publishPackageV1Handler(
       makeCtx({ runAction, runMutation }),
@@ -3725,7 +3731,8 @@ describe("httpApiV1 handlers", () => {
     expect(body.token).toEqual(expect.any(String));
     expect(body.expiresAt).toEqual(expect.any(Number));
     const createCall = runMutation.mock.calls.find(
-      ([, args]) => typeof args === "object" && args !== null && "packageId" in args && "tokenHash" in args,
+      ([, args]) =>
+        typeof args === "object" && args !== null && "packageId" in args && "tokenHash" in args,
     );
     expect(createCall?.[1]).toEqual(
       expect.objectContaining({
@@ -3786,7 +3793,9 @@ describe("httpApiV1 handlers", () => {
     );
 
     if (response.status !== 200) throw new Error(await response.text());
-    expect(fetchGitHubRepositoryIdentity).toHaveBeenCalledWith("https://github.com/openclaw/openclaw");
+    expect(fetchGitHubRepositoryIdentity).toHaveBeenCalledWith(
+      "https://github.com/openclaw/openclaw",
+    );
     expect(runMutation).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -3843,7 +3852,9 @@ describe("httpApiV1 handlers", () => {
     );
 
     if (response.status !== 200) throw new Error(await response.text());
-    expect(fetchGitHubRepositoryIdentity).toHaveBeenCalledWith("https://github.com/openclaw/openclaw");
+    expect(fetchGitHubRepositoryIdentity).toHaveBeenCalledWith(
+      "https://github.com/openclaw/openclaw",
+    );
     expect(await response.json()).toEqual({
       trustedPublisher: {
         provider: "github-actions",
@@ -3855,7 +3866,8 @@ describe("httpApiV1 handlers", () => {
       },
     });
     const setCall = runMutation.mock.calls.find(
-      ([, args]) => typeof args === "object" && args !== null && "packageName" in args && "actorUserId" in args,
+      ([, args]) =>
+        typeof args === "object" && args !== null && "packageName" in args && "actorUserId" in args,
     );
     expect(setCall?.[1]).toEqual(
       expect.objectContaining({

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -8,17 +8,17 @@ import {
 import { api, internal } from "../_generated/api";
 import type { Doc, Id } from "../_generated/dataModel";
 import type { ActionCtx } from "../_generated/server";
+import { getOptionalApiTokenUserId } from "../lib/apiTokenAuth";
 import {
   fetchGitHubRepositoryIdentity,
   verifyGitHubActionsTrustedPublishJwt,
 } from "../lib/githubActionsOidc";
-import { getOptionalApiTokenUserId } from "../lib/apiTokenAuth";
 import { corsHeaders, mergeHeaders } from "../lib/httpHeaders";
+import { applyRateLimit } from "../lib/httpRateLimit";
 import { getPackageDownloadSecurityBlock } from "../lib/packageSecurity";
 import { getPublishFileSizeError, MAX_PUBLISH_FILE_BYTES } from "../lib/publishLimits";
-import { applyRateLimit } from "../lib/httpRateLimit";
-import { buildDeterministicPackageZip } from "../lib/skillZip";
 import { isMacJunkPath, isTextFile } from "../lib/skills";
+import { buildDeterministicPackageZip } from "../lib/skillZip";
 import { generateToken, hashToken } from "../lib/tokens";
 import {
   MAX_RAW_FILE_BYTES,
@@ -206,9 +206,13 @@ async function resolvePackageTags(
 ): Promise<Record<string, string>> {
   const releaseIds = Object.values(tags);
   if (releaseIds.length === 0) return {};
-  const releases = await runQueryRef<ReleaseLike[]>(ctx, internalRefs.packages.getReleasesByIdsInternal, {
-    releaseIds,
-  });
+  const releases = await runQueryRef<ReleaseLike[]>(
+    ctx,
+    internalRefs.packages.getReleasesByIdsInternal,
+    {
+      releaseIds,
+    },
+  );
   const byId = new Map(releases.map((release) => [release._id, release.version]));
   return Object.fromEntries(
     Object.entries(tags)
@@ -279,8 +283,12 @@ function decodeUnifiedCatalogCursor(raw: string | null | undefined): UnifiedCata
     };
   }
   try {
-    const parsed = JSON.parse(raw.slice(UNIFIED_CATALOG_CURSOR_PREFIX.length)) as Partial<UnifiedCatalogCursorState>;
-    const normalize = (input: Partial<CatalogSourceCursorState> | undefined): CatalogSourceCursorState => ({
+    const parsed = JSON.parse(
+      raw.slice(UNIFIED_CATALOG_CURSOR_PREFIX.length),
+    ) as Partial<UnifiedCatalogCursorState>;
+    const normalize = (
+      input: Partial<CatalogSourceCursorState> | undefined,
+    ): CatalogSourceCursorState => ({
       cursor: typeof input?.cursor === "string" ? input.cursor : null,
       offset: typeof input?.offset === "number" && input.offset > 0 ? input.offset : 0,
       pageSize: typeof input?.pageSize === "number" && input.pageSize > 0 ? input.pageSize : null,
@@ -475,7 +483,9 @@ async function parseMultipartPackagePublish(ctx: ActionCtx, request: Request) {
     }
     const buffer = new Uint8Array(await entry.arrayBuffer());
     const digest = await crypto.subtle.digest("SHA-256", buffer);
-    const sha256 = Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+    const sha256 = Array.from(new Uint8Array(digest), (byte) =>
+      byte.toString(16).padStart(2, "0"),
+    ).join("");
     const storageId = await ctx.storage.store(entry);
     files.push({
       path: entry.name,
@@ -588,7 +598,10 @@ async function listPackages(
       ]);
 
       if (!packageCandidate && !skillCandidate) break;
-      if (!skillCandidate || (packageCandidate && compareCatalogItems(packageCandidate, skillCandidate) <= 0)) {
+      if (
+        !skillCandidate ||
+        (packageCandidate && compareCatalogItems(packageCandidate, skillCandidate) <= 0)
+      ) {
         items.push(packageCandidate!);
         packageSource.index += 1;
       } else {
@@ -681,9 +694,13 @@ export async function publishPackageV1Handler(ctx: ActionCtx, request: Request) 
 }
 
 async function getPackageAndTrustedPublisherByName(ctx: ActionCtx, packageName: string) {
-  const pkg = await runQueryRef<Doc<"packages"> | null>(ctx, internalRefs.packages.getPackageByNameInternal, {
-    name: packageName,
-  });
+  const pkg = await runQueryRef<Doc<"packages"> | null>(
+    ctx,
+    internalRefs.packages.getPackageByNameInternal,
+    {
+      name: packageName,
+    },
+  );
   if (!pkg || pkg.softDeletedAt) return { pkg: null, trustedPublisher: null };
   const trustedPublisher = await runQueryRef<PackageTrustedPublisherLike | null>(
     ctx,
@@ -701,12 +718,19 @@ export async function mintPublishTokenV1Handler(ctx: ActionCtx, request: Request
   if (!parsedBody) return text("Invalid JSON", 400, rate.headers);
 
   try {
-    const payload = parseArk(PublishTokenMintRequestSchema, parsedBody, "Publish token mint payload") as {
+    const payload = parseArk(
+      PublishTokenMintRequestSchema,
+      parsedBody,
+      "Publish token mint payload",
+    ) as {
       packageName: string;
       version: string;
       githubOidcToken: string;
     };
-    const { pkg, trustedPublisher } = await getPackageAndTrustedPublisherByName(ctx, payload.packageName);
+    const { pkg, trustedPublisher } = await getPackageAndTrustedPublisherByName(
+      ctx,
+      payload.packageName,
+    );
     if (!pkg) return text("Package not found", 404, rate.headers);
     if (!trustedPublisher) {
       return text("Trusted publisher config is not set for this package", 403, rate.headers);
@@ -725,60 +749,69 @@ export async function mintPublishTokenV1Handler(ctx: ActionCtx, request: Request
       const tokenHash = await hashToken(token);
       const expiresAt = Date.now() + 15 * 60_000;
 
-      await ctx.runMutation(internalRefs.packagePublishTokens.createInternal as never, {
-        packageId: pkg._id,
-        version: payload.version,
-        prefix,
-        tokenHash,
-        provider: "github-actions",
-        repository: verified.repository,
-        repositoryId: verified.repositoryId,
-        repositoryOwner: verified.repositoryOwner,
-        repositoryOwnerId: verified.repositoryOwnerId,
-        workflowFilename: verified.workflowFilename,
-        ...(trustedPublisher.environment ? { environment: trustedPublisher.environment } : {}),
-        runId: verified.runId,
-        runAttempt: verified.runAttempt,
-        sha: verified.sha,
-        ref: verified.ref,
-        ...(verified.refType ? { refType: verified.refType } : {}),
-        ...(verified.actor ? { actor: verified.actor } : {}),
-        ...(verified.actorId ? { actorId: verified.actorId } : {}),
-        expiresAt,
-      } as never);
-      await ctx.runMutation(internalRefs.packages.insertAuditLogInternal as never, {
-        actorUserId: pkg.ownerUserId,
-        action: "package.publish_token.mint",
-        targetType: "package",
-        targetId: String(pkg._id),
-        metadata: {
+      await ctx.runMutation(
+        internalRefs.packagePublishTokens.createInternal as never,
+        {
+          packageId: pkg._id,
           version: payload.version,
+          prefix,
+          tokenHash,
+          provider: "github-actions",
           repository: verified.repository,
+          repositoryId: verified.repositoryId,
+          repositoryOwner: verified.repositoryOwner,
+          repositoryOwnerId: verified.repositoryOwnerId,
           workflowFilename: verified.workflowFilename,
-          ...(verified.environment ? { environment: verified.environment } : {}),
+          ...(trustedPublisher.environment ? { environment: trustedPublisher.environment } : {}),
           runId: verified.runId,
           runAttempt: verified.runAttempt,
           sha: verified.sha,
           ref: verified.ref,
-          decision: "allowed",
-        },
-      } as never);
+          ...(verified.refType ? { refType: verified.refType } : {}),
+          ...(verified.actor ? { actor: verified.actor } : {}),
+          ...(verified.actorId ? { actorId: verified.actorId } : {}),
+          expiresAt,
+        } as never,
+      );
+      await ctx.runMutation(
+        internalRefs.packages.insertAuditLogInternal as never,
+        {
+          actorUserId: pkg.ownerUserId,
+          action: "package.publish_token.mint",
+          targetType: "package",
+          targetId: String(pkg._id),
+          metadata: {
+            version: payload.version,
+            repository: verified.repository,
+            workflowFilename: verified.workflowFilename,
+            ...(verified.environment ? { environment: verified.environment } : {}),
+            runId: verified.runId,
+            runAttempt: verified.runAttempt,
+            sha: verified.sha,
+            ref: verified.ref,
+            decision: "allowed",
+          },
+        } as never,
+      );
       return json({ token, expiresAt }, 200, rate.headers);
     } catch (error) {
-      await ctx.runMutation(internalRefs.packages.insertAuditLogInternal as never, {
-        actorUserId: pkg.ownerUserId,
-        action: "package.publish_token.mint_rejected",
-        targetType: "package",
-        targetId: String(pkg._id),
-        metadata: {
-          version: payload.version,
-          repository: trustedPublisher.repository,
-          workflowFilename: trustedPublisher.workflowFilename,
-          ...(trustedPublisher.environment ? { environment: trustedPublisher.environment } : {}),
-          decision: "rejected",
-          reason: error instanceof Error ? error.message : "Token verification failed",
-        },
-      } as never);
+      await ctx.runMutation(
+        internalRefs.packages.insertAuditLogInternal as never,
+        {
+          actorUserId: pkg.ownerUserId,
+          action: "package.publish_token.mint_rejected",
+          targetType: "package",
+          targetId: String(pkg._id),
+          metadata: {
+            version: payload.version,
+            repository: trustedPublisher.repository,
+            workflowFilename: trustedPublisher.workflowFilename,
+            ...(trustedPublisher.environment ? { environment: trustedPublisher.environment } : {}),
+            decision: "rejected",
+            reason: error instanceof Error ? error.message : "Token verification failed",
+          },
+        } as never,
+      );
       throw error;
     }
   } catch (error) {
@@ -821,9 +854,17 @@ export async function packagesPostRouterV1Handler(ctx: ActionCtx, request: Reque
         ...(body.environment ? { environment: body.environment } : {}),
       },
     );
-    return json({ trustedPublisher: toPublicTrustedPublisher(trustedPublisher) }, 200, rate.headers);
+    return json(
+      { trustedPublisher: toPublicTrustedPublisher(trustedPublisher) },
+      200,
+      rate.headers,
+    );
   } catch (error) {
-    return text(error instanceof Error ? error.message : "Trusted publisher update failed", 400, rate.headers);
+    return text(
+      error instanceof Error ? error.message : "Trusted publisher update failed",
+      400,
+      rate.headers,
+    );
   }
 }
 
@@ -844,7 +885,11 @@ export async function packagesDeleteRouterV1Handler(ctx: ActionCtx, request: Req
     });
     return json({ ok: true }, 200, rate.headers);
   } catch (error) {
-    return text(error instanceof Error ? error.message : "Trusted publisher delete failed", 400, rate.headers);
+    return text(
+      error instanceof Error ? error.message : "Trusted publisher delete failed",
+      400,
+      rate.headers,
+    );
   }
 }
 
@@ -889,9 +934,7 @@ async function getReleaseForRequest(
 function isReadmeVariantPath(path: string) {
   const normalized = path.trim().toLowerCase();
   return (
-    normalized === "readme.md" ||
-    normalized === "readme.mdx" ||
-    normalized === "readme.markdown"
+    normalized === "readme.md" || normalized === "readme.mdx" || normalized === "readme.markdown"
   );
 }
 
@@ -931,13 +974,11 @@ function resolvePackageFilePath(release: ReleaseLike, requestedPath: string) {
 }
 
 async function getSkillDetailForRequest(ctx: ActionCtx, slug: string) {
-  return (await runQueryRef(ctx, apiRefs.skills.getBySlug, { slug })) as
-    | {
-        skill: SkillPackageDocLike | null;
-        latestVersion: SkillVersionLike | null;
-        owner: { handle?: string; displayName?: string; image?: string } | null;
-      }
-    | null;
+  return (await runQueryRef(ctx, apiRefs.skills.getBySlug, { slug })) as {
+    skill: SkillPackageDocLike | null;
+    latestVersion: SkillVersionLike | null;
+    owner: { handle?: string; displayName?: string; image?: string } | null;
+  } | null;
 }
 
 async function getSkillVersionForRequest(
@@ -1002,25 +1043,33 @@ async function searchPackages(
 
   let results: CatalogSearchEntry[];
   if (family === "skill") {
-    results = await runQueryRef<CatalogSearchEntry[]>(ctx, apiRefs.skills.searchPackageCatalogPublic, {
-      query: queryText,
-      limit,
-      channel,
-      isOfficial,
-      executesCode,
-      capabilityTag,
-    });
+    results = await runQueryRef<CatalogSearchEntry[]>(
+      ctx,
+      apiRefs.skills.searchPackageCatalogPublic,
+      {
+        query: queryText,
+        limit,
+        channel,
+        isOfficial,
+        executesCode,
+        capabilityTag,
+      },
+    );
   } else if (family || !includeSkills) {
-    results = await runQueryRef<CatalogSearchEntry[]>(ctx, internalRefs.packages.searchForViewerInternal, {
-      query: queryText,
-      limit,
-      family,
-      channel,
-      isOfficial,
-      executesCode,
-      capabilityTag,
-      viewerUserId: viewerUserId ?? undefined,
-    });
+    results = await runQueryRef<CatalogSearchEntry[]>(
+      ctx,
+      internalRefs.packages.searchForViewerInternal,
+      {
+        query: queryText,
+        limit,
+        family,
+        channel,
+        isOfficial,
+        executesCode,
+        capabilityTag,
+        viewerUserId: viewerUserId ?? undefined,
+      },
+    );
   } else {
     const [packageResults, skillResults] = await Promise.all([
       runQueryRef<CatalogSearchEntry[]>(ctx, internalRefs.packages.searchForViewerInternal, {
@@ -1073,20 +1122,14 @@ export async function packagesGetRouterV1Handler(ctx: ActionCtx, request: Reques
 
   const packageName = segments[0] ?? "";
   const viewerUserId = await getOptionalViewerUserIdForRequest(ctx, request);
-  const detail = (await runQueryRef(
-    ctx,
-    internalRefs.packages.getByNameForViewerInternal,
-    {
-      name: packageName,
-      viewerUserId: viewerUserId ?? undefined,
-    },
-  )) as
-    | {
-        package: PublicPackageDocLike | null;
-        latestRelease: ReleaseLike | null;
-        owner: { _id: Id<"users">; handle?: string; displayName?: string; image?: string } | null;
-      }
-    | null;
+  const detail = (await runQueryRef(ctx, internalRefs.packages.getByNameForViewerInternal, {
+    name: packageName,
+    viewerUserId: viewerUserId ?? undefined,
+  })) as {
+    package: PublicPackageDocLike | null;
+    latestRelease: ReleaseLike | null;
+    owner: { _id: Id<"users">; handle?: string; displayName?: string; image?: string } | null;
+  } | null;
   const skillDetail = detail?.package ? null : await getSkillDetailForRequest(ctx, packageName);
   if (!detail?.package && !skillDetail?.skill) return text("Package not found", 404, rate.headers);
   const packageDetail = detail?.package ? detail : null;
@@ -1106,19 +1149,23 @@ export async function packagesGetRouterV1Handler(ctx: ActionCtx, request: Reques
         rate.headers,
       );
     }
-    return json({
-      package: {
-        ...publicPackage!,
-        tags: await resolvePackageTags(ctx, publicPackage!.tags),
+    return json(
+      {
+        package: {
+          ...publicPackage!,
+          tags: await resolvePackageTags(ctx, publicPackage!.tags),
+        },
+        owner: packageOwner
+          ? {
+              handle: packageOwner.handle ?? null,
+              displayName: packageOwner.displayName ?? null,
+              image: packageOwner.image ?? null,
+            }
+          : null,
       },
-      owner: packageOwner
-        ? {
-            handle: packageOwner.handle ?? null,
-            displayName: packageOwner.displayName ?? null,
-            image: packageOwner.image ?? null,
-          }
-        : null,
-    }, 200, rate.headers);
+      200,
+      rate.headers,
+    );
   }
 
   if (segments[1] === "trusted-publisher" && segments.length === 2) {
@@ -1128,11 +1175,18 @@ export async function packagesGetRouterV1Handler(ctx: ActionCtx, request: Reques
       internalRefs.packages.getTrustedPublisherByPackageIdInternal,
       { packageId: publicPackage._id },
     );
-    return json({ trustedPublisher: toPublicTrustedPublisher(trustedPublisher) }, 200, rate.headers);
+    return json(
+      { trustedPublisher: toPublicTrustedPublisher(trustedPublisher) },
+      200,
+      rate.headers,
+    );
   }
 
   if (segments[1] === "versions" && segments.length === 2) {
-    const limit = Math.max(1, Math.min(toOptionalNumber(new URL(request.url).searchParams.get("limit")) ?? 25, 100));
+    const limit = Math.max(
+      1,
+      Math.min(toOptionalNumber(new URL(request.url).searchParams.get("limit")) ?? 25, 100),
+    );
     const cursor = new URL(request.url).searchParams.get("cursor");
     if (skillDetail?.skill) {
       const result = (await runQueryRef(ctx, apiRefs.skills.listVersionsPage, {
@@ -1144,15 +1198,19 @@ export async function packagesGetRouterV1Handler(ctx: ActionCtx, request: Reques
         nextCursor: string | null;
       };
       const tags = await resolveSkillTags(ctx, skillDetail.skill.tags);
-      return json({
-        items: result.items.map((version) => ({
-          version: version.version,
-          createdAt: version.createdAt,
-          changelog: version.changelog,
-          distTags: skillVersionTags(tags, version.version),
-        })),
-        nextCursor: result.nextCursor,
-      }, 200, rate.headers);
+      return json(
+        {
+          items: result.items.map((version) => ({
+            version: version.version,
+            createdAt: version.createdAt,
+            changelog: version.changelog,
+            distTags: skillVersionTags(tags, version.version),
+          })),
+          nextCursor: result.nextCursor,
+        },
+        200,
+        rate.headers,
+      );
     }
     const result = await runQueryRef<{
       page: ReleaseLike[];
@@ -1163,47 +1221,59 @@ export async function packagesGetRouterV1Handler(ctx: ActionCtx, request: Reques
       viewerUserId: viewerUserId ?? undefined,
       paginationOpts: { cursor, numItems: limit },
     });
-    return json({
-      items: result.page.map((release: ReleaseLike) => ({
-        version: release.version,
-        createdAt: release.createdAt,
-        changelog: release.changelog,
-        distTags: release.distTags ?? [],
-      })),
-      nextCursor: result.isDone ? null : result.continueCursor,
-    }, 200, rate.headers);
+    return json(
+      {
+        items: result.page.map((release: ReleaseLike) => ({
+          version: release.version,
+          createdAt: release.createdAt,
+          changelog: release.changelog,
+          distTags: release.distTags ?? [],
+        })),
+        nextCursor: result.isDone ? null : result.continueCursor,
+      },
+      200,
+      rate.headers,
+    );
   }
 
   if (segments[1] === "versions" && segments[2]) {
     if (skillDetail?.skill) {
-      const version = (await runQueryRef(ctx, internalRefs.skills.getVersionBySkillAndVersionInternal, {
-        skillId: skillDetail.skill._id,
-        version: segments[2],
-      })) as SkillVersionLike | null;
+      const version = (await runQueryRef(
+        ctx,
+        internalRefs.skills.getVersionBySkillAndVersionInternal,
+        {
+          skillId: skillDetail.skill._id,
+          version: segments[2],
+        },
+      )) as SkillVersionLike | null;
       if (!version || version.softDeletedAt) return text("Version not found", 404, rate.headers);
       const tags = await resolveSkillTags(ctx, skillDetail.skill.tags);
-      return json({
-        package: {
-          name: skillDetail.skill.slug,
-          displayName: skillDetail.skill.displayName,
-          family: "skill",
+      return json(
+        {
+          package: {
+            name: skillDetail.skill.slug,
+            displayName: skillDetail.skill.displayName,
+            family: "skill",
+          },
+          version: {
+            version: version.version,
+            createdAt: version.createdAt,
+            changelog: version.changelog,
+            distTags: skillVersionTags(tags, version.version),
+            files: version.files.map((file) => ({
+              path: file.path,
+              size: file.size,
+              sha256: file.sha256,
+              contentType: file.contentType,
+            })),
+            compatibility: null,
+            capabilities: null,
+            verification: null,
+          },
         },
-        version: {
-          version: version.version,
-          createdAt: version.createdAt,
-          changelog: version.changelog,
-          distTags: skillVersionTags(tags, version.version),
-          files: version.files.map((file) => ({
-            path: file.path,
-            size: file.size,
-            sha256: file.sha256,
-            contentType: file.contentType,
-          })),
-          compatibility: null,
-          capabilities: null,
-          verification: null,
-        },
-      }, 200, rate.headers);
+        200,
+        rate.headers,
+      );
     }
     const result = (await runQueryRef(
       ctx,
@@ -1215,32 +1285,36 @@ export async function packagesGetRouterV1Handler(ctx: ActionCtx, request: Reques
       },
     )) as { package: PublicPackageDocLike; version: ReleaseLike } | null;
     if (!result) return text("Version not found", 404, rate.headers);
-    return json({
-      package: {
-        name: result.package.name,
-        displayName: result.package.displayName,
-        family: result.package.family,
+    return json(
+      {
+        package: {
+          name: result.package.name,
+          displayName: result.package.displayName,
+          family: result.package.family,
+        },
+        version: {
+          version: result.version.version,
+          createdAt: result.version.createdAt,
+          changelog: result.version.changelog,
+          distTags: result.version.distTags ?? [],
+          files: result.version.files.map((file) => ({
+            path: file.path,
+            size: file.size,
+            sha256: file.sha256,
+            contentType: file.contentType,
+          })),
+          compatibility: result.version.compatibility ?? null,
+          capabilities: result.version.capabilities ?? null,
+          verification: result.version.verification ?? null,
+          sha256hash: result.version.sha256hash ?? null,
+          vtAnalysis: result.version.vtAnalysis ?? null,
+          llmAnalysis: result.version.llmAnalysis ?? null,
+          staticScan: result.version.staticScan ?? null,
+        },
       },
-      version: {
-        version: result.version.version,
-        createdAt: result.version.createdAt,
-        changelog: result.version.changelog,
-        distTags: result.version.distTags ?? [],
-        files: result.version.files.map((file) => ({
-          path: file.path,
-          size: file.size,
-          sha256: file.sha256,
-          contentType: file.contentType,
-        })),
-        compatibility: result.version.compatibility ?? null,
-        capabilities: result.version.capabilities ?? null,
-        verification: result.version.verification ?? null,
-        sha256hash: result.version.sha256hash ?? null,
-        vtAnalysis: result.version.vtAnalysis ?? null,
-        llmAnalysis: result.version.llmAnalysis ?? null,
-        staticScan: result.version.staticScan ?? null,
-      },
-    }, 200, rate.headers);
+      200,
+      rate.headers,
+    );
   }
 
   if (segments[1] === "file") {
@@ -1251,7 +1325,8 @@ export async function packagesGetRouterV1Handler(ctx: ActionCtx, request: Reques
       if (!version || version.softDeletedAt) return text("Version not found", 404, rate.headers);
       const file = resolveSkillFilePath(version, path);
       if (!file) return text("File not found", 404, rate.headers);
-      if (!("storageId" in file) || !file.storageId) return text("File not found", 404, rate.headers);
+      if (!("storageId" in file) || !file.storageId)
+        return text("File not found", 404, rate.headers);
       if (!isTextFile(file.path, file.contentType)) {
         return text("Binary files are not served inline", 415, rate.headers);
       }

--- a/convex/httpApiV1/usersV1.ts
+++ b/convex/httpApiV1/usersV1.ts
@@ -236,9 +236,9 @@ async function handleAdminEnsurePublisher(
   const handle = typeof payload.handle === "string" ? payload.handle.trim().toLowerCase() : "";
   if (!handle) return text("Missing handle", 400, headers);
 
-  const displayName = typeof payload.displayName === "string" ? payload.displayName.trim() : undefined;
-  const trusted =
-    typeof payload.trusted === "boolean" ? payload.trusted : true;
+  const displayName =
+    typeof payload.displayName === "string" ? payload.displayName.trim() : undefined;
+  const trusted = typeof payload.trusted === "boolean" ? payload.trusted : true;
 
   try {
     const result = await ctx.runMutation(internal.publishers.ensureOrgPublisherHandleInternal, {

--- a/convex/lib/apiTokenAuth.ts
+++ b/convex/lib/apiTokenAuth.ts
@@ -38,17 +38,26 @@ export async function requireApiTokenUser(
   if (!token) throw new ConvexError("Unauthorized");
 
   const tokenHash = await hashToken(token);
-  const apiToken = (await ctx.runQuery(internalRefs.tokens.getByHashInternal as never, {
-    tokenHash,
-  } as never)) as ApiTokenDoc | null;
+  const apiToken = (await ctx.runQuery(
+    internalRefs.tokens.getByHashInternal as never,
+    {
+      tokenHash,
+    } as never,
+  )) as ApiTokenDoc | null;
   if (!apiToken || apiToken.revokedAt) throw new ConvexError("Unauthorized");
 
-  const user = (await ctx.runQuery(internalRefs.tokens.getUserForTokenInternal as never, {
-    tokenId: apiToken._id,
-  } as never)) as Doc<"users"> | null;
+  const user = (await ctx.runQuery(
+    internalRefs.tokens.getUserForTokenInternal as never,
+    {
+      tokenId: apiToken._id,
+    } as never,
+  )) as Doc<"users"> | null;
   if (!user || user.deletedAt || user.deactivatedAt) throw new ConvexError("Unauthorized");
 
-  await ctx.runMutation(internalRefs.tokens.touchInternal as never, { tokenId: apiToken._id } as never);
+  await ctx.runMutation(
+    internalRefs.tokens.touchInternal as never,
+    { tokenId: apiToken._id } as never,
+  );
   return { user, userId: user._id };
 }
 
@@ -61,14 +70,20 @@ export async function getOptionalApiTokenUserId(
   if (!token) return null;
 
   const tokenHash = await hashToken(token);
-  const apiToken = (await ctx.runQuery(internalRefs.tokens.getByHashInternal as never, {
-    tokenHash,
-  } as never)) as ApiTokenDoc | null;
+  const apiToken = (await ctx.runQuery(
+    internalRefs.tokens.getByHashInternal as never,
+    {
+      tokenHash,
+    } as never,
+  )) as ApiTokenDoc | null;
   if (!apiToken || apiToken.revokedAt) return null;
 
-  const user = (await ctx.runQuery(internalRefs.tokens.getUserForTokenInternal as never, {
-    tokenId: apiToken._id,
-  } as never)) as Doc<"users"> | null;
+  const user = (await ctx.runQuery(
+    internalRefs.tokens.getUserForTokenInternal as never,
+    {
+      tokenId: apiToken._id,
+    } as never,
+  )) as Doc<"users"> | null;
   if (!user || user.deletedAt || user.deactivatedAt) return null;
 
   return user._id;
@@ -90,9 +105,12 @@ export async function requirePackagePublishAuth(
     } as never,
   )) as PackagePublishTokenDoc | null;
   if (publishToken && !publishToken.revokedAt && publishToken.expiresAt > Date.now()) {
-    await ctx.runMutation(internalRefs.packagePublishTokens.touchInternal as never, {
-      tokenId: publishToken._id,
-    } as never);
+    await ctx.runMutation(
+      internalRefs.packagePublishTokens.touchInternal as never,
+      {
+        tokenId: publishToken._id,
+      } as never,
+    );
     return { kind: "github-actions", publishToken };
   }
 

--- a/convex/lib/githubActionsOidc.test.ts
+++ b/convex/lib/githubActionsOidc.test.ts
@@ -112,13 +112,17 @@ describe("verifyGitHubActionsTrustedPublishJwt", () => {
       iat: Math.floor(Date.now() / 1000) - 5,
     });
 
-    const identity = await verifyGitHubActionsTrustedPublishJwt(token, trustedPublisherWithoutEnvironment, {
-      fetchImpl: async () =>
-        new Response(JSON.stringify({ keys: [jwks] }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
-    });
+    const identity = await verifyGitHubActionsTrustedPublishJwt(
+      token,
+      trustedPublisherWithoutEnvironment,
+      {
+        fetchImpl: async () =>
+          new Response(JSON.stringify({ keys: [jwks] }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      },
+    );
 
     expect(identity).toMatchObject({
       repository: trustedPublisher.repository,
@@ -160,10 +164,10 @@ describe("verifyGitHubActionsTrustedPublishJwt", () => {
     await expect(
       verifyGitHubActionsTrustedPublishJwt(token, trustedPublisher, {
         fetchImpl: async () =>
-        new Response(JSON.stringify({ keys: [jwks] }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
+          new Response(JSON.stringify({ keys: [jwks] }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
       }),
     ).rejects.toThrow("Only the official ClawHub reusable workflow is supported");
   });
@@ -303,7 +307,11 @@ async function createSignedToken(payload: Record<string, unknown>, kid = "test-k
   const encodedPayload = base64UrlEncodeJson(payload);
   const signingInput = `${encodedHeader}.${encodedPayload}`;
   const signature = new Uint8Array(
-    await crypto.subtle.sign("RSASSA-PKCS1-v1_5", keyPair.privateKey, new TextEncoder().encode(signingInput)),
+    await crypto.subtle.sign(
+      "RSASSA-PKCS1-v1_5",
+      keyPair.privateKey,
+      new TextEncoder().encode(signingInput),
+    ),
   );
   const publicJwk = (await crypto.subtle.exportKey("jwk", keyPair.publicKey)) as JsonWebKey & {
     kid?: string;

--- a/convex/lib/githubActionsOidc.ts
+++ b/convex/lib/githubActionsOidc.ts
@@ -135,7 +135,9 @@ export async function verifyGitHubActionsTrustedPublishJwt(
   const actorId = optionalStringValue(payload.actor_id);
 
   if (repository !== trustedPublisher.repository) {
-    throw new Error(`GitHub OIDC repository mismatch: expected ${trustedPublisher.repository}, got ${repository}`);
+    throw new Error(
+      `GitHub OIDC repository mismatch: expected ${trustedPublisher.repository}, got ${repository}`,
+    );
   }
   if (repositoryId !== trustedPublisher.repositoryId) {
     throw new Error(
@@ -169,7 +171,9 @@ export async function verifyGitHubActionsTrustedPublishJwt(
     }
   }
   if (runnerEnvironment !== "github-hosted") {
-    throw new Error(`Only GitHub-hosted runners may mint trusted publish tokens, got ${runnerEnvironment}`);
+    throw new Error(
+      `Only GitHub-hosted runners may mint trusted publish tokens, got ${runnerEnvironment}`,
+    );
   }
   // v1 keeps secretless publishing behind a manual entry point. Environment
   // pinning is optional, but if configured it must match exactly.
@@ -219,7 +223,9 @@ export async function fetchGitHubRepositoryIdentity(
     },
   });
   if (!response.ok) {
-    throw new Error(`GitHub repository lookup failed for ${normalizedRepository}: ${response.status}`);
+    throw new Error(
+      `GitHub repository lookup failed for ${normalizedRepository}: ${response.status}`,
+    );
   }
   const body = (await response.json()) as {
     id?: unknown;
@@ -237,13 +243,19 @@ export async function fetchGitHubRepositoryIdentity(
 }
 
 export function normalizeGitHubRepository(repository: string) {
-  const trimmed = repository.trim().replace(/^https?:\/\/github\.com\//i, "").replace(/\.git$/i, "");
+  const trimmed = repository
+    .trim()
+    .replace(/^https?:\/\/github\.com\//i, "")
+    .replace(/\.git$/i, "");
   const match = /^([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)$/.exec(trimmed);
   if (!match) return null;
   return `${match[1]}/${match[2]}`;
 }
 
-export function extractWorkflowFilenameFromWorkflowRef(workflowRef: string, expectedRepository?: string) {
+export function extractWorkflowFilenameFromWorkflowRef(
+  workflowRef: string,
+  expectedRepository?: string,
+) {
   return parseWorkflowRef(workflowRef, expectedRepository).workflowFilename;
 }
 
@@ -338,7 +350,8 @@ function assertTokenTimeWindow(payload: JwtPayload, now: number) {
   if (now - CLOCK_SKEW_MS >= expiresAt) {
     throw new Error("GitHub OIDC token has expired");
   }
-  const notBefore = payload.nbf === undefined ? undefined : requireNumericClaim(payload.nbf, "nbf") * 1000;
+  const notBefore =
+    payload.nbf === undefined ? undefined : requireNumericClaim(payload.nbf, "nbf") * 1000;
   if (typeof notBefore === "number" && now + CLOCK_SKEW_MS < notBefore) {
     throw new Error("GitHub OIDC token is not active yet");
   }

--- a/convex/lib/packageRegistry.test.ts
+++ b/convex/lib/packageRegistry.test.ts
@@ -139,9 +139,9 @@ describe("packageRegistry", () => {
 
   it("validates package name consistency and summary extraction", () => {
     ensurePluginNameMatchesPackage("demo-plugin", { name: "demo-plugin" });
-    expect(() =>
-      ensurePluginNameMatchesPackage("demo-plugin", { name: "other-plugin" }),
-    ).toThrow("must match published package name");
+    expect(() => ensurePluginNameMatchesPackage("demo-plugin", { name: "other-plugin" })).toThrow(
+      "must match published package name",
+    );
 
     expect(
       summarizePackageForSearch({

--- a/convex/lib/packageRegistry.ts
+++ b/convex/lib/packageRegistry.ts
@@ -88,7 +88,10 @@ export function normalizePublishFiles(files: PublishFile[]) {
   return normalized.map((file) => ({ ...file, path: file.path as string }));
 }
 
-export function assertPackageVersion(family: "code-plugin" | "bundle-plugin" | "skill", version: string) {
+export function assertPackageVersion(
+  family: "code-plugin" | "bundle-plugin" | "skill",
+  version: string,
+) {
   const trimmed = version.trim();
   if (!trimmed) throw new ConvexError("Version required");
   if (family === "code-plugin" && !semver.valid(trimmed)) {
@@ -129,9 +132,15 @@ function parseJsonFile(text: string, label: string): JsonRecord {
   }
 }
 
-function deriveSummary(params: { packageName: string; packageJson?: JsonRecord; readmeText?: string | null }) {
+function deriveSummary(params: {
+  packageName: string;
+  packageJson?: JsonRecord;
+  readmeText?: string | null;
+}) {
   const directDescription =
-    typeof params.packageJson?.description === "string" ? params.packageJson.description.trim() : "";
+    typeof params.packageJson?.description === "string"
+      ? params.packageJson.description.trim()
+      : "";
   if (directDescription) return directDescription;
   const readme = params.readmeText?.trim() ?? "";
   if (!readme) return params.packageName;
@@ -169,7 +178,9 @@ function buildVerification(source: SourceInfo | undefined): PackageVerificationS
   };
 }
 
-function extractCompatibility(packageJson: JsonRecord | undefined): PackageCompatibility | undefined {
+function extractCompatibility(
+  packageJson: JsonRecord | undefined,
+): PackageCompatibility | undefined {
   return normalizeOpenClawExternalPluginCompatibility(packageJson);
 }
 
@@ -238,7 +249,9 @@ export function extractCodePluginArtifacts(params: {
     executesCode: true,
     runtimeId,
     pluginKind:
-      typeof params.pluginManifest.kind === "string" ? params.pluginManifest.kind.trim() : undefined,
+      typeof params.pluginManifest.kind === "string"
+        ? params.pluginManifest.kind.trim()
+        : undefined,
     channels,
     providers,
     hooks,
@@ -334,7 +347,9 @@ export function ensurePluginNameMatchesPackage(packageName: string, packageJson:
   const normalizedDeclared = normalizePackageName(declaredName);
   const normalizedExpected = normalizePackageName(packageName);
   if (normalizedDeclared !== normalizedExpected) {
-    throw new ConvexError(`package.json name must match published package name (${normalizedExpected})`);
+    throw new ConvexError(
+      `package.json name must match published package name (${normalizedExpected})`,
+    );
   }
 }
 

--- a/convex/lib/packageSearchDigest.ts
+++ b/convex/lib/packageSearchDigest.ts
@@ -145,10 +145,7 @@ export async function deletePackageSearchDigests(
 function hasDigestChanged<
   TExisting extends Record<string, unknown>,
   TFields extends Record<string, unknown>,
->(
-  existing: TExisting,
-  fields: TFields,
-): boolean {
+>(existing: TExisting, fields: TFields): boolean {
   for (const key of Object.keys(fields)) {
     const oldValue = (existing as Record<string, unknown>)[key];
     const newValue = (fields as Record<string, unknown>)[key];

--- a/convex/lib/packageSecurity.ts
+++ b/convex/lib/packageSecurity.ts
@@ -52,7 +52,8 @@ export function getPackageDownloadSecurityBlock(release: PackageReleaseSecurityL
   if (scanStatus === "malicious") {
     return {
       status: 403,
-      message: "Blocked: this package release has been flagged as malicious and cannot be downloaded.",
+      message:
+        "Blocked: this package release has been flagged as malicious and cannot be downloaded.",
     };
   }
 

--- a/convex/lib/publishers.ts
+++ b/convex/lib/publishers.ts
@@ -18,8 +18,7 @@ function derivePersonalPublisherHandle(user: Doc<"users">) {
   const emailLocalPart = user.email?.split("@")[0];
   const userIdSuffix = String(user._id).split(":").pop();
   return (
-    normalizePublisherHandle(user.handle ?? user.name ?? emailLocalPart ?? userIdSuffix) ??
-    "user"
+    normalizePublisherHandle(user.handle ?? user.name ?? emailLocalPart ?? userIdSuffix) ?? "user"
   );
 }
 
@@ -27,7 +26,8 @@ function synthesizePersonalPublisher(user: Doc<"users">): Doc<"publishers"> {
   const handle = derivePersonalPublisherHandle(user);
   const now = user.updatedAt ?? user.createdAt ?? user._creationTime;
   return {
-    _id: (user.personalPublisherId ?? (`publishers:${handle}` as Id<"publishers">)) as Id<"publishers">,
+    _id: (user.personalPublisherId ??
+      (`publishers:${handle}` as Id<"publishers">)) as Id<"publishers">,
     _creationTime: user._creationTime,
     kind: "user",
     handle,
@@ -43,10 +43,7 @@ function synthesizePersonalPublisher(user: Doc<"users">): Doc<"publishers"> {
   };
 }
 
-export async function getPersonalPublisherForUserOrFallback(
-  ctx: DbCtx,
-  user: Doc<"users">,
-) {
+export async function getPersonalPublisherForUserOrFallback(ctx: DbCtx, user: Doc<"users">) {
   if (user.personalPublisherId) {
     const publisher = await ctx.db.get(user.personalPublisherId);
     if (isPublisherActive(publisher)) return publisher;
@@ -80,10 +77,7 @@ export function isPublisherRoleAllowed(role: PublisherRole, allowed: PublisherRo
   return allowed.some((candidate) => ranks[role] >= ranks[candidate]);
 }
 
-export async function getPublisherByHandle(
-  ctx: DbCtx,
-  handle: string | undefined | null,
-) {
+export async function getPublisherByHandle(ctx: DbCtx, handle: string | undefined | null) {
   const normalized = normalizePublisherHandle(handle);
   if (!normalized) return null;
   try {
@@ -111,7 +105,12 @@ export async function getUserByHandleOrPersonalPublisher(
   if (user) return user;
 
   const publisher = await getPublisherByHandle(ctx, normalized);
-  if (!publisher || !isPublisherActive(publisher) || publisher.kind !== "user" || !publisher.linkedUserId) {
+  if (
+    !publisher ||
+    !isPublisherActive(publisher) ||
+    publisher.kind !== "user" ||
+    !publisher.linkedUserId
+  ) {
     return null;
   }
 
@@ -127,10 +126,7 @@ export async function getActiveUserByHandleOrPersonalPublisher(
   return user;
 }
 
-export async function getPersonalPublisherForUser(
-  ctx: DbCtx,
-  userId: Id<"users">,
-) {
+export async function getPersonalPublisherForUser(ctx: DbCtx, userId: Id<"users">) {
   try {
     return await ctx.db
       .query("publishers")
@@ -149,10 +145,9 @@ export async function ensurePersonalPublisherForUser(
   const handle = derivePersonalPublisherHandle(user);
   let existing: Doc<"publishers"> | null = null;
   try {
-    existing =
-      user.personalPublisherId
-        ? await ctx.db.get(user.personalPublisherId)
-        : await getPersonalPublisherForUser(ctx, user._id);
+    existing = user.personalPublisherId
+      ? await ctx.db.get(user.personalPublisherId)
+      : await getPersonalPublisherForUser(ctx, user._id);
   } catch (error) {
     if (!isMissingPublisherTableError(error)) throw error;
     return synthesizePersonalPublisher(user);
@@ -240,7 +235,9 @@ export async function ensurePersonalPublisherForUser(
 
     const existingMember = await ctx.db
       .query("publisherMembers")
-      .withIndex("by_publisher_user", (q) => q.eq("publisherId", publisherId).eq("userId", user._id))
+      .withIndex("by_publisher_user", (q) =>
+        q.eq("publisherId", publisherId).eq("userId", user._id),
+      )
       .unique();
     if (!existingMember) {
       await ctx.db.insert("publisherMembers", {

--- a/convex/lib/skillPublish.ts
+++ b/convex/lib/skillPublish.ts
@@ -9,6 +9,13 @@ import { generateEmbedding } from "./embeddings";
 import { requireGitHubAccountAge } from "./githubAccount";
 import type { PublicUser } from "./public";
 import {
+  findOversizedPublishFile,
+  getPublishFileSizeError,
+  getPublishTotalSizeError,
+  MAX_PUBLISH_TOTAL_BYTES,
+} from "./publishLimits";
+import { deriveSkillCapabilityTags } from "./skillCapabilityTags";
+import {
   computeQualitySignals,
   evaluateQuality,
   getTrustTier,
@@ -27,15 +34,8 @@ import {
   sanitizePath,
 } from "./skills";
 import { generateSkillSummary } from "./skillSummary";
-import { deriveSkillCapabilityTags } from "./skillCapabilityTags";
 import { runStaticPublishScan } from "./staticPublishScan";
 import type { WebhookSkillPayload } from "./webhooks";
-import {
-  findOversizedPublishFile,
-  getPublishFileSizeError,
-  getPublishTotalSizeError,
-  MAX_PUBLISH_TOTAL_BYTES,
-} from "./publishLimits";
 
 const MAX_FILES_FOR_EMBEDDING = 40;
 const QUALITY_WINDOW_MS = 24 * 60 * 60 * 1000;

--- a/convex/lib/skillSearchDigest.ts
+++ b/convex/lib/skillSearchDigest.ts
@@ -122,8 +122,7 @@ export function digestToOwnerInfo(
   // Empty string means backfilled but owner has no handle.
   // Use userId as fallback handle, matching the live getOwnerInfo path.
   const handle = digest.ownerHandle || undefined;
-  const fallbackHandle =
-    handle ?? String(digest.ownerPublisherId ?? digest.ownerUserId);
+  const fallbackHandle = handle ?? String(digest.ownerPublisherId ?? digest.ownerUserId);
   const resolvedHandle = handle ?? fallbackHandle;
   // Determine if we have real profile data (deactivated/deleted owners have
   // all profile fields undefined, while handle-less visible owners still have

--- a/convex/lib/skillZip.test.ts
+++ b/convex/lib/skillZip.test.ts
@@ -150,7 +150,10 @@ describe("skillZip", () => {
       ]);
       const unzipped = unzipSync(zip);
 
-      expect(Object.keys(unzipped).sort()).toEqual(["package/dist/index.js", "package/package.json"]);
+      expect(Object.keys(unzipped).sort()).toEqual([
+        "package/dist/index.js",
+        "package/package.json",
+      ]);
       expect(unzipped["_meta.json"]).toBeUndefined();
     });
   });

--- a/convex/llmEval.ts
+++ b/convex/llmEval.ts
@@ -323,7 +323,10 @@ export const evaluatePackageReleaseWithLlm = internalAction({
         const content = await blob.text();
         fileContents.push({ path: f.path, content });
         const lower = f.path.toLowerCase();
-        if (!readmeContent && (lower === "readme.md" || lower === "readme.mdx" || lower === "readme.markdown")) {
+        if (
+          !readmeContent &&
+          (lower === "readme.md" || lower === "readme.mdx" || lower === "readme.markdown")
+        ) {
           readmeContent = content;
         }
       } catch {
@@ -332,8 +335,11 @@ export const evaluatePackageReleaseWithLlm = internalAction({
     }
 
     if (!readmeContent) {
-      const packageJsonText = fileContents.find((entry) => entry.path.toLowerCase() === "package.json")?.content;
-      readmeContent = packageJsonText ?? `# ${pkg.displayName}\n\n${release.summary ?? pkg.summary ?? pkg.name}`;
+      const packageJsonText = fileContents.find(
+        (entry) => entry.path.toLowerCase() === "package.json",
+      )?.content;
+      readmeContent =
+        packageJsonText ?? `# ${pkg.displayName}\n\n${release.summary ?? pkg.summary ?? pkg.name}`;
     }
 
     const allContent = [readmeContent, ...fileContents.map((f) => f.content)].join("\n");

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -5,6 +5,7 @@ import type { ActionCtx } from "./_generated/server";
 import { action, internalAction, internalMutation, internalQuery } from "./functions";
 import { assertRole, requireUserFromAction } from "./lib/access";
 import { buildSkillSummaryBackfillPatch, type ParsedSkillData } from "./lib/skillBackfill";
+import { deriveSkillCapabilityTags } from "./lib/skillCapabilityTags";
 import {
   computeQualitySignals,
   evaluateQuality,
@@ -13,7 +14,6 @@ import {
 } from "./lib/skillQuality";
 import { hashSkillFiles, isTextFile } from "./lib/skills";
 import { computeIsSuspicious } from "./lib/skillSafety";
-import { deriveSkillCapabilityTags } from "./lib/skillCapabilityTags";
 import { extractDigestFields } from "./lib/skillSearchDigest";
 import { generateSkillSummary } from "./lib/skillSummary";
 
@@ -494,13 +494,17 @@ export const backfillSkillCapabilityTagsInternal = internalAction({
 
     if (!args.dryRun && !result.isDone && result.cursor) {
       const delayMs = clampInt(args.delayMs ?? DEFAULT_CAPABILITY_BACKFILL_DELAY_MS, 0, 60_000);
-      await ctx.scheduler.runAfter(delayMs, internal.maintenance.backfillSkillCapabilityTagsInternal, {
-        dryRun: false,
-        cursor: result.cursor,
-        batchSize: args.batchSize,
-        maxBatches: 1,
+      await ctx.scheduler.runAfter(
         delayMs,
-      });
+        internal.maintenance.backfillSkillCapabilityTagsInternal,
+        {
+          dryRun: false,
+          cursor: result.cursor,
+          batchSize: args.batchSize,
+          maxBatches: 1,
+          delayMs,
+        },
+      );
     }
 
     return result;

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -331,8 +331,8 @@ function makeDigestCtx(options: {
   const pageByTable = new Map<
     string,
     Map<
-    string | null,
-    { page: Array<Record<string, unknown>>; isDone: boolean; continueCursor: string }
+      string | null,
+      { page: Array<Record<string, unknown>>; isDone: boolean; continueCursor: string }
     >
   >();
   const indexNames: string[] = [];
@@ -430,7 +430,8 @@ function makeDigestCtx(options: {
                     indexName === "by_name"
                       ? matchedValue
                         ? String(pkg.normalizedName) === matchedValue
-                        : String(pkg.normalizedName) >= lowerBound && String(pkg.normalizedName) < upperBound
+                        : String(pkg.normalizedName) >= lowerBound &&
+                          String(pkg.normalizedName) < upperBound
                       : matchedValue
                         ? String(pkg.runtimeId) === matchedValue
                         : String(pkg.runtimeId) >= lowerBound && String(pkg.runtimeId) < upperBound,
@@ -497,12 +498,17 @@ function makeDigestCtx(options: {
                     lt: () => queryBuilder,
                   };
                   builder?.(queryBuilder);
-                  const match = (options.exactDigests ?? []).find((digest) => digest.packageId === packageId);
+                  const match = (options.exactDigests ?? []).find(
+                    (digest) => digest.packageId === packageId,
+                  );
                   return {
                     unique: vi.fn().mockResolvedValue(match ?? null),
                   };
                 }
-                if (indexName === "by_active_normalized_name" || indexName === "by_active_runtime_id") {
+                if (
+                  indexName === "by_active_normalized_name" ||
+                  indexName === "by_active_runtime_id"
+                ) {
                   let lowerBound = "";
                   let upperBound = "";
                   const queryBuilder = {
@@ -551,9 +557,7 @@ function makeInsertReleaseCtx(
   recordsById: Record<string, Record<string, unknown>> = {},
 ) {
   const patch = vi.fn();
-  const insert = vi
-    .fn()
-    .mockResolvedValueOnce("packageReleases:new");
+  const insert = vi.fn().mockResolvedValueOnce("packageReleases:new");
   return {
     patch,
     insert,
@@ -822,10 +826,7 @@ describe("packages public queries", () => {
     const { ctx } = makeDigestCtx({
       pages: [
         {
-          page: [
-            makeDigest("secret-plugin", { channel: "private" }),
-            makeDigest("public-plugin"),
-          ],
+          page: [makeDigest("secret-plugin", { channel: "private" }), makeDigest("public-plugin")],
           isDone: true,
           continueCursor: "",
         },
@@ -1446,10 +1447,11 @@ describe("packages public queries", () => {
       continueCursor: "",
     });
     await expect(
-      getVersionByNameHandler(
-        ctx,
-        { name: "demo-plugin", version: "1.0.0", viewerUserId: "users:owner" } as never,
-      ),
+      getVersionByNameHandler(ctx, {
+        name: "demo-plugin",
+        version: "1.0.0",
+        viewerUserId: "users:owner",
+      } as never),
     ).resolves.toBeNull();
   });
 
@@ -1647,7 +1649,7 @@ describe("packages public queries", () => {
         integritySha256: "abc123",
         runtimeId: "other.plugin",
       }),
-    ).rejects.toThrow('runtime id changes are not allowed');
+    ).rejects.toThrow("runtime id changes are not allowed");
   });
 
   it("promotes existing packages to official when publisher becomes trusted", async () => {
@@ -2096,7 +2098,9 @@ describe("packages public queries", () => {
           files: [],
         },
       }),
-    ).rejects.toThrow("Trusted publish token no longer matches the current package trusted publisher");
+    ).rejects.toThrow(
+      "Trusted publish token no longer matches the current package trusted publisher",
+    );
   });
 
   it("revokes trusted publish tokens after a successful publish", async () => {
@@ -2337,7 +2341,9 @@ describe("packages public queries", () => {
           files: [],
         },
       }),
-    ).rejects.toThrow("Manual publishes for packages with trusted publisher config require manualOverrideReason");
+    ).rejects.toThrow(
+      "Manual publishes for packages with trusted publisher config require manualOverrideReason",
+    );
   });
 
   it("scans plugin publishes and forwards scan status to insertReleaseInternal", async () => {
@@ -2370,8 +2376,14 @@ describe("packages public queries", () => {
                 },
               }),
             ],
-            ["storage:manifest", JSON.stringify({ id: "demo.plugin", tools: [{ name: "demoTool" }] })],
-            ["storage:code", "import { execSync } from 'node:child_process';\nexecSync('curl http://x');\n"],
+            [
+              "storage:manifest",
+              JSON.stringify({ id: "demo.plugin", tools: [{ name: "demoTool" }] }),
+            ],
+            [
+              "storage:code",
+              "import { execSync } from 'node:child_process';\nexecSync('curl http://x');\n",
+            ],
           ]);
           const content = files.get(storageId);
           return content ? new Blob([content]) : null;
@@ -2476,9 +2488,11 @@ describe("packages public queries", () => {
             if (table !== "packages") throw new Error(`Unexpected table ${table}`);
             return {
               withIndex: vi.fn(() => ({
-                unique: vi.fn().mockResolvedValue(
-                  makePackageDoc({ ownerUserId: "users:owner", scanStatus: "pending" }),
-                ),
+                unique: vi
+                  .fn()
+                  .mockResolvedValue(
+                    makePackageDoc({ ownerUserId: "users:owner", scanStatus: "pending" }),
+                  ),
               })),
             };
           }),

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -1,5 +1,3 @@
-import { paginationOptsValidator } from "convex/server";
-import { ConvexError, v } from "convex/values";
 import {
   PackagePublishRequestSchema,
   parseArk,
@@ -7,18 +5,20 @@ import {
   type PackageFamily,
   type PackagePublishRequest,
 } from "clawhub-schema";
+import { paginationOptsValidator } from "convex/server";
+import { ConvexError, v } from "convex/values";
 import { internal } from "./_generated/api";
-import { action, internalAction, internalMutation, internalQuery, query } from "./functions";
 import type { Doc, Id } from "./_generated/dataModel";
 import type { ActionCtx, MutationCtx, QueryCtx } from "./_generated/server";
-import { requireGitHubAccountAge } from "./lib/githubAccount";
-import { normalizeGitHubRepository } from "./lib/githubActionsOidc";
+import { action, internalAction, internalMutation, internalQuery, query } from "./functions";
 import {
   assertAdmin,
   assertModerator,
   getOptionalActiveAuthUserId,
   requireUserFromAction,
 } from "./lib/access";
+import { requireGitHubAccountAge } from "./lib/githubAccount";
+import { normalizeGitHubRepository } from "./lib/githubActionsOidc";
 import {
   assertPackageVersion,
   ensurePluginNameMatchesPackage,
@@ -30,21 +30,18 @@ import {
   readOptionalTextFile,
   summarizePackageForSearch,
 } from "./lib/packageRegistry";
+import { isPackageBlockedFromPublic, resolvePackageReleaseScanStatus } from "./lib/packageSecurity";
+import { toPublicPublisher } from "./lib/public";
+import { getOwnerPublisher, getPublisherMembership } from "./lib/publishers";
 import {
   findOversizedPublishFile,
   getPublishFileSizeError,
   getPublishTotalSizeError,
   MAX_PUBLISH_TOTAL_BYTES,
 } from "./lib/publishLimits";
-import { getOwnerPublisher, getPublisherMembership } from "./lib/publishers";
-import { toPublicPublisher } from "./lib/public";
-import { runStaticPublishScan } from "./lib/staticPublishScan";
-import {
-  isPackageBlockedFromPublic,
-  resolvePackageReleaseScanStatus,
-} from "./lib/packageSecurity";
 import { tokenize } from "./lib/searchText";
 import { hashSkillFiles } from "./lib/skills";
+import { runStaticPublishScan } from "./lib/staticPublishScan";
 
 const MAX_PACKAGE_SCAN_DOCUMENTS = 30_000;
 const MAX_PUBLIC_LIST_SCAN_PAGES = 200;
@@ -267,21 +264,16 @@ async function viewerCanAccessPackageOwner(
   const cached = membershipCache?.get(cacheKey);
   if (cached) return await cached;
 
-  const membershipPromise = getPublisherMembership(
-    ctx,
-    digest.ownerPublisherId,
-    viewerUserId,
-  ).then(Boolean);
+  const membershipPromise = getPublisherMembership(ctx, digest.ownerPublisherId, viewerUserId).then(
+    Boolean,
+  );
   membershipCache?.set(cacheKey, membershipPromise);
   return await membershipPromise;
 }
 
 async function canViewerReadPackage(
   ctx: DbReaderCtx,
-  digest: Pick<
-    PackageDigestLike,
-    "channel" | "scanStatus" | "ownerUserId" | "ownerPublisherId"
-  >,
+  digest: Pick<PackageDigestLike, "channel" | "scanStatus" | "ownerUserId" | "ownerPublisherId">,
   viewerUserId: Id<"users"> | undefined,
   membershipCache?: Map<string, Promise<boolean>>,
 ) {
@@ -305,7 +297,7 @@ function toPublicPackage(
   if (!pkg || pkg.softDeletedAt) return null;
   const latestVersion =
     latestRelease === undefined
-      ? pkg.latestVersionSummary?.version ?? null
+      ? (pkg.latestVersionSummary?.version ?? null)
       : latestRelease && !latestRelease.softDeletedAt
         ? latestRelease.version
         : null;
@@ -423,8 +415,7 @@ async function listDashboardPackagesForOwnerPublisher(
       )
       .unique()) ?? null;
   const isOwnDashboard = Boolean(
-    membership ||
-      (ownerPublisher?.kind === "user" && ownerPublisher.linkedUserId === viewerUserId),
+    membership || (ownerPublisher?.kind === "user" && ownerPublisher.linkedUserId === viewerUserId),
   );
   if (!isOwnDashboard) return [];
 
@@ -484,12 +475,13 @@ function decodePublicPageCursor(raw: string | null | undefined): PublicPageCurso
     return { cursor: raw, offset: 0, pageSize: null, done: false };
   }
   try {
-    const parsed = JSON.parse(raw.slice(PUBLIC_PAGE_CURSOR_PREFIX.length)) as Partial<PublicPageCursorState>;
+    const parsed = JSON.parse(
+      raw.slice(PUBLIC_PAGE_CURSOR_PREFIX.length),
+    ) as Partial<PublicPageCursorState>;
     return {
       cursor: typeof parsed.cursor === "string" ? parsed.cursor : null,
       offset: typeof parsed.offset === "number" && parsed.offset > 0 ? parsed.offset : 0,
-      pageSize:
-        typeof parsed.pageSize === "number" && parsed.pageSize > 0 ? parsed.pageSize : null,
+      pageSize: typeof parsed.pageSize === "number" && parsed.pageSize > 0 ? parsed.pageSize : null,
       done: parsed.done === true,
     };
   } catch {
@@ -554,7 +546,8 @@ async function resolveDirectPackageSearchDigests(
       ? ctx.db
           .query("packageSearchDigest")
           .withIndex("by_active_normalized_name", (q) =>
-            q.eq("softDeletedAt", undefined)
+            q
+              .eq("softDeletedAt", undefined)
               .gte("normalizedName", normalizedQuery)
               .lt("normalizedName", prefixUpperBound(normalizedQuery)),
           )
@@ -564,7 +557,8 @@ async function resolveDirectPackageSearchDigests(
       ? ctx.db
           .query("packageSearchDigest")
           .withIndex("by_active_runtime_id", (q) =>
-            q.eq("softDeletedAt", undefined)
+            q
+              .eq("softDeletedAt", undefined)
               .gte("runtimeId", runtimePrefix)
               .lt("runtimeId", prefixUpperBound(runtimePrefix)),
           )
@@ -592,83 +586,115 @@ function buildPackageDigestQuery(
   const executesCode = args.executesCode;
 
   if (family && channel && typeof executesCode === "boolean") {
-    return ctx.db.query("packageSearchDigest").withIndex("by_active_family_channel_executes_updated", (q) =>
-      q.eq("softDeletedAt", undefined)
-        .eq("family", family)
-        .eq("channel", channel)
-        .eq("executesCode", executesCode),
-    );
+    return ctx.db
+      .query("packageSearchDigest")
+      .withIndex("by_active_family_channel_executes_updated", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("family", family)
+          .eq("channel", channel)
+          .eq("executesCode", executesCode),
+      );
   }
   if (family && typeof isOfficial === "boolean" && typeof executesCode === "boolean") {
-    return ctx.db.query("packageSearchDigest").withIndex("by_active_family_official_executes_updated", (q) =>
-      q.eq("softDeletedAt", undefined)
-        .eq("family", family)
-        .eq("isOfficial", isOfficial)
-        .eq("executesCode", executesCode),
-    );
+    return ctx.db
+      .query("packageSearchDigest")
+      .withIndex("by_active_family_official_executes_updated", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("family", family)
+          .eq("isOfficial", isOfficial)
+          .eq("executesCode", executesCode),
+      );
   }
   if (channel && typeof isOfficial === "boolean" && typeof executesCode === "boolean") {
-    return ctx.db.query("packageSearchDigest").withIndex("by_active_channel_official_executes_updated", (q) =>
-      q.eq("softDeletedAt", undefined)
-        .eq("channel", channel)
-        .eq("isOfficial", isOfficial)
-        .eq("executesCode", executesCode),
-    );
+    return ctx.db
+      .query("packageSearchDigest")
+      .withIndex("by_active_channel_official_executes_updated", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("channel", channel)
+          .eq("isOfficial", isOfficial)
+          .eq("executesCode", executesCode),
+      );
   }
   if (family && typeof executesCode === "boolean") {
-    return ctx.db.query("packageSearchDigest").withIndex("by_active_family_executes_updated", (q) =>
-      q.eq("softDeletedAt", undefined).eq("family", family).eq("executesCode", executesCode),
-    );
+    return ctx.db
+      .query("packageSearchDigest")
+      .withIndex("by_active_family_executes_updated", (q) =>
+        q.eq("softDeletedAt", undefined).eq("family", family).eq("executesCode", executesCode),
+      );
   }
   if (channel && typeof executesCode === "boolean") {
-    return ctx.db.query("packageSearchDigest").withIndex("by_active_channel_executes_updated", (q) =>
-      q.eq("softDeletedAt", undefined).eq("channel", channel).eq("executesCode", executesCode),
-    );
+    return ctx.db
+      .query("packageSearchDigest")
+      .withIndex("by_active_channel_executes_updated", (q) =>
+        q.eq("softDeletedAt", undefined).eq("channel", channel).eq("executesCode", executesCode),
+      );
   }
   if (typeof isOfficial === "boolean" && typeof executesCode === "boolean") {
-    return ctx.db.query("packageSearchDigest").withIndex("by_active_official_executes_updated", (q) =>
-      q.eq("softDeletedAt", undefined).eq("isOfficial", isOfficial).eq("executesCode", executesCode),
-    );
+    return ctx.db
+      .query("packageSearchDigest")
+      .withIndex("by_active_official_executes_updated", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("isOfficial", isOfficial)
+          .eq("executesCode", executesCode),
+      );
   }
   if (typeof executesCode === "boolean") {
-    return ctx.db.query("packageSearchDigest").withIndex("by_active_executes_updated", (q) =>
-      q.eq("softDeletedAt", undefined).eq("executesCode", executesCode),
-    );
+    return ctx.db
+      .query("packageSearchDigest")
+      .withIndex("by_active_executes_updated", (q) =>
+        q.eq("softDeletedAt", undefined).eq("executesCode", executesCode),
+      );
   }
 
   if (family && channel) {
-    return ctx.db.query("packageSearchDigest").withIndex("by_active_family_channel_updated", (q) =>
-      q.eq("softDeletedAt", undefined).eq("family", family).eq("channel", channel),
-    );
+    return ctx.db
+      .query("packageSearchDigest")
+      .withIndex("by_active_family_channel_updated", (q) =>
+        q.eq("softDeletedAt", undefined).eq("family", family).eq("channel", channel),
+      );
   }
   if (family && typeof isOfficial === "boolean") {
-    return ctx.db.query("packageSearchDigest").withIndex("by_active_family_official_updated", (q) =>
-      q.eq("softDeletedAt", undefined).eq("family", family).eq("isOfficial", isOfficial),
-    );
+    return ctx.db
+      .query("packageSearchDigest")
+      .withIndex("by_active_family_official_updated", (q) =>
+        q.eq("softDeletedAt", undefined).eq("family", family).eq("isOfficial", isOfficial),
+      );
   }
   if (family) {
-    return ctx.db.query("packageSearchDigest").withIndex("by_active_family_updated", (q) =>
-      q.eq("softDeletedAt", undefined).eq("family", family),
-    );
+    return ctx.db
+      .query("packageSearchDigest")
+      .withIndex("by_active_family_updated", (q) =>
+        q.eq("softDeletedAt", undefined).eq("family", family),
+      );
   }
   if (channel && typeof isOfficial === "boolean") {
-    return ctx.db.query("packageSearchDigest").withIndex("by_active_channel_official_updated", (q) =>
-      q.eq("softDeletedAt", undefined).eq("channel", channel).eq("isOfficial", isOfficial),
-    );
+    return ctx.db
+      .query("packageSearchDigest")
+      .withIndex("by_active_channel_official_updated", (q) =>
+        q.eq("softDeletedAt", undefined).eq("channel", channel).eq("isOfficial", isOfficial),
+      );
   }
   if (channel) {
-    return ctx.db.query("packageSearchDigest").withIndex("by_active_channel_updated", (q) =>
-      q.eq("softDeletedAt", undefined).eq("channel", channel),
-    );
+    return ctx.db
+      .query("packageSearchDigest")
+      .withIndex("by_active_channel_updated", (q) =>
+        q.eq("softDeletedAt", undefined).eq("channel", channel),
+      );
   }
   if (typeof isOfficial === "boolean") {
-    return ctx.db.query("packageSearchDigest").withIndex("by_active_official_updated", (q) =>
-      q.eq("softDeletedAt", undefined).eq("isOfficial", isOfficial),
-    );
+    return ctx.db
+      .query("packageSearchDigest")
+      .withIndex("by_active_official_updated", (q) =>
+        q.eq("softDeletedAt", undefined).eq("isOfficial", isOfficial),
+      );
   }
-  return ctx.db.query("packageSearchDigest").withIndex("by_active_updated", (q) =>
-    q.eq("softDeletedAt", undefined),
-  );
+  return ctx.db
+    .query("packageSearchDigest")
+    .withIndex("by_active_updated", (q) => q.eq("softDeletedAt", undefined));
 }
 
 function buildPackageCapabilityDigestQuery(
@@ -690,7 +716,8 @@ function buildPackageCapabilityDigestQuery(
     return ctx.db
       .query("packageCapabilitySearchDigest")
       .withIndex("by_active_family_channel_tag_executes_updated", (q) =>
-        q.eq("softDeletedAt", undefined)
+        q
+          .eq("softDeletedAt", undefined)
           .eq("family", family)
           .eq("channel", channel)
           .eq("capabilityTag", args.capabilityTag)
@@ -701,7 +728,8 @@ function buildPackageCapabilityDigestQuery(
     return ctx.db
       .query("packageCapabilitySearchDigest")
       .withIndex("by_active_family_official_tag_executes_updated", (q) =>
-        q.eq("softDeletedAt", undefined)
+        q
+          .eq("softDeletedAt", undefined)
           .eq("family", family)
           .eq("isOfficial", isOfficial)
           .eq("capabilityTag", args.capabilityTag)
@@ -712,7 +740,8 @@ function buildPackageCapabilityDigestQuery(
     return ctx.db
       .query("packageCapabilitySearchDigest")
       .withIndex("by_active_channel_official_tag_executes_updated", (q) =>
-        q.eq("softDeletedAt", undefined)
+        q
+          .eq("softDeletedAt", undefined)
           .eq("channel", channel)
           .eq("isOfficial", isOfficial)
           .eq("capabilityTag", args.capabilityTag)
@@ -720,80 +749,116 @@ function buildPackageCapabilityDigestQuery(
       );
   }
   if (family && channel) {
-    return ctx.db.query("packageCapabilitySearchDigest").withIndex("by_active_family_channel_tag_updated", (q) =>
-      q.eq("softDeletedAt", undefined)
-        .eq("family", family)
-        .eq("channel", channel)
-        .eq("capabilityTag", args.capabilityTag),
-    );
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_family_channel_tag_updated", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("family", family)
+          .eq("channel", channel)
+          .eq("capabilityTag", args.capabilityTag),
+      );
   }
   if (family && typeof isOfficial === "boolean") {
-    return ctx.db.query("packageCapabilitySearchDigest").withIndex("by_active_family_official_tag_updated", (q) =>
-      q.eq("softDeletedAt", undefined)
-        .eq("family", family)
-        .eq("isOfficial", isOfficial)
-        .eq("capabilityTag", args.capabilityTag),
-    );
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_family_official_tag_updated", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("family", family)
+          .eq("isOfficial", isOfficial)
+          .eq("capabilityTag", args.capabilityTag),
+      );
   }
   if (channel && typeof isOfficial === "boolean") {
-    return ctx.db.query("packageCapabilitySearchDigest").withIndex("by_active_channel_official_tag_updated", (q) =>
-      q.eq("softDeletedAt", undefined)
-        .eq("channel", channel)
-        .eq("isOfficial", isOfficial)
-        .eq("capabilityTag", args.capabilityTag),
-    );
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_channel_official_tag_updated", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("channel", channel)
+          .eq("isOfficial", isOfficial)
+          .eq("capabilityTag", args.capabilityTag),
+      );
   }
   if (family && typeof executesCode === "boolean") {
-    return ctx.db.query("packageCapabilitySearchDigest").withIndex("by_active_family_tag_executes_updated", (q) =>
-      q.eq("softDeletedAt", undefined)
-        .eq("family", family)
-        .eq("capabilityTag", args.capabilityTag)
-        .eq("executesCode", executesCode),
-    );
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_family_tag_executes_updated", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("family", family)
+          .eq("capabilityTag", args.capabilityTag)
+          .eq("executesCode", executesCode),
+      );
   }
   if (channel && typeof executesCode === "boolean") {
-    return ctx.db.query("packageCapabilitySearchDigest").withIndex("by_active_channel_tag_executes_updated", (q) =>
-      q.eq("softDeletedAt", undefined)
-        .eq("channel", channel)
-        .eq("capabilityTag", args.capabilityTag)
-        .eq("executesCode", executesCode),
-    );
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_channel_tag_executes_updated", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("channel", channel)
+          .eq("capabilityTag", args.capabilityTag)
+          .eq("executesCode", executesCode),
+      );
   }
   if (typeof isOfficial === "boolean" && typeof executesCode === "boolean") {
-    return ctx.db.query("packageCapabilitySearchDigest").withIndex("by_active_official_tag_executes_updated", (q) =>
-      q.eq("softDeletedAt", undefined)
-        .eq("isOfficial", isOfficial)
-        .eq("capabilityTag", args.capabilityTag)
-        .eq("executesCode", executesCode),
-    );
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_official_tag_executes_updated", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("isOfficial", isOfficial)
+          .eq("capabilityTag", args.capabilityTag)
+          .eq("executesCode", executesCode),
+      );
   }
   if (family) {
-    return ctx.db.query("packageCapabilitySearchDigest").withIndex("by_active_family_tag_updated", (q) =>
-      q.eq("softDeletedAt", undefined).eq("family", family).eq("capabilityTag", args.capabilityTag),
-    );
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_family_tag_updated", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("family", family)
+          .eq("capabilityTag", args.capabilityTag),
+      );
   }
   if (channel) {
-    return ctx.db.query("packageCapabilitySearchDigest").withIndex("by_active_channel_tag_updated", (q) =>
-      q.eq("softDeletedAt", undefined).eq("channel", channel).eq("capabilityTag", args.capabilityTag),
-    );
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_channel_tag_updated", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("channel", channel)
+          .eq("capabilityTag", args.capabilityTag),
+      );
   }
   if (typeof isOfficial === "boolean") {
-    return ctx.db.query("packageCapabilitySearchDigest").withIndex("by_active_official_tag_updated", (q) =>
-      q.eq("softDeletedAt", undefined)
-        .eq("isOfficial", isOfficial)
-        .eq("capabilityTag", args.capabilityTag),
-    );
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_official_tag_updated", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("isOfficial", isOfficial)
+          .eq("capabilityTag", args.capabilityTag),
+      );
   }
   if (typeof executesCode === "boolean") {
-    return ctx.db.query("packageCapabilitySearchDigest").withIndex("by_active_tag_executes_updated", (q) =>
-      q.eq("softDeletedAt", undefined)
-        .eq("capabilityTag", args.capabilityTag)
-        .eq("executesCode", executesCode),
-    );
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_tag_executes_updated", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("capabilityTag", args.capabilityTag)
+          .eq("executesCode", executesCode),
+      );
   }
-  return ctx.db.query("packageCapabilitySearchDigest").withIndex("by_active_tag_updated", (q) =>
-    q.eq("softDeletedAt", undefined).eq("capabilityTag", args.capabilityTag),
-  );
+  return ctx.db
+    .query("packageCapabilitySearchDigest")
+    .withIndex("by_active_tag_updated", (q) =>
+      q.eq("softDeletedAt", undefined).eq("capabilityTag", args.capabilityTag),
+    );
 }
 
 async function getPackageByNormalizedName(ctx: DbReaderCtx, normalizedName: string) {
@@ -815,10 +880,7 @@ async function getReadablePackageByName(
   return pkg;
 }
 
-async function getPackageTrustedPublisherByPackageId(
-  ctx: DbReaderCtx,
-  packageId: Id<"packages">,
-) {
+async function getPackageTrustedPublisherByPackageId(ctx: DbReaderCtx, packageId: Id<"packages">) {
   return await ctx.db
     .query("packageTrustedPublishers")
     .withIndex("by_package", (q) => q.eq("packageId", packageId))
@@ -951,7 +1013,9 @@ export const getVersionByName = query({
     if (!publicPackage) return null;
     const release = await ctx.db
       .query("packageReleases")
-      .withIndex("by_package_version", (q) => q.eq("packageId", pkg._id).eq("version", args.version))
+      .withIndex("by_package_version", (q) =>
+        q.eq("packageId", pkg._id).eq("version", args.version),
+      )
       .unique();
     if (!release || release.softDeletedAt) return null;
     return {
@@ -974,7 +1038,9 @@ export const getVersionByNameForViewerInternal = internalQuery({
     if (!publicPackage) return null;
     const release = await ctx.db
       .query("packageReleases")
-      .withIndex("by_package_version", (q) => q.eq("packageId", pkg._id).eq("version", args.version))
+      .withIndex("by_package_version", (q) =>
+        q.eq("packageId", pkg._id).eq("version", args.version),
+      )
       .unique();
     if (!release || release.softDeletedAt) return null;
     return {
@@ -1014,7 +1080,9 @@ export const listPublicPage = query({
     family: v.optional(
       v.union(v.literal("skill"), v.literal("code-plugin"), v.literal("bundle-plugin")),
     ),
-    channel: v.optional(v.union(v.literal("official"), v.literal("community"), v.literal("private"))),
+    channel: v.optional(
+      v.union(v.literal("official"), v.literal("community"), v.literal("private")),
+    ),
     isOfficial: v.optional(v.boolean()),
     executesCode: v.optional(v.boolean()),
     capabilityTag: v.optional(v.string()),
@@ -1030,7 +1098,9 @@ export const listPageForViewerInternal = internalQuery({
     family: v.optional(
       v.union(v.literal("skill"), v.literal("code-plugin"), v.literal("bundle-plugin")),
     ),
-    channel: v.optional(v.union(v.literal("official"), v.literal("community"), v.literal("private"))),
+    channel: v.optional(
+      v.union(v.literal("official"), v.literal("community"), v.literal("private")),
+    ),
     isOfficial: v.optional(v.boolean()),
     executesCode: v.optional(v.boolean()),
     capabilityTag: v.optional(v.string()),
@@ -1083,7 +1153,9 @@ async function listPackagePageImpl(
     loops += 1;
     const effectivePageSize = Math.min(
       remainingScanBudget,
-      offset > 0 && pageSize ? Math.max(pageSize, offset + 1) : Math.max(targetCount * 3, targetCount),
+      offset > 0 && pageSize
+        ? Math.max(pageSize, offset + 1)
+        : Math.max(targetCount * 3, targetCount),
     );
     if (effectivePageSize <= 0) break;
     remainingScanBudget -= effectivePageSize;
@@ -1096,7 +1168,12 @@ async function listPackagePageImpl(
           isOfficial,
           executesCode: args.executesCode,
         })
-      : buildPackageDigestQuery(ctx, { family, channel, isOfficial, executesCode: args.executesCode });
+      : buildPackageDigestQuery(ctx, {
+          family,
+          channel,
+          isOfficial,
+          executesCode: args.executesCode,
+        });
     const page: {
       page: PackageDigestLike[];
       isDone: boolean;
@@ -1151,7 +1228,9 @@ export const searchPublic = query({
     family: v.optional(
       v.union(v.literal("skill"), v.literal("code-plugin"), v.literal("bundle-plugin")),
     ),
-    channel: v.optional(v.union(v.literal("official"), v.literal("community"), v.literal("private"))),
+    channel: v.optional(
+      v.union(v.literal("official"), v.literal("community"), v.literal("private")),
+    ),
     isOfficial: v.optional(v.boolean()),
     executesCode: v.optional(v.boolean()),
     capabilityTag: v.optional(v.string()),
@@ -1168,7 +1247,9 @@ export const searchForViewerInternal = internalQuery({
     family: v.optional(
       v.union(v.literal("skill"), v.literal("code-plugin"), v.literal("bundle-plugin")),
     ),
-    channel: v.optional(v.union(v.literal("official"), v.literal("community"), v.literal("private"))),
+    channel: v.optional(
+      v.union(v.literal("official"), v.literal("community"), v.literal("private")),
+    ),
     isOfficial: v.optional(v.boolean()),
     executesCode: v.optional(v.boolean()),
     capabilityTag: v.optional(v.string()),
@@ -1311,7 +1392,9 @@ export const setTrustedPublisherForUserInternal = internalMutation({
     const pkg = await getPackageByNormalizedName(ctx, normalizePackageName(args.packageName));
     if (!pkg) throw new ConvexError("Package not found");
     if (pkg.family === "skill") {
-      throw new ConvexError("Trusted publishers are only supported for code-plugin and bundle-plugin packages");
+      throw new ConvexError(
+        "Trusted publishers are only supported for code-plugin and bundle-plugin packages",
+      );
     }
     await requireTrustedPublisherEditor(ctx, pkg, args.actorUserId);
 
@@ -1493,7 +1576,9 @@ export const getReleaseByPackageAndVersionInternal = internalQuery({
   handler: async (ctx, args) => {
     return await ctx.db
       .query("packageReleases")
-      .withIndex("by_package_version", (q) => q.eq("packageId", args.packageId).eq("version", args.version))
+      .withIndex("by_package_version", (q) =>
+        q.eq("packageId", args.packageId).eq("version", args.version),
+      )
       .unique();
   },
 });
@@ -1525,7 +1610,10 @@ export const getPackageReleaseScanBackfillBatchInternal = internalQuery({
 
     const [recentReleases, backlogReleases] = await Promise.all([
       prioritizeRecent
-        ? ctx.db.query("packageReleases").order("desc").take(batchSize * 2)
+        ? ctx.db
+            .query("packageReleases")
+            .order("desc")
+            .take(batchSize * 2)
         : Promise.resolve([]),
       ctx.db
         .query("packageReleases")
@@ -1605,7 +1693,7 @@ function resolveTrustedPublishSource(
   }
   const requestedRepo =
     typeof source?.repo === "string" && source.repo.trim()
-      ? normalizeGitHubRepository(source.repo) ?? source.repo.trim()
+      ? (normalizeGitHubRepository(source.repo) ?? source.repo.trim())
       : undefined;
   if (requestedRepo && requestedRepo !== publishToken.repository) {
     throw new ConvexError("Trusted publish source repo must match the verified GitHub repository");
@@ -1633,15 +1721,15 @@ function doesTrustedPublisherMatchPublishToken(
   publishToken: Doc<"packagePublishTokens">,
 ) {
   return Boolean(
-      trustedPublisher &&
-      trustedPublisher.packageId === publishToken.packageId &&
-      trustedPublisher.provider === publishToken.provider &&
-      trustedPublisher.repository === publishToken.repository &&
-      trustedPublisher.repositoryId === publishToken.repositoryId &&
-      trustedPublisher.repositoryOwner === publishToken.repositoryOwner &&
-      trustedPublisher.repositoryOwnerId === publishToken.repositoryOwnerId &&
-      trustedPublisher.workflowFilename === publishToken.workflowFilename &&
-      trustedPublisher.environment === publishToken.environment,
+    trustedPublisher &&
+    trustedPublisher.packageId === publishToken.packageId &&
+    trustedPublisher.provider === publishToken.provider &&
+    trustedPublisher.repository === publishToken.repository &&
+    trustedPublisher.repositoryId === publishToken.repositoryId &&
+    trustedPublisher.repositoryOwner === publishToken.repositoryOwner &&
+    trustedPublisher.repositoryOwnerId === publishToken.repositoryOwnerId &&
+    trustedPublisher.workflowFilename === publishToken.workflowFilename &&
+    trustedPublisher.environment === publishToken.environment,
   );
 }
 
@@ -1744,9 +1832,21 @@ async function publishPackageImpl(
     throw new ConvexError("Code plugins require source repo and commit metadata");
   }
 
-  const packageJsonEntry = await readOptionalTextFile(ctx, files, (path) => path === "package.json");
-  const pluginManifestEntry = await readOptionalTextFile(ctx, files, (path) => path === "openclaw.plugin.json");
-  const bundleManifestEntry = await readOptionalTextFile(ctx, files, (path) => path === "openclaw.bundle.json");
+  const packageJsonEntry = await readOptionalTextFile(
+    ctx,
+    files,
+    (path) => path === "package.json",
+  );
+  const pluginManifestEntry = await readOptionalTextFile(
+    ctx,
+    files,
+    (path) => path === "openclaw.plugin.json",
+  );
+  const bundleManifestEntry = await readOptionalTextFile(
+    ctx,
+    files,
+    (path) => path === "openclaw.bundle.json",
+  );
   const readmeEntry = await readOptionalTextFile(
     ctx,
     files,
@@ -1771,12 +1871,16 @@ async function publishPackageImpl(
     family === "code-plugin"
       ? extractCodePluginArtifacts({
           packageName: name,
-          packageJson: packageJson ?? (() => {
-            throw new ConvexError("package.json is required for code plugins");
-          })(),
-          pluginManifest: maybeParseJson(pluginManifestEntry?.text) ?? (() => {
-            throw new ConvexError("openclaw.plugin.json is required for code plugins");
-          })(),
+          packageJson:
+            packageJson ??
+            (() => {
+              throw new ConvexError("package.json is required for code plugins");
+            })(),
+          pluginManifest:
+            maybeParseJson(pluginManifestEntry?.text) ??
+            (() => {
+              throw new ConvexError("openclaw.plugin.json is required for code plugins");
+            })(),
           source: effectiveSource,
         })
       : null;
@@ -1790,14 +1894,14 @@ async function publishPackageImpl(
     slug: name,
     displayName,
     summary,
-      metadata: {
-        packageJson,
-        pluginManifest: maybeParseJson(pluginManifestEntry?.text),
-        bundleManifest: maybeParseJson(bundleManifestEntry?.text),
-        source: effectiveSource,
-      },
-      files,
-    });
+    metadata: {
+      packageJson,
+      pluginManifest: maybeParseJson(pluginManifestEntry?.text),
+      bundleManifest: maybeParseJson(bundleManifestEntry?.text),
+      source: effectiveSource,
+    },
+    files,
+  });
   const verificationSource = codeArtifacts?.verification ?? bundleArtifacts?.verification;
   const initialScanStatus = staticScan.status === "malicious" ? "malicious" : "pending";
   const verification = verificationSource
@@ -1810,38 +1914,38 @@ async function publishPackageImpl(
     files.map((file) => ({ path: file.path, sha256: file.sha256 })),
   );
 
-  const publishResult = await runMutationRef<{ ok: true; packageId: Id<"packages">; releaseId: Id<"packageReleases"> }>(
-    ctx,
-    internalRefs.packages.insertReleaseInternal,
-    {
-      actorUserId,
-      ownerUserId,
-      ownerPublisherId,
-      publishActor,
-      name,
-      displayName,
-      family,
-      version,
-      changelog: payload.changelog.trim(),
-      tags: payload.tags?.map((tag: string) => tag.trim()).filter(Boolean) ?? ["latest"],
-      summary,
-      sourceRepo: effectiveSource?.repo || effectiveSource?.url,
-      runtimeId: codeArtifacts?.runtimeId ?? bundleArtifacts?.runtimeId,
-      channel: payload.channel,
-      compatibility: codeArtifacts?.compatibility ?? bundleArtifacts?.compatibility,
-      capabilities: codeArtifacts?.capabilities ?? bundleArtifacts?.capabilities,
-      verification,
-      staticScan,
-      files,
-      integritySha256,
-      extractedPackageJson: packageJson,
-      extractedPluginManifest:
-        family === "code-plugin" ? maybeParseJson(pluginManifestEntry?.text) : undefined,
-      normalizedBundleManifest:
-        family === "bundle-plugin" ? maybeParseJson(bundleManifestEntry?.text) : undefined,
-      source: effectiveSource,
-    },
-  );
+  const publishResult = await runMutationRef<{
+    ok: true;
+    packageId: Id<"packages">;
+    releaseId: Id<"packageReleases">;
+  }>(ctx, internalRefs.packages.insertReleaseInternal, {
+    actorUserId,
+    ownerUserId,
+    ownerPublisherId,
+    publishActor,
+    name,
+    displayName,
+    family,
+    version,
+    changelog: payload.changelog.trim(),
+    tags: payload.tags?.map((tag: string) => tag.trim()).filter(Boolean) ?? ["latest"],
+    summary,
+    sourceRepo: effectiveSource?.repo || effectiveSource?.url,
+    runtimeId: codeArtifacts?.runtimeId ?? bundleArtifacts?.runtimeId,
+    channel: payload.channel,
+    compatibility: codeArtifacts?.compatibility ?? bundleArtifacts?.compatibility,
+    capabilities: codeArtifacts?.capabilities ?? bundleArtifacts?.capabilities,
+    verification,
+    staticScan,
+    files,
+    integritySha256,
+    extractedPackageJson: packageJson,
+    extractedPluginManifest:
+      family === "code-plugin" ? maybeParseJson(pluginManifestEntry?.text) : undefined,
+    normalizedBundleManifest:
+      family === "bundle-plugin" ? maybeParseJson(bundleManifestEntry?.text) : undefined,
+    source: effectiveSource,
+  });
 
   if (auth.kind === "github-actions") {
     await runMutationRef(ctx, internalRefs.packagePublishTokens.revokeInternal, {
@@ -1884,9 +1988,14 @@ async function publishPackageImpl(
     });
   }
 
-  await runAfterRef(ctx, INITIAL_PACKAGE_VT_SCAN_DELAY_MS, internalRefs.vt.scanPackageReleaseWithVirusTotal, {
-    releaseId: publishResult.releaseId,
-  });
+  await runAfterRef(
+    ctx,
+    INITIAL_PACKAGE_VT_SCAN_DELAY_MS,
+    internalRefs.vt.scanPackageReleaseWithVirusTotal,
+    {
+      releaseId: publishResult.releaseId,
+    },
+  );
   await runAfterRef(ctx, 0, internalRefs.llmEval.evaluatePackageReleaseWithLlm, {
     releaseId: publishResult.releaseId,
   });
@@ -1908,7 +2017,11 @@ export const publishPackageForUserInternal = internalAction({
     payload: v.any(),
   },
   handler: async (ctx, args) => {
-    return await publishPackageImpl(ctx, { kind: "user", actorUserId: args.actorUserId }, args.payload);
+    return await publishPackageImpl(
+      ctx,
+      { kind: "user", actorUserId: args.actorUserId },
+      args.payload,
+    );
   },
 });
 
@@ -1932,7 +2045,9 @@ export const publishPackageForTrustedPublisherInternal = internalAction({
       { packageId: publishToken.packageId },
     );
     if (!doesTrustedPublisherMatchPublishToken(trustedPublisher, publishToken)) {
-      throw new ConvexError("Trusted publish token no longer matches the current package trusted publisher");
+      throw new ConvexError(
+        "Trusted publish token no longer matches the current package trusted publisher",
+      );
     }
     return await publishPackageImpl(ctx, { kind: "github-actions", publishToken }, args.payload);
   },
@@ -1976,7 +2091,9 @@ export const insertReleaseInternal = internalMutation({
     summary: v.string(),
     sourceRepo: v.optional(v.string()),
     runtimeId: v.optional(v.string()),
-    channel: v.optional(v.union(v.literal("official"), v.literal("community"), v.literal("private"))),
+    channel: v.optional(
+      v.union(v.literal("official"), v.literal("community"), v.literal("private")),
+    ),
     compatibility: v.optional(v.any()),
     capabilities: v.optional(v.any()),
     verification: v.optional(v.any()),
@@ -2003,9 +2120,7 @@ export const insertReleaseInternal = internalMutation({
     if (!actor) throw new ConvexError("Unauthorized");
     const owner = await ctx.db.get(args.ownerUserId);
     if (!owner) throw new ConvexError("Unauthorized");
-    const ownerPublisher = args.ownerPublisherId
-      ? await ctx.db.get(args.ownerPublisherId)
-      : null;
+    const ownerPublisher = args.ownerPublisherId ? await ctx.db.get(args.ownerPublisherId) : null;
     if (args.ownerUserId !== args.actorUserId) {
       assertAdmin(actor);
     }
@@ -2016,19 +2131,15 @@ export const insertReleaseInternal = internalMutation({
     const existing = await getPackageByNormalizedName(ctx, normalizedName);
     const nextChannel =
       args.channel ??
-      (existing?.channel === "private"
-        ? "private"
-        : publisherTrusted
-          ? "official"
-          : "community");
+      (existing?.channel === "private" ? "private" : publisherTrusted ? "official" : "community");
     const nextIsOfficial = nextChannel === "official";
     if (existing) {
       const existingIsLegacyPersonalPackage =
         !existing.ownerPublisherId &&
         Boolean(
           args.ownerPublisherId &&
-            ownerPublisher?.kind === "user" &&
-            ownerPublisher.linkedUserId === existing.ownerUserId,
+          ownerPublisher?.kind === "user" &&
+          ownerPublisher.linkedUserId === existing.ownerUserId,
         );
       const existingOwnerKey = existing.ownerPublisherId
         ? `publisher:${existing.ownerPublisherId}`
@@ -2064,7 +2175,9 @@ export const insertReleaseInternal = internalMutation({
         .withIndex("by_runtime_id", (q) => q.eq("runtimeId", args.runtimeId))
         .unique();
       if (runtimeCollision && runtimeCollision._id !== existing?._id) {
-        throw new ConvexError(`Plugin id "${args.runtimeId}" is already claimed by another package`);
+        throw new ConvexError(
+          `Plugin id "${args.runtimeId}" is already claimed by another package`,
+        );
       }
     }
 
@@ -2097,7 +2210,9 @@ export const insertReleaseInternal = internalMutation({
     if (existing) {
       const releaseExists = await ctx.db
         .query("packageReleases")
-        .withIndex("by_package_version", (q) => q.eq("packageId", existing._id).eq("version", args.version))
+        .withIndex("by_package_version", (q) =>
+          q.eq("packageId", existing._id).eq("version", args.version),
+        )
         .unique();
       if (releaseExists) throw new ConvexError(`Version ${args.version} already exists`);
     }
@@ -2140,7 +2255,9 @@ export const insertReleaseInternal = internalMutation({
     const nextTags = { ...pkg.tags };
     for (const tag of effectiveTags) nextTags[tag] = releaseId;
     for (const priorRelease of priorReleases) {
-      const nextDistTags = (priorRelease.distTags ?? []).filter((tag) => !effectiveTags.includes(tag));
+      const nextDistTags = (priorRelease.distTags ?? []).filter(
+        (tag) => !effectiveTags.includes(tag),
+      );
       if (nextDistTags.length === (priorRelease.distTags ?? []).length) continue;
       await ctx.db.patch(priorRelease._id, { distTags: nextDistTags });
     }
@@ -2167,7 +2284,7 @@ export const insertReleaseInternal = internalMutation({
         : pkg.latestVersionSummary,
       tags: nextTags,
       capabilityTags: shouldPromoteLatest
-        ? args.capabilities?.capabilityTags ?? pkg.capabilityTags
+        ? (args.capabilities?.capabilityTags ?? pkg.capabilityTags)
         : pkg.capabilityTags,
       executesCode: shouldPromoteLatest
         ? typeof args.capabilities?.executesCode === "boolean"
@@ -2193,10 +2310,7 @@ function isReleaseActive(release: Doc<"packageReleases"> | null | undefined) {
   return Boolean(release && !release.softDeletedAt);
 }
 
-async function syncLatestPackageVerification(
-  ctx: MutationCtx,
-  release: Doc<"packageReleases">,
-) {
+async function syncLatestPackageVerification(ctx: MutationCtx, release: Doc<"packageReleases">) {
   const pkg = await ctx.db.get(release.packageId);
   if (!pkg || pkg.latestReleaseId !== release._id) return;
   const scanStatus = resolvePackageReleaseScanStatus(release);
@@ -2263,7 +2377,10 @@ export const updateReleaseScanResultsInternal = internalMutation({
       await ctx.db.patch(args.releaseId, patch);
     }
     if (args.vtAnalysis !== undefined) {
-      await syncLatestPackageVerification(ctx, { ...activeRelease, ...patch } as Doc<"packageReleases">);
+      await syncLatestPackageVerification(ctx, {
+        ...activeRelease,
+        ...patch,
+      } as Doc<"packageReleases">);
     }
   },
 });
@@ -2343,7 +2460,10 @@ export const updateReleaseStaticScanInternal = internalMutation({
 
     await ctx.db.patch(args.releaseId, patch);
 
-    await syncLatestPackageVerification(ctx, { ...activeRelease, ...patch } as Doc<"packageReleases">);
+    await syncLatestPackageVerification(ctx, {
+      ...activeRelease,
+      ...patch,
+    } as Doc<"packageReleases">);
   },
 });
 
@@ -2404,11 +2524,15 @@ export const backfillPackageReleaseScansInternal = internalAction({
   },
   handler: async (ctx, args) => {
     const batchSize = Math.max(1, Math.min(args.batchSize ?? 50, 200));
-    const batch = (await runQueryRef(ctx, internalRefs.packages.getPackageReleaseScanBackfillBatchInternal, {
-      cursor: args.cursor,
-      batchSize,
-      prioritizeRecent: args.cursor === undefined,
-    })) as {
+    const batch = (await runQueryRef(
+      ctx,
+      internalRefs.packages.getPackageReleaseScanBackfillBatchInternal,
+      {
+        cursor: args.cursor,
+        batchSize,
+        prioritizeRecent: args.cursor === undefined,
+      },
+    )) as {
       releases: Array<{
         releaseId: Id<"packageReleases">;
         needsVt: boolean;

--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -16,9 +16,11 @@ type WrappedHandler<TArgs, TResult = unknown> = {
 };
 
 const addMemberHandler = (
-  addMember as unknown as WrappedHandler<
-    { publisherId: string; userHandle: string; role: "owner" | "admin" | "publisher" }
-  >
+  addMember as unknown as WrappedHandler<{
+    publisherId: string;
+    userHandle: string;
+    role: "owner" | "admin" | "publisher";
+  }>
 )._handler;
 
 const removeMemberHandler = (
@@ -232,98 +234,115 @@ describe("publishers membership controls", () => {
         query: vi.fn((table: string) => {
           if (table === "publisherMembers") {
             return {
-              withIndex: vi.fn((indexName: string, builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown) => {
-                if (indexName !== "by_publisher_user") {
-                  throw new Error(`unexpected index ${indexName}`);
-                }
-                let publisherId = "";
-                let userId = "";
-                const q = {
-                  eq: (field: string, value: string) => {
-                    if (field === "publisherId") publisherId = value;
-                    if (field === "userId") userId = value;
-                    return q;
-                  },
-                };
-                builder?.(q);
-                return {
-                  unique: vi.fn(async () =>
-                    publisherMembers.find(
-                      (member) => member.publisherId === publisherId && member.userId === userId,
-                    ) ?? null,
-                  ),
-                };
-              }),
+              withIndex: vi.fn(
+                (
+                  indexName: string,
+                  builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown,
+                ) => {
+                  if (indexName !== "by_publisher_user") {
+                    throw new Error(`unexpected index ${indexName}`);
+                  }
+                  let publisherId = "";
+                  let userId = "";
+                  const q = {
+                    eq: (field: string, value: string) => {
+                      if (field === "publisherId") publisherId = value;
+                      if (field === "userId") userId = value;
+                      return q;
+                    },
+                  };
+                  builder?.(q);
+                  return {
+                    unique: vi.fn(
+                      async () =>
+                        publisherMembers.find(
+                          (member) =>
+                            member.publisherId === publisherId && member.userId === userId,
+                        ) ?? null,
+                    ),
+                  };
+                },
+              ),
             };
           }
           if (table === "users") {
             return {
-              withIndex: vi.fn((indexName: string, builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown) => {
-                if (indexName !== "handle") {
-                  throw new Error(`unexpected index ${indexName}`);
-                }
-                let handle = "";
-                const q = {
-                  eq: (field: string, value: string) => {
-                    if (field === "handle") handle = value;
-                    return q;
-                  },
-                };
-                builder?.(q);
-                return {
-                  unique: vi.fn(async () => {
-                    if (handle === "owner") return { _id: "users:owner", handle: "owner" };
-                    return null;
-                  }),
-                };
-              }),
+              withIndex: vi.fn(
+                (
+                  indexName: string,
+                  builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown,
+                ) => {
+                  if (indexName !== "handle") {
+                    throw new Error(`unexpected index ${indexName}`);
+                  }
+                  let handle = "";
+                  const q = {
+                    eq: (field: string, value: string) => {
+                      if (field === "handle") handle = value;
+                      return q;
+                    },
+                  };
+                  builder?.(q);
+                  return {
+                    unique: vi.fn(async () => {
+                      if (handle === "owner") return { _id: "users:owner", handle: "owner" };
+                      return null;
+                    }),
+                  };
+                },
+              ),
             };
           }
           if (table === "publishers") {
             return {
-              withIndex: vi.fn((indexName: string, builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown) => {
-                let handle = "";
-                let linkedUserId = "";
-                const q = {
-                  eq: (field: string, value: string) => {
-                    if (field === "handle") handle = value;
-                    if (field === "linkedUserId") linkedUserId = value;
-                    return q;
-                  },
-                };
-                builder?.(q);
-                return {
-                  unique: vi.fn(async () => {
-                    if (indexName === "by_handle" && handle === "jaredforreal") {
-                      return {
-                        _id: "publishers:jaredforreal",
-                        _creationTime: 1,
-                        kind: "user",
-                        handle: "jaredforreal",
-                        displayName: "Jared",
-                        linkedUserId: "users:jared",
-                        trustedPublisher: false,
-                        createdAt: 1,
-                        updatedAt: 1,
-                      };
-                    }
-                    if (indexName === "by_linked_user" && linkedUserId === "users:jared") {
-                      return {
-                        _id: "publishers:jaredforreal",
-                        _creationTime: 1,
-                        kind: "user",
-                        handle: "jaredforreal",
-                        displayName: "Jared",
-                        linkedUserId: "users:jared",
-                        trustedPublisher: false,
-                        createdAt: 1,
-                        updatedAt: 1,
-                      };
-                    }
-                    return null;
-                  }),
-                };
-              }),
+              withIndex: vi.fn(
+                (
+                  indexName: string,
+                  builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown,
+                ) => {
+                  let handle = "";
+                  let linkedUserId = "";
+                  const q = {
+                    eq: (field: string, value: string) => {
+                      if (field === "handle") handle = value;
+                      if (field === "linkedUserId") linkedUserId = value;
+                      return q;
+                    },
+                  };
+                  builder?.(q);
+                  return {
+                    unique: vi.fn(async () => {
+                      if (indexName === "by_handle" && handle === "jaredforreal") {
+                        return {
+                          _id: "publishers:jaredforreal",
+                          _creationTime: 1,
+                          kind: "user",
+                          handle: "jaredforreal",
+                          displayName: "Jared",
+                          linkedUserId: "users:jared",
+                          trustedPublisher: false,
+                          createdAt: 1,
+                          updatedAt: 1,
+                        };
+                      }
+                      if (indexName === "by_linked_user" && linkedUserId === "users:jared") {
+                        return {
+                          _id: "publishers:jaredforreal",
+                          _creationTime: 1,
+                          kind: "user",
+                          handle: "jaredforreal",
+                          displayName: "Jared",
+                          linkedUserId: "users:jared",
+                          trustedPublisher: false,
+                          createdAt: 1,
+                          updatedAt: 1,
+                        };
+                      }
+                      return null;
+                    }),
+                  };
+                },
+              ),
             };
           }
           throw new Error(`unexpected table ${table}`);
@@ -526,101 +545,126 @@ describe("legacy publisher migration", () => {
     const query = vi.fn((table: string) => {
       if (table === "users") {
         return {
-          withIndex: vi.fn((_indexName: string, builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown) => {
-            let handle = "";
-            const q = {
-              eq: (field: string, value: string) => {
-                if (field === "handle") handle = value;
-                return q;
-              },
-            };
-            builder?.(q);
-            return {
-              unique: vi.fn(async () =>
-                [...users.values()].find((user) => user.handle === handle) ?? null,
-              ),
-            };
-          }),
+          withIndex: vi.fn(
+            (
+              _indexName: string,
+              builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown,
+            ) => {
+              let handle = "";
+              const q = {
+                eq: (field: string, value: string) => {
+                  if (field === "handle") handle = value;
+                  return q;
+                },
+              };
+              builder?.(q);
+              return {
+                unique: vi.fn(
+                  async () => [...users.values()].find((user) => user.handle === handle) ?? null,
+                ),
+              };
+            },
+          ),
         };
       }
       if (table === "publishers") {
         return {
-          withIndex: vi.fn((_indexName: string, builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown) => {
-            let handle = "";
-            let linkedUserId = "";
-            const q = {
-              eq: (field: string, value: string) => {
-                if (field === "handle") handle = value;
-                if (field === "linkedUserId") linkedUserId = value;
-                return q;
-              },
-            };
-            builder?.(q);
-            return {
-              unique: vi.fn(async () => {
-                if (handle) {
-                  return [...publishers.values()].find((publisher) => publisher.handle === handle) ?? null;
-                }
-                if (linkedUserId) {
-                  return (
-                    [...publishers.values()].find((publisher) => publisher.linkedUserId === linkedUserId) ??
-                    null
-                  );
-                }
-                return null;
-              }),
-            };
-          }),
+          withIndex: vi.fn(
+            (
+              _indexName: string,
+              builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown,
+            ) => {
+              let handle = "";
+              let linkedUserId = "";
+              const q = {
+                eq: (field: string, value: string) => {
+                  if (field === "handle") handle = value;
+                  if (field === "linkedUserId") linkedUserId = value;
+                  return q;
+                },
+              };
+              builder?.(q);
+              return {
+                unique: vi.fn(async () => {
+                  if (handle) {
+                    return (
+                      [...publishers.values()].find((publisher) => publisher.handle === handle) ??
+                      null
+                    );
+                  }
+                  if (linkedUserId) {
+                    return (
+                      [...publishers.values()].find(
+                        (publisher) => publisher.linkedUserId === linkedUserId,
+                      ) ?? null
+                    );
+                  }
+                  return null;
+                }),
+              };
+            },
+          ),
         };
       }
       if (table === "publisherMembers") {
         return {
-          withIndex: vi.fn((_indexName: string, builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown) => {
-            let publisherId = "";
-            let userId = "";
-            const q = {
-              eq: (field: string, value: string) => {
-                if (field === "publisherId") publisherId = value;
-                if (field === "userId") userId = value;
-                return q;
-              },
-            };
-            builder?.(q);
-            return {
-              unique: vi.fn(async () =>
-                publisherMembers.find(
-                  (member) => member.publisherId === publisherId && member.userId === userId,
-                ) ?? null,
-              ),
-            };
-          }),
+          withIndex: vi.fn(
+            (
+              _indexName: string,
+              builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown,
+            ) => {
+              let publisherId = "";
+              let userId = "";
+              const q = {
+                eq: (field: string, value: string) => {
+                  if (field === "publisherId") publisherId = value;
+                  if (field === "userId") userId = value;
+                  return q;
+                },
+              };
+              builder?.(q);
+              return {
+                unique: vi.fn(
+                  async () =>
+                    publisherMembers.find(
+                      (member) => member.publisherId === publisherId && member.userId === userId,
+                    ) ?? null,
+                ),
+              };
+            },
+          ),
         };
       }
       if (table === "packages") {
         return {
-          withIndex: vi.fn((_indexName: string, builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown) => {
-            let ownerUserId = "";
-            let ownerPublisherId = "";
-            const q = {
-              eq: (field: string, value: string) => {
-                if (field === "ownerUserId") ownerUserId = value;
-                if (field === "ownerPublisherId") ownerPublisherId = value;
-                return q;
-              },
-            };
-            builder?.(q);
-            return {
-              collect: vi.fn(async () => {
-                if (ownerUserId) {
-                  return packages.filter((pkg) => pkg.ownerUserId === ownerUserId);
-                }
-                if (ownerPublisherId) {
-                  return packages.filter((pkg) => pkg.ownerPublisherId === ownerPublisherId);
-                }
-                return [];
-              }),
-            };
-          }),
+          withIndex: vi.fn(
+            (
+              _indexName: string,
+              builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown,
+            ) => {
+              let ownerUserId = "";
+              let ownerPublisherId = "";
+              const q = {
+                eq: (field: string, value: string) => {
+                  if (field === "ownerUserId") ownerUserId = value;
+                  if (field === "ownerPublisherId") ownerPublisherId = value;
+                  return q;
+                },
+              };
+              builder?.(q);
+              return {
+                collect: vi.fn(async () => {
+                  if (ownerUserId) {
+                    return packages.filter((pkg) => pkg.ownerUserId === ownerUserId);
+                  }
+                  if (ownerPublisherId) {
+                    return packages.filter((pkg) => pkg.ownerPublisherId === ownerPublisherId);
+                  }
+                  return [];
+                }),
+              };
+            },
+          ),
         };
       }
       if (table === "skills") {
@@ -636,9 +680,7 @@ describe("legacy publisher migration", () => {
     const result = await migrateLegacyPublisherHandleToOrgInternalHandler(
       {
         db: {
-          get: vi.fn(async (id: string) =>
-            users.get(id) ?? publishers.get(id) ?? null,
-          ),
+          get: vi.fn(async (id: string) => users.get(id) ?? publishers.get(id) ?? null),
           query,
           patch,
           insert,

--- a/convex/publishers.ts
+++ b/convex/publishers.ts
@@ -4,6 +4,7 @@ import type { Doc, Id } from "./_generated/dataModel";
 import type { MutationCtx } from "./_generated/server";
 import { internalMutation, internalQuery, mutation, query } from "./functions";
 import { assertAdmin, requireUser } from "./lib/access";
+import { toPublicPublisher } from "./lib/public";
 import {
   ensurePersonalPublisherForUser,
   getActiveUserByHandleOrPersonalPublisher,
@@ -14,7 +15,6 @@ import {
   isPublisherRoleAllowed,
   normalizePublisherHandle,
 } from "./lib/publishers";
-import { toPublicPublisher } from "./lib/public";
 
 const PUBLISHER_HANDLE_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$/;
 
@@ -88,10 +88,9 @@ async function migrateLegacyPublisherHandleToOrgWithActor(
     throw new ConvexError(`Legacy user "@${orgHandle}" not found`);
   }
 
-  const personalPublisher =
-    legacyUser.personalPublisherId
-      ? await ctx.db.get(legacyUser.personalPublisherId)
-      : await getPersonalPublisherForUser(ctx, legacyUser._id);
+  const personalPublisher = legacyUser.personalPublisherId
+    ? await ctx.db.get(legacyUser.personalPublisherId)
+    : await getPersonalPublisherForUser(ctx, legacyUser._id);
   const convertiblePublisher =
     handlePublisher?.kind === "user" && handlePublisher.linkedUserId === legacyUser._id
       ? handlePublisher
@@ -356,7 +355,9 @@ export const resolvePublishTargetForUserInternal = internalMutation({
   args: {
     actorUserId: v.id("users"),
     ownerHandle: v.optional(v.string()),
-    minimumRole: v.optional(v.union(v.literal("owner"), v.literal("admin"), v.literal("publisher"))),
+    minimumRole: v.optional(
+      v.union(v.literal("owner"), v.literal("admin"), v.literal("publisher")),
+    ),
   },
   handler: async (ctx, args) => {
     const actor = await ctx.db.get(args.actorUserId);
@@ -418,9 +419,9 @@ export const listMine = query({
         if (!publicPublisher) return null;
         return {
           publisher: publicPublisher,
-        role: membership.role,
-      };
-    }),
+          role: membership.role,
+        };
+      }),
     );
     const visiblePublishers = publishers.filter(
       (

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -909,12 +909,7 @@ const packageCapabilitySearchDigest = defineTable({
     "executesCode",
     "updatedAt",
   ])
-  .index("by_active_family_tag_updated", [
-    "softDeletedAt",
-    "family",
-    "capabilityTag",
-    "updatedAt",
-  ])
+  .index("by_active_family_tag_updated", ["softDeletedAt", "family", "capabilityTag", "updatedAt"])
   .index("by_active_family_tag_executes_updated", [
     "softDeletedAt",
     "family",

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -240,9 +240,14 @@ describe("search helpers", () => {
 
     const result = await searchSkillsHandler(
       {
-        vectorSearch: vi.fn().mockResolvedValue(
-          vectorEntries.map((entry, index) => ({ _id: entry.embeddingId, _score: 0.9 - index * 0.01 })),
-        ),
+        vectorSearch: vi
+          .fn()
+          .mockResolvedValue(
+            vectorEntries.map((entry, index) => ({
+              _id: entry.embeddingId,
+              _score: 0.9 - index * 0.01,
+            })),
+          ),
         runQuery,
       },
       { query: "skill-downloader", limit: 10 },

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -132,13 +132,12 @@ export const searchSkills: ReturnType<typeof action> = action({
     if (!query) return [];
     const queryTokens = tokenize(query);
     if (queryTokens.length === 0) return [];
-    const rawExactSlugMatch =
-      isSlugLikeQuery(query)
-        ? ((await ctx.runQuery(internal.search.getExactSkillSlugMatch, {
-            slug: query.toLowerCase(),
-            nonSuspiciousOnly: args.nonSuspiciousOnly,
-          })) as SkillSearchEntry | null)
-        : null;
+    const rawExactSlugMatch = isSlugLikeQuery(query)
+      ? ((await ctx.runQuery(internal.search.getExactSkillSlugMatch, {
+          slug: query.toLowerCase(),
+          nonSuspiciousOnly: args.nonSuspiciousOnly,
+        })) as SkillSearchEntry | null)
+      : null;
     const exactSlugMatch =
       rawExactSlugMatch && (!args.highlightedOnly || isSkillHighlighted(rawExactSlugMatch.skill))
         ? rawExactSlugMatch

--- a/convex/skills.deleteTags.test.ts
+++ b/convex/skills.deleteTags.test.ts
@@ -37,10 +37,7 @@ function buildDigestQuery(table: string) {
   };
 }
 
-function makeCtx(params: {
-  user: Record<string, unknown>;
-  skill: Record<string, unknown> | null;
-}) {
+function makeCtx(params: { user: Record<string, unknown>; skill: Record<string, unknown> | null }) {
   vi.mocked(getAuthUserId).mockResolvedValue(params.user._id as never);
   const patch = vi.fn(async (_id: string, value: Record<string, unknown>) => value);
   const db = {
@@ -144,10 +141,7 @@ describe("deleteTags", () => {
   it("throws for non-owner non-moderator user", async () => {
     const { db, auth } = makeCtx({ user: otherUser, skill: baseSkill });
     await expect(
-      deleteTagsHandler(
-        { db, auth } as never,
-        { skillId: "skills:1", tags: ["stable"] } as never,
-      ),
+      deleteTagsHandler({ db, auth } as never, { skillId: "skills:1", tags: ["stable"] } as never),
     ).rejects.toThrow();
   });
 

--- a/convex/skills.packageCatalog.test.ts
+++ b/convex/skills.packageCatalog.test.ts
@@ -105,8 +105,13 @@ function makeDigest(
   };
 }
 
-function makeCtx(pages: Array<{ page: Array<Record<string, unknown>>; isDone: boolean; continueCursor: string }>) {
-  const pageByCursor = new Map<string | null, { page: Array<Record<string, unknown>>; isDone: boolean; continueCursor: string }>();
+function makeCtx(
+  pages: Array<{ page: Array<Record<string, unknown>>; isDone: boolean; continueCursor: string }>,
+) {
+  const pageByCursor = new Map<
+    string | null,
+    { page: Array<Record<string, unknown>>; isDone: boolean; continueCursor: string }
+  >();
   const allDigests = pages.flatMap((page) => page.page);
   let cursor: string | null = null;
   for (const page of pages) {
@@ -118,7 +123,12 @@ function makeCtx(pages: Array<{ page: Array<Record<string, unknown>>; isDone: bo
       query: (table: string) => {
         if (table === "skills") {
           return {
-            withIndex: (_index: string, builder: (q: { eq: (field: string, value: string) => { field: string; value: string } }) => { field: string; value: string }) => {
+            withIndex: (
+              _index: string,
+              builder: (q: {
+                eq: (field: string, value: string) => { field: string; value: string };
+              }) => { field: string; value: string },
+            ) => {
               const constraint = builder({ eq: (field, value) => ({ field, value }) });
               return {
                 unique: async () => {

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -66,13 +66,13 @@ import {
   reserveSlugForHardDeleteFinalize,
   upsertReservedSlugForRightfulOwner,
 } from "./lib/reservedSlugs";
+import { SKILL_CAPABILITY_TAGS } from "./lib/skillCapabilityTags";
 import {
   fetchText,
   type PublishResult,
   publishVersionForUser,
   queueHighlightedWebhook,
 } from "./lib/skillPublish";
-import { SKILL_CAPABILITY_TAGS } from "./lib/skillCapabilityTags";
 import { getFrontmatterValue, hashSkillFiles } from "./lib/skills";
 import { computeIsSuspicious, isSkillSuspicious } from "./lib/skillSafety";
 import {
@@ -2078,7 +2078,8 @@ export const list = query({
           )
           .unique());
       const isOwnDashboard = Boolean(
-        membership || (userId && ownerPublisher?.kind === "user" && ownerPublisher.linkedUserId === userId),
+        membership ||
+        (userId && ownerPublisher?.kind === "user" && ownerPublisher.linkedUserId === userId),
       );
       const scopedEntries = await ctx.db
         .query("skills")
@@ -2798,12 +2799,13 @@ function decodeSkillCatalogCursor(raw: string | null | undefined): SkillCatalogC
     return { cursor: raw, offset: 0, pageSize: null, done: false };
   }
   try {
-    const parsed = JSON.parse(raw.slice(SKILL_CATALOG_CURSOR_PREFIX.length)) as Partial<SkillCatalogCursorState>;
+    const parsed = JSON.parse(
+      raw.slice(SKILL_CATALOG_CURSOR_PREFIX.length),
+    ) as Partial<SkillCatalogCursorState>;
     return {
       cursor: typeof parsed.cursor === "string" ? parsed.cursor : null,
       offset: typeof parsed.offset === "number" && parsed.offset > 0 ? parsed.offset : 0,
-      pageSize:
-        typeof parsed.pageSize === "number" && parsed.pageSize > 0 ? parsed.pageSize : null,
+      pageSize: typeof parsed.pageSize === "number" && parsed.pageSize > 0 ? parsed.pageSize : null,
       done: parsed.done === true,
     };
   } catch {
@@ -2842,7 +2844,8 @@ function skillCatalogMatchesFilters(
   const channel = getSkillCatalogChannel(digest);
   if (typeof args.isOfficial === "boolean" && isOfficial !== args.isOfficial) return false;
   if (args.channel && channel !== args.channel) return false;
-  if (args.capabilityTag && !(digest.capabilityTags ?? []).includes(args.capabilityTag)) return false;
+  if (args.capabilityTag && !(digest.capabilityTags ?? []).includes(args.capabilityTag))
+    return false;
   return true;
 }
 
@@ -2891,7 +2894,9 @@ function isKnownSkillCapabilityTag(tag: string | undefined) {
 
 export const listPackageCatalogPage = query({
   args: {
-    channel: v.optional(v.union(v.literal("official"), v.literal("community"), v.literal("private"))),
+    channel: v.optional(
+      v.union(v.literal("official"), v.literal("community"), v.literal("private")),
+    ),
     isOfficial: v.optional(v.boolean()),
     executesCode: v.optional(v.boolean()),
     capabilityTag: v.optional(v.string()),
@@ -2924,7 +2929,9 @@ export const listPackageCatalogPage = query({
       loops += 1;
       const effectivePageSize = Math.min(
         remainingScanBudget,
-        offset > 0 && pageSize ? Math.max(pageSize, offset + 1) : Math.max(targetCount * 3, targetCount),
+        offset > 0 && pageSize
+          ? Math.max(pageSize, offset + 1)
+          : Math.max(targetCount * 3, targetCount),
       );
       if (effectivePageSize <= 0) break;
       remainingScanBudget -= effectivePageSize;
@@ -2978,7 +2985,9 @@ export const searchPackageCatalogPublic = query({
   args: {
     query: v.string(),
     limit: v.optional(v.number()),
-    channel: v.optional(v.union(v.literal("official"), v.literal("community"), v.literal("private"))),
+    channel: v.optional(
+      v.union(v.literal("official"), v.literal("community"), v.literal("private")),
+    ),
     isOfficial: v.optional(v.boolean()),
     executesCode: v.optional(v.boolean()),
     capabilityTag: v.optional(v.string()),
@@ -5002,7 +5011,9 @@ export const setSoftDeleted = mutation({
     const now = Date.now();
     const note = args.reason ? trimManualOverrideNote(args.reason) : undefined;
     if (!note) {
-      throw new ConvexError(args.deleted ? "Hide reason is required." : "Restore reason is required.");
+      throw new ConvexError(
+        args.deleted ? "Hide reason is required." : "Restore reason is required.",
+      );
     }
     const patch: Partial<Doc<"skills">> = {
       softDeletedAt: args.deleted ? now : undefined,

--- a/convex/souls.test.ts
+++ b/convex/souls.test.ts
@@ -23,7 +23,10 @@ describe("souls.insertVersion", () => {
       query: vi.fn((table: string) => {
         if (table !== "souls") throw new Error(`unexpected table ${table}`);
         return {
-          withIndex: (name: string, build: ((q: { eq: (field: string, value: string) => unknown }) => unknown) | undefined) => {
+          withIndex: (
+            name: string,
+            build: ((q: { eq: (field: string, value: string) => unknown }) => unknown) | undefined,
+          ) => {
             if (name !== "by_slug") throw new Error(`unexpected index ${name}`);
             const q = {
               eq: (field: string, value: string) => {
@@ -92,7 +95,12 @@ describe("souls.insertVersion", () => {
           query: vi.fn((table: string) => {
             if (table !== "souls") throw new Error(`unexpected table ${table}`);
             return {
-              withIndex: (name: string, build: ((q: { eq: (field: string, value: string) => unknown }) => unknown) | undefined) => {
+              withIndex: (
+                name: string,
+                build:
+                  | ((q: { eq: (field: string, value: string) => unknown }) => unknown)
+                  | undefined,
+              ) => {
                 if (name !== "by_slug") throw new Error(`unexpected index ${name}`);
                 const q = {
                   eq: (field: string, value: string) => {

--- a/convex/users.test.ts
+++ b/convex/users.test.ts
@@ -33,9 +33,8 @@ type WrappedHandler<TArgs, TResult> = {
 };
 
 const meHandler = (me as unknown as WrappedHandler<Record<string, never>, unknown>)._handler;
-const getByHandleHandler = (
-  getByHandle as unknown as WrappedHandler<{ handle: string }, unknown>
-)._handler;
+const getByHandleHandler = (getByHandle as unknown as WrappedHandler<{ handle: string }, unknown>)
+  ._handler;
 
 function makeCtx() {
   const patch = vi.fn();
@@ -136,7 +135,10 @@ function makeListCtx(
     if (table === "users") {
       return {
         order,
-        withIndex: (name: string, cb?: (q: { eq: (field: string, value: string) => unknown }) => unknown) => {
+        withIndex: (
+          name: string,
+          cb?: (q: { eq: (field: string, value: string) => unknown }) => unknown,
+        ) => {
           if (name !== "handle") throw new Error(`Unexpected users index ${name}`);
           let handle = "";
           cb?.({
@@ -145,13 +147,18 @@ function makeListCtx(
               return {};
             },
           });
-          return { unique: vi.fn(async () => users.find((user) => user.handle === handle) ?? null) };
+          return {
+            unique: vi.fn(async () => users.find((user) => user.handle === handle) ?? null),
+          };
         },
       };
     }
     if (table === "publishers") {
       return {
-        withIndex: (name: string, cb?: (q: { eq: (field: string, value: string) => unknown }) => unknown) => {
+        withIndex: (
+          name: string,
+          cb?: (q: { eq: (field: string, value: string) => unknown }) => unknown,
+        ) => {
           if (name !== "by_handle") throw new Error(`Unexpected publishers index ${name}`);
           let handle = "";
           cb?.({
@@ -397,7 +404,10 @@ describe("ensureHandler", () => {
       }
       if (table === "publishers") {
         return {
-          withIndex: (name: string, builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown) => {
+          withIndex: (
+            name: string,
+            builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown,
+          ) => {
             let handle = "";
             let linkedUserId = "";
             const q = {
@@ -548,7 +558,10 @@ describe("ensureHandler", () => {
       }
       if (table === "publishers") {
         return {
-          withIndex: (name: string, builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown) => {
+          withIndex: (
+            name: string,
+            builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown,
+          ) => {
             let handle = "";
             let linkedUserId = "";
             const q = {
@@ -908,7 +921,10 @@ describe("users.syncGitHubProfileInternal", () => {
       }
       if (table === "publishers") {
         return {
-          withIndex: (name: string, builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown) => {
+          withIndex: (
+            name: string,
+            builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown,
+          ) => {
             let handle = "";
             let linkedUserId = "";
             const q = {

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -3,15 +3,20 @@ import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import type { ActionCtx, MutationCtx } from "./_generated/server";
 import { internalAction, internalMutation, internalQuery, mutation, query } from "./functions";
-import { assertAdmin, assertModerator, getOptionalActiveAuthUserId, requireUser } from "./lib/access";
+import {
+  assertAdmin,
+  assertModerator,
+  getOptionalActiveAuthUserId,
+  requireUser,
+} from "./lib/access";
 import { syncGitHubProfile } from "./lib/githubAccount";
+import { toPublicUser } from "./lib/public";
 import {
   ensurePersonalPublisherForUser,
   getActiveUserByHandleOrPersonalPublisher,
   getPublisherByHandle,
   getUserByHandleOrPersonalPublisher,
 } from "./lib/publishers";
-import { toPublicUser } from "./lib/public";
 import {
   getLatestActiveReservedHandle,
   isHandleReservedForAnotherUser,
@@ -296,7 +301,9 @@ export async function ensureHandler(ctx: MutationCtx) {
     updates.updatedAt = Date.now();
     await ctx.db.patch(userId, updates);
   }
-  const ensuredUser = hasUpdates ? ({ ...user, ...updates } as Doc<"users">) : ((await ctx.db.get(userId)) ?? user);
+  const ensuredUser = hasUpdates
+    ? ({ ...user, ...updates } as Doc<"users">)
+    : ((await ctx.db.get(userId)) ?? user);
   await ensurePersonalPublisherForUser(ctx, ensuredUser);
   return await ctx.db.get(userId);
 }
@@ -853,7 +860,8 @@ async function ensurePublisherHandleWithActor(
 
   if (existing) {
     const nextDisplayName =
-      args.displayName?.trim() && (!existing.displayName || existing.displayName === existing.handle)
+      args.displayName?.trim() &&
+      (!existing.displayName || existing.displayName === existing.handle)
         ? displayName
         : existing.displayName;
     await ctx.db.patch(existing._id, {

--- a/convex/vt.test.ts
+++ b/convex/vt.test.ts
@@ -161,11 +161,10 @@ describe("package VT retries", () => {
       { releaseId: "packageReleases:demo", attempt: 2 },
     );
 
-    expect(scheduler.runAfter).toHaveBeenCalledWith(
-      5 * 60 * 1000,
-      expect.anything(),
-      { releaseId: "packageReleases:demo", attempt: 3 },
-    );
+    expect(scheduler.runAfter).toHaveBeenCalledWith(5 * 60 * 1000, expect.anything(), {
+      releaseId: "packageReleases:demo",
+      attempt: 3,
+    });
   });
 
   it("retries package upload when VT upload fails", async () => {
@@ -195,7 +194,9 @@ describe("package VT retries", () => {
         runMutation,
         scheduler,
         storage: {
-          get: vi.fn(async () => new Blob(['{"name":"demo-plugin"}'], { type: "application/json" })),
+          get: vi.fn(
+            async () => new Blob(['{"name":"demo-plugin"}'], { type: "application/json" }),
+          ),
         },
       } as never,
       { releaseId: "packageReleases:demo" },
@@ -208,11 +209,10 @@ describe("package VT retries", () => {
         sha256hash: expect.any(String),
       }),
     );
-    expect(scheduler.runAfter).toHaveBeenCalledWith(
-      5 * 60 * 1000,
-      expect.anything(),
-      { releaseId: "packageReleases:demo", attempt: 2 },
-    );
+    expect(scheduler.runAfter).toHaveBeenCalledWith(5 * 60 * 1000, expect.anything(), {
+      releaseId: "packageReleases:demo",
+      attempt: 2,
+    });
   });
 
   it("uses existing AV engine verdicts for packages without re-uploading", async () => {
@@ -258,7 +258,9 @@ describe("package VT retries", () => {
         runMutation,
         scheduler,
         storage: {
-          get: vi.fn(async () => new Blob(['{"name":"demo-plugin"}'], { type: "application/json" })),
+          get: vi.fn(
+            async () => new Blob(['{"name":"demo-plugin"}'], { type: "application/json" }),
+          ),
         },
       } as never,
       { releaseId: "packageReleases:demo" },
@@ -324,7 +326,9 @@ describe("package VT retries", () => {
         runMutation,
         scheduler,
         storage: {
-          get: vi.fn(async () => new Blob(['{"name":"demo-plugin"}'], { type: "application/json" })),
+          get: vi.fn(
+            async () => new Blob(['{"name":"demo-plugin"}'], { type: "application/json" }),
+          ),
         },
       } as never,
       { releaseId: "packageReleases:demo" },
@@ -334,9 +338,7 @@ describe("package VT retries", () => {
     const mutationCalls = runMutation.mock.calls as unknown as Array<
       [unknown, Record<string, unknown>]
     >;
-    expect(
-      mutationCalls.some(([, payload]) => "vtAnalysis" in payload),
-    ).toBe(false);
+    expect(mutationCalls.some(([, payload]) => "vtAnalysis" in payload)).toBe(false);
     expect(fetchMock.mock.calls.length).toBe(2);
     expect(scheduler.runAfter.mock.calls.length).toBe(1);
   });
@@ -384,7 +386,9 @@ describe("package VT retries", () => {
         runMutation,
         scheduler,
         storage: {
-          get: vi.fn(async () => new Blob(['{"name":"demo-plugin"}'], { type: "application/json" })),
+          get: vi.fn(
+            async () => new Blob(['{"name":"demo-plugin"}'], { type: "application/json" }),
+          ),
         },
       } as never,
       { releaseId: "packageReleases:demo" },
@@ -448,7 +452,9 @@ describe("package VT retries", () => {
         runMutation,
         scheduler,
         storage: {
-          get: vi.fn(async () => new Blob(['{"name":"demo-plugin"}'], { type: "application/json" })),
+          get: vi.fn(
+            async () => new Blob(['{"name":"demo-plugin"}'], { type: "application/json" }),
+          ),
         },
       } as never,
       { releaseId: "packageReleases:demo" },
@@ -488,11 +494,10 @@ describe("package VT retries", () => {
       { releaseId: "packageReleases:demo", attempt: 3 },
     );
 
-    expect(scheduler.runAfter).toHaveBeenCalledWith(
-      5 * 60 * 1000,
-      expect.anything(),
-      { releaseId: "packageReleases:demo", attempt: 4 },
-    );
+    expect(scheduler.runAfter).toHaveBeenCalledWith(5 * 60 * 1000, expect.anything(), {
+      releaseId: "packageReleases:demo",
+      attempt: 4,
+    });
   });
 
   it("does not apply undetected-only fallback during package polling when static scan is suspicious", async () => {
@@ -660,10 +665,9 @@ describe("package VT retries", () => {
 
     expect(runMutation).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(scheduler.runAfter).toHaveBeenCalledWith(
-      5 * 60 * 1000,
-      expect.anything(),
-      { releaseId: "packageReleases:demo", attempt: 4 },
-    );
+    expect(scheduler.runAfter).toHaveBeenCalledWith(5 * 60 * 1000, expect.anything(), {
+      releaseId: "packageReleases:demo",
+      attempt: 4,
+    });
   });
 });

--- a/convex/vt.ts
+++ b/convex/vt.ts
@@ -635,10 +635,15 @@ export const scanPackageReleaseWithVirusTotal = internalAction({
         `[vt:package] Release ${args.releaseId} missing ${missingFiles}/${release.files.length} files, retrying`,
       );
       if (attempt < PACKAGE_SCAN_MAX_ATTEMPTS) {
-        await runAfterRef(ctx, PACKAGE_SCAN_RETRY_DELAY_MS, internalRefs.vt.scanPackageReleaseWithVirusTotal, {
-          releaseId: args.releaseId,
-          attempt: attempt + 1,
-        });
+        await runAfterRef(
+          ctx,
+          PACKAGE_SCAN_RETRY_DELAY_MS,
+          internalRefs.vt.scanPackageReleaseWithVirusTotal,
+          {
+            releaseId: args.releaseId,
+            attempt: attempt + 1,
+          },
+        );
       }
       return;
     }
@@ -686,18 +691,28 @@ export const scanPackageReleaseWithVirusTotal = internalAction({
         const error = await response.text();
         console.error("[vt:package] VirusTotal upload error:", error);
         if (attempt < PACKAGE_SCAN_MAX_ATTEMPTS) {
-          await runAfterRef(ctx, PACKAGE_SCAN_RETRY_DELAY_MS, internalRefs.vt.scanPackageReleaseWithVirusTotal, {
-            releaseId: args.releaseId,
-            attempt: attempt + 1,
-          });
+          await runAfterRef(
+            ctx,
+            PACKAGE_SCAN_RETRY_DELAY_MS,
+            internalRefs.vt.scanPackageReleaseWithVirusTotal,
+            {
+              releaseId: args.releaseId,
+              attempt: attempt + 1,
+            },
+          );
         }
         return;
       }
 
-      await runAfterRef(ctx, PACKAGE_SCAN_RETRY_DELAY_MS, internalRefs.vt.pollPackageReleaseScanResults, {
-        releaseId: args.releaseId,
-        attempt: 1,
-      });
+      await runAfterRef(
+        ctx,
+        PACKAGE_SCAN_RETRY_DELAY_MS,
+        internalRefs.vt.pollPackageReleaseScanResults,
+        {
+          releaseId: args.releaseId,
+          attempt: 1,
+        },
+      );
 
       console.log(
         `[vt:package] Uploaded ${pkg.name}@${release.version} for scanning (${sha256hash})`,
@@ -705,10 +720,15 @@ export const scanPackageReleaseWithVirusTotal = internalAction({
     } catch (error) {
       console.error("[vt:package] Failed to upload to VirusTotal:", error);
       if (attempt < PACKAGE_SCAN_MAX_ATTEMPTS) {
-        await runAfterRef(ctx, PACKAGE_SCAN_RETRY_DELAY_MS, internalRefs.vt.scanPackageReleaseWithVirusTotal, {
-          releaseId: args.releaseId,
-          attempt: attempt + 1,
-        });
+        await runAfterRef(
+          ctx,
+          PACKAGE_SCAN_RETRY_DELAY_MS,
+          internalRefs.vt.scanPackageReleaseWithVirusTotal,
+          {
+            releaseId: args.releaseId,
+            attempt: attempt + 1,
+          },
+        );
       }
     }
   },
@@ -737,10 +757,15 @@ export const pollPackageReleaseScanResults = internalAction({
       const vtResult = await checkExistingFile(apiKey, release.sha256hash);
       if (!vtResult) {
         if (attempt < PACKAGE_SCAN_MAX_ATTEMPTS) {
-          await runAfterRef(ctx, PACKAGE_SCAN_RETRY_DELAY_MS, internalRefs.vt.pollPackageReleaseScanResults, {
-            releaseId: args.releaseId,
-            attempt: attempt + 1,
-          });
+          await runAfterRef(
+            ctx,
+            PACKAGE_SCAN_RETRY_DELAY_MS,
+            internalRefs.vt.pollPackageReleaseScanResults,
+            {
+              releaseId: args.releaseId,
+              attempt: attempt + 1,
+            },
+          );
         }
         return;
       }
@@ -756,18 +781,28 @@ export const pollPackageReleaseScanResults = internalAction({
 
       await requestRescan(apiKey, release.sha256hash);
       if (attempt < PACKAGE_SCAN_MAX_ATTEMPTS) {
-        await runAfterRef(ctx, PACKAGE_SCAN_RETRY_DELAY_MS, internalRefs.vt.pollPackageReleaseScanResults, {
-          releaseId: args.releaseId,
-          attempt: attempt + 1,
-        });
+        await runAfterRef(
+          ctx,
+          PACKAGE_SCAN_RETRY_DELAY_MS,
+          internalRefs.vt.pollPackageReleaseScanResults,
+          {
+            releaseId: args.releaseId,
+            attempt: attempt + 1,
+          },
+        );
       }
     } catch (error) {
       console.error(`[vt:package] Error polling ${release.sha256hash}:`, error);
       if (attempt < PACKAGE_SCAN_MAX_ATTEMPTS) {
-        await runAfterRef(ctx, PACKAGE_SCAN_RETRY_DELAY_MS, internalRefs.vt.pollPackageReleaseScanResults, {
-          releaseId: args.releaseId,
-          attempt: attempt + 1,
-        });
+        await runAfterRef(
+          ctx,
+          PACKAGE_SCAN_RETRY_DELAY_MS,
+          internalRefs.vt.pollPackageReleaseScanResults,
+          {
+            releaseId: args.releaseId,
+            attempt: attempt + 1,
+          },
+        );
       }
     }
   },

--- a/docs/orgs.md
+++ b/docs/orgs.md
@@ -485,4 +485,3 @@ Add or update tests for:
   drift
 - Do not keep slug-only and scoped lookup logic equally primary; one must win
 - Prefer publisher abstraction over `ownerUserId | ownerOrgId` unions
-

--- a/e2e/clawhub.e2e.test.ts
+++ b/e2e/clawhub.e2e.test.ts
@@ -370,242 +370,246 @@ describe("clawhub e2e", () => {
     expect(result.stdout).toMatch(/--json/);
   });
 
-  itIfLiveMutations("publishes, deletes, and undeletes a skill (logged-in)", async () => {
-    const registry = getRegistry();
-    const site = getSite();
-    const token = mustGetToken() ?? (await readGlobalConfig())?.token ?? null;
-    if (!token) {
-      throw new Error("Missing token. Set CLAWHUB_E2E_TOKEN or run: bun clawhub auth login");
-    }
-
-    const cfg = await makeTempConfig(registry, token);
-    const workdir = await mkdtemp(join(tmpdir(), "clawhub-e2e-publish-"));
-    const installWorkdir = await mkdtemp(join(tmpdir(), "clawhub-e2e-install-"));
-    const slug = `e2e-${Date.now()}`;
-    const skillDir = join(workdir, slug);
-
-    try {
-      await mkdir(skillDir, { recursive: true });
-      await writeFile(join(skillDir, "SKILL.md"), buildE2ESkillMarkdown(slug), "utf8");
-
-      const publish1 = spawnSync(
-        "bun",
-        [
-          "clawhub",
-          "publish",
-          skillDir,
-          "--slug",
-          slug,
-          "--name",
-          `E2E ${slug}`,
-          "--version",
-          "1.0.0",
-          "--tags",
-          "latest",
-          "--site",
-          site,
-          "--registry",
-          registry,
-          "--workdir",
-          workdir,
-        ],
-        {
-          cwd: process.cwd(),
-          env: { ...process.env, CLAWHUB_CONFIG_PATH: cfg.path, CLAWHUB_DISABLE_TELEMETRY: "1" },
-          encoding: "utf8",
-        },
-      );
-      expect(publish1.status).toBe(0);
-      expect(publish1.stderr).not.toMatch(/changelog required/i);
-
-      const publish2 = spawnSync(
-        "bun",
-        [
-          "clawhub",
-          "publish",
-          skillDir,
-          "--slug",
-          slug,
-          "--name",
-          `E2E ${slug}`,
-          "--version",
-          "1.0.1",
-          "--tags",
-          "latest",
-          "--site",
-          site,
-          "--registry",
-          registry,
-          "--workdir",
-          workdir,
-        ],
-        {
-          cwd: process.cwd(),
-          env: { ...process.env, CLAWHUB_CONFIG_PATH: cfg.path, CLAWHUB_DISABLE_TELEMETRY: "1" },
-          encoding: "utf8",
-        },
-      );
-      expect(publish2.status).toBe(0);
-      expect(publish2.stderr).not.toMatch(/changelog required/i);
-
-      const downloadUrl = new URL(ApiRoutes.download, registry);
-      downloadUrl.searchParams.set("slug", slug);
-      downloadUrl.searchParams.set("version", "1.0.1");
-      const zipRes = await fetchWithTimeout(downloadUrl.toString());
-      expect(zipRes.ok).toBe(true);
-      const zipBytes = new Uint8Array(await zipRes.arrayBuffer());
-      const unzipped = unzipSync(zipBytes);
-      expect(Object.keys(unzipped)).toContain("SKILL.md");
-
-      const install = spawnSync(
-        "bun",
-        [
-          "clawhub",
-          "install",
-          slug,
-          "--version",
-          "1.0.0",
-          "--force",
-          "--site",
-          site,
-          "--registry",
-          registry,
-          "--workdir",
-          installWorkdir,
-        ],
-        {
-          cwd: process.cwd(),
-          env: { ...process.env, CLAWHUB_CONFIG_PATH: cfg.path, CLAWHUB_DISABLE_TELEMETRY: "1" },
-          encoding: "utf8",
-        },
-      );
-      expect(install.status).toBe(0);
-
-      const list = spawnSync(
-        "bun",
-        ["clawhub", "list", "--site", site, "--registry", registry, "--workdir", installWorkdir],
-        {
-          cwd: process.cwd(),
-          env: { ...process.env, CLAWHUB_CONFIG_PATH: cfg.path, CLAWHUB_DISABLE_TELEMETRY: "1" },
-          encoding: "utf8",
-        },
-      );
-      expect(list.status).toBe(0);
-      expect(list.stdout).toMatch(new RegExp(`${slug}\\s+1\\.0\\.0`));
-
-      const update = spawnSync(
-        "bun",
-        [
-          "clawhub",
-          "update",
-          slug,
-          "--force",
-          "--site",
-          site,
-          "--registry",
-          registry,
-          "--workdir",
-          installWorkdir,
-        ],
-        {
-          cwd: process.cwd(),
-          env: { ...process.env, CLAWHUB_CONFIG_PATH: cfg.path, CLAWHUB_DISABLE_TELEMETRY: "1" },
-          encoding: "utf8",
-        },
-      );
-      expect(update.status).toBe(0);
-
-      const metaUrl = new URL(`${ApiRoutes.skills}/${slug}`, registry);
-      const metaRes = await fetchWithTimeout(metaUrl.toString(), {
-        headers: { Accept: "application/json" },
-      });
-      expect(metaRes.status).toBe(200);
-
-      const del = spawnSync(
-        "bun",
-        [
-          "clawhub",
-          "delete",
-          slug,
-          "--yes",
-          "--site",
-          site,
-          "--registry",
-          registry,
-          "--workdir",
-          workdir,
-        ],
-        {
-          cwd: process.cwd(),
-          env: { ...process.env, CLAWHUB_CONFIG_PATH: cfg.path, CLAWHUB_DISABLE_TELEMETRY: "1" },
-          encoding: "utf8",
-        },
-      );
-      expect(del.status).toBe(0);
-
-      const metaAfterDelete = await fetchWithTimeout(metaUrl.toString(), {
-        headers: { Accept: "application/json" },
-      });
-      expect(metaAfterDelete.status).toBe(404);
-
-      const downloadAfterDelete = await fetchWithTimeout(downloadUrl.toString());
-      expect(downloadAfterDelete.status).toBe(404);
-
-      const undelete = spawnSync(
-        "bun",
-        [
-          "clawhub",
-          "undelete",
-          slug,
-          "--yes",
-          "--site",
-          site,
-          "--registry",
-          registry,
-          "--workdir",
-          workdir,
-        ],
-        {
-          cwd: process.cwd(),
-          env: { ...process.env, CLAWHUB_CONFIG_PATH: cfg.path, CLAWHUB_DISABLE_TELEMETRY: "1" },
-          encoding: "utf8",
-        },
-      );
-      expect(undelete.status).toBe(0);
-
-      const metaAfterUndelete = await fetchWithTimeout(metaUrl.toString(), {
-        headers: { Accept: "application/json" },
-      });
-      expect(metaAfterUndelete.status).toBe(200);
-    } finally {
-      const cleanup = spawnSync(
-        "bun",
-        [
-          "clawhub",
-          "delete",
-          slug,
-          "--yes",
-          "--site",
-          site,
-          "--registry",
-          registry,
-          "--workdir",
-          workdir,
-        ],
-        {
-          cwd: process.cwd(),
-          env: { ...process.env, CLAWHUB_CONFIG_PATH: cfg.path, CLAWHUB_DISABLE_TELEMETRY: "1" },
-          encoding: "utf8",
-        },
-      );
-      if (cleanup.status !== 0) {
-        // best-effort cleanup
+  itIfLiveMutations(
+    "publishes, deletes, and undeletes a skill (logged-in)",
+    async () => {
+      const registry = getRegistry();
+      const site = getSite();
+      const token = mustGetToken() ?? (await readGlobalConfig())?.token ?? null;
+      if (!token) {
+        throw new Error("Missing token. Set CLAWHUB_E2E_TOKEN or run: bun clawhub auth login");
       }
-      await rm(workdir, { recursive: true, force: true });
-      await rm(installWorkdir, { recursive: true, force: true });
-      await rm(cfg.dir, { recursive: true, force: true });
-    }
-  }, 180_000);
+
+      const cfg = await makeTempConfig(registry, token);
+      const workdir = await mkdtemp(join(tmpdir(), "clawhub-e2e-publish-"));
+      const installWorkdir = await mkdtemp(join(tmpdir(), "clawhub-e2e-install-"));
+      const slug = `e2e-${Date.now()}`;
+      const skillDir = join(workdir, slug);
+
+      try {
+        await mkdir(skillDir, { recursive: true });
+        await writeFile(join(skillDir, "SKILL.md"), buildE2ESkillMarkdown(slug), "utf8");
+
+        const publish1 = spawnSync(
+          "bun",
+          [
+            "clawhub",
+            "publish",
+            skillDir,
+            "--slug",
+            slug,
+            "--name",
+            `E2E ${slug}`,
+            "--version",
+            "1.0.0",
+            "--tags",
+            "latest",
+            "--site",
+            site,
+            "--registry",
+            registry,
+            "--workdir",
+            workdir,
+          ],
+          {
+            cwd: process.cwd(),
+            env: { ...process.env, CLAWHUB_CONFIG_PATH: cfg.path, CLAWHUB_DISABLE_TELEMETRY: "1" },
+            encoding: "utf8",
+          },
+        );
+        expect(publish1.status).toBe(0);
+        expect(publish1.stderr).not.toMatch(/changelog required/i);
+
+        const publish2 = spawnSync(
+          "bun",
+          [
+            "clawhub",
+            "publish",
+            skillDir,
+            "--slug",
+            slug,
+            "--name",
+            `E2E ${slug}`,
+            "--version",
+            "1.0.1",
+            "--tags",
+            "latest",
+            "--site",
+            site,
+            "--registry",
+            registry,
+            "--workdir",
+            workdir,
+          ],
+          {
+            cwd: process.cwd(),
+            env: { ...process.env, CLAWHUB_CONFIG_PATH: cfg.path, CLAWHUB_DISABLE_TELEMETRY: "1" },
+            encoding: "utf8",
+          },
+        );
+        expect(publish2.status).toBe(0);
+        expect(publish2.stderr).not.toMatch(/changelog required/i);
+
+        const downloadUrl = new URL(ApiRoutes.download, registry);
+        downloadUrl.searchParams.set("slug", slug);
+        downloadUrl.searchParams.set("version", "1.0.1");
+        const zipRes = await fetchWithTimeout(downloadUrl.toString());
+        expect(zipRes.ok).toBe(true);
+        const zipBytes = new Uint8Array(await zipRes.arrayBuffer());
+        const unzipped = unzipSync(zipBytes);
+        expect(Object.keys(unzipped)).toContain("SKILL.md");
+
+        const install = spawnSync(
+          "bun",
+          [
+            "clawhub",
+            "install",
+            slug,
+            "--version",
+            "1.0.0",
+            "--force",
+            "--site",
+            site,
+            "--registry",
+            registry,
+            "--workdir",
+            installWorkdir,
+          ],
+          {
+            cwd: process.cwd(),
+            env: { ...process.env, CLAWHUB_CONFIG_PATH: cfg.path, CLAWHUB_DISABLE_TELEMETRY: "1" },
+            encoding: "utf8",
+          },
+        );
+        expect(install.status).toBe(0);
+
+        const list = spawnSync(
+          "bun",
+          ["clawhub", "list", "--site", site, "--registry", registry, "--workdir", installWorkdir],
+          {
+            cwd: process.cwd(),
+            env: { ...process.env, CLAWHUB_CONFIG_PATH: cfg.path, CLAWHUB_DISABLE_TELEMETRY: "1" },
+            encoding: "utf8",
+          },
+        );
+        expect(list.status).toBe(0);
+        expect(list.stdout).toMatch(new RegExp(`${slug}\\s+1\\.0\\.0`));
+
+        const update = spawnSync(
+          "bun",
+          [
+            "clawhub",
+            "update",
+            slug,
+            "--force",
+            "--site",
+            site,
+            "--registry",
+            registry,
+            "--workdir",
+            installWorkdir,
+          ],
+          {
+            cwd: process.cwd(),
+            env: { ...process.env, CLAWHUB_CONFIG_PATH: cfg.path, CLAWHUB_DISABLE_TELEMETRY: "1" },
+            encoding: "utf8",
+          },
+        );
+        expect(update.status).toBe(0);
+
+        const metaUrl = new URL(`${ApiRoutes.skills}/${slug}`, registry);
+        const metaRes = await fetchWithTimeout(metaUrl.toString(), {
+          headers: { Accept: "application/json" },
+        });
+        expect(metaRes.status).toBe(200);
+
+        const del = spawnSync(
+          "bun",
+          [
+            "clawhub",
+            "delete",
+            slug,
+            "--yes",
+            "--site",
+            site,
+            "--registry",
+            registry,
+            "--workdir",
+            workdir,
+          ],
+          {
+            cwd: process.cwd(),
+            env: { ...process.env, CLAWHUB_CONFIG_PATH: cfg.path, CLAWHUB_DISABLE_TELEMETRY: "1" },
+            encoding: "utf8",
+          },
+        );
+        expect(del.status).toBe(0);
+
+        const metaAfterDelete = await fetchWithTimeout(metaUrl.toString(), {
+          headers: { Accept: "application/json" },
+        });
+        expect(metaAfterDelete.status).toBe(404);
+
+        const downloadAfterDelete = await fetchWithTimeout(downloadUrl.toString());
+        expect(downloadAfterDelete.status).toBe(404);
+
+        const undelete = spawnSync(
+          "bun",
+          [
+            "clawhub",
+            "undelete",
+            slug,
+            "--yes",
+            "--site",
+            site,
+            "--registry",
+            registry,
+            "--workdir",
+            workdir,
+          ],
+          {
+            cwd: process.cwd(),
+            env: { ...process.env, CLAWHUB_CONFIG_PATH: cfg.path, CLAWHUB_DISABLE_TELEMETRY: "1" },
+            encoding: "utf8",
+          },
+        );
+        expect(undelete.status).toBe(0);
+
+        const metaAfterUndelete = await fetchWithTimeout(metaUrl.toString(), {
+          headers: { Accept: "application/json" },
+        });
+        expect(metaAfterUndelete.status).toBe(200);
+      } finally {
+        const cleanup = spawnSync(
+          "bun",
+          [
+            "clawhub",
+            "delete",
+            slug,
+            "--yes",
+            "--site",
+            site,
+            "--registry",
+            registry,
+            "--workdir",
+            workdir,
+          ],
+          {
+            cwd: process.cwd(),
+            env: { ...process.env, CLAWHUB_CONFIG_PATH: cfg.path, CLAWHUB_DISABLE_TELEMETRY: "1" },
+            encoding: "utf8",
+          },
+        );
+        if (cleanup.status !== 0) {
+          // best-effort cleanup
+        }
+        await rm(workdir, { recursive: true, force: true });
+        await rm(installWorkdir, { recursive: true, force: true });
+        await rm(cfg.dir, { recursive: true, force: true });
+      }
+    },
+    180_000,
+  );
 
   it("delete returns proper error for non-existent skill", async () => {
     const registry = getRegistry();

--- a/packages/clawhub/package.json
+++ b/packages/clawhub/package.json
@@ -3,10 +3,10 @@
   "version": "0.10.0",
   "description": "ClawHub CLI \\u2014 install, update, search, and publish skills plus OpenClaw packages.",
   "homepage": "https://clawhub.ai",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/openclaw/clawhub/issues"
   },
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/openclaw/clawhub.git",
@@ -16,9 +16,6 @@
     "clawdhub": "bin/clawdhub.js",
     "clawhub": "bin/clawdhub.js"
   },
-  "publishConfig": {
-    "access": "public"
-  },
   "files": [
     "bin",
     "dist",
@@ -26,15 +23,18 @@
     "LICENSE"
   ],
   "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "node ./scripts/build.mjs",
     "dev": "node --enable-source-maps dist/cli.js",
     "prepublishOnly": "npm run build",
     "test": "bun run test:src",
-    "test:src": "vitest run -c vitest.config.ts",
-    "verify:build": "tsc -p tsconfig.json --noEmit",
     "test:artifact": "bun run build && vitest run -c vitest.artifact.config.ts",
-    "verify": "bun run test:src && bun run verify:build && bun run test:artifact"
+    "test:src": "vitest run -c vitest.config.ts",
+    "verify": "bun run test:src && bun run verify:build && bun run test:artifact",
+    "verify:build": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
     "@clack/prompts": "^1.1.0",

--- a/packages/clawhub/src/cli.ts
+++ b/packages/clawhub/src/cli.ts
@@ -348,9 +348,7 @@ skill
     await cmdPublish(opts, folder, options);
   });
 
-const packageCmd = program
-  .command("package")
-  .description("Browse and publish OpenClaw packages");
+const packageCmd = program.command("package").description("Browse and publish OpenClaw packages");
 
 packageCmd
   .command("explore")

--- a/packages/clawhub/src/cli/commands/github.test.ts
+++ b/packages/clawhub/src/cli/commands/github.test.ts
@@ -1,9 +1,9 @@
 /* @vitest-environment node */
 
+import { spawnSync } from "node:child_process";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { spawnSync } from "node:child_process";
 import { zipSync } from "fflate";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { fetchGitHubSource, resolveLocalGitInfo, resolveSourceInput } from "./github";
@@ -60,7 +60,16 @@ function mockGitHubCommitLookup(validRefs: string[]) {
 
 describe("github publish source helpers", () => {
   it.each([
-    ["owner/repo", { kind: "github", owner: "owner", repo: "repo", path: ".", url: "https://github.com/owner/repo" }],
+    [
+      "owner/repo",
+      {
+        kind: "github",
+        owner: "owner",
+        repo: "repo",
+        path: ".",
+        url: "https://github.com/owner/repo",
+      },
+    ],
     [
       "owner/repo@v1.0.0",
       {
@@ -172,18 +181,22 @@ describe("github publish source helpers", () => {
     }
   });
 
-  it.each(["./local-folder", "/absolute/path", "~/path", ".", "@scope/package", "owner/repo/extra"])(
-    "treats %s as a local path",
-    async (input) => {
-      const workdir = await makeTmpDir();
-      try {
-        const resolved = await resolveSourceInput(input, { workdir });
-        expect(resolved.kind).toBe("local");
-      } finally {
-        await rm(workdir, { recursive: true, force: true });
-      }
-    },
-  );
+  it.each([
+    "./local-folder",
+    "/absolute/path",
+    "~/path",
+    ".",
+    "@scope/package",
+    "owner/repo/extra",
+  ])("treats %s as a local path", async (input) => {
+    const workdir = await makeTmpDir();
+    try {
+      const resolved = await resolveSourceInput(input, { workdir });
+      expect(resolved.kind).toBe("local");
+    } finally {
+      await rm(workdir, { recursive: true, force: true });
+    }
+  });
 
   it("prefers an existing local directory over GitHub shorthand", async () => {
     const workdir = await makeTmpDir();
@@ -210,7 +223,15 @@ describe("github publish source helpers", () => {
       runGit(root, ["init", "-b", "main"]);
       runGit(root, ["remote", "add", "origin", "git@github.com:openclaw/demo-repo.git"]);
       runGit(root, ["add", "."]);
-      runGit(root, ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init"]);
+      runGit(root, [
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.com",
+        "commit",
+        "-m",
+        "init",
+      ]);
       const commit = runGit(root, ["rev-parse", "HEAD"]);
       const gitRoot = runGit(root, ["rev-parse", "--show-toplevel"]);
       runGit(root, ["-c", "tag.gpgSign=false", "tag", "v1.0.0"]);
@@ -243,7 +264,9 @@ describe("github publish source helpers", () => {
       "repo-root/.agents/": new Uint8Array(),
       "repo-root/.agents/config.json": new TextEncoder().encode('{"ok":true}\n'),
       "repo-root/package.json": new TextEncoder().encode('{"name":"demo","version":"1.0.0"}\n'),
-      "repo-root/openclaw.plugin.json": new TextEncoder().encode('{"id":"demo","configSchema":{"type":"object"}}\n'),
+      "repo-root/openclaw.plugin.json": new TextEncoder().encode(
+        '{"id":"demo","configSchema":{"type":"object"}}\n',
+      ),
     });
     const archiveBody = archiveBytes.buffer.slice(
       archiveBytes.byteOffset,
@@ -304,7 +327,9 @@ describe("github publish source helpers", () => {
     const archiveBytes = zipSync({
       "repo-root/../../escape.txt": new TextEncoder().encode("bad\n"),
       "repo-root/package.json": new TextEncoder().encode('{"name":"demo","version":"1.0.0"}\n'),
-      "repo-root/openclaw.plugin.json": new TextEncoder().encode('{"id":"demo","configSchema":{"type":"object"}}\n'),
+      "repo-root/openclaw.plugin.json": new TextEncoder().encode(
+        '{"id":"demo","configSchema":{"type":"object"}}\n',
+      ),
     });
     const archiveBody = archiveBytes.buffer.slice(
       archiveBytes.byteOffset,

--- a/packages/clawhub/src/cli/commands/github.ts
+++ b/packages/clawhub/src/cli/commands/github.ts
@@ -1,8 +1,8 @@
 import { spawnSync } from "node:child_process";
 import { mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises";
-import { unzipSync } from "fflate";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve, sep } from "node:path";
+import { unzipSync } from "fflate";
 
 const GITHUB_API = "https://api.github.com";
 const GITHUB_HOSTS = new Set(["github.com", "www.github.com"]);
@@ -68,11 +68,14 @@ export async function resolveSourceInput(
   return { kind: "local", path: resolveLocalPath(options.workdir, trimmed) };
 }
 
-export async function fetchGitHubSource(source: Extract<ResolvedPublishSource, { kind: "github" }>) {
+export async function fetchGitHubSource(
+  source: Extract<ResolvedPublishSource, { kind: "github" }>,
+) {
   const token = process.env.GITHUB_TOKEN?.trim() || undefined;
   const repo = `${source.owner}/${source.repo}`;
   const repoUrl = `https://github.com/${repo}`;
-  const resolvedRef = source.ref?.trim() || (await resolveDefaultBranch(source.owner, source.repo, token));
+  const resolvedRef =
+    source.ref?.trim() || (await resolveDefaultBranch(source.owner, source.repo, token));
   const commit = await resolveCommitSha(source.owner, source.repo, resolvedRef, token);
   const archiveBytes = await downloadGitHubZip(source.owner, source.repo, commit, token);
   const entries = stripSingleTopLevelFolder(unzipSync(archiveBytes));
@@ -152,7 +155,9 @@ export function normalizeGitHubRepo(value: string) {
   }
 }
 
-function parseGitHubShorthand(input: string): Extract<ResolvedPublishSource, { kind: "github" }> | null {
+function parseGitHubShorthand(
+  input: string,
+): Extract<ResolvedPublishSource, { kind: "github" }> | null {
   const atIndex = input.lastIndexOf("@");
   const rawRepo = atIndex > 0 ? input.slice(0, atIndex) : input;
   const rawRef = atIndex > 0 ? input.slice(atIndex + 1).trim() : "";
@@ -178,7 +183,9 @@ function parseGitHubShorthand(input: string): Extract<ResolvedPublishSource, { k
   };
 }
 
-async function parseGitHubUrl(input: string): Promise<Extract<ResolvedPublishSource, { kind: "github" }>> {
+async function parseGitHubUrl(
+  input: string,
+): Promise<Extract<ResolvedPublishSource, { kind: "github" }>> {
   let url: URL;
   try {
     url = new URL(input);

--- a/packages/clawhub/src/cli/commands/moderation.test.ts
+++ b/packages/clawhub/src/cli/commands/moderation.test.ts
@@ -31,7 +31,11 @@ describe("cmdBanUser", () => {
   });
 
   it("posts handle payload", async () => {
-    httpMocks.apiRequest.mockResolvedValueOnce({ ok: true, alreadyBanned: false, deletedSkills: 1 });
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      ok: true,
+      alreadyBanned: false,
+      deletedSkills: 1,
+    });
     await cmdBanUser(makeGlobalOpts(), "hightower6eu", { yes: true }, false);
     expect(httpMocks.apiRequest).toHaveBeenCalledWith(
       expect.anything(),
@@ -45,7 +49,11 @@ describe("cmdBanUser", () => {
   });
 
   it("includes reason when provided", async () => {
-    httpMocks.apiRequest.mockResolvedValueOnce({ ok: true, alreadyBanned: false, deletedSkills: 0 });
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      ok: true,
+      alreadyBanned: false,
+      deletedSkills: 0,
+    });
     await cmdBanUser(
       makeGlobalOpts(),
       "hightower6eu",
@@ -64,7 +72,11 @@ describe("cmdBanUser", () => {
   });
 
   it("posts user id payload when --id is set", async () => {
-    httpMocks.apiRequest.mockResolvedValueOnce({ ok: true, alreadyBanned: false, deletedSkills: 0 });
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      ok: true,
+      alreadyBanned: false,
+      deletedSkills: 0,
+    });
     await cmdBanUser(makeGlobalOpts(), "user_123", { yes: true, id: true }, false);
     expect(httpMocks.apiRequest).toHaveBeenCalledWith(
       expect.anything(),

--- a/packages/clawhub/src/cli/commands/ownership.test.ts
+++ b/packages/clawhub/src/cli/commands/ownership.test.ts
@@ -27,9 +27,9 @@ afterEach(() => {
 
 describe("ownership commands", () => {
   it("rename requires --yes when input is disabled", async () => {
-    await expect(
-      cmdRenameSkill(makeGlobalOpts(), "demo", "demo-new", {}, false),
-    ).rejects.toThrow(/--yes/i);
+    await expect(cmdRenameSkill(makeGlobalOpts(), "demo", "demo-new", {}, false)).rejects.toThrow(
+      /--yes/i,
+    );
   });
 
   it("rename calls rename endpoint", async () => {

--- a/packages/clawhub/src/cli/commands/packages.test.ts
+++ b/packages/clawhub/src/cli/commands/packages.test.ts
@@ -1,9 +1,9 @@
 /* @vitest-environment node */
 
+import { spawnSync } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { spawnSync } from "node:child_process";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createAuthTokenModuleMocks,
@@ -222,7 +222,11 @@ describe("package commands", () => {
         "utf8",
       );
       await writeFile(join(folder, ".gitignore"), "dist/\n", "utf8");
-      await writeFile(join(folder, "openclaw.plugin.json"), JSON.stringify({ id: "demo.plugin" }), "utf8");
+      await writeFile(
+        join(folder, "openclaw.plugin.json"),
+        JSON.stringify({ id: "demo.plugin" }),
+        "utf8",
+      );
       await writeFile(join(folder, "dist", "index.js"), "export const demo = true;\n", "utf8");
 
       httpMocks.apiRequestForm.mockResolvedValueOnce({
@@ -298,7 +302,11 @@ describe("package commands", () => {
         }),
         "utf8",
       );
-      await writeFile(join(folder, "openclaw.plugin.json"), JSON.stringify({ id: "demo.plugin" }), "utf8");
+      await writeFile(
+        join(folder, "openclaw.plugin.json"),
+        JSON.stringify({ id: "demo.plugin" }),
+        "utf8",
+      );
 
       httpMocks.apiRequest.mockResolvedValueOnce({
         token: "clh_short_publish",
@@ -338,7 +346,9 @@ describe("package commands", () => {
         }),
         expect.anything(),
       );
-      const publishArgs = httpMocks.apiRequestForm.mock.calls[0]?.[1] as { token?: string } | undefined;
+      const publishArgs = httpMocks.apiRequestForm.mock.calls[0]?.[1] as
+        | { token?: string }
+        | undefined;
       expect(publishArgs?.token).toBe("clh_short_publish");
     } finally {
       await rm(workdir, { recursive: true, force: true });
@@ -364,7 +374,11 @@ describe("package commands", () => {
         }),
         "utf8",
       );
-      await writeFile(join(folder, "openclaw.plugin.json"), JSON.stringify({ id: "demo.plugin" }), "utf8");
+      await writeFile(
+        join(folder, "openclaw.plugin.json"),
+        JSON.stringify({ id: "demo.plugin" }),
+        "utf8",
+      );
 
       authTokenMocks.requireAuthToken.mockResolvedValueOnce("manual-token");
       httpMocks.apiRequestForm.mockResolvedValueOnce({
@@ -381,7 +395,9 @@ describe("package commands", () => {
 
       expect(fetchMock).not.toHaveBeenCalled();
       expect(httpMocks.apiRequest).not.toHaveBeenCalled();
-      const publishArgs = httpMocks.apiRequestForm.mock.calls[0]?.[1] as { token?: string; form?: FormData } | undefined;
+      const publishArgs = httpMocks.apiRequestForm.mock.calls[0]?.[1] as
+        | { token?: string; form?: FormData }
+        | undefined;
       expect(publishArgs?.token).toBe("manual-token");
       const payloadEntry = publishArgs?.form?.get("payload");
       if (typeof payloadEntry !== "string") {
@@ -419,7 +435,11 @@ describe("package commands", () => {
         }),
         "utf8",
       );
-      await writeFile(join(folder, "openclaw.plugin.json"), JSON.stringify({ id: "demo.plugin" }), "utf8");
+      await writeFile(
+        join(folder, "openclaw.plugin.json"),
+        JSON.stringify({ id: "demo.plugin" }),
+        "utf8",
+      );
 
       authTokenMocks.requireAuthToken.mockResolvedValueOnce("fallback-token");
       httpMocks.apiRequest.mockRejectedValueOnce(
@@ -436,7 +456,9 @@ describe("package commands", () => {
         sourceCommit: "abc123",
       });
 
-      const publishArgs = httpMocks.apiRequestForm.mock.calls[0]?.[1] as { token?: string } | undefined;
+      const publishArgs = httpMocks.apiRequestForm.mock.calls[0]?.[1] as
+        | { token?: string }
+        | undefined;
       expect(publishArgs?.token).toBe("fallback-token");
     } finally {
       await rm(workdir, { recursive: true, force: true });
@@ -467,7 +489,11 @@ describe("package commands", () => {
         }),
         "utf8",
       );
-      await writeFile(join(folder, "openclaw.plugin.json"), JSON.stringify({ id: "demo.plugin" }), "utf8");
+      await writeFile(
+        join(folder, "openclaw.plugin.json"),
+        JSON.stringify({ id: "demo.plugin" }),
+        "utf8",
+      );
 
       authTokenMocks.requireAuthToken.mockResolvedValueOnce("fallback-token");
       httpMocks.apiRequest.mockRejectedValueOnce(
@@ -484,7 +510,9 @@ describe("package commands", () => {
         sourceCommit: "abc123",
       });
 
-      const publishArgs = httpMocks.apiRequestForm.mock.calls[0]?.[1] as { token?: string } | undefined;
+      const publishArgs = httpMocks.apiRequestForm.mock.calls[0]?.[1] as
+        | { token?: string }
+        | undefined;
       expect(publishArgs?.token).toBe("fallback-token");
     } finally {
       await rm(workdir, { recursive: true, force: true });
@@ -515,7 +543,11 @@ describe("package commands", () => {
         }),
         "utf8",
       );
-      await writeFile(join(folder, "openclaw.plugin.json"), JSON.stringify({ id: "demo.plugin" }), "utf8");
+      await writeFile(
+        join(folder, "openclaw.plugin.json"),
+        JSON.stringify({ id: "demo.plugin" }),
+        "utf8",
+      );
 
       authTokenMocks.requireAuthToken.mockResolvedValueOnce("fallback-token");
       httpMocks.apiRequestForm.mockResolvedValueOnce({
@@ -529,7 +561,9 @@ describe("package commands", () => {
         sourceCommit: "abc123",
       });
 
-      const publishArgs = httpMocks.apiRequestForm.mock.calls[0]?.[1] as { token?: string } | undefined;
+      const publishArgs = httpMocks.apiRequestForm.mock.calls[0]?.[1] as
+        | { token?: string }
+        | undefined;
       expect(publishArgs?.token).toBe("fallback-token");
     } finally {
       await rm(workdir, { recursive: true, force: true });
@@ -600,7 +634,11 @@ describe("package commands", () => {
         makeCodePluginPackageJson({ name: "demo-plugin", version: "1.0.0" }),
         "utf8",
       );
-      await writeFile(join(folder, "openclaw.plugin.json"), JSON.stringify({ id: "demo.plugin" }), "utf8");
+      await writeFile(
+        join(folder, "openclaw.plugin.json"),
+        JSON.stringify({ id: "demo.plugin" }),
+        "utf8",
+      );
 
       await expect(cmdPublishPackage(makeOpts(workdir), "demo-plugin", {})).rejects.toThrow(
         "--source-repo and --source-commit required for code plugins",
@@ -708,11 +746,19 @@ describe("package commands", () => {
         }),
         "utf8",
       );
-      await writeFile(join(folder, "openclaw.plugin.json"), JSON.stringify({ id: "ignored.plugin" }), "utf8");
+      await writeFile(
+        join(folder, "openclaw.plugin.json"),
+        JSON.stringify({ id: "ignored.plugin" }),
+        "utf8",
+      );
       await writeFile(join(folder, ".clawhubignore"), "ignored.txt\n", "utf8");
       await writeFile(join(folder, "dist", "index.js"), "export {};\n", "utf8");
       await writeFile(join(folder, "ignored.txt"), "ignore me\n", "utf8");
-      await writeFile(join(folder, "node_modules", "pkg", "index.js"), "module.exports = {};\n", "utf8");
+      await writeFile(
+        join(folder, "node_modules", "pkg", "index.js"),
+        "module.exports = {};\n",
+        "utf8",
+      );
       await writeFile(join(folder, ".git", "HEAD"), "ref: refs/heads/main\n", "utf8");
 
       httpMocks.apiRequestForm.mockResolvedValueOnce({
@@ -751,7 +797,11 @@ describe("package commands", () => {
         }),
         "utf8",
       );
-      await writeFile(join(folder, "openclaw.plugin.json"), JSON.stringify({ id: "broken.plugin" }), "utf8");
+      await writeFile(
+        join(folder, "openclaw.plugin.json"),
+        JSON.stringify({ id: "broken.plugin" }),
+        "utf8",
+      );
 
       httpMocks.apiRequestForm.mockRejectedValueOnce(new Error("Registry rejected upload"));
 
@@ -786,13 +836,25 @@ describe("package commands", () => {
         }),
         "utf8",
       );
-      await writeFile(join(folder, "openclaw.plugin.json"), JSON.stringify({ id: "demo.plugin" }), "utf8");
+      await writeFile(
+        join(folder, "openclaw.plugin.json"),
+        JSON.stringify({ id: "demo.plugin" }),
+        "utf8",
+      );
       await writeFile(join(folder, "dist", "index.js"), "export const demo = true;\n", "utf8");
 
       runGit(folder, ["init", "-b", "main"]);
       runGit(folder, ["remote", "add", "origin", "git@github.com:openclaw/demo-plugin.git"]);
       runGit(folder, ["add", "."]);
-      runGit(folder, ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init"]);
+      runGit(folder, [
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.com",
+        "commit",
+        "-m",
+        "init",
+      ]);
       const commit = runGit(folder, ["rev-parse", "HEAD"]);
       runGit(folder, ["-c", "tag.gpgSign=false", "tag", "v1.0.0"]);
 
@@ -838,12 +900,24 @@ describe("package commands", () => {
         }),
         "utf8",
       );
-      await writeFile(join(folder, "openclaw.plugin.json"), JSON.stringify({ id: "demo.plugin" }), "utf8");
+      await writeFile(
+        join(folder, "openclaw.plugin.json"),
+        JSON.stringify({ id: "demo.plugin" }),
+        "utf8",
+      );
 
       runGit(folder, ["init", "-b", "main"]);
       runGit(folder, ["remote", "add", "origin", "git@github.com:openclaw/demo-plugin.git"]);
       runGit(folder, ["add", "."]);
-      runGit(folder, ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init"]);
+      runGit(folder, [
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.com",
+        "commit",
+        "-m",
+        "init",
+      ]);
 
       httpMocks.apiRequestForm.mockResolvedValueOnce({
         ok: true,
@@ -905,7 +979,15 @@ describe("package commands", () => {
       runGit(workdir, ["init", "-b", "main"]);
       runGit(workdir, ["remote", "add", "origin", "git@github.com:openclaw/demo-plugin.git"]);
       runGit(workdir, ["add", "."]);
-      runGit(workdir, ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init"]);
+      runGit(workdir, [
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.com",
+        "commit",
+        "-m",
+        "init",
+      ]);
 
       httpMocks.apiRequestForm.mockResolvedValueOnce({
         ok: true,
@@ -953,13 +1035,25 @@ describe("package commands", () => {
         }),
         "utf8",
       );
-      await writeFile(join(folder, "openclaw.plugin.json"), JSON.stringify({ id: "demo.plugin" }), "utf8");
+      await writeFile(
+        join(folder, "openclaw.plugin.json"),
+        JSON.stringify({ id: "demo.plugin" }),
+        "utf8",
+      );
       await writeFile(join(folder, "dist", "index.js"), "export const demo = true;\n", "utf8");
 
       runGit(folder, ["init", "-b", "main"]);
       runGit(folder, ["remote", "add", "origin", "git@github.com:openclaw/demo-plugin.git"]);
       runGit(folder, ["add", "."]);
-      runGit(folder, ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init"]);
+      runGit(folder, [
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.com",
+        "commit",
+        "-m",
+        "init",
+      ]);
       const commit = runGit(folder, ["rev-parse", "HEAD"]);
 
       await cmdPublishPackage(makeOpts(workdir), "demo-plugin", { dryRun: true });
@@ -996,12 +1090,24 @@ describe("package commands", () => {
         }),
         "utf8",
       );
-      await writeFile(join(folder, "openclaw.plugin.json"), JSON.stringify({ id: "demo.plugin" }), "utf8");
+      await writeFile(
+        join(folder, "openclaw.plugin.json"),
+        JSON.stringify({ id: "demo.plugin" }),
+        "utf8",
+      );
 
       runGit(folder, ["init", "-b", "main"]);
       runGit(folder, ["remote", "add", "origin", "git@github.com:openclaw/demo-plugin.git"]);
       runGit(folder, ["add", "."]);
-      runGit(folder, ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init"]);
+      runGit(folder, [
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.com",
+        "commit",
+        "-m",
+        "init",
+      ]);
 
       await cmdPublishPackage(makeOpts(workdir), "demo-plugin", { dryRun: true, json: true });
 

--- a/packages/clawhub/src/cli/commands/packages.ts
+++ b/packages/clawhub/src/cli/commands/packages.ts
@@ -5,12 +5,6 @@ import mime from "mime";
 import semver from "semver";
 import { apiRequest, apiRequestForm, fetchText, registryUrl } from "../../http.js";
 import {
-  fetchGitHubSource,
-  normalizeGitHubRepo,
-  resolveLocalGitInfo,
-  resolveSourceInput,
-} from "./github.js";
-import {
   ApiRoutes,
   ApiV1PackageListResponseSchema,
   ApiV1PackagePublishResponseSchema,
@@ -33,6 +27,12 @@ import { getRegistry } from "../registry.js";
 import { titleCase } from "../slug.js";
 import type { GlobalOpts } from "../types.js";
 import { createSpinner, fail, formatError } from "../ui.js";
+import {
+  fetchGitHubSource,
+  normalizeGitHubRepo,
+  resolveLocalGitInfo,
+  resolveSourceInput,
+} from "./github.js";
 
 const DOT_DIR = ".clawhub";
 const LEGACY_DOT_DIR = ".clawdhub";
@@ -263,9 +263,7 @@ export async function cmdInspectPackage(
       versionResult = await apiRequestPackageVersion(registry, trimmed, targetVersion, token);
     }
 
-    let versionsList:
-      | Awaited<ReturnType<typeof apiRequestPackageVersions>>
-      | null = null;
+    let versionsList: Awaited<ReturnType<typeof apiRequestPackageVersions>> | null = null;
     if (options.versions) {
       const limit = clampLimit(options.limit ?? 25, 100);
       spinner.text = `Fetching versions (${limit})`;
@@ -274,7 +272,10 @@ export async function cmdInspectPackage(
 
     let fileContent: string | null = null;
     if (options.file) {
-      const url = registryUrl(`${ApiRoutes.packages}/${encodeURIComponent(trimmed)}/file`, registry);
+      const url = registryUrl(
+        `${ApiRoutes.packages}/${encodeURIComponent(trimmed)}/file`,
+        registry,
+      );
       url.searchParams.set("path", options.file);
       if (options.version) {
         url.searchParams.set("version", options.version);
@@ -309,7 +310,9 @@ export async function cmdInspectPackage(
 
     if (shouldPrintMeta && versionResult?.version) {
       printVersionSummary(versionResult.version);
-      printCompatibility(versionResult.version.compatibility ?? detail.package.compatibility ?? null);
+      printCompatibility(
+        versionResult.version.compatibility ?? detail.package.compatibility ?? null,
+      );
       printCapabilities(versionResult.version.capabilities ?? detail.package.capabilities ?? null);
       printVerification(versionResult.version.verification ?? detail.package.verification ?? null);
     } else if (shouldPrintMeta) {
@@ -767,10 +770,7 @@ async function readJsonFile(path: string) {
   }
 }
 
-function packageJsonString(
-  value: Record<string, unknown> | null,
-  key: string,
-): string | undefined {
+function packageJsonString(value: Record<string, unknown> | null, key: string): string | undefined {
   const candidate = value?.[key];
   return typeof candidate === "string" && candidate.trim() ? candidate.trim() : undefined;
 }
@@ -964,7 +964,9 @@ async function requestGitHubActionsOidcToken(
   });
   const responseText = await response.text();
   if (!response.ok) {
-    throw new Error(`GitHub OIDC token request failed (${response.status}): ${responseText || response.statusText}`);
+    throw new Error(
+      `GitHub OIDC token request failed (${response.status}): ${responseText || response.statusText}`,
+    );
   }
 
   let parsed: unknown;
@@ -1047,10 +1049,7 @@ async function resolvePackagePublishToken(params: {
   }
 }
 
-function buildSource(
-  options: PackagePublishOptions,
-  inferred?: InferredPublishSource,
-) {
+function buildSource(options: PackagePublishOptions, inferred?: InferredPublishSource) {
   const rawRepo = options.sourceRepo?.trim() || inferred?.repo?.trim();
   const rawCommit = options.sourceCommit?.trim() || inferred?.commit?.trim();
   const rawRef = options.sourceRef?.trim() || inferred?.ref?.trim();

--- a/packages/clawhub/src/cli/commands/publish.test.ts
+++ b/packages/clawhub/src/cli/commands/publish.test.ts
@@ -133,7 +133,9 @@ describe("cmdPublish", () => {
           version: "1.0.0",
           tags: "latest",
         }),
-      ).rejects.toThrow('This looks like a plugin. Use "clawhub package publish <source>" instead.');
+      ).rejects.toThrow(
+        'This looks like a plugin. Use "clawhub package publish <source>" instead.',
+      );
       expect(authTokenMocks.requireAuthToken).not.toHaveBeenCalled();
       expect(httpMocks.apiRequestForm).not.toHaveBeenCalled();
     } finally {

--- a/packages/clawhub/src/cli/commands/publish.ts
+++ b/packages/clawhub/src/cli/commands/publish.ts
@@ -114,7 +114,9 @@ async function looksLikePluginFolder(folder: string) {
   }
   try {
     const raw = JSON.parse(await readFile(checks[2], "utf8")) as { openclaw?: unknown };
-    return Boolean(raw && typeof raw === "object" && raw.openclaw && typeof raw.openclaw === "object");
+    return Boolean(
+      raw && typeof raw === "object" && raw.openclaw && typeof raw.openclaw === "object",
+    );
   } catch {
     return false;
   }

--- a/packages/clawhub/src/cli/commands/skills.test.ts
+++ b/packages/clawhub/src/cli/commands/skills.test.ts
@@ -1,7 +1,6 @@
 /* @vitest-environment node */
 
 import * as fsPromises from "node:fs/promises";
-import * as skillStore from "../../skills.js";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createAuthTokenModuleMocks,
@@ -11,6 +10,7 @@ import {
   makeGlobalOpts,
 } from "../../../test/cliCommandTestKit.js";
 import { ApiRoutes } from "../../schema/index.js";
+import * as skillStore from "../../skills.js";
 
 const fsMocks = vi.hoisted(() => ({
   mkdir: vi.fn(),
@@ -28,7 +28,7 @@ vi.mock("node:fs/promises", async () => {
   };
 });
 
-const mocked = <T,>(value: T) => value as T & Record<string, unknown>;
+const mocked = <T>(value: T) => value as T & Record<string, unknown>;
 Object.assign(vi as object, { mocked });
 
 const authTokenMocks = createAuthTokenModuleMocks();

--- a/packages/clawhub/src/cli/commands/sync.test.ts
+++ b/packages/clawhub/src/cli/commands/sync.test.ts
@@ -14,7 +14,8 @@ const mockOutro = vi.fn();
 const mockLog = vi.fn();
 const mockMultiselect = vi.fn(async (_args?: unknown) => [] as string[]);
 let interactive = false;
-const mocked = <T,>(value: T) => value as T & { mockImplementation: (...args: unknown[]) => unknown };
+const mocked = <T>(value: T) =>
+  value as T & { mockImplementation: (...args: unknown[]) => unknown };
 
 const defaultFindSkillFolders = async (root: string) => {
   if (!root.endsWith("/scan")) return [];
@@ -74,7 +75,9 @@ const mockListTextFiles = vi.fn(async (folder: string) => [
   { relPath: "SKILL.md", bytes: new TextEncoder().encode(folder) },
 ]);
 const mockHashSkillFiles = vi.fn((files: Array<{ relPath: string; bytes: Uint8Array }>) => ({
-  fingerprint: files.map((file) => `${file.relPath}:${Buffer.from(file.bytes).toString("hex")}`).join("|"),
+  fingerprint: files
+    .map((file) => `${file.relPath}:${Buffer.from(file.bytes).toString("hex")}`)
+    .join("|"),
   files: [],
 }));
 const mockHashSkillZip = vi.fn((_zip?: Uint8Array) => ({
@@ -84,14 +87,16 @@ const mockHashSkillZip = vi.fn((_zip?: Uint8Array) => ({
 const mockReadSkillOrigin = vi.fn(async (_folder?: string) => null);
 vi.mock("../../skills.js", () => ({
   listTextFiles: (folder: string) => mockListTextFiles(folder),
-  hashSkillFiles: (files: Array<{ relPath: string; bytes: Uint8Array }>) => mockHashSkillFiles(files),
+  hashSkillFiles: (files: Array<{ relPath: string; bytes: Uint8Array }>) =>
+    mockHashSkillFiles(files),
   hashSkillZip: (zip: Uint8Array) => mockHashSkillZip(zip),
   readSkillOrigin: (folder: string) => mockReadSkillOrigin(folder),
 }));
 
 const mockCmdPublish = vi.fn();
 vi.mock("./publish.js", () => ({
-  cmdPublish: (opts: unknown, folder: unknown, options?: unknown) => mockCmdPublish(opts, folder, options),
+  cmdPublish: (opts: unknown, folder: unknown, options?: unknown) =>
+    mockCmdPublish(opts, folder, options),
 }));
 
 const { cmdSync } = await import("./sync");

--- a/packages/clawhub/src/cli/commands/transfer.test.ts
+++ b/packages/clawhub/src/cli/commands/transfer.test.ts
@@ -35,9 +35,7 @@ afterEach(() => {
 
 describe("transfer commands", () => {
   it("request requires --yes when input is disabled", async () => {
-    await expect(
-      cmdTransferRequest(makeGlobalOpts(), "demo", "@alice", {}, false),
-    ).rejects.toThrow(
+    await expect(cmdTransferRequest(makeGlobalOpts(), "demo", "@alice", {}, false)).rejects.toThrow(
       /--yes/i,
     );
   });

--- a/packages/clawhub/src/http.bun.test.ts
+++ b/packages/clawhub/src/http.bun.test.ts
@@ -137,10 +137,13 @@ describe("bun http client", () => {
       readFileValue: Buffer.from("not found"),
     });
 
-    await expect(client.fetchText("https://registry.example", { path: "/v1/readme" })).resolves.toBe(
-      "hello world",
-    );
-    const bytes = await client.downloadZip("https://registry.example", { slug: "demo", token: "t" });
+    await expect(
+      client.fetchText("https://registry.example", { path: "/v1/readme" }),
+    ).resolves.toBe("hello world");
+    const bytes = await client.downloadZip("https://registry.example", {
+      slug: "demo",
+      token: "t",
+    });
     expect(Array.from(bytes)).toEqual(Array.from(Buffer.from("not found")));
     await expect(
       client.downloadZip("https://registry.example", { slug: "demo", token: "t" }),

--- a/packages/clawhub/src/http.test.ts
+++ b/packages/clawhub/src/http.test.ts
@@ -158,9 +158,9 @@ describe("node http client", () => {
       clearTimeoutImpl,
     });
 
-    await expect(client.apiRequest("https://example.com", { method: "GET", path: "/x" })).rejects.toThrow(
-      /retry in 34s.*remaining: 0\/20.*reset in 34s/i,
-    );
+    await expect(
+      client.apiRequest("https://example.com", { method: "GET", path: "/x" }),
+    ).rejects.toThrow(/retry in 34s.*remaining: 0\/20.*reset in 34s/i);
     expect(fetchImpl).toHaveBeenCalledTimes(3);
     expect(clearTimeoutImpl).toHaveBeenCalledTimes(3);
   });
@@ -184,9 +184,9 @@ describe("node http client", () => {
       now: () => 1_771_404_500_000,
     });
 
-    await expect(client.apiRequest("https://example.com", { method: "GET", path: "/x" })).rejects.toThrow(
-      /retry in 40s.*remaining: 0\/20/i,
-    );
+    await expect(
+      client.apiRequest("https://example.com", { method: "GET", path: "/x" }),
+    ).rejects.toThrow(/retry in 40s.*remaining: 0\/20/i);
   });
 
   it("falls back to HTTP status when response bodies are empty", async () => {
@@ -244,9 +244,9 @@ describe("node http client", () => {
       clearTimeoutImpl,
     });
 
-    await expect(client.apiRequest("https://example.com", { method: "GET", path: "/x" })).rejects.toThrow(
-      /timed out/i,
-    );
+    await expect(
+      client.apiRequest("https://example.com", { method: "GET", path: "/x" }),
+    ).rejects.toThrow(/timed out/i);
     await expect(client.fetchText("https://example.com", { path: "/x" })).rejects.toThrow(
       /timed out/i,
     );
@@ -260,9 +260,9 @@ describe("node http client", () => {
     });
     const client = createNodeClient({ fetchImpl: fetchImpl as unknown as typeof fetch });
 
-    await expect(client.apiRequest("https://example.com", { method: "GET", path: "/x" })).rejects.toThrow(
-      "The operation was aborted",
-    );
+    await expect(
+      client.apiRequest("https://example.com", { method: "GET", path: "/x" }),
+    ).rejects.toThrow("The operation was aborted");
   });
 
   it("posts form data, retries 429, and uses the upload timeout", async () => {

--- a/packages/clawhub/src/http.ts
+++ b/packages/clawhub/src/http.ts
@@ -161,7 +161,12 @@ export function createHttpClient(options: HttpClientOptions = {}): HttpClient {
         body,
       });
       if (!response.ok) {
-        throwHttpStatusError(response.status, await readResponseTextSafe(response), response.headers, deps.now);
+        throwHttpStatusError(
+          response.status,
+          await readResponseTextSafe(response),
+          response.headers,
+          deps.now,
+        );
       }
       return (await response.json()) as unknown;
     });
@@ -193,7 +198,12 @@ export function createHttpClient(options: HttpClientOptions = {}): HttpClient {
         UPLOAD_TIMEOUT_MS,
       );
       if (!response.ok) {
-        throwHttpStatusError(response.status, await readResponseTextSafe(response), response.headers, deps.now);
+        throwHttpStatusError(
+          response.status,
+          await readResponseTextSafe(response),
+          response.headers,
+          deps.now,
+        );
       }
       return (await response.json()) as unknown;
     });
@@ -235,7 +245,12 @@ export function createHttpClient(options: HttpClientOptions = {}): HttpClient {
       if (args.token) headers.Authorization = `Bearer ${args.token}`;
       const response = await fetchWithTimeout(deps, url.toString(), { method: "GET", headers });
       if (!response.ok) {
-        throwHttpStatusError(response.status, await readResponseTextSafe(response), response.headers, deps.now);
+        throwHttpStatusError(
+          response.status,
+          await readResponseTextSafe(response),
+          response.headers,
+          deps.now,
+        );
       }
       return new Uint8Array(await response.arrayBuffer());
     });
@@ -527,7 +542,13 @@ async function fetchJsonViaCurl(
 async function fetchJsonFormViaCurl(
   deps: Pick<
     HttpClientDeps,
-    "spawnSyncImpl" | "mkdtempImpl" | "mkdirImpl" | "writeFileImpl" | "rmImpl" | "tmpdirPath" | "now"
+    | "spawnSyncImpl"
+    | "mkdtempImpl"
+    | "mkdirImpl"
+    | "writeFileImpl"
+    | "rmImpl"
+    | "tmpdirPath"
+    | "now"
   >,
   url: string,
   args: FormRequestArgs,

--- a/packages/clawhub/src/schema/packages.ts
+++ b/packages/clawhub/src/schema/packages.ts
@@ -72,8 +72,7 @@ export const PackageLlmAnalysisDimensionSchema = type({
   rating: "string",
   detail: "string",
 });
-export type PackageLlmAnalysisDimension =
-  (typeof PackageLlmAnalysisDimensionSchema)[inferred];
+export type PackageLlmAnalysisDimension = (typeof PackageLlmAnalysisDimensionSchema)[inferred];
 
 export const PackageLlmAnalysisSchema = type({
   status: "string",
@@ -261,5 +260,4 @@ export const ApiV1PublishTokenMintResponseSchema = type({
   token: "string",
   expiresAt: "number",
 });
-export type ApiV1PublishTokenMintResponse =
-  (typeof ApiV1PublishTokenMintResponseSchema)[inferred];
+export type ApiV1PublishTokenMintResponse = (typeof ApiV1PublishTokenMintResponseSchema)[inferred];

--- a/packages/clawhub/test-artifact/cli.artifact.test.ts
+++ b/packages/clawhub/test-artifact/cli.artifact.test.ts
@@ -1,9 +1,9 @@
 /* @vitest-environment node */
 
+import { spawnSync } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { spawnSync } from "node:child_process";
 import { afterEach, describe, expect, it } from "vitest";
 
 const packageRoot = resolve(import.meta.dirname, "..");
@@ -92,7 +92,15 @@ describe("built CLI artifact", () => {
     runGit(root, ["init"]);
     runGit(root, ["remote", "add", "origin", "https://github.com/openclaw/demo-plugin.git"]);
     runGit(root, ["add", "."]);
-    runGit(root, ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init"]);
+    runGit(root, [
+      "-c",
+      "user.name=Test",
+      "-c",
+      "user.email=test@example.com",
+      "commit",
+      "-m",
+      "init",
+    ]);
 
     const result = runNode([
       binPath,

--- a/packages/schema/src/licenseConstants.ts
+++ b/packages/schema/src/licenseConstants.ts
@@ -1,5 +1,5 @@
-export const PLATFORM_SKILL_LICENSE = 'MIT-0' as const;
-export const PLATFORM_SKILL_LICENSE_NAME = 'MIT No Attribution' as const;
+export const PLATFORM_SKILL_LICENSE = "MIT-0" as const;
+export const PLATFORM_SKILL_LICENSE_NAME = "MIT No Attribution" as const;
 export const PLATFORM_SKILL_LICENSE_SUMMARY =
-  'Free to use, modify, and redistribute. No attribution required.' as const;
-export const PLATFORM_SKILL_LICENSE_URL = 'https://spdx.org/licenses/MIT-0.html' as const;
+  "Free to use, modify, and redistribute. No attribution required." as const;
+export const PLATFORM_SKILL_LICENSE_URL = "https://spdx.org/licenses/MIT-0.html" as const;

--- a/packages/schema/src/packages.ts
+++ b/packages/schema/src/packages.ts
@@ -72,8 +72,7 @@ export const PackageLlmAnalysisDimensionSchema = type({
   rating: "string",
   detail: "string",
 });
-export type PackageLlmAnalysisDimension =
-  (typeof PackageLlmAnalysisDimensionSchema)[inferred];
+export type PackageLlmAnalysisDimension = (typeof PackageLlmAnalysisDimensionSchema)[inferred];
 
 export const PackageLlmAnalysisSchema = type({
   status: "string",
@@ -267,5 +266,4 @@ export const ApiV1PublishTokenMintResponseSchema = type({
   token: "string",
   expiresAt: "number",
 });
-export type ApiV1PublishTokenMintResponse =
-  (typeof ApiV1PublishTokenMintResponseSchema)[inferred];
+export type ApiV1PublishTokenMintResponse = (typeof ApiV1PublishTokenMintResponseSchema)[inferred];

--- a/scripts/clawhub-cli-npm-release-check.mjs
+++ b/scripts/clawhub-cli-npm-release-check.mjs
@@ -42,7 +42,9 @@ function normalizeUrl(value) {
 }
 
 function readPackageJson() {
-  return JSON.parse(readFileSync(new URL("../packages/clawhub/package.json", import.meta.url), "utf8"));
+  return JSON.parse(
+    readFileSync(new URL("../packages/clawhub/package.json", import.meta.url), "utf8"),
+  );
 }
 
 function isStableSemverVersion(value) {
@@ -72,7 +74,9 @@ function collectPackageMetadataErrors(pkg) {
     errors.push("packages/clawhub/package.json description must be non-empty.");
   }
   if (pkg.license !== "MIT") {
-    errors.push(`packages/clawhub/package.json license must be "MIT"; found "${pkg.license ?? ""}".`);
+    errors.push(
+      `packages/clawhub/package.json license must be "MIT"; found "${pkg.license ?? ""}".`,
+    );
   }
   if (normalizeUrl(pkg.homepage) !== EXPECTED_HOMEPAGE_URL) {
     errors.push(
@@ -145,7 +149,9 @@ function collectReleaseTagErrors({ packageVersion, releaseTag, releaseSha, relea
         { stdio: "ignore" },
       );
     } catch {
-      errors.push(`Tagged commit ${releaseSha.trim()} is not contained in ${releaseMainRef.trim()}.`);
+      errors.push(
+        `Tagged commit ${releaseSha.trim()} is not contained in ${releaseMainRef.trim()}.`,
+      );
     }
   }
 

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -33,8 +33,13 @@ vi.mock("../lib/theme", () => ({
 }));
 
 vi.mock("../lib/theme-transition", () => ({
-  startThemeTransition: ({ setTheme, nextTheme }: { setTheme: (value: string) => void; nextTheme: string }) =>
-    setTheme(nextTheme),
+  startThemeTransition: ({
+    setTheme,
+    nextTheme,
+  }: {
+    setTheme: (value: string) => void;
+    nextTheme: string;
+  }) => setTheme(nextTheme),
 }));
 
 vi.mock("../lib/useAuthError", () => ({
@@ -73,7 +78,9 @@ vi.mock("../components/ui/dropdown-menu", () => ({
 
 vi.mock("../components/ui/toggle-group", () => ({
   ToggleGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  ToggleGroupItem: ({ children }: { children: ReactNode }) => <button type="button">{children}</button>,
+  ToggleGroupItem: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
 }));
 
 describe("Header", () => {

--- a/src/__tests__/import.route.test.tsx
+++ b/src/__tests__/import.route.test.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { vi } from "vitest";
 import { ImportGitHub } from "../routes/import";
 

--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -2,6 +2,7 @@
 
 import { render, screen } from "@testing-library/react";
 import type { AnchorHTMLAttributes, ComponentType, ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   fetchPackageDetail,
   fetchPackageReadme,
@@ -9,7 +10,6 @@ import {
   type PackageDetailResponse,
   type PackageVersionDetail,
 } from "../lib/packageApi";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type PluginDetailLoaderData = {
   detail: PackageDetailResponse;
@@ -42,17 +42,11 @@ let loaderDataMock: PluginDetailLoaderData = {
 };
 
 vi.mock("@tanstack/react-router", () => ({
-  createFileRoute:
-    () =>
-    (config: {
-      loader?: unknown;
-      head?: unknown;
-      component?: unknown;
-    }) => ({
-      __config: config,
-      useParams: () => paramsMock,
-      useLoaderData: () => loaderDataMock,
-    }),
+  createFileRoute: () => (config: { loader?: unknown; head?: unknown; component?: unknown }) => ({
+    __config: config,
+    useParams: () => paramsMock,
+    useLoaderData: () => loaderDataMock,
+  }),
   Link: ({
     children,
     to,
@@ -72,7 +66,9 @@ vi.mock("../lib/packageApi", () => ({
   fetchPackageReadme: vi.fn(),
   fetchPackageVersion: vi.fn(),
   getPackageDownloadPath: vi.fn((name: string, version?: string | null) =>
-    version ? `/api/v1/packages/${name}/download?version=${version}` : `/api/v1/packages/${name}/download`,
+    version
+      ? `/api/v1/packages/${name}/download?version=${version}`
+      : `/api/v1/packages/${name}/download`,
   ),
 }));
 
@@ -176,7 +172,11 @@ describe("plugin detail route", () => {
 
   it("falls back to the official scoped package name for short plugin routes", async () => {
     const route = await loadRoute();
-    const loader = route.__config.loader as ({ params }: { params: { name: string } }) => Promise<PluginDetailLoaderData>;
+    const loader = route.__config.loader as ({
+      params,
+    }: {
+      params: { name: string };
+    }) => Promise<PluginDetailLoaderData>;
     const fetchPackageDetailMock = vi.mocked(fetchPackageDetail);
     const fetchPackageReadmeMock = vi.mocked(fetchPackageReadme);
     const fetchPackageVersionMock = vi.mocked(fetchPackageVersion);

--- a/src/__tests__/packages-publish-route.test.tsx
+++ b/src/__tests__/packages-publish-route.test.tsx
@@ -5,9 +5,10 @@ import { createElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@tanstack/react-router", () => ({
-  createFileRoute:
-    (path: string) =>
-    (config: { component: unknown }) => ({ __config: config, __path: path }),
+  createFileRoute: (path: string) => (config: { component: unknown }) => ({
+    __config: config,
+    __path: path,
+  }),
   useSearch: () => ({
     ownerHandle: undefined,
     name: undefined,
@@ -270,9 +271,7 @@ describe("plugins publish route", () => {
     fireEvent.change(getFileInput(), { target: { files: [packageJson, manifest] } });
 
     await waitFor(() => {
-      expect(
-        screen.getByText(/Missing required OpenClaw package metadata:/i),
-      ).toBeTruthy();
+      expect(screen.getByText(/Missing required OpenClaw package metadata:/i)).toBeTruthy();
     });
 
     expect(screen.getByText(/openclaw\.compat\.pluginApi/i)).toBeTruthy();
@@ -404,11 +403,9 @@ describe("plugins publish route", () => {
       "opik-openclaw-0.2.9/openclaw.plugin.json",
       { type: "application/json" },
     );
-    const readme = new File(
-      ["# Opik OpenClaw\n"],
-      "opik-openclaw-0.2.9/README.md",
-      { type: "text/markdown" },
-    );
+    const readme = new File(["# Opik OpenClaw\n"], "opik-openclaw-0.2.9/README.md", {
+      type: "text/markdown",
+    });
 
     fireEvent.change(getFileInput(), { target: { files: [packageJson, manifest, readme] } });
 
@@ -419,7 +416,9 @@ describe("plugins publish route", () => {
       expect(screen.getByDisplayValue("comet-ml/opik-openclaw")).toBeTruthy();
       expect(screen.getByText(/Metadata detected and prefilled/i)).toBeTruthy();
       expect(
-        screen.getByText(/Autofilled package type, plugin name, display name, version, source repo, compatibility\./i),
+        screen.getByText(
+          /Autofilled package type, plugin name, display name, version, source repo, compatibility\./i,
+        ),
       ).toBeTruthy();
       expect(screen.getByText("Package manifest")).toBeTruthy();
       expect(screen.getByText("Plugin manifest")).toBeTruthy();
@@ -431,9 +430,13 @@ describe("plugins publish route", () => {
     renderPublishRoute();
 
     const packageJson = withRelativePath(
-      new File([makeCodePluginPackageJson({ name: "demo-plugin", version: "1.0.0" })], "package.json", {
-        type: "application/json",
-      }),
+      new File(
+        [makeCodePluginPackageJson({ name: "demo-plugin", version: "1.0.0" })],
+        "package.json",
+        {
+          type: "application/json",
+        },
+      ),
       "demo-plugin/package.json",
     );
     const ignoreFile = withRelativePath(
@@ -498,9 +501,13 @@ describe("plugins publish route", () => {
     renderPublishRoute();
 
     const packageJson = withRelativePath(
-      new File([makeCodePluginPackageJson({ name: "demo-plugin", version: "1.0.0" })], "package.json", {
-        type: "application/json",
-      }),
+      new File(
+        [makeCodePluginPackageJson({ name: "demo-plugin", version: "1.0.0" })],
+        "package.json",
+        {
+          type: "application/json",
+        },
+      ),
       "demo-plugin/package.json",
     );
     const manifest = withRelativePath(
@@ -529,9 +536,13 @@ describe("plugins publish route", () => {
     renderPublishRoute();
 
     const packageJson = withRelativePath(
-      new File([makeCodePluginPackageJson({ name: "demo-plugin", version: "1.0.0" })], "package.json", {
-        type: "application/json",
-      }),
+      new File(
+        [makeCodePluginPackageJson({ name: "demo-plugin", version: "1.0.0" })],
+        "package.json",
+        {
+          type: "application/json",
+        },
+      ),
       "demo-plugin/package.json",
     );
     const manifest = withRelativePath(

--- a/src/__tests__/packages-route.test.tsx
+++ b/src/__tests__/packages-route.test.tsx
@@ -67,7 +67,9 @@ describe("plugins route", () => {
 
   it("rejects skill family filter in search state", async () => {
     const route = await loadRoute();
-    const validateSearch = route.__config.validateSearch as (search: Record<string, unknown>) => Record<string, unknown>;
+    const validateSearch = route.__config.validateSearch as (
+      search: Record<string, unknown>,
+    ) => Record<string, unknown>;
 
     expect(validateSearch({ family: "skill", q: "demo" })).toEqual({
       family: undefined,
@@ -137,8 +139,24 @@ describe("plugins route", () => {
   it("filters out skills from loader results", async () => {
     fetchPluginCatalogMock.mockResolvedValue({
       items: [
-        { name: "my-skill", displayName: "My Skill", family: "skill", channel: "community", isOfficial: false, createdAt: 1, updatedAt: 1 },
-        { name: "my-plugin", displayName: "My Plugin", family: "code-plugin", channel: "community", isOfficial: false, createdAt: 1, updatedAt: 1 },
+        {
+          name: "my-skill",
+          displayName: "My Skill",
+          family: "skill",
+          channel: "community",
+          isOfficial: false,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+        {
+          name: "my-plugin",
+          displayName: "My Plugin",
+          family: "code-plugin",
+          channel: "community",
+          isOfficial: false,
+          createdAt: 1,
+          updatedAt: 1,
+        },
       ],
       nextCursor: null,
     });

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -56,7 +56,9 @@ describe("SkillDetailPage", () => {
 
     const { container } = render(<SkillDetailPage slug="weather" />);
     // Loading state now renders a skeleton, not text
-    expect(container.querySelector('[class*="animate-pulse"], [data-slot="skeleton"]')).toBeTruthy();
+    expect(
+      container.querySelector('[class*="animate-pulse"], [data-slot="skeleton"]'),
+    ).toBeTruthy();
     expect(screen.queryByText(/Skill not found/i)).toBeNull();
   });
 
@@ -388,17 +390,17 @@ describe("SkillDetailPage", () => {
     useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
       if (args === "skip") return undefined;
       if (args && typeof args === "object" && "skillId" in args) return [];
-        return {
-          skill: {
-            _id: "skills:1",
-            slug: "weather",
-            displayName: "Weather",
-            summary: "Get current weather.",
-            ownerUserId: "users:1",
-            ownerPublisherId: "publishers:steipete",
-            tags: {},
-            stats: { stars: 0, downloads: 0 },
-          },
+      return {
+        skill: {
+          _id: "skills:1",
+          slug: "weather",
+          displayName: "Weather",
+          summary: "Get current weather.",
+          ownerUserId: "users:1",
+          ownerPublisherId: "publishers:steipete",
+          tags: {},
+          stats: { stars: 0, downloads: 0 },
+        },
         owner: {
           _id: "publishers:steipete",
           _creationTime: 0,

--- a/src/components/AppProviders.test.tsx
+++ b/src/components/AppProviders.test.tsx
@@ -1,10 +1,7 @@
 /* @vitest-environment jsdom */
 import { render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  ACCESS_DENIED_SIGN_IN_MESSAGE,
-  BANNED_SIGN_IN_MESSAGE,
-} from "../lib/authErrorMessage";
+import { ACCESS_DENIED_SIGN_IN_MESSAGE, BANNED_SIGN_IN_MESSAGE } from "../lib/authErrorMessage";
 import { getAuthErrorSnapshot, clearAuthError } from "../lib/useAuthError";
 import { AuthCodeHandler, AuthErrorHandler } from "./AppProviders";
 

--- a/src/components/AppProviders.tsx
+++ b/src/components/AppProviders.tsx
@@ -71,7 +71,9 @@ export function AuthErrorHandler() {
     handledErrorRef.current = pending.description;
 
     window.history.replaceState(null, "", pending.relativeUrl);
-    setAuthError(normalizeAuthErrorMessage(pending.description, "Sign in failed. Please try again."));
+    setAuthError(
+      normalizeAuthErrorMessage(pending.description, "Sign in failed. Please try again."),
+    );
   }, []);
 
   return null;

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -70,13 +70,7 @@ function extractErrorMessage(error: unknown): string {
   return "An unexpected error occurred. Please try again.";
 }
 
-export function ErrorFallback({
-  error,
-  onRetry,
-}: {
-  error: unknown;
-  onRetry?: () => void;
-}) {
+export function ErrorFallback({ error, onRetry }: { error: unknown; onRetry?: () => void }) {
   return (
     <div className="flex flex-col items-center justify-center gap-4 rounded-[var(--radius-md)] border border-[color:var(--line)] bg-[color:var(--surface)] p-10 text-center">
       <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[rgba(255,107,74,0.12)]">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -54,11 +54,24 @@ export default function Header() {
 
   const navLinks = (
     <>
-      {isSoulMode ? <a href={clawHubUrl} className="text-[color:var(--ink-soft)] font-semibold text-sm transition-colors duration-150 hover:text-[color:var(--ink)]">ClawHub</a> : null}
+      {isSoulMode ? (
+        <a
+          href={clawHubUrl}
+          className="text-[color:var(--ink-soft)] font-semibold text-sm transition-colors duration-150 hover:text-[color:var(--ink)]"
+        >
+          ClawHub
+        </a>
+      ) : null}
       {isSoulMode ? (
         <Link
           to="/souls"
-          search={{ q: undefined, sort: undefined, dir: undefined, view: undefined, focus: undefined }}
+          search={{
+            q: undefined,
+            sort: undefined,
+            dir: undefined,
+            view: undefined,
+            focus: undefined,
+          }}
           className="text-[color:var(--ink-soft)] font-semibold text-sm transition-colors duration-150 hover:text-[color:var(--ink)]"
         >
           Souls
@@ -66,14 +79,25 @@ export default function Header() {
       ) : (
         <Link
           to="/skills"
-          search={{ q: undefined, sort: undefined, dir: undefined, highlighted: undefined, nonSuspicious: undefined, view: undefined, focus: undefined }}
+          search={{
+            q: undefined,
+            sort: undefined,
+            dir: undefined,
+            highlighted: undefined,
+            nonSuspicious: undefined,
+            view: undefined,
+            focus: undefined,
+          }}
           className="text-[color:var(--ink-soft)] font-semibold text-sm transition-colors duration-150 hover:text-[color:var(--ink)]"
         >
           Skills
         </Link>
       )}
       {isSoulMode ? null : (
-        <Link to="/plugins" className="text-[color:var(--ink-soft)] font-semibold text-sm transition-colors duration-150 hover:text-[color:var(--ink)]">
+        <Link
+          to="/plugins"
+          className="text-[color:var(--ink-soft)] font-semibold text-sm transition-colors duration-150 hover:text-[color:var(--ink)]"
+        >
           Plugins
         </Link>
       )}
@@ -82,7 +106,15 @@ export default function Header() {
         search={
           isSoulMode
             ? { q: undefined, sort: undefined, dir: undefined, view: undefined, focus: "search" }
-            : { q: undefined, sort: undefined, dir: undefined, highlighted: undefined, nonSuspicious: undefined, view: undefined, focus: "search" }
+            : {
+                q: undefined,
+                sort: undefined,
+                dir: undefined,
+                highlighted: undefined,
+                nonSuspicious: undefined,
+                view: undefined,
+                focus: "search",
+              }
         }
         className="text-[color:var(--ink-soft)] font-semibold text-sm transition-colors duration-150 hover:text-[color:var(--ink)] inline-flex items-center gap-1.5"
       >
@@ -90,17 +122,27 @@ export default function Header() {
         Search
       </Link>
       {isSoulMode ? null : (
-        <Link to="/about" className="text-[color:var(--ink-soft)] font-semibold text-sm transition-colors duration-150 hover:text-[color:var(--ink)]">
+        <Link
+          to="/about"
+          className="text-[color:var(--ink-soft)] font-semibold text-sm transition-colors duration-150 hover:text-[color:var(--ink)]"
+        >
           About
         </Link>
       )}
       {me ? (
-        <Link to="/stars" className="text-[color:var(--ink-soft)] font-semibold text-sm transition-colors duration-150 hover:text-[color:var(--ink)]">
+        <Link
+          to="/stars"
+          className="text-[color:var(--ink-soft)] font-semibold text-sm transition-colors duration-150 hover:text-[color:var(--ink)]"
+        >
           Stars
         </Link>
       ) : null}
       {isStaff ? (
-        <Link to="/management" search={{ skill: undefined }} className="text-[color:var(--ink-soft)] font-semibold text-sm transition-colors duration-150 hover:text-[color:var(--ink)]">
+        <Link
+          to="/management"
+          search={{ skill: undefined }}
+          className="text-[color:var(--ink-soft)] font-semibold text-sm transition-colors duration-150 hover:text-[color:var(--ink)]"
+        >
           Management
         </Link>
       ) : null}
@@ -117,21 +159,28 @@ export default function Header() {
           className="flex items-center gap-2.5 font-display text-lg font-bold text-[color:var(--ink)] no-underline transition-opacity hover:opacity-80"
         >
           <span className="flex h-8 w-8 items-center justify-center rounded-full bg-gradient-to-br from-[color:var(--accent)] to-[color:var(--accent-deep)] p-0.5">
-            <img src="/clawd-logo.png" alt="" aria-hidden="true" className="h-full w-full rounded-full object-cover" />
+            <img
+              src="/clawd-logo.png"
+              alt=""
+              aria-hidden="true"
+              className="h-full w-full rounded-full object-cover"
+            />
           </span>
           <span>{siteName}</span>
         </Link>
 
         {/* Desktop nav */}
-        <nav className="hidden items-center gap-6 md:flex">
-          {navLinks}
-        </nav>
+        <nav className="hidden items-center gap-6 md:flex">{navLinks}</nav>
 
         {/* Actions */}
         <div className="flex items-center gap-3">
           {/* Publish CTA (desktop, authenticated) */}
           {isAuthenticated && me && (
-            <Link to="/publish-skill" search={{ updateSlug: undefined }} className="hidden sm:block">
+            <Link
+              to="/publish-skill"
+              search={{ updateSlug: undefined }}
+              className="hidden sm:block"
+            >
               <Button variant="primary" size="sm">
                 <Plus className="h-3.5 w-3.5" />
                 Publish
@@ -151,12 +200,12 @@ export default function Header() {
                 <SheetHeader>
                   <SheetTitle>{siteName}</SheetTitle>
                 </SheetHeader>
-                <nav className="mt-6 flex flex-col gap-4">
-                  {navLinks}
-                </nav>
+                <nav className="mt-6 flex flex-col gap-4">{navLinks}</nav>
                 {/* Mobile theme toggle */}
                 <div className="mt-6 flex flex-col gap-2">
-                  <span className="text-xs font-bold uppercase tracking-widest text-[color:var(--ink-soft)]">Theme</span>
+                  <span className="text-xs font-bold uppercase tracking-widest text-[color:var(--ink-soft)]">
+                    Theme
+                  </span>
                   <ToggleGroup
                     type="single"
                     value={mode}
@@ -224,7 +273,9 @@ export default function Header() {
                   className="flex cursor-pointer items-center gap-2 rounded-full border border-[color:var(--line)] bg-[color:var(--surface)] px-2 py-1.5 text-sm font-semibold text-[color:var(--ink)] transition-colors hover:border-[color:var(--border-ui-hover)]"
                 >
                   <Avatar className="h-7 w-7">
-                    {avatar && <AvatarImage src={avatar} alt={me.displayName ?? me.name ?? "User avatar"} />}
+                    {avatar && (
+                      <AvatarImage src={avatar} alt={me.displayName ?? me.name ?? "User avatar"} />
+                    )}
                     <AvatarFallback className="text-xs">{initial}</AvatarFallback>
                   </Avatar>
                   <span className="hidden font-mono text-xs sm:inline">@{handle}</span>
@@ -245,7 +296,10 @@ export default function Header() {
           ) : (
             <>
               {authError ? (
-                <div className="flex items-center gap-1 text-[0.85rem] text-red-600 dark:text-red-400" role="alert">
+                <div
+                  className="flex items-center gap-1 text-[0.85rem] text-red-600 dark:text-red-400"
+                  role="alert"
+                >
                   {authError}
                   <button
                     type="button"
@@ -267,7 +321,9 @@ export default function Header() {
                     "github",
                     signInRedirectTo ? { redirectTo: signInRedirectTo } : undefined,
                   ).catch((error) => {
-                    setAuthError(getUserFacingAuthError(error, "Sign in failed. Please try again."));
+                    setAuthError(
+                      getUserFacingAuthError(error, "Sign in failed. Please try again."),
+                    );
                   });
                 }}
               >

--- a/src/components/InstallSwitcher.tsx
+++ b/src/components/InstallSwitcher.tsx
@@ -29,7 +29,9 @@ export function InstallSwitcher({ exampleSlug = "sonoscli" }: InstallSwitcherPro
   return (
     <div className="flex flex-col gap-3 rounded-[var(--radius-md)] border border-[color:var(--line)] bg-[color:var(--surface-muted)] p-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="text-sm text-[color:var(--ink-soft)]">Install any skill folder in one shot:</div>
+        <div className="text-sm text-[color:var(--ink-soft)]">
+          Install any skill folder in one shot:
+        </div>
         <div
           className="inline-flex items-center gap-0.5 rounded-full border border-[color:var(--line)] bg-[color:var(--surface)] p-[3px]"
           role="tablist"
@@ -53,7 +55,9 @@ export function InstallSwitcher({ exampleSlug = "sonoscli" }: InstallSwitcherPro
           ))}
         </div>
       </div>
-      <div className="overflow-x-auto rounded-[var(--radius-sm)] bg-[color:var(--surface)] p-3 font-mono text-xs">{command}</div>
+      <div className="overflow-x-auto rounded-[var(--radius-sm)] bg-[color:var(--surface)] p-3 font-mono text-xs">
+        {command}
+      </div>
     </div>
   );
 }

--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -1,10 +1,6 @@
-import { useEffect, useRef, useState } from "react";
 import { parse } from "@create-markdown/core";
-import {
-  blocksToHTML,
-  renderAsync,
-  shikiPlugin,
-} from "@create-markdown/preview";
+import { blocksToHTML, renderAsync, shikiPlugin } from "@create-markdown/preview";
+import { useEffect, useRef, useState } from "react";
 import { cn } from "../lib/utils";
 
 interface MarkdownPreviewProps {
@@ -43,11 +39,7 @@ function autolinkURLs(html: string): string {
  * Renders markdown → HTML with optional Shiki syntax highlighting.
  * Falls back to synchronous (unhighlighted) rendering while Shiki loads.
  */
-export function MarkdownPreview({
-  children,
-  className,
-  highlight = true,
-}: MarkdownPreviewProps) {
+export function MarkdownPreview({ children, className, highlight = true }: MarkdownPreviewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   // Initial sync render (no highlighting) for instant display
   const [html, setHtml] = useState(() => {
@@ -73,13 +65,15 @@ export function MarkdownPreview({
       // Async render with Shiki syntax highlighting
       void renderAsync(blocks, {
         plugins: [shikiPlugin({ theme: "github-dark" })],
-      }).then((highlighted) => {
-        if (!cancelled) {
-          setHtml(autolinkURLs(highlighted));
-        }
-      }).catch(() => {
-        // Shiki failed to load — keep the sync render
-      });
+      })
+        .then((highlighted) => {
+          if (!cancelled) {
+            setHtml(autolinkURLs(highlighted));
+          }
+        })
+        .catch(() => {
+          // Shiki failed to load — keep the sync render
+        });
     } catch {
       // Parse failed — clear
       setHtml("");

--- a/src/components/PackageSourceChooser.tsx
+++ b/src/components/PackageSourceChooser.tsx
@@ -1,12 +1,12 @@
-import { Package } from 'lucide-react';
-import type { PackageCompatibility } from 'clawhub-schema';
-import { useRef, useState } from 'react';
-import { expandDroppedItems } from '../lib/uploadFiles';
-import { formatBytes } from '../routes/upload/-utils';
-import { formatPackageCompatibility } from '../lib/pluginPublishPrefill';
-import { Badge } from './ui/badge';
-import { Button } from './ui/button';
-import { Card } from './ui/card';
+import type { PackageCompatibility } from "clawhub-schema";
+import { Package } from "lucide-react";
+import { useRef, useState } from "react";
+import { formatPackageCompatibility } from "../lib/pluginPublishPrefill";
+import { expandDroppedItems } from "../lib/uploadFiles";
+import { formatBytes } from "../routes/upload/-utils";
+import { Badge } from "./ui/badge";
+import { Button } from "./ui/button";
+import { Card } from "./ui/card";
 
 export function PackageSourceChooser(props: {
   files: File[];
@@ -15,7 +15,7 @@ export function PackageSourceChooser(props: {
   normalizedPathSet: Set<string>;
   ignoredPaths: string[];
   detectedPrefillFields: string[];
-  family: 'code-plugin' | 'bundle-plugin';
+  family: "code-plugin" | "bundle-plugin";
   validationError: string | null;
   codePluginFieldIssues: string[];
   codePluginCompatibility: PackageCompatibility | null;
@@ -29,8 +29,8 @@ export function PackageSourceChooser(props: {
   const setDirectoryInputRef = (node: HTMLInputElement | null) => {
     directoryInputRef.current = node;
     if (node) {
-      node.setAttribute('webkitdirectory', '');
-      node.setAttribute('directory', '');
+      node.setAttribute("webkitdirectory", "");
+      node.setAttribute("directory", "");
     }
   };
 
@@ -60,8 +60,8 @@ export function PackageSourceChooser(props: {
       <div
         className={`flex flex-col items-center gap-4 rounded-[var(--radius-md)] border-2 border-dashed p-8 text-center transition-colors ${
           isDragging
-            ? 'border-[color:var(--accent)] bg-[rgba(255,107,74,0.06)]'
-            : 'border-[color:var(--line)] bg-[color:var(--surface-muted)]'
+            ? "border-[color:var(--accent)] bg-[rgba(255,107,74,0.06)]"
+            : "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
         }`}
         onDragOver={(event) => {
           event.preventDefault();
@@ -79,7 +79,10 @@ export function PackageSourceChooser(props: {
           })();
         }}
       >
-        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-[color:var(--surface)]" aria-hidden="true">
+        <div
+          className="flex h-14 w-14 items-center justify-center rounded-full bg-[color:var(--surface)]"
+          aria-hidden="true"
+        >
           <Package size={28} className="text-[color:var(--ink-soft)]" />
         </div>
         <div className="flex flex-col items-center gap-2">
@@ -94,31 +97,27 @@ export function PackageSourceChooser(props: {
             of the form.
           </span>
           <div className="flex gap-2 pt-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => archiveInputRef.current?.click()}
-            >
+            <Button variant="outline" size="sm" onClick={() => archiveInputRef.current?.click()}>
               Browse files
             </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => directoryInputRef.current?.click()}
-            >
+            <Button variant="ghost" size="sm" onClick={() => directoryInputRef.current?.click()}>
               Choose folder
             </Button>
           </div>
         </div>
       </div>
 
-      <div className={`rounded-[var(--radius-sm)] border px-4 py-3 transition-colors ${
-        isMetadataLocked
-          ? 'border-[color:var(--line)] bg-[color:var(--surface-muted)]'
-          : 'border-emerald-300/40 bg-emerald-50 dark:border-emerald-500/30 dark:bg-emerald-950/30'
-      }`}>
+      <div
+        className={`rounded-[var(--radius-sm)] border px-4 py-3 transition-colors ${
+          isMetadataLocked
+            ? "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
+            : "border-emerald-300/40 bg-emerald-50 dark:border-emerald-500/30 dark:bg-emerald-950/30"
+        }`}
+      >
         {props.normalizedPaths.length === 0 ? (
-          <div className="text-sm text-[color:var(--ink-soft)]">No plugin package selected yet.</div>
+          <div className="text-sm text-[color:var(--ink-soft)]">
+            No plugin package selected yet.
+          </div>
         ) : (
           <>
             <div className="flex items-center justify-between">
@@ -129,20 +128,19 @@ export function PackageSourceChooser(props: {
             </div>
             <p className="mt-1 text-sm text-[color:var(--ink-soft)]">
               {props.detectedPrefillFields.length > 0
-                ? `Autofilled ${props.detectedPrefillFields.join(', ')}.`
-                : 'Package files were detected. Review and fill the release details below.'}
+                ? `Autofilled ${props.detectedPrefillFields.join(", ")}.`
+                : "Package files were detected. Review and fill the release details below."}
             </p>
             <div className="mt-2 flex flex-wrap gap-1.5">
-              {props.normalizedPathSet.has('package.json') ? (
-                <Badge>Package manifest</Badge>
-              ) : null}
-              {props.normalizedPathSet.has('openclaw.plugin.json') ? (
+              {props.normalizedPathSet.has("package.json") ? <Badge>Package manifest</Badge> : null}
+              {props.normalizedPathSet.has("openclaw.plugin.json") ? (
                 <Badge>Plugin manifest</Badge>
               ) : null}
-              {props.normalizedPathSet.has('openclaw.bundle.json') ? (
+              {props.normalizedPathSet.has("openclaw.bundle.json") ? (
                 <Badge>Bundle manifest</Badge>
               ) : null}
-              {props.normalizedPathSet.has('readme.md') || props.normalizedPathSet.has('readme.mdx') ? (
+              {props.normalizedPathSet.has("readme.md") ||
+              props.normalizedPathSet.has("readme.mdx") ? (
                 <Badge>README</Badge>
               ) : null}
               {props.ignoredPaths.length > 0 ? (
@@ -153,14 +151,17 @@ export function PackageSourceChooser(props: {
         )}
       </div>
       {props.validationError ? <Badge variant="accent">{props.validationError}</Badge> : null}
-      {props.family === 'code-plugin' && props.codePluginFieldIssues.length > 0 ? (
+      {props.family === "code-plugin" && props.codePluginFieldIssues.length > 0 ? (
         <Badge variant="accent">
-          Missing required OpenClaw package metadata: {props.codePluginFieldIssues.join(', ')}. Add these
-          fields to <code>package.json</code> before publishing. See{' '}
-          <a href="/plugins/sdk-setup#package-metadata" className="underline">Plugin Setup and Config</a>.
+          Missing required OpenClaw package metadata: {props.codePluginFieldIssues.join(", ")}. Add
+          these fields to <code>package.json</code> before publishing. See{" "}
+          <a href="/plugins/sdk-setup#package-metadata" className="underline">
+            Plugin Setup and Config
+          </a>
+          .
         </Badge>
       ) : null}
-      {props.family === 'code-plugin' && props.codePluginCompatibility ? (
+      {props.family === "code-plugin" && props.codePluginCompatibility ? (
         <p className="text-sm text-[color:var(--ink-soft)]">
           Compatibility: {formatPackageCompatibility(props.codePluginCompatibility)}
         </p>

--- a/src/components/SkillCard.tsx
+++ b/src/components/SkillCard.tsx
@@ -38,11 +38,19 @@ export function SkillCard({
       {hasTags ? (
         <div className="flex flex-wrap items-center gap-1.5">
           {badges.map((label) => (
-            <Badge key={label} variant="default">{label}</Badge>
+            <Badge key={label} variant="default">
+              {label}
+            </Badge>
           ))}
-          {chip ? <Badge variant="accent" className="text-[0.72rem] px-2.5 py-0.5">{chip}</Badge> : null}
+          {chip ? (
+            <Badge variant="accent" className="text-[0.72rem] px-2.5 py-0.5">
+              {chip}
+            </Badge>
+          ) : null}
           {platformLabels?.map((label) => (
-            <Badge key={label} variant="compact">{label}</Badge>
+            <Badge key={label} variant="compact">
+              {label}
+            </Badge>
           ))}
           {verified && (
             <span className="inline-flex items-center gap-1 text-[0.72rem] font-semibold text-emerald-600 dark:text-emerald-400">

--- a/src/components/SkillCommentsPanel.tsx
+++ b/src/components/SkillCommentsPanel.tsx
@@ -108,9 +108,7 @@ export function SkillCommentsPanel({ skillId, isAuthenticated, me }: SkillCommen
 
   return (
     <Card>
-      <h2 className="m-0 font-display text-[1.2rem] font-bold text-[color:var(--ink)]">
-        Comments
-      </h2>
+      <h2 className="m-0 font-display text-[1.2rem] font-bold text-[color:var(--ink)]">Comments</h2>
       {isAuthenticated ? (
         <form
           onSubmit={(event) => {
@@ -133,7 +131,9 @@ export function SkillCommentsPanel({ skillId, isAuthenticated, me }: SkillCommen
       ) : (
         <p className="text-sm text-[color:var(--ink-soft)]">Sign in to comment.</p>
       )}
-      {reportNotice ? <div className="text-sm text-[color:var(--ink-soft)]">{reportNotice}</div> : null}
+      {reportNotice ? (
+        <div className="text-sm text-[color:var(--ink-soft)]">{reportNotice}</div>
+      ) : null}
       <div className="grid gap-3 pt-1">
         {comments === undefined ? (
           <Skeleton className="h-16 w-full" />
@@ -141,10 +141,17 @@ export function SkillCommentsPanel({ skillId, isAuthenticated, me }: SkillCommen
           <div className="text-sm text-[color:var(--ink-soft)]">No comments yet.</div>
         ) : (
           comments.map((entry) => (
-            <div key={entry.comment._id} className="flex gap-3 rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)] p-3">
+            <div
+              key={entry.comment._id}
+              className="flex gap-3 rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)] p-3"
+            >
               <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-                <strong className="text-sm">@{entry.user?.handle ?? entry.user?.name ?? "user"}</strong>
-                <div className="whitespace-pre-wrap break-words text-sm text-[color:var(--ink)]">{entry.comment.body}</div>
+                <strong className="text-sm">
+                  @{entry.user?.handle ?? entry.user?.name ?? "user"}
+                </strong>
+                <div className="whitespace-pre-wrap break-words text-sm text-[color:var(--ink)]">
+                  {entry.comment.body}
+                </div>
                 {isAuthenticated && reportingCommentId === entry.comment._id ? (
                   <form
                     className="mt-2 flex flex-col gap-2 rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface-muted)] p-3"
@@ -171,15 +178,13 @@ export function SkillCommentsPanel({ skillId, isAuthenticated, me }: SkillCommen
                       >
                         Cancel
                       </Button>
-                      <Button
-                        size="sm"
-                        type="submit"
-                        disabled={isSubmittingReport}
-                      >
+                      <Button size="sm" type="submit" disabled={isSubmittingReport}>
                         {isSubmittingReport ? "Reporting…" : "Submit report"}
                       </Button>
                     </div>
-                    {reportError ? <div className="text-sm text-red-600 dark:text-red-400">{reportError}</div> : null}
+                    {reportError ? (
+                      <div className="text-sm text-red-600 dark:text-red-400">{reportError}</div>
+                    ) : null}
                     <div className="text-sm text-[color:var(--ink-soft)]">
                       Reports require a reason. Abuse of reporting may result in bans.
                     </div>

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -10,6 +10,8 @@ import type { SkillBySlugResult, SkillPageInitialData } from "../lib/skillPage";
 import { useAuthStatus } from "../lib/useAuthStatus";
 import { ClientOnly } from "./ClientOnly";
 import { EmptyState } from "./EmptyState";
+import { Container } from "./layout/Container";
+import { SkillDetailSkeleton } from "./skeletons/SkillDetailSkeleton";
 import { SkillCommentsPanel } from "./SkillCommentsPanel";
 import { SkillDetailTabs } from "./SkillDetailTabs";
 import {
@@ -22,8 +24,6 @@ import {
 import { SkillHeader } from "./SkillHeader";
 import { SkillOwnershipPanel } from "./SkillOwnershipPanel";
 import { SkillReportDialog } from "./SkillReportDialog";
-import { Container } from "./layout/Container";
-import { SkillDetailSkeleton } from "./skeletons/SkillDetailSkeleton";
 import { Card } from "./ui/card";
 import { Skeleton } from "./ui/skeleton";
 
@@ -359,131 +359,125 @@ export function SkillDetailPage({
   return (
     <main className="py-10">
       <Container>
-      <div className="flex flex-col gap-6">
-        <SkillHeader
-          skill={skill}
-          owner={owner}
-          ownerHandle={ownerHandle}
-          latestVersion={latestVersion}
-          modInfo={modInfo}
-          canManage={canManage}
-          isAuthenticated={isAuthenticated}
-          isStaff={isStaff}
-          isStarred={isStarred}
-          onToggleStar={() => void toggleStar({ skillId: skill._id })}
-          onOpenReport={openReportDialog}
-          forkOf={forkOf}
-          forkOfLabel={forkOfLabel}
-          forkOfHref={forkOfHref}
-          forkOfOwnerHandle={forkOfOwnerHandle}
-          canonical={canonical}
-          canonicalHref={canonicalHref}
-          canonicalOwnerHandle={canonicalOwnerHandle}
-          staffModerationNote={staffModerationNote}
-          staffVisibilityTag={staffVisibilityTag}
-          isAutoHidden={isAutoHidden}
-          isRemoved={isRemoved}
-          nixPlugin={nixPlugin}
-          hasPluginBundle={hasPluginBundle}
-          configRequirements={configRequirements}
-          cliHelp={cliHelp}
-          tagEntries={tagEntries}
-          versionById={versionById}
-          tagName={tagName}
-          onTagNameChange={setTagName}
-          tagVersionId={tagVersionId}
-          onTagVersionChange={setTagVersionId}
-          onTagSubmit={submitTag}
-          onTagDelete={deleteTag}
-          tagVersions={versions ?? []}
-          clawdis={clawdis}
-          osLabels={osLabels}
-        />
-
-        {isOwner && skill ? (
-          <SkillOwnershipPanel
-            skillId={skill._id}
-            slug={skill.slug}
+        <div className="flex flex-col gap-6">
+          <SkillHeader
+            skill={skill}
+            owner={owner}
             ownerHandle={ownerHandle}
-            ownerId={owner?._id ?? null}
-            ownedSkills={(ownedSkills ?? []).filter((entry) => entry._id !== skill._id)}
+            latestVersion={latestVersion}
+            modInfo={modInfo}
+            canManage={canManage}
+            isAuthenticated={isAuthenticated}
+            isStaff={isStaff}
+            isStarred={isStarred}
+            onToggleStar={() => void toggleStar({ skillId: skill._id })}
+            onOpenReport={openReportDialog}
+            forkOf={forkOf}
+            forkOfLabel={forkOfLabel}
+            forkOfHref={forkOfHref}
+            forkOfOwnerHandle={forkOfOwnerHandle}
+            canonical={canonical}
+            canonicalHref={canonicalHref}
+            canonicalOwnerHandle={canonicalOwnerHandle}
+            staffModerationNote={staffModerationNote}
+            staffVisibilityTag={staffVisibilityTag}
+            isAutoHidden={isAutoHidden}
+            isRemoved={isRemoved}
+            nixPlugin={nixPlugin}
+            hasPluginBundle={hasPluginBundle}
+            configRequirements={configRequirements}
+            cliHelp={cliHelp}
+            tagEntries={tagEntries}
+            versionById={versionById}
+            tagName={tagName}
+            onTagNameChange={setTagName}
+            tagVersionId={tagVersionId}
+            onTagVersionChange={setTagVersionId}
+            onTagSubmit={submitTag}
+            onTagDelete={deleteTag}
+            tagVersions={versions ?? []}
+            clawdis={clawdis}
+            osLabels={osLabels}
           />
-        ) : null}
 
-        {nixSnippet ? (
-          <Card>
-            <h2 className="font-display text-lg font-bold text-[color:var(--ink)]">
-              Install via Nix
-            </h2>
-            <p className="text-sm text-[color:var(--ink-soft)]">
-              {nixSystems.length ? `Systems: ${nixSystems.join(", ")}` : "nix-clawdbot"}
-            </p>
-            <pre className="hero-install-code mt-3">
-              {nixSnippet}
-            </pre>
-          </Card>
-        ) : null}
+          {isOwner && skill ? (
+            <SkillOwnershipPanel
+              skillId={skill._id}
+              slug={skill.slug}
+              ownerHandle={ownerHandle}
+              ownerId={owner?._id ?? null}
+              ownedSkills={(ownedSkills ?? []).filter((entry) => entry._id !== skill._id)}
+            />
+          ) : null}
 
-        {configExample ? (
-          <Card>
-            <h2 className="font-display text-lg font-bold text-[color:var(--ink)]">
-              Config example
-            </h2>
-            <p className="text-sm text-[color:var(--ink-soft)]">
-              Starter config for this plugin bundle.
-            </p>
-            <pre className="hero-install-code mt-3">
-              {configExample}
-            </pre>
-          </Card>
-        ) : null}
-
-        <SkillDetailTabs
-          activeTab={activeTab}
-          setActiveTab={setActiveTab}
-          onCompareIntent={() => setShouldPrefetchCompare(true)}
-          readmeContent={readmeContent}
-          readmeError={readmeError}
-          latestFiles={latestFiles}
-          latestVersionId={latestVersion?._id ?? null}
-          skill={skill as Doc<"skills">}
-          diffVersions={diffVersions}
-          versions={versions}
-          nixPlugin={Boolean(nixPlugin)}
-          suppressVersionScanResults={suppressVersionScanResults}
-          scanResultsSuppressedMessage={scanResultsSuppressedMessage}
-        />
-
-        <ClientOnly
-          fallback={
+          {nixSnippet ? (
             <Card>
               <h2 className="font-display text-lg font-bold text-[color:var(--ink)]">
-                Comments
+                Install via Nix
               </h2>
-              <div className="flex flex-col gap-3 pt-2">
-                <Skeleton className="h-4 w-48" />
-                <Skeleton className="h-20 w-full" />
-              </div>
+              <p className="text-sm text-[color:var(--ink-soft)]">
+                {nixSystems.length ? `Systems: ${nixSystems.join(", ")}` : "nix-clawdbot"}
+              </p>
+              <pre className="hero-install-code mt-3">{nixSnippet}</pre>
             </Card>
-          }
-        >
-          <SkillCommentsPanel
-            skillId={skill._id}
-            isAuthenticated={isAuthenticated}
-            me={me ?? null}
-          />
-        </ClientOnly>
-      </div>
+          ) : null}
 
-      <SkillReportDialog
-        isOpen={isAuthenticated && isReportDialogOpen}
-        isSubmitting={isSubmittingReport}
-        reportReason={reportReason}
-        reportError={reportError}
-        onReasonChange={setReportReason}
-        onCancel={closeReportDialog}
-        onSubmit={() => void submitReport()}
-      />
+          {configExample ? (
+            <Card>
+              <h2 className="font-display text-lg font-bold text-[color:var(--ink)]">
+                Config example
+              </h2>
+              <p className="text-sm text-[color:var(--ink-soft)]">
+                Starter config for this plugin bundle.
+              </p>
+              <pre className="hero-install-code mt-3">{configExample}</pre>
+            </Card>
+          ) : null}
+
+          <SkillDetailTabs
+            activeTab={activeTab}
+            setActiveTab={setActiveTab}
+            onCompareIntent={() => setShouldPrefetchCompare(true)}
+            readmeContent={readmeContent}
+            readmeError={readmeError}
+            latestFiles={latestFiles}
+            latestVersionId={latestVersion?._id ?? null}
+            skill={skill as Doc<"skills">}
+            diffVersions={diffVersions}
+            versions={versions}
+            nixPlugin={Boolean(nixPlugin)}
+            suppressVersionScanResults={suppressVersionScanResults}
+            scanResultsSuppressedMessage={scanResultsSuppressedMessage}
+          />
+
+          <ClientOnly
+            fallback={
+              <Card>
+                <h2 className="font-display text-lg font-bold text-[color:var(--ink)]">Comments</h2>
+                <div className="flex flex-col gap-3 pt-2">
+                  <Skeleton className="h-4 w-48" />
+                  <Skeleton className="h-20 w-full" />
+                </div>
+              </Card>
+            }
+          >
+            <SkillCommentsPanel
+              skillId={skill._id}
+              isAuthenticated={isAuthenticated}
+              me={me ?? null}
+            />
+          </ClientOnly>
+        </div>
+
+        <SkillReportDialog
+          isOpen={isAuthenticated && isReportDialogOpen}
+          isSubmitting={isSubmittingReport}
+          reportReason={reportReason}
+          reportError={reportError}
+          onReasonChange={setReportReason}
+          onCancel={closeReportDialog}
+          onSubmit={() => void submitReport()}
+        />
       </Container>
     </main>
   );

--- a/src/components/SkillDetailTabs.tsx
+++ b/src/components/SkillDetailTabs.tsx
@@ -1,9 +1,9 @@
 import { lazy, Suspense } from "react";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
+import { SkillVersionsPanel } from "./SkillVersionsPanel";
 import { Card } from "./ui/card";
 import { Skeleton } from "./ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
-import { SkillVersionsPanel } from "./SkillVersionsPanel";
 
 const SkillDiffCard = lazy(() =>
   import("./SkillDiffCard").then((module) => ({ default: module.SkillDiffCard })),
@@ -50,9 +50,7 @@ export function SkillDetailTabs({
     <Card>
       <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as typeof activeTab)}>
         <TabsList>
-          <TabsTrigger value="files">
-            Files
-          </TabsTrigger>
+          <TabsTrigger value="files">Files</TabsTrigger>
           <TabsTrigger
             value="compare"
             onMouseEnter={() => {
@@ -66,9 +64,7 @@ export function SkillDetailTabs({
           >
             Compare
           </TabsTrigger>
-          <TabsTrigger value="versions">
-            Versions
-          </TabsTrigger>
+          <TabsTrigger value="versions">Versions</TabsTrigger>
         </TabsList>
 
         <TabsContent value="files">

--- a/src/components/SkillDiffCard.tsx
+++ b/src/components/SkillDiffCard.tsx
@@ -13,12 +13,12 @@ import {
   selectDefaultFilePath,
   sortVersionsBySemver,
 } from "../lib/diffing";
+import { ClientOnly } from "./ClientOnly";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import { Card } from "./ui/card";
 import { Label } from "./ui/label";
 import { Skeleton } from "./ui/skeleton";
-import { ClientOnly } from "./ClientOnly";
 
 type SkillDiffCardProps = {
   skill: Doc<"skills">;
@@ -404,18 +404,26 @@ export function SkillDiffCard({ skill, versions, variant = "card" }: SkillDiffCa
         </div>
         <div className="relative min-h-[300px]">
           {error ? (
-            <div className="flex h-full items-center justify-center p-4 text-sm text-[color:var(--ink-soft)]">{error}</div>
+            <div className="flex h-full items-center justify-center p-4 text-sm text-[color:var(--ink-soft)]">
+              {error}
+            </div>
           ) : sizeWarning ? (
             <div className="flex h-full items-center justify-center p-4 text-sm text-[color:var(--ink-soft)]">
               {sizeWarning.side === "left" ? "Left" : "Right"} file exceeds 200KB:{" "}
               {sizeWarning.path}
             </div>
           ) : diffUnavailable ? (
-            <div className="flex h-full items-center justify-center p-4 text-sm text-[color:var(--ink-soft)]">Publish another version to compare.</div>
+            <div className="flex h-full items-center justify-center p-4 text-sm text-[color:var(--ink-soft)]">
+              Publish another version to compare.
+            </div>
           ) : !selectionReady ? (
-            <div className="flex h-full items-center justify-center p-4 text-sm text-[color:var(--ink-soft)]">Select two versions to compare.</div>
+            <div className="flex h-full items-center justify-center p-4 text-sm text-[color:var(--ink-soft)]">
+              Select two versions to compare.
+            </div>
           ) : !fileSelected ? (
-            <div className="flex h-full items-center justify-center p-4 text-sm text-[color:var(--ink-soft)]">Select a file to compare.</div>
+            <div className="flex h-full items-center justify-center p-4 text-sm text-[color:var(--ink-soft)]">
+              Select a file to compare.
+            </div>
           ) : (
             <ClientOnly fallback={<Skeleton className="h-full w-full" />}>
               <DiffEditor

--- a/src/components/SkillFilesPanel.tsx
+++ b/src/components/SkillFilesPanel.tsx
@@ -1,10 +1,10 @@
 import { useAction } from "convex/react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { MarkdownPreview } from "./MarkdownPreview";
 import { api } from "../../convex/_generated/api";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
-import { Skeleton } from "./ui/skeleton";
+import { MarkdownPreview } from "./MarkdownPreview";
 import { formatBytes } from "./skillDetailUtils";
+import { Skeleton } from "./ui/skeleton";
 
 type SkillFile = Doc<"skillVersions">["files"][number];
 
@@ -100,7 +100,9 @@ export function SkillFilesPanel({
           {readmeContent ? (
             <MarkdownPreview>{readmeContent}</MarkdownPreview>
           ) : readmeError ? (
-            <div className="text-sm text-[color:var(--ink-soft)]">Failed to load SKILL.md: {readmeError}</div>
+            <div className="text-sm text-[color:var(--ink-soft)]">
+              Failed to load SKILL.md: {readmeError}
+            </div>
           ) : (
             <Skeleton className="h-24 w-full" />
           )}
@@ -118,7 +120,9 @@ export function SkillFilesPanel({
           </div>
           <div className="flex max-h-[400px] flex-col overflow-y-auto">
             {latestFiles.length === 0 ? (
-              <div className="px-3 py-2 text-sm text-[color:var(--ink-soft)]">No files available.</div>
+              <div className="px-3 py-2 text-sm text-[color:var(--ink-soft)]">
+                No files available.
+              </div>
             ) : (
               latestFiles.map((file) => (
                 <button
@@ -133,7 +137,9 @@ export function SkillFilesPanel({
                   aria-current={selectedPath === file.path ? "true" : undefined}
                 >
                   <span className="truncate font-mono text-xs">{file.path}</span>
-                  <span className="ml-2 shrink-0 text-xs text-[color:var(--ink-soft)]">{formatBytes(file.size)}</span>
+                  <span className="ml-2 shrink-0 text-xs text-[color:var(--ink-soft)]">
+                    {formatBytes(file.size)}
+                  </span>
                 </button>
               ))
             )}
@@ -152,9 +158,13 @@ export function SkillFilesPanel({
             {isLoading ? (
               <Skeleton className="h-24 w-full" />
             ) : fileError ? (
-              <div className="text-sm text-[color:var(--ink-soft)]">Failed to load file: {fileError}</div>
+              <div className="text-sm text-[color:var(--ink-soft)]">
+                Failed to load file: {fileError}
+              </div>
             ) : fileContent ? (
-              <pre className="m-0 overflow-x-auto whitespace-pre-wrap break-words font-mono text-xs leading-relaxed">{fileContent}</pre>
+              <pre className="m-0 overflow-x-auto whitespace-pre-wrap break-words font-mono text-xs leading-relaxed">
+                {fileContent}
+              </pre>
             ) : (
               <div className="text-sm text-[color:var(--ink-soft)]">Select a file to preview.</div>
             )}

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -1,5 +1,5 @@
-import type { ClawdisSkillMetadata } from "clawhub-schema";
 import { Link } from "@tanstack/react-router";
+import type { ClawdisSkillMetadata } from "clawhub-schema";
 import {
   PLATFORM_SKILL_LICENSE,
   PLATFORM_SKILL_LICENSE_SUMMARY,
@@ -10,12 +10,12 @@ import { getSkillBadges } from "../lib/badges";
 import { formatCompactStat, formatSkillStatsTriplet } from "../lib/numberFormat";
 import type { PublicPublisher, PublicSkill } from "../lib/publicUser";
 import { getRuntimeEnv } from "../lib/runtimeEnv";
+import { SkillInstallCard } from "./SkillInstallCard";
+import { type LlmAnalysis, SecurityScanResults } from "./SkillSecurityScanResults";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import { Card, CardContent } from "./ui/card";
 import { Input } from "./ui/input";
-import { SkillInstallCard } from "./SkillInstallCard";
-import { type LlmAnalysis, SecurityScanResults } from "./SkillSecurityScanResults";
 import { UserBadge } from "./UserBadge";
 
 export type SkillModerationInfo = {
@@ -207,10 +207,14 @@ export function SkillHeader({
                   ) : null}
                   {nixPlugin ? <Badge variant="accent">Plugin bundle (nix)</Badge> : null}
                 </div>
-                <p className="m-0 text-sm text-[color:var(--ink-soft)]">{skill.summary ?? "No summary provided."}</p>
+                <p className="m-0 text-sm text-[color:var(--ink-soft)]">
+                  {skill.summary ?? "No summary provided."}
+                </p>
 
                 {isStaff && staffModerationNote ? (
-                  <div className="rounded-[var(--radius-sm)] border border-amber-200/60 bg-amber-50/60 px-3 py-2 text-sm text-[color:var(--ink-soft)] dark:border-amber-500/20 dark:bg-amber-950/30">{staffModerationNote}</div>
+                  <div className="rounded-[var(--radius-sm)] border border-amber-200/60 bg-amber-50/60 px-3 py-2 text-sm text-[color:var(--ink-soft)] dark:border-amber-500/20 dark:bg-amber-950/30">
+                    {staffModerationNote}
+                  </div>
                 ) : null}
                 {nixPlugin ? (
                   <div className="rounded-[var(--radius-sm)] border border-amber-200/60 bg-amber-50/60 px-3 py-2 text-sm text-[color:var(--ink-soft)] dark:border-amber-500/20 dark:bg-amber-950/30">
@@ -220,13 +224,21 @@ export function SkillHeader({
 
                 <div className="flex flex-col gap-2 pt-1">
                   <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-sm text-[color:var(--ink-soft)]">⭐ {formattedStats.stars}</span>
+                    <span className="text-sm text-[color:var(--ink-soft)]">
+                      ⭐ {formattedStats.stars}
+                    </span>
                     <span className="text-[color:var(--ink-soft)] opacity-40">·</span>
-                    <span className="flex items-center gap-1 text-sm text-[color:var(--ink-soft)]"><Package size={14} aria-hidden="true" /> {formattedStats.downloads}</span>
+                    <span className="flex items-center gap-1 text-sm text-[color:var(--ink-soft)]">
+                      <Package size={14} aria-hidden="true" /> {formattedStats.downloads}
+                    </span>
                     <span className="text-[color:var(--ink-soft)] opacity-40">·</span>
-                    <span className="text-sm text-[color:var(--ink-soft)]">{formatCompactStat(skill.stats.installsCurrent ?? 0)} current</span>
+                    <span className="text-sm text-[color:var(--ink-soft)]">
+                      {formatCompactStat(skill.stats.installsCurrent ?? 0)} current
+                    </span>
                     <span className="text-[color:var(--ink-soft)] opacity-40">·</span>
-                    <span className="text-sm text-[color:var(--ink-soft)]">{formattedStats.installsAllTime} all-time</span>
+                    <span className="text-sm text-[color:var(--ink-soft)]">
+                      {formattedStats.installsAllTime} all-time
+                    </span>
                   </div>
                   <div className="flex flex-wrap items-center gap-2">
                     <UserBadge
@@ -290,8 +302,12 @@ export function SkillHeader({
               ) : null}
               <div className="flex flex-col gap-2">
                 <div className="flex flex-col gap-0.5">
-                  <span className="text-xs font-semibold text-[color:var(--ink-soft)]">License</span>
-                  <span className="text-sm text-[color:var(--ink)]">{PLATFORM_SKILL_LICENSE} · {PLATFORM_SKILL_LICENSE_SUMMARY}</span>
+                  <span className="text-xs font-semibold text-[color:var(--ink-soft)]">
+                    License
+                  </span>
+                  <span className="text-sm text-[color:var(--ink)]">
+                    {PLATFORM_SKILL_LICENSE} · {PLATFORM_SKILL_LICENSE_SUMMARY}
+                  </span>
                 </div>
               </div>
               <div className="flex items-center gap-2">
@@ -325,7 +341,9 @@ export function SkillHeader({
 
           {/* Security scan — full width below the header columns */}
           {suppressScanResults ? (
-            <div className="rounded-[var(--radius-sm)] border border-amber-200/60 bg-amber-50/60 px-3 py-2 text-sm text-[color:var(--ink-soft)] dark:border-amber-500/20 dark:bg-amber-950/30">{overrideScanMessage}</div>
+            <div className="rounded-[var(--radius-sm)] border border-amber-200/60 bg-amber-50/60 px-3 py-2 text-sm text-[color:var(--ink-soft)] dark:border-amber-500/20 dark:bg-amber-950/30">
+              {overrideScanMessage}
+            </div>
           ) : latestVersion?.sha256hash ||
             latestVersion?.llmAnalysis ||
             (latestVersion?.staticScan?.findings?.length ?? 0) > 0 ? (
@@ -346,8 +364,12 @@ export function SkillHeader({
             <Card className="border-dashed">
               <CardContent>
                 <div className="flex flex-col gap-1">
-                  <div className="font-display text-base font-bold text-[color:var(--ink)]">Plugin bundle (nix)</div>
-                  <div className="text-sm text-[color:var(--ink-soft)]">Skill pack · CLI binary · Config</div>
+                  <div className="font-display text-base font-bold text-[color:var(--ink)]">
+                    Plugin bundle (nix)
+                  </div>
+                  <div className="text-sm text-[color:var(--ink-soft)]">
+                    Skill pack · CLI binary · Config
+                  </div>
                 </div>
                 <div className="flex flex-wrap gap-2">
                   <Badge>SKILL.md</Badge>
@@ -356,7 +378,9 @@ export function SkillHeader({
                 </div>
                 {configRequirements ? (
                   <div className="flex flex-col gap-2">
-                    <div className="text-sm font-semibold text-[color:var(--ink)]">Config requirements</div>
+                    <div className="text-sm font-semibold text-[color:var(--ink)]">
+                      Config requirements
+                    </div>
                     <div className="flex flex-col gap-1">
                       {configRequirements.requiredEnv?.length ? (
                         <div className="text-sm text-[color:var(--ink-soft)]">
@@ -375,8 +399,12 @@ export function SkillHeader({
                 ) : null}
                 {cliHelp ? (
                   <details className="flex flex-col gap-2">
-                    <summary className="cursor-pointer text-sm font-semibold text-[color:var(--ink)]">CLI help (from plugin)</summary>
-                    <pre className="mt-2 overflow-x-auto rounded-[var(--radius-sm)] bg-[color:var(--surface-muted)] p-3 font-mono text-xs">{cliHelp}</pre>
+                    <summary className="cursor-pointer text-sm font-semibold text-[color:var(--ink)]">
+                      CLI help (from plugin)
+                    </summary>
+                    <pre className="mt-2 overflow-x-auto rounded-[var(--radius-sm)] bg-[color:var(--surface-muted)] p-3 font-mono text-xs">
+                      {cliHelp}
+                    </pre>
                   </details>
                 ) : null}
               </CardContent>
@@ -386,9 +414,7 @@ export function SkillHeader({
 
         <div className="flex flex-wrap items-center gap-2 border-t border-[color:var(--line)] pt-4">
           {tagEntries.length === 0 ? (
-            <span className="m-0 text-sm text-[color:var(--ink-soft)]">
-              No tags yet.
-            </span>
+            <span className="m-0 text-sm text-[color:var(--ink-soft)]">No tags yet.</span>
           ) : (
             tagEntries.map(([tag, versionId]) => (
               <Badge key={tag} className="gap-1.5">
@@ -437,9 +463,7 @@ export function SkillHeader({
                 </option>
               ))}
             </select>
-            <Button type="submit">
-              Update tag
-            </Button>
+            <Button type="submit">Update tag</Button>
           </form>
         ) : null}
 

--- a/src/components/SkillInstallCard.tsx
+++ b/src/components/SkillInstallCard.tsx
@@ -4,9 +4,9 @@ import {
   PLATFORM_SKILL_LICENSE_SUMMARY,
   PLATFORM_SKILL_LICENSE_URL,
 } from "clawhub-schema/licenseConstants";
+import { formatInstallCommand, formatInstallLabel } from "./skillDetailUtils";
 import { Badge } from "./ui/badge";
 import { Card, CardContent } from "./ui/card";
-import { formatInstallCommand, formatInstallLabel } from "./skillDetailUtils";
 
 type SkillInstallCardProps = {
   clawdis: ClawdisSkillMetadata | undefined;
@@ -53,7 +53,12 @@ export function SkillInstallCard({ clawdis, osLabels }: SkillInstallCardProps) {
               </div>
               <div className="text-sm text-[color:var(--ink-soft)]">
                 <strong>Terms</strong>
-                <a href={PLATFORM_SKILL_LICENSE_URL} target="_blank" rel="noopener noreferrer" className="ml-1">
+                <a
+                  href={PLATFORM_SKILL_LICENSE_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="ml-1"
+                >
                   {PLATFORM_SKILL_LICENSE_URL}
                 </a>
               </div>
@@ -109,19 +114,12 @@ export function SkillInstallCard({ clawdis, osLabels }: SkillInstallCardProps) {
                     <strong>Environment variables</strong>
                     <div className="mt-1 flex flex-col gap-1">
                       {envVars.map((env, index) => (
-                        <div
-                          key={`${env.name}-${index}`}
-                          className="flex items-baseline gap-2"
-                        >
+                        <div key={`${env.name}-${index}`} className="flex items-baseline gap-2">
                           <code className="text-[0.85rem]">{env.name}</code>
                           {env.required === false ? (
-                            <span className="text-xs text-[color:var(--ink-soft)]">
-                              optional
-                            </span>
+                            <span className="text-xs text-[color:var(--ink-soft)]">optional</span>
                           ) : env.required === true ? (
-                            <span className="text-xs text-[color:var(--accent)]">
-                              required
-                            </span>
+                            <span className="text-xs text-[color:var(--accent)]">required</span>
                           ) : null}
                           {env.description ? (
                             <span className="text-[0.8rem] text-[color:var(--ink-soft)]">
@@ -145,7 +143,10 @@ export function SkillInstallCard({ clawdis, osLabels }: SkillInstallCardProps) {
               </h3>
               <div className="flex flex-col gap-2">
                 {dependencies.map((dep, index) => (
-                  <div key={`${dep.name}-${index}`} className="text-sm text-[color:var(--ink-soft)]">
+                  <div
+                    key={`${dep.name}-${index}`}
+                    className="text-sm text-[color:var(--ink-soft)]"
+                  >
                     <div>
                       <strong>{dep.name}</strong>
                       <span className="ml-2 text-[0.85rem] text-[color:var(--ink-soft)]">
@@ -183,7 +184,10 @@ export function SkillInstallCard({ clawdis, osLabels }: SkillInstallCardProps) {
                 {installSpecs.map((spec, index) => {
                   const command = formatInstallCommand(spec);
                   return (
-                    <div key={`${spec.id ?? spec.kind}-${index}`} className="text-sm text-[color:var(--ink-soft)]">
+                    <div
+                      key={`${spec.id ?? spec.kind}-${index}`}
+                      className="text-sm text-[color:var(--ink-soft)]"
+                    >
                       <div>
                         <strong>{spec.label ?? formatInstallLabel(spec)}</strong>
                         {spec.bins?.length ? (
@@ -191,7 +195,9 @@ export function SkillInstallCard({ clawdis, osLabels }: SkillInstallCardProps) {
                             Bins: {spec.bins.join(", ")}
                           </div>
                         ) : null}
-                        {command ? <code className="mt-0.5 block font-mono text-xs">{command}</code> : null}
+                        {command ? (
+                          <code className="mt-0.5 block font-mono text-xs">{command}</code>
+                        ) : null}
                       </div>
                     </div>
                   );
@@ -210,7 +216,12 @@ export function SkillInstallCard({ clawdis, osLabels }: SkillInstallCardProps) {
                 {links?.homepage ? (
                   <div className="text-sm text-[color:var(--ink-soft)]">
                     <strong>Homepage</strong>
-                    <a href={links.homepage} target="_blank" rel="noopener noreferrer" className="ml-1 break-all">
+                    <a
+                      href={links.homepage}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="ml-1 break-all"
+                    >
                       {links.homepage}
                     </a>
                   </div>
@@ -218,7 +229,12 @@ export function SkillInstallCard({ clawdis, osLabels }: SkillInstallCardProps) {
                 {links?.repository ? (
                   <div className="text-sm text-[color:var(--ink-soft)]">
                     <strong>Repository</strong>
-                    <a href={links.repository} target="_blank" rel="noopener noreferrer" className="ml-1 break-all">
+                    <a
+                      href={links.repository}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="ml-1 break-all"
+                    >
                       {links.repository}
                     </a>
                   </div>
@@ -226,7 +242,12 @@ export function SkillInstallCard({ clawdis, osLabels }: SkillInstallCardProps) {
                 {links?.documentation ? (
                   <div className="text-sm text-[color:var(--ink-soft)]">
                     <strong>Docs</strong>
-                    <a href={links.documentation} target="_blank" rel="noopener noreferrer" className="ml-1">
+                    <a
+                      href={links.documentation}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="ml-1"
+                    >
                       {links.documentation}
                     </a>
                   </div>

--- a/src/components/SkillOwnershipPanel.tsx
+++ b/src/components/SkillOwnershipPanel.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { api } from "../../convex/_generated/api";
 import type { Id } from "../../convex/_generated/dataModel";
+import { buildSkillHref } from "./skillDetailUtils";
 import { Button } from "./ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "./ui/card";
 import {
@@ -16,7 +17,6 @@ import {
 } from "./ui/dialog";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
-import { buildSkillHref } from "./skillDetailUtils";
 
 type OwnedSkillOption = {
   _id: Id<"skills">;
@@ -115,135 +115,138 @@ export function SkillOwnershipPanel({
 
   return (
     <>
-    <Card className="border-[color:var(--border-ui)]/30 bg-[color:var(--surface-muted)]/50" data-skill-id={skillId}>
-      <CardHeader>
-        <CardTitle className="text-base">Owner tools</CardTitle>
-        <CardDescription>
-          Rename the canonical slug or fold this listing into another one you own. Old slugs stay as
-          redirects and stop polluting search/list views.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <div className="grid gap-4 sm:grid-cols-2">
-          {/* Rename */}
-          <div className="flex flex-col gap-2">
-            <Label>Rename slug</Label>
-            <Input
-              value={renameSlug}
-              onChange={(event) => setRenameSlug(event.target.value)}
-              placeholder="new-slug"
-              autoComplete="off"
-              spellCheck={false}
-            />
-            <span className="text-xs text-[color:var(--ink-soft)]">
-              Current page: {ownerHref(slug)}
-            </span>
+      <Card
+        className="border-[color:var(--border-ui)]/30 bg-[color:var(--surface-muted)]/50"
+        data-skill-id={skillId}
+      >
+        <CardHeader>
+          <CardTitle className="text-base">Owner tools</CardTitle>
+          <CardDescription>
+            Rename the canonical slug or fold this listing into another one you own. Old slugs stay
+            as redirects and stop polluting search/list views.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {/* Rename */}
+            <div className="flex flex-col gap-2">
+              <Label>Rename slug</Label>
+              <Input
+                value={renameSlug}
+                onChange={(event) => setRenameSlug(event.target.value)}
+                placeholder="new-slug"
+                autoComplete="off"
+                spellCheck={false}
+              />
+              <span className="text-xs text-[color:var(--ink-soft)]">
+                Current page: {ownerHref(slug)}
+              </span>
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label>Rename action</Label>
+              <Button
+                variant="outline"
+                onClick={() => setConfirmRename(true)}
+                disabled={isSubmitting || renameSlug.trim().toLowerCase() === slug}
+              >
+                Rename and redirect
+              </Button>
+            </div>
+
+            {/* Merge */}
+            <div className="flex flex-col gap-2">
+              <Label>Merge into</Label>
+              <select
+                className="w-full min-h-[44px] rounded-[var(--radius-sm)] border border-[rgba(29,59,78,0.22)] bg-[rgba(255,255,255,0.94)] px-3.5 py-[13px] text-[color:var(--ink)] dark:border-[rgba(255,255,255,0.12)] dark:bg-[rgba(14,28,37,0.84)]"
+                value={mergeTargetSlug}
+                onChange={(event) => setMergeTargetSlug(event.target.value)}
+                disabled={ownedSkills.length === 0 || isSubmitting}
+              >
+                {ownedSkills.length === 0 ? <option value="">No other owned skills</option> : null}
+                {ownedSkills.map((entry) => (
+                  <option key={entry._id} value={entry.slug}>
+                    {entry.displayName} ({entry.slug})
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label>Merge action</Label>
+              <Button
+                variant="outline"
+                onClick={() => setConfirmMerge(true)}
+                disabled={isSubmitting || !mergeTargetSlug}
+              >
+                Merge into target
+              </Button>
+            </div>
           </div>
-          <div className="flex flex-col gap-2">
-            <Label>Rename action</Label>
-            <Button
-              variant="outline"
-              onClick={() => setConfirmRename(true)}
-              disabled={isSubmitting || renameSlug.trim().toLowerCase() === slug}
-            >
-              Rename and redirect
+
+          {error ? (
+            <p className="mt-3 text-sm font-medium text-red-600 dark:text-red-400">{error}</p>
+          ) : null}
+          <p className="mt-3 text-xs text-[color:var(--ink-soft)]">
+            Merge keeps the target live and hides this row. Versions and stats stay on the original
+            records for now.
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Rename confirmation dialog */}
+      <Dialog open={confirmRename} onOpenChange={setConfirmRename}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Rename skill slug?</DialogTitle>
+            <DialogDescription>
+              This will permanently rename <strong>{slug}</strong> to{" "}
+              <strong>{renameSlug.trim().toLowerCase()}</strong>. The old slug will become a
+              redirect. This cannot be undone without another rename.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmRename(false)}>
+              Cancel
             </Button>
-          </div>
-
-          {/* Merge */}
-          <div className="flex flex-col gap-2">
-            <Label>Merge into</Label>
-            <select
-              className="w-full min-h-[44px] rounded-[var(--radius-sm)] border border-[rgba(29,59,78,0.22)] bg-[rgba(255,255,255,0.94)] px-3.5 py-[13px] text-[color:var(--ink)] dark:border-[rgba(255,255,255,0.12)] dark:bg-[rgba(14,28,37,0.84)]"
-              value={mergeTargetSlug}
-              onChange={(event) => setMergeTargetSlug(event.target.value)}
-              disabled={ownedSkills.length === 0 || isSubmitting}
-            >
-              {ownedSkills.length === 0 ? <option value="">No other owned skills</option> : null}
-              {ownedSkills.map((entry) => (
-                <option key={entry._id} value={entry.slug}>
-                  {entry.displayName} ({entry.slug})
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className="flex flex-col gap-2">
-            <Label>Merge action</Label>
             <Button
-              variant="outline"
-              onClick={() => setConfirmMerge(true)}
-              disabled={isSubmitting || !mergeTargetSlug}
+              variant="primary"
+              loading={isSubmitting}
+              onClick={() => {
+                void handleRename().finally(() => setConfirmRename(false));
+              }}
             >
-              Merge into target
+              Rename
             </Button>
-          </div>
-        </div>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
-        {error ? (
-          <p className="mt-3 text-sm font-medium text-red-600 dark:text-red-400">{error}</p>
-        ) : null}
-        <p className="mt-3 text-xs text-[color:var(--ink-soft)]">
-          Merge keeps the target live and hides this row. Versions and stats stay on the original
-          records for now.
-        </p>
-      </CardContent>
-    </Card>
-
-    {/* Rename confirmation dialog */}
-    <Dialog open={confirmRename} onOpenChange={setConfirmRename}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Rename skill slug?</DialogTitle>
-          <DialogDescription>
-            This will permanently rename <strong>{slug}</strong> to{" "}
-            <strong>{renameSlug.trim().toLowerCase()}</strong>. The old slug will become a
-            redirect. This cannot be undone without another rename.
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter>
-          <Button variant="outline" onClick={() => setConfirmRename(false)}>
-            Cancel
-          </Button>
-          <Button
-            variant="primary"
-            loading={isSubmitting}
-            onClick={() => {
-              void handleRename().finally(() => setConfirmRename(false));
-            }}
-          >
-            Rename
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-
-    {/* Merge confirmation dialog */}
-    <Dialog open={confirmMerge} onOpenChange={setConfirmMerge}>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Merge into another skill?</DialogTitle>
-          <DialogDescription>
-            This will hide <strong>{slug}</strong> and redirect it to{" "}
-            <strong>{mergeTargetSlug.trim().toLowerCase()}</strong>. The listing row will be
-            removed from search and browse views. This is not easily reversible.
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter>
-          <Button variant="outline" onClick={() => setConfirmMerge(false)}>
-            Cancel
-          </Button>
-          <Button
-            variant="destructive"
-            loading={isSubmitting}
-            onClick={() => {
-              void handleMerge().finally(() => setConfirmMerge(false));
-            }}
-          >
-            Merge and hide
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      {/* Merge confirmation dialog */}
+      <Dialog open={confirmMerge} onOpenChange={setConfirmMerge}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Merge into another skill?</DialogTitle>
+            <DialogDescription>
+              This will hide <strong>{slug}</strong> and redirect it to{" "}
+              <strong>{mergeTargetSlug.trim().toLowerCase()}</strong>. The listing row will be
+              removed from search and browse views. This is not easily reversible.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmMerge(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              loading={isSubmitting}
+              onClick={() => {
+                void handleMerge().finally(() => setConfirmMerge(false));
+              }}
+            >
+              Merge and hide
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/src/components/SkillReportDialog.tsx
+++ b/src/components/SkillReportDialog.tsx
@@ -29,7 +29,12 @@ export function SkillReportDialog({
   onSubmit,
 }: SkillReportDialogProps) {
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => { if (!open && !isSubmitting) onCancel(); }}>
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open && !isSubmitting) onCancel();
+      }}
+    >
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Report skill</DialogTitle>

--- a/src/components/SkillVersionsPanel.tsx
+++ b/src/components/SkillVersionsPanel.tsx
@@ -29,12 +29,17 @@ export function SkillVersionsPanel({
             ? "Review release history and changelog."
             : "Download older releases or scan the changelog."}
         </p>
-        {suppressedMessage ? <p className="text-sm text-[color:var(--ink-soft)]">{suppressedMessage}</p> : null}
+        {suppressedMessage ? (
+          <p className="text-sm text-[color:var(--ink-soft)]">{suppressedMessage}</p>
+        ) : null}
       </div>
       <div className="max-h-[600px] overflow-y-auto">
         <div className="flex flex-col gap-3">
           {(versions ?? []).map((version) => (
-            <div key={version._id} className="flex items-start justify-between gap-4 rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)] p-3">
+            <div
+              key={version._id}
+              className="flex items-start justify-between gap-4 rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)] p-3"
+            >
               <div className="flex min-w-0 flex-1 flex-col gap-1">
                 <div>
                   v{version.version} · {new Date(version.createdAt).toLocaleDateString()}
@@ -42,7 +47,9 @@ export function SkillVersionsPanel({
                     <span className="text-[color:var(--ink-soft)]"> · auto</span>
                   ) : null}
                 </div>
-                <div className="whitespace-pre-wrap break-words text-[color:var(--ink-soft)]">{version.changelog}</div>
+                <div className="whitespace-pre-wrap break-words text-[color:var(--ink-soft)]">
+                  {version.changelog}
+                </div>
                 <div className="pt-1">
                   {!suppressScanResults && (version.sha256hash || version.llmAnalysis) ? (
                     <SecurityScanResults

--- a/src/components/SoulDetailPage.tsx
+++ b/src/components/SoulDetailPage.tsx
@@ -1,6 +1,5 @@
 import { useAction, useMutation, useQuery } from "convex/react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { MarkdownPreview } from "./MarkdownPreview";
 import { api } from "../../convex/_generated/api";
 import type { Doc } from "../../convex/_generated/dataModel";
 import type { PublicSoul, PublicUser } from "../lib/publicUser";
@@ -9,6 +8,7 @@ import { getRuntimeEnv } from "../lib/runtimeEnv";
 import { useAuthStatus } from "../lib/useAuthStatus";
 import { EmptyState } from "./EmptyState";
 import { Container } from "./layout/Container";
+import { MarkdownPreview } from "./MarkdownPreview";
 import { SkillCardSkeletonGrid } from "./skeletons/SkillCardSkeleton";
 import { stripFrontmatter } from "./skillDetailUtils";
 import { SoulStatsTripletLine } from "./SoulStats";
@@ -128,7 +128,10 @@ export function SoulDetailPage({ slug }: SoulDetailPageProps) {
     return (
       <main className="py-10">
         <Container size="narrow">
-          <EmptyState title="Soul not found" description="This soul does not exist or has been removed." />
+          <EmptyState
+            title="Soul not found"
+            description="This soul does not exist or has been removed."
+          />
         </Container>
       </main>
     );
@@ -149,13 +152,21 @@ export function SoulDetailPage({ slug }: SoulDetailPageProps) {
                   <h1 className="font-display text-2xl font-bold text-[color:var(--ink)]">
                     {soul.displayName}
                   </h1>
-                  <p className="text-sm text-[color:var(--ink-soft)]">{soul.summary ?? "No summary provided."}</p>
+                  <p className="text-sm text-[color:var(--ink-soft)]">
+                    {soul.summary ?? "No summary provided."}
+                  </p>
                   <div className="text-sm text-[color:var(--ink-soft)]">
                     <SoulStatsTripletLine stats={soul.stats} versionSuffix="versions" />
                   </div>
                   {ownerHandle ? (
                     <div className="text-sm text-[color:var(--ink-soft)]">
-                      by <a href={`/u/${ownerHandle}`} className="text-[color:var(--accent)] hover:underline">@{ownerHandle}</a>
+                      by{" "}
+                      <a
+                        href={`/u/${ownerHandle}`}
+                        className="text-[color:var(--accent)] hover:underline"
+                      >
+                        @{ownerHandle}
+                      </a>
                     </div>
                   ) : null}
                   <div className="flex items-center gap-2">
@@ -197,7 +208,9 @@ export function SoulDetailPage({ slug }: SoulDetailPageProps) {
               {readmeContent ? (
                 <MarkdownPreview>{readmeContent}</MarkdownPreview>
               ) : readmeError ? (
-                <div className="text-sm text-[color:var(--ink-soft)]">Failed to load SOUL.md: {readmeError}</div>
+                <div className="text-sm text-[color:var(--ink-soft)]">
+                  Failed to load SOUL.md: {readmeError}
+                </div>
               ) : (
                 <div className="flex flex-col gap-2">
                   <Skeleton className="h-4 w-3/4" />
@@ -216,10 +229,14 @@ export function SoulDetailPage({ slug }: SoulDetailPageProps) {
               <div className="max-h-[400px] overflow-y-auto">
                 <div className="flex flex-col gap-3">
                   {(versions ?? []).map((version) => (
-                    <div key={version._id} className="flex items-center justify-between gap-3 rounded-[var(--radius-sm)] border border-[color:var(--line)] px-3 py-2">
+                    <div
+                      key={version._id}
+                      className="flex items-center justify-between gap-3 rounded-[var(--radius-sm)] border border-[color:var(--line)] px-3 py-2"
+                    >
                       <div className="flex flex-col gap-0.5">
                         <div className="text-sm">
-                          v{version.version} &middot; {new Date(version.createdAt).toLocaleDateString()}
+                          v{version.version} &middot;{" "}
+                          {new Date(version.createdAt).toLocaleDateString()}
                           {version.changelogSource === "auto" ? (
                             <span className="text-[color:var(--ink-soft)]"> &middot; auto</span>
                           ) : null}
@@ -279,12 +296,21 @@ export function SoulDetailPage({ slug }: SoulDetailPageProps) {
                   <div className="text-sm text-[color:var(--ink-soft)]">No comments yet.</div>
                 ) : (
                   (comments ?? []).map((entry) => (
-                    <div key={entry.comment._id} className="flex items-start justify-between gap-3 rounded-[var(--radius-sm)] border border-[color:var(--line)] px-3 py-2">
+                    <div
+                      key={entry.comment._id}
+                      className="flex items-start justify-between gap-3 rounded-[var(--radius-sm)] border border-[color:var(--line)] px-3 py-2"
+                    >
                       <div className="flex flex-col gap-1">
-                        <strong className="text-sm">@{entry.user?.handle ?? entry.user?.name ?? "user"}</strong>
-                        <div className="whitespace-pre-wrap break-words text-sm text-[color:var(--ink)]">{entry.comment.body}</div>
+                        <strong className="text-sm">
+                          @{entry.user?.handle ?? entry.user?.name ?? "user"}
+                        </strong>
+                        <div className="whitespace-pre-wrap break-words text-sm text-[color:var(--ink)]">
+                          {entry.comment.body}
+                        </div>
                       </div>
-                      {isAuthenticated && me && (me._id === entry.comment.userId || isModerator(me)) ? (
+                      {isAuthenticated &&
+                      me &&
+                      (me._id === entry.comment.userId || isModerator(me)) ? (
                         <Button
                           variant="destructive"
                           size="sm"

--- a/src/components/UserBadge.tsx
+++ b/src/components/UserBadge.tsx
@@ -18,8 +18,7 @@ export function UserBadge({
   showName = false,
 }: UserBadgeProps) {
   const userName = user && "name" in user ? user.name?.trim() : undefined;
-  const displayName =
-    user?.displayName?.trim() || userName || null;
+  const displayName = user?.displayName?.trim() || userName || null;
   const handle = user?.handle ?? fallbackHandle ?? null;
   const href =
     user?.handle && "kind" in user

--- a/src/components/layout/Breadcrumb.tsx
+++ b/src/components/layout/Breadcrumb.tsx
@@ -1,5 +1,5 @@
-import { ChevronRight } from "lucide-react";
 import { Link } from "@tanstack/react-router";
+import { ChevronRight } from "lucide-react";
 import type { ReactNode } from "react";
 import { cn } from "../../lib/utils";
 
@@ -33,9 +33,7 @@ export function Breadcrumb({ items, className }: BreadcrumbProps) {
             ) : (
               <span
                 className={cn(
-                  isLast
-                    ? "font-semibold text-[color:var(--ink)]"
-                    : "text-[color:var(--ink-soft)]",
+                  isLast ? "font-semibold text-[color:var(--ink)]" : "text-[color:var(--ink-soft)]",
                 )}
               >
                 {item.label}

--- a/src/components/skeletons/DashboardSkeleton.tsx
+++ b/src/components/skeletons/DashboardSkeleton.tsx
@@ -15,7 +15,10 @@ export function DashboardSkeleton() {
       {/* Stats row */}
       <div className="mb-8 grid grid-cols-2 gap-4 sm:grid-cols-4">
         {Array.from({ length: 4 }, (_, i) => (
-          <div key={i} className="flex flex-col gap-2 rounded-[var(--radius-md)] border border-[color:var(--line)] bg-[color:var(--surface)] p-5">
+          <div
+            key={i}
+            className="flex flex-col gap-2 rounded-[var(--radius-md)] border border-[color:var(--line)] bg-[color:var(--surface)] p-5"
+          >
             <Skeleton className="h-4 w-20" />
             <Skeleton className="h-7 w-16" />
           </div>

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -8,10 +8,7 @@ const Avatar = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Root
     ref={ref}
-    className={cn(
-      "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
-      className,
-    )}
+    className={cn("relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full", className)}
     {...props}
   />
 ));

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -11,7 +11,19 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ asChild, className, variant = "default", size = "default", loading, children, disabled, ...props }, ref) => {
+  (
+    {
+      asChild,
+      className,
+      variant = "default",
+      size = "default",
+      loading,
+      children,
+      disabled,
+      ...props
+    },
+    ref,
+  ) => {
     const Comp = asChild ? Slot : "button";
     return (
       <Comp

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -18,11 +18,7 @@ Card.displayName = "Card";
 
 const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div
-      ref={ref}
-      className={cn("flex flex-col gap-1.5", className)}
-      {...props}
-    />
+    <div ref={ref} className={cn("flex flex-col gap-1.5", className)} {...props} />
   ),
 );
 CardHeader.displayName = "CardHeader";
@@ -31,42 +27,34 @@ const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTML
   ({ className, ...props }, ref) => (
     <h3
       ref={ref}
-      className={cn("font-display text-lg font-bold leading-tight text-[color:var(--ink)]", className)}
+      className={cn(
+        "font-display text-lg font-bold leading-tight text-[color:var(--ink)]",
+        className,
+      )}
       {...props}
     />
   ),
 );
 CardTitle.displayName = "CardTitle";
 
-const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
-  ({ className, ...props }, ref) => (
-    <p
-      ref={ref}
-      className={cn("text-sm text-[color:var(--ink-soft)]", className)}
-      {...props}
-    />
-  ),
-);
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p ref={ref} className={cn("text-sm text-[color:var(--ink-soft)]", className)} {...props} />
+));
 CardDescription.displayName = "CardDescription";
 
 const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div
-      ref={ref}
-      className={cn("flex flex-col gap-3", className)}
-      {...props}
-    />
+    <div ref={ref} className={cn("flex flex-col gap-3", className)} {...props} />
   ),
 );
 CardContent.displayName = "CardContent";
 
 const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div
-      ref={ref}
-      className={cn("flex items-center gap-3 pt-2", className)}
-      {...props}
-    />
+    <div ref={ref} className={cn("flex items-center gap-3 pt-2", className)} {...props} />
   ),
 );
 CardFooter.displayName = "CardFooter";

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,18 +1,13 @@
 import * as React from "react";
 import { cn } from "../../lib/utils";
 
-const Table = React.forwardRef<
-  HTMLTableElement,
-  React.HTMLAttributes<HTMLTableElement>
->(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
-    <table
-      ref={ref}
-      className={cn("w-full caption-bottom text-sm", className)}
-      {...props}
-    />
-  </div>
-));
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="relative w-full overflow-auto">
+      <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
+    </div>
+  ),
+);
 Table.displayName = "Table";
 
 const TableHeader = React.forwardRef<
@@ -27,11 +22,7 @@ const TableBody = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <tbody
-    ref={ref}
-    className={cn("[&_tr:last-child]:border-0", className)}
-    {...props}
-  />
+  <tbody ref={ref} className={cn("[&_tr:last-child]:border-0", className)} {...props} />
 ));
 TableBody.displayName = "TableBody";
 
@@ -50,19 +41,18 @@ const TableFooter = React.forwardRef<
 ));
 TableFooter.displayName = "TableFooter";
 
-const TableRow = React.forwardRef<
-  HTMLTableRowElement,
-  React.HTMLAttributes<HTMLTableRowElement>
->(({ className, ...props }, ref) => (
-  <tr
-    ref={ref}
-    className={cn(
-      "border-b border-[color:var(--line)] transition-colors hover:bg-[color:var(--surface-muted)]/50 data-[state=selected]:bg-[color:var(--surface-muted)]",
-      className,
-    )}
-    {...props}
-  />
-));
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn(
+        "border-b border-[color:var(--line)] transition-colors hover:bg-[color:var(--surface-muted)]/50 data-[state=selected]:bg-[color:var(--surface-muted)]",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
 TableRow.displayName = "TableRow";
 
 const TableHead = React.forwardRef<
@@ -107,13 +97,4 @@ const TableCaption = React.forwardRef<
 ));
 TableCaption.displayName = "TableCaption";
 
-export {
-  Table,
-  TableHeader,
-  TableBody,
-  TableFooter,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableCaption,
-};
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -10,10 +10,7 @@ const TabsList = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.List
     ref={ref}
-    className={cn(
-      "inline-flex items-center gap-0 border-b border-[color:var(--line)]",
-      className,
-    )}
+    className={cn("inline-flex items-center gap-0 border-b border-[color:var(--line)]", className)}
     {...props}
   />
 ));

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,29 +1,30 @@
 import * as React from "react";
 import { cn } from "../../lib/utils";
 
-const Textarea = React.forwardRef<HTMLTextAreaElement, React.TextareaHTMLAttributes<HTMLTextAreaElement>>(
-  ({ className, ...props }, ref) => (
-    <textarea
-      ref={ref}
-      className={cn(
-        // Base styles matching .form-input
-        "w-full min-h-[100px] resize-y rounded-[var(--radius-sm)] border px-3.5 py-[13px] text-[color:var(--ink)] transition-all duration-[180ms] ease-out",
-        "border-[rgba(29,59,78,0.22)] bg-[rgba(255,255,255,0.94)]",
-        "placeholder:text-[rgba(88,115,133,0.72)]",
-        // Focus
-        "focus:outline-none focus:border-[color-mix(in_srgb,var(--accent)_70%,white)] focus:shadow-[0_0_0_3px_color-mix(in_srgb,var(--accent)_22%,transparent)]",
-        // Dark mode
-        "dark:border-[rgba(255,255,255,0.12)] dark:bg-[rgba(14,28,37,0.84)]",
-        "dark:placeholder:text-[rgba(184,205,216,0.68)]",
-        "dark:focus:border-[rgba(255,131,95,0.75)] dark:focus:shadow-[0_0_0_3px_rgba(255,131,95,0.2)]",
-        // Disabled
-        "disabled:cursor-not-allowed disabled:opacity-60",
-        className,
-      )}
-      {...props}
-    />
-  ),
-);
+const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
+>(({ className, ...props }, ref) => (
+  <textarea
+    ref={ref}
+    className={cn(
+      // Base styles matching .form-input
+      "w-full min-h-[100px] resize-y rounded-[var(--radius-sm)] border px-3.5 py-[13px] text-[color:var(--ink)] transition-all duration-[180ms] ease-out",
+      "border-[rgba(29,59,78,0.22)] bg-[rgba(255,255,255,0.94)]",
+      "placeholder:text-[rgba(88,115,133,0.72)]",
+      // Focus
+      "focus:outline-none focus:border-[color-mix(in_srgb,var(--accent)_70%,white)] focus:shadow-[0_0_0_3px_color-mix(in_srgb,var(--accent)_22%,transparent)]",
+      // Dark mode
+      "dark:border-[rgba(255,255,255,0.12)] dark:bg-[rgba(14,28,37,0.84)]",
+      "dark:placeholder:text-[rgba(184,205,216,0.68)]",
+      "dark:focus:border-[rgba(255,131,95,0.75)] dark:focus:shadow-[0_0_0_3px_rgba(255,131,95,0.2)]",
+      // Disabled
+      "disabled:cursor-not-allowed disabled:opacity-60",
+      className,
+    )}
+    {...props}
+  />
+));
 Textarea.displayName = "Textarea";
 
 export { Textarea };

--- a/src/lib/packageApi.test.ts
+++ b/src/lib/packageApi.test.ts
@@ -63,7 +63,9 @@ describe("fetchPackages", () => {
     vi.stubEnv("VITE_CONVEX_URL", "https://registry.example");
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
-      .mockResolvedValue(new Response(JSON.stringify({ items: [], nextCursor: null }), { status: 200 }));
+      .mockResolvedValue(
+        new Response(JSON.stringify({ items: [], nextCursor: null }), { status: 200 }),
+      );
 
     await fetchPackages({
       family: "skill",
@@ -84,7 +86,9 @@ describe("fetchPackages", () => {
     vi.stubEnv("VITE_CONVEX_URL", "https://registry.example");
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
-      .mockResolvedValue(new Response(JSON.stringify({ items: [], nextCursor: null }), { status: 200 }));
+      .mockResolvedValue(
+        new Response(JSON.stringify({ items: [], nextCursor: null }), { status: 200 }),
+      );
 
     await fetchPackages({
       cursor: "pkgpage:test",
@@ -105,7 +109,9 @@ describe("fetchPackages", () => {
     vi.stubEnv("VITE_CONVEX_URL", "https://registry.example");
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
-      .mockResolvedValue(new Response(JSON.stringify({ items: [], nextCursor: null }), { status: 200 }));
+      .mockResolvedValue(
+        new Response(JSON.stringify({ items: [], nextCursor: null }), { status: 200 }),
+      );
 
     await fetchPackages({
       isOfficial: false,
@@ -167,9 +173,11 @@ describe("fetchPackages", () => {
         "fly-client-ip": "203.0.113.9",
       }),
     );
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ package: null, owner: null }), { status: 200 }),
-    );
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ package: null, owner: null }), { status: 200 }),
+      );
 
     await fetchPackageDetail("private-plugin");
 
@@ -195,9 +203,11 @@ describe("fetchPackages", () => {
     vi.stubGlobal("window", {
       location: { origin: "https://app.example" },
     });
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ package: null, owner: null }), { status: 200 }),
-    );
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ package: null, owner: null }), { status: 200 }),
+      );
 
     await fetchPackageDetail("private-plugin");
 
@@ -212,7 +222,9 @@ describe("fetchPackages", () => {
     });
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
-      .mockResolvedValue(new Response(JSON.stringify({ items: [], nextCursor: null }), { status: 200 }));
+      .mockResolvedValue(
+        new Response(JSON.stringify({ items: [], nextCursor: null }), { status: 200 }),
+      );
 
     await fetchPackages({
       family: "bundle-plugin",
@@ -226,7 +238,9 @@ describe("fetchPackages", () => {
     vi.stubEnv("VITE_CONVEX_URL", "https://registry.example");
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
-      .mockResolvedValue(new Response(JSON.stringify({ items: [], nextCursor: null }), { status: 200 }));
+      .mockResolvedValue(
+        new Response(JSON.stringify({ items: [], nextCursor: null }), { status: 200 }),
+      );
 
     await fetchPluginCatalog({
       limit: 12,
@@ -350,7 +364,9 @@ describe("fetchPluginCatalog", () => {
     vi.stubEnv("VITE_CONVEX_URL", "https://registry.example");
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
-      .mockResolvedValue(new Response(JSON.stringify({ items: [], nextCursor: "plugins:next" }), { status: 200 }));
+      .mockResolvedValue(
+        new Response(JSON.stringify({ items: [], nextCursor: "plugins:next" }), { status: 200 }),
+      );
 
     const result = await fetchPluginCatalog({
       isOfficial: true,
@@ -366,41 +382,39 @@ describe("fetchPluginCatalog", () => {
 
   it("uses the dedicated plugins search endpoint for search mode", async () => {
     vi.stubEnv("VITE_CONVEX_URL", "https://registry.example");
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            results: [
-              {
-                score: 5,
-                package: {
-                  name: "code-demo",
-                  displayName: "Code Demo",
-                  family: "code-plugin",
-                  channel: "community",
-                  isOfficial: true,
-                  createdAt: 2,
-                  updatedAt: 2,
-                },
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          results: [
+            {
+              score: 5,
+              package: {
+                name: "code-demo",
+                displayName: "Code Demo",
+                family: "code-plugin",
+                channel: "community",
+                isOfficial: true,
+                createdAt: 2,
+                updatedAt: 2,
               },
-              {
-                score: 4,
-                package: {
-                  name: "bundle-demo",
-                  displayName: "Bundle Demo",
-                  family: "bundle-plugin",
-                  channel: "community",
-                  isOfficial: false,
-                  createdAt: 1,
-                  updatedAt: 1,
-                },
+            },
+            {
+              score: 4,
+              package: {
+                name: "bundle-demo",
+                displayName: "Bundle Demo",
+                family: "bundle-plugin",
+                channel: "community",
+                isOfficial: false,
+                createdAt: 1,
+                updatedAt: 1,
               },
-            ],
-          }),
-          { status: 200 },
-        ),
-      );
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
 
     const result = await fetchPluginCatalog({
       q: "demo",

--- a/src/lib/packageApi.ts
+++ b/src/lib/packageApi.ts
@@ -137,8 +137,7 @@ async function packageApiUrl(path: string) {
   // In production, Vercel rewrites /api/* but SSR loaders run server-side
   // where the rewrite doesn't apply. Using getRequestUrl() would loop back
   // into TanStack Start / Nitro, which rejects non-HTML requests.
-  const base =
-    getRuntimeEnv("VITE_CONVEX_SITE_URL") ?? getRequiredRuntimeEnv("VITE_CONVEX_URL");
+  const base = getRuntimeEnv("VITE_CONVEX_SITE_URL") ?? getRequiredRuntimeEnv("VITE_CONVEX_URL");
   return new URL(normalizedPath, base);
 }
 
@@ -152,9 +151,7 @@ async function getForwardedHeaders() {
   if (typeof window !== "undefined" || !import.meta.env.SSR) return {};
   try {
     const serverRuntimeModule = "@tanstack/react-start/server";
-    const { getRequestHeaders } = (await import(
-      /* @vite-ignore */ serverRuntimeModule
-    )) as {
+    const { getRequestHeaders } = (await import(/* @vite-ignore */ serverRuntimeModule)) as {
       getRequestHeaders: () => Headers;
     };
     const requestHeaders = getRequestHeaders();
@@ -181,8 +178,7 @@ async function getForwardedHeaders() {
 
 async function packageFetch(url: URL, accept: string) {
   const forwarded = await getForwardedHeaders();
-  const isSameOrigin =
-    typeof window !== "undefined" && url.origin === window.location.origin;
+  const isSameOrigin = typeof window !== "undefined" && url.origin === window.location.origin;
   return await fetch(url.toString(), {
     method: "GET",
     // Only send credentials for same-origin requests (production Vercel
@@ -265,7 +261,8 @@ export async function fetchPluginCatalog(params: {
       limit: params.limit,
     });
     return {
-      items: "results" in response ? response.results.map((entry) => entry.package) : response.items,
+      items:
+        "results" in response ? response.results.map((entry) => entry.package) : response.items,
       nextCursor: "results" in response ? null : response.nextCursor,
     };
   }
@@ -280,7 +277,9 @@ export async function fetchPluginCatalog(params: {
     if (typeof params.executesCode === "boolean") {
       url.searchParams.set("executesCode", String(params.executesCode));
     }
-    const response = await fetchJson<{ results: Array<{ score: number; package: PackageListItem }> }>(url);
+    const response = await fetchJson<{
+      results: Array<{ score: number; package: PackageListItem }>;
+    }>(url);
     return {
       items: response.results.map((entry) => entry.package),
       nextCursor: null,

--- a/src/lib/packageUpload.test.ts
+++ b/src/lib/packageUpload.test.ts
@@ -1,16 +1,20 @@
 /* @vitest-environment node */
 
 import { describe, expect, it, vi } from "vitest";
-import { buildPackageUploadEntries, filterIgnoredPackageFiles, normalizePackageUploadPath } from "./packageUpload";
+import {
+  buildPackageUploadEntries,
+  filterIgnoredPackageFiles,
+  normalizePackageUploadPath,
+} from "./packageUpload";
 
 describe("normalizePackageUploadPath", () => {
   it("strips the picked folder prefix", () => {
-    expect(normalizePackageUploadPath("my-plugin/package.json", { stripTopLevelFolder: true })).toBe(
-      "package.json",
-    );
-    expect(normalizePackageUploadPath("my-plugin/src/index.ts", { stripTopLevelFolder: true })).toBe(
-      "src/index.ts",
-    );
+    expect(
+      normalizePackageUploadPath("my-plugin/package.json", { stripTopLevelFolder: true }),
+    ).toBe("package.json");
+    expect(
+      normalizePackageUploadPath("my-plugin/src/index.ts", { stripTopLevelFolder: true }),
+    ).toBe("src/index.ts");
   });
 
   it("keeps flat files unchanged", () => {
@@ -25,41 +29,41 @@ describe("normalizePackageUploadPath", () => {
 describe("buildPackageUploadEntries", () => {
   it("filters builtin and package-ignore-file paths before upload", async () => {
     const filtered = await filterIgnoredPackageFiles([
-      new File(['{}'], 'demo-plugin/package.json', { type: 'application/json' }),
-      new File(['dist/\nsecret.txt\n'], 'demo-plugin/.clawhubignore', { type: 'text/plain' }),
-      new File(['ignored'], 'demo-plugin/node_modules/pkg/index.js', { type: 'text/javascript' }),
-      new File(['ignored'], 'demo-plugin/.git/config', { type: 'text/plain' }),
-      new File(['ignored'], 'demo-plugin/dist/index.js', { type: 'text/javascript' }),
-      new File(['kept'], 'demo-plugin/src/index.js', { type: 'text/javascript' }),
-      new File(['ignored'], 'demo-plugin/secret.txt', { type: 'text/plain' }),
+      new File(["{}"], "demo-plugin/package.json", { type: "application/json" }),
+      new File(["dist/\nsecret.txt\n"], "demo-plugin/.clawhubignore", { type: "text/plain" }),
+      new File(["ignored"], "demo-plugin/node_modules/pkg/index.js", { type: "text/javascript" }),
+      new File(["ignored"], "demo-plugin/.git/config", { type: "text/plain" }),
+      new File(["ignored"], "demo-plugin/dist/index.js", { type: "text/javascript" }),
+      new File(["kept"], "demo-plugin/src/index.js", { type: "text/javascript" }),
+      new File(["ignored"], "demo-plugin/secret.txt", { type: "text/plain" }),
     ]);
 
     expect(filtered.files.map((file) => file.name)).toEqual([
-      'demo-plugin/package.json',
-      'demo-plugin/.clawhubignore',
-      'demo-plugin/src/index.js',
+      "demo-plugin/package.json",
+      "demo-plugin/.clawhubignore",
+      "demo-plugin/src/index.js",
     ]);
     expect(filtered.ignoredPaths).toEqual([
-      'node_modules/pkg/index.js',
-      '.git/config',
-      'dist/index.js',
-      'secret.txt',
+      "node_modules/pkg/index.js",
+      ".git/config",
+      "dist/index.js",
+      "secret.txt",
     ]);
   });
 
   it("does not apply repo .gitignore rules to package uploads", async () => {
     const filtered = await filterIgnoredPackageFiles([
-      new File(['{}'], 'demo-plugin/package.json', { type: 'application/json' }),
-      new File(['dist/\nsecret.txt\n'], 'demo-plugin/.gitignore', { type: 'text/plain' }),
-      new File(['kept'], 'demo-plugin/dist/index.js', { type: 'text/javascript' }),
-      new File(['kept'], 'demo-plugin/secret.txt', { type: 'text/plain' }),
+      new File(["{}"], "demo-plugin/package.json", { type: "application/json" }),
+      new File(["dist/\nsecret.txt\n"], "demo-plugin/.gitignore", { type: "text/plain" }),
+      new File(["kept"], "demo-plugin/dist/index.js", { type: "text/javascript" }),
+      new File(["kept"], "demo-plugin/secret.txt", { type: "text/plain" }),
     ]);
 
     expect(filtered.files.map((file) => file.name)).toEqual([
-      'demo-plugin/package.json',
-      'demo-plugin/.gitignore',
-      'demo-plugin/dist/index.js',
-      'demo-plugin/secret.txt',
+      "demo-plugin/package.json",
+      "demo-plugin/.gitignore",
+      "demo-plugin/dist/index.js",
+      "demo-plugin/secret.txt",
     ]);
     expect(filtered.ignoredPaths).toEqual([]);
   });
@@ -79,7 +83,10 @@ describe("buildPackageUploadEntries", () => {
         webkitRelativePath: "demo-plugin/dist/index.js",
       },
     ];
-    const generateUploadUrl = vi.fn().mockResolvedValueOnce("upload-1").mockResolvedValueOnce("upload-2");
+    const generateUploadUrl = vi
+      .fn()
+      .mockResolvedValueOnce("upload-1")
+      .mockResolvedValueOnce("upload-2");
     const hashFile = vi.fn(async (file: (typeof files)[number]) => `sha:${file.name}`);
     const uploadFile = vi
       .fn()

--- a/src/lib/packageUpload.ts
+++ b/src/lib/packageUpload.ts
@@ -11,26 +11,33 @@ type UploadablePackageFile = {
   webkitRelativePath?: string;
 };
 
-export type NormalizedPackageUploadFile<TFile extends UploadablePackageFile = UploadablePackageFile> = {
+export type NormalizedPackageUploadFile<
+  TFile extends UploadablePackageFile = UploadablePackageFile,
+> = {
   file: TFile;
   path: string;
 };
 
 const KNOWN_PACKAGE_ROOT_PATHS = new Set([
-  'package.json',
-  'openclaw.plugin.json',
-  'openclaw.bundle.json',
-  'README.md',
-  'readme.md',
-  'README.mdx',
-  'readme.mdx',
+  "package.json",
+  "openclaw.plugin.json",
+  "openclaw.bundle.json",
+  "README.md",
+  "readme.md",
+  "README.mdx",
+  "readme.mdx",
 ]);
-const DOT_DIR = '.clawhub';
-const LEGACY_DOT_DIR = '.clawdhub';
-const DOT_IGNORE = '.clawhubignore';
-const LEGACY_DOT_IGNORE = '.clawdhubignore';
+const DOT_DIR = ".clawhub";
+const LEGACY_DOT_DIR = ".clawdhub";
+const DOT_IGNORE = ".clawhubignore";
+const LEGACY_DOT_IGNORE = ".clawdhubignore";
 const PACKAGE_IGNORE_FILES = new Set([DOT_IGNORE, LEGACY_DOT_IGNORE]);
-const DEFAULT_PACKAGE_IGNORE_PATTERNS = ['.git/', 'node_modules/', `${DOT_DIR}/`, `${LEGACY_DOT_DIR}/`];
+const DEFAULT_PACKAGE_IGNORE_PATTERNS = [
+  ".git/",
+  "node_modules/",
+  `${DOT_DIR}/`,
+  `${LEGACY_DOT_DIR}/`,
+];
 
 export function normalizePackageUploadPath(
   path: string,
@@ -82,9 +89,9 @@ export function normalizePackageUploadFiles<TFile extends UploadablePackageFile>
   }));
 }
 
-export async function filterIgnoredPackageFiles<TFile extends UploadablePackageFile & Pick<File, "text">>(
-  files: TFile[],
-) {
+export async function filterIgnoredPackageFiles<
+  TFile extends UploadablePackageFile & Pick<File, "text">,
+>(files: TFile[]) {
   const normalized = normalizePackageUploadFiles(files);
   const ig = ignore();
   ig.add(DEFAULT_PACKAGE_IGNORE_PATTERNS);

--- a/src/lib/pluginPublishPrefill.ts
+++ b/src/lib/pluginPublishPrefill.ts
@@ -1,13 +1,13 @@
-import type { PackageCompatibility } from 'clawhub-schema';
+import type { PackageCompatibility } from "clawhub-schema";
 import {
   normalizeOpenClawExternalPluginCompatibility,
   validateOpenClawExternalCodePluginPackageJson,
-} from 'clawhub-schema';
+} from "clawhub-schema";
 
 type JsonRecord = Record<string, unknown>;
 
 export type PluginPublishPrefill = {
-  family?: 'code-plugin' | 'bundle-plugin';
+  family?: "code-plugin" | "bundle-plugin";
   name?: string;
   displayName?: string;
   version?: string;
@@ -19,18 +19,18 @@ export type PluginPublishPrefill = {
 };
 
 function isRecord(value: unknown): value is JsonRecord {
-  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function getString(value: unknown) {
-  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 function getStringList(value: unknown) {
   if (Array.isArray(value)) return value.map(getString).filter(Boolean) as string[];
-  if (typeof value === 'string') {
+  if (typeof value === "string") {
     return value
-      .split(',')
+      .split(",")
       .map((entry) => entry.trim())
       .filter(Boolean);
   }
@@ -42,17 +42,17 @@ async function readJsonUploadFile(
   expectedPath: string,
 ): Promise<JsonRecord | null> {
   const normalizedExpectedPath = expectedPath.toLowerCase();
-  const expectedFileName = normalizedExpectedPath.split('/').at(-1);
+  const expectedFileName = normalizedExpectedPath.split("/").at(-1);
   const entry =
     files.find((file) => file.path.toLowerCase() === normalizedExpectedPath) ??
     files.find((file) => file.path.toLowerCase().endsWith(`/${normalizedExpectedPath}`)) ??
     files.find((file) => {
       const normalizedPath = file.path.toLowerCase();
-      return expectedFileName ? normalizedPath.split('/').at(-1) === expectedFileName : false;
+      return expectedFileName ? normalizedPath.split("/").at(-1) === expectedFileName : false;
     });
   if (!entry) return null;
   try {
-    const parsed = JSON.parse((await entry.file.text()).replace(/^\uFEFF/, '')) as unknown;
+    const parsed = JSON.parse((await entry.file.text()).replace(/^\uFEFF/, "")) as unknown;
     return isRecord(parsed) ? parsed : null;
   } catch {
     return null;
@@ -62,9 +62,9 @@ async function readJsonUploadFile(
 function normalizeGitHubRepo(value: string) {
   const trimmed = value
     .trim()
-    .replace(/^git\+/, '')
-    .replace(/\.git$/i, '')
-    .replace(/^git@github\.com:/i, 'https://github.com/');
+    .replace(/^git\+/, "")
+    .replace(/\.git$/i, "")
+    .replace(/^git@github\.com:/i, "https://github.com/");
   if (!trimmed) return undefined;
 
   const shorthand = trimmed.match(/^([a-z0-9_.-]+)\/([a-z0-9_.-]+)$/i);
@@ -72,8 +72,8 @@ function normalizeGitHubRepo(value: string) {
 
   try {
     const url = new URL(trimmed);
-    if (url.hostname !== 'github.com' && url.hostname !== 'www.github.com') return undefined;
-    const [owner, repo] = url.pathname.replace(/^\/+|\/+$/g, '').split('/');
+    if (url.hostname !== "github.com" && url.hostname !== "www.github.com") return undefined;
+    const [owner, repo] = url.pathname.replace(/^\/+|\/+$/g, "").split("/");
     if (!owner || !repo) return undefined;
     return `${owner}/${repo}`;
   } catch {
@@ -84,12 +84,12 @@ function normalizeGitHubRepo(value: string) {
 function extractSourceRepo(packageJson: JsonRecord | null) {
   if (!packageJson) return undefined;
   const repository = packageJson.repository;
-  if (typeof repository === 'string') return normalizeGitHubRepo(repository);
-  if (isRecord(repository) && typeof repository.url === 'string') {
+  if (typeof repository === "string") return normalizeGitHubRepo(repository);
+  if (isRecord(repository) && typeof repository.url === "string") {
     return normalizeGitHubRepo(repository.url);
   }
-  if (typeof packageJson.homepage === 'string') return normalizeGitHubRepo(packageJson.homepage);
-  if (isRecord(packageJson.bugs) && typeof packageJson.bugs.url === 'string') {
+  if (typeof packageJson.homepage === "string") return normalizeGitHubRepo(packageJson.homepage);
+  if (isRecord(packageJson.bugs) && typeof packageJson.bugs.url === "string") {
     return normalizeGitHubRepo(packageJson.bugs.url);
   }
   return undefined;
@@ -98,17 +98,25 @@ function extractSourceRepo(packageJson: JsonRecord | null) {
 export async function derivePluginPrefill(
   files: Array<{ file: File; path: string }>,
 ): Promise<PluginPublishPrefill> {
-  const packageJson = await readJsonUploadFile(files, 'package.json');
-  const pluginManifest = await readJsonUploadFile(files, 'openclaw.plugin.json');
-  const bundleManifest = await readJsonUploadFile(files, 'openclaw.bundle.json');
+  const packageJson = await readJsonUploadFile(files, "package.json");
+  const pluginManifest = await readJsonUploadFile(files, "openclaw.plugin.json");
+  const bundleManifest = await readJsonUploadFile(files, "openclaw.bundle.json");
   const openclaw = isRecord(packageJson?.openclaw) ? packageJson.openclaw : undefined;
   const hostTargets = bundleManifest
-    ? [...new Set([...getStringList(bundleManifest.hostTargets), ...getStringList(openclaw?.hostTargets)])]
+    ? [
+        ...new Set([
+          ...getStringList(bundleManifest.hostTargets),
+          ...getStringList(openclaw?.hostTargets),
+        ]),
+      ]
     : [];
 
   return {
-    family: pluginManifest ? 'code-plugin' : bundleManifest ? 'bundle-plugin' : undefined,
-    name: getString(packageJson?.name) ?? getString(pluginManifest?.id) ?? getString(bundleManifest?.id),
+    family: pluginManifest ? "code-plugin" : bundleManifest ? "bundle-plugin" : undefined,
+    name:
+      getString(packageJson?.name) ??
+      getString(pluginManifest?.id) ??
+      getString(bundleManifest?.id),
     displayName:
       getString(packageJson?.displayName) ??
       getString(pluginManifest?.name) ??
@@ -116,8 +124,10 @@ export async function derivePluginPrefill(
     version: getString(packageJson?.version),
     sourceRepo: extractSourceRepo(packageJson),
     bundleFormat: getString(bundleManifest?.format) ?? getString(openclaw?.bundleFormat),
-    hostTargets: hostTargets.length > 0 ? hostTargets.join(', ') : undefined,
-    compatibility: pluginManifest ? normalizeOpenClawExternalPluginCompatibility(packageJson) : undefined,
+    hostTargets: hostTargets.length > 0 ? hostTargets.join(", ") : undefined,
+    compatibility: pluginManifest
+      ? normalizeOpenClawExternalPluginCompatibility(packageJson)
+      : undefined,
     missingRequiredFields: pluginManifest
       ? validateOpenClawExternalCodePluginPackageJson(packageJson).issues.map(
           (issue) => issue.fieldPath,
@@ -128,14 +138,14 @@ export async function derivePluginPrefill(
 
 export function listPrefilledFields(prefill: PluginPublishPrefill) {
   const fields: string[] = [];
-  if (prefill.family) fields.push('package type');
-  if (prefill.name) fields.push('plugin name');
-  if (prefill.displayName) fields.push('display name');
-  if (prefill.version) fields.push('version');
-  if (prefill.sourceRepo) fields.push('source repo');
-  if (prefill.compatibility) fields.push('compatibility');
-  if (prefill.bundleFormat) fields.push('bundle format');
-  if (prefill.hostTargets) fields.push('host targets');
+  if (prefill.family) fields.push("package type");
+  if (prefill.name) fields.push("plugin name");
+  if (prefill.displayName) fields.push("display name");
+  if (prefill.version) fields.push("version");
+  if (prefill.sourceRepo) fields.push("source repo");
+  if (prefill.compatibility) fields.push("compatibility");
+  if (prefill.bundleFormat) fields.push("bundle format");
+  if (prefill.hostTargets) fields.push("host targets");
   return fields;
 }
 
@@ -149,5 +159,5 @@ export function formatPackageCompatibility(compatibility: PackageCompatibility) 
     compatibility.minGatewayVersion ? `minGateway=${compatibility.minGatewayVersion}` : null,
   ]
     .filter(Boolean)
-    .join(', ');
+    .join(", ");
 }

--- a/src/lib/skillPage.ts
+++ b/src/lib/skillPage.ts
@@ -84,7 +84,8 @@ export async function fetchSkillPageData(slug: string): Promise<SkillPageLoaderD
       owner:
         result.owner?.handle ??
         result.owner?.displayName ??
-        ((result.owner as { name?: string | null } | null)?.name ?? null),
+        (result.owner as { name?: string | null } | null)?.name ??
+        null,
       displayName: result.skill.displayName ?? null,
       summary: result.skill.summary ?? null,
       version: result.latestVersion?.version ?? null,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -112,9 +112,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
             <ClientOnly>
               <DeploymentDriftBanner />
             </ClientOnly>
-            <RouteErrorBoundary>
-              {children}
-            </RouteErrorBoundary>
+            <RouteErrorBoundary>{children}</RouteErrorBoundary>
             <Footer />
           </div>
           <Toaster
@@ -140,11 +138,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
 }
 
 /** Resets the error boundary whenever the route pathname changes. */
-function RouteErrorBoundary({ children }: { children: React.ReactNode; }) {
+function RouteErrorBoundary({ children }: { children: React.ReactNode }) {
   const location = useLocation();
-  return (
-    <ErrorBoundary resetKey={location.pathname}>
-      {children}
-    </ErrorBoundary>
-  );
+  return <ErrorBoundary resetKey={location.pathname}>{children}</ErrorBoundary>;
 }

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -1,69 +1,69 @@
-import { createFileRoute, Link } from '@tanstack/react-router';
-import { AlertTriangle, Shield, ShieldAlert } from 'lucide-react';
-import { Badge } from '../components/ui/badge';
-import { Button } from '../components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
-import { Container } from '../components/layout/Container';
-import { Separator } from '../components/ui/separator';
-import { getSiteMode, getSiteName, getSiteUrlForMode } from '../lib/site';
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { AlertTriangle, Shield, ShieldAlert } from "lucide-react";
+import { Container } from "../components/layout/Container";
+import { Badge } from "../components/ui/badge";
+import { Button } from "../components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
+import { Separator } from "../components/ui/separator";
+import { getSiteMode, getSiteName, getSiteUrlForMode } from "../lib/site";
 
 const prohibitedCategories = [
   {
-    title: 'Bypass and unauthorized access',
+    title: "Bypass and unauthorized access",
     examples:
-      'Auth bypass, account takeover, CAPTCHA bypass, Cloudflare or anti-bot evasion, rate-limit bypass, reusable session theft, live call or agent takeover.',
+      "Auth bypass, account takeover, CAPTCHA bypass, Cloudflare or anti-bot evasion, rate-limit bypass, reusable session theft, live call or agent takeover.",
   },
   {
-    title: 'Platform abuse and ban evasion',
+    title: "Platform abuse and ban evasion",
     examples:
-      'Stealth accounts after bans, account warming/farming, fake engagement, multi-account automation, spam posting, marketplace or social automation built to avoid detection.',
+      "Stealth accounts after bans, account warming/farming, fake engagement, multi-account automation, spam posting, marketplace or social automation built to avoid detection.",
   },
   {
-    title: 'Fraud and deception',
+    title: "Fraud and deception",
     examples:
-      'Fake certificates, fake invoices, deceptive payment flows, fake social proof, scam outreach, or synthetic-identity workflows built to create accounts for fraud.',
+      "Fake certificates, fake invoices, deceptive payment flows, fake social proof, scam outreach, or synthetic-identity workflows built to create accounts for fraud.",
   },
   {
-    title: 'Privacy-invasive surveillance',
+    title: "Privacy-invasive surveillance",
     examples:
-      'Mass contact scraping for spam, doxxing, stalking, covert monitoring, biometric / face-matching workflows without clear consent, or buying, publishing, downloading, or operationalizing leaked data or breach dumps.',
+      "Mass contact scraping for spam, doxxing, stalking, covert monitoring, biometric / face-matching workflows without clear consent, or buying, publishing, downloading, or operationalizing leaked data or breach dumps.",
   },
   {
-    title: 'Non-consensual impersonation',
+    title: "Non-consensual impersonation",
     examples:
-      'Face swap, digital twins, cloned influencers, fake personas, or other identity manipulation used to impersonate or mislead.',
+      "Face swap, digital twins, cloned influencers, fake personas, or other identity manipulation used to impersonate or mislead.",
   },
   {
-    title: 'Explicit sexual content',
+    title: "Explicit sexual content",
     examples:
-      'NSFW image, video, or text generation, especially wrappers around third-party APIs with safety checks disabled.',
+      "NSFW image, video, or text generation, especially wrappers around third-party APIs with safety checks disabled.",
   },
   {
-    title: 'Hidden or misleading execution',
+    title: "Hidden or misleading execution",
     examples:
-      'Obfuscated install commands, `curl | sh`, undeclared secret requirements, undeclared private-key use, or remote `npx @latest` execution without reviewability.',
+      "Obfuscated install commands, `curl | sh`, undeclared secret requirements, undeclared private-key use, or remote `npx @latest` execution without reviewability.",
   },
 ];
 
 const recentPatterns = [
-  'Create stealth seller accounts after marketplace bans.',
-  'Modify Telegram pairing so unapproved users automatically receive pairing codes.',
-  'Cultivate Reddit or Twitter accounts with undetectable automation.',
-  'Generate professional certificates or invoices for arbitrary use.',
-  'Generate NSFW content with safety checks disabled.',
-  'Scrape leads, enrich contacts, and launch cold outreach at scale.',
-  'Buy, publish, or download leaked data or breach dumps.',
-  'Bulk-create email or social accounts with synthetic identities or CAPTCHA solving.',
+  "Create stealth seller accounts after marketplace bans.",
+  "Modify Telegram pairing so unapproved users automatically receive pairing codes.",
+  "Cultivate Reddit or Twitter accounts with undetectable automation.",
+  "Generate professional certificates or invoices for arbitrary use.",
+  "Generate NSFW content with safety checks disabled.",
+  "Scrape leads, enrich contacts, and launch cold outreach at scale.",
+  "Buy, publish, or download leaked data or breach dumps.",
+  "Bulk-create email or social accounts with synthetic identities or CAPTCHA solving.",
 ];
 
-export const Route = createFileRoute('/about')({
+export const Route = createFileRoute("/about")({
   head: () => {
     const mode = getSiteMode();
     const siteName = getSiteName(mode);
     const siteUrl = getSiteUrlForMode(mode);
     const title = `About · ${siteName}`;
     const description =
-      'What ClawHub allows, what we do not host, and the abuse patterns that lead to removal or account bans.';
+      "What ClawHub allows, what we do not host, and the abuse patterns that lead to removal or account bans.";
 
     return {
       links: [
@@ -74,11 +74,11 @@ export const Route = createFileRoute('/about')({
       ],
       meta: [
         { title },
-        { name: 'description', content: description },
-        { property: 'og:title', content: title },
-        { property: 'og:description', content: description },
-        { property: 'og:type', content: 'website' },
-        { property: 'og:url', content: `${siteUrl}/about` },
+        { name: "description", content: description },
+        { property: "og:title", content: title },
+        { property: "og:description", content: description },
+        { property: "og:type", content: "website" },
+        { property: "og:url", content: `${siteUrl}/about` },
       ],
     };
   },
@@ -100,9 +100,9 @@ function AboutPage() {
                 What ClawHub Will Not Host
               </h1>
               <p className="text-sm leading-relaxed text-[color:var(--ink-soft)]">
-                ClawHub is for useful agent tooling, not abuse workflows. If a skill is built to evade
-                defenses, abuse platforms, scam people, invade privacy, or enable non-consensual
-                behavior, it does not belong here.
+                ClawHub is for useful agent tooling, not abuse workflows. If a skill is built to
+                evade defenses, abuse platforms, scam people, invade privacy, or enable
+                non-consensual behavior, it does not belong here.
               </p>
               <div className="flex items-center gap-2 rounded-[var(--radius-sm)] bg-[color:var(--surface-muted)] px-4 py-3 text-sm font-medium text-[color:var(--ink-soft)]">
                 <Shield className="h-4 w-4 shrink-0 text-[color:var(--accent)]" />
@@ -181,7 +181,18 @@ function AboutPage() {
               </ul>
               <Separator />
               <div className="flex flex-wrap gap-3">
-                <Link to="/skills" search={{ q: undefined, sort: undefined, dir: undefined, highlighted: undefined, nonSuspicious: undefined, view: undefined, focus: undefined }}>
+                <Link
+                  to="/skills"
+                  search={{
+                    q: undefined,
+                    sort: undefined,
+                    dir: undefined,
+                    highlighted: undefined,
+                    nonSuspicious: undefined,
+                    view: undefined,
+                    focus: undefined,
+                  }}
+                >
                   <Button variant="primary">Browse Skills</Button>
                 </Link>
                 <a

--- a/src/routes/cli/auth.tsx
+++ b/src/routes/cli/auth.tsx
@@ -120,9 +120,14 @@ function CliAuth() {
               <CardTitle className="text-2xl">CLI login</CardTitle>
             </CardHeader>
             <CardContent>
-              <p className="text-sm text-[color:var(--ink-soft)]">Sign in to create an API token for the CLI.</p>
+              <p className="text-sm text-[color:var(--ink-soft)]">
+                Sign in to create an API token for the CLI.
+              </p>
               {authError ? (
-                <p className="rounded-[var(--radius-sm)] border border-red-300/40 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-950/50 dark:text-red-300" role="alert">
+                <p
+                  className="rounded-[var(--radius-sm)] border border-red-300/40 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-950/50 dark:text-red-300"
+                  role="alert"
+                >
                   {authError}{" "}
                   <button
                     type="button"
@@ -143,7 +148,9 @@ function CliAuth() {
                     "github",
                     signInRedirectTo ? { redirectTo: signInRedirectTo } : undefined,
                   ).catch((error) => {
-                    setAuthError(getUserFacingAuthError(error, "Sign in failed. Please try again."));
+                    setAuthError(
+                      getUserFacingAuthError(error, "Sign in failed. Please try again."),
+                    );
                   });
                 }}
               >

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -67,7 +67,6 @@ type DashboardPackage = {
   } | null;
 };
 
-
 export const Route = createFileRoute("/dashboard")({
   component: Dashboard,
 });
@@ -110,7 +109,8 @@ function Dashboard() {
 
   useEffect(() => {
     if (selectedPublisherId) return;
-    const personal = publishers?.find((entry) => entry.publisher.kind === "user") ?? publishers?.[0];
+    const personal =
+      publishers?.find((entry) => entry.publisher.kind === "user") ?? publishers?.[0];
     if (personal?.publisher._id) {
       setSelectedPublisherId(personal.publisher._id);
     }
@@ -231,7 +231,10 @@ function Dashboard() {
                   description="Publish your first plugin release to validate and distribute it."
                 >
                   <Button asChild variant="primary">
-                    <Link to="/publish-plugin" search={{ ...emptyPluginPublishSearch, ownerHandle }}>
+                    <Link
+                      to="/publish-plugin"
+                      search={{ ...emptyPluginPublishSearch, ownerHandle }}
+                    >
                       <Plug className="h-4 w-4" aria-hidden="true" />
                       Publish Plugin
                     </Link>
@@ -281,7 +284,8 @@ function SkillRow({ skill, ownerHandle }: { skill: DashboardSkill; ownerHandle: 
         </div>
         <div className="flex flex-wrap items-center gap-3 text-xs text-[color:var(--ink-soft)]">
           <span className="inline-flex items-center gap-1">
-            <ArrowDownToLine size={13} aria-hidden="true" /> {formatCompactStat(skill.stats.downloads)}
+            <ArrowDownToLine size={13} aria-hidden="true" />{" "}
+            {formatCompactStat(skill.stats.downloads)}
           </span>
           <span className="inline-flex items-center gap-1">
             <Star size={13} aria-hidden="true" /> {formatCompactStat(skill.stats.stars)}
@@ -380,7 +384,9 @@ function PackageStatusTag({
 function PackageRow({ pkg, ownerHandle }: { pkg: DashboardPackage; ownerHandle: string }) {
   const scanLabel = scanStatusLabel(pkg.scanStatus);
   const nextVersion = pkg.latestVersion ? semver.inc(pkg.latestVersion, "patch") : null;
-  const sourceLabel = pkg.sourceRepo?.replace(/^https?:\/\/github\.com\//, "").replace(/\.git$/, "");
+  const sourceLabel = pkg.sourceRepo
+    ?.replace(/^https?:\/\/github\.com\//, "")
+    .replace(/\.git$/, "");
   const scanTone =
     pkg.scanStatus === "pending"
       ? "pending"
@@ -430,7 +436,8 @@ function PackageRow({ pkg, ownerHandle }: { pkg: DashboardPackage; ownerHandle: 
         </div>
         <div className="flex flex-wrap items-center gap-3 text-xs text-[color:var(--ink-soft)]">
           <span className="inline-flex items-center gap-1">
-            <ArrowDownToLine size={13} aria-hidden="true" /> {formatCompactStat(pkg.stats.downloads)}
+            <ArrowDownToLine size={13} aria-hidden="true" />{" "}
+            {formatCompactStat(pkg.stats.downloads)}
           </span>
           <span className="inline-flex items-center gap-1">
             <Star size={13} aria-hidden="true" /> {formatCompactStat(pkg.stats.stars)}

--- a/src/routes/import.tsx
+++ b/src/routes/import.tsx
@@ -236,9 +236,15 @@ export function ImportGitHub() {
         <header className="mb-6">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
             <div>
-              <p className="text-xs font-bold uppercase tracking-[0.14em] text-[color:var(--accent)]">GitHub import</p>
-              <h1 className="font-display text-2xl font-bold text-[color:var(--ink)]">Import from GitHub</h1>
-              <p className="text-sm text-[color:var(--ink-soft)]">Public repos only. Detects SKILL.md automatically.</p>
+              <p className="text-xs font-bold uppercase tracking-[0.14em] text-[color:var(--accent)]">
+                GitHub import
+              </p>
+              <h1 className="font-display text-2xl font-bold text-[color:var(--ink)]">
+                Import from GitHub
+              </h1>
+              <p className="text-sm text-[color:var(--ink-soft)]">
+                Public repos only. Detects SKILL.md automatically.
+              </p>
               <Badge variant="accent" className="mt-3 w-fit">
                 Skill-only import. Plugins are not supported here. Use{" "}
                 <Link
@@ -270,7 +276,9 @@ export function ImportGitHub() {
             <div>
               <div className="flex items-center justify-between">
                 <Label htmlFor="github-url">GitHub URL</Label>
-                <span className="text-xs text-[color:var(--ink-soft)]">Repo, tree path, or blob</span>
+                <span className="text-xs text-[color:var(--ink-soft)]">
+                  Repo, tree path, or blob
+                </span>
               </div>
               <Input
                 id="github-url"
@@ -308,7 +316,10 @@ export function ImportGitHub() {
             <h2 className="font-display text-lg font-bold text-[color:var(--ink)]">Pick a skill</h2>
             <div className="flex flex-col gap-2">
               {candidates.map((candidate) => (
-                <label key={candidate.path} className="flex items-center gap-3 rounded-[var(--radius-sm)] border border-[color:var(--line)] px-3 py-2 cursor-pointer hover:bg-[color:var(--surface-muted)]">
+                <label
+                  key={candidate.path}
+                  className="flex items-center gap-3 rounded-[var(--radius-sm)] border border-[color:var(--line)] px-3 py-2 cursor-pointer hover:bg-[color:var(--surface-muted)]"
+                >
                   <input
                     type="radio"
                     name="candidate"
@@ -338,7 +349,9 @@ export function ImportGitHub() {
                   <div>
                     <div className="flex items-center justify-between">
                       <Label htmlFor="slug">Slug</Label>
-                      <span className="text-xs text-[color:var(--ink-soft)]">Unique, lowercase</span>
+                      <span className="text-xs text-[color:var(--ink-soft)]">
+                        Unique, lowercase
+                      </span>
                     </div>
                     <Input
                       id="slug"
@@ -353,7 +366,9 @@ export function ImportGitHub() {
                   <div>
                     <div className="flex items-center justify-between">
                       <Label htmlFor="name">Display name</Label>
-                      <span className="text-xs text-[color:var(--ink-soft)]">Shown in listings</span>
+                      <span className="text-xs text-[color:var(--ink-soft)]">
+                        Shown in listings
+                      </span>
                     </div>
                     <Input
                       id="name"
@@ -381,7 +396,9 @@ export function ImportGitHub() {
                     <div>
                       <div className="flex items-center justify-between">
                         <Label htmlFor="tags">Tags</Label>
-                        <span className="text-xs text-[color:var(--ink-soft)]">Comma-separated</span>
+                        <span className="text-xs text-[color:var(--ink-soft)]">
+                          Comma-separated
+                        </span>
                       </div>
                       <Input
                         id="tags"
@@ -396,12 +413,16 @@ export function ImportGitHub() {
                   </div>
                 </div>
                 <aside className="flex flex-col gap-1 rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface-muted)] px-4 py-3">
-                  <div className="flex items-center gap-2 text-sm font-semibold text-emerald-600">Commit pinned</div>
+                  <div className="flex items-center gap-2 text-sm font-semibold text-emerald-600">
+                    Commit pinned
+                  </div>
                   <div className="text-sm text-[color:var(--ink-soft)]">
                     {preview.resolved.owner}/{preview.resolved.repo}@
                     {preview.resolved.commit.slice(0, 7)}
                   </div>
-                  <div className="font-mono text-xs text-[color:var(--ink-soft)]">{preview.candidate.path || "repo root"}</div>
+                  <div className="font-mono text-xs text-[color:var(--ink-soft)]">
+                    {preview.candidate.path || "repo root"}
+                  </div>
                 </aside>
               </div>
             </Card>
@@ -431,7 +452,10 @@ export function ImportGitHub() {
               </p>
               <div className="flex flex-col gap-1">
                 {preview.files.map((file) => (
-                  <label key={file.path} className="flex items-center gap-3 rounded-[var(--radius-sm)] px-2 py-1.5 hover:bg-[color:var(--surface-muted)]">
+                  <label
+                    key={file.path}
+                    className="flex items-center gap-3 rounded-[var(--radius-sm)] px-2 py-1.5 hover:bg-[color:var(--surface-muted)]"
+                  >
                     <input
                       type="checkbox"
                       checked={Boolean(selected[file.path])}
@@ -441,7 +465,9 @@ export function ImportGitHub() {
                       disabled={isBusy}
                     />
                     <span className="flex-1 truncate font-mono text-xs">{file.path}</span>
-                    <span className="shrink-0 text-xs text-[color:var(--ink-soft)]">{formatBytes(file.size)}</span>
+                    <span className="shrink-0 text-xs text-[color:var(--ink-soft)]">
+                      {formatBytes(file.size)}
+                    </span>
                   </label>
                 ))}
               </div>
@@ -466,7 +492,10 @@ export function ImportGitHub() {
                     {slugCollision.url ? (
                       <>
                         {" "}
-                        <a href={slugCollision.url} className="text-[color:var(--accent)] hover:underline">
+                        <a
+                          href={slugCollision.url}
+                          className="text-[color:var(--accent)] hover:underline"
+                        >
                           {slugCollision.url}
                         </a>
                       </>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -5,13 +5,13 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../../convex/_generated/api";
 import { InstallSwitcher } from "../components/InstallSwitcher";
 import { Container } from "../components/layout/Container";
+import { SkillCardSkeletonGrid } from "../components/skeletons/SkillCardSkeleton";
 import { SkillCard } from "../components/SkillCard";
 import { SkillStatsTripletLine } from "../components/SkillStats";
 import { SoulCard } from "../components/SoulCard";
 import { SoulStatsTripletLine } from "../components/SoulStats";
 import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
-import { SkillCardSkeletonGrid } from "../components/skeletons/SkillCardSkeleton";
 import { UserBadge } from "../components/UserBadge";
 import { convexHttp } from "../convex/client";
 import { getSkillBadges } from "../lib/badges";
@@ -84,7 +84,8 @@ function SkillsHome() {
                 ClawHub, the skill dock for sharp agents.
               </h1>
               <p className="max-w-lg text-lg leading-relaxed text-[color:var(--ink-soft)]">
-                Browse, install, and publish skill packs. Versioned like npm, searchable with vectors, no gatekeeping.
+                Browse, install, and publish skill packs. Versioned like npm, searchable with
+                vectors, no gatekeeping.
               </p>
               {/* Stats bar */}
               {totalSkillsText && (
@@ -95,7 +96,15 @@ function SkillsHome() {
               <div className="flex flex-wrap gap-3 pt-2">
                 <Link
                   to="/skills"
-                  search={{ q: undefined, sort: undefined, dir: undefined, highlighted: undefined, nonSuspicious: true, view: undefined, focus: undefined }}
+                  search={{
+                    q: undefined,
+                    sort: undefined,
+                    dir: undefined,
+                    highlighted: undefined,
+                    nonSuspicious: true,
+                    view: undefined,
+                    focus: undefined,
+                  }}
                 >
                   <Button variant="primary" size="lg">
                     Browse skills
@@ -111,7 +120,9 @@ function SkillsHome() {
             </div>
             <div className="hero-card hero-search-card fade-up" data-delay="2">
               <div className="hero-install" style={{ marginTop: 18 }}>
-                <div className="text-sm font-semibold text-[color:var(--ink-soft)]">Search skills. Versioned, rollback-ready.</div>
+                <div className="text-sm font-semibold text-[color:var(--ink-soft)]">
+                  Search skills. Versioned, rollback-ready.
+                </div>
                 <InstallSwitcher exampleSlug="sonoscli" />
               </div>
             </div>
@@ -125,12 +136,24 @@ function SkillsHome() {
           <div className="flex flex-col gap-6">
             <div className="flex items-end justify-between">
               <div>
-                <h2 className="font-display text-xl font-bold text-[color:var(--ink)]">Staff Picks</h2>
-                <p className="mt-1 text-sm text-[color:var(--ink-soft)]">Curated signal — highlighted for quick trust.</p>
+                <h2 className="font-display text-xl font-bold text-[color:var(--ink)]">
+                  Staff Picks
+                </h2>
+                <p className="mt-1 text-sm text-[color:var(--ink-soft)]">
+                  Curated signal — highlighted for quick trust.
+                </p>
               </div>
               <Link
                 to="/skills"
-                search={{ q: undefined, sort: undefined, dir: undefined, highlighted: true, nonSuspicious: undefined, view: undefined, focus: undefined }}
+                search={{
+                  q: undefined,
+                  sort: undefined,
+                  dir: undefined,
+                  highlighted: true,
+                  nonSuspicious: undefined,
+                  view: undefined,
+                  focus: undefined,
+                }}
                 className="hidden text-sm font-semibold text-[color:var(--accent)] hover:underline sm:block"
               >
                 View all
@@ -174,8 +197,12 @@ function SkillsHome() {
         <Container>
           <div className="flex flex-col gap-6">
             <div>
-              <h2 className="font-display text-xl font-bold text-[color:var(--ink)]">Popular skills</h2>
-              <p className="mt-1 text-sm text-[color:var(--ink-soft)]">Most-downloaded, verified picks.</p>
+              <h2 className="font-display text-xl font-bold text-[color:var(--ink)]">
+                Popular skills
+              </h2>
+              <p className="mt-1 text-sm text-[color:var(--ink-soft)]">
+                Most-downloaded, verified picks.
+              </p>
             </div>
             {!loaded && popular.length === 0 ? (
               <SkillCardSkeletonGrid count={6} />
@@ -208,7 +235,15 @@ function SkillsHome() {
             <div className="flex justify-center pt-4">
               <Link
                 to="/skills"
-                search={{ q: undefined, sort: undefined, dir: undefined, highlighted: undefined, nonSuspicious: true, view: undefined, focus: undefined }}
+                search={{
+                  q: undefined,
+                  sort: undefined,
+                  dir: undefined,
+                  highlighted: undefined,
+                  nonSuspicious: true,
+                  view: undefined,
+                  focus: undefined,
+                }}
               >
                 <Button variant="outline">
                   See all skills
@@ -250,17 +285,28 @@ function OnlyCrabsHome() {
                 SoulHub, where system lore lives.
               </h1>
               <p className="max-w-lg text-lg leading-relaxed text-[color:var(--ink-soft)]">
-                Share SOUL.md bundles, version them like docs, and keep personal system lore in one public place.
+                Share SOUL.md bundles, version them like docs, and keep personal system lore in one
+                public place.
               </p>
               <div className="flex flex-wrap gap-3 pt-2">
                 <Link to="/publish-skill" search={{ updateSlug: undefined }}>
-                  <Button variant="primary" size="lg">Publish Soul</Button>
+                  <Button variant="primary" size="lg">
+                    Publish Soul
+                  </Button>
                 </Link>
                 <Link
                   to="/souls"
-                  search={{ q: undefined, sort: undefined, dir: undefined, view: undefined, focus: undefined }}
+                  search={{
+                    q: undefined,
+                    sort: undefined,
+                    dir: undefined,
+                    view: undefined,
+                    focus: undefined,
+                  }}
                 >
-                  <Button variant="outline" size="lg">Browse souls</Button>
+                  <Button variant="outline" size="lg">
+                    Browse souls
+                  </Button>
                 </Link>
               </div>
             </div>
@@ -290,7 +336,9 @@ function OnlyCrabsHome() {
                 />
               </form>
               <div className="hero-install" style={{ marginTop: 18 }}>
-                <div className="text-sm font-semibold text-[color:var(--ink-soft)]">Search souls. Versioned, readable, easy to remix.</div>
+                <div className="text-sm font-semibold text-[color:var(--ink-soft)]">
+                  Search souls. Versioned, readable, easy to remix.
+                </div>
               </div>
             </div>
           </div>
@@ -301,8 +349,12 @@ function OnlyCrabsHome() {
         <Container>
           <div className="flex flex-col gap-6">
             <div>
-              <h2 className="font-display text-xl font-bold text-[color:var(--ink)]">Latest souls</h2>
-              <p className="mt-1 text-sm text-[color:var(--ink-soft)]">Newest SOUL.md bundles across the hub.</p>
+              <h2 className="font-display text-xl font-bold text-[color:var(--ink)]">
+                Latest souls
+              </h2>
+              <p className="mt-1 text-sm text-[color:var(--ink-soft)]">
+                Newest SOUL.md bundles across the hub.
+              </p>
             </div>
             {latest.length === 0 ? (
               <SkillCardSkeletonGrid count={6} />
@@ -325,7 +377,13 @@ function OnlyCrabsHome() {
             <div className="flex justify-center pt-4">
               <Link
                 to="/souls"
-                search={{ q: undefined, sort: undefined, dir: undefined, view: undefined, focus: undefined }}
+                search={{
+                  q: undefined,
+                  sort: undefined,
+                  dir: undefined,
+                  view: undefined,
+                  focus: undefined,
+                }}
               >
                 <Button variant="outline">
                   See all souls

--- a/src/routes/management.tsx
+++ b/src/routes/management.tsx
@@ -36,7 +36,6 @@ const SKILL_CAPABILITY_LABELS: Record<string, string> = {
 
 const SKILL_AUDIT_LOG_LIMIT = 10;
 
-
 type ManagementUserSummary = {
   _id: Id<"users">;
   handle?: string | null;
@@ -395,7 +394,9 @@ function Management() {
                           size="sm"
                           onClick={() => {
                             const action = skill.softDeletedAt ? "Restore" : "Hide";
-                            const reason = window.prompt(`${action} reason for "${skill.displayName}"`);
+                            const reason = window.prompt(
+                              `${action} reason for "${skill.displayName}"`,
+                            );
                             if (!reason?.trim()) return;
                             void setSoftDeleted({
                               skillId: skill._id,
@@ -457,10 +458,7 @@ function Management() {
                   <Skeleton className="h-32 w-full" />
                 </div>
               ) : !selectedSkill?.skill ? (
-                <EmptyState
-                  icon={Shield}
-                  title={`No skill found for "${selectedSlug}"`}
-                />
+                <EmptyState icon={Shield} title={`No skill found for "${selectedSlug}"`} />
               ) : (
                 (() => {
                   const { skill, latestVersion, owner, canonical, overrideReviewer, auditLogs } =
@@ -475,7 +473,8 @@ function Management() {
                   const isOfficial = isSkillOfficial(skill);
                   const isDeprecated = isSkillDeprecated(skill);
                   const badges = getSkillBadges(skill);
-                  const capabilityTags = latestVersion?.capabilityTags ?? skill.capabilityTags ?? [];
+                  const capabilityTags =
+                    latestVersion?.capabilityTags ?? skill.capabilityTags ?? [];
                   const ownerUserId = skill.ownerUserId ?? selectedOwnerUserId;
                   const ownerHandle = owner?.handle ?? owner?.name ?? "user";
                   const isOwnerAdmin = owner?.role === "admin";
@@ -534,7 +533,10 @@ function Management() {
                                   Current override
                                 </span>
                                 <span>
-                                  {formatManualOverrideState(skill.manualOverride, overrideReviewer)}
+                                  {formatManualOverrideState(
+                                    skill.manualOverride,
+                                    overrideReviewer,
+                                  )}
                                 </span>
                               </div>
                               <div className="flex flex-col gap-1">
@@ -551,9 +553,7 @@ function Management() {
                                 <span className="text-xs font-medium text-[color:var(--ink-soft)]">
                                   Behavior
                                 </span>
-                                <span>
-                                  Applies to the full skill until a moderator clears it.
-                                </span>
+                                <span>Applies to the full skill until a moderator clears it.</span>
                               </div>
                               <Textarea
                                 rows={4}
@@ -600,9 +600,7 @@ function Management() {
                                 <span className="text-xs font-medium text-[color:var(--ink-soft)]">
                                   Window
                                 </span>
-                                <span>
-                                  Last {SKILL_AUDIT_LOG_LIMIT} entries for this skill.
-                                </span>
+                                <span>Last {SKILL_AUDIT_LOG_LIMIT} entries for this skill.</span>
                               </div>
                               {auditLogs.length === 0 ? (
                                 <div className="text-sm text-[color:var(--ink-soft)]">
@@ -711,19 +709,18 @@ function Management() {
                       </div>
                       <div className="flex flex-wrap gap-2">
                         <Button asChild variant="outline" size="sm">
-                        <Link
-                          to="/$owner/$slug"
-                          params={{ owner: ownerParam, slug: skill.slug }}
-                        >
-                          View
-                        </Link>
+                          <Link to="/$owner/$slug" params={{ owner: ownerParam, slug: skill.slug }}>
+                            View
+                          </Link>
                         </Button>
                         <Button
                           variant="outline"
                           size="sm"
                           onClick={() => {
                             const action = skill.softDeletedAt ? "Restore" : "Hide";
-                            const reason = window.prompt(`${action} reason for "${skill.displayName}"`);
+                            const reason = window.prompt(
+                              `${action} reason for "${skill.displayName}"`,
+                            );
                             if (!reason?.trim()) return;
                             void setSoftDeleted({
                               skillId: skill._id,
@@ -863,18 +860,18 @@ function Management() {
                             </div>
                             <div className="flex flex-wrap items-center gap-2">
                               <Button asChild variant="outline" size="sm">
-                              <Link
-                                to="/$owner/$slug"
-                                params={{
-                                  owner: resolveOwnerParam(
-                                    match.owner?.handle ?? null,
-                                    match.owner?._id ?? match.skill.ownerUserId,
-                                  ),
-                                  slug: match.skill.slug,
-                                }}
-                              >
-                                View
-                              </Link>
+                                <Link
+                                  to="/$owner/$slug"
+                                  params={{
+                                    owner: resolveOwnerParam(
+                                      match.owner?.handle ?? null,
+                                      match.owner?._id ?? match.skill.ownerUserId,
+                                    ),
+                                    slug: match.skill.slug,
+                                  }}
+                                >
+                                  View
+                                </Link>
                               </Button>
                               <Button
                                 variant="outline"

--- a/src/routes/orgs/$handle.tsx
+++ b/src/routes/orgs/$handle.tsx
@@ -1,18 +1,18 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
+import { Building2, Users } from "lucide-react";
 import { api } from "../../../convex/_generated/api";
-import type { PublicPublisher, PublicSkill } from "../../lib/publicUser";
+import { EmptyState } from "../../components/EmptyState";
+import { Container } from "../../components/layout/Container";
+import { SkillCardSkeletonGrid } from "../../components/skeletons/SkillCardSkeleton";
 import { SkillCard } from "../../components/SkillCard";
-import { getSkillBadges } from "../../lib/badges";
 import { SkillStatsTripletLine } from "../../components/SkillStats";
 import { Avatar, AvatarFallback, AvatarImage } from "../../components/ui/avatar";
 import { Badge } from "../../components/ui/badge";
 import { Card, CardContent } from "../../components/ui/card";
-import { Container } from "../../components/layout/Container";
-import { EmptyState } from "../../components/EmptyState";
-import { SkillCardSkeletonGrid } from "../../components/skeletons/SkillCardSkeleton";
 import { Skeleton } from "../../components/ui/skeleton";
-import { Building2, Users } from "lucide-react";
+import { getSkillBadges } from "../../lib/badges";
+import type { PublicPublisher, PublicSkill } from "../../lib/publicUser";
 
 export const Route = createFileRoute("/orgs/$handle")({
   component: OrgProfile,
@@ -130,7 +130,10 @@ function OrgProfile() {
                 ))}
               </div>
             ) : (
-              <EmptyState title="No published skills yet" description="This organization hasn't published any skills." />
+              <EmptyState
+                title="No published skills yet"
+                description="This organization hasn't published any skills."
+              />
             )}
           </section>
 
@@ -147,9 +150,14 @@ function OrgProfile() {
                     <CardContent className="flex items-center justify-between py-4">
                       <div className="flex items-center gap-3">
                         <Avatar className="h-9 w-9">
-                          <AvatarImage src={entry.user.image ?? undefined} alt={entry.user.displayName ?? entry.user.handle ?? "User"} />
+                          <AvatarImage
+                            src={entry.user.image ?? undefined}
+                            alt={entry.user.displayName ?? entry.user.handle ?? "User"}
+                          />
                           <AvatarFallback>
-                            {(entry.user.displayName ?? entry.user.handle ?? "U").charAt(0).toUpperCase()}
+                            {(entry.user.displayName ?? entry.user.handle ?? "U")
+                              .charAt(0)
+                              .toUpperCase()}
                           </AvatarFallback>
                         </Avatar>
                         <div className="flex flex-col">
@@ -167,7 +175,11 @@ function OrgProfile() {
                           ) : null}
                         </div>
                       </div>
-                      <Badge variant={(roleColor[entry.role] ?? "default") as "accent" | "default" | "compact"}>
+                      <Badge
+                        variant={
+                          (roleColor[entry.role] ?? "default") as "accent" | "default" | "compact"
+                        }
+                      >
                         {entry.role}
                       </Badge>
                     </CardContent>
@@ -175,7 +187,10 @@ function OrgProfile() {
                 ))}
               </div>
             ) : (
-              <EmptyState title="No members listed" description="Member information is not available." />
+              <EmptyState
+                title="No members listed"
+                description="Member information is not available."
+              />
             )}
           </section>
         </div>

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -1,9 +1,9 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { ExternalLink, Copy, Check, Download } from "lucide-react";
 import { useState } from "react";
-import { MarkdownPreview } from "../../components/MarkdownPreview";
 import { EmptyState } from "../../components/EmptyState";
 import { Container } from "../../components/layout/Container";
+import { MarkdownPreview } from "../../components/MarkdownPreview";
 import { SecurityScanResults } from "../../components/SkillSecurityScanResults";
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
@@ -121,18 +121,21 @@ function CopyButton({ text }: { text: string }) {
       className="shrink-0"
       onClick={() => {
         if (navigator.clipboard?.writeText) {
-          void navigator.clipboard.writeText(text).then(() => {
-            setState("copied");
-            setTimeout(() => setState("idle"), 2000);
-          }).catch(() => {
-            if (fallbackCopy(text)) {
+          void navigator.clipboard
+            .writeText(text)
+            .then(() => {
               setState("copied");
               setTimeout(() => setState("idle"), 2000);
-            } else {
-              setState("failed");
-              setTimeout(() => setState("idle"), 2000);
-            }
-          });
+            })
+            .catch(() => {
+              if (fallbackCopy(text)) {
+                setState("copied");
+                setTimeout(() => setState("idle"), 2000);
+              } else {
+                setState("failed");
+                setTimeout(() => setState("idle"), 2000);
+              }
+            });
         } else if (fallbackCopy(text)) {
           setState("copied");
           setTimeout(() => setState("idle"), 2000);
@@ -188,7 +191,10 @@ function PluginDetailRoute() {
     return (
       <main className="py-10">
         <Container size="narrow">
-          <EmptyState title="Plugin not found" description="This plugin does not exist or has been removed." />
+          <EmptyState
+            title="Plugin not found"
+            description="This plugin does not exist or has been removed."
+          />
         </Container>
       </main>
     );
@@ -210,7 +216,8 @@ function PluginDetailRoute() {
 
   const capEntries = capabilities
     ? Object.entries(capabilities).filter(
-        ([, v]) => v !== undefined && v !== null && v !== false && !(Array.isArray(v) && v.length === 0),
+        ([, v]) =>
+          v !== undefined && v !== null && v !== false && !(Array.isArray(v) && v.length === 0),
       )
     : [];
 
@@ -248,9 +255,7 @@ function PluginDetailRoute() {
                 {pkg.summary ?? "No summary provided."}
               </p>
               <div className="flex flex-wrap items-center gap-2 text-sm text-[color:var(--ink-soft)]">
-                <span className="font-mono text-xs">
-                  {pkg.name}
-                </span>
+                <span className="font-mono text-xs">{pkg.name}</span>
                 {pkg.runtimeId ? (
                   <>
                     <span className="opacity-40">&middot;</span>
@@ -282,7 +287,9 @@ function PluginDetailRoute() {
               {/* Install */}
               <div className="mt-4">
                 <div className="flex items-center gap-2 rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface-muted)] p-3">
-                  <pre className="flex-1 overflow-x-auto font-mono text-xs text-[color:var(--ink)]"><code>{installSnippet}</code></pre>
+                  <pre className="flex-1 overflow-x-auto font-mono text-xs text-[color:var(--ink)]">
+                    <code>{installSnippet}</code>
+                  </pre>
                   <CopyButton text={installSnippet} />
                 </div>
               </div>
@@ -316,16 +323,14 @@ function PluginDetailRoute() {
                 <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
                   {capEntries.map(([key, value]) => (
                     <div key={key} className="col-span-2 grid grid-cols-subgrid">
-                      <dt className="font-semibold text-[color:var(--ink-soft)]">{CAPABILITY_LABELS[key] ?? key}</dt>
+                      <dt className="font-semibold text-[color:var(--ink-soft)]">
+                        {CAPABILITY_LABELS[key] ?? key}
+                      </dt>
                       <dd className="text-[color:var(--ink)]">
                         {key === "capabilityTags" && Array.isArray(value) ? (
                           <div className="flex flex-wrap gap-1.5">
                             {(value as string[]).map((tag) => (
-                              <Link
-                                key={tag}
-                                to="/plugins"
-                                search={{ q: tag }}
-                              >
+                              <Link key={tag} to="/plugins" search={{ q: tag }}>
                                 <Badge variant="compact">{tag}</Badge>
                               </Link>
                             ))}
@@ -333,7 +338,9 @@ function PluginDetailRoute() {
                         ) : key === "hostTargets" && Array.isArray(value) ? (
                           <div className="flex flex-wrap gap-1.5">
                             {(value as string[]).map((target) => (
-                              <Badge key={target} variant="compact">{target}</Badge>
+                              <Badge key={target} variant="compact">
+                                {target}
+                              </Badge>
                             ))}
                           </div>
                         ) : (
@@ -394,13 +401,17 @@ function PluginDetailRoute() {
                   {verification.tier ? (
                     <div className="col-span-2 grid grid-cols-subgrid">
                       <dt className="font-semibold text-[color:var(--ink-soft)]">Tier</dt>
-                      <dd className="text-[color:var(--ink)]">{verification.tier.replace(/-/g, " ")}</dd>
+                      <dd className="text-[color:var(--ink)]">
+                        {verification.tier.replace(/-/g, " ")}
+                      </dd>
                     </div>
                   ) : null}
                   {verification.scope ? (
                     <div className="col-span-2 grid grid-cols-subgrid">
                       <dt className="font-semibold text-[color:var(--ink-soft)]">Scope</dt>
-                      <dd className="text-[color:var(--ink)]">{verification.scope.replace(/-/g, " ")}</dd>
+                      <dd className="text-[color:var(--ink)]">
+                        {verification.scope.replace(/-/g, " ")}
+                      </dd>
                     </div>
                   ) : null}
                   {verification.summary ? (
@@ -409,43 +420,51 @@ function PluginDetailRoute() {
                       <dd className="text-[color:var(--ink)]">{verification.summary}</dd>
                     </div>
                   ) : null}
-                  {verification.sourceRepo ? (() => {
-                    const raw = verification.sourceRepo;
-                    const href = /^https?:\/\//.test(raw) ? raw : `https://github.com/${raw}`;
-                    const display = href.replace(/^https?:\/\//, "");
-                    return (
-                      <div className="col-span-2 grid grid-cols-subgrid">
-                        <dt className="font-semibold text-[color:var(--ink-soft)]">Source</dt>
-                        <dd className="text-[color:var(--ink)]">
-                          <a
-                            href={href}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="inline-flex items-center gap-1 text-[color:var(--accent)] hover:underline"
-                          >
-                            {display}
-                            <ExternalLink className="h-3 w-3" aria-hidden="true" />
-                          </a>
-                        </dd>
-                      </div>
-                    );
-                  })() : null}
+                  {verification.sourceRepo
+                    ? (() => {
+                        const raw = verification.sourceRepo;
+                        const href = /^https?:\/\//.test(raw) ? raw : `https://github.com/${raw}`;
+                        const display = href.replace(/^https?:\/\//, "");
+                        return (
+                          <div className="col-span-2 grid grid-cols-subgrid">
+                            <dt className="font-semibold text-[color:var(--ink-soft)]">Source</dt>
+                            <dd className="text-[color:var(--ink)]">
+                              <a
+                                href={href}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center gap-1 text-[color:var(--accent)] hover:underline"
+                              >
+                                {display}
+                                <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                              </a>
+                            </dd>
+                          </div>
+                        );
+                      })()
+                    : null}
                   {verification.sourceCommit ? (
                     <div className="col-span-2 grid grid-cols-subgrid">
                       <dt className="font-semibold text-[color:var(--ink-soft)]">Commit</dt>
-                      <dd className="font-mono text-xs text-[color:var(--ink)]">{verification.sourceCommit.slice(0, 12)}</dd>
+                      <dd className="font-mono text-xs text-[color:var(--ink)]">
+                        {verification.sourceCommit.slice(0, 12)}
+                      </dd>
                     </div>
                   ) : null}
                   {verification.sourceTag ? (
                     <div className="col-span-2 grid grid-cols-subgrid">
                       <dt className="font-semibold text-[color:var(--ink-soft)]">Tag</dt>
-                      <dd className="font-mono text-xs text-[color:var(--ink)]">{verification.sourceTag}</dd>
+                      <dd className="font-mono text-xs text-[color:var(--ink)]">
+                        {verification.sourceTag}
+                      </dd>
                     </div>
                   ) : null}
                   {verification.hasProvenance !== undefined ? (
                     <div className="col-span-2 grid grid-cols-subgrid">
                       <dt className="font-semibold text-[color:var(--ink-soft)]">Provenance</dt>
-                      <dd className="text-[color:var(--ink)]">{verification.hasProvenance ? "Yes" : "No"}</dd>
+                      <dd className="text-[color:var(--ink)]">
+                        {verification.hasProvenance ? "Yes" : "No"}
+                      </dd>
                     </div>
                   ) : null}
                   {verification.scanStatus ? (

--- a/src/routes/plugins/index.tsx
+++ b/src/routes/plugins/index.tsx
@@ -37,9 +37,7 @@ export const Route = createFileRoute("/plugins/")({
         ? true
         : undefined,
     executesCode:
-      search.executesCode === true ||
-      search.executesCode === "true" ||
-      search.executesCode === "1"
+      search.executesCode === true || search.executesCode === "true" || search.executesCode === "1"
         ? true
         : undefined,
   }),
@@ -101,12 +99,8 @@ export function PluginsIndex() {
     <main className="py-10">
       <Container size="wide">
         <header className="mb-6">
-          <h1 className="font-display text-2xl font-bold text-[color:var(--ink)] mb-2">
-            Plugins
-          </h1>
-          <p className="text-sm text-[color:var(--ink-soft)]">
-            Browse the plugin catalog.
-          </p>
+          <h1 className="font-display text-2xl font-bold text-[color:var(--ink)] mb-2">Plugins</h1>
+          <p className="text-sm text-[color:var(--ink-soft)]">Browse the plugin catalog.</p>
         </header>
 
         <div className="flex flex-col gap-3">
@@ -124,7 +118,10 @@ export function PluginsIndex() {
                 });
               }}
             >
-              <Search className="pointer-events-none absolute left-3 h-4 w-4 text-[color:var(--ink-soft)] opacity-50" aria-hidden="true" />
+              <Search
+                className="pointer-events-none absolute left-3 h-4 w-4 text-[color:var(--ink-soft)] opacity-50"
+                aria-hidden="true"
+              />
               <Input
                 className="pl-9"
                 placeholder="Search plugins..."
@@ -148,12 +145,16 @@ export function PluginsIndex() {
             </Link>
           </div>
           <div className="flex flex-wrap items-center gap-2">
-            <div className="flex items-center rounded-[var(--radius-pill)] border border-[color:var(--line)]" role="group" aria-label="Filter by type">
-              {([
+            <div
+              className="flex items-center rounded-[var(--radius-pill)] border border-[color:var(--line)]"
+              role="group"
+              aria-label="Filter by type"
+            >
+              {[
                 { value: undefined, label: "All" },
                 { value: "code-plugin" as const, label: "Code" },
                 { value: "bundle-plugin" as const, label: "Bundles" },
-              ]).map((opt) => (
+              ].map((opt) => (
                 <button
                   key={opt.label}
                   className={`px-3 py-1.5 text-sm font-semibold transition-colors first:rounded-l-[var(--radius-pill)] last:rounded-r-[var(--radius-pill)] ${
@@ -225,11 +226,7 @@ export function PluginsIndex() {
             <>
               <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-5">
                 {items.map((item) => (
-                  <Link
-                    key={item.name}
-                    to="/plugins/$name"
-                    params={{ name: item.name }}
-                  >
+                  <Link key={item.name} to="/plugins/$name" params={{ name: item.name }}>
                     <Card className="h-full cursor-pointer hover:-translate-y-px hover:shadow-[0_10px_20px_rgba(29,26,23,0.12)]">
                       <div className="flex flex-wrap gap-1.5">
                         <Badge variant="compact">{familyLabel(item.family)}</Badge>
@@ -239,7 +236,9 @@ export function PluginsIndex() {
                           </Badge>
                         ) : null}
                       </div>
-                      <h3 className="font-display text-lg font-bold text-[color:var(--ink)]">{item.displayName}</h3>
+                      <h3 className="font-display text-lg font-bold text-[color:var(--ink)]">
+                        {item.displayName}
+                      </h3>
                       <p className="text-sm text-[color:var(--ink-soft)]">
                         {item.summary ?? "No summary provided."}
                       </p>
@@ -248,7 +247,9 @@ export function PluginsIndex() {
                           {item.ownerHandle ? `by ${item.ownerHandle}` : "community"}
                         </span>
                         {item.latestVersion ? (
-                          <span className="text-sm text-[color:var(--ink-soft)]">v{item.latestVersion}</span>
+                          <span className="text-sm text-[color:var(--ink-soft)]">
+                            v{item.latestVersion}
+                          </span>
                         ) : null}
                       </div>
                     </Card>

--- a/src/routes/publish-plugin.tsx
+++ b/src/routes/publish-plugin.tsx
@@ -5,26 +5,20 @@ import { startTransition, useEffect, useMemo, useState } from "react";
 import semver from "semver";
 import { toast } from "sonner";
 import { api } from "../../convex/_generated/api";
-import { PackageSourceChooser } from "../components/PackageSourceChooser";
+import { MAX_PUBLISH_FILE_BYTES, MAX_PUBLISH_TOTAL_BYTES } from "../../convex/lib/publishLimits";
 import { Container } from "../components/layout/Container";
+import { PackageSourceChooser } from "../components/PackageSourceChooser";
 import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
 import { Card } from "../components/ui/card";
 import { Input } from "../components/ui/input";
 import { Textarea } from "../components/ui/textarea";
 import {
-  MAX_PUBLISH_FILE_BYTES,
-  MAX_PUBLISH_TOTAL_BYTES,
-} from "../../convex/lib/publishLimits";
-import {
   buildPackageUploadEntries,
   filterIgnoredPackageFiles,
   normalizePackageUploadFiles,
 } from "../lib/packageUpload";
-import {
-  derivePluginPrefill,
-  listPrefilledFields,
-} from "../lib/pluginPublishPrefill";
+import { derivePluginPrefill, listPrefilledFields } from "../lib/pluginPublishPrefill";
 import { expandFilesWithReport } from "../lib/uploadFiles";
 import { useAuthStatus } from "../lib/useAuthStatus";
 import { formatPublishError, hashFile, uploadFile } from "./upload/-utils";
@@ -65,9 +59,9 @@ export function PublishPluginRoute() {
       }>
     | undefined;
   const generateUploadUrl = useMutation(api.uploads.generateUploadUrl);
-  const publishRelease = useAction(apiRefs.packages.publishRelease as never) as unknown as (
-    args: { payload: unknown },
-  ) => Promise<unknown>;
+  const publishRelease = useAction(apiRefs.packages.publishRelease as never) as unknown as (args: {
+    payload: unknown;
+  }) => Promise<unknown>;
   const [family, setFamily] = useState<"code-plugin" | "bundle-plugin">(
     search.family === "bundle-plugin" ? "bundle-plugin" : "code-plugin",
   );
@@ -299,9 +293,7 @@ export function PublishPluginRoute() {
                 Boolean(validationError) ||
                 isSubmitting ||
                 (family === "code-plugin" &&
-                  (!sourceRepo.trim() ||
-                    !sourceCommit.trim() ||
-                    codePluginFieldIssues.length > 0))
+                  (!sourceRepo.trim() || !sourceCommit.trim() || codePluginFieldIssues.length > 0))
               }
               onClick={() => {
                 startTransition(() => {

--- a/src/routes/publish-skill.tsx
+++ b/src/routes/publish-skill.tsx
@@ -11,10 +11,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import semver from "semver";
 import { toast } from "sonner";
 import { api } from "../../convex/_generated/api";
-import {
-  MAX_PUBLISH_FILE_BYTES,
-  MAX_PUBLISH_TOTAL_BYTES,
-} from "../../convex/lib/publishLimits";
+import { MAX_PUBLISH_FILE_BYTES, MAX_PUBLISH_TOTAL_BYTES } from "../../convex/lib/publishLimits";
 import { EmptyState } from "../components/EmptyState";
 import { Container } from "../components/layout/Container";
 import { Badge } from "../components/ui/badge";
@@ -206,7 +203,9 @@ export function Upload() {
 
   useEffect(() => {
     if (ownerHandle) return;
-    const personalPublisher = publisherMemberships?.find((entry) => entry.publisher.kind === "user");
+    const personalPublisher = publisherMemberships?.find(
+      (entry) => entry.publisher.kind === "user",
+    );
     if (personalPublisher?.publisher.handle) {
       setOwnerHandle(personalPublisher.publisher.handle);
     }
@@ -446,8 +445,7 @@ export function Upload() {
       setChangelogSource("user");
       if (result) {
         toast.success(`Published ${trimmedSlug}@${version}`);
-        const ownerParam =
-          ownerHandle || me?.handle || (me?._id ? String(me._id) : "unknown");
+        const ownerParam = ownerHandle || me?.handle || (me?._id ? String(me._id) : "unknown");
         void navigate({
           to: isSoulMode ? "/souls/$slug" : "/$owner/$slug",
           params: isSoulMode ? { slug: trimmedSlug } : { owner: ownerParam, slug: trimmedSlug },
@@ -488,9 +486,7 @@ export function Upload() {
                   placeholder={`${contentLabel}-name`}
                 />
                 {trimmedSlug && SLUG_PATTERN.test(trimmedSlug) && slugAvailability ? (
-                  <Badge
-                    variant={slugAvailability.available ? "success" : "destructive"}
-                  >
+                  <Badge variant={slugAvailability.available ? "success" : "destructive"}>
                     {slugAvailability.available ? "Available" : "Taken"}
                   </Badge>
                 ) : null}
@@ -636,7 +632,10 @@ export function Upload() {
               {slugCollision?.url ? (
                 <div className="text-sm text-[color:var(--ink-soft)]">
                   Existing skill:{" "}
-                  <a href={slugCollision.url} className="text-[color:var(--accent)] hover:underline">
+                  <a
+                    href={slugCollision.url}
+                    className="text-[color:var(--accent)] hover:underline"
+                  >
                     {slugCollision.url}
                   </a>
                 </div>
@@ -709,9 +708,7 @@ export function Upload() {
                   {error}
                 </div>
               ) : null}
-              {status ? (
-                <div className="text-sm text-[color:var(--ink-soft)]">{status}</div>
-              ) : null}
+              {status ? <div className="text-sm text-[color:var(--ink-soft)]">{status}</div> : null}
               {hasAttempted && !validation.ready ? (
                 <div className="text-sm text-[color:var(--ink-soft)]">
                   Fix validation issues to continue.

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -156,9 +156,7 @@ export function Settings() {
         <Card>
           <CardContent className="flex items-center gap-4">
             <Avatar className="h-16 w-16">
-              {avatar ? (
-                <AvatarImage src={avatar} alt={identityName} />
-              ) : null}
+              {avatar ? <AvatarImage src={avatar} alt={identityName} /> : null}
               <AvatarFallback className="text-lg">
                 {identityName[0]?.toUpperCase() ?? "U"}
               </AvatarFallback>
@@ -364,11 +362,7 @@ export function Settings() {
               />
             </div>
             <div className="flex flex-col items-start gap-3">
-              <Button
-                variant="primary"
-                type="button"
-                onClick={() => void onCreateToken()}
-              >
+              <Button variant="primary" type="button" onClick={() => void onCreateToken()}>
                 Create token
               </Button>
               {newToken ? (
@@ -427,7 +421,8 @@ export function Settings() {
           <CardHeader>
             <CardTitle className="text-red-700 dark:text-red-300">Danger zone</CardTitle>
             <CardDescription>
-              Delete your account permanently. This cannot be undone. Published skills remain public.
+              Delete your account permanently. This cannot be undone. Published skills remain
+              public.
             </CardDescription>
           </CardHeader>
           <CardContent>

--- a/src/routes/skills/-SkillsResults.tsx
+++ b/src/routes/skills/-SkillsResults.tsx
@@ -2,10 +2,10 @@ import { Link } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
 import type { RefObject } from "react";
 import { EmptyState } from "../../components/EmptyState";
+import { SkillCardSkeletonGrid } from "../../components/skeletons/SkillCardSkeleton";
 import { SkillCard } from "../../components/SkillCard";
 import { getPlatformLabels } from "../../components/skillDetailUtils";
 import { SkillMetricsRow, SkillStatsTripletLine } from "../../components/SkillStats";
-import { SkillCardSkeletonGrid } from "../../components/skeletons/SkillCardSkeleton";
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
 import { UserBadge } from "../../components/UserBadge";
@@ -105,13 +105,19 @@ export function SkillsResults({
               >
                 <span className="flex flex-col gap-1">
                   <span className="flex items-center gap-2">
-                    <span className="font-semibold text-[color:var(--ink)]">{skill.displayName}</span>
+                    <span className="font-semibold text-[color:var(--ink)]">
+                      {skill.displayName}
+                    </span>
                     {getSkillBadges(skill).map((badge) => (
-                      <Badge key={badge} variant="compact">{badge}</Badge>
+                      <Badge key={badge} variant="compact">
+                        {badge}
+                      </Badge>
                     ))}
                   </span>
                   {entry.latestVersion?.version ? (
-                    <span className="font-mono text-xs text-[color:var(--ink-soft)]">v{entry.latestVersion.version}</span>
+                    <span className="font-mono text-xs text-[color:var(--ink-soft)]">
+                      v{entry.latestVersion.version}
+                    </span>
                   ) : null}
                 </span>
                 <span className="truncate text-sm text-[color:var(--ink-soft)]">
@@ -136,10 +142,7 @@ export function SkillsResults({
 
       {/* Load more */}
       {(canLoadMore || isLoadingMore) && (
-        <div
-          ref={canAutoLoad ? loadMoreRef : null}
-          className="flex justify-center pt-4"
-        >
+        <div ref={canAutoLoad ? loadMoreRef : null} className="flex justify-center pt-4">
           {canAutoLoad ? (
             isLoadingMore ? (
               <div className="flex items-center gap-2 text-sm font-medium text-[color:var(--ink-soft)]">
@@ -150,7 +153,12 @@ export function SkillsResults({
               <div className="text-sm text-[color:var(--ink-soft)]">Scroll to load more</div>
             )
           ) : (
-            <Button variant="outline" onClick={loadMore} disabled={isLoadingMore} loading={isLoadingMore}>
+            <Button
+              variant="outline"
+              onClick={loadMore}
+              disabled={isLoadingMore}
+              loading={isLoadingMore}
+            >
               Load more
             </Button>
           )}

--- a/src/routes/skills/-SkillsToolbar.tsx
+++ b/src/routes/skills/-SkillsToolbar.tsx
@@ -1,5 +1,6 @@
 import { ArrowDownUp, Check, Grid3X3, List, Search, X } from "lucide-react";
 import type { RefObject } from "react";
+import { Button } from "../../components/ui/button";
 import { Input } from "../../components/ui/input";
 import {
   Select,
@@ -8,7 +9,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../../components/ui/select";
-import { Button } from "../../components/ui/button";
 import { type SortDir, type SortKey } from "./-params";
 
 type SkillsToolbarProps = {
@@ -83,7 +83,10 @@ export function SkillsToolbar({
 
         {/* Sort */}
         <Select value={sort} onValueChange={onSortChange}>
-          <SelectTrigger className="w-auto min-w-[140px] min-h-[36px] py-1.5 text-xs font-semibold" aria-label="Sort skills">
+          <SelectTrigger
+            className="w-auto min-w-[140px] min-h-[36px] py-1.5 text-xs font-semibold"
+            aria-label="Sort skills"
+          >
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -104,7 +107,9 @@ export function SkillsToolbar({
           aria-label={`Sort direction: ${dir === "asc" ? "ascending" : "descending"}`}
           className="min-h-[36px] px-2"
         >
-          <ArrowDownUp className={`h-4 w-4 transition-transform ${dir === "asc" ? "rotate-180" : ""}`} />
+          <ArrowDownUp
+            className={`h-4 w-4 transition-transform ${dir === "asc" ? "rotate-180" : ""}`}
+          />
         </Button>
 
         {/* View toggle */}

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -104,7 +104,8 @@ export function SkillsIndex() {
           {/* Results count */}
           {!model.isLoadingSkills && model.sorted.length > 0 && (
             <p className="text-xs font-medium text-[color:var(--ink-soft)]">
-              Showing {model.sorted.length}{totalSkillsText ? ` of ${totalSkillsText}` : ""} skills
+              Showing {model.sorted.length}
+              {totalSkillsText ? ` of ${totalSkillsText}` : ""} skills
               {model.hasQuery ? ` matching "${model.query}"` : ""}
             </p>
           )}

--- a/src/routes/souls/index.tsx
+++ b/src/routes/souls/index.tsx
@@ -115,9 +115,7 @@ function SoulsIndex() {
       <Container>
         <header className="flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <h1 className="font-display text-2xl font-bold text-[color:var(--ink)] mb-2">
-              Souls
-            </h1>
+            <h1 className="font-display text-2xl font-bold text-[color:var(--ink)] mb-2">Souls</h1>
             <p className="text-sm text-[color:var(--ink-soft)]">
               {isLoadingSouls
                 ? "Loading souls..."
@@ -126,7 +124,10 @@ function SoulsIndex() {
           </div>
           <div className="flex flex-col gap-3 sm:items-end">
             <div className="relative flex items-center">
-              <Search className="pointer-events-none absolute left-3 h-4 w-4 text-[color:var(--ink-soft)] opacity-50" aria-hidden="true" />
+              <Search
+                className="pointer-events-none absolute left-3 h-4 w-4 text-[color:var(--ink-soft)] opacity-50"
+                aria-hidden="true"
+              />
               <Input
                 ref={searchInputRef}
                 className="pl-9"
@@ -235,10 +236,14 @@ function SoulsIndex() {
                 >
                   <div className="flex min-w-0 flex-col gap-1">
                     <div className="flex items-center gap-2">
-                      <span className="font-display font-bold text-[color:var(--ink)]">{soul.displayName}</span>
+                      <span className="font-display font-bold text-[color:var(--ink)]">
+                        {soul.displayName}
+                      </span>
                       <span className="text-sm text-[color:var(--ink-soft)]">/{soul.slug}</span>
                     </div>
-                    <div className="text-sm text-[color:var(--ink-soft)]">{soul.summary ?? "SOUL.md bundle."}</div>
+                    <div className="text-sm text-[color:var(--ink-soft)]">
+                      {soul.summary ?? "SOUL.md bundle."}
+                    </div>
                   </div>
                   <div className="flex shrink-0 items-center gap-4">
                     <SoulMetricsRow stats={soul.stats} />

--- a/src/routes/stars.tsx
+++ b/src/routes/stars.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { Star } from "lucide-react";
 import { useMutation, useQuery } from "convex/react";
+import { Star } from "lucide-react";
 import { toast } from "sonner";
 import { api } from "../../convex/_generated/api";
 import type { Doc } from "../../convex/_generated/dataModel";
@@ -42,8 +42,12 @@ function Stars() {
       <Container size="narrow">
         <div className="flex flex-col gap-6">
           <header>
-            <h1 className="font-display text-2xl font-bold text-[color:var(--ink)]">Your highlights</h1>
-            <p className="mt-1 text-sm text-[color:var(--ink-soft)]">Skills you've starred for quick access.</p>
+            <h1 className="font-display text-2xl font-bold text-[color:var(--ink)]">
+              Your highlights
+            </h1>
+            <p className="mt-1 text-sm text-[color:var(--ink-soft)]">
+              Skills you've starred for quick access.
+            </p>
           </header>
           {skills.length === 0 ? (
             <EmptyState
@@ -61,7 +65,11 @@ function Stars() {
                     key={skill._id}
                     className="flex w-full flex-col gap-3 rounded-[var(--radius-md)] border border-[color:var(--line)] bg-[color:var(--surface)] p-[22px] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_12px_28px_rgba(29,26,23,0.12)]"
                   >
-                    <Link to="/$owner/$slug" params={{ owner, slug: skill.slug }} className="no-underline">
+                    <Link
+                      to="/$owner/$slug"
+                      params={{ owner, slug: skill.slug }}
+                      className="no-underline"
+                    >
                       <h3 className="font-display text-base font-bold text-[color:var(--ink)] hover:text-[color:var(--accent)]">
                         {skill.displayName}
                       </h3>

--- a/src/routes/u/$handle.tsx
+++ b/src/routes/u/$handle.tsx
@@ -7,9 +7,9 @@ import { api } from "../../../convex/_generated/api";
 import type { Doc } from "../../../convex/_generated/dataModel";
 import { EmptyState } from "../../components/EmptyState";
 import { Container } from "../../components/layout/Container";
+import { SkillCardSkeletonGrid } from "../../components/skeletons/SkillCardSkeleton";
 import { SkillCard } from "../../components/SkillCard";
 import { SkillStatsTripletLine } from "../../components/SkillStats";
-import { SkillCardSkeletonGrid } from "../../components/skeletons/SkillCardSkeleton";
 import { Avatar, AvatarFallback, AvatarImage } from "../../components/ui/avatar";
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
@@ -96,7 +96,9 @@ function UserProfile() {
               <AvatarFallback className="text-xl">{initial}</AvatarFallback>
             </Avatar>
             <div>
-              <h1 className="font-display text-xl font-bold text-[color:var(--ink)]">{displayName}</h1>
+              <h1 className="font-display text-xl font-bold text-[color:var(--ink)]">
+                {displayName}
+              </h1>
               <p className="font-mono text-sm text-[color:var(--ink-soft)]">@{displayHandle}</p>
             </div>
           </Card>
@@ -154,7 +156,9 @@ function PublishedAndStarred({
       {/* Published */}
       <section>
         <h2 className="font-display text-lg font-bold text-[color:var(--ink)]">Published</h2>
-        <p className="mt-1 mb-4 text-sm text-[color:var(--ink-soft)]">Skills published by this user.</p>
+        <p className="mt-1 mb-4 text-sm text-[color:var(--ink-soft)]">
+          Skills published by this user.
+        </p>
         {isLoadingPublished ? (
           <SkillCardSkeletonGrid count={3} />
         ) : published.length > 0 ? (
@@ -181,7 +185,9 @@ function PublishedAndStarred({
       {/* Stars */}
       <section>
         <h2 className="font-display text-lg font-bold text-[color:var(--ink)]">Stars</h2>
-        <p className="mt-1 mb-4 text-sm text-[color:var(--ink-soft)]">Skills this user has starred.</p>
+        <p className="mt-1 mb-4 text-sm text-[color:var(--ink-soft)]">
+          Skills this user has starred.
+        </p>
         {isLoadingSkills ? (
           <SkillCardSkeletonGrid count={3} />
         ) : skills.length === 0 ? (
@@ -295,7 +301,9 @@ function InstalledSection(props: {
                 <Badge variant="default">{root.skills.length} skills</Badge>
               </div>
               {root.skills.length === 0 ? (
-                <p className="text-sm text-[color:var(--ink-soft)]">No skills found in this root.</p>
+                <p className="text-sm text-[color:var(--ink-soft)]">
+                  No skills found in this root.
+                </p>
               ) : (
                 <div className="flex flex-col gap-1">
                   {root.skills.map((entry) => (


### PR DESCRIPTION
## Summary
- Apply consistent formatting (line wrapping, import ordering, indentation) across frontend components, routes, Convex functions, CLI, and tests using Biome/Prettier conventions.
- Add CHANGELOG entry for v0.10.0 documenting all design system, API, and management changes shipped in prior PRs.

**No logic, behavior, or runtime changes.** All functional work (design system primitives, API routing fixes, auth changes, capability-tags restoration, management improvements) landed in PR #1527. This PR is the formatting/linting cleanup that followed.

Reviewers: use GitHub's **"Hide whitespace changes"** toggle to confirm the diff is style-only.

## Test plan
- [ ] Verify `bun run test` passes (all 928 tests)
- [ ] Verify `bun run lint` passes
- [ ] Spot-check a few files with "Hide whitespace" to confirm no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)