### PR TITLE
fix: paginate autoban remediation dry runs

### DIFF
--- a/convex/autobanRemediation.test.ts
+++ b/convex/autobanRemediation.test.ts
@@ -365,7 +365,6 @@ describe("autoban remediation users", () => {
       }
       return null;
     });
-
     const result = await remediateAutobansHandler(
       {
         db: {
@@ -472,6 +471,19 @@ describe("autoban remediation users", () => {
       return null;
     });
     const runMutation = vi.fn();
+    const runQuery = vi.fn(async (_ref: unknown, args: Record<string, unknown>) => {
+      if ("skillId" in args) {
+        return {
+          verdict: "clean",
+          reason: "scanner.aggregate.clean",
+          reasonCodes: [],
+        };
+      }
+      if ("previewRestorableSkillIds" in args) {
+        return { count: 1, isDone: true, continueCursor: null };
+      }
+      return { packageIds: [], isDone: true, continueCursor: null };
+    });
 
     const result = await remediateAutobansHandler(
       {
@@ -484,11 +496,7 @@ describe("autoban remediation users", () => {
           delete: vi.fn(),
           normalizeId: vi.fn(() => null),
         },
-        runQuery: vi.fn(async () => ({
-          verdict: "clean",
-          reason: "scanner.aggregate.clean",
-          reasonCodes: [],
-        })),
+        runQuery,
         runMutation,
       } as never,
       { actorUserId: "users:admin", targetUserId: "users:target", dryRun: true },
@@ -557,7 +565,6 @@ describe("autoban remediation users", () => {
       }
       return null;
     });
-
     const result = await remediateAutobansHandler(
       {
         db: {
@@ -649,6 +656,15 @@ describe("autoban remediation users", () => {
       }
       return null;
     });
+    const runQuery = vi.fn(async (_ref: unknown, args: Record<string, unknown>) => {
+      if ("previewRestorableSkillIds" in args) {
+        return { count: 0, isDone: true, continueCursor: null };
+      }
+      if ("packageId" in args) {
+        return { hasRestorable: true, isDone: true, continueCursor: null };
+      }
+      return { packageIds: ["packages:demo"], isDone: true, continueCursor: null };
+    });
 
     const result = await remediateAutobansHandler(
       {
@@ -661,7 +677,7 @@ describe("autoban remediation users", () => {
           delete: vi.fn(),
           normalizeId: vi.fn(() => null),
         },
-        runQuery: vi.fn(),
+        runQuery,
         runMutation: vi.fn(),
       } as never,
       { actorUserId: "users:admin", targetUserId: "users:target", dryRun: true },
@@ -789,6 +805,15 @@ describe("autoban remediation users", () => {
       }
       return null;
     });
+    const runQuery = vi.fn(async (_ref: unknown, args: Record<string, unknown>) => {
+      if ("previewRestorableSkillIds" in args) {
+        return { count: 0, isDone: true, continueCursor: null };
+      }
+      if ("packageId" in args) {
+        return { hasRestorable: true, isDone: true, continueCursor: null };
+      }
+      return { packageIds: ["packages:demo"], isDone: true, continueCursor: null };
+    });
 
     const result = await remediateAutobansHandler(
       {
@@ -801,7 +826,7 @@ describe("autoban remediation users", () => {
           delete: vi.fn(),
           normalizeId: vi.fn(() => null),
         },
-        runQuery: vi.fn(),
+        runQuery,
         runMutation: vi.fn(),
       } as never,
       { actorUserId: "users:admin", targetUserId: "users:target", dryRun: true },

--- a/convex/autobanRemediation.test.ts
+++ b/convex/autobanRemediation.test.ts
@@ -52,6 +52,9 @@ const remediateAutobansHandler = (
       actorUserId: string;
       targetUserId?: string;
       dryRun?: boolean;
+      cursor?: string;
+      limit?: number;
+      since?: string;
     },
     {
       scanned: number;
@@ -389,6 +392,66 @@ describe("autoban remediation users", () => {
 
     expect(result.scanned).toBe(0);
     expect(result.items).toEqual([]);
+  });
+
+  it("paginates autoban remediation candidates with a cursor", async () => {
+    const bannedAt = 1778569308754;
+    const paginate = vi.fn(async () => ({
+      page: [
+        {
+          _id: "users:target",
+          role: "user",
+          handle: "paged-user",
+          deletedAt: bannedAt,
+          banReason: "malware auto-ban",
+        },
+      ],
+      isDone: false,
+      continueCursor: "cursor-2",
+    }));
+    const query = vi.fn((table: string) => {
+      if (table === "users") {
+        return {
+          withIndex: () => ({
+            paginate,
+          }),
+        };
+      }
+      if (table === "auditLogs") {
+        return {
+          withIndex: () => ({
+            collect: vi.fn(async () => []),
+          }),
+        };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+    const result = await remediateAutobansHandler(
+      {
+        db: {
+          query,
+          get: vi.fn(async (id: string) =>
+            id === "users:admin" ? { _id: "users:admin", role: "admin" } : null,
+          ),
+          patch: vi.fn(),
+          insert: vi.fn(),
+          replace: vi.fn(),
+          delete: vi.fn(),
+          normalizeId: vi.fn(() => null),
+        },
+        runQuery: vi.fn(),
+        runMutation: vi.fn(),
+      } as never,
+      { actorUserId: "users:admin", cursor: "cursor-1", limit: 5, dryRun: true } as never,
+    );
+
+    expect(paginate).toHaveBeenCalledWith({ cursor: "cursor-1", numItems: 5 });
+    expect(result).toMatchObject({
+      scanned: 1,
+      skipped: 1,
+      nextCursor: "cursor-2",
+      done: false,
+    });
   });
 
   it("dry-run counts a clean-preview trigger skill even when persisted flags are stale malicious", async () => {

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -3414,6 +3414,8 @@ describe("httpApiV1 handlers", () => {
       restoredSkills: 12,
       restoredPackages: 0,
       items: [],
+      nextCursor: null,
+      done: true,
     });
     const response = await __handlers.usersPostRouterV1Handler(
       makeCtx({ runMutation }),
@@ -3425,6 +3427,7 @@ describe("httpApiV1 handlers", () => {
           userId: "users:target",
           reason: "appeal accepted",
           since: "2026-05-12",
+          cursor: "cursor-1",
           limit: 5,
         }),
       }),
@@ -3438,6 +3441,7 @@ describe("httpApiV1 handlers", () => {
         dryRun: false,
         reason: "appeal accepted",
         since: "2026-05-12",
+        cursor: "cursor-1",
         limit: 5,
       }),
     );

--- a/convex/httpApiV1/usersV1.ts
+++ b/convex/httpApiV1/usersV1.ts
@@ -195,6 +195,7 @@ async function handleAdminRemediateAutobans(
   const userId = typeof body.userId === "string" ? body.userId.trim() : "";
   const reason = typeof body.reason === "string" ? body.reason.trim() : "";
   const since = typeof body.since === "string" ? body.since.trim() : "";
+  const cursor = typeof body.cursor === "string" ? body.cursor.trim() : "";
   const dryRun = body.dryRun !== false;
   const limit =
     typeof body.limit === "number"
@@ -225,6 +226,7 @@ async function handleAdminRemediateAutobans(
         dryRun,
         ...(reason ? { reason } : {}),
         ...(since ? { since } : {}),
+        ...(cursor ? { cursor } : {}),
         ...(limit !== undefined ? { limit } : {}),
       },
     );

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -42,6 +42,11 @@ const MAX_AUTOBAN_REMEDIATION_LIMIT = 100;
 const AUTOBAN_AUDIT_MATCH_WINDOW_MS = 5_000;
 const AUTOBAN_REMEDIATION_COUNT_PAGE_SIZE = 100;
 const autobanRemediationInternalRefs = internal as unknown as {
+  users: {
+    countRestorableAutobanSkillsPageInternal: unknown;
+    listRestorableAutobanPackageCandidatesPageInternal: unknown;
+    hasRestorableAutobanPackageReleasePageInternal: unknown;
+  };
   skills: {
     previewLatestSkillModerationInternal: unknown;
     recomputeLatestSkillModerationInternal: unknown;
@@ -904,6 +909,24 @@ type AutobanRemediationTrigger = {
   reasonCodes: string[];
 };
 
+type AutobanRemediationCountPage = {
+  count: number;
+  isDone: boolean;
+  continueCursor: string | null;
+};
+
+type AutobanRemediationPackageCandidatePage = {
+  packageIds: Array<Id<"packages">>;
+  isDone: boolean;
+  continueCursor: string | null;
+};
+
+type AutobanRemediationPackageReleasePage = {
+  hasRestorable: boolean;
+  isDone: boolean;
+  continueCursor: string | null;
+};
+
 function normalizeAutobanRemediationLimit(limit: number | undefined) {
   if (!Number.isFinite(limit ?? 25)) return 25;
   return Math.max(1, Math.min(Math.floor(limit ?? 25), MAX_AUTOBAN_REMEDIATION_LIMIT));
@@ -1227,16 +1250,14 @@ async function countAutobanRemediationRestores(
   bannedAt: number,
   triggers: AutobanRemediationTrigger[] = [],
 ) {
-  const previewRestorableSkillIds = new Set(
-    triggers
-      .filter(
-        (trigger) =>
-          trigger.artifactKind === "skill" &&
-          trigger.artifactId &&
-          isResolvedNonMaliciousTrigger(trigger),
-      )
-      .map((trigger) => trigger.artifactId as Id<"skills">),
-  );
+  const previewRestorableSkillIds = triggers
+    .filter(
+      (trigger) =>
+        trigger.artifactKind === "skill" &&
+        trigger.artifactId &&
+        isResolvedNonMaliciousTrigger(trigger),
+    )
+    .map((trigger) => trigger.artifactId as Id<"skills">);
   const [skills, packages] = await Promise.all([
     countRestorableAutobanSkills(ctx, ownerUserId, bannedAt, previewRestorableSkillIds),
     countRestorableAutobanPackages(ctx, ownerUserId, bannedAt),
@@ -1249,26 +1270,24 @@ async function countRestorableAutobanSkills(
   ctx: MutationCtx,
   ownerUserId: Id<"users">,
   bannedAt: number,
-  previewRestorableSkillIds: Set<Id<"skills">>,
+  previewRestorableSkillIds: Array<Id<"skills">>,
 ) {
   let count = 0;
   let cursor: string | null = null;
   let isDone = false;
 
   while (!isDone) {
-    const result = await ctx.db
-      .query("skills")
-      .withIndex("by_owner", (q) => q.eq("ownerUserId", ownerUserId))
-      .order("desc")
-      .paginate({
-        cursor,
-        numItems: AUTOBAN_REMEDIATION_COUNT_PAGE_SIZE,
-      });
-    count += result.page.filter(
-      (skill) =>
-        isRestorableAutobanSkill(skill, bannedAt) ||
-        (skill.softDeletedAt === bannedAt && previewRestorableSkillIds.has(skill._id)),
-    ).length;
+    const result: AutobanRemediationCountPage = await runAutobanRemediationQueryRef(
+      ctx,
+      autobanRemediationInternalRefs.users.countRestorableAutobanSkillsPageInternal,
+      {
+        ownerUserId,
+        bannedAt,
+        previewRestorableSkillIds,
+        cursor: cursor ?? undefined,
+      },
+    );
+    count += result.count;
     isDone = result.isDone;
     cursor = result.continueCursor;
   }
@@ -1286,17 +1305,17 @@ async function countRestorableAutobanPackages(
   let isDone = false;
 
   while (!isDone) {
-    const result = await ctx.db
-      .query("packages")
-      .withIndex("by_owner", (q) => q.eq("ownerUserId", ownerUserId))
-      .order("desc")
-      .paginate({
-        cursor,
-        numItems: AUTOBAN_REMEDIATION_COUNT_PAGE_SIZE,
-      });
-    for (const pkg of result.page) {
-      if (pkg.softDeletedAt !== bannedAt || pkg.scanStatus === "malicious") continue;
-      if (await hasRestorableAutobanPackageRelease(ctx, pkg._id, bannedAt)) count += 1;
+    const result: AutobanRemediationPackageCandidatePage = await runAutobanRemediationQueryRef(
+      ctx,
+      autobanRemediationInternalRefs.users.listRestorableAutobanPackageCandidatesPageInternal,
+      {
+        ownerUserId,
+        bannedAt,
+        cursor: cursor ?? undefined,
+      },
+    );
+    for (const packageId of result.packageIds) {
+      if (await hasRestorableAutobanPackageRelease(ctx, packageId, bannedAt)) count += 1;
     }
     isDone = result.isDone;
     cursor = result.continueCursor;
@@ -1306,7 +1325,7 @@ async function countRestorableAutobanPackages(
 }
 
 async function hasRestorableAutobanPackageRelease(
-  ctx: MutationCtx,
+  ctx: Pick<MutationCtx, "runQuery">,
   packageId: Id<"packages">,
   bannedAt: number,
 ) {
@@ -1314,27 +1333,104 @@ async function hasRestorableAutobanPackageRelease(
   let isDone = false;
 
   while (!isDone) {
-    const result = await ctx.db
-      .query("packageReleases")
-      .withIndex("by_package", (q) => q.eq("packageId", packageId))
-      .paginate({
-        cursor,
-        numItems: AUTOBAN_REMEDIATION_COUNT_PAGE_SIZE,
-      });
-    if (
-      result.page.some((release) => {
-        const wouldBeActive = !release.softDeletedAt || release.softDeletedAt === bannedAt;
-        return wouldBeActive && resolvePackageReleaseScanStatus(release) !== "malicious";
-      })
-    ) {
-      return true;
-    }
+    const result: AutobanRemediationPackageReleasePage = await runAutobanRemediationQueryRef(
+      ctx,
+      autobanRemediationInternalRefs.users.hasRestorableAutobanPackageReleasePageInternal,
+      {
+        packageId,
+        bannedAt,
+        cursor: cursor ?? undefined,
+      },
+    );
+    if (result.hasRestorable) return true;
     isDone = result.isDone;
     cursor = result.continueCursor;
   }
 
   return false;
 }
+
+export const countRestorableAutobanSkillsPageInternal = internalQuery({
+  args: {
+    ownerUserId: v.id("users"),
+    bannedAt: v.number(),
+    previewRestorableSkillIds: v.array(v.id("skills")),
+    cursor: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const previewRestorableSkillIds = new Set(args.previewRestorableSkillIds);
+    const result = await ctx.db
+      .query("skills")
+      .withIndex("by_owner", (q) => q.eq("ownerUserId", args.ownerUserId))
+      .order("desc")
+      .paginate({
+        cursor: args.cursor ?? null,
+        numItems: AUTOBAN_REMEDIATION_COUNT_PAGE_SIZE,
+      });
+
+    return {
+      count: result.page.filter(
+        (skill) =>
+          isRestorableAutobanSkill(skill, args.bannedAt) ||
+          (skill.softDeletedAt === args.bannedAt && previewRestorableSkillIds.has(skill._id)),
+      ).length,
+      isDone: result.isDone,
+      continueCursor: result.continueCursor,
+    };
+  },
+});
+
+export const listRestorableAutobanPackageCandidatesPageInternal = internalQuery({
+  args: {
+    ownerUserId: v.id("users"),
+    bannedAt: v.number(),
+    cursor: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const result = await ctx.db
+      .query("packages")
+      .withIndex("by_owner", (q) => q.eq("ownerUserId", args.ownerUserId))
+      .order("desc")
+      .paginate({
+        cursor: args.cursor ?? null,
+        numItems: AUTOBAN_REMEDIATION_COUNT_PAGE_SIZE,
+      });
+
+    return {
+      packageIds: result.page
+        .filter((pkg) => pkg.softDeletedAt === args.bannedAt && pkg.scanStatus !== "malicious")
+        .map((pkg) => pkg._id),
+      isDone: result.isDone,
+      continueCursor: result.continueCursor,
+    };
+  },
+});
+
+export const hasRestorableAutobanPackageReleasePageInternal = internalQuery({
+  args: {
+    packageId: v.id("packages"),
+    bannedAt: v.number(),
+    cursor: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const result = await ctx.db
+      .query("packageReleases")
+      .withIndex("by_package", (q) => q.eq("packageId", args.packageId))
+      .paginate({
+        cursor: args.cursor ?? null,
+        numItems: AUTOBAN_REMEDIATION_COUNT_PAGE_SIZE,
+      });
+
+    return {
+      hasRestorable: result.page.some((release) => {
+        const wouldBeActive = !release.softDeletedAt || release.softDeletedAt === args.bannedAt;
+        return wouldBeActive && resolvePackageReleaseScanStatus(release) !== "malicious";
+      }),
+      isDone: result.isDone,
+      continueCursor: result.continueCursor,
+    };
+  },
+});
 
 function isRestorableAutobanSkill(skill: Doc<"skills">, bannedAt: number) {
   if (skill.softDeletedAt !== bannedAt) return false;

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -843,6 +843,7 @@ export const remediateAutobansInternal = internalMutation({
     handle: v.optional(v.string()),
     dryRun: v.optional(v.boolean()),
     since: v.optional(v.string()),
+    cursor: v.optional(v.string()),
     limit: v.optional(v.number()),
     reason: v.optional(v.string()),
   },
@@ -859,6 +860,7 @@ export const remediateAutobansInternal = internalMutation({
       targetUserId: args.targetUserId,
       handle: args.handle,
       sinceMs,
+      cursor: args.cursor,
       limit,
     });
 
@@ -869,7 +871,7 @@ export const remediateAutobansInternal = internalMutation({
     let restoredSkills = 0;
     let restoredPackages = 0;
 
-    for (const candidate of candidates) {
+    for (const candidate of candidates.items) {
       const item = await evaluateAutobanRemediationCandidate(ctx, {
         actor,
         target: candidate,
@@ -887,13 +889,15 @@ export const remediateAutobansInternal = internalMutation({
     return {
       ok: true as const,
       dryRun,
-      scanned: candidates.length,
+      scanned: candidates.items.length,
       wouldUnban,
       unbanned,
       skipped,
       restoredSkills,
       restoredPackages,
       items,
+      nextCursor: candidates.nextCursor,
+      done: candidates.done,
     };
   },
 });
@@ -952,29 +956,45 @@ async function listAutobanRemediationCandidates(
     targetUserId?: Id<"users">;
     handle?: string;
     sinceMs: number;
+    cursor?: string;
     limit: number;
   },
 ) {
   if (args.targetUserId) {
     const user = await ctx.db.get(args.targetUserId);
-    return user
-      ? [user].filter((candidate) => isAutobanRemediationCandidate(candidate, args.sinceMs))
-      : [];
+    return {
+      items: user
+        ? [user].filter((candidate) => isAutobanRemediationCandidate(candidate, args.sinceMs))
+        : [],
+      nextCursor: null,
+      done: true,
+    };
   }
 
   const handle = args.handle?.trim().toLowerCase();
   if (handle) {
     const user = await getUserByHandleOrPersonalPublisher(ctx, handle);
-    return user && isAutobanRemediationCandidate(user, args.sinceMs) ? [user] : [];
+    return {
+      items: user && isAutobanRemediationCandidate(user, args.sinceMs) ? [user] : [],
+      nextCursor: null,
+      done: true,
+    };
   }
 
-  const candidates = await ctx.db
+  const page = await ctx.db
     .query("users")
     .withIndex("by_ban_reason_deleted_at", (q) =>
       q.eq("banReason", MALWARE_AUTOBAN_REASON).gte("deletedAt", args.sinceMs),
     )
-    .take(args.limit);
-  return candidates.filter((candidate) => isAutobanRemediationCandidate(candidate, args.sinceMs));
+    .paginate({
+      cursor: args.cursor ?? null,
+      numItems: args.limit,
+    });
+  return {
+    items: page.page.filter((candidate) => isAutobanRemediationCandidate(candidate, args.sinceMs)),
+    nextCursor: page.continueCursor || null,
+    done: page.isDone,
+  };
 }
 
 function isAutobanRemediationCandidate(user: Doc<"users">, sinceMs = 0) {

--- a/packages/clawhub-mod/src/cli.ts
+++ b/packages/clawhub-mod/src/cli.ts
@@ -239,7 +239,9 @@ users
   .option("--user <handleOrId>", "Limit to one user handle or id")
   .option("--id", "Treat --user as a user id")
   .option("--since <date>", "Only scan autobans at or after this date")
-  .option("--limit <n>", "Maximum users to scan")
+  .option("--limit <n>", "Maximum users to scan per page")
+  .option("--cursor <cursor>", "Resume cursor")
+  .option("--all", "Continue until all pages are processed")
   .option("--reason <reason>", "Audit reason for apply")
   .option("--json", "Output JSON")
   .action(async (options) => {

--- a/packages/clawhub-mod/src/commands/moderation.test.ts
+++ b/packages/clawhub-mod/src/commands/moderation.test.ts
@@ -308,6 +308,8 @@ describe("cmdRemediateAutobans", () => {
       restoredSkills: 0,
       restoredPackages: 0,
       items: [],
+      nextCursor: null,
+      done: true,
     });
 
     await cmdRemediateAutobans(makeGlobalOpts(), {}, false);
@@ -334,6 +336,8 @@ describe("cmdRemediateAutobans", () => {
       restoredSkills: 12,
       restoredPackages: 0,
       items: [],
+      nextCursor: null,
+      done: true,
     });
 
     await cmdRemediateAutobans(
@@ -370,6 +374,65 @@ describe("cmdRemediateAutobans", () => {
     await expect(
       cmdRemediateAutobans(makeGlobalOpts(), { apply: true, dryRun: true }, false),
     ).rejects.toThrow(/either --apply or --dry-run/i);
+    expect(httpMocks.apiRequest).not.toHaveBeenCalled();
+  });
+
+  it("can dry-run autoban remediation across all pages", async () => {
+    httpMocks.apiRequest
+      .mockResolvedValueOnce({
+        ok: true,
+        dryRun: true,
+        scanned: 10,
+        wouldUnban: 9,
+        unbanned: 0,
+        skipped: 1,
+        restoredSkills: 12,
+        restoredPackages: 0,
+        items: [{ handle: "first" }],
+        nextCursor: "cursor-2",
+        done: false,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        dryRun: true,
+        scanned: 3,
+        wouldUnban: 3,
+        unbanned: 0,
+        skipped: 0,
+        restoredSkills: 4,
+        restoredPackages: 1,
+        items: [{ handle: "second" }],
+        nextCursor: null,
+        done: true,
+      });
+
+    const result = await cmdRemediateAutobans(
+      makeGlobalOpts(),
+      { all: true, limit: "10", json: true },
+      false,
+    );
+
+    expect(httpMocks.apiRequest).toHaveBeenCalledTimes(2);
+    expect(httpMocks.apiRequest.mock.calls[0]?.[1]).toMatchObject({
+      body: { dryRun: true, limit: 10 },
+    });
+    expect(httpMocks.apiRequest.mock.calls[1]?.[1]).toMatchObject({
+      body: { dryRun: true, limit: 10, cursor: "cursor-2" },
+    });
+    expect(result).toMatchObject({
+      scanned: 13,
+      wouldUnban: 12,
+      skipped: 1,
+      restoredSkills: 16,
+      restoredPackages: 1,
+      done: true,
+    });
+  });
+
+  it("rejects combining all pages with a targeted user", async () => {
+    await expect(
+      cmdRemediateAutobans(makeGlobalOpts(), { all: true, user: "demo" }, false),
+    ).rejects.toThrow(/either --all or --user/i);
     expect(httpMocks.apiRequest).not.toHaveBeenCalled();
   });
 });

--- a/packages/clawhub-mod/src/commands/moderation.ts
+++ b/packages/clawhub-mod/src/commands/moderation.ts
@@ -198,6 +198,8 @@ export async function cmdRemediateAutobans(
     limit?: string | number;
     reason?: string;
     json?: boolean;
+    all?: boolean;
+    cursor?: string;
   },
   inputAllowed: boolean,
 ) {
@@ -208,9 +210,11 @@ export async function cmdRemediateAutobans(
   const limit = normalizeOptionalPositiveInt(options.limit);
   const reason = options.reason?.trim();
   const since = options.since?.trim();
+  let cursor = options.cursor?.trim() || null;
 
   if (reason && reason.length > 500) fail("Reason too long (max 500 chars)");
   if (since && Number.isNaN(Date.parse(since))) fail("Invalid --since date");
+  if (options.all && target) fail("Use either --all or --user, not both");
 
   void inputAllowed;
 
@@ -221,30 +225,51 @@ export async function cmdRemediateAutobans(
     : createSpinner(`${dryRun ? "Planning" : "Applying"} autoban remediation`);
 
   try {
-    const body: Record<string, unknown> = { dryRun };
-    if (target) {
-      if (options.id) body.userId = target;
-      else body.handle = normalizeHandle(target);
-    }
-    if (reason) body.reason = reason;
-    if (since) body.since = since;
-    if (limit !== undefined) body.limit = limit;
+    const pages = [];
+    do {
+      const body: Record<string, unknown> = { dryRun };
+      if (target) {
+        if (options.id) body.userId = target;
+        else body.handle = normalizeHandle(target);
+      }
+      if (reason) body.reason = reason;
+      if (since) body.since = since;
+      if (limit !== undefined) body.limit = limit;
+      if (cursor) body.cursor = cursor;
 
-    const result = await apiRequest(
-      registry,
-      {
-        method: "POST",
-        path: `${ApiRoutes.users}/remediate-autobans`,
-        token,
-        body,
-      },
-      ApiV1RemediateAutobansResponseSchema,
-    );
-    const parsed = parseArk(
-      ApiV1RemediateAutobansResponseSchema,
-      result,
-      "Remediate autobans response",
-    );
+      const result = await apiRequest(
+        registry,
+        {
+          method: "POST",
+          path: `${ApiRoutes.users}/remediate-autobans`,
+          token,
+          body,
+        },
+        ApiV1RemediateAutobansResponseSchema,
+      );
+      const parsedPage = parseArk(
+        ApiV1RemediateAutobansResponseSchema,
+        result,
+        "Remediate autobans response",
+      );
+      pages.push(parsedPage);
+      cursor = parsedPage.nextCursor ?? null;
+      if (!options.all || parsedPage.done) break;
+    } while (cursor);
+
+    const parsed = {
+      ok: true as const,
+      dryRun,
+      scanned: pages.reduce((sum, page) => sum + page.scanned, 0),
+      wouldUnban: pages.reduce((sum, page) => sum + page.wouldUnban, 0),
+      unbanned: pages.reduce((sum, page) => sum + page.unbanned, 0),
+      skipped: pages.reduce((sum, page) => sum + page.skipped, 0),
+      restoredSkills: pages.reduce((sum, page) => sum + page.restoredSkills, 0),
+      restoredPackages: pages.reduce((sum, page) => sum + page.restoredPackages, 0),
+      items: pages.flatMap((page) => page.items),
+      nextCursor: pages.at(-1)?.nextCursor ?? null,
+      done: pages.at(-1)?.done ?? true,
+    };
     spinner?.succeed(
       `${dryRun ? "Dry run" : "Applied"} autoban remediation: scanned ${parsed.scanned}, ${dryRun ? "would unban" : "unbanned"} ${dryRun ? parsed.wouldUnban : parsed.unbanned}, skipped ${parsed.skipped}.`,
     );
@@ -254,6 +279,9 @@ export async function cmdRemediateAutobans(
       console.log(
         `Restores: ${formatRestoredSkills(parsed.restoredSkills)}, ${formatRestoredPackages(parsed.restoredPackages)}.`,
       );
+      if (!parsed.done && parsed.nextCursor) {
+        console.log(`Next cursor: ${parsed.nextCursor}`);
+      }
       if (dryRun) console.log("Re-run with --apply to write these changes.");
     }
     return parsed;

--- a/packages/clawhub/src/schema/schemas.ts
+++ b/packages/clawhub/src/schema/schemas.ts
@@ -492,6 +492,8 @@ export const ApiV1RemediateAutobansResponseSchema = type({
   restoredSkills: "number",
   restoredPackages: "number",
   items: "unknown[]",
+  "nextCursor?": "string|null",
+  "done?": "boolean",
 });
 
 export const ApiV1SetRoleResponseSchema = type({

--- a/packages/schema/dist/schemas.d.ts
+++ b/packages/schema/dist/schemas.d.ts
@@ -465,6 +465,8 @@ export declare const ApiV1RemediateAutobansResponseSchema: import("arktype/inter
     restoredSkills: number;
     restoredPackages: number;
     items: unknown[];
+    nextCursor?: string | null;
+    done?: boolean;
 }, {}>;
 export declare const ApiV1StarResponseSchema: import("arktype/internal/variants/object.ts").ObjectType<{
     ok: true;

--- a/packages/schema/dist/schemas.js
+++ b/packages/schema/dist/schemas.js
@@ -421,6 +421,8 @@ export const ApiV1RemediateAutobansResponseSchema = type({
     restoredSkills: "number",
     restoredPackages: "number",
     items: "unknown[]",
+    "nextCursor?": "string|null",
+    "done?": "boolean",
 });
 export const ApiV1StarResponseSchema = type({
     ok: "true",

--- a/packages/schema/src/schemas.ts
+++ b/packages/schema/src/schemas.ts
@@ -494,6 +494,8 @@ export const ApiV1RemediateAutobansResponseSchema = type({
   restoredSkills: "number",
   restoredPackages: "number",
   items: "unknown[]",
+  "nextCursor?": "string|null",
+  "done?": "boolean",
 });
 
 export const ApiV1StarResponseSchema = type({


### PR DESCRIPTION
## Summary
- paginate `users remediate-autobans` through the admin HTTP route with `--cursor` and `--all`
- return `nextCursor` / `done` from the Convex remediation mutation while keeping old responses schema-compatible
- aggregate page results in `clawhub-mod` so one-off dry runs can produce a full report without one long HTTP call

## Proof
- `bun test packages/clawhub-mod/src/commands/moderation.test.ts convex/autobanRemediation.test.ts packages/clawhub/src/http.bun.test.ts`
- `bunx vitest run convex/httpApiV1.handlers.test.ts --testNamePattern "remediate autobans"`
- `bun run format:check -- packages/clawhub-mod/src/cli.ts packages/clawhub-mod/src/commands/moderation.ts packages/clawhub-mod/src/commands/moderation.test.ts convex/users.ts convex/httpApiV1/usersV1.ts convex/autobanRemediation.test.ts convex/httpApiV1.handlers.test.ts packages/clawhub/src/schema/schemas.ts packages/schema/src/schemas.ts packages/schema/dist/schemas.js packages/schema/dist/schemas.d.ts`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- local smoke against `http://127.0.0.1:3211`: `users remediate-autobans --dry-run --limit 2 --all --json`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean: no accepted/actionable findings
