### PR TITLE
fix(cli): preserve root skill manifest during publish

### DIFF
--- a/packages/clawhub/src/cli/commands/publish.test.ts
+++ b/packages/clawhub/src/cli/commands/publish.test.ts
@@ -114,6 +114,42 @@ describe("cmdPublish", () => {
     }
   });
 
+  it("still publishes a root SKILL.md hidden by broad ignore patterns", async () => {
+    const workdir = await makeTmpWorkdir();
+    try {
+      const folder = join(workdir, "ignored-manifest");
+      await mkdir(folder, { recursive: true });
+      await writeFile(join(folder, ".gitignore"), "*.md\n", "utf8");
+      await writeFile(join(folder, "SKILL.md"), "# Skill\n", "utf8");
+      await writeFile(join(folder, "notes.md"), "ignored notes\n", "utf8");
+
+      httpMocks.apiRequestForm.mockResolvedValueOnce({
+        ok: true,
+        skillId: "skill_1",
+        versionId: "ver_1",
+      });
+
+      await cmdPublish(makeOpts(workdir), "ignored-manifest", {
+        slug: "ignored-manifest",
+        name: "Ignored Manifest",
+        version: "1.0.0",
+        changelog: "",
+        tags: "latest",
+      });
+
+      const publishCall = httpMocks.apiRequestForm.mock.calls.find((call) => {
+        const req = call[1] as { path?: string } | undefined;
+        return req?.path === "/api/v1/skills";
+      });
+      if (!publishCall) throw new Error("Missing publish call");
+      const publishForm = (publishCall[1] as { form?: FormData }).form as FormData;
+      const files = publishForm.getAll("files") as Array<Blob & { name?: string }>;
+      expect(files.map((file) => file.name ?? "")).toEqual(["SKILL.md"]);
+    } finally {
+      await rm(workdir, { recursive: true, force: true });
+    }
+  });
+
   it('rejects plugin folders with guidance to use "clawhub package publish"', async () => {
     const workdir = await makeTmpWorkdir();
     try {

--- a/packages/clawhub/src/cli/commands/publish.ts
+++ b/packages/clawhub/src/cli/commands/publish.ts
@@ -1,4 +1,4 @@
-import { readFile, stat } from "node:fs/promises";
+import { readFile, readdir, stat } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 import semver from "semver";
 import { apiRequestForm } from "../../http.js";
@@ -52,7 +52,7 @@ export async function cmdPublish(
 
   const spinner = createSpinner(`Preparing ${slug}@${version}`);
   try {
-    const filesOnDisk = await listTextFiles(folder);
+    const filesOnDisk = await ensureRootManifestFile(folder, await listTextFiles(folder));
     if (filesOnDisk.length === 0) fail("No files found");
     if (
       !filesOnDisk.some((file) => {
@@ -97,6 +97,36 @@ export async function cmdPublish(
     spinner.fail(formatError(error));
     throw error;
   }
+}
+
+async function ensureRootManifestFile(
+  folder: string,
+  files: Awaited<ReturnType<typeof listTextFiles>>,
+) {
+  if (
+    files.some((file) => {
+      const lower = file.relPath.toLowerCase();
+      return lower === "skill.md" || lower === "skills.md";
+    })
+  ) {
+    return files;
+  }
+
+  const entries = await readdir(folder, { withFileTypes: true }).catch(() => []);
+  const manifest = entries.find((entry) => {
+    const lower = entry.name.toLowerCase();
+    return entry.isFile() && (lower === "skill.md" || lower === "skills.md");
+  });
+  if (!manifest) return files;
+
+  return [
+    ...files,
+    {
+      relPath: manifest.name,
+      bytes: new Uint8Array(await readFile(join(folder, manifest.name))),
+      contentType: "text/markdown",
+    },
+  ];
 }
 
 async function looksLikePluginFolder(folder: string) {


### PR DESCRIPTION
## Summary

Fixes #1509 by ensuring `clawhub publish` still includes a root `SKILL.md` or `SKILLS.md` manifest when broad ignore rules hide markdown files from the normal text-file walk.

## What changed

- After normal file discovery, publish now checks for a root manifest if no manifest was discovered.
- If present, the root manifest is added back to the upload as `text/markdown`.
- Added a regression test for a skill folder with `.gitignore` containing `*.md`, where `SKILL.md` must still publish but other ignored markdown stays ignored.

## What did not change

- This does not bypass plugin-folder detection.
- This does not change backend publish validation.
- This only recovers the required root manifest, not arbitrary ignored files.

## Validation

- `git diff --check`
- `./node_modules/.bin/tsc -p packages/clawhub/tsconfig.json --noEmit`
- `../../node_modules/.bin/vitest run -c vitest.config.ts src/cli/commands/publish.test.ts`

