### PR TITLE
fix: prevent publisher title clipping

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -11265,11 +11265,12 @@ a.search-empty-action {
   min-width: 0;
   margin: 0;
   overflow: hidden;
+  padding-block: 0.08em 0.14em;
   color: var(--ink);
   font-size: clamp(1.55rem, 2.45vw, 2.15rem);
   font-weight: 800;
   letter-spacing: 0;
-  line-height: 1.05;
+  line-height: 1.18;
   text-overflow: ellipsis;
   white-space: nowrap;
 }


### PR DESCRIPTION
## Summary

Publisher names with descenders could look clipped in the profile hero.
This change gives the publisher title enough vertical room while keeping the existing single-line truncation behavior.
It matters for org profiles such as Hugging Face, where the lowercase letters made the clipping visible.

## What Changed

The change is limited to the publisher profile title CSS.
It increases the title line height and adds a small vertical padding buffer so browser font rounding does not cut off glyphs.

- Updated `.publisher-profile-title-row h1` in `src/styles.css`.
- Preserved `overflow: hidden`, `text-overflow: ellipsis`, and `white-space: nowrap` for long names.

## Testing

I checked the affected profile locally and verified the title box has enough height.
I also ran the formatter check for the touched file.

- Loaded `/user/huggingface` locally against the public Convex backend.
- Verified the title box reported matching `clientHeight` and `scrollHeight` at `44px`.
- `bun run format:check -- src/styles.css`

## Risks

Risk is low because the change only affects the publisher profile title style.
The main visual difference is a few pixels of extra height in the hero title row.
