### PR TITLE
Cancel old queued VT update scan work

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1026,6 +1026,7 @@ const securityScanJobs = defineTable({
   updatedAt: v.number(),
 })
   .index("by_status_and_next_run_at", ["status", "nextRunAt"])
+  .index("by_status_source_created_at", ["status", "source", "createdAt"])
   .index("by_status_source_target_kind_created_at", ["status", "source", "targetKind", "createdAt"])
   .index("by_status_and_lease_expires_at", ["status", "leaseExpiresAt"])
   .index("by_status_malicious_signal_next_run_at", ["status", "hasMaliciousSignal", "nextRunAt"])

--- a/convex/securityScan.test.ts
+++ b/convex/securityScan.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { claimCodexScanJobs, pruneRedundantQueuedVtScanJobsInternal } from "./securityScan";
+import { cancelQueuedVtUpdateJobsInternal, claimCodexScanJobs } from "./securityScan";
 
 type WrappedHandler<TArgs, TResult = unknown> = {
   _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
@@ -12,16 +12,17 @@ const claimCodexScanJobsHandler = (
   >
 )._handler;
 
-type PruneArgs = {
+type CancelArgs = {
   dryRun: boolean;
+  createdBefore: number;
   scanLimit?: number;
   deleteLimit?: number;
 };
 
-type PruneResult = {
+type CancelResult = {
   dryRun: boolean;
   scanned: number;
-  eligible: number;
+  matched: number;
   deleted: number;
   wouldDelete: number;
   skippedByReason: Record<string, number>;
@@ -29,11 +30,11 @@ type PruneResult = {
   newestScannedCreatedAt: number | null;
   oldestScannedNextRunAt: number | null;
   newestScannedNextRunAt: number | null;
-  sampleEligibleJobIds: string[];
+  sampleMatchedJobIds: string[];
   sampleDeletedJobIds: string[];
 };
 
-type PruneJob = {
+type ScanJob = {
   _id: string;
   _creationTime: number;
   status: string;
@@ -50,8 +51,8 @@ type PruneJob = {
   updatedAt: number;
 };
 
-const pruneRedundantQueuedVtScanJobsInternalHandler = (
-  pruneRedundantQueuedVtScanJobsInternal as unknown as WrappedHandler<PruneArgs, PruneResult>
+const cancelQueuedVtUpdateJobsInternalHandler = (
+  cancelQueuedVtUpdateJobsInternal as unknown as WrappedHandler<CancelArgs, CancelResult>
 )._handler;
 
 const claimedJob = {
@@ -69,8 +70,8 @@ const claimedJob = {
   leaseToken: "lease-token",
 };
 
-function makeScanJob(overrides: Partial<PruneJob> = {}): PruneJob {
-  const suffix = (overrides._id ?? "eligible").split(":").at(-1) ?? "eligible";
+function makeScanJob(overrides: Partial<ScanJob> = {}): ScanJob {
+  const suffix = (overrides._id ?? "matched").split(":").at(-1) ?? "matched";
   return {
     _id: `securityScanJobs:${suffix}`,
     _creationTime: 1,
@@ -89,50 +90,38 @@ function makeScanJob(overrides: Partial<PruneJob> = {}): PruneJob {
   };
 }
 
-function makeVersion(
-  llmStatus?: string,
-  vtStatus?: string,
-  overrides: Record<string, unknown> = {},
-) {
+function makeTarget(llmStatus?: string) {
+  if (!llmStatus) return {};
   return {
-    ...(llmStatus
-      ? {
-          llmAnalysis: {
-            status: llmStatus,
-            checkedAt: 123,
-          },
-        }
-      : {}),
-    ...(vtStatus
-      ? {
-          vtAnalysis: {
-            status: vtStatus,
-            checkedAt: 456,
-          },
-        }
-      : {}),
-    ...overrides,
+    llmAnalysis: {
+      status: llmStatus,
+      checkedAt: 123,
+    },
   };
 }
 
-function makePruneCtx(jobs: PruneJob[], versions: Map<string, unknown>) {
+function makeCancelCtx(jobs: ScanJob[], targets: Map<string, unknown> = new Map()) {
   const deleted: string[] = [];
   const deleteDoc = vi.fn(async (id: string) => {
     deleted.push(id);
   });
-  const get = vi.fn(async (id: string) => versions.get(id) ?? null);
+  const get = vi.fn(async (id: string) => targets.get(id) ?? null);
   const noopWrite = vi.fn(async () => undefined);
   const take = vi.fn(async (limit: number) => jobs.slice(0, limit));
   const order = vi.fn(() => ({ take }));
-  const indexBuilder: { eq: ReturnType<typeof vi.fn> } = {
+  const indexBuilder: {
+    eq: ReturnType<typeof vi.fn>;
+    lt: ReturnType<typeof vi.fn>;
+  } = {
     eq: vi.fn(() => indexBuilder),
+    lt: vi.fn(() => indexBuilder),
   };
   const withIndex = vi.fn((indexName: string, buildRange: (q: typeof indexBuilder) => unknown) => {
-    expect(indexName).toBe("by_status_source_target_kind_created_at");
+    expect(indexName).toBe("by_status_source_created_at");
     buildRange(indexBuilder);
     expect(indexBuilder.eq).toHaveBeenCalledWith("status", "queued");
     expect(indexBuilder.eq).toHaveBeenCalledWith("source", "vt-update");
-    expect(indexBuilder.eq).toHaveBeenCalledWith("targetKind", "skillVersion");
+    expect(indexBuilder.lt).toHaveBeenCalledWith("createdAt", 1000);
     return { order };
   });
   const query = vi.fn((tableName: string) => {
@@ -241,20 +230,23 @@ describe("securityScan", () => {
     );
   });
 
-  it("dry-runs redundant queued vt-update skill jobs without deleting", async () => {
+  it("dry-runs queued vt-update jobs without deleting", async () => {
     const job = makeScanJob({ _id: "securityScanJobs:dry-run" });
-    const versions = new Map<string, unknown>([["skillVersions:dry-run", makeVersion("clean")]]);
-    const { ctx, deleteDoc, take } = makePruneCtx([job], versions);
+    const { ctx, deleteDoc, take } = makeCancelCtx(
+      [job],
+      new Map<string, unknown>([["skillVersions:dry-run", makeTarget("clean")]]),
+    );
 
-    const result = await pruneRedundantQueuedVtScanJobsInternalHandler(ctx, {
+    const result = await cancelQueuedVtUpdateJobsInternalHandler(ctx, {
       dryRun: true,
+      createdBefore: 1000,
     });
 
     expect(take).toHaveBeenCalledWith(1000);
     expect(result).toMatchObject({
       dryRun: true,
       scanned: 1,
-      eligible: 1,
+      matched: 1,
       wouldDelete: 1,
       deleted: 0,
       oldestScannedCreatedAt: 50,
@@ -262,19 +254,15 @@ describe("securityScan", () => {
       oldestScannedNextRunAt: 100,
       newestScannedNextRunAt: 100,
       skippedByReason: {},
-      sampleEligibleJobIds: ["securityScanJobs:dry-run"],
+      sampleMatchedJobIds: ["securityScanJobs:dry-run"],
       sampleDeletedJobIds: [],
     });
     expect(deleteDoc).not.toHaveBeenCalled();
   });
 
-  it("deletes only queued vt-update skill jobs with final llmAnalysis", async () => {
+  it("deletes all queued vt-update jobs while preserving other sources and running jobs", async () => {
     const jobs = [
       makeScanJob({ _id: "securityScanJobs:clean" }),
-      makeScanJob({ _id: "securityScanJobs:suspicious" }),
-      makeScanJob({ _id: "securityScanJobs:malicious" }),
-      makeScanJob({ _id: "securityScanJobs:publish", source: "publish" }),
-      makeScanJob({ _id: "securityScanJobs:running", status: "running" }),
       makeScanJob({
         _id: "securityScanJobs:package",
         targetKind: "packageRelease",
@@ -285,95 +273,93 @@ describe("securityScan", () => {
         _id: "securityScanJobs:malicious-signal",
         hasMaliciousSignal: true,
       }),
-      makeScanJob({ _id: "securityScanJobs:missing-version" }),
-      makeScanJob({ _id: "securityScanJobs:no-llm" }),
-      makeScanJob({ _id: "securityScanJobs:error-llm" }),
-      makeScanJob({ _id: "securityScanJobs:clawscan-note-fresh" }),
       makeScanJob({ _id: "securityScanJobs:vt-mismatch" }),
+      makeScanJob({ _id: "securityScanJobs:no-llm" }),
+      makeScanJob({ _id: "securityScanJobs:publish", source: "publish" }),
+      makeScanJob({ _id: "securityScanJobs:manual", source: "manual" }),
+      makeScanJob({ _id: "securityScanJobs:clawscan-note", source: "clawscan-note" }),
+      makeScanJob({ _id: "securityScanJobs:backfill", source: "backfill" }),
+      makeScanJob({ _id: "securityScanJobs:running", status: "running" }),
     ];
-    const versions = new Map<string, unknown>([
-      ["skillVersions:clean", makeVersion("clean")],
-      ["skillVersions:suspicious", makeVersion("suspicious")],
-      ["skillVersions:malicious", makeVersion("malicious")],
-      ["skillVersions:running", makeVersion("clean")],
-      ["skillVersions:malicious-signal", makeVersion("clean")],
-      ["skillVersions:no-llm", makeVersion()],
-      ["skillVersions:error-llm", makeVersion("error")],
-      [
-        "skillVersions:clawscan-note-fresh",
-        makeVersion("clean", "clean", { clawScanNoteUpdatedAt: 456 }),
-      ],
-      ["skillVersions:vt-mismatch", makeVersion("clean", "malicious")],
-    ]);
-    const { ctx, deleted } = makePruneCtx(jobs, versions);
+    const { ctx, deleted, get } = makeCancelCtx(
+      jobs,
+      new Map<string, unknown>([
+        ["skillVersions:clean", makeTarget("clean")],
+        ["packageReleases:package", makeTarget("clean")],
+        ["skillVersions:malicious-signal", makeTarget("clean")],
+        ["skillVersions:vt-mismatch", makeTarget("clean")],
+        ["skillVersions:no-llm", makeTarget()],
+        ["skillVersions:running", makeTarget("clean")],
+      ]),
+    );
 
-    const result = await pruneRedundantQueuedVtScanJobsInternalHandler(ctx, {
+    const result = await cancelQueuedVtUpdateJobsInternalHandler(ctx, {
       dryRun: false,
+      createdBefore: 1000,
       scanLimit: 25,
       deleteLimit: 10,
     });
 
     expect(deleted).toEqual([
       "securityScanJobs:clean",
-      "securityScanJobs:suspicious",
-      "securityScanJobs:malicious",
+      "securityScanJobs:package",
+      "securityScanJobs:vt-mismatch",
     ]);
+    expect(get).toHaveBeenCalled();
     expect(result).toMatchObject({
       dryRun: false,
-      scanned: 12,
-      eligible: 3,
+      scanned: 10,
+      matched: 3,
       wouldDelete: 3,
       deleted: 3,
       skippedByReason: {
-        "not-vt-update": 1,
-        "not-queued": 1,
-        "not-skill-version": 1,
+        "not-vt-update": 4,
+        "not-queued-vt-update": 1,
         "malicious-signal": 1,
-        "missing-version": 1,
         "missing-llm-analysis": 1,
-        "non-final-llm-analysis": 1,
-        "clawscan-note-newer-than-llm": 1,
-        "vt-llm-status-mismatch": 1,
       },
-      sampleEligibleJobIds: [
+      sampleMatchedJobIds: [
         "securityScanJobs:clean",
-        "securityScanJobs:suspicious",
-        "securityScanJobs:malicious",
+        "securityScanJobs:package",
+        "securityScanJobs:vt-mismatch",
       ],
       sampleDeletedJobIds: [
         "securityScanJobs:clean",
-        "securityScanJobs:suspicious",
-        "securityScanJobs:malicious",
+        "securityScanJobs:package",
+        "securityScanJobs:vt-mismatch",
       ],
     });
   });
 
-  it("counts eligible jobs beyond the per-run delete limit without deleting them", async () => {
+  it("counts matched jobs beyond the per-run delete limit without deleting them", async () => {
     const jobs = [
       makeScanJob({ _id: "securityScanJobs:first" }),
       makeScanJob({ _id: "securityScanJobs:second" }),
     ];
-    const versions = new Map<string, unknown>([
-      ["skillVersions:first", makeVersion("clean")],
-      ["skillVersions:second", makeVersion("clean")],
-    ]);
-    const { ctx, deleted } = makePruneCtx(jobs, versions);
+    const { ctx, deleted } = makeCancelCtx(
+      jobs,
+      new Map<string, unknown>([
+        ["skillVersions:first", makeTarget("clean")],
+        ["skillVersions:second", makeTarget("clean")],
+      ]),
+    );
 
-    const result = await pruneRedundantQueuedVtScanJobsInternalHandler(ctx, {
+    const result = await cancelQueuedVtUpdateJobsInternalHandler(ctx, {
       dryRun: false,
+      createdBefore: 1000,
       deleteLimit: 1,
     });
 
     expect(deleted).toEqual(["securityScanJobs:first"]);
     expect(result).toMatchObject({
       scanned: 2,
-      eligible: 2,
+      matched: 2,
       wouldDelete: 1,
       deleted: 1,
       skippedByReason: {
         "delete-limit-reached": 1,
       },
-      sampleEligibleJobIds: ["securityScanJobs:first", "securityScanJobs:second"],
+      sampleMatchedJobIds: ["securityScanJobs:first", "securityScanJobs:second"],
       sampleDeletedJobIds: ["securityScanJobs:first"],
     });
   });

--- a/convex/securityScan.ts
+++ b/convex/securityScan.ts
@@ -7,24 +7,22 @@ const MAX_PARALLEL_CODEX_SCANS = 10;
 const DEFAULT_VT_WAIT_MS = 10 * 60 * 1000;
 const DEFAULT_LEASE_MS = 30 * 60 * 1000;
 const MAX_ATTEMPTS = 3;
-const DEFAULT_PRUNE_SCAN_LIMIT = 1000;
-const DEFAULT_PRUNE_DELETE_LIMIT = 500;
-const MAX_PRUNE_SCAN_LIMIT = 5000;
-const PRUNE_SAMPLE_LIMIT = 20;
+const DEFAULT_CANCEL_SCAN_LIMIT = 1000;
+const DEFAULT_CANCEL_DELETE_LIMIT = 500;
+const MAX_CANCEL_SCAN_LIMIT = 5000;
+const CANCEL_SAMPLE_LIMIT = 20;
 
 const finalLlmAnalysisStatuses = new Set(["clean", "suspicious", "malicious"]);
 
-type PruneSkipReason =
+type CancelSkipReason =
   | "not-queued"
   | "not-vt-update"
-  | "not-skill-version"
+  | "not-queued-vt-update"
   | "malicious-signal"
-  | "missing-version-id"
-  | "missing-version"
+  | "missing-target-id"
+  | "missing-target"
   | "missing-llm-analysis"
   | "non-final-llm-analysis"
-  | "clawscan-note-newer-than-llm"
-  | "vt-llm-status-mismatch"
   | "delete-limit-reached";
 
 const jobSourceValidator = v.union(
@@ -142,20 +140,20 @@ function normalizeLimit(limit: number | undefined) {
 }
 
 function normalizeMaintenanceScanLimit(limit: number | undefined) {
-  const normalized = Number.isFinite(limit) ? Math.floor(limit ?? DEFAULT_PRUNE_SCAN_LIMIT) : null;
-  return Math.max(1, Math.min(normalized ?? DEFAULT_PRUNE_SCAN_LIMIT, MAX_PRUNE_SCAN_LIMIT));
+  const normalized = Number.isFinite(limit) ? Math.floor(limit ?? DEFAULT_CANCEL_SCAN_LIMIT) : null;
+  return Math.max(1, Math.min(normalized ?? DEFAULT_CANCEL_SCAN_LIMIT, MAX_CANCEL_SCAN_LIMIT));
 }
 
 function normalizeMaintenanceDeleteLimit(limit: number | undefined, scanLimit: number) {
   const normalized = Number.isFinite(limit)
-    ? Math.floor(limit ?? DEFAULT_PRUNE_DELETE_LIMIT)
+    ? Math.floor(limit ?? DEFAULT_CANCEL_DELETE_LIMIT)
     : null;
-  return Math.max(0, Math.min(normalized ?? DEFAULT_PRUNE_DELETE_LIMIT, scanLimit));
+  return Math.max(0, Math.min(normalized ?? DEFAULT_CANCEL_DELETE_LIMIT, scanLimit));
 }
 
 function incrementSkip(
-  skippedByReason: Partial<Record<PruneSkipReason, number>>,
-  reason: PruneSkipReason,
+  skippedByReason: Partial<Record<CancelSkipReason, number>>,
+  reason: CancelSkipReason,
 ) {
   skippedByReason[reason] = (skippedByReason[reason] ?? 0) + 1;
 }
@@ -268,9 +266,10 @@ export const enqueuePackageReleaseScanInternal = internalMutation({
   },
 });
 
-export const pruneRedundantQueuedVtScanJobsInternal = internalMutation({
+export const cancelQueuedVtUpdateJobsInternal = internalMutation({
   args: {
     dryRun: v.boolean(),
+    createdBefore: v.number(),
     scanLimit: v.optional(v.number()),
     deleteLimit: v.optional(v.number()),
   },
@@ -279,73 +278,61 @@ export const pruneRedundantQueuedVtScanJobsInternal = internalMutation({
     const deleteLimit = normalizeMaintenanceDeleteLimit(args.deleteLimit, scanLimit);
     const jobs = await ctx.db
       .query("securityScanJobs")
-      .withIndex("by_status_source_target_kind_created_at", (q) =>
-        q.eq("status", "queued").eq("source", "vt-update").eq("targetKind", "skillVersion"),
+      .withIndex("by_status_source_created_at", (q) =>
+        q.eq("status", "queued").eq("source", "vt-update").lt("createdAt", args.createdBefore),
       )
       .order("asc")
       .take(scanLimit);
 
-    const skippedByReason: Partial<Record<PruneSkipReason, number>> = {};
-    const sampleEligibleJobIds: string[] = [];
+    const skippedByReason: Partial<Record<CancelSkipReason, number>> = {};
+    const sampleMatchedJobIds: string[] = [];
     const sampleDeletedJobIds: string[] = [];
-    let eligible = 0;
+    let matched = 0;
     let deleted = 0;
 
     for (const job of jobs) {
       if (job.status !== "queued") {
-        incrementSkip(skippedByReason, "not-queued");
+        incrementSkip(
+          skippedByReason,
+          job.source === "vt-update" ? "not-queued-vt-update" : "not-queued",
+        );
         continue;
       }
       if (job.source !== "vt-update") {
         incrementSkip(skippedByReason, "not-vt-update");
         continue;
       }
-      if (job.targetKind !== "skillVersion") {
-        incrementSkip(skippedByReason, "not-skill-version");
-        continue;
-      }
       if (job.hasMaliciousSignal) {
         incrementSkip(skippedByReason, "malicious-signal");
         continue;
       }
-      if (!job.skillVersionId) {
-        incrementSkip(skippedByReason, "missing-version-id");
+
+      const targetId =
+        job.targetKind === "skillVersion" ? job.skillVersionId : job.packageReleaseId;
+      if (!targetId) {
+        incrementSkip(skippedByReason, "missing-target-id");
         continue;
       }
-
-      const version = await ctx.db.get(job.skillVersionId);
-      if (!version || version.softDeletedAt) {
-        incrementSkip(skippedByReason, "missing-version");
+      const target = await ctx.db.get(targetId);
+      if (!target || target.softDeletedAt) {
+        incrementSkip(skippedByReason, "missing-target");
         continue;
       }
-
-      const llmAnalysis = version.llmAnalysis;
-      const rawLlmStatus = llmAnalysis?.status?.trim();
-      if (!llmAnalysis || !rawLlmStatus) {
+      const rawLlmStatus = target.llmAnalysis?.status?.trim();
+      if (!rawLlmStatus) {
         incrementSkip(skippedByReason, "missing-llm-analysis");
         continue;
       }
-      const llmStatus = rawLlmStatus.toLowerCase();
-      if (!finalLlmAnalysisStatuses.has(llmStatus)) {
+      if (!finalLlmAnalysisStatuses.has(rawLlmStatus.toLowerCase())) {
         incrementSkip(skippedByReason, "non-final-llm-analysis");
         continue;
       }
-      if ((version.clawScanNoteUpdatedAt ?? 0) > llmAnalysis.checkedAt) {
-        incrementSkip(skippedByReason, "clawscan-note-newer-than-llm");
-        continue;
-      }
 
-      // This helper cancels retroactive VT freshness work after the all-active sweep;
-      // preserve jobs where the current finalized VT outcome disagrees with ClawScan.
-      const vtStatus = version.vtAnalysis?.status?.trim().toLowerCase();
-      if (vtStatus && finalLlmAnalysisStatuses.has(vtStatus) && vtStatus !== llmStatus) {
-        incrementSkip(skippedByReason, "vt-llm-status-mismatch");
-        continue;
-      }
-
-      eligible += 1;
-      if (sampleEligibleJobIds.length < PRUNE_SAMPLE_LIMIT) sampleEligibleJobIds.push(job._id);
-      if (eligible > deleteLimit) {
+      // Emergency cleanup: source may have been overwritten by a VT update, but this
+      // intentionally cancels old VT-origin work once ClawScan has a final result.
+      matched += 1;
+      if (sampleMatchedJobIds.length < CANCEL_SAMPLE_LIMIT) sampleMatchedJobIds.push(job._id);
+      if (matched > deleteLimit) {
         incrementSkip(skippedByReason, "delete-limit-reached");
         continue;
       }
@@ -353,7 +340,7 @@ export const pruneRedundantQueuedVtScanJobsInternal = internalMutation({
 
       await ctx.db.delete(job._id);
       deleted += 1;
-      if (sampleDeletedJobIds.length < PRUNE_SAMPLE_LIMIT) sampleDeletedJobIds.push(job._id);
+      if (sampleDeletedJobIds.length < CANCEL_SAMPLE_LIMIT) sampleDeletedJobIds.push(job._id);
     }
 
     const oldestScannedJob = jobs[0];
@@ -361,15 +348,15 @@ export const pruneRedundantQueuedVtScanJobsInternal = internalMutation({
     return {
       dryRun: args.dryRun,
       scanned: jobs.length,
-      eligible,
-      wouldDelete: Math.min(eligible, deleteLimit),
+      matched,
+      wouldDelete: Math.min(matched, deleteLimit),
       deleted,
       skippedByReason,
       oldestScannedCreatedAt: oldestScannedJob?.createdAt ?? null,
       newestScannedCreatedAt: newestScannedJob?.createdAt ?? null,
       oldestScannedNextRunAt: oldestScannedJob?.nextRunAt ?? null,
       newestScannedNextRunAt: newestScannedJob?.nextRunAt ?? null,
-      sampleEligibleJobIds,
+      sampleMatchedJobIds,
       sampleDeletedJobIds,
     };
   },


### PR DESCRIPTION
## Summary
- replace the selective redundant prune helper with `cancelQueuedVtUpdateJobsInternal`
- cancel queued `vt-update` scan jobs older than an operator-provided cutoff, across skill and package targets
- keep hard rails for running jobs, non-`vt-update` sources, malicious-signal jobs, and targets without final ClawScan results

## Operator flow
Capture a cutoff immediately before the first dry run/deletion batch:

```bash
cutoff=$(node -e 'console.log(Date.now())')
```

Dry run:

```bash
bunx convex run --deployment wry-manatee-359 securityScan:cancelQueuedVtUpdateJobsInternal "{\"dryRun\":true,\"createdBefore\":$cutoff,\"scanLimit\":1000,\"deleteLimit\":500}"
```

Real batch:

```bash
bunx convex run --deployment wry-manatee-359 securityScan:cancelQueuedVtUpdateJobsInternal "{\"dryRun\":false,\"createdBefore\":$cutoff,\"scanLimit\":1000,\"deleteLimit\":500}"
```

Repeat real batches with the same cutoff until `matched` is `0`.

## Risk note
Autoreview correctly flagged that cancelling old VT-disagreement jobs can leave existing ClawScan verdicts unreconciled with newer VT telemetry. That is the explicit emergency tradeoff for this cleanup: VT remains telemetry, publish-time ClawScan remains the baseline, and this flow cancels old VT-origin backlog instead of spending several days processing it.

## Tests
- `bunx vitest run convex/securityScan.test.ts`
- `bun run format:check -- convex/schema.ts convex/securityScan.ts convex/securityScan.test.ts`
- `bun run lint`
- `bunx tsc --noEmit --pretty false`
- `bun run ci:static`
- `bun run ci:unit`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local` (reported the intentional VT-disagreement risk above)
