### PR TITLE
fix: rename plugins cards view to grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changes
 
 - Web: polish browse/listing surfaces across skills, plugins, and search, including plugin card view parity, clearer search controls, visible safety filtering, and more consistent card metadata treatment (#2084) (thanks @vyctorbrzezowski).
-- Web: rename the skills browse alternate view from Cards to Grid while keeping legacy `view=cards` URLs compatible (#2090) (thanks @vyctorbrzezowski).
+- Web: rename the skills and plugins browse alternate view from Cards to Grid while keeping legacy `view=cards` URLs compatible (#2090) (thanks @vyctorbrzezowski).
 - Web: allow skill owners and publisher admins to edit a skill summary from the detail page (#1411) (thanks @SylvanXiao).
 
 ### Fixes

--- a/src/__tests__/packages-route.test.tsx
+++ b/src/__tests__/packages-route.test.tsx
@@ -122,7 +122,20 @@ describe("plugins route", () => {
     });
   });
 
-  it("accepts the cards view in search state", async () => {
+  it("uses grid as the canonical browse view in search state", async () => {
+    const route = await loadRoute();
+    const validateSearch = route.__config.validateSearch as (
+      search: Record<string, unknown>,
+    ) => Record<string, unknown>;
+
+    expect(validateSearch({ view: "grid" })).toEqual(
+      expect.objectContaining({
+        view: "grid",
+      }),
+    );
+  });
+
+  it("keeps legacy cards URLs compatible with the grid view", async () => {
     const route = await loadRoute();
     const validateSearch = route.__config.validateSearch as (
       search: Record<string, unknown>,
@@ -130,7 +143,7 @@ describe("plugins route", () => {
 
     expect(validateSearch({ view: "cards" })).toEqual(
       expect.objectContaining({
-        view: "cards",
+        view: "grid",
       }),
     );
   });
@@ -193,7 +206,7 @@ describe("plugins route", () => {
     });
   });
 
-  it("renders a title count and switches to card view", async () => {
+  it("renders a title count and switches to grid view", async () => {
     loaderDataMock = {
       items: [
         {
@@ -218,15 +231,54 @@ describe("plugins route", () => {
 
     expect(screen.getByRole("heading", { name: "Plugins 1" })).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Cards" }));
+    fireEvent.click(screen.getByRole("button", { name: "Grid" }));
 
     expect(navigateMock).toHaveBeenCalled();
     const lastCall = navigateMock.mock.calls.at(-1)?.[0] as {
+      replace?: boolean;
       search: (prev: Record<string, unknown>) => Record<string, unknown>;
     };
+    expect(lastCall.replace).toBe(true);
     expect(lastCall.search({})).toEqual({
-      view: "cards",
+      view: "grid",
     });
+  });
+
+  it("switches legacy cards URLs back to list view", async () => {
+    searchMock = { view: "cards" };
+    loaderDataMock = {
+      items: [
+        {
+          name: "demo-plugin",
+          displayName: "Demo Plugin",
+          family: "code-plugin",
+          channel: "community",
+          isOfficial: false,
+          executesCode: true,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      nextCursor: null,
+      rateLimited: false,
+      retryAfterSeconds: null,
+    };
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    const gridButton = screen.getByRole("button", { name: "Grid" });
+    expect(gridButton.className).toContain("is-active");
+
+    fireEvent.click(screen.getByRole("button", { name: "List" }));
+
+    const lastCall = navigateMock.mock.calls.at(-1)?.[0] as {
+      replace?: boolean;
+      search: (prev: Record<string, unknown>) => Record<string, unknown>;
+    };
+    expect(lastCall.replace).toBe(true);
+    expect(lastCall.search({ view: "cards" })).toEqual({ view: undefined });
   });
 
   it("filters out skills from loader results", async () => {

--- a/src/routes/plugins/index.tsx
+++ b/src/routes/plugins/index.tsx
@@ -17,8 +17,17 @@ type PluginSearchState = {
   featured?: boolean;
   verified?: boolean;
   executesCode?: boolean;
-  view?: "list" | "cards";
+  view?: LegacyPluginView;
 };
+
+type PluginView = "list" | "grid";
+type LegacyPluginView = PluginView | "cards";
+
+function normalizePluginView(value: unknown): PluginView | undefined {
+  if (value === "list") return "list";
+  if (value === "grid" || value === "cards") return "grid";
+  return undefined;
+}
 
 type PluginsLoaderData = {
   items: PackageListItem[];
@@ -54,7 +63,7 @@ export const Route = createFileRoute("/plugins/")({
       search.executesCode === true || search.executesCode === "true" || search.executesCode === "1"
         ? true
         : undefined,
-    view: search.view === "cards" || search.view === "list" ? search.view : undefined,
+    view: normalizePluginView(search.view),
   }),
   loaderDeps: ({ search }) => ({
     q: search.q,
@@ -117,7 +126,7 @@ function PluginsIndex() {
   const rateLimited = loaderData?.rateLimited ?? false;
   const retryAfterSeconds = loaderData?.retryAfterSeconds ?? null;
   const apiError = loaderData?.apiError ?? !loaderData;
-  const view = search.view ?? "list";
+  const view = normalizePluginView(search.view) ?? "list";
 
   const [query, setQuery] = useState(search.q ?? "");
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -181,12 +190,13 @@ function PluginsIndex() {
     });
   };
 
-  const handleToggleView = (nextView: "list" | "cards") => {
+  const handleToggleView = () => {
     void navigate({
       search: (prev) => ({
         ...prev,
-        view: nextView === "list" ? undefined : nextView,
+        view: normalizePluginView(prev.view) === "grid" ? undefined : "grid",
       }),
+      replace: true,
     });
   };
 
@@ -254,16 +264,16 @@ function PluginsIndex() {
               <button
                 className={`browse-view-btn${view === "list" ? " is-active" : ""}`}
                 type="button"
-                onClick={view === "cards" ? () => handleToggleView("list") : undefined}
+                onClick={view === "grid" ? handleToggleView : undefined}
               >
                 List
               </button>
               <button
-                className={`browse-view-btn${view === "cards" ? " is-active" : ""}`}
+                className={`browse-view-btn${view === "grid" ? " is-active" : ""}`}
                 type="button"
-                onClick={view === "list" ? () => handleToggleView("cards") : undefined}
+                onClick={view === "list" ? handleToggleView : undefined}
               >
-                Cards
+                Grid
               </button>
             </div>
           </div>
@@ -288,12 +298,12 @@ function PluginsIndex() {
               <p className="empty-state-body">Try a different search term or remove filters.</p>
             </div>
           ) : (
-            <div className={view === "cards" ? "grid" : "results-list"}>
+            <div className={view === "grid" ? "grid" : "results-list"}>
               {items.map((item) => (
                 <PluginListItem
                   key={item.name}
                   item={item}
-                  variant={view === "cards" ? "card" : "list"}
+                  variant={view === "grid" ? "card" : "list"}
                 />
               ))}
             </div>


### PR DESCRIPTION
## Summary

- What changed: Renamed the `/plugins` browse alternate view from `Cards` to `Grid`, made `view=grid` the canonical URL value, and kept legacy `view=cards` URLs compatible.
- Why: `/skills` already uses `List` / `Grid`; plugins should use the same layout terminology and URL semantics.

## Linked Issue

- Related #52
- Follow-up to #2090

## Screenshots

N/A - this is a one-word control label and URL semantics change; no layout styling changed.

- [x] Screenshots/recordings attached, or `N/A`

## Security / Trust Impact

- [x] No security/trust impact
- [ ] Security/trust impact explained

## Data / Deploy Impact

- [x] No data/deploy impact
- [ ] Data/deploy impact explained

## Verification

- [x] `git diff --check`
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run test -- src/__tests__/packages-route.test.tsx`
- [x] `VITE_CONVEX_URL=https://example.invalid bun run build`
- [x] `VITE_SOULHUB_SITE_URL= VITE_SITE_MODE= VITE_SOULHUB_HOST= SITE_URL= VITE_SITE_URL= bun run test`
- [x] `/Users/vyctor/.codex/skills/oss-pr-contributions/scripts/public_pr_preflight.sh /Users/vyctor/Code/clawhub`

