### PR TITLE
fix: separate historical tags on skill detail page

### DIFF
--- a/PR_1784_body.md
+++ b/PR_1784_body.md
@@ -1,0 +1,17 @@
+## Summary
+
+- show only tags that point at the latest skill version in the public detail-page tag surfaces
+- move older tag mappings into a separate manager-only "Historical tags" section so they are no longer mixed with current metadata
+- add focused detail-page tests covering both the public filtering behavior and the manager-only historical tag view
+
+## Root Cause
+
+The skill detail page rendered every entry from `skill.tags`, even though that map can intentionally retain tag pointers for older versions. After metadata refreshes, the page mixed current tags with historical tags because it did not filter by `latestVersionId`.
+
+## User Impact
+
+Publishers and visitors now see the current/latest tag set on the detail page instead of a noisy blend of old and new metadata. Managers still keep visibility into historical tag mappings and can delete them from the same page.
+
+## Validation
+
+- Unable to run `vitest` locally in this checkout because `bun` is not installed and `node_modules` is missing.

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -553,6 +553,123 @@ describe("SkillDetailPage", () => {
     expect(screen.getByRole("button", { name: /Merge into target/i })).toBeTruthy();
   });
 
+  it("shows only latest-version tags in public tag surfaces", async () => {
+    useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
+      if (args === "skip") return undefined;
+      if (args && typeof args === "object" && "skillId" in args) {
+        return [
+          { _id: "skillVersions:1", version: "1.0.7", files: [] },
+          { _id: "skillVersions:2", version: "1.0.8", files: [] },
+        ];
+      }
+      if (args && typeof args === "object" && "slug" in args) {
+        return {
+          skill: {
+            _id: "skills:ip-publisher",
+            slug: "ip-publisher",
+            displayName: "IP Publisher",
+            summary: "Publish knowledge-base content everywhere.",
+            ownerUserId: "users:1",
+            ownerPublisherId: "publishers:veeicwgy",
+            latestVersionId: "skillVersions:2",
+            tags: {
+              "ip-publisher": "skillVersions:2",
+              "knowledge-base": "skillVersions:2",
+              "content-rewrite": "skillVersions:1",
+            },
+            stats: { stars: 0, downloads: 0 },
+          },
+          owner: {
+            _id: "publishers:veeicwgy",
+            _creationTime: 0,
+            kind: "user",
+            handle: "veeicwgy",
+            displayName: "Vee",
+            linkedUserId: "users:1",
+          },
+          latestVersion: {
+            _id: "skillVersions:2",
+            version: "1.0.8",
+            parsed: {},
+            files: [],
+          },
+          forkOf: null,
+          canonical: null,
+        };
+      }
+      return undefined;
+    });
+
+    render(<SkillDetailPage slug="ip-publisher" />);
+
+    expect((await screen.findAllByText("ip-publisher")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("knowledge-base").length).toBeGreaterThan(0);
+    expect(screen.queryByText("content-rewrite")).toBeNull();
+    expect(screen.queryByText("Historical tags")).toBeNull();
+  });
+
+  it("separates historical tags for managers", async () => {
+    useAuthStatusMock.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      me: { _id: "users:1", role: "user" },
+    });
+    useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
+      if (args === "skip") return undefined;
+      if (args && typeof args === "object" && "ownerUserId" in args) {
+        return [{ _id: "skills:ip-publisher", slug: "ip-publisher", displayName: "IP Publisher" }];
+      }
+      if (args && typeof args === "object" && "skillId" in args) {
+        return [
+          { _id: "skillVersions:1", version: "1.0.7", files: [] },
+          { _id: "skillVersions:2", version: "1.0.8", files: [] },
+        ];
+      }
+      if (args && typeof args === "object" && "slug" in args) {
+        return {
+          skill: {
+            _id: "skills:ip-publisher",
+            slug: "ip-publisher",
+            displayName: "IP Publisher",
+            summary: "Publish knowledge-base content everywhere.",
+            ownerUserId: "users:1",
+            ownerPublisherId: "publishers:veeicwgy",
+            latestVersionId: "skillVersions:2",
+            tags: {
+              "ip-publisher": "skillVersions:2",
+              "knowledge-base": "skillVersions:2",
+              "content-rewrite": "skillVersions:1",
+            },
+            stats: { stars: 0, downloads: 0 },
+          },
+          owner: {
+            _id: "publishers:veeicwgy",
+            _creationTime: 0,
+            kind: "user",
+            handle: "veeicwgy",
+            displayName: "Vee",
+            linkedUserId: "users:1",
+          },
+          latestVersion: {
+            _id: "skillVersions:2",
+            version: "1.0.8",
+            parsed: {},
+            files: [],
+          },
+          forkOf: null,
+          canonical: null,
+        };
+      }
+      return undefined;
+    });
+
+    render(<SkillDetailPage slug="ip-publisher" />);
+
+    expect(await screen.findByText("Historical tags")).toBeTruthy();
+    expect(screen.getByText("content-rewrite")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Delete tag content-rewrite" })).toBeTruthy();
+  });
+
   it("defers compare version query until compare tab is requested", async () => {
     useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
       if (args === "skip") return undefined;

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -344,6 +344,15 @@ export function SkillDetailPage({
   }
 
   const tagEntries = Object.entries(skill.tags ?? {}) as Array<[string, Id<"skillVersions">]>;
+  const latestTagVersionId = latestVersion?._id ?? skill.latestVersionId ?? null;
+  const currentTagEntries =
+    latestTagVersionId === null
+      ? tagEntries
+      : tagEntries.filter(([, versionId]) => versionId === latestTagVersionId);
+  const historicalTagEntries =
+    latestTagVersionId === null
+      ? []
+      : tagEntries.filter(([, versionId]) => versionId !== latestTagVersionId);
 
   return (
     <main className="section">
@@ -375,7 +384,8 @@ export function SkillDetailPage({
           hasPluginBundle={hasPluginBundle}
           configRequirements={configRequirements}
           cliHelp={cliHelp}
-          tagEntries={tagEntries}
+          tagEntries={currentTagEntries}
+          historicalTagEntries={historicalTagEntries}
           versionById={versionById}
           tagName={tagName}
           onTagNameChange={setTagName}
@@ -405,7 +415,7 @@ export function SkillDetailPage({
           ownerHandle={ownerHandle}
           clawdis={clawdis}
           osLabels={osLabels}
-          tagEntries={tagEntries}
+          tagEntries={currentTagEntries}
           isMalwareBlocked={modInfo?.isMalwareBlocked}
           isRemoved={modInfo?.isRemoved}
           nixPlugin={nixPlugin}

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -64,6 +64,7 @@ type SkillHeaderProps = {
   configRequirements: ClawdisSkillMetadata["config"] | undefined;
   cliHelp: string | undefined;
   tagEntries: Array<[string, Id<"skillVersions">]>;
+  historicalTagEntries: Array<[string, Id<"skillVersions">]>;
   versionById: Map<Id<"skillVersions">, Doc<"skillVersions">>;
   tagName: string;
   onTagNameChange: (value: string) => void;
@@ -104,6 +105,7 @@ export function SkillHeader({
   configRequirements,
   cliHelp,
   tagEntries,
+  historicalTagEntries,
   versionById,
   tagName,
   onTagNameChange,
@@ -395,6 +397,33 @@ export function SkillHeader({
             ))
           )}
         </div>
+
+        {canManage && historicalTagEntries.length > 0 ? (
+          <div className="skill-tag-history">
+            <div className="skill-tag-history-label">Historical tags</div>
+            <div className="skill-tag-row">
+              {historicalTagEntries.map(([tag, versionId]) => (
+                <Badge key={tag}>
+                  {tag}
+                  <span className="tag-meta">
+                    v{versionById.get(versionId)?.version ?? versionId}
+                  </span>
+                  {tag !== "latest" ? (
+                    <button
+                      type="button"
+                      className="tag-delete"
+                      onClick={() => onTagDelete(tag)}
+                      aria-label={`Delete tag ${tag}`}
+                      title={`Delete tag "${tag}"`}
+                    >
+                      ×
+                    </button>
+                  ) : null}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        ) : null}
 
         {canManage ? (
           <form

--- a/src/styles.css
+++ b/src/styles.css
@@ -3729,6 +3729,19 @@ code {
   min-width: 0;
 }
 
+.skill-tag-history {
+  display: grid;
+  gap: 8px;
+}
+
+.skill-tag-history-label {
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-soft);
+}
+
 .tag-meta {
   font-size: 0.72rem;
   font-weight: 600;


### PR DESCRIPTION
## Summary

- show only tags that point at the latest skill version in the public detail-page tag surfaces
- move older tag mappings into a separate manager-only "Historical tags" section so they are no longer mixed with current metadata
- add focused detail-page tests covering both the public filtering behavior and the manager-only historical tag view

## Root Cause

The skill detail page rendered every entry from `skill.tags`, even though that map can intentionally retain tag pointers for older versions. After metadata refreshes, the page mixed current tags with historical tags because it did not filter by `latestVersionId`.

## User Impact

Publishers and visitors now see the current/latest tag set on the detail page instead of a noisy blend of old and new metadata. Managers still keep visibility into historical tag mappings and can delete them from the same page.

## Validation

- `git diff --check`
- `./node_modules/.bin/oxlint --type-aware --tsconfig ./tsconfig.oxlint.json ./src ./convex ./packages/clawhub/src ./packages/schema/src`
- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/tsc -p packages/schema/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc -p packages/clawhub/tsconfig.json --noEmit`
- `./node_modules/.bin/vite build`
- `node --import tsx scripts/copy-og-assets.ts`
