### PR TITLE
fix(cli): show owners in skill search results

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -437,6 +437,13 @@ describe("httpApiV1 handlers", () => {
     const runAction = vi.fn().mockResolvedValue([
       {
         score: 1,
+        ownerHandle: "openclaw",
+        owner: {
+          handle: "openclaw",
+          displayName: "OpenClaw",
+          image: "https://example.com/openclaw.png",
+          bio: "extra publisher fields stay private to search",
+        },
         skill: { slug: "a", displayName: "A", summary: null, updatedAt: 1 },
         version: { version: "1.0.0" },
       },
@@ -455,6 +462,19 @@ describe("httpApiV1 handlers", () => {
       highlightedOnly: true,
       nonSuspiciousOnly: undefined,
     });
+    const body = await response.json();
+    expect(body.results[0]).toMatchObject({
+      score: 1,
+      slug: "a",
+      displayName: "A",
+      ownerHandle: "openclaw",
+      owner: {
+        handle: "openclaw",
+        displayName: "OpenClaw",
+        image: "https://example.com/openclaw.png",
+      },
+    });
+    expect(body.results[0].owner.bio).toBeUndefined();
   });
 
   it("search forwards nonSuspiciousOnly", async () => {

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -37,6 +37,12 @@ import {
 
 type SearchSkillEntry = {
   score: number;
+  ownerHandle?: string | null;
+  owner?: {
+    handle?: string | null;
+    displayName?: string | null;
+    image?: string | null;
+  } | null;
   skill: {
     slug?: string;
     displayName?: string;
@@ -434,14 +440,25 @@ export async function searchSkillsV1Handler(ctx: ActionCtx, request: Request) {
 
   return json(
     {
-      results: results.map((result) => ({
-        score: result.score,
-        slug: result.skill?.slug,
-        displayName: result.skill?.displayName,
-        summary: result.skill?.summary ?? null,
-        version: result.version?.version ?? null,
-        updatedAt: result.skill?.updatedAt,
-      })),
+      results: results.map((result) => {
+        const ownerHandle = result.ownerHandle ?? result.owner?.handle ?? null;
+        return {
+          score: result.score,
+          slug: result.skill?.slug,
+          displayName: result.skill?.displayName,
+          summary: result.skill?.summary ?? null,
+          version: result.version?.version ?? null,
+          updatedAt: result.skill?.updatedAt,
+          ownerHandle,
+          owner: result.owner
+            ? {
+                handle: result.owner.handle ?? null,
+                displayName: result.owner.displayName ?? null,
+                image: result.owner.image ?? null,
+              }
+            : null,
+        };
+      }),
     },
     200,
     rate.headers,

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -781,11 +781,12 @@ async function getSkillBySlugForAvailabilityPublisher(
     .take(2);
   if (scopedSkills[0]) return scopedSkills[0];
 
-  if (publisher.kind !== "user" || !publisher.linkedUserId) return null;
+  const linkedUserId = publisher.linkedUserId;
+  if (publisher.kind !== "user" || !linkedUserId) return null;
 
   const legacySkills = await ctx.db
     .query("skills")
-    .withIndex("by_owner_slug", (q) => q.eq("ownerUserId", publisher.linkedUserId).eq("slug", slug))
+    .withIndex("by_owner_slug", (q) => q.eq("ownerUserId", linkedUserId).eq("slug", slug))
     .take(2);
   return (
     legacySkills.find(

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -98,6 +98,7 @@ Stores your API token + cached registry URL.
 ### `search <query...>`
 
 - Calls `/api/v1/search?q=...`.
+- Output: `<slug>[ v<version>]  @<owner>  <name>  (<score>)`; use the slug before any version suffix as the install slug.
 - Search favors exact slug/name token matches before download popularity. A standalone slug token such as `map` matches `personal-map` more strongly than the substring inside `amap`.
 - Downloads are a small popularity prior, not a guarantee of top placement.
 - If a skill should appear but does not, run `clawhub inspect <slug>` while logged in to check owner-visible moderation diagnostics before renaming metadata.

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -100,6 +100,12 @@ Response:
       "displayName": "GifGrep",
       "summary": "…",
       "version": "1.2.3",
+      "ownerHandle": "openclaw",
+      "owner": {
+        "handle": "openclaw",
+        "displayName": "OpenClaw",
+        "image": "https://example.com/avatar.png"
+      },
       "updatedAt": 1730000000000
     }
   ]
@@ -108,6 +114,7 @@ Response:
 
 Notes:
 
+- `ownerHandle` and `owner` disambiguate same-named skills in search clients. Install commands still use the bare `slug`.
 - Results are returned in relevance order (embedding similarity + exact slug/name token boosts + popularity prior from downloads).
 - Relevance is stronger than popularity. A precise slug or display-name token match can outrank a looser match with many more downloads.
 - ASCII text is tokenized on word and punctuation boundaries. For example, `personal-map` contains a standalone `map` token, while `amap-jsapi-skill` contains `amap`, `jsapi`, and `skill`; searching for `map` therefore gives `personal-map` a stronger lexical match than `amap-jsapi-skill`.

--- a/packages/clawhub/src/cli/commands/skills.test.ts
+++ b/packages/clawhub/src/cli/commands/skills.test.ts
@@ -254,6 +254,47 @@ describe("cmdSearch", () => {
     const url = new URL(String(requestArgs?.url));
     expect(url.searchParams.get("limit")).toBe("5");
   });
+
+  it("prints owner handles as a separate search column", async () => {
+    mockGetOptionalAuthToken.mockResolvedValue(undefined);
+    mockApiRequest.mockResolvedValue({
+      results: [
+        {
+          slug: "weather",
+          displayName: "Weather",
+          version: "1.0.0",
+          ownerHandle: "steipete",
+          owner: { handle: "steipete", displayName: "Peter Steinberger", image: null },
+          score: 4.553,
+        },
+      ],
+    });
+
+    await cmdSearch(makeOpts(), "weather", 1);
+
+    expect(mockLog).toHaveBeenCalledWith("weather v1.0.0  @steipete  Weather  (4.553)");
+    expect(mockLog).not.toHaveBeenCalledWith(expect.stringContaining("steipete/weather"));
+  });
+
+  it("falls back without crashing when search owner metadata is absent", async () => {
+    mockGetOptionalAuthToken.mockResolvedValue(undefined);
+    mockApiRequest.mockResolvedValue({
+      results: [
+        {
+          slug: "weather",
+          displayName: "Weather",
+          version: null,
+          ownerHandle: null,
+          owner: null,
+          score: 1,
+        },
+      ],
+    });
+
+    await cmdSearch(makeOpts(), "weather", 1);
+
+    expect(mockLog).toHaveBeenCalledWith("weather  unknown owner  Weather  (1.000)");
+  });
 });
 
 describe("skill moderation commands", () => {

--- a/packages/clawhub/src/cli/commands/skills.ts
+++ b/packages/clawhub/src/cli/commands/skills.ts
@@ -89,6 +89,15 @@ function formatPinnedDetails(entry?: { pinReason?: string }) {
   return entry?.pinReason ? ` (${entry.pinReason})` : "";
 }
 
+function formatSearchOwner(entry: {
+  ownerHandle?: string | null;
+  owner?: { handle?: string | null; displayName?: string | null } | null;
+}) {
+  const handle = entry.ownerHandle ?? entry.owner?.handle ?? null;
+  if (handle) return `@${handle.replace(/^@+/, "")}`;
+  return entry.owner?.displayName?.trim() || "unknown owner";
+}
+
 export async function cmdSearch(opts: GlobalOpts, query: string, limit?: number) {
   if (!query) fail("Query required");
 
@@ -111,7 +120,8 @@ export async function cmdSearch(opts: GlobalOpts, query: string, limit?: number)
       const slug = entry.slug ?? "unknown";
       const name = entry.displayName ?? slug;
       const version = entry.version ? ` v${entry.version}` : "";
-      console.log(`${slug}${version}  ${name}  (${entry.score.toFixed(3)})`);
+      const owner = formatSearchOwner(entry);
+      console.log(`${slug}${version}  ${owner}  ${name}  (${entry.score.toFixed(3)})`);
     }
   } catch (error) {
     spinner.fail(formatError(error));

--- a/packages/clawhub/src/schema/schemas.test.ts
+++ b/packages/clawhub/src/schema/schemas.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, it } from "vitest";
 import { parseArk } from "./ark";
-import { ClawdisSkillMetadataSchema } from "./schemas";
+import { ApiV1SearchResponseSchema, ClawdisSkillMetadataSchema } from "./schemas";
 
 describe("packages/clawhub skill metadata schema", () => {
   it("preserves optional env var declarations", () => {
@@ -22,5 +22,31 @@ describe("packages/clawhub skill metadata schema", () => {
       required: false,
       description: "Default project",
     });
+  });
+
+  it("parses v1 search owner metadata", () => {
+    const parsed = parseArk(
+      ApiV1SearchResponseSchema,
+      {
+        results: [
+          {
+            slug: "weather",
+            displayName: "Weather",
+            version: "1.0.0",
+            score: 4.553,
+            ownerHandle: "steipete",
+            owner: {
+              handle: "steipete",
+              displayName: "Peter Steinberger",
+              image: null,
+            },
+          },
+        ],
+      },
+      "V1 search",
+    );
+
+    expect(parsed.results[0]?.ownerHandle).toBe("steipete");
+    expect(parsed.results[0]?.owner?.handle).toBe("steipete");
   });
 });

--- a/packages/clawhub/src/schema/schemas.ts
+++ b/packages/clawhub/src/schema/schemas.ts
@@ -164,6 +164,14 @@ export const ApiV1SearchResponseSchema = type({
     version: "string|null?",
     score: "number",
     updatedAt: "number?",
+    ownerHandle: "string|null?",
+    owner: type({
+      handle: "string|null",
+      displayName: "string|null?",
+      image: "string|null?",
+    })
+      .or("null")
+      .optional(),
   }).array(),
 });
 

--- a/packages/schema/src/schemas.test.ts
+++ b/packages/schema/src/schemas.test.ts
@@ -6,6 +6,7 @@ import { MAX_CLAWSCAN_NOTE_CHARS, normalizeClawScanNote } from "./clawScanNote";
 import { DocsLinks, openClawDocsUrl } from "./docsLinks";
 import { getPackageScopeOwnerMismatch, inferPackageNameScope } from "./packages";
 import {
+  ApiV1SearchResponseSchema,
   ApiSearchResponseSchema,
   CliPublishRequestSchema,
   CliSkillDeleteRequestSchema,
@@ -186,6 +187,39 @@ describe("clawhub-schema", () => {
     );
     expect(parsed.results).toHaveLength(2);
     expect(parsed.results[0]?.slug).toBe("a");
+  });
+
+  it("parses v1 search owner metadata while accepting older result shapes", async () => {
+    const parsed = parseArk(
+      ApiV1SearchResponseSchema,
+      {
+        results: [
+          {
+            slug: "weather",
+            displayName: "Weather",
+            version: "1.0.0",
+            score: 4.553,
+            ownerHandle: "steipete",
+            owner: {
+              handle: "steipete",
+              displayName: "Peter Steinberger",
+              image: null,
+            },
+          },
+          {
+            slug: "weather-1-0-0",
+            displayName: "Weather 1.0.0",
+            version: null,
+            score: 3.125,
+          },
+        ],
+      },
+      "V1 search",
+    );
+
+    expect(parsed.results[0]?.ownerHandle).toBe("steipete");
+    expect(parsed.results[0]?.owner?.handle).toBe("steipete");
+    expect(parsed.results[1]?.ownerHandle).toBeUndefined();
   });
 
   it("parses delete request payload", () => {

--- a/packages/schema/src/schemas.ts
+++ b/packages/schema/src/schemas.ts
@@ -165,6 +165,14 @@ export const ApiV1SearchResponseSchema = type({
     version: "string|null?",
     score: "number",
     updatedAt: "number?",
+    ownerHandle: "string|null?",
+    owner: type({
+      handle: "string|null",
+      displayName: "string|null?",
+      image: "string|null?",
+    })
+      .or("null")
+      .optional(),
   }).array(),
 });
 


### PR DESCRIPTION
## Summary

- What changed: `/api/v1/search` now includes additive owner metadata for each result, and `clawhub search` renders the owner as a separate column.
- Why: search results with the same or similar slug/display name were indistinguishable in the CLI, which made it easy to pick the wrong bare slug.

## Linked Issue

- Closes #804
- Related #

## Previous result

Before this change, the public search response only carried the result score and skill fields:

```json
{
  "results": [
    {
      "score": 4.553,
      "slug": "weather",
      "displayName": "Weather",
      "summary": null,
      "version": "1.0.0",
      "updatedAt": 1730000000000
    }
  ]
}
```

The CLI rendered only the bare slug, name, and score:

```text
weather  Weather  (4.553)
weather-1-0-0  Weather 1.0.0  (3.125)
```

That left users guessing which `weather` result belonged to which publisher.

## New expected result

The v1 search response now includes `ownerHandle` and a minimal `owner` object:

```json
{
  "results": [
    {
      "score": 4.553,
      "slug": "weather",
      "displayName": "Weather",
      "summary": null,
      "version": "1.0.0",
      "ownerHandle": "steipete",
      "owner": {
        "handle": "steipete",
        "displayName": "Peter Steinberger",
        "image": null
      },
      "updatedAt": 1730000000000
    }
  ]
}
```

The CLI keeps the installable slug first, then shows the owner separately:

```text
weather v1.0.0  @steipete  Weather  (4.553)
weather-1-0-0  @99percentgod  Weather 1.0.0  (3.125)
```

## UX decision

This intentionally does **not** render results as `owner/slug` and does **not** add `clawhub install owner/slug` support in this PR.

`clawhub install` currently accepts bare slugs, and slash-containing locators go through a broader filesystem/lockfile/install contract. Showing the owner as a separate column fixes the ambiguity without teaching users to paste a locator the CLI does not support yet. The first token remains the install slug.

## Contract details

- The API change is additive: older clients can keep ignoring the new fields.
- The shared schema and CLI-local schema both accept the new owner metadata.
- Older/partial search responses without owner fields still parse.
- If owner metadata is absent, the CLI renders a safe fallback instead of crashing.
- The API response exposes only minimal owner display data (`handle`, `displayName`, `image`) instead of passing through the full publisher object.
- A small TypeScript narrowing in slug availability keeps the current `main` typecheck green without changing runtime behavior.

## Screenshots

For website/UI changes, attach screenshots or recordings from the real app. Include mobile/narrow views when layout changes.

- [x] Screenshots/recordings attached, or `N/A`

## Security / Trust Impact

- [ ] No security/trust impact
- [x] Security/trust impact explained

Search responses now expose minimal public publisher identity for disambiguation. The implementation avoids leaking extra publisher fields such as bio or linked user id.

## Data / Deploy Impact

- [ ] No data/deploy impact
- [x] Data/deploy impact explained

No migration is required. Production still needs the normal manual deploy/release flow before the API and CLI package changes reach users.

## Verification

- [x] `bun run format:check`
- [x] `bun run lint`
- [ ] `bun run test`
- [x] Other:

Additional commands run:

```text
bun run test -- packages/clawhub/src/cli/commands/skills.test.ts convex/httpApiV1.handlers.test.ts
bun run --cwd packages/clawhub test -- src/schema/schemas.test.ts src/cli/commands/skills.test.ts
bunx vitest run packages/schema/src/schemas.test.ts --root .
bunx tsc -p packages/schema/tsconfig.json --noEmit
bunx tsc -p packages/clawhub/tsconfig.json --noEmit
bun run --cwd packages/schema build
bun run --cwd packages/clawhub verify:build
bun run ci:static
bun run ci:packages
bun run ci:types-build
bun run test -- convex/skills.slugAvailability.test.ts
bun run ci:unit
bun run ci:e2e-http
```
