### PR TITLE
fix(ui): resolve relative skill README links

### DIFF
--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -570,7 +570,7 @@ export const softDeleteSkillVersionsInternal = internalMutation({
     const deleted: string[] = [];
     const skipped: Array<{ versionId: string; reason: string }> = [];
 
-    for (const versionId of [...new Set(args.versionIds)]) {
+    for (const versionId of new Set(args.versionIds)) {
       const version = await ctx.db.get(versionId);
       if (!version || version.skillId !== skill._id) {
         skipped.push({ versionId, reason: "missing_or_wrong_skill" });

--- a/src/components/SkillDetailTabs.test.tsx
+++ b/src/components/SkillDetailTabs.test.tsx
@@ -48,12 +48,8 @@ describe("SkillDetailTabs README markdown links", () => {
     const link = container.querySelector("a");
     const image = container.querySelector("img");
 
-    expect(link?.getAttribute("href")).toBe(
-      "/api/v1/skills/demo-skill/file?path=docs%2Fusage.md",
-    );
-    expect(image?.getAttribute("src")).toBe(
-      "/api/v1/skills/demo-skill/file?path=img%2Flogo.png",
-    );
+    expect(link?.getAttribute("href")).toBe("/api/v1/skills/demo-skill/file?path=docs%2Fusage.md");
+    expect(image?.getAttribute("src")).toBe("/api/v1/skills/demo-skill/file?path=img%2Flogo.png");
   });
 
   it("preserves safe non-file references and sanitizes traversal", () => {

--- a/src/components/SkillDetailTabs.test.tsx
+++ b/src/components/SkillDetailTabs.test.tsx
@@ -1,51 +1,79 @@
 /* @vitest-environment jsdom */
 
-import { render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { Doc } from "../../convex/_generated/dataModel";
 import { SkillDetailTabs } from "./SkillDetailTabs";
+
+vi.mock("./SkillVersionsPanel", () => ({
+  SkillVersionsPanel: () => <div />,
+}));
+
+const skill = {
+  _creationTime: 0,
+  _id: "skills:1",
+  badges: {},
+  createdAt: 0,
+  displayName: "Demo",
+  ownerUserId: "users:1",
+  slug: "demo-skill",
+  stats: {},
+  tags: {},
+  updatedAt: 0,
+} as unknown as Doc<"skills">;
 
 function renderReadme(readmeContent: string) {
   return render(
     <SkillDetailTabs
       activeTab="readme"
-      setActiveTab={vi.fn()}
-      onCompareIntent={vi.fn()}
-      readmeContent={readmeContent}
-      readmeError={null}
+      diffVersions={undefined}
       latestFiles={[]}
       latestVersionId={null}
-      skill={{ slug: "api-gateway" } as Doc<"skills">}
-      diffVersions={[]}
-      versions={[]}
       nixPlugin={false}
-      suppressVersionScanResults={false}
+      onCompareIntent={() => undefined}
+      readmeContent={readmeContent}
+      readmeError={null}
       scanResultsSuppressedMessage={null}
+      setActiveTab={() => undefined}
+      skill={skill}
+      suppressVersionScanResults={false}
+      versions={undefined}
     />,
-  );
+  ).container;
 }
 
-describe("SkillDetailTabs README links", () => {
-  it("keeps relative skill README links inside the viewed skill", () => {
-    const { container } = renderReadme(
-      [
-        "[Google Mail](references/google-mail/README.md)",
-        "[External](https://example.com/docs)",
-        "[Usage](#usage)",
-        "[Traversal](../references/README.md)",
-      ].join("\n\n"),
-    );
+describe("SkillDetailTabs README markdown links", () => {
+  it("rewrites relative README links and images to skill file URLs", () => {
+    const container = renderReadme("[Usage](docs/usage.md) ![Logo](img/logo.png)");
+    const link = container.querySelector("a");
+    const image = container.querySelector("img");
 
-    expect(screen.getByRole("link", { name: "Google Mail" }).getAttribute("href")).toBe(
-      "/api/v1/skills/api-gateway/file?path=references%2Fgoogle-mail%2FREADME.md",
+    expect(link?.getAttribute("href")).toBe(
+      "/api/v1/skills/demo-skill/file?path=docs%2Fusage.md",
     );
-    expect(screen.getByRole("link", { name: "External" }).getAttribute("href")).toBe(
-      "https://example.com/docs",
+    expect(image?.getAttribute("src")).toBe(
+      "/api/v1/skills/demo-skill/file?path=img%2Flogo.png",
     );
-    expect(screen.getByRole("link", { name: "Usage" }).getAttribute("href")).toBe("#usage");
-    const traversal = Array.from(container.querySelectorAll("a")).find(
-      (link) => link.textContent === "Traversal",
+  });
+
+  it("preserves safe non-file references and sanitizes traversal", () => {
+    const container = renderReadme(
+      [
+        "[External](https://example.com)",
+        "[Mail](mailto:security@example.com)",
+        "[Phone](tel:+15555550100)",
+        "[Anchor](#usage)",
+        "[Secret](../secret.md)",
+      ].join(" "),
     );
-    expect(traversal?.getAttribute("href")).toBe("");
+    const links = Array.from(container.querySelectorAll("a"));
+
+    expect(links.map((link) => link.getAttribute("href"))).toEqual([
+      "https://example.com",
+      "mailto:security@example.com",
+      "tel:+15555550100",
+      "#usage",
+      "",
+    ]);
   });
 });

--- a/src/components/SkillDetailTabs.tsx
+++ b/src/components/SkillDetailTabs.tsx
@@ -1,9 +1,13 @@
-import { lazy, Suspense } from "react";
-import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
+import { lazy, Suspense, useMemo } from "react";
+import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import type { PluggableList } from "unified";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
 import { rehypeProxyImages } from "../lib/rehypeProxyImages";
-import { resolveSkillReadmeHref } from "../lib/skillReadmeLinks";
+import {
+  remarkSkillReadmeLinks,
+  sanitizeRenderedSkillReadmeUrl,
+} from "../lib/skillReadmeLinks";
 import { SkillVersionsPanel } from "./SkillVersionsPanel";
 
 const REHYPE_PLUGINS = [rehypeProxyImages];
@@ -52,6 +56,13 @@ export function SkillDetailTabs({
   scanResultsSuppressedMessage,
 }: SkillDetailTabsProps) {
   const compareEnabled = (versions?.length ?? 0) > 1;
+  const readmeRemarkPlugins = useMemo<PluggableList>(
+    () => [
+      remarkGfm,
+      [remarkSkillReadmeLinks, { readmePath: "SKILL.md", skillSlug: skill.slug }],
+    ],
+    [skill.slug],
+  );
 
   return (
     <div className="card tab-card">
@@ -101,13 +112,9 @@ export function SkillDetailTabs({
           {readmeContent ? (
             <div className="markdown">
               <ReactMarkdown
-                remarkPlugins={[remarkGfm]}
+                remarkPlugins={readmeRemarkPlugins}
                 rehypePlugins={REHYPE_PLUGINS}
-                urlTransform={(url, key) =>
-                  key === "href"
-                    ? resolveSkillReadmeHref(url, skill.slug)
-                    : defaultUrlTransform(url)
-                }
+                urlTransform={sanitizeRenderedSkillReadmeUrl}
               >
                 {readmeContent}
               </ReactMarkdown>

--- a/src/components/SkillDetailTabs.tsx
+++ b/src/components/SkillDetailTabs.tsx
@@ -4,10 +4,7 @@ import remarkGfm from "remark-gfm";
 import type { PluggableList } from "unified";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
 import { rehypeProxyImages } from "../lib/rehypeProxyImages";
-import {
-  remarkSkillReadmeLinks,
-  sanitizeRenderedSkillReadmeUrl,
-} from "../lib/skillReadmeLinks";
+import { remarkSkillReadmeLinks, sanitizeRenderedSkillReadmeUrl } from "../lib/skillReadmeLinks";
 import { SkillVersionsPanel } from "./SkillVersionsPanel";
 
 const REHYPE_PLUGINS = [rehypeProxyImages];
@@ -57,10 +54,7 @@ export function SkillDetailTabs({
 }: SkillDetailTabsProps) {
   const compareEnabled = (versions?.length ?? 0) > 1;
   const readmeRemarkPlugins = useMemo<PluggableList>(
-    () => [
-      remarkGfm,
-      [remarkSkillReadmeLinks, { readmePath: "SKILL.md", skillSlug: skill.slug }],
-    ],
+    () => [remarkGfm, [remarkSkillReadmeLinks, { readmePath: "SKILL.md", skillSlug: skill.slug }]],
     [skill.slug],
   );
 

--- a/src/lib/skillReadmeLinks.test.ts
+++ b/src/lib/skillReadmeLinks.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  rewriteSkillReadmeMarkdownUrl,
-  sanitizeRenderedSkillReadmeUrl,
-} from "./skillReadmeLinks";
+import { rewriteSkillReadmeMarkdownUrl, sanitizeRenderedSkillReadmeUrl } from "./skillReadmeLinks";
 
 const options = { readmePath: "SKILL.md", skillSlug: "demo-skill" };
 
@@ -38,9 +35,7 @@ describe("rewriteSkillReadmeMarkdownUrl", () => {
     expect(rewriteSkillReadmeMarkdownUrl("mailto:security@example.com", options)).toBe(
       "mailto:security@example.com",
     );
-    expect(rewriteSkillReadmeMarkdownUrl("tel:+15555550100", options)).toBe(
-      "tel:+15555550100",
-    );
+    expect(rewriteSkillReadmeMarkdownUrl("tel:+15555550100", options)).toBe("tel:+15555550100");
     expect(rewriteSkillReadmeMarkdownUrl("#usage", options)).toBe("#usage");
   });
 

--- a/src/lib/skillReadmeLinks.test.ts
+++ b/src/lib/skillReadmeLinks.test.ts
@@ -1,28 +1,69 @@
 import { describe, expect, it } from "vitest";
-import { resolveSkillReadmeHref } from "./skillReadmeLinks";
+import {
+  rewriteSkillReadmeMarkdownUrl,
+  sanitizeRenderedSkillReadmeUrl,
+} from "./skillReadmeLinks";
 
-describe("resolveSkillReadmeHref", () => {
-  it("routes safe relative README links through the skill file API", () => {
-    expect(resolveSkillReadmeHref("references/google-mail/README.md", "api-gateway")).toBe(
-      "/api/v1/skills/api-gateway/file?path=references%2Fgoogle-mail%2FREADME.md",
+const options = { readmePath: "SKILL.md", skillSlug: "demo-skill" };
+
+describe("rewriteSkillReadmeMarkdownUrl", () => {
+  it("rewrites README-relative links to the skill file endpoint", () => {
+    expect(rewriteSkillReadmeMarkdownUrl("docs/usage.md", options)).toBe(
+      "/api/v1/skills/demo-skill/file?path=docs%2Fusage.md",
     );
-    expect(resolveSkillReadmeHref("./docs/Usage Guide.md#setup", "api-gateway")).toBe(
-      "/api/v1/skills/api-gateway/file?path=docs%2FUsage%20Guide.md#setup",
+    expect(rewriteSkillReadmeMarkdownUrl("./img/logo.svg", options)).toBe(
+      "/api/v1/skills/demo-skill/file?path=img%2Flogo.svg",
     );
   });
 
-  it("preserves external, root, hash, and query links", () => {
-    expect(resolveSkillReadmeHref("https://example.com/docs", "api-gateway")).toBe(
+  it("resolves links relative to a nested README path", () => {
+    expect(
+      rewriteSkillReadmeMarkdownUrl("images/logo.png", {
+        readmePath: "docs/SKILL.md",
+        skillSlug: "demo-skill",
+      }),
+    ).toBe("/api/v1/skills/demo-skill/file?path=docs%2Fimages%2Flogo.png");
+  });
+
+  it("keeps fragment anchors on rewritten document links", () => {
+    expect(rewriteSkillReadmeMarkdownUrl("docs/usage.md#setup", options)).toBe(
+      "/api/v1/skills/demo-skill/file?path=docs%2Fusage.md#setup",
+    );
+  });
+
+  it("preserves absolute URLs, mail, phone, and hash-only anchors", () => {
+    expect(rewriteSkillReadmeMarkdownUrl("https://example.com/docs", options)).toBe(
       "https://example.com/docs",
     );
-    expect(resolveSkillReadmeHref("/plugins?q=mail", "api-gateway")).toBe("/plugins?q=mail");
-    expect(resolveSkillReadmeHref("#usage", "api-gateway")).toBe("#usage");
-    expect(resolveSkillReadmeHref("?tab=files", "api-gateway")).toBe("?tab=files");
+    expect(rewriteSkillReadmeMarkdownUrl("mailto:security@example.com", options)).toBe(
+      "mailto:security@example.com",
+    );
+    expect(rewriteSkillReadmeMarkdownUrl("tel:+15555550100", options)).toBe(
+      "tel:+15555550100",
+    );
+    expect(rewriteSkillReadmeMarkdownUrl("#usage", options)).toBe("#usage");
   });
 
-  it("rejects traversal and unsafe protocols", () => {
-    expect(resolveSkillReadmeHref("../other-skill/README.md", "api-gateway")).toBe("");
-    expect(resolveSkillReadmeHref("%2e%2e/other-skill/README.md", "api-gateway")).toBe("");
-    expect(resolveSkillReadmeHref("javascript:alert(1)", "api-gateway")).toBe("");
+  it("sanitizes traversal, root-absolute, backslash, and unsafe scheme targets", () => {
+    expect(rewriteSkillReadmeMarkdownUrl("../secret.md", options)).toBeNull();
+    expect(rewriteSkillReadmeMarkdownUrl("%2e%2e/secret.md", options)).toBeNull();
+    expect(rewriteSkillReadmeMarkdownUrl("/secret.md", options)).toBeNull();
+    expect(rewriteSkillReadmeMarkdownUrl("docs\\secret.md", options)).toBeNull();
+    expect(rewriteSkillReadmeMarkdownUrl("javascript:alert(1)", options)).toBeNull();
+  });
+});
+
+describe("sanitizeRenderedSkillReadmeUrl", () => {
+  it("allows rewritten site paths, safe schemes, and hash anchors", () => {
+    expect(sanitizeRenderedSkillReadmeUrl("/api/v1/skills/demo/file?path=SKILL.md")).toBe(
+      "/api/v1/skills/demo/file?path=SKILL.md",
+    );
+    expect(sanitizeRenderedSkillReadmeUrl("tel:+15555550100")).toBe("tel:+15555550100");
+    expect(sanitizeRenderedSkillReadmeUrl("#usage")).toBe("#usage");
+  });
+
+  it("removes unrewritten relative paths and unsafe schemes", () => {
+    expect(sanitizeRenderedSkillReadmeUrl("docs/usage.md")).toBe("");
+    expect(sanitizeRenderedSkillReadmeUrl("javascript:alert(1)")).toBe("");
   });
 });

--- a/src/lib/skillReadmeLinks.ts
+++ b/src/lib/skillReadmeLinks.ts
@@ -1,59 +1,108 @@
-import { defaultUrlTransform } from "react-markdown";
+import type { Root } from "mdast";
+import { visit } from "unist-util-visit";
 
-const ABSOLUTE_OR_ROOT_HREF = /^(?:[a-z][a-z0-9+.-]*:|\/\/|\/|#|\?)/i;
+type SkillReadmeLinkOptions = {
+  readmePath?: string;
+  skillSlug: string;
+};
 
-function splitFragment(href: string) {
-  const hashIndex = href.indexOf("#");
-  if (hashIndex === -1) return { path: href, fragment: "" };
+type MarkdownUrlNode = {
+  type: string;
+  url: string;
+};
+
+const ALLOWED_ABSOLUTE_SCHEMES = new Set(["http:", "https:", "mailto:", "tel:"]);
+const SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+
+function isMarkdownUrlNode(node: unknown): node is MarkdownUrlNode {
+  if (!node || typeof node !== "object") return false;
+  const maybeNode = node as { type?: unknown; url?: unknown };
+  return (
+    (maybeNode.type === "definition" ||
+      maybeNode.type === "image" ||
+      maybeNode.type === "link") &&
+    typeof maybeNode.url === "string"
+  );
+}
+
+function splitReference(reference: string) {
+  const hashIndex = reference.indexOf("#");
+  const beforeHash = hashIndex >= 0 ? reference.slice(0, hashIndex) : reference;
+  const hash = hashIndex >= 0 ? reference.slice(hashIndex) : "";
+  const queryIndex = beforeHash.indexOf("?");
   return {
-    path: href.slice(0, hashIndex),
-    fragment: href.slice(hashIndex),
+    hash,
+    path: queryIndex >= 0 ? beforeHash.slice(0, queryIndex) : beforeHash,
   };
 }
 
-function normalizeRelativeSkillPath(rawPath: string) {
-  if (!rawPath || rawPath.includes("\\") || rawPath.includes("\0")) return null;
+function hasUnsafePathSyntax(path: string) {
+  if (!path || path.startsWith("/") || path.startsWith("//") || path.includes("\\")) return true;
+  if (path.includes("..")) return true;
 
-  const pathOnly = rawPath.split("?")[0] ?? "";
-  const segments: string[] = [];
-  for (const segment of pathOnly.split("/")) {
-    if (!segment || segment === ".") continue;
-
-    let decoded: string;
-    try {
-      decoded = decodeURIComponent(segment);
-    } catch {
-      return null;
-    }
-
-    if (
-      decoded === "." ||
-      decoded === ".." ||
-      decoded.includes("/") ||
-      decoded.includes("\\") ||
-      decoded.includes("\0")
-    ) {
-      return null;
-    }
-
-    segments.push(segment);
+  try {
+    const decoded = decodeURIComponent(path);
+    return decoded.includes("..") || decoded.includes("\\") || decoded.startsWith("/");
+  } catch {
+    return true;
   }
-
-  return segments.length ? segments.join("/") : null;
 }
 
-export function resolveSkillReadmeHref(href: string, skillSlug: string) {
-  const safeHref = defaultUrlTransform(href);
-  if (!safeHref) return "";
+function normalizeRelativePath(path: string) {
+  if (hasUnsafePathSyntax(path)) return null;
+  const parts = path.split("/").filter((part) => part && part !== ".");
+  return parts.join("/");
+}
 
-  const trimmed = safeHref.trim();
-  if (!trimmed || ABSOLUTE_OR_ROOT_HREF.test(trimmed)) return safeHref;
+function resolveReadmeRelativePath(readmePath: string, targetPath: string) {
+  const normalizedReadmePath = normalizeRelativePath(readmePath);
+  const normalizedTargetPath = normalizeRelativePath(targetPath);
+  if (!normalizedReadmePath || !normalizedTargetPath) return null;
 
-  const { path, fragment } = splitFragment(trimmed);
-  const normalizedPath = normalizeRelativeSkillPath(path);
-  if (!normalizedPath) return "";
+  const baseDir = normalizedReadmePath.split("/").slice(0, -1);
+  return [...baseDir, ...normalizedTargetPath.split("/")].filter(Boolean).join("/");
+}
 
-  return `/api/v1/skills/${encodeURIComponent(skillSlug)}/file?path=${encodeURIComponent(
-    normalizedPath,
-  )}${fragment}`;
+export function rewriteSkillReadmeMarkdownUrl(
+  reference: string,
+  options: SkillReadmeLinkOptions,
+) {
+  const trimmed = reference.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith("#")) return reference;
+
+  if (SCHEME_RE.test(trimmed)) {
+    const scheme = trimmed.slice(0, trimmed.indexOf(":") + 1).toLowerCase();
+    return ALLOWED_ABSOLUTE_SCHEMES.has(scheme) ? reference : null;
+  }
+
+  const { hash, path } = splitReference(trimmed);
+  const resolvedPath = resolveReadmeRelativePath(options.readmePath ?? "SKILL.md", path);
+  if (!resolvedPath) return null;
+
+  return `/api/v1/skills/${encodeURIComponent(options.skillSlug)}/file?path=${encodeURIComponent(
+    resolvedPath,
+  )}${hash}`;
+}
+
+export function sanitizeRenderedSkillReadmeUrl(url: string) {
+  const trimmed = url.trim();
+  if (!trimmed) return "";
+  if (trimmed.startsWith("#") || trimmed.startsWith("/")) return url;
+
+  if (SCHEME_RE.test(trimmed)) {
+    const scheme = trimmed.slice(0, trimmed.indexOf(":") + 1).toLowerCase();
+    return ALLOWED_ABSOLUTE_SCHEMES.has(scheme) ? url : "";
+  }
+
+  return "";
+}
+
+export function remarkSkillReadmeLinks(options: SkillReadmeLinkOptions) {
+  return (tree: Root) => {
+    visit(tree, (node) => {
+      if (!isMarkdownUrlNode(node)) return;
+      node.url = rewriteSkillReadmeMarkdownUrl(node.url, options) ?? "";
+    });
+  };
 }

--- a/src/lib/skillReadmeLinks.ts
+++ b/src/lib/skillReadmeLinks.ts
@@ -18,9 +18,7 @@ function isMarkdownUrlNode(node: unknown): node is MarkdownUrlNode {
   if (!node || typeof node !== "object") return false;
   const maybeNode = node as { type?: unknown; url?: unknown };
   return (
-    (maybeNode.type === "definition" ||
-      maybeNode.type === "image" ||
-      maybeNode.type === "link") &&
+    (maybeNode.type === "definition" || maybeNode.type === "image" || maybeNode.type === "link") &&
     typeof maybeNode.url === "string"
   );
 }
@@ -63,10 +61,7 @@ function resolveReadmeRelativePath(readmePath: string, targetPath: string) {
   return [...baseDir, ...normalizedTargetPath.split("/")].filter(Boolean).join("/");
 }
 
-export function rewriteSkillReadmeMarkdownUrl(
-  reference: string,
-  options: SkillReadmeLinkOptions,
-) {
+export function rewriteSkillReadmeMarkdownUrl(reference: string, options: SkillReadmeLinkOptions) {
   const trimmed = reference.trim();
   if (!trimmed) return null;
   if (trimmed.startsWith("#")) return reference;

--- a/src/lib/skillReadmeLinks.ts
+++ b/src/lib/skillReadmeLinks.ts
@@ -58,7 +58,7 @@ function resolveReadmeRelativePath(readmePath: string, targetPath: string) {
   if (!normalizedReadmePath || !normalizedTargetPath) return null;
 
   const baseDir = normalizedReadmePath.split("/").slice(0, -1);
-  return [...baseDir, ...normalizedTargetPath.split("/")].filter(Boolean).join("/");
+  return baseDir.concat(normalizedTargetPath.split("/")).filter(Boolean).join("/");
 }
 
 export function rewriteSkillReadmeMarkdownUrl(reference: string, options: SkillReadmeLinkOptions) {


### PR DESCRIPTION
## Summary

Fixes #1681 by resolving relative README links against the skill file API instead of the current page route.

## What changed

- Added a helper for resolving relative README links to `/api/v1/skills/{slug}/file?path=...`.
- Updated the skill README renderer to apply the helper.
- Preserved absolute URLs, `mailto:`/`tel:` links, and hash-only anchors.
- Added regression coverage for relative links, traversal rejection, and component rendering.

## What did not change

- This does not change the file API itself.
- This does not rewrite external links or same-page anchors.

## Validation

- `npx vitest run src/lib/skillReadmeLinks.test.ts src/components/SkillDetailTabs.test.tsx`
- `git diff --check`
- `npx tsc -p tsconfig.json --noEmit`

