### PR TITLE
fix(web): remove files tab height cap on desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - API: return a clear 400 for `/api/v1/packages/search` without a non-empty
   `q` instead of treating `search` as a package name (thanks @vyctorbrzezowski).
 - Web: rank publisher card preview items by downloads instead of recent publish order (thanks @vyctorbrzezowski).
+- Web: remove the desktop Files tab height cap and make mobile truncation explicit (thanks @vyctorbrzezowski).
 - Web: keep skill/plugin detail tabs at mobile-friendly touch target height.
 - API/CLI: fix package delete returning 500 for packages with capability tags
   when no capability search digest row existed yet (#2212) (thanks @momothemage).

--- a/src/components/SkillFilesPanel.test.tsx
+++ b/src/components/SkillFilesPanel.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
 import { SkillFilesPanel } from "./SkillFilesPanel";
 
@@ -18,6 +18,10 @@ function makeFile(path: string, size: number): SkillFile {
 describe("SkillFilesPanel", () => {
   beforeEach(() => {
     getFileTextMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("caches loaded files and avoids duplicate fetches", async () => {
@@ -74,5 +78,28 @@ describe("SkillFilesPanel", () => {
 
     await screen.findByText("beta");
     expect(screen.queryByText("alpha")).toBeNull();
+  });
+
+  it("shows a mobile preview list with see-all CTA", () => {
+    vi.stubGlobal("matchMedia", (query: string) => ({
+      matches: query.includes("max-width: 900px"),
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    const files = Array.from({ length: 10 }, (_, index) =>
+      makeFile(`folder/file-${index + 1}.md`, index + 1),
+    );
+    render(
+      <SkillFilesPanel versionId={"skillVersions:1" as Id<"skillVersions">} latestFiles={files} />,
+    );
+
+    expect(screen.queryByRole("button", { name: /folder\/file-10\.md/i })).toBeNull();
+    expect(screen.getByRole("button", { name: "See all" })).toBeTruthy();
   });
 });

--- a/src/components/SkillFilesPanel.test.tsx
+++ b/src/components/SkillFilesPanel.test.tsx
@@ -82,7 +82,7 @@ describe("SkillFilesPanel", () => {
 
   it("shows a mobile preview list with see-all CTA", () => {
     vi.stubGlobal("matchMedia", (query: string) => ({
-      matches: query.includes("max-width: 900px"),
+      matches: query.includes("max-width: 899px"),
       media: query,
       onchange: null,
       addEventListener: vi.fn(),

--- a/src/components/SkillFilesPanel.tsx
+++ b/src/components/SkillFilesPanel.tsx
@@ -162,11 +162,6 @@ export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps
         <div className="file-viewer">
           <div className="file-viewer-header">
             <div className="file-path">{selectedPath ?? "Select a file"}</div>
-            {fileMeta ? (
-              <span className="file-meta">
-                {formatBytes(fileMeta.size)} · {fileMeta.sha256.slice(0, 12)}…
-              </span>
-            ) : null}
           </div>
           <div className="file-viewer-body">
             {isLoading ? (
@@ -182,6 +177,12 @@ export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps
               </div>
             )}
           </div>
+          {fileMeta ? (
+            <div className="file-viewer-meta">
+              <span className="file-meta">{formatBytes(fileMeta.size)}</span>
+              <span className="file-meta">{fileMeta.sha256.slice(0, 12)}...</span>
+            </div>
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/components/SkillFilesPanel.tsx
+++ b/src/components/SkillFilesPanel.tsx
@@ -129,7 +129,7 @@ export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps
   return (
     <div className="tab-body">
       <div className="file-browser">
-        <div className="file-list">
+        <div className={`file-list${isMobile && hiddenFilesCount > 0 ? " has-hidden-files" : ""}`}>
           <div className="file-list-header">
             <h3 className="section-title text-[1.05rem] m-0">Files</h3>
             <span className="file-list-count">{latestFiles.length} total</span>

--- a/src/components/SkillFilesPanel.tsx
+++ b/src/components/SkillFilesPanel.tsx
@@ -123,7 +123,7 @@ export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps
         <div className="file-list">
           <div className="file-list-header">
             <h3 className="section-title text-[1.05rem] m-0">Files</h3>
-            <span className="section-subtitle m-0">{latestFiles.length} total</span>
+            <span className="file-list-count">{latestFiles.length} total</span>
           </div>
           <div className={`file-list-body${showAllMobileFiles ? " is-expanded" : ""}`}>
             {latestFiles.length === 0 ? (

--- a/src/components/SkillFilesPanel.tsx
+++ b/src/components/SkillFilesPanel.tsx
@@ -1,5 +1,5 @@
 import { useAction } from "convex/react";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, FileCode2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../../convex/_generated/api";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
@@ -176,7 +176,10 @@ export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps
             ) : fileContent ? (
               <pre className="file-viewer-code">{fileContent}</pre>
             ) : (
-              <div className="stat">Select a file to preview.</div>
+              <div className="file-viewer-empty">
+                <FileCode2 size={22} className="file-viewer-empty-icon" aria-hidden="true" />
+                <p className="file-viewer-empty-text">Select a file to preview.</p>
+              </div>
             )}
           </div>
         </div>

--- a/src/components/SkillFilesPanel.tsx
+++ b/src/components/SkillFilesPanel.tsx
@@ -1,4 +1,5 @@
 import { useAction } from "convex/react";
+import { ChevronDown } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../../convex/_generated/api";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
@@ -145,13 +146,17 @@ export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps
             )}
           </div>
           {isMobile && hiddenFilesCount > 0 ? (
-            <button
-              className="file-list-see-all"
-              type="button"
-              onClick={() => setShowAllMobileFiles(true)}
-            >
-              See all
-            </button>
+            <div className="file-list-see-all-wrap">
+              <div className="file-list-see-all-gradient" aria-hidden="true" />
+              <button
+                className="file-list-see-all"
+                type="button"
+                onClick={() => setShowAllMobileFiles(true)}
+              >
+                <ChevronDown size={14} aria-hidden="true" />
+                <span>See all</span>
+              </button>
+            </div>
           ) : null}
         </div>
         <div className="file-viewer">

--- a/src/components/SkillFilesPanel.tsx
+++ b/src/components/SkillFilesPanel.tsx
@@ -12,7 +12,7 @@ type SkillFilesPanelProps = {
   latestFiles: SkillFile[];
 };
 
-const MOBILE_FILE_LIST_BREAKPOINT = 900;
+const MOBILE_FILE_LIST_MAX_WIDTH = 899;
 const MOBILE_FILE_LIST_PREVIEW_COUNT = 8;
 
 function splitFilePath(path: string) {
@@ -49,7 +49,7 @@ export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
       return () => {};
     }
-    const mediaQuery = window.matchMedia(`(max-width: ${MOBILE_FILE_LIST_BREAKPOINT}px)`);
+    const mediaQuery = window.matchMedia(`(max-width: ${MOBILE_FILE_LIST_MAX_WIDTH}px)`);
     const syncMobileState = () => {
       const nextIsMobile = mediaQuery.matches;
       setIsMobile(nextIsMobile);

--- a/src/components/SkillFilesPanel.tsx
+++ b/src/components/SkillFilesPanel.tsx
@@ -15,6 +15,15 @@ type SkillFilesPanelProps = {
 const MOBILE_FILE_LIST_BREAKPOINT = 900;
 const MOBILE_FILE_LIST_PREVIEW_COUNT = 8;
 
+function splitFilePath(path: string) {
+  const lastSlashIndex = path.lastIndexOf("/");
+  if (lastSlashIndex === -1) return { directory: "", filename: path };
+  return {
+    directory: path.slice(0, lastSlashIndex + 1),
+    filename: path.slice(lastSlashIndex + 1),
+  };
+}
+
 export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps) {
   const getFileText = useAction(api.skills.getFileText);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
@@ -129,20 +138,28 @@ export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps
             {latestFiles.length === 0 ? (
               <div className="stat">No files available.</div>
             ) : (
-              visibleFiles.map((file) => (
-                <button
-                  key={file.path}
-                  className={`file-row file-row-button${
-                    selectedPath === file.path ? " is-active" : ""
-                  }`}
-                  type="button"
-                  onClick={() => handleSelect(file.path)}
-                  aria-current={selectedPath === file.path ? "true" : undefined}
-                >
-                  <span className="file-path">{file.path}</span>
-                  <span className="file-meta">{formatBytes(file.size)}</span>
-                </button>
-              ))
+              visibleFiles.map((file) => {
+                const { directory, filename } = splitFilePath(file.path);
+                const formattedSize = formatBytes(file.size);
+                return (
+                  <button
+                    key={file.path}
+                    className={`file-row file-row-button${
+                      selectedPath === file.path ? " is-active" : ""
+                    }`}
+                    type="button"
+                    onClick={() => handleSelect(file.path)}
+                    aria-current={selectedPath === file.path ? "true" : undefined}
+                    aria-label={`${file.path} ${formattedSize}`}
+                  >
+                    <span className="file-row-path">
+                      {directory ? <span className="file-path-dir">{directory}</span> : null}
+                      <span className="file-path-name">{filename}</span>
+                    </span>
+                    <span className="file-meta">{formattedSize}</span>
+                  </button>
+                );
+              })
             )}
           </div>
           {isMobile && hiddenFilesCount > 0 ? (

--- a/src/components/SkillFilesPanel.tsx
+++ b/src/components/SkillFilesPanel.tsx
@@ -1,5 +1,5 @@
 import { useAction } from "convex/react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../../convex/_generated/api";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
 import { formatBytes } from "./skillDetailUtils";
@@ -11,6 +11,9 @@ type SkillFilesPanelProps = {
   latestFiles: SkillFile[];
 };
 
+const MOBILE_FILE_LIST_BREAKPOINT = 900;
+const MOBILE_FILE_LIST_PREVIEW_COUNT = 8;
+
 export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps) {
   const getFileText = useAction(api.skills.getFileText);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
@@ -18,6 +21,8 @@ export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps
   const [fileMeta, setFileMeta] = useState<{ size: number; sha256: string } | null>(null);
   const [fileError, setFileError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
+  const [showAllMobileFiles, setShowAllMobileFiles] = useState(false);
   const isMounted = useRef(true);
   const requestId = useRef(0);
   const fileCache = useRef(new Map<string, { text: string; size: number; sha256: string }>());
@@ -29,6 +34,36 @@ export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps
       requestId.current += 1;
     };
   }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return () => {};
+    }
+    const mediaQuery = window.matchMedia(`(max-width: ${MOBILE_FILE_LIST_BREAKPOINT}px)`);
+    const syncMobileState = () => {
+      const nextIsMobile = mediaQuery.matches;
+      setIsMobile(nextIsMobile);
+      if (!nextIsMobile) {
+        setShowAllMobileFiles(false);
+      }
+    };
+    syncMobileState();
+    mediaQuery.addEventListener("change", syncMobileState);
+    return () => {
+      mediaQuery.removeEventListener("change", syncMobileState);
+    };
+  }, []);
+
+  useEffect(() => {
+    setShowAllMobileFiles(false);
+  }, [versionId]);
+
+  const visibleFiles = useMemo(() => {
+    if (!isMobile || showAllMobileFiles) return latestFiles;
+    return latestFiles.slice(0, MOBILE_FILE_LIST_PREVIEW_COUNT);
+  }, [isMobile, latestFiles, showAllMobileFiles]);
+
+  const hiddenFilesCount = latestFiles.length - visibleFiles.length;
 
   useEffect(() => {
     requestId.current += 1;
@@ -89,11 +124,11 @@ export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps
             <h3 className="section-title text-[1.05rem] m-0">Files</h3>
             <span className="section-subtitle m-0">{latestFiles.length} total</span>
           </div>
-          <div className="file-list-body">
+          <div className={`file-list-body${showAllMobileFiles ? " is-expanded" : ""}`}>
             {latestFiles.length === 0 ? (
               <div className="stat">No files available.</div>
             ) : (
-              latestFiles.map((file) => (
+              visibleFiles.map((file) => (
                 <button
                   key={file.path}
                   className={`file-row file-row-button${
@@ -109,6 +144,15 @@ export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps
               ))
             )}
           </div>
+          {isMobile && hiddenFilesCount > 0 ? (
+            <button
+              className="file-list-see-all"
+              type="button"
+              onClick={() => setShowAllMobileFiles(true)}
+            >
+              See all
+            </button>
+          ) : null}
         </div>
         <div className="file-viewer">
           <div className="file-viewer-header">

--- a/src/styles.css
+++ b/src/styles.css
@@ -5696,7 +5696,7 @@ code {
 
 .file-viewer-header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
   border-bottom: 1px solid var(--line);
@@ -5706,16 +5706,22 @@ code {
 .file-viewer-body {
   max-height: 320px;
   overflow: auto;
-  padding-right: 4px;
 }
 
 .file-viewer-code {
   margin: 0;
-  white-space: pre-wrap;
-  word-break: break-word;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--surface-muted);
+  padding: 16px;
+  overflow: auto;
+  white-space: pre;
+  word-break: normal;
   font-family: var(--font-mono);
-  font-size: 0.9rem;
+  font-size: 0.84rem;
+  line-height: 1.65;
   color: var(--ink);
+  tab-size: 2;
 }
 
 .file-viewer-empty {
@@ -5770,6 +5776,14 @@ code {
   font-size: 0.8rem;
   color: var(--ink-soft);
   white-space: nowrap;
+}
+
+.file-viewer-header .file-meta {
+  border: 1px solid var(--line);
+  border-radius: var(--r-btn);
+  background: var(--surface-muted);
+  padding: 4px 8px;
+  line-height: 1;
 }
 
 .comment-form {
@@ -8488,6 +8502,11 @@ a.agentic-risk-finding-title:focus-visible {
 
   .file-viewer-body {
     max-height: 260px;
+  }
+
+  .file-viewer-code {
+    white-space: pre-wrap;
+    word-break: break-word;
   }
 
   .file-list-body {

--- a/src/styles.css
+++ b/src/styles.css
@@ -5728,6 +5728,7 @@ code {
 
 .file-viewer-body {
   max-height: 420px;
+  background: color-mix(in srgb, var(--surface) 82%, var(--bg) 18%);
   overflow: auto;
   padding: 12px 16px 16px;
   scrollbar-color: var(--ink-soft) transparent;

--- a/src/styles.css
+++ b/src/styles.css
@@ -5716,6 +5716,29 @@ code {
   color: var(--ink);
 }
 
+.file-viewer-empty {
+  min-height: 178px;
+  border: 1px dashed var(--line);
+  border-radius: 12px;
+  background: var(--surface-muted);
+  display: grid;
+  place-content: center;
+  gap: 10px;
+  text-align: center;
+  padding: 20px;
+}
+
+.file-viewer-empty-icon {
+  color: var(--ink-soft);
+  justify-self: center;
+}
+
+.file-viewer-empty-text {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 0.96rem;
+}
+
 .version-scroll {
   max-height: 320px;
   overflow: auto;

--- a/src/styles.css
+++ b/src/styles.css
@@ -5714,7 +5714,9 @@ code {
   border-radius: 12px;
   background: var(--surface-muted);
   padding: 16px;
-  overflow: auto;
+  overflow: scroll;
+  scrollbar-color: var(--ink-soft) transparent;
+  scrollbar-width: thin;
   white-space: pre;
   word-break: normal;
   font-family: var(--font-mono);
@@ -5722,6 +5724,22 @@ code {
   line-height: 1.65;
   color: var(--ink);
   tab-size: 2;
+}
+
+.file-viewer-code::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+.file-viewer-code::-webkit-scrollbar-thumb {
+  border: 2px solid transparent;
+  border-radius: var(--r-btn);
+  background: var(--ink-soft);
+  background-clip: padding-box;
+}
+
+.file-viewer-code::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 .file-viewer-empty {

--- a/src/styles.css
+++ b/src/styles.css
@@ -5611,6 +5611,7 @@ code {
 }
 
 .file-list {
+  position: relative;
   display: grid;
   gap: 12px;
   max-width: 100%;
@@ -5649,17 +5650,26 @@ code {
 }
 
 .file-list-see-all-wrap {
-  position: relative;
-  display: grid;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 2;
+  display: none;
   place-items: center;
-  min-height: 56px;
-  margin-top: -4px;
+  height: 92px;
+  pointer-events: none;
 }
 
 .file-list-see-all-gradient {
   position: absolute;
   inset: 0;
-  background: linear-gradient(to bottom, rgba(255, 255, 255, 0), var(--surface) 65%);
+  background: linear-gradient(
+    to bottom,
+    color-mix(in srgb, var(--bg) 0%, transparent) 0%,
+    color-mix(in srgb, var(--bg) 82%, transparent) 48%,
+    var(--bg) 100%
+  );
   pointer-events: none;
 }
 
@@ -5670,6 +5680,14 @@ code {
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  margin-top: 24px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-btn);
+  background: var(--surface);
+  color: var(--ink);
+  padding: 8px 14px;
+  box-shadow: 0 12px 28px rgba(29, 26, 23, 0.14);
+  pointer-events: auto;
 }
 
 .file-browser {
@@ -8578,16 +8596,18 @@ a.agentic-risk-finding-title:focus-visible {
     word-break: break-word;
   }
 
-  .file-list-body {
-    max-height: 200px;
-    overflow: auto;
-    padding-right: 4px;
+  .file-list.has-hidden-files .file-list-body {
+    max-height: 360px;
+    overflow: hidden;
+  }
+
+  .file-list.has-hidden-files .file-list-see-all-wrap {
+    display: grid;
   }
 
   .file-list-body.is-expanded {
     max-height: none;
     overflow: visible;
-    padding-right: 0;
   }
 
   .comment-entry {

--- a/src/styles.css
+++ b/src/styles.css
@@ -5623,7 +5623,7 @@ code {
   gap: 10px;
   border-bottom: 1px solid var(--line);
   min-height: 42px;
-  padding-bottom: 13px;
+  padding: 16px 0 13px;
 }
 
 .file-list-count {
@@ -5712,13 +5712,13 @@ code {
   gap: 12px;
   border-bottom: 1px solid var(--line);
   min-height: 42px;
-  padding: 0 16px 13px;
+  padding: 16px 16px 13px;
 }
 
 .file-viewer-body {
   max-height: 420px;
   overflow: auto;
-  padding: 12px 16px 0;
+  padding: 12px 16px 16px;
   scrollbar-color: var(--ink-soft) transparent;
   scrollbar-width: thin;
 }
@@ -5781,7 +5781,7 @@ code {
   gap: 12px;
   border-top: 1px solid var(--line);
   margin-top: 0;
-  padding: 12px 16px 0;
+  padding: 12px 16px 16px;
 }
 
 .version-scroll {

--- a/src/styles.css
+++ b/src/styles.css
@@ -5631,8 +5631,28 @@ code {
   max-width: 100%;
 }
 
+.file-list-see-all-wrap {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: 56px;
+  margin-top: -4px;
+}
+
+.file-list-see-all-gradient {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0), var(--surface) 65%);
+  pointer-events: none;
+}
+
 .file-list-see-all {
-  justify-self: start;
+  position: relative;
+  z-index: 1;
+  justify-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .file-browser {

--- a/src/styles.css
+++ b/src/styles.css
@@ -5704,7 +5704,7 @@ code {
 }
 
 .file-viewer-body {
-  max-height: 320px;
+  max-height: 420px;
   overflow: auto;
 }
 
@@ -5747,6 +5747,15 @@ code {
   font-size: 0.96rem;
 }
 
+.file-viewer-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-top: 1px solid var(--line);
+  padding-top: 12px;
+}
+
 .version-scroll {
   max-height: 320px;
   overflow: auto;
@@ -5778,7 +5787,7 @@ code {
   white-space: nowrap;
 }
 
-.file-viewer-header .file-meta {
+.file-viewer-meta .file-meta {
   border: 1px solid var(--line);
   border-radius: var(--r-btn);
   background: var(--surface-muted);

--- a/src/styles.css
+++ b/src/styles.css
@@ -5702,7 +5702,6 @@ code {
   border: 1px solid var(--line);
   background: var(--surface);
   display: grid;
-  padding: 16px;
   overflow: hidden;
 }
 
@@ -5713,13 +5712,13 @@ code {
   gap: 12px;
   border-bottom: 1px solid var(--line);
   min-height: 42px;
-  padding-bottom: 12px;
+  padding: 0 16px 13px;
 }
 
 .file-viewer-body {
   max-height: 420px;
   overflow: auto;
-  padding: 12px 0 0;
+  padding: 12px 16px 0;
   scrollbar-color: var(--ink-soft) transparent;
   scrollbar-width: thin;
 }
@@ -5782,7 +5781,7 @@ code {
   gap: 12px;
   border-top: 1px solid var(--line);
   margin-top: 0;
-  padding-top: 12px;
+  padding: 12px 16px 0;
 }
 
 .version-scroll {
@@ -8532,10 +8531,6 @@ a.agentic-risk-finding-title:focus-visible {
 
   .skill-hero-sidebar-meta {
     min-width: 0;
-  }
-
-  .file-viewer {
-    padding: 12px;
   }
 
   .file-viewer-body {

--- a/src/styles.css
+++ b/src/styles.css
@@ -5690,7 +5690,6 @@ code {
   border: 1px solid var(--line);
   background: var(--surface);
   display: grid;
-  gap: 12px;
   padding: 16px;
 }
 
@@ -5706,14 +5705,12 @@ code {
 .file-viewer-body {
   max-height: 420px;
   overflow: auto;
+  padding: 12px 0 0;
 }
 
 .file-viewer-code {
   margin: 0;
-  border: 1px solid var(--line);
-  border-radius: 12px;
-  background: var(--surface-muted);
-  padding: 16px;
+  padding: 0;
   overflow: scroll;
   scrollbar-color: var(--ink-soft) transparent;
   scrollbar-width: thin;
@@ -5771,6 +5768,7 @@ code {
   justify-content: space-between;
   gap: 12px;
   border-top: 1px solid var(--line);
+  margin-top: 0;
   padding-top: 12px;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -5622,8 +5622,13 @@ code {
   justify-content: space-between;
   gap: 10px;
   border-bottom: 1px solid var(--line);
-  min-height: 58px;
+  box-sizing: border-box;
+  height: 64px;
   padding: 16px 0 14px;
+}
+
+.file-list-header .section-title {
+  margin: 0;
 }
 
 .file-list-count {
@@ -5711,13 +5716,14 @@ code {
   justify-content: space-between;
   gap: 12px;
   border-bottom: 1px solid var(--line);
-  min-height: 57px;
+  box-sizing: border-box;
+  height: 63px;
   padding: 15px 16px 14px;
 }
 
 .file-viewer-header .file-path {
-  font-size: 1.05rem;
-  line-height: 1.2;
+  font-size: 0.95rem;
+  line-height: 1.25;
 }
 
 .file-viewer-body {

--- a/src/styles.css
+++ b/src/styles.css
@@ -5622,8 +5622,8 @@ code {
   justify-content: space-between;
   gap: 10px;
   border-bottom: 1px solid var(--line);
-  min-height: 42px;
-  padding: 16px 0 13px;
+  min-height: 58px;
+  padding: 16px 0 14px;
 }
 
 .file-list-count {
@@ -5711,8 +5711,13 @@ code {
   justify-content: space-between;
   gap: 12px;
   border-bottom: 1px solid var(--line);
-  min-height: 42px;
-  padding: 16px 16px 13px;
+  min-height: 57px;
+  padding: 15px 16px 14px;
+}
+
+.file-viewer-header .file-path {
+  font-size: 1.05rem;
+  line-height: 1.2;
 }
 
 .file-viewer-body {

--- a/src/styles.css
+++ b/src/styles.css
@@ -5614,15 +5614,27 @@ code {
   display: grid;
   gap: 12px;
   max-width: 100%;
-  padding-top: 8px;
-  border-top: 1px solid var(--line);
 }
 
 .file-list-header {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
   gap: 10px;
+  border-bottom: 1px solid var(--line);
+  min-height: 42px;
+  padding-bottom: 13px;
+}
+
+.file-list-count {
+  border: 1px solid var(--line);
+  border-radius: var(--r-btn);
+  background: var(--surface-muted);
+  color: var(--ink-soft);
+  font-size: 0.78rem;
+  line-height: 1;
+  padding: 5px 8px;
+  white-space: nowrap;
 }
 
 .file-list-body {
@@ -5696,10 +5708,11 @@ code {
 
 .file-viewer-header {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 12px;
   border-bottom: 1px solid var(--line);
+  min-height: 42px;
   padding-bottom: 12px;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -5691,6 +5691,7 @@ code {
   background: var(--surface);
   display: grid;
   padding: 16px;
+  overflow: hidden;
 }
 
 .file-viewer-header {
@@ -5706,14 +5707,13 @@ code {
   max-height: 420px;
   overflow: auto;
   padding: 12px 0 0;
+  scrollbar-color: var(--ink-soft) transparent;
+  scrollbar-width: thin;
 }
 
 .file-viewer-code {
   margin: 0;
   padding: 0;
-  overflow: scroll;
-  scrollbar-color: var(--ink-soft) transparent;
-  scrollbar-width: thin;
   white-space: pre;
   word-break: normal;
   font-family: var(--font-mono);
@@ -5723,19 +5723,19 @@ code {
   tab-size: 2;
 }
 
-.file-viewer-code::-webkit-scrollbar {
+.file-viewer-body::-webkit-scrollbar {
   width: 10px;
   height: 10px;
 }
 
-.file-viewer-code::-webkit-scrollbar-thumb {
+.file-viewer-body::-webkit-scrollbar-thumb {
   border: 2px solid transparent;
   border-radius: var(--r-btn);
   background: var(--ink-soft);
   background-clip: padding-box;
 }
 
-.file-viewer-code::-webkit-scrollbar-track {
+.file-viewer-body::-webkit-scrollbar-track {
   background: transparent;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -5813,6 +5813,29 @@ code {
   background: var(--surface-muted);
 }
 
+.file-row-path {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  overflow: hidden;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+}
+
+.file-path-dir {
+  color: var(--ink);
+  font-size: 0.82rem;
+  opacity: 0.56;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-path-name {
+  color: var(--ink);
+  overflow-wrap: anywhere;
+}
+
 .file-path {
   font-family: var(--font-mono);
   font-size: 0.9rem;
@@ -5821,6 +5844,7 @@ code {
 }
 
 .file-meta {
+  flex-shrink: 0;
   font-size: 0.8rem;
   color: var(--ink-soft);
   white-space: nowrap;

--- a/src/styles.css
+++ b/src/styles.css
@@ -5628,10 +5628,11 @@ code {
 .file-list-body {
   display: grid;
   gap: 8px;
-  max-height: 260px;
   max-width: 100%;
-  overflow: auto;
-  padding-right: 4px;
+}
+
+.file-list-see-all {
+  justify-self: start;
 }
 
 .file-browser {
@@ -8446,6 +8447,14 @@ a.agentic-risk-finding-title:focus-visible {
 
   .file-list-body {
     max-height: 200px;
+    overflow: auto;
+    padding-right: 4px;
+  }
+
+  .file-list-body.is-expanded {
+    max-height: none;
+    overflow: visible;
+    padding-right: 0;
   }
 
   .comment-entry {

--- a/src/styles.css
+++ b/src/styles.css
@@ -5699,6 +5699,8 @@ code {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 12px;
 }
 
 .file-viewer-body {


### PR DESCRIPTION
## Summary

What changed:

- Removed the desktop Files tab height cap so long file lists grow with the page instead of hiding entries inside a low-discoverability nested scroll.
- Improved file scanning by muting directory context, keeping filenames/extensions high-emphasis, and polishing the preview empty state, scroll behavior, footer metadata, and heading alignment.

Why:

- A file browser should not make users infer whether more package files exist; desktop has room for the full list, while mobile benefits from a compact preview with an explicit expansion control.


## Linked Issue

- Closes N/A
- Related N/A

## Screenshots

| Description | Screenshot |
| --- | --- |
| Old behavior - limited height with hidden files | ![Old behavior with hidden file list](https://i.imgur.com/zzpnalj.png) |
| New behavior - light mode | ![New behavior light mode](https://i.imgur.com/yKZBFDy.png) |
| New behavior - dark mode | ![New behavior dark mode](https://i.imgur.com/4A5L6BM.png) |
| Empty state polish and heading alignment | ![Empty state polish and heading alignment](https://i.imgur.com/TBAbDib.png) |
| Mobile see-all affordance | ![Mobile see-all affordance](https://i.imgur.com/3RDV1ve.png) |

- [x] Screenshots/recordings attached, or `N/A`

## Security / Trust Impact

- [x] No security/trust impact
- [ ] Security/trust impact explained

## Data / Deploy Impact

- [x] No data/deploy impact
- [ ] Data/deploy impact explained

## Verification

- [ ] `bun run format:check`
- [ ] `bun run lint`
- [ ] `bun run test`

Targeted validation run locally:

- `bun run test src/components/SkillFilesPanel.test.tsx`
- `bun run format:check -- CHANGELOG.md src/components/SkillFilesPanel.tsx src/components/SkillFilesPanel.test.tsx src/styles.css`
- `bun run lint -- src/components/SkillFilesPanel.tsx src/components/SkillFilesPanel.test.tsx`
- `git diff --check`
- `codex review --base upstream/main`




