### PR TITLE
fix(clawsweeper): remove PAT dispatch fallback

### DIFF
--- a/.github/workflows/clawsweeper-dispatch.yml
+++ b/.github/workflows/clawsweeper-dispatch.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Dispatch exact ClawSweeper review
         env:
-          GH_TOKEN: ${{ steps.token.outputs.token || secrets.OPENCLAW_GH_TOKEN }}
+          GH_TOKEN: ${{ steps.token.outputs.token }}
           TARGET_REPO: ${{ github.repository }}
           ITEM_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
           ITEM_KIND: ${{ github.event_name == 'pull_request_target' && 'pull_request' || 'issue' }}


### PR DESCRIPTION
## Summary
- remove `secrets.OPENCLAW_GH_TOKEN` fallback from the ClawHub ClawSweeper dispatcher
- require the ClawSweeper GitHub App dispatch token path instead of silently falling back to a PAT

## Why
ClawSweeper docs say write-capable dispatch should not fall back to PAT-based tokens. This keeps ClawHub aligned with the current trust boundary.

## Validation
- confirmed `.github/workflows/clawsweeper-dispatch.yml` no longer references `secrets.OPENCLAW_GH_TOKEN`
- confirmed dispatcher still uses `steps.token.outputs.token`