### PR TITLE
feat: allow moderators to transfer skill publishers

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -2147,6 +2147,47 @@ describe("httpApiV1 handlers", () => {
     );
   });
 
+  it("publisher endpoint forwards to setSkillPublisherInternal", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:moderator",
+      user: { handle: "p" },
+    } as never);
+
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if ("key" in args) return okRate();
+      return {
+        ok: true,
+        changed: true,
+        skillSlug: "shop",
+        ownerPublisherHandle: "shopify",
+        ownerPublisherId: "publishers:shopify",
+      };
+    });
+
+    const response = await __handlers.skillsPostRouterV1Handler(
+      makeCtx({ runMutation }),
+      new Request("https://example.com/api/v1/skills/shop/publisher", {
+        method: "POST",
+        headers: { Authorization: "Bearer clh_test", "content-type": "application/json" },
+        body: JSON.stringify({
+          targetPublisherHandle: "shopify",
+          reason: "org migration",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        actorUserId: "users:moderator",
+        slug: "shop",
+        targetPublisherHandle: "shopify",
+        reason: "org migration",
+      }),
+    );
+  });
+
   it("transfer list returns incoming transfers", async () => {
     vi.mocked(requireApiTokenUser).mockResolvedValue({
       userId: "users:1",

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -1096,6 +1096,37 @@ async function handleSkillMergePost(
   }
 }
 
+async function handleSkillPublisherPost(
+  ctx: ActionCtx,
+  request: Request,
+  slug: string,
+  headers: HeadersInit,
+) {
+  const auth = await requireApiTokenUserOrResponse(ctx, request, headers);
+  if (!auth.ok) return auth.response;
+
+  const parsed = await parseJsonPayload(request, headers);
+  if (!parsed.ok) return parsed.response;
+  const targetPublisherHandle =
+    typeof parsed.payload.targetPublisherHandle === "string"
+      ? parsed.payload.targetPublisherHandle
+      : "";
+  const reason = typeof parsed.payload.reason === "string" ? parsed.payload.reason : undefined;
+  if (!targetPublisherHandle.trim()) return text("targetPublisherHandle required", 400, headers);
+
+  try {
+    const result = await ctx.runMutation(internal.skills.setSkillPublisherInternal, {
+      actorUserId: auth.userId,
+      slug,
+      targetPublisherHandle,
+      reason,
+    });
+    return json(result, 200, headers);
+  } catch (error) {
+    return ownershipErrorToResponse(error, headers);
+  }
+}
+
 export async function skillsPostRouterV1Handler(ctx: ActionCtx, request: Request) {
   const rate = await applyRateLimit(ctx, request, "write");
   if (!rate.ok) return rate.response;
@@ -1130,6 +1161,11 @@ export async function skillsPostRouterV1Handler(ctx: ActionCtx, request: Request
   if (segments.length === 2 && action === "merge") {
     if (!slug) return text("Slug required", 400, rate.headers);
     return handleSkillMergePost(ctx, request, slug, rate.headers);
+  }
+
+  if (segments.length === 2 && action === "publisher") {
+    if (!slug) return text("Slug required", 400, rate.headers);
+    return handleSkillPublisherPost(ctx, request, slug, rate.headers);
   }
 
   return text("Not found", 404, rate.headers);

--- a/convex/skills.publisherTransfer.test.ts
+++ b/convex/skills.publisherTransfer.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from "vitest";
+import { setSkillPublisherInternal } from "./skills";
+
+type WrappedHandler<TArgs, TResult = unknown> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
+};
+
+const setSkillPublisherInternalHandler = (
+  setSkillPublisherInternal as unknown as WrappedHandler<{
+    actorUserId: string;
+    slug: string;
+    targetPublisherHandle: string;
+    reason?: string;
+  }>
+)._handler;
+
+describe("setSkillPublisherInternal", () => {
+  it("lets moderators move a skill to a target org publisher and updates aliases", async () => {
+    const patch = vi.fn(async () => {});
+    const insert = vi.fn(async () => "auditLogs:1");
+    const get = vi.fn(async (...args: string[]) => {
+      const id = args.at(-1);
+      if (id === "users:moderator") {
+        return {
+          _id: "users:moderator",
+          role: "moderator",
+        };
+      }
+      return null;
+    });
+    const query = vi.fn((table: string) => {
+      if (table === "skills") {
+        return {
+          withIndex: (indexName: string) => {
+            expect(indexName).toBe("by_slug");
+            return {
+              unique: async () => ({
+                _id: "skills:1",
+                slug: "shop",
+                ownerUserId: "users:owner",
+                ownerPublisherId: "publishers:pushmatrix",
+              }),
+            };
+          },
+        };
+      }
+      if (table === "publishers") {
+        return {
+          withIndex: (indexName: string) => {
+            expect(indexName).toBe("by_handle");
+            return {
+              unique: async () => ({
+                _id: "publishers:shopify",
+                handle: "shopify",
+              }),
+            };
+          },
+        };
+      }
+      if (table === "skillSlugAliases") {
+        return {
+          withIndex: (indexName: string) => {
+            expect(indexName).toBe("by_skill");
+            return {
+              collect: async () => [
+                {
+                  _id: "skillSlugAliases:1",
+                  slug: "shop-old",
+                  skillId: "skills:1",
+                  ownerUserId: "users:owner",
+                  ownerPublisherId: "publishers:pushmatrix",
+                },
+              ],
+            };
+          },
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    });
+    const normalizeId = vi.fn((table: string, id: string) => (id.startsWith(`${table}:`) ? id : null));
+
+    const result = (await setSkillPublisherInternalHandler(
+      {
+        db: {
+          get,
+          query,
+          patch,
+          replace: vi.fn(async () => {}),
+          delete: vi.fn(async () => {}),
+          insert,
+          normalizeId,
+        },
+      } as never,
+      {
+        actorUserId: "users:moderator",
+        slug: "shop",
+        targetPublisherHandle: "shopify",
+        reason: "org migration",
+      } as never,
+    )) as {
+      ok: boolean;
+      changed: boolean;
+      skillSlug: string;
+      ownerPublisherHandle: string;
+      ownerPublisherId: string;
+    };
+
+    expect(result).toEqual({
+      ok: true,
+      changed: true,
+      skillSlug: "shop",
+      ownerPublisherHandle: "shopify",
+      ownerPublisherId: "publishers:shopify",
+    });
+    expect(patch.mock.calls).toContainEqual([
+      "skills",
+      "skills:1",
+      expect.objectContaining({
+        ownerPublisherId: "publishers:shopify",
+      }),
+    ]);
+    expect(patch.mock.calls).toContainEqual([
+      "skillSlugAliases:1",
+      expect.objectContaining({
+        ownerPublisherId: "publishers:shopify",
+      }),
+    ]);
+    expect(insert).toHaveBeenCalledWith(
+      "auditLogs",
+      expect.objectContaining({
+        action: "skill.publisher.change",
+        metadata: expect.objectContaining({
+          slug: "shop",
+          fromPublisherId: "publishers:pushmatrix",
+          toPublisherId: "publishers:shopify",
+          reason: "org migration",
+        }),
+      }),
+    );
+  });
+
+  it("rejects non-moderators", async () => {
+    await expect(
+      setSkillPublisherInternalHandler(
+        {
+          db: {
+            get: vi.fn(async (...args: string[]) => {
+              const id = args.at(-1);
+              if (id === "users:member") {
+                return {
+                  _id: "users:member",
+                  role: "user",
+                };
+              }
+              return null;
+            }),
+            query: vi.fn(),
+            patch: vi.fn(),
+            replace: vi.fn(),
+            delete: vi.fn(),
+            insert: vi.fn(),
+            normalizeId: vi.fn(),
+          },
+        } as never,
+        {
+          actorUserId: "users:member",
+          slug: "shop",
+          targetPublisherHandle: "shopify",
+        } as never,
+      ),
+    ).rejects.toThrow("Forbidden");
+  });
+});

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -52,7 +52,9 @@ import {
 } from "./lib/public";
 import {
   ensurePersonalPublisherForUser,
+  getPublisherByHandle,
   getOwnerPublisher,
+  isPublisherActive,
   requirePublisherRole,
 } from "./lib/publishers";
 import {
@@ -5360,6 +5362,80 @@ export const changeOwner = mutation({
       metadata: { from: skill.ownerUserId, to: args.ownerUserId },
       createdAt: now,
     });
+  },
+});
+
+export const setSkillPublisherInternal = internalMutation({
+  args: {
+    actorUserId: v.id("users"),
+    slug: v.string(),
+    targetPublisherHandle: v.string(),
+    reason: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const actor = await ctx.db.get(args.actorUserId);
+    if (!actor || actor.deletedAt || actor.deactivatedAt) throw new Error("User not found");
+    assertModerator(actor);
+
+    const slug = normalizeSkillSlugForWrite(args.slug);
+    const targetPublisherHandle = args.targetPublisherHandle.trim();
+    if (!targetPublisherHandle) throw new Error("targetPublisherHandle required");
+
+    const resolved = await resolveSkillBySlugOrAlias(ctx, slug);
+    const skill = resolved.skill;
+    if (!skill || skill.softDeletedAt) throw new Error("Skill not found");
+
+    const targetPublisher = await getPublisherByHandle(ctx, targetPublisherHandle);
+    if (!targetPublisher || !isPublisherActive(targetPublisher)) {
+      throw new Error("Publisher not found");
+    }
+
+    if (skill.ownerPublisherId === targetPublisher._id) {
+      return {
+        ok: true as const,
+        changed: false as const,
+        skillSlug: skill.slug,
+        ownerPublisherHandle: targetPublisher.handle,
+        ownerPublisherId: targetPublisher._id,
+      };
+    }
+
+    const now = Date.now();
+    await ctx.db.patch(skill._id, {
+      ownerPublisherId: targetPublisher._id,
+      lastReviewedAt: now,
+      updatedAt: now,
+    });
+
+    const aliases = await listSkillSlugAliasesForSkill(ctx, skill._id);
+    for (const alias of aliases) {
+      await ctx.db.patch(alias._id, {
+        ownerPublisherId: targetPublisher._id,
+        updatedAt: now,
+      });
+    }
+
+    await ctx.db.insert("auditLogs", {
+      actorUserId: actor._id,
+      action: "skill.publisher.change",
+      targetType: "skill",
+      targetId: skill._id,
+      metadata: {
+        slug: skill.slug,
+        fromPublisherId: skill.ownerPublisherId,
+        toPublisherId: targetPublisher._id,
+        reason: args.reason?.trim() || undefined,
+      },
+      createdAt: now,
+    });
+
+    return {
+      ok: true as const,
+      changed: true as const,
+      skillSlug: skill.slug,
+      ownerPublisherHandle: targetPublisher.handle,
+      ownerPublisherId: targetPublisher._id,
+    };
   },
 });
 


### PR DESCRIPTION
## Summary
- add a moderator-gated internal mutation to move a skill to a different publisher
- expose a `POST /api/v1/skills/:slug/publisher` API route for API-token-authenticated staff use
- cover the route wiring and publisher transfer behavior with focused tests

## Testing
- bunx tsc -p tsconfig.json --noEmit
- bun run test convex/httpApiV1.handlers.test.ts convex/skills.publisherTransfer.test.ts