### PR TITLE
fix: harden package publish contention

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -7014,6 +7014,64 @@ describe("httpApiV1 handlers", () => {
     );
   });
 
+  it("package publish returns retryable status for transient Convex contention", async () => {
+    vi.mocked(getOptionalApiTokenUser).mockResolvedValue({
+      userId: "users:1",
+      user: { _id: "users:1", handle: "p" },
+    } as never);
+    vi.mocked(getOptionalApiTokenUserId).mockResolvedValue("users:1" as never);
+    vi.mocked(requirePackagePublishAuth).mockResolvedValue({
+      kind: "user",
+      userId: "users:1",
+      user: { _id: "users:1", handle: "p" },
+    } as never);
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const runAction = vi
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          'Documents read from or written to the "publishers" table changed while this mutation was being run and on every subsequent retry.',
+        ),
+      );
+
+    const response = await __handlers.publishPackageV1Handler(
+      makeCtx({ runAction, runMutation }),
+      new Request("https://example.com/api/v1/packages", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer clh_test",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          name: "demo-plugin",
+          ownerHandle: "openclaw",
+          family: "bundle-plugin",
+          version: "1.0.0",
+          changelog: "init",
+          bundle: { hostTargets: ["desktop"] },
+          files: [
+            {
+              path: "openclaw.plugin.json",
+              size: 2,
+              storageId: "storage:1",
+              sha256: "a".repeat(64),
+            },
+            {
+              path: ".codex-plugin/plugin.json",
+              size: 2,
+              storageId: "storage:1",
+              sha256: "a".repeat(64),
+            },
+          ],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("Retry-After")).toBe("1");
+    await expect(response.text()).resolves.toContain("Transient ClawHub write contention");
+  });
+
   it("multipart package publish ignores macOS junk files", async () => {
     vi.mocked(getOptionalApiTokenUserId).mockResolvedValue("users:1" as never);
     vi.mocked(requirePackagePublishAuth).mockResolvedValue({

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -143,6 +143,28 @@ function packageOperationErrorToResponse(
   return text(message, 400, headers);
 }
 
+function isTransientConvexContentionMessage(message: string) {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes("optimistic concurrency") ||
+    lower.includes("write conflict") ||
+    (/documents read from or written to the ".+" table changed/.test(lower) &&
+      lower.includes("while this mutation was being run"))
+  );
+}
+
+function packagePublishErrorToResponse(error: unknown, headers: HeadersInit) {
+  const message = error instanceof Error ? error.message : "Publish failed";
+  if (!isTransientConvexContentionMessage(message)) {
+    return text(message, 400, headers);
+  }
+  return text(
+    `Transient ClawHub write contention. Package validation was not the cause; retrying usually succeeds. ${message}`,
+    503,
+    mergeHeaders(headers, { "Retry-After": "1" }),
+  );
+}
+
 async function runQueryRef<T>(ctx: ActionCtx, ref: unknown, args: unknown): Promise<T> {
   return (await ctx.runQuery(ref as never, args as never)) as T;
 }
@@ -1514,7 +1536,7 @@ export async function publishPackageV1Handler(ctx: ActionCtx, request: Request) 
           });
     return json(result, 200, rate.headers);
   } catch (error) {
-    return text(error instanceof Error ? error.message : "Publish failed", 400, rate.headers);
+    return packagePublishErrorToResponse(error, rate.headers);
   }
 }
 

