### PR TITLE
fix: harden skill transfer acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Fixes
 
+- Security: cancel pending skill ownership transfers before rejecting accept attempts when the requester is inactive or the skill is hidden, removed, or malicious (#2276, #2277) (thanks @vyctorbrzezowski).
 - Web/API: keep search results limited to items with match evidence, preserve
   trust and popularity as tie-breakers, and show `N+` counts without exact
   count queries (#2206) (thanks @vyctorbrzezowski).

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -3119,6 +3119,41 @@ describe("httpApiV1 handlers", () => {
     expect(response.status).toBe(404);
   });
 
+  it("transfer accept maps committed cancellation failures to an error response", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:1",
+      user: { handle: "p" },
+    } as never);
+
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("slug" in args) return { _id: "skills:1", slug: "demo" };
+      if ("toUserId" in args) {
+        return {
+          _id: "skillOwnershipTransfers:1",
+          skillId: "skills:1",
+          toUserId: "users:1",
+          status: "pending",
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if ("key" in args) return okRate();
+      return { ok: false, error: "Skill is under moderation" };
+    });
+
+    const response = await __handlers.skillsPostRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/demo/transfer/accept", {
+        method: "POST",
+        headers: { Authorization: "Bearer clh_test" },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe("Skill is under moderation");
+  });
+
   it("rename endpoint forwards to renameOwnedSkillInternal", async () => {
     vi.mocked(requireApiTokenUser).mockResolvedValue({
       userId: "users:1",

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -1081,6 +1081,15 @@ function hasAcceptedLegacyLicenseTerms(acceptLicenseTerms: boolean | undefined) 
 
 type TransferDecisionAction = "accept" | "reject" | "cancel";
 
+function isTransferDecisionFailure(result: unknown): result is { ok: false; error: string } {
+  return (
+    typeof result === "object" &&
+    result !== null &&
+    (result as { ok?: unknown }).ok === false &&
+    typeof (result as { error?: unknown }).error === "string"
+  );
+}
+
 function transferErrorToResponse(error: unknown, headers: HeadersInit) {
   const message = error instanceof Error ? error.message : "Transfer failed";
   const lower = message.toLowerCase();
@@ -1210,6 +1219,9 @@ async function handleTransferDecision(
       actorUserId: transferContext.userId,
       transferId: pendingTransfer._id,
     });
+    if (isTransferDecisionFailure(result)) {
+      return transferErrorToResponse(new Error(result.error), headers);
+    }
     return json(result, 200, headers);
   } catch (error) {
     return transferErrorToResponse(error, headers);

--- a/convex/skillTransfers.test.ts
+++ b/convex/skillTransfers.test.ts
@@ -310,6 +310,14 @@ describe("skillTransfers", () => {
         db: {
           normalizeId: vi.fn(),
           get: vi.fn(async (id: string) => {
+            if (id === "users:1") {
+              return {
+                _id: "users:1",
+                handle: "owner",
+                deletedAt: undefined,
+                deactivatedAt: undefined,
+              };
+            }
             if (id === "users:2") {
               return {
                 _id: "users:2",

--- a/convex/skillTransfers.test.ts
+++ b/convex/skillTransfers.test.ts
@@ -548,45 +548,150 @@ describe("skillTransfers", () => {
   it("acceptTransferInternal cancels stale transfer when ownership changed", async () => {
     const patch = vi.fn(async () => {});
 
-    await expect(
-      acceptTransferInternalHandler(
-        {
-          db: {
-            normalizeId: vi.fn(),
-            query: vi.fn(),
-            get: vi.fn(async (id: string) => {
-              if (id === "users:2") return { _id: "users:2", handle: "alice" };
-              if (id === "skillOwnershipTransfers:1") {
-                return {
-                  _id: "skillOwnershipTransfers:1",
-                  skillId: "skills:1",
-                  fromUserId: "users:1",
-                  toUserId: "users:2",
-                  status: "pending",
-                  requestedAt: Date.now() - 1_000,
-                  expiresAt: Date.now() + 10_000,
-                };
-              }
-              if (id === "skills:1") {
-                return {
-                  _id: "skills:1",
-                  slug: "demo",
-                  ownerUserId: "users:someone-else",
-                };
-              }
-              return null;
-            }),
-            patch,
-            insert: vi.fn(async () => "auditLogs:1"),
-          },
-        } as never,
-        {
-          actorUserId: "users:2",
-          transferId: "skillOwnershipTransfers:1",
-        } as never,
-      ),
-    ).rejects.toThrow(/no longer valid/i);
+    const result = await acceptTransferInternalHandler(
+      {
+        db: {
+          normalizeId: vi.fn(),
+          query: vi.fn(),
+          get: vi.fn(async (id: string) => {
+            if (id === "users:2") return { _id: "users:2", handle: "alice" };
+            if (id === "skillOwnershipTransfers:1") {
+              return {
+                _id: "skillOwnershipTransfers:1",
+                skillId: "skills:1",
+                fromUserId: "users:1",
+                toUserId: "users:2",
+                status: "pending",
+                requestedAt: Date.now() - 1_000,
+                expiresAt: Date.now() + 10_000,
+              };
+            }
+            if (id === "skills:1") {
+              return {
+                _id: "skills:1",
+                slug: "demo",
+                ownerUserId: "users:someone-else",
+              };
+            }
+            return null;
+          }),
+          patch,
+          insert: vi.fn(async () => "auditLogs:1"),
+        },
+      } as never,
+      {
+        actorUserId: "users:2",
+        transferId: "skillOwnershipTransfers:1",
+      } as never,
+    );
 
+    expect(result).toEqual({ ok: false, error: "Transfer is no longer valid" });
+
+    expect(patch).toHaveBeenCalledWith(
+      "skillOwnershipTransfers:1",
+      expect.objectContaining({ status: "cancelled" }),
+    );
+    expect(patch).not.toHaveBeenCalledWith(
+      "skills:1",
+      expect.objectContaining({ ownerUserId: "users:2" }),
+    );
+  });
+
+  it("acceptTransferInternal cancels transfer when requester is inactive", async () => {
+    const patch = vi.fn(async () => {});
+
+    const result = await acceptTransferInternalHandler(
+      {
+        db: {
+          normalizeId: vi.fn(),
+          query: vi.fn(),
+          get: vi.fn(async (id: string) => {
+            if (id === "users:2") return { _id: "users:2", handle: "alice" };
+            if (id === "users:1") return { _id: "users:1", handle: "owner", deletedAt: 1 };
+            if (id === "skillOwnershipTransfers:1") {
+              return {
+                _id: "skillOwnershipTransfers:1",
+                skillId: "skills:1",
+                fromUserId: "users:1",
+                toUserId: "users:2",
+                status: "pending",
+                requestedAt: Date.now() - 1_000,
+                expiresAt: Date.now() + 10_000,
+              };
+            }
+            if (id === "skills:1") {
+              return {
+                _id: "skills:1",
+                slug: "demo",
+                ownerUserId: "users:1",
+              };
+            }
+            return null;
+          }),
+          patch,
+          insert: vi.fn(async () => "auditLogs:1"),
+        },
+      } as never,
+      {
+        actorUserId: "users:2",
+        transferId: "skillOwnershipTransfers:1",
+      } as never,
+    );
+
+    expect(result).toEqual({ ok: false, error: "Transfer is no longer valid" });
+    expect(patch).toHaveBeenCalledWith(
+      "skillOwnershipTransfers:1",
+      expect.objectContaining({ status: "cancelled" }),
+    );
+    expect(patch).not.toHaveBeenCalledWith(
+      "skills:1",
+      expect.objectContaining({ ownerUserId: "users:2" }),
+    );
+  });
+
+  it("acceptTransferInternal cancels transfer when skill is under moderation", async () => {
+    const patch = vi.fn(async () => {});
+
+    const result = await acceptTransferInternalHandler(
+      {
+        db: {
+          normalizeId: vi.fn(),
+          query: vi.fn(),
+          get: vi.fn(async (id: string) => {
+            if (id === "users:2") return { _id: "users:2", handle: "alice" };
+            if (id === "skillOwnershipTransfers:1") {
+              return {
+                _id: "skillOwnershipTransfers:1",
+                skillId: "skills:1",
+                fromUserId: "users:1",
+                toUserId: "users:2",
+                status: "pending",
+                requestedAt: Date.now() - 1_000,
+                expiresAt: Date.now() + 10_000,
+              };
+            }
+            if (id === "skills:1") {
+              return {
+                _id: "skills:1",
+                slug: "demo",
+                ownerUserId: "users:1",
+                moderationVerdict: "malicious",
+                moderationStatus: "hidden",
+              };
+            }
+            return null;
+          }),
+          patch,
+          insert: vi.fn(async () => "auditLogs:1"),
+        },
+      } as never,
+      {
+        actorUserId: "users:2",
+        transferId: "skillOwnershipTransfers:1",
+      } as never,
+    );
+
+    expect(result).toEqual({ ok: false, error: "Skill is under moderation" });
     expect(patch).toHaveBeenCalledWith(
       "skillOwnershipTransfers:1",
       expect.objectContaining({ status: "cancelled" }),

--- a/convex/skillTransfers.ts
+++ b/convex/skillTransfers.ts
@@ -183,20 +183,29 @@ export const acceptTransferInternal = internalMutation({
       role: "recipient",
       now,
     });
+    const cancelTransfer = async (message: string) => {
+      await ctx.db.patch(transfer._id, { status: "cancelled" as const, respondedAt: now });
+      return { ok: false as const, error: message };
+    };
 
     const skill = await ctx.db.get(transfer.skillId);
     if (!skill || skill.softDeletedAt) throw new Error("Skill not found");
+    if (
+      skill.moderationVerdict === "malicious" ||
+      skill.moderationStatus === "hidden" ||
+      skill.moderationStatus === "removed"
+    ) {
+      return await cancelTransfer("Skill is under moderation");
+    }
     const requester = await ctx.db.get(transfer.fromUserId);
     if (!requester || requester.deletedAt || requester.deactivatedAt) {
-      await ctx.db.patch(transfer._id, { status: "cancelled", respondedAt: now });
-      throw new Error("Transfer is no longer valid");
+      return await cancelTransfer("Transfer is no longer valid");
     }
     if (skill.ownerUserId !== transfer.fromUserId) {
       try {
         await assertCanRequestSkillTransfer(ctx, requester, skill);
       } catch {
-        await ctx.db.patch(transfer._id, { status: "cancelled", respondedAt: now });
-        throw new Error("Transfer is no longer valid");
+        return await cancelTransfer("Transfer is no longer valid");
       }
     }
 

--- a/convex/skillTransfers.ts
+++ b/convex/skillTransfers.ts
@@ -186,12 +186,12 @@ export const acceptTransferInternal = internalMutation({
 
     const skill = await ctx.db.get(transfer.skillId);
     if (!skill || skill.softDeletedAt) throw new Error("Skill not found");
+    const requester = await ctx.db.get(transfer.fromUserId);
+    if (!requester || requester.deletedAt || requester.deactivatedAt) {
+      await ctx.db.patch(transfer._id, { status: "cancelled", respondedAt: now });
+      throw new Error("Transfer is no longer valid");
+    }
     if (skill.ownerUserId !== transfer.fromUserId) {
-      const requester = await ctx.db.get(transfer.fromUserId);
-      if (!requester || requester.deletedAt || requester.deactivatedAt) {
-        await ctx.db.patch(transfer._id, { status: "cancelled", respondedAt: now });
-        throw new Error("Transfer is no longer valid");
-      }
       try {
         await assertCanRequestSkillTransfer(ctx, requester, skill);
       } catch {

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -70,6 +70,10 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
 - Any scanner path that determines a skill is malicious must hide the skill and
   schedule the same account-level autoban/token-revocation workflow. Static
   scan malicious findings must not diverge into a softer moderation-only state.
+- Pending skill ownership transfers must not be accepted when the requesting
+  owner is deleted/deactivated or when the skill is malicious, hidden, or
+  removed. The accept path is the final shared gate before ownership changes,
+  so it must cancel the pending transfer before reporting the rejection.
 - `clawScanNote` is optional publisher-authored context stored directly on a
   `skillVersions` or `packageReleases` row. It is not an appeal, has no
   accepted/rejected state, does not imply staff response, and must not drive


### PR DESCRIPTION
## Summary

- Harden skill transfer acceptance against stale requester state and moderated skills.
- Cancel the pending transfer before returning the rejection, so the cancellation is committed instead of rolled back with a thrown Convex mutation error.
- Add regression coverage for inactive requesters, moderated skills, stale ownership, and the public HTTP error mapping.

This folds in the same acceptance-path concern from #2277 so both fixes land together.

## Proof

- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode auto` (clean after fixes)
- `bunx vitest run convex/skillTransfers.test.ts convex/httpApiV1.handlers.test.ts --testNamePattern "transfer"`
- `bun run format:check -- convex/skillTransfers.ts convex/skillTransfers.test.ts convex/httpApiV1/skillsV1.ts convex/httpApiV1.handlers.test.ts specs/security-moderation.md`
- `bun run format:check -- CHANGELOG.md`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
