### PR TITLE
feat: allow package owners to delete plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Packages: expose owned plugin/package soft-delete in the CLI and dashboard, keep moderator takedown access, and remove deleted packages from package search surfaces (thanks @Patrick-Erichsen).
 - CLI/moderation: allow `delete`, `hide`, `undelete`, and `unhide` to record moderation reasons in skill notes and audit logs for legal or policy reviews (thanks @steipete).
 - API: raise public read rate limits to reduce false-positive 429s from browser pages and production smoke tests (thanks @steipete).
 - Moderation: calibrate VirusTotal Code Insight suspicious verdicts so uncorroborated AI-only findings do not keep otherwise clean skills quarantined (#1830, #1841) (thanks @deepujain).

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -1159,11 +1159,18 @@ function makeSoftDeletePackageCtx(options?: {
   releases?: Array<Record<string, unknown>>;
   user?: Record<string, unknown> | null;
   membership?: Record<string, unknown> | null;
+  packageSearchDigest?: Record<string, unknown> | null;
+  capabilityDigests?: Array<Record<string, unknown>>;
 }) {
   const pkg = options?.pkg ?? makePackageDoc();
   const releases = options?.releases ?? [makeReleaseDoc()];
   const user = options?.user ?? { _id: "users:owner", role: "user" };
   const membership = options?.membership ?? null;
+  const packageSearchDigest =
+    options?.packageSearchDigest === undefined
+      ? { _id: "packageSearchDigest:demo", packageId: pkg?._id }
+      : options.packageSearchDigest;
+  const capabilityDigests = options?.capabilityDigests ?? [];
   const patch = vi.fn();
   const insert = vi.fn();
   return {
@@ -1200,21 +1207,14 @@ function makeSoftDeletePackageCtx(options?: {
           if (table === "packageSearchDigest") {
             return {
               withIndex: vi.fn(() => ({
-                unique: vi.fn().mockResolvedValue({
-                  _id: "packageSearchDigest:demo",
-                  packageId: pkg?._id,
-                  name: pkg?.name,
-                  normalizedName: pkg?.normalizedName,
-                  displayName: pkg?.displayName,
-                  softDeletedAt: undefined,
-                }),
+                unique: vi.fn().mockResolvedValue(packageSearchDigest),
               })),
             };
           }
           if (table === "packageCapabilitySearchDigest") {
             return {
               withIndex: vi.fn(() => ({
-                collect: vi.fn().mockResolvedValue([]),
+                collect: vi.fn().mockResolvedValue(capabilityDigests),
               })),
             };
           }
@@ -2237,6 +2237,46 @@ describe("packages public queries", () => {
     });
     expect(patch).toHaveBeenCalledWith(
       "packages:demo",
+      expect.objectContaining({
+        softDeletedAt: expect.any(Number),
+      }),
+    );
+  });
+
+  it("syncs package search digests when packages are soft-deleted", async () => {
+    const { ctx, patch } = makeSoftDeletePackageCtx({
+      pkg: makePackageDoc({ capabilityTags: ["tools"] }),
+      packageSearchDigest: {
+        _id: "packageSearchDigest:demo",
+        packageId: "packages:demo",
+        softDeletedAt: undefined,
+      },
+      capabilityDigests: [
+        {
+          _id: "packageCapabilitySearchDigest:tools",
+          packageId: "packages:demo",
+          capabilityTag: "tools",
+          softDeletedAt: undefined,
+        },
+      ],
+    });
+
+    await expect(
+      softDeletePackageInternalHandler(ctx, {
+        userId: "users:owner",
+        name: "demo-plugin",
+      }),
+    ).resolves.toMatchObject({ ok: true, alreadyDeleted: false });
+
+    expect(patch).toHaveBeenCalledWith(
+      "packageSearchDigest:demo",
+      expect.objectContaining({
+        softDeletedAt: expect.any(Number),
+        updatedAt: expect.any(Number),
+      }),
+    );
+    expect(patch).toHaveBeenCalledWith(
+      "packageCapabilitySearchDigest:tools",
       expect.objectContaining({
         softDeletedAt: expect.any(Number),
       }),

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -1158,13 +1158,17 @@ function makeSoftDeletePackageCtx(options?: {
   pkg?: Record<string, unknown> | null;
   releases?: Array<Record<string, unknown>>;
   user?: Record<string, unknown> | null;
+  membership?: Record<string, unknown> | null;
 }) {
   const pkg = options?.pkg ?? makePackageDoc();
   const releases = options?.releases ?? [makeReleaseDoc()];
   const user = options?.user ?? { _id: "users:owner", role: "user" };
+  const membership = options?.membership ?? null;
   const patch = vi.fn();
+  const insert = vi.fn();
   return {
     patch,
+    insert,
     ctx: {
       db: {
         get: vi.fn(async (id: string) => {
@@ -1186,10 +1190,38 @@ function makeSoftDeletePackageCtx(options?: {
               })),
             };
           }
+          if (table === "publisherMembers") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue(membership),
+              })),
+            };
+          }
+          if (table === "packageSearchDigest") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue({
+                  _id: "packageSearchDigest:demo",
+                  packageId: pkg?._id,
+                  name: pkg?.name,
+                  normalizedName: pkg?.normalizedName,
+                  displayName: pkg?.displayName,
+                  softDeletedAt: undefined,
+                }),
+              })),
+            };
+          }
+          if (table === "packageCapabilitySearchDigest") {
+            return {
+              withIndex: vi.fn(() => ({
+                collect: vi.fn().mockResolvedValue([]),
+              })),
+            };
+          }
           throw new Error(`Unexpected table ${table}`);
         }),
         patch,
