### PR TITLE
fix: increase clawscan worker throughput

### DIFF
--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -4,9 +4,21 @@ on:
   workflow_dispatch:
     inputs:
       limit:
-        description: "Maximum Codex scans to claim"
+        description: "Deprecated alias for batch-limit"
+        required: false
+        default: ""
+      batch-limit:
+        description: "Maximum Codex scans to run in parallel per batch"
         required: true
-        default: "10"
+        default: "20"
+      max-jobs:
+        description: "Optional total jobs cap for this run"
+        required: false
+        default: ""
+      max-runtime-minutes:
+        description: "Stop claiming new batches after this many minutes"
+        required: true
+        default: "40"
   schedule:
     - cron: "*/10 * * * *"
 
@@ -20,13 +32,16 @@ permissions:
 jobs:
   codex-security-scan:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     environment: Production
     env:
       CONVEX_URL: ${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}
       SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      CODEX_SECURITY_SCAN_LIMIT: ${{ inputs.limit || '10' }}
+      CODEX_SECURITY_SCAN_LIMIT: ${{ inputs.limit || inputs['batch-limit'] || '20' }}
+      CODEX_SECURITY_SCAN_MAX_JOBS: ${{ inputs['max-jobs'] || '' }}
+      CODEX_SECURITY_SCAN_MAX_RUNTIME_MINUTES: ${{ inputs['max-runtime-minutes'] || '40' }}
+      CODEX_SECURITY_SCAN_LEASE_MINUTES: "60"
     steps:
       - uses: actions/checkout@v6
 
@@ -56,4 +71,9 @@ jobs:
         run: printf '%s' "$OPENAI_API_KEY" | codex login --with-api-key
 
       - name: Run Codex security worker
-        run: bun scripts/security/run-codex-scan-worker.ts --limit "$CODEX_SECURITY_SCAN_LIMIT"
+        run: |
+          bun scripts/security/run-codex-scan-worker.ts \
+            --batch-limit "$CODEX_SECURITY_SCAN_LIMIT" \
+            --max-jobs "$CODEX_SECURITY_SCAN_MAX_JOBS" \
+            --max-runtime-minutes "$CODEX_SECURITY_SCAN_MAX_RUNTIME_MINUTES" \
+            --lease-minutes "$CODEX_SECURITY_SCAN_LEASE_MINUTES"

--- a/convex/securityScan.ts
+++ b/convex/securityScan.ts
@@ -3,9 +3,9 @@ import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { action, internalMutation, internalQuery } from "./functions";
 
-const MAX_PARALLEL_CODEX_SCANS = 10;
+const MAX_PARALLEL_CODEX_SCANS = 20;
 const DEFAULT_VT_WAIT_MS = 10 * 60 * 1000;
-const DEFAULT_LEASE_MS = 30 * 60 * 1000;
+const DEFAULT_LEASE_MS = 60 * 60 * 1000;
 const MAX_ATTEMPTS = 3;
 const DEFAULT_CANCEL_SCAN_LIMIT = 1000;
 const DEFAULT_CANCEL_DELETE_LIMIT = 500;
