### PR TITLE
test: isolate site helper env

### DIFF
--- a/src/lib/site.test.ts
+++ b/src/lib/site.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment node */
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   detectSiteMode,
   detectSiteModeFromUrl,
@@ -13,6 +13,14 @@ import {
   getSiteName,
   getSiteUrlForMode,
 } from "./site";
+
+const SITE_ENV_KEYS = [
+  "SITE_URL",
+  "VITE_SITE_MODE",
+  "VITE_SITE_URL",
+  "VITE_SOULHUB_HOST",
+  "VITE_SOULHUB_SITE_URL",
+];
 
 function withServerEnv<T>(values: Record<string, string | undefined>, run: () => T): T {
   const previous = new Map<string, string | undefined>();
@@ -31,9 +39,20 @@ function withServerEnv<T>(values: Record<string, string | undefined>, run: () =>
   }
 }
 
+function clearSiteEnv() {
+  for (const key of SITE_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+beforeEach(() => {
+  clearSiteEnv();
+});
+
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
+  clearSiteEnv();
 });
 
 describe("site helpers", () => {


### PR DESCRIPTION
## Summary

- What changed: Cleared site-related environment variables around \`src/lib/site.test.ts\` cases.
- Why: The test suite can load \`.env.local\` during local runs, and SoulHub/site-mode values can make these helper tests fail even though the runtime behavior is unchanged.

## Linked Issue

- Related #2119

## Screenshots

N/A - test-only change.

- [x] Screenshots/recordings attached, or \`N/A\`

## Security / Trust Impact

- [x] No security/trust impact
- [ ] Security/trust impact explained

## Data / Deploy Impact

- [x] No data/deploy impact
- [ ] Data/deploy impact explained

## Verification

- [x] \`VITE_SOULHUB_SITE_URL=https://onlycrabs.ai VITE_SITE_MODE=skills VITE_SOULHUB_HOST=onlycrabs.ai SITE_URL=http://localhost:3000 bun run test -- src/lib/site.test.ts\`
- [x] \`git diff --check\`
- [x] \`bun run format:check\`
- [x] \`bun run lint\`
- [x] \`bun run test -- src/lib/site.test.ts\`
- [x] \`bun run test\`