### PR TITLE
fix: contain skill install command card

### DIFF
--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -228,6 +228,8 @@ describe("restored UI design contract", () => {
     expect(cssRule(css, ".skill-hero-lower.has-sidebar")).toContain(
       "grid-template-columns: minmax(0, 1fr) minmax(300px, 360px)",
     );
+    expect(cssRule(css, ".skill-hero-main-extra")).toContain("overflow: hidden");
+    expect(cssRule(css, ".skill-install-command-shell")).toContain("max-width: 100%");
     expect(cssRule(css, ".skill-hero-action-grid")).toContain(
       "grid-template-columns: repeat(auto-fit, minmax(min(360px, 100%), 1fr))",
     );

--- a/src/styles.css
+++ b/src/styles.css
@@ -4036,6 +4036,13 @@ code {
   display: grid;
   gap: 66px;
   min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.skill-hero-main-extra > * {
+  min-width: 0;
+  max-width: 100%;
 }
 
 .skill-hero-action-grid {
@@ -4956,7 +4963,10 @@ code {
   position: relative;
   display: grid;
   width: 100%;
+  max-width: 100%;
   min-width: 0;
+  box-sizing: border-box;
+  overflow: hidden;
   border-radius: var(--radius-md);
   border: 1px solid var(--line);
   background: var(--surface-muted);


### PR DESCRIPTION
## Summary

Fixes the skill detail install command overflow visible on `https://clawhub.ai/jimliu/baoyu-xhs-images`, where the install command card expanded underneath the right metadata sidebar.

The detail grid was correctly sizing the main column and sidebar, but the install command card could still escape its grid item. On the production page, the left content column measured about 904px while the command card expanded to about 1915px, visually running under the sidebar.

This change adds containment to the hero main-extra column and command shell so the install card respects the grid column width. It also adds a small UI design contract regression check for the containment rules.

## Verification

- `bunx vitest run src/__tests__/ui-design-contract.test.ts src/components/SkillInstallSurface.test.tsx`
- `bun run format:check -- src/styles.css src/__tests__/ui-design-contract.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- Production DOM measurement with patched CSS injected: install card width changed from ~1915px to 904px and no longer overlapped the sidebar.
