### PR TITLE
fix(cli): use explorer on Windows to preserve auth URL params

### DIFF
--- a/packages/clawhub/src/cli/ui.test.ts
+++ b/packages/clawhub/src/cli/ui.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 const mockSpawn = vi.fn();
+const originalPlatform = process.platform;
 
 vi.mock("node:child_process", () => ({
   spawn: (...args: unknown[]) => mockSpawn(...args),
@@ -26,6 +27,26 @@ function createMockChild() {
 }
 
 describe("openInBrowser", () => {
+  it("uses explorer on Windows and preserves query params in the URL argument", () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValueOnce(child);
+    const url =
+      "https://clawhub.ai/auth?redirect_uri=http%3A%2F%2F127.0.0.1%3A43123%2Fcallback&state=abc123";
+
+    try {
+      Object.defineProperty(process, "platform", { value: "win32" });
+      openInBrowser(url);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+
+    expect(mockSpawn).toHaveBeenCalledWith("explorer", [url], {
+      stdio: "ignore",
+      detached: true,
+    });
+    expect(child.unref).toHaveBeenCalledOnce();
+  });
+
   it("prints manual URL instructions when browser opener is missing", () => {
     const child = createMockChild();
     mockSpawn.mockReturnValueOnce(child);

--- a/packages/clawhub/src/cli/ui.ts
+++ b/packages/clawhub/src/cli/ui.ts
@@ -48,7 +48,7 @@ export function openInBrowser(url: string) {
     process.platform === "darwin"
       ? ["open", url]
       : process.platform === "win32"
-        ? ["cmd", "/c", "start", "", `"${url}"`]
+        ? ["explorer", url]
         : ["xdg-open", url];
   const [command, ...commandArgs] = args;
   if (!command) return;

--- a/packages/clawhub/src/cli/ui.ts
+++ b/packages/clawhub/src/cli/ui.ts
@@ -48,7 +48,7 @@ export function openInBrowser(url: string) {
     process.platform === "darwin"
       ? ["open", url]
       : process.platform === "win32"
-        ? ["cmd", "/c", "start", "", url]
+        ? ["cmd", "/c", "start", "", `"${url}"`]
         : ["xdg-open", url];
   const [command, ...commandArgs] = args;
   if (!command) return;


### PR DESCRIPTION
On Windows, `cmd /c start` treats `&` as a command separator, which can truncate auth URLs that contain query params.

This switches the CLI browser opener to `explorer`, which avoids `cmd.exe` shell parsing entirely, and adds a unit test that locks the Windows spawn args to the full URL.

## Test plan

- `bun run --cwd packages/clawhub test:src -- src/cli/ui.test.ts src/cli/commands/auth.test.ts src/browserAuth.test.ts`
