### PR TITLE
fix: gate privileged cli help by role

### DIFF
--- a/packages/clawhub/src/cli.ts
+++ b/packages/clawhub/src/cli.ts
@@ -2,7 +2,12 @@
 import { stat } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { Command } from "commander";
-import { shouldShowAdminCommandsInHelp } from "./cli/adminHelp.js";
+import {
+  type CommandAudience,
+  createCommandPathRegistry,
+  resolveHelpRole,
+  shouldShowAudienceInHelp,
+} from "./cli/adminHelp.js";
 import { getCliBuildLabel, getCliVersion } from "./cli/buildInfo.js";
 import { resolveClawdbotDefaultWorkspace } from "./cli/clawdbotConfig.js";
 import { cmdLoginFlow, cmdLogout, cmdWhoami } from "./cli/commands/auth.js";
@@ -66,9 +71,6 @@ import type { GlobalOpts } from "./cli/types.js";
 import { fail } from "./cli/ui.js";
 import { readGlobalConfig } from "./config.js";
 
-const showAdminCommandsInHelp = await shouldShowAdminCommandsInHelp();
-const adminCommandOptions = showAdminCommandsInHelp ? undefined : { hidden: true };
-
 const program = new Command()
   .name("clawhub")
   .description(
@@ -92,6 +94,37 @@ const program = new Command()
   );
 
 configureCommanderHelp(program);
+
+const commandPaths = createCommandPathRegistry();
+const commandsWithAudience: Array<{ command: Command; audience: CommandAudience }> = [];
+
+function registerCommand(
+  parent: Command,
+  path: readonly string[],
+  audience: CommandAudience = "public",
+) {
+  commandPaths.add(path);
+  return registerCommandGroup(parent, path, audience);
+}
+
+function registerCommandGroup(
+  parent: Command,
+  path: readonly string[],
+  audience: CommandAudience = "public",
+) {
+  const command = parent.command(path.at(-1) ?? "");
+  commandsWithAudience.push({ command, audience });
+  return command;
+}
+
+function applyCommandAudienceVisibility(audienceRole: Awaited<ReturnType<typeof resolveHelpRole>>) {
+  for (const { command, audience } of commandsWithAudience) {
+    (command as unknown as { _hidden: boolean })._hidden = !shouldShowAudienceInHelp(
+      audience,
+      audienceRole,
+    );
+  }
+}
 
 async function resolveGlobalOpts(): Promise<GlobalOpts> {
   const raw = program.opts<{ workdir?: string; dir?: string; site?: string; registry?: string }>();
@@ -149,8 +182,7 @@ async function pathExists(path: string) {
   }
 }
 
-program
-  .command("login")
+registerCommand(program, ["login"])
   .description("Log in (opens browser or stores token)")
   .option("--token <token>", "API token")
   .option("--label <label>", "Token label (browser flow only)", "CLI token")
@@ -160,30 +192,26 @@ program
     await cmdLoginFlow(opts, options, isInputAllowed());
   });
 
-program
-  .command("logout")
+registerCommand(program, ["logout"])
   .description("Remove stored token")
   .action(async () => {
     const opts = await resolveGlobalOpts();
     await cmdLogout(opts);
   });
 
-program
-  .command("whoami")
+registerCommand(program, ["whoami"])
   .description("Validate token")
   .action(async () => {
     const opts = await resolveGlobalOpts();
     await cmdWhoami(opts);
   });
 
-const auth = program
-  .command("auth")
+const auth = registerCommandGroup(program, ["auth"])
   .description("Authentication commands")
   .showHelpAfterError()
   .showSuggestionAfterError();
 
-auth
-  .command("login")
+registerCommand(auth, ["auth", "login"])
   .description("Log in (opens browser or stores token)")
   .option("--token <token>", "API token")
   .option("--label <label>", "Token label (browser flow only)", "CLI token")
@@ -193,24 +221,21 @@ auth
     await cmdLoginFlow(opts, options, isInputAllowed());
   });
 
-auth
-  .command("logout")
+registerCommand(auth, ["auth", "logout"])
   .description("Remove stored token")
   .action(async () => {
     const opts = await resolveGlobalOpts();
     await cmdLogout(opts);
   });
 
-auth
-  .command("whoami")
+registerCommand(auth, ["auth", "whoami"])
   .description("Validate token")
   .action(async () => {
     const opts = await resolveGlobalOpts();
     await cmdWhoami(opts);
   });
 
-program
-  .command("search")
+registerCommand(program, ["search"])
   .description("Vector search skills")
   .argument("<query...>", "Query string")
   .option("--limit <n>", "Max results", (value) => Number.parseInt(value, 10))
@@ -220,8 +245,7 @@ program
     await cmdSearch(opts, query, options.limit);
   });
 
-program
-  .command("install")
+registerCommand(program, ["install"])
   .description("Install into <dir>/<slug>")
   .argument("<slug>", "Skill slug")
   .option("--version <version>", "Version to install")
@@ -231,8 +255,7 @@ program
     await cmdInstall(opts, slug, options.version, options.force);
   });
 
