### PR TITLE
test: add skill publish lifecycle e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,3 +107,27 @@ jobs:
           name: playwright-report
           path: playwright-report/
           if-no-files-found: ignore
+
+  playwright-publish-lifecycle:
+    name: playwright-publish-lifecycle
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
+      - name: Skill publish lifecycle e2e
+        run: bun run test:pw:publish-lifecycle
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-publish-lifecycle-report
+          path: playwright-report/
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,8 @@ jobs:
           path: playwright-report/
           if-no-files-found: ignore
 
-  playwright-publish-lifecycle:
-    name: playwright-publish-lifecycle
+  playwright-local-auth:
+    name: playwright-local-auth
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -121,13 +121,13 @@ jobs:
       - name: Install Playwright browsers
         run: bunx playwright install --with-deps chromium
 
-      - name: Skill publish lifecycle e2e
-        run: bun run test:pw:publish-lifecycle
+      - name: Local-auth browser e2e
+        run: bun run test:pw:local-auth
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-publish-lifecycle-report
+          name: playwright-local-auth-report
           path: playwright-report/
           if-no-files-found: ignore

--- a/convex/lib/devAuth.test.ts
+++ b/convex/lib/devAuth.test.ts
@@ -24,11 +24,29 @@ describe("isLocalDevAuthEnabled", () => {
     ).toBe(true);
   });
 
