### PR TITLE
fix(upload): fall back to octet-stream for files with empty Content-Type

### DIFF
--- a/src/lib/uploadUtils.ts
+++ b/src/lib/uploadUtils.ts
@@ -8,7 +8,7 @@ import { getUserFacingConvexError } from "./convexError";
 export async function uploadFile(uploadUrl: string, file: File) {
   const path = file.webkitRelativePath || file.name;
   const contentType =
-    normalizeTextContentType(path, file.type) ?? file.type ?? "application/octet-stream";
+    normalizeTextContentType(path, file.type) || file.type || "application/octet-stream";
   const response = await fetch(uploadUrl, {
     method: "POST",
     headers: { "Content-Type": contentType },

--- a/src/routes/upload/-utils.ts
+++ b/src/routes/upload/-utils.ts
@@ -8,7 +8,7 @@ import { getUserFacingConvexError } from "../../lib/convexError";
 export async function uploadFile(uploadUrl: string, file: File) {
   const path = file.webkitRelativePath || file.name;
   const contentType =
-    normalizeTextContentType(path, file.type) ?? file.type ?? "application/octet-stream";
+    normalizeTextContentType(path, file.type) || file.type || "application/octet-stream";
   const response = await fetch(uploadUrl, {
     method: "POST",
     headers: { "Content-Type": contentType },


### PR DESCRIPTION
Fixes #1697

## Summary

- Fall back to `application/octet-stream` when the browser provides an empty `file.type` for an uploaded file.
- Keep existing MIME normalization behavior for recognized text files.

## Why this is safe

`normalizeTextContentType` already returns either a non-empty content type or `undefined`, so changing the fallback chain only affects the empty-string case from the browser.

## Test plan

- `bunx vitest run src/lib/uploadUtils.test.ts src/lib/packageUpload.test.ts packages/schema/src/textFiles.test.ts`
