### PR TITLE
fix: enhance dark mode styles in SkillsToolbar component

### DIFF
--- a/src/routes/skills/-SkillsToolbar.tsx
+++ b/src/routes/skills/-SkillsToolbar.tsx
@@ -260,7 +260,7 @@ function FilterChip({
       type="button"
       aria-pressed={active}
       onClick={onClick}
-      className={`inline-flex items-center gap-1.5 rounded-[var(--radius-sm)] border border-[rgba(29,59,78,0.22)] bg-[rgba(255,255,255,0.94)] px-3.5 min-h-[36px] text-xs font-semibold transition-all duration-150 ${
+      className={`inline-flex items-center gap-1.5 rounded-[var(--radius-sm)] border border-[rgba(29,59,78,0.22)] bg-[rgba(255,255,255,0.94)] dark:border-[rgba(255,255,255,0.12)] dark:bg-[rgba(14,28,37,0.84)] px-3.5 min-h-[36px] text-xs font-semibold transition-all duration-150 ${
         active
           ? "border-[color:var(--accent)]/30 bg-[color:var(--accent)]/10 text-[color:var(--accent)]"
           : "text-[color:var(--ink-soft)] hover:border-[color:var(--border-ui-hover)] hover:text-[color:var(--ink)] dark:text-[rgba(245,238,232,0.88)] dark:hover:text-[rgba(245,238,232,0.96)]"


### PR DESCRIPTION
### Summary

The first two filter chips on the skills browse toolbar (“Staff Picks” and “Clean only”) only applied light-mode surface styles (white background and light-theme border). In dark mode they stayed bright and looked wrong next to the category and sort controls, which already use the shared dark surface tokens.

### Changes

- Update `FilterChip` in `src/routes/skills/-SkillsToolbar.tsx` with the same dark-mode border and background as other toolbar controls (`dark:border-[rgba(255,255,255,0.12)]`, `dark:bg-[rgba(14,28,37,0.84)]`).

### Testing

- Open the skills browse page in dark theme and confirm the two chips match the “All categories” / sort surfaces when inactive.
- Toggle each chip on and confirm the active (accent) state still reads clearly.

### Screenshots

before
<img width="2752" height="392" alt="image" src="https://github.com/user-attachments/assets/d301e3e9-13e1-4083-acd1-f7c6b2acafc7" />

after
<img width="2734" height="330" alt="image" src="https://github.com/user-attachments/assets/a719e29c-856d-4771-bf73-784497d07bb5" />
