### PR TITLE
Create SKILL.md

### DIFF
--- a/defi-yield-engine/SKILL.md
+++ b/defi-yield-engine/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: defi-yield-engine
+version: 1.0.0
+description: Risk-adjusted DeFi yield recommendations across 
+             548 protocols. One actionable answer, not a data dump.
+url: https://defi-yield-engine-production.up.railway.app/mcp
+tags: [defi, yield, finance, USDC, ETH, aave, morpho, risk]
+pricing: 0.02-0.05 USDC per call (x402/Base)
+---
+
+## DeFi Yield Decision Engine
+
+Scores 13,800+ DeFi pools using a 9-signal risk algorithm.
+Returns one recommendation with reasoning.
+
+### Tools
+- `get_best_yield` — Best yield for asset + risk profile (0.05 USDC)
+- `explain_risk` — Risk breakdown for a protocol (0.02 USDC)
+- `compare_yields` — Side-by-side comparison (0.03 USDC)
+
+### Free resources
+- `defi://market-overview` — Real-time yield snapshot
+- `defi://risk-glossary` — Risk term definitions


### PR DESCRIPTION
a new skill for AI agents

## Summary

- What changed: Added DeFi Yield Decision Engine MCP skill — risk-adjusted yield recommendations across 548 DeFi protocols via DeFiLlama.
- Why: No existing ClawHub skill provides risk-adjusted yield recommendations. Existing solutions return raw data (13,800+ pools). This skill returns one opinionated recommendation with reasoning, 97% fewer tokens. Paid via x402 USDC on Base.

## Linked Issue

- Closes # N/A
- Related # N/A

## Screenshots 

For website/UI changes, attach screenshots or recordings from the real app. Include mobile/narrow views when layout changes.

- [ ] Screenshots/recordings attached, or `N/A` N/A

## Security / Trust Impact

- [X] No security/trust impact
- [ ] Security/trust impact explained

## Data / Deploy Impact

- [X] No data/deploy impact
- [ ] Data/deploy impact explained

## Verification

- [ ] `bun run format:check`
- [ ] `bun run lint`
- [ ] `bun run test`
- [X] Other: External MCP server — no local build required. Server tested and live at Railway.
