### PR TITLE
chore: prepare clawhub cli 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 ### Fixes
 
+## 0.14.0 - 2026-05-11
+
+### Changes
+
+- Web: add publisher notes and unify ClawScan review pages (#2111).
+- Dev: auto-start services for Codex worktrees and add a local dev persona FAB (#2146, #2147).
+- Dev: add a local ClawScan dry-run helper script (#2143).
+
+### Fixes
+
 - API: return deterministic 403 responses for skill/package rescan and package transfer permission denials, with CI e2e coverage for protected write endpoints.
 
 ## 0.13.0 - 2026-05-11

--- a/bun.lock
+++ b/bun.lock
@@ -79,7 +79,7 @@
     },
     "packages/clawhub": {
       "name": "clawhub",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "bin": {
         "clawdhub": "bin/clawdhub.js",
         "clawhub": "bin/clawdhub.js",

--- a/packages/clawhub/package.json
+++ b/packages/clawhub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawhub",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "ClawHub CLI \\u2014 install, update, search, and publish skills plus OpenClaw packages.",
   "homepage": "https://clawhub.ai",
   "bugs": {


### PR DESCRIPTION
## Summary
- bump the public `clawhub` CLI package version to `0.14.0`
- add a `0.14.0 - 2026-05-11` changelog section for the post-0.13.0 main changes
- update `bun.lock` to match the package version

## Validation
- `npm view clawhub@0.14.0 version --prefer-online` returned 404, confirming the version is not published yet
- `node scripts/clawhub-cli-npm-release-check.mjs --tag v0.14.0`
- `bun install --frozen-lockfile`
- `bun run --cwd packages/clawhub verify`
