### PR TITLE
Stabilize preferences sync and keep diff editor mounted

### DIFF
--- a/src/components/SkillDiffCard.test.tsx
+++ b/src/components/SkillDiffCard.test.tsx
@@ -1,10 +1,13 @@
 /* @vitest-environment jsdom */
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useEffect } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
 import { SkillDiffCard } from "./SkillDiffCard";
 
 const getFileTextMock = vi.fn();
+let diffEditorMounts = 0;
+let diffEditorUnmounts = 0;
 
 vi.mock("convex/react", () => ({
   useAction: () => getFileTextMock,
@@ -18,15 +21,37 @@ vi.mock("@monaco-editor/react", () => ({
     className?: string;
     options?: { renderSideBySide?: boolean; useInlineViewWhenSpaceIsLimited?: boolean };
   }) => (
+    <MockDiffEditor
+      className={className}
+      options={options}
+    />
+  ),
+  useMonaco: () => null,
+}));
+
+function MockDiffEditor({
+  className,
+  options,
+}: {
+  className?: string;
+  options?: { renderSideBySide?: boolean; useInlineViewWhenSpaceIsLimited?: boolean };
+}) {
+  useEffect(() => {
+    diffEditorMounts += 1;
+    return () => {
+      diffEditorUnmounts += 1;
+    };
+  }, []);
+
+  return (
     <div
       className={className}
       data-inline-fallback={String(options?.useInlineViewWhenSpaceIsLimited)}
       data-side-by-side={String(options?.renderSideBySide)}
       data-testid="diff-editor"
     />
-  ),
-  useMonaco: () => null,
-}));
+  );
+}
 
 function installMatchMedia(matches: boolean) {
   Object.defineProperty(window, "matchMedia", {
@@ -65,6 +90,8 @@ describe("SkillDiffCard", () => {
   beforeEach(() => {
     getFileTextMock.mockReset();
     getFileTextMock.mockResolvedValue({ text: "content" });
+    diffEditorMounts = 0;
+    diffEditorUnmounts = 0;
   });
 
   it("defaults to inline mode on narrow screens", async () => {
@@ -107,5 +134,35 @@ describe("SkillDiffCard", () => {
       expect(screen.getByTestId("diff-editor").getAttribute("data-side-by-side")).toBe("true");
     });
     expect(screen.getByRole("button", { name: "Side-by-side" }).className).toContain("is-active");
+  });
+
+  it("keeps the diff editor mounted when toggling view mode", async () => {
+    installMatchMedia(false);
+
+    render(
+      <SkillDiffCard
+        skill={skill}
+        versions={[
+          makeVersion("skillVersions:1", "1.0.1"),
+          makeVersion("skillVersions:2", "1.0.2"),
+        ]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("diff-editor")).toBeTruthy();
+    });
+
+    expect(diffEditorMounts).toBe(1);
+    expect(diffEditorUnmounts).toBe(0);
+
+    fireEvent.click(screen.getByRole("button", { name: "Inline" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("diff-editor").getAttribute("data-side-by-side")).toBe("false");
+    });
+
+    expect(diffEditorMounts).toBe(1);
+    expect(diffEditorUnmounts).toBe(0);
   });
 });

--- a/src/components/SkillDiffCard.tsx
+++ b/src/components/SkillDiffCard.tsx
@@ -402,7 +402,6 @@ export function SkillDiffCard({ skill, versions, variant = "card" }: SkillDiffCa
           ) : (
             <ClientOnly fallback={<div className="diff-empty">Preparing diff…</div>}>
               <DiffEditor
-                key={`diff-${viewMode}`}
                 className={`diff-monaco diff-monaco-${viewMode}`}
                 original={leftText}
                 modified={rightText}

--- a/src/lib/preferences.test.tsx
+++ b/src/lib/preferences.test.tsx
@@ -1,0 +1,57 @@
+/* @vitest-environment jsdom */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { usePreferences, getStoredPreferencesSnapshot } from "./preferences";
+
+const PREFERENCES_KEY = "clawhub-preferences";
+
+function PreferencesProbe() {
+  const { preferences, updatePreference, isAdvancedMode } = usePreferences();
+
+  return (
+    <div>
+      <div data-testid="density">{preferences.layoutDensity}</div>
+      <div data-testid="advanced">{String(isAdvancedMode)}</div>
+      <button
+        type="button"
+        onClick={() => updatePreference("advancedMode", !preferences.advancedMode)}
+      >
+        Toggle advanced
+      </button>
+    </div>
+  );
+}
+
+describe("preferences store", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns a stable snapshot when storage has not changed", () => {
+    const first = getStoredPreferencesSnapshot();
+    const second = getStoredPreferencesSnapshot();
+
+    expect(first).toBe(second);
+    expect(first.layoutDensity).toBe("comfortable");
+  });
+
+  it("re-renders cleanly after a preference update", () => {
+    window.localStorage.setItem(
+      PREFERENCES_KEY,
+      JSON.stringify({
+        advancedMode: false,
+      }),
+    );
+
+    render(<PreferencesProbe />);
+
+    expect(screen.getByTestId("advanced").textContent).toBe("false");
+
+    fireEvent.click(screen.getByRole("button", { name: /toggle advanced/i }));
+
+    expect(screen.getByTestId("advanced").textContent).toBe("true");
+    expect(JSON.parse(window.localStorage.getItem(PREFERENCES_KEY) ?? "{}")).toMatchObject({
+      advancedMode: true,
+    });
+  });
+});

