### PR TITLE
feat: add skill install prompt surface

### DIFF
--- a/docs/superpowers/specs/2026-04-22-skill-install-surface-design.md
+++ b/docs/superpowers/specs/2026-04-22-skill-install-surface-design.md
@@ -1,0 +1,308 @@
+# Skill Install Surface Design
+
+- Date: 2026-04-22
+- Status: Approved for planning
+- Scope: skill detail page install UX on ClawHub
+
+## Problem
+
+The skill detail page does not treat installation as a primary action. Plugin pages already surface a direct install command prominently, but skill pages bury install-related information inside a denser metadata block. This is weaker for users who arrive on a skill page intending to install immediately.
+
+There is also no first-class prompt-based install flow for OpenClaw. That is especially awkward for remote sessions and server-side environments where the better user experience is often "copy one prompt into OpenClaw and let it handle the install and setup guidance" rather than manually piecing together commands and requirements.
+
+## Goals
+
+1. Make installation a prominent, above-the-fold action on the skill page.
+2. Keep exact install commands visible, copyable, and trustworthy.
+3. Add an OpenClaw prompt-based install flow that works through copyable prompts only.
+4. Support two prompt scopes:
+   - `Install Only`
+   - `Install & Setup`
+5. Keep the flow explicit enough that users can see what will be copied before they use it.
+
+## Non-Goals
+
+1. No direct handoff, deep link, or automatic execution into OpenClaw.
+2. No backend or Convex changes.
+3. No plugin detail page redesign in this slice.
+4. No attempt to auto-complete setup inside ClawHub itself.
+5. No hidden prompt generation that users cannot inspect.
+
+## Final UX Direction
+
+Add a new `Install` section near the top of the skill hero, using a split layout:
+
+1. `Install with OpenClaw`
+2. `CLI Commands`
+
+Desktop should render these as two sibling panels inside one install surface. Mobile should stack them vertically with `Install with OpenClaw` first.
+
+This section becomes the primary install surface for the page. Existing runtime requirements, dependency metadata, links, and install specs remain available below as supporting information, not as the primary call-to-action.
+
+## Install With OpenClaw Panel
+
+### Structure
+
+The OpenClaw panel contains:
+
+1. A short explanation that this path is best for remote or guided setup.
+2. A `Copy Prompt` action with menu behavior.
+3. A prompt option menu with two choices:
+   - `Install Only`
+   - `Install & Setup`
+4. A prompt preview area showing the exact prompt that will be copied.
+
+### Interaction Model
+
+The `Copy Prompt` control should behave like a menu trigger, not a blind copy button.
+
+When opened, it reveals:
+
+1. `Install Only`
+   Copies a prompt that tells OpenClaw to install the skill and stop there.
+2. `Install & Setup`
+   Copies a prompt that tells OpenClaw to install the skill, inspect the skill metadata, and help the user finish setup.
+
+Selecting an option should:
+
+1. Update the prompt preview area.
+2. Copy the corresponding prompt to the clipboard.
+3. Show clear success or failure feedback.
+
+The preview area should remain visible after selection so the copied text is inspectable.
+
+### Prompt Content Rules
+
+Both prompts should include the concrete skill identity, not vague prose.
+
+Prefer:
+
+- canonical install target: `owner/slug`
+- canonical skill page URL
+- enough setup context to avoid ambiguous or unsafe follow-up behavior
+
+#### Install Only Prompt
+
+The prompt should instruct OpenClaw to:
+
+1. Install the skill from ClawHub.
+2. Keep the action narrowly scoped to that skill.
+3. Stop after install rather than making setup changes.
+
+#### Install & Setup Prompt
+
+The prompt should instruct OpenClaw to:
+
+1. Install the skill from ClawHub.
+2. Inspect the skill metadata and installation requirements.
+3. Help the user finish setup steps such as:
+   - required env vars
+   - required binaries
+   - config files or follow-up instructions
+4. Avoid unrelated changes.
+5. Ask before making broader environment changes.
+
+This prompt is intentionally "full service" but still constrained. It should guide OpenClaw toward a narrow setup flow rather than a vague "do everything" request.
+
+## CLI Commands Panel
+
+The CLI panel keeps the raw install paths visible and copyable.
+
+It should contain two command blocks:
+
+1. `OpenClaw CLI`
+2. `ClawHub CLI`
+
+### OpenClaw CLI Command
+
+Primary format:
+
+```sh
+openclaw skills install owner/slug
+```
+
+If the canonical owner handle is unavailable, fall back to the best canonical identifier already used by the page route. If no owner-qualified target can be built safely, fall back to the plain slug command rather than fabricating a broken owner path.
+
+### ClawHub CLI Command
+
+Preserve package-manager flexibility rather than hard-coding one package manager.
+
+Expected behavior:
+
+1. Reuse the existing package-manager switching pattern already present on the skill page.
+2. Keep `npm` selected by default to preserve the current behavior of that switcher.
+3. Keep the copied command fully explicit.
+
+Example variants:
+
+```sh
+npx clawhub@latest install slug
+pnpm dlx clawhub@latest install slug
+bunx clawhub@latest install slug
+```
+
+Each command block should have its own copy action.
+
+## Supporting Metadata
+
+The current metadata-driven install details should not disappear. Instead, they should move into a clearly secondary role below the new install surface.
+
+This includes:
+
+1. runtime requirements
+2. dependencies
+3. install specs declared by the skill
+4. relevant links
+
+The user should be able to:
+
+1. install immediately from the hero
+2. then scroll into requirements and metadata if they need deeper operational detail
+
+## Information Architecture
+
+The page hierarchy after this change should be:
+
+1. skill header and summary
+2. primary install surface
+3. security scan and other trust signals
+4. supporting metadata panels
+5. README, files, comments, versions, compare, owner tools
+
+If the existing hero composition requires rearranging nearby blocks to avoid crowding, favor install clarity over preserving the current exact order.
+
+## Component-Level Design
+
+Recommended component split:
+
+1. `SkillInstallSurface`
+   Owns the new install section, layout, copy interactions, and prompt preview state.
+2. `SkillPromptMenu` or equivalent local subcomponent
+   Owns prompt option selection and menu rendering.
+3. `InstallCopyButton`
+   Shared copy button behavior for commands and prompts, ideally reusing the plugin page copy feedback pattern.
+4. Small pure helpers in `skillDetailUtils.ts`
+   Build canonical commands and prompt text.
+
+The existing `SkillInstallCard` should be narrowed to supporting metadata panels only. The new
+primary install surface should live in a separate component so prompt generation, copy state, and
+hero layout are not tangled with dependency metadata rendering.
+The goal is to avoid one oversized component that mixes hero layout, prompt generation, copy
+logic, and metadata panels.
+
+## Copy and Content Rules
+
+### OpenClaw Copy
+
+- Label: `Copy Prompt`
+- Menu options:
+  - `Install Only`
+  - `Install & Setup`
+- Preview should show exact copied text
+
+### CLI Copy
+
+- Keep labels literal: `Copy`
+- Do not hide the actual command behind a tooltip-only surface
+
+### Tone
+
+The UI copy should be direct and operational, not marketing-heavy.
+
+Good:
+
+- `Install with OpenClaw`
+- `Copy Prompt`
+- `Install & Setup`
+- `OpenClaw CLI`
+- `ClawHub CLI`
+
+Avoid:
+
+- vague claims about automation
+- promise-heavy language
+- copy that suggests ClawHub will execute anything on the user's behalf
+
+## Accessibility
+
+The new surface must remain keyboard-usable and screen-reader-legible.
+
+Requirements:
+
+1. The prompt menu trigger is keyboard accessible.
+2. Menu items expose clear labels and descriptions.
+3. Copy success feedback does not rely on color alone.
+4. Command text remains selectable and readable at small widths.
+5. Mobile layout stacks cleanly without horizontal clipping.
+
+## Error Handling
+
+### Clipboard Failure
+
+If clipboard write fails:
+
+1. use the existing fallback copy path where available
+2. show failure feedback if both copy mechanisms fail
+
+### Missing Metadata
+
+If prompt generation cannot build full setup guidance because some metadata is absent:
+
+1. still allow prompt copy
+2. generate the best constrained prompt available
+3. do not invent requirements that the page does not know
+
+### Missing Canonical Owner
+
+If the owner-qualified target cannot be built reliably:
+
+1. degrade gracefully to the safest install target available
+2. keep copied text accurate
+3. do not render misleading `owner/slug` syntax
+
+## Testing
+
+### Unit Tests
+
+Add or update tests for:
+
+1. command builders
+2. prompt builders
+3. canonical owner fallback behavior
+4. copy state transitions if extracted into reusable helpers
+
+### Component Tests
+
+Add or update tests for:
+
+1. the new install surface rendering on skill detail pages
+2. prompt menu open and selection behavior
+3. prompt preview updates
+4. OpenClaw and ClawHub command visibility
+5. copy success feedback paths
+
+### Manual Verification
+
+Verify:
+
+1. desktop layout
+2. mobile stacking
+3. long owner/slug values
+4. skill pages with sparse metadata
+5. copy behavior in browsers with and without `navigator.clipboard`
+
+## Rollout Notes
+
+This feature should ship as a focused UI slice. Keep scope disciplined:
+
+1. no direct OpenClaw handoff
+2. no execution inside ClawHub
+3. no broad refactor outside the skill detail install surface unless needed to keep the component boundary clean
+
+## Open Questions Resolved
+
+1. The primary layout is the split install surface, not a single merged box.
+2. OpenClaw uses copyable prompts only.
+3. The prompt flow supports both `Install Only` and `Install & Setup`.
+4. The `Copy Prompt` control reveals those prompt options.
+5. Raw CLI commands remain visible underneath the OpenClaw flow.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "type": "module",
   "scripts": {
-    "build": "bun --bun vite build && bun scripts/copy-og-assets.ts",
+    "build": "vite build && bun scripts/copy-og-assets.ts",
     "check": "bun run lint",
     "check:peers": "bun scripts/check-peer-deps.ts",
     "check:secrets": "bun scripts/check-staged-secrets.mjs",

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -152,6 +152,89 @@ describe("SkillDetailPage", () => {
     expect(screen.queryByRole("button", { name: "Compare" })).toBeNull();
   });
 
+  it("renders the install surface above the security scan with visible prompts and commands", async () => {
+    useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
+      if (args === "skip") return undefined;
+      return undefined;
+    });
+
+    render(
+      <SkillDetailPage
+        slug="weather"
+        initialData={{
+          result: {
+            skill: {
+              _id: skillId,
+              _creationTime: 0,
+              slug: "weather",
+              displayName: "Weather",
+              summary: "Get current weather.",
+              ownerUserId: ownerId,
+              ownerPublisherId,
+              tags: {},
+              badges: {},
+              stats: {
+                stars: 12,
+                downloads: 34,
+                installsCurrent: 5,
+                installsAllTime: 8,
+                versions: 1,
+                comments: 0,
+              },
+              createdAt: 0,
+              updatedAt: 0,
+            },
+            owner: {
+              _id: ownerPublisherId,
+              _creationTime: 0,
+              kind: "user",
+              handle: "steipete",
+              displayName: "Peter",
+              linkedUserId: ownerId,
+            },
+            latestVersion: {
+              _id: versionId,
+              _creationTime: 0,
+              skillId,
+              version: "1.0.0",
+              fingerprint: "abc",
+              changelog: "Initial release",
+              parsed: {
+                license: "MIT-0",
+                frontmatter: {},
+                clawdis: {
+                  requires: {
+                    env: ["WEATHER_API_KEY"],
+                    bins: ["curl"],
+                  },
+                },
+              },
+              files: [],
+              sha256hash: "abc123",
+              createdBy: ownerId,
+              createdAt: 0,
+            },
+            forkOf: null,
+            canonical: null,
+          },
+          readme: "# Weather",
+          readmeError: null,
+        }}
+      />,
+    );
+
+    const installHeading = await screen.findByRole("heading", { name: "Install with OpenClaw" });
+    const scanDisclaimer = screen.getByText(
+      /Like a lobster shell, security has layers — review code before you run it\./i,
+    );
+
+    expect(screen.getByRole("heading", { name: "CLI Commands" })).toBeTruthy();
+    expect(screen.getByText("openclaw skills install steipete/weather")).toBeTruthy();
+    expect(screen.getByText("npx clawhub@latest install weather")).toBeTruthy();
+    expect(screen.getByText(/After install, inspect the skill metadata/i)).toBeTruthy();
+    expect(installHeading.compareDocumentPosition(scanDisclaimer) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it("does not refetch readme when SSR data already matches the latest version", async () => {
     useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
       if (args === "skip") return undefined;

--- a/src/components/InstallCopyButton.tsx
+++ b/src/components/InstallCopyButton.tsx
@@ -1,0 +1,100 @@
+import { Check, Copy } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { cn } from "../lib/utils";
+import { Button } from "./ui/button";
+
+type CopyState = "idle" | "copied" | "failed";
+
+export async function copyText(text: string) {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return true;
+  }
+
+  if (typeof document === "undefined" || typeof document.execCommand !== "function") {
+    return false;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  textarea.style.pointerEvents = "none";
+  document.body.appendChild(textarea);
+  textarea.select();
+  textarea.setSelectionRange(0, text.length);
+
+  try {
+    return document.execCommand("copy");
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+export function InstallCopyButton({
+  text,
+  label = "Copy",
+  ariaLabel,
+  className,
+}: {
+  text: string;
+  label?: string;
+  ariaLabel?: string;
+  className?: string;
+}) {
+  const [copyState, setCopyState] = useState<CopyState>("idle");
+  const resetTimeoutRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (resetTimeoutRef.current !== null) {
+        window.clearTimeout(resetTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  const scheduleReset = () => {
+    if (resetTimeoutRef.current !== null) {
+      window.clearTimeout(resetTimeoutRef.current);
+    }
+
+    resetTimeoutRef.current = window.setTimeout(() => {
+      setCopyState("idle");
+      resetTimeoutRef.current = null;
+    }, 2000);
+  };
+
+  const buttonLabel =
+    copyState === "copied" ? "Copied" : copyState === "failed" ? "Copy Failed" : label;
+
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="outline"
+      className={cn("skill-install-copy-button", className)}
+      aria-label={ariaLabel ?? label}
+      data-copy-state={copyState}
+      onClick={() => {
+        void copyText(text)
+          .then((didCopy) => {
+            setCopyState(didCopy ? "copied" : "failed");
+            scheduleReset();
+          })
+          .catch(() => {
+            setCopyState("failed");
+            scheduleReset();
+          });
+      }}
+    >
+      {copyState === "copied" ? (
+        <Check className="h-3.5 w-3.5" aria-hidden="true" />
+      ) : (
+        <Copy className="h-3.5 w-3.5" aria-hidden="true" />
+      )}
+      <span aria-live="polite">{buttonLabel}</span>
+    </Button>
+  );
+}

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -8,6 +8,7 @@ import type { PublicPublisher, PublicSkill } from "../lib/publicUser";
 
 import { type LlmAnalysis, SecurityScanResults } from "./SkillSecurityScanResults";
 import { SkillInstallCard } from "./SkillInstallCard";
+import { SkillInstallSurface } from "./SkillInstallSurface";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import { UserBadge } from "./UserBadge";
@@ -123,6 +124,7 @@ export function SkillHeader({
   const overrideScanMessage = suppressScanResults
     ? "Security findings were reviewed by staff and cleared for public use."
     : null;
+  const installOwnerId = owner?._id ?? skill.ownerPublisherId ?? skill.ownerUserId ?? null;
 
   return (
     <>
@@ -297,6 +299,14 @@ export function SkillHeader({
             </div>
           </div>
 
+          <SkillInstallSurface
+            slug={skill.slug}
+            displayName={skill.displayName}
+            ownerHandle={ownerHandle}
+            ownerId={installOwnerId}
+            clawdis={clawdis}
+          />
+
           {/* Security scan — full width below the header columns */}
           {suppressScanResults ? (
             <div className="skill-hero-note">{overrideScanMessage}</div>
@@ -395,13 +405,17 @@ export function SkillHeader({
             className="tag-form"
           >
             <input
+              aria-label="Tag name"
               className="search-input"
+              name="tagName"
               value={tagName}
               onChange={(event) => onTagNameChange(event.target.value)}
-              placeholder="latest"
+              placeholder="latest…"
             />
             <select
+              aria-label="Tag version"
               className="search-input"
+              name="tagVersion"
               value={tagVersionId ?? ""}
               onChange={(event) => onTagVersionChange(event.target.value as Id<"skillVersions">)}
             >
@@ -412,7 +426,7 @@ export function SkillHeader({
               ))}
             </select>
             <Button type="submit">
-              Update tag
+              Update Tag
             </Button>
           </form>
         ) : null}

--- a/src/components/SkillInstallSurface.test.tsx
+++ b/src/components/SkillInstallSurface.test.tsx
@@ -1,0 +1,94 @@
+/* @vitest-environment jsdom */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SkillInstallSurface } from "./SkillInstallSurface";
+
+const writeTextMock = vi.fn();
+
+vi.mock("./ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+  }: {
+    children: ReactNode;
+    onSelect?: () => void;
+  }) => (
+    <button type="button" onClick={() => onSelect?.()}>
+      {children}
+    </button>
+  ),
+}));
+
+describe("SkillInstallSurface", () => {
+  const ownerPublisherId = "publishers:1" as never;
+
+  beforeEach(() => {
+    writeTextMock.mockReset();
+    writeTextMock.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: writeTextMock,
+      },
+    });
+  });
+
+  it("renders the default install-and-setup preview and copies the selected prompt", async () => {
+    render(
+      <SkillInstallSurface
+        slug="weather"
+        displayName="Weather"
+        ownerHandle="steipete"
+        ownerId={ownerPublisherId}
+        clawdis={
+          {
+            requires: {
+              env: ["WEATHER_API_KEY"],
+              bins: ["curl"],
+            },
+          } as never
+        }
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Install with OpenClaw" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "CLI Commands" })).toBeTruthy();
+    expect(screen.getByText(/After install, inspect the skill metadata/i)).toBeTruthy();
+    expect(screen.getAllByText("Install & Setup").length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole("button", { name: /Install Only/i }));
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith(
+        expect.stringContaining("Stop after the skill is installed."),
+      );
+    });
+    expect(screen.getByText(/Stop after the skill is installed\./i)).toBeTruthy();
+    expect(screen.getAllByText("Install Only").length).toBeGreaterThan(0);
+  });
+
+  it("switches the ClawHub command and copies the visible CLI command", async () => {
+    render(
+      <SkillInstallSurface
+        slug="weather"
+        displayName="Weather"
+        ownerHandle="steipete"
+        ownerId={ownerPublisherId}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Use pnpm for ClawHub install command" }));
+    expect(screen.getByText("pnpm dlx clawhub@latest install weather")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy ClawHub CLI command" }));
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith("pnpm dlx clawhub@latest install weather");
+    });
+  });
+});

--- a/src/components/SkillInstallSurface.tsx
+++ b/src/components/SkillInstallSurface.tsx
@@ -1,0 +1,238 @@
+import type { ClawdisSkillMetadata } from "clawhub-schema";
+import { ChevronDown } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
+import type { Id } from "../../convex/_generated/dataModel";
+import { copyText, InstallCopyButton } from "./InstallCopyButton";
+import {
+  buildSkillInstallTarget,
+  formatClawHubInstallCommand,
+  formatOpenClawInstallCommand,
+  formatOpenClawPrompt,
+  type SkillPackageManager,
+  type SkillPromptMode,
+} from "./skillDetailUtils";
+import { Button } from "./ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
+
+const PACKAGE_MANAGERS: SkillPackageManager[] = ["npm", "pnpm", "bun"];
+
+const PROMPT_OPTIONS: Array<{
+  description: string;
+  label: string;
+  mode: SkillPromptMode;
+}> = [
+  {
+    mode: "install-only",
+    label: "Install Only",
+    description: "Install the skill and stop there.",
+  },
+  {
+    mode: "install-and-setup",
+    label: "Install & Setup",
+    description: "Install first, then help finish setup from skill metadata.",
+  },
+];
+
+type PromptCopyState = "idle" | "copied" | "failed";
+
+type SkillInstallSurfaceProps = {
+  slug: string;
+  displayName: string;
+  ownerHandle: string | null;
+  ownerId: Id<"users"> | Id<"publishers"> | null;
+  clawdis?: ClawdisSkillMetadata;
+};
+
+export function SkillInstallSurface({
+  slug,
+  displayName,
+  ownerHandle,
+  ownerId,
+  clawdis,
+}: SkillInstallSurfaceProps) {
+  const headingId = useId();
+  const [packageManager, setPackageManager] = useState<SkillPackageManager>("npm");
+  const [promptMode, setPromptMode] = useState<SkillPromptMode>("install-and-setup");
+  const [promptCopyState, setPromptCopyState] = useState<PromptCopyState>("idle");
+  const promptResetTimeoutRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (promptResetTimeoutRef.current !== null) {
+        window.clearTimeout(promptResetTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  const schedulePromptReset = () => {
+    if (promptResetTimeoutRef.current !== null) {
+      window.clearTimeout(promptResetTimeoutRef.current);
+    }
+
+    promptResetTimeoutRef.current = window.setTimeout(() => {
+      setPromptCopyState("idle");
+      promptResetTimeoutRef.current = null;
+    }, 2000);
+  };
+
+  const selectedPrompt = PROMPT_OPTIONS.find((option) => option.mode === promptMode) ?? PROMPT_OPTIONS[1];
+  const installTarget = buildSkillInstallTarget(ownerHandle, ownerId, slug);
+  const openClawCommand = formatOpenClawInstallCommand(ownerHandle, ownerId, slug);
+  const clawHubCommand = formatClawHubInstallCommand(slug, packageManager);
+  const promptPreview = formatOpenClawPrompt({
+    mode: promptMode,
+    skillName: displayName,
+    slug,
+    ownerHandle,
+    ownerId,
+    clawdis,
+  });
+
+  const promptFeedback =
+    promptCopyState === "copied"
+      ? `${selectedPrompt.label} prompt copied.`
+      : promptCopyState === "failed"
+        ? "Copy failed. Try again."
+        : `Previewing ${selectedPrompt.label}.`;
+
+  const selectPromptMode = (mode: SkillPromptMode) => {
+    const promptText = formatOpenClawPrompt({
+      mode,
+      skillName: displayName,
+      slug,
+      ownerHandle,
+      ownerId,
+      clawdis,
+    });
+
+    setPromptMode(mode);
+
+    void copyText(promptText)
+      .then((didCopy) => {
+        setPromptCopyState(didCopy ? "copied" : "failed");
+        schedulePromptReset();
+      })
+      .catch(() => {
+        setPromptCopyState("failed");
+        schedulePromptReset();
+      });
+  };
+
+  return (
+    <section className="skill-install-surface" aria-labelledby={headingId}>
+      <h2 id={headingId} className="sr-only">
+        Install
+      </h2>
+
+      <div className="skill-install-grid">
+        <article className="skill-install-panel">
+          <div className="skill-install-panel-header">
+            <p className="skill-install-kicker">OpenClaw Prompt Flow</p>
+            <h3 className="skill-install-panel-title">Install with OpenClaw</h3>
+            <p className="skill-install-panel-copy">
+              Best for remote or guided setup. Copy the exact prompt, then paste it into OpenClaw
+              for <code translate="no">{installTarget}</code>.
+            </p>
+          </div>
+
+          <div className="skill-install-actions">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button type="button" className="skill-install-prompt-trigger">
+                  <span>Copy Prompt</span>
+                  <ChevronDown className="h-4 w-4" aria-hidden="true" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="skill-install-menu">
+                {PROMPT_OPTIONS.map((option) => (
+                  <DropdownMenuItem key={option.mode} onSelect={() => selectPromptMode(option.mode)}>
+                    <div className="skill-install-menu-copy">
+                      <span className="skill-install-menu-label">{option.label}</span>
+                      <span className="skill-install-menu-description">{option.description}</span>
+                    </div>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <span className="skill-install-copy-feedback" aria-live="polite">
+              {promptFeedback}
+            </span>
+          </div>
+
+          <div className="skill-install-preview-meta">
+            <span className="skill-install-preview-label">Prompt Preview</span>
+            <span className="skill-install-preview-mode">{selectedPrompt.label}</span>
+          </div>
+
+          <pre className="skill-install-prompt-preview">
+            <code translate="no">{promptPreview}</code>
+          </pre>
+        </article>
+
+        <article className="skill-install-panel">
+          <div className="skill-install-panel-header">
+            <p className="skill-install-kicker">Command Line</p>
+            <h3 className="skill-install-panel-title">CLI Commands</h3>
+            <p className="skill-install-panel-copy">
+              Use the direct CLI path if you want to install manually and keep every step visible.
+            </p>
+          </div>
+
+          <div className="skill-install-command-card">
+            <div className="skill-install-command-header">
+              <div className="skill-install-command-copy">
+                <p className="skill-install-command-label">OpenClaw CLI</p>
+                <p className="skill-install-command-caption">Canonical install target</p>
+              </div>
+              <InstallCopyButton
+                text={openClawCommand}
+                ariaLabel="Copy OpenClaw CLI command"
+              />
+            </div>
+            <pre className="skill-install-command">
+              <code translate="no">{openClawCommand}</code>
+            </pre>
+          </div>
+
+          <div className="skill-install-command-card">
+            <div className="skill-install-command-header">
+              <div className="skill-install-command-copy">
+                <p className="skill-install-command-label">ClawHub CLI</p>
+                <p className="skill-install-command-caption">Package manager switcher</p>
+              </div>
+              <InstallCopyButton
+                text={clawHubCommand}
+                ariaLabel="Copy ClawHub CLI command"
+              />
+            </div>
+
+            <div className="install-switcher-toggle" aria-label="ClawHub install command">
+              {PACKAGE_MANAGERS.map((entry) => (
+                <button
+                  key={entry}
+                  type="button"
+                  aria-label={`Use ${entry} for ClawHub install command`}
+                  aria-pressed={packageManager === entry}
+                  className={`install-switcher-pill${packageManager === entry ? " is-active" : ""}`}
+                  onClick={() => setPackageManager(entry)}
+                >
+                  {entry}
+                </button>
+              ))}
+            </div>
+
+            <pre className="skill-install-command">
+              <code translate="no">{clawHubCommand}</code>
+            </pre>
+          </div>
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/src/components/skillDetailUtils.test.ts
+++ b/src/components/skillDetailUtils.test.ts
@@ -1,0 +1,76 @@
+import type { ClawdisSkillMetadata } from "clawhub-schema";
+import { describe, expect, it } from "vitest";
+import type { Id } from "../../convex/_generated/dataModel";
+import {
+  buildSkillInstallTarget,
+  buildSkillPageUrl,
+  formatClawHubInstallCommand,
+  formatOpenClawInstallCommand,
+  formatOpenClawPrompt,
+} from "./skillDetailUtils";
+
+describe("skill detail install helpers", () => {
+  const ownerPublisherId = "publishers:1" as Id<"publishers">;
+
+  it("prefers the owner handle for install targets", () => {
+    expect(buildSkillInstallTarget("steipete", ownerPublisherId, "weather")).toBe("steipete/weather");
+  });
+
+  it("falls back to owner id and then plain slug", () => {
+    expect(buildSkillInstallTarget(null, ownerPublisherId, "weather")).toBe("publishers:1/weather");
+    expect(buildSkillInstallTarget(null, null, "weather")).toBe("weather");
+  });
+
+  it("formats the OpenClaw and ClawHub commands", () => {
+    expect(formatOpenClawInstallCommand("steipete", ownerPublisherId, "weather")).toBe(
+      "openclaw skills install steipete/weather",
+    );
+    expect(formatClawHubInstallCommand("weather", "npm")).toBe("npx clawhub@latest install weather");
+    expect(formatClawHubInstallCommand("weather", "pnpm")).toBe(
+      "pnpm dlx clawhub@latest install weather",
+    );
+    expect(formatClawHubInstallCommand("weather", "bun")).toBe("bunx clawhub@latest install weather");
+  });
+
+  it("builds the install-and-setup prompt from known metadata only", () => {
+    const clawdis = {
+      requires: {
+        env: ["WEATHER_API_KEY"],
+        bins: ["curl"],
+        config: ["~/.weatherrc"],
+      },
+    } satisfies Partial<ClawdisSkillMetadata>;
+
+    const prompt = formatOpenClawPrompt({
+      mode: "install-and-setup",
+      skillName: "Weather",
+      slug: "weather",
+      ownerHandle: "steipete",
+      ownerId: ownerPublisherId,
+      clawdis: clawdis as ClawdisSkillMetadata,
+    });
+
+    expect(prompt).toContain("steipete/weather");
+    expect(prompt).toContain("https://clawhub.ai/steipete/weather");
+    expect(prompt).toContain("WEATHER_API_KEY");
+    expect(prompt).toContain("curl");
+    expect(prompt).toContain("~/.weatherrc");
+    expect(prompt).not.toContain("unknown");
+  });
+
+  it("avoids fabricating unknown owner URLs when the owner is missing", () => {
+    expect(buildSkillPageUrl(null, null, "weather")).toBeNull();
+
+    const prompt = formatOpenClawPrompt({
+      mode: "install-only",
+      skillName: "Weather",
+      slug: "weather",
+      ownerHandle: null,
+      ownerId: null,
+    });
+
+    expect(prompt).toContain('Install the skill "Weather" (weather) from ClawHub.');
+    expect(prompt).not.toContain("Skill page:");
+    expect(prompt).not.toContain("unknown");
+  });
+});

--- a/src/components/skillDetailUtils.ts
+++ b/src/components/skillDetailUtils.ts
@@ -1,5 +1,20 @@
-import type { SkillInstallSpec } from "clawhub-schema";
+import type { ClawdisSkillMetadata, SkillInstallSpec } from "clawhub-schema";
 import type { Id } from "../../convex/_generated/dataModel";
+import { getClawHubSiteUrl } from "../lib/site";
+
+export type SkillPromptMode = "install-only" | "install-and-setup";
+export type SkillPackageManager = "npm" | "pnpm" | "bun";
+
+type SkillOwnerId = Id<"users"> | Id<"publishers">;
+
+type SkillPromptContext = {
+  mode: SkillPromptMode;
+  skillName: string;
+  slug: string;
+  ownerHandle: string | null;
+  ownerId: SkillOwnerId | null;
+  clawdis?: ClawdisSkillMetadata;
+};
 
 export function buildSkillHref(
   ownerHandle: string | null,
@@ -149,6 +164,102 @@ export function formatInstallCommand(spec: SkillInstallSpec) {
     return `uv tool install ${spec.package}`;
   }
   return null;
+}
+
+export function buildSkillInstallTarget(
+  ownerHandle: string | null,
+  ownerId: SkillOwnerId | null,
+  slug: string,
+) {
+  const handle = ownerHandle?.trim();
+  if (handle) return `${handle}/${slug}`;
+  if (ownerId) return `${String(ownerId)}/${slug}`;
+  return slug;
+}
+
+export function buildSkillPageUrl(
+  ownerHandle: string | null,
+  ownerId: SkillOwnerId | null,
+  slug: string,
+) {
+  const handle = ownerHandle?.trim();
+  const owner = handle || (ownerId ? String(ownerId) : null);
+  if (!owner) return null;
+
+  const path = `/${encodeURIComponent(owner)}/${encodeURIComponent(slug)}`;
+  return new URL(path, getClawHubSiteUrl()).toString();
+}
+
+export function formatOpenClawInstallCommand(
+  ownerHandle: string | null,
+  ownerId: SkillOwnerId | null,
+  slug: string,
+) {
+  return `openclaw skills install ${buildSkillInstallTarget(ownerHandle, ownerId, slug)}`;
+}
+
+export function formatClawHubInstallCommand(slug: string, pm: SkillPackageManager) {
+  switch (pm) {
+    case "npm":
+      return `npx clawhub@latest install ${slug}`;
+    case "pnpm":
+      return `pnpm dlx clawhub@latest install ${slug}`;
+    case "bun":
+      return `bunx clawhub@latest install ${slug}`;
+  }
+
+  const _exhaustiveCheck: never = pm;
+  throw new Error("Unsupported package manager");
+}
+
+export function formatOpenClawPrompt({
+  mode,
+  skillName,
+  slug,
+  ownerHandle,
+  ownerId,
+  clawdis,
+}: SkillPromptContext) {
+  const target = buildSkillInstallTarget(ownerHandle, ownerId, slug);
+  const pageUrl = buildSkillPageUrl(ownerHandle, ownerId, slug);
+  const displayName = skillName.trim() || slug;
+  const requiredEnvVars = new Set(clawdis?.requires?.env ?? []);
+
+  for (const envVar of clawdis?.envVars ?? []) {
+    const name = envVar.name?.trim();
+    if (!name) continue;
+    if (envVar.required === false) continue;
+    requiredEnvVars.add(name);
+  }
+
+  const lines = [`Install the skill "${displayName}" (${target}) from ClawHub.`];
+
+  if (pageUrl) {
+    lines.push(`Skill page: ${pageUrl}`);
+  }
+
+  lines.push("Keep the work scoped to this skill only.");
+
+  if (mode === "install-only") {
+    lines.push("Stop after the skill is installed.");
+    return lines.join("\n");
+  }
+
+  lines.push("After install, inspect the skill metadata and help me finish setup.");
+
+  if (requiredEnvVars.size > 0) {
+    lines.push(`Required env vars: ${Array.from(requiredEnvVars).join(", ")}`);
+  }
+  if (clawdis?.requires?.bins?.length) {
+    lines.push(`Required binaries: ${clawdis.requires.bins.join(", ")}`);
+  }
+  if (clawdis?.requires?.config?.length) {
+    lines.push(`Config paths to check: ${clawdis.requires.config.join(", ")}`);
+  }
+
+  lines.push("Use only the metadata you can verify from ClawHub; do not invent missing requirements.");
+  lines.push("Ask before making any broader environment changes.");
+  return lines.join("\n");
 }
 
 export function formatBytes(bytes: number) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -3373,6 +3373,323 @@ code {
   gap: 6px;
 }
 
+.skill-install-surface {
+  display: grid;
+  gap: 16px;
+}
+
+.skill-install-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1.08fr) minmax(0, 0.92fr);
+}
+
+.skill-install-panel {
+  display: grid;
+  gap: 16px;
+  padding: 20px;
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background:
+    linear-gradient(180deg, rgba(25, 21, 19, 0.96), rgba(13, 13, 15, 0.98)),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  box-shadow: 0 18px 42px rgba(0, 0, 0, 0.18);
+  min-width: 0;
+}
+
+[data-theme-resolved="light"] .skill-install-panel {
+  border-color: rgba(78, 49, 28, 0.1);
+  background:
+    linear-gradient(180deg, rgba(255, 250, 244, 0.98), rgba(248, 240, 230, 0.98)),
+    radial-gradient(circle at top right, rgba(197, 126, 69, 0.14), rgba(197, 126, 69, 0));
+  box-shadow: 0 18px 42px rgba(58, 35, 20, 0.08);
+}
+
+.skill-install-panel-header {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.skill-install-kicker {
+  margin: 0;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+.skill-install-panel-title {
+  margin: 0;
+  font-size: 1.08rem;
+  font-weight: 700;
+  color: var(--ink);
+  text-wrap: balance;
+}
+
+.skill-install-panel-copy {
+  margin: 0;
+  max-width: 52ch;
+  font-size: 0.92rem;
+  line-height: 1.55;
+  color: var(--ink-soft);
+}
+
+.skill-install-panel-copy code {
+  display: inline-block;
+  border-radius: 999px;
+  padding: 2px 8px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  overflow-wrap: anywhere;
+}
+
+[data-theme-resolved="light"] .skill-install-panel-copy code {
+  background: rgba(15, 12, 10, 0.08);
+}
+
+.skill-install-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.skill-install-prompt-trigger {
+  min-height: 46px;
+  border: 1px solid rgba(0, 0, 0, 0.7);
+  border-radius: 999px;
+  background: #0e0e10;
+  color: #f8f2e9;
+  padding-inline: 18px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.16);
+  transition:
+    transform 0.18s ease,
+    box-shadow 0.18s ease,
+    border-color 0.18s ease,
+    background-color 0.18s ease;
+  touch-action: manipulation;
+}
+
+.skill-install-prompt-trigger:hover {
+  border-color: rgba(0, 0, 0, 0.82);
+  background: #161619;
+}
+
+.skill-install-copy-button {
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--ink);
+  transition:
+    transform 0.18s ease,
+    border-color 0.18s ease,
+    background-color 0.18s ease,
+    box-shadow 0.18s ease;
+  touch-action: manipulation;
+}
+
+[data-theme-resolved="light"] .skill-install-copy-button {
+  border-color: rgba(15, 12, 10, 0.12);
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.skill-install-copy-button[data-copy-state="copied"] {
+  border-color: rgba(34, 197, 94, 0.36);
+  color: var(--status-success-fg);
+}
+
+.skill-install-copy-button[data-copy-state="failed"] {
+  border-color: rgba(239, 68, 68, 0.32);
+  color: var(--status-error-fg);
+}
+
+.skill-install-menu {
+  max-width: 280px;
+}
+
+.skill-install-menu-copy {
+  display: grid;
+  gap: 2px;
+}
+
+.skill-install-menu-label {
+  font-size: 0.9rem;
+}
+
+.skill-install-menu-description {
+  font-size: 0.78rem;
+  font-weight: 500;
+  line-height: 1.4;
+  color: var(--ink-soft);
+}
+
+.skill-install-copy-feedback {
+  min-height: 1.25rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--ink-soft);
+}
+
+.skill-install-preview-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.skill-install-preview-label,
+.skill-install-command-label {
+  margin: 0;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+.skill-install-preview-mode {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 6px 10px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--ink);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+[data-theme-resolved="light"] .skill-install-preview-mode {
+  background: rgba(15, 12, 10, 0.08);
+}
+
+.skill-install-prompt-preview,
+.skill-install-command {
+  margin: 0;
+  min-width: 0;
+  overflow-x: auto;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background:
+    linear-gradient(180deg, rgba(12, 12, 14, 0.96), rgba(19, 19, 22, 0.98)),
+    radial-gradient(circle at top right, rgba(220, 38, 38, 0.14), rgba(220, 38, 38, 0));
+  color: #f8f2e9;
+  padding: 16px 18px;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  line-height: 1.7;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  font-variant-numeric: tabular-nums;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.skill-install-command-card {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  padding: 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+[data-theme-resolved="light"] .skill-install-command-card {
+  border-color: rgba(15, 12, 10, 0.08);
+  background: rgba(255, 255, 255, 0.42);
+}
+
+.skill-install-command-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.skill-install-command-copy {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.skill-install-command-caption {
+  margin: 0;
+  font-size: 0.84rem;
+  line-height: 1.45;
+  color: var(--ink-soft);
+}
+
+.install-switcher-toggle {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  gap: 4px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  padding: 4px;
+}
+
+[data-theme-resolved="light"] .install-switcher-toggle {
+  border-color: rgba(15, 12, 10, 0.08);
+  background: rgba(15, 12, 10, 0.04);
+}
+
+.install-switcher-pill {
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--ink-soft);
+  cursor: pointer;
+  padding: 8px 12px;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1;
+  text-transform: lowercase;
+  transition:
+    background-color 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease;
+  touch-action: manipulation;
+}
+
+.install-switcher-pill:hover {
+  color: var(--ink);
+}
+
+.install-switcher-pill:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.install-switcher-pill.is-active,
+.install-switcher-pill[aria-selected="true"] {
+  background: #0f0f11;
+  color: #f8f2e9;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.16);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skill-install-prompt-trigger,
+  .skill-install-copy-button,
+  .install-switcher-pill {
+    transition: none;
+    transform: none;
+  }
+}
+
+@media (max-width: 860px) {
+  .skill-install-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 /* Legacy compatibility — keep for any existing references */
 .skill-hero-cta {
   display: flex;
@@ -4208,6 +4525,14 @@ code {
   .skill-hero-sidebar-meta {
     flex: 1;
     min-width: 200px;
+  }
+
+  .skill-install-panel {
+    padding: 18px;
+  }
+
+  .skill-install-command-card {
+    padding: 14px;
   }
 
   .skill-hero-cta {
@@ -5994,6 +6319,32 @@ html.theme-transition::view-transition-new(theme) {
 
   .skill-hero-note {
     font-size: 0.82rem;
+  }
+
+  .skill-install-actions,
+  .skill-install-preview-meta,
+  .skill-install-command-header {
+    align-items: stretch;
+  }
+
+  .skill-install-copy-feedback {
+    width: 100%;
+  }
+
+  .skill-install-prompt-trigger,
+  .skill-install-copy-button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .install-switcher-toggle {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .install-switcher-pill {
+    flex: 1 1 0;
+    justify-content: center;
   }
 
   .card {


### PR DESCRIPTION
## Summary
- add a dedicated skill install surface that pairs OpenClaw prompt-driven install with visible CLI commands
- add prompt-copy flows for `Install Only` and `Install & Setup`, plus package-manager switching for the ClawHub CLI command
- wire the new surface into the skill header, add regression tests, and make `bun run build` use the repo's working Vite path

## Test Plan
- [x] `bun run build`
- [x] `bun run test -- src/components/skillDetailUtils.test.ts src/components/SkillInstallSurface.test.tsx`
- [x] `bun run test -- src/__tests__/skill-detail-page.test.tsx -t "renders the install surface above the security scan with visible prompts and commands"`
