### PR TITLE
feat: support local dev auth impersonation

### DIFF
--- a/convex/lib/access.test.ts
+++ b/convex/lib/access.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@convex-dev/auth/server", () => ({
   getAuthUserId: vi.fn(),
@@ -6,7 +6,7 @@ vi.mock("@convex-dev/auth/server", () => ({
 }));
 
 const { getAuthUserId } = await import("@convex-dev/auth/server");
-const { assertAdmin, assertModerator, assertRole, requireUser, requireUserFromAction } =
+const { assertAdmin, assertModerator, assertRole, requireUser, requireUserFromAction, isDevImpersonationAllowed } =
   await import("./access");
 
 describe("access.requireUser", () => {
@@ -127,5 +127,63 @@ describe("access role assertions", () => {
     expect(() => assertModerator({ role: "admin" } as never)).not.toThrow();
     expect(() => assertModerator({ role: "moderator" } as never)).not.toThrow();
     expect(() => assertModerator({ role: "user" } as never)).toThrow("Forbidden");
+  });
+});
+
+describe("access.isDevImpersonationAllowed", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.CLAW_HUB_DEV_IMPERSONATE_USER_HANDLE;
+    delete process.env.CONVEX_DEPLOYMENT;
+    delete process.env.CLAW_HUB_ENABLE_DEV_IMPERSONATION;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns false when CLAW_HUB_DEV_IMPERSONATE_USER_HANDLE is not 'local'", () => {
+    process.env.CLAW_HUB_DEV_IMPERSONATE_USER_HANDLE = "other";
+    process.env.CONVEX_DEPLOYMENT = "dev:my-deployment";
+    expect(isDevImpersonationAllowed()).toBe(false);
+  });
+
+  it("blocks deployments starting with prod:", () => {
+    process.env.CLAW_HUB_DEV_IMPERSONATE_USER_HANDLE = "local";
+    process.env.CONVEX_DEPLOYMENT = "prod:my-project";
+    expect(isDevImpersonationAllowed()).toBe(false);
+  });
+
+  it("blocks deployments containing production", () => {
+    process.env.CLAW_HUB_DEV_IMPERSONATE_USER_HANDLE = "local";
+    process.env.CONVEX_DEPLOYMENT = "my-production-env";
+    expect(isDevImpersonationAllowed()).toBe(false);
+  });
+
+  it("allows anonymous: deployments", () => {
+    process.env.CLAW_HUB_DEV_IMPERSONATE_USER_HANDLE = "local";
+    process.env.CONVEX_DEPLOYMENT = "anonymous:local-123";
+    expect(isDevImpersonationAllowed()).toBe(true);
+  });
+
+  it("allows dev: deployments", () => {
+    process.env.CLAW_HUB_DEV_IMPERSONATE_USER_HANDLE = "local";
+    process.env.CONVEX_DEPLOYMENT = "dev:my-project";
+    expect(isDevImpersonationAllowed()).toBe(true);
+  });
+
+  it("allows local: deployments", () => {
+    process.env.CLAW_HUB_DEV_IMPERSONATE_USER_HANDLE = "local";
+    process.env.CONVEX_DEPLOYMENT = "local:my-project";
+    expect(isDevImpersonationAllowed()).toBe(true);
+  });
+
+  it("allows non-standard deployments when CLAW_HUB_ENABLE_DEV_IMPERSONATION=1", () => {
+    process.env.CLAW_HUB_DEV_IMPERSONATE_USER_HANDLE = "local";
+    process.env.CONVEX_DEPLOYMENT = "custom-deployment";
+    process.env.CLAW_HUB_ENABLE_DEV_IMPERSONATION = "1";
+    expect(isDevImpersonationAllowed()).toBe(true);
   });
 });

--- a/convex/lib/access.ts
+++ b/convex/lib/access.ts
@@ -12,7 +12,7 @@ function readEnv(name: string) {
   return value ? value : undefined;
 }
 
