### PR TITLE
chore(ci): update package publish artifact action

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -73,6 +73,9 @@ on:
         description: Published release id when dry_run is false.
         value: ${{ jobs.publish.outputs.release_id }}
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -334,7 +337,7 @@ jobs:
           PY
 
       - name: Upload publish JSON artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: clawhub-package-publish-json
           path: ${{ runner.temp }}/package-publish.json

--- a/src/__tests__/skills-route-default-sort.test.ts
+++ b/src/__tests__/skills-route-default-sort.test.ts
@@ -40,7 +40,7 @@ function runBeforeLoad(search: Record<string, unknown>) {
 
 describe("skills route default sort", () => {
   it("redirects browse view to downloads when sort is missing", () => {
-    expect(runBeforeLoad({ nonSuspicious: true })).toEqual({
+    expect(runBeforeLoad({})).toEqual({
       redirect: {
         to: "/skills",
         search: {
@@ -48,7 +48,8 @@ describe("skills route default sort", () => {
           sort: "downloads",
           dir: undefined,
           highlighted: undefined,
-          nonSuspicious: true,
+          featured: undefined,
+          nonSuspicious: undefined,
           tag: undefined,
           view: undefined,
           focus: undefined,
@@ -60,5 +61,11 @@ describe("skills route default sort", () => {
 
   it("does not redirect when query is present", () => {
     expect(runBeforeLoad({ q: "notion" })).toBeUndefined();
+  });
+
+  it("does not redirect when filters are present", () => {
+    expect(runBeforeLoad({ nonSuspicious: true })).toBeUndefined();
+    expect(runBeforeLoad({ featured: true })).toBeUndefined();
+    expect(runBeforeLoad({ highlighted: true })).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- opt the reusable package publish workflow into Node 24 JavaScript actions
- bump the publish JSON artifact upload from `actions/upload-artifact@v4` to `@v7`
- repair the current `skills-route-default-sort` test expectation so CI matches the featured/filter route behavior on `main`

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/package-publish.yml"); puts "package-publish.yml yaml ok"'`
- `bun run test src/__tests__/skills-route-default-sort.test.ts`
