### PR TITLE
fix: clarify CLI sync and package publish paths

### DIFF
--- a/packages/clawhub/src/cli/commands/github.test.ts
+++ b/packages/clawhub/src/cli/commands/github.test.ts
@@ -213,6 +213,32 @@ describe("github publish source helpers", () => {
     }
   });
 
+  it("prefers an existing local path from an alternate workdir", async () => {
+    const workspace = await makeTmpDir();
+    const callerCwd = await makeTmpDir();
+    try {
+      const localDir = join(callerCwd, "plugin");
+      await mkdir(localDir, { recursive: true });
+
+      await expect(
+        resolveSourceInput(".", { workdir: workspace, localWorkdirs: [callerCwd, workspace] }),
+      ).resolves.toEqual({
+        kind: "local",
+        path: callerCwd,
+      });
+
+      await expect(
+        resolveSourceInput("plugin", { workdir: workspace, localWorkdirs: [callerCwd, workspace] }),
+      ).resolves.toEqual({
+        kind: "local",
+        path: localDir,
+      });
+    } finally {
+      await rm(callerCwd, { recursive: true, force: true });
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   it("resolves git metadata for a nested folder in a real git repo", async () => {
     const root = await makeTmpDir();
     try {

--- a/packages/clawhub/src/cli/commands/github.ts
+++ b/packages/clawhub/src/cli/commands/github.ts
@@ -46,10 +46,11 @@ type FetchedGitHubSource = {
 
 export async function resolveSourceInput(
   input: string,
-  options: { workdir: string },
+  options: { workdir: string; localWorkdirs?: string[] },
 ): Promise<ResolvedPublishSource> {
   const trimmed = input.trim();
   if (!trimmed) throw new Error("Path required");
+  const localWorkdirs = normalizeLocalWorkdirs(options.workdir, options.localWorkdirs);
 
   if (trimmed.startsWith("https://")) {
     return await parseGitHubUrl(trimmed);
@@ -57,15 +58,24 @@ export async function resolveSourceInput(
 
   const shorthand = parseGitHubShorthand(trimmed);
   if (shorthand) {
-    const localPath = resolveLocalPath(options.workdir, trimmed);
-    const localStat = await stat(localPath).catch(() => null);
-    if (localStat?.isDirectory()) {
-      return { kind: "local", path: localPath };
+    for (const workdir of localWorkdirs) {
+      const localPath = resolveLocalPath(workdir, trimmed);
+      const localStat = await stat(localPath).catch(() => null);
+      if (localStat?.isDirectory()) {
+        return { kind: "local", path: localPath };
+      }
     }
     return shorthand;
   }
 
-  return { kind: "local", path: resolveLocalPath(options.workdir, trimmed) };
+  for (const workdir of localWorkdirs) {
+    const localPath = resolveLocalPath(workdir, trimmed);
+    if (await stat(localPath).catch(() => null)) {
+      return { kind: "local", path: localPath };
+    }
+  }
+
+  return { kind: "local", path: resolveLocalPath(localWorkdirs[0] ?? options.workdir, trimmed) };
 }
 
 export async function fetchGitHubSource(
@@ -237,6 +247,11 @@ function resolveLocalPath(workdir: string, input: string) {
   if (input === "~") return homedir();
   if (input.startsWith("~/")) return resolve(homedir(), input.slice(2));
   return resolve(workdir, input);
+}
+
+function normalizeLocalWorkdirs(workdir: string, localWorkdirs?: string[]) {
+  const values = localWorkdirs?.length ? localWorkdirs : [workdir];
+  return Array.from(new Set(values.map((value) => resolve(value))));
 }
 
 function normalizePath(pathValue: string) {

--- a/packages/clawhub/src/cli/commands/packages.test.ts
+++ b/packages/clawhub/src/cli/commands/packages.test.ts
@@ -1055,6 +1055,47 @@ describe("package commands", () => {
     }
   });
 
+  it("resolves package publish dot paths from the caller cwd before the OpenClaw workdir", async () => {
+    const workspace = await makeTmpWorkdir();
+    const pluginRoot = await makeTmpWorkdir();
+    const previousCwd = process.cwd();
+    try {
+      await mkdir(join(pluginRoot, "dist"), { recursive: true });
+      await writeFile(
+        join(pluginRoot, "package.json"),
+        makeCodePluginPackageJson({
+          name: "@scope/cwd-plugin",
+          displayName: "Cwd Plugin",
+          version: "1.0.0",
+          files: ["dist", "openclaw.plugin.json"],
+        }),
+        "utf8",
+      );
+      await writeFile(
+        join(pluginRoot, "openclaw.plugin.json"),
+        JSON.stringify({ id: "cwd.plugin", configSchema: { type: "object" } }),
+        "utf8",
+      );
+      await writeFile(join(pluginRoot, "dist", "index.js"), "export const demo = true;\n", "utf8");
+
+      process.chdir(pluginRoot);
+
+      await cmdPublishPackage(makeOpts(workspace), ".", {
+        dryRun: true,
+        sourceRepo: "openclaw/cwd-plugin",
+        sourceCommit: "abc123",
+      });
+
+      const output = mockLog.mock.calls.map((call) => String(call[0])).join("\n");
+      expect(output).toContain("Name:      @scope/cwd-plugin");
+      expect(output).toContain("Files:     3");
+    } finally {
+      process.chdir(previousCwd);
+      await rm(pluginRoot, { recursive: true, force: true });
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
   it("rejects oversized clawscan notes before uploading package files", async () => {
     const workdir = await makeTmpWorkdir();
     try {

--- a/packages/clawhub/src/cli/commands/packages.ts
+++ b/packages/clawhub/src/cli/commands/packages.ts
@@ -494,7 +494,12 @@ export async function cmdPackPackage(
   options: PackagePackOptions = {},
 ) {
   if (!sourceArg?.trim()) fail("Path required");
-  const sourcePath = resolve(opts.workdir, sourceArg);
+  const resolvedSource = await resolveSourceInput(sourceArg, {
+    workdir: opts.workdir,
+    localWorkdirs: [process.cwd(), opts.workdir],
+  });
+  if (resolvedSource.kind !== "local") fail("Path must be a package folder");
+  const sourcePath = resolvedSource.path;
   const sourceStat = await stat(sourcePath).catch(() => null);
   if (!sourceStat?.isDirectory()) fail("Path must be a package folder");
 
@@ -1592,7 +1597,10 @@ async function preparePackagePublishPlan(
   sourceArg: string,
   options: PackagePublishOptions,
 ): Promise<PackagePublishPlan> {
-  const resolvedSource = await resolveSourceInput(sourceArg, { workdir: opts.workdir });
+  const resolvedSource = await resolveSourceInput(sourceArg, {
+    workdir: opts.workdir,
+    localWorkdirs: [process.cwd(), opts.workdir],
+  });
   const sourceForFetch = applyGitHubSourcePath(resolvedSource, options.sourcePath);
   let folder = sourceForFetch.kind === "local" ? sourceForFetch.path : "";
   let cleanup: (() => Promise<void>) | undefined;

--- a/packages/clawhub/src/cli/commands/sync.test.ts
+++ b/packages/clawhub/src/cli/commands/sync.test.ts
@@ -189,6 +189,35 @@ describe("cmdSync", () => {
     expect(mockCmdPublish).toHaveBeenCalledTimes(2);
   });
 
+  it("labels unmatched local content as proposed publish versions, not registry updates", async () => {
+    interactive = false;
+    mockApiRequest.mockImplementation(async (_registry: string, args: { path: string }) => {
+      if (args.path === "/api/v1/whoami") return { user: { handle: "steipete" } };
+      if (args.path === "/api/cli/telemetry/sync") return { ok: true };
+      if (args.path.startsWith("/api/v1/resolve?")) {
+        const u = new URL(`https://x.test${args.path}`);
+        const slug = u.searchParams.get("slug");
+        if (slug === "new-skill") {
+          throw new Error("Skill not found");
+        }
+        if (slug === "synced-skill") {
+          return { match: { version: "1.2.3" }, latestVersion: { version: "1.2.3" } };
+        }
+        if (slug === "update-skill") {
+          return { match: null, latestVersion: { version: "1.0.0" } };
+        }
+      }
+      throw new Error(`Unexpected apiRequest: ${args.path}`);
+    });
+
+    await cmdSync(makeOpts(), { root: ["/scan"], all: true, dryRun: true }, true);
+
+    const output = mockLog.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(output).toMatch(/update-skill\s+LOCAL CHANGES latest 1\.0\.0; publish 1\.0\.1/);
+    expect(output).toMatch(/new-skill\s+NEW \(publish 1\.0\.0\)/);
+    expect(output).not.toMatch(/UPDATE 1\.0\.0/);
+  });
+
   it("shows condensed synced list when nothing to sync", async () => {
     interactive = false;
     mockApiRequest.mockImplementation(async (_registry: string, args: { path: string }) => {

--- a/packages/clawhub/src/cli/commands/syncHelpers.ts
+++ b/packages/clawhub/src/cli/commands/syncHelpers.ts
@@ -370,11 +370,11 @@ export function dedupeSkillsBySlug(skills: SkillFolder[]) {
 }
 
 function formatActionableStatus(candidate: Candidate, bump: "patch" | "minor" | "major"): string {
-  if (candidate.status === "new") return "NEW";
+  if (candidate.status === "new") return "NEW (publish 1.0.0)";
   const latest = candidate.latestVersion;
   const next = latest ? semver.inc(latest, bump) : null;
-  if (latest && next) return `UPDATE ${latest} → ${next}`;
-  return "UPDATE";
+  if (latest && next) return `LOCAL CHANGES latest ${latest}; publish ${next}`;
+  return "LOCAL CHANGES";
 }
 
 export function formatActionableLine(


### PR DESCRIPTION
## Summary
- Clarify `clawhub sync` output so unmatched local content is shown as local changes with a proposed publish version, not as an available registry update.
- Resolve local package publish/pack source paths from the caller cwd before falling back to the resolved OpenClaw workdir, so `clawhub package publish .` works from plugin folders even when global workdir points elsewhere.
- Add focused regressions for both paths.

Fixes #618.
Fixes #1226.

## Validation
- `bunx vitest run -c vitest.config.ts src/cli/commands/sync.test.ts` from `packages/clawhub`
- `bunx vitest run -c vitest.config.ts src/cli/commands/github.test.ts src/cli/commands/packages.test.ts` from `packages/clawhub`
- `bun run format:check -- packages/clawhub/src/cli/commands/github.ts packages/clawhub/src/cli/commands/github.test.ts packages/clawhub/src/cli/commands/packages.ts packages/clawhub/src/cli/commands/packages.test.ts packages/clawhub/src/cli/commands/syncHelpers.ts packages/clawhub/src/cli/commands/sync.test.ts`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bun run lint`
- `bun run ci:packages`
