### PR TITLE
fix: increase security scan worker throughput

### DIFF
--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -8,11 +8,11 @@ on:
         required: false
         default: ""
       batch-limit:
-        description: "Maximum Codex scans to run in parallel per batch"
+        description: "Maximum Codex scans to run in parallel per worker shard"
         required: true
-        default: "20"
+        default: "6"
       max-jobs:
-        description: "Optional total jobs cap for this run"
+        description: "Optional total jobs cap per worker shard"
         required: false
         default: ""
       max-runtime-minutes:
@@ -20,29 +20,32 @@ on:
         required: true
         default: "40"
   schedule:
-    - cron: "*/10 * * * *"
-
-concurrency:
-  group: security-scan-codex-worker
-  cancel-in-progress: false
+    - cron: "*/5 * * * *"
 
 permissions:
   contents: read
 
 jobs:
   codex-security-scan:
-    runs-on: ubuntu-latest
+    name: Codex security scan shard ${{ matrix.shard }}
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 60
     environment: Production
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
     env:
       CONVEX_URL: ${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}
       SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      CODEX_SECURITY_SCAN_LIMIT: ${{ inputs.limit || inputs['batch-limit'] || '20' }}
+      CODEX_SECURITY_SCAN_LIMIT: ${{ inputs.limit || inputs['batch-limit'] || '6' }}
       CODEX_SECURITY_SCAN_MAX_JOBS: ${{ inputs['max-jobs'] || '' }}
       CODEX_SECURITY_SCAN_MAX_RUNTIME_MINUTES: ${{ inputs['max-runtime-minutes'] || '40' }}
       CODEX_SECURITY_SCAN_LEASE_MINUTES: "60"
-      CODEX_SECURITY_SCAN_DIAGNOSTICS_DIR: codex-security-scan-diagnostics
+      CODEX_SECURITY_SCAN_DIAGNOSTICS_DIR: codex-security-scan-diagnostics-${{ matrix.shard }}
+      CODEX_SECURITY_SCAN_SHARD: ${{ matrix.shard }}
+      CODEX_SECURITY_SCAN_WORKER_ID: "github-actions:${{ github.run_id }}:${{ github.run_attempt }}:${{ matrix.shard }}"
       SKILLSPECTOR_PROVIDER: openai
     steps:
       - uses: actions/checkout@v6
@@ -98,6 +101,6 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
-          name: codex-security-scan-diagnostics-${{ github.run_id }}
+          name: codex-security-scan-diagnostics-${{ github.run_id }}-${{ matrix.shard }}
           path: ${{ env.CODEX_SECURITY_SCAN_DIAGNOSTICS_DIR }}
           if-no-files-found: ignore

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1067,6 +1067,7 @@ const securityScanJobs = defineTable({
 })
   .index("by_status_and_next_run_at", ["status", "nextRunAt"])
   .index("by_status_source_created_at", ["status", "source", "createdAt"])
+  .index("by_status_source_next_run_at", ["status", "source", "nextRunAt"])
   .index("by_status_source_target_kind_created_at", ["status", "source", "targetKind", "createdAt"])
   .index("by_status_and_lease_expires_at", ["status", "leaseExpiresAt"])
   .index("by_status_malicious_signal_next_run_at", ["status", "hasMaliciousSignal", "nextRunAt"])

--- a/convex/securityScan.test.ts
+++ b/convex/securityScan.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   cancelQueuedVtUpdateJobsInternal,
   claimCodexScanJobs,
+  claimQueuedJobsInternal,
   completeCodexScanJob,
   failCodexScanJob,
   requestPackageRescanForUserInternal,
@@ -23,6 +24,13 @@ const claimCodexScanJobsHandler = (
   claimCodexScanJobs as unknown as WrappedHandler<
     { token: string; workerId: string; limit?: number },
     Array<unknown>
+  >
+)._handler;
+
+const claimQueuedJobsInternalHandler = (
+  claimQueuedJobsInternal as unknown as WrappedHandler<
+    { workerId: string; limit: number; leaseMs?: number },
+    Array<ScanJob & { leaseToken: string; workerId: string }>
   >
 )._handler;
 
