### PR TITLE
Drain redundant VT scan queue backlog

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1026,6 +1026,7 @@ const securityScanJobs = defineTable({
   updatedAt: v.number(),
 })
   .index("by_status_and_next_run_at", ["status", "nextRunAt"])
+  .index("by_status_source_target_kind_created_at", ["status", "source", "targetKind", "createdAt"])
   .index("by_status_and_lease_expires_at", ["status", "leaseExpiresAt"])
   .index("by_status_malicious_signal_next_run_at", ["status", "hasMaliciousSignal", "nextRunAt"])
   .index("by_skill_version", ["skillVersionId"])

--- a/convex/securityScan.test.ts
+++ b/convex/securityScan.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { claimCodexScanJobs } from "./securityScan";
+import { claimCodexScanJobs, pruneRedundantQueuedVtScanJobsInternal } from "./securityScan";
 
 type WrappedHandler<TArgs, TResult = unknown> = {
   _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
@@ -10,6 +10,48 @@ const claimCodexScanJobsHandler = (
     { token: string; workerId: string; limit?: number },
     Array<unknown>
   >
+)._handler;
+
+type PruneArgs = {
+  dryRun: boolean;
+  scanLimit?: number;
+  deleteLimit?: number;
+};
+
+type PruneResult = {
+  dryRun: boolean;
+  scanned: number;
+  eligible: number;
+  deleted: number;
+  wouldDelete: number;
+  skippedByReason: Record<string, number>;
+  oldestScannedCreatedAt: number | null;
+  newestScannedCreatedAt: number | null;
+  oldestScannedNextRunAt: number | null;
+  newestScannedNextRunAt: number | null;
+  sampleEligibleJobIds: string[];
+  sampleDeletedJobIds: string[];
+};
+
+type PruneJob = {
+  _id: string;
+  _creationTime: number;
+  status: string;
+  targetKind: string;
+  skillVersionId?: string;
+  packageReleaseId?: string;
+  source: string;
+  priority: number;
+  hasMaliciousSignal: boolean;
+  waitForVtUntil: number;
+  nextRunAt: number;
+  attempts: number;
+  createdAt: number;
+  updatedAt: number;
+};
+
+const pruneRedundantQueuedVtScanJobsInternalHandler = (
+  pruneRedundantQueuedVtScanJobsInternal as unknown as WrappedHandler<PruneArgs, PruneResult>
 )._handler;
 
 const claimedJob = {
@@ -26,6 +68,97 @@ const claimedJob = {
   attempts: 1,
   leaseToken: "lease-token",
 };
+
+function makeScanJob(overrides: Partial<PruneJob> = {}): PruneJob {
+  const suffix = (overrides._id ?? "eligible").split(":").at(-1) ?? "eligible";
+  return {
+    _id: `securityScanJobs:${suffix}`,
+    _creationTime: 1,
+    status: "queued",
+    targetKind: "skillVersion",
+    skillVersionId: `skillVersions:${suffix}`,
+    source: "vt-update",
+    priority: 0,
+    hasMaliciousSignal: false,
+    waitForVtUntil: 0,
+    nextRunAt: 100,
+    attempts: 0,
+    createdAt: 50,
+    updatedAt: 50,
+    ...overrides,
+  };
+}
+
+function makeVersion(
+  llmStatus?: string,
+  vtStatus?: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    ...(llmStatus
+      ? {
+          llmAnalysis: {
+            status: llmStatus,
+            checkedAt: 123,
+          },
+        }
+      : {}),
+    ...(vtStatus
+      ? {
+          vtAnalysis: {
+            status: vtStatus,
+            checkedAt: 456,
+          },
+        }
+      : {}),
+    ...overrides,
+  };
+}
+
+function makePruneCtx(jobs: PruneJob[], versions: Map<string, unknown>) {
+  const deleted: string[] = [];
+  const deleteDoc = vi.fn(async (id: string) => {
+    deleted.push(id);
+  });
+  const get = vi.fn(async (id: string) => versions.get(id) ?? null);
+  const noopWrite = vi.fn(async () => undefined);
+  const take = vi.fn(async (limit: number) => jobs.slice(0, limit));
+  const order = vi.fn(() => ({ take }));
+  const indexBuilder: { eq: ReturnType<typeof vi.fn> } = {
+    eq: vi.fn(() => indexBuilder),
+  };
+  const withIndex = vi.fn((indexName: string, buildRange: (q: typeof indexBuilder) => unknown) => {
+    expect(indexName).toBe("by_status_source_target_kind_created_at");
+    buildRange(indexBuilder);
+    expect(indexBuilder.eq).toHaveBeenCalledWith("status", "queued");
+    expect(indexBuilder.eq).toHaveBeenCalledWith("source", "vt-update");
+    expect(indexBuilder.eq).toHaveBeenCalledWith("targetKind", "skillVersion");
+    return { order };
+  });
+  const query = vi.fn((tableName: string) => {
+    expect(tableName).toBe("securityScanJobs");
+    return { withIndex };
+  });
+
+  return {
+    ctx: {
+      db: {
+        query,
+        get,
+        delete: deleteDoc,
+        insert: noopWrite,
+        patch: noopWrite,
+        replace: noopWrite,
+        normalizeId: vi.fn(() => null),
+        system: {},
+      },
+    },
+    deleted,
+    deleteDoc,
+    get,
+    take,
+  };
+}
 
 describe("securityScan", () => {
   afterEach(() => {
@@ -106,5 +239,142 @@ describe("securityScan", () => {
         error: "ClawPack artifact unavailable",
       }),
     );
+  });
+
+  it("dry-runs redundant queued vt-update skill jobs without deleting", async () => {
+    const job = makeScanJob({ _id: "securityScanJobs:dry-run" });
+    const versions = new Map<string, unknown>([["skillVersions:dry-run", makeVersion("clean")]]);
+    const { ctx, deleteDoc, take } = makePruneCtx([job], versions);
+
+    const result = await pruneRedundantQueuedVtScanJobsInternalHandler(ctx, {
+      dryRun: true,
+    });
+
+    expect(take).toHaveBeenCalledWith(1000);
+    expect(result).toMatchObject({
+      dryRun: true,
+      scanned: 1,
+      eligible: 1,
+      wouldDelete: 1,
+      deleted: 0,
+      oldestScannedCreatedAt: 50,
+      newestScannedCreatedAt: 50,
+      oldestScannedNextRunAt: 100,
+      newestScannedNextRunAt: 100,
+      skippedByReason: {},
+      sampleEligibleJobIds: ["securityScanJobs:dry-run"],
+      sampleDeletedJobIds: [],
+    });
+    expect(deleteDoc).not.toHaveBeenCalled();
+  });
+
+  it("deletes only queued vt-update skill jobs with final llmAnalysis", async () => {
+    const jobs = [
+      makeScanJob({ _id: "securityScanJobs:clean" }),
+      makeScanJob({ _id: "securityScanJobs:suspicious" }),
+      makeScanJob({ _id: "securityScanJobs:malicious" }),
+      makeScanJob({ _id: "securityScanJobs:publish", source: "publish" }),
+      makeScanJob({ _id: "securityScanJobs:running", status: "running" }),
+      makeScanJob({
+        _id: "securityScanJobs:package",
+        targetKind: "packageRelease",
+        skillVersionId: undefined,
+        packageReleaseId: "packageReleases:package",
+      }),
+      makeScanJob({
+        _id: "securityScanJobs:malicious-signal",
+        hasMaliciousSignal: true,
+      }),
+      makeScanJob({ _id: "securityScanJobs:missing-version" }),
+      makeScanJob({ _id: "securityScanJobs:no-llm" }),
+      makeScanJob({ _id: "securityScanJobs:error-llm" }),
+      makeScanJob({ _id: "securityScanJobs:clawscan-note-fresh" }),
+      makeScanJob({ _id: "securityScanJobs:vt-mismatch" }),
+    ];
+    const versions = new Map<string, unknown>([
+      ["skillVersions:clean", makeVersion("clean")],
+      ["skillVersions:suspicious", makeVersion("suspicious")],
+      ["skillVersions:malicious", makeVersion("malicious")],
+      ["skillVersions:running", makeVersion("clean")],
+      ["skillVersions:malicious-signal", makeVersion("clean")],
+      ["skillVersions:no-llm", makeVersion()],
+      ["skillVersions:error-llm", makeVersion("error")],
+      [
+        "skillVersions:clawscan-note-fresh",
+        makeVersion("clean", "clean", { clawScanNoteUpdatedAt: 456 }),
+      ],
+      ["skillVersions:vt-mismatch", makeVersion("clean", "malicious")],
+    ]);
+    const { ctx, deleted } = makePruneCtx(jobs, versions);
+
+    const result = await pruneRedundantQueuedVtScanJobsInternalHandler(ctx, {
+      dryRun: false,
+      scanLimit: 25,
+      deleteLimit: 10,
+    });
+
+    expect(deleted).toEqual([
+      "securityScanJobs:clean",
+      "securityScanJobs:suspicious",
+      "securityScanJobs:malicious",
+    ]);
+    expect(result).toMatchObject({
+      dryRun: false,
+      scanned: 12,
+      eligible: 3,
+      wouldDelete: 3,
+      deleted: 3,
+      skippedByReason: {
+        "not-vt-update": 1,
+        "not-queued": 1,
+        "not-skill-version": 1,
+        "malicious-signal": 1,
+        "missing-version": 1,
+        "missing-llm-analysis": 1,
+        "non-final-llm-analysis": 1,
+        "clawscan-note-newer-than-llm": 1,
+        "vt-llm-status-mismatch": 1,
+      },
+      sampleEligibleJobIds: [
+        "securityScanJobs:clean",
+        "securityScanJobs:suspicious",
+        "securityScanJobs:malicious",
+      ],
+      sampleDeletedJobIds: [
+        "securityScanJobs:clean",
+        "securityScanJobs:suspicious",
+        "securityScanJobs:malicious",
+      ],
+    });
+  });
+
+  it("counts eligible jobs beyond the per-run delete limit without deleting them", async () => {
+    const jobs = [
+      makeScanJob({ _id: "securityScanJobs:first" }),
+      makeScanJob({ _id: "securityScanJobs:second" }),
+    ];
+    const versions = new Map<string, unknown>([
+      ["skillVersions:first", makeVersion("clean")],
+      ["skillVersions:second", makeVersion("clean")],
+    ]);
+    const { ctx, deleted } = makePruneCtx(jobs, versions);
+
+    const result = await pruneRedundantQueuedVtScanJobsInternalHandler(ctx, {
+      dryRun: false,
+      deleteLimit: 1,
+    });
+
+    expect(deleted).toEqual(["securityScanJobs:first"]);
+    expect(result).toMatchObject({
+      scanned: 2,
+      eligible: 2,
+      wouldDelete: 1,
+      deleted: 1,
+      skippedByReason: {
+        "delete-limit-reached": 1,
+      },
+      sampleEligibleJobIds: ["securityScanJobs:first", "securityScanJobs:second"],
+      sampleDeletedJobIds: ["securityScanJobs:first"],
+    });
   });
 });

