### PR TITLE
docs: document public catalog reuse

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -11,6 +11,18 @@ Base: `https://clawhub.ai`
 
 OpenAPI: `/api/v1/openapi.json`
 
+## Public catalog reuse
+
+You can build a third-party catalog, directory, or search surface on top of ClawHub's public read APIs. Public skill metadata and skill files are published under ClawHub's skill license rules, while the API itself is rate-limited and should be consumed responsibly.
+
+Guidelines:
+
+- Use public read endpoints such as `GET /api/v1/skills`, `GET /api/v1/search`, and `GET /api/v1/skills/{slug}` for catalog listings.
+- Cache responses and respect `429`, `Retry-After`, and rate-limit headers instead of polling aggressively.
+- Link back to the canonical ClawHub skill URL when displaying listings so users can inspect the source registry record.
+- Do not imply that ClawHub endorses, verifies, or operates the third-party site.
+- Do not mirror hidden, private, or moderation-blocked content by bypassing public API filters or auth boundaries.
+
 ## Auth
 
 - Public read: no token required.

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -13,6 +13,10 @@ All v1 paths are under `/api/v1/...` and implemented by Convex HTTP routes (`con
 Legacy `/api/...` and `/api/cli/...` remain for compatibility (see `DEPRECATIONS.md`).
 OpenAPI: `/api/v1/openapi.json`.
 
+## Public catalog reuse
+
+Third-party directories may use the public read endpoints to list or search ClawHub skills. Please cache results, honor `429`/`Retry-After`, link users back to the canonical ClawHub listing, and avoid implying ClawHub endorsement of the third-party site. Do not attempt to mirror hidden, private, or moderation-blocked content outside the public API surface.
+
 ## Rate limits
 
 Enforcement model:


### PR DESCRIPTION
## What problem was happening

ClawHub did not document whether a third-party site may list public ClawHub skills, leaving #1825 to be answered manually instead of through the API docs.

## Why this is the right fix

The public API already exposes read-only catalog and search endpoints. The docs should explain the expected reuse pattern: use public endpoints, cache responsibly, honor rate limits, link back to canonical ClawHub listings, and avoid implying endorsement or mirroring non-public content.

## What changed

- Added public catalog reuse guidance to `docs/api.md`.
- Added the same concise guidance to `docs/http-api.md` near the API overview.

## What did not change

- No rate limits, auth behavior, or API responses changed.
- This does not authorize bypassing private, hidden, or moderation-blocked content.
- Merging to `main` does not deploy production; production deploy remains a manual workflow.

## Validation

- `./node_modules/.bin/vitest run src/__tests__/skills-index.test.tsx src/__tests__/skills-index-load-more.test.tsx`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/oxlint --type-aware --tsconfig ./tsconfig.oxlint.json ./convex ./packages/clawhub/src ./packages/schema/src`
- `git diff --check`
- `./node_modules/.bin/tsc -p packages/clawhub/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc -p packages/schema/tsconfig.json --noEmit`
- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/vite build`
