### PR TITLE
[codex] remove card link hover underlines

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -294,6 +294,17 @@ a:hover {
   text-underline-offset: 2px;
 }
 
+a.card:hover,
+a.skill-card:hover,
+a.skill-list-item:hover,
+a.home-quick-link:hover,
+a.home-category-card:hover,
+a.home-v2-c-card:hover,
+a.home-v2-cat-item:hover,
+a.home-v2-trend-card:hover {
+  text-decoration: none;
+}
+
 /* Global focus indicator for keyboard navigation */
 :focus-visible {
   outline: 2px solid var(--accent);


### PR DESCRIPTION
## Summary
- Remove inherited hover underlines from linked card surfaces.
- Covers skill cards, plugin/user list rows, home quick/category cards, carousel cards, and Trending Now cards.

## Why
The global `a:hover` underline was showing on full-card links, which made card surfaces like Skills, Plugins, Users, Trending Now, and category cards look like inline text links.

## Validation
- `bunx oxfmt --check src/styles.css`
- `git diff --check`
- `bun run lint`
- `bun run format:check` currently fails on 76 pre-existing unrelated files; `src/styles.css` passes the targeted formatter check and is not listed in the failures.

## Preview
- Opened local preview at `http://localhost:3000/` with public ClawHub Convex endpoints and verified card hover behavior visually.
