### PR TITLE
feat(cli): show skill moderation in inspect

### DIFF
--- a/packages/clawhub/src/cli/commands/inspect.test.ts
+++ b/packages/clawhub/src/cli/commands/inspect.test.ts
@@ -132,6 +132,80 @@ describe("cmdInspect", () => {
     expect(mockLog).toHaveBeenCalledWith("Model: gpt-5.2");
   });
 
+  it("prints skill moderation status without requiring a version fetch", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      skill: {
+        slug: "demo",
+        displayName: "Demo",
+        summary: null,
+        tags: { latest: "2.0.0" },
+        stats: {},
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      latestVersion: { version: "2.0.0", createdAt: 3, changelog: "init", license: "MIT-0" },
+      owner: null,
+      moderation: {
+        isSuspicious: true,
+        isMalwareBlocked: false,
+        verdict: "suspicious",
+        reasonCodes: ["network-send", "credential-pattern"],
+        updatedAt: 1_700_000_000_000,
+        engineVersion: "scanner-v2",
+        summary: "Found credential-like configuration and outbound network behavior.",
+      },
+    });
+
+    await cmdInspect(makeGlobalOpts(), "demo");
+
+    expect(httpMocks.apiRequest).toHaveBeenCalledTimes(1);
+    expect(mockLog).toHaveBeenCalledWith("Moderation: SUSPICIOUS");
+    expect(mockLog).toHaveBeenCalledWith("Reasons: network-send, credential-pattern");
+    expect(mockLog).toHaveBeenCalledWith("Moderation Updated: 2023-11-14T22:13:20.000Z");
+    expect(mockLog).toHaveBeenCalledWith("Moderation Engine: scanner-v2");
+    expect(mockLog).toHaveBeenCalledWith(
+      "Moderation Summary: Found credential-like configuration and outbound network behavior.",
+    );
+  });
+
+  it("includes moderation metadata in inspect JSON output", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      skill: {
+        slug: "demo",
+        displayName: "Demo",
+        summary: null,
+        tags: {},
+        stats: {},
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      latestVersion: null,
+      owner: null,
+      moderation: {
+        isSuspicious: false,
+        isMalwareBlocked: false,
+        verdict: "clean",
+        reasonCodes: [],
+        updatedAt: null,
+        engineVersion: null,
+        summary: null,
+      },
+    });
+
+    await cmdInspect(makeGlobalOpts(), "demo", { json: true });
+
+    const output = JSON.parse(String(mockLog.mock.calls[0]?.[0]));
+    expect(output.moderation).toEqual({
+      isSuspicious: false,
+      isMalwareBlocked: false,
+      verdict: "clean",
+      reasonCodes: [],
+      updatedAt: null,
+      engineVersion: null,
+      summary: null,
+    });
+  });
+
   it("rejects when both version and tag are provided", async () => {
     await expect(
       cmdInspect(makeGlobalOpts(), "demo", { version: "1.0.0", tag: "latest" }),

--- a/packages/clawhub/src/cli/commands/inspect.ts
+++ b/packages/clawhub/src/cli/commands/inspect.ts
@@ -36,6 +36,16 @@ type SecurityStatus = {
   model: string | null;
 };
 
+type ModerationStatus = {
+  isSuspicious: boolean;
+  isMalwareBlocked: boolean;
+  verdict?: "clean" | "suspicious" | "malicious";
+  reasonCodes?: string[];
+  updatedAt?: number | null;
+  engineVersion?: string | null;
+  summary?: string | null;
+};
+
 export async function cmdInspect(opts: GlobalOpts, slug: string, options: InspectOptions = {}) {
   const trimmed = slug.trim();
   if (!trimmed) fail("Slug required");
@@ -121,6 +131,7 @@ export async function cmdInspect(opts: GlobalOpts, slug: string, options: Inspec
       skill: skillResult.skill,
       latestVersion: skillResult.latestVersion,
       owner: skillResult.owner,
+      moderation: skillResult.moderation ?? null,
       version: versionResult?.version ?? null,
       versions: versionsList?.items ?? null,
       file: options.file ? { path: options.file, content: fileContent } : null,
@@ -140,6 +151,7 @@ export async function cmdInspect(opts: GlobalOpts, slug: string, options: Inspec
           (versionResult?.version as { license?: string | null } | undefined)?.license ?? null,
         owner: skillResult.owner,
       });
+      printModerationSummary(skillResult.moderation ?? null);
     }
 
     if (shouldPrintMeta && versionResult?.version) {
@@ -234,6 +246,60 @@ function printVersionSummary(version: unknown) {
   if (typeof entry.changelog === "string" && entry.changelog.trim()) {
     console.log(`Changelog: ${truncate(entry.changelog, 120)}`);
   }
+}
+
+function printModerationSummary(moderation: unknown) {
+  const status = normalizeModeration(moderation);
+  if (!status) return;
+  const label = status.isMalwareBlocked
+    ? "MALICIOUS"
+    : status.isSuspicious
+      ? "SUSPICIOUS"
+      : (status.verdict ?? "clean").toUpperCase();
+  console.log(`Moderation: ${label}`);
+  if (status.reasonCodes?.length) {
+    console.log(`Reasons: ${status.reasonCodes.join(", ")}`);
+  }
+  if (typeof status.updatedAt === "number") {
+    console.log(`Moderation Updated: ${formatTimestamp(status.updatedAt)}`);
+  }
+  if (status.engineVersion) {
+    console.log(`Moderation Engine: ${status.engineVersion}`);
+  }
+  if (status.summary) {
+    console.log(`Moderation Summary: ${truncate(status.summary, 160)}`);
+  }
+}
+
+function normalizeModeration(moderation: unknown): ModerationStatus | null {
+  if (!moderation || typeof moderation !== "object") return null;
+  const value = moderation as {
+    isSuspicious?: unknown;
+    isMalwareBlocked?: unknown;
+    verdict?: unknown;
+    reasonCodes?: unknown;
+    updatedAt?: unknown;
+    engineVersion?: unknown;
+    summary?: unknown;
+  };
+  if (typeof value.isSuspicious !== "boolean") return null;
+  if (typeof value.isMalwareBlocked !== "boolean") return null;
+  const verdict =
+    value.verdict === "clean" || value.verdict === "suspicious" || value.verdict === "malicious"
+      ? value.verdict
+      : undefined;
+  const reasonCodes = Array.isArray(value.reasonCodes)
+    ? value.reasonCodes.filter((reason): reason is string => typeof reason === "string")
+    : undefined;
+  return {
+    isSuspicious: value.isSuspicious,
+    isMalwareBlocked: value.isMalwareBlocked,
+    verdict,
+    reasonCodes,
+    updatedAt: typeof value.updatedAt === "number" ? value.updatedAt : null,
+    engineVersion: typeof value.engineVersion === "string" ? value.engineVersion : null,
+    summary: typeof value.summary === "string" && value.summary.trim() ? value.summary : null,
+  };
 }
 
 function normalizeTags(tags: unknown): Record<string, string> {

--- a/packages/clawhub/src/schema/schemas.ts
+++ b/packages/clawhub/src/schema/schemas.ts
@@ -251,6 +251,14 @@ export const ApiV1SkillVersionResponseSchema = type({
     changelogSource: '"auto"|"user"|null?',
     license: '"MIT-0"|null?',
     files: "unknown?",
+    security: type({
+      status: '"clean"|"suspicious"|"malicious"|"pending"|"error"',
+      hasWarnings: "boolean",
+      checkedAt: "number|null?",
+      model: "string|null?",
+    })
+      .or("null")
+      .optional(),
   }).or("null"),
   skill: type({
     slug: "string",


### PR DESCRIPTION
## Summary

Fixes #1483 by making `clawhub inspect <slug>` show the skill-level moderation/security status returned by the v1 skill detail API, without requiring a separate version fetch. JSON output now also preserves the `moderation` block so scripts can filter for clean/suspicious/malicious skills.

## What changed

- Print moderation verdict, reason codes, update timestamp, engine version, and summary in plain `clawhub inspect` output.
- Include `moderation` in `--json` inspect output.
- Allow version-level `security` metadata through the CLI schema so existing version security output remains typed.
- Added regression tests for plain inspect output and JSON output.

## What did not change

- This does not add install-time filtering or automatic benign-only install selection.
- This does not change backend moderation or scanner behavior.

## Validation

- `git diff --check`
- `./node_modules/.bin/tsc -p packages/clawhub/tsconfig.json --noEmit`
- `../../node_modules/.bin/vitest run -c vitest.config.ts src/cli/commands/inspect.test.ts`

