### PR TITLE
fix: render CJK text in OG images

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@fontsource/bricolage-grotesque": "5.2.10",
         "@fontsource/ibm-plex-mono": "5.2.7",
         "@fontsource/manrope": "5.2.8",
+        "@fontsource/noto-sans-sc": "5.2.9",
         "@monaco-editor/react": "4.7.0",
         "@radix-ui/react-avatar": "1.1.11",
         "@radix-ui/react-dialog": "1.1.15",
@@ -80,7 +81,7 @@
     },
     "packages/clawhub": {
       "name": "clawhub",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "bin": {
         "clawdhub": "bin/clawdhub.js",
         "clawhub": "bin/clawdhub.js",
@@ -296,6 +297,8 @@
     "@fontsource/ibm-plex-mono": ["@fontsource/ibm-plex-mono@5.2.7", "", {}, "sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w=="],
 
     "@fontsource/manrope": ["@fontsource/manrope@5.2.8", "", {}, "sha512-gJHJmcuUk7qWcNCfcAri/DJQtXtBYqi9yKratr4jXhSo0I3xUtNNKI+igQIcw5c+m95g0vounk8ZnX/kb8o0TA=="],
+
+    "@fontsource/noto-sans-sc": ["@fontsource/noto-sans-sc@5.2.9", "", {}, "sha512-bTUIWGBgJDpwi5qAr+x0/lcgv80IHTB9vl6s2f6EymZEa7qYV99yNRBZuKFT+SYDKVunZrjCEhWtpxqmbXWl5Q=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -54,6 +54,7 @@ const config = {
         "@fontsource/bricolage-grotesque",
         "@fontsource/ibm-plex-mono",
         "@fontsource/manrope",
+        "@fontsource/noto-sans-sc",
         "tailwindcss",
         "tw-animate-css",
       ],

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@fontsource/bricolage-grotesque": "5.2.10",
     "@fontsource/ibm-plex-mono": "5.2.7",
     "@fontsource/manrope": "5.2.8",
+    "@fontsource/noto-sans-sc": "5.2.9",
     "@monaco-editor/react": "4.7.0",
     "@radix-ui/react-avatar": "1.1.11",
     "@radix-ui/react-dialog": "1.1.15",

--- a/scripts/copy-og-assets.ts
+++ b/scripts/copy-og-assets.ts
@@ -37,6 +37,16 @@ const bricolage500Source = await resolveExistingPath(
 const ibmPlex500Source = await resolveExistingPath(
   nodeModuleCandidates("@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-500-normal.woff2"),
 );
+const notoSansSc800Source = await resolveExistingPath(
+  nodeModuleCandidates(
+    "@fontsource/noto-sans-sc/files/noto-sans-sc-chinese-simplified-800-normal.woff2",
+  ),
+);
+const notoSansSc500Source = await resolveExistingPath(
+  nodeModuleCandidates(
+    "@fontsource/noto-sans-sc/files/noto-sans-sc-chinese-simplified-500-normal.woff2",
+  ),
+);
 
 const copies = [
   {
@@ -105,6 +115,28 @@ const copies = [
       ),
       path.resolve(
         ".vercel/output/functions/__server.func/node_modules/@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-500-normal.woff2",
+      ),
+    ],
+  },
+  {
+    source: notoSansSc800Source,
+    targets: [
+      path.resolve(
+        ".output/server/node_modules/@fontsource/noto-sans-sc/files/noto-sans-sc-chinese-simplified-800-normal.woff2",
+      ),
+      path.resolve(
+        ".vercel/output/functions/__server.func/node_modules/@fontsource/noto-sans-sc/files/noto-sans-sc-chinese-simplified-800-normal.woff2",
+      ),
+    ],
+  },
+  {
+    source: notoSansSc500Source,
+    targets: [
+      path.resolve(
+        ".output/server/node_modules/@fontsource/noto-sans-sc/files/noto-sans-sc-chinese-simplified-500-normal.woff2",
+      ),
+      path.resolve(
+        ".vercel/output/functions/__server.func/node_modules/@fontsource/noto-sans-sc/files/noto-sans-sc-chinese-simplified-500-normal.woff2",
       ),
     ],
   },

--- a/server/og/ogAssets.test.ts
+++ b/server/og/ogAssets.test.ts
@@ -90,15 +90,17 @@ describe("ogAssets", () => {
     const first = await getFontBuffers();
     const second = await getFontBuffers();
 
-    expect(first).toHaveLength(3);
+    expect(first).toHaveLength(5);
     expect(first[0]).toBeInstanceOf(Uint8Array);
     expect(second).toEqual(first);
-    expect(readFileMock).toHaveBeenCalledTimes(3);
+    expect(readFileMock).toHaveBeenCalledTimes(5);
     expect(readFileMock.mock.calls.map((call) => String(call[0]))).toEqual(
       expect.arrayContaining([
         expect.stringContaining("bricolage-grotesque-latin-800-normal.woff2"),
         expect.stringContaining("bricolage-grotesque-latin-500-normal.woff2"),
         expect.stringContaining("ibm-plex-mono-latin-500-normal.woff2"),
+        expect.stringContaining("noto-sans-sc-chinese-simplified-800-normal.woff2"),
+        expect.stringContaining("noto-sans-sc-chinese-simplified-500-normal.woff2"),
       ]),
     );
   });

--- a/server/og/ogAssets.ts
+++ b/server/og/ogAssets.ts
@@ -111,6 +111,16 @@ export async function getFontBuffers() {
           "node_modules/@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-500-normal.woff2",
         ),
       ),
+      readFile(
+        getServerUrl(
+          "node_modules/@fontsource/noto-sans-sc/files/noto-sans-sc-chinese-simplified-800-normal.woff2",
+        ),
+      ),
+      readFile(
+        getServerUrl(
+          "node_modules/@fontsource/noto-sans-sc/files/noto-sans-sc-chinese-simplified-500-normal.woff2",
+        ),
+      ),
     ]).then((buffers) => buffers.map((buffer) => new Uint8Array(buffer)));
   }
   return fontBuffersPromise;

