### PR TITLE
fix: transfer request fails with toUserHandle required

### DIFF
--- a/packages/clawhub/src/cli/commands/transfer.test.ts
+++ b/packages/clawhub/src/cli/commands/transfer.test.ts
@@ -64,8 +64,9 @@ describe("transfer commands", () => {
       }),
       expect.anything(),
     );
-    const requestArgs = httpMocks.apiRequest.mock.calls[0]?.[1] as { body?: string };
-    expect(requestArgs.body).toContain('"toUserHandle":"alice"');
+    const requestArgs = httpMocks.apiRequest.mock.calls[0]?.[1] as { body?: unknown };
+    expect(typeof requestArgs.body).toBe('object');
+    expect(requestArgs.body).toEqual({ toUserHandle: 'alice', message: 'Please take over' });
   });
 
   it("list calls incoming transfers endpoint", async () => {

--- a/packages/clawhub/src/cli/commands/transfer.ts
+++ b/packages/clawhub/src/cli/commands/transfer.ts
@@ -88,10 +88,10 @@ export async function cmdTransferRequest(
         method: "POST",
         path: `${ApiRoutes.skills}/${encodeURIComponent(slug)}/transfer`,
         token,
-        body: JSON.stringify({
+        body: {
           toUserHandle: toHandle,
           message: options.message,
-        }),
+        },
       },
       ApiV1TransferRequestResponseSchema,
     );


### PR DESCRIPTION
## Problem
CLI `transfer request` command fails with "toUserHandle required" error due to double JSON.stringify in the request body.

## Root Cause
1. `transfer.ts` was using `JSON.stringify()` on the body
2. `apiRequest` also serializes the body
3. Result: server received stringified string instead of object, `toUserHandle` became undefined

## Solution
1. **transfer.ts**: Remove `JSON.stringify()`, pass plain object to `apiRequest`
2. **transfer.test.ts**: 
   - Fix undefined `mockApiRequest` → use `httpMocks.apiRequest`
   - Update assertion to expect object instead of stringified JSON

## Testing
bash
✓ 5 pass, 0 fail
✓ All transfer command tests passing

## Related
- Fixes test failures blocking PR #973
- Unblocks skill ownership transfer workflow
- Resolves issue where CLI transfer command fails with "toUserHandle required"