### PR TITLE
feat: add ban reclassification tool

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -3447,6 +3447,101 @@ describe("httpApiV1 handlers", () => {
     );
   });
 
+  it("reclassify ban requires admin", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:actor",
+      user: { _id: "users:actor", role: "user" },
+    } as never);
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const response = await __handlers.usersPostRouterV1Handler(
+      makeCtx({ runMutation }),
+      new Request("https://example.com/api/v1/users/reclassify-ban", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ handle: "demo", reason: "bulk publishing spam" }),
+      }),
+    );
+    expect(response.status).toBe(403);
+  });
+
+  it("reclassify ban forwards admin payload", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:admin",
+      user: { _id: "users:admin", role: "admin" },
+    } as never);
+    const runMutation = vi.fn().mockResolvedValueOnce(okRate()).mockResolvedValueOnce({
+      ok: true,
+      dryRun: false,
+      userId: "users:target",
+      handle: "demo",
+      previousReason: "malware auto-ban",
+      nextReason: "bulk publishing spam",
+      changed: true,
+    });
+    const response = await __handlers.usersPostRouterV1Handler(
+      makeCtx({ runMutation }),
+      new Request("https://example.com/api/v1/users/reclassify-ban", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          dryRun: false,
+          userId: "users:target",
+          reason: "bulk publishing spam",
+        }),
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        actorUserId: "users:admin",
+        targetUserId: "users:target",
+        dryRun: false,
+        reason: "bulk publishing spam",
+      }),
+    );
+  });
+
+  it("reclassify ban resolves banned users by handle", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:admin",
+      user: { _id: "users:admin", role: "admin" },
+    } as never);
+    const runQuery = vi.fn().mockResolvedValue({ _id: "users:target", deletedAt: 123 });
+    const runMutation = vi.fn().mockResolvedValueOnce(okRate()).mockResolvedValueOnce({
+      ok: true,
+      dryRun: true,
+      userId: "users:target",
+      handle: "demo",
+      previousReason: "malware auto-ban",
+      nextReason: "bulk publishing spam",
+      changed: true,
+    });
+    const response = await __handlers.usersPostRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/users/reclassify-ban", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          handle: "demo",
+          reason: "bulk publishing spam",
+        }),
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(runQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ handle: "demo" }),
+    );
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        targetUserId: "users:target",
+        dryRun: true,
+      }),
+    );
+  });
+
   it("set role requires auth", async () => {
     vi.mocked(requireApiTokenUser).mockRejectedValueOnce(new Error("Unauthorized"));
     const runMutation = vi.fn().mockResolvedValue(okRate());

--- a/convex/httpApiV1/usersV1.ts
+++ b/convex/httpApiV1/usersV1.ts
@@ -14,9 +14,19 @@ import {
 
 const usersV1InternalRefs = internal as unknown as {
   users: {
+    getByHandleInternal: unknown;
     remediateAutobansInternal: unknown;
+    reclassifyBanInternal: unknown;
   };
 };
+
+async function runUsersV1QueryRef<T>(
+  ctx: Pick<ActionCtx, "runQuery">,
+  ref: unknown,
+  args: unknown,
+): Promise<T> {
+  return (await ctx.runQuery(ref as never, args as never)) as T;
+}
 
 async function runUsersV1MutationRef<T>(
   ctx: Pick<ActionCtx, "runMutation">,
@@ -41,6 +51,7 @@ export async function usersPostRouterV1Handler(ctx: ActionCtx, request: Request)
     action !== "role" &&
     action !== "restore" &&
     action !== "remediate-autobans" &&
+    action !== "reclassify-ban" &&
     action !== "reclaim" &&
     action !== "reserve" &&
     action !== "publisher"
@@ -68,6 +79,12 @@ export async function usersPostRouterV1Handler(ctx: ActionCtx, request: Request)
     const admin = requireAdminOrResponse(actorUser, rate.headers);
     if (!admin.ok) return admin.response;
     return handleAdminRemediateAutobans(ctx, payload, actorUserId, rate.headers);
+  }
+
+  if (action === "reclassify-ban") {
+    const admin = requireAdminOrResponse(actorUser, rate.headers);
+    if (!admin.ok) return admin.response;
+    return handleAdminReclassifyBan(ctx, payload, actorUserId, rate.headers);
   }
 
   if (action === "reclaim") {
@@ -181,6 +198,58 @@ export async function usersPostRouterV1Handler(ctx: ActionCtx, request: Request)
       return text(message, 404, rate.headers);
     }
     return text(message, 400, rate.headers);
+  }
+}
+
+async function handleAdminReclassifyBan(
+  ctx: ActionCtx,
+  payload: unknown,
+  actorUserId: Id<"users">,
+  headers: HeadersInit,
+) {
+  const body = payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
+  const handle = typeof body.handle === "string" ? body.handle.trim() : "";
+  const userId = typeof body.userId === "string" ? body.userId.trim() : "";
+  const reason = typeof body.reason === "string" ? body.reason.trim() : "";
+  const dryRun = body.dryRun !== false;
+
+  if (handle && userId) return text("Pass handle or userId, not both", 400, headers);
+  if (!handle && !userId) return text("Missing userId or handle", 400, headers);
+  if (!reason) return text("Missing reason", 400, headers);
+  if (reason.length > 500) return text("Reason too long (max 500 chars)", 400, headers);
+
+  let targetUserId: Id<"users"> | null = userId ? (userId as Id<"users">) : null;
+  if (!targetUserId) {
+    const user = await runUsersV1QueryRef<{ _id?: Id<"users"> } | null>(
+      ctx,
+      usersV1InternalRefs.users.getByHandleInternal,
+      { handle: handle.toLowerCase() },
+    );
+    if (!user?._id) return text("User not found", 404, headers);
+    targetUserId = user._id;
+  }
+
+  try {
+    const result = await runUsersV1MutationRef(
+      ctx,
+      usersV1InternalRefs.users.reclassifyBanInternal,
+      {
+        actorUserId,
+        targetUserId,
+        reason,
+        dryRun,
+      },
+    );
+    return json(result, 200, headers);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Ban reclassification failed";
+    if (message.toLowerCase().includes("forbidden")) {
+      return text("Forbidden", 403, headers);
+    }
+    if (message.toLowerCase().includes("not found")) {
+      return text(message, 404, headers);
+    }
+    return text(message, 400, headers);
   }
 }
 

--- a/convex/users.test.ts
+++ b/convex/users.test.ts
@@ -22,6 +22,7 @@ const {
   list,
   searchInternal,
   banUserInternal,
+  reclassifyBanInternal,
   me,
   placeUserUnderModerationInternal,
   liftModerationHoldInternal,
@@ -1937,6 +1938,153 @@ describe("users.banUserInternal", () => {
       softDeletedAt: 1_600_000_000_000,
       deletedBy: "users:actor",
     });
+  });
+});
+
+describe("users.reclassifyBanInternal", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("dry-runs a ban reason reclassification without patching or auditing", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    const { ctx, get, patch, insert } = makeBanCtx();
+    get.mockImplementation(async (id: string) => {
+      if (id === "users:actor") return { _id: "users:actor", role: "admin" };
+      if (id === "users:target") {
+        return {
+          _id: "users:target",
+          role: "user",
+          handle: "hanxueyuan",
+          deletedAt: 1_600_000_000_000,
+          banReason: "malware auto-ban",
+        };
+      }
+      return null;
+    });
+
+    const handler = (
+      reclassifyBanInternal as unknown as {
+        _handler: (
+          ctx: unknown,
+          args: {
+            actorUserId: string;
+            targetUserId: string;
+            reason: string;
+            dryRun?: boolean;
+          },
+        ) => Promise<unknown>;
+      }
+    )._handler;
+
+    const result = await handler(ctx, {
+      actorUserId: "users:actor",
+      targetUserId: "users:target",
+      reason: "bulk publishing spam",
+      dryRun: true,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      dryRun: true,
+      userId: "users:target",
+      handle: "hanxueyuan",
+      previousReason: "malware auto-ban",
+      nextReason: "bulk publishing spam",
+      changed: true,
+    });
+    expect(patch).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it("applies a ban reason reclassification with an audit log", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    const { ctx, get, patch, insert } = makeBanCtx();
+    get.mockImplementation(async (id: string) => {
+      if (id === "users:actor") return { _id: "users:actor", role: "admin" };
+      if (id === "users:target") {
+        return {
+          _id: "users:target",
+          role: "user",
+          handle: "hanxueyuan",
+          deletedAt: 1_600_000_000_000,
+          banReason: "malware auto-ban",
+        };
+      }
+      return null;
+    });
+
+    const handler = (
+      reclassifyBanInternal as unknown as {
+        _handler: (
+          ctx: unknown,
+          args: {
+            actorUserId: string;
+            targetUserId: string;
+            reason: string;
+            dryRun?: boolean;
+          },
+        ) => Promise<unknown>;
+      }
+    )._handler;
+
+    const result = await handler(ctx, {
+      actorUserId: "users:actor",
+      targetUserId: "users:target",
+      reason: "bulk publishing spam",
+      dryRun: false,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      dryRun: false,
+      userId: "users:target",
+      previousReason: "malware auto-ban",
+      nextReason: "bulk publishing spam",
+      changed: true,
+    });
+    expect(patch).toHaveBeenCalledWith("users:target", {
+      banReason: "bulk publishing spam",
+      updatedAt: 1_700_000_000_000,
+    });
+    expect(insert).toHaveBeenCalledWith(
+      "auditLogs",
+      expect.objectContaining({
+        action: "user.ban.reclassify",
+        targetType: "user",
+        targetId: "users:target",
+        metadata: {
+          previousReason: "malware auto-ban",
+          nextReason: "bulk publishing spam",
+        },
+      }),
+    );
+  });
+
+  it("rejects unbanned users", async () => {
+    const { ctx, get } = makeBanCtx();
+    get.mockImplementation(async (id: string) => {
+      if (id === "users:actor") return { _id: "users:actor", role: "admin" };
+      if (id === "users:target") return { _id: "users:target", role: "user" };
+      return null;
+    });
+
+    const handler = (
+      reclassifyBanInternal as unknown as {
+        _handler: (
+          ctx: unknown,
+          args: { actorUserId: string; targetUserId: string; reason: string },
+        ) => Promise<unknown>;
+      }
+    )._handler;
+
+    await expect(
+      handler(ctx, {
+        actorUserId: "users:actor",
+        targetUserId: "users:target",
+        reason: "bulk publishing spam",
+      }),
+    ).rejects.toThrow(/not currently banned/i);
   });
 });
 

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -836,6 +836,66 @@ export const unbanUserInternal = internalMutation({
   },
 });
 
