### PR TITLE
Show full skill descriptions on detail pages

### DIFF
--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -1417,6 +1417,7 @@ type PublicSkillListVersion = Pick<
 
 type PublicSkillVersionParsed = {
   license?: typeof PLATFORM_SKILL_LICENSE;
+  description?: string;
   clawdis?: {
     os?: string[];
     nix?: {
@@ -1633,6 +1634,9 @@ function toPublicSkillVersion(
   version: Doc<"skillVersions"> | null | undefined,
 ): PublicSkillVersion | null {
   if (!version) return null;
+  const description = version.parsed?.frontmatter
+    ? getFrontmatterValue(version.parsed.frontmatter, "description")?.trim()
+    : undefined;
   return {
     _id: version._id,
     _creationTime: version._creationTime,
@@ -1650,6 +1654,7 @@ function toPublicSkillVersion(
     parsed: version.parsed
       ? {
           license: version.parsed.license,
+          ...(description ? { description } : {}),
           clawdis: version.parsed.clawdis,
         }
       : undefined,

--- a/convex/skills.versions.public.test.ts
+++ b/convex/skills.versions.public.test.ts
@@ -72,7 +72,7 @@ function makeVersion() {
       },
     ],
     parsed: {
-      frontmatter: { secret: "value" },
+      frontmatter: { description: "Full uploaded description", secret: "value" },
       metadata: { hidden: true },
       clawdis: { os: ["macos"] },
       moltbot: { prompt: "hidden" },
@@ -196,6 +196,7 @@ describe("public skill version queries", () => {
     expect(result?.latestVersion?.files[0]).not.toHaveProperty("storageId");
     expect(result?.latestVersion?.parsed).toEqual({
       clawdis: { os: ["macos"] },
+      description: "Full uploaded description",
       license: "MIT-0",
     });
     expect(result?.latestVersion?.staticScan?.findings?.[0]?.evidence).toBe("");
@@ -249,6 +250,7 @@ describe("public skill version queries", () => {
       expect(result?.parsed).not.toHaveProperty("frontmatter");
       expect(result?.parsed).not.toHaveProperty("metadata");
       expect(result?.parsed).not.toHaveProperty("moltbot");
+      expect(result?.parsed?.description).toBe("Full uploaded description");
       expect(result?.staticScan?.findings?.[0]?.evidence).toBe("");
     }
   });

--- a/src/components/SkillHeader.test.tsx
+++ b/src/components/SkillHeader.test.tsx
@@ -105,4 +105,54 @@ describe("SkillHeader", () => {
     expect(screen.getByText("2")).toBeTruthy();
     expect(container.querySelector('a[href="/p/local"]')).toBeTruthy();
   });
+
+  it("shows the latest version description instead of the short catalog summary", () => {
+    renderHeader({
+      latestVersion: {
+        _id: "skillVersions:demo" as Id<"skillVersions">,
+        _creationTime: 1,
+        skillId: skill._id,
+        version: "1.0.0",
+        changelog: "Initial release",
+        files: [],
+        parsed: {
+          description:
+            "Full uploaded description with more operational context than the short summary.",
+          frontmatter: {},
+        },
+        createdBy: "users:owner" as Id<"users">,
+        createdAt: 1,
+      },
+    });
+
+    expect(
+      screen.getByText(
+        "Full uploaded description with more operational context than the short summary.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText("Demo summary")).toBeNull();
+  });
+
+  it("falls back to legacy parsed frontmatter description when present", () => {
+    renderHeader({
+      latestVersion: {
+        _id: "skillVersions:demo" as Id<"skillVersions">,
+        _creationTime: 1,
+        skillId: skill._id,
+        version: "1.0.0",
+        changelog: "Initial release",
+        files: [],
+        parsed: {
+          frontmatter: {
+            description: "Legacy full description from parsed frontmatter.",
+          },
+        },
+        createdBy: "users:owner" as Id<"users">,
+        createdAt: 1,
+      },
+    });
+
+    expect(screen.getByText("Legacy full description from parsed frontmatter.")).toBeTruthy();
+    expect(screen.queryByText("Demo summary")).toBeNull();
+  });
 });

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -42,11 +42,28 @@ type SkillCanonical = {
   owner: { handle: string | null; userId: Id<"users"> | null };
 };
 
+type SkillHeaderLatestVersion =
+  | (Omit<Doc<"skillVersions">, "parsed"> & {
+      parsed?: (Partial<Doc<"skillVersions">["parsed"]> & { description?: string }) | null;
+    })
+  | null;
+
+function getLatestVersionDescription(latestVersion: SkillHeaderLatestVersion) {
+  const parsed = latestVersion?.parsed;
+  const description =
+    typeof parsed?.description === "string"
+      ? parsed.description
+      : typeof parsed?.frontmatter?.description === "string"
+        ? parsed.frontmatter.description
+        : null;
+  return description?.trim() || null;
+}
+
 type SkillHeaderProps = {
   skill: Doc<"skills"> | PublicSkill;
   owner: PublicPublisher | null;
   ownerHandle: string | null;
-  latestVersion: Doc<"skillVersions"> | null;
+  latestVersion: SkillHeaderLatestVersion;
   modInfo: SkillModerationInfo | null;
   canManage: boolean;
   isAuthenticated: boolean;
@@ -116,6 +133,8 @@ export function SkillHeader({
   const badges = getSkillBadges(skill);
   const showHeroMeta = Boolean((forkOf && forkOfHref) || canonicalHref);
   const showTitleBadges = badges.length > 0;
+  const headerDescription =
+    getLatestVersionDescription(latestVersion) ?? skill.summary ?? "No summary provided.";
 
   return (
     <>
@@ -268,9 +287,7 @@ export function SkillHeader({
                 {nixPlugin ? <Badge variant="accent">Plugin bundle (nix)</Badge> : null}
               </div>
               <div className="skill-summary-block">
-                <p className="section-subtitle skill-summary-line">
-                  {skill.summary ?? "No summary provided."}
-                </p>
+                <p className="section-subtitle skill-summary-line">{headerDescription}</p>
               </div>
 
               {nixPlugin ? (
@@ -398,7 +415,7 @@ function SkillSidebarStats({
   owner: PublicPublisher | null;
   ownerHandle: string | null;
   formattedStats: ReturnType<typeof formatSkillStatsTriplet>;
-  latestVersion: Doc<"skillVersions"> | null;
+  latestVersion: SkillHeaderLatestVersion;
 }) {
   const versionCount = skill.stats.versions ?? 0;
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -2354,10 +2354,6 @@ code {
 
 .skill-summary-line {
   margin-bottom: 0;
-  display: -webkit-box;
-  overflow: hidden;
-  -webkit-line-clamp: 5;
-  -webkit-box-orient: vertical;
 }
 
 .grid {


### PR DESCRIPTION
## Summary
- expose uploaded frontmatter descriptions on public latest-version payloads without leaking raw frontmatter
- render the full uploaded description in the skill detail header while keeping short summaries for catalog surfaces
- remove the detail-header summary clamp and add backend/UI regression tests for the description path

## Tests
- `VITE_CONVEX_URL=https://example.invalid bun run test src/components/SkillHeader.test.tsx convex/skills.versions.public.test.ts`
- `bun run format:check`
- `bun run lint`
- `VITE_CONVEX_URL=https://example.invalid bunx tsc --noEmit`
