### PR TITLE
refactor: update SkillStats and SoulStats components for improved layout

### DIFF
--- a/src/components/SkillStats.tsx
+++ b/src/components/SkillStats.tsx
@@ -8,9 +8,13 @@ type SkillMetricsStats = SkillStatsTriplet & {
 export function SkillStatsTripletLine({ stats }: { stats: SkillStatsTriplet }) {
   const formatted = formatSkillStatsTriplet(stats);
   return (
-    <>
-      ⭐ {formatted.stars} · <Package size={13} aria-hidden="true" /> {formatted.downloads}
-    </>
+    <span className="inline-flex items-center gap-1.5">
+      <span className="inline-flex items-center gap-0.5">⭐ {formatted.stars}</span>
+      <span className="opacity-40">·</span>
+      <span className="inline-flex items-center gap-0.5">
+        <Package size={13} aria-hidden="true" /> {formatted.downloads}
+      </span>
+    </span>
   );
 }
 

--- a/src/components/SoulStats.tsx
+++ b/src/components/SoulStats.tsx
@@ -10,10 +10,15 @@ export function SoulStatsTripletLine({
 }) {
   const formatted = formatSoulStatsTriplet(stats);
   return (
-    <>
-      ⭐ {formatted.stars} · <Package size={13} aria-hidden="true" /> {formatted.downloads} ·{" "}
-      {formatted.versions} {versionSuffix}
-    </>
+    <span className="inline-flex items-center gap-1.5">
+      <span className="inline-flex items-center gap-0.5">⭐ {formatted.stars}</span>
+      <span className="opacity-40">·</span>
+      <span className="inline-flex items-center gap-0.5">
+        <Package size={13} aria-hidden="true" /> {formatted.downloads}
+      </span>
+      <span className="opacity-40">·</span>
+      <span>{formatted.versions} {versionSuffix}</span>
+    </span>
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes the stats row on skill and soul cards so stars, downloads, and (for souls) version counts stay on one line with aligned icons instead of wrapping vertically.

## Problem

`SkillStatsTripletLine` and `SoulStatsTripletLine` returned fragments mixing text, emoji, and Lucide `<Package />` SVGs. Without an explicit inline flex layout, the SVG could break the line and stack stats awkwardly in card footers (e.g. home, skills browse, souls browse, soul detail).

## Changes

- **`src/components/SkillStats.tsx`** — `SkillStatsTripletLine`: outer `inline-flex items-center` with grouped segments and muted `·` separators.
- **`src/components/SoulStats.tsx`** — `SoulStatsTripletLine`: same pattern, including the version segment and `versionSuffix` support.

## How to test

1. `bun run dev`
2. Open pages that render skill cards (e.g. `/`, `/skills`) and soul cards (e.g. `/souls`, souls home when `VITE_SITE_MODE=souls`).
3. Confirm each card’s bottom stats read as one horizontal line: ⭐ count · package count (and versions for souls).

## Screenshots

before
<img width="2380" height="696" alt="image" src="https://github.com/user-attachments/assets/2ad7eefa-dd30-4611-bbcd-e1bbf8cc38c8" />

after
<img width="2402" height="586" alt="image" src="https://github.com/user-attachments/assets/c1eb83be-7e65-47de-9c6a-51113a2d7fd2" />
