### PR TITLE
fix: satisfy skill install typecheck

### DIFF
--- a/src/components/skillDetailUtils.ts
+++ b/src/components/skillDetailUtils.ts
@@ -5,6 +5,10 @@ import { getClawHubSiteUrl } from "../lib/site";
 export type SkillPromptMode = "install-only" | "install-and-setup";
 export type SkillPackageManager = "npm" | "pnpm" | "bun";
 
+function assertNever(value: never): never {
+  throw new Error(`Unsupported package manager: ${String(value)}`);
+}
+
 type SkillOwnerId = Id<"users"> | Id<"publishers">;
 
 type SkillPromptContext = {
@@ -208,8 +212,7 @@ export function formatClawHubInstallCommand(slug: string, pm: SkillPackageManage
       return `bunx clawhub@latest install ${slug}`;
   }
 
-  const _exhaustiveCheck: never = pm;
-  throw new Error("Unsupported package manager");
+  return assertNever(pm);
 }
 
 export function formatOpenClawPrompt({


### PR DESCRIPTION
## Summary
- fix the skill install surface package-manager exhaustiveness helper so TypeScript does not report an unused local in `skillDetailUtils`
- keep the switch exhaustive with a shared `assertNever` helper
- repair the follow-up CI/typecheck issue after #1800 merged

## Test Plan
- [x] `bunx tsc -p packages/schema/tsconfig.json --noEmit && bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- [x] `bun run test -- src/components/skillDetailUtils.test.ts src/components/SkillInstallSurface.test.tsx`
