### PR TITLE
ci: add lightweight CodeQL scans

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,7 @@
 # If you add overlapping rules below the secops block, include @openclaw/openclaw-secops
 # on those entries too or you can silently remove required secops review.
 # Security-sensitive code, config, workflows, and docs require secops review.
+/.github/codeql/ @openclaw/openclaw-secops
 /.github/workflows/ @openclaw/openclaw-secops
 /scripts/check-staged-secrets.mjs @openclaw/openclaw-secops
 /scripts/clawhub-cli-npm-publish.sh @openclaw/openclaw-secops

--- a/.github/codeql/codeql-actions-security.yml
+++ b/.github/codeql/codeql-actions-security.yml
@@ -1,0 +1,17 @@
+name: clawhub-codeql-actions-security
+
+disable-default-queries: true
+
+queries:
+  - uses: security-extended
+
+query-filters:
+  - include:
+      precision:
+        - high
+        - very-high
+      tags contain: security
+      security-severity: /([7-9]|10)\.(\d)+/
+
+paths:
+  - .github/workflows

--- a/.github/codeql/codeql-backend-api-security.yml
+++ b/.github/codeql/codeql-backend-api-security.yml
@@ -1,0 +1,76 @@
+name: clawhub-codeql-backend-api-security
+
+disable-default-queries: true
+
+queries:
+  - uses: security-extended
+
+query-filters:
+  - include:
+      precision:
+        - high
+        - very-high
+      tags contain: security
+      security-severity: /([7-9]|10)\.(\d)+/
+
+paths:
+  - convex/auth.config.ts
+  - convex/auth.ts
+  - convex/commentModeration.ts
+  - convex/http.ts
+  - convex/httpApi.ts
+  - convex/httpApiV1
+  - convex/packagePublishTokens.ts
+  - convex/packages.ts
+  - convex/publishers.ts
+  - convex/rateLimits.ts
+  - convex/rescanRequests.ts
+  - convex/skills.ts
+  - convex/skillTransfers.ts
+  - convex/tokens.ts
+  - convex/uploads.ts
+  - convex/vt.ts
+  - convex/webhooks.ts
+  - convex/lib/access.ts
+  - convex/lib/apiTokenAuth.ts
+  - convex/lib/commentScamPrompt.ts
+  - convex/lib/githubActionsOidc.ts
+  - convex/lib/httpHeaders.ts
+  - convex/lib/httpRateLimit.ts
+  - convex/lib/httpUtils.ts
+  - convex/lib/manualOverrides.ts
+  - convex/lib/moderation.ts
+  - convex/lib/moderationEngine.ts
+  - convex/lib/moderationReasonCodes.ts
+  - convex/lib/packageRegistry.ts
+  - convex/lib/packageSecurity.ts
+  - convex/lib/publishers.ts
+  - convex/lib/publishLimits.ts
+  - convex/lib/reporting.ts
+  - convex/lib/securityPrompt.ts
+  - convex/lib/skillPublish.ts
+  - convex/lib/skillSafety.ts
+  - convex/lib/staticPublishScan.ts
+  - convex/lib/tokens.ts
+  - convex/lib/webhooks.ts
+  - convex/model/packages/rescans.ts
+  - convex/model/rescans/policy.ts
+  - convex/model/skills/rescans.ts
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/dist"
+  - "**/dist/**"
+  - "**/*.generated.ts"
+  - "**/*.bundle.js"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"
+  - "**/*test-support*"
+  - "**/*test-helper*"
+  - "**/*mock*"
+  - "**/*fixture*"
+  - "**/*bench*"
+  - "convex/_generated/**"

--- a/.github/codeql/codeql-cli-package-security.yml
+++ b/.github/codeql/codeql-cli-package-security.yml
@@ -1,0 +1,59 @@
+name: clawhub-codeql-cli-package-security
+
+disable-default-queries: true
+
+queries:
+  - uses: security-extended
+
+query-filters:
+  - include:
+      precision:
+        - high
+        - very-high
+      tags contain: security
+      security-severity: /([7-9]|10)\.(\d)+/
+
+paths:
+  - packages/clawhub/src/browserAuth.ts
+  - packages/clawhub/src/http.ts
+  - packages/clawhub/src/cli/adminHelp.ts
+  - packages/clawhub/src/cli/authToken.ts
+  - packages/clawhub/src/cli/clawdbotConfig.ts
+  - packages/clawhub/src/cli/commands/auth.ts
+  - packages/clawhub/src/cli/commands/delete.ts
+  - packages/clawhub/src/cli/commands/github.ts
+  - packages/clawhub/src/cli/commands/moderation.ts
+  - packages/clawhub/src/cli/commands/ownership.ts
+  - packages/clawhub/src/cli/commands/packages.ts
+  - packages/clawhub/src/cli/commands/publish.ts
+  - packages/clawhub/src/cli/commands/rescan.ts
+  - packages/clawhub/src/cli/commands/sync.ts
+  - packages/clawhub/src/cli/commands/transfer.ts
+  - packages/clawhub/src/cli/scanSkills.ts
+  - packages/clawhub/src/schema/openclawContract.ts
+  - packages/clawhub/src/schema/packages.ts
+  - packages/clawhub/src/schema/routes.ts
+  - packages/clawhub/src/schema/schemas.ts
+  - packages/clawhub/src/schema/textFiles.ts
+  - packages/schema/src/openclawContract.ts
+  - packages/schema/src/packages.ts
+  - packages/schema/src/routes.ts
+  - packages/schema/src/schemas.ts
+  - packages/schema/src/textFiles.ts
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/dist"
+  - "**/dist/**"
+  - "**/*.generated.ts"
+  - "**/*.bundle.js"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"
+  - "**/*test-support*"
+  - "**/*test-helper*"
+  - "**/*mock*"
+  - "**/*fixture*"
+  - "**/*bench*"

