### PR TITLE
feat: refine SkillSpector audit UI

### DIFF
--- a/src/components/DetailSecuritySummary.test.tsx
+++ b/src/components/DetailSecuritySummary.test.tsx
@@ -182,11 +182,11 @@ describe("DetailSecuritySummary", () => {
     expect(document.querySelector(".security-audit-meter")?.getAttribute("data-level")).toBe("4");
   });
 
-  it("renders malicious scanner outcomes with the lowest safety meter level", () => {
+  it("bases the compact verdict on ClawScan instead of supporting scanner findings", () => {
     render(
       <DetailSecuritySummary
         auditHref="/steipete/weather/security-audit"
-        vtAnalysis={{ status: "clean", checkedAt: 1 }}
+        vtAnalysis={{ status: "pending", checkedAt: 1 }}
         llmAnalysis={{ status: "clean", summary: "No mismatches found.", checkedAt: 1 }}
         staticScan={{
           status: "malicious",
@@ -199,8 +199,10 @@ describe("DetailSecuritySummary", () => {
       />,
     );
 
-    expect(screen.getByText("Malicious")).toBeTruthy();
-    expect(document.querySelector(".security-audit-meter")?.getAttribute("data-level")).toBe("1");
+    expect(screen.getByText("Pass")).toBeTruthy();
+    expect(screen.queryByText("Malicious")).toBeNull();
+    expect(screen.queryByText("Pending")).toBeNull();
+    expect(document.querySelector(".security-audit-meter")?.getAttribute("data-level")).toBe("4");
   });
 
   it("keeps legacy non-engine VirusTotal fields neutral in the aggregate verdict", () => {
@@ -286,7 +288,7 @@ describe("DetailSecuritySummary", () => {
     expect(screen.queryByText("undetected-only-fallback")).toBeNull();
   });
 
-  it("shows static suspicious as review without rolling it up to suspicious", () => {
+  it("does not let static suspicious drive the compact verdict", () => {
     render(
       <DetailSecuritySummary
         auditHref="/steipete/weather/security-audit"
@@ -303,11 +305,12 @@ describe("DetailSecuritySummary", () => {
       />,
     );
 
-    expect(screen.getByText("Review")).toBeTruthy();
+    expect(screen.getByText("Pass")).toBeTruthy();
+    expect(screen.queryByText("Review")).toBeNull();
     expect(screen.queryByText("Warn")).toBeNull();
   });
 
-  it("does not aggregate scanner operational errors as malicious verdicts", () => {
+  it("does not let supporting scanner operational errors drive the compact verdict", () => {
     render(
       <DetailSecuritySummary
         auditHref="/steipete/weather/security-audit"
@@ -324,7 +327,8 @@ describe("DetailSecuritySummary", () => {
       />,
     );
 
-    expect(screen.getByText("Error")).toBeTruthy();
+    expect(screen.getByText("Pass")).toBeTruthy();
+    expect(screen.queryByText("Error")).toBeNull();
     expect(screen.queryByText("Malicious")).toBeNull();
   });
 });

--- a/src/components/SecurityAuditPage.tsx
+++ b/src/components/SecurityAuditPage.tsx
@@ -1,4 +1,4 @@
-import { Clock, ExternalLink, Info, RefreshCw, X } from "lucide-react";
+import { Check, Clock, ExternalLink, Info, RefreshCw, TriangleAlert, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { Id } from "../../convex/_generated/dataModel";
 import { getRuntimeEnv } from "../lib/runtimeEnv";
@@ -66,8 +66,190 @@ type SecurityAuditPageProps = {
 
 const EMPTY_STATIC_FINDINGS: StaticScanAnalysis["findings"] = [];
 const EMPTY_SKILLSPECTOR_ISSUES: SkillSpectorIssue[] = [];
+const SKILLSPECTOR_VISIBLE_CHECK_LIMIT = 5;
 const RISK_ANALYSIS_SCOPE_COPY =
   "ClawHub reviews SkillSpector, VirusTotal, static analysis, and artifact evidence before producing the final verdict.";
+const SKILLSPECTOR_CLEAN_CHECKS = [
+  {
+    category: "Prompt Injection",
+    ruleIds: ["P1", "P2", "P3", "P4", "P5"],
+    patterns: ["Instruction Override", "Hidden Instructions", "Exfiltration Commands"],
+  },
+  {
+    category: "Data Exfiltration",
+    ruleIds: ["E1", "E2", "E3", "E4"],
+    patterns: ["External Transmission", "Env Variable Harvesting", "File System Enumeration"],
+  },
+  {
+    category: "Privilege Escalation",
+    ruleIds: ["PE1", "PE2", "PE3"],
+    patterns: ["Excessive Permissions", "Sudo/Root Execution", "Credential Access"],
+  },
+  {
+    category: "Supply Chain",
+    ruleIds: ["SC1", "SC2", "SC3", "SC4", "SC5", "SC6"],
+    patterns: ["Unpinned Dependencies", "External Script Fetching", "Obfuscated Code"],
+  },
+  {
+    category: "Excessive Agency",
+    ruleIds: ["EA1", "EA2", "EA3", "EA4", "SDI2", "SDI3"],
+    patterns: ["Unrestricted Tool Access", "Autonomous Decision Making", "Scope Creep"],
+  },
+  {
+    category: "Output Handling",
+    ruleIds: ["OH1", "OH2", "OH3"],
+    patterns: ["Unvalidated Output Injection", "Cross-Context Output", "Unbounded Output"],
+  },
+  {
+    category: "System Prompt Leakage",
+    ruleIds: ["P6", "P7", "P8"],
+    patterns: ["Direct Leakage", "Indirect Extraction", "Tool-Based Exfiltration"],
+  },
+  {
+    category: "Memory Poisoning",
+    ruleIds: ["MP1", "MP2", "MP3"],
+    patterns: ["Persistent Context Injection", "Context Window Stuffing", "Memory Manipulation"],
+  },
+  {
+    category: "Tool Misuse",
+    ruleIds: ["TM1", "TM2", "TM3"],
+    patterns: ["Tool Parameter Abuse", "Chaining Abuse", "Unsafe Defaults"],
+  },
+  {
+    category: "Rogue Agent",
+    ruleIds: ["RA1", "RA2"],
+    patterns: ["Self-Modification", "Session Persistence"],
+  },
+  {
+    category: "Trigger Abuse",
+    ruleIds: ["TR1", "TR2", "TR3", "SQP1"],
+    patterns: ["Overly Broad Trigger", "Shadow Command Trigger", "Keyword Baiting Trigger"],
+  },
+  {
+    category: "Behavioral AST",
+    ruleIds: ["AST1", "AST2", "AST3", "AST4", "AST5", "AST6", "AST7", "AST8"],
+    patterns: ["exec() Call", "eval() Call", "Dynamic Import"],
+  },
+  {
+    category: "Taint Tracking",
+    ruleIds: ["TT1", "TT2", "TT3", "TT4", "TT5"],
+    patterns: [
+      "Direct Taint Flow",
+      "Variable-Mediated Taint Flow",
+      "Credential Exfiltration Chain",
+    ],
+  },
+  {
+    category: "YARA Signatures",
+    ruleIds: ["YR1", "YR2", "YR3", "YR4"],
+    patterns: ["Malware Match", "Webshell Match", "Cryptominer Match"],
+  },
+  {
+    category: "MCP Least Privilege",
+    ruleIds: ["LP1", "LP2", "LP3", "LP4"],
+    patterns: ["Underdeclared Capability", "Wildcard Permission", "Missing Permission Declaration"],
+  },
+  {
+    category: "MCP Tool Poisoning",
+    ruleIds: ["TP1", "TP2", "TP3", "TP4", "SDI1", "SDI4"],
+    patterns: ["Hidden Instructions", "Unicode Deception", "Parameter Description Injection"],
+  },
+];
+
+function normalizeSkillSpectorPatternValue(value?: string | null) {
+  return value
+    ?.trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "");
+}
+
+function normalizeSkillSpectorIssueId(value?: string | null) {
+  return value
+    ?.trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "");
+}
+
+function getSkillSpectorIssueSearchText(issue: SkillSpectorIssue) {
+  return [
+    issue.issueId,
+    issue.category,
+    issue.pattern,
+    issue.finding,
+    issue.explanation,
+    issue.codeSnippet,
+    issue.remediation,
+  ]
+    .filter((value): value is string => Boolean(value?.trim()))
+    .join(" ")
+    .toLowerCase();
+}
+
+function inferSkillSpectorPatternCategory(issue: SkillSpectorIssue) {
+  const issueId = normalizeSkillSpectorIssueId(issue.issueId);
+  const category = normalizeSkillSpectorPatternValue(issue.category);
+  const pattern = normalizeSkillSpectorPatternValue(issue.pattern);
+
+  for (const check of SKILLSPECTOR_CLEAN_CHECKS) {
+    if (check.ruleIds.some((ruleId) => normalizeSkillSpectorIssueId(ruleId) === issueId)) {
+      return check.category;
+    }
+  }
+  for (const check of SKILLSPECTOR_CLEAN_CHECKS) {
+    if (normalizeSkillSpectorPatternValue(check.category) === category) return check.category;
+  }
+  for (const check of SKILLSPECTOR_CLEAN_CHECKS) {
+    if (check.patterns.some((value) => normalizeSkillSpectorPatternValue(value) === pattern)) {
+      return check.category;
+    }
+  }
+
+  const text = getSkillSpectorIssueSearchText(issue);
+  if (
+    /\b(exfiltrat\w*|external|transmit\w*|upload\w*|send|sending|post|session|token|secret|credential\w*)\b/.test(
+      text,
+    )
+  ) {
+    return "Data Exfiltration";
+  }
+  if (/\b(sudo|root|ssh key|password|credential access)\b/.test(text)) {
+    return "Privilege Escalation";
+  }
+  if (/\b(unpinned|dependency|curl\s*\|\s*bash|remote script|obfuscat|typosquat)\b/.test(text)) {
+    return "Supply Chain";
+  }
+  if (/\b(scope creep|autonomous|unrestricted|excessive|capability)\b/.test(text)) {
+    return "Excessive Agency";
+  }
+  if (/\b(system prompt|prompt leakage|internal rules)\b/.test(text)) {
+    return "System Prompt Leakage";
+  }
+  if (/\b(trigger|activation|keyword)\b/.test(text)) {
+    return "Trigger Abuse";
+  }
+  if (/\b(exec|eval|subprocess|os\.system|dynamic import)\b/.test(text)) {
+    return "Behavioral AST";
+  }
+  if (
+    /\b(description.behavior|description behavior|mismatch|hidden instruction|unicode|parameter)\b/.test(
+      text,
+    )
+  ) {
+    return "MCP Tool Poisoning";
+  }
+  if (/\b(ignore|override|hidden instruction|jailbreak|instruction)\b/.test(text)) {
+    return "Prompt Injection";
+  }
+  return null;
+}
+
+function getFlaggedSkillSpectorPatternCategories(issues: SkillSpectorIssue[]) {
+  return new Set(
+    issues
+      .map((issue) => inferSkillSpectorPatternCategory(issue))
+      .filter((category): category is string => Boolean(category)),
+  );
+}
 
 function formatTime(value?: number | null) {
   if (!value) return "Not checked yet";
@@ -340,7 +522,16 @@ function SkillSpectorSection(props: SecurityAuditPageProps) {
     props.entity,
     analysis?.issues ?? EMPTY_SKILLSPECTOR_ISSUES,
   );
-  const showOverview = !(analysis && hasSkillSpectorFindings(analysis));
+  const hasFindings = analysis ? hasSkillSpectorFindings(analysis) : false;
+  const issueCount = getSkillSpectorIssueCount(analysis);
+  const storedIssueCount = analysis?.issues.length ?? 0;
+  const hasHiddenFindings = issueCount > storedIssueCount;
+  const findingsTitle = issueCount > 0 ? `Findings (${issueCount})` : "Findings";
+  const status = analysis?.status?.trim().toLowerCase();
+  const showChecks = Boolean(
+    analysis && !["error", "failed", "loading", "not_found", "pending"].includes(status ?? ""),
+  );
+  const showOverview = !hasFindings && !showChecks;
 
   return (
     <div className="security-report-panel-body security-report-panel-body-findings">
@@ -349,8 +540,73 @@ function SkillSpectorSection(props: SecurityAuditPageProps) {
           <p>{overviewCopy}</p>
         </div>
       ) : null}
-      {analysis && hasSkillSpectorFindings(analysis) ? (
-        <SkillSpectorFindings analysis={analysis} contentSnippets={contentSnippets} />
+      {showChecks ? (
+        <SkillSpectorChecks
+          hasHiddenFindings={hasHiddenFindings}
+          issues={analysis?.issues ?? EMPTY_SKILLSPECTOR_ISSUES}
+        />
+      ) : null}
+      {analysis && hasFindings ? (
+        <div className="skillspector-findings-block">
+          <div className="skillspector-subsection-title">{findingsTitle}</div>
+          <SkillSpectorFindings analysis={analysis} contentSnippets={contentSnippets} />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function SkillSpectorChecks({
+  hasHiddenFindings,
+  issues,
+}: {
+  hasHiddenFindings: boolean;
+  issues: SkillSpectorIssue[];
+}) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const flaggedCategories = getFlaggedSkillSpectorPatternCategories(issues);
+  const sortedChecks = [...SKILLSPECTOR_CLEAN_CHECKS].sort((left, right) => {
+    const leftFlagged = flaggedCategories.has(left.category);
+    const rightFlagged = flaggedCategories.has(right.category);
+    if (leftFlagged === rightFlagged) return 0;
+    return leftFlagged ? -1 : 1;
+  });
+  const visibleChecks = isExpanded
+    ? sortedChecks
+    : sortedChecks.slice(0, SKILLSPECTOR_VISIBLE_CHECK_LIMIT);
+  const remainingCount = sortedChecks.length - SKILLSPECTOR_VISIBLE_CHECK_LIMIT;
+
+  return (
+    <div className="skillspector-checks" aria-label="SkillSpector checks">
+      <div className="skillspector-subsection-title">Vulnerability Patterns</div>
+      <ul className="skillspector-checks-list">
+        {visibleChecks.map((check) => {
+          const isFlagged = flaggedCategories.has(check.category);
+          const isUnknown = hasHiddenFindings && !isFlagged;
+          const Icon = isFlagged ? TriangleAlert : isUnknown ? Info : Check;
+          return (
+            <li
+              className={`skillspector-check-row${isFlagged ? " skillspector-check-row-flagged" : ""}${isUnknown ? " skillspector-check-row-unknown" : ""}`}
+              key={check.category}
+            >
+              <Icon
+                className={`skillspector-check-icon${isFlagged ? " skillspector-check-icon-flagged" : ""}${isUnknown ? " skillspector-check-icon-unknown" : ""}`}
+                aria-hidden="true"
+              />
+              <span className="skillspector-check-category">{check.category}</span>
+              <span className="skillspector-check-patterns">{check.patterns.join(", ")}</span>
+            </li>
+          );
+        })}
+      </ul>
+      {remainingCount > 0 ? (
+        <button
+          type="button"
+          className="skillspector-checks-toggle"
+          onClick={() => setIsExpanded((value) => !value)}
+        >
+          {isExpanded ? "Show less" : `Show ${remainingCount} more`}
+        </button>
       ) : null}
     </div>
   );
@@ -638,12 +894,6 @@ function SecurityAuditScannerSection({
   props: SecurityAuditPageProps;
 }) {
   const label = AUDIT_SCANNER_LABELS[kind];
-  const skillSpectorIssueCount =
-    kind === "skillspector" ? getSkillSpectorIssueCount(props.skillSpectorAnalysis) : 0;
-  const heading =
-    kind === "skillspector" && skillSpectorIssueCount > 0
-      ? `${label} (${skillSpectorIssueCount})`
-      : label;
   return (
     <section
       className="security-report-panel security-report-panel-compact"
@@ -652,7 +902,7 @@ function SecurityAuditScannerSection({
       <div className="security-report-panel-header">
         <div className="security-report-panel-title-row">
           <h2 id={`${kind}-heading`} className="skill-install-panel-title">
-            {heading}
+            {label}
           </h2>
           {kind === "clawscan" ? <RiskAnalysisInfoLink /> : null}
           {kind === "skillspector" ? <SkillSpectorAttribution /> : null}

--- a/src/components/SkillSecurityScanResults.test.tsx
+++ b/src/components/SkillSecurityScanResults.test.tsx
@@ -502,7 +502,7 @@ describe("SecurityScanResults static guidance", () => {
       />,
     );
 
-    expect(screen.getByRole("heading", { name: "SkillSpector (1)" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "SkillSpector" })).toBeTruthy();
     expect(screen.getByText("By NVIDIA")).toBeTruthy();
     expect(screen.queryByText("SkillSpector found 1 issue.")).toBeNull();
     expect(screen.getByRole("heading", { name: "Description-Behavior Mismatch" })).toBeTruthy();
@@ -514,11 +514,94 @@ describe("SecurityScanResults static guidance", () => {
     expect(screen.getByText(/generic security benchmark skill/i)).toBeTruthy();
     expect(screen.queryByText(/Make the manifest and body accurately describe/i)).toBeNull();
     expect(screen.queryByText(/OWASP Agentic Skills Top 10/i)).toBeNull();
+    expect(screen.queryByText("SkillSpector found 1 issue.")).toBeNull();
+    expect(screen.getByText("Findings (1)")).toBeTruthy();
+    expect(screen.getByText("Vulnerability Patterns")).toBeTruthy();
+    expect(screen.getByText("Prompt Injection")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Show 11 more" })).toBeTruthy();
+    const pageText = container.textContent ?? "";
+    expect(pageText.indexOf("Vulnerability Patterns")).toBeLessThan(
+      pageText.indexOf("Description-Behavior Mismatch"),
+    );
+    expect(
+      container.querySelector(".skillspector-check-row .skillspector-check-category")?.textContent,
+    ).toBe("MCP Tool Poisoning");
+    expect(container.querySelector(".skillspector-check-row-flagged")).toBeTruthy();
     expect(
       Array.from(container.querySelectorAll(".security-report-main > section h2")).map((node) =>
         node.textContent?.trim(),
       ),
-    ).toEqual(["Overview", "SkillSpector (1)", "Static analysis", "VirusTotal"]);
+    ).toEqual(["Overview", "SkillSpector", "Static analysis", "VirusTotal"]);
+  });
+
+  it("uses ClawScan only for the security audit outcome", () => {
+    const { container } = render(
+      <SecurityAuditPage
+        entity={{
+          kind: "skill",
+          title: "Discrawl",
+          name: "discrawl",
+          version: "1.0.0",
+          detailPath: "/openclaw/discrawl",
+        }}
+        llmAnalysis={{
+          status: "clean",
+          verdict: "benign",
+          summary: "Discrawl is purpose-aligned.",
+          guidance: "Use least-privilege credentials.",
+          checkedAt: Date.now(),
+        }}
+        skillSpectorAnalysis={{
+          status: "clean",
+          score: 0,
+          severity: "LOW",
+          recommendation: "SAFE",
+          issueCount: 0,
+          scannerVersion: "2.0.0",
+          checkedAt: Date.now(),
+          issues: [],
+        }}
+        vtAnalysis={{ status: "pending", checkedAt: Date.now() }}
+        staticScan={{
+          status: "malicious",
+          reasonCodes: ["malicious.external_transfer"],
+          findings: [],
+          summary: "External transfer.",
+          engineVersion: "v1",
+          checkedAt: Date.now(),
+        }}
+      />,
+    );
+
+    const outcomeRow = Array.from(
+      container.querySelectorAll(".security-report-sidebar .sidebar-metadata-row"),
+    ).find(
+      (row) => row.querySelector(".sidebar-metadata-label")?.textContent?.trim() === "Outcome",
+    );
+    expect(outcomeRow?.textContent).toContain("Pass");
+    expect(outcomeRow?.textContent).not.toContain("Pending");
+    expect(outcomeRow?.textContent).not.toContain("Malicious");
+    expect(
+      screen.getByText("VirusTotal findings are pending for this skill version."),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("Static analysis reported malicious with no visible findings."),
+    ).toBeTruthy();
+    expect(screen.queryByText("No SkillSpector findings.")).toBeNull();
+    expect(screen.getByText("Vulnerability Patterns")).toBeTruthy();
+    expect(screen.getByText("Prompt Injection")).toBeTruthy();
+    expect(
+      container.querySelector(".skillspector-check-row .skillspector-check-category")?.textContent,
+    ).toBe("Prompt Injection");
+    expect(container.querySelector(".skillspector-check-row-flagged")).toBeNull();
+    expect(
+      screen.getByText("Instruction Override, Hidden Instructions, Exfiltration Commands"),
+    ).toBeTruthy();
+    expect(screen.queryByText("Output Handling")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Show 11 more" }));
+    expect(screen.getByText("Output Handling")).toBeTruthy();
+    expect(screen.getByText("MCP Tool Poisoning")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Show less" })).toBeTruthy();
   });
 
   it("uses the full SkillSpector issue count when stored findings are capped", () => {
@@ -530,7 +613,7 @@ describe("SecurityScanResults static guidance", () => {
 
     expect(getSkillSpectorIssueCount(cappedSkillSpectorAnalysis)).toBe(30);
 
-    render(
+    const { container } = render(
       <SecurityAuditPage
         entity={{
           kind: "skill",
@@ -543,7 +626,76 @@ describe("SecurityScanResults static guidance", () => {
       />,
     );
 
-    expect(screen.getByRole("heading", { name: "SkillSpector (30)" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "SkillSpector" })).toBeTruthy();
+    expect(screen.getByText("Findings (30)")).toBeTruthy();
+    expect(
+      container.querySelector(".skillspector-check-row .skillspector-check-category")?.textContent,
+    ).toBe("MCP Tool Poisoning");
+    expect(container.querySelector(".skillspector-check-row-unknown")).toBeTruthy();
+    expect(container.querySelector(".skillspector-check-icon-unknown")).toBeTruthy();
+  });
+
+  it("prioritizes SkillSpector rule IDs over overlapping pattern labels", () => {
+    const overlappingPatternAnalysis: SkillSpectorAnalysis = {
+      ...skillSpectorAnalysis,
+      issues: [
+        {
+          ...skillSpectorAnalysis.issues[0],
+          issueId: "TP1",
+          category: "MCP Tool Poisoning",
+          pattern: "Hidden Instructions",
+        },
+      ],
+    };
+
+    const { container } = render(
+      <SecurityAuditPage
+        entity={{
+          kind: "skill",
+          title: "Benchmark Guard",
+          name: "benchmark-guard",
+          version: "1.0.0",
+          detailPath: "/local/benchmark-guard",
+        }}
+        skillSpectorAnalysis={overlappingPatternAnalysis}
+      />,
+    );
+
+    expect(
+      container.querySelector(".skillspector-check-row .skillspector-check-category")?.textContent,
+    ).toBe("MCP Tool Poisoning");
+    expect(screen.getByRole("heading", { name: "Hidden Instructions" })).toBeTruthy();
+  });
+
+  it("flags Data Exfiltration from unstructured SkillSpector finding text", () => {
+    const unstructuredFindingAnalysis: SkillSpectorAnalysis = {
+      ...skillSpectorAnalysis,
+      issues: [
+        {
+          ...skillSpectorAnalysis.issues[0],
+          issueId: "UNKNOWN-1",
+          explanation:
+            "The skill performs session exfiltration to an external endpoint without clear purpose alignment.",
+        },
+      ],
+    };
+
+    const { container } = render(
+      <SecurityAuditPage
+        entity={{
+          kind: "skill",
+          title: "Benchmark Guard",
+          name: "benchmark-guard",
+          version: "1.0.0",
+          detailPath: "/local/benchmark-guard",
+        }}
+        skillSpectorAnalysis={unstructuredFindingAnalysis}
+      />,
+    );
+
+    expect(
+      container.querySelector(".skillspector-check-row .skillspector-check-category")?.textContent,
+    ).toBe("Data Exfiltration");
   });
 
   it("prefers SkillSpector findings over legacy ClawScan agentic findings during rollout", () => {
@@ -1037,6 +1189,7 @@ describe("SecurityScanResults static guidance", () => {
     expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "SkillSpector" })).toBeTruthy();
     expect(screen.getByText("SkillSpector findings are pending for this release.")).toBeTruthy();
+    expect(screen.queryByText("Prompt Injection")).toBeNull();
     expect(screen.queryByRole("heading", { name: "Risk analysis" })).toBeNull();
     expect(
       screen.queryByText("No visible risk-analysis findings were reported for this release."),

--- a/src/components/securityAuditModel.ts
+++ b/src/components/securityAuditModel.ts
@@ -49,12 +49,6 @@ const SUPPORTING_AUDIT_SCANNER_ORDER: AuditScannerKind[] = DEFAULT_AUDIT_SCANNER
   (kind) => kind !== "skillspector" && kind !== "clawscan",
 );
 
-const POLICY_VERDICT_SCANNER_ORDER: AuditScannerKind[] = [
-  "static-analysis",
-  "virustotal",
-  "clawscan",
-];
-
 function getStaticScanDisplayStatus(staticScan?: StaticScanAnalysis | null) {
   const status = staticScan?.status?.trim().toLowerCase();
   if (status === "malicious") return "malicious";
@@ -73,21 +67,8 @@ export function getAuditScannerStatus(kind: AuditScannerKind, signals: SecurityA
 }
 
 export function aggregateAuditVerdict(signals: SecurityAuditSignals) {
-  const statuses = POLICY_VERDICT_SCANNER_ORDER.map((kind) => getAuditScannerStatus(kind, signals));
-  const normalized = statuses.map((status) => status.toLowerCase());
-  if (normalized.some((status) => status === "malicious")) return "malicious";
-  if (normalized.some((status) => status === "warn" || status === "warning")) return "warn";
-  if (normalized.some((status) => status === "suspicious")) return "warn";
-  if (normalized.some((status) => status === "review")) return "review";
-  if (normalized.some((status) => status === "error" || status === "failed")) return "error";
-  if (
-    normalized.some(
-      (status) => status === "pending" || status === "loading" || status === "not_found",
-    )
-  ) {
-    return "pending";
-  }
-  return signals.suppressScanResults ? "cleared" : "benign";
+  if (signals.suppressScanResults) return "cleared";
+  return getClawScanDisplayStatus(signals.llmAnalysis);
 }
 
 export function getSecurityAuditOverviewCopy({

--- a/src/styles.css
+++ b/src/styles.css
@@ -1406,6 +1406,111 @@ code {
   border-radius: 3px;
 }
 
+.skillspector-findings-block {
+  display: grid;
+  gap: 18px;
+}
+
+.skillspector-checks {
+  display: grid;
+  gap: 10px;
+  margin-top: 28px;
+}
+
+.skillspector-findings-block + .skillspector-checks {
+  margin-top: 44px;
+}
+
+.skillspector-checks + .skillspector-findings-block {
+  margin-top: 44px;
+}
+
+.skillspector-subsection-title {
+  color: var(--ink);
+  font-size: 1.1rem;
+  font-weight: 720;
+  line-height: 1.25;
+}
+
+.skillspector-checks-list {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.skillspector-check-row {
+  display: grid;
+  align-items: center;
+  grid-template-columns: 24px minmax(170px, max-content) minmax(0, 1fr);
+  gap: 10px 14px;
+  padding: 8px 0;
+}
+
+.skillspector-check-row-flagged .skillspector-check-category {
+  color: var(--ink);
+}
+
+.skillspector-check-icon {
+  width: 18px;
+  height: 18px;
+  align-self: center;
+  color: var(--status-success-fg);
+  stroke-width: 2.2;
+}
+
+.skillspector-check-icon-flagged {
+  color: var(--status-warning-fg);
+}
+
+.skillspector-check-icon-unknown {
+  color: var(--ink-soft);
+}
+
+.skillspector-check-category {
+  color: var(--ink);
+  font-size: 0.95rem;
+  font-weight: 650;
+  line-height: 1.35;
+}
+
+.skillspector-check-patterns {
+  color: var(--ink-soft);
+  font-size: 0.95rem;
+  line-height: 1.35;
+}
+
+.skillspector-checks-toggle {
+  width: fit-content;
+  border: 0;
+  background: transparent;
+  padding: 4px 0;
+  color: var(--ink);
+  font-size: 0.88rem;
+  font-weight: 700;
+  line-height: 1.3;
+  cursor: pointer;
+}
+
+.skillspector-checks-toggle:hover,
+.skillspector-checks-toggle:focus-visible {
+  color: var(--accent);
+  outline: none;
+}
+
+@media (max-width: 720px) {
+  .skillspector-check-row {
+    align-items: center;
+    grid-template-columns: 24px minmax(0, 1fr);
+    gap: 4px 12px;
+  }
+
+  .skillspector-check-patterns {
+    grid-column: 2;
+  }
+}
+
 .security-report-title-info-link {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary

This PR refines the security audit UI now that SkillSpector is the agentic-risk finding source. It keeps the overall ClawHub verdict driven by ClawScan while rendering SkillSpector evidence as its own scanner section.

## What changed

- Makes the compact audit outcome come from ClawScan only, instead of rolling up VirusTotal or static scanner status.
- Moves SkillSpector above static analysis in the audit scanner order.
- Adds a SkillSpector vulnerability-patterns section with a collapsed first-five view and `Show N more` expansion.
- Shows SkillSpector findings under a `Findings (N)` header and keeps the count out of the top-level title.
- Maps SkillSpector issues back to top-level vulnerability families so flagged families float to the top.
- Uses a yellow warning triangle for flagged families, a green check for confirmed-clean families, and a neutral icon when stored findings are capped and hidden findings may exist.
- Removes the redundant `No SkillSpector findings.` copy when the vulnerability-patterns list already explains what was scanned.
- Keeps legacy ClawScan risk analysis as a rollout fallback only when SkillSpector content is absent.

## Validation

- `bun run format:check -- src/components/SecurityAuditPage.tsx src/components/SkillSecurityScanResults.test.tsx src/components/DetailSecuritySummary.test.tsx src/components/securityAuditModel.ts src/styles.css`
- `bunx vitest run src/components/SkillSecurityScanResults.test.tsx src/components/DetailSecuritySummary.test.tsx`
- `bunx oxlint --type-aware --tsconfig ./tsconfig.oxlint.json src/components/SecurityAuditPage.tsx src/components/securityAuditModel.ts src/components/SkillSecurityScanResults.test.tsx src/components/DetailSecuritySummary.test.tsx`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --parallel-tests ""` returned `autoreview clean: no accepted/actionable findings reported`

Note: repo-wide `bun run lint` still reports an unrelated existing issue in `convex/securityScan.test.ts`; touched-file type-aware oxlint is clean.
