### PR TITLE
Add capability tag filtering to skills browse

### DIFF
--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -345,6 +345,55 @@ describe("search helpers", () => {
     expect(result[0].skill.slug).toBe("downloader-1");
   });
 
+  it("filters vector search results by capability tag", async () => {
+    generateEmbeddingMock.mockResolvedValueOnce([0, 1, 2]);
+
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce([
+        {
+          embeddingId: "skillEmbeddings:crypto",
+          skill: makePublicSkill({
+            id: "skills:crypto",
+            slug: "wallet-helper",
+            displayName: "Wallet Helper",
+            capabilityTags: ["crypto", "requires-wallet"],
+          }),
+          version: null,
+          ownerHandle: "owner",
+          owner: null,
+        },
+        {
+          embeddingId: "skillEmbeddings:oauth",
+          skill: makePublicSkill({
+            id: "skills:oauth",
+            slug: "x-poster",
+            displayName: "X Poster",
+            capabilityTags: ["requires-oauth-token", "posts-externally"],
+          }),
+          version: null,
+          ownerHandle: "owner",
+          owner: null,
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const result = await searchSkillsHandler(
+      {
+        vectorSearch: vi.fn().mockResolvedValue([
+          { _id: "skillEmbeddings:crypto", _score: 0.9 },
+          { _id: "skillEmbeddings:oauth", _score: 0.8 },
+        ]),
+        runQuery,
+      },
+      { query: "helper", limit: 10, capabilityTag: "crypto" },
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].skill.slug).toBe("wallet-helper");
+  });
+
   it("deduplicates exact slug injection against vector exact matches", async () => {
     generateEmbeddingMock.mockResolvedValueOnce([0, 1, 2]);
 
@@ -824,6 +873,7 @@ function makePublicSkill(params: {
   slug: string;
   displayName: string;
   downloads?: number;
+  capabilityTags?: string[];
 }) {
   return {
     _id: params.id,
@@ -836,6 +886,7 @@ function makePublicSkill(params: {
     forkOf: undefined,
     latestVersionId: "skillVersions:1",
     tags: {},
+    capabilityTags: params.capabilityTags,
     badges: {},
     stats: {
       downloads: params.downloads ?? 0,

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -7,6 +7,7 @@ import { isSkillHighlighted } from "./lib/badges";
 import { generateEmbedding } from "./lib/embeddings";
 import type { HydratableSkill, PublicPublisher } from "./lib/public";
 import { toPublicPublisher, toPublicSkill, toPublicSoul } from "./lib/public";
+import { SKILL_CAPABILITY_TAGS } from "./lib/skillCapabilityTags";
 import { getOwnerPublisher } from "./lib/publishers";
 import { matchesExactTokens, tokenize } from "./lib/searchText";
 import { isSkillSuspicious } from "./lib/skillSafety";
@@ -51,6 +52,7 @@ const NAME_EXACT_BOOST = 1.1;
 const NAME_PREFIX_BOOST = 0.6;
 const POPULARITY_WEIGHT = 0.08;
 const FALLBACK_SCAN_LIMIT = 500;
+const SKILL_CAPABILITY_TAG_SET = new Set<string>(SKILL_CAPABILITY_TAGS);
 
 function getNextCandidateLimit(current: number, max: number) {
   const next = Math.min(current * 2, max);
@@ -120,16 +122,26 @@ function isSlugLikeQuery(query: string) {
   return /^[a-z0-9][a-z0-9-]*$/.test(query.trim().toLowerCase());
 }
 
+function matchesCapabilityTag(
+  skill: Pick<HydratableSkill, "capabilityTags">,
+  capabilityTag?: string,
+) {
+  if (!capabilityTag) return true;
+  return (skill.capabilityTags ?? []).includes(capabilityTag);
+}
+
 export const searchSkills: ReturnType<typeof action> = action({
   args: {
     query: v.string(),
     limit: v.optional(v.number()),
     highlightedOnly: v.optional(v.boolean()),
     nonSuspiciousOnly: v.optional(v.boolean()),
+    capabilityTag: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<SearchResult[]> => {
     const query = args.query.trim();
     if (!query) return [];
+    if (args.capabilityTag && !SKILL_CAPABILITY_TAG_SET.has(args.capabilityTag)) return [];
     const queryTokens = tokenize(query);
     if (queryTokens.length === 0) return [];
     const rawExactSlugMatch = isSlugLikeQuery(query)
@@ -139,7 +151,9 @@ export const searchSkills: ReturnType<typeof action> = action({
         })) as SkillSearchEntry | null)
       : null;
     const exactSlugMatch =
-      rawExactSlugMatch && (!args.highlightedOnly || isSkillHighlighted(rawExactSlugMatch.skill))
+      rawExactSlugMatch &&
+      (!args.highlightedOnly || isSkillHighlighted(rawExactSlugMatch.skill)) &&
+      matchesCapabilityTag(rawExactSlugMatch.skill, args.capabilityTag)
         ? rawExactSlugMatch
         : null;
     let vector: number[];
@@ -185,9 +199,11 @@ export const searchSkills: ReturnType<typeof action> = action({
 
       // Skills already have badges from their docs (via toPublicSkill).
       // No need for a separate badge table lookup.
-      const filtered = args.highlightedOnly
-        ? hydrated.filter((entry) => isSkillHighlighted(entry.skill))
-        : hydrated;
+      const filtered = hydrated.filter(
+        (entry) =>
+          (!args.highlightedOnly || isSkillHighlighted(entry.skill)) &&
+          matchesCapabilityTag(entry.skill, args.capabilityTag),
+      );
 
       exactMatches = filtered.filter((entry) =>
         matchesExactTokens(queryTokens, [
@@ -219,6 +235,7 @@ export const searchSkills: ReturnType<typeof action> = action({
             limit: Math.min(Math.max(limit * 4, 200), FALLBACK_SCAN_LIMIT),
             highlightedOnly: args.highlightedOnly,
             nonSuspiciousOnly: args.nonSuspiciousOnly,
+            capabilityTag: args.capabilityTag,
             skipExactSlugLookup: true,
           })) as SkillSearchEntry[]);
     const mergedMatches = mergeUniqueBySkillId(primaryMatches, fallbackMatches);
@@ -330,9 +347,11 @@ export const lexicalFallbackSkills = internalQuery({
     limit: v.optional(v.number()),
     highlightedOnly: v.optional(v.boolean()),
     nonSuspiciousOnly: v.optional(v.boolean()),
+    capabilityTag: v.optional(v.string()),
     skipExactSlugLookup: v.optional(v.boolean()),
   },
   handler: async (ctx, args): Promise<SkillSearchEntry[]> => {
+    if (args.capabilityTag && !SKILL_CAPABILITY_TAG_SET.has(args.capabilityTag)) return [];
     const limit = Math.min(Math.max(args.limit ?? 200, 10), FALLBACK_SCAN_LIMIT);
     const seenSkillIds = new Set<Id<"skills">>();
     const candidates: HydratableSkill[] = [];
@@ -352,7 +371,8 @@ export const lexicalFallbackSkills = internalQuery({
       if (
         exactSlugSkill &&
         !exactSlugSkill.softDeletedAt &&
-        (!args.nonSuspiciousOnly || !isSkillSuspicious(exactSlugSkill))
+        (!args.nonSuspiciousOnly || !isSkillSuspicious(exactSlugSkill)) &&
+        matchesCapabilityTag(exactSlugSkill, args.capabilityTag)
       ) {
         seenSkillIds.add(exactSlugSkill._id);
         candidates.push(exactSlugSkill);
@@ -370,6 +390,7 @@ export const lexicalFallbackSkills = internalQuery({
       if (seenSkillIds.has(digest.skillId)) continue;
       const skill = digestToHydratableSkill(digest);
       if (args.nonSuspiciousOnly && isSkillSuspicious(skill)) continue;
+      if (!matchesCapabilityTag(skill, args.capabilityTag)) continue;
       seenSkillIds.add(digest.skillId);
       candidates.push(skill);
       // Pre-resolve owner from digest to avoid users table reads.

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -323,6 +323,8 @@ const NONSUSPICIOUS_SORT_INDEXES = {
   stars: "by_nonsuspicious_stars",
   installs: "by_nonsuspicious_installs",
 } as const;
+const MAX_FILTERED_PUBLIC_LIST_SCAN_PAGES = 12;
+const MAX_FILTERED_PUBLIC_LIST_SCAN_ROWS = 500;
 
 function isSkillVersionId(
   value: Id<"skillVersions"> | null | undefined,
@@ -2694,8 +2696,12 @@ export const listPublicPageV4 = query({
     dir: v.optional(v.union(v.literal("asc"), v.literal("desc"))),
     highlightedOnly: v.optional(v.boolean()),
     nonSuspiciousOnly: v.optional(v.boolean()),
+    capabilityTag: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
+    if (args.capabilityTag && !isKnownSkillCapabilityTag(args.capabilityTag)) {
+      return { page: [], hasMore: false, nextCursor: null };
+    }
     const sort = args.sort ?? "newest";
     const dir = args.dir ?? (sort === "name" ? "asc" : "desc");
     const numItems = clampInt(args.numItems ?? 25, 1, MAX_PUBLIC_LIST_LIMIT);
@@ -2708,6 +2714,7 @@ export const listPublicPageV4 = query({
         sort,
         dir,
         numItems,
+        capabilityTag: args.capabilityTag,
         nonSuspiciousOnly: args.nonSuspiciousOnly ?? false,
       });
     }
@@ -2724,45 +2731,104 @@ export const listPublicPageV4 = query({
     const isFirstPage = !decodedCursor;
     const startIndexKey: IndexKey = decodedCursor ?? eqPrefix;
 
-    const result = await getPage(ctx, {
-      table: "skillSearchDigest",
-      startIndexKey,
-      startInclusive: isFirstPage,
-      endIndexKey: eqPrefix,
-      endInclusive: true,
-      absoluteMaxRows: numItems,
-      order: dir,
-      index: indexName,
-      schema,
-    });
-
-    // Build PublicSkillEntry[] from digests
-    const items: PublicSkillEntry[] = [];
-    for (const digest of result.page) {
-      const hydratable = digestToHydratableSkill(digest);
-      const publicSkill = toPublicSkill(hydratable);
-      if (!publicSkill) continue;
-      const ownerInfo = digestToOwnerInfo(digest);
-      if (!ownerInfo?.owner) continue;
-      const latestVersion = digest.latestVersionSummary
-        ? toPublicSkillListVersionFromSummary(digest.latestVersionSummary, digest.latestVersionId)
-        : null;
-      items.push({
-        skill: publicSkill,
-        latestVersion,
-        ownerHandle: ownerInfo.ownerHandle,
-        owner: ownerInfo.owner,
+    if (!args.capabilityTag) {
+      const result = await getPage(ctx, {
+        table: "skillSearchDigest",
+        startIndexKey,
+        startInclusive: isFirstPage,
+        endIndexKey: eqPrefix,
+        endInclusive: true,
+        absoluteMaxRows: numItems,
+        order: dir,
+        index: indexName,
+        schema,
       });
+
+      const items = result.page
+        .map((digest) => buildPublicSkillEntryFromDigest(digest))
+        .filter((item): item is PublicSkillEntry => item !== null);
+      let nextCursor: string | null = null;
+      if (result.hasMore && result.indexKeys.length > 0) {
+        nextCursor = encodeIndexKey(result.indexKeys[result.indexKeys.length - 1]);
+      }
+
+      return { page: items, hasMore: result.hasMore, nextCursor };
     }
 
+    const items: PublicSkillEntry[] = [];
+    let scanCursor = startIndexKey;
+    let scanInclusive = isFirstPage;
+    let hasMore = false;
     let nextCursor: string | null = null;
-    if (result.hasMore && result.indexKeys.length > 0) {
-      nextCursor = encodeIndexKey(result.indexKeys[result.indexKeys.length - 1]);
+    let remainingRows = Math.max(numItems, Math.min(MAX_FILTERED_PUBLIC_LIST_SCAN_ROWS, numItems * 12));
+
+    for (let pageCount = 0; pageCount < MAX_FILTERED_PUBLIC_LIST_SCAN_PAGES; pageCount += 1) {
+      if (remainingRows <= 0) break;
+      const batchSize = Math.min(remainingRows, Math.max(numItems * 3, numItems));
+      const result = await getPage(ctx, {
+        table: "skillSearchDigest",
+        startIndexKey: scanCursor,
+        startInclusive: scanInclusive,
+        endIndexKey: eqPrefix,
+        endInclusive: true,
+        absoluteMaxRows: batchSize,
+        order: dir,
+        index: indexName,
+        schema,
+      });
+      remainingRows -= batchSize;
+      if (result.indexKeys.length === 0) {
+        hasMore = false;
+        nextCursor = null;
+        break;
+      }
+
+      for (let index = 0; index < result.page.length; index += 1) {
+        const digest = result.page[index];
+        const cursor = result.indexKeys[index];
+        if ((digest.capabilityTags ?? []).includes(args.capabilityTag)) {
+          const item = buildPublicSkillEntryFromDigest(digest);
+          if (item) items.push(item);
+        }
+        if (items.length >= numItems) {
+          hasMore = result.hasMore || index < result.page.length - 1;
+          nextCursor = hasMore ? encodeIndexKey(cursor) : null;
+          return { page: items, hasMore, nextCursor };
+        }
+      }
+
+      if (!result.hasMore) {
+        hasMore = false;
+        nextCursor = null;
+        break;
+      }
+
+      scanCursor = result.indexKeys[result.indexKeys.length - 1];
+      scanInclusive = false;
+      hasMore = true;
+      nextCursor = encodeIndexKey(scanCursor);
     }
 
-    return { page: items, hasMore: result.hasMore, nextCursor };
+    return { page: items, hasMore, nextCursor };
   },
 });
+
+function buildPublicSkillEntryFromDigest(digest: Doc<"skillSearchDigest">): PublicSkillEntry | null {
+  const hydratable = digestToHydratableSkill(digest);
+  const publicSkill = toPublicSkill(hydratable);
+  if (!publicSkill) return null;
+  const ownerInfo = digestToOwnerInfo(digest);
+  if (!ownerInfo?.owner) return null;
+  const latestVersion = digest.latestVersionSummary
+    ? toPublicSkillListVersionFromSummary(digest.latestVersionSummary, digest.latestVersionId)
+    : null;
+  return {
+    skill: publicSkill,
+    latestVersion,
+    ownerHandle: ownerInfo.ownerHandle,
+    owner: ownerInfo.owner,
+  };
+}
 
 type PublicSkillCatalogItem = {
   name: string;
@@ -3060,6 +3126,7 @@ async function fetchHighlightedPage(
     sort: SortKey;
     dir: "asc" | "desc";
     numItems: number;
+    capabilityTag?: string;
     nonSuspiciousOnly: boolean;
   },
 ) {
@@ -3079,6 +3146,7 @@ async function fetchHighlightedPage(
       .unique();
     if (!digest || digest.softDeletedAt) continue;
     if (opts.nonSuspiciousOnly && digest.isSuspicious) continue;
+    if (opts.capabilityTag && !(digest.capabilityTags ?? []).includes(opts.capabilityTag)) continue;
     digests.push(digest);
   }
 
@@ -3105,23 +3173,9 @@ async function fetchHighlightedPage(
   const trimmed = digests.slice(0, opts.numItems);
 
   // Build PublicSkillEntry[]
-  const items: PublicSkillEntry[] = [];
-  for (const digest of trimmed) {
-    const hydratable = digestToHydratableSkill(digest);
-    const publicSkill = toPublicSkill(hydratable);
-    if (!publicSkill) continue;
-    const ownerInfo = digestToOwnerInfo(digest);
-    if (!ownerInfo?.owner) continue;
-    const latestVersion = digest.latestVersionSummary
-      ? toPublicSkillListVersionFromSummary(digest.latestVersionSummary, digest.latestVersionId)
-      : null;
-    items.push({
-      skill: publicSkill,
-      latestVersion,
-      ownerHandle: ownerInfo.ownerHandle,
-      owner: ownerInfo.owner,
-    });
-  }
+  const items = trimmed
+    .map((digest) => buildPublicSkillEntryFromDigest(digest))
+    .filter((item): item is PublicSkillEntry => item !== null);
 
   // Highlighted skills are few enough to return in one page — no cursor needed
   return { page: items, hasMore: false, nextCursor: null };

--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -288,6 +288,19 @@ describe("SkillsIndex", () => {
     );
   });
 
+  it("passes capabilityTag to list query when tag filter is active", async () => {
+    searchMock = { tag: "crypto" };
+    render(<SkillsIndex />);
+    await act(async () => {});
+
+    expect(convexHttpMock.query).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        capabilityTag: "crypto",
+      }),
+    );
+  });
+
   it("shows load-more button when more results are available", async () => {
     vi.stubGlobal("IntersectionObserver", undefined);
     convexHttpMock.query.mockResolvedValue({

--- a/src/__tests__/skills-route-default-sort.test.ts
+++ b/src/__tests__/skills-route-default-sort.test.ts
@@ -49,6 +49,7 @@ describe("skills route default sort", () => {
           dir: undefined,
           highlighted: undefined,
           nonSuspicious: true,
+          tag: undefined,
           view: undefined,
           focus: undefined,
         },

--- a/src/routes/skills/-SkillsToolbar.tsx
+++ b/src/routes/skills/-SkillsToolbar.tsx
@@ -1,5 +1,6 @@
 import { ArrowDownUp, Check, Grid3X3, List, Search, X } from "lucide-react";
 import type { RefObject } from "react";
+import { SKILL_CAPABILITY_TAGS } from "../../../convex/lib/skillCapabilityTags";
 import { Button } from "../../components/ui/button";
 import { Input } from "../../components/ui/input";
 import {
@@ -20,12 +21,23 @@ type SkillsToolbarProps = {
   view: "cards" | "list";
   highlightedOnly: boolean;
   nonSuspiciousOnly: boolean;
+  capabilityTag?: string;
   onQueryChange: (next: string) => void;
   onToggleHighlighted: () => void;
   onToggleNonSuspicious: () => void;
+  onCapabilityTagChange: (value: string) => void;
   onSortChange: (value: string) => void;
   onToggleDir: () => void;
   onToggleView: () => void;
+};
+
+const SKILL_CAPABILITY_LABELS: Record<string, string> = {
+  crypto: "Crypto",
+  "requires-wallet": "Requires wallet",
+  "can-make-purchases": "Payments",
+  "can-sign-transactions": "Signs transactions",
+  "requires-oauth-token": "OAuth",
+  "posts-externally": "External posting",
 };
 
 export function SkillsToolbar({
@@ -37,9 +49,11 @@ export function SkillsToolbar({
   view,
   highlightedOnly,
   nonSuspiciousOnly,
+  capabilityTag,
   onQueryChange,
   onToggleHighlighted,
   onToggleNonSuspicious,
+  onCapabilityTagChange,
   onSortChange,
   onToggleDir,
   onToggleView,
@@ -77,6 +91,22 @@ export function SkillsToolbar({
         <FilterChip active={nonSuspiciousOnly} onClick={onToggleNonSuspicious}>
           Clean only
         </FilterChip>
+        <Select value={capabilityTag ?? "__all__"} onValueChange={onCapabilityTagChange}>
+          <SelectTrigger
+            className="w-auto min-w-[156px] min-h-[36px] py-1.5 text-xs font-semibold"
+            aria-label="Filter by tag"
+          >
+            <SelectValue placeholder="All tags" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All tags</SelectItem>
+            {SKILL_CAPABILITY_TAGS.map((tag) => (
+              <SelectItem key={tag} value={tag}>
+                {SKILL_CAPABILITY_LABELS[tag] ?? tag}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
 
         {/* Spacer */}
         <div className="ml-auto" />

--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -15,8 +15,18 @@ export type SkillsSearchState = {
   dir?: SortDir;
   highlighted?: boolean;
   nonSuspicious?: boolean;
+  tag?: string;
   view?: SkillsView;
   focus?: "search";
+};
+
+const SKILL_CAPABILITY_LABELS: Record<string, string> = {
+  crypto: "crypto",
+  "requires-wallet": "requires wallet",
+  "can-make-purchases": "payments",
+  "can-sign-transactions": "signs transactions",
+  "requires-oauth-token": "oauth",
+  "posts-externally": "external posting",
 };
 
 type SkillsNavigate = (options: {
@@ -47,6 +57,7 @@ export function useSkillsBrowseModel({
   const view: SkillsView = search.view ?? "list";
   const highlightedOnly = search.highlighted ?? false;
   const nonSuspiciousOnly = search.nonSuspicious ?? false;
+  const capabilityTag = search.tag;
   const searchSkills = useAction(api.search.searchSkills);
 
   const trimmedQuery = useMemo(() => query.trim(), [query]);
@@ -58,7 +69,7 @@ export function useSkillsBrowseModel({
   const listSort = toListSort(sort);
   const dir = parseDir(search.dir, sort);
   const searchKey = trimmedQuery
-    ? `${trimmedQuery}::${highlightedOnly ? "1" : "0"}::${nonSuspiciousOnly ? "1" : "0"}`
+    ? `${trimmedQuery}::${highlightedOnly ? "1" : "0"}::${nonSuspiciousOnly ? "1" : "0"}::${capabilityTag ?? ""}`
     : "";
 
   // One-shot paginated fetches (no reactive subscription)
@@ -77,6 +88,7 @@ export function useSkillsBrowseModel({
           dir,
           highlightedOnly,
           nonSuspiciousOnly,
+          capabilityTag,
         });
         if (generation !== fetchGeneration.current) return;
         setListResults((prev) => (cursor ? [...prev, ...result.page] : result.page));
@@ -90,7 +102,7 @@ export function useSkillsBrowseModel({
         setListStatus(cursor ? "idle" : "done");
       }
     },
-    [listSort, dir, highlightedOnly, nonSuspiciousOnly],
+    [capabilityTag, dir, highlightedOnly, listSort, nonSuspiciousOnly],
   );
 
   // Reset and fetch first page when sort/dir/filters change
@@ -142,6 +154,7 @@ export function useSkillsBrowseModel({
             query: trimmedQuery,
             highlightedOnly,
             nonSuspiciousOnly,
+            capabilityTag,
             limit: searchLimit,
           })) as Array<SkillSearchEntry>;
           if (requestId === searchRequest.current) {
@@ -155,7 +168,15 @@ export function useSkillsBrowseModel({
       })();
     }, 220);
     return () => window.clearTimeout(handle);
-  }, [hasQuery, highlightedOnly, nonSuspiciousOnly, searchLimit, searchSkills, trimmedQuery]);
+  }, [
+    capabilityTag,
+    hasQuery,
+    highlightedOnly,
+    nonSuspiciousOnly,
+    searchLimit,
+    searchSkills,
+    trimmedQuery,
+  ]);
 
   const baseItems = useMemo(() => {
     if (hasQuery) {
@@ -347,9 +368,24 @@ export function useSkillsBrowseModel({
   const activeFilters: string[] = [];
   if (highlightedOnly) activeFilters.push("highlighted");
   if (nonSuspiciousOnly) activeFilters.push("non-suspicious");
+  if (capabilityTag) activeFilters.push(SKILL_CAPABILITY_LABELS[capabilityTag] ?? capabilityTag);
+
+  const onCapabilityTagChange = useCallback(
+    (value: string) => {
+      void navigate({
+        search: (prev) => ({
+          ...prev,
+          tag: value === "__all__" ? undefined : value,
+        }),
+        replace: true,
+      });
+    },
+    [navigate],
+  );
 
   return {
     activeFilters,
+    capabilityTag,
     canAutoLoad,
     canLoadMore,
     dir,
@@ -360,6 +396,7 @@ export function useSkillsBrowseModel({
     loadMore,
     loadMoreRef,
     nonSuspiciousOnly,
+    onCapabilityTagChange,
     onQueryChange,
     onSortChange,
     onToggleDir,

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -2,11 +2,14 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
 import { useRef } from "react";
 import { api } from "../../../convex/_generated/api";
+import { SKILL_CAPABILITY_TAGS } from "../../../convex/lib/skillCapabilityTags";
 import { Container } from "../../components/layout/Container";
 import { parseSort } from "./-params";
 import { SkillsResults } from "./-SkillsResults";
 import { SkillsToolbar } from "./-SkillsToolbar";
 import { useSkillsBrowseModel, type SkillsSearchState } from "./-useSkillsBrowseModel";
+
+const SKILL_CAPABILITY_TAG_SET = new Set<string>(SKILL_CAPABILITY_TAGS);
 
 export const Route = createFileRoute("/skills/")({
   validateSearch: (search): SkillsSearchState => {
@@ -24,6 +27,10 @@ export const Route = createFileRoute("/skills/")({
         search.nonSuspicious === true
           ? true
           : undefined,
+      tag:
+        typeof search.tag === "string" && SKILL_CAPABILITY_TAG_SET.has(search.tag)
+          ? search.tag
+          : undefined,
       view: search.view === "cards" || search.view === "list" ? search.view : undefined,
       focus: search.focus === "search" ? "search" : undefined,
     };
@@ -39,6 +46,7 @@ export const Route = createFileRoute("/skills/")({
         dir: search.dir || undefined,
         highlighted: search.highlighted || undefined,
         nonSuspicious: search.nonSuspicious || undefined,
+        tag: search.tag || undefined,
         view: search.view || undefined,
         focus: search.focus || undefined,
       },
@@ -93,9 +101,11 @@ export function SkillsIndex() {
             view={model.view}
             highlightedOnly={model.highlightedOnly}
             nonSuspiciousOnly={model.nonSuspiciousOnly}
+            capabilityTag={model.capabilityTag}
             onQueryChange={model.onQueryChange}
             onToggleHighlighted={model.onToggleHighlighted}
             onToggleNonSuspicious={model.onToggleNonSuspicious}
+            onCapabilityTagChange={model.onCapabilityTagChange}
             onSortChange={model.onSortChange}
             onToggleDir={model.onToggleDir}
             onToggleView={model.onToggleView}


### PR DESCRIPTION
## Summary
- Adds a capability tag filter to the Skills browse toolbar and wires it through route state and browse fetching.
- Filters both search and public list queries by selected capability tag, including validation of known tags.
- Updates unit tests to cover query propagation and tag-filtered search behavior.

## Testing
- `Not run`