### PR TITLE
Add category-aware related skills

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,12 @@ For website/UI changes, attach screenshots or recordings from the real app. Incl
 
 - [ ] Screenshots/recordings attached, or `N/A`
 
+## Behavioural Proof
+
+Describe how you verified the user-facing behavior. For UI changes, include the path tested and what changed on screen. For backend/API changes, include the request, command, or scenario that proves the behavior.
+
+- [ ] Behavioural proof included, or `N/A`
+
 ## Security / Trust Impact
 
 - [ ] No security/trust impact

--- a/convex/skills.publicListCursor.test.ts
+++ b/convex/skills.publicListCursor.test.ts
@@ -18,7 +18,7 @@ vi.mock("convex-helpers/server/pagination", async () => {
 });
 
 const pagination = await import("convex-helpers/server/pagination");
-const { listPublicApiPageV1, listPublicPageV4 } = await import("./skills");
+const { listPublicApiPageV1, listPublicPageV4, listRelatedByCategory } = await import("./skills");
 
 type WrappedHandler<TArgs, TResult> = {
   _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
@@ -32,6 +32,9 @@ type PublicListArgs = {
   highlightedOnly?: boolean;
   nonSuspiciousOnly?: boolean;
   capabilityTag?: string;
+  categorySlug?: string;
+  categoryKeywords?: string[];
+  excludeCategoryKeywords?: string[];
 };
 
 type PublicListResult = {
@@ -51,6 +54,12 @@ const listPublicPageV4Handler = (
 )._handler;
 const listPublicApiPageV1Handler = (
   listPublicApiPageV1 as unknown as WrappedHandler<PublicListArgs, PublicApiListResult>
+)._handler;
+const listRelatedByCategoryHandler = (
+  listRelatedByCategory as unknown as WrappedHandler<
+    { skillId: string; categorySlug?: string; keywords: string[]; limit?: number },
+    { items: Array<{ skill: { slug: string }; ownerHandle: string | null }> }
+  >
 )._handler;
 
 function legacyCursor(key: unknown[]): string {
@@ -151,5 +160,258 @@ describe("public skill list deterministic cursors", () => {
       startIndexKey: [undefined],
       startInclusive: true,
     });
+  });
+
+  it("applies token-based category filters while scanning public list pages", async () => {
+    getPageMock.mockResolvedValueOnce({
+      page: [
+        makeDigest({
+          slug: "navigation-without-screens",
+          displayName: "Navigation Without Screens",
+          summary: "Physical navigation skills without digital devices.",
+          statsDownloads: 22,
+        }),
+        makeDigest({
+          slug: "developer-utils",
+          displayName: "Developer Utils",
+          summary: "Utilities for build and debug workflows.",
+          statsDownloads: 21,
+        }),
+      ],
+      hasMore: false,
+      indexKeys: [
+        [undefined, 22, 1],
+        [undefined, 21, 2],
+      ],
+    });
+
+    const result = await listPublicPageV4Handler(
+      {} as never,
+      {
+        categoryKeywords: ["dev", "debug", "lint", "test", "build"],
+        categorySlug: "dev-tools",
+        nonSuspiciousOnly: false,
+        numItems: 10,
+        sort: "downloads",
+      } as PublicListArgs,
+    );
+
+    expect(getPageMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        absoluteMaxRows: expect.any(Number),
+        index: "by_active_stats_downloads",
+      }),
+    );
+    expect(
+      (result.page as Array<{ skill: { slug: string } }>).map((entry) => entry.skill.slug),
+    ).toEqual(["developer-utils"]);
+  });
+
+  it("continues filtered public list pagination across empty scan windows", async () => {
+    const emptySecurityWindow = (downloads: number) => ({
+      page: [
+        makeDigest({
+          slug: `weather-helper-${downloads}`,
+          displayName: "Weather Helper",
+          summary: "Get current forecasts.",
+          statsDownloads: downloads,
+        }),
+      ],
+      hasMore: true,
+      indexKeys: [[undefined, downloads, downloads]],
+    });
+    getPageMock
+      .mockResolvedValueOnce(emptySecurityWindow(30))
+      .mockResolvedValueOnce(emptySecurityWindow(29))
+      .mockResolvedValueOnce(emptySecurityWindow(28))
+      .mockResolvedValueOnce(emptySecurityWindow(27));
+
+    const result = await listPublicPageV4Handler({} as never, {
+      categoryKeywords: ["security", "scan", "auth", "encrypt"],
+      categorySlug: "security",
+      nonSuspiciousOnly: false,
+      numItems: 10,
+      sort: "downloads",
+    });
+
+    expect(result.page).toEqual([]);
+    expect(result.hasMore).toBe(true);
+    expect(result.nextCursor).toBeTruthy();
+  });
+});
+
+function makeDigest(overrides: Record<string, unknown>) {
+  return {
+    _id: `skillSearchDigest:${String(overrides.slug)}`,
+    _creationTime: 0,
+    skillId: `skills:${String(overrides.slug)}`,
+    slug: String(overrides.slug),
+    displayName: String(overrides.displayName ?? overrides.slug),
+    summary: overrides.summary,
+    ownerUserId: "users:owner",
+    ownerPublisherId: "publishers:owner",
+    ownerHandle: "owner",
+    ownerKind: "user",
+    ownerDisplayName: "Owner",
+    tags: {},
+    badges: {},
+    stats: {
+      downloads: 0,
+      installsCurrent: 0,
+      installsAllTime: 0,
+      stars: 0,
+      versions: 1,
+      comments: 0,
+    },
+    statsDownloads: overrides.statsDownloads ?? 0,
+    statsStars: 0,
+    statsInstallsCurrent: 0,
+    statsInstallsAllTime: 0,
+    softDeletedAt: overrides.softDeletedAt,
+    moderationStatus: overrides.moderationStatus ?? "active",
+    moderationFlags: overrides.moderationFlags,
+    isSuspicious: overrides.isSuspicious,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+describe("skills.listRelatedByCategory", () => {
+  it("uses an indexed bounded digest query and returns matching public category skills", async () => {
+    const digests = [
+      makeDigest({
+        skillId: "skills:current",
+        slug: "workflow-runner",
+        displayName: "Workflow Runner",
+        summary: "Build workflow pipelines.",
+      }),
+      makeDigest({
+        slug: "pipeline-builder",
+        displayName: "Pipeline Builder",
+        summary: "Compose workflow automations.",
+        statsDownloads: 20,
+      }),
+      makeDigest({
+        slug: "calendar",
+        displayName: "Calendar",
+        summary: "Track meetings.",
+        statsDownloads: 18,
+      }),
+      makeDigest({
+        slug: "hidden-workflow",
+        displayName: "Hidden Workflow",
+        summary: "Workflow helper.",
+        moderationStatus: "hidden",
+        statsDownloads: 16,
+      }),
+      makeDigest({
+        slug: "suspicious-workflow",
+        displayName: "Suspicious Workflow",
+        summary: "Workflow helper.",
+        moderationFlags: ["flagged.suspicious"],
+        isSuspicious: true,
+        statsDownloads: 14,
+      }),
+      makeDigest({
+        slug: "workflow-audit",
+        displayName: "Workflow Audit",
+        summary: "Review workflow runs.",
+        statsDownloads: 12,
+      }),
+    ];
+    const take = vi.fn().mockResolvedValue(digests);
+    const order = vi.fn(() => ({ take }));
+    const eq = vi.fn(() => ({ eq }));
+    const withIndex = vi.fn((_index: string, builder: (q: { eq: typeof eq }) => void) => {
+      builder({ eq });
+      return { order };
+    });
+    const query = vi.fn((table: string) => {
+      if (table !== "skillSearchDigest") throw new Error(`Unexpected query table: ${table}`);
+      return { withIndex };
+    });
+
+    const result = await listRelatedByCategoryHandler({ db: { query } } as never, {
+      skillId: "skills:current",
+      keywords: ["workflow"],
+      limit: 2,
+    });
+
+    expect(withIndex).toHaveBeenCalledWith("by_active_stats_downloads", expect.any(Function));
+    expect(eq).toHaveBeenCalledWith("softDeletedAt", undefined);
+    expect(order).toHaveBeenCalledWith("desc");
+    expect(take).toHaveBeenCalledWith(expect.any(Number));
+    expect(result.items.map((entry) => entry.skill.slug)).toEqual([
+      "pipeline-builder",
+      "workflow-audit",
+    ]);
+    expect(result.items[0]?.ownerHandle).toBe("owner");
+  });
+
+  it("does not match generated dev slug prefixes as Dev Tools suggestions", async () => {
+    const digests = [
+      makeDigest({
+        skillId: "skills:current",
+        slug: "debug-helper",
+        displayName: "Debug Helper",
+        summary: "Debug build failures.",
+      }),
+      makeDigest({
+        slug: "navigation-without-screens",
+        displayName: "Navigation Without Screens",
+        summary: "Physical navigation skills without digital devices.",
+        statsDownloads: 22,
+      }),
+      makeDigest({
+        slug: "developer-utils",
+        displayName: "Developer Utils",
+        summary: "Utilities for build and debug workflows.",
+        statsDownloads: 21,
+      }),
+      makeDigest({
+        slug: "web3-dev",
+        displayName: "Blockscout for Web3 Dev",
+        summary:
+          "Build web3 applications that need blockchain data via the Blockscout PRO API over HTTP.",
+        statsDownloads: 19,
+      }),
+      makeDigest({
+        slug: "dev-jh86ceyb-weather-helper",
+        displayName: "Weather Helper",
+        summary: "Get current forecasts.",
+        statsDownloads: 20,
+      }),
+      makeDigest({
+        slug: "build-runner",
+        displayName: "Build Runner",
+        summary: "Run build checks.",
+        statsDownloads: 18,
+      }),
+    ];
+    const take = vi.fn().mockResolvedValue(digests);
+    const order = vi.fn(() => ({ take }));
+    const eq = vi.fn(() => ({ eq }));
+    const withIndex = vi.fn((_index: string, builder: (q: { eq: typeof eq }) => void) => {
+      builder({ eq });
+      return { order };
+    });
+    const query = vi.fn((table: string) => {
+      if (table !== "skillSearchDigest") throw new Error(`Unexpected query table: ${table}`);
+      return { withIndex };
+    });
+
+    const result = await listRelatedByCategoryHandler({ db: { query } } as never, {
+      skillId: "skills:current",
+      categorySlug: "dev-tools",
+      keywords: ["dev", "debug", "lint", "test", "build"],
+      limit: 3,
+    });
+
+    expect(result.items.map((entry) => entry.skill.slug)).toEqual([
+      "developer-utils",
+      "build-runner",
+    ]);
   });
 });

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -141,6 +141,9 @@ const MAX_LIST_TAKE = 1000;
 const MAX_SKILL_CATALOG_SCAN_DOCUMENTS = 500;
 const MAX_SKILL_CATALOG_SCAN_PAGES = 6;
 const MAX_SKILL_CATALOG_SEARCH_PAGE_SIZE = 200;
+const DEFAULT_RELATED_CATEGORY_SKILL_LIMIT = 5;
+const MAX_RELATED_CATEGORY_SKILL_LIMIT = 8;
+const MAX_RELATED_CATEGORY_SCAN_ROWS = 240;
 const HARD_DELETE_BATCH_SIZE = 100;
 const HARD_DELETE_VERSION_BATCH_SIZE = 10;
 const HARD_DELETE_LEADERBOARD_BATCH_SIZE = 25;
@@ -4238,11 +4241,19 @@ export const listPublicPageV4 = query({
     highlightedOnly: v.optional(v.boolean()),
     nonSuspiciousOnly: v.optional(v.boolean()),
     capabilityTag: v.optional(v.string()),
+    categorySlug: v.optional(v.string()),
+    categoryKeywords: v.optional(v.array(v.string())),
+    excludeCategoryKeywords: v.optional(v.array(v.string())),
   },
   handler: async (ctx, args) => {
     if (args.capabilityTag && !isKnownSkillCapabilityTag(args.capabilityTag)) {
       return { page: [], hasMore: false, nextCursor: null };
     }
+    const categoryKeywords = normalizeRelatedCategoryKeywords(args.categoryKeywords ?? []);
+    const excludeCategoryKeywords = normalizeRelatedCategoryKeywords(
+      args.excludeCategoryKeywords ?? [],
+    );
+    const categorySlug = normalizeRelatedCategorySlug(args.categorySlug);
     const sort = args.sort ?? "newest";
     const dir = args.dir ?? (sort === "name" ? "asc" : "desc");
     const numItems = clampInt(args.numItems ?? 25, 1, MAX_PUBLIC_LIST_LIMIT);
@@ -4256,6 +4267,9 @@ export const listPublicPageV4 = query({
         dir,
         numItems,
         capabilityTag: args.capabilityTag,
+        categorySlug,
+        categoryKeywords,
+        excludeCategoryKeywords,
         nonSuspiciousOnly: args.nonSuspiciousOnly ?? false,
       });
     }
@@ -4278,7 +4292,13 @@ export const listPublicPageV4 = query({
     const isFirstPage = !decodedCursor;
     const startIndexKey: IndexKey = decodedCursor ?? eqPrefix;
 
-    if (!args.capabilityTag) {
+    const hasDigestFilters =
+      Boolean(args.capabilityTag) ||
+      Boolean(categorySlug) ||
+      categoryKeywords.length > 0 ||
+      excludeCategoryKeywords.length > 0;
+
+    if (!hasDigestFilters) {
       const result = await getPage(ctx, {
         table: "skillSearchDigest",
         startIndexKey,
@@ -4336,7 +4356,14 @@ export const listPublicPageV4 = query({
       for (let index = 0; index < result.page.length; index += 1) {
         const digest = result.page[index];
         const cursor = result.indexKeys[index];
-        if ((digest.capabilityTags ?? []).includes(args.capabilityTag)) {
+        if (
+          digestPassesPublicListFilters(digest, {
+            capabilityTag: args.capabilityTag,
+            categorySlug,
+            categoryKeywords,
+            excludeCategoryKeywords,
+          })
+        ) {
           const item = buildPublicSkillEntryFromDigest(digest);
           if (item) items.push(item);
         }
@@ -4359,15 +4386,191 @@ export const listPublicPageV4 = query({
       nextCursor = encodeIndexKey(indexName, scanCursor);
     }
 
-    // Guard: never signal more pages when the scan budget is exhausted
-    // without finding any items — that would cause the client's
-    // IntersectionObserver auto-load to loop on empty responses.
-    if (items.length === 0) {
-      hasMore = false;
-      nextCursor = null;
+    return { page: items, hasMore, nextCursor };
+  },
+});
+
+const SERVER_SKILL_CATEGORIES = [
+  { slug: "mcp-tools", keywords: ["mcp", "tool", "server"] },
+  { slug: "prompts", keywords: ["prompt", "template", "system"] },
+  { slug: "workflows", keywords: ["workflow", "pipeline", "chain"] },
+  { slug: "dev-tools", keywords: ["dev", "debug", "lint", "test", "build"] },
+  { slug: "data", keywords: ["api", "data", "fetch", "http", "rest", "graphql"] },
+  { slug: "security", keywords: ["security", "scan", "auth", "encrypt"] },
+  { slug: "automation", keywords: ["auto", "cron", "schedule", "bot"] },
+] as const;
+
+const SERVER_SKILL_CATEGORY_SLUGS = new Set<string>([
+  ...SERVER_SKILL_CATEGORIES.map((category) => category.slug),
+  "other",
+]);
+
+type ServerSkillCategorySlug = (typeof SERVER_SKILL_CATEGORIES)[number]["slug"] | "other";
+
+function normalizeRelatedCategorySlug(categorySlug: string | undefined) {
+  const value = categorySlug?.trim().toLowerCase();
+  return value && SERVER_SKILL_CATEGORY_SLUGS.has(value)
+    ? (value as ServerSkillCategorySlug)
+    : null;
+}
+
+function normalizeRelatedCategoryKeywords(keywords: string[]) {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const keyword of keywords) {
+    const value = keyword.trim().toLowerCase();
+    if (!value || value.length > 40 || seen.has(value)) continue;
+    seen.add(value);
+    normalized.push(value);
+    if (normalized.length >= 12) break;
+  }
+
+  return normalized;
+}
+
+function stripGeneratedRelatedSlugPrefixTokens(tokens: string[]) {
+  if (tokens[0] !== "dev") return tokens;
+  const maybeGeneratedId = tokens[1];
+  if (!maybeGeneratedId || maybeGeneratedId.length < 7 || !/\d/.test(maybeGeneratedId)) {
+    return tokens;
+  }
+  return tokens.slice(2);
+}
+
+function relatedTokenMatchesKeyword(token: string, keyword: string) {
+  if (token === keyword) return true;
+  if (keyword === "dev") {
+    return token === "developer" || token === "development" || token === "devops";
+  }
+  if (keyword === "api") {
+    return token === "apis";
+  }
+  return keyword.length >= 4 && token.includes(keyword);
+}
+
+function digestMatchesRelatedCategory(
+  digest: Pick<Doc<"skillSearchDigest">, "slug" | "displayName" | "summary" | "capabilityTags">,
+  keywords: string[],
+) {
+  const primaryTokens = tokenize(
+    [digest.displayName, digest.summary ?? "", ...(digest.capabilityTags ?? [])].join(" "),
+  );
+  const slugTokens = stripGeneratedRelatedSlugPrefixTokens(tokenize(digest.slug));
+
+  return keywords.some(
+    (keyword) =>
+      primaryTokens.some((token) => relatedTokenMatchesKeyword(token, keyword)) ||
+      slugTokens.some((token) => relatedTokenMatchesKeyword(token, keyword)),
+  );
+}
+
+function scoreDigestSkillCategory(
+  primaryTokens: string[],
+  slugTokens: string[],
+  category: (typeof SERVER_SKILL_CATEGORIES)[number],
+) {
+  return category.keywords.reduce((score, keyword) => {
+    const primaryScore = primaryTokens.some((token) => relatedTokenMatchesKeyword(token, keyword))
+      ? 2
+      : 0;
+    const slugScore = slugTokens.some((token) => relatedTokenMatchesKeyword(token, keyword))
+      ? 1
+      : 0;
+    return score + primaryScore + slugScore;
+  }, 0);
+}
+
+function inferDigestSkillCategorySlug(
+  digest: Pick<Doc<"skillSearchDigest">, "slug" | "displayName" | "summary" | "capabilityTags">,
+): ServerSkillCategorySlug {
+  const primaryTokens = tokenize(
+    [digest.displayName, digest.summary ?? "", ...(digest.capabilityTags ?? [])].join(" "),
+  );
+  const slugTokens = stripGeneratedRelatedSlugPrefixTokens(tokenize(digest.slug));
+  let bestSlug: ServerSkillCategorySlug = "other";
+  let bestScore = 0;
+
+  for (const category of SERVER_SKILL_CATEGORIES) {
+    const score = scoreDigestSkillCategory(primaryTokens, slugTokens, category);
+    if (score > bestScore) {
+      bestSlug = category.slug;
+      bestScore = score;
+    }
+  }
+
+  return bestSlug;
+}
+
+function digestPassesPublicListFilters(
+  digest: Doc<"skillSearchDigest">,
+  opts: {
+    capabilityTag?: string;
+    categorySlug: ServerSkillCategorySlug | null;
+    categoryKeywords: string[];
+    excludeCategoryKeywords: string[];
+  },
+) {
+  if (opts.capabilityTag && !(digest.capabilityTags ?? []).includes(opts.capabilityTag)) {
+    return false;
+  }
+  if (opts.categorySlug && inferDigestSkillCategorySlug(digest) !== opts.categorySlug) {
+    return false;
+  }
+  if (
+    opts.categoryKeywords.length > 0 &&
+    !digestMatchesRelatedCategory(digest, opts.categoryKeywords)
+  ) {
+    return false;
+  }
+  if (
+    opts.excludeCategoryKeywords.length > 0 &&
+    digestMatchesRelatedCategory(digest, opts.excludeCategoryKeywords)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export const listRelatedByCategory = query({
+  args: {
+    skillId: v.id("skills"),
+    categorySlug: v.optional(v.string()),
+    keywords: v.array(v.string()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const keywords = normalizeRelatedCategoryKeywords(args.keywords);
+    const categorySlug = normalizeRelatedCategorySlug(args.categorySlug);
+    if (keywords.length === 0) return { items: [] };
+
+    const limit = clampInt(
+      args.limit ?? DEFAULT_RELATED_CATEGORY_SKILL_LIMIT,
+      1,
+      MAX_RELATED_CATEGORY_SKILL_LIMIT,
+    );
+    const scanLimit = Math.min(MAX_RELATED_CATEGORY_SCAN_ROWS, Math.max(80, limit * 24));
+
+    const digests = await ctx.db
+      .query("skillSearchDigest")
+      .withIndex("by_active_stats_downloads", (q) => q.eq("softDeletedAt", undefined))
+      .order("desc")
+      .take(scanLimit);
+
+    const items: PublicSkillEntry[] = [];
+    for (const digest of digests) {
+      if (digest.skillId === args.skillId) continue;
+      const hydratable = digestToHydratableSkill(digest);
+      if (isSkillSuspicious(hydratable)) continue;
+      if (categorySlug && inferDigestSkillCategorySlug(digest) !== categorySlug) continue;
+      if (!digestMatchesRelatedCategory(digest, keywords)) continue;
+      const item = buildPublicSkillEntryFromDigest(digest);
+      if (!item) continue;
+      items.push(item);
+      if (items.length >= limit) break;
     }
 
-    return { page: items, hasMore, nextCursor };
+    return { items };
   },
 });
 
@@ -4958,6 +5161,9 @@ async function fetchHighlightedPage(
     dir: "asc" | "desc";
     numItems: number;
     capabilityTag?: string;
+    categorySlug: ServerSkillCategorySlug | null;
+    categoryKeywords: string[];
+    excludeCategoryKeywords: string[];
     nonSuspiciousOnly: boolean;
   },
 ) {
@@ -4977,7 +5183,16 @@ async function fetchHighlightedPage(
       .unique();
     if (!digest || digest.softDeletedAt) continue;
     if (opts.nonSuspiciousOnly && digest.isSuspicious) continue;
-    if (opts.capabilityTag && !(digest.capabilityTags ?? []).includes(opts.capabilityTag)) continue;
+    if (
+      !digestPassesPublicListFilters(digest, {
+        capabilityTag: opts.capabilityTag,
+        categorySlug: opts.categorySlug,
+        categoryKeywords: opts.categoryKeywords,
+        excludeCategoryKeywords: opts.excludeCategoryKeywords,
+      })
+    ) {
+      continue;
+    }
     digests.push(digest);
   }
 

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -169,6 +169,116 @@ describe("SkillDetailPage", () => {
     expect(screen.queryByRole("button", { name: "Compare" })).toBeNull();
   });
 
+  it("renders related skills from the inferred category with a browse link", async () => {
+    useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
+      if (args === "skip") return undefined;
+      if (
+        args &&
+        typeof args === "object" &&
+        "keywords" in args &&
+        Array.isArray((args as { keywords?: unknown }).keywords)
+      ) {
+        return {
+          items: [
+            {
+              skill: {
+                _id: "skills:2" as Id<"skills">,
+                _creationTime: 0,
+                slug: "pipeline-builder",
+                displayName: "Pipeline Builder",
+                summary: "Compose agent workflow pipelines.",
+                ownerUserId: ownerId,
+                ownerPublisherId,
+                tags: {},
+                badges: {},
+                stats: {
+                  stars: 4,
+                  downloads: 12,
+                  installsCurrent: 1,
+                  installsAllTime: 3,
+                  versions: 1,
+                  comments: 0,
+                },
+                createdAt: 0,
+                updatedAt: 0,
+              },
+              latestVersion: null,
+              ownerHandle: "steipete",
+              owner: null,
+            },
+          ],
+        };
+      }
+      return undefined;
+    });
+
+    render(
+      <SkillDetailPage
+        slug="workflow-runner"
+        initialData={{
+          result: {
+            skill: {
+              _id: skillId,
+              _creationTime: 0,
+              slug: "workflow-runner",
+              displayName: "Workflow Runner",
+              summary: "Build repeatable agent workflow pipelines.",
+              ownerUserId: ownerId,
+              ownerPublisherId,
+              tags: {},
+              badges: {},
+              stats: {
+                stars: 12,
+                downloads: 34,
+                installsCurrent: 5,
+                installsAllTime: 8,
+                versions: 1,
+                comments: 0,
+              },
+              createdAt: 0,
+              updatedAt: 0,
+            },
+            owner: {
+              _id: ownerPublisherId,
+              _creationTime: 0,
+              kind: "user",
+              handle: "steipete",
+              displayName: "Peter",
+              linkedUserId: ownerId,
+            },
+            latestVersion: {
+              _id: versionId,
+              _creationTime: 0,
+              skillId,
+              version: "1.0.0",
+              fingerprint: "abc",
+              changelog: "Initial release",
+              parsed: { license: "MIT-0", frontmatter: {} },
+              files: [],
+              createdBy: ownerId,
+              createdAt: 0,
+            },
+            forkOf: null,
+            canonical: null,
+          },
+          readme: "# Workflow Runner",
+          readmeError: null,
+        }}
+      />,
+    );
+
+    expect(await screen.findByRole("heading", { name: "Related skills" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "View Workflows skills" }).getAttribute("href")).toBe(
+      "/skills?category=workflows",
+    );
+    expect(screen.getByRole("link", { name: "More in Workflows" }).getAttribute("href")).toBe(
+      "/skills?category=workflows",
+    );
+    expect(screen.getByRole("link", { name: /Pipeline Builder/i })).toBeTruthy();
+    expect(screen.getByText(/Compose agent workflow pipelines\./i)).toBeTruthy();
+    expect(screen.getByText("steipete/pipeline-builder")).toBeTruthy();
+  });
+
   it("renders the install surface above the security scan with visible prompts and commands", async () => {
     useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
       if (args === "skip") return undefined;

--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -295,6 +295,37 @@ describe("SkillsIndex", () => {
     expect(titles[1]).toBe("Newer Low Score");
   });
 
+  it("filters category browse results to the inferred skill category", async () => {
+    searchMock = { category: "dev-tools" };
+    convexHttpMock.query.mockResolvedValue({
+      page: [
+        makeListResult("web3-dev", "Blockscout for Web3 Dev", {
+          summary:
+            "Build web3 applications that need blockchain data via the Blockscout PRO API over HTTP.",
+        }),
+        makeListResult("developer-utils", "Developer Utils", {
+          summary: "Utilities for build and debug workflows.",
+        }),
+      ],
+      hasMore: false,
+      nextCursor: null,
+    });
+
+    render(<SkillsIndex />);
+    await act(async () => {});
+
+    expect(convexHttpMock.query).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        categorySlug: "dev-tools",
+        categoryKeywords: expect.arrayContaining(["dev"]),
+        excludeCategoryKeywords: undefined,
+      }),
+    );
+    expect(screen.queryByText("Blockscout for Web3 Dev")).toBeNull();
+    expect(screen.getByText("Developer Utils")).toBeTruthy();
+  });
+
   it("does not render the warning filter", async () => {
     convexHttpMock.query.mockResolvedValue({
       page: [makeListResult("clean-skill", "Clean Skill")],
@@ -363,14 +394,14 @@ describe("SkillsIndex", () => {
 function makeListResult(
   slug: string,
   displayName: string,
-  options: { isSuspicious?: boolean } = {},
+  options: { isSuspicious?: boolean; summary?: string } = {},
 ) {
   return {
     skill: {
       _id: `skill_${slug}`,
       slug,
       displayName,
-      summary: `${displayName} summary`,
+      summary: options.summary ?? `${displayName} summary`,
       tags: {},
       stats: {
         downloads: 0,

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { api } from "../../convex/_generated/api";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
 import { getUserFacingAuthError } from "../lib/authErrorMessage";
+import { getSkillCategoryForSkill } from "../lib/categories";
 import { getUserFacingConvexError } from "../lib/convexError";
 import { canManageSkill, isModerator } from "../lib/roles";
 import type { SkillBySlugResult, SkillPageInitialData } from "../lib/skillPage";
@@ -29,6 +30,7 @@ import {
 import { SkillHeader } from "./SkillHeader";
 import { buildSkillInstallTabs } from "./SkillInstallCard";
 import { SkillOwnershipPanel } from "./SkillOwnershipPanel";
+import { SkillRelatedSection, type RelatedSkillEntry } from "./SkillRelatedSection";
 import { SkillReportDialog } from "./SkillReportDialog";
 import { Alert, AlertDescription } from "./ui/alert";
 import { Card } from "./ui/card";
@@ -208,6 +210,21 @@ export function SkillDetailPage({
   const skill = result?.skill;
   const owner = result?.owner ?? null;
   const latestVersion = result?.latestVersion ?? null;
+  const relatedCategory = useMemo(() => (skill ? getSkillCategoryForSkill(skill) : null), [skill]);
+  const shouldLoadRelatedSkills = Boolean(
+    skill && relatedCategory && relatedCategory.keywords.length > 0,
+  );
+  const relatedSkillsResult = useQuery(
+    api.skills.listRelatedByCategory,
+    shouldLoadRelatedSkills && skill && relatedCategory
+      ? {
+          skillId: skill._id,
+          categorySlug: relatedCategory.slug,
+          keywords: relatedCategory.keywords,
+          limit: 5,
+        }
+      : "skip",
+  ) as { items: RelatedSkillEntry[] } | undefined;
 
   const versions = useQuery(
     api.skills.listVersions,
@@ -679,6 +696,7 @@ export function SkillDetailPage({
           configRequirements={configRequirements}
           cliHelp={cliHelp}
           clawdis={clawdis}
+          category={relatedCategory}
           priorityContent={priorityContent}
           newVersionHref={newVersionHref}
           settingsHref={settingsHref}
@@ -731,6 +749,12 @@ export function SkillDetailPage({
               />
             </ClientOnly>
           ) : null}
+
+          <SkillRelatedSection
+            category={relatedCategory}
+            relatedSkills={relatedSkillsResult?.items ?? []}
+            isLoading={shouldLoadRelatedSkills && relatedSkillsResult === undefined}
+          />
         </SkillHeader>
       </DetailPageShell>
 

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -5,6 +5,7 @@ import { Download, Flag, Settings, ShieldCheck, Star, Upload } from "lucide-reac
 import type { ReactNode } from "react";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
 import { getSkillBadges } from "../lib/badges";
+import { buildSkillCategoryBrowseHref, type SkillCategory } from "../lib/categories";
 import { formatSkillStatsTriplet } from "../lib/numberFormat";
 import type { PublicPublisher, PublicSkill } from "../lib/publicUser";
 import { getRuntimeEnv } from "../lib/runtimeEnv";
@@ -87,6 +88,7 @@ type SkillHeaderProps = {
   configRequirements: ClawdisSkillMetadata["config"] | undefined;
   cliHelp: string | undefined;
   clawdis: ClawdisSkillMetadata | undefined;
+  category?: SkillCategory | null;
   priorityContent?: ReactNode;
   newVersionHref?: string | null;
   settingsHref?: string | null;
@@ -118,6 +120,7 @@ export function SkillHeader({
   configRequirements,
   cliHelp,
   clawdis,
+  category,
   priorityContent,
   newVersionHref,
   settingsHref,
@@ -277,22 +280,33 @@ export function SkillHeader({
                   {skill.slug}
                 </a>
               </nav>
-              <div className="skill-hero-title-row">
-                <h1 className="skill-page-title">{skill.displayName}</h1>
-                {showTitleBadges ? (
-                  <div className="skill-title-badges">
-                    {badges.map((badge) =>
-                      badge === "Verified" ? (
-                        <VerifiedBadge key={badge} />
-                      ) : (
-                        <Badge key={badge} variant="compact">
-                          {badge}
-                        </Badge>
-                      ),
-                    )}
-                  </div>
+              <div className="skill-hero-heading-stack">
+                <div className="skill-hero-title-row">
+                  <h1 className="skill-page-title">{skill.displayName}</h1>
+                  {showTitleBadges ? (
+                    <div className="skill-title-badges">
+                      {badges.map((badge) =>
+                        badge === "Verified" ? (
+                          <VerifiedBadge key={badge} />
+                        ) : (
+                          <Badge key={badge} variant="compact">
+                            {badge}
+                          </Badge>
+                        ),
+                      )}
+                    </div>
+                  ) : null}
+                  {nixPlugin ? <Badge variant="accent">Plugin bundle (nix)</Badge> : null}
+                </div>
+                {category ? (
+                  <a
+                    className="skill-category-chip"
+                    href={buildSkillCategoryBrowseHref(category)}
+                    aria-label={`View ${category.label} skills`}
+                  >
+                    {category.label}
+                  </a>
                 ) : null}
-                {nixPlugin ? <Badge variant="accent">Plugin bundle (nix)</Badge> : null}
               </div>
               <div className="skill-summary-block">
                 <p className="section-subtitle skill-summary-line">{headerDescription}</p>

--- a/src/components/SkillRelatedSection.tsx
+++ b/src/components/SkillRelatedSection.tsx
@@ -1,0 +1,84 @@
+import { buildSkillCategoryBrowseHref, type SkillCategory } from "../lib/categories";
+import type { PublicPublisher, PublicSkill } from "../lib/publicUser";
+import { buildSkillHref } from "./skillDetailUtils";
+
+export type RelatedSkillEntry = {
+  skill: PublicSkill;
+  ownerHandle?: string | null;
+  owner?: PublicPublisher | null;
+};
+
+type SkillRelatedSectionProps = {
+  category: SkillCategory | null;
+  relatedSkills: RelatedSkillEntry[];
+  isLoading: boolean;
+};
+
+function ownerLabel(entry: RelatedSkillEntry) {
+  return (
+    entry.ownerHandle?.trim() ||
+    entry.owner?.handle?.trim() ||
+    String(entry.skill.ownerPublisherId ?? entry.skill.ownerUserId)
+  );
+}
+
+export function SkillRelatedSection({
+  category,
+  relatedSkills,
+  isLoading,
+}: SkillRelatedSectionProps) {
+  const visibleSkills = relatedSkills.slice(0, 5);
+  if (!category || (!isLoading && visibleSkills.length === 0)) return null;
+
+  return (
+    <section className="related-skills-section" aria-labelledby="related-skills-heading">
+      <div className="related-skills-header">
+        <h2 id="related-skills-heading" className="related-skills-title">
+          Related skills
+        </h2>
+        <a className="related-skills-category-link" href={buildSkillCategoryBrowseHref(category)}>
+          More in {category.label}
+        </a>
+      </div>
+      <div className="related-skills-list" aria-busy={isLoading}>
+        {isLoading
+          ? Array.from({ length: 3 }).map((_, index) => (
+              <div
+                key={`related-skill-skeleton-${index}`}
+                className="related-skill-row related-skill-row-skeleton"
+              >
+                <span className="related-skill-copy">
+                  <span className="related-skill-title-skeleton" />
+                  <span className="related-skill-summary-skeleton" />
+                </span>
+                <span className="related-skill-owner-skeleton" />
+              </div>
+            ))
+          : visibleSkills.map((entry) => {
+              const owner = ownerLabel(entry);
+              const ownerId =
+                entry.owner?._id ?? entry.skill.ownerPublisherId ?? entry.skill.ownerUserId;
+              const href = buildSkillHref(
+                entry.ownerHandle ?? entry.owner?.handle ?? null,
+                ownerId,
+                entry.skill.slug,
+              );
+
+              return (
+                <a key={entry.skill._id} href={href} className="related-skill-row">
+                  <span className="related-skill-copy">
+                    <span className="related-skill-name">{entry.skill.displayName}</span>
+                    {entry.skill.summary ? (
+                      <span className="related-skill-summary">{entry.skill.summary}</span>
+                    ) : null}
+                  </span>
+                  <span className="related-skill-owner">
+                    {owner}/{entry.skill.slug}
+                  </span>
+                </a>
+              );
+            })}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/categories.test.ts
+++ b/src/lib/categories.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSkillCategoryBrowseHref,
+  getSkillCategoryForSkill,
+  SKILL_CATEGORIES,
+} from "./categories";
+
+describe("skill category helpers", () => {
+  it("picks the strongest matching skill category from searchable skill fields", () => {
+    const category = getSkillCategoryForSkill({
+      slug: "workflow-runner",
+      displayName: "Workflow Runner",
+      summary: "Build repeatable agent pipelines.",
+    });
+
+    expect(category?.slug).toBe("workflows");
+  });
+
+  it("falls back to the Other category when no keyword matches", () => {
+    const category = getSkillCategoryForSkill({
+      slug: "weather",
+      displayName: "Weather",
+      summary: "Get current forecasts.",
+    });
+
+    expect(category?.slug).toBe("other");
+  });
+
+  it("does not let generated slug prefixes outweigh the skill summary", () => {
+    const category = getSkillCategoryForSkill({
+      slug: "dev-jh86ceyb-local-agentic-risk-demo",
+      displayName: "Local Agentic Risk Demo",
+      summary: "Local fixture for security bucket rendering.",
+    });
+
+    expect(category?.slug).toBe("security");
+  });
+
+  it("ignores generated dev slug prefixes when no skill content matches a category", () => {
+    const category = getSkillCategoryForSkill({
+      slug: "dev-jh86ceyb-weather-helper",
+      displayName: "Weather Helper",
+      summary: "Get current forecasts.",
+    });
+
+    expect(category?.slug).toBe("other");
+  });
+
+  it("does not classify unrelated digital device text as Dev Tools", () => {
+    const category = getSkillCategoryForSkill({
+      slug: "navigation-without-screens",
+      displayName: "Navigation Without Screens",
+      summary: "Physical navigation skills without digital devices. Use for learning maps.",
+    });
+
+    expect(category?.slug).toBe("other");
+  });
+
+  it("prefers Data & APIs when web3 developer wording is outweighed by API data terms", () => {
+    const category = getSkillCategoryForSkill({
+      slug: "web3-dev",
+      displayName: "Blockscout for Web3 Dev",
+      summary:
+        "Build web3 applications, scripts, CLIs, bots, mobile apps, and desktop apps that need blockchain data via the Blockscout PRO API over HTTP.",
+    });
+
+    expect(category?.slug).toBe("data");
+  });
+
+  it("still recognizes developer utility wording as Dev Tools", () => {
+    const category = getSkillCategoryForSkill({
+      slug: "developer-utils",
+      displayName: "Developer Utils",
+      summary: "Utilities for build and debug workflows.",
+    });
+
+    expect(category?.slug).toBe("dev-tools");
+  });
+
+  it("builds browse links from the category filter slug", () => {
+    const workflows = SKILL_CATEGORIES.find((category) => category.slug === "workflows");
+
+    expect(workflows ? buildSkillCategoryBrowseHref(workflows) : null).toBe(
+      "/skills?category=workflows",
+    );
+  });
+});

--- a/src/lib/categories.ts
+++ b/src/lib/categories.ts
@@ -63,3 +63,102 @@ export const PLUGIN_CATEGORIES: BrowseCategory[] = PLUGIN_CATEGORY_DEFINITIONS.m
 );
 
 export const ALL_CATEGORY_KEYWORDS = SKILL_CATEGORIES.flatMap((c) => c.keywords);
+
+type SkillCategoryCandidate = {
+  slug: string;
+  displayName: string;
+  summary?: string | null;
+  capabilityTags?: string[] | null;
+};
+
+const OTHER_SKILL_CATEGORY = SKILL_CATEGORIES.find((category) => category.slug === "other") ?? null;
+
+function normalizeCategoryText(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function tokenizeCategoryText(value: string) {
+  return normalizeCategoryText(value).match(/[a-z0-9]+/g) ?? [];
+}
+
+function categoryTokenMatchesKeyword(token: string, keyword: string) {
+  if (token === keyword) return true;
+  if (keyword === "dev") {
+    return token === "developer" || token === "development" || token === "devops";
+  }
+  if (keyword === "api") {
+    return token === "apis";
+  }
+  return keyword.length >= 4 && token.includes(keyword);
+}
+
+function stripGeneratedSlugPrefixTokens(tokens: string[]) {
+  if (tokens[0] !== "dev") return tokens;
+  const maybeGeneratedId = tokens[1];
+  if (!maybeGeneratedId || maybeGeneratedId.length < 7 || !/\d/.test(maybeGeneratedId)) {
+    return tokens;
+  }
+  return tokens.slice(2);
+}
+
+function getSkillCategoryPrimarySearchTokens(skill: SkillCategoryCandidate) {
+  return tokenizeCategoryText(
+    [skill.displayName, skill.summary ?? "", ...(skill.capabilityTags ?? [])].join(" "),
+  );
+}
+
+function scoreSkillCategory(
+  primaryTokens: string[],
+  slugTokens: string[],
+  category: SkillCategory,
+) {
+  return category.keywords.reduce((score, keyword) => {
+    const normalizedKeyword = normalizeCategoryText(keyword);
+    if (!normalizedKeyword) return score;
+    const primaryScore = primaryTokens.some((token) =>
+      categoryTokenMatchesKeyword(token, normalizedKeyword),
+    )
+      ? 2
+      : 0;
+    const slugScore = slugTokens.some((token) =>
+      categoryTokenMatchesKeyword(token, normalizedKeyword),
+    )
+      ? 1
+      : 0;
+    return score + primaryScore + slugScore;
+  }, 0);
+}
+
+export function getSkillCategoryForSkill(skill: SkillCategoryCandidate): SkillCategory | null {
+  const primaryTokens = getSkillCategoryPrimarySearchTokens(skill);
+  const slugTokens = stripGeneratedSlugPrefixTokens(tokenizeCategoryText(skill.slug));
+  let bestCategory: SkillCategory | null = null;
+  let bestScore = 0;
+
+  for (const category of SKILL_CATEGORIES) {
+    if (category.slug === "other") continue;
+    const score = scoreSkillCategory(primaryTokens, slugTokens, category);
+    if (score > bestScore) {
+      bestCategory = category;
+      bestScore = score;
+    }
+  }
+
+  return bestCategory ?? OTHER_SKILL_CATEGORY;
+}
+
+export function getSkillCategoryBySlug(slug: string | null | undefined) {
+  if (!slug) return null;
+  return SKILL_CATEGORIES.find((category) => category.slug === slug) ?? null;
+}
+
+export function getSkillCategoryByKeyword(keyword: string | null | undefined) {
+  const normalizedKeyword = keyword?.trim().toLowerCase();
+  if (!normalizedKeyword) return null;
+  return SKILL_CATEGORIES.find((category) => category.keywords.includes(normalizedKeyword)) ?? null;
+}
+
+export function buildSkillCategoryBrowseHref(category: SkillCategory) {
+  const params = new URLSearchParams({ category: category.slug });
+  return `/skills?${params.toString()}`;
+}

--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -2,7 +2,12 @@ import { useAction } from "convex/react";
 import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import { api } from "../../../convex/_generated/api";
 import { convexHttp } from "../../convex/client";
-import { ALL_CATEGORY_KEYWORDS } from "../../lib/categories";
+import {
+  ALL_CATEGORY_KEYWORDS,
+  getSkillCategoryByKeyword,
+  getSkillCategoryBySlug,
+  getSkillCategoryForSkill,
+} from "../../lib/categories";
 import { parseDir, parseSort, toListSort, type SortDir, type SortKey } from "./-params";
 import type { SkillListEntry, SkillSearchEntry } from "./-types";
 
@@ -30,6 +35,7 @@ export type SkillsSearchState = {
   dir?: SortDir;
   highlighted?: boolean;
   featured?: boolean;
+  category?: string;
   tag?: string;
   view?: LegacySkillsView;
   focus?: "search";
@@ -75,16 +81,25 @@ export function useSkillsBrowseModel({
   const capabilityTag = search.tag;
   const searchSkills = useAction(api.search.searchSkills);
 
-  const isOtherCategory = query === "__other__";
   const trimmedQuery = useMemo(() => query.trim(), [query]);
-  const hasQuery = !isOtherCategory && trimmedQuery.length > 0;
+  const legacyQueryCategory = useMemo(() => {
+    if (query === "__other__") return getSkillCategoryBySlug("other");
+    return getSkillCategoryByKeyword(trimmedQuery);
+  }, [query, trimmedQuery]);
+  const urlCategory = useMemo(() => getSkillCategoryBySlug(search.category), [search.category]);
+  const activeCategory = urlCategory ?? legacyQueryCategory;
+  const categoryKeywords =
+    activeCategory && activeCategory.slug !== "other" ? activeCategory.keywords : undefined;
+  const excludeCategoryKeywords =
+    activeCategory?.slug === "other" ? ALL_CATEGORY_KEYWORDS : undefined;
+  const hasQuery = trimmedQuery.length > 0 && (Boolean(urlCategory) || !legacyQueryCategory);
   const sort: SortKey =
     search.sort === "relevance" && !hasQuery
       ? "downloads"
       : (search.sort ?? (hasQuery ? "relevance" : "downloads"));
   const listSort = toListSort(sort);
   const dir = parseDir(search.dir, sort);
-  const searchKey = trimmedQuery
+  const searchKey = hasQuery
     ? `${trimmedQuery}::${featuredOnly ? "1" : "0"}::${capabilityTag ?? ""}`
     : "";
 
@@ -104,6 +119,9 @@ export function useSkillsBrowseModel({
           dir,
           highlightedOnly: featuredOnly,
           capabilityTag,
+          categorySlug: activeCategory?.slug,
+          categoryKeywords,
+          excludeCategoryKeywords,
         });
         if (generation !== fetchGeneration.current) return;
         setListResults((prev) => (cursor ? [...prev, ...result.page] : result.page));
@@ -119,7 +137,15 @@ export function useSkillsBrowseModel({
         setListStatus(cursor ? "idle" : "done");
       }
     },
-    [capabilityTag, dir, featuredOnly, listSort],
+    [
+      activeCategory?.slug,
+      capabilityTag,
+      categoryKeywords,
+      dir,
+      excludeCategoryKeywords,
+      featuredOnly,
+      listSort,
+    ],
   );
 
   // Reset and fetch first page when sort/dir/filters change
@@ -205,18 +231,16 @@ export function useSkillsBrowseModel({
   }, [hasQuery, listResults, searchResults]);
 
   const sorted = useMemo(() => {
-    if (isOtherCategory) {
-      return baseItems.filter((entry) => {
-        const text =
-          `${entry.skill.displayName} ${entry.skill.summary ?? ""} ${entry.skill.slug}`.toLowerCase();
-        return !ALL_CATEGORY_KEYWORDS.some((kw) => text.includes(kw));
-      });
-    }
+    const categoryItems = activeCategory
+      ? baseItems.filter(
+          (entry) => getSkillCategoryForSkill(entry.skill)?.slug === activeCategory.slug,
+        )
+      : baseItems;
     if (!hasQuery) {
-      return baseItems;
+      return categoryItems;
     }
     const multiplier = dir === "asc" ? 1 : -1;
-    const results = [...baseItems];
+    const results = [...categoryItems];
     results.sort((a, b) => {
       const tieBreak = () => {
         const updated = (a.skill.updatedAt - b.skill.updatedAt) * multiplier;
@@ -253,7 +277,7 @@ export function useSkillsBrowseModel({
       }
     });
     return results;
-  }, [baseItems, dir, hasQuery, isOtherCategory, sort]);
+  }, [activeCategory, baseItems, dir, hasQuery, sort]);
 
   const isLoadingSkills = hasQuery ? isSearching && searchResults.length === 0 : isLoadingList;
   const canLoadMore = hasQuery
@@ -341,6 +365,21 @@ export function useSkillsBrowseModel({
     });
   }, [navigate]);
 
+  const onClearFilters = useCallback(() => {
+    window.clearTimeout(navigateTimer.current);
+    setQuery("");
+    void navigate({
+      search: (prev) => ({
+        ...prev,
+        q: undefined,
+        category: undefined,
+        featured: undefined,
+        highlighted: undefined,
+      }),
+      replace: true,
+    });
+  }, [navigate]);
+
   const onSortChange = useCallback(
     (value: string) => {
       const nextSort = parseSort(value);
@@ -395,6 +434,7 @@ export function useSkillsBrowseModel({
 
   return {
     activeFilters,
+    activeCategory: activeCategory?.slug,
     capabilityTag,
     canAutoLoad,
     canLoadMore,
@@ -406,6 +446,7 @@ export function useSkillsBrowseModel({
     loadMore,
     loadMoreRef,
     onCapabilityTagChange,
+    onClearFilters,
     onQueryChange,
     onSortChange,
     onToggleDir,

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
 import { Search } from "lucide-react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { api } from "../../../convex/_generated/api";
 import { BrowseSidebar } from "../../components/BrowseSidebar";
 import { SKILL_CATEGORIES } from "../../lib/categories";
@@ -23,6 +23,12 @@ const SORT_OPTIONS = [
   { value: "name", label: "Name" },
 ];
 
+const SKILL_CATEGORY_SLUGS = new Set(SKILL_CATEGORIES.map((category) => category.slug));
+
+function parseSkillCategorySlug(value: unknown) {
+  return typeof value === "string" && SKILL_CATEGORY_SLUGS.has(value) ? value : undefined;
+}
+
 export const Route = createFileRoute("/skills/")({
   validateSearch: (search): SkillsSearchState => {
     return {
@@ -37,19 +43,21 @@ export const Route = createFileRoute("/skills/")({
         search.featured === "1" || search.featured === "true" || search.featured === true
           ? true
           : undefined,
+      category: parseSkillCategorySlug(search.category),
       view: normalizeSkillsView(search.view),
       focus: search.focus === "search" ? "search" : undefined,
     };
   },
   beforeLoad: ({ search }) => {
     const hasQuery = Boolean(search.q?.trim());
-    if (hasQuery || search.sort || search.featured || search.highlighted) {
+    if (hasQuery || search.category || search.sort || search.featured || search.highlighted) {
       return;
     }
     throw redirect({
       to: "/skills",
       search: {
         q: search.q || undefined,
+        category: search.category || undefined,
         sort: "downloads",
         dir: search.dir || undefined,
         highlighted: search.highlighted || undefined,
@@ -109,31 +117,24 @@ export function SkillsIndex() {
   );
 
   const handleClear = useCallback(() => {
-    model.onQueryChange("");
-    if (model.featuredOnly) model.onToggleFeatured();
-  }, [model.featuredOnly, model.onQueryChange, model.onToggleFeatured]);
+    model.onClearFilters();
+  }, [model.onClearFilters]);
 
   const handleCategoryChange = useCallback(
     (slug: string | undefined) => {
-      if (slug) {
-        const cat = SKILL_CATEGORIES.find((c) => c.slug === slug);
-        if (cat?.keywords[0]) {
-          model.onQueryChange(cat.keywords[0]);
-        }
-      } else {
-        model.onQueryChange("");
-      }
+      const category = parseSkillCategorySlug(slug);
+      void navigate({
+        search: (prev: SkillsSearchState) => ({
+          ...prev,
+          category,
+          featured: undefined,
+          highlighted: undefined,
+        }),
+        replace: true,
+      });
     },
-    [model.onQueryChange],
+    [navigate],
   );
-
-  const activeCategory = useMemo(() => {
-    if (!model.query) return undefined;
-    return (
-      SKILL_CATEGORIES.find((c) => c.keywords.some((k) => k === model.query.trim().toLowerCase()))
-        ?.slug ?? undefined
-    );
-  }, [model.query]);
 
   return (
     <main className="browse-page">
@@ -164,7 +165,7 @@ export function SkillsIndex() {
       <div className={`browse-layout${sidebarOpen ? " sidebar-open" : ""}`}>
         <BrowseSidebar
           categories={SKILL_CATEGORIES}
-          activeCategory={activeCategory}
+          activeCategory={model.activeCategory}
           onCategoryChange={handleCategoryChange}
           sortOptions={[{ value: "featured", label: "Featured" }, ...sortOptionsWithRelevance]}
           activeSort={model.featuredOnly ? "featured" : model.sort}
@@ -174,7 +175,7 @@ export function SkillsIndex() {
           <div className="browse-results-toolbar">
             <span className="browse-results-count">
               {model.isLoadingSkills ? "\u2014" : `${model.sorted.length} results`}
-              {model.hasQuery || model.featuredOnly ? (
+              {model.hasQuery || model.activeCategory || model.featuredOnly ? (
                 <button className="browse-clear-btn" type="button" onClick={handleClear}>
                   Clear
                 </button>

--- a/src/styles.css
+++ b/src/styles.css
@@ -3992,6 +3992,13 @@ code {
   margin-bottom: -4px;
 }
 
+.skill-hero-heading-stack {
+  display: grid;
+  justify-items: start;
+  gap: 10px;
+  min-width: 0;
+}
+
 .skill-hero-breadcrumbs {
   display: flex;
   flex-wrap: wrap;
@@ -4051,6 +4058,31 @@ code {
   align-items: center;
   gap: 6px;
   align-self: center;
+}
+
+.skill-category-chip {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 28px;
+  border: 1px solid color-mix(in srgb, var(--line) 82%, transparent);
+  border-radius: var(--r-pill);
+  padding: 4px 10px;
+  background: color-mix(in srgb, var(--surface-muted) 76%, transparent);
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.skill-category-chip:hover {
+  border-color: color-mix(in srgb, var(--ink-soft) 36%, var(--line));
+  color: var(--ink);
+  text-decoration: none;
 }
 
 .skill-settings-link {
@@ -5167,6 +5199,153 @@ code {
   gap: 8px;
 }
 
+.related-skills-section {
+  display: grid;
+  gap: 16px;
+  min-width: 0;
+}
+
+.related-skills-header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 16px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.related-skills-title {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: var(--fs-lg);
+  font-weight: 600;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.related-skills-category-link {
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  line-height: 1.2;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--ink-soft) 42%, transparent);
+  text-underline-offset: 0.28em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.related-skills-category-link:hover {
+  color: var(--ink);
+  text-decoration-color: currentColor;
+}
+
+.related-skills-list {
+  display: grid;
+  min-width: 0;
+  border-top: 1px solid color-mix(in srgb, var(--line) 70%, transparent);
+}
+
+.related-skill-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(180px, 0.34fr);
+  gap: 24px;
+  align-items: center;
+  min-width: 0;
+  padding: 18px 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--line) 70%, transparent);
+  color: inherit;
+  text-decoration: none;
+}
+
+.related-skill-row:hover .related-skill-name {
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+}
+
+.related-skill-row:hover {
+  text-decoration: none;
+}
+
+.related-skill-copy {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+}
+
+.related-skill-name {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--ink);
+  font-family: var(--font-display);
+  font-size: var(--fs-md);
+  font-weight: 600;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.related-skill-summary {
+  display: -webkit-box;
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: var(--ink-soft);
+  font-size: var(--fs-sm);
+  line-height: 1.45;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+}
+
+.related-skill-owner {
+  min-width: 0;
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  line-height: 1.3;
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.related-skill-row-skeleton {
+  pointer-events: none;
+}
+
+.related-skill-title-skeleton,
+.related-skill-summary-skeleton,
+.related-skill-owner-skeleton {
+  display: block;
+  overflow: hidden;
+  border-radius: var(--r-sm);
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--surface-muted) 70%, transparent),
+    color-mix(in srgb, var(--line) 72%, transparent),
+    color-mix(in srgb, var(--surface-muted) 70%, transparent)
+  );
+  background-size: 220% 100%;
+  animation: skeleton-shimmer 1.15s ease-in-out infinite;
+}
+
+.related-skill-title-skeleton {
+  width: min(260px, 70%);
+  height: 20px;
+}
+
+.related-skill-summary-skeleton {
+  width: min(520px, 86%);
+  height: 16px;
+}
+
+.related-skill-owner-skeleton {
+  justify-self: end;
+  width: min(190px, 100%);
+  height: 18px;
+}
+
 .runtime-requirements-panel .stat {
   color: var(--ink);
 }
@@ -6086,6 +6265,26 @@ code {
 
   .skill-hero-main-extra {
     gap: 32px;
+  }
+
+  .related-skills-header {
+    align-items: start;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .related-skill-row {
+    grid-template-columns: 1fr;
+    gap: 8px;
+    padding: 16px 0;
+  }
+
+  .related-skill-owner {
+    text-align: left;
+  }
+
+  .related-skill-owner-skeleton {
+    justify-self: start;
   }
 
   .skill-hero-layout.has-sidebar .skill-summary-block {


### PR DESCRIPTION
## Summary

- What changed: Added category-aware related skills to skill detail pages, category chips that link into category browse, shared category inference for browse filtering, and a Behavioural Proof section in the PR template.
- Why: Skill pages should surface related skills from the same inferred category, and category browse results should match the category shown on the opened skill.

## Linked Issue

- Closes #
- Related #

## Screenshots

For website/UI changes, attach screenshots or recordings from the real app. Include mobile/narrow views when layout changes.

- [x] Screenshots/recordings attached, or `N/A`

Related skills section:

![related-skills-section.png](https://github.com/user-attachments/assets/b14aa9f1-d084-4187-8903-b6f16b2cd758)

Skill detail category chip:

![skill-detail-category-chip.png](https://github.com/user-attachments/assets/84e28922-a4c9-4c41-870e-a3825934e024)

Dev Tools category filter:

![dev-tools-category-filter.png](https://github.com/user-attachments/assets/799a84a4-4ac0-430c-b3eb-1615ca093773)

## Behavioural Proof

Describe how you verified the user-facing behavior. For UI changes, include the path tested and what changed on screen. For backend/API changes, include the request, command, or scenario that proves the behavior.

- [x] Behavioural proof included, or `N/A`
- Ran a browser smoke check against localhost:
  - `/local-corpus-mckayla-olson/web3-dev` shows the category chip `DATA & APIS` linking to `/skills?category=data`.
  - The same page renders the new `RELATED SKILLS` section with `MORE IN DATA & APIS` and five related skills from that category.
  - `/skills?q=dev` and `/skills?category=dev-tools` show Dev Tools as the active category and do not list `Blockscout for Web3 Dev`.
  - `/skills?category=dev-tools` returned Dev Tools results with `Blockscout for Web3 Dev` absent.
- Ran `bunx convex dev --once` so the local dev backend used the updated related/category query code.

## Security / Trust Impact

- [x] No security/trust impact
- [ ] Security/trust impact explained

## Data / Deploy Impact

- [x] No data/deploy impact
- [ ] Data/deploy impact explained
- Convex functions changed, but no schema/data migration is included.

## Verification

- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run test`
- [x] Other:
  - `bun run ci:static`
  - `VITE_CONVEX_URL=https://example.invalid bun run coverage`
  - `bun run test -- convex/skills.publicListCursor.test.ts src/__tests__/skills-index.test.tsx src/__tests__/skill-detail-page.test.tsx src/lib/categories.test.ts`
  - `bunx tsc --noEmit`
  - `git diff --check`
  - `bunx convex dev --once`