### PR TITLE
[codex] Use GitHub App auth for publish gate lookups

### DIFF
--- a/convex/lib/githubAccount.test.ts
+++ b/convex/lib/githubAccount.test.ts
@@ -44,7 +44,11 @@ describe("requireGitHubAccountAge", () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
-    await requireGitHubAccountAge({ runQuery, runMutation } as never, "users:1" as never);
+    await requireGitHubAccountAge(
+      { runQuery, runMutation } as never,
+      "users:1" as never,
+      { allowGitHubAppAuth: true },
+    );
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(runMutation).not.toHaveBeenCalled();
@@ -254,7 +258,11 @@ describe("requireGitHubAccountAge", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    await requireGitHubAccountAge({ runQuery, runMutation } as never, "users:1" as never);
+    await requireGitHubAccountAge(
+      { runQuery, runMutation } as never,
+      "users:1" as never,
+      { allowGitHubAppAuth: true },
+    );
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.github.com/user/12345",
@@ -262,6 +270,50 @@ describe("requireGitHubAccountAge", () => {
         headers: {
           "User-Agent": "clawhub",
           Authorization: "Bearer ghp_test123",
+        },
+      }),
+    );
+  });
+
+  it("uses a GitHub App installation token when GITHUB_TOKEN is missing", async () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-02-02T12:00:00Z");
+    vi.setSystemTime(now);
+
+    vi.stubEnv("GITHUB_APP_ID", "123");
+    vi.stubEnv("GITHUB_APP_INSTALLATION_ID", "456");
+    vi.stubEnv("GITHUB_APP_PRIVATE_KEY", await generatePrivateKeyPem());
+
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce({
+        _id: "users:1",
+        githubCreatedAt: undefined,
+      })
+      .mockResolvedValueOnce("12345");
+    const runMutation = vi.fn();
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/app/installations/456/access_tokens")) {
+        return Response.json({ token: "ghs_installation" });
+      }
+      return Response.json({
+        created_at: "2020-01-01T00:00:00Z",
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await requireGitHubAccountAge(
+      { runQuery, runMutation } as never,
+      "users:1" as never,
+      { allowGitHubAppAuth: true },
+    );
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://api.github.com/user/12345",
+      expect.objectContaining({
+        headers: {
+          "User-Agent": "clawhub",
+          Authorization: "Bearer ghs_installation",
         },
       }),
     );
@@ -403,3 +455,20 @@ describe("syncGitHubProfile", () => {
     });
   });
 });
+
+async function generatePrivateKeyPem() {
+  const keyPair = await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  );
+  const pkcs8 = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+  const base64 = Buffer.from(pkcs8).toString("base64");
+  const lines = base64.match(/.{1,64}/g)?.join("\n") ?? base64;
+  return `-----BEGIN PRIVATE KEY-----\n${lines}\n-----END PRIVATE KEY-----`;
+}

--- a/convex/lib/githubAccount.ts
+++ b/convex/lib/githubAccount.ts
@@ -2,12 +2,14 @@ import { ConvexError } from "convex/values";
 import { internal } from "../_generated/api";
 import type { Id } from "../_generated/dataModel";
 import type { ActionCtx } from "../_generated/server";
+import { getGitHubApiAuthorization } from "./githubAuth";
 import { GITHUB_PROFILE_SYNC_WINDOW_MS } from "./githubProfileSync";
 
 const GITHUB_API = "https://api.github.com";
 const MIN_ACCOUNT_AGE_MS = 14 * 24 * 60 * 60 * 1000;
 
 type GitHubAccountGateCtx = Pick<ActionCtx, "runQuery" | "runMutation">;
+type GitHubAccountGateOptions = { allowGitHubAppAuth?: boolean };
 
 type GitHubUser = {
   login?: string;
@@ -22,16 +24,21 @@ function assertGitHubNumericId(providerAccountId: string) {
   }
 }
 
-function buildGitHubHeaders() {
+async function buildGitHubHeaders(options: GitHubAccountGateOptions = {}) {
   const headers: Record<string, string> = { "User-Agent": "clawhub" };
-  const token = process.env.GITHUB_TOKEN;
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
-  }
+  const authorization = await getGitHubApiAuthorization({
+    userAgent: "clawhub",
+    allowGitHubApp: options.allowGitHubAppAuth,
+  });
+  if (authorization) headers.Authorization = authorization;
   return headers;
 }
 
