### PR TITLE
Separate financial capability tags from crypto

### DIFF
--- a/convex/lib/skillCapabilityTags.test.ts
+++ b/convex/lib/skillCapabilityTags.test.ts
@@ -23,11 +23,678 @@ describe("deriveSkillCapabilityTags", () => {
 
     expect(tags).toEqual([
       "crypto",
+      "financial-authority",
       "requires-wallet",
       "can-make-purchases",
       "can-sign-transactions",
       "requires-sensitive-credentials",
     ]);
+  });
+
+  it("treats purchase authority as financial authority, not crypto", () => {
+    const tags = deriveSkillCapabilityTags({
+      slug: "stripe-credit-buyer",
+      displayName: "Stripe Credit Buyer",
+      frontmatter: {},
+      readmeText:
+        "Buy credits for the user's SaaS account through Stripe checkout after explicit approval.",
+      fileContents: [],
+    });
+
+    expect(tags).toContain("financial-authority");
+    expect(tags).toContain("can-make-purchases");
+    expect(tags).not.toContain("crypto");
+    expect(tags).not.toContain("requires-wallet");
+  });
+
+  it("detects payment processing as purchase authority without crypto", () => {
+    const tags = deriveSkillCapabilityTags({
+      slug: "stripe-payments",
+      displayName: "Stripe Payments",
+      frontmatter: {},
+      readmeText: "Process Stripe payments for customer invoices.",
+      fileContents: [],
+    });
+
+    expect(tags).toEqual(["financial-authority", "can-make-purchases"]);
+  });
+
+  it("detects inflected payment processing verbs without crypto", () => {
+    const tags = deriveSkillCapabilityTags({
+      slug: "stripe-invoices",
+      displayName: "Stripe Invoice Helper",
+      frontmatter: {},
+      readmeText: "Processes Stripe payments and accepts credit card payments for invoices.",
+      fileContents: [],
+    });
+
+    expect(tags).toEqual(["financial-authority", "can-make-purchases"]);
+  });
+
+  it("detects direct payment actions as purchase authority without crypto", () => {
+    const tags = deriveSkillCapabilityTags({
+      slug: "vendor-payments",
+      displayName: "Vendor Payments",
+      frontmatter: {},
+      readmeText:
+        "Make payments to vendors from the connected Stripe account and pay invoices after approval.",
+      fileContents: [],
+    });
+
+    expect(tags).toEqual(["financial-authority", "can-make-purchases"]);
+  });
+
+  it("detects ordinary ecommerce purchase authority without crypto", () => {
+    for (const readmeText of [
+      "Purchase products on Amazon after approval.",
+      "Purchase a book for the user after approval.",
+      "Buy airline tickets for the user after approval.",
+      "Order groceries using Instacart after approval.",
+    ]) {
+      const tags = deriveSkillCapabilityTags({
+        slug: "shopping-helper",
+        displayName: "Shopping Helper",
+        frontmatter: {},
+        readmeText,
+        fileContents: [],
+      });
+
+      expect(tags).toEqual(["financial-authority", "can-make-purchases"]);
+    }
+  });
+
+  it("detects financially binding purchases outside ordinary ecommerce", () => {
+    for (const readmeText of [
+      "Purchase domain names after approval.",
+      "Purchase software licenses after approval.",
+      "Buy gift cards for employees after approval.",
+      "Purchase subscriptions after approval.",
+      "Purchase plans after approval.",
+    ]) {
+      const tags = deriveSkillCapabilityTags({
+        slug: "procurement-helper",
+        displayName: "Procurement Helper",
+        frontmatter: {},
+        readmeText,
+        fileContents: [],
+      });
+
+      expect(tags).toEqual(["financial-authority", "can-make-purchases"]);
+    }
+  });
+
+  it("detects purchase authority from capability and approval phrasing", () => {
+    for (const readmeText of [
+      "This skill can purchase after approval.",
+      "Use when an agent may purchase, book, reserve, subscribe, renew, or upgrade.",
+      "Purchase after user approval.",
+      "Book hotels after approval.",
+      "Books flights after approval.",
+      "Reserves rental cars after approval.",
+      "Reserve airline tickets after approval.",
+      "Subscribes to plans after approval.",
+      "Renews domains after approval.",
+      "Upgrade memberships after user approval.",
+      "Upgrades subscriptions after user approval.",
+    ]) {
+      const tags = deriveSkillCapabilityTags({
+        slug: "approval-purchase-helper",
+        displayName: "Approval Purchase Helper",
+        frontmatter: {},
+        readmeText,
+        fileContents: [],
+      });
+
+      expect(tags).toEqual(["financial-authority", "can-make-purchases"]);
+    }
+  });
+
+  it("does not treat non-financial subscribe, reserve, or upgrade verbs as purchases", () => {
+    for (const readmeText of [
+      "This integration can subscribe to GitHub webhook events.",
+      "Use when an agent may subscribe to a GraphQL subscription.",
+      "Reserve capacity in Kubernetes after approval.",
+      "Upgrade package dependencies after approval.",
+      "Can book meeting rooms.",
+      "This tool can order search results by relevance.",
+      "This skill can order tasks by priority.",
+      "This workflow can order support tickets by priority.",
+      "Walking outside improves mental health more than most things you can buy.",
+      "DOL can order back pay and penalties for wage claims.",
+      "Buys groceries that go to waste every week.",
+      "State concerns overlap with pending orders alongside committed orders.",
+    ]) {
+      const tags = deriveSkillCapabilityTags({
+        slug: "automation-helper",
+        displayName: "Automation Helper",
+        frontmatter: {},
+        readmeText,
+        fileContents: [],
+      });
+
+      expect(tags).toEqual([]);
+    }
+  });
+
+  it("detects card charging as purchase authority without crypto", () => {
+    const tags = deriveSkillCapabilityTags({
+      slug: "card-billing",
+      displayName: "Card Billing",
+      frontmatter: {},
+      readmeText: "Charge customer cards for approved invoices.",
+      fileContents: [],
+    });
+
+    expect(tags).toEqual(["financial-authority", "can-make-purchases"]);
+  });
+
+  it("treats transaction signing as financial authority, not crypto without crypto evidence", () => {
+    const tags = deriveSkillCapabilityTags({
+      slug: "bank-transfer-approval",
+      displayName: "Bank Transfer Approval",
+      frontmatter: {},
+      readmeText:
+        "Sign and submit bank transfer transactions after the user confirms the payee and amount.",
+      fileContents: [],
+    });
+
+    expect(tags).toContain("financial-authority");
+    expect(tags).toContain("can-sign-transactions");
+    expect(tags).toContain("requires-sensitive-credentials");
+    expect(tags).not.toContain("crypto");
+    expect(tags).not.toContain("requires-wallet");
+  });
+
+  it("detects standalone transaction action verbs as financial authority", () => {
+    const tags = deriveSkillCapabilityTags({
+      slug: "ach-approvals",
+      displayName: "ACH Approvals",
+      frontmatter: {},
+      readmeText: "Approves ACH transactions after user confirmation.",
+      fileContents: [],
+    });
+
+    expect(tags).toContain("financial-authority");
+    expect(tags).toContain("can-sign-transactions");
+    expect(tags).toContain("requires-sensitive-credentials");
+    expect(tags).not.toContain("crypto");
+    expect(tags).not.toContain("requires-wallet");
+  });
+
+  it("keeps financial rails tagged when adjacent to internal wording", () => {
+    const tags = deriveSkillCapabilityTags({
+      slug: "ach-approvals",
+      displayName: "ACH Approvals",
+      frontmatter: {},
+      readmeText: "Approves internal ACH transactions after approval.",
+      fileContents: [],
+    });
+
+    expect(tags).toEqual([
+      "financial-authority",
+      "can-sign-transactions",
+      "requires-sensitive-credentials",
+    ]);
+  });
+
+  it("detects standalone crypto transaction sending as wallet authority", () => {
+    const tags = deriveSkillCapabilityTags({
+      slug: "eth-sender",
+      displayName: "ETH Sender",
+      frontmatter: {},
+      readmeText: "Send Ethereum transactions from a wallet.",
+      fileContents: [],
+    });
+
+    expect(tags).toEqual([
+      "crypto",
+      "financial-authority",
+      "requires-wallet",
+      "can-sign-transactions",
+      "requires-sensitive-credentials",
+    ]);
+  });
+
+  it("detects hyphenated ERC-20 transaction sending as wallet authority", () => {
+    const tags = deriveSkillCapabilityTags({
+      slug: "token-sender",
+      displayName: "Token Sender",
+      frontmatter: {},
+      readmeText: "Send ERC-20 transactions after approval.",
+      fileContents: [],
+    });
+
+    expect(tags).toEqual([
+      "crypto",
+      "financial-authority",
+      "requires-wallet",
+      "can-sign-transactions",
+      "requires-sensitive-credentials",
+    ]);
+  });
+
+  it("does not treat database transactions as financial transaction authority", () => {
+    for (const readmeText of [
+      "Executes database transactions in Postgres and rolls back on failure.",
+      "Signs database transactions after approval.",
+    ]) {
+      const tags = deriveSkillCapabilityTags({
+        slug: "sql-helper",
+        displayName: "SQL Helper",
+        frontmatter: {},
+        readmeText,
+        fileContents: [],
+      });
+
+      expect(tags).toEqual([]);
+    }
+  });
+
+  it("does not treat internal workflow transactions as financial transaction authority", () => {
+    const tags = deriveSkillCapabilityTags({
+      slug: "workflow-engine",
+      displayName: "Workflow Engine",
+      frontmatter: {},
+      readmeText: "Approves pending transactions in the internal queue.",
+      fileContents: [],
+    });
+
+    expect(tags).toEqual([]);
+  });
+
+  it("does not treat sign in or sign up wording as transaction signing", () => {
+    const tags = deriveSkillCapabilityTags({
+      slug: "bank-alerts",
+      displayName: "Bank Alerts",
+      frontmatter: {},
+      readmeText:
+        "Sign in to view transactions and sign up for transaction alerts on the dashboard.",
+      fileContents: [],
+    });
+
+    expect(tags).toEqual([]);
+  });
+
+  it("does not treat sign out wording as transaction signing", () => {
+    const tags = deriveSkillCapabilityTags({
+      slug: "bank-session-help",
+      displayName: "Bank Session Help",
+      frontmatter: {},
+      readmeText: "Sign out before viewing transactions on a shared device.",
+      fileContents: [],
+    });
+
+    expect(tags).toEqual([]);
+  });
+
+  it("does not treat sign-in variants as transaction signing", () => {
+    for (const readmeText of [
+      "Sign into view transactions in the dashboard.",
+      "Sign onto the transaction portal before checking balances.",
+      "Sign off before viewing transactions on a shared device.",
+      "Signs in to view transactions on the dashboard.",
+      "Signed in to view transactions on the dashboard.",
+    ]) {
+      const tags = deriveSkillCapabilityTags({
+        slug: "bank-auth-help",
+        displayName: "Bank Auth Help",
+        frontmatter: {},
+        readmeText,
+        fileContents: [],
+      });
+
+      expect(tags).toEqual([]);
+    }
+  });
+
+  it("detects inflected transaction signing verbs as financial authority", () => {
+    for (const readmeText of [
+      "Signs bank transactions after approval.",
+      "Signed bank transactions after approval.",
+    ]) {
+      const tags = deriveSkillCapabilityTags({
+        slug: "bank-signing",
+        displayName: "Bank Signing",
+        frontmatter: {},
+        readmeText,
+        fileContents: [],
+      });
+
+      expect(tags).toEqual([
+        "financial-authority",
+        "can-sign-transactions",
+        "requires-sensitive-credentials",
+      ]);
+    }
+  });
+
+  it("keeps inferred crypto wallet requirements tied to sensitive credentials", () => {
+    const tags = deriveSkillCapabilityTags({
+      slug: "onchain-approval",
+      displayName: "Onchain Approval",
+      frontmatter: {},
+      readmeText: "Sign and submit on-chain transaction approvals for the user's account.",
+      fileContents: [],
+    });
+
+    expect(tags).toEqual([
+      "crypto",
+      "financial-authority",
+      "requires-wallet",
+      "can-sign-transactions",
+      "requires-sensitive-credentials",
+    ]);
+  });
+
+  it("keeps EIP-712 transaction signing tagged as crypto wallet authority", () => {
+    const tags = deriveSkillCapabilityTags({
+      slug: "typed-data-signer",
+      displayName: "Typed Data Signer",
+      frontmatter: {},
+      readmeText: "Signs EIP-712 transactions after approval.",
+      fileContents: [],
+    });
+
+    expect(tags).toEqual([
+      "crypto",
+      "financial-authority",
+      "requires-wallet",
+      "can-sign-transactions",
+      "requires-sensitive-credentials",
+    ]);
+  });
+
+  it("keeps hyphenated ERC-20 transaction signing tagged as crypto wallet authority", () => {
+    const tags = deriveSkillCapabilityTags({
+      slug: "token-helper",
+      displayName: "Token Helper",
+      frontmatter: {},
+      readmeText: "Signs ERC-20 transactions after approval.",
+      fileContents: [],
+    });
+
+    expect(tags).toEqual([
+      "crypto",
+      "financial-authority",
+      "requires-wallet",
+      "can-sign-transactions",
+      "requires-sensitive-credentials",
+    ]);
+  });
+
+  it("keeps walletClient transactions tagged as crypto wallet authority", () => {
+    const tags = deriveSkillCapabilityTags({
+      slug: "tx-helper",
+      displayName: "Transaction Helper",
+      frontmatter: {},
+      readmeText: "Submit user transactions.",
+      fileContents: [
+        {
+          path: "src/client.ts",
+          content: "await walletClient.sendTransaction({ to, value });",
+        },
+      ],
+    });
+
+    expect(tags).toEqual([
+      "crypto",
+      "financial-authority",
+      "requires-wallet",
+      "can-sign-transactions",
+      "requires-sensitive-credentials",
+    ]);
+  });
+
+  it("keeps bare sendTransaction calls tagged as crypto wallet authority", () => {
+    const tags = deriveSkillCapabilityTags({
+      slug: "tx-helper",
+      displayName: "Transaction Helper",
+      frontmatter: {},
+      readmeText: "Submit user transactions.",
+      fileContents: [
+        {
+          path: "src/client.ts",
+          content: "await sendTransaction({ to, value });",
+        },
+      ],
+    });
+
+    expect(tags).toEqual([
+      "crypto",
+      "financial-authority",
+      "requires-wallet",
+      "can-sign-transactions",
+      "requires-sensitive-credentials",
+    ]);
+  });
+
+  it("treats billing setup helper text as paid-service metadata, not purchase or crypto authority", () => {
+    const tags = deriveSkillCapabilityTags({
+      slug: "child-dangerous-behavior-recognition-analysis",
+      displayName: "Child Hazardous Behavior Recognition Tool",
+      summary: "Detects risky child behavior in monitoring videos.",
+      frontmatter: {},
+      readmeText:
+        "Analyze video streams for climbing, fire play, power source contact, and dangerous window behavior.",
+      fileContents: [
+        {
+          path: "skills/smyx_common/scripts/util.py",
+          content:
+            'HTTP 402: 账户余额不足. 先输入命令 "安装支付技能 smyx-payment", 再输入命令 "技能账户充值".',
+        },
+      ],
+    });
+
+    expect(tags).toContain("requires-paid-service");
+    expect(tags).not.toContain("financial-authority");
+    expect(tags).not.toContain("can-make-purchases");
+    expect(tags).not.toContain("crypto");
+  });
+
+  it("treats price-only cost text as paid-service metadata", () => {
+    for (const readmeText of [
+      "This skill costs $5 per month to use.",
+      "Calls cost $0.01 via the provider API.",
+      "Users pay for API usage via Stripe.",
+      "Pay for provider API calls before use.",
+      "The pro plan costs $20/month.",
+      "The provider charges $0.01 per call.",
+      "Users are charged $5/month.",
+      "The API is charged per request.",
+      "Payment is required to use this skill.",
+      "A paid subscription is required.",
+      "Requires a paid plan.",
+      "Requires a pro plan.",
+      "Requires a premium subscription.",
+      "Requires a subscription.",
+      "Pricing $4.99 - One-time purchase.",
+    ]) {
+      const tags = deriveSkillCapabilityTags({
+        slug: "paid-helper",
+        displayName: "Paid Helper",
+        frontmatter: {},
+        readmeText,
+        fileContents: [],
+      });
+
+      expect(tags).toEqual(["requires-paid-service"]);
+    }
+  });
+
+  it("does not treat one-time purchase action text as paid-service metadata", () => {
+    for (const readmeText of [
+      "Make a one-time purchase for the user after explicit approval.",
+      "Use the saved payment method to make a one-time purchase after approval.",
+      "Payment method: saved card. Make a one-time purchase after approval.",
+      "Requires payment method: saved card. Make a one-time purchase after approval.",
+      "Requires payment method on file before making approved purchases.",
+      "Requires payment methods on file before making approved purchases.",
+      "Requires payment cards on file before making approved purchases.",
+      "Requires payment sources on file before making approved purchases.",
+      "Pay with the saved card after approval.",
+      "Installation\nMake a one-time purchase after approval.",
+    ]) {
+      const tags = deriveSkillCapabilityTags({
+        slug: "checkout-helper",
+        displayName: "Checkout Helper",
+        frontmatter: {},
+        readmeText,
+        fileContents: [],
+      });
+
+      expect(tags).toEqual(["financial-authority", "can-make-purchases"]);
+    }
+  });
+
+  it("does not treat subscription identifiers as paid-service metadata", () => {
+    for (const readmeText of [
+      "Requires subscription ID to access Azure resources.",
+      "Requires a subscription ID to access Azure resources.",
+      "Requires subscription IDs to access Azure resources.",
+      "Requires subscription identifier to access Azure resources.",
+      "Requires a subscription key to access Azure resources.",
+      "Requires subscription to GitHub webhook events.",
+      "Requires a subscription to GraphQL updates.",
+    ]) {
+      const tags = deriveSkillCapabilityTags({
+        slug: "azure-helper",
+        displayName: "Azure Helper",
+        frontmatter: {},
+        readmeText,
+        fileContents: [],
+      });
+
+      expect(tags).toEqual([]);
+    }
+  });
+
+  it("does not treat negated paid-service wording as paid-service metadata", () => {
+    for (const readmeText of [
+      "Does not require a subscription.",
+      "Doesn't require a paid plan.",
+      "Does not require payment.",
+      "No payment required.",
+      "No payments are required.",
+      "No additional payment is required.",
+      "No extra payment is required.",
+      "Does not currently require a subscription.",
+      "Never requires payment.",
+      "Never requires a subscription.",
+      "Never requires a pro plan.",
+      "Doesn’t require a pro plan.",
+    ]) {
+      const tags = deriveSkillCapabilityTags({
+        slug: "free-helper",
+        displayName: "Free Helper",
+        frontmatter: {},
+        readmeText,
+        fileContents: [],
+      });
+
+      expect(tags).toEqual([]);
+    }
+  });
+
+  it("does not treat ordinary bank balance wording as paid-service metadata", () => {
+    const tags = deriveSkillCapabilityTags({
+      slug: "bank-balance-alerts",
+      displayName: "Bank Balance Alerts",
+      frontmatter: {},
+      readmeText:
+        "Alerts you when a checking account has insufficient account balance before payroll runs.",
+      fileContents: [],
+    });
+
+    expect(tags).toEqual([]);
+  });
+
+  it("does not treat ordinary planning wording as paid-service metadata", () => {
+    for (const readmeText of [
+      "Requires a plan before implementing the migration.",
+      "Requires plan documents and acceptance criteria.",
+      "A plumber charges $150-300 for a visit.",
+    ]) {
+      const tags = deriveSkillCapabilityTags({
+        slug: "planning-helper",
+        displayName: "Planning Helper",
+        frontmatter: {},
+        readmeText,
+        fileContents: [],
+      });
+
+      expect(tags).toEqual([]);
+    }
+  });
+
+  it("does not treat ordinary account credential wording as paid-service metadata", () => {
+    for (const readmeText of [
+      "Requires service account credentials to access Google Cloud APIs.",
+      "Requires account access to query invoices.",
+    ]) {
+      const tags = deriveSkillCapabilityTags({
+        slug: "account-helper",
+        displayName: "Account Helper",
+        frontmatter: {},
+        readmeText,
+        fileContents: [],
+      });
+
+      expect(tags).toEqual([]);
+    }
+  });
+
+  it("still detects payment-error account balance wording as paid-service metadata", () => {
+    const tags = deriveSkillCapabilityTags({
+      slug: "paid-api-helper",
+      displayName: "Paid API Helper",
+      frontmatter: {},
+      readmeText:
+        "HTTP 402: insufficient account balance. Recharge the skill account before retrying.",
+      fileContents: [],
+    });
+
+    expect(tags).toEqual(["requires-paid-service"]);
+  });
+
+  it("does not treat generic API or LLM token purchases as crypto", () => {
+    for (const readmeText of [
+      "Buy API tokens after approval.",
+      "Purchase OpenAI tokens after approval.",
+      "Buy model usage tokens for the user's SaaS account after explicit approval.",
+    ]) {
+      const tags = deriveSkillCapabilityTags({
+        slug: "token-buyer",
+        displayName: "Token Buyer",
+        frontmatter: {},
+        readmeText,
+        fileContents: [],
+      });
+
+      expect(tags).toEqual(["financial-authority", "can-make-purchases"]);
+    }
+  });
+
+  it("preserves crypto labels for crypto asset purchases", () => {
+    for (const readmeText of [
+      "Buy NFT after approval.",
+      "Buys crypto tokens after approval.",
+      "Buying NFTs after approval.",
+      "Buy on-chain tokens after approval.",
+      "Purchase coins from the marketplace.",
+      "Purchased ERC20 tokens from the marketplace.",
+      "Purchase cryptocurrency after approval.",
+      "Buy cryptocurrencies after approval.",
+    ]) {
+      const tags = deriveSkillCapabilityTags({
+        slug: "asset-buyer",
+        displayName: "Asset Buyer",
+        frontmatter: {},
+        readmeText,
+        fileContents: [],
+      });
+
+      expect(tags).toEqual(["crypto", "financial-authority", "can-make-purchases"]);
+    }
   });
 
   it("detects OAuth-backed external posting behavior", () => {

--- a/convex/lib/skillCapabilityTags.ts
+++ b/convex/lib/skillCapabilityTags.ts
@@ -1,8 +1,10 @@
 export const SKILL_CAPABILITY_TAGS = [
   "crypto",
+  "financial-authority",
   "requires-wallet",
   "can-make-purchases",
   "can-sign-transactions",
+  "requires-paid-service",
   "requires-oauth-token",
   "requires-sensitive-credentials",
   "posts-externally",
@@ -29,14 +31,27 @@ function matches(text: string, patterns: RegExp[]) {
   return patterns.some((pattern) => pattern.test(text));
 }
 
+function removeMatches(text: string, patterns: RegExp[]) {
+  return patterns.reduce(
+    (result, pattern) => result.replace(new RegExp(pattern.source, `${pattern.flags}g`), " "),
+    text,
+  );
+}
+
 const CRYPTO_PATTERNS = [
   /\bcrypto\b/,
+  /\bcryptocurrenc(?:y|ies)\b/,
   /\bblockchain\b/,
   /\bdefi\b/,
   /\bon-?chain\b/,
   /\bwallet\b/,
   /\bprivate key\b/,
-  /\berc20\b/,
+  /\bwalletclient\b/,
+  /\bsendtransaction\b/,
+  /\beip-712\b/,
+  /\berc-?20\b/,
+  /\bbitcoin\b/,
+  /\bbtc\b/,
   /\busdc\b/,
   /\beth(?:ereum)?\b/,
   /\bbase network\b/,
@@ -49,6 +64,8 @@ const CRYPTO_PATTERNS = [
   /\btoken balance\b/,
   /\b(?:defi|token|tokens|coin|coins|nft|nfts|usdc|eth|ethereum|erc20|crypto)\s+swaps?\b/,
   /\bswaps?\s+(?:defi|token|tokens|coin|coins|nft|nfts|usdc|eth|ethereum|erc20|crypto)\b/,
+  /\b(?:buy|buys|buying|bought|purchas(?:e|es|ed|ing))\s+(?:[\w-]+\s+){0,2}(?:coins?|nfts?|cryptocurrenc(?:y|ies))\b/,
+  /\b(?:buy|buys|buying|bought|purchas(?:e|es|ed|ing))\s+(?:[\w-]+\s+){0,2}(?:crypto|defi|on-?chain|wallet|erc-?20|ethereum|bitcoin|btc|eth|usdc|solana|polygon|base|arbitrum|optimism|avalanche)\s+tokens?\b/,
   /\bbridge\b/,
   /\bliquidity\b/,
   /\bens\b/,
@@ -58,6 +75,8 @@ const CRYPTO_PATTERNS = [
 const WALLET_PATTERNS = [
   /\bprivate[_ -]?key\b/,
   /\bwallet\b/,
+  /\bwalletclient\b/,
+  /\bsendtransaction\b/,
   /\bmnemonic\b/,
   /\bseed phrase\b/,
   /\bconfigured wallet\b/,
@@ -66,22 +85,60 @@ const WALLET_PATTERNS = [
 ] satisfies RegExp[];
 
 const PURCHASE_PATTERNS = [
-  /\bpayments?\b/,
-  /\bpay\s+(?:for|with|using|via|in)\b/,
+  /\bpay\s+(?:for|with|using|via|in)\s+(?:[\w-]+\s+){0,6}(?:after|with|upon|on)\s+(?:explicit\s+)?(?:user\s+)?(?:approval|confirmation|consent)\b/,
   /\bpaid automatically\b/,
-  /\bpay per call\b/,
   /\bmicro-?payments?\b/,
-  /\bpayment required\b/,
-  /\bcosts? \$\d/,
-  /\bcharged?\b/,
-  /\bpurchase\b/,
-  /\bbuy(?:\s+(?:credits?|tokens?|coins?|nft|subscription|plan))\b/,
+  /\b(?:process(?:es|ed|ing)?|accept(?:s|ed|ing)?|collect(?:s|ed|ing)?|captur(?:e|es|ed|ing)|settl(?:e|es|ed|ing))\s+(?:[\w-]+\s+){0,4}payments?\b/,
+  /\b(?:make|makes|making|made|send|sends|sending|sent|initiat(?:e|es|ed|ing)|schedul(?:e|es|ed|ing)|approv(?:e|es|ed|ing)|authoriz(?:e|es|ed|ing))\s+(?:[\w-]+\s+){0,4}payments?\b/,
+  /\bpay(?:s|ing)?\s+(?:[\w-]+\s+){0,3}(?:invoices?|bills?|vendors?|suppliers?|merchants?)\b/,
+  /\bpayment processing\b/,
+  /\bcharg(?:e|es|ed|ing)\s+(?:[\w-]+\s+){0,3}(?:cards?|credit cards?|customers?|users?|accounts?)\b/,
+  /\b(?:make|makes|making|made|complete|completes|completed|place|places|placed|submit|submits|submitted)\s+(?:a\s+)?(?:[\w-]+\s+){0,3}(?:one-?time\s+)?purchases?\b/,
+  /\b(?:(?:this|the|your)\s+)?(?:skill|agent|assistant|tool|workflow|integration)\s+(?:can\s+|may\s+|will\s+|is\s+able\s+to\s+|able\s+to\s+)?(?:buy|buys|buying|bought|order|orders|ordered|ordering|purchas(?:e|es|ed|ing))\s+(?:a|an|the)?\s*(?:[\w-]+\s+){0,3}(?:products?|items?|goods?|books?|groceries|supplies|materials?|equipment|merchandise|orders?|licenses?|domain names?|domains?|gift cards?)\b/,
+  /\b(?:buy|buys|buying|bought|purchas(?:e|es|ed|ing))\s+(?:[\w-]+\s+){0,2}(?:credits?|tokens?|coins?|nfts?|subscriptions?|plans?)\b/,
+  /\b(?:(?:this|the|an?|your)\s+)?(?:[\w-]+\s+){0,2}(?:skill|agent|assistant|tool|workflow|integration)\s+(?:can|may|is\s+able\s+to|able\s+to)\s+(?:buy|purchase)\b/,
+  /\b(?:buy|purchase|order)\s+(?:(?:a|an|the)\s+)?(?:[\w-]+\s+){0,6}(?:after|with|upon|on)\s+(?:explicit\s+)?(?:user\s+)?(?:approval|confirmation|consent)\b/,
+  /\b(?:book|books|booked|booking|reserv(?:e|es|ed|ing))\s+(?:[\w-]+\s+){0,3}(?:hotels?|flights?|airline tickets?|tickets?|travel|rental cars?)\s+(?:after|with|upon|on)\s+(?:explicit\s+)?(?:user\s+)?(?:approval|confirmation|consent)\b/,
+  /\b(?:subscrib(?:e|es|ed|ing)(?:\s+to)?|renew(?:s|ed|ing)?|upgrad(?:e|es|ed|ing))\s+(?:[\w-]+\s+){0,3}(?:subscriptions?|plans?|memberships?|licenses?|domains?|accounts?|tiers?)\s+(?:after|with|upon|on)\s+(?:explicit\s+)?(?:user\s+)?(?:approval|confirmation|consent)\b/,
   /\bpayment checkout\b/,
   /\bone-?click checkout\b/,
 ] satisfies RegExp[];
 
+const PAID_SERVICE_PATTERNS = [
+  /(?<!no )\bpayment required\b/,
+  /(?<!no )\bpayments?\s+(?:is|are|was|were|be|being|been)?\s*required\b/,
+  /(?<!no )\bpaid (?:subscription|plan|account|service|tier|api|provider|membership)\s+(?:is|are|was|were|be|being|been)?\s*required\b/,
+  /(?<!not )(?<!n't )\brequires? (?:a )?(?:subscription(?!\s+(?:ids?|identifiers?|keys?|to)\b)|payment(?!\s+(?:methods?|details?|info|cards?|sources?)\b))\b/,
+  /(?<!not )(?<!n't )\brequires? (?:a )?(?:pro|premium|billing) (?:subscription|plan|tier|account|service|api|provider|membership)\b/,
+  /(?<!not )(?<!n't )\brequires? (?:a )?paid (?:subscription|plan|account|service|tier|api|provider|membership)\b/,
+  /\bpay per call\b/,
+  /\busers?\s+pay\s+for\s+(?:[\w-]+\s+){0,4}(?:api|provider|service|skill|tool|calls?|requests?|usage)\b/,
+  /\bpay\s+for\s+(?:[\w-]+\s+){0,4}(?:api|provider|service|skill|tool|calls?|requests?|usage)\b/,
+  /\b(?:this\s+)?(?:skill|tool|api|provider|service|subscription|plans?|calls?|requests?)\s+costs?\s+\$\d/,
+  /\b(?:provider|api|service|skill|tool|subscription|plans?)\s+charges?\s+\$\d/,
+  /\busers?\s+(?:is|are|was|were|will be|can be)?\s*charged\s+\$\d/,
+  /\b(?:pricing|price|cost|costs?|paid|subscription|plan)\b[\s\S]{0,80}\bone-?time purchase\b/,
+  /\b(?:is|are|be|being|been)?\s*charged per (?:call|request|use|execution|run)\b/,
+  /\bcharges? per (?:call|request|use|execution|run)\b/,
+  /\b(?:http 402|402 payment required|payment required)[\s\S]{0,80}\binsufficient (?:account )?balance\b/,
+  /\binsufficient (?:skill|billing|payment|provider|api) account balance\b/,
+  /\baccount (?:top-?up|recharge)\b/,
+  /\b(?:top ?up|recharge) (?:the )?(?:skill )?account\b/,
+  /账户余额不足/,
+  /技能账户充值/,
+  /安装支付技能/,
+] satisfies RegExp[];
+
+const NEGATED_PAID_SERVICE_PATTERNS = [
+  /\bno\s+(?:(?:additional|extra|further)\s+)?payments?\s+(?:(?:is|are|was|were|be|being|been)\s+)?required\b/,
+  /\bnever\s+requires?\s+(?:a\s+)?(?:(?:paid|pro|premium|billing)\s+)?(?:subscription|payment|plan|account|service|tier|api|provider|membership)\b/,
+  /\b(?:do|does|did)\s+not\s+(?:currently\s+|also\s+|normally\s+|usually\s+)?requires?\s+(?:a\s+)?(?:(?:paid|pro|premium|billing)\s+)?(?:subscription|payment|plan|account|service|tier|api|provider|membership)\b/,
+  /\b(?:do|does|did)n['’]t\s+(?:currently\s+|also\s+|normally\s+|usually\s+)?requires?\s+(?:a\s+)?(?:(?:paid|pro|premium|billing)\s+)?(?:subscription|payment|plan|account|service|tier|api|provider|membership)\b/,
+] satisfies RegExp[];
+
 const TRANSACTION_PATTERNS = [
-  /\bsign(?:ing)? (?:and )?(?:submit|send|broadcast)? ?transactions?\b/,
+  /\bsign(?:s|ed|ing)?\s+(?!in(?:to)?\b|up\b|out\b|on(?:to)?\b|off\b)(?:and\s+)?(?:(?:submit|send|broadcast|authorize|approve)\s+)?(?:[\w-]+\s+){0,4}transactions?\b/,
+  /\b(?:send|sends|sending|sent|submit|submits|submitting|submitted|broadcast|broadcasts|broadcasting|broadcasted|authorize|authorizes|authorizing|authorized|approve|approves|approving|approved)\s+(?:[\w-]+\s+){0,4}(?:ach|bank|wire|payment|card|credit|debit|invoice|vendor|supplier|merchant|ethereum|eth|bitcoin|btc|crypto|on-?chain|wallet|tokens?|coins?|nfts?|usdc|erc-?20)\s+(?:[\w-]+\s+){0,4}transactions?\b/,
   /\bsendtransaction\b/,
   /\bapproval_required\b/,
   /\bon-?chain (?:tx|transaction)\b/,
@@ -89,6 +146,10 @@ const TRANSACTION_PATTERNS = [
   /\bbroadcast (?:transaction|tx)\b/,
   /\btransaction broadcast\b/,
   /\bwalletclient\.sendtransaction\b/,
+] satisfies RegExp[];
+
+const NON_FINANCIAL_TRANSACTION_PATTERNS = [
+  /\b(?:signs?|signed|signing|executes?|executed|executing|approves?|approved|approving)\s+(?:[\w-]+\s+){0,3}(?:database|sql|postgres|mysql|internal|workflow)\s+transactions?\b/,
 ] satisfies RegExp[];
 
 const OAUTH_PATTERNS = [
@@ -143,26 +204,29 @@ export function deriveSkillCapabilityTags(params: {
   const isCrypto = matches(text, CRYPTO_PATTERNS);
   const requiresWallet = matches(text, WALLET_PATTERNS);
   const canMakePurchases = matches(text, PURCHASE_PATTERNS);
-  const canSignTransactions = matches(text, TRANSACTION_PATTERNS);
+  const paidServiceText = removeMatches(text, NEGATED_PAID_SERVICE_PATTERNS);
+  const requiresPaidService = matches(paidServiceText, PAID_SERVICE_PATTERNS);
+  const transactionText = removeMatches(text, NON_FINANCIAL_TRANSACTION_PATTERNS);
+  const canSignTransactions = matches(transactionText, TRANSACTION_PATTERNS);
   const requiresOauthToken = matches(text, OAUTH_PATTERNS);
   const requiresSensitiveCredentials = matches(text, SENSITIVE_CREDENTIAL_PATTERNS);
   const postsExternally = matches(text, EXTERNAL_POST_PATTERNS);
+  const hasFinancialAuthority = canMakePurchases || canSignTransactions;
 
   if (isCrypto) tags.add("crypto");
+  if (hasFinancialAuthority) tags.add("financial-authority");
   if (requiresWallet) tags.add("requires-wallet");
   if (canMakePurchases) tags.add("can-make-purchases");
   if (canSignTransactions) tags.add("can-sign-transactions");
+  if (requiresPaidService) tags.add("requires-paid-service");
   if (requiresOauthToken) tags.add("requires-oauth-token");
   if (requiresSensitiveCredentials) tags.add("requires-sensitive-credentials");
   if (postsExternally) tags.add("posts-externally");
 
-  if (canSignTransactions || canMakePurchases) {
-    tags.add("crypto");
-  }
-  if (canSignTransactions) {
+  if (canSignTransactions && isCrypto) {
     tags.add("requires-wallet");
   }
-  if (requiresWallet || canSignTransactions || requiresOauthToken) {
+  if (tags.has("requires-wallet") || canSignTransactions || requiresOauthToken) {
     tags.add("requires-sensitive-credentials");
   }
 

--- a/convex/maintenance.test.ts
+++ b/convex/maintenance.test.ts
@@ -16,6 +16,8 @@ vi.mock("./_generated/api", () => ({
         "applySkillFingerprintBackfillPatchInternal",
       ),
       backfillSkillFingerprintsInternal: Symbol("backfillSkillFingerprintsInternal"),
+      applySkillCapabilityTagsInternal: Symbol("applySkillCapabilityTagsInternal"),
+      backfillSkillCapabilityTagsInternal: Symbol("backfillSkillCapabilityTagsInternal"),
       getEmptySkillCleanupPageInternal: Symbol("getEmptySkillCleanupPageInternal"),
       applyEmptySkillCleanupInternal: Symbol("applyEmptySkillCleanupInternal"),
       nominateUserForEmptySkillSpamInternal: Symbol("nominateUserForEmptySkillSpamInternal"),
@@ -38,6 +40,7 @@ vi.mock("./lib/skillSummary", () => ({
 }));
 
 const {
+  applySkillCapabilityTagsInternal,
   backfillLatestVersionSummaryInternal,
   backfillSkillFingerprintsInternalHandler,
   backfillSkillSummariesInternalHandler,
@@ -406,6 +409,188 @@ describe("maintenance badge denormalization", () => {
       badges: {
         official: { byUserId: "users:2", at: 456 },
       },
+    });
+  });
+});
+
+describe("maintenance capability tag backfill", () => {
+  it("keeps latest skill search digest capability tags in sync", async () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1234);
+    const get = vi
+      .fn()
+      .mockResolvedValueOnce({
+        _id: "skillVersions:1",
+        capabilityTags: ["can-make-purchases"],
+      })
+      .mockResolvedValueOnce({
+        _id: "skills:1",
+        latestVersionId: "skillVersions:1",
+        capabilityTags: ["can-make-purchases"],
+      });
+    const unique = vi.fn().mockResolvedValue({
+      _id: "skillSearchDigest:1",
+      capabilityTags: ["can-make-purchases"],
+    });
+    const withIndex = vi.fn((_indexName, callback) => {
+      callback({ eq: vi.fn() });
+      return { unique };
+    });
+    const query = vi.fn().mockReturnValue({ withIndex });
+    const patch = vi.fn().mockResolvedValue(undefined);
+
+    const result = await (
+      applySkillCapabilityTagsInternal as unknown as { _handler: Function }
+    )._handler(
+      {
+        db: {
+          get,
+          patch,
+          query,
+          normalizeId: vi.fn(),
+        },
+      } as never,
+      {
+        skillId: "skills:1",
+        versionId: "skillVersions:1",
+        capabilityTags: ["financial-authority", "can-make-purchases"],
+      },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      versionPatched: true,
+      skillPatched: true,
+      digestPatched: true,
+    });
+    expect(patch).toHaveBeenNthCalledWith(1, "skillVersions:1", {
+      capabilityTags: ["financial-authority", "can-make-purchases"],
+    });
+    expect(patch).toHaveBeenNthCalledWith(2, "skills:1", {
+      capabilityTags: ["financial-authority", "can-make-purchases"],
+      updatedAt: 1234,
+    });
+    expect(patch).toHaveBeenNthCalledWith(3, "skillSearchDigest:1", {
+      capabilityTags: ["financial-authority", "can-make-purchases"],
+      updatedAt: 1234,
+    });
+    expect(query).toHaveBeenCalledWith("skillSearchDigest");
+    expect(withIndex).toHaveBeenCalledWith("by_skill", expect.any(Function));
+
+    nowSpy.mockRestore();
+  });
+
+  it("counts trigger-synced digest tags when the latest skill tags change", async () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(2222);
+    const get = vi
+      .fn()
+      .mockResolvedValueOnce({
+        _id: "skillVersions:1",
+        capabilityTags: ["can-make-purchases"],
+      })
+      .mockResolvedValueOnce({
+        _id: "skills:1",
+        latestVersionId: "skillVersions:1",
+        capabilityTags: ["can-make-purchases"],
+      });
+    const unique = vi.fn().mockResolvedValue({
+      _id: "skillSearchDigest:1",
+      capabilityTags: ["financial-authority", "can-make-purchases"],
+    });
+    const withIndex = vi.fn((_indexName, callback) => {
+      callback({ eq: vi.fn() });
+      return { unique };
+    });
+    const query = vi.fn().mockReturnValue({ withIndex });
+    const patch = vi.fn().mockResolvedValue(undefined);
+
+    const result = await (
+      applySkillCapabilityTagsInternal as unknown as { _handler: Function }
+    )._handler(
+      {
+        db: {
+          get,
+          patch,
+          query,
+          normalizeId: vi.fn(),
+        },
+      } as never,
+      {
+        skillId: "skills:1",
+        versionId: "skillVersions:1",
+        capabilityTags: ["financial-authority", "can-make-purchases"],
+      },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      versionPatched: true,
+      skillPatched: true,
+      digestPatched: true,
+    });
+    expect(patch).toHaveBeenCalledTimes(2);
+    expect(patch).toHaveBeenNthCalledWith(1, "skillVersions:1", {
+      capabilityTags: ["financial-authority", "can-make-purchases"],
+    });
+    expect(patch).toHaveBeenNthCalledWith(2, "skills:1", {
+      capabilityTags: ["financial-authority", "can-make-purchases"],
+      updatedAt: 2222,
+    });
+
+    nowSpy.mockRestore();
+  });
+
+  it("repairs a stale latest skill search digest even when skill tags already match", async () => {
+    const get = vi
+      .fn()
+      .mockResolvedValueOnce({
+        _id: "skillVersions:1",
+        capabilityTags: ["financial-authority", "can-make-purchases"],
+      })
+      .mockResolvedValueOnce({
+        _id: "skills:1",
+        latestVersionId: "skillVersions:1",
+        capabilityTags: ["financial-authority", "can-make-purchases"],
+        updatedAt: 987,
+      });
+    const unique = vi.fn().mockResolvedValue({
+      _id: "skillSearchDigest:1",
+      capabilityTags: ["can-make-purchases"],
+    });
+    const withIndex = vi.fn((_indexName, callback) => {
+      callback({ eq: vi.fn() });
+      return { unique };
+    });
+    const query = vi.fn().mockReturnValue({ withIndex });
+    const patch = vi.fn().mockResolvedValue(undefined);
+
+    const result = await (
+      applySkillCapabilityTagsInternal as unknown as { _handler: Function }
+    )._handler(
+      {
+        db: {
+          get,
+          patch,
+          query,
+          normalizeId: vi.fn(),
+        },
+      } as never,
+      {
+        skillId: "skills:1",
+        versionId: "skillVersions:1",
+        capabilityTags: ["financial-authority", "can-make-purchases"],
+      },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      versionPatched: false,
+      skillPatched: false,
+      digestPatched: true,
+    });
+    expect(patch).toHaveBeenCalledTimes(1);
+    expect(patch).toHaveBeenCalledWith("skillSearchDigest:1", {
+      capabilityTags: ["financial-authority", "can-make-purchases"],
+      updatedAt: 987,
     });
   });
 });

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -497,6 +497,7 @@ type CapabilityBackfillStats = {
   skillsScanned: number;
   skillsPatched: number;
   versionsPatched: number;
+  digestsPatched: number;
   missingVersions: number;
   missingStorageBlob: number;
 };
@@ -521,12 +522,15 @@ export const applySkillCapabilityTagsInternal = internalMutation({
     if (!skill) return { ok: false as const, reason: "missing_skill" as const };
 
     const normalizedTags = [...new Set(args.capabilityTags)];
+    const nextCapabilityTags = normalizedTags.length ? normalizedTags : undefined;
     let versionPatched = false;
     let skillPatched = false;
+    let digestPatched = false;
+    let skillUpdatedAt: number | undefined;
 
     if (JSON.stringify(version.capabilityTags ?? []) !== JSON.stringify(normalizedTags)) {
       await ctx.db.patch(version._id, {
-        capabilityTags: normalizedTags.length ? normalizedTags : undefined,
+        capabilityTags: nextCapabilityTags,
       });
       versionPatched = true;
     }
@@ -535,14 +539,33 @@ export const applySkillCapabilityTagsInternal = internalMutation({
       skill.latestVersionId === version._id &&
       JSON.stringify(skill.capabilityTags ?? []) !== JSON.stringify(normalizedTags)
     ) {
+      skillUpdatedAt = Date.now();
       await ctx.db.patch(skill._id, {
-        capabilityTags: normalizedTags.length ? normalizedTags : undefined,
-        updatedAt: Date.now(),
+        capabilityTags: nextCapabilityTags,
+        updatedAt: skillUpdatedAt,
       });
       skillPatched = true;
+      digestPatched = true;
     }
 
-    return { ok: true as const, versionPatched, skillPatched };
+    if (skill.latestVersionId === version._id) {
+      const digest = await ctx.db
+        .query("skillSearchDigest")
+        .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
+        .unique();
+      if (
+        digest &&
+        JSON.stringify(digest.capabilityTags ?? []) !== JSON.stringify(normalizedTags)
+      ) {
+        await ctx.db.patch(digest._id, {
+          capabilityTags: nextCapabilityTags,
+          updatedAt: skillUpdatedAt ?? skill.updatedAt,
+        });
+        digestPatched = true;
+      }
+    }
+
+    return { ok: true as const, versionPatched, skillPatched, digestPatched };
   },
 });
 
@@ -566,6 +589,7 @@ export async function backfillSkillCapabilityTagsInternalHandler(
     skillsScanned: 0,
     skillsPatched: 0,
     versionsPatched: 0,
+    digestsPatched: 0,
     missingVersions: 0,
     missingStorageBlob: 0,
   };
@@ -644,6 +668,7 @@ export async function backfillSkillCapabilityTagsInternalHandler(
       if (result.ok) {
         if (result.skillPatched) stats.skillsPatched += 1;
         if (result.versionPatched) stats.versionsPatched += 1;
+        if (result.digestPatched) stats.digestsPatched += 1;
       }
     }
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -361,8 +361,9 @@ Notes:
 - If neither `version` nor `tag` is provided, uses the latest version.
 - Includes normalized verification status plus scanner-specific details.
 - `security.capabilityTags` includes deterministic capability/risk labels such as
-  `crypto`, `requires-wallet`, `can-make-purchases`, `can-sign-transactions`,
-  `requires-oauth-token`, and `posts-externally` when detected.
+  `crypto`, `financial-authority`, `requires-wallet`, `can-make-purchases`,
+  `can-sign-transactions`, `requires-paid-service`, `requires-oauth-token`, and
+  `posts-externally` when detected.
 - `security.hasScanResult` is `true` only when a scanner produced a definitive verdict (`clean`, `suspicious`, or `malicious`).
 - `moderation` is a current skill-level moderation snapshot derived from the latest version.
 - When querying a historical version, check `moderation.matchesRequestedVersion` and `moderation.sourceVersion` before treating `moderation` and `security` as the same version context.

--- a/src/components/SkillSecurityScanResults.test.tsx
+++ b/src/components/SkillSecurityScanResults.test.tsx
@@ -155,15 +155,23 @@ describe("SecurityScanResults static guidance", () => {
   it("renders capability labels separately from scan verdicts", () => {
     render(
       <SecurityScanResults
-        capabilityTags={["crypto", "requires-wallet", "can-make-purchases"]}
+        capabilityTags={[
+          "crypto",
+          "financial-authority",
+          "requires-wallet",
+          "can-make-purchases",
+          "requires-paid-service",
+        ]}
         llmAnalysis={{ status: "clean", checkedAt: Date.now() }}
       />,
     );
 
     expect(screen.getByText("Capability signals")).toBeTruthy();
     expect(screen.getByText("Crypto")).toBeTruthy();
+    expect(screen.getByText("Financial authority")).toBeTruthy();
     expect(screen.getByText("Requires wallet")).toBeTruthy();
     expect(screen.getByText("Can make purchases")).toBeTruthy();
+    expect(screen.getByText("Requires paid service")).toBeTruthy();
   });
 
   it("hides advisory static findings from the public scan panel", () => {

--- a/src/components/SkillSecurityScanResults.tsx
+++ b/src/components/SkillSecurityScanResults.tsx
@@ -43,9 +43,11 @@ type LlmRiskSummary = Record<ClawScanRiskBucket, LlmRiskSummaryBucket>;
 
 const SKILL_CAPABILITY_LABELS: Record<string, string> = {
   crypto: "Crypto",
+  "financial-authority": "Financial authority",
   "requires-wallet": "Requires wallet",
   "can-make-purchases": "Can make purchases",
   "can-sign-transactions": "Can sign transactions",
+  "requires-paid-service": "Requires paid service",
   "requires-oauth-token": "Requires OAuth token",
   "requires-sensitive-credentials": "Requires sensitive credentials",
   "posts-externally": "Posts externally",

--- a/src/routes/skills/-SkillsToolbar.tsx
+++ b/src/routes/skills/-SkillsToolbar.tsx
@@ -48,9 +48,11 @@ type SkillsToolbarProps = {
 
 const SKILL_CAPABILITY_LABELS: Record<string, string> = {
   crypto: "Crypto",
+  "financial-authority": "Financial authority",
   "requires-wallet": "Requires wallet",
   "can-make-purchases": "Payments",
   "can-sign-transactions": "Signs transactions",
+  "requires-paid-service": "Paid service",
   "requires-oauth-token": "OAuth",
   "requires-sensitive-credentials": "Sensitive credentials",
   "posts-externally": "External posting",

--- a/src/routes/skills/-useSkillsBrowseModel.ts
+++ b/src/routes/skills/-useSkillsBrowseModel.ts
@@ -37,9 +37,11 @@ export type SkillsSearchState = {
 
 const SKILL_CAPABILITY_LABELS: Record<string, string> = {
   crypto: "crypto",
+  "financial-authority": "financial authority",
   "requires-wallet": "requires wallet",
   "can-make-purchases": "payments",
   "can-sign-transactions": "signs transactions",
+  "requires-paid-service": "paid service",
   "requires-oauth-token": "oauth",
   "requires-sensitive-credentials": "sensitive credentials",
   "posts-externally": "external posting",


### PR DESCRIPTION
## Summary

- Add `financial-authority` and `requires-paid-service` skill capability tags.
- Stop deriving `crypto` and `requires-wallet` from purchase or transaction-signing authority alone.
- Split billing/setup helper text, including SMYX-style 402 recharge guidance, from actual purchase authority.
- Add UI labels and API docs for the new capability tags.

## Tests

- `bunx vitest run convex/lib/skillCapabilityTags.test.ts`
- `bunx vitest run src/components/SkillSecurityScanResults.test.tsx`
- `bun run format:check`
- `bun run lint`
- `bun run test`
- `bunx tsc --noEmit`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`

## Notes

The isolated worktree needed `bun install` before broad tests because it initially resolved partial dependencies from the parent checkout.
