### PR TITLE
fix: package delete returns 500 for packages with capability tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
   `q` instead of treating `search` as a package name (thanks @vyctorbrzezowski).
 - Web: rank publisher card preview items by downloads instead of recent publish order (thanks @vyctorbrzezowski).
 - Web: keep skill/plugin detail tabs at mobile-friendly touch target height.
+- API/CLI: fix package delete returning 500 for packages with capability tags
+  when no capability search digest row existed yet (#2212) (thanks @momothemage).
 
 ## 0.15.0 - 2026-05-12
 

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -6514,10 +6514,7 @@ describe("softDeletePackageInternal", () => {
 
     expect(result).toMatchObject({ ok: true, alreadyDeleted: true, releaseCount: 0 });
     // No release patches should have been made.
-    expect(patch).not.toHaveBeenCalledWith(
-      "packageReleases:demo-1",
-      expect.anything(),
-    );
+    expect(patch).not.toHaveBeenCalledWith("packageReleases:demo-1", expect.anything());
   });
 });
 

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -6331,3 +6331,272 @@ describe("package scan backfill", () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// softDeletePackageInternal / restorePackageInternal
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a ctx that exercises the full softDeletePackageDoc / restorePackageDoc
+ * path, including the upsertPackageSearchDigest → syncPackageCapabilitySearchDigests
+ * branch that previously crashed when ownerHandle was missing.
+ */
+function makeSoftDeleteCtx(options?: {
+  pkg?: Record<string, unknown>;
+  /** When true, no existing packageCapabilitySearchDigest rows exist (forces insert). */
+  noCapabilityDigest?: boolean;
+  /** Personal publisher linked to the owner user. */
+  personalPublisher?: Record<string, unknown> | null;
+  /** Override the releases returned for this package. */
+  releases?: Array<Record<string, unknown>>;
+}) {
+  const pkg =
+    options?.pkg ??
+    makePackageDoc({
+      ownerUserId: "users:owner",
+      ownerPublisherId: "publishers:owner-personal",
+      capabilityTags: ["read-files"],
+    });
+
+  const personalPublisher =
+    options?.personalPublisher === undefined
+      ? {
+          _id: "publishers:owner-personal",
+          kind: "user",
+          handle: "tongfei11",
+          linkedUserId: "users:owner",
+        }
+      : options.personalPublisher;
+
+  const existingCapabilityRows =
+    options?.noCapabilityDigest === true
+      ? []
+      : [
+          {
+            _id: "packageCapabilitySearchDigest:demo-read-files",
+            packageId: pkg._id,
+            capabilityTag: "read-files",
+            ownerHandle: "tongfei11",
+          },
+        ];
+
+  const releases = options?.releases ?? [
+    makeReleaseDoc({ _id: "packageReleases:demo-1", softDeletedAt: undefined }),
+  ];
+
+  const patch = vi.fn();
+  const insert = vi.fn().mockResolvedValue("auditLogs:1");
+
+  return {
+    patch,
+    insert,
+    ctx: {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "users:owner") return { _id: id, role: "user" };
+          if (id === "publishers:owner-personal") return personalPublisher;
+          return null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table === "packages") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue(pkg),
+              })),
+            };
+          }
+          if (table === "packageReleases") {
+            return {
+              withIndex: vi.fn(() => ({
+                collect: vi.fn().mockResolvedValue(releases),
+              })),
+            };
+          }
+          if (table === "packageSearchDigest") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi
+                  .fn()
+                  .mockResolvedValue({ _id: "packageSearchDigest:demo", packageId: pkg._id }),
+              })),
+            };
+          }
+          if (table === "packageCapabilitySearchDigest") {
+            return {
+              withIndex: vi.fn(() => ({
+                collect: vi.fn().mockResolvedValue(existingCapabilityRows),
+              })),
+            };
+          }
+          if (table === "packagePluginCategorySearchDigest") {
+            return {
+              withIndex: vi.fn(() => ({
+                collect: vi.fn().mockResolvedValue([]),
+              })),
+            };
+          }
+          if (table === "publisherMemberships") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue(null),
+              })),
+            };
+          }
+          throw new Error(`Unexpected table: ${table}`);
+        }),
+        insert,
+        patch,
+        replace: vi.fn(),
+        delete: vi.fn(),
+        normalizeId: vi.fn(),
+      },
+    },
+  };
+}
+
+describe("softDeletePackageInternal", () => {
+  it("soft-deletes a package owned by a personal publisher and writes ownerHandle to the search digest", async () => {
+    const { ctx, patch, insert } = makeSoftDeleteCtx();
+
+    const result = await softDeletePackageInternalHandler(ctx as never, {
+      userId: "users:owner",
+      name: "demo-plugin",
+    });
+
+    expect(result).toMatchObject({ ok: true, alreadyDeleted: false, releaseCount: 1 });
+
+    // The package doc must be soft-deleted.
+    expect(patch).toHaveBeenCalledWith(
+      "packages:demo",
+      expect.objectContaining({ softDeletedAt: expect.any(Number) }),
+    );
+
+    // The packageSearchDigest row must be updated with ownerHandle resolved.
+    expect(patch).toHaveBeenCalledWith(
+      "packageSearchDigest:demo",
+      expect.objectContaining({ ownerHandle: "tongfei11", softDeletedAt: expect.any(Number) }),
+    );
+
+    // An audit log must be inserted.
+    expect(insert).toHaveBeenCalledWith(
+      "auditLogs",
+      expect.objectContaining({ action: "package.delete" }),
+    );
+  });
+
+  it("writes ownerHandle via insert when no packageCapabilitySearchDigest row exists yet", async () => {
+    const { ctx, insert } = makeSoftDeleteCtx({ noCapabilityDigest: true });
+
+    await softDeletePackageInternalHandler(ctx as never, {
+      userId: "users:owner",
+      name: "demo-plugin",
+    });
+
+    // A new capability digest row must be inserted with ownerHandle populated.
+    expect(insert).toHaveBeenCalledWith(
+      "packageCapabilitySearchDigest",
+      expect.objectContaining({
+        capabilityTag: "read-files",
+        ownerHandle: "tongfei11",
+      }),
+    );
+  });
+
+  it("returns alreadyDeleted:true without touching releases when package is already soft-deleted", async () => {
+    const { ctx, patch } = makeSoftDeleteCtx({
+      pkg: makePackageDoc({ softDeletedAt: 999, softDeletedByRole: "user" }),
+    });
+
+    const result = await softDeletePackageInternalHandler(ctx as never, {
+      userId: "users:owner",
+      name: "demo-plugin",
+    });
+
+    expect(result).toMatchObject({ ok: true, alreadyDeleted: true, releaseCount: 0 });
+    // No release patches should have been made.
+    expect(patch).not.toHaveBeenCalledWith(
+      "packageReleases:demo-1",
+      expect.anything(),
+    );
+  });
+});
+
+describe("restorePackageInternal", () => {
+  it("restores a soft-deleted package and writes ownerHandle to the search digest", async () => {
+    const pkg = makePackageDoc({
+      ownerUserId: "users:owner",
+      ownerPublisherId: "publishers:owner-personal",
+      softDeletedAt: 500,
+      softDeletedByRole: "user",
+      softDeletedBy: "users:owner",
+      latestReleaseId: "packageReleases:demo-1",
+      tags: { latest: "packageReleases:demo-1" },
+    });
+    // The release was soft-deleted together with the package; it carries
+    // capabilityTags so that restorePackageDoc rebuilds them on the package.
+    const restoredRelease = makeReleaseDoc({
+      _id: "packageReleases:demo-1",
+      softDeletedAt: 500,
+      distTags: ["latest"],
+      version: "1.0.0",
+      changelog: "",
+      integritySha256: "abc",
+      capabilities: { capabilityTags: ["read-files"] },
+      compatibility: null,
+      verification: null,
+      scanStatus: "clean",
+    });
+
+    const { ctx, patch, insert } = makeSoftDeleteCtx({
+      pkg,
+      noCapabilityDigest: true,
+      releases: [restoredRelease],
+    });
+
+    const result = await restorePackageInternalHandler(ctx as never, {
+      userId: "users:owner",
+      name: "demo-plugin",
+    });
+
+    expect(result).toMatchObject({ ok: true, alreadyRestored: false });
+
+    // The package doc must have softDeletedAt cleared.
+    expect(patch).toHaveBeenCalledWith(
+      "packages:demo",
+      expect.objectContaining({ softDeletedAt: undefined }),
+    );
+
+    // The packageSearchDigest row must be updated with ownerHandle resolved.
+    expect(patch).toHaveBeenCalledWith(
+      "packageSearchDigest:demo",
+      expect.objectContaining({ ownerHandle: "tongfei11", softDeletedAt: undefined }),
+    );
+
+    // A new capability digest row must be inserted with ownerHandle populated.
+    expect(insert).toHaveBeenCalledWith(
+      "packageCapabilitySearchDigest",
+      expect.objectContaining({
+        capabilityTag: "read-files",
+        ownerHandle: "tongfei11",
+      }),
+    );
+
+    // An audit log must be inserted.
+    expect(insert).toHaveBeenCalledWith(
+      "auditLogs",
+      expect.objectContaining({ action: "package.undelete" }),
+    );
+  });
+
+  it("returns alreadyRestored:true when package is not soft-deleted", async () => {
+    const { ctx, patch } = makeSoftDeleteCtx();
+
+    const result = await restorePackageInternalHandler(ctx as never, {
+      userId: "users:owner",
+      name: "demo-plugin",
+    });
+
+    expect(result).toMatchObject({ ok: true, alreadyRestored: true, releaseCount: 0 });
+    expect(patch).not.toHaveBeenCalledWith("packages:demo", expect.anything());
+  });
+});

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -2556,7 +2556,15 @@ async function softDeletePackageDoc(
   };
   const nextPackage: Doc<"packages"> = { ...pkg, ...packagePatch };
   await ctx.db.patch(pkg._id, packagePatch);
