### PR TITLE
docs(api): update v1 OpenAPI catalog contract

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -37,8 +37,9 @@ Auth-aware enforcement:
 - Authenticated requests (valid Bearer token): per user bucket.
 - Missing/invalid token falls back to IP enforcement.
 
-- Read: 600/min per IP, 2400/min per key
-- Write: 45/min per IP, 180/min per key
+- Read: 3000/min per IP, 12000/min per key
+- Write: 300/min per IP, 3000/min per key
+- Download: 1200/min per IP, 6000/min per key
 
 Headers: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, `RateLimit-Limit`, `RateLimit-Remaining`, `RateLimit-Reset`, `Retry-After` (on 429).
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -33,9 +33,9 @@ Enforcement model:
   deleted/banned/disabled accounts should each get actionable text so CLI
   clients can tell users what blocked them.
 
-- Read: 600/min per IP, 2400/min per key
-- Write: 45/min per IP, 180/min per key
-- Download: 30/min per IP, 180/min per key (`/api/v1/download`)
+- Read: 3000/min per IP, 12000/min per key
+- Write: 300/min per IP, 3000/min per key
+- Download: 1200/min per IP, 6000/min per key (download endpoints)
 
 Headers:
 

--- a/public/api/v1/openapi.json
+++ b/public/api/v1/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "ClawHub API",
     "version": "1.0.0",
-    "description": "Public REST API for ClawHub skills and package catalog endpoints. Rate limits: read 600/min per IP + 2400/min per key; write 45/min per IP + 180/min per key; download 30/min per IP + 180/min per key. Responses include RateLimit-* and legacy X-RateLimit-* headers; 429 responses include Retry-After."
+    "description": "Public REST API for ClawHub skills and package catalog endpoints. Rate limits: read 3000/min per IP + 12000/min per key; write 300/min per IP + 3000/min per key; download 1200/min per IP + 6000/min per key. Responses include RateLimit-* and legacy X-RateLimit-* headers; 429 responses include Retry-After."
   },
   "servers": [{ "url": "https://clawhub.ai" }],
   "components": {

--- a/public/api/v1/openapi.json
+++ b/public/api/v1/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "ClawHub API",
     "version": "1.0.0",
-    "description": "Public REST API for skills. Rate limits: read 120/min per IP + 600/min per key; write 30/min per IP + 120/min per key."
+    "description": "Public REST API for ClawHub skills and package catalog endpoints. Rate limits: read 600/min per IP + 2400/min per key; write 45/min per IP + 180/min per key; download 30/min per IP + 180/min per key. Responses include RateLimit-* and legacy X-RateLimit-* headers; 429 responses include Retry-After."
   },
   "servers": [{ "url": "https://clawhub.ai" }],
   "components": {
@@ -250,6 +250,273 @@
             }
           }
         }