--- a/src/lib/preferences.test.tsx
+++ b/src/lib/preferences.test.tsx
@@ -1,5 +1,5 @@
 /* @vitest-environment jsdom */
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { usePreferences, getStoredPreferencesSnapshot } from "./preferences";
 
@@ -35,6 +35,52 @@ describe("preferences store", () => {
     expect(first.layoutDensity).toBe("comfortable");
   });
 
+  it("falls back to defaults when localStorage reads throw", () => {
+    const getItemSpy = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new DOMException("blocked", "SecurityError");
+      });
+
+    render(<PreferencesProbe />);
+
+    expect(screen.getByTestId("density").textContent).toBe("comfortable");
+    expect(screen.getByTestId("advanced").textContent).toBe("false");
+
+    getItemSpy.mockRestore();
+  });
+
+  it("resets to defaults when the preference key is cleared in another tab", () => {
+    window.localStorage.setItem(
+      PREFERENCES_KEY,
+      JSON.stringify({
+        advancedMode: true,
+        layoutDensity: "compact",
+      }),
+    );
+
+    render(<PreferencesProbe />);
+    expect(screen.getByTestId("advanced").textContent).toBe("true");
+    expect(screen.getByTestId("density").textContent).toBe("compact");
+
+    window.localStorage.removeItem(PREFERENCES_KEY);
+    act(() => {
+      const event = Object.assign(new Event("storage"), {
+        key: PREFERENCES_KEY,
+        newValue: null,
+        oldValue: JSON.stringify({
+          advancedMode: true,
+          layoutDensity: "compact",
+        }),
+        storageArea: window.localStorage,
+      });
+      window.dispatchEvent(event);
+    });
+
+    expect(screen.getByTestId("advanced").textContent).toBe("false");
+    expect(screen.getByTestId("density").textContent).toBe("comfortable");
+  });
+
   it("re-renders cleanly after a preference update", () => {
     window.localStorage.setItem(
       PREFERENCES_KEY,
@@ -53,5 +99,23 @@ describe("preferences store", () => {
     expect(JSON.parse(window.localStorage.getItem(PREFERENCES_KEY) ?? "{}")).toMatchObject({
       advancedMode: true,
     });
+  });
+
+  it("does not cache a preference change when storage writes fail", () => {
+    const setItemSpy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new DOMException("quota", "QuotaExceededError");
+      });
+
+    render(<PreferencesProbe />);
+    expect(screen.getByTestId("advanced").textContent).toBe("false");
+
+    fireEvent.click(screen.getByRole("button", { name: /toggle advanced/i }));
+
+    expect(screen.getByTestId("advanced").textContent).toBe("false");
+    expect(window.localStorage.getItem(PREFERENCES_KEY)).toBeNull();
+
+    setItemSpy.mockRestore();
   });
 });

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -108,8 +108,17 @@ function subscribe(listener: () => void) {
         return;
       }
 
