### PR TITLE
fix: polish browse listing surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+- Web: polish browse/listing surfaces across skills, plugins, and search, including plugin card view parity, clearer search controls, visible safety filtering, and more consistent card metadata treatment (#2084) (thanks @vyctorbrzezowski).
 - Web: rename the skills browse alternate view from Cards to Grid while keeping legacy `view=cards` URLs compatible (#2090) (thanks @vyctorbrzezowski).
 
 ### Fixes

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -225,7 +225,7 @@ describe("Header", () => {
     expect(screen.getAllByText("Docs")).toHaveLength(1);
     expect(screen.queryByText("Dashboard")).toBeNull();
     expect(screen.queryByText("Manage")).toBeNull();
-    expect(screen.getByPlaceholderText("Search skills, plugins, users")).toBeTruthy();
+    expect(screen.getByPlaceholderText("Search skills and plugins")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: /Cycle theme mode/i }));
     expect(setModeMock).toHaveBeenCalledWith("light");
@@ -287,7 +287,7 @@ describe("Header", () => {
 
     render(<Header />);
 
-    const input = screen.getByPlaceholderText("Search skills, plugins, users");
+    const input = screen.getByPlaceholderText("Search skills and plugins");
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: "weather" } });
 
@@ -330,7 +330,7 @@ describe("Header", () => {
 
     render(<Header />);
 
-    const input = screen.getByPlaceholderText("Search skills, plugins, users");
+    const input = screen.getByPlaceholderText("Search skills and plugins");
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: "weather" } });
     fireEvent.click(screen.getByRole("option", { name: /Weather Skill/i }));
@@ -359,7 +359,7 @@ describe("Header", () => {
 
     render(<Header />);
 
-    const input = screen.getByPlaceholderText("Search skills, plugins, users");
+    const input = screen.getByPlaceholderText("Search skills and plugins");
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: "zzzz" } });
 

--- a/src/__tests__/packages-route.test.tsx
+++ b/src/__tests__/packages-route.test.tsx
@@ -101,6 +101,7 @@ describe("plugins route", () => {
       featured: undefined,
       verified: undefined,
       executesCode: undefined,
+      view: undefined,
     });
   });
 
@@ -117,7 +118,21 @@ describe("plugins route", () => {
       featured: undefined,
       verified: undefined,
       executesCode: undefined,
+      view: undefined,
     });
