### PR TITLE
feat: add featured plugin curation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - `bun run preview` — preview built app.
 - `bunx convex dev` — Convex dev deployment + function watcher.
 - `bunx convex codegen` — regenerate `convex/_generated`.
+- `bun run format:check` — formatting check.
 - `bun run lint` — Biome + oxlint (type-aware).
 - `bun run test` — Vitest (unit tests).
 - `bun run coverage` — coverage run; keep global >= 80%.
@@ -37,6 +38,7 @@
 
 - Commit messages: Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`…).
 - Keep changes scoped; avoid repo-wide search/replace.
+- Before commit/PR handoff, run `bun run format:check` and `bun run lint`; include commands run in the PR summary.
 - PRs: include summary + test commands run. Add screenshots for UI changes.
 - Before merging any PR, verify TypeScript cleanly with `bunx tsc -p packages/schema/tsconfig.json --noEmit` and `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`; if Convex code changed, also run the repo typecheck path used by deploy so `bunx convex deploy` will not fail on `tsc`.
 - GitHub comments: for multiline `gh` comments/close messages, use `--body-file`, `--input`, or stdin/heredoc with real newlines; never pass literal `\\n` in shell strings.
@@ -90,11 +92,13 @@
 - **Before writing or reviewing Convex queries, check deployment health.** Run `bunx convex insights` to check for OCC conflicts, `bytesReadLimit`, and `documentsReadLimit` errors. Run `bunx convex logs --failure` to see individual error messages and stack traces. This helps identify which functions are causing bandwidth issues so you can prioritize fixes.
 
 <!-- convex-ai-start -->
+
 This project uses [Convex](https://convex.dev) as its backend.
 
 When working on Convex code, **always read `convex/_generated/ai/guidelines.md` first** for important guidelines on how to correctly use Convex APIs and patterns. The file contains rules that override what you may have learned about Convex from training data.
 
 Convex agent skills for common tasks can be installed by running `npx convex ai-files install`.
+
 <!-- convex-ai-end -->
 
 ## Stat Field Migration Rules
@@ -102,11 +106,11 @@ Convex agent skills for common tasks can be installed by running `npx convex ai-
 The `skills` table maintains two parallel sets of stat fields as part of an in-progress field migration:
 
 | Legacy (nested, `@deprecated`) | Top-level (source of truth, indexable) |
-|---|---|
-| `stats.downloads` | `statsDownloads` |
-| `stats.stars` | `statsStars` |
-| `stats.installsCurrent` | `statsInstallsCurrent` |
-| `stats.installsAllTime` | `statsInstallsAllTime` |
+| ------------------------------ | -------------------------------------- |
+| `stats.downloads`              | `statsDownloads`                       |
+| `stats.stars`                  | `statsStars`                           |
+| `stats.installsCurrent`        | `statsInstallsCurrent`                 |
+| `stats.installsAllTime`        | `statsInstallsAllTime`                 |
 
 **Rules:**
 

--- a/convex/devSeed.ts
+++ b/convex/devSeed.ts
@@ -20,6 +20,19 @@ type SeedSkillSpec = {
   rawSkillMd: string;
 };
 
+type SeedPluginSpec = {
+  name: string;
+  displayName: string;
+  summary: string;
+  version: string;
+  runtimeId: string;
+  sourceRepo: string;
+  isOfficial: boolean;
+  capabilityTags: string[];
+  stats: { downloads: number; installs: number; stars: number; versions: number };
+  readme: string;
+};
+
 type SeedActionArgs = {
   reset?: boolean;
 };
@@ -55,6 +68,134 @@ const SCANNED_PLUGIN_README = `# Local Scanned Runtime Plugin
 This seeded plugin is public and intentionally has completed scan results so local development can
 preview plugin scanner detail pages without owner-only visibility.
 `;
