### PR TITLE
fix: address shadcn primitive review feedback

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -20,9 +20,13 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-const CommandDialog = ({ children, ...props }: React.ComponentProps<typeof Dialog>) => (
+const CommandDialog = ({
+  children,
+  showCloseButton = false,
+  ...props
+}: React.ComponentProps<typeof Dialog> & { showCloseButton?: boolean }) => (
   <Dialog {...props}>
-    <DialogContent className="overflow-hidden p-0">
+    <DialogContent className="overflow-hidden p-0" showCloseButton={showCloseButton}>
       <Command>{children}</Command>
     </DialogContent>
   </Dialog>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -17,7 +17,7 @@ const DialogOverlay = React.forwardRef<
     ref={ref}
     className={cn(
       // Matches .report-dialog-backdrop
-      "fixed inset-0 z-80 grid place-items-center bg-overlay-bg p-5 backdrop-blur-[3px]",
+      "fixed inset-0 z-80 bg-overlay-bg backdrop-blur-[3px]",
       "data-[state=open]:animate-in data-[state=open]:fade-in-0",
       "data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
       className,

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -63,8 +63,8 @@ const ToggleGroupItem = React.forwardRef<
     <ToggleGroupPrimitive.Item
       ref={ref}
       data-slot="toggle-group-item"
-      data-variant={context.variant ?? variant}
-      data-size={context.size ?? size}
+      data-variant={variant ?? context.variant}
+      data-size={size ?? context.size}
       className={cn(
         toggleGroupItemVariants({
           variant: variant ?? context.variant,


### PR DESCRIPTION
## Summary
- forward `showCloseButton` through `CommandDialog` and default command palettes to no visible close button
- align toggle group item `data-*` precedence with its variant class precedence
- remove inert layout utilities from the dialog overlay

## Validation
- `bunx tsc --noEmit --pretty false`
- `bun run lint`
- `bun run test`
- `bun run build`