-function isDevImpersonationAllowed() {
+export function isDevImpersonationAllowed() {
   const requestedHandle = readEnv("CLAW_HUB_DEV_IMPERSONATE_USER_HANDLE");
   if (requestedHandle !== DEV_IMPERSONATE_LOCAL_HANDLE) return false;
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -80,3 +80,39 @@ Revoked, invalid, or missing tokens return `401 Unauthorized`. Sign in again
 with `clawhub login` or provide a fresh token with `clawhub login --token`.
 
 Deleted, banned, or disabled accounts cannot continue using existing API tokens.
+
+## Local development impersonation
+
+For local development, you can browse authenticated pages without a real GitHub
+OAuth flow or production tokens.
+
+Requirements:
+
+1. Run the dev seed so the `local` user exists:
+   ```bash
+   bunx convex dev --once
+   bunx convex run devSeed:seedNixSkills
+   ```
+2. Set the impersonation env var on your Convex deployment:
+   ```bash
+   bunx convex env set CLAW_HUB_DEV_IMPERSONATE_USER_HANDLE local
+   ```
+3. Start the app normally:
+   ```bash
+   bun run dev
+   ```
+
+What happens:
+
+- The backend resolves `api.users.me` to the seeded `local` admin user.
+- The frontend treats this as an authenticated session for navigation and UI.
+- A small **dev** badge appears in the header so you know it is not real GitHub auth.
+- Sign-out is hidden because there is no real session to end.
+
+Guardrails:
+
+- This only works on dev/local Convex deployments (`anonymous:`, `dev:`, `local:`)
+  or when `CLAW_HUB_ENABLE_DEV_IMPERSONATION=1` is explicitly set.
+- It is blocked on any deployment name containing `prod` or `production`.
+- No JWT is minted, no production token is copied, and the real OAuth flow is
+  untouched.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -113,6 +113,6 @@ Guardrails:
 
 - This only works on dev/local Convex deployments (`anonymous:`, `dev:`, `local:`)
   or when `CLAW_HUB_ENABLE_DEV_IMPERSONATION=1` is explicitly set.
-- It is blocked on any deployment name containing `prod` or `production`.
+- It is blocked on deployment names starting with `prod:` or containing `production`.
 - No JWT is minted, no production token is copied, and the real OAuth flow is
   untouched.

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -87,7 +87,7 @@ type TypeaheadItem =
     };
 
 export default function Header() {
-  const { isAuthenticated, isLoading, me } = useAuthStatus();
+  const { isAuthenticated, isLoading, me, isDevImpersonated } = useAuthStatus();
   const { signIn, signOut } = useAuthActions();
   const { theme, mode, setMode } = useThemeMode();
   const siteMode = getSiteMode();
@@ -464,7 +464,13 @@ export default function Header() {
                       <span className="user-menu-fallback">{initial}</span>
                     )}
                     <span className="mono truncate">@{handle}</span>
-                    <ChevronDown className="user-menu-chevron" size={16} />
+                    {isDevImpersonated ? (
+                      <span className="ml-1 rounded bg-amber-100 px-1 text-[0.65rem] font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+                        dev
+                      </span>
+                    ) : (
+                      <ChevronDown className="user-menu-chevron" size={16} />
+                    )}
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="user-dropdown-content">
@@ -486,8 +492,18 @@ export default function Header() {
                       Settings
                     </Link>
                   </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem onClick={() => void signOut()}>Sign out</DropdownMenuItem>
+                  {isDevImpersonated ? (
+                    <DropdownMenuItem disabled>
+                      <span className="text-xs text-[color:var(--ink-soft)]">
+                        Local dev impersonation
+                      </span>
+                    </DropdownMenuItem>
+                  ) : (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem onClick={() => void signOut()}>Sign out</DropdownMenuItem>
+                    </>
+                  )}
                 </DropdownMenuContent>
               </DropdownMenu>
             ) : (

--- a/src/components/UserBootstrap.tsx
+++ b/src/components/UserBootstrap.tsx
@@ -4,17 +4,17 @@ import { api } from "../../convex/_generated/api";
 import { useAuthStatus } from "../lib/useAuthStatus";
 
 export function UserBootstrap() {
-  const { isAuthenticated, isLoading } = useAuthStatus();
+  const { isAuthenticated, isLoading, isDevImpersonated } = useAuthStatus();
   const ensureUser = useMutation(api.users.ensure);
   const didRun = useRef(false);
 
   useEffect(() => {
-    if (isLoading || !isAuthenticated || didRun.current) return;
+    if (isLoading || !isAuthenticated || didRun.current || isDevImpersonated) return;
     didRun.current = true;
     void ensureUser().catch(() => {
       // Best-effort normalization. Broken auth state should not crash the UI.
     });
-  }, [isAuthenticated, isLoading, ensureUser]);
+  }, [isAuthenticated, isLoading, ensureUser, isDevImpersonated]);
 
   return null;
 }

