### PR TITLE
Allow placeholder runtime ID correction on publish

### DIFF
--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -157,6 +157,16 @@ const insertReleaseInternalHandler = (
       verification?: unknown;
       staticScan?: unknown;
       artifactKind?: "legacy-zip" | "npm-pack";
+      publishActor?:
+        | { kind: "user"; userId: string }
+        | {
+            kind: "github-actions";
+            repository: string;
+            workflow: string;
+            runId: string;
+            runAttempt: string;
+            sha: string;
+          };
       clawpackStorageId?: string;
       clawpackSha256?: string;
       clawpackSize?: number;
@@ -3365,6 +3375,122 @@ describe("packages public queries", () => {
         files: [],
         integritySha256: "abc123",
         runtimeId: "other.plugin",
+      }),
+    ).rejects.toThrow("runtime id changes are not allowed");
+  });
+
+  it("allows latest publishes to correct placeholder code plugin runtime ids", async () => {
+    const ctx = makeInsertReleaseCtx(
+      makePackageDoc({
+        name: "@openviking/openclaw-plugin",
+        normalizedName: "@openviking/openclaw-plugin",
+        runtimeId: "openviking-openclaw-plugin-placeholder",
+        stats: { downloads: 0, installs: 0, stars: 0, versions: 1 },
+      }),
+    );
+
+    await expect(
+      insertReleaseInternalHandler(ctx, {
+        actorUserId: "users:owner",
+        ownerUserId: "users:owner",
+        name: "@openviking/openclaw-plugin",
+        displayName: "OpenViking OpenClaw Plugin",
+        family: "code-plugin",
+        version: "1.0.1",
+        changelog: "correct runtime id",
+        tags: ["latest"],
+        summary: "OpenViking memory integration",
+        files: [],
+        integritySha256: "abc123",
+        runtimeId: "openviking",
+        publishActor: {
+          kind: "github-actions",
+          repository: "openviking/openviking",
+          workflow: "publish-openclaw-plugin.yml",
+          runId: "123",
+          runAttempt: "1",
+          sha: "abc123",
+        },
+        capabilities: {
+          runtimeId: "openviking",
+          capabilityTags: ["tools"],
+          executesCode: true,
+        },
+      }),
+    ).resolves.toMatchObject({ ok: true, packageId: "packages:demo" });
+
+    expect(ctx.patch).toHaveBeenCalledWith(
+      "packages:demo",
+      expect.objectContaining({
+        runtimeId: "openviking",
+        capabilities: expect.objectContaining({ runtimeId: "openviking" }),
+      }),
+    );
+    expect(ctx.insert).toHaveBeenCalledWith(
+      "auditLogs",
+      expect.objectContaining({
+        action: "package.runtime_id.placeholder_repair",
+        targetType: "package",
+        targetId: "packages:demo",
+        metadata: expect.objectContaining({
+          previousRuntimeId: "openviking-openclaw-plugin-placeholder",
+          nextRuntimeId: "openviking",
+          source: "publish",
+        }),
+      }),
+    );
+  });
+
+  it("rejects owner user-publish attempts to correct placeholder runtime ids", async () => {
+    const ctx = makeInsertReleaseCtx(
+      makePackageDoc({
+        name: "@openviking/openclaw-plugin",
+        normalizedName: "@openviking/openclaw-plugin",
+        runtimeId: "openviking-openclaw-plugin-placeholder",
+      }),
+    );
+
+    await expect(
+      insertReleaseInternalHandler(ctx, {
+        actorUserId: "users:owner",
+        ownerUserId: "users:owner",
+        name: "@openviking/openclaw-plugin",
+        displayName: "OpenViking OpenClaw Plugin",
+        family: "code-plugin",
+        version: "1.0.1",
+        changelog: "retarget runtime id",
+        tags: ["latest"],
+        summary: "OpenViking memory integration",
+        files: [],
+        integritySha256: "abc123",
+        runtimeId: "openviking",
+      }),
+    ).rejects.toThrow("runtime id changes are not allowed");
+  });
+
+  it("rejects placeholder-like runtime id changes that do not match the package name", async () => {
+    const ctx = makeInsertReleaseCtx(
+      makePackageDoc({
+        name: "@openviking/openclaw-plugin",
+        normalizedName: "@openviking/openclaw-plugin",
+        runtimeId: "some-other-placeholder",
+      }),
+    );
+
+    await expect(
+      insertReleaseInternalHandler(ctx, {
+        actorUserId: "users:owner",
+        ownerUserId: "users:owner",
+        name: "@openviking/openclaw-plugin",
+        displayName: "OpenViking OpenClaw Plugin",
+        family: "code-plugin",
+        version: "1.0.1",
+        changelog: "retarget runtime id",
+        tags: ["latest"],
+        summary: "OpenViking memory integration",
+        files: [],
+        integritySha256: "abc123",
+        runtimeId: "openviking",
       }),
     ).rejects.toThrow("runtime id changes are not allowed");
   });

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -156,6 +156,19 @@ function inferOwnerHandleFromScopedPackageName(name: string) {
   return match?.[1] || undefined;
 }
 