--- a/convex/lib/publisherStats.test.ts
+++ b/convex/lib/publisherStats.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { adjustPublisherStatsForSkillChange } from "./publisherStats";
+import {
+  adjustPublisherStatsForPackageChange,
+  adjustPublisherStatsForSkillChange,
+} from "./publisherStats";
 
 function makeSkill(overrides: Record<string, unknown>) {
   return {
@@ -10,6 +13,16 @@ function makeSkill(overrides: Record<string, unknown>) {
     statsStars: 2,
     statsInstallsAllTime: 4,
     stats: { downloads: 10, stars: 2, installsCurrent: 1, installsAllTime: 4 },
+    ...overrides,
+  } as never;
+}
+
+function makePackage(overrides: Record<string, unknown>) {
+  return {
+    _id: "packages:demo",
+    ownerPublisherId: "publishers:alice",
+    softDeletedAt: undefined,
+    stats: { downloads: 10, installs: 4, stars: 2, versions: 1 },
     ...overrides,
   } as never;
 }
@@ -111,6 +124,56 @@ describe("publisher stat maintenance", () => {
       totalDownloads: 18,
       totalStars: 3,
     });
+    expect(ctx.db.query).not.toHaveBeenCalled();
+  });
+
+  it("does not touch publisher rows for existing package version-only updates", async () => {
+    const ctx = {
+      db: {
+        get: vi.fn(),
+        patch: vi.fn(),
+        query: vi.fn(),
+      },
+    };
+
+    await adjustPublisherStatsForPackageChange(
+      ctx as never,
+      makePackage({ stats: { downloads: 10, installs: 4, stars: 2, versions: 1 } }),
+      makePackage({ stats: { downloads: 10, installs: 4, stars: 2, versions: 2 } }),
+    );
+
+    expect(ctx.db.get).not.toHaveBeenCalled();
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+    expect(ctx.db.query).not.toHaveBeenCalled();
+  });
+
+  it("keeps concurrent package version publishes off the shared publisher row", async () => {
+    const ctx = {
+      db: {
+        get: vi.fn(),
+        patch: vi.fn(),
+        query: vi.fn(),
+      },
+    };
+
+    await Promise.all(
+      ["alpha", "bravo", "charlie", "delta"].map((name, index) =>
+        adjustPublisherStatsForPackageChange(
+          ctx as never,
+          makePackage({
+            _id: `packages:${name}`,
+            stats: { downloads: 10 + index, installs: 4, stars: 2, versions: 1 },
+          }),
+          makePackage({
+            _id: `packages:${name}`,
+            stats: { downloads: 10 + index, installs: 4, stars: 2, versions: 2 },
+          }),
+        ),
+      ),
+    );
+
+    expect(ctx.db.get).not.toHaveBeenCalled();
+    expect(ctx.db.patch).not.toHaveBeenCalled();
     expect(ctx.db.query).not.toHaveBeenCalled();
   });
 });

--- a/convex/lib/publisherStats.ts
+++ b/convex/lib/publisherStats.ts
@@ -91,11 +91,23 @@ async function recomputePublisherStats(
   );
 }
 
