### PR TITLE
Fix mobile layout responsiveness

### DIFF
--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -252,7 +252,7 @@ describe("Header", () => {
     expect(signInButton.querySelector(".sign-in-compact-copy")?.textContent).toBe("GitHub");
   });
 
-  it("keeps inline search and content nav visible in the compact header", () => {
+  it("keeps inline search and moves content nav into the compact menu", () => {
     const css = compactHeaderCss();
 
     expect(css).toContain(".navbar-search-wrap");
@@ -262,11 +262,10 @@ describe("Header", () => {
     expect(css).toContain(".navbar-search-mobile-trigger");
     expect(css).toContain("display: none;");
     expect(css).toContain(".navbar-tabs {");
-    expect(css).toContain("display: flex;");
-    expect(css).toContain(".navbar-tabs-secondary");
+    expect(css).toContain("display: none;");
+    expect(css).toContain(".nav-mobile {");
     expect(css).toContain("display: inline-flex;");
     expect(css).not.toContain(".navbar-search {\n    display: none;");
-    expect(css).not.toContain(".navbar-tabs {\n    display: none;");
   });
 
   it("aligns the restored header shell to the browse page width", () => {
@@ -276,7 +275,7 @@ describe("Header", () => {
     expect(css).toContain(".navbar-inner {\n  width: 100%;\n  max-width: var(--page-max);");
     expect(css).toContain("margin: 0 auto;\n  padding: 0 var(--space-5);");
     expect(compactCss).toContain("padding: 10px 16px;");
-    expect(compactCss).toContain("scroll-padding-inline: 16px;");
+    expect(compactCss).toContain(".navbar-tabs {\n    display: none;");
     expect(css).not.toContain(".navbar-inner,\n  .section.detail-page-section");
   });
 

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -102,11 +102,10 @@ describe("restored UI design contract", () => {
     const compact = cssMediaContaining(css, "(max-width: 760px)", [
       "grid-template-columns: 56px minmax(0, 1fr) 56px",
       ".navbar-search {\n    display: flex;",
-      ".navbar-tabs {\n    display: flex;",
-      ".navbar-tabs-secondary {\n    display: inline-flex;",
+      ".navbar-tabs {\n    display: none;",
+      ".nav-mobile {\n    display: inline-flex;",
     ]);
     expect(compact).not.toContain(".navbar-search {\n    display: none;");
-    expect(compact).not.toContain(".navbar-tabs {\n    display: none;");
   });
 
   it("requires the restored home hero, carousel, category grid, and Trending Now sections", () => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -4802,14 +4802,7 @@ code {
   }
 
   .navbar-tabs {
-    display: flex;
-    align-items: center;
-    gap: 0;
-    min-height: 64px;
-    padding: 0 16px;
-    overflow-x: auto;
-    overscroll-behavior-x: contain;
-    scroll-padding-inline: 16px;
+    display: none;
   }
 
   .navbar-tabs-primary,
@@ -7965,6 +7958,25 @@ code {
 }
 
 @media (max-width: 760px) {
+  .skill-list-item-summary {
+    -webkit-line-clamp: 2;
+  }
+
+  .tab-card {
+    overflow-x: hidden;
+  }
+
+  .tab-header {
+    display: flex;
+    flex-wrap: wrap;
+    overflow-x: visible;
+  }
+
+  .tab-button {
+    flex: 1 1 auto;
+    justify-content: center;
+  }
+
   .browse-page {
     padding: 16px 16px 40px;
   }
@@ -9996,6 +10008,9 @@ code {
   .home-v2-hero {
     padding: 48px 20px 36px;
   }
+  .home-v2-ring {
+    display: none;
+  }
   .home-v2-headline {
     font-size: clamp(28px, 6vw, 38px);
     white-space: normal;
@@ -10025,12 +10040,23 @@ code {
   .home-v2-carousel-header {
     padding: 0 20px;
   }
+  .home-v2-carousel-wrap {
+    overflow: visible;
+  }
+  .home-v2-carousel-wrap::before,
+  .home-v2-carousel-wrap::after {
+    display: none;
+  }
   .home-v2-carousel-track {
+    width: auto;
+    flex-direction: column;
+    animation: none;
     padding: 12px 20px 36px;
   }
   .home-v2-c-card {
-    min-width: 280px;
-    max-width: 280px;
+    width: 100%;
+    min-width: 0;
+    max-width: none;
   }
   .home-v2-categories {
     padding: 32px 20px 0;


### PR DESCRIPTION
## Summary
- Hide the duplicate desktop tab rail on compact mobile headers so the hamburger menu owns mobile navigation.
- Improve mobile catalog/detail readability by allowing two-line summaries and wrapping detail tabs.
- Convert the home carousel into a vertical mobile list and hide decorative rings on mobile to avoid offscreen visual overflow.

## Screenshots
Screenshots were generated for this PR and hosted outside the repo so no docs or screenshot artifacts are committed.

### Before
<img width="440" alt="Before mobile audit contact sheet" src="https://gist.githubusercontent.com/Patrick-Erichsen/7f89ab25f488fc7491c2c1b64a82d0ec/raw/617825339b30636550e20e92fd627aa57a3fb4a4/before.svg">

### After
<img width="440" alt="After mobile audit contact sheet" src="https://gist.githubusercontent.com/Patrick-Erichsen/7f89ab25f488fc7491c2c1b64a82d0ec/raw/ac20a5a9f6eca9bf0f5c726922546f7a745f0175/after.svg">

Mobile verification result: 24/24 representative pages passed at `390x844` with no horizontal overflow or visible offscreen elements.

## Tests
- `bun run format:check`
- `bun run lint`
- `bun run test:ui-contract`
- Mobile screenshot/overflow sweep at `390x844` across 24 representative routes