+      },
+      "PackageCompatibility": {
+        "type": "object",
+        "properties": {
+          "pluginApiRange": { "type": "string" },
+          "builtWithOpenClawVersion": { "type": "string" },
+          "pluginSdkVersion": { "type": "string" },
+          "minGatewayVersion": { "type": "string" }
+        }
+      },
+      "PackageCapabilities": {
+        "type": "object",
+        "properties": {
+          "executesCode": { "type": "boolean" },
+          "runtimeId": { "type": "string" },
+          "pluginKind": { "type": "string" },
+          "channels": { "type": "array", "items": { "type": "string" } },
+          "providers": { "type": "array", "items": { "type": "string" } },
+          "hooks": { "type": "array", "items": { "type": "string" } },
+          "bundledSkills": { "type": "array", "items": { "type": "string" } },
+          "setupEntry": { "type": "boolean" },
+          "configSchema": { "type": "boolean" },
+          "configUiHints": { "type": "boolean" },
+          "materializesDependencies": { "type": "boolean" },
+          "toolNames": { "type": "array", "items": { "type": "string" } },
+          "commandNames": { "type": "array", "items": { "type": "string" } },
+          "serviceNames": { "type": "array", "items": { "type": "string" } },
+          "capabilityTags": { "type": "array", "items": { "type": "string" } },
+          "httpRouteCount": { "type": "number" },
+          "bundleFormat": { "type": "string" },
+          "hostTargets": { "type": "array", "items": { "type": "string" } }
+        }
+      },
+      "PackageVerification": {
+        "type": "object",
+        "properties": {
+          "tier": {
+            "type": "string",
+            "enum": ["structural", "source-linked", "provenance-verified", "rebuild-verified"]
+          },
+          "scope": { "type": "string", "enum": ["artifact-only", "dependency-graph-aware"] },
+          "summary": { "type": "string" },
+          "sourceRepo": { "type": "string" },
+          "sourceCommit": { "type": "string" },
+          "sourceTag": { "type": "string" },
+          "hasProvenance": { "type": "boolean" },
+          "scanStatus": {
+            "type": "string",
+            "enum": ["clean", "suspicious", "malicious", "pending", "not-run"]
+          }
+        }
+      },
+      "PackageArtifactSummary": {
+        "type": "object",
+        "properties": {
+          "kind": { "type": "string", "enum": ["legacy-zip", "npm-pack"] },
+          "sha256": { "type": "string" },
+          "size": { "type": "number" },
+          "format": { "type": "string" },
+          "npmIntegrity": { "type": "string" },
+          "npmShasum": { "type": "string" },
+          "npmTarballName": { "type": "string" },
+          "npmUnpackedSize": { "type": "number" },
+          "npmFileCount": { "type": "number" },
+          "source": { "type": "string", "enum": ["clawhub"] },
+          "artifactKind": { "type": "string", "enum": ["legacy-zip", "npm-pack"] },
+          "artifactSha256": { "type": "string" },
+          "packageName": { "type": "string" },
+          "version": { "type": "string" }
+        }
+      },
+      "PackageStats": {
+        "type": "object",
+        "properties": {
+          "downloads": { "type": "number" },
+          "installs": { "type": "number" },
+          "stars": { "type": "number" },
+          "versions": { "type": "number" }
+        }
+      },
+      "PackageCatalogItem": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "displayName": { "type": "string" },
+          "family": { "type": "string", "enum": ["skill", "code-plugin", "bundle-plugin"] },
+          "runtimeId": { "type": ["string", "null"] },
+          "channel": { "type": "string", "enum": ["official", "community", "private"] },
+          "isOfficial": { "type": "boolean" },
+          "summary": { "type": ["string", "null"] },
+          "ownerHandle": { "type": ["string", "null"] },
+          "createdAt": { "type": "number" },
+          "updatedAt": { "type": "number" },
+          "latestVersion": { "type": ["string", "null"] },
+          "capabilityTags": { "type": "array", "items": { "type": "string" } },
+          "executesCode": { "type": "boolean" },
+          "verificationTier": {
+            "type": ["string", "null"],
+            "enum": ["structural", "source-linked", "provenance-verified", "rebuild-verified", null]
+          }
+        }
+      },
+      "PackageListResponse": {
+        "type": "object",
+        "properties": {
+          "items": { "type": "array", "items": { "$ref": "#/components/schemas/PackageCatalogItem" } },
+          "nextCursor": { "type": ["string", "null"] }
+        }
+      },
+      "PackageSearchResponse": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "score": { "type": "number" },
+                "package": { "$ref": "#/components/schemas/PackageCatalogItem" }
+              }
+            }
+          }
+        }
+      },
+      "PackageResponse": {
+        "type": "object",
+        "properties": {
+          "package": {
+            "type": ["object", "null"],
+            "properties": {
+              "name": { "type": "string" },
+              "displayName": { "type": "string" },
+              "family": { "type": "string", "enum": ["skill", "code-plugin", "bundle-plugin"] },
+              "runtimeId": { "type": ["string", "null"] },
+              "channel": { "type": "string", "enum": ["official", "community", "private"] },
+              "isOfficial": { "type": "boolean" },
+              "summary": { "type": ["string", "null"] },
+              "ownerHandle": { "type": ["string", "null"] },
+              "createdAt": { "type": "number" },
+              "updatedAt": { "type": "number" },
+              "latestVersion": { "type": ["string", "null"] },
+              "tags": { "type": "object", "additionalProperties": true },
+              "compatibility": { "anyOf": [{ "$ref": "#/components/schemas/PackageCompatibility" }, { "type": "null" }] },
+              "capabilities": { "anyOf": [{ "$ref": "#/components/schemas/PackageCapabilities" }, { "type": "null" }] },
+              "verification": { "anyOf": [{ "$ref": "#/components/schemas/PackageVerification" }, { "type": "null" }] },
+              "artifact": { "anyOf": [{ "$ref": "#/components/schemas/PackageArtifactSummary" }, { "type": "null" }] },
+              "stats": { "$ref": "#/components/schemas/PackageStats" }
+            }
+          },
+          "owner": { "$ref": "#/components/schemas/Owner" }
+        }
+      },
+      "PackageVersionListResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "version": { "type": "string" },
+                "createdAt": { "type": "number" },
+                "changelog": { "type": "string" },
+                "distTags": { "type": "array", "items": { "type": "string" } }
+              }
+            }
+          },
+          "nextCursor": { "type": ["string", "null"] }
+        }
+      },
+      "PackageFileEntry": {
+        "type": "object",
+        "properties": {
+          "path": { "type": "string" },
+          "size": { "type": "number" },
+          "sha256": { "type": "string" },
+          "contentType": { "type": ["string", "null"] }
+        }
+      },
+      "PackageVersionResponse": {
+        "type": "object",
+        "properties": {
+          "package": {
+            "type": ["object", "null"],
+            "properties": {
+              "name": { "type": "string" },
+              "displayName": { "type": "string" },
+              "family": { "type": "string", "enum": ["skill", "code-plugin", "bundle-plugin"] }
+            }
+          },
+          "version": {
+            "type": ["object", "null"],
+            "properties": {
+              "version": { "type": "string" },
+              "createdAt": { "type": "number" },
+              "changelog": { "type": "string" },
+              "distTags": { "type": "array", "items": { "type": "string" } },
+              "files": { "type": "array", "items": { "$ref": "#/components/schemas/PackageFileEntry" } },
+              "compatibility": { "anyOf": [{ "$ref": "#/components/schemas/PackageCompatibility" }, { "type": "null" }] },
+              "capabilities": { "anyOf": [{ "$ref": "#/components/schemas/PackageCapabilities" }, { "type": "null" }] },
+              "verification": { "anyOf": [{ "$ref": "#/components/schemas/PackageVerification" }, { "type": "null" }] },
+              "artifact": { "anyOf": [{ "$ref": "#/components/schemas/PackageArtifactSummary" }, { "type": "null" }] },
+              "sha256hash": { "type": ["string", "null"] },
+              "vtAnalysis": { "type": ["object", "null"], "additionalProperties": true },
+              "llmAnalysis": { "type": ["object", "null"], "additionalProperties": true },
+              "clawScanNote": { "type": ["string", "null"] },
+              "clawScanNoteUpdatedAt": { "type": ["number", "null"] },
+              "staticScan": { "type": ["object", "null"], "additionalProperties": true }
+            }
+          }
+        }
+      },
+      "PackageArtifactResponse": {
+        "type": "object",
+        "properties": {
+          "package": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "displayName": { "type": "string" },
+              "family": { "type": "string", "enum": ["skill", "code-plugin", "bundle-plugin"] }
+            }
+          },
+          "version": { "type": "string" },
+          "artifact": {
+            "allOf": [
+              { "$ref": "#/components/schemas/PackageArtifactSummary" },
+              {
+                "type": "object",
+                "properties": {
+                  "downloadUrl": { "type": "string" },
+                  "tarballUrl": { "type": "string" },
+                  "legacyDownloadUrl": { "type": "string" }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "PackageReadinessResponse": {
+        "type": "object",
+        "properties": {
+          "package": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "displayName": { "type": "string" },
+              "family": { "type": "string", "enum": ["skill", "code-plugin", "bundle-plugin"] },
+              "isOfficial": { "type": "boolean" },
+              "latestVersion": { "type": ["string", "null"] }
+            }
+          },
+          "ready": { "type": "boolean" },
+          "checks": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "label": { "type": "string" },
+                "status": { "type": "string", "enum": ["pass", "warn", "fail"] },
+                "message": { "type": "string" }
+              }
+            }
+          },
+          "blockers": { "type": "array", "items": { "type": "string" } }
+        }
       }
     }
   },
