### PR TITLE
fix(auth): fail fast when AUTH_GITHUB_ID/SECRET env vars are missing

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,4 @@
+# Stub values so convex/auth.ts module initialization doesn't throw during tests.
+# These are not real credentials — GitHub OAuth is not exercised in the test suite.
+AUTH_GITHUB_ID=test-github-client-id
+AUTH_GITHUB_SECRET=test-github-client-secret

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,15 @@ jobs:
 
       - name: Test
         run: bun run test
+        env:
+          AUTH_GITHUB_ID: test-github-client-id
+          AUTH_GITHUB_SECRET: test-github-client-secret
 
       - name: Coverage
         run: bun run coverage
+        env:
+          AUTH_GITHUB_ID: test-github-client-id
+          AUTH_GITHUB_SECRET: test-github-client-secret
 
       - name: ClawHub CLI Verify
         run: bun run --cwd packages/clawhub verify

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -70,11 +70,18 @@ export async function handleDeletedUserSignIn(
   throw new ConvexError(DELETED_ACCOUNT_REAUTH_MESSAGE);
 }
 
+function missingEnvVar(name: string): never {
+  throw new Error(
+    `Missing required environment variable: ${name}. ` +
+    `Set it in the Convex dashboard under Settings → Environment Variables.`,
+  );
+}
+
 export const { auth, signIn, signOut, store, isAuthenticated } = convexAuth({
   providers: [
     GitHub({
-      clientId: process.env.AUTH_GITHUB_ID ?? "",
-      clientSecret: process.env.AUTH_GITHUB_SECRET ?? "",
+      clientId: process.env.AUTH_GITHUB_ID ?? missingEnvVar("AUTH_GITHUB_ID"),
+      clientSecret: process.env.AUTH_GITHUB_SECRET ?? missingEnvVar("AUTH_GITHUB_SECRET"),
       profile(profile) {
         return {
           id: String(profile.id),


### PR DESCRIPTION
## Problem

`/api/auth/signin/github` returns HTTP 500, breaking `clawhub login` for all users. Tracked in #1717.

## Root Cause

In `convex/auth.ts`, missing env vars silently fall back to empty strings:

```typescript
clientId: process.env.AUTH_GITHUB_ID ?? "",
clientSecret: process.env.AUTH_GITHUB_SECRET ?? "",
```

Auth.js receives empty credentials, fails internally, and Convex surfaces this as an unhandled HTTP 500 with no useful diagnostic information.

## Fix

Replace the `?? ""` fallbacks with a `missingEnvVar()` helper that throws immediately with a clear message pointing to the Convex dashboard:

```
Error: Missing required environment variable: AUTH_GITHUB_ID.
Set it in the Convex dashboard under Settings → Environment Variables.
```

This makes misconfigured deployments fail loudly at startup instead of silently at request time.

## To Fix the Live Deployment

In addition to merging this PR, the `AUTH_GITHUB_ID` and `AUTH_GITHUB_SECRET` values need to be set in the Convex dashboard:

1. Go to **Convex Dashboard → your deployment → Settings → Environment Variables**
2. Add `AUTH_GITHUB_ID` and `AUTH_GITHUB_SECRET` from your GitHub OAuth App
3. Redeploy

The GitHub OAuth App credentials can be found at: **GitHub → Settings → Developer Settings → OAuth Apps**