@@ -331,6 +339,86 @@ function makeCancelCtx(jobs: ScanJob[], targets: Map<string, unknown> = new Map(
   };
 }
 
+function makeClaimCtx(jobs: ScanJob[]) {
+  const patches: Array<{ id: string; patch: Record<string, unknown> }> = [];
+  const patch = vi.fn(async (id: string, doc: Record<string, unknown>) => {
+    patches.push({ id, patch: doc });
+  });
+  const query = vi.fn((tableName: string) => {
+    expect(tableName).toBe("securityScanJobs");
+    return {
+      withIndex: vi.fn(
+        (
+          indexName: string,
+          buildRange: (q: {
+            eq: (field: string, value: unknown) => unknown;
+            lte: (field: string, value: number) => unknown;
+          }) => unknown,
+        ) => {
+          const eqFilters = new Map<string, unknown>();
+          const lteFilters = new Map<string, number>();
+          const indexBuilder = {
+            eq(field: string, value: unknown) {
+              eqFilters.set(field, value);
+              return indexBuilder;
+            },
+            lte(field: string, value: number) {
+              lteFilters.set(field, value);
+              return indexBuilder;
+            },
+          };
+          buildRange(indexBuilder);
+          const select = () =>
+            jobs
+              .filter((job) => {
+                for (const [field, value] of eqFilters) {
+                  if ((job as unknown as Record<string, unknown>)[field] !== value) return false;
+                }
+                for (const [field, value] of lteFilters) {
+                  const fieldValue = (job as unknown as Record<string, unknown>)[field];
+                  if (typeof fieldValue !== "number" || fieldValue > value) return false;
+                }
+                return true;
+              })
+              .sort((a, b) => {
+                if (indexName.includes("next_run_at")) return a.nextRunAt - b.nextRunAt;
+                if (indexName.includes("lease_expires_at")) {
+                  return (
+                    Number((a as unknown as { leaseExpiresAt?: number }).leaseExpiresAt ?? 0) -
+                    Number((b as unknown as { leaseExpiresAt?: number }).leaseExpiresAt ?? 0)
+                  );
+                }
+                return a.createdAt - b.createdAt;
+              });
+          const take = vi.fn(async (limit: number) => select().slice(0, limit));
+          return {
+            take,
+            order: vi.fn(() => ({ take })),
+          };
+        },
+      ),
+    };
+  });
+
+  return {
+    ctx: {
+      db: {
+        query,
+        patch,
+        get: vi.fn(),
+        insert: vi.fn(),
+        replace: vi.fn(),
+        delete: vi.fn(),
+        normalizeId: vi.fn(() => null),
+        system: {},
+      },
+    },
+    patches,
+    patch,
+    query,
+  };
+}
+
 describe("securityScan", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
@@ -633,6 +721,85 @@ describe("securityScan", () => {
         error: "ClawPack artifact unavailable",
       }),
     );
