### PR TITLE
fix(ui): trim version input before semver validation

### DIFF
--- a/src/routes/publish-skill.tsx
+++ b/src/routes/publish-skill.tsx
@@ -167,6 +167,7 @@ export function Upload() {
   const trimmedSlug = slug.trim();
   const trimmedName = displayName.trim();
   const trimmedChangelog = changelog.trim();
+  const trimmedVersion = version.trim();
   const slugAvailability = useQuery(
     api.skills.checkSlugAvailability,
     !isSoulMode && isAuthenticated && trimmedSlug && SLUG_PATTERN.test(trimmedSlug)
@@ -215,7 +216,7 @@ export function Upload() {
     if (changelogTouchedRef.current) return;
     if (trimmedChangelog) return;
     if (!trimmedSlug || !SLUG_PATTERN.test(trimmedSlug)) return;
-    if (!semver.valid(version)) return;
+    if (!semver.valid(trimmedVersion)) return;
     if (!hasRequiredFile) return;
     if (files.length === 0) return;
 
@@ -228,7 +229,7 @@ export function Upload() {
     const requiredFile = files[requiredIndex];
     if (!requiredFile) return;
 
-    const key = `${trimmedSlug}:${version}:${requiredFile.size}:${requiredFile.lastModified}:${normalizedPaths.length}`;
+    const key = `${trimmedSlug}:${trimmedVersion}:${requiredFile.size}:${requiredFile.lastModified}:${normalizedPaths.length}`;
     if (changelogKeyRef.current === key) return;
     changelogKeyRef.current = key;
 
@@ -240,7 +241,7 @@ export function Upload() {
         if (changelogRequestRef.current !== requestId) return null;
         return generateChangelogPreview({
           slug: trimmedSlug,
-          version,
+          trimmedVersion,
           readmeText: text.slice(0, 20_000),
           filePaths: normalizedPaths,
         });
@@ -264,7 +265,7 @@ export function Upload() {
     normalizedPaths,
     trimmedChangelog,
     trimmedSlug,
-    version,
+    trimmedVersion,
   ]);
   const parsedTags = useMemo(
     () =>
@@ -284,7 +285,7 @@ export function Upload() {
     if (!trimmedName) {
       issues.push("Display name is required.");
     }
-    if (!semver.valid(version)) {
+    if (!semver.valid(trimmedVersion)) {
       issues.push("Version must be valid semver (e.g. 1.0.0).");
     }
     if (parsedTags.length === 0) {
@@ -324,7 +325,7 @@ export function Upload() {
   }, [
     trimmedSlug,
     trimmedName,
-    version,
+    trimmedVersion,
     parsedTags.length,
     acceptedLicenseTerms,
     files,
@@ -434,7 +435,7 @@ export function Upload() {
         ownerHandle: isSoulMode ? undefined : ownerHandle || undefined,
         slug: trimmedSlug,
         displayName: trimmedName,
-        version,
+        trimmedVersion,
         changelog: trimmedChangelog,
         acceptLicenseTerms: isSoulMode ? undefined : acceptedLicenseTerms,
         tags: parsedTags,
@@ -445,7 +446,7 @@ export function Upload() {
       setHasAttempted(false);
       setChangelogSource("user");
       if (result) {
-        toast.success(`Published ${trimmedSlug}@${version}`);
+        toast.success(`Published ${trimmedSlug}@${trimmedVersion}`);
         const ownerParam = ownerHandle || me?.handle || (me?._id ? String(me._id) : "unknown");
         void navigate({
           to: isSoulMode ? "/souls/$slug" : "/$owner/$slug",


### PR DESCRIPTION
Fixes #1739

## Problem
The version field on the publish-skill page rejects valid minor/major bumps (e.g. `1.6.0` after `1.5.1`) because user input may contain leading/trailing whitespace.

`semver.valid()` returns `null` for strings with whitespace, triggering the "Version must be valid semver (e.g. 1.0.0)" error even though the trimmed value would be valid.

## Root Cause
- `version` state variable was not trimmed before validation
- Other fields (`slug`, `displayName`, `changelog`) are trimmed, but `version` was missed

## Solution
Added `trimmedVersion = version.trim()` and used it in:
- `semver.valid()` checks (line 219, 288)
- `publishVersion` call (line 435)
- Toast success message (line 446)
- Changelog preview generation (line 241)
- All useMemo dependencies

The Input value remains untrimmed for user visibility.

## Testing
Users can now manually enter:
- `1.6.0` (no whitespace) ✓
- `  1.6.0` (leading space) ✓
- `1.6.0  ` (trailing space) ✓

All will be trimmed and accepted as valid semver.

## Impact
- Skill maintainers can now publish minor/major releases from the web UI
- No need to workaround by publishing via CLI or using patch-only bumps