### PR TITLE
fix(web): polish stars page

### DIFF
--- a/src/routes/-stars.test.tsx
+++ b/src/routes/-stars.test.tsx
@@ -1,0 +1,143 @@
+/* @vitest-environment jsdom */
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Stars } from "./stars";
+
+const useQueryMock = vi.fn();
+const useMutationMock = vi.fn();
+const useConvexAuthMock = vi.fn();
+const useAuthActionsMock = vi.fn();
+const navigateMock = vi.fn();
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => useConvexAuthMock(),
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
+  useMutation: (...args: unknown[]) => useMutationMock(...args),
+}));
+
+vi.mock("@convex-dev/auth/react", () => ({
+  useAuthActions: () => useAuthActionsMock(),
+}));
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual =
+    await vi.importActual<typeof import("@tanstack/react-router")>("@tanstack/react-router");
+  return {
+    ...actual,
+    createFileRoute: () => (options: unknown) => ({
+      ...(options as Record<string, unknown>),
+      useNavigate: () => navigateMock,
+      useSearch: () => ({}),
+    }),
+    Link: ({ children, to }: { children: ReactNode; to: string }) => <a href={to}>{children}</a>,
+  };
+});
+
+function makeSkill(params: { _id: string; slug: string; displayName: string; summary?: string }) {
+  return {
+    _id: params._id,
+    _creationTime: Date.now(),
+    slug: params.slug,
+    displayName: params.displayName,
+    summary: params.summary ?? null,
+    ownerUserId: "user_123",
+    ownerPublisherId: null,
+    canonicalSkillId: null,
+    forkOf: null,
+    latestVersionId: null,
+    tags: [],
+    capabilityTags: [],
+    badges: null,
+    stats: { stars: 5, downloads: 12, versions: 1, comments: 0 },
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+describe("Stars", () => {
+  const toggleStarMock = vi.fn();
+
+  beforeEach(() => {
+    useQueryMock.mockReset();
+    useMutationMock.mockReset();
+    useConvexAuthMock.mockReset();
+    useAuthActionsMock.mockReset();
+    navigateMock.mockReset();
+    useMutationMock.mockReturnValue(toggleStarMock);
+    useConvexAuthMock.mockReturnValue({ isAuthenticated: true, isLoading: false });
+    useAuthActionsMock.mockReturnValue({ signIn: vi.fn() });
+    toggleStarMock.mockReset();
+    toggleStarMock.mockResolvedValue(null);
+  });
+
+  it("shows sign-in prompt when user is not authenticated", () => {
+    useConvexAuthMock.mockReturnValue({ isAuthenticated: false, isLoading: false });
+    useQueryMock.mockImplementation((_query, args) => {
+      if (args === undefined) return null;
+      return undefined;
+    });
+
+    render(<Stars />);
+
+    expect(screen.getByText("Sign in to see your highlights")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /sign in/i })).toBeTruthy();
+  });
+
+  it("shows skeleton while loading", () => {
+    useConvexAuthMock.mockReturnValue({ isAuthenticated: false, isLoading: true });
+    useQueryMock.mockImplementation((_query, args) => {
+      if (args === undefined) return { _id: "user_123" };
+      return undefined;
+    });
+
+    render(<Stars />);
+
+    expect(document.querySelector(".skeleton-list")).toBeTruthy();
+    expect(screen.queryByText("No stars yet")).toBeNull();
+  });
+
+  it("shows empty state when user has no stars", () => {
+    useQueryMock.mockImplementation((_query, args) => {
+      if (args === undefined) return { _id: "user_123" };
+      return [];
+    });
+
+    render(<Stars />);
+
+    expect(screen.getByText("No stars yet")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Browse skills" })).toBeTruthy();
+    expect(screen.queryByRole("combobox", { name: "Sort starred skills" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Grid view" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "List view" })).toBeNull();
+  });
+
+  it("renders skill cards when user has stars", () => {
+    useQueryMock.mockImplementation((_query, args) => {
+      if (args === undefined) return { _id: "user_123" };
+      if (args === "skip") return undefined;
+      return [makeSkill({ _id: "skill_1", slug: "test-skill", displayName: "Test Skill" })];
+    });
+
+    render(<Stars />);
+
+    expect(screen.getByRole("heading", { name: "Test Skill" })).toBeTruthy();
+    expect(screen.getByLabelText("Unstar Test Skill")).toBeTruthy();
+    expect(screen.getByText("Your highlights")).toBeTruthy();
+  });
+
+  it("calls toggleStar when unstar button is clicked", () => {
+    const skill = makeSkill({ _id: "skill_1", slug: "test-skill", displayName: "Test Skill" });
+    useQueryMock.mockImplementation((_query, args) => {
+      if (args === undefined) return { _id: "user_123" };
+      if (args === "skip") return undefined;
+      return [skill];
+    });
+
+    render(<Stars />);
+    const unstarBtn = screen.getByLabelText("Unstar Test Skill");
+    fireEvent.click(unstarBtn);
+
+    expect(toggleStarMock).toHaveBeenCalledWith({ skillId: "skill_1" });
+  });
+});

--- a/src/routes/stars.tsx
+++ b/src/routes/stars.tsx
@@ -1,39 +1,165 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useMutation, useQuery } from "convex/react";
-import { Star } from "lucide-react";
+import { useConvexAuth, useMutation, useQuery } from "convex/react";
+import { ArrowDownUp, LayoutGrid, List, Star } from "lucide-react";
+import { startTransition, useOptimistic } from "react";
 import { toast } from "sonner";
 import { api } from "../../convex/_generated/api";
 import type { Doc } from "../../convex/_generated/dataModel";
 import { EmptyState } from "../components/EmptyState";
 import { SignInButton } from "../components/SignInButton";
+import { SkillCard } from "../components/SkillCard";
+import { SkillListItem } from "../components/SkillListItem";
+import { SkillStatsTripletLine } from "../components/SkillStats";
 import { Button } from "../components/ui/button";
-import { formatCompactStat } from "../lib/numberFormat";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../components/ui/select";
+import { Separator } from "../components/ui/separator";
+import { getSkillBadges } from "../lib/badges";
 import type { PublicSkill } from "../lib/publicUser";
 
+type StarsView = "grid" | "list";
+type StarsSort = "starred" | "updated" | "stars";
+type OptimisticStarsAction =
+  | { type: "remove"; skillId: PublicSkill["_id"] }
+  | { type: "restore"; skill: PublicSkill };
+
+const STARRED_SKILLS_LIMIT = 50;
+
 export const Route = createFileRoute("/stars")({
+  validateSearch: (search): { view?: StarsView; sort?: StarsSort } => ({
+    view: search.view === "list" ? "list" : undefined,
+    sort: ["starred", "updated", "stars"].includes(search.sort as string)
+      ? (search.sort as StarsSort)
+      : undefined,
+  }),
   component: Stars,
 });
 
-function Stars() {
+export function Stars() {
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
   const me = useQuery(api.users.me) as Doc<"users"> | null | undefined;
-  const skills =
-    (useQuery(api.stars.listByUser, me ? { userId: me._id, limit: 50 } : "skip") as
-      | PublicSkill[]
-      | undefined) ?? [];
 
+  const search = Route.useSearch();
+  const navigate = Route.useNavigate();
+  const activeView: StarsView = search.view ?? "grid";
+  const activeSort: StarsSort = search.sort ?? "starred";
+
+  const skillsQuery = useQuery(
+    api.stars.listByUser,
+    me ? { userId: me._id, limit: STARRED_SKILLS_LIMIT } : "skip",
+  ) as PublicSkill[] | undefined;
   const toggleStar = useMutation(api.stars.toggle);
 
-  if (!me) {
+  const [optimisticSkills, updateOptimisticSkills] = useOptimistic(
+    skillsQuery ?? [],
+    (state: PublicSkill[], action: OptimisticStarsAction) => {
+      if (action.type === "remove") return state.filter((s) => s._id !== action.skillId);
+      if (state.some((s) => s._id === action.skill._id)) return state;
+      return [action.skill, ...state];
+    },
+  );
+  const canSortCompleteSet = skillsQuery !== undefined && skillsQuery.length < STARRED_SKILLS_LIMIT;
+  const effectiveSort = canSortCompleteSet ? activeSort : "starred";
+
+  const skills = [...optimisticSkills].sort((a, b) => {
+    if (effectiveSort === "updated") return b.updatedAt - a.updatedAt;
+    if (effectiveSort === "stars") return b.stats.stars - a.stats.stars;
+    return 0; // "starred" keeps server order (starredAt desc)
+  });
+  const hasStars = skills.length > 0;
+
+  const handleUnstar = (skill: PublicSkill) => {
+    startTransition(() => {
+      updateOptimisticSkills({ type: "remove", skillId: skill._id });
+    });
+    toggleStar({ skillId: skill._id }).catch((err: Error) => {
+      startTransition(() => {
+        updateOptimisticSkills({ type: "restore", skill });
+      });
+      console.error("Failed to unstar skill:", err);
+      toast.error("Unable to unstar this skill. Please try again.");
+    });
+  };
+
+  if (isAuthLoading) {
     return (
       <main className="browse-page">
-        <div className="browse-page-narrow">
-          <EmptyState
-            icon={Star}
-            title="Sign in to see your highlights"
-            description="Star skills for quick access later."
-          >
-            <SignInButton />
-          </EmptyState>
+        <div className="skeleton-list">
+          {Array.from({ length: 4 }, (_, i) => (
+            <div key={i} className="skeleton-row">
+              <div className="skeleton-icon" />
+              <div className="skeleton-row-body">
+                <div className="skeleton-bar skeleton-bar-lg" />
+                <div className="skeleton-bar skeleton-bar-sm" />
+                <div className="skeleton-bar skeleton-bar-xs" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </main>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <main
+        className="relative mx-auto flex min-h-[430px] w-full flex-col overflow-hidden px-4 pb-12 pt-20 sm:px-6 sm:pt-24 lg:px-6"
+        style={{ maxWidth: "var(--page-max)" }}
+      >
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute -top-20 inset-x-10 h-64"
+          style={{
+            background:
+              "linear-gradient(to bottom, color-mix(in srgb, var(--accent) 22%, transparent), color-mix(in srgb, var(--accent) 5%, transparent) 42%, transparent 74%)",
+            filter: "blur(2px)",
+            maskImage: "linear-gradient(to right, transparent, black 22%, black 78%, transparent)",
+            WebkitMaskImage:
+              "linear-gradient(to right, transparent, black 22%, black 78%, transparent)",
+          }}
+        />
+        <section className="relative z-10 mx-auto w-full max-w-[980px]">
+          <div className="relative isolate flex min-w-0 flex-col gap-6 overflow-hidden rounded-[var(--radius-md)] border border-[color:var(--line)] bg-[color:var(--surface)] px-5 pb-10 pt-7 shadow-[0_18px_50px_rgba(0,0,0,0.16)] sm:flex-row sm:items-center sm:justify-between sm:px-8 sm:py-8 sm:pb-10">
+            <div className="min-w-0">
+              <span className="mb-4 inline-flex h-11 w-11 items-center justify-center rounded-[var(--radius-md)] border border-[color:var(--line)] bg-[color:var(--surface-muted)] text-[color:var(--ink-soft)] sm:h-12 sm:w-12">
+                <Star size={21} />
+              </span>
+              <h1 className="font-display text-xl font-black leading-tight text-[color:var(--ink)] sm:text-3xl">
+                Sign in to see your highlights
+              </h1>
+              <p className="mt-1 max-w-2xl text-sm leading-6 text-[color:var(--ink-soft)] sm:text-base sm:leading-7">
+                Star skills for quick access later.
+              </p>
+            </div>
+            <SignInButton
+              size="sm"
+              className="min-h-10 w-full shrink-0 border-[color-mix(in_srgb,var(--accent)_82%,var(--border-ui))] bg-transparent px-4 text-sm text-[color:var(--ink)] hover:not-disabled:border-[color:var(--accent)] hover:not-disabled:bg-[color-mix(in_srgb,var(--accent)_7%,transparent)] sm:w-auto"
+            />
+          </div>
+        </section>
+      </main>
+    );
+  }
+
+  if (skillsQuery === undefined) {
+    return (
+      <main className="browse-page">
+        <div className="skeleton-list">
+          {Array.from({ length: 4 }, (_, i) => (
+            <div key={i} className="skeleton-row">
+              <div className="skeleton-icon" />
+              <div className="skeleton-row-body">
+                <div className="skeleton-bar skeleton-bar-lg" />
+                <div className="skeleton-bar skeleton-bar-sm" />
+                <div className="skeleton-bar skeleton-bar-xs" />
+              </div>
+            </div>
+          ))}
         </div>
       </main>
     );
@@ -41,70 +167,128 @@ function Stars() {
 
   return (
     <main className="browse-page">
-      <div className="browse-page-narrow">
-        <div className="flex flex-col gap-6">
-          <header>
-            <h1 className="font-display text-2xl font-bold text-[color:var(--ink)]">
-              Your highlights
-            </h1>
-            <p className="mt-1 text-sm text-[color:var(--ink-soft)]">
-              Skills you've starred for quick access.
-            </p>
-          </header>
-          {skills.length === 0 ? (
-            <EmptyState
-              icon={Star}
-              title="No stars yet"
-              description="Browse skills and star your favorites."
-              action={{ label: "Browse skills", href: "/skills" }}
-            />
-          ) : (
-            <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-5">
-              {skills.map((skill) => {
-                const owner = encodeURIComponent(String(skill.ownerUserId));
-                return (
-                  <div
-                    key={skill._id}
-                    className="flex w-full flex-col gap-3 rounded-[var(--radius-md)] border border-[color:var(--line)] bg-[color:var(--surface)] p-[22px] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_12px_28px_rgba(29,26,23,0.12)]"
-                  >
-                    <Link
-                      to="/$owner/$slug"
-                      params={{ owner, slug: skill.slug }}
-                      className="no-underline"
-                    >
-                      <h3 className="font-display text-base font-bold text-[color:var(--ink)] hover:text-[color:var(--accent)]">
-                        {skill.displayName}
-                      </h3>
-                    </Link>
-                    <div className="flex items-center justify-between">
-                      <span className="text-sm text-[color:var(--ink-soft)]">
-                        <Star className="mr-1 inline h-3.5 w-3.5" />
-                        {formatCompactStat(skill.stats.stars)}
-                      </span>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={async () => {
-                          try {
-                            await toggleStar({ skillId: skill._id });
-                          } catch (error) {
-                            console.error("Failed to unstar skill:", error);
-                            toast.error("Unable to unstar this skill. Please try again.");
-                          }
-                        }}
-                        aria-label={`Unstar ${skill.displayName}`}
-                        className="text-[color:var(--gold)]"
-                      >
-                        <span aria-hidden="true">★</span>
-                      </Button>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
+      <header className="stars-header">
+        <h1 className="stars-header-title font-display text-3xl font-black leading-none text-[color:var(--ink)]">
+          Your highlights
+        </h1>
+        {hasStars ? (
+          <div className="stars-header-controls">
+            <Select
+              value={effectiveSort}
+              disabled={!canSortCompleteSet}
+              onValueChange={(value) => {
+                void navigate({
+                  to: "/stars",
+                  search: { ...search, sort: value as StarsSort },
+                  resetScroll: false,
+                });
+              }}
+            >
+              <SelectTrigger
+                className="stars-sort-trigger h-8 min-w-[140px] text-xs font-semibold"
+                aria-label="Sort starred skills"
+              >
+                <ArrowDownUp className="mr-1.5 h-3.5 w-3.5" />
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="starred">Recently starred</SelectItem>
+                <SelectItem value="updated" disabled={!canSortCompleteSet}>
+                  Recently updated
+                </SelectItem>
+                <SelectItem value="stars" disabled={!canSortCompleteSet}>
+                  Most stars
+                </SelectItem>
+              </SelectContent>
+            </Select>
+            <nav
+              className="publisher-filter-tabs publisher-view-tabs stars-view-tabs"
+              aria-label="Starred skills view"
+            >
+              <Link
+                to="/stars"
+                search={{ ...search, view: undefined }}
+                resetScroll={false}
+                className={`publisher-filter-tab${activeView === "grid" ? " is-active" : ""}`}
+                aria-label="Grid view"
+              >
+                <LayoutGrid size={14} aria-hidden="true" />
+              </Link>
+              <Link
+                to="/stars"
+                search={{ ...search, view: "list" }}
+                resetScroll={false}
+                className={`publisher-filter-tab${activeView === "list" ? " is-active" : ""}`}
+                aria-label="List view"
+              >
+                <List size={14} aria-hidden="true" />
+              </Link>
+            </nav>
+          </div>
+        ) : null}
+      </header>
+      <Separator className="mb-6" />
+
+      {skills.length === 0 ? (
+        <EmptyState
+          icon={Star}
+          title="No stars yet"
+          description="Browse skills and star your favorites."
+          action={{ label: "Browse skills", href: "/skills" }}
+        />
+      ) : activeView === "grid" ? (
+        <div className="stars-grid">
+          {skills.map((skill) => {
+            const ownerId = String(skill.ownerPublisherId ?? skill.ownerUserId);
+            const href = `/${encodeURIComponent(ownerId)}/${encodeURIComponent(skill.slug)}`;
+            return (
+              <div key={skill._id} className="stars-card-shell">
+                <SkillCard
+                  skill={skill}
+                  href={href}
+                  badge={getSkillBadges(skill)}
+                  summaryFallback="Agent-ready skill pack."
+                  meta={<SkillStatsTripletLine stats={skill.stats} />}
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    handleUnstar(skill);
+                  }}
+                  aria-label={`Unstar ${skill.displayName}`}
+                  className="stars-card-unstar text-[color:var(--gold)] hover:text-red-500"
+                >
+                  <Star className="h-4 w-4 fill-current" />
+                </Button>
+              </div>
+            );
+          })}
         </div>
-      </div>
+      ) : (
+        <div className="results-list">
+          {skills.map((skill) => (
+            <div key={skill._id} className="relative">
+              <SkillListItem skill={skill} />
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  handleUnstar(skill);
+                }}
+                aria-label={`Unstar ${skill.displayName}`}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-[color:var(--gold)] hover:text-red-500"
+              >
+                <Star className="h-4 w-4 fill-current" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
     </main>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -2367,6 +2367,101 @@ code {
   max-width: 100%;
 }
 
+.stars-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 16px;
+}
+
+.stars-header-title {
+  min-width: 0;
+}
+
+.stars-header-controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  min-width: 0;
+}
+
+.stars-sort-trigger {
+  width: 168px;
+}
+
+.stars-view-tabs .publisher-filter-tab {
+  width: 34px;
+  height: 34px;
+  justify-content: center;
+  padding: 0;
+}
+
+.stars-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  max-width: 100%;
+}
+
+.stars-card-shell {
+  position: relative;
+  min-width: 0;
+}
+
+.stars-card-shell .skill-card {
+  height: 100%;
+}
+
+.stars-card-shell .skill-card-footer {
+  padding-right: 44px;
+}
+
+.stars-card-unstar {
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+  z-index: 1;
+}
+
+@media (max-width: 1024px) {
+  .stars-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .stars-header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .stars-header-title {
+    font-size: var(--fs-2xl);
+    line-height: 1.1;
+  }
+
+  .stars-header-controls {
+    display: block;
+    width: 100%;
+  }
+
+  .stars-sort-trigger {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .stars-view-tabs {
+    display: none;
+  }
+
+  .stars-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 .skills-header-top {
   margin-bottom: 22px;
 }


### PR DESCRIPTION
## Summary

- What changed: Polished `/stars` with the shared signed-out treatment, `Your highlights` header, grid/list controls, client-side sorting, SkillCard/ListItem layouts, and optimistic unstar behavior.
- Why: The highlights page now matches the visual patterns used by settings, publishers, and skills while keeping the starred query small.

## Linked Issue

- Closes N/A
- Related N/A

## Screenshots

For website/UI changes, attach screenshots or recordings from the real app. Include mobile/narrow views when layout changes.

- [x] Screenshots/recordings attached, or `N/A`

| Grid | List | Sorting |
| --- | --- | --- |
| ![Stars grid](https://i.imgur.com/HLLhv88.png) | ![Stars list](https://i.imgur.com/oUJMJlP.png) | ![Stars sorting dropdown](https://i.imgur.com/xywrjZ9.png) |

## Security / Trust Impact

- [x] No security/trust impact
- [ ] Security/trust impact explained

## Data / Deploy Impact

- [x] No data/deploy impact
- [ ] Data/deploy impact explained

## Verification

- [x] `bun run format:check`
- [x] `bun run lint`
- [ ] `bun run test`
- [x] Other: `bunx vitest run src/routes/-stars.test.tsx`
- [x] Other: `bunx tsc --noEmit --pretty false`
- [x] Other: `VITE_CONVEX_URL=https://example.invalid bun run build`
- [x] Other: `codex review --uncommitted`
- [x] Other: manual local smoke of `/stars` sign-in, grid/list, sorting, and optimistic unstar

