### PR TITLE
feat: Device Flow auth for headless environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+- CLI/Auth: add device-code login for remote or headless shells, backed by ClawHub device authorization endpoints (#1867) (thanks @LumenFromTheFuture).
 - Web: polish browse/listing surfaces across skills, plugins, and search, including plugin card view parity, clearer search controls, visible safety filtering, and more consistent card metadata treatment (#2084) (thanks @vyctorbrzezowski).
 - Web: rename the skills and plugins browse alternate view from Cards to Grid while keeping legacy `view=cards` URLs compatible (#2090) (thanks @vyctorbrzezowski).
 - Web: allow skill owners and publisher admins to edit a skill summary from the detail page (#1411) (thanks @SylvanXiao).

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as appMeta from "../appMeta.js";
 import type * as auth from "../auth.js";
+import type * as cliDeviceAuth from "../cliDeviceAuth.js";
 import type * as commentModeration from "../commentModeration.js";
 import type * as comments from "../comments.js";
 import type * as crons from "../crons.js";
@@ -140,6 +141,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   appMeta: typeof appMeta;
   auth: typeof auth;
+  cliDeviceAuth: typeof cliDeviceAuth;
   commentModeration: typeof commentModeration;
   comments: typeof comments;
   crons: typeof crons;

--- a/convex/cliDeviceAuth.ts
+++ b/convex/cliDeviceAuth.ts
@@ -1,0 +1,172 @@
+import { v } from "convex/values";
+import { internalMutation, mutation } from "./functions";
+import { requireUser } from "./lib/access";
+import { generateToken, hashToken } from "./lib/tokens";
+
+const DEVICE_CODE_TTL_MS = 15 * 60_000;
+const DEVICE_POLL_INTERVAL_SECONDS = 5;
+const USER_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+
+export const createInternal = internalMutation({
+  args: {
+    scope: v.optional(v.string()),
+    label: v.optional(v.string()),
+    siteUrl: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const deviceCode = generateOpaqueCode();
+    const userCode = generateUserCode();
+    const now = Date.now();
+    const label = (args.label?.trim() || "CLI device login").slice(0, 120);
+    const scope = (args.scope?.trim() || "read write").slice(0, 200);
+
+    await ctx.db.insert("cliDeviceCodes", {
+      deviceCodeHash: await hashToken(deviceCode),
+      userCodeHash: await hashToken(normalizeUserCode(userCode)),
+      userCode,
+      label,
+      scope,
+      status: "pending",
+      createdAt: now,
+      expiresAt: now + DEVICE_CODE_TTL_MS,
+    });
+
+    const verificationUrl = getVerificationUrl(args.siteUrl, userCode);
+
+    return {
+      device_code: deviceCode,
+      user_code: userCode,
+      verification_uri: verificationUrl.toString(),
+      expires_in: Math.floor(DEVICE_CODE_TTL_MS / 1000),
+      interval: DEVICE_POLL_INTERVAL_SECONDS,
+    };
+  },
+});
+
+export const pollInternal = internalMutation({
+  args: { deviceCode: v.string() },
+  handler: async (ctx, args) => {
+    const deviceCodeHash = await hashToken(args.deviceCode);
+    const row = await ctx.db
+      .query("cliDeviceCodes")
+      .withIndex("by_device_code_hash", (q) => q.eq("deviceCodeHash", deviceCodeHash))
+      .unique();
+    if (!row) return { error: "expired_token" as const };
+
+    const now = Date.now();
+    if (row.expiresAt <= now) {
+      if (row.status !== "expired") await ctx.db.patch(row._id, { status: "expired" });
+      return { error: "expired_token" as const };
+    }
+    if (row.status === "pending") return { error: "authorization_pending" as const };
+    if (row.status === "denied") return { error: "access_denied" as const };
+    if (row.status === "consumed" || row.status === "expired") {
+      return { error: "expired_token" as const };
+    }
+    if (!row.approvedByUserId) return { error: "authorization_pending" as const };
+
+    const { token, prefix } = generateToken();
+    await ctx.db.insert("apiTokens", {
+      userId: row.approvedByUserId,
+      label: row.label,
+      prefix,
+      tokenHash: await hashToken(token),
+      createdAt: now,
+      lastUsedAt: undefined,
+      revokedAt: undefined,
+    });
+    await ctx.db.patch(row._id, { status: "consumed", consumedAt: now });
+    return { access_token: token, token_type: "bearer" as const, scope: row.scope };
+  },
+});
+
+export const approve = mutation({
+  args: { userCode: v.string() },
+  handler: async (ctx, args) => {
+    const { userId } = await requireUser(ctx);
+    const normalized = normalizeUserCode(args.userCode);
+    if (!normalized) throw new Error("Code required");
+
+    const userCodeHash = await hashToken(normalized);
+    const row = await ctx.db
+      .query("cliDeviceCodes")
+      .withIndex("by_user_code_hash", (q) => q.eq("userCodeHash", userCodeHash))
+      .unique();
+    if (!row) throw new Error("Device code not found");
+
+    const now = Date.now();
+    if (row.expiresAt <= now) {
+      if (row.status !== "expired") await ctx.db.patch(row._id, { status: "expired" });
+      throw new Error("Device code expired");
+    }
+    if (row.status === "consumed") throw new Error("Device code already used");
+    if (row.status === "approved") throw new Error("Device code already authorized");
+    if (row.status === "denied") throw new Error("Device code was denied");
+
+    await ctx.db.patch(row._id, {
+      status: "approved",
+      approvedByUserId: userId,
+      approvedAt: now,
+    });
+    return { ok: true, userCode: row.userCode, expiresAt: row.expiresAt };
+  },
+});
+
+export const deny = mutation({
+  args: { userCode: v.string() },
+  handler: async (ctx, args) => {
+    await requireUser(ctx);
+    const normalized = normalizeUserCode(args.userCode);
+    if (!normalized) throw new Error("Code required");
+    const userCodeHash = await hashToken(normalized);
+    const row = await ctx.db
+      .query("cliDeviceCodes")
+      .withIndex("by_user_code_hash", (q) => q.eq("userCodeHash", userCodeHash))
+      .unique();
+    if (!row) throw new Error("Device code not found");
+    const now = Date.now();
+    if (row.status === "approved") throw new Error("Device code already authorized");
+    if (row.status === "pending") {
+      await ctx.db.patch(row._id, { status: "denied", deniedAt: now });
+    }
+    return { ok: true };
+  },
+});
+
+function normalizeUserCode(value: string) {
+  return value
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "");
+}
+
+function generateUserCode() {
+  const bytes = new Uint8Array(8);
+  crypto.getRandomValues(bytes);
+  const raw = Array.from(
+    bytes,
+    (byte) => USER_CODE_ALPHABET[byte % USER_CODE_ALPHABET.length],
+  ).join("");
+  return `${raw.slice(0, 4)}-${raw.slice(4)}`;
+}
+
+function generateOpaqueCode() {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function getVerificationUrl(siteUrlValue: string | undefined, userCode: string) {
+  const baseUrl = siteUrlValue?.trim() || "https://clawhub.ai";
+  let verificationUrl: URL;
+  try {
+    verificationUrl = new URL("/cli/device", baseUrl);
+    if (verificationUrl.protocol !== "http:" && verificationUrl.protocol !== "https:") {
+      verificationUrl = new URL("/cli/device", "https://clawhub.ai");
+    }
+  } catch {
+    verificationUrl = new URL("/cli/device", "https://clawhub.ai");
+  }
+  verificationUrl.searchParams.set("code", userCode);
+  return verificationUrl;
+}

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -4,6 +4,8 @@ import { auth } from "./auth";
 import { downloadZip } from "./downloads";
 import {
   cliPublishHttp,
+  cliDeviceCodeHttp,
+  cliDeviceTokenHttp,
   cliSkillDeleteHttp,
   cliSkillUndeleteHttp,
   cliTelemetrySyncHttp,
@@ -187,6 +189,18 @@ http.route({
   path: ApiRoutes.whoami,
   method: "GET",
   handler: whoamiV1Http,
+});
+
+http.route({
+  path: "/api/cli/device/code",
+  method: "POST",
+  handler: cliDeviceCodeHttp,
+});
+
+http.route({
+  path: "/api/cli/device/token",
+  method: "POST",
+  handler: cliDeviceTokenHttp,
 });
 
 http.route({

--- a/convex/httpApi.handlers.test.ts
+++ b/convex/httpApi.handlers.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./lib/apiTokenAuth", () => ({
+  getOptionalApiTokenUser: vi.fn(),
   requireApiTokenUser: vi.fn(),
 }));
 
@@ -9,7 +10,7 @@ vi.mock("./skills", () => ({
   publishVersionForUser: vi.fn(),
 }));
 
-const { requireApiTokenUser } = await import("./lib/apiTokenAuth");
+const { getOptionalApiTokenUser, requireApiTokenUser } = await import("./lib/apiTokenAuth");
 const { publishVersionForUser } = await import("./skills");
 const { __handlers } = await import("./httpApi");
 const { hashSkillFiles } = await import("./lib/skills");
@@ -20,6 +21,7 @@ function makeCtx(partial: Record<string, unknown>) {
 
 describe("httpApi handlers", () => {
   afterEach(() => {
+    vi.mocked(getOptionalApiTokenUser).mockReset();
     vi.mocked(requireApiTokenUser).mockReset();
     vi.mocked(publishVersionForUser).mockReset();
   });
@@ -343,6 +345,102 @@ describe("httpApi handlers", () => {
       }),
     );
     expect(response.status).toBe(401);
+  });
+
+  it("cliDeviceCodeHttp rate limits and creates a device code", async () => {
+    vi.mocked(getOptionalApiTokenUser).mockResolvedValueOnce(null);
+    const result = {
+      device_code: "device",
+      user_code: "ABCD-2345",
+      verification_uri: "https://clawhub.ai/cli/device?code=ABCD-2345",
+      expires_in: 900,
+      interval: 5,
+    };
+    const runQuery = vi.fn().mockResolvedValue({
+      allowed: true,
+      remaining: 300,
+      limit: 300,
+      resetAt: Date.now() + 60_000,
+    });
+    const runMutation = vi
+      .fn()
+      .mockResolvedValueOnce({ allowed: true, remaining: 299 })
+      .mockResolvedValueOnce(result);
+
+    const response = await __handlers.cliDeviceCodeHandler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://x/api/cli/device/code", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          scope: "read write",
+          label: "ssh box",
+          site_url: "https://clawhub.ai",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("RateLimit-Limit")).toBe("300");
+    expect(await response.json()).toEqual(result);
+    expect(runMutation).toHaveBeenLastCalledWith(expect.anything(), {
+      scope: "read write",
+      label: "ssh box",
+      siteUrl: "https://clawhub.ai",
+    });
+  });
+
+  it("cliDeviceTokenHttp requires the device grant type", async () => {
+    vi.mocked(getOptionalApiTokenUser).mockResolvedValueOnce(null);
+    const runQuery = vi.fn().mockResolvedValue({
+      allowed: true,
+      remaining: 300,
+      limit: 300,
+      resetAt: Date.now() + 60_000,
+    });
+    const runMutation = vi.fn().mockResolvedValueOnce({ allowed: true, remaining: 299 });
+
+    const response = await __handlers.cliDeviceTokenHandler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://x/api/cli/device/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ device_code: "device" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: "unsupported_grant_type" });
+    expect(runMutation).toHaveBeenCalledTimes(1);
+  });
+
+  it("cliDeviceTokenHttp returns pending as retryable", async () => {
+    vi.mocked(getOptionalApiTokenUser).mockResolvedValueOnce(null);
+    const runQuery = vi.fn().mockResolvedValue({
+      allowed: true,
+      remaining: 300,
+      limit: 300,
+      resetAt: Date.now() + 60_000,
+    });
+    const runMutation = vi
+      .fn()
+      .mockResolvedValueOnce({ allowed: true, remaining: 299 })
+      .mockResolvedValueOnce({ error: "authorization_pending" });
+
+    const response = await __handlers.cliDeviceTokenHandler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://x/api/cli/device/token", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          device_code: "device",
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(428);
+    expect(await response.json()).toEqual({ error: "authorization_pending" });
   });
 
   it("cliUploadUrlHttp returns uploadUrl", async () => {

--- a/convex/httpApi.ts
+++ b/convex/httpApi.ts
@@ -12,6 +12,7 @@ import type { ActionCtx } from "./_generated/server";
 import { httpAction } from "./functions";
 import { requireApiTokenUser } from "./lib/apiTokenAuth";
 import { corsHeaders, mergeHeaders } from "./lib/httpHeaders";
+import { applyRateLimit } from "./lib/httpRateLimit";
 import { parseBooleanQueryParam, resolveBooleanQueryParam } from "./lib/httpUtils";
 import { publishVersionForUser } from "./skills";
 
@@ -254,7 +255,61 @@ async function cliTelemetrySyncHandler(ctx: ActionCtx, request: Request) {
 
 export const cliTelemetrySyncHttp = httpAction(cliTelemetrySyncHandler);
 
-function json(value: unknown, status = 200) {
+async function cliDeviceCodeHandler(ctx: ActionCtx, request: Request) {
+  if (request.method !== "POST") return text("Method not allowed", 405);
+  const rate = await applyRateLimit(ctx, request, "write");
+  if (!rate.ok) return rate.response;
+
+  const body = (await request.json().catch(() => ({}))) as {
+    scope?: unknown;
+    label?: unknown;
+    site_url?: unknown;
+  };
+  const result = await ctx.runMutation(internal.cliDeviceAuth.createInternal, {
+    scope: typeof body.scope === "string" ? body.scope : undefined,
+    label: typeof body.label === "string" ? body.label : undefined,
+    siteUrl: typeof body.site_url === "string" ? body.site_url : undefined,
+  });
+  return json(result, 200, rate.headers);
+}
+
+export const cliDeviceCodeHttp = httpAction(cliDeviceCodeHandler);
+
+async function cliDeviceTokenHandler(ctx: ActionCtx, request: Request) {
+  if (request.method !== "POST") return text("Method not allowed", 405);
+  const rate = await applyRateLimit(ctx, request, "write");
+  if (!rate.ok) return rate.response;
+
+  const body = (await request.json().catch(() => null)) as {
+    device_code?: unknown;
+    grant_type?: unknown;
+  } | null;
+  const deviceCode = typeof body?.device_code === "string" ? body.device_code.trim() : "";
+  const grantType = typeof body?.grant_type === "string" ? body.grant_type.trim() : "";
+  if (!deviceCode) {
+    return json(
+      { error: "invalid_request", error_description: "device_code required" },
+      400,
+      rate.headers,
+    );
+  }
+  if (grantType !== "urn:ietf:params:oauth:grant-type:device_code") {
+    return json(
+      { error: "unsupported_grant_type", error_description: "device_code grant required" },
+      400,
+      rate.headers,
+    );
+  }
+
+  const result = await ctx.runMutation(internal.cliDeviceAuth.pollInternal, { deviceCode });
+  if ("access_token" in result) return json(result, 200, rate.headers);
+  const status = result.error === "authorization_pending" ? 428 : 400;
+  return json(result, status, rate.headers);
+}
+
+export const cliDeviceTokenHttp = httpAction(cliDeviceTokenHandler);
+
+function json(value: unknown, status = 200, headers?: HeadersInit) {
   return new Response(JSON.stringify(value), {
     status,
     headers: mergeHeaders(
@@ -262,12 +317,13 @@ function json(value: unknown, status = 200) {
         "Content-Type": "application/json",
         "Cache-Control": "no-store",
       },
+      headers,
       corsHeaders(),
     ),
   });
 }
 
-function text(value: string, status: number) {
+function text(value: string, status: number, headers?: HeadersInit) {
   return new Response(value, {
     status,
     headers: mergeHeaders(
@@ -275,6 +331,7 @@ function text(value: string, status: number) {
         "Content-Type": "text/plain; charset=utf-8",
         "Cache-Control": "no-store",
       },
+      headers,
       corsHeaders(),
     ),
   });
@@ -331,4 +388,6 @@ export const __handlers = {
   cliPublishHandler,
   cliSkillDeleteHandler,
   cliTelemetrySyncHandler,
+  cliDeviceCodeHandler,
+  cliDeviceTokenHandler,
 };

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1528,6 +1528,30 @@ const apiTokens = defineTable({
   .index("by_user", ["userId"])
   .index("by_hash", ["tokenHash"]);
 
+const cliDeviceCodes = defineTable({
+  deviceCodeHash: v.string(),
+  userCodeHash: v.string(),
+  userCode: v.string(),
+  label: v.string(),
+  scope: v.string(),
+  status: v.union(
+    v.literal("pending"),
+    v.literal("approved"),
+    v.literal("denied"),
+    v.literal("consumed"),
+    v.literal("expired"),
+  ),
+  approvedByUserId: v.optional(v.id("users")),
+  createdAt: v.number(),
+  expiresAt: v.number(),
+  approvedAt: v.optional(v.number()),
+  consumedAt: v.optional(v.number()),
+  deniedAt: v.optional(v.number()),
+})
+  .index("by_device_code_hash", ["deviceCodeHash"])
+  .index("by_user_code_hash", ["userCodeHash"])
+  .index("by_status_expires", ["status", "expiresAt"]);
+
 const rateLimits = defineTable({
   key: v.string(),
   windowStart: v.number(),
@@ -1700,6 +1724,7 @@ export default defineSchema({
   vtScanLogs,
   rescanRequests,
   apiTokens,
+  cliDeviceCodes,
   rateLimits,
   rateLimitShards,
   downloadDedupes,

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -49,6 +49,15 @@ clawhub login --token clh_...
 
 Use this flow for servers, CI jobs, or terminal-only environments.
 
+For remote shells where you can open a browser elsewhere, run:
+
+```bash
+clawhub login --device
+```
+
+The CLI prints a one-time code and waits while you authorize it at
+`https://clawhub.ai/cli/device`.
+
 ## Token storage
 
 Default config paths:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -83,6 +83,7 @@ Stores your API token + cached registry URL.
 
 - Default: opens browser to `<site>/cli/auth` and completes via loopback callback.
 - Headless: `clawhub login --token clh_...`
+- Remote/headless interactive: `clawhub login --device` prints a code and waits while you authorize it at `<site>/cli/device`.
 
 ### `whoami`
 

--- a/packages/clawhub/src/cli.ts
+++ b/packages/clawhub/src/cli.ts
@@ -148,6 +148,7 @@ registerCommand(program, ["login"])
   .option("--token <token>", "API token")
   .option("--label <label>", "Token label (browser flow only)", "CLI token")
   .option("--no-browser", "Do not open browser (requires --token)")
+  .option("--device", "Use Device Flow (for headless/remote environments)")
   .action(async (options) => {
     const opts = await resolveGlobalOpts();
     await cmdLoginFlow(opts, options, isInputAllowed());
@@ -177,6 +178,7 @@ registerCommand(auth, ["auth", "login"])
   .option("--token <token>", "API token")
   .option("--label <label>", "Token label (browser flow only)", "CLI token")
   .option("--no-browser", "Do not open browser (requires --token)")
+  .option("--device", "Use Device Flow (for headless/remote environments)")
   .action(async (options) => {
     const opts = await resolveGlobalOpts();
     await cmdLoginFlow(opts, options, isInputAllowed());

--- a/packages/clawhub/src/cli/commands/auth.ts
+++ b/packages/clawhub/src/cli/commands/auth.ts
@@ -1,5 +1,6 @@
 import { buildCliAuthUrl, startLoopbackAuthServer } from "../../browserAuth.js";
 import { readGlobalConfig, writeGlobalConfig } from "../../config.js";
+import { pollForDeviceToken, requestDeviceCode } from "../../deviceAuth.js";
 import { discoverRegistryFromSite } from "../../discovery.js";
 import { apiRequest } from "../../http.js";
 import { ApiRoutes, ApiV1WhoamiResponseSchema } from "../../schema/index.js";
@@ -10,7 +11,7 @@ import { createSpinner, fail, formatError, openInBrowser, promptHidden } from ".
 
 export async function cmdLoginFlow(
   opts: GlobalOpts,
-  options: { token?: string; label?: string; browser?: boolean },
+  options: { token?: string; label?: string; browser?: boolean; device?: boolean },
   inputAllowed: boolean,
 ) {
   if (options.token) {
@@ -18,8 +19,13 @@ export async function cmdLoginFlow(
     return;
   }
 
+  if (options.device) {
+    await cmdDeviceLogin(opts);
+    return;
+  }
+
   if (options.browser === false) {
-    fail("Token required (use --token or remove --no-browser)");
+    fail("Token required (use --token, --device, or remove --no-browser)");
   }
 
   const label = (options.label ?? "CLI token").trim() || "CLI token";
@@ -88,6 +94,51 @@ export async function cmdWhoami(opts: GlobalOpts) {
     spinner.succeed(whoami.user.handle ?? "unknown");
   } catch (error) {
     spinner.fail(formatError(error));
+    throw error;
+  }
+}
+
+/**
+ * Device Flow login for headless environments.
+ * Requests a device code, displays it to the user, then polls until authorized.
+ */
+export async function cmdDeviceLogin(opts: GlobalOpts) {
+  const discovery = await discoverRegistryFromSite(opts.site).catch(() => null);
+  const authBase = discovery?.authBase?.trim() || opts.site;
+
+  const spinner = createSpinner("Requesting device code");
+  let deviceCode;
+  try {
+    deviceCode = await requestDeviceCode({ siteUrl: authBase });
+    spinner.succeed("Device code received");
+  } catch (error) {
+    spinner.fail(formatError(error));
+    throw error;
+  }
+
+  // Display the code and URL for the user
+  console.log();
+  console.log("  To authenticate, visit:");
+  console.log(`  ${deviceCode.verification_uri}`);
+  console.log();
+  console.log(`  And enter code: ${deviceCode.user_code}`);
+  console.log();
+  console.log(`  Code expires in ${Math.floor(deviceCode.expires_in / 60)} minutes.`);
+  console.log();
+
+  const pollSpinner = createSpinner("Waiting for authorization");
+  try {
+    const tokenResponse = await pollForDeviceToken(
+      { siteUrl: authBase },
+      deviceCode.device_code,
+      { interval: deviceCode.interval, expiresIn: deviceCode.expires_in },
+    );
+    pollSpinner.succeed("Authorized");
+
+    // Store the token
+    await cmdLogin(opts, tokenResponse.access_token, true);
+  } catch (error) {
+    pollSpinner.fail(formatError(error));
     throw error;
   }
 }

--- a/packages/clawhub/src/cli/commands/auth.ts
+++ b/packages/clawhub/src/cli/commands/auth.ts
@@ -105,11 +105,12 @@ export async function cmdWhoami(opts: GlobalOpts) {
 export async function cmdDeviceLogin(opts: GlobalOpts) {
   const discovery = await discoverRegistryFromSite(opts.site).catch(() => null);
   const authBase = discovery?.authBase?.trim() || opts.site;
+  const registry = await getRegistry(opts, { cache: true });
 
   const spinner = createSpinner("Requesting device code");
   let deviceCode;
   try {
-    deviceCode = await requestDeviceCode({ siteUrl: authBase });
+    deviceCode = await requestDeviceCode({ apiUrl: registry, siteUrl: authBase });
     spinner.succeed("Device code received");
   } catch (error) {
     spinner.fail(formatError(error));
@@ -129,14 +130,14 @@ export async function cmdDeviceLogin(opts: GlobalOpts) {
   const pollSpinner = createSpinner("Waiting for authorization");
   try {
     const tokenResponse = await pollForDeviceToken(
-      { siteUrl: authBase },
+      { apiUrl: registry, siteUrl: authBase },
       deviceCode.device_code,
       { interval: deviceCode.interval, expiresIn: deviceCode.expires_in },
     );
     pollSpinner.succeed("Authorized");
 
     // Store the token
-    await cmdLogin(opts, tokenResponse.access_token, true);
+    await cmdLogin({ ...opts, registry, registrySource: "cli" }, tokenResponse.access_token, true);
   } catch (error) {
     pollSpinner.fail(formatError(error));
     throw error;

--- a/packages/clawhub/src/deviceAuth.test.ts
+++ b/packages/clawhub/src/deviceAuth.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+import { pollForDeviceToken, requestDeviceCode } from "./deviceAuth.js";
+
+describe("deviceAuth", () => {
+  describe("requestDeviceCode", () => {
+    it("should POST to /cli/device/code and return device code response", async () => {
+      const mockResponse = {
+        device_code: "abc123",
+        user_code: "ABCD-1234",
+        verification_uri: "https://clawhub.ai/device",
+        expires_in: 900,
+        interval: 5,
+      };
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      });
+
+      const result = await requestDeviceCode({ siteUrl: "https://clawhub.ai" });
+
+      expect(result).toEqual(mockResponse);
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://clawhub.ai/cli/device/code",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "Content-Type": "application/json",
+          }),
+        }),
+      );
+    });
+
+    it("should throw on non-ok response", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        text: () => Promise.resolve("endpoint not found"),
+      });
+
+      await expect(requestDeviceCode({ siteUrl: "https://clawhub.ai" })).rejects.toThrow(
+        "Device code request failed (404)",
+      );
+    });
+
+    it("should throw on invalid response (missing fields)", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ device_code: "abc" }),
+      });
+
+      await expect(requestDeviceCode({ siteUrl: "https://clawhub.ai" })).rejects.toThrow(
+        "Invalid device code response",
+      );
+    });
+  });
+
+  describe("pollForDeviceToken", () => {
+    it("should return token on successful authorization", async () => {
+      const tokenResponse = {
+        access_token: "token123",
+        token_type: "bearer",
+        scope: "read write",
+      };
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(tokenResponse),
+      });
+
+      const result = await pollForDeviceToken(
+        { siteUrl: "https://clawhub.ai" },
+        "device_code_123",
+        { interval: 0.01, expiresIn: 10 },
+      );
+
+      expect(result.access_token).toBe("token123");
+    });
+
+    it("should keep polling on authorization_pending", async () => {
+      let callCount = 0;
+      global.fetch = vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount < 3) {
+          return Promise.resolve({
+            ok: false,
+            json: () => Promise.resolve({ error: "authorization_pending" }),
+          });
+        }
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              access_token: "token_after_wait",
+              token_type: "bearer",
+              scope: "read write",
+            }),
+        });
+      });
+
+      const result = await pollForDeviceToken(
+        { siteUrl: "https://clawhub.ai" },
+        "device_code_123",
+        { interval: 0.01, expiresIn: 10 },
+      );
+
+      expect(result.access_token).toBe("token_after_wait");
+      expect(callCount).toBe(3);
+    });
+
+    it("should throw on access_denied", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        json: () => Promise.resolve({ error: "access_denied" }),
+      });
+
+      await expect(
+        pollForDeviceToken({ siteUrl: "https://clawhub.ai" }, "device_code_123", {
+          interval: 0.01,
+          expiresIn: 10,
+        }),
+      ).rejects.toThrow("Authorization denied");
+    });
+
+    it("should throw on expired_token", async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        json: () => Promise.resolve({ error: "expired_token" }),
+      });
+
+      await expect(
+        pollForDeviceToken({ siteUrl: "https://clawhub.ai" }, "device_code_123", {
+          interval: 0.01,
+          expiresIn: 10,
+        }),
+      ).rejects.toThrow("expired");
+    });
+  });
+});

