### PR TITLE
fix: add full-text skill digest search

### DIFF
--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -230,6 +230,28 @@ describe("search helpers", () => {
     expect(result.map((entry) => entry.skill.slug)).toEqual(["baidu-yijian-vision"]);
   });
 
+  it("does not return soft-deleted skills via full-text search", async () => {
+    const active = makeSkillDoc({
+      id: "skills:active",
+      slug: "baidu-yijian-vision",
+      displayName: "Baidu Yijian Vision",
+    });
+    const softDeleted = makeSkillDoc({
+      id: "skills:deleted",
+      slug: "deleted-yijian-tool",
+      displayName: "Deleted Yijian Tool",
+      softDeletedAt: 123,
+    });
+    const ctx = makeDirectPrefixCtx([active, softDeleted]);
+
+    const result = await directPrefixSkillMatchesHandler(ctx, {
+      query: "yijian",
+      limit: 10,
+    });
+
+    expect(result.map((entry) => entry.skill.slug)).toEqual(["baidu-yijian-vision"]);
+  });
+
   it("dedupes skills matched by both legacy prefix indexes and the new full-text index", async () => {
     // First-token queries hit *all six* recall paths (4 prefix + 2 full-text).
     // The skillId-based filter inside `directPrefixSkillMatches` must prevent

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -63,6 +63,7 @@ const MIN_FALLBACK_SCAN_LIMIT = 100;
 const FALLBACK_RECALL_MULTIPLIER = 2;
 const MIN_STABLE_SEARCH_RECALL_LIMIT = 100;
 const MAX_DIRECT_SKILL_SEARCH_CANDIDATES = 100;
+const MAX_DIRECT_SKILL_FULL_TEXT_CANDIDATES = 40;
 const MIN_VECTOR_SEARCH_CANDIDATES = 50;
 const MAX_VECTOR_SEARCH_CANDIDATES = 128;
 const SKILL_CAPABILITY_TAG_SET = new Set<string>(SKILL_CAPABILITY_TAGS);
@@ -450,13 +451,13 @@ export const directPrefixSkillMatches = internalQuery({
                 .eq("softDeletedAt", undefined)
                 .eq("isSuspicious", false),
             )
-            .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
+            .take(MAX_DIRECT_SKILL_FULL_TEXT_CANDIDATES)
         : ctx.db
             .query("skillSearchDigest")
             .withSearchIndex("search_by_display_name", (q) =>
               q.search("displayName", args.query).eq("softDeletedAt", undefined),
             )
-            .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES),
+            .take(MAX_DIRECT_SKILL_FULL_TEXT_CANDIDATES),
       // Full-text search on slug — same rationale, covers slug middle/tail tokens
       // (e.g. "yijian" or "vision" inside "baidu-yijian-vision").
       args.nonSuspiciousOnly
@@ -465,13 +466,13 @@ export const directPrefixSkillMatches = internalQuery({
             .withSearchIndex("search_by_slug", (q) =>
               q.search("slug", args.query).eq("softDeletedAt", undefined).eq("isSuspicious", false),
             )
-            .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES)
+            .take(MAX_DIRECT_SKILL_FULL_TEXT_CANDIDATES)
         : ctx.db
             .query("skillSearchDigest")
             .withSearchIndex("search_by_slug", (q) =>
               q.search("slug", args.query).eq("softDeletedAt", undefined),
             )
-            .take(MAX_DIRECT_SKILL_SEARCH_CANDIDATES),
+            .take(MAX_DIRECT_SKILL_FULL_TEXT_CANDIDATES),
     ]);
     // Mirrors the `matchesExactTokens` filter the vector path applies on
     // hydrated results, so every recall path shares one literal-match


### PR DESCRIPTION
## Summary
- add full-text search indexes to `skillSearchDigest` for slug and display name
- merge full-text digest results into direct skill search alongside existing prefix queries
- cover non-first-token recall and suspicious-result filtering in search tests

## Why
Skill keyword search only matched slug/name prefixes and first tokens, so queries like `yijian` missed `baidu-yijian-vision` unless vector search or recency fallback happened to catch it. Full-text digest search gives stable token recall without depending on update recency.

Fixes #2137

## Tests
- bun run test -- convex/search.test.ts
- bun run format:check -- convex/search.ts convex/search.test.ts convex/schema.ts
- bunx tsc -p convex/tsconfig.json --noEmit
- bunx tsc -p packages/schema/tsconfig.json --noEmit
- bunx tsc -p packages/clawhub/tsconfig.json --noEmit
