### PR TITLE
fix: discover shared env for worktree dev

### DIFF
--- a/scripts/dev-worktree.test.ts
+++ b/scripts/dev-worktree.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { buildEnvFileCandidates, parseEnv, parseGitWorktreeList } from "./dev-worktree";
+
+describe("dev-worktree helpers", () => {
+  it("parses env files without treating inline comments as values", () => {
+    expect(
+      parseEnv(`
+        CONVEX_DEPLOYMENT=local:local-amantus-clawdhub # team: amantus, project: clawdhub
+        SITE_URL=http://localhost:3000
+        HASH_VALUE=abc#123
+        QUOTED_HASH="value # kept"
+      `),
+    ).toEqual({
+      CONVEX_DEPLOYMENT: "local:local-amantus-clawdhub",
+      SITE_URL: "http://localhost:3000",
+      HASH_VALUE: "abc#123",
+      QUOTED_HASH: "value # kept",
+    });
+  });
+
+  it("discovers the primary worktree env file after the current checkout", () => {
+    expect(
+      buildEnvFileCandidates({
+        explicit: null,
+        cwd: "/tmp/worktrees/feature",
+        worktrees: [
+          "/Users/me/Git/openclaw/clawhub",
+          "/tmp/worktrees/feature",
+          "/tmp/worktrees/other-feature",
+        ],
+      }),
+    ).toEqual([".env.local", "/Users/me/Git/openclaw/clawhub/.env.local"]);
+  });
+
+  it("does not scan every sibling worktree for env files", () => {
+    expect(
+      buildEnvFileCandidates({
+        explicit: null,
+        cwd: "/tmp/worktrees/feature",
+        worktrees: ["/tmp/worktrees/feature", "/tmp/worktrees/other-feature"],
+      }),
+    ).toEqual([".env.local"]);
+  });
+
+  it("keeps explicit env files authoritative", () => {
+    expect(
+      buildEnvFileCandidates({
+        explicit: "/secure/shared.env",
+        cwd: "/tmp/worktrees/feature",
+        worktrees: ["/Users/me/Git/openclaw/clawhub"],
+      }),
+    ).toEqual(["/secure/shared.env"]);
+  });
+
+  it("parses git worktree porcelain output", () => {
+    expect(
+      parseGitWorktreeList(`worktree /Users/me/Git/openclaw/clawhub
+HEAD abc123
+branch refs/heads/main
+
+worktree /tmp/worktrees/feature
+HEAD def456
+branch refs/heads/feature
+`),
+    ).toEqual(["/Users/me/Git/openclaw/clawhub", "/tmp/worktrees/feature"]);
+  });
+});

--- a/scripts/dev-worktree.ts
+++ b/scripts/dev-worktree.ts
@@ -47,14 +47,66 @@ function parseArgs(argv: string[]): Options {
   return options;
 }
 
+export function parseGitWorktreeList(text: string) {
+  return text
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("worktree "))
+    .map((line) => line.slice("worktree ".length).trim())
+    .filter(Boolean);
+}
+
+function listGitWorktrees() {
+  const result = spawnSync("git", ["worktree", "list", "--porcelain"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+  if (result.status !== 0 || typeof result.stdout !== "string") return [];
+  return parseGitWorktreeList(result.stdout);
+}
+
+export function buildEnvFileCandidates(options: {
+  explicit: string | null;
+  cwd: string;
+  worktrees?: string[];
+}) {
+  if (options.explicit) return [options.explicit];
+  const primaryWorktree = options.worktrees?.[0];
+  return [
+    ...DEFAULT_ENV_SOURCES,
+    ...(primaryWorktree && resolve(primaryWorktree) !== resolve(options.cwd)
+      ? [`${primaryWorktree}/.env.local`]
+      : []),
+  ];
+}
+
 function findEnvFile(explicit: string | null) {
-  const candidates = explicit ? [explicit] : DEFAULT_ENV_SOURCES;
+  const candidates = buildEnvFileCandidates({
+    explicit,
+    cwd: process.cwd(),
+    worktrees: explicit ? [] : listGitWorktrees(),
+  });
   return candidates
     .map((candidate) => resolve(candidate))
     .find((candidate) => existsSync(candidate));
 }
 
-function parseEnv(text: string) {
+function stripInlineComment(value: string) {
+  let quote: '"' | "'" | null = null;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    const previous = value[index - 1];
+    if ((char === '"' || char === "'") && previous !== "\\") {
+      quote = quote === char ? null : (quote ?? char);
+      continue;
+    }
+    if (char === "#" && quote === null && (index === 0 || /\s/.test(previous ?? ""))) {
+      return value.slice(0, index).trimEnd();
+    }
+  }
+  return value;
+}
+
+export function parseEnv(text: string) {
   const env: Record<string, string> = {};
   for (const rawLine of text.split(/\r?\n/)) {
     const line = rawLine.trim();
@@ -62,7 +114,7 @@ function parseEnv(text: string) {
     const match = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line);
     if (!match) continue;
     const [, key, rawValue] = match;
-    let value = rawValue.trim();
+    let value = stripInlineComment(rawValue.trim());
     if (
       (value.startsWith('"') && value.endsWith('"')) ||
       (value.startsWith("'") && value.endsWith("'"))
@@ -170,7 +222,7 @@ async function main() {
   const envFile = findEnvFile(options.envFile);
   if (!envFile) {
     console.error(
-      "Could not find .env.local. Pass --env-file <path> or set CLAWHUB_ENV_FILE to a shared local env file.",
+      "Could not find .env.local in this checkout or the primary git worktree. Pass --env-file <path> or set CLAWHUB_ENV_FILE to a shared local env file.",
     );
     process.exit(1);
   }
@@ -212,4 +264,6 @@ async function main() {
   process.exit(await waitForExit(vite));
 }
 
-await main();
+if (import.meta.main) {
+  await main();
+}


### PR DESCRIPTION
## Summary
- let `dev:worktree` fall back from the current checkout's `.env.local` to the primary/main git worktree's `.env.local`
- keep explicit `--env-file` / `CLAWHUB_ENV_FILE` selection authoritative
- strip inline comments from parsed env values so `CONVEX_DEPLOYMENT=... # comment` does not break Convex CLI targeting
- add focused unit coverage for env parsing and primary worktree discovery

## Tests
- `bunx vitest run scripts/dev-worktree.test.ts`
- `bun run format:check`
- `bun run lint`
- `VITE_CONVEX_URL=https://example.invalid bunx tsc --noEmit`
