### PR TITLE
feat: add docs nav link

### DIFF
--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -222,6 +222,7 @@ describe("Header", () => {
     expect(screen.getAllByText("Plugins")).toHaveLength(1);
     expect(screen.getAllByText("Users")).toHaveLength(1);
     expect(screen.getAllByText("About")).toHaveLength(1);
+    expect(screen.getAllByText("Docs")).toHaveLength(1);
     expect(screen.queryByText("Dashboard")).toBeNull();
     expect(screen.queryByText("Manage")).toBeNull();
     expect(screen.getByPlaceholderText("Search skills, plugins, users")).toBeTruthy();
@@ -236,6 +237,7 @@ describe("Header", () => {
     expect(screen.getAllByText("Plugins")).toHaveLength(2);
     expect(screen.getAllByText("Users")).toHaveLength(2);
     expect(screen.getAllByText("About")).toHaveLength(2);
+    expect(screen.getAllByText("Docs")).toHaveLength(2);
   });
 
   it("renders the GitHub sign-in button with desktop and compact labels", () => {
@@ -383,6 +385,7 @@ describe("Header", () => {
       .filter((label): label is string => Boolean(label));
 
     expect(labels.slice(0, 2)).toEqual(["Home", "Skills"]);
+    expect(labels.slice(3, 6)).toEqual(["Users", "About", "Docs"]);
   });
 
   it("keeps Stars out of signed-in header navigation", () => {

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -87,6 +87,7 @@ describe("restored UI design contract", () => {
     expect(navSource).toContain("export const SECONDARY_NAV_ITEMS");
     expect(navSource).toContain('label: "Users"');
     expect(navSource).toContain('label: "About"');
+    expect(navSource).toContain('label: "Docs"');
     expect(navSource).not.toContain('label: "Stars"');
     expect(navSource).not.toContain('label: "Management"');
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -301,16 +301,30 @@ export default function Header() {
                   ) : null}
                   {primaryItems.map((item) => (
                     <SheetClose key={item.to + item.label} asChild>
-                      <Link to={item.to} search={item.search ?? {}} className="mobile-nav-link">
+                      <Link
+                        to={item.to}
+                        search={(item.search ?? {}) as never}
+                        className="mobile-nav-link"
+                      >
                         {item.label}
                       </Link>
                     </SheetClose>
                   ))}
                   {secondaryItems.map((item) => (
-                    <SheetClose key={item.to + item.label} asChild>
-                      <Link to={item.to} search={item.search ?? {}} className="mobile-nav-link">
-                        {item.label}
-                      </Link>
+                    <SheetClose key={(item.href ?? item.to ?? "") + item.label} asChild>
+                      {item.href ? (
+                        <a href={item.href} className="mobile-nav-link">
+                          {item.label}
+                        </a>
+                      ) : (
+                        <Link
+                          to={item.to}
+                          search={(item.search ?? {}) as never}
+                          className="mobile-nav-link"
+                        >
+                          {item.label}
+                        </Link>
+                      )}
                     </SheetClose>
                   ))}
                 </div>
@@ -528,7 +542,7 @@ export default function Header() {
                   key={item.to + item.label}
                   to={item.to}
                   className="navbar-tab"
-                  search={item.search ?? {}}
+                  search={(item.search ?? {}) as never}
                   data-status={isActiveByPrefix ? "active" : undefined}
                 >
                   {Icon ? <Icon size={14} className="opacity-50" aria-hidden="true" /> : null}
@@ -542,11 +556,19 @@ export default function Header() {
               const isActiveByPrefix = item.activePathPrefixes?.some((prefix) =>
                 location.pathname.startsWith(prefix),
               );
-              return (
+              return item.href ? (
+                <a
+                  key={item.href + item.label}
+                  href={item.href}
+                  className="navbar-tab navbar-tab-secondary"
+                >
+                  {item.label}
+                </a>
+              ) : (
                 <Link
-                  key={item.to + item.label}
+                  key={(item.to ?? "") + item.label}
                   to={item.to}
-                  search={item.search ?? {}}
+                  search={(item.search ?? {}) as never}
                   className="navbar-tab navbar-tab-secondary"
                   data-status={isActiveByPrefix ? "active" : undefined}
                 >

--- a/src/lib/nav-items.ts
+++ b/src/lib/nav-items.ts
@@ -8,15 +8,9 @@ import { FEATURE_SOULS } from "./features";
 /** Lucide icon name used as a key to look up the component at render time. */
 export type NavIconName = "wrench" | "plug" | "ghost";
 
-interface NavItem {
+interface NavItemBase {
   /** Visible link text */
   label: string;
-  /** Route path passed to `<Link to>` */
-  to: string;
-  /** Optional search params object passed to `<Link search>` */
-  search?: Record<string, unknown>;
-  /** Optional lucide icon name shown beside the label in navbar tabs */
-  icon?: NavIconName;
   /** Link only shown when user is authenticated */
   authRequired: boolean;
   /** Link only shown for staff / moderator users */
@@ -30,6 +24,26 @@ interface NavItem {
   /** Feature flag that must be truthy for this item to show */
   featureFlag?: boolean;
 }
+
+interface RouteNavItem extends NavItemBase {
+  /** Route path passed to `<Link to>` */
+  to: string;
+  href?: never;
+  /** Optional search params object passed to `<Link search>` */
+  search?: Record<string, unknown>;
+  /** Optional lucide icon name shown beside the label in navbar tabs */
+  icon?: NavIconName;
+}
+
+interface ExternalNavItem extends NavItemBase {
+  /** External URL rendered as a normal anchor */
+  href: string;
+  to?: never;
+  search?: never;
+  icon?: never;
+}
+
+type NavItem = RouteNavItem | ExternalNavItem;
 
 // ---------------------------------------------------------------------------
 // Search-param shapes (kept here so Header, Footer, and mobile menu all agree)
@@ -115,6 +129,14 @@ export const SECONDARY_NAV_ITEMS: NavItem[] = [
   {
     label: "About",
     to: "/about",
+    authRequired: false,
+    staffOnly: false,
+    soulModeOnly: false,
+    soulModeHide: true,
+  },
+  {
+    label: "Docs",
+    href: "https://documentation.openclaw.ai/clawhub/",
     authRequired: false,
     staffOnly: false,
     soulModeOnly: false,


### PR DESCRIPTION
## Summary

- Add a public `Docs` item after `About` in the ClawHub header secondary navigation.
- Support external secondary nav links in the shared header/mobile nav config.
- Cover the new Docs item in header and UI design contract tests.

## Verification

- `bun run test src/__tests__/header.test.tsx src/__tests__/ui-design-contract.test.ts`
- `bunx tsc --noEmit`
- `bunx oxfmt --check --threads=1 src/components/Header.tsx src/lib/nav-items.ts src/__tests__/header.test.tsx src/__tests__/ui-design-contract.test.ts`
- `bun run lint`
- `git diff --check HEAD~1..HEAD`
- `VITE_CONVEX_URL=https://example.invalid bun run build`
- Playwright local check at `http://127.0.0.1:3001/`: secondary nav order is `Users`, `About`, `Docs`; Docs href is `https://documentation.openclaw.ai/clawhub/`.

Note: full `bun run format:check` currently fails on pre-existing unrelated files: `convex/publishers.test.ts`, `convex/publishers.ts`, `convex/users.ts`, `packages/schema/src/schemas.test.ts`, `src/routes/plugins/publish.tsx`.
