### PR TITLE
fix: streamline security audit agentic lanes

### DIFF
--- a/convex/securityScan.ts
+++ b/convex/securityScan.ts
@@ -2,8 +2,9 @@ import { ConvexError, v } from "convex/values";
 import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import type { MutationCtx } from "./_generated/server";
-import { action, internalMutation, internalQuery } from "./functions";
-import { assertModerator } from "./lib/access";
+import { action, internalMutation, internalQuery, mutation } from "./functions";
+import { assertModerator, requireUser } from "./lib/access";
+import { assertCanManageOwnedResource } from "./lib/publishers";
 
 const MAX_PARALLEL_CODEX_SCANS = 20;
 const DEFAULT_VT_WAIT_MS = 10 * 60 * 1000;
@@ -418,6 +419,71 @@ export const enqueueSkillRescanForModeratorInternal = internalMutation({
 
     await ctx.db.insert("auditLogs", {
       actorUserId: actor._id,
+      action: "skill.clawscan.rescan",
+      targetType: "skillVersion",
+      targetId: version._id,
+      metadata: {
+        skillId: skill._id,
+        slug: skill.slug,
+        version: version.version,
+        jobId: queued.jobId,
+        alreadyQueued: queued.alreadyQueued === true,
+      },
+      createdAt: Date.now(),
+    });
+
+    return {
+      ok: true as const,
+      slug: skill.slug,
+      version: version.version,
+      skillId: skill._id,
+      skillVersionId: version._id,
+      jobId: queued.jobId,
+      alreadyQueued: queued.alreadyQueued === true,
+    };
+  },
+});
+
+export const requestSkillRescan = mutation({
+  args: {
+    skillId: v.id("skills"),
+    version: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const { user } = await requireUser(ctx);
+    const skill = await ctx.db.get(args.skillId);
+    if (!skill || skill.softDeletedAt) throw new ConvexError("Skill not found");
+
+    await assertCanManageOwnedResource(ctx, {
+      actor: user,
+      ownerUserId: skill.ownerUserId,
+      ownerPublisherId: skill.ownerPublisherId,
+      allowPlatformAdmin: true,
+    });
+
+    const requestedVersion = args.version?.trim();
+    const version = requestedVersion
+      ? await ctx.db
+          .query("skillVersions")
+          .withIndex("by_skill_version", (q) =>
+            q.eq("skillId", skill._id).eq("version", requestedVersion),
+          )
+          .unique()
+      : skill.latestVersionId
+        ? await ctx.db.get(skill.latestVersionId)
+        : null;
+    if (!version || version.softDeletedAt) throw new ConvexError("Skill version not found");
+
+    const queued = await enqueueSkillVersionScan(ctx, {
+      versionId: version._id,
+      source: "manual",
+      priority: 100,
+      waitForVtMs: 0,
+    });
+    if (!queued.jobId) throw new ConvexError("Skill version not found");
+
+    await ctx.db.insert("auditLogs", {
+      actorUserId: user._id,
       action: "skill.clawscan.rescan",
       targetType: "skillVersion",
       targetId: version._id,

--- a/src/__tests__/skill-security-scanner-route.test.tsx
+++ b/src/__tests__/skill-security-scanner-route.test.tsx
@@ -5,6 +5,7 @@ import type { ComponentType } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const useQueryMock = vi.fn();
+const useMutationMock = vi.fn();
 const useAuthStatusMock = vi.fn();
 
 let paramsMock = {
@@ -38,6 +39,7 @@ vi.mock("@tanstack/react-router", () => ({
 }));
 
 vi.mock("convex/react", () => ({
+  useMutation: (...args: unknown[]) => useMutationMock(...args),
   useQuery: (...args: unknown[]) => useQueryMock(...args),
 }));
 
@@ -61,6 +63,8 @@ describe("skill security audit route", () => {
   beforeEach(() => {
     useQueryMock.mockReset();
     useQueryMock.mockReturnValue(undefined);
+    useMutationMock.mockReset();
+    useMutationMock.mockReturnValue(vi.fn());
     useAuthStatusMock.mockReturnValue({ me: null });
     paramsMock = {
       owner: "local",

--- a/src/components/DetailSecuritySummary.test.tsx
+++ b/src/components/DetailSecuritySummary.test.tsx
@@ -42,6 +42,7 @@ describe("DetailSecuritySummary", () => {
         "Security checks across static analysis, malware telemetry, and agentic risk",
       ),
     ).toBeNull();
+    expect(document.querySelector(".security-audit-meter")?.getAttribute("data-level")).toBe("4");
     expect(document.querySelectorAll(".security-audit-meter span")).toHaveLength(4);
   });
 
@@ -178,6 +179,28 @@ describe("DetailSecuritySummary", () => {
 
     expect(screen.getByText("Pass")).toBeTruthy();
     expect(screen.queryByText("Benign")).toBeNull();
+    expect(document.querySelector(".security-audit-meter")?.getAttribute("data-level")).toBe("4");
+  });
+
+  it("renders malicious scanner outcomes with the lowest safety meter level", () => {
+    render(
+      <DetailSecuritySummary
+        auditHref="/steipete/weather/security-audit"
+        vtAnalysis={{ status: "clean", checkedAt: 1 }}
+        llmAnalysis={{ status: "clean", summary: "No mismatches found.", checkedAt: 1 }}
+        staticScan={{
+          status: "malicious",
+          reasonCodes: ["malicious.external_transfer"],
+          findings: [],
+          summary: "External transfer.",
+          engineVersion: "v1",
+          checkedAt: 1,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Malicious")).toBeTruthy();
+    expect(document.querySelector(".security-audit-meter")?.getAttribute("data-level")).toBe("1");
   });
 
   it("keeps legacy non-engine VirusTotal fields neutral in the aggregate verdict", () => {

--- a/src/components/DetailSecuritySummary.tsx
+++ b/src/components/DetailSecuritySummary.tsx
@@ -18,17 +18,17 @@ type DetailSecuritySummaryProps = {
 function auditVerdictMeterLevel(status: string) {
   switch (status.toLowerCase()) {
     case "malicious":
-      return 4;
+      return 1;
     case "warn":
     case "warning":
     case "suspicious":
-      return 3;
-    case "review":
       return 2;
+    case "review":
+      return 3;
     case "benign":
     case "clean":
     case "cleared":
-      return 1;
+      return 4;
     default:
       return 0;
   }

--- a/src/components/SecurityAuditPage.tsx
+++ b/src/components/SecurityAuditPage.tsx
@@ -1,4 +1,4 @@
-import { Clock, ExternalLink, Info, Loader2, RefreshCw, X } from "lucide-react";
+import { Clock, ExternalLink, Info, RefreshCw, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { Id } from "../../convex/_generated/dataModel";
 import { getRuntimeEnv } from "../lib/runtimeEnv";
@@ -30,6 +30,7 @@ import {
   type VtAnalysis,
 } from "./SkillSecurityScanResults";
 import { Alert, AlertDescription } from "./ui/alert";
+import { Button } from "./ui/button";
 import { Skeleton } from "./ui/skeleton";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
 
@@ -597,7 +598,7 @@ function StaticAnalysisFinding({
         </div>
         {trimmedSnippet ? (
           <div>
-            <dt>Skill content</dt>
+            <dt>Content</dt>
             <dd>
               <pre className="agentic-risk-evidence-snippet">{trimmedSnippet}</pre>
             </dd>
@@ -691,20 +692,20 @@ function SecurityAuditSidebar(props: SecurityAuditPageProps) {
       <span>{props.entity.version ?? "Latest"}</span>
       {showRescanButton ? (
         <>
-          <button
+          <Button
             type="button"
-            className="security-audit-rescan-button"
+            variant="outline"
+            className="skill-sidebar-action-button security-audit-rescan-button"
             onClick={() => void requestRescan()}
             disabled={isRescanBusy}
-            aria-label={isRescanBusy ? "Security scan queued" : "Rescan security audit"}
+            loading={isRescanBusy}
+            aria-label={isRescanBusy ? "Scanning" : "Rescan"}
           >
-            {isRescanBusy ? (
-              <Loader2 className="security-audit-rescan-icon is-spinning" aria-hidden="true" />
-            ) : (
+            {!isRescanBusy ? (
               <RefreshCw className="security-audit-rescan-icon" aria-hidden="true" />
-            )}
-            <span>{isRescanBusy ? "Scan queued" : "Rescan"}</span>
-          </button>
+            ) : null}
+            <span>{isRescanBusy ? "Scanning" : "Rescan"}</span>
+          </Button>
           {rescanState === "error" ? (
             <span className="security-audit-rescan-error" role="status">
               Rescan could not be queued.

--- a/src/components/SecurityAuditPage.tsx
+++ b/src/components/SecurityAuditPage.tsx
@@ -1,4 +1,4 @@
-import { Clock, ExternalLink, Info, X } from "lucide-react";
+import { Clock, ExternalLink, Info, Loader2, RefreshCw, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { Id } from "../../convex/_generated/dataModel";
 import { getRuntimeEnv } from "../lib/runtimeEnv";
@@ -60,6 +60,7 @@ type SecurityAuditPageProps = {
   clawScanNote?: string | null;
   canManageArtifact?: boolean;
   settingsHref?: string | null;
+  onRequestRescan?: (() => Promise<unknown>) | null;
 };
 
 const EMPTY_STATIC_FINDINGS: StaticScanAnalysis["findings"] = [];
@@ -270,26 +271,15 @@ function SecurityAuditOverview(props: SecurityAuditPageProps) {
 }
 
 function ClawScanSection(props: SecurityAuditPageProps) {
-  const skillSpectorFindingsAvailable = hasSkillSpectorFindings(props.skillSpectorAnalysis);
   const riskAnalysis =
-    !skillSpectorFindingsAvailable && props.llmAnalysis && hasClawScanRiskReview(props.llmAnalysis)
+    props.llmAnalysis && !props.skillSpectorAnalysis && hasClawScanRiskReview(props.llmAnalysis)
       ? props.llmAnalysis
       : null;
+  if (!riskAnalysis) return null;
 
   return (
     <div className="security-report-panel-body security-report-panel-body-findings">
-      {skillSpectorFindingsAvailable ? (
-        <p className="security-audit-empty-detail">
-          Agentic-risk findings are shown in SkillSpector. ClawScan uses those findings with the
-          other scanners to make the final verdict.
-        </p>
-      ) : riskAnalysis ? (
-        <ClawScanRiskReview analysis={riskAnalysis} showTitle={false} />
-      ) : (
-        <p className="security-audit-empty-detail">
-          No visible risk-analysis findings were reported for this release.
-        </p>
-      )}
+      <ClawScanRiskReview analysis={riskAnalysis} showTitle={false} />
     </div>
   );
 }
@@ -344,11 +334,7 @@ function VirusTotalSection(props: SecurityAuditPageProps) {
 
 function SkillSpectorSection(props: SecurityAuditPageProps) {
   const analysis = props.skillSpectorAnalysis ?? null;
-  const hasLegacyFindings =
-    props.llmAnalysis && hasClawScanRiskReview(props.llmAnalysis) && !analysis;
-  const overviewCopy = hasLegacyFindings
-    ? "SkillSpector has not run for this release. Legacy ClawScan findings remain available under Risk analysis."
-    : getSkillSpectorOverviewCopy(analysis);
+  const overviewCopy = getSkillSpectorOverviewCopy(analysis);
   const contentSnippets = useSkillSpectorContentSnippets(
     props.entity,
     analysis?.issues ?? EMPTY_SKILLSPECTOR_ISSUES,
@@ -682,6 +668,52 @@ function SecurityAuditScannerSection({
 function SecurityAuditSidebar(props: SecurityAuditPageProps) {
   const latestCheckedAt = getLatestAuditCheckedAt(props);
   const verdict = aggregateAuditVerdict(props);
+  const [rescanState, setRescanState] = useState<"idle" | "submitting" | "queued" | "error">(
+    "idle",
+  );
+  const showRescanButton =
+    props.entity.kind === "skill" && props.canManageArtifact && props.onRequestRescan;
+  const isRescanBusy = rescanState === "submitting" || rescanState === "queued";
+
+  async function requestRescan() {
+    if (!props.onRequestRescan || isRescanBusy) return;
+    setRescanState("submitting");
+    try {
+      await props.onRequestRescan();
+      setRescanState("queued");
+    } catch {
+      setRescanState("error");
+    }
+  }
+
+  const versionValue = (
+    <div className="security-audit-version-stack">
+      <span>{props.entity.version ?? "Latest"}</span>
+      {showRescanButton ? (
+        <>
+          <button
+            type="button"
+            className="security-audit-rescan-button"
+            onClick={() => void requestRescan()}
+            disabled={isRescanBusy}
+            aria-label={isRescanBusy ? "Security scan queued" : "Rescan security audit"}
+          >
+            {isRescanBusy ? (
+              <Loader2 className="security-audit-rescan-icon is-spinning" aria-hidden="true" />
+            ) : (
+              <RefreshCw className="security-audit-rescan-icon" aria-hidden="true" />
+            )}
+            <span>{isRescanBusy ? "Scan queued" : "Rescan"}</span>
+          </button>
+          {rescanState === "error" ? (
+            <span className="security-audit-rescan-error" role="status">
+              Rescan could not be queued.
+            </span>
+          ) : null}
+        </>
+      ) : null}
+    </div>
+  );
 
   return (
     <SidebarMetadata
@@ -701,7 +733,7 @@ function SecurityAuditSidebar(props: SecurityAuditPageProps) {
             </span>
           ),
         },
-        { label: "Version", value: props.entity.version ?? "Latest" },
+        { label: "Version", value: versionValue },
       ]}
     />
   );

--- a/src/components/SkillSecurityScanResults.test.tsx
+++ b/src/components/SkillSecurityScanResults.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SecurityAuditPage } from "./SecurityAuditPage";
 import {
   getSkillSpectorIssueCount,
@@ -159,7 +159,11 @@ const skillSpectorAnalysis: SkillSpectorAnalysis = {
   ],
 };
 
+const originalFetch = globalThis.fetch;
+
 beforeEach(() => {
+  vi.restoreAllMocks();
+  globalThis.fetch = originalFetch;
   window.localStorage.clear();
   window.history.replaceState(null, "", "/");
 });
@@ -474,14 +478,7 @@ describe("SecurityScanResults static guidance", () => {
       Array.from(container.querySelectorAll(".security-report-main > section h2")).map((node) =>
         node.textContent?.trim(),
       ),
-    ).toEqual([
-      "Overview",
-      "Publisher note",
-      "SkillSpector",
-      "Static analysis",
-      "VirusTotal",
-      "Risk analysis",
-    ]);
+    ).toEqual(["Overview", "Publisher note", "Static analysis", "VirusTotal", "Risk analysis"]);
   });
 
   it("renders SkillSpector findings as the agentic-risk finding source", () => {
@@ -714,7 +711,7 @@ describe("SecurityScanResults static guidance", () => {
       Array.from(container.querySelectorAll(".security-report-main > section h2")).map((node) =>
         node.textContent?.trim(),
       ),
-    ).toEqual(["Overview", "SkillSpector", "Static analysis", "VirusTotal", "Risk analysis"]);
+    ).toEqual(["Overview", "SkillSpector", "Static analysis", "VirusTotal"]);
   });
 
   it("summarizes completed engine-only VirusTotal scans", () => {
@@ -945,7 +942,7 @@ describe("SecurityScanResults static guidance", () => {
       Array.from(container.querySelectorAll(".security-report-main > section h2")).map((node) =>
         node.textContent?.trim(),
       ),
-    ).toEqual(["Overview", "SkillSpector", "Static analysis", "VirusTotal", "Risk analysis"]);
+    ).toEqual(["Overview", "SkillSpector", "Static analysis", "VirusTotal"]);
   });
 
   it("shows plugins with legacy ClawScan analysis in the new ClawScan report shell", () => {
@@ -1007,7 +1004,7 @@ describe("SecurityScanResults static guidance", () => {
     ).toBeTruthy();
   });
 
-  it("shows the new ClawScan empty state when no analysis exists yet", () => {
+  it("shows only SkillSpector pending when no agentic-risk source exists yet", () => {
     render(
       <SecurityAuditPage
         entity={{
@@ -1038,6 +1035,64 @@ describe("SecurityScanResults static guidance", () => {
     ).toBeNull();
     expect(screen.queryByText("Review Dimensions")).toBeNull();
     expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "SkillSpector" })).toBeTruthy();
+    expect(screen.getByText("SkillSpector findings are pending for this release.")).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Risk analysis" })).toBeNull();
+    expect(
+      screen.queryByText("No visible risk-analysis findings were reported for this release."),
+    ).toBeNull();
     expect(screen.getByRole("heading", { name: "Security Audit Metadata" })).toBeTruthy();
+  });
+
+  it("shows only legacy Risk analysis when legacy agentic-risk findings exist without SkillSpector", () => {
+    const { container } = render(
+      <SecurityAuditPage
+        entity={{
+          kind: "skill",
+          title: "Legacy Risk Skill",
+          name: "legacy-risk-skill",
+          version: "1.0.0",
+          detailPath: "/local/legacy-risk-skill",
+        }}
+        llmAnalysis={clawScanAnalysis}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Risk analysis" })).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "SkillSpector" })).toBeNull();
+    expect(
+      screen.queryByText(/Legacy ClawScan findings remain available under Risk analysis/i),
+    ).toBeNull();
+    expect(
+      Array.from(container.querySelectorAll(".security-report-main > section h2")).map((node) =>
+        node.textContent?.trim(),
+      ),
+    ).toEqual(["Overview", "Static analysis", "VirusTotal", "Risk analysis"]);
+  });
+
+  it("lets skill managers enqueue a security rescan from the audit sidebar", async () => {
+    const requestRescan = vi.fn().mockResolvedValue({ ok: true });
+
+    render(
+      <SecurityAuditPage
+        entity={{
+          kind: "skill",
+          title: "Rescan Guard",
+          name: "rescan-guard",
+          version: "1.0.0",
+          detailPath: "/local/rescan-guard",
+        }}
+        canManageArtifact
+        onRequestRescan={requestRescan}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Rescan security audit" }));
+
+    await waitFor(() => expect(requestRescan).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole("button", { name: "Security scan queued" })).toHaveProperty(
+      "disabled",
+      true,
+    );
   });
 });

--- a/src/components/SkillSecurityScanResults.test.tsx
+++ b/src/components/SkillSecurityScanResults.test.tsx
@@ -933,7 +933,7 @@ describe("SecurityScanResults static guidance", () => {
     expect(screen.getByText("Network access found in skill instructions.")).toBeTruthy();
     expect(screen.queryByText("Location")).toBeNull();
     expect(screen.queryByText("SKILL.md:12")).toBeNull();
-    expect(screen.getByText("Skill content")).toBeTruthy();
+    expect(screen.getByText("Content")).toBeTruthy();
     expect(screen.getByText("curl https://example.test")).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Security Audit Metadata" })).toBeTruthy();
     expect(screen.queryByText("Scanner verdict")).toBeNull();
@@ -1087,12 +1087,9 @@ describe("SecurityScanResults static guidance", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Rescan security audit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Rescan" }));
 
     await waitFor(() => expect(requestRescan).toHaveBeenCalledTimes(1));
-    expect(screen.getByRole("button", { name: "Security scan queued" })).toHaveProperty(
-      "disabled",
-      true,
-    );
+    expect(screen.getByRole("button", { name: "Scanning" })).toHaveProperty("disabled", true);
   });
 });

--- a/src/components/securityAuditModel.ts
+++ b/src/components/securityAuditModel.ts
@@ -2,6 +2,7 @@ import {
   getClawScanDisplayStatus,
   getSkillSpectorDisplayStatus,
   getVirusTotalDisplayStatus,
+  hasClawScanRiskReview,
   type LlmAnalysis,
   type SkillSpectorAnalysis,
   type StaticFinding,
@@ -43,6 +44,10 @@ const DEFAULT_AUDIT_SCANNER_ORDER: AuditScannerKind[] = [
   "virustotal",
   "clawscan",
 ];
+
+const SUPPORTING_AUDIT_SCANNER_ORDER: AuditScannerKind[] = DEFAULT_AUDIT_SCANNER_ORDER.filter(
+  (kind) => kind !== "skillspector" && kind !== "clawscan",
+);
 
 const POLICY_VERDICT_SCANNER_ORDER: AuditScannerKind[] = [
   "static-analysis",
@@ -101,11 +106,14 @@ export function getSecurityAuditOverviewCopy({
   ].filter((copy): copy is string => Boolean(copy));
 }
 
-export function getAuditScannerOrder(signals?: SecurityAuditSignals) {
+export function getAuditScannerOrder(signals?: SecurityAuditSignals): AuditScannerKind[] {
   if (signals?.skillSpectorAnalysis) {
-    return DEFAULT_AUDIT_SCANNER_ORDER.filter((kind) => kind !== "clawscan");
+    return ["skillspector", ...SUPPORTING_AUDIT_SCANNER_ORDER];
   }
-  return DEFAULT_AUDIT_SCANNER_ORDER;
+  if (hasClawScanRiskReview(signals?.llmAnalysis)) {
+    return [...SUPPORTING_AUDIT_SCANNER_ORDER, "clawscan"];
+  }
+  return ["skillspector", ...SUPPORTING_AUDIT_SCANNER_ORDER];
 }
 
 export function getLatestAuditCheckedAt(signals: SecurityAuditSignals) {

--- a/src/routes/$owner/$slug/security-audit.tsx
+++ b/src/routes/$owner/$slug/security-audit.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, notFound, redirect } from "@tanstack/react-router";
-import { useQuery } from "convex/react";
+import { useMutation, useQuery } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
 import {
   SecurityAuditPage,
@@ -65,6 +65,7 @@ function SkillSecurityAuditRoute() {
   const { owner, slug } = Route.useParams();
   const { initialData } = Route.useLoaderData();
   const liveResult = useQuery(api.skills.getBySlug, { slug });
+  const requestSkillRescan = useMutation(api.securityScan.requestSkillRescan);
   const { me } = useAuthStatus();
   const myPublishers = useQuery(api.publishers.listMine, me ? {} : "skip") as
     | Array<{ publisher: { _id: string }; role: string }>
@@ -117,6 +118,11 @@ function SkillSecurityAuditRoute() {
       clawScanNote={latestVersion.clawScanNote ?? null}
       canManageArtifact={canManageArtifact}
       settingsHref={canManageArtifact ? settingsHref : null}
+      onRequestRescan={
+        canManageArtifact
+          ? () => requestSkillRescan({ skillId: skill._id, version: latestVersion.version })
+          : null
+      }
     />
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -4651,41 +4651,12 @@ code {
 .security-audit-version-stack {
   display: grid;
   justify-items: start;
-  gap: 10px;
+  gap: 16px;
+  width: 100%;
 }
 
 .security-audit-rescan-button {
-  display: inline-flex;
-  min-height: 32px;
-  align-items: center;
-  justify-content: center;
-  gap: 7px;
-  padding: 6px 10px;
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  background: color-mix(in srgb, var(--hover-bg) 70%, transparent);
-  color: var(--ink);
-  font-size: 0.82rem;
-  font-weight: 730;
-  line-height: 1.2;
-  cursor: pointer;
-  transition:
-    border-color 0.16s ease,
-    background-color 0.16s ease,
-    color 0.16s ease,
-    opacity 0.16s ease;
-}
-
-.security-audit-rescan-button:hover,
-.security-audit-rescan-button:focus-visible {
-  border-color: color-mix(in srgb, var(--ink-soft) 42%, var(--line));
-  background: var(--hover-bg);
-  outline: none;
-}
-
-.security-audit-rescan-button:disabled {
-  cursor: default;
-  opacity: 0.74;
+  margin-top: 4px;
 }
 
 .security-audit-rescan-icon {
@@ -4694,21 +4665,11 @@ code {
   flex: 0 0 auto;
 }
 
-.security-audit-rescan-icon.is-spinning {
-  animation: security-audit-spin 0.85s linear infinite;
-}
-
 .security-audit-rescan-error {
   color: var(--danger);
   font-size: 0.78rem;
   font-weight: 650;
   line-height: 1.35;
-}
-
-@keyframes security-audit-spin {
-  to {
-    transform: rotate(360deg);
-  }
 }
 
 .skill-action-count {

--- a/src/styles.css
+++ b/src/styles.css
@@ -4444,19 +4444,19 @@ code {
 }
 
 .security-audit-meter[data-level="1"] span:first-child {
-  background: #79e68e;
+  background: #ef7777;
 }
 
 .security-audit-meter[data-level="2"] span:nth-child(-n + 2) {
-  background: #6aa9ff;
-}
-
-.security-audit-meter[data-level="3"] span:nth-child(-n + 3) {
   background: #f1b85a;
 }
 
+.security-audit-meter[data-level="3"] span:nth-child(-n + 3) {
+  background: #6aa9ff;
+}
+
 .security-audit-meter[data-level="4"] span {
-  background: #ef7777;
+  background: #79e68e;
 }
 
 .publisher-clawscan-note {

--- a/src/styles.css
+++ b/src/styles.css
@@ -4648,6 +4648,69 @@ code {
   gap: 8px;
 }
 
+.security-audit-version-stack {
+  display: grid;
+  justify-items: start;
+  gap: 10px;
+}
+
+.security-audit-rescan-button {
+  display: inline-flex;
+  min-height: 32px;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 6px 10px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--hover-bg) 70%, transparent);
+  color: var(--ink);
+  font-size: 0.82rem;
+  font-weight: 730;
+  line-height: 1.2;
+  cursor: pointer;
+  transition:
+    border-color 0.16s ease,
+    background-color 0.16s ease,
+    color 0.16s ease,
+    opacity 0.16s ease;
+}
+
+.security-audit-rescan-button:hover,
+.security-audit-rescan-button:focus-visible {
+  border-color: color-mix(in srgb, var(--ink-soft) 42%, var(--line));
+  background: var(--hover-bg);
+  outline: none;
+}
+
+.security-audit-rescan-button:disabled {
+  cursor: default;
+  opacity: 0.74;
+}
+
+.security-audit-rescan-icon {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+}
+
+.security-audit-rescan-icon.is-spinning {
+  animation: security-audit-spin 0.85s linear infinite;
+}
+
+.security-audit-rescan-error {
+  color: var(--danger);
+  font-size: 0.78rem;
+  font-weight: 650;
+  line-height: 1.35;
+}
+
+@keyframes security-audit-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .skill-action-count {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary

This PR tightens the security-audit page rollout behavior for SkillSpector. The agentic-risk area now renders exactly one source of findings: SkillSpector when present, legacy Risk analysis only when SkillSpector has not run and legacy findings exist, and SkillSpector pending when neither source has results.

It also adds a manager-only Rescan button under the audit Version metadata for skill security-audit pages. The button uses the signed-in Convex session, queues a manual security scan through a new `api.securityScan.requestSkillRescan` mutation, and switches into a queued spinner state after the request succeeds.

## Cause and User Impact

The previous scanner ordering always included both SkillSpector pending and Risk analysis unless a SkillSpector analysis object existed. That meant releases with no agentic-risk findings could show two empty or misleading sections, including stale copy pointing users from SkillSpector to legacy Risk analysis.

## Fix

- Updated scanner ordering so SkillSpector and legacy Risk analysis are mutually exclusive agentic lanes.
- Removed stale SkillSpector legacy fallback copy and empty Risk-analysis rendering.
- Added the skill-owner/admin rescan UI and a session-authenticated Convex mutation to enqueue manual rescans.
- Covered the rollout matrix and rescan button behavior in component tests.

## Verification

- `bun run test src/components/SkillSecurityScanResults.test.tsx`
- `bunx tsc --noEmit`
- `bun run lint`
- `bun run format:check -- src/components/SecurityAuditPage.tsx src/components/securityAuditModel.ts src/components/SkillSecurityScanResults.test.tsx 'src/routes/$owner/$slug/security-audit.tsx' convex/securityScan.ts src/styles.css`
