### PR TITLE
fix: use generic 404 for missing skill pages

### DIFF
--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -649,7 +649,9 @@ describe("SkillDetailPage", () => {
     });
 
     render(<SkillDetailPage slug="missing-skill" />);
-    expect(await screen.findByText(/Skill not found/i)).toBeTruthy();
+    expect(
+      await screen.findByRole("heading", { name: /We couldn't find that page/i }),
+    ).toBeTruthy();
   });
 
   it("redirects legacy routes to canonical owner/slug", async () => {

--- a/src/components/GenericNotFoundPage.tsx
+++ b/src/components/GenericNotFoundPage.tsx
@@ -1,0 +1,26 @@
+export function GenericNotFoundPage() {
+  return (
+    <main className="border-b border-[color:var(--line)] bg-[color:var(--bg)]">
+      <section className="mx-auto flex w-full max-w-[1120px] flex-col gap-8 px-5 py-10 sm:px-8 sm:py-14 lg:py-16">
+        <div className="flex max-w-[840px] flex-col gap-4">
+          <div className="flex flex-col gap-4">
+            <h1 className="font-display text-4xl font-black leading-[0.98] text-[color:var(--ink)] sm:text-5xl">
+              We couldn't find that page.
+            </h1>
+            <p className="max-w-xl text-base leading-7 text-[color:var(--ink-soft)] sm:text-lg">
+              We couldn't find a skill, plugin, or profile at this URL. Try search, browse the
+              catalog, or publish the thing you expected to see here.
+            </p>
+          </div>
+        </div>
+
+        <img
+          src="/404-lobster-detective.jpg"
+          alt="A lobster detective inspecting an empty 404 package crate."
+          className="aspect-[16/9] w-full max-w-[920px] rounded-[var(--r-md)] border border-[color:var(--line)] object-cover object-left shadow-[var(--shadow-hover)]"
+          loading="lazy"
+        />
+      </section>
+    </main>
+  );
+}

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -17,6 +17,7 @@ import { useAuthStatus } from "../lib/useAuthStatus";
 import { ClientOnly } from "./ClientOnly";
 import { DetailBody, DetailPageShell } from "./DetailPageShell";
 import { DetailSecuritySummary } from "./DetailSecuritySummary";
+import { GenericNotFoundPage } from "./GenericNotFoundPage";
 import { SkillDetailSkeleton } from "./skeletons/SkillDetailSkeleton";
 import { SkillCommentsPanel } from "./SkillCommentsPanel";
 import { SkillDetailTabs, type DetailTab } from "./SkillDetailTabs";
@@ -585,11 +586,7 @@ export function SkillDetailPage({
   }
 
   if (result === null || !skill || !displayedSkill) {
-    return (
-      <main className="section detail-page-section">
-        <Card>Skill not found.</Card>
-      </main>
-    );
+    return <GenericNotFoundPage />;
   }
 
   const securitySummary = latestVersion ? (

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -7,6 +7,7 @@ import { ClientOnly } from "../components/ClientOnly";
 import { DeploymentDriftBanner } from "../components/DeploymentDriftBanner";
 import { ErrorBoundary } from "../components/ErrorBoundary";
 import { Footer } from "../components/Footer";
+import { GenericNotFoundPage } from "../components/GenericNotFoundPage";
 import Header from "../components/Header";
 import { getSiteDescription, getSiteMode, getSiteName, getSiteUrlForMode } from "../lib/site";
 import appCss from "../styles.css?url";
@@ -113,7 +114,7 @@ export const Route = createRootRoute({
   },
 
   shellComponent: RootDocument,
-  notFoundComponent: NotFoundPage,
+  notFoundComponent: GenericNotFoundPage,
 });
 
 function RootDocument({ children }: { children: React.ReactNode }) {
@@ -169,31 +170,4 @@ function RootDocument({ children }: { children: React.ReactNode }) {
 function RouteErrorBoundary({ children }: { children: React.ReactNode }) {
   const location = useLocation();
   return <ErrorBoundary resetKey={location.pathname}>{children}</ErrorBoundary>;
-}
-
-function NotFoundPage() {
-  return (
-    <main className="border-b border-[color:var(--line)] bg-[color:var(--bg)]">
-      <section className="mx-auto flex w-full max-w-[1120px] flex-col gap-8 px-5 py-10 sm:px-8 sm:py-14 lg:py-16">
-        <div className="flex max-w-[840px] flex-col gap-4">
-          <div className="flex flex-col gap-4">
-            <h1 className="font-display text-4xl font-black leading-[0.98] text-[color:var(--ink)] sm:text-5xl">
-              We couldn't find that page.
-            </h1>
-            <p className="max-w-xl text-base leading-7 text-[color:var(--ink-soft)] sm:text-lg">
-              We couldn't find a skill, plugin, or profile at this URL. Try search, browse the
-              catalog, or publish the thing you expected to see here.
-            </p>
-          </div>
-        </div>
-
-        <img
-          src="/404-lobster-detective.jpg"
-          alt="A lobster detective inspecting an empty 404 package crate."
-          className="aspect-[16/9] w-full max-w-[920px] rounded-[var(--r-md)] border border-[color:var(--line)] object-cover object-left shadow-[var(--shadow-hover)]"
-          loading="lazy"
-        />
-      </section>
-    </main>
-  );
 }


### PR DESCRIPTION
## Summary
- extract the existing root 404 view into a shared `GenericNotFoundPage`
- render that generic 404 view when a skill detail query resolves missing
- update the skill detail test to assert the generic 404 heading instead of the old `Skill not found.` card

## Tests
- `VITE_CONVEX_URL=https://example.invalid bun run test src/__tests__/skill-route-loader.test.ts src/__tests__/skill-detail-page.test.tsx`
- `bun run format:check -- src/routes/__root.tsx 'src/routes/$owner/$slug.tsx' src/components/SkillDetailPage.tsx src/components/GenericNotFoundPage.tsx src/__tests__/skill-route-loader.test.ts src/__tests__/skill-detail-page.test.tsx`
- `VITE_CONVEX_URL=https://example.invalid bunx tsc --noEmit`
- `bun run ci:static`
- `VITE_CONVEX_URL=https://example.invalid bun run coverage`
- `.agents/skills/autoreview/scripts/autoreview --parallel-tests "bun run ci:static"`

## Review
- First autoreview found that route-level `notFound()` would block owner/staff access to moderated skills; fixed by keeping the fallback at the component layer.
- Final autoreview: clean, no accepted/actionable findings reported.
