### PR TITLE
Fix clawhub-mod installer

### DIFF
--- a/packages/clawhub-mod/package.json
+++ b/packages/clawhub-mod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/clawhub-mod",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Moderator-only ClawHub operator CLI for platform moderation and package operations.",
   "homepage": "https://clawhub.ai",

--- a/scripts/install-clawhub-mod.sh
+++ b/scripts/install-clawhub-mod.sh
@@ -107,7 +107,11 @@ fi
 tarball="$(find "$tmpdir" -type f -name "*.tgz" -print | sort | head -n 1)"
 
 echo "Installing ${tarball}..."
-npm install -g "${tarball}" "${npm_args[@]}"
+if [[ "${#npm_args[@]}" -gt 0 ]]; then
+  npm install -g "${tarball}" "${npm_args[@]}"
+else
+  npm install -g "${tarball}"
+fi
 
 echo "Installed:"
 clawhub-mod --cli-version


### PR DESCRIPTION
## Summary
- avoid expanding empty npm args under macOS Bash nounset
- bump clawhub-mod to 0.1.1 for a clean moderator CLI release

## Validation
- `bash -n scripts/install-clawhub-mod.sh && bash scripts/install-clawhub-mod.sh --help`
- `bun run --cwd packages/clawhub-mod verify`
- `bun run format:check`