### PR TITLE
fix(packages): return not found for invalid lookups

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -3306,6 +3306,22 @@ describe("httpApiV1 handlers", () => {
     });
   });
 
+  it("packages detail returns not found for invalid package lookup names", async () => {
+    const runQuery = vi.fn(async () => {
+      throw new Error("unexpected package lookup");
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.packagesGetRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/packages/openclaw%2Fdiscord"),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Package not found");
+    expect(runQuery).not.toHaveBeenCalled();
+  });
+
   it("packages detail returns stats for plugins", async () => {
     const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
       if ("name" in args) {
@@ -4852,6 +4868,22 @@ describe("httpApiV1 handlers", () => {
         },
       },
     });
+  });
+
+  it("npm mirror returns not found for invalid package lookup names", async () => {
+    const runQuery = vi.fn(async () => {
+      throw new Error("unexpected package lookup");
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.npmMirrorGetHandler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/npm/openclaw%2Fdiscord"),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Package not found");
+    expect(runQuery).not.toHaveBeenCalled();
   });
 
   it("npm mirror accepts encoded scoped package packument paths", async () => {

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -30,6 +30,7 @@ import {
 } from "../lib/githubActionsOidc";
 import { corsHeaders, mergeHeaders } from "../lib/httpHeaders";
 import { applyRateLimit } from "../lib/httpRateLimit";
+import { tryNormalizePackageName } from "../lib/packageRegistry";
 import { getPackageDownloadSecurityBlock } from "../lib/packageSecurity";
 import {
   getClawPackSizeError,
@@ -2192,17 +2193,21 @@ export async function packagesGetRouterV1Handler(ctx: ActionCtx, request: Reques
       : "read";
   const rate = await applyRateLimit(ctx, request, rateKind);
   if (!rate.ok) return rate.response;
+  const normalizedPackageName = tryNormalizePackageName(packageName);
+  if (!normalizedPackageName) return text("Package not found", 404, rate.headers);
 
   const viewerUserId = await getOptionalViewerUserIdForRequest(ctx, request);
   const detail = (await runQueryRef(ctx, internalRefs.packages.getByNameForViewerInternal, {
-    name: packageName,
+    name: normalizedPackageName,
     viewerUserId: viewerUserId ?? undefined,
   })) as {
     package: PublicPackageDocLike | null;
     latestRelease: ReleaseLike | null;
     owner: { _id: Id<"users">; handle?: string; displayName?: string; image?: string } | null;
   } | null;
-  const skillDetail = detail?.package ? null : await getSkillDetailForRequest(ctx, packageName);
+  const skillDetail = detail?.package
+    ? null
+    : await getSkillDetailForRequest(ctx, normalizedPackageName);
   if (!detail?.package && !skillDetail?.skill) return text("Package not found", 404, rate.headers);
   const packageDetail = detail?.package ? detail : null;
   const publicPackage = packageDetail?.package ?? null;
@@ -2652,10 +2657,12 @@ export async function npmMirrorGetHandler(ctx: ActionCtx, request: Request) {
   const isTarballRequest = path.rest[0] === "-" && Boolean(path.rest[1]);
   const rate = await applyRateLimit(ctx, request, isTarballRequest ? "download" : "read");
   if (!rate.ok) return rate.response;
+  const normalizedPackageName = tryNormalizePackageName(path.packageName);
+  if (!normalizedPackageName) return text("Package not found", 404, rate.headers);
 
   const viewerUserId = await getOptionalViewerUserIdForRequest(ctx, request);
   const detail = (await runQueryRef(ctx, internalRefs.packages.getByNameForViewerInternal, {
-    name: path.packageName,
+    name: normalizedPackageName,
     viewerUserId: viewerUserId ?? undefined,
   })) as {
     package: PublicPackageDocLike | null;
@@ -2664,7 +2671,7 @@ export async function npmMirrorGetHandler(ctx: ActionCtx, request: Request) {
   } | null;
   if (!detail?.package) return text("Package not found", 404, rate.headers);
 
-  const releases = await listNpmPackReleases(ctx, path.packageName, viewerUserId);
+  const releases = await listNpmPackReleases(ctx, normalizedPackageName, viewerUserId);
   if (isTarballRequest) {
     const tarballName = path.rest[1]!;
     const release = releases.find((candidate) => candidate.npmTarballName === tarballName);

--- a/convex/lib/packageRegistry.test.ts
+++ b/convex/lib/packageRegistry.test.ts
@@ -7,9 +7,16 @@ import {
   extractCodePluginArtifacts,
   summarizePackageForSearch,
   toConvexSafeJsonValue,
+  tryNormalizePackageName,
 } from "./packageRegistry";
 
 describe("packageRegistry", () => {
+  it("can validate package names without throwing", () => {
+    expect(tryNormalizePackageName("@OpenClaw/Discord")).toBe("@openclaw/discord");
+    expect(tryNormalizePackageName("openclaw/discord")).toBeNull();
+    expect(tryNormalizePackageName("   ")).toBeNull();
+  });
+
   it("extracts code plugin compatibility and capabilities", () => {
     const result = extractCodePluginArtifacts({
       packageName: "@scope/demo-plugin",

--- a/convex/lib/packageRegistry.ts
+++ b/convex/lib/packageRegistry.ts
@@ -160,12 +160,20 @@ function extractHostTargetCapabilityTags(hostTargets: string[]) {
 export function normalizePackageName(name: string) {
   const trimmed = name.trim();
   if (!trimmed) throw new ConvexError("Package name required");
-  const normalized = trimmed.toLowerCase();
-  if (!PACKAGE_NAME_PATTERN.test(normalized)) {
+  const normalized = tryNormalizePackageName(trimmed);
+  if (!normalized) {
     throw new ConvexError(
       "Package name must be lowercase and npm-safe (example: @scope/name or plugin-name)",
     );
   }
+  return normalized;
+}
+
+export function tryNormalizePackageName(name: string) {
+  const trimmed = name.trim();
+  if (!trimmed) return null;
+  const normalized = trimmed.toLowerCase();
+  if (!PACKAGE_NAME_PATTERN.test(normalized)) return null;
   return normalized;
 }
 


### PR DESCRIPTION
## Summary
- return `404 Package not found` for invalid package lookup names before Convex package validation can throw
- reuse a non-throwing package-name normalizer for read/resolve paths
- cover package detail and npm mirror regressions for `openclaw%2Fdiscord`

## Tests
- `bun run test -- convex/httpApiV1.handlers.test.ts convex/lib/packageRegistry.test.ts`
- `bun run format:check`
- `bun run lint`
