### PR TITLE
fix(web): show suspicious filter conditionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Dev setup: make local seed reset deterministic by cleaning stale seed lookup and badge rows for repeated Convex dev runs (#2057) (thanks @vyctorbrzezowski).
 - Skills: repair publisher-owned skill merges, bound historical slug redirects, block protected slug namespaces, and expire owner-unpublished slug reservations after 30 days (#2115) (thanks @fuller-stack-dev).
 - Web: restore dashboard skill metrics for owned skills and use pointer cursors on dropdown menu items (#2113) (thanks @fuller-stack-dev).
+- Web: show the skills browse `Hide suspicious` control only when the loaded results include suspicious skills (thanks @vyctorbrzezowski).
 - Skills: allow confirmed owner migration when republishing an existing skill to another publisher, preserving versions, stats, aliases, and audit history (#1998, #2102) (thanks @momothemage).
 - Security: block owner delete/undelete paths from overriding moderator or scanner hides, and return explicit 403 authz responses for owner restore denials (#2078) (thanks @momothemage).
 - Search/Web: disclose when `/search` is hiding suspicious skills and add an explicit opt-out so unified search no longer silently differs from `/skills` for the same query (#2079) (thanks @momothemage).

--- a/convex/lib/public.ts
+++ b/convex/lib/public.ts
@@ -27,6 +27,7 @@ export type PublicSkill = Pick<
   | "capabilityTags"
   | "badges"
   | "stats"
+  | "isSuspicious"
   | "createdAt"
   | "updatedAt"
 >;
@@ -62,6 +63,7 @@ export type HydratableSkill = Pick<
   | "moderationStatus"
   | "moderationFlags"
   | "moderationReason"
+  | "isSuspicious"
   | "createdAt"
   | "updatedAt"
 >;
@@ -146,6 +148,7 @@ export function toPublicSkill(skill: HydratableSkill | null | undefined): Public
     capabilityTags: skill.capabilityTags,
     badges: skill.badges,
     stats,
+    isSuspicious: skill.isSuspicious,
     createdAt: skill.createdAt,
     updatedAt: skill.updatedAt,
   };

--- a/convex/lib/skillSearchDigest.test.ts
+++ b/convex/lib/skillSearchDigest.test.ts
@@ -1,7 +1,11 @@
 /* @vitest-environment node */
 
 import { describe, expect, it } from "vitest";
-import { extractDigestFields, digestToOwnerInfo } from "./skillSearchDigest";
+import {
+  digestToHydratableSkill,
+  extractDigestFields,
+  digestToOwnerInfo,
+} from "./skillSearchDigest";
 
 function makeSkillDoc(overrides: Record<string, unknown> = {}) {
   return {
@@ -141,6 +145,13 @@ describe("extractDigestFields", () => {
     expect(fakeDoc.ownerUserId).toBe("users:owner");
     expect(fakeDoc.tags).toEqual({});
     expect(fakeDoc.stats).toBeDefined();
+  });
+
+  it("preserves suspicious state through digest hydration", () => {
+    const digest = extractDigestFields(makeSkillDoc({ isSuspicious: true }) as never);
+    const hydratable = digestToHydratableSkill(digest as never);
+
+    expect(hydratable.isSuspicious).toBe(true);
   });
 });
 

--- a/convex/lib/skillSearchDigest.ts
+++ b/convex/lib/skillSearchDigest.ts
@@ -36,6 +36,7 @@ const SHARED_KEYS = [
   "moderationStatus",
   "moderationFlags",
   "moderationReason",
+  "isSuspicious",
   "createdAt",
   "updatedAt",
 ] as const satisfies readonly SharedSkillKey[];
@@ -47,7 +48,6 @@ export type SkillSearchDigestFields = Pick<Doc<"skills">, (typeof SHARED_KEYS)[n
   normalizedSlugFirstToken?: string;
   normalizedDisplayName?: string;
   normalizedDisplayNameFirstToken?: string;
-  isSuspicious?: boolean;
   ownerHandle?: string;
   ownerKind?: "user" | "org";
   ownerName?: string;
@@ -64,7 +64,6 @@ export function extractDigestFields(skill: Doc<"skills">): SkillSearchDigestFiel
     normalizedSlugFirstToken: getFirstSearchToken(skill.slug),
     normalizedDisplayName: normalizeSkillSearchText(skill.displayName),
     normalizedDisplayNameFirstToken: getFirstSearchToken(skill.displayName),
-    isSuspicious: skill.isSuspicious,
   };
 }
 

--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -306,6 +306,46 @@ describe("SkillsIndex", () => {
     );
   });
 
+  it("hides the suspicious filter when loaded results are clean", async () => {
+    convexHttpMock.query.mockResolvedValue({
+      page: [makeListResult("clean-skill", "Clean Skill")],
+      hasMore: false,
+      nextCursor: null,
+    });
+
+    render(<SkillsIndex />);
+    await act(async () => {});
+
+    expect(screen.queryByLabelText("Hide suspicious")).toBeNull();
+  });
+
+  it("shows the suspicious filter when loaded results include a suspicious skill", async () => {
+    convexHttpMock.query.mockResolvedValue({
+      page: [makeListResult("suspicious-skill", "Suspicious Skill", { isSuspicious: true })],
+      hasMore: false,
+      nextCursor: null,
+    });
+
+    render(<SkillsIndex />);
+    await act(async () => {});
+
+    expect(screen.getByLabelText("Hide suspicious")).toBeTruthy();
+  });
+
+  it("keeps the suspicious filter visible while active", async () => {
+    searchMock = { nonSuspicious: true };
+    convexHttpMock.query.mockResolvedValue({
+      page: [makeListResult("clean-skill", "Clean Skill")],
+      hasMore: false,
+      nextCursor: null,
+    });
+
+    render(<SkillsIndex />);
+    await act(async () => {});
+
+    expect(screen.getByLabelText("Hide suspicious")).toBeTruthy();
+  });
+
   it("passes highlightedOnly to list query when filter is active", async () => {
     searchMock = { highlighted: true };
     render(<SkillsIndex />);
@@ -358,7 +398,11 @@ describe("SkillsIndex", () => {
   });
 });
 
-function makeListResult(slug: string, displayName: string) {
+function makeListResult(
+  slug: string,
+  displayName: string,
+  options: { isSuspicious?: boolean } = {},
+) {
   return {
     skill: {
       _id: `skill_${slug}`,
@@ -374,6 +418,7 @@ function makeListResult(slug: string, displayName: string) {
         versions: 1,
         comments: 0,
       },
+      isSuspicious: options.isSuspicious,
       createdAt: 0,
       updatedAt: 0,
     },

--- a/src/lib/publicUser.ts
+++ b/src/lib/publicUser.ts
@@ -26,6 +26,7 @@ export type PublicSkill = Pick<
   | "capabilityTags"
   | "badges"
   | "stats"
+  | "isSuspicious"
   | "createdAt"
   | "updatedAt"
 >;

--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -254,6 +254,8 @@ export function useSkillsBrowseModel({
   }, [baseItems, dir, hasQuery, isOtherCategory, sort]);
 
   const isLoadingSkills = hasQuery ? isSearching && searchResults.length === 0 : isLoadingList;
+  const hasSuspiciousResults = sorted.some((entry) => entry.skill.isSuspicious === true);
+  const showSuspiciousFilter = nonSuspiciousOnly || hasSuspiciousResults;
   const canLoadMore = hasQuery
     ? !isSearching && searchResults.length === searchLimit && searchResults.length > 0
     : canLoadMoreList;
@@ -409,6 +411,8 @@ export function useSkillsBrowseModel({
     canLoadMore,
     dir,
     hasQuery,
+    hasSuspiciousResults,
+    showSuspiciousFilter,
     featuredOnly,
     isLoadingMore,
     isLoadingSkills,

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -203,14 +203,16 @@ export function SkillsIndex() {
               ) : null}
             </span>
             <div className="browse-results-actions">
-              <label className="browse-toolbar-checkbox">
-                <input
-                  type="checkbox"
-                  checked={model.nonSuspiciousOnly}
-                  onChange={model.onToggleNonSuspicious}
-                />
-                <span>Hide suspicious</span>
-              </label>
+              {model.showSuspiciousFilter ? (
+                <label className="browse-toolbar-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={model.nonSuspiciousOnly}
+                    onChange={model.onToggleNonSuspicious}
+                  />
+                  <span>Hide suspicious</span>
+                </label>
+              ) : null}
               <div className="browse-view-toggle">
                 <button
                   className={`browse-view-btn${model.view === "list" ? " is-active" : ""}`}


### PR DESCRIPTION
## Summary

- What changed: shows the skills browse Hide suspicious checkbox only when loaded results include suspicious skills, while keeping it visible when active so users can undo it.
- Why: PR #2084 made the safety filter more prominent, but clean result sets should not carry a safety control that has no relevant items to act on.

## Linked Issue

- Closes N/A
- Related #2084

## Screenshots

Current state:

![Current state](https://i.imgur.com/aOIMnJe.png)

No suspicious skills listed:

![No suspicious skills listed](https://i.imgur.com/aL1bHS8.png)

- [x] Screenshots/recordings attached, or `N/A`

## Security / Trust Impact

- [ ] No security/trust impact
- [x] Security/trust impact explained

This changes only visibility of an existing browse filter. It exposes the existing denormalized `isSuspicious` boolean on public skill list payloads so the client can decide whether the filter is relevant; it does not change moderation decisions, suspicious filtering semantics, scanner outcomes, auth, or permissions.

## Data / Deploy Impact

- [x] No data/deploy impact
- [ ] Data/deploy impact explained

No schema or migration changes. Existing digest rows already store `isSuspicious`; this passes it through the public skill payload used by browse results.

## Verification

- [x] `bun run format:check`
- [x] `bun run lint`
- [ ] `bun run test`
- [x] Other:
  - `bun run test src/__tests__/skills-index.test.tsx convex/lib/public.test.ts convex/lib/skillSearchDigest.test.ts`
  - `bunx tsc --noEmit --pretty false`
  - `bun run build`
  - `codex review --base origin/main`
