### PR TITLE
Remove redundant skill verify JSON flag

### DIFF
--- a/e2e/clawhub.e2e.test.ts
+++ b/e2e/clawhub.e2e.test.ts
@@ -588,6 +588,19 @@ describe("clawhub e2e", () => {
     expect(result.stdout).toMatch(/--json/);
   });
 
+  it("skill verify help omits the redundant json flag", async () => {
+    const result = spawnSync("bun", ["clawhub", "skill", "verify", "--help"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toMatch(/--version/);
+    expect(result.stdout).toMatch(/--tag/);
+    expect(result.stdout).toMatch(/--card/);
+    expect(result.stdout).not.toMatch(/--json/);
+  });
+
   itIfLiveMutations(
     "publishes, deletes, and undeletes a skill (logged-in)",
     async () => {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "check": "bun run lint",
     "check:peers": "bun scripts/check-peer-deps.ts",
     "check:secrets": "bun scripts/check-staged-secrets.mjs",
-    "ci:e2e-http": "bun run test:e2e:prod-http && bunx vitest run -c vitest.e2e.config.ts e2e/clawhub.e2e.test.ts --testNamePattern \"prints CLI version|search endpoint returns a results array|cli search does not error|package publish --dry-run from a GitHub repo|package publish --dry-run --json|package publish help shows\" && bunx vitest run -c vitest.e2e.config.ts e2e/permissions.e2e.test.ts",
+    "ci:e2e-http": "bun run test:e2e:prod-http && bunx vitest run -c vitest.e2e.config.ts e2e/clawhub.e2e.test.ts --testNamePattern \"prints CLI version|search endpoint returns a results array|cli search does not error|package publish --dry-run from a GitHub repo|package publish --dry-run --json|package publish help shows|skill verify help omits the redundant json flag\" && bunx vitest run -c vitest.e2e.config.ts e2e/permissions.e2e.test.ts",
     "ci:packages": "bun run --cwd packages/schema build && bun run --cwd packages/clawhub verify && bun run --cwd packages/clawhub-mod verify",
     "ci:playwright": "VITE_CONVEX_URL=https://wry-manatee-359.convex.cloud VITE_CONVEX_SITE_URL=https://wry-manatee-359.convex.site bun run build && VITE_CONVEX_URL=https://wry-manatee-359.convex.cloud VITE_CONVEX_SITE_URL=https://wry-manatee-359.convex.site bun run test:pw",
     "ci:playwright-smoke": "VITE_CONVEX_URL=https://wry-manatee-359.convex.cloud VITE_CONVEX_SITE_URL=https://wry-manatee-359.convex.site bun run build && VITE_CONVEX_URL=https://wry-manatee-359.convex.cloud VITE_CONVEX_SITE_URL=https://wry-manatee-359.convex.site bun run test:pw -- --project=chromium e2e/ci-smoke.pw.test.ts",

--- a/packages/clawhub/src/cli.ts
+++ b/packages/clawhub/src/cli.ts
@@ -387,7 +387,6 @@ registerCommand(skill, ["skill", "verify"])
   .argument("<slug>", "Skill slug")
   .option("--version <version>", "Version to verify")
   .option("--tag <tag>", "Tag to verify")
-  .option("--json", "Output JSON (default)")
   .option("--card", "Output generated skill-card.md Markdown")
   .action(async (slug, options) => {
     const opts = await resolveGlobalOpts();

--- a/packages/clawhub/src/cli/commands/inspect.ts
+++ b/packages/clawhub/src/cli/commands/inspect.ts
@@ -27,7 +27,6 @@ type InspectOptions = {
 type VerifySkillOptions = {
   version?: string;
   tag?: string;
-  json?: boolean;
   card?: boolean;
 };
 


### PR DESCRIPTION
## Summary
- Remove the redundant `--json` option from `clawhub skill verify`; JSON remains the default output mode.
- Keep the explicit alternate mode as `--card` and leave `--version` / `--tag` intact.
- Add a help-output regression test and include it in the e2e HTTP subset so the flag does not reappear accidentally.

## Linear
- CLAW-186

## Tests
- `bunx vitest run -c vitest.config.ts src/cli/commands/inspect.test.ts` (from `packages/clawhub`)
- `bunx vitest run -c vitest.e2e.config.ts e2e/clawhub.e2e.test.ts --testNamePattern "skill verify help omits the redundant json flag"`
- `bun run ci:static`
- `bun run --cwd packages/clawhub verify:build`
- `bun run --cwd packages/clawhub test:src`
