### PR TITLE
fix: flag destructive troubleshooting delete commands

### DIFF
--- a/convex/lib/moderationEngine.test.ts
+++ b/convex/lib/moderationEngine.test.ts
@@ -144,6 +144,291 @@ describe("moderationEngine", () => {
     expect(result.status).toBe("clean");
   });
 
+  it("flags destructive rm -rf troubleshooting commands without confirmation", () => {
+    const result = runStaticModerationScan({
+      slug: "stt-simple",
+      displayName: "STT Simple",
+      summary: "Simple speech-to-text setup",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "SKILL.md", size: 512 }],
+      fileContents: [
+        {
+          path: "SKILL.md",
+          content: [
+            "## Troubleshooting",
+            "",
+            "```bash",
+            "# Reinstall",
+            "rm -rf /root/.openclaw/venv/stt-simple",
+            "/root/.openclaw/workspace/skills/stt-simple/install.sh",
+            "```",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.destructive_delete_command");
+    expect(result.status).toBe("suspicious");
+    expect(
+      result.findings.find((finding) => finding.code === "suspicious.destructive_delete_command")
+        ?.message,
+    ).toContain("confirmation gate");
+  });
+
+  it("does not flag destructive rm -rf commands when confirmation is required nearby", () => {
+    const result = runStaticModerationScan({
+      slug: "stt-simple",
+      displayName: "STT Simple",
+      summary: "Simple speech-to-text setup",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "SKILL.md", size: 640 }],
+      fileContents: [
+        {
+          path: "SKILL.md",
+          content: [
+            "## Troubleshooting",
+            "Before reinstalling, ask the user for explicit confirmation.",
+            'Continue? (yes/no)',
+            "",
+            "```bash",
+            "# Reinstall",
+            "rm -rf /root/.openclaw/venv/stt-simple",
+            "/root/.openclaw/workspace/skills/stt-simple/install.sh",
+            "```",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).not.toContain("suspicious.destructive_delete_command");
+    expect(result.status).toBe("clean");
+  });
+
+  it("flags a later unguarded rm -rf even if an earlier one is confirmed", () => {
+    const result = runStaticModerationScan({
+      slug: "stt-simple",
+      displayName: "STT Simple",
+      summary: "Simple speech-to-text setup",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "SKILL.md", size: 768 }],
+      fileContents: [
+        {
+          path: "SKILL.md",
+          content: [
+            "## Troubleshooting",
+            "Ask the user for explicit confirmation first.",
+            "```bash",
+            "rm -rf /root/.openclaw/venv/stt-simple",
+            "```",
+            "",
+            "## Notes",
+            "More details",
+            "Extra detail",
+            "Another detail",
+            "Yet another detail",
+            "Still discussing",
+            "One more line",
+            "Second more line",
+            "## Rebuild again",
+            "```bash",
+            "rm -rf /root/.openclaw/cache/stt-simple",
+            "```",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.destructive_delete_command");
+    expect(
+      result.findings.find((finding) => finding.code === "suspicious.destructive_delete_command")
+        ?.line,
+    ).toBe(17);
+  });
+
+  it("flags destructive troubleshooting commands in untyped code fences", () => {
+    const result = runStaticModerationScan({
+      slug: "stt-simple",
+      displayName: "STT Simple",
+      summary: "Simple speech-to-text setup",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "SKILL.md", size: 512 }],
+      fileContents: [
+        {
+          path: "SKILL.md",
+          content: [
+            "## Troubleshooting",
+            "```",
+            "rm -rf /root/.openclaw/venv/stt-simple",
+            "```",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.destructive_delete_command");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("does not treat 'no confirmation required' as a confirmation gate", () => {
+    const result = runStaticModerationScan({
+      slug: "stt-simple",
+      displayName: "STT Simple",
+      summary: "Simple speech-to-text setup",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "SKILL.md", size: 512 }],
+      fileContents: [
+        {
+          path: "SKILL.md",
+          content: [
+            "## Troubleshooting",
+            "No confirmation required for this reinstall.",
+            "```bash",
+            "rm -rf /root/.openclaw/venv/stt-simple",
+            "```",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.destructive_delete_command");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("flags destructive troubleshooting commands that use '--' before the target", () => {
+    const result = runStaticModerationScan({
+      slug: "stt-simple",
+      displayName: "STT Simple",
+      summary: "Simple speech-to-text setup",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "SKILL.md", size: 512 }],
+      fileContents: [
+        {
+          path: "SKILL.md",
+          content: [
+            "## Troubleshooting",
+            "```bash",
+            "rm -rf -- /root/.openclaw/venv/stt-simple",
+            "```",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.destructive_delete_command");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("flags destructive troubleshooting commands when the target path is quoted", () => {
+    const result = runStaticModerationScan({
+      slug: "stt-simple",
+      displayName: "STT Simple",
+      summary: "Simple speech-to-text setup",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "SKILL.md", size: 512 }],
+      fileContents: [
+        {
+          path: "SKILL.md",
+          content: [
+            "## Troubleshooting",
+            "```bash",
+            'rm -rf "/root/.openclaw/venv/stt-simple"',
+            "```",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.destructive_delete_command");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("flags destructive troubleshooting commands when a later target is sensitive", () => {
+    const result = runStaticModerationScan({
+      slug: "stt-simple",
+      displayName: "STT Simple",
+      summary: "Simple speech-to-text setup",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "SKILL.md", size: 512 }],
+      fileContents: [
+        {
+          path: "SKILL.md",
+          content: [
+            "## Troubleshooting",
+            "```bash",
+            "rm -rf /tmp/stt-simple-cache /root/.openclaw/venv/stt-simple",
+            "```",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.destructive_delete_command");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("does not flag routine project cleanup commands outside troubleshooting context", () => {
+    const result = runStaticModerationScan({
+      slug: "frontend-build",
+      displayName: "Frontend Build",
+      summary: "Project setup helpers",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "SKILL.md", size: 512 }],
+      fileContents: [
+        {
+          path: "SKILL.md",
+          content: [
+            "## Build from scratch",
+            "",
+            "```bash",
+            "rm -rf node_modules dist",
+            "bun install",
+            "bun run build",
+            "```",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).not.toContain("suspicious.destructive_delete_command");
+    expect(result.status).toBe("clean");
+  });
+
+  it("does not flag troubleshooting cleanup for temp directories", () => {
+    const result = runStaticModerationScan({
+      slug: "temp-cleaner",
+      displayName: "Temp Cleaner",
+      summary: "Troubleshoot temp workspace issues",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "SKILL.md", size: 512 }],
+      fileContents: [
+        {
+          path: "SKILL.md",
+          content: [
+            "## Troubleshooting",
+            "",
+            "```bash",
+            "# Reinstall",
+            "rm -rf /tmp/stt-simple-cache",
+            "```",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).not.toContain("suspicious.destructive_delete_command");
+    expect(result.status).toBe("clean");
+  });
+
   it("flags hardcoded connection_id UUIDs in markdown examples", () => {
     const result = runStaticModerationScan({
       slug: "api-gateway",

--- a/convex/lib/moderationEngine.ts
+++ b/convex/lib/moderationEngine.ts
@@ -54,10 +54,15 @@ const GENERATED_SOURCE_PLACEHOLDER_PATTERN =
   /^\s*[A-Za-z_][A-Za-z0-9_]*\s*=.*["']\$\{[A-Za-z_][A-Za-z0-9_-]*\}["']/m;
 const GENERATED_SOURCE_CONTEXT_PATTERN =
   /```(?:python|py|javascript|js|typescript|ts|shell|bash|sh)\b|cat\s*(?:>|>>)?\s*[^`\n]*\.(?:py|js|ts|sh)\b|python3?\b|node\b/i;
+const RM_RF_PATTERN = /^\s*(?:sudo\s+)?rm\s+-[^\s]*r[^\s]*f[^\s]*\s+[^\n]+/gim;
+const TROUBLESHOOTING_REINSTALL_CONTEXT_PATTERN =
+  /troubleshooting|故障排查|reinstall|re-install|repair|reset|recovery|clean install|rebuild/i;
 const HARDCODED_CONNECTION_ID_PATTERN =
   /["']connection_id["']\s*:\s*["'][0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}["']/i;
 const GOOGLE_SHEETS_SPREADSHEET_URL_PATTERN =
   /https?:\/\/[^\s"'`]*\/spreadsheets\/([A-Za-z0-9_-]{20,})\/[^\s"'`]*/i;
+const CONFIRMATION_GATE_PATTERN =
+  /explicit(?:ly)?\s+confirm|ask\s+(?:the\s+)?user\s+(?:for\s+)?(?:explicit\s+)?confirmation|(?:require|requires)\s+(?:the\s+)?(?:user\s+)?confirmation|wait(?:ing)?\s+for\s+(?:the\s+)?(?:user\s+)?confirmation|continue\?\s*\(?(?:yes\/no|y\/n)\)?|reply\s+["']?yes["']?|only\s+after\s+(?:the\s+user\s+)?(?:repl(?:y|ies)|responds?)\s+["']?yes["']?/i;
 
 function hasMaliciousInstallPrompt(content: string) {
   const hasTerminalInstruction =
@@ -110,6 +115,45 @@ function findLineAtIndex(content: string, index: number) {
   const nextNewline = content.indexOf("\n", index);
   const lineEnd = nextNewline === -1 ? content.length : nextNewline;
   return { line, text: content.slice(lineStart, lineEnd) };
+}
+
+function hasNearbyConfirmationGate(content: string, index: number, contextLines = 8) {
+  const lines = content.split("\n");
+  const lineNumber = content.slice(0, index).split("\n").length - 1;
+  const start = Math.max(0, lineNumber - contextLines);
+  const end = Math.min(lines.length, lineNumber + contextLines + 1);
+  return CONFIRMATION_GATE_PATTERN.test(lines.slice(start, end).join("\n"));
+}
+
+function hasNearbyTroubleshootingContext(content: string, index: number, contextLines = 8) {
+  const lines = content.split("\n");
+  const lineNumber = content.slice(0, index).split("\n").length - 1;
+  const start = Math.max(0, lineNumber - contextLines);
+  const end = Math.min(lines.length, lineNumber + contextLines + 1);
+  return TROUBLESHOOTING_REINSTALL_CONTEXT_PATTERN.test(lines.slice(start, end).join("\n"));
+}
+
+function extractDeleteTargets(commandLine: string) {
+  return commandLine
+    .trim()
+    .replace(/^sudo\s+/, "")
+    .replace(/^rm\s+-[^\s]+\s+/, "")
+    .split(/\s+/)
+    .filter((token) => token && token !== "--")
+    .map((token) => token.replace(/^['"]+|['"]+$/g, ""));
+}
+
+function isSensitiveDeleteTarget(target: string | undefined) {
+  if (!target) return false;
+  if (/^\/(?:tmp|var\/tmp)(?:\/|$)/i.test(target)) return false;
+  if (/^(?:\.\/)?(?:dist|build|coverage|node_modules|tmp|temp)(?:\/|$)/i.test(target)) {
+    return false;
+  }
+  return /^(?:\/|~\/|\$HOME\/)/.test(target);
+}
+
+function hasSensitiveDeleteTarget(commandLine: string) {
+  return extractDeleteTargets(commandLine).some((target) => isSensitiveDeleteTarget(target));
 }
 
 function scanCodeFile(path: string, content: string, findings: ModerationFinding[]) {
@@ -261,6 +305,24 @@ function scanMarkdownFile(path: string, content: string, findings: ModerationFin
       message: "User-controlled placeholder is embedded directly into generated source code.",
       evidence: match.text,
     });
+  }
+
+  for (const destructiveDeleteMatch of content.matchAll(RM_RF_PATTERN)) {
+    if (destructiveDeleteMatch.index === undefined) continue;
+    if (!hasNearbyTroubleshootingContext(content, destructiveDeleteMatch.index)) continue;
+    if (!hasSensitiveDeleteTarget(destructiveDeleteMatch[0])) continue;
+    if (hasNearbyConfirmationGate(content, destructiveDeleteMatch.index)) continue;
+
+    const match = findLineAtIndex(content, destructiveDeleteMatch.index);
+    addFinding(findings, {
+      code: REASON_CODES.DESTRUCTIVE_DELETE_COMMAND,
+      severity: "critical",
+      file: path,
+      line: match.line,
+      message: "Destructive rm -rf command appears without an explicit confirmation gate.",
+      evidence: match.text,
+    });
+    break;
   }
 
   if (HARDCODED_CONNECTION_ID_PATTERN.test(content)) {

--- a/convex/lib/moderationReasonCodes.ts
+++ b/convex/lib/moderationReasonCodes.ts
@@ -12,11 +12,12 @@ export type ModerationFinding = {
   evidence: string;
 };
 
-export const MODERATION_ENGINE_VERSION = "v2.4.0";
+export const MODERATION_ENGINE_VERSION = "v2.5.0";
 
 export const REASON_CODES = {
   DANGEROUS_EXEC: "suspicious.dangerous_exec",
   DYNAMIC_CODE: "suspicious.dynamic_code_execution",
+  DESTRUCTIVE_DELETE_COMMAND: "suspicious.destructive_delete_command",
   GENERATED_SOURCE_TEMPLATE: "suspicious.generated_source_template_injection",
   EXPOSED_RESOURCE_IDENTIFIER: "suspicious.exposed_resource_identifier",
   CREDENTIAL_HARVEST: "suspicious.env_credential_access",


### PR DESCRIPTION
## Summary

This updates skill moderation to catch the `#1592` class of issue: destructive troubleshooting commands in public `SKILL.md` docs that an agent could execute without an explicit user confirmation gate.

## What changed

- add a new static moderation rule for destructive delete commands in markdown docs
- flag `rm -rf` only when it appears in troubleshooting/reinstall-style guidance
- require the delete target to be a sensitive absolute/home-style path
- suppress the finding when the docs clearly require user confirmation first
- do not flag routine project cleanup like `rm -rf node_modules dist`
- do not flag temp-directory cleanup like `/tmp/...`
- bump the moderation engine version so the rule is reflected in scan metadata

## Why

Issue #1592 showed that `stt-simple` includes a destructive reinstall path in its Troubleshooting section:

```bash
rm -rf /root/.openclaw/venv/stt-simple
/root/.openclaw/workspace/skills/stt-simple/install.sh
```

In an agent context, troubleshooting sections are executable guidance. Destructive reinstall steps against real user/system paths should be gated behind explicit user confirmation.

## Validation

- `bun test convex/lib/moderationEngine.test.ts`

## Notes

`bunx tsc -p tsconfig.json --noEmit` is currently blocked in this clean worktree by baseline type-resolution issues (`vite/client`, `vitest/globals`), not by this change.