+function expectedPlaceholderRuntimeIdForPackageName(normalizedName: string) {
+  return `${normalizedName.replace(/^@/, "").replace(/\//g, "-")}-placeholder`;
+}
+
+function isPlaceholderPackageRuntimeId(
+  runtimeId: string | null | undefined,
+  normalizedName: string,
+) {
+  const value = runtimeId?.trim().toLowerCase();
+  if (!value) return false;
+  return value === expectedPlaceholderRuntimeIdForPackageName(normalizedName);
+}
+
 const internalRefs = internal as unknown as {
   llmEval: {
     evaluatePackageReleaseWithLlm: unknown;
@@ -5144,13 +5157,19 @@ export const insertReleaseInternal = internalMutation({
         `Package "${nextNameLabel}" already exists as a ${existing.family}; family changes are not allowed`,
       );
     }
-    if (
+    const runtimeIdWillChange =
       existing &&
       existing.family === "code-plugin" &&
+      args.family === "code-plugin" &&
       existing.runtimeId &&
       args.runtimeId &&
-      existing.runtimeId !== args.runtimeId
-    ) {
+      existing.runtimeId !== args.runtimeId;
+    const correctingPlaceholderRuntimeId =
+      Boolean(runtimeIdWillChange) &&
+      args.tags.includes("latest") &&
+      isPlaceholderPackageRuntimeId(existing?.runtimeId, normalizedName) &&
+      (args.publishActor?.kind === "github-actions" || actor.role === "admin");
+    if (runtimeIdWillChange && !correctingPlaceholderRuntimeId) {
       throw new ConvexError(
         `Package "${nextNameLabel}" already exists with plugin id "${existing.runtimeId}"; runtime id changes are not allowed`,
       );
@@ -5277,7 +5296,7 @@ export const insertReleaseInternal = internalMutation({
       await ctx.db.patch(priorRelease._id, { distTags: nextDistTags });
     }
 
-    await ctx.db.patch(pkgId, {
+    const packagePatch: Partial<Doc<"packages">> = {
       displayName: args.displayName,
       ownerUserId: args.ownerUserId,
       ownerPublisherId: args.ownerPublisherId ?? pkg.ownerPublisherId,
@@ -5312,7 +5331,25 @@ export const insertReleaseInternal = internalMutation({
       scanStatus: shouldPromoteLatest ? args.verification?.scanStatus : pkg.scanStatus,
       stats: { ...pkg.stats, versions: (pkg.stats?.versions ?? 0) + 1 },
       updatedAt: now,
-    });
+    };
+    await ctx.db.patch(pkgId, packagePatch);
+
+    if (correctingPlaceholderRuntimeId && existing?.runtimeId && args.runtimeId) {
+      await ctx.db.insert("auditLogs", {
+        actorUserId: args.actorUserId,
+        action: "package.runtime_id.placeholder_repair",
+        targetType: "package",
+        targetId: pkgId,
+        metadata: {
+          name: normalizedName,
+          version: args.version,
+          previousRuntimeId: existing.runtimeId,
+          nextRuntimeId: args.runtimeId,
+          source: "publish",
+        },
+        createdAt: now,
+      });
+    }
 
     return {
       ok: true as const,


### PR DESCRIPTION
﻿## Summary
- allow code-plugin publishes to correct an existing package-name-derived placeholder runtimeId only when publishing a latest release through trusted GitHub Actions or an admin publish
- keep ordinary owner user-publish runtimeId immutability and active runtimeId collision checks intact
- write an audit log when a placeholder runtimeId is corrected through publish

Fixes #2133.

## Security boundary
The exception is intentionally narrow:

- the existing runtimeId must exactly equal the deterministic placeholder derived from the normalized package name
- `@openviking/openclaw-plugin` -> `openviking-openclaw-plugin-placeholder`
- `demo-plugin` -> `demo-plugin-placeholder`
- the release must promote `latest`
- the publish must be from trusted GitHub Actions (`publishActor.kind === "github-actions"`) or an admin actor
- active runtimeId collisions are still rejected before the release is written

A normal owner user-publish and a placeholder-like runtimeId such as `some-other-placeholder` are both still rejected by the runtimeId immutability error.

## Real behavior proof
Targeted publish-path tests after the fix:

```text
RUN  v4.1.6 G:/gitcode/clawhub/clawhub

Test Files  1 passed (1)
Tests  6 passed | 121 skipped (127)
Start at  14:19:16
Duration  1.29s (transform 315ms, setup 30ms, import 937ms, tests 11ms, environment 0ms)
```

Full package public test file after the fix:

```text
RUN  v4.1.6 G:/gitcode/clawhub/clawhub

Test Files  1 passed (1)
Tests  127 passed (127)
Start at  14:20:52
Duration  1.18s (transform 316ms, setup 32ms, import 941ms, tests 81ms, environment 0ms)
```

Static checks:

```text
npx -y bun run format:check
Checking formatting...
All matched files use the correct format.

npx -y bun run lint:oxlint
Found 0 warnings and 0 errors.

npx -y bun x tsc --noEmit
# exited 0
```

## Tests
- npx -y bun x vitest run convex/packages.public.test.ts --testNamePattern "runtime id|plugin id collisions"
- npx -y bun run format:check
- npx -y bun run lint:oxlint
- npx -y bun x tsc --noEmit
- npx -y bun x vitest run convex/packages.public.test.ts
