### PR TITLE
fix(search): preserve vector scores across loop iterations and tighte…

### DIFF
--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -866,6 +866,83 @@ describe("search helpers", () => {
     expect(merged).toHaveLength(2);
     expect(merged.map((entry) => entry.skill._id)).toEqual(["skills:1", "skills:2"]);
   });
+
+  it("preserves vector scores across candidate expansion iterations", async () => {
+    // Regression test for scoreById overwrite bug.
+    //
+    // Setup:
+    //   limit=10  →  candidateLimit starts at 50, maxCandidate=200
+    //   Iteration 1: vectorSearch returns exactly 50 results (= candidateLimit)
+    //                → results.length < candidateLimit is false → loop continues
+    //   Iteration 2: vectorSearch returns 2 results (< 100) → loop exits
+    //
+    // skillA appears ONLY in iteration 1 (score 0.95).
+    // skillB appears ONLY in iteration 2 (score 0.5).
+    //
+    // With the BUG:  scoreById = new Map(iter2_results) → skillA missing → vectorScore=0
+    // With the FIX:  scoreById.set() merges → skillA retains 0.95
+    generateEmbeddingMock.mockResolvedValueOnce([0, 1, 2]);
+
+    const skillA = makePublicSkill({
+      id: "skills:a",
+      slug: "baidu-yijian-vision",
+      displayName: "Baidu Yijian Vision",
+      downloads: 100,
+    });
+    const skillB = makePublicSkill({
+      id: "skills:b",
+      slug: "baidu-yijian-test",
+      displayName: "Baidu Yijian Test",
+      downloads: 50,
+    });
+
+    // Iteration 1: exactly 50 entries so the loop does NOT exit early.
+    // skillA is entry 0; entries 1-49 are fillers filtered out by hydrateResults.
+    const iter1Results = Array.from({ length: 50 }, (_, i) => ({
+      _id: i === 0 ? "skillEmbeddings:a" : `skillEmbeddings:filler${i}`,
+      _score: i === 0 ? 0.95 : 0.1,
+    }));
+
+    // Iteration 2: 2 entries, both new IDs (skillA is absent from this batch).
+    // results.length (2) < candidateLimit (100) → loop exits.
+    const iter2Results = [
+      { _id: "skillEmbeddings:b", _score: 0.5 },
+      { _id: "skillEmbeddings:filler50", _score: 0.08 },
+    ];
+
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce(null) // getExactSkillSlugMatch
+      // hydrateResults iteration 1: 50 new IDs → only skillA survives hydration
+      .mockResolvedValueOnce([
+        { embeddingId: "skillEmbeddings:a", skill: skillA, version: null, ownerHandle: "owner", owner: null },
+      ])
+      // hydrateResults iteration 2: 2 new IDs → only skillB survives hydration
+      .mockResolvedValueOnce([
+        { embeddingId: "skillEmbeddings:b", skill: skillB, version: null, ownerHandle: "owner", owner: null },
+      ])
+      // lexicalFallbackSkills (exactMatches < limit after loop exits)
+      .mockResolvedValueOnce([]);
+
+    const result = await searchSkillsHandler(
+      {
+        vectorSearch: vi
+          .fn()
+          .mockResolvedValueOnce(iter1Results) // iteration 1: 50 results, loop continues
+          .mockResolvedValueOnce(iter2Results), // iteration 2: 2 results, loop exits
+        runQuery,
+      },
+      { query: "baidu yijian", limit: 10 },
+    );
+
+    const resultA = result.find((r: { skill: { slug: string } }) => r.skill.slug === "baidu-yijian-vision");
+    expect(resultA).toBeDefined();
+    // With scoreById correctly merged: skillA retains vectorScore=0.95.
+    // With the bug (overwrite): skillA.embeddingId absent from iter2 map → vectorScore=0.
+    // Lexical boost for "baidu-yijian-vision" slug matching "baidu yijian" ≈ 0.8 (prefix).
+    // Fix: score ≈ 0.95 + 0.8 + popularity > 1.5; Bug: score ≈ 0 + 0.8 + popularity < 0.9.
+    expect(resultA!.score).toBeGreaterThan(1.0);
+  });
 });
 
 function makePublicSkill(params: {

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -193,9 +193,9 @@ export const searchSkills: ReturnType<typeof action> = action({
         hydrated = [...hydrated, ...newEntries];
       }
 
-      scoreById = new Map<Id<"skillEmbeddings">, number>(
-        results.map((result) => [result._id, result._score]),
-      );
+      for (const result of results) {
+        scoreById.set(result._id, result._score);
+      }
 
       // Skills already have badges from their docs (via toPublicSkill).
       // No need for a separate badge table lookup.
@@ -476,9 +476,9 @@ export const searchSouls: ReturnType<typeof action> = action({
         embeddingIds: results.map((result) => result._id),
       })) as HydratedSoulEntry[];
 
-      scoreById = new Map<Id<"soulEmbeddings">, number>(
-        results.map((result) => [result._id, result._score]),
-      );
+      for (const result of results) {
+        scoreById.set(result._id, result._score);
+      }
 
       exactMatches = hydrated.filter((entry) =>
         matchesExactTokens(queryTokens, [


### PR DESCRIPTION
## Problem

The `searchSkills` and `searchSouls` actions have a bug that causes vector scores to be lost across candidate expansion iterations, leading to inconsistent and incorrect search rankings.

### Bug: `scoreById` overwritten each loop iteration

```typescript
// convex/search.ts (inside while loop)
scoreById = new Map<Id<"skillEmbeddings">, number>(
  results.map((result) => [result._id, result._score]),
);
```

The entire map is **replaced** on each iteration rather than merged. Meanwhile, `hydrated` entries are correctly accumulated across iterations:

```typescript
hydrated = [...hydrated, ...newEntries]; // accumulated ✅
```

Skills found in earlier iterations lose their vector scores (treated as 0 via `scoreById.get(entry.embeddingId) ?? 0`), causing severe ranking degradation. This also makes search results inconsistent — the same query produces different rankings depending on the `limit` parameter.

**Why ranking changes with `limit`:** When the frontend requests a larger `limit` (e.g., 75), the initial `candidateLimit` starts higher (225), so fewer loop iterations are needed and `scoreById` is overwritten fewer times. In the extreme case where only one iteration is needed, no scores are lost.

## Changes

### `convex/search.ts`
- Changed `scoreById = new Map(...)` → `for (result) scoreById.set(...)` in both `searchSkills` and `searchSouls`

### `convex/search.test.ts`
- Added: `preserves vector scores across candidate expansion iterations`

## Test

- Vector scores preserved across loop iterations — early-found skills retain their scores
