### PR TITLE
fix: show owner names when handles are hidden

### DIFF
--- a/src/components/UserBadge.test.tsx
+++ b/src/components/UserBadge.test.tsx
@@ -52,4 +52,21 @@ describe("UserBadge", () => {
       "/p/openclaw",
     );
   });
+
+  it("shows the display name when handles are hidden", () => {
+    const publisher: PublicPublisher = {
+      ...orgPublisher,
+      _id: "publisher-acme" as Id<"publishers">,
+      handle: "acme",
+      displayName: "Acme",
+    };
+
+    render(
+      <TooltipProvider>
+        <UserBadge user={publisher} prefix="" showName showHandle={false} disableTooltip />
+      </TooltipProvider>,
+    );
+
+    expect(screen.getByText("Acme")).toBeTruthy();
+  });
 });

--- a/src/components/UserBadge.tsx
+++ b/src/components/UserBadge.tsx
@@ -39,8 +39,7 @@ export function UserBadge({
   const hasUsefulName =
     showName &&
     Boolean(displayName) &&
-    Boolean(handle) &&
-    displayName!.toLowerCase() !== handle!.toLowerCase();
+    (!showHandle || !handle || displayName!.toLowerCase() !== handle.toLowerCase());
   const initial = (displayName ?? handle ?? "u").charAt(0).toUpperCase();
 
   // Resolve userId for stats query — PublicUser has _id directly,


### PR DESCRIPTION
## Summary
- Show publisher display names in compact owner badges when handles are intentionally hidden
- Add regression coverage for display names that only differ from handles by casing

## Validation
- `VITE_CONVEX_URL=http://127.0.0.1:3210 bunx vitest run src/components/UserBadge.test.tsx`
- `bun run format:check`
- `bun run lint`

/review confirmed in thread before publish.
