### PR TITLE
fix: keep browse sidebar below sticky header

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -7749,6 +7749,7 @@ code {
   max-width: var(--page-max);
   margin: 0 auto;
   padding: var(--space-5) var(--space-5) var(--space-7);
+  --browse-sticky-top: calc(128px + var(--space-4));
 }
 
 .browse-page-narrow {
@@ -7868,13 +7869,13 @@ code {
 
 .browse-sidebar {
   position: sticky;
-  top: 90px;
+  top: var(--browse-sticky-top);
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
   padding-right: 16px;
   border-right: 1px solid var(--line);
-  max-height: calc(100vh - 100px);
+  max-height: calc(100vh - var(--browse-sticky-top) - var(--space-4));
   overflow-y: auto;
   scrollbar-width: thin;
 }
@@ -8037,6 +8038,7 @@ code {
 
   .browse-page {
     padding: 16px 16px 40px;
+    --browse-sticky-top: calc(76px + var(--space-4));
   }
 
   .browse-page-search {


### PR DESCRIPTION
# fix: keep browse sidebar below sticky header

## Summary

- Makes the browse sidebar sticky relative to the global sticky header instead of using the previous hard-coded `90px` offset.
- Keeps the existing mobile behavior: the sidebar remains hidden/static unless the mobile filter toggle opens it.

## Behavior

New behavior (proposed):
https://i.imgur.com/Vax1tV2.mp4

Previous behavior:
https://i.imgur.com/8O9QAaJ.mp4

_The extra bottom spacing visible in the previous-behavior video is not included in this PR; it was applied locally only for testing._

## Why

On `/skills` and `/plugins`, the browse sidebar could scroll behind the sticky site header. This made the top of the filter list partially hidden while the header stayed fixed.

This PR keeps the change CSS-only and scoped to the browse layout.

## Validation

- `bun run format:check`
- `bun run lint`
- `bunx vitest run src/__tests__/header.test.tsx`
- Playwright viewport checks:
  - `/skills?sort=updated&dir=desc&featured=true` at `1146x943`, `1548x943`, and `600x943`
  - `/plugins` at `1146x943`, `1548x943`, and `600x943`
  - Desktop: sidebar top stayed below navbar bottom (`144px` vs `128px`)
  - Mobile: sidebar remained `display: none` / `position: static`

## Gate Notes

Decision: READY. Vyctor approved push/open in-thread.

Thesis: Browse sidebars should remain visible below the sticky global header on skills/plugins pages.

Scope: `src/styles.css` only.

Maintainer activity: checked open PRs and issue search for sticky/sidebar/header/browse overlap; no duplicate PR or issue found.

Public hygiene: pushed to the existing PR branch after local validation; no unrelated files.

## AI Assistance

AI-assisted. I reviewed the diff and ran the validation above.
