### PR TITLE
fix: refresh skill star state

### DIFF
--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -5,6 +5,7 @@ import type { Id } from "../../convex/_generated/dataModel";
 import { SkillDetailPage } from "../components/SkillDetailPage";
 
 const navigateMock = vi.fn();
+const routerInvalidateMock = vi.fn();
 const useAuthStatusMock = vi.fn();
 
 process.env.VITE_CONVEX_URL = process.env.VITE_CONVEX_URL ?? "https://example.convex.cloud";
@@ -21,6 +22,7 @@ vi.mock("../convex/client", () => ({
 vi.mock("@tanstack/react-router", () => ({
   Link: ({ children }: { children: ReactNode }) => children,
   useNavigate: () => navigateMock,
+  useRouter: () => ({ invalidate: routerInvalidateMock }),
 }));
 
 vi.mock("@convex-dev/auth/react", () => ({
@@ -28,12 +30,13 @@ vi.mock("@convex-dev/auth/react", () => ({
 }));
 
 const useQueryMock = vi.fn();
+const useMutationMock = vi.fn();
 const getReadmeMock = vi.fn();
 
 vi.mock("convex/react", () => ({
   ConvexReactClient: class {},
   useQuery: (...args: unknown[]) => useQueryMock(...args),
-  useMutation: () => vi.fn(),
+  useMutation: (...args: unknown[]) => useMutationMock(...args),
   useAction: () => getReadmeMock,
 }));
 
@@ -61,10 +64,13 @@ describe("SkillDetailPage", () => {
 
   beforeEach(() => {
     useQueryMock.mockReset();
+    useMutationMock.mockReset();
     getReadmeMock.mockReset();
     navigateMock.mockReset();
+    routerInvalidateMock.mockReset();
     useAuthStatusMock.mockReset();
     getReadmeMock.mockResolvedValue({ text: "" });
+    useMutationMock.mockReturnValue(vi.fn());
     useAuthStatusMock.mockReturnValue({
       isAuthenticated: false,
       isLoading: false,
@@ -659,6 +665,92 @@ describe("SkillDetailPage", () => {
     expect(screen.queryByText(/Loading skill/i)).toBeNull();
     expect(screen.getAllByText("Weather").length).toBeGreaterThan(0);
     expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("invalidates route data and updates the star button while the live skill query is stale", async () => {
+    const toggleStarMock = vi
+      .fn()
+      .mockResolvedValueOnce({ starred: true })
+      .mockResolvedValueOnce({ starred: false });
+    useMutationMock.mockReturnValue(toggleStarMock);
+    useAuthStatusMock.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      me: { _id: "users:viewer", role: "user" },
+    });
+    useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
+      if (args === "skip") return undefined;
+      if (args && typeof args === "object" && "skillId" in args && "limit" in args) return [];
+      if (args && typeof args === "object" && "skillId" in args) return false;
+      if (args && typeof args === "object" && "slug" in args) {
+        return {
+          skill: {
+            _id: skillId,
+            _creationTime: 0,
+            slug: "weather",
+            displayName: "Weather",
+            summary: "Get current weather.",
+            ownerUserId: ownerId,
+            ownerPublisherId,
+            tags: {},
+            badges: {},
+            stats: {
+              stars: 8,
+              downloads: 34,
+              installsCurrent: 5,
+              installsAllTime: 8,
+              versions: 1,
+              comments: 0,
+            },
+            createdAt: 0,
+            updatedAt: 0,
+          },
+          owner: {
+            _id: ownerPublisherId,
+            _creationTime: 0,
+            kind: "user",
+            handle: "steipete",
+            displayName: "Peter",
+            linkedUserId: ownerId,
+          },
+          latestVersion: {
+            _id: versionId,
+            _creationTime: 0,
+            skillId,
+            version: "1.0.0",
+            fingerprint: "abc",
+            changelog: "Initial release",
+            parsed: { license: "MIT-0", frontmatter: {} },
+            files: [],
+            createdBy: ownerId,
+            createdAt: 0,
+          },
+          forkOf: null,
+          canonical: null,
+        };
+      }
+      return undefined;
+    });
+
+    render(<SkillDetailPage slug="weather" />);
+
+    const starButton = await screen.findByRole("button", { name: "Star skill" });
+    expect(starButton.textContent).toContain("8");
+
+    fireEvent.click(starButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Unstar skill" }).textContent).toContain("9");
+    });
+    expect(toggleStarMock).toHaveBeenCalledWith({ skillId });
+
+    fireEvent.click(screen.getByRole("button", { name: "Unstar skill" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Star skill" }).textContent).toContain("8");
+    });
+    expect(toggleStarMock).toHaveBeenCalledTimes(2);
+    expect(routerInvalidateMock).toHaveBeenCalledTimes(2);
   });
 
   it("opens report dialog for authenticated users", async () => {

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useAuthActions } from "@convex-dev/auth/react";
-import { useNavigate } from "@tanstack/react-router";
+import { useNavigate, useRouter } from "@tanstack/react-router";
 import type { ClawdisSkillMetadata } from "clawhub-schema";
 import { useAction, useMutation, useQuery } from "convex/react";
 import { ArrowLeft, TriangleAlert } from "lucide-react";
@@ -160,6 +160,7 @@ export function SkillDetailPage({
   mode = "detail",
 }: SkillDetailPageProps) {
   const navigate = useNavigate();
+  const router = useRouter();
   const { isAuthenticated, me } = useAuthStatus();
   const { signIn } = useAuthActions();
   const initialResult = initialData?.result ?? undefined;
@@ -195,6 +196,13 @@ export function SkillDetailPage({
   const [reportReason, setReportReason] = useState("");
   const [reportError, setReportError] = useState<string | null>(null);
   const [isSubmittingReport, setIsSubmittingReport] = useState(false);
+  const [optimisticStar, setOptimisticStar] = useState<{
+    skillId: Id<"skills">;
+    starred: boolean;
+    baselineStarred: boolean;
+    baselineStars: number;
+    delta: number;
+  } | null>(null);
 
   const isLoadingSkill = isStaff ? staffResult === undefined : result === undefined;
   const skill = result?.skill;
@@ -217,6 +225,21 @@ export function SkillDetailPage({
     api.stars.isStarred,
     isAuthenticated && skill ? { skillId: skill._id } : "skip",
   );
+  const activeOptimisticStar =
+    optimisticStar && skill && optimisticStar.skillId === skill._id ? optimisticStar : null;
+  const effectiveIsStarred = activeOptimisticStar?.starred ?? isStarred;
+  const displayedSkill = useMemo(() => {
+    if (!skill || !activeOptimisticStar) return skill;
+    const currentStars = skill.stats.stars ?? 0;
+    if (currentStars !== activeOptimisticStar.baselineStars) return skill;
+    return {
+      ...skill,
+      stats: {
+        ...skill.stats,
+        stars: Math.max(0, currentStars + activeOptimisticStar.delta),
+      },
+    };
+  }, [activeOptimisticStar, skill]);
 
   const myPublisherIds = useMemo(
     () =>
@@ -397,6 +420,13 @@ export function SkillDetailPage({
     };
   }, [getReadme, latestVersionId, loadedReadmeVersionId, readme, readmeError]);
 
+  useEffect(() => {
+    if (!skill || !activeOptimisticStar) return;
+    if (skill.stats.stars !== activeOptimisticStar.baselineStars) {
+      setOptimisticStar(null);
+    }
+  }, [activeOptimisticStar, skill]);
+
   const closeReportDialog = () => {
     setIsReportDialogOpen(false);
     setReportReason("");
@@ -469,6 +499,36 @@ export function SkillDetailPage({
     }
   };
 
+  const handleToggleStar = async () => {
+    if (!skill) return;
+    const activeStar = activeOptimisticStar;
+    const baselineStarred = activeStar?.baselineStarred ?? Boolean(effectiveIsStarred);
+    const previousIsStarred = Boolean(effectiveIsStarred);
+    const baselineStars = activeStar?.baselineStars ?? skill.stats.stars ?? 0;
+
+    try {
+      const starResult = (await toggleStar({ skillId: skill._id })) as { starred: boolean };
+      setOptimisticStar({
+        skillId: skill._id,
+        starred: starResult.starred,
+        baselineStarred,
+        baselineStars,
+        delta:
+          starResult.starred === previousIsStarred
+            ? (activeStar?.delta ?? 0)
+            : starResult.starred === baselineStarred
+              ? 0
+              : starResult.starred
+                ? 1
+                : -1,
+      });
+      void router.invalidate();
+    } catch (error) {
+      console.error("Failed to toggle star", error);
+      toast.error(getUserFacingConvexError(error, "Unable to update star. Please try again."));
+    }
+  };
+
   const requireSignIn = () => {
     clearAuthError();
     const redirectTo =
@@ -490,7 +550,7 @@ export function SkillDetailPage({
     );
   }
 
-  if (result === null || !skill) {
+  if (result === null || !skill || !displayedSkill) {
     return (
       <main className="section detail-page-section">
         <Card>Skill not found.</Card>
@@ -574,7 +634,7 @@ export function SkillDetailPage({
     <main className="section detail-page-section">
       <DetailPageShell>
         <SkillHeader
-          skill={skill}
+          skill={displayedSkill}
           owner={owner}
           ownerHandle={ownerHandle}
           latestVersion={latestVersion}
@@ -582,8 +642,8 @@ export function SkillDetailPage({
           canManage={canManage}
           isAuthenticated={isAuthenticated}
           isStaff={isStaff}
-          isStarred={isStarred}
-          onToggleStar={() => void toggleStar({ skillId: skill._id })}
+          isStarred={effectiveIsStarred}
+          onToggleStar={() => void handleToggleStar()}
           onOpenReport={openReportDialog}
           onRequireSignIn={requireSignIn}
           forkOf={forkOf}


### PR DESCRIPTION
## Summary
- refresh the skill detail route loader after star toggles
- keep the star button/count locally up to date while batched skill stat sync is stale
- cover star and immediate unstar behavior with a regression test

## Verification
- bunx vitest run src/__tests__/skill-detail-page.test.tsx
- bun run format:check
- bun run lint
- bunx tsc --noEmit
