### PR TITLE
fix: unify download count icon to ArrowDownToLine across all pages

### DIFF
--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -4,7 +4,7 @@ import {
   PLATFORM_SKILL_LICENSE,
   PLATFORM_SKILL_LICENSE_SUMMARY,
 } from "clawhub-schema/licenseConstants";
-import { Package } from "lucide-react";
+import { ArrowDownToLine } from "lucide-react";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
 import { getSkillBadges } from "../lib/badges";
 import { formatCompactStat, formatSkillStatsTriplet } from "../lib/numberFormat";
@@ -229,7 +229,7 @@ export function SkillHeader({
                     </span>
                     <span className="text-[color:var(--ink-soft)] opacity-40">·</span>
                     <span className="flex items-center gap-1 text-sm text-[color:var(--ink-soft)]">
-                      <Package size={14} aria-hidden="true" /> {formattedStats.downloads}
+                      <ArrowDownToLine size={14} aria-hidden="true" /> {formattedStats.downloads}
                     </span>
                     <span className="text-[color:var(--ink-soft)] opacity-40">·</span>
                     <span className="text-sm text-[color:var(--ink-soft)]">

--- a/src/components/SkillStats.tsx
+++ b/src/components/SkillStats.tsx
@@ -1,4 +1,4 @@
-import { Package } from "lucide-react";
+import { ArrowDownToLine } from "lucide-react";
 import { formatSkillStatsTriplet, type SkillStatsTriplet } from "../lib/numberFormat";
 
 type SkillMetricsStats = SkillStatsTriplet & {
@@ -9,7 +9,7 @@ export function SkillStatsTripletLine({ stats }: { stats: SkillStatsTriplet }) {
   const formatted = formatSkillStatsTriplet(stats);
   return (
     <>
-      ⭐ {formatted.stars} · <Package size={13} aria-hidden="true" /> {formatted.downloads}
+      ⭐ {formatted.stars} · <ArrowDownToLine size={13} aria-hidden="true" /> {formatted.downloads}
     </>
   );
 }
@@ -19,7 +19,7 @@ export function SkillMetricsRow({ stats }: { stats: SkillMetricsStats }) {
   return (
     <>
       <span>
-        <Package size={13} aria-hidden="true" /> {formatted.downloads}
+        <ArrowDownToLine size={13} aria-hidden="true" /> {formatted.downloads}
       </span>
       <span>★ {formatted.stars}</span>
       <span>{stats.versions} v</span>

--- a/src/components/SoulStats.tsx
+++ b/src/components/SoulStats.tsx
@@ -1,4 +1,4 @@
-import { Package } from "lucide-react";
+import { ArrowDownToLine } from "lucide-react";
 import { formatSoulStatsTriplet, type SoulStatsTriplet } from "../lib/numberFormat";
 
 export function SoulStatsTripletLine({
@@ -11,7 +11,7 @@ export function SoulStatsTripletLine({
   const formatted = formatSoulStatsTriplet(stats);
   return (
     <>
-      ⭐ {formatted.stars} · <Package size={13} aria-hidden="true" /> {formatted.downloads} ·{" "}
+      ⭐ {formatted.stars} · <ArrowDownToLine size={13} aria-hidden="true" /> {formatted.downloads} ·{" "}
       {formatted.versions} {versionSuffix}
     </>
   );
@@ -22,7 +22,7 @@ export function SoulMetricsRow({ stats }: { stats: SoulStatsTriplet }) {
   return (
     <>
       <span>
-        <Package size={13} aria-hidden="true" /> {formatted.downloads}
+        <ArrowDownToLine size={13} aria-hidden="true" /> {formatted.downloads}
       </span>
       <span>★ {formatted.stars}</span>
       <span>{formatted.versions} v</span>


### PR DESCRIPTION
## Summary

The download count used different icons on different pages:
- **Publisher Dashboard**: ArrowDownToLine ↓ (correct, semantically clear)
- **Public skill detail page**: Package 📦 (ambiguous, looks like version count)

This PR replaces the Package icon with ArrowDownToLine in SkillStats, SoulStats, and SkillHeader components so the download metric is consistent everywhere.

## Changes
- `src/components/SkillStats.tsx`: Package → ArrowDownToLine
- `src/components/SoulStats.tsx`: Package → ArrowDownToLine
- `src/components/SkillHeader.tsx`: Package → ArrowDownToLine

Fixes #1534