-export async function requireGitHubAccountAge(ctx: GitHubAccountGateCtx, userId: Id<"users">) {
+export async function requireGitHubAccountAge(
+  ctx: GitHubAccountGateCtx,
+  userId: Id<"users">,
+  options: GitHubAccountGateOptions = {},
+) {
   const user = await ctx.runQuery(internal.users.getByIdInternal, { userId });
   if (!user || user.deletedAt || user.deactivatedAt) throw new ConvexError("User not found");
 
@@ -51,7 +58,7 @@ export async function requireGitHubAccountAge(ctx: GitHubAccountGateCtx, userId:
 
     // Fetch by immutable GitHub numeric ID to avoid username swap attacks entirely.
     const response = await fetch(`${GITHUB_API}/user/${providerAccountId}`, {
-      headers: buildGitHubHeaders(),
+      headers: await buildGitHubHeaders(options),
     });
     if (!response.ok) {
       if (response.status === 403 || response.status === 429) {
@@ -107,7 +114,7 @@ export async function syncGitHubProfile(ctx: ActionCtx, userId: Id<"users">) {
   assertGitHubNumericId(providerAccountId);
 
   const response = await fetch(`${GITHUB_API}/user/${providerAccountId}`, {
-    headers: buildGitHubHeaders(),
+    headers: await buildGitHubHeaders(),
   });
   if (!response.ok) {
     // Silently fail - this is a best-effort sync, not critical path

--- a/convex/lib/githubActionsOidc.test.ts
+++ b/convex/lib/githubActionsOidc.test.ts
@@ -33,6 +33,7 @@ const signingKeyPairPromise = crypto.subtle.generateKey(
 
 afterEach(() => {
   vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
 });
 
 describe("extractWorkflowFilenameFromWorkflowRef", () => {
@@ -94,6 +95,32 @@ describe("fetchGitHubRepositoryIdentity", () => {
         "User-Agent": "clawhub/package-trusted-publisher",
       },
     });
+  });
+
+  it("uses a GitHub App installation token for repository lookup when GITHUB_TOKEN is missing", async () => {
+    vi.stubEnv("GITHUB_APP_ID", "123");
+    vi.stubEnv("GITHUB_APP_INSTALLATION_ID", "456");
+    vi.stubEnv("GITHUB_APP_PRIVATE_KEY", await generatePrivateKeyPem());
+    const appFetchMock = vi.fn(async () => Response.json({ token: "ghs_installation" }));
+    vi.stubGlobal("fetch", appFetchMock);
+    const fetchMock = vi.fn(async () =>
+      Response.json({
+        id: 123,
+        full_name: "openclaw/clawhub",
+        owner: { login: "openclaw", id: 456 },
+      }),
+    );
+
+    await fetchGitHubRepositoryIdentity("openclaw/clawhub", fetchMock);
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://api.github.com/repos/openclaw/clawhub",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer ghs_installation",
+        }),
+      }),
+    );
   });
 });
 
@@ -387,4 +414,21 @@ function base64UrlEncodeBytes(bytes: Uint8Array) {
   let binary = "";
   for (const byte of bytes) binary += String.fromCharCode(byte);
   return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+async function generatePrivateKeyPem() {
+  const keyPair = await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  );
+  const pkcs8 = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+  const base64 = Buffer.from(pkcs8).toString("base64");
+  const lines = base64.match(/.{1,64}/g)?.join("\n") ?? base64;
+  return `-----BEGIN PRIVATE KEY-----\n${lines}\n-----END PRIVATE KEY-----`;
 }

