### PR TITLE
fix: calibrate VT Code Insight moderation

### DIFF
--- a/convex/lib/moderationEngine.test.ts
+++ b/convex/lib/moderationEngine.test.ts
@@ -527,4 +527,60 @@ describe("moderationEngine", () => {
     expect(snapshot.reasonCodes).toContain("suspicious.env_credential_access");
     expect(snapshot.reasonCodes).toContain("suspicious.vt_suspicious");
   });
+
+  it("does not let uncorroborated VT Code Insight suspicious override clean local scans", () => {
+    const snapshot = buildModerationSnapshot({
+      staticScan: {
+        status: "clean",
+        reasonCodes: [],
+        findings: [],
+        summary: "",
+        engineVersion: "v2.1.1",
+        checkedAt: Date.now(),
+      },
+      vtAnalysis: {
+        status: "suspicious",
+        scanner: "code_insight",
+        source: "VirusTotal Code Insight",
+        engineStats: {
+          malicious: 0,
+          suspicious: 0,
+          harmless: 12,
+          undetected: 54,
+        },
+      },
+      llmStatus: "clean",
+    });
+
+    expect(snapshot.verdict).toBe("clean");
+    expect(snapshot.reasonCodes).toEqual([]);
+  });
+
+  it("keeps VT Code Insight suspicious when AV engines also report suspicious", () => {
+    const snapshot = buildModerationSnapshot({
+      staticScan: {
+        status: "clean",
+        reasonCodes: [],
+        findings: [],
+        summary: "",
+        engineVersion: "v2.1.1",
+        checkedAt: Date.now(),
+      },
+      vtAnalysis: {
+        status: "suspicious",
+        scanner: "code_insight",
+        source: "VirusTotal Code Insight",
+        engineStats: {
+          malicious: 0,
+          suspicious: 1,
+          harmless: 12,
+          undetected: 53,
+        },
+      },
+      llmStatus: "clean",
+    });
+
+    expect(snapshot.verdict).toBe("suspicious");
+    expect(snapshot.reasonCodes).toContain("suspicious.vt_suspicious");
+  });
 });

--- a/convex/lib/moderationEngine.ts
+++ b/convex/lib/moderationEngine.ts
@@ -13,6 +13,22 @@ import {
 } from "./moderationReasonCodes";
 
 type TextFile = { path: string; content: string };
