### PR TITLE
fix: allow package publishes when matching skill slug is owned

### DIFF
--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -3486,6 +3486,94 @@ describe("packages public queries", () => {
     expect(ctx.runMutation).not.toHaveBeenCalled();
   });
 
+  it("allows package publishes when the matching skill slug belongs to the same owner", async () => {
+    const ctx = {
+      runQuery: vi
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          _id: "users:owner",
+          githubCreatedAt: Date.now() - 20 * 24 * 60 * 60 * 1000,
+        })
+        .mockResolvedValueOnce({
+          _id: "users:owner",
+          role: "user",
+          githubCreatedAt: Date.now() - 20 * 24 * 60 * 60 * 1000,
+        })
+        .mockResolvedValueOnce({
+          _id: "skills:demo",
+          slug: "demo-plugin",
+          ownerUserId: "users:owner",
+          ownerPublisherId: "publishers:owner",
+        }),
+      runMutation: vi.fn(async () => ({
+        publisherId: "publishers:owner",
+        linkedUserId: "users:owner",
+      })),
+      scheduler: { runAfter: vi.fn() },
+      storage: { get: vi.fn() },
+    };
+
+    await expect(
+      publishPackageForUserInternalHandler(ctx as never, {
+        actorUserId: "users:owner",
+        payload: {
+          name: "demo-plugin",
+          displayName: "Demo Plugin",
+          family: "bundle-plugin",
+          version: "1.0.0",
+          changelog: "init",
+          bundle: { hostTargets: ["desktop"] },
+          files: [],
+        },
+      }),
+    ).rejects.toThrow("openclaw.plugin.json is required");
+  });
+
+  it("rejects package publishes when the matching skill slug belongs to another owner", async () => {
+    const ctx = {
+      runQuery: vi
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          _id: "users:owner",
+          githubCreatedAt: Date.now() - 20 * 24 * 60 * 60 * 1000,
+        })
+        .mockResolvedValueOnce({
+          _id: "users:owner",
+          role: "user",
+          githubCreatedAt: Date.now() - 20 * 24 * 60 * 60 * 1000,
+        })
+        .mockResolvedValueOnce({
+          _id: "skills:demo",
+          slug: "demo-plugin",
+          ownerUserId: "users:other",
+          ownerPublisherId: "publishers:other",
+        }),
+      runMutation: vi.fn(async () => ({
+        publisherId: "publishers:owner",
+        linkedUserId: "users:owner",
+      })),
+      scheduler: { runAfter: vi.fn() },
+      storage: { get: vi.fn() },
+    };
+
+    await expect(
+      publishPackageForUserInternalHandler(ctx as never, {
+        actorUserId: "users:owner",
+        payload: {
+          name: "demo-plugin",
+          displayName: "Demo Plugin",
+          family: "bundle-plugin",
+          version: "1.0.0",
+          changelog: "init",
+          bundle: { hostTargets: ["desktop"] },
+          files: [],
+        },
+      }),
+    ).rejects.toThrow('Package name collides with existing skill slug "demo-plugin"');
+  });
+
   it("rejects runtime id changes on an existing code plugin package", async () => {
     const ctx = makeInsertReleaseCtx(makePackageDoc({ runtimeId: "demo.plugin" }));
 

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -4535,6 +4535,17 @@ function doesTrustedPublisherMatchPublishToken(
   );
 }
 
+function doesPackagePublishOwnMatchingSkillSlug(
+  skill: Pick<Doc<"skills">, "ownerUserId" | "ownerPublisherId">,
+  ownerUserId: Id<"users">,
+  ownerPublisherId: Id<"publishers"> | undefined,
+) {
+  if (skill.ownerPublisherId && ownerPublisherId) {
+    return skill.ownerPublisherId === ownerPublisherId;
+  }
+  return skill.ownerUserId === ownerUserId;
+}
+
 async function publishPackageImpl(
   ctx: Parameters<typeof requireGitHubAccountAge>[0] & Pick<ActionCtx, "storage" | "scheduler">,
   auth: PackagePublishAuthContext,
@@ -4674,10 +4685,14 @@ async function publishPackageImpl(
     throw new ConvexError(getPublishTotalSizeError("package"));
   }
 
-  const existingSkill = await runQueryRef(ctx, internalRefs.skills.getSkillBySlugInternal, {
-    slug: name,
-  });
-  if (existingSkill) {
+  const existingSkill = await runQueryRef<Pick<
+    Doc<"skills">,
+    "ownerUserId" | "ownerPublisherId"
+  > | null>(ctx, internalRefs.skills.getSkillBySlugInternal, { slug: name });
+  if (
+    existingSkill &&
+    !doesPackagePublishOwnMatchingSkillSlug(existingSkill, ownerUserId, ownerPublisherId)
+  ) {
     throw new ConvexError(`Package name collides with existing skill slug "${name}"`);
   }
   if (family === "code-plugin" && (!effectiveSource?.repo || !effectiveSource?.commit)) {


### PR DESCRIPTION
## Summary

- Allow package publishes to proceed when an existing skill with the same slug is owned by the same user/publisher.
- Keep the existing collision block when the matching skill slug belongs to a different owner.
- Add regression coverage for both same-owner and different-owner package publish paths.

Fixes #2390.

## Tests

- `bunx vitest run convex/packages.public.test.ts --testNamePattern "allows package publishes when the matching skill slug belongs to the same owner" --reporter verbose` (red before implementation, green after)
- `bunx vitest run convex/packages.public.test.ts --testNamePattern "matching skill slug" --reporter verbose`
- `bunx vitest run convex/packages.public.test.ts --reporter dot`
- `bunx oxfmt --check convex/packages.ts convex/packages.public.test.ts`
- `git diff --check`
- `bunx tsc --noEmit --pretty false`
- `bunx oxlint --type-aware --tsconfig ./tsconfig.oxlint.json convex/packages.ts convex/packages.public.test.ts`

## Notes

Full repo `bun run format:check` currently reports an unrelated formatting issue in `convex/lib/securityPrompt.test.ts`, and full `bun run lint` reports unrelated `no-unnecessary-type-conversion` errors in `convex/securityScan.test.ts`. I left those files untouched.