+  });
+
+  it("claims manual rescans and malicious signals before older publish backlog", async () => {
+    const { ctx, patches } = makeClaimCtx([
+      makeScanJob({
+        _id: "securityScanJobs:old-publish",
+        source: "publish",
+        createdAt: 10,
+        nextRunAt: 10,
+      }),
+      makeScanJob({
+        _id: "securityScanJobs:older-vt-update",
+        source: "vt-update",
+        createdAt: 20,
+        nextRunAt: 20,
+      }),
+      makeScanJob({
+        _id: "securityScanJobs:malicious-publish",
+        source: "publish",
+        hasMaliciousSignal: true,
+        createdAt: 30,
+        nextRunAt: 30,
+      }),
+      makeScanJob({
+        _id: "securityScanJobs:clawscan-note",
+        source: "clawscan-note",
+        createdAt: 40,
+        nextRunAt: 40,
+      }),
+      makeScanJob({
+        _id: "securityScanJobs:backfill",
+        source: "backfill",
+        createdAt: 50,
+        nextRunAt: 50,
+      }),
+      makeScanJob({
+        _id: "securityScanJobs:manual",
+        source: "manual",
+        priority: 100,
+        createdAt: 1000,
+        nextRunAt: 1000,
+      }),
+    ]);
+
+    const claimed = await claimQueuedJobsInternalHandler(ctx, {
+      workerId: "worker-1",
+      limit: 4,
+      leaseMs: 60_000,
+    });
+
+    expect(claimed.map((job) => job._id)).toEqual([
+      "securityScanJobs:manual",
+      "securityScanJobs:malicious-publish",
+      "securityScanJobs:clawscan-note",
+      "securityScanJobs:backfill",
+    ]);
+    expect(patches.map((entry) => entry.id)).toEqual(claimed.map((job) => job._id));
+  });
+
+  it("allows up to 64 active Codex scan claims", async () => {
+    const { ctx } = makeClaimCtx(
+      Array.from({ length: 70 }, (_, index) =>
+        makeScanJob({
+          _id: `securityScanJobs:manual-${index}`,
+          source: "manual",
+          priority: 100,
+          createdAt: index,
+          nextRunAt: index,
+        }),
+      ),
+    );
+
+    const claimed = await claimQueuedJobsInternalHandler(ctx, {
+      workerId: "worker-1",
+      limit: 100,
+      leaseMs: 60_000,
+    });
+
+    expect(claimed).toHaveLength(64);
   });
 
   it("caps SkillSpector findings before storing completed scan results", async () => {

--- a/convex/securityScan.ts
+++ b/convex/securityScan.ts
@@ -7,7 +7,7 @@ import { assertModerator, requireUser } from "./lib/access";
 import { normalizePackageName } from "./lib/packageRegistry";
 import { assertCanManageOwnedResource } from "./lib/publishers";
 
-const MAX_PARALLEL_CODEX_SCANS = 20;
+const MAX_PARALLEL_CODEX_SCANS = 64;
 const DEFAULT_VT_WAIT_MS = 10 * 60 * 1000;
 const DEFAULT_LEASE_MS = 60 * 60 * 1000;
 const MAX_ATTEMPTS = 3;
@@ -81,16 +81,25 @@ const jobSourceValidator = v.union(
   v.literal("manual"),
 );
 
+type SecurityScanJobSource = "publish" | "clawscan-note" | "vt-update" | "backfill" | "manual";
+
+const CLAIM_SOURCE_ORDER: SecurityScanJobSource[] = [
+  "clawscan-note",
+  "backfill",
+  "publish",
+  "vt-update",
+];
+
 type EnqueueSkillVersionScanArgs = {
   versionId: Id<"skillVersions">;
-  source: "publish" | "clawscan-note" | "vt-update" | "backfill" | "manual";
+  source: SecurityScanJobSource;
   priority?: number;
   waitForVtMs?: number;
 };
 
 type EnqueuePackageReleaseScanArgs = {
   releaseId: Id<"packageReleases">;
-  source: "publish" | "clawscan-note" | "vt-update" | "backfill" | "manual";
+  source: SecurityScanJobSource;
   priority?: number;
   waitForVtMs?: number;
 };
@@ -871,28 +880,46 @@ export const claimQueuedJobsInternal = internalMutation({
     const capacity = Math.max(0, Math.min(limit, MAX_PARALLEL_CODEX_SCANS - activeRunning));
     if (capacity === 0) return [];
 
-    const maliciousSignalReady = await ctx.db
-      .query("securityScanJobs")
-      .withIndex("by_status_malicious_signal_next_run_at", (q) =>
-        q.eq("status", "queued").eq("hasMaliciousSignal", true).lte("nextRunAt", now),
-      )
-      .order("asc")
-      .take(capacity);
-    const claimedIds = new Set(maliciousSignalReady.map((job) => job._id));
-    const remainingCapacity = capacity - maliciousSignalReady.length;
-    const queued = remainingCapacity
-      ? await ctx.db
+    const ready: Doc<"securityScanJobs">[] = [];
+    const claimedIds = new Set<Id<"securityScanJobs">>();
+    const remainingCapacity = () => capacity - ready.length;
+    const addReadyJobs = (jobs: Doc<"securityScanJobs">[]) => {
+      for (const job of jobs) {
+        if (remainingCapacity() === 0) break;
+        if (claimedIds.has(job._id) || job.nextRunAt > now) continue;
+        claimedIds.add(job._id);
+        ready.push(job);
+      }
+    };
+    const takeReadySourceJobs = async (source: SecurityScanJobSource) => {
+      if (remainingCapacity() === 0) return [];
+      return await ctx.db
+        .query("securityScanJobs")
+        .withIndex("by_status_source_next_run_at", (q) =>
+          q.eq("status", "queued").eq("source", source).lte("nextRunAt", now),
+        )
+        .order("asc")
+        .take(remainingCapacity());
+    };
+
+    addReadyJobs(await takeReadySourceJobs("manual"));
+
+    if (remainingCapacity() > 0) {
+      addReadyJobs(
+        await ctx.db
           .query("securityScanJobs")
-          .withIndex("by_status_and_next_run_at", (q) =>
-            q.eq("status", "queued").lte("nextRunAt", now),
+          .withIndex("by_status_malicious_signal_next_run_at", (q) =>
+            q.eq("status", "queued").eq("hasMaliciousSignal", true).lte("nextRunAt", now),
           )
           .order("asc")
-          .take(remainingCapacity * 4)
-      : [];
-    const ready = [...maliciousSignalReady, ...queued.filter((job) => !claimedIds.has(job._id))]
-      .filter((job) => job.nextRunAt <= now)
-      .sort((a, b) => b.priority - a.priority || a.createdAt - b.createdAt)
-      .slice(0, capacity);
+          .take(remainingCapacity()),
+      );
+    }
+
+    for (const source of CLAIM_SOURCE_ORDER) {
+      addReadyJobs(await takeReadySourceJobs(source));
+      if (remainingCapacity() === 0) break;
+    }
 
     const claimed = [];
     for (const job of ready) {

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -97,7 +97,7 @@ type JobDiagnosticInput = {
   status: "completed" | "failed";
 };
 
-const DEFAULT_BATCH_LIMIT = 20;
+const DEFAULT_BATCH_LIMIT = 6;
 const DEFAULT_MAX_RUNTIME_MS = 40 * 60 * 1000;
 const DEFAULT_CODEX_SCAN_TIMEOUT_MS = 20 * 60 * 1000;
 const MAX_DIAGNOSTIC_TEXT_CHARS = 20_000;
@@ -1070,7 +1070,11 @@ async function main() {
   if (!convexUrl) throw new Error("CONVEX_URL or VITE_CONVEX_URL is required");
   const token = requireEnv("SECURITY_SCAN_WORKER_TOKEN");
   const client = new ConvexHttpClient(convexUrl);
-  const workerId = `github-actions:${process.env.GITHUB_RUN_ID ?? process.pid}`;
+  const workerId =
+    process.env.CODEX_SECURITY_SCAN_WORKER_ID ??
+    `github-actions:${process.env.GITHUB_RUN_ID ?? process.pid}:${
+      process.env.GITHUB_RUN_ATTEMPT ?? "1"
+    }:${process.env.CODEX_SECURITY_SCAN_SHARD ?? process.env.GITHUB_JOB ?? "0"}`;
   const startedAt = Date.now();
   const claimDeadline = startedAt + maxRuntimeMs;
   let totalClaimed = 0;


### PR DESCRIPTION
## Summary
- shard the Codex security scan workflow across 8 Blacksmith workers every 5 minutes, with 6 scans per shard and shard-specific diagnostics
- prioritize manual rescans and malicious-signal jobs ahead of older backlog, then claim clawscan-note/backfill/publish/vt-update buckets
- raise the global active Codex scan cap to 64 and cover claim ordering/cap behavior in tests

## Tests
- `bunx vitest run convex/securityScan.test.ts scripts/security/run-codex-scan-worker.test.ts`
- `bun run ci:unit`
- `bunx tsc --noEmit`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit && bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bun run format:check -- .github/workflows/security-scan-codex.yml convex/schema.ts convex/securityScan.ts convex/securityScan.test.ts scripts/security/run-codex-scan-worker.ts && git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/security-scan-codex.yml`

Note: `bun run ci:static` currently fails on an unrelated formatting issue in `convex/lib/securityPrompt.test.ts`, which this PR does not touch.
