### PR TITLE
feat: make UI proof full-stack by default

### DIFF
--- a/.agents/skills/clawhub-ui-proof/SKILL.md
+++ b/.agents/skills/clawhub-ui-proof/SKILL.md
@@ -85,3 +85,9 @@ bun run proof:publish -- --proof-dir .artifacts/clawhub-ui-proof/<timestamp> --t
 present, MP4s, `summary.json`, and `report.md` to the `qa-artifacts` branch,
 then upserts a marker-backed PR comment with inline screenshots/previews and
 linked MP4s. Use `--dry-run` first when drafting or checking the comment body.
+
+## Share In GitHub Issues
+
+When proof images or screenshots should appear in GitHub issues, share
+`here.now` links instead of uploading image attachments directly to GitHub.
+Include a short note about what the linked image proves.

--- a/.agents/skills/clawhub-ui-proof/SKILL.md
+++ b/.agents/skills/clawhub-ui-proof/SKILL.md
@@ -15,6 +15,12 @@ temporary scenario for the feature instead of manually clicking through the UI.
   default and runs baseline `origin/main` plus the candidate worktree.
 - Use `--mode feature` for new pages, new workflows, or new UI states that do
   not exist on main. This runs only the candidate lane.
+- Every proof lane runs full-stack by default: the lane's Git checkout starts
+  its own local Convex backend, pushes that lane's functions/schema, and builds
+  the frontend against that lane-local Convex URL. Add
+  `--seed-command '<command>'` when the scenario needs fixtures.
+- Dev auth is opt-in. Use `--dev-auth` or explicit `--env KEY=VALUE` entries
+  only for scenarios that need development auth controls.
 - Do not use `proof:ui` to inspect contributor-provided screenshots, videos, or
   logs. Review those artifacts directly and cite what they prove or fail to
   prove.
@@ -53,6 +59,12 @@ Run real desktop proof on a Crabbox-owned provider:
 
 ```sh
 bun run proof:ui -- --mode before-after --scenario .artifacts/proof-scenarios/my-fix.pw.ts --provider hetzner
+```
+
+Run proof with seeded lane-local Convex fixtures:
+
+```sh
+bun run proof:ui -- --mode before-after --seed-command 'bunx convex run --no-push devSeed:seedNixSkills' --scenario .artifacts/proof-scenarios/my-fix.pw.ts --provider hetzner
 ```
 
 Artifacts are written under `.artifacts/clawhub-ui-proof/<timestamp>/` with

--- a/scripts/ui-proof.mjs
+++ b/scripts/ui-proof.mjs
@@ -14,19 +14,24 @@ const DEFAULT_IDLE_TIMEOUT = "60m";
 const DEFAULT_TTL = "120m";
 const DEFAULT_VIDEO_DURATION = "60";
 const DEFAULT_PORTS = {
-  baseline: 4317,
-  candidate: 4318,
+  baseline: {
+    convexCloud: 4417,
+    convexSite: 4517,
+    frontend: 4317,
+  },
+  candidate: {
+    convexCloud: 4418,
+    convexSite: 4518,
+    frontend: 4318,
+  },
 };
