### PR TITLE
Fix legacy personal skill rows on publisher profiles

### DIFF
--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { assertCanManageOwnedResource } from "./lib/publishers";
 import {
   addMember,
+  getProfileByHandle,
   listPublicPage,
   listPublic,
   listMine,
@@ -103,6 +104,22 @@ const listPublishedPageHandler = (
       continueCursor: string;
       isDone: boolean;
     }
+  >
+)._handler;
+
+const getProfileByHandleHandler = (
+  getProfileByHandle as unknown as WrappedHandler<
+    { handle: string },
+    {
+      stats: {
+        skills: number;
+        packages: number;
+        downloads: number;
+        installs: number;
+        stars: number;
+      };
+      publishedItems: Array<{ displayName: string; downloads: number }>;
+    } | null
   >
 )._handler;
 
@@ -231,10 +248,16 @@ describe("publishers membership controls", () => {
                 skillRows.filter((skill) => skill.ownerPublisherId === fields.ownerPublisherId),
               );
             }
+            if (table === "skills" && indexName === "by_owner_active_updated") {
+              return indexedRows([]);
+            }
             if (table === "packages" && indexName === "by_owner_publisher_active_updated") {
               return indexedRows(
                 packageRows.filter((pkg) => pkg.ownerPublisherId === fields.ownerPublisherId),
               );
+            }
+            if (table === "packages" && indexName === "by_owner") {
+              return indexedRows([]);
             }
             throw new Error(`unexpected ${table} index ${indexName}`);
           }),
