### PR TITLE
fix: prevent skill tabs from scrolling

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -5426,18 +5426,18 @@ code {
 .tab-card {
   gap: 18px;
   max-width: 100%;
-  overflow-x: auto;
+  overflow: visible;
 }
 
 .tab-header {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 22px;
   padding: 0;
   border-bottom: 1px solid var(--line);
   background: transparent;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
+  overflow: visible;
   scrollbar-width: none;
   max-width: 100%;
 }
@@ -9857,12 +9857,12 @@ a.agentic-risk-finding-title:focus-visible {
   }
 
   .tab-card {
-    overflow-x: hidden;
+    overflow: visible;
   }
 
   .tab-header {
     gap: 18px;
-    overflow-x: auto;
+    overflow: visible;
   }
 
   .tab-button {


### PR DESCRIPTION
## Summary

Fixes the skill detail tab strip so mouse wheel or trackpad input over the tabs no longer scrolls the tab row. The tab header now wraps tabs when space is constrained instead of behaving like a hidden horizontal scroll container.

## Issue

On skill detail pages such as `https://clawhub.ai/spotify/save-to-spotify`, the tabs around `SKILL.md`, `Files`, `Compare`, and `Versions` could intercept scroll gestures while the pointer was over the tab strip. That made the tab area feel like it had its own scroll behavior even though the tabs are navigation controls.

## Root Cause

`.tab-card` and `.tab-header` were configured with horizontal overflow. The scrollbar was hidden, but the element was still a scroll container, so wheel/trackpad input could be captured by the tab row.

## Fix

- Remove scroll-container behavior from the skill detail tab card/header.
- Allow the tab header to wrap when it has more tabs than fit in the available width.
- Preserve the mobile breakpoint behavior with visible overflow instead of hidden/auto overflow.

## Verification

- `bun run test src/components/SkillDetailTabs.test.tsx`
- `bun run format:check`
- `bun run lint`
- Browser checked `http://localhost:3001/local/padel` in the Codex app browser and confirmed wheel input over the detail tabs scrolls the page normally.
