### PR TITLE
fix: align local Convex site URL setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Docs/dev: document the local Convex site proxy URL and make worktree setup reject misconfigured local site URLs that break HTTP routes (#2060) (thanks @vyctorbrzezowski).
 - Skills: repair publisher-owned skill merges, bound historical slug redirects, block protected slug namespaces, and expire owner-unpublished slug reservations after 30 days (#2115) (thanks @fuller-stack-dev).
 - Web: restore dashboard skill metrics for owned skills and use pointer cursors on dropdown menu items (#2113) (thanks @fuller-stack-dev).
 - Skills: allow confirmed owner migration when republishing an existing skill to another publisher, preserving versions, stats, aliases, and audit history (#1998, #2102) (thanks @momothemage).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,18 +25,23 @@ Edit `.env.local` with the following values for **local Convex**:
 ```bash
 # Frontend
 VITE_CONVEX_URL=http://127.0.0.1:3210
-VITE_CONVEX_SITE_URL=http://127.0.0.1:3210
+VITE_CONVEX_SITE_URL=http://127.0.0.1:3211
 SITE_URL=http://localhost:3000
+
+# Convex Auth / HTTP routes
+CONVEX_SITE_URL=http://127.0.0.1:3211
 
 # Deployment used by `bunx convex dev`
 CONVEX_DEPLOYMENT=anonymous:anonymous-clawhub
 ```
 
+Local Convex serves the function endpoint on port 3210 and HTTP routes (`/api/*` and auth callbacks) through the site proxy on port 3211.
+
 ### GitHub OAuth App (for login)
 
 1. Go to [github.com/settings/developers](https://github.com/settings/developers) and create a new OAuth App.
 2. Set **Homepage URL** to `http://localhost:3000`.
-3. Set **Authorization callback URL** to `http://127.0.0.1:3210/api/auth/callback/github`.
+3. Set **Authorization callback URL** to `http://127.0.0.1:3211/api/auth/callback/github`.
 4. Copy the Client ID and generate a Client Secret.
 
 ### Run the Convex backend
@@ -114,7 +119,7 @@ The CLI source lives in [`packages/clawhub/`](packages/clawhub/). Both `clawhub`
 To test the CLI against your local instance:
 
 ```bash
-CLAWHUB_REGISTRY=http://127.0.0.1:3210 CLAWHUB_SITE=http://localhost:3000 clawhub search "padel"
+CLAWHUB_REGISTRY=http://127.0.0.1:3211 CLAWHUB_SITE=http://localhost:3000 clawhub search "padel"
 ```
 
 Use the package-local verification contract when working on the CLI:

--- a/scripts/setup-worktree.test.ts
+++ b/scripts/setup-worktree.test.ts
@@ -4,16 +4,55 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { findSource } from "./setup-worktree";
 
-function writeWorktree(path: string, deploymentName: string) {
+function writeWorktree(
+  path: string,
+  deploymentName: string,
+  options?: {
+    env?: Record<string, string | null>;
+    ports?: { cloud: number; site?: number };
+  },
+) {
+  const cloudPort = options?.ports?.cloud ?? 3210;
+  const sitePort = options?.ports?.site ?? cloudPort + 1;
+  const env: Record<string, string> = {
+    CONVEX_DEPLOYMENT: `local:${deploymentName}`,
+    VITE_CONVEX_URL: `http://127.0.0.1:${cloudPort}`,
+    VITE_CONVEX_SITE_URL: `http://127.0.0.1:${sitePort}`,
+    CONVEX_SITE_URL: `http://127.0.0.1:${sitePort}`,
+  };
+
+  for (const [key, value] of Object.entries(options?.env ?? {})) {
+    if (value === null) {
+      delete env[key];
+    } else {
+      env[key] = value;
+    }
+  }
+
   mkdirSync(join(path, ".convex/local/default"), { recursive: true });
   writeFileSync(
     join(path, ".env.local"),
-    `CONVEX_DEPLOYMENT=local:${deploymentName}\nVITE_CONVEX_URL=http://127.0.0.1:3210\n`,
+    Object.entries(env)
+      .map(([key, value]) => `${key}=${value}`)
+      .join("\n") + "\n",
   );
   writeFileSync(
     join(path, ".convex/local/default/config.json"),
-    JSON.stringify({ deploymentName, ports: { cloud: 3210 } }),
+    JSON.stringify({ deploymentName, ports: options?.ports ?? { cloud: 3210, site: 3211 } }),
   );
+}
+
+function withSourceAndCurrent(run: (source: string, current: string) => void) {
+  const root = mkdtempSync(join(tmpdir(), "clawhub-worktree-"));
+  try {
+    const source = join(root, "source");
+    const current = join(root, "current");
+    mkdirSync(source);
+    mkdirSync(current);
+    run(source, current);
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
 }
 
 describe("setup-worktree", () => {
@@ -40,5 +79,98 @@ describe("setup-worktree", () => {
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
+  });
+
+  it("rejects local sources that point browser HTTP routes at the Convex function port", () => {
+    withSourceAndCurrent((source, current) => {
+      writeWorktree(source, "local-clawhub", {
+        env: { VITE_CONVEX_SITE_URL: "http://127.0.0.1:3210" },
+      });
+
+      expect(() =>
+        findSource(
+          {
+            force: false,
+            from: source,
+            quiet: true,
+          },
+          current,
+        ),
+      ).toThrow(
+        "VITE_CONVEX_SITE_URL port 3210 does not match .convex/local/default/config.json site port 3211",
+      );
+    });
+  });
+
+  it("rejects local sources without the server Convex site URL used by auth", () => {
+    withSourceAndCurrent((source, current) => {
+      writeWorktree(source, "local-clawhub", { env: { CONVEX_SITE_URL: null } });
+
+      expect(() =>
+        findSource(
+          {
+            force: false,
+            from: source,
+            quiet: true,
+          },
+          current,
+        ),
+      ).toThrow(
+        "CONVEX_SITE_URL is required for local Convex HTTP routes; set it to http://127.0.0.1:3211",
+      );
+    });
+  });
+
+  it("rejects local site URLs without an explicit site proxy port", () => {
+    withSourceAndCurrent((source, current) => {
+      writeWorktree(source, "local-clawhub", {
+        env: { VITE_CONVEX_SITE_URL: "http://127.0.0.1" },
+      });
+
+      expect(() =>
+        findSource(
+          {
+            force: false,
+            from: source,
+            quiet: true,
+          },
+          current,
+        ),
+      ).toThrow("VITE_CONVEX_SITE_URL must include local site proxy port 3211");
+    });
+  });
+
+  it("uses the configured local site port when it is not cloud port plus one", () => {
+    withSourceAndCurrent((source, current) => {
+      writeWorktree(source, "local-clawhub", { ports: { cloud: 3210, site: 4321 } });
+
+      expect(
+        findSource(
+          {
+            force: false,
+            from: source,
+            quiet: true,
+          },
+          current,
+        ).path,
+      ).toBe(source);
+    });
+  });
+
+  it("falls back to the next port for older local configs without a site port", () => {
+    withSourceAndCurrent((source, current) => {
+      writeWorktree(source, "local-clawhub", { ports: { cloud: 3210 } });
+
+      expect(
+        findSource(
+          {
+            force: false,
+            from: source,
+            quiet: true,
+          },
+          current,
+        ).path,
+      ).toBe(source);
+    });
   });
 });

--- a/scripts/setup-worktree.ts
+++ b/scripts/setup-worktree.ts
@@ -12,7 +12,7 @@ type Options = {
 type Source = {
   path: string;
   env: Record<string, string>;
-  convexConfig: { deploymentName?: string; ports?: { cloud?: number } } | null;
+  convexConfig: { deploymentName?: string; ports?: { cloud?: number; site?: number } } | null;
 };
 
 const LOCAL_CONVEX_CONFIG = ".convex/local/default/config.json";
@@ -87,6 +87,38 @@ function readSource(path: string): Source | null {
   };
 }
 
+function isLocalHost(hostname: string) {
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "0.0.0.0" ||
+    hostname === "[::1]"
+  );
+}
+
+function validateLocalSiteUrl(name: string, value: string | undefined, expectedPort: number) {
+  if (!value) {
+    return `${name} is required for local Convex HTTP routes; set it to http://127.0.0.1:${expectedPort}`;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return `${name} is not a valid URL`;
+  }
+
+  if (!isLocalHost(url.hostname)) return null;
+
+  const port = Number(url.port);
+  if (!port) return `${name} must include local site proxy port ${expectedPort}`;
+  if (port !== expectedPort) {
+    return `${name} port ${port} does not match ${LOCAL_CONVEX_CONFIG} site port ${expectedPort}`;
+  }
+
+  return null;
+}
+
 function validateSource(source: Source) {
   const deployment = source.env.CONVEX_DEPLOYMENT;
   if (!deployment) return "missing CONVEX_DEPLOYMENT";
@@ -109,6 +141,23 @@ function validateSource(source: Source) {
       } catch {
         return "VITE_CONVEX_URL is not a valid URL";
       }
+    }
+
+    const sitePort = source.convexConfig.ports?.site ?? (configPort ? configPort + 1 : null);
+    if (sitePort) {
+      const invalidViteSiteUrl = validateLocalSiteUrl(
+        "VITE_CONVEX_SITE_URL",
+        source.env.VITE_CONVEX_SITE_URL,
+        sitePort,
+      );
+      if (invalidViteSiteUrl) return invalidViteSiteUrl;
+
+      const invalidServerSiteUrl = validateLocalSiteUrl(
+        "CONVEX_SITE_URL",
+        source.env.CONVEX_SITE_URL,
+        sitePort,
+      );
+      if (invalidServerSiteUrl) return invalidServerSiteUrl;
     }
   }
 


### PR DESCRIPTION
## Summary
- document the local Convex site proxy on port 3211 for `VITE_CONVEX_SITE_URL`, `CONVEX_SITE_URL`, the OAuth callback, and the local CLI registry smoke command
- make `setup:worktree` reject local sources that point Convex site URLs at the cloud/functions port
- cover missing site URL, missing local port, configured site ports, and the legacy `cloud + 1` fallback in `setup-worktree` tests

## Why
Local Convex exposes the function/cloud endpoint on port 3210 and HTTP routes through the site proxy on port 3211. The current contributing guide points local HTTP-route consumers at port 3210, so routes such as `/api/v1/plugins` return 404 even when local package data exists.

## Scope
This does not change production URL resolution, app routing, Convex HTTP handlers, or seeded data. It only fixes local setup docs and the worktree bootstrap guard for local Convex state.

## Behavior proof
- `curl -i http://127.0.0.1:3210/api/v1/plugins?limit=1` -> `404 Not Found`
- `curl -i http://127.0.0.1:3211/api/v1/plugins?limit=1` -> `200 OK` with `Yuanbao`
- `curl -i http://127.0.0.1:3210/api/v1/search?q=padel` -> `404 Not Found`
- `curl -i http://127.0.0.1:3211/api/v1/search?q=padel` -> `200 OK` with `Padel`
- with `VITE_CONVEX_SITE_URL=http://127.0.0.1:3211`, `GET /plugins` SSR returned `11 plugins` including `Yuanbao` and `wecom` instead of the unavailable catalog state

## Validation
- `bunx vitest run scripts/setup-worktree.test.ts scripts/dev-worktree.test.ts`
- `bun run format:check`
- `bun run lint`
- `bun run deadcode:ci`
- `bunx tsc --noEmit`
- `VITE_CONVEX_URL=https://example.invalid bun run build`
