### PR TITLE
fix: show VT undetected fallback as pass

### DIFF
--- a/src/components/DetailSecuritySummary.test.tsx
+++ b/src/components/DetailSecuritySummary.test.tsx
@@ -219,6 +219,35 @@ describe("DetailSecuritySummary", () => {
     expect(screen.queryByText("Warn")).toBeNull();
   });
 
+  it("renders VirusTotal undetected-only fallback as pass", () => {
+    render(
+      <DetailSecuritySummary
+        scannerBasePath="/plugins/@opik/opik-openclaw/security"
+        vtAnalysis={{
+          status: "clean",
+          verdict: "undetected-only-fallback",
+          analysis:
+            "VirusTotal reported no malicious or suspicious engine hits. ClawHub promoted this source-linked package after clean LLM and clean static scans.",
+          source: "engines-undetected-fallback",
+          checkedAt: 1,
+        }}
+        llmAnalysis={{ status: "clean", checkedAt: 1 }}
+        staticScan={{
+          status: "clean",
+          reasonCodes: [],
+          findings: [],
+          summary: "Clean.",
+          engineVersion: "v1",
+          checkedAt: 1,
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "VirusTotal: Pass" })).toBeTruthy();
+    expect(screen.getAllByText("Pass")).toHaveLength(4);
+    expect(screen.queryByText("undetected-only-fallback")).toBeNull();
+  });
+
   it("shows static suspicious as review without rolling it up to suspicious", () => {
     render(
       <DetailSecuritySummary

--- a/src/components/SkillSecurityScanResults.test.tsx
+++ b/src/components/SkillSecurityScanResults.test.tsx
@@ -565,6 +565,38 @@ describe("SecurityScanResults static guidance", () => {
     expect(screen.queryByText(/No VirusTotal analysis has been recorded/i)).toBeNull();
   });
 
+  it("renders VirusTotal undetected-only fallback as pass", () => {
+    render(
+      <SecurityScannerPage
+        scanner="virustotal"
+        entity={{
+          kind: "plugin",
+          title: "Opik",
+          name: "@opik/opik-openclaw",
+          version: "0.2.14",
+          detailPath: "/plugins/@opik/opik-openclaw",
+        }}
+        sha256hash="abc123"
+        vtAnalysis={{
+          status: "clean",
+          verdict: "undetected-only-fallback",
+          analysis:
+            "VirusTotal reported no malicious or suspicious engine hits. ClawHub promoted this source-linked package after clean LLM and clean static scans.",
+          source: "engines-undetected-fallback",
+          checkedAt: Date.now(),
+        }}
+        llmAnalysis={clawScanAnalysis}
+      />,
+    );
+
+    expect(screen.getByText(/Audited by VirusTotal/i)).toBeTruthy();
+    expect(screen.getByText("Pass")).toBeTruthy();
+    expect(
+      screen.getByText(/VirusTotal reported no malicious or suspicious engine hits/i),
+    ).toBeTruthy();
+    expect(screen.queryByText("undetected-only-fallback")).toBeNull();
+  });
+
   it("treats legacy non-engine VirusTotal text as neutral and hidden", () => {
     render(
       <SecurityScannerPage

--- a/src/components/SkillSecurityScanResults.tsx
+++ b/src/components/SkillSecurityScanResults.tsx
@@ -137,6 +137,7 @@ export function getScanStatusInfo(status: string) {
   switch (status.toLowerCase()) {
     case "benign":
     case "clean":
+    case "undetected-only-fallback":
       return { label: "Pass", className: "scan-status-clean", badgeVariant: "success" };
     case "cleared":
       return { label: "Cleared", className: "scan-status-clean", badgeVariant: "success" };
@@ -253,6 +254,7 @@ export function getVirusTotalDisplayStatus(analysis?: VtAnalysis | null) {
   }
 
   if (hasNonEngineVirusTotalSource(analysis)) return "benign";
+  if (analysis?.verdict === "undetected-only-fallback") return "benign";
 
   return analysis?.verdict ?? analysis?.status ?? "pending";
 }


### PR DESCRIPTION
## Summary
- Render VirusTotal `undetected-only-fallback` as the normal green `Pass` state in security UI
- Add regressions for the compact audit row and VirusTotal scanner detail page so the raw fallback enum does not leak again

## Tests
- `bun run test src/components/DetailSecuritySummary.test.tsx src/components/SkillSecurityScanResults.test.tsx`
- `bun run format:check -- src/components/SkillSecurityScanResults.tsx src/components/DetailSecuritySummary.test.tsx src/components/SkillSecurityScanResults.test.tsx`
- `bun run ci:static`
- `bun run ci:unit`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local`