--- a/convex/lib/githubActionsOidc.ts
+++ b/convex/lib/githubActionsOidc.ts
@@ -1,3 +1,5 @@
+import { getGitHubApiAuthorization } from "./githubAuth";
+
 type JwtHeader = {
   alg?: unknown;
   kid?: unknown;
@@ -217,7 +219,7 @@ export async function fetchGitHubRepositoryIdentity(
     throw new Error(`Invalid GitHub repository: ${repository}`);
   }
   const response = await fetchImpl(`https://api.github.com/repos/${normalizedRepository}`, {
-    headers: buildGitHubRepositoryLookupHeaders(),
+    headers: await buildGitHubRepositoryLookupHeaders(),
   });
   if (!response.ok) {
     throw new Error(
@@ -239,15 +241,16 @@ export async function fetchGitHubRepositoryIdentity(
   };
 }
 
-function buildGitHubRepositoryLookupHeaders() {
+async function buildGitHubRepositoryLookupHeaders() {
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
     "User-Agent": "clawhub/package-trusted-publisher",
   };
-  const token = process.env.GITHUB_TOKEN?.trim();
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
-  }
+  const authorization = await getGitHubApiAuthorization({
+    userAgent: "clawhub/package-trusted-publisher",
+    allowGitHubApp: true,
+  });
+  if (authorization) headers.Authorization = authorization;
   return headers;
 }
 

--- a/convex/lib/githubAppAuth.test.ts
+++ b/convex/lib/githubAppAuth.test.ts
@@ -1,0 +1,62 @@
+/* @vitest-environment node */
+import { generateKeyPairSync } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildGitHubHeaders, createInstallationToken, isGitHubAppConfigured } from "./githubAppAuth";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("githubAppAuth", () => {
+  it("detects GitHub App env configuration", () => {
+    expect(isGitHubAppConfigured()).toBe(false);
+
+    vi.stubEnv("GITHUB_APP_ID", "123");
+    vi.stubEnv("GITHUB_APP_INSTALLATION_ID", "456");
+    vi.stubEnv("GITHUB_APP_PRIVATE_KEY", generatePrivateKeyPem());
+
+    expect(isGitHubAppConfigured()).toBe(true);
+  });
+
+  it("mints an installation token using the existing backup signing flow", async () => {
+    vi.stubEnv("GITHUB_APP_ID", "123");
+    vi.stubEnv("GITHUB_APP_INSTALLATION_ID", "456");
+    vi.stubEnv("GITHUB_APP_PRIVATE_KEY", generatePrivateKeyPem());
+    const fetchMock = vi.fn(async () => Response.json({ token: "ghs_installation" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(createInstallationToken("clawhub/test")).resolves.toBe("ghs_installation");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/app/installations/456/access_tokens",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Accept: "application/vnd.github+json",
+          Authorization: expect.stringMatching(/^Bearer [^.]+\.[^.]+\.[^.]+$/),
+          "User-Agent": "clawhub/test",
+        }),
+      }),
+    );
+  });
+
+  it("builds GitHub API headers with backup-compatible auth schemes", () => {
+    expect(buildGitHubHeaders("installation", "clawhub/test")).toEqual({
+      Authorization: "token installation",
+      Accept: "application/vnd.github+json",
+      "User-Agent": "clawhub/test",
+    });
+    expect(buildGitHubHeaders("jwt", "clawhub/test", true)).toEqual({
+      Authorization: "Bearer jwt",
+      Accept: "application/vnd.github+json",
+      "User-Agent": "clawhub/test",
+    });
+  });
+});
+
+function generatePrivateKeyPem() {
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  return privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+}

--- a/convex/lib/githubAppAuth.ts
+++ b/convex/lib/githubAppAuth.ts
@@ -1,0 +1,67 @@
+"use node";
+
+import { createPrivateKey, createSign } from "node:crypto";
+
+const GITHUB_API = "https://api.github.com";
+
+export function isGitHubAppConfigured() {
+  return Boolean(
+    process.env.GITHUB_APP_ID &&
+      process.env.GITHUB_APP_PRIVATE_KEY &&
+      process.env.GITHUB_APP_INSTALLATION_ID,
+  );
+}
+
+export async function createInstallationToken(userAgent: string) {
+  const appId = process.env.GITHUB_APP_ID;
+  const installationId = process.env.GITHUB_APP_INSTALLATION_ID;
+  if (!appId || !installationId) {
+    throw new Error("GitHub App credentials missing");
+  }
+  const jwt = createAppJwt(appId);
+  const response = await fetch(`${GITHUB_API}/app/installations/${installationId}/access_tokens`, {
+    method: "POST",
+    headers: buildGitHubHeaders(jwt, userAgent, true),
+  });
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`GitHub App token failed: ${message}`);
+  }
+  const payload = (await response.json()) as { token?: string };
+  if (!payload.token) throw new Error("GitHub App token missing");
+  return payload.token;
+}
+
+function createAppJwt(appId: string) {
+  const privateKey = loadPrivateKey();
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "RS256", typ: "JWT" };
+  const payload = { iat: now - 60, exp: now + 9 * 60, iss: appId };
+  const encodedHeader = base64Url(JSON.stringify(header));
+  const encodedPayload = base64Url(JSON.stringify(payload));
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+  const sign = createSign("RSA-SHA256");
+  sign.update(signingInput);
+  sign.end();
+  const signature = sign.sign(privateKey);
+  return `${signingInput}.${base64Url(signature)}`;
+}
+
+function loadPrivateKey() {
+  const raw = process.env.GITHUB_APP_PRIVATE_KEY;
+  if (!raw) throw new Error("GITHUB_APP_PRIVATE_KEY is not configured");
+  const normalized = raw.replace(/\\n/g, "\n");
+  return createPrivateKey(normalized);
+}
+
+export function buildGitHubHeaders(token: string, userAgent: string, isAppJwt = false) {
+  return {
+    Authorization: `${isAppJwt ? "Bearer" : "token"} ${token}`,
+    Accept: "application/vnd.github+json",
+    "User-Agent": userAgent,
+  };
+}
+
+function base64Url(input: string | Uint8Array) {
+  return Buffer.from(input).toString("base64url");
+}

