### PR TITLE
Remove VirusTotal Code Insight scans

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -1732,7 +1732,7 @@ describe("httpApiV1 handlers", () => {
           sha256hash: "a".repeat(64),
           vtAnalysis: {
             status: "suspicious",
-            source: "code_insight",
+            source: "legacy-ai",
             checkedAt: 123,
           },
           files: [],

--- a/convex/lib/moderationEngine.test.ts
+++ b/convex/lib/moderationEngine.test.ts
@@ -2032,7 +2032,7 @@ describe("moderationEngine", () => {
     expect(snapshot.reasonCodes).not.toContain("suspicious.vt_suspicious");
   });
 
-  it("ignores AI-only VT suspicious as moderation authority", () => {
+  it("ignores VT suspicious status as moderation authority", () => {
     const snapshot = buildModerationSnapshot({
       staticScan: {
         status: "clean",
@@ -2044,8 +2044,6 @@ describe("moderationEngine", () => {
       },
       vtAnalysis: {
         status: "suspicious",
-        scanner: "code_insight",
-        source: "palm",
         engineStats: {
           malicious: 0,
           suspicious: 0,
@@ -2060,7 +2058,7 @@ describe("moderationEngine", () => {
     expect(snapshot.reasonCodes).toEqual([]);
   });
 
-  it("ignores AI-only VT malicious without AV-engine corroboration", () => {
+  it("ignores VT malicious status without local corroboration", () => {
     const snapshot = buildModerationSnapshot({
       staticScan: {
         status: "clean",
@@ -2072,8 +2070,6 @@ describe("moderationEngine", () => {
       },
       vtAnalysis: {
         status: "malicious",
-        scanner: "code_insight",
-        source: "palm",
         engineStats: {
           malicious: 0,
           suspicious: 0,
@@ -2127,7 +2123,7 @@ describe("moderationEngine", () => {
     expect(snapshot.legacyFlags).toEqual(["flagged.suspicious"]);
   });
 
-  it("does not let uncorroborated VT Code Insight suspicious override clean local scans", () => {
+  it("does not let uncorroborated VT suspicious override clean local scans", () => {
     const snapshot = buildModerationSnapshot({
       staticScan: {
         status: "clean",
@@ -2139,8 +2135,6 @@ describe("moderationEngine", () => {
       },
       vtAnalysis: {
         status: "suspicious",
-        scanner: "code_insight",
-        source: "VirusTotal Code Insight",
         engineStats: {
           malicious: 0,
           suspicious: 0,
@@ -2155,7 +2149,7 @@ describe("moderationEngine", () => {
     expect(snapshot.reasonCodes).toEqual([]);
   });
 
-  it("keeps VT Code Insight plus engine suspicious as telemetry only", () => {
+  it("keeps VT engine suspicious as telemetry only", () => {
     const snapshot = buildModerationSnapshot({
       staticScan: {
         status: "clean",
@@ -2167,8 +2161,6 @@ describe("moderationEngine", () => {
       },
       vtAnalysis: {
         status: "suspicious",
-        scanner: "code_insight",
-        source: "VirusTotal Code Insight",
         engineStats: {
           malicious: 0,
           suspicious: 1,

--- a/convex/lib/packageSecurity.test.ts
+++ b/convex/lib/packageSecurity.test.ts
@@ -40,13 +40,13 @@ describe("packageSecurity", () => {
     ).toBeNull();
   });
 
-  it("keeps AI-only VT suspicious advisory when engines are clean", () => {
+  it("keeps legacy VT suspicious status as telemetry when engines are clean", () => {
     const release = {
       sha256hash: "a".repeat(64),
       vtAnalysis: {
         status: "suspicious",
-        scanner: "code_insight",
-        source: "palm",
+        scanner: "legacy-ai",
+        source: "legacy-ai",
         engineStats: { malicious: 0, suspicious: 0, harmless: 12, undetected: 54 },
       },
     } as never;
@@ -55,13 +55,13 @@ describe("packageSecurity", () => {
     expect(getPackageDownloadSecurityBlock(release)).toBeNull();
   });
 
-  it("keeps AI-only VT malicious advisory when engines are clean", () => {
+  it("keeps legacy VT malicious status as telemetry when engines are clean", () => {
     const release = {
       sha256hash: "a".repeat(64),
       vtAnalysis: {
         status: "malicious",
-        scanner: "code_insight",
-        source: "palm",
+        scanner: "legacy-ai",
+        source: "legacy-ai",
         engineStats: { malicious: 0, suspicious: 0, harmless: 12, undetected: 54 },
       },
     } as never;
@@ -75,8 +75,8 @@ describe("packageSecurity", () => {
       resolvePackageReleaseScanStatus({
         vtAnalysis: {
           status: "clean",
-          scanner: "code_insight",
-          source: "palm",
+          scanner: "legacy-ai",
+          source: "legacy-ai",
           engineStats: { malicious: 0, suspicious: 1, harmless: 12, undetected: 54 },
         },
       } as never),
@@ -87,8 +87,8 @@ describe("packageSecurity", () => {
     const release = {
       vtAnalysis: {
         status: "clean",
-        scanner: "code_insight",
-        source: "palm",
+        scanner: "legacy-ai",
+        source: "legacy-ai",
         engineStats: { malicious: 1, suspicious: 0, harmless: 12, undetected: 54 },
       },
     } as never;
@@ -182,14 +182,14 @@ describe("packageSecurity", () => {
     ).toEqual(["manual:quarantined", "scan:malicious", "reports:2"]);
   });
 
-  it("does not expose AI-only VT advisory statuses as public trust reasons", () => {
+  it("does not expose legacy VT-only statuses as public trust reasons", () => {
     expect(
       getPackageTrustReasons(
         {
           vtAnalysis: {
             status: "malicious",
-            scanner: "code_insight",
-            source: "palm",
+            scanner: "legacy-ai",
+            source: "legacy-ai",
             engineStats: { malicious: 0, suspicious: 0, harmless: 12, undetected: 54 },
           },
         } as never,

--- a/convex/skills.manualOverrides.test.ts
+++ b/convex/skills.manualOverrides.test.ts
@@ -590,7 +590,7 @@ describe("skills manual overrides", () => {
     );
   });
 
-  it("clears legacy suspicious state when LLM corroborates clean VT Code Insight-only suspicious", async () => {
+  it("clears legacy suspicious state when LLM corroborates clean VT telemetry", async () => {
     const now = 1_700_000_400_000;
     vi.spyOn(Date, "now").mockReturnValue(now);
 
@@ -617,7 +617,7 @@ describe("skills manual overrides", () => {
       },
       vtAnalysis: {
         status: "suspicious",
-        scanner: "code_insight",
+        scanner: "legacy-ai",
         engineStats: {
           malicious: 0,
           suspicious: 0,

--- a/convex/skills.rateLimit.test.ts
+++ b/convex/skills.rateLimit.test.ts
@@ -1107,7 +1107,7 @@ describe("skills anti-spam guards", () => {
     );
   });
 
-  it("does not hide or autoban for AI-only VT malicious without engine hits", async () => {
+  it("does not hide or autoban for VT-only malicious without engine hits", async () => {
     const patch = vi.fn(async () => {});
     const runAfter = vi.fn();
     const version = {
@@ -1123,8 +1123,8 @@ describe("skills anti-spam guards", () => {
       },
       vtAnalysis: {
         status: "malicious",
-        scanner: "code_insight",
-        source: "palm",
+        scanner: "legacy-ai",
+        source: "legacy-ai",
         engineStats: { malicious: 0, suspicious: 0, harmless: 12, undetected: 54 },
       },
       llmAnalysis: { status: "clean" },
@@ -2029,7 +2029,7 @@ describe("skills anti-spam guards", () => {
     );
   });
 
-  it("vt suspicious escalation clears legacy quarantine for uncorroborated Code Insight", async () => {
+  it("vt suspicious escalation clears legacy quarantine when local scans are clean", async () => {
     const patch = vi.fn(async () => {});
     const version = {
       _id: "skillVersions:1",
@@ -2044,7 +2044,7 @@ describe("skills anti-spam guards", () => {
       },
       vtAnalysis: {
         status: "suspicious",
-        scanner: "code_insight",
+        scanner: "legacy-ai",
         engineStats: {
           malicious: 0,
           suspicious: 0,
@@ -2115,7 +2115,7 @@ describe("skills anti-spam guards", () => {
     );
   });
 
-  it("vt malicious escalation clears legacy quarantine for AI-only Code Insight", async () => {
+  it("vt malicious escalation clears legacy quarantine when local scans are clean", async () => {
     const patch = vi.fn(async () => {});
     const runAfter = vi.fn();
     const version = {
@@ -2131,8 +2131,8 @@ describe("skills anti-spam guards", () => {
       },
       vtAnalysis: {
         status: "malicious",
-        scanner: "code_insight",
-        source: "palm",
+        scanner: "legacy-ai",
+        source: "legacy-ai",
         engineStats: {
           malicious: 0,
           suspicious: 0,
@@ -2476,8 +2476,8 @@ describe("skills anti-spam guards", () => {
       },
       vtAnalysis: {
         status: "malicious",
-        scanner: "code_insight",
-        source: "palm",
+        scanner: "legacy-ai",
+        source: "legacy-ai",
         engineStats: { malicious: 0, suspicious: 0, harmless: 12, undetected: 54 },
       },
       llmAnalysis: { status: "clean" },

--- a/convex/skills.versions.public.test.ts
+++ b/convex/skills.versions.public.test.ts
@@ -86,7 +86,7 @@ function makeVersion() {
       status: "clean",
       verdict: "clean",
       analysis: "safe",
-      source: "code_insight",
+      source: "legacy-ai",
       checkedAt: 1,
     },
     llmAnalysis: {

--- a/convex/vt.test.ts
+++ b/convex/vt.test.ts
@@ -219,6 +219,54 @@ describe("vt result lookup", () => {
       headers: { "x-apikey": "test-key" },
     });
   });
+
+  it("ignores VirusTotal Code Insight results and reports engine stats only", async () => {
+    process.env.VT_API_KEY = "test-key";
+    const hash = "b".repeat(64);
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          attributes: {
+            crowdsourced_ai_results: [
+              {
+                category: "code_insight",
+                verdict: "malicious",
+                analysis: "AI-only claim that should be ignored.",
+                source: "palm",
+              },
+            ],
+            last_analysis_stats: {
+              malicious: 0,
+              suspicious: 0,
+              harmless: 2,
+              undetected: 20,
+            },
+          },
+        },
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchResultsHandler({} as never, { sha256hash: hash });
+
+    expect(result).toMatchObject({
+      status: "clean",
+      source: "engines",
+      metadata: {
+        stats: {
+          malicious: 0,
+          suspicious: 0,
+          harmless: 2,
+          undetected: 20,
+        },
+      },
+    });
+    expect((result as { metadata?: Record<string, unknown> }).metadata).not.toHaveProperty(
+      "aiVerdict",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("package VT retries", () => {
@@ -856,10 +904,63 @@ describe("package VT retries", () => {
     );
 
     expect(runMutation).not.toHaveBeenCalled();
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(scheduler.runAfter).toHaveBeenCalledWith(5 * 60 * 1000, expect.anything(), {
       releaseId: "packageReleases:demo",
       attempt: 4,
+    });
+  });
+});
+
+describe("vt pending polling", () => {
+  it("does not request VirusTotal reanalysis to trigger Code Insight", async () => {
+    process.env.VT_API_KEY = "test-key";
+    const hash = "c".repeat(64);
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          attributes: {
+            last_analysis_stats: {
+              malicious: 0,
+              suspicious: 0,
+              harmless: 0,
+              undetected: 66,
+            },
+          },
+        },
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce({
+        queueSize: 1,
+        staleCount: 0,
+        veryStaleCount: 0,
+        oldestAgeMinutes: 5,
+        healthy: true,
+      })
+      .mockResolvedValueOnce([
+        {
+          skillId: "skills:pending",
+          versionId: "skillVersions:pending",
+          sha256hash: hash,
+          checkCount: 9,
+        },
+      ]);
+    const runMutation = vi.fn(async () => null);
+
+    const result = await pollPendingScansHandler({ runQuery, runMutation } as never, {
+      batchSize: 1,
+    });
+
+    expect(result).toMatchObject({ processed: 1, updated: 0, staled: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(`https://www.virustotal.com/api/v3/files/${hash}`, {
+      method: "GET",
+      headers: { "x-apikey": "test-key" },
     });
   });
 });

--- a/convex/vt.ts
+++ b/convex/vt.ts
@@ -146,33 +146,10 @@ export const logScanResultInternal = internalMutation({
   },
 });
 
-const BENIGN_VERDICTS = new Set(["benign", "clean"]);
-const MALICIOUS_VERDICTS = new Set(["malicious"]);
-const SUSPICIOUS_VERDICTS = new Set(["suspicious"]);
-
-function normalizeVerdict(value?: string) {
-  return value?.trim().toLowerCase() ?? "";
-}
-
-function verdictToStatus(verdict: string) {
-  if (BENIGN_VERDICTS.has(verdict)) return "clean";
-  if (MALICIOUS_VERDICTS.has(verdict)) return "malicious";
-  if (SUSPICIOUS_VERDICTS.has(verdict)) return "suspicious";
-  return "pending";
-}
-
-type VTAIResult = {
-  category: string;
-  verdict: string;
-  analysis?: string;
-  source?: string;
-};
-
 type VTFileResponse = {
   data: {
     attributes: {
       sha256: string;
-      crowdsourced_ai_results?: VTAIResult[];
       last_analysis_stats?: {
         malicious: number;
         suspicious: number;
@@ -255,23 +232,6 @@ function buildPackageScanAnalysisFromVtResult(
   pkg: PackageScanDoc,
   vtResult: VTFileResponse,
 ) {
-  const aiResult = vtResult.data.attributes.crowdsourced_ai_results?.find(
-    (r) => r.category === "code_insight",
-  );
-  if (aiResult) {
-    const verdict = normalizeVerdict(aiResult.verdict);
-    const stats = vtResult.data.attributes.last_analysis_stats;
-    return {
-      status: verdictToStatus(verdict),
-      verdict: aiResult.verdict,
-      analysis: aiResult.analysis,
-      source: aiResult.source,
-      scanner: "code_insight",
-      engineStats: normalizeVtEngineStats(stats),
-      checkedAt: Date.now(),
-    };
-  }
-
   const stats = vtResult.data.attributes.last_analysis_stats;
   const status = statusFromAvStats(stats);
   if (status) {
@@ -340,13 +300,6 @@ type ActiveSkillsMissingVTCache = {
   slug: string;
 };
 
-type PendingVTSkill = {
-  skillId: Id<"skills">;
-  versionId: Id<"skillVersions">;
-  slug: string;
-  sha256hash: string;
-};
-
 type NullModerationStatusSkill = {
   skillId: Id<"skills">;
   slug: string;
@@ -378,10 +331,6 @@ type ScanLegacySkillsResult =
 
 type BackfillActiveSkillsVTCacheResult =
   | { total: number; updated: number; noResults: number; errors: number; done: boolean }
-  | { error: string };
-
-type RequestReanalysisForPendingResult =
-  | { total: number; requested: number; errors?: number; done: boolean }
   | { error: string };
 
 type FixNullModerationStatusResult = { total: number; fixed: number; done: boolean };
@@ -486,28 +435,14 @@ export const fetchResults = internalAction({
       }
 
       const data = (await response.json()) as VTFileResponse;
-      const aiResult = data.data.attributes.crowdsourced_ai_results?.find(
-        (r) => r.category === "code_insight",
-      );
-
       const stats = data.data.attributes.last_analysis_stats;
-      let status = "pending";
-
-      if (aiResult?.verdict) {
-        // Prioritize AI Analysis (Code Insight)
-        status = verdictToStatus(normalizeVerdict(aiResult.verdict));
-      } else {
-        status = statusFromAvStats(stats) ?? "pending";
-      }
+      const status = statusFromAvStats(stats) ?? "pending";
 
       return {
         status,
-        source: aiResult?.verdict ? "code_insight" : "engines",
+        source: "engines",
         url: `https://www.virustotal.com/gui/file/${args.sha256hash}`,
         metadata: {
-          aiVerdict: aiResult?.verdict,
-          aiAnalysis: aiResult?.analysis,
-          aiSource: aiResult?.source,
           stats: stats,
         },
       };
@@ -579,22 +514,16 @@ export const scanWithVirusTotal = internalAction({
       sha256hash,
     });
 
-    // Check if file already exists in VT and has AI analysis
+    // Check if file already exists in VT and has engine analysis.
     try {
       const existingFile = await checkExistingFile(apiKey, sha256hash);
 
       if (existingFile) {
-        const aiResult = existingFile.data.attributes.crowdsourced_ai_results?.find(
-          (r) => r.category === "code_insight",
-        );
-
-        if (aiResult) {
-          const stats = existingFile.data.attributes.last_analysis_stats;
-          // File exists and has AI analysis - use the verdict
-          const verdict = normalizeVerdict(aiResult.verdict);
-          const status = verdictToStatus(verdict);
+        const stats = existingFile.data.attributes.last_analysis_stats;
+        const status = statusFromAvStats(stats);
+        if (status) {
           console.log(
-            `Version ${args.versionId} found in VT with AI analysis. Hash: ${sha256hash}. Verdict: ${verdict}`,
+            `Version ${args.versionId} found in VT with engine analysis. Hash: ${sha256hash}. Status: ${status}`,
           );
 
           // Cache VT analysis in version
@@ -602,10 +531,7 @@ export const scanWithVirusTotal = internalAction({
             versionId: args.versionId,
             vtAnalysis: {
               status,
-              verdict: aiResult.verdict,
-              analysis: aiResult.analysis,
-              source: aiResult.source,
-              scanner: "code_insight",
+              source: "engines",
               engineStats: normalizeVtEngineStats(stats),
               checkedAt: Date.now(),
             },
@@ -615,9 +541,8 @@ export const scanWithVirusTotal = internalAction({
           return;
         }
 
-        // File exists but no AI analysis - need to upload for fresh scan
         console.log(
-          `Version ${args.versionId} found in VT but no AI analysis. Hash: ${sha256hash}. Uploading...`,
+          `Version ${args.versionId} found in VT but no decisive engine analysis. Hash: ${sha256hash}. Uploading...`,
         );
       } else {
         console.log(`Version ${args.versionId} not found in VT. Hash: ${sha256hash}. Uploading...`);
@@ -893,7 +818,6 @@ export const pollPackageReleaseScanResults = internalAction({
         return;
       }
 
-      await requestRescan(apiKey, release.sha256hash);
       if (attempt < PACKAGE_SCAN_MAX_ATTEMPTS) {
         await runAfterRef(
           ctx,
@@ -1018,84 +942,39 @@ export const pollPendingScans = internalAction({
           continue;
         }
 
-        const aiResult = vtResult.data.attributes.crowdsourced_ai_results?.find(
-          (r) => r.category === "code_insight",
-        );
+        const stats = vtResult.data.attributes.last_analysis_stats;
+        const status = statusFromAvStats(stats);
 
-        if (!aiResult) {
-          // No Code Insight - check AV engine stats as fallback
-          const stats = vtResult.data.attributes.last_analysis_stats;
-          const status = statusFromAvStats(stats);
-          let source = "engines";
-
-          if (status) {
-            // We have a verdict from AV engines - update the skill
-            console.log(
-              `[vt:pollPendingScans] Hash ${sha256hash} verdict from AV engines: ${status}`,
-            );
-
-            // Cache VT analysis in version
-            await ctx.runMutation(internal.skills.updateVersionScanResultsInternal, {
-              versionId,
-              vtAnalysis: {
-                status,
-                source,
-                engineStats: normalizeVtEngineStats(stats),
-                checkedAt: Date.now(),
-              },
-            });
-
-            await enqueueSkillCodexForVtSignal(ctx, versionId);
-            updated++;
-            continue;
-          }
-
-          // No verdict from engines either - trigger a rescan to get Code Insight
+        if (status) {
           console.log(
-            `[vt:pollPendingScans] Hash ${sha256hash} has no Code Insight or engine stats, requesting rescan`,
+            `[vt:pollPendingScans] Hash ${sha256hash} verdict from AV engines: ${status}`,
           );
-          await requestRescan(apiKey, sha256hash);
-          // Check if we've exceeded max attempts — write stale vtAnalysis so it
-          // drops out of the poll query without overwriting LLM moderationReason
-          if (checkCount + 1 >= MAX_CHECK_COUNT) {
-            console.warn(
-              `[vt:pollPendingScans] Skill ${skillId} exceeded max checks, marking stale`,
-            );
-            await ctx.runMutation(internal.skills.updateVersionScanResultsInternal, {
-              versionId,
-              vtAnalysis: { status: "stale", checkedAt: Date.now() },
-            });
-            await enqueueSkillCodexForVtSignal(ctx, versionId);
-            staled++;
-          }
+
+          await ctx.runMutation(internal.skills.updateVersionScanResultsInternal, {
+            versionId,
+            vtAnalysis: {
+              status,
+              source: "engines",
+              engineStats: normalizeVtEngineStats(stats),
+              checkedAt: Date.now(),
+            },
+          });
+
+          await enqueueSkillCodexForVtSignal(ctx, versionId);
+          updated++;
           continue;
         }
 
-        // We have a verdict - update the skill
-        const verdict = normalizeVerdict(aiResult.verdict);
-        const status = verdictToStatus(verdict);
-        const stats = vtResult.data.attributes.last_analysis_stats;
-
-        console.log(
-          `[vt:pollPendingScans] Hash ${sha256hash} verdict: ${verdict} -> status: ${status}`,
-        );
-
-        // Cache VT analysis in version
-        await ctx.runMutation(internal.skills.updateVersionScanResultsInternal, {
-          versionId,
-          vtAnalysis: {
-            status,
-            verdict: aiResult.verdict,
-            analysis: aiResult.analysis,
-            source: aiResult.source,
-            scanner: "code_insight",
-            engineStats: normalizeVtEngineStats(stats),
-            checkedAt: Date.now(),
-          },
-        });
-
-        await enqueueSkillCodexForVtSignal(ctx, versionId);
-        updated++;
+        if (checkCount + 1 >= MAX_CHECK_COUNT) {
+          console.log(`[vt:pollPendingScans] Hash ${sha256hash} has no decisive engine stats`);
+          console.warn(`[vt:pollPendingScans] Skill ${skillId} exceeded max checks, marking stale`);
+          await ctx.runMutation(internal.skills.updateVersionScanResultsInternal, {
+            versionId,
+            vtAnalysis: { status: "stale", checkedAt: Date.now() },
+          });
+          await enqueueSkillCodexForVtSignal(ctx, versionId);
+          staled++;
+        }
       } catch (error) {
         console.error(`[vt:pollPendingScans] Error checking hash ${sha256hash}:`, error);
       }
@@ -1141,30 +1020,6 @@ async function checkExistingFile(
   return (await response.json()) as VTFileResponse;
 }
 
-/**
- * Request a rescan of a file to trigger Code Insight analysis
- */
-async function requestRescan(apiKey: string, sha256hash: string): Promise<boolean> {
-  try {
-    const response = await fetch(`https://www.virustotal.com/api/v3/files/${sha256hash}/analyse`, {
-      method: "POST",
-      headers: {
-        "x-apikey": apiKey,
-      },
-    });
-
-    if (!response.ok) {
-      console.error(`[vt:requestRescan] Failed for ${sha256hash}: ${response.status}`);
-      return false;
-    }
-
-    return true;
-  } catch (error) {
-    console.error(`[vt:requestRescan] Error for ${sha256hash}:`, error);
-    return false;
-  }
-}
-
 export const __test = {
   VIRUSTOTAL_DIRECT_UPLOAD_LIMIT_BYTES,
   normalizeVtEngineStats,
@@ -1181,14 +1036,12 @@ export const backfillPendingScans = internalAction({
   args: {
     triggerRescans: v.optional(v.boolean()),
   },
-  handler: async (ctx, args): Promise<BackfillPendingScansResult> => {
+  handler: async (ctx): Promise<BackfillPendingScansResult> => {
     const apiKey = process.env.VT_API_KEY;
     if (!apiKey) {
       console.log("[vt:backfill] VT_API_KEY not configured");
       return { error: "VT_API_KEY not configured" };
     }
-
-    const triggerRescans = args.triggerRescans ?? true;
 
     // Get ALL pending skills (no limit)
     const pendingSkills: PendingScanSkill[] = await ctx.runQuery(
@@ -1222,56 +1075,19 @@ export const backfillPendingScans = internalAction({
           continue;
         }
 
-        const aiResult = vtResult.data.attributes.crowdsourced_ai_results?.find(
-          (r) => r.category === "code_insight",
-        );
+        const stats = vtResult.data.attributes.last_analysis_stats;
+        const status = statusFromAvStats(stats);
 
-        if (!aiResult) {
-          // No Code Insight - check AV engine stats as fallback
-          const stats = vtResult.data.attributes.last_analysis_stats;
-          const status = statusFromAvStats(stats);
-
-          if (status) {
-            // We have a verdict from AV engines - update the skill
-            console.log(`[vt:backfill] Hash ${sha256hash} verdict from AV engines: ${status}`);
-            await ctx.runMutation(internal.skills.updateVersionScanResultsInternal, {
-              versionId,
-              vtAnalysis: {
-                status,
-                source: "engines",
-                engineStats: normalizeVtEngineStats(stats),
-                checkedAt: Date.now(),
-              },
-            });
-            await enqueueSkillCodexForVtSignal(ctx, versionId);
-            updated++;
-            continue;
-          }
-
-          // No verdict from engines either - trigger a rescan
-          if (triggerRescans) {
-            console.log(
-              `[vt:backfill] Hash ${sha256hash} has no Code Insight or engine stats, requesting rescan`,
-            );
-            await requestRescan(apiKey, sha256hash);
-            rescansRequested++;
-          }
+        if (!status) {
           continue;
         }
 
-        // We have a verdict - update the skill
-        const verdict = normalizeVerdict(aiResult.verdict);
-        const status = verdictToStatus(verdict);
-        const stats = vtResult.data.attributes.last_analysis_stats;
-
+        console.log(`[vt:backfill] Hash ${sha256hash} verdict from AV engines: ${status}`);
         await ctx.runMutation(internal.skills.updateVersionScanResultsInternal, {
           versionId,
           vtAnalysis: {
             status,
-            verdict: aiResult.verdict,
-            analysis: aiResult.analysis,
-            source: aiResult.source,
-            scanner: "code_insight",
+            source: "engines",
             engineStats: normalizeVtEngineStats(stats),
             checkedAt: Date.now(),
           },
@@ -1355,69 +1171,28 @@ export const rescanActiveSkills = internalAction({
           continue;
         }
 
-        const aiResult = vtResult.data.attributes.crowdsourced_ai_results?.find(
-          (r) => r.category === "code_insight",
-        );
+        const stats = vtResult.data.attributes.last_analysis_stats;
+        const status = statusFromAvStats(stats);
 
-        if (!aiResult) {
-          // No Code Insight - check AV engine stats as fallback
-          const stats = vtResult.data.attributes.last_analysis_stats;
-          const status = statusFromAvStats(stats);
-          let source = "engines";
-
-          if (!status) {
-            // No verdict from engines either - keep as pending
-            await ctx.runMutation(internal.skills.updateVersionScanResultsInternal, {
-              versionId,
-              vtAnalysis: {
-                status: "pending",
-                checkedAt: Date.now(),
-              },
-            });
-            accUnchanged++;
-            continue;
-          }
-
-          // We have a verdict from AV engines - continue with normal flow
-          console.log(`[vt:rescan] ${slug} verdict from AV engines: ${status}`);
-
+        if (!status) {
           await ctx.runMutation(internal.skills.updateVersionScanResultsInternal, {
             versionId,
             vtAnalysis: {
-              status,
-              source,
-              engineStats: normalizeVtEngineStats(stats),
+              status: "pending",
               checkedAt: Date.now(),
             },
           });
-
-          if (status === "malicious" || status === "suspicious") {
-            console.warn(`[vt:rescan] ${slug}: verdict changed to ${status}!`);
-            accFlaggedSkills.push({ slug, status });
-            await enqueueSkillCodexForVtSignal(ctx, versionId);
-            accUpdated++;
-          } else if (wasFlagged && status === "clean") {
-            console.log(`[vt:rescan] ${slug}: VT verdict improved to clean`);
-            await enqueueSkillCodexForVtSignal(ctx, versionId);
-            accUpdated++;
-          } else {
-            accUnchanged++;
-          }
+          accUnchanged++;
           continue;
         }
 
-        const verdict = normalizeVerdict(aiResult.verdict);
-        const status = verdictToStatus(verdict);
-        const stats = vtResult.data.attributes.last_analysis_stats;
+        console.log(`[vt:rescan] ${slug} verdict from AV engines: ${status}`);
 
         await ctx.runMutation(internal.skills.updateVersionScanResultsInternal, {
           versionId,
           vtAnalysis: {
             status,
-            verdict: aiResult.verdict,
-            analysis: aiResult.analysis,
-            source: aiResult.source,
-            scanner: "code_insight",
+            source: "engines",
             engineStats: normalizeVtEngineStats(stats),
             checkedAt: Date.now(),
           },
@@ -1666,53 +1441,23 @@ export const backfillActiveSkillsVTCache = internalAction({
           continue;
         }
 
-        const aiResult = vtResult.data.attributes.crowdsourced_ai_results?.find(
-          (r) => r.category === "code_insight",
-        );
+        const stats = vtResult.data.attributes.last_analysis_stats;
+        const status = statusFromAvStats(stats);
 
-        if (!aiResult) {
-          // No Code Insight - check AV engine stats as fallback
-          const stats = vtResult.data.attributes.last_analysis_stats;
-          const status = statusFromAvStats(stats);
-          let source = "engines";
-
-          if (!status) {
-            console.log(`[vt:backfillActive] ${slug}: no Code Insight or engine stats yet`);
-            noResults++;
-            continue;
-          }
-
-          // We have a verdict from AV engines - update the version
-          console.log(`[vt:backfillActive] ${slug}: updated with ${status} (from AV engines)`);
-
-          await ctx.runMutation(internal.skills.updateVersionScanResultsInternal, {
-            versionId,
-            sha256hash,
-            vtAnalysis: {
-              status,
-              source,
-              checkedAt: Date.now(),
-            },
-          });
-          await enqueueSkillCodexForVtSignal(ctx, versionId);
-          updated++;
+        if (!status) {
+          console.log(`[vt:backfillActive] ${slug}: no decisive engine stats yet`);
+          noResults++;
           continue;
         }
 
-        // Update the version with VT analysis
-        const verdict = normalizeVerdict(aiResult.verdict);
-        const status = verdictToStatus(verdict);
-        const stats = vtResult.data.attributes.last_analysis_stats;
+        console.log(`[vt:backfillActive] ${slug}: updated with ${status} (from AV engines)`);
 
         await ctx.runMutation(internal.skills.updateVersionScanResultsInternal, {
           versionId,
           sha256hash,
           vtAnalysis: {
             status,
-            verdict: aiResult.verdict,
-            analysis: aiResult.analysis,
-            source: aiResult.source,
-            scanner: "code_insight",
+            source: "engines",
             engineStats: normalizeVtEngineStats(stats),
             checkedAt: Date.now(),
           },
@@ -1743,63 +1488,6 @@ export const backfillActiveSkillsVTCache = internalAction({
       await ctx.scheduler.runAfter(0, internal.vt.backfillActiveSkillsVTCache, { batchSize });
     }
 
-    return result;
-  },
-});
-
-/**
- * Request VT reanalysis for skills stuck at scanner.vt.pending.
- * This pushes them to the front of VT's Code Insight queue.
- */
-export const requestReanalysisForPending = internalAction({
-  args: { batchSize: v.optional(v.number()) },
-  handler: async (ctx, args): Promise<RequestReanalysisForPendingResult> => {
-    const apiKey = process.env.VT_API_KEY;
-    if (!apiKey) {
-      console.log("[vt:requestReanalysis] VT_API_KEY not configured");
-      return { error: "VT_API_KEY not configured" };
-    }
-
-    const batchSize = args.batchSize ?? 100;
-
-    // Get skills with scanner.vt.pending moderationReason
-    const skills: PendingVTSkill[] = await ctx.runQuery(
-      internal.skills.getPendingVTSkillsInternal,
-      { limit: batchSize },
-    );
-
-    if (skills.length === 0) {
-      console.log("[vt:requestReanalysis] No pending skills found");
-      return { total: 0, requested: 0, done: true };
-    }
-
-    console.log(`[vt:requestReanalysis] Found ${skills.length} skills to request reanalysis`);
-
-    let requested = 0;
-    let errors = 0;
-
-    for (const { slug, sha256hash } of skills) {
-      try {
-        const success = await requestRescan(apiKey, sha256hash);
-        if (success) {
-          console.log(`[vt:requestReanalysis] ${slug}: rescan requested`);
-          requested++;
-        } else {
-          errors++;
-        }
-      } catch (error) {
-        console.error(`[vt:requestReanalysis] ${slug}: error`, error);
-        errors++;
-      }
-    }
-
-    const result: RequestReanalysisForPendingResult = {
-      total: skills.length,
-      requested,
-      errors,
-      done: skills.length < batchSize,
-    };
-    console.log("[vt:requestReanalysis] Complete:", result);
     return result;
   },
 });

--- a/packages/clawhub/src/cli/commands/skills.ts
+++ b/packages/clawhub/src/cli/commands/skills.ts
@@ -172,7 +172,7 @@ export async function cmdInstall(
     if (skillMeta.moderation?.isSuspicious && !force) {
       spinner.stop();
       console.log(
-        `\n⚠️  Warning: "${trimmed}" is flagged as suspicious by VirusTotal Code Insight.\n` +
+        `\n⚠️  Warning: "${trimmed}" is flagged for ClawHub security review.\n` +
           "   This skill may contain risky patterns (crypto keys, external APIs, eval, etc.)\n" +
           "   Review the skill code before use.\n",
       );
@@ -295,7 +295,7 @@ export async function cmdUpdate(
       if (skillMeta.moderation?.isSuspicious && !options.force) {
         spinner.stop();
         console.log(
-          `\n⚠️  Warning: "${entry}" is flagged as suspicious by VirusTotal Code Insight.\n` +
+          `\n⚠️  Warning: "${entry}" is flagged for ClawHub security review.\n` +
             "   This skill may contain risky patterns (crypto keys, external APIs, eval, etc.)\n",
         );
         if (allowPrompt) {

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -132,8 +132,8 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   scans the exact uploaded `.tgz`; ClawHub does not currently run deep static/LLM scans across every
   tarball file.
 - Source-linked packages can fall back to a clean package verdict when VirusTotal only returns
-  undetected engine results, provided the LLM scan is clean and static scan is non-malicious. This
-  avoids indefinite pending scans when VT Code Insight never materializes.
+  undetected engine results, provided the LLM scan is clean and static scan is non-malicious. ClawHub
+  does not request or consume VirusTotal AI/code-insight results; VT is engine/vendor telemetry only.
 - Skill moderation state stores a structured snapshot:
   - `moderationVerdict`: `clean | suspicious | malicious`
   - `moderationReasonCodes[]`: canonical machine-readable reasons

--- a/src/components/DetailSecuritySummary.test.tsx
+++ b/src/components/DetailSecuritySummary.test.tsx
@@ -164,15 +164,16 @@ describe("DetailSecuritySummary", () => {
     expect(screen.queryByText("Benign")).toBeNull();
   });
 
-  it("renders VirusTotal AI-only advisory scans as pass", () => {
+  it("renders legacy VirusTotal AI fields from engine stats instead of source", () => {
     render(
       <DetailSecuritySummary
         scannerBasePath="/tokauthai/skillscan/security"
         vtAnalysis={{
           status: "suspicious",
-          source: "VirusTotal Code Insight",
-          scanner: "code_insight",
-          analysis: "AI-only advisory context.",
+          source: "legacy-ai",
+          scanner: "legacy-ai",
+          analysis: "Legacy AI advisory context.",
+          engineStats: { malicious: 0, suspicious: 0, harmless: 12, undetected: 54 },
           checkedAt: 1,
         }}
         llmAnalysis={{ status: "clean", checkedAt: 1 }}
@@ -189,6 +190,33 @@ describe("DetailSecuritySummary", () => {
 
     expect(screen.getByRole("link", { name: "VirusTotal: Pass" })).toBeTruthy();
     expect(screen.queryByText("Advisory")).toBeNull();
+  });
+
+  it("renders legacy VirusTotal AI fields without engine stats as neutral", () => {
+    render(
+      <DetailSecuritySummary
+        scannerBasePath="/tokauthai/skillscan/security"
+        vtAnalysis={{
+          status: "suspicious",
+          source: "legacy-ai",
+          scanner: "legacy-ai",
+          analysis: "Legacy AI advisory context.",
+          checkedAt: 1,
+        }}
+        llmAnalysis={{ status: "clean", checkedAt: 1 }}
+        staticScan={{
+          status: "clean",
+          reasonCodes: [],
+          findings: [],
+          summary: "Clean.",
+          engineVersion: "v1",
+          checkedAt: 1,
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "VirusTotal: Pass" })).toBeTruthy();
+    expect(screen.queryByText("Warn")).toBeNull();
   });
 
   it("shows static suspicious as review without rolling it up to suspicious", () => {

--- a/src/components/SecurityScannerPage.tsx
+++ b/src/components/SecurityScannerPage.tsx
@@ -10,7 +10,6 @@ import {
   getVisibleClawScanFindingCount,
   getVirusTotalDisplayStatus,
   hasClawScanRiskReview,
-  isVirusTotalAiOnlyAnalysis,
   RiskLevelBadge,
   ScanResultBadge,
   type LlmAnalysis,
@@ -159,26 +158,68 @@ function SecurityScannerHero({ label, props }: { label: string; props: SecurityS
 function getVisibleFindingCount(props: SecurityScannerPageProps) {
   if (props.scanner === "static-analysis") return props.staticScan?.findings?.length ?? 0;
   if (props.scanner === "clawscan") return getVisibleClawScanFindingCount(props.llmAnalysis);
-  if (props.scanner === "virustotal" && getVirusTotalAdvisoryText(props.vtAnalysis)) return 1;
   return 0;
 }
 
-function getVirusTotalAdvisoryText(analysis?: VtAnalysis | null) {
-  if (!isVirusTotalAiOnlyAnalysis(analysis)) return null;
-  const text = analysis?.analysis?.trim();
-  if (!text) return null;
-  return text.replace(/^Type:\s*.+?\s+Name:\s*.+?\s+Version:\s*\S+\s+/i, "").trim();
+function getVirusTotalEngineStats(analysis?: VtAnalysis | null) {
+  return analysis?.engineStats ?? analysis?.metadata?.stats ?? null;
+}
+
+function hasEngineVirusTotalSource(analysis?: VtAnalysis | null) {
+  const source = analysis?.source?.trim().toLowerCase();
+  const scanner = analysis?.scanner?.trim().toLowerCase();
+  return Boolean(source?.startsWith("engines") || scanner?.startsWith("engines"));
+}
+
+function hasNonEngineVirusTotalSource(analysis?: VtAnalysis | null) {
+  if (!analysis) return false;
+  const source = analysis.source?.trim().toLowerCase();
+  const scanner = analysis.scanner?.trim().toLowerCase();
+  return Boolean(
+    (source && !source.startsWith("engines")) || (scanner && !scanner.startsWith("engines")),
+  );
+}
+
+function getVirusTotalEngineOverview(analysis?: VtAnalysis | null) {
+  const stats = getVirusTotalEngineStats(analysis);
+  if (stats) {
+    const malicious = stats.malicious ?? 0;
+    const suspicious = stats.suspicious ?? 0;
+    if (malicious > 0 || suspicious > 0) {
+      return `VirusTotal vendor engines reported ${malicious} malicious and ${suspicious} suspicious detection(s) for this artifact. ClawHub treats this as telemetry for ClawScan, not as a standalone blocking verdict.`;
+    }
+    return "VirusTotal vendor engines reported no malicious or suspicious detections for this artifact.";
+  }
+
+  if (hasNonEngineVirusTotalSource(analysis)) {
+    return "No VirusTotal vendor-engine telemetry has been recorded for this artifact.";
+  }
+
+  const status = analysis?.status?.trim().toLowerCase();
+  if (status && !["loading", "not_found", "pending"].includes(status)) {
+    return `VirusTotal engine telemetry is currently ${status} for this artifact.`;
+  }
+
+  return null;
+}
+
+function getVirusTotalAnalysisText(analysis?: VtAnalysis | null) {
+  if (!analysis?.analysis || !hasEngineVirusTotalSource(analysis)) return null;
+  return analysis.analysis;
+}
+
+function getVirusTotalSourceLabel(analysis?: VtAnalysis | null) {
+  if (getVirusTotalEngineStats(analysis) || hasEngineVirusTotalSource(analysis)) {
+    return analysis?.source ?? "Engine telemetry";
+  }
+  return "File reputation";
 }
 
 function getOverviewCopy(props: SecurityScannerPageProps) {
   if (props.scanner === "virustotal") {
-    if (isVirusTotalAiOnlyAnalysis(props.vtAnalysis)) {
-      return [
-        "VirusTotal did not report multi-engine malware detections for this artifact. AI-only context from VirusTotal is treated as advisory and does not require user action.",
-      ];
-    }
     return [
-      props.vtAnalysis?.analysis ??
+      getVirusTotalAnalysisText(props.vtAnalysis) ??
+        getVirusTotalEngineOverview(props.vtAnalysis) ??
         "No VirusTotal analysis has been recorded yet. File reputation checks will appear here once the artifact hash has been scanned.",
     ];
   }
@@ -252,10 +293,8 @@ function SecurityScannerReport(props: SecurityScannerPageProps) {
       ? props.llmAnalysis
       : null;
   const riskLevel = props.scanner === "clawscan" ? getClawScanRiskLevel(props.llmAnalysis) : null;
-  const vtAdvisoryText = getVirusTotalAdvisoryText(props.vtAnalysis);
   const visibleFindingCount = getVisibleFindingCount(props);
   const overviewCopy = getOverviewCopy(props).filter(Boolean);
-  const showOverview = !(props.scanner === "virustotal" && vtAdvisoryText);
   const showPublisherNotePrompt =
     props.scanner === "clawscan" &&
     props.canManageArtifact &&
@@ -273,7 +312,7 @@ function SecurityScannerReport(props: SecurityScannerPageProps) {
 
         <div className="security-report-layout">
           <div className="security-report-main">
-            {showOverview ? (
+            {overviewCopy.length > 0 ? (
               <section className="security-report-panel" aria-labelledby="overview-heading">
                 <div className="security-report-panel-header">
                   <h2 id="overview-heading" className="skill-install-panel-title">
@@ -307,21 +346,6 @@ function SecurityScannerReport(props: SecurityScannerPageProps) {
                     />
                   ) : null}
                   <ClawScanRiskReview analysis={riskAnalysis} showTitle={false} />
-                </div>
-              </section>
-            ) : null}
-
-            {props.scanner === "virustotal" && vtAdvisoryText ? (
-              <section className="security-report-panel" aria-labelledby="vt-advisory-heading">
-                <div className="security-report-panel-header">
-                  <h2 id="vt-advisory-heading" className="skill-install-panel-title">
-                    Findings ({visibleFindingCount})
-                  </h2>
-                </div>
-                <div className="security-report-panel-body">
-                  <div className="vt-advisory-finding">
-                    <p>{vtAdvisoryText}</p>
-                  </div>
                 </div>
               </section>
             ) : null}
@@ -435,7 +459,7 @@ function SecurityScannerReport(props: SecurityScannerPageProps) {
                       },
                       {
                         label: "Source",
-                        value: props.vtAnalysis?.source ?? "File reputation",
+                        value: getVirusTotalSourceLabel(props.vtAnalysis),
                       },
                       {
                         label: "External report",

--- a/src/components/SkillSecurityScanResults.test.tsx
+++ b/src/components/SkillSecurityScanResults.test.tsx
@@ -518,8 +518,8 @@ describe("SecurityScanResults static guidance", () => {
         vtAnalysis={{
           status: "clean",
           verdict: "benign",
-          analysis: "No known malicious reputation signals were found.",
-          source: "VirusTotal",
+          source: "engines",
+          engineStats: { malicious: 0, suspicious: 0, harmless: 4, undetected: 58 },
           checkedAt: Date.now(),
         }}
         llmAnalysis={clawScanAnalysis}
@@ -529,7 +529,7 @@ describe("SecurityScanResults static guidance", () => {
     expect(screen.getByRole("heading", { name: "Hash Guard" })).toBeTruthy();
     expect(screen.getByText(/Audited by VirusTotal/i)).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
-    expect(screen.getByText("No known malicious reputation signals were found.")).toBeTruthy();
+    expect(screen.getByText(/VirusTotal vendor engines reported no malicious/i)).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Scan Metadata" })).toBeTruthy();
     expect(screen.getByText("abc123")).toBeTruthy();
     expect(screen.queryByRole("heading", { name: /Findings/i })).toBeNull();
@@ -538,7 +538,34 @@ describe("SecurityScanResults static guidance", () => {
     expect(screen.queryByText("Artifact")).toBeNull();
   });
 
-  it("shows neutral VirusTotal summary and advisory paragraph for AI-only context", () => {
+  it("summarizes completed engine-only VirusTotal scans", () => {
+    render(
+      <SecurityScannerPage
+        scanner="virustotal"
+        entity={{
+          kind: "skill",
+          title: "Hash Guard",
+          name: "hash-guard",
+          version: "1.2.3",
+          detailPath: "/local/hash-guard",
+        }}
+        sha256hash="abc123"
+        vtAnalysis={{
+          status: "clean",
+          source: "engines",
+          engineStats: { malicious: 0, suspicious: 0, harmless: 2, undetected: 60 },
+          checkedAt: Date.now(),
+        }}
+        llmAnalysis={clawScanAnalysis}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
+    expect(screen.getByText(/VirusTotal vendor engines reported no malicious/i)).toBeTruthy();
+    expect(screen.queryByText(/No VirusTotal analysis has been recorded/i)).toBeNull();
+  });
+
+  it("treats legacy non-engine VirusTotal text as neutral and hidden", () => {
     render(
       <SecurityScannerPage
         scanner="virustotal"
@@ -553,7 +580,7 @@ describe("SecurityScanResults static guidance", () => {
         vtAnalysis={{
           status: "suspicious",
           analysis: "Type: OpenClaw Skill Name: skillscan Version: 1.1.6 raw AI context",
-          source: "palm",
+          source: "legacy-ai",
           checkedAt: Date.now(),
         }}
         llmAnalysis={clawScanAnalysis}
@@ -561,12 +588,12 @@ describe("SecurityScanResults static guidance", () => {
     );
 
     expect(screen.getByText(/Audited by VirusTotal/i)).toBeTruthy();
-    expect(screen.queryByRole("heading", { name: "Overview" })).toBeNull();
+    expect(screen.getByText("Pass")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
     expect(screen.queryByText(/multi-engine malware detections/i)).toBeNull();
-    expect(screen.getByRole("heading", { name: "Findings (1)" })).toBeTruthy();
-    expect(screen.queryByText("Advisory")).toBeNull();
-    expect(screen.getByText(/raw AI context/i)).toBeTruthy();
-    expect(screen.queryByText(/Type: OpenClaw Skill Name/i)).toBeNull();
+    expect(screen.queryByRole("heading", { name: /Findings/ })).toBeNull();
+    expect(screen.queryByText(/raw AI context/i)).toBeNull();
+    expect(screen.getByText(/No VirusTotal vendor-engine telemetry/i)).toBeTruthy();
   });
 
   it("shows static analysis reports in the shared scanner report shell", () => {

--- a/src/components/SkillSecurityScanResults.tsx
+++ b/src/components/SkillSecurityScanResults.tsx
@@ -235,10 +235,13 @@ function getVtEngineStats(analysis?: VtAnalysis | null) {
   return analysis?.engineStats ?? analysis?.metadata?.stats;
 }
 
-export function isVirusTotalAiOnlyAnalysis(analysis?: VtAnalysis | null) {
-  const scanner = analysis?.scanner?.trim().toLowerCase();
-  const source = analysis?.source?.trim().toLowerCase();
-  return scanner === "code_insight" || source === "palm" || source?.includes("code insight");
+function hasNonEngineVirusTotalSource(analysis?: VtAnalysis | null) {
+  if (!analysis) return false;
+  const source = analysis.source?.trim().toLowerCase();
+  const scanner = analysis.scanner?.trim().toLowerCase();
+  return Boolean(
+    (source && !source.startsWith("engines")) || (scanner && !scanner.startsWith("engines")),
+  );
 }
 
 export function getVirusTotalDisplayStatus(analysis?: VtAnalysis | null) {
@@ -249,7 +252,8 @@ export function getVirusTotalDisplayStatus(analysis?: VtAnalysis | null) {
     return "benign";
   }
 
-  if (isVirusTotalAiOnlyAnalysis(analysis)) return "benign";
+  if (hasNonEngineVirusTotalSource(analysis)) return "benign";
+
   return analysis?.verdict ?? analysis?.status ?? "pending";
 }
 
@@ -682,9 +686,6 @@ export function SecurityScanResults({
 
   const vtStatus = getVirusTotalDisplayStatus(vtAnalysis);
   const vtUrl = sha256hash ? `https://www.virustotal.com/gui/file/${sha256hash}` : null;
-  const isCodeInsight = vtAnalysis?.source === "code_insight";
-  const aiAnalysis = vtAnalysis?.analysis;
-
   const llmVerdict = llmAnalysis?.verdict ?? llmAnalysis?.status;
   const llmDisplayStatus = getClawScanDisplayStatus(llmAnalysis);
   const llmStatusInfo = llmVerdict ? getScanStatusInfo(llmDisplayStatus) : null;
@@ -780,12 +781,6 @@ export function SecurityScanResults({
                 Details →
               </a>
             ) : null}
-          </div>
-        ) : null}
-        {isCodeInsight && aiAnalysis && (vtStatus === "malicious" || vtStatus === "suspicious") ? (
-          <div className={`code-insight-analysis ${vtStatus}`}>
-            <div className="code-insight-label">Code Insight</div>
-            <p className="code-insight-text">{aiAnalysis}</p>
           </div>
         ) : null}
         {llmStatusInfo && llmAnalysis ? (

--- a/src/styles.css
+++ b/src/styles.css
@@ -7640,55 +7640,6 @@ code {
   text-decoration: underline;
 }
 
-/* Code Insight Analysis */
-.code-insight-analysis {
-  margin-top: 12px;
-  padding: 10px 12px;
-  border-radius: 8px;
-}
-
-.code-insight-analysis.malicious {
-  background: rgba(239, 68, 68, 0.06);
-  border-left: 3px solid #dc2626;
-}
-
-.code-insight-analysis.suspicious {
-  background: rgba(245, 158, 11, 0.06);
-  border-left: 3px solid #f59e0b;
-}
-
-.code-insight-label {
-  font-size: 0.7rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  margin-bottom: 6px;
-}
-
-.code-insight-analysis.malicious .code-insight-label {
-  color: #dc2626;
-}
-
-.code-insight-analysis.suspicious .code-insight-label {
-  color: #f59e0b;
-}
-
-.code-insight-text {
-  font-size: 0.82rem;
-  line-height: 1.5;
-  color: var(--ink);
-  margin: 0;
-}
-
-.code-insight-text code {
-  font-family: var(--font-mono);
-  font-size: 0.78rem;
-  background: rgba(0, 0, 0, 0.06);
-  padding: 2px 5px;
-  border-radius: 4px;
-  word-break: break-all;
-}
-
 .version-scan-results {
   display: flex;
   gap: 8px;


### PR DESCRIPTION
## Summary
- stop requesting or consuming VirusTotal Code Insight/PALM results
- keep VirusTotal handling limited to vendor engine telemetry and engine stats
- hide legacy AI-only VT text/status in the UI and update CLI/spec copy away from Code Insight

## Tests
- `bun run test convex/vt.test.ts src/components/SkillSecurityScanResults.test.tsx src/components/DetailSecuritySummary.test.tsx convex/lib/packageSecurity.test.ts convex/lib/moderationEngine.test.ts`
- `bun run test convex/skills.manualOverrides.test.ts convex/skills.rateLimit.test.ts convex/skills.versions.public.test.ts convex/httpApiV1.handlers.test.ts`
- `bun run format:check -- convex/vt.ts convex/vt.test.ts src/components/SecurityScannerPage.tsx src/components/SkillSecurityScanResults.tsx src/components/SkillSecurityScanResults.test.tsx src/components/DetailSecuritySummary.test.tsx src/styles.css packages/clawhub/src/cli/commands/skills.ts specs/security-moderation.md convex/lib/packageSecurity.test.ts convex/lib/moderationEngine.test.ts convex/skills.manualOverrides.test.ts convex/skills.rateLimit.test.ts convex/skills.versions.public.test.ts convex/httpApiV1.handlers.test.ts`
- `bun run ci:static`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local`
