### PR TITLE
fix: prefer plugin manifest display names

### DIFF
--- a/packages/clawhub/src/cli/commands/packages.test.ts
+++ b/packages/clawhub/src/cli/commands/packages.test.ts
@@ -1100,6 +1100,44 @@ describe("package commands", () => {
     }
   });
 
+  it("prefers the OpenClaw plugin manifest name over package.json displayName", async () => {
+    const workdir = await makeTmpWorkdir();
+    try {
+      const folder = join(workdir, "demo-plugin");
+      await mkdir(join(folder, "dist"), { recursive: true });
+      await writeFile(
+        join(folder, "package.json"),
+        makeCodePluginPackageJson({
+          name: "@scope/demo-plugin",
+          displayName: "Package Display Name",
+          version: "1.0.0",
+          files: ["dist", "openclaw.plugin.json"],
+        }),
+        "utf8",
+      );
+      await writeFile(
+        join(folder, "openclaw.plugin.json"),
+        JSON.stringify({ id: "demo.plugin", name: "Manifest Display Name" }),
+        "utf8",
+      );
+      await writeFile(join(folder, "dist", "index.js"), "export const demo = true;\n", "utf8");
+
+      await cmdPublishPackage(makeOpts(workdir), "demo-plugin", {
+        dryRun: true,
+        json: true,
+        sourceRepo: "openclaw/demo-plugin",
+        sourceCommit: "abc123",
+      });
+
+      const output = String(mockWrite.mock.calls[0]?.[0] ?? "").trim();
+      expect(JSON.parse(output)).toMatchObject({
+        displayName: "Manifest Display Name",
+      });
+    } finally {
+      await rm(workdir, { recursive: true, force: true });
+    }
+  });
+
   it("preserves literal trailing hashes in README H1 display name fallbacks", async () => {
     const workdir = await makeTmpWorkdir();
     try {

--- a/packages/clawhub/src/cli/commands/packages.ts
+++ b/packages/clawhub/src/cli/commands/packages.ts
@@ -1723,8 +1723,8 @@ async function preparePackagePublishPlan(
     basename(folder).trim().toLowerCase();
   const displayName =
     options.displayName?.trim() ||
-    packageJsonString(packageJson, "displayName") ||
     packageJsonString(pluginManifest, "name") ||
+    packageJsonString(packageJson, "displayName") ||
     packageJsonString(bundleManifest, "name") ||
     readReadmeH1FromPackageFiles(filesOnDisk) ||
     titleCase(basename(folder));

--- a/src/lib/pluginPublishPrefill.test.ts
+++ b/src/lib/pluginPublishPrefill.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { derivePluginPrefill } from "./pluginPublishPrefill";
+
+function jsonFile(path: string, value: unknown) {
+  return {
+    path,
+    file: new File([JSON.stringify(value)], path.split("/").at(-1) ?? path, {
+      type: "application/json",
+    }),
+  };
+}
+
+describe("derivePluginPrefill", () => {
+  it("prefers the OpenClaw plugin manifest name over package.json displayName", async () => {
+    const prefill = await derivePluginPrefill([
+      jsonFile("package.json", {
+        name: "@scope/demo-plugin",
+        displayName: "Package Display Name",
+        version: "1.0.0",
+      }),
+      jsonFile("openclaw.plugin.json", {
+        id: "demo.plugin",
+        name: "Manifest Display Name",
+      }),
+    ]);
+
+    expect(prefill.displayName).toBe("Manifest Display Name");
+  });
+});

--- a/src/lib/pluginPublishPrefill.ts
+++ b/src/lib/pluginPublishPrefill.ts
@@ -125,8 +125,8 @@ export async function derivePluginPrefill(
       getString(pluginManifest?.id) ??
       getString(bundleManifest?.id),
     displayName:
-      getString(packageJson?.displayName) ??
       getString(pluginManifest?.name) ??
+      getString(packageJson?.displayName) ??
       getString(bundleManifest?.name),
     version: getString(packageJson?.version),
     sourceRepo: extractSourceRepo(packageJson),


### PR DESCRIPTION
## Summary
- Prefer `openclaw.plugin.json.name` before `package.json.displayName` when resolving plugin publish display names.
- Apply the same precedence in the browser publish prefill path so CLI and web uploads match.
- Add focused regression tests for both paths.

## Validation
- `bunx vitest run src/lib/pluginPublishPrefill.test.ts`
- `bunx vitest run -c vitest.config.ts src/cli/commands/packages.test.ts` from `packages/clawhub`
- `bun run --cwd packages/clawhub verify:build`
- `bunx tsc --noEmit`
- `bun run format:check -- packages/clawhub/src/cli/commands/packages.ts packages/clawhub/src/cli/commands/packages.test.ts src/lib/pluginPublishPrefill.ts src/lib/pluginPublishPrefill.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
