### PR TITLE
fix: normalize package moderation queue timestamps

### DIFF
--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -4556,6 +4556,68 @@ describe("package scan backfill", () => {
     ]);
   });
 
+  it("normalizes legacy package release timestamps for the moderation queue", async () => {
+    const result = await listPackageModerationQueueInternalHandler(
+      {
+        db: {
+          get: vi.fn(async (id: string) => {
+            if (id === "users:moderator") return { _id: id, role: "moderator" };
+            if (id === "packages:demo") {
+              return {
+                ...makePackageDoc(),
+                _id: "packages:demo",
+                name: "@scope/demo",
+                displayName: "Demo",
+                family: "code-plugin",
+                channel: "community",
+                isOfficial: false,
+              };
+            }
+            return null;
+          }),
+          query: vi.fn((table: string) => {
+            if (table !== "packageReleases") throw new Error(`Unexpected table ${table}`);
+            return {
+              withIndex: vi.fn(() => ({
+                order: vi.fn(() => ({
+                  paginate: vi.fn().mockResolvedValue({
+                    page: [
+                      {
+                        ...makeReleaseDoc({
+                          _id: "packageReleases:legacy",
+                          _creationTime: 321,
+                          packageId: "packages:demo",
+                          createdAt: undefined,
+                          manualModeration: {
+                            state: "quarantined",
+                            reason: "manual review",
+                            reviewerUserId: "users:moderator",
+                            updatedAt: 2,
+                          },
+                        }),
+                      },
+                    ],
+                    continueCursor: null,
+                    isDone: true,
+                  }),
+                })),
+              })),
+            };
+          }),
+        },
+      } as never,
+      { actorUserId: "users:moderator", limit: 10, status: "manual" },
+    );
+
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        releaseId: "packageReleases:legacy",
+        createdAt: 321,
+        moderationState: "quarantined",
+      }),
+    ]);
+  });
+
   it("dry-runs package artifact kind backfill without patching releases", async () => {
     const patch = vi.fn();
     const result = await backfillPackageArtifactKindsInternalHandler(

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -199,6 +199,9 @@ type PublicPackageListItem = {
   verificationTier: PackageVerificationTier | null;
 };
 type PackageReleaseScanStatus = ReturnType<typeof resolvePackageReleaseScanStatus>;
+type PackageReleaseModerationQueueDoc = Omit<Doc<"packageReleases">, "createdAt"> & {
+  createdAt?: number;
+};
 type PackageReportStatus = "open" | "triaged" | "dismissed";
 type PackageModerationQueueItem = {
   packageId: Id<"packages">;
@@ -335,7 +338,7 @@ function isReservedPackagePlaceholder(pkg: PackageDoc | null | undefined) {
 }
 
 function getPackageModerationQueueReasons(
-  release: Doc<"packageReleases">,
+  release: Pick<Doc<"packageReleases">, "manualModeration" | "staticScan" | "vtAnalysis">,
   scanStatus: PackageReleaseScanStatus,
   reportCount = 0,
 ) {
@@ -379,9 +382,13 @@ function shouldIncludeReleaseInModerationQueue(
   );
 }
 
+function getPackageReleaseCreatedAt(release: PackageReleaseModerationQueueDoc) {
+  return typeof release.createdAt === "number" ? release.createdAt : release._creationTime;
+}
+
 function toPackageModerationQueueItem(
   pkg: Doc<"packages">,
-  release: Doc<"packageReleases">,
+  release: PackageReleaseModerationQueueDoc,
 ): PackageModerationQueueItem {
   const scanStatus = resolvePackageReleaseScanStatus(release);
   const reportCount = pkg.reportCount ?? 0;
@@ -399,7 +406,7 @@ function toPackageModerationQueueItem(
     channel: pkg.channel,
     isOfficial: pkg.isOfficial,
     version: release.version,
-    createdAt: release.createdAt,
+    createdAt: getPackageReleaseCreatedAt(release),
     artifactKind: release.artifactKind ?? null,
     scanStatus,
     moderationState: release.manualModeration?.state ?? null,


### PR DESCRIPTION
## Summary
- Normalize legacy package release timestamps in the package moderation queue by falling back to Convex `_creationTime` when `createdAt` is missing.
- Add a regression test for the manual moderation queue path with a legacy release row.

## Repro
- Verified with the local `./clawhub` CLI before the fix: `package moderation-queue --status blocked --limit 1 --json` and `--status manual` returned Convex Server Error request IDs.
- Neighboring moderation surfaces `package reports` and `package appeals` returned successfully.

## Tests
- `bunx vitest run convex/packages.public.test.ts --testNamePattern "moderation queue"`
- `bunx vitest run convex/httpApiV1.handlers.test.ts --testNamePattern "package moderation queue"`
- `bun run --cwd packages/clawhub test -- --run src/cli/commands/packages.test.ts --testNamePattern "moderation queue"`
- `bunx tsc --noEmit`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bun run format:check`
- `bun run lint`
