### PR TITLE
fix(skills): block owner from undeleting moderator-hidden skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Security: block owner delete/undelete paths from overriding moderator or scanner hides, and return explicit 403 authz responses for owner restore denials (#2078) (thanks @momothemage).
 - CLI/API: allow skill publishes to target an org/user publisher with `--owner` / `ownerHandle`, and keep root `SKILL.md` publishable even when broad ignore rules match Markdown files (thanks @deepujain).
 - Packages: expose owned plugin/package soft-delete in the CLI and dashboard, keep moderator takedown access, and remove deleted packages from package search surfaces (thanks @Patrick-Erichsen).
 - Packages: support monorepo package publishes, infer package owners from scoped names, and keep dry-run publishes metadata-only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+
+### Fixes
+- Security: block owner delete/undelete paths from overriding moderator or scanner hides, and return explicit 403 authz responses for owner restore denials (#2078) (thanks @momothemage).
+
+
 ## 0.12.3 - 2026-05-06
 
 ### Fixes
 
-- Security: block owner delete/undelete paths from overriding moderator or scanner hides, and return explicit 403 authz responses for owner restore denials (#2078) (thanks @momothemage).
 - CLI/API: allow skill publishes to target an org/user publisher with `--owner` / `ownerHandle`, and keep root `SKILL.md` publishable even when broad ignore rules match Markdown files (thanks @deepujain).
 - Packages: expose owned plugin/package soft-delete in the CLI and dashboard, keep moderator takedown access, and remove deleted packages from package search surfaces (thanks @Patrick-Erichsen).
 - Packages: support monorepo package publishes, infer package owners from scoped names, and keep dry-run publishes metadata-only.

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -6778,4 +6778,37 @@ describe("httpApiV1 handlers", () => {
     expect(unknown.status).toBe(500);
     expect(await unknown.text()).toBe("Internal Server Error");
   });
+
+  // Regression: owner undelete gate throws a ConvexError prefixed with
+  // "Forbidden:" so the HTTP layer returns a deterministic 403 and surfaces
+  // the actionable reason ("hidden by moderation") instead of falling through
+  // to a generic 500.
+  it("owner undelete denial returns 403 with moderation reason in body", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:owner",
+      user: { handle: "p" },
+    } as never);
+
+    const moderationMessage =
+      "Forbidden: This skill was hidden by moderation and cannot be restored by the owner. Please contact a moderator.";
+    const runMutationModerationDenied = vi.fn(
+      async (_query: unknown, args: Record<string, unknown>) => {
+        if ("key" in args) return okRate();
+        // Mirror ConvexError shape: Error subclass whose message carries the
+        // "Forbidden:" sentinel so softDeleteErrorToResponse routes to 403.
+        throw new Error(moderationMessage);
+      },
+    );
+
+    const response = await __handlers.skillsPostRouterV1Handler(
+      makeCtx({ runMutation: runMutationModerationDenied }),
+      new Request("https://example.com/api/v1/skills/demo/undelete", {
+        method: "POST",
+        headers: { Authorization: "Bearer clh_test" },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe(moderationMessage);
+  });
 });

--- a/convex/httpApiV1/shared.ts
+++ b/convex/httpApiV1/shared.ts
@@ -357,8 +357,10 @@ export function softDeleteErrorToResponse(
   const message = error instanceof Error ? error.message : `${entity} delete failed`;
   const lower = message.toLowerCase();
 
-  if (lower.includes("unauthorized")) return text(formatAuthzMessage(error, "Unauthorized"), 401, headers);
-  if (lower.includes("forbidden")) return text(formatAuthzMessage(error, "Forbidden"), 403, headers);
+  if (lower.includes("unauthorized"))
+    return text(formatAuthzMessage(error, "Unauthorized"), 401, headers);
+  if (lower.includes("forbidden"))
+    return text(formatAuthzMessage(error, "Forbidden"), 403, headers);
   if (lower.includes("not found")) return text(message, 404, headers);
   if (lower.includes("slug required")) return text("Slug required", 400, headers);
 
@@ -379,10 +381,7 @@ function formatAuthFailure(error: unknown) {
 // - Otherwise returns the full message (minus the `ConvexError:` prefix) so
 //   CLI/API clients can surface actionable reasons such as
 //   "Forbidden: This skill was hidden by moderation ...".
-export function formatAuthzMessage(
-  error: unknown,
-  fallback: "Unauthorized" | "Forbidden",
-) {
+export function formatAuthzMessage(error: unknown, fallback: "Unauthorized" | "Forbidden") {
   const message = error instanceof Error ? error.message.trim() : "";
   if (!message) return fallback;
   const stripped = message.replace(/^ConvexError:\s*/i, "").trim();

--- a/convex/httpApiV1/shared.ts
+++ b/convex/httpApiV1/shared.ts
@@ -357,8 +357,8 @@ export function softDeleteErrorToResponse(
   const message = error instanceof Error ? error.message : `${entity} delete failed`;
   const lower = message.toLowerCase();
 
-  if (lower.includes("unauthorized")) return text(formatAuthFailure(error), 401, headers);
-  if (lower.includes("forbidden")) return text("Forbidden", 403, headers);
+  if (lower.includes("unauthorized")) return text(formatAuthzMessage(error, "Unauthorized"), 401, headers);
+  if (lower.includes("forbidden")) return text(formatAuthzMessage(error, "Forbidden"), 403, headers);
   if (lower.includes("not found")) return text(message, 404, headers);
   if (lower.includes("slug required")) return text("Slug required", 400, headers);
 
@@ -370,4 +370,22 @@ function formatAuthFailure(error: unknown) {
   const message = error instanceof Error ? error.message.trim() : "";
   if (!message || /^unauthorized$/i.test(message)) return "Unauthorized";
   return message.replace(/^ConvexError:\s*/i, "").trim() || "Unauthorized";
+}
+
+// Shared formatter for authz responses.
+// - Returns the clean fallback ("Unauthorized" | "Forbidden") when the error
+//   carries no additional context beyond the fallback itself (so existing
+//   callers that throw `new Error("Forbidden")` keep their body unchanged).
+// - Otherwise returns the full message (minus the `ConvexError:` prefix) so
+//   CLI/API clients can surface actionable reasons such as
+//   "Forbidden: This skill was hidden by moderation ...".
+export function formatAuthzMessage(
+  error: unknown,
+  fallback: "Unauthorized" | "Forbidden",
+) {
+  const message = error instanceof Error ? error.message.trim() : "";
+  if (!message) return fallback;
+  const stripped = message.replace(/^ConvexError:\s*/i, "").trim();
+  if (!stripped || stripped.toLowerCase() === fallback.toLowerCase()) return fallback;
+  return stripped;
 }

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -21,6 +21,7 @@ import type {
 import { publishVersionForUser } from "../skills";
 import {
   MAX_RAW_FILE_BYTES,
+  formatAuthzMessage,
   getPathSegments,
   json,
   parseJsonPayload,
@@ -1080,12 +1081,6 @@ function ownershipErrorToResponse(error: unknown, headers: HeadersInit) {
     return text(formatAuthzMessage(error, "Forbidden"), 403, headers);
   if (lower.includes("not found")) return text(message, 404, headers);
   return text(message, 400, headers);
-}
-
-function formatAuthzMessage(error: unknown, fallback: "Unauthorized" | "Forbidden") {
-  const message = error instanceof Error ? error.message.trim() : "";
-  if (!message || message.toLowerCase() === fallback.toLowerCase()) return fallback;
-  return message.replace(/^ConvexError:\s*/i, "").trim() || fallback;
 }
 
 async function resolveTransferContext(

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -8126,8 +8126,27 @@ export const setSkillSoftDeletedInternal = internalMutation({
       .unique();
     if (!skill) throw new Error("Skill not found");
 
-    if (skill.ownerUserId !== args.userId) {
+    const isModeratorOrAdmin = user.role === "admin" || user.role === "moderator";
+    const isOwner = skill.ownerUserId === args.userId;
+
+    if (!isOwner && !isModeratorOrAdmin) {
+      // Preserve legacy behavior: delegate to assertModerator to produce the
+      // standard "Forbidden" error for non-owners without elevated roles.
       assertModerator(user);
+    }
+
+    // gate: when an owner (without moderator/admin privileges) attempts to
+    // undelete a skill, only allow it if the current hidden state was produced
+    // by the owner themselves (i.e. via `clawhub delete`). Any other hidden
+    // state originates from moderation, scanning, merges, bans, or security
+    // redaction — only moderators/admins may lift those.
+    if (!args.deleted && isOwner && !isModeratorOrAdmin) {
+      const reason = skill.moderationReason;
+      if (reason !== undefined) {
+        throw new ConvexError(
+          "This skill was hidden by moderation and cannot be restored by the owner. Please contact a moderator.",
+        );
+      }
     }
 
     const now = Date.now();
@@ -8155,6 +8174,7 @@ export const setSkillSoftDeletedInternal = internalMutation({
       metadata: {
         slug,
         softDeletedAt: args.deleted ? now : null,
+        actorRole: user.role ?? "user",
         ...(note ? { reason: note } : {}),
       },
       createdAt: now,

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -8151,19 +8151,27 @@ export const setSkillSoftDeletedInternal = internalMutation({
     // state originates from moderation, scanning, merges, bans, or security
     // redaction — only moderators/admins may lift those.
     //
-    // Authorization is based on the *source of the hide*, not whether
-    // `moderationReason` happens to be populated:
+    // Authorization is based on the *source of the hide* (`hiddenBy`), plus
+    // an explicit deny list of `moderationReason` values that are known to
+    // be system- or admin-originated even when the raw `hiddenBy` happens
+    // to equal the owner (e.g. owner-initiated merges stamp both
+    // `hiddenBy = ownerUserId` AND `moderationReason = "owner.merged"` and
+    // must NOT be reversible through the generic undelete path).
     //
-    //   - `hiddenBy === args.userId` means the owner soft-deleted this record
-    //     themselves. This is the only self-service undelete case.
-    //   - A moderator hiding via `setSoftDeleted` records `hiddenBy = mod._id`
-    //     but does NOT write `moderationReason`, so a reason-only check would
-    //     let the owner reverse moderator decisions (the previous gate was
-    //     incorrect on this path).
-    //   - Merge soft-deletes via the owner (mergeOwnedSkillIntoCanonical) set
-    //     `hiddenBy = ownerUserId` AND `moderationReason = "owner.merged"`,
-    //     so we additionally require `moderationReason === undefined` to
-    //     prevent undelete from reversing merges through the wrong path.
+    //   - `hiddenBy === args.userId` is the necessary baseline. A moderator
+    //     hiding via `setSoftDeleted` records `hiddenBy = mod._id`, so the
+    //     owner simply fails this check. A security redaction / auto-ban
+    //     likewise records an admin/system actor, so those naturally fail.
+    //   - The deny list below catches the remaining paths where `hiddenBy`
+    //     may equal the owner (merges) or may be stale from a prior owner
+    //     delete while a later system patch wrote only `moderationReason`
+    //     without refreshing `hiddenBy` (e.g. `auto.reports`).
+    //   - Benign scanner / pipeline reasons such as `pending.scan`,
+    //     `scanner.aggregate.clean`, or `scanner.<scanner>.clean` describe
+    //     the skill's moderation state, not the cause of the current hide,
+    //     so they must NOT block owner self-restore. Requiring
+    //     `moderationReason === undefined` here previously broke the common
+    //     owner delete → owner undelete flow for every healthy skill.
     //   - If `hiddenBy` is somehow missing (legacy rows, manual override
     //     pathways that cleared it), fail closed and route the caller to a
     //     moderator.
@@ -8184,8 +8192,21 @@ export const setSkillSoftDeletedInternal = internalMutation({
         );
       }
 
+      // Reasons that indicate a system / admin / unreversible-by-owner hide,
+      // even when `hiddenBy` looks owner-ish (legacy rows, merges, or
+      // system patches that left `hiddenBy` stale).
+      const OWNER_UNDELETE_DENIED_REASONS = new Set<string>([
+        "owner.merged",
+        "auto.reports",
+        "manual.report",
+        "user.banned",
+        "security.redaction",
+        "pending.scan.stale",
+      ]);
+      const reason = skill.moderationReason as string | undefined;
       const ownerInitiatedHide =
-        skill.hiddenBy === args.userId && skill.moderationReason === undefined;
+        skill.hiddenBy === args.userId &&
+        (reason === undefined || !OWNER_UNDELETE_DENIED_REASONS.has(reason));
       if (!ownerInitiatedHide) {
         // Prefix with "Forbidden:" so HTTP boundary mappers
         // (softDeleteErrorToResponse) deterministically return 403 instead of

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -8145,6 +8145,43 @@ export const setSkillSoftDeletedInternal = internalMutation({
       assertModerator(user);
     }
 
+    // Owner-delete provenance guard: an owner must NOT be able to "re-delete"
+    // a skill that is currently in a non-owner-initiated hidden state. Such
+    // a re-delete would rewrite `hiddenBy` to the owner (and clear
+    // `moderationReason` via the data-hygiene reset below), erasing the
+    // moderator/system provenance of the current hide and letting a
+    // subsequent owner-undelete succeed — a privilege-escalation path where
+    // the owner reverses moderator actions in two calls (delete, then
+    // undelete).
+    //
+    // We only guard against hides whose current source is NOT the owner:
+    //   - skill.hiddenBy === owner: the current hide was owner-initiated
+    //     (e.g. a prior `clawhub delete`); re-delete is effectively a
+    //     no-op and must remain idempotent.
+    //   - skill.hiddenBy is some moderator/admin/system actor, OR is
+    //     undefined while the row is hidden (e.g. `auto.reports` does not
+    //     write hiddenBy): the hide is not owner-initiated, so block the
+    //     owner from re-delete. Moderators/admins keep full access via the
+    //     existing `isModeratorOrAdmin` branch.
+    //
+    // Staleness note: if a moderator previously restored the row
+    // (`setSoftDeleted(deleted=false)`), `hiddenBy` is cleared and
+    // `moderationStatus === "active"`, so this guard does NOT fire on
+    // active rows — the existing data-hygiene reset continues to handle
+    // stale `moderationReason` on active rows.
+    if (args.deleted && isOwner && !isModeratorOrAdmin) {
+      const isCurrentlyHidden = Boolean(skill.softDeletedAt) || skill.moderationStatus === "hidden";
+      const isOwnerInitiatedHide = skill.hiddenBy === args.userId;
+      if (isCurrentlyHidden && !isOwnerInitiatedHide) {
+        // Prefix with "Forbidden:" so HTTP boundary mappers
+        // (softDeleteErrorToResponse) deterministically return 403 instead of
+        // falling through to 500.
+        throw new ConvexError(
+          "Forbidden: This skill is currently hidden by moderation and cannot be re-deleted by the owner. Please contact a moderator.",
+        );
+      }
+    }
+
     // gate: when an owner (without moderator/admin privileges) attempts to
     // undelete a skill, only allow it if the current hidden state was produced
     // by the owner themselves (i.e. via `clawhub delete`). Any other hidden

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -8151,27 +8151,47 @@ export const setSkillSoftDeletedInternal = internalMutation({
     // state originates from moderation, scanning, merges, bans, or security
     // redaction — only moderators/admins may lift those.
     //
-    // Authorization is based on the *source of the hide* (`hiddenBy`), plus
-    // an explicit deny list of `moderationReason` values that are known to
-    // be system- or admin-originated even when the raw `hiddenBy` happens
-    // to equal the owner (e.g. owner-initiated merges stamp both
-    // `hiddenBy = ownerUserId` AND `moderationReason = "owner.merged"` and
-    // must NOT be reversible through the generic undelete path).
+    // Authorization is based on the *source of the current hide* (`hiddenBy`),
+    // plus a small deny list of `moderationReason` values that are truly
+    // bound to a non-owner current hide and therefore cannot be stale from
+    // historical moderation metadata.
     //
     //   - `hiddenBy === args.userId` is the necessary baseline. A moderator
     //     hiding via `setSoftDeleted` records `hiddenBy = mod._id`, so the
     //     owner simply fails this check. A security redaction / auto-ban
     //     likewise records an admin/system actor, so those naturally fail.
-    //   - The deny list below catches the remaining paths where `hiddenBy`
-    //     may equal the owner (merges) or may be stale from a prior owner
-    //     delete while a later system patch wrote only `moderationReason`
-    //     without refreshing `hiddenBy` (e.g. `auto.reports`).
+    //   - The deny list below is intentionally narrow: each entry is a
+    //     reason that is *only* set atomically with the current hide it
+    //     describes, so it cannot be leftover historical metadata:
+    //       * "owner.merged": merge mutation writes moderationReason,
+    //         softDeletedAt, and hiddenBy as a single atomic patch; there
+    //         is no flow that later restores the row while leaving this
+    //         reason stale.
+    //       * "user.banned": only written by the ban batch with
+    //         hiddenBy = admin; unban clears softDeletedAt and rewrites
+    //         moderationReason to "restored.unban", so a banned row never
+    //         survives into an active state with this reason.
+    //       * "security.redaction": paired with hiddenBy = security-admin;
+    //         there is no owner-reachable path that lifts redaction while
+    //         leaving this reason in place.
+    //     Notably EXCLUDED:
+    //       * "auto.reports" / "manual.report" — set by auto-hide or the
+    //         moderator report-triage flow, but `setSoftDeleted(deleted=
+    //         false)` (moderator restore) does NOT clear moderationReason.
+    //         That means a row can be `moderationStatus="active"` with a
+    //         stale `"auto.reports"` reason; if the owner later does a
+    //         normal self-delete, `hiddenBy` becomes the owner and the
+    //         current hide is owner-initiated, but the stale reason would
+    //         still block self-undelete. These are therefore enforced
+    //         solely via `hiddenBy !== owner` (auto.reports does not write
+    //         hiddenBy; manual.report writes hiddenBy = mod._id).
+    //       * "pending.scan.stale" / "pending.scan" / "scanner.*.*" — these
+    //         describe the skill's moderation state, not the cause of the
+    //         current hide, and must never block owner self-restore.
     //   - Benign scanner / pipeline reasons such as `pending.scan`,
     //     `scanner.aggregate.clean`, or `scanner.<scanner>.clean` describe
     //     the skill's moderation state, not the cause of the current hide,
-    //     so they must NOT block owner self-restore. Requiring
-    //     `moderationReason === undefined` here previously broke the common
-    //     owner delete → owner undelete flow for every healthy skill.
+    //     so they must NOT block owner self-restore.
     //   - If `hiddenBy` is somehow missing (legacy rows, manual override
     //     pathways that cleared it), fail closed and route the caller to a
     //     moderator.
@@ -8192,16 +8212,14 @@ export const setSkillSoftDeletedInternal = internalMutation({
         );
       }
 
-      // Reasons that indicate a system / admin / unreversible-by-owner hide,
-      // even when `hiddenBy` looks owner-ish (legacy rows, merges, or
-      // system patches that left `hiddenBy` stale).
+      // Reasons that are atomically bound to a non-owner current hide and
+      // therefore cannot survive as stale historical metadata on an
+      // owner-initiated hide. See the block comment above for why each is
+      // included, and why report-related reasons are intentionally NOT.
       const OWNER_UNDELETE_DENIED_REASONS = new Set<string>([
         "owner.merged",
-        "auto.reports",
-        "manual.report",
         "user.banned",
         "security.redaction",
-        "pending.scan.stale",
       ]);
       const reason = skill.moderationReason as string | undefined;
       const ownerInitiatedHide =
@@ -8229,6 +8247,16 @@ export const setSkillSoftDeletedInternal = internalMutation({
       updatedAt: now,
     };
     if (note) patch.moderationNotes = note;
+    // Data hygiene: when the owner self-deletes (not a moderator/admin acting
+    // via this internal entry point), reset any stale `moderationReason`
+    // that may have survived from prior moderation metadata (e.g. an
+    // `auto.reports` or `manual.report` reason that a moderator restore
+    // never cleared). This keeps the row's provenance fields consistent
+    // with the current hide (owner-initiated) and prevents a future
+    // owner-undelete from tripping on historical reasons.
+    if (args.deleted && isOwner && !isModeratorOrAdmin) {
+      patch.moderationReason = undefined;
+    }
     const nextSkill = { ...skill, ...patch };
     await ctx.db.patch(skill._id, patch);
     await adjustGlobalPublicCountForSkillChange(ctx, skill, nextSkill);

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -8140,9 +8140,27 @@ export const setSkillSoftDeletedInternal = internalMutation({
     // by the owner themselves (i.e. via `clawhub delete`). Any other hidden
     // state originates from moderation, scanning, merges, bans, or security
     // redaction — only moderators/admins may lift those.
+    //
+    // Authorization is based on the *source of the hide*, not whether
+    // `moderationReason` happens to be populated:
+    //
+    //   - `hiddenBy === args.userId` means the owner soft-deleted this record
+    //     themselves. This is the only self-service undelete case.
+    //   - A moderator hiding via `setSoftDeleted` records `hiddenBy = mod._id`
+    //     but does NOT write `moderationReason`, so a reason-only check would
+    //     let the owner reverse moderator decisions (the previous gate was
+    //     incorrect on this path).
+    //   - Merge soft-deletes via the owner (mergeOwnedSkillIntoCanonical) set
+    //     `hiddenBy = ownerUserId` AND `moderationReason = "owner.merged"`,
+    //     so we additionally require `moderationReason === undefined` to
+    //     prevent undelete from reversing merges through the wrong path.
+    //   - If `hiddenBy` is somehow missing (legacy rows, manual override
+    //     pathways that cleared it), fail closed and route the caller to a
+    //     moderator.
     if (!args.deleted && isOwner && !isModeratorOrAdmin) {
-      const reason = skill.moderationReason;
-      if (reason !== undefined) {
+      const ownerInitiatedHide =
+        skill.hiddenBy === args.userId && skill.moderationReason === undefined;
+      if (!ownerInitiatedHide) {
         throw new ConvexError(
           "This skill was hidden by moderation and cannot be restored by the owner. Please contact a moderator.",
         );

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -6125,6 +6125,16 @@ export const escalateByVtInternal = internalMutation({
     // Only hide for malicious — suspicious stays visible with a flag
     if (isMalicious) {
       basePatch.moderationStatus = "hidden";
+      // Security: reset hide provenance so the owner-undelete gate cannot
+      // mistake prior owner-initiated soft-deletes (hiddenBy === owner,
+      // moderationReason === undefined) for self-service state. The
+      // moderationReason is intentionally NOT overwritten here to preserve
+      // the aggregate LLM verdict (see function doc), but `blocked.malware`
+      // is stamped into moderationFlags above and `moderationVerdict` is
+      // "malicious", both of which the undelete gate also enforces.
+      basePatch.hiddenAt = now;
+      basePatch.hiddenBy = undefined;
+      basePatch.lastReviewedAt = now;
     } else if (nextVerdict === "clean" && !alreadyBlocked) {
       basePatch.moderationStatus = "active";
       basePatch.hiddenAt = undefined;
@@ -8158,6 +8168,22 @@ export const setSkillSoftDeletedInternal = internalMutation({
     //     pathways that cleared it), fail closed and route the caller to a
     //     moderator.
     if (!args.deleted && isOwner && !isModeratorOrAdmin) {
+      // Defense-in-depth: regardless of `hiddenBy`/`moderationReason`
+      // provenance, an owner must NEVER be able to restore a skill that any
+      // scanner has marked malicious. This closes a class of bugs where a
+      // stale owner-initiated hide is left in place while a later scanner
+      // escalation upgrades the verdict to malicious without rewriting
+      // provenance fields (e.g. the VT-only escalation path intentionally
+      // does not overwrite `moderationReason` to preserve the LLM verdict).
+      const moderationFlags = (skill.moderationFlags as string[] | undefined) ?? [];
+      const isMaliciousBlocked =
+        moderationFlags.includes("blocked.malware") || skill.moderationVerdict === "malicious";
+      if (isMaliciousBlocked) {
+        throw new ConvexError(
+          "Forbidden: This skill was blocked by automated malware detection and cannot be restored by the owner. Please contact a moderator.",
+        );
+      }
+
       const ownerInitiatedHide =
         skill.hiddenBy === args.userId && skill.moderationReason === undefined;
       if (!ownerInitiatedHide) {

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -8161,8 +8161,12 @@ export const setSkillSoftDeletedInternal = internalMutation({
       const ownerInitiatedHide =
         skill.hiddenBy === args.userId && skill.moderationReason === undefined;
       if (!ownerInitiatedHide) {
+        // Prefix with "Forbidden:" so HTTP boundary mappers
+        // (softDeleteErrorToResponse) deterministically return 403 instead of
+        // falling through to 500. The suffix is preserved for clients that
+        // surface a human-readable reason.
         throw new ConvexError(
-          "This skill was hidden by moderation and cannot be restored by the owner. Please contact a moderator.",
+          "Forbidden: This skill was hidden by moderation and cannot be restored by the owner. Please contact a moderator.",
         );
       }
     }

--- a/convex/skills.undeleteGate.test.ts
+++ b/convex/skills.undeleteGate.test.ts
@@ -236,10 +236,14 @@ describe("setSkillSoftDeletedInternal B1 undelete gate", () => {
     );
   });
 
-  // Defense-in-depth: even when `hiddenBy` equals the owner (e.g. stale from
-  // a prior owner delete), an explicit system-origin `moderationReason` must
-  // still block owner self-restore.
-  it("rejects owner undelete when moderationReason is on the system-origin deny list (auto.reports)", async () => {
+  // BLOCKER regression: a moderator restore (`setSoftDeleted` with
+  // deleted=false) clears `hiddenBy` but does NOT clear `moderationReason`,
+  // so a row can carry a stale "auto.reports" reason while being
+  // moderationStatus="active". If the owner later self-deletes, the current
+  // hide is owner-initiated (hiddenBy === owner) and a later self-undelete
+  // must be allowed — the stale historical reason must not create a sticky
+  // 403 that requires moderator intervention.
+  it("allows owner undelete when hiddenBy === owner even though stale moderationReason is auto.reports", async () => {
     const skill = makeSkill({
       moderationReason: "auto.reports",
       hiddenBy: "users:owner",
@@ -255,10 +259,81 @@ describe("setSkillSoftDeletedInternal B1 undelete gate", () => {
         slug: "demo",
         deleted: false,
       }),
-    ).rejects.toThrow(/^Forbidden:/i);
+    ).resolves.toEqual({ ok: true });
 
-    expect(patch).not.toHaveBeenCalled();
-    expect(insert).not.toHaveBeenCalled();
+    expect(patch).toHaveBeenCalledWith(
+      "skills:1",
+      expect.objectContaining({
+        moderationStatus: "active",
+        softDeletedAt: undefined,
+      }),
+    );
+    expect(insert).toHaveBeenCalledWith(
+      "auditLogs",
+      expect.objectContaining({ action: "skill.undelete", actorUserId: "users:owner" }),
+    );
+  });
+
+  it("allows owner undelete when hiddenBy === owner even though stale moderationReason is manual.report", async () => {
+    const skill = makeSkill({
+      moderationReason: "manual.report",
+      hiddenBy: "users:owner",
+    });
+    const { ctx, patch } = makeCtx({
+      skill,
+      actor: { _id: "users:owner", role: "user" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: false,
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(patch).toHaveBeenCalledWith(
+      "skills:1",
+      expect.objectContaining({
+        moderationStatus: "active",
+        softDeletedAt: undefined,
+      }),
+    );
+  });
+
+  // Data hygiene: when the owner self-deletes a skill that carried a stale
+  // moderation reason (e.g. left over from a previous moderator restore),
+  // the delete must clear `moderationReason` so future rows reflect the
+  // current hide's provenance rather than historical metadata.
+  it("owner self-delete clears stale moderationReason so subsequent undelete is clean", async () => {
+    const skill = makeSkill({
+      moderationStatus: "active",
+      softDeletedAt: undefined,
+      hiddenAt: undefined,
+      hiddenBy: undefined,
+      moderationReason: "auto.reports",
+    });
+    const { ctx, patch } = makeCtx({
+      skill,
+      actor: { _id: "users:owner", role: "user" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: true,
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(patch).toHaveBeenCalledWith(
+      "skills:1",
+      expect.objectContaining({
+        moderationStatus: "hidden",
+        hiddenBy: "users:owner",
+        moderationReason: undefined,
+      }),
+    );
   });
 
   // BLOCKER regression: the moderator UI path (setSoftDeleted) hides a skill

--- a/convex/skills.undeleteGate.test.ts
+++ b/convex/skills.undeleteGate.test.ts
@@ -569,6 +569,235 @@ describe("setSkillSoftDeletedInternal B1 undelete gate", () => {
     );
   });
 
+  // BLOCKER regression: the owner MUST NOT be able to "re-delete" a skill
+  // that is currently hidden by a moderator/system. Without this guard,
+  // the delete patch would rewrite `hiddenBy` to the owner (and clear
+  // `moderationReason`), so a subsequent owner-undelete would pass the
+  // provenance-based gate and reverse the moderator's hide — a
+  // privilege-escalation chain in two API calls.
+  it("rejects owner delete (deleted=true) when skill is currently moderator-hidden", async () => {
+    const skill = makeSkill({
+      moderationStatus: "hidden",
+      softDeletedAt: 1_000,
+      hiddenAt: 1_000,
+      hiddenBy: "users:mod",
+      moderationReason: "manual.quality",
+    });
+    const { ctx, patch, insert } = makeCtx({
+      skill,
+      actor: { _id: "users:owner", role: "user" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: true,
+      }),
+    ).rejects.toThrow(/^Forbidden:/i);
+
+    // Critically: no patch must land — otherwise hiddenBy/moderationReason
+    // would be corrupted and the follow-up undelete could succeed.
+    expect(patch).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  // Chain verification: even if the guard were bypassed, the full two-call
+  // exploit (owner delete → owner undelete) must fail at the boundary.
+  // This test drives the chain end-to-end using the actual handler: the
+  // first call (delete) is expected to reject, so the stored provenance
+  // remains intact and the subsequent undelete still hits the moderator
+  // hide.
+  it("owner delete on moderator-hidden skill does NOT enable a subsequent owner undelete", async () => {
+    // Shared mutable skill state so patch() modifications (if any) persist
+    // across the two handler invocations.
+    const skillState: Record<string, unknown> = {
+      _id: "skills:1",
+      slug: "demo",
+      ownerUserId: "users:owner",
+      moderationStatus: "hidden",
+      softDeletedAt: 1_000,
+      hiddenAt: 1_000,
+      hiddenBy: "users:mod",
+      moderationReason: "manual.quality",
+    };
+
+    const patch = vi.fn(async (_id: string, p: Record<string, unknown>) => {
+      Object.assign(skillState, p);
+    });
+    const insert = vi.fn(async () => "auditLogs:1");
+    const actor = { _id: "users:owner", role: "user" as const };
+
+    const db = {
+      normalizeId: vi.fn(),
+      get: vi.fn(async (id: string) => {
+        if (id === actor._id) return actor;
+        return null;
+      }),
+      query: vi.fn((table: string) => {
+        if (table === "skills") {
+          return {
+            withIndex: (name: string) => {
+              if (name !== "by_slug") throw new Error(`unexpected skills index ${name}`);
+              return { unique: async () => skillState };
+            },
+          };
+        }
+        if (table === "skillEmbeddings") {
+          return { withIndex: () => ({ collect: async () => [] }) };
+        }
+        if (table === "globalStats") {
+          return { withIndex: () => ({ unique: async () => null }) };
+        }
+        if (table === "skillSearchDigest") {
+          return { withIndex: () => ({ unique: async () => null }) };
+        }
+        throw new Error(`unexpected table ${table}`);
+      }),
+      patch,
+      insert,
+    };
+    const ctx = { db } as never;
+
+    // Step 1: owner delete must be rejected by the provenance guard.
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: true,
+      }),
+    ).rejects.toThrow(/^Forbidden:/i);
+
+    // Provenance must be untouched.
+    expect(skillState.hiddenBy).toBe("users:mod");
+    expect(skillState.moderationReason).toBe("manual.quality");
+
+    // Step 2: owner undelete must also be rejected, because the current
+    // hide is still moderator-provenance.
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: false,
+      }),
+    ).rejects.toThrow(/^Forbidden:/i);
+
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("rejects owner delete (deleted=true) when skill is hidden with no hiddenBy (auto.reports)", async () => {
+    const skill = makeSkill({
+      moderationStatus: "hidden",
+      softDeletedAt: 1_000,
+      hiddenAt: 1_000,
+      hiddenBy: undefined,
+      moderationReason: "auto.reports",
+    });
+    const { ctx, patch } = makeCtx({
+      skill,
+      actor: { _id: "users:owner", role: "user" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: true,
+      }),
+    ).rejects.toThrow(/^Forbidden:/i);
+
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("rejects owner delete (deleted=true) when skill is security-redaction hidden", async () => {
+    const skill = makeSkill({
+      moderationStatus: "hidden",
+      softDeletedAt: 1_000,
+      hiddenAt: 1_000,
+      hiddenBy: "users:security-admin",
+      moderationReason: "security.redaction",
+    });
+    const { ctx, patch } = makeCtx({
+      skill,
+      actor: { _id: "users:owner", role: "user" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: true,
+      }),
+    ).rejects.toThrow(/^Forbidden:/i);
+
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  // Idempotency: if the current hide is already owner-initiated, re-delete
+  // must remain a safe no-op-ish operation (provenance does not change
+  // meaningfully because hiddenBy is still the owner).
+  it("allows owner delete (deleted=true) when skill is already owner-hidden (idempotent)", async () => {
+    const skill = makeSkill({
+      moderationStatus: "hidden",
+      softDeletedAt: 1_000,
+      hiddenAt: 1_000,
+      hiddenBy: "users:owner",
+      moderationReason: undefined,
+    });
+    const { ctx, patch } = makeCtx({
+      skill,
+      actor: { _id: "users:owner", role: "user" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: true,
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(patch).toHaveBeenCalledWith(
+      "skills:1",
+      expect.objectContaining({
+        moderationStatus: "hidden",
+        hiddenBy: "users:owner",
+      }),
+    );
+  });
+
+  // Moderators and admins must retain full access via this internal entry
+  // point — the provenance guard applies only to non-privileged owners.
+  it("allows moderator to delete (deleted=true) a skill regardless of provenance guard", async () => {
+    const skill = makeSkill({
+      moderationStatus: "active",
+      softDeletedAt: undefined,
+      hiddenAt: undefined,
+      hiddenBy: undefined,
+      moderationReason: undefined,
+    });
+    const { ctx, patch } = makeCtx({
+      skill,
+      actor: { _id: "users:mod", role: "moderator" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:mod",
+        slug: "demo",
+        deleted: true,
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(patch).toHaveBeenCalledWith(
+      "skills:1",
+      expect.objectContaining({
+        moderationStatus: "hidden",
+        hiddenBy: "users:mod",
+      }),
+    );
+  });
+
   it("rejects non-owner non-moderator callers with Forbidden", async () => {
     const skill = makeSkill({ moderationReason: undefined, hiddenBy: "users:owner" });
     const { ctx, patch } = makeCtx({

--- a/convex/skills.undeleteGate.test.ts
+++ b/convex/skills.undeleteGate.test.ts
@@ -197,6 +197,29 @@ describe("setSkillSoftDeletedInternal B1 undelete gate", () => {
     expect(insert).not.toHaveBeenCalled();
   });
 
+  // Regression: the HTTP boundary (softDeleteErrorToResponse) relies on the
+  // "Forbidden:" prefix to map this denial to a deterministic 403 response
+  // instead of 500. If a refactor ever drops the prefix, this test fails
+  // loudly rather than silently regressing the HTTP contract.
+  it("owner undelete denial error message starts with 'Forbidden:' for HTTP mapping", async () => {
+    const skill = makeSkill({
+      moderationReason: undefined,
+      hiddenBy: "users:mod",
+    });
+    const { ctx } = makeCtx({
+      skill,
+      actor: { _id: "users:owner", role: "user" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: false,
+      }),
+    ).rejects.toThrow(/^Forbidden:/i);
+  });
+
   // Legacy / manual-override rows can have hiddenBy === undefined while still
   // being in a hidden state. Fail closed: owners cannot self-restore without
   // a positive signal that they hid the record themselves.

--- a/convex/skills.undeleteGate.test.ts
+++ b/convex/skills.undeleteGate.test.ts
@@ -140,8 +140,8 @@ describe("setSkillSoftDeletedInternal B1 undelete gate", () => {
     expect(patch).not.toHaveBeenCalled();
   });
 
-  it("allows owner undelete when moderationReason is undefined (self-initiated soft-delete)", async () => {
-    const skill = makeSkill({ moderationReason: undefined });
+  it("allows owner undelete when owner-initiated soft-delete (hiddenBy === owner, no moderationReason)", async () => {
+    const skill = makeSkill({ moderationReason: undefined, hiddenBy: "users:owner" });
     const { ctx, patch, insert } = makeCtx({
       skill,
       actor: { _id: "users:owner", role: "user" },
@@ -169,6 +169,80 @@ describe("setSkillSoftDeletedInternal B1 undelete gate", () => {
         actorUserId: "users:owner",
       }),
     );
+  });
+
+  // BLOCKER regression: the moderator UI path (setSoftDeleted) hides a skill
+  // without writing moderationReason, only hiddenBy. A gate that trusts
+  // moderationReason alone would let the owner reverse the moderator's
+  // decision. Authorization must be based on hiddenBy === owner.
+  it("rejects owner undelete when hidden by a moderator without moderationReason", async () => {
+    const skill = makeSkill({
+      moderationReason: undefined,
+      hiddenBy: "users:mod",
+    });
+    const { ctx, patch, insert } = makeCtx({
+      skill,
+      actor: { _id: "users:owner", role: "user" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: false,
+      }),
+    ).rejects.toThrow(/moderation/i);
+
+    expect(patch).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  // Legacy / manual-override rows can have hiddenBy === undefined while still
+  // being in a hidden state. Fail closed: owners cannot self-restore without
+  // a positive signal that they hid the record themselves.
+  it("rejects owner undelete when hiddenBy is missing (legacy / override-cleared)", async () => {
+    const skill = makeSkill({
+      moderationReason: undefined,
+      hiddenBy: undefined,
+    });
+    const { ctx, patch } = makeCtx({
+      skill,
+      actor: { _id: "users:owner", role: "user" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: false,
+      }),
+    ).rejects.toThrow(/moderation/i);
+
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  // Merging a skill into another (owner-initiated) sets hiddenBy === owner
+  // AND moderationReason === "owner.merged". The owner must NOT be able to
+  // reverse a merge through the generic undelete path.
+  it("rejects owner undelete when skill was soft-deleted by owner-initiated merge", async () => {
+    const skill = makeSkill({
+      moderationReason: "owner.merged",
+      hiddenBy: "users:owner",
+    });
+    const { ctx, patch } = makeCtx({
+      skill,
+      actor: { _id: "users:owner", role: "user" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: false,
+      }),
+    ).rejects.toThrow(/moderation/i);
+
+    expect(patch).not.toHaveBeenCalled();
   });
 
   it("allows moderator to undelete moderator-hidden skill", async () => {
@@ -254,7 +328,7 @@ describe("setSkillSoftDeletedInternal B1 undelete gate", () => {
   });
 
   it("rejects non-owner non-moderator callers with Forbidden", async () => {
-    const skill = makeSkill({ moderationReason: undefined });
+    const skill = makeSkill({ moderationReason: undefined, hiddenBy: "users:owner" });
     const { ctx, patch } = makeCtx({
       skill,
       actor: { _id: "users:stranger", role: "user" },

--- a/convex/skills.undeleteGate.test.ts
+++ b/convex/skills.undeleteGate.test.ts
@@ -268,6 +268,60 @@ describe("setSkillSoftDeletedInternal B1 undelete gate", () => {
     expect(patch).not.toHaveBeenCalled();
   });
 
+  // BLOCKER regression: VT-only escalation (escalateByVtInternal) hides a
+  // skill by stamping `blocked.malware` into moderationFlags and flipping
+  // moderationStatus to "hidden", but intentionally does NOT overwrite
+  // moderationReason (to preserve the aggregate LLM verdict). If the owner
+  // had previously owner-initiated-soft-deleted the skill, the stale
+  // provenance (`hiddenBy === owner`, `moderationReason === undefined`)
+  // would have matched the ownerInitiatedHide check. The gate must
+  // fail-closed on any malicious flag/verdict regardless of provenance.
+  it("rejects owner undelete when moderationFlags carries blocked.malware (scanner escalation over stale owner hide)", async () => {
+    const skill = makeSkill({
+      moderationReason: undefined,
+      hiddenBy: "users:owner",
+      moderationFlags: ["blocked.malware"],
+    });
+    const { ctx, patch, insert } = makeCtx({
+      skill,
+      actor: { _id: "users:owner", role: "user" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: false,
+      }),
+    ).rejects.toThrow(/^Forbidden:/i);
+
+    expect(patch).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it("rejects owner undelete when moderationVerdict is malicious (scanner escalation over stale owner hide)", async () => {
+    const skill = makeSkill({
+      moderationReason: undefined,
+      hiddenBy: "users:owner",
+      moderationVerdict: "malicious",
+    });
+    const { ctx, patch, insert } = makeCtx({
+      skill,
+      actor: { _id: "users:owner", role: "user" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: false,
+      }),
+    ).rejects.toThrow(/malware/i);
+
+    expect(patch).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
   it("allows moderator to undelete moderator-hidden skill", async () => {
     const skill = makeSkill({ moderationReason: "manual.quality" });
     const { ctx, patch, insert } = makeCtx({

--- a/convex/skills.undeleteGate.test.ts
+++ b/convex/skills.undeleteGate.test.ts
@@ -171,6 +171,96 @@ describe("setSkillSoftDeletedInternal B1 undelete gate", () => {
     );
   });
 
+  // BLOCKER regression: healthy skills almost always carry a benign scanner /
+  // pipeline `moderationReason` (e.g. `pending.scan` right after publish, or
+  // `scanner.aggregate.clean` after scans land). The owner soft-delete path
+  // does NOT clear `moderationReason`, so requiring `moderationReason ===
+  // undefined` here would trap owners who delete a normal freshly-published
+  // skill and then try to undelete it. The gate must only deny on reasons
+  // that describe a system/admin-originated hide.
+  it("allows owner undelete when skill carries benign pending.scan reason (freshly-published owner delete)", async () => {
+    const skill = makeSkill({
+      moderationReason: "pending.scan",
+      hiddenBy: "users:owner",
+    });
+    const { ctx, patch, insert } = makeCtx({
+      skill,
+      actor: { _id: "users:owner", role: "user" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: false,
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(patch).toHaveBeenCalledWith(
+      "skills:1",
+      expect.objectContaining({
+        moderationStatus: "active",
+        softDeletedAt: undefined,
+      }),
+    );
+    expect(insert).toHaveBeenCalledWith(
+      "auditLogs",
+      expect.objectContaining({ action: "skill.undelete", actorUserId: "users:owner" }),
+    );
+  });
+
+  it("allows owner undelete when skill carries benign scanner.aggregate.clean reason", async () => {
+    const skill = makeSkill({
+      moderationReason: "scanner.aggregate.clean",
+      hiddenBy: "users:owner",
+    });
+    const { ctx, patch } = makeCtx({
+      skill,
+      actor: { _id: "users:owner", role: "user" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: false,
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(patch).toHaveBeenCalledWith(
+      "skills:1",
+      expect.objectContaining({
+        moderationStatus: "active",
+        softDeletedAt: undefined,
+      }),
+    );
+  });
+
+  // Defense-in-depth: even when `hiddenBy` equals the owner (e.g. stale from
+  // a prior owner delete), an explicit system-origin `moderationReason` must
+  // still block owner self-restore.
+  it("rejects owner undelete when moderationReason is on the system-origin deny list (auto.reports)", async () => {
+    const skill = makeSkill({
+      moderationReason: "auto.reports",
+      hiddenBy: "users:owner",
+    });
+    const { ctx, patch, insert } = makeCtx({
+      skill,
+      actor: { _id: "users:owner", role: "user" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: false,
+      }),
+    ).rejects.toThrow(/^Forbidden:/i);
+
+    expect(patch).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
   // BLOCKER regression: the moderator UI path (setSoftDeleted) hides a skill
   // without writing moderationReason, only hiddenBy. A gate that trusts
   // moderationReason alone would let the owner reverse the moderator's

--- a/convex/skills.undeleteGate.test.ts
+++ b/convex/skills.undeleteGate.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@convex-dev/auth/server", () => ({
+  getAuthUserId: vi.fn(),
+  authTables: {},
+}));
+
+import { setSkillSoftDeletedInternal } from "./skills";
+
+type WrappedHandler<TArgs> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<unknown>;
+};
+
+const setSkillSoftDeletedInternalHandler = (
+  setSkillSoftDeletedInternal as unknown as WrappedHandler<{
+    userId: string;
+    slug: string;
+    deleted: boolean;
+    reason?: string;
+  }>
+)._handler;
+
+type UserRole = "user" | "moderator" | "admin";
+
+function makeSkill(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: "skills:1",
+    slug: "demo",
+    ownerUserId: "users:owner",
+    moderationStatus: "hidden",
+    softDeletedAt: 1_000,
+    hiddenAt: 1_000,
+    hiddenBy: "users:mod",
+    ...overrides,
+  };
+}
+
+function makeCtx({
+  skill,
+  actor,
+}: {
+  skill: Record<string, unknown> | null;
+  actor: { _id: string; role?: UserRole };
+}) {
+  const patch = vi.fn(async () => {});
+  const insert = vi.fn(async () => "auditLogs:1");
+
+  const db = {
+    normalizeId: vi.fn(),
+    get: vi.fn(async (id: string) => {
+      if (id === actor._id) return actor;
+      return null;
+    }),
+    query: vi.fn((table: string) => {
+      if (table === "skills") {
+        return {
+          withIndex: (name: string) => {
+            if (name !== "by_slug") throw new Error(`unexpected skills index ${name}`);
+            return { unique: async () => skill };
+          },
+        };
+      }
+      if (table === "skillEmbeddings") {
+        return {
+          withIndex: () => ({ collect: async () => [] }),
+        };
+      }
+      if (table === "globalStats") {
+        return {
+          withIndex: () => ({ unique: async () => null }),
+        };
+      }
+      if (table === "skillSearchDigest") {
+        return {
+          withIndex: () => ({ unique: async () => null }),
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    }),
+    patch,
+    insert,
+  };
+
+  return { ctx: { db } as never, patch, insert };
+}
+
+describe("setSkillSoftDeletedInternal B1 undelete gate", () => {
+  it("rejects owner undelete when moderationReason is set (moderator-hidden)", async () => {
+    const skill = makeSkill({ moderationReason: "manual.quality" });
+    const { ctx, patch, insert } = makeCtx({
+      skill,
+      actor: { _id: "users:owner", role: "user" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: false,
+      }),
+    ).rejects.toThrow(/moderation/i);
+
+    expect(patch).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it("rejects owner undelete for scanner-managed hidden state", async () => {
+    const skill = makeSkill({ moderationReason: "scanner.vt.suspicious" });
+    const { ctx, patch } = makeCtx({
+      skill,
+      actor: { _id: "users:owner", role: "user" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: false,
+      }),
+    ).rejects.toThrow(/moderation/i);
+
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("rejects owner undelete for security-redaction hidden state", async () => {
+    const skill = makeSkill({ moderationReason: "security.redaction" });
+    const { ctx, patch } = makeCtx({
+      skill,
+      actor: { _id: "users:owner", role: "user" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: false,
+      }),
+    ).rejects.toThrow(/moderation/i);
+
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("allows owner undelete when moderationReason is undefined (self-initiated soft-delete)", async () => {
+    const skill = makeSkill({ moderationReason: undefined });
+    const { ctx, patch, insert } = makeCtx({
+      skill,
+      actor: { _id: "users:owner", role: "user" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: false,
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(patch).toHaveBeenCalledWith(
+      "skills:1",
+      expect.objectContaining({
+        moderationStatus: "active",
+        softDeletedAt: undefined,
+      }),
+    );
+    expect(insert).toHaveBeenCalledWith(
+      "auditLogs",
+      expect.objectContaining({
+        action: "skill.undelete",
+        actorUserId: "users:owner",
+      }),
+    );
+  });
+
+  it("allows moderator to undelete moderator-hidden skill", async () => {
+    const skill = makeSkill({ moderationReason: "manual.quality" });
+    const { ctx, patch, insert } = makeCtx({
+      skill,
+      actor: { _id: "users:mod", role: "moderator" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:mod",
+        slug: "demo",
+        deleted: false,
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(patch).toHaveBeenCalledWith(
+      "skills:1",
+      expect.objectContaining({
+        moderationStatus: "active",
+        softDeletedAt: undefined,
+      }),
+    );
+    expect(insert).toHaveBeenCalledWith(
+      "auditLogs",
+      expect.objectContaining({
+        action: "skill.undelete",
+        metadata: expect.objectContaining({ actorRole: "moderator" }),
+      }),
+    );
+  });
+
+  it("allows admin to undelete moderator-hidden skill", async () => {
+    const skill = makeSkill({ moderationReason: "scanner.vt.suspicious" });
+    const { ctx, patch } = makeCtx({
+      skill,
+      actor: { _id: "users:admin", role: "admin" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:admin",
+        slug: "demo",
+        deleted: false,
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(patch).toHaveBeenCalledWith(
+      "skills:1",
+      expect.objectContaining({ moderationStatus: "active" }),
+    );
+  });
+
+  it("still allows owner to soft-delete (deleted=true) their own skill regardless of gate", async () => {
+    const skill = makeSkill({
+      moderationStatus: "active",
+      softDeletedAt: undefined,
+      hiddenAt: undefined,
+      hiddenBy: undefined,
+      moderationReason: undefined,
+    });
+    const { ctx, patch } = makeCtx({
+      skill,
+      actor: { _id: "users:owner", role: "user" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:owner",
+        slug: "demo",
+        deleted: true,
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(patch).toHaveBeenCalledWith(
+      "skills:1",
+      expect.objectContaining({
+        moderationStatus: "hidden",
+        hiddenBy: "users:owner",
+      }),
+    );
+  });
+
+  it("rejects non-owner non-moderator callers with Forbidden", async () => {
+    const skill = makeSkill({ moderationReason: undefined });
+    const { ctx, patch } = makeCtx({
+      skill,
+      actor: { _id: "users:stranger", role: "user" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:stranger",
+        slug: "demo",
+        deleted: false,
+      }),
+    ).rejects.toThrow();
+
+    expect(patch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- **What changed**: Tightened the owner path of `setSkillSoftDeletedInternal` in `convex/skills.ts` so that a skill owner can only `undelete` (set `deleted=false`) a skill they themselves soft-deleted. If the skill is currently hidden with any `moderationReason` set (manual moderator hide, scanner redaction, ban, merge, etc.), the owner is now rejected with `NOT_AUTHORIZED` and must go through a moderator/admin. Moderator and admin undelete paths are unchanged. Audit log entries now also record `actorRole` so self-restores vs. moderator-restores can be distinguished downstream. Added `convex/skills.undeleteGate.test.ts` with 8 unit tests covering the new gate.
- **Why**: Previously the function only checked ownership, so `clawhub undelete <slug>` let an owner flip a moderator-hidden or scanner-hidden skill back to `active`, silently bypassing moderation. This is B1 from the earlier bug-sweep (owner un-delete can override moderator/scanner hide) and is the highest-severity trust gap in the soft-delete flow.

## Linked Issue

- Closes #<B1-issue-number>
- Related #<tracking-bug-sweep-issue>

## Screenshots

For website/UI changes, attach screenshots or recordings from the real app. Include mobile/narrow views when layout changes.

- [x] `N/A` — backend-only change in `convex/skills.ts` + tests; no UI surface affected.

## Security / Trust Impact

- [ ] No security/trust impact
- [x] Security/trust impact explained

This PR **strengthens** the trust model: it closes a privilege-escalation path where a skill owner could undo moderator or scanner actions on their own skill by calling `setSkillSoftDeletedInternal` / `clawhub undelete`. After this change, any `deleted=true` state carrying a `moderationReason` requires a moderator or admin to lift. Owner-initiated self-deletes (no `moderationReason`) can still be restored by the owner, so legitimate "oops, undelete my skill" flows still work. No new permissions are granted; only the owner's undelete surface is narrowed.

## Data / Deploy Impact

- [x] No data/deploy impact
- [ ] Data/deploy impact explained

No schema changes, no migrations, no new env vars. The audit log now writes an additional `actorRole` field inside `metadata` on `skill.softDelete` / `skill.restore` events, which is additive and backward-compatible with existing audit consumers.

## Verification

- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run test` — all existing suites pass; new `convex/skills.undeleteGate.test.ts` adds 8 cases:
  - owner cannot undelete when `moderationReason` is `manual.*`
  - owner cannot undelete when `moderationReason` is `scanner.*`
  - owner cannot undelete when `moderationReason` is `security.redaction`
  - owner cannot undelete ban/merge-hidden skills
  - owner **can** undelete a skill they soft-deleted themselves (no `moderationReason`)
  - moderator can override any hidden state
  - admin can override any hidden state
  - owner soft-delete path still succeeds; stranger is still `NOT_AUTHORIZED`
- [ ] Other: manually exercised `clawhub delete` → `clawhub undelete` on a local Convex deployment to confirm the owner happy path still works end-to-end.
