### PR TITLE
Fix undetected VirusTotal results staying pending

### DIFF
--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -4,9 +4,21 @@ on:
   workflow_dispatch:
     inputs:
       limit:
-        description: "Maximum Codex scans to claim"
+        description: "Deprecated alias for batch-limit"
+        required: false
+        default: ""
+      batch-limit:
+        description: "Maximum Codex scans to run in parallel per batch"
         required: true
-        default: "10"
+        default: "20"
+      max-jobs:
+        description: "Optional total jobs cap for this run"
+        required: false
+        default: ""
+      max-runtime-minutes:
+        description: "Stop claiming new batches after this many minutes"
+        required: true
+        default: "40"
   schedule:
     - cron: "*/10 * * * *"
 
@@ -20,13 +32,16 @@ permissions:
 jobs:
   codex-security-scan:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     environment: Production
     env:
       CONVEX_URL: ${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}
       SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      CODEX_SECURITY_SCAN_LIMIT: ${{ inputs.limit || '10' }}
+      CODEX_SECURITY_SCAN_LIMIT: ${{ inputs.limit || inputs['batch-limit'] || '20' }}
+      CODEX_SECURITY_SCAN_MAX_JOBS: ${{ inputs['max-jobs'] || '' }}
+      CODEX_SECURITY_SCAN_MAX_RUNTIME_MINUTES: ${{ inputs['max-runtime-minutes'] || '40' }}
+      CODEX_SECURITY_SCAN_LEASE_MINUTES: "60"
     steps:
       - uses: actions/checkout@v6
 
@@ -56,4 +71,9 @@ jobs:
         run: printf '%s' "$OPENAI_API_KEY" | codex login --with-api-key
 
       - name: Run Codex security worker
-        run: bun scripts/security/run-codex-scan-worker.ts --limit "$CODEX_SECURITY_SCAN_LIMIT"
+        run: |
+          bun scripts/security/run-codex-scan-worker.ts \
+            --batch-limit "$CODEX_SECURITY_SCAN_LIMIT" \
+            --max-jobs "$CODEX_SECURITY_SCAN_MAX_JOBS" \
+            --max-runtime-minutes "$CODEX_SECURITY_SCAN_MAX_RUNTIME_MINUTES" \
+            --lease-minutes "$CODEX_SECURITY_SCAN_LEASE_MINUTES"

--- a/convex/securityScan.ts
+++ b/convex/securityScan.ts
@@ -3,9 +3,9 @@ import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import { action, internalMutation, internalQuery } from "./functions";
 
-const MAX_PARALLEL_CODEX_SCANS = 10;
+const MAX_PARALLEL_CODEX_SCANS = 20;
 const DEFAULT_VT_WAIT_MS = 10 * 60 * 1000;
-const DEFAULT_LEASE_MS = 30 * 60 * 1000;
+const DEFAULT_LEASE_MS = 60 * 60 * 1000;
 const MAX_ATTEMPTS = 3;
 const DEFAULT_CANCEL_SCAN_LIMIT = 1000;
 const DEFAULT_CANCEL_DELETE_LIMIT = 500;
