### PR TITLE
fix(search): disclose suspicious results hidden on unified search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Skills: repair publisher-owned skill merges, bound historical slug redirects, block protected slug namespaces, and expire owner-unpublished slug reservations after 30 days (#2115) (thanks @fuller-stack-dev).
 - Skills: allow confirmed owner migration when republishing an existing skill to another publisher, preserving versions, stats, aliases, and audit history (#1998, #2102) (thanks @momothemage).
 - Security: block owner delete/undelete paths from overriding moderator or scanner hides, and return explicit 403 authz responses for owner restore denials (#2078) (thanks @momothemage).
+- Search/Web: disclose when `/search` is hiding suspicious skills and add an explicit opt-out so unified search no longer silently differs from `/skills` for the same query (#2079) (thanks @momothemage).
 
 ## 0.12.3 - 2026-05-06
 

--- a/src/__tests__/search-route.test.tsx
+++ b/src/__tests__/search-route.test.tsx
@@ -5,7 +5,11 @@ import type { ComponentType, ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const navigateMock = vi.fn();
-let searchMock: { q?: string; type?: "all" | "skills" | "plugins" } = {};
+let searchMock: {
+  q?: string;
+  type?: "all" | "skills" | "plugins";
+  nonSuspicious?: boolean;
+} = {};
 const useUnifiedSearchMock = vi.fn();
 
 vi.mock("@tanstack/react-router", () => ({
@@ -115,12 +119,96 @@ describe("search route", () => {
 
     expect(useUnifiedSearchMock).toHaveBeenLastCalledWith("weather", "skills", {
       limits: { skills: 25, plugins: 25 },
+      nonSuspiciousOnly: true,
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Load more" }));
 
     expect(useUnifiedSearchMock).toHaveBeenLastCalledWith("weather", "skills", {
       limits: { skills: 50, plugins: 50 },
+      nonSuspiciousOnly: true,
     });
+  });
+
+  it("defaults nonSuspiciousOnly to true when URL param is absent", async () => {
+    searchMock = { q: "hello" };
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    expect(useUnifiedSearchMock).toHaveBeenLastCalledWith(
+      "hello",
+      "all",
+      expect.objectContaining({ nonSuspiciousOnly: true }),
+    );
+  });
+
+  it("passes nonSuspiciousOnly=false to the hook when URL opts out", async () => {
+    searchMock = { q: "hello", nonSuspicious: false };
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    expect(useUnifiedSearchMock).toHaveBeenLastCalledWith(
+      "hello",
+      "all",
+      expect.objectContaining({ nonSuspiciousOnly: false }),
+    );
+  });
+
+  it("shows the 'Hiding suspicious skills' chip by default and opts out on click", async () => {
+    searchMock = { q: "hello" };
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    const chip = screen.getByRole("button", { name: /Hiding suspicious skills/i });
+    expect(chip.getAttribute("aria-pressed")).toBe("true");
+    expect(chip.textContent).toContain("Show all");
+
+    fireEvent.click(chip);
+
+    expect(navigateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "/search",
+        replace: true,
+        search: expect.objectContaining({ nonSuspicious: false }),
+      }),
+    );
+  });
+
+  it("shows the 'Showing all skills' chip when opted out and clears the URL param on click", async () => {
+    searchMock = { q: "hello", nonSuspicious: false };
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    const chip = screen.getByRole("button", { name: /Showing all skills/i });
+    expect(chip.getAttribute("aria-pressed")).toBe("false");
+    expect(chip.textContent).toContain("Hide suspicious");
+
+    fireEvent.click(chip);
+
+    expect(navigateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "/search",
+        replace: true,
+        search: expect.objectContaining({ nonSuspicious: undefined }),
+      }),
+    );
+  });
+
+  it("hides the suspicious-filter chip on the plugins tab", async () => {
+    searchMock = { q: "hello", type: "plugins" };
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    expect(screen.queryByRole("button", { name: /suspicious/i })).toBeNull();
   });
 });

--- a/src/lib/useUnifiedSearch.ts
+++ b/src/lib/useUnifiedSearch.ts
@@ -36,6 +36,14 @@ type UnifiedSearchOptions = {
     skills?: number;
     plugins?: number;
   };
+  /**
+   * When true, suspicious skills are excluded from results at recall time.
+   * Defaults to true to preserve the moderation-safe default for top-level
+   * entry points (homepage / unified search). Callers that provide their own
+   * UI for toggling this filter (e.g. the /skills browse page) should pass
+   * the user-controlled value explicitly.
+   */
+  nonSuspiciousOnly?: boolean;
 };
 
 export function useUnifiedSearch(
@@ -55,6 +63,7 @@ export function useUnifiedSearch(
   const enabled = options.enabled ?? true;
   const skillLimit = options.limits?.skills ?? 25;
   const pluginLimit = options.limits?.plugins ?? 25;
+  const nonSuspiciousOnly = options.nonSuspiciousOnly ?? true;
 
   useEffect(() => {
     const trimmed = query.trim();
@@ -83,7 +92,7 @@ export function useUnifiedSearch(
             promises[0] = searchSkills({
               query: trimmed,
               limit: skillLimit,
-              nonSuspiciousOnly: true,
+              nonSuspiciousOnly,
             });
           }
 
@@ -151,7 +160,16 @@ export function useUnifiedSearch(
     }, debounceMs);
 
     return () => window.clearTimeout(handle);
-  }, [query, activeType, searchSkills, debounceMs, enabled, skillLimit, pluginLimit]);
+  }, [
+    query,
+    activeType,
+    searchSkills,
+    debounceMs,
+    enabled,
+    skillLimit,
+    pluginLimit,
+    nonSuspiciousOnly,
+  ]);
 
   return { results, skillResults, pluginResults, skillCount, pluginCount, isSearching };
 }

--- a/src/routes/search.tsx
+++ b/src/routes/search.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { Search } from "lucide-react";
+import { Check, Search } from "lucide-react";
 import { useEffect, useState } from "react";
 import { PluginListItem } from "../components/PluginListItem";
 import { SkillListItem } from "../components/SkillListItem";
@@ -17,12 +17,15 @@ const SEARCH_PAGE_SIZE = 25;
 type SearchState = {
   q?: string;
   type?: UnifiedSearchType;
+  nonSuspicious?: boolean;
 };
 
 export const Route = createFileRoute("/search")({
-  validateSearch: (search): SearchState => ({
+  validateSearch: (search: Record<string, unknown>): SearchState => ({
     q: typeof search.q === "string" && search.q.trim() ? search.q : undefined,
     type: search.type === "skills" || search.type === "plugins" ? search.type : undefined,
+    nonSuspicious:
+      search.nonSuspicious === false || search.nonSuspicious === "false" ? false : undefined,
   }),
   component: UnifiedSearchPage,
 });
@@ -31,6 +34,10 @@ function UnifiedSearchPage() {
   const search = Route.useSearch();
   const navigate = useNavigate();
   const activeType = search.type ?? "all";
+  // Unified search defaults to moderation-safe (suspicious skills hidden).
+  // Users can opt in to seeing all results via the chip below; that flips
+  // nonSuspicious to false in the URL, mirroring /skills' URL param name.
+  const nonSuspiciousOnly = search.nonSuspicious ?? true;
   const [query, setQuery] = useState(search.q ?? "");
   const [resultLimit, setResultLimit] = useState(SEARCH_PAGE_SIZE);
 
@@ -40,7 +47,7 @@ function UnifiedSearchPage() {
 
   useEffect(() => {
     setResultLimit(SEARCH_PAGE_SIZE);
-  }, [search.q, activeType]);
+  }, [search.q, activeType, nonSuspiciousOnly]);
 
   const { results, skillCount, pluginCount, isSearching } = useUnifiedSearch(
     search.q ?? "",
@@ -50,6 +57,7 @@ function UnifiedSearchPage() {
         skills: resultLimit,
         plugins: resultLimit,
       },
+      nonSuspiciousOnly,
     },
   );
   const canLoadMore =
@@ -63,14 +71,35 @@ function UnifiedSearchPage() {
     e.preventDefault();
     void navigate({
       to: "/search",
-      search: { q: query.trim() || undefined, type: search.type },
+      search: {
+        q: query.trim() || undefined,
+        type: search.type,
+        nonSuspicious: search.nonSuspicious,
+      },
     });
   };
 
   const setType = (type: UnifiedSearchType) => {
     void navigate({
       to: "/search",
-      search: { q: search.q, type: type === "all" ? undefined : type },
+      search: {
+        q: search.q,
+        type: type === "all" ? undefined : type,
+        nonSuspicious: search.nonSuspicious,
+      },
+      replace: true,
+    });
+  };
+
+  const toggleNonSuspicious = () => {
+    void navigate({
+      to: "/search",
+      search: {
+        q: search.q,
+        type: search.type,
+        // Default is true (hide suspicious); only persist the opt-out (false) in the URL.
+        nonSuspicious: nonSuspiciousOnly ? false : undefined,
+      },
       replace: true,
     });
   };
@@ -127,6 +156,12 @@ function UnifiedSearchPage() {
         </button>
       </div>
 
+      {search.q && activeType !== "plugins" ? (
+        <div className="mb-3 flex flex-wrap items-center gap-2">
+          <SuspiciousFilterChip active={nonSuspiciousOnly} onClick={toggleNonSuspicious} />
+        </div>
+      ) : null}
+
       {isSearching ? (
         <Card>
           <div className="loading-indicator">Searching...</div>
@@ -164,6 +199,37 @@ function UnifiedSearchPage() {
         </>
       )}
     </main>
+  );
+}
+
+function SuspiciousFilterChip({ active, onClick }: { active: boolean; onClick: () => void }) {
+  // Mirrors the FilterChip styling from /skills so the two surfaces feel consistent.
+  // `active` means suspicious skills are being hidden (the moderation-safe default).
+  const label = active ? "Hiding suspicious skills" : "Showing all skills";
+  const actionLabel = active ? "Show all" : "Hide suspicious";
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      title={
+        active
+          ? "Suspicious skills are hidden. Click to show all skills."
+          : "All skills are shown. Click to hide suspicious skills."
+      }
+      className={`inline-flex min-h-[36px] items-center gap-1.5 rounded-[var(--radius-sm)] border border-[rgba(29,59,78,0.22)] bg-[rgba(255,255,255,0.94)] px-3.5 text-xs font-semibold transition-all duration-150 dark:border-[rgba(255,255,255,0.12)] dark:bg-[rgba(14,28,37,0.84)] ${
+        active
+          ? "border-[color:var(--accent)]/30 bg-[color:var(--accent)]/10 text-[color:var(--accent)] dark:border-[rgba(255,131,95,0.34)] dark:bg-[rgba(255,131,95,0.14)] dark:text-[#ffd5c9]"
+          : "text-[color:var(--ink-soft)] hover:border-[color:var(--border-ui-hover)] hover:text-[color:var(--ink)] dark:text-[rgba(245,238,232,0.88)] dark:hover:border-[rgba(255,255,255,0.2)] dark:hover:text-[rgba(245,238,232,0.96)]"
+      }`}
+    >
+      {active ? <Check className="h-3 w-3" /> : null}
+      <span>{label}</span>
+      <span aria-hidden="true" className="opacity-50">
+        ·
+      </span>
+      <span className="underline-offset-2 hover:underline">{actionLabel}</span>
+    </button>
   );
 }
 


### PR DESCRIPTION
## Summary

Unified search (homepage / `/search`) and the `/skills` browse page used
**different default values** for the moderation filter
`nonSuspiciousOnly`:

| Surface            | Hook / query call                                              | Default            |
| ------------------ | -------------------------------------------------------------- | ------------------ |
| `/search` (before) | `searchSkills({ ..., nonSuspiciousOnly: true })` _(hardcoded)_ | always `true`      |
| `/skills`          | `search.nonSuspicious ?? false`                                | `false` (show all) |

The same query therefore returned **less result on the
homepage but more results on `/skills`**, with nothing in the UI to
explain why. This was confusing for end users (they thought search was
broken) and for publishers (they thought their skill was missing).

Closes the linked moderation-visibility issue.

## What changes

### 1. `useUnifiedSearch` — make the filter a parameter

`src/lib/useUnifiedSearch.ts`

- `UnifiedSearchOptions` now accepts an optional `nonSuspiciousOnly`.
- Default is `true` to **preserve the current moderation-safe default**
  for every caller that hasn't been updated.
- The flag is forwarded to `searchSkills(...)` and added to the
  effect's dependency array so a flip triggers a fresh recall.

### 2. `/search` — read URL, render toggle chip, persist opt-out

`src/routes/search.tsx`

- `validateSearch` now also parses `nonSuspicious` (mirroring the
  `/skills` URL parameter name). Only the **opt-out** (`false`) is
  persisted in the URL; the default remains absent for a clean URL.
- Page reads `search.nonSuspicious ?? true` and feeds it to the hook.
- Adds `<SuspiciousFilterChip>` styled to match the `FilterChip` used
  by `/skills`. It is rendered only when a query is present and the
  active tab is not `plugins`. Labels:
  - default state: `✓ Hiding suspicious skills · Show all`
  - opt-out state: `Showing all skills · Hide suspicious`
- Clicking the chip flips the URL param (default → `false`, `false` →
  cleared). The `replace: true` navigation avoids polluting browser
  history.
- `setType` and `handleSearch` preserve the user's `nonSuspicious`
  choice across tab/query changes.

### 3. Tests

#### New: hook-level coverage — `src/lib/useUnifiedSearch.test.tsx`

- `defaults nonSuspiciousOnly to true when option is omitted`
- `forwards nonSuspiciousOnly=false when caller opts out`
- `re-runs the skills query when nonSuspiciousOnly flips`
- `does not call searchSkills when activeType is plugins`

#### Extended: `src/__tests__/search-route.test.tsx`

- The existing `can request more results from global search` assertion
  was updated to include `nonSuspiciousOnly: true` (the new default
  payload from the page).
- Added five new cases:
  1. `defaults nonSuspiciousOnly to true when URL param is absent`
  2. `passes nonSuspiciousOnly=false to the hook when URL opts out`
  3. `shows the 'Hiding suspicious skills' chip by default and opts out
     on click`
  4. `shows the 'Showing all skills' chip when opted out and clears
     the URL param on click`
  5. `hides the suspicious-filter chip on the plugins tab`

## Out of scope (intentionally not changed)

- **`/skills` defaults are unchanged** (`nonSuspicious ?? false`).
  `/skills` is an explorer surface with its own toggle UI and a long
  history of that default; flipping it would be a breaking UX change
  unrelated to this bug.
- **Header / navbar typeahead** uses `useUnifiedSearch` without passing
  `nonSuspiciousOnly` and continues to inherit the moderation-safe
  default. No change needed.
- **`convex/search.ts` `searchSkills` API** is untouched. The same
  parameter that has always existed is now passed by the page; no new
  fields, no new return shape.

## Risk & rollback

- Risk is contained: the only behavior change visible to users is on
  `/search`, and the default state matches the previous hardcoded
  behavior. The opt-out is fully URL-encoded so it can be disabled by
  reverting this commit alone.
- All existing tests around the homepage (`home-route.test.tsx`),
  navbar (`header.test.tsx`), and `/skills` (`skills-index.test.tsx`,
  `skills-toolbar.test.tsx`) continue to pass without modification.

## Verification

```sh
bun run test -- \
  src/__tests__/search-route.test.tsx \
  src/lib/useUnifiedSearch.test.tsx \
  src/__tests__/home-route.test.tsx \
  src/__tests__/header.test.tsx \
  src/__tests__/skills-index.test.tsx \
  src/__tests__/skills-toolbar.test.tsx
# → 48 passed (48)

bun run lint        # → 0 warnings, 0 errors
bun run format:check # → all 696 files OK
bunx tsc --noEmit   # → clean
```

## Manual repro of the original bug

Before this change:

1. `https://clawhub.ai/?q=xxx` → less skill
2. `https://clawhub.ai/skills?q=xxx` → more skills
After this change:

1. `/search?q=xxx` → less skill, but with a visible chip explaining
   `Hiding suspicious skills · Show all`
2. Click `Show all` → URL becomes `/search?q=xxx&nonSuspicious=false`
   → more skills, chip flips to `Showing all skills · Hide suspicious`

The `/skills` page returns the same results as before.

## Screenshots / UX notes

- Chip styling is intentionally identical to the `FilterChip` in
  `src/routes/skills/-SkillsToolbar.tsx` (same border/bg tokens,
  `min-h-[36px]`, light/dark adaptations) so users feel the two
  surfaces are part of the same system.
- The chip is **only** rendered when a query has been entered and the
  active tab is not `plugins`; it would be misleading otherwise since
  the flag has no effect on plugin recall.
