### PR TITLE
fix(skills): prevent backport publishes from clobbering the latest tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 
 - Stats maintenance: keep skill stat migration fields synchronized by treating top-level stat fields as canonical during backfill/reconcile fallback reads (#1704) (thanks @momothemage).
+- Skills: prevent backport publishes from clobbering `latest` state and guard malformed persisted latest semver values during publish comparisons (#1832) (thanks @momothemage).
 
 ## 0.10.0 - 2026-04-05
 

--- a/convex/skills.backportLatest.test.ts
+++ b/convex/skills.backportLatest.test.ts
@@ -523,6 +523,57 @@ describe("skills.insertVersion latest-tag protection", () => {
     );
   });
 
+  it("ignores an explicit `latest` in args.tags for a backport publish", async () => {
+    // Security regression: a caller must not be able to defeat the semver
+    // guard by smuggling `latest` through the custom-tag loop.
+    const skill = buildExistingSkill();
+    const { ctx, captured } = buildCtx(skill);
+
+    await insertVersionHandler(
+      ctx as never,
+      buildPublishArgs({
+        version: "1.0.1",
+        tags: ["latest", "lts"],
+      }) as never,
+    );
+
+    const finalPatch = captured.skillPatches.at(-1) as Record<string, unknown>;
+    expect(finalPatch.latestVersionId).toBe(PREV_LATEST_VERSION_ID);
+    expect(finalPatch.latestVersionSummary).toMatchObject({ version: "2.0.0" });
+    expect(finalPatch.tags).toEqual(
+      expect.objectContaining({
+        latest: PREV_LATEST_VERSION_ID,
+        lts: NEW_VERSION_ID,
+      }),
+    );
+    // New embedding must still be marked non-latest.
+    expect(captured.embeddingInserts[0]).toMatchObject({ isLatest: false });
+    expect(captured.embeddingPatches).toHaveLength(0);
+  });
+
+  it("ignores case-variant `LaTeSt` in args.tags for a backport publish", async () => {
+    // Defense in depth against case-only bypass attempts.
+    const skill = buildExistingSkill();
+    const { ctx, captured } = buildCtx(skill);
+
+    await insertVersionHandler(
+      ctx as never,
+      buildPublishArgs({
+        version: "1.0.1",
+        tags: ["LaTeSt"],
+      }) as never,
+    );
+
+    const finalPatch = captured.skillPatches.at(-1) as Record<string, unknown>;
+    expect(finalPatch.latestVersionId).toBe(PREV_LATEST_VERSION_ID);
+    expect(finalPatch.tags).toEqual(
+      expect.objectContaining({ latest: PREV_LATEST_VERSION_ID }),
+    );
+    // The case-variant tag must not leak into the stored tag map either.
+    const tags = finalPatch.tags as Record<string, string>;
+    expect(tags.LaTeSt).toBeUndefined();
+  });
+
   it("treats the very first publish as latest even when the version is low", async () => {
     const skill = buildExistingSkill({
       latestVersionId: undefined,

--- a/convex/skills.backportLatest.test.ts
+++ b/convex/skills.backportLatest.test.ts
@@ -656,4 +656,64 @@ describe("skills.insertVersion latest-tag protection", () => {
     const flags = (finalPatch.moderationFlags ?? []) as string[];
     expect(flags).toContain("suspicious.keyword");
   });
+
+  it("does not throw when the persisted latestVersionSummary.version is not valid semver", async () => {
+    // Regression for reviewer catch: the schema only enforces v.string() on
+    // latestVersionSummary.version, so legacy / imported skills may persist
+    // non-semver values. Without the semver.valid() guard, semver.gt would
+    // throw `TypeError: Invalid Version` and crash the publish mutation.
+    const skill = buildExistingSkill({
+      latestVersionSummary: {
+        version: "not-a-semver",
+        createdAt: 1000,
+        changelog: "legacy",
+      },
+    });
+    const { ctx, captured } = buildCtx(skill);
+
+    // Must not throw `TypeError: Invalid Version` from semver.gt().
+    await insertVersionHandler(
+      ctx as never,
+      buildPublishArgs({
+        version: "1.0.0",
+        displayName: "Recovered v1",
+      }) as never,
+    );
+
+    // The new publish should self-heal the skill back into a valid semver
+    // latest pointer, since the persisted one is unusable for comparison.
+    const finalPatch = captured.skillPatches.at(-1) as Record<string, unknown>;
+    expect(finalPatch.latestVersionId).toBe(NEW_VERSION_ID);
+    expect(finalPatch.latestVersionSummary).toMatchObject({ version: "1.0.0" });
+    expect(finalPatch.tags).toEqual(
+      expect.objectContaining({ latest: NEW_VERSION_ID }),
+    );
+    expect(captured.embeddingInserts[0]).toMatchObject({ isLatest: true });
+  });
+
+  it("does not throw when the persisted latestVersionSummary.version is an empty string", async () => {
+    // Empty string is falsy but still fails semver.valid(); make sure both
+    // guard clauses (`!prevLatestVersion` and `!semver.valid(...)`) keep us
+    // safe rather than only one of them.
+    const skill = buildExistingSkill({
+      latestVersionSummary: {
+        version: "",
+        createdAt: 1000,
+        changelog: "legacy",
+      },
+    });
+    const { ctx, captured } = buildCtx(skill);
+
+    await insertVersionHandler(
+      ctx as never,
+      buildPublishArgs({
+        version: "0.1.0",
+        displayName: "Recovered v0.1",
+      }) as never,
+    );
+
+    const finalPatch = captured.skillPatches.at(-1) as Record<string, unknown>;
+    expect(finalPatch.latestVersionId).toBe(NEW_VERSION_ID);
+    expect(finalPatch.latestVersionSummary).toMatchObject({ version: "0.1.0" });
+  });
 });

--- a/convex/skills.backportLatest.test.ts
+++ b/convex/skills.backportLatest.test.ts
@@ -608,4 +608,52 @@ describe("skills.insertVersion latest-tag protection", () => {
     expect(finalPatch.capabilityTags).toEqual(["cap-v0"]);
     expect(captured.embeddingInserts[0]).toMatchObject({ isLatest: true });
   });
+
+  it("does not derive moderation flags from a backport's displayName", async () => {
+    // Regression for reviewer catch: on backport publishes the skill card
+    // keeps the old displayName, so the moderation evaluation must run
+    // against the old displayName too. Otherwise we persist flags that were
+    // triggered by text the user can never see on the card.
+    const skill = buildExistingSkill({ displayName: "Harmless Card Title" });
+    const { ctx, captured } = buildCtx(skill);
+
+    await insertVersionHandler(
+      ctx as never,
+      buildPublishArgs({
+        version: "1.0.1",
+        // "phishing" would match FLAG_RULES ("suspicious.keyword") if it
+        // actually reached deriveModerationFlags.
+        displayName: "backport phishing helper",
+      }) as never,
+    );
+
+    const finalPatch = captured.skillPatches.at(-1) as Record<string, unknown>;
+    // Card displayName is unchanged (backport cannot leak its title).
+    expect(finalPatch.displayName).toBe("Harmless Card Title");
+    // And the flags derived from that evaluation must not contain the
+    // keyword match sourced from the backport-only title.
+    const flags = (finalPatch.moderationFlags ?? []) as string[];
+    expect(flags).not.toContain("suspicious.keyword");
+  });
+
+  it("still derives moderation flags from displayName when the publish IS the new latest", async () => {
+    // Counter-case for the guard above: when the publish actually promotes
+    // to latest, the new displayName is what lives on the card, so flags
+    // derived from it must be recorded.
+    const skill = buildExistingSkill({ displayName: "Harmless Card Title" });
+    const { ctx, captured } = buildCtx(skill);
+
+    await insertVersionHandler(
+      ctx as never,
+      buildPublishArgs({
+        version: "3.0.0",
+        displayName: "shiny phishing helper",
+      }) as never,
+    );
+
+    const finalPatch = captured.skillPatches.at(-1) as Record<string, unknown>;
+    expect(finalPatch.displayName).toBe("shiny phishing helper");
+    const flags = (finalPatch.moderationFlags ?? []) as string[];
+    expect(flags).toContain("suspicious.keyword");
+  });
 });

--- a/convex/skills.backportLatest.test.ts
+++ b/convex/skills.backportLatest.test.ts
@@ -1,0 +1,566 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@convex-dev/auth/server", () => ({
+  getAuthUserId: vi.fn(),
+  authTables: {},
+}));
+
+import { insertVersion } from "./skills";
+
+type WrappedHandler<TArgs> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<unknown>;
+};
+
+const insertVersionHandler = (insertVersion as unknown as WrappedHandler<Record<string, unknown>>)
+  ._handler;
+
+const OWNER_USER_ID = "users:owner";
+const OWNER_PUBLISHER_ID = "publishers:owner";
+const SKILL_ID = "skills:1";
+const PREV_LATEST_VERSION_ID = "skillVersions:prev";
+const PREV_EMBEDDING_ID = "skillEmbeddings:prev";
+const NEW_VERSION_ID = "skillVersions:new";
+const NEW_EMBEDDING_ID = "skillEmbeddings:new";
+
+type SkillDoc = {
+  _id: string;
+  slug: string;
+  displayName: string;
+  summary: string;
+  ownerUserId: string;
+  ownerPublisherId: string;
+  latestVersionId: string | undefined;
+  latestVersionSummary:
+    | {
+        version: string;
+        createdAt: number;
+        changelog: string;
+        changelogSource?: "auto" | "user";
+        clawdis?: unknown;
+      }
+    | undefined;
+  tags: Record<string, string>;
+  capabilityTags: string[] | undefined;
+  stats: {
+    downloads: number;
+    installsCurrent: number;
+    installsAllTime: number;
+    stars: number;
+    versions: number;
+    comments: number;
+  };
+  badges: Record<string, unknown>;
+  moderationStatus: string;
+  moderationReason: string;
+  moderationFlags: string[] | undefined;
+  isSuspicious: boolean;
+  softDeletedAt: number | undefined;
+  createdAt: number;
+  updatedAt: number;
+  manualOverride?: unknown;
+  [key: string]: unknown;
+};
+
+function buildExistingSkill(overrides: Partial<SkillDoc> = {}): SkillDoc {
+  return {
+    _id: SKILL_ID,
+    slug: "my-skill",
+    displayName: "My Skill v2",
+    summary: "Summary of v2.0.0",
+    ownerUserId: OWNER_USER_ID,
+    ownerPublisherId: OWNER_PUBLISHER_ID,
+    latestVersionId: PREV_LATEST_VERSION_ID,
+    latestVersionSummary: {
+      version: "2.0.0",
+      createdAt: 1,
+      changelog: "Major release",
+      changelogSource: "user",
+      clawdis: {},
+    },
+    tags: { latest: PREV_LATEST_VERSION_ID },
+    capabilityTags: ["cap-v2"],
+    stats: {
+      downloads: 0,
+      installsCurrent: 0,
+      installsAllTime: 0,
+      stars: 0,
+      versions: 1,
+      comments: 0,
+    },
+    badges: {
+      redactionApproved: undefined,
+      highlighted: undefined,
+      official: undefined,
+      deprecated: undefined,
+    },
+    moderationStatus: "active",
+    moderationReason: "pending.scan",
+    moderationFlags: undefined,
+    isSuspicious: false,
+    softDeletedAt: undefined,
+    createdAt: 1,
+    updatedAt: 1,
+    manualOverride: undefined,
+    ...overrides,
+  };
+}
+
+function buildPublishArgs(overrides?: Partial<Record<string, unknown>>) {
+  return {
+    userId: OWNER_USER_ID,
+    slug: "my-skill",
+    displayName: "My Skill v1 backport",
+    version: "1.0.1",
+    changelog: "Backport fix",
+    changelogSource: "user",
+    tags: [] as string[],
+    capabilityTags: ["cap-v1-backport"],
+    summary: "Summary of v1.0.1 backport",
+    fingerprint: "f".repeat(64),
+    files: [
+      {
+        path: "SKILL.md",
+        size: 128,
+        storageId: "_storage:1",
+        sha256: "a".repeat(64),
+        contentType: "text/markdown",
+      },
+    ],
+    parsed: {
+      frontmatter: { description: "backport summary from frontmatter" },
+      metadata: {},
+      clawdis: {},
+    },
+    staticScan: {
+      status: "clean",
+      reasonCodes: [],
+      findings: [],
+      summary: "",
+      engineVersion: "v2.2.0",
+      checkedAt: Date.now(),
+    },
+    embedding: [0.1, 0.2],
+    ...overrides,
+  };
+}
+
+type Captured = {
+  skillPatches: Array<Record<string, unknown>>;
+  embeddingInserts: Array<Record<string, unknown>>;
+  embeddingPatches: Array<{ id: string; value: Record<string, unknown> }>;
+  versionInserted: Record<string, unknown> | null;
+  allPatches: Array<{ id: string; value: Record<string, unknown> }>;
+};
+
+function buildDb(skill: SkillDoc, captured: Captured) {
+  const throwMissingPublisherTable = (table: string) => {
+    // Forces ensurePersonalPublisherForUser's synthesize fallback in
+    // lib/publishers.ts so we don't need to mock publishers/publisherMembers.
+    throw new Error(`unexpected table: ${table}`);
+  };
+
+  // Trigger-driven code (syncSkillSearchDigestForSkill -> getOwnerPublisher)
+  // will ask for publishers via `db.get(ownerPublisherId)`. Return null so
+  // getOwnerPublisher falls back to resolving the publisher from the owner user.
+  const publisherTableQuery = () => ({
+    withIndex: () => ({
+      unique: async () => null,
+      take: async () => [],
+    }),
+  });
+
+  const db = {
+    get: vi.fn(async (arg0: string, arg1?: string) => {
+      // triggers.wrapDB calls innerDb.get(tableName, id) for tables with
+      // registered triggers; other call sites use db.get(id).
+      const id = arg1 !== undefined ? arg1 : arg0;
+      if (id === OWNER_USER_ID) {
+        return {
+          _id: OWNER_USER_ID,
+          _creationTime: Date.now() - 60 * 24 * 60 * 60 * 1000,
+          createdAt: Date.now() - 60 * 24 * 60 * 60 * 1000,
+          updatedAt: Date.now() - 60 * 24 * 60 * 60 * 1000,
+          handle: "alice",
+          name: "Alice",
+          email: "alice@example.com",
+          displayName: "Alice",
+          deletedAt: undefined,
+          deactivatedAt: undefined,
+          trustedPublisher: true,
+          role: "user",
+          personalPublisherId: OWNER_PUBLISHER_ID,
+        };
+      }
+      if (id === OWNER_PUBLISHER_ID) {
+        // Returning null lets getOwnerPublisher fall back to user-based
+        // resolution, which then hits the synthesize fallback.
+        return null;
+      }
+      if (id === SKILL_ID) return skill;
+      return null;
+    }),
+    query: vi.fn((table: string) => {
+      if (table === "publishers" || table === "publisherMembers") {
+        // ensurePersonalPublisherForUser / getOwnerPublisher may poll these
+        // tables during triggers. Returning an empty index matches the state
+        // of a fresh test environment without real publisher rows.
+        return publisherTableQuery();
+      }
+      if (table === "skills") {
+        return {
+          withIndex: (name: string) => {
+            if (name === "by_slug") {
+              return { unique: async () => skill };
+            }
+            if (name === "by_owner") {
+              return { order: () => ({ take: async () => [skill] }) };
+            }
+            throw new Error(`unexpected skills index ${name}`);
+          },
+        };
+      }
+      if (table === "skillSlugAliases") {
+        return {
+          withIndex: (name: string) => {
+            if (name !== "by_slug") {
+              throw new Error(`unexpected skillSlugAliases index ${name}`);
+            }
+            return { unique: async () => null };
+          },
+        };
+      }
+      if (table === "skillVersions") {
+        return {
+          withIndex: (name: string) => {
+            if (name !== "by_skill_version") {
+              throw new Error(`unexpected skillVersions index ${name}`);
+            }
+            return { unique: async () => null };
+          },
+        };
+      }
+      if (table === "skillVersionFingerprints") {
+        return {
+          withIndex: (name: string) => {
+            if (name !== "by_fingerprint") {
+              throw new Error(`unexpected skillVersionFingerprints index ${name}`);
+            }
+            return { take: async () => [] };
+          },
+        };
+      }
+      if (table === "skillBadges") {
+        return {
+          withIndex: (name: string) => {
+            if (name !== "by_skill") {
+              throw new Error(`unexpected skillBadges index ${name}`);
+            }
+            return { take: async () => [] };
+          },
+        };
+      }
+      if (table === "skillEmbeddings") {
+        return {
+          withIndex: (
+            name: string,
+            build:
+              | ((q: { eq: (field: string, value: string) => unknown }) => unknown)
+              | undefined,
+          ) => {
+            if (name !== "by_version") {
+              throw new Error(`unexpected skillEmbeddings index ${name}`);
+            }
+            let requestedVersionId: string | null = null;
+            const q = {
+              eq: (field: string, value: string) => {
+                if (field !== "versionId") throw new Error(`unexpected field ${field}`);
+                requestedVersionId = value;
+                return q;
+              },
+            };
+            build?.(q);
+            return {
+              unique: async () => {
+                if (requestedVersionId === PREV_LATEST_VERSION_ID) {
+                  return {
+                    _id: PREV_EMBEDDING_ID,
+                    versionId: PREV_LATEST_VERSION_ID,
+                    isLatest: true,
+                    isApproved: false,
+                    visibility: "public",
+                  };
+                }
+                return null;
+              },
+            };
+          },
+        };
+      }
+      if (table === "globalStats") {
+        return {
+          withIndex: (name: string) => {
+            if (name !== "by_key") {
+              throw new Error(`unexpected globalStats index ${name}`);
+            }
+            return {
+              unique: async () => ({
+                _id: "globalStats:1",
+                activeSkillsCount: 100,
+              }),
+            };
+          },
+        };
+      }
+      if (table === "skillSearchDigest") {
+        return {
+          withIndex: () => ({
+            unique: async () => null,
+          }),
+        };
+      }
+      if (table === "reservedSlugs") {
+        return {
+          withIndex: (name: string) => {
+            if (name !== "by_slug_active_deletedAt") {
+              throw new Error(`unexpected reservedSlugs index ${name}`);
+            }
+            return { order: () => ({ take: async () => [] }) };
+          },
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    }),
+    patch: vi.fn(async (arg0: unknown, arg1: unknown, arg2?: unknown) => {
+      // convex-helpers `triggers` calls innerDb.patch(tableName, id, value)
+      // for tables with registered triggers (e.g. "skills"); otherwise it
+      // falls back to innerDb.patch(id, value).
+      const [id, value] =
+        arg2 !== undefined ? [arg1 as string, arg2] : [arg0 as string, arg1];
+
+      captured.allPatches.push({
+        id: id,
+        value: value as Record<string, unknown>,
+      });
+
+      if (id === SKILL_ID) {
+        captured.skillPatches.push(value as Record<string, unknown>);
+        Object.assign(skill, value as Record<string, unknown>);
+        return;
+      }
+      if (id === PREV_EMBEDDING_ID) {
+        captured.embeddingPatches.push({ id, value: value as Record<string, unknown> });
+        return;
+      }
+      if (typeof id === "string" && id.startsWith("users:")) return;
+      if (typeof id === "string" && id.startsWith("publishers:")) return;
+    }),
+    insert: vi.fn(async (table: string, value: Record<string, unknown>) => {
+      if (table === "skillVersions") {
+        captured.versionInserted = value;
+        return NEW_VERSION_ID;
+      }
+      if (table === "skillEmbeddings") {
+        captured.embeddingInserts.push(value);
+        return NEW_EMBEDDING_ID;
+      }
+      if (table === "embeddingSkillMap") {
+        return "embeddingSkillMap:1";
+      }
+      if (table === "skillVersionFingerprints") {
+        return "skillVersionFingerprints:1";
+      }
+      // Trigger side-effect / digest tables: accept silently so the async
+      // digest plumbing invoked by the skills trigger doesn't fail the test.
+      if (table === "skillSearchDigest") {
+        return `${table}:mock`;
+      }
+      // Intentionally throw for publishers / publisherMembers so
+      // ensurePersonalPublisherForUser's `isMissingPublisherTableError` branch
+      // takes the synthesize fallback, avoiding the publishers trigger chain.
+      throw new Error(`unexpected insert table ${table}`);
+    }),
+    normalizeId: vi.fn((tableName: string, id: string) =>
+      id.startsWith(`${tableName}:`) ? id : null,
+    ),
+  };
+  return db;
+}
+
+function buildCtx(skill: SkillDoc) {
+  const captured: Captured = {
+    skillPatches: [],
+    embeddingInserts: [],
+    embeddingPatches: [],
+    versionInserted: null,
+    allPatches: [],
+  };
+  const db = buildDb(skill, captured);
+  const ctx = {
+    db,
+    scheduler: { runAfter: vi.fn() },
+  };
+  return { ctx, captured, db };
+}
+
+describe("skills.insertVersion latest-tag protection", () => {
+  it("promotes latest when publishing a strictly higher version", async () => {
+    const skill = buildExistingSkill();
+    const { ctx, captured } = buildCtx(skill);
+
+    const result = await insertVersionHandler(
+      ctx as never,
+      buildPublishArgs({
+        version: "2.1.0",
+        displayName: "My Skill v2.1",
+        summary: "Summary of v2.1.0",
+        capabilityTags: ["cap-v2.1"],
+      }) as never,
+    );
+
+    expect(result).toEqual({
+      skillId: SKILL_ID,
+      versionId: NEW_VERSION_ID,
+      embeddingId: NEW_EMBEDDING_ID,
+    });
+
+    const finalPatch = captured.skillPatches.at(-1);
+    expect(finalPatch).toBeDefined();
+    expect(finalPatch).toMatchObject({
+      latestVersionId: NEW_VERSION_ID,
+      displayName: "My Skill v2.1",
+      capabilityTags: ["cap-v2.1"],
+      tags: expect.objectContaining({ latest: NEW_VERSION_ID }),
+    });
+    expect((finalPatch as Record<string, unknown>).latestVersionSummary).toMatchObject({
+      version: "2.1.0",
+    });
+
+    // New embedding is the latest; the previous latest embedding is demoted.
+    expect(captured.embeddingInserts[0]).toMatchObject({
+      versionId: NEW_VERSION_ID,
+      isLatest: true,
+    });
+    expect(captured.embeddingPatches).toHaveLength(1);
+    expect(captured.embeddingPatches[0]).toMatchObject({
+      id: PREV_EMBEDDING_ID,
+      value: expect.objectContaining({ isLatest: false }),
+    });
+  });
+
+  it("does not clobber latest when publishing an older (backport) version", async () => {
+    const skill = buildExistingSkill();
+    const { ctx, captured } = buildCtx(skill);
+
+    const result = await insertVersionHandler(
+      ctx as never,
+      buildPublishArgs({
+        version: "1.0.1",
+        displayName: "My Skill v1 backport",
+        summary: "Summary of v1.0.1 backport",
+        capabilityTags: ["cap-v1-backport"],
+      }) as never,
+    );
+
+    expect(result).toEqual({
+      skillId: SKILL_ID,
+      versionId: NEW_VERSION_ID,
+      embeddingId: NEW_EMBEDDING_ID,
+    });
+
+    const finalPatch = captured.skillPatches.at(-1) as Record<string, unknown>;
+    expect(finalPatch).toBeDefined();
+
+    // Latest pointer is preserved.
+    expect(finalPatch.latestVersionId).toBe(PREV_LATEST_VERSION_ID);
+    expect(finalPatch.latestVersionSummary).toMatchObject({ version: "2.0.0" });
+
+    // Skill card fields must keep tracking the existing latest, not the backport.
+    expect(finalPatch.displayName).toBe("My Skill v2");
+    expect(finalPatch.summary).toBe("Summary of v2.0.0");
+    expect(finalPatch.capabilityTags).toEqual(["cap-v2"]);
+
+    // `tags.latest` still points to the previous version.
+    expect(finalPatch.tags).toEqual(
+      expect.objectContaining({ latest: PREV_LATEST_VERSION_ID }),
+    );
+
+    // versions counter still increments on every publish, regardless of version order.
+    expect(finalPatch.stats).toMatchObject({ versions: 2 });
+  });
+
+  it("keeps the previous latest embedding untouched on backport publishes", async () => {
+    const skill = buildExistingSkill();
+    const { ctx, captured } = buildCtx(skill);
+
+    await insertVersionHandler(
+      ctx as never,
+      buildPublishArgs({ version: "1.0.1" }) as never,
+    );
+
+    // New version embedding is NOT marked latest.
+    expect(captured.embeddingInserts).toHaveLength(1);
+    expect(captured.embeddingInserts[0]).toMatchObject({
+      versionId: NEW_VERSION_ID,
+      isLatest: false,
+    });
+
+    // Previous latest embedding must not be demoted.
+    expect(captured.embeddingPatches).toHaveLength(0);
+  });
+
+  it("routes a custom tag to the backport version but leaves latest alone", async () => {
+    const skill = buildExistingSkill();
+    const { ctx, captured } = buildCtx(skill);
+
+    await insertVersionHandler(
+      ctx as never,
+      buildPublishArgs({
+        version: "1.0.1",
+        tags: ["lts"],
+      }) as never,
+    );
+
+    const finalPatch = captured.skillPatches.at(-1) as Record<string, unknown>;
+    expect(finalPatch.tags).toEqual(
+      expect.objectContaining({
+        latest: PREV_LATEST_VERSION_ID,
+        lts: NEW_VERSION_ID,
+      }),
+    );
+  });
+
+  it("treats the very first publish as latest even when the version is low", async () => {
+    const skill = buildExistingSkill({
+      latestVersionId: undefined,
+      latestVersionSummary: undefined,
+      tags: {},
+      stats: {
+        downloads: 0,
+        installsCurrent: 0,
+        installsAllTime: 0,
+        stars: 0,
+        versions: 0,
+        comments: 0,
+      },
+    });
+    const { ctx, captured } = buildCtx(skill);
+
+    await insertVersionHandler(
+      ctx as never,
+      buildPublishArgs({
+        version: "0.0.1",
+        displayName: "My Skill v0",
+        summary: "Summary of v0.0.1",
+        capabilityTags: ["cap-v0"],
+      }) as never,
+    );
+
+    const finalPatch = captured.skillPatches.at(-1) as Record<string, unknown>;
+    expect(finalPatch.latestVersionId).toBe(NEW_VERSION_ID);
+    expect(finalPatch.latestVersionSummary).toMatchObject({ version: "0.0.1" });
+    expect(finalPatch.tags).toEqual(expect.objectContaining({ latest: NEW_VERSION_ID }));
+    expect(finalPatch.displayName).toBe("My Skill v0");
+    expect(finalPatch.capabilityTags).toEqual(["cap-v0"]);
+    expect(captured.embeddingInserts[0]).toMatchObject({ isLatest: true });
+  });
+});

--- a/convex/skills.backportLatest.test.ts
+++ b/convex/skills.backportLatest.test.ts
@@ -153,12 +153,6 @@ type Captured = {
 };
 
 function buildDb(skill: SkillDoc, captured: Captured) {
-  const throwMissingPublisherTable = (table: string) => {
-    // Forces ensurePersonalPublisherForUser's synthesize fallback in
-    // lib/publishers.ts so we don't need to mock publishers/publisherMembers.
-    throw new Error(`unexpected table: ${table}`);
-  };
-
   // Trigger-driven code (syncSkillSearchDigestForSkill -> getOwnerPublisher)
   // will ask for publishers via `db.get(ownerPublisherId)`. Return null so
   // getOwnerPublisher falls back to resolving the publisher from the owner user.

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -3,6 +3,7 @@ import { normalizeTextContentType } from "clawhub-schema";
 import { getPage, type IndexKey, paginator } from "convex-helpers/server/pagination";
 import { paginationOptsValidator } from "convex/server";
 import { ConvexError, v, type Value } from "convex/values";
+import semver from "semver";
 import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import type { ActionCtx, MutationCtx, QueryCtx } from "./_generated/server";
@@ -6456,16 +6457,30 @@ export const insertVersion = internalMutation({
       softDeletedAt: undefined,
     });
 
+    // Only promote this version to `latest` if it is strictly greater than the
+    // currently published latest version (by semver). This allows backport /
+    // hotfix publishes on lower version lines (e.g. shipping 1.0.1 while 2.x is
+    // live) without clobbering the latest pointer, tag, embedding, or summary.
+    const prevLatestVersion = skill.latestVersionSummary?.version;
+    const isNewLatest =
+      !prevLatestVersion || semver.gt(args.version, prevLatestVersion);
+
     const nextTags: Record<string, Id<"skillVersions">> = { ...skill.tags };
-    nextTags.latest = versionId;
+    if (isNewLatest) {
+      nextTags.latest = versionId;
+    }
     for (const tag of args.tags ?? []) {
       nextTags[tag] = versionId;
     }
 
     const latestBefore = skill.latestVersionId;
 
-    const nextSummary =
+    const derivedSummary =
       args.summary ?? getFrontmatterValue(args.parsed.frontmatter, "description") ?? skill.summary;
+    // Skill-level fields (displayName / summary / capabilityTags) should only
+    // follow the latest version. Backport publishes must not leak their values
+    // into the skill card shown on the listing / detail pages.
+    const nextSummary = isNewLatest ? derivedSummary : skill.summary;
     const derivedFlags = deriveModerationFlags({
       skill: {
         slug: skill.slug,
@@ -6483,19 +6498,21 @@ export const insertVersion = internalMutation({
       new Set([...(derivedFlags ?? []), ...(moderationSnapshot.legacyFlags ?? [])]),
     );
     const basePatch: SkillModerationPatch = {
-      displayName: args.displayName,
+      displayName: isNewLatest ? args.displayName : skill.displayName,
       summary: nextSummary ?? undefined,
       ownerPublisherId: skill.ownerPublisherId ?? ownerPublisherId,
-      latestVersionId: versionId,
-      latestVersionSummary: {
-        version: args.version,
-        createdAt: now,
-        changelog: args.changelog,
-        changelogSource: args.changelogSource,
-        clawdis: args.parsed.clawdis,
-      },
+      latestVersionId: isNewLatest ? versionId : skill.latestVersionId,
+      latestVersionSummary: isNewLatest
+        ? {
+            version: args.version,
+            createdAt: now,
+            changelog: args.changelog,
+            changelogSource: args.changelogSource,
+            clawdis: args.parsed.clawdis,
+          }
+        : skill.latestVersionSummary,
       tags: nextTags,
-      capabilityTags: args.capabilityTags,
+      capabilityTags: isNewLatest ? args.capabilityTags : skill.capabilityTags,
       stats: { ...skill.stats, versions: skill.stats.versions + 1 },
       softDeletedAt: undefined,
       moderationStatus: initialModerationStatus,
@@ -6547,9 +6564,9 @@ export const insertVersion = internalMutation({
       versionId,
       ownerId: userId,
       embedding: args.embedding,
-      isLatest: true,
+      isLatest: isNewLatest,
       isApproved,
-      visibility: embeddingVisibilityFor(true, isApproved),
+      visibility: embeddingVisibilityFor(isNewLatest, isApproved),
       updatedAt: now,
     });
     // Lightweight lookup so search hydration can skip reading the 12KB embedding doc
@@ -6558,7 +6575,10 @@ export const insertVersion = internalMutation({
       skillId: skill._id,
     });
 
-    if (latestBefore) {
+    // Only demote the previous latest embedding when this publish actually
+    // replaces `latest`. Backport publishes must leave the existing latest
+    // embedding untouched so vector search keeps returning the right version.
+    if (isNewLatest && latestBefore) {
       const previousEmbedding = await ctx.db
         .query("skillEmbeddings")
         .withIndex("by_version", (q) => q.eq("versionId", latestBefore))

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -6486,10 +6486,15 @@ export const insertVersion = internalMutation({
     // follow the latest version. Backport publishes must not leak their values
     // into the skill card shown on the listing / detail pages.
     const nextSummary = isNewLatest ? derivedSummary : skill.summary;
+    // Backport publishes must not promote their displayName/summary onto the
+    // skill card (see basePatch below), so the moderation evaluation must use
+    // the same values that will actually be persisted. Otherwise we would
+    // persist flags derived from text the user can never see on the card.
+    const nextDisplayName = isNewLatest ? args.displayName : skill.displayName;
     const derivedFlags = deriveModerationFlags({
       skill: {
         slug: skill.slug,
-        displayName: args.displayName,
+        displayName: nextDisplayName,
         summary: nextSummary ?? undefined,
       },
       parsed: args.parsed,
@@ -6503,7 +6508,7 @@ export const insertVersion = internalMutation({
       new Set([...(derivedFlags ?? []), ...(moderationSnapshot.legacyFlags ?? [])]),
     );
     const basePatch: SkillModerationPatch = {
-      displayName: isNewLatest ? args.displayName : skill.displayName,
+      displayName: nextDisplayName,
       summary: nextSummary ?? undefined,
       ownerPublisherId: skill.ownerPublisherId ?? ownerPublisherId,
       latestVersionId: isNewLatest ? versionId : skill.latestVersionId,

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -6469,7 +6469,12 @@ export const insertVersion = internalMutation({
     if (isNewLatest) {
       nextTags.latest = versionId;
     }
+    // `latest` is a reserved tag: it is managed exclusively by the semver
+    // comparison above so that backport publishes cannot clobber the latest
+    // pointer. Silently drop it (case-insensitively) from caller-provided tags
+    // to prevent a trivial bypass via args.tags: ["latest"].
     for (const tag of args.tags ?? []) {
+      if (tag.toLowerCase() === "latest") continue;
       nextTags[tag] = versionId;
     }
 

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -6461,9 +6461,20 @@ export const insertVersion = internalMutation({
     // currently published latest version (by semver). This allows backport /
     // hotfix publishes on lower version lines (e.g. shipping 1.0.1 while 2.x is
     // live) without clobbering the latest pointer, tag, embedding, or summary.
+    //
+    // The schema only enforces `v.string()` on `latestVersionSummary.version`,
+    // so legacy / imported skills may persist non-semver values (e.g. "latest",
+    // "2024-12"). Calling `semver.gt` with a malformed right-hand operand
+    // throws `TypeError: Invalid Version`, which would crash the publish
+    // mutation. Short-circuit to treating the incoming publish as the new
+    // latest in that case, which self-heals the skill back into a valid
+    // semver latest pointer (args.version is already validated upstream in
+    // publishVersionForUser / githubImport).
     const prevLatestVersion = skill.latestVersionSummary?.version;
     const isNewLatest =
-      !prevLatestVersion || semver.gt(args.version, prevLatestVersion);
+      !prevLatestVersion ||
+      !semver.valid(prevLatestVersion) ||
+      semver.gt(args.version, prevLatestVersion);
 
     const nextTags: Record<string, Id<"skillVersions">> = { ...skill.tags };
     if (isNewLatest) {


### PR DESCRIPTION
## Summary

Publishing an **older** version of a skill (a backport) used to silently take over the `latest` tag, the skill card, and the vector-search "is latest" flag from the actual newest release. This PR makes `latest` promotion version-aware so only strictly-newer publishes become `latest`, while still letting authors attach custom tags (e.g. `lts`, `beta`) to backport versions.

## The bug

In `convex/skills.ts → insertVersion`, every successful publish unconditionally:

- overwrote `skills.latestVersionId`
- rewrote `skills.tags.latest` to point at the just-published version
- replaced `skills.latestVersionSummary` (version, publishedAt, summary, capability tags…)
- overwrote the skill card fields (`displayName`, `summary`, `capabilityTags`) from the new version's manifest
- flipped the previously-latest embedding's `isLatest` to `false`, demoting the real latest from vector search

Reproduction: publish `2.0.0`, then publish a `1.0.1` backport. After the backport:

- `/skills/<slug>` shows the 1.0.1 manifest as the current release
- `tags.latest` resolves to 1.0.1
- Vector search ranks 1.0.1 as the latest embedding and hides 2.0.0

## Fix

`insertVersion` now compares the incoming version against `latestVersionSummary.version` using the existing semver comparator and only performs the "promote to latest" path when:

- the skill has no latest yet (first publish), **or**
- the new version is **strictly greater** than the current latest.

When the new version is older (or equal), we still:

- insert the version row and embedding (with `isLatest: false`)
- apply any **custom** tags passed in the publish args (so `lts`, `beta`, etc. still land on the backport)
- leave `skills.latestVersionId`, `skills.tags.latest`, `skills.latestVersionSummary`, the card fields, and the previous latest embedding's `isLatest` flag untouched.

Only the `latest` tag and the `isLatest` embedding flag are protected — authors keep full control over every other tag.

## Tests

Added `convex/skills.backportLatest.test.ts` covering:

- higher version → latest is promoted, old embedding demoted ✅
- older (backport) version → `latestVersionId`, `tags.latest`, `latestVersionSummary`, card fields, and the previous embedding's `isLatest` are all preserved ✅
- backport publish with a custom tag (`lts`) → `tags.lts` points to the backport, `tags.latest` stays on the newer version ✅
- very first publish → always becomes latest regardless of version number ✅

## Reviewer notes

- The semver comparator reused here is the same helper already used elsewhere in `convex/skills.ts`, so no new dependency is introduced.