+
+const FEATURED_PLUGIN_SEEDS: SeedPluginSpec[] = [
+  {
+    name: "@apify/apify-openclaw-plugin",
+    displayName: "Apify",
+    summary:
+      "Scrape websites through Apify actors and make structured web data available to agents.",
+    version: "1.0.0",
+    runtimeId: "apify",
+    sourceRepo: "apify/apify-openclaw-plugin",
+    isOfficial: false,
+    capabilityTags: ["web", "scraping", "automation"],
+    stats: { downloads: 1200, installs: 320, stars: 45, versions: 1 },
+    readme: "# Apify\n\nScrape websites through Apify actors from OpenClaw.",
+  },
+  {
+    name: "openclaw-codex-app-server",
+    displayName: "Codex App Server Bridge",
+    summary: "Bind OpenClaw chats to Codex App Server conversations and control threads from chat.",
+    version: "1.0.0",
+    runtimeId: "codex-app-server",
+    sourceRepo: "pwrdrvr/openclaw-codex-app-server",
+    isOfficial: false,
+    capabilityTags: ["codex", "chat", "bridge"],
+    stats: { downloads: 980, installs: 280, stars: 37, versions: 1 },
+    readme: "# Codex App Server Bridge\n\nBridge OpenClaw chat sessions to Codex App Server.",
+  },
+  {
+    name: "@largezhou/ddingtalk",
+    displayName: "DingTalk",
+    summary: "Connect OpenClaw to DingTalk enterprise robots with text, image, and file messages.",
+    version: "1.0.0",
+    runtimeId: "dingtalk",
+    sourceRepo: "largezhou/openclaw-dingtalk",
+    isOfficial: false,
+    capabilityTags: ["channel", "dingtalk", "enterprise"],
+    stats: { downloads: 930, installs: 250, stars: 32, versions: 1 },
+    readme: "# DingTalk\n\nDingTalk enterprise robot plugin for OpenClaw.",
+  },
+  {
+    name: "kudosity-openclaw-sms",
+    displayName: "Kudosity SMS",
+    summary: "Send and receive SMS through Kudosity as an OpenClaw plugin.",
+    version: "1.0.0",
+    runtimeId: "kudosity-sms",
+    sourceRepo: "kudosity/openclaw-sms",
+    isOfficial: false,
+    capabilityTags: ["channel", "sms", "kudosity"],
+    stats: { downloads: 860, installs: 210, stars: 29, versions: 1 },
+    readme: "# Kudosity SMS\n\nKudosity SMS channel plugin for OpenClaw.",
+  },
+  {
+    name: "@martian-engineering/lossless-claw",
+    displayName: "Lossless Claw",
+    summary:
+      "Preserve conversation context with DAG-based summarization and incremental compaction.",
+    version: "1.0.0",
+    runtimeId: "lossless-claw",
+    sourceRepo: "Martian-Engineering/lossless-claw",
+    isOfficial: false,
+    capabilityTags: ["memory", "context", "summarization"],
+    stats: { downloads: 820, installs: 190, stars: 28, versions: 1 },
+    readme: "# Lossless Claw\n\nLossless context management plugin for OpenClaw.",
+  },
+  {
+    name: "@opik/opik-openclaw",
+    displayName: "Opik",
+    summary: "Export OpenClaw traces to Opik for monitoring, costs, token usage, and debugging.",
+    version: "1.0.0",
+    runtimeId: "opik",
+    sourceRepo: "comet-ml/opik-openclaw",
+    isOfficial: true,
+    capabilityTags: ["observability", "tracing", "monitoring"],
+    stats: { downloads: 760, installs: 180, stars: 25, versions: 1 },
+    readme: "# Opik\n\nTrace OpenClaw agents with Opik.",
+  },
+  {
+    name: "@prometheusavatar/openclaw-plugin",
+    displayName: "Prometheus Avatar",
+    summary: "Give OpenClaw agents a Live2D avatar with lip-sync, expressions, and speech.",
+    version: "1.0.0",
+    runtimeId: "prometheus-avatar",
+    sourceRepo: "myths-labs/prometheus-avatar",
+    isOfficial: false,
+    capabilityTags: ["avatar", "tts", "live2d"],
+    stats: { downloads: 690, installs: 150, stars: 22, versions: 1 },
+    readme: "# Prometheus Avatar\n\nLive2D avatar plugin for OpenClaw.",
+  },
+  {
+    name: "@tencent-connect/openclaw-qqbot",
+    displayName: "QQbot",
+    summary:
+      "Connect OpenClaw to QQ private chats, group mentions, channel messages, and rich media.",
+    version: "1.0.0",
+    runtimeId: "qqbot",
+    sourceRepo: "tencent-connect/openclaw-qqbot",
+    isOfficial: true,
+    capabilityTags: ["channel", "qq", "messaging"],
+    stats: { downloads: 640, installs: 140, stars: 20, versions: 1 },
+    readme: "# QQbot\n\nQQ Bot plugin for OpenClaw.",
+  },
+  {
+    name: "@wecom/wecom-openclaw-plugin",
+    displayName: "wecom",
+    summary:
+      "Use WeCom Bot WebSocket connections for direct messages, group chats, and proactive messaging.",
+    version: "1.0.0",
+    runtimeId: "wecom",
+    sourceRepo: "WecomTeam/wecom-openclaw-plugin",
+    isOfficial: true,
+    capabilityTags: ["channel", "wecom", "enterprise"],
+    stats: { downloads: 610, installs: 130, stars: 18, versions: 1 },
+    readme: "# wecom\n\nWeCom channel plugin for OpenClaw.",
+  },
+  {
+    name: "openclaw-plugin-yuanbao",
+    displayName: "Yuanbao",
+    summary:
+      "Connect OpenClaw to Yuanbao with direct messages, group chats, media, and slash commands.",
+    version: "1.0.0",
+    runtimeId: "yuanbao",
+    sourceRepo: "yb-claw/openclaw-plugin-yuanbao",
+    isOfficial: false,
+    capabilityTags: ["channel", "yuanbao", "messaging"],
+    stats: { downloads: 580, installs: 125, stars: 17, versions: 1 },
+    readme: "# Yuanbao\n\nYuanbao channel plugin for OpenClaw.",
+  },
+];
 
 type RoleHelpFixtureUser = {
   handle: string;
@@ -382,12 +523,13 @@ async function seedNixSkillsHandler(
     results.push({ slug: spec.slug, ...result });
   }
 
-  const [flaggedSkillStorageId, flaggedPluginStorageId, scannedPluginStorageId] =
-    await Promise.all([
-    ctx.storage.store(new Blob([FLAGGED_SKILL_MD], { type: "text/markdown" })),
-    ctx.storage.store(new Blob([FLAGGED_PLUGIN_README], { type: "text/markdown" })),
-    ctx.storage.store(new Blob([SCANNED_PLUGIN_README], { type: "text/markdown" })),
-  ]);
+  const [flaggedSkillStorageId, flaggedPluginStorageId, scannedPluginStorageId] = await Promise.all(
+    [
+      ctx.storage.store(new Blob([FLAGGED_SKILL_MD], { type: "text/markdown" })),
+      ctx.storage.store(new Blob([FLAGGED_PLUGIN_README], { type: "text/markdown" })),
+      ctx.storage.store(new Blob([SCANNED_PLUGIN_README], { type: "text/markdown" })),
+    ],
+  );
   const fixtureResult: SeedMutationResult = await ctx.runMutation(
     internal.devSeed.seedRescanUxFixturesMutation,
     {
@@ -401,6 +543,32 @@ async function seedNixSkillsHandler(
     },
   );
   results.push({ slug: FLAGGED_SKILL_SLUG, ...fixtureResult });
+
+  const featuredPluginStorageIds = await Promise.all(
+    FEATURED_PLUGIN_SEEDS.map(async (spec) =>
+      ctx.storage.store(new Blob([spec.readme], { type: "text/markdown" })),
+    ),
+  );
+  const featuredResult: SeedMutationResult = await ctx.runMutation(
+    internal.devSeed.seedFeaturedPluginPackagesMutation,
+    {
+      reset: args.reset,
+      packages: FEATURED_PLUGIN_SEEDS.map((spec, index) => ({
+        name: spec.name,
+        displayName: spec.displayName,
+        summary: spec.summary,
+        version: spec.version,
+        runtimeId: spec.runtimeId,
+        sourceRepo: spec.sourceRepo,
+        isOfficial: spec.isOfficial,
+        capabilityTags: spec.capabilityTags,
+        stats: spec.stats,
+        storageId: featuredPluginStorageIds[index],
+        readmeSize: spec.readme.length,
+      })),
+    },
+  );
+  results.push({ slug: "featured-plugins", ...featuredResult });
 
   return { ok: true, results };
 }
@@ -560,6 +728,59 @@ async function findSeedPluginFixture(ctx: MutationCtx) {
 
 async function findScannedPluginFixture(ctx: MutationCtx) {
   return await findSeedPluginFixtureByName(ctx, SCANNED_PLUGIN_NAME);
+}
+
+async function ensureHighlightedSkillBadge(
+  ctx: MutationCtx,
+  skillId: Id<"skills">,
+  userId: Id<"users">,
+  at: number,
+) {
+  const existing = await ctx.db
+    .query("skillBadges")
+    .withIndex("by_skill_kind", (q) => q.eq("skillId", skillId).eq("kind", "highlighted"))
+    .unique();
+  if (existing) {
+    await ctx.db.patch(existing._id, { byUserId: userId, at });
+  } else {
+    await ctx.db.insert("skillBadges", {
+      skillId,
+      kind: "highlighted",
+      byUserId: userId,
+      at,
+    });
+  }
+  const skill = await ctx.db.get(skillId);
+  if (skill) {
+    await ctx.db.patch(skillId, {
+      badges: {
+        ...(skill.badges as Record<string, unknown> | undefined),
+        highlighted: { byUserId: userId, at },
+      },
+    });
+  }
+}
+
+async function ensureHighlightedPackageBadge(
+  ctx: MutationCtx,
+  packageId: Id<"packages">,
+  userId: Id<"users">,
+  at: number,
+) {
+  const existing = await ctx.db
+    .query("packageBadges")
+    .withIndex("by_package_kind", (q) => q.eq("packageId", packageId).eq("kind", "highlighted"))
+    .unique();
+  if (existing) {
+    await ctx.db.patch(existing._id, { byUserId: userId, at });
+  } else {
+    await ctx.db.insert("packageBadges", {
+      packageId,
+      kind: "highlighted",
+      byUserId: userId,
+      at,
+    });
+  }
 }
 
 function staticMaliciousScan(now: number) {
@@ -1083,6 +1304,166 @@ export const seedRescanUxFixturesMutation = internalMutation({
   handler: seedRescanUxFixturesHandler,
 });
 
+export const seedFeaturedPluginPackagesMutation = internalMutation({
+  args: {
+    reset: v.optional(v.boolean()),
+    packages: v.array(
+      v.object({
+        name: v.string(),
+        displayName: v.string(),
+        summary: v.string(),
+        version: v.string(),
+        runtimeId: v.string(),
+        sourceRepo: v.string(),
+        isOfficial: v.boolean(),
+        capabilityTags: v.array(v.string()),
+        stats: v.object({
+          downloads: v.number(),
+          installs: v.number(),
+          stars: v.number(),
+          versions: v.number(),
+        }),
+        storageId: v.id("_storage"),
+        readmeSize: v.number(),
+      }),
+    ),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const { userId, publisherId } = await ensureLocalSeedOwner(ctx);
+    const seeded: string[] = [];
+    const skipped: string[] = [];
+
+    for (const spec of args.packages) {
+      const existing = await findSeedPluginFixtureByName(ctx, spec.name);
+      if (existing && !args.reset) {
+        await ensureHighlightedPackageBadge(ctx, existing._id, userId, now);
+        skipped.push(spec.name);
+        continue;
+      }
+      if (existing && args.reset) {
+        await deleteSeedPluginFixtureByName(ctx, spec.name);
+      }
+
+      const compatibility = { pluginApiRange: ">=0.1.0" };
+      const capabilities = {
+        executesCode: true,
+        runtimeId: spec.runtimeId,
+        pluginKind: "runtime" as const,
+        capabilityTags: spec.capabilityTags,
+      };
+      const verification = {
+        tier: "source-linked" as const,
+        scope: "artifact-only" as const,
+        summary: "Local dev featured plugin fixture linked to source metadata.",
+        sourceRepo: spec.sourceRepo,
+        scanStatus: "clean" as const,
+      };
+      const normalizedName = normalizePackageName(spec.name);
+
+      const packageId = await ctx.db.insert("packages", {
+        name: spec.name,
+        normalizedName,
+        displayName: spec.displayName,
+        summary: spec.summary,
+        ownerUserId: userId,
+        ownerPublisherId: publisherId,
+        family: "code-plugin",
+        channel: "community",
+        isOfficial: spec.isOfficial,
+        runtimeId: spec.runtimeId,
+        sourceRepo: spec.sourceRepo,
+        latestReleaseId: undefined,
+        latestVersionSummary: undefined,
+        tags: {},
+        capabilityTags: spec.capabilityTags,
+        executesCode: true,
+        compatibility,
+        capabilities,
+        verification,
+        scanStatus: "clean",
+        stats: { ...spec.stats, versions: 0 },
+        softDeletedAt: undefined,
+        createdAt: now,
+        updatedAt: now,
+      });
+      const releaseId = await ctx.db.insert("packageReleases", {
+        packageId,
+        version: spec.version,
+        changelog: "Seeded local featured plugin release.",
+        summary: spec.summary,
+        distTags: ["latest"],
+        files: [
+          {
+            path: "README.md",
+            size: spec.readmeSize,
+            storageId: spec.storageId,
+            sha256: `seeded-featured-plugin-${normalizedName}`,
+            contentType: "text/markdown",
+          },
+        ],
+        integritySha256: `seeded-featured-plugin-integrity-${normalizedName}`,
+        extractedPackageJson: {
+          name: spec.name,
+          version: spec.version,
+          description: spec.summary,
+        },
+        compatibility,
+        capabilities,
+        verification,
+        sha256hash: `seeded-featured-plugin-hash-${normalizedName}`,
+        vtAnalysis: {
+          status: "clean",
+          verdict: "clean",
+          analysis: "Local featured plugin fixture scanned clean.",
+          source: "local-dev-seed",
+          checkedAt: now,
+        },
+        llmAnalysis: {
+          status: "clean",
+          verdict: "clean",
+          confidence: "high",
+          summary: "Local featured plugin fixture is safe sample content.",
+          model: "local-dev-seed",
+          checkedAt: now,
+        },
+        staticScan: {
+          status: "clean",
+          reasonCodes: [],
+          findings: [],
+          summary: "Local featured plugin fixture static scan clean.",
+          engineVersion: "local-dev-fixture",
+          checkedAt: now,
+        },
+        source: { kind: "github", repo: spec.sourceRepo, path: "." },
+        createdBy: userId,
+        publishActor: { kind: "user", userId },
+        createdAt: now,
+        softDeletedAt: undefined,
+      });
+
+      await ctx.db.patch(packageId, {
+        latestReleaseId: releaseId,
+        latestVersionSummary: {
+          version: spec.version,
+          createdAt: now,
+          changelog: "Seeded local featured plugin release.",
+          compatibility,
+          capabilities,
+          verification,
+        },
+        tags: { latest: releaseId },
+        stats: { ...spec.stats, versions: 1 },
+        updatedAt: now,
+      });
+      await ensureHighlightedPackageBadge(ctx, packageId, userId, now);
+      seeded.push(spec.name);
+    }
+
+    return { ok: true, seeded, skipped };
+  },
+});
+
 export const seedCliRoleHelpFixtures = rawInternalMutation({
   args: {},
   handler: async (ctx) => {
@@ -1135,11 +1516,7 @@ async function upsertRoleHelpFixtureUser(ctx: MutationCtx, user: RoleHelpFixture
   return created;
 }
 
-async function replaceRoleHelpFixtureToken(
-  ctx: MutationCtx,
-  userId: Id<"users">,
-  now: number,
-) {
+async function replaceRoleHelpFixtureToken(ctx: MutationCtx, userId: Id<"users">, now: number) {
   const existingTokens = await ctx.db
     .query("apiTokens")
     .withIndex("by_user", (q) => q.eq("userId", userId))
@@ -1177,12 +1554,15 @@ export const seedSkillMutation = internalMutation({
     version: v.string(),
   },
   handler: async (ctx, args) => {
+    const now = Date.now();
+    const { userId, publisherId } = await ensureLocalSeedOwner(ctx);
     const existing = await ctx.db
       .query("skills")
       .withIndex("by_slug", (q) => q.eq("slug", args.slug))
       .unique();
 
     if (existing && !args.reset) {
+      await ensureHighlightedSkillBadge(ctx, existing._id, userId, now);
       return { ok: true, skipped: true, skillId: existing._id };
     }
 
@@ -1204,9 +1584,6 @@ export const seedSkillMutation = internalMutation({
       await ctx.db.delete(existing._id);
     }
 
-    const now = Date.now();
-    const { userId, publisherId } = await ensureLocalSeedOwner(ctx);
-
     const skillId = await ctx.db.insert("skills", {
       slug: args.slug,
       displayName: args.displayName,
@@ -1216,7 +1593,7 @@ export const seedSkillMutation = internalMutation({
       latestVersionId: undefined,
       tags: {},
       softDeletedAt: undefined,
-      badges: { redactionApproved: undefined },
+      badges: { highlighted: { byUserId: userId, at: now }, redactionApproved: undefined },
       statsDownloads: 0,
       statsStars: 0,
       statsInstallsCurrent: 0,
@@ -1232,6 +1609,7 @@ export const seedSkillMutation = internalMutation({
       createdAt: now,
       updatedAt: now,
     });
+    await ensureHighlightedSkillBadge(ctx, skillId, userId, now);
     const versionId = await ctx.db.insert("skillVersions", {
       skillId,
       version: args.version,

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -7,8 +7,8 @@ import {
 import { api, internal } from "../_generated/api";
 import type { Doc, Id } from "../_generated/dataModel";
 import type { ActionCtx } from "../_generated/server";
-import { getOptionalApiTokenUserId } from "../lib/apiTokenAuth";
 import { getOptionalActiveAuthUserIdFromAction } from "../lib/access";
+import { getOptionalApiTokenUserId } from "../lib/apiTokenAuth";
 import {
   fetchGitHubRepositoryIdentity,
   verifyGitHubActionsTrustedPublishJwt,
@@ -104,6 +104,7 @@ type PackageListQueryArgs = {
   family?: "skill" | "code-plugin" | "bundle-plugin";
   channel?: "official" | "community" | "private";
   isOfficial?: boolean;
+  highlightedOnly?: boolean;
   executesCode?: boolean;
   capabilityTag?: string;
   viewerUserId?: Id<"users">;
@@ -458,6 +459,7 @@ async function searchPackageCatalogByListing(
     family?: "skill" | "code-plugin" | "bundle-plugin";
     channel?: "official" | "community" | "private";
     isOfficial?: boolean;
+    highlightedOnly?: boolean;
     executesCode?: boolean;
     capabilityTag?: string;
     viewerUserId?: Id<"users">;
@@ -482,6 +484,7 @@ async function searchPackageCatalogByListing(
       family: args.family,
       channel: args.channel,
       isOfficial: args.isOfficial,
+      highlightedOnly: args.highlightedOnly,
       executesCode: args.executesCode,
       capabilityTag: args.capabilityTag,
       viewerUserId: args.viewerUserId,
@@ -650,6 +653,11 @@ async function listPackages(
   const channelRaw = url.searchParams.get("channel")?.trim();
   const capabilityTag = url.searchParams.get("capabilityTag")?.trim() || undefined;
   const isOfficialRaw = url.searchParams.get("isOfficial");
+  const highlightedOnly =
+    url.searchParams.get("featured") === "true" ||
+    url.searchParams.get("featured") === "1" ||
+    url.searchParams.get("highlightedOnly") === "true" ||
+    url.searchParams.get("highlightedOnly") === "1";
   const executesCodeRaw = url.searchParams.get("executesCode");
   const effectiveFamily =
     family ??
@@ -674,6 +682,7 @@ async function listPackages(
     }>(ctx, apiRefs.skills.listPackageCatalogPage, {
       channel,
       isOfficial,
+      highlightedOnly: highlightedOnly || undefined,
       executesCode,
       capabilityTag,
       paginationOpts: { cursor, numItems: limit },
@@ -701,6 +710,7 @@ async function listPackages(
           }>(ctx, internalRefs.packages.listPageForViewerInternal, {
             channel,
             isOfficial,
+            highlightedOnly: highlightedOnly || undefined,
             executesCode,
             capabilityTag,
             viewerUserId: viewerUserId ?? undefined,
@@ -720,6 +730,7 @@ async function listPackages(
           }>(ctx, apiRefs.skills.listPackageCatalogPage, {
             channel,
             isOfficial,
+            highlightedOnly: highlightedOnly || undefined,
             executesCode,
             capabilityTag,
             paginationOpts: { cursor: pageCursor, numItems },
@@ -783,6 +794,7 @@ async function listPackages(
         family: pluginFamily,
         channel,
         isOfficial,
+        highlightedOnly: highlightedOnly || undefined,
         executesCode,
         capabilityTag,
         viewerUserId: viewerUserId ?? undefined,
@@ -850,6 +862,7 @@ async function listPackages(
     family: effectiveFamily,
     channel,
     isOfficial,
+    highlightedOnly: highlightedOnly || undefined,
     executesCode,
     capabilityTag,
     viewerUserId: viewerUserId ?? undefined,
@@ -1279,6 +1292,11 @@ async function searchPackages(
   const familyRaw = url.searchParams.get("family");
   const channelRaw = url.searchParams.get("channel");
   const isOfficialRaw = url.searchParams.get("isOfficial");
+  const highlightedOnly =
+    url.searchParams.get("featured") === "true" ||
+    url.searchParams.get("featured") === "1" ||
+    url.searchParams.get("highlightedOnly") === "true" ||
+    url.searchParams.get("highlightedOnly") === "1";
   const executesCodeRaw = url.searchParams.get("executesCode");
   const capabilityTag = url.searchParams.get("capabilityTag")?.trim() || undefined;
   const family =
@@ -1305,6 +1323,7 @@ async function searchPackages(
         limit,
         channel,
         isOfficial,
+        highlightedOnly: highlightedOnly || undefined,
         executesCode,
         capabilityTag,
       },
@@ -1319,6 +1338,7 @@ async function searchPackages(
             family: pluginFamily,
             channel,
             isOfficial,
+            highlightedOnly: highlightedOnly || undefined,
             executesCode,
             capabilityTag,
             viewerUserId: viewerUserId ?? undefined,
@@ -1343,6 +1363,7 @@ async function searchPackages(
         family,
         channel,
         isOfficial,
+        highlightedOnly: highlightedOnly || undefined,
         executesCode,
         capabilityTag,
         viewerUserId: viewerUserId ?? undefined,
@@ -1355,6 +1376,7 @@ async function searchPackages(
         limit,
         channel,
         isOfficial,
+        highlightedOnly: highlightedOnly || undefined,
         executesCode,
         capabilityTag,
         viewerUserId: viewerUserId ?? undefined,
@@ -1364,6 +1386,7 @@ async function searchPackages(
         limit,
         channel,
         isOfficial,
+        highlightedOnly: highlightedOnly || undefined,
         executesCode,
         capabilityTag,
       }),

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -167,6 +167,8 @@ type PublicPackageListItem = {
   executesCode: boolean;
   verificationTier: PackageVerificationTier | null;
 };
+
+type PackageBadgeKind = Doc<"packageBadges">["kind"];
 type PackageDigestLike = Pick<
   Doc<"packageSearchDigest">,
   | "packageId"
@@ -407,6 +409,36 @@ function digestMatchesSearchFilters(
     return false;
   }
   return digestMatchesFilters(digest, args);
+}
+
+async function upsertPackageBadge(
+  ctx: MutationCtx,
+  packageId: Id<"packages">,
+  kind: PackageBadgeKind,
+  userId: Id<"users">,
+  at: number,
+) {
+  const existing = await ctx.db
+    .query("packageBadges")
+    .withIndex("by_package_kind", (q) => q.eq("packageId", packageId).eq("kind", kind))
+    .unique();
+  if (existing) {
+    await ctx.db.patch(existing._id, { byUserId: userId, at });
+    return;
+  }
+  await ctx.db.insert("packageBadges", { packageId, kind, byUserId: userId, at });
+}
+
+async function removePackageBadge(
+  ctx: MutationCtx,
+  packageId: Id<"packages">,
+  kind: PackageBadgeKind,
+) {
+  const existing = await ctx.db
+    .query("packageBadges")
+    .withIndex("by_package_kind", (q) => q.eq("packageId", packageId).eq("kind", kind))
+    .unique();
+  if (existing) await ctx.db.delete(existing._id);
 }
 
 function toPublicPackageListItem(digest: PackageDigestLike): PublicPackageListItem {
@@ -935,6 +967,62 @@ function buildPackageCapabilityDigestQuery(
     );
 }
 
+async function fetchHighlightedPackageDigests(
+  ctx: DbReaderCtx,
+  args: {
+    family?: PackageFamily;
+    channel?: PackageChannel;
+    isOfficial?: boolean;
+    executesCode?: boolean;
+    capabilityTag?: string;
+    viewerUserId?: Id<"users">;
+  },
+) {
+  const viewerUserId = args.viewerUserId;
+  const membershipCache = new Map<string, Promise<boolean>>();
+  const badges = await ctx.db
+    .query("packageBadges")
+    .withIndex("by_kind_at", (q) => q.eq("kind", "highlighted"))
+    .order("desc")
+    .take(MAX_PUBLIC_LIST_PAGE_SIZE);
+  const digests: PackageDigestLike[] = [];
+  for (const badge of badges) {
+    const digest = await ctx.db
+      .query("packageSearchDigest")
+      .withIndex("by_package", (q) => q.eq("packageId", badge.packageId))
+      .unique();
+    if (!digest || digest.softDeletedAt) continue;
+    if (!(await canViewerReadPackage(ctx, digest, viewerUserId, membershipCache))) continue;
+    if (!digestMatchesSearchFilters(digest, args)) continue;
+    digests.push(digest);
+  }
+  return digests;
+}
+
+async function fetchHighlightedPackagePage(
+  ctx: DbReaderCtx,
+  args: {
+    family?: PackageFamily;
+    channel?: PackageChannel;
+    isOfficial?: boolean;
+    executesCode?: boolean;
+    capabilityTag?: string;
+    viewerUserId?: Id<"users">;
+    numItems: number;
+  },
+) {
+  const digests = await fetchHighlightedPackageDigests(ctx, args);
+  return digests
+    .sort(
+      (a, b) =>
+        Number(b.isOfficial) - Number(a.isOfficial) ||
+        b.updatedAt - a.updatedAt ||
+        a.name.localeCompare(b.name),
+    )
+    .slice(0, args.numItems)
+    .map(toPublicPackageListItem);
+}
+
 async function getPackageByNormalizedName(ctx: DbReaderCtx, normalizedName: string) {
   return (await ctx.db
     .query("packages")
@@ -1007,6 +1095,32 @@ export const getByName = query({
       package: publicPackage,
       latestRelease: latestRelease && !latestRelease.softDeletedAt ? latestRelease : null,
       owner,
+    };
+  },
+});
+
+export const getByNameForStaff = query({
+  args: { name: v.string() },
+  handler: async (ctx, args) => {
+    const { user } = await requireUser(ctx);
+    assertModerator(user);
+
+    const pkg = await getPackageByNormalizedName(ctx, normalizePackageName(args.name));
+    if (!pkg || pkg.softDeletedAt || pkg.family === "skill") return null;
+
+    const highlighted = await ctx.db
+      .query("packageBadges")
+      .withIndex("by_package_kind", (q) => q.eq("packageId", pkg._id).eq("kind", "highlighted"))
+      .unique();
+
+    return {
+      package: pkg,
+      highlighted: highlighted
+        ? {
+            byUserId: highlighted.byUserId,
+            at: highlighted.at,
+          }
+        : null,
     };
   },
 });
@@ -1158,6 +1272,7 @@ export const listPublicPage = query({
       v.union(v.literal("official"), v.literal("community"), v.literal("private")),
     ),
     isOfficial: v.optional(v.boolean()),
+    highlightedOnly: v.optional(v.boolean()),
     executesCode: v.optional(v.boolean()),
     capabilityTag: v.optional(v.string()),
     paginationOpts: paginationOptsValidator,
@@ -1176,6 +1291,7 @@ export const listPageForViewerInternal = internalQuery({
       v.union(v.literal("official"), v.literal("community"), v.literal("private")),
     ),
     isOfficial: v.optional(v.boolean()),
+    highlightedOnly: v.optional(v.boolean()),
     executesCode: v.optional(v.boolean()),
     capabilityTag: v.optional(v.string()),
     viewerUserId: v.optional(v.id("users")),
@@ -1192,6 +1308,7 @@ async function listPackagePageImpl(
     family?: PackageFamily;
     channel?: PackageChannel;
     isOfficial?: boolean;
+    highlightedOnly?: boolean;
     executesCode?: boolean;
     capabilityTag?: string;
     viewerUserId?: Id<"users">;
@@ -1206,6 +1323,15 @@ async function listPackagePageImpl(
   const canViewPackage = async (digest: PackageDigestLike) =>
     await canViewerReadPackage(ctx, digest, viewerUserId, membershipCache);
   const targetCount = args.paginationOpts.numItems;
+
+  if (args.highlightedOnly) {
+    const page = await fetchHighlightedPackagePage(ctx, {
+      ...args,
+      numItems: targetCount,
+    });
+    return { page, isDone: true, continueCursor: "" };
+  }
+
   const collected: PublicPackageListItem[] = [];
   const decodedCursor = decodePublicPageCursor(args.paginationOpts.cursor);
   if (decodedCursor.done && decodedCursor.offset === 0) {
@@ -1300,6 +1426,7 @@ export const searchPublic = query({
       v.union(v.literal("official"), v.literal("community"), v.literal("private")),
     ),
     isOfficial: v.optional(v.boolean()),
+    highlightedOnly: v.optional(v.boolean()),
     executesCode: v.optional(v.boolean()),
     capabilityTag: v.optional(v.string()),
   },
@@ -1319,6 +1446,7 @@ export const searchForViewerInternal = internalQuery({
       v.union(v.literal("official"), v.literal("community"), v.literal("private")),
     ),
     isOfficial: v.optional(v.boolean()),
+    highlightedOnly: v.optional(v.boolean()),
     executesCode: v.optional(v.boolean()),
     capabilityTag: v.optional(v.string()),
     viewerUserId: v.optional(v.id("users")),
@@ -1336,6 +1464,7 @@ async function searchPackagesImpl(
     family?: PackageFamily;
     channel?: PackageChannel;
     isOfficial?: boolean;
+    highlightedOnly?: boolean;
     executesCode?: boolean;
     capabilityTag?: string;
     viewerUserId?: Id<"users">;
@@ -1349,6 +1478,21 @@ async function searchPackagesImpl(
   const membershipCache = new Map<string, Promise<boolean>>();
   const canViewPackage = async (digest: PackageDigestLike) =>
     await canViewerReadPackage(ctx, digest, viewerUserId, membershipCache);
+  if (args.highlightedOnly) {
+    const digests = await fetchHighlightedPackageDigests(ctx, args);
+    return digests
+      .map((digest) => ({ score: packageSearchScore(digest, queryText), package: digest }))
+      .filter((entry) => entry.score > 0)
+      .sort(
+        (a, b) =>
+          b.score - a.score ||
+          Number(b.package.isOfficial) - Number(a.package.isOfficial) ||
+          b.package.updatedAt - a.package.updatedAt,
+      )
+      .slice(0, targetCount)
+      .map((entry) => ({ score: entry.score, package: toPublicPackageListItem(entry.package) }));
+  }
+
   const builder = args.capabilityTag
     ? buildPackageCapabilityDigestQuery(ctx, {
         capabilityTag: args.capabilityTag,
@@ -2794,6 +2938,36 @@ export const requestRescan = mutation({
         artifactId: target.release._id,
       })),
     };
+  },
+});
+
+export const setBatch = mutation({
+  args: { packageId: v.id("packages"), batch: v.optional(v.string()) },
+  handler: async (ctx, args) => {
+    const { user } = await requireUser(ctx);
+    assertModerator(user);
+    const pkg = await ctx.db.get(args.packageId);
+    if (!pkg || pkg.softDeletedAt || pkg.family === "skill") {
+      throw new ConvexError("Plugin not found");
+    }
+    const nextBatch = args.batch?.trim() || undefined;
+    const nextHighlighted = nextBatch === "highlighted";
+    const now = Date.now();
+
+    if (nextHighlighted) {
+      await upsertPackageBadge(ctx, pkg._id, "highlighted", user._id, now);
+    } else {
+      await removePackageBadge(ctx, pkg._id, "highlighted");
+    }
+
+    await ctx.db.insert("auditLogs", {
+      actorUserId: user._id,
+      action: "package.badge.highlighted",
+      targetType: "package",
+      targetId: pkg._id,
+      metadata: { highlighted: nextHighlighted },
+      createdAt: now,
+    });
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -547,6 +547,16 @@ const skillBadges = defineTable({
   .index("by_skill_kind", ["skillId", "kind"])
   .index("by_kind_at", ["kind", "at"]);
 
+const packageBadges = defineTable({
+  packageId: v.id("packages"),
+  kind: v.union(v.literal("highlighted")),
+  byUserId: v.id("users"),
+  at: v.number(),
+})
+  .index("by_package", ["packageId"])
+  .index("by_package_kind", ["packageId", "kind"])
+  .index("by_kind_at", ["kind", "at"]);
+
 const soulVersionFingerprints = defineTable({
   soulId: v.id("souls"),
   versionId: v.id("soulVersions"),
@@ -1219,12 +1229,7 @@ const rescanRequests = defineTable({
   .index("by_skill_version", ["targetKind", "skillVersionId", "createdAt"])
   .index("by_skill_version_status", ["targetKind", "skillVersionId", "status", "createdAt"])
   .index("by_package_release", ["targetKind", "packageReleaseId", "createdAt"])
-  .index("by_package_release_status", [
-    "targetKind",
-    "packageReleaseId",
-    "status",
-    "createdAt",
-  ])
+  .index("by_package_release_status", ["targetKind", "packageReleaseId", "status", "createdAt"])
   .index("by_requester", ["requestedByUserId", "createdAt"]);
 
 const apiTokens = defineTable({
@@ -1362,6 +1367,7 @@ export default defineSchema({
   packageReleases,
   packageTrustedPublishers,
   packagePublishTokens,
+  packageBadges,
   packageSearchDigest,
   packageCapabilitySearchDigest,
   souls,

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -3055,6 +3055,7 @@ function skillCatalogMatchesFilters(
   args: {
     channel?: "official" | "community" | "private";
     isOfficial?: boolean;
+    highlightedOnly?: boolean;
     executesCode?: boolean;
     capabilityTag?: string;
   },
@@ -3065,6 +3066,7 @@ function skillCatalogMatchesFilters(
   const isOfficial = isSkillCatalogOfficial(digest);
   const channel = getSkillCatalogChannel(digest);
   if (typeof args.isOfficial === "boolean" && isOfficial !== args.isOfficial) return false;
+  if (args.highlightedOnly && !isSkillHighlighted(digest)) return false;
   if (args.channel && channel !== args.channel) return false;
   if (args.capabilityTag && !(digest.capabilityTags ?? []).includes(args.capabilityTag))
     return false;
@@ -3120,6 +3122,7 @@ export const listPackageCatalogPage = query({
       v.union(v.literal("official"), v.literal("community"), v.literal("private")),
     ),
     isOfficial: v.optional(v.boolean()),
+    highlightedOnly: v.optional(v.boolean()),
     executesCode: v.optional(v.boolean()),
     capabilityTag: v.optional(v.string()),
     paginationOpts: paginationOptsValidator,
@@ -3211,6 +3214,7 @@ export const searchPackageCatalogPublic = query({
       v.union(v.literal("official"), v.literal("community"), v.literal("private")),
     ),
     isOfficial: v.optional(v.boolean()),
+    highlightedOnly: v.optional(v.boolean()),
     executesCode: v.optional(v.boolean()),
     capabilityTag: v.optional(v.string()),
   },

--- a/src/__tests__/packages-route.test.tsx
+++ b/src/__tests__/packages-route.test.tsx
@@ -5,6 +5,7 @@ import type { ComponentType, ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const fetchPluginCatalogMock = vi.fn();
+const fetchFeaturedPluginsMock = vi.fn();
 const isRateLimitedPackageApiErrorMock = vi.fn(
   (error: unknown) =>
     typeof error === "object" && error !== null && (error as { status?: number }).status === 429,
@@ -57,6 +58,10 @@ vi.mock("../lib/packageApi", () => ({
   isRateLimitedPackageApiError: (error: unknown) => isRateLimitedPackageApiErrorMock(error),
 }));
 
+vi.mock("../lib/featuredCatalog", () => ({
+  fetchFeaturedPlugins: (...args: unknown[]) => fetchFeaturedPluginsMock(...args),
+}));
+
 async function loadRoute() {
   return (await import("../routes/plugins/index")).Route as unknown as {
     __config: {
@@ -70,6 +75,7 @@ async function loadRoute() {
 describe("plugins route", () => {
   beforeEach(() => {
     fetchPluginCatalogMock.mockReset();
+    fetchFeaturedPluginsMock.mockReset();
     isRateLimitedPackageApiErrorMock.mockClear();
     navigateMock.mockReset();
     searchMock = {};
@@ -92,6 +98,7 @@ describe("plugins route", () => {
       family: undefined,
       q: "demo",
       cursor: undefined,
+      featured: undefined,
       verified: undefined,
       executesCode: undefined,
     });
@@ -211,12 +218,29 @@ describe("plugins route", () => {
     );
   });
 
+  it("selects featured from the sort group", async () => {
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole("radio", { name: "Featured" }));
+
+    expect(navigateMock).toHaveBeenCalled();
+    const lastCall = navigateMock.mock.calls.at(-1)?.[0] as {
+      search: (prev: Record<string, unknown>) => Record<string, unknown>;
+    };
+    expect(lastCall.search({ family: "code-plugin", cursor: "cursor:current" })).toEqual({
+      family: undefined,
+      cursor: undefined,
+      featured: true,
+    });
+  });
+
   it("returns a retryable empty state when the catalog is rate limited", async () => {
     fetchPluginCatalogMock.mockRejectedValue({ status: 429, retryAfterSeconds: 22 });
     const route = await loadRoute();
-    const loader = route.__config.loader as (args: {
-      deps: Record<string, unknown>;
-    }) => Promise<{
+    const loader = route.__config.loader as (args: { deps: Record<string, unknown> }) => Promise<{
       items: Array<{ name: string }>;
       nextCursor: string | null;
       rateLimited: boolean;
@@ -237,9 +261,7 @@ describe("plugins route", () => {
   it("flags API errors for filtered catalog requests", async () => {
     fetchPluginCatalogMock.mockRejectedValue(new Error("boom"));
     const route = await loadRoute();
-    const loader = route.__config.loader as (args: {
-      deps: Record<string, unknown>;
-    }) => Promise<{
+    const loader = route.__config.loader as (args: { deps: Record<string, unknown> }) => Promise<{
       items: Array<{ name: string }>;
       nextCursor: string | null;
       rateLimited: boolean;

--- a/src/lib/featuredCatalog.ts
+++ b/src/lib/featuredCatalog.ts
@@ -1,0 +1,6 @@
+import { fetchPluginCatalog } from "./packageApi";
+
+export async function fetchFeaturedPlugins(limit: number = 50) {
+  const result = await fetchPluginCatalog({ featured: true, limit });
+  return result.items;
+}

--- a/src/lib/packageApi.ts
+++ b/src/lib/packageApi.ts
@@ -255,6 +255,7 @@ export async function fetchPackages(params: {
   cursor?: string;
   family?: "skill" | "code-plugin" | "bundle-plugin";
   isOfficial?: boolean;
+  featured?: boolean;
   executesCode?: boolean;
   capabilityTag?: string;
   limit?: number;
@@ -267,6 +268,7 @@ export async function fetchPackages(params: {
     if (typeof params.isOfficial === "boolean") {
       url.searchParams.set("isOfficial", String(params.isOfficial));
     }
+    if (params.featured) url.searchParams.set("featured", "true");
     if (typeof params.executesCode === "boolean") {
       url.searchParams.set("executesCode", String(params.executesCode));
     }
@@ -287,6 +289,7 @@ export async function fetchPackages(params: {
   if (typeof params.isOfficial === "boolean") {
     url.searchParams.set("isOfficial", String(params.isOfficial));
   }
+  if (params.featured) url.searchParams.set("featured", "true");
   if (typeof params.executesCode === "boolean") {
     url.searchParams.set("executesCode", String(params.executesCode));
   }
@@ -299,6 +302,7 @@ export async function fetchPluginCatalog(params: {
   cursor?: string;
   family?: PluginFamily;
   isOfficial?: boolean;
+  featured?: boolean;
   executesCode?: boolean;
   limit?: number;
 }): Promise<PluginCatalogResult> {
@@ -308,6 +312,7 @@ export async function fetchPluginCatalog(params: {
       cursor: params.cursor,
       family: params.family,
       isOfficial: params.isOfficial,
+      featured: params.featured,
       executesCode: params.executesCode,
       limit: params.limit,
     });
@@ -332,6 +337,7 @@ export async function fetchPluginCatalog(params: {
     if (typeof params.isOfficial === "boolean") {
       url.searchParams.set("isOfficial", String(params.isOfficial));
     }
+    if (params.featured) url.searchParams.set("featured", "true");
     if (typeof params.executesCode === "boolean") {
       url.searchParams.set("executesCode", String(params.executesCode));
     }
@@ -339,7 +345,9 @@ export async function fetchPluginCatalog(params: {
       results?: Array<{ score: number; package: PackageListItem }>;
     }>(url);
     return {
-      items: (response?.results ?? []).map((entry) => entry?.package).filter(Boolean) as PackageListItem[],
+      items: (response?.results ?? [])
+        .map((entry) => entry?.package)
+        .filter(Boolean) as PackageListItem[],
       nextCursor: null,
     };
   }
@@ -350,6 +358,7 @@ export async function fetchPluginCatalog(params: {
   if (typeof params.isOfficial === "boolean") {
     url.searchParams.set("isOfficial", String(params.isOfficial));
   }
+  if (params.featured) url.searchParams.set("featured", "true");
   if (typeof params.executesCode === "boolean") {
     url.searchParams.set("executesCode", String(params.executesCode));
   }
@@ -370,7 +379,10 @@ export async function fetchPackageDetail(name: string): Promise<PackageDetailRes
   return (await response.json()) as PackageDetailResponse;
 }
 
-export async function fetchPackageVersion(name: string, version: string): Promise<PackageVersionDetail | null> {
+export async function fetchPackageVersion(
+  name: string,
+  version: string,
+): Promise<PackageVersionDetail | null> {
   try {
     const url = await packageApiUrl(
       `${ApiRoutes.packages}/${encodeURIComponent(name)}/versions/${encodeURIComponent(version)}`,
@@ -382,7 +394,10 @@ export async function fetchPackageVersion(name: string, version: string): Promis
   }
 }
 
-export async function fetchPackageReadme(name: string, version?: string | null): Promise<string | null> {
+export async function fetchPackageReadme(
+  name: string,
+  version?: string | null,
+): Promise<string | null> {
   const url = await packageApiUrl(`${ApiRoutes.packages}/${encodeURIComponent(name)}/file`);
   url.searchParams.set("path", "README.md");
   if (version) url.searchParams.set("version", version);

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -16,6 +16,8 @@ import { api } from "../../convex/_generated/api";
 import { SoulCard } from "../components/SoulCard";
 import { SoulStatsTripletLine } from "../components/SoulStats";
 import { convexHttp } from "../convex/client";
+import { fetchFeaturedPlugins } from "../lib/featuredCatalog";
+import type { PackageListItem } from "../lib/packageApi";
 import type { PublicSkill, PublicSoul, PublicUser } from "../lib/publicUser";
 import { getSiteMode } from "../lib/site";
 
@@ -37,7 +39,7 @@ function SkillsHome() {
   };
 
   const [highlighted, setHighlighted] = useState<SkillPageEntry[]>([]);
-  const [popular, setPopular] = useState<SkillPageEntry[]>([]);
+  const [featuredPlugins, setFeaturedPlugins] = useState<PackageListItem[]>([]);
   const [query, setQuery] = useState("");
   const navigate = useNavigate();
 
@@ -49,15 +51,9 @@ function SkillsHome() {
         if (!cancelled) setHighlighted(r as SkillPageEntry[]);
       })
       .catch(() => {});
-    convexHttp
-      .query(api.skills.listPublicPageV4, {
-        numItems: 12,
-        sort: "downloads",
-        dir: "desc",
-        nonSuspiciousOnly: true,
-      })
-      .then((r) => {
-        if (!cancelled) setPopular((r as { page: SkillPageEntry[] }).page);
+    fetchFeaturedPlugins(6)
+      .then((items) => {
+        if (!cancelled) setFeaturedPlugins(items);
       })
       .catch(() => {});
     return () => {
@@ -179,8 +175,24 @@ function SkillsHome() {
       {carouselCards.length > 0 && (
         <section className="home-v2-carousel-section">
           <div className="home-v2-carousel-header">
-            <h2>Featured</h2>
+            <h2>Featured skills</h2>
             <div className="home-v2-carousel-controls">
+              <Link
+                to="/skills"
+                search={{
+                  q: undefined,
+                  sort: undefined,
+                  dir: undefined,
+                  featured: true,
+                  highlighted: undefined,
+                  nonSuspicious: undefined,
+                  view: undefined,
+                  focus: undefined,
+                }}
+                className="home-v2-section-link"
+              >
+                View all <ArrowRight size={14} />
+              </Link>
               <button type="button" className="home-v2-carousel-btn" aria-label="Previous">
                 <ArrowLeft size={16} />
               </button>
@@ -345,21 +357,20 @@ function SkillsHome() {
         </div>
       </div>
 
-      {/* ═══ TRENDING ═══ */}
-      {popular.length > 0 && (
+      {/* ═══ FEATURED PLUGINS ═══ */}
+      {featuredPlugins.length > 0 && (
         <section className="home-v2-trending-section">
           <div className="home-v2-section-header">
-            <h2>Trending Now</h2>
+            <h2>Featured plugins</h2>
             <Link
-              to="/skills"
+              to="/plugins"
               search={{
                 q: undefined,
-                sort: "downloads",
-                dir: "desc",
-                highlighted: undefined,
-                nonSuspicious: true,
-                view: undefined,
-                focus: undefined,
+                cursor: undefined,
+                family: undefined,
+                featured: true,
+                verified: undefined,
+                executesCode: undefined,
               }}
               className="home-v2-section-link"
             >
@@ -367,27 +378,26 @@ function SkillsHome() {
             </Link>
           </div>
           <div className="home-v2-trending-grid">
-            {popular.slice(0, 6).map((entry) => (
-              <Link key={entry.skill._id} to={skillLink(entry)} className="home-v2-trend-card">
+            {featuredPlugins.slice(0, 6).map((plugin) => (
+              <Link
+                key={plugin.name}
+                to="/plugins/$name"
+                params={{ name: plugin.name }}
+                className="home-v2-trend-card"
+              >
                 <div className="home-v2-trend-head">
-                  <div className="home-v2-trend-title">
-                    {entry.skill.displayName || entry.skill.slug}
-                  </div>
+                  <div className="home-v2-trend-title">{plugin.displayName || plugin.name}</div>
                   <div className="home-v2-trend-creator">
-                    by {entry.ownerHandle || entry.owner?.handle || "unknown"}
+                    {plugin.ownerHandle ? `by @${plugin.ownerHandle}` : "community plugin"}
                   </div>
                 </div>
                 <div className="home-v2-trend-desc">
-                  {entry.skill.summary || "Agent-ready skill pack."}
+                  {plugin.summary || "Gateway plugin for OpenClaw workflows."}
                 </div>
                 <div className="home-v2-trend-bottom">
                   <div className="home-v2-trend-signals">
-                    <span>
-                      <Star size={12} /> {formatStat(entry.skill.stats?.stars)}
-                    </span>
-                    <span>
-                      <Download size={12} /> {formatStat(entry.skill.stats?.downloads)}
-                    </span>
+                    {plugin.isOfficial ? <span>Verified</span> : null}
+                    {plugin.latestVersion ? <span>v{plugin.latestVersion}</span> : null}
                   </div>
                   <span className="home-v2-trend-install">
                     <Download size={13} /> Install

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -26,6 +26,7 @@ import {
   type PackageVersionDetail,
 } from "../../lib/packageApi";
 import { familyLabel } from "../../lib/packageLabels";
+import { isModerator } from "../../lib/roles";
 import { useAuthStatus } from "../../lib/useAuthStatus";
 
 type PluginDetailRateLimitState = {
@@ -184,8 +185,14 @@ function PluginDetailRoute() {
   const { name } = Route.useParams();
   const { detail, version, readme, rateLimited } = Route.useLoaderData() as PluginDetailLoaderData;
   const pathname = useRouterState({ select: (state) => state.location.pathname });
-  const { isAuthenticated } = useAuthStatus();
+  const { isAuthenticated, me } = useAuthStatus();
+  const staff = isModerator(me);
+  const setPackageBatch = useMutation(api.packages.setBatch);
   const requestPluginRescan = useMutation(api.packages.requestRescan);
+  const staffPackage = useQuery(
+    api.packages.getByNameForStaff,
+    staff && detail.package ? { name: detail.package.name } : "skip",
+  ) as { package: { _id: Id<"packages"> }; highlighted: { at: number } | null } | null | undefined;
   const rescanState = useQuery(
     api.packages.getOwnerRescanStateByName,
     isAuthenticated && detail.package ? { name: detail.package.name } : "skip",
@@ -242,6 +249,21 @@ function PluginDetailRoute() {
       : pkg.family === "bundle-plugin"
         ? `openclaw bundles install clawhub:${pkg.name}`
         : `openclaw skills install ${pkg.name}`;
+  const isHighlighted = Boolean(staffPackage?.highlighted);
+
+  const toggleHighlighted = async () => {
+    const packageId = staffPackage?.package._id;
+    if (!packageId) return;
+    try {
+      await setPackageBatch({
+        packageId,
+        batch: isHighlighted ? undefined : "highlighted",
+      });
+      toast.success(isHighlighted ? "Plugin unhighlighted." : "Plugin highlighted.");
+    } catch (error) {
+      toast.error(getUserFacingConvexError(error, "Could not update plugin highlight."));
+    }
+  };
 
   const capabilities = latestRelease?.capabilities ?? pkg.capabilities;
   const compatibility = latestRelease?.compatibility ?? pkg.compatibility;
@@ -302,6 +324,13 @@ function PluginDetailRoute() {
                 {isDownloadBlocked ? (
                   <div className="skill-title-actions">
                     <Badge variant="destructive">Download blocked</Badge>
+                  </div>
+                ) : null}
+                {staffPackage ? (
+                  <div className="skill-title-actions">
+                    <Button variant="outline" size="sm" onClick={() => void toggleHighlighted()}>
+                      {isHighlighted ? "Unhighlight" : "Highlight"}
+                    </Button>
                   </div>
                 ) : null}
               </div>
@@ -400,195 +429,194 @@ function PluginDetailRoute() {
           ) : null}
 
           {/* Capabilities */}
-        {capEntries.length > 0 ? (
-          <Card>
-            <CardHeader className="gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <CardTitle>Capabilities</CardTitle>
-              <InstallCopyButton
-                text={JSON.stringify(capabilities, null, 2)}
-                ariaLabel="Copy capabilities JSON"
-              />
-            </CardHeader>
-            <CardContent>
-              <dl className="flex flex-col gap-3 text-sm">
-                {capEntries.map(([key, value]) => (
-                  <div
-                    key={key}
-                    className="flex flex-col gap-1.5 border-b border-[color:var(--line)] pb-3 last:border-b-0 last:pb-0 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0"
-                  >
-                    <dt className="font-semibold text-[color:var(--ink-soft)] sm:pr-2">
-                      {CAPABILITY_LABELS[key] ?? key}
-                    </dt>
-                    <dd className="min-w-0 break-words text-[color:var(--ink)]">
-                      {key === "capabilityTags" && Array.isArray(value) ? (
-                        <div className="flex flex-wrap gap-1.5">
-                          {(value as string[]).map((tag) => (
-                            <Link key={tag} to="/plugins" search={{ q: tag }}>
-                              <Badge variant="compact">{tag}</Badge>
-                            </Link>
-                          ))}
-                        </div>
-                      ) : key === "hostTargets" && Array.isArray(value) ? (
-                        <div className="flex flex-wrap gap-1.5">
-                          {(value as string[]).map((target) => (
-                            <Badge key={target} variant="compact">
-                              {target}
-                            </Badge>
-                          ))}
-                        </div>
-                      ) : (
-                        formatCapabilityValue(value)
-                      )}
-                    </dd>
-                  </div>
-                ))}
-              </dl>
-            </CardContent>
-          </Card>
-        ) : null}
+          {capEntries.length > 0 ? (
+            <Card>
+              <CardHeader className="gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <CardTitle>Capabilities</CardTitle>
+                <InstallCopyButton
+                  text={JSON.stringify(capabilities, null, 2)}
+                  ariaLabel="Copy capabilities JSON"
+                />
+              </CardHeader>
+              <CardContent>
+                <dl className="flex flex-col gap-3 text-sm">
+                  {capEntries.map(([key, value]) => (
+                    <div
+                      key={key}
+                      className="flex flex-col gap-1.5 border-b border-[color:var(--line)] pb-3 last:border-b-0 last:pb-0 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0"
+                    >
+                      <dt className="font-semibold text-[color:var(--ink-soft)] sm:pr-2">
+                        {CAPABILITY_LABELS[key] ?? key}
+                      </dt>
+                      <dd className="min-w-0 break-words text-[color:var(--ink)]">
+                        {key === "capabilityTags" && Array.isArray(value) ? (
+                          <div className="flex flex-wrap gap-1.5">
+                            {(value as string[]).map((tag) => (
+                              <Link key={tag} to="/plugins" search={{ q: tag }}>
+                                <Badge variant="compact">{tag}</Badge>
+                              </Link>
+                            ))}
+                          </div>
+                        ) : key === "hostTargets" && Array.isArray(value) ? (
+                          <div className="flex flex-wrap gap-1.5">
+                            {(value as string[]).map((target) => (
+                              <Badge key={target} variant="compact">
+                                {target}
+                              </Badge>
+                            ))}
+                          </div>
+                        ) : (
+                          formatCapabilityValue(value)
+                        )}
+                      </dd>
+                    </div>
+                  ))}
+                </dl>
+              </CardContent>
+            </Card>
+          ) : null}
 
-        {/* Compatibility */}
-        {compatEntries.length > 0 ? (
-          <Card>
-            <CardHeader className="gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <CardTitle>Compatibility</CardTitle>
-              <InstallCopyButton
-                text={JSON.stringify(compatibility, null, 2)}
-                ariaLabel="Copy compatibility JSON"
-              />
-            </CardHeader>
-            <CardContent>
-              <dl className="flex flex-col gap-3 text-sm">
-                {compatEntries.map(([key, value]) => (
-                  <div
-                    key={key}
-                    className="flex flex-col gap-1.5 border-b border-[color:var(--line)] pb-3 last:border-b-0 last:pb-0 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0"
-                  >
-                    <dt className="font-semibold text-[color:var(--ink-soft)] sm:pr-2">
-                      {key.replace(/([A-Z])/g, " $1").replace(/^./, (s) => s.toUpperCase())}
-                    </dt>
-                    <dd className="min-w-0 break-all font-mono text-xs text-[color:var(--ink)]">
-                      {value}
-                    </dd>
-                  </div>
-                ))}
-              </dl>
-            </CardContent>
-          </Card>
-        ) : null}
+          {/* Compatibility */}
+          {compatEntries.length > 0 ? (
+            <Card>
+              <CardHeader className="gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <CardTitle>Compatibility</CardTitle>
+                <InstallCopyButton
+                  text={JSON.stringify(compatibility, null, 2)}
+                  ariaLabel="Copy compatibility JSON"
+                />
+              </CardHeader>
+              <CardContent>
+                <dl className="flex flex-col gap-3 text-sm">
+                  {compatEntries.map(([key, value]) => (
+                    <div
+                      key={key}
+                      className="flex flex-col gap-1.5 border-b border-[color:var(--line)] pb-3 last:border-b-0 last:pb-0 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0"
+                    >
+                      <dt className="font-semibold text-[color:var(--ink-soft)] sm:pr-2">
+                        {key.replace(/([A-Z])/g, " $1").replace(/^./, (s) => s.toUpperCase())}
+                      </dt>
+                      <dd className="min-w-0 break-all font-mono text-xs text-[color:var(--ink)]">
+                        {value}
+                      </dd>
+                    </div>
+                  ))}
+                </dl>
+              </CardContent>
+            </Card>
+          ) : null}
 
-        {/* Verification */}
-        {verification && !isEmptyObject(verification) ? (
-          <Card>
-            <CardHeader>
-              <CardTitle>Verification</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <dl className="flex flex-col gap-3 text-sm">
-                {verification.tier ? (
-                  <div className="flex flex-col gap-1.5 border-b border-[color:var(--line)] pb-3 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0">
-                    <dt className="font-semibold text-[color:var(--ink-soft)]">Tier</dt>
-                    <dd className="text-[color:var(--ink)]">
-                      {verification.tier.replace(/-/g, " ")}
-                    </dd>
-                  </div>
-                ) : null}
-                {verification.scope ? (
-                  <div className="flex flex-col gap-1.5 border-b border-[color:var(--line)] pb-3 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0">
-                    <dt className="font-semibold text-[color:var(--ink-soft)]">Scope</dt>
-                    <dd className="text-[color:var(--ink)]">
-                      {verification.scope.replace(/-/g, " ")}
-                    </dd>
-                  </div>
-                ) : null}
-                {verification.summary ? (
-                  <div className="flex flex-col gap-1.5 border-b border-[color:var(--line)] pb-3 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0">
-                    <dt className="font-semibold text-[color:var(--ink-soft)]">Summary</dt>
-                    <dd className="text-[color:var(--ink)]">{verification.summary}</dd>
-                  </div>
-                ) : null}
-                {verification.sourceRepo
-                  ? (() => {
-                      const raw = verification.sourceRepo;
-                      const href = /^https?:\/\//.test(raw) ? raw : `https://github.com/${raw}`;
-                      const display = href.replace(/^https?:\/\//, "");
-                      return (
-                        <div className="flex flex-col gap-1.5 border-b border-[color:var(--line)] pb-3 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0">
-                          <dt className="font-semibold text-[color:var(--ink-soft)]">Source</dt>
-                          <dd className="text-[color:var(--ink)]">
-                            <a
-                              href={href}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="inline-flex max-w-full flex-wrap items-center gap-1 break-all text-[color:var(--accent)] hover:underline"
-                            >
-                              {display}
-                              <ExternalLink className="h-3 w-3" aria-hidden="true" />
-                            </a>
-                          </dd>
-                        </div>
-                      );
-                    })()
-                  : null}
-                {verification.sourceCommit ? (
-                  <div className="flex flex-col gap-1.5 border-b border-[color:var(--line)] pb-3 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0">
-                    <dt className="font-semibold text-[color:var(--ink-soft)]">Commit</dt>
-                    <dd className="min-w-0 break-all font-mono text-xs text-[color:var(--ink)]">
-                      {verification.sourceCommit.slice(0, 12)}
-                    </dd>
-                  </div>
-                ) : null}
-                {verification.sourceTag ? (
-                  <div className="flex flex-col gap-1.5 border-b border-[color:var(--line)] pb-3 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0">
-                    <dt className="font-semibold text-[color:var(--ink-soft)]">Tag</dt>
-                    <dd className="min-w-0 break-all font-mono text-xs text-[color:var(--ink)]">
-                      {verification.sourceTag}
-                    </dd>
-                  </div>
-                ) : null}
-                {verification.hasProvenance !== undefined ? (
-                  <div className="flex flex-col gap-1.5 border-b border-[color:var(--line)] pb-3 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0">
-                    <dt className="font-semibold text-[color:var(--ink-soft)]">Provenance</dt>
-                    <dd className="text-[color:var(--ink)]">
-                      {verification.hasProvenance ? "Yes" : "No"}
-                    </dd>
-                  </div>
-                ) : null}
-                {verification.scanStatus ? (
-                  <div className="flex flex-col gap-1.5 last:border-b-0 last:pb-0 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0">
-                    <dt className="font-semibold text-[color:var(--ink-soft)]">Scan status</dt>
-                    <dd className="text-[color:var(--ink)]">{verification.scanStatus}</dd>
-                  </div>
-                ) : null}
-              </dl>
-            </CardContent>
-          </Card>
-        ) : null}
+          {/* Verification */}
+          {verification && !isEmptyObject(verification) ? (
+            <Card>
+              <CardHeader>
+                <CardTitle>Verification</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <dl className="flex flex-col gap-3 text-sm">
+                  {verification.tier ? (
+                    <div className="flex flex-col gap-1.5 border-b border-[color:var(--line)] pb-3 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0">
+                      <dt className="font-semibold text-[color:var(--ink-soft)]">Tier</dt>
+                      <dd className="text-[color:var(--ink)]">
+                        {verification.tier.replace(/-/g, " ")}
+                      </dd>
+                    </div>
+                  ) : null}
+                  {verification.scope ? (
+                    <div className="flex flex-col gap-1.5 border-b border-[color:var(--line)] pb-3 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0">
+                      <dt className="font-semibold text-[color:var(--ink-soft)]">Scope</dt>
+                      <dd className="text-[color:var(--ink)]">
+                        {verification.scope.replace(/-/g, " ")}
+                      </dd>
+                    </div>
+                  ) : null}
+                  {verification.summary ? (
+                    <div className="flex flex-col gap-1.5 border-b border-[color:var(--line)] pb-3 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0">
+                      <dt className="font-semibold text-[color:var(--ink-soft)]">Summary</dt>
+                      <dd className="text-[color:var(--ink)]">{verification.summary}</dd>
+                    </div>
+                  ) : null}
+                  {verification.sourceRepo
+                    ? (() => {
+                        const raw = verification.sourceRepo;
+                        const href = /^https?:\/\//.test(raw) ? raw : `https://github.com/${raw}`;
+                        const display = href.replace(/^https?:\/\//, "");
+                        return (
+                          <div className="flex flex-col gap-1.5 border-b border-[color:var(--line)] pb-3 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0">
+                            <dt className="font-semibold text-[color:var(--ink-soft)]">Source</dt>
+                            <dd className="text-[color:var(--ink)]">
+                              <a
+                                href={href}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex max-w-full flex-wrap items-center gap-1 break-all text-[color:var(--accent)] hover:underline"
+                              >
+                                {display}
+                                <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                              </a>
+                            </dd>
+                          </div>
+                        );
+                      })()
+                    : null}
+                  {verification.sourceCommit ? (
+                    <div className="flex flex-col gap-1.5 border-b border-[color:var(--line)] pb-3 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0">
+                      <dt className="font-semibold text-[color:var(--ink-soft)]">Commit</dt>
+                      <dd className="min-w-0 break-all font-mono text-xs text-[color:var(--ink)]">
+                        {verification.sourceCommit.slice(0, 12)}
+                      </dd>
+                    </div>
+                  ) : null}
+                  {verification.sourceTag ? (
+                    <div className="flex flex-col gap-1.5 border-b border-[color:var(--line)] pb-3 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0">
+                      <dt className="font-semibold text-[color:var(--ink-soft)]">Tag</dt>
+                      <dd className="min-w-0 break-all font-mono text-xs text-[color:var(--ink)]">
+                        {verification.sourceTag}
+                      </dd>
+                    </div>
+                  ) : null}
+                  {verification.hasProvenance !== undefined ? (
+                    <div className="flex flex-col gap-1.5 border-b border-[color:var(--line)] pb-3 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0">
+                      <dt className="font-semibold text-[color:var(--ink-soft)]">Provenance</dt>
+                      <dd className="text-[color:var(--ink)]">
+                        {verification.hasProvenance ? "Yes" : "No"}
+                      </dd>
+                    </div>
+                  ) : null}
+                  {verification.scanStatus ? (
+                    <div className="flex flex-col gap-1.5 last:border-b-0 last:pb-0 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0">
+                      <dt className="font-semibold text-[color:var(--ink-soft)]">Scan status</dt>
+                      <dd className="text-[color:var(--ink)]">{verification.scanStatus}</dd>
+                    </div>
+                  ) : null}
+                </dl>
+              </CardContent>
+            </Card>
+          ) : null}
 
-        {/* Tags */}
-        {pkg.tags && Object.keys(pkg.tags).length > 0 ? (
-          <Card>
-            <CardHeader>
-              <CardTitle>Tags</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <dl className="flex flex-col gap-3 text-sm">
-                {Object.entries(pkg.tags).map(([key, value]) => (
-                  <div
-                    key={key}
-                    className="flex flex-col gap-1.5 border-b border-[color:var(--line)] pb-3 last:border-b-0 last:pb-0 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0"
-                  >
-                    <dt className="font-semibold text-[color:var(--ink-soft)]">{key}</dt>
-                    <dd className="min-w-0 break-all font-mono text-xs text-[color:var(--ink)]">
-                      {value}
-                    </dd>
-                  </div>
-                ))}
-              </dl>
-            </CardContent>
-          </Card>
-        ) : null}
-
+          {/* Tags */}
+          {pkg.tags && Object.keys(pkg.tags).length > 0 ? (
+            <Card>
+              <CardHeader>
+                <CardTitle>Tags</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <dl className="flex flex-col gap-3 text-sm">
+                  {Object.entries(pkg.tags).map(([key, value]) => (
+                    <div
+                      key={key}
+                      className="flex flex-col gap-1.5 border-b border-[color:var(--line)] pb-3 last:border-b-0 last:pb-0 sm:grid sm:grid-cols-[minmax(140px,220px)_1fr] sm:gap-x-4 sm:gap-y-0"
+                    >
+                      <dt className="font-semibold text-[color:var(--ink-soft)]">{key}</dt>
+                      <dd className="min-w-0 break-all font-mono text-xs text-[color:var(--ink)]">
+                        {value}
+                      </dd>
+                    </div>
+                  ))}
+                </dl>
+              </CardContent>
+            </Card>
+          ) : null}
         </DetailHero>
       </DetailPageShell>
     </main>

--- a/src/routes/plugins/index.tsx
+++ b/src/routes/plugins/index.tsx
@@ -14,6 +14,7 @@ type PluginSearchState = {
   q?: string;
   cursor?: string;
   family?: "code-plugin" | "bundle-plugin";
+  featured?: boolean;
   verified?: boolean;
   executesCode?: boolean;
 };
@@ -43,14 +44,16 @@ export const Route = createFileRoute("/plugins/")({
       search.family === "code-plugin" || search.family === "bundle-plugin"
         ? search.family
         : undefined,
+    featured:
+      search.featured === true || search.featured === "true" || search.featured === "1"
+        ? true
+        : undefined,
     verified:
       search.verified === true || search.verified === "true" || search.verified === "1"
         ? true
         : undefined,
     executesCode:
-      search.executesCode === true ||
-      search.executesCode === "true" ||
-      search.executesCode === "1"
+      search.executesCode === true || search.executesCode === "true" || search.executesCode === "1"
         ? true
         : undefined,
   }),
@@ -61,6 +64,7 @@ export const Route = createFileRoute("/plugins/")({
         q: deps.q,
         cursor: deps.q ? undefined : deps.cursor,
         family: deps.family,
+        featured: deps.featured,
         isOfficial: deps.verified,
         executesCode: deps.executesCode,
         limit: 50,
@@ -100,14 +104,14 @@ function PluginsIndex() {
   const search = Route.useSearch();
   const navigate = Route.useNavigate();
   const loaderData = Route.useLoaderData() as PluginsLoaderData | undefined;
-  
+
   // Defensive handling for when loader data is unavailable (SSR errors, etc.)
   const items = loaderData?.items ?? [];
   const nextCursor = loaderData?.nextCursor ?? null;
   const rateLimited = loaderData?.rateLimited ?? false;
   const retryAfterSeconds = loaderData?.retryAfterSeconds ?? null;
   const apiError = loaderData?.apiError ?? !loaderData;
-  
+
   const [query, setQuery] = useState(search.q ?? "");
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
@@ -136,12 +140,24 @@ function PluginsIndex() {
   };
 
   const handleFamilySort = (value: string) => {
-    const family =
-      value === "code-plugin" || value === "bundle-plugin" ? value : undefined;
+    if (value === "featured") {
+      void navigate({
+        search: (prev) => ({
+          ...prev,
+          cursor: undefined,
+          featured: true,
+          family: undefined,
+        }),
+      });
+      return;
+    }
+
+    const family = value === "code-plugin" || value === "bundle-plugin" ? value : undefined;
     void navigate({
       search: (prev) => ({
         ...prev,
         cursor: undefined,
+        featured: undefined,
         family: family as "code-plugin" | "bundle-plugin" | undefined,
       }),
     });
@@ -200,11 +216,12 @@ function PluginsIndex() {
       <div className={`browse-layout${sidebarOpen ? " sidebar-open" : ""}`}>
         <BrowseSidebar
           sortOptions={[
+            { value: "featured", label: "Featured" },
             { value: "all", label: "All types" },
             { value: "code-plugin", label: "Code plugins" },
             { value: "bundle-plugin", label: "Bundle plugins" },
           ]}
-          activeSort={search.family ?? "all"}
+          activeSort={search.featured ? "featured" : (search.family ?? "all")}
           onSortChange={handleFamilySort}
           filters={[
             { key: "verified", label: "Verified only", active: search.verified ?? false },
@@ -231,9 +248,7 @@ function PluginsIndex() {
             <div className="empty-state">
               <AlertTriangle size={20} aria-hidden="true" />
               <p className="empty-state-title">Plugin catalog is temporarily unavailable</p>
-              <p className="empty-state-body">
-                Try again {formatRetryDelay(retryAfterSeconds)}.
-              </p>
+              <p className="empty-state-body">Try again {formatRetryDelay(retryAfterSeconds)}.</p>
             </div>
           ) : items.length === 0 ? (
             <div className="empty-state">

--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -15,6 +15,7 @@ export type SkillsSearchState = {
   sort?: SortKey;
   dir?: SortDir;
   highlighted?: boolean;
+  featured?: boolean;
   nonSuspicious?: boolean;
   tag?: string;
   view?: SkillsView;
@@ -57,7 +58,7 @@ export function useSkillsBrowseModel({
   const navigateTimer = useRef<number>(0);
 
   const view: SkillsView = search.view ?? "list";
-  const highlightedOnly = search.highlighted ?? false;
+  const featuredOnly = search.featured ?? search.highlighted ?? false;
   const nonSuspiciousOnly = search.nonSuspicious ?? false;
   const capabilityTag = search.tag;
   const searchSkills = useAction(api.search.searchSkills);
@@ -72,7 +73,7 @@ export function useSkillsBrowseModel({
   const listSort = toListSort(sort);
   const dir = parseDir(search.dir, sort);
   const searchKey = trimmedQuery
-    ? `${trimmedQuery}::${highlightedOnly ? "1" : "0"}::${nonSuspiciousOnly ? "1" : "0"}::${capabilityTag ?? ""}`
+    ? `${trimmedQuery}::${featuredOnly ? "1" : "0"}::${nonSuspiciousOnly ? "1" : "0"}::${capabilityTag ?? ""}`
     : "";
 
   // One-shot paginated fetches (no reactive subscription)
@@ -89,7 +90,7 @@ export function useSkillsBrowseModel({
           numItems: pageSize,
           sort: listSort,
           dir,
-          highlightedOnly,
+          highlightedOnly: featuredOnly,
           nonSuspiciousOnly,
           capabilityTag,
         });
@@ -105,7 +106,7 @@ export function useSkillsBrowseModel({
         setListStatus(cursor ? "idle" : "done");
       }
     },
-    [capabilityTag, dir, highlightedOnly, listSort, nonSuspiciousOnly],
+    [capabilityTag, dir, featuredOnly, listSort, nonSuspiciousOnly],
   );
 
   // Reset and fetch first page when sort/dir/filters change
@@ -155,7 +156,7 @@ export function useSkillsBrowseModel({
         try {
           const data = (await searchSkills({
             query: trimmedQuery,
-            highlightedOnly,
+            highlightedOnly: featuredOnly,
             nonSuspiciousOnly,
             capabilityTag,
             limit: searchLimit,
@@ -174,7 +175,7 @@ export function useSkillsBrowseModel({
   }, [
     capabilityTag,
     hasQuery,
-    highlightedOnly,
+    featuredOnly,
     nonSuspiciousOnly,
     searchLimit,
     searchSkills,
@@ -197,7 +198,8 @@ export function useSkillsBrowseModel({
   const sorted = useMemo(() => {
     if (isOtherCategory) {
       return baseItems.filter((entry) => {
-        const text = `${entry.skill.displayName} ${entry.skill.summary ?? ""} ${entry.skill.slug}`.toLowerCase();
+        const text =
+          `${entry.skill.displayName} ${entry.skill.summary ?? ""} ${entry.skill.slug}`.toLowerCase();
         return !ALL_CATEGORY_KEYWORDS.some((kw) => text.includes(kw));
       });
     }
@@ -319,11 +321,12 @@ export function useSkillsBrowseModel({
     [navigate],
   );
 
-  const onToggleHighlighted = useCallback(() => {
+  const onToggleFeatured = useCallback(() => {
     void navigate({
       search: (prev) => ({
         ...prev,
-        highlighted: prev.highlighted ? undefined : true,
+        featured: prev.featured || prev.highlighted ? undefined : true,
+        highlighted: undefined,
       }),
       replace: true,
     });
@@ -375,7 +378,7 @@ export function useSkillsBrowseModel({
   }, [navigate]);
 
   const activeFilters: string[] = [];
-  if (highlightedOnly) activeFilters.push("highlighted");
+  if (featuredOnly) activeFilters.push("featured");
   if (nonSuspiciousOnly) activeFilters.push("non-suspicious");
   if (capabilityTag) activeFilters.push(SKILL_CAPABILITY_LABELS[capabilityTag] ?? capabilityTag);
 
@@ -399,7 +402,7 @@ export function useSkillsBrowseModel({
     canLoadMore,
     dir,
     hasQuery,
-    highlightedOnly,
+    featuredOnly,
     isLoadingMore,
     isLoadingSkills,
     loadMore,
@@ -409,7 +412,7 @@ export function useSkillsBrowseModel({
     onQueryChange,
     onSortChange,
     onToggleDir,
-    onToggleHighlighted,
+    onToggleFeatured,
     onToggleNonSuspicious,
     onToggleView,
     query,

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -6,7 +6,7 @@ import { api } from "../../../convex/_generated/api";
 import { BrowseSidebar } from "../../components/BrowseSidebar";
 import { SKILL_CATEGORIES } from "../../lib/categories";
 import { formatCompactStat } from "../../lib/numberFormat";
-import { parseSort } from "./-params";
+import { parseDir, parseSort } from "./-params";
 import { SkillsResults } from "./-SkillsResults";
 import { useSkillsBrowseModel, type SkillsSearchState } from "./-useSkillsBrowseModel";
 
@@ -29,6 +29,10 @@ export const Route = createFileRoute("/skills/")({
         search.highlighted === "1" || search.highlighted === "true" || search.highlighted === true
           ? true
           : undefined,
+      featured:
+        search.featured === "1" || search.featured === "true" || search.featured === true
+          ? true
+          : undefined,
       nonSuspicious:
         search.nonSuspicious === "1" ||
         search.nonSuspicious === "true" ||
@@ -41,7 +45,9 @@ export const Route = createFileRoute("/skills/")({
   },
   beforeLoad: ({ search }) => {
     const hasQuery = Boolean(search.q?.trim());
-    if (hasQuery || search.sort) return;
+    if (hasQuery || search.sort || search.featured || search.highlighted || search.nonSuspicious) {
+      return;
+    }
     throw redirect({
       to: "/skills",
       search: {
@@ -49,6 +55,7 @@ export const Route = createFileRoute("/skills/")({
         sort: "downloads",
         dir: search.dir || undefined,
         highlighted: search.highlighted || undefined,
+        featured: search.featured || undefined,
         nonSuspicious: search.nonSuspicious || undefined,
         view: search.view || undefined,
         focus: search.focus || undefined,
@@ -64,8 +71,7 @@ export function SkillsIndex() {
   const search = Route.useSearch();
   const searchInputRef = useRef<HTMLInputElement>(null);
   const totalSkills = useQuery(api.skills.countPublicSkills);
-  const totalSkillsText =
-    typeof totalSkills === "number" ? formatCompactStat(totalSkills) : null;
+  const totalSkillsText = typeof totalSkills === "number" ? formatCompactStat(totalSkills) : null;
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const model = useSkillsBrowseModel({
@@ -80,11 +86,49 @@ export function SkillsIndex() {
 
   const handleFilterToggle = useCallback(
     (key: string) => {
-      if (key === "highlighted") model.onToggleHighlighted();
-      else if (key === "nonSuspicious") model.onToggleNonSuspicious();
+      if (key === "nonSuspicious") model.onToggleNonSuspicious();
     },
-    [model.onToggleHighlighted, model.onToggleNonSuspicious],
+    [model.onToggleNonSuspicious],
   );
+
+  const handleSortChange = useCallback(
+    (value: string) => {
+      if (value === "featured") {
+        if (!model.featuredOnly) model.onToggleFeatured();
+        return;
+      }
+
+      if (model.featuredOnly) {
+        const nextSort = parseSort(value);
+        void navigate({
+          search: (prev) => ({
+            ...prev,
+            sort: nextSort,
+            dir: parseDir(prev.dir, nextSort),
+            featured: undefined,
+            highlighted: undefined,
+          }),
+          replace: true,
+        });
+        return;
+      }
+
+      model.onSortChange(value);
+    },
+    [model.featuredOnly, model.onSortChange, model.onToggleFeatured, navigate],
+  );
+
+  const handleClear = useCallback(() => {
+    model.onQueryChange("");
+    if (model.featuredOnly) model.onToggleFeatured();
+    if (model.nonSuspiciousOnly) model.onToggleNonSuspicious();
+  }, [
+    model.featuredOnly,
+    model.onQueryChange,
+    model.onToggleFeatured,
+    model.onToggleNonSuspicious,
+    model.nonSuspiciousOnly,
+  ]);
 
   const handleCategoryChange = useCallback(
     (slug: string | undefined) => {
@@ -103,9 +147,8 @@ export function SkillsIndex() {
   const activeCategory = useMemo(() => {
     if (!model.query) return undefined;
     return (
-      SKILL_CATEGORIES.find((c) =>
-        c.keywords.some((k) => k === model.query.trim().toLowerCase()),
-      )?.slug ?? undefined
+      SKILL_CATEGORIES.find((c) => c.keywords.some((k) => k === model.query.trim().toLowerCase()))
+        ?.slug ?? undefined
     );
   }, [model.query]);
 
@@ -122,9 +165,7 @@ export function SkillsIndex() {
         </button>
         <h1 className="browse-title">
           Skills
-          {totalSkillsText ? (
-            <span className="browse-count">{totalSkillsText}</span>
-          ) : null}
+          {totalSkillsText ? <span className="browse-count">{totalSkillsText}</span> : null}
         </h1>
       </div>
       <div className="browse-page-search">
@@ -142,11 +183,10 @@ export function SkillsIndex() {
           categories={SKILL_CATEGORIES}
           activeCategory={activeCategory}
           onCategoryChange={handleCategoryChange}
-          sortOptions={sortOptionsWithRelevance}
-          activeSort={model.sort}
-          onSortChange={model.onSortChange}
+          sortOptions={[{ value: "featured", label: "Featured" }, ...sortOptionsWithRelevance]}
+          activeSort={model.featuredOnly ? "featured" : model.sort}
+          onSortChange={handleSortChange}
           filters={[
-            { key: "highlighted", label: "Staff picks", active: model.highlightedOnly },
             { key: "nonSuspicious", label: "Hide suspicious", active: model.nonSuspiciousOnly },
           ]}
           onFilterToggle={handleFilterToggle}
@@ -154,19 +194,9 @@ export function SkillsIndex() {
         <div className="browse-results">
           <div className="browse-results-toolbar">
             <span className="browse-results-count">
-              {model.isLoadingSkills
-                ? "\u2014"
-                : `${model.sorted.length} results`}
-              {(model.hasQuery || model.highlightedOnly || model.nonSuspiciousOnly) ? (
-                <button
-                  className="browse-clear-btn"
-                  type="button"
-                  onClick={() => {
-                    model.onQueryChange("");
-                    if (model.highlightedOnly) model.onToggleHighlighted();
-                    if (model.nonSuspiciousOnly) model.onToggleNonSuspicious();
-                  }}
-                >
+              {model.isLoadingSkills ? "\u2014" : `${model.sorted.length} results`}
+              {model.hasQuery || model.featuredOnly || model.nonSuspiciousOnly ? (
+                <button className="browse-clear-btn" type="button" onClick={handleClear}>
                   Clear
                 </button>
               ) : null}


### PR DESCRIPTION
## Summary

This moves ClawHub's front-page curation to the same highlighted/featured model for both skills and plugins.

- Adds `featured=true` support to the existing skills and plugins browse/search pages.
- Backs plugin curation with a new `packageBadges` highlighted badge, matching the skills `highlighted` concept.
- Adds moderator/admin plugin highlight toggling from plugin detail pages.
- Updates the homepage to link to featured skills/plugins and load featured plugins from the backend instead of a hardcoded frontend list.
- Seeds the current docs-backed community plugin recommendations as highlighted local dev fixtures.

## Context

OpenClaw docs currently contain manual community plugin recommendations. We want ClawHub to be the canonical discovery and curation surface instead, so docs can point users to:

- `https://clawhub.ai/plugins?featured=true`
- `https://clawhub.ai/skills?featured=true`

That should reduce docs-only PRs whose real goal is plugin discoverability, and give staff a product-level way to curate popular/recommended skills and plugins.

## Validation

- `bunx convex codegen`
- `bun run lint`
- `bun run test src/lib/packageApi.test.ts src/__tests__/packages-route.test.tsx`
- `bun run build`

Build still emits the existing TanStack route warning for `src/routes/dashboard.test.tsx` and the Shiki WASM fallback warning, but exits successfully.
