### PR TITLE
fix: keep local dev seed state deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Docs/dev: document the local Convex site proxy URL and make worktree setup reject misconfigured local site URLs that break HTTP routes (#2060) (thanks @vyctorbrzezowski).
+- Dev setup: make local seed reset deterministic by cleaning stale seed lookup and badge rows for repeated Convex dev runs (#2057) (thanks @vyctorbrzezowski).
 - Skills: repair publisher-owned skill merges, bound historical slug redirects, block protected slug namespaces, and expire owner-unpublished slug reservations after 30 days (#2115) (thanks @fuller-stack-dev).
 - Web: restore dashboard skill metrics for owned skills and use pointer cursors on dropdown menu items (#2113) (thanks @fuller-stack-dev).
 - Skills: allow confirmed owner migration when republishing an existing skill to another publisher, preserving versions, stats, aliases, and audit history (#1998, #2102) (thanks @momothemage).

--- a/convex/devSeed.rescanFixtures.test.ts
+++ b/convex/devSeed.rescanFixtures.test.ts
@@ -1,6 +1,21 @@
 import { describe, expect, it } from "vitest";
-import { seedRescanUxFixturesHandler } from "./devSeed";
+import {
+  seedFeaturedPluginPackagesMutation,
+  seedRescanUxFixturesHandler,
+  seedSkillMutation,
+} from "./devSeed";
 import { MAX_OWNER_RESCAN_REQUESTS_PER_RELEASE } from "./model/rescans/policy";
+
+type WrappedHandler<TArgs> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<unknown>;
+};
+
+const seedSkillMutationHandler = (
+  seedSkillMutation as unknown as WrappedHandler<Record<string, unknown>>
+)._handler;
+const seedFeaturedPluginPackagesHandler = (
+  seedFeaturedPluginPackagesMutation as unknown as WrappedHandler<Record<string, unknown>>
+)._handler;
 
 function chainEq(constraints: Record<string, unknown>) {
   return {
@@ -18,6 +33,7 @@ function matches(doc: Record<string, unknown>, constraints: Record<string, unkno
 function createDb() {
   const tables: Record<string, Array<Record<string, unknown> & { _id: string }>> = {};
   const counters: Record<string, number> = {};
+  const operations: Array<{ type: "delete"; table: string; id: string }> = [];
 
   const list = (table: string) => {
     tables[table] ??= [];
@@ -25,7 +41,8 @@ function createDb() {
   };
 
   const db = {
-    get: async (id: string) => {
+    get: async (arg0: string, arg1?: string) => {
+      const id = arg1 ?? arg0;
       const table = id.split(":")[0] ?? "";
       return list(table).find((doc) => doc._id === id) ?? null;
     },
@@ -39,17 +56,38 @@ function createDb() {
       list(table).push(inserted);
       return inserted._id;
     },
-    patch: async (id: string, patch: Record<string, unknown>) => {
+    patch: async (
+      arg0: string,
+      arg1: string | Record<string, unknown>,
+      arg2?: Record<string, unknown>,
+    ) => {
+      const id = arg2 ? (arg1 as string) : arg0;
+      const patch = arg2 ?? (arg1 as Record<string, unknown>);
       const table = id.split(":")[0] ?? "";
       const doc = list(table).find((candidate) => candidate._id === id);
       if (doc) Object.assign(doc, patch);
     },
-    delete: async (id: string) => {
+    replace: async (
+      arg0: string,
+      arg1: string | Record<string, unknown>,
+      arg2?: Record<string, unknown>,
+    ) => {
+      const id = arg2 ? (arg1 as string) : arg0;
+      const replacement = arg2 ?? (arg1 as Record<string, unknown>);
       const table = id.split(":")[0] ?? "";
+      const rows = list(table);
+      const index = rows.findIndex((doc) => doc._id === id);
+      if (index !== -1) rows[index] = { ...rows[index], ...replacement, _id: id };
+    },
+    delete: async (arg0: string, arg1?: string) => {
+      const id = arg1 ?? arg0;
+      const table = id.split(":")[0] ?? "";
+      operations.push({ type: "delete", table, id });
       const rows = list(table);
       const index = rows.findIndex((doc) => doc._id === id);
       if (index !== -1) rows.splice(index, 1);
     },
+    normalizeId: (tableName: string, id: string) => (id.startsWith(`${tableName}:`) ? id : null),
     query: (table: string) => ({
       withIndex: (_name: string, build: (q: ReturnType<typeof chainEq>) => unknown) => {
         const constraints: Record<string, unknown> = {};
@@ -59,15 +97,25 @@ function createDb() {
         return {
           collect: async () => matched(),
           unique: async () => matched()[0] ?? null,
+          paginate: async () => ({
+            page: matched(),
+            isDone: true,
+            continueCursor: null,
+          }),
           order: () => ({
             collect: async () => matched(),
+            paginate: async () => ({
+              page: matched(),
+              isDone: true,
+              continueCursor: null,
+            }),
           }),
         };
       },
     }),
   };
 
-  return { db, tables };
+  return { db, tables, operations };
 }
 
 describe("devSeed rescan UX fixtures", () => {
@@ -171,5 +219,97 @@ describe("devSeed rescan UX fixtures", () => {
       tables.rescanRequests?.filter((request) => request.targetKind === "plugin") ?? [];
     expect(skillRequests).toHaveLength(1);
     expect(pluginRequests).toHaveLength(MAX_OWNER_RESCAN_REQUESTS_PER_RELEASE);
+  });
+});
+
+describe("devSeed local catalog fixtures", () => {
+  function seedSkillArgs(storageId: string) {
+    const clawdis = {
+      os: ["linux"],
+      nix: {
+        plugin: "github:example/catalog-demo",
+        systems: ["x86_64-linux"],
+      },
+    };
+    return {
+      storageId,
+      metadata: { clawdbot: { nix: clawdis.nix } },
+      frontmatter: { name: "catalog-demo", description: "Catalog demo" },
+      clawdis,
+      skillMd: "# Catalog demo",
+      slug: "catalog-demo",
+      displayName: "Catalog Demo",
+      summary: "Seeded catalog demo.",
+      version: "0.1.0",
+    };
+  }
+
+  it("resets core skill fixtures without stale badges or embedding maps", async () => {
+    const { db, tables } = createDb();
+    const ctx = { db, scheduler: { runAfter: async () => null } };
+
+    await seedSkillMutationHandler(ctx as never, seedSkillArgs("storage:first") as never);
+    await seedSkillMutationHandler(
+      ctx as never,
+      { ...seedSkillArgs("storage:second"), reset: true } as never,
+    );
+
+    expect(tables.skills).toHaveLength(1);
+    expect(tables.skillVersions).toHaveLength(1);
+    expect(tables.skillEmbeddings).toHaveLength(1);
+    expect(tables.embeddingSkillMap).toHaveLength(1);
+    expect(tables.skillBadges).toHaveLength(1);
+    expect(tables.skillSearchDigest).toHaveLength(1);
+    expect(tables.skills?.[0]?.latestVersionSummary).toBeUndefined();
+    expect(tables.skillSearchDigest?.[0]?.latestVersionSummary).toBeUndefined();
+    expect(tables.skillVersions?.[0]).toEqual(
+      expect.objectContaining({
+        parsed: expect.objectContaining({
+          clawdis: expect.objectContaining({
+            os: ["linux"],
+            nix: expect.objectContaining({ systems: ["x86_64-linux"] }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("resets featured plugin fixtures without stale package badges", async () => {
+    const { db, tables, operations } = createDb();
+    const ctx = { db, scheduler: { runAfter: async () => null } };
+    const args = {
+      packages: [
+        {
+          name: "@local/catalog-plugin",
+          displayName: "Catalog Plugin",
+          summary: "Seeded catalog plugin.",
+          version: "1.0.0",
+          runtimeId: "catalog-plugin",
+          sourceRepo: "openclaw/catalog-plugin",
+          isOfficial: false,
+          capabilityTags: ["catalog"],
+          stats: { downloads: 1, installs: 1, stars: 1, versions: 1 },
+          storageId: "storage:plugin",
+          readmeSize: 16,
+        },
+      ],
+    };
+
+    await seedFeaturedPluginPackagesHandler(ctx as never, args as never);
+    const oldPackageId = tables.packages?.[0]?._id;
+    const oldReleaseId = tables.packageReleases?.[0]?._id;
+    await seedFeaturedPluginPackagesHandler(ctx as never, { ...args, reset: true } as never);
+
+    expect(tables.packages).toHaveLength(1);
+    expect(tables.packageReleases).toHaveLength(1);
+    expect(tables.packageBadges).toHaveLength(1);
+    const oldPackageDeleteIndex = operations.findIndex(
+      (op) => op.table === "packages" && op.id === oldPackageId,
+    );
+    const oldReleaseDeleteIndex = operations.findIndex(
+      (op) => op.table === "packageReleases" && op.id === oldReleaseId,
+    );
+    expect(oldPackageDeleteIndex).toBeGreaterThanOrEqual(0);
+    expect(oldReleaseDeleteIndex).toBeGreaterThan(oldPackageDeleteIndex);
   });
 });

--- a/convex/devSeed.ts
+++ b/convex/devSeed.ts
@@ -787,6 +787,44 @@ async function deleteRescanRequestsForPackageRelease(ctx: MutationCtx, releaseId
   for (const request of requests) await ctx.db.delete(request._id);
 }
 
+async function deleteEmbeddingMapsForEmbedding(
+  ctx: MutationCtx,
+  embeddingId: Id<"skillEmbeddings">,
+) {
+  const maps = await ctx.db
+    .query("embeddingSkillMap")
+    .withIndex("by_embedding", (q) => q.eq("embeddingId", embeddingId))
+    .collect();
+  for (const map of maps) await ctx.db.delete(map._id);
+}
+
+async function deleteSkillEmbeddingsForSkill(ctx: MutationCtx, skillId: Id<"skills">) {
+  const embeddings = await ctx.db
+    .query("skillEmbeddings")
+    .withIndex("by_skill", (q) => q.eq("skillId", skillId))
+    .collect();
+  for (const embedding of embeddings) {
+    await deleteEmbeddingMapsForEmbedding(ctx, embedding._id);
+    await ctx.db.delete(embedding._id);
+  }
+}
+
+async function deleteSkillBadgesForSkill(ctx: MutationCtx, skillId: Id<"skills">) {
+  const badges = await ctx.db
+    .query("skillBadges")
+    .withIndex("by_skill", (q) => q.eq("skillId", skillId))
+    .collect();
+  for (const badge of badges) await ctx.db.delete(badge._id);
+}
+
+async function deletePackageBadgesForPackage(ctx: MutationCtx, packageId: Id<"packages">) {
+  const badges = await ctx.db
+    .query("packageBadges")
+    .withIndex("by_package", (q) => q.eq("packageId", packageId))
+    .collect();
+  for (const badge of badges) await ctx.db.delete(badge._id);
+}
+
 async function deleteSeedSkillFixture(ctx: MutationCtx) {
   const existing = await findSeedSkillFixture(ctx);
   if (!existing) return;
@@ -811,6 +849,7 @@ async function deleteSeedSkillFixture(ctx: MutationCtx) {
     for (const map of maps) await ctx.db.delete(map._id);
     await ctx.db.delete(embedding._id);
   }
+  await deleteSkillBadgesForSkill(ctx, existing._id);
   await ctx.db.delete(existing._id);
 }
 
@@ -845,6 +884,7 @@ async function deleteScannedSkillFixture(ctx: MutationCtx) {
     for (const map of maps) await ctx.db.delete(map._id);
     await ctx.db.delete(embedding._id);
   }
+  await deleteSkillBadgesForSkill(ctx, existing._id);
   await ctx.db.delete(existing._id);
 }
 
@@ -863,11 +903,12 @@ async function deleteSeedPluginFixtureByName(ctx: MutationCtx, name: string) {
     .query("packageReleases")
     .withIndex("by_package", (q) => q.eq("packageId", existing._id))
     .collect();
+  await deletePackageBadgesForPackage(ctx, existing._id);
+  await ctx.db.delete(existing._id);
   for (const release of releases) {
     await deleteRescanRequestsForPackageRelease(ctx, release._id);
     await ctx.db.delete(release._id);
   }
-  await ctx.db.delete(existing._id);
 }
 
 async function deleteSeedPluginFixture(ctx: MutationCtx) {
@@ -2117,13 +2158,8 @@ export const seedSkillMutation = internalMutation({
       for (const version of versions) {
         await ctx.db.delete(version._id);
       }
-      const embeddings = await ctx.db
-        .query("skillEmbeddings")
-        .withIndex("by_skill", (q) => q.eq("skillId", existing._id))
-        .collect();
-      for (const embedding of embeddings) {
-        await ctx.db.delete(embedding._id);
-      }
+      await deleteSkillEmbeddingsForSkill(ctx, existing._id);
+      await deleteSkillBadgesForSkill(ctx, existing._id);
       await ctx.db.delete(existing._id);
     }
 


### PR DESCRIPTION
## Summary

- clean stale embedding map and badge rows when resetting seeded skill fixtures
- clean stale package badge rows when resetting seeded plugin fixtures
- make the documented local seed reset complete after featured plugin packages have already been seeded
- add focused coverage for reset cleanup and plugin fixture reset ordering

## Why

ClawHub's local browse surfaces are data-backed, so the documented dev seed reset should be repeatable against an existing local database. Before this change, reset paths could leave stale lookup or badge rows behind.

There was also a reset failure in the documented command path. After featured plugin packages existed, `devSeed:seedNixSkills {"reset": true}` could delete old package releases while the package fixture still existed. Each release delete runs the package release trigger, which may repoint the latest release through a paginated fallback query. Deleting multiple releases in the same mutation can hit Convex's single-paginated-query limit.

This keeps the fix scoped to dev seed cleanup. Reset now removes the package fixture before deleting its old releases, so release triggers do not try to repoint a package that is being discarded. It does not add visual fixture content or change production browse behavior.

## Validation

- `bunx vitest run convex/devSeed.rescanFixtures.test.ts`
  - `Test Files 1 passed (1)`
  - `Tests 3 passed (3)`
- `bun run format:check`
  - `All matched files use the correct format.`
- `bun run lint`
  - `Found 0 warnings and 0 errors.`
- `bunx tsc --noEmit`
- `git diff --check`
- `bunx convex run --no-push devSeed:seedNixSkills '{"reset": true}'`
  - returned `"ok": true`
  - recreated the seeded skills (`padel`, `gohome`, `xuezh`, `hanzi-helper`) and local rescan fixtures
  - recreated the featured plugin fixtures with `"skipped": []`
- `bunx convex run --no-push statsMaintenance:updateGlobalStatsAction`
  - returned `{ "count": 5 }`
- `bunx convex run --no-push skills:listPublicPageV4 '{"sort":"downloads","numItems":5}' | jq '[.page[] | {slug: .skill.slug, latestParsed: .latestVersion.parsed}]'`
  - seeded list rows returned `"latestParsed": null`, confirming this cleanup does not surface Clawdis-derived browse chips
