### PR TITLE
chore(release): prepare clawhub cli 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.17.0 - 2026-05-19
+
 - CLI/API: add self-serve org publisher creation with `clawhub publisher create <handle>` and scoped package publish errors that point to the command.
 
 ## 0.16.0 - 2026-05-18

--- a/packages/clawhub/package.json
+++ b/packages/clawhub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawhub",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "ClawHub CLI \\u2014 install, update, search, and publish skills plus OpenClaw packages.",
   "homepage": "https://clawhub.ai",
   "bugs": {


### PR DESCRIPTION
## Summary

Prepare the ClawHub CLI 0.17.0 release by bumping `packages/clawhub/package.json` and moving the current CLI/API org-publisher creation changelog note from Unreleased into a dated 0.17.0 section.

## Validation

- `RELEASE_TAG=v0.17.0 RELEASE_SHA=$(git rev-parse HEAD) RELEASE_MAIN_REF=origin/main node scripts/clawhub-cli-npm-release-check.mjs`
- `bun run --cwd packages/clawhub verify`
- `npm view clawhub@0.17.0 version` returns 404, confirming the version is not published yet
