### PR TITLE
fix: split autoban dry-run pagination

### DIFF
--- a/convex/autobanRemediation.test.ts
+++ b/convex/autobanRemediation.test.ts
@@ -365,7 +365,6 @@ describe("autoban remediation users", () => {
       }
       return null;
     });
-
     const result = await remediateAutobansHandler(
       {
         db: {
@@ -472,6 +471,19 @@ describe("autoban remediation users", () => {
       return null;
     });
     const runMutation = vi.fn();
+    const runQuery = vi.fn(async (_ref: unknown, args: Record<string, unknown>) => {
+      if ("skillId" in args) {
+        return {
+          verdict: "clean",
+          reason: "scanner.aggregate.clean",
+          reasonCodes: [],
+        };
+      }
+      if ("previewRestorableSkillIds" in args) {
+        return { count: 1, isDone: true, continueCursor: null };
+      }
+      return { packageIds: [], isDone: true, continueCursor: null };
+    });
 
     const result = await remediateAutobansHandler(
       {
@@ -484,11 +496,7 @@ describe("autoban remediation users", () => {
           delete: vi.fn(),
           normalizeId: vi.fn(() => null),
         },
-        runQuery: vi.fn(async () => ({
-          verdict: "clean",
-          reason: "scanner.aggregate.clean",
-          reasonCodes: [],
-        })),
+        runQuery,
         runMutation,
       } as never,
       { actorUserId: "users:admin", targetUserId: "users:target", dryRun: true },
@@ -557,7 +565,6 @@ describe("autoban remediation users", () => {
       }
       return null;
     });
-
     const result = await remediateAutobansHandler(
       {
         db: {
@@ -649,6 +656,15 @@ describe("autoban remediation users", () => {
       }
       return null;
     });
+    const runQuery = vi.fn(async (_ref: unknown, args: Record<string, unknown>) => {
+      if ("previewRestorableSkillIds" in args) {
+        return { count: 0, isDone: true, continueCursor: null };
+      }
+      if ("packageId" in args) {
+        return { hasRestorable: true, isDone: true, continueCursor: null };
+      }
+      return { packageIds: ["packages:demo"], isDone: true, continueCursor: null };
+    });
 
     const result = await remediateAutobansHandler(
       {
@@ -661,7 +677,7 @@ describe("autoban remediation users", () => {
           delete: vi.fn(),
           normalizeId: vi.fn(() => null),
         },
-        runQuery: vi.fn(),
+        runQuery,
         runMutation: vi.fn(),
       } as never,
       { actorUserId: "users:admin", targetUserId: "users:target", dryRun: true },
@@ -789,6 +805,15 @@ describe("autoban remediation users", () => {
       }
       return null;
     });
+    const runQuery = vi.fn(async (_ref: unknown, args: Record<string, unknown>) => {
+      if ("previewRestorableSkillIds" in args) {
+        return { count: 0, isDone: true, continueCursor: null };
+      }
+      if ("packageId" in args) {
+        return { hasRestorable: true, isDone: true, continueCursor: null };
+      }
+      return { packageIds: ["packages:demo"], isDone: true, continueCursor: null };
+    });
 
     const result = await remediateAutobansHandler(
       {
@@ -801,7 +826,7 @@ describe("autoban remediation users", () => {
           delete: vi.fn(),
           normalizeId: vi.fn(() => null),
         },
-        runQuery: vi.fn(),
+        runQuery,
         runMutation: vi.fn(),
       } as never,
       { actorUserId: "users:admin", targetUserId: "users:target", dryRun: true },

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -42,6 +42,11 @@ const MAX_AUTOBAN_REMEDIATION_LIMIT = 100;
 const AUTOBAN_AUDIT_MATCH_WINDOW_MS = 5_000;
 const AUTOBAN_REMEDIATION_COUNT_PAGE_SIZE = 100;
 const autobanRemediationInternalRefs = internal as unknown as {
+  users: {
+    countRestorableAutobanSkillsPageInternal: unknown;
+    listRestorableAutobanPackageCandidatesPageInternal: unknown;
+    hasRestorableAutobanPackageReleasePageInternal: unknown;
+  };
   skills: {
     previewLatestSkillModerationInternal: unknown;
     recomputeLatestSkillModerationInternal: unknown;
@@ -904,6 +909,24 @@ type AutobanRemediationTrigger = {
   reasonCodes: string[];
 };
 
+type AutobanRemediationCountPage = {
+  count: number;
+  isDone: boolean;
+  continueCursor: string | null;
+};
+
+type AutobanRemediationPackageCandidatePage = {
+  packageIds: Array<Id<"packages">>;
+  isDone: boolean;
+  continueCursor: string | null;
+};
+
+type AutobanRemediationPackageReleasePage = {
+  hasRestorable: boolean;
+  isDone: boolean;
+  continueCursor: string | null;
+};
+
 function normalizeAutobanRemediationLimit(limit: number | undefined) {
   if (!Number.isFinite(limit ?? 25)) return 25;
   return Math.max(1, Math.min(Math.floor(limit ?? 25), MAX_AUTOBAN_REMEDIATION_LIMIT));
@@ -1227,16 +1250,14 @@ async function countAutobanRemediationRestores(
   bannedAt: number,
   triggers: AutobanRemediationTrigger[] = [],
 ) {
-  const previewRestorableSkillIds = new Set(
-    triggers
-      .filter(
-        (trigger) =>
-          trigger.artifactKind === "skill" &&
-          trigger.artifactId &&
-          isResolvedNonMaliciousTrigger(trigger),
-      )
-      .map((trigger) => trigger.artifactId as Id<"skills">),
-  );
+  const previewRestorableSkillIds = triggers
+    .filter(
+      (trigger) =>
+        trigger.artifactKind === "skill" &&
+        trigger.artifactId &&
+        isResolvedNonMaliciousTrigger(trigger),
+    )
+    .map((trigger) => trigger.artifactId as Id<"skills">);
   const [skills, packages] = await Promise.all([
     countRestorableAutobanSkills(ctx, ownerUserId, bannedAt, previewRestorableSkillIds),
     countRestorableAutobanPackages(ctx, ownerUserId, bannedAt),
@@ -1249,26 +1270,24 @@ async function countRestorableAutobanSkills(
   ctx: MutationCtx,
   ownerUserId: Id<"users">,
   bannedAt: number,
-  previewRestorableSkillIds: Set<Id<"skills">>,
+  previewRestorableSkillIds: Array<Id<"skills">>,
 ) {
   let count = 0;
   let cursor: string | null = null;
   let isDone = false;
 
   while (!isDone) {
-    const result = await ctx.db
-      .query("skills")
-      .withIndex("by_owner", (q) => q.eq("ownerUserId", ownerUserId))
-      .order("desc")
-      .paginate({
-        cursor,
-        numItems: AUTOBAN_REMEDIATION_COUNT_PAGE_SIZE,
-      });
-    count += result.page.filter(
-      (skill) =>
-        isRestorableAutobanSkill(skill, bannedAt) ||
-        (skill.softDeletedAt === bannedAt && previewRestorableSkillIds.has(skill._id)),
-    ).length;
+    const result: AutobanRemediationCountPage = await runAutobanRemediationQueryRef(
+      ctx,
+      autobanRemediationInternalRefs.users.countRestorableAutobanSkillsPageInternal,
+      {
+        ownerUserId,
+        bannedAt,
+        previewRestorableSkillIds,
+        cursor: cursor ?? undefined,
+      },
+    );
+    count += result.count;
     isDone = result.isDone;
     cursor = result.continueCursor;
   }
@@ -1286,17 +1305,17 @@ async function countRestorableAutobanPackages(
   let isDone = false;
 
   while (!isDone) {
-    const result = await ctx.db
-      .query("packages")
-      .withIndex("by_owner", (q) => q.eq("ownerUserId", ownerUserId))
-      .order("desc")
-      .paginate({
-        cursor,
-        numItems: AUTOBAN_REMEDIATION_COUNT_PAGE_SIZE,
-      });
-    for (const pkg of result.page) {
-      if (pkg.softDeletedAt !== bannedAt || pkg.scanStatus === "malicious") continue;
-      if (await hasRestorableAutobanPackageRelease(ctx, pkg._id, bannedAt)) count += 1;
+    const result: AutobanRemediationPackageCandidatePage = await runAutobanRemediationQueryRef(
+      ctx,
+      autobanRemediationInternalRefs.users.listRestorableAutobanPackageCandidatesPageInternal,
+      {
+        ownerUserId,
+        bannedAt,
+        cursor: cursor ?? undefined,
+      },
+    );
+    for (const packageId of result.packageIds) {
+      if (await hasRestorableAutobanPackageRelease(ctx, packageId, bannedAt)) count += 1;
     }
     isDone = result.isDone;
     cursor = result.continueCursor;
@@ -1306,7 +1325,7 @@ async function countRestorableAutobanPackages(
 }
 
 async function hasRestorableAutobanPackageRelease(
-  ctx: MutationCtx,
+  ctx: Pick<MutationCtx, "runQuery">,
   packageId: Id<"packages">,
   bannedAt: number,
 ) {
@@ -1314,27 +1333,104 @@ async function hasRestorableAutobanPackageRelease(
   let isDone = false;
 
   while (!isDone) {
-    const result = await ctx.db
-      .query("packageReleases")
-      .withIndex("by_package", (q) => q.eq("packageId", packageId))
-      .paginate({
-        cursor,
-        numItems: AUTOBAN_REMEDIATION_COUNT_PAGE_SIZE,
-      });
-    if (
-      result.page.some((release) => {
-        const wouldBeActive = !release.softDeletedAt || release.softDeletedAt === bannedAt;
-        return wouldBeActive && resolvePackageReleaseScanStatus(release) !== "malicious";
-      })
-    ) {
-      return true;
-    }
+    const result: AutobanRemediationPackageReleasePage = await runAutobanRemediationQueryRef(
+      ctx,
+      autobanRemediationInternalRefs.users.hasRestorableAutobanPackageReleasePageInternal,
+      {
+        packageId,
+        bannedAt,
+        cursor: cursor ?? undefined,
+      },
+    );
+    if (result.hasRestorable) return true;
     isDone = result.isDone;
     cursor = result.continueCursor;
   }
 
   return false;
 }
+
+export const countRestorableAutobanSkillsPageInternal = internalQuery({
+  args: {
+    ownerUserId: v.id("users"),
+    bannedAt: v.number(),
+    previewRestorableSkillIds: v.array(v.id("skills")),
+    cursor: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const previewRestorableSkillIds = new Set(args.previewRestorableSkillIds);
+    const result = await ctx.db
+      .query("skills")
+      .withIndex("by_owner", (q) => q.eq("ownerUserId", args.ownerUserId))
+      .order("desc")
+      .paginate({
+        cursor: args.cursor ?? null,
+        numItems: AUTOBAN_REMEDIATION_COUNT_PAGE_SIZE,
+      });
+
+    return {
+      count: result.page.filter(
+        (skill) =>
+          isRestorableAutobanSkill(skill, args.bannedAt) ||
+          (skill.softDeletedAt === args.bannedAt && previewRestorableSkillIds.has(skill._id)),
+      ).length,
+      isDone: result.isDone,
+      continueCursor: result.continueCursor,
+    };
+  },
+});
+
+export const listRestorableAutobanPackageCandidatesPageInternal = internalQuery({
+  args: {
+    ownerUserId: v.id("users"),
+    bannedAt: v.number(),
+    cursor: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const result = await ctx.db
+      .query("packages")
+      .withIndex("by_owner", (q) => q.eq("ownerUserId", args.ownerUserId))
+      .order("desc")
+      .paginate({
+        cursor: args.cursor ?? null,
+        numItems: AUTOBAN_REMEDIATION_COUNT_PAGE_SIZE,
+      });
+
+    return {
+      packageIds: result.page
+        .filter((pkg) => pkg.softDeletedAt === args.bannedAt && pkg.scanStatus !== "malicious")
+        .map((pkg) => pkg._id),
+      isDone: result.isDone,
+      continueCursor: result.continueCursor,
+    };
+  },
+});
+
+export const hasRestorableAutobanPackageReleasePageInternal = internalQuery({
+  args: {
+    packageId: v.id("packages"),
+    bannedAt: v.number(),
+    cursor: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const result = await ctx.db
+      .query("packageReleases")
+      .withIndex("by_package", (q) => q.eq("packageId", args.packageId))
+      .paginate({
+        cursor: args.cursor ?? null,
+        numItems: AUTOBAN_REMEDIATION_COUNT_PAGE_SIZE,
+      });
+
+    return {
+      hasRestorable: result.page.some((release) => {
+        const wouldBeActive = !release.softDeletedAt || release.softDeletedAt === args.bannedAt;
+        return wouldBeActive && resolvePackageReleaseScanStatus(release) !== "malicious";
+      }),
+      isDone: result.isDone,
+      continueCursor: result.continueCursor,
+    };
+  },
+});
 
 function isRestorableAutobanSkill(skill: Doc<"skills">, bannedAt: number) {
   if (skill.softDeletedAt !== bannedAt) return false;


### PR DESCRIPTION
## Summary
- Split autoban remediation dry-run restore counting into page-scoped internal queries so each Convex function invocation performs at most one `.paginate()` call.
- Preserve the existing dry-run response shape while avoiding the production runtime error from multiple paginated queries in one mutation.
- Update autoban remediation tests to mock the new internal query boundaries for skill/package restore counts.

## Proof
- `bun run test packages/clawhub-mod/src/commands/moderation.test.ts convex/httpApiV1.handlers.test.ts convex/autobanRemediation.test.ts`
- `bun run ci:static`
- `bunx tsc --noEmit && bunx tsc -p packages/schema/tsconfig.json --noEmit && bunx tsc -p packages/clawhub/tsconfig.json --noEmit && bun run --cwd packages/clawhub-mod typecheck`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local`
- Local Convex smoke after `bun run seed:dev`: `bun run mod -- --registry http://127.0.0.1:3211 users remediate-autobans --dry-run --user local-corpus-wilhelm-bartell --json` returned `ok: true`, `decision: "would_unban"`, and `restoredSkills: 44`.

## Notes
- The smoke used a local-only autoban candidate created through the existing internal autoban path; no production mutation was run.
