### PR TITLE
fix: Implement theme-aware syntax highlighting and adjust markdown styles

### DIFF
--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -1,6 +1,7 @@
 import { parse } from "@create-markdown/core";
 import { blocksToHTML, renderAsync, shikiPlugin } from "@create-markdown/preview";
 import { useEffect, useRef, useState } from "react";
+import { useResolvedTheme } from "../lib/theme";
 import { cn } from "../lib/utils";
 
 interface MarkdownPreviewProps {
@@ -8,28 +9,6 @@ interface MarkdownPreviewProps {
   className?: string;
   /** Enable Shiki syntax highlighting for code blocks (async). Default: true */
   highlight?: boolean;
-}
-
-function getResolvedTheme(): "light" | "dark" {
-  if (typeof document === "undefined") return "light";
-  return document.documentElement.dataset.theme === "dark" ? "dark" : "light";
-}
-
-function useResolvedTheme(): "light" | "dark" {
-  const [theme, setTheme] = useState(getResolvedTheme);
-
-  useEffect(() => {
-    setTheme(getResolvedTheme());
-
-    const observer = new MutationObserver(() => setTheme(getResolvedTheme()));
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["data-theme"],
-    });
-    return () => observer.disconnect();
-  }, []);
-
-  return theme;
 }
 
 /**

--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -10,20 +10,38 @@ interface MarkdownPreviewProps {
   highlight?: boolean;
 }
 
+function getResolvedTheme(): "light" | "dark" {
+  if (typeof document === "undefined") return "light";
+  return document.documentElement.dataset.theme === "dark" ? "dark" : "light";
+}
+
+function useResolvedTheme(): "light" | "dark" {
+  const [theme, setTheme] = useState(getResolvedTheme);
+
+  useEffect(() => {
+    setTheme(getResolvedTheme());
+
+    const observer = new MutationObserver(() => setTheme(getResolvedTheme()));
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  return theme;
+}
+
 /**
  * Auto-link bare URLs in HTML that aren't already inside anchor tags or attributes.
  * Matches http/https URLs in text nodes only (not inside tags).
  */
 function autolinkURLs(html: string): string {
-  // Split HTML into tags and text segments, then only linkify text segments
   return html.replace(
     /(<[^>]*>)|((https?:\/\/)[^\s<>"')\]]+)/gi,
     (match, tag: string | undefined, url: string | undefined) => {
-      // If it's an HTML tag, leave it alone
       if (tag) return tag;
-      // If it's a bare URL in text content, wrap it
       if (url) {
-        // Trim trailing punctuation that's likely not part of the URL
         const trailingPunct = /[.,;:!?)]+$/.exec(url);
         const cleanUrl = trailingPunct ? url.slice(0, -trailingPunct[0].length) : url;
         const suffix = trailingPunct ? trailingPunct[0] : "";
@@ -41,7 +59,8 @@ function autolinkURLs(html: string): string {
  */
 export function MarkdownPreview({ children, className, highlight = true }: MarkdownPreviewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  // Initial sync render (no highlighting) for instant display
+  const resolvedTheme = useResolvedTheme();
+
   const [html, setHtml] = useState(() => {
     try {
       const blocks = parse(children);
@@ -54,7 +73,6 @@ export function MarkdownPreview({ children, className, highlight = true }: Markd
   useEffect(() => {
     let cancelled = false;
 
-    // Re-parse synchronously on content change
     try {
       const blocks = parse(children);
       const syncHtml = autolinkURLs(blocksToHTML(blocks));
@@ -62,9 +80,10 @@ export function MarkdownPreview({ children, className, highlight = true }: Markd
 
       if (!highlight) return;
 
-      // Async render with Shiki syntax highlighting
+      const shikiTheme = resolvedTheme === "dark" ? "github-dark" : "github-light";
+
       void renderAsync(blocks, {
-        plugins: [shikiPlugin({ theme: "github-dark" })],
+        plugins: [shikiPlugin({ theme: shikiTheme })],
       })
         .then((highlighted) => {
           if (!cancelled) {
@@ -75,14 +94,13 @@ export function MarkdownPreview({ children, className, highlight = true }: Markd
           // Shiki failed to load — keep the sync render
         });
     } catch {
-      // Parse failed — clear
       setHtml("");
     }
 
     return () => {
       cancelled = true;
     };
-  }, [children, highlight]);
+  }, [children, highlight, resolvedTheme]);
 
   return (
     <div

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -51,3 +51,32 @@ export function useThemeMode() {
 
   return { mode, setMode };
 }
+
+export type ResolvedTheme = "light" | "dark";
+
+export function getResolvedTheme(): ResolvedTheme {
+  if (typeof document === "undefined") return "light";
+  return document.documentElement.dataset.theme === "dark" ? "dark" : "light";
+}
+
+/**
+ * Returns the currently active theme ("light" | "dark") and reactively updates
+ * whenever the theme changes. Observes the `data-theme` attribute on `<html>`
+ * which `applyTheme` sets on every toggle.
+ */
+export function useResolvedTheme(): ResolvedTheme {
+  const [theme, setTheme] = useState<ResolvedTheme>(getResolvedTheme);
+
+  useEffect(() => {
+    setTheme(getResolvedTheme());
+
+    const observer = new MutationObserver(() => setTheme(getResolvedTheme()));
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  return theme;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -64,8 +64,8 @@
   --font-display: "Bricolage Grotesque", "Manrope", sans-serif;
   --font-body: "Manrope", "Bricolage Grotesque", sans-serif;
   --font-mono:
-    "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
-    "Courier New", monospace;
+    "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
 }
 
 [data-theme="dark"] {
@@ -105,8 +105,17 @@ body {
   font-family: var(--font-body);
   color: var(--ink);
   background:
-    radial-gradient(1200px 800px at 20% -10%, var(--bg-glow-1) 0%, transparent 60%),
-    radial-gradient(900px 600px at 90% 10%, var(--bg-glow-2) 0%, transparent 60%), var(--bg);
+    radial-gradient(
+      1200px 800px at 20% -10%,
+      var(--bg-glow-1) 0%,
+      transparent 60%
+    ),
+    radial-gradient(
+      900px 600px at 90% 10%,
+      var(--bg-glow-2) 0%,
+      transparent 60%
+    ),
+    var(--bg);
   min-height: 100vh;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -181,7 +190,11 @@ code {
 
 .hero-install-code {
   border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--line));
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(255, 250, 247, 0.9));
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.92),
+    rgba(255, 250, 247, 0.9)
+  );
   border-radius: 12px;
   padding: 12px 14px;
   font-size: 0.9rem;
@@ -203,7 +216,11 @@ code {
 
 [data-theme="dark"] .hero-install-code {
   border-color: color-mix(in srgb, var(--accent) 52%, var(--line));
-  background: linear-gradient(180deg, rgba(26, 20, 18, 0.9), rgba(20, 16, 14, 0.85));
+  background: linear-gradient(
+    180deg,
+    rgba(26, 20, 18, 0.9),
+    rgba(20, 16, 14, 0.85)
+  );
   color: #f5e9e3;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
@@ -345,7 +362,11 @@ code {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
   background:
-    radial-gradient(1200px 220px at 12% 0%, rgba(255, 107, 74, 0.08), transparent 55%),
+    radial-gradient(
+      1200px 220px at 12% 0%,
+      rgba(255, 107, 74, 0.08),
+      transparent 55%
+    ),
     linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(255, 250, 247, 0.9));
   border: 1px solid rgba(255, 107, 74, 0.2);
   border-radius: 12px;
@@ -371,7 +392,11 @@ code {
 
 [data-theme="dark"] .markdown pre {
   background:
-    radial-gradient(900px 260px at 12% 0%, rgba(255, 168, 142, 0.08), transparent 55%),
+    radial-gradient(
+      900px 260px at 12% 0%,
+      rgba(255, 168, 142, 0.08),
+      transparent 55%
+    ),
     linear-gradient(180deg, rgba(14, 22, 32, 0.95), rgba(10, 16, 24, 0.92));
   border: 1px solid rgba(255, 168, 142, 0.22);
   color: rgba(244, 238, 234, 0.96);
@@ -388,12 +413,6 @@ code {
 [data-theme="dark"] .markdown pre code {
   background: transparent;
   color: inherit;
-}
-
-/* Strip Shiki's inline background so the CSS gradient on .markdown pre shows. */
-.markdown .shiki,
-.markdown .shiki code {
-  background: transparent !important;
 }
 
 /* ── Markdown tables ── */
@@ -489,10 +508,14 @@ code {
 
 @keyframes theme-circle-transition {
   0% {
-    clip-path: circle(0% at var(--theme-switch-x, 50%) var(--theme-switch-y, 50%));
+    clip-path: circle(
+      0% at var(--theme-switch-x, 50%) var(--theme-switch-y, 50%)
+    );
   }
   100% {
-    clip-path: circle(150% at var(--theme-switch-x, 50%) var(--theme-switch-y, 50%));
+    clip-path: circle(
+      150% at var(--theme-switch-x, 50%) var(--theme-switch-y, 50%)
+    );
   }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -390,6 +390,12 @@ code {
   color: inherit;
 }
 
+/* Strip Shiki's inline background so the CSS gradient on .markdown pre shows. */
+.markdown .shiki,
+.markdown .shiki code {
+  background: transparent !important;
+}
+
 /* ── Markdown tables ── */
 .markdown table {
   width: 100%;


### PR DESCRIPTION
## Summary

Fixes markdown code blocks on light theme by aligning Shiki’s syntax theme with the app’s resolved light/dark mode, and centralizes “which theme is active?” in `theme.ts`.

## Problem

`MarkdownPreview` always used Shiki with `github-dark`. That theme emits light token colors meant for dark backgrounds. On light mode, those colors sat on the light `.markdown pre` styling and were nearly unreadable.

## Changes

- **`src/components/MarkdownPreview.tsx`** — Chooses `github-light` vs `github-dark` based on the resolved theme and re-runs async highlighting when the theme changes.
- **`src/lib/theme.ts`** — Adds `getResolvedTheme()` and `useResolvedTheme()` that read `document.documentElement.dataset.theme` (what `applyTheme` sets) and subscribe via `MutationObserver` so theme toggles update consumers without a global React context.

## How to test

1. Open any page that renders `MarkdownPreview` with fenced code (e.g. skill detail **Files** tab / `SKILL.md`).
2. Use light theme: code inside fences should be clearly readable.
3. Switch to dark theme: highlighting should switch to the dark palette and remain readable.
4. Toggle back to light: markdown should re-highlight without a full reload.

## Screenshot
before
<img width="2316" height="1092" alt="image" src="https://github.com/user-attachments/assets/e0b513dc-4da4-4428-9b9b-220bb3b236df" />

after
<img width="2316" height="1150" alt="image" src="https://github.com/user-attachments/assets/3fedaaf3-b9ed-4ae1-966d-eff41cd9059f" />
