### PR TITLE
fix: default workdir to ~/.openclaw instead of cwd

### DIFF
--- a/packages/clawhub/src/cli.ts
+++ b/packages/clawhub/src/cli.ts
@@ -104,7 +104,9 @@ async function resolveWorkdir(explicit?: string) {
   if (hasMarker) return cwd;
 
   const clawdbotWorkspace = await resolveClawdbotDefaultWorkspace();
-  return clawdbotWorkspace ? resolve(clawdbotWorkspace) : cwd;
+  if (clawdbotWorkspace) return resolve(clawdbotWorkspace);
+  // Default to ~/.openclaw instead of cwd to avoid mixing npm skills with custom skills
+  return resolve(process.env.HOME ?? "", ".openclaw");
 }
 
 async function hasClawhubMarker(workdir: string) {


### PR DESCRIPTION
## Problem

clawhub install defaults to cwd, which means where you run it from determines where skills land. Skills from two completely different sources (OpenClaw team bundled skills vs custom clawhub skills) end up mixed in one directory with no way to tell them apart.

## Solution

Change the default workdir fallback from `cwd` to `~/.openclaw`. Skills installed via clawhub now land in `~/.openclaw/<skill>` by default instead of `cwd/skills/`.

## Priority order (unchanged except for last item)

1. Explicit `--workdir` flag
2. `CLAWHUB_WORKDIR` / `CLAWDHUB_WORKDIR` env vars
3. `.clawhub` marker directory in cwd
4. clawdbot workspace (if set)
5. `~/.openclaw` (was `cwd`)