### PR TITLE
fix(api): use listPublicPageV4 in v1 skills endpoint

### DIFF
--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -470,13 +470,19 @@ export async function listSkillsV1Handler(ctx: ActionCtx, request: Request) {
     url.searchParams.get("nonSuspiciousOnly"),
     url.searchParams.get("nonSuspicious"),
   );
+  // Map V1 sort to V4 sort (V4 uses "newest" instead of "updated")
+  const v4Sort = sort === "updated" ? "newest" :
+                 sort === "installsCurrent" ? "installs" :
+                 sort === "installsAllTime" ? "installs" : sort;
 
-  const result = (await ctx.runQuery(api.skills.listPublicPage, {
-    limit,
+  const v4Result = await ctx.runQuery(api.skills.listPublicPageV4, {
     cursor,
-    sort,
+    numItems: limit,
+    sort: v4Sort,
     nonSuspiciousOnly: nonSuspiciousOnly || undefined,
-  })) as ListSkillsResult;
+  });
+
+  const result = { items: v4Result.page ?? [], nextCursor: v4Result.nextCursor ?? null } as ListSkillsResult;
 
   // Batch resolve all tags in a single query instead of N queries
   const resolvedTagsList = await resolveTagsBatch(


### PR DESCRIPTION
Fixes #1722

## Problem
The `/api/v1/skills` endpoint returns empty `{"items":[],"nextCursor":null}` for all callers because it calls `listPublicPage` which is a deprecated stub.

## Root Cause
In `convex/httpApiV1/skillsV1.ts:474`, the handler calls `api.skills.listPublicPage` which always returns empty.

## Solution
Changed to call `listPublicPageV4` which has the actual implementation with proper filtering and pagination.

## Changes
1. Call `listPublicPageV4` instead of `listPublicPage`
2. Map V1 sort params to V4 format
3. Map V4 return format (page -> items)

## Impact
- `clawhub explore` CLI command will work again
- Public skills listing via API will return actual results