### PR TITLE
Restore dashboard skill metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - Skills: repair publisher-owned skill merges, bound historical slug redirects, block protected slug namespaces, and expire owner-unpublished slug reservations after 30 days (#2115) (thanks @fuller-stack-dev).
+- Web: restore dashboard skill metrics for owned skills and use pointer cursors on dropdown menu items (#2113).
 - Skills: allow confirmed owner migration when republishing an existing skill to another publisher, preserving versions, stats, aliases, and audit history (#1998, #2102) (thanks @momothemage).
 - Security: block owner delete/undelete paths from overriding moderator or scanner hides, and return explicit 403 authz responses for owner restore denials (#2078) (thanks @momothemage).
 - Search/Web: disclose when `/search` is hiding suspicious skills and add an explicit opt-out so unified search no longer silently differs from `/skills` for the same query (#2079) (thanks @momothemage).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Fixes
 
 - Skills: repair publisher-owned skill merges, bound historical slug redirects, block protected slug namespaces, and expire owner-unpublished slug reservations after 30 days (#2115) (thanks @fuller-stack-dev).
-- Web: restore dashboard skill metrics for owned skills and use pointer cursors on dropdown menu items (#2113).
+- Web: restore dashboard skill metrics for owned skills and use pointer cursors on dropdown menu items (#2113) (thanks @fuller-stack-dev).
 - Skills: allow confirmed owner migration when republishing an existing skill to another publisher, preserving versions, stats, aliases, and audit history (#1998, #2102) (thanks @momothemage).
 - Security: block owner delete/undelete paths from overriding moderator or scanner hides, and return explicit 403 authz responses for owner restore denials (#2078) (thanks @momothemage).
 - Search/Web: disclose when `/search` is hiding suspicious skills and add an explicit opt-out so unified search no longer silently differs from `/skills` for the same query (#2079) (thanks @momothemage).

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -41,7 +41,7 @@ const DropdownMenuItem = React.forwardRef<
     data-inset={inset}
     data-variant={variant}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-[var(--radius-sm)] px-3 py-2 text-sm font-semibold text-[color:var(--ink)] outline-none transition-colors focus:bg-[color:var(--surface-muted)] data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset=true]:pl-8 data-[variant=destructive]:text-status-error-fg",
+      "relative flex cursor-pointer select-none items-center gap-2 rounded-[var(--radius-sm)] px-3 py-2 text-sm font-semibold text-[color:var(--ink)] outline-none transition-colors focus:bg-[color:var(--surface-muted)] data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset=true]:pl-8 data-[variant=destructive]:text-status-error-fg",
       className,
     )}
     {...props}

--- a/src/routes/-dashboard.test.tsx
+++ b/src/routes/-dashboard.test.tsx
@@ -51,6 +51,8 @@ type TestSkill = {
   badges: {};
   stats: {
     downloads: number;
+    installsCurrent: number;
+    installsAllTime: number;
     stars: number;
     versions: number;
   };
@@ -135,7 +137,7 @@ function createSkill(overrides?: Partial<TestSkill>): TestSkill {
     ownerPublisherId: publishers[0].publisher._id,
     tags: {},
     badges: {},
-    stats: { downloads: 0, stars: 0, versions: 1 },
+    stats: { downloads: 1_234, installsCurrent: 12, installsAllTime: 56, stars: 7, versions: 3 },
     moderationVerdict: "suspicious",
     moderationFlags: ["flagged.suspicious"],
     isSuspicious: true,
@@ -225,7 +227,7 @@ function renderDashboard() {
   );
 }
 
-describe("Dashboard minimal rows", () => {
+describe("Dashboard rows", () => {
   beforeEach(() => {
     mocks.useQuery.mockReset();
     mocks.usePaginatedQuery.mockReset();
@@ -240,7 +242,7 @@ describe("Dashboard minimal rows", () => {
     mocks.toastError.mockReset();
   });
 
-  it("renders entry links, summaries, and aggregate statuses only", () => {
+  it("renders entry links, summaries, metrics, and aggregate statuses", () => {
     arrangeDashboard({ skills: [createSkill()], packages: [createPackage()] });
 
     renderDashboard();
@@ -249,6 +251,11 @@ describe("Dashboard minimal rows", () => {
     expect(screen.getByRole("link", { name: "Local Flagged Runtime Plugin" })).toBeTruthy();
     expect(screen.getByText("Flagged skill fixture.")).toBeTruthy();
     expect(screen.getByText("Flagged plugin fixture.")).toBeTruthy();
+    expect(screen.getByLabelText("Metrics for Local Flagged Skill")).toBeTruthy();
+    expect(screen.getByText(/1\.2k downloads/)).toBeTruthy();
+    expect(screen.getByText(/56 installs/)).toBeTruthy();
+    expect(screen.getByText(/7 stars/)).toBeTruthy();
+    expect(screen.getByText(/3 versions/)).toBeTruthy();
     expect(screen.getByText("Suspicious")).toBeTruthy();
     expect(screen.getByText("Blocked")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Suspicious status reason" })).toBeTruthy();

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -1,6 +1,19 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useMutation, usePaginatedQuery, useQuery } from "convex/react";
-import { Clock, Info, Loader2, MoreVertical, Plus, RotateCw, Settings, Trash2 } from "lucide-react";
+import {
+  Clock,
+  Download,
+  History,
+  Info,
+  Loader2,
+  MoreVertical,
+  Package,
+  Plus,
+  RotateCw,
+  Settings,
+  Star,
+  Trash2,
+} from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { api } from "../../convex/_generated/api";
@@ -18,6 +31,7 @@ import {
 } from "../components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../components/ui/tooltip";
 import { getUserFacingConvexError } from "../lib/convexError";
+import { formatCompactStat } from "../lib/numberFormat";
 
 const emptyPluginPublishSearch = {
   ownerHandle: undefined,
@@ -326,6 +340,7 @@ function SkillRow({ skill, ownerHandle }: { skill: DashboardSkill; ownerHandle: 
             {skill.displayName}
           </Link>
         </div>
+        <SkillMetrics stats={skill.stats} label={skill.displayName} />
       </div>
       <div className="dashboard-list-summary">{skill.summary ?? "No summary provided."}</div>
       <div className="dashboard-list-status">
@@ -339,6 +354,29 @@ function SkillRow({ skill, ownerHandle }: { skill: DashboardSkill; ownerHandle: 
         statusLabel={status.label}
         rescanState={skill.rescanState ?? null}
       />
+    </div>
+  );
+}
+
+function SkillMetrics({ stats, label }: { stats: DashboardSkill["stats"]; label: string }) {
+  return (
+    <div className="dashboard-skill-metrics" aria-label={`Metrics for ${label}`}>
+      <span className="dashboard-skill-metric" title="Downloads">
+        <Download className="h-3.5 w-3.5" aria-hidden="true" />
+        {formatCompactStat(stats.downloads)} downloads
+      </span>
+      <span className="dashboard-skill-metric" title="All-time installs">
+        <History className="h-3.5 w-3.5" aria-hidden="true" />
+        {formatCompactStat(stats.installsAllTime ?? 0)} installs
+      </span>
+      <span className="dashboard-skill-metric" title="Stars">
+        <Star className="h-3.5 w-3.5" aria-hidden="true" />
+        {formatCompactStat(stats.stars)} stars
+      </span>
+      <span className="dashboard-skill-metric" title="Versions">
+        <Package className="h-3.5 w-3.5" aria-hidden="true" />
+        {stats.versions ?? 0} versions
+      </span>
     </div>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -5801,6 +5801,32 @@ code {
   text-overflow: ellipsis;
 }
 
+.dashboard-skill-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 12px;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  line-height: 1.35;
+  color: var(--color-muted);
+}
+
+.dashboard-skill-metric {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  white-space: nowrap;
+}
+
+.dashboard-skill-metric svg {
+  width: 14px;
+  height: 14px;
+  flex: none;
+  opacity: 0.82;
+}
+
 .dashboard-list-summary {
   font-size: 0.9rem;
   line-height: 1.5;


### PR DESCRIPTION
## Summary
- Restore dashboard skill row metrics for downloads, all-time installs, stars, and versions.
- Add compact metric styling with lucide icons.
- Make dropdown menu items show a pointer cursor on hover.
- Update dashboard route tests to cover rendered metrics.
- Add the required Unreleased changelog entry.

## Real behavior proof
- Environment: local dev app served at `http://localhost:3000/dashboard` with `bun run dev`, signed in through GitHub OAuth against the Convex dev deployment.
- Setup: seeded one temporary dev-only owned skill row with `downloads=1234`, `installsAllTime=56`, `stars=7`, and `versions=3`; captured the rendered dashboard; then cleaned up the temporary row and removed the temporary seed function before committing.
- Observed after fix in Chrome accessibility output from the live dashboard:

```text
Dashboard
Skills
Dashboard Metrics Proof
Metrics for Dashboard Metrics Proof
1.2k downloads
56 installs
7 stars
3 versions
Visible
```

- Result: the actual dashboard row rendered the restored metric group beneath the owned skill title.

## Tests
- `bunx vitest run src/routes/-dashboard.test.tsx`
- `bun run lint`
- `bun run format:check`