### PR TITLE
fix(clawhub): continue sync after slug conflicts

### DIFF
--- a/e2e/clawhub.e2e.test.ts
+++ b/e2e/clawhub.e2e.test.ts
@@ -1,7 +1,9 @@
 /* @vitest-environment node */
 
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer, type IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -30,6 +32,47 @@ import {
 const itIfLiveMutations = allowLiveMutations() ? it : it.skip;
 const itIfAdminAndUserTokens =
   (getAdminToken() && getUserToken()) || shouldSeedRoleHelpTokens() ? it : it.skip;
+
+async function readRequestBody(req: IncomingMessage) {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function spawnCommand(
+  command: string,
+  args: string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv },
+) {
+  return await new Promise<{
+    status: number | null;
+    signal: NodeJS.Signals | null;
+    stdout: string;
+    stderr: string;
+  }>((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (status, signal) => {
+      resolve({ status, signal, stdout, stderr });
+    });
+  });
+}
 
 describe("clawhub e2e", () => {
   it("prints CLI version via --cli-version", async () => {
@@ -231,6 +274,91 @@ describe("clawhub e2e", () => {
       expect(result.stdout).toMatch(/Dry run/i);
     } finally {
       await rm(root, { recursive: true, force: true });
+      await rm(cfg.dir, { recursive: true, force: true });
+    }
+  });
+
+  it("sync continues after a per-skill publish failure", async () => {
+    const publishedSlugs: string[] = [];
+    const server = createServer(async (req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (req.method === "GET" && url.pathname === ApiRoutes.whoami) {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ user: { handle: "tester" } }));
+        return;
+      }
+      if (req.method === "GET" && url.pathname === ApiRoutes.resolve) {
+        res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+        res.end("Skill not found");
+        return;
+      }
+      if (req.method === "POST" && url.pathname === ApiRoutes.skills) {
+        const body = await readRequestBody(req);
+        const slug = body.includes('"slug":"failed-skill"') ? "failed-skill" : "successful-skill";
+        publishedSlugs.push(slug);
+        if (slug === "failed-skill") {
+          res.writeHead(409, { "Content-Type": "text/plain; charset=utf-8" });
+          res.end("Registry rejected failed-skill");
+          return;
+        }
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: true, skillId: "skill-successful", versionId: "version-1" }));
+        return;
+      }
+      res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("not found");
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+
+    const registry = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+    const cfg = await makeTempConfig(registry, "test-token");
+    const root = await mkdtemp(join(tmpdir(), "clawhub-e2e-sync-publish-"));
+    const workdir = await mkdtemp(join(tmpdir(), "clawhub-e2e-sync-workdir-"));
+    const stateDir = await mkdtemp(join(tmpdir(), "clawhub-e2e-sync-state-"));
+    try {
+      for (const slug of ["failed-skill", "successful-skill"]) {
+        const skillDir = join(root, slug);
+        await mkdir(skillDir, { recursive: true });
+        await writeFile(join(skillDir, "SKILL.md"), `# ${slug}\n`, "utf8");
+      }
+
+      const result = await spawnCommand(
+        "bun",
+        [
+          "clawhub",
+          "sync",
+          "--all",
+          "--root",
+          root,
+          "--workdir",
+          workdir,
+          "--site",
+          registry,
+          "--registry",
+          registry,
+        ],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...process.env,
+            CLAWHUB_CONFIG_PATH: cfg.path,
+            CLAWHUB_DISABLE_TELEMETRY: "1",
+            CLAWDBOT_STATE_DIR: stateDir,
+            OPENCLAW_STATE_DIR: stateDir,
+          },
+        },
+      );
+
+      expect(result.status).toBe(1);
+      expect(publishedSlugs).toEqual(["failed-skill", "successful-skill"]);
+      expect(result.stdout).toMatch(/Failed to upload/);
+      expect(result.stdout).toMatch(/failed-skill: Registry rejected failed-skill/);
+      expect(result.stdout).toMatch(/Uploaded 1 of 2 skill\(s\)\. 1 failed\./);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await rm(root, { recursive: true, force: true });
+      await rm(workdir, { recursive: true, force: true });
+      await rm(stateDir, { recursive: true, force: true });
       await rm(cfg.dir, { recursive: true, force: true });
     }
   });