@@ -348,6 +615,269 @@
         },
         "responses": {
           "200": { "description": "Published", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PublishResponse" } } } }
+        }
+      }
+    },
+    "/api/v1/packages": {
+      "get": {
+        "summary": "List unified catalog packages",
+        "description": "Lists skills, code plugins, and bundle plugins. Anonymous callers see public package channels; authenticated callers can also see readable private packages.",
+        "security": [{}, { "bearerAuth": [] }],
+        "parameters": [
+          { "name": "limit", "in": "query", "required": false, "schema": { "type": "integer", "minimum": 1, "maximum": 100 } },
+          { "name": "cursor", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "family", "in": "query", "required": false, "schema": { "type": "string", "enum": ["skill", "code-plugin", "bundle-plugin"] } },
+          { "name": "channel", "in": "query", "required": false, "schema": { "type": "string", "enum": ["official", "community", "private"] } },
+          { "name": "isOfficial", "in": "query", "required": false, "schema": { "type": "boolean" } },
+          { "name": "executesCode", "in": "query", "required": false, "schema": { "type": "boolean" } },
+          { "name": "capabilityTag", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "target", "in": "query", "required": false, "schema": { "type": "string" }, "description": "Shorthand for a host capability tag." },
+          { "name": "hostTarget", "in": "query", "required": false, "schema": { "type": "string" }, "description": "Shorthand for a host capability tag." },
+          { "name": "os", "in": "query", "required": false, "schema": { "type": "string" }, "description": "Shorthand for a host OS capability tag." },
+          { "name": "arch", "in": "query", "required": false, "schema": { "type": "string" }, "description": "Shorthand for a host architecture capability tag." },
+          { "name": "libc", "in": "query", "required": false, "schema": { "type": "string" }, "description": "Shorthand for a host libc capability tag." },
+          { "name": "requiresBrowser", "in": "query", "required": false, "schema": { "type": "boolean" } },
+          { "name": "requiresDesktop", "in": "query", "required": false, "schema": { "type": "boolean" } },
+          { "name": "requiresNativeDeps", "in": "query", "required": false, "schema": { "type": "boolean" } },
+          { "name": "requiresExternalService", "in": "query", "required": false, "schema": { "type": "boolean" } },
+          { "name": "requiresBinary", "in": "query", "required": false, "schema": { "type": "boolean" } },
+          { "name": "requiresOsPermission", "in": "query", "required": false, "schema": { "type": "boolean" } },
+          { "name": "externalService", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "binary", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "osPermission", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "artifactKind", "in": "query", "required": false, "schema": { "type": "string", "enum": ["legacy-zip", "npm-pack"] } },
+          { "name": "npmMirror", "in": "query", "required": false, "schema": { "type": "boolean" }, "description": "true/1 filters for ClawPack-backed versions available through the npm mirror." }
+        ],
+        "responses": {
+          "200": { "description": "Catalog page", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PackageListResponse" } } } },
+          "429": { "description": "Rate limit exceeded" }
+        }
+      }
+    },
+    "/api/v1/plugins": {
+      "get": {
+        "summary": "List plugin catalog packages",
+        "description": "Lists code-plugin and bundle-plugin catalog entries.",
+        "security": [{}, { "bearerAuth": [] }],
+        "parameters": [
+          { "name": "limit", "in": "query", "required": false, "schema": { "type": "integer", "minimum": 1, "maximum": 100 } },
+          { "name": "cursor", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "channel", "in": "query", "required": false, "schema": { "type": "string", "enum": ["official", "community", "private"] } },
+          { "name": "isOfficial", "in": "query", "required": false, "schema": { "type": "boolean" } },
+          { "name": "executesCode", "in": "query", "required": false, "schema": { "type": "boolean" } },
+          { "name": "capabilityTag", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "artifactKind", "in": "query", "required": false, "schema": { "type": "string", "enum": ["legacy-zip", "npm-pack"] } },
+          { "name": "npmMirror", "in": "query", "required": false, "schema": { "type": "boolean" } }
+        ],
+        "responses": {
+          "200": { "description": "Plugin catalog page", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PackageListResponse" } } } }
+        }
+      }
+    },
+    "/api/v1/code-plugins": {
+      "get": {
+        "summary": "List code plugin catalog packages",
+        "security": [{}, { "bearerAuth": [] }],
+        "parameters": [
+          { "name": "limit", "in": "query", "required": false, "schema": { "type": "integer", "minimum": 1, "maximum": 100 } },
+          { "name": "cursor", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "channel", "in": "query", "required": false, "schema": { "type": "string", "enum": ["official", "community", "private"] } },
+          { "name": "isOfficial", "in": "query", "required": false, "schema": { "type": "boolean" } },
+          { "name": "executesCode", "in": "query", "required": false, "schema": { "type": "boolean" } },
+          { "name": "capabilityTag", "in": "query", "required": false, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Code plugin catalog page", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PackageListResponse" } } } }
+        }
+      }
+    },
+    "/api/v1/bundle-plugins": {
+      "get": {
+        "summary": "List bundle plugin catalog packages",
+        "security": [{}, { "bearerAuth": [] }],
+        "parameters": [
+          { "name": "limit", "in": "query", "required": false, "schema": { "type": "integer", "minimum": 1, "maximum": 100 } },
+          { "name": "cursor", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "channel", "in": "query", "required": false, "schema": { "type": "string", "enum": ["official", "community", "private"] } },
+          { "name": "isOfficial", "in": "query", "required": false, "schema": { "type": "boolean" } },
+          { "name": "executesCode", "in": "query", "required": false, "schema": { "type": "boolean" } },
+          { "name": "capabilityTag", "in": "query", "required": false, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Bundle plugin catalog page", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PackageListResponse" } } } }
+        }
+      }
+    },
+    "/api/v1/packages/search": {
+      "get": {
+        "summary": "Search unified package catalog",
+        "description": "Searches skills and plugin packages.",
+        "security": [{}, { "bearerAuth": [] }],
+        "parameters": [
+          { "name": "q", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "limit", "in": "query", "required": false, "schema": { "type": "integer", "minimum": 1, "maximum": 100 } },
+          { "name": "family", "in": "query", "required": false, "schema": { "type": "string", "enum": ["skill", "code-plugin", "bundle-plugin"] } },
+          { "name": "channel", "in": "query", "required": false, "schema": { "type": "string", "enum": ["official", "community", "private"] } },
+          { "name": "isOfficial", "in": "query", "required": false, "schema": { "type": "boolean" } },
+          { "name": "executesCode", "in": "query", "required": false, "schema": { "type": "boolean" } },
+          { "name": "capabilityTag", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "artifactKind", "in": "query", "required": false, "schema": { "type": "string", "enum": ["legacy-zip", "npm-pack"] } },
+          { "name": "npmMirror", "in": "query", "required": false, "schema": { "type": "boolean" } }
+        ],
+        "responses": {
+          "200": { "description": "Catalog search results", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PackageSearchResponse" } } } }
+        }
+      }
+    },
+    "/api/v1/plugins/search": {
+      "get": {
+        "summary": "Search plugin catalog packages",
+        "description": "Searches code-plugin and bundle-plugin catalog entries.",
+        "security": [{}, { "bearerAuth": [] }],
+        "parameters": [
+          { "name": "q", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "limit", "in": "query", "required": false, "schema": { "type": "integer", "minimum": 1, "maximum": 100 } },
+          { "name": "channel", "in": "query", "required": false, "schema": { "type": "string", "enum": ["official", "community", "private"] } },
+          { "name": "isOfficial", "in": "query", "required": false, "schema": { "type": "boolean" } },
+          { "name": "executesCode", "in": "query", "required": false, "schema": { "type": "boolean" } },
+          { "name": "capabilityTag", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "artifactKind", "in": "query", "required": false, "schema": { "type": "string", "enum": ["legacy-zip", "npm-pack"] } },
+          { "name": "npmMirror", "in": "query", "required": false, "schema": { "type": "boolean" } }
+        ],
+        "responses": {
+          "200": { "description": "Plugin catalog search results", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PackageSearchResponse" } } } }
+        }
+      }
+    },
+    "/api/v1/packages/{name}": {
+      "get": {
+        "summary": "Get package detail",
+        "description": "Returns package detail metadata. Skills can also resolve through this unified catalog route.",
+        "security": [{}, { "bearerAuth": [] }],
+        "parameters": [
+          { "name": "name", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Package name. Scoped package names must be URL path encoded." }
+        ],
+        "responses": {
+          "200": { "description": "Package detail", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PackageResponse" } } } },
+          "404": { "description": "Not found" }
+        }
+      }
+    },
+    "/api/v1/packages/{name}/versions": {
+      "get": {
+        "summary": "List package versions",
+        "security": [{}, { "bearerAuth": [] }],
+        "parameters": [
+          { "name": "name", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Package name. Scoped package names must be URL path encoded." },
+          { "name": "limit", "in": "query", "required": false, "schema": { "type": "integer", "minimum": 1, "maximum": 100 } },
+          { "name": "cursor", "in": "query", "required": false, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Package versions", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PackageVersionListResponse" } } } },
+          "404": { "description": "Not found" }
+        }
+      }
+    },
+    "/api/v1/packages/{name}/versions/{version}": {
+      "get": {
+        "summary": "Get package version",
+        "description": "Returns file metadata, compatibility, capabilities, verification, artifact metadata, and scan data for one package version.",
+        "security": [{}, { "bearerAuth": [] }],
+        "parameters": [
+          { "name": "name", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Package name. Scoped package names must be URL path encoded." },
+          { "name": "version", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Package version", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PackageVersionResponse" } } } },
+          "404": { "description": "Not found" }
+        }
+      }
+    },
+    "/api/v1/packages/{name}/versions/{version}/artifact": {
+      "get": {
+        "summary": "Get package artifact resolver metadata",
+        "description": "Returns explicit artifact resolver metadata for a package version, including format-specific download URLs.",
+        "security": [{}, { "bearerAuth": [] }],
+        "parameters": [
+          { "name": "name", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Package name. Scoped package names must be URL path encoded." },
+          { "name": "version", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Artifact metadata", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PackageArtifactResponse" } } } },
+          "404": { "description": "Not found" }
+        }
+      }
+    },
+    "/api/v1/packages/{name}/versions/{version}/artifact/download": {
+      "get": {
+        "summary": "Download package version artifact",
+        "description": "Streams npm-pack ClawPack bytes or redirects legacy ZIP versions to the package download endpoint. Uses the download rate bucket.",
+        "security": [{}, { "bearerAuth": [] }],
+        "parameters": [
+          { "name": "name", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Package name. Scoped package names must be URL path encoded." },
+          { "name": "version", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Artifact bytes",
+            "content": { "application/octet-stream": { "schema": { "type": "string", "format": "binary" } } }
+          },
+          "307": { "description": "Redirect to legacy ZIP download" },
+          "403": { "description": "Blocked by package moderation" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Rate limit exceeded" }
+        }
+      }
+    },
+    "/api/v1/packages/{name}/readiness": {
+      "get": {
+        "summary": "Get package OpenClaw readiness",
+        "description": "Returns computed readiness checks for OpenClaw consumption.",
+        "security": [{}, { "bearerAuth": [] }],
+        "parameters": [
+          { "name": "name", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Package name. Scoped package names must be URL path encoded." }
+        ],
+        "responses": {
+          "200": { "description": "Readiness", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PackageReadinessResponse" } } } },
+          "404": { "description": "Not found" }
+        }
+      }
+    },
+    "/api/v1/packages/{name}/file": {
+      "get": {
+        "summary": "Fetch raw package file",
+        "description": "Returns raw text content for a package file. Uses the read rate bucket.",
+        "security": [{}, { "bearerAuth": [] }],
+        "parameters": [
+          { "name": "name", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Package name. Scoped package names must be URL path encoded." },
+          { "name": "path", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "version", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "tag", "in": "query", "required": false, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "File contents", "content": { "text/plain": { "schema": { "type": "string" } } } },
+          "413": { "description": "File too large" },
+          "415": { "description": "Binary files are not served inline" },
+          "404": { "description": "Not found" }
+        }
+      }
+    },
+    "/api/v1/packages/{name}/download": {
+      "get": {
+        "summary": "Download package ZIP archive",
+        "description": "Downloads the legacy deterministic ZIP archive for a package release. This route stays ZIP-only and uses the download rate bucket.",
+        "security": [{}, { "bearerAuth": [] }],
+        "parameters": [
+          { "name": "name", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Package name. Scoped package names must be URL path encoded." },
+          { "name": "version", "in": "query", "required": false, "schema": { "type": "string" } },
+          { "name": "tag", "in": "query", "required": false, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "ZIP archive", "content": { "application/zip": { "schema": { "type": "string", "format": "binary" } } } },
+          "307": { "description": "Skill compatibility redirect to /api/v1/download" },
+          "403": { "description": "Blocked by package moderation" },
+          "404": { "description": "Not found" },
+          "429": { "description": "Rate limit exceeded" }
         }
       }
     },


### PR DESCRIPTION
## Summary

- What changed: updated the static v1 OpenAPI contract with the implemented package catalog/search/detail/version/artifact/download/readiness endpoints, plus plugin catalog aliases.
- Also changed: aligned `public/api/v1/openapi.json`, `docs/api.md`, and `docs/http-api.md` rate-limit text with `convex/lib/httpRateLimit.ts`.
- Why: the OpenAPI document only covered the older skills/search/download/resolve surface, and the rate-limit description must match the server constants exposed through response headers.

## Linked Issue

- Closes N/A
- Related N/A

## Screenshots

- [x] N/A

## Security / Trust Impact

- [x] No security/trust impact
- [ ] Security/trust impact explained

## Data / Deploy Impact

- [x] No data/deploy impact
- [ ] Data/deploy impact explained

## Verification

- [x] `jq empty public/api/v1/openapi.json`
- [x] `jq -e '.openapi and .info.description and (.paths["/api/v1/packages"].get) and (.paths["/api/v1/packages/{name}/versions/{version}/artifact"].get)' public/api/v1/openapi.json >/dev/null`
- [x] `git diff --check`
- [x] `bun run ci:static`
- [x] Rate-limit source/docs smoke:

```text
Public REST API for ClawHub skills and package catalog endpoints. Rate limits: read 3000/min per IP + 12000/min per key; write 300/min per IP + 3000/min per key; download 1200/min per IP + 6000/min per key. Responses include RateLimit-* and legacy X-RateLimit-* headers; 429 responses include Retry-After.
convex/lib/httpRateLimit.ts:10:  read: { ip: 3000, key: 12000, adminKey: 120000 },
convex/lib/httpRateLimit.ts:11:  write: { ip: 300, key: 3000, adminKey: 30000 },
convex/lib/httpRateLimit.ts:13:  download: { ip: 1200, key: 6000, adminKey: 60000 },
docs/api.md:40:- Read: 3000/min per IP, 12000/min per key
docs/api.md:41:- Write: 300/min per IP, 3000/min per key
docs/api.md:42:- Download: 1200/min per IP, 6000/min per key
docs/http-api.md:36:- Read: 3000/min per IP, 12000/min per key
docs/http-api.md:37:- Write: 300/min per IP, 3000/min per key
docs/http-api.md:38:- Download: 1200/min per IP, 6000/min per key (download endpoints)
```

CI note: Vercel preview requires team authorization. The current `types-build` failure matches `main` at `af96221e` and reports `convex/skills.ts(788,60)`, outside this docs/OpenAPI diff.
