### PR TITLE
Keep mod org creation actor out of org members

### DIFF
--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -1998,7 +1998,7 @@ describe("self-serve org publisher creation", () => {
 });
 
 describe("legacy publisher migration", () => {
-  it("lets admins create a missing org publisher and add a legacy package owner as admin", async () => {
+  it("lets admins create a missing org publisher with only the legacy package owner as owner", async () => {
     vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
 
     const users = new Map<string, Record<string, unknown>>([
@@ -2131,7 +2131,7 @@ describe("legacy publisher migration", () => {
         handle: "opik",
         displayName: "Opik",
         memberHandle: "vincentkoc",
-        memberRole: "admin",
+        memberRole: "owner",
       },
     );
 
@@ -2142,25 +2142,28 @@ describe("legacy publisher migration", () => {
       member: {
         userId: "users:vincent",
         handle: "vincentkoc",
-        role: "admin",
+        role: "owner",
       },
     });
-    expect(inserts).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          table: "publishers",
-          value: expect.objectContaining({ kind: "org", handle: "opik", displayName: "Opik" }),
-        }),
-        expect.objectContaining({
-          table: "publisherMembers",
-          value: expect.objectContaining({
-            publisherId: result.publisherId,
-            userId: "users:vincent",
-            role: "admin",
-          }),
-        }),
-      ]),
+    expect(inserts).toContainEqual(
+      expect.objectContaining({
+        table: "publishers",
+        value: expect.objectContaining({ kind: "org", handle: "opik", displayName: "Opik" }),
+      }),
     );
+    const memberInserts = inserts.filter(
+      (entry) =>
+        entry.table === "publisherMembers" && entry.value.publisherId === result.publisherId,
+    );
+    expect(memberInserts).toEqual([
+      expect.objectContaining({
+        value: expect.objectContaining({
+          publisherId: result.publisherId,
+          userId: "users:vincent",
+          role: "owner",
+        }),
+      }),
+    ]);
   });
 
   it("converts a legacy personal publisher into an org and rehomes package ownership", async () => {

--- a/convex/publishers.ts
+++ b/convex/publishers.ts
@@ -669,16 +669,6 @@ async function ensureOrgPublisherHandleWithActor(
       trustedPublisher: args.trusted ?? existingPublisher.trustedPublisher,
       updatedAt: now,
     });
-    const membership = await getPublisherMembership(ctx, existingPublisher._id, args.actorUserId);
-    if (!membership) {
-      await ctx.db.insert("publisherMembers", {
-        publisherId: existingPublisher._id,
-        userId: args.actorUserId,
-        role: "owner",
-        createdAt: now,
-        updatedAt: now,
-      });
-    }
     const member = await ensureMember(existingPublisher._id);
     return {
       ok: true as const,
@@ -716,6 +706,10 @@ async function ensureOrgPublisherHandleWithActor(
     };
   }
 
+  if (!normalizePublisherHandle(args.memberHandle)) {
+    throw new ConvexError("memberHandle required when creating org publisher");
+  }
+
   const publisherId = await ctx.db.insert("publishers", {
     kind: "org",
     handle,
@@ -724,13 +718,6 @@ async function ensureOrgPublisherHandleWithActor(
     image: undefined,
     linkedUserId: undefined,
     trustedPublisher: args.trusted || undefined,
-    createdAt: now,
-    updatedAt: now,
-  });
-  await ctx.db.insert("publisherMembers", {
-    publisherId,
-    userId: args.actorUserId,
-    role: "owner",
     createdAt: now,
     updatedAt: now,
   });
@@ -769,7 +756,7 @@ async function ensureOrgPublisherMemberWithActor(
 ) {
   const memberHandle = normalizePublisherHandle(args.memberHandle);
   if (!memberHandle) return null;
-  const requestedRole = args.memberRole ?? "admin";
+  const requestedRole = args.memberRole ?? "owner";
   const targetUser = await getActiveUserByHandleOrPersonalPublisher(ctx, memberHandle);
   if (!targetUser) throw new ConvexError(`User "@${memberHandle}" not found`);
   await ensurePersonalPublisherForUser(ctx, targetUser, {

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -1188,9 +1188,11 @@ Status codes:
 
 Admin-only. Ensures an org publisher exists for a handle. If the handle still points at a
 legacy shared user/personal publisher, the endpoint migrates it into an org publisher first.
+For a newly-created org, provide `memberHandle`; the acting admin is not added as a member.
+`memberRole` defaults to `owner`.
 
-- Body: `{ "handle": "openclaw", "displayName": "OpenClaw", "trusted": true }`
-- Response: `{ "ok": true, "publisherId": "...", "handle": "openclaw", "created": true, "migrated": false, "trusted": true }`
+- Body: `{ "handle": "openclaw", "displayName": "OpenClaw", "memberHandle": "alice", "memberRole": "owner", "trusted": true }`
+- Response: `{ "ok": true, "publisherId": "...", "handle": "openclaw", "created": true, "migrated": false, "trusted": true, "member": { "userId": "...", "handle": "alice", "role": "owner" } }`
 
 ### `POST /api/v1/publishers`
 

--- a/packages/clawhub-mod/README.md
+++ b/packages/clawhub-mod/README.md
@@ -97,6 +97,15 @@ bun run mod -- unban-user <handleOrId>
 bun run mod -- set-role <handleOrId> <user|moderator|admin>
 ```
 
+Org publisher administration:
+
+```bash
+bun run mod -- org create <handle> --member <handle> [--display-name <name>] [--role owner|admin|publisher] [--trusted] [--json]
+```
+
+`org create` requires `--member` and defaults that member to `owner`; it does
+not add the moderator running the command as an org member.
+
 Package moderation and operations:
 
 ```bash

--- a/packages/clawhub-mod/src/cli.ts
+++ b/packages/clawhub-mod/src/cli.ts
@@ -351,7 +351,7 @@ function registerOrgCommands(command: Command) {
     .argument("<handle>", "Org publisher handle")
     .option("--display-name <name>", "Display name")
     .option("--member <handle>", "User handle to add to the org")
-    .option("--role <role>", "owner|admin|publisher for --member", "admin")
+    .option("--role <role>", "owner|admin|publisher for --member", "owner")
     .option("--trusted", "Mark org as trusted")
     .option("--json", "Output JSON")
     .action(async (handle, options) => {

--- a/packages/clawhub-mod/src/commands/orgs.test.ts
+++ b/packages/clawhub-mod/src/commands/orgs.test.ts
@@ -26,7 +26,7 @@ afterEach(() => {
 });
 
 describe("cmdCreateOrg", () => {
-  it("creates an org publisher and adds a legacy owner member", async () => {
+  it("creates an org publisher and adds the legacy owner as owner by default", async () => {
     httpMocks.apiRequest.mockResolvedValueOnce({
       ok: true,
       publisherId: "publishers:opik",
@@ -37,14 +37,13 @@ describe("cmdCreateOrg", () => {
       member: {
         userId: "users:vincent",
         handle: "vincentkoc",
-        role: "admin",
+        role: "owner",
       },
     });
 
     await cmdCreateOrg(makeGlobalOpts(), "Opik", {
       displayName: "Opik",
       member: "vincentkoc",
-      role: "admin",
     });
 
     expect(authTokenMocks.requireAuthToken).toHaveBeenCalled();
@@ -58,7 +57,7 @@ describe("cmdCreateOrg", () => {
           handle: "opik",
           displayName: "Opik",
           memberHandle: "vincentkoc",
-          memberRole: "admin",
+          memberRole: "owner",
         },
       }),
       expect.anything(),
@@ -73,15 +72,22 @@ describe("cmdCreateOrg", () => {
       created: true,
       migrated: false,
       trusted: true,
+      member: {
+        userId: "users:vincent",
+        handle: "vincentkoc",
+        role: "owner",
+      },
     });
 
-    await cmdCreateOrg(makeGlobalOpts(), "opik", { trusted: true });
+    await cmdCreateOrg(makeGlobalOpts(), "opik", { member: "vincentkoc", trusted: true });
 
     expect(httpMocks.apiRequest).toHaveBeenCalledWith(
       "https://clawhub.ai",
       expect.objectContaining({
         body: {
           handle: "opik",
+          memberHandle: "vincentkoc",
+          memberRole: "owner",
           trusted: true,
         },
       }),
@@ -96,6 +102,11 @@ describe("cmdCreateOrg", () => {
         role: "moderator",
       }),
     ).rejects.toThrow(/--role must be owner, admin, or publisher/i);
+    expect(httpMocks.apiRequest).not.toHaveBeenCalled();
+  });
+
+  it("requires an explicit member so the moderator is not added as owner", async () => {
+    await expect(cmdCreateOrg(makeGlobalOpts(), "opik", {})).rejects.toThrow(/--member required/i);
     expect(httpMocks.apiRequest).not.toHaveBeenCalled();
   });
 });

--- a/packages/clawhub-mod/src/commands/orgs.ts
+++ b/packages/clawhub-mod/src/commands/orgs.ts
@@ -25,7 +25,7 @@ function normalizeHandleOrFail(handle: string, label: string) {
 }
 
 function normalizeRoleOrFail(role: string | undefined): OrgMemberRole {
-  const normalized = (role ?? "admin").trim().toLowerCase();
+  const normalized = (role ?? "owner").trim().toLowerCase();
   if (normalized === "owner" || normalized === "admin" || normalized === "publisher") {
     return normalized;
   }
@@ -36,7 +36,8 @@ export async function cmdCreateOrg(opts: GlobalOpts, handle: string, options: Or
   const orgHandle = normalizeHandleOrFail(handle, "Org handle");
   const displayName = options.displayName?.trim();
   const memberHandle = options.member ? normalizeHandleOrFail(options.member, "--member") : "";
-  const memberRole = memberHandle ? normalizeRoleOrFail(options.role) : undefined;
+  if (!memberHandle) fail("--member required");
+  const memberRole = normalizeRoleOrFail(options.role);
   const trusted = options.trusted === true ? true : undefined;
 
   const token = await requireAuthToken();


### PR DESCRIPTION
## Summary
- stop the admin ensure-org path from automatically adding the acting moderator as an org owner
- require `clawhub-mod org create` to name a target member, and default that member to `owner`
- document the moderator org-creation behavior and HTTP API member semantics

## Production note
- Promoted `@vincentkoc` to `owner` on the live `@opik` org after the original repair created him as `admin`.
- This PR prevents future moderator org repairs from adding the operator as a member.

## Testing
- `bunx vitest run convex/publishers.test.ts packages/clawhub-mod/src/commands/orgs.test.ts`
- `bun packages/clawhub-mod/src/cli.ts org create --help`
- `bun run format:check -- convex/publishers.ts convex/publishers.test.ts packages/clawhub-mod/src/cli.ts packages/clawhub-mod/src/commands/orgs.ts packages/clawhub-mod/src/commands/orgs.test.ts packages/clawhub-mod/README.md docs/http-api.md`
- `bun run ci:static`
- `bun run ci:packages`
- `codex review --disable plugins --disable memories --uncommitted`