-program
-  .command("update")
+registerCommand(program, ["update"])
   .description("Update installed skills")
   .argument("[slug]", "Skill slug")
   .option("--all", "Update all installed skills")
@@ -243,8 +266,7 @@ program
     await cmdUpdate(opts, slug, options, isInputAllowed());
   });
 
-program
-  .command("uninstall")
+registerCommand(program, ["uninstall"])
   .description("Uninstall a skill")
   .argument("<slug>", "Skill slug")
   .option("--yes", "Skip confirmation")
@@ -253,16 +275,14 @@ program
     await cmdUninstall(opts, slug, options, isInputAllowed());
   });
 
-program
-  .command("list")
+registerCommand(program, ["list"])
   .description("List installed skills (tracked and manually installed)")
   .action(async () => {
     const opts = await resolveGlobalOpts();
     await cmdList(opts);
   });
 
-program
-  .command("explore")
+registerCommand(program, ["explore"])
   .description("Browse latest updated skills from the registry")
   .option(
     "--limit <n>",
@@ -283,8 +303,7 @@ program
     await cmdExplore(opts, { limit, sort: options.sort, json: options.json });
   });
 
-program
-  .command("inspect")
+registerCommand(program, ["inspect"])
   .description("Fetch skill metadata and files without installing")
   .argument("<slug>", "Skill slug")
   .option("--version <version>", "Version to inspect")
@@ -299,8 +318,7 @@ program
     await cmdInspect(opts, slug, options);
   });
 
-program
-  .command("publish")
+registerCommand(program, ["publish"])
   .description("Legacy alias: publish a skill from folder")
   .argument("<path>", "Skill folder path")
   .option("--slug <slug>", "Skill slug")
@@ -314,8 +332,7 @@ program
     await cmdPublish(opts, folder, options);
   });
 
-program
-  .command("delete")
+registerCommand(program, ["delete"])
   .description("Soft-delete a skill (owner, moderator, or admin)")
   .argument("<slug>", "Skill slug")
   .option("--reason <text>", "Moderation note/reason")
@@ -326,8 +343,7 @@ program
     await cmdDeleteSkill(opts, slug, options, isInputAllowed());
   });
 
-program
-  .command("hide")
+registerCommand(program, ["hide"])
   .description("Hide a skill (owner, moderator, or admin)")
   .argument("<slug>", "Skill slug")
   .option("--reason <text>", "Moderation note/reason")
@@ -338,8 +354,7 @@ program
     await cmdHideSkill(opts, slug, options, isInputAllowed());
   });
 
-program
-  .command("undelete")
+registerCommand(program, ["undelete"])
   .description("Restore a hidden skill (owner, moderator, or admin)")
   .argument("<slug>", "Skill slug")
   .option("--reason <text>", "Moderation note/reason")
@@ -350,8 +365,7 @@ program
     await cmdUndeleteSkill(opts, slug, options, isInputAllowed());
   });
 
-program
-  .command("unhide")
+registerCommand(program, ["unhide"])
   .description("Unhide a skill (owner, moderator, or admin)")
   .argument("<slug>", "Skill slug")
   .option("--reason <text>", "Moderation note/reason")
@@ -362,9 +376,8 @@ program
     await cmdUnhideSkill(opts, slug, options, isInputAllowed());
   });
 
-const skill = program.command("skill").description("Manage published skills");
-skill
-  .command("publish")
+const skill = registerCommandGroup(program, ["skill"]).description("Manage published skills");
+registerCommand(skill, ["skill", "publish"])
   .description("Publish a skill from folder")
   .argument("<path>", "Skill folder path")
   .option("--slug <slug>", "Skill slug")
@@ -378,10 +391,11 @@ skill
     await cmdPublish(opts, folder, options);
   });
 
-const packageCmd = program.command("package").description("Browse and publish OpenClaw packages");
+const packageCmd = registerCommandGroup(program, ["package"]).description(
+  "Browse and publish OpenClaw packages",
+);
 
-packageCmd
-  .command("explore")
+registerCommand(packageCmd, ["package", "explore"])
   .description("Browse published packages and plugins")
   .argument("[query...]", "Optional search query")
   .option("--family <family>", "skill|code-plugin|bundle-plugin")
@@ -413,8 +427,7 @@ packageCmd
     await cmdExplorePackages(opts, query, options);
   });
 
-packageCmd
-  .command("inspect")
+registerCommand(packageCmd, ["package", "inspect"])
   .description("Fetch package metadata and files without installing")
   .argument("<name>", "Package name")
   .option("--version <version>", "Version to inspect")
@@ -429,8 +442,7 @@ packageCmd
     await cmdInspectPackage(opts, name, options);
   });
 
-packageCmd
-  .command("download")
+registerCommand(packageCmd, ["package", "download"])
   .description("Download a package artifact and verify its published digests")
   .argument("<name>", "Package name")
   .option("--version <version>", "Version to download")
@@ -443,8 +455,7 @@ packageCmd
     await cmdDownloadPackage(opts, name, options);
   });
 