--- a/src/lib/useAuthStatus.test.tsx
+++ b/src/lib/useAuthStatus.test.tsx
@@ -13,13 +13,14 @@ vi.mock("convex/react", () => ({
 }));
 
 function Probe() {
-  const { isAuthenticated, isLoading, me } = useAuthStatus();
+  const { isAuthenticated, isLoading, me, isDevImpersonated } = useAuthStatus();
   return (
     <output>
       {JSON.stringify({
         isAuthenticated,
         isLoading,
         me,
+        isDevImpersonated,
       })}
     </output>
   );
@@ -35,7 +36,9 @@ describe("useAuthStatus", () => {
 
     render(<Probe />);
 
-    expect(screen.getByText('{"isAuthenticated":false,"isLoading":false}')).toBeTruthy();
+    expect(
+      screen.getByText('{"isAuthenticated":false,"isLoading":false,"isDevImpersonated":false}'),
+    ).toBeTruthy();
   });
 
   it("preserves authenticated session state before the profile query resolves", () => {
@@ -47,6 +50,40 @@ describe("useAuthStatus", () => {
 
     render(<Probe />);
 
-    expect(screen.getByText('{"isAuthenticated":true,"isLoading":false}')).toBeTruthy();
+    expect(
+      screen.getByText('{"isAuthenticated":true,"isLoading":false,"isDevImpersonated":false}'),
+    ).toBeTruthy();
+  });
+
+  it("treats a resolved local user without convex auth as dev-impersonated authenticated", () => {
+    useConvexAuthMock.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+    });
+    useQueryMock.mockReturnValue({ _id: "user-local", handle: "local" });
+
+    render(<Probe />);
+
+    expect(
+      screen.getByText(
+        '{"isAuthenticated":true,"isLoading":false,"me":{"_id":"user-local","handle":"local"},"isDevImpersonated":true}',
+      ),
+    ).toBeTruthy();
+  });
+
+  it("does not mark dev-impersonated when convex auth is already present", () => {
+    useConvexAuthMock.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+    });
+    useQueryMock.mockReturnValue({ _id: "user-real", handle: "real" });
+
+    render(<Probe />);
+
+    expect(
+      screen.getByText(
+        '{"isAuthenticated":true,"isLoading":false,"me":{"_id":"user-real","handle":"real"},"isDevImpersonated":false}',
+      ),
+    ).toBeTruthy();
   });
 });

--- a/src/lib/useAuthStatus.ts
+++ b/src/lib/useAuthStatus.ts
@@ -5,9 +5,14 @@ import type { Doc } from "../../convex/_generated/dataModel";
 export function useAuthStatus() {
   const auth = useConvexAuth();
   const me = useQuery(api.users.me) as Doc<"users"> | null | undefined;
+
+  const isDevImpersonated = !auth.isAuthenticated && !!me;
+  const isAuthenticated = auth.isAuthenticated || isDevImpersonated;
+
   return {
     me,
     isLoading: auth.isLoading,
-    isAuthenticated: auth.isAuthenticated,
+    isAuthenticated,
+    isDevImpersonated,
   };
 }

