### PR TITLE
Restore skill rescan command for moderators

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -2956,23 +2956,73 @@ describe("httpApiV1 handlers", () => {
     );
   });
 
-  it("does not expose the removed skill rescan route", async () => {
+  it("skill rescan enqueues moderator ClawScan jobs", async () => {
     vi.mocked(requireApiTokenUser).mockResolvedValue({
-      userId: "users:1",
-      user: { handle: "p" },
+      userId: "users:moderator",
+      user: { _id: "users:moderator", role: "moderator" },
     } as never);
-    const runMutation = vi.fn(async () => okRate());
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      return {
+        ok: true,
+        slug: "demo",
+        version: "1.0.0",
+        skillId: "skills:1",
+        skillVersionId: "skillVersions:1",
+        jobId: "securityScanJobs:1",
+        alreadyQueued: false,
+      };
+    });
 
     const response = await __handlers.skillsPostRouterV1Handler(
       makeCtx({ runMutation }),
       new Request("https://example.com/api/v1/skills/demo/rescan", {
         method: "POST",
         headers: { Authorization: "Bearer clh_test" },
+        body: JSON.stringify({ version: "1.0.0" }),
       }),
     );
 
-    expect(response.status).toBe(404);
-    expect(runMutation.mock.calls.length).toBe(1);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      slug: "demo",
+      version: "1.0.0",
+      jobId: "securityScanJobs:1",
+    });
+    expect(runMutation).toHaveBeenCalledWith(
+      (internal as unknown as { securityScan: Record<string, unknown> }).securityScan
+        .enqueueSkillRescanForModeratorInternal,
+      {
+        actorUserId: "users:moderator",
+        slug: "demo",
+        version: "1.0.0",
+      },
+    );
+  });
+
+  it("skill rescan rejects malformed JSON", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:moderator",
+      user: { _id: "users:moderator", role: "moderator" },
+    } as never);
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      throw new Error("should not enqueue");
+    });
+
+    const response = await __handlers.skillsPostRouterV1Handler(
+      makeCtx({ runMutation }),
+      new Request("https://example.com/api/v1/skills/demo/rescan", {
+        method: "POST",
+        headers: { Authorization: "Bearer clh_test" },
+        body: "{",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.text()).resolves.toBe("Invalid JSON");
+    expect(runMutation).toHaveBeenCalledTimes(1);
   });
 
   it("does not expose the removed package rescan route", async () => {

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -254,6 +254,9 @@ type SkillSecuritySnapshot = {
 };
 
 const internalRefs = internal as unknown as {
+  securityScan: {
+    enqueueSkillRescanForModeratorInternal: unknown;
+  };
   skills: {
     reportSkillForUserInternal: unknown;
     listSkillReportsInternal: unknown;
@@ -1444,6 +1447,29 @@ export async function skillsPostRouterV1Handler(ctx: ActionCtx, request: Request
     }
   }
 
+  if (segments.length === 2 && action === "rescan") {
+    if (!slug) return text("Slug required", 400, rate.headers);
+    const auth = await requireApiTokenUserOrResponse(ctx, request, rate.headers);
+    if (!auth.ok) return auth.response;
+    try {
+      const body = await readOptionalJson(request);
+      const version = optionalStringField(body, "version");
+      const result = await runMutationRef(
+        ctx,
+        internalRefs.securityScan.enqueueSkillRescanForModeratorInternal,
+        {
+          actorUserId: auth.userId,
+          slug,
+          ...(version ? { version } : {}),
+        },
+      );
+      return json(result, 200, rate.headers);
+    } catch (error) {
+      if (error instanceof SyntaxError) return text("Invalid JSON", 400, rate.headers);
+      return skillRescanErrorToResponse(error, rate.headers);
+    }
+  }
+
   if (segments.length === 2 && action === "undelete") {
     try {
       const { userId } = await requireApiTokenUser(ctx, request);
@@ -1476,6 +1502,19 @@ export async function skillsPostRouterV1Handler(ctx: ActionCtx, request: Request
   }
 
   return text("Not found", 404, rate.headers);
+}
+
+function skillRescanErrorToResponse(error: unknown, headers: HeadersInit) {
+  const message = error instanceof Error ? error.message : "Skill rescan failed";
+  const lower = message.toLowerCase();
+  if (lower.includes("unauthorized")) {
+    return text(formatAuthzMessage(error, "Unauthorized"), 401, headers);
+  }
+  if (lower.includes("forbidden")) {
+    return text(formatAuthzMessage(error, "Forbidden"), 403, headers);
+  }
+  if (lower.includes("not found")) return text(message, 404, headers);
+  return text(message, 400, headers);
 }
 
 export async function skillsDeleteRouterV1Handler(ctx: ActionCtx, request: Request) {

--- a/convex/securityScan.ts
+++ b/convex/securityScan.ts
@@ -1,7 +1,9 @@
 import { ConvexError, v } from "convex/values";
 import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
+import type { MutationCtx } from "./_generated/server";
 import { action, internalMutation, internalQuery } from "./functions";
+import { assertModerator } from "./lib/access";
 
 const MAX_PARALLEL_CODEX_SCANS = 20;
 const DEFAULT_VT_WAIT_MS = 10 * 60 * 1000;
@@ -32,6 +34,13 @@ const jobSourceValidator = v.union(
   v.literal("backfill"),
   v.literal("manual"),
 );
+
+type EnqueueSkillVersionScanArgs = {
+  versionId: Id<"skillVersions">;
+  source: "publish" | "clawscan-note" | "vt-update" | "backfill" | "manual";
+  priority?: number;
+  waitForVtMs?: number;
+};
 
 const llmAgenticRiskEvidenceValidator = v.object({
   path: v.string(),
@@ -176,46 +185,117 @@ export const enqueueSkillVersionScanInternal = internalMutation({
     waitForVtMs: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const version = await ctx.db.get(args.versionId);
-    if (!version || version.softDeletedAt) return { ok: true as const, skipped: "missing" };
-    const now = Date.now();
-    const waitForVtUntil = now + Math.max(0, args.waitForVtMs ?? DEFAULT_VT_WAIT_MS);
-    const nextRunAt = args.waitForVtMs === 0 || version.vtAnalysis ? now : waitForVtUntil;
-    const hasMaliciousSignal = version.staticScan?.status === "malicious";
-
-    const existing = await ctx.db
-      .query("securityScanJobs")
-      .withIndex("by_skill_version", (q) => q.eq("skillVersionId", args.versionId))
-      .collect();
-    const active = existing.find((job) => job.status === "queued" || job.status === "running");
-    if (active) {
-      await ctx.db.patch(active._id, {
-        source: args.source,
-        priority: Math.max(active.priority, args.priority ?? 0),
-        hasMaliciousSignal: active.hasMaliciousSignal || hasMaliciousSignal,
-        waitForVtUntil: Math.min(active.waitForVtUntil, waitForVtUntil),
-        nextRunAt: Math.min(active.nextRunAt, nextRunAt),
-        updatedAt: now,
-      });
-      return { ok: true as const, jobId: active._id };
-    }
-
-    const jobId = await ctx.db.insert("securityScanJobs", {
-      targetKind: "skillVersion",
-      skillVersionId: args.versionId,
-      status: "queued",
-      source: args.source,
-      priority: args.priority ?? (hasMaliciousSignal ? 100 : 0),
-      hasMaliciousSignal,
-      waitForVtUntil,
-      nextRunAt,
-      attempts: 0,
-      createdAt: now,
-      updatedAt: now,
-    });
-    return { ok: true as const, jobId };
+    return enqueueSkillVersionScan(ctx, args);
   },
 });
+
+export const enqueueSkillRescanForModeratorInternal = internalMutation({
+  args: {
+    actorUserId: v.id("users"),
+    slug: v.string(),
+    version: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const actor = await ctx.db.get(args.actorUserId);
+    if (!actor) throw new ConvexError("Unauthorized");
+    assertModerator(actor);
+
+    const slug = args.slug.trim().toLowerCase();
+    if (!slug) throw new ConvexError("Slug required");
+    const skill = await ctx.db
+      .query("skills")
+      .withIndex("by_slug", (q) => q.eq("slug", slug))
+      .unique();
+    if (!skill || skill.softDeletedAt) throw new ConvexError("Skill not found");
+
+    const requestedVersion = args.version?.trim();
+    const version = requestedVersion
+      ? await ctx.db
+          .query("skillVersions")
+          .withIndex("by_skill_version", (q) =>
+            q.eq("skillId", skill._id).eq("version", requestedVersion),
+          )
+          .unique()
+      : skill.latestVersionId
+        ? await ctx.db.get(skill.latestVersionId)
+        : null;
+    if (!version || version.softDeletedAt) throw new ConvexError("Skill version not found");
+
+    const queued = await enqueueSkillVersionScan(ctx, {
+      versionId: version._id,
+      source: "manual",
+      priority: 100,
+      waitForVtMs: 0,
+    });
+    if (!queued.jobId) throw new ConvexError("Skill version not found");
+
+    await ctx.db.insert("auditLogs", {
+      actorUserId: actor._id,
+      action: "skill.clawscan.rescan",
+      targetType: "skillVersion",
+      targetId: version._id,
+      metadata: {
+        skillId: skill._id,
+        slug: skill.slug,
+        version: version.version,
+        jobId: queued.jobId,
+        alreadyQueued: queued.alreadyQueued === true,
+      },
+      createdAt: Date.now(),
+    });
+
+    return {
+      ok: true as const,
+      slug: skill.slug,
+      version: version.version,
+      skillId: skill._id,
+      skillVersionId: version._id,
+      jobId: queued.jobId,
+      alreadyQueued: queued.alreadyQueued === true,
+    };
+  },
+});
+
+async function enqueueSkillVersionScan(ctx: MutationCtx, args: EnqueueSkillVersionScanArgs) {
+  const version = await ctx.db.get(args.versionId);
+  if (!version || version.softDeletedAt) return { ok: true as const, skipped: "missing" as const };
+  const now = Date.now();
+  const waitForVtUntil = now + Math.max(0, args.waitForVtMs ?? DEFAULT_VT_WAIT_MS);
+  const nextRunAt = args.waitForVtMs === 0 || version.vtAnalysis ? now : waitForVtUntil;
+  const hasMaliciousSignal = version.staticScan?.status === "malicious";
+
+  const existing = await ctx.db
+    .query("securityScanJobs")
+    .withIndex("by_skill_version", (q) => q.eq("skillVersionId", args.versionId))
+    .collect();
+  const active = existing.find((job) => job.status === "queued" || job.status === "running");
+  if (active) {
+    await ctx.db.patch(active._id, {
+      source: args.source,
+      priority: Math.max(active.priority, args.priority ?? 0),
+      hasMaliciousSignal: active.hasMaliciousSignal || hasMaliciousSignal,
+      waitForVtUntil: Math.min(active.waitForVtUntil, waitForVtUntil),
+      nextRunAt: Math.min(active.nextRunAt, nextRunAt),
+      updatedAt: now,
+    });
+    return { ok: true as const, jobId: active._id, alreadyQueued: true as const };
+  }
+
+  const jobId = await ctx.db.insert("securityScanJobs", {
+    targetKind: "skillVersion",
+    skillVersionId: args.versionId,
+    status: "queued",
+    source: args.source,
+    priority: args.priority ?? (hasMaliciousSignal ? 100 : 0),
+    hasMaliciousSignal,
+    waitForVtUntil,
+    nextRunAt,
+    attempts: 0,
+    createdAt: now,
+    updatedAt: now,
+  });
+  return { ok: true as const, jobId, alreadyQueued: false as const };
+}
 
 export const enqueuePackageReleaseScanInternal = internalMutation({
   args: {

--- a/packages/clawhub-mod/README.md
+++ b/packages/clawhub-mod/README.md
@@ -101,11 +101,11 @@ Package moderation and operations:
 
 ```bash
 bun run mod -- skills reports [--status open|confirmed|dismissed|all]
+bun run mod -- skills rescan <slug> [--version <version>] [--yes] [--json]
 bun run mod -- skills unhide <slug> --reason <text> [--yes]
 bun run mod -- skills triage-report <report-id> --status open|confirmed|dismissed [--note <text>] [--action none|hide] [--yes]
 
 bun run mod -- plugins moderate <name> --version <version> --state approved|quarantined|revoked --reason <text>
-bun run mod -- plugins rescan <name> [--yes]
 bun run mod -- plugins status <name>
 bun run mod -- plugins queue [--status open|blocked|manual|all]
 bun run mod -- plugins reports [--status open|confirmed|dismissed|all]

--- a/packages/clawhub-mod/src/cli.ts
+++ b/packages/clawhub-mod/src/cli.ts
@@ -26,6 +26,7 @@ import {
   cmdBanUser,
   cmdReclassifyBan,
   cmdRemediateAutobans,
+  cmdRescanSkill,
   cmdSetRole,
   cmdUnbanUser,
 } from "./commands/moderation.js";
@@ -528,6 +529,18 @@ function registerSkillModerationCommands(command: Command) {
       }
       const opts = await resolveGlobalOpts();
       await cmdUnhideSkill(opts, slug, options, isInputAllowed());
+    });
+
+  command
+    .command("rescan")
+    .description("Queue a moderator ClawScan rescan for a skill")
+    .argument("<slug>", "Skill slug")
+    .option("--version <version>", "Specific skill version; defaults to latest")
+    .option("--yes", "Skip confirmation")
+    .option("--json", "Output JSON")
+    .action(async (slug, options) => {
+      const opts = await resolveGlobalOpts();
+      await cmdRescanSkill(opts, slug, options, isInputAllowed());
     });
 
   command

--- a/packages/clawhub-mod/src/commands/moderation.test.ts
+++ b/packages/clawhub-mod/src/commands/moderation.test.ts
@@ -19,8 +19,14 @@ vi.mock("../../../clawhub/src/cli/registry.js", () => registryMocks.moduleFactor
 vi.mock("../../../clawhub/src/http.js", () => httpMocks.moduleFactory());
 vi.mock("../../../clawhub/src/cli/ui.js", () => uiMocks.moduleFactory());
 
-const { cmdBanUser, cmdReclassifyBan, cmdRemediateAutobans, cmdSetRole, cmdUnbanUser } =
-  await import("./moderation");
+const {
+  cmdBanUser,
+  cmdReclassifyBan,
+  cmdRemediateAutobans,
+  cmdRescanSkill,
+  cmdSetRole,
+  cmdUnbanUser,
+} = await import("./moderation");
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -150,6 +156,44 @@ describe("cmdBanUser", () => {
     await expect(
       cmdBanUser(makeGlobalOpts(), "moonshine", { yes: true, fuzzy: true }, false),
     ).rejects.toThrow(/multiple users matched/i);
+  });
+});
+
+describe("cmdRescanSkill", () => {
+  it("requires --yes when input is disabled", async () => {
+    await expect(cmdRescanSkill(makeGlobalOpts(), "demo", {}, false)).rejects.toThrow(/--yes/i);
+    expect(httpMocks.apiRequest).not.toHaveBeenCalled();
+  });
+
+  it("posts a moderator skill rescan request", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      ok: true,
+      slug: "markdown2doc",
+      version: "1.0.4",
+      skillId: "skills:1",
+      skillVersionId: "skillVersions:1",
+      jobId: "securityScanJobs:1",
+      alreadyQueued: false,
+    });
+
+    const result = await cmdRescanSkill(
+      makeGlobalOpts(),
+      "Markdown2Doc",
+      { yes: true, version: "1.0.4" },
+      false,
+    );
+
+    expect(result).toMatchObject({ ok: true, slug: "markdown2doc", version: "1.0.4" });
+    expect(httpMocks.apiRequest).toHaveBeenCalledWith(
+      "https://clawhub.ai",
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/v1/skills/markdown2doc/rescan",
+        token: "tkn",
+        body: { version: "1.0.4" },
+      }),
+      expect.anything(),
+    );
   });
 });
 

--- a/packages/clawhub-mod/src/commands/moderation.ts
+++ b/packages/clawhub-mod/src/commands/moderation.ts
@@ -16,6 +16,7 @@ import {
   ApiV1ReclassifyBanResponseSchema,
   ApiV1RemediateAutobansResponseSchema,
   ApiV1SetRoleResponseSchema,
+  ApiV1SkillRescanResponseSchema,
   ApiV1UnbanUserResponseSchema,
   ApiV1UserSearchResponseSchema,
   parseArk,
@@ -184,6 +185,51 @@ export async function cmdSetRole(
     return parsed;
   } catch (error) {
     spinner.fail(formatError(error));
+    throw error;
+  }
+}
+
+export async function cmdRescanSkill(
+  opts: GlobalOpts,
+  slugArg: string,
+  options: { version?: string; yes?: boolean; json?: boolean },
+  inputAllowed: boolean,
+) {
+  const slug = normalizeSkillSlug(slugArg);
+  const version = options.version?.trim();
+  const allowPrompt = isInteractive() && inputAllowed !== false;
+
+  if (!options.yes) {
+    if (!allowPrompt) fail("Pass --yes (no input)");
+    const target = version ? `${slug}@${version}` : `${slug} latest`;
+    const ok = await promptConfirm(`Queue ClawScan rescan for ${target}? (moderator/admin)`);
+    if (!ok) return undefined;
+  }
+
+  const token = await requireAuthToken();
+  const registry = await getRegistry(opts, { cache: true });
+  const spinner = options.json ? null : createSpinner(`Queueing ClawScan rescan for ${slug}`);
+  try {
+    const result = await apiRequest(
+      registry,
+      {
+        method: "POST",
+        path: `${ApiRoutes.skills}/${encodeURIComponent(slug)}/rescan`,
+        token,
+        body: version ? { version } : {},
+      },
+      ApiV1SkillRescanResponseSchema,
+    );
+    const parsed = parseArk(ApiV1SkillRescanResponseSchema, result, "Skill rescan response");
+    spinner?.succeed(
+      `OK. Queued ClawScan for ${parsed.slug}@${parsed.version} (${parsed.alreadyQueued ? "existing job" : "new job"}).`,
+    );
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(parsed, null, 2)}\n`);
+    }
+    return parsed;
+  } catch (error) {
+    spinner?.fail(formatError(error));
     throw error;
   }
 }
@@ -375,6 +421,14 @@ export async function cmdRemediateAutobans(
 function normalizeHandle(value: string) {
   const trimmed = value.trim();
   return trimmed.startsWith("@") ? trimmed.slice(1).toLowerCase() : trimmed.toLowerCase();
+}
+
+function normalizeSkillSlug(value: string) {
+  const slug = value.trim().toLowerCase();
+  if (!slug) fail("Slug required");
+  if (slug.includes("/") || slug.includes("\\") || slug.includes(".."))
+    fail(`Invalid slug: ${slug}`);
+  return slug;
 }
 
 type ResolvedUser = {

--- a/packages/clawhub/src/schema/schemas.ts
+++ b/packages/clawhub/src/schema/schemas.ts
@@ -387,6 +387,17 @@ export const ApiV1SkillAppealResolveResponseSchema = type({
 export type ApiV1SkillAppealResolveResponse =
   (typeof ApiV1SkillAppealResolveResponseSchema)[inferred];
 
+export const ApiV1SkillRescanResponseSchema = type({
+  ok: "true",
+  slug: "string",
+  version: "string",
+  skillId: "string",
+  skillVersionId: "string",
+  jobId: "string",
+  alreadyQueued: "boolean",
+});
+export type ApiV1SkillRescanResponse = (typeof ApiV1SkillRescanResponseSchema)[inferred];
+
 export const ApiV1SkillVersionListResponseSchema = type({
   items: type({
     version: "string",

--- a/packages/schema/src/schemas.ts
+++ b/packages/schema/src/schemas.ts
@@ -388,6 +388,17 @@ export const ApiV1SkillAppealResolveResponseSchema = type({
 export type ApiV1SkillAppealResolveResponse =
   (typeof ApiV1SkillAppealResolveResponseSchema)[inferred];
 
+export const ApiV1SkillRescanResponseSchema = type({
+  ok: "true",
+  slug: "string",
+  version: "string",
+  skillId: "string",
+  skillVersionId: "string",
+  jobId: "string",
+  alreadyQueued: "boolean",
+});
+export type ApiV1SkillRescanResponse = (typeof ApiV1SkillRescanResponseSchema)[inferred];
+
 export const ApiV1SkillVersionListResponseSchema = type({
   items: type({
     version: "string",


### PR DESCRIPTION
## Summary
- add `clawhub-mod skills rescan <slug>` with optional `--version`, `--yes`, and `--json`
- add moderator-only `POST /api/v1/skills/:slug/rescan` enqueue path for manual ClawScan jobs
- add response schema, audit logging, docs, and malformed JSON handling

## Tests
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `bun run ci:static`
- `bunx vitest run convex/httpApiV1.handlers.test.ts packages/clawhub-mod/src/commands/moderation.test.ts`
- `bun run --cwd packages/clawhub-mod typecheck`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