+type VirusTotalEngineStats = {
+  malicious?: number;
+  suspicious?: number;
+  undetected?: number;
+  harmless?: number;
+};
+
+type VirusTotalAnalysis = {
+  status?: string;
+  scanner?: string;
+  source?: string;
+  engineStats?: VirusTotalEngineStats;
+  metadata?: {
+    stats?: VirusTotalEngineStats;
+  };
+};
 
 export type StaticScanInput = {
   slug: string;
@@ -412,11 +428,40 @@ function dedupeEvidence(evidence: ModerationFinding[]) {
   return out.slice(0, 40);
 }
 
-function addScannerStatusReason(reasonCodes: string[], scanner: "vt" | "llm", status?: string) {
+function isStaticScanClean(staticScan: StaticScanResult | undefined) {
+  return !staticScan || staticScan.reasonCodes.length === 0 || staticScan.status === "clean";
+}
+
+function isAvEngineStatsClean(stats: VirusTotalEngineStats | undefined) {
+  if (!stats) return false;
+  return (stats.malicious ?? 0) === 0 && (stats.suspicious ?? 0) === 0;
+}
+
+function getVtEngineStats(analysis: VirusTotalAnalysis | undefined) {
+  return analysis?.engineStats ?? analysis?.metadata?.stats;
+}
+
+function isUncorroboratedVtCodeInsightSuspicious(params: {
+  vtAnalysis?: VirusTotalAnalysis;
+  staticScan?: StaticScanResult;
+  llmStatus?: string;
+}) {
+  if (params.vtAnalysis?.scanner !== "code_insight") return false;
+  if (!isExternalScannerClean(params.llmStatus)) return false;
+  if (!isStaticScanClean(params.staticScan)) return false;
+  return isAvEngineStatsClean(getVtEngineStats(params.vtAnalysis));
+}
+
+function addScannerStatusReason(
+  reasonCodes: string[],
+  scanner: "vt" | "llm",
+  status?: string,
+  options: { suppressSuspicious?: boolean } = {},
+) {
   const normalized = status?.trim().toLowerCase();
   if (normalized === "malicious") {
     reasonCodes.push(`malicious.${scanner}_malicious`);
-  } else if (normalized === "suspicious") {
+  } else if (normalized === "suspicious" && !options.suppressSuspicious) {
     reasonCodes.push(`suspicious.${scanner}_suspicious`);
   }
 }
@@ -493,6 +538,7 @@ function isExternalScannerClean(status: string | undefined): boolean {
 
 export function buildModerationSnapshot(params: {
   staticScan?: StaticScanResult;
+  vtAnalysis?: VirusTotalAnalysis;
   vtStatus?: string;
   llmStatus?: string;
   sourceVersionId?: Id<"skillVersions">;
@@ -510,7 +556,14 @@ export function buildModerationSnapshot(params: {
   }
 
   const reasonCodes = [...staticCodes];
-  addScannerStatusReason(reasonCodes, "vt", params.vtStatus);
+  const vtStatus = params.vtStatus ?? params.vtAnalysis?.status;
+  addScannerStatusReason(reasonCodes, "vt", vtStatus, {
+    suppressSuspicious: isUncorroboratedVtCodeInsightSuspicious({
+      vtAnalysis: params.vtAnalysis,
+      staticScan: params.staticScan,
+      llmStatus: params.llmStatus,
+    }),
+  });
   addScannerStatusReason(reasonCodes, "llm", params.llmStatus);
 
   const normalizedCodes = normalizeReasonCodes(reasonCodes);

--- a/convex/lib/moderationEngine.ts
+++ b/convex/lib/moderationEngine.ts
@@ -429,6 +429,8 @@ function dedupeEvidence(evidence: ModerationFinding[]) {
 }
 
 function isStaticScanClean(staticScan: StaticScanResult | undefined) {
+  // Older moderation records can predate static scan persistence; absence means
+  // there are no static findings available to corroborate an external signal.
   return !staticScan || staticScan.reasonCodes.length === 0 || staticScan.status === "clean";
 }
 

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -51,6 +51,21 @@ const MAX_SEARCH_SCAN_DOCUMENTS = 1_000;
 const MAX_SEARCH_SCAN_PAGES = 20;
 const MAX_DIRECT_PACKAGE_SEARCH_CANDIDATES = 20;
 const INITIAL_PACKAGE_VT_SCAN_DELAY_MS = 30_000;
+const vtEngineStatsValidator = v.object({
+  malicious: v.optional(v.number()),
+  suspicious: v.optional(v.number()),
+  undetected: v.optional(v.number()),
+  harmless: v.optional(v.number()),
+});
+const vtAnalysisValidator = v.object({
+  status: v.string(),
+  verdict: v.optional(v.string()),
+  analysis: v.optional(v.string()),
+  source: v.optional(v.string()),
+  scanner: v.optional(v.string()),
+  engineStats: v.optional(vtEngineStatsValidator),
+  checkedAt: v.number(),
+});
 const internalRefs = internal as unknown as {
   llmEval: {
     evaluatePackageReleaseWithLlm: unknown;
@@ -2374,15 +2389,7 @@ export const updateReleaseScanResultsInternal = internalMutation({
   args: {
     releaseId: v.id("packageReleases"),
     sha256hash: v.optional(v.string()),
-    vtAnalysis: v.optional(
-      v.object({
-        status: v.string(),
-        verdict: v.optional(v.string()),
-        analysis: v.optional(v.string()),
-        source: v.optional(v.string()),
-        checkedAt: v.number(),
-      }),
-    ),
+    vtAnalysis: v.optional(vtAnalysisValidator),
   },
   handler: async (ctx, args) => {
     const release = await ctx.db.get(args.releaseId);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -12,6 +12,23 @@ const manualModerationOverride = v.object({
   updatedAt: v.number(),
 });
 
+const vtEngineStatsValidator = v.object({
+  malicious: v.optional(v.number()),
+  suspicious: v.optional(v.number()),
+  undetected: v.optional(v.number()),
+  harmless: v.optional(v.number()),
+});
+
+const vtAnalysisValidator = v.object({
+  status: v.string(),
+  verdict: v.optional(v.string()),
+  analysis: v.optional(v.string()),
+  source: v.optional(v.string()),
+  scanner: v.optional(v.string()),
+  engineStats: v.optional(vtEngineStatsValidator),
+  checkedAt: v.number(),
+});
+
 const users = defineTable({
   name: v.optional(v.string()),
   image: v.optional(v.string()),
@@ -429,15 +446,7 @@ const skillVersions = defineTable({
   createdAt: v.number(),
   softDeletedAt: v.optional(v.number()),
   sha256hash: v.optional(v.string()),
-  vtAnalysis: v.optional(
-    v.object({
-      status: v.string(),
-      verdict: v.optional(v.string()),
-      analysis: v.optional(v.string()),
-      source: v.optional(v.string()),
-      checkedAt: v.number(),
-    }),
-  ),
+  vtAnalysis: v.optional(vtAnalysisValidator),
   llmAnalysis: v.optional(
     v.object({
       status: v.string(),
@@ -704,15 +713,7 @@ const packageReleases = defineTable({
   capabilities: packageCapabilitiesValidator,
   verification: packageVerificationValidator,
   sha256hash: v.optional(v.string()),
-  vtAnalysis: v.optional(
-    v.object({
-      status: v.string(),
-      verdict: v.optional(v.string()),
-      analysis: v.optional(v.string()),
-      source: v.optional(v.string()),
-      checkedAt: v.number(),
-    }),
-  ),
+  vtAnalysis: v.optional(vtAnalysisValidator),
   llmAnalysis: v.optional(
     v.object({
       status: v.string(),

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -128,8 +128,26 @@ const USER_MODERATION_REASON = "user.moderation";
 const SKILL_CATALOG_CURSOR_PREFIX = "skillcat:";
 const SKILL_CAPABILITY_TAG_SET = new Set<string>(SKILL_CAPABILITY_TAGS);
 
+const vtEngineStatsValidator = v.object({
+  malicious: v.optional(v.number()),
+  suspicious: v.optional(v.number()),
+  undetected: v.optional(v.number()),
+  harmless: v.optional(v.number()),
+});
+
+const vtAnalysisValidator = v.object({
+  status: v.string(),
+  verdict: v.optional(v.string()),
+  analysis: v.optional(v.string()),
+  source: v.optional(v.string()),
+  scanner: v.optional(v.string()),
+  engineStats: v.optional(vtEngineStatsValidator),
+  checkedAt: v.number(),
+});
+
 function buildStructuredModerationPatch(params: {
   staticScan?: Doc<"skillVersions">["staticScan"];
+  vtAnalysis?: Doc<"skillVersions">["vtAnalysis"];
   vtStatus?: string;
   llmStatus?: string;
   sourceVersionId?: Id<"skillVersions">;
@@ -145,6 +163,7 @@ function buildStructuredModerationPatch(params: {
 > {
   const snapshot = buildModerationSnapshot({
     staticScan: params.staticScan,
+    vtAnalysis: params.vtAnalysis,
     vtStatus: params.vtStatus,
     llmStatus: params.llmStatus,
     sourceVersionId: params.sourceVersionId,
@@ -210,6 +229,7 @@ function buildScannerModerationPatchFromVersion(params: {
 }): SkillModerationPatch {
   const structuredPatch = buildStructuredModerationPatch({
     staticScan: params.version.staticScan,
+    vtAnalysis: params.version.vtAnalysis,
     vtStatus: params.version.vtAnalysis?.status,
     llmStatus: params.version.llmAnalysis?.status,
     sourceVersionId: params.version._id,
@@ -4085,6 +4105,7 @@ export const escalateSkillByIdInternal = internalMutation({
     const llmStatus = reasonMatch?.[1] === "llm" ? reasonMatch[2] : version?.llmAnalysis?.status;
     const snapshot = buildModerationSnapshot({
       staticScan: version?.staticScan,
+      vtAnalysis: version?.vtAnalysis,
       vtStatus,
       llmStatus,
       sourceVersionId: version?._id,
@@ -4572,15 +4593,7 @@ export const updateVersionScanResultsInternal = internalMutation({
   args: {
     versionId: v.id("skillVersions"),
     sha256hash: v.optional(v.string()),
-    vtAnalysis: v.optional(
-      v.object({
-        status: v.string(),
-        verdict: v.optional(v.string()),
-        analysis: v.optional(v.string()),
-        source: v.optional(v.string()),
-        checkedAt: v.number(),
-      }),
-    ),
+    vtAnalysis: v.optional(vtAnalysisValidator),
   },
   handler: async (ctx, args) => {
     const version = await ctx.db.get(args.versionId);
@@ -4694,11 +4707,6 @@ export const approveSkillByHashInternal = internalMutation({
 
       const now = Date.now();
       const qualityLocked = skill.moderationReason === "quality.low" && !isMalicious;
-      const nextModerationReason = qualityLocked
-        ? "quality.low"
-        : bypassSuspicious
-          ? `scanner.${args.scanner}.clean`
-          : `scanner.${args.scanner}.${args.status}`;
       const nextModerationNotes = qualityLocked
         ? (skill.moderationNotes ??
           "Quality gate quarantine is still active. Manual moderation review required.")
@@ -4706,6 +4714,7 @@ export const approveSkillByHashInternal = internalMutation({
       const scanner = args.scanner.trim().toLowerCase();
       const snapshot = buildModerationSnapshot({
         staticScan: version.staticScan,
+        vtAnalysis: version.vtAnalysis,
         vtStatus: scanner === "vt" ? args.status : version.vtAnalysis?.status,
         llmStatus: scanner === "llm" ? args.status : version.llmAnalysis?.status,
         sourceVersionId: version._id,
@@ -4716,6 +4725,16 @@ export const approveSkillByHashInternal = internalMutation({
           : snapshot.reasonCodes;
       const nextVerdict = verdictFromCodes(nextReasonCodes);
       const nextLegacyFlags = legacyFlagsFromVerdict(nextVerdict);
+      if (nextVerdict === "clean" && !alreadyBlocked) {
+        newFlags = undefined;
+      }
+      const nextModerationReason = qualityLocked
+        ? "quality.low"
+        : bypassSuspicious
+          ? `scanner.${args.scanner}.clean`
+          : nextVerdict === "clean"
+            ? "scanner.aggregate.clean"
+            : `scanner.${args.scanner}.${args.status}`;
       const nextModerationStatus =
         nextVerdict === "malicious" || qualityLocked ? "hidden" : "active";
 
@@ -4801,9 +4820,9 @@ export const escalateByVtInternal = internalMutation({
       newFlags = ["flagged.suspicious"];
     }
 
-    const nextModerationFlags = newFlags.length ? newFlags : undefined;
     const snapshot = buildModerationSnapshot({
       staticScan: version.staticScan,
+      vtAnalysis: version.vtAnalysis,
       vtStatus: args.status,
       llmStatus: version.llmAnalysis?.status,
       sourceVersionId: version._id,
@@ -4813,6 +4832,13 @@ export const escalateByVtInternal = internalMutation({
         ? snapshot.reasonCodes.filter((code) => !code.startsWith("suspicious."))
         : snapshot.reasonCodes;
     const nextVerdict = verdictFromCodes(nextReasonCodes);
+    const nextLegacyFlags = legacyFlagsFromVerdict(nextVerdict);
+    const nextModerationFlags =
+      nextVerdict === "clean" && !alreadyBlocked
+        ? undefined
+        : newFlags.length
+          ? newFlags
+          : nextLegacyFlags;
     const now = Date.now();
     const basePatch: SkillModerationPatch = {
       moderationFlags: nextModerationFlags,

--- a/convex/vt.ts
+++ b/convex/vt.ts
@@ -203,11 +203,14 @@ function buildPackageScanAnalysisFromVtResult(
   );
   if (aiResult) {
     const verdict = normalizeVerdict(aiResult.verdict);
+    const stats = vtResult.data.attributes.last_analysis_stats;
     return {
       status: verdictToStatus(verdict),
       verdict: aiResult.verdict,
       analysis: aiResult.analysis,
       source: aiResult.source,
+      scanner: "code_insight",
+      engineStats: stats,
       checkedAt: Date.now(),
     };
   }
@@ -511,6 +514,7 @@ export const scanWithVirusTotal = internalAction({
         );
 
         if (aiResult) {
+          const stats = existingFile.data.attributes.last_analysis_stats;
           // File exists and has AI analysis - use the verdict
           const verdict = normalizeVerdict(aiResult.verdict);
           const status = verdictToStatus(verdict);
@@ -526,6 +530,8 @@ export const scanWithVirusTotal = internalAction({
               verdict: aiResult.verdict,
               analysis: aiResult.analysis,
               source: aiResult.source,
+              scanner: "code_insight",
+              engineStats: stats,
               checkedAt: Date.now(),
             },
           });
@@ -914,6 +920,7 @@ export const pollPendingScans = internalAction({
               vtAnalysis: {
                 status,
                 source,
+                engineStats: stats,
                 checkedAt: Date.now(),
               },
             });
@@ -952,6 +959,7 @@ export const pollPendingScans = internalAction({
         // We have a verdict - update the skill
         const verdict = normalizeVerdict(aiResult.verdict);
         const status = verdictToStatus(verdict);
+        const stats = vtResult.data.attributes.last_analysis_stats;
 
         console.log(
           `[vt:pollPendingScans] Hash ${sha256hash} verdict: ${verdict} -> status: ${status}`,
@@ -965,6 +973,8 @@ export const pollPendingScans = internalAction({
             verdict: aiResult.verdict,
             analysis: aiResult.analysis,
             source: aiResult.source,
+            scanner: "code_insight",
+            engineStats: stats,
             checkedAt: Date.now(),
           },
         });
@@ -1249,6 +1259,7 @@ export const rescanActiveSkills = internalAction({
             vtAnalysis: {
               status,
               source,
+              engineStats: stats,
               checkedAt: Date.now(),
             },
           });
@@ -1278,6 +1289,7 @@ export const rescanActiveSkills = internalAction({
 
         const verdict = normalizeVerdict(aiResult.verdict);
         const status = verdictToStatus(verdict);
+        const stats = vtResult.data.attributes.last_analysis_stats;
 
         await ctx.runMutation(internal.skills.updateVersionScanResultsInternal, {
           versionId,
@@ -1286,6 +1298,8 @@ export const rescanActiveSkills = internalAction({
             verdict: aiResult.verdict,
             analysis: aiResult.analysis,
             source: aiResult.source,
+            scanner: "code_insight",
+            engineStats: stats,
             checkedAt: Date.now(),
           },
         });
@@ -1576,6 +1590,7 @@ export const backfillActiveSkillsVTCache = internalAction({
         // Update the version with VT analysis
         const verdict = normalizeVerdict(aiResult.verdict);
         const status = verdictToStatus(verdict);
+        const stats = vtResult.data.attributes.last_analysis_stats;
 
         await ctx.runMutation(internal.skills.updateVersionScanResultsInternal, {
           versionId,
@@ -1585,6 +1600,8 @@ export const backfillActiveSkillsVTCache = internalAction({
             verdict: aiResult.verdict,
             analysis: aiResult.analysis,
             source: aiResult.source,
+            scanner: "code_insight",
+            engineStats: stats,
             checkedAt: Date.now(),
           },
         });


### PR DESCRIPTION
## What problem was happening

VirusTotal Code Insight can return a `suspicious` verdict even when the local ClawHub static scanner, the LLM moderation result, and VirusTotal AV engine stats are all clean. That makes benign repositories, such as the skill-factory false positive in #1830, stay quarantined without corroborating scanner evidence.

## Why this is the right fix

The moderation aggregate should still treat malicious VT verdicts and AV-engine suspicious findings as strong signals. The false-positive seam is narrower: a lone Code Insight `suspicious` verdict should not override otherwise clean local and AV scanner evidence.

## What changed

- Stores VT scanner provenance and engine stats in `vtAnalysis` for skills and packages.
- Suppresses the `suspicious.vt_suspicious` moderation reason only when the VT scanner is `code_insight`, static scan is clean, LLM moderation is clean/benign, and VT AV engine malicious/suspicious counts are zero.
- Keeps VT suspicious moderation active when AV engines also report suspicious results.
- Clears legacy quarantine flags when a newly computed aggregate snapshot is clean, while preserving admin/moderator bypass reasons.
- Adds regression coverage for both the uncorroborated Code Insight false-positive case and the corroborated suspicious case.

## What did not change

- Malicious VT verdicts still quarantine.
- Suspicious VT verdicts from AV-engine evidence still quarantine.
- Existing already-flagged rows may need a rescan/backfill after deploy so stored `vtAnalysis.engineStats` is available for aggregate recalculation.
- Merging to `main` does not deploy production; production deploys remain manual.

## Validation

- `./node_modules/.bin/vitest run convex/skills.rateLimit.test.ts convex/lib/moderationEngine.test.ts convex/vt.test.ts convex/packages.public.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/oxlint --type-aware --tsconfig ./tsconfig.oxlint.json ./convex ./packages/clawhub/src ./packages/schema/src`
- `git diff --check`
- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/vite build`
- `./node_modules/.bin/tsc -p packages/schema/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc -p packages/clawhub/tsconfig.json --noEmit`