--- a/convex/securityScan.ts
+++ b/convex/securityScan.ts
@@ -7,6 +7,25 @@ const MAX_PARALLEL_CODEX_SCANS = 10;
 const DEFAULT_VT_WAIT_MS = 10 * 60 * 1000;
 const DEFAULT_LEASE_MS = 30 * 60 * 1000;
 const MAX_ATTEMPTS = 3;
+const DEFAULT_PRUNE_SCAN_LIMIT = 1000;
+const DEFAULT_PRUNE_DELETE_LIMIT = 500;
+const MAX_PRUNE_SCAN_LIMIT = 5000;
+const PRUNE_SAMPLE_LIMIT = 20;
+
+const finalLlmAnalysisStatuses = new Set(["clean", "suspicious", "malicious"]);
+
+type PruneSkipReason =
+  | "not-queued"
+  | "not-vt-update"
+  | "not-skill-version"
+  | "malicious-signal"
+  | "missing-version-id"
+  | "missing-version"
+  | "missing-llm-analysis"
+  | "non-final-llm-analysis"
+  | "clawscan-note-newer-than-llm"
+  | "vt-llm-status-mismatch"
+  | "delete-limit-reached";
 
 const jobSourceValidator = v.union(
   v.literal("publish"),
@@ -122,6 +141,25 @@ function normalizeLimit(limit: number | undefined) {
   );
 }
 
