### PR TITLE
fix: revalidate package publish owners before insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - API: fix `GET /api/v1/skills` pagination so `cursor` advances to the next page instead of repeating the first page for supported non-trending sorts (#2275) (thanks @vyctorbrzezowski, @enerj).
+- Security/API: revalidate package publish actor, owner, and owner publisher active state in the final release insert (thanks @vyctorbrzezowski).
 
 ## 0.17.0 - 2026-05-19
 

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -3419,6 +3419,93 @@ describe("packages public queries", () => {
     ).rejects.toThrow("Restore it before publishing another release");
   });
 
+  it("rejects final package publish inserts when the actor was banned mid-publish", async () => {
+    const ctx = makeInsertReleaseCtx(makePackageDoc(), [], {
+      "users:owner": {
+        _id: "users:owner",
+        role: "user",
+        trustedPublisher: false,
+        deletedAt: 123,
+      },
+    });
+
+    await expect(
+      insertReleaseInternalHandler(ctx, {
+        actorUserId: "users:owner",
+        ownerUserId: "users:owner",
+        name: "demo-plugin",
+        displayName: "Demo Plugin",
+        family: "code-plugin",
+        version: "1.0.1",
+        changelog: "try banned owner",
+        tags: ["latest"],
+        summary: "demo",
+        files: [],
+        integritySha256: "abc123",
+      }),
+    ).rejects.toThrow("Unauthorized");
+    expect(ctx.insert).not.toHaveBeenCalledWith("packageReleases", expect.anything());
+  });
+
+  it("rejects final package publish inserts when the requested owner was banned mid-publish", async () => {
+    const ctx = makeInsertReleaseCtx(makePackageDoc(), [], {
+      "users:admin": { _id: "users:admin", role: "admin", trustedPublisher: false },
+      "users:owner": {
+        _id: "users:owner",
+        role: "user",
+        trustedPublisher: false,
+        deletedAt: 123,
+      },
+    });
+
+    await expect(
+      insertReleaseInternalHandler(ctx, {
+        actorUserId: "users:admin",
+        ownerUserId: "users:owner",
+        name: "demo-plugin",
+        displayName: "Demo Plugin",
+        family: "code-plugin",
+        version: "1.0.1",
+        changelog: "try banned owner",
+        tags: ["latest"],
+        summary: "demo",
+        files: [],
+        integritySha256: "abc123",
+      }),
+    ).rejects.toThrow("Package owner is unavailable");
+    expect(ctx.insert).not.toHaveBeenCalledWith("packageReleases", expect.anything());
+  });
+
+  it("rejects final package publish inserts when the owner publisher was deleted mid-publish", async () => {
+    const ctx = makeInsertReleaseCtx(makePackageDoc(), [], {
+      "users:owner": { _id: "users:owner", role: "user", trustedPublisher: false },
+      "publishers:org": {
+        _id: "publishers:org",
+        kind: "org",
+        handle: "org",
+        deletedAt: 123,
+      },
+    });
+
+    await expect(
+      insertReleaseInternalHandler(ctx, {
+        actorUserId: "users:owner",
+        ownerUserId: "users:owner",
+        ownerPublisherId: "publishers:org",
+        name: "demo-plugin",
+        displayName: "Demo Plugin",
+        family: "code-plugin",
+        version: "1.0.1",
+        changelog: "try deleted publisher",
+        tags: ["latest"],
+        summary: "demo",
+        files: [],
+        integritySha256: "abc123",
+      }),
+    ).rejects.toThrow("Package owner publisher is unavailable");
+    expect(ctx.insert).not.toHaveBeenCalledWith("packageReleases", expect.anything());
+  });
+
   it("rejects package scopes that do not match the selected owner handle", async () => {
     const runMutation = vi.fn();
     const ctx = {

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -133,6 +133,16 @@ const insertReleaseInternalHandler = (
       actorUserId: string;
       ownerUserId: string;
       ownerPublisherId?: string;
+      publishActor?:
+        | { kind: "user"; userId: string }
+        | {
+            kind: "github-actions";
+            repository: string;
+            workflow: string;
+            runId: string;
+            runAttempt: string;
+            sha: string;
+          };
       name: string;
       displayName: string;
       family: "skill" | "code-plugin" | "bundle-plugin";
@@ -935,6 +945,7 @@ function makeInsertReleaseCtx(
   priorReleases: Array<Record<string, unknown>> = [],
   recordsById: Record<string, Record<string, unknown>> = {},
   runtimePackages: Array<Record<string, unknown>> = [],
+  finalPublisherMembershipRole?: "owner" | "admin" | "publisher" | null,
 ) {
   const patch = vi.fn();
   let insertedPackage: Record<string, unknown> | null = null;
@@ -1029,6 +1040,39 @@ function makeInsertReleaseCtx(
                 }
                 return {
                   unique: vi.fn().mockResolvedValue(null),
+                };
+              },
+            ),
+          };
+        }
+        if (table === "publisherMembers") {
+          return {
+            withIndex: vi.fn(
+              (
+                _indexName: string,
+                buildQuery?: (q: { eq: (field: string, value: unknown) => unknown }) => unknown,
+              ) => {
+                const filters = new Map<string, unknown>();
+                const query = {
+                  eq(field: string, value: unknown) {
+                    filters.set(field, value);
+                    return query;
+                  },
+                };
+                buildQuery?.(query);
+                const membership =
+                  finalPublisherMembershipRole &&
+                  filters.get("publisherId") === "publishers:org" &&
+                  filters.get("userId") === "users:member"
+                    ? {
+                        _id: "publisherMembers:org-member",
+                        publisherId: "publishers:org",
+                        userId: "users:member",
+                        role: finalPublisherMembershipRole,
+                      }
+                    : null;
+                return {
+                  unique: vi.fn().mockResolvedValue(membership),
                 };
               },
             ),
@@ -3504,6 +3548,160 @@ describe("packages public queries", () => {
       }),
     ).rejects.toThrow("Package owner publisher is unavailable");
     expect(ctx.insert).not.toHaveBeenCalledWith("packageReleases", expect.anything());
+  });
+
+  it("rejects final user org package publish inserts when membership was removed mid-publish", async () => {
+    const ctx = makeInsertReleaseCtx(null, [], {
+      "users:member": { _id: "users:member", role: "user", trustedPublisher: false },
+      "publishers:org": {
+        _id: "publishers:org",
+        kind: "org",
+        handle: "org",
+        trustedPublisher: false,
+      },
+    });
+
+    await expect(
+      insertReleaseInternalHandler(ctx, {
+        actorUserId: "users:member",
+        ownerUserId: "users:member",
+        ownerPublisherId: "publishers:org",
+        publishActor: { kind: "user", userId: "users:member" },
+        name: "@org/demo-plugin",
+        displayName: "Demo Plugin",
+        family: "bundle-plugin",
+        version: "1.0.0",
+        changelog: "init",
+        tags: ["latest"],
+        summary: "demo",
+        files: [],
+        integritySha256: "abc123",
+      }),
+    ).rejects.toThrow('publish access for "@org"');
+    expect(ctx.insert).not.toHaveBeenCalledWith("packages", expect.anything());
+    expect(ctx.insert).not.toHaveBeenCalledWith("packageReleases", expect.anything());
+  });
+
+  it("rejects final user org package publish inserts when publish actor drifts from actor user", async () => {
+    const ctx = makeInsertReleaseCtx(
+      null,
+      [],
+      {
+        "users:member": { _id: "users:member", role: "user", trustedPublisher: false },
+        "publishers:org": {
+          _id: "publishers:org",
+          kind: "org",
+          handle: "org",
+          trustedPublisher: false,
+        },
+      },
+      [],
+      "publisher",
+    );
+
+    await expect(
+      insertReleaseInternalHandler(ctx, {
+        actorUserId: "users:member",
+        ownerUserId: "users:member",
+        ownerPublisherId: "publishers:org",
+        publishActor: { kind: "user", userId: "users:other" },
+        name: "@org/demo-plugin",
+        displayName: "Demo Plugin",
+        family: "bundle-plugin",
+        version: "1.0.0",
+        changelog: "init",
+        tags: ["latest"],
+        summary: "demo",
+        files: [],
+        integritySha256: "abc123",
+      }),
+    ).rejects.toThrow("Publish actor must match the authenticated actor");
+    expect(ctx.insert).not.toHaveBeenCalledWith("packages", expect.anything());
+    expect(ctx.insert).not.toHaveBeenCalledWith("packageReleases", expect.anything());
+  });
+
+  it("keeps final user org package publishes working when membership remains valid", async () => {
+    const ctx = makeInsertReleaseCtx(
+      null,
+      [],
+      {
+        "users:member": { _id: "users:member", role: "user", trustedPublisher: false },
+        "publishers:org": {
+          _id: "publishers:org",
+          kind: "org",
+          handle: "org",
+          trustedPublisher: false,
+        },
+      },
+      [],
+      "publisher",
+    );
+
+    await expect(
+      insertReleaseInternalHandler(ctx, {
+        actorUserId: "users:member",
+        ownerUserId: "users:member",
+        ownerPublisherId: "publishers:org",
+        publishActor: { kind: "user", userId: "users:member" },
+        name: "@org/demo-plugin",
+        displayName: "Demo Plugin",
+        family: "bundle-plugin",
+        version: "1.0.0",
+        changelog: "init",
+        tags: ["latest"],
+        summary: "demo",
+        files: [],
+        integritySha256: "abc123",
+      }),
+    ).resolves.toMatchObject({ ok: true, packageId: "packages:new" });
+    expect(ctx.insert).toHaveBeenCalledWith("packageReleases", expect.anything());
+  });
+
+  it("preserves trusted GitHub Actions package publishes without org membership", async () => {
+    const ctx = makeInsertReleaseCtx(
+      makePackageDoc({
+        name: "@org/demo-plugin",
+        normalizedName: "@org/demo-plugin",
+        ownerUserId: "users:member",
+        ownerPublisherId: "publishers:org",
+      }),
+      [],
+      {
+        "users:member": { _id: "users:member", role: "user", trustedPublisher: false },
+        "publishers:org": {
+          _id: "publishers:org",
+          kind: "org",
+          handle: "org",
+          trustedPublisher: false,
+        },
+      },
+    );
+
+    await expect(
+      insertReleaseInternalHandler(ctx, {
+        actorUserId: "users:member",
+        ownerUserId: "users:member",
+        ownerPublisherId: "publishers:org",
+        publishActor: {
+          kind: "github-actions",
+          repository: "org/demo-plugin",
+          workflow: "publish.yml",
+          runId: "1",
+          runAttempt: "1",
+          sha: "abc123",
+        },
+        name: "@org/demo-plugin",
+        displayName: "Demo Plugin",
+        family: "code-plugin",
+        version: "1.0.1",
+        changelog: "trusted publish",
+        tags: ["latest"],
+        summary: "demo",
+        files: [],
+        integritySha256: "abc123",
+      }),
+    ).resolves.toMatchObject({ ok: true, packageId: "packages:demo" });
+    expect(ctx.insert).toHaveBeenCalledWith("packageReleases", expect.anything());
   });
 
   it("rejects package scopes that do not match the selected owner handle", async () => {

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -5417,10 +5417,18 @@ export const insertReleaseInternal = internalMutation({
     const now = Date.now();
     const normalizedName = normalizePackageName(args.name);
     const actor = await ctx.db.get(args.actorUserId);
-    if (!actor) throw new ConvexError("Unauthorized");
+    if (!actor || actor.deletedAt || actor.deactivatedAt) throw new ConvexError("Unauthorized");
     const owner = await ctx.db.get(args.ownerUserId);
-    if (!owner) throw new ConvexError("Unauthorized");
+    if (!owner || owner.deletedAt || owner.deactivatedAt) {
+      throw new ConvexError("Package owner is unavailable");
+    }
     const ownerPublisher = args.ownerPublisherId ? await ctx.db.get(args.ownerPublisherId) : null;
+    if (
+      args.ownerPublisherId &&
+      (!ownerPublisher || ownerPublisher.deletedAt || ownerPublisher.deactivatedAt)
+    ) {
+      throw new ConvexError("Package owner publisher is unavailable");
+    }
     if (args.ownerUserId !== args.actorUserId) {
       assertAdmin(actor);
     }

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -5429,6 +5429,21 @@ export const insertReleaseInternal = internalMutation({
     ) {
       throw new ConvexError("Package owner publisher is unavailable");
     }
+    if (args.publishActor?.kind === "user" && args.publishActor.userId !== args.actorUserId) {
+      throw new ConvexError("Publish actor must match the authenticated actor");
+    }
+    if (args.publishActor?.kind === "user" && ownerPublisher?.kind === "org") {
+      const membership = await getPublisherMembership(
+        ctx,
+        ownerPublisher._id,
+        args.publishActor.userId,
+      );
+      if (!membership || !isPublisherRoleAllowed(membership.role, ["publisher"])) {
+        throw new ConvexError(
+          `You do not have publish access for "@${ownerPublisher.handle}". Ask an owner or admin to add you before publishing this package.`,
+        );
+      }
+    }
     if (args.ownerUserId !== args.actorUserId) {
       assertAdmin(actor);
     }

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -53,6 +53,10 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   API/CLI, including open report count, latest release moderation state, and
   download-block reasons. Reporter identities and report bodies remain moderator
   intake data.
+- Package publish actions may spend time validating and scanning before the
+  final release write. The final `insertReleaseInternal` mutation must re-read
+  the publish actor, owner user, and owner publisher and reject if any of those
+  principals are banned, deactivated, or deleted.
 - OpenClaw install clients can read the exact-release public trust endpoint at
   `GET /api/v1/packages/{name}/versions/{version}/security` without owner or
   moderator credentials. The endpoint returns only package identity, exact


### PR DESCRIPTION
## Summary

Checks package publish authority one last time right before the release is inserted. If the actor, owner, or publisher was removed during the publish window, nothing gets written.

## What changed

- Final release insert rechecks actor state.
- Final release insert rechecks owner user state.
- Final release insert rechecks owner publisher active state.
- A publish that started while valid cannot complete if the actor/owner/publisher is banned, deleted, or deactivated before the final write.

## Public behavior

Package publish rejects the final insert when the actor, requested owner, or owner publisher becomes invalid during the publish window. It does not create a package or release row under stale authority.

## Behavior proof

Live Convex runtime proof from the final package publish insert boundary:

```text
$ bunx convex run --push --typecheck=disable --codegen disable proof2281:run
- Preparing Convex functions...

✔ Convex functions ready!
{
  "actorRevoked": {
    "publish": {
      "error": "Unauthorized",
      "ok": false
    },
    "revokedPrincipal": "actor",
    "snapshot": {
      "packageInserted": false,
      "releaseCount": 0
    }
  },
  "ownerRevoked": {
    "publish": {
      "error": "Package owner is unavailable",
      "ok": false
    },
    "revokedPrincipal": "owner",
    "snapshot": {
      "packageInserted": false,
      "releaseCount": 0
    }
  },
  "publisherRevoked": {
    "publish": {
      "error": "Package owner publisher is unavailable",
      "ok": false
    },
    "revokedPrincipal": "publisher",
    "snapshot": {
      "packageInserted": false,
      "releaseCount": 0
    }
  }
}
```

This proof starts from valid publish principals, revokes one principal before the final insert, and confirms the release insert aborts without creating package/release data.

Focused regression suite:

```text
$ bun run test convex/packages.public.test.ts
Test Files  1 passed (1)
Tests       132 passed (132)
```

## Validation

```text
$ bun run ci:unit
Test Files  204 passed (204)
Tests       1988 passed (1988)
Statements  85.98%
Branches    75.17%
Functions   86.37%
Lines        89.48%
```

```text
$ bun run ci:types-build
tsc, package typechecks, clawhub-mod typecheck, Vite build, and Nitro build passed.
```

Current GitHub CI for this head also has `packages`, `types-build`, `e2e-http`, `playwright-smoke`, and `playwright-local-auth` passing. The `static` job currently stops at `bun audit` on the existing transitive `ws` advisory `GHSA-58qx-3vcg-4xpx`.
