### PR TITLE
chore(release): prepare clawhub cli 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## Unreleased
 
+## 0.18.0 - 2026-05-25
+
 ### Changes
 
+- CLI/API: add Skill Card verification surfaces, including `clawhub skill verify <slug>` JSON output and `--card` Markdown retrieval (#2382).
 - Web/API: surface an "API key required" attribute on skills so listings, cards, and detail views show whether a skill needs an LLM API key, with publish-time inference from skill prompts and metadata (#2353) (thanks @momothemage).
 
 ### Fixes

--- a/bun.lock
+++ b/bun.lock
@@ -81,7 +81,7 @@
     },
     "packages/clawhub": {
       "name": "clawhub",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "bin": {
         "clawdhub": "bin/clawdhub.js",
         "clawhub": "bin/clawdhub.js",

--- a/packages/clawhub/package.json
+++ b/packages/clawhub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawhub",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "ClawHub CLI \\u2014 install, update, search, and publish skills plus OpenClaw packages.",
   "homepage": "https://clawhub.ai",
   "bugs": {


### PR DESCRIPTION
## Summary

- Bump the `clawhub` CLI package to `0.18.0`.
- Add release notes for the new `clawhub skill verify <slug>` / `--card` Skill Card verification command from #2382.
- Keep `bun.lock` workspace metadata in sync with the package version.

## Verification

- `bun install --frozen-lockfile`
- `node scripts/clawhub-cli-npm-release-check.mjs --tag v0.18.0`
- `node scripts/extract-changelog-release.mjs --tag v0.18.0`
- `bun run --cwd packages/clawhub verify`
- `bun clawhub --cli-version`
- `bun clawhub skill verify --help`
- Production API smoke: `https://clawhub.ai/api/v1/skills/gifgrep/verify` returned `schema: "clawhub.skill.verify.v1"`
