### PR TITLE
docs: reconcile local dev worktree workflows

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,8 @@ For website/UI changes, attach screenshots or recordings from the real app. Incl
 
 ## Verification
 
-- [ ] `bun run format:check`
-- [ ] `bun run lint`
-- [ ] `bun run test`
+- [ ] `bun run ci:static`
+- [ ] Focused tests for touched behavior:
+- [ ] `bun run ci:unit` or `N/A` for docs/config-only:
+- [ ] Broader gate when required (`ci:types-build`, `ci:packages`, `ci:e2e-http`, `ci:playwright-smoke`, `test:pw:local-auth`, `proof:ui`):
 - [ ] Other:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,15 +18,24 @@
 
 ## Build, Test, and Development Commands
 
-- `bun run dev` — local app server at `http://localhost:3000`.
+Keep this section as the command map agents normally need, not a full `package.json` script index.
+
+- `bun run dev` — foreground local app server at `http://localhost:3000`.
+- `bunx convex dev --typecheck=disable` — local Convex backend/function watcher for manual setup.
+- `bunx convex codegen` — regenerate `convex/_generated` after Convex API/schema changes.
+- `bun run setup:worktree` — link `.env.local` and `.convex` from a usable source worktree into the current worktree. Use `-- --from <path>` or `CLAWHUB_WORKTREE_SOURCE=<path>` when auto-discovery picks the wrong source.
+- `bun run dev:worktree` — Worktrunk-managed detached worktree server. Requires `wt` on `PATH`; from that worktree use `wt --yes url` to print the branch URL and `wt --yes stop` to stop it.
+- `bun run seed:dev` — canonical local seed path; runs worktree setup, waits for local Convex, seeds local fixtures plus the public corpus, and refreshes stats.
 - `bun run build` — production build (Vite + Nitro).