@@ -734,6 +757,186 @@ describe("publishers membership controls", () => {
 
     expect(result.page).toMatchObject([
       { displayName: "Example Plugin", href: "/plugins/@openclaw/example-plugin" },
+    ]);
+  });
+
+  it("includes legacy user-owned rows on personal publisher profile pages", async () => {
+    const publisher = {
+      _id: "publishers:ivan",
+      _creationTime: 1,
+      kind: "user",
+      handle: "ivangdavila",
+      displayName: "Ivan",
+      linkedUserId: "users:ivan",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const scopedSkill = {
+      _id: "skills:scoped",
+      ownerUserId: "users:ivan",
+      ownerPublisherId: "publishers:ivan",
+      softDeletedAt: undefined,
+      slug: "scoped",
+      displayName: "Scoped Skill",
+      summary: "Modern publisher-owned skill",
+      stats: { downloads: 10, installsAllTime: 1, stars: 0 },
+      updatedAt: 10,
+    };
+    const legacySkill = {
+      _id: "skills:legacy",
+      ownerUserId: "users:ivan",
+      ownerPublisherId: undefined,
+      softDeletedAt: undefined,
+      slug: "self-improving",
+      displayName: "Self Improving",
+      summary: "Legacy user-owned skill",
+      stats: { downloads: 100, installsAllTime: 5, stars: 2 },
+      updatedAt: 20,
+    };
+    const orgSkill = {
+      _id: "skills:org",
+      ownerUserId: "users:ivan",
+      ownerPublisherId: "publishers:org",
+      softDeletedAt: undefined,
+      slug: "org-skill",
+      displayName: "Org Skill",
+      summary: "Belongs to another publisher",
+      stats: { downloads: 200, installsAllTime: 1, stars: 0 },
+      updatedAt: 30,
+    };
+    const scopedPackage = {
+      _id: "packages:scoped",
+      ownerUserId: "users:ivan",
+      ownerPublisherId: "publishers:ivan",
+      softDeletedAt: undefined,
+      family: "code-plugin",
+      name: "scoped-plugin",
+      displayName: "Scoped Plugin",
+      summary: "Modern publisher-owned plugin",
+      stats: { downloads: 5, installs: 1, stars: 0, versions: 1 },
+      updatedAt: 5,
+    };
+    const legacyPackage = {
+      _id: "packages:legacy",
+      ownerUserId: "users:ivan",
+      ownerPublisherId: undefined,
+      softDeletedAt: undefined,
+      family: "code-plugin",
+      name: "legacy-plugin",
+      displayName: "Legacy Plugin",
+      summary: "Legacy user-owned plugin",
+      stats: { downloads: 50, installs: 3, stars: 1, versions: 1 },
+      updatedAt: 15,
+    };
+    const orgPackage = {
+      _id: "packages:org",
+      ownerUserId: "users:ivan",
+      ownerPublisherId: "publishers:org",
+      softDeletedAt: undefined,
+      family: "code-plugin",
+      name: "org-plugin",
+      displayName: "Org Plugin",
+      summary: "Belongs to another publisher",
+      stats: { downloads: 500, installs: 1, stars: 0, versions: 1 },
+      updatedAt: 25,
+    };
+    const queryIndexes: Array<{
+      table: string;
+      indexName: string;
+      fields: Record<string, unknown>;
+    }> = [];
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "publishers:ivan") return publisher;
+          if (id === "users:ivan") return { _id: id, image: "https://github.com/ivan.png" };
+          return null;
+        }),
+        query: vi.fn((table: string) => ({
+          withIndex: vi.fn((indexName: string, buildQuery: (q: unknown) => unknown) => {
+            const fields: Record<string, unknown> = {};
+            const q = {
+              eq: (field: string, value: unknown) => {
+                fields[field] = value;
+                return q;
+              },
+            };
+            buildQuery(q);
+            queryIndexes.push({ table, indexName, fields });
+            if (table === "publishers" && indexName === "by_handle") {
+              return {
+                unique: vi.fn(async () => (fields.handle === "ivangdavila" ? publisher : null)),
+              };
+            }
+            if (table === "skills" && indexName === "by_owner_publisher_active_updated") {
+              return indexedRows([scopedSkill]);
+            }
+            if (table === "skills" && indexName === "by_owner_active_updated") {
+              return indexedRows([legacySkill, scopedSkill, orgSkill]);
+            }
+            if (table === "packages" && indexName === "by_owner_publisher_active_updated") {
+              return indexedRows([scopedPackage]);
+            }
+            if (table === "packages" && indexName === "by_owner") {
+              return indexedRows([legacyPackage, scopedPackage, orgPackage]);
+            }
+            if (table === "publisherMembers" && indexName === "by_user") {
+              return indexedRows([]);
+            }
+            if (table === "stars" && indexName === "by_user") {
+              return indexedRows([]);
+            }
+            throw new Error(`unexpected ${table} index ${indexName}`);
+          }),
+        })),
+      },
+    };
+
+    const result = await listPublishedPageHandler(ctx as never, {
+      handle: "ivangdavila",
+      paginationOpts: { cursor: null, numItems: 12 },
+    });
+
+    expect(result.page.map((item) => item.displayName)).toEqual([
+      "Self Improving",
+      "Legacy Plugin",
+      "Scoped Skill",
+      "Scoped Plugin",
+    ]);
+    expect(result.page.slice(0, 2)).toMatchObject([
+      { displayName: "Self Improving", href: "/ivangdavila/self-improving" },
+      { displayName: "Legacy Plugin", href: "/plugins/legacy-plugin" },
+    ]);
+    expect(queryIndexes).toEqual(
+      expect.arrayContaining([
+        {
+          table: "skills",
+          indexName: "by_owner_active_updated",
+          fields: { ownerUserId: "users:ivan", softDeletedAt: undefined },
+        },
+        {
+          table: "packages",
+          indexName: "by_owner",
+          fields: { ownerUserId: "users:ivan" },
+        },
+      ]),
+    );
+
+    const profile = await getProfileByHandleHandler(ctx as never, {
+      handle: "ivangdavila",
+    });
+
+    expect(profile?.stats).toEqual({
+      skills: 2,
+      packages: 2,
+      installs: 10,
+      downloads: 165,
+      stars: 3,
+    });
+    expect(profile?.publishedItems.map((item) => item.displayName)).toEqual([
+      "Self Improving",
+      "Legacy Plugin",
+      "Scoped Skill",
     ]);
   });
 

--- a/convex/publishers.ts
+++ b/convex/publishers.ts
@@ -138,11 +138,34 @@ type PublisherPublishedRows = {
   packages: Doc<"packages">[];
 };
 
