### PR TITLE
feat: add clawhub unban command

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -2504,6 +2504,71 @@ describe("httpApiV1 handlers", () => {
     );
   });
 
+  it("unban user requires auth", async () => {
+    vi.mocked(requireApiTokenUser).mockRejectedValueOnce(new Error("Unauthorized"));
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const response = await __handlers.usersPostRouterV1Handler(
+      makeCtx({ runMutation }),
+      new Request("https://example.com/api/v1/users/unban", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ handle: "demo" }),
+      }),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  it("unban user succeeds with handle", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:1",
+      user: { handle: "p" },
+    } as never);
+    const runQuery = vi.fn().mockResolvedValue({ _id: "users:2" });
+    const runMutation = vi
+      .fn()
+      .mockResolvedValueOnce(okRate())
+      .mockResolvedValueOnce({ ok: true, alreadyUnbanned: false, restoredSkills: 2 });
+    const response = await __handlers.usersPostRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/users/unban", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ handle: "demo" }),
+      }),
+    );
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.restoredSkills).toBe(2);
+  });
+
+  it("unban user forwards reason", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:1",
+      user: { handle: "p" },
+    } as never);
+    const runQuery = vi.fn().mockResolvedValue({ _id: "users:2" });
+    const runMutation = vi
+      .fn()
+      .mockResolvedValueOnce(okRate())
+      .mockResolvedValueOnce({ ok: true, alreadyUnbanned: false, restoredSkills: 0 });
+    await __handlers.usersPostRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/users/unban", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ handle: "demo", reason: "appeal accepted" }),
+      }),
+    );
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        actorUserId: "users:1",
+        targetUserId: "users:2",
+        reason: "appeal accepted",
+      }),
+    );
+  });
+
   it("set role requires auth", async () => {
     vi.mocked(requireApiTokenUser).mockRejectedValueOnce(new Error("Unauthorized"));
     const runMutation = vi.fn().mockResolvedValue(okRate());

--- a/convex/httpApiV1/usersV1.ts
+++ b/convex/httpApiV1/usersV1.ts
@@ -24,6 +24,7 @@ export async function usersPostRouterV1Handler(ctx: ActionCtx, request: Request)
   const action = segments[0];
   if (
     action !== "ban" &&
+    action !== "unban" &&
     action !== "role" &&
     action !== "restore" &&
     action !== "reclaim" &&
@@ -99,6 +100,30 @@ export async function usersPostRouterV1Handler(ctx: ActionCtx, request: Request)
       return json(result, 200, rate.headers);
     } catch (error) {
       const message = error instanceof Error ? error.message : "Ban failed";
+      if (message.toLowerCase().includes("forbidden")) {
+        return text("Forbidden", 403, rate.headers);
+      }
+      if (message.toLowerCase().includes("not found")) {
+        return text(message, 404, rate.headers);
+      }
+      return text(message, 400, rate.headers);
+    }
+  }
+
+  if (action === "unban") {
+    const reason = reasonRaw.length > 0 ? reasonRaw : undefined;
+    if (reason && reason.length > 500) {
+      return text("Reason too long (max 500 chars)", 400, rate.headers);
+    }
+    try {
+      const result = await ctx.runMutation(internal.users.unbanUserInternal, {
+        actorUserId,
+        targetUserId,
+        reason,
+      });
+      return json(result, 200, rate.headers);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unban failed";
       if (message.toLowerCase().includes("forbidden")) {
         return text("Forbidden", 403, rate.headers);
       }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -205,6 +205,15 @@ Stores your API token + cached registry URL.
 - `--reason` records an optional ban reason.
 - `--yes` skips confirmation.
 
+### `unban-user <handleOrId>`
+
+- Unban a user and restore eligible skills (admin only).
+- Calls `POST /api/v1/users/unban`.
+- `--id` treats the argument as a user id instead of a handle.
+- `--fuzzy` resolves the handle via fuzzy user search (admin only).
+- `--reason` records an optional unban reason.
+- `--yes` skips confirmation.
+
 ### `set-role <handleOrId> <role>`
 
 - Change a user role (admin only).

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -515,6 +515,28 @@ Response:
 { "ok": true, "alreadyBanned": false, "deletedSkills": 3 }
 ```
 
+### `POST /api/v1/users/unban`
+
+Unban a user and restore eligible skills (admin only).
+
+Body:
+
+```json
+{ "handle": "user_handle", "reason": "optional unban reason" }
+```
+
+or
+
+```json
+{ "userId": "users_...", "reason": "optional unban reason" }
+```
+
+Response:
+
+```json
+{ "ok": true, "alreadyUnbanned": false, "restoredSkills": 3 }
+```
+
 ### `POST /api/v1/users/role`
 
 Change a user role (admin only).

--- a/e2e/clawhub.e2e.test.ts
+++ b/e2e/clawhub.e2e.test.ts
@@ -88,7 +88,7 @@ function shouldSeedRoleHelpTokens() {
 
 const itIfLiveMutations = allowLiveMutations() ? it : it.skip;
 const itIfAdminAndUserTokens =
-  getAdminToken() && getUserToken() || shouldSeedRoleHelpTokens() ? it : it.skip;
+  (getAdminToken() && getUserToken()) || shouldSeedRoleHelpTokens() ? it : it.skip;
 
 type RoleHelpTokens = {
   adminToken: string;
@@ -325,9 +325,11 @@ describe("clawhub e2e", () => {
 
       expect(adminResult.status).toBe(0);
       expect(adminResult.stdout).toContain("ban-user");
+      expect(adminResult.stdout).toContain("unban-user");
       expect(adminResult.stdout).toContain("set-role");
       expect(userResult.status).toBe(0);
       expect(userResult.stdout).not.toContain("ban-user");
+      expect(userResult.stdout).not.toContain("unban-user");
       expect(userResult.stdout).not.toContain("set-role");
     } finally {
       await rm(adminCfg.dir, { recursive: true, force: true });

--- a/packages/clawhub/src/cli.ts
+++ b/packages/clawhub/src/cli.ts
@@ -13,7 +13,7 @@ import {
   cmdUnhideSkill,
 } from "./cli/commands/delete.js";
 import { cmdInspect } from "./cli/commands/inspect.js";
-import { cmdBanUser, cmdSetRole } from "./cli/commands/moderation.js";
+import { cmdBanUser, cmdSetRole, cmdUnbanUser } from "./cli/commands/moderation.js";
 import { cmdMergeSkill, cmdRenameSkill } from "./cli/commands/ownership.js";
 import {
   cmdExplorePackages,
@@ -511,6 +511,19 @@ program
   .action(async (handleOrId, options) => {
     const opts = await resolveGlobalOpts();
     await cmdBanUser(opts, handleOrId, options, isInputAllowed());
+  });
+
+program
+  .command("unban-user", adminCommandOptions)
+  .description("Unban a user and restore eligible skills (admin only)")
+  .argument("<handleOrId>", "User handle (default) or user id")
+  .option("--id", "Treat argument as user id")
+  .option("--fuzzy", "Resolve handle via fuzzy user search (admin only)")
+  .option("--reason <reason>", "Unban reason (optional)")
+  .option("--yes", "Skip confirmation")
+  .action(async (handleOrId, options) => {
+    const opts = await resolveGlobalOpts();
+    await cmdUnbanUser(opts, handleOrId, options, isInputAllowed());
   });
 
 program

--- a/packages/clawhub/src/cli/commands/moderation.test.ts
+++ b/packages/clawhub/src/cli/commands/moderation.test.ts
@@ -19,7 +19,7 @@ vi.mock("../registry.js", () => registryMocks.moduleFactory());
 vi.mock("../../http.js", () => httpMocks.moduleFactory());
 vi.mock("../ui.js", () => uiMocks.moduleFactory());
 
-const { cmdBanUser, cmdSetRole } = await import("./moderation");
+const { cmdBanUser, cmdSetRole, cmdUnbanUser } = await import("./moderation");
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -188,6 +188,108 @@ describe("cmdSetRole", () => {
         method: "POST",
         path: "/api/v1/users/role",
         body: { userId: "user_123", role: "admin" },
+      }),
+      expect.anything(),
+    );
+  });
+});
+
+describe("cmdUnbanUser", () => {
+  it("requires --yes when input is disabled", async () => {
+    await expect(cmdUnbanUser(makeGlobalOpts(), "demo", {}, false)).rejects.toThrow(/--yes/i);
+  });
+
+  it("posts handle payload", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      ok: true,
+      alreadyUnbanned: false,
+      restoredSkills: 1,
+    });
+    await cmdUnbanUser(makeGlobalOpts(), "hightower6eu", { yes: true }, false);
+    expect(httpMocks.apiRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/v1/users/unban",
+        body: { handle: "hightower6eu" },
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("includes reason when provided", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      ok: true,
+      alreadyUnbanned: false,
+      restoredSkills: 0,
+    });
+    await cmdUnbanUser(
+      makeGlobalOpts(),
+      "hightower6eu",
+      { yes: true, reason: "appeal accepted" },
+      false,
+    );
+    expect(httpMocks.apiRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/v1/users/unban",
+        body: { handle: "hightower6eu", reason: "appeal accepted" },
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("posts user id payload when --id is set", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      ok: true,
+      alreadyUnbanned: false,
+      restoredSkills: 0,
+    });
+    await cmdUnbanUser(makeGlobalOpts(), "user_123", { yes: true, id: true }, false);
+    expect(httpMocks.apiRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/v1/users/unban",
+        body: { userId: "user_123" },
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("resolves user via fuzzy search", async () => {
+    httpMocks.apiRequest
+      .mockResolvedValueOnce({
+        items: [
+          {
+            userId: "users_123",
+            handle: "moonshine-100rze",
+            displayName: null,
+            name: null,
+            role: "user",
+          },
+        ],
+        total: 1,
+      })
+      .mockResolvedValueOnce({ ok: true, alreadyUnbanned: false, restoredSkills: 0 });
+    await cmdUnbanUser(makeGlobalOpts(), "moonshine-100rze", { yes: true, fuzzy: true }, false);
+    expect(httpMocks.apiRequest).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({
+        method: "GET",
+        url: expect.stringContaining("/api/v1/users?"),
+      }),
+      expect.anything(),
+    );
+    expect(httpMocks.apiRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/v1/users/unban",
+        body: { userId: "users_123" },
       }),
       expect.anything(),
     );

--- a/packages/clawhub/src/cli/commands/moderation.ts
+++ b/packages/clawhub/src/cli/commands/moderation.ts
@@ -4,6 +4,7 @@ import {
   ApiRoutes,
   ApiV1BanUserResponseSchema,
   ApiV1SetRoleResponseSchema,
+  ApiV1UnbanUserResponseSchema,
   ApiV1UserSearchResponseSchema,
   parseArk,
 } from "../../schema/index.js";
@@ -62,6 +63,65 @@ export async function cmdBanUser(
       return parsed;
     }
     spinner.succeed(`OK. Banned ${resolved.label} (${formatDeletedSkills(parsed.deletedSkills)})`);
+    return parsed;
+  } catch (error) {
+    spinner.fail(formatError(error));
+    throw error;
+  }
+}
+
+export async function cmdUnbanUser(
+  opts: GlobalOpts,
+  identifierArg: string,
+  options: { yes?: boolean; id?: boolean; fuzzy?: boolean; reason?: string },
+  inputAllowed: boolean,
+) {
+  const raw = identifierArg.trim();
+  if (!raw) fail("Handle or user id required");
+
+  const reason = options.reason?.trim() || undefined;
+
+  const token = await requireAuthToken();
+  const registry = await getRegistry(opts, { cache: true });
+  const allowPrompt = isInteractive() && inputAllowed !== false;
+  const resolved = await resolveUserIdentifier(
+    registry,
+    token,
+    raw,
+    { id: options.id, fuzzy: options.fuzzy },
+    allowPrompt,
+  );
+  if (!resolved) return undefined;
+  if (!options.yes) {
+    if (!allowPrompt) fail("Pass --yes (no input)");
+    const ok = await promptConfirm(
+      `Unban ${resolved.label}? (admin only; restores eligible skills)`,
+    );
+    if (!ok) return undefined;
+  }
+
+  const spinner = createSpinner(`Unbanning ${resolved.label}`);
+  try {
+    const result = await apiRequest(
+      registry,
+      {
+        method: "POST",
+        path: `${ApiRoutes.users}/unban`,
+        token,
+        body: resolved.userId
+          ? { userId: resolved.userId, reason }
+          : { handle: resolved.handle, reason },
+      },
+      ApiV1UnbanUserResponseSchema,
+    );
+    const parsed = parseArk(ApiV1UnbanUserResponseSchema, result, "Unban user response");
+    if (parsed.alreadyUnbanned) {
+      spinner.succeed(`OK. ${resolved.label} already unbanned`);
+      return parsed;
+    }
+    spinner.succeed(
+      `OK. Unbanned ${resolved.label} (${formatRestoredSkills(parsed.restoredSkills)})`,
+    );
     return parsed;
   } catch (error) {
     spinner.fail(formatError(error));
@@ -225,4 +285,10 @@ function formatDeletedSkills(count: number) {
   if (!Number.isFinite(count)) return "deleted skills unknown";
   if (count === 1) return "deleted 1 skill";
   return `deleted ${count} skills`;
+}
+
+function formatRestoredSkills(count: number | undefined) {
+  if (!Number.isFinite(count)) return "restored skills unknown";
+  if (count === 1) return "restored 1 skill";
+  return `restored ${count} skills`;
 }

--- a/packages/clawhub/src/schema/schemas.ts
+++ b/packages/clawhub/src/schema/schemas.ts
@@ -340,6 +340,12 @@ export const ApiV1BanUserResponseSchema = type({
   deletedSkills: "number",
 });
 
+export const ApiV1UnbanUserResponseSchema = type({
+  ok: "true",
+  alreadyUnbanned: "boolean",
+  restoredSkills: "number?",
+});
+
 export const ApiV1SetRoleResponseSchema = type({
   ok: "true",
   role: '"admin"|"moderator"|"user"',


### PR DESCRIPTION
## Summary
- add POST /api/v1/users/unban as a thin API-token wrapper around the existing unban mutation
- add clawhub unban-user with --id, --fuzzy, --reason, and --yes support
- document the HTTP and CLI surfaces and extend CLI/API coverage

## Validation
- bun run test:src src/cli/commands/moderation.test.ts
- bunx vitest run convex/httpApiV1.handlers.test.ts
- bun run lint
- bunx oxfmt --check convex/httpApiV1.handlers.test.ts convex/httpApiV1/usersV1.ts docs/cli.md docs/http-api.md e2e/clawhub.e2e.test.ts packages/clawhub/src/cli.ts packages/clawhub/src/cli/commands/moderation.test.ts packages/clawhub/src/cli/commands/moderation.ts packages/clawhub/src/schema/schemas.ts
- bunx tsc -p packages/schema/tsconfig.json --noEmit
- bunx tsc -p packages/clawhub/tsconfig.json --noEmit
- bun clawhub unban-user --help

## Notes
- Repo-wide bun run format:check still reports pre-existing formatting drift across untouched files.
- Repo-wide bunx tsc --noEmit still fails in scripts/security-dataset/* with existing errors unrelated to this change.
- The private local Codex skill was created at ~/.codex/skills/clawhub-moderation and is intentionally not part of this PR.