### PR TITLE
feat: clarify about page policy patterns

### DIFF
--- a/convex/lib/clawpack.ts
+++ b/convex/lib/clawpack.ts
@@ -1,11 +1,11 @@
 import { gunzipSync } from "fflate";
 
-export type ClawPackEntry = {
+type ClawPackEntry = {
   path: string;
   bytes: Uint8Array;
 };
 
-export type ParsedClawPack = {
+type ParsedClawPack = {
   artifactSha256: string;
   npmIntegrity: string;
   npmShasum: string;
@@ -110,7 +110,7 @@ function parseTarEntries(bytes: Uint8Array): ClawPackEntry[] {
 async function digestBytes(algorithm: "SHA-1" | "SHA-256" | "SHA-512", bytes: Uint8Array) {
   const input = new Uint8Array(bytes.byteLength);
   input.set(bytes);
-  const digest = await crypto.subtle.digest(algorithm, input.buffer);
+  const digest = await crypto.subtle.digest(algorithm, input);
   return new Uint8Array(digest);
 }
 

--- a/docs/acceptable-usage.md
+++ b/docs/acceptable-usage.md
@@ -1,5 +1,5 @@
 ---
-summary: "Marketplace policy: what ClawHub will not allow."
+summary: "Marketplace policy: what ClawHub allows and what it will not host."
 read_when:
   - Reviewing uploads for abuse or policy violations
   - Writing moderation docs or reviewer runbooks
@@ -8,9 +8,18 @@ read_when:
 
 # Acceptable Usage
 
-This page describes the kinds of skills and content ClawHub is not okay with.
+This page describes the kinds of skills and content ClawHub is okay with, and the abuse workflows it will not host.
 
 These rules are intentionally practical. We care most about end-to-end abuse workflows, not just isolated keywords. If a skill is built to evade defenses, abuse platforms, scam people, invade privacy, or enable non-consensual behavior, it does not belong on ClawHub.
+
+## Recent patterns we are explicitly okay with
+
+- Frontend and design-system work that uses real components, semantic tokens, accessible states, and tested user flows.
+- shadcn/ui composition that uses installed source components, project aliases, and documented variants instead of one-off markup.
+- UI5 JavaScript-to-TypeScript conversion that preserves comments, uses concrete UI5 types, and keeps generated control interfaces reviewable.
+- Defensive security review, moderation tooling, and abuse-detection prompts that show evidence and keep human approval boundaries clear.
+- Consent-based workflow automation for personal or team accounts with explicit credentials, transparent setup, and dry-run or preview modes.
+- Docs, migration runbooks, local developer utilities, and test fixtures scoped to the repository they support.
 
 ## Not okay
 

--- a/packages/clawhub/src/clawpack.ts
+++ b/packages/clawhub/src/clawpack.ts
@@ -1,11 +1,11 @@
 import { gunzipSync } from "fflate";
 
-export type ClawPackEntry = {
+type ClawPackEntry = {
   path: string;
   bytes: Uint8Array;
 };
 
-export type ParsedClawPack = {
+type ParsedClawPack = {
   packageName: string;
   packageVersion: string;
   entries: ClawPackEntry[];

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,17 +1,6 @@
 import { useAuthActions } from "@convex-dev/auth/react";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
-import {
-  ArrowRight,
-  Ghost,
-  GitPullRequest,
-  Menu,
-  Monitor,
-  Moon,
-  Plug,
-  Search,
-  Sun,
-  Wrench,
-} from "lucide-react";
+import { ArrowRight, Ghost, Menu, Monitor, Moon, Plug, Search, Sun, Wrench } from "lucide-react";
 import { type ComponentType, useEffect, useMemo, useRef, useState } from "react";
 import { getUserFacingAuthError } from "../lib/authErrorMessage";
 import { gravatarUrl } from "../lib/gravatar";
@@ -56,6 +45,14 @@ const NAV_ICONS: Record<NavIconName, ComponentType<{ size?: number; className?: 
 };
 
 const THEME_MODE_SEQUENCE: Array<"system" | "light" | "dark"> = ["system", "light", "dark"];
+
+function GitHubLogo({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+      <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56 0-.28-.01-1.02-.02-2-3.2.7-3.88-1.54-3.88-1.54-.52-1.33-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.55-.29-5.24-1.28-5.24-5.68 0-1.25.45-2.28 1.18-3.08-.12-.29-.51-1.46.11-3.04 0 0 .97-.31 3.16 1.18.92-.26 1.9-.38 2.88-.39.98 0 1.96.13 2.88.39 2.19-1.49 3.15-1.18 3.15-1.18.63 1.58.24 2.75.12 3.04.74.8 1.18 1.83 1.18 3.08 0 4.42-2.69 5.39-5.25 5.67.42.36.78 1.07.78 2.15 0 1.55-.01 2.8-.01 3.18 0 .31.21.67.8.56A11.51 11.51 0 0 0 23.5 12C23.5 5.65 18.35.5 12 .5Z" />
+    </svg>
+  );
+}
 
 type TypeaheadItem =
   | {
@@ -486,7 +483,7 @@ export default function Header() {
                     });
                   }}
                 >
-                  <GitPullRequest className="h-5 w-5" aria-hidden="true" />
+                  <GitHubLogo className="github-sign-in-logo" />
                   <span className="sign-in-full-copy" aria-hidden="true">
                     Sign in with GitHub
                   </span>

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -1,9 +1,21 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import type { LucideIcon } from "lucide-react";
-import { Banknote, Drama, Eye, EyeOff, ImageOff, ShieldOff, UserX } from "lucide-react";
+import {
+  Banknote,
+  Ban,
+  CheckCircle2,
+  Drama,
+  Eye,
+  EyeOff,
+  ImageOff,
+  ShieldCheck,
+  ShieldOff,
+  UserX,
+} from "lucide-react";
 import type { ReactNode } from "react";
 import { Badge } from "../components/ui/badge";
 import { Button } from "../components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
 import { getSiteMode, getSiteName, getSiteUrlForMode } from "../lib/site";
 
 export function renderWithInlineCode(text: string): ReactNode[] {
@@ -65,7 +77,16 @@ const prohibitedCategories: { title: string; icon: LucideIcon; examples: string 
   },
 ];
 
-const recentPatterns = [
+const acceptedPatterns = [
+  "Frontend and design-system work that uses real components, semantic tokens, accessible states, and tested user flows.",
+  "shadcn/ui composition that uses installed source components, project aliases, and documented variants instead of one-off markup.",
+  "UI5 JavaScript-to-TypeScript conversion that preserves comments, uses concrete UI5 types, and keeps generated control interfaces reviewable.",
+  "Defensive security review, moderation tooling, and abuse-detection prompts that show evidence and keep human approval boundaries clear.",
+  "Consent-based workflow automation for personal or team accounts with explicit credentials, transparent setup, and dry-run or preview modes.",
+  "Docs, migration runbooks, local developer utilities, and test fixtures scoped to the repository they support.",
+];
+
+const rejectedPatterns = [
   "Create stealth seller accounts after marketplace bans.",
   "Modify Telegram pairing so unapproved users automatically receive pairing codes.",
   "Cultivate Reddit or Twitter accounts with undetectable automation.",
@@ -117,9 +138,9 @@ function AboutPage() {
             </div>
             <h1 className="about-title">What ClawHub will not host</h1>
             <p className="about-lead">
-              ClawHub is for useful agent tooling, not abuse workflows. If a skill is built to evade
-              defenses, scam people, invade privacy, or enable non-consensual behavior, it does not
-              belong here.
+              ClawHub is for useful, reviewable agent tooling. Skills that improve developer
+              workflows, migrations, security review, or product implementation belong here. Abuse
+              workflows do not.
             </p>
           </div>
         </section>
@@ -142,30 +163,74 @@ function AboutPage() {
             {prohibitedCategories.map((category) => {
               const Icon = category.icon;
               return (
-                <article key={category.title} className="about-rule-card">
-                  <div className="about-rule-card-header">
+                <Card key={category.title} className="about-rule-card">
+                  <CardHeader className="about-rule-card-header">
                     <div className="about-rule-card-icon">
-                      <Icon size={18} />
+                      <Icon />
                     </div>
-                    <h3>{category.title}</h3>
-                  </div>
-                  <p>{renderWithInlineCode(category.examples)}</p>
-                </article>
+                    <CardTitle>{category.title}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p>{renderWithInlineCode(category.examples)}</p>
+                  </CardContent>
+                </Card>
               );
             })}
           </div>
         </section>
 
         <section className="about-panel about-panel-patterns">
-          <div className="home-section-header">
-            <h2 className="home-section-title">Recent patterns we are explicitly not okay with</h2>
+          <div className="about-patterns-header">
+            <div className="skill-card-tags">
+              <Badge variant="success">Okay</Badge>
+              <Badge variant="destructive">Not okay</Badge>
+            </div>
+            <h2 className="home-section-title">Recent patterns we are explicitly okay with</h2>
+            <p className="about-panel-copy">
+              The line is intent and execution. Reviewable tooling for real work stays; tooling
+              optimized for evasion, deception, or non-consensual use gets rejected.
+            </p>
           </div>
-          <div className="about-patterns">
-            {recentPatterns.map((pattern) => (
-              <div key={pattern} className="about-pattern">
-                {pattern}
-              </div>
-            ))}
+          <div className="about-pattern-lanes">
+            <Card className="about-pattern-lane about-pattern-lane-accepted">
+              <CardHeader className="about-pattern-lane-header">
+                <div className="about-rule-card-icon">
+                  <CheckCircle2 />
+                </div>
+                <div>
+                  <Badge variant="success">Allowed</Badge>
+                  <CardTitle>Useful, consent-based tooling</CardTitle>
+                </div>
+              </CardHeader>
+              <CardContent className="about-patterns">
+                {acceptedPatterns.map((pattern) => (
+                  <div key={pattern} className="about-pattern about-pattern-accepted">
+                    <ShieldCheck />
+                    <span>{pattern}</span>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+
+            <Card className="about-pattern-lane about-pattern-lane-rejected">
+              <CardHeader className="about-pattern-lane-header">
+                <div className="about-rule-card-icon">
+                  <Ban />
+                </div>
+                <div>
+                  <Badge variant="destructive">Rejected</Badge>
+                  <CardTitle>Abuse workflows in disguise</CardTitle>
+                </div>
+              </CardHeader>
+              <CardContent className="about-patterns">
+                {rejectedPatterns.map((pattern) => (
+                  <div key={pattern} className="about-pattern about-pattern-rejected">
+                    <ShieldOff />
+                    <span>{pattern}</span>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
           </div>
         </section>
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1008,7 +1008,7 @@ code {
   color: var(--ink) !important;
 }
 
-.github-sign-in-button svg {
+.github-sign-in-button .github-sign-in-logo {
   width: 22px;
   height: 22px;
 }
@@ -4892,7 +4892,7 @@ code {
     border-radius: var(--r-md) !important;
   }
 
-  .github-sign-in-button svg {
+  .github-sign-in-button .github-sign-in-logo {
     width: 24px;
     height: 24px;
   }
@@ -8453,7 +8453,7 @@ code {
   gap: var(--space-4);
   padding: var(--space-5);
   border: 1px solid var(--line);
-  border-radius: var(--r-xl);
+  border-radius: var(--r-lg);
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--surface) 88%, transparent), transparent),
     color-mix(in srgb, var(--surface-muted) 58%, transparent);
@@ -8480,9 +8480,9 @@ code {
 .about-title {
   margin: 0;
   font-family: var(--font-display);
-  font-size: clamp(2.2rem, 5vw, 4rem);
+  font-size: 3.5rem;
   line-height: 0.98;
-  letter-spacing: -0.04em;
+  letter-spacing: 0;
 }
 
 .about-lead {
@@ -8497,7 +8497,7 @@ code {
   display: grid;
   gap: 12px;
   padding: 18px;
-  border-radius: 22px;
+  border-radius: var(--r-lg);
   border: 1px solid color-mix(in srgb, var(--line) 84%, transparent);
   background: color-mix(in srgb, var(--surface) 80%, transparent);
 }
@@ -8530,9 +8530,9 @@ code {
 
 .about-categories-header .home-section-title {
   max-width: 18ch;
-  font-size: clamp(1.9rem, 3vw, 2.6rem);
+  font-size: 2.35rem;
   line-height: 1.02;
-  letter-spacing: -0.035em;
+  letter-spacing: 0;
 }
 
 .about-grid,
@@ -8551,15 +8551,14 @@ code {
   grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
 }
 
-.about-rule-card,
-.about-pattern {
+.about-rule-card {
   display: flex;
   flex-direction: column;
   gap: 16px;
   min-height: 220px;
   padding: 28px 26px 24px;
   border: 1px solid var(--line);
-  border-radius: 22px;
+  border-radius: var(--r-lg);
   background: color-mix(in srgb, var(--surface) 88%, transparent);
   transition:
     border-color 0.25s,
@@ -8586,12 +8585,12 @@ code {
 .about-rule-card-icon {
   width: 36px;
   height: 36px;
-  border-radius: 8px;
+  border-radius: var(--r-sm);
   display: flex;
   align-items: center;
   justify-content: center;
   background: var(--accent-subtle);
-  border: 1.5px solid rgba(220, 38, 38, 0.25);
+  border: 1.5px solid color-mix(in srgb, var(--status-error-fg) 25%, var(--line));
   flex-shrink: 0;
   transition:
     background 0.2s,
@@ -8599,12 +8598,14 @@ code {
 }
 
 .about-rule-card-icon svg {
+  width: 18px;
+  height: 18px;
   color: var(--accent);
 }
 
 .about-rule-card:hover .about-rule-card-icon {
-  background: rgba(220, 38, 38, 0.18);
-  box-shadow: 0 0 14px rgba(220, 38, 38, 0.08);
+  background: var(--status-error-bg);
+  box-shadow: 0 0 14px color-mix(in srgb, var(--status-error-fg) 8%, transparent);
 }
 
 .about-rule-card :is(h2, h3) {
@@ -8613,7 +8614,7 @@ code {
   font-family: var(--font-display);
   font-weight: 600;
   line-height: 1.08;
-  letter-spacing: -0.03em;
+  letter-spacing: 0;
   color: var(--ink);
 }
 
@@ -8636,9 +8637,93 @@ code {
 
 .about-pattern {
   margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  background: color-mix(in srgb, var(--surface) 82%, transparent);
   color: var(--ink-soft);
   line-height: 1.6;
   font-size: var(--fs-sm);
+}
+
+.about-pattern svg {
+  width: 16px;
+  height: 16px;
+  margin-top: 3px;
+  flex-shrink: 0;
+}
+
+.about-pattern-accepted svg {
+  color: var(--status-success-fg);
+}
+
+.about-pattern-rejected svg {
+  color: var(--status-error-fg);
+}
+
+.about-pattern-lanes {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-4);
+}
+
+.about-patterns-header {
+  display: grid;
+  gap: var(--space-3);
+  max-width: 76ch;
+}
+
+.about-pattern-lane {
+  min-height: 100%;
+  padding: var(--space-5);
+  border-radius: var(--r-lg);
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+}
+
+.about-pattern-lane-header {
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.about-pattern-lane-header > div:last-child {
+  display: grid;
+  gap: 10px;
+}
+
+.about-pattern-lane-accepted {
+  border-color: color-mix(in srgb, var(--status-success-fg) 30%, var(--line));
+}
+
+.about-pattern-lane-accepted .about-rule-card-icon {
+  background: var(--status-success-bg);
+  border-color: color-mix(in srgb, var(--status-success-fg) 35%, var(--line));
+}
+
+.about-pattern-lane-accepted .about-rule-card-icon svg {
+  color: var(--status-success-fg);
+}
+
+.about-pattern-lane-rejected {
+  border-color: color-mix(in srgb, var(--status-error-fg) 30%, var(--line));
+}
+
+.about-pattern-lane-rejected .about-rule-card-icon {
+  background: var(--status-error-bg);
+  border-color: color-mix(in srgb, var(--status-error-fg) 35%, var(--line));
+}
+
+.about-pattern-lane-rejected .about-rule-card-icon svg {
+  color: var(--status-error-fg);
+}
+
+.about-pattern-lane .about-patterns {
+  grid-template-columns: 1fr;
+  gap: 12px;
 }
 
 .souls-coming-page {
@@ -8713,15 +8798,24 @@ code {
   .about-patterns {
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }
+
+  .about-pattern-lanes {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 640px) {
   .about-bento,
   .about-grid,
   .about-patterns,
+  .about-pattern-lanes,
   .about-panel-categories .about-grid,
   .souls-coming-grid {
     grid-template-columns: 1fr;
+  }
+
+  .about-title {
+    font-size: 2.4rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds positive, explicitly allowed recent patterns to the About page and acceptable usage docs.
- Reworks the About patterns section into allowed/rejected lanes using existing shadcn Card/Badge composition and semantic status tokens.
- Replaces the top-nav Git sign-in icon with a GitHub logo.
- Fixes the current `ci:static` dead-export failure by making internal ClawPack parser types non-exported.

## Test Plan
- bun run format:check
- bun run lint
- bun run ci:static
- bunx tsc --noEmit
- bunx tsc -p packages/schema/tsconfig.json --noEmit
- bunx tsc -p packages/clawhub/tsconfig.json --noEmit
- bun run test -- src/__tests__/about-inline-code.test.tsx
- bun run test -- convex/lib/clawpack.test.ts packages/clawhub/src/cli/commands/packages.test.ts
- VITE_CONVEX_URL=https://example.invalid bun run build
