### PR TITLE
fix: keep skill moderation tied to latest version

### DIFF
--- a/convex/maintenance.test.ts
+++ b/convex/maintenance.test.ts
@@ -23,6 +23,7 @@ vi.mock("./_generated/api", () => ({
       nominateEmptySkillSpammersInternal: Symbol("nominateEmptySkillSpammersInternal"),
     },
     skills: {
+      backfillLatestSkillModerationInternal: Symbol("skills.backfillLatestSkillModerationInternal"),
       getVersionByIdInternal: Symbol("skills.getVersionByIdInternal"),
       getOwnerSkillActivityInternal: Symbol("skills.getOwnerSkillActivityInternal"),
     },

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -1965,6 +1965,20 @@ export const backfillLatestVersionSummaryInternal = internalMutation({
   },
 });
 
+// Repair stale skill-level moderation that was sourced from a non-latest version.
+// Run once after deploying the latest-version moderation fix:
+//   npx convex run maintenance:backfillLatestSkillModeration --prod
+export const backfillLatestSkillModeration: ReturnType<typeof action> = action({
+  args: {
+    batchSize: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const { user } = await requireUserFromAction(ctx);
+    assertRole(user, ["admin"]);
+    return await ctx.runMutation(internal.skills.backfillLatestSkillModerationInternal, args);
+  },
+});
+
 /**
  * Backfill `isSuspicious` on all skills. Cursor-based paginated mutation
  * that self-schedules until done.

--- a/convex/skills.rateLimit.test.ts
+++ b/convex/skills.rateLimit.test.ts
@@ -7,6 +7,7 @@ vi.mock("@convex-dev/auth/server", () => ({
 
 import {
   approveSkillByHashInternal,
+  backfillLatestSkillModerationInternal,
   clearOwnerSuspiciousFlagsInternal,
   escalateSkillByIdInternal,
   escalateByVtInternal,
@@ -27,6 +28,9 @@ const escalateSkillByIdHandler = (
 )._handler;
 const escalateByVtHandler = (
   escalateByVtInternal as unknown as WrappedHandler<Record<string, unknown>>
+)._handler;
+const backfillLatestSkillModerationHandler = (
+  backfillLatestSkillModerationInternal as unknown as WrappedHandler<Record<string, unknown>>
 )._handler;
 const clearOwnerSuspiciousFlagsHandler = (
   clearOwnerSuspiciousFlagsInternal as unknown as WrappedHandler<Record<string, unknown>>
@@ -1147,6 +1151,63 @@ describe("skills anti-spam guards", () => {
     );
   });
 
+  it("ignores non-latest versions when approving by hash", async () => {
+    const patch = vi.fn(async () => {});
+    const version = {
+      _id: "skillVersions:old",
+      skillId: "skills:1",
+      staticScan: {
+        status: "suspicious",
+        reasonCodes: ["suspicious.dynamic_code_execution"],
+        findings: [],
+        summary: "",
+        engineVersion: "v2.1.1",
+        checkedAt: Date.now(),
+      },
+      vtAnalysis: { status: "suspicious" },
+      llmAnalysis: { status: "clean" },
+    };
+    const skill = {
+      _id: "skills:1",
+      slug: "rollback-helper",
+      ownerUserId: "users:owner",
+      latestVersionId: "skillVersions:latest",
+      moderationFlags: undefined,
+      moderationReason: "scanner.vt.clean",
+    };
+
+    const db = {
+      get: vi.fn(async (id: string) => {
+        if (id === "skills:1") return skill;
+        return null;
+      }),
+      query: vi.fn((table: string) => {
+        if (table === "skillVersions") {
+          return {
+            withIndex: () => ({
+              unique: async () => version,
+            }),
+          };
+        }
+        throw new Error(`unexpected table ${table}`);
+      }),
+      patch,
+      insert: vi.fn(),
+      normalizeId: vi.fn(),
+    };
+
+    await approveSkillByHashHandler(
+      { db, scheduler: { runAfter: vi.fn() } } as never,
+      {
+        sha256hash: "h".repeat(64),
+        scanner: "vt",
+        status: "clean",
+      } as never,
+    );
+
+    expect(patch).not.toHaveBeenCalled();
+  });
+
   it("vt suspicious escalation does not keep suspicious flags for admin owners", async () => {
     const patch = vi.fn(async () => {});
     const version = { _id: "skillVersions:1", skillId: "skills:1" };
@@ -1203,6 +1264,61 @@ describe("skills anti-spam guards", () => {
         moderationReason: "scanner.llm.clean",
       }),
     );
+  });
+
+  it("ignores vt escalation for non-latest versions", async () => {
+    const patch = vi.fn(async () => {});
+    const version = {
+      _id: "skillVersions:old",
+      skillId: "skills:1",
+      staticScan: {
+        status: "suspicious",
+        reasonCodes: ["suspicious.dynamic_code_execution"],
+        findings: [],
+        summary: "",
+        engineVersion: "v2.1.1",
+        checkedAt: Date.now(),
+      },
+      llmAnalysis: { status: "clean" },
+    };
+    const skill = {
+      _id: "skills:1",
+      slug: "rollback-helper",
+      ownerUserId: "users:owner",
+      latestVersionId: "skillVersions:latest",
+      moderationFlags: undefined,
+      moderationReason: "scanner.vt.clean",
+    };
+
+    const db = {
+      get: vi.fn(async (id: string) => {
+        if (id === "skills:1") return skill;
+        return null;
+      }),
+      query: vi.fn((table: string) => {
+        if (table === "skillVersions") {
+          return {
+            withIndex: () => ({
+              unique: async () => version,
+            }),
+          };
+        }
+        throw new Error(`unexpected table ${table}`);
+      }),
+      patch,
+      insert: vi.fn(),
+      normalizeId: vi.fn(),
+    };
+
+    await escalateByVtHandler(
+      { db, scheduler: { runAfter: vi.fn() } } as never,
+      {
+        sha256hash: "h".repeat(64),
+        status: "suspicious",
+      } as never,
+    );
+
+    expect(patch).not.toHaveBeenCalled();
   });
 
   it("rebuilds structured moderation state for legacy skillId escalation", async () => {
@@ -1354,6 +1470,94 @@ describe("skills anti-spam guards", () => {
         moderationFlags: undefined,
         moderationReason: "scanner.vt.clean",
         moderationStatus: "active",
+      }),
+    );
+  });
+
+  it("re-syncs stale skill moderation from latestVersionId during backfill", async () => {
+    const paginate = vi.fn().mockResolvedValue({
+      page: [
+        {
+          _id: "skills:1",
+          slug: "rollback-helper",
+          ownerUserId: "users:owner",
+          latestVersionId: "skillVersions:latest",
+          moderationSourceVersionId: "skillVersions:old",
+          moderationStatus: "hidden",
+          moderationReason: "scanner.vt.suspicious",
+          moderationFlags: ["flagged.suspicious"],
+          manualOverride: undefined,
+          softDeletedAt: undefined,
+        },
+      ],
+      continueCursor: null,
+      isDone: true,
+    });
+    const patch = vi.fn(async () => {});
+    const latestVersion = {
+      _id: "skillVersions:latest",
+      staticScan: {
+        status: "clean",
+        reasonCodes: [],
+        findings: [],
+        summary: "",
+        engineVersion: "v2.1.1",
+        checkedAt: Date.now(),
+      },
+      vtAnalysis: { status: "clean" },
+      llmAnalysis: { status: "clean" },
+    };
+    const owner = {
+      _id: "users:owner",
+      role: "user",
+      _creationTime: Date.now() - 60 * 24 * 60 * 60 * 1000,
+      createdAt: Date.now() - 60 * 24 * 60 * 60 * 1000,
+      deletedAt: undefined,
+    };
+
+    const db = {
+      get: vi.fn(async (id: string) => {
+        if (id === "skillVersions:latest") return latestVersion;
+        if (id === "users:owner") return owner;
+        return null;
+      }),
+      query: vi.fn((table: string) => {
+        const globalStatsQuery = buildGlobalStatsQuery(table);
+        if (globalStatsQuery) return globalStatsQuery;
+        if (table === "skills") {
+          return {
+            paginate,
+          };
+        }
+        throw new Error(`unexpected table ${table}`);
+      }),
+      patch,
+      insert: vi.fn(),
+      normalizeId: vi.fn(),
+    };
+
+    const result = await backfillLatestSkillModerationHandler(
+      { db, scheduler: { runAfter: vi.fn() } } as never,
+      { batchSize: 10 } as never,
+    );
+
+    expect(result).toEqual({ patched: 1, isDone: true, scanned: 1 });
+    expect(patch).toHaveBeenNthCalledWith(
+      1,
+      "skills:1",
+      expect.objectContaining({
+        moderationStatus: "active",
+        moderationReason: "scanner.vt.clean",
+        moderationFlags: undefined,
+        moderationVerdict: "clean",
+        moderationSourceVersionId: "skillVersions:latest",
+      }),
+    );
+    expect(patch).toHaveBeenNthCalledWith(
+      2,
+      "globalStats:1",
+      expect.objectContaining({
+        activeSkillsCount: 101,
       }),
     );
   });

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -4593,6 +4593,10 @@ export const approveSkillByHashInternal = internalMutation({
     // Update the skill's moderation status based on scan result
     const skill = await ctx.db.get(version.skillId);
     if (skill) {
+      if (skill.latestVersionId !== version._id) {
+        return { ok: true, skillId: version.skillId, versionId: version._id };
+      }
+
       const owner = skill.ownerUserId ? await ctx.db.get(skill.ownerUserId) : null;
       const isMalicious = args.status === "malicious";
       const isSuspicious = args.status === "suspicious";
@@ -4717,6 +4721,7 @@ export const escalateByVtInternal = internalMutation({
 
     const skill = await ctx.db.get(version.skillId);
     if (!skill) return;
+    if (skill.latestVersionId !== version._id) return;
 
     const isMalicious = args.status === "malicious";
     const existingFlags: string[] = (skill.moderationFlags as string[] | undefined) ?? [];
@@ -4794,6 +4799,40 @@ export const escalateByVtInternal = internalMutation({
         slug: skill.slug,
       });
     }
+  },
+});
+
+/**
+ * Re-sync skill-level moderation from each skill's current latest version.
+ * This repairs rows that were previously stamped from an older version scan.
+ */
+export const backfillLatestSkillModerationInternal = internalMutation({
+  args: {
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const batchSize = clampInt(args.batchSize ?? 100, 10, 200);
+    const { page, continueCursor, isDone } = await ctx.db
+      .query("skills")
+      .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
+
+    let patched = 0;
+    for (const skill of page) {
+      if (!shouldSyncModerationFromLatestVersion(skill)) continue;
+      if (skill.moderationSourceVersionId === skill.latestVersionId) continue;
+      await syncSkillModerationFromLatestVersion(ctx, skill, Date.now());
+      patched++;
+    }
+
+    if (!isDone) {
+      await ctx.scheduler.runAfter(0, internal.skills.backfillLatestSkillModerationInternal, {
+        cursor: continueCursor,
+        batchSize: args.batchSize,
+      });
+    }
+
+    return { patched, isDone, scanned: page.length };
   },
 });
 

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -4593,7 +4593,7 @@ export const approveSkillByHashInternal = internalMutation({
     // Update the skill's moderation status based on scan result
     const skill = await ctx.db.get(version.skillId);
     if (skill) {
-      if (skill.latestVersionId !== version._id) {
+      if (skill.latestVersionId && skill.latestVersionId !== version._id) {
         return { ok: true, skillId: version.skillId, versionId: version._id };
       }
 
@@ -4721,7 +4721,7 @@ export const escalateByVtInternal = internalMutation({
 
     const skill = await ctx.db.get(version.skillId);
     if (!skill) return;
-    if (skill.latestVersionId !== version._id) return;
+    if (skill.latestVersionId && skill.latestVersionId !== version._id) return;
 
     const isMalicious = args.status === "malicious";
     const existingFlags: string[] = (skill.moderationFlags as string[] | undefined) ?? [];


### PR DESCRIPTION
## Summary

Fixes #1795.

- stop hash-based VT callbacks from overwriting skill-level moderation when they target an older version
- keep skill-level moderation sourced from the current `latestVersionId`
- add a paginated moderation resync path for stale rows whose `moderationSourceVersionId` still points at an older version
- add focused regression tests for both the prevention path and the repair path

## Root cause

`approveSkillByHashInternal` and `escalateByVtInternal` updated the parent `skills` row for any matching version hash, even when that hash belonged to an older release. If an older suspicious release was rescanned after a clean newer release existed, the skill-level badge could be re-poisoned from the stale version.

## Follow-up

The broader validation pass found that older test fixtures without `latestVersionId` were being skipped too aggressively. Commit `aead53f` preserves the latest-version guard while allowing legacy fixtures/documents that do not yet have `latestVersionId`.

## Repair path

After deploy, admins can run:

- `npx convex run maintenance:backfillLatestSkillModeration --prod`

That backfill only touches scanner-managed rows whose `moderationSourceVersionId` no longer matches `latestVersionId`, so it repairs stale skill badges without broad moderation churn.

## Validation

- `git diff --check`
- `./node_modules/.bin/oxlint --type-aware --tsconfig ./tsconfig.oxlint.json ./src ./convex ./packages/clawhub/src ./packages/schema/src`
- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/tsc -p packages/schema/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc -p packages/clawhub/tsconfig.json --noEmit`
- `./node_modules/.bin/vite build`
- `node --import tsx scripts/copy-og-assets.ts`