@@ -521,6 +521,7 @@ export const claimCodexScanJobs = action({
     token: v.string(),
     workerId: v.string(),
     limit: v.optional(v.number()),
+    leaseMs: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     assertWorkerToken(args.token);
@@ -530,6 +531,7 @@ export const claimCodexScanJobs = action({
       {
         workerId: args.workerId,
         limit: normalizeLimit(args.limit),
+        leaseMs: args.leaseMs,
       },
     );
 

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -5942,16 +5942,16 @@ export const getSkillsWithStaleModerationReasonInternal = internalQuery({
  * Returns skills regardless of whether they have vtAnalysis cached.
  */
 export const getPendingVTSkillsInternal = internalQuery({
-  args: { limit: v.optional(v.number()) },
+  args: { limit: v.optional(v.number()), cursor: v.optional(v.union(v.string(), v.null())) },
   handler: async (ctx, args) => {
     const limit = args.limit ?? 100;
 
-    const skills = await ctx.db
+    const { page, continueCursor, isDone } = await ctx.db
       .query("skills")
       .withIndex("by_moderation", (q) =>
         q.eq("moderationStatus", "active").eq("moderationReason", "scanner.vt.pending"),
       )
-      .take(limit);
+      .paginate({ cursor: args.cursor ?? null, numItems: limit });
 
     const results: Array<{
       skillId: Id<"skills">;
@@ -5960,7 +5960,7 @@ export const getPendingVTSkillsInternal = internalQuery({
       sha256hash: string;
     }> = [];
 
-    for (const skill of skills) {
+    for (const skill of page) {
       if (!skill.latestVersionId) continue;
       const version = await ctx.db.get(skill.latestVersionId);
       if (!version?.sha256hash) continue;
@@ -5973,7 +5973,7 @@ export const getPendingVTSkillsInternal = internalQuery({
       });
     }
 
-    return results;
+    return { skills: results, cursor: continueCursor, done: isDone };
   },
 });
 

--- a/convex/vt.test.ts
+++ b/convex/vt.test.ts
@@ -6,6 +6,7 @@ import {
   fetchResults,
   pollPendingScans,
   pollPackageReleaseScanResults,
+  repairPendingSkillVtAnalysis,
   scanWithVirusTotal,
   scanPackageReleaseWithVirusTotal,
 } from "./vt";
@@ -46,7 +47,41 @@ const pollPendingScansHandler = (
   >
 )._handler;
 
+const repairPendingSkillVtAnalysisHandler = (
+  repairPendingSkillVtAnalysis as unknown as WrappedHandler<
+    { dryRun: boolean; batchSize?: number; cursor?: string | null },
+    {
+      dryRun: boolean;
+      total: number;
+      wouldUpdate: number;
+      updated: number;
+      noResults: number;
+      noDecisiveStats: number;
+      errors: number;
+      done: boolean;
+      cursor: string | null;
+      statusCounts: Record<string, number>;
+      sampleUpdated: Array<{ slug: string; status: string }>;
+    }
+  >
+)._handler;
+
 const originalVtApiKey = process.env.VT_API_KEY;
+
+function mutationPayloads(mock: ReturnType<typeof vi.fn>) {
+  return mock.mock.calls.map((call) => call[1] as Record<string, unknown>);
+}
+
+function expectVtAnalysisMutation(
+  mock: ReturnType<typeof vi.fn>,
+  expected: Record<string, unknown>,
+) {
+  expect(mutationPayloads(mock)).toContainEqual(
+    expect.objectContaining({
+      vtAnalysis: expect.objectContaining(expected),
+    }),
+  );
+}
 
 afterEach(() => {
   if (originalVtApiKey === undefined) {
@@ -167,7 +202,7 @@ describe("vt AV engine fallback verdicts", () => {
     ).toBe("clean");
   });
 
-  it("keeps undetected-only results pending", () => {
+  it("treats undetected-only engine results as clean no-detections telemetry", () => {
     expect(
       __test.statusFromAvStats({
         malicious: 0,
@@ -175,7 +210,7 @@ describe("vt AV engine fallback verdicts", () => {
         harmless: 0,
         undetected: 40,
       }),
-    ).toBeNull();
+    ).toBe("clean");
   });
 });
 
@@ -517,7 +552,7 @@ describe("package VT retries", () => {
     expect(scheduler.runAfter).not.toHaveBeenCalled();
   });
 
-  it("does not promote official source-linked packages with suspicious static scans via fallback", async () => {
+  it("stores undetected-only package VT telemetry even when static scans are suspicious", async () => {
     process.env.VT_API_KEY = "test-key";
     const fetchMock = vi
       .fn()
@@ -574,16 +609,16 @@ describe("package VT retries", () => {
       { releaseId: "packageReleases:demo" },
     );
 
-    expect(runMutation.mock.calls.length).toBe(1);
-    const mutationCalls = runMutation.mock.calls as unknown as Array<
-      [unknown, Record<string, unknown>]
-    >;
-    expect(mutationCalls.some(([, payload]) => "vtAnalysis" in payload)).toBe(false);
-    expect(fetchMock.mock.calls.length).toBe(2);
-    expect(scheduler.runAfter.mock.calls.length).toBe(1);
+    expectVtAnalysisMutation(runMutation, {
+      status: "clean",
+      source: "engines",
+      engineStats: expect.objectContaining({ undetected: 66 }),
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(scheduler.runAfter).not.toHaveBeenCalled();
   });
 
-  it("promotes official source-linked packages with clean static scans via fallback", async () => {
+  it("stores undetected-only official package VT telemetry as clean engine results", async () => {
     process.env.VT_API_KEY = "test-key";
     const fetchMock = vi.fn().mockResolvedValueOnce({
       ok: true,
@@ -634,22 +669,16 @@ describe("package VT retries", () => {
       { releaseId: "packageReleases:demo" },
     );
 
-    expect(runMutation).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        releaseId: "packageReleases:demo",
-        vtAnalysis: expect.objectContaining({
-          status: "clean",
-          source: "engines-undetected-fallback",
-          verdict: "undetected-only-fallback",
-        }),
-      }),
-    );
+    expectVtAnalysisMutation(runMutation, {
+      status: "clean",
+      source: "engines",
+      engineStats: expect.objectContaining({ undetected: 66 }),
+    });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(scheduler.runAfter).not.toHaveBeenCalled();
   });
 
-  it("promotes community source-linked packages with undetected-only VT stats via fallback", async () => {
+  it("stores undetected-only community package VT telemetry as clean engine results", async () => {
     process.env.VT_API_KEY = "test-key";
     const fetchMock = vi.fn().mockResolvedValueOnce({
       ok: true,
@@ -700,17 +729,11 @@ describe("package VT retries", () => {
       { releaseId: "packageReleases:demo" },
     );
 
-    expect(runMutation).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        releaseId: "packageReleases:demo",
-        vtAnalysis: expect.objectContaining({
-          status: "clean",
-          source: "engines-undetected-fallback",
-          verdict: "undetected-only-fallback",
-        }),
-      }),
-    );
+    expectVtAnalysisMutation(runMutation, {
+      status: "clean",
+      source: "engines",
+      engineStats: expect.objectContaining({ undetected: 66 }),
+    });
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(scheduler.runAfter).not.toHaveBeenCalled();
   });
@@ -740,7 +763,7 @@ describe("package VT retries", () => {
     });
   });
 
-  it("does not apply undetected-only fallback during package polling when static scan is suspicious", async () => {
+  it("stores undetected-only package VT telemetry during polling even when static scan is suspicious", async () => {
     process.env.VT_API_KEY = "test-key";
     vi.stubGlobal(
       "fetch",
@@ -787,11 +810,15 @@ describe("package VT retries", () => {
       { releaseId: "packageReleases:demo", attempt: 3 },
     );
 
-    expect(runMutation).not.toHaveBeenCalled();
-    expect(scheduler.runAfter).toHaveBeenCalledTimes(1);
+    expectVtAnalysisMutation(runMutation, {
+      status: "clean",
+      source: "engines",
+      engineStats: expect.objectContaining({ undetected: 66 }),
+    });
+    expect(scheduler.runAfter).not.toHaveBeenCalled();
   });
 
-  it("applies the same undetected-only fallback during community package polling", async () => {
+  it("stores undetected-only community package VT telemetry during polling", async () => {
     process.env.VT_API_KEY = "test-key";
     vi.stubGlobal(
       "fetch",
@@ -838,21 +865,15 @@ describe("package VT retries", () => {
       { releaseId: "packageReleases:demo", attempt: 3 },
     );
 
-    expect(runMutation).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        releaseId: "packageReleases:demo",
-        vtAnalysis: expect.objectContaining({
-          status: "clean",
-          source: "engines-undetected-fallback",
-          verdict: "undetected-only-fallback",
-        }),
-      }),
-    );
+    expectVtAnalysisMutation(runMutation, {
+      status: "clean",
+      source: "engines",
+      engineStats: expect.objectContaining({ undetected: 66 }),
+    });
     expect(scheduler.runAfter).not.toHaveBeenCalled();
   });
 
-  it("does not promote undetected-only community packages without trusted verification", async () => {
+  it("stores undetected-only package VT telemetry without requiring trusted verification", async () => {
     process.env.VT_API_KEY = "test-key";
     const fetchMock = vi
       .fn()
@@ -903,12 +924,13 @@ describe("package VT retries", () => {
       { releaseId: "packageReleases:demo", attempt: 3 },
     );
 
-    expect(runMutation).not.toHaveBeenCalled();
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(scheduler.runAfter).toHaveBeenCalledWith(5 * 60 * 1000, expect.anything(), {
-      releaseId: "packageReleases:demo",
-      attempt: 4,
+    expectVtAnalysisMutation(runMutation, {
+      status: "clean",
+      source: "engines",
+      engineStats: expect.objectContaining({ undetected: 66 }),
     });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(scheduler.runAfter).not.toHaveBeenCalled();
   });
 });
 
@@ -956,11 +978,266 @@ describe("vt pending polling", () => {
       batchSize: 1,
     });
 
-    expect(result).toMatchObject({ processed: 1, updated: 0, staled: 1 });
+    expect(result).toMatchObject({ processed: 1, updated: 1, staled: 0 });
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        versionId: "skillVersions:pending",
+        vtAnalysis: expect.objectContaining({
+          status: "clean",
+          source: "engines",
+          engineStats: expect.objectContaining({ undetected: 66 }),
+        }),
+      }),
+    );
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith(`https://www.virustotal.com/api/v3/files/${hash}`, {
       method: "GET",
       headers: { "x-apikey": "test-key" },
+    });
+  });
+});
+
+describe("vt pending repair", () => {
+  it("dry-runs completed undetected-only pending skills without writing", async () => {
+    process.env.VT_API_KEY = "test-key";
+    const hash = "d".repeat(64);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: {
+            attributes: {
+              last_analysis_stats: {
+                malicious: 0,
+                suspicious: 0,
+                harmless: 0,
+                undetected: 66,
+              },
+            },
+          },
+        }),
+      }),
+    );
+
+    const runMutation = vi.fn(async () => null);
+    const result = await repairPendingSkillVtAnalysisHandler(
+      {
+        runQuery: vi.fn().mockResolvedValue({
+          skills: [
+            {
+              skillId: "skills:pending",
+              versionId: "skillVersions:pending",
+              slug: "pending-skill",
+              sha256hash: hash,
+            },
+          ],
+          cursor: "next-page",
+          done: false,
+        }),
+        runMutation,
+      } as never,
+      { dryRun: true, batchSize: 1, cursor: "start-page" },
+    );
+
+    expect(result).toMatchObject({
+      dryRun: true,
+      total: 1,
+      wouldUpdate: 1,
+      updated: 0,
+      done: false,
+      cursor: "next-page",
+      statusCounts: { clean: 1 },
+      sampleUpdated: [{ slug: "pending-skill", status: "clean" }],
+    });
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("repairs completed undetected-only pending skills and recomputes moderation", async () => {
+    process.env.VT_API_KEY = "test-key";
+    const hash = "e".repeat(64);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: {
+            attributes: {
+              last_analysis_stats: {
+                malicious: 0,
+                suspicious: 0,
+                harmless: 0,
+                undetected: 66,
+              },
+            },
+          },
+        }),
+      }),
+    );
+
+    const runMutation = vi.fn(async () => null);
+    const result = await repairPendingSkillVtAnalysisHandler(
+      {
+        runQuery: vi.fn().mockResolvedValue({
+          skills: [
+            {
+              skillId: "skills:pending",
+              versionId: "skillVersions:pending",
+              slug: "pending-skill",
+              sha256hash: hash,
+            },
+          ],
+          cursor: null,
+          done: true,
+        }),
+        runMutation,
+      } as never,
+      { dryRun: false, batchSize: 1 },
+    );
+
+    expect(result).toMatchObject({
+      dryRun: false,
+      total: 1,
+      wouldUpdate: 1,
+      updated: 1,
+      done: true,
+      cursor: null,
+      statusCounts: { clean: 1 },
+    });
+    expect(mutationPayloads(runMutation)).toContainEqual(
+      expect.objectContaining({
+        versionId: "skillVersions:pending",
+        sha256hash: hash,
+        vtAnalysis: expect.objectContaining({
+          status: "clean",
+          source: "engines",
+          engineStats: expect.objectContaining({ undetected: 66 }),
+        }),
+      }),
+    );
+    expect(mutationPayloads(runMutation)).toContainEqual(
+      expect.objectContaining({ skillId: "skills:pending" }),
+    );
+    expect(mutationPayloads(runMutation)).not.toContainEqual(
+      expect.objectContaining({ source: "vt-update" }),
+    );
+  });
+
+  it("queues ClawScan follow-up when repaired VT telemetry is suspicious", async () => {
+    process.env.VT_API_KEY = "test-key";
+    const hash = "f".repeat(64);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: {
+            attributes: {
+              last_analysis_stats: {
+                malicious: 0,
+                suspicious: 1,
+                harmless: 0,
+                undetected: 65,
+              },
+            },
+          },
+        }),
+      }),
+    );
+
+    const runMutation = vi.fn(async () => null);
+    const result = await repairPendingSkillVtAnalysisHandler(
+      {
+        runQuery: vi.fn().mockResolvedValue({
+          skills: [
+            {
+              skillId: "skills:pending",
+              versionId: "skillVersions:pending",
+              slug: "pending-skill",
+              sha256hash: hash,
+            },
+          ],
+          cursor: null,
+          done: true,
+        }),
+        runMutation,
+      } as never,
+      { dryRun: false, batchSize: 100 },
+    );
+
+    expect(result).toMatchObject({
+      wouldUpdate: 1,
+      updated: 1,
+      statusCounts: { suspicious: 1 },
+    });
+    expect(mutationPayloads(runMutation)).toContainEqual(
+      expect.objectContaining({
+        versionId: "skillVersions:pending",
+        source: "vt-update",
+        waitForVtMs: 0,
+      }),
+    );
+    expect(mutationPayloads(runMutation)).not.toContainEqual(
+      expect.objectContaining({ skillId: "skills:pending" }),
+    );
+  });
+
+  it("returns pagination cursor when unresolved pending VT rows are skipped", async () => {
+    process.env.VT_API_KEY = "test-key";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+      }),
+    );
+
+    const runMutation = vi.fn(async () => null);
+    const result = await repairPendingSkillVtAnalysisHandler(
+      {
+        runQuery: vi.fn().mockResolvedValue({
+          skills: [
+            {
+              skillId: "skills:pending",
+              versionId: "skillVersions:pending",
+              slug: "pending-skill",
+              sha256hash: "a".repeat(64),
+            },
+          ],
+          cursor: "next-page",
+          done: false,
+        }),
+        runMutation,
+      } as never,
+      { dryRun: true, batchSize: 1 },
+    );
+
+    expect(result).toMatchObject({
+      total: 1,
+      wouldUpdate: 0,
+      noResults: 1,
+      done: false,
+      cursor: "next-page",
+    });
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("reports done only when no pending VT skills are selected", async () => {
+    process.env.VT_API_KEY = "test-key";
+
+    const result = await repairPendingSkillVtAnalysisHandler(
+      {
+        runQuery: vi.fn().mockResolvedValue({ skills: [], cursor: null, done: true }),
+        runMutation: vi.fn(async () => null),
+      } as never,
+      { dryRun: true, batchSize: 100 },
+    );
+
+    expect(result).toMatchObject({
+      total: 0,
+      wouldUpdate: 0,
+      done: true,
     });
   });
 });

--- a/convex/vt.ts
+++ b/convex/vt.ts
@@ -238,6 +238,7 @@ function buildPackageScanAnalysisFromVtResult(
     return {
       status,
       source: "engines",
+      engineStats: normalizeVtEngineStats(stats),
       checkedAt: Date.now(),
     };
   }
@@ -300,6 +301,13 @@ type ActiveSkillsMissingVTCache = {
   slug: string;
 };
 
+type PendingVTSkill = {
+  skillId: Id<"skills">;
+  versionId: Id<"skillVersions">;
+  sha256hash: string;
+  slug: string;
+};
+
 type NullModerationStatusSkill = {
   skillId: Id<"skills">;
   slug: string;
@@ -333,6 +341,22 @@ type BackfillActiveSkillsVTCacheResult =
   | { total: number; updated: number; noResults: number; errors: number; done: boolean }
   | { error: string };
 
+type RepairPendingSkillVtAnalysisResult =
+  | {
+      dryRun: boolean;
+      total: number;
+      wouldUpdate: number;
+      updated: number;
+      noResults: number;
+      noDecisiveStats: number;
+      errors: number;
+      done: boolean;
+      cursor: string | null;
+      statusCounts: Record<string, number>;
+      sampleUpdated: Array<{ slug: string; status: string }>;
+    }
+  | { error: string };
+
 type FixNullModerationStatusResult = { total: number; fixed: number; done: boolean };
 
 type SyncModerationReasonsResult = {
@@ -348,8 +372,9 @@ function statusFromAvStats(
   if (!stats) return null;
   if (stats.malicious > 0) return "malicious";
   if (stats.suspicious > 0) return "suspicious";
-  // Keep this aligned with fetchResults: undetected-only should stay pending.
-  if (stats.harmless > 0) return "clean";
+  // VirusTotal "undetected" means engines completed and found no detection;
+  // it is resolved no-detections telemetry, not an in-progress scan.
+  if (stats.harmless > 0 || stats.undetected > 0) return "clean";
   return null;
 }
 
@@ -989,6 +1014,98 @@ export const pollPendingScans = internalAction({
       staled,
       healthy: health.healthy,
       queueSize: health.queueSize,
+    };
+  },
+});
+
+export const repairPendingSkillVtAnalysis = internalAction({
+  args: {
+    dryRun: v.boolean(),
+    batchSize: v.optional(v.number()),
+    cursor: v.optional(v.union(v.string(), v.null())),
+  },
+  handler: async (ctx, args): Promise<RepairPendingSkillVtAnalysisResult> => {
+    const apiKey = process.env.VT_API_KEY;
+    if (!apiKey) {
+      console.log("[vt:repairPendingSkillVt] VT_API_KEY not configured");
+      return { error: "VT_API_KEY not configured" };
+    }
+
+    const batchSize = Math.max(1, Math.min(Math.floor(args.batchSize ?? 100), 500));
+    const pendingPage: {
+      skills: PendingVTSkill[];
+      cursor: string | null;
+      done: boolean;
+    } = await ctx.runQuery(internal.skills.getPendingVTSkillsInternal, {
+      limit: batchSize,
+      cursor: args.cursor ?? null,
+    });
+    const skills = pendingPage.skills;
+
+    let wouldUpdate = 0;
+    let updated = 0;
+    let noResults = 0;
+    let noDecisiveStats = 0;
+    let errors = 0;
+    const statusCounts: Record<string, number> = {};
+    const sampleUpdated: Array<{ slug: string; status: string }> = [];
+
+    for (const { skillId, versionId, sha256hash, slug } of skills) {
+      try {
+        const vtResult = await checkExistingFile(apiKey, sha256hash);
+        if (!vtResult) {
+          noResults++;
+          continue;
+        }
+
+        const stats = vtResult.data.attributes.last_analysis_stats;
+        const status = statusFromAvStats(stats);
+        if (!status) {
+          noDecisiveStats++;
+          continue;
+        }
+
+        wouldUpdate++;
+        statusCounts[status] = (statusCounts[status] ?? 0) + 1;
+        if (sampleUpdated.length < 20) sampleUpdated.push({ slug, status });
+        if (args.dryRun) continue;
+
+        await ctx.runMutation(internal.skills.updateVersionScanResultsInternal, {
+          versionId,
+          sha256hash,
+          vtAnalysis: {
+            status,
+            source: "engines",
+            engineStats: normalizeVtEngineStats(stats),
+            checkedAt: Date.now(),
+          },
+        });
+        if (status === "malicious" || status === "suspicious") {
+          await enqueueSkillCodexForVtSignal(ctx, versionId);
+        } else {
+          await ctx.runMutation(internal.skills.recomputeLatestSkillModerationInternal, {
+            skillId,
+          });
+        }
+        updated++;
+      } catch (error) {
+        console.error(`[vt:repairPendingSkillVt] Error for ${slug}:`, error);
+        errors++;
+      }
+    }
+
+    return {
+      dryRun: args.dryRun,
+      total: skills.length,
+      wouldUpdate,
+      updated,
+      noResults,
+      noDecisiveStats,
+      errors,
+      done: pendingPage.done,
+      cursor: pendingPage.cursor,
+      statusCounts,
+      sampleUpdated,
     };
   },
 });

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -32,6 +32,11 @@ type ClaimedJob = {
   };
 };
 
+const DEFAULT_BATCH_LIMIT = 20;
+const DEFAULT_MAX_RUNTIME_MS = 40 * 60 * 1000;
+const DEFAULT_CODEX_SCAN_TIMEOUT_MS = 20 * 60 * 1000;
+const DEFAULT_LEASE_MS = 60 * 60 * 1000;
+
 const root = resolve(new URL("../..", import.meta.url).pathname);
 const schemaPath = join(root, "scripts/security/codex-scan-output.schema.json");
 const ARTIFACT_SIGNAL_FILE_EXTENSIONS = new Set([
@@ -59,8 +64,30 @@ function parseArgs() {
     const index = args.indexOf(name);
     return index === -1 ? undefined : args[index + 1];
   };
+  const numberFrom = (value: string | undefined, fallback: number) => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  };
+  const optionalNumberFrom = (value: string | undefined) => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+  };
   return {
-    limit: Number(get("--limit") ?? process.env.CODEX_SECURITY_SCAN_LIMIT ?? 10),
+    batchLimit: numberFrom(
+      get("--batch-limit") ?? get("--limit") ?? process.env.CODEX_SECURITY_SCAN_LIMIT,
+      DEFAULT_BATCH_LIMIT,
+    ),
+    maxJobs: optionalNumberFrom(get("--max-jobs") ?? process.env.CODEX_SECURITY_SCAN_MAX_JOBS),
+    maxRuntimeMs:
+      numberFrom(
+        get("--max-runtime-minutes") ?? process.env.CODEX_SECURITY_SCAN_MAX_RUNTIME_MINUTES,
+        DEFAULT_MAX_RUNTIME_MS / 60_000,
+      ) * 60_000,
+    leaseMs:
+      numberFrom(
+        get("--lease-minutes") ?? process.env.CODEX_SECURITY_SCAN_LEASE_MINUTES,
+        DEFAULT_LEASE_MS / 60_000,
+      ) * 60_000,
   };
 }
 
@@ -256,6 +283,11 @@ function verdictToStatus(verdict: string) {
   return verdict === "benign" ? "clean" : verdict;
 }
 
+function codexScanTimeoutMs() {
+  const parsed = Number(process.env.CODEX_SECURITY_SCAN_TIMEOUT_MS);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_CODEX_SCAN_TIMEOUT_MS;
+}
+
 async function runCodex(job: ClaimedJob, workspace: string) {
   const resultPath = join(workspace, "codex-result.json");
   const args = [
@@ -292,7 +324,7 @@ async function runCodex(job: ClaimedJob, workspace: string) {
   await runCommand("codex", args, {
     cwd: workspace,
     input: prompt,
-    timeoutMs: Number(process.env.CODEX_SECURITY_SCAN_TIMEOUT_MS ?? 20 * 60 * 1000),
+    timeoutMs: codexScanTimeoutMs(),
   });
 
   const raw = await readFile(resultPath, "utf8");
@@ -343,20 +375,45 @@ async function processJob(client: ConvexHttpClient, token: string, job: ClaimedJ
 }
 
 async function main() {
-  const { limit } = parseArgs();
+  const { batchLimit, maxJobs, maxRuntimeMs, leaseMs } = parseArgs();
   const convexUrl = process.env.CONVEX_URL ?? process.env.VITE_CONVEX_URL;
   if (!convexUrl) throw new Error("CONVEX_URL or VITE_CONVEX_URL is required");
   const token = requireEnv("SECURITY_SCAN_WORKER_TOKEN");
   const client = new ConvexHttpClient(convexUrl);
   const workerId = `github-actions:${process.env.GITHUB_RUN_ID ?? process.pid}`;
-  const jobs = (await client.action(api.securityScan.claimCodexScanJobs, {
-    token,
-    workerId,
-    limit,
-  })) as ClaimedJob[];
-  console.log(`claimed ${jobs.length} job(s)`);
-  const results = await Promise.all(jobs.map((job) => processJob(client, token, job)));
-  if (results.some((ok) => !ok)) {
+  const startedAt = Date.now();
+  const claimDeadline = startedAt + maxRuntimeMs;
+  let totalClaimed = 0;
+  let totalCompleted = 0;
+  let totalFailed = 0;
+
+  while (Date.now() < claimDeadline) {
+    const remainingJobs = maxJobs === undefined ? batchLimit : Math.max(0, maxJobs - totalClaimed);
+    if (remainingJobs === 0) break;
+    const claimLimit = Math.min(batchLimit, remainingJobs);
+    const jobs = (await client.action(api.securityScan.claimCodexScanJobs, {
+      token,
+      workerId,
+      limit: claimLimit,
+      leaseMs,
+    })) as ClaimedJob[];
+    console.log(`claimed ${jobs.length} job(s)`);
+    if (jobs.length === 0) break;
+
+    totalClaimed += jobs.length;
+    const results = await Promise.all(jobs.map((job) => processJob(client, token, job)));
+    totalCompleted += results.filter(Boolean).length;
+    totalFailed += results.filter((ok) => !ok).length;
+
+    if (jobs.length < claimLimit) break;
+  }
+
+  console.log(
+    `worker summary: claimed=${totalClaimed} completed=${totalCompleted} failed=${totalFailed} elapsedMs=${
+      Date.now() - startedAt
+    }`,
+  );
+  if (totalFailed > 0) {
     process.exitCode = 1;
   }
 }

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -114,6 +114,10 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   concerns remain `flagged.suspicious` and are hidden by the suspicious filter.
 - VirusTotal is telemetry only. It is included in the Codex workspace as signal,
   but VT alone must never hide, block, or set malicious/suspicious public status.
+- VirusTotal engine stats with zero malicious and zero suspicious detections and
+  one or more undetected engines are resolved no-detections telemetry, not an
+  in-progress scan. ClawHub should cache them as clean VT results instead of
+  leaving public badges pending.
 - All-active daily VirusTotal sweeps are disabled. Any future recurring VT
   freshness job must be bounded or delta-driven, and must not starve
   publish-triggered ClawScan jobs.
@@ -134,9 +138,9 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   `package.json`, `openclaw.plugin.json`, package/source metadata, and release facts. VirusTotal
   scans the exact uploaded `.tgz`; ClawHub does not currently run deep static/LLM scans across every
   tarball file.
-- Source-linked packages can fall back to a clean package verdict when VirusTotal only returns
-  undetected engine results, provided the LLM scan is clean and static scan is non-malicious. ClawHub
-  does not request or consume VirusTotal AI/code-insight results; VT is engine/vendor telemetry only.
+- Packages cache VirusTotal undetected-only engine results as clean VT telemetry.
+  ClawHub does not request or consume VirusTotal AI/code-insight results; VT is
+  engine/vendor telemetry only.
 - Skill moderation state stores a structured snapshot:
   - `moderationVerdict`: `clean | suspicious | malicious`
   - `moderationReasonCodes[]`: canonical machine-readable reasons


### PR DESCRIPTION
## Summary

- Treat VirusTotal undetected-only engine results as clean no-detections telemetry instead of leaving them pending
- Add a paginated internal repair action for existing `scanner.vt.pending` skill rows
- Keep suspicious/malicious VT repairs cautious by enqueueing ClawScan follow-up instead of clearing moderation immediately
- Document the VT telemetry semantics in the security moderation spec

## Tests

- `bunx vitest run convex/vt.test.ts`
- `bun run format:check -- convex/vt.ts convex/vt.test.ts convex/skills.ts specs/security-moderation.md`
- `bun run lint`
- `bun run ci:static`
- `bun run ci:unit`
- `.agents/skills/autoreview/scripts/autoreview --mode auto --parallel-tests ""`
