### PR TITLE
fix(web): default skills browse to non-suspicious results

### DIFF
--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -57,7 +57,7 @@ describe("SkillsIndex", () => {
         sort: "downloads",
         dir: "desc",
         highlightedOnly: false,
-        nonSuspiciousOnly: false,
+        nonSuspiciousOnly: true,
         cursor: undefined,
         numItems: 25,
       }),
@@ -155,7 +155,7 @@ describe("SkillsIndex", () => {
     expect(actionFn).toHaveBeenCalledWith({
       query: "remind",
       highlightedOnly: false,
-      nonSuspiciousOnly: false,
+      nonSuspiciousOnly: true,
       limit: 25,
     });
     await act(async () => {
@@ -164,7 +164,7 @@ describe("SkillsIndex", () => {
     expect(actionFn).toHaveBeenCalledWith({
       query: "remind",
       highlightedOnly: false,
-      nonSuspiciousOnly: false,
+      nonSuspiciousOnly: true,
       limit: 25,
     });
   });
@@ -243,7 +243,7 @@ describe("SkillsIndex", () => {
     expect(actionFn).toHaveBeenLastCalledWith({
       query: "remind",
       highlightedOnly: false,
-      nonSuspiciousOnly: false,
+      nonSuspiciousOnly: true,
       limit: 50,
     });
   });
@@ -365,7 +365,7 @@ describe("SkillsIndex", () => {
         sort: "downloads",
         dir: "desc",
         highlightedOnly: true,
-        nonSuspiciousOnly: false,
+        nonSuspiciousOnly: true,
       }),
     );
   });

--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -73,7 +73,7 @@ export function useSkillsBrowseModel({
 
   const view: SkillsView = normalizeSkillsView(search.view) ?? "list";
   const featuredOnly = search.featured ?? search.highlighted ?? false;
-  const nonSuspiciousOnly = search.nonSuspicious ?? false;
+  const nonSuspiciousOnly = search.nonSuspicious ?? true;
   const capabilityTag = search.tag;
   const searchSkills = useAction(api.search.searchSkills);
 

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -118,13 +118,13 @@ export function SkillsIndex() {
   const handleClear = useCallback(() => {
     model.onQueryChange("");
     if (model.featuredOnly) model.onToggleFeatured();
-    if (model.nonSuspiciousOnly) model.onToggleNonSuspicious();
+    if (search.nonSuspicious) model.onToggleNonSuspicious();
   }, [
     model.featuredOnly,
     model.onQueryChange,
     model.onToggleFeatured,
     model.onToggleNonSuspicious,
-    model.nonSuspiciousOnly,
+    search.nonSuspicious,
   ]);
 
   const handleCategoryChange = useCallback(
@@ -188,7 +188,7 @@ export function SkillsIndex() {
           <div className="browse-results-toolbar">
             <span className="browse-results-count">
               {model.isLoadingSkills ? "\u2014" : `${model.sorted.length} results`}
-              {model.hasQuery || model.featuredOnly || model.nonSuspiciousOnly ? (
+              {model.hasQuery || model.featuredOnly || search.nonSuspicious ? (
                 <button className="browse-clear-btn" type="button" onClick={handleClear}>
                   Clear
                 </button>


### PR DESCRIPTION
## Summary
- Default the skills browse page to filter out suspicious results (`nonSuspiciousOnly: true`), matching the behavior already present on `/search`.
- Adjust the "Clear" button to only appear when `nonSuspicious` is explicitly set in the URL (user-initiated filter), not when it is the implicit safe default.

## Why
The `/search` route and `useUnifiedSearch` hook already default `nonSuspiciousOnly` to `true`. The skills browse page (`/skills`) diverged by defaulting to `false`, exposing flagged content in the public catalog.

## Verification
- [x] `bun run test -- src/__tests__/skills-index.test.tsx` — 20 passed
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `git diff --check`

## Notes
- Production code diff is 4 lines: `?? false` to `?? true` + Clear button uses explicit URL state.
- No UI/layout changes.