### PR TITLE
test: drop removed rescan e2e probes

### DIFF
--- a/e2e/permissions.e2e.test.ts
+++ b/e2e/permissions.e2e.test.ts
@@ -88,7 +88,6 @@ describe("permission boundary e2e", () => {
         path: `${ApiRoutes.skills}/gifgrep/transfer`,
         body: { toUserHandle: "openclaw" },
       },
-      { method: "POST", path: `${ApiRoutes.skills}/gifgrep/rescan`, body: {} },
       { method: "DELETE", path: `${ApiRoutes.packages}/e2e-nonexistent-permission` },
       { method: "POST", path: `${ApiRoutes.packages}/e2e-nonexistent-permission/undelete` },
       {
@@ -96,7 +95,6 @@ describe("permission boundary e2e", () => {
         path: `${ApiRoutes.packages}/e2e-nonexistent-permission/transfer`,
         body: { toOwner: "openclaw" },
       },
-      { method: "POST", path: `${ApiRoutes.packages}/e2e-nonexistent-permission/rescan` },
       {
         method: "POST",
         path: `${ApiRoutes.packages}/e2e-nonexistent-permission/trusted-publisher`,
@@ -127,7 +125,7 @@ describe("permission boundary e2e", () => {
   });
 
   itIfLiveMutationsAndUserToken(
-    "rejects non-owner skill lifecycle, transfer, and rescan actions",
+    "rejects non-owner skill lifecycle and transfer actions",
     async () => {
       const registry = getRegistry();
       const site = getSite();
@@ -206,14 +204,6 @@ describe("permission boundary e2e", () => {
             },
           ),
         );
-        expectForbiddenCli(
-          spawnSync("bun", ["clawhub", "skill", "rescan", slug, "--yes", ...baseArgs], {
-            cwd: process.cwd(),
-            env: strangerEnv,
-            encoding: "utf8",
-          }),
-        );
-
         const metaAfterDeniedActions = await fetchWithTimeout(metaUrl.toString(), {
           headers: { Accept: "application/json" },
         });
@@ -252,7 +242,7 @@ describe("permission boundary e2e", () => {
   );
 
   itIfLiveMutationsAndUserToken(
-    "rejects non-owner package lifecycle, transfer, and rescan actions",
+    "rejects non-owner package lifecycle and transfer actions",
     async () => {
       const registry = getRegistry();
       const site = getSite();
@@ -327,14 +317,6 @@ describe("permission boundary e2e", () => {
             },
           ),
         );
-        expectForbiddenCli(
-          spawnSync("bun", ["clawhub", "package", "rescan", packageName, "--yes", ...baseArgs], {
-            cwd: process.cwd(),
-            env: strangerEnv,
-            encoding: "utf8",
-          }),
-        );
-
         const ownerInspect = spawnSync(
           "bun",
           ["clawhub", "package", "inspect", packageName, ...baseArgs],


### PR DESCRIPTION
## Summary
- remove stale permission e2e probes for removed skill/package rescan endpoints
- keep the unauthenticated 401 matrix focused on protected write endpoints that still exist
- align skipped live permission checks with the current CLI surface

## Root cause
The owner-requested rescan HTTP routes and CLI commands were removed, and handler unit tests now assert those `/rescan` routes return 404. The `e2e-http` permission test still expected unauthenticated `/rescan` requests to return 401, causing main CI to fail with `POST /api/v1/skills/gifgrep/rescan: expected 404 to be 401`.

## Tests
- `bunx vitest run -c vitest.e2e.config.ts e2e/permissions.e2e.test.ts`
- `bunx vitest run convex/httpApiV1.handlers.test.ts --testNamePattern "removed .* rescan route"`
- `bun run format:check`
- `bun run lint`
