### PR TITLE
fix: use README heading for package display fallback

### DIFF
--- a/packages/clawhub/src/cli/commands/packages.test.ts
+++ b/packages/clawhub/src/cli/commands/packages.test.ts
@@ -1058,6 +1058,86 @@ describe("package commands", () => {
     }
   });
 
+  it("uses the README H1 as a package display name fallback", async () => {
+    const workdir = await makeTmpWorkdir();
+    try {
+      const folder = join(workdir, "clawhub-github-publish-clh4hR");
+      await mkdir(join(folder, "dist"), { recursive: true });
+      await writeFile(
+        join(folder, "package.json"),
+        makeCodePluginPackageJson({
+          name: "@scope/demo-plugin",
+          version: "1.0.0",
+          files: ["dist", "openclaw.plugin.json", "README.md"],
+        }),
+        "utf8",
+      );
+      await writeFile(
+        join(folder, "openclaw.plugin.json"),
+        JSON.stringify({ id: "demo.plugin" }),
+        "utf8",
+      );
+      await writeFile(
+        join(folder, "README.md"),
+        "---\nignored: true\n---\n\n# Honcho Memory Plugin for OpenClaw\n\nDetails.\n",
+        "utf8",
+      );
+      await writeFile(join(folder, "dist", "index.js"), "export const demo = true;\n", "utf8");
+
+      await cmdPublishPackage(makeOpts(workdir), "clawhub-github-publish-clh4hR", {
+        dryRun: true,
+        json: true,
+        sourceRepo: "openclaw/demo-plugin",
+        sourceCommit: "abc123",
+      });
+
+      const output = String(mockWrite.mock.calls[0]?.[0] ?? "").trim();
+      expect(JSON.parse(output)).toMatchObject({
+        displayName: "Honcho Memory Plugin for OpenClaw",
+      });
+    } finally {
+      await rm(workdir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves literal trailing hashes in README H1 display name fallbacks", async () => {
+    const workdir = await makeTmpWorkdir();
+    try {
+      const folder = join(workdir, "language-plugin");
+      await mkdir(join(folder, "dist"), { recursive: true });
+      await writeFile(
+        join(folder, "package.json"),
+        makeCodePluginPackageJson({
+          name: "@scope/language-plugin",
+          version: "1.0.0",
+          files: ["dist", "openclaw.plugin.json", "README.md"],
+        }),
+        "utf8",
+      );
+      await writeFile(
+        join(folder, "openclaw.plugin.json"),
+        JSON.stringify({ id: "language.plugin" }),
+        "utf8",
+      );
+      await writeFile(join(folder, "README.md"), "# C#\n\nDetails.\n", "utf8");
+      await writeFile(join(folder, "dist", "index.js"), "export const demo = true;\n", "utf8");
+
+      await cmdPublishPackage(makeOpts(workdir), "language-plugin", {
+        dryRun: true,
+        json: true,
+        sourceRepo: "openclaw/language-plugin",
+        sourceCommit: "abc123",
+      });
+
+      const output = String(mockWrite.mock.calls[0]?.[0] ?? "").trim();
+      expect(JSON.parse(output)).toMatchObject({
+        displayName: "C#",
+      });
+    } finally {
+      await rm(workdir, { recursive: true, force: true });
+    }
+  });
+
   it("resolves package publish dot paths from the caller cwd before the OpenClaw workdir", async () => {
     const workspace = await makeTmpWorkdir();
     const pluginRoot = await makeTmpWorkdir();

--- a/packages/clawhub/src/cli/commands/packages.ts
+++ b/packages/clawhub/src/cli/commands/packages.ts
@@ -1518,6 +1518,37 @@ async function readJsonFile(path: string) {
   }
 }
 
+function stripMarkdownFrontmatter(content: string) {
+  const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  if (!normalized.startsWith("---\n")) return normalized;
+  const endIndex = normalized.indexOf("\n---", 4);
+  if (endIndex === -1) return normalized;
+  return normalized.slice(endIndex + 4).replace(/^\n+/, "");
+}
+
+function extractReadmeH1(content: string) {
+  const body = stripMarkdownFrontmatter(content);
+  for (const line of body.split("\n")) {
+    const match = /^#(?!#)\s+(.+?)\s*$/.exec(line.trim());
+    const title = match?.[1]?.replace(/\s+#+$/, "").trim();
+    if (title) return title;
+  }
+  return undefined;
+}
+
+function readReadmeH1FromPackageFiles(files: PackageFile[]) {
+  const readme = files.find((file) => {
+    const path = file.relPath.toLowerCase();
+    return path === "readme.md" || path === "readme.mdx";
+  });
+  if (!readme) return undefined;
+  try {
+    return extractReadmeH1(new TextDecoder().decode(readme.bytes));
+  } catch {
+    return undefined;
+  }
+}
+
 function packageJsonString(value: Record<string, unknown> | null, key: string): string | undefined {
   const candidate = value?.[key];
   return typeof candidate === "string" && candidate.trim() ? candidate.trim() : undefined;
@@ -1695,6 +1726,7 @@ async function preparePackagePublishPlan(
     packageJsonString(packageJson, "displayName") ||
     packageJsonString(pluginManifest, "name") ||
     packageJsonString(bundleManifest, "name") ||
+    readReadmeH1FromPackageFiles(filesOnDisk) ||
     titleCase(basename(folder));
   const ownerHandle = options.owner?.trim().replace(/^@+/, "");
   const version =


### PR DESCRIPTION
## Summary
- use the first README.md/README.mdx H1 as the package display-name fallback before falling back to the source folder name
- strip simple frontmatter before reading the README heading
- preserve literal trailing hashes in headings like `# C#` while still trimming Markdown closing hashes like `# Title #`

## Tests
- `bunx vitest run -c vitest.config.ts src/cli/commands/packages.test.ts`
- `bun run format:check packages/clawhub/src/cli/commands/packages.ts packages/clawhub/src/cli/commands/packages.test.ts`
- `bun run --cwd packages/clawhub verify:build`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `bun run ci:packages`