+  });
+
+  it("accepts the cards view in search state", async () => {
+    const route = await loadRoute();
+    const validateSearch = route.__config.validateSearch as (
+      search: Record<string, unknown>,
+    ) => Record<string, unknown>;
+
+    expect(validateSearch({ view: "cards" })).toEqual(
+      expect.objectContaining({
+        view: "cards",
+      }),
+    );
   });
 
   it("forwards opaque cursors through the loader", async () => {
@@ -175,6 +190,42 @@ describe("plugins route", () => {
     expect(lastCall.search({ family: "code-plugin" })).toEqual({
       family: "code-plugin",
       cursor: "cursor:next",
+    });
+  });
+
+  it("renders a title count and switches to card view", async () => {
+    loaderDataMock = {
+      items: [
+        {
+          name: "demo-plugin",
+          displayName: "Demo Plugin",
+          family: "code-plugin",
+          channel: "community",
+          isOfficial: false,
+          executesCode: true,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      nextCursor: null,
+      rateLimited: false,
+      retryAfterSeconds: null,
+    };
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    expect(screen.getByRole("heading", { name: "Plugins 1" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cards" }));
+
+    expect(navigateMock).toHaveBeenCalled();
+    const lastCall = navigateMock.mock.calls.at(-1)?.[0] as {
+      search: (prev: Record<string, unknown>) => Record<string, unknown>;
+    };
+    expect(lastCall.search({})).toEqual({
+      view: "cards",
     });
   });
 

--- a/src/__tests__/search-route.test.tsx
+++ b/src/__tests__/search-route.test.tsx
@@ -89,6 +89,40 @@ describe("search route", () => {
     expect(screen.queryByRole("button", { name: /users/i })).toBeNull();
   });
 
+  it("shows zero counts consistently for active search tabs", async () => {
+    useUnifiedSearchMock.mockReturnValue({
+      results: [],
+      skillResults: [],
+      pluginResults: [{ type: "plugin", plugin: { name: "github-plugin" } }],
+      skillCount: 0,
+      pluginCount: 3,
+      isSearching: false,
+    });
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    expect(screen.getByRole("button", { name: "All 3" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Skills 0" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Plugins 3" })).toBeTruthy();
+  });
+
+  it("clears the active search query from the input", async () => {
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear search" }));
+
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: "/search",
+      search: { q: undefined, type: undefined },
+      replace: true,
+    });
+  });
+
   it("can request more results from global search", async () => {
     searchMock = { q: "weather", type: "skills" };
     useUnifiedSearchMock.mockReturnValue({
@@ -117,14 +151,14 @@ describe("search route", () => {
 
     render(<Component />);
 
-    expect(useUnifiedSearchMock).toHaveBeenLastCalledWith("weather", "skills", {
+    expect(useUnifiedSearchMock).toHaveBeenLastCalledWith("weather", "all", {
       limits: { skills: 25, plugins: 25 },
       nonSuspiciousOnly: true,
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Load more" }));
 
-    expect(useUnifiedSearchMock).toHaveBeenLastCalledWith("weather", "skills", {
+    expect(useUnifiedSearchMock).toHaveBeenLastCalledWith("weather", "all", {
       limits: { skills: 50, plugins: 50 },
       nonSuspiciousOnly: true,
     });

--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -260,7 +260,7 @@ describe("SkillsIndex", () => {
       await vi.runAllTimersAsync();
     });
 
-    const links = screen.getAllByRole("link");
+    const links = screen.getAllByRole("link").filter((link) => link.textContent?.includes("Skill"));
     expect(links[0]?.textContent).toContain("Skill B");
     expect(links[1]?.textContent).toContain("Skill A");
     expect(links[2]?.textContent).toContain("Skill C");

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -80,7 +80,7 @@ describe("restored UI design contract", () => {
     expect(headerSource).toContain('className="github-sign-in-button"');
     expect(headerSource).toContain('className="sign-in-full-copy"');
     expect(headerSource).toContain('className="sign-in-compact-copy"');
-    expect(headerSource).toContain("Search skills, plugins, users");
+    expect(headerSource).toContain("Search skills and plugins");
     expect(headerSource).toContain('className="navbar-tabs-primary"');
     expect(headerSource).toContain('className="navbar-tabs-secondary"');
 

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -99,6 +99,7 @@ describe("restored UI design contract", () => {
     expect(themeControl).toContain("min-width: 154px");
     expect(themeControl).toContain("min-height: 50px");
     expect(themeControl).toContain("border: 1px solid var(--line)");
+    expect(css).toContain("--r-btn: var(--r-sm)");
 
     const compact = cssMediaContaining(css, "(max-width: 760px)", [
       "grid-template-columns: 56px minmax(0, 1fr) 56px",

--- a/src/components/BrowseSidebar.tsx
+++ b/src/components/BrowseSidebar.tsx
@@ -28,8 +28,8 @@ type BrowseSidebarProps = {
   sortOptions: SortOption[];
   activeSort: string;
   onSortChange: (value: string) => void;
-  filters: FilterItem[];
-  onFilterToggle: (key: string) => void;
+  filters?: FilterItem[];
+  onFilterToggle?: (key: string) => void;
 };
 
 const CATEGORY_ICONS: Record<string, React.ReactNode> = {
@@ -50,9 +50,27 @@ export function BrowseSidebar({
   sortOptions,
   activeSort,
   onSortChange,
-  filters,
+  filters = [],
   onFilterToggle,
 }: BrowseSidebarProps) {
+  const filterSection =
+    filters.length && onFilterToggle ? (
+      <fieldset className="sidebar-section" aria-label="Toggle filters">
+        <legend className="sidebar-title">Filters</legend>
+        {filters.map((f) => (
+          <label key={f.key} className="sidebar-checkbox">
+            <input
+              type="checkbox"
+              checked={f.active}
+              onChange={() => onFilterToggle(f.key)}
+              aria-label={f.label}
+            />
+            <span>{f.label}</span>
+          </label>
+        ))}
+      </fieldset>
+    ) : null;
+
   return (
     <aside className="browse-sidebar" aria-label="Browse filters">
       <fieldset className="sidebar-section" role="radiogroup" aria-label="Sort order">
@@ -101,20 +119,7 @@ export function BrowseSidebar({
         </fieldset>
       ) : null}
 
-      <fieldset className="sidebar-section" aria-label="Toggle filters">
-        <legend className="sidebar-title">Filters</legend>
-        {filters.map((f) => (
-          <label key={f.key} className="sidebar-checkbox">
-            <input
-              type="checkbox"
-              checked={f.active}
-              onChange={() => onFilterToggle(f.key)}
-              aria-label={f.label}
-            />
-            <span>{f.label}</span>
-          </label>
-        ))}
-      </fieldset>
+      {filterSection}
     </aside>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -368,7 +368,7 @@ export default function Header() {
               <input
                 className="navbar-search-input"
                 type="search"
-                placeholder={isSoulMode ? "Search souls..." : "Search skills, plugins, users"}
+                placeholder={isSoulMode ? "Search souls..." : "Search skills and plugins"}
                 value={navSearchQuery}
                 onChange={(e) => {
                   setNavSearchQuery(e.target.value);
@@ -517,7 +517,7 @@ export default function Header() {
             <input
               className="navbar-search-input"
               type="text"
-              placeholder={isSoulMode ? "Search souls..." : "Search skills, plugins, users"}
+              placeholder={isSoulMode ? "Search souls..." : "Search skills and plugins"}
               value={navSearchQuery}
               onChange={(e) => setNavSearchQuery(e.target.value)}
               autoFocus

--- a/src/components/PluginListItem.tsx
+++ b/src/components/PluginListItem.tsx
@@ -6,9 +6,44 @@ import { Badge } from "./ui/badge";
 
 type PluginListItemProps = {
   item: PackageListItem;
+  variant?: "list" | "card";
 };
 
-export function PluginListItem({ item }: PluginListItemProps) {
+export function PluginListItem({ item, variant = "list" }: PluginListItemProps) {
+  if (variant === "card") {
+    return (
+      <Link
+        to="/plugins/$name"
+        params={{ name: item.name }}
+        className="card skill-card plugin-card"
+        aria-label={`Plugin: ${item.displayName}`}
+      >
+        <div className="skill-card-tags">
+          <Badge variant="compact">{familyLabel(item.family)}</Badge>
+          {item.isOfficial ? <Badge variant="accent">Verified</Badge> : null}
+        </div>
+        <div className="skill-card-header">
+          <MarketplaceIcon kind="plugin" label={item.displayName} size="md" />
+          <h3 className="skill-card-title">{item.displayName}</h3>
+        </div>
+        <p className="skill-card-summary">
+          {item.summary ?? "Plugin package for agent workflows."}
+        </p>
+        <div className="skill-card-footer">
+          <div className="skill-list-item-meta plugin-card-meta">
+            <span className="skill-list-item-meta-item">Plugin</span>
+            {item.latestVersion ? (
+              <span className="skill-list-item-meta-item">v{item.latestVersion}</span>
+            ) : null}
+            <span className="skill-list-item-meta-item">
+              {item.ownerHandle ? `@${item.ownerHandle}` : "community"}
+            </span>
+          </div>
+        </div>
+      </Link>
+    );
+  }
+
   return (
     <Link
       to="/plugins/$name"

--- a/src/components/SkillCard.tsx
+++ b/src/components/SkillCard.tsx
@@ -12,6 +12,7 @@ type SkillCardProps = {
   summaryFallback: string;
   meta: ReactNode;
   href?: string;
+  className?: string;
 };
 
 export function SkillCard({
@@ -22,6 +23,7 @@ export function SkillCard({
   summaryFallback,
   meta,
   href,
+  className,
 }: SkillCardProps) {
   const owner = encodeURIComponent(String(skill.ownerUserId));
   const link = href ?? `/${owner}/${skill.slug}`;
@@ -29,7 +31,7 @@ export function SkillCard({
   const hasTags = badges.length || chip || platformLabels?.length;
 
   return (
-    <Link to={link} className="card skill-card">
+    <Link to={link} className={["card skill-card", className].filter(Boolean).join(" ")}>
       {hasTags ? (
         <div className="skill-card-tags">
           {badges.map((label) => (

--- a/src/components/SkillStats.tsx
+++ b/src/components/SkillStats.tsx
@@ -1,11 +1,19 @@
-import { ArrowDownToLine } from "lucide-react";
+import { ArrowDownToLine, Star } from "lucide-react";
 import { formatSkillStatsTriplet, type SkillStatsTriplet } from "../lib/numberFormat";
 
 export function SkillStatsTripletLine({ stats }: { stats: SkillStatsTriplet }) {
   const formatted = formatSkillStatsTriplet(stats);
   return (
-    <>
-      ⭐ {formatted.stars} · <ArrowDownToLine size={13} aria-hidden="true" /> {formatted.downloads}
-    </>
+    <span className="skill-stats-triplet">
+      <span className="skill-stats-item">
+        <Star size={14} aria-hidden="true" />
+        {formatted.stars}
+      </span>
+      <span className="skill-stats-dot">·</span>
+      <span className="skill-stats-item">
+        <ArrowDownToLine size={14} aria-hidden="true" />
+        {formatted.downloads}
+      </span>
+    </span>
   );
 }

--- a/src/routes/plugins/index.tsx
+++ b/src/routes/plugins/index.tsx
@@ -17,6 +17,7 @@ type PluginSearchState = {
   featured?: boolean;
   verified?: boolean;
   executesCode?: boolean;
+  view?: "list" | "cards";
 };
 
 type PluginsLoaderData = {
@@ -53,6 +54,7 @@ export const Route = createFileRoute("/plugins/")({
       search.executesCode === true || search.executesCode === "true" || search.executesCode === "1"
         ? true
         : undefined,
+    view: search.view === "cards" || search.view === "list" ? search.view : undefined,
   }),
   loaderDeps: ({ search }) => search,
   loader: async ({ deps }): Promise<PluginsLoaderData> => {
@@ -108,6 +110,7 @@ function PluginsIndex() {
   const rateLimited = loaderData?.rateLimited ?? false;
   const retryAfterSeconds = loaderData?.retryAfterSeconds ?? null;
   const apiError = loaderData?.apiError ?? !loaderData;
+  const view = search.view ?? "list";
 
   const [query, setQuery] = useState(search.q ?? "");
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -171,6 +174,15 @@ function PluginsIndex() {
     });
   };
 
+  const handleToggleView = (nextView: "list" | "cards") => {
+    void navigate({
+      search: (prev) => ({
+        ...prev,
+        view: nextView === "list" ? undefined : nextView,
+      }),
+    });
+  };
+
   return (
     <main className="browse-page">
       <div className="browse-page-header">
@@ -182,7 +194,9 @@ function PluginsIndex() {
         >
           Filters
         </button>
-        <h1 className="browse-title">Plugins</h1>
+        <h1 className="browse-title">
+          Plugins <span className="browse-count">{items.length}</span>
+        </h1>
         <div className="browse-page-actions">
           <Button asChild variant="primary">
             <Link
@@ -227,8 +241,24 @@ function PluginsIndex() {
         <div className="browse-results">
           <div className="browse-results-toolbar">
             <span className="browse-results-count">
-              {items.length} plugin{items.length !== 1 ? "s" : ""}
+              {items.length} result{items.length !== 1 ? "s" : ""}
             </span>
+            <div className="browse-view-toggle">
+              <button
+                className={`browse-view-btn${view === "list" ? " is-active" : ""}`}
+                type="button"
+                onClick={view === "cards" ? () => handleToggleView("list") : undefined}
+              >
+                List
+              </button>
+              <button
+                className={`browse-view-btn${view === "cards" ? " is-active" : ""}`}
+                type="button"
+                onClick={view === "list" ? () => handleToggleView("cards") : undefined}
+              >
+                Cards
+              </button>
+            </div>
           </div>
 
           {apiError ? (
@@ -251,9 +281,13 @@ function PluginsIndex() {
               <p className="empty-state-body">Try a different search term or remove filters.</p>
             </div>
           ) : (
-            <div className="results-list">
+            <div className={view === "cards" ? "grid" : "results-list"}>
               {items.map((item) => (
-                <PluginListItem key={item.name} item={item} />
+                <PluginListItem
+                  key={item.name}
+                  item={item}
+                  variant={view === "cards" ? "card" : "list"}
+                />
               ))}
             </div>
           )}

--- a/src/routes/plugins/index.tsx
+++ b/src/routes/plugins/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { AlertTriangle, Search } from "lucide-react";
+import { PackageSearch, Search } from "lucide-react";
 import { useEffect, useState } from "react";
 import { BrowseSidebar } from "../../components/BrowseSidebar";
 import { PluginListItem } from "../../components/PluginListItem";
@@ -270,7 +270,7 @@ function PluginsIndex() {
 
           {apiError ? (
             <div className="empty-state">
-              <AlertTriangle size={20} aria-hidden="true" />
+              <PackageSearch size={22} className="empty-state-icon" aria-hidden="true" />
               <p className="empty-state-title">Unable to load plugins</p>
               <p className="empty-state-body">
                 The plugin catalog is temporarily unavailable. Please try again later.
@@ -278,7 +278,7 @@ function PluginsIndex() {
             </div>
           ) : rateLimited ? (
             <div className="empty-state">
-              <AlertTriangle size={20} aria-hidden="true" />
+              <PackageSearch size={22} className="empty-state-icon" aria-hidden="true" />
               <p className="empty-state-title">Plugin catalog is temporarily unavailable</p>
               <p className="empty-state-body">Try again {formatRetryDelay(retryAfterSeconds)}.</p>
             </div>

--- a/src/routes/plugins/index.tsx
+++ b/src/routes/plugins/index.tsx
@@ -56,7 +56,14 @@ export const Route = createFileRoute("/plugins/")({
         : undefined,
     view: search.view === "cards" || search.view === "list" ? search.view : undefined,
   }),
-  loaderDeps: ({ search }) => search,
+  loaderDeps: ({ search }) => ({
+    q: search.q,
+    cursor: search.cursor,
+    family: search.family,
+    featured: search.featured,
+    verified: search.verified,
+    executesCode: search.executesCode,
+  }),
   loader: async ({ deps }): Promise<PluginsLoaderData> => {
     try {
       const data = await fetchPluginCatalog({

--- a/src/routes/search.tsx
+++ b/src/routes/search.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { Check, Search } from "lucide-react";
+import { Check, Search, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { PluginListItem } from "../components/PluginListItem";
 import { SkillListItem } from "../components/SkillListItem";
@@ -49,17 +49,24 @@ function UnifiedSearchPage() {
     setResultLimit(SEARCH_PAGE_SIZE);
   }, [search.q, activeType, nonSuspiciousOnly]);
 
-  const { results, skillCount, pluginCount, isSearching } = useUnifiedSearch(
-    search.q ?? "",
-    activeType,
-    {
-      limits: {
-        skills: resultLimit,
-        plugins: resultLimit,
-      },
-      nonSuspiciousOnly,
+  const {
+    results: allResults,
+    skillCount,
+    pluginCount,
+    isSearching,
+  } = useUnifiedSearch(search.q ?? "", "all", {
+    limits: {
+      skills: resultLimit,
+      plugins: resultLimit,
     },
-  );
+    nonSuspiciousOnly,
+  });
+  const results =
+    activeType === "all"
+      ? allResults
+      : allResults.filter((item) => item.type === (activeType === "skills" ? "skill" : "plugin"));
+  const showSearchCounts = Boolean(search.q);
+  const allCount = skillCount + pluginCount;
   const canLoadMore =
     search.q &&
     !isSearching &&
@@ -104,6 +111,15 @@ function UnifiedSearchPage() {
     });
   };
 
+  const clearSearch = () => {
+    setQuery("");
+    void navigate({
+      to: "/search",
+      search: { q: undefined, type: search.type },
+      replace: true,
+    });
+  };
+
   return (
     <main className="browse-page">
       <h1 className="browse-title mb-4">
@@ -117,7 +133,7 @@ function UnifiedSearchPage() {
       </h1>
 
       <form className="search-page-form" onSubmit={handleSearch}>
-        <div className="browse-search-bar max-w-[560px] flex-1">
+        <div className="browse-search-bar search-page-field max-w-[560px] flex-1">
           <Search size={16} className="navbar-search-icon" aria-hidden="true" />
           <input
             className="browse-search-input"
@@ -127,6 +143,16 @@ function UnifiedSearchPage() {
             onChange={(e) => setQuery(e.target.value)}
             autoFocus
           />
+          {query ? (
+            <button
+              className="search-clear-button"
+              type="button"
+              aria-label="Clear search"
+              onClick={clearSearch}
+            >
+              <X size={15} aria-hidden="true" />
+            </button>
+          ) : null}
         </div>
       </form>
 
@@ -136,23 +162,22 @@ function UnifiedSearchPage() {
           type="button"
           onClick={() => setType("all")}
         >
-          All
+          All {showSearchCounts ? <span className="search-tab-count">{allCount}</span> : null}
         </button>
         <button
           className={`search-tab${activeType === "skills" ? " is-active" : ""}`}
           type="button"
           onClick={() => setType("skills")}
         >
-          Skills
-          {skillCount > 0 ? <span className="search-tab-count">{skillCount}</span> : null}
+          Skills {showSearchCounts ? <span className="search-tab-count">{skillCount}</span> : null}
         </button>
         <button
           className={`search-tab${activeType === "plugins" ? " is-active" : ""}`}
           type="button"
           onClick={() => setType("plugins")}
         >
-          Plugins
-          {pluginCount > 0 ? <span className="search-tab-count">{pluginCount}</span> : null}
+          Plugins{" "}
+          {showSearchCounts ? <span className="search-tab-count">{pluginCount}</span> : null}
         </button>
       </div>
 

--- a/src/routes/skills/-SkillsResults.tsx
+++ b/src/routes/skills/-SkillsResults.tsx
@@ -6,6 +6,7 @@ import { SkillStatsTripletLine } from "../../components/SkillStats";
 import { Button } from "../../components/ui/button";
 import { UserBadge } from "../../components/UserBadge";
 import { getSkillBadges } from "../../lib/badges";
+import { timeAgo } from "../../lib/timeAgo";
 import { buildSkillHref, type SkillListEntry } from "./-types";
 import type { SkillsView } from "./-useSkillsBrowseModel";
 
@@ -72,6 +73,7 @@ export function SkillsResults({
                 key={skill._id}
                 skill={skill}
                 href={skillHref}
+                className="skill-card-spaced-footer"
                 badge={getSkillBadges(skill)}
                 chip={isPlugin ? "Plugin bundle (nix)" : undefined}
                 platformLabels={platforms.length ? platforms : undefined}
@@ -85,7 +87,12 @@ export function SkillsResults({
                       link={false}
                     />
                     <div className="stat">
-                      <SkillStatsTripletLine stats={skill.stats} />
+                      <div className="skill-card-statline">
+                        <span className="skill-card-updated">
+                          Updated {timeAgo(skill.updatedAt)}
+                        </span>
+                        <SkillStatsTripletLine stats={skill.stats} />
+                      </div>
                     </div>
                   </div>
                 }

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -88,13 +88,6 @@ export function SkillsIndex() {
     ? [{ value: "relevance", label: "Relevance" }, ...SORT_OPTIONS]
     : SORT_OPTIONS;
 
-  const handleFilterToggle = useCallback(
-    (key: string) => {
-      if (key === "nonSuspicious") model.onToggleNonSuspicious();
-    },
-    [model.onToggleNonSuspicious],
-  );
-
   const handleSortChange = useCallback(
     (value: string) => {
       if (value === "featured") {
@@ -190,10 +183,6 @@ export function SkillsIndex() {
           sortOptions={[{ value: "featured", label: "Featured" }, ...sortOptionsWithRelevance]}
           activeSort={model.featuredOnly ? "featured" : model.sort}
           onSortChange={handleSortChange}
-          filters={[
-            { key: "nonSuspicious", label: "Hide suspicious", active: model.nonSuspiciousOnly },
-          ]}
-          onFilterToggle={handleFilterToggle}
         />
         <div className="browse-results">
           <div className="browse-results-toolbar">
@@ -205,21 +194,31 @@ export function SkillsIndex() {
                 </button>
               ) : null}
             </span>
-            <div className="browse-view-toggle">
-              <button
-                className={`browse-view-btn${model.view === "list" ? " is-active" : ""}`}
-                type="button"
-                onClick={model.view === "grid" ? model.onToggleView : undefined}
-              >
-                List
-              </button>
-              <button
-                className={`browse-view-btn${model.view === "grid" ? " is-active" : ""}`}
-                type="button"
-                onClick={model.view === "list" ? model.onToggleView : undefined}
-              >
-                Grid
-              </button>
+            <div className="browse-results-actions">
+              <label className="browse-toolbar-checkbox">
+                <input
+                  type="checkbox"
+                  checked={model.nonSuspiciousOnly}
+                  onChange={model.onToggleNonSuspicious}
+                />
+                <span>Hide suspicious</span>
+              </label>
+              <div className="browse-view-toggle">
+                <button
+                  className={`browse-view-btn${model.view === "list" ? " is-active" : ""}`}
+                  type="button"
+                  onClick={model.view === "grid" ? model.onToggleView : undefined}
+                >
+                  List
+                </button>
+                <button
+                  className={`browse-view-btn${model.view === "grid" ? " is-active" : ""}`}
+                  type="button"
+                  onClick={model.view === "list" ? model.onToggleView : undefined}
+                >
+                  Grid
+                </button>
+              </div>
             </div>
           </div>
           <SkillsResults

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -1,9 +1,10 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute, Link, redirect } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
 import { Search } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { api } from "../../../convex/_generated/api";
 import { BrowseSidebar } from "../../components/BrowseSidebar";
+import { Button } from "../../components/ui/button";
 import { SKILL_CATEGORIES } from "../../lib/categories";
 import { formatCompactStat } from "../../lib/numberFormat";
 import { parseDir, parseSort } from "./-params";
@@ -164,6 +165,13 @@ export function SkillsIndex() {
           Skills
           {totalSkillsText ? <span className="browse-count">{totalSkillsText}</span> : null}
         </h1>
+        <div className="browse-page-actions">
+          <Button asChild variant="primary">
+            <Link to="/publish-skill" search={{ updateSlug: undefined }}>
+              Publish
+            </Link>
+          </Button>
+        </div>
       </div>
       <div className="browse-page-search">
         <Search size={15} className="navbar-search-icon" aria-hidden="true" />

--- a/src/styles.css
+++ b/src/styles.css
@@ -2659,6 +2659,9 @@ code {
 
 .plugin-card {
   min-height: 180px;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .skill-card:hover {

--- a/src/styles.css
+++ b/src/styles.css
@@ -8279,6 +8279,35 @@ code {
   margin-bottom: var(--space-5);
 }
 
+.search-page-field {
+  padding-right: var(--space-2);
+}
+
+.search-clear-button {
+  all: unset;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: var(--r-sm);
+  color: var(--ink-soft);
+  cursor: pointer;
+  transition:
+    color var(--transition-fast),
+    background-color var(--transition-fast);
+}
+
+.search-clear-button:hover {
+  background: var(--surface-muted);
+  color: var(--ink);
+}
+
+.search-clear-button:focus-visible {
+  outline: 2px solid var(--input-focus-border);
+  outline-offset: 2px;
+}
+
 .search-tabs {
   display: flex;
   gap: 0;

--- a/src/styles.css
+++ b/src/styles.css
@@ -7898,7 +7898,7 @@ code {
   top: var(--browse-sticky-top);
   display: flex;
   flex-direction: column;
-  gap: var(--space-4);
+  gap: var(--space-3);
   padding-right: 16px;
   border-right: 1px solid var(--line);
   max-height: calc(100vh - var(--browse-sticky-top) - var(--space-4));
@@ -7909,19 +7909,24 @@ code {
 .sidebar-section {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 0;
   border: none;
   padding: 0;
   margin: 0;
 }
 
+.sidebar-section + .sidebar-section {
+  margin-top: var(--space-3);
+}
+
 .sidebar-title {
-  font-size: var(--fs-xs);
-  font-weight: 600;
+  font-size: 0.68rem;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   color: var(--ink-soft);
-  padding: var(--space-1) 0;
+  opacity: 0.78;
+  padding: 2px 0 1px;
 }
 
 .sidebar-option {
@@ -7929,11 +7934,13 @@ code {
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  padding: var(--space-2) 0;
+  padding: 5px 0;
   font-size: var(--fs-sm);
-  color: var(--ink-soft);
+  font-weight: 500;
+  line-height: 1.25;
+  color: color-mix(in srgb, var(--ink-soft) 82%, var(--ink));
   cursor: pointer;
-  min-height: 32px;
+  min-height: 28px;
 }
 
 .sidebar-option:hover {
@@ -7961,11 +7968,12 @@ code {
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  padding: var(--space-2) 0;
+  padding: 5px 0;
   font-size: var(--fs-sm);
+  line-height: 1.25;
   color: var(--ink-soft);
   cursor: pointer;
-  min-height: 32px;
+  min-height: 28px;
 }
 
 .sidebar-checkbox:hover {
@@ -7990,6 +7998,14 @@ code {
   gap: 12px;
 }
 
+.browse-results-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
 .browse-results-count {
   display: flex;
   align-items: center;
@@ -8008,6 +8024,24 @@ code {
 
 .browse-clear-btn:hover {
   text-decoration: underline;
+}
+
+.browse-toolbar-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: 30px;
+  color: var(--ink-soft);
+  cursor: pointer;
+  font-size: var(--fs-sm);
+}
+
+.browse-toolbar-checkbox:hover {
+  color: var(--ink);
+}
+
+.browse-toolbar-checkbox input[type="checkbox"] {
+  accent-color: var(--accent);
 }
 
 .browse-view-toggle {

--- a/src/styles.css
+++ b/src/styles.css
@@ -10669,11 +10669,11 @@ code {
 
 /* ═══════════════════════════════════════════════════════════════════════
    BUTTON RADIUS CONSISTENCY
-   Single token for all buttons: --r-btn (4px — semi-rounded, not pill)
+   Single token for all buttons: --r-btn (matches search controls, not pills)
    ═══════════════════════════════════════════════════════════════════════ */
 
 :root {
-  --r-btn: 4px;
+  --r-btn: var(--r-sm);
 }
 
 /* Core buttons */

--- a/src/styles.css
+++ b/src/styles.css
@@ -2657,6 +2657,10 @@ code {
   transition: all 0.2s ease;
 }
 
+.plugin-card {
+  min-height: 180px;
+}
+
 .skill-card:hover {
   border-color: var(--border-ui-hover);
   transform: translateY(-2px);
@@ -7587,6 +7591,10 @@ code {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+}
+
+.plugin-card-meta {
+  justify-content: flex-end;
 }
 
 .user-list-item .skill-list-item-owner {

--- a/src/styles.css
+++ b/src/styles.css
@@ -2665,7 +2665,7 @@ code {
 
 .skill-card-header {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 14px;
 }
 
@@ -2761,6 +2761,12 @@ code {
   margin-top: auto;
 }
 
+.skill-card-spaced-footer .skill-card-footer {
+  display: flex;
+  flex: 1;
+  margin-top: 0;
+}
+
 .skill-card-footer-inline {
   display: flex;
   align-items: center;
@@ -2775,8 +2781,53 @@ code {
   align-items: start;
 }
 
+.skill-card-spaced-footer .skill-card-footer-rows {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+
 .skill-card-footer-rows .stat {
   justify-self: end;
+}
+
+.skill-card-spaced-footer .skill-card-footer-rows .stat {
+  align-self: stretch;
+  margin-top: auto;
+  padding-top: 8px;
+}
+
+.skill-card-statline,
+.skill-stats-triplet,
+.skill-stats-item {
+  display: inline-flex;
+  align-items: center;
+}
+
+.skill-card-statline {
+  width: 100%;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--ink-soft);
+  font-size: var(--fs-xs);
+}
+
+.skill-card-updated {
+  color: color-mix(in srgb, var(--ink-soft) 78%, var(--surface));
+}
+
+.skill-card-statline-dot,
+.skill-stats-dot {
+  color: var(--ink-muted);
+}
+
+.skill-stats-triplet {
+  gap: 6px;
+}
+
+.skill-stats-item {
+  gap: 4px;
 }
 
 .user-badge {

--- a/src/styles.css
+++ b/src/styles.css
@@ -7961,6 +7961,7 @@ code {
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
+  padding-top: 4px;
   padding-right: 16px;
   border-right: 1px solid var(--line);
   max-height: calc(100vh - var(--browse-sticky-top) - var(--space-4));
@@ -8187,6 +8188,7 @@ code {
     max-height: none;
     border-right: none;
     border-bottom: 1px solid var(--line);
+    padding-top: 0;
     padding-right: 0;
     padding-bottom: 16px;
     flex-direction: row;
@@ -9086,6 +9088,12 @@ code {
   padding: var(--space-7) var(--space-5);
   border: 1px solid var(--line);
   border-radius: var(--r-sm);
+}
+
+.empty-state-icon {
+  display: block;
+  margin: 0 auto var(--space-3);
+  color: var(--ink-soft);
 }
 
 .empty-state-title {


### PR DESCRIPTION
## Summary

- What changed: aligned ClawHub's browse/listing chrome across skills, plugins, and search, including search cleanup, plugin list/card controls, safer filter placement, consistent control radius, card metadata polish, and a cleaner plugin empty state.
- Why: comparable browse surfaces were drifting in small but visible ways. Plugins did not expose the same listing affordances as skills, search mixed user suggestions into a skills/plugins query surface, Hide suspicious was buried in the sidebar, and card metadata spacing/icons differed between list and card views.

## Linked Issue

- Closes N/A
- Related N/A

## Screenshots

- [x] Screenshots/recordings attached, or `N/A`

### Search scope, clear action, and result counts

| Before | After |
| --- | --- |
| ![Before search exposed users and had no clear action](https://i.imgur.com/2GZBqaC.png) | ![After search removes users, adds a clear action, and shows result counts](https://i.imgur.com/j7V51HG.png) |

The search surface is now scoped to skills and plugins, the typed query can be cleared directly from the input, and the tabs expose result counts for the searchable catalog types. (The Users label was removed because the current search does not actually return users; user search can be proposed separately, but the current UI should not imply behavior it does not support.)

### Safety filter visibility in the results toolbar

| Before | After |
| --- | --- |
| ![Before Hide suspicious was buried in sidebar filters](https://i.imgur.com/OudwrfH.png) | ![After Hide suspicious is next to the view toggle](https://i.imgur.com/7xoXD4q.png) |

The safety filter moved from the bottom of the sidebar into the results toolbar. This makes an important safety control discoverable without requiring users to scroll through the sidebar first, and keeps it visible beside the active catalog view where users are already scanning results.

### Sidebar section hierarchy and grouping

| Before | After |
| --- | --- |
| ![Before sidebar hierarchy](https://i.imgur.com/2HO5s6s.png) | ![After sidebar hierarchy](https://i.imgur.com/gBFvXmw.png) |

The sidebar keeps the same filter options, but section-label contrast and spacing now separate Sort by from Categories more clearly.

### Skill card hierarchy and metadata treatment

| Before | After |
| --- | --- |
| ![Before skills card metadata](https://i.imgur.com/vF0l9RA.png) | ![After skills card metadata](https://i.imgur.com/VJhkp8N.png) |

Skill cards now have a clearer hierarchy: the icon/title group reads as one header, the title aligns more predictably with the icon block, the star treatment matches list rows, and updated/stats metadata is grouped into a calmer footer instead of competing with the main content.

### Skill card density, balance, and flexible footer spacing

| Before | After |
| --- | --- |
| ![Before extra card space separated description and author](https://i.imgur.com/hCQ8oZQ.png) | ![After extra card space separates author and stats](https://i.imgur.com/IYUXOWE.png) |

Card height compensation now preserves the content group first: title, description, and author stay visually connected, while flexible space is absorbed before the stats/action area. That keeps dense cards readable without making sparse cards feel stretched through the body copy.

### Plugin browse chrome parity and card view

| Before | After |
| --- | --- |
| ![Before plugin browse chrome](https://i.imgur.com/h38wDzz.png) | ![After plugin browse chrome](https://i.imgur.com/Chy68Nd.png) |

Plugins now match the skills browse chrome more closely, including count placement, publish action balance, and the list/card control area.

![Plugin card view](https://i.imgur.com/6jao7pT.png)

Plugins now support the same card-oriented scan pattern as skills without changing the plugin data being rendered.

### Plugin unavailable-state presentation

| Before | After |
| --- | --- |
| ![Before plugin empty state](https://i.imgur.com/YpVj0tJ.png) | ![After plugin empty state](https://i.imgur.com/MOgeoyw.png) |

The plugin catalog empty state is centered as a single unit and uses a catalog/search icon instead of a warning icon, which better matches an unavailable listing state.

### Shared control radius across browse chrome

| Before | After |
| --- | --- |
| ![Before inconsistent control radius](https://i.imgur.com/sfg8S7F.png) | ![After consistent control radius](https://i.imgur.com/oMLBDnu.png) |

Header controls, view toggles, and action buttons now share the same rounded-corner language as the search field instead of mixing multiple radii on the same chrome.

### Sidebar and results-column top alignment

| Before | After |
| --- | --- |
| ![Before sidebar and result count alignment](https://i.imgur.com/WG2Yekj.png) | ![After sidebar and result count alignment](https://i.imgur.com/I0dIFF1.png) |

The sidebar label and results count now start on the same visual baseline, reducing the uneven top edge between the filter rail and the listing column.

## Security / Trust Impact

- [x] No security/trust impact
- [ ] Security/trust impact explained

This moves the existing Hide suspicious control into the results toolbar so the safety filter is visible near the result-view controls. It does not change the filter semantics, suspicious-skill defaults, moderation data, auth, permissions, or backend trust behavior.

## Data / Deploy Impact

- [x] No data/deploy impact
- [ ] Data/deploy impact explained

No schema, migration, API, publishing, or catalog data changes. The plugin card toggle keeps the same loaded data and avoids re-running the plugin loader when only the local view mode changes.

## Verification

- [x] `bun run format:check`
- [x] `bun run lint`
- [ ] `bun run test`
- [x] Other:
  - `bun run test src/__tests__/search-route.test.tsx src/__tests__/header.test.tsx src/__tests__/packages-route.test.tsx src/__tests__/skills-index.test.tsx src/__tests__/skills-toolbar.test.tsx src/__tests__/ui-design-contract.test.ts`
  - `bun run build`
  - `/Users/vyctor/.codex/skills/oss-pr-contributions/scripts/public_pr_preflight.sh /Users/vyctor/Code/clawhub`



