### PR TITLE
Include package OpenClaw env metadata in ClawScan prompts

### DIFF
--- a/convex/llmEval.test.ts
+++ b/convex/llmEval.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment node */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { backfillLlmEval } from "./llmEval";
+import { backfillLlmEval, buildOpenClawMetadataForEval } from "./llmEval";
 
 type WrappedHandler<TArgs, TResult> = {
   _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
@@ -115,6 +115,33 @@ describe("llm eval backfill", () => {
       nextCursor: 42,
       done: false,
       moderationMode: "preserve",
+    });
+  });
+});
+
+describe("package OpenClaw metadata for LLM eval", () => {
+  it("maps package openclaw.environment declarations into scanner requirements metadata", () => {
+    const metadata = buildOpenClawMetadataForEval(
+      JSON.stringify({
+        openclaw: {
+          environment: {
+            requiredEnv: ["REQUIRED_TOKEN"],
+            optionalEnv: ["OPTIONAL_API_KEY"],
+            configPaths: ["~/.openclaw/agents/main/agent/models.json"],
+          },
+        },
+      }),
+    );
+
+    expect(metadata).toMatchObject({
+      primaryEnv: "REQUIRED_TOKEN",
+      envVars: [
+        { name: "REQUIRED_TOKEN", required: true },
+        { name: "OPTIONAL_API_KEY", required: false },
+      ],
+      requires: {
+        config: ["~/.openclaw/agents/main/agent/models.json"],
+      },
     });
   });
 });

--- a/convex/llmEval.ts
+++ b/convex/llmEval.ts
@@ -39,6 +39,47 @@ const llmEvalModerationModeValidator = v.optional(
 
 type LlmEvalModerationMode = "normal" | "preserve";
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function parseJsonRecord(text: string | undefined): Record<string, unknown> {
+  if (!text) return {};
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function normalizeStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter((entry) => entry.length > 0);
+}
+
+export function buildOpenClawMetadataForEval(packageJsonText: string | undefined) {
+  const packageJson = parseJsonRecord(packageJsonText);
+  const openclaw = isRecord(packageJson.openclaw) ? packageJson.openclaw : {};
+  const environment = isRecord(openclaw.environment) ? openclaw.environment : {};
+  const optionalEnv = normalizeStringList(environment.optionalEnv);
+  const requiredEnv = normalizeStringList(environment.requiredEnv);
+  const configPaths = normalizeStringList(environment.configPaths);
+  const envVars = [
+    ...requiredEnv.map((name) => ({ name, required: true })),
+    ...optionalEnv.map((name) => ({ name, required: false })),
+  ];
+
+  return {
+    ...openclaw,
+    ...(envVars.length > 0 ? { envVars } : {}),
+    ...(requiredEnv.length > 0 ? { primaryEnv: requiredEnv[0] } : {}),
+    ...(configPaths.length > 0 ? { requires: { config: configPaths } } : {}),
+  };
+}
+
 async function runQueryRef<T>(
   ctx: { runQuery: (ref: never, args: never) => Promise<unknown> },
   ref: unknown,
@@ -362,10 +403,10 @@ export const evaluatePackageReleaseWithLlm = internalAction({
       }
     }
 
+    const packageJsonText = fileContents.find(
+      (entry) => entry.path.toLowerCase() === "package.json",
+    )?.content;
     if (!readmeContent) {
-      const packageJsonText = fileContents.find(
-        (entry) => entry.path.toLowerCase() === "package.json",
-      )?.content;
       readmeContent =
         packageJsonText ?? `# ${pkg.displayName}\n\n${release.summary ?? pkg.summary ?? pkg.name}`;
     }
@@ -389,6 +430,7 @@ export const evaluatePackageReleaseWithLlm = internalAction({
           capabilities: release.capabilities,
           verification: release.verification,
           staticScan: release.staticScan,
+          openclaw: buildOpenClawMetadataForEval(packageJsonText),
         },
       },
       files: release.files.map((f) => ({ path: f.path, size: f.size })),


### PR DESCRIPTION
## Summary
- parse package.json `openclaw.environment` during package LLM evaluation
- pass declared env vars and config paths into the existing scanner requirements metadata
- add coverage for required/optional env vars and OpenClaw config paths

## Why
ClawScan currently derives `environment:declared` capability tags, but the LLM prompt still reports env vars/config paths as `none`. That causes packages with correctly declared `openclaw.environment` metadata to be reviewed as underdeclared.

## Verification
- `bunx vitest run convex/llmEval.test.ts convex/lib/securityPrompt.test.ts`
- `bunx tsc --noEmit --pretty false`