+export function isZeroPublisherStatsContribution(delta: PublisherStatsContribution) {
+  return (
+    delta.publishedSkills === 0 &&
+    delta.publishedPackages === 0 &&
+    delta.totalInstalls === 0 &&
+    delta.totalDownloads === 0 &&
+    delta.totalStars === 0
+  );
+}
+
 async function patchPublisherStats(
   ctx: Pick<MutationCtx, "db">,
   publisherId: Id<"publishers">,
   delta: PublisherStatsContribution,
 ) {
+  if (isZeroPublisherStatsContribution(delta)) return;
+
   const publisher = await ctx.db.get(publisherId);
   if (!publisher) return;
 

--- a/packages/clawhub/src/cli/commands/packages.test.ts
+++ b/packages/clawhub/src/cli/commands/packages.test.ts
@@ -1035,6 +1035,9 @@ describe("package commands", () => {
       });
       expect(getUploadedFileNames()).toEqual([]);
       expect(getUploadedClawPackNames()).toEqual(["scope-demo-plugin-1.0.0.tgz"]);
+      expect(httpMocks.apiRequestForm.mock.calls[0]?.[1]).toEqual(
+        expect.objectContaining({ retryCount: 5 }),
+      );
       const uploadedPack = getUploadedClawPacks()[0];
       if (!uploadedPack) throw new Error("Missing uploaded ClawPack");
       const parsed = parseClawPack(new Uint8Array(await uploadedPack.arrayBuffer()));

--- a/packages/clawhub/src/cli/commands/packages.ts
+++ b/packages/clawhub/src/cli/commands/packages.ts
@@ -52,6 +52,7 @@ const LEGACY_DOT_DIR = ".clawdhub";
 const DOT_IGNORE = ".clawhubignore";
 const LEGACY_DOT_IGNORE = ".clawdhubignore";
 const MAX_CLAWPACK_BYTES = 120 * 1024 * 1024;
+const PACKAGE_PUBLISH_RETRY_COUNT = 5;
 
 type PackageInspectOptions = {
   version?: string;
@@ -687,7 +688,13 @@ export async function cmdPublishPackage(
       if (spinner) spinner.text = `Publishing ${plan.payload.name}@${plan.payload.version}`;
       const result = await apiRequestForm(
         registry,
-        { method: "POST", path: ApiRoutes.packages, token: publishToken, form },
+        {
+          method: "POST",
+          path: ApiRoutes.packages,
+          token: publishToken,
+          form,
+          retryCount: PACKAGE_PUBLISH_RETRY_COUNT,
+        },
         ApiV1PackagePublishResponseSchema,
       );
 

--- a/packages/clawhub/src/http.test.ts
+++ b/packages/clawhub/src/http.test.ts
@@ -208,6 +208,61 @@ describe("node http client", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(3);
   });
 
+  it("retries and labels transient Convex write contention", async () => {
+    const contention =
+      'Documents read from or written to the "publishers" table changed while this mutation was being run';
+    const { setTimeoutImpl, clearTimeoutImpl } = createImmediateTimeouts();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: async () => contention,
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: async () => contention,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true }),
+      });
+    const client = createNodeClient({
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      setTimeoutImpl: setTimeoutImpl as unknown as typeof setTimeout,
+      clearTimeoutImpl,
+    });
+
+    await expect(
+      client.apiRequestForm(
+        "https://example.com",
+        { method: "POST", path: "/upload", form: new FormData(), retryCount: 5 },
+        undefined,
+      ),
+    ).resolves.toEqual({ ok: true });
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+
+    const failingFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: async () => contention,
+    });
+    const failingClient = createNodeClient({
+      fetchImpl: failingFetch as unknown as typeof fetch,
+      setTimeoutImpl: setTimeoutImpl as unknown as typeof setTimeout,
+      clearTimeoutImpl,
+    });
+    await expect(
+      failingClient.apiRequestForm("https://example.com", {
+        method: "POST",
+        path: "/upload",
+        form: new FormData(),
+        retryCount: 0,
+      }),
+    ).rejects.toThrow(/Transient ClawHub write contention.*package artifact passed/i);
+  });
+
   it("expands generic auth and visibility failures into actionable messages", async () => {
     const fetchImpl = vi
       .fn()

--- a/packages/clawhub/src/http.test.ts
+++ b/packages/clawhub/src/http.test.ts
@@ -235,11 +235,12 @@ describe("node http client", () => {
     });
 
     await expect(
-      client.apiRequestForm(
-        "https://example.com",
-        { method: "POST", path: "/upload", form: new FormData(), retryCount: 5 },
-        undefined,
-      ),
+      client.apiRequestForm("https://example.com", {
+        method: "POST",
+        path: "/upload",
+        form: new FormData(),
+        retryCount: 5,
+      }),
     ).resolves.toEqual({ ok: true });
     expect(fetchImpl).toHaveBeenCalledTimes(3);
 

--- a/packages/clawhub/src/http.ts
+++ b/packages/clawhub/src/http.ts
@@ -32,12 +32,24 @@ const CURL_WRITE_OUT_FORMAT = [
 export type HttpRuntime = "node" | "bun";
 
 type RequestArgs =
-  | { method: "GET" | "POST" | "DELETE"; path: string; token?: string; body?: unknown }
-  | { method: "GET" | "POST" | "DELETE"; url: string; token?: string; body?: unknown };
+  | {
+      method: "GET" | "POST" | "DELETE";
+      path: string;
+      token?: string;
+      body?: unknown;
+      retryCount?: number;
+    }
+  | {
+      method: "GET" | "POST" | "DELETE";
+      url: string;
+      token?: string;
+      body?: unknown;
+      retryCount?: number;
+    };
 
 type FormRequestArgs =
-  | { method: "POST"; path: string; token?: string; form: FormData }
-  | { method: "POST"; url: string; token?: string; form: FormData };
+  | { method: "POST"; path: string; token?: string; form: FormData; retryCount?: number }
+  | { method: "POST"; url: string; token?: string; form: FormData; retryCount?: number };
 
 type TextRequestArgs = { path: string; token?: string } | { url: string; token?: string };
 
@@ -170,7 +182,7 @@ export function createHttpClient(options: HttpClientOptions = {}): HttpClient {
         );
       }
       return (await response.json()) as unknown;
-    });
+    }, args.retryCount);
     if (schema) return parseArk(schema, json, "API response");
     return json as T;
   }