--- a/packages/clawhub/src/cli/commands/sync.test.ts
+++ b/packages/clawhub/src/cli/commands/sync.test.ts
@@ -302,7 +302,7 @@ describe("cmdSync", () => {
     expect(update.changelog).toBe("");
   });
 
-  it("continues uploading after a slug conflict publish failure", async () => {
+  it("continues uploading after a publish failure", async () => {
     interactive = false;
     mockApiRequest.mockImplementation(async (_registry: string, args: { path: string }) => {
       if (args.path === "/api/v1/whoami") return { user: { handle: "steipete" } };
@@ -325,9 +325,7 @@ describe("cmdSync", () => {
     mockCmdPublish.mockImplementation(async (_opts, _folder, options?: unknown) => {
       const { slug } = options as { slug: string };
       if (slug === "new-skill") {
-        throw new Error(
-          "Slug is already taken. Choose a different slug. Existing skill: /TheSethRose/agent-browser",
-        );
+        throw new Error("Registry rejected upload");
       }
     });
 
@@ -342,7 +340,7 @@ describe("cmdSync", () => {
     const output = mockLog.mock.calls.map((call) => String(call[0])).join("\n");
     expect(output).toMatch(/Failed to upload/);
     expect(output).toMatch(/new-skill/);
-    expect(output).toMatch(/Existing skill: \/TheSethRose\/agent-browser/);
+    expect(output).toMatch(/Registry rejected upload/);
 
     const outro = mockOutro.mock.calls.at(-1)?.[0];
     expect(String(outro)).toMatch(/Uploaded 1 of 2 skill\(s\). 1 failed/);
@@ -442,7 +440,7 @@ describe("cmdSync", () => {
     expect(process.exitCode).toBe(1);
   });
 
-  it("does not swallow unrelated publish failures", async () => {
+  it("records unrelated publish failures as per-skill failures", async () => {
     interactive = false;
     mockApiRequest.mockImplementation(async (_registry: string, args: { path: string }) => {
       if (args.path === "/api/v1/whoami") return { user: { handle: "steipete" } };
@@ -464,11 +462,48 @@ describe("cmdSync", () => {
     });
     mockCmdPublish.mockRejectedValueOnce(new Error("HTTP 500"));
 
-    await expect(
-      cmdSync(makeOpts(), { root: ["/scan"], all: true, dryRun: false, bump: "patch" }, true),
-    ).rejects.toThrow("HTTP 500");
+    await cmdSync(makeOpts(), { root: ["/scan"], all: true, dryRun: false, bump: "patch" }, true);
 
-    expect(mockCmdPublish).toHaveBeenCalledTimes(1);
+    expect(mockCmdPublish).toHaveBeenCalledTimes(2);
+    expect(mockCmdPublish.mock.calls.map((call) => (call[2] as { slug: string }).slug)).toEqual([
+      "new-skill",
+      "update-skill",
+    ]);
+
+    const output = mockLog.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(output).toMatch(/Failed to upload/);
+    expect(output).toMatch(/new-skill: HTTP 500/);
+
+    const outro = mockOutro.mock.calls.at(-1)?.[0];
+    expect(String(outro)).toMatch(/Uploaded 1 of 2 skill\(s\). 1 failed/);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("aborts command-level failures before publishing", async () => {
+    interactive = false;
+    const { findSkillFolders } = await import("../scanSkills.js");
+    mocked(findSkillFolders).mockImplementation(async (root: string) => {
+      if (!root.endsWith("/scan")) return [];
+      return [{ folder: "/scan/update-skill", slug: "update-skill", displayName: "Update Skill" }];
+    });
+    mockApiRequest.mockImplementation(async (_registry: string, args: { path: string }) => {
+      if (args.path === "/api/v1/whoami") return { user: { handle: "steipete" } };
+      if (args.path === "/api/cli/telemetry/sync") return { ok: true };
+      if (args.path.startsWith("/api/v1/resolve?")) {
+        return { match: null, latestVersion: { version: "1.0.0" } };
+      }
+      throw new Error(`Unexpected apiRequest: ${args.path}`);
+    });
+
+    await expect(
+      cmdSync(
+        makeOpts(),
+        { root: ["/scan"], all: true, dryRun: false, bump: "not-semver" as never },
+        true,
+      ),
+    ).rejects.toThrow("Could not bump version for update-skill");
+
+    expect(mockCmdPublish).not.toHaveBeenCalled();
   });
 
   it("skips telemetry when CLAWHUB_DISABLE_TELEMETRY is set", async () => {

--- a/packages/clawhub/src/cli/commands/sync.test.ts
+++ b/packages/clawhub/src/cli/commands/sync.test.ts
@@ -107,6 +107,8 @@ function makeOpts() {
 
 afterEach(async () => {
   vi.clearAllMocks();
+  mockCmdPublish.mockReset();
+  process.exitCode = undefined;
   const { findSkillFolders } = await import("../scanSkills.js");
   mocked(findSkillFolders).mockImplementation(defaultFindSkillFolders);
 });
@@ -298,6 +300,129 @@ describe("cmdSync", () => {
     const update = calls.find((c) => c.slug === "update-skill");
     if (!update) throw new Error("Missing update-skill publish");
     expect(update.changelog).toBe("");
+  });
+
+  it("continues uploading after a slug conflict publish failure", async () => {
+    interactive = false;
+    mockApiRequest.mockImplementation(async (_registry: string, args: { path: string }) => {
+      if (args.path === "/api/v1/whoami") return { user: { handle: "steipete" } };
+      if (args.path === "/api/cli/telemetry/sync") return { ok: true };
+      if (args.path.startsWith("/api/v1/resolve?")) {
+        const u = new URL(`https://x.test${args.path}`);
+        const slug = u.searchParams.get("slug");
+        if (slug === "new-skill") {
+          throw new Error("Skill not found");
+        }
+        if (slug === "synced-skill") {
+          return { match: { version: "1.2.3" }, latestVersion: { version: "1.2.3" } };
+        }
+        if (slug === "update-skill") {
+          return { match: null, latestVersion: { version: "1.0.0" } };
+        }
+      }
+      throw new Error(`Unexpected apiRequest: ${args.path}`);
+    });
+    mockCmdPublish.mockImplementation(async (_opts, _folder, options?: unknown) => {
+      const { slug } = options as { slug: string };
+      if (slug === "new-skill") {
+        throw new Error(
+          "Slug is already taken. Choose a different slug. Existing skill: /TheSethRose/agent-browser",
+        );
+      }
+    });
+
+    await cmdSync(makeOpts(), { root: ["/scan"], all: true, dryRun: false, bump: "patch" }, true);
+
+    expect(mockCmdPublish).toHaveBeenCalledTimes(2);
+    expect(mockCmdPublish.mock.calls.map((call) => (call[2] as { slug: string }).slug)).toEqual([
+      "new-skill",
+      "update-skill",
+    ]);
+
+    const output = mockLog.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(output).toMatch(/Failed to upload/);
+    expect(output).toMatch(/new-skill/);
+    expect(output).toMatch(/Existing skill: \/TheSethRose\/agent-browser/);
+
+    const outro = mockOutro.mock.calls.at(-1)?.[0];
+    expect(String(outro)).toMatch(/Uploaded 1 of 2 skill\(s\). 1 failed/);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("continues uploading after an alias slug conflict publish failure", async () => {
+    interactive = false;
+    mockApiRequest.mockImplementation(async (_registry: string, args: { path: string }) => {
+      if (args.path === "/api/v1/whoami") return { user: { handle: "steipete" } };
+      if (args.path === "/api/cli/telemetry/sync") return { ok: true };
+      if (args.path.startsWith("/api/v1/resolve?")) {
+        const u = new URL(`https://x.test${args.path}`);
+        const slug = u.searchParams.get("slug");
+        if (slug === "new-skill") {
+          throw new Error("Skill not found");
+        }
+        if (slug === "synced-skill") {
+          return { match: { version: "1.2.3" }, latestVersion: { version: "1.2.3" } };
+        }
+        if (slug === "update-skill") {
+          return { match: null, latestVersion: { version: "1.0.0" } };
+        }
+      }
+      throw new Error(`Unexpected apiRequest: ${args.path}`);
+    });
+    mockCmdPublish.mockImplementation(async (_opts, _folder, options?: unknown) => {
+      const { slug } = options as { slug: string };
+      if (slug === "new-skill") {
+        throw new Error(
+          "Slug redirects to an existing skill. Choose a different slug. Existing skill: /alice/demo",
+        );
+      }
+    });
+
+    await cmdSync(makeOpts(), { root: ["/scan"], all: true, dryRun: false, bump: "patch" }, true);
+
+    expect(mockCmdPublish).toHaveBeenCalledTimes(2);
+    expect(mockCmdPublish.mock.calls.map((call) => (call[2] as { slug: string }).slug)).toEqual([
+      "new-skill",
+      "update-skill",
+    ]);
+
+    const output = mockLog.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(output).toMatch(/Failed to upload/);
+    expect(output).toMatch(/Slug redirects to an existing skill/);
+    expect(output).toMatch(/Existing skill: \/alice\/demo/);
+
+    const outro = mockOutro.mock.calls.at(-1)?.[0];
+    expect(String(outro)).toMatch(/Uploaded 1 of 2 skill\(s\). 1 failed/);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("does not swallow unrelated publish failures", async () => {
+    interactive = false;
+    mockApiRequest.mockImplementation(async (_registry: string, args: { path: string }) => {
+      if (args.path === "/api/v1/whoami") return { user: { handle: "steipete" } };
+      if (args.path === "/api/cli/telemetry/sync") return { ok: true };
+      if (args.path.startsWith("/api/v1/resolve?")) {
+        const u = new URL(`https://x.test${args.path}`);
+        const slug = u.searchParams.get("slug");
+        if (slug === "new-skill") {
+          throw new Error("Skill not found");
+        }
+        if (slug === "synced-skill") {
+          return { match: { version: "1.2.3" }, latestVersion: { version: "1.2.3" } };
+        }
+        if (slug === "update-skill") {
+          return { match: null, latestVersion: { version: "1.0.0" } };
+        }
+      }
+      throw new Error(`Unexpected apiRequest: ${args.path}`);
+    });
+    mockCmdPublish.mockRejectedValueOnce(new Error("HTTP 500"));
+
+    await expect(
+      cmdSync(makeOpts(), { root: ["/scan"], all: true, dryRun: false, bump: "patch" }, true),
+    ).rejects.toThrow("HTTP 500");
+
+    expect(mockCmdPublish).toHaveBeenCalledTimes(1);
   });
 
   it("skips telemetry when CLAWHUB_DISABLE_TELEMETRY is set", async () => {

--- a/packages/clawhub/src/cli/commands/sync.test.ts
+++ b/packages/clawhub/src/cli/commands/sync.test.ts
@@ -396,6 +396,52 @@ describe("cmdSync", () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it("continues uploading after a locked slug publish failure", async () => {
+    interactive = false;
+    mockApiRequest.mockImplementation(async (_registry: string, args: { path: string }) => {
+      if (args.path === "/api/v1/whoami") return { user: { handle: "steipete" } };
+      if (args.path === "/api/cli/telemetry/sync") return { ok: true };
+      if (args.path.startsWith("/api/v1/resolve?")) {
+        const u = new URL(`https://x.test${args.path}`);
+        const slug = u.searchParams.get("slug");
+        if (slug === "new-skill") {
+          throw new Error("Skill not found");
+        }
+        if (slug === "synced-skill") {
+          return { match: { version: "1.2.3" }, latestVersion: { version: "1.2.3" } };
+        }
+        if (slug === "update-skill") {
+          return { match: null, latestVersion: { version: "1.0.0" } };
+        }
+      }
+      throw new Error(`Unexpected apiRequest: ${args.path}`);
+    });
+    mockCmdPublish.mockImplementation(async (_opts, _folder, options?: unknown) => {
+      const { slug } = options as { slug: string };
+      if (slug === "new-skill") {
+        throw new Error(
+          "This slug is locked to a deleted or banned account. If you believe you are the rightful owner, please contact security@openclaw.ai to reclaim it.",
+        );
+      }
+    });
+
+    await cmdSync(makeOpts(), { root: ["/scan"], all: true, dryRun: false, bump: "patch" }, true);
+
+    expect(mockCmdPublish).toHaveBeenCalledTimes(2);
+    expect(mockCmdPublish.mock.calls.map((call) => (call[2] as { slug: string }).slug)).toEqual([
+      "new-skill",
+      "update-skill",
+    ]);
+
+    const output = mockLog.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(output).toMatch(/Failed to upload/);
+    expect(output).toMatch(/This slug is locked to a deleted or banned account/);
+
+    const outro = mockOutro.mock.calls.at(-1)?.[0];
+    expect(String(outro)).toMatch(/Uploaded 1 of 2 skill\(s\). 1 failed/);
+    expect(process.exitCode).toBe(1);
+  });
+
   it("does not swallow unrelated publish failures", async () => {
     interactive = false;
     mockApiRequest.mockImplementation(async (_registry: string, args: { path: string }) => {

--- a/packages/clawhub/src/cli/commands/sync.ts
+++ b/packages/clawhub/src/cli/commands/sync.ts
@@ -28,12 +28,6 @@ import {
 } from "./syncHelpers.js";
 import type { Candidate, LocalSkill, SyncOptions } from "./syncTypes.js";
 
-const RECOVERABLE_SLUG_CONFLICT_MESSAGES = [
-  "Slug is already taken. Choose a different slug.",
-  "Slug redirects to an existing skill. Choose a different slug.",
-  "This slug is locked to a deleted or banned account.",
-] as const;
-
 export async function cmdSync(opts: GlobalOpts, options: SyncOptions, inputAllowed: boolean) {
   const allowPrompt = isInteractive() && inputAllowed !== false;
   intro("ClawHub sync");
@@ -199,9 +193,7 @@ export async function cmdSync(opts: GlobalOpts, options: SyncOptions, inputAllow
       });
       uploaded += 1;
     } catch (error) {
-      const conflictMessage = getSlugConflictMessage(error);
-      if (!conflictMessage) throw error;
-      failedUploads.push({ slug: skill.slug, message: conflictMessage });
+      failedUploads.push({ slug: skill.slug, message: formatError(error) });
     }
   }
 
@@ -223,11 +215,4 @@ export async function cmdSync(opts: GlobalOpts, options: SyncOptions, inputAllow
 
 function normalizeRegistry(value: string) {
   return value.trim().replace(/\/+$/, "").toLowerCase();
-}
-
-function getSlugConflictMessage(error: unknown) {
-  const message = formatError(error);
-  return RECOVERABLE_SLUG_CONFLICT_MESSAGES.some((conflict) => message.includes(conflict))
-    ? message
-    : null;
 }

--- a/packages/clawhub/src/cli/commands/sync.ts
+++ b/packages/clawhub/src/cli/commands/sync.ts
@@ -31,6 +31,7 @@ import type { Candidate, LocalSkill, SyncOptions } from "./syncTypes.js";
 const RECOVERABLE_SLUG_CONFLICT_MESSAGES = [
   "Slug is already taken. Choose a different slug.",
   "Slug redirects to an existing skill. Choose a different slug.",
+  "This slug is locked to a deleted or banned account.",
 ] as const;
 
 export async function cmdSync(opts: GlobalOpts, options: SyncOptions, inputAllowed: boolean) {

--- a/packages/clawhub/src/cli/commands/sync.ts
+++ b/packages/clawhub/src/cli/commands/sync.ts
@@ -28,6 +28,11 @@ import {
 } from "./syncHelpers.js";
 import type { Candidate, LocalSkill, SyncOptions } from "./syncTypes.js";
 
+const RECOVERABLE_SLUG_CONFLICT_MESSAGES = [
+  "Slug is already taken. Choose a different slug.",
+  "Slug redirects to an existing skill. Choose a different slug.",
+] as const;
+
 export async function cmdSync(opts: GlobalOpts, options: SyncOptions, inputAllowed: boolean) {
   const allowPrompt = isInteractive() && inputAllowed !== false;
   intro("ClawHub sync");
@@ -167,6 +172,8 @@ export async function cmdSync(opts: GlobalOpts, options: SyncOptions, inputAllow
   }
 
   const tags = options.tags ?? "latest";
+  const failedUploads: Array<{ slug: string; message: string }> = [];
+  let uploaded = 0;
 
   for (const skill of selected) {
     const { publishVersion, changelog } = await resolvePublishMeta(skill, {
@@ -180,14 +187,34 @@ export async function cmdSync(opts: GlobalOpts, options: SyncOptions, inputAllow
           ? `${skill.origin.slug}@${skill.origin.installedVersion}`
           : undefined
         : undefined;
-    await cmdPublish(opts, skill.folder, {
-      slug: skill.slug,
-      name: skill.displayName,
-      version: publishVersion,
-      changelog,
-      tags,
-      forkOf,
-    });
+    try {
+      await cmdPublish(opts, skill.folder, {
+        slug: skill.slug,
+        name: skill.displayName,
+        version: publishVersion,
+        changelog,
+        tags,
+        forkOf,
+      });
+      uploaded += 1;
+    } catch (error) {
+      const conflictMessage = getSlugConflictMessage(error);
+      if (!conflictMessage) throw error;
+      failedUploads.push({ slug: skill.slug, message: conflictMessage });
+    }
+  }
+
+  if (failedUploads.length > 0) {
+    printSection(
+      "Failed to upload",
+      formatBulletList(
+        failedUploads.map((failure) => `${failure.slug}: ${failure.message}`),
+        20,
+      ),
+    );
+    outro(`Uploaded ${uploaded} of ${selected.length} skill(s). ${failedUploads.length} failed.`);
+    process.exitCode = 1;
+    return;
   }
 
   outro(`Uploaded ${selected.length} skill(s).`);
@@ -195,4 +222,11 @@ export async function cmdSync(opts: GlobalOpts, options: SyncOptions, inputAllow
 
 function normalizeRegistry(value: string) {
   return value.trim().replace(/\/+$/, "").toLowerCase();
+}
+
+function getSlugConflictMessage(error: unknown) {
+  const message = formatError(error);
+  return RECOVERABLE_SLUG_CONFLICT_MESSAGES.some((conflict) => message.includes(conflict))
+    ? message
+    : null;
 }


### PR DESCRIPTION
## Summary
- catch known slug-conflict publish failures per selected skill during `clawhub sync`
- continue uploading later selected skills after recoverable direct, alias, and locked-owner slug conflicts
- report partial success with a non-zero exit code while preserving unrelated publish failures
- add regression coverage for direct, alias, locked deleted/banned owner, and unrelated publish failure cases

Fixes #868

## Behavior proof
The focused sync regression suite exercises the partial-failure behavior after the fix:

- `continues uploading after a slug conflict publish failure` asserts sync tries `new-skill` and then `update-skill`, prints `Failed to upload`, reports `Uploaded 1 of 2 skill(s). 1 failed.`, and sets `process.exitCode = 1`.
- `continues uploading after an alias slug conflict publish failure` covers the alias redirect collision message.
- `continues uploading after a locked slug publish failure` covers the backend deleted/banned owner message: `This slug is locked to a deleted or banned account...`.
- `does not swallow unrelated publish failures` verifies non-slug publish errors still throw instead of being downgraded.

Focused terminal proof after the latest fix:

```text
$ ../../node_modules/.bin/vitest run -c vitest.config.ts src/cli/commands/sync.test.ts --reporter verbose -t "continues uploading after|does not swallow unrelated publish failures"

✓ src/cli/commands/sync.test.ts > cmdSync > continues uploading after a slug conflict publish failure
✓ src/cli/commands/sync.test.ts > cmdSync > continues uploading after an alias slug conflict publish failure
✓ src/cli/commands/sync.test.ts > cmdSync > continues uploading after a locked slug publish failure
✓ src/cli/commands/sync.test.ts > cmdSync > does not swallow unrelated publish failures

Test Files  1 passed (1)
Tests       4 passed | 7 skipped (11)
```

## Validation
- `bun run test:src src/cli/commands/sync.test.ts`
- `bun run verify:build`
- `bun run format:check`
- `bun run lint`
- `git diff --check origin/main...HEAD`

Validation output highlights:

```text
Test Files  1 passed (1)
Tests       11 passed (11)
All matched files use the correct format.
Found 0 warnings and 0 errors.
```