### PR TITLE
fix(api): validate missing package search query

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -5590,46 +5590,52 @@ describe("httpApiV1 handlers", () => {
     });
   });
 
-  it("treats /packages/search without q as a package detail route", async () => {
+  it("rejects packages search when q is missing", async () => {
     const runMutation = vi.fn().mockResolvedValue(okRate());
-    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
-      if ("name" in args) {
-        return {
-          package: {
-            _id: "packages:search",
-            name: "search",
-            displayName: "Search Package",
-            family: "code-plugin",
-            tags: {},
-            latestReleaseId: null,
-            channel: "community",
-            isOfficial: false,
-            createdAt: 1,
-            updatedAt: 1,
-          },
-          latestRelease: null,
-          owner: null,
-        };
-      }
-      return [];
-    });
+    const runQuery = vi.fn();
 
     const response = await __handlers.packagesGetRouterV1Handler(
       makeCtx({ runQuery, runMutation }),
       new Request("https://example.com/api/v1/packages/search"),
     );
 
+    expect(response.status).toBe(400);
+    await expect(response.text()).resolves.toBe("Missing q query parameter");
+    expect(runQuery).not.toHaveBeenCalled();
+  });
+
+  it("rejects packages search when q is empty", async () => {
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const runQuery = vi.fn();
+
+    const response = await __handlers.packagesGetRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/packages/search?q=%20%20"),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.text()).resolves.toBe("Missing q query parameter");
+    expect(runQuery).not.toHaveBeenCalled();
+  });
+
+  it("routes packages search with q to catalog search", async () => {
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("query" in args) return [];
+      throw new Error(`Unexpected query args: ${JSON.stringify(args)}`);
+    });
+
+    const response = await __handlers.packagesGetRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/packages/search?q=demo"),
+    );
+
     expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ results: [] });
     expect(runQuery).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        name: "search",
-      }),
-    );
-    expect(runQuery).not.toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        query: expect.any(String),
+        query: "demo",
       }),
     );
   });

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -5640,6 +5640,25 @@ describe("httpApiV1 handlers", () => {
     );
   });
 
+  it("does not route packages search subpaths to catalog search", async () => {
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const runQuery = vi.fn().mockResolvedValue(null);
+
+    const response = await __handlers.packagesGetRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/packages/search/extra?q=demo"),
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Package not found");
+    expect(runQuery).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: "demo",
+      }),
+    );
+  });
+
   it("package download uses download rate limiting", async () => {
     const runMutation = vi.fn().mockResolvedValue(okRate());
     const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -1985,6 +1985,7 @@ async function searchPackages(
   const url = new URL(request.url);
   const viewerUserId = await getOptionalViewerUserIdForRequest(ctx, request);
   const queryText = url.searchParams.get("q")?.trim() ?? "";
+  if (!queryText) return text("Missing q query parameter", 400, rate.headers);
   const limit = Math.max(1, Math.min(toOptionalNumber(url.searchParams.get("limit")) ?? 20, 100));
   const familyRaw = url.searchParams.get("family");
   const channelRaw = url.searchParams.get("channel");
@@ -2105,7 +2106,7 @@ async function searchPackages(
 export async function packagesGetRouterV1Handler(ctx: ActionCtx, request: Request) {
   const segments = getPathSegments(request, "/api/v1/packages/");
   if (segments.length === 0) return text("Not found", 404);
-  if (segments[0] === "search" && new URL(request.url).searchParams.has("q")) {
+  if (segments[0] === "search") {
     return await searchPackages(ctx, request, { includeSkills: true });
   }
 

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -2106,7 +2106,7 @@ async function searchPackages(
 export async function packagesGetRouterV1Handler(ctx: ActionCtx, request: Request) {
   const segments = getPathSegments(request, "/api/v1/packages/");
   if (segments.length === 0) return text("Not found", 404);
-  if (segments[0] === "search") {
+  if (segments[0] === "search" && segments.length === 1) {
     return await searchPackages(ctx, request, { includeSkills: true });
   }
 


### PR DESCRIPTION
## Summary

- What changed: `/api/v1/packages/search` now matches the exact search route even when `q` is missing, validates the trimmed query, and returns `400` for missing or blank `q`.
- Why: the documented search endpoint requires `q`; the previous router fell through to package-detail handling and could return misleading package lookup behavior.
- Guardrail: `/api/v1/packages/search/...` subpaths are not treated as catalog search.

## Linked Issue

- Closes N/A
- Related N/A

## Screenshots

- [x] N/A

## Security / Trust Impact

- [x] No security/trust impact
- [ ] Security/trust impact explained

## Data / Deploy Impact

- [x] No data/deploy impact
- [ ] Data/deploy impact explained

## Verification

- [x] `bun run ci:static`
- [x] `bun run test -- convex/httpApiV1.handlers.test.ts -t "packages search"`
- [x] `bun run format:check -- convex/httpApiV1/packagesV1.ts convex/httpApiV1.handlers.test.ts`
- [x] `git diff --check`
- [x] Direct exported-handler smoke:

```text
/api/v1/packages/search -> 400 text/plain; charset=utf-8 Missing q query parameter
/api/v1/packages/search?q=%20%20 -> 400 text/plain; charset=utf-8 Missing q query parameter
/api/v1/packages/search?q=demo -> 200 application/json {"results":[]}
/api/v1/packages/search/extra?q=demo -> 404 text/plain; charset=utf-8 Package not found
```

CI note: Vercel preview requires team authorization. The current `types-build` failure matches `main` at `af96221e` and reports `convex/skills.ts(788,60)`, outside this PR's touched files.