+export const reclassifyBanInternal = internalMutation({
+  args: {
+    actorUserId: v.id("users"),
+    targetUserId: v.id("users"),
+    reason: v.string(),
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const actor = await ctx.db.get(args.actorUserId);
+    if (!actor || actor.deletedAt || actor.deactivatedAt) throw new Error("User not found");
+    assertAdmin(actor);
+
+    const target = await ctx.db.get(args.targetUserId);
+    if (!target) throw new Error("User not found");
+    if (target.deactivatedAt || target.purgedAt) {
+      throw new Error("Cannot reclassify a deactivated account");
+    }
+    if (!target.deletedAt) {
+      throw new Error("User is not currently banned");
+    }
+
+    const nextReason = args.reason.trim();
+    if (!nextReason) throw new Error("Reason required");
+    if (nextReason.length > 500) throw new Error("Reason too long (max 500 chars)");
+
+    const previousReason = target.banReason ?? null;
+    const changed = previousReason !== nextReason;
+    const dryRun = args.dryRun !== false;
+
+    if (!dryRun && changed) {
+      const now = Date.now();
+      await ctx.db.patch(args.targetUserId, {
+        banReason: nextReason,
+        updatedAt: now,
+      });
+      await ctx.db.insert("auditLogs", {
+        actorUserId: actor._id,
+        action: "user.ban.reclassify",
+        targetType: "user",
+        targetId: args.targetUserId,
+        metadata: {
+          previousReason,
+          nextReason,
+        },
+        createdAt: now,
+      });
+    }
+
+    return {
+      ok: true as const,
+      dryRun,
+      userId: args.targetUserId,
+      handle: target.handle ?? null,
+      previousReason,
+      nextReason,
+      changed,
+    };
+  },
+});
+
 export const remediateAutobansInternal = internalMutation({
   args: {
     actorUserId: v.id("users"),

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -1272,6 +1272,37 @@ Response:
 { "ok": true, "alreadyUnbanned": false, "restoredSkills": 3 }
 ```
 
+### `POST /api/v1/users/reclassify-ban`
+
+Change the stored reason for an existing ban without unbanning or restoring
+content (admin only). Defaults to dry-run unless `dryRun` is `false`.
+
+Body:
+
+```json
+{ "handle": "user_handle", "reason": "bulk publishing spam", "dryRun": true }
+```
+
+or
+
+```json
+{ "userId": "users_...", "reason": "bulk publishing spam", "dryRun": false }
+```
+
+Response:
+
+```json
+{
+  "ok": true,
+  "dryRun": false,
+  "userId": "users_...",
+  "handle": "user_handle",
+  "previousReason": "malware auto-ban",
+  "nextReason": "bulk publishing spam",
+  "changed": true
+}
+```
+
 ### `POST /api/v1/users/role`
 
 Change a user role (admin only).

--- a/packages/clawhub-mod/README.md
+++ b/packages/clawhub-mod/README.md
@@ -85,6 +85,8 @@ User administration:
 bun run mod -- users ban <handleOrId> [--id] [--fuzzy] [--reason <text>] [--yes]
 bun run mod -- users unban <handleOrId> [--id] [--fuzzy] [--reason <text>] [--yes]
 bun run mod -- users set-role <handleOrId> <user|moderator|admin> [--id] [--fuzzy] [--yes]
+bun run mod -- users reclassify-ban <handleOrId> --reason <text> [--id] [--fuzzy] [--dry-run|--apply] [--yes] [--json]
+bun run mod -- users remediate-autobans [--dry-run|--apply] [--user <handleOrId>] [--id] [--since <date>] [--limit <n>] [--cursor <cursor>] [--all] [--json]
 ```
 
 The old top-level names are also available on the moderator binary:

--- a/packages/clawhub-mod/src/cli.ts
+++ b/packages/clawhub-mod/src/cli.ts
@@ -24,6 +24,7 @@ import { fail } from "../../clawhub/src/cli/ui.js";
 import { getModeratorCliBuildLabel, getModeratorCliVersion } from "./buildInfo.js";
 import {
   cmdBanUser,
+  cmdReclassifyBan,
   cmdRemediateAutobans,
   cmdSetRole,
   cmdUnbanUser,
@@ -229,6 +230,22 @@ users
   .action(async (handleOrId, role, options) => {
     const opts = await resolveGlobalOpts();
     await cmdSetRole(opts, handleOrId, role, options, isInputAllowed());
+  });
+
+users
+  .command("reclassify-ban")
+  .description("Change the stored reason for an existing ban")
+  .argument("<handleOrId>", "User handle (default) or user id")
+  .option("--apply", "Write changes; defaults to dry-run")
+  .option("--dry-run", "Plan only (default)")
+  .option("--id", "Treat argument as user id")
+  .option("--fuzzy", "Resolve handle via fuzzy user search")
+  .requiredOption("--reason <reason>", "New ban reason")
+  .option("--yes", "Skip confirmation for --apply")
+  .option("--json", "Output JSON")
+  .action(async (handleOrId, options) => {
+    const opts = await resolveGlobalOpts();
+    await cmdReclassifyBan(opts, handleOrId, options, isInputAllowed());
   });
 
 users

--- a/packages/clawhub-mod/src/commands/moderation.test.ts
+++ b/packages/clawhub-mod/src/commands/moderation.test.ts
@@ -19,7 +19,8 @@ vi.mock("../../../clawhub/src/cli/registry.js", () => registryMocks.moduleFactor
 vi.mock("../../../clawhub/src/http.js", () => httpMocks.moduleFactory());
 vi.mock("../../../clawhub/src/cli/ui.js", () => uiMocks.moduleFactory());
 
-const { cmdBanUser, cmdRemediateAutobans, cmdSetRole, cmdUnbanUser } = await import("./moderation");
+const { cmdBanUser, cmdReclassifyBan, cmdRemediateAutobans, cmdSetRole, cmdUnbanUser } =
+  await import("./moderation");
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -433,6 +434,85 @@ describe("cmdRemediateAutobans", () => {
     await expect(
       cmdRemediateAutobans(makeGlobalOpts(), { all: true, user: "demo" }, false),
     ).rejects.toThrow(/either --all or --user/i);
+    expect(httpMocks.apiRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe("cmdReclassifyBan", () => {
+  it("defaults to dry run and posts handle payload", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      ok: true,
+      dryRun: true,
+      userId: "users:target",
+      handle: "hanxueyuan",
+      previousReason: "malware auto-ban",
+      nextReason: "bulk publishing spam",
+      changed: true,
+    });
+
+    await cmdReclassifyBan(
+      makeGlobalOpts(),
+      "hanxueyuan",
+      { reason: "bulk publishing spam" },
+      false,
+    );
+
+    expect(httpMocks.apiRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/v1/users/reclassify-ban",
+        body: { handle: "hanxueyuan", reason: "bulk publishing spam", dryRun: true },
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("posts apply payload with user id when --id is set", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      ok: true,
+      dryRun: false,
+      userId: "users:target",
+      handle: null,
+      previousReason: "malware auto-ban",
+      nextReason: "bulk publishing spam",
+      changed: true,
+    });
+
+    await cmdReclassifyBan(
+      makeGlobalOpts(),
+      "users:target",
+      { id: true, apply: true, yes: true, reason: "bulk publishing spam" },
+      false,
+    );
+
+    expect(httpMocks.apiRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/v1/users/reclassify-ban",
+        body: { userId: "users:target", reason: "bulk publishing spam", dryRun: false },
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("requires a reason", async () => {
+    await expect(cmdReclassifyBan(makeGlobalOpts(), "hanxueyuan", {}, false)).rejects.toThrow(
+      /reason/i,
+    );
+    expect(httpMocks.apiRequest).not.toHaveBeenCalled();
+  });
+
+  it("requires --yes for apply when input is disabled", async () => {
+    await expect(
+      cmdReclassifyBan(
+        makeGlobalOpts(),
+        "hanxueyuan",
+        { apply: true, reason: "bulk publishing spam" },
+        false,
+      ),
+    ).rejects.toThrow(/--yes/i);
     expect(httpMocks.apiRequest).not.toHaveBeenCalled();
   });
 });

--- a/packages/clawhub-mod/src/commands/moderation.ts
+++ b/packages/clawhub-mod/src/commands/moderation.ts
@@ -13,6 +13,7 @@ import { apiRequest, registryUrl } from "../../../clawhub/src/http.js";
 import {
   ApiRoutes,
   ApiV1BanUserResponseSchema,
+  ApiV1ReclassifyBanResponseSchema,
   ApiV1RemediateAutobansResponseSchema,
   ApiV1SetRoleResponseSchema,
   ApiV1UnbanUserResponseSchema,
@@ -183,6 +184,86 @@ export async function cmdSetRole(
     return parsed;
   } catch (error) {
     spinner.fail(formatError(error));
+    throw error;
+  }
+}
+
+export async function cmdReclassifyBan(
+  opts: GlobalOpts,
+  identifierArg: string,
+  options: {
+    apply?: boolean;
+    dryRun?: boolean;
+    yes?: boolean;
+    id?: boolean;
+    fuzzy?: boolean;
+    reason?: string;
+    json?: boolean;
+  },
+  inputAllowed: boolean,
+) {
+  if (options.apply && options.dryRun) fail("Choose either --apply or --dry-run, not both");
+
+  const raw = identifierArg.trim();
+  if (!raw) fail("Handle or user id required");
+
+  const reason = options.reason?.trim();
+  if (!reason) fail("Reason required");
+  if (reason.length > 500) fail("Reason too long (max 500 chars)");
+
+  const dryRun = options.apply !== true;
+  const token = await requireAuthToken();
+  const registry = await getRegistry(opts, { cache: true });
+  const allowPrompt = isInteractive() && inputAllowed !== false;
+  const resolved = await resolveUserIdentifier(
+    registry,
+    token,
+    raw,
+    { id: options.id, fuzzy: options.fuzzy },
+    allowPrompt,
+  );
+  if (!resolved) return undefined;
+
+  if (!dryRun && !options.yes) {
+    if (!allowPrompt) fail("Pass --yes (no input)");
+    const ok = await promptConfirm(
+      `Reclassify ban for ${resolved.label} as "${reason}"? (admin only; no unban/restore)`,
+    );
+    if (!ok) return undefined;
+  }
+
+  const spinner = options.json
+    ? null
+    : createSpinner(
+        `${dryRun ? "Planning" : "Applying"} ban reclassification for ${resolved.label}`,
+      );
+  try {
+    const result = await apiRequest(
+      registry,
+      {
+        method: "POST",
+        path: `${ApiRoutes.users}/reclassify-ban`,
+        token,
+        body: {
+          ...(resolved.userId ? { userId: resolved.userId } : { handle: resolved.handle }),
+          reason,
+          dryRun,
+        },
+      },
+      ApiV1ReclassifyBanResponseSchema,
+    );
+    const parsed = parseArk(ApiV1ReclassifyBanResponseSchema, result, "Reclassify ban response");
+    spinner?.succeed(
+      `${dryRun ? "Dry run" : "Applied"} ban reclassification for ${resolved.label}: ${parsed.previousReason ?? "none"} -> ${parsed.nextReason}${parsed.changed ? "" : " (already set)"}.`,
+    );
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(parsed, null, 2)}\n`);
+    } else if (dryRun) {
+      console.log("Re-run with --apply --yes to write this change.");
+    }
+    return parsed;
+  } catch (error) {
+    spinner?.fail(formatError(error));
     throw error;
   }
 }

--- a/packages/clawhub/src/schema/schemas.ts
+++ b/packages/clawhub/src/schema/schemas.ts
@@ -482,6 +482,16 @@ export const ApiV1UnbanUserResponseSchema = type({
   restoredSkills: "number?",
 });
 
+export const ApiV1ReclassifyBanResponseSchema = type({
+  ok: "true",
+  dryRun: "boolean",
+  userId: "string",
+  handle: "string|null",
+  previousReason: "string|null",
+  nextReason: "string",
+  changed: "boolean",
+});
+
 export const ApiV1RemediateAutobansResponseSchema = type({
   ok: "true",
   dryRun: "boolean",

--- a/packages/schema/dist/schemas.d.ts
+++ b/packages/schema/dist/schemas.d.ts
@@ -455,6 +455,15 @@ export declare const ApiV1SetRoleResponseSchema: import("arktype/internal/varian
     ok: true;
     role: "user" | "admin" | "moderator";
 }, {}>;
+export declare const ApiV1ReclassifyBanResponseSchema: import("arktype/internal/variants/object.ts").ObjectType<{
+    ok: true;
+    dryRun: boolean;
+    userId: string;
+    handle: string | null;
+    previousReason: string | null;
+    nextReason: string;
+    changed: boolean;
+}, {}>;
 export declare const ApiV1RemediateAutobansResponseSchema: import("arktype/internal/variants/object.ts").ObjectType<{
     ok: true;
     dryRun: boolean;

--- a/packages/schema/dist/schemas.js
+++ b/packages/schema/dist/schemas.js
@@ -411,6 +411,15 @@ export const ApiV1SetRoleResponseSchema = type({
     ok: "true",
     role: '"admin"|"moderator"|"user"',
 });
+export const ApiV1ReclassifyBanResponseSchema = type({
+    ok: "true",
+    dryRun: "boolean",
+    userId: "string",
+    handle: "string|null",
+    previousReason: "string|null",
+    nextReason: "string",
+    changed: "boolean",
+});
 export const ApiV1RemediateAutobansResponseSchema = type({
     ok: "true",
     dryRun: "boolean",

--- a/packages/schema/src/schemas.ts
+++ b/packages/schema/src/schemas.ts
@@ -484,6 +484,16 @@ export const ApiV1SetRoleResponseSchema = type({
   role: '"admin"|"moderator"|"user"',
 });
 
+export const ApiV1ReclassifyBanResponseSchema = type({
+  ok: "true",
+  dryRun: "boolean",
+  userId: "string",
+  handle: "string|null",
+  previousReason: "string|null",
+  nextReason: "string",
+  changed: "boolean",
+});
+
 export const ApiV1RemediateAutobansResponseSchema = type({
   ok: "true",
   dryRun: "boolean",

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -184,6 +184,9 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
 - Admins can manually unban (`deletedAt` + `banReason` cleared); revoked API tokens
   stay revoked and should be recreated by the user.
 - Optional ban reason is stored in `users.banReason` and audit logs.
+- Admins can reclassify an existing ban reason without unbanning or restoring
+  content. This preserves the ban while removing users from remediation flows
+  that key off a specific historical reason such as `malware auto-ban`.
 - Moderators cannot ban admins; nobody can ban themselves.
 - Report counters effectively reset because deleted/banned skills are no longer
   considered active in the per-user report cap.


### PR DESCRIPTION
## Summary
- add admin `POST /api/v1/users/reclassify-ban` for changing the stored reason on an existing ban without unbanning or restoring content
- add `clawhub-mod users reclassify-ban` with dry-run default, `--apply`, handle/id targeting, JSON output, and confirmation guardrails
- document the new operator path and cover CLI, HTTP routing, inactive-handle resolution, and Convex mutation behavior with tests

## Tests
- `bunx vitest run convex/httpApiV1.handlers.test.ts packages/clawhub-mod/src/commands/moderation.test.ts convex/users.test.ts`
- `bun run ci:static`
- `.agents/skills/autoreview/scripts/autoreview --mode auto` -> clean after fixing inactive handle resolution
