### PR TITLE
feat: add ClawScan finding permalinks

### DIFF
--- a/src/components/SkillSecurityScanResults.test.tsx
+++ b/src/components/SkillSecurityScanResults.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { SecurityScannerPage } from "./SecurityScannerPage";
 import { SecurityScanResults, type LlmAnalysis } from "./SkillSecurityScanResults";
 
@@ -129,13 +129,9 @@ const lowConfidenceConcernAnalysis: LlmAnalysis = {
   ],
 };
 
-let scrollIntoViewMock: ReturnType<typeof vi.fn>;
-
 beforeEach(() => {
   window.localStorage.clear();
   window.history.replaceState(null, "", "/");
-  scrollIntoViewMock = vi.fn();
-  Element.prototype.scrollIntoView = scrollIntoViewMock;
 });
 
 describe("SecurityScanResults static guidance", () => {
@@ -436,33 +432,6 @@ describe("SecurityScanResults static guidance", () => {
     expect(
       document.getElementById("clawscan-finding-asi03-identity-and-privilege-abuse-1"),
     ).toBeTruthy();
-  });
-
-  it("scrolls to a ClawScan finding when the page loads with that anchor", () => {
-    window.history.replaceState(
-      null,
-      "",
-      "/local/todo-guard/security/clawscan#clawscan-finding-asi07-insecure-inter-agent-communication-2",
-    );
-
-    render(
-      <SecurityScannerPage
-        scanner="clawscan"
-        entity={{
-          kind: "skill",
-          title: "Todo Guard",
-          name: "todo-guard",
-          version: "1.0.0",
-          detailPath: "/local/todo-guard",
-        }}
-        llmAnalysis={clawScanAnalysis}
-      />,
-    );
-
-    expect(scrollIntoViewMock).toHaveBeenCalledWith({
-      block: "start",
-      behavior: "smooth",
-    });
   });
 
   it("prompts publishers to add a note on review ClawScan reports without one", () => {

--- a/src/components/SkillSecurityScanResults.tsx
+++ b/src/components/SkillSecurityScanResults.tsx
@@ -1,5 +1,5 @@
 import { ShieldCheck } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useState } from "react";
 import { Badge, type BadgeProps } from "./ui/badge";
 
 type LlmAnalysisDimension = {
@@ -365,15 +365,6 @@ function getClawScanFindingAnchorId(finding: LlmAgenticRiskFinding, index: numbe
   return `clawscan-finding-${slug || "finding"}-${index + 1}`;
 }
 
-function getCurrentLocationAnchorId() {
-  if (typeof window === "undefined" || !window.location.hash) return "";
-  try {
-    return decodeURIComponent(window.location.hash.slice(1));
-  } catch {
-    return "";
-  }
-}
-
 function AgenticRiskFindingCard({
   finding,
   index,
@@ -456,18 +447,6 @@ export function ClawScanRiskReview({
   findingsTitle?: string;
 }) {
   const visibleFindings = getVisibleAgenticRiskFindings(analysis);
-  const findingAnchorIds = useMemo(
-    () => visibleFindings.map((finding, index) => getClawScanFindingAnchorId(finding, index)),
-    [visibleFindings],
-  );
-
-  useEffect(() => {
-    const anchor = getCurrentLocationAnchorId();
-    if (!anchor) return;
-    if (!findingAnchorIds.includes(anchor)) return;
-    document.getElementById(anchor)?.scrollIntoView({ block: "start", behavior: "smooth" });
-  }, [findingAnchorIds]);
-
   if (visibleFindings.length === 0) return null;
 
   return (

--- a/src/lib/clawScanHashScroll.ts
+++ b/src/lib/clawScanHashScroll.ts
@@ -1,0 +1,7 @@
+const DISABLE_DUPLICATE_CLAWSCAN_HASH_SCROLL = `(function(){try{if(location.hash.indexOf('#clawscan-finding-')!==0)return;history.replaceState(Object.assign({},history.state,{__hashScrollIntoViewOptions:false}),'',location.href)}catch(e){}})()`;
+
+export function getClawScanHashScrollScripts(scanner: string) {
+  return scanner === "clawscan"
+    ? [{ children: DISABLE_DUPLICATE_CLAWSCAN_HASH_SCROLL }]
+    : undefined;
+}

--- a/src/routes/$owner/$slug/security/$scanner.tsx
+++ b/src/routes/$owner/$slug/security/$scanner.tsx
@@ -6,6 +6,7 @@ import {
   SecurityScannerPageSkeleton,
   type ScannerSlug,
 } from "../../../../components/SecurityScannerPage";
+import { getClawScanHashScrollScripts } from "../../../../lib/clawScanHashScroll";
 import { buildSkillMeta } from "../../../../lib/og";
 import { isAdmin } from "../../../../lib/roles";
 import { fetchSkillPageData } from "../../../../lib/skillPage";
@@ -59,6 +60,7 @@ export const Route = createFileRoute("/$owner/$slug/security/$scanner")({
       initialData: data.initialData,
     };
   },
+  scripts: ({ params }) => getClawScanHashScrollScripts(params.scanner),
   head: ({ params, loaderData }) => {
     const scanner = parseScanner(params.scanner);
     const scannerLabel =

--- a/src/routes/plugins/$name/security/$scanner.tsx
+++ b/src/routes/plugins/$name/security/$scanner.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound, redirect } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
 import { api } from "../../../../../convex/_generated/api";
 import { SecurityScannerPage, type ScannerSlug } from "../../../../components/SecurityScannerPage";
+import { getClawScanHashScrollScripts } from "../../../../lib/clawScanHashScroll";
 import { getOpenClawPackageCandidateNames } from "../../../../lib/openClawExtensionSlugs";
 import {
   fetchPackageDetail,
@@ -112,6 +113,7 @@ export const Route = createFileRoute("/plugins/$name/security/$scanner")({
     }
   },
   loader: async ({ params }) => loadPluginSecurity(params.name),
+  scripts: ({ params }) => getClawScanHashScrollScripts(params.scanner),
   head: ({ params, loaderData }) => pluginSecurityHead(params.name, params.scanner, loaderData),
   component: PluginSecurityScannerRoute,
 });

--- a/src/routes/plugins/$scope/$name/security/$scanner.tsx
+++ b/src/routes/plugins/$scope/$name/security/$scanner.tsx
@@ -6,6 +6,7 @@ import {
   pluginSecurityHead,
   type PluginSecurityLoaderData,
 } from "../../../$name/security/$scanner";
+import { getClawScanHashScrollScripts } from "../../../../../lib/clawScanHashScroll";
 import {
   buildPluginSecurityHref,
   packageNameFromScopedRoute,
@@ -29,6 +30,7 @@ export const Route = createFileRoute("/plugins/$scope/$name/security/$scanner")(
     parsePluginSecurityScanner(params.scanner);
   },
   loader: async ({ params }) => loadPluginSecurity(packageNameFromParams(params)),
+  scripts: ({ params }) => getClawScanHashScrollScripts(params.scanner),
   head: ({ params, loaderData }) =>
     pluginSecurityHead(packageNameFromParams(params), params.scanner, loaderData),
   component: ScopedPluginSecurityScannerRoute,


### PR DESCRIPTION
## Summary
- Add stable in-page anchors for ClawScan finding cards
- Show a subtle `#` permalink to the left of each finding title on hover/focus
- Use native browser hash scrolling plus CSS `scroll-margin-top`; opt ClawScan finding hashes out of TanStack's duplicate client scroll-restoration pass

## Verification
- `bun run test src/components/SkillSecurityScanResults.test.tsx`
- `bun run format:check -- src/router.tsx src/components/SkillSecurityScanResults.tsx src/components/SkillSecurityScanResults.test.tsx src/styles.css`
- `bun run lint`
- Manual browser check on `http://127.0.0.1:4175/halthelobster/proactive-agent/security/clawscan#clawscan-finding-asi03-identity-and-privilege-abuse-2`; one hash scroll call, no clipping
