### PR TITLE
fix: move plugin settings action into sidebar

### DIFF
--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -185,14 +185,49 @@ describe("plugin detail route", () => {
       package: { _id: "packages:1", name: "demo-plugin", displayName: "Demo Plugin" },
       latestRelease: { _id: "packageReleases:1" },
     });
+    loaderDataMock = {
+      detail: {
+        package: {
+          ...loaderDataMock.detail.package!,
+          latestVersion: "1.0.0",
+        },
+        owner: null,
+      },
+      version: {
+        package: {
+          name: "demo-plugin",
+          displayName: "Demo Plugin",
+          family: "code-plugin",
+        },
+        version: {
+          version: "1.0.0",
+          createdAt: 1,
+          changelog: "Initial release",
+          distTags: ["latest"],
+          files: [],
+          compatibility: null,
+          capabilities: null,
+          verification: null,
+          sha256hash: null,
+          vtAnalysis: null,
+          llmAnalysis: null,
+          staticScan: null,
+        },
+      },
+      readme: null,
+      rateLimited: null,
+    };
     const route = await loadRoute();
     const Component = route.__config.component as ComponentType;
 
     render(<Component />);
 
-    expect(screen.getByRole("link", { name: /settings/i }).getAttribute("href")).toBe(
-      "/plugins/demo-plugin/settings",
-    );
+    const downloadLink = screen.getByRole("link", { name: /download/i });
+    const settingsLink = screen.getByRole("link", { name: /settings/i });
+    expect(settingsLink.getAttribute("href")).toBe("/plugins/demo-plugin/settings");
+    expect(
+      downloadLink.compareDocumentPosition(settingsLink) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     expect(useQueryMock).toHaveBeenCalledWith(expect.anything(), {
       name: "demo-plugin",
       candidateNames: ["@openclaw/demo-plugin", "demo-plugin"],

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -613,19 +613,9 @@ export function PluginDetailPage({
               </nav>
               <div className="skill-hero-title-row">
                 <h1 className="skill-page-title">{pkg.displayName}</h1>
-                {settingsHref || isDownloadBlocked ? (
+                {isDownloadBlocked ? (
                   <div className="skill-title-actions">
-                    {settingsHref ? (
-                      <Button asChild variant="outline" size="sm" className="skill-settings-link">
-                        <a href={settingsHref}>
-                          <Settings size={14} aria-hidden="true" />
-                          Settings
-                        </a>
-                      </Button>
-                    ) : null}
-                    {isDownloadBlocked ? (
-                      <Badge variant="destructive">Download blocked</Badge>
-                    ) : null}
+                    <Badge variant="destructive">Download blocked</Badge>
                   </div>
                 ) : null}
               </div>
@@ -662,14 +652,24 @@ export function PluginDetailPage({
                 />
               ) : null}
 
-              {pkg.latestVersion && !isDownloadBlocked ? (
+              {(pkg.latestVersion && !isDownloadBlocked) || settingsHref ? (
                 <div className="skill-sidebar-actions">
-                  <Button asChild variant="outline" className="skill-sidebar-action-button">
-                    <a href={downloadPath}>
-                      <Download size={14} aria-hidden="true" />
-                      Download
-                    </a>
-                  </Button>
+                  {pkg.latestVersion && !isDownloadBlocked ? (
+                    <Button asChild variant="outline" className="skill-sidebar-action-button">
+                      <a href={downloadPath}>
+                        <Download size={14} aria-hidden="true" />
+                        Download
+                      </a>
+                    </Button>
+                  ) : null}
+                  {settingsHref ? (
+                    <Button asChild variant="outline" className="skill-sidebar-action-button">
+                      <a href={settingsHref}>
+                        <Settings size={14} aria-hidden="true" />
+                        Settings
+                      </a>
+                    </Button>
+                  ) : null}
                 </div>
               ) : null}
             </div>


### PR DESCRIPTION
## Summary

- Move the plugin Settings action out of the title row and into the sidebar action stack under Download.
- Keep the existing settings visibility policy from #2163.
- Add a regression assertion that Settings follows Download in document order.

## Validation

- `bun run vitest run src/__tests__/package-detail-route.test.tsx`
- `bun run format:check`
- `bun run lint`
- `bunx tsc --noEmit`
