### PR TITLE
fix: polish dashboard artifact cards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@
 
 - Commit messages: Conventional Commits (`feat:`, `fix:`, `chore:`, `docs:`…).
 - Keep changes scoped; avoid repo-wide search/replace.
-- Before commit/PR handoff, run `bun run format:check` and `bun run lint`; include commands run in the PR summary.
+- Before commit/PR handoff, run `bun run ci:static` so formatting, linting, audit/peer checks, and dead-code export checks match the CI `static` job. For faster inner loops, targeted `bun run format:check -- <files>` / `bun run lint` are fine, but do not treat them as the final pre-push gate.
 - PRs: include summary + test commands run. Add screenshots for UI changes.
 - Before merging any PR, verify TypeScript cleanly with `bunx tsc -p packages/schema/tsconfig.json --noEmit` and `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`; if Convex code changed, also run the repo typecheck path used by deploy so `bunx convex deploy` will not fail on `tsc`.
 - GitHub comments: for multiline `gh` comments/close messages, use `--body-file`, `--input`, or stdin/heredoc with real newlines; never pass literal `\\n` in shell strings.

--- a/src/components/artifacts/ArtifactCard.tsx
+++ b/src/components/artifacts/ArtifactCard.tsx
@@ -1,16 +1,10 @@
 import type { ReactNode } from "react";
