### PR TITLE
fix: reject skill transfer when skill is under moderation

### DIFF
--- a/convex/skillTransfers.ts
+++ b/convex/skillTransfers.ts
@@ -186,6 +186,14 @@ export const acceptTransferInternal = internalMutation({
 
     const skill = await ctx.db.get(transfer.skillId);
     if (!skill || skill.softDeletedAt) throw new Error("Skill not found");
+    if (
+      skill.moderationVerdict === "malicious" ||
+      skill.moderationStatus === "hidden" ||
+      skill.moderationStatus === "removed"
+    ) {
+      await ctx.db.patch(transfer._id, { status: "cancelled", respondedAt: now });
+      throw new Error("Skill is under moderation");
+    }
     if (skill.ownerUserId !== transfer.fromUserId) {
       const requester = await ctx.db.get(transfer.fromUserId);
       if (!requester || requester.deletedAt || requester.deactivatedAt) {


### PR DESCRIPTION
## Summary

Closes a race condition where a skill flagged as malicious by a scanner could be transferred to another owner before the automatic ban of the original owner executes. The scanner commits `moderationVerdict = "malicious"` on the skill, then schedules the autoban via `scheduler.runAfter(0, ...)` — a separate transaction. A pending transfer acceptance during this window would succeed, letting the skill escape the autoban.

## Root Cause

In `acceptTransferInternal`, there was no check on the skill's moderation state. The skill could have `moderationVerdict = "malicious"` (committed by the scanner in the current transaction) while the autoban (scheduled via `runAfter(0)`) had not yet executed:

```
Scanner mutation:
  1. Patch skill: { moderationVerdict: "malicious" }  ← commits immediately
  2. runAfter(0, autoban)                               ← separate transaction
                           ↑
                     acceptTransferInternal runs here
                     skill.softDeletedAt = undefined ✓
                     skill.moderationVerdict = "malicious" ← NOT checked
                     → transfer succeeds, skill escapes autoban
```

## Fix

Adds a moderation check in `acceptTransferInternal` immediately after the `softDeletedAt` check. The transfer is cancelled when the skill:

- Has `moderationVerdict = "malicious"` — flagged by scanner
- Has `moderationStatus = "hidden"` — hidden by moderator/system
- Has `moderationStatus = "removed"` — removed by moderator

```diff
 const skill = await ctx.db.get(transfer.skillId);
 if (!skill || skill.softDeletedAt) throw new Error("Skill not found");
+if (
+  skill.moderationVerdict === "malicious" ||
+  skill.moderationStatus === "hidden" ||
+  skill.moderationStatus === "removed"
+) {
+  await ctx.db.patch(transfer._id, { status: "cancelled", respondedAt: now });
+  throw new Error("Skill is under moderation");
+}
```

## Scope

- `convex/skillTransfers.ts` — 8-line addition in `acceptTransferInternal`
- No test changes needed — existing mock skills have no moderation fields (undefined), which correctly passes through the check

## Relationship to #2276

This PR is independent of #2276 (`fix: prevent skill transfer acceptance after requester is banned`). They fix different race conditions:

| PR | Race condition | Window |
|----|---------------|--------|
| #2276 | Requester banned → skill still transferable | Between ban batch page 1 and page 2 |
| This PR | Skill flagged as malicious → skill still transferable | Between scanner detection and autoban execution |

They modify adjacent lines and can be merged in either order with trivial conflict resolution.

## Verification

All transfer-related tests pass:

| Command | Result |
|---------|--------|
| `bun run test convex/skillTransfers.test.ts` | 6/6 passed |
| `bun run test convex/httpApiV1.handlers.test.ts -t "transfer"` | 9/9 passed |
| Combined (both above + ownership) | 12/12 passed |

### Manual checklist

- [x] Scanner code confirms: `moderationVerdict = "malicious"` committed before `runAfter(0, autoban)` in all 4 scanner paths
- [x] A skill with `moderationVerdict = undefined, moderationStatus = undefined` (normal skill) passes through unchanged
- [x] A skill with `moderationVerdict = "clean", moderationStatus = "active"` passes through unchanged
- [x] Single file change, +8 lines, no test changes needed
- [x] Branch is 1 commit ahead of `origin/main`, clean tree