-packageCmd
-  .command("verify")
+registerCommand(packageCmd, ["package", "verify"])
   .description("Verify a local package artifact against ClawHub or expected digests")
   .argument("<file>", "Artifact file")
   .option("--package <name>", "Package name to resolve expected artifact metadata")
@@ -462,8 +473,7 @@ packageCmd
     });
   });
 
-packageCmd
-  .command("moderate")
+registerCommand(packageCmd, ["package", "moderate"], "moderator")
   .description("Set package release moderation state")
   .argument("<name>", "Package name")
   .requiredOption("--version <version>", "Package version")
@@ -475,8 +485,7 @@ packageCmd
     await cmdModeratePackageRelease(opts, name, options);
   });
 
-packageCmd
-  .command("report")
+registerCommand(packageCmd, ["package", "report"])
   .description("Report a package for moderator review")
   .argument("<name>", "Package name")
   .option("--version <version>", "Package version")
@@ -487,8 +496,7 @@ packageCmd
     await cmdReportPackage(opts, name, options);
   });
 
-packageCmd
-  .command("appeal")
+registerCommand(packageCmd, ["package", "appeal"])
   .description("Appeal moderation for a package release")
   .argument("<name>", "Package name")
   .requiredOption("--version <version>", "Package version")
@@ -499,8 +507,7 @@ packageCmd
     await cmdAppealPackage(opts, name, options);
   });
 
-packageCmd
-  .command("appeals")
+registerCommand(packageCmd, ["package", "appeals"], "moderator")
   .description("List package appeals for moderator review")
   .option("--status <status>", "open|accepted|rejected|all", "open")
   .option("--cursor <cursor>", "Resume cursor")
@@ -516,8 +523,7 @@ packageCmd
     await cmdListPackageAppeals(opts, options);
   });
 
-packageCmd
-  .command("resolve-appeal")
+registerCommand(packageCmd, ["package", "resolve-appeal"], "moderator")
   .description("Resolve or reopen a package appeal")
   .argument("<appeal-id>", "Package appeal id")
   .requiredOption("--status <status>", "open|accepted|rejected")
@@ -528,8 +534,7 @@ packageCmd
     await cmdResolvePackageAppeal(opts, appealId, options);
   });
 
-packageCmd
-  .command("reports")
+registerCommand(packageCmd, ["package", "reports"], "moderator")
   .description("List package reports for moderator review")
   .option("--status <status>", "open|triaged|dismissed|all", "open")
   .option("--cursor <cursor>", "Resume cursor")
@@ -545,8 +550,7 @@ packageCmd
     await cmdListPackageReports(opts, options);
   });
 
-packageCmd
-  .command("triage-report")
+registerCommand(packageCmd, ["package", "triage-report"], "moderator")
   .description("Resolve or reopen a package report")
   .argument("<report-id>", "Package report id")
   .requiredOption("--status <status>", "open|triaged|dismissed")
@@ -557,8 +561,7 @@ packageCmd
     await cmdTriagePackageReport(opts, reportId, options);
   });
 
-packageCmd
-  .command("moderation-status")
+registerCommand(packageCmd, ["package", "moderation-status"])
   .description("Show owner/staff package moderation status")
   .argument("<name>", "Package name")
   .option("--json", "Output JSON")
@@ -567,8 +570,7 @@ packageCmd
     await cmdPackageModerationStatus(opts, name, options);
   });
 
-packageCmd
-  .command("moderation-queue")
+registerCommand(packageCmd, ["package", "moderation-queue"], "moderator")
   .description("List package releases that need moderation")
   .option("--status <status>", "open|blocked|manual|all", "open")
   .option("--cursor <cursor>", "Resume cursor")
@@ -584,8 +586,7 @@ packageCmd
     await cmdPackageModerationQueue(opts, options);
   });
 
-packageCmd
-  .command("backfill-artifacts")
+registerCommand(packageCmd, ["package", "backfill-artifacts"], "admin")
   .description("Backfill missing package artifact-kind metadata (admin only)")
   .option("--cursor <cursor>", "Resume cursor")
   .option("--batch-size <n>", "Batch size", (value) => Number.parseInt(value, 10))
@@ -597,8 +598,7 @@ packageCmd
     await cmdBackfillPackageArtifacts(opts, options);
   });
 
-packageCmd
-  .command("readiness")
+registerCommand(packageCmd, ["package", "readiness"])
   .description("Check package readiness for future OpenClaw consumption")
   .argument("<name>", "Package name")
   .option("--json", "Output JSON")
@@ -607,8 +607,7 @@ packageCmd
     await cmdPackageReadiness(opts, name, options);
   });
 
-packageCmd
-  .command("migration-status")
+registerCommand(packageCmd, ["package", "migration-status"])
   .description("Show package migration status for future OpenClaw consumption")
   .argument("<name>", "Package name")
   .option("--json", "Output JSON")
@@ -617,8 +616,7 @@ packageCmd
     await cmdPackageMigrationStatus(opts, name, options);
   });
 
