### PR TITLE
Mobile search icon + system theme on first load

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -117,6 +117,11 @@ function RootDocument({ children }: { children: React.ReactNode }) {
     <html lang="en">
       <head>
         <HeadContent />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var d=document.documentElement,s='clawhub-theme-selection',k='clawhub-theme',n='clawhub-theme-name',l='clawdhub-theme';var sel;try{var raw=localStorage.getItem(s);if(raw){sel=JSON.parse(raw)}}catch(e){}if(!sel){var m=localStorage.getItem(k),t=localStorage.getItem(n);if(m||t){sel={theme:t||'claw',mode:m||'system'}}else{var lg=localStorage.getItem(l);if(lg){var map={dark:'dark',light:'light',system:'system',defaultTheme:'dark',docsTheme:'light',lightTheme:'dark',landingTheme:'dark',newTheme:'dark',openknot:'dark',fieldmanual:'dark',clawdash:'light'};sel={theme:'claw',mode:map[lg]||'system'}}}}if(!sel)sel={theme:'claw',mode:'system'};var themes=['claw'],modes=['system','light','dark'];if(themes.indexOf(sel.theme)<0)sel.theme='claw';if(modes.indexOf(sel.mode)<0)sel.mode='system';var resolved=sel.mode==='system'?(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):sel.mode;d.dataset.theme=resolved;d.dataset.themeResolved=resolved;d.dataset.themeMode=sel.mode;d.dataset.themeFamily=sel.theme;if(resolved==='dark')d.classList.add('dark');else d.classList.remove('dark')}catch(e){}})()`,
+          }}
+        />
       </head>
       <body>
         <AppProviders>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -438,7 +438,8 @@ function SkillsHome() {
             />
             <kbd>/</kbd>
             <button type="submit" className="home-v2-search-go">
-              Search <ArrowRight size={16} />
+              <span className="home-v2-search-go-label">Search</span>{" "}
+              <ArrowRight size={16} />
             </button>
           </form>
         </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -8747,6 +8747,12 @@ html.theme-transition::view-transition-new(theme) {
     padding: 20px;
     gap: 16px;
   }
+  .home-v2-search-go-label {
+    display: none;
+  }
+  .home-v2-search-go {
+    padding: 13px 16px;
+  }
 }
 
 /* ═══ HOME V2 — Full-width overrides ═══ */


### PR DESCRIPTION
## Summary
- **Mobile search button**: On screens ≤768px, the "Search" label is hidden and only the → arrow icon is shown, keeping the button compact.
- **System theme on first load**: Added an inline `<script>` in `<head>` that reads the stored theme preference (or falls back to `prefers-color-scheme`) and applies the correct `data-*` attributes and `.dark` class on `<html>` before first paint — eliminates the flash of dark theme for light-mode system users.

## Test plan
- [ ] On mobile viewport (≤768px), verify the home page search button shows only the → icon, no "Search" text
- [ ] On desktop, verify the button still shows "Search →" as before
- [ ] Clear localStorage, set OS to light mode, reload — page should render in light theme immediately with no dark flash
- [ ] Clear localStorage, set OS to dark mode, reload — page should render in dark theme
- [ ] Set theme to "light" in settings, reload — should persist correctly
- [ ] Set theme to "system" in settings, toggle OS dark/light — should respond in real time

🤖 Generated with [Claude Code](https://claude.com/claude-code)