### PR TITLE
fix(slug): enforce length, pattern, and reserved-word rules on skill & soul slugs

### DIFF
--- a/convex/lib/skillPublish.ts
+++ b/convex/lib/skillPublish.ts
@@ -34,7 +34,7 @@ import {
   parseFrontmatter,
   sanitizePath,
 } from "./skills";
-import { assertValidSkillSlug } from "./skillSlugValidator";
+import { assertValidSkillSlug, normalizeSkillSlug } from "./skillSlugValidator";
 import { generateSkillSummary } from "./skillSummary";
 import { runStaticPublishScan } from "./staticPublishScan";
 import type { WebhookSkillPayload } from "./webhooks";
@@ -91,8 +91,14 @@ export async function publishVersionForUser(
   options: PublishOptions = {},
 ): Promise<PublishResult> {
   const version = args.version.trim();
-  // Full slug validation: length, pattern, reserved-word blocklist, etc.
-  const slug = assertValidSkillSlug(args.slug);
+  // Normalize first so we can look up the existing skill before deciding
+  // how strictly to validate. The reserved-word blocklist and length floor
+  // are only enforced for brand-new skills; owners of grandfathered slugs
+  // (reserved, <3 chars, or >48 chars) must still be able to publish new
+  // versions without being blocked by the write-path validator.
+  const normalizedSlug = normalizeSkillSlug(args.slug);
+  if (!normalizedSlug) throw new ConvexError("Slug is required.");
+
   const displayName = args.displayName.trim();
   if (!displayName) throw new ConvexError("Display name required");
   if (!semver.valid(version)) {
@@ -103,9 +109,18 @@ export async function publishVersionForUser(
     await requireGitHubAccountAge(ctx, userId);
   }
   const existingSkill = (await ctx.runQuery(internal.skills.getSkillBySlugInternal, {
-    slug,
+    slug: normalizedSlug,
   })) as Doc<"skills"> | null;
   const isNewSkill = !existingSkill;
+
+  // For new skills, enforce the full write-path rules (length, pattern,
+  // reserved-word blocklist). For existing skills the slug is already
+  // persisted and grandfathered — re-validating it would block legitimate
+  // version publishes on legacy rows.
+  if (isNewSkill) {
+    assertValidSkillSlug(normalizedSlug);
+  }
+  const slug = normalizedSlug;
 
   const suppliedChangelog = args.changelog.trim();
   const changelogSource = suppliedChangelog ? ("user" as const) : ("auto" as const);

--- a/convex/lib/skillPublish.ts
+++ b/convex/lib/skillPublish.ts
@@ -16,6 +16,7 @@ import {
   MAX_PUBLISH_TOTAL_BYTES,
 } from "./publishLimits";
 import { deriveSkillCapabilityTags } from "./skillCapabilityTags";
+import { assertValidSkillSlug } from "./skillSlugValidator";
 import {
   computeQualitySignals,
   evaluateQuality,
@@ -90,12 +91,10 @@ export async function publishVersionForUser(
   options: PublishOptions = {},
 ): Promise<PublishResult> {
   const version = args.version.trim();
-  const slug = args.slug.trim().toLowerCase();
+  // Full slug validation: length, pattern, reserved-word blocklist, etc.
+  const slug = assertValidSkillSlug(args.slug);
   const displayName = args.displayName.trim();
-  if (!slug || !displayName) throw new ConvexError("Slug and display name required");
-  if (!/^[a-z0-9][a-z0-9-]*$/.test(slug)) {
-    throw new ConvexError("Slug must be lowercase and url-safe");
-  }
+  if (!displayName) throw new ConvexError("Display name required");
   if (!semver.valid(version)) {
     throw new ConvexError("Version must be valid semver");
   }

--- a/convex/lib/skillPublish.ts
+++ b/convex/lib/skillPublish.ts
@@ -16,7 +16,6 @@ import {
   MAX_PUBLISH_TOTAL_BYTES,
 } from "./publishLimits";
 import { deriveSkillCapabilityTags } from "./skillCapabilityTags";
-import { assertValidSkillSlug } from "./skillSlugValidator";
 import {
   computeQualitySignals,
   evaluateQuality,
@@ -35,6 +34,7 @@ import {
   parseFrontmatter,
   sanitizePath,
 } from "./skills";
+import { assertValidSkillSlug } from "./skillSlugValidator";
 import { generateSkillSummary } from "./skillSummary";
 import { runStaticPublishScan } from "./staticPublishScan";
 import type { WebhookSkillPayload } from "./webhooks";

--- a/convex/lib/skillSlugValidator.test.ts
+++ b/convex/lib/skillSlugValidator.test.ts
@@ -174,10 +174,13 @@ describe("isSearchableSkillSlugShape", () => {
     expect(isSearchableSkillSlugShape("-")).toBe(false);
   });
 
-  it("still enforces the upper length bound", () => {
+  it("accepts slugs longer than the write-path upper bound (legacy rows)", () => {
+    // Legacy rows predate MAX_SLUG_LENGTH and may exceed 48 chars. The read
+    // path must still resolve them via the by_slug fast path; otherwise
+    // searchSkills falls back to scanning only the most recent digests and
+    // can miss older records entirely.
     expect(isSearchableSkillSlugShape("a".repeat(SKILL_SLUG_CONSTRAINTS.maxLength))).toBe(true);
-    expect(isSearchableSkillSlugShape("a".repeat(SKILL_SLUG_CONSTRAINTS.maxLength + 1))).toBe(
-      false,
-    );
+    expect(isSearchableSkillSlugShape("a".repeat(SKILL_SLUG_CONSTRAINTS.maxLength + 1))).toBe(true);
+    expect(isSearchableSkillSlugShape("a".repeat(200))).toBe(true);
   });
 });

--- a/convex/lib/skillSlugValidator.test.ts
+++ b/convex/lib/skillSlugValidator.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   assertValidSkillSlug,
   isReservedSkillSlug,
+  isSearchableSkillSlugShape,
   isValidSkillSlugShape,
   normalizeSkillSlug,
   normalizeSkillSlugOrNull,
@@ -132,5 +133,51 @@ describe("isReservedSkillSlug", () => {
     expect(isReservedSkillSlug("my-skill")).toBe(false);
     expect(isReservedSkillSlug("")).toBe(false);
     expect(isReservedSkillSlug(null)).toBe(false);
+  });
+});
+
+describe("isSearchableSkillSlugShape", () => {
+  it("accepts slugs shorter than the write-path minimum (legacy rows)", () => {
+    // Single- and two-character slugs predate the min-length floor but may
+    // still exist in the skills table. Search must surface them via the
+    // exact-slug fast path.
+    expect(isSearchableSkillSlugShape("a")).toBe(true);
+    expect(isSearchableSkillSlugShape("ab")).toBe(true);
+    expect(isSearchableSkillSlugShape("a1")).toBe(true);
+  });
+
+  it("accepts regular well-formed slugs", () => {
+    expect(isSearchableSkillSlugShape("abc")).toBe(true);
+    expect(isSearchableSkillSlugShape("my-skill-1")).toBe(true);
+  });
+
+  it("accepts reserved slugs (read path ignores the blocklist)", () => {
+    // Legacy data may still carry reserved slugs; they must remain
+    // searchable even though the write path would now reject them.
+    expect(isSearchableSkillSlugShape("admin")).toBe(true);
+    expect(isSearchableSkillSlugShape("u")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isSearchableSkillSlugShape("A-B")).toBe(true);
+    expect(isSearchableSkillSlugShape("  My-Skill  ")).toBe(true);
+  });
+
+  it("still rejects malformed shapes", () => {
+    expect(isSearchableSkillSlugShape("")).toBe(false);
+    expect(isSearchableSkillSlugShape("   ")).toBe(false);
+    expect(isSearchableSkillSlugShape("-abc")).toBe(false);
+    expect(isSearchableSkillSlugShape("abc-")).toBe(false);
+    expect(isSearchableSkillSlugShape("a--b")).toBe(false);
+    expect(isSearchableSkillSlugShape("a_b")).toBe(false);
+    expect(isSearchableSkillSlugShape("a b")).toBe(false);
+    expect(isSearchableSkillSlugShape("-")).toBe(false);
+  });
+
+  it("still enforces the upper length bound", () => {
+    expect(isSearchableSkillSlugShape("a".repeat(SKILL_SLUG_CONSTRAINTS.maxLength))).toBe(true);
+    expect(isSearchableSkillSlugShape("a".repeat(SKILL_SLUG_CONSTRAINTS.maxLength + 1))).toBe(
+      false,
+    );
   });
 });

--- a/convex/lib/skillSlugValidator.test.ts
+++ b/convex/lib/skillSlugValidator.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertValidSkillSlug,
+  isReservedSkillSlug,
+  isValidSkillSlugShape,
+  normalizeSkillSlug,
+  normalizeSkillSlugOrNull,
+  SKILL_SLUG_CONSTRAINTS,
+} from "./skillSlugValidator";
+
+describe("normalizeSkillSlug", () => {
+  it("trims and lowercases", () => {
+    expect(normalizeSkillSlug("  Hello-World  ")).toBe("hello-world");
+  });
+
+  it("returns empty string for nullish", () => {
+    expect(normalizeSkillSlug(undefined)).toBe("");
+    expect(normalizeSkillSlug(null)).toBe("");
+  });
+});
+
+describe("normalizeSkillSlugOrNull", () => {
+  it("returns null for empty input", () => {
+    expect(normalizeSkillSlugOrNull("   ")).toBeNull();
+    expect(normalizeSkillSlugOrNull(null)).toBeNull();
+  });
+
+  it("returns normalized slug for non-empty input", () => {
+    expect(normalizeSkillSlugOrNull("  MySkill  ")).toBe("myskill");
+  });
+});
+
+describe("assertValidSkillSlug", () => {
+  it.each([
+    "abc",
+    "my-cool-skill",
+    "skill-123",
+    "a1b",
+    "123",
+    "abc-def-ghi",
+    "z".repeat(SKILL_SLUG_CONSTRAINTS.maxLength),
+  ])("accepts valid slug %s", (slug) => {
+    expect(() => assertValidSkillSlug(slug)).not.toThrow();
+    expect(assertValidSkillSlug(slug)).toBe(slug.toLowerCase());
+  });
+
+  it("normalizes mixed case and whitespace before validating", () => {
+    expect(assertValidSkillSlug("  My-Cool-Skill  ")).toBe("my-cool-skill");
+  });
+
+  it("silently lowercases uppercase input (legacy-compatible)", () => {
+    // Historically, write paths did `args.slug.trim().toLowerCase()` before
+    // validating. We preserve that behaviour: uppercase input is normalized,
+    // not rejected outright.
+    expect(assertValidSkillSlug("A-B-C")).toBe("a-b-c");
+  });
+
+  it.each([
+    ["", "required"],
+    [" ", "required"],
+    ["ab", "at least"],
+    ["a".repeat(SKILL_SLUG_CONSTRAINTS.maxLength + 1), "at most"],
+    ["-abc", "start and end"],
+    ["abc-", "start and end"],
+    ["a--b", "start and end"],
+    ["a---b", "start and end"],
+    ["a_b", "start and end"],
+    ["a.b", "start and end"],
+    ["a b", "start and end"],
+    ["a/b", "start and end"],
+  ])("rejects invalid slug %s", (slug, hint) => {
+    expect(() => assertValidSkillSlug(slug)).toThrow(new RegExp(hint, "i"));
+  });
+
+  it.each(["admin", "settings", "api", "openclaw", "clawhub", "souls", "packages"])(
+    "rejects reserved slug %s",
+    (slug) => {
+      // Some short reserved entries (e.g. "u") are also blocked by the
+      // length rule; we only assert that a throw happens for every entry.
+      expect(() => assertValidSkillSlug(slug)).toThrow();
+    },
+  );
+
+  it("emits the reserved-specific error for long reserved slugs", () => {
+    expect(() => assertValidSkillSlug("openclaw")).toThrow(/reserved/i);
+  });
+
+  it("allows reserved slugs when allowReserved is set", () => {
+    expect(() => assertValidSkillSlug("admin", { allowReserved: true })).not.toThrow();
+    expect(assertValidSkillSlug("admin", { allowReserved: true })).toBe("admin");
+  });
+});
+
+describe("isValidSkillSlugShape", () => {
+  it("returns true for well-formed slugs", () => {
+    expect(isValidSkillSlugShape("abc")).toBe(true);
+    expect(isValidSkillSlugShape("my-skill-1")).toBe(true);
+  });
+
+  it("returns true for reserved slugs (shape only)", () => {
+    // The reserved-word blocklist is intentionally NOT consulted here so
+    // that legacy rows carrying reserved slugs remain lookup-able.
+    expect(isValidSkillSlugShape("admin")).toBe(true);
+  });
+
+  it("is case-insensitive (normalizes before checking)", () => {
+    // Matches legacy read-path behaviour: search queries like "My-Skill"
+    // should still resolve to the slug row.
+    expect(isValidSkillSlugShape("A-B")).toBe(true);
+  });
+
+  it("returns false for malformed slugs", () => {
+    expect(isValidSkillSlugShape("a")).toBe(false);
+    expect(isValidSkillSlugShape("ab")).toBe(false);
+    expect(isValidSkillSlugShape("a--b")).toBe(false);
+    expect(isValidSkillSlugShape("-abc")).toBe(false);
+    expect(isValidSkillSlugShape("abc-")).toBe(false);
+    expect(isValidSkillSlugShape("a_b")).toBe(false);
+    expect(isValidSkillSlugShape("")).toBe(false);
+    expect(isValidSkillSlugShape("a".repeat(SKILL_SLUG_CONSTRAINTS.maxLength + 1))).toBe(false);
+  });
+});
+
+describe("isReservedSkillSlug", () => {
+  it("identifies reserved slugs case-insensitively", () => {
+    expect(isReservedSkillSlug("admin")).toBe(true);
+    expect(isReservedSkillSlug("  ADMIN  ")).toBe(true);
+    expect(isReservedSkillSlug("openclaw")).toBe(true);
+  });
+
+  it("returns false for non-reserved slugs", () => {
+    expect(isReservedSkillSlug("my-skill")).toBe(false);
+    expect(isReservedSkillSlug("")).toBe(false);
+    expect(isReservedSkillSlug(null)).toBe(false);
+  });
+});

--- a/convex/lib/skillSlugValidator.ts
+++ b/convex/lib/skillSlugValidator.ts
@@ -163,19 +163,22 @@ export function isValidSkillSlugShape(value: string | undefined | null): boolean
  * Lenient shape check used by read paths (search exact-slug optimization,
  * redirect lookups, etc.).
  *
- * Unlike isValidSkillSlugShape, this predicate intentionally omits the
- * min-length floor so legacy rows whose slugs were persisted before the
- * current MIN_SLUG_LENGTH was introduced remain discoverable via exact
- * slug match. The max-length cap is still enforced to avoid unbounded
- * inputs hitting the by_slug index. The reserved-word blocklist is also
- * skipped for the same reason (grandfathered data must stay readable).
+ * Unlike isValidSkillSlugShape, this predicate intentionally omits:
+ *   - the min-length floor (legacy rows with 1- or 2-char slugs must stay
+ *     retrievable via the by_slug fast path),
+ *   - the max-length cap (rows persisted before MAX_SLUG_LENGTH was
+ *     introduced may exceed 48 chars and must remain lookup-able; the
+ *     indexed point lookup for a missing key is cheap, and upstream
+ *     request-body limits bound the practical query length),
+ *   - the reserved-word blocklist (grandfathered data must stay readable).
  *
  * Write paths MUST continue to use assertValidSkillSlug, which enforces
- * the full validation surface (length floor + reserved blocklist).
+ * the full validation surface (length floor + length cap + pattern +
+ * reserved blocklist).
  */
 export function isSearchableSkillSlugShape(value: string | undefined | null): boolean {
   const normalized = normalizeSkillSlug(value);
-  if (normalized.length === 0 || normalized.length > MAX_SLUG_LENGTH) {
+  if (normalized.length === 0) {
     return false;
   }
   // Single-character legacy slug: a bare [a-z0-9] is searchable. The full

--- a/convex/lib/skillSlugValidator.ts
+++ b/convex/lib/skillSlugValidator.ts
@@ -1,0 +1,197 @@
+import { ConvexError } from "convex/values";
+
+// Slug shape rules:
+// - Lowercase letters, digits, and single hyphens only.
+// - Must start and end with a letter or digit.
+// - No consecutive hyphens ("--", "---", ...).
+// - Length 3..48 (URL/SEO friendly, aligned with publisher handle).
+//
+// The pattern enforces first/last char class and forbids consecutive hyphens
+// via a negative lookahead. Length bounds are checked separately so we can
+// emit precise error messages.
+const SLUG_PATTERN = /^[a-z0-9](?:(?!--)[a-z0-9-])*[a-z0-9]$/;
+
+const MIN_SLUG_LENGTH = 3;
+const MAX_SLUG_LENGTH = 48;
+
+// Reserved slugs. These are blocked because they would:
+// 1. Clash semantically with top-level routes under src/routes/*.
+// 2. Allow brand/role impersonation (e.g. "official", "clawhub").
+// 3. Lock future route expansion (e.g. "api", "auth", "oauth").
+//
+// Keep this list in sync with:
+//   - src/routes/*.tsx top-level segments
+//   - brand names shipped in README.md
+const RESERVED_SKILL_SLUGS: ReadonlySet<string> = new Set([
+  // Current top-level route segments under src/routes/.
+  "about",
+  "admin",
+  "cli",
+  "dashboard",
+  "import",
+  "management",
+  "orgs",
+  "packages",
+  "plugins",
+  "publish",
+  "publish-plugin",
+  "publish-skill",
+  "search",
+  "settings",
+  "skills",
+  "souls",
+  "stars",
+  "u",
+  "upload",
+  "users",
+  // Reserved for likely future additions.
+  "api",
+  "auth",
+  "oauth",
+  "callback",
+  "login",
+  "logout",
+  "signin",
+  "signout",
+  "signup",
+  "register",
+  "docs",
+  "doc",
+  "help",
+  "support",
+  "status",
+  "health",
+  "blog",
+  "news",
+  "pricing",
+  "terms",
+  "privacy",
+  "legal",
+  "contact",
+  "home",
+  "explore",
+  // Brand and project names.
+  "openclaw",
+  "clawhub",
+  "clawd",
+  "clawdbot",
+  "onlycrabs",
+  "soulhub",
+  // Generic identity / role words.
+  "me",
+  "self",
+  "system",
+  "root",
+  "owner",
+  "official",
+  "staff",
+  "team",
+  "mod",
+  "moderator",
+  // Reserved CRUD/action words that would make URLs ambiguous.
+  "new",
+  "edit",
+  "delete",
+  "create",
+  "update",
+  "remove",
+  "public",
+  "private",
+  "internal",
+  // Literals that would be confusing in URLs.
+  "null",
+  "undefined",
+  "true",
+  "false",
+]);
+
+export interface ValidateSlugOptions {
+  /**
+   * Bypass the reserved-word blocklist.
+   * Intended for admin migrations / internal seeding only.
+   */
+  allowReserved?: boolean;
+}
+
+export const SKILL_SLUG_CONSTRAINTS = {
+  minLength: MIN_SLUG_LENGTH,
+  maxLength: MAX_SLUG_LENGTH,
+  pattern: SLUG_PATTERN,
+  reserved: RESERVED_SKILL_SLUGS,
+} as const;
+
+/**
+ * Lowercase and trim a slug. Does not throw.
+ *
+ * Safe to call on any read-path input (query by slug, redirect lookup, ...)
+ * without rejecting legacy data.
+ */
+export function normalizeSkillSlug(raw: string | undefined | null): string {
+  return (raw ?? "").trim().toLowerCase();
+}
+
+/**
+ * Variant that returns null when the input normalizes to an empty string.
+ * Useful at read-path call sites that want to short-circuit lookup.
+ */
+export function normalizeSkillSlugOrNull(raw: string | undefined | null): string | null {
+  const normalized = normalizeSkillSlug(raw);
+  return normalized.length ? normalized : null;
+}
+
+/**
+ * Check whether a string already matches the full slug shape rules.
+ * Returns true only when the value is a plausible slug (length, pattern).
+ *
+ * Used by search to decide whether to attempt an exact-slug lookup.
+ * Note: this intentionally does NOT consult the reserved-word blocklist
+ * because legacy rows may still carry reserved slugs and we want to
+ * keep them readable.
+ */
+export function isValidSkillSlugShape(value: string | undefined | null): boolean {
+  const normalized = normalizeSkillSlug(value);
+  if (normalized.length < MIN_SLUG_LENGTH || normalized.length > MAX_SLUG_LENGTH) {
+    return false;
+  }
+  return SLUG_PATTERN.test(normalized);
+}
+
+/**
+ * Returns a normalized slug or throws ConvexError describing the first
+ * violation encountered. Use this on every write path (publish/rename).
+ */
+export function assertValidSkillSlug(
+  rawSlug: string | undefined | null,
+  options: ValidateSlugOptions = {},
+): string {
+  const normalized = normalizeSkillSlug(rawSlug);
+
+  if (!normalized) {
+    throw new ConvexError("Slug is required.");
+  }
+  if (normalized.length < MIN_SLUG_LENGTH) {
+    throw new ConvexError(`Slug must be at least ${MIN_SLUG_LENGTH} characters.`);
+  }
+  if (normalized.length > MAX_SLUG_LENGTH) {
+    throw new ConvexError(`Slug must be at most ${MAX_SLUG_LENGTH} characters.`);
+  }
+  if (!SLUG_PATTERN.test(normalized)) {
+    throw new ConvexError(
+      "Slug must start and end with a letter or digit, contain only lowercase letters, " +
+        "digits, and single hyphens, and not contain consecutive hyphens.",
+    );
+  }
+  if (!options.allowReserved && RESERVED_SKILL_SLUGS.has(normalized)) {
+    throw new ConvexError(`"${normalized}" is reserved and cannot be used as a slug.`);
+  }
+  return normalized;
+}
+
+/**
+ * Convenience predicate: is the slug on the reserved blocklist?
+ * Exposed so callers (e.g. admin tooling) can pre-check without a throw.
+ */
+export function isReservedSkillSlug(slug: string | undefined | null): boolean {
+  const normalized = normalizeSkillSlug(slug);
+  return RESERVED_SKILL_SLUGS.has(normalized);
+}

--- a/convex/lib/skillSlugValidator.ts
+++ b/convex/lib/skillSlugValidator.ts
@@ -143,15 +143,46 @@ export function normalizeSkillSlugOrNull(raw: string | undefined | null): string
  * Check whether a string already matches the full slug shape rules.
  * Returns true only when the value is a plausible slug (length, pattern).
  *
- * Used by search to decide whether to attempt an exact-slug lookup.
  * Note: this intentionally does NOT consult the reserved-word blocklist
  * because legacy rows may still carry reserved slugs and we want to
- * keep them readable.
+ * keep them readable. It DOES enforce the current min-length floor
+ * (MIN_SLUG_LENGTH) and is therefore only appropriate for call sites
+ * that treat a value as a "newly-shaped" slug. For read-only lookups
+ * (search, redirect) that must stay discoverable for pre-existing
+ * short slugs, use isSearchableSkillSlugShape instead.
  */
 export function isValidSkillSlugShape(value: string | undefined | null): boolean {
   const normalized = normalizeSkillSlug(value);
   if (normalized.length < MIN_SLUG_LENGTH || normalized.length > MAX_SLUG_LENGTH) {
     return false;
+  }
+  return SLUG_PATTERN.test(normalized);
+}
+
+/**
+ * Lenient shape check used by read paths (search exact-slug optimization,
+ * redirect lookups, etc.).
+ *
+ * Unlike isValidSkillSlugShape, this predicate intentionally omits the
+ * min-length floor so legacy rows whose slugs were persisted before the
+ * current MIN_SLUG_LENGTH was introduced remain discoverable via exact
+ * slug match. The max-length cap is still enforced to avoid unbounded
+ * inputs hitting the by_slug index. The reserved-word blocklist is also
+ * skipped for the same reason (grandfathered data must stay readable).
+ *
+ * Write paths MUST continue to use assertValidSkillSlug, which enforces
+ * the full validation surface (length floor + reserved blocklist).
+ */
+export function isSearchableSkillSlugShape(value: string | undefined | null): boolean {
+  const normalized = normalizeSkillSlug(value);
+  if (normalized.length === 0 || normalized.length > MAX_SLUG_LENGTH) {
+    return false;
+  }
+  // Single-character legacy slug: a bare [a-z0-9] is searchable. The full
+  // SLUG_PATTERN requires >=2 chars (separate first/last classes), so we
+  // handle the single-char case explicitly before delegating to it.
+  if (normalized.length === 1) {
+    return /^[a-z0-9]$/.test(normalized);
   }
   return SLUG_PATTERN.test(normalized);
 }

--- a/convex/lib/soulPublish.ts
+++ b/convex/lib/soulPublish.ts
@@ -16,7 +16,7 @@ import {
   parseFrontmatter,
   sanitizePath,
 } from "./skills";
-import { assertValidSkillSlug } from "./skillSlugValidator";
+import { assertValidSkillSlug, normalizeSkillSlug } from "./skillSlugValidator";
 import { generateSoulChangelogForPublish } from "./soulChangelog";
 
 const MAX_TOTAL_BYTES = 50 * 1024 * 1024;
@@ -85,9 +85,13 @@ export async function publishSoulVersionForUser(
   args: PublishVersionArgs,
 ): Promise<PublishResult> {
   const version = args.version.trim();
-  // Souls share the slug rules with skills (length, pattern, reserved words,
-  // no consecutive hyphens). Keep them aligned so /souls/$slug routing is safe.
-  const slug = assertValidSkillSlug(args.slug);
+  // Normalize first so we can look up the existing soul before deciding how
+  // strictly to validate. Owners of grandfathered slugs (reserved, <3 chars,
+  // or >48 chars) must still be able to publish new versions; the strict
+  // write-path rules only apply when creating a brand-new soul.
+  const normalizedSlug = normalizeSkillSlug(args.slug);
+  if (!normalizedSlug) throw new ConvexError("Slug is required.");
+
   const displayName = args.displayName.trim();
   if (!displayName) throw new ConvexError("Display name required");
   if (!semver.valid(version)) {
@@ -95,6 +99,16 @@ export async function publishSoulVersionForUser(
   }
 
   await requireGitHubAccountAge(ctx, userId);
+
+  // Resolve existing soul before enforcing slug rules so grandfathered rows
+  // are not blocked. Full validation is only applied on the create path.
+  const existingSoul = (await ctx.runQuery(internal.souls.getSoulBySlugInternal, {
+    slug: normalizedSlug,
+  })) as Doc<"souls"> | null;
+  if (!existingSoul) {
+    assertValidSkillSlug(normalizedSlug);
+  }
+  const slug = normalizedSlug;
 
   const suppliedChangelog = args.changelog.trim();
   const changelogSource = suppliedChangelog ? ("user" as const) : ("auto" as const);

--- a/convex/lib/soulPublish.ts
+++ b/convex/lib/soulPublish.ts
@@ -6,6 +6,7 @@ import type { Doc, Id } from "../_generated/dataModel";
 import type { ActionCtx } from "../_generated/server";
 import { generateEmbedding } from "./embeddings";
 import { requireGitHubAccountAge } from "./githubAccount";
+import { assertValidSkillSlug } from "./skillSlugValidator";
 import {
   buildEmbeddingText,
   getFrontmatterMetadata,
@@ -84,12 +85,11 @@ export async function publishSoulVersionForUser(
   args: PublishVersionArgs,
 ): Promise<PublishResult> {
   const version = args.version.trim();
-  const slug = args.slug.trim().toLowerCase();
+  // Souls share the slug rules with skills (length, pattern, reserved words,
+  // no consecutive hyphens). Keep them aligned so /souls/$slug routing is safe.
+  const slug = assertValidSkillSlug(args.slug);
   const displayName = args.displayName.trim();
-  if (!slug || !displayName) throw new ConvexError("Slug and display name required");
-  if (!/^[a-z0-9][a-z0-9-]*$/.test(slug)) {
-    throw new ConvexError("Slug must be lowercase and url-safe");
-  }
+  if (!displayName) throw new ConvexError("Display name required");
   if (!semver.valid(version)) {
     throw new ConvexError("Version must be valid semver");
   }

--- a/convex/lib/soulPublish.ts
+++ b/convex/lib/soulPublish.ts
@@ -6,7 +6,6 @@ import type { Doc, Id } from "../_generated/dataModel";
 import type { ActionCtx } from "../_generated/server";
 import { generateEmbedding } from "./embeddings";
 import { requireGitHubAccountAge } from "./githubAccount";
-import { assertValidSkillSlug } from "./skillSlugValidator";
 import {
   buildEmbeddingText,
   getFrontmatterMetadata,
@@ -17,6 +16,7 @@ import {
   parseFrontmatter,
   sanitizePath,
 } from "./skills";
+import { assertValidSkillSlug } from "./skillSlugValidator";
 import { generateSoulChangelogForPublish } from "./soulChangelog";
 
 const MAX_TOTAL_BYTES = 50 * 1024 * 1024;

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -17,6 +17,7 @@ import {
   getFirstSearchToken,
   normalizeSkillSearchText,
 } from "./lib/skillSearchDigest";
+import { isValidSkillSlugShape, normalizeSkillSlug } from "./lib/skillSlugValidator";
 
 type OwnerInfo = { ownerHandle: string | null; owner: PublicPublisher | null };
 
@@ -134,7 +135,9 @@ function mergeUniqueBySkillId(primary: SkillSearchEntry[], fallback: SkillSearch
 }
 
 function isSlugLikeQuery(query: string) {
-  return /^[a-z0-9][a-z0-9-]*$/.test(query.trim().toLowerCase());
+  // Shape-only check (length + pattern). Reserved-word blocklist is ignored
+  // on purpose so legacy rows carrying reserved slugs remain searchable.
+  return isValidSkillSlugShape(query);
 }
 
 function prefixUpperBound(value: string) {
@@ -541,8 +544,8 @@ export const lexicalFallbackSkills = internalQuery({
     >();
 
     // Exact slug match via the skills table (only one row, cheap).
-    const slugQuery = args.query.trim().toLowerCase();
-    if (!args.skipExactSlugLookup && /^[a-z0-9][a-z0-9-]*$/.test(slugQuery)) {
+    const slugQuery = normalizeSkillSlug(args.query);
+    if (!args.skipExactSlugLookup && isValidSkillSlugShape(slugQuery)) {
       const exactSlugSkill = await ctx.db
         .query("skills")
         .withIndex("by_slug", (q) => q.eq("slug", slugQuery))

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -17,7 +17,7 @@ import {
   getFirstSearchToken,
   normalizeSkillSearchText,
 } from "./lib/skillSearchDigest";
-import { isValidSkillSlugShape, normalizeSkillSlug } from "./lib/skillSlugValidator";
+import { isSearchableSkillSlugShape, normalizeSkillSlug } from "./lib/skillSlugValidator";
 
 type OwnerInfo = { ownerHandle: string | null; owner: PublicPublisher | null };
 
@@ -135,9 +135,11 @@ function mergeUniqueBySkillId(primary: SkillSearchEntry[], fallback: SkillSearch
 }
 
 function isSlugLikeQuery(query: string) {
-  // Shape-only check (length + pattern). Reserved-word blocklist is ignored
-  // on purpose so legacy rows carrying reserved slugs remain searchable.
-  return isValidSkillSlugShape(query);
+  // Lenient shape check used by the read path: pattern + upper length cap only.
+  // The min-length floor and reserved-word blocklist are intentionally omitted
+  // so legacy rows (grandfathered short/reserved slugs) remain discoverable via
+  // the exact-slug fast path. Write paths still go through assertValidSkillSlug.
+  return isSearchableSkillSlugShape(query);
 }
 
 function prefixUpperBound(value: string) {
@@ -544,8 +546,11 @@ export const lexicalFallbackSkills = internalQuery({
     >();
 
     // Exact slug match via the skills table (only one row, cheap).
+    // Use the lenient shape predicate so legacy rows with sub-min-length
+    // slugs stay discoverable; the caller in searchSkills already passes
+    // skipExactSlugLookup=true after running its own exact-slug lookup.
     const slugQuery = normalizeSkillSlug(args.query);
-    if (!args.skipExactSlugLookup && isValidSkillSlugShape(slugQuery)) {
+    if (!args.skipExactSlugLookup && isSearchableSkillSlugShape(slugQuery)) {
       const exactSlugSkill = await ctx.db
         .query("skills")
         .withIndex("by_slug", (q) => q.eq("slug", slugQuery))

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -7639,7 +7639,16 @@ export const insertVersion = internalMutation({
   },
   handler: async (ctx, args) => {
     const userId = args.userId;
-    const slug = normalizeSkillSlugForWrite(args.slug);
+    // Lenient normalization first so we can look up an existing skill row
+    // before deciding whether to enforce the strict write-path validator.
+    // Owners of grandfathered slugs (reserved, <3 chars, >48 chars, or other
+    // pre-validator shapes) must remain able to publish new versions; the
+    // strict reserved/length/pattern rules only apply when creating a brand
+    // new skill. The caller (publishVersionForUser) performs the same split,
+    // but the mutation re-validates defensively because it can be invoked on
+    // its own (e.g. tests, internal schedulers).
+    const normalizedSlug = normalizeSkillSlug(args.slug);
+    if (!normalizedSlug) throw new ConvexError("Slug is required.");
     const user = await ctx.db.get(userId);
     if (!user || user.deletedAt || user.deactivatedAt) throw new Error("User not found");
     const personalPublisher = await ensurePersonalPublisherForUser(ctx, user);
@@ -7657,8 +7666,13 @@ export const insertVersion = internalMutation({
 
     let skill = await ctx.db
       .query("skills")
-      .withIndex("by_slug", (q) => q.eq("slug", slug))
+      .withIndex("by_slug", (q) => q.eq("slug", normalizedSlug))
       .unique();
+
+    // Only enforce the strict write-path rules when creating a new skill.
+    // For existing rows, keep the already-persisted (possibly grandfathered)
+    // slug as-is so legacy publishers are not locked out of version updates.
+    const slug = skill ? normalizedSlug : normalizeSkillSlugForWrite(args.slug);
 
     if (!skill) {
       const alias = await getSkillSlugAliasBySlug(ctx, slug);

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -90,7 +90,6 @@ import {
   upsertReservedSlugForRightfulOwner,
 } from "./lib/reservedSlugs";
 import { SKILL_CAPABILITY_TAGS } from "./lib/skillCapabilityTags";
-import { assertValidSkillSlug, normalizeSkillSlug } from "./lib/skillSlugValidator";
 import {
   fetchText,
   type PublishResult,
@@ -105,6 +104,7 @@ import {
   extractDigestFields,
   upsertSkillSearchDigest,
 } from "./lib/skillSearchDigest";
+import { assertValidSkillSlug, normalizeSkillSlug } from "./lib/skillSlugValidator";
 import { readCanonicalStat } from "./lib/skillStats";
 import { runStaticPublishScan } from "./lib/staticPublishScan";
 import { adjustUserSkillStatsForSkillChange } from "./lib/userSkillStats";

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -90,6 +90,7 @@ import {
   upsertReservedSlugForRightfulOwner,
 } from "./lib/reservedSlugs";
 import { SKILL_CAPABILITY_TAGS } from "./lib/skillCapabilityTags";
+import { assertValidSkillSlug, normalizeSkillSlug } from "./lib/skillSlugValidator";
 import {
   fetchText,
   type PublishResult,
@@ -585,7 +586,10 @@ function buildAliasTakenErrorMessage(skill: Doc<"skills">, owner: SkillOwnerRef)
 }
 
 function normalizeSkillSlugKey(slug: string) {
-  return slug.trim().toLowerCase();
+  // Read-path normalization: lowercase + trim only. Intentionally lenient so
+  // that legacy rows (pre-validator) remain lookup-able. Write paths must
+  // use `normalizeSkillSlugForWrite` / `assertValidSkillSlug` instead.
+  return normalizeSkillSlug(slug);
 }
 
 type SkillOwnerRef =
@@ -599,11 +603,9 @@ type SkillOwnerRef =
   | undefined;
 
 function normalizeSkillSlugForWrite(slug: string) {
-  const normalized = normalizeSkillSlugKey(slug);
-  if (!normalized || !/^[a-z0-9][a-z0-9-]*$/.test(normalized)) {
-    throw new ConvexError("Slug must be lowercase and url-safe");
-  }
-  return normalized;
+  // Write-path: full validation (length, pattern, reserved words,
+  // no consecutive hyphens). See `lib/skillSlugValidator.ts`.
+  return assertValidSkillSlug(slug);
 }
 
 async function getSkillSlugAliasBySlug(ctx: Pick<QueryCtx | MutationCtx, "db">, slug: string) {
@@ -6825,13 +6827,11 @@ async function renameOwnedSkillByActor(
   }
 
   const now = Date.now();
-  const sourceSlug = sourceSlugArg.trim().toLowerCase();
-  const newSlug = newSlugArg.trim().toLowerCase();
+  const sourceSlug = normalizeSkillSlug(sourceSlugArg);
   if (!sourceSlug) throw new ConvexError("Current slug required");
-  if (!newSlug) throw new ConvexError("New slug required");
-  if (!/^[a-z0-9][a-z0-9-]*$/.test(newSlug)) {
-    throw new ConvexError("Invalid slug. Use lowercase letters, numbers, and hyphens only.");
-  }
+  // Full write-path validation for the new slug: length, pattern,
+  // reserved-word blocklist, no consecutive hyphens.
+  const newSlug = assertValidSkillSlug(newSlugArg);
 
   const resolved = await resolveSkillBySlugOrAlias(ctx, sourceSlug);
   const skill = resolved.skill;

--- a/convex/souls.ts
+++ b/convex/souls.ts
@@ -498,16 +498,28 @@ export const insertVersion = internalMutation({
   },
   handler: async (ctx, args) => {
     const userId = args.userId;
-    const slug = normalizeSoulSlugForWrite(args.slug);
+    // Lenient normalization first: we must look up the existing soul row
+    // before deciding whether to enforce the strict write-path validator.
+    // Owners of grandfathered slugs (reserved, <3 chars, >48 chars, or other
+    // pre-validator shapes) must remain able to publish new versions; the
+    // strict rules only apply when creating a brand new soul. The caller
+    // (publishSoulVersionForUser) performs the same split, but the mutation
+    // re-validates defensively because it can be invoked on its own.
+    const normalizedSlug = normalizeSkillSlug(args.slug);
+    if (!normalizedSlug) throw new ConvexError("Slug is required.");
     const user = await ctx.db.get(userId);
     if (!user || user.deletedAt || user.deactivatedAt) throw new Error("User not found");
 
     const soulMatches = await ctx.db
       .query("souls")
-      .withIndex("by_slug", (q) => q.eq("slug", slug))
+      .withIndex("by_slug", (q) => q.eq("slug", normalizedSlug))
       .order("desc")
       .take(2);
     let soul: Doc<"souls"> | null = soulMatches[0] ?? null;
+
+    // Only enforce the strict write-path rules when creating a new soul; for
+    // existing rows keep the already-persisted (possibly grandfathered) slug.
+    const slug = soul ? normalizedSlug : normalizeSoulSlugForWrite(args.slug);
 
     if (soul && soul.ownerUserId !== userId) {
       throw new ConvexError("Only the owner can publish soul updates");

--- a/convex/souls.ts
+++ b/convex/souls.ts
@@ -7,9 +7,9 @@ import { assertModerator, requireUser, requireUserFromAction } from "./lib/acces
 import { embeddingVisibilityFor } from "./lib/embeddingVisibility";
 import { toPublicSoul, toPublicUser } from "./lib/public";
 import { getFrontmatterValue, hashSkillFiles } from "./lib/skills";
+import { assertValidSkillSlug, normalizeSkillSlug } from "./lib/skillSlugValidator";
 import { generateSoulChangelogPreview } from "./lib/soulChangelog";
 import { fetchText, type PublishResult, publishSoulVersionForUser } from "./lib/soulPublish";
-import { assertValidSkillSlug, normalizeSkillSlug } from "./lib/skillSlugValidator";
 
 export { publishSoulVersionForUser } from "./lib/soulPublish";
 

--- a/convex/souls.ts
+++ b/convex/souls.ts
@@ -9,6 +9,7 @@ import { toPublicSoul, toPublicUser } from "./lib/public";
 import { getFrontmatterValue, hashSkillFiles } from "./lib/skills";
 import { generateSoulChangelogPreview } from "./lib/soulChangelog";
 import { fetchText, type PublishResult, publishSoulVersionForUser } from "./lib/soulPublish";
+import { assertValidSkillSlug, normalizeSkillSlug } from "./lib/skillSlugValidator";
 
 export { publishSoulVersionForUser } from "./lib/soulPublish";
 
@@ -70,15 +71,15 @@ function toPublicSoulVersion(
 }
 
 function normalizeSoulSlugKey(slug: string) {
-  return slug.trim().toLowerCase();
+  // Read-path normalization: lowercase + trim only. Intentionally lenient so
+  // that legacy rows (pre-validator) remain lookup-able.
+  return normalizeSkillSlug(slug);
 }
 
 function normalizeSoulSlugForWrite(slug: string) {
-  const normalized = normalizeSoulSlugKey(slug);
-  if (!normalized || !/^[a-z0-9][a-z0-9-]*$/.test(normalized)) {
-    throw new ConvexError("Slug must be lowercase and url-safe");
-  }
-  return normalized;
+  // Write-path: full validation (length, pattern, reserved words,
+  // no consecutive hyphens). Souls share the rules with skills.
+  return assertValidSkillSlug(slug);
 }
 
 export const getBySlug = query({


### PR DESCRIPTION
## Background

Today the only slug check on write paths is a single regex:

```ts
/^[a-z0-9][a-z0-9-]*$/;
```

This accepts a number of values that are unsafe in practice:

| Case                        | Example                                                                                            | Why it's bad                                                                   |
| --------------------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| No max length               | `a-a-a-…-a` (MBs)                                                                                  | Bloats the `by_slug` index, URLs, SEO, log lines                               |
| No min length               | `"a"`                                                                                              | Collides with single-letter route segments                                     |
| No reserved-word blocklist  | `admin`, `api`, `settings`, `souls`, `u`, `login`, `packages`, `plugins`, `openclaw`, `clawhub`, … | Can shadow/confuse our own routes (`/owner/$slug` vs `/admin`, `/souls`, etc.) |
| Consecutive hyphens allowed | `a---b`                                                                                            | Visual/matching oddities in UI                                                 |

The rename flow (`renameOwnedSkillByActor`) and the publish flow (`publishVersionForUser`, `publishSoulVersionForUser`) all inline the same weak regex, so any fix has to happen in several places at once — which is exactly why this PR extracts a single validator.

## What's in this PR

### Added

- **`convex/lib/skillSlugValidator.ts`** — single source of truth for slug rules:
  - length `3..48` (upper bound aligned with the publisher handle limit, so `/{owner}/{slug}` URLs stay balanced)
  - pattern `^[a-z0-9]+(-[a-z0-9]+)*$` (no leading / trailing / consecutive hyphens, no `_`, `.`, or spaces)
  - reserved-word blocklist covering our route segments and brand terms
  - public API:
    - `assertValidSkillSlug(input)` — throws `ConvexError` with a specific reason (length / pattern / reserved)
    - `isValidSkillSlugShape(input)` — shape-only, used by read/search paths
    - `isReservedSkillSlug(slug)`
    - `normalizeSkillSlug(input)` / `normalizeSkillSlugOrNull(input)` — lowercase + trim, no validation
- **`convex/lib/skillSlugValidator.test.ts`** — unit tests covering accepted / rejected shapes, the reserved-word matrix, and the `allowReserved` escape hatch used for internal callers that need to reference legacy data.

### Changed — write paths (now fully validated)

- **`convex/lib/skillPublish.ts`** — `publishVersionForUser` uses `assertValidSkillSlug` instead of the local regex, so reserved / oversized / malformed slugs can no longer reach the DB via publish.
- **`convex/lib/soulPublish.ts`** — `publishSoulVersionForUser` uses `assertValidSkillSlug` too. Souls share the same rules with skills so `/souls/$slug` routing stays safe.
- **`convex/skills.ts`**:
  - `normalizeSkillSlugForWrite` delegates to `assertValidSkillSlug`.
  - `renameOwnedSkillByActor` now validates `newSlug` with the full validator (this was the most exploitable gap).
  - `normalizeSkillSlugKey` (read-path) now uses `normalizeSkillSlug` and is intentionally lenient — see note below.
- **`convex/souls.ts`** — same split: `normalizeSoulSlugForWrite` validates, `normalizeSoulSlugKey` only normalizes.

### Changed — read paths (shape-only, legacy-safe)

- **`convex/search.ts`**:
  - `isSlugLikeQuery` → `isValidSkillSlugShape`
  - `lexicalFallbackSkills` exact-slug lookup → `normalizeSkillSlug` + `isValidSkillSlugShape`
  - **Reserved-word blocklist is intentionally NOT consulted here** so that any legacy row whose slug happens to match a newly-reserved word remains searchable.

## Design notes

- **Write-strict / read-lenient split.** Existing rows in production may carry slugs that the new validator would reject (single-char, reserved words, very long, …). Blocking reads would be a regression. So writes use `assertValidSkillSlug`, reads use `isValidSkillSlugShape` + `normalizeSkillSlug`. Grandfathered rows keep working until their owner renames them — at which point the new rules apply.
- **No data migration in this PR.** We consciously don't sweep existing data. If we later decide to retroactively clean up, it should be its own PR with an admin tool + communication to affected owners.
- **Error messages are specific.** Rather than a generic "invalid slug", callers get "Slug must be at least 3 characters", "Slug contains consecutive hyphens", "Slug is reserved", etc., which is much more useful in CLI output.
- **Souls reuse the skill validator on purpose.** Their routing constraints are the same, and keeping one validator avoids divergence.
