### PR TITLE
fix: flag exposed secrets in skill docs

### DIFF
--- a/convex/lib/moderationEngine.test.ts
+++ b/convex/lib/moderationEngine.test.ts
@@ -23,7 +23,7 @@ describe("moderationEngine", () => {
     expect(result.status).toBe("clean");
   });
 
-  it("flags hardcoded API secrets in skill documentation and redacts evidence", () => {
+  it("flags hardcoded API secrets in skill documentation and redacts every evidence copy", () => {
     const exposedSecret = "ak_live_1234567890abcdefSECRET";
     const result = runStaticModerationScan({
       slug: "seo-admin",
@@ -38,7 +38,7 @@ describe("moderationEngine", () => {
           content: [
             "# SEO Admin",
             "Production endpoint: https://example.com/admin/api",
-            `API secret: ${exposedSecret}`,
+            `API secret: ${exposedSecret} # rotate ${exposedSecret}`,
           ].join("\n"),
         },
       ],
@@ -50,7 +50,7 @@ describe("moderationEngine", () => {
     expect(result.findings[0]?.evidence).not.toContain(exposedSecret);
   });
 
-  it("does not flag placeholder secret examples", () => {
+  it("does not flag placeholder or env-var secret examples", () => {
     const result = runStaticModerationScan({
       slug: "demo",
       displayName: "Demo",
@@ -61,7 +61,11 @@ describe("moderationEngine", () => {
       fileContents: [
         {
           path: "SKILL.md",
-          content: "Set `API secret: your-secret-here` before running the sample.",
+          content: [
+            "Set `API secret: your-secret-here` before running the sample.",
+            "const api_key = process.env.PROVIDER_API_KEY;",
+            "api_secret = os.environ['PROVIDER_API_SECRET']",
+          ].join("\n"),
         },
       ],
     });

--- a/convex/lib/moderationEngine.test.ts
+++ b/convex/lib/moderationEngine.test.ts
@@ -23,6 +23,53 @@ describe("moderationEngine", () => {
     expect(result.status).toBe("clean");
   });
 
+  it("flags hardcoded API secrets in skill documentation and redacts evidence", () => {
+    const exposedSecret = "ak_live_1234567890abcdefSECRET";
+    const result = runStaticModerationScan({
+      slug: "seo-admin",
+      displayName: "SEO Admin",
+      summary: "Manage production SEO content",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "SKILL.md", size: 256 }],
+      fileContents: [
+        {
+          path: "SKILL.md",
+          content: [
+            "# SEO Admin",
+            "Production endpoint: https://example.com/admin/api",
+            `API secret: ${exposedSecret}`,
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.exposed_secret_literal");
+    expect(result.status).toBe("suspicious");
+    expect(result.findings[0]?.evidence).toContain("[REDACTED]");
+    expect(result.findings[0]?.evidence).not.toContain(exposedSecret);
+  });
+
+  it("does not flag placeholder secret examples", () => {
+    const result = runStaticModerationScan({
+      slug: "demo",
+      displayName: "Demo",
+      summary: "A normal integration skill",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "SKILL.md", size: 128 }],
+      fileContents: [
+        {
+          path: "SKILL.md",
+          content: "Set `API secret: your-secret-here` before running the sample.",
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).not.toContain("suspicious.exposed_secret_literal");
+    expect(result.status).toBe("clean");
+  });
+
   it("flags dynamic eval usage as suspicious", () => {
     const result = runStaticModerationScan({
       slug: "demo",

--- a/convex/lib/moderationEngine.ts
+++ b/convex/lib/moderationEngine.ts
@@ -58,6 +58,10 @@ const HARDCODED_CONNECTION_ID_PATTERN =
   /["']connection_id["']\s*:\s*["'][0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}["']/i;
 const GOOGLE_SHEETS_SPREADSHEET_URL_PATTERN =
   /https?:\/\/[^\s"'`]*\/spreadsheets\/([A-Za-z0-9_-]{20,})\/[^\s"'`]*/i;
+const SECRET_ASSIGNMENT_PATTERN =
+  /\b(?:api[_\s-]?(?:secret|key)|secret[_\s-]?key|access[_\s-]?token|auth[_\s-]?token|bearer[_\s-]?token|password)\b\s*[:=]\s*["'`]?([A-Za-z0-9][A-Za-z0-9._~+/=-]{15,})["'`]?/i;
+const AUTH_HEADER_SECRET_PATTERN =
+  /\b(?:authorization|x-api-key|x-api-secret)\b\s*[:=]\s*(?:Bearer\s+)?["'`]?([A-Za-z0-9][A-Za-z0-9._~+/=-]{15,})["'`]?/i;
 
 function hasMaliciousInstallPrompt(content: string) {
   const hasTerminalInstruction =
@@ -85,6 +89,30 @@ function truncateEvidence(evidence: string, maxLen = 160) {
 
 function looksLikePlaceholderIdentifier(identifier: string) {
   return /^[A-Z0-9_]+$/.test(identifier) || /(your|example|placeholder)/i.test(identifier);
+}
+
+function looksLikePlaceholderSecret(secret: string) {
+  const normalized = secret.trim().toLowerCase();
+  if (!normalized) return true;
+  if (/^(?:x+|_+|-+|\*+|\.{3})$/.test(normalized)) return true;
+  return /(your|example|placeholder|change-?me|replace|redacted|dummy|sample|test-token|token-here|secret-here|api-key-here)/i.test(
+    normalized,
+  );
+}
+
+function findHardcodedSecret(content: string) {
+  const lines = content.split("\n");
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    const match = line.match(SECRET_ASSIGNMENT_PATTERN) ?? line.match(AUTH_HEADER_SECRET_PATTERN);
+    const secret = match?.[1];
+    if (!secret || looksLikePlaceholderSecret(secret)) continue;
+    return {
+      line: i + 1,
+      text: line.replace(secret, "[REDACTED]"),
+    };
+  }
+  return null;
 }
 
 function addFinding(
@@ -296,6 +324,18 @@ function scanCodeFile(
 
 function scanMarkdownFile(path: string, content: string, findings: ModerationFinding[]) {
   if (!MARKDOWN_EXTENSION.test(path)) return;
+
+  const secretMatch = findHardcodedSecret(content);
+  if (secretMatch) {
+    addFinding(findings, {
+      code: REASON_CODES.EXPOSED_SECRET_LITERAL,
+      severity: "critical",
+      file: path,
+      line: secretMatch.line,
+      message: "Documentation appears to expose a hardcoded API secret or token.",
+      evidence: secretMatch.text,
+    });
+  }
 
   if (hasMaliciousInstallPrompt(content)) {
     const match = findFirstLine(

--- a/convex/lib/moderationEngine.ts
+++ b/convex/lib/moderationEngine.ts
@@ -95,6 +95,7 @@ function looksLikePlaceholderSecret(secret: string) {
   const normalized = secret.trim().toLowerCase();
   if (!normalized) return true;
   if (/^(?:x+|_+|-+|\*+|\.{3})$/.test(normalized)) return true;
+  if (/process\.env\.|os\.environ[.[]|getenv\s*\(/.test(normalized)) return true;
   return /(your|example|placeholder|change-?me|replace|redacted|dummy|sample|test-token|token-here|secret-here|api-key-here)/i.test(
     normalized,
   );
@@ -109,7 +110,7 @@ function findHardcodedSecret(content: string) {
     if (!secret || looksLikePlaceholderSecret(secret)) continue;
     return {
       line: i + 1,
-      text: line.replace(secret, "[REDACTED]"),
+      text: line.replaceAll(secret, "[REDACTED]"),
     };
   }
   return null;

--- a/convex/lib/moderationReasonCodes.ts
+++ b/convex/lib/moderationReasonCodes.ts
@@ -12,13 +12,14 @@ export type ModerationFinding = {
   evidence: string;
 };
 
-export const MODERATION_ENGINE_VERSION = "v2.4.1";
+export const MODERATION_ENGINE_VERSION = "v2.4.2";
 
 export const REASON_CODES = {
   DANGEROUS_EXEC: "suspicious.dangerous_exec",
   DYNAMIC_CODE: "suspicious.dynamic_code_execution",
   GENERATED_SOURCE_TEMPLATE: "suspicious.generated_source_template_injection",
   EXPOSED_RESOURCE_IDENTIFIER: "suspicious.exposed_resource_identifier",
+  EXPOSED_SECRET_LITERAL: "suspicious.exposed_secret_literal",
   CREDENTIAL_HARVEST: "suspicious.env_credential_access",
   EXFILTRATION: "suspicious.potential_exfiltration",
   OBFUSCATED_CODE: "suspicious.obfuscated_code",

--- a/convex/skills.pendingScanQueue.test.ts
+++ b/convex/skills.pendingScanQueue.test.ts
@@ -9,6 +9,7 @@ import {
   getActiveSkillBatchForStaticScanBackfillInternal,
   getPendingScanSkillsInternal,
 } from "./skills";
+import { MODERATION_ENGINE_VERSION } from "./lib/moderationReasonCodes";
 
 type PendingScanResult = Array<{
   skillId: string;
@@ -279,7 +280,7 @@ describe("skills.getActiveSkillBatchForStaticScanBackfillInternal", () => {
         "skillVersions:current-static",
         {
           _id: "skillVersions:current-static",
-          staticScan: { engineVersion: "v2.4.1" },
+          staticScan: { engineVersion: MODERATION_ENGINE_VERSION },
         },
       ],
       [


### PR DESCRIPTION
## Summary

The static moderation scanner now detects production-looking hardcoded API secrets and tokens in skill documentation. When it records evidence, the detected secret value is redacted before being stored or displayed.

Refs #1760.

## What Changed

- Added a new static reason code: `suspicious.exposed_secret_literal`.
- Added markdown scanning for hardcoded secret assignments and auth header examples such as API secrets, API keys, bearer tokens, and access tokens.
- Added placeholder filtering so examples like `your-secret-here` remain clean.
- Redacted detected secret values from static-scan evidence.
- Bumped the moderation engine version to queue existing static scans for refresh.
- Updated the pending static-scan queue test to reference the current engine version instead of a hardcoded version string.

## What Did Not Change

- This does not remove or rewrite existing archived content.
- This does not contact affected publishers or rotate third-party credentials.
- This does not replace dedicated repository-wide secret scanners such as GitHub secret scanning, gitleaks, or truffleHog.
- Production deploys remain manual after merge.

## Validation

- `./node_modules/.bin/vitest run convex/lib/moderationEngine.test.ts`
- `./node_modules/.bin/vitest run convex/lib/moderationEngine.test.ts convex/skills.pendingScanQueue.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/oxlint --type-aware --tsconfig ./tsconfig.oxlint.json ./convex ./packages/clawhub/src ./packages/schema/src`
- `git diff --check`
- `./node_modules/.bin/tsc -p packages/clawhub/tsconfig.json --noEmit`
- `./node_modules/.bin/tsc -p packages/schema/tsconfig.json --noEmit`
- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/vite build`
