### PR TITLE
ci: check oxfmt on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: oven-sh/setup-bun@e3914758a49697077f7bcd190d36582a61667aad
         with:
@@ -21,6 +23,24 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Peer deps
         run: bun run check:peers
+
+      - name: Format
+        if: github.event_name == 'pull_request'
+        run: |
+          mapfile -d '' changed_files < <(
+            git diff --name-only --diff-filter=ACMR -z \
+              "${{ github.event.pull_request.base.sha }}" \
+              "${{ github.event.pull_request.head.sha }}" \
+              -- \
+              '*.css' '*.js' '*.jsx' '*.json' '*.md' '*.mjs' '*.ts' '*.tsx' '*.yaml' '*.yml'
+          )
+
+          if (( ${#changed_files[@]} == 0 )); then
+            echo "No changed files supported by oxfmt."
+            exit 0
+          fi
+
+          bun run format:check -- "${changed_files[@]}"
 
       - name: Lint
         run: bun run lint

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev": "bun --bun vite dev --port 3000",
     "docs:list": "bun scripts/docs-list.ts",
     "format": "oxfmt --write",
+    "format:check": "oxfmt --check",
     "install:local-hooks": "bun scripts/install-git-hooks.mjs",
     "lint": "bun run lint:oxlint",
     "lint:fix": "oxlint --type-aware --tsconfig ./tsconfig.oxlint.json ./src ./convex ./packages/clawhub/src ./packages/schema/src --fix && bun run format",


### PR DESCRIPTION
## Summary

- add an `oxfmt --check` npm script for non-mutating format validation
- run a PR-only CI format step against changed files supported by `oxfmt`

## Validation

- `bun run format:check -- package.json .github/workflows/ci.yml`
- `bun run lint`
- `git diff --check -- .github/workflows/ci.yml package.json`