-packageCmd
-  .command("migrations")
+registerCommand(packageCmd, ["package", "migrations"], "moderator")
   .description("List official plugin migration rows")
   .option(
     "--phase <phase>",
@@ -638,8 +636,7 @@ packageCmd
     await cmdListPackageMigrations(opts, options);
   });
 
-packageCmd
-  .command("set-migration")
+registerCommand(packageCmd, ["package", "set-migration"], "admin")
   .description("Create or update an official plugin migration row")
   .argument("<bundled-plugin-id>", "Bundled OpenClaw plugin id")
   .requiredOption("--package <name>", "ClawHub package name")
@@ -663,8 +660,7 @@ packageCmd
     await cmdUpsertPackageMigration(opts, bundledPluginId, options);
   });
 
-packageCmd
-  .command("pack")
+registerCommand(packageCmd, ["package", "pack"])
   .description("Create a ClawPack npm tarball from a plugin package folder")
   .argument("<source>", "Package folder path")
   .option("--pack-destination <dir>", "Directory for the generated .tgz (default: workdir)")
@@ -674,8 +670,7 @@ packageCmd
     await cmdPackPackage(opts, source, options);
   });
 
-packageCmd
-  .command("publish")
+registerCommand(packageCmd, ["package", "publish"])
   .description("Publish a code plugin or bundle plugin from a folder or GitHub source")
   .argument("<source>", "Package folder path, GitHub repo (owner/repo[@ref]), or URL")
   .option("--family <family>", "code-plugin|bundle-plugin")
@@ -702,12 +697,12 @@ packageCmd
     await cmdPublishPackage(opts, source, options);
   });
 
-const trustedPublisherCmd = packageCmd
-  .command("trusted-publisher")
-  .description("Manage package trusted publisher config");
+const trustedPublisherCmd = registerCommandGroup(packageCmd, [
+  "package",
+  "trusted-publisher",
+]).description("Manage package trusted publisher config");
 
-trustedPublisherCmd
-  .command("get")
+registerCommand(trustedPublisherCmd, ["package", "trusted-publisher", "get"])
   .description("Show trusted publisher config for a package")
   .argument("<name>", "Package name")
   .option("--json", "Output JSON")
@@ -716,8 +711,7 @@ trustedPublisherCmd
     await cmdGetPackageTrustedPublisher(opts, name, options);
   });
 
-trustedPublisherCmd
-  .command("set")
+registerCommand(trustedPublisherCmd, ["package", "trusted-publisher", "set"], "admin")
   .description("Attach or replace trusted publisher config for a package")
   .argument("<name>", "Package name")
   .requiredOption("--repository <repo>", "GitHub repo (owner/repo or URL)")
@@ -729,8 +723,7 @@ trustedPublisherCmd
     await cmdSetPackageTrustedPublisher(opts, name, options);
   });
 
-trustedPublisherCmd
-  .command("delete")
+registerCommand(trustedPublisherCmd, ["package", "trusted-publisher", "delete"], "admin")
   .description("Remove trusted publisher config from a package")
   .argument("<name>", "Package name")
   .option("--json", "Output JSON")
@@ -739,8 +732,7 @@ trustedPublisherCmd
     await cmdDeletePackageTrustedPublisher(opts, name, options);
   });
 
-packageCmd
-  .command("rescan")
+registerCommand(packageCmd, ["package", "rescan"])
   .description("Request a security rescan for the latest published package release")
   .argument("<name>", "Package name")
   .option("--yes", "Skip confirmation")
@@ -750,8 +742,7 @@ packageCmd
     await cmdRescanPackage(opts, name, options, isInputAllowed());
   });
 
-skill
-  .command("rename")
+registerCommand(skill, ["skill", "rename"])
   .description("Rename a published skill and keep the old slug as a redirect")
   .argument("<slug>", "Current skill slug")
   .argument("<new-slug>", "New canonical slug")
@@ -761,8 +752,7 @@ skill
     await cmdRenameSkill(opts, slug, newSlug, options, isInputAllowed());
   });
 
-skill
-  .command("merge")
+registerCommand(skill, ["skill", "merge"])
   .description("Merge one owned skill into another and redirect the old slug")
   .argument("<source-slug>", "Source skill slug")
   .argument("<target-slug>", "Target canonical slug")
@@ -772,8 +762,7 @@ skill
     await cmdMergeSkill(opts, sourceSlug, targetSlug, options, isInputAllowed());
   });
 
-skill
-  .command("rescan")
+registerCommand(skill, ["skill", "rescan"])
   .description("Request a security rescan for the latest published skill version")
   .argument("<slug>", "Skill slug")
   .option("--yes", "Skip confirmation")
@@ -783,8 +772,7 @@ skill
     await cmdRescanSkill(opts, slug, options, isInputAllowed());
   });
 
-program
-  .command("ban-user", adminCommandOptions)
+registerCommand(program, ["ban-user"], "moderator")
   .description("Ban a user and delete owned skills (moderator/admin only)")
   .argument("<handleOrId>", "User handle (default) or user id")
   .option("--id", "Treat argument as user id")
@@ -796,8 +784,7 @@ program
     await cmdBanUser(opts, handleOrId, options, isInputAllowed());
   });
 