--- a/packages/clawhub/src/deviceAuth.test.ts
+++ b/packages/clawhub/src/deviceAuth.test.ts
@@ -3,7 +3,7 @@ import { pollForDeviceToken, requestDeviceCode } from "./deviceAuth.js";
 
 describe("deviceAuth", () => {
   describe("requestDeviceCode", () => {
-    it("should POST to /cli/device/code and return device code response", async () => {
+    it("should POST to /api/cli/device/code and return device code response", async () => {
       const mockResponse = {
         device_code: "abc123",
         user_code: "ABCD-1234",
@@ -17,11 +17,14 @@ describe("deviceAuth", () => {
         json: () => Promise.resolve(mockResponse),
       });
 
-      const result = await requestDeviceCode({ siteUrl: "https://clawhub.ai" });
+      const result = await requestDeviceCode({
+        apiUrl: "https://api.example",
+        siteUrl: "https://clawhub.ai",
+      });
 
       expect(result).toEqual(mockResponse);
       expect(global.fetch).toHaveBeenCalledWith(
-        "https://clawhub.ai/cli/device/code",
+        "https://api.example/api/cli/device/code",
         expect.objectContaining({
           method: "POST",
           headers: expect.objectContaining({
@@ -39,9 +42,9 @@ describe("deviceAuth", () => {
         text: () => Promise.resolve("endpoint not found"),
       });
 
-      await expect(requestDeviceCode({ siteUrl: "https://clawhub.ai" })).rejects.toThrow(
-        "Device code request failed (404)",
-      );
+      await expect(
+        requestDeviceCode({ apiUrl: "https://api.example", siteUrl: "https://clawhub.ai" }),
+      ).rejects.toThrow("Device code request failed (404)");
     });
 
     it("should throw on invalid response (missing fields)", async () => {
@@ -50,9 +53,9 @@ describe("deviceAuth", () => {
         json: () => Promise.resolve({ device_code: "abc" }),
       });
 
-      await expect(requestDeviceCode({ siteUrl: "https://clawhub.ai" })).rejects.toThrow(
-        "Invalid device code response",
-      );
+      await expect(
+        requestDeviceCode({ apiUrl: "https://api.example", siteUrl: "https://clawhub.ai" }),
+      ).rejects.toThrow("Invalid device code response");
     });
   });
 
@@ -70,7 +73,7 @@ describe("deviceAuth", () => {
       });
 
       const result = await pollForDeviceToken(
-        { siteUrl: "https://clawhub.ai" },
+        { apiUrl: "https://api.example", siteUrl: "https://clawhub.ai" },
         "device_code_123",
         { interval: 0.01, expiresIn: 10 },
       );
@@ -100,7 +103,7 @@ describe("deviceAuth", () => {
       });
 
       const result = await pollForDeviceToken(
-        { siteUrl: "https://clawhub.ai" },
+        { apiUrl: "https://api.example", siteUrl: "https://clawhub.ai" },
         "device_code_123",
         { interval: 0.01, expiresIn: 10 },
       );
@@ -116,10 +119,14 @@ describe("deviceAuth", () => {
       });
 
       await expect(
-        pollForDeviceToken({ siteUrl: "https://clawhub.ai" }, "device_code_123", {
-          interval: 0.01,
-          expiresIn: 10,
-        }),
+        pollForDeviceToken(
+          { apiUrl: "https://api.example", siteUrl: "https://clawhub.ai" },
+          "device_code_123",
+          {
+            interval: 0.01,
+            expiresIn: 10,
+          },
+        ),
       ).rejects.toThrow("Authorization denied");
     });
 
@@ -130,10 +137,14 @@ describe("deviceAuth", () => {
       });
 
       await expect(
-        pollForDeviceToken({ siteUrl: "https://clawhub.ai" }, "device_code_123", {
-          interval: 0.01,
-          expiresIn: 10,
-        }),
+        pollForDeviceToken(
+          { apiUrl: "https://api.example", siteUrl: "https://clawhub.ai" },
+          "device_code_123",
+          {
+            interval: 0.01,
+            expiresIn: 10,
+          },
+        ),
       ).rejects.toThrow("expired");
     });
   });

--- a/packages/clawhub/src/deviceAuth.ts
+++ b/packages/clawhub/src/deviceAuth.ts
@@ -1,0 +1,144 @@
+/**
+ * GitHub Device Flow authentication for headless environments.
+ *
+ * Implements RFC 8628 / GitHub's Device Flow:
+ * https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow
+ *
+ * This allows CLI authentication without a browser redirect to localhost,
+ * enabling headless agents and remote servers to authenticate.
+ */
+
+export type DeviceCodeResponse = {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  expires_in: number;
+  interval: number;
+};
+
+export type DeviceTokenResponse = {
+  access_token: string;
+  token_type: string;
+  scope: string;
+};
+
+export type DeviceTokenErrorResponse = {
+  error: string;
+  error_description?: string;
+  interval?: number;
+};
+
+export type DeviceFlowConfig = {
+  /** The ClawHub site URL that exposes device flow endpoints */
+  siteUrl: string;
+  /** Client ID for the OAuth app (provided by ClawHub) */
+  clientId?: string;
+  /** Scope to request */
+  scope?: string;
+};
+
+const DEFAULT_SCOPE = "read write";
+
+/**
+ * Request a device code from the ClawHub device flow endpoint.
+ */
+export async function requestDeviceCode(config: DeviceFlowConfig): Promise<DeviceCodeResponse> {
+  const url = new URL("/cli/device/code", config.siteUrl);
+
+  const body: Record<string, string> = {
+    scope: config.scope ?? DEFAULT_SCOPE,
+  };
+  if (config.clientId) {
+    body.client_id = config.clientId;
+  }
+
+  const response = await fetch(url.toString(), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(
+      `Device code request failed (${response.status}): ${text || response.statusText}`,
+    );
+  }
+
+  const data = (await response.json()) as DeviceCodeResponse;
+
+  if (!data.device_code || !data.user_code || !data.verification_uri) {
+    throw new Error("Invalid device code response from server");
+  }
+
+  return data;
+}
+
+/**
+ * Poll for the device flow token until the user completes authorization,
+ * the code expires, or an unrecoverable error occurs.
+ */
+export async function pollForDeviceToken(
+  config: DeviceFlowConfig,
+  deviceCode: string,
+  options: { interval: number; expiresIn: number },
+): Promise<DeviceTokenResponse> {
+  const url = new URL("/cli/device/token", config.siteUrl);
+  const deadline = Date.now() + options.expiresIn * 1000;
+  let interval = options.interval * 1000;
+
+  const body: Record<string, string> = {
+    device_code: deviceCode,
+    grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+  };
+  if (config.clientId) {
+    body.client_id = config.clientId;
+  }
+
+  while (Date.now() < deadline) {
+    await sleep(interval);
+
+    const response = await fetch(url.toString(), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (response.ok) {
+      const data = (await response.json()) as DeviceTokenResponse;
+      if (data.access_token) return data;
+    }
+
+    const errorData = (await response.json().catch(() => ({}))) as DeviceTokenErrorResponse;
+
+    switch (errorData.error) {
+      case "authorization_pending":
+        // User hasn't completed auth yet — keep polling
+        break;
+      case "slow_down":
+        // Server requests longer interval
+        interval = (errorData.interval ?? Math.ceil(interval / 1000) + 5) * 1000;
+        break;
+      case "expired_token":
+        throw new Error("Device code expired. Please try again.");
+      case "access_denied":
+        throw new Error("Authorization denied by user.");
+      default:
+        throw new Error(
+          `Device flow error: ${errorData.error_description || errorData.error || "unknown error"}`,
+        );
+    }
+  }
+
+  throw new Error("Device code expired (timeout). Please try again.");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/clawhub/src/deviceAuth.ts
+++ b/packages/clawhub/src/deviceAuth.ts
@@ -110,12 +110,16 @@ export async function pollForDeviceToken(
       body: JSON.stringify(body),
     });
 
-    if (response.ok) {
-      const data = (await response.json()) as DeviceTokenResponse;
-      if (data.access_token) return data;
+    // Parse JSON once to avoid "body already read" errors
+    const data = (await response.json().catch(() => ({}))) as
+      | DeviceTokenResponse
+      | DeviceTokenErrorResponse;
+
+    if (response.ok && "access_token" in data && data.access_token) {
+      return data as DeviceTokenResponse;
     }
 
-    const errorData = (await response.json().catch(() => ({}))) as DeviceTokenErrorResponse;
+    const errorData = data as DeviceTokenErrorResponse;
 
     switch (errorData.error) {
       case "authorization_pending":

--- a/packages/clawhub/src/deviceAuth.ts
+++ b/packages/clawhub/src/deviceAuth.ts
@@ -8,7 +8,7 @@
  * enabling headless agents and remote servers to authenticate.
  */
 
-export type DeviceCodeResponse = {
+type DeviceCodeResponse = {
   device_code: string;
   user_code: string;
   verification_uri: string;
@@ -16,20 +16,22 @@ export type DeviceCodeResponse = {
   interval: number;
 };
 
-export type DeviceTokenResponse = {
+type DeviceTokenResponse = {
   access_token: string;
   token_type: string;
   scope: string;
 };
 
-export type DeviceTokenErrorResponse = {
+type DeviceTokenErrorResponse = {
   error: string;
   error_description?: string;
   interval?: number;
 };
 
-export type DeviceFlowConfig = {
-  /** The ClawHub site URL that exposes device flow endpoints */
+type DeviceFlowConfig = {
+  /** The ClawHub API URL that exposes device flow endpoints */
+  apiUrl: string;
+  /** The ClawHub site URL that hosts the verification page */
   siteUrl: string;
   /** Client ID for the OAuth app (provided by ClawHub) */
   clientId?: string;
@@ -43,10 +45,11 @@ const DEFAULT_SCOPE = "read write";
  * Request a device code from the ClawHub device flow endpoint.
  */
 export async function requestDeviceCode(config: DeviceFlowConfig): Promise<DeviceCodeResponse> {
-  const url = new URL("/cli/device/code", config.siteUrl);
+  const url = new URL("/api/cli/device/code", config.apiUrl);
 
   const body: Record<string, string> = {
     scope: config.scope ?? DEFAULT_SCOPE,
+    site_url: config.siteUrl,
   };
   if (config.clientId) {
     body.client_id = config.clientId;
@@ -86,7 +89,7 @@ export async function pollForDeviceToken(
   deviceCode: string,
   options: { interval: number; expiresIn: number },
 ): Promise<DeviceTokenResponse> {
-  const url = new URL("/cli/device/token", config.siteUrl);
+  const url = new URL("/api/cli/device/token", config.apiUrl);
   const deadline = Date.now() + options.expiresIn * 1000;
   let interval = options.interval * 1000;
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -37,6 +37,7 @@ import { Route as PackagesNewRouteImport } from './routes/packages/new'
 import { Route as PackagesNameRouteImport } from './routes/packages/$name'
 import { Route as OrgsHandleRouteImport } from './routes/orgs/$handle'
 import { Route as DocsAuthRouteImport } from './routes/docs/auth'
+import { Route as CliDeviceRouteImport } from './routes/cli/device'
 import { Route as CliAuthRouteImport } from './routes/cli/auth'
 import { Route as OwnerSlugRouteImport } from './routes/$owner/$slug'
 import { Route as PluginsScopeNameRouteImport } from './routes/plugins/$scope/$name'
@@ -186,6 +187,11 @@ const DocsAuthRoute = DocsAuthRouteImport.update({
   path: '/docs/auth',
   getParentRoute: () => rootRouteImport,
 } as any)
+const CliDeviceRoute = CliDeviceRouteImport.update({
+  id: '/cli/device',
+  path: '/cli/device',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CliAuthRoute = CliAuthRouteImport.update({
   id: '/cli/auth',
   path: '/cli/auth',
@@ -246,6 +252,7 @@ export interface FileRoutesByFullPath {
   '/upload': typeof UploadRoute
   '/$owner/$slug': typeof OwnerSlugRouteWithChildren
   '/cli/auth': typeof CliAuthRoute
+  '/cli/device': typeof CliDeviceRoute
   '/docs/auth': typeof DocsAuthRoute
   '/orgs/$handle': typeof OrgsHandleRoute
   '/packages/$name': typeof PackagesNameRoute
@@ -284,6 +291,7 @@ export interface FileRoutesByTo {
   '/upload': typeof UploadRoute
   '/$owner/$slug': typeof OwnerSlugRouteWithChildren
   '/cli/auth': typeof CliAuthRoute
+  '/cli/device': typeof CliDeviceRoute
   '/docs/auth': typeof DocsAuthRoute
   '/orgs/$handle': typeof OrgsHandleRoute
   '/packages/$name': typeof PackagesNameRoute
@@ -323,6 +331,7 @@ export interface FileRoutesById {
   '/upload': typeof UploadRoute
   '/$owner/$slug': typeof OwnerSlugRouteWithChildren
   '/cli/auth': typeof CliAuthRoute
+  '/cli/device': typeof CliDeviceRoute
   '/docs/auth': typeof DocsAuthRoute
   '/orgs/$handle': typeof OrgsHandleRoute
   '/packages/$name': typeof PackagesNameRoute
@@ -363,6 +372,7 @@ export interface FileRouteTypes {
     | '/upload'
     | '/$owner/$slug'
     | '/cli/auth'
+    | '/cli/device'
     | '/docs/auth'
     | '/orgs/$handle'
     | '/packages/$name'
@@ -401,6 +411,7 @@ export interface FileRouteTypes {
     | '/upload'
     | '/$owner/$slug'
     | '/cli/auth'
+    | '/cli/device'
     | '/docs/auth'
     | '/orgs/$handle'
     | '/packages/$name'
@@ -439,6 +450,7 @@ export interface FileRouteTypes {
     | '/upload'
     | '/$owner/$slug'
     | '/cli/auth'
+    | '/cli/device'
     | '/docs/auth'
     | '/orgs/$handle'
     | '/packages/$name'
@@ -478,6 +490,7 @@ export interface RootRouteChildren {
   UploadRoute: typeof UploadRoute
   OwnerSlugRoute: typeof OwnerSlugRouteWithChildren
   CliAuthRoute: typeof CliAuthRoute
+  CliDeviceRoute: typeof CliDeviceRoute
   DocsAuthRoute: typeof DocsAuthRoute
   OrgsHandleRoute: typeof OrgsHandleRoute
   PackagesNameRoute: typeof PackagesNameRoute
@@ -695,6 +708,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DocsAuthRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/cli/device': {
+      id: '/cli/device'
+      path: '/cli/device'
+      fullPath: '/cli/device'
+      preLoaderRoute: typeof CliDeviceRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/cli/auth': {
       id: '/cli/auth'
       path: '/cli/auth'
@@ -807,6 +827,7 @@ const rootRouteChildren: RootRouteChildren = {
   UploadRoute: UploadRoute,
   OwnerSlugRoute: OwnerSlugRouteWithChildren,
   CliAuthRoute: CliAuthRoute,
+  CliDeviceRoute: CliDeviceRoute,
   DocsAuthRoute: DocsAuthRoute,
   OrgsHandleRoute: OrgsHandleRoute,
   PackagesNameRoute: PackagesNameRoute,

--- a/src/routes/cli/device.tsx
+++ b/src/routes/cli/device.tsx
@@ -1,0 +1,95 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useMutation } from "convex/react";
+import { useState } from "react";
+import { api } from "../../../convex/_generated/api";
+import { Container } from "../../components/layout/Container";
+import { SignInButton } from "../../components/SignInButton";
+import { Button } from "../../components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
+import { Input } from "../../components/ui/input";
+import { Label } from "../../components/ui/label";
+import { useAuthStatus } from "../../lib/useAuthStatus";
+
+export const Route = createFileRoute("/cli/device")({
+  component: CliDeviceAuth,
+});
+
+export function CliDeviceAuth() {
+  const search = Route.useSearch() as { code?: string };
+  const [code, setCode] = useState(search.code ?? "");
+  const [status, setStatus] = useState<string | null>(null);
+  const { isAuthenticated, isLoading, me } = useAuthStatus();
+  const approve = useMutation(api.cliDeviceAuth.approve);
+  const deny = useMutation(api.cliDeviceAuth.deny);
+
+  const submit = async () => {
+    const trimmed = code.trim();
+    if (!trimmed) {
+      setStatus("Enter the code shown in your terminal.");
+      return;
+    }
+    setStatus("Authorizing...");
+    try {
+      await approve({ userCode: trimmed });
+      setStatus("Authorized. You can return to your terminal.");
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : "Authorization failed.");
+    }
+  };
+
+  const cancel = async () => {
+    const trimmed = code.trim();
+    if (!trimmed) return;
+    setStatus("Denying...");
+    try {
+      await deny({ userCode: trimmed });
+      setStatus("Denied. You can close this page.");
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : "Deny failed.");
+    }
+  };
+
+  return (
+    <main className="py-10">
+      <Container size="narrow">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-2xl">CLI device login</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {!isAuthenticated || !me ? (
+              <>
+                <p className="text-sm text-[color:var(--ink-soft)]">
+                  Sign in to authorize the CLI.
+                </p>
+                <SignInButton disabled={isLoading} />
+              </>
+            ) : (
+              <>
+                <div className="space-y-2">
+                  <Label htmlFor="device-code">Code</Label>
+                  <Input
+                    id="device-code"
+                    value={code}
+                    onChange={(event) => setCode(event.currentTarget.value)}
+                    autoComplete="one-time-code"
+                    className="font-mono uppercase"
+                  />
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Button type="button" onClick={submit}>
+                    Authorize
+                  </Button>
+                  <Button type="button" variant="outline" onClick={cancel}>
+                    Deny
+                  </Button>
+                </div>
+                {status ? <p className="text-sm text-[color:var(--ink-soft)]">{status}</p> : null}
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </Container>
+    </main>
+  );
+}

--- a/src/routes/plugins/index.tsx
+++ b/src/routes/plugins/index.tsx
@@ -138,7 +138,7 @@ function PluginsIndex() {
   const handleFilterToggle = (key: string) => {
     if (key === "verified") {
       void navigate({
-        search: (prev) => ({
+        search: (prev: PluginSearchState) => ({
           ...prev,
           cursor: undefined,
           verified: prev.verified ? undefined : true,
@@ -146,7 +146,7 @@ function PluginsIndex() {
       });
     } else if (key === "executesCode") {
       void navigate({
-        search: (prev) => ({
+        search: (prev: PluginSearchState) => ({
           ...prev,
           cursor: undefined,
           executesCode: prev.executesCode ? undefined : true,
@@ -158,7 +158,7 @@ function PluginsIndex() {
   const handleFamilySort = (value: string) => {
     if (value === "featured") {
       void navigate({
-        search: (prev) => ({
+        search: (prev: PluginSearchState) => ({
           ...prev,
           cursor: undefined,
           featured: true,
@@ -170,7 +170,7 @@ function PluginsIndex() {
 
     const family = value === "code-plugin" ? value : undefined;
     void navigate({
-      search: (prev) => ({
+      search: (prev: PluginSearchState) => ({
         ...prev,
         cursor: undefined,
         featured: undefined,
@@ -182,7 +182,7 @@ function PluginsIndex() {
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
     void navigate({
-      search: (prev) => ({
+      search: (prev: PluginSearchState) => ({
         ...prev,
         cursor: undefined,
         q: query.trim() || undefined,
@@ -192,7 +192,7 @@ function PluginsIndex() {
 
   const handleToggleView = () => {
     void navigate({
-      search: (prev) => ({
+      search: (prev: PluginSearchState) => ({
         ...prev,
         view: normalizePluginView(prev.view) === "grid" ? undefined : "grid",
       }),
@@ -316,7 +316,7 @@ function PluginsIndex() {
                   type="button"
                   onClick={() => {
                     void navigate({
-                      search: (prev) => ({ ...prev, cursor: undefined }),
+                      search: (prev: PluginSearchState) => ({ ...prev, cursor: undefined }),
                     });
                   }}
                 >
@@ -329,7 +329,7 @@ function PluginsIndex() {
                   type="button"
                   onClick={() => {
                     void navigate({
-                      search: (prev) => ({ ...prev, cursor: nextCursor }),
+                      search: (prev: PluginSearchState) => ({ ...prev, cursor: nextCursor }),
                     });
                   }}
                 >

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -99,7 +99,7 @@ export function SkillsIndex() {
       if (model.featuredOnly) {
         const nextSort = parseSort(value);
         void navigate({
-          search: (prev) => ({
+          search: (prev: SkillsSearchState) => ({
             ...prev,
             sort: nextSort,
             dir: parseDir(prev.dir, nextSort),


### PR DESCRIPTION
## Summary

Implements [GitHub-style Device Flow](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow) (RFC 8628) authentication for the ClawHub CLI.

## Problem

Headless agents running on cloud servers cannot complete OAuth browser flows because:
1. OAuth redirects to `localhost` callbacks that are inaccessible
2. No human is present to interact with the browser
3. Browser sessions don't persist across invocations

## Solution

New `--device` flag on `clawhub login` / `clawhub auth login`:

```bash
clawhub login --device
```

This will:
1. Request a device code from the server (`POST /cli/device/code`)
2. Display a user code and verification URL
3. Poll for completion (`POST /cli/device/token`) with proper backoff
4. Store the token once authorized

### Example output:
```
✔ Device code received

  To authenticate, visit:
  https://clawhub.ai/device

  And enter code: ABCD-1234

  Code expires in 15 minutes.

⠋ Waiting for authorization...
✔ Authorized
✔ OK. Logged in as @lumen.
```

## Changes

- **New**: `src/deviceAuth.ts` — Device Flow protocol implementation (request code, poll with backoff)
- **New**: `src/deviceAuth.test.ts` — Unit tests for the device auth module
- **Modified**: `src/cli/commands/auth.ts` — Added `cmdDeviceLogin()` function
- **Modified**: `src/cli.ts` — Added `--device` option to both login commands

## Server-side requirements

This PR adds the client-side implementation. The ClawHub server needs to expose:
- `POST /cli/device/code` — returns `{ device_code, user_code, verification_uri, expires_in, interval }`
- `POST /cli/device/token` — returns token or error (`authorization_pending`, `slow_down`, `expired_token`, `access_denied`)
- A verification page at the `verification_uri` where users enter the code

## Testing

Unit tests cover:
- Successful device code request
- Error handling for failed requests
- Polling with authorization_pending
- Error cases (access_denied, expired_token)

Closes #613