### PR TITLE
docs: add community skill example (iflow-search) to quickstart

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,6 +37,41 @@ openclaw skills update --all
 OpenClaw records where the skill came from so later updates can continue to
 resolve through ClawHub.
 
+### Example: a community skill
+
+The community skill [`iflow-search`](https://clawhub.ai/iflow-ai/iflow-search) is
+a third-party example of the install path above. It bundles three bash scripts
+that call the iFlow Search API for web search, image search, and webpage fetch.
+
+Requirements (declared in the skill's `SKILL.md`):
+
+- `env`: `IFLOW_API_KEY`
+- `bins`: `bash`, `curl`
+
+Set the API key in your shell before launching the agent (do not pass it as a
+CLI flag, and do not commit it):
+
+```bash
+echo 'export IFLOW_API_KEY="YOUR_IFLOW_API_KEY"' >> ~/.zshrc
+source ~/.zshrc
+```
+
+Use the equivalent shell profile file if you use bash or another shell.
+
+Install and verify:
+
+```bash
+openclaw skills install iflow-search
+openclaw skills info iflow-search   # shows ✓ Ready when env + bins are present
+```
+
+Source and API references:
+
+- ClawHub listing: <https://clawhub.ai/iflow-ai/iflow-search>
+- Skill source: <https://github.com/iflow-ai/iflow-skills/tree/main/skills/iflow-search>
+- iFlow skill docs: <https://platform.iflow.cn/docs/skill>
+- iFlow platform docs: <https://platform.iflow.cn/docs/>
+
 ## Find and install a plugin
 
 Search from OpenClaw:


### PR DESCRIPTION
## Summary

Adds a short "Example: a community skill" subsection to `docs/quickstart.md` under "Find and install a skill", using `iflow-search` as a concrete third-party example of the existing install/verify flow.

Why: the current quickstart shows `openclaw skills install <skill-slug>` with a placeholder. A real, copy-paste-able example helps new users see what a fully-set-up community skill looks like — requirements declaration, env-var setup, and the `openclaw skills info` verification step.

This is a community / third-party skill example, not an endorsement.

## What's in the patch

- One additive subsection in `docs/quickstart.md`
- No changes to other files, navigation, sidebar, or frontmatter

## Verification

Performed against a fresh OpenClaw profile before drafting this PR:

- `openclaw skills install iflow-search` → installed `iflow-search@1.0.0` from ClawHub
- `openclaw skills info iflow-search` → `✓ Ready` (env `IFLOW_API_KEY` ✓, bins `bash` ✓ / `curl` ✓)
- Three bundled scripts (`web_search.sh`, `image_search.sh`, `web_fetch.sh`) each returned `success: true, code: 200` against the live iFlow API
- Listing: <https://clawhub.ai/iflow-ai/iflow-search> (ClawScan: CLEAN)

API key was env-only — never printed, never written to a file, never passed as a CLI argument.

## Scope notes

- Docs-only.
- I can share a short heads-up in `#clawhub` on Discord if maintainers prefer that for non-trivial doc changes — happy to do that before or after review.
- Open to alternative placements, such as a separate examples page, or trimming to a one-line pointer if that fits the docs style better.