### PR TITLE
Make security review badges neutral

### DIFF
--- a/src/components/DetailSecuritySummary.tsx
+++ b/src/components/DetailSecuritySummary.tsx
@@ -56,7 +56,7 @@ function badgeVariantForScanStatus(status: string): BadgeProps["variant"] {
   const normalized = status.toLowerCase();
   if (normalized === "clean" || normalized === "benign") return "success";
   if (normalized === "cleared") return "success";
-  if (normalized === "suspicious") return "warning";
+  if (normalized === "suspicious") return "default";
   if (normalized === "malicious" || normalized === "error") return "destructive";
   if (normalized === "pending" || normalized === "queued" || normalized === "loading") {
     return "pending";

--- a/src/styles.css
+++ b/src/styles.css
@@ -6331,8 +6331,8 @@ code {
 }
 
 .scan-status-suspicious {
-  background: rgba(245, 158, 11, 0.1);
-  color: #f59e0b;
+  background: var(--hover-bg);
+  color: var(--ink-soft);
 }
 
 .scan-status-pending {


### PR DESCRIPTION
## Summary
- Change suspicious security scan badges labeled `Review` from yellow warning styling to neutral gray styling.
- Keep the user-facing `Review` wording unchanged while aligning the badge treatment across scan pages and detail summaries.

## Tests
- `bun run test src/components/SkillSecurityScanResults.test.tsx src/components/DetailSecuritySummary.test.tsx`
- `bun run format:check`
- `bun run lint`
- `git diff --check`
