### PR TITLE
feat: add ClawScan finding permalinks

### DIFF
--- a/src/components/SkillSecurityScanResults.test.tsx
+++ b/src/components/SkillSecurityScanResults.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SecurityScannerPage } from "./SecurityScannerPage";
 import { SecurityScanResults, type LlmAnalysis } from "./SkillSecurityScanResults";
 
@@ -129,8 +129,13 @@ const lowConfidenceConcernAnalysis: LlmAnalysis = {
   ],
 };
 
+let scrollIntoViewMock: ReturnType<typeof vi.fn>;
+
 beforeEach(() => {
   window.localStorage.clear();
+  window.history.replaceState(null, "", "/");
+  scrollIntoViewMock = vi.fn();
+  Element.prototype.scrollIntoView = scrollIntoViewMock;
 });
 
 describe("SecurityScanResults static guidance", () => {
@@ -404,6 +409,60 @@ describe("SecurityScanResults static guidance", () => {
     expect(screen.getAllByText("Skill content").length).toBeGreaterThan(0);
     expect(screen.getByText("requires.env: TODOIST_API_TOKEN")).toBeTruthy();
     expect(screen.queryByText("Confidence")).toBeNull();
+  });
+
+  it("adds in-page permalinks to dedicated ClawScan findings", () => {
+    render(
+      <SecurityScannerPage
+        scanner="clawscan"
+        entity={{
+          kind: "skill",
+          title: "Todo Guard",
+          name: "todo-guard",
+          version: "1.0.0",
+          detailPath: "/local/todo-guard",
+        }}
+        llmAnalysis={clawScanAnalysis}
+      />,
+    );
+
+    const permalink = screen.getByRole("link", {
+      name: "Link to ASI03: Identity and Privilege Abuse",
+    });
+    expect(permalink.textContent).toBe("#");
+    expect(permalink.getAttribute("href")).toBe(
+      "#clawscan-finding-asi03-identity-and-privilege-abuse-1",
+    );
+    expect(
+      document.getElementById("clawscan-finding-asi03-identity-and-privilege-abuse-1"),
+    ).toBeTruthy();
+  });
+
+  it("scrolls to a ClawScan finding when the page loads with that anchor", () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/local/todo-guard/security/clawscan#clawscan-finding-asi07-insecure-inter-agent-communication-2",
+    );
+
+    render(
+      <SecurityScannerPage
+        scanner="clawscan"
+        entity={{
+          kind: "skill",
+          title: "Todo Guard",
+          name: "todo-guard",
+          version: "1.0.0",
+          detailPath: "/local/todo-guard",
+        }}
+        llmAnalysis={clawScanAnalysis}
+      />,
+    );
+
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({
+      block: "start",
+      behavior: "smooth",
+    });
   });
 
   it("prompts publishers to add a note on review ClawScan reports without one", () => {

--- a/src/components/SkillSecurityScanResults.tsx
+++ b/src/components/SkillSecurityScanResults.tsx
@@ -1,5 +1,5 @@
 import { ShieldCheck } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Badge, type BadgeProps } from "./ui/badge";
 
 type LlmAnalysisDimension = {
@@ -352,6 +352,28 @@ function getOwaspAgenticSkillsHref(categoryId: string) {
   return `https://owasp.org/www-project-agentic-skills-top-10/ast${match[1]}`;
 }
 
+function slugifyFindingAnchorPart(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function getClawScanFindingAnchorId(finding: LlmAgenticRiskFinding, index: number) {
+  const slug = slugifyFindingAnchorPart(`${finding.categoryId}-${finding.categoryLabel}`);
+  return `clawscan-finding-${slug || "finding"}-${index + 1}`;
+}
+
+function getCurrentLocationAnchorId() {
+  if (typeof window === "undefined" || !window.location.hash) return "";
+  try {
+    return decodeURIComponent(window.location.hash.slice(1));
+  } catch {
+    return "";
+  }
+}
+
 function AgenticRiskFindingCard({
   finding,
   index,
@@ -363,30 +385,40 @@ function AgenticRiskFindingCard({
   if (!evidence) return null;
   const categoryHref = getOwaspAgenticSkillsHref(finding.categoryId);
   const severityBadge = getFindingSeverityBadgeMeta(finding.severity);
+  const title = `${finding.categoryId}: ${finding.categoryLabel}`;
+  const anchorId = getClawScanFindingAnchorId(finding, index);
 
   return (
     <div
       key={`${finding.categoryId}-${finding.riskBucket}-${index}`}
       className="agentic-risk-finding"
+      id={anchorId}
     >
       <div className="agentic-risk-finding-header">
         <div className="agentic-risk-finding-badges">
           <Badge variant={severityBadge.variant}>{severityBadge.label}</Badge>
         </div>
-        {categoryHref ? (
+        <div className="agentic-risk-finding-title-row">
           <a
-            className="agentic-risk-finding-title"
-            href={categoryHref}
-            target="_blank"
-            rel="noopener noreferrer"
+            className="agentic-risk-finding-anchor"
+            href={`#${anchorId}`}
+            aria-label={`Link to ${title}`}
           >
-            {finding.categoryId}: {finding.categoryLabel}
+            #
           </a>
-        ) : (
-          <div className="agentic-risk-finding-title">
-            {finding.categoryId}: {finding.categoryLabel}
-          </div>
-        )}
+          {categoryHref ? (
+            <a
+              className="agentic-risk-finding-title"
+              href={categoryHref}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {title}
+            </a>
+          ) : (
+            <div className="agentic-risk-finding-title">{title}</div>
+          )}
+        </div>
       </div>
       <div className="agentic-risk-report-rows">
         <div className="agentic-risk-report-row">
@@ -424,6 +456,18 @@ export function ClawScanRiskReview({
   findingsTitle?: string;
 }) {
   const visibleFindings = getVisibleAgenticRiskFindings(analysis);
+  const findingAnchorIds = useMemo(
+    () => visibleFindings.map((finding, index) => getClawScanFindingAnchorId(finding, index)),
+    [visibleFindings],
+  );
+
+  useEffect(() => {
+    const anchor = getCurrentLocationAnchorId();
+    if (!anchor) return;
+    if (!findingAnchorIds.includes(anchor)) return;
+    document.getElementById(anchor)?.scrollIntoView({ block: "start", behavior: "smooth" });
+  }, [findingAnchorIds]);
+
   if (visibleFindings.length === 0) return null;
 
   return (

--- a/src/styles.css
+++ b/src/styles.css
@@ -8027,6 +8027,43 @@ code {
   color: var(--ink);
 }
 
+.agentic-risk-finding-title-row {
+  position: relative;
+  display: inline-flex;
+  align-items: baseline;
+  width: fit-content;
+  max-width: 100%;
+}
+
+.agentic-risk-finding-anchor {
+  position: absolute;
+  right: calc(100% + 8px);
+  top: 0.15em;
+  color: color-mix(in srgb, var(--ink-soft) 58%, transparent);
+  font-size: 0.95rem;
+  font-weight: 750;
+  line-height: 1;
+  opacity: 0;
+  text-decoration: none;
+  transition:
+    color 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.agentic-risk-finding-title-row:hover .agentic-risk-finding-anchor,
+.agentic-risk-finding-title-row:focus-within .agentic-risk-finding-anchor {
+  opacity: 1;
+}
+
+.agentic-risk-finding-anchor:hover,
+.agentic-risk-finding-anchor:focus-visible {
+  color: var(--accent);
+}
+
+.agentic-risk-finding {
+  scroll-margin-top: 132px;
+}
+
 a.agentic-risk-finding-title {
   color: inherit;
   text-decoration: underline;


### PR DESCRIPTION
## Summary
- Add stable in-page anchors for ClawScan finding cards
- Show a subtle `#` permalink to the left of each finding title on hover/focus
- Scroll hash-linked ClawScan findings into view below the sticky navbar

## Verification
- `bun run test src/components/SkillSecurityScanResults.test.tsx`
- `bun run format:check -- src/components/SkillSecurityScanResults.tsx src/components/SkillSecurityScanResults.test.tsx src/styles.css`
- `bun run lint`
- Manual browser check on `http://127.0.0.1:4175/halthelobster/proactive-agent/security/clawscan#clawscan-finding-asi03-identity-and-privilege-abuse-2`
