### PR TITLE
fix: make security scan worker dispatchable

### DIFF
--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -42,7 +42,7 @@ jobs:
       CODEX_SECURITY_SCAN_MAX_JOBS: ${{ inputs['max-jobs'] || '' }}
       CODEX_SECURITY_SCAN_MAX_RUNTIME_MINUTES: ${{ inputs['max-runtime-minutes'] || '40' }}
       CODEX_SECURITY_SCAN_LEASE_MINUTES: "60"
-      CODEX_SECURITY_SCAN_DIAGNOSTICS_DIR: ${{ runner.temp }}/codex-security-scan-diagnostics
+      CODEX_SECURITY_SCAN_DIAGNOSTICS_DIR: codex-security-scan-diagnostics
       SKILLSPECTOR_PROVIDER: openai
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Make the security scan worker manually dispatchable by removing the unsupported `runner.temp` expression from job-level env.
- Keep diagnostics upload pointed at a stable relative directory.

## Verification
- `actionlint .github/workflows/security-scan-codex.yml`
