### PR TITLE
fix(clawhub): cap embedding text by bytes

### DIFF
--- a/convex/lib/skills.test.ts
+++ b/convex/lib/skills.test.ts
@@ -184,6 +184,29 @@ describe("skills utils", () => {
     expect(text.length).toBe(10);
   });
 
+  it("truncates embedding text by maxChars without splitting surrogate pairs", () => {
+    const text = buildEmbeddingText({
+      frontmatter: {},
+      readme: "\u{1f4a1}\u{1f4a1}x",
+      otherFiles: [],
+      maxChars: 1,
+      maxBytes: 100,
+    });
+    expect(text).toBe("\u{1f4a1}");
+  });
+
+  it("truncates embedding text by maxBytes", () => {
+    const text = buildEmbeddingText({
+      frontmatter: {},
+      readme: "\u20ac".repeat(20),
+      otherFiles: [],
+      maxChars: 100,
+      maxBytes: 9,
+    });
+    expect(new TextEncoder().encode(text).byteLength).toBeLessThanOrEqual(9);
+    expect(text).toBe("\u20ac\u20ac\u20ac");
+  });
+
   it("truncates embedding text by default max chars", () => {
     const text = buildEmbeddingText({
       frontmatter: {},
@@ -191,6 +214,25 @@ describe("skills utils", () => {
       otherFiles: [],
     });
     expect(text.length).toBeLessThanOrEqual(12_000);
+  });
+
+  it("keeps default embedding text below the OpenAI token-limit byte budget", () => {
+    const text = buildEmbeddingText({
+      frontmatter: { name: "Dense bundle", description: "Publishes scripts" },
+      readme: "a".repeat(3_090),
+      otherFiles: [
+        { path: "references/FLOW.md", content: "f".repeat(6_663) },
+        { path: "references/DOCTOR.md", content: "d".repeat(5_843) },
+        { path: "references/terms-of-service.md", content: "t".repeat(5_510) },
+        { path: "scripts/auth.py", content: "b".repeat(9_559) },
+        { path: "scripts/bind.py", content: "c".repeat(13_217) },
+        { path: "scripts/diag_auth_log.py", content: "l".repeat(4_917) },
+        { path: "scripts/diag_bind_log.py", content: "m".repeat(4_933) },
+        { path: "scripts/init.sh", content: "i".repeat(3_660) },
+        { path: "scripts/qrcode.sh", content: "q".repeat(3_020) },
+      ],
+    });
+    expect(new TextEncoder().encode(text).byteLength).toBeLessThanOrEqual(7_500);
   });
 
   it("hashes skill files deterministically", async () => {

--- a/convex/lib/skills.ts
+++ b/convex/lib/skills.ts
@@ -15,6 +15,11 @@ export type { ClawdisSkillMetadata, SkillInstallSpec };
 
 const FRONTMATTER_START = "---";
 const DEFAULT_EMBEDDING_MAX_CHARS = 12_000;
+// Each OpenAI token maps to at least one UTF-8 byte; keep publish embeddings
+// below the 8192-token model limit with conservative headroom.
+const DEFAULT_EMBEDDING_MAX_BYTES = 7_500;
+
+const encoder = new TextEncoder();
 
 export function parseFrontmatter(content: string): ParsedSkillFrontmatter {
   const frontmatter: ParsedSkillFrontmatter = {};
@@ -184,8 +189,15 @@ export function buildEmbeddingText(params: {
   readme: string;
   otherFiles: Array<{ path: string; content: string }>;
   maxChars?: number;
+  maxBytes?: number;
 }) {
-  const { frontmatter, readme, otherFiles, maxChars = DEFAULT_EMBEDDING_MAX_CHARS } = params;
+  const {
+    frontmatter,
+    readme,
+    otherFiles,
+    maxChars = DEFAULT_EMBEDDING_MAX_CHARS,
+    maxBytes = DEFAULT_EMBEDDING_MAX_BYTES,
+  } = params;
   const headerParts = [
     getFrontmatterValue(frontmatter, "name"),
     getFrontmatterValue(frontmatter, "description"),
@@ -196,11 +208,9 @@ export function buildEmbeddingText(params: {
   ].filter(Boolean);
   const fileParts = otherFiles.map((file) => `# ${file.path}\n${file.content}`);
   const raw = [headerParts.join("\n"), readme, ...fileParts].filter(Boolean).join("\n\n");
-  if (raw.length <= maxChars) return raw;
-  return raw.slice(0, maxChars);
+  const charLimited = truncateCodePoints(raw, maxChars);
+  return truncateUtf8Bytes(charLimited, maxBytes);
 }
-
-const encoder = new TextEncoder();
 
 export async function hashSkillFiles(files: Array<{ path: string; sha256: string }>) {
   const normalized = files
@@ -210,6 +220,49 @@ export async function hashSkillFiles(files: Array<{ path: string; sha256: string
   const payload = normalized.map((file) => `${file.path}:${file.sha256}`).join("\n");
   const digest = await crypto.subtle.digest("SHA-256", encoder.encode(payload));
   return toHex(new Uint8Array(digest));
+}
+
+function truncateCodePoints(text: string, maxChars: number) {
+  if (maxChars <= 0) return "";
+  if (text.length <= maxChars) return text;
+
+  let count = 0;
+  let end = 0;
+  for (const char of text) {
+    if (count >= maxChars) break;
+    end += char.length;
+    count += 1;
+  }
+  return end >= text.length ? text : text.slice(0, end);
+}
+
+function truncateUtf8Bytes(text: string, maxBytes: number) {
+  if (maxBytes <= 0) return "";
+  if (encoder.encode(text).byteLength <= maxBytes) return text;
+
+  const codePointEnds: number[] = [];
+  let end = 0;
+  for (const char of text) {
+    end += char.length;
+    codePointEnds.push(end);
+  }
+
+  let low = 0;
+  let high = codePointEnds.length;
+  let bestEnd = 0;
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const candidateEnd = mid === 0 ? 0 : codePointEnds[mid - 1];
+    const candidateBytes = encoder.encode(text.slice(0, candidateEnd)).byteLength;
+    if (candidateBytes <= maxBytes) {
+      bestEnd = candidateEnd;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  return text.slice(0, bestEnd);
 }
 
 function toJsonValue(value: unknown): unknown {


### PR DESCRIPTION
## Summary
- cap publish embedding input with a conservative UTF-8 byte budget before calling the embedding provider
- keep the existing character cap, then truncate on code-point/byte boundaries so multibyte text is not split
- add regression coverage for byte-limited truncation, surrogate-pair-safe truncation, and a dense publish bundle shaped like the reported failure

Fixes #2314

## Validation
- `bun run test -- convex/lib/skills.test.ts convex/lib/embeddings.test.ts convex/lib/skillPublish.test.ts` - 3 files passed, 42 tests
- `bun run ci:unit` - 208 files passed, 2061 tests
- `bun run ci:static` - passed
- `bun run ci:types-build` - passed
- `git diff --check origin/main...HEAD` - passed