### PR TITLE
Replace search loading boxes with skeletons

### DIFF
--- a/src/__tests__/packages-route.test.tsx
+++ b/src/__tests__/packages-route.test.tsx
@@ -73,6 +73,7 @@ async function loadRoute() {
     __config: {
       loader?: (args: { deps: Record<string, unknown> }) => Promise<unknown>;
       component?: ComponentType;
+      pendingComponent?: ComponentType;
       validateSearch?: (search: Record<string, unknown>) => Record<string, unknown>;
     };
   };
@@ -384,6 +385,16 @@ describe("plugins route", () => {
 
     expect(screen.queryByRole("link", { name: "Publish" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Publish" })).toBeNull();
+  });
+
+  it("renders browse skeletons while the plugins route is pending", async () => {
+    const route = await loadRoute();
+    const PendingComponent = route.__config.pendingComponent as ComponentType;
+
+    render(<PendingComponent />);
+
+    expect(screen.getByRole("status", { name: "Loading results" })).toBeTruthy();
+    expect(screen.queryByText("Unable to load plugins")).toBeNull();
   });
 
   it("switches legacy cards URLs back to list view", async () => {

--- a/src/__tests__/search-route.test.tsx
+++ b/src/__tests__/search-route.test.tsx
@@ -89,6 +89,24 @@ describe("search route", () => {
     expect(screen.queryByRole("button", { name: /users/i })).toBeNull();
   });
 
+  it("uses result skeletons instead of a boxed searching message", async () => {
+    useUnifiedSearchMock.mockReturnValue({
+      results: [],
+      skillResults: [],
+      pluginResults: [],
+      skillCount: 0,
+      pluginCount: 0,
+      isSearching: true,
+    });
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    expect(screen.getByRole("status", { name: "Loading results" })).toBeTruthy();
+    expect(screen.queryByText("Searching...")).toBeNull();
+  });
+
   it("shows zero counts consistently for active search tabs", async () => {
     useUnifiedSearchMock.mockReturnValue({
       results: [],

--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -85,6 +85,7 @@ describe("SkillsIndex", () => {
     await act(async () => {});
     // Results area shows skeleton or dash while loading
     expect(screen.getByText("\u2014")).toBeTruthy();
+    expect(screen.getByRole("status", { name: "Loading results" })).toBeTruthy();
     expect(screen.queryByText("No skills found")).toBeNull();
   });
 
@@ -383,7 +384,7 @@ describe("SkillsIndex", () => {
     expect(screen.getByRole("button", { name: "Load more" })).toBeTruthy();
   });
 
-  it("shows loading indicator during load-more", async () => {
+  it("shows skeletons during load-more", async () => {
     vi.stubGlobal("IntersectionObserver", undefined);
     convexHttpMock.query
       .mockResolvedValueOnce({
@@ -402,7 +403,8 @@ describe("SkillsIndex", () => {
       fireEvent.click(loadMoreButton);
     });
 
-    expect(screen.getByText(/Loading/)).toBeTruthy();
+    expect(screen.getByRole("status", { name: "Loading results" })).toBeTruthy();
+    expect(screen.queryByText(/Loading/)).toBeNull();
   });
 });
 

--- a/src/components/skeletons/BrowseResultsSkeleton.tsx
+++ b/src/components/skeletons/BrowseResultsSkeleton.tsx
@@ -1,0 +1,75 @@
+import { Skeleton } from "../ui/skeleton";
+
+type BrowseResultsSkeletonProps = {
+  count?: number;
+  variant?: "list" | "grid";
+};
+
+export function BrowseResultsSkeleton({ count = 6, variant = "list" }: BrowseResultsSkeletonProps) {
+  if (variant === "grid") {
+    return (
+      <div className="grid" role="status" aria-label="Loading results">
+        {Array.from({ length: count }, (_, i) => (
+          <div
+            // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholder count
+            key={i}
+            className="card skill-card skill-card-spaced-footer"
+          >
+            <div className="skill-card-tags">
+              <Skeleton className="h-6 w-16 rounded-[var(--radius-pill)]" />
+              <Skeleton className="h-6 w-20 rounded-[var(--radius-pill)]" />
+            </div>
+            <div className="skill-card-header">
+              <Skeleton className="h-11 w-11 rounded-[var(--r-sm)]" />
+              <Skeleton className="h-6 w-40 max-w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-5/6" />
+            </div>
+            <div className="skill-card-footer">
+              <div className="skill-card-footer-rows">
+                <div className="flex items-center gap-2">
+                  <Skeleton className="h-6 w-6 rounded-full" />
+                  <Skeleton className="h-4 w-24" />
+                </div>
+                <Skeleton className="h-4 w-44 max-w-full" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="results-list" role="status" aria-label="Loading results">
+      {Array.from({ length: count }, (_, i) => (
+        <div
+          // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholder count
+          key={i}
+          className="skill-list-item"
+        >
+          <Skeleton className="h-11 w-11 shrink-0 rounded-[var(--r-sm)]" />
+          <div className="skill-list-item-body">
+            <div className="skill-list-item-main">
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-4 w-2" />
+              <Skeleton className="h-5 w-44 max-w-full" />
+              <Skeleton className="h-6 w-16 rounded-[var(--radius-pill)]" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-3/4" />
+            </div>
+            <div className="skill-list-item-meta">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-4 w-16" />
+              <Skeleton className="h-4 w-20" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/routes/plugins/index.tsx
+++ b/src/routes/plugins/index.tsx
@@ -4,6 +4,7 @@ import { PackageSearch, Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { BrowseSidebar } from "../../components/BrowseSidebar";
 import { PluginListItem } from "../../components/PluginListItem";
+import { BrowseResultsSkeleton } from "../../components/skeletons/BrowseResultsSkeleton";
 import { Button } from "../../components/ui/button";
 import { PLUGIN_CATEGORIES } from "../../lib/categories";
 import {
@@ -94,6 +95,7 @@ function sortPluginSearchItems(items: PackageListItem[], sort: PluginSort) {
 }
 
 export const Route = createFileRoute("/plugins/")({
+  pendingComponent: PluginsIndexPending,
   validateSearch: (search): PluginSearchState => ({
     q: typeof search.q === "string" && search.q.trim() ? search.q.trim() : undefined,
     category:
@@ -183,6 +185,55 @@ export const Route = createFileRoute("/plugins/")({
   },
   component: PluginsIndex,
 });
+
+function PluginsIndexPending() {
+  return (
+    <main className="browse-page">
+      <div className="browse-page-header">
+        <button className="browse-sidebar-toggle" type="button" disabled>
+          Filters
+        </button>
+        <h1 className="browse-title">Plugins</h1>
+      </div>
+      <div className="browse-page-search">
+        <Search size={15} className="navbar-search-icon" aria-hidden="true" />
+        <input className="browse-search-input" placeholder="Search plugins..." disabled />
+      </div>
+      <div className="browse-layout">
+        <BrowseSidebar
+          categories={PLUGIN_CATEGORIES}
+          activeCategory={undefined}
+          onCategoryChange={() => {}}
+          sortOptions={[
+            { value: "featured", label: "Featured" },
+            { value: "updated", label: "Recently updated" },
+          ]}
+          activeSort="updated"
+          onSortChange={() => {}}
+          filters={[
+            { key: "verified", label: "Verified only", active: false },
+            { key: "executesCode", label: "Executes code", active: false },
+          ]}
+          onFilterToggle={() => {}}
+        />
+        <div className="browse-results">
+          <div className="browse-results-toolbar">
+            <span className="browse-results-count">Loading results</span>
+            <div className="browse-view-toggle">
+              <button className="browse-view-btn is-active" type="button" disabled>
+                List
+              </button>
+              <button className="browse-view-btn" type="button" disabled>
+                Grid
+              </button>
+            </div>
+          </div>
+          <BrowseResultsSkeleton />
+        </div>
+      </div>
+    </main>
+  );
+}
 
 function PluginsIndex() {
   const search = Route.useSearch();

--- a/src/routes/search.tsx
+++ b/src/routes/search.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Search, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { PluginListItem } from "../components/PluginListItem";
+import { BrowseResultsSkeleton } from "../components/skeletons/BrowseResultsSkeleton";
 import { SkillListItem } from "../components/SkillListItem";
 import { Card } from "../components/ui/card";
 import type { PublicSkill } from "../lib/publicUser";
@@ -169,9 +170,7 @@ function UnifiedSearchPage() {
       </div>
 
       {isSearching ? (
-        <Card>
-          <div className="loading-indicator">Searching...</div>
-        </Card>
+        <BrowseResultsSkeleton count={activeType === "all" ? 8 : 6} />
       ) : !search.q ? (
         <Card className="text-center p-10">
           <p className="text-ink-soft">Enter a search term to find skills and plugins</p>

--- a/src/routes/skills/-SkillsResults.tsx
+++ b/src/routes/skills/-SkillsResults.tsx
@@ -1,4 +1,5 @@
 import type { RefObject } from "react";
+import { BrowseResultsSkeleton } from "../../components/skeletons/BrowseResultsSkeleton";
 import { SkillCard } from "../../components/SkillCard";
 import { getPlatformLabels } from "../../components/skillDetailUtils";
 import { SkillListItem } from "../../components/SkillListItem";
@@ -38,18 +39,7 @@ export function SkillsResults({
   return (
     <>
       {isLoadingSkills ? (
-        <div className="skeleton-list">
-          {Array.from({ length: 6 }, (_, i) => (
-            <div key={i} className="skeleton-row">
-              <div className="skeleton-icon" />
-              <div className="skeleton-row-body">
-                <div className="skeleton-bar skeleton-bar-lg" />
-                <div className="skeleton-bar skeleton-bar-sm" />
-                <div className="skeleton-bar skeleton-bar-xs" />
-              </div>
-            </div>
-          ))}
-        </div>
+        <BrowseResultsSkeleton variant={view} />
       ) : sorted.length === 0 ? (
         <div className="empty-state">
           <p className="empty-state-title">No skills found</p>
@@ -117,17 +107,17 @@ export function SkillsResults({
         </div>
       )}
 
-      {canLoadMore || isLoadingMore ? (
+      {isLoadingMore ? (
+        <div ref={canAutoLoad ? loadMoreRef : null} className="mt-4">
+          <BrowseResultsSkeleton count={2} variant={view} />
+        </div>
+      ) : canLoadMore ? (
         <div ref={canAutoLoad ? loadMoreRef : null} className="card mt-4 flex justify-center">
           {canAutoLoad ? (
-            isLoadingMore ? (
-              "Loading more..."
-            ) : (
-              "Scroll to load more"
-            )
+            "Scroll to load more"
           ) : (
             <Button type="button" onClick={loadMore} disabled={isLoadingMore}>
-              {isLoadingMore ? "Loading..." : "Load more"}
+              Load more
             </Button>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Add a shared browse-results skeleton that matches list and grid result layouts.
- Replace the unified search "Searching..." card and skills browse/load-more text states with skeleton rows.
- Add a plugins route pending skeleton for route-loader transitions.

## Screenshots
Local screenshots captured from `http://127.0.0.1:3000`:

- Unified search skeleton: `/tmp/clawhub-skeleton-proof/search-skeleton.png`
- Skills browse skeleton: `/tmp/clawhub-skeleton-proof/skills-skeleton.png`
- Plugins route attempt: `/tmp/clawhub-skeleton-proof/plugins-client-pending.png`

Note: GitHub CLI cannot upload local image attachments directly from this environment, so these are local proof paths for now.

## Validation
- `VITE_CONVEX_URL=https://example.invalid bunx vitest run src/__tests__/search-route.test.tsx src/__tests__/skills-index.test.tsx src/__tests__/packages-route.test.tsx`
- `bun run ci:static`

## Crabbox
- `bun run crabbox:run -- --provider hetzner --desktop --browser ...` could not acquire a lease because the configured Hetzner token returned 401.
- `bun run crabbox:run -- --provider aws --desktop --browser ...` acquired `cbx_78430ca504ee`, but SSH never opened after ~6 minutes; the lease was released with `bun run crabbox:stop -- --provider aws cbx_78430ca504ee`.
- `bun run crabbox:run -- --provider blacksmith-testbox --shell -- 'VITE_CONVEX_URL=https://example.invalid bunx vitest run ... && bun run ci:static'` stayed queued for several minutes and was stopped locally before execution.
