### PR TITLE
feat: add moderation hold recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 
+- Security: add an admin-only moderation hold lift path for false-positive publisher holds, with audited skill restoration that preserves independently hidden skills (#1133) (thanks @Justincredible-tech).
 - Docs/dev: document the local Convex site proxy URL and make worktree setup reject misconfigured local site URLs that break HTTP routes (#2060) (thanks @vyctorbrzezowski).
 - Dev setup: make local seed reset deterministic by cleaning stale seed lookup and badge rows for repeated Convex dev runs (#2057) (thanks @vyctorbrzezowski).
 - Skills: repair publisher-owned skill merges, bound historical slug redirects, block protected slug namespaces, and expire owner-unpublished slug reservations after 30 days (#2115) (thanks @fuller-stack-dev).

--- a/convex/skills.moderationHold.test.ts
+++ b/convex/skills.moderationHold.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyUserModerationToOwnedSkillsBatchInternal,
+  restoreOwnedSkillsForModerationLiftBatchInternal,
+} from "./skills";
+
+type WrappedHandler<TArgs, TResult> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
+};
+
+const applyHoldHandler = (
+  applyUserModerationToOwnedSkillsBatchInternal as unknown as WrappedHandler<
+    { ownerUserId: string; hiddenAt: number; cursor?: string },
+    { hiddenCount: number; scheduled: boolean }
+  >
+)._handler;
+
+const restoreHoldHandler = (
+  restoreOwnedSkillsForModerationLiftBatchInternal as unknown as WrappedHandler<
+    { ownerUserId: string; holdPlacedAt: number; cursor?: string },
+    { restoredCount: number; scheduled: boolean; aborted?: boolean }
+  >
+)._handler;
+
+function makeCtx({
+  user = { _id: "users:owner", requiresModerationAt: 1_000 },
+  skills = [],
+  versions = {},
+}: {
+  user?: Record<string, unknown> | null;
+  skills?: Array<Record<string, unknown>>;
+  versions?: Record<string, Record<string, unknown> | null>;
+} = {}) {
+  const patch = vi.fn();
+  const insert = vi.fn();
+  const replace = vi.fn();
+  const delete_ = vi.fn();
+  const normalizeId = vi.fn();
+  const get = vi.fn(async (id: string) => {
+    if (id === "users:owner") return user;
+    return versions[id] ?? null;
+  });
+  const query = vi.fn((table: string) => {
+    if (table === "skills") {
+      return {
+        withIndex: () => ({
+          order: () => ({
+            paginate: async () => ({ page: skills, isDone: true, continueCursor: null }),
+          }),
+        }),
+      };
+    }
+    if (table === "globalStats") {
+      return { withIndex: () => ({ unique: async () => null }) };
+    }
+    throw new Error(`Unexpected table ${table}`);
+  });
+  const scheduler = { runAfter: vi.fn() };
+  return {
+    ctx: {
+      db: { get, insert, patch, replace, delete: delete_, query, normalizeId },
+      scheduler,
+    } as never,
+    patch,
+    scheduler,
+  };
+}
+
+describe("skills moderation holds", () => {
+  it("does not overwrite existing hidden moderation reasons when applying a user hold", async () => {
+    const { ctx, patch } = makeCtx({
+      skills: [
+        {
+          _id: "skills:active",
+          ownerUserId: "users:owner",
+          moderationStatus: "active",
+          moderationReason: "scanner.vt.clean",
+          moderationVerdict: "clean",
+          moderationFlags: undefined,
+          softDeletedAt: undefined,
+        },
+        {
+          _id: "skills:manual",
+          ownerUserId: "users:owner",
+          moderationStatus: "hidden",
+          moderationReason: "manual.report",
+          moderationVerdict: "suspicious",
+          moderationFlags: undefined,
+          softDeletedAt: undefined,
+        },
+      ],
+    });
+
+    const result = await applyHoldHandler(ctx, {
+      ownerUserId: "users:owner",
+      hiddenAt: 1_000,
+    });
+
+    expect(result.hiddenCount).toBe(1);
+    expect(patch).toHaveBeenCalledTimes(1);
+    expect(patch).toHaveBeenCalledWith(
+      "skills:active",
+      expect.objectContaining({
+        moderationStatus: "hidden",
+        moderationReason: "user.moderation",
+      }),
+    );
+  });
+
+  it("restores clean hold-hidden skills but keeps unscanned skills hidden pending scan", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(2_000);
+    const { ctx, patch } = makeCtx({
+      user: { _id: "users:owner", requiresModerationAt: undefined },
+      versions: {
+        "versions:clean": { _id: "versions:clean", vtAnalysis: { status: "clean" } },
+        "versions:pending": { _id: "versions:pending" },
+      },
+      skills: [
+        {
+          _id: "skills:clean",
+          ownerUserId: "users:owner",
+          latestVersionId: "versions:clean",
+          moderationStatus: "hidden",
+          moderationReason: "user.moderation",
+          moderationFlags: undefined,
+          softDeletedAt: undefined,
+          hiddenAt: 1_000,
+        },
+        {
+          _id: "skills:pending",
+          ownerUserId: "users:owner",
+          latestVersionId: "versions:pending",
+          moderationStatus: "hidden",
+          moderationReason: "user.moderation",
+          moderationFlags: undefined,
+          softDeletedAt: undefined,
+          hiddenAt: 1_000,
+        },
+      ],
+    });
+
+    const result = await restoreHoldHandler(ctx, {
+      ownerUserId: "users:owner",
+      holdPlacedAt: 1_000,
+    });
+
+    expect(result.restoredCount).toBe(2);
+    expect(patch).toHaveBeenCalledWith(
+      "skills:clean",
+      expect.objectContaining({
+        moderationStatus: "active",
+        moderationReason: "restored.moderation_lift",
+        hiddenAt: undefined,
+      }),
+    );
+    expect(patch).toHaveBeenCalledWith(
+      "skills:pending",
+      expect.objectContaining({
+        moderationStatus: "hidden",
+        moderationReason: "pending.scan",
+        hiddenAt: undefined,
+      }),
+    );
+  });
+
+  it("aborts restore when the user was re-held", async () => {
+    const { ctx, patch } = makeCtx({
+      user: { _id: "users:owner", requiresModerationAt: 2_000 },
+      skills: [{ _id: "skills:one" }],
+    });
+
+    const result = await restoreHoldHandler(ctx, {
+      ownerUserId: "users:owner",
+      holdPlacedAt: 1_000,
+    });
+
+    expect(result).toMatchObject({ restoredCount: 0, scheduled: false, aborted: true });
+    expect(patch).not.toHaveBeenCalled();
+  });
+});

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -5798,6 +5798,15 @@ export const applyUserModerationToOwnedSkillsBatchInternal = internalMutation({
     cursor: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
+    // Stale batch guard: if the hold was lifted between batch pages,
+    // stop hiding skills. Without this, a liftModerationHold call that
+    // races with a multi-page hide chain can leave late-hidden skills
+    // permanently stuck (the restore may have already paged past them).
+    const user = await ctx.db.get(args.ownerUserId);
+    if (user && !user.requiresModerationAt) {
+      return { ok: true as const, hiddenCount: 0, scheduled: false, aborted: true };
+    }
+
     const { page, isDone, continueCursor } = await ctx.db
       .query("skills")
       .withIndex("by_owner", (q) => q.eq("ownerUserId", args.ownerUserId))
@@ -5895,6 +5904,108 @@ export const restoreOwnedSkillsForUnbanBatchInternal = internalMutation({
     scheduleNextBatchIfNeeded(
       ctx.scheduler,
       internal.skills.restoreOwnedSkillsForUnbanBatchInternal,
+      args,
+      isDone,
+      continueCursor,
+    );
+
+    return { ok: true as const, restoredCount, scheduled: !isDone };
+  },
+});
+
+/**
+ * Batch restore skills hidden by a moderation hold.
+ * Only restores skills where moderationReason is "user.moderation"
+ * and moderationStatus is "hidden".
+ *
+ * Race condition safety: before processing each page, verifies the user
+ * has not been placed under a new moderation hold. If requiresModerationAt
+ * is set again (new hold placed between batch pages), the batch aborts
+ * to avoid restoring skills that should remain hidden.
+ *
+ * Skills published while under hold also get moderationReason "user.moderation"
+ * and are included in the restore. Skills hidden for other reasons (manual
+ * moderator action, community reports) are not affected.
+ */
+export const restoreOwnedSkillsForModerationLiftBatchInternal = internalMutation({
+  args: {
+    ownerUserId: v.id("users"),
+    holdPlacedAt: v.number(),
+    cursor: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    // Race condition guard: if the user has been re-held between batch pages,
+    // abort to avoid restoring skills that should stay hidden under the new hold.
+    const user = await ctx.db.get(args.ownerUserId);
+    if (user?.requiresModerationAt) {
+      return { ok: true as const, restoredCount: 0, scheduled: false, aborted: true };
+    }
+
+    const now = Date.now();
+    const { page, isDone, continueCursor } = await ctx.db
+      .query("skills")
+      .withIndex("by_owner", (q) => q.eq("ownerUserId", args.ownerUserId))
+      .order("desc")
+      .paginate({
+        cursor: args.cursor ?? null,
+        numItems: BAN_USER_SKILLS_BATCH_SIZE,
+      });
+
+    let restoredCount = 0;
+    for (const skill of page) {
+      // Skip skills hidden before this hold was placed — they belong to
+      // an earlier moderation action and should not be restored here.
+      // We use >= (not ===) because the hide batch may stamp hiddenAt
+      // with the same `now` used for requiresModerationAt, or a later
+      // timestamp if the user was re-moderated without clearing the hold.
+      // The primary race-condition guard is the requiresModerationAt check
+      // above: if a *new* hold exists, the batch aborts entirely.
+      if (skill.hiddenAt != null && skill.hiddenAt < args.holdPlacedAt) continue;
+      // Skip soft-deleted skills: if a ban raced with this batch, those
+      // rows need their moderationReason intact for unban recovery.
+      if (skill.softDeletedAt) continue;
+      if (skill.moderationReason !== USER_MODERATION_REASON) continue;
+      if (skill.moderationStatus !== "hidden") continue;
+
+      // Re-evaluate based on the skill's own scan data rather than blindly
+      // setting to active. If the skill's own static scan was malicious,
+      // keep it hidden -- only the user-level hold should be lifted.
+      const latestVersion = skill.latestVersionId
+        ? await ctx.db.get(skill.latestVersionId)
+        : null;
+      const ownStaticVerdict = latestVersion?.staticScan?.status;
+      if (ownStaticVerdict === "malicious") continue;
+
+      // If the skill was never scanned (or was pending scan when the hold
+      // was placed), re-queue it into the VT pipeline instead of marking it
+      // as restored. The VT queue selector only picks up "pending.scan",
+      // "pending.scan.stale", and "scanner.*" reasons, so
+      // "restored.moderation_lift" would leave these skills permanently
+      // unscanned.
+      const vtStatus = latestVersion?.vtAnalysis?.status;
+      const needsScan = !vtStatus || vtStatus === "pending" || vtStatus === "loading";
+      const nextReason = needsScan ? "pending.scan" : "restored.moderation_lift";
+      const patch: Partial<Doc<"skills">> = {
+        moderationStatus: needsScan ? "hidden" : "active",
+        moderationReason: nextReason,
+        isSuspicious: computeIsSuspicious({
+          moderationFlags: skill.moderationFlags,
+          moderationReason: nextReason,
+        }),
+        hiddenAt: undefined,
+        hiddenBy: undefined,
+        lastReviewedAt: now,
+        updatedAt: now,
+      };
+      const nextSkill = { ...skill, ...patch };
+      await ctx.db.patch(skill._id, patch);
+      await adjustGlobalPublicCountForSkillChange(ctx, skill, nextSkill);
+      restoredCount += 1;
+    }
+
+    scheduleNextBatchIfNeeded(
+      ctx.scheduler,
+      internal.skills.restoreOwnedSkillsForModerationLiftBatchInternal,
       args,
       isDone,
       continueCursor,

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -5818,8 +5818,14 @@ export const applyUserModerationToOwnedSkillsBatchInternal = internalMutation({
 
     let hiddenCount = 0;
     for (const skill of page) {
+      if (skill.softDeletedAt) continue;
+      const currentStatus = skill.moderationStatus ?? "active";
+      if (currentStatus !== "active") continue;
+
       const nextReason =
-        skill.moderationVerdict === "malicious" ? skill.moderationReason : USER_MODERATION_REASON;
+        skill.moderationVerdict === "malicious"
+          ? (skill.moderationReason ?? "scanner.aggregate.malicious")
+          : USER_MODERATION_REASON;
       const nextStatus = "hidden";
       const patch: Partial<Doc<"skills">> = {
         moderationStatus: nextStatus,
@@ -5970,9 +5976,7 @@ export const restoreOwnedSkillsForModerationLiftBatchInternal = internalMutation
       // Re-evaluate based on the skill's own scan data rather than blindly
       // setting to active. If the skill's own static scan was malicious,
       // keep it hidden -- only the user-level hold should be lifted.
-      const latestVersion = skill.latestVersionId
-        ? await ctx.db.get(skill.latestVersionId)
-        : null;
+      const latestVersion = skill.latestVersionId ? await ctx.db.get(skill.latestVersionId) : null;
       const ownStaticVerdict = latestVersion?.staticScan?.status;
       if (ownStaticVerdict === "malicious") continue;
 

--- a/convex/users.test.ts
+++ b/convex/users.test.ts
@@ -24,6 +24,7 @@ const {
   banUserInternal,
   me,
   placeUserUnderModerationInternal,
+  liftModerationHoldInternal,
   reserveHandleInternal,
   syncGitHubProfileInternal,
 } = await import("./users");
@@ -1820,5 +1821,207 @@ describe("users.reserveHandleInternal", () => {
         targetId: "openclaw",
       }),
     );
+  });
+});
+
+describe("users.liftModerationHoldInternal", () => {
+  it("clears the moderation hold and restores skills", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_100_000);
+    const patch = vi.fn();
+    const insert = vi.fn();
+    const get = vi.fn(async (id: string) => {
+      if (id === "users:admin") {
+        return {
+          _id: "users:admin",
+          role: "admin",
+          deletedAt: undefined,
+          deactivatedAt: undefined,
+        };
+      }
+      if (id === "users:target") {
+        return {
+          _id: "users:target",
+          role: "user",
+          handle: "security-researcher",
+          deletedAt: undefined,
+          deactivatedAt: undefined,
+          requiresModerationAt: 1_700_000_000_000,
+          requiresModerationReason:
+            "Auto-held for moderation after malicious upload (malicious.install_terminal_payload)",
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn(async () => ({ restoredCount: 5, scheduled: false }));
+
+    const handler = (
+      liftModerationHoldInternal as unknown as {
+        _handler: (
+          ctx: unknown,
+          args: { actorUserId: string; targetUserId: string; reason?: string },
+        ) => Promise<unknown>;
+      }
+    )._handler;
+
+    const result = (await handler(
+      {
+        db: {
+          get,
+          patch,
+          insert,
+          delete: vi.fn(),
+          replace: vi.fn(),
+          query: vi.fn(),
+          normalizeId: vi.fn(),
+        },
+        runMutation,
+      } as never,
+      {
+        actorUserId: "users:admin",
+        targetUserId: "users:target",
+        reason: "False positive from security tool scanning",
+      },
+    )) as {
+      ok: boolean;
+      alreadyCleared: boolean;
+      restoredSkills: number;
+      scheduledSkills: boolean;
+    };
+
+    expect(result).toEqual({
+      ok: true,
+      alreadyCleared: false,
+      restoredSkills: 5,
+      scheduledSkills: false,
+    });
+
+    // Verify hold was cleared
+    expect(patch).toHaveBeenCalledWith("users:target", {
+      requiresModerationAt: undefined,
+      requiresModerationReason: undefined,
+      updatedAt: 1_700_000_100_000,
+    });
+
+    // Verify skill restoration was triggered with holdPlacedAt for race-condition safety
+    expect(runMutation).toHaveBeenCalledWith(expect.anything(), {
+      ownerUserId: "users:target",
+      holdPlacedAt: 1_700_000_000_000,
+      cursor: undefined,
+    });
+
+    // Verify audit log
+    expect(insert).toHaveBeenCalledWith(
+      "auditLogs",
+      expect.objectContaining({
+        actorUserId: "users:admin",
+        action: "user.moderation.lift",
+        targetType: "user",
+        targetId: "users:target",
+        metadata: expect.objectContaining({
+          reason: "False positive from security tool scanning",
+          holdPlacedAt: 1_700_000_000_000,
+          restoredSkills: 5,
+        }),
+      }),
+    );
+  });
+
+  it("returns early when user has no moderation hold", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_100_000);
+    const patch = vi.fn();
+    const get = vi.fn(async (id: string) => {
+      if (id === "users:admin") {
+        return { _id: "users:admin", role: "admin", deletedAt: undefined, deactivatedAt: undefined };
+      }
+      if (id === "users:target") {
+        return {
+          _id: "users:target",
+          role: "user",
+          deletedAt: undefined,
+          deactivatedAt: undefined,
+          requiresModerationAt: undefined,
+        };
+      }
+      return null;
+    });
+
+    const handler = (
+      liftModerationHoldInternal as unknown as {
+        _handler: (
+          ctx: unknown,
+          args: { actorUserId: string; targetUserId: string },
+        ) => Promise<unknown>;
+      }
+    )._handler;
+
+    const result = (await handler(
+      {
+        db: {
+          get,
+          patch,
+          insert: vi.fn(),
+          delete: vi.fn(),
+          replace: vi.fn(),
+          query: vi.fn(),
+          normalizeId: vi.fn(),
+        },
+        runMutation: vi.fn(),
+      } as never,
+      {
+        actorUserId: "users:admin",
+        targetUserId: "users:target",
+      },
+    )) as { ok: boolean; alreadyCleared: boolean };
+
+    expect(result).toEqual({
+      ok: true,
+      alreadyCleared: true,
+      restoredSkills: 0,
+      scheduledSkills: false,
+    });
+
+    // Verify no patches were made
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("throws when actor is not admin", async () => {
+    const get = vi.fn(async (id: string) => {
+      if (id === "users:mod") {
+        return {
+          _id: "users:mod",
+          role: "moderator",
+          deletedAt: undefined,
+          deactivatedAt: undefined,
+        };
+      }
+      return null;
+    });
+
+    const handler = (
+      liftModerationHoldInternal as unknown as {
+        _handler: (
+          ctx: unknown,
+          args: { actorUserId: string; targetUserId: string },
+        ) => Promise<unknown>;
+      }
+    )._handler;
+
+    await expect(
+      handler(
+        {
+          db: {
+            get,
+            patch: vi.fn(),
+            insert: vi.fn(),
+            delete: vi.fn(),
+            replace: vi.fn(),
+            query: vi.fn(),
+            normalizeId: vi.fn(),
+          },
+          runMutation: vi.fn(),
+        } as never,
+        { actorUserId: "users:mod", targetUserId: "users:target" },
+      ),
+    ).rejects.toThrow();
   });
 });

--- a/convex/users.test.ts
+++ b/convex/users.test.ts
@@ -1825,6 +1825,10 @@ describe("users.reserveHandleInternal", () => {
 });
 
 describe("users.liftModerationHoldInternal", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("clears the moderation hold and restores skills", async () => {
     vi.spyOn(Date, "now").mockReturnValue(1_700_000_100_000);
     const patch = vi.fn();
@@ -1931,7 +1935,12 @@ describe("users.liftModerationHoldInternal", () => {
     const patch = vi.fn();
     const get = vi.fn(async (id: string) => {
       if (id === "users:admin") {
-        return { _id: "users:admin", role: "admin", deletedAt: undefined, deactivatedAt: undefined };
+        return {
+          _id: "users:admin",
+          role: "admin",
+          deletedAt: undefined,
+          deactivatedAt: undefined,
+        };
       }
       if (id === "users:target") {
         return {

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -801,6 +801,115 @@ async function unbanUserWithActor(
   };
 }
 
+// ---------------------------------------------------------------------------
+// Moderation hold management
+// ---------------------------------------------------------------------------
+
+/**
+ * Admin-only: lift the moderation hold placed on a user after a false-positive
+ * malicious upload detection.
+ *
+ * When the static scanner flags a skill as malicious, the publisher is placed
+ * under a moderation hold (`requiresModerationAt` set). This hides all their
+ * skills and causes all future publishes to start hidden. The hold has no
+ * self-service release path -- only an admin can lift it.
+ *
+ * This mutation:
+ * 1. Clears `requiresModerationAt` and `requiresModerationReason` on the user
+ * 2. Restores skills that were hidden due to the moderation hold
+ * 3. Creates an audit log entry
+ */
+export const liftModerationHold = mutation({
+  args: {
+    userId: v.id("users"),
+    reason: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const { user } = await requireUser(ctx);
+    return liftModerationHoldWithActor(ctx, user, args.userId, args.reason);
+  },
+});
+
+export const liftModerationHoldInternal = internalMutation({
+  args: {
+    actorUserId: v.id("users"),
+    targetUserId: v.id("users"),
+    reason: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const actor = await ctx.db.get(args.actorUserId);
+    if (!actor || actor.deletedAt || actor.deactivatedAt) throw new Error("User not found");
+    return liftModerationHoldWithActor(ctx, actor, args.targetUserId, args.reason);
+  },
+});
+
+async function liftModerationHoldWithActor(
+  ctx: MutationCtx,
+  actor: Doc<"users">,
+  targetUserId: Id<"users">,
+  reasonRaw?: string,
+) {
+  assertAdmin(actor);
+
+  const target = await ctx.db.get(targetUserId);
+  if (!target) throw new Error("User not found");
+  if (target.deletedAt || target.deactivatedAt) {
+    throw new Error("Cannot lift hold on a deleted or deactivated account");
+  }
+  if (!target.requiresModerationAt) {
+    return { ok: true as const, alreadyCleared: true, restoredSkills: 0, scheduledSkills: false };
+  }
+
+  const reason = reasonRaw?.trim();
+  if (reason && reason.length > 500) {
+    throw new Error("Reason too long (max 500 chars)");
+  }
+
+  const holdPlacedAt = target.requiresModerationAt;
+  const now = Date.now();
+
+  // Clear the moderation hold on the user
+  await ctx.db.patch(targetUserId, {
+    requiresModerationAt: undefined,
+    requiresModerationReason: undefined,
+    updatedAt: now,
+  });
+
+  // Restore skills that were hidden due to the moderation hold.
+  // The batch handler checks if the user has been re-held between pages
+  // and aborts if so (race condition safety).
+  const restoreResult = (await ctx.runMutation(
+    internal.skills.restoreOwnedSkillsForModerationLiftBatchInternal,
+    {
+      ownerUserId: targetUserId,
+      holdPlacedAt,
+      cursor: undefined,
+    },
+  )) as { restoredCount?: number; scheduled?: boolean };
+  const restoredCount = restoreResult.restoredCount ?? 0;
+  const scheduledSkills = restoreResult.scheduled ?? false;
+
+  await ctx.db.insert("auditLogs", {
+    actorUserId: actor._id,
+    action: "user.moderation.lift",
+    targetType: "user",
+    targetId: targetUserId,
+    metadata: {
+      reason: reason || undefined,
+      holdPlacedAt,
+      restoredSkills: restoredCount,
+    },
+    createdAt: now,
+  });
+
+  return {
+    ok: true as const,
+    alreadyCleared: false,
+    restoredSkills: restoredCount,
+    scheduledSkills,
+  };
+}
+
 /**
  * Admin-only: set or unset the trustedPublisher flag for a user.
  * Trusted publishers bypass the pending.scan auto-hide for new skill publishes.

--- a/docs/security.md
+++ b/docs/security.md
@@ -117,6 +117,24 @@ For moderated content, owners may be able to submit an appeal from the
 owner-visible ClawHub surfaces. Appeals should explain what changed or why the
 flag is incorrect.
 
+## Moderation Holds
+
+When the static scanner flags an uploaded skill as malicious, the publisher is
+automatically placed under a moderation hold (`requiresModerationAt` set on the
+user). This hides all of the publisher's skills, causes future publishes to
+start hidden, and creates a `user.moderation.auto` audit log entry.
+
+Admins can lift a false-positive hold:
+
+```bash
+npx convex run users:liftModerationHold '{"userId": "<user-id>", "reason": "False positive from security tool scanning"}'
+```
+
+This clears `requiresModerationAt` and `requiresModerationReason`, restores
+skills hidden by the user-level hold, and writes a `user.moderation.lift` audit
+log entry. Skills hidden for other reasons, or whose own static scan remains
+malicious, stay hidden.
+
 ## Bans and account standing
 
 Accounts that violate ClawHub policy may lose publishing access. Severe abuse


### PR DESCRIPTION
## Summary

- completes #1133 on a maintainer-owned branch because the contributor fork rejected maintainer pushes
- adds admin-only moderation hold lifting with audit logs and docs
- hardens the hold/restore batches so existing hidden/manual scanner reasons are preserved

## Tests

- `bunx vitest run convex/users.test.ts convex/skills.moderationHold.test.ts --testNamePattern "liftModerationHold|reserveHandleInternal|moderation holds"`
- `bunx tsc --noEmit && bunx tsc -p packages/schema/tsconfig.json --noEmit && bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bun run ci:static`
- `bunx convex codegen`

Co-authored-by: Justin Sparks <openclaw@openclaw-secure.local>