-program
-  .command("unban-user", adminCommandOptions)
+registerCommand(program, ["unban-user"], "admin")
   .description("Unban a user and restore eligible skills (admin only)")
   .argument("<handleOrId>", "User handle (default) or user id")
   .option("--id", "Treat argument as user id")
@@ -809,8 +796,7 @@ program
     await cmdUnbanUser(opts, handleOrId, options, isInputAllowed());
   });
 
-program
-  .command("set-role", adminCommandOptions)
+registerCommand(program, ["set-role"], "admin")
   .description("Change a user role (admin only)")
   .argument("<handleOrId>", "User handle (default) or user id")
   .argument("<role>", "user | moderator | admin")
@@ -822,10 +808,11 @@ program
     await cmdSetRole(opts, handleOrId, role, options, isInputAllowed());
   });
 
-const transfer = program.command("transfer").description("Transfer skill ownership");
+const transfer = registerCommandGroup(program, ["transfer"]).description(
+  "Transfer skill ownership",
+);
 
-transfer
-  .command("request")
+registerCommand(transfer, ["transfer", "request"])
   .description("Request skill transfer to another user")
   .argument("<slug>", "Skill slug")
   .argument("<handle>", "Recipient handle (e.g., @username)")
@@ -836,8 +823,7 @@ transfer
     await cmdTransferRequest(opts, slug, handle, options, isInputAllowed());
   });
 
-transfer
-  .command("list")
+registerCommand(transfer, ["transfer", "list"])
   .description("List pending transfer requests")
   .option("--outgoing", "Show outgoing transfer requests")
   .action(async (options) => {
@@ -845,8 +831,7 @@ transfer
     await cmdTransferList(opts, options);
   });
 
-transfer
-  .command("accept")
+registerCommand(transfer, ["transfer", "accept"])
   .description("Accept incoming transfer for a skill")
   .argument("<slug>", "Skill slug")
   .option("--yes", "Skip confirmation")
@@ -855,8 +840,7 @@ transfer
     await cmdTransferAccept(opts, slug, options, isInputAllowed());
   });
 
-transfer
-  .command("reject")
+registerCommand(transfer, ["transfer", "reject"])
   .description("Reject incoming transfer for a skill")
   .argument("<slug>", "Skill slug")
   .option("--yes", "Skip confirmation")
@@ -865,8 +849,7 @@ transfer
     await cmdTransferReject(opts, slug, options, isInputAllowed());
   });
 
-transfer
-  .command("cancel")
+registerCommand(transfer, ["transfer", "cancel"])
   .description("Cancel outgoing transfer for a skill")
   .argument("<slug>", "Skill slug")
   .option("--yes", "Skip confirmation")
@@ -875,8 +858,7 @@ transfer
     await cmdTransferCancel(opts, slug, options, isInputAllowed());
   });
 
-program
-  .command("star")
+registerCommand(program, ["star"])
   .description("Add a skill to your highlights")
   .argument("<slug>", "Skill slug")
   .option("--yes", "Skip confirmation")
@@ -885,8 +867,7 @@ program
     await cmdStarSkill(opts, slug, options, isInputAllowed());
   });
 
-program
-  .command("unstar")
+registerCommand(program, ["unstar"])
   .description("Remove a skill from your highlights")
   .argument("<slug>", "Skill slug")
   .option("--yes", "Skip confirmation")
@@ -895,8 +876,7 @@ program
     await cmdUnstarSkill(opts, slug, options, isInputAllowed());
   });
 
-program
-  .command("sync")
+registerCommand(program, ["sync"])
   .description("Scan local skills and publish new/updated ones")
   .option("--root <dir...>", "Extra scan roots (one or more)")
   .option("--all", "Upload all new/updated skills without prompting")
@@ -937,6 +917,8 @@ program.action(async () => {
   program.outputHelp();
   process.exitCode = 0;
 });
