### PR TITLE
fix: tolerate stale auth in star status

### DIFF
--- a/convex/soulStars.ts
+++ b/convex/soulStars.ts
@@ -1,12 +1,13 @@
 import { v } from "convex/values";
 import { mutation, query } from "./functions";
-import { requireUser } from "./lib/access";
+import { getOptionalActiveAuthUserId, requireUser } from "./lib/access";
 import { toPublicSoul } from "./lib/public";
 
 export const isStarred = query({
   args: { soulId: v.id("souls") },
   handler: async (ctx, args) => {
-    const { userId } = await requireUser(ctx);
+    const userId = await getOptionalActiveAuthUserId(ctx);
+    if (!userId) return false;
     const existing = await ctx.db
       .query("soulStars")
       .withIndex("by_soul_user", (q) => q.eq("soulId", args.soulId).eq("userId", userId))

--- a/convex/stars.test.ts
+++ b/convex/stars.test.ts
@@ -9,20 +9,22 @@ vi.mock("@convex-dev/auth/server", () => ({
   getAuthUserId: vi.fn(),
 }));
 
-type WrappedHandler<TArgs, TResult> = {
-  _handler?: (ctx: unknown, args: TArgs) => Promise<TResult>;
-};
-
-function unwrapHandler<TArgs, TResult>(
-  wrapped: unknown,
-): (ctx: unknown, args: TArgs) => Promise<TResult> {
-  const handler = (wrapped as WrappedHandler<TArgs, TResult>)._handler;
-  if (!handler) throw new Error("Expected Convex test wrapper to expose _handler");
+function unwrapHandler(wrapped: unknown) {
+  const handler = (wrapped as { _handler?: unknown })._handler;
+  if (typeof handler !== "function") {
+    throw new Error("Expected Convex test wrapper to expose _handler");
+  }
   return handler;
 }
 
-const isStarredHandler = unwrapHandler<{ skillId: string }, boolean>(isStarred);
-const isSoulStarredHandler = unwrapHandler<{ soulId: string }, boolean>(isSoulStarred);
+const isStarredHandler = unwrapHandler(isStarred) as (
+  ctx: unknown,
+  args: { skillId: string },
+) => Promise<boolean>;
+const isSoulStarredHandler = unwrapHandler(isSoulStarred) as (
+  ctx: unknown,
+  args: { soulId: string },
+) => Promise<boolean>;
 
 function makeCtx(options: { user?: Record<string, unknown> | null; existingStar?: unknown }) {
   return {

--- a/convex/stars.test.ts
+++ b/convex/stars.test.ts
@@ -10,15 +10,19 @@ vi.mock("@convex-dev/auth/server", () => ({
 }));
 
 type WrappedHandler<TArgs, TResult> = {
-  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
+  _handler?: (ctx: unknown, args: TArgs) => Promise<TResult>;
 };
 
-const isStarredHandler = (
-  isStarred as unknown as WrappedHandler<{ skillId: string }, boolean>
-)._handler;
-const isSoulStarredHandler = (
-  isSoulStarred as unknown as WrappedHandler<{ soulId: string }, boolean>
-)._handler;
+function unwrapHandler<TArgs, TResult>(
+  wrapped: unknown,
+): (ctx: unknown, args: TArgs) => Promise<TResult> {
+  const handler = (wrapped as WrappedHandler<TArgs, TResult>)._handler;
+  if (!handler) throw new Error("Expected Convex test wrapper to expose _handler");
+  return handler;
+}
+
+const isStarredHandler = unwrapHandler<{ skillId: string }, boolean>(isStarred);
+const isSoulStarredHandler = unwrapHandler<{ soulId: string }, boolean>(isSoulStarred);
 
 function makeCtx(options: { user?: Record<string, unknown> | null; existingStar?: unknown }) {
   return {
@@ -63,6 +67,16 @@ describe("stars queries", () => {
     await expect(
       isStarredHandler(makeCtx({ existingStar: { _id: "stars:demo" } }), {
         skillId: "skills:demo",
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("still reports existing soul stars for active users", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:viewer" as never);
+
+    await expect(
+      isSoulStarredHandler(makeCtx({ existingStar: { _id: "soulStars:demo" } }), {
+        soulId: "souls:demo",
       }),
     ).resolves.toBe(true);
   });

--- a/convex/stars.test.ts
+++ b/convex/stars.test.ts
@@ -1,0 +1,69 @@
+/* @vitest-environment node */
+
+import { getAuthUserId } from "@convex-dev/auth/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { isStarred } from "./stars";
+import { isStarred as isSoulStarred } from "./soulStars";
+
+vi.mock("@convex-dev/auth/server", () => ({
+  getAuthUserId: vi.fn(),
+}));
+
+type WrappedHandler<TArgs, TResult> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
+};
+
+const isStarredHandler = (
+  isStarred as unknown as WrappedHandler<{ skillId: string }, boolean>
+)._handler;
+const isSoulStarredHandler = (
+  isSoulStarred as unknown as WrappedHandler<{ soulId: string }, boolean>
+)._handler;
+
+function makeCtx(options: { user?: Record<string, unknown> | null; existingStar?: unknown }) {
+  return {
+    db: {
+      get: vi.fn(async (id: string) => {
+        if (id === "users:viewer") return options.user ?? { _id: "users:viewer" };
+        return null;
+      }),
+      query: vi.fn(() => ({
+        withIndex: vi.fn(() => ({
+          unique: vi.fn().mockResolvedValue(options.existingStar ?? null),
+        })),
+      })),
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.mocked(getAuthUserId).mockReset();
+});
+
+describe("stars queries", () => {
+  it("returns false instead of throwing when skill star auth is stale", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:viewer" as never);
+
+    await expect(
+      isStarredHandler(makeCtx({ user: null }), { skillId: "skills:demo" }),
+    ).resolves.toBe(false);
+  });
+
+  it("returns false instead of throwing when soul star auth is stale", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:viewer" as never);
+
+    await expect(
+      isSoulStarredHandler(makeCtx({ user: null }), { soulId: "souls:demo" }),
+    ).resolves.toBe(false);
+  });
+
+  it("still reports existing stars for active users", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:viewer" as never);
+
+    await expect(
+      isStarredHandler(makeCtx({ existingStar: { _id: "stars:demo" } }), {
+        skillId: "skills:demo",
+      }),
+    ).resolves.toBe(true);
+  });
+});

--- a/convex/stars.ts
+++ b/convex/stars.ts
@@ -1,13 +1,14 @@
 import { v } from "convex/values";
 import { internalMutation, mutation, query } from "./functions";
-import { requireUser } from "./lib/access";
+import { getOptionalActiveAuthUserId, requireUser } from "./lib/access";
 import { toPublicSkill } from "./lib/public";
 import { insertStatEvent } from "./skillStatEvents";
 
 export const isStarred = query({
   args: { skillId: v.id("skills") },
   handler: async (ctx, args) => {
-    const { userId } = await requireUser(ctx);
+    const userId = await getOptionalActiveAuthUserId(ctx);
+    if (!userId) return false;
     const existing = await ctx.db
       .query("stars")
       .withIndex("by_skill_user", (q) => q.eq("skillId", args.skillId).eq("userId", userId))


### PR DESCRIPTION
## What problem was happening

Skill detail pages could crash from the read-only `stars:isStarred` query when the browser believed the user was authenticated but the Convex user lookup was stale, deleted, deactivated, or otherwise unavailable. In that state the page did not need to fail; it only needed to know whether to render the star button as active.

## Why this is the right fix

Star status is a read-only affordance. If the active user cannot be resolved, the safest fallback is `false`, while the write paths that mutate stars should continue to require a valid active user.

## What changed

- `stars.isStarred` now uses optional active-user resolution and returns `false` for stale auth.
- `soulStars.isStarred` gets the same defensive behavior for the equivalent soul detail affordance.
- Added regressions for stale skill-star auth, stale soul-star auth, and the still-working active-user starred case.

## What did not change

- Star/unstar mutations still require an active authenticated user.
- This does not make moderation-hidden or soft-deleted skills public; it only prevents the star status query from crashing the page.
- Merging to `main` does not deploy production; production deploy remains a manual workflow.

## Validation

- `./node_modules/.bin/vitest run convex/stars.test.ts src/__tests__/skill-detail-page.test.tsx`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/oxlint --type-aware --tsconfig ./tsconfig.oxlint.json ./convex ./packages/clawhub/src ./packages/schema/src`
- `git diff --check`
- `./node_modules/.bin/tsc -p packages/clawhub/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc -p packages/schema/tsconfig.json --noEmit`
- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/vite build`
