### PR TITLE
Polish icons and brand mark styling

### DIFF
--- a/src/components/BrowseSidebar.tsx
+++ b/src/components/BrowseSidebar.tsx
@@ -4,9 +4,9 @@ import {
   MessageSquare,
   Package,
   Plug,
+  RefreshCw,
   Shield,
   Wrench,
-  Zap,
 } from "lucide-react";
 import type { SkillCategory } from "../lib/categories";
 
@@ -39,7 +39,7 @@ const CATEGORY_ICONS: Record<string, React.ReactNode> = {
   "dev-tools": <Wrench size={15} />,
   data: <Database size={15} />,
   security: <Shield size={15} />,
-  automation: <Zap size={15} />,
+  automation: <RefreshCw size={15} />,
   other: <Package size={15} />,
 };
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,12 +7,10 @@ import {
   ChevronRight,
   Code2,
   Download,
-  Layers,
+  Package,
   Search,
-  Shield,
   Star,
   Users,
-  Zap,
 } from "lucide-react";
 import { api } from "../../convex/_generated/api";
 import { SoulCard } from "../components/SoulCard";
@@ -452,28 +450,28 @@ function SkillsHome() {
             className="home-v2-suggestion"
             onClick={() => handleSuggestion("self-improving agent")}
           >
-            <Zap size={13} /> self-improving agent
+            self-improving agent
           </button>
           <button
             type="button"
             className="home-v2-suggestion"
             onClick={() => handleSuggestion("GitHub integration")}
           >
-            <Code2 size={13} /> GitHub integration
+            GitHub integration
           </button>
           <button
             type="button"
             className="home-v2-suggestion"
             onClick={() => handleSuggestion("security soul")}
           >
-            <Shield size={13} /> security soul
+            security soul
           </button>
           <button
             type="button"
             className="home-v2-suggestion"
             onClick={() => handleSuggestion("dashboard builder")}
           >
-            <Layers size={13} /> dashboard builder
+            dashboard builder
           </button>
         </div>
       </section>
@@ -502,9 +500,6 @@ function SkillsHome() {
                   className="home-v2-c-card"
                 >
                   <div className="home-v2-c-head">
-                    <div className="home-v2-c-icon">
-                      <Zap size={18} />
-                    </div>
                     <div className="home-v2-c-meta">
                       <div className="home-v2-c-name">
                         {entry.skill.displayName || entry.skill.slug}
@@ -514,9 +509,7 @@ function SkillsHome() {
                       </div>
                     </div>
                   </div>
-                  <span className="home-v2-c-tag">
-                    <Zap size={11} /> Skill
-                  </span>
+                  <span className="home-v2-c-tag">Skill</span>
                   <div className="home-v2-c-desc">
                     {entry.skill.summary || "A fresh skill bundle."}
                   </div>
@@ -545,9 +538,6 @@ function SkillsHome() {
                   className="home-v2-c-card"
                 >
                   <div className="home-v2-c-head">
-                    <div className="home-v2-c-icon">
-                      <Zap size={18} />
-                    </div>
                     <div className="home-v2-c-meta">
                       <div className="home-v2-c-name">
                         {entry.skill.displayName || entry.skill.slug}
@@ -557,9 +547,7 @@ function SkillsHome() {
                       </div>
                     </div>
                   </div>
-                  <span className="home-v2-c-tag">
-                    <Zap size={11} /> Skill
-                  </span>
+                  <span className="home-v2-c-tag">Skill</span>
                   <div className="home-v2-c-desc">
                     {entry.skill.summary || "A fresh skill bundle."}
                   </div>
@@ -602,7 +590,7 @@ function SkillsHome() {
             className="home-v2-cat-item"
           >
             <div className="home-v2-cat-icon">
-              <Zap size={20} />
+              <Package size={20} />
             </div>
             <div className="home-v2-cat-text">
               <div className="home-v2-cat-name">Skills</div>

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -9,9 +9,7 @@ import {
   Moon,
   RotateCcw,
   Settings2,
-  Sparkles,
   Sun,
-  Zap,
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -495,8 +493,7 @@ export function Settings() {
 
                 {/* Code & Content Section - Advanced */}
                 <div className="space-y-4">
-                  <Label className="text-sm font-semibold text-[color:var(--ink)] flex items-center gap-2">
-                    <Sparkles size={14} className="text-[color:var(--accent)]" />
+                  <Label className="text-sm font-semibold text-[color:var(--ink)]">
                     Code &amp; Content
                   </Label>
                   
@@ -533,10 +530,7 @@ export function Settings() {
                         </SelectTrigger>
                         <SelectContent>
                           <SelectItem value="full">
-                            <span className="flex items-center gap-2">
-                              <Zap size={14} />
-                              Full
-                            </span>
+                            Full
                           </SelectItem>
                           <SelectItem value="reduced">Reduced</SelectItem>
                           <SelectItem value="none">None</SelectItem>
@@ -604,8 +598,7 @@ export function Settings() {
 
                 {/* Experimental Features - Advanced */}
                 <div className="space-y-4">
-                  <Label className="text-sm font-semibold text-[color:var(--ink)] flex items-center gap-2">
-                    <Sparkles size={14} className="text-[color:var(--gold)]" />
+                  <Label className="text-sm font-semibold text-[color:var(--ink)]">
                     Experimental
                   </Label>
                   

--- a/src/routes/skills/-SkillsToolbar.tsx
+++ b/src/routes/skills/-SkillsToolbar.tsx
@@ -8,11 +8,11 @@ import {
   MessageSquare,
   Package,
   Plug,
+  RefreshCw,
   Search,
   Shield,
   Wrench,
   X,
-  Zap,
 } from "lucide-react";
 import type { RefObject } from "react";
 import { useMemo } from "react";
@@ -64,7 +64,7 @@ const CATEGORY_ICONS: Record<string, React.ReactNode> = {
   "dev-tools": <Wrench size={13} />,
   data: <Database size={13} />,
   security: <Shield size={13} />,
-  automation: <Zap size={13} />,
+  automation: <RefreshCw size={13} />,
   other: <Package size={13} />,
 };
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -912,6 +912,11 @@ code {
   place-items: center;
   overflow: hidden;
   background: transparent;
+  box-shadow:
+    inset 0 0 0 1px color-mix(in srgb, var(--ink) 8%, transparent),
+    0 1px 2px rgba(0, 0, 0, 0.10),
+    0 2px 6px rgba(0, 0, 0, 0.05);
+  transition: box-shadow 0.2s ease;
 }
 
 .brand-mark img {
@@ -919,6 +924,7 @@ code {
   height: 100%;
   object-fit: cover;
   border-radius: var(--r-sm);
+  transform: translateZ(0);
 }
 
 .nav-links {


### PR DESCRIPTION
- Simplify home and settings labels by removing redundant icons
- Swap automation icons to refresh glyphs in sidebars and toolbar
- Add subtle border and shadow treatment to the brand mark