### PR TITLE
fix: rename skills cards view to grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changes
 
+- Web: rename the skills browse alternate view from Cards to Grid while keeping legacy `view=cards` URLs compatible (#2090) (thanks @vyctorbrzezowski).
+
 ### Fixes
 
 - Skills: repair publisher-owned skill merges, bound historical slug redirects, block protected slug namespaces, and expire owner-unpublished slug reservations after 30 days (#2115) (thanks @fuller-stack-dev).

--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -80,6 +80,36 @@ describe("SkillsIndex", () => {
     expect(screen.queryByText("No skills found")).toBeNull();
   });
 
+  it("uses grid as the canonical browse view URL value", async () => {
+    render(<SkillsIndex />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Grid" }));
+
+    const lastCall = navigateMock.mock.calls.at(-1)?.[0] as {
+      replace?: boolean;
+      search: (prev: Record<string, unknown>) => Record<string, unknown>;
+    };
+    expect(lastCall.replace).toBe(true);
+    expect(lastCall.search({})).toEqual({ view: "grid" });
+  });
+
+  it("keeps legacy cards URLs compatible with the grid view", async () => {
+    searchMock = { view: "cards" };
+    render(<SkillsIndex />);
+
+    const gridButton = screen.getByRole("button", { name: "Grid" });
+    expect(gridButton.className).toContain("is-active");
+
+    fireEvent.click(screen.getByRole("button", { name: "List" }));
+
+    const lastCall = navigateMock.mock.calls.at(-1)?.[0] as {
+      replace?: boolean;
+      search: (prev: Record<string, unknown>) => Record<string, unknown>;
+    };
+    expect(lastCall.replace).toBe(true);
+    expect(lastCall.search({ view: "cards" })).toEqual({ view: undefined });
+  });
+
   it("shows empty state immediately when search returns no results", async () => {
     searchMock = { q: "nonexistent-skill-xyz" };
     const actionFn = vi.fn().mockResolvedValue([]);

--- a/src/routes/skills/-SkillsResults.tsx
+++ b/src/routes/skills/-SkillsResults.tsx
@@ -7,11 +7,12 @@ import { Button } from "../../components/ui/button";
 import { UserBadge } from "../../components/UserBadge";
 import { getSkillBadges } from "../../lib/badges";
 import { buildSkillHref, type SkillListEntry } from "./-types";
+import type { SkillsView } from "./-useSkillsBrowseModel";
 
 type SkillsResultsProps = {
   isLoadingSkills: boolean;
   sorted: SkillListEntry[];
-  view: "cards" | "list";
+  view: SkillsView;
   listDoneLoading: boolean;
   hasQuery: boolean;
   canLoadMore: boolean;
@@ -57,7 +58,7 @@ export function SkillsResults({
               : "No skills have been published yet."}
           </p>
         </div>
-      ) : view === "cards" ? (
+      ) : view === "grid" ? (
         <div className="grid">
           {sorted.map((entry) => {
             const skill = entry.skill;

--- a/src/routes/skills/-SkillsToolbar.tsx
+++ b/src/routes/skills/-SkillsToolbar.tsx
@@ -27,6 +27,7 @@ import {
 } from "../../components/ui/select";
 import { SKILL_CATEGORIES, type SkillCategory } from "../../lib/categories";
 import { type SortDir, type SortKey } from "./-params";
+import type { SkillsView } from "./-useSkillsBrowseModel";
 
 type SkillsToolbarProps = {
   searchInputRef: RefObject<HTMLInputElement | null>;
@@ -34,7 +35,7 @@ type SkillsToolbarProps = {
   hasQuery: boolean;
   sort: SortKey;
   dir: SortDir;
-  view: "cards" | "list";
+  view: SkillsView;
   highlightedOnly: boolean;
   nonSuspiciousOnly: boolean;
   capabilityTag?: string;
@@ -218,7 +219,7 @@ export function SkillsToolbar({
             type="button"
             onClick={view === "list" ? onToggleView : undefined}
             className={`inline-flex h-[30px] w-[30px] items-center justify-center rounded-full transition-colors ${
-              view === "cards"
+              view === "grid"
                 ? "bg-accent text-accent-fg"
                 : "text-[color:var(--ink-soft)] hover:text-[color:var(--ink)]"
             }`}
@@ -228,7 +229,7 @@ export function SkillsToolbar({
           </button>
           <button
             type="button"
-            onClick={view === "cards" ? onToggleView : undefined}
+            onClick={view === "grid" ? onToggleView : undefined}
             className={`inline-flex h-[30px] w-[30px] items-center justify-center rounded-full transition-colors ${
               view === "list"
                 ? "bg-accent text-accent-fg"

--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -8,7 +8,14 @@ import type { SkillListEntry, SkillSearchEntry } from "./-types";
 
 const pageSize = 25;
 
-type SkillsView = "cards" | "list";
+export type SkillsView = "grid" | "list";
+type LegacySkillsView = SkillsView | "cards";
+
+export function normalizeSkillsView(value: unknown): SkillsView | undefined {
+  if (value === "list") return "list";
+  if (value === "grid" || value === "cards") return "grid";
+  return undefined;
+}
 
 export type SkillsSearchState = {
   q?: string;
@@ -18,7 +25,7 @@ export type SkillsSearchState = {
   featured?: boolean;
   nonSuspicious?: boolean;
   tag?: string;
-  view?: SkillsView;
+  view?: LegacySkillsView;
   focus?: "search";
 };
 
@@ -57,7 +64,7 @@ export function useSkillsBrowseModel({
   const loadMoreInFlightRef = useRef(false);
   const navigateTimer = useRef<number>(0);
 
-  const view: SkillsView = search.view ?? "list";
+  const view: SkillsView = normalizeSkillsView(search.view) ?? "list";
   const featuredOnly = search.featured ?? search.highlighted ?? false;
   const nonSuspiciousOnly = search.nonSuspicious ?? false;
   const capabilityTag = search.tag;
@@ -371,7 +378,7 @@ export function useSkillsBrowseModel({
     void navigate({
       search: (prev) => ({
         ...prev,
-        view: prev.view === "cards" ? undefined : "cards",
+        view: normalizeSkillsView(prev.view) === "grid" ? undefined : "grid",
       }),
       replace: true,
     });

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -8,7 +8,11 @@ import { SKILL_CATEGORIES } from "../../lib/categories";
 import { formatCompactStat } from "../../lib/numberFormat";
 import { parseDir, parseSort } from "./-params";
 import { SkillsResults } from "./-SkillsResults";
-import { useSkillsBrowseModel, type SkillsSearchState } from "./-useSkillsBrowseModel";
+import {
+  normalizeSkillsView,
+  useSkillsBrowseModel,
+  type SkillsSearchState,
+} from "./-useSkillsBrowseModel";
 
 const SORT_OPTIONS = [
   { value: "downloads", label: "Most downloaded" },
@@ -39,7 +43,7 @@ export const Route = createFileRoute("/skills/")({
         search.nonSuspicious === true
           ? true
           : undefined,
-      view: search.view === "cards" || search.view === "list" ? search.view : undefined,
+      view: normalizeSkillsView(search.view),
       focus: search.focus === "search" ? "search" : undefined,
     };
   },
@@ -205,16 +209,16 @@ export function SkillsIndex() {
               <button
                 className={`browse-view-btn${model.view === "list" ? " is-active" : ""}`}
                 type="button"
-                onClick={model.view === "cards" ? model.onToggleView : undefined}
+                onClick={model.view === "grid" ? model.onToggleView : undefined}
               >
                 List
               </button>
               <button
-                className={`browse-view-btn${model.view === "cards" ? " is-active" : ""}`}
+                className={`browse-view-btn${model.view === "grid" ? " is-active" : ""}`}
                 type="button"
                 onClick={model.view === "list" ? model.onToggleView : undefined}
               >
-                Cards
+                Grid
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Why

The browse toggle is choosing between two layout modes, so both labels should describe layout at the same level of abstraction. `List` describes the layout of the results, while `Cards` describes the presentation of each item inside the alternate layout. Renaming that option to `Grid` makes the pair read as two comparable layout choices: `List` or `Grid`.

This also lets new URLs use `view=grid`, which better matches the visible mode, while keeping existing `view=cards` links working for compatibility.

## What changed

- Renamed the `/skills` view toggle from `Cards` to `Grid`.
- Made `view=grid` the canonical URL value when switching from list view.
- Kept legacy `view=cards` URLs compatible by normalizing them to the grid view.
- Updated the skills browse view type through the model/results/toolbar path.
- Added focused tests for the new canonical URL value and the legacy `view=cards` alias.
- Added a changelog entry with contributor credit.

## Linked Issue

- Related #52

## Screenshots

N/A - this is a one-word control label and URL semantics change; no layout styling changed.

- [ ] Screenshots/recordings attached, or `N/A`

## Security / Trust Impact

- [x] No security/trust impact
- [ ] Security/trust impact explained

## Data / Deploy Impact

- [x] No data/deploy impact
- [ ] Data/deploy impact explained

## Verification

- [x] `git diff --check`
- [x] `bun run format:check`
- [x] `VITE_CONVEX_URL=https://example.invalid bun run test -- src/__tests__/skills-index.test.tsx src/__tests__/skills-toolbar.test.tsx`
- [x] `bun run lint`
- [x] `VITE_CONVEX_URL=https://example.invalid bun run build`
- [x] `VITE_CONVEX_URL=https://example.invalid bun run test`
