### PR TITLE
Add new version detail actions

### DIFF
--- a/e2e/local-auth/publish-skill-lifecycle.pw.test.ts
+++ b/e2e/local-auth/publish-skill-lifecycle.pw.test.ts
@@ -121,9 +121,8 @@ test("skill publishers can create a skill and publish a new version", async ({
   await expect(metadata.getByText("Current version", { exact: true })).toBeVisible();
   await expect(metadata.getByText("v1.0.0", { exact: true })).toBeVisible();
 
-  await page.getByRole("link", { name: "Settings" }).click();
-  await expect(page.getByRole("heading", { name: "Skill settings" })).toBeVisible();
-  await page.getByRole("link", { name: "New Version" }).click();
+  await expect(page.getByRole("link", { name: "Settings" })).toBeVisible();
+  await page.getByRole("link", { name: "New version" }).click();
 
   await expect(page).toHaveURL(/\/skills\/publish\?updateSlug=/);
   await expect(page.locator("#slug")).toHaveValue(slug);

--- a/scripts/ui-proof.mjs
+++ b/scripts/ui-proof.mjs
@@ -20,6 +20,7 @@ const DEFAULT_PORTS = {
 const DEFAULT_PUBLIC_ENV = {
   VITE_CONVEX_SITE_URL: "https://wry-manatee-359.convex.site",
   VITE_CONVEX_URL: "https://wry-manatee-359.convex.cloud",
+  VITE_ENABLE_DEV_AUTH: "1",
 };
 
 export function parseProofUiArgs(argv = []) {

--- a/scripts/ui-proof.mjs
+++ b/scripts/ui-proof.mjs
@@ -20,7 +20,6 @@ const DEFAULT_PORTS = {
 const DEFAULT_PUBLIC_ENV = {
   VITE_CONVEX_SITE_URL: "https://wry-manatee-359.convex.site",
   VITE_CONVEX_URL: "https://wry-manatee-359.convex.cloud",
-  VITE_ENABLE_DEV_AUTH: "1",
 };
 
 export function parseProofUiArgs(argv = []) {

--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -191,7 +191,7 @@ describe("plugin detail route", () => {
           ...loaderDataMock.detail.package!,
           latestVersion: "1.0.0",
         },
-        owner: null,
+        owner: { handle: "demo-owner", displayName: "Demo Owner", image: null },
       },
       version: {
         package: {
@@ -223,8 +223,18 @@ describe("plugin detail route", () => {
     render(<Component />);
 
     const downloadLink = screen.getByRole("link", { name: /download/i });
+    const newVersionLink = screen.getByRole("link", { name: "New version" });
     const settingsLink = screen.getByRole("link", { name: /settings/i });
+    expect(newVersionLink.getAttribute("href")).toBe(
+      "/plugins/publish?ownerHandle=demo-owner&name=demo-plugin&displayName=Demo+Plugin",
+    );
     expect(settingsLink.getAttribute("href")).toBe("/plugins/demo-plugin/settings");
+    expect(
+      downloadLink.compareDocumentPosition(newVersionLink) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      newVersionLink.compareDocumentPosition(settingsLink) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     expect(
       downloadLink.compareDocumentPosition(settingsLink) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
@@ -246,7 +256,43 @@ describe("plugin detail route", () => {
 
     render(<Component />);
 
+    expect(screen.queryByRole("link", { name: "New version" })).toBeNull();
     expect(screen.queryByRole("link", { name: /settings/i })).toBeNull();
+  });
+
+  it("checks plugin management when a dev viewer exists without a Convex auth session", async () => {
+    useAuthStatusMock.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+      me: { _id: "users:1", role: "user" },
+    });
+    useQueryMock.mockReturnValue({
+      package: { _id: "packages:1", name: "demo-plugin", displayName: "Demo Plugin" },
+      latestRelease: { _id: "packageReleases:1" },
+    });
+    loaderDataMock = {
+      detail: {
+        package: {
+          ...loaderDataMock.detail.package!,
+          latestVersion: "1.0.0",
+        },
+        owner: { handle: "demo-owner", displayName: "Demo Owner", image: null },
+      },
+      version: null,
+      readme: null,
+      rateLimited: null,
+    };
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    expect(useQueryMock).toHaveBeenCalledWith(expect.anything(), {
+      name: "demo-plugin",
+      candidateNames: ["@openclaw/demo-plugin", "demo-plugin"],
+    });
+    expect(screen.getByRole("link", { name: "New version" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: /settings/i })).toBeTruthy();
   });
 
   it("renders package security scan results when scan data is present", async () => {

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -438,7 +438,9 @@ describe("SkillDetailPage", () => {
       />,
     );
 
-    expect(await screen.findByText("Publish a new version")).toBeTruthy();
+    await screen.findByText("Short summary");
+    expect(screen.queryByText("Publish a new version")).toBeNull();
+    expect(screen.queryByRole("link", { name: "New Version" })).toBeNull();
     expect(screen.queryByText(/request security/i)).toBeNull();
     expect(screen.queryByRole("button", { name: "Rescan" })).toBeNull();
     expect(screen.queryByText(/rescans/i)).toBeNull();
@@ -760,7 +762,7 @@ describe("SkillDetailPage", () => {
     useAuthStatusMock.mockReturnValue({
       isAuthenticated: true,
       isLoading: false,
-      me: { _id: "users:1", role: "user" },
+      me: { _id: "users:reporter", role: "user" },
     });
     useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
       if (args === "skip") return undefined;
@@ -858,7 +860,8 @@ describe("SkillDetailPage", () => {
     render(<SkillDetailPage slug="weather" mode="settings" />);
 
     expect(await screen.findByRole("heading", { name: /Skill settings/i })).toBeTruthy();
-    expect(screen.getByText("Publish a new version")).toBeTruthy();
+    expect(screen.queryByText("Publish a new version")).toBeNull();
+    expect(screen.queryByRole("link", { name: "New Version" })).toBeNull();
     expect(screen.getByText("Rename slug")).toBeTruthy();
     expect(screen.getByText("Merge listing")).toBeTruthy();
   });

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -278,6 +278,13 @@ export function SkillDetailPage({
     canAccessSettings && skill
       ? `${buildSkillHref(ownerHandle, owner?._id ?? null, skill.slug)}/settings`
       : null;
+  const newVersionHref =
+    canAccessSettings && skill
+      ? `/skills/publish?${new URLSearchParams({
+          updateSlug: skill.slug,
+          ...(ownerHandle ? { ownerHandle } : {}),
+        }).toString()}`
+      : null;
   const canonicalOwnerParam =
     typeof canonicalOwner === "string" ? canonicalOwner.trim().toLowerCase() : null;
   const wantsCanonicalRedirect = Boolean(
@@ -663,6 +670,7 @@ export function SkillDetailPage({
           cliHelp={cliHelp}
           clawdis={clawdis}
           priorityContent={priorityContent}
+          newVersionHref={newVersionHref}
           settingsHref={settingsHref}
         >
           {nixSnippet ? (

--- a/src/components/SkillHeader.test.tsx
+++ b/src/components/SkillHeader.test.tsx
@@ -1,11 +1,31 @@
 /* @vitest-environment jsdom */
 
 import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import type { Id } from "../../convex/_generated/dataModel";
 import type { PublicPublisher, PublicSkill } from "../lib/publicUser";
 import { SkillHeader } from "./SkillHeader";
 import { TooltipProvider } from "./ui/tooltip";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    children,
+    to,
+    search,
+  }: {
+    children?: ReactNode;
+    to?: string;
+    search?: Record<string, string | number | boolean | undefined>;
+  }) => {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(search ?? {})) {
+      if (value !== undefined) params.set(key, String(value));
+    }
+    const query = params.toString();
+    return <a href={`${to ?? "#"}${query ? `?${query}` : ""}`}>{children}</a>;
+  },
+}));
 
 describe("SkillHeader", () => {
   const skill: PublicSkill = {
@@ -104,6 +124,59 @@ describe("SkillHeader", () => {
     expect(screen.getByText("Downloads")).toBeTruthy();
     expect(screen.getByText("2")).toBeTruthy();
     expect(container.querySelector('a[href="/p/local"]')).toBeTruthy();
+  });
+
+  it("shows a New version action for managers above Settings", () => {
+    renderHeader({
+      canManage: true,
+      isAuthenticated: true,
+      settingsHref: "/local/demo/settings",
+      newVersionHref: "/skills/publish?updateSlug=demo&ownerHandle=local",
+    } as Partial<Parameters<typeof SkillHeader>[0]>);
+
+    const newVersionLink = screen.getByRole("link", { name: "New version" });
+    const settingsLink = screen.getByRole("link", { name: "Settings" });
+
+    expect(newVersionLink.getAttribute("href")).toBe(
+      "/skills/publish?updateSlug=demo&ownerHandle=local",
+    );
+    expect(
+      newVersionLink.compareDocumentPosition(settingsLink) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("does not show a New version action without a manager href", () => {
+    renderHeader({
+      canManage: false,
+      isAuthenticated: true,
+      settingsHref: null,
+      newVersionHref: null,
+    });
+
+    expect(screen.queryByRole("link", { name: "New version" })).toBeNull();
+  });
+
+  it("hides Report for non-staff managers", () => {
+    renderHeader({
+      canManage: true,
+      isAuthenticated: true,
+      settingsHref: "/local/demo/settings",
+      newVersionHref: "/skills/publish?updateSlug=demo&ownerHandle=local",
+    } as Partial<Parameters<typeof SkillHeader>[0]>);
+
+    expect(screen.queryByRole("button", { name: "Report" })).toBeNull();
+  });
+
+  it("keeps Report visible for staff managers", () => {
+    renderHeader({
+      canManage: true,
+      isAuthenticated: true,
+      isStaff: true,
+      settingsHref: "/local/demo/settings",
+      newVersionHref: "/skills/publish?updateSlug=demo&ownerHandle=local",
+    } as Partial<Parameters<typeof SkillHeader>[0]>);
+
+    expect(screen.getByRole("button", { name: "Report" })).toBeTruthy();
   });
 
   it("shows the latest version description instead of the short catalog summary", () => {

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import type { ClawdisSkillMetadata } from "clawhub-schema";
 import { PLATFORM_SKILL_LICENSE } from "clawhub-schema/licenseConstants";
-import { Download, Flag, Settings, ShieldCheck, Star } from "lucide-react";
+import { Download, Flag, Settings, ShieldCheck, Star, Upload } from "lucide-react";
 import type { ReactNode } from "react";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
 import { getSkillBadges } from "../lib/badges";
@@ -88,6 +88,7 @@ type SkillHeaderProps = {
   cliHelp: string | undefined;
   clawdis: ClawdisSkillMetadata | undefined;
   priorityContent?: ReactNode;
+  newVersionHref?: string | null;
   settingsHref?: string | null;
   children?: ReactNode;
 };
@@ -98,6 +99,7 @@ export function SkillHeader({
   ownerHandle,
   latestVersion,
   modInfo,
+  canManage,
   isAuthenticated,
   isStaff,
   isStarred,
@@ -117,6 +119,7 @@ export function SkillHeader({
   cliHelp,
   clawdis,
   priorityContent,
+  newVersionHref,
   settingsHref,
   children,
 }: SkillHeaderProps) {
@@ -128,8 +131,13 @@ export function SkillHeader({
       ? `${convexSiteUrl}/api/v1/download?slug=${encodeURIComponent(skill.slug)}`
       : null;
   const hasTitleActions = isStaff;
+  const showReportAction = !canManage || isStaff;
   const hasSidebarActions =
-    Boolean(downloadHref) || Boolean(onOpenReport) || Boolean(settingsHref) || hasTitleActions;
+    Boolean(downloadHref) ||
+    showReportAction ||
+    Boolean(newVersionHref) ||
+    Boolean(settingsHref) ||
+    hasTitleActions;
   const badges = getSkillBadges(skill);
   const showHeroMeta = Boolean((forkOf && forkOfHref) || canonicalHref);
   const showTitleBadges = badges.length > 0;
@@ -217,20 +225,30 @@ export function SkillHeader({
                     </a>
                   </Button>
                 ) : null}
-                <SignedInActionTooltip
-                  isAuthenticated={isAuthenticated}
-                  message="You must be signed in to report a skill"
-                >
-                  <Button
-                    variant="outline"
-                    type="button"
-                    className="skill-sidebar-action-button"
-                    onClick={isAuthenticated ? onOpenReport : onRequireSignIn}
+                {showReportAction ? (
+                  <SignedInActionTooltip
+                    isAuthenticated={isAuthenticated}
+                    message="You must be signed in to report a skill"
                   >
-                    <Flag size={14} aria-hidden="true" />
-                    Report
+                    <Button
+                      variant="outline"
+                      type="button"
+                      className="skill-sidebar-action-button"
+                      onClick={isAuthenticated ? onOpenReport : onRequireSignIn}
+                    >
+                      <Flag size={14} aria-hidden="true" />
+                      Report
+                    </Button>
+                  </SignedInActionTooltip>
+                ) : null}
+                {newVersionHref ? (
+                  <Button asChild variant="outline" className="skill-sidebar-action-button">
+                    <a href={newVersionHref}>
+                      <Upload size={14} aria-hidden="true" />
+                      New version
+                    </a>
                   </Button>
-                </SignedInActionTooltip>
+                ) : null}
                 {settingsHref ? (
                   <Button asChild variant="outline" className="skill-sidebar-action-button">
                     <a href={settingsHref}>

--- a/src/components/SkillOwnershipPanel.tsx
+++ b/src/components/SkillOwnershipPanel.tsx
@@ -174,15 +174,6 @@ export function SkillOwnershipPanel({
     <>
       <div className="skill-admin-panel" data-skill-id={skillId}>
         <SettingsActionRow
-          title="Publish a new version"
-          description="Upload a replacement release for this skill. New releases get a fresh scan."
-        >
-          <Button asChild variant="outline">
-            <a href={`/publish-skill?updateSlug=${encodeURIComponent(slug)}`}>New Version</a>
-          </Button>
-        </SettingsActionRow>
-
-        <SettingsActionRow
           title="Short summary"
           description="Update the short summary used in cards, search, and previews."
         >

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link, Outlet, redirect, useRouterState } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
-import { AlertTriangle, Download, Settings } from "lucide-react";
+import { AlertTriangle, Download, Settings, Upload } from "lucide-react";
 import { useState, type ReactNode } from "react";
 import { api } from "../../../convex/_generated/api";
 import { DetailHero, DetailPageShell } from "../../components/DetailPageShell";
@@ -324,13 +324,13 @@ export function PluginDetailPage({
 }) {
   const { detail, version, readme, rateLimited } = loaderData;
   const pathname = useRouterState({ select: (state) => state.location.pathname });
-  const { isAuthenticated } = useAuthStatus();
+  const { me } = useAuthStatus();
   const isNestedPluginRoute = pathname.includes("/security/") || pathname.endsWith("/settings");
   const settingsCandidateNames = getOpenClawPackageCandidateNames(name);
   const settingsLookupName = detail.package?.name ?? settingsCandidateNames[0] ?? name;
   const settings = useQuery(
     api.packages.getClawScanNoteSettings,
-    isAuthenticated && !isNestedPluginRoute && detail.package
+    me && !isNestedPluginRoute && detail.package
       ? { name: settingsLookupName, candidateNames: settingsCandidateNames }
       : "skip",
   );
@@ -402,6 +402,13 @@ export function PluginDetailPage({
       ? getPackageArtifactDownloadPath(pkg.name, latestRelease.version)
       : getPackageDownloadPath(pkg.name, pkg.latestVersion);
   const settingsHref = settings ? `${buildPluginDetailHref(pkg.name)}/settings` : null;
+  const newVersionHref = settings
+    ? `/plugins/publish?${new URLSearchParams({
+        ...(owner?.handle ? { ownerHandle: owner.handle } : {}),
+        name: pkg.name,
+        displayName: pkg.displayName,
+      }).toString()}`
+    : null;
   const capEntries = capabilities
     ? Object.entries(capabilities).filter(
         ([, v]) =>
@@ -652,13 +659,21 @@ export function PluginDetailPage({
                 />
               ) : null}
 
-              {(pkg.latestVersion && !isDownloadBlocked) || settingsHref ? (
+              {(pkg.latestVersion && !isDownloadBlocked) || newVersionHref || settingsHref ? (
                 <div className="skill-sidebar-actions">
                   {pkg.latestVersion && !isDownloadBlocked ? (
                     <Button asChild variant="outline" className="skill-sidebar-action-button">
                       <a href={downloadPath}>
                         <Download size={14} aria-hidden="true" />
                         Download
+                      </a>
+                    </Button>
+                  ) : null}
+                  {newVersionHref ? (
+                    <Button asChild variant="outline" className="skill-sidebar-action-button">
+                      <a href={newVersionHref}>
+                        <Upload size={14} aria-hidden="true" />
+                        New version
                       </a>
                     </Button>
                   ) : null}


### PR DESCRIPTION
## Summary

- Adds a manager-only `New version` action to skill and plugin detail sidebars.
- Places `New version` above `Settings` and links to the appropriate publish/update flow.
- Hides skill `Report` for non-staff managers while preserving it for staff/moderators.
- Removes the old buried skill settings row for publishing a new version.

## Validation

- `bun run test src/__tests__/package-detail-route.test.tsx`
- `bun run format:check -- src/__tests__/package-detail-route.test.tsx 'src/routes/plugins/$name.tsx'`
- `bun run test scripts/ui-proof.test.mjs`
- `VITE_CONVEX_URL=https://example.invalid bunx vitest run -c vitest.e2e.config.ts e2e/clawhub.e2e.test.ts --testNamePattern "package publish --dry-run from a GitHub repo|package publish --dry-run --json"`
- `bun run test:pw:local-auth`
- `bun run lint`

## Local Preview

- Verified with `bun run dev:worktree` at `http://localhost:3002/`.
- Skill detail showed `Download -> Report -> New version -> Settings -> Manage` for the local staff manager fixture.
- Plugin detail showed `Download -> New version -> Settings` after fixing the management-query gate to use `me` instead of only `isAuthenticated`.
