### PR TITLE
fix: refresh detail page loading skeletons

### DIFF
--- a/src/components/skeletons/SkillDetailSkeleton.tsx
+++ b/src/components/skeletons/SkillDetailSkeleton.tsx
@@ -1,62 +1,138 @@
 import { Skeleton } from "../ui/skeleton";
 
-export function SkillDetailSkeleton() {
+type SkillDetailSkeletonProps = {
+  kind?: "skill" | "plugin";
+};
+
+export function SkillDetailSkeleton({ kind = "skill" }: SkillDetailSkeletonProps) {
+  const tabCount = kind === "plugin" ? 4 : 6;
+
   return (
     <div className="skill-detail-stack">
-      <div className="rounded-[var(--r-md)] border border-[color:var(--line)] bg-[color:var(--surface)] p-5">
-        <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
-          <div className="min-w-0 flex-1 space-y-4">
-            <Skeleton className="h-4 w-48" />
-            <div className="space-y-3">
-              <div className="flex flex-wrap items-center gap-3">
-                <Skeleton className="h-9 w-full max-w-[360px]" />
-                <Skeleton className="h-6 w-20 rounded-[var(--r-pill)]" />
+      <div className="skill-hero">
+        <div className="skill-hero-top">
+          <div className="skill-hero-layout has-sidebar">
+            <div className="skill-hero-main">
+              <div className="skill-hero-title">
+                <div className="skill-hero-breadcrumbs">
+                  <Skeleton className="h-4 w-14" />
+                  <Skeleton className="h-4 w-3" />
+                  <Skeleton className="h-4 w-24" />
+                  <Skeleton className="h-4 w-3" />
+                  {kind === "plugin" ? (
+                    <>
+                      <Skeleton className="h-4 w-14" />
+                      <Skeleton className="h-4 w-3" />
+                    </>
+                  ) : null}
+                  <Skeleton className="h-4 w-36 max-w-[45vw]" />
+                </div>
+
+                <div className="skill-hero-title-row">
+                  <Skeleton className="h-12 w-full max-w-[430px]" />
+                  <Skeleton className="h-7 w-24 rounded-[var(--r-pill)]" />
+                </div>
+
+                <div className="space-y-3">
+                  <Skeleton className="h-5 w-full max-w-[720px]" />
+                  <Skeleton className="h-5 w-3/4 max-w-[560px]" />
+                </div>
+
+                {kind === "plugin" ? (
+                  <div className="skill-hero-badges">
+                    <Skeleton className="h-6 w-56 rounded-[var(--r-pill)]" />
+                  </div>
+                ) : null}
               </div>
-              <Skeleton className="h-5 w-full max-w-[680px]" />
-              <Skeleton className="h-5 w-3/4 max-w-[520px]" />
-            </div>
-            <div className="flex flex-wrap items-center gap-4">
-              <Skeleton className="h-8 w-8 rounded-full" />
-              <Skeleton className="h-4 w-24" />
-              <Skeleton className="h-4 w-28" />
-              <Skeleton className="h-4 w-20" />
-            </div>
-          </div>
-          <div className="w-full space-y-3 lg:max-w-[360px]">
-            <Skeleton className="h-12 w-full rounded-[var(--r-sm)]" />
-            <Skeleton className="h-12 w-full rounded-[var(--r-pill)]" />
-            <div className="grid grid-cols-3 gap-3">
-              <Skeleton className="h-14" />
-              <Skeleton className="h-14" />
-              <Skeleton className="h-14" />
-            </div>
-          </div>
-        </div>
-      </div>
 
-      <div className="detail-layout">
-        <div className="detail-main">
-          <div className="rounded-[var(--r-md)] border border-[color:var(--line)] bg-[color:var(--surface)] p-5">
-            <div className="mb-4 flex flex-wrap gap-2">
-              <Skeleton className="h-10 w-24 rounded-[var(--r-pill)]" />
-              <Skeleton className="h-10 w-20 rounded-[var(--r-pill)]" />
-              <Skeleton className="h-10 w-24 rounded-[var(--r-pill)]" />
-            </div>
-            <div className="space-y-3">
-              <Skeleton className="h-6 w-40" />
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-11/12" />
-              <Skeleton className="h-4 w-5/6" />
-              <Skeleton className="mt-5 h-5 w-52" />
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-3/4" />
-            </div>
-          </div>
+              <div className="skill-hero-lower has-sidebar">
+                <div className="skill-hero-main-extra">
+                  <Skeleton className="h-12 w-full rounded-[var(--r-sm)]" />
 
-          <div className="rounded-[var(--r-md)] border border-[color:var(--line)] bg-[color:var(--surface)] p-5">
-            <Skeleton className="mb-3 h-6 w-28" />
-            <Skeleton className="h-4 w-2/3" />
+                  <article className="skill-install-command-card">
+                    <div className="skill-install-command-header">
+                      <Skeleton className="h-7 w-20" />
+                      {kind === "skill" ? (
+                        <div className="flex gap-2">
+                          <Skeleton className="h-8 w-14 rounded-[var(--r-pill)]" />
+                          <Skeleton className="h-8 w-20 rounded-[var(--r-pill)]" />
+                        </div>
+                      ) : null}
+                    </div>
+                    <div className="skill-install-command-wrap">
+                      <div className="skill-install-command-shell">
+                        <Skeleton className="h-5 w-full max-w-[520px]" />
+                        <Skeleton className="skill-install-command-inline-button h-[34px] rounded-[var(--r-btn)]" />
+                      </div>
+                    </div>
+                  </article>
+
+                  <div className="tab-card">
+                    <div className="tab-header">
+                      {Array.from({ length: tabCount }).map((_, i) => (
+                        <Skeleton
+                          // biome-ignore lint/suspicious/noArrayIndexKey: static placeholder count
+                          key={i}
+                          className="h-9 w-24 shrink-0 rounded-none"
+                        />
+                      ))}
+                    </div>
+                    <div className="tab-body">
+                      <div className="space-y-3">
+                        <Skeleton className="h-6 w-40" />
+                        <Skeleton className="h-4 w-full" />
+                        <Skeleton className="h-4 w-full" />
+                        <Skeleton className="h-4 w-11/12" />
+                        <Skeleton className="h-4 w-5/6" />
+                        <Skeleton className="mt-5 h-5 w-52" />
+                        <Skeleton className="h-4 w-full" />
+                        <Skeleton className="h-4 w-3/4" />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <aside className="skill-hero-sidebar">
+                  <div className="skill-hero-sidebar-stack">
+                    <div className="sidebar-metadata sidebar-metadata-compact">
+                      <div className="sidebar-metadata-row sidebar-metadata-row-large">
+                        <Skeleton className="h-3 w-16" />
+                        <Skeleton className="h-8 w-24" />
+                      </div>
+                      <div className="sidebar-metadata-row">
+                        <Skeleton className="h-3 w-14" />
+                        <div className="flex items-center gap-2">
+                          <Skeleton className="h-7 w-7 rounded-full" />
+                          <Skeleton className="h-5 w-32" />
+                        </div>
+                      </div>
+                      <div className="sidebar-metadata-grid">
+                        <div className="sidebar-metadata-row">
+                          <Skeleton className="h-3 w-24" />
+                          <Skeleton className="h-5 w-16" />
+                        </div>
+                        <div className="sidebar-metadata-row">
+                          <Skeleton className="h-3 w-12" />
+                          <Skeleton className="h-5 w-20" />
+                        </div>
+                      </div>
+                      <div className="sidebar-metadata-row">
+                        <Skeleton className="h-3 w-20" />
+                        <Skeleton className="h-5 w-28" />
+                      </div>
+                    </div>
+
+                    <div className="skill-sidebar-actions">
+                      <Skeleton className="h-10 w-full rounded-[var(--r-btn)]" />
+                      <Skeleton className="h-10 w-full rounded-[var(--r-btn)]" />
+                      {kind === "skill" ? (
+                        <Skeleton className="h-10 w-full rounded-[var(--r-btn)]" />
+                      ) : null}
+                    </div>
+                  </div>
+                </aside>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -8,6 +8,7 @@ import { InstallCopyButton } from "../../components/InstallCopyButton";
 import { Container } from "../../components/layout/Container";
 import { MarkdownPreview } from "../../components/MarkdownPreview";
 import { SidebarMetadata } from "../../components/SidebarMetadata";
+import { SkillDetailSkeleton } from "../../components/skeletons/SkillDetailSkeleton";
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
@@ -142,6 +143,7 @@ export const Route = createFileRoute("/plugins/$name")({
   },
   loader: async ({ params }) => loadPluginDetail(params.name),
   head: ({ params, loaderData }) => pluginDetailHead(params.name, loaderData),
+  pendingComponent: PluginDetailPending,
   component: PluginDetailRoute,
 });
 
@@ -297,6 +299,16 @@ function PluginDetailRoute() {
       name={Route.useParams().name}
       loaderData={Route.useLoaderData() as PluginDetailLoaderData}
     />
+  );
+}
+
+export function PluginDetailPending() {
+  return (
+    <main className="section detail-page-section" aria-busy="true">
+      <div role="status" aria-label="Loading plugin details">
+        <SkillDetailSkeleton kind="plugin" />
+      </div>
+    </main>
   );
 }
 

--- a/src/routes/plugins/$scope/$name.tsx
+++ b/src/routes/plugins/$scope/$name.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import {
   loadPluginDetail,
   PluginDetailPage,
+  PluginDetailPending,
   pluginDetailHead,
   type PluginDetailLoaderData,
 } from "../$name";
@@ -19,6 +20,7 @@ export const Route = createFileRoute("/plugins/$scope/$name")({
   },
   loader: async ({ params }) => loadPluginDetail(packageNameFromParams(params)),
   head: ({ params, loaderData }) => pluginDetailHead(packageNameFromParams(params), loaderData),
+  pendingComponent: PluginDetailPending,
   component: ScopedPluginDetailRoute,
 });
 


### PR DESCRIPTION
## Summary
- Refresh the shared skill detail skeleton to match the current detail hero, install card, tab, and sidebar layout
- Add plugin pending skeletons for unscoped and scoped plugin detail routes

## Tests
- bun run format:check
- bun run lint
- bunx tsc --noEmit
- bun run test -- src/__tests__/skill-detail-page.test.tsx src/__tests__/package-detail-route.test.tsx src/__tests__/scoped-plugin-route-redirects.test.ts