+type PublisherOwnedRow = {
+  _id: unknown;
+  ownerPublisherId?: Id<"publishers">;
+  softDeletedAt?: number;
+};
+
+function mergePersonalPublisherRows<T extends PublisherOwnedRow>(
+  publisherId: Id<"publishers">,
+  scopedRows: T[],
+  legacyRows: T[],
+) {
+  const seen = new Set<unknown>();
+  return [...scopedRows, ...legacyRows].filter((row) => {
+    if (row.softDeletedAt) return false;
+    if (row.ownerPublisherId && row.ownerPublisherId !== publisherId) return false;
+    if (seen.has(row._id)) return false;
+    seen.add(row._id);
+    return true;
+  });
+}
+
 async function getPublisherPublishedRows(
   ctx: Pick<QueryCtx, "db">,
-  publisherId: Id<"publishers">,
+  publisher: Doc<"publishers">,
 ): Promise<PublisherPublishedRows> {
-  const [skills, packages] = await Promise.all([
+  const publisherId = publisher._id;
+  const shouldIncludeLegacyRows = publisher.kind === "user" && publisher.linkedUserId;
+  const [skills, packages, legacySkills, legacyPackages] = await Promise.all([
     ctx.db
       .query("skills")
       .withIndex("by_owner_publisher_active_updated", (q) =>
@@ -155,8 +178,26 @@ async function getPublisherPublishedRows(
         q.eq("ownerPublisherId", publisherId).eq("softDeletedAt", undefined),
       )
       .collect(),
+    shouldIncludeLegacyRows
+      ? ctx.db
+          .query("skills")
+          .withIndex("by_owner_active_updated", (q) =>
+            q.eq("ownerUserId", publisher.linkedUserId!).eq("softDeletedAt", undefined),
+          )
+          .collect()
+      : [],
+    shouldIncludeLegacyRows
+      ? ctx.db
+          .query("packages")
+          .withIndex("by_owner", (q) => q.eq("ownerUserId", publisher.linkedUserId!))
+          .collect()
+      : [],
   ]);
-  return { skills, packages };
+  if (!shouldIncludeLegacyRows) return { skills, packages };
+  return {
+    skills: mergePersonalPublisherRows(publisherId, skills, legacySkills),
+    packages: mergePersonalPublisherRows(publisherId, packages, legacyPackages),
+  };
 }
 
 async function getPublisherPublishedPreviewRows(
@@ -301,7 +342,7 @@ async function toPublisherListItem(
       : null;
   let publishedRows: PublisherPublishedRows | null = null;
   const getRows = async () => {
-    publishedRows ??= await getPublisherPublishedRows(ctx, publisher._id);
+    publishedRows ??= await getPublisherPublishedRows(ctx, publisher);
     return publishedRows;
   };
   const getPreviewRows = async () =>
@@ -979,7 +1020,7 @@ export const listPublishedPage = query({
     const safeOffset = Number.isFinite(offset) && offset > 0 ? Math.trunc(offset) : 0;
     const items = getPublisherCatalogItems(
       publisher,
-      await getPublisherPublishedRows(ctx, publisher._id),
+      await getPublisherPublishedRows(ctx, publisher),
       args.sort ?? "downloads",
     ).filter((item) => !args.kind || item.kind === args.kind);
     const nextOffset = safeOffset + numItems;


### PR DESCRIPTION
## Summary

- Include legacy `ownerUserId`-owned rows when loading a user-kind publisher profile catalog.
- Keep `ownerPublisherId` as the canonical public owner ID, but union/dedupe legacy personal rows where `ownerPublisherId` is absent.
- Filter out rows that already belong to a different publisher so org-owned content does not leak back onto a personal profile.

## Root Cause

`/user/:handle` loads `api.publishers.getProfileByHandle` and `api.publishers.listPublishedPage`. Both depended on `getPublisherPublishedRows()`, which only queried content by `ownerPublisherId`.

That misses legacy skills published before the publisher migration where the row has `ownerUserId` but no `ownerPublisherId`. Skill detail pages still worked because `api.skills.getBySlug` falls back from `ownerUserId` to the user's personal publisher, so individual skills resolved while the profile catalog did not.

## Behavioral Proof

Live production baseline before this fix, using `https://wry-manatee-359.convex.cloud`:

```json
{
  "currentProdProfileStats": {
    "downloads": 1253,
    "installs": 0,
    "packages": 13,
    "skills": 1,
    "stars": 0
  },
  "currentProdPublishedPage": {
    "count": 14,
    "isDone": true,
    "names": [
      "Email",
      "Clawic CLI",
      "Database",
      "Excel",
      "Tasks",
      "Deep Research",
      "WhatsApp",
      "Google",
      "Notes",
      "Drive",
      "Flights",
      "Real Estate",
      "Cloudflare",
      "Sentry"
    ]
  },
  "currentProdLegacyUserSkillCount": 955,
  "legacyUserPages": 10
}
```

Regression proof on this branch:

- `bunx vitest run convex/publishers.test.ts --testNamePattern "legacy user-owned"`
  - 1 passed, 21 skipped
  - Covers `listPublishedPage` returning legacy personal skill/plugin rows, deduping scoped rows, and rejecting rows already assigned to another publisher.
  - Covers `getProfileByHandle` stats and preview items including legacy personal rows.
- `bunx vitest run convex/publishers.test.ts`
  - 22 passed
- `bun run ci:unit`
  - 205 test files passed
  - 2022 tests passed
  - global coverage: statements 85.99%, branches 75.11%, functions 86.37%, lines 89.49%
- `bun run ci:static`
  - peer checks passed
  - `bun audit --ignore GHSA-rmmr-r34h-pfm5` passed
  - format check passed
  - oxlint passed
  - knip dead-code checks passed
- `bunx tsc --noEmit`
  - passed

No screenshot proof was generated because this is a Convex profile read fix; the failing and fixed behavior is at the query boundary used by the page.