--- a/convex/lib/githubAuth.ts
+++ b/convex/lib/githubAuth.ts
@@ -1,0 +1,22 @@
+type GitHubAuthOptions = {
+  userAgent: string;
+  allowGitHubApp?: boolean;
+};
+
+export async function getGitHubApiAuthorization(options: GitHubAuthOptions) {
+  const token = process.env.GITHUB_TOKEN?.trim();
+  if (token) return `Bearer ${token}`;
+
+  if (!options.allowGitHubApp || !isGitHubAppConfigured()) return undefined;
+
+  const { createInstallationToken } = await import("./githubAppAuth");
+  return `Bearer ${await createInstallationToken(options.userAgent)}`;
+}
+
+function isGitHubAppConfigured() {
+  return Boolean(
+    process.env.GITHUB_APP_ID &&
+      process.env.GITHUB_APP_PRIVATE_KEY &&
+      process.env.GITHUB_APP_INSTALLATION_ID,
+  );
+}

--- a/convex/lib/githubBackup.ts
+++ b/convex/lib/githubBackup.ts
@@ -1,8 +1,12 @@
 "use node";
 
-import { createPrivateKey, createSign } from "node:crypto";
 import type { Id } from "../_generated/dataModel";
 import type { ActionCtx } from "../_generated/server";
+import {
+  buildGitHubHeaders,
+  createInstallationToken,
+  isGitHubAppConfigured,
+} from "./githubAppAuth";
 
 const GITHUB_API = "https://api.github.com";
 const DEFAULT_REPO = "clawdbot/skills";
