### PR TITLE
fix(cli): filter suspicious skills from search by default

### DIFF
--- a/packages/clawhub/src/cli.ts
+++ b/packages/clawhub/src/cli.ts
@@ -206,10 +206,11 @@ registerCommand(program, ["search"])
   .description("Vector search skills")
   .argument("<query...>", "Query string")
   .option("--limit <n>", "Max results", (value) => Number.parseInt(value, 10))
+  .option("--include-suspicious", "Include suspicious skills in results")
   .action(async (queryParts, options) => {
     const opts = await resolveGlobalOpts();
     const query = queryParts.join(" ").trim();
-    await cmdSearch(opts, query, options.limit);
+    await cmdSearch(opts, query, options.limit, options.includeSuspicious);
   });
 
 registerCommand(program, ["install"])

--- a/packages/clawhub/src/cli/commands/skills.test.ts
+++ b/packages/clawhub/src/cli/commands/skills.test.ts
@@ -231,6 +231,8 @@ describe("cmdSearch", () => {
 
     const [, requestArgs] = mockApiRequest.mock.calls[0] ?? [];
     expect(requestArgs?.token).toBe("tkn");
+    const url = new URL(String(requestArgs?.url));
+    expect(url.searchParams.get("nonSuspiciousOnly")).toBe("true");
   });
 
   it("defaults limit to 25 when not specified", async () => {
@@ -241,6 +243,7 @@ describe("cmdSearch", () => {
 
     const [, requestArgs] = mockApiRequest.mock.calls[0] ?? [];
     const url = new URL(String(requestArgs?.url));
+    expect(url.searchParams.get("nonSuspiciousOnly")).toBe("true");
     expect(url.searchParams.get("limit")).toBe("25");
   });
 
@@ -252,7 +255,20 @@ describe("cmdSearch", () => {
 
     const [, requestArgs] = mockApiRequest.mock.calls[0] ?? [];
     const url = new URL(String(requestArgs?.url));
+    expect(url.searchParams.get("nonSuspiciousOnly")).toBe("true");
     expect(url.searchParams.get("limit")).toBe("5");
+  });
+
+  it("allows including suspicious skills via --include-suspicious", async () => {
+    mockGetOptionalAuthToken.mockResolvedValue(undefined);
+    mockApiRequest.mockResolvedValue({ results: [] });
+
+    await cmdSearch(makeOpts(), "stock price", 25, true);
+
+    const [, requestArgs] = mockApiRequest.mock.calls[0] ?? [];
+    const url = new URL(String(requestArgs?.url));
+    expect(url.searchParams.get("nonSuspiciousOnly")).toBeNull();
+    expect(url.searchParams.get("limit")).toBe("25");
   });
 
   it("prints skill owners in search results", async () => {

--- a/packages/clawhub/src/cli/commands/skills.ts
+++ b/packages/clawhub/src/cli/commands/skills.ts
@@ -98,7 +98,7 @@ function formatSearchOwner(entry: {
   return entry.owner?.displayName ?? "unknown owner";
 }
 
-export async function cmdSearch(opts: GlobalOpts, query: string, limit?: number) {
+export async function cmdSearch(opts: GlobalOpts, query: string, limit?: number, includeSuspicious?: boolean) {
   if (!query) fail("Query required");
 
   const token = await getOptionalAuthToken();
@@ -107,6 +107,7 @@ export async function cmdSearch(opts: GlobalOpts, query: string, limit?: number)
   try {
     const url = registryUrl(ApiRoutes.search, registry);
     url.searchParams.set("q", query);
+    if (!includeSuspicious) url.searchParams.set("nonSuspiciousOnly", "true");
     const effectiveLimit = typeof limit === "number" && Number.isFinite(limit) ? limit : 25;
     url.searchParams.set("limit", String(effectiveLimit));
     const result = await apiRequest(


### PR DESCRIPTION
## Summary
- Add `nonSuspiciousOnly=true` to CLI skill search requests by default.
- Add `--include-suspicious` flag for explicit opt-out.

## Why
The web search surfaces already default to filtering suspicious results. The CLI diverged by not sending `nonSuspiciousOnly`, exposing flagged content that the web hides.

## Verification
- [x] `bunx vitest run -c vitest.config.ts src/cli/commands/skills.test.ts` from `packages/clawhub`
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `git diff --check`

## Notes
- 3 lines of production code: new CLI flag + guard.
- No behavioral change for users who do not pass the new flag.
