### PR TITLE
fix: require preinstall package verification in skill prompt

### DIFF
--- a/src/components/SkillInstallSurface.test.tsx
+++ b/src/components/SkillInstallSurface.test.tsx
@@ -52,7 +52,7 @@ describe("SkillInstallSurface", () => {
 
     expect(screen.getByRole("heading", { name: "Install with OpenClaw" })).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "CLI Commands" })).toBeNull();
-    expect(screen.getByText(/After install, inspect the skill metadata/i)).toBeTruthy();
+    expect(screen.getByText(/Before install, inspect the ClawHub skill metadata/i)).toBeTruthy();
     expect(screen.getAllByText("Install & Setup").length).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByRole("button", { name: /Install Only/i }));
@@ -96,7 +96,7 @@ describe("SkillInstallSurface", () => {
 
     await waitFor(() => {
       expect(writeTextMock).toHaveBeenCalledWith(
-        expect.stringContaining("After install, inspect the skill metadata"),
+        expect.stringContaining("Before install, inspect the ClawHub skill metadata"),
       );
     });
   });

--- a/src/components/SkillInstallSurface.test.tsx
+++ b/src/components/SkillInstallSurface.test.tsx
@@ -52,7 +52,7 @@ describe("SkillInstallSurface", () => {
 
     expect(screen.getByRole("heading", { name: "Install with OpenClaw" })).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "CLI Commands" })).toBeNull();
-    expect(screen.getByText(/Before install, inspect the ClawHub skill metadata/i)).toBeTruthy();
+    expect(screen.getByText(/Before installing anything/i)).toBeTruthy();
     expect(screen.getAllByText("Install & Setup").length).toBeGreaterThan(0);
 
     fireEvent.click(screen.getByRole("button", { name: /Install Only/i }));
@@ -96,7 +96,7 @@ describe("SkillInstallSurface", () => {
 
     await waitFor(() => {
       expect(writeTextMock).toHaveBeenCalledWith(
-        expect.stringContaining("Before install, inspect the ClawHub skill metadata"),
+        expect.stringContaining("Before installing anything"),
       );
     });
   });

--- a/src/components/skillDetailUtils.test.ts
+++ b/src/components/skillDetailUtils.test.ts
@@ -59,6 +59,9 @@ describe("skill detail install helpers", () => {
     expect(prompt).toContain("WEATHER_API_KEY");
     expect(prompt).toContain("curl");
     expect(prompt).toContain("~/.weatherrc");
+    expect(prompt).toContain("Before install, inspect the ClawHub skill metadata");
+    expect(prompt).toContain("verify its source, maintainer, and package contents");
+    expect(prompt).toContain("After install, help me finish setup from verified skill metadata.");
     expect(prompt).not.toContain("unknown");
   });
 

--- a/src/components/skillDetailUtils.test.ts
+++ b/src/components/skillDetailUtils.test.ts
@@ -59,8 +59,11 @@ describe("skill detail install helpers", () => {
     expect(prompt).toContain("WEATHER_API_KEY");
     expect(prompt).toContain("curl");
     expect(prompt).toContain("~/.weatherrc");
-    expect(prompt).toContain("Before install, inspect the ClawHub skill metadata");
+    expect(prompt.startsWith("Before installing anything")).toBe(true);
     expect(prompt).toContain("verify its source, maintainer, and package contents");
+    expect(prompt).toContain(
+      'Install the skill "Weather" (steipete/weather) from ClawHub only after those checks pass.',
+    );
     expect(prompt).toContain("After install, help me finish setup from verified skill metadata.");
     expect(prompt).not.toContain("unknown");
   });
@@ -76,7 +79,11 @@ describe("skill detail install helpers", () => {
       ownerId: null,
     });
 
-    expect(prompt).toContain('Install the skill "Weather" (weather) from ClawHub.');
+    expect(prompt.startsWith("Before installing anything")).toBe(true);
+    expect(prompt).toContain(
+      'Install the skill "Weather" (weather) from ClawHub only after those checks pass.',
+    );
+    expect(prompt).toContain("verify its source, maintainer, and package contents");
     expect(prompt).not.toContain("Skill page:");
     expect(prompt).not.toContain("unknown");
   });

--- a/src/components/skillDetailUtils.ts
+++ b/src/components/skillDetailUtils.ts
@@ -244,7 +244,11 @@ export function formatOpenClawPrompt({
     return lines.join("\n");
   }
 
-  lines.push("After install, inspect the skill metadata and help me finish setup.");
+  lines.push("Before install, inspect the ClawHub skill metadata and setup requirements.");
+  lines.push(
+    "If the skill asks you to install a third-party package or CLI, verify its source, maintainer, and package contents before running the install command.",
+  );
+  lines.push("After install, help me finish setup from verified skill metadata.");
 
   if (requiredEnvVars.size > 0) {
     lines.push(`Required env vars: ${Array.from(requiredEnvVars).join(", ")}`);

--- a/src/components/skillDetailUtils.ts
+++ b/src/components/skillDetailUtils.ts
@@ -231,7 +231,11 @@ export function formatOpenClawPrompt({
     requiredEnvVars.add(name);
   }
 
-  const lines = [`Install the skill "${displayName}" (${target}) from ClawHub.`];
+  const lines = [
+    "Before installing anything, inspect the ClawHub skill metadata and setup requirements.",
+    "If the skill asks you to install a third-party package or CLI, verify its source, maintainer, and package contents before running the install command.",
+    `Install the skill "${displayName}" (${target}) from ClawHub only after those checks pass.`,
+  ];
 
   if (pageUrl) {
     lines.push(`Skill page: ${pageUrl}`);
@@ -244,10 +248,6 @@ export function formatOpenClawPrompt({
     return lines.join("\n");
   }
 
-  lines.push("Before install, inspect the ClawHub skill metadata and setup requirements.");
-  lines.push(
-    "If the skill asks you to install a third-party package or CLI, verify its source, maintainer, and package contents before running the install command.",
-  );
   lines.push("After install, help me finish setup from verified skill metadata.");
 
   if (requiredEnvVars.size > 0) {


### PR DESCRIPTION
## Summary
- update generated OpenClaw install/setup prompts to inspect ClawHub metadata before install
- require source, maintainer, and package-content verification before running third-party package or CLI installers
- update prompt surface tests for the safer ordering

## Why
Issue #2014 describes agents treating install as setup and deferring package verification until later. npm installs can execute third-party code during install, so the generated prompt should make verification a pre-install step.

Fixes #2014

## Tests
- bun run test -- src/components/skillDetailUtils.test.ts src/components/SkillInstallSurface.test.tsx
- bunx tsc -p packages/clawhub/tsconfig.json --noEmit