-      cachedPreferencesRaw = null;
-      cachedPreferencesSnapshot = readStoredPreferences();
+      cachedPreferencesRaw = event.newValue;
+      if (!event.newValue) {
+        cachedPreferencesSnapshot = defaultPreferences;
+      } else {
+        try {
+          const parsed = JSON.parse(event.newValue) as Partial<UserPreferences>;
+          cachedPreferencesSnapshot = normalizePreferences(parsed);
+        } catch {
+          cachedPreferencesSnapshot = defaultPreferences;
+        }
+      }
       notifyListeners();
     };
 

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -68,6 +68,7 @@ const defaultPreferences: UserPreferences = {
 const listeners = new Set<() => void>();
 let cachedPreferencesRaw: string | null = null;
 let cachedPreferencesSnapshot: UserPreferences = defaultPreferences;
+let hasCachedPreferences = false;
 let removeStorageListener: (() => void) | null = null;
 
 function normalizePreferences(parsed: Partial<UserPreferences> | null): UserPreferences {
@@ -75,28 +76,35 @@ function normalizePreferences(parsed: Partial<UserPreferences> | null): UserPref
   return { ...defaultPreferences, ...parsed };
 }
 
+function parsePreferences(raw: string | null): UserPreferences {
+  if (!raw) return defaultPreferences;
+  try {
+    const parsed = JSON.parse(raw) as Partial<UserPreferences>;
+    return normalizePreferences(parsed);
+  } catch {
+    return defaultPreferences;
+  }
+}
+
 function readStoredPreferences(): UserPreferences {
   if (typeof window === "undefined") return defaultPreferences;
 
-  const stored = window.localStorage.getItem(PREFERENCES_KEY);
-  if (stored === cachedPreferencesRaw) {
-    return cachedPreferencesSnapshot;
-  }
-
-  cachedPreferencesRaw = stored;
-  if (!stored) {
-    cachedPreferencesSnapshot = defaultPreferences;
-    return cachedPreferencesSnapshot;
-  }
-
   try {
-    const parsed = JSON.parse(stored) as Partial<UserPreferences>;
-    cachedPreferencesSnapshot = normalizePreferences(parsed);
-  } catch {
-    cachedPreferencesSnapshot = defaultPreferences;
-  }
+    const stored = window.localStorage.getItem(PREFERENCES_KEY);
+    if (hasCachedPreferences && stored === cachedPreferencesRaw) {
+      return cachedPreferencesSnapshot;
+    }
 
-  return cachedPreferencesSnapshot;
+    cachedPreferencesRaw = stored;
+    cachedPreferencesSnapshot = parsePreferences(stored);
+    hasCachedPreferences = true;
+    return cachedPreferencesSnapshot;
+  } catch {
+    cachedPreferencesRaw = null;
+    cachedPreferencesSnapshot = defaultPreferences;
+    hasCachedPreferences = true;
+    return cachedPreferencesSnapshot;
+  }
 }
 
 function subscribe(listener: () => void) {
@@ -109,16 +117,8 @@ function subscribe(listener: () => void) {
       }
 
       cachedPreferencesRaw = event.newValue;
-      if (!event.newValue) {
-        cachedPreferencesSnapshot = defaultPreferences;
-      } else {
-        try {
-          const parsed = JSON.parse(event.newValue) as Partial<UserPreferences>;
-          cachedPreferencesSnapshot = normalizePreferences(parsed);
-        } catch {
-          cachedPreferencesSnapshot = defaultPreferences;
-        }
-      }
+      cachedPreferencesSnapshot = parsePreferences(event.newValue);
+      hasCachedPreferences = true;
       notifyListeners();
     };
 
@@ -146,9 +146,10 @@ function savePreferences(prefs: UserPreferences) {
   if (typeof window === "undefined") return;
   try {
     const serialized = JSON.stringify(prefs);
+    window.localStorage.setItem(PREFERENCES_KEY, serialized);
     cachedPreferencesRaw = serialized;
     cachedPreferencesSnapshot = prefs;
-    window.localStorage.setItem(PREFERENCES_KEY, serialized);
+    hasCachedPreferences = true;
   } catch {
     // Storage might be full or disabled
   }

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useSyncExternalStore } from "react";
 
 const PREFERENCES_KEY = "clawhub-preferences";
 
