### PR TITLE
Add issuer to GitHub authentication configuration

### DIFF
--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -74,7 +74,7 @@ export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
   providers: [
     GitHub({
       clientId: process.env.AUTH_GITHUB_ID ?? "",
-      clientSecret: process.env.AUTH_GITHUB_SECRET ?? "",,
+      clientSecret: process.env.AUTH_GITHUB_SECRET ?? "",
       issuer: "https://github.com/login/oauth",
       profile(profile) {
         return {

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -74,7 +74,8 @@ export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
   providers: [
     GitHub({
       clientId: process.env.AUTH_GITHUB_ID ?? "",
-      clientSecret: process.env.AUTH_GITHUB_SECRET ?? "",
+      clientSecret: process.env.AUTH_GITHUB_SECRET ?? "",,
+      issuer: "https://github.com/login/oauth",
       profile(profile) {
         return {
           id: String(profile.id),


### PR DESCRIPTION
Rather than waiting on convex to pick up the fix from nextjs here: https://github.com/nextauthjs/next-auth/pull/13410

This pulls the issuer config up to your convex profile.  It's untested, I'm afraid, but happy to figure out how to build and deploy if it helps. 

This fixes the issues reported here: 
* https://github.com/openclaw/clawhub/issues/1621
* https://github.com/openclaw/clawhub/issues/1619

The root cause of those issues can be read about here: https://github.com/langfuse/langfuse/issues/13091

The net is that we rolled out a new security feature, but this uncovered a bug / unexpected behavior in nextJS and its component libraries. Apps attempted to validate the issuer value in the code response, but nextJS gives them nothing to validate it against, causing the validation to fail. By providing the issuer in your config, your app will now successfully validate the issuer value that we send (when we start sending it again, in the future). 