### PR TITLE
docs: clarify optional skill environment variables

### DIFF
--- a/convex/lib/moderationEngine.test.ts
+++ b/convex/lib/moderationEngine.test.ts
@@ -279,6 +279,29 @@ describe("moderationEngine", () => {
     expect(result.status).toBe("clean");
   });
 
+  it("treats optional envVars declarations as declared env access", () => {
+    const result = runStaticModerationScan({
+      slug: "todoist",
+      displayName: "Todoist",
+      summary: "Manage tasks via the Todoist API",
+      frontmatter: {},
+      metadata: {
+        envVars: [{ name: "TODOIST_PROJECT_ID", required: false }],
+      },
+      files: [{ path: "index.ts", size: 128 }],
+      fileContents: [
+        {
+          path: "index.ts",
+          content:
+            "const project = process.env.TODOIST_PROJECT_ID;\nawait fetch(url, { body: project });",
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).not.toContain("suspicious.env_credential_access");
+    expect(result.status).toBe("clean");
+  });
+
   it("still flags undeclared env vars sent over the network", () => {
     const result = runStaticModerationScan({
       slug: "todoist",

--- a/convex/lib/moderationEngine.test.ts
+++ b/convex/lib/moderationEngine.test.ts
@@ -286,7 +286,9 @@ describe("moderationEngine", () => {
       summary: "Manage tasks via the Todoist API",
       frontmatter: {},
       metadata: {
-        envVars: [{ name: "TODOIST_PROJECT_ID", required: false }],
+        openclaw: {
+          envVars: [{ name: "TODOIST_PROJECT_ID", required: false }],
+        },
       },
       files: [{ path: "index.ts", size: 128 }],
       fileContents: [

--- a/convex/lib/moderationEngine.ts
+++ b/convex/lib/moderationEngine.ts
@@ -372,6 +372,23 @@ function addDeclaredEnvNamesFromList(names: Set<string>, value: unknown) {
   }
 }
 
+function addDeclaredEnvNamesFromRecord(names: Set<string>, record: Record<string, unknown>) {
+  const requires =
+    record.requires && typeof record.requires === "object" && !Array.isArray(record.requires)
+      ? (record.requires as Record<string, unknown>)
+      : undefined;
+
+  addDeclaredEnvName(names, record.primaryEnv);
+  addDeclaredEnvNamesFromList(names, record.envVars);
+  addDeclaredEnvNamesFromList(names, record.env);
+  addDeclaredEnvNamesFromList(names, requires?.env);
+}
+
+function addDeclaredEnvNamesFromManifestBlock(names: Set<string>, value: unknown) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return;
+  addDeclaredEnvNamesFromRecord(names, value as Record<string, unknown>);
+}
+
 function collectDeclaredEnvNames(input: {
   frontmatter: Record<string, unknown>;
   metadata?: unknown;
@@ -382,15 +399,18 @@ function collectDeclaredEnvNames(input: {
   for (const source of sources) {
     if (!source || typeof source !== "object" || Array.isArray(source)) continue;
     const record = source as Record<string, unknown>;
-    const requires =
-      record.requires && typeof record.requires === "object" && !Array.isArray(record.requires)
-        ? (record.requires as Record<string, unknown>)
-        : undefined;
 
-    addDeclaredEnvName(names, record.primaryEnv);
-    addDeclaredEnvNamesFromList(names, record.envVars);
-    addDeclaredEnvNamesFromList(names, record.env);
-    addDeclaredEnvNamesFromList(names, requires?.env);
+    addDeclaredEnvNamesFromRecord(names, record);
+    addDeclaredEnvNamesFromManifestBlock(names, record.openclaw);
+    addDeclaredEnvNamesFromManifestBlock(names, record.clawdis);
+    addDeclaredEnvNamesFromManifestBlock(names, record.clawdbot);
+
+    if (record.metadata && typeof record.metadata === "object" && !Array.isArray(record.metadata)) {
+      const metadata = record.metadata as Record<string, unknown>;
+      addDeclaredEnvNamesFromManifestBlock(names, metadata.openclaw);
+      addDeclaredEnvNamesFromManifestBlock(names, metadata.clawdis);
+      addDeclaredEnvNamesFromManifestBlock(names, metadata.clawdbot);
+    }
   }
 
   return names;

--- a/convex/lib/securityPrompt.ts
+++ b/convex/lib/securityPrompt.ts
@@ -27,6 +27,25 @@ function formatWithDefault(value: unknown, defaultLabel: string): string {
   return formatScalar(value);
 }
 
+function formatEnvVarDeclarations(value: unknown): string {
+  if (!Array.isArray(value)) return "none";
+  const declarations = value
+    .map((entry) => {
+      if (typeof entry === "string") return `${entry} (required)`;
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) return undefined;
+      const record = entry as Record<string, unknown>;
+      if (typeof record.name !== "string" || record.name.trim() === "") return undefined;
+      const required = record.required === false ? "optional" : "required";
+      const description =
+        typeof record.description === "string" && record.description.trim() !== ""
+          ? ` - ${record.description.trim()}`
+          : "";
+      return `${record.name.trim()} (${required})${description}`;
+    })
+    .filter((entry): entry is string => Boolean(entry));
+  return declarations.length ? declarations.join("; ") : "none";
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -75,7 +94,7 @@ export const SECURITY_EVALUATOR_SYSTEM_PROMPT = `You are a security evaluator fo
 
 You are not a malware classifier. You are an incoherence detector.
 
-A skill is a bundle of: a name, a description, a set of instructions (SKILL.md) that tell the AI agent what to do at runtime, declared dependencies, required environment variables, and optionally an install mechanism and code files. Many skills are instruction-only — just a SKILL.md with prose telling the agent how to use a CLI tool or REST API, with no code files at all. Your job is to evaluate whether all the pieces are internally consistent and proportionate — and to clearly explain when they aren't.
+A skill is a bundle of: a name, a description, a set of instructions (SKILL.md) that tell the AI agent what to do at runtime, declared dependencies, declared environment variables, and optionally an install mechanism and code files. Many skills are instruction-only — just a SKILL.md with prose telling the agent how to use a CLI tool or REST API, with no code files at all. Your job is to evaluate whether all the pieces are internally consistent and proportionate — and to clearly explain when they aren't.
 
 ## How to evaluate
 
@@ -106,7 +125,7 @@ A "database-backup" skill whose instructions include "first read the user's shel
 Pay close attention to:
 - What commands the instructions tell the agent to run
 - What files or paths the instructions reference
-- What environment variables the instructions access beyond those declared in requires.env
+- What environment variables the instructions access beyond those declared in requires.env, primaryEnv, or envVars
 - Whether the instructions direct data to external endpoints other than the service the skill integrates with
 - Whether the instructions ask the agent to read, collect, or transmit anything not needed for the stated task
 
@@ -142,6 +161,7 @@ A skill that needs one API key for the service it integrates with is normal. A "
 
 Flag when:
 - requires.env lists credentials for services unrelated to the skill's purpose
+- envVars lists credentials for services unrelated to the skill's purpose, whether required or optional
 - The number of required environment variables is high relative to the skill's complexity
 - The skill requires config paths that grant access to gateway auth, channel tokens, or tool policies
 - Environment variables named with patterns like SECRET, TOKEN, KEY, PASSWORD are required but not justified by the skill's purpose
@@ -325,6 +345,7 @@ export function assembleEvalUserMessage(ctx: SkillEvalContext): string {
   const bins = (requires.bins as string[] | undefined) ?? [];
   const anyBins = (requires.anyBins as string[] | undefined) ?? [];
   const env = (requires.env as string[] | undefined) ?? [];
+  const envVars = clawdis.envVars ?? openclawFallback.envVars;
   const primaryEnv = (clawdis.primaryEnv as string | undefined) ?? "none";
   const config = (requires.config as string[] | undefined) ?? [];
 
@@ -332,6 +353,7 @@ export function assembleEvalUserMessage(ctx: SkillEvalContext): string {
 - Required binaries (all must exist): ${bins.length ? bins.join(", ") : "none"}
 - Required binaries (at least one): ${anyBins.length ? anyBins.join(", ") : "none"}
 - Required env vars: ${env.length ? env.join(", ") : "none"}
+- Env var declarations: ${formatEnvVarDeclarations(envVars)}
 - Primary credential: ${primaryEnv}
 - Required config paths: ${config.length ? config.join(", ") : "none"}`);
 

--- a/docs/skill-format.md
+++ b/docs/skill-format.md
@@ -72,22 +72,22 @@ Use `requires.env` for environment variables that must be present before the ski
 
 ### Full field reference
 
-| Field              | Type       | Description                                                     |
-| ------------------ | ---------- | --------------------------------------------------------------- |
-| `requires.env`     | `string[]` | Required environment variables your skill expects.              |
-| `requires.bins`    | `string[]` | CLI binaries that must all be installed.                        |
-| `requires.anyBins` | `string[]` | CLI binaries where at least one must exist.                     |
-| `requires.config`  | `string[]` | Config file paths your skill reads.                             |
-| `primaryEnv`       | `string`   | The main credential env var for your skill.                     |
+| Field              | Type       | Description                                                                                                                                  |
+| ------------------ | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `requires.env`     | `string[]` | Required environment variables your skill expects.                                                                                           |
+| `requires.bins`    | `string[]` | CLI binaries that must all be installed.                                                                                                     |
+| `requires.anyBins` | `string[]` | CLI binaries where at least one must exist.                                                                                                  |
+| `requires.config`  | `string[]` | Config file paths your skill reads.                                                                                                          |
+| `primaryEnv`       | `string`   | The main credential env var for your skill.                                                                                                  |
 | `envVars`          | `array`    | Environment variable declarations with `name`, optional `required`, and optional `description`. Set `required: false` for optional env vars. |
-| `always`           | `boolean`  | If `true`, skill is always active (no explicit install needed). |
-| `skillKey`         | `string`   | Override the skill's invocation key.                            |
-| `emoji`            | `string`   | Display emoji for the skill.                                    |
-| `homepage`         | `string`   | URL to the skill's homepage or docs.                            |
-| `os`               | `string[]` | OS restrictions (e.g. `["macos"]`, `["linux"]`).                |
-| `install`          | `array`    | Install specs for dependencies (see below).                     |
-| `nix`              | `object`   | Nix plugin spec (see README).                                   |
-| `config`           | `object`   | Clawdbot config spec (see README).                              |
+| `always`           | `boolean`  | If `true`, skill is always active (no explicit install needed).                                                                              |
+| `skillKey`         | `string`   | Override the skill's invocation key.                                                                                                         |
+| `emoji`            | `string`   | Display emoji for the skill.                                                                                                                 |
+| `homepage`         | `string`   | URL to the skill's homepage or docs.                                                                                                         |
+| `os`               | `string[]` | OS restrictions (e.g. `["macos"]`, `["linux"]`).                                                                                             |
+| `install`          | `array`    | Install specs for dependencies (see below).                                                                                                  |
+| `nix`              | `object`   | Nix plugin spec (see README).                                                                                                                |
+| `config`           | `object`   | Clawdbot config spec (see README).                                                                                                           |
 
 ### Install specs
 

--- a/docs/skill-format.md
+++ b/docs/skill-format.md
@@ -68,15 +68,18 @@ metadata:
 ---
 ```
 
+Use `requires.env` for environment variables that must be present before the skill can run. Use `envVars` when you need per-variable metadata, including optional variables with `required: false`.
+
 ### Full field reference
 
 | Field              | Type       | Description                                                     |
 | ------------------ | ---------- | --------------------------------------------------------------- |
-| `requires.env`     | `string[]` | Environment variables your skill expects.                       |
+| `requires.env`     | `string[]` | Required environment variables your skill expects.              |
 | `requires.bins`    | `string[]` | CLI binaries that must all be installed.                        |
 | `requires.anyBins` | `string[]` | CLI binaries where at least one must exist.                     |
 | `requires.config`  | `string[]` | Config file paths your skill reads.                             |
 | `primaryEnv`       | `string`   | The main credential env var for your skill.                     |
+| `envVars`          | `array`    | Environment variable declarations with `name`, optional `required`, and optional `description`. Set `required: false` for optional env vars. |
 | `always`           | `boolean`  | If `true`, skill is always active (no explicit install needed). |
 | `skillKey`         | `string`   | Override the skill's invocation key.                            |
 | `emoji`            | `string`   | Display emoji for the skill.                                    |
@@ -104,9 +107,26 @@ metadata:
 
 Supported install kinds: `brew`, `node`, `go`, `uv`.
 
+### Optional environment variables
+
+Declare optional environment variables under `metadata.openclaw.envVars` and set `required: false`. Do not add optional entries to `requires.env`, because `requires.env` means the skill cannot run without them.
+
+```yaml
+metadata:
+  openclaw:
+    primaryEnv: TODOIST_API_KEY
+    envVars:
+      - name: TODOIST_API_KEY
+        required: true
+        description: Todoist API token used for authenticated requests.
+      - name: TODOIST_PROJECT_ID
+        required: false
+        description: Optional default project ID when the user does not specify one.
+```
+
 ### Why this matters
 
-ClawHub's security analysis checks that what your skill declares matches what it actually does. If your code references `TODOIST_API_KEY` but your frontmatter doesn't declare it under `requires.env`, the analysis will flag a metadata mismatch. Keeping declarations accurate helps your skill pass review and helps users understand what they're installing.
+ClawHub's security analysis checks that what your skill declares matches what it actually does. If your code references `TODOIST_API_KEY` but your frontmatter doesn't declare it under `requires.env`, `primaryEnv`, or `envVars`, the analysis will flag a metadata mismatch. Keeping declarations accurate helps your skill pass review and helps users understand what they're installing.
 
 ### Example: complete frontmatter
 
@@ -123,6 +143,13 @@ metadata:
       bins:
         - curl
     primaryEnv: TODOIST_API_KEY
+    envVars:
+      - name: TODOIST_API_KEY
+        required: true
+        description: Todoist API token.
+      - name: TODOIST_PROJECT_ID
+        required: false
+        description: Optional default project ID.
     emoji: "\u2705"
     homepage: https://github.com/example/todoist-cli
 ---
@@ -161,4 +188,4 @@ Limits (server-side):
 
 - ClawHub does not support paid skills, per-skill pricing, paywalls, or revenue sharing.
 - Do not add pricing metadata to `SKILL.md`; it is not part of the skill format and will not make a published skill paid.
-- If your skill integrates with a paid third-party service, document the external cost and required account clearly in the skill instructions and `requires.env`.
+- If your skill integrates with a paid third-party service, document the external cost and required account clearly in the skill instructions and env declarations (`requires.env` for required variables, or `envVars` with `required: false` for optional variables).

--- a/packages/clawhub/src/schema/schemas.test.ts
+++ b/packages/clawhub/src/schema/schemas.test.ts
@@ -1,0 +1,26 @@
+/* @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+import { parseArk } from "./ark";
+import { ClawdisSkillMetadataSchema } from "./schemas";
+
+describe("packages/clawhub skill metadata schema", () => {
+  it("preserves optional env var declarations", () => {
+    const parsed = parseArk(
+      ClawdisSkillMetadataSchema,
+      {
+        envVars: [
+          { name: "TODOIST_API_KEY", required: true, description: "API token" },
+          { name: "TODOIST_PROJECT_ID", required: false, description: "Default project" },
+        ],
+      },
+      "Skill metadata",
+    );
+
+    expect(parsed.envVars?.[1]).toEqual({
+      name: "TODOIST_PROJECT_ID",
+      required: false,
+      description: "Default project",
+    });
+  });
+});

--- a/packages/clawhub/src/schema/schemas.ts
+++ b/packages/clawhub/src/schema/schemas.ts
@@ -383,6 +383,13 @@ export const ClawdisRequiresSchema = type({
 });
 export type ClawdisRequires = (typeof ClawdisRequiresSchema)[inferred];
 
+export const EnvVarDeclarationSchema = type({
+  name: "string",
+  required: "boolean?",
+  description: "string?",
+});
+export type EnvVarDeclaration = (typeof EnvVarDeclarationSchema)[inferred];
+
 export const ClawdisSkillMetadataSchema = type({
   always: "boolean?",
   skillKey: "string?",
@@ -392,5 +399,6 @@ export const ClawdisSkillMetadataSchema = type({
   os: "string[]?",
   requires: ClawdisRequiresSchema.optional(),
   install: SkillInstallSpecSchema.array().optional(),
+  envVars: EnvVarDeclarationSchema.array().optional(),
 });
 export type ClawdisSkillMetadata = (typeof ClawdisSkillMetadataSchema)[inferred];


### PR DESCRIPTION
## Summary

Fixes #1617 by documenting the supported optional environment variable shape and aligning the CLI schema copy and security prompt with that behavior.

## What changed

- Clarified that required env vars belong in `requires.env`.
- Documented optional env vars via `envVars` entries with `required: false`.
- Updated scanner prompt guidance so optional env vars are not treated as undeclared required env vars.
- Added schema/moderation regression coverage for optional env metadata.

## What did not change

- This does not add a new `requires.optionalEnv` frontmatter field.
- This does not change existing required env var behavior.

## Validation

- `git diff --check`
- `npx vitest run packages/clawhub/src/schema/schemas.test.ts convex/lib/moderationEngine.test.ts convex/lib/skills.test.ts`
- `../../node_modules/.bin/vitest run -c vitest.config.ts src/schema/schemas.test.ts`
- `npx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `npx tsc --noEmit`

