### PR TITLE
fix(ui): use download icon for public skill stats

### DIFF
--- a/src/components/SkillListItem.tsx
+++ b/src/components/SkillListItem.tsx
@@ -1,11 +1,11 @@
 import { Link } from "@tanstack/react-router";
 import { ArrowDownToLine, Star } from "lucide-react";
-import { MarketplaceIcon } from "./MarketplaceIcon";
-import { Badge } from "./ui/badge";
 import { getSkillBadges } from "../lib/badges";
 import { formatCompactStat } from "../lib/numberFormat";
 import type { PublicPublisher, PublicSkill } from "../lib/publicUser";
 import { timeAgo } from "../lib/timeAgo";
+import { MarketplaceIcon } from "./MarketplaceIcon";
+import { Badge } from "./ui/badge";
 
 type SkillListItemProps = {
   skill: PublicSkill;

--- a/src/components/SkillListItem.tsx
+++ b/src/components/SkillListItem.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { Package, Star } from "lucide-react";
+import { ArrowDownToLine, Star } from "lucide-react";
 import { MarketplaceIcon } from "./MarketplaceIcon";
 import { Badge } from "./ui/badge";
 import { getSkillBadges } from "../lib/badges";
@@ -44,7 +44,8 @@ export function SkillListItem({ skill, ownerHandle, owner }: SkillListItemProps)
             <Star size={14} aria-hidden="true" /> {formatCompactStat(skill.stats.stars)}
           </span>
           <span className="skill-list-item-meta-item">
-            <Package size={14} aria-hidden="true" /> {formatCompactStat(skill.stats.downloads)}
+            <ArrowDownToLine size={14} aria-hidden="true" />{" "}
+            {formatCompactStat(skill.stats.downloads)}
           </span>
         </div>
       </div>

--- a/src/components/SkillStats.tsx
+++ b/src/components/SkillStats.tsx
@@ -1,4 +1,4 @@
-import { Package } from "lucide-react";
+import { ArrowDownToLine } from "lucide-react";
 import { formatSkillStatsTriplet, type SkillStatsTriplet } from "../lib/numberFormat";
 
 type SkillMetricsStats = SkillStatsTriplet & {
@@ -9,7 +9,8 @@ export function SkillStatsTripletLine({ stats }: { stats: SkillStatsTriplet }) {
   const formatted = formatSkillStatsTriplet(stats);
   return (
     <>
-      ⭐ {formatted.stars} · <Package size={13} aria-hidden="true" /> {formatted.downloads}
+      ⭐ {formatted.stars} · <ArrowDownToLine size={13} aria-hidden="true" />{" "}
+      {formatted.downloads}
     </>
   );
 }
@@ -19,7 +20,7 @@ export function SkillMetricsRow({ stats }: { stats: SkillMetricsStats }) {
   return (
     <>
       <span className="inline-flex w-14 items-center justify-end gap-1 tabular-nums">
-        <Package size={13} aria-hidden="true" /> {formatted.downloads}
+        <ArrowDownToLine size={13} aria-hidden="true" /> {formatted.downloads}
       </span>
       <span className="inline-flex w-14 items-center justify-end gap-1 tabular-nums">
         ★ {formatted.stars}

--- a/src/components/SkillStats.tsx
+++ b/src/components/SkillStats.tsx
@@ -9,8 +9,7 @@ export function SkillStatsTripletLine({ stats }: { stats: SkillStatsTriplet }) {
   const formatted = formatSkillStatsTriplet(stats);
   return (
     <>
-      ⭐ {formatted.stars} · <ArrowDownToLine size={13} aria-hidden="true" />{" "}
-      {formatted.downloads}
+      ⭐ {formatted.stars} · <ArrowDownToLine size={13} aria-hidden="true" /> {formatted.downloads}
     </>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #1534 by using the same semantic download icon on public skill stats that the publisher dashboard already uses.

## What changed

- Replaced the package/box icon with `ArrowDownToLine` for public skill download counts in the skill header.
- Updated shared public skill stats rows and skill list items to use the same download icon.

## What did not change

- No stat calculations, labels, or layout behavior changed.
- The package icon remains available for package/version concepts elsewhere.

## Validation

- `git diff --check`
- `./node_modules/.bin/tsc -p packages/clawhub/tsconfig.json --noEmit`

