### PR TITLE
fix: authenticate GitHub repository lookups

### DIFF
--- a/convex/lib/githubActionsOidc.test.ts
+++ b/convex/lib/githubActionsOidc.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   extractWorkflowFilenameFromWorkflowRef,
+  fetchGitHubRepositoryIdentity,
   verifyGitHubActionsTrustedPublishJwt,
   type TrustedGitHubActionsPublisher,
 } from "./githubActionsOidc";
@@ -38,6 +39,46 @@ describe("extractWorkflowFilenameFromWorkflowRef", () => {
         "openclaw/openclaw",
       ),
     ).toBe("plugin-clawhub-release.yml");
+  });
+});
+
+describe("fetchGitHubRepositoryIdentity", () => {
+  it("uses GITHUB_TOKEN for repository lookup when configured", async () => {
+    const previousToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = "ghs_test_token";
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        id: 123,
+        full_name: "openclaw/clawhub",
+        owner: { login: "openclaw", id: 456 },
+      }),
+    );
+
+    try {
+      await expect(fetchGitHubRepositoryIdentity("openclaw/clawhub", fetchMock)).resolves.toEqual({
+        repository: "openclaw/clawhub",
+        repositoryId: "123",
+        repositoryOwner: "openclaw",
+        repositoryOwnerId: "456",
+      });
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.GITHUB_TOKEN;
+      } else {
+        process.env.GITHUB_TOKEN = previousToken;
+      }
+    }
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/repos/openclaw/clawhub",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer ghs_test_token",
+          Accept: "application/vnd.github+json",
+          "User-Agent": "clawhub/package-trusted-publisher",
+        }),
+      }),
+    );
   });
 });
 

--- a/convex/lib/githubActionsOidc.ts
+++ b/convex/lib/githubActionsOidc.ts
@@ -217,10 +217,7 @@ export async function fetchGitHubRepositoryIdentity(
     throw new Error(`Invalid GitHub repository: ${repository}`);
   }
   const response = await fetchImpl(`https://api.github.com/repos/${normalizedRepository}`, {
-    headers: {
-      Accept: "application/vnd.github+json",
-      "User-Agent": "clawhub/package-trusted-publisher",
-    },
+    headers: buildGitHubRepositoryLookupHeaders(),
   });
   if (!response.ok) {
     throw new Error(
@@ -240,6 +237,18 @@ export async function fetchGitHubRepositoryIdentity(
     repositoryOwner: ownerLogin,
     repositoryOwnerId: requireClaimString(body.owner?.id, "owner.id"),
   };
+}
+
+function buildGitHubRepositoryLookupHeaders() {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "clawhub/package-trusted-publisher",
+  };
+  const token = process.env.GITHUB_TOKEN?.trim();
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
 }
 
 export function normalizeGitHubRepository(repository: string) {


### PR DESCRIPTION
## Summary

GitHub repository identity lookups used by the plugin trusted-publisher flow now send the deployment `GITHUB_TOKEN` when it is configured. That keeps the lookup aligned with the existing GitHub account-age check and avoids falling back to GitHub's much smaller anonymous API rate limit during publish/setup.

Refs #1820.

## What Changed

- Added shared headers for GitHub repository lookups, including `Accept`, `User-Agent`, and optional `Authorization`.
- Reused `GITHUB_TOKEN` as a bearer token when present, matching the repo's existing GitHub metadata lookup pattern.
- Added a regression test that proves repository identity fetches include the configured token and still parse the response.

## What Did Not Change

- This does not bypass GitHub ownership, account-age, or trusted-publisher checks.
- Deployments still need `GITHUB_TOKEN` configured for authenticated GitHub API access.
- Production deploys remain manual after merge.

## Validation

- `./node_modules/.bin/vitest run convex/lib/githubActionsOidc.test.ts convex/httpApiV1.handlers.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/oxlint --type-aware --tsconfig ./tsconfig.oxlint.json ./convex ./packages/clawhub/src ./packages/schema/src`
- `git diff --check`
- `./node_modules/.bin/tsc -p packages/clawhub/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc -p packages/schema/tsconfig.json --noEmit`
- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/vite build`
