### PR TITLE
fix: move stars link into settings

### DIFF
--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -2,197 +2,209 @@
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import Header from "../components/Header";
+
+type HeaderAuthStatus = {
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  me: Record<string, unknown> | null;
+};
 
 const siteModeMock = vi.fn(() => "souls");
 const navigateMock = vi.fn();
 
 vi.mock("@tanstack/react-router", () => ({
-	Link: (props: {
-		children: ReactNode;
-		className?: string;
-		hash?: string;
-		to?: string;
-	}) => (
-		<a
-			href={`${props.to ?? "/"}${props.hash ? `#${props.hash}` : ""}`}
-			className={props.className}
-		>
-			{props.children}
-		</a>
-	),
-	useLocation: () => ({ pathname: "/" }),
-	useNavigate: () => navigateMock,
+  Link: (props: { children: ReactNode; className?: string; hash?: string; to?: string }) => (
+    <a href={`${props.to ?? "/"}${props.hash ? `#${props.hash}` : ""}`} className={props.className}>
+      {props.children}
+    </a>
+  ),
+  useLocation: () => ({ pathname: "/" }),
+  useNavigate: () => navigateMock,
 }));
 
 vi.mock("@convex-dev/auth/react", () => ({
-	useAuthActions: () => ({
-		signIn: vi.fn(),
-		signOut: vi.fn(),
-	}),
+  useAuthActions: () => ({
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  }),
 }));
 
-const authStatusMock = vi.fn(() => ({
-	isAuthenticated: false,
-	isLoading: false,
-	me: null,
+const authStatusMock = vi.fn<() => HeaderAuthStatus>(() => ({
+  isAuthenticated: false,
+  isLoading: false,
+  me: null,
 }));
 
 vi.mock("../lib/useAuthStatus", () => ({
-	useAuthStatus: () => authStatusMock(),
+  useAuthStatus: () => authStatusMock(),
 }));
 
 const setThemeMock = vi.fn();
 const setModeMock = vi.fn();
 
 vi.mock("../lib/theme", () => ({
-	applyTheme: vi.fn(),
-	THEME_OPTIONS: [
-		{ value: "claw", label: "Claw", description: "" },
-		{ value: "hub", label: "Hub", description: "" },
-	],
-	useThemeMode: () => ({
-		theme: "hub",
-		mode: "system",
-		setTheme: setThemeMock,
-		setMode: setModeMock,
-	}),
+  applyTheme: vi.fn(),
+  THEME_OPTIONS: [
+    { value: "claw", label: "Claw", description: "" },
+    { value: "hub", label: "Hub", description: "" },
+  ],
+  useThemeMode: () => ({
+    theme: "hub",
+    mode: "system",
+    setTheme: setThemeMock,
+    setMode: setModeMock,
+  }),
 }));
 
 vi.mock("../lib/theme-transition", () => ({
-	startThemeTransition: ({
-		setTheme,
-		nextTheme,
-	}: {
-		setTheme: (value: string) => void;
-		nextTheme: string;
-	}) => setTheme(nextTheme),
+  startThemeTransition: ({
+    setTheme,
+    nextTheme,
+  }: {
+    setTheme: (value: string) => void;
+    nextTheme: string;
+  }) => setTheme(nextTheme),
 }));
 
 vi.mock("../lib/useAuthError", () => ({
-	setAuthError: vi.fn(),
-	useAuthError: () => ({
-		error: null,
-		clear: vi.fn(),
-	}),
+  setAuthError: vi.fn(),
+  useAuthError: () => ({
+    error: null,
+    clear: vi.fn(),
+  }),
 }));
 
 vi.mock("../lib/roles", () => ({
-	isModerator: () => false,
+  isModerator: () => false,
 }));
 
 vi.mock("../lib/site", () => ({
-	getClawHubSiteUrl: () => "https://clawhub.ai",
-	getSiteMode: () => siteModeMock(),
-	getSiteName: () => "OnlyCrabs",
+  getClawHubSiteUrl: () => "https://clawhub.ai",
+  getSiteMode: () => siteModeMock(),
+  getSiteName: () => "OnlyCrabs",
 }));
 
 vi.mock("../lib/gravatar", () => ({
-	gravatarUrl: vi.fn(),
+  gravatarUrl: vi.fn(),
 }));
 
 vi.mock("../components/ui/dropdown-menu", () => ({
-	DropdownMenu: ({ children }: { children: ReactNode }) => (
-		<div>{children}</div>
-	),
-	DropdownMenuContent: ({ children }: { children: ReactNode }) => (
-		<div>{children}</div>
-	),
-	DropdownMenuItem: ({ children }: { children: ReactNode }) => (
-		<div>{children}</div>
-	),
-	DropdownMenuSeparator: () => <hr />,
-	DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
-		<div>{children}</div>
-	),
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
 
 vi.mock("../components/ui/toggle-group", () => ({
-	ToggleGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-	ToggleGroupItem: ({ children }: { children: ReactNode }) => (
-		<button type="button">{children}</button>
-	),
+  ToggleGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  ToggleGroupItem: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
 }));
 
 describe("Header", () => {
-	it("hides Packages navigation in soul mode on mobile and desktop", () => {
-		siteModeMock.mockReturnValue("souls");
+  beforeEach(() => {
+    authStatusMock.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+      me: null,
+    });
+    siteModeMock.mockReturnValue("souls");
+  });
 
-		render(<Header />);
+  it("hides Packages navigation in soul mode on mobile and desktop", () => {
+    siteModeMock.mockReturnValue("souls");
 
-		expect(screen.queryByText("Packages")).toBeNull();
-	});
+    render(<Header />);
 
-	it("renders simplified desktop nav and theme toggle", () => {
-		siteModeMock.mockReturnValue("skills");
-		setThemeMock.mockClear();
-		setModeMock.mockClear();
+    expect(screen.queryByText("Packages")).toBeNull();
+  });
 
-		render(<Header />);
+  it("renders simplified desktop nav and theme toggle", () => {
+    siteModeMock.mockReturnValue("skills");
+    setThemeMock.mockClear();
+    setModeMock.mockClear();
 
-		expect(
-			screen.getByRole("button", { name: /Toggle theme\. Current: system/i }),
-		).toBeTruthy();
-		expect(screen.getAllByText("Skills")).toHaveLength(1);
-		expect(screen.getAllByText("Plugins")).toHaveLength(1);
-		expect(screen.queryByText("Users")).toBeNull();
-		expect(screen.queryByText("Dashboard")).toBeNull();
-		expect(screen.queryByText("Manage")).toBeNull();
-		expect(
-			screen.getByPlaceholderText("Search skills, plugins, users"),
-		).toBeTruthy();
+    render(<Header />);
 
-		fireEvent.click(
-			screen.getByRole("button", { name: /Toggle theme\. Current: system/i }),
-		);
-		expect(setModeMock).toHaveBeenCalledWith("dark");
+    expect(screen.getByRole("button", { name: /Toggle theme\. Current: system/i })).toBeTruthy();
+    expect(screen.getAllByText("Skills")).toHaveLength(1);
+    expect(screen.getAllByText("Plugins")).toHaveLength(1);
+    expect(screen.queryByText("Users")).toBeNull();
+    expect(screen.queryByText("Dashboard")).toBeNull();
+    expect(screen.queryByText("Manage")).toBeNull();
+    expect(screen.getByPlaceholderText("Search skills, plugins, users")).toBeTruthy();
 
-		fireEvent.click(screen.getByRole("button", { name: "Open menu" }));
+    fireEvent.click(screen.getByRole("button", { name: /Toggle theme\. Current: system/i }));
+    expect(setModeMock).toHaveBeenCalledWith("dark");
 
-		expect(screen.getAllByText("Home")).toHaveLength(1);
-		expect(screen.getAllByText("Skills")).toHaveLength(2);
-		expect(screen.getAllByText("Plugins")).toHaveLength(2);
-	});
+    fireEvent.click(screen.getByRole("button", { name: "Open menu" }));
 
-	it("shows Home above Skills in the mobile menu", () => {
-		siteModeMock.mockReturnValue("skills");
+    expect(screen.getAllByText("Home")).toHaveLength(1);
+    expect(screen.getAllByText("Skills")).toHaveLength(2);
+    expect(screen.getAllByText("Plugins")).toHaveLength(2);
+  });
 
-		render(<Header />);
+  it("shows Home above Skills in the mobile menu", () => {
+    siteModeMock.mockReturnValue("skills");
 
-		fireEvent.click(screen.getByRole("button", { name: "Open menu" }));
+    render(<Header />);
 
-		expect(document.querySelector(".mobile-nav-brand-mark-image")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Open menu" }));
 
-		const labels = Array.from(
-			document.querySelectorAll(".mobile-nav-section .mobile-nav-link"),
-		)
-			.map((element) => element.textContent?.trim())
-			.filter((label): label is string => Boolean(label));
+    expect(document.querySelector(".mobile-nav-brand-mark-image")).toBeTruthy();
 
-		expect(labels.slice(0, 2)).toEqual(["Home", "Skills"]);
-	});
+    const labels = Array.from(document.querySelectorAll(".mobile-nav-section .mobile-nav-link"))
+      .map((element) => element.textContent?.trim())
+      .filter((label): label is string => Boolean(label));
 
-	it("routes soul-mode header searches to the souls browse page", () => {
-		siteModeMock.mockReturnValue("souls");
-		navigateMock.mockReset();
+    expect(labels.slice(0, 2)).toEqual(["Home", "Skills"]);
+  });
 
-		render(<Header />);
+  it("keeps Stars out of signed-in header navigation", () => {
+    siteModeMock.mockReturnValue("skills");
+    authStatusMock.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      me: {
+        displayName: "Patrick",
+        email: "patrick@example.com",
+        handle: "patrick",
+        image: null,
+        name: "Patrick",
+      },
+    });
 
-		fireEvent.change(screen.getByPlaceholderText("Search souls..."), {
-			target: { value: "angler" },
-		});
-		fireEvent.submit(screen.getByRole("search", { name: "Site search" }));
+    render(<Header />);
 
-		expect(navigateMock).toHaveBeenCalledWith({
-			to: "/souls",
-			search: {
-				q: "angler",
-				sort: undefined,
-				dir: undefined,
-				view: undefined,
-				focus: undefined,
-			},
-		});
-	});
+    expect(screen.queryByText("Stars")).toBeNull();
+    expect(screen.getAllByText("Dashboard").length).toBeGreaterThan(0);
+    expect(screen.getByText("Settings")).toBeTruthy();
+  });
+
+  it("routes soul-mode header searches to the souls browse page", () => {
+    siteModeMock.mockReturnValue("souls");
+    navigateMock.mockReset();
+
+    render(<Header />);
+
+    fireEvent.change(screen.getByPlaceholderText("Search souls..."), {
+      target: { value: "angler" },
+    });
+    fireEvent.submit(screen.getByRole("search", { name: "Site search" }));
+
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: "/souls",
+      search: {
+        q: "angler",
+        sort: undefined,
+        dir: undefined,
+        view: undefined,
+        focus: undefined,
+      },
+    });
+  });
 });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,11 +4,7 @@ import { Ghost, Menu, Moon, Plug, Search, Sun, Wrench } from "lucide-react";
 import { type ComponentType, useMemo, useState } from "react";
 import { getUserFacingAuthError } from "../lib/authErrorMessage";
 import { gravatarUrl } from "../lib/gravatar";
-import {
-  filterNavItems,
-  type NavIconName,
-  PRIMARY_NAV_ITEMS,
-} from "../lib/nav-items";
+import { filterNavItems, type NavIconName, PRIMARY_NAV_ITEMS } from "../lib/nav-items";
 import { isModerator } from "../lib/roles";
 import { getClawHubSiteUrl, getSiteMode, getSiteName } from "../lib/site";
 import { applyTheme, useThemeMode } from "../lib/theme";
@@ -176,7 +172,12 @@ export default function Header() {
             <span className="brand-name brand-name-responsive">{siteName}</span>
           </Link>
 
-          <form className="navbar-search" onSubmit={handleNavSearch} role="search" aria-label="Site search">
+          <form
+            className="navbar-search"
+            onSubmit={handleNavSearch}
+            role="search"
+            aria-label="Site search"
+          >
             <Search size={16} className="navbar-search-icon" aria-hidden="true" />
             <input
               className="navbar-search-input"
@@ -249,9 +250,6 @@ export default function Header() {
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
                   <DropdownMenuItem asChild>
-                    <Link to="/stars">Stars</Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem asChild>
                     <Link to="/dashboard">Dashboard</Link>
                   </DropdownMenuItem>
                   <DropdownMenuItem asChild>
@@ -287,7 +285,9 @@ export default function Header() {
                       "github",
                       signInRedirectTo ? { redirectTo: signInRedirectTo } : undefined,
                     ).catch((error) => {
-                      setAuthError(getUserFacingAuthError(error, "Sign in failed. Please try again."));
+                      setAuthError(
+                        getUserFacingAuthError(error, "Sign in failed. Please try again."),
+                      );
                     });
                   }}
                 >
@@ -312,7 +312,6 @@ export default function Header() {
             />
           </form>
         ) : null}
-
       </div>
     </header>
   );