@@ -66,36 +66,85 @@ const defaultPreferences: UserPreferences = {
 
 // Simple event emitter for cross-tab sync
 const listeners = new Set<() => void>();
+let cachedPreferencesRaw: string | null = null;
+let cachedPreferencesSnapshot: UserPreferences = defaultPreferences;
+let removeStorageListener: (() => void) | null = null;
+
+function normalizePreferences(parsed: Partial<UserPreferences> | null): UserPreferences {
+  if (!parsed) return defaultPreferences;
+  return { ...defaultPreferences, ...parsed };
+}
+
+function readStoredPreferences(): UserPreferences {
+  if (typeof window === "undefined") return defaultPreferences;
+
+  const stored = window.localStorage.getItem(PREFERENCES_KEY);
+  if (stored === cachedPreferencesRaw) {
+    return cachedPreferencesSnapshot;
+  }
+
+  cachedPreferencesRaw = stored;
+  if (!stored) {
+    cachedPreferencesSnapshot = defaultPreferences;
+    return cachedPreferencesSnapshot;
+  }
+
+  try {
+    const parsed = JSON.parse(stored) as Partial<UserPreferences>;
+    cachedPreferencesSnapshot = normalizePreferences(parsed);
+  } catch {
+    cachedPreferencesSnapshot = defaultPreferences;
+  }
+
+  return cachedPreferencesSnapshot;
+}
 
 function subscribe(listener: () => void) {
   listeners.add(listener);
-  return () => listeners.delete(listener);
+
+  if (typeof window !== "undefined" && !removeStorageListener) {
+    const handleStorage = (event: StorageEvent) => {
+      if (event.storageArea !== window.localStorage || event.key !== PREFERENCES_KEY) {
+        return;
+      }
+
+      cachedPreferencesRaw = null;
+      cachedPreferencesSnapshot = readStoredPreferences();
+      notifyListeners();
+    };
+
+    window.addEventListener("storage", handleStorage);
+    removeStorageListener = () => {
+      window.removeEventListener("storage", handleStorage);
+      removeStorageListener = null;
+    };
+  }
+
+  return () => {
+    listeners.delete(listener);
+
+    if (listeners.size === 0 && removeStorageListener) {
+      removeStorageListener();
+    }
+  };
 }
 
 function notifyListeners() {
   listeners.forEach((listener) => listener());
 }
 
-function getStoredPreferences(): UserPreferences {
-  if (typeof window === "undefined") return defaultPreferences;
-  try {
-    const stored = window.localStorage.getItem(PREFERENCES_KEY);
-    if (!stored) return defaultPreferences;
-    const parsed = JSON.parse(stored) as Partial<UserPreferences>;
-    return { ...defaultPreferences, ...parsed };
-  } catch {
-    return defaultPreferences;
-  }
-}
-
 function savePreferences(prefs: UserPreferences) {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(PREFERENCES_KEY, JSON.stringify(prefs));
-    notifyListeners();
+    const serialized = JSON.stringify(prefs);
+    cachedPreferencesRaw = serialized;
+    cachedPreferencesSnapshot = prefs;
+    window.localStorage.setItem(PREFERENCES_KEY, serialized);
   } catch {
     // Storage might be full or disabled
   }
+
+  notifyListeners();
 }
 
 // Server snapshot for SSR
@@ -106,7 +155,7 @@ function getServerSnapshot(): UserPreferences {
 export function usePreferences() {
   const preferences = useSyncExternalStore(
     subscribe,
-    getStoredPreferences,
+    readStoredPreferences,
     getServerSnapshot
   );
 
@@ -114,13 +163,13 @@ export function usePreferences() {
     key: K,
     value: UserPreferences[K]
   ) => {
-    const current = getStoredPreferences();
+    const current = readStoredPreferences();
     const updated = { ...current, [key]: value };
     savePreferences(updated);
   }, []);
 
   const updatePreferences = useCallback((updates: Partial<UserPreferences>) => {
-    const current = getStoredPreferences();
+    const current = readStoredPreferences();
     const updated = { ...current, ...updates };
     savePreferences(updated);
   }, []);
@@ -163,3 +212,4 @@ export function usePreferences() {
 }
 
 export { defaultPreferences };
+export { readStoredPreferences as getStoredPreferencesSnapshot };


### PR DESCRIPTION
## Summary
- Keep the Monaco diff editor mounted when switching between inline and side-by-side views, preserving editor state during mode changes.
- Add preference snapshot caching so repeated reads return a stable object when `localStorage` has not changed.
- Improve storage sync by handling cross-tab `storage` events and keeping the in-memory cache aligned with saved preferences.
- Add regression tests for diff editor mounting behavior and preference store re-render/snapshot stability.

## Testing
- `Not run`
- Added coverage for toggling diff view mode without unmounting the editor.
- Added coverage for stable preference snapshots and update-driven re-renders.