-import { ArtifactScanResult, ArtifactScanStrip } from "./ArtifactScanStrip";
-import type { ArtifactDisplayStatus, ArtifactScanSignalStatus } from "./artifactStatus";
+import { ArtifactScanStatusValue } from "./ArtifactScanStrip";
+import type { ArtifactDisplayStatus } from "./artifactStatus";
 
 type ArtifactStat = {
   label: string;
-  value: string;
-};
-
-type ArtifactScanSignals = {
-  vtStatus: string | null;
-  llmStatus: string | null;
-  staticScanStatus: ArtifactScanSignalStatus;
+  value: ReactNode;
 };
 
 export function ArtifactCard({
@@ -18,10 +12,7 @@ export function ArtifactCard({
   title,
   titleId,
   icon,
-  meta,
-  summary,
   status,
-  scanSignals,
   stats,
   actions,
 }: {
@@ -29,34 +20,29 @@ export function ArtifactCard({
   title: string;
   titleId: string;
   icon: ReactNode;
-  meta: ReactNode;
-  summary?: string | null;
   status: ArtifactDisplayStatus;
-  scanSignals: ArtifactScanSignals;
   stats: ArtifactStat[];
   actions?: ReactNode;
 }) {
   return (
     <div className="dashboard-artifact-card">
-      <a href={href} className="dashboard-artifact-card-body" aria-labelledby={titleId}>
-        <div className="dashboard-artifact-main">
-          <div className="dashboard-artifact-icon" aria-hidden="true">
-            {icon}
-          </div>
-          <div className="dashboard-artifact-heading">
-            <div className="dashboard-artifact-title-row">
-              <span id={titleId} className="dashboard-skill-name">
-                {title}
-              </span>
-              <ArtifactScanResult status={status} />
-            </div>
-            <div className="dashboard-artifact-meta">{meta}</div>
+      <a href={href} className="dashboard-artifact-link" aria-label={title} />
+      <div className="dashboard-artifact-card-body">
+        <div className="dashboard-artifact-icon">{icon}</div>
+        <div className="dashboard-artifact-heading">
+          <div className="dashboard-artifact-title-row">
+            <span id={titleId} className="dashboard-skill-name">
+              {title}
+            </span>
           </div>
         </div>
-        <p className="dashboard-artifact-summary">{summary ?? "No summary provided."}</p>
-        <ArtifactScanStrip {...scanSignals} />
-        <ArtifactStats stats={stats} />
-      </a>
+      </div>
+      <ArtifactStats
+        stats={[
+          { label: "Security scan", value: <ArtifactScanStatusValue status={status} /> },
+          ...stats,
+        ]}
+      />
       {actions}
     </div>
   );

--- a/src/components/artifacts/ArtifactScanStrip.tsx
+++ b/src/components/artifacts/ArtifactScanStrip.tsx
@@ -1,43 +1,10 @@
 import { ScanResultBadge } from "../SkillSecurityScanResults";
-import {
-  artifactStatusToScanStatus,
-  type ArtifactDisplayStatus,
-  type ArtifactScanSignalStatus,
-} from "./artifactStatus";
+import { artifactStatusToScanStatus, type ArtifactDisplayStatus } from "./artifactStatus";
 
-export function ArtifactScanStrip({
-  vtStatus,
-  llmStatus,
-  staticScanStatus,
-}: {
-  vtStatus: string | null;
-  llmStatus: string | null;
-  staticScanStatus: ArtifactScanSignalStatus;
-}) {
+export function ArtifactScanStatusValue({ status }: { status: ArtifactDisplayStatus }) {
   return (
-    <div className="dashboard-scan-strip" aria-label="Latest scan signals">
-      <ScanSignal label="VT" status={vtStatus} />
-      <ScanSignal label="LLM" status={llmStatus} />
-      <ScanSignal label="Static" status={staticScanStatus} />
-    </div>
-  );
-}
-
-function ScanSignal({ label, status }: { label: string; status: string | null }) {
-  const normalized = status ?? "not-run";
-  return (
-    <span className="dashboard-scan-signal">
-      <span className="dashboard-scan-label">{label}</span>
-      <ScanResultBadge status={normalized} />
-    </span>
-  );
-}
-
-export function ArtifactScanResult({ status }: { status: ArtifactDisplayStatus }) {
-  return (
-    <div className="dashboard-scan-result-kv">
-      <span>Scan result</span>
+    <span className="dashboard-scan-result-value">
       <ScanResultBadge status={artifactStatusToScanStatus(status)} />
-    </div>
+    </span>
   );
 }

--- a/src/components/artifacts/artifactStatus.ts
+++ b/src/components/artifacts/artifactStatus.ts
@@ -5,7 +5,7 @@ export type ArtifactDisplayStatus = {
   variant: "default" | "pending" | "warning" | "destructive" | "success";
 };
 
-export type ArtifactScanSignalStatus = "clean" | "suspicious" | "malicious" | null;
+type ArtifactScanSignalStatus = "clean" | "suspicious" | "malicious" | null;
 
 type SkillArtifactStatusInput = {
   moderationStatus?: string;

--- a/src/routes/-dashboard.test.tsx
+++ b/src/routes/-dashboard.test.tsx
@@ -1,5 +1,5 @@
 /* @vitest-environment jsdom */
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import type React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Id } from "../../convex/_generated/dataModel";
@@ -242,7 +242,7 @@ describe("Dashboard rows", () => {
     mocks.toastError.mockReset();
   });
 
-  it("renders rich artifact cards with status, scan, and inventory context", () => {
+  it("renders compact clickable artifact cards with status and inventory context", () => {
     arrangeDashboard({
       skills: [createSkill()],
       packages: [createPackage({ stats: { downloads: 42, installs: 9, stars: 0, versions: 1 } })],
@@ -256,23 +256,25 @@ describe("Dashboard rows", () => {
     expect(
       screen.getByRole("link", { name: "Local Flagged Runtime Plugin" }).getAttribute("href"),
     ).toBe("/plugins/local-flagged-runtime-plugin");
-    expect(screen.getByText("Flagged skill fixture.")).toBeTruthy();
-    expect(screen.getByText("Flagged plugin fixture.")).toBeTruthy();
     expect(screen.getAllByText("Review").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Malicious").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Scan result").length).toBe(2);
-    expect(screen.getAllByText("VT").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("LLM").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Static").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Security scan").length).toBe(2);
+    expect(screen.queryByText("Flagged skill fixture.")).toBeNull();
+    expect(screen.queryByText("Flagged plugin fixture.")).toBeNull();
+    expect(screen.queryByText("VT")).toBeNull();
+    expect(screen.queryByText("LLM")).toBeNull();
+    expect(screen.queryByText("Static")).toBeNull();
     expect(screen.queryByText(/rescans/i)).toBeNull();
     expect(screen.queryByText("Limit reached (3/3)")).toBeNull();
     expect(screen.getAllByText("Downloads").length).toBeGreaterThan(0);
     expect(screen.queryByText("Installs")).toBeNull();
+    expect(screen.getAllByText("Current version").length).toBe(2);
+    expect(screen.getAllByText("Last updated").length).toBe(2);
     expect(
-      screen.getByRole("button", { name: "Open actions for Local Flagged Skill" }),
+      screen.getByRole("link", { name: "Open settings for Local Flagged Skill" }),
     ).toBeTruthy();
     expect(
-      screen.getByRole("button", { name: "Open actions for Local Flagged Runtime Plugin" }),
+      screen.getByRole("link", { name: "Open settings for Local Flagged Runtime Plugin" }),
     ).toBeTruthy();
   });
 
@@ -330,16 +332,18 @@ describe("Dashboard rows", () => {
     );
   });
 
-  it("exposes package delete from the plugin row action menu", () => {
+  it("links directly to plugin settings from the row action", () => {
     arrangeDashboard({ packages: [createPackage({ scanStatus: "clean" })] });
 
     renderDashboard();
 
-    fireEvent.pointerDown(
-      screen.getByRole("button", { name: "Open actions for Local Flagged Runtime Plugin" }),
-    );
-
-    expect(screen.getByRole("menuitem", { name: /delete plugin/i })).toBeTruthy();
+    expect(
+      screen
+        .getByRole("link", { name: "Open settings for Local Flagged Runtime Plugin" })
+        .getAttribute("href"),
+    ).toBe("/plugins/local-flagged-runtime-plugin/settings");
+    expect(screen.queryByRole("button", { name: /open actions/i })).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: /delete plugin/i })).toBeNull();
   });
 
   it("does not render legacy table column titles or scanner prefixes", () => {

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -1,23 +1,16 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useMutation, usePaginatedQuery, useQuery } from "convex/react";
-import { Box, Loader2, MoreVertical, Package, Plus, Settings, Trash2 } from "lucide-react";
+import { usePaginatedQuery, useQuery } from "convex/react";
+import { Box, Loader2, Package, Plus, Settings } from "lucide-react";
 import { useEffect, useState } from "react";
-import { toast } from "sonner";
 import { api } from "../../convex/_generated/api";
 import type { Doc } from "../../convex/_generated/dataModel";
 import { ArtifactCard } from "../components/artifacts/ArtifactCard";
 import { packageArtifactStatus, skillArtifactStatus } from "../components/artifacts/artifactStatus";
 import { DashboardSkeleton } from "../components/skeletons/DashboardSkeleton";
+import { buildSkillHref } from "../components/skillDetailUtils";
 import { Button } from "../components/ui/button";
 import { Card } from "../components/ui/card";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "../components/ui/dropdown-menu";
-import { getUserFacingConvexError } from "../lib/convexError";
+import { buildPluginDetailHref } from "../lib/pluginRoutes";
 
 const emptyPluginPublishSearch = {
   ownerHandle: undefined,
@@ -53,8 +46,8 @@ type DashboardSkill = Pick<
   | "updatedAt"
 > & {
   ownerPath: string;
-  detailHref: string;
-  settingsHref: string;
+  detailHref?: string;
+  settingsHref?: string;
   pendingReview?: boolean;
   qualityDecision?: "pass" | "quarantine" | "reject";
   latestVersion: {
@@ -241,7 +234,7 @@ export function Dashboard() {
           ) : (
             <div className="dashboard-list">
               {skills.map((skill) => (
-                <SkillRow key={skill._id} skill={skill} />
+                <SkillRow key={skill._id} skill={skill} ownerHandle={ownerHandle} />
               ))}
             </div>
           )}
@@ -288,46 +281,29 @@ export function Dashboard() {
   );
 }
 
-function SkillRow({ skill }: { skill: DashboardSkill }) {
+function SkillRow({ skill, ownerHandle }: { skill: DashboardSkill; ownerHandle: string }) {
   const status = skillArtifactStatus(skill);
   const titleId = `dashboard-skill-title-${skill._id}`;
+  const detailHref =
+    skill.detailHref ??
+    buildSkillHref(ownerHandle, skill.ownerPublisherId ?? skill.ownerUserId ?? null, skill.slug);
+  const settingsHref = skill.settingsHref ?? `${detailHref}/settings`;
   const stats = [
     { label: "Downloads", value: formatCompactNumber(skill.stats?.downloads ?? 0) },
-    { label: "Stars", value: formatCompactNumber(skill.stats?.stars ?? 0) },
-    { label: "Versions", value: formatCompactNumber(skill.stats?.versions ?? 0) },
-    { label: "Updated", value: formatShortDate(skill.updatedAt) },
+    { label: "Current version", value: formatVersion(skill.latestVersion?.version) },
+    { label: "Last updated", value: formatShortDate(skill.updatedAt) },
   ];
 
   return (
     <ArtifactCard
-      href={skill.detailHref}
+      href={detailHref}
       title={skill.displayName}
       titleId={titleId}
       icon={<Box className="h-5 w-5" />}
-      meta={
-        <>
-          <span>Skill</span>
-          <span>
-            /{skill.ownerPath}/{skill.slug}
-          </span>
-          {skill.latestVersion?.version ? <span>v{skill.latestVersion.version}</span> : null}
-        </>
-      }
-      summary={skill.summary}
       status={status}
-      scanSignals={{
-        vtStatus: skill.latestVersion?.vtStatus ?? null,
-        llmStatus: skill.latestVersion?.llmStatus ?? null,
-        staticScanStatus: skill.latestVersion?.staticScanStatus ?? null,
-      }}
       stats={stats}
       actions={
-        <RowMenu
-          kind="skill"
-          targetId={skill._id}
-          targetLabel={skill.displayName}
-          settingsHref={skill.settingsHref}
-        />
+        <SettingsLink href={settingsHref} label={`Open settings for ${skill.displayName}`} />
       }
     />
   );
@@ -335,18 +311,13 @@ function SkillRow({ skill }: { skill: DashboardSkill }) {
 
 function PackageRow({ pkg }: { pkg: DashboardPackage }) {
   const status = packageArtifactStatus(pkg);
-  const detailHref = `/plugins/${encodeURIComponent(pkg.name)}`;
+  const detailHref = buildPluginDetailHref(pkg.name);
+  const settingsHref = `${detailHref}/settings`;
   const titleId = `dashboard-package-title-${pkg._id}`;
-  const familyLabel =
-    pkg.family === "bundle-plugin"
-      ? "Bundle Plugin"
-      : pkg.family === "code-plugin"
-        ? "Code Plugin"
-        : "Skill Package";
   const stats = [
     { label: "Downloads", value: formatCompactNumber(pkg.stats.downloads ?? 0) },
-    { label: "Stars", value: formatCompactNumber(pkg.stats.stars ?? 0) },
-    { label: "Updated", value: formatShortDate(pkg.updatedAt) },
+    { label: "Current version", value: formatVersion(pkg.latestVersion) },
+    { label: "Last updated", value: formatShortDate(pkg.updatedAt) },
   ];
 
   return (
@@ -355,30 +326,9 @@ function PackageRow({ pkg }: { pkg: DashboardPackage }) {
       title={pkg.displayName}
       titleId={titleId}
       icon={<Package className="h-5 w-5" />}
-      meta={
-        <>
-          <span>{familyLabel}</span>
-          <span>{pkg.name}</span>
-          {pkg.latestVersion ? <span>v{pkg.latestVersion}</span> : null}
-          <span>{pkg.channel}</span>
-        </>
-      }
-      summary={pkg.summary}
       status={status}
-      scanSignals={{
-        vtStatus: pkg.latestRelease?.vtStatus ?? null,
-        llmStatus: pkg.latestRelease?.llmStatus ?? null,
-        staticScanStatus: pkg.latestRelease?.staticScanStatus ?? null,
-      }}
       stats={stats}
-      actions={
-        <RowMenu
-          kind="plugin"
-          targetId={pkg._id}
-          targetLabel={pkg.displayName}
-          settingsHref={detailHref}
-        />
-      }
+      actions={<SettingsLink href={settingsHref} label={`Open settings for ${pkg.displayName}`} />}
     />
   );
 }
@@ -396,73 +346,18 @@ function formatShortDate(timestamp: number | undefined) {
   );
 }
 
-function RowMenu({
-  kind,
-  targetId,
-  targetLabel,
-  settingsHref,
-}: {
-  kind: "skill" | "plugin";
-  targetId: string;
-  targetLabel: string;
-  settingsHref: string;
-}) {
-  const deletePackage = useMutation(api.packages.softDeletePackage);
-  const [isDeleting, setIsDeleting] = useState(false);
+function formatVersion(version: string | null | undefined) {
+  return version ? `v${version}` : "Unknown";
+}
 
-  async function deletePlugin() {
-    if (kind !== "plugin" || isDeleting) return;
-    const confirmed = window.confirm(
-      `Delete ${targetLabel}? This removes the plugin package and all releases from ClawHub.`,
-    );
-    if (!confirmed) return;
-
-    setIsDeleting(true);
-    try {
-      await deletePackage({ packageId: targetId as Doc<"packages">["_id"] });
-      toast.success(`Deleted ${targetLabel}.`);
-    } catch (error) {
-      toast.error(getUserFacingConvexError(error, "Could not delete this plugin."));
-    } finally {
-      setIsDeleting(false);
-    }
-  }
-
+function SettingsLink({ href, label }: { href: string; label: string }) {
   return (
-    <div className="dashboard-row-menu">
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            aria-label={`Open actions for ${targetLabel}`}
-          >
-            <MoreVertical className="h-4 w-4" aria-hidden="true" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="dashboard-row-menu-content">
-          <DropdownMenuItem asChild>
-            <a href={settingsHref}>
-              <Settings className="h-4 w-4" aria-hidden="true" />
-              Settings
-            </a>
-          </DropdownMenuItem>
-          {kind === "plugin" ? (
-            <>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                disabled={isDeleting}
-                variant="destructive"
-                onSelect={() => void deletePlugin()}
-              >
-                <Trash2 className="h-4 w-4" aria-hidden="true" />
-                {isDeleting ? "Deleting..." : "Delete plugin"}
-              </DropdownMenuItem>
-            </>
-          ) : null}
-        </DropdownMenuContent>
-      </DropdownMenu>
+    <div className="dashboard-row-action">
+      <Button asChild variant="ghost" size="icon-sm">
+        <a href={href} aria-label={label} title="Settings">
+          <Settings className="h-4 w-4" aria-hidden="true" />
+        </a>
+      </Button>
     </div>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -4810,8 +4810,8 @@ code {
   width: 100%;
   min-width: 0;
   border-radius: var(--radius-md);
-  border: 1px solid color-mix(in srgb, var(--line) 72%, var(--ink) 28%);
-  background: color-mix(in srgb, var(--surface-muted) 78%, var(--ink) 10%);
+  border: 1px solid var(--line);
+  background: var(--surface-muted);
   padding: 16px 62px 16px 18px;
 }
 
@@ -4846,6 +4846,17 @@ code {
   right: 12px;
   width: 34px;
   padding-inline: 0;
+}
+
+[data-theme-resolved="dark"] .skill-install-command-inline-button {
+  border-color: color-mix(in srgb, var(--line) 68%, transparent);
+  background: color-mix(in srgb, var(--surface-muted) 44%, var(--bg) 56%);
+  color: color-mix(in srgb, var(--ink) 82%, var(--ink-soft) 18%);
+}
+
+[data-theme-resolved="dark"] .skill-install-command-inline-button:hover {
+  border-color: color-mix(in srgb, var(--line) 90%, var(--accent) 10%);
+  background: color-mix(in srgb, var(--surface-muted) 58%, var(--bg) 42%);
 }
 
 .skill-install-command-caption {
@@ -6866,30 +6877,35 @@ code {
     box-shadow 0.16s ease;
 }
 
+.dashboard-artifact-card:has(.dashboard-artifact-link:hover) {
+  cursor: pointer;
+}
+
 .dashboard-artifact-card:hover {
   border-color: color-mix(in srgb, var(--accent) 34%, var(--card-border));
   box-shadow: 0 18px 48px rgb(0 0 0 / 0.2);
   transform: translateY(-1px);
 }
 
-.dashboard-artifact-card-body {
-  display: grid;
-  grid-column: 1 / -1;
-  min-width: 0;
-  gap: 14px;
-  color: inherit;
-  text-decoration: none;
+.dashboard-artifact-link {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  border-radius: inherit;
 }
 
-.dashboard-artifact-card-body:hover {
-  color: inherit;
-  text-decoration: none;
-}
-
-.dashboard-artifact-card-body:focus-visible {
+.dashboard-artifact-link:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 4px;
-  border-radius: 8px;
+}
+
+.dashboard-artifact-card-body {
+  display: flex;
+  min-width: 0;
+  gap: 12px;
+  align-items: center;
+  color: inherit;
+  text-decoration: none;
 }
 
 .dashboard-artifact-main {
@@ -6993,7 +7009,7 @@ code {
 
 .dashboard-artifact-stats {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(92px, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 8px;
   margin: 0;
 }
@@ -7029,7 +7045,12 @@ code {
   line-height: 1.2;
 }
 
-.dashboard-row-menu {
+.dashboard-scan-result-value {
+  display: inline-flex;
+  align-items: center;
+}
+
+.dashboard-row-action {
   display: flex;
   justify-content: flex-end;
   align-items: center;
@@ -7040,48 +7061,16 @@ code {
   z-index: 2;
 }
 
-.dashboard-row-menu [data-slot="button"] {
+.dashboard-row-action [data-slot="button"] {
   width: 32px;
   height: 32px;
   min-height: 32px;
   padding: 0;
 }
 
-.dashboard-row-menu [data-slot="button"] svg {
+.dashboard-row-action [data-slot="button"] svg {
   width: 16px;
   height: 16px;
-}
-
-.dashboard-row-menu-content {
-  width: 190px;
-  min-width: 190px;
-  padding: 6px;
-  border-radius: 10px;
-  box-shadow:
-    0 18px 48px rgb(0 0 0 / 0.28),
-    0 0 0 1px rgb(255 255 255 / 0.04);
-}
-
-.dashboard-row-menu-content [data-slot="dropdown-menu-item"] {
-  display: flex;
-  width: 100%;
-  min-height: 34px;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 8px;
-  padding: 8px 10px;
-  line-height: 1.2;
-  white-space: nowrap;
-}
-
-.dashboard-row-menu-content [data-slot="dropdown-menu-item"] svg {
-  width: 16px;
-  height: 16px;
-  flex: none;
-}
-
-.dashboard-row-menu-content [data-slot="dropdown-menu-separator"] {
-  margin-block: 4px;
 }
 
 .btn-sm {
@@ -7135,11 +7124,8 @@ code {
     padding: 14px;
   }
 
-  .dashboard-artifact-main,
-  .dashboard-artifact-summary,
-  .dashboard-scan-strip,
   .dashboard-artifact-stats {
-    grid-column: auto;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .dashboard-artifact-title-row {


### PR DESCRIPTION
## Summary
- simplify dashboard artifact cards to the requested compact fields
- make the whole card navigate to the artifact page and the gear navigate directly to settings
- align the install command shell with markdown codeblock colors in dark mode
- document `bun run ci:static` as the final pre-commit/PR static gate

## Validation
- bun run ci:static
- bun run test src/routes/-dashboard.test.tsx
