### PR TITLE
fix: avoid slug availability crash for duplicate slugs

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -446,6 +446,8 @@ const skills = defineTable({
   .index("by_slug", ["slug"])
   .index("by_owner", ["ownerUserId"])
   .index("by_owner_publisher", ["ownerPublisherId"])
+  .index("by_owner_slug", ["ownerUserId", "slug"])
+  .index("by_owner_publisher_slug", ["ownerPublisherId", "slug"])
   .index("by_owner_active_updated", ["ownerUserId", "softDeletedAt", "updatedAt"])
   .index("by_owner_publisher_active_updated", ["ownerPublisherId", "softDeletedAt", "updatedAt"])
   .index("by_updated", ["updatedAt"])
@@ -495,7 +497,9 @@ const skillSlugAliases = defineTable({
   .index("by_slug", ["slug"])
   .index("by_skill", ["skillId"])
   .index("by_owner", ["ownerUserId"])
-  .index("by_owner_publisher", ["ownerPublisherId"]);
+  .index("by_owner_publisher", ["ownerPublisherId"])
+  .index("by_owner_slug", ["ownerUserId", "slug"])
+  .index("by_owner_publisher_slug", ["ownerPublisherId", "slug"]);
 
 const souls = defineTable({
   slug: v.string(),

--- a/convex/skills.slugAvailability.test.ts
+++ b/convex/skills.slugAvailability.test.ts
@@ -34,13 +34,23 @@ type ReservationDoc = {
   releasedAt?: number;
 };
 
+type AliasDoc = {
+  _id: string;
+  slug: string;
+  skillId: string;
+  ownerUserId?: string;
+  ownerPublisherId?: string;
+};
+
 const checkSlugAvailabilityHandler = (
   checkSlugAvailability as unknown as WrappedHandler<{ slug: string; ownerHandle?: string }>
 )._handler;
 
 function createCtx(options: {
   skill: SkillDoc | null;
-  alias?: { _id: string; slug: string; skillId: string } | null;
+  skills?: SkillDoc[];
+  alias?: AliasDoc | null;
+  aliases?: AliasDoc[];
   aliasedSkill?: SkillDoc | null;
   reservation?: ReservationDoc | null;
   owner?: {
@@ -67,23 +77,104 @@ function createCtx(options: {
 }) {
   const callerId = options.callerId ?? "users:caller";
   let authAccountLookupCount = 0;
+  const skills = options.skills ?? (options.skill ? [options.skill] : []);
+  const aliases = options.aliases ?? (options.alias ? [options.alias] : []);
+
+  const captureConstraints = (
+    callback?: (query: { eq: (field: string, value: unknown) => unknown }) => unknown,
+  ) => {
+    const constraints: Record<string, unknown> = {};
+    const query = {
+      eq: (field: string, value: unknown) => {
+        constraints[field] = value;
+        return query;
+      },
+    };
+    callback?.(query);
+    return constraints;
+  };
+
+  const filterSkills = (name: string, constraints: Record<string, unknown>) => {
+    if (name === "by_slug") {
+      return skills.filter((skill) => skill.slug === constraints.slug);
+    }
+    if (name === "by_owner_publisher_slug") {
+      return skills.filter(
+        (skill) =>
+          skill.ownerPublisherId === constraints.ownerPublisherId &&
+          skill.slug === constraints.slug,
+      );
+    }
+    if (name === "by_owner_slug") {
+      return skills.filter(
+        (skill) => skill.ownerUserId === constraints.ownerUserId && skill.slug === constraints.slug,
+      );
+    }
+    throw new Error(`unexpected skills index ${name}`);
+  };
+
+  const filterAliases = (name: string, constraints: Record<string, unknown>) => {
+    if (name === "by_slug") {
+      return aliases.filter((alias) => alias.slug === constraints.slug);
+    }
+    if (name === "by_owner_publisher_slug") {
+      return aliases.filter(
+        (alias) =>
+          alias.ownerPublisherId === constraints.ownerPublisherId &&
+          alias.slug === constraints.slug,
+      );
+    }
+    if (name === "by_owner_slug") {
+      return aliases.filter(
+        (alias) => alias.ownerUserId === constraints.ownerUserId && alias.slug === constraints.slug,
+      );
+    }
+    throw new Error(`unexpected skillSlugAliases index ${name}`);
+  };
 
   const db = {
     get: vi.fn(async (id: string) => {
+      if (options.publisher && id === options.publisher._id) return options.publisher;
       if (options.owner && id === options.owner._id) return options.owner;
       if (id === callerId) {
         return { _id: callerId, deletedAt: undefined, deactivatedAt: undefined };
       }
+      const skill = skills.find((entry) => entry._id === id);
+      if (skill) return skill;
       if (options.aliasedSkill && id === options.aliasedSkill._id) return options.aliasedSkill;
       return null;
     }),
     query: vi.fn((table: string) => {
       if (table === "skills") {
         return {
-          withIndex: (name: string) => {
-            if (name !== "by_slug") throw new Error(`unexpected skills index ${name}`);
+          withIndex: (
+            name: string,
+            callback?: (query: { eq: (field: string, value: unknown) => unknown }) => unknown,
+          ) => {
+            const matches = filterSkills(name, captureConstraints(callback));
             return {
-              unique: async () => options.skill,
+              unique: async () => {
+                if (matches.length > 1) throw new Error("unique() query returned multiple rows");
+                return matches[0] ?? null;
+              },
+              take: async (limit: number) => matches.slice(0, limit),
+            };
+          },
+        };
+      }
+      if (table === "users") {
+        return {
+          withIndex: (
+            name: string,
+            callback?: (query: { eq: (field: string, value: unknown) => unknown }) => unknown,
+          ) => {
+            if (name !== "handle") throw new Error(`unexpected users index ${name}`);
+            const constraints = captureConstraints(callback);
+            return {
+              unique: async () => {
+                const candidates = [options.owner].filter(Boolean);
+                return candidates.find((user) => user?.handle === constraints.handle) ?? null;
+              },
             };
           },
         };
@@ -104,10 +195,17 @@ function createCtx(options: {
       }
       if (table === "skillSlugAliases") {
         return {
-          withIndex: (name: string) => {
-            if (name !== "by_slug") throw new Error(`unexpected skillSlugAliases index ${name}`);
+          withIndex: (
+            name: string,
+            callback?: (query: { eq: (field: string, value: unknown) => unknown }) => unknown,
+          ) => {
+            const matches = filterAliases(name, captureConstraints(callback));
             return {
-              unique: async () => options.alias ?? null,
+              unique: async () => {
+                if (matches.length > 1) throw new Error("unique() query returned multiple rows");
+                return matches[0] ?? null;
+              },
+              take: async (limit: number) => matches.slice(0, limit),
             };
           },
         };
@@ -133,12 +231,28 @@ function createCtx(options: {
       }
       if (table === "publishers") {
         return {
-          withIndex: (name: string) => {
+          withIndex: (
+            name: string,
+            callback?: (query: { eq: (field: string, value: unknown) => unknown }) => unknown,
+          ) => {
             if (name !== "by_handle" && name !== "by_linked_user") {
               throw new Error(`unexpected publishers index ${name}`);
             }
+            const constraints = captureConstraints(callback);
             return {
-              unique: async () => options.publisher ?? null,
+              unique: async () => {
+                if (!options.publisher) return null;
+                if (name === "by_handle" && options.publisher.handle !== constraints.handle) {
+                  return null;
+                }
+                if (
+                  name === "by_linked_user" &&
+                  options.publisher.linkedUserId !== constraints.linkedUserId
+                ) {
+                  return null;
+                }
+                return options.publisher;
+              },
             };
           },
         };
@@ -502,6 +616,54 @@ describe("skills.checkSlugAvailability", () => {
       available: true,
       reason: "available",
       message: null,
+      url: null,
+    });
+  });
+
+  it("returns a validation result instead of throwing when duplicate slugs exist", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:caller" as never);
+
+    const result = (await checkSlugAvailabilityHandler(
+      createCtx({
+        skill: null,
+        skills: [
+          {
+            _id: "skills:personal-shared",
+            slug: "shared-slug",
+            ownerUserId: "users:alice",
+            ownerPublisherId: "publishers:alice",
+            softDeletedAt: undefined,
+            moderationStatus: "active",
+            moderationFlags: undefined,
+          },
+          {
+            _id: "skills:org-shared",
+            slug: "shared-slug",
+            ownerUserId: "users:bob",
+            ownerPublisherId: "publishers:other-org",
+            softDeletedAt: undefined,
+            moderationStatus: "active",
+            moderationFlags: undefined,
+          },
+        ],
+        publisher: {
+          _id: "publishers:target-org",
+          handle: "target-org",
+          kind: "org",
+        },
+      }) as never,
+      { slug: "shared-slug", ownerHandle: "target-org" } as never,
+    )) as {
+      available: boolean;
+      reason: string;
+      message: string | null;
+      url: string | null;
+    };
+
+    expect(result).toEqual({
+      available: false,
+      reason: "taken",
+      message: "Slug is already used by multiple publishers. Choose a specific owner.",
       url: null,
     });
   });

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -74,6 +74,7 @@ import {
 import {
   assertCanManageOwnedResource,
   ensurePersonalPublisherForUser,
+  getActiveUserByHandleOrPersonalPublisher,
   getOwnerPublisher,
   getPersonalPublisherForUserOrFallback,
   getPublisherByHandle,
@@ -742,6 +743,108 @@ async function getSkillSlugAliasBySlug(ctx: Pick<QueryCtx | MutationCtx, "db">, 
     .query("skillSlugAliases")
     .withIndex("by_slug", (q) => q.eq("slug", normalizedSlug))
     .unique();
+}
+
+async function resolveRequestedAvailabilityPublisher(
+  ctx: Pick<QueryCtx, "db">,
+  ownerHandle: string | undefined,
+) {
+  const requestedHandle = normalizePublisherHandle(ownerHandle);
+  if (!requestedHandle) {
+    return { requestedHandle, requestedPublisher: null };
+  }
+
+  const materializedPublisher = await getPublisherByHandle(ctx, requestedHandle);
+  if (materializedPublisher) {
+    return { requestedHandle, requestedPublisher: materializedPublisher };
+  }
+
+  const user = await getActiveUserByHandleOrPersonalPublisher(ctx, requestedHandle);
+  const fallbackPublisher = user ? await getPersonalPublisherForUserOrFallback(ctx, user) : null;
+  return {
+    requestedHandle,
+    requestedPublisher:
+      fallbackPublisher?.handle === requestedHandle ? fallbackPublisher : materializedPublisher,
+  };
+}
+
+async function getSkillBySlugForAvailabilityPublisher(
+  ctx: Pick<QueryCtx, "db">,
+  slug: string,
+  publisher: Doc<"publishers">,
+) {
+  const scopedSkills = await ctx.db
+    .query("skills")
+    .withIndex("by_owner_publisher_slug", (q) =>
+      q.eq("ownerPublisherId", publisher._id).eq("slug", slug),
+    )
+    .take(2);
+  if (scopedSkills[0]) return scopedSkills[0];
+
+  if (publisher.kind !== "user" || !publisher.linkedUserId) return null;
+
+  const legacySkills = await ctx.db
+    .query("skills")
+    .withIndex("by_owner_slug", (q) => q.eq("ownerUserId", publisher.linkedUserId).eq("slug", slug))
+    .take(2);
+  return (
+    legacySkills.find(
+      (skill) => !skill.ownerPublisherId || skill.ownerPublisherId === publisher._id,
+    ) ?? null
+  );
+}
+
+async function getUnscopedSkillBySlugForAvailability(ctx: Pick<QueryCtx, "db">, slug: string) {
+  const skills = await ctx.db
+    .query("skills")
+    .withIndex("by_slug", (q) => q.eq("slug", slug))
+    .take(2);
+  return {
+    skill: skills.length === 1 ? skills[0] : null,
+    ambiguous: skills.length > 1,
+  };
+}
+
+async function getUnscopedSkillSlugAliasBySlugForAvailability(
+  ctx: Pick<QueryCtx, "db">,
+  slug: string,
+) {
+  const aliases = await ctx.db
+    .query("skillSlugAliases")
+    .withIndex("by_slug", (q) => q.eq("slug", slug))
+    .take(2);
+  return {
+    alias: aliases.length === 1 ? aliases[0] : null,
+    ambiguous: aliases.length > 1,
+  };
+}
+
+async function getSkillSlugAliasBySlugForAvailabilityPublisher(
+  ctx: Pick<QueryCtx, "db">,
+  slug: string,
+  publisher: Doc<"publishers">,
+) {
+  const scopedAliases = await ctx.db
+    .query("skillSlugAliases")
+    .withIndex("by_owner_publisher_slug", (q) =>
+      q.eq("ownerPublisherId", publisher._id).eq("slug", slug),
+    )
+    .take(2);
+  if (scopedAliases[0]) return scopedAliases[0];
+
+  if (publisher.kind !== "user" || !publisher.linkedUserId) return null;
+
+  const legacyAliases = await ctx.db
+    .query("skillSlugAliases")
+    .withIndex("by_owner_slug", (q) =>
+      q.eq("ownerUserId", publisher.linkedUserId as Id<"users">).eq("slug", slug),
+    )
+    .take(2);
+  return (
+    legacyAliases.find(
+      (alias) => !alias.ownerPublisherId || alias.ownerPublisherId === publisher._id,
+    ) ?? null
+  );
 }
 
 async function listSkillSlugAliasesForSkill(
@@ -2012,16 +2115,49 @@ export const checkSlugAvailability = query({
       };
     }
 
-    const skill = await ctx.db
-      .query("skills")
-      .withIndex("by_slug", (q) => q.eq("slug", slug))
-      .unique();
+    const { requestedHandle, requestedPublisher } = await resolveRequestedAvailabilityPublisher(
+      ctx,
+      args.ownerHandle,
+    );
+    const unscopedSkillResult = await getUnscopedSkillBySlugForAvailability(ctx, slug);
+    const scopedSkill = requestedPublisher
+      ? await getSkillBySlugForAvailabilityPublisher(ctx, slug, requestedPublisher)
+      : null;
+    const skill = scopedSkill ?? unscopedSkillResult.skill;
+
+    if (!scopedSkill && unscopedSkillResult.ambiguous) {
+      return {
+        available: false,
+        reason: "taken" as const,
+        message: "Slug is already used by multiple publishers. Choose a specific owner.",
+        url: null,
+      };
+    }
 
     if (!skill) {
-      const alias = await getSkillSlugAliasBySlug(ctx, slug);
+      const scopedAlias = requestedPublisher
+        ? await getSkillSlugAliasBySlugForAvailabilityPublisher(ctx, slug, requestedPublisher)
+        : null;
+      const unscopedAliasResult = scopedAlias
+        ? null
+        : await getUnscopedSkillSlugAliasBySlugForAvailability(ctx, slug);
+      if (!scopedAlias && unscopedAliasResult?.ambiguous) {
+        return {
+          available: false,
+          reason: "taken" as const,
+          message: "Slug redirects to skills under multiple publishers. Choose a specific owner.",
+          url: null,
+        };
+      }
+      const alias = scopedAlias ?? unscopedAliasResult?.alias;
       if (alias) {
         const aliasedSkill = await ctx.db.get(alias.skillId);
-        const owner = aliasedSkill ? await ctx.db.get(aliasedSkill.ownerUserId) : null;
+        const owner = aliasedSkill
+          ? await getOwnerPublisher(ctx, {
+              ownerPublisherId: aliasedSkill.ownerPublisherId,
+              ownerUserId: aliasedSkill.ownerUserId,
+            })
+          : null;
         return {
           available: false,
           reason: "taken" as const,
@@ -2085,22 +2221,6 @@ export const checkSlugAvailability = query({
       };
     }
 
-    const requestedHandle = normalizePublisherHandle(args.ownerHandle);
-    const materializedRequestedPublisher = requestedHandle
-      ? await getPublisherByHandle(ctx, requestedHandle)
-      : null;
-    const fallbackOwner =
-      requestedHandle && !materializedRequestedPublisher
-        ? await ctx.db.get(skill.ownerUserId)
-        : null;
-    const fallbackRequestedPublisher =
-      fallbackOwner && !fallbackOwner.deletedAt && !fallbackOwner.deactivatedAt
-        ? await getPersonalPublisherForUserOrFallback(ctx, fallbackOwner)
-        : null;
-    const requestedPublisher =
-      fallbackRequestedPublisher?.handle === requestedHandle
-        ? fallbackRequestedPublisher
-        : materializedRequestedPublisher;
     const requestedPublisherMatchesSkill = requestedPublisher
       ? skill.ownerPublisherId
         ? requestedPublisher._id === skill.ownerPublisherId
@@ -2128,7 +2248,10 @@ export const checkSlugAvailability = query({
       }
     }
 
-    const owner = await ctx.db.get(skill.ownerUserId);
+    const owner = await getOwnerPublisher(ctx, {
+      ownerPublisherId: skill.ownerPublisherId,
+      ownerUserId: skill.ownerUserId,
+    });
     const url = buildConflictingSkillUrl(skill, owner);
     const slugTakenMessage = buildSlugTakenErrorMessage(skill, owner);
 


### PR DESCRIPTION
## Summary

This is a critical prod bug, wanted to help address it asap. 🤷‍♂️ 

  - What changed: Fixed `skills.checkSlugAvailability` so duplicate scoped slugs across publishers return a
  validation result instead of throwing a Convex server error. Added owner+slug indexes for scoped skill and
  alias availability lookups, plus regression coverage.
  - Why: Typing in the `/skills/publish` slug field could call a global `by_slug().unique()` lookup. With
  publisher-scoped namespaces, duplicate slugs can legitimately exist, and `unique()` throws when multiple rows
  match.

  ## Linked Issue

  - Closes #2178 
  - Related #2177

  ## Screenshots

  N/A

  ## Security / Trust Impact

  - [ ] No security/trust impact
  - [x] Security/trust impact explained

  This touches publish preflight validation only. It preserves slug collision blocking behavior and changes duplicate scoped-slug cases from an unhandled server error to a normal unavailable-slug response.

  ## Data / Deploy Impact

  - [ ] No data/deploy impact
  - [x] Data/deploy impact explained

  Adds Convex indexes on `skills` and `skillSlugAliases` for `(ownerUserId, slug)` and `(ownerPublisherId, slug)`. Convex will build these indexes on deploy.

  ## Verification

  - [ ] `bun run format:check`
  - [ ] `bun run lint`
  - [ ] `bun run test`
  - [x] Other:
    - `npm test -- convex/skills.slugAvailability.test.ts`
    - `node_modules/.bin/oxfmt --check convex/skills.ts convex/schema.ts convex/skills.slugAvailability.test.ts`
    - `node_modules/.bin/oxlint --type-aware --tsconfig ./tsconfig.oxlint.json convex/skills.ts convex/schema.ts
  convex/skills.slugAvailability.test.ts`
    - `git diff --check`