+
+applyCommandAudienceVisibility(await resolveHelpRole({ commandPaths }));
 
 void program.parseAsync(process.argv).catch((error) => {
   const message = error instanceof Error ? error.message : String(error);

--- a/packages/clawhub/src/cli/adminHelp.test.ts
+++ b/packages/clawhub/src/cli/adminHelp.test.ts
@@ -14,41 +14,100 @@ vi.mock("../http.js", () => ({
   apiRequest: (...args: unknown[]) => mockApiRequest(...args),
 }));
 
-const { isHelpRequest, shouldShowAdminCommandsInHelp } = await import("./adminHelp");
+const {
+  commandOptionsForAudience,
+  createCommandPathRegistry,
+  isHelpRequest,
+  resolveHelpRole,
+  shouldShowAdminCommandsInHelp,
+  shouldShowAudienceInHelp,
+} = await import("./adminHelp");
 
 afterEach(() => {
   vi.clearAllMocks();
 });
 
+function createTestCommandPaths() {
+  const paths = createCommandPathRegistry();
+  for (const path of [
+    ["search"],
+    ["ban-user"],
+    ["package", "trusted-publisher", "get"],
+    ["package", "trusted-publisher", "set"],
+  ]) {
+    paths.add(path);
+  }
+  return paths;
+}
+
 describe("admin help gating", () => {
   it("treats root help-like invocations as help requests", () => {
-    expect(isHelpRequest(["node", "clawhub", "--help"])).toBe(true);
-    expect(isHelpRequest(["node", "clawhub", "help"])).toBe(true);
-    expect(isHelpRequest(["node", "clawhub"])).toBe(true);
-    expect(isHelpRequest(["node", "clawhub", "search", "weather"])).toBe(false);
+    const paths = createTestCommandPaths();
+
+    expect(isHelpRequest(["node", "clawhub", "--help"], paths)).toBe(true);
+    expect(isHelpRequest(["node", "clawhub", "help"], paths)).toBe(true);
+    expect(isHelpRequest(["node", "clawhub"], paths)).toBe(true);
+    expect(isHelpRequest(["node", "clawhub", "package"], paths)).toBe(true);
+    expect(isHelpRequest(["node", "clawhub", "package", "trusted-publisher"], paths)).toBe(true);
+    expect(isHelpRequest(["node", "clawhub", "search", "weather"], paths)).toBe(false);
+    expect(
+      isHelpRequest(["node", "clawhub", "--registry", "https://r.example", "search", "x"], paths),
+    ).toBe(false);
+    expect(
+      isHelpRequest(
+        [
+          "node",
+          "clawhub",
+          "--registry=https://r.example",
+          "--workdir",
+          "/tmp/demo",
+          "package",
+          "trusted-publisher",
+          "set",
+          "demo",
+          "--repository",
+          "openclaw/demo",
+        ],
+        paths,
+      ),
+    ).toBe(false);
+  });
+
+  it("treats unknown commands as help requests so error help stays filtered", () => {
+    const paths = createTestCommandPaths();
+
+    expect(isHelpRequest(["node", "clawhub", "upgrade"], paths)).toBe(true);
+    expect(isHelpRequest(["node", "clawhub", "package", "bogus"], paths)).toBe(true);
+    expect(isHelpRequest(["node", "clawhub", "package", "trusted-publisher", "bogus"], paths)).toBe(
+      true,
+    );
+    expect(isHelpRequest(["node", "clawhub", "package", "trusted-publisher", "get"], paths)).toBe(
+      false,
+    );
   });
 
   it("does not hide commands for normal command execution", async () => {
     await expect(
       shouldShowAdminCommandsInHelp({
         argv: ["node", "clawhub", "ban-user", "demo"],
+        commandPaths: createTestCommandPaths(),
       }),
     ).resolves.toBe(true);
     expect(mockReadGlobalConfig).not.toHaveBeenCalled();
   });
 
-  it("hides admin commands from help when logged out", async () => {
+  it("resolves no help role when logged out", async () => {
     mockReadGlobalConfig.mockResolvedValueOnce(null);
 
     await expect(
-      shouldShowAdminCommandsInHelp({
+      resolveHelpRole({
         argv: ["node", "clawhub", "--help"],
       }),
-    ).resolves.toBe(false);
+    ).resolves.toBeNull();
     expect(mockApiRequest).not.toHaveBeenCalled();
   });
 
-  it("shows admin commands in help for stored admin tokens", async () => {
+  it("resolves admin help role for stored admin tokens", async () => {
     mockReadGlobalConfig.mockResolvedValueOnce({
       registry: "https://registry.example",
       token: "clh_admin",
@@ -58,10 +117,10 @@ describe("admin help gating", () => {
     });
 
     await expect(
-      shouldShowAdminCommandsInHelp({
+      resolveHelpRole({
         argv: ["node", "clawhub", "--help"],
       }),
-    ).resolves.toBe(true);
+    ).resolves.toBe("admin");
     expect(mockApiRequest).toHaveBeenCalledWith(
       "https://registry.example",
       expect.objectContaining({ path: "/api/v1/whoami", token: "clh_admin" }),
@@ -69,10 +128,26 @@ describe("admin help gating", () => {
     );
   });
 
-  it("hides admin commands in help for non-admin tokens", async () => {
+  it("resolves moderator help role for stored moderator tokens", async () => {
     mockReadGlobalConfig.mockResolvedValueOnce({
       registry: "https://registry.example",
-      token: "clh_user",
+      token: "clh_moderator",
+    });
+    mockApiRequest.mockResolvedValueOnce({
+      user: { handle: "p", role: "moderator" },
+    });
+
+    await expect(
+      resolveHelpRole({
+        argv: ["node", "clawhub", "--help"],
+      }),
+    ).resolves.toBe("moderator");
+  });
+
+  it("keeps the legacy admin-only helper behavior", async () => {
+    mockReadGlobalConfig.mockResolvedValueOnce({
+      registry: "https://registry.example",
+      token: "clh_moderator",
     });
     mockApiRequest.mockResolvedValueOnce({
       user: { handle: "p", role: "moderator" },
@@ -83,5 +158,26 @@ describe("admin help gating", () => {
         argv: ["node", "clawhub", "--help"],
       }),
     ).resolves.toBe(false);
+  });
+
+  it("maps command audiences to platform roles", () => {
+    expect(shouldShowAudienceInHelp("public", null)).toBe(true);
+    expect(shouldShowAudienceInHelp("authenticated", null)).toBe(true);
+    expect(shouldShowAudienceInHelp("owner", null)).toBe(true);
+
+    expect(shouldShowAudienceInHelp("moderator", null)).toBe(false);
+    expect(shouldShowAudienceInHelp("moderator", "user")).toBe(false);
+    expect(shouldShowAudienceInHelp("moderator", "moderator")).toBe(true);
+    expect(shouldShowAudienceInHelp("moderator", "admin")).toBe(true);
+
+    expect(shouldShowAudienceInHelp("admin", "moderator")).toBe(false);
+    expect(shouldShowAudienceInHelp("admin", "admin")).toBe(true);
+  });
+
+  it("returns Commander hidden options for hidden audiences", () => {
+    expect(commandOptionsForAudience("moderator", "user")).toEqual({ hidden: true });
+    expect(commandOptionsForAudience("moderator", "moderator")).toBeUndefined();
+    expect(commandOptionsForAudience("admin", "moderator")).toEqual({ hidden: true });
+    expect(commandOptionsForAudience("admin", "admin")).toBeUndefined();
   });
 });

--- a/packages/clawhub/src/cli/adminHelp.ts
+++ b/packages/clawhub/src/cli/adminHelp.ts
@@ -1,25 +1,55 @@
 import { readGlobalConfig } from "../config.js";
 import { apiRequest } from "../http.js";
-import { ApiRoutes, ApiV1WhoamiResponseSchema } from "../schema/index.js";
+import { ApiRoutes, ApiV1WhoamiResponseSchema, parseArk } from "../schema/index.js";
 import { DEFAULT_REGISTRY } from "./registry.js";
 
 type AdminHelpDeps = {
   argv?: string[];
   env?: NodeJS.ProcessEnv;
+  commandPaths?: CommandPathRegistry;
 };
 
-export function isHelpRequest(argv: string[] = process.argv) {
-  const args = argv.slice(2);
-  return args.length === 0 || args[0] === "help" || args.includes("--help") || args.includes("-h");
+type PlatformRole = "admin" | "moderator" | "user";
+export type CommandAudience = "public" | "authenticated" | "owner" | "moderator" | "admin";
+
+type CommandPathRegistry = {
+  add: (path: readonly string[]) => void;
+  hasKnownLeafPrefix: (path: readonly string[]) => boolean;
+};
+
+const GLOBAL_VALUE_FLAGS = new Set(["--dir", "--registry", "--site", "--workdir"]);
+
+export function createCommandPathRegistry(): CommandPathRegistry {
+  const leafPaths: string[][] = [];
+  return {
+    add(path) {
+      leafPaths.push([...path]);
+    },
+    hasKnownLeafPrefix(path) {
+      return leafPaths.some((leafPath) => isPathPrefix(leafPath, path));
+    },
+  };
 }
 
-export async function shouldShowAdminCommandsInHelp(deps: AdminHelpDeps = {}) {
-  if (!isHelpRequest(deps.argv)) return true;
+export function isHelpRequest(
+  argv: string[] = process.argv,
+  commandPaths: CommandPathRegistry = createCommandPathRegistry(),
+) {
+  const args = argv.slice(2);
+  if (args.length === 0 || args[0] === "help" || args.includes("--help") || args.includes("-h")) {
+    return true;
+  }
+
+  return !commandPaths.hasKnownLeafPrefix(readCommandPath(args));
+}
+
+export async function resolveHelpRole(deps: AdminHelpDeps = {}): Promise<PlatformRole | null> {
+  if (!isHelpRequest(deps.argv, deps.commandPaths)) return "admin";
 
   const env = deps.env ?? process.env;
   const cfg = await readGlobalConfig();
   const token = cfg?.token?.trim();
-  if (!token) return false;
+  if (!token) return null;
 
   const registry =
     readFlagValue(deps.argv ?? process.argv, "--registry")?.trim() ||
@@ -29,15 +59,31 @@ export async function shouldShowAdminCommandsInHelp(deps: AdminHelpDeps = {}) {
     DEFAULT_REGISTRY;
 
   try {
-    const whoami = await apiRequest(
+    const result = await apiRequest(
       registry,
       { method: "GET", path: ApiRoutes.whoami, token },
       ApiV1WhoamiResponseSchema,
     );
-    return whoami.user.role === "admin";
+    const whoami = parseArk(ApiV1WhoamiResponseSchema, result, "Whoami response");
+    const role = whoami.user.role;
+    return role === "admin" || role === "moderator" || role === "user" ? role : null;
   } catch {
-    return false;
+    return null;
   }
+}
+
+export async function shouldShowAdminCommandsInHelp(deps: AdminHelpDeps = {}) {
+  return shouldShowAudienceInHelp("admin", await resolveHelpRole(deps));
+}
+
+export function shouldShowAudienceInHelp(audience: CommandAudience, role: PlatformRole | null) {
+  if (audience !== "moderator" && audience !== "admin") return true;
+  if (audience === "moderator") return role === "moderator" || role === "admin";
+  return role === "admin";
+}
+
+export function commandOptionsForAudience(audience: CommandAudience, role: PlatformRole | null) {
+  return shouldShowAudienceInHelp(audience, role) ? undefined : { hidden: true };
 }
 
 function readFlagValue(argv: string[], flag: string) {
@@ -48,4 +94,20 @@ function readFlagValue(argv: string[], flag: string) {
     if (arg?.startsWith(`${flag}=`)) return arg.slice(flag.length + 1);
   }
   return undefined;
+}
+
+function readCommandPath(args: string[]) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg?.startsWith("-")) {
+      return args.slice(index).filter((candidate) => !candidate.startsWith("-"));
+    }
+    const [flag] = arg.split("=", 1);
+    if (!arg.includes("=") && GLOBAL_VALUE_FLAGS.has(flag)) index += 1;
+  }
+  return [];
+}
+
+function isPathPrefix(prefix: readonly string[], path: readonly string[]) {
+  return prefix.length <= path.length && prefix.every((part, index) => path[index] === part);
 }


### PR DESCRIPTION
## Summary
- add a command registration helper that records command path + help audience in one place
- add role-aware CLI help audiences for moderator/admin command visibility
- hide privileged package moderation/operator commands from normal user and logged-out help
- keep transfer visible while filtering typo/error help such as `clawhub upgrade`

## Sample help visibility

Logged-out / `user` root help hides moderator/admin commands, but keeps normal owner/auth commands like `transfer`:

```text
Commands:
  ...
  package                      Browse and publish OpenClaw packages
  transfer                     Transfer skill ownership
  star [options] <slug>        Add a skill to your highlights
  unstar [options] <slug>      Remove a skill from your highlights
  sync [options]               Scan local skills and publish new/updated ones
```

Logged-out / `user` package help hides moderation/operator commands, but keeps public or owner-facing package commands:

```text
Commands:
  explore [options] [query...]        Browse published packages and plugins
  inspect [options] <name>            Fetch package metadata and files without installing
  download [options] <name>           Download a package artifact and verify its published digests
  verify [options] <file>             Verify a local package artifact against ClawHub or expected digests
  report [options] <name>             Report a package for moderator review
  appeal [options] <name>             Appeal moderation for a package release
  moderation-status [options] <name>  Show owner/staff package moderation status
  readiness [options] <name>          Check package readiness for future OpenClaw consumption
  migration-status [options] <name>   Show package migration status for future OpenClaw consumption
  pack [options] <source>             Create a ClawPack npm tarball from a plugin package folder
  publish [options] <source>          Publish a code plugin or bundle plugin from a folder or GitHub source
  trusted-publisher                   Manage package trusted publisher config
  rescan [options] <name>             Request a security rescan for the latest published package release
```

`moderator` root help adds moderator-visible commands, but still hides admin-only commands:

```text
Commands:
  ...
  package                          Browse and publish OpenClaw packages
  ban-user [options] <handleOrId>  Ban a user and delete owned skills (moderator/admin only)
  transfer                         Transfer skill ownership
  star [options] <slug>            Add a skill to your highlights
  unstar [options] <slug>          Remove a skill from your highlights
  sync [options]                   Scan local skills and publish new/updated ones
```

`moderator` package help adds moderator review/intake commands:

```text
Commands:
  ...
  moderate [options] <name>             Set package release moderation state
  appeals [options]                     List package appeals for moderator review
  resolve-appeal [options] <appeal-id>  Resolve or reopen a package appeal
  reports [options]                     List package reports for moderator review
  triage-report [options] <report-id>   Resolve or reopen a package report
  moderation-queue [options]            List package releases that need moderation
  migrations [options]                  List official plugin migration rows
  ...
```

`admin` root help includes both moderator and admin-only commands:

```text
Commands:
  ...
  ban-user [options] <handleOrId>         Ban a user and delete owned skills (moderator/admin only)
  unban-user [options] <handleOrId>       Unban a user and restore eligible skills (admin only)
  set-role [options] <handleOrId> <role>  Change a user role (admin only)
  transfer                                Transfer skill ownership
  ...
```

`admin` package help includes moderator commands plus admin-only operator commands:

```text
Commands:
  ...
  moderation-queue [options]                   List package releases that need moderation
  backfill-artifacts [options]                 Backfill missing package artifact-kind metadata (admin only)
  migrations [options]                         List official plugin migration rows
  set-migration [options] <bundled-plugin-id>  Create or update an official plugin migration row
  trusted-publisher                            Manage package trusted publisher config
  ...
```

Typo/error help is also filtered. For example, logged-out `clawhub upgrade` shows `transfer` but not `ban-user`, `unban-user`, `set-role`, or package operator commands.

## Tests
- `bun run test:src src/cli/adminHelp.test.ts`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bun run ci:static`
- `bun run format:check`
- `bun run lint`
- manual logged-out `clawhub upgrade` help check

