### PR TITLE
fix: hide empty VirusTotal stats

### DIFF
--- a/convex/devSeed.ts
+++ b/convex/devSeed.ts
@@ -1746,6 +1746,14 @@ export async function seedLocalModerationFixturesHandler(
                 "Reconcile local wallet exports against exchange activity and flag mismatched transfers.",
             },
           },
+          vtAnalysis: {
+            status: "malicious",
+            verdict: "malicious",
+            analysis: "Local dev fixture intentionally flagged by VirusTotal.",
+            source: "local-dev-seed",
+            engineStats: { malicious: 2, suspicious: 1, harmless: 3, undetected: 58 },
+            checkedAt: now,
+          },
         });
       }
       if (
@@ -1786,6 +1794,21 @@ export async function seedLocalModerationFixturesHandler(
         await ctx.db.patch(latestRelease._id, {
           clawScanNote: SCANNED_PLUGIN_CLAWSCAN_NOTE,
           llmAnalysis: pluginClawScanRiskAnalysis(now),
+        });
+      }
+    }
+    if (existingPlugin.latestReleaseId) {
+      const latestRelease = await ctx.db.get(existingPlugin.latestReleaseId);
+      if (latestRelease) {
+        await ctx.db.patch(latestRelease._id, {
+          vtAnalysis: {
+            status: "malicious",
+            verdict: "malicious",
+            analysis: "Local dev fixture intentionally flagged by VirusTotal.",
+            source: "local-dev-seed",
+            engineStats: { malicious: 2, suspicious: 1, harmless: 3, undetected: 58 },
+            checkedAt: now,
+          },
         });
       }
     }
@@ -1884,6 +1907,7 @@ export async function seedLocalModerationFixturesHandler(
       verdict: "malicious",
       analysis: "Local dev fixture intentionally flagged by VirusTotal.",
       source: "local-dev-seed",
+      engineStats: { malicious: 2, suspicious: 1, harmless: 3, undetected: 58 },
       checkedAt: now,
     },
     llmAnalysis: flaggedWalletClawScanAnalysis(now),
