### PR TITLE
fix: show plugin settings action to managers

### DIFF
--- a/convex/clawScanNoteUpdates.test.ts
+++ b/convex/clawScanNoteUpdates.test.ts
@@ -187,4 +187,42 @@ describe("publisher ClawScan note updates", () => {
       }),
     );
   });
+
+  it("allows platform moderators to update latest skill publisher notes", async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:moderator",
+      user: { _id: "users:moderator", role: "moderator" },
+    } as never);
+    const { db, version } = createDb();
+    const scheduler = { runAfter: vi.fn(async () => undefined) };
+
+    await updateSkillClawScanNoteAndRequestRescanHandler({ db, scheduler } as never, {
+      skillId: "skills:1",
+      clawScanNote: "Moderator context.",
+    });
+
+    expect(version).toMatchObject({
+      clawScanNote: "Moderator context.",
+      clawScanNoteUpdatedAt: expect.any(Number),
+    });
+  });
+
+  it("allows platform moderators to update latest plugin publisher notes", async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:moderator",
+      user: { _id: "users:moderator", role: "moderator" },
+    } as never);
+    const { db, release } = createDb();
+    const scheduler = { runAfter: vi.fn(async () => undefined) };
+
+    await updatePackageClawScanNoteAndRequestRescanHandler({ db, scheduler } as never, {
+      packageId: "packages:1",
+      clawScanNote: "Moderator plugin context.",
+    });
+
+    expect(release).toMatchObject({
+      clawScanNote: "Moderator plugin context.",
+      clawScanNoteUpdatedAt: expect.any(Number),
+    });
+  });
 });

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -1497,7 +1497,7 @@ export const getClawScanNoteSettings = query({
 
     const actor = await ctx.db.get(viewerUserId);
     if (!actor || actor.deletedAt || actor.deactivatedAt) return null;
-    if (actor.role !== "admin") {
+    if (actor.role !== "admin" && actor.role !== "moderator") {
       const canAccess = await viewerCanManagePackageOwner(ctx, pkg, viewerUserId);
       if (!canAccess) return null;
     }
@@ -5511,7 +5511,7 @@ export const updateLatestClawScanNoteAndRequestRescan = mutation({
       actor: user,
       ownerUserId: pkg.ownerUserId,
       ownerPublisherId: pkg.ownerPublisherId,
-      allowPlatformAdmin: true,
+      allowPlatformModerator: true,
     });
 
     const now = Date.now();

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -5793,7 +5793,7 @@ export const updateLatestClawScanNoteAndRequestRescan = mutation({
       actor: user,
       ownerUserId: skill.ownerUserId,
       ownerPublisherId: skill.ownerPublisherId,
-      allowPlatformAdmin: true,
+      allowPlatformModerator: true,
     });
 
     const now = Date.now();

--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -175,6 +175,45 @@ describe("plugin detail route", () => {
     expect(screen.queryByRole("link", { name: "Download zip" })).toBeNull();
   });
 
+  it("shows plugin settings when the viewer can manage the plugin", async () => {
+    useAuthStatusMock.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      me: { _id: "users:1", role: "moderator" },
+    });
+    useQueryMock.mockReturnValue({
+      package: { _id: "packages:1", name: "demo-plugin", displayName: "Demo Plugin" },
+      latestRelease: { _id: "packageReleases:1" },
+    });
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    expect(screen.getByRole("link", { name: /settings/i }).getAttribute("href")).toBe(
+      "/plugins/demo-plugin/settings",
+    );
+    expect(useQueryMock).toHaveBeenCalledWith(expect.anything(), {
+      name: "demo-plugin",
+      candidateNames: ["@openclaw/demo-plugin", "demo-plugin"],
+    });
+  });
+
+  it("hides plugin settings when the viewer cannot manage the plugin", async () => {
+    useAuthStatusMock.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      me: { _id: "users:1", role: "user" },
+    });
+    useQueryMock.mockReturnValue(null);
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    expect(screen.queryByRole("link", { name: /settings/i })).toBeNull();
+  });
+
   it("renders package security scan results when scan data is present", async () => {
     loaderDataMock = {
       detail: loaderDataMock.detail,

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -664,6 +664,9 @@ describe("SkillDetailPage", () => {
 
     expect(screen.queryByText(/Loading skill/i)).toBeNull();
     expect(screen.getAllByText("Weather").length).toBeGreaterThan(0);
+    expect(screen.getByRole("link", { name: /settings/i }).getAttribute("href")).toBe(
+      "/SteiPete/weather/settings",
+    );
     expect(navigateMock).not.toHaveBeenCalled();
   });
 

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -9,7 +9,7 @@ import { api } from "../../convex/_generated/api";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
 import { getUserFacingAuthError } from "../lib/authErrorMessage";
 import { getUserFacingConvexError } from "../lib/convexError";
-import { canManageSkill, isAdmin, isModerator } from "../lib/roles";
+import { canManageSkill, isModerator } from "../lib/roles";
 import type { SkillBySlugResult, SkillPageInitialData } from "../lib/skillPage";
 import { clearAuthError, setAuthError } from "../lib/useAuthError";
 import { useAuthStatus } from "../lib/useAuthStatus";
@@ -262,7 +262,7 @@ export function SkillDetailPage({
     Boolean(skill?.ownerPublisherId && myPublisherIds.has(skill.ownerPublisherId));
   const canAccessSettings =
     Boolean(me && skill && me._id === skill.ownerUserId) ||
-    isAdmin(me) ||
+    isStaff ||
     Boolean(skill?.ownerPublisherId && myManagePublisherIds.has(skill.ownerPublisherId));
   const ownedSkills = useQuery(
     api.skills.list,
@@ -620,7 +620,8 @@ export function SkillDetailPage({
               <Card>
                 <h2 className="section-title text-[1.2rem] m-0">Settings unavailable</h2>
                 <p className="section-subtitle mt-3 mb-0">
-                  Only the skill owner can manage these settings.
+                  Only the skill owner, an owner org admin, or platform staff can manage these
+                  settings.
                 </p>
               </Card>
             )}

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute, Link, Outlet, redirect, useRouterState } from "@tanstack/react-router";
-import { AlertTriangle, Download } from "lucide-react";
+import { useQuery } from "convex/react";
+import { AlertTriangle, Download, Settings } from "lucide-react";
 import { useState, type ReactNode } from "react";
+import { api } from "../../../convex/_generated/api";
 import { DetailHero, DetailPageShell } from "../../components/DetailPageShell";
 import { DetailSecuritySummary } from "../../components/DetailSecuritySummary";
 import { EmptyState } from "../../components/EmptyState";
@@ -30,6 +32,7 @@ import {
   buildPluginSecurityBaseHref,
   parseScopedPackageName,
 } from "../../lib/pluginRoutes";
+import { useAuthStatus } from "../../lib/useAuthStatus";
 
 type PluginDetailRateLimitState = {
   scope: "detail" | "metadata";
@@ -321,6 +324,16 @@ export function PluginDetailPage({
 }) {
   const { detail, version, readme, rateLimited } = loaderData;
   const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const { isAuthenticated } = useAuthStatus();
+  const isNestedPluginRoute = pathname.includes("/security/") || pathname.endsWith("/settings");
+  const settingsCandidateNames = getOpenClawPackageCandidateNames(name);
+  const settingsLookupName = detail.package?.name ?? settingsCandidateNames[0] ?? name;
+  const settings = useQuery(
+    api.packages.getClawScanNoteSettings,
+    isAuthenticated && !isNestedPluginRoute && detail.package
+      ? { name: settingsLookupName, candidateNames: settingsCandidateNames }
+      : "skip",
+  );
   const [activeTab, setActiveTab] = useState<PluginDetailTab>(() => {
     if (typeof window === "undefined") return "readme";
     const hash = window.location.hash.replace("#", "");
@@ -328,7 +341,7 @@ export function PluginDetailPage({
       ? hash
       : "readme";
   });
-  if (pathname.includes("/security/") || pathname.endsWith("/settings")) {
+  if (isNestedPluginRoute) {
     return <Outlet />;
   }
 
@@ -388,6 +401,7 @@ export function PluginDetailPage({
     pkg.latestVersion && latestRelease?.version && artifact?.kind === "npm-pack"
       ? getPackageArtifactDownloadPath(pkg.name, latestRelease.version)
       : getPackageDownloadPath(pkg.name, pkg.latestVersion);
+  const settingsHref = settings ? `${buildPluginDetailHref(pkg.name)}/settings` : null;
   const capEntries = capabilities
     ? Object.entries(capabilities).filter(
         ([, v]) =>
@@ -599,9 +613,19 @@ export function PluginDetailPage({
               </nav>
               <div className="skill-hero-title-row">
                 <h1 className="skill-page-title">{pkg.displayName}</h1>
-                {isDownloadBlocked ? (
+                {settingsHref || isDownloadBlocked ? (
                   <div className="skill-title-actions">
-                    <Badge variant="destructive">Download blocked</Badge>
+                    {settingsHref ? (
+                      <Button asChild variant="outline" size="sm" className="skill-settings-link">
+                        <a href={settingsHref}>
+                          <Settings size={14} aria-hidden="true" />
+                          Settings
+                        </a>
+                      </Button>
+                    ) : null}
+                    {isDownloadBlocked ? (
+                      <Badge variant="destructive">Download blocked</Badge>
+                    ) : null}
                   </div>
                 ) : null}
               </div>

--- a/src/routes/plugins/$name/settings.tsx
+++ b/src/routes/plugins/$name/settings.tsx
@@ -69,7 +69,8 @@ export function PluginSettingsPage({ name }: { name: string }) {
             <Card>
               <h2 className="section-title text-[1.2rem] m-0">Settings unavailable</h2>
               <p className="section-subtitle mt-3 mb-0">
-                Only the plugin publisher can manage these settings.
+                Only the plugin publisher, an owner org admin, or platform staff can manage these
+                settings.
               </p>
             </Card>
           </DetailBody>


### PR DESCRIPTION
## Summary

- Add a Settings action to plugin detail pages when the current viewer can manage the plugin.
- Reuse the existing plugin settings permission query so admins and publisher managers see the same access the settings page grants.
- Cover visible and hidden settings states in the plugin detail route test.

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run vitest run src/__tests__/package-detail-route.test.tsx`
- `bunx tsc --noEmit`
