### PR TITLE
fix: wait for Convex functions before seeding worktrees

### DIFF
--- a/scripts/dev-worktree.test.ts
+++ b/scripts/dev-worktree.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { buildEnvFileCandidates, parseEnv, parseGitWorktreeList } from "./dev-worktree";
+import {
+  buildEnvFileCandidates,
+  isConvexFunctionUnavailableOutput,
+  parseEnv,
+  parseGitWorktreeList,
+} from "./dev-worktree";
 
 describe("dev-worktree helpers", () => {
   it("parses env files without treating inline comments as values", () => {
@@ -63,5 +68,17 @@ HEAD def456
 branch refs/heads/feature
 `),
     ).toEqual(["/Users/me/Git/openclaw/clawhub", "/tmp/worktrees/feature"]);
+  });
+
+  it("recognizes Convex functions that are not queryable yet", () => {
+    expect(
+      isConvexFunctionUnavailableOutput(`
+        Failed to run function "devSeed:seedNixSkills":
+        Could not find function for 'devSeed:seedNixSkills'. Did you forget to run \`npx convex dev\`?
+        No functions found.
+      `),
+    ).toBe(true);
+
+    expect(isConvexFunctionUnavailableOutput("AUTH_GITHUB_ID is required")).toBe(false);
   });
 });

--- a/scripts/dev-worktree.ts
+++ b/scripts/dev-worktree.ts
@@ -13,6 +13,7 @@ type Options = {
 
 const DEFAULT_ENV_SOURCES = [".env.local"];
 const CONVEX_START_TIMEOUT_MS = 120_000;
+const CONVEX_FUNCTIONS_READY_TIMEOUT_MS = 120_000;
 const REACHABILITY_POLL_MS = 500;
 const managedChildren = new Set<ChildProcess>();
 
@@ -153,6 +154,57 @@ function runSync(command: string, args: string[], extraEnv: Record<string, strin
   );
 }
 
+function runSyncBuffered(
+  command: string,
+  args: string[],
+  extraEnv: Record<string, string | undefined>,
+) {
+  const result = spawnSync(command, args, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: { ...process.env, ...extraEnv },
+  });
+
+  return {
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+    status: result.status ?? 1,
+  };
+}
+
+function writeBufferedOutput(output: string) {
+  if (output) process.stdout.write(output);
+}
+
+export function isConvexFunctionUnavailableOutput(output: string) {
+  return (
+    output.includes("Could not find function for") &&
+    output.includes("Did you forget to run `npx convex dev`")
+  );
+}
+
+async function runConvexFunctionWhenReady(args: string[]) {
+  const startedAt = Date.now();
+
+  while (true) {
+    const result = runSyncBuffered("bunx", args, {});
+    if (result.status === 0) {
+      writeBufferedOutput(result.output);
+      return 0;
+    }
+
+    if (
+      !isConvexFunctionUnavailableOutput(result.output) ||
+      Date.now() - startedAt >= CONVEX_FUNCTIONS_READY_TIMEOUT_MS
+    ) {
+      writeBufferedOutput(result.output);
+      return result.status;
+    }
+
+    console.log("Convex functions are not queryable yet; retrying...");
+    await sleep(REACHABILITY_POLL_MS);
+  }
+}
+
 function spawnManaged(command: string, args: string[]) {
   const child = spawn(command, args, {
     cwd: process.cwd(),
@@ -245,18 +297,27 @@ async function main() {
 
   if (options.seed) {
     console.log("Seeding sample skills...");
-    const seedStatus = runSync("bunx", ["convex", "run", "--no-push", "devSeed:seedNixSkills"], {});
+    const seedStatus = await runConvexFunctionWhenReady([
+      "convex",
+      "run",
+      "--no-push",
+      "devSeed:seedNixSkills",
+    ]);
     if (seedStatus !== 0) process.exit(seedStatus);
 
-    const statsStatus = runSync(
-      "bunx",
-      ["convex", "run", "--no-push", "statsMaintenance:updateGlobalStatsAction"],
-      {},
-    );
+    const statsStatus = await runConvexFunctionWhenReady([
+      "convex",
+      "run",
+      "--no-push",
+      "statsMaintenance:updateGlobalStatsAction",
+    ]);
     if (statsStatus !== 0) process.exit(statsStatus);
   }
 
-  if (options.seedOnly) return;
+  if (options.seedOnly) {
+    stopManagedChildren();
+    return;
+  }
 
   console.log(`Starting ClawHub from ${process.cwd()}`);
   console.log(`Using env file: ${envFile}`);


### PR DESCRIPTION
## Summary
- retry seeded worktree Convex run commands while local Convex is still making functions queryable
- keep non-readiness Convex failures failing immediately
- stop the managed Convex child before returning from `--seed-only`

## Reproduction
- Before this patch, `bun run dev:worktree -- --seed-only` failed twice while Convex was still preparing functions with `Could not find function for 'devSeed:seedNixSkills'`.
- After this patch, the same command retried until Convex functions were ready, seeded successfully, exited, and left port 3210 free.

## Tests
- `bunx vitest run scripts/dev-worktree.test.ts`
- `bun run format:check`
- `bun run lint`
- `git diff --check`
- `bun run dev:worktree -- --seed-only`

## AI assistance
AI-assisted; I reviewed the patch and verified the focused behavior locally.
