### PR TITLE
chore: remove stale maintenance helpers

### DIFF
--- a/convex/maintenance.test.ts
+++ b/convex/maintenance.test.ts
@@ -21,7 +21,6 @@ vi.mock("./_generated/api", () => ({
       nominateUserForEmptySkillSpamInternal: Symbol("nominateUserForEmptySkillSpamInternal"),
       cleanupEmptySkillsInternal: Symbol("cleanupEmptySkillsInternal"),
       nominateEmptySkillSpammersInternal: Symbol("nominateEmptySkillSpammersInternal"),
-      backfillConfirmedReportStatusesInternal: Symbol("backfillConfirmedReportStatusesInternal"),
     },
     skills: {
       backfillLatestSkillModerationInternal: Symbol("skills.backfillLatestSkillModerationInternal"),
@@ -40,7 +39,6 @@ vi.mock("./lib/skillSummary", () => ({
 
 const {
   backfillLatestVersionSummaryInternal,
-  backfillConfirmedReportStatusesInternalHandler,
   backfillSkillFingerprintsInternalHandler,
   backfillSkillSummariesInternalHandler,
   backfillUserStatsInternalHandler,
@@ -56,77 +54,6 @@ function makeBlob(text: string) {
 }
 
 describe("maintenance backfill", () => {
-  it("backfills legacy report triaged statuses to confirmed", async () => {
-    const patch = vi.fn();
-    const query = vi.fn((table: string) => {
-      const page =
-        table === "skillReports"
-          ? [{ _id: "skillReports:1" }, { _id: "skillReports:2" }]
-          : [{ _id: "packageReports:1" }];
-      return {
-        withIndex: vi.fn((_index: string, cb: (q: { eq: typeof vi.fn }) => unknown) => {
-          cb({ eq: vi.fn() });
-          return {
-            order: vi.fn(() => ({
-              take: vi.fn(async () => page),
-            })),
-          };
-        }),
-      };
-    });
-
-    const result = await backfillConfirmedReportStatusesInternalHandler(
-      { db: { query, patch } } as never,
-      { batchSize: 10 },
-    );
-
-    expect(result).toMatchObject({
-      ok: true,
-      dryRun: false,
-      hasMore: false,
-      stats: {
-        skillReportsScanned: 2,
-        skillReportsPatched: 2,
-        packageReportsScanned: 1,
-        packageReportsPatched: 1,
-      },
-    });
-    expect(patch).toHaveBeenCalledWith("skillReports:1", { status: "confirmed" });
-    expect(patch).toHaveBeenCalledWith("skillReports:2", { status: "confirmed" });
-    expect(patch).toHaveBeenCalledWith("packageReports:1", { status: "confirmed" });
-  });
-
-  it("can dry-run the legacy report status backfill", async () => {
-    const patch = vi.fn();
-    const query = vi.fn(() => ({
-      withIndex: vi.fn((_index: string, cb: (q: { eq: typeof vi.fn }) => unknown) => {
-        cb({ eq: vi.fn() });
-        return {
-          order: vi.fn(() => ({
-            take: vi.fn(async () => [{ _id: "reports:1" }] as Array<{ _id: string }>),
-          })),
-        };
-      }),
-    }));
-
-    const result = await backfillConfirmedReportStatusesInternalHandler(
-      { db: { query, patch } } as never,
-      { batchSize: 1, dryRun: true },
-    );
-
-    expect(result).toMatchObject({
-      dryRun: true,
-      hasMore: true,
-      stats: {
-        skillReportsScanned: 1,
-        skillReportsPatched: 0,
-        packageReportsScanned: 1,
-        packageReportsPatched: 0,
-      },
-    });
-    expect(patch).not.toHaveBeenCalled();
-  });
-
   it("repairs summary + parsed by reparsing SKILL.md", async () => {
     const runQuery = vi.fn().mockResolvedValue({
       items: [

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -1,7 +1,7 @@
 import { ConvexError, v } from "convex/values";
 import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
-import type { ActionCtx, MutationCtx } from "./_generated/server";
+import type { ActionCtx } from "./_generated/server";
 import { action, internalAction, internalMutation, internalQuery } from "./functions";
 import { assertRole, requireUserFromAction } from "./lib/access";
 import { buildSkillSummaryBackfillPatch, type ParsedSkillData } from "./lib/skillBackfill";
@@ -29,14 +29,6 @@ const DEFAULT_EMPTY_SKILL_MAX_README_BYTES = 8000;
 const DEFAULT_EMPTY_SKILL_NOMINATION_THRESHOLD = 3;
 const DEFAULT_CAPABILITY_BACKFILL_DELAY_MS = 500;
 const PLATFORM_SKILL_LICENSE = "MIT-0" as const;
-
-type ReportStatusBackfillStats = {
-  skillReportsScanned: number;
-  skillReportsPatched: number;
-  packageReportsScanned: number;
-  packageReportsPatched: number;
-  batches: number;
-};
 
 type BackfillStats = {
   skillsScanned: number;
@@ -550,70 +542,6 @@ export const applySkillCapabilityTagsInternal = internalMutation({
     }
 
     return { ok: true as const, versionPatched, skillPatched };
-  },
-});
-
-export const softDeleteSkillVersionsInternal = internalMutation({
-  args: {
-    actorUserId: v.id("users"),
-    slug: v.string(),
-    versionIds: v.array(v.id("skillVersions")),
-    reason: v.string(),
-  },
-  handler: async (ctx, args) => {
-    const actor = await ctx.db.get(args.actorUserId);
-    if (!actor || actor.deletedAt || actor.deactivatedAt) {
-      throw new ConvexError("Actor not found");
-    }
-    assertRole(actor, ["admin", "moderator"]);
-
-    const slug = args.slug.trim().toLowerCase();
-    if (!slug) throw new ConvexError("Slug required");
-    if (args.versionIds.length === 0) throw new ConvexError("versionIds required");
-
-    const skill = await ctx.db
-      .query("skills")
-      .withIndex("by_slug", (q) => q.eq("slug", slug))
-      .unique();
-    if (!skill) throw new ConvexError("Skill not found");
-
-    const latestId = skill.latestVersionId ?? skill.tags.latest;
-    const now = Date.now();
-    const deleted: string[] = [];
-    const skipped: Array<{ versionId: string; reason: string }> = [];
-
-    for (const versionId of new Set(args.versionIds)) {
-      const version = await ctx.db.get(versionId);
-      if (!version || version.skillId !== skill._id) {
-        skipped.push({ versionId, reason: "missing_or_wrong_skill" });
-        continue;
-      }
-      if (version._id === latestId) {
-        throw new ConvexError("Refusing to soft-delete latest skill version");
-      }
-      if (version.softDeletedAt) {
-        skipped.push({ versionId, reason: "already_deleted" });
-        continue;
-      }
-      await ctx.db.patch(version._id, { softDeletedAt: now });
-      deleted.push(version.version);
-    }
-
-    await ctx.db.insert("auditLogs", {
-      actorUserId: actor._id,
-      action: "skill_versions.soft_delete",
-      targetType: "skill",
-      targetId: skill._id,
-      metadata: {
-        slug,
-        deleted,
-        skipped,
-        reason: args.reason,
-      },
-      createdAt: now,
-    });
-
-    return { ok: true as const, slug, deleted, skipped };
   },
 });
 
@@ -2052,111 +1980,6 @@ export const backfillLatestSkillModeration: ReturnType<typeof action> = action({
     const { user } = await requireUserFromAction(ctx);
     assertRole(user, ["admin"]);
     return await ctx.runMutation(internal.skills.backfillLatestSkillModerationInternal, args);
-  },
-});
-
-export async function backfillConfirmedReportStatusesInternalHandler(
-  ctx: Pick<MutationCtx, "db">,
-  args: {
-    batchSize?: number;
-    dryRun?: boolean;
-  },
-) {
-  const batchSize = clampInt(args.batchSize ?? 100, 1, 500);
-  const dryRun = args.dryRun ?? false;
-
-  const skillReports = await ctx.db
-    .query("skillReports")
-    .withIndex("by_status_createdAt", (q) => q.eq("status", "triaged"))
-    .order("asc")
-    .take(batchSize);
-  const packageReports = await ctx.db
-    .query("packageReports")
-    .withIndex("by_status_createdAt", (q) => q.eq("status", "triaged"))
-    .order("asc")
-    .take(batchSize);
-
-  if (!dryRun) {
-    for (const report of skillReports) {
-      await ctx.db.patch(report._id, { status: "confirmed" });
-    }
-    for (const report of packageReports) {
-      await ctx.db.patch(report._id, { status: "confirmed" });
-    }
-  }
-
-  return {
-    ok: true as const,
-    dryRun,
-    hasMore: skillReports.length === batchSize || packageReports.length === batchSize,
-    stats: {
-      skillReportsScanned: skillReports.length,
-      skillReportsPatched: dryRun ? 0 : skillReports.length,
-      packageReportsScanned: packageReports.length,
-      packageReportsPatched: dryRun ? 0 : packageReports.length,
-    },
-  };
-}
-
-export const backfillConfirmedReportStatusesInternal = internalMutation({
-  args: {
-    batchSize: v.optional(v.number()),
-    dryRun: v.optional(v.boolean()),
-  },
-  handler: backfillConfirmedReportStatusesInternalHandler,
-});
-
-// Normalize legacy report outcome rows after deploying the confirmed/dismissed
-// report status contract:
-//   npx convex run maintenance:backfillConfirmedReportStatuses '{"dryRun":true}' --prod
-//   npx convex run maintenance:backfillConfirmedReportStatuses '{"batchSize":100,"maxBatches":20}' --prod
-export const backfillConfirmedReportStatuses: ReturnType<typeof action> = action({
-  args: {
-    batchSize: v.optional(v.number()),
-    maxBatches: v.optional(v.number()),
-    dryRun: v.optional(v.boolean()),
-  },
-  handler: async (ctx, args) => {
-    const { user } = await requireUserFromAction(ctx);
-    assertRole(user, ["admin"]);
-
-    const batchSize = clampInt(args.batchSize ?? 100, 1, 500);
-    const maxBatches = clampInt(args.maxBatches ?? 10, 1, 100);
-    const stats: ReportStatusBackfillStats = {
-      skillReportsScanned: 0,
-      skillReportsPatched: 0,
-      packageReportsScanned: 0,
-      packageReportsPatched: 0,
-      batches: 0,
-    };
-    let hasMore = false;
-
-    for (let i = 0; i < maxBatches; i += 1) {
-      const result = (await ctx.runMutation(
-        internal.maintenance.backfillConfirmedReportStatusesInternal,
-        {
-          batchSize,
-          dryRun: args.dryRun,
-        },
-      )) as {
-        hasMore: boolean;
-        stats: Omit<ReportStatusBackfillStats, "batches">;
-      };
-      stats.skillReportsScanned += result.stats.skillReportsScanned;
-      stats.skillReportsPatched += result.stats.skillReportsPatched;
-      stats.packageReportsScanned += result.stats.packageReportsScanned;
-      stats.packageReportsPatched += result.stats.packageReportsPatched;
-      stats.batches += 1;
-      hasMore = result.hasMore;
-      if (args.dryRun || !hasMore) break;
-    }
-
-    return {
-      ok: true as const,
-      dryRun: args.dryRun ?? false,
-      isDone: !hasMore,
-      stats,
-    };
   },
 });
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -74,9 +74,8 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   `packageModerationEventLogs`.
 - Public queries hide non-active moderation statuses; moderators can still access via
   moderator-only queries and unhide/restore/delete/ban.
-- Legacy report rows with `status: "triaged"` are normalized to `confirmed` by
-  `maintenance:backfillConfirmedReportStatuses`. Run a dry run after deploy,
-  then apply the backfill until `isDone` is true.
+- Legacy report rows with `status: "triaged"` are read as `confirmed` for
+  compatibility while new writes store `confirmed`.
 - Skills directory supports an optional "Hide suspicious" filter to exclude
   active-but-flagged (`flagged.suspicious`) entries from browse/search results.
 


### PR DESCRIPTION
## Summary
- remove the completed `triaged` -> `confirmed` report status maintenance backfill
- remove the unused direct skill-version soft-delete maintenance mutation
- update security docs to describe legacy `triaged` read compatibility instead of a runnable backfill

## Validation
- `bunx convex codegen`
- `bun run test convex/maintenance.test.ts`
- `bun run format:check`
- `bun run lint`