-const DEFAULT_PUBLIC_ENV = {
-  VITE_CONVEX_SITE_URL: "https://wry-manatee-359.convex.site",
-  VITE_CONVEX_URL: "https://wry-manatee-359.convex.cloud",
-};
-
 export function parseProofUiArgs(argv = []) {
   const opts = {
     baseline: DEFAULT_BASELINE,
     candidate: DEFAULT_CANDIDATE,
+    devAuth: false,
     dryRun: false,
+    env: {},
     idleTimeout: DEFAULT_IDLE_TIMEOUT,
     keepLease: false,
     machineClass: DEFAULT_CLASS,
@@ -57,6 +62,15 @@ export function parseProofUiArgs(argv = []) {
       index += 1;
     } else if (arg === "--dry-run") {
       opts.dryRun = true;
+    } else if (arg === "--dev-auth") {
+      opts.devAuth = true;
+    } else if (arg === "--env") {
+      const [key, value] = parseEnvAssignment(requireValue(arg, next), arg);
+      opts.env[key] = value;
+      index += 1;
+    } else if (arg.startsWith("--env=")) {
+      const [key, value] = parseEnvAssignment(arg.slice("--env=".length), "--env");
+      opts.env[key] = value;
     } else if (arg === "--idle-timeout") {
       opts.idleTimeout = requireValue(arg, next);
       index += 1;
@@ -76,6 +90,9 @@ export function parseProofUiArgs(argv = []) {
       index += 1;
     } else if (arg === "--scenario") {
       opts.scenario = requireValue(arg, next);
+      index += 1;
+    } else if (arg === "--seed-command") {
+      opts.seedCommand = requireValue(arg, next);
       index += 1;
     } else if (arg === "--skip-install") {
       opts.skipInstall = true;
@@ -105,8 +122,32 @@ function requireValue(flag, value) {
   return value;
 }
 
+function parseEnvAssignment(raw, flag) {
+  const separator = raw.indexOf("=");
+  if (separator <= 0) {
+    throw new Error(`${flag} requires KEY=VALUE`);
+  }
+  const key = raw.slice(0, separator);
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(key)) {
+    throw new Error(`${flag} has invalid environment variable name: ${key}`);
+  }
+  return [key, raw.slice(separator + 1)];
+}
+
 function timestamp(now) {
   return now().toISOString().replace(/[:.]/gu, "-");
+}
+
+function buildLane({ name, outputDir, ref }) {
+  const ports = DEFAULT_PORTS[name];
+  return {
+    convexCloudPort: ports.convexCloud,
+    convexSitePort: ports.convexSite,
+    name,
+    outputDir,
+    port: ports.frontend,
+    ref,
+  };
 }
 
 export function buildProofUiPlan({ now = () => new Date(), opts, repoRoot }) {
@@ -114,22 +155,20 @@ export function buildProofUiPlan({ now = () => new Date(), opts, repoRoot }) {
     repoRoot,
     opts.outputDir ?? path.join(".artifacts", "clawhub-ui-proof", timestamp(now)),
   );
-  const candidateLane = {
+  const candidateLane = buildLane({
     name: "candidate",
     outputDir: path.join(outputDir, "candidate"),
-    port: DEFAULT_PORTS.candidate,
     ref: opts.candidate,
-  };
+  });
   const lanes =
     opts.mode === "feature"
       ? [candidateLane]
       : [
-          {
+          buildLane({
             name: "baseline",
             outputDir: path.join(outputDir, "baseline"),
-            port: DEFAULT_PORTS.baseline,
             ref: opts.baseline,
-          },
+          }),
           candidateLane,
         ];
   return {
@@ -202,6 +241,100 @@ function shellQuote(value) {
   return `'${String(value).replaceAll("'", "'\\''")}'`;
 }
 
+function renderExportEnv(env) {
+  return Object.entries(env)
+    .map(([key, value]) => `export ${key}=${shellQuote(value)}`)
+    .join("\n");
+}
+
+function laneLocalConvexEnv(lane, opts) {
+  const appUrl = `http://127.0.0.1:${lane.port}`;
+  const convexUrl = `http://127.0.0.1:${lane.convexCloudPort}`;
+  const convexSiteUrl = `http://127.0.0.1:${lane.convexSitePort}`;
+  const deployment = `local:anonymous-clawhub-ui-proof-${lane.name}`;
+  return {
+    CONVEX_DEPLOYMENT: deployment,
+    CONVEX_SITE_URL: convexSiteUrl,
+    SITE_URL: appUrl,
+    VITE_CONVEX_SITE_URL: convexSiteUrl,
+    VITE_CONVEX_URL: convexUrl,
+    VITE_SITE_URL: appUrl,
+    ...(opts.devAuth
+      ? {
+          DEV_AUTH_CONVEX_DEPLOYMENT: deployment,
+          DEV_AUTH_ENABLED: "1",
+          VITE_ENABLE_DEV_AUTH: "1",
+        }
+      : {}),
+    ...opts.env,
+  };
+}
+
+function renderWaitForUrl(url, label) {
+  return `bun -e ${shellQuote(`const url = ${JSON.stringify(url)};
+const label = ${JSON.stringify(label)};
+const started = Date.now();
+async function tick() {
+  try {
+    const res = await fetch(url);
+    if (res.status < 500) process.exit(0);
+  } catch {}
+  if (Date.now() - started > 60000) {
+    console.error(label + " did not become ready: " + url);
+    process.exit(1);
+  }
+  setTimeout(tick, 500);
+}
+tick();`)}`;
+}
+
+function renderLocalConvexSetup({ lane, opts }) {
+  const env = laneLocalConvexEnv(lane, opts);
+  const envFileLines = Object.entries(env)
+    .map(([key, value]) => `${key}=${value}`)
+    .join("\n");
+  const convexUrl = env.VITE_CONVEX_URL;
+  const devAuthDeploymentExport = opts.devAuth
+    ? `export DEV_AUTH_CONVEX_DEPLOYMENT="$CONVEX_DEPLOYMENT"`
+    : "";
+  const seedCommand = opts.seedCommand
+    ? `(cd "$app_root" && ${opts.seedCommand} > "$remote_out/seed.log" 2>&1)`
+    : `: > "$remote_out/seed.log"`;
+  return `
+lane_env_file="$remote_out/.env.local"
+cat > "$lane_env_file" <<'CLAWHUB_UI_PROOF_ENV'
+${envFileLines}
+CLAWHUB_UI_PROOF_ENV
+rm -rf "$app_root/.convex/local/default"
+(cd "$app_root" && bunx convex dev --local --env-file "$lane_env_file" --typecheck disable --codegen disable --local-cloud-port ${lane.convexCloudPort} --local-site-port ${lane.convexSitePort} > "$remote_out/convex.log" 2>&1 & echo $! > "$remote_out/convex.pid")
+convex_pid="$(cat "$remote_out/convex.pid")"
+${renderWaitForUrl(convexUrl, "local Convex")}
+for _ in $(seq 1 120); do
+  if [ -f "$app_root/.env.local" ] && grep -q '^CONVEX_DEPLOYMENT=' "$app_root/.env.local"; then
+    break
+  fi
+  sleep 0.5
+done
+if [ ! -f "$app_root/.env.local" ] || ! grep -q '^CONVEX_DEPLOYMENT=' "$app_root/.env.local"; then
+  echo "local Convex did not write $app_root/.env.local" >&2
+  exit 1
+fi
+if [ -f "$app_root/.env.local" ]; then
+  set -a
+  . "$app_root/.env.local"
+  set +a
+fi
+export CONVEX_SITE_URL=${shellQuote(env.CONVEX_SITE_URL)}
+export SITE_URL=${shellQuote(env.SITE_URL)}
+export VITE_CONVEX_SITE_URL=${shellQuote(env.VITE_CONVEX_SITE_URL)}
+export VITE_CONVEX_URL=${shellQuote(env.VITE_CONVEX_URL)}
+export VITE_SITE_URL=${shellQuote(env.VITE_SITE_URL)}
+${devAuthDeploymentExport}
+(cd "$app_root" && bunx convex run --push --typecheck disable --codegen disable appMeta:getDeploymentInfo '{}' >> "$remote_out/convex.log" 2>&1)
+${seedCommand}
+`;
+}
+
 export function renderRemoteLaneScript({ lane, opts, plan, scenarioText }) {
   const scenarioB64 = Buffer.from(scenarioText, "utf8").toString("base64");
   const runtimePath = path.join("scripts", "ui-proof-runtime.mjs");
@@ -216,9 +349,8 @@ export function renderRemoteLaneScript({ lane, opts, plan, scenarioText }) {
           `app_root="$PWD/.artifacts/clawhub-ui-proof/worktrees/${lane.name}"`,
         ].join("\n")
       : `app_root="$PWD"`;
-  const envExports = Object.entries(DEFAULT_PUBLIC_ENV)
-    .map(([key, value]) => `export ${key}=${shellQuote(value)}`)
-    .join("\n");
+  const envExports = renderExportEnv(laneLocalConvexEnv(lane, opts));
+  const localConvexSetup = renderLocalConvexSetup({ lane, opts });
 
   return `set -euo pipefail
 export DISPLAY="\${DISPLAY:-:99}"
@@ -226,6 +358,7 @@ remote_out="$PWD/${laneRemoteDir}"
 rm -rf "$remote_out"
 mkdir -p "$remote_out"
 echo "__CLAWHUB_UI_PROOF_REMOTE_OUTPUT__=$remote_out"
+convex_pid=""
 video_pid=""
 cleanup_proof_processes() {
   if [ -n "$video_pid" ]; then
@@ -236,6 +369,14 @@ cleanup_proof_processes() {
   if [ -f "$remote_out/preview.pid" ]; then
     kill "$(cat "$remote_out/preview.pid")" >/dev/null 2>&1 || true
     rm -f "$remote_out/preview.pid"
+  fi
+  if [ -n "$convex_pid" ]; then
+    kill "$convex_pid" >/dev/null 2>&1 || true
+    wait "$convex_pid" >/dev/null 2>&1 || true
+    convex_pid=""
+  elif [ -f "$remote_out/convex.pid" ]; then
+    kill "$(cat "$remote_out/convex.pid")" >/dev/null 2>&1 || true
+    rm -f "$remote_out/convex.pid"
   fi
   return 0
 }
@@ -276,22 +417,10 @@ if [ ${opts.skipInstall ? "1" : "0"} -ne 1 ]; then
   fi
   bunx playwright install chromium > "$remote_out/playwright-install.log" 2>&1
 fi
+${localConvexSetup}
 (cd "$app_root" && bun run build > "$remote_out/build.log" 2>&1)
 (cd "$app_root" && bun run preview -- --host 127.0.0.1 --port ${lane.port} > "$remote_out/preview.log" 2>&1 & echo $! > "$remote_out/preview.pid")
-bun -e ${shellQuote(`const url = "http://127.0.0.1:${lane.port}";
-const started = Date.now();
-async function tick() {
-  try {
-    const res = await fetch(url);
-    if (res.status < 500) process.exit(0);
-  } catch {}
-  if (Date.now() - started > 60000) {
-    console.error("preview did not become ready: " + url);
-    process.exit(1);
-  }
-  setTimeout(tick, 500);
-}
-tick();`)}
+${renderWaitForUrl(`http://127.0.0.1:${lane.port}`, "preview")}
 if command -v ffmpeg >/dev/null 2>&1; then
   display_input="$DISPLAY"
   case "$display_input" in
@@ -328,6 +457,11 @@ fi
 if [ -f "$remote_out/preview.pid" ]; then
   kill "$(cat "$remote_out/preview.pid")" >/dev/null 2>&1 || true
   rm -f "$remote_out/preview.pid"
+fi
+if [ -n "$convex_pid" ]; then
+  kill "$convex_pid" >/dev/null 2>&1 || true
+  wait "$convex_pid" >/dev/null 2>&1 || true
+  convex_pid=""
 fi
 cat > "$remote_out/lane-summary.json" <<CLAWHUB_UI_PROOF_SUMMARY
 {

--- a/scripts/ui-proof.test.mjs
+++ b/scripts/ui-proof.test.mjs
@@ -18,6 +18,7 @@ describe("ui-proof", () => {
       {
         baseline: "origin/main",
         candidate: "worktree",
+        devAuth: false,
         mode: "before-after",
         provider: "hetzner",
         scenario: ".artifacts/proof-scenarios/demo.pw.ts",
@@ -49,6 +50,41 @@ describe("ui-proof", () => {
     expect(() =>
       parseProofUiArgs(["--mode", "smoke", "--scenario", ".artifacts/proof-scenarios/demo.pw.ts"]),
     ).toThrow("Unknown proof:ui mode: smoke");
+  });
+
+  it("parses seed command and explicit proof env options", () => {
+    expect(
+      parseProofUiArgs([
+        "--dev-auth",
+        "--env",
+        "FEATURE_FLAG=1",
+        "--seed-command",
+        "bunx convex run --no-push devSeed:seedNixSkills",
+        "--scenario",
+        ".artifacts/proof-scenarios/demo.pw.ts",
+      ]),
+    ).toMatchObject({
+      devAuth: true,
+      env: { FEATURE_FLAG: "1" },
+      seedCommand: "bunx convex run --no-push devSeed:seedNixSkills",
+    });
+
+    expect(() =>
+      parseProofUiArgs([
+        "--backend",
+        "prod",
+        "--scenario",
+        ".artifacts/proof-scenarios/demo.pw.ts",
+      ]),
+    ).toThrow("Unknown proof:ui argument: --backend");
+    expect(() =>
+      parseProofUiArgs([
+        "--env",
+        "FEATURE_FLAG",
+        "--scenario",
+        ".artifacts/proof-scenarios/demo.pw.ts",
+      ]),
+    ).toThrow("--env requires KEY=VALUE");
   });
 
   it("builds a before/after plan with stable lane output directories", () => {
@@ -251,5 +287,77 @@ describe("ui-proof", () => {
     expect(script).toContain(
       'manifest_status="$(CLAWHUB_UI_PROOF_MANIFEST="$remote_out/proof-steps.json" bun -e',
     );
+  });
+
+  it("renders lane-local Convex env, seed command, and process cleanup for proof lanes", () => {
+    const script = renderRemoteLaneScript({
+      lane: {
+        convexCloudPort: 4417,
+        convexSitePort: 4517,
+        name: "baseline",
+        outputDir: "/tmp/out/baseline",
+        port: 4317,
+        ref: "origin/main",
+      },
+      opts: {
+        devAuth: true,
+        env: { FEATURE_FLAG: "1" },
+        seedCommand: "bunx convex run --no-push devSeed:seedNixSkills",
+        skipInstall: true,
+        videoDuration: "1",
+      },
+      plan: {
+        outputDir: "/tmp/out",
+      },
+      scenarioText: "export default async function scenario() {}\n",
+    });
+
+    expect(script).toContain('convex_pid=""');
+    expect(script).toContain('kill "$convex_pid"');
+    expect(script).toContain("VITE_CONVEX_URL='http://127.0.0.1:4417'");
+    expect(script).toContain("VITE_CONVEX_SITE_URL='http://127.0.0.1:4517'");
+    expect(script).toContain("CONVEX_DEPLOYMENT='local:anonymous-clawhub-ui-proof-baseline'");
+    expect(script).toContain(
+      "DEV_AUTH_CONVEX_DEPLOYMENT='local:anonymous-clawhub-ui-proof-baseline'",
+    );
+    expect(script).toContain("local Convex did not write $app_root/.env.local");
+    expect(script).toContain('. "$app_root/.env.local"');
+    expect(script).toContain('export DEV_AUTH_CONVEX_DEPLOYMENT="$CONVEX_DEPLOYMENT"');
+    expect(script).toContain("--local-cloud-port 4417");
+    expect(script).toContain("--local-site-port 4517");
+    expect(script).toContain('bunx convex dev --local --env-file "$lane_env_file"');
+    expect(script).toContain("bunx convex run --no-push devSeed:seedNixSkills");
+    expect(script).toContain("VITE_ENABLE_DEV_AUTH=1");
+    expect(script).toContain("FEATURE_FLAG='1'");
+    expect(script).not.toContain("https://wry-manatee-359.convex.cloud");
+  });
+
+  it("does not enable dev auth by default but still uses lane-local Convex", () => {
+    const script = renderRemoteLaneScript({
+      lane: {
+        convexCloudPort: 4418,
+        convexSitePort: 4518,
+        name: "candidate",
+        outputDir: "/tmp/out/candidate",
+        port: 4318,
+        ref: "worktree",
+      },
+      opts: {
+        devAuth: false,
+        env: {},
+        skipInstall: true,
+        videoDuration: "1",
+      },
+      plan: {
+        outputDir: "/tmp/out",
+      },
+      scenarioText: "export default async function scenario() {}\n",
+    });
+
+    expect(script).toContain("VITE_CONVEX_URL='http://127.0.0.1:4418'");
+    expect(script).toContain("VITE_CONVEX_SITE_URL='http://127.0.0.1:4518'");
+    expect(script).toContain("convex dev --local");
+    expect(script).not.toContain("VITE_ENABLE_DEV_AUTH=1");
+    expect(script).not.toContain("https://wry-manatee-359.convex.cloud");
   });
 });

--- a/specs/ui-proof.md
+++ b/specs/ui-proof.md
@@ -1,0 +1,17 @@
+# UI Proof Runtime
+
+`proof:ui` is always full-stack. Each lane starts local Convex from that lane's
+checkout, on deterministic lane-specific ports, then builds and previews the
+frontend against those local Convex URLs.
+
+The proof runner must not provide a shared-backend mode. UI proof is meant to
+prove the control plane and data plane together: the Git checkout controls both
+frontend and Convex source, and the lane-local Convex URL controls the runtime
+backend/data used by the browser.
+
+Use `--mode before-after` for baseline-vs-candidate proof and `--mode feature`
+for candidate-only proof. Use `--seed-command` when a scenario needs fixtures.
+
+Dev auth must be explicit. The proof runner must not set
+`VITE_ENABLE_DEV_AUTH=1` by default; scenarios that need it should pass
+`--dev-auth` or explicit `--env` values.


### PR DESCRIPTION
## Summary

Makes `proof:ui` full-stack by default. Every lane now starts local Convex from that lane's own Git checkout, pushes that lane's functions/schema, and builds/previews the frontend against that lane-local Convex URL. There is no shared-backend proof option.

The existing proof mode flag remains focused on lane shape: `--mode before-after` runs baseline plus candidate, and `--mode feature` runs candidate only. Both modes use lane-local Convex.

## Why

The proof runner previously let the Git checkout control frontend source while a hardcoded Convex URL controlled the runtime backend and data plane. That meant candidate UI could be proven against old/shared backend code and mutable shared data, leaving backend/schema/data regressions invisible in UI proof.

This changes the invariant: UI proof always couples the control plane and data plane. The checkout controls frontend and backend source; the lane-local Convex URL controls the runtime backend/data used by the browser.

## Details

- Removes the shared-backend path and hardcoded public Convex URLs from `proof:ui`.
- Keeps `--mode before-after|feature` as the only proof mode switch.
- Adds explicit `--dev-auth` and repeated `--env KEY=VALUE` support instead of baking dev auth into proof defaults.
- Adds optional `--seed-command` for fixture setup in local Convex proof runs.
- Uses deterministic non-conflicting lane ports for frontend, Convex cloud, and Convex site URLs.
- Waits for Convex to write its generated local `.env.local`, then sources the real anonymous deployment before push/seed/build.
- Cleans up preview, video, and Convex processes for each lane.
- Documents the always-full-stack proof invariant in the ClawHub UI proof skill and `specs/ui-proof.md`.

## Verification

- `bun run test scripts/ui-proof.test.mjs`
- `bun run format:check`
- `bun run lint`
- Local generated candidate-lane smoke without any backend flag, which started lane-local Convex on `4418/4518`, pushed functions, built the app, previewed on `4318`, ran the proof scenario, and wrote a passing `proof-steps.json`.