-        insert: vi.fn(),
+        insert,
         replace: vi.fn(),
         delete: vi.fn(),
         normalizeId: vi.fn(),
@@ -2138,6 +2170,14 @@ describe("packages public queries", () => {
         updatedAt: expect.any(Number),
       }),
     );
+    expect(patch).toHaveBeenCalledWith(
+      "packageSearchDigest:demo",
+      expect.objectContaining({
+        packageId: "packages:demo",
+        softDeletedAt: expect.any(Number),
+        updatedAt: expect.any(Number),
+      }),
+    );
   });
 
   it("rejects non-owner package soft deletes without moderator access", async () => {
@@ -2152,6 +2192,55 @@ describe("packages public queries", () => {
         name: "demo-plugin",
       }),
     ).rejects.toThrow("Forbidden");
+  });
+
+  it("allows moderators to soft-delete packages without ownership", async () => {
+    const { ctx, patch } = makeSoftDeletePackageCtx({
+      pkg: makePackageDoc({ ownerUserId: "users:someone-else" }),
+      user: { _id: "users:moderator", role: "moderator" },
+    });
+
+    await expect(
+      softDeletePackageInternalHandler(ctx, {
+        userId: "users:moderator",
+        name: "demo-plugin",
+      }),
+    ).resolves.toMatchObject({ ok: true, alreadyDeleted: false });
+    expect(patch).toHaveBeenCalledWith(
+      "packages:demo",
+      expect.objectContaining({
+        softDeletedAt: expect.any(Number),
+      }),
+    );
+  });
+
+  it("allows org publisher admins to soft-delete packages", async () => {
+    const { ctx, patch } = makeSoftDeletePackageCtx({
+      pkg: makePackageDoc({
+        ownerUserId: "users:org-linked",
+        ownerPublisherId: "publishers:org",
+      }),
+      user: { _id: "users:owner", role: "user" },
+      membership: { _id: "publisherMembers:1", role: "admin" },
+    });
+
+    const result = await softDeletePackageInternalHandler(ctx, {
+      userId: "users:owner",
+      name: "demo-plugin",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      packageId: "packages:demo",
+      releaseCount: 1,
+      alreadyDeleted: false,
+    });
+    expect(patch).toHaveBeenCalledWith(
+      "packages:demo",
+      expect.objectContaining({
+        softDeletedAt: expect.any(Number),
+      }),
+    );
   });
 
   it("reserves private package placeholders without releases", async () => {

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -45,6 +45,7 @@ import {
   summarizePackageForSearch,
   toConvexSafeJsonValue,
 } from "./lib/packageRegistry";
+import { extractPackageDigestFields, upsertPackageSearchDigest } from "./lib/packageSearchDigest";
 import { isPackageBlockedFromPublic, resolvePackageReleaseScanStatus } from "./lib/packageSecurity";
 import { toPublicPublisher } from "./lib/public";
 import {
@@ -2084,6 +2085,46 @@ export const insertAuditLogInternal = internalMutation({
   },
 });
 
+async function softDeletePackageDoc(ctx: Pick<MutationCtx, "db">, pkg: Doc<"packages">) {
+  if (pkg.softDeletedAt) {
+    return {
+      ok: true as const,
+      packageId: pkg._id,
+      releaseCount: 0,
+      alreadyDeleted: true as const,
+    };
+  }
+
+  const now = Date.now();
+  const releases = await ctx.db
+    .query("packageReleases")
+    .withIndex("by_package", (q) => q.eq("packageId", pkg._id))
+    .collect();
+  let releaseCount = 0;
+  for (const release of releases) {
+    if (release.softDeletedAt) continue;
+    await ctx.db.patch(release._id, { softDeletedAt: now });
+    releaseCount += 1;
+  }
+
+  const packagePatch = {
+    softDeletedAt: now,
+    updatedAt: now,
+  };
+  await ctx.db.patch(pkg._id, packagePatch);
+  await upsertPackageSearchDigest(ctx, {
+    ...extractPackageDigestFields(pkg),
+    ...packagePatch,
+  });
+
+  return {
+    ok: true as const,
+    packageId: pkg._id,
+    releaseCount,
+    alreadyDeleted: false as const,
+  };
+}
+
 export const softDeletePackageInternal = internalMutation({
   args: {
     userId: v.id("users"),
@@ -2099,42 +2140,38 @@ export const softDeletePackageInternal = internalMutation({
     const pkg = await getPackageByNormalizedName(ctx, normalizedName);
     if (!pkg) throw new Error("Package not found");
 
-    if (pkg.ownerUserId !== args.userId) {
-      assertModerator(user);
+    if (user.role !== "moderator" && user.role !== "admin") {
+      await assertCanManageOwnedResource(ctx, {
+        actor: user,
+        ownerUserId: pkg.ownerUserId,
+        ownerPublisherId: pkg.ownerPublisherId,
+        allowedPublisherRoles: ["admin"],
+      });
     }
 
-    if (pkg.softDeletedAt) {
-      return {
-        ok: true as const,
-        packageId: pkg._id,
-        releaseCount: 0,
-        alreadyDeleted: true as const,
-      };
+    return await softDeletePackageDoc(ctx, pkg);
+  },
+});
+
+export const softDeletePackage = mutation({
+  args: {
+    packageId: v.id("packages"),
+  },
+  handler: async (ctx, args) => {
+    const { user } = await requireUser(ctx);
+    const pkg = await ctx.db.get(args.packageId);
+    if (!pkg) throw new ConvexError("Package not found");
+
+    if (user.role !== "moderator" && user.role !== "admin") {
+      await assertCanManageOwnedResource(ctx, {
+        actor: user,
+        ownerUserId: pkg.ownerUserId,
+        ownerPublisherId: pkg.ownerPublisherId,
+        allowedPublisherRoles: ["admin"],
+      });
     }
 
-    const now = Date.now();
-    const releases = await ctx.db
-      .query("packageReleases")
-      .withIndex("by_package", (q) => q.eq("packageId", pkg._id))
-      .collect();
-    let releaseCount = 0;
-    for (const release of releases) {
-      if (release.softDeletedAt) continue;
-      await ctx.db.patch(release._id, { softDeletedAt: now });
-      releaseCount += 1;
-    }
-
-    await ctx.db.patch(pkg._id, {
-      softDeletedAt: now,
-      updatedAt: now,
-    });
-
-    return {
-      ok: true as const,
-      packageId: pkg._id,
-      releaseCount,
-      alreadyDeleted: false as const,
-    };
+    return await softDeletePackageDoc(ctx, pkg);
   },
 });
 

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -2140,7 +2140,9 @@ export const softDeletePackageInternal = internalMutation({
     const pkg = await getPackageByNormalizedName(ctx, normalizedName);
     if (!pkg) throw new Error("Package not found");
 
-    if (user.role !== "moderator" && user.role !== "admin") {
+    if (user.role === "moderator" || user.role === "admin") {
+      // Staff can moderate packages outside their own publisher memberships.
+    } else {
       await assertCanManageOwnedResource(ctx, {
         actor: user,
         ownerUserId: pkg.ownerUserId,
@@ -2162,7 +2164,9 @@ export const softDeletePackage = mutation({
     const pkg = await ctx.db.get(args.packageId);
     if (!pkg) throw new ConvexError("Package not found");
 
-    if (user.role !== "moderator" && user.role !== "admin") {
+    if (user.role === "moderator" || user.role === "admin") {
+      // Staff can moderate packages outside their own publisher memberships.
+    } else {
       await assertCanManageOwnedResource(ctx, {
         actor: user,
         ownerUserId: pkg.ownerUserId,

--- a/docs/api.md
+++ b/docs/api.md
@@ -97,6 +97,7 @@ Auth required:
 
 - `POST /api/v1/skills` (publish, multipart preferred)
 - `DELETE /api/v1/skills/{slug}`
+- `DELETE /api/v1/packages/{name}`
 - `POST /api/v1/skills/{slug}/undelete`
 - `POST /api/v1/skills/{slug}/rename`
 - `POST /api/v1/skills/{slug}/merge`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -313,6 +313,21 @@ clawhub package verify ./example-plugin-1.2.3.tgz --package @openclaw/example-pl
 clawhub package verify ./example-plugin-1.2.3.tgz --sha256 <hex>
 ```
 
+### `package delete <name>`
+
+- Soft-deletes a package and all releases.
+- Requires the package owner, an org publisher owner/admin, platform moderator,
+  or platform admin.
+- Flags:
+  - `--yes`: skip confirmation.
+  - `--json`: machine-readable output.
+
+Example:
+
+```bash
+clawhub package delete @openclaw/example-plugin --yes
+```
+
 ### `package moderate <name>`
 
 - Moderator/admin command for package release review.

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -351,6 +351,15 @@ Notes:
 - Skills can also resolve through this route in the unified catalog.
 - Private packages return `404` unless the caller can read the owning publisher.
 
+### `DELETE /api/v1/packages/{name}`
+
+Soft-deletes a package and all releases.
+
+Notes:
+
+- Requires an API token for the package owner, an org publisher owner/admin,
+  platform moderator, or platform admin.
+
 ### `GET /api/v1/packages/{name}/versions`
 
 Returns version history.

--- a/packages/clawhub/src/cli.ts
+++ b/packages/clawhub/src/cli.ts
@@ -23,6 +23,7 @@ import { cmdMergeSkill, cmdRenameSkill } from "./cli/commands/ownership.js";
 import {
   cmdBackfillPackageArtifacts,
   cmdAppealPackage,
+  cmdDeletePackage,
   cmdDownloadPackage,
   cmdExplorePackages,
   cmdGetPackageTrustedPublisher,
@@ -471,6 +472,16 @@ registerCommand(packageCmd, ["package", "verify"])
       ...options,
       packageName: options.package,
     });
+  });
+
+registerCommand(packageCmd, ["package", "delete"])
+  .description("Soft-delete a package and all releases")
+  .argument("<name>", "Package name")
+  .option("--yes", "Skip confirmation")
+  .option("--json", "Output JSON")
+  .action(async (name, options) => {
+    const opts = await resolveGlobalOpts();
+    await cmdDeletePackage(opts, name, options, isInputAllowed());
   });
 
 registerCommand(packageCmd, ["package", "moderate"], "moderator")

--- a/packages/clawhub/src/cli/commands/packages.test.ts
+++ b/packages/clawhub/src/cli/commands/packages.test.ts
@@ -28,6 +28,7 @@ vi.mock("../authToken.js", () => authTokenMocks.moduleFactory());
 vi.mock("../ui.js", () => uiMocks.moduleFactory());
 
 const {
+  cmdDeletePackage,
   cmdDeletePackageTrustedPublisher,
   cmdAppealPackage,
   cmdDownloadPackage,
@@ -2440,5 +2441,29 @@ describe("package commands", () => {
       }),
       undefined,
     );
+  });
+
+  it("soft-deletes a package with confirmation bypass", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({ ok: true });
+
+    await cmdDeletePackage(makeOpts(), "@openclaw/zalo", { yes: true }, false);
+
+    expect(authTokenMocks.requireAuthToken).toHaveBeenCalled();
+    expect(httpMocks.apiRequest).toHaveBeenCalledWith(
+      "https://clawhub.ai",
+      expect.objectContaining({
+        method: "DELETE",
+        path: "/api/v1/packages/%40openclaw%2Fzalo",
+        token: "tkn",
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("requires --yes for non-interactive package deletes", async () => {
+    await expect(cmdDeletePackage(makeOpts(), "@openclaw/zalo", {}, false)).rejects.toThrow(
+      /--yes/i,
+    );
+    expect(httpMocks.apiRequest).not.toHaveBeenCalled();
   });
 });

--- a/packages/clawhub/src/cli/commands/packages.ts
+++ b/packages/clawhub/src/cli/commands/packages.ts
@@ -10,6 +10,7 @@ import { parseClawPack } from "../../clawpack.js";
 import { apiRequest, apiRequestForm, fetchBinary, fetchText, registryUrl } from "../../http.js";
 import {
   ApiRoutes,
+  ApiV1DeleteResponseSchema,
   ApiV1PackageArtifactBackfillResponseSchema,
   ApiV1PackageArtifactResponseSchema,
   ApiV1PackageAppealResponseSchema,
@@ -54,7 +55,7 @@ import { getOptionalAuthToken, requireAuthToken } from "../authToken.js";
 import { getRegistry } from "../registry.js";
 import { titleCase } from "../slug.js";
 import type { GlobalOpts } from "../types.js";
-import { createSpinner, fail, formatError } from "../ui.js";
+import { createSpinner, fail, formatError, isInteractive, promptConfirm } from "../ui.js";
 import {
   fetchGitHubSource,
   normalizeGitHubRepo,
@@ -246,6 +247,11 @@ type PackageTrustedPublisherSetOptions = {
 };
 
 type PackageTrustedPublisherDeleteOptions = {
+  json?: boolean;
+};
+
+type PackageDeleteOptions = {
+  yes?: boolean;
   json?: boolean;
 };
 
@@ -1002,6 +1008,45 @@ export async function cmdVerifyPackage(
     }
   } catch (error) {
     spinner?.fail(formatError(error));
+    throw error;
+  }
+}
+
+export async function cmdDeletePackage(
+  opts: GlobalOpts,
+  nameArg: string,
+  options: PackageDeleteOptions = {},
+  inputAllowed = true,
+) {
+  const name = nameArg.trim();
+  if (!name) fail("Package name required");
+
+  if (!options.yes) {
+    if (!isInteractive() || inputAllowed === false) fail("Pass --yes (no input)");
+    const ok = await promptConfirm(`Delete ${name}? (soft delete package and all releases)`);
+    if (!ok) return undefined;
+  }
+
+  const token = await requireAuthToken();
+  const registry = await getRegistry(opts, { cache: true });
+  const spinner = createSpinner(`Deleting ${name}`);
+  try {
+    const result = await apiRequest(
+      registry,
+      {
+        method: "DELETE",
+        path: `${ApiRoutes.packages}/${encodeURIComponent(name)}`,
+        token,
+      },
+      ApiV1DeleteResponseSchema,
+    );
+    spinner.succeed(`OK. Deleted ${name}`);
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2));
+    }
+    return result;
+  } catch (error) {
+    spinner.fail(formatError(error));
     throw error;
   }
 }

--- a/src/routes/-dashboard.test.tsx
+++ b/src/routes/-dashboard.test.tsx
@@ -1,5 +1,5 @@
 /* @vitest-environment jsdom */
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Id } from "../../convex/_generated/dataModel";
@@ -94,7 +94,7 @@ type TestPackage = {
     versions: number;
   };
   verification: null;
-  scanStatus: "suspicious" | "malicious";
+  scanStatus: "clean" | "suspicious" | "malicious";
   latestRelease: {
     version: string;
     createdAt: number;
@@ -280,6 +280,18 @@ describe("Dashboard minimal rows", () => {
     expect(screen.queryByRole("link", { name: /new version/i })).toBeNull();
     expect(screen.queryByRole("link", { name: /new release/i })).toBeNull();
     expect(screen.queryByRole("link", { name: /^view$/i })).toBeNull();
+  });
+
+  it("exposes package delete from the plugin row action menu", () => {
+    arrangeDashboard({ packages: [createPackage({ scanStatus: "clean" })] });
+
+    renderDashboard();
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "Open actions for Local Flagged Runtime Plugin" }),
+    );
+
+    expect(screen.getByRole("menuitem", { name: /delete plugin/i })).toBeTruthy();
   });
 
   it("does not render column titles, scanner details, or plugin metadata chips", () => {

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useMutation, usePaginatedQuery, useQuery } from "convex/react";
-import { Clock, Info, Loader2, MoreVertical, Plus, RotateCw, Settings } from "lucide-react";
+import { Clock, Info, Loader2, MoreVertical, Plus, RotateCw, Settings, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { api } from "../../convex/_generated/api";
@@ -13,6 +13,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "../components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../components/ui/tooltip";
@@ -474,7 +475,9 @@ function RowMenu({
 }) {
   const requestSkillRescan = useMutation(api.skills.requestRescan);
   const requestPluginRescan = useMutation(api.packages.requestRescan);
+  const deletePackage = useMutation(api.packages.softDeletePackage);
   const [isRequesting, setIsRequesting] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
   const isScanInProgress = Boolean(rescanState?.inProgressRequest);
   const showRescan = canShowDashboardRescan(statusLabel, rescanState);
   const showRescanItem = showRescan || isScanInProgress;
@@ -498,6 +501,24 @@ function RowMenu({
       toast.error(getUserFacingConvexError(error, "Could not request a rescan."));
     } finally {
       setIsRequesting(false);
+    }
+  }
+
+  async function deletePlugin() {
+    if (kind !== "plugin" || isDeleting) return;
+    const confirmed = window.confirm(
+      `Delete ${targetLabel}? This removes the plugin package and all releases from ClawHub.`,
+    );
+    if (!confirmed) return;
+
+    setIsDeleting(true);
+    try {
+      await deletePackage({ packageId: targetId as Doc<"packages">["_id"] });
+      toast.success(`Deleted ${targetLabel}.`);
+    } catch (error) {
+      toast.error(getUserFacingConvexError(error, "Could not delete this plugin."));
+    } finally {
+      setIsDeleting(false);
     }
   }
 
@@ -536,6 +557,19 @@ function RowMenu({
               />
               {rescanLabel}
             </DropdownMenuItem>
+          ) : null}
+          {kind === "plugin" ? (
+            <>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                disabled={isDeleting}
+                variant="destructive"
+                onSelect={() => void deletePlugin()}
+              >
+                <Trash2 className="h-4 w-4" aria-hidden="true" />
+                {isDeleting ? "Deleting..." : "Delete plugin"}
+              </DropdownMenuItem>
+            </>
           ) : null}
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/styles.css
+++ b/src/styles.css
@@ -5707,13 +5707,26 @@ code {
 
 .dashboard-section-header {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  gap: 16px;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 12px;
 }
 
 .dashboard-section-action {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
   font-size: 0.92rem;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.dashboard-section-action svg {
+  width: 16px;
+  height: 16px;
+  flex: none;
 }
 
 .dashboard-inline-empty {
@@ -5857,10 +5870,51 @@ code {
   justify-content: flex-end;
   justify-self: end;
   align-items: center;
+  min-width: 32px;
+}
+
+.dashboard-row-menu [data-slot="button"] {
+  width: 32px;
+  height: 32px;
+  min-height: 32px;
+  padding: 0;
+}
+
+.dashboard-row-menu [data-slot="button"] svg {
+  width: 16px;
+  height: 16px;
 }
 
 .dashboard-row-menu-content {
-  min-width: 170px;
+  width: 190px;
+  min-width: 190px;
+  padding: 6px;
+  border-radius: 10px;
+  box-shadow:
+    0 18px 48px rgb(0 0 0 / 0.28),
+    0 0 0 1px rgb(255 255 255 / 0.04);
+}
+
+.dashboard-row-menu-content [data-slot="dropdown-menu-item"] {
+  display: flex;
+  width: 100%;
+  min-height: 34px;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  padding: 8px 10px;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.dashboard-row-menu-content [data-slot="dropdown-menu-item"] svg {
+  width: 16px;
+  height: 16px;
+  flex: none;
+}
+
+.dashboard-row-menu-content [data-slot="dropdown-menu-separator"] {
+  margin-block: 4px;
 }
 
 .btn-sm {
@@ -5896,6 +5950,10 @@ code {
   .dashboard-section-header {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .dashboard-section-action {
+    justify-self: start;
   }
 
   .dashboard-inline-empty {


### PR DESCRIPTION
## Summary
- tighten package delete authorization to personal owners, org publisher owners/admins, and platform staff moderators/admins
- add `clawhub package delete <name>` plus dashboard plugin-row delete action
- sync package search digests when packages are soft-deleted so deleted plugins leave search surfaces
- document package delete behavior in CLI and HTTP API docs
- polish dashboard row action placement so create actions sit by section headings and row menus stay compact

## Screenshots
- Real app server checked at `http://localhost:3000/dashboard`; authenticated dashboard capture needs an auth storage state. No static HTML preview screenshot is included.

## Tests
- `bun run format:check`
- `bun run lint`
- `VITE_CONVEX_URL=https://example.invalid bunx tsc --noEmit && bunx tsc -p packages/schema/tsconfig.json --noEmit && bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bunx vitest run convex/packages.public.test.ts`
- `bun run --cwd packages/clawhub test:src -- packages.test.ts`
- `VITE_CONVEX_URL=https://example.invalid bunx vitest run src/routes/-dashboard.test.tsx`
- `VITE_CONVEX_URL=https://example.invalid bun run test`
