### PR TITLE
feat: export ClawScan findings sidecar

### DIFF
--- a/convex/securityDataset.ts
+++ b/convex/securityDataset.ts
@@ -345,6 +345,7 @@ function normalizeLlmAnalysis(analysis: StoredLlmAnalysis) {
     dimensions: analysis.dimensions ?? null,
     guidance: analysis.guidance ?? null,
     findings: analysis.findings ?? null,
+    agenticRiskFindings: analysis.agenticRiskFindings ?? [],
     model: analysis.model ?? null,
     checkedAt: analysis.checkedAt,
   };

--- a/scripts/security-dataset/convexExport.test.ts
+++ b/scripts/security-dataset/convexExport.test.ts
@@ -48,7 +48,7 @@ describe("Convex export dataset ingestion", () => {
             summary: "asks for secrets",
             agenticRiskFindings: [
               {
-                categoryId: "ASI-SEC-004",
+                categoryId: "ASI04",
                 categoryLabel: "Tool and permission overreach",
                 riskBucket: "permission_boundary",
                 status: "concern",
@@ -138,7 +138,7 @@ describe("Convex export dataset ingestion", () => {
     });
     expect(rows[1]?.llmAnalysis?.agenticRiskFindings).toMatchObject([
       {
-        categoryId: "ASI-SEC-004",
+        categoryId: "ASI04",
         riskBucket: "permission_boundary",
         status: "concern",
         severity: "high",

--- a/scripts/security-dataset/convexExport.test.ts
+++ b/scripts/security-dataset/convexExport.test.ts
@@ -46,6 +46,23 @@ describe("Convex export dataset ingestion", () => {
             verdict: "suspicious",
             confidence: "high",
             summary: "asks for secrets",
+            agenticRiskFindings: [
+              {
+                categoryId: "ASI-SEC-004",
+                categoryLabel: "Tool and permission overreach",
+                riskBucket: "permission_boundary",
+                status: "concern",
+                severity: "high",
+                confidence: "high",
+                evidence: {
+                  path: "SKILL.md",
+                  snippet: "Use token=supersecret123",
+                  explanation: "References sensitive token handling.",
+                },
+                userImpact: "Could expose credentials.",
+                recommendation: "Require least-privilege credentials.",
+              },
+            ],
             model: "gpt-test",
             checkedAt: 3,
           },
@@ -119,6 +136,17 @@ describe("Convex export dataset ingestion", () => {
       llmAnalysis: { model: "gpt-test" },
       skillMdContentRedacted: "Use this skill safely. [REDACTED_SECRET]",
     });
+    expect(rows[1]?.llmAnalysis?.agenticRiskFindings).toMatchObject([
+      {
+        categoryId: "ASI-SEC-004",
+        riskBucket: "permission_boundary",
+        status: "concern",
+        severity: "high",
+        evidence: {
+          path: "SKILL.md",
+        },
+      },
+    ]);
   });
 
   it("reads table JSONL files from a Convex export zip", async () => {

--- a/scripts/security-dataset/convexExport.ts
+++ b/scripts/security-dataset/convexExport.ts
@@ -257,8 +257,52 @@ function llmAnalysisFromExport(value: unknown): LlmAnalysisInput | null {
     dimensions: llmDimensionsFromExport(value.dimensions),
     guidance: stringOrNull(value.guidance),
     findings: stringOrNull(value.findings),
+    agenticRiskFindings: llmAgenticRiskFindingsFromExport(value.agenticRiskFindings),
     model: stringOrNull(value.model),
     checkedAt: numberValue(value.checkedAt, "llmAnalysis.checkedAt"),
+  };
+}
+
+function llmAgenticRiskFindingsFromExport(value: unknown): LlmAnalysisInput["agenticRiskFindings"] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((finding) => {
+    if (!isRecord(finding)) return [];
+    const riskBucket = finding.riskBucket;
+    if (
+      riskBucket !== "abnormal_behavior_control" &&
+      riskBucket !== "permission_boundary" &&
+      riskBucket !== "sensitive_data_protection"
+    ) {
+      return [];
+    }
+    const status = finding.status;
+    if (status !== "none" && status !== "note" && status !== "concern") return [];
+    const confidence = finding.confidence;
+    if (confidence !== "high" && confidence !== "medium" && confidence !== "low") return [];
+    return [
+      {
+        categoryId: stringOrNull(finding.categoryId) ?? "",
+        categoryLabel: stringOrNull(finding.categoryLabel) ?? "",
+        riskBucket,
+        status,
+        severity: stringOrNull(finding.severity) ?? "none",
+        confidence,
+        evidence: llmRiskEvidenceFromExport(finding.evidence),
+        userImpact: stringOrNull(finding.userImpact) ?? "",
+        recommendation: stringOrNull(finding.recommendation) ?? "",
+      },
+    ];
+  });
+}
+
+function llmRiskEvidenceFromExport(
+  value: unknown,
+): LlmAnalysisInput["agenticRiskFindings"][number]["evidence"] {
+  if (!isRecord(value)) return null;
+  return {
+    path: stringOrNull(value.path) ?? "",
+    snippet: stringOrNull(value.snippet) ?? "",
+    explanation: stringOrNull(value.explanation) ?? "",
   };
 }
 

--- a/scripts/security-dataset/export-snapshot.ts
+++ b/scripts/security-dataset/export-snapshot.ts
@@ -73,6 +73,7 @@ type SnapshotState = {
     artifacts: number;
     scanResults: number;
     staticFindings: number;
+    clawScanFindings: number;
     labels: number;
     splits: number;
   };
@@ -84,6 +85,7 @@ type SnapshotWriters = {
   artifacts: WriteStream;
   scanResults: WriteStream;
   staticFindings: WriteStream;
+  clawScanFindings: WriteStream;
   labels: WriteStream;
   splits: WriteStream;
 };
@@ -368,12 +370,13 @@ function buildManifest(input: {
       artifacts: state.rowCounts.artifacts,
       scanResults: state.rowCounts.scanResults,
       staticFindings: state.rowCounts.staticFindings,
+      clawScanFindings: state.rowCounts.clawScanFindings,
       labels: state.rowCounts.labels,
       splits: state.rowCounts.splits,
     },
     scannerVersions: Array.from(state.scannerVersions).sort(),
     modelNames: Array.from(state.modelNames).sort(),
-    redactionPolicyVersion: "public-signals-v1",
+    redactionPolicyVersion: "public-signals-v2",
     sourceTables: ["skillVersions", "packageReleases"],
     timeWindow: options.timeWindow,
   });
@@ -396,6 +399,7 @@ function createSnapshotState(): SnapshotState {
       artifacts: 0,
       scanResults: 0,
       staticFindings: 0,
+      clawScanFindings: 0,
       labels: 0,
       splits: 0,
     },
@@ -414,6 +418,7 @@ async function processArtifactInputs(input: {
   state.rowCounts.artifacts += rows.artifacts.length;
   state.rowCounts.scanResults += rows.scanResults.length;
   state.rowCounts.staticFindings += rows.staticFindings.length;
+  state.rowCounts.clawScanFindings += rows.clawScanFindings.length;
   state.rowCounts.labels += rows.labels.length;
   state.rowCounts.splits += rows.splits.length;
   for (const row of rows.scanResults) {
@@ -431,6 +436,9 @@ async function openSnapshotWriters(snapshotDir: string): Promise<SnapshotWriters
     artifacts: createWriteStream(join(snapshotDir, "artifacts.jsonl"), { encoding: "utf8" }),
     scanResults: createWriteStream(join(snapshotDir, "scan_results.jsonl"), { encoding: "utf8" }),
     staticFindings: createWriteStream(join(snapshotDir, "static_findings.jsonl"), {
+      encoding: "utf8",
+    }),
+    clawScanFindings: createWriteStream(join(snapshotDir, "clawscan_findings.jsonl"), {
       encoding: "utf8",
     }),
     labels: createWriteStream(join(snapshotDir, "labels.jsonl"), { encoding: "utf8" }),
@@ -451,6 +459,7 @@ async function writeNormalizedRows(writers: SnapshotWriters, rows: NormalizedDat
   await writeJsonlRows(writers.artifacts, rows.artifacts);
   await writeJsonlRows(writers.scanResults, rows.scanResults);
   await writeJsonlRows(writers.staticFindings, rows.staticFindings);
+  await writeJsonlRows(writers.clawScanFindings, rows.clawScanFindings);
   await writeJsonlRows(writers.labels, rows.labels);
   await writeJsonlRows(writers.splits, rows.splits);
 }

--- a/scripts/security-dataset/manifest.test.ts
+++ b/scripts/security-dataset/manifest.test.ts
@@ -18,6 +18,7 @@ describe("security dataset manifest", () => {
         artifacts: 1,
         scanResults: 2,
         staticFindings: 3,
+        clawScanFindings: 5,
         labels: 4,
         splits: 1,
       },
@@ -36,6 +37,9 @@ describe("security dataset manifest", () => {
       created_time_window: {
         created_at_gte: 1777507200000,
         created_at_lt: 1780185600000,
+      },
+      row_counts: {
+        clawscan_findings: 5,
       },
     });
   });

--- a/scripts/security-dataset/manifest.ts
+++ b/scripts/security-dataset/manifest.ts
@@ -13,6 +13,7 @@ export type SnapshotManifestInput = {
     artifacts: number;
     scanResults: number;
     staticFindings: number;
+    clawScanFindings: number;
     labels: number;
     splits: number;
   };
@@ -43,6 +44,7 @@ export function buildSecurityDatasetManifest(input: SnapshotManifestInput) {
       artifacts: input.rowCounts.artifacts,
       scan_results: input.rowCounts.scanResults,
       static_findings: input.rowCounts.staticFindings,
+      clawscan_findings: input.rowCounts.clawScanFindings,
       labels: input.rowCounts.labels,
       splits: input.rowCounts.splits,
     },

--- a/scripts/security-dataset/normalize.test.ts
+++ b/scripts/security-dataset/normalize.test.ts
@@ -74,11 +74,11 @@ const baseArtifact: ArtifactExportInput = {
     findings: null,
     agenticRiskFindings: [
       {
-        categoryId: "ASI-SEC-004",
-        categoryLabel: "Tool and permission overreach",
+        categoryId: "ASI04",
+        categoryLabel: "Ignore this label token=supersecret123",
         riskBucket: "permission_boundary",
         status: "note",
-        severity: "medium",
+        severity: "MEDIUM",
         confidence: "high",
         evidence: {
           path: "SKILL.md",
@@ -89,7 +89,22 @@ const baseArtifact: ArtifactExportInput = {
         recommendation: "Use a narrowly scoped token.",
       },
       {
-        categoryId: "ASI-SEC-005",
+        categoryId: "UNKNOWN token=supersecret123",
+        categoryLabel: "Unknown category token=supersecret123",
+        riskBucket: "permission_boundary",
+        status: "note",
+        severity: "critical",
+        confidence: "high",
+        evidence: {
+          path: "SKILL.md",
+          snippet: "Unknown category should not export.",
+          explanation: "Unknown categories are not part of the public sidecar contract.",
+        },
+        userImpact: "Should not export.",
+        recommendation: "Should not export.",
+      },
+      {
+        categoryId: "ASI05",
         categoryLabel: "Sensitive data protection",
         riskBucket: "sensitive_data_protection",
         status: "none",
@@ -138,7 +153,8 @@ describe("security dataset normalizer", () => {
     expect(rows.staticFindings[0]?.evidence_redacted).toContain("[REDACTED_SECRET]");
     expect(rows.clawScanFindings).toHaveLength(1);
     expect(rows.clawScanFindings[0]).toMatchObject({
-      category_id: "ASI-SEC-004",
+      category_id: "ASI04",
+      category_label: "Agentic Supply Chain Vulnerabilities",
       risk_bucket: "permission_boundary",
       status: "note",
       severity: "medium",

--- a/scripts/security-dataset/normalize.test.ts
+++ b/scripts/security-dataset/normalize.test.ts
@@ -72,6 +72,34 @@ const baseArtifact: ArtifactExportInput = {
     dimensions: null,
     guidance: null,
     findings: null,
+    agenticRiskFindings: [
+      {
+        categoryId: "ASI-SEC-004",
+        categoryLabel: "Tool and permission overreach",
+        riskBucket: "permission_boundary",
+        status: "note",
+        severity: "medium",
+        confidence: "high",
+        evidence: {
+          path: "SKILL.md",
+          snippet: "Use TOKEN=ghp_abcdefghijklmnopqrstuvwxyz1234567890 for setup",
+          explanation: "The skill documents token use.",
+        },
+        userImpact: "Users should understand the token scope before install.",
+        recommendation: "Use a narrowly scoped token.",
+      },
+      {
+        categoryId: "ASI-SEC-005",
+        categoryLabel: "Sensitive data protection",
+        riskBucket: "sensitive_data_protection",
+        status: "none",
+        severity: "none",
+        confidence: "high",
+        evidence: null,
+        userImpact: "",
+        recommendation: "",
+      },
+    ],
     model: "test-model",
     checkedAt: Date.UTC(2026, 3, 29),
   },
@@ -108,6 +136,17 @@ describe("security dataset normalizer", () => {
       line_bucket: "21-50",
     });
     expect(rows.staticFindings[0]?.evidence_redacted).toContain("[REDACTED_SECRET]");
+    expect(rows.clawScanFindings).toHaveLength(1);
+    expect(rows.clawScanFindings[0]).toMatchObject({
+      category_id: "ASI-SEC-004",
+      risk_bucket: "permission_boundary",
+      status: "note",
+      severity: "medium",
+      confidence: "high",
+      evidence_path_hash: hashString("SKILL.md"),
+      evidence_file_ext: ".md",
+    });
+    expect(rows.clawScanFindings[0]?.evidence_snippet_redacted).toContain("[REDACTED_SECRET]");
     expect(rows.labels.find((row) => row.label_source === "moderation_consensus")).toMatchObject({
       label: "malicious",
       label_confidence: "derived_consensus",

--- a/scripts/security-dataset/normalize.ts
+++ b/scripts/security-dataset/normalize.ts
@@ -4,6 +4,11 @@ export type SourceKind = "skill" | "package";
 export type DatasetLabel = "clean" | "suspicious" | "malicious" | "unknown";
 export type DatasetSplit = "train" | "validation" | "test" | "eval_holdout";
 export type ScannerName = "static" | "virustotal" | "llm" | "moderation_consensus";
+export type ClawScanRiskBucket =
+  | "abnormal_behavior_control"
+  | "permission_boundary"
+  | "sensitive_data_protection";
+export type ClawScanFindingStatus = "none" | "note" | "concern";
 
 export type ExportFileInput = {
   path: string;
@@ -56,6 +61,21 @@ export type LlmAnalysisInput = {
   }> | null;
   guidance: string | null;
   findings: string | null;
+  agenticRiskFindings: Array<{
+    categoryId: string;
+    categoryLabel: string;
+    riskBucket: ClawScanRiskBucket;
+    status: ClawScanFindingStatus;
+    severity: string;
+    confidence: "high" | "medium" | "low";
+    evidence: {
+      path: string;
+      snippet: string;
+      explanation: string;
+    } | null;
+    userImpact: string;
+    recommendation: string;
+  }>;
   model: string | null;
   checkedAt: number;
 };
@@ -146,6 +166,23 @@ export type StaticFindingRow = {
   evidence_redacted: string;
 };
 
+export type ClawScanFindingRow = {
+  artifact_id: string;
+  finding_id: string;
+  category_id: string;
+  category_label: string;
+  risk_bucket: ClawScanRiskBucket;
+  status: "note" | "concern";
+  severity: string;
+  confidence: "high" | "medium" | "low";
+  evidence_path_hash: string | null;
+  evidence_file_ext: string | null;
+  evidence_snippet_redacted: string | null;
+  evidence_explanation_redacted: string | null;
+  user_impact_redacted: string;
+  recommendation_redacted: string;
+};
+
 export type LabelRow = {
   artifact_id: string;
   label: DatasetLabel;
@@ -167,6 +204,7 @@ export type NormalizedDatasetRows = {
   artifacts: ArtifactRow[];
   scanResults: ScanResultRow[];
   staticFindings: StaticFindingRow[];
+  clawScanFindings: ClawScanFindingRow[];
   labels: LabelRow[];
   splits: SplitRow[];
 };
@@ -214,6 +252,7 @@ export function normalizeArtifactExport(inputs: ArtifactExportInput[]): Normaliz
   const artifacts: ArtifactRow[] = [];
   const scanResults: ScanResultRow[] = [];
   const staticFindings: StaticFindingRow[] = [];
+  const clawScanFindings: ClawScanFindingRow[] = [];
   const labels: LabelRow[] = [];
   const splits: SplitRow[] = [];
 
@@ -223,11 +262,12 @@ export function normalizeArtifactExport(inputs: ArtifactExportInput[]): Normaliz
     artifacts.push(artifact);
     scanResults.push(...buildScanResultRows(input, artifactId));
     staticFindings.push(...buildStaticFindingRows(input, artifactId));
+    clawScanFindings.push(...buildClawScanFindingRows(input, artifactId));
     labels.push(...buildLabelRows(input, artifactId));
     splits.push(buildSplitRow(input, artifactId));
   }
 
-  return { artifacts, scanResults, staticFindings, labels, splits };
+  return { artifacts, scanResults, staticFindings, clawScanFindings, labels, splits };
 }
 
 export function buildArtifactId(input: ArtifactExportInput) {
@@ -365,6 +405,40 @@ function buildStaticFindingRows(
     message: finding.message,
     evidence_redacted: redactText(finding.evidence) ?? "",
   }));
+}
+
+function buildClawScanFindingRows(
+  input: ArtifactExportInput,
+  artifactId: string,
+): ClawScanFindingRow[] {
+  return (input.llmAnalysis?.agenticRiskFindings ?? [])
+    .filter(
+      (finding): finding is typeof finding & { status: "note" | "concern" } =>
+        finding.status === "note" || finding.status === "concern",
+    )
+    .map((finding, index) => {
+      const evidence = finding.evidence;
+      return {
+        artifact_id: artifactId,
+        finding_id: `${artifactId}:clawscan:${index}:${hashString(
+          `${finding.categoryId}:${finding.riskBucket}:${finding.status}:${finding.severity}:${
+            evidence?.path ?? ""
+          }:${evidence?.snippet ?? ""}:${finding.userImpact}`,
+        ).slice(0, 12)}`,
+        category_id: finding.categoryId,
+        category_label: finding.categoryLabel,
+        risk_bucket: finding.riskBucket,
+        status: finding.status,
+        severity: finding.severity,
+        confidence: finding.confidence,
+        evidence_path_hash: evidence ? hashString(evidence.path) : null,
+        evidence_file_ext: evidence ? fileExtension(evidence.path) : null,
+        evidence_snippet_redacted: redactText(evidence?.snippet),
+        evidence_explanation_redacted: redactText(evidence?.explanation),
+        user_impact_redacted: redactText(finding.userImpact) ?? "",
+        recommendation_redacted: redactText(finding.recommendation) ?? "",
+      };
+    });
 }
 
 function buildLabelRows(input: ArtifactExportInput, artifactId: string): LabelRow[] {

--- a/scripts/security-dataset/normalize.ts
+++ b/scripts/security-dataset/normalize.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { AGENTIC_RISK_CATEGORIES } from "../../convex/lib/securityPrompt.ts";
 
 export type SourceKind = "skill" | "package";
 export type DatasetLabel = "clean" | "suspicious" | "malicious" | "unknown";
@@ -9,6 +10,7 @@ export type ClawScanRiskBucket =
   | "permission_boundary"
   | "sensitive_data_protection";
 export type ClawScanFindingStatus = "none" | "note" | "concern";
+export type ClawScanSeverity = "none" | "info" | "low" | "medium" | "high" | "critical";
 
 export type ExportFileInput = {
   path: string;
@@ -173,7 +175,7 @@ export type ClawScanFindingRow = {
   category_label: string;
   risk_bucket: ClawScanRiskBucket;
   status: "note" | "concern";
-  severity: string;
+  severity: ClawScanSeverity;
   confidence: "high" | "medium" | "low";
   evidence_path_hash: string | null;
   evidence_file_ext: string | null;
@@ -212,6 +214,17 @@ export type NormalizedDatasetRows = {
 const SPLIT_VERSION = "sha256-v1";
 const MAX_REDACTED_TEXT_LENGTH = 240;
 const MAX_REDACTED_SKILL_CONTENT_LENGTH = 120_000;
+const CLAWSCAN_SEVERITIES = new Set<ClawScanSeverity>([
+  "none",
+  "info",
+  "low",
+  "medium",
+  "high",
+  "critical",
+]);
+const AGENTIC_RISK_CATEGORY_LABEL_BY_ID: ReadonlyMap<string, string> = new Map(
+  AGENTIC_RISK_CATEGORIES.map((category) => [category.id, category.label] as const),
+);
 
 const SECRET_PATTERNS: RegExp[] = [
   /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi,
@@ -416,28 +429,33 @@ function buildClawScanFindingRows(
       (finding): finding is typeof finding & { status: "note" | "concern" } =>
         finding.status === "note" || finding.status === "concern",
     )
-    .map((finding, index) => {
+    .flatMap((finding, index) => {
       const evidence = finding.evidence;
-      return {
-        artifact_id: artifactId,
-        finding_id: `${artifactId}:clawscan:${index}:${hashString(
-          `${finding.categoryId}:${finding.riskBucket}:${finding.status}:${finding.severity}:${
-            evidence?.path ?? ""
-          }:${evidence?.snippet ?? ""}:${finding.userImpact}`,
-        ).slice(0, 12)}`,
-        category_id: finding.categoryId,
-        category_label: finding.categoryLabel,
-        risk_bucket: finding.riskBucket,
-        status: finding.status,
-        severity: finding.severity,
-        confidence: finding.confidence,
-        evidence_path_hash: evidence ? hashString(evidence.path) : null,
-        evidence_file_ext: evidence ? fileExtension(evidence.path) : null,
-        evidence_snippet_redacted: redactText(evidence?.snippet),
-        evidence_explanation_redacted: redactText(evidence?.explanation),
-        user_impact_redacted: redactText(finding.userImpact) ?? "",
-        recommendation_redacted: redactText(finding.recommendation) ?? "",
-      };
+      const categoryLabel = AGENTIC_RISK_CATEGORY_LABEL_BY_ID.get(finding.categoryId);
+      if (!categoryLabel) return [];
+      const severity = normalizeClawScanSeverity(finding.severity);
+      return [
+        {
+          artifact_id: artifactId,
+          finding_id: `${artifactId}:clawscan:${index}:${hashString(
+            `${finding.categoryId}:${finding.riskBucket}:${finding.status}:${severity}:${
+              evidence?.path ?? ""
+            }:${evidence?.snippet ?? ""}:${finding.userImpact}`,
+          ).slice(0, 12)}`,
+          category_id: finding.categoryId,
+          category_label: categoryLabel,
+          risk_bucket: finding.riskBucket,
+          status: finding.status,
+          severity,
+          confidence: finding.confidence,
+          evidence_path_hash: evidence ? hashString(evidence.path) : null,
+          evidence_file_ext: evidence ? fileExtension(evidence.path) : null,
+          evidence_snippet_redacted: redactText(evidence?.snippet),
+          evidence_explanation_redacted: redactText(evidence?.explanation),
+          user_impact_redacted: redactText(finding.userImpact) ?? "",
+          recommendation_redacted: redactText(finding.recommendation) ?? "",
+        },
+      ];
     });
 }
 
@@ -560,6 +578,13 @@ function labelFromText(value: string | null | undefined): DatasetLabel {
 function normalizeLabel(value: string): DatasetLabel {
   if (value === "clean" || value === "suspicious" || value === "malicious") return value;
   return labelFromText(value);
+}
+
+function normalizeClawScanSeverity(value: string): ClawScanSeverity {
+  const normalized = value.trim().toLowerCase();
+  return CLAWSCAN_SEVERITIES.has(normalized as ClawScanSeverity)
+    ? (normalized as ClawScanSeverity)
+    : "none";
 }
 
 function countFileExtensions(files: ExportFileInput[]) {


### PR DESCRIPTION
## Summary

- carry ClawScan `agenticRiskFindings` through the Convex security dataset export response
- write redacted finding rows to a new snapshot sidecar file, `clawscan_findings.jsonl`
- add the sidecar row count to the snapshot manifest and bump the redaction policy to `public-signals-v2`
- keep the existing HF projection unchanged; this PR only changes the ClawHub snapshot export

## Deployment note

The normal prod snapshot command calls the deployed Convex export function. After this merges, deploy ClawHub backend before rerunning:

```bash
bun run dataset:snapshot -- --prod --out-dir ../clawhub-security/.data/snapshots
```

## Tests

- `bun run test -- scripts/security-dataset/normalize.test.ts scripts/security-dataset/convexExport.test.ts scripts/security-dataset/manifest.test.ts`
- `bun run ci:static`
- `bunx tsc --noEmit`
- `bun run ci:unit`
