### PR TITLE
feat: show ClawScan risk levels in UI

### DIFF
--- a/src/__tests__/packages-route.test.tsx
+++ b/src/__tests__/packages-route.test.tsx
@@ -376,6 +376,16 @@ describe("plugins route", () => {
     });
   });
 
+  it("does not render the publish CTA on the plugins browse page", async () => {
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    expect(screen.queryByRole("link", { name: "Publish" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Publish" })).toBeNull();
+  });
+
   it("switches legacy cards URLs back to list view", async () => {
     searchMock = { view: "cards" };
     loaderDataMock = {

--- a/src/__tests__/search-route.test.tsx
+++ b/src/__tests__/search-route.test.tsx
@@ -192,57 +192,45 @@ describe("search route", () => {
     );
   });
 
-  it("shows the 'Hiding suspicious skills' chip by default and opts out on click", async () => {
+  it("does not render a warning filter chip while keeping the safe default", async () => {
     searchMock = { q: "hello" };
     const route = await loadRoute();
     const Component = route.__config.component as ComponentType;
 
     render(<Component />);
 
-    const chip = screen.getByRole("button", { name: /Hiding suspicious skills/i });
-    expect(chip.getAttribute("aria-pressed")).toBe("true");
-    expect(chip.textContent).toContain("Show all");
-
-    fireEvent.click(chip);
-
-    expect(navigateMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        to: "/search",
-        replace: true,
-        search: expect.objectContaining({ nonSuspicious: false }),
-      }),
+    expect(screen.queryByRole("button", { name: /Hiding warnings/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Showing all skills/i })).toBeNull();
+    expect(useUnifiedSearchMock).toHaveBeenCalledWith(
+      "hello",
+      "all",
+      expect.objectContaining({ nonSuspiciousOnly: true }),
     );
   });
 
-  it("shows the 'Showing all skills' chip when opted out and clears the URL param on click", async () => {
+  it("does not render a warning filter chip when opted out", async () => {
     searchMock = { q: "hello", nonSuspicious: false };
     const route = await loadRoute();
     const Component = route.__config.component as ComponentType;
 
     render(<Component />);
 
-    const chip = screen.getByRole("button", { name: /Showing all skills/i });
-    expect(chip.getAttribute("aria-pressed")).toBe("false");
-    expect(chip.textContent).toContain("Hide suspicious");
-
-    fireEvent.click(chip);
-
-    expect(navigateMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        to: "/search",
-        replace: true,
-        search: expect.objectContaining({ nonSuspicious: undefined }),
-      }),
+    expect(screen.queryByRole("button", { name: /Hiding warnings/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Showing all skills/i })).toBeNull();
+    expect(useUnifiedSearchMock).toHaveBeenCalledWith(
+      "hello",
+      "all",
+      expect.objectContaining({ nonSuspiciousOnly: false }),
     );
   });
 
-  it("hides the suspicious-filter chip on the plugins tab", async () => {
+  it("does not render a warning-filter chip on the plugins tab", async () => {
     searchMock = { q: "hello", type: "plugins" };
     const route = await loadRoute();
     const Component = route.__config.component as ComponentType;
 
     render(<Component />);
 
-    expect(screen.queryByRole("button", { name: /suspicious/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /warnings/i })).toBeNull();
   });
 });

--- a/src/__tests__/skill-security-scanner-route.test.tsx
+++ b/src/__tests__/skill-security-scanner-route.test.tsx
@@ -1,0 +1,100 @@
+/* @vitest-environment jsdom */
+
+import { render, screen } from "@testing-library/react";
+import type { ComponentType } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const useQueryMock = vi.fn();
+const useAuthStatusMock = vi.fn();
+
+let paramsMock = {
+  owner: "local",
+  slug: "local-agentic-risk-demo",
+  scanner: "static-analysis",
+};
+let loaderDataMock: {
+  owner: string;
+  displayName: string | null;
+  summary: string | null;
+  version: string | null;
+  initialData?: { result?: unknown };
+} = {
+  owner: "local",
+  displayName: "Local Agentic Risk Demo",
+  summary: null,
+  version: null,
+  initialData: { result: undefined },
+};
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute:
+    () =>
+    (config: { component?: unknown; beforeLoad?: unknown; loader?: unknown; head?: unknown }) => ({
+      __config: config,
+      useParams: () => paramsMock,
+      useLoaderData: () => loaderDataMock,
+    }),
+  notFound: () => ({ notFound: true }),
+  redirect: (options: unknown) => ({ redirect: options }),
+}));
+
+vi.mock("convex/react", () => ({
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
+}));
+
+vi.mock("../lib/useAuthStatus", () => ({
+  useAuthStatus: () => useAuthStatusMock(),
+}));
+
+vi.mock("../lib/skillPage", () => ({
+  fetchSkillPageData: vi.fn(),
+}));
+
+async function loadRoute() {
+  return (await import("../routes/$owner/$slug/security/$scanner")).Route as unknown as {
+    __config: {
+      component?: ComponentType;
+    };
+  };
+}
+
+describe("skill security scanner route", () => {
+  beforeEach(() => {
+    useQueryMock.mockReset();
+    useQueryMock.mockReturnValue(undefined);
+    useAuthStatusMock.mockReturnValue({ me: null });
+    paramsMock = {
+      owner: "local",
+      slug: "local-agentic-risk-demo",
+      scanner: "static-analysis",
+    };
+    loaderDataMock = {
+      owner: "local",
+      displayName: "Local Agentic Risk Demo",
+      summary: null,
+      version: null,
+      initialData: { result: undefined },
+    };
+  });
+
+  it.each(["static-analysis", "clawscan", "virustotal"] as const)(
+    "renders a skeleton while %s security details are loading",
+    async (scanner) => {
+      paramsMock = {
+        owner: "local",
+        slug: "local-agentic-risk-demo",
+        scanner,
+      };
+
+      const route = await loadRoute();
+      const Component = route.__config.component as ComponentType;
+
+      render(<Component />);
+
+      expect(screen.queryByText("Loading security details...")).toBeNull();
+      const loadingRegion = screen.getByRole("status", { name: "Loading security details" });
+      expect(loadingRegion.getAttribute("aria-busy")).toBe("true");
+      expect(document.querySelector(".security-scanner-skeleton")).toBeTruthy();
+    },
+  );
+});

--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -70,6 +70,14 @@ describe("SkillsIndex", () => {
     expect(screen.getByText("No skills found")).toBeTruthy();
   });
 
+  it("does not render the publish CTA on the skills browse page", async () => {
+    render(<SkillsIndex />);
+    await act(async () => {});
+
+    expect(screen.queryByRole("link", { name: "Publish" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Publish" })).toBeNull();
+  });
+
   it("shows loading state before fetch completes", async () => {
     // Never resolve the query to keep the component in loading state
     convexHttpMock.query.mockReturnValue(new Promise(() => {}));
@@ -306,7 +314,7 @@ describe("SkillsIndex", () => {
     );
   });
 
-  it("hides the suspicious filter when loaded results are clean", async () => {
+  it("does not render the warning filter when loaded results are clean", async () => {
     convexHttpMock.query.mockResolvedValue({
       page: [makeListResult("clean-skill", "Clean Skill")],
       hasMore: false,
@@ -316,10 +324,10 @@ describe("SkillsIndex", () => {
     render(<SkillsIndex />);
     await act(async () => {});
 
-    expect(screen.queryByLabelText("Hide suspicious")).toBeNull();
+    expect(screen.queryByLabelText("Hide warnings")).toBeNull();
   });
 
-  it("shows the suspicious filter when loaded results include a suspicious skill", async () => {
+  it("does not render the warning filter when loaded results include a warning skill", async () => {
     convexHttpMock.query.mockResolvedValue({
       page: [makeListResult("suspicious-skill", "Suspicious Skill", { isSuspicious: true })],
       hasMore: false,
@@ -329,10 +337,10 @@ describe("SkillsIndex", () => {
     render(<SkillsIndex />);
     await act(async () => {});
 
-    expect(screen.getByLabelText("Hide suspicious")).toBeTruthy();
+    expect(screen.queryByLabelText("Hide warnings")).toBeNull();
   });
 
-  it("keeps the suspicious filter visible while active", async () => {
+  it("does not render the warning filter while the URL filter is active", async () => {
     searchMock = { nonSuspicious: true };
     convexHttpMock.query.mockResolvedValue({
       page: [makeListResult("clean-skill", "Clean Skill")],
@@ -343,7 +351,7 @@ describe("SkillsIndex", () => {
     render(<SkillsIndex />);
     await act(async () => {});
 
-    expect(screen.getByLabelText("Hide suspicious")).toBeTruthy();
+    expect(screen.queryByLabelText("Hide warnings")).toBeNull();
   });
 
   it("passes highlightedOnly to list query when filter is active", async () => {

--- a/src/components/DetailSecuritySummary.test.tsx
+++ b/src/components/DetailSecuritySummary.test.tsx
@@ -54,10 +54,10 @@ describe("DetailSecuritySummary", () => {
     expect(screen.getByRole("link", { name: /VirusTotal.*Cleared/i })).toBeTruthy();
     expect(screen.getByRole("link", { name: /ClawScan.*Cleared/i })).toBeTruthy();
     expect(screen.getByRole("link", { name: /Static analysis.*Cleared/i })).toBeTruthy();
-    expect(screen.queryByText("Suspicious")).toBeNull();
+    expect(screen.queryByText("Warn")).toBeNull();
   });
 
-  it("shows review and suspicious as separate audit states", () => {
+  it("shows review and warn as separate audit states", () => {
     const { rerender } = render(
       <DetailSecuritySummary
         scannerBasePath="/steipete/weather/security"
@@ -66,15 +66,23 @@ describe("DetailSecuritySummary", () => {
           status: "suspicious",
           verdict: "suspicious",
           checkedAt: 1,
-          riskSummary: {
-            abnormal_behavior_control: {
+          agenticRiskFindings: [
+            {
+              categoryId: "ASI02",
+              categoryLabel: "Tool Misuse and Exploitation",
+              riskBucket: "abnormal_behavior_control",
               status: "concern",
-              summary: "Needs context.",
-              highestSeverity: "medium",
+              severity: "medium",
+              confidence: "medium",
+              evidence: {
+                path: "SKILL.md",
+                snippet: "uses privileged tool",
+                explanation: "The skill uses a privileged tool.",
+              },
+              userImpact: "Needs context.",
+              recommendation: "Review before install.",
             },
-            permission_boundary: { status: "none", summary: "No issue." },
-            sensitive_data_protection: { status: "none", summary: "No issue." },
-          },
+          ],
         }}
         staticScan={{
           status: "clean",
@@ -98,15 +106,23 @@ describe("DetailSecuritySummary", () => {
           status: "suspicious",
           verdict: "suspicious",
           checkedAt: 1,
-          riskSummary: {
-            abnormal_behavior_control: {
+          agenticRiskFindings: [
+            {
+              categoryId: "ASI02",
+              categoryLabel: "Tool Misuse and Exploitation",
+              riskBucket: "abnormal_behavior_control",
               status: "concern",
-              summary: "High concern.",
-              highestSeverity: "high",
+              severity: "high",
+              confidence: "high",
+              evidence: {
+                path: "SKILL.md",
+                snippet: "terminates cloud instances",
+                explanation: "The skill can terminate cloud instances.",
+              },
+              userImpact: "High concern.",
+              recommendation: "Require confirmation.",
             },
-            permission_boundary: { status: "none", summary: "No issue." },
-            sensitive_data_protection: { status: "none", summary: "No issue." },
-          },
+          ],
         }}
         staticScan={{
           status: "clean",
@@ -119,8 +135,9 @@ describe("DetailSecuritySummary", () => {
       />,
     );
 
-    expect(screen.getByRole("link", { name: "ClawScan: Suspicious" })).toBeTruthy();
-    expect(screen.getAllByText("Suspicious").length).toBeGreaterThan(0);
+    expect(screen.getByRole("link", { name: "ClawScan: Warn" })).toBeTruthy();
+    expect(screen.getAllByText("Warn").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Suspicious")).toBeNull();
   });
 
   it("renders clean scanner outcomes as pass in the user-facing audit UI", () => {
@@ -166,7 +183,7 @@ describe("DetailSecuritySummary", () => {
 
     expect(screen.getByRole("link", { name: "Static analysis: Review" })).toBeTruthy();
     expect(screen.getAllByText("Pass")).toHaveLength(3);
-    expect(screen.queryByText("Suspicious")).toBeNull();
+    expect(screen.queryByText("Warn")).toBeNull();
   });
 
   it("does not aggregate scanner operational errors as malicious verdicts", () => {

--- a/src/components/DetailSecuritySummary.tsx
+++ b/src/components/DetailSecuritySummary.tsx
@@ -37,7 +37,7 @@ function statusFromStaticScan(staticScan: DetailSecuritySummaryProps["staticScan
 function severityLevelForStatus(status: string) {
   const normalized = status.toLowerCase();
   if (normalized === "malicious") return 4;
-  if (normalized === "suspicious") return 3;
+  if (normalized === "warn" || normalized === "warning" || normalized === "suspicious") return 3;
   if (normalized === "review") return 2;
   if (normalized === "clean" || normalized === "benign" || normalized === "cleared") return 1;
   return 0;
@@ -48,7 +48,13 @@ function aggregateAuditVerdict(statuses: string[]) {
   if (normalized.some((status) => status === "malicious")) {
     return "malicious";
   }
-  if (normalized.includes("suspicious")) return "suspicious";
+  if (
+    normalized.some(
+      (status) => status === "warn" || status === "warning" || status === "suspicious",
+    )
+  ) {
+    return "warn";
+  }
   if (normalized.some((status) => status === "error" || status === "failed")) return "error";
   if (
     normalized.some(
@@ -64,6 +70,8 @@ function auditVerdictBadgeVariant(status: string): BadgeProps["variant"] {
   switch (status.toLowerCase()) {
     case "malicious":
       return "destructive";
+    case "warn":
+    case "warning":
     case "suspicious":
       return "warning";
     case "pending":

--- a/src/components/PluginListItem.test.tsx
+++ b/src/components/PluginListItem.test.tsx
@@ -1,0 +1,44 @@
+/* @vitest-environment jsdom */
+
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { PackageListItem } from "../lib/packageApi";
+import { PluginListItem } from "./PluginListItem";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to }: { children?: ReactNode; to?: string }) => <a href={to}>{children}</a>,
+}));
+
+describe("PluginListItem", () => {
+  it("renders official list plugins with the shared verified badge", () => {
+    const { container } = render(<PluginListItem item={makePlugin()} />);
+
+    expect(screen.getByText("Verified")).toBeTruthy();
+    expect(container.querySelector(".verified-badge")).toBeTruthy();
+    expect(container.querySelector(".verified-badge-icon")).toBeTruthy();
+  });
+
+  it("renders official plugin cards with the shared verified badge", () => {
+    const { container } = render(<PluginListItem item={makePlugin()} variant="card" />);
+
+    expect(screen.getByText("Verified")).toBeTruthy();
+    expect(container.querySelector(".verified-badge")).toBeTruthy();
+    expect(container.querySelector(".verified-badge-icon")).toBeTruthy();
+  });
+});
+
+function makePlugin(): PackageListItem {
+  return {
+    name: "demo-plugin",
+    displayName: "Demo Plugin",
+    family: "code-plugin",
+    channel: "official",
+    isOfficial: true,
+    summary: "Demo summary",
+    ownerHandle: "local",
+    createdAt: 1,
+    updatedAt: 1,
+    latestVersion: "1.0.0",
+  };
+}

--- a/src/components/PluginListItem.tsx
+++ b/src/components/PluginListItem.tsx
@@ -21,7 +21,7 @@ export function PluginListItem({ item, variant = "list" }: PluginListItemProps) 
       >
         <div className="skill-card-tags">
           <Badge variant="compact">{familyLabel(item.family)}</Badge>
-          {item.isOfficial ? <Badge variant="accent">Verified</Badge> : null}
+          {item.isOfficial ? <VerifiedBadge /> : null}
         </div>
         <div className="skill-card-header">
           <MarketplaceIcon kind="plugin" label={item.displayName} size="md" />

--- a/src/components/SecurityScannerPage.tsx
+++ b/src/components/SecurityScannerPage.tsx
@@ -5,10 +5,12 @@ import { PublisherClawScanNote } from "./PublisherClawScanNote";
 import { SidebarMetadata } from "./SidebarMetadata";
 import {
   ClawScanRiskReview,
-  ConfidenceMeter,
   getClawScanDisplayStatus,
+  getClawScanRiskLevel,
+  getVisibleClawScanFindingCount,
   getVirusTotalDisplayStatus,
   hasClawScanRiskReview,
+  RiskLevelBadge,
   ScanResultBadge,
   type LlmAnalysis,
   type StaticFinding,
@@ -16,6 +18,7 @@ import {
 } from "./SkillSecurityScanResults";
 import { Alert, AlertDescription } from "./ui/alert";
 import { Badge } from "./ui/badge";
+import { Skeleton } from "./ui/skeleton";
 
 export type ScannerSlug = "virustotal" | "clawscan" | "static-analysis";
 
@@ -154,14 +157,7 @@ function SecurityScannerHero({ label, props }: { label: string; props: SecurityS
 
 function getVisibleFindingCount(props: SecurityScannerPageProps) {
   if (props.scanner === "static-analysis") return props.staticScan?.findings?.length ?? 0;
-  if (props.scanner === "clawscan") {
-    return (
-      props.llmAnalysis?.agenticRiskFindings?.filter(
-        (finding) =>
-          (finding.status === "note" || finding.status === "concern") && finding.evidence,
-      ).length ?? 0
-    );
-  }
+  if (props.scanner === "clawscan") return getVisibleClawScanFindingCount(props.llmAnalysis);
   return 0;
 }
 
@@ -188,7 +184,7 @@ function getOverviewCopy(props: SecurityScannerPageProps) {
 
 function isReviewStatus(status: string) {
   const normalized = status.trim().toLowerCase();
-  return normalized === "review" || normalized === "suspicious";
+  return normalized === "review" || normalized === "warn" || normalized === "suspicious";
 }
 
 function PublisherNotePrompt({
@@ -239,6 +235,7 @@ function SecurityScannerReport(props: SecurityScannerPageProps) {
   const sourceCommit = formatValue(props.source?.commit ?? props.source?.sha);
   const riskAnalysis =
     props.llmAnalysis && hasClawScanRiskReview(props.llmAnalysis) ? props.llmAnalysis : null;
+  const riskLevel = props.scanner === "clawscan" ? getClawScanRiskLevel(props.llmAnalysis) : null;
   const visibleFindingCount = getVisibleFindingCount(props);
   const overviewCopy = getOverviewCopy(props).filter(Boolean);
   const showPublisherNotePrompt =
@@ -346,20 +343,11 @@ function SecurityScannerReport(props: SecurityScannerPageProps) {
               ariaLabel="Scan metadata"
               density="compact"
               blocks={[
-                {
-                  label: "Verdict",
-                  value: <ScanResultBadge status={status} tone="review" />,
-                },
                 ...(props.scanner === "clawscan"
                   ? [
                       {
-                        label: "Confidence",
-                        value: (
-                          <ConfidenceMeter
-                            value={props.llmAnalysis?.confidence}
-                            includeNoun={false}
-                          />
-                        ),
+                        label: "Risk level",
+                        value: riskLevel ? <RiskLevelBadge level={riskLevel} /> : null,
                       },
                     ]
                   : []),
@@ -462,4 +450,108 @@ function SecurityScannerReport(props: SecurityScannerPageProps) {
 
 export function SecurityScannerPage(props: SecurityScannerPageProps) {
   return <SecurityScannerReport {...props} />;
+}
+
+export function SecurityScannerPageSkeleton() {
+  return (
+    <main className="section detail-page-section security-report-section">
+      <div
+        className="security-report-shell security-scanner-skeleton"
+        role="status"
+        aria-label="Loading security details"
+        aria-busy="true"
+      >
+        <header className="security-scan-hero">
+          <div className="skill-hero-breadcrumbs">
+            <Skeleton className="h-4 w-12" />
+            <Skeleton className="h-4 w-3" />
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-3" />
+            <Skeleton className="h-4 w-40 max-w-[42vw]" />
+            <Skeleton className="h-4 w-3" />
+            <Skeleton className="h-4 w-28" />
+          </div>
+          <div className="security-scan-hero-heading">
+            <Skeleton className="h-12 w-full max-w-[520px]" />
+            <div className="security-scan-hero-subtext">
+              <Skeleton className="h-8 w-24 rounded-[var(--r-pill)]" />
+              <Skeleton className="h-5 w-full max-w-[340px]" />
+            </div>
+          </div>
+        </header>
+
+        <div className="security-report-layout">
+          <div className="security-report-main">
+            <section className="security-report-panel">
+              <div className="security-report-panel-header">
+                <Skeleton className="h-6 w-28" />
+              </div>
+              <div className="security-report-overview-body">
+                <Skeleton className="h-5 w-full" />
+                <Skeleton className="h-5 w-11/12" />
+                <Skeleton className="h-5 w-3/4" />
+              </div>
+            </section>
+
+            <section className="security-report-panel">
+              <div className="security-report-panel-header">
+                <Skeleton className="h-6 w-32" />
+              </div>
+              <div className="security-report-panel-body">
+                <div className="static-analysis-findings">
+                  {Array.from({ length: 2 }).map((_, index) => (
+                    <article
+                      // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholder count
+                      key={index}
+                      className="static-analysis-finding"
+                    >
+                      <div className="static-analysis-finding-header">
+                        <Skeleton className="h-6 w-16 rounded-[var(--r-pill)]" />
+                        <Skeleton className="h-5 w-48 max-w-full" />
+                      </div>
+                      <div className="space-y-3">
+                        <Skeleton className="h-4 w-full" />
+                        <Skeleton className="h-4 w-5/6" />
+                        <Skeleton className="h-16 w-full rounded-[var(--r-sm)]" />
+                      </div>
+                    </article>
+                  ))}
+                </div>
+              </div>
+            </section>
+          </div>
+
+          <aside className="security-report-sidebar" aria-label="Scan metadata">
+            <div className="sidebar-metadata sidebar-metadata-compact">
+              <div className="sidebar-metadata-row">
+                <Skeleton className="h-3 w-16" />
+                <Skeleton className="h-5 w-40" />
+              </div>
+              <div className="sidebar-metadata-grid">
+                <div className="sidebar-metadata-row">
+                  <Skeleton className="h-3 w-16" />
+                  <Skeleton className="h-5 w-10" />
+                </div>
+                <div className="sidebar-metadata-row">
+                  <Skeleton className="h-3 w-14" />
+                  <Skeleton className="h-5 w-16" />
+                </div>
+              </div>
+              <div className="sidebar-metadata-row">
+                <Skeleton className="h-3 w-24" />
+                <div className="security-report-badge-list">
+                  <Skeleton className="h-6 w-16 rounded-[var(--r-pill)]" />
+                  <Skeleton className="h-6 w-20 rounded-[var(--r-pill)]" />
+                </div>
+              </div>
+              <div className="sidebar-metadata-row">
+                <Skeleton className="h-3 w-14" />
+                <Skeleton className="h-5 w-28" />
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </main>
+  );
 }

--- a/src/components/SkillCard.test.tsx
+++ b/src/components/SkillCard.test.tsx
@@ -1,0 +1,59 @@
+/* @vitest-environment jsdom */
+
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { Id } from "../../convex/_generated/dataModel";
+import type { PublicSkill } from "../lib/publicUser";
+import { SkillCard } from "./SkillCard";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to }: { children?: ReactNode; to?: string }) => <a href={to}>{children}</a>,
+}));
+
+describe("SkillCard", () => {
+  it("renders the Verified label with the shared verified badge", () => {
+    const { container } = render(
+      <SkillCard
+        skill={makeSkill()}
+        badge="Verified"
+        summaryFallback="Fallback summary"
+        meta={<span>meta</span>}
+      />,
+    );
+
+    expect(screen.getByText("Verified")).toBeTruthy();
+    expect(container.querySelector(".verified-badge")).toBeTruthy();
+    expect(container.querySelector(".verified-badge-icon")).toBeTruthy();
+  });
+});
+
+function makeSkill(): PublicSkill {
+  return {
+    _id: "skills:demo" as Id<"skills">,
+    _creationTime: 1,
+    slug: "demo",
+    displayName: "Demo Skill",
+    summary: "Demo summary",
+    icon: undefined,
+    ownerUserId: "users:owner" as Id<"users">,
+    ownerPublisherId: "publishers:owner" as Id<"publishers">,
+    canonicalSkillId: undefined,
+    forkOf: undefined,
+    latestVersionId: undefined,
+    tags: {},
+    capabilityTags: [],
+    badges: {},
+    stats: {
+      downloads: 0,
+      stars: 0,
+      versions: 1,
+      comments: 0,
+      installsCurrent: 0,
+      installsAllTime: 0,
+    },
+    isSuspicious: false,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}

--- a/src/components/SkillCard.tsx
+++ b/src/components/SkillCard.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import type { PublicSkill } from "../lib/publicUser";
 import { MarketplaceIcon } from "./MarketplaceIcon";
 import { Badge } from "./ui/badge";
+import { VerifiedBadge } from "./VerifiedBadge";
 
 type SkillCardProps = {
   skill: PublicSkill;
@@ -34,9 +35,13 @@ export function SkillCard({
     <Link to={link} className={["card skill-card", className].filter(Boolean).join(" ")}>
       {hasTags ? (
         <div className="skill-card-tags">
-          {badges.map((label) => (
-            <Badge key={label}>{label}</Badge>
-          ))}
+          {badges.map((label) =>
+            label === "Verified" ? (
+              <VerifiedBadge key={label} />
+            ) : (
+              <Badge key={label}>{label}</Badge>
+            ),
+          )}
           {chip ? <Badge variant="accent">{chip}</Badge> : null}
           {platformLabels?.map((label) => (
             <Badge key={label} variant="compact">

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -128,13 +128,13 @@ function buildStaffVisibilityAlert({
   } else if (moderationReason === "security.redaction") {
     reason = "because it was hidden for security redaction.";
   } else if (moderationReason?.startsWith("scanner.") && moderationReason.endsWith(".malicious")) {
-    reason = "because automated security checks marked it suspicious or malicious.";
+    reason = "because automated security checks found security warnings or malicious content.";
   } else if (moderationReason?.startsWith("scanner.") && moderationReason.endsWith(".suspicious")) {
-    reason = "because automated security checks marked it suspicious or malicious.";
+    reason = "because automated security checks found security warnings or malicious content.";
   } else if (modInfo?.isMalwareBlocked) {
-    reason = "because automated security checks marked it suspicious or malicious.";
+    reason = "because automated security checks found security warnings or malicious content.";
   } else if (modInfo?.isSuspicious) {
-    reason = "because automated security checks marked it suspicious or malicious.";
+    reason = "because automated security checks found security warnings or malicious content.";
   } else if (isSoftDeleted && !moderationReason) {
     reason = "because it was unpublished.";
   }

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -160,7 +160,7 @@ export function SkillHeader({
       ) : modInfo?.isSuspicious ? (
         <div className="pending-banner pending-banner-warning">
           <div className="pending-banner-content">
-            <strong>Skill flagged — review recommended</strong>
+            <strong>Security warning — review recommended</strong>
             <p>
               ClawHub Security found sensitive or high-impact capabilities. Review the scan results
               before using.

--- a/src/components/SkillListItem.test.tsx
+++ b/src/components/SkillListItem.test.tsx
@@ -1,0 +1,65 @@
+/* @vitest-environment jsdom */
+
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { Id } from "../../convex/_generated/dataModel";
+import type { PublicSkill } from "../lib/publicUser";
+import { SkillListItem } from "./SkillListItem";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to }: { children?: ReactNode; to?: string }) => <a href={to}>{children}</a>,
+}));
+
+describe("SkillListItem", () => {
+  it("renders official skills with the shared verified badge", () => {
+    const { container } = render(
+      <SkillListItem
+        skill={makeSkill({
+          badges: {
+            official: {
+              byUserId: "users:admin" as Id<"users">,
+              at: 1,
+            },
+          },
+        })}
+        ownerHandle="local"
+      />,
+    );
+
+    expect(screen.getByText("Verified")).toBeTruthy();
+    expect(container.querySelector(".verified-badge")).toBeTruthy();
+    expect(container.querySelector(".verified-badge-icon")).toBeTruthy();
+  });
+});
+
+function makeSkill(overrides: Partial<PublicSkill> = {}): PublicSkill {
+  return {
+    _id: "skills:demo" as Id<"skills">,
+    _creationTime: 1,
+    slug: "demo",
+    displayName: "Demo Skill",
+    summary: "Demo summary",
+    icon: undefined,
+    ownerUserId: "users:owner" as Id<"users">,
+    ownerPublisherId: "publishers:owner" as Id<"publishers">,
+    canonicalSkillId: undefined,
+    forkOf: undefined,
+    latestVersionId: undefined,
+    tags: {},
+    capabilityTags: [],
+    badges: {},
+    stats: {
+      downloads: 9,
+      stars: 2,
+      versions: 1,
+      comments: 0,
+      installsCurrent: 0,
+      installsAllTime: 0,
+    },
+    isSuspicious: false,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}

--- a/src/components/SkillListItem.tsx
+++ b/src/components/SkillListItem.tsx
@@ -6,6 +6,7 @@ import type { PublicPublisher, PublicSkill } from "../lib/publicUser";
 import { timeAgo } from "../lib/timeAgo";
 import { MarketplaceIcon } from "./MarketplaceIcon";
 import { Badge } from "./ui/badge";
+import { VerifiedBadge } from "./VerifiedBadge";
 
 type SkillListItemProps = {
   skill: PublicSkill;
@@ -31,11 +32,15 @@ export function SkillListItem({ skill, ownerHandle, owner }: SkillListItemProps)
             </>
           ) : null}
           <span className="skill-list-item-name">{skill.displayName}</span>
-          {badges.map((b) => (
-            <Badge key={b} variant="compact">
-              {b}
-            </Badge>
-          ))}
+          {badges.map((b) =>
+            b === "Verified" ? (
+              <VerifiedBadge key={b} />
+            ) : (
+              <Badge key={b} variant="compact">
+                {b}
+              </Badge>
+            ),
+          )}
         </div>
         {skill.summary ? <p className="skill-list-item-summary">{skill.summary}</p> : null}
         <div className="skill-list-item-meta">

--- a/src/components/SkillSecurityScanResults.test.tsx
+++ b/src/components/SkillSecurityScanResults.test.tsx
@@ -89,6 +89,46 @@ const legacyClawScanAnalysis: LlmAnalysis = {
   ],
 };
 
+const lowConfidenceConcernAnalysis: LlmAnalysis = {
+  status: "suspicious",
+  verdict: "suspicious",
+  confidence: "high",
+  summary: "Potential concern needs review.",
+  checkedAt: Date.now(),
+  agenticRiskFindings: [
+    {
+      categoryId: "ASI02",
+      categoryLabel: "Tool Misuse and Exploitation",
+      riskBucket: "abnormal_behavior_control",
+      status: "concern",
+      severity: "critical",
+      confidence: "low",
+      evidence: {
+        path: "SKILL.md",
+        snippet: "delete everything",
+        explanation: "The text might describe destructive behavior.",
+      },
+      userImpact: "A low-confidence concern should not be displayed to users.",
+      recommendation: "Review manually.",
+    },
+    {
+      categoryId: "ASI03",
+      categoryLabel: "Identity and Privilege Abuse",
+      riskBucket: "permission_boundary",
+      status: "note",
+      severity: "low",
+      confidence: "medium",
+      evidence: {
+        path: "metadata",
+        snippet: "requires.env: SERVICE_TOKEN",
+        explanation: "The skill requires a service token for its declared integration.",
+      },
+      userImpact: "Users should know the skill needs a service token.",
+      recommendation: "Install only if token access is expected.",
+    },
+  ],
+};
+
 beforeEach(() => {
   window.localStorage.clear();
 });
@@ -198,6 +238,69 @@ describe("SecurityScanResults static guidance", () => {
       screen.getByText("Sensitive workspace data could leave the user's machine."),
     ).toBeTruthy();
     expect(screen.queryByText("ASI01")).toBeNull();
+    expect(screen.queryByText(/Confidence/i)).toBeNull();
+  });
+
+  it("shows ClawScan risk level instead of confidence in the scan panel", () => {
+    render(<SecurityScanResults llmAnalysis={clawScanAnalysis} />);
+
+    expect(screen.getByText("Warn")).toBeTruthy();
+    expect(screen.getByText("High Risk")).toBeTruthy();
+    expect(screen.queryByText(/high confidence/i)).toBeNull();
+    expect(screen.queryByText(/Suspicious/i)).toBeNull();
+  });
+
+  it("shows low risk for clean ClawScan scans", () => {
+    render(<SecurityScanResults llmAnalysis={{ status: "clean", checkedAt: Date.now() }} />);
+
+    expect(screen.getByText("Pass")).toBeTruthy();
+    expect(screen.getByText("Low Risk")).toBeTruthy();
+  });
+
+  it("shows review and medium risk for medium-severity ClawScan findings", () => {
+    render(
+      <SecurityScanResults
+        llmAnalysis={{
+          status: "suspicious",
+          verdict: "suspicious",
+          summary: "The skill needs context before install.",
+          checkedAt: Date.now(),
+          agenticRiskFindings: [
+            {
+              categoryId: "ASI04",
+              categoryLabel: "Resource Overreach",
+              riskBucket: "permission_boundary",
+              status: "concern",
+              severity: "medium",
+              confidence: "medium",
+              evidence: {
+                path: "SKILL.md",
+                snippet: "requests write access",
+                explanation: "The skill requests write access for a broad workspace path.",
+              },
+              userImpact: "The skill can modify a broader path than expected.",
+              recommendation: "Review the requested permission boundary before install.",
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Review")).toBeTruthy();
+    expect(screen.getByText("Medium Risk")).toBeTruthy();
+    expect(screen.queryByText("Warn")).toBeNull();
+  });
+
+  it("ignores low-confidence findings for visible findings, status, and risk", () => {
+    render(<SecurityScanResults llmAnalysis={lowConfidenceConcernAnalysis} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Potential concern/i }));
+
+    expect(screen.getByText("Review")).toBeTruthy();
+    expect(screen.getByText("Low Risk")).toBeTruthy();
+    expect(screen.getByText("ASI03: Identity and Privilege Abuse")).toBeTruthy();
+    expect(screen.queryByText("ASI02: Tool Misuse and Exploitation")).toBeNull();
+    expect(screen.queryByText("delete everything")).toBeNull();
   });
 
   it("preserves legacy ClawScan dimensions when agentic fields are absent", () => {
@@ -243,7 +346,10 @@ describe("SecurityScanResults static guidance", () => {
     );
 
     expect(screen.getByRole("heading", { name: "Todo Guard" })).toBeTruthy();
-    expect(screen.getAllByText("Suspicious").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Warn").length).toBeGreaterThan(0);
+    expect(screen.getByText("Risk level")).toBeTruthy();
+    expect(screen.getByText("High Risk")).toBeTruthy();
+    expect(screen.queryByText("Verdict")).toBeNull();
     expect(screen.getByText(/Audited by ClawScan/i)).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
     expect(screen.getByText(/Collects workspace secrets/i)).toBeTruthy();
@@ -260,6 +366,7 @@ describe("SecurityScanResults static guidance", () => {
     expect(screen.queryByText("metadata")).toBeNull();
     expect(screen.getAllByText("Skill content").length).toBeGreaterThan(0);
     expect(screen.getByText("requires.env: TODOIST_API_TOKEN")).toBeTruthy();
+    expect(screen.queryByText("Confidence")).toBeNull();
   });
 
   it("prompts publishers to add a note on review ClawScan reports without one", () => {

--- a/src/components/SkillSecurityScanResults.tsx
+++ b/src/components/SkillSecurityScanResults.tsx
@@ -107,6 +107,8 @@ type SecurityScanResultsProps = {
   variant?: "panel" | "badge";
 };
 
+type ClawScanRiskLevel = "low" | "medium" | "high";
+
 function VirusTotalIcon({ className }: { className?: string }) {
   return (
     <svg
@@ -146,8 +148,10 @@ export function getScanStatusInfo(status: string) {
       };
     case "review":
       return { label: "Review", className: "scan-status-review", badgeVariant: "review" };
+    case "warn":
+    case "warning":
     case "suspicious":
-      return { label: "Suspicious", className: "scan-status-suspicious", badgeVariant: "warning" };
+      return { label: "Warn", className: "scan-status-warn", badgeVariant: "warning" };
     case "advisory":
       return { label: "Advisory", className: "scan-status-unknown", badgeVariant: "compact" };
     case "loading":
@@ -180,15 +184,22 @@ function severityRank(severity?: string) {
   }
 }
 
-function highestConcernSeverityRank(analysis?: LlmAnalysis | null) {
+function isLowConfidence(value: unknown) {
+  return typeof value === "string" && value.trim().toLowerCase() === "low";
+}
+
+function isVisibleAgenticRiskFinding(finding: LlmAgenticRiskFinding) {
+  return (
+    (finding.status === "note" || finding.status === "concern") &&
+    Boolean(finding.evidence) &&
+    !isLowConfidence(finding.confidence)
+  );
+}
+
+function highestVisibleFindingSeverityRank(analysis?: LlmAnalysis | null) {
   let highest = 0;
-  for (const finding of analysis?.agenticRiskFindings ?? []) {
-    if (finding.status === "concern") highest = Math.max(highest, severityRank(finding.severity));
-  }
-  for (const bucket of Object.values(analysis?.riskSummary ?? {})) {
-    if (bucket?.status === "concern") {
-      highest = Math.max(highest, severityRank(bucket.highestSeverity));
-    }
+  for (const finding of getVisibleAgenticRiskFindings(analysis)) {
+    highest = Math.max(highest, severityRank(finding.severity));
   }
   return highest;
 }
@@ -197,7 +208,21 @@ export function getClawScanDisplayStatus(analysis?: LlmAnalysis | null) {
   const status = (analysis?.verdict ?? analysis?.status)?.trim().toLowerCase();
   if (!status) return "pending";
   if (status !== "suspicious") return status;
-  return highestConcernSeverityRank(analysis) >= severityRank("high") ? "suspicious" : "review";
+  return highestVisibleFindingSeverityRank(analysis) >= severityRank("high") ? "warn" : "review";
+}
+
+export function getClawScanRiskLevel(analysis?: LlmAnalysis | null): ClawScanRiskLevel | null {
+  const status = (analysis?.verdict ?? analysis?.status)?.trim().toLowerCase();
+  if (!status || status === "pending" || status === "loading" || status === "not_found") {
+    return null;
+  }
+  if (status === "error" || status === "failed") return null;
+  if (status === "malicious") return "high";
+
+  const highestSeverity = highestVisibleFindingSeverityRank(analysis);
+  if (highestSeverity >= severityRank("high")) return "high";
+  if (highestSeverity >= severityRank("medium")) return "medium";
+  return "low";
 }
 
 function getVtEngineStats(analysis?: VtAnalysis | null) {
@@ -265,41 +290,25 @@ const AGENTIC_RISK_STATUS_LABELS: Record<AgenticRiskStatus, string> = {
   concern: "Concern",
 };
 
-function formatSecurityLabel(value?: string | null) {
-  if (!value) return null;
-  return value
-    .split(/[-_\s]+/)
-    .filter(Boolean)
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
-    .join(" ");
-}
+const RISK_LEVEL_BADGE_META: Record<
+  ClawScanRiskLevel,
+  { label: string; level: number; variant: BadgeProps["variant"] }
+> = {
+  low: { label: "Low Risk", level: 1, variant: "success" },
+  medium: { label: "Medium Risk", level: 2, variant: "warning" },
+  high: { label: "High Risk", level: 3, variant: "destructive" },
+};
 
-function normalizeConfidence(value: unknown, includeNoun = true) {
-  const label = formatSecurityLabel(typeof value === "string" ? value : null);
-  const normalized = label?.toLowerCase();
-  if (normalized === "high") return { label: includeNoun ? "High Confidence" : "High", level: 3 };
-  if (normalized === "medium")
-    return { label: includeNoun ? "Medium Confidence" : "Medium", level: 2 };
-  if (normalized === "low") return { label: includeNoun ? "Low Confidence" : "Low", level: 1 };
-  return { label: "Confidence not reported", level: 0 };
-}
-
-export function ConfidenceMeter({
-  value,
-  includeNoun = true,
-}: {
-  value: unknown;
-  includeNoun?: boolean;
-}) {
-  const confidence = normalizeConfidence(value, includeNoun);
+export function RiskLevelBadge({ level }: { level: ClawScanRiskLevel }) {
+  const risk = RISK_LEVEL_BADGE_META[level];
   return (
-    <Badge variant="compact" className="scan-confidence-meter" data-level={confidence.level}>
-      <span className="scan-confidence-bars" aria-hidden="true">
+    <Badge variant={risk.variant} className="scan-risk-level-badge" data-level={risk.level}>
+      <span className="scan-risk-level-bars" aria-hidden="true">
         <span />
         <span />
         <span />
       </span>
-      <span>{confidence.label}</span>
+      <span>{risk.label}</span>
     </Badge>
   );
 }
@@ -311,15 +320,17 @@ function getRiskStatusVariant(status: AgenticRiskStatus): BadgeProps["variant"] 
   return "compact";
 }
 
-function getVisibleAgenticRiskFindings(analysis: LlmAnalysis) {
-  return (analysis.agenticRiskFindings ?? []).filter(
-    (finding) => (finding.status === "note" || finding.status === "concern") && finding.evidence,
-  );
+function getVisibleAgenticRiskFindings(analysis?: LlmAnalysis | null) {
+  return (analysis?.agenticRiskFindings ?? []).filter(isVisibleAgenticRiskFinding);
+}
+
+export function getVisibleClawScanFindingCount(analysis?: LlmAnalysis | null) {
+  return getVisibleAgenticRiskFindings(analysis).length;
 }
 
 export function hasClawScanRiskReview(analysis?: LlmAnalysis | null) {
   if (!analysis) return false;
-  return getVisibleAgenticRiskFindings(analysis).length > 0;
+  return getVisibleClawScanFindingCount(analysis) > 0;
 }
 
 function getFindingBadgeLabel(finding: LlmAgenticRiskFinding) {
@@ -353,7 +364,6 @@ function AgenticRiskFindingCard({
           <Badge variant={getRiskStatusVariant(finding.status)}>
             {getFindingBadgeLabel(finding)}
           </Badge>
-          <ConfidenceMeter value={finding.confidence} />
         </div>
         {categoryHref ? (
           <a
@@ -647,6 +657,7 @@ export function SecurityScanResults({
   const llmVerdict = llmAnalysis?.verdict ?? llmAnalysis?.status;
   const llmDisplayStatus = getClawScanDisplayStatus(llmAnalysis);
   const llmStatusInfo = llmVerdict ? getScanStatusInfo(llmDisplayStatus) : null;
+  const llmRiskLevel = getClawScanRiskLevel(llmAnalysis);
 
   if (variant === "badge") {
     return (
@@ -712,7 +723,7 @@ export function SecurityScanResults({
             </div>
             <div className="scan-capability-note">
               These labels describe what authority the skill may exercise. They are separate from
-              suspicious or malicious moderation verdicts.
+              warning or malicious moderation verdicts.
             </div>
           </div>
         ) : null}
@@ -753,8 +764,10 @@ export function SecurityScanResults({
               <span className="scan-result-scanner-name">ClawScan</span>
             </div>
             <ScanResultBadge status={llmDisplayStatus} tone="review" />
-            {llmAnalysis.confidence ? (
-              <span className="scan-result-confidence">{llmAnalysis.confidence} confidence</span>
+            {llmRiskLevel ? (
+              <span className="scan-result-risk">
+                <RiskLevelBadge level={llmRiskLevel} />
+              </span>
             ) : null}
             {scannerBasePath ? (
               <a href={`${scannerBasePath}/clawscan`} className="scan-result-link">

--- a/src/lib/useUnifiedSearch.ts
+++ b/src/lib/useUnifiedSearch.ts
@@ -37,7 +37,7 @@ type UnifiedSearchOptions = {
     plugins?: number;
   };
   /**
-   * When true, suspicious skills are excluded from results at recall time.
+   * When true, skills with warning-level moderation signals are excluded at recall time.
    * Defaults to true to preserve the moderation-safe default for top-level
    * entry points (homepage / unified search). Callers that provide their own
    * UI for toggling this filter (e.g. the /skills browse page) should pass

--- a/src/routes/$owner/$slug/security/$scanner.tsx
+++ b/src/routes/$owner/$slug/security/$scanner.tsx
@@ -1,7 +1,11 @@
 import { createFileRoute, notFound, redirect } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
 import { api } from "../../../../../convex/_generated/api";
-import { SecurityScannerPage, type ScannerSlug } from "../../../../components/SecurityScannerPage";
+import {
+  SecurityScannerPage,
+  SecurityScannerPageSkeleton,
+  type ScannerSlug,
+} from "../../../../components/SecurityScannerPage";
 import { buildSkillMeta } from "../../../../lib/og";
 import { isAdmin } from "../../../../lib/roles";
 import { fetchSkillPageData } from "../../../../lib/skillPage";
@@ -96,11 +100,7 @@ function SkillSecurityScannerRoute() {
   const latestVersion = result?.latestVersion;
 
   if (result === undefined) {
-    return (
-      <main className="section">
-        <div className="card">Loading security details...</div>
-      </main>
-    );
+    return <SecurityScannerPageSkeleton />;
   }
 
   if (!skill || !latestVersion) {

--- a/src/routes/plugins/index.tsx
+++ b/src/routes/plugins/index.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link, redirect } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import { isPluginCategorySlug } from "clawhub-schema";
 import { PackageSearch, Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -365,23 +365,6 @@ function PluginsIndex() {
         <h1 className="browse-title">
           Plugins <span className="browse-count">{visibleItems.length}</span>
         </h1>
-        <div className="browse-page-actions">
-          <Button asChild variant="primary">
-            <Link
-              to="/plugins/publish"
-              search={{
-                ownerHandle: undefined,
-                name: undefined,
-                displayName: undefined,
-                family: undefined,
-                nextVersion: undefined,
-                sourceRepo: undefined,
-              }}
-            >
-              Publish
-            </Link>
-          </Button>
-        </div>
       </div>
       <form className="browse-page-search" onSubmit={handleSearch}>
         <Search size={15} className="navbar-search-icon" aria-hidden="true" />

--- a/src/routes/search.tsx
+++ b/src/routes/search.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { Check, Search, X } from "lucide-react";
+import { Search, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { PluginListItem } from "../components/PluginListItem";
 import { SkillListItem } from "../components/SkillListItem";
@@ -34,9 +34,9 @@ function UnifiedSearchPage() {
   const search = Route.useSearch();
   const navigate = useNavigate();
   const activeType = search.type ?? "all";
-  // Unified search defaults to moderation-safe (suspicious skills hidden).
-  // Users can opt in to seeing all results via the chip below; that flips
-  // nonSuspicious to false in the URL, mirroring /skills' URL param name.
+  // Unified search defaults to moderation-safe (skills with warnings hidden).
+  // Keep the URL flag for compatibility even though the search UI no longer
+  // exposes a warning filter control.
   const nonSuspiciousOnly = search.nonSuspicious ?? true;
   const [query, setQuery] = useState(search.q ?? "");
   const [resultLimit, setResultLimit] = useState(SEARCH_PAGE_SIZE);
@@ -93,19 +93,6 @@ function UnifiedSearchPage() {
         q: search.q,
         type: type === "all" ? undefined : type,
         nonSuspicious: search.nonSuspicious,
-      },
-      replace: true,
-    });
-  };
-
-  const toggleNonSuspicious = () => {
-    void navigate({
-      to: "/search",
-      search: {
-        q: search.q,
-        type: search.type,
-        // Default is true (hide suspicious); only persist the opt-out (false) in the URL.
-        nonSuspicious: nonSuspiciousOnly ? false : undefined,
       },
       replace: true,
     });
@@ -181,12 +168,6 @@ function UnifiedSearchPage() {
         </button>
       </div>
 
-      {search.q && activeType !== "plugins" ? (
-        <div className="mb-3 flex flex-wrap items-center gap-2">
-          <SuspiciousFilterChip active={nonSuspiciousOnly} onClick={toggleNonSuspicious} />
-        </div>
-      ) : null}
-
       {isSearching ? (
         <Card>
           <div className="loading-indicator">Searching...</div>
@@ -224,37 +205,6 @@ function UnifiedSearchPage() {
         </>
       )}
     </main>
-  );
-}
-
-function SuspiciousFilterChip({ active, onClick }: { active: boolean; onClick: () => void }) {
-  // Mirrors the FilterChip styling from /skills so the two surfaces feel consistent.
-  // `active` means suspicious skills are being hidden (the moderation-safe default).
-  const label = active ? "Hiding suspicious skills" : "Showing all skills";
-  const actionLabel = active ? "Show all" : "Hide suspicious";
-  return (
-    <button
-      type="button"
-      aria-pressed={active}
-      onClick={onClick}
-      title={
-        active
-          ? "Suspicious skills are hidden. Click to show all skills."
-          : "All skills are shown. Click to hide suspicious skills."
-      }
-      className={`inline-flex min-h-[36px] items-center gap-1.5 rounded-[var(--radius-sm)] border border-[rgba(29,59,78,0.22)] bg-[rgba(255,255,255,0.94)] px-3.5 text-xs font-semibold transition-all duration-150 dark:border-[rgba(255,255,255,0.12)] dark:bg-[rgba(14,28,37,0.84)] ${
-        active
-          ? "border-[color:var(--accent)]/30 bg-[color:var(--accent)]/10 text-[color:var(--accent)] dark:border-[rgba(255,131,95,0.34)] dark:bg-[rgba(255,131,95,0.14)] dark:text-[#ffd5c9]"
-          : "text-[color:var(--ink-soft)] hover:border-[color:var(--border-ui-hover)] hover:text-[color:var(--ink)] dark:text-[rgba(245,238,232,0.88)] dark:hover:border-[rgba(255,255,255,0.2)] dark:hover:text-[rgba(245,238,232,0.96)]"
-      }`}
-    >
-      {active ? <Check className="h-3 w-3" /> : null}
-      <span>{label}</span>
-      <span aria-hidden="true" className="opacity-50">
-        ·
-      </span>
-      <span className="underline-offset-2 hover:underline">{actionLabel}</span>
-    </button>
   );
 }
 

--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -268,8 +268,6 @@ export function useSkillsBrowseModel({
   }, [baseItems, dir, hasQuery, isOtherCategory, sort]);
 
   const isLoadingSkills = hasQuery ? isSearching && searchResults.length === 0 : isLoadingList;
-  const hasSuspiciousResults = sorted.some((entry) => entry.skill.isSuspicious === true);
-  const showSuspiciousFilter = nonSuspiciousOnly || hasSuspiciousResults;
   const canLoadMore = hasQuery
     ? !isSearching && searchResults.length === searchLimit && searchResults.length > 0
     : canLoadMoreList;
@@ -402,7 +400,7 @@ export function useSkillsBrowseModel({
 
   const activeFilters: string[] = [];
   if (featuredOnly) activeFilters.push("featured");
-  if (nonSuspiciousOnly) activeFilters.push("non-suspicious");
+  if (nonSuspiciousOnly) activeFilters.push("warnings hidden");
   if (capabilityTag) activeFilters.push(SKILL_CAPABILITY_LABELS[capabilityTag] ?? capabilityTag);
 
   const onCapabilityTagChange = useCallback(
@@ -425,8 +423,6 @@ export function useSkillsBrowseModel({
     canLoadMore,
     dir,
     hasQuery,
-    hasSuspiciousResults,
-    showSuspiciousFilter,
     featuredOnly,
     isLoadingMore,
     isLoadingSkills,

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -1,10 +1,9 @@
-import { createFileRoute, Link, redirect } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
 import { Search } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { api } from "../../../convex/_generated/api";
 import { BrowseSidebar } from "../../components/BrowseSidebar";
-import { Button } from "../../components/ui/button";
 import { SKILL_CATEGORIES } from "../../lib/categories";
 import { formatCompactStat } from "../../lib/numberFormat";
 import { parseDir, parseSort } from "./-params";
@@ -165,13 +164,6 @@ export function SkillsIndex() {
           Skills
           {totalSkillsText ? <span className="browse-count">{totalSkillsText}</span> : null}
         </h1>
-        <div className="browse-page-actions">
-          <Button asChild variant="primary">
-            <Link to="/publish-skill" search={{ updateSlug: undefined, ownerHandle: undefined }}>
-              Publish
-            </Link>
-          </Button>
-        </div>
       </div>
       <div className="browse-page-search">
         <Search size={15} className="navbar-search-icon" aria-hidden="true" />
@@ -203,16 +195,6 @@ export function SkillsIndex() {
               ) : null}
             </span>
             <div className="browse-results-actions">
-              {model.showSuspiciousFilter ? (
-                <label className="browse-toolbar-checkbox">
-                  <input
-                    type="checkbox"
-                    checked={model.nonSuspiciousOnly}
-                    onChange={model.onToggleNonSuspicious}
-                  />
-                  <span>Hide suspicious</span>
-                </label>
-              ) : null}
               <div className="browse-view-toggle">
                 <button
                   className={`browse-view-btn${model.view === "list" ? " is-active" : ""}`}

--- a/src/styles.css
+++ b/src/styles.css
@@ -4628,6 +4628,11 @@ code {
   color: #6aa9ff;
 }
 
+.skill-list-item-main .verified-badge {
+  padding-block: 0;
+  line-height: 1.35;
+}
+
 .skill-hero-scan-row {
   display: grid;
   gap: 6px;
@@ -7596,9 +7601,10 @@ code {
   color: #dc2626;
 }
 
+.scan-status-warn,
 .scan-status-suspicious {
-  background: var(--hover-bg);
-  color: var(--ink-soft);
+  background: var(--status-warning-bg);
+  color: var(--status-warning-fg);
 }
 
 .scan-status-pending {
@@ -7733,14 +7739,7 @@ code {
   font-style: italic;
 }
 
-/* OpenClaw confidence label */
-.scan-result-confidence {
-  font-size: 0.72rem;
-  font-weight: 600;
-  color: var(--ink-soft);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  opacity: 0.7;
+.scan-result-risk {
   justify-self: end;
 }
 
@@ -8186,7 +8185,7 @@ a.agentic-risk-finding-title:focus-visible {
   }
 }
 
-.scan-confidence-meter {
+.scan-risk-level-badge {
   width: fit-content;
   max-width: 100%;
   gap: 8px;
@@ -8198,7 +8197,7 @@ a.agentic-risk-finding-title:focus-visible {
   overflow-wrap: normal;
 }
 
-.scan-confidence-bars {
+.scan-risk-level-bars {
   display: inline-grid;
   grid-template-columns: repeat(3, 3px);
   gap: 3px;
@@ -8206,7 +8205,7 @@ a.agentic-risk-finding-title:focus-visible {
   height: 10px;
 }
 
-.scan-confidence-bars span {
+.scan-risk-level-bars span {
   display: block;
   width: 3px;
   height: 10px;
@@ -8214,9 +8213,9 @@ a.agentic-risk-finding-title:focus-visible {
   background: color-mix(in srgb, currentColor 22%, transparent);
 }
 
-.scan-confidence-meter[data-level="1"] .scan-confidence-bars span:nth-child(-n + 1),
-.scan-confidence-meter[data-level="2"] .scan-confidence-bars span:nth-child(-n + 2),
-.scan-confidence-meter[data-level="3"] .scan-confidence-bars span:nth-child(-n + 3) {
+.scan-risk-level-badge[data-level="1"] .scan-risk-level-bars span:nth-child(-n + 1),
+.scan-risk-level-badge[data-level="2"] .scan-risk-level-bars span:nth-child(-n + 2),
+.scan-risk-level-badge[data-level="3"] .scan-risk-level-bars span:nth-child(-n + 3) {
   background: currentColor;
 }
 
@@ -8261,7 +8260,7 @@ a.agentic-risk-finding-title:focus-visible {
   border-color: rgba(239, 68, 68, 0.4);
 }
 
-/* Suspicious/warning banner variant */
+/* Warning banner variant */
 .pending-banner-warning {
   background: rgba(245, 158, 11, 0.12);
   border-color: rgba(245, 158, 11, 0.4);
@@ -8419,7 +8418,7 @@ a.agentic-risk-finding-title:focus-visible {
   }
 
   .scan-result-link,
-  .scan-result-confidence {
+  .scan-result-risk {
     grid-column: 1 / -1;
     justify-self: start;
   }


### PR DESCRIPTION
## Summary
- replace ClawScan confidence display with risk-level rollups from visible non-low-confidence findings
- use Warn/Warning user-facing language while keeping internal suspicious wiring intact
- hide low-confidence ClawScan findings, remove search warning-filter/publish affordances, reuse verified badges, and add security-page skeleton loaders

## Tests
- `VITE_CONVEX_URL=https://example.invalid bun run test -- src/components/SkillSecurityScanResults.test.tsx src/components/DetailSecuritySummary.test.tsx src/__tests__/search-route.test.tsx src/__tests__/skills-index.test.tsx src/__tests__/packages-route.test.tsx src/__tests__/skill-security-scanner-route.test.tsx src/components/PluginListItem.test.tsx src/components/SkillCard.test.tsx src/components/SkillListItem.test.tsx scripts/security-dataset/normalize.test.ts scripts/security-dataset/convexExport.test.ts scripts/security-dataset/manifest.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
