### PR TITLE
fix: preserve skill updated timestamp on scans

### DIFF
--- a/.agents/skills/autoreview/SKILL.md
+++ b/.agents/skills/autoreview/SKILL.md
@@ -50,15 +50,15 @@ Use when:
 
 Pick the smallest proof that matches the touched surface:
 
-| Touched surface | Usual proof |
-| --- | --- |
-| Formatting/lint/static repo health | `bun run ci:static` |
-| Unit-tested source behavior | focused `bunx vitest run ...`, then `bun run ci:unit` when PR-ready |
-| Convex code | read `convex/_generated/ai/guidelines.md` first; run focused tests and the deploy/typecheck path that covers the change |
-| Packages/CLI/mod tool | `bun run ci:packages` or the package-specific `verify` script |
-| Runtime/build/package surface | `bun run ci:types-build`, `bun run ci:e2e-http`, or the matching broader gate |
-| UI behavior | use `clawhub-ui-proof` with `proof:ui`; publish proof before final PR comments when needed |
-| Linux/CI-parity validation | use `crabbox`, normally through the repo scripts |
+| Touched surface                    | Usual proof                                                                                                             |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Formatting/lint/static repo health | `bun run ci:static`                                                                                                     |
+| Unit-tested source behavior        | focused `bunx vitest run ...`, then `bun run ci:unit` when PR-ready                                                     |
+| Convex code                        | read `convex/_generated/ai/guidelines.md` first; run focused tests and the deploy/typecheck path that covers the change |
+| Packages/CLI/mod tool              | `bun run ci:packages` or the package-specific `verify` script                                                           |
+| Runtime/build/package surface      | `bun run ci:types-build`, `bun run ci:e2e-http`, or the matching broader gate                                           |
+| UI behavior                        | use `clawhub-ui-proof` with `proof:ui`; publish proof before final PR comments when needed                              |
+| Linux/CI-parity validation         | use `crabbox`, normally through the repo scripts                                                                        |
 
 For Convex query or schema work, apply the repo's Convex rules: prefer indexes
 over `.filter()` scans, use cursor-based backfills for data shape changes, and