-- `bun run preview` — preview built app.
-- `bunx convex dev` — Convex dev deployment + function watcher.
-- `bunx convex codegen` — regenerate `convex/_generated`.
-- `bun run format:check` — formatting check.
-- `bun run lint` — Biome + oxlint (type-aware).
-- `bun run test` — Vitest (unit tests).
-- `bun run coverage` — coverage run; keep global >= 80%.
+- `bun run ci:static` — required pre-handoff static gate: peer checks, audit, formatting, lint, and dead-code checks.
+- `bun run ci:unit` — Vitest coverage gate; required for source/test PRs unless docs/config-only.
+- `bun run ci:types-build` — full TypeScript/build gate for app, Convex, and packages.
+- `bun run ci:packages` — schema, CLI, and moderation package verification.
+- `bun run ci:e2e-http` — secretless HTTP and CLI e2e subset.
+- `bun run ci:playwright-smoke` — chromium smoke against the public read backend.
+- `bun run test:pw:local-auth` — local Convex/dev-auth browser gate for signed-in/write flows.
+
+Specialized corpus, scanner, security-worker, UI proof, proof publishing, Crabbox, docs-authoring, and dataset scripts are real maintenance tools, but they should stay in the relevant specs, skills, or package script lookup unless the task touches that subsystem.
 
 ## Coding Style & Naming Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Welcome! ClawHub is the public skill registry for [OpenClaw](https://github.com/
 
 - [Bun](https://bun.sh/) (Convex CLI runs via `bunx`, no global install needed)
 - [Node.js](https://nodejs.org/) v18, 20, 22, or 24 (required by the local Convex backend; v25+ is not yet supported)
+- [Worktrunk](https://github.com/max-sixty/worktrunk) (`wt`) for `bun run dev:worktree` and disposable/Codex worktrees. On macOS, `brew install worktrunk` is the quickest path; shell integration is optional.
 
 ### Install and configure
 
@@ -80,16 +81,49 @@ bun run dev -- --port 3000
 
 Change the port if 3000 is already in use, and update `SITE_URL` in both `.env.local` and the Convex backend (`bunx convex env set SITE_URL ...`) to match.
 
+### Worktree/Codex fast path
+
+Use this path for disposable branches, Codex sessions, or parallel worktrees after one source worktree already has a working `.env.local` and `.convex` local Convex setup:
+
+```bash
+bun run setup:worktree
+bun run dev:worktree
+wt --yes url
+wt --yes stop
+```
+
+`setup:worktree` finds a usable source worktree and symlinks `.env.local` plus `.convex` into the current checkout. If discovery picks the wrong source, pass one explicitly:
+
+```bash
+bun run setup:worktree -- --from /path/to/source/worktree
+CLAWHUB_WORKTREE_SOURCE=/path/to/source/worktree bun run setup:worktree
+```
+
+`dev:worktree` is the Worktrunk entrypoint. It runs the hooks in `.config/wt.toml`, copies ignored dependencies listed in `.worktreeinclude` when possible, falls back to `bun install` if Vite is missing, and starts detached services on a branch-hashed loopback port. Use `wt --yes url` from the same worktree to print the URL.
+
+The detached server writes runtime state under `.codex/runtime/`. Stop it with `wt --yes stop` before removing the worktree.
+
 ### Seed the database
 
 Populate local QA fixtures and the committed public corpus so the UI isn't empty:
 
 ```bash
-# local moderation/security fixtures
+bun run seed:dev
+```
+
+`seed:dev` runs worktree setup, starts or waits for local Convex, seeds the hand-authored local QA fixtures, imports the committed public corpus, and refreshes cached global stats. It is safe to rerun after fixture or schema changes.
+
+Lower-level seed commands are available for manual recovery or focused fixture work:
+
+```bash
+# local moderation/security fixtures only
 bunx convex run --no-push devSeed:seedLocalFixtures
 
-# real-ish public corpus rows under deterministic dummy accounts
+# committed public corpus only
 bun run seed:public-corpus
+
+# validate the committed public corpus fixture
+bun run validate:public-corpus
 
 # 50 extra skills for pagination testing (optional)
 bunx convex run --no-push devSeedExtra:seedExtraSkillsInternal
@@ -103,7 +137,21 @@ To reset and re-seed:
 ```bash
 bunx convex run --no-push devSeed:seedLocalFixtures '{"reset": true}'
 bun run seed:public-corpus -- --reset
+bunx convex run --no-push statsMaintenance:updateGlobalStatsAction
 ```
+
+Without `OPENAI_API_KEY`, public corpus import still works, but semantic search quality degrades because embeddings fall back to zero vectors.
+
+### Worktree troubleshooting
+
+- `wt: command not found`: install Worktrunk, then rerun `bun run dev:worktree`. Manual `bun run dev` plus `bunx convex dev --typecheck=disable` still works without Worktrunk.
+- Missing `.env.local` or `.convex`: run `bun run setup:worktree -- --from /path/to/source/worktree`. The source must contain `.env.local` and, for local Convex deployments, `.convex/local/default/config.json`.
+- Wrong local Convex deployment: make sure `CONVEX_DEPLOYMENT` in `.env.local` matches the local Convex deployment in `.convex/local/default/config.json` when using a `local:` deployment.
+- Port mismatch: local Convex normally serves cloud functions at `http://127.0.0.1:3210` and HTTP routes/auth callbacks at `http://127.0.0.1:3211`. Keep `VITE_CONVEX_URL`, `VITE_CONVEX_SITE_URL`, and `CONVEX_SITE_URL` aligned with the local config.
+- `wt step copy-ignored` reports that `.convex` cannot be copied: this can happen when `.convex` is a symlink to the source worktree. The Worktrunk hook continues; confirm `.env.local`, `.convex`, and `node_modules/.bin/vite` exist before debugging deeper.
+- Local Convex functions are not queryable yet during seeding: leave `bunx convex dev --typecheck=disable` running or rerun `bun run seed:dev`; the seed runner retries while Convex finishes pushing functions.
+- Local seeding hits a transient Convex write conflict: `seed:public-corpus` retries retryable batch conflicts. If retries are exhausted, stop other local writers and rerun `bun run seed:dev`.
+- Stale detached services: run `wt --yes stop`, then inspect `.codex/runtime/dev-worktree.log` if the server still does not restart cleanly.
 
 ### Optional environment variables
 
@@ -153,16 +201,16 @@ clawhub publish <path-to-skill-directory>
 
 ## Before Submitting a PR
 
-```bash
-bun run format:check # oxfmt
-bun run lint       # oxlint
-bun run deadcode:ci # Knip files/deps/exports
-bun run test       # Vitest (80% coverage threshold)
-bun run build      # Vite + Nitro
-bun run --cwd packages/clawhub verify
-```
+Run the narrowest meaningful check while iterating, then run the matching CI aliases before handoff:
 
-These are the same checks that run in CI (`.github/workflows/ci.yml`).
+- All PRs: `bun run ci:static`.
+- Source or test changes: focused tests for the touched behavior plus `bun run ci:unit` unless the change is docs/config-only or a maintainer asks to rely on CI.
+- App runtime, Convex, or build changes: `bun run ci:types-build`.
+- Package changes: `bun run ci:packages`.
+- HTTP/API/CLI integration changes: `bun run ci:e2e-http`.
+- Browser smoke or visual behavior changes: `bun run ci:playwright-smoke`, `bun run test:pw:local-auth`, and/or `bun run proof:ui` depending on the touched flow.
+
+`bun run ci:pr` is the local aggregate for the non-browser PR gates. See [`specs/ci.md`](specs/ci.md) for the full CI contract.
 
 ### Crabbox remote checks
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Details: [`docs/telemetry.md`](docs/telemetry.md).
 
 ## Local dev
 
-Prereqs: [Bun](https://bun.sh/) (Convex runs via `bunx`, no global install needed).
+Prereqs: [Bun](https://bun.sh/) (Convex runs via `bunx`, no global install needed). The detached worktree path also requires [Worktrunk](https://github.com/max-sixty/worktrunk) (`wt`).
 
 ```bash
 bun install
@@ -106,7 +106,9 @@ bunx convex dev
 bun run dev
 
 # detached/Codex worktree preview
+bun run setup:worktree
 bun run dev:worktree
+wt --yes url
 
 # seed local QA fixtures and the public corpus
 bun run seed:dev

--- a/scripts/dev-worktree.ts
+++ b/scripts/dev-worktree.ts
@@ -245,6 +245,11 @@ function stopManagedChildren() {
   }
 }
 
+function exitAfterStoppingManagedChildren(status: number): never {
+  stopManagedChildren();
+  process.exit(status);
+}
+
 function waitForExit(child: ChildProcess) {
   return new Promise<number>((resolve) => {
     child.once("exit", (code, signal) => {
@@ -354,10 +359,10 @@ async function main() {
       "--no-push",
       "devSeed:seedLocalFixtures",
     ]);
-    if (seedStatus !== 0) process.exit(seedStatus);
+    if (seedStatus !== 0) exitAfterStoppingManagedChildren(seedStatus);
 
     const publicCorpusStatus = runSync("bun", ["scripts/public-corpus/seed-public-corpus.ts"], {});
-    if (publicCorpusStatus !== 0) process.exit(publicCorpusStatus);
+    if (publicCorpusStatus !== 0) exitAfterStoppingManagedChildren(publicCorpusStatus);
 
     const statsStatus = await runConvexFunctionWhenReady([
       "convex",
@@ -365,7 +370,7 @@ async function main() {
       "--no-push",
       "statsMaintenance:updateGlobalStatsAction",
     ]);
-    if (statsStatus !== 0) process.exit(statsStatus);
+    if (statsStatus !== 0) exitAfterStoppingManagedChildren(statsStatus);
   }
 
   if (options.seedOnly) {

--- a/scripts/public-corpus/seed-public-corpus.test.ts
+++ b/scripts/public-corpus/seed-public-corpus.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  isRetryableConvexSeedBatchOutput,
+  runConvexSeedBatchWithRetry,
+  type SeedBatchRunOnce,
+} from "./seed-public-corpus";
+
+describe("public corpus seed runner", () => {
+  it("recognizes retryable Convex write conflicts", () => {
+    expect(
+      isRetryableConvexSeedBatchOutput(
+        "Uncaught Error: Data read or written in this mutation changed while it was being run.",
+      ),
+    ).toBe(true);
+    expect(isRetryableConvexSeedBatchOutput("AUTH_GITHUB_ID is required")).toBe(false);
+  });
+
+  it("retries retryable batch conflicts before succeeding", async () => {
+    const runOnce: SeedBatchRunOnce = vi
+      .fn()
+      .mockReturnValueOnce({
+        status: 1,
+        output:
+          "Uncaught Error: Data read or written in this mutation changed while it was being run.",
+      })
+      .mockReturnValueOnce({ status: 0, output: '{"ok":true}' });
+    const sleep = vi.fn(async () => undefined);
+    const log = vi.fn();
+
+    await expect(
+      runConvexSeedBatchWithRetry(
+        { rows: [] },
+        { runOnce, sleep, maxAttempts: 3, retryDelayMs: () => 0, log },
+      ),
+    ).resolves.toBe(0);
+
+    expect(runOnce).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith(
+      "Convex seed batch hit a retryable write conflict; retrying (2/3).",
+    );
+  });
+
+  it("does not retry non-conflict failures", async () => {
+    const runOnce: SeedBatchRunOnce = vi
+      .fn()
+      .mockReturnValue({ status: 1, output: "AUTH_GITHUB_ID is required" });
+
+    await expect(
+      runConvexSeedBatchWithRetry({ rows: [] }, { runOnce, maxAttempts: 3 }),
+    ).resolves.toBe(1);
+
+    expect(runOnce).toHaveBeenCalledTimes(1);
+  });
+});

--- a/scripts/public-corpus/seed-public-corpus.ts
+++ b/scripts/public-corpus/seed-public-corpus.ts
@@ -21,6 +21,15 @@ type SeedCorpusRow = PublicCorpusRow & {
 };
 
 const DEFAULT_BATCH_BYTES = 96_000;
+const MAX_SEED_BATCH_ATTEMPTS = 4;
+const BASE_SEED_BATCH_RETRY_DELAY_MS = 500;
+
+export type SeedBatchRunResult = {
+  status: number;
+  output: string;
+};
+
+export type SeedBatchRunOnce = (args: unknown) => SeedBatchRunResult;
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
@@ -48,7 +57,7 @@ async function main() {
       resetOwnerHandles: options.reset ? owners.map((owner) => owner.handle) : [],
       rows: batch,
     };
-    const status = runConvexSeedBatch(args);
+    const status = await runConvexSeedBatchWithRetry(args);
     if (status !== 0) process.exit(status);
     console.log(
       `Seeded public corpus batch ${index + 1}/${batches.length} (${batch.length} rows).`,
@@ -133,17 +142,70 @@ function corpusKey(row: PublicCorpusRow) {
   return row.kind === "skill" ? `skill:${row.slug}` : `plugin:${row.name}`;
 }
 
-function runConvexSeedBatch(args: unknown) {
+function sleep(ms: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function retryDelayMs(attempt: number) {
+  return BASE_SEED_BATCH_RETRY_DELAY_MS * 2 ** (attempt - 1);
+}
+
+function writeCommandOutput(output: string) {
+  if (output) process.stdout.write(output);
+}
+
+export function isRetryableConvexSeedBatchOutput(output: string) {
+  return output.includes("Data read or written in this mutation changed while it was being run");
+}
+
+export function runConvexSeedBatchOnce(args: unknown): SeedBatchRunResult {
   const result = spawnSync(
     "bunx",
     ["convex", "run", "--no-push", "devSeed:seedPublicCorpusBatch", JSON.stringify(args)],
     {
       cwd: process.cwd(),
       encoding: "utf8",
-      stdio: "inherit",
     },
   );
-  return result.status ?? 1;
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}${
+    result.error ? `${result.error.message}\n` : ""
+  }`;
+  writeCommandOutput(output);
+  return { status: result.status ?? 1, output };
+}
+
+export async function runConvexSeedBatchWithRetry(
+  args: unknown,
+  options: {
+    runOnce?: SeedBatchRunOnce;
+    sleep?: (ms: number) => Promise<void>;
+    maxAttempts?: number;
+    retryDelayMs?: (attempt: number) => number;
+    log?: (message: string) => void;
+  } = {},
+) {
+  const runOnce = options.runOnce ?? runConvexSeedBatchOnce;
+  const sleepFn = options.sleep ?? sleep;
+  const maxAttempts = Math.max(1, options.maxAttempts ?? MAX_SEED_BATCH_ATTEMPTS);
+  const delayMs = options.retryDelayMs ?? retryDelayMs;
+  const log = options.log ?? console.warn;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const result = runOnce(args);
+    if (result.status === 0) return 0;
+    if (!isRetryableConvexSeedBatchOutput(result.output) || attempt >= maxAttempts) {
+      return result.status;
+    }
+
+    log(
+      `Convex seed batch hit a retryable write conflict; retrying (${attempt + 1}/${maxAttempts}).`,
+    );
+    await sleepFn(delayMs(attempt));
+  }
+
+  return 1;
 }
 
 function readValue(args: string[], index: number, flag: string) {
@@ -159,7 +221,9 @@ function readPositiveInt(value: string, flag: string) {
   return parsed;
 }
 
-main().catch((error: unknown) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  process.exit(1);
-});
+if (import.meta.main) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/specs/README.md
+++ b/specs/README.md
@@ -24,6 +24,8 @@ into `docs/` and leave only the design record here.
 - `slug-routing.md`: internal web route precedence and plugin alias contract.
 - `ci.md`: PR check and production deploy audit-tag policy.
 - `manual-testing.md`: maintainer CLI smoke checklist.
+- `dev-worktrees.md`: disposable Worktrunk/Codex worktree lifecycle contract.
+- `dev-seeding.md`: local development fixture seeding ownership rules.
 - `mintlify.md`: docs publishing setup notes.
 - `openclaw-docs-extraction.md`: CLAW-89 extraction classification.
 - `deploy.md`: maintainer deploy checklist for the ClawHub project.

--- a/specs/dev-seeding.md
+++ b/specs/dev-seeding.md
@@ -11,7 +11,11 @@ read_when:
 Local fixture seeding is command-driven by default:
 
 - CLI seeding (`bun run seed:dev`) populates shared catalog fixtures under `@local`, including
-  skill, plugin, scanner, and moderation fixtures. This is the documented local setup path.
+  skill, plugin, scanner, and moderation fixtures. It also imports the committed public corpus and
+  refreshes cached global stats. This is the documented local setup path.
+- `bun run seed:public-corpus` is the lower-level corpus-only import command. Use it for corpus
+  fixture work, not as the default local setup command.
+- `bun run validate:public-corpus` validates the committed public corpus fixture without seeding.
 - `internal.devSeed.seedCurrentUserFixtures` remains a dev-only internal action for explicit local
   development tools/tests that need fixtures cloned to a local user.
 
@@ -23,3 +27,7 @@ stable per-user seed key so multiple developers can use the same dev deployment 
 Current-user fixture seeding is dev-only. It must reject production Convex deployments, and it
 should not be exposed as a first-run dashboard button unless the UX and ownership rules are
 intentionally revisited.
+
+Without `OPENAI_API_KEY`, public corpus import may use zero vectors. That is
+acceptable for local setup and layout QA, but semantic search quality will be weaker than an
+embedding-backed local database.

--- a/specs/dev-worktrees.md
+++ b/specs/dev-worktrees.md
@@ -1,0 +1,70 @@
+---
+summary: "Disposable Worktrunk/Codex worktree lifecycle contract."
+read_when:
+  - Editing worktree setup or dev scripts
+  - Changing .config/wt.toml or .worktreeinclude
+  - Updating contributor setup for local Convex
+---
+
+# Dev Worktrees
+
+Disposable worktrees are the preferred local shape for Codex sessions, parallel PR work, and short-lived branches. The Worktrunk-managed path is intentionally separate from the plain manual path:
+
+- Manual path: `bunx convex dev --typecheck=disable` plus `bun run dev`.
+- Worktree path: `bun run setup:worktree`, `bun run dev:worktree`, `wt --yes url`, and `wt --yes stop`.
+
+## Source Of Truth
+
+The source of truth for the worktree lifecycle is:
+
+- `package.json` scripts for public entrypoints.
+- `.config/wt.toml` for Worktrunk hooks, branch-hashed URLs, detached startup, and stop cleanup.
+- `.worktreeinclude` for ignored assets Worktrunk should copy when possible.
+- `scripts/setup-worktree.ts` for ignored local state discovery and symlinking.
+- `scripts/dev-worktree.ts` for detached app startup, local Convex reachability, and seeding.
+
+`.codex/environments/environment.toml` is Codex app configuration. It can expose convenient actions, but it is not the source of truth for the developer workflow. Update it only when the corresponding package script or worktree contract changes.
+
+## Environment Contract
+
+`setup:worktree` must link `.env.local` and `.convex` from a coherent source worktree into the current worktree. A source is coherent when it has `.env.local` and, for `local:` Convex deployments, a matching `.convex/local/default/config.json`.
+
+When auto-discovery picks the wrong source, contributors should pass an explicit source:
+
+```bash
+bun run setup:worktree -- --from /path/to/source/worktree
+CLAWHUB_WORKTREE_SOURCE=/path/to/source/worktree bun run setup:worktree
+```
+
+The setup helper validates common local Convex mistakes before linking:
+
+- missing `CONVEX_DEPLOYMENT`
+- local deployment name mismatch
+- `VITE_CONVEX_URL` port mismatch
+- `VITE_CONVEX_SITE_URL` or `CONVEX_SITE_URL` missing or pointing at the wrong local site port
+
+## Worktrunk Contract
+
+`bun run dev:worktree` requires the `wt` executable on `PATH`. The current repo contract treats Worktrunk as mandatory for the detached worktree path and keeps the non-Worktrunk fallback as the manual path.
+
+Worktrunk runs the configured pre-start hooks before starting the detached server:
+
+```text
+bun run setup:worktree -- --quiet
+wt step copy-ignored || true; test -x node_modules/.bin/vite || bun install
+```
+
+The copy step is best effort. If `.convex` is already a symlink to the source worktree, Worktrunk may report that it refused to copy `.convex` outside the destination worktree. That is acceptable as long as `setup:worktree` linked `.convex` and `.env.local`, and dependencies are present.
+
+## Runtime Contract
+
+`scripts/dev-worktree.ts` loads `.env.local`, checks `VITE_CONVEX_URL`, starts local Convex if it is not reachable, then starts Vite on the requested port. Detached runtime state lives under `.codex/runtime/`:
+
+- `.codex/runtime/dev-worktree.pid`
+- `.codex/runtime/dev-worktree.log`
+
+Use `wt --yes stop` before removing or recreating a worktree. If a stale pid blocks startup, stop the service and inspect the runtime log before deleting files by hand.
+
+## Seeding Contract
+
+`bun run seed:dev` uses the same worktree setup helper and the same local Convex readiness checks as the detached dev server. It must remain the documented default seed command. Lower-level Convex calls and `seed:public-corpus` are recovery or fixture-authoring tools, not the first-run path.


### PR DESCRIPTION
## Summary

Closes #2325.

This updates the local development docs so the current Worktrunk/worktree and seeding workflow is documented where contributors and agents are likely to look, while keeping specialized maintenance commands out of the main agent command map.

Changes included:

- Updates `AGENTS.md` with a curated command map for the normal agent workflow: local dev, Convex/codegen, worktree setup, `seed:dev`, build, CI, and local-auth browser checks.
- Expands `CONTRIBUTING.md` and `README.md` with the Worktrunk worktree path, `seed:dev` as the default local seed command, and troubleshooting for local Convex / `.env.local` / `.convex` setup.
- Adds `specs/dev-worktrees.md` and updates `specs/dev-seeding.md` so the workflow intent is preserved outside of contributor-facing docs.
- Updates the PR template verification checklist to use the current `ci:*` gates.
- Hardens the tested flow by retrying transient Convex public-corpus seed conflicts and stopping managed child processes when seed-only exits early on failure.

## Notes for reviewers

`AGENTS.md` is intentionally a curated command map rather than a full `package.json` script index. Specialized corpus, scanner, security-worker, UI proof, proof publishing, Crabbox, docs-authoring, and dataset workflows are left to the relevant specs, skills, or package script lookup when a task touches that subsystem.

`bun run seed:dev` is documented as the default local setup path. `bun run seed:public-corpus` and `bun run validate:public-corpus` remain documented as focused corpus/recovery commands.

Worktrunk is documented as required for detached worktree previews. The plain manual dev path remains `bunx convex dev --typecheck=disable` plus `bun run dev`.

## Verification

- `git diff --check`
- `bun run validate:public-corpus`
- `bunx vitest run scripts/public-corpus/seed-public-corpus.test.ts scripts/public-corpus/validate.test.ts scripts/dev-worktree.test.ts`
- Worktree smoke: `setup:worktree`, `dev:worktree`, `wt --yes url`, local URL returned 200, `wt --yes stop`
- `bun run seed:dev`
- `bun run format:check`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- Additional review pass: no actionable findings
