### PR TITLE
fix: disable daily VT rescan

### DIFF
--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -72,9 +72,6 @@ crons.interval(
   { batchSize: 100 },
 );
 
-// Daily re-scan of all active skills at 3am UTC
-crons.daily("vt-daily-rescan", { hourUTC: 3, minuteUTC: 0 }, internal.vt.rescanActiveSkills, {});
-
 crons.interval(
   "download-dedupe-prune",
   { hours: 24 },

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -114,6 +114,9 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   concerns remain `flagged.suspicious` and are hidden by the suspicious filter.
 - VirusTotal is telemetry only. It is included in the Codex workspace as signal,
   but VT alone must never hide, block, or set malicious/suspicious public status.
+- All-active daily VirusTotal sweeps are disabled. Any future recurring VT
+  freshness job must be bounded or delta-driven, and must not starve
+  publish-triggered ClawScan jobs.
 - Prompt-injection pre-scan hits are also context for Codex, not a deterministic
   post-Codex veto. The release worker must not downgrade a benign Codex verdict
   solely from regex telemetry.


### PR DESCRIPTION
## Summary
- remove the scheduled all-active `vt-daily-rescan` cron
- keep the internal `rescanActiveSkills` action available for manual use
- document that future VT freshness jobs must be bounded or delta-driven and must not starve publish-triggered ClawScan jobs

## Tests
- `bun run format:check -- convex/crons.ts specs/security-moderation.md`
- `bun run lint`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local --reviewer codex --fallback-reviewer none`
