### PR TITLE
fix(search): add full-text search indexes to fix non-first-token skill underrecall

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -788,7 +788,15 @@ const skillSearchDigest = defineTable({
     "isSuspicious",
     "statsInstallsAllTime",
     "updatedAt",
-  ]);
+  ])
+  .searchIndex("search_by_display_name", {
+    searchField: "displayName",
+    filterFields: ["softDeletedAt", "isSuspicious"],
+  })
+  .searchIndex("search_by_slug", {
+    searchField: "slug",
+    filterFields: ["softDeletedAt", "isSuspicious"],
+  });
 
 const packages = defineTable({
   name: v.string(),

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -162,6 +162,101 @@ describe("search helpers", () => {
     );
   });
 
+  it("finds skill by non-first-token keyword via full-text search on displayName", async () => {
+    const skill = makeSkillDoc({
+      id: "skills:byv",
+      slug: "baidu-yijian-vision",
+      displayName: "Baidu Yijian Vision",
+    });
+    const ctx = makeDirectPrefixCtx([skill]);
+
+    const result = await directPrefixSkillMatchesHandler(ctx, { query: "yijian" });
+
+    expect(result.map((e) => e.skill.slug)).toContain("baidu-yijian-vision");
+    expect(ctx.usedIndexes).toContain("search_by_display_name");
+  });
+
+  it("finds skill by trailing token via full-text search on displayName", async () => {
+    const skill = makeSkillDoc({
+      id: "skills:byv",
+      slug: "baidu-yijian-vision",
+      displayName: "Baidu Yijian Vision",
+    });
+    const ctx = makeDirectPrefixCtx([skill]);
+
+    const result = await directPrefixSkillMatchesHandler(ctx, { query: "vision" });
+
+    expect(result.map((e) => e.skill.slug)).toContain("baidu-yijian-vision");
+    expect(ctx.usedIndexes).toContain("search_by_display_name");
+  });
+
+  it("finds skill by non-first-token keyword via full-text search on slug", async () => {
+    const skill = makeSkillDoc({
+      id: "skills:byv",
+      slug: "baidu-yijian-vision",
+      displayName: "Baidu Yijian Vision",
+    });
+    const ctx = makeDirectPrefixCtx([skill]);
+
+    const result = await directPrefixSkillMatchesHandler(ctx, { query: "yijian" });
+
+    expect(result.map((e) => e.skill.slug)).toContain("baidu-yijian-vision");
+    expect(ctx.usedIndexes).toContain("search_by_slug");
+  });
+
+  it("does not return unrelated skills for multi-token query via full-text search", async () => {
+    const target = makeSkillDoc({
+      id: "skills:byv",
+      slug: "baidu-yijian-vision",
+      displayName: "Baidu Yijian Vision",
+    });
+    const unrelated = makeSkillDoc({
+      id: "skills:bws",
+      slug: "baidu-web-search",
+      displayName: "Baidu Web Search",
+    });
+    const ctx = makeDirectPrefixCtx([target, unrelated]);
+
+    const result = await directPrefixSkillMatchesHandler(ctx, { query: "yijian vision" });
+    const slugs = result.map((e) => e.skill.slug);
+
+    expect(slugs).toContain("baidu-yijian-vision");
+    expect(slugs).not.toContain("baidu-web-search");
+  });
+
+  it("uses nonsuspicious full-text search indexes when nonSuspiciousOnly is set", async () => {
+    const skill = makeSkillDoc({
+      id: "skills:byv",
+      slug: "baidu-yijian-vision",
+      displayName: "Baidu Yijian Vision",
+    });
+    const ctx = makeDirectPrefixCtx([skill]);
+
+    await directPrefixSkillMatchesHandler(ctx, {
+      query: "yijian",
+      nonSuspiciousOnly: true,
+    });
+
+    // Full-text search indexes should be used
+    expect(ctx.usedIndexes).toContain("search_by_display_name");
+    expect(ctx.usedIndexes).toContain("search_by_slug");
+  });
+
+  it("deduplicates skills that appear in both prefix and full-text results", async () => {
+    // "baidu-yijian-vision" is hit by both firstToken prefix ("baidu") and full-text ("yijian")
+    const skill = makeSkillDoc({
+      id: "skills:byv",
+      slug: "baidu-yijian-vision",
+      displayName: "Baidu Yijian Vision",
+    });
+    const ctx = makeDirectPrefixCtx([skill]);
+
+    const result = await directPrefixSkillMatchesHandler(ctx, { query: "baidu yijian" });
+
+    const byvResults = result.filter((e) => e.skill.slug === "baidu-yijian-vision");
+    expect(byvResults).toHaveLength(1);
+  });
+
   it("applies highlightedOnly filtering in lexical fallback", async () => {
     const highlighted = {
       ...makeSkillDoc({
@@ -1490,6 +1585,32 @@ function makeDirectPrefixCtx(skills: Array<ReturnType<typeof makeSkillDoc>>) {
                     : "normalizedDisplayName";
                 const prefix = range[field] ?? "";
                 return digestRows.filter((digest) => (digest[field] ?? "").startsWith(prefix));
+              }),
+            };
+          },
+          withSearchIndex: (index: string, builder: (q: unknown) => unknown) => {
+            usedIndexes.push(index);
+            let searchField = "";
+            let searchQuery = "";
+            const q = {
+              search: (field: string, value: string) => {
+                searchField = field;
+                searchQuery = value.toLowerCase();
+                return q;
+              },
+              eq: () => q,
+            };
+            builder(q);
+            return {
+              take: vi.fn(async () => {
+                // Simulate full-text token matching: any token in the field matches any query token
+                const queryTokens = searchQuery.match(/[a-z0-9]+/g) ?? [];
+                return digestRows.filter((digest) => {
+                  const raw = (digest as Record<string, unknown>)[searchField];
+                  const fieldValue = (typeof raw === "string" ? raw : JSON.stringify(raw ?? "")).toLowerCase();
+                  const fieldTokens = fieldValue.match(/[a-z0-9]+/g) ?? [];
+                  return queryTokens.every((qt) => fieldTokens.some((ft) => ft.startsWith(qt)));
+                });
               }),
             };
           },

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -345,99 +345,140 @@ export const directPrefixSkillMatches = internalQuery({
 
     const upperBound = prefixUpperBound(normalizedQuery);
     const firstTokenUpperBound = firstToken ? prefixUpperBound(firstToken) : null;
-    const [slugDigests, displayNameDigests, slugFirstTokenDigests, displayNameFirstTokenDigests] =
-      await Promise.all([
-        args.nonSuspiciousOnly
+    // Phase 1 (existing): prefix-index paths — kept for zero-regression transition.
+    // Phase 2 (new): full-text search paths appended below; remove Phase 1 after searchIndex backfill completes.
+    const [
+      slugDigests,
+      displayNameDigests,
+      slugFirstTokenDigests,
+      displayNameFirstTokenDigests,
+      ftDisplayNameDigests,
+      ftSlugDigests,
+    ] = await Promise.all([
+      args.nonSuspiciousOnly
+        ? ctx.db
+            .query("skillSearchDigest")
+            .withIndex("by_nonsuspicious_normalized_slug", (q) =>
+              q
+                .eq("softDeletedAt", undefined)
+                .eq("isSuspicious", false)
+                .gte("normalizedSlug", normalizedQuery)
+                .lt("normalizedSlug", upperBound),
+            )
+            .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
+        : ctx.db
+            .query("skillSearchDigest")
+            .withIndex("by_active_normalized_slug", (q) =>
+              q
+                .eq("softDeletedAt", undefined)
+                .gte("normalizedSlug", normalizedQuery)
+                .lt("normalizedSlug", upperBound),
+            )
+            .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES),
+      args.nonSuspiciousOnly
+        ? ctx.db
+            .query("skillSearchDigest")
+            .withIndex("by_nonsuspicious_normalized_display_name", (q) =>
+              q
+                .eq("softDeletedAt", undefined)
+                .eq("isSuspicious", false)
+                .gte("normalizedDisplayName", normalizedQuery)
+                .lt("normalizedDisplayName", upperBound),
+            )
+            .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
+        : ctx.db
+            .query("skillSearchDigest")
+            .withIndex("by_active_normalized_display_name", (q) =>
+              q
+                .eq("softDeletedAt", undefined)
+                .gte("normalizedDisplayName", normalizedQuery)
+                .lt("normalizedDisplayName", upperBound),
+            )
+            .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES),
+      firstTokenUpperBound
+        ? args.nonSuspiciousOnly
           ? ctx.db
               .query("skillSearchDigest")
-              .withIndex("by_nonsuspicious_normalized_slug", (q) =>
+              .withIndex("by_nonsuspicious_normalized_slug_first_token", (q) =>
                 q
                   .eq("softDeletedAt", undefined)
                   .eq("isSuspicious", false)
-                  .gte("normalizedSlug", normalizedQuery)
-                  .lt("normalizedSlug", upperBound),
+                  .gte("normalizedSlugFirstToken", firstToken)
+                  .lt("normalizedSlugFirstToken", firstTokenUpperBound),
               )
               .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
           : ctx.db
               .query("skillSearchDigest")
-              .withIndex("by_active_normalized_slug", (q) =>
+              .withIndex("by_active_normalized_slug_first_token", (q) =>
                 q
                   .eq("softDeletedAt", undefined)
-                  .gte("normalizedSlug", normalizedQuery)
-                  .lt("normalizedSlug", upperBound),
+                  .gte("normalizedSlugFirstToken", firstToken)
+                  .lt("normalizedSlugFirstToken", firstTokenUpperBound),
               )
-              .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES),
-        args.nonSuspiciousOnly
+              .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
+        : Promise.resolve([]),
+      firstTokenUpperBound
+        ? args.nonSuspiciousOnly
           ? ctx.db
               .query("skillSearchDigest")
-              .withIndex("by_nonsuspicious_normalized_display_name", (q) =>
+              .withIndex("by_nonsuspicious_normalized_display_name_first_token", (q) =>
                 q
                   .eq("softDeletedAt", undefined)
                   .eq("isSuspicious", false)
-                  .gte("normalizedDisplayName", normalizedQuery)
-                  .lt("normalizedDisplayName", upperBound),
+                  .gte("normalizedDisplayNameFirstToken", firstToken)
+                  .lt("normalizedDisplayNameFirstToken", firstTokenUpperBound),
               )
               .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
           : ctx.db
               .query("skillSearchDigest")
-              .withIndex("by_active_normalized_display_name", (q) =>
+              .withIndex("by_active_normalized_display_name_first_token", (q) =>
                 q
                   .eq("softDeletedAt", undefined)
-                  .gte("normalizedDisplayName", normalizedQuery)
-                  .lt("normalizedDisplayName", upperBound),
+                  .gte("normalizedDisplayNameFirstToken", firstToken)
+                  .lt("normalizedDisplayNameFirstToken", firstTokenUpperBound),
               )
-              .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES),
-        firstTokenUpperBound
-          ? args.nonSuspiciousOnly
-            ? ctx.db
-                .query("skillSearchDigest")
-                .withIndex("by_nonsuspicious_normalized_slug_first_token", (q) =>
-                  q
-                    .eq("softDeletedAt", undefined)
-                    .eq("isSuspicious", false)
-                    .gte("normalizedSlugFirstToken", firstToken)
-                    .lt("normalizedSlugFirstToken", firstTokenUpperBound),
-                )
-                .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
-            : ctx.db
-                .query("skillSearchDigest")
-                .withIndex("by_active_normalized_slug_first_token", (q) =>
-                  q
-                    .eq("softDeletedAt", undefined)
-                    .gte("normalizedSlugFirstToken", firstToken)
-                    .lt("normalizedSlugFirstToken", firstTokenUpperBound),
-                )
-                .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
-          : Promise.resolve([]),
-        firstTokenUpperBound
-          ? args.nonSuspiciousOnly
-            ? ctx.db
-                .query("skillSearchDigest")
-                .withIndex("by_nonsuspicious_normalized_display_name_first_token", (q) =>
-                  q
-                    .eq("softDeletedAt", undefined)
-                    .eq("isSuspicious", false)
-                    .gte("normalizedDisplayNameFirstToken", firstToken)
-                    .lt("normalizedDisplayNameFirstToken", firstTokenUpperBound),
-                )
-                .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
-            : ctx.db
-                .query("skillSearchDigest")
-                .withIndex("by_active_normalized_display_name_first_token", (q) =>
-                  q
-                    .eq("softDeletedAt", undefined)
-                    .gte("normalizedDisplayNameFirstToken", firstToken)
-                    .lt("normalizedDisplayNameFirstToken", firstTokenUpperBound),
-                )
-                .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
-          : Promise.resolve([]),
-      ]);
+              .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
+        : Promise.resolve([]),
+      // Phase 2: full-text search on displayName — matches any token, not just the first
+      args.nonSuspiciousOnly
+        ? ctx.db
+            .query("skillSearchDigest")
+            .withSearchIndex("search_by_display_name", (q) =>
+              q
+                .search("displayName", args.query)
+                .eq("softDeletedAt", undefined)
+                .eq("isSuspicious", false),
+            )
+            .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
+        : ctx.db
+            .query("skillSearchDigest")
+            .withSearchIndex("search_by_display_name", (q) =>
+              q.search("displayName", args.query).eq("softDeletedAt", undefined),
+            )
+            .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES),
+      // Phase 2: full-text search on slug — matches any token, not just the first
+      args.nonSuspiciousOnly
+        ? ctx.db
+            .query("skillSearchDigest")
+            .withSearchIndex("search_by_slug", (q) =>
+              q.search("slug", args.query).eq("softDeletedAt", undefined).eq("isSuspicious", false),
+            )
+            .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
+        : ctx.db
+            .query("skillSearchDigest")
+            .withSearchIndex("search_by_slug", (q) =>
+              q.search("slug", args.query).eq("softDeletedAt", undefined),
+            )
+            .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES),
+    ]);
 
     const digests = [
       ...slugDigests,
       ...displayNameDigests,
       ...slugFirstTokenDigests,
       ...displayNameFirstTokenDigests,
+      ...ftDisplayNameDigests,
+      ...ftSlugDigests,
     ].filter(
       (digest, index, all) =>
         all.findIndex((candidate) => candidate.skillId === digest.skillId) === index,


### PR DESCRIPTION
## Summary

Skills are systematically invisible in search when the query keyword is not the first token of the skill name. For example, `baidu-yijian-vision` cannot be found by searching `yijian` or `vision`, only by `baidu yijian` — because all four recall queries in `directPrefixSkillMatches` are string-prefix queries that miss any word not at the start of the slug/displayName.

Additionally, the `lexicalFallbackSkills` path is bounded by an `updatedAt` recency window, causing visibility to decay over time as newer skills push older ones out.

## Linked Issue

- Related #2137

## Screenshots

- N/A

## Security / Trust Impact

- No security/trust impact

## Data / Deploy Impact

This PR implements a **two-phase zero-downtime rollout**:

**Phase 1 — this PR:**
- New `searchIndex` definitions are deployed; Convex begins async backfill automatically
- New full-text queries run **in parallel** with legacy prefix queries; results merged via existing dedup
- No user-facing regression: legacy path continues covering all previously-working queries
- Monitor index status in the Convex dashboard until `status = ready`

**Phase 2 — follow-up PR (after backfill completes):**
- Remove the four legacy prefix queries from `directPrefixSkillMatches`
- Remove the corresponding `by_active_normalized_slug_first_token` / `by_active_normalized_display_name_first_token` (and `by_nonsuspicious_*`) index definitions from schema

## Verification

- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run test`
