### PR TITLE
feat(schema): include .r files in text whitelist

### DIFF
--- a/packages/clawhub/src/schema/textFiles.ts
+++ b/packages/clawhub/src/schema/textFiles.ts
@@ -15,6 +15,7 @@ const RAW_TEXT_FILE_EXTENSIONS = [
   "jsx",
   "py",
   "sh",
+  "r",
   "rb",
   "go",
   "rs",

--- a/packages/schema/src/textFiles.ts
+++ b/packages/schema/src/textFiles.ts
@@ -15,6 +15,7 @@ const RAW_TEXT_FILE_EXTENSIONS = [
   "jsx",
   "py",
   "sh",
+  "r",
   "rb",
   "go",
   "rs",


### PR DESCRIPTION
## Summary

R source files are filtered out by `listTextFiles` in
`packages/clawhub/src/skills.ts` via `TEXT_FILE_EXTENSION_SET`. The
set is shared by the publish CLI, the GitHub Import path, and the
Web Upload path — all three import from `clawhub-schema`. There is
no server-side override.

R-language skills consequently publish with their `.R` sources
stripped: the bundle retains wrapper shell scripts, JSON specs, and
CSV examples, but not the R code those scripts invoke. A
representative example is `cuiweig/r-stats` v1.1.0 — the bundle
served at `/api/v1/skills/r-stats/versions/1.1.0` lists 36 `.csv`,
73 `.json`, 3 `.md`, 2 `.sh`, and 0 `.R`.

## Change

Adds `"r"` to `RAW_TEXT_FILE_EXTENSIONS` in:

- `packages/schema/src/textFiles.ts`
- `packages/clawhub/src/schema/textFiles.ts`

Insertion is at the existing `r*` cluster (between `sh` and `rb`)
to keep local alphabetical order. Extension comparison is
lower-cased at the call site, so the single entry covers both `.r`
and `.R`.

## Compatibility

Additive. Previously-rejected `.r` and `.R` files now pass the
whitelist. No extension is removed; no existing bundle is
invalidated.

## Verification

After merging and the next CLI release, publishing an R skill
should yield a bundle whose manifest includes the `.R` sources
alongside the existing shell and JSON files. The `r-stats` skill
above can be republished as a regression check.
