### PR TITLE
fix: show downloads as primary adoption metric

### DIFF
--- a/src/components/SkillHeader.test.tsx
+++ b/src/components/SkillHeader.test.tsx
@@ -101,6 +101,8 @@ describe("SkillHeader", () => {
     expect(onToggleStar).not.toHaveBeenCalled();
     expect(onOpenReport).not.toHaveBeenCalled();
     expect(screen.getByText("Owner")).toBeTruthy();
+    expect(screen.getByText("Downloads")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
     expect(container.querySelector('a[href="/p/local"]')).toBeTruthy();
   });
 });

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -407,7 +407,7 @@ function SkillSidebarStats({
       ariaLabel="Skill metadata"
       density="compact"
       blocks={[
-        { label: "Installs", value: formattedStats.installsAllTime, large: true },
+        { label: "Downloads", value: formattedStats.downloads, large: true },
         {
           label: "Owner",
           value: (

--- a/src/routes/-dashboard.test.tsx
+++ b/src/routes/-dashboard.test.tsx
@@ -243,7 +243,10 @@ describe("Dashboard rows", () => {
   });
 
   it("renders rich artifact cards with status, scan, and inventory context", () => {
-    arrangeDashboard({ skills: [createSkill()], packages: [createPackage()] });
+    arrangeDashboard({
+      skills: [createSkill()],
+      packages: [createPackage({ stats: { downloads: 42, installs: 9, stars: 0, versions: 1 } })],
+    });
 
     renderDashboard();
 
@@ -264,6 +267,7 @@ describe("Dashboard rows", () => {
     expect(screen.queryByText(/rescans/i)).toBeNull();
     expect(screen.queryByText("Limit reached (3/3)")).toBeNull();
     expect(screen.getAllByText("Downloads").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Installs")).toBeNull();
     expect(
       screen.getByRole("button", { name: "Open actions for Local Flagged Skill" }),
     ).toBeTruthy();

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -345,7 +345,6 @@ function PackageRow({ pkg }: { pkg: DashboardPackage }) {
         : "Skill Package";
   const stats = [
     { label: "Downloads", value: formatCompactNumber(pkg.stats.downloads ?? 0) },
-    { label: "Installs", value: formatCompactNumber(pkg.stats.installs ?? 0) },
     { label: "Stars", value: formatCompactNumber(pkg.stats.stars ?? 0) },
     { label: "Updated", value: formatShortDate(pkg.updatedAt) },
   ];


### PR DESCRIPTION
## Summary
- Show downloads instead of installs as the primary skill detail sidebar metric
- Remove installs from dashboard plugin/package stats so downloads remain the visible adoption signal
- Add focused assertions for the updated labels

## Tests
- bun run test src/routes/-dashboard.test.tsx src/components/SkillHeader.test.tsx
- bun run format:check src/components/SkillHeader.tsx src/components/SkillHeader.test.tsx src/routes/dashboard.tsx src/routes/-dashboard.test.tsx
