### PR TITLE
feat: add package ownership transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Search: add CJK tokenization support (Chinese/Japanese/Korean) with Intl.Segmenter plus fallback behavior to improve skill query matching (#1596) (thanks @pq-dong).
+- Skill ownership transfers now support org targets: `transfer request` and `transfer accept` accept a `--publisher` flag to send or receive a skill on behalf of an org. Org admins can see incoming org-targeted transfers via `GET /api/v1/transfers/incoming`. (#1603 thanks @TommYDeeee)
 
 ## 0.10.0 - 2026-04-05
 

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -2153,18 +2153,25 @@ describe("httpApiV1 handlers", () => {
       user: { handle: "p" },
     } as never);
 
+    let transferQueryCount = 0;
     const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
       if (isRateLimitArgs(args)) return okRate();
       if ("userId" in args) {
-        return [
-          {
-            _id: "skillOwnershipTransfers:1",
-            skill: { _id: "skills:1", slug: "demo", displayName: "Demo" },
-            fromUser: { _id: "users:2", handle: "alice", displayName: "Alice" },
-            requestedAt: 100,
-            expiresAt: 200,
-          },
-        ];
+        transferQueryCount++;
+        // First call is skill transfers, second is package transfers
+        if (transferQueryCount === 1) {
+          return [
+            {
+              _id: "skillOwnershipTransfers:1",
+              type: "skill",
+              skill: { _id: "skills:1", slug: "demo", displayName: "Demo" },
+              fromUser: { _id: "users:2", handle: "alice", displayName: "Alice" },
+              requestedAt: 100,
+              expiresAt: 200,
+            },
+          ];
+        }
+        return [];
       }
       return null;
     });

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -24,6 +24,7 @@ import {
   MAX_RAW_FILE_BYTES,
   getPathSegments,
   json,
+  parseJsonPayload,
   resolveTagsBatch,
   requireApiTokenUserOrResponse,
   requirePackagePublishAuthOrResponse,
@@ -47,10 +48,10 @@ const apiRefs = api as unknown as {
 const internalRefs = internal as unknown as {
   packages: {
     getByNameForViewerInternal: unknown;
+    getPackageByNameInternal: unknown;
     listPageForViewerInternal: unknown;
     searchForViewerInternal: unknown;
     listVersionsForViewerInternal: unknown;
-    getPackageByNameInternal: unknown;
     getTrustedPublisherByPackageIdInternal: unknown;
     getVersionByNameForViewerInternal: unknown;
     publishPackageForUserInternal: unknown;
@@ -70,18 +71,32 @@ const internalRefs = internal as unknown as {
     getVersionByIdInternal: unknown;
     getVersionBySkillAndVersionInternal: unknown;
   };
+  publishers: {
+    getByHandleInternal: unknown;
+  };
+  packageTransfers: {
+    requestTransferInternal: unknown;
+    acceptTransferInternal: unknown;
+    rejectTransferInternal: unknown;
+    cancelTransferInternal: unknown;
+    listIncomingInternal: unknown;
+    listOutgoingInternal: unknown;
+    getPendingTransferByPackageInternal: unknown;
+    getPendingTransferByPackageAndUserInternal: unknown;
+    getPendingTransferByPackageAndFromUserInternal: unknown;
+  };
 };
 
 async function runQueryRef<T>(ctx: ActionCtx, ref: unknown, args: unknown): Promise<T> {
   return (await ctx.runQuery(ref as never, args as never)) as T;
 }
 
-async function runActionRef<T>(ctx: ActionCtx, ref: unknown, args: unknown): Promise<T> {
-  return (await ctx.runAction(ref as never, args as never)) as T;
-}
-
 async function runMutationRef<T>(ctx: ActionCtx, ref: unknown, args: unknown): Promise<T> {
   return (await ctx.runMutation(ref as never, args as never)) as T;
+}
+
+async function runActionRef<T>(ctx: ActionCtx, ref: unknown, args: unknown): Promise<T> {
+  return (await ctx.runAction(ref as never, args as never)) as T;
 }
 
 async function getOptionalViewerUserIdForRequest(ctx: ActionCtx, request: Request) {
@@ -820,52 +835,60 @@ export async function mintPublishTokenV1Handler(ctx: ActionCtx, request: Request
 }
 
 export async function packagesPostRouterV1Handler(ctx: ActionCtx, request: Request) {
-  const segments = getPathSegments(request, "/api/v1/packages/");
-  if (segments[1] !== "trusted-publisher" || segments.length !== 2) {
-    return text("Not found", 404);
-  }
   const rate = await applyRateLimit(ctx, request, "write");
   if (!rate.ok) return rate.response;
-  const auth = await requireApiTokenUserOrResponse(ctx, request, rate.headers);
-  if (!auth.ok) return auth.response;
 
-  try {
-    const body = parseArk(
-      PackageTrustedPublisherUpsertRequestSchema,
-      await request.json(),
-      "Trusted publisher payload",
-    ) as {
-      repository: string;
-      workflowFilename: string;
-      environment?: string;
-    };
-    const repositoryIdentity = await fetchGitHubRepositoryIdentity(body.repository);
-    const trustedPublisher = await runMutationRef<PackageTrustedPublisherLike | null>(
-      ctx,
-      internalRefs.packages.setTrustedPublisherForUserInternal,
-      {
-        actorUserId: auth.userId,
-        packageName: segments[0]!,
-        repository: repositoryIdentity.repository,
-        repositoryId: repositoryIdentity.repositoryId,
-        repositoryOwner: repositoryIdentity.repositoryOwner,
-        repositoryOwnerId: repositoryIdentity.repositoryOwnerId,
-        workflowFilename: body.workflowFilename,
-        ...(body.environment ? { environment: body.environment } : {}),
-      },
-    );
-    return json(
-      { trustedPublisher: toPublicTrustedPublisher(trustedPublisher) },
-      200,
-      rate.headers,
-    );
-  } catch (error) {
-    return text(
-      error instanceof Error ? error.message : "Trusted publisher update failed",
-      400,
-      rate.headers,
-    );
+  const segments = getPathSegments(request, "/api/v1/packages/");
+  const action = segments[1] ?? "";
+
+  if (action === "transfer") {
+    return handlePackagesTransferPost(ctx, request, segments, rate.headers);
   }
+
+  if (action === "trusted-publisher" && segments.length === 2) {
+    const auth = await requireApiTokenUserOrResponse(ctx, request, rate.headers);
+    if (!auth.ok) return auth.response;
+
+    try {
+      const body = parseArk(
+        PackageTrustedPublisherUpsertRequestSchema,
+        await request.json(),
+        "Trusted publisher payload",
+      ) as {
+        repository: string;
+        workflowFilename: string;
+        environment?: string;
+      };
+      const repositoryIdentity = await fetchGitHubRepositoryIdentity(body.repository);
+      const trustedPublisher = await runMutationRef<PackageTrustedPublisherLike | null>(
+        ctx,
+        internalRefs.packages.setTrustedPublisherForUserInternal,
+        {
+          actorUserId: auth.userId,
+          packageName: segments[0]!,
+          repository: repositoryIdentity.repository,
+          repositoryId: repositoryIdentity.repositoryId,
+          repositoryOwner: repositoryIdentity.repositoryOwner,
+          repositoryOwnerId: repositoryIdentity.repositoryOwnerId,
+          workflowFilename: body.workflowFilename,
+          ...(body.environment ? { environment: body.environment } : {}),
+        },
+      );
+      return json(
+        { trustedPublisher: toPublicTrustedPublisher(trustedPublisher) },
+        200,
+        rate.headers,
+      );
+    } catch (error) {
+      return text(
+        error instanceof Error ? error.message : "Trusted publisher update failed",
+        400,
+        rate.headers,
+      );
+    }
+  }
+
+  return text("Not found", 404, rate.headers);
 }
 
 export async function packagesDeleteRouterV1Handler(ctx: ActionCtx, request: Request) {
@@ -1436,3 +1459,218 @@ type PublicPackageDocLike = {
   createdAt: number;
   updatedAt: number;
 };
+
+// ---------------------------------------------------------------------------
+// Package transfer handlers
+// ---------------------------------------------------------------------------
+
+type PackageTransferDecisionAction = "accept" | "reject" | "cancel";
+
+function packageTransferErrorToResponse(error: unknown, headers: HeadersInit) {
+  const message = error instanceof Error ? error.message : "Transfer failed";
+  const lower = message.toLowerCase();
+  if (lower.includes("unauthorized")) return text("Unauthorized", 401, headers);
+  if (lower.includes("forbidden")) return text("Forbidden", 403, headers);
+  if (lower.includes("not found")) return text(message, 404, headers);
+  if (lower.includes("required") || lower.includes("invalid") || lower.includes("pending")) {
+    return text(message, 400, headers);
+  }
+  return text(message, 400, headers);
+}
+
+type PackageTransferDocLike = {
+  _id: Id<"packages">;
+  softDeletedAt?: number;
+};
+
+type PendingTransferLike = {
+  _id: Id<"packageOwnershipTransfers">;
+};
+
+async function resolvePackageTransferContext(
+  ctx: ActionCtx,
+  request: Request,
+  name: string,
+  headers: HeadersInit,
+): Promise<
+  { ok: true; userId: Id<"users">; pkg: PackageTransferDocLike } | { ok: false; response: Response }
+> {
+  const auth = await requireApiTokenUserOrResponse(ctx, request, headers);
+  if (!auth.ok) return auth;
+
+  const pkg = await runQueryRef<PackageTransferDocLike | null>(
+    ctx,
+    internalRefs.packages.getPackageByNameInternal,
+    { name },
+  );
+  if (!pkg || pkg.softDeletedAt)
+    return { ok: false, response: text("Package not found", 404, headers) };
+
+  return { ok: true, userId: auth.userId, pkg };
+}
+
+async function handlePackageTransferRequest(
+  ctx: ActionCtx,
+  request: Request,
+  name: string,
+  headers: HeadersInit,
+) {
+  const transferContext = await resolvePackageTransferContext(ctx, request, name, headers);
+  if (!transferContext.ok) return transferContext.response;
+
+  const parsed = await parseJsonPayload(request, headers);
+  if (!parsed.ok) return parsed.response;
+
+  const toUserHandleRaw =
+    typeof parsed.payload.toUserHandle === "string" ? parsed.payload.toUserHandle.trim() : "";
+  if (!toUserHandleRaw) return text("toUserHandle required", 400, headers);
+  const message = typeof parsed.payload.message === "string" ? parsed.payload.message : undefined;
+
+  // Resolve optional publisher handle to a publisher ID
+  const toPublisherHandleRaw =
+    typeof parsed.payload.toPublisherHandle === "string"
+      ? parsed.payload.toPublisherHandle.trim()
+      : "";
+  let toPublisherId: Id<"publishers"> | undefined;
+  if (toPublisherHandleRaw) {
+    const publisher = await runQueryRef<{ _id: Id<"publishers"> } | null>(
+      ctx,
+      internalRefs.publishers.getByHandleInternal,
+      { handle: toPublisherHandleRaw },
+    );
+    if (!publisher) return text("Publisher not found", 404, headers);
+    toPublisherId = publisher._id;
+  }
+
+  try {
+    const result = await runMutationRef(
+      ctx,
+      internalRefs.packageTransfers.requestTransferInternal,
+      {
+        actorUserId: transferContext.userId,
+        packageId: transferContext.pkg._id,
+        toUserHandle: toUserHandleRaw,
+        toPublisherId,
+        message,
+      },
+    );
+    return json(result, 200, headers);
+  } catch (error) {
+    return packageTransferErrorToResponse(error, headers);
+  }
+}
+
+async function handlePackageTransferDecision(
+  ctx: ActionCtx,
+  request: Request,
+  name: string,
+  decision: PackageTransferDecisionAction,
+  headers: HeadersInit,
+) {
+  const transferContext = await resolvePackageTransferContext(ctx, request, name, headers);
+  if (!transferContext.ok) return transferContext.response;
+
+  let pendingTransfer: PendingTransferLike | null;
+  if (decision === "cancel") {
+    pendingTransfer = await runQueryRef<PendingTransferLike | null>(
+      ctx,
+      internalRefs.packageTransfers.getPendingTransferByPackageAndFromUserInternal,
+      {
+        packageId: transferContext.pkg._id,
+        fromUserId: transferContext.userId,
+      },
+    );
+    if (!pendingTransfer) {
+      // Fallback: allow org admins to cancel transfers initiated by other admins
+      pendingTransfer = await runQueryRef<PendingTransferLike | null>(
+        ctx,
+        internalRefs.packageTransfers.getPendingTransferByPackageInternal,
+        { packageId: transferContext.pkg._id },
+      );
+    }
+  } else {
+    // Try user-specific lookup first, then fall back to any pending transfer
+    // for the package (allows org admins other than toUserId to accept/reject)
+    pendingTransfer = await runQueryRef<PendingTransferLike | null>(
+      ctx,
+      internalRefs.packageTransfers.getPendingTransferByPackageAndUserInternal,
+      {
+        packageId: transferContext.pkg._id,
+        toUserId: transferContext.userId,
+      },
+    );
+    if (!pendingTransfer) {
+      pendingTransfer = await runQueryRef<PendingTransferLike | null>(
+        ctx,
+        internalRefs.packageTransfers.getPendingTransferByPackageInternal,
+        { packageId: transferContext.pkg._id },
+      );
+    }
+  }
+  if (!pendingTransfer) return text("No pending transfer found", 404, headers);
+
+  const mutation =
+    decision === "accept"
+      ? internalRefs.packageTransfers.acceptTransferInternal
+      : decision === "reject"
+        ? internalRefs.packageTransfers.rejectTransferInternal
+        : internalRefs.packageTransfers.cancelTransferInternal;
+
+  try {
+    // For accept, resolve optional publisher handle to forward publisherId
+    let publisherId: Id<"publishers"> | undefined;
+    if (decision === "accept") {
+      const parsed = await parseJsonPayload(request, headers);
+      if (parsed.ok) {
+        const publisherHandleRaw =
+          typeof parsed.payload.publisherHandle === "string"
+            ? parsed.payload.publisherHandle.trim()
+            : "";
+        if (publisherHandleRaw) {
+          const publisher = await runQueryRef<{ _id: Id<"publishers"> } | null>(
+            ctx,
+            internalRefs.publishers.getByHandleInternal,
+            { handle: publisherHandleRaw },
+          );
+          if (!publisher) return text("Publisher not found", 404, headers);
+          publisherId = publisher._id;
+        }
+      }
+    }
+
+    const mutationArgs: Record<string, unknown> = {
+      actorUserId: transferContext.userId,
+      transferId: pendingTransfer._id,
+    };
+    if (publisherId) {
+      mutationArgs.publisherId = publisherId;
+    }
+
+    const result = await runMutationRef(ctx, mutation, mutationArgs);
+    return json(result, 200, headers);
+  } catch (error) {
+    return packageTransferErrorToResponse(error, headers);
+  }
+}
+
+async function handlePackagesTransferPost(
+  ctx: ActionCtx,
+  request: Request,
+  segments: string[],
+  headers: HeadersInit,
+) {
+  const name = segments[0]?.trim().toLowerCase() ?? "";
+  if (!name) return text("Package name required", 400, headers);
+
+  if (segments.length === 2) {
+    return handlePackageTransferRequest(ctx, request, name, headers);
+  }
+  if (segments.length === 3) {
+    const decision = segments[2]?.trim().toLowerCase();
+    if (decision === "accept" || decision === "reject" || decision === "cancel") {
+      return handlePackageTransferDecision(ctx, request, name, decision, headers);
+    }
+  }
+  return text("Not found", 404, headers);
+}
+

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -1047,11 +1047,8 @@ async function handleTransferDecision(
     // For accept, resolve optional publisher handle to forward publisherId
     let publisherId: Id<"publishers"> | undefined;
     if (decision === "accept") {
-      const contentType = request.headers.get("content-type") ?? "";
-      const hasBody = contentType.includes("json");
-      const parsed = hasBody ? await parseJsonPayload(request, headers) : null;
-      if (parsed && !parsed.ok) return parsed.response;
-      if (parsed?.ok) {
+      const parsed = await parseJsonPayload(request, headers);
+      if (parsed.ok) {
         const publisherHandleRaw =
           typeof parsed.payload.publisherHandle === "string"
             ? parsed.payload.publisherHandle.trim()

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -1036,13 +1036,6 @@ async function handleTransferDecision(
   }
   if (!pendingTransfer) return text("No pending transfer found", 404, headers);
 
-  const mutation =
-    decision === "accept"
-      ? internal.skillTransfers.acceptTransferInternal
-      : decision === "reject"
-        ? internal.skillTransfers.rejectTransferInternal
-        : internal.skillTransfers.cancelTransferInternal;
-
   try {
     // For accept, resolve optional publisher handle to forward publisherId
     let publisherId: Id<"publishers"> | undefined;
@@ -1063,15 +1056,19 @@ async function handleTransferDecision(
       }
     }
 
-    const mutationArgs: Record<string, unknown> = {
+    const baseArgs = {
       actorUserId: transferContext.userId,
       transferId: pendingTransfer._id,
     };
-    if (publisherId) {
-      mutationArgs.publisherId = publisherId;
-    }
 
-    const result = await ctx.runMutation(mutation, mutationArgs as never);
+    const result = await (decision === "accept"
+      ? ctx.runMutation(internal.skillTransfers.acceptTransferInternal, {
+          ...baseArgs,
+          publisherId,
+        })
+      : decision === "reject"
+        ? ctx.runMutation(internal.skillTransfers.rejectTransferInternal, baseArgs)
+        : ctx.runMutation(internal.skillTransfers.cancelTransferInternal, baseArgs));
     return json(result, 200, headers);
   } catch (error) {
     return transferErrorToResponse(error, headers);

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -969,11 +969,26 @@ async function handleTransferRequest(
   if (!toUserHandleRaw) return text("toUserHandle required", 400, headers);
   const message = typeof parsed.payload.message === "string" ? parsed.payload.message : undefined;
 
+  // Resolve optional publisher handle to a publisher ID
+  const toPublisherHandleRaw =
+    typeof parsed.payload.toPublisherHandle === "string"
+      ? parsed.payload.toPublisherHandle.trim()
+      : "";
+  let toPublisherId: Id<"publishers"> | undefined;
+  if (toPublisherHandleRaw) {
+    const publisher = await ctx.runQuery(internal.publishers.getByHandleInternal, {
+      handle: toPublisherHandleRaw,
+    });
+    if (!publisher) return text("Publisher not found", 404, headers);
+    toPublisherId = publisher._id;
+  }
+
   try {
     const result = await ctx.runMutation(internal.skillTransfers.requestTransferInternal, {
       actorUserId: transferContext.userId,
       skillId: transferContext.skill._id,
       toUserHandle: toUserHandleRaw,
+      toPublisherId,
       message,
     });
     return json(result, 200, headers);
@@ -992,16 +1007,33 @@ async function handleTransferDecision(
   const transferContext = await resolveTransferContext(ctx, request, slug, headers);
   if (!transferContext.ok) return transferContext.response;
 
-  const pendingTransfer =
-    decision === "cancel"
-      ? await ctx.runQuery(internal.skillTransfers.getPendingTransferBySkillAndFromUserInternal, {
-          skillId: transferContext.skill._id,
-          fromUserId: transferContext.userId,
-        })
-      : await ctx.runQuery(internal.skillTransfers.getPendingTransferBySkillAndUserInternal, {
-          skillId: transferContext.skill._id,
-          toUserId: transferContext.userId,
-        });
+  let pendingTransfer;
+  if (decision === "cancel") {
+    pendingTransfer = await ctx.runQuery(
+      internal.skillTransfers.getPendingTransferBySkillAndFromUserInternal,
+      { skillId: transferContext.skill._id, fromUserId: transferContext.userId },
+    );
+    if (!pendingTransfer) {
+      // Fallback: allow org admins to cancel transfers initiated by other admins
+      pendingTransfer = await ctx.runQuery(
+        internal.skillTransfers.getPendingTransferBySkillInternal,
+        { skillId: transferContext.skill._id },
+      );
+    }
+  } else {
+    // Try user-specific lookup first, then fall back to any pending transfer
+    // for the skill (allows org admins other than toUserId to accept/reject)
+    pendingTransfer = await ctx.runQuery(
+      internal.skillTransfers.getPendingTransferBySkillAndUserInternal,
+      { skillId: transferContext.skill._id, toUserId: transferContext.userId },
+    );
+    if (!pendingTransfer) {
+      pendingTransfer = await ctx.runQuery(
+        internal.skillTransfers.getPendingTransferBySkillInternal,
+        { skillId: transferContext.skill._id },
+      );
+    }
+  }
   if (!pendingTransfer) return text("No pending transfer found", 404, headers);
 
   const mutation =
@@ -1012,10 +1044,37 @@ async function handleTransferDecision(
         : internal.skillTransfers.cancelTransferInternal;
 
   try {
-    const result = await ctx.runMutation(mutation, {
+    // For accept, resolve optional publisher handle to forward publisherId
+    let publisherId: Id<"publishers"> | undefined;
+    if (decision === "accept") {
+      const contentType = request.headers.get("content-type") ?? "";
+      const hasBody = contentType.includes("json");
+      const parsed = hasBody ? await parseJsonPayload(request, headers) : null;
+      if (parsed && !parsed.ok) return parsed.response;
+      if (parsed?.ok) {
+        const publisherHandleRaw =
+          typeof parsed.payload.publisherHandle === "string"
+            ? parsed.payload.publisherHandle.trim()
+            : "";
+        if (publisherHandleRaw) {
+          const publisher = await ctx.runQuery(internal.publishers.getByHandleInternal, {
+            handle: publisherHandleRaw,
+          });
+          if (!publisher) return text("Publisher not found", 404, headers);
+          publisherId = publisher._id;
+        }
+      }
+    }
+
+    const mutationArgs: Record<string, unknown> = {
       actorUserId: transferContext.userId,
       transferId: pendingTransfer._id,
-    });
+    };
+    if (publisherId) {
+      mutationArgs.publisherId = publisherId;
+    }
+
+    const result = await ctx.runMutation(mutation, mutationArgs as never);
     return json(result, 200, headers);
   } catch (error) {
     return transferErrorToResponse(error, headers);

--- a/convex/httpApiV1/transfersV1.ts
+++ b/convex/httpApiV1/transfersV1.ts
@@ -3,6 +3,17 @@ import type { ActionCtx } from "../_generated/server";
 import { applyRateLimit } from "../lib/httpRateLimit";
 import { getPathSegments, json, requireApiTokenUserOrResponse, text } from "./shared";
 
+const internalRefs = internal as unknown as {
+  packageTransfers: {
+    listIncomingInternal: unknown;
+    listOutgoingInternal: unknown;
+  };
+};
+
+async function runQueryRef<T>(ctx: ActionCtx, ref: unknown, args: unknown): Promise<T> {
+  return (await ctx.runQuery(ref as never, args as never)) as T;
+}
+
 export async function transfersGetRouterV1Handler(ctx: ActionCtx, request: Request) {
   const rate = await applyRateLimit(ctx, request, "read");
   if (!rate.ok) return rate.response;
@@ -16,13 +27,19 @@ export async function transfersGetRouterV1Handler(ctx: ActionCtx, request: Reque
   const auth = await requireApiTokenUserOrResponse(ctx, request, rate.headers);
   if (!auth.ok) return auth.response;
 
-  const skillTransfers =
+  const [skillTransfers, packageTransfers] = await Promise.all([
     direction === "incoming"
-      ? await ctx.runQuery(internal.skillTransfers.listIncomingInternal, { userId: auth.userId })
-      : await ctx.runQuery(internal.skillTransfers.listOutgoingInternal, { userId: auth.userId });
+      ? ctx.runQuery(internal.skillTransfers.listIncomingInternal, { userId: auth.userId })
+      : ctx.runQuery(internal.skillTransfers.listOutgoingInternal, { userId: auth.userId }),
+    direction === "incoming"
+      ? runQueryRef<unknown[]>(ctx, internalRefs.packageTransfers.listIncomingInternal, { userId: auth.userId })
+      : runQueryRef<unknown[]>(ctx, internalRefs.packageTransfers.listOutgoingInternal, { userId: auth.userId }),
+  ]);
 
-  const transfers = skillTransfers.sort(
-    (a, b) => (b.requestedAt ?? 0) - (a.requestedAt ?? 0),
+  const transfers = [...skillTransfers, ...packageTransfers].sort(
+    (a, b) =>
+      ((b as { requestedAt?: number }).requestedAt ?? 0) -
+      ((a as { requestedAt?: number }).requestedAt ?? 0),
   );
 
   return json({ transfers }, 200, rate.headers);

--- a/convex/httpApiV1/transfersV1.ts
+++ b/convex/httpApiV1/transfersV1.ts
@@ -16,9 +16,14 @@ export async function transfersGetRouterV1Handler(ctx: ActionCtx, request: Reque
   const auth = await requireApiTokenUserOrResponse(ctx, request, rate.headers);
   if (!auth.ok) return auth.response;
 
-  const transfers =
+  const skillTransfers =
     direction === "incoming"
       ? await ctx.runQuery(internal.skillTransfers.listIncomingInternal, { userId: auth.userId })
       : await ctx.runQuery(internal.skillTransfers.listOutgoingInternal, { userId: auth.userId });
+
+  const transfers = skillTransfers
+    .map((t) => ({ ...t, type: "skill" as const }))
+    .sort((a, b) => (b.requestedAt ?? 0) - (a.requestedAt ?? 0));
+
   return json({ transfers }, 200, rate.headers);
 }

--- a/convex/httpApiV1/transfersV1.ts
+++ b/convex/httpApiV1/transfersV1.ts
@@ -21,9 +21,9 @@ export async function transfersGetRouterV1Handler(ctx: ActionCtx, request: Reque
       ? await ctx.runQuery(internal.skillTransfers.listIncomingInternal, { userId: auth.userId })
       : await ctx.runQuery(internal.skillTransfers.listOutgoingInternal, { userId: auth.userId });
 
-  const transfers = skillTransfers
-    .map((t) => ({ ...t, type: "skill" as const }))
-    .sort((a, b) => (b.requestedAt ?? 0) - (a.requestedAt ?? 0));
+  const transfers = skillTransfers.sort(
+    (a, b) => (b.requestedAt ?? 0) - (a.requestedAt ?? 0),
+  );
 
   return json({ transfers }, 200, rate.headers);
 }

--- a/convex/lib/transfers.test.ts
+++ b/convex/lib/transfers.test.ts
@@ -66,6 +66,7 @@ describe("transfers", () => {
       const ctx = {
         db: {
           normalizeId: vi.fn(),
+          get: vi.fn(async () => ({ _id: "publishers:org1", kind: "org" })),
           query: vi.fn((table: string) => {
             if (table === "publisherMembers") {
               return {
@@ -97,6 +98,7 @@ describe("transfers", () => {
       const ctx = {
         db: {
           normalizeId: vi.fn(),
+          get: vi.fn(async () => ({ _id: "publishers:org1", kind: "org" })),
           query: vi.fn((table: string) => {
             if (table === "publisherMembers") {
               return {
@@ -128,6 +130,7 @@ describe("transfers", () => {
       const ctx = {
         db: {
           normalizeId: vi.fn(),
+          get: vi.fn(async () => ({ _id: "publishers:org1", kind: "org" })),
           query: vi.fn((table: string) => {
             if (table === "publisherMembers") {
               return {
@@ -159,6 +162,7 @@ describe("transfers", () => {
       const ctx = {
         db: {
           normalizeId: vi.fn(),
+          get: vi.fn(async () => ({ _id: "publishers:org1", kind: "org" })),
           query: vi.fn((table: string) => {
             if (table === "publisherMembers") {
               return {
@@ -194,6 +198,56 @@ describe("transfers", () => {
           actorUserId: "users:2" as never,
           ownerUserId: "users:1" as never,
           ownerPublisherId: undefined,
+        }),
+      ).rejects.toThrow("Forbidden");
+    });
+
+    it("passes for personal publisher owner (kind: user)", async () => {
+      const ctx = {
+        db: {
+          normalizeId: vi.fn(),
+          get: vi.fn(async () => ({ _id: "publishers:alice", kind: "user" })),
+          query: vi.fn(),
+        },
+      };
+
+      await expect(
+        validateTransferOwnership(ctx as never, {
+          actorUserId: "users:1" as never,
+          ownerUserId: "users:1" as never,
+          ownerPublisherId: "publishers:alice" as never,
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("rejects personal publisher member who is not the owner user (kind: user)", async () => {
+      const ctx = {
+        db: {
+          normalizeId: vi.fn(),
+          get: vi.fn(async () => ({ _id: "publishers:alice", kind: "user" })),
+          query: vi.fn((table: string) => {
+            if (table === "publisherMembers") {
+              return {
+                withIndex: () => ({
+                  unique: async () => ({
+                    _id: "publisherMembers:1",
+                    publisherId: "publishers:alice",
+                    userId: "users:2",
+                    role: "admin",
+                  }),
+                }),
+              };
+            }
+            throw new Error(`unexpected table ${table}`);
+          }),
+        },
+      };
+
+      await expect(
+        validateTransferOwnership(ctx as never, {
+          actorUserId: "users:2" as never,
+          ownerUserId: "users:1" as never,
+          ownerPublisherId: "publishers:alice" as never,
         }),
       ).rejects.toThrow("Forbidden");
     });

--- a/convex/lib/transfers.test.ts
+++ b/convex/lib/transfers.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  TRANSFER_EXPIRY_MS,
+  isTransferExpired,
+  normalizeTransferHandle,
+  validateTransferOwnership,
+  validateTransferAcceptPermission,
+} from "./transfers";
+
+describe("transfers", () => {
+  it("TRANSFER_EXPIRY_MS is 7 days", () => {
+    expect(TRANSFER_EXPIRY_MS).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+
+  describe("isTransferExpired", () => {
+    it("returns true when expiresAt is in the past", () => {
+      expect(isTransferExpired({ expiresAt: 1000 }, 2000)).toBe(true);
+    });
+
+    it("returns false when expiresAt is in the future", () => {
+      expect(isTransferExpired({ expiresAt: 3000 }, 2000)).toBe(false);
+    });
+
+    it("returns false when expiresAt equals now", () => {
+      expect(isTransferExpired({ expiresAt: 2000 }, 2000)).toBe(false);
+    });
+  });
+
+  describe("normalizeTransferHandle", () => {
+    it("trims whitespace", () => {
+      expect(normalizeTransferHandle("  alice  ")).toBe("alice");
+    });
+
+    it("strips leading @ and lowercases", () => {
+      expect(normalizeTransferHandle("@Alice")).toBe("alice");
+    });
+
+    it("strips multiple leading @ signs", () => {
+      expect(normalizeTransferHandle("@@Bob")).toBe("bob");
+    });
+
+    it("lowercases without @", () => {
+      expect(normalizeTransferHandle("Charlie")).toBe("charlie");
+    });
+  });
+
+  describe("validateTransferOwnership", () => {
+    it("passes for direct owner (personal, no publisher)", async () => {
+      const ctx = {
+        db: {
+          normalizeId: vi.fn(),
+          query: vi.fn(),
+        },
+      };
+
+      await expect(
+        validateTransferOwnership(ctx as never, {
+          actorUserId: "users:1" as never,
+          ownerUserId: "users:1" as never,
+          ownerPublisherId: undefined,
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("passes for org admin", async () => {
+      const ctx = {
+        db: {
+          normalizeId: vi.fn(),
+          query: vi.fn((table: string) => {
+            if (table === "publisherMembers") {
+              return {
+                withIndex: () => ({
+                  unique: async () => ({
+                    _id: "publisherMembers:1",
+                    publisherId: "publishers:org1",
+                    userId: "users:1",
+                    role: "admin",
+                  }),
+                }),
+              };
+            }
+            throw new Error(`unexpected table ${table}`);
+          }),
+        },
+      };
+
+      await expect(
+        validateTransferOwnership(ctx as never, {
+          actorUserId: "users:1" as never,
+          ownerUserId: "users:99" as never,
+          ownerPublisherId: "publishers:org1" as never,
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("passes for org owner role", async () => {
+      const ctx = {
+        db: {
+          normalizeId: vi.fn(),
+          query: vi.fn((table: string) => {
+            if (table === "publisherMembers") {
+              return {
+                withIndex: () => ({
+                  unique: async () => ({
+                    _id: "publisherMembers:1",
+                    publisherId: "publishers:org1",
+                    userId: "users:1",
+                    role: "owner",
+                  }),
+                }),
+              };
+            }
+            throw new Error(`unexpected table ${table}`);
+          }),
+        },
+      };
+
+      await expect(
+        validateTransferOwnership(ctx as never, {
+          actorUserId: "users:1" as never,
+          ownerUserId: "users:99" as never,
+          ownerPublisherId: "publishers:org1" as never,
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("rejects non-admin org member (publisher role)", async () => {
+      const ctx = {
+        db: {
+          normalizeId: vi.fn(),
+          query: vi.fn((table: string) => {
+            if (table === "publisherMembers") {
+              return {
+                withIndex: () => ({
+                  unique: async () => ({
+                    _id: "publisherMembers:1",
+                    publisherId: "publishers:org1",
+                    userId: "users:1",
+                    role: "publisher",
+                  }),
+                }),
+              };
+            }
+            throw new Error(`unexpected table ${table}`);
+          }),
+        },
+      };
+
+      await expect(
+        validateTransferOwnership(ctx as never, {
+          actorUserId: "users:1" as never,
+          ownerUserId: "users:99" as never,
+          ownerPublisherId: "publishers:org1" as never,
+        }),
+      ).rejects.toThrow("Forbidden");
+    });
+
+    it("rejects non-owner non-member", async () => {
+      const ctx = {
+        db: {
+          normalizeId: vi.fn(),
+          query: vi.fn((table: string) => {
+            if (table === "publisherMembers") {
+              return {
+                withIndex: () => ({
+                  unique: async () => null,
+                }),
+              };
+            }
+            throw new Error(`unexpected table ${table}`);
+          }),
+        },
+      };
+
+      await expect(
+        validateTransferOwnership(ctx as never, {
+          actorUserId: "users:1" as never,
+          ownerUserId: "users:99" as never,
+          ownerPublisherId: "publishers:org1" as never,
+        }),
+      ).rejects.toThrow("Forbidden");
+    });
+
+    it("rejects personal item when actor is not the owner", async () => {
+      const ctx = {
+        db: {
+          normalizeId: vi.fn(),
+          query: vi.fn(),
+        },
+      };
+
+      await expect(
+        validateTransferOwnership(ctx as never, {
+          actorUserId: "users:2" as never,
+          ownerUserId: "users:1" as never,
+          ownerPublisherId: undefined,
+        }),
+      ).rejects.toThrow("Forbidden");
+    });
+  });
+
+  describe("validateTransferAcceptPermission", () => {
+    it("passes for personal target when actor is the target user", async () => {
+      const ctx = {
+        db: {
+          normalizeId: vi.fn(),
+          query: vi.fn(),
+        },
+      };
+
+      await expect(
+        validateTransferAcceptPermission(ctx as never, {
+          actorUserId: "users:1" as never,
+          toUserId: "users:1" as never,
+          toPublisherId: undefined,
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("rejects personal target when actor is not the target user", async () => {
+      const ctx = {
+        db: {
+          normalizeId: vi.fn(),
+          query: vi.fn(),
+        },
+      };
+
+      await expect(
+        validateTransferAcceptPermission(ctx as never, {
+          actorUserId: "users:2" as never,
+          toUserId: "users:1" as never,
+          toPublisherId: undefined,
+        }),
+      ).rejects.toThrow("No pending transfer found");
+    });
+
+    it("passes for org target when actor is admin", async () => {
+      const ctx = {
+        db: {
+          normalizeId: vi.fn(),
+          get: vi.fn(async () => ({
+            _id: "publishers:org1",
+            kind: "org",
+            handle: "myorg",
+          })),
+          query: vi.fn((table: string) => {
+            if (table === "publisherMembers") {
+              return {
+                withIndex: () => ({
+                  unique: async () => ({
+                    _id: "publisherMembers:1",
+                    publisherId: "publishers:org1",
+                    userId: "users:1",
+                    role: "admin",
+                  }),
+                }),
+              };
+            }
+            throw new Error(`unexpected table ${table}`);
+          }),
+        },
+      };
+
+      await expect(
+        validateTransferAcceptPermission(ctx as never, {
+          actorUserId: "users:1" as never,
+          toUserId: "users:99" as never,
+          toPublisherId: "publishers:org1" as never,
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("rejects org target when actor is not admin/owner", async () => {
+      const ctx = {
+        db: {
+          normalizeId: vi.fn(),
+          get: vi.fn(async () => ({
+            _id: "publishers:org1",
+            kind: "org",
+            handle: "myorg",
+          })),
+          query: vi.fn((table: string) => {
+            if (table === "publisherMembers") {
+              return {
+                withIndex: () => ({
+                  unique: async () => ({
+                    _id: "publisherMembers:1",
+                    publisherId: "publishers:org1",
+                    userId: "users:1",
+                    role: "publisher",
+                  }),
+                }),
+              };
+            }
+            throw new Error(`unexpected table ${table}`);
+          }),
+        },
+      };
+
+      await expect(
+        validateTransferAcceptPermission(ctx as never, {
+          actorUserId: "users:1" as never,
+          toUserId: "users:99" as never,
+          toPublisherId: "publishers:org1" as never,
+        }),
+      ).rejects.toThrow("No pending transfer found");
+    });
+  });
+});

--- a/convex/lib/transfers.test.ts
+++ b/convex/lib/transfers.test.ts
@@ -359,5 +359,27 @@ describe("transfers", () => {
         }),
       ).rejects.toThrow("No pending transfer found");
     });
+
+    it("rejects personal publisher as transfer target (kind: user)", async () => {
+      const ctx = {
+        db: {
+          normalizeId: vi.fn(),
+          get: vi.fn(async () => ({
+            _id: "publishers:alice",
+            kind: "user",
+            handle: "alice",
+          })),
+          query: vi.fn(),
+        },
+      };
+
+      await expect(
+        validateTransferAcceptPermission(ctx as never, {
+          actorUserId: "users:1" as never,
+          toUserId: "users:1" as never,
+          toPublisherId: "publishers:alice" as never,
+        }),
+      ).rejects.toThrow("No pending transfer found");
+    });
   });
 });

--- a/convex/lib/transfers.ts
+++ b/convex/lib/transfers.ts
@@ -1,0 +1,91 @@
+import type { Doc, Id } from "../_generated/dataModel";
+import type { QueryCtx, MutationCtx } from "../_generated/server";
+import { getPublisherMembership, isPublisherActive, isPublisherRoleAllowed } from "./publishers";
+
+type DbCtx = Pick<QueryCtx | MutationCtx, "db">;
+
+/** 7 days in milliseconds */
+export const TRANSFER_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Returns true if the transfer has expired (expiresAt is strictly less than now). */
+export function isTransferExpired(transfer: { expiresAt: number }, now: number): boolean {
+  return transfer.expiresAt < now;
+}
+
+/**
+ * Trims whitespace, strips leading `@` characters, and lowercases:
+ * `"@Alice"` -> `"alice"`, `"@@Bob"` -> `"bob"`
+ */
+export function normalizeTransferHandle(value: string): string {
+  return value.trim().replace(/^@+/, "").toLowerCase();
+}
+
+/**
+ * Validates that `actorUserId` has permission to initiate a transfer.
+ *
+ * - If the item is personally owned (`ownerPublisherId` is null/undefined):
+ *   actor must be the `ownerUserId`.
+ * - If the item is org-owned: actor must be an admin or owner in that org's
+ *   publisherMembers.
+ *
+ * @throws {Error} "Forbidden" on failure
+ */
+export async function validateTransferOwnership(
+  ctx: DbCtx,
+  params: {
+    actorUserId: Id<"users">;
+    ownerUserId: Id<"users">;
+    ownerPublisherId?: Id<"publishers"> | null;
+  },
+): Promise<void> {
+  if (!params.ownerPublisherId) {
+    // Personally owned — actor must be the owner
+    if (params.actorUserId !== params.ownerUserId) {
+      throw new Error("Forbidden");
+    }
+    return;
+  }
+
+  // Org-owned — actor must be admin or owner in the org
+  const membership = await getPublisherMembership(ctx, params.ownerPublisherId, params.actorUserId);
+  if (!membership || !isPublisherRoleAllowed(membership.role, ["admin"])) {
+    throw new Error("Forbidden");
+  }
+}
+
+/**
+ * Validates that `actorUserId` can accept a transfer.
+ *
+ * - If `toPublisherId` is null (personal target): actor must be `toUserId`.
+ * - If `toPublisherId` is set (org target): actor must be admin/owner of that org.
+ *
+ * @throws {Error} "No pending transfer found" on failure
+ */
+export async function validateTransferAcceptPermission(
+  ctx: DbCtx,
+  params: {
+    actorUserId: Id<"users">;
+    toUserId?: Id<"users"> | null;
+    toPublisherId?: Id<"publishers"> | null;
+  },
+): Promise<void> {
+  if (!params.toPublisherId) {
+    // Personal target — actor must be the target user
+    if (params.actorUserId !== params.toUserId) {
+      throw new Error("No pending transfer found");
+    }
+    return;
+  }
+
+  // Org target — publisher must be active and actor must be admin or owner
+  const db = (ctx as { db: { get: (id: Id<"publishers">) => Promise<Doc<"publishers"> | null> } })
+    .db;
+  const publisher = await db.get(params.toPublisherId);
+  if (!isPublisherActive(publisher)) {
+    throw new Error("Publisher not found");
+  }
+  const membership = await getPublisherMembership(ctx, params.toPublisherId, params.actorUserId);
+  if (!membership || !isPublisherRoleAllowed(membership.role, ["admin"])) {
+    throw new Error("No pending transfer found");
+  }
+}

--- a/convex/lib/transfers.ts
+++ b/convex/lib/transfers.ts
@@ -89,12 +89,15 @@ export async function validateTransferAcceptPermission(
     return;
   }
 
-  // Org target — publisher must be active and actor must be admin or owner
+  // Target must be an active org publisher — personal publishers are not valid transfer targets
   const db = (ctx as { db: { get: (id: Id<"publishers">) => Promise<Doc<"publishers"> | null> } })
     .db;
   const publisher = await db.get(params.toPublisherId);
   if (!isPublisherActive(publisher)) {
     throw new Error("Publisher not found");
+  }
+  if (publisher!.kind === "user") {
+    throw new Error("No pending transfer found");
   }
   const membership = await getPublisherMembership(ctx, params.toPublisherId, params.actorUserId);
   if (!membership || !isPublisherRoleAllowed(membership.role, ["admin"])) {

--- a/convex/lib/transfers.ts
+++ b/convex/lib/transfers.ts
@@ -39,14 +39,26 @@ export async function validateTransferOwnership(
   },
 ): Promise<void> {
   if (!params.ownerPublisherId) {
-    // Personally owned — actor must be the owner
     if (params.actorUserId !== params.ownerUserId) {
       throw new Error("Forbidden");
     }
     return;
   }
 
-  // Org-owned — actor must be admin or owner in the org
+  const db = (ctx as { db: { get: (id: Id<"publishers">) => Promise<Doc<"publishers"> | null> } })
+    .db;
+  const publisher = await db.get(params.ownerPublisherId);
+  if (!publisher) throw new Error("Forbidden");
+
+  if (publisher.kind === "user") {
+    // Personal publisher — require direct user ownership, not membership
+    if (params.actorUserId !== params.ownerUserId) {
+      throw new Error("Forbidden");
+    }
+    return;
+  }
+
+  // Org publisher — actor must be admin or owner
   const membership = await getPublisherMembership(ctx, params.ownerPublisherId, params.actorUserId);
   if (!membership || !isPublisherRoleAllowed(membership.role, ["admin"])) {
     throw new Error("Forbidden");

--- a/convex/packageTransfers.test.ts
+++ b/convex/packageTransfers.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  acceptTransferInternal,
+  requestTransferInternal,
+} from "./packageTransfers";
+
+type WrappedHandler<TArgs, TResult = unknown> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
+};
+
+const requestTransferInternalHandler = (
+  requestTransferInternal as unknown as WrappedHandler<{
+    actorUserId: string;
+    packageId: string;
+    toUserHandle: string;
+    toPublisherId?: string;
+    message?: string;
+  }>
+)._handler;
+
+const acceptTransferInternalHandler = (
+  acceptTransferInternal as unknown as WrappedHandler<{
+    actorUserId: string;
+    transferId: string;
+    publisherId?: string;
+  }>
+)._handler;
+
+describe("packageTransfers", () => {
+  it("requestTransferInternal creates pending transfer for user→user", async () => {
+    const insert = vi.fn(async (table: string) => {
+      if (table === "packageOwnershipTransfers") return "packageOwnershipTransfers:new";
+      return "auditLogs:1";
+    });
+
+    const result = (await requestTransferInternalHandler(
+      {
+        db: {
+          normalizeId: vi.fn(),
+          get: vi.fn(async (id: string) => {
+            if (id === "users:1") return { _id: "users:1", handle: "owner" };
+            if (id === "packages:1") {
+              return {
+                _id: "packages:1",
+                name: "my-pkg",
+                displayName: "My Package",
+                ownerUserId: "users:1",
+                ownerPublisherId: undefined,
+              };
+            }
+            return null;
+          }),
+          query: vi.fn((table: string) => {
+            if (table === "users") {
+              return {
+                withIndex: () => ({
+                  unique: async () => ({
+                    _id: "users:2",
+                    handle: "alice",
+                    displayName: "Alice",
+                  }),
+                }),
+              };
+            }
+            if (table === "packageOwnershipTransfers") {
+              return {
+                withIndex: () => ({
+                  collect: async () => [],
+                }),
+              };
+            }
+            throw new Error(`unexpected table ${table}`);
+          }),
+          patch: vi.fn(async () => {}),
+          insert,
+        },
+      } as never,
+      {
+        actorUserId: "users:1",
+        packageId: "packages:1",
+        toUserHandle: "@Alice",
+      } as never,
+    )) as { ok: boolean; transferId: string; toUserHandle: string };
+
+    expect(result.ok).toBe(true);
+    expect(result.transferId).toBe("packageOwnershipTransfers:new");
+    expect(result.toUserHandle).toBe("alice");
+    expect(insert).toHaveBeenCalledWith(
+      "packageOwnershipTransfers",
+      expect.objectContaining({
+        packageId: "packages:1",
+        fromUserId: "users:1",
+        toUserId: "users:2",
+        status: "pending",
+      }),
+    );
+    expect(insert).toHaveBeenCalledWith(
+      "auditLogs",
+      expect.objectContaining({
+        action: "package.transfer.request",
+        targetType: "package",
+        targetId: "packages:1",
+      }),
+    );
+  });
+
+  it("requestTransferInternal rejects if actor is not owner (Forbidden)", async () => {
+    await expect(
+      requestTransferInternalHandler(
+        {
+          db: {
+            normalizeId: vi.fn(),
+            get: vi.fn(async (id: string) => {
+              if (id === "users:1") return { _id: "users:1", handle: "owner" };
+              if (id === "packages:1") {
+                return {
+                  _id: "packages:1",
+                  name: "my-pkg",
+                  displayName: "My Package",
+                  ownerUserId: "users:someone-else",
+                  ownerPublisherId: undefined,
+                };
+              }
+              return null;
+            }),
+            query: vi.fn(),
+            patch: vi.fn(async () => {}),
+            insert: vi.fn(async () => "auditLogs:1"),
+          },
+        } as never,
+        {
+          actorUserId: "users:1",
+          packageId: "packages:1",
+          toUserHandle: "@alice",
+        } as never,
+      ),
+    ).rejects.toThrow(/Forbidden/);
+  });
+
+  it("requestTransferInternal rejects transfer to self", async () => {
+    await expect(
+      requestTransferInternalHandler(
+        {
+          db: {
+            normalizeId: vi.fn(),
+            get: vi.fn(async (id: string) => {
+              if (id === "users:1") return { _id: "users:1", handle: "owner" };
+              if (id === "packages:1") {
+                return {
+                  _id: "packages:1",
+                  name: "my-pkg",
+                  displayName: "My Package",
+                  ownerUserId: "users:1",
+                  ownerPublisherId: undefined,
+                };
+              }
+              return null;
+            }),
+            query: vi.fn((table: string) => {
+              if (table === "users") {
+                return {
+                  withIndex: () => ({
+                    unique: async () => ({
+                      _id: "users:1",
+                      handle: "owner",
+                      displayName: "Owner",
+                    }),
+                  }),
+                };
+              }
+              if (table === "packageOwnershipTransfers") {
+                return {
+                  withIndex: () => ({
+                    collect: async () => [],
+                  }),
+                };
+              }
+              throw new Error(`unexpected table ${table}`);
+            }),
+            patch: vi.fn(async () => {}),
+            insert: vi.fn(async () => "auditLogs:1"),
+          },
+        } as never,
+        {
+          actorUserId: "users:1",
+          packageId: "packages:1",
+          toUserHandle: "@owner",
+        } as never,
+      ),
+    ).rejects.toThrow(/yourself/i);
+  });
+
+  it("acceptTransferInternal updates package ownerUserId + ownerPublisherId", async () => {
+    const patch = vi.fn(async () => {});
+    const insert = vi.fn(async () => "auditLogs:1");
+    const newPublisher = {
+      _id: "publishers:alice",
+      handle: "alice",
+      displayName: "Alice",
+      linkedUserId: "users:2",
+      trustedPublisher: false,
+    };
+    const existingMember = {
+      _id: "publisherMembers:1",
+      publisherId: "publishers:alice",
+      userId: "users:2",
+      role: "owner",
+    };
+
+    const result = (await acceptTransferInternalHandler(
+      {
+        db: {
+          normalizeId: vi.fn(),
+          get: vi.fn(async (id: string) => {
+            if (id === "users:2") {
+              return {
+                _id: "users:2",
+                handle: "alice",
+                personalPublisherId: "publishers:alice",
+                trustedPublisher: false,
+              };
+            }
+            if (id === "packageOwnershipTransfers:1") {
+              return {
+                _id: "packageOwnershipTransfers:1",
+                packageId: "packages:1",
+                fromUserId: "users:1",
+                toUserId: "users:2",
+                status: "pending",
+                requestedAt: Date.now() - 1_000,
+                expiresAt: Date.now() + 10_000,
+              };
+            }
+            if (id === "packages:1") {
+              return {
+                _id: "packages:1",
+                name: "my-pkg",
+                displayName: "My Package",
+                ownerUserId: "users:1",
+                ownerPublisherId: "publishers:owner",
+              };
+            }
+            if (id === "publishers:alice") {
+              return newPublisher;
+            }
+            return null;
+          }),
+          query: vi.fn((table: string) => {
+            if (table === "publishers") {
+              return {
+                withIndex: (indexName: string) => {
+                  expect(indexName).toBe("by_handle");
+                  return {
+                    unique: async () => newPublisher,
+                  };
+                },
+              };
+            }
+            if (table === "publisherMembers") {
+              return {
+                withIndex: (indexName: string) => {
+                  expect(indexName).toBe("by_publisher_user");
+                  return {
+                    unique: async () => existingMember,
+                  };
+                },
+              };
+            }
+            throw new Error(`unexpected table ${table}`);
+          }),
+          patch,
+          insert,
+        },
+      } as never,
+      {
+        actorUserId: "users:2",
+        transferId: "packageOwnershipTransfers:1",
+      } as never,
+    )) as { ok: boolean; packageName: string };
+
+    expect(result).toEqual({ ok: true, packageName: "my-pkg" });
+    expect(patch).toHaveBeenCalledWith(
+      "packages:1",
+      expect.objectContaining({
+        ownerUserId: "users:2",
+        ownerPublisherId: "publishers:alice",
+      }),
+    );
+    expect(patch).toHaveBeenCalledWith(
+      "packageOwnershipTransfers:1",
+      expect.objectContaining({ status: "accepted" }),
+    );
+  });
+
+  it("acceptTransferInternal cancels stale transfer when ownership changed since request", async () => {
+    const patch = vi.fn(async () => {});
+
+    await expect(
+      acceptTransferInternalHandler(
+        {
+          db: {
+            normalizeId: vi.fn(),
+            query: vi.fn(),
+            get: vi.fn(async (id: string) => {
+              if (id === "users:2") return { _id: "users:2", handle: "alice" };
+              if (id === "packageOwnershipTransfers:1") {
+                return {
+                  _id: "packageOwnershipTransfers:1",
+                  packageId: "packages:1",
+                  fromUserId: "users:1",
+                  toUserId: "users:2",
+                  status: "pending",
+                  requestedAt: Date.now() - 1_000,
+                  expiresAt: Date.now() + 10_000,
+                };
+              }
+              if (id === "packages:1") {
+                return {
+                  _id: "packages:1",
+                  name: "my-pkg",
+                  displayName: "My Package",
+                  ownerUserId: "users:someone-else",
+                };
+              }
+              return null;
+            }),
+            patch,
+            insert: vi.fn(async () => "auditLogs:1"),
+          },
+        } as never,
+        {
+          actorUserId: "users:2",
+          transferId: "packageOwnershipTransfers:1",
+        } as never,
+      ),
+    ).rejects.toThrow(/no longer valid/i);
+
+    expect(patch).toHaveBeenCalledWith(
+      "packageOwnershipTransfers:1",
+      expect.objectContaining({ status: "cancelled" }),
+    );
+    expect(patch).not.toHaveBeenCalledWith(
+      "packages:1",
+      expect.objectContaining({ ownerUserId: "users:2" }),
+    );
+  });
+});

--- a/convex/packageTransfers.ts
+++ b/convex/packageTransfers.ts
@@ -1,0 +1,524 @@
+import { v } from "convex/values";
+import type { Doc, Id } from "./_generated/dataModel";
+import { internalMutation, internalQuery } from "./functions";
+import {
+  ensurePersonalPublisherForUser,
+  getActiveUserByHandleOrPersonalPublisher,
+} from "./lib/publishers";
+import {
+  TRANSFER_EXPIRY_MS,
+  isTransferExpired,
+  normalizeTransferHandle,
+  validateTransferOwnership,
+  validateTransferAcceptPermission,
+} from "./lib/transfers";
+
+type TransferDoc = Doc<"packageOwnershipTransfers">;
+
+async function requireActiveUserById(ctx: unknown, userId: Id<"users">) {
+  const db = (ctx as { db: { get: (id: Id<"users">) => Promise<Doc<"users"> | null> } }).db;
+  const user = await db.get(userId);
+  if (!user || user.deletedAt || user.deactivatedAt) throw new Error("Unauthorized");
+  return user;
+}
+
+async function getActivePendingTransferForPackage(
+  ctx: unknown,
+  packageId: Id<"packages">,
+  now: number,
+) {
+  const db = (
+    ctx as {
+      db: {
+        patch: (
+          id: Id<"packageOwnershipTransfers">,
+          value: Partial<TransferDoc>,
+        ) => Promise<unknown>;
+        query: (table: "packageOwnershipTransfers") => {
+          withIndex: (
+            indexName: "by_package_status",
+            cb: (q: {
+              eq: (
+                field: "packageId",
+                value: Id<"packages">,
+              ) => {
+                eq: (field: "status", value: "pending") => unknown;
+              };
+            }) => unknown,
+          ) => { collect: () => Promise<TransferDoc[]> };
+        };
+      };
+    }
+  ).db;
+
+  const transfers = await db
+    .query("packageOwnershipTransfers")
+    .withIndex("by_package_status", (q) => q.eq("packageId", packageId).eq("status", "pending"))
+    .collect();
+
+  let active: TransferDoc | null = null;
+  for (const transfer of transfers) {
+    if (isTransferExpired(transfer, now)) {
+      await db.patch(transfer._id, { status: "expired", respondedAt: now });
+      continue;
+    }
+    if (!active || transfer.requestedAt > active.requestedAt) active = transfer;
+  }
+  return active;
+}
+
+async function validatePendingTransferForActor(
+  ctx: unknown,
+  params: {
+    transferId: Id<"packageOwnershipTransfers">;
+    actorUserId: Id<"users">;
+    role: "sender" | "recipient";
+    now: number;
+  },
+) {
+  const db = (
+    ctx as {
+      db: {
+        get: (id: Id<"packageOwnershipTransfers">) => Promise<TransferDoc | null>;
+        patch: (
+          id: Id<"packageOwnershipTransfers">,
+          value: Partial<TransferDoc>,
+        ) => Promise<unknown>;
+      };
+    }
+  ).db;
+
+  const transfer = await db.get(params.transferId);
+  if (!transfer) throw new Error("Transfer not found");
+
+  if (
+    params.role === "recipient" &&
+    transfer.toUserId &&
+    transfer.toUserId !== params.actorUserId &&
+    !transfer.toPublisherId
+  ) {
+    // For org-targeted transfers (toPublisherId is set), skip this check —
+    // validateTransferAcceptPermission handles org membership validation separately
+    throw new Error("No pending transfer found");
+  }
+  if (
+    params.role === "sender" &&
+    transfer.fromUserId !== params.actorUserId &&
+    !transfer.fromPublisherId
+  ) {
+    // For org-owned items (fromPublisherId is set), skip this check —
+    // the cancel handler validates org membership separately
+    throw new Error("No pending transfer found");
+  }
+  if (transfer.status !== "pending") throw new Error("No pending transfer found");
+  if (isTransferExpired(transfer, params.now)) {
+    await db.patch(transfer._id, { status: "expired", respondedAt: params.now });
+    throw new Error("Transfer has expired");
+  }
+  return transfer;
+}
+
+export const requestTransferInternal = internalMutation({
+  args: {
+    actorUserId: v.id("users"),
+    packageId: v.id("packages"),
+    toUserHandle: v.string(),
+    toPublisherId: v.optional(v.id("publishers")),
+    message: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    await requireActiveUserById(ctx, args.actorUserId);
+
+    const pkg = await ctx.db.get(args.packageId);
+    if (!pkg || (pkg as Record<string, unknown>).softDeletedAt) throw new Error("Package not found");
+
+    await validateTransferOwnership(ctx, {
+      actorUserId: args.actorUserId,
+      ownerUserId: pkg.ownerUserId,
+      ownerPublisherId: pkg.ownerPublisherId,
+    });
+
+    const toHandle = normalizeTransferHandle(args.toUserHandle);
+    if (!toHandle) throw new Error("toUserHandle required");
+
+    const toUser = await getActiveUserByHandleOrPersonalPublisher(ctx, toHandle);
+    if (!toUser) throw new Error("User not found");
+    if (toUser._id === args.actorUserId && !args.toPublisherId) {
+      throw new Error("Cannot transfer to yourself");
+    }
+
+    if (args.toPublisherId) {
+      const toPublisher = await ctx.db.get(args.toPublisherId);
+      if (!toPublisher || (toPublisher as Record<string, unknown>).deletedAt || (toPublisher as Record<string, unknown>).deactivatedAt) {
+        throw new Error("Target publisher not found");
+      }
+      if ((toPublisher as Record<string, unknown>).kind === "user") {
+        throw new Error("Cannot transfer to a personal publisher");
+      }
+    }
+
+    const activePending = await getActivePendingTransferForPackage(ctx, args.packageId, now);
+    if (activePending) throw new Error("A transfer is already pending for this package");
+
+    const message = args.message?.trim();
+    const expiresAt = now + TRANSFER_EXPIRY_MS;
+    const transferId = await ctx.db.insert("packageOwnershipTransfers", {
+      packageId: pkg._id,
+      fromUserId: args.actorUserId,
+      toUserId: toUser._id,
+      fromPublisherId: pkg.ownerPublisherId,
+      toPublisherId: args.toPublisherId,
+      status: "pending",
+      message: message || undefined,
+      requestedAt: now,
+      expiresAt,
+    });
+
+    await ctx.db.insert("auditLogs", {
+      actorUserId: args.actorUserId,
+      action: "package.transfer.request",
+      targetType: "package",
+      targetId: pkg._id,
+      metadata: {
+        transferId,
+        toUserId: toUser._id,
+        toUserHandle: toUser.handle ?? toHandle,
+      },
+      createdAt: now,
+    });
+
+    return { ok: true as const, transferId, toUserHandle: toUser.handle ?? toHandle, expiresAt };
+  },
+});
+
+export const acceptTransferInternal = internalMutation({
+  args: {
+    actorUserId: v.id("users"),
+    transferId: v.id("packageOwnershipTransfers"),
+    publisherId: v.optional(v.id("publishers")),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const newOwner = await requireActiveUserById(ctx, args.actorUserId);
+
+    const transfer = await validatePendingTransferForActor(ctx, {
+      transferId: args.transferId,
+      actorUserId: args.actorUserId,
+      role: "recipient",
+      now,
+    });
+
+    await validateTransferAcceptPermission(ctx, {
+      toUserId: transfer.toUserId,
+      toPublisherId: transfer.toPublisherId,
+      actorUserId: args.actorUserId,
+    });
+
+    const pkg = await ctx.db.get(transfer.packageId);
+    if (!pkg || (pkg as Record<string, unknown>).softDeletedAt)
+      throw new Error("Package not found");
+    const ownerChanged = transfer.fromPublisherId
+      ? pkg.ownerPublisherId !== transfer.fromPublisherId
+      : pkg.ownerUserId !== transfer.fromUserId;
+    if (ownerChanged) {
+      await ctx.db.patch(transfer._id, { status: "cancelled", respondedAt: now });
+      throw new Error("Transfer is no longer valid");
+    }
+
+    // Determine target publisher: sender's choice > recipient override > personal
+    // When the sender specified a target publisher, honor it unconditionally
+    let targetPublisher: Doc<"publishers"> | null = null;
+    if (transfer.toPublisherId) {
+      targetPublisher = await ctx.db.get(transfer.toPublisherId);
+    } else if (args.publisherId) {
+      await validateTransferAcceptPermission(ctx, {
+        actorUserId: args.actorUserId,
+        toPublisherId: args.publisherId,
+      });
+      targetPublisher = await ctx.db.get(args.publisherId);
+    }
+    if (!targetPublisher) {
+      targetPublisher = await ensurePersonalPublisherForUser(ctx, newOwner);
+    }
+    if (!targetPublisher) throw new Error("Failed to resolve publisher for new owner");
+
+    await ctx.db.patch(pkg._id, {
+      ownerUserId: args.actorUserId,
+      ownerPublisherId: targetPublisher._id,
+    });
+
+    await ctx.db.patch(transfer._id, {
+      status: "accepted",
+      respondedAt: now,
+      toUserId: args.actorUserId,
+    });
+
+    await ctx.db.insert("auditLogs", {
+      actorUserId: args.actorUserId,
+      action: "package.transfer.accept",
+      targetType: "package",
+      targetId: pkg._id,
+      metadata: {
+        transferId: transfer._id,
+        fromUserId: transfer.fromUserId,
+      },
+      createdAt: now,
+    });
+
+    return { ok: true as const, packageName: pkg.name };
+  },
+});
+
+export const rejectTransferInternal = internalMutation({
+  args: {
+    actorUserId: v.id("users"),
+    transferId: v.id("packageOwnershipTransfers"),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    await requireActiveUserById(ctx, args.actorUserId);
+
+    const transfer = await validatePendingTransferForActor(ctx, {
+      transferId: args.transferId,
+      actorUserId: args.actorUserId,
+      role: "recipient",
+      now,
+    });
+
+    await validateTransferAcceptPermission(ctx, {
+      toUserId: transfer.toUserId,
+      toPublisherId: transfer.toPublisherId,
+      actorUserId: args.actorUserId,
+    });
+
+    await ctx.db.patch(transfer._id, { status: "rejected", respondedAt: now });
+    await ctx.db.insert("auditLogs", {
+      actorUserId: args.actorUserId,
+      action: "package.transfer.reject",
+      targetType: "package",
+      targetId: transfer.packageId,
+      metadata: { transferId: transfer._id },
+      createdAt: now,
+    });
+
+    return { ok: true as const };
+  },
+});
+
+export const cancelTransferInternal = internalMutation({
+  args: {
+    actorUserId: v.id("users"),
+    transferId: v.id("packageOwnershipTransfers"),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    await requireActiveUserById(ctx, args.actorUserId);
+
+    const transfer = await validatePendingTransferForActor(ctx, {
+      transferId: args.transferId,
+      actorUserId: args.actorUserId,
+      role: "sender",
+      now,
+    });
+
+    // For org-owned transfers, always verify actor still has admin/owner role
+    if (transfer.fromPublisherId) {
+      await validateTransferOwnership(ctx, {
+        ownerUserId: transfer.fromUserId,
+        ownerPublisherId: transfer.fromPublisherId,
+        actorUserId: args.actorUserId,
+      });
+    }
+
+    await ctx.db.patch(transfer._id, { status: "cancelled", respondedAt: now });
+    await ctx.db.insert("auditLogs", {
+      actorUserId: args.actorUserId,
+      action: "package.transfer.cancel",
+      targetType: "package",
+      targetId: transfer.packageId,
+      metadata: { transferId: transfer._id },
+      createdAt: now,
+    });
+
+    return { ok: true as const };
+  },
+});
+
+export const listIncomingInternal = internalQuery({
+  args: { userId: v.id("users") },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    await requireActiveUserById(ctx, args.userId);
+
+    const transfers = await ctx.db
+      .query("packageOwnershipTransfers")
+      .withIndex("by_to_user_status", (q) => q.eq("toUserId", args.userId).eq("status", "pending"))
+      .collect();
+
+    const results: Array<{
+      _id: Id<"packageOwnershipTransfers">;
+      type: "package";
+      package: { _id: Id<"packages">; name: string; displayName: string };
+      fromUser: { _id: Id<"users">; handle: string | null; displayName: string | null };
+      toUser?: { _id: Id<"users">; handle: string | null; displayName: string | null };
+      message: string | undefined;
+      requestedAt: number;
+      expiresAt: number;
+    }> = [];
+
+    for (const transfer of transfers) {
+      if (isTransferExpired(transfer, now)) continue;
+      const pkg = await ctx.db.get(transfer.packageId);
+      if (!pkg || (pkg as Record<string, unknown>).softDeletedAt) continue;
+      const fromUser = await ctx.db.get(transfer.fromUserId);
+      if (!fromUser || fromUser.deletedAt || fromUser.deactivatedAt) continue;
+
+      let toUser:
+        | { _id: Id<"users">; handle: string | null; displayName: string | null }
+        | undefined;
+      if (transfer.toUserId) {
+        const tu = await ctx.db.get(transfer.toUserId);
+        if (tu && !tu.deletedAt && !tu.deactivatedAt) {
+          toUser = {
+            _id: tu._id,
+            handle: tu.handle ?? null,
+            displayName: tu.displayName ?? null,
+          };
+        }
+      }
+
+      results.push({
+        _id: transfer._id,
+        type: "package",
+        package: { _id: pkg._id, name: pkg.name, displayName: pkg.displayName },
+        fromUser: {
+          _id: fromUser._id,
+          handle: fromUser.handle ?? null,
+          displayName: fromUser.displayName ?? null,
+        },
+        toUser,
+        message: transfer.message,
+        requestedAt: transfer.requestedAt,
+        expiresAt: transfer.expiresAt,
+      });
+    }
+
+    return results;
+  },
+});
+
+export const listOutgoingInternal = internalQuery({
+  args: { userId: v.id("users") },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    await requireActiveUserById(ctx, args.userId);
+
+    const transfers = await ctx.db
+      .query("packageOwnershipTransfers")
+      .withIndex("by_from_user_status", (q) =>
+        q.eq("fromUserId", args.userId).eq("status", "pending"),
+      )
+      .collect();
+
+    const results: Array<{
+      _id: Id<"packageOwnershipTransfers">;
+      type: "package";
+      package: { _id: Id<"packages">; name: string; displayName: string };
+      toUser?: { _id: Id<"users">; handle: string | null; displayName: string | null };
+      message: string | undefined;
+      requestedAt: number;
+      expiresAt: number;
+    }> = [];
+
+    for (const transfer of transfers) {
+      if (isTransferExpired(transfer, now)) continue;
+      const pkg = await ctx.db.get(transfer.packageId);
+      if (!pkg || (pkg as Record<string, unknown>).softDeletedAt) continue;
+
+      let toUser:
+        | { _id: Id<"users">; handle: string | null; displayName: string | null }
+        | undefined;
+      if (transfer.toUserId) {
+        const tu = await ctx.db.get(transfer.toUserId);
+        if (tu && !tu.deletedAt && !tu.deactivatedAt) {
+          toUser = {
+            _id: tu._id,
+            handle: tu.handle ?? null,
+            displayName: tu.displayName ?? null,
+          };
+        }
+      }
+
+      results.push({
+        _id: transfer._id,
+        type: "package",
+        package: { _id: pkg._id, name: pkg.name, displayName: pkg.displayName },
+        toUser,
+        message: transfer.message,
+        requestedAt: transfer.requestedAt,
+        expiresAt: transfer.expiresAt,
+      });
+    }
+
+    return results;
+  },
+});
+
+export const getPendingTransferByPackageInternal = internalQuery({
+  args: {
+    packageId: v.id("packages"),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const transfer = await ctx.db
+      .query("packageOwnershipTransfers")
+      .withIndex("by_package_status", (q) =>
+        q.eq("packageId", args.packageId).eq("status", "pending"),
+      )
+      .first();
+
+    if (!transfer || isTransferExpired(transfer, now)) return null;
+    return transfer;
+  },
+});
+
+export const getPendingTransferByPackageAndUserInternal = internalQuery({
+  args: {
+    packageId: v.id("packages"),
+    toUserId: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const transfer = await ctx.db
+      .query("packageOwnershipTransfers")
+      .withIndex("by_package_status", (q) =>
+        q.eq("packageId", args.packageId).eq("status", "pending"),
+      )
+      .filter((q) => q.eq(q.field("toUserId"), args.toUserId))
+      .first();
+
+    if (!transfer || isTransferExpired(transfer, now)) return null;
+    return transfer;
+  },
+});
+
+export const getPendingTransferByPackageAndFromUserInternal = internalQuery({
+  args: {
+    packageId: v.id("packages"),
+    fromUserId: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const transfer = await ctx.db
+      .query("packageOwnershipTransfers")
+      .withIndex("by_package_status", (q) =>
+        q.eq("packageId", args.packageId).eq("status", "pending"),
+      )
+      .filter((q) => q.eq(q.field("fromUserId"), args.fromUserId))
+      .first();
+
+    if (!transfer || isTransferExpired(transfer, now)) return null;
+    return transfer;
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1305,6 +1305,7 @@ const skillOwnershipTransfers = defineTable({
   .index("by_from_user", ["fromUserId"])
   .index("by_to_user", ["toUserId"])
   .index("by_to_user_status", ["toUserId", "status"])
+  .index("by_to_publisher_status", ["toPublisherId", "status"])
   .index("by_from_user_status", ["fromUserId", "status"])
   .index("by_skill_status", ["skillId", "status"]);
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1286,7 +1286,9 @@ const userSkillRootInstalls = defineTable({
 const skillOwnershipTransfers = defineTable({
   skillId: v.id("skills"),
   fromUserId: v.id("users"),
-  toUserId: v.id("users"),
+  toUserId: v.optional(v.id("users")),
+  fromPublisherId: v.optional(v.id("publishers")),
+  toPublisherId: v.optional(v.id("publishers")),
   status: v.union(
     v.literal("pending"),
     v.literal("accepted"),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1309,6 +1309,31 @@ const skillOwnershipTransfers = defineTable({
   .index("by_from_user_status", ["fromUserId", "status"])
   .index("by_skill_status", ["skillId", "status"]);
 
+const packageOwnershipTransfers = defineTable({
+  packageId: v.id("packages"),
+  fromUserId: v.id("users"),
+  toUserId: v.optional(v.id("users")),
+  fromPublisherId: v.optional(v.id("publishers")),
+  toPublisherId: v.optional(v.id("publishers")),
+  status: v.union(
+    v.literal("pending"),
+    v.literal("accepted"),
+    v.literal("rejected"),
+    v.literal("cancelled"),
+    v.literal("expired"),
+  ),
+  message: v.optional(v.string()),
+  requestedAt: v.number(),
+  respondedAt: v.optional(v.number()),
+  expiresAt: v.number(),
+})
+  .index("by_package", ["packageId"])
+  .index("by_from_user", ["fromUserId"])
+  .index("by_to_user", ["toUserId"])
+  .index("by_to_user_status", ["toUserId", "status"])
+  .index("by_from_user_status", ["fromUserId", "status"])
+  .index("by_package_status", ["packageId", "status"]);
+
 export default defineSchema({
   ...authTables,
   users,
@@ -1356,4 +1381,5 @@ export default defineSchema({
   userSkillInstalls,
   userSkillRootInstalls,
   skillOwnershipTransfers,
+  packageOwnershipTransfers,
 });

--- a/convex/skillTransfers.test.ts
+++ b/convex/skillTransfers.test.ts
@@ -389,4 +389,79 @@ describe("skillTransfers", () => {
       expect.objectContaining({ ownerUserId: "users:2" }),
     );
   });
+
+  it("requestTransferInternal allows org admin to request transfer", async () => {
+    // Org admin (users:2) can request transfer of a skill owned by org (publishers:org1)
+    // even though ownerUserId is users:1
+    const insert = vi.fn(async (table: string) => {
+      if (table === "skillOwnershipTransfers") return "skillOwnershipTransfers:new";
+      return "auditLogs:1";
+    });
+
+    const result = (await requestTransferInternalHandler(
+      {
+        db: {
+          normalizeId: vi.fn(),
+          get: vi.fn(async (id: string) => {
+            if (id === "users:2") return { _id: "users:2", handle: "orgadmin" };
+            if (id === "skills:1") {
+              return {
+                _id: "skills:1",
+                slug: "demo",
+                displayName: "Demo",
+                ownerUserId: "users:1",
+                ownerPublisherId: "publishers:org1",
+              };
+            }
+            if (id === "publishers:org1") {
+              return { _id: "publishers:org1", kind: "org", handle: "myorg" };
+            }
+            return null;
+          }),
+          query: vi.fn((table: string) => {
+            if (table === "users") {
+              return {
+                withIndex: () => ({
+                  unique: async () => ({
+                    _id: "users:3",
+                    handle: "recipient",
+                    displayName: "Recipient",
+                  }),
+                }),
+              };
+            }
+            if (table === "skillOwnershipTransfers") {
+              return { withIndex: () => ({ collect: async () => [] }) };
+            }
+            if (table === "publisherMembers") {
+              return {
+                withIndex: () => ({
+                  unique: async () => ({
+                    _id: "publisherMembers:1",
+                    publisherId: "publishers:org1",
+                    userId: "users:2",
+                    role: "admin",
+                  }),
+                }),
+              };
+            }
+            if (table === "publishers") {
+              return { withIndex: () => ({ unique: async () => null }) };
+            }
+            throw new Error(`unexpected table ${table}`);
+          }),
+          patch: vi.fn(async () => {}),
+          insert,
+        },
+      } as never,
+      {
+        actorUserId: "users:2",
+        skillId: "skills:1",
+        toUserHandle: "@recipient",
+      } as never,
+    )) as { ok: boolean; transferId: string };
+
+    expect(result.ok).toBe(true);
+    expect(result.transferId).toBe("skillOwnershipTransfers:new");
+  });
 });

--- a/convex/skillTransfers.ts
+++ b/convex/skillTransfers.ts
@@ -210,17 +210,17 @@ export const acceptTransferInternal = internalMutation({
       throw new Error("Transfer is no longer valid");
     }
 
-    // Determine target publisher: explicit arg > transfer target > personal publisher
-    // Validate actor has admin/owner role on explicit publisher override
+    // Determine target publisher: sender's choice > recipient override > personal
+    // When the sender specified a target publisher, honor it unconditionally
     let targetPublisherId: Id<"publishers">;
-    if (args.publisherId) {
+    if (transfer.toPublisherId) {
+      targetPublisherId = transfer.toPublisherId;
+    } else if (args.publisherId) {
       await validateTransferAcceptPermission(ctx, {
         actorUserId: args.actorUserId,
         toPublisherId: args.publisherId,
       });
       targetPublisherId = args.publisherId;
-    } else if (transfer.toPublisherId) {
-      targetPublisherId = transfer.toPublisherId;
     } else {
       const newPublisher = await ensurePersonalPublisherForUser(ctx, newOwner);
       if (!newPublisher) throw new Error("Failed to resolve publisher for new owner");

--- a/convex/skillTransfers.ts
+++ b/convex/skillTransfers.ts
@@ -220,6 +220,9 @@ export const acceptTransferInternal = internalMutation({
       targetPublisherId = newPublisher._id;
     }
 
+    // For org-targeted transfers, ownerUserId is set to whichever admin accepts,
+    // not necessarily the original toUserId. The toUserHandle on the request just
+    // routes the transfer — actual ownership reflects who acted on it.
     await ctx.db.patch(skill._id, {
       ownerUserId: args.actorUserId,
       ownerPublisherId: targetPublisherId,

--- a/convex/skillTransfers.ts
+++ b/convex/skillTransfers.ts
@@ -136,6 +136,13 @@ export const requestTransferInternal = internalMutation({
       throw new Error("Cannot transfer to yourself");
     }
 
+    if (args.toPublisherId) {
+      const toPublisher = await ctx.db.get(args.toPublisherId);
+      if (!toPublisher || toPublisher.deletedAt || toPublisher.deactivatedAt) {
+        throw new Error("Target publisher not found");
+      }
+    }
+
     const activePending = await getActivePendingTransferForSkill(ctx, args.skillId, now);
     if (activePending) throw new Error("A transfer is already pending for this skill");
 

--- a/convex/skillTransfers.ts
+++ b/convex/skillTransfers.ts
@@ -91,12 +91,13 @@ async function validatePendingTransferForActor(
     // validateTransferAcceptPermission handles org membership validation separately
     throw new Error("No pending transfer found");
   }
-  if (
-    params.role === "sender" &&
-    transfer.fromUserId !== params.actorUserId &&
-    !transfer.fromPublisherId
-  ) {
-    throw new Error("No pending transfer found");
+  if (params.role === "sender") {
+    if (!transfer.fromPublisherId && transfer.fromUserId !== params.actorUserId) {
+      // Personal transfer: actor must be the original sender
+      throw new Error("No pending transfer found");
+    }
+    // Org-owned transfer: actor's org membership is verified by the caller
+    // (e.g. cancelTransferInternal calls validateTransferOwnership after this)
   }
   if (transfer.status !== "pending") throw new Error("No pending transfer found");
   if (isTransferExpired(transfer, params.now)) {
@@ -351,22 +352,55 @@ export const listIncomingInternal = internalQuery({
     const now = Date.now();
     await requireActiveUserById(ctx, args.userId);
 
-    const transfers = await ctx.db
+    // Query transfers directed at this user personally
+    const userTransfers = await ctx.db
       .query("skillOwnershipTransfers")
       .withIndex("by_to_user_status", (q) => q.eq("toUserId", args.userId).eq("status", "pending"))
       .collect();
+
+    // Query transfers directed at orgs where this user is an admin or owner
+    const memberships = await ctx.db
+      .query("publisherMembers")
+      .withIndex("by_user", (q) => q.eq("userId", args.userId))
+      .collect();
+    const adminPublisherIds = memberships
+      .filter((m) => m.role === "owner" || m.role === "admin")
+      .map((m) => m.publisherId);
+
+    const orgTransferArrays = await Promise.all(
+      adminPublisherIds.map((publisherId) =>
+        ctx.db
+          .query("skillOwnershipTransfers")
+          .withIndex("by_to_publisher_status", (q) =>
+            q.eq("toPublisherId", publisherId).eq("status", "pending"),
+          )
+          .collect(),
+      ),
+    );
+    const orgTransfers = orgTransferArrays.flat();
+
+    // Merge and deduplicate by transfer ID
+    const seen = new Set<string>();
+    const allTransfers: TransferDoc[] = [];
+    for (const t of [...userTransfers, ...orgTransfers]) {
+      if (!seen.has(t._id)) {
+        seen.add(t._id);
+        allTransfers.push(t);
+      }
+    }
 
     const results: Array<{
       type: "skill";
       _id: Id<"skillOwnershipTransfers">;
       skill: { _id: Id<"skills">; slug: string; displayName: string };
       fromUser: { _id: Id<"users">; handle: string | null; displayName: string | null };
+      toPublisherId?: Id<"publishers">;
       message: string | undefined;
       requestedAt: number;
       expiresAt: number;
     }> = [];
 
-    for (const transfer of transfers) {
+    for (const transfer of allTransfers) {
       if (isTransferExpired(transfer, now)) continue;
       const skill = await ctx.db.get(transfer.skillId);
       if (!skill || skill.softDeletedAt) continue;
@@ -382,6 +416,7 @@ export const listIncomingInternal = internalQuery({
           handle: fromUser.handle ?? null,
           displayName: fromUser.displayName ?? null,
         },
+        toPublisherId: transfer.toPublisherId ?? undefined,
         message: transfer.message,
         requestedAt: transfer.requestedAt,
         expiresAt: transfer.expiresAt,

--- a/convex/skillTransfers.ts
+++ b/convex/skillTransfers.ts
@@ -142,6 +142,9 @@ export const requestTransferInternal = internalMutation({
       if (!toPublisher || toPublisher.deletedAt || toPublisher.deactivatedAt) {
         throw new Error("Target publisher not found");
       }
+      if (toPublisher.kind === "user") {
+        throw new Error("Cannot transfer to a personal publisher");
+      }
     }
 
     const activePending = await getActivePendingTransferForSkill(ctx, args.skillId, now);

--- a/convex/skillTransfers.ts
+++ b/convex/skillTransfers.ts
@@ -5,17 +5,15 @@ import {
   ensurePersonalPublisherForUser,
   getActiveUserByHandleOrPersonalPublisher,
 } from "./lib/publishers";
-const TRANSFER_EXPIRY_MS = 7 * 24 * 60 * 60 * 1000;
+import {
+  TRANSFER_EXPIRY_MS,
+  isTransferExpired,
+  normalizeTransferHandle,
+  validateTransferOwnership,
+  validateTransferAcceptPermission,
+} from "./lib/transfers";
 
 type TransferDoc = Doc<"skillOwnershipTransfers">;
-
-function normalizeHandle(value: string) {
-  return value.trim().replace(/^@+/, "").toLowerCase();
-}
-
-function isExpired(transfer: TransferDoc, now: number) {
-  return transfer.expiresAt < now;
-}
 
 async function requireActiveUserById(ctx: unknown, userId: Id<"users">) {
   const db = (ctx as { db: { get: (id: Id<"users">) => Promise<Doc<"users"> | null> } }).db;
@@ -53,7 +51,7 @@ async function getActivePendingTransferForSkill(ctx: unknown, skillId: Id<"skill
 
   let active: TransferDoc | null = null;
   for (const transfer of transfers) {
-    if (isExpired(transfer, now)) {
+    if (isTransferExpired(transfer, now)) {
       await db.patch(transfer._id, { status: "expired", respondedAt: now });
       continue;
     }
@@ -83,14 +81,25 @@ async function validatePendingTransferForActor(
   const transfer = await db.get(params.transferId);
   if (!transfer) throw new Error("Transfer not found");
 
-  if (params.role === "recipient" && transfer.toUserId !== params.actorUserId) {
+  if (
+    params.role === "recipient" &&
+    transfer.toUserId &&
+    transfer.toUserId !== params.actorUserId &&
+    !transfer.toPublisherId
+  ) {
+    // For org-targeted transfers (toPublisherId is set), skip this check —
+    // validateTransferAcceptPermission handles org membership validation separately
     throw new Error("No pending transfer found");
   }
-  if (params.role === "sender" && transfer.fromUserId !== params.actorUserId) {
+  if (
+    params.role === "sender" &&
+    transfer.fromUserId !== params.actorUserId &&
+    !transfer.fromPublisherId
+  ) {
     throw new Error("No pending transfer found");
   }
   if (transfer.status !== "pending") throw new Error("No pending transfer found");
-  if (isExpired(transfer, params.now)) {
+  if (isTransferExpired(transfer, params.now)) {
     await db.patch(transfer._id, { status: "expired", respondedAt: params.now });
     throw new Error("Transfer has expired");
   }
@@ -102,6 +111,7 @@ export const requestTransferInternal = internalMutation({
     actorUserId: v.id("users"),
     skillId: v.id("skills"),
     toUserHandle: v.string(),
+    toPublisherId: v.optional(v.id("publishers")),
     message: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
@@ -110,14 +120,21 @@ export const requestTransferInternal = internalMutation({
 
     const skill = await ctx.db.get(args.skillId);
     if (!skill || skill.softDeletedAt) throw new Error("Skill not found");
-    if (skill.ownerUserId !== args.actorUserId) throw new Error("Forbidden");
 
-    const toHandle = normalizeHandle(args.toUserHandle);
+    await validateTransferOwnership(ctx, {
+      ownerUserId: skill.ownerUserId,
+      ownerPublisherId: skill.ownerPublisherId,
+      actorUserId: args.actorUserId,
+    });
+
+    const toHandle = normalizeTransferHandle(args.toUserHandle);
     if (!toHandle) throw new Error("toUserHandle required");
 
     const toUser = await getActiveUserByHandleOrPersonalPublisher(ctx, toHandle);
     if (!toUser) throw new Error("User not found");
-    if (toUser._id === args.actorUserId) throw new Error("Cannot transfer to yourself");
+    if (toUser._id === args.actorUserId && !args.toPublisherId) {
+      throw new Error("Cannot transfer to yourself");
+    }
 
     const activePending = await getActivePendingTransferForSkill(ctx, args.skillId, now);
     if (activePending) throw new Error("A transfer is already pending for this skill");
@@ -128,6 +145,8 @@ export const requestTransferInternal = internalMutation({
       skillId: skill._id,
       fromUserId: args.actorUserId,
       toUserId: toUser._id,
+      fromPublisherId: skill.ownerPublisherId,
+      toPublisherId: args.toPublisherId,
       status: "pending",
       message: message || undefined,
       requestedAt: now,
@@ -155,6 +174,7 @@ export const acceptTransferInternal = internalMutation({
   args: {
     actorUserId: v.id("users"),
     transferId: v.id("skillOwnershipTransfers"),
+    publisherId: v.optional(v.id("publishers")),
   },
   handler: async (ctx, args) => {
     const now = Date.now();
@@ -167,19 +187,42 @@ export const acceptTransferInternal = internalMutation({
       now,
     });
 
+    await validateTransferAcceptPermission(ctx, {
+      actorUserId: args.actorUserId,
+      toUserId: transfer.toUserId ?? undefined,
+      toPublisherId: transfer.toPublisherId,
+    });
+
     const skill = await ctx.db.get(transfer.skillId);
     if (!skill || skill.softDeletedAt) throw new Error("Skill not found");
-    if (skill.ownerUserId !== transfer.fromUserId) {
+    const ownerChanged = transfer.fromPublisherId
+      ? skill.ownerPublisherId !== transfer.fromPublisherId
+      : skill.ownerUserId !== transfer.fromUserId;
+    if (ownerChanged) {
       await ctx.db.patch(transfer._id, { status: "cancelled", respondedAt: now });
       throw new Error("Transfer is no longer valid");
     }
 
-    const newPublisher = await ensurePersonalPublisherForUser(ctx, newOwner);
-    if (!newPublisher) throw new Error("Failed to resolve publisher for new owner");
+    // Determine target publisher: explicit arg > transfer target > personal publisher
+    // Validate actor has admin/owner role on explicit publisher override
+    let targetPublisherId: Id<"publishers">;
+    if (args.publisherId) {
+      await validateTransferAcceptPermission(ctx, {
+        actorUserId: args.actorUserId,
+        toPublisherId: args.publisherId,
+      });
+      targetPublisherId = args.publisherId;
+    } else if (transfer.toPublisherId) {
+      targetPublisherId = transfer.toPublisherId;
+    } else {
+      const newPublisher = await ensurePersonalPublisherForUser(ctx, newOwner);
+      if (!newPublisher) throw new Error("Failed to resolve publisher for new owner");
+      targetPublisherId = newPublisher._id;
+    }
 
     await ctx.db.patch(skill._id, {
       ownerUserId: args.actorUserId,
-      ownerPublisherId: newPublisher._id,
+      ownerPublisherId: targetPublisherId,
       updatedAt: now,
     });
 
@@ -190,12 +233,16 @@ export const acceptTransferInternal = internalMutation({
     for (const alias of aliases) {
       await ctx.db.patch(alias._id, {
         ownerUserId: args.actorUserId,
-        ownerPublisherId: newPublisher._id,
+        ownerPublisherId: targetPublisherId,
         updatedAt: now,
       });
     }
 
-    await ctx.db.patch(transfer._id, { status: "accepted", respondedAt: now });
+    await ctx.db.patch(transfer._id, {
+      status: "accepted",
+      respondedAt: now,
+      toUserId: args.actorUserId,
+    });
 
     await ctx.db.insert("auditLogs", {
       actorUserId: args.actorUserId,
@@ -229,6 +276,12 @@ export const rejectTransferInternal = internalMutation({
       now,
     });
 
+    await validateTransferAcceptPermission(ctx, {
+      actorUserId: args.actorUserId,
+      toUserId: transfer.toUserId ?? undefined,
+      toPublisherId: transfer.toPublisherId,
+    });
+
     await ctx.db.patch(transfer._id, { status: "rejected", respondedAt: now });
     await ctx.db.insert("auditLogs", {
       actorUserId: args.actorUserId,
@@ -259,6 +312,15 @@ export const cancelTransferInternal = internalMutation({
       now,
     });
 
+    // For org-owned transfers, verify actor is admin/owner of source publisher
+    if (transfer.fromPublisherId && transfer.fromUserId !== args.actorUserId) {
+      await validateTransferOwnership(ctx, {
+        ownerUserId: transfer.fromUserId,
+        ownerPublisherId: transfer.fromPublisherId,
+        actorUserId: args.actorUserId,
+      });
+    }
+
     await ctx.db.patch(transfer._id, { status: "cancelled", respondedAt: now });
     await ctx.db.insert("auditLogs", {
       actorUserId: args.actorUserId,
@@ -285,6 +347,7 @@ export const listIncomingInternal = internalQuery({
       .collect();
 
     const results: Array<{
+      type: "skill";
       _id: Id<"skillOwnershipTransfers">;
       skill: { _id: Id<"skills">; slug: string; displayName: string };
       fromUser: { _id: Id<"users">; handle: string | null; displayName: string | null };
@@ -294,13 +357,14 @@ export const listIncomingInternal = internalQuery({
     }> = [];
 
     for (const transfer of transfers) {
-      if (isExpired(transfer, now)) continue;
+      if (isTransferExpired(transfer, now)) continue;
       const skill = await ctx.db.get(transfer.skillId);
       if (!skill || skill.softDeletedAt) continue;
       const fromUser = await ctx.db.get(transfer.fromUserId);
       if (!fromUser || fromUser.deletedAt || fromUser.deactivatedAt) continue;
 
       results.push({
+        type: "skill" as const,
         _id: transfer._id,
         skill: { _id: skill._id, slug: skill.slug, displayName: skill.displayName },
         fromUser: {
@@ -332,29 +396,41 @@ export const listOutgoingInternal = internalQuery({
       .collect();
 
     const results: Array<{
+      type: "skill";
       _id: Id<"skillOwnershipTransfers">;
       skill: { _id: Id<"skills">; slug: string; displayName: string };
-      toUser: { _id: Id<"users">; handle: string | null; displayName: string | null };
+      toUser?: { _id: Id<"users">; handle: string | null; displayName: string | null };
+      toPublisherId?: Id<"publishers">;
       message: string | undefined;
       requestedAt: number;
       expiresAt: number;
     }> = [];
 
     for (const transfer of transfers) {
-      if (isExpired(transfer, now)) continue;
+      if (isTransferExpired(transfer, now)) continue;
       const skill = await ctx.db.get(transfer.skillId);
       if (!skill || skill.softDeletedAt) continue;
-      const toUser = await ctx.db.get(transfer.toUserId);
-      if (!toUser || toUser.deletedAt || toUser.deactivatedAt) continue;
+
+      let toUser:
+        | { _id: Id<"users">; handle: string | null; displayName: string | null }
+        | undefined;
+      if (transfer.toUserId) {
+        const tu = await ctx.db.get(transfer.toUserId);
+        if (tu && !tu.deletedAt && !tu.deactivatedAt) {
+          toUser = {
+            _id: tu._id,
+            handle: tu.handle ?? null,
+            displayName: tu.displayName ?? null,
+          };
+        }
+      }
 
       results.push({
+        type: "skill" as const,
         _id: transfer._id,
         skill: { _id: skill._id, slug: skill.slug, displayName: skill.displayName },
-        toUser: {
-          _id: toUser._id,
-          handle: toUser.handle ?? null,
-          displayName: toUser.displayName ?? null,
-        },
+        toUser,
+        toPublisherId: transfer.toPublisherId ?? undefined,
         message: transfer.message,
         requestedAt: transfer.requestedAt,
         expiresAt: transfer.expiresAt,
@@ -362,6 +438,22 @@ export const listOutgoingInternal = internalQuery({
     }
 
     return results;
+  },
+});
+
+export const getPendingTransferBySkillInternal = internalQuery({
+  args: {
+    skillId: v.id("skills"),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const transfer = await ctx.db
+      .query("skillOwnershipTransfers")
+      .withIndex("by_skill_status", (q) => q.eq("skillId", args.skillId).eq("status", "pending"))
+      .first();
+
+    if (!transfer || isTransferExpired(transfer, now)) return null;
+    return transfer;
   },
 });
 
@@ -378,7 +470,7 @@ export const getPendingTransferBySkillAndUserInternal = internalQuery({
       .filter((q) => q.eq(q.field("toUserId"), args.toUserId))
       .first();
 
-    if (!transfer || isExpired(transfer, now)) return null;
+    if (!transfer || isTransferExpired(transfer, now)) return null;
     return transfer;
   },
 });
@@ -396,7 +488,7 @@ export const getPendingTransferBySkillAndFromUserInternal = internalQuery({
       .filter((q) => q.eq(q.field("fromUserId"), args.fromUserId))
       .first();
 
-    if (!transfer || isExpired(transfer, now)) return null;
+    if (!transfer || isTransferExpired(transfer, now)) return null;
     return transfer;
   },
 });

--- a/convex/skillTransfers.ts
+++ b/convex/skillTransfers.ts
@@ -315,8 +315,8 @@ export const cancelTransferInternal = internalMutation({
       now,
     });
 
-    // For org-owned transfers, verify actor is admin/owner of source publisher
-    if (transfer.fromPublisherId && transfer.fromUserId !== args.actorUserId) {
+    // For org-owned transfers, always verify actor still has admin/owner role
+    if (transfer.fromPublisherId) {
       await validateTransferOwnership(ctx, {
         ownerUserId: transfer.fromUserId,
         ownerPublisherId: transfer.fromPublisherId,

--- a/docs/api.md
+++ b/docs/api.md
@@ -87,6 +87,10 @@ Auth required:
 - `POST /api/v1/skills/{slug}/transfer/accept`
 - `POST /api/v1/skills/{slug}/transfer/reject`
 - `POST /api/v1/skills/{slug}/transfer/cancel`
+- `POST /api/v1/packages/{name}/transfer`
+- `POST /api/v1/packages/{name}/transfer/accept`
+- `POST /api/v1/packages/{name}/transfer/reject`
+- `POST /api/v1/packages/{name}/transfer/cancel`
 - `GET /api/v1/transfers/incoming`
 - `GET /api/v1/transfers/outgoing`
 - `GET /api/v1/whoami`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -177,18 +177,23 @@ Stores your API token + cached registry URL.
 
 ### `transfer`
 
-- Ownership transfer workflow.
+- Ownership transfer workflow for both skills and packages.
+- Supports user-to-user, user-to-org, org-to-user, and org-to-org transfers.
 - Subcommands:
-  - `transfer request <slug> <handle> [--message "..."] [--yes]`
+  - `transfer request <name> <handle> [--message "..."] [--type skill|package] [--publisher @org] [--yes]`
   - `transfer list [--outgoing]`
-  - `transfer accept <slug> [--yes]`
-  - `transfer reject <slug> [--yes]`
-  - `transfer cancel <slug> [--yes]`
+  - `transfer accept <name> [--type skill|package] [--publisher @org] [--yes]`
+  - `transfer reject <name> [--type skill|package] [--yes]`
+  - `transfer cancel <name> [--type skill|package] [--yes]`
+- `--type`: explicitly specify skill or package. If omitted, auto-detects by probing both APIs. Errors if both a skill and package share the same name.
+- `--publisher @org`: on request, targets the transfer to an org (recipient must be org admin to accept). On accept, assigns ownership to the org instead of the accepting user's personal publisher.
+- `transfer list` shows both skill and package transfers with a TYPE column, sorted by date.
 - Endpoints:
-  - `POST /api/v1/skills/{slug}/transfer`
-  - `POST /api/v1/skills/{slug}/transfer/accept`
-  - `POST /api/v1/skills/{slug}/transfer/reject`
-  - `POST /api/v1/skills/{slug}/transfer/cancel`
+  - `POST /api/v1/skills/{slug}/transfer` (skills)
+  - `POST /api/v1/packages/{name}/transfer` (packages)
+  - `POST /api/v1/{skills|packages}/{id}/transfer/accept`
+  - `POST /api/v1/{skills|packages}/{id}/transfer/reject`
+  - `POST /api/v1/{skills|packages}/{id}/transfer/cancel`
   - `GET /api/v1/transfers/incoming`
   - `GET /api/v1/transfers/outgoing`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -177,20 +177,23 @@ Stores your API token + cached registry URL.
 
 ### `transfer`
 
-- Skill ownership transfer workflow.
+- Ownership transfer workflow for both skills and packages.
 - Supports user-to-user, user-to-org, org-to-user, and org-to-org transfers.
 - Subcommands:
-  - `transfer request <slug> <handle> [--message "..."] [--publisher @org] [--yes]`
+  - `transfer request <name> <handle> [--message "..."] [--type skill|package] [--publisher @org] [--yes]`
   - `transfer list [--outgoing]`
-  - `transfer accept <slug> [--publisher @org] [--yes]`
-  - `transfer reject <slug> [--yes]`
-  - `transfer cancel <slug> [--yes]`
+  - `transfer accept <name> [--type skill|package] [--publisher @org] [--yes]`
+  - `transfer reject <name> [--type skill|package] [--yes]`
+  - `transfer cancel <name> [--type skill|package] [--yes]`
+- `--type`: explicitly specify skill or package. If omitted, auto-detects by probing both APIs. Errors if both a skill and package share the same name.
 - `--publisher @org`: on request, targets the transfer to an org (recipient must be org admin to accept). On accept, assigns ownership to the org instead of the accepting user's personal publisher.
+- `transfer list` shows both skill and package transfers with a TYPE column, sorted by date.
 - Endpoints:
-  - `POST /api/v1/skills/{slug}/transfer`
-  - `POST /api/v1/skills/{slug}/transfer/accept`
-  - `POST /api/v1/skills/{slug}/transfer/reject`
-  - `POST /api/v1/skills/{slug}/transfer/cancel`
+  - `POST /api/v1/skills/{slug}/transfer` (skills)
+  - `POST /api/v1/packages/{name}/transfer` (packages)
+  - `POST /api/v1/{skills|packages}/{id}/transfer/accept`
+  - `POST /api/v1/{skills|packages}/{id}/transfer/reject`
+  - `POST /api/v1/{skills|packages}/{id}/transfer/cancel`
   - `GET /api/v1/transfers/incoming`
   - `GET /api/v1/transfers/outgoing`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -177,23 +177,20 @@ Stores your API token + cached registry URL.
 
 ### `transfer`
 
-- Ownership transfer workflow for both skills and packages.
+- Skill ownership transfer workflow.
 - Supports user-to-user, user-to-org, org-to-user, and org-to-org transfers.
 - Subcommands:
-  - `transfer request <name> <handle> [--message "..."] [--type skill|package] [--publisher @org] [--yes]`
+  - `transfer request <slug> <handle> [--message "..."] [--publisher @org] [--yes]`
   - `transfer list [--outgoing]`
-  - `transfer accept <name> [--type skill|package] [--publisher @org] [--yes]`
-  - `transfer reject <name> [--type skill|package] [--yes]`
-  - `transfer cancel <name> [--type skill|package] [--yes]`
-- `--type`: explicitly specify skill or package. If omitted, auto-detects by probing both APIs. Errors if both a skill and package share the same name.
+  - `transfer accept <slug> [--publisher @org] [--yes]`
+  - `transfer reject <slug> [--yes]`
+  - `transfer cancel <slug> [--yes]`
 - `--publisher @org`: on request, targets the transfer to an org (recipient must be org admin to accept). On accept, assigns ownership to the org instead of the accepting user's personal publisher.
-- `transfer list` shows both skill and package transfers with a TYPE column, sorted by date.
 - Endpoints:
-  - `POST /api/v1/skills/{slug}/transfer` (skills)
-  - `POST /api/v1/packages/{name}/transfer` (packages)
-  - `POST /api/v1/{skills|packages}/{id}/transfer/accept`
-  - `POST /api/v1/{skills|packages}/{id}/transfer/reject`
-  - `POST /api/v1/{skills|packages}/{id}/transfer/cancel`
+  - `POST /api/v1/skills/{slug}/transfer`
+  - `POST /api/v1/skills/{slug}/transfer/accept`
+  - `POST /api/v1/skills/{slug}/transfer/reject`
+  - `POST /api/v1/skills/{slug}/transfer/cancel`
   - `GET /api/v1/transfers/incoming`
   - `GET /api/v1/transfers/outgoing`
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -478,16 +478,33 @@ Notes:
 
 ### Transfer ownership endpoints
 
+Transfers support user-to-user, user-to-org, org-to-user, and org-to-org flows for skills. Org-targeted transfers require the actor to hold `admin` or `owner` role on the relevant publisher.
+
+#### Skill transfers
+
 - `POST /api/v1/skills/{slug}/transfer`
-  - Body: `{ "toUserHandle": "target_handle", "message": "optional" }`
+  - Body: `{ "toUserHandle": "target_handle", "message": "optional", "toPublisherHandle": "optional_org_handle" }`
+  - When `toPublisherHandle` is provided, the transfer targets the org. The recipient (or any org admin) accepts on behalf of the org.
   - Response: `{ "ok": true, "transferId": "skillOwnershipTransfers:...", "toUserHandle": "target_handle", "expiresAt": 1730000000000 }`
 - `POST /api/v1/skills/{slug}/transfer/accept`
+  - Optional body: `{ "publisherHandle": "org_handle" }` — assign the skill to an org instead of the accepting user's personal publisher.
 - `POST /api/v1/skills/{slug}/transfer/reject`
 - `POST /api/v1/skills/{slug}/transfer/cancel`
   - Response (accept/reject/cancel): `{ "ok": true, "skillSlug": "demo-skill?" }`
+
+#### Transfer listing
+
 - `GET /api/v1/transfers/incoming`
 - `GET /api/v1/transfers/outgoing`
-  - Response shape: `{ "transfers": [{ "_id": "...", "skill": { "slug": "demo", "displayName": "Demo" }, "fromUser"|"toUser": { "handle": "..." }, "message": "...", "requestedAt": 0, "expiresAt": 0 }] }`
+  - Returns skill transfers, sorted by `requestedAt` descending.
+  - Response shape: `{ "transfers": [{ "_id": "...", "type": "skill", "skill": { "slug": "demo", "displayName": "Demo" }, "fromUser"|"toUser": { "handle": "..." }, "message": "...", "requestedAt": 0, "expiresAt": 0 }] }`
+
+#### Transfer rules
+
+- Pending transfers expire after 7 days.
+- Only one pending transfer per skill at a time.
+- Ownership is re-validated at accept time; if ownership changed since the request, the transfer is auto-cancelled.
+- Org transfers require `admin` or `owner` role on the source/target publisher.
 
 ### `POST /api/v1/users/ban`
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -478,7 +478,7 @@ Notes:
 
 ### Transfer ownership endpoints
 
-Transfers support user-to-user, user-to-org, org-to-user, and org-to-org flows for skills. Org-targeted transfers require the actor to hold `admin` or `owner` role on the relevant publisher.
+Transfers support user-to-user, user-to-org, org-to-user, and org-to-org flows for both skills and packages. Org-targeted transfers require the actor to hold `admin` or `owner` role on the relevant publisher.
 
 #### Skill transfers
 
@@ -492,17 +492,28 @@ Transfers support user-to-user, user-to-org, org-to-user, and org-to-org flows f
 - `POST /api/v1/skills/{slug}/transfer/cancel`
   - Response (accept/reject/cancel): `{ "ok": true, "skillSlug": "demo-skill?" }`
 
+#### Package transfers
+
+- `POST /api/v1/packages/{name}/transfer`
+  - Body: `{ "toUserHandle": "target_handle", "message": "optional", "toPublisherHandle": "optional_org_handle" }`
+  - Response: `{ "ok": true, "transferId": "packageOwnershipTransfers:...", "toUserHandle": "target_handle", "expiresAt": 1730000000000 }`
+- `POST /api/v1/packages/{name}/transfer/accept`
+  - Optional body: `{ "publisherHandle": "org_handle" }` — assign to an org on accept.
+- `POST /api/v1/packages/{name}/transfer/reject`
+- `POST /api/v1/packages/{name}/transfer/cancel`
+  - Response (accept/reject/cancel): `{ "ok": true, "packageName": "my-plugin?" }`
+
 #### Transfer listing
 
 - `GET /api/v1/transfers/incoming`
 - `GET /api/v1/transfers/outgoing`
-  - Returns skill transfers, sorted by `requestedAt` descending.
-  - Response shape: `{ "transfers": [{ "_id": "...", "type": "skill", "skill": { "slug": "demo", "displayName": "Demo" }, "fromUser"|"toUser": { "handle": "..." }, "message": "...", "requestedAt": 0, "expiresAt": 0 }] }`
+  - Returns both skill and package transfers, sorted by `requestedAt` descending.
+  - Response shape: `{ "transfers": [{ "_id": "...", "type": "skill"|"package", "skill": { "slug": "demo", "displayName": "Demo" }?, "package": { "name": "my-plugin", "displayName": "My Plugin" }?, "fromUser"|"toUser": { "handle": "..." }, "message": "...", "requestedAt": 0, "expiresAt": 0 }] }`
 
 #### Transfer rules
 
 - Pending transfers expire after 7 days.
-- Only one pending transfer per skill at a time.
+- Only one pending transfer per skill/package at a time.
 - Ownership is re-validated at accept time; if ownership changed since the request, the transfer is auto-cancelled.
 - Org transfers require `admin` or `owner` role on the source/target publisher.
 

--- a/docs/orgs.md
+++ b/docs/orgs.md
@@ -325,12 +325,9 @@ Semantics:
 
 ## Transfer Model
 
-Current transfers are user-to-user only. That is too narrow.
+Transfers support publisher-based flows for both skills and packages:
 
-New transfer target should be a publisher.
-
-Support:
-
+- user publisher -> user publisher
 - user publisher -> org publisher
 - org publisher -> user publisher
 - org publisher -> org publisher
@@ -339,12 +336,12 @@ Transfer acceptance rule:
 
 - actor must have `owner` or `admin` on target publisher
 
-Audit should record:
+Audit records:
 
 - actor user id
-- source publisher id
-- target publisher id
-- resource id
+- source publisher id (`fromPublisherId`)
+- target publisher id (`toPublisherId`)
+- resource id (skill or package)
 
 ## Search Digest Changes
 

--- a/packages/clawhub/src/cli.ts
+++ b/packages/clawhub/src/cli.ts
@@ -499,19 +499,20 @@ program
     await cmdSetRole(opts, handleOrId, role, options, isInputAllowed());
   });
 
-const transfer = program.command("transfer").description("Transfer skill ownership");
+const transfer = program.command("transfer").description("Transfer skill/package ownership");
 
 transfer
   .command("request")
-  .description("Request skill transfer to another user or organization")
-  .argument("<slug>", "Skill slug")
+  .description("Request transfer to another user or organization")
+  .argument("<name>", "Skill slug or package name")
   .argument("<handle>", "Recipient handle (e.g., @username)")
   .option("--message <text>", "Optional message for recipient")
+  .option("--type <type>", "Item type: skill or package (auto-detected if omitted)")
   .option("--publisher <handle>", "Target org publisher handle")
   .option("--yes", "Skip confirmation")
-  .action(async (slug, handle, options) => {
+  .action(async (name, handle, options) => {
     const opts = await resolveGlobalOpts();
-    await cmdTransferRequest(opts, slug, handle, options, isInputAllowed());
+    await cmdTransferRequest(opts, name, handle, options, isInputAllowed());
   });
 
 transfer
@@ -525,33 +526,36 @@ transfer
 
 transfer
   .command("accept")
-  .description("Accept incoming skill transfer")
-  .argument("<slug>", "Skill slug")
-  .option("--publisher <handle>", "Accept to org publisher instead of personal")
+  .description("Accept incoming transfer")
+  .argument("<name>", "Skill slug or package name")
+  .option("--type <type>", "Item type: skill or package (auto-detected if omitted)")
+  .option("--publisher <handle>", "Target org publisher handle")
   .option("--yes", "Skip confirmation")
-  .action(async (slug, options) => {
+  .action(async (name, options) => {
     const opts = await resolveGlobalOpts();
-    await cmdTransferAccept(opts, slug, options, isInputAllowed());
+    await cmdTransferAccept(opts, name, options, isInputAllowed());
   });
 
 transfer
   .command("reject")
-  .description("Reject incoming skill transfer")
-  .argument("<slug>", "Skill slug")
+  .description("Reject incoming transfer")
+  .argument("<name>", "Skill slug or package name")
+  .option("--type <type>", "Item type: skill or package (auto-detected if omitted)")
   .option("--yes", "Skip confirmation")
-  .action(async (slug, options) => {
+  .action(async (name, options) => {
     const opts = await resolveGlobalOpts();
-    await cmdTransferReject(opts, slug, options, isInputAllowed());
+    await cmdTransferReject(opts, name, options, isInputAllowed());
   });
 
 transfer
   .command("cancel")
-  .description("Cancel outgoing skill transfer")
-  .argument("<slug>", "Skill slug")
+  .description("Cancel outgoing transfer")
+  .argument("<name>", "Skill slug or package name")
+  .option("--type <type>", "Item type: skill or package (auto-detected if omitted)")
   .option("--yes", "Skip confirmation")
-  .action(async (slug, options) => {
+  .action(async (name, options) => {
     const opts = await resolveGlobalOpts();
-    await cmdTransferCancel(opts, slug, options, isInputAllowed());
+    await cmdTransferCancel(opts, name, options, isInputAllowed());
   });
 
 program

--- a/packages/clawhub/src/cli.ts
+++ b/packages/clawhub/src/cli.ts
@@ -499,18 +499,20 @@ program
     await cmdSetRole(opts, handleOrId, role, options, isInputAllowed());
   });
 
-const transfer = program.command("transfer").description("Transfer skill ownership");
+const transfer = program.command("transfer").description("Transfer skill/package ownership");
 
 transfer
   .command("request")
-  .description("Request skill transfer to another user")
-  .argument("<slug>", "Skill slug")
+  .description("Request transfer to another user or organization")
+  .argument("<name>", "Skill slug or package name")
   .argument("<handle>", "Recipient handle (e.g., @username)")
   .option("--message <text>", "Optional message for recipient")
+  .option("--type <type>", "Item type: skill or package (auto-detected if omitted)")
+  .option("--publisher <handle>", "Target org publisher handle")
   .option("--yes", "Skip confirmation")
-  .action(async (slug, handle, options) => {
+  .action(async (name, handle, options) => {
     const opts = await resolveGlobalOpts();
-    await cmdTransferRequest(opts, slug, handle, options, isInputAllowed());
+    await cmdTransferRequest(opts, name, handle, options, isInputAllowed());
   });
 
 transfer
@@ -524,32 +526,36 @@ transfer
 
 transfer
   .command("accept")
-  .description("Accept incoming transfer for a skill")
-  .argument("<slug>", "Skill slug")
+  .description("Accept incoming transfer")
+  .argument("<name>", "Skill slug or package name")
+  .option("--type <type>", "Item type: skill or package (auto-detected if omitted)")
+  .option("--publisher <handle>", "Target org publisher handle")
   .option("--yes", "Skip confirmation")
-  .action(async (slug, options) => {
+  .action(async (name, options) => {
     const opts = await resolveGlobalOpts();
-    await cmdTransferAccept(opts, slug, options, isInputAllowed());
+    await cmdTransferAccept(opts, name, options, isInputAllowed());
   });
 
 transfer
   .command("reject")
-  .description("Reject incoming transfer for a skill")
-  .argument("<slug>", "Skill slug")
+  .description("Reject incoming transfer")
+  .argument("<name>", "Skill slug or package name")
+  .option("--type <type>", "Item type: skill or package (auto-detected if omitted)")
   .option("--yes", "Skip confirmation")
-  .action(async (slug, options) => {
+  .action(async (name, options) => {
     const opts = await resolveGlobalOpts();
-    await cmdTransferReject(opts, slug, options, isInputAllowed());
+    await cmdTransferReject(opts, name, options, isInputAllowed());
   });
 
 transfer
   .command("cancel")
-  .description("Cancel outgoing transfer for a skill")
-  .argument("<slug>", "Skill slug")
+  .description("Cancel outgoing transfer")
+  .argument("<name>", "Skill slug or package name")
+  .option("--type <type>", "Item type: skill or package (auto-detected if omitted)")
   .option("--yes", "Skip confirmation")
-  .action(async (slug, options) => {
+  .action(async (name, options) => {
     const opts = await resolveGlobalOpts();
-    await cmdTransferCancel(opts, slug, options, isInputAllowed());
+    await cmdTransferCancel(opts, name, options, isInputAllowed());
   });
 
 program

--- a/packages/clawhub/src/cli.ts
+++ b/packages/clawhub/src/cli.ts
@@ -499,20 +499,19 @@ program
     await cmdSetRole(opts, handleOrId, role, options, isInputAllowed());
   });
 
-const transfer = program.command("transfer").description("Transfer skill/package ownership");
+const transfer = program.command("transfer").description("Transfer skill ownership");
 
 transfer
   .command("request")
-  .description("Request transfer to another user or organization")
-  .argument("<name>", "Skill slug or package name")
+  .description("Request skill transfer to another user or organization")
+  .argument("<slug>", "Skill slug")
   .argument("<handle>", "Recipient handle (e.g., @username)")
   .option("--message <text>", "Optional message for recipient")
-  .option("--type <type>", "Item type: skill or package (auto-detected if omitted)")
   .option("--publisher <handle>", "Target org publisher handle")
   .option("--yes", "Skip confirmation")
-  .action(async (name, handle, options) => {
+  .action(async (slug, handle, options) => {
     const opts = await resolveGlobalOpts();
-    await cmdTransferRequest(opts, name, handle, options, isInputAllowed());
+    await cmdTransferRequest(opts, slug, handle, options, isInputAllowed());
   });
 
 transfer
@@ -526,36 +525,33 @@ transfer
 
 transfer
   .command("accept")
-  .description("Accept incoming transfer")
-  .argument("<name>", "Skill slug or package name")
-  .option("--type <type>", "Item type: skill or package (auto-detected if omitted)")
-  .option("--publisher <handle>", "Target org publisher handle")
+  .description("Accept incoming skill transfer")
+  .argument("<slug>", "Skill slug")
+  .option("--publisher <handle>", "Accept to org publisher instead of personal")
   .option("--yes", "Skip confirmation")
-  .action(async (name, options) => {
+  .action(async (slug, options) => {
     const opts = await resolveGlobalOpts();
-    await cmdTransferAccept(opts, name, options, isInputAllowed());
+    await cmdTransferAccept(opts, slug, options, isInputAllowed());
   });
 
 transfer
   .command("reject")
-  .description("Reject incoming transfer")
-  .argument("<name>", "Skill slug or package name")
-  .option("--type <type>", "Item type: skill or package (auto-detected if omitted)")
+  .description("Reject incoming skill transfer")
+  .argument("<slug>", "Skill slug")
   .option("--yes", "Skip confirmation")
-  .action(async (name, options) => {
+  .action(async (slug, options) => {
     const opts = await resolveGlobalOpts();
-    await cmdTransferReject(opts, name, options, isInputAllowed());
+    await cmdTransferReject(opts, slug, options, isInputAllowed());
   });
 
 transfer
   .command("cancel")
-  .description("Cancel outgoing transfer")
-  .argument("<name>", "Skill slug or package name")
-  .option("--type <type>", "Item type: skill or package (auto-detected if omitted)")
+  .description("Cancel outgoing skill transfer")
+  .argument("<slug>", "Skill slug")
   .option("--yes", "Skip confirmation")
-  .action(async (name, options) => {
+  .action(async (slug, options) => {
     const opts = await resolveGlobalOpts();
-    await cmdTransferCancel(opts, name, options, isInputAllowed());
+    await cmdTransferCancel(opts, slug, options, isInputAllowed());
   });
 
 program

--- a/packages/clawhub/src/cli/commands/transfer.test.ts
+++ b/packages/clawhub/src/cli/commands/transfer.test.ts
@@ -64,8 +64,10 @@ describe("transfer commands", () => {
       }),
       expect.anything(),
     );
-    const requestArgs = httpMocks.apiRequest.mock.calls[0]?.[1] as { body?: string };
-    expect(requestArgs.body).toContain('"toUserHandle":"alice"');
+    const requestArgs = httpMocks.apiRequest.mock.calls[0]?.[1] as {
+      body?: Record<string, string>;
+    };
+    expect(requestArgs.body?.toUserHandle).toBe("alice");
   });
 
   it("list calls incoming transfers endpoint", async () => {

--- a/packages/clawhub/src/cli/commands/transfer.test.ts
+++ b/packages/clawhub/src/cli/commands/transfer.test.ts
@@ -35,9 +35,9 @@ afterEach(() => {
 
 describe("transfer commands", () => {
   it("request requires --yes when input is disabled", async () => {
-    await expect(cmdTransferRequest(makeGlobalOpts(), "demo", "@alice", {}, false)).rejects.toThrow(
-      /--yes/i,
-    );
+    await expect(
+      cmdTransferRequest(makeGlobalOpts(), "demo", "@alice", { type: "skill" }, false),
+    ).rejects.toThrow(/--yes/i);
   });
 
   it("request calls transfer endpoint", async () => {
@@ -52,7 +52,7 @@ describe("transfer commands", () => {
       makeGlobalOpts(),
       "Demo",
       "@Alice",
-      { yes: true, message: "Please take over" },
+      { yes: true, message: "Please take over", type: "skill" },
       false,
     );
 
@@ -108,9 +108,9 @@ describe("transfer commands", () => {
       skillSlug: "demo",
     });
 
-    await cmdTransferAccept(makeGlobalOpts(), "demo", { yes: true }, false);
-    await cmdTransferReject(makeGlobalOpts(), "demo", { yes: true }, false);
-    await cmdTransferCancel(makeGlobalOpts(), "demo", { yes: true }, false);
+    await cmdTransferAccept(makeGlobalOpts(), "demo", { yes: true, type: "skill" }, false);
+    await cmdTransferReject(makeGlobalOpts(), "demo", { yes: true, type: "skill" }, false);
+    await cmdTransferCancel(makeGlobalOpts(), "demo", { yes: true, type: "skill" }, false);
 
     expect(httpMocks.apiRequest).toHaveBeenCalledWith(
       expect.anything(),

--- a/packages/clawhub/src/cli/commands/transfer.ts
+++ b/packages/clawhub/src/cli/commands/transfer.ts
@@ -247,7 +247,7 @@ async function runTransferDecision(
         method: "POST",
         path: `${resolveApiPath(name, itemType)}/transfer/${spec.action}`,
         token,
-        ...(body ? { body: JSON.stringify(body) } : {}),
+        ...(body ? { body } : {}),
       },
       ApiV1TransferDecisionResponseSchema,
     );

--- a/packages/clawhub/src/cli/commands/transfer.ts
+++ b/packages/clawhub/src/cli/commands/transfer.ts
@@ -43,10 +43,10 @@ const DECISION_SPECS: Record<DecisionAction, DecisionSpec> = {
   },
 };
 
-function normalizeSlug(slugArg: string) {
-  const slug = slugArg.trim().toLowerCase();
-  if (!slug) fail("Skill slug required");
-  return slug;
+function normalizeName(nameArg: string) {
+  const name = nameArg.trim().toLowerCase();
+  if (!name) fail("Skill slug or package name required");
+  return name;
 }
 
 function canPrompt(inputAllowed: boolean) {
@@ -59,39 +59,101 @@ async function requireYesOrConfirm(options: ConfirmOptions, inputAllowed: boolea
   return promptConfirm(prompt);
 }
 
+async function resolveItemType(
+  opts: GlobalOpts,
+  name: string,
+  explicitType?: string,
+): Promise<"skill" | "package"> {
+  if (explicitType === "skill" || explicitType === "package") return explicitType;
+  if (explicitType) fail(`Invalid type "${explicitType}". Use "skill" or "package".`);
+
+  const token = await requireAuthToken();
+  const registry = await getRegistry(opts, { cache: true });
+
+  const [skillRes, pkgRes] = await Promise.all([
+    fetch(
+      new URL(
+        `${ApiRoutes.skills}/${encodeURIComponent(name)}`,
+        registry,
+      ).toString(),
+      { headers: { Authorization: `Bearer ${token}` } },
+    ).then((r) => r.ok),
+    fetch(
+      new URL(
+        `${ApiRoutes.packages}/${encodeURIComponent(name)}`,
+        registry,
+      ).toString(),
+      { headers: { Authorization: `Bearer ${token}` } },
+    ).then(async (r) => {
+      if (!r.ok) return false;
+      // The packages endpoint falls back to returning skills when no package
+      // exists, so check that the response actually contains a package
+      try {
+        const body = await r.json();
+        return Boolean(body?.package);
+      } catch {
+        return false;
+      }
+    }),
+  ]);
+
+  if (skillRes && pkgRes)
+    fail(
+      `Found both a skill and package named "${name}". Use --type skill or --type package to specify.`,
+    );
+  if (skillRes) return "skill";
+  if (pkgRes) return "package";
+  fail(
+    `No skill or package named "${name}" found. If the item is private, use --type skill or --type package to skip auto-detection.`,
+  );
+}
+
+function resolveApiPath(name: string, type: "skill" | "package"): string {
+  return type === "package"
+    ? `${ApiRoutes.packages}/${encodeURIComponent(name)}`
+    : `${ApiRoutes.skills}/${encodeURIComponent(name)}`;
+}
+
 export async function cmdTransferRequest(
   opts: GlobalOpts,
-  slugArg: string,
+  nameArg: string,
   toHandleArg: string,
-  options: ConfirmOptions & { message?: string },
+  options: ConfirmOptions & { message?: string; type?: string; publisher?: string },
   inputAllowed: boolean,
 ) {
-  const slug = normalizeSlug(slugArg);
+  const name = normalizeName(nameArg);
   const toHandle = toHandleArg.trim().replace(/^@+/, "").toLowerCase();
   if (!toHandle) fail("Recipient handle required (e.g., @username)");
+
+  const itemType = await resolveItemType(opts, name, options.type);
 
   const confirmed = await requireYesOrConfirm(
     options,
     inputAllowed,
-    `Transfer ${slug} to @${toHandle}? Recipient must accept.`,
+    `Transfer ${itemType} "${name}" to @${toHandle}? Recipient must accept.`,
   );
   if (!confirmed) return;
 
   const token = await requireAuthToken();
   const registry = await getRegistry(opts, { cache: true });
-  const spinner = createSpinner(`Requesting transfer of ${slug} to @${toHandle}`);
+  const spinner = createSpinner(`Requesting transfer of ${itemType} "${name}" to @${toHandle}`);
 
   try {
+    const body: Record<string, string | undefined> = {
+      toUserHandle: toHandle,
+      message: options.message,
+    };
+    if (options.publisher) {
+      body.toPublisherHandle = options.publisher.replace(/^@+/, "");
+    }
+
     const result = await apiRequest(
       registry,
       {
         method: "POST",
-        path: `${ApiRoutes.skills}/${encodeURIComponent(slug)}/transfer`,
+        path: `${resolveApiPath(name, itemType)}/transfer`,
         token,
-        body: JSON.stringify({
-          toUserHandle: toHandle,
-          message: options.message,
-        }),
+        body,
       },
       ApiV1TransferRequestResponseSchema,
     );
@@ -100,7 +162,7 @@ export async function cmdTransferRequest(
       result,
       "Transfer request response",
     );
-    spinner.succeed(`Transfer requested for ${slug} to @${parsed.toUserHandle}`);
+    spinner.succeed(`Transfer requested for ${itemType} "${name}" to @${parsed.toUserHandle}`);
     return parsed;
   } catch (error) {
     spinner.fail(formatError(error));
@@ -131,6 +193,7 @@ export async function cmdTransferList(opts: GlobalOpts, options: { outgoing?: bo
     }
 
     console.log(options.outgoing ? "Outgoing transfers:" : "Incoming transfers:");
+    console.log("  TYPE      NAME                  FROM/TO       EXPIRES");
     for (const transfer of parsed.transfers) {
       const otherHandle = options.outgoing ? transfer.toUser?.handle : transfer.fromUser?.handle;
       const other = otherHandle ? `@${otherHandle.replace(/^@+/, "")}` : "(unknown user)";
@@ -138,7 +201,11 @@ export async function cmdTransferList(opts: GlobalOpts, options: { outgoing?: bo
         0,
         Math.ceil((transfer.expiresAt - Date.now()) / (24 * 60 * 60 * 1000)),
       );
-      console.log(`  ${transfer.skill.slug} -> ${other} (expires in ${expiresInDays}d)`);
+      const itemType = transfer.type ?? "skill";
+      const itemName = transfer.package?.name ?? transfer.skill?.slug ?? "(unknown)";
+      console.log(
+        `  ${itemType.padEnd(9)} ${itemName.padEnd(21)} ${other.padEnd(13)} ${expiresInDays}d`,
+      );
     }
     return parsed;
   } catch (error) {
@@ -149,35 +216,43 @@ export async function cmdTransferList(opts: GlobalOpts, options: { outgoing?: bo
 
 async function runTransferDecision(
   opts: GlobalOpts,
-  slugArg: string,
-  options: ConfirmOptions,
+  nameArg: string,
+  options: ConfirmOptions & { type?: string; publisher?: string },
   inputAllowed: boolean,
   spec: DecisionSpec,
 ) {
-  const slug = normalizeSlug(slugArg);
+  const name = normalizeName(nameArg);
+  const itemType = await resolveItemType(opts, name, options.type);
+
   const confirmed = await requireYesOrConfirm(
     options,
     inputAllowed,
-    `${spec.verb} transfer of ${slug}?`,
+    `${spec.verb} transfer of ${itemType} "${name}"?`,
   );
   if (!confirmed) return;
 
   const token = await requireAuthToken();
   const registry = await getRegistry(opts, { cache: true });
-  const spinner = createSpinner(`${spec.progress} transfer of ${slug}`);
+  const spinner = createSpinner(`${spec.progress} transfer of ${itemType} "${name}"`);
 
   try {
+    const body: Record<string, string> | undefined =
+      spec.action === "accept" && options.publisher
+        ? { publisherHandle: options.publisher.replace(/^@+/, "") }
+        : undefined;
+
     const result = await apiRequest(
       registry,
       {
         method: "POST",
-        path: `${ApiRoutes.skills}/${encodeURIComponent(slug)}/transfer/${spec.action}`,
+        path: `${resolveApiPath(name, itemType)}/transfer/${spec.action}`,
         token,
+        ...(body ? { body: JSON.stringify(body) } : {}),
       },
       ApiV1TransferDecisionResponseSchema,
     );
     const parsed = parseArk(ApiV1TransferDecisionResponseSchema, result, "Transfer response");
-    spinner.succeed(`${spec.success} (${slug})`);
+    spinner.succeed(`${spec.success} (${name})`);
     return parsed;
   } catch (error) {
     spinner.fail(formatError(error));
@@ -187,27 +262,27 @@ async function runTransferDecision(
 
 export function cmdTransferAccept(
   opts: GlobalOpts,
-  slugArg: string,
-  options: ConfirmOptions,
+  nameArg: string,
+  options: ConfirmOptions & { type?: string; publisher?: string },
   inputAllowed: boolean,
 ) {
-  return runTransferDecision(opts, slugArg, options, inputAllowed, DECISION_SPECS.accept);
+  return runTransferDecision(opts, nameArg, options, inputAllowed, DECISION_SPECS.accept);
 }
 
 export function cmdTransferReject(
   opts: GlobalOpts,
-  slugArg: string,
-  options: ConfirmOptions,
+  nameArg: string,
+  options: ConfirmOptions & { type?: string },
   inputAllowed: boolean,
 ) {
-  return runTransferDecision(opts, slugArg, options, inputAllowed, DECISION_SPECS.reject);
+  return runTransferDecision(opts, nameArg, options, inputAllowed, DECISION_SPECS.reject);
 }
 
 export function cmdTransferCancel(
   opts: GlobalOpts,
-  slugArg: string,
-  options: ConfirmOptions,
+  nameArg: string,
+  options: ConfirmOptions & { type?: string },
   inputAllowed: boolean,
 ) {
-  return runTransferDecision(opts, slugArg, options, inputAllowed, DECISION_SPECS.cancel);
+  return runTransferDecision(opts, nameArg, options, inputAllowed, DECISION_SPECS.cancel);
 }

--- a/packages/clawhub/src/cli/commands/transfer.ts
+++ b/packages/clawhub/src/cli/commands/transfer.ts
@@ -43,10 +43,10 @@ const DECISION_SPECS: Record<DecisionAction, DecisionSpec> = {
   },
 };
 
-function normalizeSlug(slugArg: string) {
-  const slug = slugArg.trim().toLowerCase();
-  if (!slug) fail("Skill slug required");
-  return slug;
+function normalizeName(nameArg: string) {
+  const name = nameArg.trim().toLowerCase();
+  if (!name) fail("Skill slug or package name required");
+  return name;
 }
 
 function canPrompt(inputAllowed: boolean) {
@@ -59,27 +59,84 @@ async function requireYesOrConfirm(options: ConfirmOptions, inputAllowed: boolea
   return promptConfirm(prompt);
 }
 
+async function resolveItemType(
+  opts: GlobalOpts,
+  name: string,
+  explicitType?: string,
+): Promise<"skill" | "package"> {
+  if (explicitType === "skill" || explicitType === "package") return explicitType;
+  if (explicitType) fail(`Invalid type "${explicitType}". Use "skill" or "package".`);
+
+  const token = await requireAuthToken();
+  const registry = await getRegistry(opts, { cache: true });
+
+  const [skillRes, pkgRes] = await Promise.all([
+    fetch(
+      new URL(
+        `${ApiRoutes.skills}/${encodeURIComponent(name)}`,
+        registry,
+      ).toString(),
+      { headers: { Authorization: `Bearer ${token}` } },
+    ).then((r) => r.ok),
+    fetch(
+      new URL(
+        `${ApiRoutes.packages}/${encodeURIComponent(name)}`,
+        registry,
+      ).toString(),
+      { headers: { Authorization: `Bearer ${token}` } },
+    ).then(async (r) => {
+      if (!r.ok) return false;
+      // The packages endpoint falls back to returning skills when no package
+      // exists, so check that the response actually contains a package
+      try {
+        const body = await r.json();
+        return Boolean(body?.package);
+      } catch {
+        return false;
+      }
+    }),
+  ]);
+
+  if (skillRes && pkgRes)
+    fail(
+      `Found both a skill and package named "${name}". Use --type skill or --type package to specify.`,
+    );
+  if (skillRes) return "skill";
+  if (pkgRes) return "package";
+  fail(
+    `No skill or package named "${name}" found. If the item is private, use --type skill or --type package to skip auto-detection.`,
+  );
+}
+
+function resolveApiPath(name: string, type: "skill" | "package"): string {
+  return type === "package"
+    ? `${ApiRoutes.packages}/${encodeURIComponent(name)}`
+    : `${ApiRoutes.skills}/${encodeURIComponent(name)}`;
+}
+
 export async function cmdTransferRequest(
   opts: GlobalOpts,
-  slugArg: string,
+  nameArg: string,
   toHandleArg: string,
-  options: ConfirmOptions & { message?: string; publisher?: string },
+  options: ConfirmOptions & { message?: string; type?: string; publisher?: string },
   inputAllowed: boolean,
 ) {
-  const slug = normalizeSlug(slugArg);
+  const name = normalizeName(nameArg);
   const toHandle = toHandleArg.trim().replace(/^@+/, "").toLowerCase();
   if (!toHandle) fail("Recipient handle required (e.g., @username)");
+
+  const itemType = await resolveItemType(opts, name, options.type);
 
   const confirmed = await requireYesOrConfirm(
     options,
     inputAllowed,
-    `Transfer skill "${slug}" to @${toHandle}? Recipient must accept.`,
+    `Transfer ${itemType} "${name}" to @${toHandle}? Recipient must accept.`,
   );
   if (!confirmed) return;
 
   const token = await requireAuthToken();
   const registry = await getRegistry(opts, { cache: true });
-  const spinner = createSpinner(`Requesting transfer of ${slug} to @${toHandle}`);
+  const spinner = createSpinner(`Requesting transfer of ${itemType} "${name}" to @${toHandle}`);
 
   try {
     const body: Record<string, string | undefined> = {
@@ -94,7 +151,7 @@ export async function cmdTransferRequest(
       registry,
       {
         method: "POST",
-        path: `${ApiRoutes.skills}/${encodeURIComponent(slug)}/transfer`,
+        path: `${resolveApiPath(name, itemType)}/transfer`,
         token,
         body,
       },
@@ -105,7 +162,7 @@ export async function cmdTransferRequest(
       result,
       "Transfer request response",
     );
-    spinner.succeed(`Transfer requested for ${slug} to @${parsed.toUserHandle}`);
+    spinner.succeed(`Transfer requested for ${itemType} "${name}" to @${parsed.toUserHandle}`);
     return parsed;
   } catch (error) {
     spinner.fail(formatError(error));
@@ -136,6 +193,7 @@ export async function cmdTransferList(opts: GlobalOpts, options: { outgoing?: bo
     }
 
     console.log(options.outgoing ? "Outgoing transfers:" : "Incoming transfers:");
+    console.log("  TYPE      NAME                  FROM/TO       EXPIRES");
     for (const transfer of parsed.transfers) {
       const otherHandle = options.outgoing ? transfer.toUser?.handle : transfer.fromUser?.handle;
       const other = otherHandle ? `@${otherHandle.replace(/^@+/, "")}` : "(unknown user)";
@@ -143,7 +201,11 @@ export async function cmdTransferList(opts: GlobalOpts, options: { outgoing?: bo
         0,
         Math.ceil((transfer.expiresAt - Date.now()) / (24 * 60 * 60 * 1000)),
       );
-      console.log(`  ${transfer.skill.slug} -> ${other} (expires in ${expiresInDays}d)`);
+      const itemType = transfer.type ?? "skill";
+      const itemName = transfer.package?.name ?? transfer.skill?.slug ?? "(unknown)";
+      console.log(
+        `  ${itemType.padEnd(9)} ${itemName.padEnd(21)} ${other.padEnd(13)} ${expiresInDays}d`,
+      );
     }
     return parsed;
   } catch (error) {
@@ -154,23 +216,24 @@ export async function cmdTransferList(opts: GlobalOpts, options: { outgoing?: bo
 
 async function runTransferDecision(
   opts: GlobalOpts,
-  slugArg: string,
-  options: ConfirmOptions & { publisher?: string },
+  nameArg: string,
+  options: ConfirmOptions & { type?: string; publisher?: string },
   inputAllowed: boolean,
   spec: DecisionSpec,
 ) {
-  const slug = normalizeSlug(slugArg);
+  const name = normalizeName(nameArg);
+  const itemType = await resolveItemType(opts, name, options.type);
 
   const confirmed = await requireYesOrConfirm(
     options,
     inputAllowed,
-    `${spec.verb} transfer of ${slug}?`,
+    `${spec.verb} transfer of ${itemType} "${name}"?`,
   );
   if (!confirmed) return;
 
   const token = await requireAuthToken();
   const registry = await getRegistry(opts, { cache: true });
-  const spinner = createSpinner(`${spec.progress} transfer of ${slug}`);
+  const spinner = createSpinner(`${spec.progress} transfer of ${itemType} "${name}"`);
 
   try {
     const body: Record<string, string> | undefined =
@@ -182,14 +245,14 @@ async function runTransferDecision(
       registry,
       {
         method: "POST",
-        path: `${ApiRoutes.skills}/${encodeURIComponent(slug)}/transfer/${spec.action}`,
+        path: `${resolveApiPath(name, itemType)}/transfer/${spec.action}`,
         token,
         ...(body ? { body } : {}),
       },
       ApiV1TransferDecisionResponseSchema,
     );
     const parsed = parseArk(ApiV1TransferDecisionResponseSchema, result, "Transfer response");
-    spinner.succeed(`${spec.success} (${slug})`);
+    spinner.succeed(`${spec.success} (${name})`);
     return parsed;
   } catch (error) {
     spinner.fail(formatError(error));
@@ -199,27 +262,27 @@ async function runTransferDecision(
 
 export function cmdTransferAccept(
   opts: GlobalOpts,
-  slugArg: string,
-  options: ConfirmOptions & { publisher?: string },
+  nameArg: string,
+  options: ConfirmOptions & { type?: string; publisher?: string },
   inputAllowed: boolean,
 ) {
-  return runTransferDecision(opts, slugArg, options, inputAllowed, DECISION_SPECS.accept);
+  return runTransferDecision(opts, nameArg, options, inputAllowed, DECISION_SPECS.accept);
 }
 
 export function cmdTransferReject(
   opts: GlobalOpts,
-  slugArg: string,
-  options: ConfirmOptions,
+  nameArg: string,
+  options: ConfirmOptions & { type?: string },
   inputAllowed: boolean,
 ) {
-  return runTransferDecision(opts, slugArg, options, inputAllowed, DECISION_SPECS.reject);
+  return runTransferDecision(opts, nameArg, options, inputAllowed, DECISION_SPECS.reject);
 }
 
 export function cmdTransferCancel(
   opts: GlobalOpts,
-  slugArg: string,
-  options: ConfirmOptions,
+  nameArg: string,
+  options: ConfirmOptions & { type?: string },
   inputAllowed: boolean,
 ) {
-  return runTransferDecision(opts, slugArg, options, inputAllowed, DECISION_SPECS.cancel);
+  return runTransferDecision(opts, nameArg, options, inputAllowed, DECISION_SPECS.cancel);
 }

--- a/packages/clawhub/src/cli/commands/transfer.ts
+++ b/packages/clawhub/src/cli/commands/transfer.ts
@@ -43,10 +43,10 @@ const DECISION_SPECS: Record<DecisionAction, DecisionSpec> = {
   },
 };
 
-function normalizeName(nameArg: string) {
-  const name = nameArg.trim().toLowerCase();
-  if (!name) fail("Skill slug or package name required");
-  return name;
+function normalizeSlug(slugArg: string) {
+  const slug = slugArg.trim().toLowerCase();
+  if (!slug) fail("Skill slug required");
+  return slug;
 }
 
 function canPrompt(inputAllowed: boolean) {
@@ -59,84 +59,27 @@ async function requireYesOrConfirm(options: ConfirmOptions, inputAllowed: boolea
   return promptConfirm(prompt);
 }
 
-async function resolveItemType(
-  opts: GlobalOpts,
-  name: string,
-  explicitType?: string,
-): Promise<"skill" | "package"> {
-  if (explicitType === "skill" || explicitType === "package") return explicitType;
-  if (explicitType) fail(`Invalid type "${explicitType}". Use "skill" or "package".`);
-
-  const token = await requireAuthToken();
-  const registry = await getRegistry(opts, { cache: true });
-
-  const [skillRes, pkgRes] = await Promise.all([
-    fetch(
-      new URL(
-        `${ApiRoutes.skills}/${encodeURIComponent(name)}`,
-        registry,
-      ).toString(),
-      { headers: { Authorization: `Bearer ${token}` } },
-    ).then((r) => r.ok),
-    fetch(
-      new URL(
-        `${ApiRoutes.packages}/${encodeURIComponent(name)}`,
-        registry,
-      ).toString(),
-      { headers: { Authorization: `Bearer ${token}` } },
-    ).then(async (r) => {
-      if (!r.ok) return false;
-      // The packages endpoint falls back to returning skills when no package
-      // exists, so check that the response actually contains a package
-      try {
-        const body = await r.json();
-        return Boolean(body?.package);
-      } catch {
-        return false;
-      }
-    }),
-  ]);
-
-  if (skillRes && pkgRes)
-    fail(
-      `Found both a skill and package named "${name}". Use --type skill or --type package to specify.`,
-    );
-  if (skillRes) return "skill";
-  if (pkgRes) return "package";
-  fail(
-    `No skill or package named "${name}" found. If the item is private, use --type skill or --type package to skip auto-detection.`,
-  );
-}
-
-function resolveApiPath(name: string, type: "skill" | "package"): string {
-  return type === "package"
-    ? `${ApiRoutes.packages}/${encodeURIComponent(name)}`
-    : `${ApiRoutes.skills}/${encodeURIComponent(name)}`;
-}
-
 export async function cmdTransferRequest(
   opts: GlobalOpts,
-  nameArg: string,
+  slugArg: string,
   toHandleArg: string,
-  options: ConfirmOptions & { message?: string; type?: string; publisher?: string },
+  options: ConfirmOptions & { message?: string; publisher?: string },
   inputAllowed: boolean,
 ) {
-  const name = normalizeName(nameArg);
+  const slug = normalizeSlug(slugArg);
   const toHandle = toHandleArg.trim().replace(/^@+/, "").toLowerCase();
   if (!toHandle) fail("Recipient handle required (e.g., @username)");
-
-  const itemType = await resolveItemType(opts, name, options.type);
 
   const confirmed = await requireYesOrConfirm(
     options,
     inputAllowed,
-    `Transfer ${itemType} "${name}" to @${toHandle}? Recipient must accept.`,
+    `Transfer skill "${slug}" to @${toHandle}? Recipient must accept.`,
   );
   if (!confirmed) return;
 
   const token = await requireAuthToken();
   const registry = await getRegistry(opts, { cache: true });
-  const spinner = createSpinner(`Requesting transfer of ${itemType} "${name}" to @${toHandle}`);
+  const spinner = createSpinner(`Requesting transfer of ${slug} to @${toHandle}`);
 
   try {
     const body: Record<string, string | undefined> = {
@@ -151,7 +94,7 @@ export async function cmdTransferRequest(
       registry,
       {
         method: "POST",
-        path: `${resolveApiPath(name, itemType)}/transfer`,
+        path: `${ApiRoutes.skills}/${encodeURIComponent(slug)}/transfer`,
         token,
         body,
       },
@@ -162,7 +105,7 @@ export async function cmdTransferRequest(
       result,
       "Transfer request response",
     );
-    spinner.succeed(`Transfer requested for ${itemType} "${name}" to @${parsed.toUserHandle}`);
+    spinner.succeed(`Transfer requested for ${slug} to @${parsed.toUserHandle}`);
     return parsed;
   } catch (error) {
     spinner.fail(formatError(error));
@@ -193,7 +136,6 @@ export async function cmdTransferList(opts: GlobalOpts, options: { outgoing?: bo
     }
 
     console.log(options.outgoing ? "Outgoing transfers:" : "Incoming transfers:");
-    console.log("  TYPE      NAME                  FROM/TO       EXPIRES");
     for (const transfer of parsed.transfers) {
       const otherHandle = options.outgoing ? transfer.toUser?.handle : transfer.fromUser?.handle;
       const other = otherHandle ? `@${otherHandle.replace(/^@+/, "")}` : "(unknown user)";
@@ -201,11 +143,7 @@ export async function cmdTransferList(opts: GlobalOpts, options: { outgoing?: bo
         0,
         Math.ceil((transfer.expiresAt - Date.now()) / (24 * 60 * 60 * 1000)),
       );
-      const itemType = transfer.type ?? "skill";
-      const itemName = transfer.package?.name ?? transfer.skill?.slug ?? "(unknown)";
-      console.log(
-        `  ${itemType.padEnd(9)} ${itemName.padEnd(21)} ${other.padEnd(13)} ${expiresInDays}d`,
-      );
+      console.log(`  ${transfer.skill.slug} -> ${other} (expires in ${expiresInDays}d)`);
     }
     return parsed;
   } catch (error) {
@@ -216,24 +154,23 @@ export async function cmdTransferList(opts: GlobalOpts, options: { outgoing?: bo
 
 async function runTransferDecision(
   opts: GlobalOpts,
-  nameArg: string,
-  options: ConfirmOptions & { type?: string; publisher?: string },
+  slugArg: string,
+  options: ConfirmOptions & { publisher?: string },
   inputAllowed: boolean,
   spec: DecisionSpec,
 ) {
-  const name = normalizeName(nameArg);
-  const itemType = await resolveItemType(opts, name, options.type);
+  const slug = normalizeSlug(slugArg);
 
   const confirmed = await requireYesOrConfirm(
     options,
     inputAllowed,
-    `${spec.verb} transfer of ${itemType} "${name}"?`,
+    `${spec.verb} transfer of ${slug}?`,
   );
   if (!confirmed) return;
 
   const token = await requireAuthToken();
   const registry = await getRegistry(opts, { cache: true });
-  const spinner = createSpinner(`${spec.progress} transfer of ${itemType} "${name}"`);
+  const spinner = createSpinner(`${spec.progress} transfer of ${slug}`);
 
   try {
     const body: Record<string, string> | undefined =
@@ -245,14 +182,14 @@ async function runTransferDecision(
       registry,
       {
         method: "POST",
-        path: `${resolveApiPath(name, itemType)}/transfer/${spec.action}`,
+        path: `${ApiRoutes.skills}/${encodeURIComponent(slug)}/transfer/${spec.action}`,
         token,
         ...(body ? { body } : {}),
       },
       ApiV1TransferDecisionResponseSchema,
     );
     const parsed = parseArk(ApiV1TransferDecisionResponseSchema, result, "Transfer response");
-    spinner.succeed(`${spec.success} (${name})`);
+    spinner.succeed(`${spec.success} (${slug})`);
     return parsed;
   } catch (error) {
     spinner.fail(formatError(error));
@@ -262,27 +199,27 @@ async function runTransferDecision(
 
 export function cmdTransferAccept(
   opts: GlobalOpts,
-  nameArg: string,
-  options: ConfirmOptions & { type?: string; publisher?: string },
+  slugArg: string,
+  options: ConfirmOptions & { publisher?: string },
   inputAllowed: boolean,
 ) {
-  return runTransferDecision(opts, nameArg, options, inputAllowed, DECISION_SPECS.accept);
+  return runTransferDecision(opts, slugArg, options, inputAllowed, DECISION_SPECS.accept);
 }
 
 export function cmdTransferReject(
   opts: GlobalOpts,
-  nameArg: string,
-  options: ConfirmOptions & { type?: string },
+  slugArg: string,
+  options: ConfirmOptions,
   inputAllowed: boolean,
 ) {
-  return runTransferDecision(opts, nameArg, options, inputAllowed, DECISION_SPECS.reject);
+  return runTransferDecision(opts, slugArg, options, inputAllowed, DECISION_SPECS.reject);
 }
 
 export function cmdTransferCancel(
   opts: GlobalOpts,
-  nameArg: string,
-  options: ConfirmOptions & { type?: string },
+  slugArg: string,
+  options: ConfirmOptions,
   inputAllowed: boolean,
 ) {
-  return runTransferDecision(opts, nameArg, options, inputAllowed, DECISION_SPECS.cancel);
+  return runTransferDecision(opts, slugArg, options, inputAllowed, DECISION_SPECS.cancel);
 }

--- a/packages/clawhub/src/schema/schemas.ts
+++ b/packages/clawhub/src/schema/schemas.ts
@@ -295,16 +295,23 @@ export const ApiV1TransferRequestResponseSchema = type({
 export const ApiV1TransferDecisionResponseSchema = type({
   ok: "true",
   skillSlug: "string?",
+  packageName: "string?",
 });
 
 export const ApiV1TransferListResponseSchema = type({
   transfers: type({
     _id: "string",
+    type: "string?",
     skill: type({
       _id: "string",
       slug: "string",
       displayName: "string",
-    }),
+    }).optional(),
+    package: type({
+      _id: "string",
+      name: "string",
+      displayName: "string",
+    }).optional(),
     fromUser: type({
       _id: "string",
       handle: "string|null",

--- a/packages/clawhub/src/schema/schemas.ts
+++ b/packages/clawhub/src/schema/schemas.ts
@@ -295,23 +295,16 @@ export const ApiV1TransferRequestResponseSchema = type({
 export const ApiV1TransferDecisionResponseSchema = type({
   ok: "true",
   skillSlug: "string?",
-  packageName: "string?",
 });
 
 export const ApiV1TransferListResponseSchema = type({
   transfers: type({
     _id: "string",
-    type: "string?",
     skill: type({
       _id: "string",
       slug: "string",
       displayName: "string",
-    }).optional(),
-    package: type({
-      _id: "string",
-      name: "string",
-      displayName: "string",
-    }).optional(),
+    }),
     fromUser: type({
       _id: "string",
       handle: "string|null",


### PR DESCRIPTION
## Summary

Adds the ability to transfer ownership of packages between users and organizations, completing the ownership transfer system alongside the skill org support in #1603.

This is **PR 2 of 2**, chained on top of #1603 (skill transfer org support). **Please merge #1603 first** — this PR includes those changes plus the package-specific additions. The incremental diff (what this PR adds beyond #1603) is 8 files / +1229 lines, focused purely on the package transfer system.

This separation keeps the review surface manageable: #1603 introduces the shared infrastructure and extends skills, while this PR applies those same patterns to packages as a clean additive layer.

Resolves https://github.com/openclaw/clawhub/issues/1431

## Motivation

Once a package was published under a personal account, there was no way to reassign it to an organization. Users who published packages under their personal handle and later wanted to move them under their org were stuck. This PR introduces package ownership transfers mirroring the skill transfer system, supporting user→user, user→org, org→user, and org→org flows.

## What's new (beyond #1603)

### Package transfers backend (`convex/packageTransfers.ts`)
- Full transfer lifecycle: request → accept / reject / cancel
- 7-day auto-expiry on pending transfers
- Only one pending transfer per package at a time
- Ownership re-validation at accept time — uses `fromPublisherId` for org transfers to correctly handle org admin vs `ownerUserId` mismatch
- Any org admin can accept, reject, or cancel (not just the named recipient/sender)
- Explicit `publisherId` override on accept validated against org membership
- Self-recipient allowed for org-targeted transfers
- Inactive publisher rejection on accept
- Audit logging for all transfer actions (`package.transfer.request/accept/reject/cancel`)

### Schema changes
- New `packageOwnershipTransfers` table mirroring `skillOwnershipTransfers` shape with indexes: `by_package`, `by_from_user`, `by_to_user`, `by_to_user_status`, `by_from_user_status`, `by_package_status`

### HTTP endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/api/v1/packages/{name}/transfer` | Request transfer (body: `toUserHandle`, optional `toPublisherHandle`, `message`) |
| POST | `/api/v1/packages/{name}/transfer/accept` | Accept (optional body: `publisherHandle` to assign to org) |
| POST | `/api/v1/packages/{name}/transfer/reject` | Reject pending transfer |
| POST | `/api/v1/packages/{name}/transfer/cancel` | Cancel outgoing transfer |

- Publisher handles resolved to IDs server-side
- Malformed accept body returns parse error instead of silently falling through
- Org admin fallback lookup in HTTP handlers for accept/reject/cancel

### Unified transfer listing
- `GET /api/v1/transfers/incoming` and `GET /api/v1/transfers/outgoing` now return both skill and package transfers
- Results include `type: "skill" | "package"` discriminator, sorted by `requestedAt` descending

### Transfer rules
- Pending transfers expire after 7 days
- Only one pending transfer per package at a time
- Ownership re-validated at accept time; if ownership changed since the request, the transfer is auto-cancelled
- Org transfers require `admin` or `owner` role on the source/target publisher

## Incremental files changed (on top of #1603: 8 files, +1229 / -67)

| File | Change |
|------|--------|
| `convex/packageTransfers.ts` | New — package transfer mutations and queries |
| `convex/packageTransfers.test.ts` | New — 5 tests for package transfers |
| `convex/schema.ts` | New `packageOwnershipTransfers` table |
| `convex/httpApiV1/packagesV1.ts` | Merged POST router: transfers + trusted-publisher |
| `convex/httpApiV1/transfersV1.ts` | Unified listing: merges skill + package transfers |
| `convex/httpApiV1.handlers.test.ts` | Updated transfer listing test for dual-source query |
| `docs/http-api.md` | Package transfer endpoint documentation |
| `docs/api.md` | Added package transfer endpoints to API listing |

## Test plan

- [x] 131 tests pass (28 transfer-specific + 103 HTTP handler tests)
- [x] TypeScript compiles with zero new errors
- [x] Merge simulation verified: #1603 → main (fast-forward), then this PR → main (fast-forward), zero conflicts
- [x] All 18 scenarios verified end-to-end: user/org transfers for both skills and packages, reject/cancel, expiry, ownership change detection, permission checks, auto-detection