+  it("allows local Convex site URLs when deployment name is not exposed to functions", () => {
+    expect(
+      isLocalDevAuthEnabled({
+        DEV_AUTH_ENABLED: "1",
+        CONVEX_SITE_URL: "http://127.0.0.1:3211",
+      }),
+    ).toBe(true);
+  });
+
   it("rejects cloud dev deployments even when the dev auth flag is set", () => {
     expect(
       isLocalDevAuthEnabled({
         DEV_AUTH_ENABLED: "1",
         CONVEX_DEPLOYMENT: "dev:clever-rabbit-123",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects non-local Convex site URLs even when the dev auth flag is set", () => {
+    expect(
+      isLocalDevAuthEnabled({
+        DEV_AUTH_ENABLED: "1",
+        CONVEX_SITE_URL: "https://clawhub.ai",
       }),
     ).toBe(false);
   });

--- a/convex/lib/devAuth.test.ts
+++ b/convex/lib/devAuth.test.ts
@@ -3,12 +3,18 @@ import { isLocalDevAuthEnabled } from "./devAuth";
 
 describe("isLocalDevAuthEnabled", () => {
   it("requires the explicit dev auth flag", () => {
-    expect(isLocalDevAuthEnabled({ CONVEX_DEPLOYMENT: "local:clawhub" })).toBe(false);
+    expect(
+      isLocalDevAuthEnabled({
+        CONVEX_DEPLOYMENT: "local:clawhub",
+        CONVEX_SITE_URL: "http://127.0.0.1:3211",
+      }),
+    ).toBe(false);
   });
 
   it("allows local Convex deployments", () => {
     expect(
       isLocalDevAuthEnabled({
+        CONVEX_SITE_URL: "http://127.0.0.1:3211",
         DEV_AUTH_ENABLED: "1",
         CONVEX_DEPLOYMENT: "local:clawhub",
       }),
@@ -18,17 +24,19 @@ describe("isLocalDevAuthEnabled", () => {
   it("allows anonymous local Convex deployments", () => {
     expect(
       isLocalDevAuthEnabled({
+        CONVEX_SITE_URL: "http://127.0.0.1:3211",
         DEV_AUTH_ENABLED: "1",
         CONVEX_DEPLOYMENT: "anonymous:clawhub",
       }),
     ).toBe(true);
   });
 
-  it("allows local Convex site URLs when deployment name is not exposed to functions", () => {
+  it("allows the test runner deployment marker when Convex does not expose deployment name", () => {
     expect(
       isLocalDevAuthEnabled({
-        DEV_AUTH_ENABLED: "1",
         CONVEX_SITE_URL: "http://127.0.0.1:3211",
+        DEV_AUTH_CONVEX_DEPLOYMENT: "local:clawhub",
+        DEV_AUTH_ENABLED: "1",
       }),
     ).toBe(true);
   });
@@ -36,17 +44,39 @@ describe("isLocalDevAuthEnabled", () => {
   it("rejects cloud dev deployments even when the dev auth flag is set", () => {
     expect(
       isLocalDevAuthEnabled({
+        CONVEX_SITE_URL: "http://127.0.0.1:3211",
         DEV_AUTH_ENABLED: "1",
         CONVEX_DEPLOYMENT: "dev:clever-rabbit-123",
       }),
     ).toBe(false);
   });
 
-  it("rejects non-local Convex site URLs even when the dev auth flag is set", () => {
+  it("rejects localhost site URLs without a local deployment marker", () => {
     expect(
       isLocalDevAuthEnabled({
+        CONVEX_SITE_URL: "http://127.0.0.1:3211",
         DEV_AUTH_ENABLED: "1",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects local deployment markers without localhost Convex site URLs", () => {
+    expect(
+      isLocalDevAuthEnabled({
+        CONVEX_DEPLOYMENT: "local:clawhub",
         CONVEX_SITE_URL: "https://clawhub.ai",
+        DEV_AUTH_ENABLED: "1",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not allow the test runner marker to override a cloud deployment", () => {
+    expect(
+      isLocalDevAuthEnabled({
+        CONVEX_DEPLOYMENT: "dev:clever-rabbit-123",
+        CONVEX_SITE_URL: "http://127.0.0.1:3211",
+        DEV_AUTH_CONVEX_DEPLOYMENT: "local:clawhub",
+        DEV_AUTH_ENABLED: "1",
       }),
     ).toBe(false);
   });
@@ -54,6 +84,7 @@ describe("isLocalDevAuthEnabled", () => {
   it("rejects production deployments", () => {
     expect(
       isLocalDevAuthEnabled({
+        CONVEX_SITE_URL: "http://127.0.0.1:3211",
         DEV_AUTH_ENABLED: "1",
         CONVEX_DEPLOYMENT: "prod:wry-manatee-359",
       }),

--- a/convex/lib/devAuth.ts
+++ b/convex/lib/devAuth.ts
@@ -1,10 +1,23 @@
 type DevAuthEnv = {
   CONVEX_DEPLOYMENT?: string;
+  CONVEX_SITE_URL?: string;
   DEV_AUTH_ENABLED?: string;
 };
 
 export function isLocalDevAuthEnabled(env: DevAuthEnv = process.env) {
   if (env.DEV_AUTH_ENABLED !== "1") return false;
   const deployment = env.CONVEX_DEPLOYMENT ?? "";
-  return deployment.startsWith("local:") || deployment.startsWith("anonymous:");
+  if (deployment.startsWith("local:") || deployment.startsWith("anonymous:")) return true;
+
+  return isLocalhostUrl(env.CONVEX_SITE_URL);
+}
+
+function isLocalhostUrl(value: string | undefined) {
+  if (!value) return false;
+  try {
+    const { hostname } = new URL(value);
+    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
+  } catch {
+    return false;
+  }
 }

--- a/convex/lib/devAuth.ts
+++ b/convex/lib/devAuth.ts
@@ -1,15 +1,18 @@
 type DevAuthEnv = {
   CONVEX_DEPLOYMENT?: string;
   CONVEX_SITE_URL?: string;
+  DEV_AUTH_CONVEX_DEPLOYMENT?: string;
   DEV_AUTH_ENABLED?: string;
 };
 
 export function isLocalDevAuthEnabled(env: DevAuthEnv = process.env) {
   if (env.DEV_AUTH_ENABLED !== "1") return false;
-  const deployment = env.CONVEX_DEPLOYMENT ?? "";
-  if (deployment.startsWith("local:") || deployment.startsWith("anonymous:")) return true;
+  const deployment = env.CONVEX_DEPLOYMENT?.trim() || env.DEV_AUTH_CONVEX_DEPLOYMENT?.trim() || "";
+  return isLocalConvexDeployment(deployment) && isLocalhostUrl(env.CONVEX_SITE_URL);
+}
 
-  return isLocalhostUrl(env.CONVEX_SITE_URL);
+function isLocalConvexDeployment(deployment: string) {
+  return deployment.startsWith("local:") || deployment.startsWith("anonymous:");
 }
 
 function isLocalhostUrl(value: string | undefined) {

--- a/convex/lib/publishers.ts
+++ b/convex/lib/publishers.ts
@@ -14,11 +14,21 @@ function isMissingPublisherTableError(error: unknown) {
   );
 }
 
+function normalizeGeneratedPublisherHandle(handle: string | undefined | null) {
+  const normalized = normalizePublisherHandle(handle);
+  const sanitized = normalized
+    ?.replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[-_]+|[-_]+$/g, "");
+  return sanitized || undefined;
+}
+
 function derivePersonalPublisherHandle(user: Doc<"users">) {
   const emailLocalPart = user.email?.split("@")[0];
   const userIdSuffix = String(user._id).split(":").pop();
   return (
-    normalizePublisherHandle(user.handle ?? user.name ?? emailLocalPart ?? userIdSuffix) ?? "user"
+    normalizeGeneratedPublisherHandle(user.handle ?? user.name ?? emailLocalPart ?? userIdSuffix) ??
+    "user"
   );
 }
 

--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -1108,6 +1108,38 @@ describe("publisher-owned resource authorization", () => {
 });
 
 describe("publisher bootstrap", () => {
+  function makeSynthesizedPublisherCtx(userId: string, user: Record<string, unknown>) {
+    return {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === userId) return { _id: id, ...user };
+          return null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table === "publisherMembers") {
+            return {
+              withIndex: vi.fn((indexName: string) => {
+                if (indexName !== "by_user") throw new Error(`unexpected index ${indexName}`);
+                return { collect: vi.fn().mockResolvedValue([]) };
+              }),
+            };
+          }
+          if (table === "publishers") {
+            return {
+              withIndex: vi.fn((indexName: string) => {
+                if (indexName !== "by_linked_user") {
+                  throw new Error(`unexpected index ${indexName}`);
+                }
+                return { unique: vi.fn().mockResolvedValue(null) };
+              }),
+            };
+          }
+          throw new Error(`unexpected table ${table}`);
+        }),
+      },
+    };
+  }
+
   it("lists a synthesized personal publisher when membership rows are missing", async () => {
     vi.mocked(getAuthUserId).mockResolvedValue("users:alice" as never);
     const ctx = {
@@ -1157,6 +1189,85 @@ describe("publisher bootstrap", () => {
           handle: "alice",
           kind: "user",
           linkedUserId: "users:alice",
+        }),
+      }),
+    ]);
+  });
+
+  it("derives route-safe handles for synthesized personal publishers", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:local" as never);
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "users:local") {
+            return {
+              _id: id,
+              _creationTime: 1,
+              name: "Local Owner",
+              displayName: "Local Owner",
+              trustedPublisher: false,
+              createdAt: 1,
+              updatedAt: 1,
+            };
+          }
+          return null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table === "publisherMembers") {
+            return {
+              withIndex: vi.fn((indexName: string) => {
+                if (indexName !== "by_user") throw new Error(`unexpected index ${indexName}`);
+                return { collect: vi.fn().mockResolvedValue([]) };
+              }),
+            };
+          }
+          if (table === "publishers") {
+            return {
+              withIndex: vi.fn((indexName: string) => {
+                if (indexName !== "by_linked_user") {
+                  throw new Error(`unexpected index ${indexName}`);
+                }
+                return { unique: vi.fn().mockResolvedValue(null) };
+              }),
+            };
+          }
+          throw new Error(`unexpected table ${table}`);
+        }),
+      },
+    };
+
+    await expect(listMineHandler(ctx as never, {} as never)).resolves.toEqual([
+      expect.objectContaining({
+        role: "owner",
+        publisher: expect.objectContaining({
+          displayName: "Local Owner",
+          handle: "local-owner",
+          kind: "user",
+          linkedUserId: "users:local",
+        }),
+      }),
+    ]);
+  });
+
+  it("falls back when synthesized personal publisher handles sanitize to empty", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:symbols" as never);
+    const ctx = makeSynthesizedPublisherCtx("users:symbols", {
+      _creationTime: 1,
+      name: "!!!",
+      displayName: "!!!",
+      trustedPublisher: false,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+
+    await expect(listMineHandler(ctx as never, {} as never)).resolves.toEqual([
+      expect.objectContaining({
+        role: "owner",
+        publisher: expect.objectContaining({
+          displayName: "!!!",
+          handle: "user",
+          kind: "user",
+          linkedUserId: "users:symbols",
         }),
       }),
     ]);

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -33,6 +33,7 @@ const ADMIN_HANDLE = "steipete";
 const MAX_USER_LIST_LIMIT = 200;
 const MAX_USER_SEARCH_SCAN = 5_000;
 const MIN_USER_SEARCH_SCAN = 500;
+const DEV_PERSONA_GITHUB_CREATED_AT = Date.UTC(2020, 0, 1);
 
 const DEV_PERSONAS = {
   owner: {
@@ -77,6 +78,7 @@ export const upsertDevPersonaInternal = internalMutation({
       displayName: persona.displayName,
       name: persona.displayName,
       role: persona.role,
+      githubCreatedAt: DEV_PERSONA_GITHUB_CREATED_AT,
       deletedAt: undefined,
       deactivatedAt: undefined,
       purgedAt: undefined,

--- a/e2e/local-auth/publish-skill-lifecycle.pw.test.ts
+++ b/e2e/local-auth/publish-skill-lifecycle.pw.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { expect, test, type Page, type TestInfo } from "@playwright/test";
-import { expectHealthyPage, trackRuntimeErrors, waitForHydration } from "./helpers/runtimeErrors";
+import { expectHealthyPage, trackRuntimeErrors, waitForHydration } from "../helpers/runtimeErrors";
 
 function skillMd(args: { slug: string; displayName: string; versionLabel: string }) {
   return `---

--- a/e2e/publish-skill-lifecycle.pw.test.ts
+++ b/e2e/publish-skill-lifecycle.pw.test.ts
@@ -1,0 +1,146 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { expect, test, type Page, type TestInfo } from "@playwright/test";
+import { expectHealthyPage, trackRuntimeErrors, waitForHydration } from "./helpers/runtimeErrors";
+
+function skillMd(args: { slug: string; displayName: string; versionLabel: string }) {
+  return `---
+name: ${args.slug}
+description: ${args.displayName} verifies that ClawHub can publish and replace skill releases through the browser UI.
+---
+
+# ${args.displayName}
+
+Use this skill when validating ClawHub's browser publishing workflow in local development or pull request CI.
+
+## Workflow
+
+The skill documents a realistic release process so the publish quality gate sees meaningful content.
+
+- Prepare a small folder with SKILL.md and supporting text files.
+- Publish the first release through the browser form.
+- Return from the detail page and publish a new version from owner settings.
+- Confirm the current version and version history both update after publication.
+
+## Verification Notes
+
+This ${args.versionLabel} payload is intentionally deterministic and text-only.
+It avoids external credentials, network access, binary files, and production state.
+Maintainers can run it against a disposable local Convex backend to prove the UI still supports the full version lifecycle.
+`;
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function signInAsLocalOwner(page: Page) {
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await waitForHydration(page);
+
+  await page.getByRole("button", { name: "Open local dev personas" }).click();
+  await page.getByRole("menuitem", { name: /use owner/i }).click();
+  await expect(page.locator("header .user-trigger")).toContainText(/@local(?: owner)?/i, {
+    timeout: 15_000,
+  });
+
+  await page.goto("/skills/publish", { waitUntil: "domcontentloaded" });
+  await expect(page.getByRole("heading", { name: "Publish a skill" })).toBeVisible();
+  const ownerSelect = page.locator("#ownerHandle");
+  await expect(ownerSelect).not.toHaveValue("");
+  const ownerHandle = await ownerSelect.inputValue();
+  expect(ownerHandle.toLowerCase()).toContain("local");
+  return ownerHandle;
+}
+
+async function publishSkillVersion(
+  page: Page,
+  testInfo: TestInfo,
+  args: {
+    ownerHandle: string;
+    slug: string;
+    displayName: string;
+    version: string;
+    versionLabel: string;
+    changelog: string;
+  },
+) {
+  const skillDir = testInfo.outputPath(`${args.slug}-${args.version}`);
+  await mkdir(skillDir, { recursive: true });
+  await writeFile(
+    join(skillDir, "SKILL.md"),
+    skillMd({
+      slug: args.slug,
+      displayName: args.displayName,
+      versionLabel: args.versionLabel,
+    }),
+    "utf8",
+  );
+
+  await page.locator("#slug").fill(args.slug);
+  await page.locator("#displayName").fill(args.displayName);
+  await page.locator("#version").fill(args.version);
+  await page.locator("#tags").fill("latest, stable");
+  await page.locator("#changelog").fill(args.changelog);
+  await page.getByLabel(/i have the rights to this skill/i).check();
+  await page.getByTestId("upload-input").setInputFiles(skillDir);
+
+  await expect(page.getByText("All checks passed.")).toBeVisible();
+  await page.getByRole("button", { name: "Publish skill" }).click();
+  await expect(page).toHaveURL(
+    new RegExp(`/${escapeRegExp(encodeURIComponent(args.ownerHandle))}/${args.slug}$`),
+    { timeout: 60_000 },
+  );
+  await expect(page.locator(".skill-page-title")).toHaveText(args.displayName);
+}
+
+test("skill publishers can create a skill and publish a new version", async ({
+  page,
+}, testInfo) => {
+  const errors = trackRuntimeErrors(page);
+  const slug = `pw-life-${Date.now().toString(36)}`;
+  const displayName = "Playwright Lifecycle Skill";
+
+  const ownerHandle = await signInAsLocalOwner(page);
+
+  await publishSkillVersion(page, testInfo, {
+    ownerHandle,
+    slug,
+    displayName,
+    version: "1.0.0",
+    versionLabel: "first release",
+    changelog: "Initial release from the browser publish flow.",
+  });
+
+  const metadata = page.locator(".sidebar-metadata");
+  await expect(metadata.getByText("Current version", { exact: true })).toBeVisible();
+  await expect(metadata.getByText("v1.0.0", { exact: true })).toBeVisible();
+
+  await page.getByRole("link", { name: "Settings" }).click();
+  await expect(page.getByRole("heading", { name: "Skill settings" })).toBeVisible();
+  await page.getByRole("link", { name: "New Version" }).click();
+
+  await expect(page).toHaveURL(/\/skills\/publish\?updateSlug=/);
+  await expect(page.locator("#slug")).toHaveValue(slug);
+  await expect(page.locator("#displayName")).toHaveValue(displayName);
+  await expect(page.locator("#version")).toHaveValue("1.0.1");
+  await expect(page.locator("#ownerHandle")).toHaveValue(ownerHandle);
+
+  await publishSkillVersion(page, testInfo, {
+    ownerHandle,
+    slug,
+    displayName,
+    version: "1.0.1",
+    versionLabel: "second release",
+    changelog: "Second release published through the owner new-version workflow.",
+  });
+
+  await expect(metadata.getByText("Current version", { exact: true })).toBeVisible();
+  await expect(metadata.getByText("v1.0.1", { exact: true })).toBeVisible();
+  await page.getByRole("tab", { name: "Versions" }).click();
+  await expect(page.getByRole("heading", { name: "Versions" })).toBeVisible();
+  await expect(page.getByText(/^v1\.0\.1\b/).first()).toBeVisible();
+  await expect(page.getByText(/^v1\.0\.0\b/).first()).toBeVisible();
+
+  await expectHealthyPage(page, errors);
+});

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "test:e2e:local": "bash scripts/run-playwright-local.sh",
     "test:e2e:prod-http": "vitest run -c vitest.e2e.config.ts e2e/prod-http-smoke.e2e.test.ts",
     "test:pw": "playwright test",
+    "test:pw:local-auth": "bun scripts/run-playwright-local-auth.ts",
+    "test:pw:publish-lifecycle": "bun run test:pw:local-auth -- --project=chromium e2e/publish-skill-lifecycle.pw.test.ts",
     "test:ui-contract": "vitest run src/__tests__/ui-design-contract.test.ts src/__tests__/header.test.tsx src/__tests__/home-route.test.tsx src/components/Footer.test.tsx src/lib/theme.test.tsx src/routes/-settings.test.tsx",
     "test:watch": "vitest",
     "testbox:claim": "node scripts/blacksmith-testbox-runner.mjs --claim",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "test:e2e:prod-http": "vitest run -c vitest.e2e.config.ts e2e/prod-http-smoke.e2e.test.ts",
     "test:pw": "playwright test",
     "test:pw:local-auth": "bun scripts/run-playwright-local-auth.ts",
-    "test:pw:publish-lifecycle": "bun run test:pw:local-auth -- --project=chromium e2e/publish-skill-lifecycle.pw.test.ts",
+    "test:pw:publish-lifecycle": "bun run test:pw:local-auth -- --project=chromium e2e/local-auth/publish-skill-lifecycle.pw.test.ts",
     "test:ui-contract": "vitest run src/__tests__/ui-design-contract.test.ts src/__tests__/header.test.tsx src/__tests__/home-route.test.tsx src/components/Footer.test.tsx src/lib/theme.test.tsx src/routes/-settings.test.tsx",
     "test:watch": "vitest",
     "testbox:claim": "node scripts/blacksmith-testbox-runner.mjs --claim",

--- a/scripts/playwright-local-auth-config.test.ts
+++ b/scripts/playwright-local-auth-config.test.ts
@@ -26,10 +26,13 @@ describe("playwright local-auth runner config", () => {
     });
   });
 
-  it("passes explicit Playwright args and defaults to chromium", () => {
+  it("passes explicit Playwright args and defaults to the local-auth suite", () => {
     expect(resolveLocalAuthRunnerConfig({}, ["--", "e2e/example.pw.test.ts"])).toMatchObject({
       playwrightArgs: ["e2e/example.pw.test.ts"],
     });
-    expect(resolveLocalAuthRunnerConfig({}).playwrightArgs).toEqual(["--project=chromium"]);
+    expect(resolveLocalAuthRunnerConfig({}).playwrightArgs).toEqual([
+      "--project=chromium",
+      "e2e/local-auth",
+    ]);
   });
 });

--- a/scripts/playwright-local-auth-config.test.ts
+++ b/scripts/playwright-local-auth-config.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { resolveLocalAuthRunnerConfig } from "./playwright-local-auth-config";
+
+describe("playwright local-auth runner config", () => {
+  it("does not inherit the generic CI Convex URL", () => {
+    expect(
+      resolveLocalAuthRunnerConfig({
+        VITE_CONVEX_URL: "https://example.invalid",
+        VITE_CONVEX_SITE_URL: "https://example.invalid",
+      }),
+    ).toMatchObject({
+      convexSiteUrl: "http://127.0.0.1:3211",
+      convexUrl: "http://127.0.0.1:3210",
+    });
+  });
+
+  it("uses local-auth-specific Convex URL overrides", () => {
+    expect(
+      resolveLocalAuthRunnerConfig({
+        PLAYWRIGHT_LOCAL_AUTH_CONVEX_SITE_URL: "http://127.0.0.1:4311",
+        PLAYWRIGHT_LOCAL_AUTH_CONVEX_URL: "http://127.0.0.1:4310",
+      }),
+    ).toMatchObject({
+      convexSiteUrl: "http://127.0.0.1:4311",
+      convexUrl: "http://127.0.0.1:4310",
+    });
+  });
+
+  it("passes explicit Playwright args and defaults to chromium", () => {
+    expect(resolveLocalAuthRunnerConfig({}, ["--", "e2e/example.pw.test.ts"])).toMatchObject({
+      playwrightArgs: ["e2e/example.pw.test.ts"],
+    });
+    expect(resolveLocalAuthRunnerConfig({}).playwrightArgs).toEqual(["--project=chromium"]);
+  });
+});

--- a/scripts/playwright-local-auth-config.ts
+++ b/scripts/playwright-local-auth-config.ts
@@ -1,0 +1,29 @@
+const DEFAULT_CONVEX_URL = "http://127.0.0.1:3210";
+const DEFAULT_CONVEX_SITE_URL = "http://127.0.0.1:3211";
+const DEFAULT_PLAYWRIGHT_ARGS = ["--project=chromium"];
+
+type RunnerEnv = Record<string, string | undefined>;
+
+export type LocalAuthRunnerConfig = {
+  convexDeployment: string | undefined;
+  convexSiteUrl: string;
+  convexUrl: string;
+  playwrightArgs: string[];
+};
+
+function stripPackageManagerSeparator(args: string[]) {
+  return args[0] === "--" ? args.slice(1) : args;
+}
+
+export function resolveLocalAuthRunnerConfig(
+  env: RunnerEnv = process.env,
+  argv: string[] = process.argv.slice(2),
+): LocalAuthRunnerConfig {
+  const playwrightArgs = stripPackageManagerSeparator(argv);
+  return {
+    convexDeployment: env.PLAYWRIGHT_LOCAL_AUTH_CONVEX_DEPLOYMENT,
+    convexSiteUrl: env.PLAYWRIGHT_LOCAL_AUTH_CONVEX_SITE_URL ?? DEFAULT_CONVEX_SITE_URL,
+    convexUrl: env.PLAYWRIGHT_LOCAL_AUTH_CONVEX_URL ?? DEFAULT_CONVEX_URL,
+    playwrightArgs: playwrightArgs.length > 0 ? playwrightArgs : DEFAULT_PLAYWRIGHT_ARGS,
+  };
+}

--- a/scripts/playwright-local-auth-config.ts
+++ b/scripts/playwright-local-auth-config.ts
@@ -1,6 +1,6 @@
 const DEFAULT_CONVEX_URL = "http://127.0.0.1:3210";
 const DEFAULT_CONVEX_SITE_URL = "http://127.0.0.1:3211";
-const DEFAULT_PLAYWRIGHT_ARGS = ["--project=chromium"];
+const DEFAULT_PLAYWRIGHT_ARGS = ["--project=chromium", "e2e/local-auth"];
 
 type RunnerEnv = Record<string, string | undefined>;
 

--- a/scripts/run-playwright-local-auth.ts
+++ b/scripts/run-playwright-local-auth.ts
@@ -1,0 +1,406 @@
+#!/usr/bin/env bun
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { generateKeyPairSync } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveLocalAuthRunnerConfig } from "./playwright-local-auth-config";
+
+const DEFAULT_CONVEX_DEPLOYMENT = "local:anonymous-agent";
+const DEFAULT_PLAYWRIGHT_PORT = 4173;
+const START_TIMEOUT_MS = 120_000;
+const FUNCTION_READY_TIMEOUT_MS = 120_000;
+const POLL_MS = 500;
+const LOCAL_CONVEX_STATE_DIR = ".convex/local/default";
+const LOCAL_ENV_FILE = ".env.local";
+
+type LocalDeploymentConfig = {
+  adminKey: string;
+  deploymentName: string;
+};
+
+const managedChildren = new Set<ChildProcess>();
+const tempDir = mkdtempSync(join(tmpdir(), "clawhub-pw-local-auth-"));
+const envFile = join(tempDir, ".env.local");
+const localConvexStateBackupDir = join(tempDir, "convex-local-default.backup");
+const localEnvBackupFile = join(tempDir, ".env.local.backup");
+let backedUpLocalConvexState = false;
+let backedUpLocalEnvFile = false;
+let isolatedLocalState = false;
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function isReachable(url: string) {
+  try {
+    const response = await fetch(url, { method: "GET" });
+    return response.status < 500;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntilReachable(url: string, label: string) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < START_TIMEOUT_MS) {
+    if (await isReachable(url)) return;
+    await sleep(POLL_MS);
+  }
+  throw new Error(`${label} did not become reachable at ${url}.`);
+}
+
+function canListen(port: number) {
+  return new Promise<boolean>((resolve) => {
+    const server = createServer();
+    server.once("error", () => resolve(false));
+    server.once("listening", () => {
+      server.close(() => resolve(true));
+    });
+    server.listen(port, "127.0.0.1");
+  });
+}
+
+async function resolveAppPort() {
+  const requested = Number(process.env.PLAYWRIGHT_PORT ?? DEFAULT_PLAYWRIGHT_PORT);
+  if (!Number.isInteger(requested) || requested <= 0) {
+    throw new Error(`Invalid PLAYWRIGHT_PORT: ${process.env.PLAYWRIGHT_PORT}`);
+  }
+
+  if (process.env.PLAYWRIGHT_PORT) {
+    if (!(await canListen(requested))) {
+      throw new Error(`PLAYWRIGHT_PORT ${requested} is already in use.`);
+    }
+    return requested;
+  }
+
+  for (let port = requested; port < requested + 50; port += 1) {
+    if (await canListen(port)) return port;
+  }
+  throw new Error(`No available preview port found starting at ${requested}.`);
+}
+
+function buildAuthKeys() {
+  const { publicKey, privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const privatePem = privateKey.export({ type: "pkcs8", format: "pem" });
+  const publicJwk = publicKey.export({ format: "jwk" });
+  return {
+    JWT_PRIVATE_KEY: privatePem.trimEnd().replace(/\n/g, " "),
+    JWKS: JSON.stringify({ keys: [{ use: "sig", ...publicJwk }] }),
+  };
+}
+
+function readLocalDeploymentConfig(): LocalDeploymentConfig | null {
+  try {
+    const raw = readFileSync(".convex/local/default/config.json", "utf8");
+    const parsed = JSON.parse(raw) as { adminKey?: unknown; deploymentName?: unknown };
+    return typeof parsed.adminKey === "string" &&
+      parsed.adminKey &&
+      typeof parsed.deploymentName === "string" &&
+      parsed.deploymentName
+      ? { adminKey: parsed.adminKey, deploymentName: parsed.deploymentName }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function readLocalDeployment() {
+  const config = readLocalDeploymentConfig();
+  return config ? `local:${config.deploymentName}` : null;
+}
+
+function spawnManaged(command: string, args: string[], env: NodeJS.ProcessEnv) {
+  const child = spawn(command, args, {
+    cwd: process.cwd(),
+    env,
+    stdio: "inherit",
+  });
+  managedChildren.add(child);
+  child.once("exit", () => managedChildren.delete(child));
+  return child;
+}
+
+function waitForChildExit(child: ChildProcess, timeoutMs = 5_000) {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+
+  return new Promise<void>((resolve) => {
+    const timeout = setTimeout(resolve, timeoutMs);
+    child.once("exit", () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
+}
+
+async function stopManagedChildren() {
+  const children = Array.from(managedChildren);
+  for (const child of managedChildren) {
+    if (!child.killed) child.kill("SIGTERM");
+  }
+  await Promise.all(children.map((child) => waitForChildExit(child)));
+}
+
+function isolateLocalState() {
+  isolatedLocalState = true;
+
+  if (existsSync(LOCAL_CONVEX_STATE_DIR)) {
+    renameSync(LOCAL_CONVEX_STATE_DIR, localConvexStateBackupDir);
+    backedUpLocalConvexState = true;
+  }
+
+  if (existsSync(LOCAL_ENV_FILE)) {
+    renameSync(LOCAL_ENV_FILE, localEnvBackupFile);
+    backedUpLocalEnvFile = true;
+  }
+}
+
+function restoreLocalState() {
+  if (!isolatedLocalState) return;
+
+  rmSync(LOCAL_CONVEX_STATE_DIR, { force: true, recursive: true });
+  if (backedUpLocalConvexState) {
+    mkdirSync(".convex/local", { recursive: true });
+    renameSync(localConvexStateBackupDir, LOCAL_CONVEX_STATE_DIR);
+  }
+
+  rmSync(LOCAL_ENV_FILE, { force: true });
+  if (backedUpLocalEnvFile) {
+    renameSync(localEnvBackupFile, LOCAL_ENV_FILE);
+  }
+}
+
+async function cleanup() {
+  await stopManagedChildren();
+  restoreLocalState();
+  rmSync(tempDir, { force: true, recursive: true });
+}
+
+function runRequired(command: string, args: string[], env: NodeJS.ProcessEnv) {
+  const result = spawnSync(command, args, {
+    cwd: process.cwd(),
+    env,
+    stdio: "inherit",
+  });
+  if ((result.status ?? 1) !== 0) {
+    throw new Error(`${command} ${args.join(" ")} failed with exit code ${result.status ?? 1}.`);
+  }
+}
+
+function runBuffered(command: string, args: string[], env: NodeJS.ProcessEnv) {
+  const result = spawnSync(command, args, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return {
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+    status: result.status ?? 1,
+  };
+}
+
+function isFunctionUnavailableOutput(output: string) {
+  return (
+    output.includes("Could not find function for") &&
+    output.includes("Did you forget to run `npx convex dev`")
+  );
+}
+
+async function setLocalConvexEnv(
+  convexUrl: string,
+  changes: Array<{ name: string; value: string }>,
+) {
+  const config = readLocalDeploymentConfig();
+  if (!config) {
+    throw new Error(
+      "Local Convex config was not found at .convex/local/default/config.json after startup.",
+    );
+  }
+
+  const response = await fetch(new URL("/api/update_environment_variables", convexUrl), {
+    body: JSON.stringify({ changes }),
+    headers: {
+      Authorization: `Convex ${config.adminKey}`,
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to configure local Convex environment: ${response.status} ${await response.text()}`,
+    );
+  }
+}
+
+async function runConvexFunctionWhenReady(
+  functionName: string,
+  args: Record<string, unknown>,
+  env: NodeJS.ProcessEnv,
+  options: { push?: boolean } = {},
+) {
+  const startedAt = Date.now();
+  while (true) {
+    const result = runBuffered(
+      "bunx",
+      [
+        "convex",
+        "run",
+        ...(options.push ? ["--push"] : []),
+        "--typecheck",
+        "disable",
+        "--codegen",
+        "disable",
+        functionName,
+        JSON.stringify(args),
+      ],
+      env,
+    );
+
+    if (result.status === 0) {
+      if (result.output) process.stdout.write(result.output);
+      return;
+    }
+
+    if (
+      !isFunctionUnavailableOutput(result.output) ||
+      Date.now() - startedAt >= FUNCTION_READY_TIMEOUT_MS
+    ) {
+      if (result.output) process.stdout.write(result.output);
+      throw new Error(`Convex function ${functionName} failed with exit code ${result.status}.`);
+    }
+
+    console.log(`Convex function ${functionName} is not queryable yet; retrying...`);
+    await sleep(POLL_MS);
+  }
+}
+
+async function main() {
+  if (!existsSync("node_modules/.bin/vite")) {
+    console.log("Installing dependencies for the Playwright local-auth e2e runner...");
+    runRequired("bun", ["install", "--frozen-lockfile"], process.env);
+  }
+
+  const runnerConfig = resolveLocalAuthRunnerConfig(process.env, process.argv.slice(2));
+  const appPort = await resolveAppPort();
+  const appUrl = `http://127.0.0.1:${appPort}`;
+  const convexUrl = runnerConfig.convexUrl;
+  const convexSiteUrl = runnerConfig.convexSiteUrl;
+  if (await isReachable(convexUrl)) {
+    throw new Error(
+      `Local Convex is already reachable at ${convexUrl}. Stop the running local Convex process before running this e2e so it can use isolated disposable state.`,
+    );
+  }
+
+  isolateLocalState();
+
+  const authKeys = buildAuthKeys();
+  const deployment =
+    runnerConfig.convexDeployment ?? readLocalDeployment() ?? DEFAULT_CONVEX_DEPLOYMENT;
+  const e2eEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    AUTH_GITHUB_ID: process.env.AUTH_GITHUB_ID ?? "local-dev",
+    AUTH_GITHUB_SECRET: process.env.AUTH_GITHUB_SECRET ?? "local-dev",
+    CONVEX_AGENT_MODE: process.env.CONVEX_AGENT_MODE ?? "anonymous",
+    CONVEX_DEPLOYMENT: deployment,
+    CONVEX_SITE_URL: convexSiteUrl,
+    DEV_AUTH_ENABLED: "1",
+    JWKS: authKeys.JWKS,
+    JWT_PRIVATE_KEY: authKeys.JWT_PRIVATE_KEY,
+    SITE_URL: appUrl,
+    VITE_CONVEX_SITE_URL: convexSiteUrl,
+    VITE_CONVEX_URL: convexUrl,
+    VITE_ENABLE_DEV_AUTH: "1",
+    VITE_SITE_URL: appUrl,
+  };
+
+  writeFileSync(
+    envFile,
+    [
+      `AUTH_GITHUB_ID=${e2eEnv.AUTH_GITHUB_ID}`,
+      `AUTH_GITHUB_SECRET=${e2eEnv.AUTH_GITHUB_SECRET}`,
+      `CONVEX_DEPLOYMENT=${deployment}`,
+      `CONVEX_SITE_URL=${convexSiteUrl}`,
+      "DEV_AUTH_ENABLED=1",
+      `JWKS=${authKeys.JWKS}`,
+      `JWT_PRIVATE_KEY=${authKeys.JWT_PRIVATE_KEY}`,
+      `SITE_URL=${appUrl}`,
+      `VITE_CONVEX_SITE_URL=${convexSiteUrl}`,
+      `VITE_CONVEX_URL=${convexUrl}`,
+      "VITE_ENABLE_DEV_AUTH=1",
+      `VITE_SITE_URL=${appUrl}`,
+      "",
+    ].join("\n"),
+  );
+
+  console.log(`Starting local Convex at ${convexUrl} with isolated e2e state.`);
+  spawnManaged(
+    "bunx",
+    [
+      "convex",
+      "dev",
+      "--local",
+      "--env-file",
+      envFile,
+      "--typecheck",
+      "disable",
+      "--codegen",
+      "disable",
+    ],
+    e2eEnv,
+  );
+  await waitUntilReachable(convexUrl, "Local Convex");
+
+  console.log("Configuring local Convex environment for local-auth Playwright e2e.");
+  await setLocalConvexEnv(convexUrl, [
+    { name: "AUTH_GITHUB_ID", value: e2eEnv.AUTH_GITHUB_ID ?? "local-dev" },
+    { name: "AUTH_GITHUB_SECRET", value: e2eEnv.AUTH_GITHUB_SECRET ?? "local-dev" },
+    { name: "DEV_AUTH_ENABLED", value: "1" },
+    { name: "JWKS", value: authKeys.JWKS },
+    { name: "JWT_PRIVATE_KEY", value: authKeys.JWT_PRIVATE_KEY },
+    { name: "SITE_URL", value: appUrl },
+  ]);
+
+  console.log("Waiting for local Convex functions.");
+  await runConvexFunctionWhenReady("appMeta:getDeploymentInfo", {}, e2eEnv, { push: true });
+
+  console.log("Building ClawHub for local-auth Playwright e2e.");
+  runRequired("bun", ["run", "build"], e2eEnv);
+
+  console.log(`Starting preview server at ${appUrl}.`);
+  spawnManaged(
+    "bun",
+    ["run", "preview", "--", "--host", "127.0.0.1", "--port", String(appPort)],
+    e2eEnv,
+  );
+  await waitUntilReachable(appUrl, "Preview server");
+
+  runRequired("bunx", ["playwright", "test", ...runnerConfig.playwrightArgs], {
+    ...e2eEnv,
+    PLAYWRIGHT_BASE_URL: appUrl,
+    PLAYWRIGHT_WORKERS: "1",
+  });
+}
+
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.once(signal, () => {
+    void cleanup().finally(() => {
+      process.exit(signal === "SIGINT" ? 130 : 143);
+    });
+  });
+}
+
+try {
+  await main();
+} finally {
+  await cleanup();
+}

--- a/scripts/run-playwright-local-auth.ts
+++ b/scripts/run-playwright-local-auth.ts
@@ -313,6 +313,7 @@ async function main() {
     CONVEX_AGENT_MODE: process.env.CONVEX_AGENT_MODE ?? "anonymous",
     CONVEX_DEPLOYMENT: deployment,
     CONVEX_SITE_URL: convexSiteUrl,
+    DEV_AUTH_CONVEX_DEPLOYMENT: deployment,
     DEV_AUTH_ENABLED: "1",
     JWKS: authKeys.JWKS,
     JWT_PRIVATE_KEY: authKeys.JWT_PRIVATE_KEY,
@@ -330,6 +331,7 @@ async function main() {
       `AUTH_GITHUB_SECRET=${e2eEnv.AUTH_GITHUB_SECRET}`,
       `CONVEX_DEPLOYMENT=${deployment}`,
       `CONVEX_SITE_URL=${convexSiteUrl}`,
+      `DEV_AUTH_CONVEX_DEPLOYMENT=${deployment}`,
       "DEV_AUTH_ENABLED=1",
       `JWKS=${authKeys.JWKS}`,
       `JWT_PRIVATE_KEY=${authKeys.JWT_PRIVATE_KEY}`,
@@ -361,9 +363,11 @@ async function main() {
   await waitUntilReachable(convexUrl, "Local Convex");
 
   console.log("Configuring local Convex environment for local-auth Playwright e2e.");
+  const localAuthDeployment = readLocalDeployment() ?? deployment;
   await setLocalConvexEnv(convexUrl, [
     { name: "AUTH_GITHUB_ID", value: e2eEnv.AUTH_GITHUB_ID ?? "local-dev" },
     { name: "AUTH_GITHUB_SECRET", value: e2eEnv.AUTH_GITHUB_SECRET ?? "local-dev" },
+    { name: "DEV_AUTH_CONVEX_DEPLOYMENT", value: localAuthDeployment },
     { name: "DEV_AUTH_ENABLED", value: "1" },
     { name: "JWKS", value: authKeys.JWKS },
     { name: "JWT_PRIVATE_KEY", value: authKeys.JWT_PRIVATE_KEY },

--- a/specs/ci.md
+++ b/specs/ci.md
@@ -17,10 +17,34 @@ status checks are precise:
 - `e2e-http` runs the secretless HTTP and CLI end-to-end subset.
 - `playwright-smoke` builds the app and runs a chromium browser smoke against the
   public read backend.
+- `playwright-publish-lifecycle` uses `test:pw:local-auth` to start a local
+  anonymous Convex backend with dev auth, then runs the chromium skill publish
+  lifecycle e2e: create a skill, publish a new version, and verify version
+  history.
 
 For local reproduction, run the matching `ci:*` package scripts. `bun run ci:pr`
 matches the non-browser PR gates. `bun run ci:playwright-smoke` assumes the
 chromium Playwright browser has already been installed.
+
+To reproduce the publish lifecycle browser gate locally, install the chromium
+Playwright browser once and run:
+
+```bash
+bunx playwright install chromium
+bun run test:pw:publish-lifecycle
+```
+
+For other authenticated local browser specs, reuse the same infra:
+
+```bash
+bun run test:pw:local-auth -- --project=chromium e2e/<spec>.pw.test.ts
+```
+
+The local-auth runner uses dev auth and a local Convex deployment; it does not
+need production credentials or a ClawHub auth token. It starts its own isolated
+local Convex process and temporarily moves aside `.env.local` plus
+`.convex/local/default`, then restores them afterward. Stop any already-running
+local Convex process before running it.
 
 The full `bun run test:e2e` suite includes token-backed CLI flows. Keep that for
 local or secret-backed validation; PR CI should not require a developer auth
@@ -36,6 +60,7 @@ GitHub rulesets should require these status checks on `main`:
 - `CI / types-build`
 - `CI / e2e-http`
 - `CI / playwright-smoke`
+- `CI / playwright-publish-lifecycle`
 - `Security Gate: Secret Scanning / Scan for Verified Secrets`
 
 `CodeQL Light` is path-filtered and skipped for draft pull requests, so it should

--- a/specs/ci.md
+++ b/specs/ci.md
@@ -17,27 +17,26 @@ status checks are precise:
 - `e2e-http` runs the secretless HTTP and CLI end-to-end subset.
 - `playwright-smoke` builds the app and runs a chromium browser smoke against the
   public read backend.
-- `playwright-publish-lifecycle` uses `test:pw:local-auth` to start a local
-  anonymous Convex backend with dev auth, then runs the chromium skill publish
-  lifecycle e2e: create a skill, publish a new version, and verify version
-  history.
+- `playwright-local-auth` uses `test:pw:local-auth` to start a local anonymous
+  Convex backend with dev auth, then runs the chromium specs under
+  `e2e/local-auth/`.
 
 For local reproduction, run the matching `ci:*` package scripts. `bun run ci:pr`
 matches the non-browser PR gates. `bun run ci:playwright-smoke` assumes the
 chromium Playwright browser has already been installed.
 
-To reproduce the publish lifecycle browser gate locally, install the chromium
+To reproduce the local-auth browser gate locally, install the chromium
 Playwright browser once and run:
 
 ```bash
 bunx playwright install chromium
-bun run test:pw:publish-lifecycle
+bun run test:pw:local-auth
 ```
 
-For other authenticated local browser specs, reuse the same infra:
+To run one authenticated local browser spec through the same infra:
 
 ```bash
-bun run test:pw:local-auth -- --project=chromium e2e/<spec>.pw.test.ts
+bun run test:pw:local-auth -- --project=chromium e2e/local-auth/<spec>.pw.test.ts
 ```
 
 The local-auth runner uses dev auth and a local Convex deployment; it does not
@@ -60,7 +59,7 @@ GitHub rulesets should require these status checks on `main`:
 - `CI / types-build`
 - `CI / e2e-http`
 - `CI / playwright-smoke`
-- `CI / playwright-publish-lifecycle`
+- `CI / playwright-local-auth`
 - `Security Gate: Secret Scanning / Scan for Verified Secrets`
 
 `CodeQL Light` is path-filtered and skipped for draft pull requests, so it should

--- a/specs/manual-testing.md
+++ b/specs/manual-testing.md
@@ -101,3 +101,24 @@ Run against a local preview server:
 ```
 bun run test:e2e:local
 ```
+
+Run the PR-facing skill publish lifecycle e2e locally:
+
+```
+bunx playwright install chromium
+bun run test:pw:publish-lifecycle
+```
+
+For other authenticated local browser specs, reuse the local-auth runner:
+
+```
+bun run test:pw:local-auth -- --project=chromium e2e/<spec>.pw.test.ts
+```
+
+The runner starts an isolated local Convex process, enables dev auth, and runs
+the requested Playwright spec against a local preview build. The lifecycle
+shortcut publishes a new skill as the local owner persona, publishes a second
+version from the skill settings flow, and checks that the latest version plus
+version history update in the UI. Stop any already-running local Convex process
+before running it; the command temporarily moves aside `.env.local` and
+`.convex/local/default`, then restores them afterward.

--- a/specs/manual-testing.md
+++ b/specs/manual-testing.md
@@ -102,23 +102,23 @@ Run against a local preview server:
 bun run test:e2e:local
 ```
 
-Run the PR-facing skill publish lifecycle e2e locally:
+Run the PR-facing authenticated local browser e2es locally:
 
 ```
 bunx playwright install chromium
+bun run test:pw:local-auth
+```
+
+To run only the skill publish lifecycle spec:
+
+```
 bun run test:pw:publish-lifecycle
 ```
 
-For other authenticated local browser specs, reuse the local-auth runner:
-
-```
-bun run test:pw:local-auth -- --project=chromium e2e/<spec>.pw.test.ts
-```
-
 The runner starts an isolated local Convex process, enables dev auth, and runs
-the requested Playwright spec against a local preview build. The lifecycle
-shortcut publishes a new skill as the local owner persona, publishes a second
-version from the skill settings flow, and checks that the latest version plus
-version history update in the UI. Stop any already-running local Convex process
-before running it; the command temporarily moves aside `.env.local` and
-`.convex/local/default`, then restores them afterward.
+the requested Playwright specs under `e2e/local-auth/` against a local preview
+build. The lifecycle spec publishes a new skill as the local owner persona,
+publishes a second version from the skill settings flow, and checks that the
+latest version plus version history update in the UI. Stop any already-running
+local Convex process before running it; the command temporarily moves aside
+`.env.local` and `.convex/local/default`, then restores them afterward.


### PR DESCRIPTION
## Summary

Adds reusable PR-facing Playwright coverage for authenticated local ClawHub UI workflows. The new local-auth browser lane starts isolated local Convex state with dev auth, builds/previews ClawHub locally, and runs every Playwright spec under `e2e/local-auth/`.

The first spec in that suite covers the skill publish lifecycle: sign in with the local owner persona, publish a skill, publish a second version through the existing settings flow, and verify the detail page plus version history recognize the new release.

## Why

A recent publish/version workflow regression was not covered by PR CI. The previous browser coverage was mostly public smoke or production deploy smoke, so it did not exercise signed-in, writeable UI flows in contributor-runnable CI.

## Changes

- Adds `e2e/local-auth/publish-skill-lifecycle.pw.test.ts` for create skill plus publish new version.
- Adds `bun run test:pw:local-auth` as reusable local Convex/dev-auth Playwright infrastructure for all specs in `e2e/local-auth/`.
- Keeps `bun run test:pw:publish-lifecycle` as a thin lifecycle-specific alias.
- Adds a PR-facing `playwright-local-auth` CI job that runs the local-auth browser suite.
- Updates local docs for running the full local-auth suite and the lifecycle shortcut.
- Fixes local dev-auth/publisher test support needed by the isolated browser flow.

## Validation

- `bun run test -- scripts/playwright-local-auth-config.test.ts`
- `bun run test -- scripts/playwright-local-auth-config.test.ts convex/publishers.test.ts convex/lib/devAuth.test.ts`
- `bun run test:pw:publish-lifecycle`
- `bun run test:pw:local-auth`
- `bun run ci:e2e-http`
- `bun run ci:static`
- `git diff --check`
