### PR TITLE
ci: add mobile skill detail deploy smoke

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -205,6 +205,10 @@ jobs:
         if: needs.validate-deploy-request.outputs.run_smoke == 'true' && needs.validate-deploy-request.outputs.deploy_frontend == 'true'
         run: bunx playwright test --workers=1 e2e/menu-smoke.pw.test.ts e2e/publish-entry-workflows.pw.test.ts e2e/upload-auth-smoke.pw.test.ts
 
+      - name: Smoke test production mobile skill detail
+        if: needs.validate-deploy-request.outputs.run_smoke == 'true' && needs.validate-deploy-request.outputs.deploy_frontend == 'true'
+        run: bunx playwright test --workers=1 --project=mobile-safari e2e/mobile-skills.pw.test.ts
+
       - name: Tag production frontend deployment
         if: needs.validate-deploy-request.outputs.deploy_frontend == 'true'
         env:

--- a/specs/ci.md
+++ b/specs/ci.md
@@ -74,6 +74,7 @@ Production-only checks stay in the manual deploy workflow:
 - `bun run verify:convex-contract -- --prod`
 - `bun run test:e2e:prod-http`
 - production Playwright smoke tests
+- production mobile WebKit skill-detail smoke tests
 
 Successful `full` and `frontend` production deploys create two annotated Git
 tags:


### PR DESCRIPTION
## Summary
- add production deploy smoke coverage for mobile Safari skill detail pages
- document the mobile WebKit skill-detail smoke in the CI/deploy spec

## Validation
- `bun run format:check .github/workflows/deploy.yml specs/ci.md`
- `ruby -e 'require "psych"; Psych.load_file(".github/workflows/deploy.yml"); puts "deploy.yml parses"'`
- `git diff --check`

Note: `actionlint` is not available in the local repo/toolchain; YAML parse and formatting passed.
