### PR TITLE
chore(ci): harden security ownership and workflow permissions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,10 @@
 # If you add overlapping rules below the secops block, include @openclaw/openclaw-secops
 # on those entries too or you can silently remove required secops review.
 # Security-sensitive code, config, workflows, and docs require secops review.
+/.github/actions/ @openclaw/openclaw-secops
+/.github/actionlint.yaml @openclaw/openclaw-secops
 /.github/codeql/ @openclaw/openclaw-secops
+/.github/dependabot.yml @openclaw/openclaw-secops
 /.github/workflows/ @openclaw/openclaw-secops
 /scripts/check-staged-secrets.mjs @openclaw/openclaw-secops
 /scripts/clawhub-cli-npm-publish.sh @openclaw/openclaw-secops

--- a/.github/workflows/clawhub-cli-npm-release.yml
+++ b/.github/workflows/clawhub-cli-npm-release.yml
@@ -21,6 +21,8 @@ concurrency:
   group: clawhub-cli-npm-release-${{ inputs.tag }}
   cancel-in-progress: false
 
+permissions: {}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24.x"

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -80,6 +80,8 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
+permissions: {}
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions: {}
+
 jobs:
   trufflehog:
     name: Scan for Verified Secrets

--- a/.github/workflows/update-convex-ai-files.yml
+++ b/.github/workflows/update-convex-ai-files.yml
@@ -10,6 +10,8 @@ concurrency:
   group: update-convex-ai-files
   cancel-in-progress: false
 
+permissions: {}
+
 env:
   BUN_VERSION: "1.3.10"
   UPDATE_BRANCH: automation/update-convex-ai-files


### PR DESCRIPTION
Summary
- add secops ownership for GitHub action, actionlint, and dependabot automation config
- default release, publish, secret-scan, and Convex automation workflows to top-level permissions: {}
- keep job-level permissions explicit where token access is required

Verification
- git diff --check
- actionlint