+function normalizeMaintenanceScanLimit(limit: number | undefined) {
+  const normalized = Number.isFinite(limit) ? Math.floor(limit ?? DEFAULT_PRUNE_SCAN_LIMIT) : null;
+  return Math.max(1, Math.min(normalized ?? DEFAULT_PRUNE_SCAN_LIMIT, MAX_PRUNE_SCAN_LIMIT));
+}
+
+function normalizeMaintenanceDeleteLimit(limit: number | undefined, scanLimit: number) {
+  const normalized = Number.isFinite(limit)
+    ? Math.floor(limit ?? DEFAULT_PRUNE_DELETE_LIMIT)
+    : null;
+  return Math.max(0, Math.min(normalized ?? DEFAULT_PRUNE_DELETE_LIMIT, scanLimit));
+}
+
+function incrementSkip(
+  skippedByReason: Partial<Record<PruneSkipReason, number>>,
+  reason: PruneSkipReason,
+) {
+  skippedByReason[reason] = (skippedByReason[reason] ?? 0) + 1;
+}
+
 function isOpenClawPluginPackage(
   pkg: Doc<"packages"> | null | undefined,
   ownerPublisher: Pick<Doc<"publishers">, "handle" | "deletedAt"> | null | undefined,
@@ -227,6 +265,113 @@ export const enqueuePackageReleaseScanInternal = internalMutation({
       updatedAt: now,
     });
     return { ok: true as const, jobId };
+  },
+});
+
+export const pruneRedundantQueuedVtScanJobsInternal = internalMutation({
+  args: {
+    dryRun: v.boolean(),
+    scanLimit: v.optional(v.number()),
+    deleteLimit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const scanLimit = normalizeMaintenanceScanLimit(args.scanLimit);
+    const deleteLimit = normalizeMaintenanceDeleteLimit(args.deleteLimit, scanLimit);
+    const jobs = await ctx.db
+      .query("securityScanJobs")
+      .withIndex("by_status_source_target_kind_created_at", (q) =>
+        q.eq("status", "queued").eq("source", "vt-update").eq("targetKind", "skillVersion"),
+      )
+      .order("asc")
+      .take(scanLimit);
+
+    const skippedByReason: Partial<Record<PruneSkipReason, number>> = {};
+    const sampleEligibleJobIds: string[] = [];
+    const sampleDeletedJobIds: string[] = [];
+    let eligible = 0;
+    let deleted = 0;
+
+    for (const job of jobs) {
+      if (job.status !== "queued") {
+        incrementSkip(skippedByReason, "not-queued");
+        continue;
+      }
+      if (job.source !== "vt-update") {
+        incrementSkip(skippedByReason, "not-vt-update");
+        continue;
+      }
+      if (job.targetKind !== "skillVersion") {
+        incrementSkip(skippedByReason, "not-skill-version");
+        continue;
+      }
+      if (job.hasMaliciousSignal) {
+        incrementSkip(skippedByReason, "malicious-signal");
+        continue;
+      }
+      if (!job.skillVersionId) {
+        incrementSkip(skippedByReason, "missing-version-id");
+        continue;
+      }
+
+      const version = await ctx.db.get(job.skillVersionId);
+      if (!version || version.softDeletedAt) {
+        incrementSkip(skippedByReason, "missing-version");
+        continue;
+      }
+
+      const llmAnalysis = version.llmAnalysis;
+      const rawLlmStatus = llmAnalysis?.status?.trim();
+      if (!llmAnalysis || !rawLlmStatus) {
+        incrementSkip(skippedByReason, "missing-llm-analysis");
+        continue;
+      }
+      const llmStatus = rawLlmStatus.toLowerCase();
+      if (!finalLlmAnalysisStatuses.has(llmStatus)) {
+        incrementSkip(skippedByReason, "non-final-llm-analysis");
+        continue;
+      }
+      if ((version.clawScanNoteUpdatedAt ?? 0) > llmAnalysis.checkedAt) {
+        incrementSkip(skippedByReason, "clawscan-note-newer-than-llm");
+        continue;
+      }
+
+      // This helper cancels retroactive VT freshness work after the all-active sweep;
+      // preserve jobs where the current finalized VT outcome disagrees with ClawScan.
+      const vtStatus = version.vtAnalysis?.status?.trim().toLowerCase();
+      if (vtStatus && finalLlmAnalysisStatuses.has(vtStatus) && vtStatus !== llmStatus) {
+        incrementSkip(skippedByReason, "vt-llm-status-mismatch");
+        continue;
+      }
+
+      eligible += 1;
+      if (sampleEligibleJobIds.length < PRUNE_SAMPLE_LIMIT) sampleEligibleJobIds.push(job._id);
+      if (eligible > deleteLimit) {
+        incrementSkip(skippedByReason, "delete-limit-reached");
+        continue;
+      }
+      if (args.dryRun) continue;
+
+      await ctx.db.delete(job._id);
+      deleted += 1;
+      if (sampleDeletedJobIds.length < PRUNE_SAMPLE_LIMIT) sampleDeletedJobIds.push(job._id);
+    }
+
+    const oldestScannedJob = jobs[0];
+    const newestScannedJob = jobs.at(-1);
+    return {
+      dryRun: args.dryRun,
+      scanned: jobs.length,
+      eligible,
+      wouldDelete: Math.min(eligible, deleteLimit),
+      deleted,
+      skippedByReason,
+      oldestScannedCreatedAt: oldestScannedJob?.createdAt ?? null,
+      newestScannedCreatedAt: newestScannedJob?.createdAt ?? null,
+      oldestScannedNextRunAt: oldestScannedJob?.nextRunAt ?? null,
+      newestScannedNextRunAt: newestScannedJob?.nextRunAt ?? null,
+      sampleEligibleJobIds,
+      sampleDeletedJobIds,
+    };
   },
 });
 