--- a/src/routes/-settings.test.tsx
+++ b/src/routes/-settings.test.tsx
@@ -1,6 +1,8 @@
 /* @vitest-environment jsdom */
 import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../convex/_generated/api";
 import { Settings } from "./settings";
 
 const useQueryMock = vi.fn();
@@ -15,6 +17,15 @@ vi.mock("convex/react", () => ({
 vi.mock("@convex-dev/auth/react", () => ({
   useAuthActions: () => useAuthActionsMock(),
 }));
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual =
+    await vi.importActual<typeof import("@tanstack/react-router")>("@tanstack/react-router");
+  return {
+    ...actual,
+    Link: ({ children, to }: { children: ReactNode; to: string }) => <a href={to}>{children}</a>,
+  };
+});
 
 describe("Settings", () => {
   beforeEach(() => {
@@ -34,5 +45,31 @@ describe("Settings", () => {
 
     expect(screen.getByText(/sign in to access settings\./i)).toBeTruthy();
     expect(useQueryMock.mock.calls.some(([, args]) => args === "skip")).toBe(true);
+  });
+
+  it("links to starred skills from signed-in settings", () => {
+    useQueryMock.mockImplementation((query, args) => {
+      if (query === api.users.me) {
+        return {
+          _id: "user_123",
+          displayName: "Patrick",
+          name: "Patrick",
+          handle: "patrick",
+          email: "patrick@example.com",
+          image: null,
+          bio: null,
+        };
+      }
+      if (args === "skip") return undefined;
+      if (args && typeof args === "object" && "publisherHandle" in args) {
+        return undefined;
+      }
+      return [];
+    });
+
+    render(<Settings />);
+
+    expect(screen.getByRole("heading", { name: "Stars" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "View stars" }).getAttribute("href")).toBe("/stars");
   });
 });

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
 import {
   Eye,
@@ -9,6 +9,7 @@ import {
   Moon,
   RotateCcw,
   Settings2,
+  Star,
   Sun,
 } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -257,6 +258,21 @@ export function Settings() {
           </CardContent>
         </Card>
 
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Star size={18} />
+              Stars
+            </CardTitle>
+            <CardDescription>Review skills you&apos;ve starred for quick access.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button asChild variant="outline">
+              <Link to="/stars">View stars</Link>
+            </Button>
+          </CardContent>
+        </Card>
+
         {/* Edit profile form */}
         <Card>
           <form className="flex flex-col gap-4" onSubmit={onSave}>
@@ -297,9 +313,7 @@ export function Settings() {
                   <Settings2 size={18} />
                   Customization
                 </CardTitle>
-                <CardDescription>
-                  Personalize your ClawHub experience
-                </CardDescription>
+                <CardDescription>Personalize your ClawHub experience</CardDescription>
               </div>
               <div className="flex items-center gap-2">
                 <Label htmlFor="advanced-mode" className="text-sm text-[color:var(--ink-soft)]">
@@ -316,7 +330,9 @@ export function Settings() {
           <CardContent className="space-y-6">
             {/* Theme Section */}
             <div className="space-y-3">
-              <Label id="theme" className="text-sm font-semibold text-[color:var(--ink)]">Theme</Label>
+              <Label id="theme" className="text-sm font-semibold text-[color:var(--ink)]">
+                Theme
+              </Label>
               <div className="flex flex-wrap gap-2">
                 <Button
                   variant={themeMode === "light" ? "primary" : "ghost"}
@@ -392,7 +408,7 @@ export function Settings() {
             {/* Layout Section */}
             <div className="space-y-4">
               <Label className="text-sm font-semibold text-[color:var(--ink)]">Layout</Label>
-              
+
               <div className="grid gap-4 sm:grid-cols-2">
                 <div className="space-y-2">
                   <Label htmlFor="layout-density" className="text-xs text-[color:var(--ink-soft)]">
@@ -400,7 +416,9 @@ export function Settings() {
                   </Label>
                   <Select
                     value={preferences.layoutDensity}
-                    onValueChange={(value) => updatePreference("layoutDensity", value as LayoutDensity)}
+                    onValueChange={(value) =>
+                      updatePreference("layoutDensity", value as LayoutDensity)
+                    }
                   >
                     <SelectTrigger id="layout-density">
                       <SelectValue />
@@ -428,7 +446,9 @@ export function Settings() {
                   </Label>
                   <Select
                     value={preferences.listViewMode}
-                    onValueChange={(value) => updatePreference("listViewMode", value as ListViewMode)}
+                    onValueChange={(value) =>
+                      updatePreference("listViewMode", value as ListViewMode)
+                    }
                   >
                     <SelectTrigger id="list-view">
                       <SelectValue />
@@ -453,7 +473,9 @@ export function Settings() {
 
               <div className="space-y-3">
                 <div className="flex items-center justify-between">
-                  <Label htmlFor="show-descriptions" className="text-sm">Show descriptions</Label>
+                  <Label htmlFor="show-descriptions" className="text-sm">
+                    Show descriptions
+                  </Label>
                   <Switch
                     id="show-descriptions"
                     checked={preferences.showDescriptions}
@@ -461,7 +483,9 @@ export function Settings() {
                   />
                 </div>
                 <div className="flex items-center justify-between">
-                  <Label htmlFor="show-stats" className="text-sm">Show statistics</Label>
+                  <Label htmlFor="show-stats" className="text-sm">
+                    Show statistics
+                  </Label>
                   <Switch
                     id="show-stats"
                     checked={preferences.showStats}
@@ -469,7 +493,9 @@ export function Settings() {
                   />
                 </div>
                 <div className="flex items-center justify-between">
-                  <Label htmlFor="show-tags" className="text-sm">Show tags</Label>
+                  <Label htmlFor="show-tags" className="text-sm">
+                    Show tags
+                  </Label>
                   <Switch
                     id="show-tags"
                     checked={preferences.showTags}
@@ -477,7 +503,9 @@ export function Settings() {
                   />
                 </div>
                 <div className="flex items-center justify-between">
-                  <Label htmlFor="sticky-header" className="text-sm">Sticky header</Label>
+                  <Label htmlFor="sticky-header" className="text-sm">
+                    Sticky header
+                  </Label>
                   <Switch
                     id="sticky-header"
                     checked={preferences.stickyHeader}
@@ -496,15 +524,20 @@ export function Settings() {
                   <Label className="text-sm font-semibold text-[color:var(--ink)]">
                     Code &amp; Content
                   </Label>
-                  
+
                   <div className="grid gap-4 sm:grid-cols-2">
                     <div className="space-y-2">
-                      <Label htmlFor="code-font-size" className="text-xs text-[color:var(--ink-soft)]">
+                      <Label
+                        htmlFor="code-font-size"
+                        className="text-xs text-[color:var(--ink-soft)]"
+                      >
                         Code font size
                       </Label>
                       <Select
                         value={preferences.codeFontSize}
-                        onValueChange={(value) => updatePreference("codeFontSize", value as CodeFontSize)}
+                        onValueChange={(value) =>
+                          updatePreference("codeFontSize", value as CodeFontSize)
+                        }
                       >
                         <SelectTrigger id="code-font-size">
                           <SelectValue />
@@ -518,20 +551,23 @@ export function Settings() {
                     </div>
 
                     <div className="space-y-2">
-                      <Label htmlFor="animation-level" className="text-xs text-[color:var(--ink-soft)]">
+                      <Label
+                        htmlFor="animation-level"
+                        className="text-xs text-[color:var(--ink-soft)]"
+                      >
                         Animation level
                       </Label>
                       <Select
                         value={preferences.animationLevel}
-                        onValueChange={(value) => updatePreference("animationLevel", value as AnimationLevel)}
+                        onValueChange={(value) =>
+                          updatePreference("animationLevel", value as AnimationLevel)
+                        }
                       >
                         <SelectTrigger id="animation-level">
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="full">
-                            Full
-                          </SelectItem>
+                          <SelectItem value="full">Full</SelectItem>
                           <SelectItem value="reduced">Reduced</SelectItem>
                           <SelectItem value="none">None</SelectItem>
                         </SelectContent>
@@ -541,7 +577,9 @@ export function Settings() {
 
                   <div className="space-y-3">
                     <div className="flex items-center justify-between">
-                      <Label htmlFor="line-numbers" className="text-sm">Line numbers in code</Label>
+                      <Label htmlFor="line-numbers" className="text-sm">
+                        Line numbers in code
+                      </Label>
                       <Switch
                         id="line-numbers"
                         checked={preferences.lineNumbers}
@@ -549,7 +587,9 @@ export function Settings() {
                       />
                     </div>
                     <div className="flex items-center justify-between">
-                      <Label htmlFor="word-wrap" className="text-sm">Word wrap in code</Label>
+                      <Label htmlFor="word-wrap" className="text-sm">
+                        Word wrap in code
+                      </Label>
                       <Switch
                         id="word-wrap"
                         checked={preferences.wordWrap}
@@ -567,11 +607,13 @@ export function Settings() {
                     <Eye size={14} className="text-[color:var(--accent)]" />
                     Accessibility
                   </Label>
-                  
+
                   <div className="space-y-3">
                     <div className="flex items-center justify-between">
                       <div>
-                        <Label htmlFor="reduced-motion" className="text-sm">Reduced motion</Label>
+                        <Label htmlFor="reduced-motion" className="text-sm">
+                          Reduced motion
+                        </Label>
                         <p className="text-xs text-[color:var(--ink-soft)]">Minimize animations</p>
                       </div>
                       <Switch
@@ -582,8 +624,12 @@ export function Settings() {
                     </div>
                     <div className="flex items-center justify-between">
                       <div>
-                        <Label htmlFor="high-contrast" className="text-sm">High contrast</Label>
-                        <p className="text-xs text-[color:var(--ink-soft)]">Increase color contrast</p>
+                        <Label htmlFor="high-contrast" className="text-sm">
+                          High contrast
+                        </Label>
+                        <p className="text-xs text-[color:var(--ink-soft)]">
+                          Increase color contrast
+                        </p>
                       </div>
                       <Switch
                         id="high-contrast"
@@ -601,16 +647,22 @@ export function Settings() {
                   <Label className="text-sm font-semibold text-[color:var(--ink)]">
                     Experimental
                   </Label>
-                  
+
                   <div className="flex items-center justify-between">
                     <div>
-                      <Label htmlFor="experimental-features" className="text-sm">Enable experimental features</Label>
-                      <p className="text-xs text-[color:var(--ink-soft)]">Try new features before they&apos;re released</p>
+                      <Label htmlFor="experimental-features" className="text-sm">
+                        Enable experimental features
+                      </Label>
+                      <p className="text-xs text-[color:var(--ink-soft)]">
+                        Try new features before they&apos;re released
+                      </p>
                     </div>
                     <Switch
                       id="experimental-features"
                       checked={preferences.experimentalFeatures}
-                      onCheckedChange={(checked) => updatePreference("experimentalFeatures", checked)}
+                      onCheckedChange={(checked) =>
+                        updatePreference("experimentalFeatures", checked)
+                      }
                     />
                   </div>
                 </div>
@@ -623,7 +675,9 @@ export function Settings() {
             <div className="flex items-center justify-between">
               <div>
                 <p className="text-sm font-medium text-[color:var(--ink)]">Reset preferences</p>
-                <p className="text-xs text-[color:var(--ink-soft)]">Restore all settings to defaults</p>
+                <p className="text-xs text-[color:var(--ink-soft)]">
+                  Restore all settings to defaults
+                </p>
               </div>
               <Button
                 variant="ghost"


### PR DESCRIPTION
## Summary

- Move the Stars account link into the signed-in settings page.
- Remove Stars from the account dropdown.
- Add focused tests for the settings link and header menu behavior.

## Tests
- bun run test -- src/routes/-settings.test.tsx src/__tests__/header.test.tsx
- bun run test
- bun run lint
- bunx tsc -p packages/schema/tsconfig.json --noEmit && bunx tsc -p packages/clawhub/tsconfig.json --noEmit

- bun run build