@@ -521,6 +521,7 @@ export const claimCodexScanJobs = action({
     token: v.string(),
     workerId: v.string(),
     limit: v.optional(v.number()),
+    leaseMs: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     assertWorkerToken(args.token);
@@ -530,6 +531,7 @@ export const claimCodexScanJobs = action({
       {
         workerId: args.workerId,
         limit: normalizeLimit(args.limit),
+        leaseMs: args.leaseMs,
       },
     );
 

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -32,6 +32,11 @@ type ClaimedJob = {
   };
 };
 
+const DEFAULT_BATCH_LIMIT = 20;
+const DEFAULT_MAX_RUNTIME_MS = 40 * 60 * 1000;
+const DEFAULT_CODEX_SCAN_TIMEOUT_MS = 20 * 60 * 1000;
+const DEFAULT_LEASE_MS = 60 * 60 * 1000;
+
 const root = resolve(new URL("../..", import.meta.url).pathname);
 const schemaPath = join(root, "scripts/security/codex-scan-output.schema.json");
 const ARTIFACT_SIGNAL_FILE_EXTENSIONS = new Set([
@@ -59,8 +64,30 @@ function parseArgs() {
     const index = args.indexOf(name);
     return index === -1 ? undefined : args[index + 1];
   };
+  const numberFrom = (value: string | undefined, fallback: number) => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  };
+  const optionalNumberFrom = (value: string | undefined) => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+  };
   return {
-    limit: Number(get("--limit") ?? process.env.CODEX_SECURITY_SCAN_LIMIT ?? 10),
+    batchLimit: numberFrom(
+      get("--batch-limit") ?? get("--limit") ?? process.env.CODEX_SECURITY_SCAN_LIMIT,
+      DEFAULT_BATCH_LIMIT,
+    ),
+    maxJobs: optionalNumberFrom(get("--max-jobs") ?? process.env.CODEX_SECURITY_SCAN_MAX_JOBS),
+    maxRuntimeMs:
+      numberFrom(
+        get("--max-runtime-minutes") ?? process.env.CODEX_SECURITY_SCAN_MAX_RUNTIME_MINUTES,
+        DEFAULT_MAX_RUNTIME_MS / 60_000,
+      ) * 60_000,
+    leaseMs:
+      numberFrom(
+        get("--lease-minutes") ?? process.env.CODEX_SECURITY_SCAN_LEASE_MINUTES,
+        DEFAULT_LEASE_MS / 60_000,
+      ) * 60_000,
   };
 }
 
@@ -256,6 +283,11 @@ function verdictToStatus(verdict: string) {
   return verdict === "benign" ? "clean" : verdict;
 }
 
+function codexScanTimeoutMs() {
+  const parsed = Number(process.env.CODEX_SECURITY_SCAN_TIMEOUT_MS);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_CODEX_SCAN_TIMEOUT_MS;
+}
+
 async function runCodex(job: ClaimedJob, workspace: string) {
   const resultPath = join(workspace, "codex-result.json");
   const args = [
@@ -292,7 +324,7 @@ async function runCodex(job: ClaimedJob, workspace: string) {
   await runCommand("codex", args, {
     cwd: workspace,
     input: prompt,
-    timeoutMs: Number(process.env.CODEX_SECURITY_SCAN_TIMEOUT_MS ?? 20 * 60 * 1000),
+    timeoutMs: codexScanTimeoutMs(),
   });
 
   const raw = await readFile(resultPath, "utf8");
@@ -343,20 +375,45 @@ async function processJob(client: ConvexHttpClient, token: string, job: ClaimedJ
 }
 
 async function main() {
-  const { limit } = parseArgs();
+  const { batchLimit, maxJobs, maxRuntimeMs, leaseMs } = parseArgs();
   const convexUrl = process.env.CONVEX_URL ?? process.env.VITE_CONVEX_URL;
   if (!convexUrl) throw new Error("CONVEX_URL or VITE_CONVEX_URL is required");
   const token = requireEnv("SECURITY_SCAN_WORKER_TOKEN");
   const client = new ConvexHttpClient(convexUrl);
   const workerId = `github-actions:${process.env.GITHUB_RUN_ID ?? process.pid}`;
-  const jobs = (await client.action(api.securityScan.claimCodexScanJobs, {
-    token,
-    workerId,
-    limit,
-  })) as ClaimedJob[];
-  console.log(`claimed ${jobs.length} job(s)`);
-  const results = await Promise.all(jobs.map((job) => processJob(client, token, job)));
-  if (results.some((ok) => !ok)) {
+  const startedAt = Date.now();
+  const claimDeadline = startedAt + maxRuntimeMs;
+  let totalClaimed = 0;
+  let totalCompleted = 0;
+  let totalFailed = 0;
+
+  while (Date.now() < claimDeadline) {
+    const remainingJobs = maxJobs === undefined ? batchLimit : Math.max(0, maxJobs - totalClaimed);
+    if (remainingJobs === 0) break;
+    const claimLimit = Math.min(batchLimit, remainingJobs);
+    const jobs = (await client.action(api.securityScan.claimCodexScanJobs, {
+      token,
+      workerId,
+      limit: claimLimit,
+      leaseMs,
+    })) as ClaimedJob[];
+    console.log(`claimed ${jobs.length} job(s)`);
+    if (jobs.length === 0) break;
+
+    totalClaimed += jobs.length;
+    const results = await Promise.all(jobs.map((job) => processJob(client, token, job)));
+    totalCompleted += results.filter(Boolean).length;
+    totalFailed += results.filter((ok) => !ok).length;
+
+    if (jobs.length < claimLimit) break;
+  }
+
+  console.log(
+    `worker summary: claimed=${totalClaimed} completed=${totalCompleted} failed=${totalFailed} elapsedMs=${
+      Date.now() - startedAt
+    }`,
+  );
+  if (totalFailed > 0) {
     process.exitCode = 1;
   }
 }


### PR DESCRIPTION
## Summary

- Increase ClawScan worker batch throughput from 10 to 20 jobs per claim/run.
- Let scheduled/manual workers keep claiming batches for up to 40 minutes, with an optional total job cap.
- Extend backend leases to 60 minutes so long-running scans are not reclaimed mid-run.

## Verification

- `bun run format:check -- .github/workflows/security-scan-codex.yml convex/securityScan.ts scripts/security/run-codex-scan-worker.ts`
- `bunx vitest run convex/securityScan.test.ts`
- `actionlint .github/workflows/security-scan-codex.yml`
- Earlier before the clean rebase: `bunx tsc --noEmit --pretty false`, `bun run ci:static`
