### PR TITLE
fix(api): align inspect security snapshot with static scan moderation

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -1250,6 +1250,101 @@ describe("httpApiV1 handlers", () => {
     expect(json.version.security.scanners.llm.normalizedStatus).toBe("clean");
   });
 
+  it("lets static-scan malicious status dominate benign vt and llm results", async () => {
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("slug" in args) {
+        return {
+          skill: { _id: "skills:1", slug: "demo", displayName: "Demo" },
+          latestVersion: null,
+          owner: { handle: "owner", displayName: "Owner", image: null },
+        };
+      }
+      if ("skillId" in args && "version" in args) {
+        return {
+          version: "1.0.0",
+          createdAt: 1,
+          changelog: "c",
+          changelogSource: "auto",
+          sha256hash: "a".repeat(64),
+          staticScan: {
+            status: "malicious",
+            reasonCodes: ["malicious.credential_harvest"],
+            summary: "Detected: malicious.credential_harvest",
+            engineVersion: "v2.4.0",
+            checkedAt: 555,
+          },
+          vtAnalysis: {
+            status: "clean",
+            verdict: "benign",
+            checkedAt: 111,
+          },
+          llmAnalysis: {
+            status: "completed",
+            verdict: "benign",
+            checkedAt: 222,
+          },
+          files: [],
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const response = await __handlers.skillsGetRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/demo/versions/1.0.0"),
+    );
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.version.security.status).toBe("malicious");
+    expect(json.version.security.hasWarnings).toBe(true);
+    expect(json.version.security.hasScanResult).toBe(true);
+    expect(json.version.security.checkedAt).toBe(555);
+    expect(json.version.security.scanners.static.normalizedStatus).toBe("malicious");
+  });
+
+  it("treats a static scan by itself as a definitive scan result", async () => {
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("slug" in args) {
+        return {
+          skill: { _id: "skills:1", slug: "demo", displayName: "Demo" },
+          latestVersion: null,
+          owner: { handle: "owner", displayName: "Owner", image: null },
+        };
+      }
+      if ("skillId" in args && "version" in args) {
+        return {
+          version: "1.0.0",
+          createdAt: 1,
+          changelog: "c",
+          changelogSource: "auto",
+          staticScan: {
+            status: "clean",
+            reasonCodes: [],
+            summary: "No issues found",
+            engineVersion: "v2.4.0",
+            checkedAt: 555,
+          },
+          files: [],
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const response = await __handlers.skillsGetRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/demo/versions/1.0.0"),
+    );
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.version.security.status).toBe("clean");
+    expect(json.version.security.hasWarnings).toBe(false);
+    expect(json.version.security.hasScanResult).toBe(true);
+    expect(json.version.security.virustotalUrl).toBeNull();
+    expect(json.version.security.scanners.static.normalizedStatus).toBe("clean");
+    expect(json.version.security.scanners.vt).toBeNull();
+    expect(json.version.security.scanners.llm).toBeNull();
+  });
+
   it("keeps hasWarnings true when llm dimensions include non-ok ratings", async () => {
     const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
       if ("slug" in args) {

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -1197,6 +1197,59 @@ describe("httpApiV1 handlers", () => {
     expect(json.version.security.virustotalUrl).toContain("virustotal.com/gui/file/");
   });
 
+  it("surfaces static-scan suspicious status in version security snapshot", async () => {
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("slug" in args) {
+        return {
+          skill: { _id: "skills:1", slug: "demo", displayName: "Demo" },
+          latestVersion: null,
+          owner: { handle: "owner", displayName: "Owner", image: null },
+        };
+      }
+      if ("skillId" in args && "version" in args) {
+        return {
+          version: "1.0.0",
+          createdAt: 1,
+          changelog: "c",
+          changelogSource: "auto",
+          sha256hash: "a".repeat(64),
+          staticScan: {
+            status: "suspicious",
+            reasonCodes: ["suspicious.dangerous_exec"],
+            summary: "Detected: suspicious.dangerous_exec",
+            engineVersion: "v2.4.0",
+            checkedAt: 555,
+          },
+          vtAnalysis: {
+            status: "clean",
+            verdict: "benign",
+            checkedAt: 111,
+          },
+          llmAnalysis: {
+            status: "completed",
+            verdict: "benign",
+            checkedAt: 222,
+          },
+          files: [],
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const response = await __handlers.skillsGetRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/demo/versions/1.0.0"),
+    );
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.version.security.status).toBe("suspicious");
+    expect(json.version.security.hasWarnings).toBe(true);
+    expect(json.version.security.hasScanResult).toBe(true);
+    expect(json.version.security.scanners.static.normalizedStatus).toBe("suspicious");
+    expect(json.version.security.scanners.vt.normalizedStatus).toBe("clean");
+    expect(json.version.security.scanners.llm.normalizedStatus).toBe("clean");
+  });
+
   it("keeps hasWarnings true when llm dimensions include non-ok ratings", async () => {
     const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
       if ("slug" in args) {

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -83,6 +83,13 @@ type PublicSkillVersionResponse = {
   sha256hash?: string;
   vtAnalysis?: Doc<"skillVersions">["vtAnalysis"];
   llmAnalysis?: Doc<"skillVersions">["llmAnalysis"];
+  staticScan?: {
+    status: string;
+    reasonCodes?: string[];
+    summary?: string;
+    engineVersion?: string;
+    checkedAt?: number;
+  };
   capabilityTags?: string[];
 };
 
@@ -194,6 +201,14 @@ type SkillSecuritySnapshot = {
   virustotalUrl: string | null;
   capabilityTags: string[];
   scanners: {
+    static: {
+      status: string;
+      normalizedStatus: NormalizedSecurityStatus;
+      reasonCodes: string[];
+      summary: string | null;
+      engineVersion: string | null;
+      checkedAt: number | null;
+    } | null;
     vt: {
       status: string;
       verdict: string | null;
@@ -277,30 +292,35 @@ function hasLlmDimensionWarnings(
 function buildSkillSecuritySnapshot(
   version: Pick<
     PublicSkillVersionResponse,
-    "sha256hash" | "vtAnalysis" | "llmAnalysis" | "capabilityTags"
+    "sha256hash" | "vtAnalysis" | "llmAnalysis" | "staticScan" | "capabilityTags"
   >,
 ): SkillSecuritySnapshot | null {
   const capabilityTags = version.capabilityTags ?? [];
   const sha256hash = version.sha256hash ?? null;
   const vt = version.vtAnalysis;
   const llm = version.llmAnalysis;
+  const staticScan = version.staticScan;
 
-  if (!sha256hash && !vt && !llm && capabilityTags.length === 0) return null;
+  if (!sha256hash && !vt && !llm && !staticScan && capabilityTags.length === 0) return null;
 
+  const staticStatus = staticScan ? normalizeSecurityStatus(staticScan.status) : null;
   const vtStatus = vt ? normalizeSecurityStatus(vt.verdict ?? vt.status) : null;
   const llmStatus = llm ? normalizeSecurityStatus(llm.verdict ?? llm.status) : null;
 
   const statuses: NormalizedSecurityStatus[] = [];
+  if (staticStatus) statuses.push(staticStatus);
   if (vtStatus) statuses.push(vtStatus);
   if (llmStatus) statuses.push(llmStatus);
   if (statuses.length === 0 && sha256hash) statuses.push("pending");
   const status = mergeSecurityStatuses(statuses);
   const hasScanResult =
-    isDefinitiveSecurityStatus(vtStatus) || isDefinitiveSecurityStatus(llmStatus);
+    isDefinitiveSecurityStatus(staticStatus) ||
+    isDefinitiveSecurityStatus(vtStatus) ||
+    isDefinitiveSecurityStatus(llmStatus);
   const hasWarnings =
     status === "suspicious" || status === "malicious" || hasLlmDimensionWarnings(llm?.dimensions);
 
-  const checkedAtCandidates = [vt?.checkedAt, llm?.checkedAt].filter(
+  const checkedAtCandidates = [staticScan?.checkedAt, vt?.checkedAt, llm?.checkedAt].filter(
     (value): value is number => typeof value === "number",
   );
   const checkedAt = checkedAtCandidates.length > 0 ? Math.max(...checkedAtCandidates) : null;
@@ -315,6 +335,16 @@ function buildSkillSecuritySnapshot(
     virustotalUrl: sha256hash ? `https://www.virustotal.com/gui/file/${sha256hash}` : null,
     capabilityTags,
     scanners: {
+      static: staticScan
+        ? {
+            status: staticScan.status,
+            normalizedStatus: staticStatus ?? "pending",
+            reasonCodes: staticScan.reasonCodes ?? [],
+            summary: staticScan.summary ?? null,
+            engineVersion: staticScan.engineVersion ?? null,
+            checkedAt: staticScan.checkedAt ?? null,
+          }
+        : null,
       vt: vt
         ? {
             status: vt.status,

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -71,6 +71,11 @@ type PublicSkillVersionParsed = {
   clawdis?: { os?: string[]; nix?: { plugin?: boolean; systems?: string[] } };
 };
 
+type PublicSkillVersionStaticScan = Pick<
+  NonNullable<Doc<"skillVersions">["staticScan"]>,
+  "status" | "reasonCodes" | "summary" | "engineVersion" | "checkedAt"
+>;
+
 type PublicSkillVersionResponse = {
   _id: Id<"skillVersions">;
   version: string;
@@ -83,13 +88,7 @@ type PublicSkillVersionResponse = {
   sha256hash?: string;
   vtAnalysis?: Doc<"skillVersions">["vtAnalysis"];
   llmAnalysis?: Doc<"skillVersions">["llmAnalysis"];
-  staticScan?: {
-    status: string;
-    reasonCodes?: string[];
-    summary?: string;
-    engineVersion?: string;
-    checkedAt?: number;
-  };
+  staticScan?: PublicSkillVersionStaticScan;
   capabilityTags?: string[];
 };
 


### PR DESCRIPTION
## Summary
- Include `staticScan` in `buildSkillSecuritySnapshot` aggregation so API `version.security.status` reflects the same moderation-relevant signal used by install-time gating.
- Expose static-scan details under `version.security.scanners.static` in the v1 skill version response.
- Add a regression test covering the real mismatch case: `staticScan=suspicious` while VT/LLM are benign.

This is a consistency fix only; it does not change moderation policy thresholds.

Fixes #1686

## Context
- Related context: #362 exposed inspect security metadata; this patch aligns that inspect path with current install/moderation behavior by including static-scan status in the same snapshot.

## Validation
- `bun vitest run convex/httpApiV1.handlers.test.ts`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bun run verify:convex-contract` *(fails locally without configured `CONVEX_DEPLOYMENT`: `No CONVEX_DEPLOYMENT set`)*