--- a/server/og/registryOgSvg.ts
+++ b/server/og/registryOgSvg.ts
@@ -36,9 +36,13 @@ export function escapeXml(value: string) {
     .replace(/'/g, "&#39;");
 }
 
+const FULL_WIDTH_GLYPH_RE =
+  /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\u3000-\u303f\uff00-\uffef]/u;
+
 function glyphWidthFactor(char: string) {
   if (char === " ") return 0.28;
   if (char === "…") return 0.62;
+  if (FULL_WIDTH_GLYPH_RE.test(char)) return 1;
   if (/[ilI.,:;|!'"`]/.test(char)) return 0.28;
   if (/[mwMW@%&]/.test(char)) return 0.9;
   if (/[A-Z]/.test(char)) return 0.68;
@@ -57,90 +61,87 @@ function truncateToWidth(value: string, maxWidth: number, fontSize: number) {
   if (!trimmed) return "";
   if (estimateTextWidth(trimmed, fontSize) <= maxWidth) return trimmed;
 
+  return markTruncated(trimmed, maxWidth, fontSize);
+}
+
+function markTruncated(value: string, maxWidth: number, fontSize: number) {
   const ellipsis = "…";
   const ellipsisWidth = estimateTextWidth(ellipsis, fontSize);
-  let out = "";
-  for (const char of trimmed) {
-    const next = out + char;
-    if (estimateTextWidth(next, fontSize) + ellipsisWidth > maxWidth) break;
-    out = next;
+  const chars = [...value.trim().replace(/[.。,;:!?]+$/g, "")];
+  while (
+    chars.length > 0 &&
+    estimateTextWidth(chars.join(""), fontSize) + ellipsisWidth > maxWidth
+  ) {
+    chars.pop();
   }
+  const out = chars
+    .join("")
+    .replace(/\s+$/g, "")
+    .replace(/[.。,;:!?]+$/g, "");
   return `${out.replace(/\s+$/g, "").replace(/[.。,;:!?]+$/g, "")}${ellipsis}`;
 }
 
 export function wrapText(value: string, maxWidth: number, fontSize: number, maxLines: number) {
+  if (maxLines <= 0) return [];
   const words = value.trim().split(/\s+/).filter(Boolean);
   const lines: string[] = [];
   let current = "";
 
-  function pushLine(line: string) {
-    if (line) lines.push(line);
-  }
-
   function splitLongWord(word: string) {
     if (estimateTextWidth(word, fontSize) <= maxWidth) return [word];
     const parts: string[] = [];
-    let remaining = word;
-    while (remaining && estimateTextWidth(remaining, fontSize) > maxWidth) {
-      let chunk = "";
-      for (const char of remaining) {
-        const next = chunk + char;
-        if (estimateTextWidth(`${next}…`, fontSize) > maxWidth) break;
-        chunk = next;
+    let chunk = "";
+    for (const char of word) {
+      const next = chunk + char;
+      if (chunk && estimateTextWidth(next, fontSize) > maxWidth) {
+        parts.push(chunk);
+        chunk = char;
+        continue;
       }
-      if (!chunk) break;
-      parts.push(`${chunk}…`);
-      remaining = remaining.slice(chunk.length);
+      chunk = next;
     }
-    if (remaining) parts.push(remaining);
+    if (chunk) parts.push(chunk);
     return parts;
   }
 
-  for (let wordIndex = 0; wordIndex < words.length; wordIndex += 1) {
-    const word = words[wordIndex];
-    if (estimateTextWidth(word, fontSize) > maxWidth) {
-      if (current) {
-        if (lines.length >= maxLines - 1) {
-          pushLine(
-            truncateToWidth(`${current} ${words.slice(wordIndex).join(" ")}`, maxWidth, fontSize),
-          );
-          current = "";
-          break;
-        }
-        pushLine(current);
-        current = "";
-        if (lines.length >= maxLines - 1) {
-          current = truncateToWidth(words.slice(wordIndex).join(" "), maxWidth, fontSize);
-          break;
-        }
-      }
-      for (const part of splitLongWord(word)) {
-        pushLine(part);
-        if (lines.length >= maxLines) break;
-      }
-      current = "";
-      if (lines.length >= maxLines - 1) break;
-      continue;
-    }
+  const tokens = words.flatMap((word, wordIndex) =>
+    splitLongWord(word).map((part, partIndex) => ({
+      text: part,
+      needsLeadingSpace: wordIndex > 0 && partIndex === 0,
+    })),
+  );
 
-    const next = current ? `${current} ${word}` : word;
+  for (let tokenIndex = 0; tokenIndex < tokens.length; tokenIndex += 1) {
+    const token = tokens[tokenIndex];
+    const separator = current && token.needsLeadingSpace ? " " : "";
+    const next = current ? `${current}${separator}${token.text}` : token.text;
     if (estimateTextWidth(next, fontSize) <= maxWidth) {
       current = next;
       continue;
     }
-    pushLine(current);
-    if (lines.length >= maxLines - 1) {
-      current = truncateToWidth(words.slice(wordIndex).join(" "), maxWidth, fontSize);
-      break;
-    }
-    current = word;
-  }
-  if (lines.length < maxLines && current) pushLine(current);
-  if (lines.length > maxLines) lines.length = maxLines;
 
-  const usedWords = lines.join(" ").split(/\s+/).filter(Boolean).length;
-  if (usedWords < words.length && lines.length > 0) {
-    lines[lines.length - 1] = truncateToWidth(lines.at(-1) ?? "", maxWidth, fontSize);
+    if (current) {
+      lines.push(current);
+      if (lines.length >= maxLines) {
+        lines[lines.length - 1] = markTruncated(lines.at(-1) ?? "", maxWidth, fontSize);
+        return lines;
+      }
+    }
+
+    current = token.text;
+  }
+
+  if (current) {
+    if (lines.length < maxLines) {
+      lines.push(current);
+    } else if (lines.length > 0) {
+      lines[lines.length - 1] = markTruncated(lines.at(-1) ?? "", maxWidth, fontSize);
+    }
+  }
+
+  if (lines.length > maxLines) {
+    lines.length = maxLines;
+    lines[lines.length - 1] = markTruncated(lines.at(-1) ?? "", maxWidth, fontSize);
   }
   return lines;
 }

--- a/server/og/skillOgSvg.test.ts
+++ b/server/og/skillOgSvg.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { wrapText } from "./registryOgSvg";
 import { buildSkillOgSvg } from "./skillOgSvg";
 
 describe("skill OG SVG", () => {
@@ -65,5 +66,23 @@ describe("skill OG SVG", () => {
     const descBlock = svg.match(/<text[^>]*font-size="28"[\s\S]*?<\/text>/)?.[0] ?? "";
     const descTspans = descBlock.match(/<tspan /g) ?? [];
     expect(descTspans.length).toBeLessThanOrEqual(2);
+  });
+
+  it("wraps CJK text as full-width glyphs without inserting continuation ellipses", () => {
+    const description = "西瓜视频数据查询助手。覆盖视频详情、用户数据、搜索、评论等全功能。";
+    const lines = wrapText(description, 760, 28, 2);
+
+    expect(lines.length).toBeGreaterThan(1);
+    expect(lines).toHaveLength(2);
+    expect(lines.join("")).toBe(description);
+    expect(lines[0]).not.toContain("…");
+  });
+
+  it("clips overlong CJK text on the last visible line", () => {
+    const lines = wrapText("视频详情用户数据搜索评论".repeat(10), 760, 28, 2);
+
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).not.toContain("…");
+    expect(lines[1]).toContain("…");
   });
 });


### PR DESCRIPTION
## Summary

- Add Noto Sans SC font buffers to the dynamic OG renderer so Chinese/CJK ideographs render instead of tofu boxes.
- Copy the new OG font assets into both Nitro and Vercel server output during builds.
- Update registry OG wrapping so full-width glyphs are measured as wide glyphs and long no-space descriptions wrap before the final ellipsis.

The shared font buffer path covers skill, plugin, profile, and soul OG routes. Soul is included intentionally because it is already a platform entity/route, even though the broader Souls project is still WIP.

## Visual stress test

| Type | Image |
| --- | --- |
| Skill: real Chinese description | ![Skill OG with Chinese description](https://raw.githubusercontent.com/vyctorbrzezowski/clawhub/qa-artifacts/og-cjk-font-fallback/01-real-chinese-skill.png) |
| Skill: long unspaced Chinese description | ![Skill OG with long unspaced Chinese description](https://raw.githubusercontent.com/vyctorbrzezowski/clawhub/qa-artifacts/og-cjk-font-fallback/02-long-unspaced-chinese-description.png) |
| Skill: Chinese title and description | ![Skill OG with Chinese title and description](https://raw.githubusercontent.com/vyctorbrzezowski/clawhub/qa-artifacts/og-cjk-font-fallback/03-chinese-title-and-description.png) |
| Plugin: mixed CJK and full-width punctuation | ![Plugin OG with mixed CJK text](https://raw.githubusercontent.com/vyctorbrzezowski/clawhub/qa-artifacts/og-cjk-font-fallback/04-mixed-cjk-plugin.png) |
| Publisher: CJK bio | ![Publisher OG with CJK bio](https://raw.githubusercontent.com/vyctorbrzezowski/clawhub/qa-artifacts/og-cjk-font-fallback/05-publisher-cjk-bio.png) |

## Tests

- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bun run test server/og/skillOgSvg.test.ts server/og/ogAssets.test.ts server/routes/og/skill.png.test.ts server/routes/og/plugin.png.test.ts server/routes/og/soul.png.test.ts`
- Verified `.output/server/node_modules/@fontsource/noto-sans-sc/files/` contains the copied 500/800 OG font assets after build.
