### PR TITLE
fix: clarify skill summary settings copy

### DIFF
--- a/src/components/SkillOwnershipPanel.tsx
+++ b/src/components/SkillOwnershipPanel.tsx
@@ -183,8 +183,8 @@ export function SkillOwnershipPanel({
         </SettingsActionRow>
 
         <SettingsActionRow
-          title="Description"
-          description="Update the short description shown on the skill detail page."
+          title="Short summary"
+          description="Update the short summary used in cards, search, and previews."
         >
           {onSaveSummary ? (
             <SummarySettingsEditor summary={summary} onSaveSummary={onSaveSummary} />


### PR DESCRIPTION
## Summary
- Rename the skill settings description field to "Short summary"
- Clarify that the field affects cards, search, and previews rather than the uploaded skill description

## Tests
- bun run ci:static