--- a/.github/codeql/codeql-frontend-publish-security.yml
+++ b/.github/codeql/codeql-frontend-publish-security.yml
@@ -1,0 +1,55 @@
+name: clawhub-codeql-frontend-publish-security
+
+disable-default-queries: true
+
+queries:
+  - uses: security-extended
+
+query-filters:
+  - include:
+      precision:
+        - high
+        - very-high
+      tags contain: security
+      security-severity: /([7-9]|10)\.(\d)+/
+
+paths:
+  - src/components/DetailSecuritySummary.tsx
+  - src/components/PackageSourceChooser.tsx
+  - src/components/SecurityScannerPage.tsx
+  - src/components/SkillSecurityScanResults.tsx
+  - src/lib/authErrorMessage.ts
+  - src/lib/packageApi.ts
+  - src/lib/packageUpload.ts
+  - src/lib/pluginPublishPrefill.ts
+  - src/lib/roles.ts
+  - src/lib/uploadFiles.ts
+  - src/lib/uploadUtils.ts
+  - src/lib/useAuthError.ts
+  - src/lib/useAuthStatus.ts
+  - src/routes/admin.tsx
+  - src/routes/cli/auth.tsx
+  - src/routes/packages/new.tsx
+  - src/routes/publish-plugin.tsx
+  - src/routes/publish-skill.tsx
+  - src/routes/upload.tsx
+  - src/routes/upload
+  - src/routes/$owner/$slug/security
+  - src/routes/plugins/$name/security
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/dist"
+  - "**/dist/**"
+  - "**/*.generated.ts"
+  - "**/*.bundle.js"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"
+  - "**/*test-support*"
+  - "**/*test-helper*"
+  - "**/*mock*"
+  - "**/*fixture*"
+  - "**/*bench*"

--- a/.github/codeql/codeql-repository-automation-security.yml
+++ b/.github/codeql/codeql-repository-automation-security.yml
@@ -1,0 +1,39 @@
+name: clawhub-codeql-repository-automation-security
+
+disable-default-queries: true
+
+queries:
+  - uses: security-extended
+
+query-filters:
+  - include:
+      precision:
+        - high
+        - very-high
+      tags contain: security
+      security-severity: /([7-9]|10)\.(\d)+/
+
+paths:
+  - scripts/check-staged-secrets.mjs
+  - scripts/clawhub-cli-npm-release-check.mjs
+  - scripts/github
+  - scripts/verify-convex-contract.ts
+  - scripts/copy-og-assets.ts
+  - scripts/check-peer-deps.ts
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/dist"
+  - "**/dist/**"
+  - "**/*.generated.ts"
+  - "**/*.bundle.js"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"
+  - "**/*test-support*"
+  - "**/*test-helper*"
+  - "**/*mock*"
+  - "**/*fixture*"
+  - "**/*bench*"

--- a/.github/workflows/codeql-light.yml
+++ b/.github/workflows/codeql-light.yml
@@ -1,0 +1,100 @@
+name: CodeQL Light
+
+on:
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: CodeQL light profile to run
+        required: false
+        default: all
+        type: choice
+        options:
+          - all
+          - backend-api
+          - frontend-publish
+          - cli-package
+          - repository-automation
+          - actions
+  push:
+    branches: [main]
+    paths:
+      - ".github/codeql/**"
+      - ".github/workflows/**"
+      - "convex/**"
+      - "packages/clawhub/**"
+      - "packages/schema/**"
+      - "scripts/**"
+      - "src/**"
+      - "bun.lock"
+      - "package.json"
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - ".github/codeql/**"
+      - ".github/workflows/**"
+      - "convex/**"
+      - "packages/clawhub/**"
+      - "packages/schema/**"
+      - "scripts/**"
+      - "src/**"
+      - "bun.lock"
+      - "package.json"
+  schedule:
+    - cron: "17 7 * * *"
+
+concurrency:
+  group: codeql-light-${{ github.event_name == 'workflow_dispatch' && github.run_id || github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.category }})
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            category: backend-api
+            config_file: ./.github/codeql/codeql-backend-api-security.yml
+          - language: javascript-typescript
+            category: frontend-publish
+            config_file: ./.github/codeql/codeql-frontend-publish-security.yml
+          - language: javascript-typescript
+            category: cli-package
+            config_file: ./.github/codeql/codeql-cli-package-security.yml
+          - language: javascript-typescript
+            category: repository-automation
+            config_file: ./.github/codeql/codeql-repository-automation-security.yml
+          - language: actions
+            category: actions
+            config_file: ./.github/codeql/codeql-actions-security.yml
+    steps:
+      - name: Checkout
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == matrix.category }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: false
+
+      - name: Initialize CodeQL
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == matrix.category }}
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ${{ matrix.config_file }}
+
+      - name: Analyze
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == matrix.category }}
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          category: "/codeql-light/${{ matrix.category }}"


### PR DESCRIPTION
## Summary
- adds a lightweight CodeQL workflow for ClawHub with path-scoped profiles
- adds CodeQL configs for backend API/security paths, frontend publish/upload paths, CLI/package contract paths, repo automation scripts, and GitHub Actions workflows
- adds CODEOWNERS coverage for the new CodeQL config directory

## Validation
- ruby YAML parse for `.github/workflows/codeql-light.yml` and `.github/codeql/*.yml`
- verified each concrete CodeQL `paths` / `paths-ignore` entry exists
- `/Users/vincentkoc/GIT/_Perso/clawhub/node_modules/.bin/oxfmt --check .github/workflows/codeql-light.yml .github/codeql/*.yml .github/CODEOWNERS`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/codeql-light.yml`
- `git diff --check HEAD~1..HEAD`