--- a/src/routes/cli/-device.test.tsx
+++ b/src/routes/cli/-device.test.tsx
@@ -1,0 +1,118 @@
+/* @vitest-environment jsdom */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const approveMock = vi.fn();
+const denyMock = vi.fn();
+let mockSearch: { code?: string } = {};
+let mockAuthStatus = {
+  isAuthenticated: true,
+  isLoading: false,
+  isDevImpersonated: false,
+  me: { _id: "user_123" } as { _id: string } | null,
+};
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (config: { component: unknown }) => ({
+    ...config,
+    useSearch: () => mockSearch,
+  }),
+}));
+
+vi.mock("convex/react", () => ({
+  useMutation: (mutation: string) => {
+    if (mutation === "cliDeviceAuth.approve") return approveMock;
+    if (mutation === "cliDeviceAuth.deny") return denyMock;
+    throw new Error(`Unexpected mutation: ${mutation}`);
+  },
+}));
+
+vi.mock("../../../convex/_generated/api", () => ({
+  api: {
+    cliDeviceAuth: {
+      approve: "cliDeviceAuth.approve",
+      deny: "cliDeviceAuth.deny",
+    },
+  },
+}));
+
+vi.mock("../../lib/useAuthStatus", () => ({
+  useAuthStatus: () => mockAuthStatus,
+}));
+
+vi.mock("../../components/layout/Container", () => ({
+  Container: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("../../components/SignInButton", () => ({
+  SignInButton: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("../../components/ui/button", () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("../../components/ui/card", () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardTitle: ({ children }: { children: React.ReactNode }) => <h1>{children}</h1>,
+}));
+
+vi.mock("../../components/ui/input", () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}));
+
+vi.mock("../../components/ui/label", () => ({
+  Label: ({ children, ...props }: React.LabelHTMLAttributes<HTMLLabelElement>) => (
+    <label {...props}>{children}</label>
+  ),
+}));
+
+const { CliDeviceAuth } = await import("./device");
+
+describe("CliDeviceAuth", () => {
+  beforeEach(() => {
+    approveMock.mockReset();
+    denyMock.mockReset();
+    mockSearch = { code: "ABCD-2345" };
+    mockAuthStatus = {
+      isAuthenticated: true,
+      isLoading: false,
+      isDevImpersonated: false,
+      me: { _id: "user_123" },
+    };
+  });
+
+  it("approves a device code for a real authenticated session", async () => {
+    approveMock.mockResolvedValue({ ok: true });
+
+    render(<CliDeviceAuth />);
+
+    fireEvent.click(screen.getByRole("button", { name: /authorize/i }));
+
+    await waitFor(() => {
+      expect(approveMock).toHaveBeenCalledWith({ userCode: "ABCD-2345" });
+    });
+    expect(screen.getByText(/authorized/i)).toBeTruthy();
+  });
+
+  it("requires real GitHub auth before approving a device code", () => {
+    mockAuthStatus = {
+      isAuthenticated: true,
+      isLoading: false,
+      isDevImpersonated: true,
+      me: { _id: "user_local" },
+    };
+
+    render(<CliDeviceAuth />);
+
+    expect(screen.getByText(/sign in to authorize the cli/i)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /authorize/i })).toBeNull();
+    expect(approveMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/routes/cli/auth.tsx
+++ b/src/routes/cli/auth.tsx
@@ -21,7 +21,7 @@ type CliAuthProps = {
 export function CliAuth({
   navigate = (url: string) => window.location.assign(url),
 }: CliAuthProps = {}) {
-  const { isAuthenticated, isLoading, me } = useAuthStatus();
+  const { isAuthenticated, isLoading, me, isDevImpersonated } = useAuthStatus();
   const { error: authError, clear: clearAuthError } = useAuthError();
   const createToken = useMutation(api.tokens.create);
 
@@ -49,11 +49,13 @@ export function CliAuth({
     return getClawHubSiteUrl();
   }, []);
 
+  const isRealAuth = isAuthenticated && !isDevImpersonated;
+
   useEffect(() => {
     if (hasRun.current) return;
     if (!safeRedirect) return;
     if (!state) return;
-    if (!isAuthenticated || !me) return;
+    if (!isRealAuth || !me) return;
     hasRun.current = true;
 
     const run = async () => {
@@ -81,17 +83,7 @@ export function CliAuth({
       setStatus(message);
       setToken(null);
     });
-  }, [
-    createToken,
-    isAuthenticated,
-    label,
-    me,
-    navigate,
-    redirectUri,
-    registry,
-    safeRedirect,
-    state,
-  ]);
+  }, [createToken, isRealAuth, label, me, navigate, redirectUri, registry, safeRedirect, state]);
 
   if (!safeRedirect) {
     return (
@@ -133,7 +125,7 @@ export function CliAuth({
     );
   }
 
-  if (!isAuthenticated || !me) {
+  if (!isRealAuth || !me) {
     return (
       <main className="py-10">
         <Container size="narrow">

--- a/src/routes/cli/device.tsx
+++ b/src/routes/cli/device.tsx
@@ -18,9 +18,10 @@ export function CliDeviceAuth() {
   const search = Route.useSearch() as { code?: string };
   const [code, setCode] = useState(search.code ?? "");
   const [status, setStatus] = useState<string | null>(null);
-  const { isAuthenticated, isLoading, me } = useAuthStatus();
+  const { isAuthenticated, isLoading, me, isDevImpersonated } = useAuthStatus();
   const approve = useMutation(api.cliDeviceAuth.approve);
   const deny = useMutation(api.cliDeviceAuth.deny);
+  const isRealAuth = isAuthenticated && !isDevImpersonated;
 
   const submit = async () => {
     const trimmed = code.trim();
@@ -57,7 +58,7 @@ export function CliDeviceAuth() {
             <CardTitle className="text-2xl">CLI device login</CardTitle>
           </CardHeader>
           <CardContent className="space-y-4">
-            {!isAuthenticated || !me ? (
+            {!isRealAuth || !me ? (
               <>
                 <p className="text-sm text-[color:var(--ink-soft)]">
                   Sign in to authorize the CLI.

--- a/src/routes/docs/auth.tsx
+++ b/src/routes/docs/auth.tsx
@@ -19,7 +19,7 @@ type DocsAuthProps = {
 };
 
 export function DocsAuth({ autoSubmit = true }: DocsAuthProps = {}) {
-  const { isAuthenticated, isLoading, me } = useAuthStatus();
+  const { isAuthenticated, isLoading, me, isDevImpersonated } = useAuthStatus();
   const authToken = useAuthToken();
   const { error: authError, clear: clearAuthError } = useAuthError();
   const formRef = useRef<HTMLFormElement>(null);
@@ -38,7 +38,8 @@ export function DocsAuth({ autoSubmit = true }: DocsAuthProps = {}) {
   }, []);
 
   const canReturn = Boolean(returnTo && callbackUrl);
-  const ready = canReturn && isAuthenticated && me && authToken;
+  const isRealAuth = isAuthenticated && !isDevImpersonated;
+  const ready = canReturn && isRealAuth && me && authToken;
 
   useEffect(() => {
     if (!autoSubmit || !ready || submittedRef.current) return;
@@ -57,7 +58,7 @@ export function DocsAuth({ autoSubmit = true }: DocsAuthProps = {}) {
     );
   }
 
-  if (!isAuthenticated || !me) {
+  if (!isRealAuth || !me) {
     return (
       <AuthFrame title="Verify with GitHub">
         <p className="text-sm text-[color:var(--ink-soft)]">


### PR DESCRIPTION
## Problem
Testing authenticated pages locally today requires a real GitHub OAuth flow or copying production tokens. This slows down local development and creates friction when iterating on UI that depends on being signed in.

## Solution
Officializes the existing backend impersonation support and makes the frontend recognize that state as authenticated for navigation and UI purposes.

- `useAuthStatus` now derives `isDevImpersonated` when `api.users.me` resolves a user without real Convex Auth.
- General navigation and UI treat dev impersonation as authenticated so dashboards, settings, stars, etc. render correctly.
- Token-dependent flows (`/docs/auth`, `/cli/auth`, `/cli/device`) still require real Convex Auth + token and are not fooled by dev impersonation.
- `UserBootstrap` skips `ensureUser` when dev impersonated to avoid unnecessary mutation calls.
- Header shows a small **dev** badge on the user trigger and hides \"Sign out\" since there is no real session to end.
- Documented the local setup in `docs/auth.md`.

## Guardrails
- Dev / local Convex deployments only. The backend guard in `convex/lib/access.ts` blocks impersonation on deployment names starting with `prod:` or containing `production`.
- No fake JWT minted.
- No production token copied.
- No changes to real GitHub OAuth flow or production auth behavior.
- No changes to upload, package install, scanner, moderation, billing, CI, or deploy paths.

## Real behavior proof
Added unit tests for `isDevImpersonationAllowed` in `convex/lib/access.test.ts` that prove the production guardrail behavior:

```
$ bun run test convex/lib/access.test.ts
 ✓ convex/lib/access.test.ts (10 tests) 9ms

 Test Files  1 passed (1)
      Tests  10 passed (10)
```

Covered cases:
- `prod:` prefix is blocked
- `production` substring is blocked
- `anonymous:`, `dev:`, `local:` deployments are allowed
- Non-standard deployments are allowed only when `CLAW_HUB_ENABLE_DEV_IMPERSONATION=1`
- Wrong handle (`!== "local"`) is rejected

## Tests / Checks
- `bun run format:check` — passed
- `bun run lint` — 0 warnings, 0 errors
- `bun run test convex/lib/access.test.ts src/routes/cli/-device.test.tsx src/routes/cli/-auth.test.tsx src/routes/docs/-auth.test.tsx src/lib/useAuthStatus.test.tsx` — 20 passed
- `bunx tsc --noEmit` — passed
- `bunx tsc -p packages/schema/tsconfig.json --noEmit` — passed
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit` — passed