-  await upsertPackageSearchDigest(ctx, extractPackageDigestFields(nextPackage));
+  const deleteOwner = await getOwnerPublisher(ctx, {
+    ownerPublisherId: pkg.ownerPublisherId,
+    ownerUserId: pkg.ownerUserId,
+  });
+  await upsertPackageSearchDigest(ctx, {
+    ...extractPackageDigestFields(nextPackage),
+    ownerHandle: deleteOwner?.handle ?? "",
+    ownerKind: deleteOwner?.kind,
+  });
   await ctx.db.insert("auditLogs", {
     actorUserId: params.actorUserId,
     action: "package.delete",
@@ -2726,7 +2734,15 @@ async function restorePackageDoc(
   };
   const nextPackage: Doc<"packages"> = { ...pkg, ...packagePatch };
   await ctx.db.patch(pkg._id, packagePatch);
-  await upsertPackageSearchDigest(ctx, extractPackageDigestFields(nextPackage));
+  const restoreOwner = await getOwnerPublisher(ctx, {
+    ownerPublisherId: pkg.ownerPublisherId,
+    ownerUserId: pkg.ownerUserId,
+  });
+  await upsertPackageSearchDigest(ctx, {
+    ...extractPackageDigestFields(nextPackage),
+    ownerHandle: restoreOwner?.handle ?? "",
+    ownerKind: restoreOwner?.kind,
+  });
   await ctx.db.insert("auditLogs", {
     actorUserId: params.actorUserId,
     action: "package.undelete",


### PR DESCRIPTION
fix #2211 

### Summary

`DELETE /api/v1/packages/{name}` (and the equivalent CLI command
`clawhub package delete <name>`) returned `500 Internal Server Error`
for any package that had `capabilityTags` set and whose
`packageCapabilitySearchDigest` row did not yet exist in the database.
The `package undelete` command succeeded for the same package, making
the failure appear inconsistent.

---

### Root Cause

Both `softDeletePackageDoc` and `restorePackageDoc` in `convex/packages.ts`
called:

```ts
await upsertPackageSearchDigest(ctx, extractPackageDigestFields(nextPackage));
```

`extractPackageDigestFields` reads only fields present on the `packages`
document. The `packages` table has no `ownerHandle` column, so
`ownerHandle` was `undefined` in the fields object passed downstream.

Inside `upsertPackageSearchDigest`, the helper `syncPackageCapabilitySearchDigests`
calls the internal `pick()` utility:

```ts
// pick uses Object.fromEntries — always emits the key, even for undefined values
pick(fields, [...CAPABILITY_SHARED_KEYS]);
// → { ..., ownerHandle: undefined, ownerKind: undefined, ... }
```

When the `packageCapabilitySearchDigest` row for the package **did not
exist yet**, the code took the `ctx.db.insert(...)` path. Convex rejected
the insert because `ownerHandle: undefined` was explicitly present in the
document object (as opposed to the key being absent), causing a schema
validation error.

That error message did not match any of the known patterns in
`softDeleteErrorToResponse` (`"unauthorized"`, `"forbidden"`,
`"not found"`, `"slug required"`), so it fell through to:

```ts
return text("Internal Server Error", 500, headers);
```

**Why `undelete` succeeded:** `restorePackageDoc` was called after a
prior delete had already created the `packageCapabilitySearchDigest` row.
The existing-row path calls `ctx.db.patch(...)` instead of `insert`, and
Convex's `patch` is lenient with `undefined` values (treats them as
no-ops). So `undelete` never hit the insert path and always succeeded.

---

### Fix

In both `softDeletePackageDoc` and `restorePackageDoc`, resolve the owner
publisher before calling `upsertPackageSearchDigest`, then pass
`ownerHandle` and `ownerKind` explicitly — mirroring the pattern already
used in `syncPackageSearchDigest` in `convex/functions.ts`:

```ts
// Before (both functions)
await upsertPackageSearchDigest(ctx, extractPackageDigestFields(nextPackage));

// After — softDeletePackageDoc
const deleteOwner = await getOwnerPublisher(ctx, {
  ownerPublisherId: pkg.ownerPublisherId,
  ownerUserId: pkg.ownerUserId,
});
await upsertPackageSearchDigest(ctx, {
  ...extractPackageDigestFields(nextPackage),
  ownerHandle: deleteOwner?.handle ?? "",
  ownerKind: deleteOwner?.kind,
});

// After — restorePackageDoc (same pattern, variable named restoreOwner)
```

---

### Tests Added

Five new unit tests in `convex/packages.public.test.ts`:

#### `softDeletePackageInternal`

| Test                                                                                             | What it verifies                                                      |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
| soft-deletes a package owned by a personal publisher and writes ownerHandle to the search digest | `packageSearchDigest` patch contains `ownerHandle: "tongfei11"`       |
| **writes ownerHandle via insert when no packageCapabilitySearchDigest row exists yet**           | The exact bug scenario: insert path populates `ownerHandle` correctly |
| returns alreadyDeleted:true without touching releases when package is already soft-deleted       | Idempotency                                                           |

#### `restorePackageInternal`

| Test                                                                        | What it verifies                                                       |
| --------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| restores a soft-deleted package and writes ownerHandle to the search digest | Restore path resolves `ownerHandle`; capability digest row is inserted |
| returns alreadyRestored:true when package is not soft-deleted               | Idempotency                                                            |

---

### Files Changed

| File                             | Change                                                                      |
| -------------------------------- | --------------------------------------------------------------------------- |
| `convex/packages.ts`             | Fix `softDeletePackageDoc` and `restorePackageDoc` to resolve `ownerHandle` |
| `convex/packages.public.test.ts` | Add 5 unit tests for the fixed paths                                        |

---

### Reproduction (from bug report)

```bash
npx -y clawhub@0.15.0 package undelete tt-plugin-tag-test-0513 --yes --json
# { "ok": true }  ← succeeded

npx -y clawhub@0.15.0 package delete tt-plugin-tag-test-0513 --yes --json
# 500 Internal Server Error  ← fixed by this PR
```

Direct HTTP API also affected:

```
DELETE /api/v1/packages/tt-plugin-tag-test-0513
→ 500 Internal Server Error  ← fixed by this PR
```
