### PR TITLE
Fix synchronous skill star counts

### DIFF
--- a/convex/skillStatEvents.test.ts
+++ b/convex/skillStatEvents.test.ts
@@ -1,11 +1,86 @@
 /* @vitest-environment node */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./functions", () => ({
+  internalAction: (def: { handler: unknown }) => ({ _handler: def.handler }),
+  internalMutation: (def: { handler: unknown }) => ({ _handler: def.handler }),
+  internalQuery: (def: { handler: unknown }) => ({ _handler: def.handler }),
+}));
+
+vi.mock("./_generated/api", () => ({
+  internal: {
+    skillStatEvents: {
+      processSkillStatEventsAction: Symbol("processSkillStatEventsAction"),
+      processSkillStatEventsInternal: Symbol("processSkillStatEventsInternal"),
+    },
+  },
+}));
+
+const { processSkillStatEventsInternal } = await import("./skillStatEvents");
+
+const processSkillStatEventsInternalHandler = (
+  processSkillStatEventsInternal as unknown as {
+    _handler: (ctx: unknown, args: { batchSize?: number }) => Promise<{ processed: number }>;
+  }
+)._handler;
 
 // Test the aggregateEvents function by importing and testing the module logic
 // Since aggregateEvents is not exported, we test the behavior indirectly through
 // the event processing contract
 
 describe("skill stat events - comment delta handling", () => {
+  it("marks queued star events processed without patching skill stats", async () => {
+    const starEvent = {
+      _id: "skillStatEvents:star",
+      skillId: "skills:1",
+      kind: "star",
+      occurredAt: 1000,
+      processedAt: undefined,
+    };
+    const skill = {
+      _id: "skills:1",
+      ownerUserId: "users:owner",
+      statsDownloads: 0,
+      statsStars: 0,
+      statsInstallsCurrent: 0,
+      statsInstallsAllTime: 0,
+      stats: {
+        downloads: 0,
+        stars: 0,
+        installsCurrent: 0,
+        installsAllTime: 0,
+        versions: 1,
+        comments: 0,
+      },
+    };
+    const patch = vi.fn();
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => (id === "skills:1" ? skill : null)),
+        patch,
+        query: vi.fn((table: string) => {
+          if (table !== "skillStatEvents") throw new Error(`unexpected table ${table}`);
+          return {
+            withIndex: () => ({
+              take: async () => [starEvent],
+            }),
+          };
+        }),
+      },
+      scheduler: { runAfter: vi.fn() },
+    };
+
+    await expect(processSkillStatEventsInternalHandler(ctx, { batchSize: 10 })).resolves.toEqual({
+      processed: 1,
+    });
+
+    expect(patch).toHaveBeenCalledTimes(1);
+    expect(patch).toHaveBeenCalledWith(
+      "skillStatEvents:star",
+      expect.objectContaining({ processedAt: expect.any(Number) }),
+    );
+  });
+
   it("aggregates comment and uncomment events into net deltas", () => {
     // Simulate the aggregation logic from processSkillStatEventsAction
     type EventKind =
@@ -45,10 +120,8 @@ describe("skill stat events - comment delta handling", () => {
           result.downloadEvents.push(event.occurredAt);
           break;
         case "star":
-          result.stars += 1;
           break;
         case "unstar":
-          result.stars -= 1;
           break;
         case "comment":
           result.comments += 1;
@@ -70,7 +143,7 @@ describe("skill stat events - comment delta handling", () => {
       }
     }
 
-    expect(result.stars).toBe(1);
+    expect(result.stars).toBe(0);
     expect(result.comments).toBe(1); // 2 comments - 1 uncomment
     expect(result.downloads).toBe(1);
     expect(result.downloadEvents).toEqual([5000]);

--- a/convex/skillStatEvents.ts
+++ b/convex/skillStatEvents.ts
@@ -30,8 +30,7 @@ import { adjustUserSkillStatsForSkillChange } from "./lib/userSkillStats";
  * Event types that affect skill stats:
  *
  * - download: User downloaded skill as zip (+1 downloads)
- * - star: User starred the skill (+1 stars)
- * - unstar: User removed their star (-1 stars)
+ * - star/unstar: legacy queued events; star rows now update counts synchronously
  * - install_new: First time this user installed this skill (+1 installsAllTime, +1 installsCurrent)
  * - install_reactivate: User re-added skill after removing it (+1 installsCurrent only)
  * - install_deactivate: User removed skill from all projects (-1 installsCurrent)
@@ -140,10 +139,11 @@ function aggregateEvents(events: Doc<"skillStatEvents">[]): AggregatedDeltas {
         result.downloadEvents.push(event.occurredAt);
         break;
       case "star":
-        result.stars += 1;
+        // Star counts are updated synchronously from `stars` mutations now.
+        // Historical queued star events are marked processed without changing stats.
         break;
       case "unstar":
-        result.stars -= 1;
+        // See `star` above.
         break;
       case "comment":
         result.comments += 1;
@@ -497,10 +497,10 @@ export const processSkillStatEventsAction = internalAction({
             skillDelta.downloadEvents.push(event.occurredAt);
             break;
           case "star":
-            skillDelta.stars += 1;
+            // Star counts are updated synchronously from `stars` mutations now.
             break;
           case "unstar":
-            skillDelta.stars -= 1;
+            // Historical queued unstar events should not double-apply.
             break;
           case "comment":
             skillDelta.comments += 1;

--- a/convex/stars.test.ts
+++ b/convex/stars.test.ts
@@ -1,52 +1,228 @@
 /* @vitest-environment node */
-
 import { getAuthUserId } from "@convex-dev/auth/server";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { isStarred as isSoulStarred } from "./soulStars";
-import { isStarred } from "./stars";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./skillStatEvents", () => ({
+  insertStatEvent: vi.fn(),
+}));
 
 vi.mock("@convex-dev/auth/server", () => ({
   getAuthUserId: vi.fn(),
 }));
 
-function unwrapHandler(wrapped: unknown) {
-  const handler = (wrapped as { _handler?: unknown })._handler;
-  if (typeof handler !== "function") {
-    throw new Error("Expected Convex test wrapper to expose _handler");
-  }
-  return handler;
-}
+vi.mock("./functions", () => ({
+  internalMutation: (def: { handler: unknown }) => ({ _handler: def.handler }),
+  mutation: (def: { handler: unknown }) => ({ _handler: def.handler }),
+  query: (def: { handler: unknown }) => ({ _handler: def.handler }),
+}));
 
-const isStarredHandler = unwrapHandler(isStarred) as (
-  ctx: unknown,
-  args: { skillId: string },
-) => Promise<boolean>;
-const isSoulStarredHandler = unwrapHandler(isSoulStarred) as (
-  ctx: unknown,
-  args: { soulId: string },
-) => Promise<boolean>;
+const { insertStatEvent } = await import("./skillStatEvents");
+const { isStarred: isSoulStarred } = await import("./soulStars");
+const { addStarInternal, isStarred, removeStarInternal, toggle } = await import("./stars");
 
-function makeCtx(options: { user?: Record<string, unknown> | null; existingStar?: unknown }) {
+type WrappedHandler<TArgs, TResult> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
+};
+
+const toggleHandler = (
+  toggle as unknown as WrappedHandler<{ skillId: string }, { starred: boolean }>
+)._handler;
+const addStarInternalHandler = (
+  addStarInternal as unknown as WrappedHandler<
+    { userId: string; skillId: string },
+    { ok: true; starred: boolean; alreadyStarred: boolean }
+  >
+)._handler;
+const removeStarInternalHandler = (
+  removeStarInternal as unknown as WrappedHandler<
+    { userId: string; skillId: string },
+    { ok: true; unstarred: boolean; alreadyUnstarred: boolean }
+  >
+)._handler;
+const isStarredHandler = (isStarred as unknown as WrappedHandler<{ skillId: string }, boolean>)
+  ._handler;
+const isSoulStarredHandler = (
+  isSoulStarred as unknown as WrappedHandler<{ soulId: string }, boolean>
+)._handler;
+
+function makeSkill(overrides: Record<string, unknown> = {}) {
   return {
-    db: {
-      get: vi.fn(async (id: string) => {
-        if (id === "users:viewer") return options.user ?? { _id: "users:viewer" };
-        return null;
-      }),
-      query: vi.fn(() => ({
-        withIndex: vi.fn(() => ({
-          unique: vi.fn().mockResolvedValue(options.existingStar ?? null),
-        })),
-      })),
+    _id: "skills:1",
+    ownerUserId: "users:owner",
+    softDeletedAt: undefined,
+    statsDownloads: 10,
+    statsStars: 2,
+    statsInstallsCurrent: 3,
+    statsInstallsAllTime: 4,
+    stats: {
+      downloads: 10,
+      stars: 2,
+      installsCurrent: 3,
+      installsAllTime: 4,
+      versions: 1,
+      comments: 0,
     },
+    ...overrides,
   };
 }
 
-beforeEach(() => {
-  vi.mocked(getAuthUserId).mockReset();
+function makeCtx(params: {
+  skill?: Record<string, unknown>;
+  existingStar?: Record<string, unknown> | null;
+  user?: Record<string, unknown> | null;
+}) {
+  const skill = params.skill ?? makeSkill();
+  const owner = {
+    _id: "users:owner",
+    publishedSkills: 1,
+    totalStars: 2,
+    totalDownloads: 10,
+  };
+  const viewer = params.user === undefined ? { _id: "users:viewer", role: "user" } : params.user;
+  const get = vi.fn(async (id: string) => {
+    if (id === "skills:1") return skill;
+    if (id === "users:owner") return owner;
+    if (id === "users:viewer") return viewer;
+    return null;
+  });
+  const insert = vi.fn();
+  const deleteDoc = vi.fn();
+  const patch = vi.fn();
+  const query = vi.fn((table: string) => {
+    if (table !== "stars" && table !== "soulStars") throw new Error(`unexpected table ${table}`);
+    return {
+      withIndex: () => ({
+        unique: async () => params.existingStar ?? null,
+      }),
+    };
+  });
+  return {
+    ctx: { db: { get, insert, delete: deleteDoc, patch, query } },
+    db: { get, insert, deleteDoc, patch, query },
+  };
+}
+
+describe("stars mutations", () => {
+  afterEach(() => {
+    vi.mocked(getAuthUserId).mockReset();
+    vi.mocked(insertStatEvent).mockReset();
+  });
+
+  it("toggle inserts a star row and updates denormalized star counts synchronously", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:viewer" as never);
+    const { ctx, db } = makeCtx({ existingStar: null });
+
+    const result = await toggleHandler(ctx, { skillId: "skills:1" });
+
+    expect(result).toEqual({ starred: true });
+    expect(db.insert).toHaveBeenCalledWith("stars", {
+      skillId: "skills:1",
+      userId: "users:viewer",
+      createdAt: expect.any(Number),
+    });
+    expect(db.patch).toHaveBeenCalledWith(
+      "skills:1",
+      expect.objectContaining({
+        statsStars: 3,
+        stats: expect.objectContaining({ stars: 3 }),
+      }),
+    );
+    expect(db.patch).toHaveBeenCalledWith(
+      "users:owner",
+      expect.objectContaining({ totalStars: 3 }),
+    );
+    expect(insertStatEvent).not.toHaveBeenCalled();
+  });
+
+  it("toggle deletes a star row and decrements counts without going below zero", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:viewer" as never);
+    const { ctx, db } = makeCtx({
+      skill: makeSkill({
+        statsStars: 0,
+        stats: {
+          downloads: 10,
+          stars: 0,
+          installsCurrent: 3,
+          installsAllTime: 4,
+          versions: 1,
+          comments: 0,
+        },
+      }),
+      existingStar: { _id: "stars:1", skillId: "skills:1", userId: "users:viewer" },
+    });
+
+    const result = await toggleHandler(ctx, { skillId: "skills:1" });
+
+    expect(result).toEqual({ starred: false });
+    expect(db.deleteDoc).toHaveBeenCalledWith("stars:1");
+    expect(db.patch).toHaveBeenCalledWith(
+      "skills:1",
+      expect.objectContaining({
+        statsStars: 0,
+        stats: expect.objectContaining({ stars: 0 }),
+      }),
+    );
+    expect(insertStatEvent).not.toHaveBeenCalled();
+  });
+
+  it("addStarInternal is idempotent and increments only when inserting a row", async () => {
+    const alreadyStarred = makeCtx({
+      existingStar: { _id: "stars:1", skillId: "skills:1", userId: "users:viewer" },
+    });
+
+    await expect(
+      addStarInternalHandler(alreadyStarred.ctx, {
+        userId: "users:viewer",
+        skillId: "skills:1",
+      }),
+    ).resolves.toEqual({ ok: true, starred: true, alreadyStarred: true });
+    expect(alreadyStarred.db.patch).not.toHaveBeenCalled();
+
+    const newStar = makeCtx({ existingStar: null });
+    await expect(
+      addStarInternalHandler(newStar.ctx, {
+        userId: "users:viewer",
+        skillId: "skills:1",
+      }),
+    ).resolves.toEqual({ ok: true, starred: true, alreadyStarred: false });
+    expect(newStar.db.patch).toHaveBeenCalledWith(
+      "skills:1",
+      expect.objectContaining({ statsStars: 3 }),
+    );
+  });
+
+  it("removeStarInternal is idempotent and decrements only when deleting a row", async () => {
+    const alreadyUnstarred = makeCtx({ existingStar: null });
+
+    await expect(
+      removeStarInternalHandler(alreadyUnstarred.ctx, {
+        userId: "users:viewer",
+        skillId: "skills:1",
+      }),
+    ).resolves.toEqual({ ok: true, unstarred: false, alreadyUnstarred: true });
+    expect(alreadyUnstarred.db.patch).not.toHaveBeenCalled();
+
+    const existing = makeCtx({
+      existingStar: { _id: "stars:1", skillId: "skills:1", userId: "users:viewer" },
+    });
+    await expect(
+      removeStarInternalHandler(existing.ctx, {
+        userId: "users:viewer",
+        skillId: "skills:1",
+      }),
+    ).resolves.toEqual({ ok: true, unstarred: true, alreadyUnstarred: false });
+    expect(existing.db.patch).toHaveBeenCalledWith(
+      "skills:1",
+      expect.objectContaining({ statsStars: 1 }),
+    );
+  });
 });
 
 describe("stars queries", () => {
+  afterEach(() => {
+    vi.mocked(getAuthUserId).mockReset();
+  });
+
   it("returns false instead of throwing when skill star auth is stale", async () => {
     vi.mocked(getAuthUserId).mockResolvedValue("users:viewer" as never);
 

--- a/convex/stars.ts
+++ b/convex/stars.ts
@@ -1,8 +1,18 @@
 import { v } from "convex/values";
+import type { Doc } from "./_generated/dataModel";
+import type { MutationCtx } from "./_generated/server";
 import { internalMutation, mutation, query } from "./functions";
 import { getOptionalActiveAuthUserId, requireUser } from "./lib/access";
 import { toPublicSkill } from "./lib/public";
-import { insertStatEvent } from "./skillStatEvents";
+import { applySkillStatDeltas } from "./lib/skillStats";
+import { adjustUserSkillStatsForSkillChange } from "./lib/userSkillStats";
+
+async function applyStarDelta(ctx: Pick<MutationCtx, "db">, skill: Doc<"skills">, delta: 1 | -1) {
+  const patch = applySkillStatDeltas(skill, { stars: delta });
+  const nextSkill = { ...skill, ...patch };
+  await ctx.db.patch(skill._id, patch);
+  await adjustUserSkillStatsForSkillChange(ctx, skill, nextSkill);
+}
 
 export const isStarred = query({
   args: { skillId: v.id("skills") },
@@ -31,7 +41,7 @@ export const toggle = mutation({
 
     if (existing) {
       await ctx.db.delete(existing._id);
-      await insertStatEvent(ctx, { skillId: skill._id, kind: "unstar" });
+      await applyStarDelta(ctx, skill, -1);
       return { starred: false };
     }
 
@@ -43,7 +53,7 @@ export const toggle = mutation({
       createdAt: Date.now(),
     });
 
-    await insertStatEvent(ctx, { skillId: skill._id, kind: "star" });
+    await applyStarDelta(ctx, skill, 1);
 
     return { starred: true };
   },
@@ -86,7 +96,7 @@ export const addStarInternal = internalMutation({
       createdAt: Date.now(),
     });
 
-    await insertStatEvent(ctx, { skillId: skill._id, kind: "star" });
+    await applyStarDelta(ctx, skill, 1);
 
     return { ok: true as const, starred: true, alreadyStarred: false };
   },
@@ -104,7 +114,7 @@ export const removeStarInternal = internalMutation({
     if (!existing) return { ok: true as const, unstarred: false, alreadyUnstarred: true };
 
     await ctx.db.delete(existing._id);
-    await insertStatEvent(ctx, { skillId: skill._id, kind: "unstar" });
+    await applyStarDelta(ctx, skill, -1);
 
     return { ok: true as const, unstarred: true, alreadyUnstarred: false };
   },

--- a/e2e/local-auth/helpers.ts
+++ b/e2e/local-auth/helpers.ts
@@ -46,20 +46,23 @@ export function escapeRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-export async function signInAsLocalPersona(page: Page, persona: DevPersona) {
+export async function expectLocalPersonaActive(page: Page, persona: DevPersona) {
   const expectedHandle = persona === "owner" ? "local" : `local-${persona}`;
+  await expect(page.locator("header .user-trigger")).toContainText(
+    devPersonaHeaderPattern(persona, expectedHandle),
+    { timeout: 15_000 },
+  );
+}
 
+export async function signInAsLocalPersona(page: Page, persona: DevPersona) {
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await waitForHydration(page);
 
   await page.getByRole("button", { name: "Open local dev personas" }).click();
   await page.getByRole("menuitem", { name: new RegExp(`use ${persona}`, "i") }).click();
-  await expect(page.locator("header .user-trigger")).toContainText(
-    devPersonaHeaderPattern(persona, expectedHandle),
-    { timeout: 15_000 },
-  );
+  await expectLocalPersonaActive(page, persona);
 
-  return expectedHandle;
+  return persona === "owner" ? "local" : `local-${persona}`;
 }
 
 export async function signInAsLocalOwner(page: Page) {

--- a/e2e/local-auth/helpers.ts
+++ b/e2e/local-auth/helpers.ts
@@ -1,0 +1,128 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { expect, type Page, type TestInfo } from "@playwright/test";
+import { waitForHydration } from "../helpers/runtimeErrors";
+
+type DevPersona = "owner" | "user" | "admin";
+
+function devPersonaHeaderPattern(persona: DevPersona, expectedHandle: string) {
+  const displayName =
+    persona === "owner" ? "Local Owner" : persona === "user" ? "Local User" : "Local Admin";
+  const exactHandle =
+    persona === "owner"
+      ? `${escapeRegExp(expectedHandle)}(?![-\\w])`
+      : escapeRegExp(expectedHandle);
+  return new RegExp(`@(?:${exactHandle}|${escapeRegExp(displayName)})`, "i");
+}
+
+export function skillMd(args: { slug: string; displayName: string; versionLabel: string }) {
+  return `---
+name: ${args.slug}
+description: ${args.displayName} verifies that ClawHub can publish and replace skill releases through the browser UI.
+---
+
+# ${args.displayName}
+
+Use this skill when validating ClawHub's browser publishing workflow in local development or pull request CI.
+
+## Workflow
+
+The skill documents a realistic release process so the publish quality gate sees meaningful content.
+
+- Prepare a small folder with SKILL.md and supporting text files.
+- Publish the first release through the browser form.
+- Return from the detail page and publish a new version from owner settings.
+- Confirm the current version and version history both update after publication.
+
+## Verification Notes
+
+This ${args.versionLabel} payload is intentionally deterministic and text-only.
+It avoids external credentials, network access, binary files, and production state.
+Maintainers can run it against a disposable local Convex backend to prove the UI still supports the full version lifecycle.
+`;
+}
+
+export function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export async function signInAsLocalPersona(page: Page, persona: DevPersona) {
+  const expectedHandle = persona === "owner" ? "local" : `local-${persona}`;
+
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await waitForHydration(page);
+
+  await page.getByRole("button", { name: "Open local dev personas" }).click();
+  await page.getByRole("menuitem", { name: new RegExp(`use ${persona}`, "i") }).click();
+  await expect(page.locator("header .user-trigger")).toContainText(
+    devPersonaHeaderPattern(persona, expectedHandle),
+    { timeout: 15_000 },
+  );
+
+  return expectedHandle;
+}
+
+export async function signInAsLocalOwner(page: Page) {
+  return await signInAsLocalPublisher(page, "owner");
+}
+
+export async function signInAsLocalPublisher(page: Page, persona: DevPersona) {
+  await signInAsLocalPersona(page, persona);
+  await page.goto("/skills/publish", { waitUntil: "domcontentloaded" });
+  await expect(page.getByRole("heading", { name: "Publish a skill" })).toBeVisible();
+  const ownerSelect = page.locator("#ownerHandle");
+  await expect(ownerSelect).not.toHaveValue("");
+  const ownerHandle = await ownerSelect.inputValue();
+  expect(ownerHandle.toLowerCase()).toContain("local");
+  return ownerHandle;
+}
+
+export async function publishSkillVersion(
+  page: Page,
+  testInfo: TestInfo,
+  args: {
+    ownerHandle: string;
+    slug: string;
+    displayName: string;
+    version: string;
+    versionLabel: string;
+    changelog: string;
+  },
+) {
+  const skillDir = testInfo.outputPath(`${args.slug}-${args.version}`);
+  await mkdir(skillDir, { recursive: true });
+  await writeFile(
+    join(skillDir, "SKILL.md"),
+    skillMd({
+      slug: args.slug,
+      displayName: args.displayName,
+      versionLabel: args.versionLabel,
+    }),
+    "utf8",
+  );
+
+  const ownerSelect = page.locator("#ownerHandle");
+  await ownerSelect.selectOption(args.ownerHandle);
+  await expect(ownerSelect).toHaveValue(args.ownerHandle);
+  await page.locator("#slug").fill(args.slug);
+  await page.locator("#displayName").fill(args.displayName);
+  await page.locator("#version").fill(args.version);
+  await page.locator("#tags").fill("latest, stable");
+  await page.locator("#changelog").fill(args.changelog);
+  await page.getByLabel(/i have the rights to this skill/i).check();
+  await page.getByTestId("upload-input").setInputFiles(skillDir);
+
+  await expect(page.getByText("All checks passed.")).toBeVisible();
+  await page.getByRole("button", { name: "Publish skill" }).click();
+  await expect(page).toHaveURL(new RegExp(`/[^/]+/${escapeRegExp(args.slug)}$`), {
+    timeout: 60_000,
+  });
+  const [, actualOwnerHandle, actualSlug] = new URL(page.url()).pathname
+    .split("/")
+    .map(decodeURIComponent);
+  expect(actualOwnerHandle).toBeTruthy();
+  expect(actualOwnerHandle?.toLowerCase()).toContain(args.ownerHandle.toLowerCase());
+  expect(actualSlug).toBe(args.slug);
+  await expect(page.locator(".skill-page-title")).toHaveText(args.displayName);
+  return actualOwnerHandle!;
+}

--- a/e2e/local-auth/helpers.ts
+++ b/e2e/local-auth/helpers.ts
@@ -71,7 +71,22 @@ export async function signInAsLocalPublisher(page: Page, persona: DevPersona) {
   await page.goto("/skills/publish", { waitUntil: "domcontentloaded" });
   await expect(page.getByRole("heading", { name: "Publish a skill" })).toBeVisible();
   const ownerSelect = page.locator("#ownerHandle");
-  await expect(ownerSelect).not.toHaveValue("");
+  await expect
+    .poll(
+      async () => {
+        const value = await ownerSelect.inputValue();
+        const optionValues = await ownerSelect
+          .locator("option")
+          .evaluateAll((options) => options.map((option) => (option as HTMLOptionElement).value));
+        const isCurrentOption = value ? optionValues.includes(value) : false;
+        // The owner persona can briefly render the user handle before the
+        // personal publisher subscription reconciles to the publishable handle.
+        if (!isCurrentOption || (persona === "owner" && value === "local")) return "";
+        return value;
+      },
+      { timeout: 15_000 },
+    )
+    .not.toBe("");
   const ownerHandle = await ownerSelect.inputValue();
   expect(ownerHandle.toLowerCase()).toContain("local");
   return ownerHandle;

--- a/e2e/local-auth/publish-skill-lifecycle.pw.test.ts
+++ b/e2e/local-auth/publish-skill-lifecycle.pw.test.ts
@@ -1,109 +1,11 @@
-import { mkdir, writeFile } from "node:fs/promises";
-import { join } from "node:path";
-import { expect, test, type Page, type TestInfo } from "@playwright/test";
-import { expectHealthyPage, trackRuntimeErrors, waitForHydration } from "../helpers/runtimeErrors";
+import { expect, test } from "@playwright/test";
+import { expectHealthyPage, trackRuntimeErrors } from "../helpers/runtimeErrors";
+import { publishSkillVersion, signInAsLocalOwner } from "./helpers";
 
 test.skip(
   process.env.VITE_ENABLE_DEV_AUTH !== "1",
   "local-auth lifecycle tests require the local dev auth runner",
 );
-
-function skillMd(args: { slug: string; displayName: string; versionLabel: string }) {
-  return `---
-name: ${args.slug}
-description: ${args.displayName} verifies that ClawHub can publish and replace skill releases through the browser UI.
----
-
-# ${args.displayName}
-
-Use this skill when validating ClawHub's browser publishing workflow in local development or pull request CI.
-
-## Workflow
-
-The skill documents a realistic release process so the publish quality gate sees meaningful content.
-
-- Prepare a small folder with SKILL.md and supporting text files.
-- Publish the first release through the browser form.
-- Return from the detail page and publish a new version from owner settings.
-- Confirm the current version and version history both update after publication.
-
-## Verification Notes
-
-This ${args.versionLabel} payload is intentionally deterministic and text-only.
-It avoids external credentials, network access, binary files, and production state.
-Maintainers can run it against a disposable local Convex backend to prove the UI still supports the full version lifecycle.
-`;
-}
-
-function escapeRegExp(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-async function signInAsLocalOwner(page: Page) {
-  await page.goto("/", { waitUntil: "domcontentloaded" });
-  await waitForHydration(page);
-
-  await page.getByRole("button", { name: "Open local dev personas" }).click();
-  await page.getByRole("menuitem", { name: /use owner/i }).click();
-  await expect(page.locator("header .user-trigger")).toContainText(/@local(?: owner)?/i, {
-    timeout: 15_000,
-  });
-
-  await page.goto("/skills/publish", { waitUntil: "domcontentloaded" });
-  await expect(page.getByRole("heading", { name: "Publish a skill" })).toBeVisible();
-  const ownerSelect = page.locator("#ownerHandle");
-  await expect(ownerSelect).not.toHaveValue("");
-  const ownerHandle = await ownerSelect.inputValue();
-  expect(ownerHandle.toLowerCase()).toContain("local");
-  return ownerHandle;
-}
-
-async function publishSkillVersion(
-  page: Page,
-  testInfo: TestInfo,
-  args: {
-    ownerHandle: string;
-    slug: string;
-    displayName: string;
-    version: string;
-    versionLabel: string;
-    changelog: string;
-  },
-) {
-  const skillDir = testInfo.outputPath(`${args.slug}-${args.version}`);
-  await mkdir(skillDir, { recursive: true });
-  await writeFile(
-    join(skillDir, "SKILL.md"),
-    skillMd({
-      slug: args.slug,
-      displayName: args.displayName,
-      versionLabel: args.versionLabel,
-    }),
-    "utf8",
-  );
-
-  await page.locator("#slug").fill(args.slug);
-  await page.locator("#displayName").fill(args.displayName);
-  await page.locator("#version").fill(args.version);
-  await page.locator("#tags").fill("latest, stable");
-  await page.locator("#changelog").fill(args.changelog);
-  await page.getByLabel(/i have the rights to this skill/i).check();
-  await page.getByTestId("upload-input").setInputFiles(skillDir);
-
-  await expect(page.getByText("All checks passed.")).toBeVisible();
-  await page.getByRole("button", { name: "Publish skill" }).click();
-  await expect(page).toHaveURL(new RegExp(`/[^/]+/${escapeRegExp(args.slug)}$`), {
-    timeout: 60_000,
-  });
-  const [, actualOwnerHandle, actualSlug] = new URL(page.url()).pathname
-    .split("/")
-    .map(decodeURIComponent);
-  expect(actualOwnerHandle).toBeTruthy();
-  expect(actualOwnerHandle?.toLowerCase()).toContain(args.ownerHandle.toLowerCase());
-  expect(actualSlug).toBe(args.slug);
-  await expect(page.locator(".skill-page-title")).toHaveText(args.displayName);
-  return actualOwnerHandle!;
-}
 
 test("skill publishers can create a skill and publish a new version", async ({
   page,

--- a/e2e/local-auth/skill-star-sync.pw.test.ts
+++ b/e2e/local-auth/skill-star-sync.pw.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+import { expectHealthyPage, trackRuntimeErrors, waitForHydration } from "../helpers/runtimeErrors";
+import { publishSkillVersion, signInAsLocalPersona, signInAsLocalPublisher } from "./helpers";
+
+test.skip(
+  process.env.VITE_ENABLE_DEV_AUTH !== "1",
+  "local-auth star sync tests require the local dev auth runner",
+);
+
+test("starring a skill survives refresh with the synchronized count", async ({
+  page,
+}, testInfo) => {
+  const errors = trackRuntimeErrors(page);
+  const slug = `pw-star-${Date.now().toString(36)}`;
+  const displayName = "Playwright Star Sync Skill";
+
+  let ownerHandle = await signInAsLocalPublisher(page, "admin");
+  ownerHandle = await publishSkillVersion(page, testInfo, {
+    ownerHandle,
+    slug,
+    displayName,
+    version: "1.0.0",
+    versionLabel: "star sync release",
+    changelog: "Initial release for the star count synchronization flow.",
+  });
+
+  await signInAsLocalPersona(page, "user");
+  await page.goto(`/${ownerHandle}/${slug}`, { waitUntil: "domcontentloaded" });
+  await waitForHydration(page);
+
+  const starButton = page.getByRole("button", { name: "Star skill" });
+  await expect(starButton).toBeVisible();
+  await expect(starButton).toContainText("0");
+
+  await starButton.click();
+
+  const unstarButton = page.getByRole("button", { name: "Unstar skill" });
+  await expect(unstarButton).toBeVisible();
+  await expect(unstarButton).toContainText("1");
+
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await waitForHydration(page);
+
+  const refreshedUnstarButton = page.getByRole("button", { name: "Unstar skill" });
+  await expect(refreshedUnstarButton).toBeVisible();
+  await expect(refreshedUnstarButton).toContainText("1");
+
+  await expectHealthyPage(page, errors);
+});

--- a/e2e/local-auth/skill-star-sync.pw.test.ts
+++ b/e2e/local-auth/skill-star-sync.pw.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from "@playwright/test";
 import { expectHealthyPage, trackRuntimeErrors, waitForHydration } from "../helpers/runtimeErrors";
-import { publishSkillVersion, signInAsLocalPersona, signInAsLocalPublisher } from "./helpers";
+import {
+  expectLocalPersonaActive,
+  publishSkillVersion,
+  signInAsLocalPersona,
+  signInAsLocalPublisher,
+} from "./helpers";
 
 test.skip(
   process.env.VITE_ENABLE_DEV_AUTH !== "1",
@@ -27,6 +32,7 @@ test("starring a skill survives refresh with the synchronized count", async ({
   await signInAsLocalPersona(page, "user");
   await page.goto(`/${ownerHandle}/${slug}`, { waitUntil: "domcontentloaded" });
   await waitForHydration(page);
+  await expectLocalPersonaActive(page, "user");
 
   const starButton = page.getByRole("button", { name: "Star skill" });
   await expect(starButton).toBeVisible();

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -815,6 +815,73 @@ describe("SkillDetailPage", () => {
     expect(routerInvalidateMock).toHaveBeenCalledTimes(2);
   });
 
+  it("renders refreshed starred server state with the synchronized star count", async () => {
+    useAuthStatusMock.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      me: { _id: "users:viewer", role: "user" },
+    });
+    useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
+      if (args === "skip") return undefined;
+      if (args && typeof args === "object" && "skillId" in args && "limit" in args) return [];
+      if (args && typeof args === "object" && "skillId" in args) return true;
+      if (args && typeof args === "object" && "slug" in args) {
+        return {
+          skill: {
+            _id: skillId,
+            _creationTime: 0,
+            slug: "weather",
+            displayName: "Weather",
+            summary: "Get current weather.",
+            ownerUserId: ownerId,
+            ownerPublisherId,
+            tags: {},
+            badges: {},
+            stats: {
+              stars: 1,
+              downloads: 34,
+              installsCurrent: 5,
+              installsAllTime: 8,
+              versions: 1,
+              comments: 0,
+            },
+            createdAt: 0,
+            updatedAt: 0,
+          },
+          owner: {
+            _id: ownerPublisherId,
+            _creationTime: 0,
+            kind: "user",
+            handle: "steipete",
+            displayName: "Peter",
+            linkedUserId: ownerId,
+          },
+          latestVersion: {
+            _id: versionId,
+            _creationTime: 0,
+            skillId,
+            version: "1.0.0",
+            fingerprint: "abc",
+            changelog: "Initial release",
+            parsed: { license: "MIT-0", frontmatter: {} },
+            files: [],
+            createdBy: ownerId,
+            createdAt: 0,
+          },
+          forkOf: null,
+          canonical: null,
+        };
+      }
+      return undefined;
+    });
+
+    render(<SkillDetailPage slug="weather" />);
+
+    expect((await screen.findByRole("button", { name: "Unstar skill" })).textContent).toContain(
+      "1",
+    );
+  });
+
   it("opens report dialog for authenticated users", async () => {
     useAuthStatusMock.mockReturnValue({
       isAuthenticated: true,


### PR DESCRIPTION
## Summary
- update skill star/unstar mutations to patch `statsStars` and legacy `stats.stars` synchronously with the `stars` relationship row
- stop star/unstar stat events from affecting skill-doc counters so old queued events cannot double-apply after deploy
- add a real local-auth Playwright e2e that publishes a skill, stars it as another user, refreshes, and verifies `Unstar 1`

## Deployment note
After deploying, run the existing star reconciliation to repair any pre-existing drift by recounting rows in the `stars` table. The event processor intentionally ignores legacy queued star/unstar events after this cutover.

## Tests
- `bunx vitest run convex/stars.test.ts convex/skillStatEvents.test.ts src/__tests__/skill-detail-page.test.tsx`
- `bun run ci:unit`
- `bun run lint`
- `bun run test:pw:local-auth -- --project=chromium e2e/local-auth/skill-star-sync.pw.test.ts`
- `bun run test:pw:local-auth -- --project=chromium e2e/local-auth/publish-skill-lifecycle.pw.test.ts`
- `bun run format:check -- convex/stars.ts convex/skillStatEvents.ts convex/stars.test.ts convex/skillStatEvents.test.ts src/__tests__/skill-detail-page.test.tsx e2e/local-auth/helpers.ts e2e/local-auth/publish-skill-lifecycle.pw.test.ts e2e/local-auth/skill-star-sync.pw.test.ts`
- `bunx tsc --noEmit`
- `git diff --check`

## Review
- Ran the `autoreview` skill from `origin/main`.
- Accepted and fixed the local-auth helper robustness issue and removed the generated review transcript.
- Reviewed the remaining queued star/unstar cutover finding as intentional per the deployment note above.