@@ -166,7 +166,7 @@ The helper:
 - writes only to stdout unless `--output` or `AUTOREVIEW_OUTPUT` is set
 - supports `--dry-run`, `--parallel-tests`, and commit refs
 - runs nested review with `--dangerously-bypass-approvals-and-sandbox --sandbox
-  danger-full-access` by default; use `--no-yolo` or `AUTOREVIEW_YOLO=0` to opt
+danger-full-access` by default; use `--no-yolo` or `AUTOREVIEW_YOLO=0` to opt
   out
 - prints `autoreview clean: no accepted/actionable findings reported` when the
   selected review command exits 0 and no accepted/actionable findings are

--- a/convex/skills.manualOverrides.test.ts
+++ b/convex/skills.manualOverrides.test.ts
@@ -78,6 +78,12 @@ function makeCtx(params: { skill: Record<string, unknown>; version?: Record<stri
   };
 }
 
+function findPatchForId(patch: ReturnType<typeof vi.fn>, id: string) {
+  return (patch.mock.calls as Array<[string, Record<string, unknown>]>).find(
+    ([patchedId]) => patchedId === id,
+  )?.[1];
+}
+
 describe("skills manual overrides", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -480,9 +486,7 @@ describe("skills manual overrides", () => {
       },
     });
 
-    const skillPatch = patch.mock.calls.find(([id]) => id === "skills:1")?.[1] as
-      | Record<string, unknown>
-      | undefined;
+    const skillPatch = findPatchForId(patch, "skills:1");
     expect(skillPatch).toEqual(
       expect.objectContaining({
         moderationEvaluatedAt: now,
@@ -534,9 +538,7 @@ describe("skills manual overrides", () => {
       },
     });
 
-    const skillPatch = patch.mock.calls.find(([id]) => id === "skills:1")?.[1] as
-      | Record<string, unknown>
-      | undefined;
+    const skillPatch = findPatchForId(patch, "skills:1");
     expect(skillPatch).toEqual(
       expect.objectContaining({
         moderationReason: "manual.override.clean",

--- a/convex/skills.manualOverrides.test.ts
+++ b/convex/skills.manualOverrides.test.ts
@@ -445,6 +445,108 @@ describe("skills manual overrides", () => {
     expect(query).not.toHaveBeenCalled();
   });
 
+  it("does not bump public updatedAt when llm scan sync updates moderation", async () => {
+    const originalUpdatedAt = 1_700_000_100_000;
+    const now = 1_700_000_300_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+
+    const skill = {
+      _id: "skills:1",
+      ownerUserId: "users:owner",
+      latestVersionId: "skillVersions:8",
+      softDeletedAt: undefined,
+      updatedAt: originalUpdatedAt,
+      moderationStatus: "active",
+      moderationReason: "scanner.vt.clean",
+      moderationVerdict: "clean",
+      moderationFlags: undefined,
+    };
+    const version = {
+      _id: "skillVersions:8",
+      skillId: "skills:1",
+      staticScan: undefined,
+      vtAnalysis: { status: "clean", checkedAt: now - 100 },
+      llmAnalysis: undefined,
+    };
+
+    const { ctx, patch } = makeCtx({ skill, version });
+
+    await updateVersionLlmAnalysisInternalHandler(ctx, {
+      versionId: "skillVersions:8",
+      llmAnalysis: {
+        status: "suspicious",
+        verdict: "suspicious",
+        checkedAt: now,
+      },
+    });
+
+    const skillPatch = patch.mock.calls.find(([id]) => id === "skills:1")?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    expect(skillPatch).toEqual(
+      expect.objectContaining({
+        moderationEvaluatedAt: now,
+        moderationSourceVersionId: "skillVersions:8",
+      }),
+    );
+    expect(skillPatch).not.toHaveProperty("updatedAt");
+  });
+
+  it("does not bump public updatedAt when llm scan sync preserves a manual override", async () => {
+    const originalUpdatedAt = 1_700_000_100_000;
+    const overrideUpdatedAt = 1_700_000_200_000;
+    const now = 1_700_000_300_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+
+    const skill = {
+      _id: "skills:1",
+      ownerUserId: "users:owner",
+      latestVersionId: "skillVersions:8",
+      softDeletedAt: undefined,
+      updatedAt: originalUpdatedAt,
+      manualOverride: {
+        verdict: "clean",
+        note: "reviewed",
+        reviewerUserId: "users:moderator",
+        updatedAt: overrideUpdatedAt,
+      },
+      moderationStatus: "active",
+      moderationReason: "manual.override.clean",
+      moderationVerdict: "clean",
+      moderationFlags: undefined,
+    };
+    const version = {
+      _id: "skillVersions:8",
+      skillId: "skills:1",
+      staticScan: undefined,
+      vtAnalysis: { status: "clean", checkedAt: now - 100 },
+      llmAnalysis: undefined,
+    };
+
+    const { ctx, patch } = makeCtx({ skill, version });
+
+    await updateVersionLlmAnalysisInternalHandler(ctx, {
+      versionId: "skillVersions:8",
+      llmAnalysis: {
+        status: "suspicious",
+        verdict: "suspicious",
+        checkedAt: now,
+      },
+    });
+
+    const skillPatch = patch.mock.calls.find(([id]) => id === "skills:1")?.[1] as
+      | Record<string, unknown>
+      | undefined;
+    expect(skillPatch).toEqual(
+      expect.objectContaining({
+        moderationReason: "manual.override.clean",
+        moderationEvaluatedAt: overrideUpdatedAt,
+        moderationSourceVersionId: "skillVersions:8",
+      }),
+    );
+    expect(skillPatch).not.toHaveProperty("updatedAt");
+  });
+
   it("updates global public count when llm scan sync restores a skill to active", async () => {
     const now = 1_700_000_300_000;
     vi.spyOn(Date, "now").mockReturnValue(now);

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -401,7 +401,6 @@ function buildScannerModerationPatchFromVersion(params: {
     hiddenAt: moderationStatus === "hidden" ? params.now : undefined,
     hiddenBy: undefined,
     lastReviewedAt: moderationStatus === "hidden" ? params.now : undefined,
-    updatedAt: params.now,
   };
 }
 
@@ -420,11 +419,13 @@ function applySkillManualOverrideToSkillPatch(params: {
   now: number;
 }) {
   if (!params.skill.manualOverride) return params.basePatch;
-  return applyManualOverrideToSkillPatch({
+  const patch = applyManualOverrideToSkillPatch({
     basePatch: params.basePatch,
     override: params.skill.manualOverride,
     now: params.now,
   });
+  const { updatedAt: _updatedAt, ...scannerPatch } = patch;
+  return scannerPatch;
 }
 
 async function patchStructuredModerationFromVersion(
@@ -448,10 +449,7 @@ async function patchStructuredModerationFromVersion(
   });
 
   const nextSkill = { ...skill, ...patch };
-  await ctx.db.patch(skill._id, {
-    ...patch,
-    updatedAt: now,
-  });
+  await ctx.db.patch(skill._id, patch);
   await adjustGlobalPublicCountForSkillChange(ctx, skill, nextSkill);
 }
 const TRUSTED_PUBLISHER_SKILL_THRESHOLD = 10;
@@ -5935,10 +5933,7 @@ export const updateSkillVersionStaticScanInternal = internalMutation({
     });
     const patch = applySkillManualOverrideToSkillPatch({
       skill,
-      basePatch: {
-        ...basePatch,
-        updatedAt: now,
-      },
+      basePatch,
       now,
     });
     const nextSkill = { ...skill, ...patch };
@@ -7011,7 +7006,6 @@ export const approveSkillByHashInternal = internalMutation({
         unpublishedSlugReleasedAt: undefined,
         unpublishedOriginalSlug: undefined,
         lastReviewedAt: nextModerationStatus === "hidden" ? now : undefined,
-        updatedAt: now,
       };
       const patch = applySkillManualOverrideToSkillPatch({
         skill,
@@ -7108,7 +7102,6 @@ export const escalateByVtInternal = internalMutation({
       moderationEngineVersion: snapshot.engineVersion,
       moderationEvaluatedAt: snapshot.evaluatedAt,
       moderationSourceVersionId: version._id,
-      updatedAt: now,
     };
     if (bypassSuspicious) {
       basePatch.moderationReason = normalizeScannerSuspiciousReason(

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -417,6 +417,7 @@ function applySkillManualOverrideToSkillPatch(params: {
   skill: Pick<Doc<"skills">, "manualOverride">;
   basePatch: SkillModerationPatch;
   now: number;
+  stripUpdatedAt?: boolean;
 }) {
   if (!params.skill.manualOverride) return params.basePatch;
   const patch = applyManualOverrideToSkillPatch({
@@ -424,8 +425,9 @@ function applySkillManualOverrideToSkillPatch(params: {
     override: params.skill.manualOverride,
     now: params.now,
   });
-  const { updatedAt: _updatedAt, ...scannerPatch } = patch;
-  return scannerPatch;
+  if (!params.stripUpdatedAt) return patch;
+  const { updatedAt: _updatedAt, ...timestampFreePatch } = patch;
+  return timestampFreePatch;
 }
 
 async function patchStructuredModerationFromVersion(
@@ -446,6 +448,7 @@ async function patchStructuredModerationFromVersion(
     skill,
     basePatch,
     now,
+    stripUpdatedAt: true,
   });
 
   const nextSkill = { ...skill, ...patch };
@@ -635,6 +638,7 @@ async function syncSkillModerationFromLatestVersion(
     skill,
     basePatch,
     now,
+    stripUpdatedAt: true,
   });
 
   const nextSkill = { ...skill, ...patch };
@@ -5935,6 +5939,7 @@ export const updateSkillVersionStaticScanInternal = internalMutation({
       skill,
       basePatch,
       now,
+      stripUpdatedAt: true,
     });
     const nextSkill = { ...skill, ...patch };
     await ctx.db.patch(skill._id, patch);
@@ -7011,6 +7016,7 @@ export const approveSkillByHashInternal = internalMutation({
         skill,
         basePatch,
         now,
+        stripUpdatedAt: true,
       });
       const nextSkill = { ...skill, ...patch };
       await ctx.db.patch(skill._id, patch);
@@ -7153,6 +7159,7 @@ export const escalateByVtInternal = internalMutation({
       skill,
       basePatch,
       now,
+      stripUpdatedAt: true,
     });
     const nextSkill = { ...skill, ...patch };
     await ctx.db.patch(skill._id, patch);


### PR DESCRIPTION
## Summary

- Keep scanner/moderation refreshes from bumping the public skill `updatedAt` timestamp
- Preserve scanner moderation sync behavior while stripping `updatedAt` from manual-override-preserved scan patches
- Add regression coverage for normal LLM scan sync and manual-override-preserved LLM scan sync

## Tests

- `bun run test convex/skills.manualOverrides.test.ts convex/lib/manualOverrides.test.ts`
- `bun run lint`
