### PR TITLE
feat: support artifact-generic security rescans

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -3252,7 +3252,7 @@ describe("httpApiV1 handlers", () => {
     );
   });
 
-  it("skill rescan enqueues moderator ClawScan jobs", async () => {
+  it("skill rescan enqueues owner-authorized ClawScan jobs", async () => {
     vi.mocked(requireApiTokenUser).mockResolvedValue({
       userId: "users:moderator",
       user: { _id: "users:moderator", role: "moderator" },
@@ -3288,7 +3288,7 @@ describe("httpApiV1 handlers", () => {
     });
     expect(runMutation).toHaveBeenCalledWith(
       (internal as unknown as { securityScan: Record<string, unknown> }).securityScan
-        .enqueueSkillRescanForModeratorInternal,
+        .requestSkillRescanForUserInternal,
       {
         actorUserId: "users:moderator",
         slug: "demo",
@@ -3321,23 +3321,73 @@ describe("httpApiV1 handlers", () => {
     expect(runMutation).toHaveBeenCalledTimes(1);
   });
 
-  it("does not expose the removed package rescan route", async () => {
+  it("package rescan enqueues owner-authorized ClawScan jobs", async () => {
     vi.mocked(requireApiTokenUser).mockResolvedValue({
       userId: "users:1",
       user: { handle: "p" },
     } as never);
-    const runMutation = vi.fn(async () => okRate());
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      return {
+        ok: true,
+        name: "@scope/demo",
+        version: "1.2.3",
+        packageId: "packages:1",
+        packageReleaseId: "packageReleases:1",
+        jobId: "securityScanJobs:1",
+        alreadyQueued: false,
+      };
+    });
 
     const response = await __handlers.packagesPostRouterV1Handler(
       makeCtx({ runMutation }),
       new Request("https://example.com/api/v1/packages/%40scope%2Fdemo/rescan", {
         method: "POST",
         headers: { Authorization: "Bearer clh_test" },
+        body: JSON.stringify({ version: "1.2.3" }),
       }),
     );
 
-    expect(response.status).toBe(404);
-    expect(runMutation.mock.calls.length).toBe(0);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      name: "@scope/demo",
+      version: "1.2.3",
+      jobId: "securityScanJobs:1",
+    });
+    expect(runMutation).toHaveBeenCalledWith(
+      (internal as unknown as { securityScan: Record<string, unknown> }).securityScan
+        .requestPackageRescanForUserInternal,
+      {
+        actorUserId: "users:1",
+        name: "@scope/demo",
+        version: "1.2.3",
+      },
+    );
+  });
+
+  it("package rescan rejects malformed JSON", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:1",
+      user: { handle: "p" },
+    } as never);
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      throw new Error("should not enqueue");
+    });
+
+    const response = await __handlers.packagesPostRouterV1Handler(
+      makeCtx({ runMutation }),
+      new Request("https://example.com/api/v1/packages/%40scope%2Fdemo/rescan", {
+        method: "POST",
+        headers: { Authorization: "Bearer clh_test" },
+        body: "{",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.text()).resolves.toBe("Invalid JSON");
+    expect(runMutation).toHaveBeenCalledTimes(1);
   });
 
   it("transfer request requires auth", async () => {

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -127,6 +127,9 @@ const internalRefs = internal as unknown as {
   publishers: {
     getByHandleInternal: unknown;
   };
+  securityScan: {
+    requestPackageRescanForUserInternal: unknown;
+  };
 };
 
 function packageOperationErrorToResponse(
@@ -142,6 +145,18 @@ function packageOperationErrorToResponse(
     return text(formatAuthzMessage(error, "Forbidden"), 403, headers);
   if (lower.includes("not found")) return text(message, 404, headers);
   return text(message, 400, headers);
+}
+
+async function readOptionalJson(request: Request): Promise<unknown> {
+  const raw = await request.text();
+  if (!raw.trim()) return undefined;
+  return JSON.parse(raw) as unknown;
+}
+
+function optionalStringField(value: unknown, key: string): string | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const field = (value as Record<string, unknown>)[key];
+  return typeof field === "string" ? field : undefined;
 }
 
 function isTransientConvexContentionMessage(message: string) {
@@ -1829,6 +1844,31 @@ export async function packagesPostRouterV1Handler(ctx: ActionCtx, request: Reque
   if (!packageRoute) return text("Not found", 404);
   const packageName = packageRoute.packageName;
   const packageSegments = packageRoute.rest;
+
+  if (packageSegments[0] === "rescan" && packageSegments.length === 1) {
+    const rate = await applyRateLimit(ctx, request, "write");
+    if (!rate.ok) return rate.response;
+    const auth = await requireApiTokenUserOrResponse(ctx, request, rate.headers);
+    if (!auth.ok) return auth.response;
+
+    try {
+      const body = await readOptionalJson(request);
+      const version = optionalStringField(body, "version");
+      const result = await runMutationRef(
+        ctx,
+        internalRefs.securityScan.requestPackageRescanForUserInternal,
+        {
+          actorUserId: auth.userId,
+          name: packageName,
+          ...(version ? { version } : {}),
+        },
+      );
+      return json(result, 200, rate.headers);
+    } catch (error) {
+      if (error instanceof SyntaxError) return text("Invalid JSON", 400, rate.headers);
+      return packageOperationErrorToResponse(error, rate.headers, "Package rescan failed");
+    }
+  }
 
   if (packageSegments[0] === "repair-name" && packageSegments.length === 1) {
     const rate = await applyRateLimit(ctx, request, "write");

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -277,7 +277,7 @@ type SkillSecuritySnapshot = {
 
 const internalRefs = internal as unknown as {
   securityScan: {
-    enqueueSkillRescanForModeratorInternal: unknown;
+    requestSkillRescanForUserInternal: unknown;
   };
   skills: {
     reportSkillForUserInternal: unknown;
@@ -1501,7 +1501,7 @@ export async function skillsPostRouterV1Handler(ctx: ActionCtx, request: Request
       const version = optionalStringField(body, "version");
       const result = await runMutationRef(
         ctx,
-        internalRefs.securityScan.enqueueSkillRescanForModeratorInternal,
+        internalRefs.securityScan.requestSkillRescanForUserInternal,
         {
           actorUserId: auth.userId,
           slug,

--- a/convex/securityScan.test.ts
+++ b/convex/securityScan.test.ts
@@ -1,10 +1,19 @@
+import { getAuthUserId } from "@convex-dev/auth/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   cancelQueuedVtUpdateJobsInternal,
   claimCodexScanJobs,
   completeCodexScanJob,
   failCodexScanJob,
+  requestPackageRescanForUserInternal,
+  requestPackageRescan,
+  requestSkillRescanForUserInternal,
+  requestSkillRescan,
 } from "./securityScan";
+
+vi.mock("@convex-dev/auth/server", () => ({
+  getAuthUserId: vi.fn(),
+}));
 
 type WrappedHandler<TArgs, TResult = unknown> = {
   _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
@@ -92,6 +101,34 @@ const cancelQueuedVtUpdateJobsInternalHandler = (
   cancelQueuedVtUpdateJobsInternal as unknown as WrappedHandler<CancelArgs, CancelResult>
 )._handler;
 
+const requestSkillRescanHandler = (
+  requestSkillRescan as unknown as WrappedHandler<
+    { skillId: string; version?: string },
+    { jobId: string; alreadyQueued: boolean }
+  >
+)._handler;
+
+const requestPackageRescanHandler = (
+  requestPackageRescan as unknown as WrappedHandler<
+    { packageId: string; version?: string },
+    { jobId: string; alreadyQueued: boolean; packageReleaseId: string }
+  >
+)._handler;
+
+const requestSkillRescanForUserInternalHandler = (
+  requestSkillRescanForUserInternal as unknown as WrappedHandler<
+    { actorUserId: string; slug: string; version?: string },
+    { jobId: string; alreadyQueued: boolean; skillVersionId: string }
+  >
+)._handler;
+
+const requestPackageRescanForUserInternalHandler = (
+  requestPackageRescanForUserInternal as unknown as WrappedHandler<
+    { actorUserId: string; name: string; version?: string },
+    { jobId: string; alreadyQueued: boolean; packageReleaseId: string }
+  >
+)._handler;
+
 const claimedJob = {
   _id: "securityScanJobs:1",
   _creationTime: 1,
@@ -134,6 +171,114 @@ function makeTarget(llmStatus?: string) {
       status: llmStatus,
       checkedAt: 123,
     },
+  };
+}
+
+function makeRescanCtx(options: {
+  actorId: string;
+  actorRole?: "admin" | "moderator" | "user";
+  docs: Record<string, Record<string, unknown>>;
+  activeJobs?: Array<Record<string, unknown>>;
+  membership?: Record<string, unknown> | null;
+}) {
+  vi.mocked(getAuthUserId).mockResolvedValue(options.actorId as never);
+  const docs = new Map<string, Record<string, unknown>>(
+    Object.entries({
+      [options.actorId]: {
+        _id: options.actorId,
+        role: options.actorRole ?? "user",
+      },
+      ...options.docs,
+    }),
+  );
+  const inserts: Array<{ table: string; doc: Record<string, unknown> }> = [];
+  const patches: Array<{ id: string; patch: Record<string, unknown> }> = [];
+  const get = vi.fn(async (id: string) => docs.get(id) ?? null);
+  const insert = vi.fn(async (table: string, doc: Record<string, unknown>) => {
+    const id = `${table}:${inserts.length + 1}`;
+    inserts.push({ table, doc });
+    return id;
+  });
+  const patch = vi.fn(async (id: string, doc: Record<string, unknown>) => {
+    patches.push({ id, patch: doc });
+  });
+  const query = vi.fn((table: string) => ({
+    withIndex: vi.fn((_indexName: string, buildRange: (q: { eq: typeof eq }) => unknown) => {
+      const equals = new Map<string, unknown>();
+      function eq(field: string, value: unknown) {
+        equals.set(field, value);
+        return { eq };
+      }
+      buildRange({ eq });
+      return {
+        collect: vi.fn(async () => {
+          if (table === "securityScanJobs") return options.activeJobs ?? [];
+          return [];
+        }),
+        unique: vi.fn(async () => {
+          if (table === "publisherMembers") return options.membership ?? null;
+          if (table === "skills") {
+            return (
+              Array.from(docs.values()).find(
+                (doc) =>
+                  doc._id?.toString().startsWith("skills:") && doc.slug === equals.get("slug"),
+              ) ?? null
+            );
+          }
+          if (table === "packages") {
+            return (
+              Array.from(docs.values()).find(
+                (doc) =>
+                  doc._id?.toString().startsWith("packages:") &&
+                  doc.normalizedName === equals.get("normalizedName"),
+              ) ?? null
+            );
+          }
+          if (table === "skillVersions") {
+            return (
+              Array.from(docs.values()).find(
+                (doc) =>
+                  doc._id?.toString().startsWith("skillVersions:") &&
+                  doc.skillId === equals.get("skillId") &&
+                  doc.version === equals.get("version"),
+              ) ?? null
+            );
+          }
+          if (table === "packageReleases") {
+            return (
+              Array.from(docs.values()).find(
+                (doc) =>
+                  doc._id?.toString().startsWith("packageReleases:") &&
+                  doc.packageId === equals.get("packageId") &&
+                  doc.version === equals.get("version"),
+              ) ?? null
+            );
+          }
+          return null;
+        }),
+      };
+    }),
+  }));
+
+  return {
+    ctx: {
+      db: {
+        get,
+        insert,
+        patch,
+        query,
+        replace: vi.fn(),
+        delete: vi.fn(),
+        normalizeId: vi.fn(() => null),
+        system: {},
+      },
+    },
+    inserts,
+    patches,
+    get,
+    insert,
+    patch,
+    query,
   };
 }
 
@@ -189,6 +334,229 @@ function makeCancelCtx(jobs: ScanJob[], targets: Map<string, unknown> = new Map(
 describe("securityScan", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
+    vi.mocked(getAuthUserId).mockReset();
+  });
+
+  it("lets platform moderators request skill rescans", async () => {
+    const { ctx, inserts } = makeRescanCtx({
+      actorId: "users:moderator",
+      actorRole: "moderator",
+      docs: {
+        "skills:1": {
+          _id: "skills:1",
+          slug: "demo-skill",
+          ownerUserId: "users:owner",
+          latestVersionId: "skillVersions:1",
+        },
+        "skillVersions:1": {
+          _id: "skillVersions:1",
+          skillId: "skills:1",
+          version: "1.0.0",
+        },
+      },
+    });
+
+    const result = await requestSkillRescanHandler(ctx, {
+      skillId: "skills:1",
+      version: "1.0.0",
+    });
+
+    expect(result).toMatchObject({
+      jobId: "securityScanJobs:1",
+      alreadyQueued: false,
+    });
+    expect(inserts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          table: "securityScanJobs",
+          doc: expect.objectContaining({
+            targetKind: "skillVersion",
+            skillVersionId: "skillVersions:1",
+            source: "manual",
+            priority: 100,
+          }),
+        }),
+        expect.objectContaining({
+          table: "auditLogs",
+          doc: expect.objectContaining({
+            actorUserId: "users:moderator",
+            action: "skill.clawscan.rescan",
+            targetType: "skillVersion",
+            targetId: "skillVersions:1",
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("lets skill owners request skill rescans through the API helper", async () => {
+    const { ctx, inserts } = makeRescanCtx({
+      actorId: "users:owner",
+      docs: {
+        "skills:1": {
+          _id: "skills:1",
+          slug: "demo-skill",
+          ownerUserId: "users:owner",
+          latestVersionId: "skillVersions:1",
+        },
+        "skillVersions:1": {
+          _id: "skillVersions:1",
+          skillId: "skills:1",
+          version: "1.0.0",
+        },
+      },
+    });
+
+    const result = await requestSkillRescanForUserInternalHandler(ctx, {
+      actorUserId: "users:owner",
+      slug: "demo-skill",
+      version: "1.0.0",
+    });
+
+    expect(result).toMatchObject({
+      skillVersionId: "skillVersions:1",
+      jobId: "securityScanJobs:1",
+      alreadyQueued: false,
+    });
+    expect(inserts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          table: "auditLogs",
+          doc: expect.objectContaining({
+            actorUserId: "users:owner",
+            action: "skill.clawscan.rescan",
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("lets platform moderators request package rescans", async () => {
+    const { ctx, inserts } = makeRescanCtx({
+      actorId: "users:moderator",
+      actorRole: "moderator",
+      docs: {
+        "packages:1": {
+          _id: "packages:1",
+          name: "@acme/demo-plugin",
+          normalizedName: "@acme/demo-plugin",
+          family: "plugin",
+          ownerUserId: "users:owner",
+          latestReleaseId: "packageReleases:1",
+        },
+        "packageReleases:1": {
+          _id: "packageReleases:1",
+          packageId: "packages:1",
+          version: "1.0.0",
+        },
+      },
+    });
+
+    const result = await requestPackageRescanHandler(ctx, {
+      packageId: "packages:1",
+      version: "1.0.0",
+    });
+
+    expect(result).toMatchObject({
+      packageReleaseId: "packageReleases:1",
+      jobId: "securityScanJobs:1",
+      alreadyQueued: false,
+    });
+    expect(inserts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          table: "securityScanJobs",
+          doc: expect.objectContaining({
+            targetKind: "packageRelease",
+            packageReleaseId: "packageReleases:1",
+            source: "manual",
+            priority: 100,
+          }),
+        }),
+        expect.objectContaining({
+          table: "auditLogs",
+          doc: expect.objectContaining({
+            actorUserId: "users:moderator",
+            action: "package.clawscan.rescan",
+            targetType: "packageRelease",
+            targetId: "packageReleases:1",
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("lets package owners request package rescans through the API helper", async () => {
+    const { ctx, inserts } = makeRescanCtx({
+      actorId: "users:owner",
+      docs: {
+        "packages:1": {
+          _id: "packages:1",
+          name: "@acme/demo-plugin",
+          normalizedName: "@acme/demo-plugin",
+          family: "code-plugin",
+          ownerUserId: "users:owner",
+          latestReleaseId: "packageReleases:1",
+        },
+        "packageReleases:1": {
+          _id: "packageReleases:1",
+          packageId: "packages:1",
+          version: "1.0.0",
+        },
+      },
+    });
+
+    const result = await requestPackageRescanForUserInternalHandler(ctx, {
+      actorUserId: "users:owner",
+      name: "@acme/demo-plugin",
+      version: "1.0.0",
+    });
+
+    expect(result).toMatchObject({
+      packageReleaseId: "packageReleases:1",
+      jobId: "securityScanJobs:1",
+      alreadyQueued: false,
+    });
+    expect(inserts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          table: "auditLogs",
+          doc: expect.objectContaining({
+            actorUserId: "users:owner",
+            action: "package.clawscan.rescan",
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("rejects unrelated package rescan callers", async () => {
+    const { ctx, insert } = makeRescanCtx({
+      actorId: "users:random",
+      actorRole: "user",
+      docs: {
+        "packages:1": {
+          _id: "packages:1",
+          name: "@acme/demo-plugin",
+          normalizedName: "@acme/demo-plugin",
+          family: "plugin",
+          ownerUserId: "users:owner",
+          latestReleaseId: "packageReleases:1",
+        },
+        "packageReleases:1": {
+          _id: "packageReleases:1",
+          packageId: "packages:1",
+          version: "1.0.0",
+        },
+      },
+    });
+
+    await expect(
+      requestPackageRescanHandler(ctx, {
+        packageId: "packages:1",
+      }),
+    ).rejects.toThrow("Forbidden");
+    expect(insert).not.toHaveBeenCalled();
   });
 
   it("fails claimed jobs when an artifact file URL is unavailable", async () => {

--- a/convex/securityScan.ts
+++ b/convex/securityScan.ts
@@ -4,6 +4,7 @@ import type { Doc, Id } from "./_generated/dataModel";
 import type { MutationCtx } from "./_generated/server";
 import { action, internalMutation, internalQuery, mutation } from "./functions";
 import { assertModerator, requireUser } from "./lib/access";
+import { normalizePackageName } from "./lib/packageRegistry";
 import { assertCanManageOwnedResource } from "./lib/publishers";
 
 const MAX_PARALLEL_CODEX_SCANS = 20;
@@ -82,6 +83,13 @@ const jobSourceValidator = v.union(
 
 type EnqueueSkillVersionScanArgs = {
   versionId: Id<"skillVersions">;
+  source: "publish" | "clawscan-note" | "vt-update" | "backfill" | "manual";
+  priority?: number;
+  waitForVtMs?: number;
+};
+
+type EnqueuePackageReleaseScanArgs = {
+  releaseId: Id<"packageReleases">;
   source: "publish" | "clawscan-note" | "vt-update" | "backfill" | "manual";
   priority?: number;
   waitForVtMs?: number;
@@ -444,6 +452,90 @@ export const enqueueSkillRescanForModeratorInternal = internalMutation({
   },
 });
 
+async function requestSkillRescanForActor(
+  ctx: MutationCtx,
+  args: {
+    actor: Doc<"users">;
+    skill: Doc<"skills">;
+    version?: string;
+  },
+) {
+  await assertCanManageOwnedResource(ctx, {
+    actor: args.actor,
+    ownerUserId: args.skill.ownerUserId,
+    ownerPublisherId: args.skill.ownerPublisherId,
+    allowPlatformModerator: true,
+  });
+
+  const requestedVersion = args.version?.trim();
+  const version = requestedVersion
+    ? await ctx.db
+        .query("skillVersions")
+        .withIndex("by_skill_version", (q) =>
+          q.eq("skillId", args.skill._id).eq("version", requestedVersion),
+        )
+        .unique()
+    : args.skill.latestVersionId
+      ? await ctx.db.get(args.skill.latestVersionId)
+      : null;
+  if (!version || version.softDeletedAt) throw new ConvexError("Skill version not found");
+
+  const queued = await enqueueSkillVersionScan(ctx, {
+    versionId: version._id,
+    source: "manual",
+    priority: 100,
+    waitForVtMs: 0,
+  });
+  if (!queued.jobId) throw new ConvexError("Skill version not found");
+
+  await ctx.db.insert("auditLogs", {
+    actorUserId: args.actor._id,
+    action: "skill.clawscan.rescan",
+    targetType: "skillVersion",
+    targetId: version._id,
+    metadata: {
+      skillId: args.skill._id,
+      slug: args.skill.slug,
+      version: version.version,
+      jobId: queued.jobId,
+      alreadyQueued: queued.alreadyQueued === true,
+    },
+    createdAt: Date.now(),
+  });
+
+  return {
+    ok: true as const,
+    slug: args.skill.slug,
+    version: version.version,
+    skillId: args.skill._id,
+    skillVersionId: version._id,
+    jobId: queued.jobId,
+    alreadyQueued: queued.alreadyQueued === true,
+  };
+}
+
+export const requestSkillRescanForUserInternal = internalMutation({
+  args: {
+    actorUserId: v.id("users"),
+    slug: v.string(),
+    version: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const actor = await ctx.db.get(args.actorUserId);
+    if (!actor) throw new ConvexError("Unauthorized");
+
+    const slug = args.slug.trim().toLowerCase();
+    if (!slug) throw new ConvexError("Slug required");
+    const skill = await ctx.db
+      .query("skills")
+      .withIndex("by_slug", (q) => q.eq("slug", slug))
+      .unique();
+    if (!skill || skill.softDeletedAt) throw new ConvexError("Skill not found");
+
+    return requestSkillRescanForActor(ctx, { actor, skill, version: args.version });
+  },
+});
+
 export const requestSkillRescan = mutation({
   args: {
     skillId: v.id("skills"),
@@ -454,58 +546,107 @@ export const requestSkillRescan = mutation({
     const skill = await ctx.db.get(args.skillId);
     if (!skill || skill.softDeletedAt) throw new ConvexError("Skill not found");
 
-    await assertCanManageOwnedResource(ctx, {
-      actor: user,
-      ownerUserId: skill.ownerUserId,
-      ownerPublisherId: skill.ownerPublisherId,
-      allowPlatformAdmin: true,
-    });
+    return requestSkillRescanForActor(ctx, { actor: user, skill, version: args.version });
+  },
+});
 
-    const requestedVersion = args.version?.trim();
-    const version = requestedVersion
-      ? await ctx.db
-          .query("skillVersions")
-          .withIndex("by_skill_version", (q) =>
-            q.eq("skillId", skill._id).eq("version", requestedVersion),
-          )
-          .unique()
-      : skill.latestVersionId
-        ? await ctx.db.get(skill.latestVersionId)
-        : null;
-    if (!version || version.softDeletedAt) throw new ConvexError("Skill version not found");
+async function requestPackageRescanForActor(
+  ctx: MutationCtx,
+  args: {
+    actor: Doc<"users">;
+    pkg: Doc<"packages">;
+    version?: string;
+  },
+) {
+  await assertCanManageOwnedResource(ctx, {
+    actor: args.actor,
+    ownerUserId: args.pkg.ownerUserId,
+    ownerPublisherId: args.pkg.ownerPublisherId,
+    allowPlatformModerator: true,
+  });
 
-    const queued = await enqueueSkillVersionScan(ctx, {
-      versionId: version._id,
-      source: "manual",
-      priority: 100,
-      waitForVtMs: 0,
-    });
-    if (!queued.jobId) throw new ConvexError("Skill version not found");
+  const requestedVersion = args.version?.trim();
+  const release = requestedVersion
+    ? await ctx.db
+        .query("packageReleases")
+        .withIndex("by_package_version", (q) =>
+          q.eq("packageId", args.pkg._id).eq("version", requestedVersion),
+        )
+        .unique()
+    : args.pkg.latestReleaseId
+      ? await ctx.db.get(args.pkg.latestReleaseId)
+      : null;
+  if (!release || release.softDeletedAt) throw new ConvexError("Package release not found");
 
-    await ctx.db.insert("auditLogs", {
-      actorUserId: user._id,
-      action: "skill.clawscan.rescan",
-      targetType: "skillVersion",
-      targetId: version._id,
-      metadata: {
-        skillId: skill._id,
-        slug: skill.slug,
-        version: version.version,
-        jobId: queued.jobId,
-        alreadyQueued: queued.alreadyQueued === true,
-      },
-      createdAt: Date.now(),
-    });
+  const queued = await enqueuePackageReleaseScan(ctx, {
+    releaseId: release._id,
+    source: "manual",
+    priority: 100,
+    waitForVtMs: 0,
+  });
+  if (!queued.jobId) throw new ConvexError("Package release not found");
 
-    return {
-      ok: true as const,
-      slug: skill.slug,
-      version: version.version,
-      skillId: skill._id,
-      skillVersionId: version._id,
+  await ctx.db.insert("auditLogs", {
+    actorUserId: args.actor._id,
+    action: "package.clawscan.rescan",
+    targetType: "packageRelease",
+    targetId: release._id,
+    metadata: {
+      packageId: args.pkg._id,
+      name: args.pkg.name,
+      version: release.version,
       jobId: queued.jobId,
       alreadyQueued: queued.alreadyQueued === true,
-    };
+    },
+    createdAt: Date.now(),
+  });
+
+  return {
+    ok: true as const,
+    name: args.pkg.name,
+    version: release.version,
+    packageId: args.pkg._id,
+    packageReleaseId: release._id,
+    jobId: queued.jobId,
+    alreadyQueued: queued.alreadyQueued === true,
+  };
+}
+
+export const requestPackageRescanForUserInternal = internalMutation({
+  args: {
+    actorUserId: v.id("users"),
+    name: v.string(),
+    version: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const actor = await ctx.db.get(args.actorUserId);
+    if (!actor) throw new ConvexError("Unauthorized");
+
+    const normalizedName = normalizePackageName(args.name);
+    if (!normalizedName) throw new ConvexError("Package name required");
+    const pkg = await ctx.db
+      .query("packages")
+      .withIndex("by_name", (q) => q.eq("normalizedName", normalizedName))
+      .unique();
+    if (!pkg || pkg.softDeletedAt || pkg.family === "skill")
+      throw new ConvexError("Package not found");
+
+    return requestPackageRescanForActor(ctx, { actor, pkg, version: args.version });
+  },
+});
+
+export const requestPackageRescan = mutation({
+  args: {
+    packageId: v.id("packages"),
+    version: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const { user } = await requireUser(ctx);
+    const pkg = await ctx.db.get(args.packageId);
+    if (!pkg || pkg.softDeletedAt || pkg.family === "skill")
+      throw new ConvexError("Package not found");
+
+    return requestPackageRescanForActor(ctx, { actor: user, pkg, version: args.version });
   },
 });
 
@@ -558,46 +699,50 @@ export const enqueuePackageReleaseScanInternal = internalMutation({
     waitForVtMs: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const release = await ctx.db.get(args.releaseId);
-    if (!release || release.softDeletedAt) return { ok: true as const, skipped: "missing" };
-    const now = Date.now();
-    const waitForVtUntil = now + Math.max(0, args.waitForVtMs ?? DEFAULT_VT_WAIT_MS);
-    const nextRunAt = args.waitForVtMs === 0 || release.vtAnalysis ? now : waitForVtUntil;
-    const hasMaliciousSignal = release.staticScan?.status === "malicious";
-
-    const existing = await ctx.db
-      .query("securityScanJobs")
-      .withIndex("by_package_release", (q) => q.eq("packageReleaseId", args.releaseId))
-      .collect();
-    const active = existing.find((job) => job.status === "queued" || job.status === "running");
-    if (active) {
-      await ctx.db.patch(active._id, {
-        source: args.source,
-        priority: Math.max(active.priority, args.priority ?? 0),
-        hasMaliciousSignal: active.hasMaliciousSignal || hasMaliciousSignal,
-        waitForVtUntil: Math.min(active.waitForVtUntil, waitForVtUntil),
-        nextRunAt: Math.min(active.nextRunAt, nextRunAt),
-        updatedAt: now,
-      });
-      return { ok: true as const, jobId: active._id };
-    }
-
-    const jobId = await ctx.db.insert("securityScanJobs", {
-      targetKind: "packageRelease",
-      packageReleaseId: args.releaseId,
-      status: "queued",
-      source: args.source,
-      priority: args.priority ?? (hasMaliciousSignal ? 100 : 0),
-      hasMaliciousSignal,
-      waitForVtUntil,
-      nextRunAt,
-      attempts: 0,
-      createdAt: now,
-      updatedAt: now,
-    });
-    return { ok: true as const, jobId };
+    return enqueuePackageReleaseScan(ctx, args);
   },
 });
+
+async function enqueuePackageReleaseScan(ctx: MutationCtx, args: EnqueuePackageReleaseScanArgs) {
+  const release = await ctx.db.get(args.releaseId);
+  if (!release || release.softDeletedAt) return { ok: true as const, skipped: "missing" as const };
+  const now = Date.now();
+  const waitForVtUntil = now + Math.max(0, args.waitForVtMs ?? DEFAULT_VT_WAIT_MS);
+  const nextRunAt = args.waitForVtMs === 0 || release.vtAnalysis ? now : waitForVtUntil;
+  const hasMaliciousSignal = release.staticScan?.status === "malicious";
+
+  const existing = await ctx.db
+    .query("securityScanJobs")
+    .withIndex("by_package_release", (q) => q.eq("packageReleaseId", args.releaseId))
+    .collect();
+  const active = existing.find((job) => job.status === "queued" || job.status === "running");
+  if (active) {
+    await ctx.db.patch(active._id, {
+      source: args.source,
+      priority: Math.max(active.priority, args.priority ?? 0),
+      hasMaliciousSignal: active.hasMaliciousSignal || hasMaliciousSignal,
+      waitForVtUntil: Math.min(active.waitForVtUntil, waitForVtUntil),
+      nextRunAt: Math.min(active.nextRunAt, nextRunAt),
+      updatedAt: now,
+    });
+    return { ok: true as const, jobId: active._id, alreadyQueued: true as const };
+  }
+
+  const jobId = await ctx.db.insert("securityScanJobs", {
+    targetKind: "packageRelease",
+    packageReleaseId: args.releaseId,
+    status: "queued",
+    source: args.source,
+    priority: args.priority ?? (hasMaliciousSignal ? 100 : 0),
+    hasMaliciousSignal,
+    waitForVtUntil,
+    nextRunAt,
+    attempts: 0,
+    createdAt: now,
+    updatedAt: now,
+  });
+  return { ok: true as const, jobId, alreadyQueued: false as const };
+}
 
 export const cancelQueuedVtUpdateJobsInternal = internalMutation({
   args: {

--- a/src/__tests__/plugin-security-audit-route.test.tsx
+++ b/src/__tests__/plugin-security-audit-route.test.tsx
@@ -1,0 +1,81 @@
+/* @vitest-environment jsdom */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PluginSecurityAuditPage } from "../routes/plugins/$name/security-audit";
+
+const useQueryMock = vi.fn();
+const useMutationMock = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute:
+    () =>
+    (config: { component?: unknown; beforeLoad?: unknown; loader?: unknown; head?: unknown }) => ({
+      __config: config,
+      useParams: () => ({ name: "demo-plugin" }),
+      useLoaderData: () => ({}),
+    }),
+  redirect: (options: unknown) => ({ redirect: options }),
+}));
+
+vi.mock("convex/react", () => ({
+  useMutation: (...args: unknown[]) => useMutationMock(...args),
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
+}));
+
+function makeLoaderData() {
+  return {
+    detail: {
+      package: {
+        _id: "packages:1",
+        name: "demo-plugin",
+        displayName: "Demo Plugin",
+      },
+      owner: null,
+    },
+    version: {
+      version: {
+        _id: "packageReleases:1",
+        version: "1.0.0",
+      },
+    },
+    resolvedName: "demo-plugin",
+    rateLimited: false,
+  };
+}
+
+describe("plugin security audit route", () => {
+  beforeEach(() => {
+    useQueryMock.mockReset();
+    useQueryMock.mockReturnValue({
+      package: { _id: "packages:1" },
+      latestRelease: { _id: "packageReleases:1" },
+    });
+    useMutationMock.mockReset();
+    useMutationMock.mockReturnValue(vi.fn().mockResolvedValue({ ok: true }));
+  });
+
+  it("wires authorized plugin rescans to the package rescan mutation", async () => {
+    const requestRescan = vi.fn().mockResolvedValue({ ok: true });
+    useMutationMock.mockReturnValue(requestRescan);
+
+    render(<PluginSecurityAuditPage name="demo-plugin" loaderData={makeLoaderData() as never} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Rescan" }));
+
+    await waitFor(() =>
+      expect(requestRescan).toHaveBeenCalledWith({
+        packageId: "packages:1",
+        version: "1.0.0",
+      }),
+    );
+  });
+
+  it("hides plugin rescans when manage settings are unavailable", () => {
+    useQueryMock.mockReturnValue(null);
+
+    render(<PluginSecurityAuditPage name="demo-plugin" loaderData={makeLoaderData() as never} />);
+
+    expect(screen.queryByRole("button", { name: "Rescan" })).toBeNull();
+  });
+});

--- a/src/__tests__/skill-security-scanner-route.test.tsx
+++ b/src/__tests__/skill-security-scanner-route.test.tsx
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ComponentType } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -89,5 +89,48 @@ describe("skill security audit route", () => {
     const loadingRegion = screen.getByRole("status", { name: "Loading security audit" });
     expect(loadingRegion.getAttribute("aria-busy")).toBe("true");
     expect(document.querySelector(".security-scanner-skeleton")).toBeTruthy();
+  });
+
+  it("lets moderators request skill rescans from the route", async () => {
+    const requestRescan = vi.fn().mockResolvedValue({ ok: true });
+    useMutationMock.mockReturnValue(requestRescan);
+    useAuthStatusMock.mockReturnValue({
+      me: { _id: "users:moderator", role: "moderator" },
+    });
+    useQueryMock.mockImplementation((_ref: unknown, args: unknown) => {
+      if (args === "skip" || (args && Object.keys(args as Record<string, unknown>).length === 0)) {
+        return [];
+      }
+      return {
+        skill: {
+          _id: "skills:1",
+          slug: "local-agentic-risk-demo",
+          displayName: "Local Agentic Risk Demo",
+          ownerUserId: "users:owner",
+        },
+        latestVersion: {
+          _id: "skillVersions:1",
+          version: "1.0.0",
+        },
+        owner: {
+          _id: "users:owner",
+          handle: "local",
+        },
+      };
+    });
+
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Rescan" }));
+
+    await waitFor(() =>
+      expect(requestRescan).toHaveBeenCalledWith({
+        skillId: "skills:1",
+        version: "1.0.0",
+      }),
+    );
   });
 });

--- a/src/components/SecurityAuditPage.tsx
+++ b/src/components/SecurityAuditPage.tsx
@@ -672,8 +672,7 @@ function SecurityAuditSidebar(props: SecurityAuditPageProps) {
   const [rescanState, setRescanState] = useState<"idle" | "submitting" | "queued" | "error">(
     "idle",
   );
-  const showRescanButton =
-    props.entity.kind === "skill" && props.canManageArtifact && props.onRequestRescan;
+  const showRescanButton = props.canManageArtifact && props.onRequestRescan;
   const isRescanBusy = rescanState === "submitting" || rescanState === "queued";
 
   async function requestRescan() {

--- a/src/components/SkillSecurityScanResults.test.tsx
+++ b/src/components/SkillSecurityScanResults.test.tsx
@@ -1092,4 +1092,27 @@ describe("SecurityScanResults static guidance", () => {
     await waitFor(() => expect(requestRescan).toHaveBeenCalledTimes(1));
     expect(screen.getByRole("button", { name: "Scanning" })).toHaveProperty("disabled", true);
   });
+
+  it("lets plugin managers use the shared security rescan control", async () => {
+    const requestRescan = vi.fn().mockResolvedValue({ ok: true });
+
+    render(
+      <SecurityAuditPage
+        entity={{
+          kind: "plugin",
+          title: "Plugin Rescan Guard",
+          name: "@acme/plugin-rescan-guard",
+          version: "1.0.0",
+          detailPath: "/plugins/@acme/plugin-rescan-guard",
+        }}
+        canManageArtifact
+        onRequestRescan={requestRescan}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Rescan" }));
+
+    await waitFor(() => expect(requestRescan).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole("button", { name: "Scanning" })).toHaveProperty("disabled", true);
+  });
 });

--- a/src/routes/$owner/$slug/security-audit.tsx
+++ b/src/routes/$owner/$slug/security-audit.tsx
@@ -6,7 +6,7 @@ import {
   SecurityAuditPageSkeleton,
 } from "../../../components/SecurityAuditPage";
 import { buildSkillMeta } from "../../../lib/og";
-import { isAdmin } from "../../../lib/roles";
+import { isModerator } from "../../../lib/roles";
 import { fetchSkillPageData } from "../../../lib/skillPage";
 import { useAuthStatus } from "../../../lib/useAuthStatus";
 
@@ -95,7 +95,7 @@ function SkillSecurityAuditRoute() {
   const canManageArtifact =
     Boolean(me && skill && me._id === skill.ownerUserId) ||
     Boolean(skill?.ownerPublisherId && myManagePublisherIds.has(skill.ownerPublisherId)) ||
-    isAdmin(me);
+    isModerator(me);
   const settingsHref = `/${encodeURIComponent(ownerSegment)}/${encodeURIComponent(slug)}/settings`;
 
   return (

--- a/src/routes/plugins/$name/security-audit.tsx
+++ b/src/routes/plugins/$name/security-audit.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
-import { useQuery } from "convex/react";
+import { useMutation, useQuery } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
 import { SecurityAuditPage } from "../../../components/SecurityAuditPage";
 import { getOpenClawPackageCandidateNames } from "../../../lib/openClawExtensionSlugs";
@@ -111,6 +111,7 @@ export function PluginSecurityAuditPage({
   const { detail, version, resolvedName, rateLimited } = loaderData;
   const pkg = detail.package;
   const release = version?.version ?? null;
+  const requestPackageRescan = useMutation(api.securityScan.requestPackageRescan);
   const settings = useQuery(api.packages.getClawScanNoteSettings, {
     name: resolvedName,
     candidateNames: getOpenClawPackageCandidateNames(name),
@@ -152,6 +153,12 @@ export function PluginSecurityAuditPage({
       clawScanNote={release.clawScanNote ?? null}
       canManageArtifact={Boolean(settings)}
       settingsHref={settings ? `${buildPluginDetailHref(resolvedName)}/settings` : null}
+      onRequestRescan={
+        settings
+          ? () =>
+              requestPackageRescan({ packageId: settings.package._id, version: release.version })
+          : null
+      }
     />
   );
 }


### PR DESCRIPTION
## Summary
- make manual ClawScan rescans artifact-generic across skills and plugin/package releases
- add owner/publisher admin/platform moderator authorization for skill and package rescan mutations
- wire plugin security-audit routes and HTTP API routes to package release rescans
- cover skill/plugin UI callbacks plus HTTP/API and Convex authorization paths

## Verification
- `bun run test convex/securityScan.test.ts convex/httpApiV1.handlers.test.ts src/components/SkillSecurityScanResults.test.tsx src/__tests__/skill-security-scanner-route.test.tsx src/__tests__/plugin-security-audit-route.test.tsx`
- `bunx tsc --noEmit`
- `bunx convex codegen`
- `bun run format:check -- convex/securityScan.ts convex/securityScan.test.ts convex/httpApiV1/skillsV1.ts convex/httpApiV1/packagesV1.ts convex/httpApiV1.handlers.test.ts src/components/SecurityAuditPage.tsx src/components/SkillSecurityScanResults.test.tsx src/__tests__/skill-security-scanner-route.test.tsx src/__tests__/plugin-security-audit-route.test.tsx src/routes/\$owner/\$slug/security-audit.tsx src/routes/plugins/\$name/security-audit.tsx`
- `bun run lint`
- `git diff --check`
- `bun run ci:unit`
- `bun run ci:static`
- `bun run ci:types-build`
- `$autoreview`: clean, no accepted/actionable findings
- read-only subagent review: clean after API route gap fix

Linear: CLAW-164, CLAW-165, CLAW-166, CLAW-167, CLAW-168