@@ -82,18 +86,14 @@ export type GitHubSkillBackupEntry = {
 };
 
 export function isGitHubBackupConfigured() {
-  return Boolean(
-    process.env.GITHUB_APP_ID &&
-    process.env.GITHUB_APP_PRIVATE_KEY &&
-    process.env.GITHUB_APP_INSTALLATION_ID,
-  );
+  return isGitHubAppConfigured();
 }
 
 export async function getGitHubBackupContext(): Promise<GitHubBackupContext> {
   const repo = process.env.GITHUB_SKILLS_REPO ?? DEFAULT_REPO;
   const root = process.env.GITHUB_SKILLS_ROOT ?? DEFAULT_ROOT;
   const [repoOwner, repoName] = parseRepo(repo);
-  const token = await createInstallationToken();
+  const token = await createInstallationToken(USER_AGENT);
   const repoInfo = await githubGet<RepoInfo>(token, `/repos/${repoOwner}/${repoName}`);
   const branch = repoInfo.default_branch ?? "main";
 
@@ -439,48 +439,6 @@ async function fetchStorageBase64(ctx: ActionCtx, storageId: Id<"_storage">) {
   return buffer.toString("base64");
 }
 
-async function createInstallationToken() {
-  const appId = process.env.GITHUB_APP_ID;
-  const installationId = process.env.GITHUB_APP_INSTALLATION_ID;
-  if (!appId || !installationId) {
-    throw new Error("GitHub App credentials missing");
-  }
-  const jwt = createAppJwt(appId);
-  const response = await fetch(`${GITHUB_API}/app/installations/${installationId}/access_tokens`, {
-    method: "POST",
-    headers: buildHeaders(jwt, true),
-  });
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(`GitHub App token failed: ${message}`);
-  }
-  const payload = (await response.json()) as { token?: string };
-  if (!payload.token) throw new Error("GitHub App token missing");
-  return payload.token;
-}
-
-function createAppJwt(appId: string) {
-  const privateKey = loadPrivateKey();
-  const now = Math.floor(Date.now() / 1000);
-  const header = { alg: "RS256", typ: "JWT" };
-  const payload = { iat: now - 60, exp: now + 9 * 60, iss: appId };
-  const encodedHeader = base64Url(JSON.stringify(header));
-  const encodedPayload = base64Url(JSON.stringify(payload));
-  const signingInput = `${encodedHeader}.${encodedPayload}`;
-  const sign = createSign("RSA-SHA256");
-  sign.update(signingInput);
-  sign.end();
-  const signature = sign.sign(privateKey);
-  return `${signingInput}.${base64Url(signature)}`;
-}
-
-function loadPrivateKey() {
-  const raw = process.env.GITHUB_APP_PRIVATE_KEY;
-  if (!raw) throw new Error("GITHUB_APP_PRIVATE_KEY is not configured");
-  const normalized = raw.replace(/\\n/g, "\n");
-  return createPrivateKey(normalized);
-}
-
 async function createBlob(token: string, repoOwner: string, repoName: string, content: string) {
   const result = await githubPost<{ sha: string }>(
     token,
@@ -531,11 +489,7 @@ async function githubPatch(token: string, path: string, body: unknown) {
 }
 
 function buildHeaders(token: string, isAppJwt = false) {
-  return {
-    Authorization: `${isAppJwt ? "Bearer" : "token"} ${token}`,
-    Accept: "application/vnd.github+json",
-    "User-Agent": USER_AGENT,
-  };
+  return buildGitHubHeaders(token, USER_AGENT, isAppJwt);
 }
 
 function parseRepo(repo: string) {
@@ -568,11 +522,6 @@ function encodePath(path: string) {
     .split("/")
     .map((segment) => encodeURIComponent(segment))
     .join("/");
-}
-
-function base64Url(value: string | Uint8Array) {
-  const buffer = typeof value === "string" ? Buffer.from(value) : Buffer.from(value);
-  return buffer.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
 }
 
 function toBase64(value: string) {

--- a/convex/lib/githubSoulBackup.ts
+++ b/convex/lib/githubSoulBackup.ts
@@ -1,8 +1,12 @@
 "use node";
 
-import { createPrivateKey, createSign } from "node:crypto";
 import type { Id } from "../_generated/dataModel";
 import type { ActionCtx } from "../_generated/server";
+import {
+  buildGitHubHeaders,
+  createInstallationToken,
+  isGitHubAppConfigured,
+} from "./githubAppAuth";
 
 const GITHUB_API = "https://api.github.com";
 const DEFAULT_REPO = "clawdbot/souls";
@@ -75,18 +79,14 @@ export type GitHubBackupContext = {
 };
 
 export function isGitHubSoulBackupConfigured() {
-  return Boolean(
-    process.env.GITHUB_APP_ID &&
-    process.env.GITHUB_APP_PRIVATE_KEY &&
-    process.env.GITHUB_APP_INSTALLATION_ID,
-  );
+  return isGitHubAppConfigured();
 }
 
 export async function getGitHubSoulBackupContext(): Promise<GitHubBackupContext> {
   const repo = process.env.GITHUB_SOULS_REPO ?? DEFAULT_REPO;
   const root = process.env.GITHUB_SOULS_ROOT ?? DEFAULT_ROOT;
   const [repoOwner, repoName] = parseRepo(repo);
-  const token = await createInstallationToken();
+  const token = await createInstallationToken(USER_AGENT);
   const repoInfo = await githubGet<RepoInfo>(token, `/repos/${repoOwner}/${repoName}`);
   const branch = repoInfo.default_branch ?? "main";
 
@@ -297,48 +297,6 @@ async function fetchStorageBase64(ctx: ActionCtx, storageId: Id<"_storage">) {
   return buffer.toString("base64");
 }
 
-async function createInstallationToken() {
-  const appId = process.env.GITHUB_APP_ID;
-  const installationId = process.env.GITHUB_APP_INSTALLATION_ID;
-  if (!appId || !installationId) {
-    throw new Error("GitHub App credentials missing");
-  }
-  const jwt = createAppJwt(appId);
-  const response = await fetch(`${GITHUB_API}/app/installations/${installationId}/access_tokens`, {
-    method: "POST",
-    headers: buildHeaders(jwt, true),
-  });
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(`GitHub App token failed: ${message}`);
-  }
-  const payload = (await response.json()) as { token?: string };
-  if (!payload.token) throw new Error("GitHub App token missing");
-  return payload.token;
-}
-
-function createAppJwt(appId: string) {
-  const privateKey = loadPrivateKey();
-  const now = Math.floor(Date.now() / 1000);
-  const header = { alg: "RS256", typ: "JWT" };
-  const payload = { iat: now - 60, exp: now + 9 * 60, iss: appId };
-  const encodedHeader = base64Url(JSON.stringify(header));
-  const encodedPayload = base64Url(JSON.stringify(payload));
-  const signingInput = `${encodedHeader}.${encodedPayload}`;
-  const sign = createSign("RSA-SHA256");
-  sign.update(signingInput);
-  sign.end();
-  const signature = sign.sign(privateKey);
-  return `${signingInput}.${base64Url(signature)}`;
-}
-
-function loadPrivateKey() {
-  const raw = process.env.GITHUB_APP_PRIVATE_KEY;
-  if (!raw) throw new Error("GITHUB_APP_PRIVATE_KEY is not configured");
-  const normalized = raw.replace(/\\n/g, "\n");
-  return createPrivateKey(normalized);
-}
-
 async function createBlob(token: string, repoOwner: string, repoName: string, content: string) {
   const result = await githubPost<{ sha: string }>(
     token,
@@ -389,11 +347,7 @@ async function githubPatch(token: string, path: string, body: unknown) {
 }
 
 function buildHeaders(token: string, isAppJwt = false) {
-  return {
-    Authorization: `${isAppJwt ? "Bearer" : "token"} ${token}`,
-    Accept: "application/vnd.github+json",
-    "User-Agent": USER_AGENT,
-  };
+  return buildGitHubHeaders(token, USER_AGENT, isAppJwt);
 }
 
 function parseRepo(repo: string) {
@@ -426,11 +380,6 @@ function encodePath(path: string) {
     .split("/")
     .map((segment) => encodeURIComponent(segment))
     .join("/");
-}
-
-function base64Url(value: string | Uint8Array) {
-  const buffer = typeof value === "string" ? Buffer.from(value) : Buffer.from(value);
-  return buffer.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
 }
 
 function toBase64(value: string) {

--- a/convex/lib/skillPublish.ts
+++ b/convex/lib/skillPublish.ts
@@ -101,7 +101,7 @@ export async function publishVersionForUser(
   }
 
   if (!options.bypassGitHubAccountAge) {
-    await requireGitHubAccountAge(ctx, userId);
+    await requireGitHubAccountAge(ctx, userId, { allowGitHubAppAuth: true });
   }
   const existingSkill = (await ctx.runQuery(internal.skills.getSkillBySlugInternal, {
     slug,

--- a/convex/lib/soulPublish.ts
+++ b/convex/lib/soulPublish.ts
@@ -94,7 +94,7 @@ export async function publishSoulVersionForUser(
     throw new ConvexError("Version must be valid semver");
   }
 
-  await requireGitHubAccountAge(ctx, userId);
+  await requireGitHubAccountAge(ctx, userId, { allowGitHubAppAuth: true });
 
   const suppliedChangelog = args.changelog.trim();
   const changelogSource = suppliedChangelog ? ("user" as const) : ("auto" as const);

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -1828,7 +1828,7 @@ async function publishPackageImpl(
     effectiveSource = resolveTrustedPublishSource(payload, auth.publishToken);
   } else {
     actorUserId = auth.actorUserId;
-    await requireGitHubAccountAge(ctx, actorUserId);
+    await requireGitHubAccountAge(ctx, actorUserId, { allowGitHubAppAuth: true });
     const ownerTarget = await runMutationRef<{
       publisherId: Id<"publishers">;
       linkedUserId?: Id<"users">;


### PR DESCRIPTION
## Summary

- extract the existing GitHub App installation-token signing flow from backup helpers into a shared Node helper
- let package, skill, and soul publish account-age lookups use GitHub App auth when `GITHUB_TOKEN` is absent
- let trusted-publisher repository identity lookups use the same fallback
- keep `GITHUB_TOKEN` as the first-choice override and leave non-publish comment gates on the existing behavior

## Why

Production already has GitHub App credentials, but publish-gate GitHub reads only used `GITHUB_TOKEN`. That meant ClawHub could still hit unauthenticated GitHub API limits unless a PAT was configured. This reuses the backup auth path instead of requiring a long-lived PAT for the publish flow.

## Validation

- `bun run test convex/lib/githubAppAuth.test.ts convex/lib/githubAccount.test.ts convex/lib/githubActionsOidc.test.ts`
- `bun run lint`
