### PR TITLE
fix(convex): scope rate limit buckets by kind

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -5555,7 +5555,7 @@ describe("httpApiV1 handlers", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("RateLimit-Limit")).toBeTruthy();
     expect(findRateLimitCallArgs(runMutation)).toMatchObject({
-      key: "user:users:1",
+      key: "user:users:1:write",
       limit: RATE_LIMITS.write.key,
     });
     expect(runAction).toHaveBeenCalledWith(
@@ -5870,7 +5870,7 @@ describe("httpApiV1 handlers", () => {
     expect(runMutation).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        key: "ip:unknown",
+        key: "ip:unknown:trustedPublish",
         limit: RATE_LIMITS.trustedPublish.ip,
       }),
     );

--- a/convex/lib/httpRateLimit.test.ts
+++ b/convex/lib/httpRateLimit.test.ts
@@ -119,18 +119,18 @@ describe("getClientIp", () => {
 
 describe("RATE_LIMITS", () => {
   it("keeps anonymous download bursts installation-friendly", () => {
-    expect(RATE_LIMITS.download.ip).toBeGreaterThanOrEqual(180);
-    expect(RATE_LIMITS.download.key).toBeGreaterThanOrEqual(720);
+    expect(RATE_LIMITS.download.ip).toBeGreaterThanOrEqual(1200);
+    expect(RATE_LIMITS.download.key).toBeGreaterThanOrEqual(6000);
   });
 
   it("keeps authenticated write bursts release-friendly", () => {
-    expect(RATE_LIMITS.write.ip).toBeLessThanOrEqual(45);
-    expect(RATE_LIMITS.write.key).toBeGreaterThanOrEqual(2400);
+    expect(RATE_LIMITS.write.ip).toBeGreaterThanOrEqual(300);
+    expect(RATE_LIMITS.write.key).toBeGreaterThanOrEqual(3000);
   });
 
   it("allows trusted publish token mint bursts from shared CI egress", () => {
-    expect(RATE_LIMITS.trustedPublish.ip).toBeGreaterThanOrEqual(600);
-    expect(RATE_LIMITS.trustedPublish.key).toBeGreaterThanOrEqual(2400);
+    expect(RATE_LIMITS.trustedPublish.ip).toBeGreaterThanOrEqual(3000);
+    expect(RATE_LIMITS.trustedPublish.key).toBeGreaterThanOrEqual(12000);
   });
 
   it("gives admin API tokens a larger authenticated bucket", () => {
@@ -326,7 +326,7 @@ describe("applyRateLimit headers", () => {
       .filter((args) => "key" in args && "limit" in args);
     expect(rateLimitStatusCalls).toContainEqual(
       expect.objectContaining({
-        key: "user:users_123",
+        key: "user:users_123:write",
         limit: RATE_LIMITS.write.adminKey,
       }),
     );
@@ -392,7 +392,76 @@ describe("applyRateLimit headers", () => {
     );
   });
 
-  it("keeps non-download missing-ip anonymous requests on the shared unknown bucket", async () => {
+  it("scopes known-ip anonymous buckets by rate limit kind", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(4_550_000);
+    const readCtx = makeRateLimitCtx({
+      ip: {
+        allowed: true,
+        remaining: 19,
+        limit: RATE_LIMITS.read.ip,
+        resetAt: 4_580_000,
+      },
+    });
+    const downloadCtx = makeRateLimitCtx({
+      ip: {
+        allowed: true,
+        remaining: 19,
+        limit: RATE_LIMITS.download.ip,
+        resetAt: 4_580_000,
+      },
+    });
+    const request = new Request("https://example.com/api/v1/packages/demo/download", {
+      headers: { "cf-connecting-ip": "203.0.113.1" },
+    });
+
+    await applyRateLimit(readCtx, request, "read");
+    await applyRateLimit(downloadCtx, request, "download");
+
+    const readMutation = (readCtx as unknown as { runMutation: ReturnType<typeof vi.fn> })
+      .runMutation;
+    const downloadMutation = (downloadCtx as unknown as { runMutation: ReturnType<typeof vi.fn> })
+      .runMutation;
+    expect(readMutation.mock.calls.map(([, args]) => String(args.key))).toContain(
+      "ip:203.0.113.1:read",
+    );
+    expect(downloadMutation.mock.calls.map(([, args]) => String(args.key))).toContain(
+      "ip:203.0.113.1:download",
+    );
+  });
+
+  it("scopes authenticated buckets by rate limit kind", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(4_575_000);
+    const ctx = makeRateLimitCtx({
+      ip: {
+        allowed: true,
+        remaining: 19,
+        limit: RATE_LIMITS.read.ip,
+        resetAt: 4_600_000,
+      },
+      user: {
+        allowed: true,
+        remaining: 42,
+        limit: RATE_LIMITS.download.key,
+        resetAt: 4_600_000,
+      },
+    });
+    const request = new Request("https://example.com/api/v1/packages/demo/download", {
+      headers: {
+        authorization: "Bearer clh_token",
+        "cf-connecting-ip": "203.0.113.1",
+      },
+    });
+
+    const result = await applyRateLimit(ctx, request, "download");
+
+    expect(result.ok).toBe(true);
+    const runMutation = (ctx as unknown as { runMutation: ReturnType<typeof vi.fn> }).runMutation;
+    expect(runMutation.mock.calls.map(([, args]) => String(args.key))).toContain(
+      "user:users_123:download",
+    );
+  });
+
+  it("scopes non-download missing-ip anonymous requests by rate limit kind", async () => {
     vi.spyOn(Date, "now").mockReturnValue(4_600_000);
     const ctx = makeRateLimitCtx({
       ip: {
@@ -409,7 +478,7 @@ describe("applyRateLimit headers", () => {
     expect(result.ok).toBe(true);
     const runMutation = (ctx as unknown as { runMutation: ReturnType<typeof vi.fn> }).runMutation;
     const consumedKeys = runMutation.mock.calls.map(([, args]) => String(args.key));
-    expect(consumedKeys).toContain("ip:unknown");
+    expect(consumedKeys).toContain("ip:unknown:read");
   });
 
   it("falls back to ip enforcement when bearer token is invalid", async () => {

--- a/convex/lib/httpRateLimit.ts
+++ b/convex/lib/httpRateLimit.ts
@@ -7,10 +7,10 @@ import { corsHeaders, mergeHeaders } from "./httpHeaders";
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_SHARDS = 64;
 export const RATE_LIMITS = {
-  read: { ip: 600, key: 2400, adminKey: 24000 },
-  write: { ip: 45, key: 2400, adminKey: 24000 },
-  trustedPublish: { ip: 600, key: 2400, adminKey: 24000 },
-  download: { ip: 180, key: 720, adminKey: 7200 },
+  read: { ip: 3000, key: 12000, adminKey: 120000 },
+  write: { ip: 300, key: 3000, adminKey: 30000 },
+  trustedPublish: { ip: 3000, key: 12000, adminKey: 120000 },
+  download: { ip: 1200, key: 6000, adminKey: 60000 },
 } as const;
 
 type RateLimitResult = {
@@ -34,7 +34,11 @@ export async function applyRateLimit(
   // avoid draining shared IP quota.
   if (auth) {
     const userLimit = getAuthenticatedRateLimit(kind, auth.user);
-    const userResult = await checkRateLimit(ctx, `user:${auth.userId}`, userLimit);
+    const userResult = await checkRateLimit(
+      ctx,
+      getAuthenticatedRateLimitKey(auth.userId, kind),
+      userLimit,
+    );
     const headers = rateHeaders(userResult);
     if (!userResult.allowed) {
       console.info("rate_limit_denied", {
@@ -101,9 +105,13 @@ export async function applyRateLimit(
 }
 
 function getAnonymousRateLimitKey(request: Request, kind: keyof typeof RATE_LIMITS, ip: string) {
-  if (ip !== "unknown") return `ip:${ip}`;
-  if (kind !== "download") return "ip:unknown";
+  if (ip !== "unknown") return `ip:${ip}:${kind}`;
+  if (kind !== "download") return `ip:unknown:${kind}`;
   return `ip:unknown:download:${getDownloadRateLimitScope(request)}`;
+}
+
+function getAuthenticatedRateLimitKey(userId: string, kind: keyof typeof RATE_LIMITS) {
+  return `user:${userId}:${kind}`;
 }
 
 function getAuthenticatedRateLimit(


### PR DESCRIPTION
## Summary
- scope anonymous and authenticated rate-limit buckets by request kind so reads cannot exhaust download quota
- raise read/download/trusted-publish limits for healthy install and CI burst headroom
- update HTTP API/rate-limit tests for the new bucket keys

## Tests
- bunx vitest run convex/lib/httpRateLimit.test.ts
- bunx vitest run convex/httpApiV1.handlers.test.ts
- bun run format:check
- bun run lint