### PR DESCRIPTION
## Summary
- add an indexed internal maintenance mutation to prune redundant queued `vt-update` ClawScan jobs for skill versions
- preserve publish/manual/note/package/running/malicious-signal work plus jobs without final ClawScan results or with VT/ClawScan deltas
- cover dry-run, deletion, preservation, and delete-limit behavior with focused tests

## Ops runbook
After this deploy lands, start with a dry run:

```bash
bunx convex run --deployment wry-manatee-359 securityScan:pruneRedundantQueuedVtScanJobsInternal '{"dryRun":true,"scanLimit":1000,"deleteLimit":500}'
```

If skipped reasons and samples look safe, run real batches and recheck queue counts after each batch:

```bash
bunx convex run --deployment wry-manatee-359 securityScan:pruneRedundantQueuedVtScanJobsInternal '{"dryRun":false,"scanLimit":1000,"deleteLimit":500}'
```

Stop when `eligible` is `0` or queued `vt-update` jobs are no longer blocking publish ClawScan work.

## Tests
- `bunx vitest run convex/securityScan*.test.ts`
- `bun run format:check -- convex/schema.ts convex/securityScan.ts convex/securityScan.test.ts`
- `bun run lint`
- `bunx tsc --noEmit --pretty false`
- `bun run ci:static`
- `bun run ci:unit`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local`
