### PR TITLE
fix(web): align header avatar controls (screenshots)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixes
 
+- Web: align signed-in header avatar controls across desktop and mobile so the menu trigger keeps consistent sizing, truncation, and dropdown styling (#2124) (thanks @vyctorbrzezowski).
 - Security: add an admin-only moderation hold lift path for false-positive publisher holds, with audited skill restoration that preserves independently hidden skills (#1133) (thanks @Justincredible-tech).
 - Docs/dev: document the local Convex site proxy URL and make worktree setup reject misconfigured local site URLs that break HTTP routes (#2060) (thanks @vyctorbrzezowski).
 - Dev setup: make local seed reset deterministic by cleaning stale seed lookup and badge rows for repeated Convex dev runs (#2057) (thanks @vyctorbrzezowski).

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import { useAuthActions } from "@convex-dev/auth/react";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
-import { ArrowRight, Ghost, Menu, Monitor, Moon, Plug, Search, Sun, Wrench } from "lucide-react";
+import { ArrowRight, ChevronDown, Ghost, Menu, Monitor, Moon, Plug, Search, Sun, Wrench } from "lucide-react";
 import { type ComponentType, useEffect, useMemo, useRef, useState } from "react";
 import { getUserFacingAuthError } from "../lib/authErrorMessage";
 import { gravatarUrl } from "../lib/gravatar";
@@ -450,7 +450,7 @@ export default function Header() {
                       <span className="user-menu-fallback">{initial}</span>
                     )}
                     <span className="mono truncate">@{handle}</span>
-                    <span className="user-menu-chevron">▾</span>
+                    <ChevronDown className="user-menu-chevron" size={16} />
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -453,7 +453,7 @@ export default function Header() {
                     <ChevronDown className="user-menu-chevron" size={16} />
                   </button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
+                <DropdownMenuContent align="end" className="user-dropdown-content">
                   <DropdownMenuItem asChild>
                     <Link to="/dashboard">Dashboard</Link>
                   </DropdownMenuItem>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,17 @@
 import { useAuthActions } from "@convex-dev/auth/react";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
-import { ArrowRight, ChevronDown, Ghost, Menu, Monitor, Moon, Plug, Search, Sun, Wrench } from "lucide-react";
+import {
+  ArrowRight,
+  ChevronDown,
+  Ghost,
+  Menu,
+  Monitor,
+  Moon,
+  Plug,
+  Search,
+  Sun,
+  Wrench,
+} from "lucide-react";
 import { type ComponentType, useEffect, useMemo, useRef, useState } from "react";
 import { getUserFacingAuthError } from "../lib/authErrorMessage";
 import { gravatarUrl } from "../lib/gravatar";

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -84,8 +84,9 @@ export default function Header() {
   const location = useLocation();
 
   const avatar = me?.image ?? (me?.email ? gravatarUrl(me.email) : undefined);
-  const handle = me?.handle ?? me?.displayName ?? "user";
-  const initial = (me?.displayName ?? me?.name ?? handle).charAt(0).toUpperCase();
+  const rawHandle = me?.handle ?? me?.displayName ?? "user";
+  const handle = rawHandle.length > 25 ? `${rawHandle.slice(0, 25)}…` : rawHandle;
+  const initial = (me?.displayName ?? me?.name ?? rawHandle).charAt(0).toUpperCase();
   const isStaff = isModerator(me);
   const hasResolvedUser = Boolean(me);
   const navCtx = useMemo(
@@ -448,7 +449,7 @@ export default function Header() {
                     ) : (
                       <span className="user-menu-fallback">{initial}</span>
                     )}
-                    <span className="mono">@{handle}</span>
+                    <span className="mono truncate">@{handle}</span>
                     <span className="user-menu-chevron">▾</span>
                   </button>
                 </DropdownMenuTrigger>

--- a/src/styles.css
+++ b/src/styles.css
@@ -5069,7 +5069,7 @@ form.summary-edit-form .summary-textarea:focus {
     width: 56px;
     min-width: 56px;
     height: 56px;
-    padding: 0;
+    padding: 3px;
     justify-content: center;
     border-radius: var(--r-md);
   }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1037,6 +1037,8 @@ code {
   padding: 0 12px 0 6px;
   border-radius: var(--r-pill);
   cursor: pointer;
+  min-width: 0;
+  overflow: hidden;
   transition:
     border-color 0.15s ease,
     box-shadow 0.15s ease;
@@ -1063,6 +1065,7 @@ code {
 .user-menu-chevron {
   font-size: 0.8rem;
   color: var(--ink-soft);
+  flex-shrink: 0;
 }
 
 /* @deprecated — use <Button> from components/ui/button.tsx */

--- a/src/styles.css
+++ b/src/styles.css
@@ -4947,8 +4947,8 @@ form.summary-edit-form .summary-textarea:focus {
   .navbar-search {
     display: flex;
     height: 56px;
-    gap: 12px;
-    padding: 0 18px;
+    gap: 8px;
+    padding: 0 12px;
   }
 
   .navbar-search-icon {

--- a/src/styles.css
+++ b/src/styles.css
@@ -5228,6 +5228,7 @@ form.summary-edit-form .summary-textarea:focus {
     min-width: 56px;
     height: 56px;
     min-height: 56px;
+    padding: 4px;
     border-radius: var(--r-md);
   }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -4934,7 +4934,7 @@ form.summary-edit-form .summary-textarea:focus {
     display: grid;
     grid-template-columns: 56px minmax(0, 1fr) 56px;
     align-items: center;
-    padding: 10px 16px;
+    padding: 10px 18px;
     gap: 12px;
     min-height: 0;
   }
@@ -5069,15 +5069,15 @@ form.summary-edit-form .summary-textarea:focus {
     width: 56px;
     min-width: 56px;
     height: 56px;
-    padding: 3px;
+    padding: 4px;
     justify-content: center;
     border-radius: var(--r-md);
   }
 
   .user-trigger img,
   .user-menu-fallback {
-    width: 48px;
-    height: 48px;
+    width: 44px;
+    height: 44px;
   }
 
   .user-trigger .mono,

--- a/src/styles.css
+++ b/src/styles.css
@@ -1031,10 +1031,10 @@ code {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  height: 38px;
+  height: 46px;
   border: 1px solid var(--line);
   background: var(--surface);
-  padding: 0 12px 0 4px;
+  padding: 0 12px 0 6px;
   border-radius: var(--r-pill);
   cursor: pointer;
   transition:
@@ -1049,15 +1049,15 @@ code {
 
 .user-trigger img,
 .user-menu-fallback {
-  width: 28px;
-  height: 28px;
+  width: 36px;
+  height: 36px;
   border-radius: 50%;
   display: grid;
   place-items: center;
   background: rgba(255, 255, 255, 0.2);
   color: var(--accent-deep);
   font-weight: 700;
-  font-size: 0.85rem;
+  font-size: 0.95rem;
 }
 
 .user-menu-chevron {
@@ -5062,8 +5062,8 @@ form.summary-edit-form .summary-textarea:focus {
 
   .user-trigger img,
   .user-menu-fallback {
-    width: 24px;
-    height: 24px;
+    width: 48px;
+    height: 48px;
   }
 
   .user-trigger .mono,

--- a/src/styles.css
+++ b/src/styles.css
@@ -1069,6 +1069,16 @@ code {
   height: 16px;
 }
 
+/* Remove global link underline and focus outline from user dropdown items */
+.user-dropdown-content a,
+.user-dropdown-content a:hover {
+  text-decoration: none;
+}
+
+.user-dropdown-content [data-slot="dropdown-menu-item"]:focus-visible {
+  outline: none;
+}
+
 /* @deprecated — use <Button> from components/ui/button.tsx */
 .btn {
   border: 1px solid var(--border-ui);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1063,9 +1063,10 @@ code {
 }
 
 .user-menu-chevron {
-  font-size: 0.8rem;
   color: var(--ink-soft);
   flex-shrink: 0;
+  width: 16px;
+  height: 16px;
 }
 
 /* @deprecated — use <Button> from components/ui/button.tsx */


### PR DESCRIPTION
## Summary

- What changed: polished the logged-in header avatar control, dropdown styling, and mobile search/header spacing for consistent desktop and mobile presentation.
- Why: the account control looked undersized on desktop, crowded on mobile, and the text/chevron/search spacing could collapse in narrow layouts.

## Linked Issue

- Closes N/A
- Related N/A

## Screenshots

For website/UI changes, attach screenshots or recordings from the real app. Include mobile/narrow views when layout changes.

- [x] Screenshots/recordings attached, or `N/A`

| Desktop before | Desktop after |
| --- | --- |
| ![desktop before](https://i.imgur.com/gsPmAr2.png) | ![desktop after](https://i.imgur.com/dAOpCrb.png) |

| Mobile before | Mobile after |
| --- | --- |
| ![mobile before](https://i.imgur.com/pCQ9RGb.png) | ![mobile after](https://i.imgur.com/hcY7v46.png) |

## Security / Trust Impact

- [x] No security/trust impact
- [ ] Security/trust impact explained

## Data / Deploy Impact

- [x] No data/deploy impact
- [ ] Data/deploy impact explained

## Verification

- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run test`
- [x] Other: `bun run test src/__tests__/header.test.tsx`
- [x] Other: `bun run test:ui-contract`
- [x] Other: `bunx tsc --noEmit`
- [x] Other: `VITE_CONVEX_URL=https://example.invalid bun run build`
