### PR TITLE
feat(skills): allow publishers to pick a custom lucide icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   investigations have a complete ledger.
 - CLI/API: include skill owner handles in search results so duplicate/common
   slugs are easier to disambiguate (thanks @vyctorbrzezowski).
-- Web: let skill publishers pick a curated lucide icon for cards and listings (#2174).
+- Web: let skill publishers pick a curated lucide icon for cards and listings (#2174) (thanks @momothemage).
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   investigations have a complete ledger.
 - CLI/API: include skill owner handles in search results so duplicate/common
   slugs are easier to disambiguate (thanks @vyctorbrzezowski).
+- Web: let skill publishers pick a curated lucide icon for cards and listings (#2174).
 
 ### Fixes
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -88,6 +88,7 @@ import type * as lib_searchText from "../lib/searchText.js";
 import type * as lib_securityPrompt from "../lib/securityPrompt.js";
 import type * as lib_skillBackfill from "../lib/skillBackfill.js";
 import type * as lib_skillCapabilityTags from "../lib/skillCapabilityTags.js";
+import type * as lib_skillIcon from "../lib/skillIcon.js";
 import type * as lib_skillPublish from "../lib/skillPublish.js";
 import type * as lib_skillQuality from "../lib/skillQuality.js";
 import type * as lib_skillSafety from "../lib/skillSafety.js";
@@ -218,6 +219,7 @@ declare const fullApi: ApiFromModules<{
   "lib/securityPrompt": typeof lib_securityPrompt;
   "lib/skillBackfill": typeof lib_skillBackfill;
   "lib/skillCapabilityTags": typeof lib_skillCapabilityTags;
+  "lib/skillIcon": typeof lib_skillIcon;
   "lib/skillPublish": typeof lib_skillPublish;
   "lib/skillQuality": typeof lib_skillQuality;
   "lib/skillSafety": typeof lib_skillSafety;

--- a/convex/lib/public.ts
+++ b/convex/lib/public.ts
@@ -18,6 +18,7 @@ export type PublicSkill = Pick<
   | "slug"
   | "displayName"
   | "summary"
+  | "icon"
   | "ownerUserId"
   | "ownerPublisherId"
   | "canonicalSkillId"
@@ -45,6 +46,7 @@ export type HydratableSkill = Pick<
   | "slug"
   | "displayName"
   | "summary"
+  | "icon"
   | "ownerUserId"
   | "ownerPublisherId"
   | "canonicalSkillId"
@@ -139,6 +141,7 @@ export function toPublicSkill(skill: HydratableSkill | null | undefined): Public
     slug: skill.slug,
     displayName: skill.displayName,
     summary: skill.summary,
+    icon: skill.icon,
     ownerUserId: skill.ownerUserId,
     ownerPublisherId: skill.ownerPublisherId,
     canonicalSkillId: skill.canonicalSkillId,

--- a/convex/lib/skillIcon.test.ts
+++ b/convex/lib/skillIcon.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSkillIconValue } from "./skillIcon";
+
+describe("normalizeSkillIconValue", () => {
+  it("returns undefined for non-string input", () => {
+    expect(normalizeSkillIconValue(undefined)).toBeUndefined();
+    expect(normalizeSkillIconValue(null)).toBeUndefined();
+    expect(normalizeSkillIconValue(42)).toBeUndefined();
+    expect(normalizeSkillIconValue({})).toBeUndefined();
+    expect(normalizeSkillIconValue([])).toBeUndefined();
+  });
+
+  it("treats blank strings as unset (also clears the field on republish)", () => {
+    expect(normalizeSkillIconValue("")).toBeUndefined();
+    expect(normalizeSkillIconValue("   ")).toBeUndefined();
+    expect(normalizeSkillIconValue("\t\n")).toBeUndefined();
+  });
+
+  it("rejects strings without a protocol prefix", () => {
+    expect(normalizeSkillIconValue("Plug")).toBeUndefined();
+    expect(normalizeSkillIconValue(":Plug")).toBeUndefined();
+    expect(normalizeSkillIconValue("lucide")).toBeUndefined();
+    expect(normalizeSkillIconValue("lucide:")).toBeUndefined();
+  });
+
+  it("normalizes the protocol to lower-case while preserving the icon name casing", () => {
+    expect(normalizeSkillIconValue("lucide:Plug")).toBe("lucide:Plug");
+    expect(normalizeSkillIconValue("LUCIDE:Plug")).toBe("lucide:Plug");
+    expect(normalizeSkillIconValue("Lucide:FileText")).toBe("lucide:FileText");
+  });
+
+  it("trims surrounding whitespace before parsing", () => {
+    expect(normalizeSkillIconValue("  lucide:Plug  ")).toBe("lucide:Plug");
+  });
+
+  it("rejects malformed lucide icon names", () => {
+    expect(normalizeSkillIconValue("lucide:plug-icon")).toBeUndefined();
+    expect(normalizeSkillIconValue("lucide:1Plug")).toBeUndefined();
+    expect(normalizeSkillIconValue("lucide:Plug Icon")).toBeUndefined();
+    expect(normalizeSkillIconValue("lucide:Plug.svg")).toBeUndefined();
+  });
+
+  it("accepts valid lucide names of mixed casing and digits", () => {
+    expect(normalizeSkillIconValue("lucide:Code2")).toBe("lucide:Code2");
+    expect(normalizeSkillIconValue("lucide:abc")).toBe("lucide:abc");
+    expect(normalizeSkillIconValue("lucide:ABC")).toBe("lucide:ABC");
+  });
+
+  it("rejects unknown protocols (phase 1 only ships lucide)", () => {
+    expect(normalizeSkillIconValue("url:https://example.com/icon.png")).toBeUndefined();
+    expect(normalizeSkillIconValue("storage:abc123")).toBeUndefined();
+    expect(normalizeSkillIconValue("emoji:🦾")).toBeUndefined();
+  });
+
+  it("rejects values that exceed the storage length budget", () => {
+    const longName = "A".repeat(60);
+    expect(normalizeSkillIconValue(`lucide:${longName}`)).toBeUndefined();
+  });
+});

--- a/convex/lib/skillIcon.ts
+++ b/convex/lib/skillIcon.ts
@@ -1,0 +1,45 @@
+/**
+ * Skill icon storage format: a `kind:value` protocol string.
+ *
+ * Phase 1 only ships the `lucide:<IconName>` source. Future phases that add
+ * external URLs or Convex Storage uploads can reuse the same field without a
+ * schema change.
+ *
+ * The server performs only minimal format validation and does not maintain
+ * the concrete lucide allow-list — `src/lib/skillIcon.ts` on the client owns
+ * the render whitelist. When the client cannot resolve an icon it falls back
+ * to the default kind icon, so we accept any well-formed identifier here to
+ * avoid coupling backend deploys to client-side constants.
+ */
+
+const MAX_ICON_VALUE_LENGTH = 64;
+const LUCIDE_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9]*$/;
+
+/**
+ * Parse and sanitize the icon string supplied at publish time.
+ * - Non-string or blank input: returns `undefined` (treated as unset).
+ * - Unknown protocol or malformed value: returns `undefined` (same as unset).
+ * - Valid `lucide:<Name>`: returns a normalized string with a lower-cased
+ *   protocol prefix and the original-case icon name preserved.
+ */
+export function normalizeSkillIconValue(input: unknown): string | undefined {
+  if (typeof input !== "string") return undefined;
+  const trimmed = input.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.length > MAX_ICON_VALUE_LENGTH) return undefined;
+
+  const colonIndex = trimmed.indexOf(":");
+  if (colonIndex <= 0) return undefined;
+
+  const kind = trimmed.slice(0, colonIndex).toLowerCase();
+  const value = trimmed.slice(colonIndex + 1);
+  if (!value) return undefined;
+
+  if (kind === "lucide") {
+    return LUCIDE_NAME_PATTERN.test(value) ? `lucide:${value}` : undefined;
+  }
+
+  // Phase 1 does not expose other protocols; extend here when adding
+  // url / storage support.
+  return undefined;
+}

--- a/convex/lib/skillPublish.ts
+++ b/convex/lib/skillPublish.ts
@@ -54,6 +54,8 @@ export type PublishResult = {
 export type PublishVersionArgs = {
   slug: string;
   displayName: string;
+  /** Optional icon hint (e.g. `lucide:Plug`). Server validates the format. */
+  icon?: string;
   version: string;
   changelog: string;
   clawScanNote?: string;
@@ -310,6 +312,7 @@ export async function publishVersionForUser(
     migrateOwner: options.migrateOwner,
     slug,
     displayName,
+    icon: args.icon,
     version,
     changelog: changelogText,
     clawScanNote: clawScanNote || undefined,

--- a/convex/lib/skillSearchDigest.ts
+++ b/convex/lib/skillSearchDigest.ts
@@ -18,6 +18,7 @@ const SHARED_KEYS = [
   "slug",
   "displayName",
   "summary",
+  "icon",
   "ownerUserId",
   "ownerPublisherId",
   "canonicalSkillId",

--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -737,6 +737,118 @@ describe("publishers membership controls", () => {
     ]);
   });
 
+  it("includes skill.icon on catalog items and surfaces null for plugins (F7)", async () => {
+    // Regression guard for F2: listPublishedPage must mirror `skills.icon`
+    // onto the catalog DTO so the publisher profile page (/p/<handle>) can
+    // render the same custom glyph that SkillCard / SkillListItem show on
+    // /skills and /search. Plugins always carry `icon: null` in Phase 1.
+    const publisher = {
+      _id: "publishers:openclaw",
+      _creationTime: 1,
+      kind: "org",
+      handle: "openclaw",
+      displayName: "OpenClaw",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => (id === "publishers:openclaw" ? publisher : null)),
+        query: vi.fn((table: string) => ({
+          withIndex: vi.fn((indexName: string, buildQuery: (q: unknown) => unknown) => {
+            const fields: Record<string, unknown> = {};
+            const q = {
+              eq: (field: string, value: unknown) => {
+                fields[field] = value;
+                return q;
+              },
+            };
+            buildQuery(q);
+            if (table === "publishers" && indexName === "by_handle") {
+              return {
+                unique: vi.fn(async () => (fields.handle === "openclaw" ? publisher : null)),
+              };
+            }
+            if (table === "skills" && indexName === "by_owner_publisher_active_updated") {
+              return indexedRows([
+                {
+                  _id: "skills:icon-skill",
+                  ownerPublisherId: "publishers:openclaw",
+                  softDeletedAt: undefined,
+                  slug: "icon-skill",
+                  displayName: "Icon Skill",
+                  summary: "Has a custom icon",
+                  icon: "lucide:Plug",
+                  stats: {
+                    downloads: 10,
+                    downloadsAllTime: 10,
+                    installs: 5,
+                    installsAllTime: 5,
+                    stars: 2,
+                  },
+                  updatedAt: 8,
+                },
+                {
+                  _id: "skills:plain-skill",
+                  ownerPublisherId: "publishers:openclaw",
+                  softDeletedAt: undefined,
+                  slug: "plain-skill",
+                  displayName: "Plain Skill",
+                  summary: "No icon set",
+                  // icon intentionally absent — must surface as null on the DTO
+                  stats: {
+                    downloads: 7,
+                    downloadsAllTime: 7,
+                    installs: 3,
+                    installsAllTime: 3,
+                    stars: 1,
+                  },
+                  updatedAt: 6,
+                },
+              ]);
+            }
+            if (table === "packages" && indexName === "by_owner_publisher_active_updated") {
+              return indexedRows([
+                {
+                  _id: "packages:plugin",
+                  ownerPublisherId: "publishers:openclaw",
+                  softDeletedAt: undefined,
+                  family: "code-plugin",
+                  name: "@openclaw/example-plugin",
+                  displayName: "Example Plugin",
+                  summary: "A plugin",
+                  stats: { downloads: 5, installs: 2, stars: 0, versions: 1 },
+                  updatedAt: 4,
+                },
+              ]);
+            }
+            throw new Error(`unexpected ${table} index ${indexName}`);
+          }),
+        })),
+      },
+    };
+
+    const result = (await listPublishedPageHandler(ctx as never, {
+      handle: "openclaw",
+      paginationOpts: { cursor: null, numItems: 12 },
+    })) as {
+      page: Array<{
+        displayName: string;
+        kind: "skill" | "plugin";
+        icon: string | null;
+      }>;
+    };
+
+    const byName = Object.fromEntries(result.page.map((item) => [item.displayName, item]));
+    // Skill with a stored icon must surface it on the DTO.
+    expect(byName["Icon Skill"]).toMatchObject({ kind: "skill", icon: "lucide:Plug" });
+    // Skill without an icon must surface null (not undefined) so the client
+    // type is uniform and MarketplaceIcon can safely pass it to parseSkillIcon.
+    expect(byName["Plain Skill"]).toMatchObject({ kind: "skill", icon: null });
+    // Plugins always carry null in Phase 1.
+    expect(byName["Example Plugin"]).toMatchObject({ kind: "plugin", icon: null });
+  });
+
   it("prevents admins from promoting members to owner", async () => {
     vi.mocked(getAuthUserId).mockResolvedValue("users:admin" as never);
     const ctx = {

--- a/convex/publishers.ts
+++ b/convex/publishers.ts
@@ -44,6 +44,11 @@ type PublisherCatalogItem = {
   kind: "skill" | "plugin";
   displayName: string;
   summary: string | null;
+  // Mirrors `skills.icon` for `kind: "skill"` items so the publisher
+  // profile catalog (`/p/<handle>`) can render the same custom glyph that
+  // `SkillCard` and `SkillListItem` show on `/skills` and `/search`.
+  // Always `null` for plugins in Phase 1.
+  icon: string | null;
   href: string;
   downloads: number;
   stars: number;
@@ -258,6 +263,7 @@ function getPublisherCatalogItems(
       kind: "skill" as const,
       displayName: skill.displayName,
       summary: skill.summary ?? null,
+      icon: skill.icon ?? null,
       href: `/${encodeURIComponent(publisher.handle)}/${encodeURIComponent(skill.slug)}`,
       downloads: readCanonicalStat(skill, "downloads"),
       stars: readCanonicalStat(skill, "stars"),
@@ -268,6 +274,7 @@ function getPublisherCatalogItems(
       kind: "plugin" as const,
       displayName: pkg.displayName,
       summary: pkg.summary ?? null,
+      icon: null,
       href: buildPluginDetailHref(pkg.name),
       downloads: pkg.stats.downloads,
       stars: pkg.stats.stars,
@@ -932,6 +939,7 @@ export const listStarredPage = query({
             kind: "skill" as const,
             displayName: skill.displayName,
             summary: skill.summary ?? null,
+            icon: skill.icon ?? null,
             href: `/${encodeURIComponent(ownerHandle)}/${encodeURIComponent(skill.slug)}`,
             downloads: readCanonicalStat(skill, "downloads"),
             stars: readCanonicalStat(skill, "stars"),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -358,6 +358,7 @@ const skills = defineTable({
   slug: v.string(),
   displayName: v.string(),
   summary: v.optional(v.string()),
+  icon: v.optional(v.string()),
   resourceId: v.optional(v.string()),
   ownerUserId: v.id("users"),
   ownerPublisherId: v.optional(v.id("publishers")),
@@ -738,6 +739,9 @@ const skillSearchDigest = defineTable({
   normalizedDisplayName: v.optional(v.string()),
   normalizedDisplayNameFirstToken: v.optional(v.string()),
   summary: v.optional(v.string()),
+  // Mirrors `skills.icon`. Kept on the digest so card/list hydration paths
+  // can render the icon without reading the full skill row.
+  icon: v.optional(v.string()),
   ownerUserId: v.id("users"),
   ownerPublisherId: v.optional(v.id("publishers")),
   ownerHandle: v.optional(v.string()),

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -98,6 +98,7 @@ import {
   upsertReservedSlugForRightfulOwner,
 } from "./lib/reservedSlugs";
 import { SKILL_CAPABILITY_TAGS } from "./lib/skillCapabilityTags";
+import { normalizeSkillIconValue } from "./lib/skillIcon";
 import {
   fetchText,
   type PublishResult,
@@ -7085,6 +7086,10 @@ export const publishVersion: ReturnType<typeof action> = action({
     migrateOwner: v.optional(v.boolean()),
     slug: v.string(),
     displayName: v.string(),
+    // Skill icon hint chosen by the publisher in the publish form. Stored as
+    // a protocol-prefixed string (e.g. `lucide:Plug`). Unknown values are
+    // silently dropped server-side; see lib/skillIcon.ts.
+    icon: v.optional(v.string()),
     version: v.string(),
     changelog: v.string(),
     clawScanNote: v.optional(v.string()),
@@ -8732,6 +8737,9 @@ export const insertVersion = internalMutation({
     migrateOwner: v.optional(v.boolean()),
     slug: v.string(),
     displayName: v.string(),
+    // Skill icon hint chosen by the publisher (e.g. `lucide:Plug`). Optional;
+    // omitted on backport publishes to preserve the existing skill icon.
+    icon: v.optional(v.string()),
     version: v.string(),
     changelog: v.string(),
     clawScanNote: v.optional(v.string()),
@@ -9186,6 +9194,7 @@ export const insertVersion = internalMutation({
         slug,
         displayName: args.displayName,
         summary: summaryValue,
+        icon: normalizeSkillIconValue(args.icon),
         ownerUserId: userId,
         ownerPublisherId,
         canonicalSkillId,
@@ -9317,6 +9326,12 @@ export const insertVersion = internalMutation({
     // the same values that will actually be persisted. Otherwise we would
     // persist flags derived from text the user can never see on the card.
     const nextDisplayName = isNewLatest ? args.displayName : skill.displayName;
+    // Skill icon follows the same "only update on new latest" rule as
+    // displayName / summary so backport publishes can't surprise the card.
+    // Only update when the publisher explicitly picked one this time —
+    // omitting `args.icon` keeps the previously stored value.
+    const nextIcon =
+      isNewLatest && args.icon !== undefined ? normalizeSkillIconValue(args.icon) : skill.icon;
     const derivedFlags = deriveModerationFlags({
       skill: {
         slug: skill.slug,
@@ -9336,6 +9351,7 @@ export const insertVersion = internalMutation({
     const basePatch: SkillModerationPatch = {
       displayName: nextDisplayName,
       summary: nextSummary ?? undefined,
+      icon: nextIcon,
       ownerPublisherId: skill.ownerPublisherId ?? ownerPublisherId,
       latestVersionId: isNewLatest ? versionId : skill.latestVersionId,
       latestVersionSummary: isNewLatest

--- a/src/__tests__/skills-publish-route.test.tsx
+++ b/src/__tests__/skills-publish-route.test.tsx
@@ -1,17 +1,13 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { getFunctionName } from "convex/server";
 import { strToU8, zipSync } from "fflate";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Upload } from "../routes/skills/publish";
 
-let routeSearch: { updateSlug?: string; ownerHandle?: string } = {
-  updateSlug: undefined,
-  ownerHandle: undefined,
-};
-
 vi.mock("@tanstack/react-router", () => ({
   createFileRoute: () => (config: { component: unknown }) => config,
   useNavigate: () => vi.fn(),
-  useSearch: () => routeSearch,
+  useSearch: () => useSearchMock(),
 }));
 
 vi.mock("@convex-dev/auth/react", () => ({
@@ -24,6 +20,10 @@ const generateChangelogPreview = vi.fn();
 const fetchMock = vi.fn();
 const useQueryMock = vi.fn();
 const useAuthStatusMock = vi.fn();
+// Allows individual test cases to drive the value `useSearch` returns.
+// The `updateSlug` search param triggers the form's "update existing"
+// branch and is required by the F1 regression cases below.
+const useSearchMock = vi.fn();
 let useActionCallCount = 0;
 
 vi.mock("convex/react", () => ({
@@ -48,7 +48,8 @@ describe("Upload route", () => {
     fetchMock.mockReset();
     useQueryMock.mockReset();
     useAuthStatusMock.mockReset();
-    routeSearch = { updateSlug: undefined, ownerHandle: undefined };
+    useSearchMock.mockReset();
+    useSearchMock.mockReturnValue({ updateSlug: undefined, ownerHandle: undefined });
     useActionCallCount = 0;
     useAuthStatusMock.mockReturnValue({
       isAuthenticated: true,
@@ -411,7 +412,7 @@ describe("Upload route", () => {
   });
 
   it("uses the ownerHandle search param for the owner selector and slug availability", async () => {
-    routeSearch = { updateSlug: undefined, ownerHandle: "clawkit" };
+    useSearchMock.mockReturnValue({ updateSlug: undefined, ownerHandle: "clawkit" });
     useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
       if (args === "skip") return undefined;
       if (
@@ -552,5 +553,156 @@ describe("Upload route", () => {
     // the default state forwards an explicit empty string.
     expect(args).toHaveProperty("icon");
     expect(args?.icon).toBe("");
+  });
+
+  it("preserves the existing icon when republishing without touching the picker (F1)", async () => {
+    // Simulate a `New Version` flow: `?updateSlug=with-icon` is in the URL
+    // and the existing skill row carries `icon: \"lucide:Plug\"`.
+    useSearchMock.mockReturnValue({ updateSlug: "with-icon" });
+    useQueryMock.mockImplementation((fn: unknown, args: unknown) => {
+      if (args === "skip") return undefined;
+      // The convex `anyApi` proxy returns a fresh proxy on every property
+      // access, so reference equality on `api.skills.getBySlug` is unsafe.
+      // `getFunctionName` resolves the proxy to its stable string id
+      // (e.g. `"skills:getBySlug"`).
+      const name = fn ? getFunctionName(fn as Parameters<typeof getFunctionName>[0]) : "";
+      if (name === "skills:getBySlug") {
+        return {
+          skill: {
+            slug: "with-icon",
+            displayName: "With Icon",
+            icon: "lucide:Plug",
+          },
+          latestVersion: { version: "1.0.0", clawScanNote: null },
+          owner: { handle: "alice", displayName: "Alice" },
+        };
+      }
+      // checkSlugAvailability + listMine + everything else stays default.
+      return null;
+    });
+    generateUploadUrl.mockResolvedValue("https://upload.local");
+    publishVersion.mockResolvedValue(undefined);
+
+    render(<Upload />);
+
+    // The picker should be pre-populated to `Plug` from the stored value.
+    await waitFor(() => {
+      expect(screen.getByRole("radio", { name: "Plug" }).getAttribute("aria-checked")).toBe("true");
+    });
+
+    // Routine version bump, never touch the picker.
+    fireEvent.change(screen.getByPlaceholderText("1.0.0"), {
+      target: { value: "1.0.1" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("latest, stable"), {
+      target: { value: "latest" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Describe what changed in this skill..."), {
+      target: { value: "Routine bump." },
+    });
+
+    const file = new File(["hello"], "SKILL.md", { type: "text/markdown" });
+    const input = screen.getByTestId("upload-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+    fireEvent.click(
+      screen.getByRole("checkbox", {
+        name: /i have the rights to this skill and agree to publish it under mit-0/i,
+      }),
+    );
+
+    await screen.findByText(/All checks passed/i);
+    fireEvent.click(screen.getByRole("button", { name: /publish skill/i }));
+
+    await waitFor(() => {
+      expect(
+        publishVersion.mock.calls.some((call) =>
+          Array.isArray((call[0] as { files?: unknown }).files),
+        ),
+      ).toBe(true);
+    });
+    const args = publishVersion.mock.calls
+      .map((call) => call[0] as Record<string, unknown>)
+      .find((call) => Array.isArray(call.files));
+    // The picker was never touched, so the form must omit `icon` entirely
+    // and let the backend keep `skill.icon` as-is. Forwarding `\"\"` here
+    // would silently clear the existing icon on a routine version bump.
+    expect(args).not.toBeUndefined();
+    expect(Object.hasOwn(args!, "icon")).toBe(false);
+  });
+
+  it("does not silently clear an unparseable existing icon on republish (F1)", async () => {
+    // Same scenario as above, except the stored lucide name is no longer
+    // in the client allow-list (e.g. `ALLOWED_LUCIDE_ICONS` was pruned in a
+    // later deploy). `parseSkillIcon` returns `null`, the picker falls back
+    // to \"No icon\", and pre-population leaves `iconName === null` without
+    // any user interaction.
+    useSearchMock.mockReturnValue({ updateSlug: "stale-icon" });
+    useQueryMock.mockImplementation((fn: unknown, args: unknown) => {
+      if (args === "skip") return undefined;
+      const name = fn ? getFunctionName(fn as Parameters<typeof getFunctionName>[0]) : "";
+      if (name === "skills:getBySlug") {
+        return {
+          skill: {
+            slug: "stale-icon",
+            displayName: "Stale Icon",
+            icon: "lucide:NoLongerAllowedGlyph",
+          },
+          latestVersion: { version: "1.0.0", clawScanNote: null },
+          owner: { handle: "alice", displayName: "Alice" },
+        };
+      }
+      return null;
+    });
+    generateUploadUrl.mockResolvedValue("https://upload.local");
+    publishVersion.mockResolvedValue(undefined);
+
+    render(<Upload />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("radio", { name: "No icon" }).getAttribute("aria-checked")).toBe(
+        "true",
+      );
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("1.0.0"), {
+      target: { value: "1.0.1" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("latest, stable"), {
+      target: { value: "latest" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Describe what changed in this skill..."), {
+      target: { value: "Routine bump." },
+    });
+
+    const file = new File(["hello"], "SKILL.md", { type: "text/markdown" });
+    const input = screen.getByTestId("upload-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+    fireEvent.click(
+      screen.getByRole("checkbox", {
+        name: /i have the rights to this skill and agree to publish it under mit-0/i,
+      }),
+    );
+
+    await screen.findByText(/All checks passed/i);
+    fireEvent.click(screen.getByRole("button", { name: /publish skill/i }));
+
+    await waitFor(() => {
+      expect(
+        publishVersion.mock.calls.some((call) =>
+          Array.isArray((call[0] as { files?: unknown }).files),
+        ),
+      ).toBe(true);
+    });
+    const args = publishVersion.mock.calls
+      .map((call) => call[0] as Record<string, unknown>)
+      .find((call) => Array.isArray(call.files));
+    // Even though the picker visually shows \"No icon\" because the stored
+    // lucide name is no longer renderable, the user did not interact with
+    // it. We must NOT forward `icon: \"\"` (which the backend would treat
+    // as an explicit clear), so that the next time the publisher visits
+    // the form with an updated allow-list, their original icon is still
+    // there.
+    expect(args).not.toBeUndefined();
+    expect(Object.hasOwn(args!, "icon")).toBe(false);
   });
 });

--- a/src/__tests__/skills-publish-route.test.tsx
+++ b/src/__tests__/skills-publish-route.test.tsx
@@ -453,4 +453,104 @@ describe("Upload route", () => {
       });
     });
   });
+
+  it("renders the icon picker and forwards the selected lucide icon to publishVersion", async () => {
+    generateUploadUrl.mockResolvedValue("https://upload.local");
+    publishVersion.mockResolvedValue(undefined);
+    render(<Upload />);
+
+    // Picker is visible in skill mode and defaults to "No icon".
+    const noneTile = screen.getByRole("radio", { name: "No icon" });
+    expect(noneTile.getAttribute("aria-checked")).toBe("true");
+
+    fireEvent.change(screen.getByPlaceholderText("skill-name"), {
+      target: { value: "with-icon" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("My skill"), {
+      target: { value: "With Icon" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("1.0.0"), {
+      target: { value: "1.0.0" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("latest, stable"), {
+      target: { value: "latest" },
+    });
+    fireEvent.click(screen.getByRole("radio", { name: "Plug" }));
+    expect(screen.getByRole("radio", { name: "Plug" }).getAttribute("aria-checked")).toBe("true");
+
+    const file = new File(["hello"], "SKILL.md", { type: "text/markdown" });
+    const input = screen.getByTestId("upload-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+    fireEvent.click(
+      screen.getByRole("checkbox", {
+        name: /i have the rights to this skill and agree to publish it under mit-0/i,
+      }),
+    );
+
+    await screen.findByText(/All checks passed/i);
+    fireEvent.click(screen.getByRole("button", { name: /publish skill/i }));
+
+    await waitFor(() => {
+      expect(
+        publishVersion.mock.calls.some((call) =>
+          Array.isArray((call[0] as { files?: unknown }).files),
+        ),
+      ).toBe(true);
+    });
+    const args = publishVersion.mock.calls
+      .map((call) => call[0] as { icon?: string; files?: unknown })
+      .find((call) => Array.isArray(call.files));
+    expect(args?.icon).toBe("lucide:Plug");
+  });
+
+  it("sends an empty icon string when the publisher explicitly picks 'No icon'", async () => {
+    generateUploadUrl.mockResolvedValue("https://upload.local");
+    publishVersion.mockResolvedValue(undefined);
+    render(<Upload />);
+
+    fireEvent.change(screen.getByPlaceholderText("skill-name"), {
+      target: { value: "no-icon-skill" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("My skill"), {
+      target: { value: "No Icon Skill" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("1.0.0"), {
+      target: { value: "1.0.0" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("latest, stable"), {
+      target: { value: "latest" },
+    });
+
+    // Pick then unpick so the publisher's intent is recorded as "clear".
+    fireEvent.click(screen.getByRole("radio", { name: "Plug" }));
+    fireEvent.click(screen.getByRole("radio", { name: "No icon" }));
+
+    const file = new File(["hello"], "SKILL.md", { type: "text/markdown" });
+    const input = screen.getByTestId("upload-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+    fireEvent.click(
+      screen.getByRole("checkbox", {
+        name: /i have the rights to this skill and agree to publish it under mit-0/i,
+      }),
+    );
+
+    await screen.findByText(/All checks passed/i);
+    fireEvent.click(screen.getByRole("button", { name: /publish skill/i }));
+
+    await waitFor(() => {
+      expect(
+        publishVersion.mock.calls.some((call) =>
+          Array.isArray((call[0] as { files?: unknown }).files),
+        ),
+      ).toBe(true);
+    });
+    const args = publishVersion.mock.calls
+      .map((call) => call[0] as { icon?: string; files?: unknown })
+      .find((call) => Array.isArray(call.files));
+    // The publish form distinguishes "clear" (empty string) from "untouched"
+    // (key absent). Since the picker is always present in skill mode, even
+    // the default state forwards an explicit empty string.
+    expect(args).toHaveProperty("icon");
+    expect(args?.icon).toBe("");
+  });
 });

--- a/src/components/MarketplaceIcon.tsx
+++ b/src/components/MarketplaceIcon.tsx
@@ -1,9 +1,15 @@
 import { Building2, FileText, Package, Plug, User } from "lucide-react";
+import { parseSkillIcon } from "../lib/skillIcon";
 
 type MarketplaceIconProps = {
   kind: "skill" | "plugin" | "soul" | "user" | "org";
   label: string;
   imageUrl?: string | null;
+  /**
+   * Skill 自定义图标协议字符串（如 `lucide:Plug`）。当前仅 `skill` kind 支持，
+   * 其他 kind 传入会被忽略，仍走默认图标。无法解析或未在白名单时也回退。
+   */
+  icon?: string | null;
   size?: "xs" | "sm" | "md";
 };
 
@@ -35,7 +41,14 @@ function getIcon(kind: MarketplaceIconProps["kind"]) {
   }
 }
 
-export function MarketplaceIcon({ kind, label, imageUrl, size = "sm" }: MarketplaceIconProps) {
+export function MarketplaceIcon({
+  kind,
+  label,
+  imageUrl,
+  icon,
+  size = "sm",
+}: MarketplaceIconProps) {
+  const customIcon = kind === "skill" ? parseSkillIcon(icon) : null;
   const Icon = getIcon(kind);
   const tone = hashTone(label);
 
@@ -52,6 +65,8 @@ export function MarketplaceIcon({ kind, label, imageUrl, size = "sm" }: Marketpl
     >
       {imageUrl ? (
         <img className="marketplace-icon-image" src={imageUrl} alt="" loading="lazy" />
+      ) : customIcon?.kind === "lucide" ? (
+        <customIcon.component className="marketplace-icon-glyph" strokeWidth={1.8} />
       ) : (
         <Icon className="marketplace-icon-glyph" strokeWidth={1.8} />
       )}

--- a/src/components/MarketplaceIcon.tsx
+++ b/src/components/MarketplaceIcon.tsx
@@ -6,8 +6,10 @@ type MarketplaceIconProps = {
   label: string;
   imageUrl?: string | null;
   /**
-   * Skill 自定义图标协议字符串（如 `lucide:Plug`）。当前仅 `skill` kind 支持，
-   * 其他 kind 传入会被忽略，仍走默认图标。无法解析或未在白名单时也回退。
+   * Skill custom-icon protocol string (e.g. `lucide:Plug`). Only honoured
+   * when `kind === "skill"`; for other kinds the prop is ignored. Falls
+   * back to the default kind icon when the value cannot be parsed or is
+   * not in the client allow-list.
    */
   icon?: string | null;
   size?: "xs" | "sm" | "md";

--- a/src/components/PublishedItemCard.test.tsx
+++ b/src/components/PublishedItemCard.test.tsx
@@ -1,0 +1,84 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PublishedItemCard } from "../routes/p/$handle";
+
+// PublishedItemCard uses <Link> from TanStack Router; stub it to a plain <a>.
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (config: { component: unknown }) => config,
+  useNavigate: () => vi.fn(),
+  useSearch: () => ({}),
+  Link: ({
+    to,
+    children,
+    ...rest
+  }: {
+    to: string;
+    children: React.ReactNode;
+    [k: string]: unknown;
+  }) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+const baseSkill = {
+  _id: "skills:test",
+  kind: "skill" as const,
+  displayName: "Test Skill",
+  summary: "A test skill",
+  href: "/alice/test-skill",
+  downloads: 42,
+  stars: 7,
+  updatedAt: Date.now(),
+};
+
+const basePlugin = {
+  _id: "packages:test",
+  kind: "plugin" as const,
+  displayName: "Test Plugin",
+  summary: "A test plugin",
+  href: "/plugins/test-plugin",
+  downloads: 10,
+  stars: 2,
+  updatedAt: Date.now(),
+};
+
+describe("PublishedItemCard", () => {
+  describe("grid view", () => {
+    it("renders the custom lucide icon for a skill with icon set (F7)", () => {
+      render(<PublishedItemCard item={{ ...baseSkill, icon: "lucide:Plug" }} view="grid" />);
+      // The Plug lucide icon renders an SVG; MarketplaceIcon wraps it in a
+      // <span aria-hidden="true"> so we assert the glyph is present via the
+      // SVG element rather than accessible text.
+      const icon = document.querySelector(".marketplace-icon-glyph");
+      expect(icon).toBeTruthy();
+      // The icon should NOT be the default Package glyph — the custom Plug
+      // glyph is rendered instead. We verify by checking the SVG path data
+      // is present (lucide-react renders deterministic SVG markup).
+      expect(document.querySelector("svg")).toBeTruthy();
+    });
+
+    it("falls back to the default kind icon when skill has no custom icon (F7)", () => {
+      render(<PublishedItemCard item={{ ...baseSkill, icon: null }} view="grid" />);
+      expect(document.querySelector(".marketplace-icon-glyph")).toBeTruthy();
+    });
+
+    it("always uses the default kind icon for plugins regardless of icon field (F7)", () => {
+      render(<PublishedItemCard item={{ ...basePlugin, icon: null }} view="grid" />);
+      expect(document.querySelector(".marketplace-icon-glyph")).toBeTruthy();
+    });
+  });
+
+  describe("list view", () => {
+    it("renders the custom lucide icon for a skill with icon set (F7)", () => {
+      render(<PublishedItemCard item={{ ...baseSkill, icon: "lucide:Plug" }} view="list" />);
+      expect(document.querySelector(".marketplace-icon-glyph")).toBeTruthy();
+    });
+
+    it("falls back to the default kind icon when skill has no custom icon (F7)", () => {
+      render(<PublishedItemCard item={{ ...baseSkill, icon: null }} view="list" />);
+      expect(document.querySelector(".marketplace-icon-glyph")).toBeTruthy();
+    });
+  });
+});

--- a/src/components/SkillCard.tsx
+++ b/src/components/SkillCard.tsx
@@ -46,7 +46,7 @@ export function SkillCard({
         </div>
       ) : null}
       <div className="skill-card-header">
-        <MarketplaceIcon kind="skill" label={skill.displayName} size="md" />
+        <MarketplaceIcon kind="skill" label={skill.displayName} icon={skill.icon} size="md" />
         <h3 className="skill-card-title">{skill.displayName}</h3>
       </div>
       <p className="skill-card-summary">{skill.summary ?? summaryFallback}</p>

--- a/src/components/SkillIconPicker.test.tsx
+++ b/src/components/SkillIconPicker.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SkillIconPicker } from "./SkillIconPicker";
+
+describe("SkillIconPicker", () => {
+  it("renders a 'None' option plus every allow-listed icon", () => {
+    render(<SkillIconPicker value={null} onChange={() => {}} />);
+    // The "None" option uses a textual label rather than an icon.
+    expect(screen.getByRole("radio", { name: "No icon" })).toBeTruthy();
+    // Each allow-listed icon shows up as a radio button labelled by its name.
+    expect(screen.getByRole("radio", { name: "Plug" })).toBeTruthy();
+    expect(screen.getByRole("radio", { name: "Code2" })).toBeTruthy();
+  });
+
+  it("marks the current selection as aria-checked", () => {
+    render(<SkillIconPicker value="Plug" onChange={() => {}} />);
+    const plug = screen.getByRole("radio", { name: "Plug" });
+    expect(plug.getAttribute("aria-checked")).toBe("true");
+    expect(screen.getByRole("radio", { name: "No icon" }).getAttribute("aria-checked")).toBe(
+      "false",
+    );
+  });
+
+  it("falls back to 'No icon' selected when value is null", () => {
+    render(<SkillIconPicker value={null} onChange={() => {}} />);
+    expect(screen.getByRole("radio", { name: "No icon" }).getAttribute("aria-checked")).toBe(
+      "true",
+    );
+  });
+
+  it("calls onChange with the icon name when a tile is clicked", () => {
+    const onChange = vi.fn();
+    render(<SkillIconPicker value={null} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("radio", { name: "Plug" }));
+    expect(onChange).toHaveBeenCalledWith("Plug");
+  });
+
+  it("calls onChange(null) when the 'No icon' tile is clicked", () => {
+    const onChange = vi.fn();
+    render(<SkillIconPicker value="Plug" onChange={onChange} />);
+    fireEvent.click(screen.getByRole("radio", { name: "No icon" }));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it("shows a contextual hint that mirrors the current selection", () => {
+    const { rerender } = render(<SkillIconPicker value={null} onChange={() => {}} />);
+    expect(screen.getByText(/Pick an icon shown on the skill card/i)).toBeTruthy();
+
+    rerender(<SkillIconPicker value="Plug" onChange={() => {}} />);
+    expect(screen.getByText(/Selected: Plug/)).toBeTruthy();
+  });
+});

--- a/src/components/SkillIconPicker.tsx
+++ b/src/components/SkillIconPicker.tsx
@@ -1,0 +1,84 @@
+import { Check } from "lucide-react";
+import { ALLOWED_LUCIDE_ICON_NAMES, ALLOWED_LUCIDE_ICONS } from "../lib/skillIcon";
+
+type SkillIconPickerProps = {
+  /** Currently selected lucide name (e.g. `Plug`) or `null` for "no icon". */
+  value: string | null;
+  onChange: (next: string | null) => void;
+};
+
+/**
+ * Grid of pre-approved lucide icons for the skill publish form.
+ *
+ * Phase 1: pure local-state picker. Phase 2 (custom upload) will plug a new
+ * tab in here without changing the surrounding form contract.
+ */
+export function SkillIconPicker({ value, onChange }: SkillIconPickerProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap gap-2" role="radiogroup" aria-label="Skill icon">
+        <IconButton label="No icon" isSelected={value === null} onSelect={() => onChange(null)}>
+          <span className="text-xs font-medium text-[color:var(--ink-soft)]">None</span>
+        </IconButton>
+
+        {ALLOWED_LUCIDE_ICON_NAMES.map((name) => {
+          const Icon = ALLOWED_LUCIDE_ICONS[name];
+          if (!Icon) return null;
+          const isSelected = value === name;
+          return (
+            <IconButton
+              key={name}
+              label={name}
+              isSelected={isSelected}
+              onSelect={() => onChange(name)}
+            >
+              <Icon className="h-5 w-5 text-[color:var(--ink)]" strokeWidth={1.8} />
+            </IconButton>
+          );
+        })}
+      </div>
+      <p className="text-xs text-[color:var(--ink-soft)]">
+        {value
+          ? `Selected: ${value}. Click again to change, or pick "None" to use the default icon.`
+          : "Optional. Pick an icon shown on the skill card and listings."}
+      </p>
+    </div>
+  );
+}
+
+function IconButton({
+  label,
+  isSelected,
+  onSelect,
+  children,
+}: {
+  label: string;
+  isSelected: boolean;
+  onSelect: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={isSelected}
+      aria-label={label}
+      title={label}
+      onClick={onSelect}
+      className={[
+        "relative flex h-11 w-11 items-center justify-center rounded-[var(--radius-sm)] border transition-all",
+        isSelected
+          ? "border-[color:var(--accent)] bg-[color:var(--accent)]/10 shadow-[0_0_0_2px_color-mix(in_srgb,var(--accent)_30%,transparent)]"
+          : "border-[rgba(29,59,78,0.18)] bg-[rgba(255,255,255,0.94)] hover:border-[color:var(--accent)]/60 dark:border-[rgba(255,255,255,0.12)] dark:bg-[rgba(14,28,37,0.84)]",
+      ].join(" ")}
+    >
+      {children}
+      {isSelected ? (
+        <Check
+          className="absolute -right-1 -top-1 h-3.5 w-3.5 rounded-full bg-[color:var(--accent)] p-[2px] text-white"
+          strokeWidth={3}
+        />
+      ) : null}
+    </button>
+  );
+}

--- a/src/components/SkillListItem.tsx
+++ b/src/components/SkillListItem.tsx
@@ -21,7 +21,7 @@ export function SkillListItem({ skill, ownerHandle, owner }: SkillListItemProps)
 
   return (
     <Link to={href} className="skill-list-item">
-      <MarketplaceIcon kind="skill" label={skill.displayName} />
+      <MarketplaceIcon kind="skill" label={skill.displayName} icon={skill.icon} />
       <div className="skill-list-item-body">
         <div className="skill-list-item-main">
           {handle ? (

--- a/src/lib/publicUser.ts
+++ b/src/lib/publicUser.ts
@@ -39,6 +39,11 @@ export type PublicPublisherCatalogItem = {
   kind: "skill" | "plugin";
   displayName: string;
   summary: string | null;
+  /**
+   * Skill custom-icon protocol string (e.g. `lucide:Plug`) mirrored from
+   * `skills.icon`. Always `null` for `kind: "plugin"` items in Phase 1.
+   */
+  icon: string | null;
   href: string;
   downloads: number;
   stars: number;

--- a/src/lib/publicUser.ts
+++ b/src/lib/publicUser.ts
@@ -52,6 +52,7 @@ export type PublicSkill = Pick<
   | "slug"
   | "displayName"
   | "summary"
+  | "icon"
   | "ownerUserId"
   | "ownerPublisherId"
   | "canonicalSkillId"

--- a/src/lib/skillIcon.test.ts
+++ b/src/lib/skillIcon.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  ALLOWED_LUCIDE_ICON_NAMES,
+  ALLOWED_LUCIDE_ICONS,
+  makeLucideIconValue,
+  parseSkillIcon,
+} from "./skillIcon";
+
+describe("ALLOWED_LUCIDE_ICONS", () => {
+  it("exposes a non-empty allow-list with React component values", () => {
+    expect(ALLOWED_LUCIDE_ICON_NAMES.length).toBeGreaterThan(0);
+    for (const name of ALLOWED_LUCIDE_ICON_NAMES) {
+      const component = ALLOWED_LUCIDE_ICONS[name];
+      expect(component).toBeTruthy();
+      // lucide-react components are forwardRef objects in the bundled build,
+      // so we accept either a function or an object reference here.
+      expect(["function", "object"]).toContain(typeof component);
+    }
+  });
+
+  it("includes the Plug icon used as the canonical example", () => {
+    expect(ALLOWED_LUCIDE_ICONS.Plug).toBeTruthy();
+    expect(ALLOWED_LUCIDE_ICON_NAMES).toContain("Plug");
+  });
+});
+
+describe("parseSkillIcon", () => {
+  it("returns null for null/undefined/empty input", () => {
+    expect(parseSkillIcon(null)).toBeNull();
+    expect(parseSkillIcon(undefined)).toBeNull();
+    expect(parseSkillIcon("")).toBeNull();
+  });
+
+  it("returns null when the protocol is missing or malformed", () => {
+    expect(parseSkillIcon("Plug")).toBeNull();
+    expect(parseSkillIcon(":Plug")).toBeNull();
+    expect(parseSkillIcon("lucide:")).toBeNull();
+  });
+
+  it("resolves lucide icons inside the allow-list", () => {
+    const parsed = parseSkillIcon("lucide:Plug");
+    expect(parsed?.kind).toBe("lucide");
+    if (parsed?.kind === "lucide") {
+      expect(parsed.name).toBe("Plug");
+      expect(parsed.component).toBe(ALLOWED_LUCIDE_ICONS.Plug);
+    }
+  });
+
+  it("returns null for lucide names not in the allow-list", () => {
+    expect(parseSkillIcon("lucide:DefinitelyNotARealIcon")).toBeNull();
+  });
+
+  it("does not resolve prototype keys like `toString` or `constructor`", () => {
+    // Bracket-access on a plain object would otherwise yield
+    // `Object.prototype.toString`, which is truthy and would be handed to
+    // the renderer as if it were a React component.
+    expect(parseSkillIcon("lucide:toString")).toBeNull();
+    expect(parseSkillIcon("lucide:constructor")).toBeNull();
+    expect(parseSkillIcon("lucide:hasOwnProperty")).toBeNull();
+  });
+
+  it("normalizes the protocol to lower-case", () => {
+    expect(parseSkillIcon("LUCIDE:Plug")?.kind).toBe("lucide");
+  });
+
+  it("recognizes the url protocol as a future-proofed kind", () => {
+    const parsed = parseSkillIcon("url:https://example.com/icon.png");
+    expect(parsed).toEqual({ kind: "url", url: "https://example.com/icon.png" });
+  });
+
+  it("recognizes the storage protocol as a future-proofed kind", () => {
+    const parsed = parseSkillIcon("storage:abc123");
+    expect(parsed).toEqual({ kind: "storage", storageId: "abc123" });
+  });
+
+  it("returns null for unknown protocols", () => {
+    expect(parseSkillIcon("emoji:🦾")).toBeNull();
+  });
+});
+
+describe("makeLucideIconValue", () => {
+  it("packs an allow-listed name into a `lucide:<Name>` string", () => {
+    expect(makeLucideIconValue("Plug")).toBe("lucide:Plug");
+    expect(makeLucideIconValue("Code2")).toBe("lucide:Code2");
+  });
+
+  it("round-trips through parseSkillIcon for every allow-listed name", () => {
+    for (const name of ALLOWED_LUCIDE_ICON_NAMES) {
+      const value = makeLucideIconValue(name);
+      const parsed = parseSkillIcon(value);
+      expect(parsed?.kind).toBe("lucide");
+      if (parsed?.kind === "lucide") {
+        expect(parsed.name).toBe(name);
+      }
+    }
+  });
+});

--- a/src/lib/skillIcon.ts
+++ b/src/lib/skillIcon.ts
@@ -95,5 +95,5 @@ export function parseSkillIcon(raw: string | null | undefined): SkillIconDescrip
 
 /** Pack a whitelisted icon name into a `lucide:<Name>` protocol string. */
 export function makeLucideIconValue(name: keyof typeof ALLOWED_LUCIDE_ICONS): string {
-  return `lucide:${String(name)}`;
+  return `lucide:${name}`;
 }

--- a/src/lib/skillIcon.ts
+++ b/src/lib/skillIcon.ts
@@ -1,0 +1,99 @@
+import {
+  BookOpen,
+  Bot,
+  Brain,
+  Cloud,
+  Code2,
+  Cpu,
+  Database,
+  FileText,
+  Folder,
+  GitBranch,
+  Globe,
+  Lock,
+  Package,
+  Palette,
+  Plug,
+  Search,
+  Sparkles,
+  Terminal,
+  Wrench,
+  Zap,
+} from "lucide-react";
+import type { ComponentType, SVGProps } from "react";
+
+export type LucideIconComponent = ComponentType<SVGProps<SVGSVGElement>>;
+
+/**
+ * Phase 1 lets users pick from this curated lucide icon set. Future phases
+ * (uploads or external URLs) will reuse the same `skill.icon` field (a
+ * protocol string) without introducing additional table columns.
+ */
+export const ALLOWED_LUCIDE_ICONS: Record<string, LucideIconComponent> = {
+  Plug,
+  FileText,
+  Package,
+  Code2,
+  Wrench,
+  Database,
+  Bot,
+  Brain,
+  Globe,
+  Search,
+  GitBranch,
+  Cpu,
+  Cloud,
+  Lock,
+  Sparkles,
+  Terminal,
+  Zap,
+  BookOpen,
+  Folder,
+  Palette,
+};
+
+export const ALLOWED_LUCIDE_ICON_NAMES = Object.keys(ALLOWED_LUCIDE_ICONS) as ReadonlyArray<
+  keyof typeof ALLOWED_LUCIDE_ICONS
+>;
+
+export type SkillIconDescriptor =
+  | { kind: "lucide"; name: string; component: LucideIconComponent }
+  | { kind: "url"; url: string }
+  | { kind: "storage"; storageId: string };
+
+/**
+ * Parse a `skill.icon` protocol string. Returns `null` for unknown protocols
+ * or icons that are not in the allow-list, leaving the caller to fall back
+ * to a default icon.
+ */
+export function parseSkillIcon(raw: string | null | undefined): SkillIconDescriptor | null {
+  if (!raw) return null;
+  const colonIndex = raw.indexOf(":");
+  if (colonIndex <= 0) return null;
+  const kind = raw.slice(0, colonIndex).toLowerCase();
+  const value = raw.slice(colonIndex + 1).trim();
+  if (!value) return null;
+
+  if (kind === "lucide") {
+    // `Object.hasOwn` guards against prototype keys like `toString` /
+    // `constructor`: bracket-access on a plain `Record<string, ...>` would
+    // otherwise resolve them to `Object.prototype` members and try to
+    // render them as React components downstream.
+    const component = Object.hasOwn(ALLOWED_LUCIDE_ICONS, value)
+      ? ALLOWED_LUCIDE_ICONS[value]
+      : undefined;
+    return component ? { kind: "lucide", name: value, component } : null;
+  }
+  if (kind === "url") {
+    return { kind: "url", url: value };
+  }
+  if (kind === "storage") {
+    return { kind: "storage", storageId: value };
+  }
+  return null;
+}
+
+/** Pack a whitelisted icon name into a `lucide:<Name>` protocol string. */
+export function makeLucideIconValue(name: keyof typeof ALLOWED_LUCIDE_ICONS): string {
+  return `lucide:${String(name)}`;
+}

--- a/src/routes/p/$handle.tsx
+++ b/src/routes/p/$handle.tsx
@@ -502,7 +502,10 @@ function ProfileDetail({
   );
 }
 
-function PublishedItemCard({
+// Exported for unit testing. The publisher profile route is the only
+// production consumer; tests assert that custom skill icons forwarded via
+// `item.icon` reach `MarketplaceIcon`.
+export function PublishedItemCard({
   item,
   view,
 }: {
@@ -513,7 +516,16 @@ function PublishedItemCard({
     return (
       <Link to={item.href} className="card skill-card">
         <div className="skill-card-header">
-          <MarketplaceIcon kind={item.kind} label={item.displayName} size="md" />
+          {/* Forward the custom icon for skill items so the publisher's
+              profile (`/p/<handle>`) renders the same lucide glyph that
+              `SkillCard` and `SkillListItem` use on `/skills` and `/search`.
+              Plugins always pass `null` per the Phase 1 contract. */}
+          <MarketplaceIcon
+            kind={item.kind}
+            label={item.displayName}
+            icon={item.kind === "skill" ? item.icon : null}
+            size="md"
+          />
           <h3 className="skill-card-title">{item.displayName}</h3>
         </div>
         <p className="skill-card-summary">
@@ -537,7 +549,11 @@ function PublishedItemCard({
 
   return (
     <Link to={item.href} className="skill-list-item publisher-published-row">
-      <MarketplaceIcon kind={item.kind} label={item.displayName} />
+      <MarketplaceIcon
+        kind={item.kind}
+        label={item.displayName}
+        icon={item.kind === "skill" ? item.icon : null}
+      />
       <div className="skill-list-item-body">
         <span className="skill-list-item-main">
           <span className="skill-list-item-owner">@{item.kind}</span>

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -102,6 +102,16 @@ export function Upload() {
   const [clawScanNote, setClawScanNote] = useState("");
   const changelogTouchedRef = useRef(false);
   const clawScanNoteTouchedRef = useRef(false);
+  // Tracks whether the publisher has interacted with the Skill icon picker
+  // during this session. Used by the submit handler to honour the "key
+  // omitted = leave existing alone" branch in skill mode: a routine New
+  // Version publish that never touches the picker must NOT forward an
+  // empty `icon: ""` (which the backend would treat as an explicit
+  // clear). This protects against silently wiping a custom icon when
+  // pre-population fails — for example after the client allow-list is
+  // pruned in a future deploy and the stored lucide name no longer
+  // resolves.
+  const iconTouchedRef = useRef(false);
   const changelogRequestRef = useRef(0);
   const changelogKeyRef = useRef<string | null>(null);
   const [status, setStatus] = useState<string | null>(null);
@@ -511,14 +521,19 @@ export function Upload() {
 
     setStatus("Publishing…");
     try {
-      // Skill mode always forwards an `icon` field so the form is the
-      // single source of truth: a whitelisted name becomes `lucide:<Name>`,
-      // while the "None" tile (or no selection) becomes `""`. The backend
-      // treats blank input as "clear the icon" and a missing key as "keep
-      // whatever is already stored" — soul mode therefore omits the field
-      // entirely so the existing soul row is left alone.
+      // Skill mode forwards an `icon` field only when the picker has
+      // actually been touched in this session, so the form is the single
+      // source of truth for the tri-state contract:
+      //   * touched + whitelisted name → `lucide:<Name>` (set)
+      //   * touched + None / unparseable selection → `""` (clear)
+      //   * untouched (or soul mode) → field omitted (keep existing)
+      // The backend treats blank input as "clear the icon" and a missing
+      // key as "keep whatever is already stored", so the omit branch is
+      // what protects routine version bumps from silently wiping an
+      // existing custom icon when pre-population fails (e.g. the stored
+      // lucide name was pruned from `ALLOWED_LUCIDE_ICONS`).
       let iconPayload: string | undefined;
-      if (isSoulMode) {
+      if (isSoulMode || !iconTouchedRef.current) {
         iconPayload = undefined;
       } else if (iconName && Object.hasOwn(ALLOWED_LUCIDE_ICONS, iconName)) {
         iconPayload = makeLucideIconValue(iconName as keyof typeof ALLOWED_LUCIDE_ICONS);
@@ -613,7 +628,17 @@ export function Upload() {
                       heading is decorative and does not need `htmlFor` —
                       `SkillIconPicker` exposes its own `aria-label`. */}
                   <Label>Icon</Label>
-                  <SkillIconPicker value={iconName} onChange={setIconName} />
+                  <SkillIconPicker
+                    value={iconName}
+                    onChange={(next) => {
+                      // Mark the picker as user-touched so the submit
+                      // handler knows it can forward the resulting value
+                      // (including `null` → "") instead of falling back
+                      // to the omit-key branch.
+                      iconTouchedRef.current = true;
+                      setIconName(next);
+                    }}
+                  />
                 </>
               ) : null}
 

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -16,6 +16,7 @@ import { MAX_PUBLISH_FILE_BYTES, MAX_PUBLISH_TOTAL_BYTES } from "../../../convex
 import { EmptyState } from "../../components/EmptyState";
 import { Container } from "../../components/layout/Container";
 import { SignInButton } from "../../components/SignInButton";
+import { SkillIconPicker } from "../../components/SkillIconPicker";
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
 import { Card, CardContent, CardTitle } from "../../components/ui/card";
@@ -23,6 +24,7 @@ import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
 import { Textarea } from "../../components/ui/textarea";
 import { getSiteMode } from "../../lib/site";
+import { ALLOWED_LUCIDE_ICONS, makeLucideIconValue, parseSkillIcon } from "../../lib/skillIcon";
 import { getPublicSlugCollision } from "../../lib/slugCollision";
 import { expandDroppedItems, expandFilesWithReport } from "../../lib/uploadFiles";
 import { useAuthStatus } from "../../lib/useAuthStatus";
@@ -70,7 +72,7 @@ export function Upload() {
   );
   const existing = (isSoulMode ? existingSoul : existingSkill) as
     | {
-        skill?: { slug: string; displayName: string };
+        skill?: { slug: string; displayName: string; icon?: string | null };
         soul?: { slug: string; displayName: string };
         latestVersion?: { version: string; clawScanNote?: string | null };
         // Present on skills.getBySlug; absent on souls.getBySlug. Used to
@@ -86,6 +88,9 @@ export function Upload() {
   const [ignoredMacJunkPaths, setIgnoredMacJunkPaths] = useState<string[]>([]);
   const [slug, setSlug] = useState(updateSlug ?? "");
   const [displayName, setDisplayName] = useState("");
+  // Selected lucide icon name (e.g. `Plug`) or null when "no icon". Skills only;
+  // souls don't expose a custom icon yet.
+  const [iconName, setIconName] = useState<string | null>(null);
   const [version, setVersion] = useState("1.0.0");
   const [tags, setTags] = useState("latest");
   const [acceptedLicenseTerms, setAcceptedLicenseTerms] = useState(false);
@@ -218,6 +223,12 @@ export function Upload() {
     const nextSlug = existing.skill?.slug ?? existing.soul?.slug;
     if (nextSlug) setSlug(nextSlug);
     if (name) setDisplayName(name);
+    // Pre-populate the icon picker from the existing skill so a New Version
+    // publish keeps the previously selected icon unless the user changes it.
+    if (!isSoulMode && existing.skill?.icon !== undefined) {
+      const parsed = parseSkillIcon(existing.skill.icon ?? null);
+      setIconName(parsed?.kind === "lucide" ? parsed.name : null);
+    }
     const nextVersion = semver.inc(existing.latestVersion.version, "patch");
     if (nextVersion) setVersion(nextVersion);
     if (!isSoulMode && !clawScanNoteTouchedRef.current) {
@@ -500,6 +511,20 @@ export function Upload() {
 
     setStatus("Publishing…");
     try {
+      // Skill mode always forwards an `icon` field so the form is the
+      // single source of truth: a whitelisted name becomes `lucide:<Name>`,
+      // while the "None" tile (or no selection) becomes `""`. The backend
+      // treats blank input as "clear the icon" and a missing key as "keep
+      // whatever is already stored" — soul mode therefore omits the field
+      // entirely so the existing soul row is left alone.
+      let iconPayload: string | undefined;
+      if (isSoulMode) {
+        iconPayload = undefined;
+      } else if (iconName && Object.hasOwn(ALLOWED_LUCIDE_ICONS, iconName)) {
+        iconPayload = makeLucideIconValue(iconName as keyof typeof ALLOWED_LUCIDE_ICONS);
+      } else {
+        iconPayload = "";
+      }
       const result = await publishVersion({
         ownerHandle: isSoulMode ? undefined : ownerHandle || undefined,
         // Only propagate the migration opt-in when the user is actually
@@ -508,6 +533,7 @@ export function Upload() {
         migrateOwner: !isSoulMode && isOwnerMigration && confirmMigrateOwner ? true : undefined,
         slug: trimmedSlug,
         displayName: trimmedName,
+        ...(iconPayload !== undefined ? { icon: iconPayload } : {}),
         version: trimmedVersion,
         changelog: trimmedChangelog,
         ...(normalizedClawScanNote ? { clawScanNote: normalizedClawScanNote } : {}),
@@ -580,6 +606,16 @@ export function Upload() {
                 id="display-name-validation-error"
                 message={displayNameIssue}
               />
+
+              {!isSoulMode ? (
+                <>
+                  {/* The picker is a custom radiogroup; the visible "Icon"
+                      heading is decorative and does not need `htmlFor` —
+                      `SkillIconPicker` exposes its own `aria-label`. */}
+                  <Label>Icon</Label>
+                  <SkillIconPicker value={iconName} onChange={setIconName} />
+                </>
+              ) : null}
 
               {!isSoulMode ? (
                 <>


### PR DESCRIPTION
# Skill custom icons — Phase 1 (curated lucide picker)

## Summary

Skill cards and list items currently render a hard-coded `Plug` glyph
for every skill. This PR lets publishers choose an icon from a curated
lucide set on the publish form, with the ground laid for future phases
(custom uploads, external URLs) without further schema churn.

The icon is stored on `skills.icon` as a protocol string of the form
`kind:value` (today only `lucide:<Name>` is accepted). The backend
validates the format only; the **client** owns the concrete render
allow-list, so adding/removing icons in future does not require a
backend deploy and unknown values gracefully degrade to the default.

## Why this shape

| Decision                                     | Rationale                                                                                                                                      |
| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
| Single `string` column instead of typed enum | Phase 2/3 (uploads, URLs) reuse the same field; no migration needed.                                                                           |
| Allow-list lives on the **client**           | Removes coupling between deploy cadences. Server only checks `^lucide:[A-Za-z][A-Za-z0-9]*$` + 64-char cap; unknown values render the default. |
| `Object.hasOwn` guard in `parseSkillIcon`    | Bracket access on a plain `Record` would otherwise resolve `toString` / `constructor` to `Object.prototype` members and crash the renderer.    |
| "Only update on new latest" semantics        | Matches `displayName` / `summary` so a backport publish to an old branch can't silently rewrite the card.                                      |
| Tri-state payload from the form              | `lucide:<Name>` = set, `""` = explicit clear, key omitted = "leave existing value alone" (used in soul mode).                                  |

## Changes

### Schema & backend (`convex/`)

- **`schema.ts`**: add `icon: v.optional(v.string())` to `skills` and
  mirror it on `skillSearchDigest` so card/list hydration paths don't
  need a full-row read.
- **`lib/skillIcon.ts`** _(new)_: `normalizeSkillIconValue` with format
  - length validation; silent-drop for unknown protocols.
- **`lib/skillIcon.test.ts`** _(new)_: unit coverage for the
  normalizer.
- **`skills.ts`**:
  - `publishVersion` + `insertVersion` accept the optional `icon` arg.
  - On insert: persist via `normalizeSkillIconValue`.
  - On patch: respect the same "new latest only" gate as
    `displayName` / `summary`; an explicit empty string clears the
    icon, omitting the field preserves the previous value.
- **`lib/skillPublish.ts`**: thread the new arg through `PublishVersionArgs`.
- **`lib/skillSearchDigest.ts`**: include `icon` in `SHARED_KEYS`.
- **`lib/public.ts`**: include `icon` in `PublicSkill` /
  `HydratableSkill` projections and `toPublicSkill`.
- **`_generated/api.d.ts`**: regenerated module map for the new
  `lib/skillIcon` module.

### Frontend (`src/`)

- **`lib/skillIcon.ts`** _(new)_: 20-entry curated lucide allow-list
  (`Plug, FileText, Package, Code2, Wrench, Database, Bot, Brain,
Globe, Search, GitBranch, Cpu, Cloud, Lock, Sparkles, Terminal, Zap,
BookOpen, Folder, Palette`), `parseSkillIcon`, `makeLucideIconValue`.
  Designed to also describe `url` / `storage` descriptors so phase 2
  callers can switch on `descriptor.kind` without rewriting consumers.
- **`lib/skillIcon.test.ts`** _(new)_: parser + factory coverage,
  prototype-key guard, unknown-name fallback.
- **`components/SkillIconPicker.tsx`** _(new)_: accessible
  `radiogroup` of icon tiles plus a "None" option; styled with the
  shared accent token.
- **`components/SkillIconPicker.test.tsx`** _(new)_: selection,
  reselection-to-clear, `aria-checked` assertions.
- **`components/MarketplaceIcon.tsx`**: accept optional `icon` (only
  honoured for `kind="skill"`); resolve via `parseSkillIcon` and fall
  back to the default kind icon on miss.
- **`components/SkillCard.tsx`** + **`components/SkillListItem.tsx`**:
  forward `skill.icon` to `MarketplaceIcon`.
- **`lib/publicUser.ts`**: include `icon` in the public skill
  projection so hydrated client types stay in sync.
- **`routes/skills/publish.tsx`**:
  - Render `SkillIconPicker` (skill mode only).
  - Pre-populate from the existing skill on a "New version" publish so
    the previously chosen icon stays selected unless the user changes it.
  - Build the tri-state `iconPayload` and spread it into the
    `publishVersion` args (omit-on-soul-mode).
- **`__tests__/skills-publish-route.test.tsx`**: two integration cases
  covering `lucide:Plug` and explicit-clear flows end-to-end.

## Migration & compatibility

- Field is `optional`; existing skills load with `icon === undefined`
  and continue to render the default `Plug` glyph.
- Unknown / future values returned from older clients render the
  default rather than crashing.
- Soul mode is untouched: the field is omitted from the publish
  payload entirely.

## Test plan

- `bun test convex/lib/skillIcon.test.ts`
- `bun test src/lib/skillIcon.test.ts`
- `bun test src/components/SkillIconPicker.test.tsx`
- `bun test src/__tests__/skills-publish-route.test.tsx`
- `bun run ci:static` (oxfmt + oxlint)
- Manual:
  - Publish a brand-new skill with `Plug` selected → card + list show
    the plug glyph.
  - Publish a new version of the same skill leaving the picker on the
    pre-populated icon → still rendered.
  - Re-publish with "None" → card reverts to the default kind icon.
  - Publish a backport (older version) without touching the picker →
    icon preserved.

## Out of scope (follow-ups)

- Phase 2: custom upload via Convex Storage (`storage:<id>`).
- Phase 3: external URL with safe-host allow-list (`url:<https-url>`).
- Soul-side icon picker (intentionally deferred).
