### PR TITLE
Show suspicious skills in UI search

### DIFF
--- a/e2e/home-workflows.pw.test.ts
+++ b/e2e/home-workflows.pw.test.ts
@@ -27,7 +27,7 @@ test("home search and browse entry points work", async ({ page }) => {
 test("search route preserves query in unified search", async ({ page }) => {
   const errors = trackRuntimeErrors(page);
 
-  await page.goto("/search?q=gifgrep&nonSuspicious=1", { waitUntil: "domcontentloaded" });
+  await page.goto("/search?q=gifgrep", { waitUntil: "domcontentloaded" });
   await expect(page).toHaveURL(/\/search\?/);
   await expect(page).toHaveURL(/q=gifgrep/);
   await expect(page.locator('input[placeholder="Search skills and plugins..."]')).toHaveValue(

--- a/src/__tests__/home-route.test.tsx
+++ b/src/__tests__/home-route.test.tsx
@@ -219,7 +219,6 @@ describe("home route", () => {
         numItems: 6,
         sort: "downloads",
         dir: "desc",
-        nonSuspiciousOnly: true,
       }),
     );
   });

--- a/src/__tests__/search-route.test.tsx
+++ b/src/__tests__/search-route.test.tsx
@@ -8,7 +8,6 @@ const navigateMock = vi.fn();
 let searchMock: {
   q?: string;
   type?: "all" | "skills" | "plugins";
-  nonSuspicious?: boolean;
 } = {};
 const useUnifiedSearchMock = vi.fn();
 
@@ -153,75 +152,25 @@ describe("search route", () => {
 
     expect(useUnifiedSearchMock).toHaveBeenLastCalledWith("weather", "all", {
       limits: { skills: 25, plugins: 25 },
-      nonSuspiciousOnly: true,
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Load more" }));
 
     expect(useUnifiedSearchMock).toHaveBeenLastCalledWith("weather", "all", {
       limits: { skills: 50, plugins: 50 },
-      nonSuspiciousOnly: true,
     });
   });
 
-  it("defaults nonSuspiciousOnly to true when URL param is absent", async () => {
+  it("passes only result limits to unified search", async () => {
     searchMock = { q: "hello" };
     const route = await loadRoute();
     const Component = route.__config.component as ComponentType;
 
     render(<Component />);
 
-    expect(useUnifiedSearchMock).toHaveBeenLastCalledWith(
-      "hello",
-      "all",
-      expect.objectContaining({ nonSuspiciousOnly: true }),
-    );
-  });
-
-  it("passes nonSuspiciousOnly=false to the hook when URL opts out", async () => {
-    searchMock = { q: "hello", nonSuspicious: false };
-    const route = await loadRoute();
-    const Component = route.__config.component as ComponentType;
-
-    render(<Component />);
-
-    expect(useUnifiedSearchMock).toHaveBeenLastCalledWith(
-      "hello",
-      "all",
-      expect.objectContaining({ nonSuspiciousOnly: false }),
-    );
-  });
-
-  it("does not render a warning filter chip while keeping the safe default", async () => {
-    searchMock = { q: "hello" };
-    const route = await loadRoute();
-    const Component = route.__config.component as ComponentType;
-
-    render(<Component />);
-
-    expect(screen.queryByRole("button", { name: /Hiding warnings/i })).toBeNull();
-    expect(screen.queryByRole("button", { name: /Showing all skills/i })).toBeNull();
-    expect(useUnifiedSearchMock).toHaveBeenCalledWith(
-      "hello",
-      "all",
-      expect.objectContaining({ nonSuspiciousOnly: true }),
-    );
-  });
-
-  it("does not render a warning filter chip when opted out", async () => {
-    searchMock = { q: "hello", nonSuspicious: false };
-    const route = await loadRoute();
-    const Component = route.__config.component as ComponentType;
-
-    render(<Component />);
-
-    expect(screen.queryByRole("button", { name: /Hiding warnings/i })).toBeNull();
-    expect(screen.queryByRole("button", { name: /Showing all skills/i })).toBeNull();
-    expect(useUnifiedSearchMock).toHaveBeenCalledWith(
-      "hello",
-      "all",
-      expect.objectContaining({ nonSuspiciousOnly: false }),
-    );
+    expect(useUnifiedSearchMock).toHaveBeenLastCalledWith("hello", "all", {
+      limits: { skills: 25, plugins: 25 },
+    });
   });
 
   it("does not render a warning-filter chip on the plugins tab", async () => {

--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -57,7 +57,6 @@ describe("SkillsIndex", () => {
         sort: "downloads",
         dir: "desc",
         highlightedOnly: false,
-        nonSuspiciousOnly: false,
         cursor: undefined,
         numItems: 25,
       }),
@@ -155,7 +154,6 @@ describe("SkillsIndex", () => {
     expect(actionFn).toHaveBeenCalledWith({
       query: "remind",
       highlightedOnly: false,
-      nonSuspiciousOnly: false,
       limit: 25,
     });
     await act(async () => {
@@ -164,7 +162,6 @@ describe("SkillsIndex", () => {
     expect(actionFn).toHaveBeenCalledWith({
       query: "remind",
       highlightedOnly: false,
-      nonSuspiciousOnly: false,
       limit: 25,
     });
   });
@@ -243,7 +240,6 @@ describe("SkillsIndex", () => {
     expect(actionFn).toHaveBeenLastCalledWith({
       query: "remind",
       highlightedOnly: false,
-      nonSuspiciousOnly: false,
       limit: 50,
     });
   });
@@ -298,50 +294,7 @@ describe("SkillsIndex", () => {
     expect(titles[1]).toBe("Newer Low Score");
   });
 
-  it("passes nonSuspiciousOnly to list query when filter is active", async () => {
-    searchMock = { nonSuspicious: true };
-    render(<SkillsIndex />);
-    await act(async () => {});
-
-    expect(convexHttpMock.query).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        sort: "downloads",
-        dir: "desc",
-        highlightedOnly: false,
-        nonSuspiciousOnly: true,
-      }),
-    );
-  });
-
-  it("does not render the warning filter when loaded results are clean", async () => {
-    convexHttpMock.query.mockResolvedValue({
-      page: [makeListResult("clean-skill", "Clean Skill")],
-      hasMore: false,
-      nextCursor: null,
-    });
-
-    render(<SkillsIndex />);
-    await act(async () => {});
-
-    expect(screen.queryByLabelText("Hide warnings")).toBeNull();
-  });
-
-  it("does not render the warning filter when loaded results include a warning skill", async () => {
-    convexHttpMock.query.mockResolvedValue({
-      page: [makeListResult("suspicious-skill", "Suspicious Skill", { isSuspicious: true })],
-      hasMore: false,
-      nextCursor: null,
-    });
-
-    render(<SkillsIndex />);
-    await act(async () => {});
-
-    expect(screen.queryByLabelText("Hide warnings")).toBeNull();
-  });
-
-  it("does not render the warning filter while the URL filter is active", async () => {
-    searchMock = { nonSuspicious: true };
+  it("does not render the warning filter", async () => {
     convexHttpMock.query.mockResolvedValue({
       page: [makeListResult("clean-skill", "Clean Skill")],
       hasMore: false,
@@ -365,7 +318,6 @@ describe("SkillsIndex", () => {
         sort: "downloads",
         dir: "desc",
         highlightedOnly: true,
-        nonSuspiciousOnly: false,
       }),
     );
   });

--- a/src/__tests__/skills-route-default-sort.test.ts
+++ b/src/__tests__/skills-route-default-sort.test.ts
@@ -49,7 +49,6 @@ describe("skills route default sort", () => {
           dir: undefined,
           highlighted: undefined,
           featured: undefined,
-          nonSuspicious: undefined,
           tag: undefined,
           view: undefined,
           focus: undefined,
@@ -64,7 +63,6 @@ describe("skills route default sort", () => {
   });
 
   it("does not redirect when filters are present", () => {
-    expect(runBeforeLoad({ nonSuspicious: true })).toBeUndefined();
     expect(runBeforeLoad({ featured: true })).toBeUndefined();
     expect(runBeforeLoad({ highlighted: true })).toBeUndefined();
   });

--- a/src/__tests__/skills-toolbar.test.tsx
+++ b/src/__tests__/skills-toolbar.test.tsx
@@ -14,11 +14,9 @@ function renderToolbar(overrides?: Partial<ComponentProps<typeof SkillsToolbar>>
       dir="desc"
       view="list"
       highlightedOnly={false}
-      nonSuspiciousOnly={false}
       capabilityTag={undefined}
       onQueryChange={vi.fn()}
       onToggleHighlighted={vi.fn()}
-      onToggleNonSuspicious={vi.fn()}
       onCapabilityTagChange={vi.fn()}
       onSortChange={vi.fn()}
       onToggleDir={vi.fn()}

--- a/src/lib/nav-items.ts
+++ b/src/lib/nav-items.ts
@@ -54,7 +54,6 @@ const SKILLS_SEARCH = {
   sort: undefined,
   dir: undefined,
   highlighted: undefined,
-  nonSuspicious: undefined,
   view: undefined,
   focus: undefined,
 } as const;

--- a/src/lib/useUnifiedSearch.ts
+++ b/src/lib/useUnifiedSearch.ts
@@ -36,14 +36,6 @@ type UnifiedSearchOptions = {
     skills?: number;
     plugins?: number;
   };
-  /**
-   * When true, skills with warning-level moderation signals are excluded at recall time.
-   * Defaults to true to preserve the moderation-safe default for top-level
-   * entry points (homepage / unified search). Callers that provide their own
-   * UI for toggling this filter (e.g. the /skills browse page) should pass
-   * the user-controlled value explicitly.
-   */
-  nonSuspiciousOnly?: boolean;
 };
 
 export function useUnifiedSearch(
@@ -63,7 +55,6 @@ export function useUnifiedSearch(
   const enabled = options.enabled ?? true;
   const skillLimit = options.limits?.skills ?? 25;
   const pluginLimit = options.limits?.plugins ?? 25;
-  const nonSuspiciousOnly = options.nonSuspiciousOnly ?? true;
 
   useEffect(() => {
     const trimmed = query.trim();
@@ -93,7 +84,6 @@ export function useUnifiedSearch(
             promises[0] = searchSkills({
               query: trimmed,
               limit: skillLimit,
-              nonSuspiciousOnly,
             });
           }
 
@@ -169,16 +159,7 @@ export function useUnifiedSearch(
       controller.abort();
       window.clearTimeout(handle);
     };
-  }, [
-    query,
-    activeType,
-    searchSkills,
-    debounceMs,
-    enabled,
-    skillLimit,
-    pluginLimit,
-    nonSuspiciousOnly,
-  ]);
+  }, [query, activeType, searchSkills, debounceMs, enabled, skillLimit, pluginLimit]);
 
   return { results, skillResults, pluginResults, skillCount, pluginCount, isSearching };
 }

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -219,7 +219,6 @@ export function Dashboard() {
                   sort: undefined,
                   dir: undefined,
                   highlighted: undefined,
-                  nonSuspicious: true,
                   view: undefined,
                   focus: undefined,
                 }}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -76,7 +76,6 @@ function SkillsHome() {
         numItems: 6,
         sort: "downloads",
         dir: "desc",
-        nonSuspiciousOnly: true,
       })
       .then((r) => {
         if (cancelled) return;
@@ -549,7 +548,6 @@ function SkillsHome() {
                         dir: undefined,
                         featured: true,
                         highlighted: undefined,
-                        nonSuspicious: undefined,
                         view: undefined,
                         focus: undefined,
                       }
@@ -559,7 +557,6 @@ function SkillsHome() {
                         dir: "desc",
                         featured: undefined,
                         highlighted: undefined,
-                        nonSuspicious: true,
                         view: undefined,
                         focus: undefined,
                       }
@@ -679,7 +676,6 @@ function SkillsHome() {
               sort: undefined,
               dir: undefined,
               highlighted: undefined,
-              nonSuspicious: true,
               view: undefined,
               focus: undefined,
             }}
@@ -783,7 +779,6 @@ function SkillsHome() {
                 dir: "desc",
                 featured: undefined,
                 highlighted: undefined,
-                nonSuspicious: true,
                 view: undefined,
                 focus: undefined,
               }}

--- a/src/routes/search.tsx
+++ b/src/routes/search.tsx
@@ -17,15 +17,12 @@ const SEARCH_PAGE_SIZE = 25;
 type SearchState = {
   q?: string;
   type?: UnifiedSearchType;
-  nonSuspicious?: boolean;
 };
 
 export const Route = createFileRoute("/search")({
   validateSearch: (search: Record<string, unknown>): SearchState => ({
     q: typeof search.q === "string" && search.q.trim() ? search.q : undefined,
     type: search.type === "skills" || search.type === "plugins" ? search.type : undefined,
-    nonSuspicious:
-      search.nonSuspicious === false || search.nonSuspicious === "false" ? false : undefined,
   }),
   component: UnifiedSearchPage,
 });
@@ -34,10 +31,6 @@ function UnifiedSearchPage() {
   const search = Route.useSearch();
   const navigate = useNavigate();
   const activeType = search.type ?? "all";
-  // Unified search defaults to moderation-safe (skills with warnings hidden).
-  // Keep the URL flag for compatibility even though the search UI no longer
-  // exposes a warning filter control.
-  const nonSuspiciousOnly = search.nonSuspicious ?? true;
   const [query, setQuery] = useState(search.q ?? "");
   const [resultLimit, setResultLimit] = useState(SEARCH_PAGE_SIZE);
 
@@ -47,7 +40,7 @@ function UnifiedSearchPage() {
 
   useEffect(() => {
     setResultLimit(SEARCH_PAGE_SIZE);
-  }, [search.q, activeType, nonSuspiciousOnly]);
+  }, [search.q, activeType]);
 
   const {
     results: allResults,
@@ -59,7 +52,6 @@ function UnifiedSearchPage() {
       skills: resultLimit,
       plugins: resultLimit,
     },
-    nonSuspiciousOnly,
   });
   const results =
     activeType === "all"
@@ -81,7 +73,6 @@ function UnifiedSearchPage() {
       search: {
         q: query.trim() || undefined,
         type: search.type,
-        nonSuspicious: search.nonSuspicious,
       },
     });
   };
@@ -92,7 +83,6 @@ function UnifiedSearchPage() {
       search: {
         q: search.q,
         type: type === "all" ? undefined : type,
-        nonSuspicious: search.nonSuspicious,
       },
       replace: true,
     });

--- a/src/routes/skills/-SkillsToolbar.tsx
+++ b/src/routes/skills/-SkillsToolbar.tsx
@@ -37,11 +37,9 @@ type SkillsToolbarProps = {
   dir: SortDir;
   view: SkillsView;
   highlightedOnly: boolean;
-  nonSuspiciousOnly: boolean;
   capabilityTag?: string;
   onQueryChange: (next: string) => void;
   onToggleHighlighted: () => void;
-  onToggleNonSuspicious: () => void;
   onCapabilityTagChange: (value: string) => void;
   onSortChange: (value: string) => void;
   onToggleDir: () => void;
@@ -77,11 +75,9 @@ export function SkillsToolbar({
   dir,
   view,
   highlightedOnly,
-  nonSuspiciousOnly,
   capabilityTag,
   onQueryChange,
   onToggleHighlighted,
-  onToggleNonSuspicious,
   onCapabilityTagChange,
   onSortChange,
   onToggleDir,
@@ -137,9 +133,6 @@ export function SkillsToolbar({
         {/* Filter chips */}
         <FilterChip active={highlightedOnly} onClick={onToggleHighlighted}>
           Staff Picks
-        </FilterChip>
-        <FilterChip active={nonSuspiciousOnly} onClick={onToggleNonSuspicious}>
-          Clean only
         </FilterChip>
         {capabilityTag ? (
           <FilterChip

--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -30,7 +30,6 @@ export type SkillsSearchState = {
   dir?: SortDir;
   highlighted?: boolean;
   featured?: boolean;
-  nonSuspicious?: boolean;
   tag?: string;
   view?: LegacySkillsView;
   focus?: "search";
@@ -73,7 +72,6 @@ export function useSkillsBrowseModel({
 
   const view: SkillsView = normalizeSkillsView(search.view) ?? "list";
   const featuredOnly = search.featured ?? search.highlighted ?? false;
-  const nonSuspiciousOnly = search.nonSuspicious ?? false;
   const capabilityTag = search.tag;
   const searchSkills = useAction(api.search.searchSkills);
 
@@ -87,7 +85,7 @@ export function useSkillsBrowseModel({
   const listSort = toListSort(sort);
   const dir = parseDir(search.dir, sort);
   const searchKey = trimmedQuery
-    ? `${trimmedQuery}::${featuredOnly ? "1" : "0"}::${nonSuspiciousOnly ? "1" : "0"}::${capabilityTag ?? ""}`
+    ? `${trimmedQuery}::${featuredOnly ? "1" : "0"}::${capabilityTag ?? ""}`
     : "";
 
   // One-shot paginated fetches (no reactive subscription)
@@ -105,7 +103,6 @@ export function useSkillsBrowseModel({
           sort: listSort,
           dir,
           highlightedOnly: featuredOnly,
-          nonSuspiciousOnly,
           capabilityTag,
         });
         if (generation !== fetchGeneration.current) return;
@@ -122,7 +119,7 @@ export function useSkillsBrowseModel({
         setListStatus(cursor ? "idle" : "done");
       }
     },
-    [capabilityTag, dir, featuredOnly, listSort, nonSuspiciousOnly],
+    [capabilityTag, dir, featuredOnly, listSort],
   );
 
   // Reset and fetch first page when sort/dir/filters change
@@ -178,7 +175,6 @@ export function useSkillsBrowseModel({
           const data = (await searchSkills({
             query: trimmedQuery,
             highlightedOnly: featuredOnly,
-            nonSuspiciousOnly,
             capabilityTag,
             limit: searchLimit,
           })) as Array<SkillSearchEntry>;
@@ -193,15 +189,7 @@ export function useSkillsBrowseModel({
       })();
     }, 220);
     return () => window.clearTimeout(handle);
-  }, [
-    capabilityTag,
-    hasQuery,
-    featuredOnly,
-    nonSuspiciousOnly,
-    searchLimit,
-    searchSkills,
-    trimmedQuery,
-  ]);
+  }, [capabilityTag, hasQuery, featuredOnly, searchLimit, searchSkills, trimmedQuery]);
 
   const baseItems = useMemo(() => {
     if (hasQuery) {
@@ -353,16 +341,6 @@ export function useSkillsBrowseModel({
     });
   }, [navigate]);
 
-  const onToggleNonSuspicious = useCallback(() => {
-    void navigate({
-      search: (prev) => ({
-        ...prev,
-        nonSuspicious: prev.nonSuspicious ? undefined : true,
-      }),
-      replace: true,
-    });
-  }, [navigate]);
-
   const onSortChange = useCallback(
     (value: string) => {
       const nextSort = parseSort(value);
@@ -400,7 +378,6 @@ export function useSkillsBrowseModel({
 
   const activeFilters: string[] = [];
   if (featuredOnly) activeFilters.push("featured");
-  if (nonSuspiciousOnly) activeFilters.push("warnings hidden");
   if (capabilityTag) activeFilters.push(SKILL_CAPABILITY_LABELS[capabilityTag] ?? capabilityTag);
 
   const onCapabilityTagChange = useCallback(
@@ -428,13 +405,11 @@ export function useSkillsBrowseModel({
     isLoadingSkills,
     loadMore,
     loadMoreRef,
-    nonSuspiciousOnly,
     onCapabilityTagChange,
     onQueryChange,
     onSortChange,
     onToggleDir,
     onToggleFeatured,
-    onToggleNonSuspicious,
     onToggleView,
     query,
     sort,

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -37,19 +37,13 @@ export const Route = createFileRoute("/skills/")({
         search.featured === "1" || search.featured === "true" || search.featured === true
           ? true
           : undefined,
-      nonSuspicious:
-        search.nonSuspicious === "1" ||
-        search.nonSuspicious === "true" ||
-        search.nonSuspicious === true
-          ? true
-          : undefined,
       view: normalizeSkillsView(search.view),
       focus: search.focus === "search" ? "search" : undefined,
     };
   },
   beforeLoad: ({ search }) => {
     const hasQuery = Boolean(search.q?.trim());
-    if (hasQuery || search.sort || search.featured || search.highlighted || search.nonSuspicious) {
+    if (hasQuery || search.sort || search.featured || search.highlighted) {
       return;
     }
     throw redirect({
@@ -60,7 +54,6 @@ export const Route = createFileRoute("/skills/")({
         dir: search.dir || undefined,
         highlighted: search.highlighted || undefined,
         featured: search.featured || undefined,
-        nonSuspicious: search.nonSuspicious || undefined,
         view: search.view || undefined,
         focus: search.focus || undefined,
       },
@@ -118,14 +111,7 @@ export function SkillsIndex() {
   const handleClear = useCallback(() => {
     model.onQueryChange("");
     if (model.featuredOnly) model.onToggleFeatured();
-    if (model.nonSuspiciousOnly) model.onToggleNonSuspicious();
-  }, [
-    model.featuredOnly,
-    model.onQueryChange,
-    model.onToggleFeatured,
-    model.onToggleNonSuspicious,
-    model.nonSuspiciousOnly,
-  ]);
+  }, [model.featuredOnly, model.onQueryChange, model.onToggleFeatured]);
 
   const handleCategoryChange = useCallback(
     (slug: string | undefined) => {
@@ -188,7 +174,7 @@ export function SkillsIndex() {
           <div className="browse-results-toolbar">
             <span className="browse-results-count">
               {model.isLoadingSkills ? "\u2014" : `${model.sorted.length} results`}
-              {model.hasQuery || model.featuredOnly || model.nonSuspiciousOnly ? (
+              {model.hasQuery || model.featuredOnly ? (
                 <button className="browse-clear-btn" type="button" onClick={handleClear}>
                   Clear
                 </button>

--- a/src/routes/souls/index.tsx
+++ b/src/routes/souls/index.tsx
@@ -71,7 +71,6 @@ function SoulsHoldingPage() {
                 sort: "downloads",
                 dir: "desc",
                 highlighted: undefined,
-                nonSuspicious: true,
                 view: undefined,
                 focus: undefined,
               }}


### PR DESCRIPTION
## Summary
- stop UI search and skills browse from sending the suspicious-skill hide filter
- remove the Clean only filter chip and stale nonSuspicious route/link state
- update route, component, and e2e tests for showing all non-blocked results

## Tests
- bunx vitest run src/__tests__/search-route.test.ts src/__tests__/search-route.test.tsx src/__tests__/skills-index.test.tsx src/__tests__/skills-route-default-sort.test.ts src/__tests__/skills-toolbar.test.tsx src/__tests__/home-route.test.tsx
- bun run format:check -- e2e/home-workflows.pw.test.ts src/__tests__/home-route.test.tsx src/__tests__/search-route.test.tsx src/__tests__/skills-index.test.tsx src/__tests__/skills-route-default-sort.test.ts src/__tests__/skills-toolbar.test.tsx src/lib/nav-items.ts src/lib/useUnifiedSearch.ts src/routes/dashboard.tsx src/routes/index.tsx src/routes/search.tsx src/routes/skills/-SkillsToolbar.tsx src/routes/skills/-useSkillsBrowseModel.ts src/routes/skills/index.tsx src/routes/souls/index.tsx
- bun run lint
