### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+
+- What changed:
+- Why:
+
+## Linked Issue
+
+- Closes #
+- Related #
+
+## Screenshots
+
+For website/UI changes, attach screenshots or recordings from the real app. Include mobile/narrow views when layout changes.
+
+- [ ] Screenshots/recordings attached, or `N/A`
+
+## Security / Trust Impact
+
+- [ ] No security/trust impact
+- [ ] Security/trust impact explained
+
+## Data / Deploy Impact
+
+- [ ] No data/deploy impact
+- [ ] Data/deploy impact explained
+
+## Verification
+
+- [ ] `bun run format:check`
+- [ ] `bun run lint`
+- [ ] `bun run test`
+- [ ] Other:


### PR DESCRIPTION
## Summary

- Adds a short GitHub pull request template for ClawHub.
- Makes screenshots/recordings a first-class prompt for website/UI changes.

## Verification

- [x] `bun run format:check`
- [ ] `bun run lint`
- [ ] `bun run test`

## Screenshots

N/A - PR template/documentation-only change.
