### PR TITLE
fix: make detail install panels full width

### DIFF
--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -228,6 +228,18 @@ describe("plugin detail route", () => {
     expect(
       screen.getByRole("link", { name: /Static analysis.*Benign/i }).getAttribute("href"),
     ).toBe("/plugins/demo-plugin/security/static-analysis");
+
+    const securityHeading = screen.getByText("Security Scans");
+    const installHeading = screen.getByRole("heading", { name: "Install" });
+    const capabilitiesHeading = screen.getByRole("heading", { name: "Capabilities" });
+    expect(
+      securityHeading.compareDocumentPosition(capabilitiesHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      installHeading.compareDocumentPosition(capabilitiesHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("shows owner-only plugin rescan state in the security summary", async () => {

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -238,6 +238,15 @@ describe("SkillDetailPage", () => {
     expect(screen.getByRole("link", { name: /Static analysis.*Pending/i })).toBeTruthy();
     expect(screen.queryByText(/Like a lobster shell, security has layers/i)).toBeNull();
     expect(screen.queryByRole("button", { name: "Rescan" })).toBeNull();
+
+    const installHeading = screen.getAllByRole("heading", { name: "Install" })[0];
+    const filesTab = screen.getByRole("button", { name: "Files" });
+    expect(
+      installHeading.compareDocumentPosition(filesTab) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      securityHeading.compareDocumentPosition(filesTab) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("applies staff-cleared moderation overrides to the public security summary", async () => {

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -217,4 +217,18 @@ describe("restored UI design contract", () => {
     expect(darkRatio).toBeGreaterThanOrEqual(7);
     expect(lightRatio).toBeGreaterThanOrEqual(7);
   });
+
+  it("keeps detail heroes full width unless an explicit sidebar is present", () => {
+    const shellSource = read("src/components/DetailPageShell.tsx");
+    const css = styles();
+
+    expect(shellSource).toContain('"skill-hero-layout has-sidebar"');
+    expect(cssRule(css, ".skill-hero-layout")).toContain("grid-template-columns: minmax(0, 1fr)");
+    expect(cssRule(css, ".skill-hero-layout.has-sidebar")).toContain(
+      "grid-template-columns: minmax(0, 1fr) minmax(300px, 360px)",
+    );
+    expect(cssRule(css, ".skill-hero-action-grid")).toContain(
+      "grid-template-columns: repeat(auto-fit, minmax(min(360px, 100%), 1fr))",
+    );
+  });
 });

--- a/src/components/DetailPageShell.tsx
+++ b/src/components/DetailPageShell.tsx
@@ -38,7 +38,7 @@ export function DetailHero({
   return (
     <div className={cn("skill-hero", className)}>
       <div className={cn("skill-hero-top", topClassName)}>
-        <div className="skill-hero-layout">
+        <div className={cn(sidebar ? "skill-hero-layout has-sidebar" : "skill-hero-layout")}>
           <div className={cn("skill-hero-main", mainClassName)}>
             {main}
             {children ? <div className="skill-hero-main-extra">{children}</div> : null}

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -440,7 +440,7 @@ export function SkillDetailPage({
           cliHelp={cliHelp}
           clawdis={clawdis}
           osLabels={osLabels}
-          sidebarContent={securitySummary}
+          priorityContent={securitySummary}
           settingsHref={settingsHref}
         >
           {mode === "detail" ? (

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -67,7 +67,7 @@ type SkillHeaderProps = {
   cliHelp: string | undefined;
   clawdis: ClawdisSkillMetadata | undefined;
   osLabels: string[];
-  sidebarContent?: ReactNode;
+  priorityContent?: ReactNode;
   settingsHref?: string | null;
   children?: ReactNode;
 };
@@ -101,7 +101,7 @@ export function SkillHeader({
   cliHelp,
   clawdis,
   osLabels,
-  sidebarContent,
+  priorityContent,
   settingsHref,
   children,
 }: SkillHeaderProps) {
@@ -171,8 +171,23 @@ export function SkillHeader({
                   <span className="plugin-version-badge">v{latestVersion.version}</span>
                 ) : null}
                 {nixPlugin ? <Badge variant="accent">Plugin bundle (nix)</Badge> : null}
-                {canManage || isStaff || settingsHref ? (
+                {isAuthenticated || canManage || isStaff || settingsHref ? (
                   <div className="skill-title-actions">
+                    {isAuthenticated ? (
+                      <>
+                        <button
+                          className={`star-toggle${isStarred ? " is-active" : ""}`}
+                          type="button"
+                          onClick={onToggleStar}
+                          aria-label={isStarred ? "Unstar skill" : "Star skill"}
+                        >
+                          <Star size={16} aria-hidden="true" />
+                        </button>
+                        <Button variant="ghost" size="sm" type="button" onClick={onOpenReport}>
+                          Report
+                        </Button>
+                      </>
+                    ) : null}
                     {isStaff ? (
                       <Button asChild variant="outline" size="sm">
                         <Link to="/management" search={{ skill: skill.slug, plugin: undefined }}>
@@ -293,34 +308,18 @@ export function SkillHeader({
             </div>
           </>
         }
-        sidebar={
-          <>
-            {isAuthenticated ? (
-              <div className="skill-actions">
-                <button
-                  className={`star-toggle${isStarred ? " is-active" : ""}`}
-                  type="button"
-                  onClick={onToggleStar}
-                  aria-label={isStarred ? "Unstar skill" : "Star skill"}
-                >
-                  <Star size={16} aria-hidden="true" />
-                </button>
-                <Button variant="ghost" size="sm" type="button" onClick={onOpenReport}>
-                  Report
-                </Button>
-              </div>
-            ) : null}
-            {sidebarContent}
-            <SkillCommandLineCard
-              slug={skill.slug}
-              displayName={skill.displayName}
-              ownerHandle={ownerHandle}
-              ownerId={installOwnerId}
-              clawdis={clawdis}
-            />
-          </>
-        }
       >
+        <div className="skill-hero-action-grid">
+          {priorityContent}
+          <SkillCommandLineCard
+            slug={skill.slug}
+            displayName={skill.displayName}
+            ownerHandle={ownerHandle}
+            ownerId={installOwnerId}
+            clawdis={clawdis}
+          />
+        </div>
+
         {children}
 
         {hasPluginBundle ? (

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -354,40 +354,39 @@ function PluginDetailRoute() {
               </div>
             </div>
           }
-          sidebar={
-            <>
-              {latestRelease ? (
-                <DetailSecuritySummary
-                  scannerBasePath={`/plugins/${encodeURIComponent(name)}/security`}
-                  sha256hash={latestRelease.sha256hash ?? null}
-                  vtAnalysis={latestRelease.vtAnalysis ?? null}
-                  llmAnalysis={latestRelease.llmAnalysis ?? null}
-                  staticScan={latestRelease.staticScan ?? null}
-                  rescanState={rescanState ?? null}
-                  onRequestRescan={rescanState ? requestRescan : null}
-                />
-              ) : null}
-              <Card className="skill-install-command-card">
-                <CardHeader>
-                  <CardTitle>Install</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="skill-install-command-wrap">
-                    <pre className="skill-install-command">
-                      <code>{installSnippet}</code>
-                    </pre>
-                    <InstallCopyButton
-                      text={installSnippet}
-                      ariaLabel="Copy plugin install command"
-                      showLabel={false}
-                      className="skill-install-command-inline-button"
-                    />
-                  </div>
-                </CardContent>
-              </Card>
-            </>
-          }
         >
+          <div className="skill-hero-action-grid">
+            {latestRelease ? (
+              <DetailSecuritySummary
+                scannerBasePath={`/plugins/${encodeURIComponent(name)}/security`}
+                sha256hash={latestRelease.sha256hash ?? null}
+                vtAnalysis={latestRelease.vtAnalysis ?? null}
+                llmAnalysis={latestRelease.llmAnalysis ?? null}
+                staticScan={latestRelease.staticScan ?? null}
+                rescanState={rescanState ?? null}
+                onRequestRescan={rescanState ? requestRescan : null}
+              />
+            ) : null}
+            <Card className="skill-install-command-card">
+              <CardHeader>
+                <CardTitle>Install</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="skill-install-command-wrap">
+                  <pre className="skill-install-command">
+                    <code>{installSnippet}</code>
+                  </pre>
+                  <InstallCopyButton
+                    text={installSnippet}
+                    ariaLabel="Copy plugin install command"
+                    showLabel={false}
+                    className="skill-install-command-inline-button"
+                  />
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
           {readme ? (
             <Card className="tab-card">
               <CardHeader>

--- a/src/styles.css
+++ b/src/styles.css
@@ -3389,9 +3389,14 @@ code {
 
 .skill-hero-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(300px, 360px);
+  grid-template-columns: minmax(0, 1fr);
   align-items: start;
   gap: 24px;
+  min-width: 0;
+}
+
+.skill-hero-layout.has-sidebar {
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 360px);
 }
 
 .skill-hero-main {
@@ -3402,7 +3407,7 @@ code {
 
 .skill-hero-main-extra {
   display: grid;
-  gap: 32px;
+  gap: 24px;
   min-width: 0;
 }
 
@@ -3473,6 +3478,18 @@ code {
 .skill-hero-content {
   display: grid;
   gap: 16px;
+}
+
+.skill-hero-action-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(360px, 100%), 1fr));
+  gap: 16px;
+  align-items: stretch;
+  min-width: 0;
+}
+
+.skill-hero-action-grid > * {
+  min-width: 0;
 }
 
 .bundle-card {
@@ -3679,7 +3696,10 @@ code {
   padding: 20px;
   border-radius: var(--radius-md);
   border: 1px solid var(--line);
-  background: var(--surface);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--surface) 96%, white), var(--surface)),
+    var(--surface);
+  box-shadow: var(--shadow-card);
   min-width: 0;
 }
 
@@ -3900,7 +3920,10 @@ code {
   padding: 20px;
   border-radius: var(--radius-md);
   border: 1px solid var(--line);
-  background: var(--surface);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--surface) 96%, white), var(--surface)),
+    var(--surface);
+  box-shadow: var(--shadow-card);
 }
 
 .skill-install-command-header {
@@ -4014,14 +4037,8 @@ code {
 }
 
 @media (max-width: 1024px) {
-  .skill-hero-layout {
+  .skill-hero-layout.has-sidebar {
     grid-template-columns: 1fr;
-  }
-}
-
-@media (min-width: 1025px) {
-  .skill-detail-stack > .detail-layout {
-    width: calc(100% - 384px);
   }
 }
 
@@ -4941,7 +4958,7 @@ code {
     justify-content: flex-start;
   }
 
-  .skill-hero-layout {
+  .skill-hero-layout.has-sidebar {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary
- make detail heroes one-column/full-width unless an explicit sidebar is present
- move skill and plugin security/install panels above the long detail content
- tighten the install panels with responsive action-grid styling

## Tests
- `bunx vitest run src/__tests__/ui-design-contract.test.ts src/__tests__/skill-detail-page.test.tsx src/__tests__/package-detail-route.test.ts`
- `bun run lint`
- `bunx oxfmt --check src/__tests__/ui-design-contract.test.ts src/__tests__/skill-detail-page.test.tsx src/__tests__/package-detail-route.test.tsx src/components/DetailPageShell.tsx src/components/SkillHeader.tsx src/components/SkillDetailPage.tsx 'src/routes/plugins/$name.tsx' src/styles.css`
- `git diff --check`
- `set -a; [ -f .env.local ] && source .env.local; set +a; bun run build`

## Notes
- `bun run format:check` still fails on the existing repo-wide 99-file formatting baseline; the files touched by this PR pass targeted `oxfmt --check`.