@@ -2078,6 +2102,7 @@ export async function seedLocalModerationFixturesHandler(
       verdict: "malicious",
       analysis: "Local dev fixture intentionally flagged by VirusTotal.",
       source: "local-dev-seed",
+      engineStats: { malicious: 2, suspicious: 1, harmless: 3, undetected: 58 },
       checkedAt: now,
     },
     llmAnalysis: {

--- a/docs/security-audits.md
+++ b/docs/security-audits.md
@@ -28,6 +28,7 @@ Before installing, review:
 - the overall audit status
 - the risk level
 - any listed findings
+- the publisher note, when present
 - required credentials, permissions, or environment variables
 - owner, source, version, changelog, downloads, stars, and other trust signals
 
@@ -103,34 +104,82 @@ Powerful behavior is not automatically bad. Many useful tools need credentials,
 local commands, provider APIs, or package installs. The audit checks whether that
 power is expected, disclosed, and proportionate.
 
-## ClawScan
+Artifact pages link to the full audit at:
 
-ClawScan is ClawHub's own security audit system. It reviews each release as an
-agent-facing artifact: instructions, metadata, declared permissions, files,
-capability signals, static scan signals, and publisher-provided context.
+```text
+/<owner>/<slug>/security-audit
+```
 
-ClawScan uses the OWASP Agentic AI Top 10 as a lens for risks such as prompt
-injection, tool misuse, credential exposure, unsafe execution, memory or context
-poisoning, and excessive agency.
+The audit page combines:
+
+1. Static analysis
+2. VirusTotal
+3. Risk analysis
+
+## Static analysis
+
+Static analysis checks the submitted artifact for deterministic patterns such as
+credential access, unexpected external transfer instructions, unsafe execution,
+or other content that should be reviewed.
+
+Static findings are shown as concrete findings with the relevant artifact
+content when ClawHub can surface it.
+
+## VirusTotal
+
+ClawHub uses VirusTotal as malware telemetry in the audit stack. VirusTotal is a
+trusted industry standard for file reputation and malware scanning, and our
+partnership lets ClawHub add broader security intelligence to skill and plugin
+review.
+
+VirusTotal is especially useful for known malicious artifacts, engine hits, and
+reputation signals that complement ClawHub's agent-aware review. When vendor
+engine counts are available, the audit summarizes them in plain language, such
+as:
+
+```text
+62/62 vendors flagged this skill as clean.
+```
+
+or:
+
+```text
+2/64 vendors flagged this skill as malicious, 1/64 flagged it as suspicious, and 61/64 flagged it as clean.
+```
+
+When ClawHub has no vendor-count telemetry to summarize, the audit says:
+
+```text
+No VirusTotal findings
+```
+
+VirusTotal remains telemetry. It does not replace ClawHub's own artifact-aware
+risk analysis.
+
+## Risk analysis
+
+Risk analysis is powered internally by ClawScan, ClawHub's own security audit
+system. It reviews each release as an agent-facing artifact: instructions,
+metadata, declared permissions, files, capability signals, static scan signals,
+VirusTotal telemetry, and publisher-provided context.
+
+Risk analysis uses the
+[OWASP Agentic Skills Top 10](https://owasp.org/www-project-agentic-skills-top-10/)
+as a lens for risks such as prompt injection, tool misuse, credential exposure,
+unsafe execution, memory or context poisoning, and excessive agency.
 
 ClawScan does not treat a scary-looking capability as automatically malicious.
 It asks whether the capability is disclosed, purpose-aligned, and supported by
 the release's stated use case.
 
-## VirusTotal
-
-ClawHub also uses VirusTotal as part of the audit stack. VirusTotal is a trusted
-industry standard for file reputation and malware scanning, and our partnership
-lets ClawHub add that broader security intelligence to skill and plugin review.
-
-VirusTotal is especially useful for known malicious artifacts, engine hits, and
-reputation signals that complement ClawScan's agent-aware review.
-
 ## Publisher notes
 
-Publishers can add a ClawScan note when publishing a skill or plugin. This note
-can explain behavior that may otherwise look unusual, such as network access,
-native host access, credentials, or broad provider APIs.
+Publishers can add a note when publishing a skill or plugin. On the Security
+audit page, the publisher note appears after the overview so you can read the
+publisher's explanation before reviewing scanner-specific sections.
+
+Publisher notes can explain behavior that may otherwise look unusual, such as
+network access, native host access, credentials, or broad provider APIs.
 
 Publisher notes help reduce false positives, but they are not trusted proof.
 ClawHub treats them as context and still checks the submitted artifacts.

--- a/specs/local-moderation-fixtures.md
+++ b/specs/local-moderation-fixtures.md
@@ -40,8 +40,9 @@ Seeded plugin fixtures:
 The scanned fixtures should cover:
 
 - artifact detail pages
-- scan summary strips
+- security audit sidebar summaries
 - security audit pages
+- security audit clean, review, and malicious states
 - publisher note display
 - mobile and desktop security layout
 - report/moderation state previews

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -104,6 +104,10 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
 - New skill publishes now persist a deterministic static scan result on the version.
 - Static suspicious findings are advisory evidence only. Static malicious findings
   hold the artifact until Codex-backed ClawScan completes.
+- Public artifact pages present static analysis, VirusTotal malware telemetry,
+  and ClawScan-powered risk review as one consolidated Security audit page.
+  This is a product-facing model only; scanner storage, moderation decisions,
+  and worker behavior remain separate internally.
 - ClawScan verdicts come from a GitHub Actions Codex worker, not a single
   hosted LLM call. Publishes enqueue a scan job that waits at most 10 minutes
   for VirusTotal telemetry, then Codex reviews the materialized artifact
@@ -114,6 +118,9 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   concerns remain `flagged.suspicious` and are hidden by the suspicious filter.
 - VirusTotal is telemetry only. It is included in the Codex workspace as signal,
   but VT alone must never hide, block, or set malicious/suspicious public status.
+  The public Security audit UI may summarize vendor engine counts, including
+  non-zero malicious or suspicious counts, but that display does not make VT a
+  blocking verdict source.
 - VirusTotal engine stats with zero malicious and zero suspicious detections and
   one or more undetected engines are resolved no-detections telemetry, not an
   in-progress scan. ClawHub should cache them as clean VT results instead of

--- a/specs/slug-routing.md
+++ b/specs/slug-routing.md
@@ -23,6 +23,9 @@ request is a skill slug, an official OpenClaw plugin alias, or a package route.
 Skills:
 
 - Canonical page: `/<owner>/<slug>`
+- Security audit page: `/<owner>/<slug>/security-audit`
+- Legacy scanner pages: `/<owner>/<slug>/security/:scanner` redirect to
+  `/<owner>/<slug>/security-audit`
 - API detail: `/api/v1/skills/<slug>`
 
 Plugins:
@@ -31,6 +34,7 @@ Plugins:
 - Encoded compatibility page: `/plugins/%40scope%2Fname`
 - Security audit page: `/plugins/@scope/name/security-audit`
 - Encoded security compatibility page: `/plugins/%40scope%2Fname/security-audit`
+- Legacy scanner pages redirect to the corresponding plugin security audit page.
 
 Publisher profiles:
 

--- a/src/components/SecurityAuditPage.tsx
+++ b/src/components/SecurityAuditPage.tsx
@@ -109,6 +109,12 @@ function getVirusTotalEngineStats(analysis?: VtAnalysis | null) {
   return analysis?.engineStats ?? analysis?.metadata?.stats ?? null;
 }
 
+function joinReadableClauses(clauses: string[]) {
+  if (clauses.length <= 1) return clauses[0] ?? "";
+  if (clauses.length === 2) return `${clauses[0]}, and ${clauses[1]}`;
+  return `${clauses.slice(0, -1).join(", ")}, and ${clauses.at(-1)}`;
+}
+
 function hasEngineVirusTotalSource(analysis?: VtAnalysis | null) {
   const source = analysis?.source?.trim().toLowerCase();
   const scanner = analysis?.scanner?.trim().toLowerCase();
@@ -128,8 +134,8 @@ function getArtifactKindLabel(entity: EntityRef) {
   return entity.kind === "plugin" ? "plugin" : "skill";
 }
 
-function getVirusTotalNoFindingsCopy(entity: EntityRef) {
-  return `No VirusTotal findings for this ${getArtifactKindLabel(entity)} version.`;
+function getVirusTotalNoFindingsCopy(_entity: EntityRef) {
+  return "No VirusTotal findings";
 }
 
 function getVirusTotalPendingCopy(entity: EntityRef) {
@@ -141,10 +147,30 @@ function getVirusTotalEngineOverview(analysis: VtAnalysis | null | undefined, en
   if (stats) {
     const malicious = stats.malicious ?? 0;
     const suspicious = stats.suspicious ?? 0;
-    if (malicious > 0 || suspicious > 0) {
-      return `VirusTotal vendor engines reported ${malicious} malicious and ${suspicious} suspicious detection(s) for this artifact. ClawHub treats this as telemetry for risk analysis, not as a standalone blocking verdict.`;
+    const clean = (stats.harmless ?? 0) + (stats.undetected ?? 0);
+    const total = malicious + suspicious + clean;
+    if (total <= 0) return getVirusTotalNoFindingsCopy(entity);
+
+    const artifactKind = getArtifactKindLabel(entity);
+    if (malicious === 0 && suspicious === 0) {
+      return `${clean}/${total} vendors flagged this ${artifactKind} as clean.`;
     }
-    return getVirusTotalNoFindingsCopy(entity);
+
+    const clauses: string[] = [];
+    if (malicious > 0) {
+      clauses.push(`${malicious}/${total} vendors flagged this ${artifactKind} as malicious`);
+    }
+    if (suspicious > 0) {
+      clauses.push(
+        clauses.length === 0
+          ? `${suspicious}/${total} vendors flagged this ${artifactKind} as suspicious`
+          : `${suspicious}/${total} flagged it as suspicious`,
+      );
+    }
+    if (clean > 0) {
+      clauses.push(`${clean}/${total} flagged it as clean`);
+    }
+    return `${joinReadableClauses(clauses)}.`;
   }
 
   if (hasNonEngineVirusTotalSource(analysis)) {
@@ -152,6 +178,13 @@ function getVirusTotalEngineOverview(analysis: VtAnalysis | null | undefined, en
   }
 
   const status = analysis?.status?.trim().toLowerCase();
+  if (
+    status === "clean" ||
+    status === "benign" ||
+    analysis?.verdict === "undetected-only-fallback"
+  ) {
+    return getVirusTotalNoFindingsCopy(entity);
+  }
   if (status && !["loading", "not_found", "pending"].includes(status)) {
     return `VirusTotal engine telemetry is currently ${status} for this artifact.`;
   }
@@ -159,17 +192,8 @@ function getVirusTotalEngineOverview(analysis: VtAnalysis | null | undefined, en
   return null;
 }
 
-function getVirusTotalAnalysisText(analysis?: VtAnalysis | null) {
-  if (!analysis?.analysis || !hasEngineVirusTotalSource(analysis)) return null;
-  return analysis.analysis;
-}
-
 function getVirusTotalOverviewCopy(analysis: VtAnalysis | null | undefined, entity: EntityRef) {
-  return (
-    getVirusTotalAnalysisText(analysis) ??
-    getVirusTotalEngineOverview(analysis, entity) ??
-    getVirusTotalPendingCopy(entity)
-  );
+  return getVirusTotalEngineOverview(analysis, entity) ?? getVirusTotalPendingCopy(entity);
 }
 
 function isReviewStatus(status: string) {
@@ -277,33 +301,12 @@ function PublisherNoteSection(props: SecurityAuditPageProps) {
 }
 
 function VirusTotalSection(props: SecurityAuditPageProps) {
-  const stats = getVirusTotalEngineStats(props.vtAnalysis);
   const vtUrl = props.sha256hash ? `https://www.virustotal.com/gui/file/${props.sha256hash}` : null;
   return (
     <div className="security-report-panel-body">
       <div className="security-report-overview-body">
         <p>{getVirusTotalOverviewCopy(props.vtAnalysis, props.entity)}</p>
       </div>
-      {stats ? (
-        <dl className="security-audit-stat-grid" aria-label="VirusTotal engine stats">
-          <div>
-            <dt>Malicious</dt>
-            <dd>{stats.malicious ?? 0}</dd>
-          </div>
-          <div>
-            <dt>Suspicious</dt>
-            <dd>{stats.suspicious ?? 0}</dd>
-          </div>
-          <div>
-            <dt>Harmless</dt>
-            <dd>{stats.harmless ?? 0}</dd>
-          </div>
-          <div>
-            <dt>Undetected</dt>
-            <dd>{stats.undetected ?? 0}</dd>
-          </div>
-        </dl>
-      ) : null}
       {vtUrl ? (
         <a
           href={vtUrl}

--- a/src/components/SecurityAuditPage.tsx
+++ b/src/components/SecurityAuditPage.tsx
@@ -115,12 +115,6 @@ function joinReadableClauses(clauses: string[]) {
   return `${clauses.slice(0, -1).join(", ")}, and ${clauses.at(-1)}`;
 }
 
-function hasEngineVirusTotalSource(analysis?: VtAnalysis | null) {
-  const source = analysis?.source?.trim().toLowerCase();
-  const scanner = analysis?.scanner?.trim().toLowerCase();
-  return Boolean(source?.startsWith("engines") || scanner?.startsWith("engines"));
-}
-
 function hasNonEngineVirusTotalSource(analysis?: VtAnalysis | null) {
   if (!analysis) return false;
   const source = analysis.source?.trim().toLowerCase();
@@ -152,23 +146,35 @@ function getVirusTotalEngineOverview(analysis: VtAnalysis | null | undefined, en
     if (total <= 0) return getVirusTotalNoFindingsCopy(entity);
 
     const artifactKind = getArtifactKindLabel(entity);
+    const hasFullEngineStats =
+      stats.malicious !== undefined &&
+      stats.suspicious !== undefined &&
+      stats.harmless !== undefined &&
+      stats.undetected !== undefined;
+    const firstCountLabel = (count: number) =>
+      hasFullEngineStats
+        ? `${count}/${total} vendors`
+        : `${count} ${count === 1 ? "vendor" : "vendors"}`;
+    const followupCountLabel = (count: number) =>
+      hasFullEngineStats ? `${count}/${total}` : `${count} ${count === 1 ? "vendor" : "vendors"}`;
+
     if (malicious === 0 && suspicious === 0) {
-      return `${clean}/${total} vendors flagged this ${artifactKind} as clean.`;
+      return `${firstCountLabel(clean)} flagged this ${artifactKind} as clean.`;
     }
 
     const clauses: string[] = [];
     if (malicious > 0) {
-      clauses.push(`${malicious}/${total} vendors flagged this ${artifactKind} as malicious`);
+      clauses.push(`${firstCountLabel(malicious)} flagged this ${artifactKind} as malicious`);
     }
     if (suspicious > 0) {
       clauses.push(
         clauses.length === 0
-          ? `${suspicious}/${total} vendors flagged this ${artifactKind} as suspicious`
-          : `${suspicious}/${total} flagged it as suspicious`,
+          ? `${firstCountLabel(suspicious)} flagged this ${artifactKind} as suspicious`
+          : `${followupCountLabel(suspicious)} flagged it as suspicious`,
       );
     }
     if (clean > 0) {
-      clauses.push(`${clean}/${total} flagged it as clean`);
+      clauses.push(`${followupCountLabel(clean)} flagged it as clean`);
     }
     return `${joinReadableClauses(clauses)}.`;
   }

--- a/src/components/SkillSecurityScanResults.test.tsx
+++ b/src/components/SkillSecurityScanResults.test.tsx
@@ -663,6 +663,30 @@ describe("SecurityScanResults static guidance", () => {
     ).toBeTruthy();
   });
 
+  it("avoids denominator prose for partial VirusTotal engine stats", () => {
+    render(
+      <SecurityAuditPage
+        entity={{
+          kind: "skill",
+          title: "Hash Guard",
+          name: "hash-guard",
+          version: "1.2.3",
+          detailPath: "/local/hash-guard",
+        }}
+        sha256hash="abc123"
+        vtAnalysis={{
+          status: "suspicious",
+          source: "engines",
+          engineStats: { suspicious: 1 },
+          checkedAt: Date.now(),
+        }}
+      />,
+    );
+
+    expect(screen.getByText("1 vendor flagged this skill as suspicious.")).toBeTruthy();
+    expect(screen.queryByText("1/1 vendors flagged this skill as suspicious.")).toBeNull();
+  });
+
   it("renders VirusTotal undetected-only fallback as pass", () => {
     render(
       <SecurityAuditPage

--- a/src/components/SkillSecurityScanResults.test.tsx
+++ b/src/components/SkillSecurityScanResults.test.tsx
@@ -565,7 +565,8 @@ describe("SecurityScanResults static guidance", () => {
       ),
     ).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
-    expect(screen.getByText(/No VirusTotal findings for this skill version/i)).toBeTruthy();
+    expect(screen.getByText("62/62 vendors flagged this skill as clean.")).toBeTruthy();
+    expect(screen.queryByLabelText("VirusTotal findings")).toBeNull();
     expect(screen.getByRole("heading", { name: "Security Audit Metadata" })).toBeTruthy();
     expect(screen.getByRole("link", { name: /View on VirusTotal/i }).getAttribute("href")).toBe(
       "https://www.virustotal.com/gui/file/abc123",
@@ -602,8 +603,64 @@ describe("SecurityScanResults static guidance", () => {
     );
 
     expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
-    expect(screen.getByText(/No VirusTotal findings for this skill version/i)).toBeTruthy();
+    expect(screen.getByText("62/62 vendors flagged this skill as clean.")).toBeTruthy();
+    expect(screen.queryByLabelText("VirusTotal findings")).toBeNull();
     expect(screen.queryByText(/No VirusTotal analysis has been recorded/i)).toBeNull();
+  });
+
+  it("summarizes non-zero VirusTotal detection counts in normal prose", () => {
+    const { rerender } = render(
+      <SecurityAuditPage
+        entity={{
+          kind: "skill",
+          title: "Hash Guard",
+          name: "hash-guard",
+          version: "1.2.3",
+          detailPath: "/local/hash-guard",
+        }}
+        sha256hash="abc123"
+        vtAnalysis={{
+          status: "malicious",
+          source: "engines",
+          engineStats: { malicious: 2, suspicious: 1, harmless: 3, undetected: 58 },
+          checkedAt: Date.now(),
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "2/64 vendors flagged this skill as malicious, 1/64 flagged it as suspicious, and 61/64 flagged it as clean.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByLabelText("VirusTotal findings")).toBeNull();
+    expect(screen.queryByText("Harmless")).toBeNull();
+    expect(screen.queryByText("Undetected")).toBeNull();
+
+    rerender(
+      <SecurityAuditPage
+        entity={{
+          kind: "plugin",
+          title: "Plugin Guard",
+          name: "plugin-guard",
+          version: "1.2.3",
+          detailPath: "/plugins/plugin-guard",
+        }}
+        sha256hash="abc123"
+        vtAnalysis={{
+          status: "suspicious",
+          source: "engines",
+          engineStats: { malicious: 0, suspicious: 1, harmless: 3, undetected: 60 },
+          checkedAt: Date.now(),
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "1/64 vendors flagged this plugin as suspicious, and 63/64 flagged it as clean.",
+      ),
+    ).toBeTruthy();
   });
 
   it("renders VirusTotal undetected-only fallback as pass", () => {
@@ -639,9 +696,7 @@ describe("SecurityScanResults static guidance", () => {
 
     expect(screen.getByRole("heading", { name: "VirusTotal" })).toBeTruthy();
     expect(screen.getByText("Pass")).toBeTruthy();
-    expect(
-      screen.getByText(/VirusTotal reported no malicious or suspicious engine hits/i),
-    ).toBeTruthy();
+    expect(screen.getByText("No VirusTotal findings")).toBeTruthy();
     expect(screen.queryByText("undetected-only-fallback")).toBeNull();
   });
 
@@ -675,7 +730,7 @@ describe("SecurityScanResults static guidance", () => {
     expect(screen.queryByText(/multi-engine malware detections/i)).toBeNull();
     expect(screen.queryByRole("heading", { name: /Findings/ })).toBeNull();
     expect(screen.queryByText(/raw AI context/i)).toBeNull();
-    expect(screen.getByText(/No VirusTotal findings for this skill version/i)).toBeTruthy();
+    expect(screen.getByText("No VirusTotal findings")).toBeTruthy();
   });
 
   it("shows static analysis reports in the shared scanner report shell", () => {
@@ -818,7 +873,7 @@ describe("SecurityScanResults static guidance", () => {
       screen.getByText("VirusTotal findings are pending for this skill version."),
     ).toBeTruthy();
     expect(screen.getByText("Static analysis findings are pending for this release.")).toBeTruthy();
-    expect(screen.queryByText("No VirusTotal findings for this skill version.")).toBeNull();
+    expect(screen.queryByText("No VirusTotal findings")).toBeNull();
     expect(
       screen.queryByText("No static analysis findings were reported for this release."),
     ).toBeNull();

--- a/src/styles.css
+++ b/src/styles.css
@@ -1563,41 +1563,6 @@ code {
   line-height: 1.55;
 }
 
-.security-audit-stat-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 1px;
-  margin: 18px 0 0;
-  overflow: hidden;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  background: var(--line);
-}
-
-.security-audit-stat-grid > div {
-  min-width: 0;
-  display: grid;
-  gap: 4px;
-  padding: 12px;
-  background: var(--surface);
-}
-
-.security-audit-stat-grid dt {
-  color: var(--ink-soft);
-  font-size: 0.72rem;
-  font-weight: 720;
-  line-height: 1.25;
-  text-transform: uppercase;
-}
-
-.security-audit-stat-grid dd {
-  margin: 0;
-  color: var(--ink);
-  font-size: 1rem;
-  font-weight: 760;
-  line-height: 1.2;
-}
-
 .security-audit-external-link {
   display: inline-flex;
   align-items: center;
@@ -1697,9 +1662,10 @@ code {
   }
 
   .security-report-sidebar {
+    order: -1;
     position: static;
     padding: 24px 0;
-    border-top: 1px solid var(--line);
+    border-bottom: 1px solid var(--line);
   }
 
   .security-report-metadata {


### PR DESCRIPTION
## Summary

Removes the VirusTotal aggregate stats grid from clean/no-finding security audit states.

Clean VirusTotal scans now show only the concise no-findings sentence and the external VirusTotal link. When VirusTotal has non-zero malicious or suspicious engine detections, the audit page shows focused finding cards for those detection counts only, without listing harmless or undetected aggregate telemetry.

## Tests

- `VITE_CONVEX_URL=https://example.invalid bun run test -- src/components/SkillSecurityScanResults.test.tsx`
- `bunx oxfmt --check src/components/SecurityAuditPage.tsx src/components/SkillSecurityScanResults.test.tsx src/styles.css`
- `git diff --check`
