### PR TITLE
Surface OAuth callback returns without auth code

### DIFF
--- a/src/components/AppProviders.test.tsx
+++ b/src/components/AppProviders.test.tsx
@@ -103,6 +103,35 @@ describe("AuthCodeHandler", () => {
       expect(getAuthErrorSnapshot()).toBe(DELETED_SIGN_IN_MESSAGE);
     });
   });
+
+  it("does not consume initial CLI device codes as OAuth callback codes", async () => {
+    window.history.replaceState(null, "", "/cli/device?code=A8H8-GCLX");
+
+    render(<AuthCodeHandler />);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(signInMock).not.toHaveBeenCalled();
+    expect(getAuthErrorSnapshot()).toBeNull();
+    expect(window.location.pathname + window.location.search + window.location.hash).toBe(
+      "/cli/device?code=A8H8-GCLX",
+    );
+  });
+
+  it("consumes OAuth callback codes on CLI device redirects while preserving the user code", async () => {
+    signInMock.mockResolvedValue({ signingIn: true });
+    markAuthRedirectAttempt("github", "/cli/device?user_code=A8H8-GCLX");
+    window.history.replaceState(null, "", "/cli/device?user_code=A8H8-GCLX&code=oauth123");
+
+    render(<AuthCodeHandler />);
+
+    await waitFor(() => {
+      expect(signInMock).toHaveBeenCalledWith(undefined, { code: "oauth123" });
+    });
+    expect(window.location.pathname + window.location.search + window.location.hash).toBe(
+      "/cli/device?user_code=A8H8-GCLX",
+    );
+  });
 });
 
 describe("AuthErrorHandler", () => {
@@ -220,6 +249,20 @@ describe("AuthRedirectFallbackHandler", () => {
     await waitFor(() => {
       expect(getAuthErrorSnapshot()).toBe(ACCESS_DENIED_SIGN_IN_MESSAGE);
     });
+  });
+
+  it("reports missing OAuth callback failures on CLI device pages without consuming the device code", async () => {
+    markAuthRedirectAttempt("github", "/cli/device?user_code=A8H8-GCLX");
+    window.history.replaceState(null, "", "/cli/device?user_code=A8H8-GCLX");
+
+    render(<AuthRedirectFallbackHandler />);
+
+    await waitFor(() => {
+      expect(getAuthErrorSnapshot()).toBe(AUTH_REDIRECT_NO_CODE_MESSAGE);
+    });
+    expect(window.location.pathname + window.location.search + window.location.hash).toBe(
+      "/cli/device?user_code=A8H8-GCLX",
+    );
   });
 
   it("does not report a missing-code failure while an auth code is being processed", async () => {

--- a/src/components/AppProviders.test.tsx
+++ b/src/components/AppProviders.test.tsx
@@ -7,16 +7,27 @@ import {
   BANNED_SIGN_IN_MESSAGE,
   DELETED_SIGN_IN_MESSAGE,
 } from "../lib/authErrorMessage";
+import { markAuthRedirectAttempt } from "../lib/authRedirectAttempt";
 import { getAuthErrorSnapshot, clearAuthError } from "../lib/useAuthError";
-import { AuthCodeHandler, AuthErrorHandler } from "./AppProviders";
+import {
+  AUTH_REDIRECT_NO_CODE_MESSAGE,
+  AuthCodeHandler,
+  AuthErrorHandler,
+  AuthRedirectFallbackHandler,
+} from "./AppProviders";
 
 const signInMock = vi.fn();
+const useConvexAuthMock = vi.fn();
 
 vi.mock("@convex-dev/auth/react", () => ({
   ConvexAuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   useAuthActions: () => ({
     signIn: signInMock,
   }),
+}));
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => useConvexAuthMock(),
 }));
 
 vi.mock("../convex/client", () => ({
@@ -155,5 +166,96 @@ describe("AuthErrorHandler", () => {
     expect(`${window.location.pathname}${window.location.search}${window.location.hash}`).toBe(
       "/sign-in",
     );
+  });
+});
+
+describe("AuthRedirectFallbackHandler", () => {
+  beforeEach(() => {
+    clearAuthError();
+    window.sessionStorage.clear();
+    window.history.replaceState(
+      null,
+      "",
+      "/cli/auth?redirect_uri=http%3A%2F%2F127.0.0.1%3A43110%2Fcallback&state=state_123",
+    );
+    useConvexAuthMock.mockReturnValue({ isAuthenticated: false, isLoading: false });
+  });
+
+  afterEach(() => {
+    clearAuthError();
+    window.sessionStorage.clear();
+  });
+
+  it("surfaces callback failures that return without code, error, or session", async () => {
+    markAuthRedirectAttempt(
+      "github",
+      "/cli/auth?redirect_uri=http%3A%2F%2F127.0.0.1%3A43110%2Fcallback&state=state_123",
+    );
+
+    render(<AuthRedirectFallbackHandler />);
+
+    await waitFor(() => {
+      expect(getAuthErrorSnapshot()).toBe(AUTH_REDIRECT_NO_CODE_MESSAGE);
+    });
+  });
+
+  it("preserves provider errors while an OAuth error callback is being processed", async () => {
+    markAuthRedirectAttempt(
+      "github",
+      "/cli/auth?redirect_uri=http%3A%2F%2F127.0.0.1%3A43110%2Fcallback&state=state_123",
+    );
+    window.history.replaceState(
+      null,
+      "",
+      "/cli/auth?redirect_uri=http%3A%2F%2F127.0.0.1%3A43110%2Fcallback&state=state_123&error=access_denied",
+    );
+
+    render(
+      <>
+        <AuthErrorHandler />
+        <AuthRedirectFallbackHandler />
+      </>,
+    );
+
+    await waitFor(() => {
+      expect(getAuthErrorSnapshot()).toBe(ACCESS_DENIED_SIGN_IN_MESSAGE);
+    });
+  });
+
+  it("does not report a missing-code failure while an auth code is being processed", async () => {
+    signInMock.mockReturnValue(new Promise(() => undefined));
+    markAuthRedirectAttempt(
+      "github",
+      "/cli/auth?redirect_uri=http%3A%2F%2F127.0.0.1%3A43110%2Fcallback&state=state_123",
+    );
+    window.history.replaceState(
+      null,
+      "",
+      "/cli/auth?redirect_uri=http%3A%2F%2F127.0.0.1%3A43110%2Fcallback&state=state_123&code=abc123",
+    );
+
+    render(
+      <>
+        <AuthCodeHandler />
+        <AuthRedirectFallbackHandler />
+      </>,
+    );
+
+    await waitFor(() => {
+      expect(signInMock).toHaveBeenCalledWith(undefined, { code: "abc123" });
+    });
+    expect(getAuthErrorSnapshot()).toBeNull();
+  });
+
+  it("clears the pending redirect marker after a successful session", () => {
+    useConvexAuthMock.mockReturnValue({ isAuthenticated: true, isLoading: false });
+    markAuthRedirectAttempt(
+      "github",
+      "/cli/auth?redirect_uri=http%3A%2F%2F127.0.0.1%3A43110%2Fcallback&state=state_123",
+    );
+
+    render(<AuthRedirectFallbackHandler />);
+
+    expect(getAuthErrorSnapshot()).toBeNull();
   });
 });

--- a/src/components/AppProviders.tsx
+++ b/src/components/AppProviders.tsx
@@ -19,6 +19,10 @@ function getPendingAuthCode() {
   const url = new URL(window.location.href);
   const code = url.searchParams.get("code");
   if (!code) return null;
+  if (url.pathname === "/cli/device") {
+    const pending = getActiveAuthRedirectAttempt();
+    if (!pending?.redirectTo.startsWith("/cli/device?user_code=")) return null;
+  }
   url.searchParams.delete("code");
   return {
     code,
@@ -109,7 +113,8 @@ export function AuthRedirectFallbackHandler() {
     }
 
     const url = new URL(window.location.href);
-    if (url.searchParams.has("code") || url.searchParams.has("error")) return;
+    const hasOAuthCode = url.pathname !== "/cli/device" && url.searchParams.has("code");
+    if (hasOAuthCode || url.searchParams.has("error")) return;
 
     const current = `${url.pathname}${url.search}${url.hash}`;
     if (current !== pending.redirectTo) return;

--- a/src/components/AppProviders.tsx
+++ b/src/components/AppProviders.tsx
@@ -1,4 +1,5 @@
 import { ConvexAuthProvider, useAuthActions } from "@convex-dev/auth/react";
+import { useConvexAuth } from "convex/react";
 import { useEffect, useRef } from "react";
 import { convex } from "../convex/client";
 import {
@@ -6,6 +7,7 @@ import {
   getUserFacingAuthError,
   normalizeAuthErrorMessage,
 } from "../lib/authErrorMessage";
+import { clearAuthRedirectAttempt, getActiveAuthRedirectAttempt } from "../lib/authRedirectAttempt";
 import { clearAuthError, setAuthError } from "../lib/useAuthError";
 import { ClientOnly } from "./ClientOnly";
 import { DevPersonaFab } from "./DevPersonaFab";
@@ -38,6 +40,7 @@ export function AuthCodeHandler() {
     if (handledCodeRef.current === pending.code) return;
     handledCodeRef.current = pending.code;
 
+    clearAuthRedirectAttempt();
     clearAuthError();
     window.history.replaceState(null, "", pending.relativeUrl);
 
@@ -77,11 +80,44 @@ export function AuthErrorHandler() {
     if (handledErrorRef.current === pending.description) return;
     handledErrorRef.current = pending.description;
 
+    clearAuthRedirectAttempt();
     window.history.replaceState(null, "", pending.relativeUrl);
     setAuthError(
       normalizeAuthErrorMessage(pending.description, "Sign in failed. Please try again."),
     );
   }, []);
+
+  return null;
+}
+
+export const AUTH_REDIRECT_NO_CODE_MESSAGE =
+  "GitHub sign-in returned to ClawHub without an auth code or error. The OAuth callback likely failed before creating a session. Check the Convex auth logs and GitHub OAuth environment configuration.";
+
+export function AuthRedirectFallbackHandler() {
+  const { isAuthenticated, isLoading } = useConvexAuth();
+  const handledRef = useRef(false);
+
+  useEffect(() => {
+    if (handledRef.current || isLoading) return;
+    const pending = getActiveAuthRedirectAttempt();
+    if (!pending) return;
+
+    if (isAuthenticated) {
+      clearAuthRedirectAttempt();
+      handledRef.current = true;
+      return;
+    }
+
+    const url = new URL(window.location.href);
+    if (url.searchParams.has("code") || url.searchParams.has("error")) return;
+
+    const current = `${url.pathname}${url.search}${url.hash}`;
+    if (current !== pending.redirectTo) return;
+
+    clearAuthRedirectAttempt();
+    handledRef.current = true;
+    setAuthError(AUTH_REDIRECT_NO_CODE_MESSAGE);
+  }, [isAuthenticated, isLoading]);
 
   return null;
 }
@@ -92,6 +128,7 @@ export function AppProviders({ children }: { children: React.ReactNode }) {
       <TooltipProvider delayDuration={400}>
         <AuthCodeHandler />
         <AuthErrorHandler />
+        <AuthRedirectFallbackHandler />
         <UserBootstrap />
         {children}
         <ClientOnly>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { getUserFacingAuthError } from "../lib/authErrorMessage";
+import { clearAuthRedirectAttempt, markAuthRedirectAttempt } from "../lib/authRedirectAttempt";
 import { gravatarUrl } from "../lib/gravatar";
 import { NAV_ICONS } from "../lib/marketplaceIcons";
 import { filterNavItems, PRIMARY_NAV_ITEMS, SECONDARY_NAV_ITEMS } from "../lib/nav-items";
@@ -510,16 +511,19 @@ export default function Header() {
                   disabled={isLoading}
                   onClick={() => {
                     clearAuthError();
+                    markAuthRedirectAttempt("github", signInRedirectTo || "/");
                     void signIn(
                       "github",
                       signInRedirectTo ? { redirectTo: signInRedirectTo } : undefined,
                     )
                       .then((result) => {
-                        if (result?.signingIn === false) {
+                        if (result?.signingIn === false && !result.redirect) {
+                          clearAuthRedirectAttempt();
                           setAuthError("Sign in failed. Please try again.");
                         }
                       })
                       .catch((error) => {
+                        clearAuthRedirectAttempt();
                         setAuthError(
                           getUserFacingAuthError(error, "Sign in failed. Please try again."),
                         );

--- a/src/components/SignInButton.test.tsx
+++ b/src/components/SignInButton.test.tsx
@@ -2,6 +2,7 @@
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getActiveAuthRedirectAttempt } from "../lib/authRedirectAttempt";
 import { SignInButton } from "./SignInButton";
 
 const signInMock = vi.fn();
@@ -32,6 +33,7 @@ describe("SignInButton", () => {
     setAuthErrorMock.mockReset();
     getUserFacingAuthErrorMock.mockReset();
     getUserFacingAuthErrorMock.mockImplementation((_, fallback) => fallback);
+    window.sessionStorage.clear();
     window.history.replaceState(null, "", "/skills?q=test#top");
   });
 
@@ -54,7 +56,23 @@ describe("SignInButton", () => {
     expect(setAuthErrorMock).not.toHaveBeenCalled();
   });
 
-  it("surfaces a generic error when sign-in resolves without redirecting", async () => {
+  it("keeps the redirect marker when sign-in starts an OAuth redirect", async () => {
+    signInMock.mockResolvedValue({
+      signingIn: false,
+      redirect: new URL("https://github.com/login"),
+    });
+
+    render(<SignInButton />);
+
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+    await waitFor(() => {
+      expect(signInMock).toHaveBeenCalled();
+    });
+    expect(setAuthErrorMock).not.toHaveBeenCalled();
+    expect(getActiveAuthRedirectAttempt()?.redirectTo).toBe("/skills?q=test#top");
+  });
+
+  it("surfaces a generic error and clears the redirect marker when sign-in resolves without redirecting", async () => {
     signInMock.mockResolvedValue({ signingIn: false });
 
     render(<SignInButton />);
@@ -63,6 +81,7 @@ describe("SignInButton", () => {
     await waitFor(() => {
       expect(setAuthErrorMock).toHaveBeenCalledWith("Sign in failed. Please try again.");
     });
+    expect(getActiveAuthRedirectAttempt()).toBeNull();
   });
 
   it("surfaces user-facing auth errors when sign-in rejects", async () => {
@@ -80,5 +99,6 @@ describe("SignInButton", () => {
       );
       expect(setAuthErrorMock).toHaveBeenCalledWith("GitHub auth unavailable");
     });
+    expect(getActiveAuthRedirectAttempt()).toBeNull();
   });
 });

--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -1,6 +1,7 @@
 import { useAuthActions } from "@convex-dev/auth/react";
 import type { ComponentProps } from "react";
 import { getUserFacingAuthError } from "../lib/authErrorMessage";
+import { clearAuthRedirectAttempt, markAuthRedirectAttempt } from "../lib/authRedirectAttempt";
 import { clearAuthError, setAuthError } from "../lib/useAuthError";
 import { Button } from "./ui/button";
 
@@ -21,13 +22,16 @@ export function SignInButton({ redirectTo, children = "Sign In", ...props }: Sig
       onClick={() => {
         clearAuthError();
         const next = redirectTo ?? getCurrentRelativeUrl();
+        markAuthRedirectAttempt("github", next || "/");
         void signIn("github", next ? { redirectTo: next } : undefined)
           .then((result) => {
-            if (result?.signingIn === false) {
+            if (result?.signingIn === false && !result.redirect) {
+              clearAuthRedirectAttempt();
               setAuthError("Sign in failed. Please try again.");
             }
           })
           .catch((error) => {
+            clearAuthRedirectAttempt();
             setAuthError(getUserFacingAuthError(error, "Sign in failed. Please try again."));
           });
       }}

--- a/src/lib/authRedirectAttempt.ts
+++ b/src/lib/authRedirectAttempt.ts
@@ -1,0 +1,56 @@
+const AUTH_REDIRECT_ATTEMPT_KEY = "clawhub.authRedirectAttempt";
+const AUTH_REDIRECT_ATTEMPT_TTL_MS = 10 * 60 * 1000;
+
+type AuthRedirectAttempt = {
+  provider: string;
+  redirectTo: string;
+  startedAt: number;
+};
+
+function getStorage() {
+  if (typeof window === "undefined") return null;
+  return window.sessionStorage;
+}
+
+export function markAuthRedirectAttempt(provider: string, redirectTo: string) {
+  try {
+    getStorage()?.setItem(
+      AUTH_REDIRECT_ATTEMPT_KEY,
+      JSON.stringify({ provider, redirectTo, startedAt: Date.now() } satisfies AuthRedirectAttempt),
+    );
+  } catch {
+    // Session storage is best-effort; auth should still proceed if unavailable.
+  }
+}
+
+export function clearAuthRedirectAttempt() {
+  try {
+    getStorage()?.removeItem(AUTH_REDIRECT_ATTEMPT_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+export function getActiveAuthRedirectAttempt() {
+  try {
+    const raw = getStorage()?.getItem(AUTH_REDIRECT_ATTEMPT_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<AuthRedirectAttempt>;
+    if (
+      typeof parsed.provider !== "string" ||
+      typeof parsed.redirectTo !== "string" ||
+      typeof parsed.startedAt !== "number"
+    ) {
+      clearAuthRedirectAttempt();
+      return null;
+    }
+    if (Date.now() - parsed.startedAt > AUTH_REDIRECT_ATTEMPT_TTL_MS) {
+      clearAuthRedirectAttempt();
+      return null;
+    }
+    return parsed as AuthRedirectAttempt;
+  } catch {
+    clearAuthRedirectAttempt();
+    return null;
+  }
+}

--- a/src/routes/cli/device.tsx
+++ b/src/routes/cli/device.tsx
@@ -14,9 +14,15 @@ export const Route = createFileRoute("/cli/device")({
   component: CliDeviceAuth,
 });
 
+function buildSignedOutRedirect(code: string) {
+  const trimmed = code.trim();
+  return trimmed ? `/cli/device?user_code=${encodeURIComponent(trimmed)}` : "/cli/device";
+}
+
 export function CliDeviceAuth() {
-  const search = Route.useSearch() as { code?: string };
-  const [code, setCode] = useState(search.code ?? "");
+  const search = Route.useSearch() as { code?: string; user_code?: string };
+  const initialCode = search.user_code ?? search.code ?? "";
+  const [code, setCode] = useState(initialCode);
   const [status, setStatus] = useState<string | null>(null);
   const { isAuthenticated, isLoading, me } = useAuthStatus();
   const approve = useMutation(api.cliDeviceAuth.approve);
@@ -62,7 +68,7 @@ export function CliDeviceAuth() {
                 <p className="text-sm text-[color:var(--ink-soft)]">
                   Sign in to authorize the CLI.
                 </p>
-                <SignInButton disabled={isLoading} />
+                <SignInButton redirectTo={buildSignedOutRedirect(code)} disabled={isLoading} />
               </>
             ) : (
               <>


### PR DESCRIPTION
## Summary
- Track browser OAuth redirect attempts before GitHub sign-in starts.
- Detect the return-to-app state where Convex redirects back without a client auth code, URL error, or session.
- Show an actionable auth diagnostic instead of leaving users on the generic sign-in screen.

## Evidence
A real ClawHub CLI auth attempt returned from GitHub through `/api/auth/callback/github` with HTTP 302, but the response `Location` was only `https://clawhub.ai/cli/auth?...` with no `code=` or `error=`. That leaves the client unable to complete token creation or explain the failure.

## Tests
- `bunx vitest run src/components/AppProviders.test.tsx src/components/SignInButton.test.tsx src/__tests__/header.test.tsx`
- `bun run lint`
- `bunx tsc --noEmit`
- `VITE_CONVEX_URL=https://example.invalid bun run build`