@@ -207,7 +219,7 @@ export function createHttpClient(options: HttpClientOptions = {}): HttpClient {
         );
       }
       return (await response.json()) as unknown;
-    });
+    }, args.retryCount);
     if (schema) return parseArk(schema, json, "API response");
     return json as T;
   }
@@ -357,9 +369,12 @@ export async function downloadZip(
 }
 
 function createRetryRunner(deps: Pick<HttpClientDeps, "setTimeoutImpl" | "random" | "now">) {
-  return async function runWithRetries<T>(fn: () => Promise<T>): Promise<T> {
+  return async function runWithRetries<T>(
+    fn: () => Promise<T>,
+    retryCount = RETRY_COUNT,
+  ): Promise<T> {
     return await pRetry(fn, {
-      retries: RETRY_COUNT,
+      retries: retryCount,
       minTimeout: 0,
       maxTimeout: 0,
       factor: 1,
@@ -436,8 +451,9 @@ function throwHttpStatusError(
   now: () => number,
 ): never {
   const rateLimit = parseRateLimitInfo(headers, now);
+  const retryableTransientContention = isTransientConvexContention(text);
   const message = buildHttpErrorMessage(status, text, rateLimit);
-  if (status === 429 || status >= 500) {
+  if (status === 429 || status >= 500 || retryableTransientContention) {
     throw new HttpStatusError(status, message, rateLimit);
   }
   throw new AbortError(message);
@@ -462,6 +478,9 @@ function normalizeHttpErrorBody(status: number, text: string): string {
   const body = text.trim();
   const lowered = body.toLowerCase();
   if (body && lowered !== "unauthorized" && lowered !== "forbidden") {
+    if (isTransientConvexContention(body)) {
+      return `Transient ClawHub write contention. The package artifact passed request validation; retrying usually succeeds. ${body}`;
+    }
     if (status === 404 && lowered === "package not found") {
       return "Package not found or not visible to this account.";
     }
@@ -478,6 +497,16 @@ function normalizeHttpErrorBody(status: number, text: string): string {
   }
   if (body) return body;
   return `HTTP ${status}`;
+}
+
+function isTransientConvexContention(text: string) {
+  const lowered = text.toLowerCase();
+  return (
+    lowered.includes("optimistic concurrency") ||
+    lowered.includes("write conflict") ||
+    (lowered.includes('documents read from or written to the "') &&
+      lowered.includes("changed while this mutation was being run"))
+  );
 }
 
 function parseRateLimitInfo(headers: HeaderSource, now: () => number): RateLimitInfo {


### PR DESCRIPTION
## Summary
- skip publisher-row writes for package publishes that only add a version and do not change publisher aggregate stats
- return retryable 503 responses for transient Convex write contention from package publish
- make CLI package publish retry transient Convex contention, including old 400 contention bodies during backend deploy skew

## Tests
- bun run test -- convex/lib/publisherStats.test.ts convex/functions.test.ts convex/packages.public.test.ts convex/httpApiV1.handlers.test.ts
- cd packages/clawhub && bun run test:src -- src/http.test.ts src/http.bun.test.ts src/cli/commands/packages.test.ts
- bunx tsc -p packages/schema/tsconfig.json --noEmit
- bunx tsc -p packages/clawhub/tsconfig.json --noEmit
- bun run ci:static
- bunx convex codegen
- codex-review --mode local
