### PR TITLE
docs: clarify skill monetization support

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -141,6 +141,7 @@ Stores your API token + cached registry URL.
 - Requires semver: `--version 1.2.3`.
 - Publishing a skill means it is released under `MIT-0` on ClawHub.
 - Published skills are free to use, modify, and redistribute without attribution.
+- ClawHub does not currently support paid skills or per-skill pricing.
 - Legacy alias: `publish <path>`.
 
 ### `delete <slug>`

--- a/docs/skill-format.md
+++ b/docs/skill-format.md
@@ -156,3 +156,9 @@ Limits (server-side):
 - Anyone may use, modify, and redistribute published skills, including commercially.
 - Attribution is not required.
 - Do not add conflicting license terms in `SKILL.md`; ClawHub does not support per-skill license overrides.
+
+## Paid skills
+
+- ClawHub does not currently support paid skills, per-skill pricing, paywalls, or revenue sharing.
+- Do not add pricing metadata to `SKILL.md`; it is not part of the skill format and will not make a published skill paid.
+- If your skill integrates with a paid third-party service, document the external cost and required account clearly in the skill instructions and `requires.env`.

--- a/src/routes/publish-skill.tsx
+++ b/src/routes/publish-skill.tsx
@@ -659,6 +659,10 @@ export function Upload() {
                       All skills published on ClawHub are licensed under {PLATFORM_SKILL_LICENSE}.{" "}
                       {PLATFORM_SKILL_LICENSE_SUMMARY}
                     </p>
+                    <p className="text-sm text-[color:var(--ink-soft)]">
+                      ClawHub does not currently support paid skills, per-skill pricing, or
+                      paywalled releases.
+                    </p>
                     <label className="flex items-start gap-2 text-sm cursor-pointer">
                       <input
                         type="checkbox"


### PR DESCRIPTION
## What problem was happening

Publishers could not tell from ClawHub docs or the publish UI whether paid skills, per-skill pricing, or monetization settings exist. That left #1752 answerable only by maintainer clarification instead of product documentation.

## Why this is the right fix

The current product behavior is that skills are published under MIT-0 and ClawHub does not support paid skill metadata or paywalled releases. The docs and publish surface should say that directly at the point where publishers make licensing/release decisions.

## What changed

- Added a `Paid skills` section to `docs/skill-format.md`.
- Clarified `clawhub skill publish` docs that paid skills/per-skill pricing are not currently supported.
- Added the same note to the publish-skill license panel in the web UI.

## What did not change

- No billing, pricing, or marketplace monetization behavior was added.
- Paid third-party services can still be documented as external requirements by the skill author.
- Merging to `main` does not deploy production; production deploy remains a manual workflow.

## Validation

- `./node_modules/.bin/vitest run src/__tests__/skill-detail-page.test.tsx src/__tests__/header.test.tsx`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/oxlint --type-aware --tsconfig ./tsconfig.oxlint.json ./convex ./packages/clawhub/src ./packages/schema/src`
- `git diff --check`
- `./node_modules/.bin/tsc -p packages/clawhub/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc -p packages/schema/tsconfig.json --noEmit`
- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/vite build`
