### PR TITLE
docs: document trademark takedown reports

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -80,7 +80,28 @@ Report examples:
 - undeclared credential or permission requirements
 - suspicious install instructions
 - scam comments or impersonation
+- bad-faith registrations or trademark misuse
 - content that violates [Acceptable usage](./acceptable-usage.md)
+
+## Bad-faith or trademark reports
+
+ClawHub uses the same report and staff moderation pipeline for bad-faith
+registrations, impersonation, and trademark-related disputes. These reports need
+enough context for staff to identify the claimant, disputed listing, and
+requested action.
+
+Include:
+
+- the canonical ClawHub skill or package URL and owner handle
+- the trademark, project, company, or product name at issue
+- public evidence of the claimant's ownership or authority
+- why the current owner is not authorized to publish under that name
+- the requested action, such as hide pending review, transfer ownership, rename,
+  or remove
+
+Do not put private secrets or sensitive legal documents in public reports. Open
+a GitHub issue with non-sensitive evidence and ask maintainers for a private
+handoff path when needed.
 
 ## Appeals and rescans
 


### PR DESCRIPTION
## Summary

Fixes #1591 by documenting how to report bad-faith registrations, impersonation, and trademark-related skill disputes through ClawHub's existing reporting and staff moderation process.

## What changed

- Added a `Bad-faith or trademark reports` section to `docs/security.md`.
- Documented what evidence reporters should provide.
- Clarified which existing staff moderation actions can be used after review.
- Warned users not to put private secrets or sensitive legal documents in the public report flow.

## What did not change

- This does not add a new legal intake system or private evidence upload flow.
- This does not change moderation permissions or enforcement behavior.

## Validation

- `git diff --check`
- Self-reviewed the docs diff for scope and non-sensitive reporting guidance.

