### PR TITLE
fix(search): recall non-first-token matches via full-text indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixes
 
+- Search: recall skill matches by non-first slug/display-name tokens while keeping multi-token queries on the direct recall path constrained to all query tokens (#2140) (thanks @momothemage).
 - Moderation: stop treating static suspicious-only findings as a verdict; keep file/line evidence for review while VT/LLM decide public suspicious status.
 - Moderation: stop treating VirusTotal Code Insight/Palm verdicts as a hide authority for skills; real AV-engine hits and ClawScan findings still contribute moderation verdicts.
 - ClawScan: lower false positives by treating purpose-aligned notes as benign unless structured LLM findings contain a material concern, and add targeted rescan batches for suspicious skills/plugins.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+
+### Fixes
+
+- Search: recall skill matches by non-first slug/display-name tokens while keeping multi-token queries on the direct recall path constrained to all query tokens (#2140) (thanks @momothemage).
+
 ## 0.13.0 - Unreleased
 
 ### Changes
@@ -14,7 +22,6 @@
 
 ### Fixes
 
-- Search: recall skill matches by non-first slug/display-name tokens while keeping multi-token queries on the direct recall path constrained to all query tokens (#2140) (thanks @momothemage).
 - Moderation: stop treating static suspicious-only findings as a verdict; keep file/line evidence for review while VT/LLM decide public suspicious status.
 - Moderation: stop treating VirusTotal Code Insight/Palm verdicts as a hide authority for skills; real AV-engine hits and ClawScan findings still contribute moderation verdicts.
 - ClawScan: lower false positives by treating purpose-aligned notes as benign unless structured LLM findings contain a material concern, and add targeted rescan batches for suspicious skills/plugins.

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -810,7 +810,15 @@ const skillSearchDigest = defineTable({
     "isSuspicious",
     "statsInstallsAllTime",
     "updatedAt",
-  ]);
+  ])
+  .searchIndex("search_by_display_name", {
+    searchField: "displayName",
+    filterFields: ["softDeletedAt", "isSuspicious"],
+  })
+  .searchIndex("search_by_slug", {
+    searchField: "slug",
+    filterFields: ["softDeletedAt", "isSuspicious"],
+  });
 
 const packages = defineTable({
   name: v.string(),

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -162,6 +162,98 @@ describe("search helpers", () => {
     );
   });
 
+  it("recalls non-first-token slug matches via the full-text search index (Bug 1)", async () => {
+    // Repro of the original bug: searching "yijian" against a skill whose
+    // slug is "baidu-yijian-vision" returned zero results because all four
+    // prefix indexes only match the *first* token. The new search index
+    // should match any token at any position.
+    const skill = makeSkillDoc({
+      id: "skills:baidu-yijian-vision",
+      slug: "baidu-yijian-vision",
+      displayName: "Baidu Yijian Vision",
+    });
+    const ctx = makeDirectPrefixCtx([skill]);
+
+    const result = await directPrefixSkillMatchesHandler(ctx, {
+      query: "yijian",
+      limit: 10,
+    });
+
+    expect(result.map((entry) => entry.skill.slug)).toEqual(["baidu-yijian-vision"]);
+    expect(ctx.usedSearchIndexes).toEqual(
+      expect.arrayContaining(["search_by_display_name", "search_by_slug"]),
+    );
+  });
+
+  it("recalls non-first-token displayName matches via the full-text search index", async () => {
+    // Companion case to the slug repro above: a query that only matches
+    // the displayName (not the slug) at a non-first position must still
+    // surface the skill.
+    const skill = makeSkillDoc({
+      id: "skills:baidu-yijian-vision",
+      slug: "baidu-yijian-vision",
+      displayName: "Baidu Yijian Vision",
+    });
+    const ctx = makeDirectPrefixCtx([skill]);
+
+    const result = await directPrefixSkillMatchesHandler(ctx, {
+      query: "Vision",
+      limit: 10,
+    });
+
+    expect(result.map((entry) => entry.skill.slug)).toEqual(["baidu-yijian-vision"]);
+  });
+
+  it("does not return suspicious skills via full-text search when nonSuspiciousOnly is set", async () => {
+    // Even though the full-text search would token-match the suspicious
+    // skill, the filterField `isSuspicious=false` plus the post-hydration
+    // `isSkillSuspicious` guard must keep it out of the results.
+    const clean = makeSkillDoc({
+      id: "skills:clean",
+      slug: "baidu-yijian-vision",
+      displayName: "Baidu Yijian Vision",
+    });
+    const flagged = makeSkillDoc({
+      id: "skills:flagged",
+      slug: "shady-yijian-trick",
+      displayName: "Shady Yijian Trick",
+      moderationFlags: ["flagged.suspicious"],
+    });
+    const ctx = makeDirectPrefixCtx([clean, flagged]);
+
+    const result = await directPrefixSkillMatchesHandler(ctx, {
+      query: "yijian",
+      nonSuspiciousOnly: true,
+      limit: 10,
+    });
+
+    expect(result.map((entry) => entry.skill.slug)).toEqual(["baidu-yijian-vision"]);
+  });
+
+  it("dedupes skills matched by both legacy prefix indexes and the new full-text index", async () => {
+    // First-token queries hit *all six* recall paths (4 prefix + 2 full-text).
+    // The skillId-based filter inside `directPrefixSkillMatches` must prevent
+    // the same skill from being emitted multiple times in the final list.
+    const skill = makeSkillDoc({
+      id: "skills:baidu-yijian-vision",
+      slug: "baidu-yijian-vision",
+      displayName: "Baidu Yijian Vision",
+    });
+    const ctx = makeDirectPrefixCtx([skill]);
+
+    const result = await directPrefixSkillMatchesHandler(ctx, {
+      query: "baidu",
+      limit: 10,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].skill.slug).toBe("baidu-yijian-vision");
+    // Sanity: both legacy prefix indexes and the new full-text indexes were
+    // queried, so the dedup is doing real work, not just a no-op pass-through.
+    expect(ctx.usedIndexes.length).toBeGreaterThanOrEqual(4);
+    expect(ctx.usedSearchIndexes.length).toBeGreaterThanOrEqual(2);
+  });
+
   it("applies highlightedOnly filtering in lexical fallback", async () => {
     const highlighted = {
       ...makeSkillDoc({
@@ -1448,6 +1540,10 @@ function makeLexicalCtx(params: {
 
 function makeDirectPrefixCtx(skills: Array<ReturnType<typeof makeSkillDoc>>) {
   const firstToken = (value: string) => value.toLowerCase().match(/[a-z0-9]+/)?.[0];
+  // Token-level splitter that mirrors Convex full-text inverted index behavior:
+  // any alphanumeric run of length >= 1 becomes a token, regardless of position.
+  const tokensOf = (value: string): string[] =>
+    (value.toLowerCase().match(/[a-z0-9]+/g) ?? []).filter(Boolean);
   const digestRows = skills.map((skill) => ({
     ...skill,
     skillId: skill._id,
@@ -1455,14 +1551,17 @@ function makeDirectPrefixCtx(skills: Array<ReturnType<typeof makeSkillDoc>>) {
     normalizedSlugFirstToken: firstToken(skill.slug),
     normalizedDisplayName: skill.displayName.toLowerCase(),
     normalizedDisplayNameFirstToken: firstToken(skill.displayName),
+    isSuspicious: (skill.moderationFlags ?? []).includes("flagged.suspicious"),
     ownerHandle: "owner",
     ownerName: "Owner",
     ownerDisplayName: "Owner",
     ownerImage: undefined,
   }));
   const usedIndexes: string[] = [];
+  const usedSearchIndexes: string[] = [];
   return {
     usedIndexes,
+    usedSearchIndexes,
     db: {
       query: vi.fn((table: string) => {
         if (table !== "skillSearchDigest") throw new Error(`Unexpected table ${table}`);
@@ -1490,6 +1589,55 @@ function makeDirectPrefixCtx(skills: Array<ReturnType<typeof makeSkillDoc>>) {
                     : "normalizedDisplayName";
                 const prefix = range[field] ?? "";
                 return digestRows.filter((digest) => (digest[field] ?? "").startsWith(prefix));
+              }),
+            };
+          },
+          // Mock for the new `searchIndex`-backed full-text queries added to
+          // `directPrefixSkillMatches`. Mirrors Convex's documented semantics:
+          // tokenize on alphanumeric runs (case-insensitive) and match a row
+          // when *any* token in the search field equals *any* token of the
+          // user query — i.e. position-independent, unlike `withIndex` which
+          // only does string-prefix matches against a normalized field.
+          withSearchIndex: (
+            indexName: string,
+            builder: (q: {
+              search: (field: string, query: string) => unknown;
+              eq: (field: string, value: unknown) => unknown;
+            }) => unknown,
+          ) => {
+            usedSearchIndexes.push(indexName);
+            let searchField = "";
+            let searchQuery = "";
+            const filters: Array<{ field: string; value: unknown }> = [];
+            const q = {
+              search: (field: string, query: string) => {
+                searchField = field;
+                searchQuery = query;
+                return q;
+              },
+              eq: (field: string, value: unknown) => {
+                filters.push({ field, value });
+                return q;
+              },
+            };
+            builder(q);
+            return {
+              take: vi.fn(async () => {
+                const queryTokens = new Set(tokensOf(searchQuery));
+                if (queryTokens.size === 0) return [];
+                return digestRows.filter((digest) => {
+                  for (const filter of filters) {
+                    if ((digest as Record<string, unknown>)[filter.field] !== filter.value) {
+                      return false;
+                    }
+                  }
+                  const fieldValue = String((digest as Record<string, unknown>)[searchField] ?? "");
+                  const fieldTokens = new Set(tokensOf(fieldValue));
+                  for (const token of queryTokens) {
+                    if (fieldTokens.has(token)) return true;
+                  }
+                  return false;
+                });
               }),
             };
           },

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -1631,7 +1631,8 @@ function makeDirectPrefixCtx(skills: Array<ReturnType<typeof makeSkillDoc>>) {
                       return false;
                     }
                   }
-                  const fieldValue = String((digest as Record<string, unknown>)[searchField] ?? "");
+                  const fieldValue =
+                    (digest as Record<string, string | undefined>)[searchField] ?? "";
                   const fieldTokens = new Set(tokensOf(fieldValue));
                   for (const token of queryTokens) {
                     if (fieldTokens.has(token)) return true;

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -254,6 +254,58 @@ describe("search helpers", () => {
     expect(ctx.usedSearchIndexes.length).toBeGreaterThanOrEqual(2);
   });
 
+  it("rejects multi-token full-text candidates when only some tokens match (AND semantics)", async () => {
+    // Convex `withSearchIndex(...).search(field, q)` is OR-disjunctive over
+    // tokens: a query like "yijian vision" can return rows that contain
+    // *either* token. Without an application-layer AND gate, a `vision`-only
+    // distractor would surface as a "direct prefix match" alongside the
+    // genuine all-tokens hit. The handler must filter the full-text path
+    // through `matchesExactTokens` so only skills whose text contains every
+    // query token survive.
+    const distractor = makeSkillDoc({
+      id: "skills:cv-expert",
+      slug: "computer-vision-expert",
+      displayName: "Computer Vision Expert",
+    });
+    const target = makeSkillDoc({
+      id: "skills:baidu-yijian-vision",
+      slug: "baidu-yijian-vision",
+      displayName: "Baidu Yijian Vision",
+    });
+    const ctx = makeDirectPrefixCtx([distractor, target]);
+
+    const result = await directPrefixSkillMatchesHandler(ctx, {
+      query: "yijian vision",
+      limit: 10,
+    });
+
+    expect(result.map((entry) => entry.skill.slug)).toEqual(["baidu-yijian-vision"]);
+  });
+
+  it("returns nothing when no single skill contains all query tokens", async () => {
+    // Each skill matches exactly one token of the multi-token query. The
+    // disjunctive search index would yield both, but the AND gate must drop
+    // them — no skill in the corpus contains *both* `yijian` and `vision`.
+    const onlyVision = makeSkillDoc({
+      id: "skills:cv-expert",
+      slug: "computer-vision-expert",
+      displayName: "Computer Vision Expert",
+    });
+    const onlyYijian = makeSkillDoc({
+      id: "skills:yijian-misc",
+      slug: "yijian-misc-tool",
+      displayName: "Yijian Misc Tool",
+    });
+    const ctx = makeDirectPrefixCtx([onlyVision, onlyYijian]);
+
+    const result = await directPrefixSkillMatchesHandler(ctx, {
+      query: "yijian vision",
+      limit: 10,
+    });
+
+    expect(result).toEqual([]);
+  });
+
   it("applies highlightedOnly filtering in lexical fallback", async () => {
     const highlighted = {
       ...makeSkillDoc({

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -1632,7 +1632,7 @@ function makeDirectPrefixCtx(skills: Array<ReturnType<typeof makeSkillDoc>>) {
                     }
                   }
                   const fieldValue =
-                    (digest as Record<string, string | undefined>)[searchField] ?? "";
+                    (digest as unknown as Record<string, string | undefined>)[searchField] ?? "";
                   const fieldTokens = new Set(tokensOf(fieldValue));
                   for (const token of queryTokens) {
                     if (fieldTokens.has(token)) return true;

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -345,99 +345,141 @@ export const directPrefixSkillMatches = internalQuery({
 
     const upperBound = prefixUpperBound(normalizedQuery);
     const firstTokenUpperBound = firstToken ? prefixUpperBound(firstToken) : null;
-    const [slugDigests, displayNameDigests, slugFirstTokenDigests, displayNameFirstTokenDigests] =
-      await Promise.all([
-        args.nonSuspiciousOnly
+    const [
+      slugDigests,
+      displayNameDigests,
+      slugFirstTokenDigests,
+      displayNameFirstTokenDigests,
+      ftDisplayNameDigests,
+      ftSlugDigests,
+    ] = await Promise.all([
+      args.nonSuspiciousOnly
+        ? ctx.db
+            .query("skillSearchDigest")
+            .withIndex("by_nonsuspicious_normalized_slug", (q) =>
+              q
+                .eq("softDeletedAt", undefined)
+                .eq("isSuspicious", false)
+                .gte("normalizedSlug", normalizedQuery)
+                .lt("normalizedSlug", upperBound),
+            )
+            .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
+        : ctx.db
+            .query("skillSearchDigest")
+            .withIndex("by_active_normalized_slug", (q) =>
+              q
+                .eq("softDeletedAt", undefined)
+                .gte("normalizedSlug", normalizedQuery)
+                .lt("normalizedSlug", upperBound),
+            )
+            .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES),
+      args.nonSuspiciousOnly
+        ? ctx.db
+            .query("skillSearchDigest")
+            .withIndex("by_nonsuspicious_normalized_display_name", (q) =>
+              q
+                .eq("softDeletedAt", undefined)
+                .eq("isSuspicious", false)
+                .gte("normalizedDisplayName", normalizedQuery)
+                .lt("normalizedDisplayName", upperBound),
+            )
+            .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
+        : ctx.db
+            .query("skillSearchDigest")
+            .withIndex("by_active_normalized_display_name", (q) =>
+              q
+                .eq("softDeletedAt", undefined)
+                .gte("normalizedDisplayName", normalizedQuery)
+                .lt("normalizedDisplayName", upperBound),
+            )
+            .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES),
+      firstTokenUpperBound
+        ? args.nonSuspiciousOnly
           ? ctx.db
               .query("skillSearchDigest")
-              .withIndex("by_nonsuspicious_normalized_slug", (q) =>
+              .withIndex("by_nonsuspicious_normalized_slug_first_token", (q) =>
                 q
                   .eq("softDeletedAt", undefined)
                   .eq("isSuspicious", false)
-                  .gte("normalizedSlug", normalizedQuery)
-                  .lt("normalizedSlug", upperBound),
+                  .gte("normalizedSlugFirstToken", firstToken)
+                  .lt("normalizedSlugFirstToken", firstTokenUpperBound),
               )
               .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
           : ctx.db
               .query("skillSearchDigest")
-              .withIndex("by_active_normalized_slug", (q) =>
+              .withIndex("by_active_normalized_slug_first_token", (q) =>
                 q
                   .eq("softDeletedAt", undefined)
-                  .gte("normalizedSlug", normalizedQuery)
-                  .lt("normalizedSlug", upperBound),
+                  .gte("normalizedSlugFirstToken", firstToken)
+                  .lt("normalizedSlugFirstToken", firstTokenUpperBound),
               )
-              .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES),
-        args.nonSuspiciousOnly
+              .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
+        : Promise.resolve([]),
+      firstTokenUpperBound
+        ? args.nonSuspiciousOnly
           ? ctx.db
               .query("skillSearchDigest")
-              .withIndex("by_nonsuspicious_normalized_display_name", (q) =>
+              .withIndex("by_nonsuspicious_normalized_display_name_first_token", (q) =>
                 q
                   .eq("softDeletedAt", undefined)
                   .eq("isSuspicious", false)
-                  .gte("normalizedDisplayName", normalizedQuery)
-                  .lt("normalizedDisplayName", upperBound),
+                  .gte("normalizedDisplayNameFirstToken", firstToken)
+                  .lt("normalizedDisplayNameFirstToken", firstTokenUpperBound),
               )
               .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
           : ctx.db
               .query("skillSearchDigest")
-              .withIndex("by_active_normalized_display_name", (q) =>
+              .withIndex("by_active_normalized_display_name_first_token", (q) =>
                 q
                   .eq("softDeletedAt", undefined)
-                  .gte("normalizedDisplayName", normalizedQuery)
-                  .lt("normalizedDisplayName", upperBound),
+                  .gte("normalizedDisplayNameFirstToken", firstToken)
+                  .lt("normalizedDisplayNameFirstToken", firstTokenUpperBound),
               )
-              .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES),
-        firstTokenUpperBound
-          ? args.nonSuspiciousOnly
-            ? ctx.db
-                .query("skillSearchDigest")
-                .withIndex("by_nonsuspicious_normalized_slug_first_token", (q) =>
-                  q
-                    .eq("softDeletedAt", undefined)
-                    .eq("isSuspicious", false)
-                    .gte("normalizedSlugFirstToken", firstToken)
-                    .lt("normalizedSlugFirstToken", firstTokenUpperBound),
-                )
-                .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
-            : ctx.db
-                .query("skillSearchDigest")
-                .withIndex("by_active_normalized_slug_first_token", (q) =>
-                  q
-                    .eq("softDeletedAt", undefined)
-                    .gte("normalizedSlugFirstToken", firstToken)
-                    .lt("normalizedSlugFirstToken", firstTokenUpperBound),
-                )
-                .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
-          : Promise.resolve([]),
-        firstTokenUpperBound
-          ? args.nonSuspiciousOnly
-            ? ctx.db
-                .query("skillSearchDigest")
-                .withIndex("by_nonsuspicious_normalized_display_name_first_token", (q) =>
-                  q
-                    .eq("softDeletedAt", undefined)
-                    .eq("isSuspicious", false)
-                    .gte("normalizedDisplayNameFirstToken", firstToken)
-                    .lt("normalizedDisplayNameFirstToken", firstTokenUpperBound),
-                )
-                .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
-            : ctx.db
-                .query("skillSearchDigest")
-                .withIndex("by_active_normalized_display_name_first_token", (q) =>
-                  q
-                    .eq("softDeletedAt", undefined)
-                    .gte("normalizedDisplayNameFirstToken", firstToken)
-                    .lt("normalizedDisplayNameFirstToken", firstTokenUpperBound),
-                )
-                .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
-          : Promise.resolve([]),
-      ]);
+              .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
+        : Promise.resolve([]),
+      // Full-text search on displayName — matches any token at any position.
+      // Resolves Bug (non-first-token undiscoverable) by leveraging the
+      // Convex inverted index added in `search_by_display_name`.
+      args.nonSuspiciousOnly
+        ? ctx.db
+            .query("skillSearchDigest")
+            .withSearchIndex("search_by_display_name", (q) =>
+              q
+                .search("displayName", args.query)
+                .eq("softDeletedAt", undefined)
+                .eq("isSuspicious", false),
+            )
+            .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
+        : ctx.db
+            .query("skillSearchDigest")
+            .withSearchIndex("search_by_display_name", (q) =>
+              q.search("displayName", args.query).eq("softDeletedAt", undefined),
+            )
+            .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES),
+      // Full-text search on slug — same rationale, covers slug middle/tail tokens
+      // (e.g. "yijian" or "vision" inside "baidu-yijian-vision").
+      args.nonSuspiciousOnly
+        ? ctx.db
+            .query("skillSearchDigest")
+            .withSearchIndex("search_by_slug", (q) =>
+              q.search("slug", args.query).eq("softDeletedAt", undefined).eq("isSuspicious", false),
+            )
+            .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
+        : ctx.db
+            .query("skillSearchDigest")
+            .withSearchIndex("search_by_slug", (q) =>
+              q.search("slug", args.query).eq("softDeletedAt", undefined),
+            )
+            .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES),
+    ]);
 
     const digests = [
       ...slugDigests,
       ...displayNameDigests,
       ...slugFirstTokenDigests,
       ...displayNameFirstTokenDigests,
+      ...ftDisplayNameDigests,
+      ...ftSlugDigests,
     ].filter(
       (digest, index, all) =>
         all.findIndex((candidate) => candidate.skillId === digest.skillId) === index,

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -342,6 +342,7 @@ export const directPrefixSkillMatches = internalQuery({
     const normalizedQuery = normalizeSkillSearchText(args.query);
     if (!normalizedQuery) return [];
     const firstToken = getFirstSearchToken(args.query);
+    const queryTokens = tokenize(args.query);
 
     const upperBound = prefixUpperBound(normalizedQuery);
     const firstTokenUpperBound = firstToken ? prefixUpperBound(firstToken) : null;
@@ -472,6 +473,14 @@ export const directPrefixSkillMatches = internalQuery({
             )
             .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES),
     ]);
+    // Mirrors the `matchesExactTokens` filter the vector path applies on
+    // hydrated results, so every recall path shares one literal-match
+    // contract. For single-token queries this gate is a no-op against the
+    // existing prefix paths, since any prefix match also implies a token
+    // match.
+    const passesAllQueryTokens = (digest: Doc<"skillSearchDigest">) =>
+      queryTokens.length === 0 ||
+      matchesExactTokens(queryTokens, [digest.displayName, digest.slug, digest.summary]);
 
     const digests = [
       ...slugDigests,
@@ -480,10 +489,12 @@ export const directPrefixSkillMatches = internalQuery({
       ...displayNameFirstTokenDigests,
       ...ftDisplayNameDigests,
       ...ftSlugDigests,
-    ].filter(
-      (digest, index, all) =>
-        all.findIndex((candidate) => candidate.skillId === digest.skillId) === index,
-    );
+    ]
+      .filter(
+        (digest, index, all) =>
+          all.findIndex((candidate) => candidate.skillId === digest.skillId) === index,
+      )
+      .filter(passesAllQueryTokens);
     if (digests.length === 0) return [];
 
     const getOwnerInfo = makeOwnerInfoGetter(ctx);


### PR DESCRIPTION
## Summary

- What changed:
  - Added two Convex full-text `searchIndex`es to `skillSearchDigest` in `convex/schema.ts`: `search_by_display_name` and `search_by_slug`, both with `filterFields: ["softDeletedAt", "isSuspicious"]`.
  - Appended two `withSearchIndex(...)` queries to the existing `Promise.all` in `directPrefixSkillMatches` (`convex/search.ts`) so non-first-token tokens are now recalled. The four legacy prefix-index queries are kept untouched and merged through the existing `skillId`-based dedup.
  - Extended the test mock in `convex/search.test.ts` to model Convex's token-level inverted-index semantics, and added 4 regression tests (non-first-token slug, non-first-token displayName, `nonSuspiciousOnly` safety, cross-path dedup).
- Why:
  - Skill search systematically returned zero results when the user's query was not a string prefix of the skill's `slug` / `displayName` and was not the first token. For example, searching `yijian` or `vision` against `baidu-yijian-vision` produced an empty list even though the skill was active and non-suspicious.
  - The four prefix indexes used by `directPrefixSkillMatches` are anchored to the start of either the full normalized field or its first alphanumeric token, so non-first-token queries miss every path simultaneously. The lexical fallback only scans the most-recently-updated/created N rows, which explains the "publish a new version, becomes findable, then disappears again" time-decay symptom. Vector search has weak recall for transliterated tokens (e.g. Chinese pinyin), so it cannot reliably backfill the gap.
  - This is Phase 1 of a two-phase zero-downtime rollout: the legacy prefix paths stay live during the index backfill, so worst case the result set is no smaller than today; once the new search indexes show `ready` in the Convex dashboard, a follow-up PR will retire the redundant prefix indexes.

## Linked Issue

- Closes #2137 
- Related #

## Screenshots

For website/UI changes, attach screenshots or recordings from the real app. Include mobile/narrow views when layout changes.

- [x] Screenshots/recordings attached, or `N/A` — N/A (backend-only change to Convex query layer; no UI surface modified)

## Security / Trust Impact

- [x] No security/trust impact
- [ ] Security/trust impact explained

Notes (kept for reviewer context, not a separate impact):

- The new `searchIndex`es declare `softDeletedAt` and `isSuspicious` as `filterFields`, and every new query passes `.eq("softDeletedAt", undefined)` plus (when `nonSuspiciousOnly` is set) `.eq("isSuspicious", false)`, matching the existing prefix-query behavior.
- The post-hydration `isSkillSuspicious(skill)` and `isSkillHighlighted(skill)` guards in `directPrefixSkillMatches` are unchanged, so suspicious or non-highlighted skills cannot leak through the new path.

## Data / Deploy Impact

- [ ] No data/deploy impact
- [x] Data/deploy impact explained

- Schema change: two new `searchIndex` entries on `skillSearchDigest`. Convex will automatically backfill all existing documents in the background once the schema is deployed; no migration script is required.
- Index readiness can be observed in the Convex dashboard. During backfill, queries against the new indexes still execute and progressively return more matches as the backfill advances; the legacy prefix paths run in parallel, so user-visible recall never regresses below the pre-PR baseline.
- No writes to existing fields, no row migrations, no data deletions.
- Rollback is safe: removing the schema entries and the two `withSearchIndex` calls restores the previous behavior with no data fix-up needed.

## Verification

- [x] `bun run format:check` — verified via `bunx oxfmt --check` on `convex/schema.ts`, `convex/search.ts`, `convex/search.test.ts`: "All matched files use the correct format."
- [x] `bun run lint` — verified via `bunx oxlint` on the same three files: 0 warnings, 0 errors across 119 rules.
- [x] `bun run test` — `bunx vitest run convex/`: 96 files / 1176 tests passed; `bunx vitest run convex/search.test.ts`: 38 / 38 passed (4 newly added).
