### PR TITLE
Add bulk skill security verdicts endpoint

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -35,6 +35,7 @@ import {
   publishSoulV1Http,
   resolveSkillVersionV1Http,
   searchSkillsV1Http,
+  skillSecurityVerdictsV1Http,
   skillsDeleteRouterV1Http,
   skillsGetRouterV1Http,
   skillsPostRouterV1Http,
@@ -161,6 +162,12 @@ http.route({
   pathPrefix: `${ApiRoutes.packages}/`,
   method: "DELETE",
   handler: packagesDeleteRouterV1Http,
+});
+
+http.route({
+  path: `${ApiRoutes.skills}/-/security-verdicts`,
+  method: "POST",
+  handler: skillSecurityVerdictsV1Http,
 });
 
 http.route({

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -2925,14 +2925,7 @@ describe("httpApiV1 handlers", () => {
             _id: "skills:1",
             slug: "demo",
             displayName: "Demo",
-            summary: "s",
-            tags: {},
-            stats: {},
-            createdAt: 1,
-            updatedAt: 2,
-            latestVersionId: "skillVersions:1",
           },
-          latestVersion: { _id: "skillVersions:1", version: "1.0.0" },
           owner: { _id: "users:1", handle: "acme", displayName: "Acme" },
           moderationInfo: {
             isPendingScan: false,
@@ -2941,9 +2934,9 @@ describe("httpApiV1 handlers", () => {
             isHiddenByMod: false,
             isRemoved: false,
           },
+          version,
         };
       }
-      if ("skillId" in args && "version" in args) return version;
       return null;
     });
     const runMutation = vi.fn().mockResolvedValue(okRate());
@@ -2994,6 +2987,11 @@ describe("httpApiV1 handlers", () => {
     expect(json.items[0].artifact).toBeUndefined();
     expect(json.items[0].security.signals.staticScan.findings).toBeUndefined();
     expect(json.items[0].security.signals.dependencyRegistry.notFoundPackages).toBeUndefined();
+    expect(runQuery.mock.calls.map(([, args]) => args)).toContainEqual({
+      slug: "demo",
+      version: "1.0.0",
+    });
+    expect(runQuery.mock.calls.some(([, args]) => "skillId" in args)).toBe(false);
   });
 
   it("keeps bulk verdict item failures local to each requested skill", async () => {
@@ -3015,13 +3013,10 @@ describe("httpApiV1 handlers", () => {
             _id: "skills:no-version",
             slug: "no-version",
             displayName: "No Version",
-            tags: {},
-            stats: {},
-            createdAt: 1,
-            updatedAt: 2,
           },
-          latestVersion: null,
           owner: null,
+          moderationInfo: null,
+          version: null,
         };
       }
       if (args.slug === "soft") {
@@ -3030,16 +3025,12 @@ describe("httpApiV1 handlers", () => {
             _id: "skills:soft",
             slug: "soft",
             displayName: "Soft",
-            tags: {},
-            stats: {},
-            createdAt: 1,
-            updatedAt: 2,
           },
-          latestVersion: softDeletedVersion,
           owner: null,
+          moderationInfo: null,
+          version: softDeletedVersion,
         };
       }
-      if (args.skillId === "skills:soft") return softDeletedVersion;
       return null;
     });
     const runMutation = vi.fn().mockResolvedValue(okRate());
@@ -3119,25 +3110,19 @@ describe("httpApiV1 handlers", () => {
             _id: "skills:1",
             slug: "demo",
             displayName: "Demo",
-            tags: {},
-            stats: {},
-            createdAt: 1,
-            updatedAt: 2,
           },
-          latestVersion: { _id: "skillVersions:1", version: "1.0.0" },
           owner: null,
-        };
-      }
-      if ("skillId" in args && "version" in args) {
-        return {
-          _id: "skillVersions:1",
-          skillId: "skills:1",
-          version: "1.0.0",
-          createdAt: 1,
-          changelog: "c",
-          files: [],
-          llmAnalysis: analysis,
-          softDeletedAt: undefined,
+          moderationInfo: null,
+          version: {
+            _id: "skillVersions:1",
+            skillId: "skills:1",
+            version: "1.0.0",
+            createdAt: 1,
+            changelog: "c",
+            files: [],
+            llmAnalysis: analysis,
+            softDeletedAt: undefined,
+          },
         };
       }
       return null;
@@ -3166,6 +3151,28 @@ describe("httpApiV1 handlers", () => {
   it("rejects malformed bulk security verdict request bodies", async () => {
     const runQuery = vi.fn();
     const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const nullBody = await __handlers.skillSecurityVerdictsV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/-/security-verdicts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "null",
+      }),
+    );
+    expect(nullBody.status).toBe(400);
+    expect(await nullBody.text()).toBe("JSON body must be an object");
+
+    const scalarBody = await __handlers.skillSecurityVerdictsV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/-/security-verdicts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify("nope"),
+      }),
+    );
+    expect(scalarBody.status).toBe(400);
+    expect(await scalarBody.text()).toBe("JSON body must be an object");
 
     const missingItems = await __handlers.skillSecurityVerdictsV1Handler(
       makeCtx({ runQuery, runMutation }),

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -2883,6 +2883,331 @@ describe("httpApiV1 handlers", () => {
     expect(await response.text()).toBe("Skill Card not found");
   });
 
+  it("returns bulk skill security verdicts without card data", async () => {
+    const version = {
+      _id: "skillVersions:1",
+      skillId: "skills:1",
+      version: "1.0.0",
+      createdAt: 1,
+      changelog: "c",
+      files: [{ path: "SKILL.md", size: 5, storageId: "storage:1", sha256: "source-sha" }],
+      staticScan: {
+        status: "clean",
+        reasonCodes: [],
+        findings: [],
+        summary: "Static scan clean.",
+        engineVersion: "static-v1",
+        checkedAt: 2,
+      },
+      llmAnalysis: {
+        status: "clean",
+        verdict: "clean",
+        confidence: "high",
+        summary: "ClawScan clean.",
+        checkedAt: 3,
+        model: "gpt-test",
+      },
+      depRegistryAnalysis: {
+        status: "clean",
+        results: [],
+        notFoundPackages: [],
+        unresolvedPackages: [],
+        summary: "No dependency issues.",
+        checkedAt: 4,
+      },
+      capabilityTags: ["dev-tools"],
+      softDeletedAt: undefined,
+    };
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("slug" in args) {
+        return {
+          skill: {
+            _id: "skills:1",
+            slug: "demo",
+            displayName: "Demo",
+            summary: "s",
+            tags: {},
+            stats: {},
+            createdAt: 1,
+            updatedAt: 2,
+            latestVersionId: "skillVersions:1",
+          },
+          latestVersion: { _id: "skillVersions:1", version: "1.0.0" },
+          owner: { _id: "users:1", handle: "acme", displayName: "Acme" },
+          moderationInfo: {
+            isPendingScan: false,
+            isMalwareBlocked: false,
+            isSuspicious: false,
+            isHiddenByMod: false,
+            isRemoved: false,
+          },
+        };
+      }
+      if ("skillId" in args && "version" in args) return version;
+      return null;
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.skillSecurityVerdictsV1Handler(
+      makeCtx({ runQuery, runMutation, storage: { get: vi.fn() } }),
+      new Request("https://example.com/api/v1/skills/-/security-verdicts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ items: [{ slug: "demo", version: "1.0.0" }] }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json).toMatchObject({
+      schema: "clawhub.skill.security-verdicts.v1",
+      items: [
+        {
+          ok: true,
+          decision: "pass",
+          reasons: [],
+          slug: "demo",
+          requestedSlug: "demo",
+          displayName: "Demo",
+          publisherHandle: "acme",
+          publisherDisplayName: "Acme",
+          requestedVersion: "1.0.0",
+          version: "1.0.0",
+          createdAt: 1,
+          checkedAt: 4,
+          skillUrl: "https://example.com/acme/demo",
+          securityAuditUrl: "https://example.com/acme/demo/security-audit?version=1.0.0",
+          security: {
+            status: "clean",
+            passed: true,
+            rawStatus: "clean",
+            verdict: "clean",
+            signals: {
+              staticScan: { status: "clean", rawStatus: "clean" },
+              dependencyRegistry: { status: "clean", rawStatus: "clean" },
+            },
+          },
+        },
+      ],
+    });
+    expect(json.items[0].card).toBeUndefined();
+    expect(json.items[0].artifact).toBeUndefined();
+    expect(json.items[0].security.signals.staticScan.findings).toBeUndefined();
+    expect(json.items[0].security.signals.dependencyRegistry.notFoundPackages).toBeUndefined();
+  });
+
+  it("keeps bulk verdict item failures local to each requested skill", async () => {
+    const softDeletedVersion = {
+      _id: "skillVersions:deleted",
+      skillId: "skills:soft",
+      version: "2.0.0",
+      createdAt: 2,
+      changelog: "c",
+      files: [],
+      llmAnalysis: { status: "clean", verdict: "clean", checkedAt: 3 },
+      softDeletedAt: 5,
+    };
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if (args.slug === "missing") return null;
+      if (args.slug === "no-version") {
+        return {
+          skill: {
+            _id: "skills:no-version",
+            slug: "no-version",
+            displayName: "No Version",
+            tags: {},
+            stats: {},
+            createdAt: 1,
+            updatedAt: 2,
+          },
+          latestVersion: null,
+          owner: null,
+        };
+      }
+      if (args.slug === "soft") {
+        return {
+          skill: {
+            _id: "skills:soft",
+            slug: "soft",
+            displayName: "Soft",
+            tags: {},
+            stats: {},
+            createdAt: 1,
+            updatedAt: 2,
+          },
+          latestVersion: softDeletedVersion,
+          owner: null,
+        };
+      }
+      if (args.skillId === "skills:soft") return softDeletedVersion;
+      return null;
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.skillSecurityVerdictsV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/-/security-verdicts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          items: [
+            { slug: "missing", version: "1.0.0" },
+            { slug: "no-version", version: "1.0.0" },
+            { slug: "soft", version: "2.0.0" },
+          ],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.items).toHaveLength(3);
+    expect(json.items.map((item: { ok: boolean }) => item.ok)).toEqual([false, false, false]);
+    expect(json.items[0]).toMatchObject({
+      requestedSlug: "missing",
+      requestedVersion: "1.0.0",
+      decision: "fail",
+      reasons: ["skill.not_found"],
+      error: { code: "skill_not_found", message: "Skill not found" },
+    });
+    expect(json.items[1]).toMatchObject({
+      requestedSlug: "no-version",
+      requestedVersion: "1.0.0",
+      decision: "fail",
+      reasons: ["version.not_found"],
+      error: { code: "version_not_found", message: "Version not found" },
+    });
+    expect(json.items[2]).toMatchObject({
+      requestedSlug: "soft",
+      requestedVersion: "2.0.0",
+      decision: "fail",
+      reasons: ["version.unavailable"],
+      error: { code: "version_unavailable", message: "Version not available" },
+    });
+  });
+
+  it.each([
+    {
+      label: "suspicious",
+      analysis: { status: "completed", verdict: "suspicious", checkedAt: 10 },
+      reasons: ["security.status_not_clean"],
+      security: { status: "suspicious", passed: false },
+    },
+    {
+      label: "malicious",
+      analysis: { status: "completed", verdict: "malicious", checkedAt: 10 },
+      reasons: ["security.status_not_clean"],
+      security: { status: "malicious", passed: false },
+    },
+    {
+      label: "pending",
+      analysis: { status: "completed", checkedAt: 11 },
+      reasons: ["security.status_not_clean", "security.pending"],
+      security: { status: "pending", passed: false },
+    },
+    {
+      label: "error",
+      analysis: { status: "failed", checkedAt: 12 },
+      reasons: ["security.status_not_clean", "security.error"],
+      security: { status: "error", passed: false },
+    },
+  ])("reports $label bulk security verdicts", async ({ analysis, reasons, security }) => {
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("slug" in args) {
+        return {
+          skill: {
+            _id: "skills:1",
+            slug: "demo",
+            displayName: "Demo",
+            tags: {},
+            stats: {},
+            createdAt: 1,
+            updatedAt: 2,
+          },
+          latestVersion: { _id: "skillVersions:1", version: "1.0.0" },
+          owner: null,
+        };
+      }
+      if ("skillId" in args && "version" in args) {
+        return {
+          _id: "skillVersions:1",
+          skillId: "skills:1",
+          version: "1.0.0",
+          createdAt: 1,
+          changelog: "c",
+          files: [],
+          llmAnalysis: analysis,
+          softDeletedAt: undefined,
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.skillSecurityVerdictsV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/-/security-verdicts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ items: [{ slug: "demo", version: "1.0.0" }] }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.items[0]).toMatchObject({
+      ok: false,
+      decision: "fail",
+      reasons,
+      security,
+    });
+  });
+
+  it("rejects malformed bulk security verdict request bodies", async () => {
+    const runQuery = vi.fn();
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const missingItems = await __handlers.skillSecurityVerdictsV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/-/security-verdicts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ items: [] }),
+      }),
+    );
+    expect(missingItems.status).toBe(400);
+    expect(await missingItems.text()).toBe("items must contain 1 to 100 entries");
+
+    const duplicate = await __handlers.skillSecurityVerdictsV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/-/security-verdicts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          items: [
+            { slug: "demo", version: "1.0.0" },
+            { slug: "demo", version: "1.0.0" },
+          ],
+        }),
+      }),
+    );
+    expect(duplicate.status).toBe(400);
+    expect(await duplicate.text()).toBe("Duplicate item: demo@1.0.0");
+
+    const ambiguous = await __handlers.skillSecurityVerdictsV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/-/security-verdicts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ items: [{ slug: "demo", version: "1.0.0", tag: "latest" }] }),
+      }),
+    );
+    expect(ambiguous.status).toBe(400);
+    expect(await ambiguous.text()).toBe("items[0] uses version only; tag is not supported");
+
+    expect(runQuery).not.toHaveBeenCalled();
+  });
+
   it("returns a skill verification envelope with card and security metadata", async () => {
     const internalVersion = {
       _id: "skillVersions:1",

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -2994,6 +2994,99 @@ describe("httpApiV1 handlers", () => {
     expect(runQuery.mock.calls.some(([, args]) => "skillId" in args)).toBe(false);
   });
 
+  it("uses the public site origin for production bulk verdict links", async () => {
+    vi.stubEnv("CONVEX_DEPLOYMENT", "prod:wry-manatee-359");
+    const runQuery = vi.fn(async () => ({
+      skill: { _id: "skills:1", slug: "demo", displayName: "Demo" },
+      owner: { _id: "users:1", handle: "acme", displayName: "Acme" },
+      moderationInfo: {
+        isPendingScan: false,
+        isMalwareBlocked: false,
+        isSuspicious: false,
+        isHiddenByMod: false,
+        isRemoved: false,
+      },
+      version: {
+        _id: "skillVersions:1",
+        version: "1.0.0",
+        createdAt: 1,
+        llmAnalysis: { status: "clean", verdict: "clean", checkedAt: 2 },
+      },
+    }));
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.skillSecurityVerdictsV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://wry-manatee-359.convex.site/api/v1/skills/-/security-verdicts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ items: [{ slug: "demo", version: "1.0.0" }] }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.items[0]).toMatchObject({
+      skillUrl: "https://clawhub.ai/acme/demo",
+      securityAuditUrl: "https://clawhub.ai/acme/demo/security-audit?version=1.0.0",
+    });
+  });
+
+  it("honors staff-cleared bulk security verdicts", async () => {
+    const runQuery = vi.fn(async () => ({
+      skill: { _id: "skills:1", slug: "demo", displayName: "Demo" },
+      owner: { _id: "users:1", handle: "acme", displayName: "Acme" },
+      moderationInfo: {
+        isPendingScan: false,
+        isMalwareBlocked: false,
+        isSuspicious: false,
+        isHiddenByMod: false,
+        isRemoved: false,
+        overrideActive: true,
+        verdict: "clean",
+        summary: "Security findings were reviewed by moderators and cleared for public use.",
+        updatedAt: 20,
+      },
+      version: {
+        _id: "skillVersions:1",
+        version: "1.0.0",
+        createdAt: 1,
+        llmAnalysis: {
+          status: "completed",
+          verdict: "suspicious",
+          summary: "Scanner found review-worthy behavior.",
+          checkedAt: 10,
+        },
+      },
+    }));
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.skillSecurityVerdictsV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/-/security-verdicts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ items: [{ slug: "demo", version: "1.0.0" }] }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.items[0]).toMatchObject({
+      ok: true,
+      decision: "pass",
+      reasons: [],
+      checkedAt: 20,
+      security: {
+        status: "clean",
+        passed: true,
+        verdict: "clean",
+        summary: "Security findings were reviewed by moderators and cleared for public use.",
+        checkedAt: 20,
+      },
+    });
+  });
+
   it("keeps bulk verdict item failures local to each requested skill", async () => {
     const softDeletedVersion = {
       _id: "skillVersions:deleted",

--- a/convex/httpApiV1.ts
+++ b/convex/httpApiV1.ts
@@ -20,6 +20,7 @@ import {
   publishSkillV1Handler,
   resolveSkillVersionV1Handler,
   searchSkillsV1Handler,
+  skillSecurityVerdictsV1Handler,
   skillsDeleteRouterV1Handler,
   skillsGetRouterV1Handler,
   skillsPostRouterV1Handler,
@@ -55,6 +56,7 @@ export const resolveSkillVersionV1Http = httpAction(resolveSkillVersionV1Handler
 export const listSkillsV1Http = httpAction(listSkillsV1Handler);
 export const skillsGetRouterV1Http = httpAction(skillsGetRouterV1Handler);
 export const publishSkillV1Http = httpAction(publishSkillV1Handler);
+export const skillSecurityVerdictsV1Http = httpAction(skillSecurityVerdictsV1Handler);
 export const skillsPostRouterV1Http = httpAction(skillsPostRouterV1Handler);
 export const skillsDeleteRouterV1Http = httpAction(skillsDeleteRouterV1Handler);
 export const exportSkillsV1Http = httpAction(exportSkillsV1Handler);
@@ -92,6 +94,7 @@ export const __handlers = {
   listSkillsV1Handler,
   skillsGetRouterV1Handler,
   publishSkillV1Handler,
+  skillSecurityVerdictsV1Handler,
   skillsPostRouterV1Handler,
   skillsDeleteRouterV1Handler,
   exportSkillsV1Handler,

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -54,6 +54,7 @@ import {
   MAX_RAW_FILE_BYTES,
   getPathSegments,
   json,
+  publicApiOrigin,
   resolveTagsBatch,
   requireApiTokenUserOrResponse,
   requireAdminOrResponse,
@@ -601,67 +602,6 @@ function encodePackagePath(name: string) {
         : encodeURIComponent(segment),
     )
     .join("/");
-}
-
-const DEFAULT_PUBLIC_SITE_URL = "https://clawhub.ai";
-
-function normalizeOrigin(value: string | null | undefined) {
-  const trimmed = value?.trim();
-  if (!trimmed) return null;
-  try {
-    return new URL(trimmed).origin;
-  } catch {
-    return null;
-  }
-}
-
-function firstForwardedValue(value: string | null) {
-  return value?.split(",")[0]?.trim() || null;
-}
-
-function isProductionDeployment() {
-  const deployment = process.env.CONVEX_DEPLOYMENT?.trim() ?? "";
-  return deployment.startsWith("prod:") || deployment.includes("production");
-}
-
-function isTrustedForwardedHost(value: string) {
-  try {
-    const hostname = new URL(`https://${value}`).hostname.toLowerCase();
-    return (
-      hostname === "clawhub.ai" ||
-      hostname === "www.clawhub.ai" ||
-      hostname === "localhost" ||
-      hostname === "127.0.0.1" ||
-      hostname === "0.0.0.0"
-    );
-  } catch {
-    return false;
-  }
-}
-
-function publicApiOrigin(request: Request) {
-  const configured = normalizeOrigin(process.env.SITE_URL ?? process.env.VITE_SITE_URL);
-  if (configured) return configured;
-
-  const forwardedHost = firstForwardedValue(request.headers.get("x-forwarded-host"));
-  if (
-    forwardedHost &&
-    !forwardedHost.endsWith(".convex.site") &&
-    isTrustedForwardedHost(forwardedHost)
-  ) {
-    const forwardedProto =
-      firstForwardedValue(request.headers.get("x-forwarded-proto")) ??
-      firstForwardedValue(request.headers.get("x-forwarded-protocol")) ??
-      "https";
-    const proto = forwardedProto === "http" ? "http" : "https";
-    return `${proto}://${forwardedHost}`;
-  }
-
-  const requestUrl = new URL(request.url);
-  if (isProductionDeployment() && requestUrl.hostname.endsWith(".convex.site")) {
-    return DEFAULT_PUBLIC_SITE_URL;
-  }
-  return requestUrl.origin;
 }
 
 function absoluteApiUrl(request: Request, path: string) {

--- a/convex/httpApiV1/shared.ts
+++ b/convex/httpApiV1/shared.ts
@@ -9,6 +9,7 @@ import { getPublishFileSizeError, MAX_PUBLISH_FILE_BYTES } from "../lib/publishL
 import { isMacJunkPath } from "../lib/skills";
 
 export const MAX_RAW_FILE_BYTES = 200 * 1024;
+const DEFAULT_PUBLIC_SITE_URL = "https://clawhub.ai";
 
 const SAFE_TEXT_FILE_CSP =
   "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'";
@@ -86,6 +87,65 @@ export async function parseJsonPayload(request: Request, headers: HeadersInit) {
   } catch {
     return { ok: false as const, response: text("Invalid JSON", 400, headers) };
   }
+}
+
+function normalizeOrigin(value: string | null | undefined) {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  try {
+    return new URL(trimmed).origin;
+  } catch {
+    return null;
+  }
+}
+
+function firstForwardedValue(value: string | null) {
+  return value?.split(",")[0]?.trim() || null;
+}
+
+function isProductionDeployment() {
+  const deployment = process.env.CONVEX_DEPLOYMENT?.trim() ?? "";
+  return deployment.startsWith("prod:") || deployment.includes("production");
+}
+
+function isTrustedForwardedHost(value: string) {
+  try {
+    const hostname = new URL(`https://${value}`).hostname.toLowerCase();
+    return (
+      hostname === "clawhub.ai" ||
+      hostname === "www.clawhub.ai" ||
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "0.0.0.0"
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function publicApiOrigin(request: Request) {
+  const configured = normalizeOrigin(process.env.SITE_URL ?? process.env.VITE_SITE_URL);
+  if (configured) return configured;
+
+  const forwardedHost = firstForwardedValue(request.headers.get("x-forwarded-host"));
+  if (
+    forwardedHost &&
+    !forwardedHost.endsWith(".convex.site") &&
+    isTrustedForwardedHost(forwardedHost)
+  ) {
+    const forwardedProto =
+      firstForwardedValue(request.headers.get("x-forwarded-proto")) ??
+      firstForwardedValue(request.headers.get("x-forwarded-protocol")) ??
+      "https";
+    const proto = forwardedProto === "http" ? "http" : "https";
+    return `${proto}://${forwardedHost}`;
+  }
+
+  const requestUrl = new URL(request.url);
+  if (isProductionDeployment() && requestUrl.hostname.endsWith(".convex.site")) {
+    return DEFAULT_PUBLIC_SITE_URL;
+  }
+  return requestUrl.origin;
 }
 
 export async function requireApiTokenUserOrResponse(

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -35,6 +35,7 @@ import {
   parseJsonPayload,
   parseMultipartPublish,
   parsePublishBody,
+  publicApiOrigin,
   requireApiTokenUserOrResponse,
   resolveTagsBatch,
   safeTextFileResponse,
@@ -445,10 +446,44 @@ type SecurityVerdictRequestItem = {
   version: string;
 };
 
-type VerifySecurityVersion = Pick<
-  Doc<"skillVersions">,
-  "staticScan" | "llmAnalysis" | "vtAnalysis" | "skillSpectorAnalysis" | "depRegistryAnalysis"
->;
+type VerifySecurityVersion = {
+  staticScan?: Pick<
+    NonNullable<Doc<"skillVersions">["staticScan"]>,
+    "status" | "reasonCodes" | "summary" | "engineVersion" | "checkedAt"
+  >;
+  llmAnalysis?: Pick<
+    NonNullable<Doc<"skillVersions">["llmAnalysis"]>,
+    "status" | "verdict" | "confidence" | "summary" | "model" | "checkedAt"
+  >;
+  vtAnalysis?: Pick<
+    NonNullable<Doc<"skillVersions">["vtAnalysis"]>,
+    "status" | "verdict" | "source" | "checkedAt"
+  > &
+    Partial<
+      Pick<NonNullable<Doc<"skillVersions">["vtAnalysis"]>, "analysis" | "scanner" | "engineStats">
+    >;
+  skillSpectorAnalysis?: Pick<
+    NonNullable<Doc<"skillVersions">["skillSpectorAnalysis"]>,
+    | "status"
+    | "score"
+    | "severity"
+    | "recommendation"
+    | "issueCount"
+    | "scannerVersion"
+    | "checkedAt"
+  > &
+    Partial<Pick<NonNullable<Doc<"skillVersions">["skillSpectorAnalysis"]>, "summary" | "error">>;
+  depRegistryAnalysis?: Pick<
+    NonNullable<Doc<"skillVersions">["depRegistryAnalysis"]>,
+    "status" | "summary" | "checkedAt"
+  > &
+    Partial<
+      Pick<
+        NonNullable<Doc<"skillVersions">["depRegistryAnalysis"]>,
+        "notFoundPackages" | "unresolvedPackages"
+      >
+    >;
+};
 
 type SecurityVerdictTargetResult = {
   skill: {
@@ -468,6 +503,7 @@ type SecurityVerdictTargetResult = {
     summary?: string;
     engineVersion?: string;
     updatedAt?: number;
+    overrideActive?: boolean;
   } | null;
   version:
     | (VerifySecurityVersion &
@@ -602,6 +638,7 @@ function buildVerifyReasons(args: {
       isMalwareBlocked: args.isMalwareBlocked,
       securityPassed: args.securityPassed,
       securityStatus: args.securityStatus,
+      staffCleared: false,
     }),
   );
   return [...new Set(reasons)];
@@ -611,12 +648,15 @@ function buildSecurityVerdictReasons(args: {
   isMalwareBlocked: boolean;
   securityPassed: boolean;
   securityStatus: NormalizedSecurityStatus;
+  staffCleared: boolean;
 }) {
   const reasons: string[] = [];
   if (args.isMalwareBlocked) reasons.push("moderation.malware_blocked");
-  if (!args.securityPassed) reasons.push("security.status_not_clean");
-  if (args.securityStatus === "pending") reasons.push("security.pending");
-  if (args.securityStatus === "error") reasons.push("security.error");
+  if (!args.staffCleared) {
+    if (!args.securityPassed) reasons.push("security.status_not_clean");
+    if (args.securityStatus === "pending") reasons.push("security.pending");
+    if (args.securityStatus === "error") reasons.push("security.error");
+  }
   return [...new Set(reasons)];
 }
 
@@ -685,6 +725,45 @@ function buildSecurityVerdictSummary(security: ReturnType<typeof buildVerifySecu
   };
 }
 
+type SecurityVerdictModerationInfo = NonNullable<SecurityVerdictTargetResult>["moderationInfo"];
+
+function isStaffClearedSecurityVerdict(moderationInfo: SecurityVerdictModerationInfo) {
+  return Boolean(
+    moderationInfo?.overrideActive &&
+    moderationInfo.verdict === "clean" &&
+    !moderationInfo.isMalwareBlocked,
+  );
+}
+
+function buildEffectiveSecurityVerdictSummary(
+  security: ReturnType<typeof buildVerifySecurity>,
+  moderationInfo: SecurityVerdictModerationInfo,
+) {
+  const summary = buildSecurityVerdictSummary(security);
+  if (!isStaffClearedSecurityVerdict(moderationInfo)) return summary;
+
+  return {
+    ...summary,
+    status: "clean" as const,
+    passed: true,
+    verdict: "clean",
+    summary: moderationInfo?.summary ?? summary.summary,
+    checkedAt: getEffectiveSecurityVerdictCheckedAt(security, moderationInfo),
+  };
+}
+
+function getEffectiveSecurityVerdictCheckedAt(
+  security: ReturnType<typeof buildVerifySecurity>,
+  moderationInfo: SecurityVerdictModerationInfo,
+) {
+  const candidates = [getVerifySecurityCheckedAt(security)];
+  if (isStaffClearedSecurityVerdict(moderationInfo)) {
+    candidates.push(moderationInfo?.updatedAt ?? null);
+  }
+  const checkedAt = candidates.filter((value): value is number => typeof value === "number");
+  return checkedAt.length > 0 ? Math.max(...checkedAt) : null;
+}
+
 function isValidRequestedVersion(version: string) {
   return version.length > 0 && version.length <= 128 && !/[\s/\\]/.test(version);
 }
@@ -732,7 +811,7 @@ function parseSecurityVerdictItems(
 }
 
 function buildSkillPageUrl(request: Request, owner: SkillUrlOwner, slug: string) {
-  const origin = new URL(request.url).origin;
+  const origin = publicApiOrigin(request);
   const ownerSegment = owner?.handle ?? owner?._id ?? null;
   if (!ownerSegment) {
     return new URL(`/api/v1/skills/${encodeURIComponent(slug)}`, origin).toString();
@@ -754,7 +833,7 @@ function buildSecurityAuditUrl(
 
   const url = new URL(
     `/${encodeURIComponent(ownerSegment)}/${encodeURIComponent(slug)}/security-audit`,
-    new URL(request.url).origin,
+    publicApiOrigin(request),
   );
   url.searchParams.set("version", version);
   return url.toString();
@@ -822,10 +901,12 @@ async function buildSecurityVerdictItem(
   }
 
   const security = buildVerifySecurity(version);
+  const staffCleared = isStaffClearedSecurityVerdict(result.moderationInfo);
   const reasons = buildSecurityVerdictReasons({
     isMalwareBlocked: result.moderationInfo?.isMalwareBlocked ?? false,
     securityPassed: security.passed,
     securityStatus: security.status,
+    staffCleared,
   });
 
   return {
@@ -840,7 +921,7 @@ async function buildSecurityVerdictItem(
     requestedVersion: item.version,
     version: version.version,
     createdAt: version.createdAt,
-    checkedAt: getVerifySecurityCheckedAt(security),
+    checkedAt: getEffectiveSecurityVerdictCheckedAt(security, result.moderationInfo),
     skillUrl: buildSkillPageUrl(request, result.owner, result.skill.slug),
     securityAuditUrl: buildSecurityAuditUrl(
       request,
@@ -848,7 +929,7 @@ async function buildSecurityVerdictItem(
       result.skill.slug,
       version.version,
     ),
-    security: buildSecurityVerdictSummary(security),
+    security: buildEffectiveSecurityVerdictSummary(security, result.moderationInfo),
   };
 }
 

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -47,6 +47,7 @@ const MAX_EXPORT_FILE_COUNT = 10_000;
 const MAX_EXPORT_PAGE_LIMIT = 250;
 const DEFAULT_EXPORT_PAGE_LIMIT = 250;
 const MAX_EXPORT_TOTAL_BYTES = 256 * 1024 * 1024;
+const MAX_SECURITY_VERDICT_ITEMS = 100;
 
 type SearchSkillEntry = {
   score: number;
@@ -175,6 +176,7 @@ type GetBySlugResult = {
     reason?: string;
   } | null;
 } | null;
+type GetBySlugOwner = NonNullable<GetBySlugResult>["owner"];
 
 type ListVersionsResult = {
   items: PublicSkillVersionResponse[];
@@ -437,6 +439,11 @@ type SkillVersionFingerprintSummary = {
   createdAt: number;
 };
 
+type SecurityVerdictRequestItem = {
+  slug: string;
+  version: string;
+};
+
 function normalizeVerificationStatus(value: string | null | undefined): NormalizedSecurityStatus {
   const normalized = value?.trim().toLowerCase();
   if (!normalized) return "pending";
@@ -559,11 +566,269 @@ function buildVerifyReasons(args: {
 }) {
   const reasons: string[] = [];
   if (!args.cardAvailable) reasons.push("card.missing");
+  reasons.push(
+    ...buildSecurityVerdictReasons({
+      isMalwareBlocked: args.isMalwareBlocked,
+      securityPassed: args.securityPassed,
+      securityStatus: args.securityStatus,
+    }),
+  );
+  return [...new Set(reasons)];
+}
+
+function buildSecurityVerdictReasons(args: {
+  isMalwareBlocked: boolean;
+  securityPassed: boolean;
+  securityStatus: NormalizedSecurityStatus;
+}) {
+  const reasons: string[] = [];
   if (args.isMalwareBlocked) reasons.push("moderation.malware_blocked");
   if (!args.securityPassed) reasons.push("security.status_not_clean");
   if (args.securityStatus === "pending") reasons.push("security.pending");
   if (args.securityStatus === "error") reasons.push("security.error");
   return [...new Set(reasons)];
+}
+
+function getVerifySecurityCheckedAt(security: ReturnType<typeof buildVerifySecurity>) {
+  const candidates = [
+    security.checkedAt,
+    security.signals.staticScan?.checkedAt,
+    security.signals.virusTotal?.checkedAt,
+    security.signals.skillSpector?.checkedAt,
+    security.signals.dependencyRegistry?.checkedAt,
+  ].filter((value): value is number => typeof value === "number");
+  return candidates.length > 0 ? Math.max(...candidates) : null;
+}
+
+function buildSecurityVerdictSummary(security: ReturnType<typeof buildVerifySecurity>) {
+  return {
+    status: security.status,
+    passed: security.passed,
+    rawStatus: security.rawStatus,
+    verdict: security.verdict,
+    confidence: security.confidence,
+    summary: security.summary,
+    model: security.model,
+    checkedAt: security.checkedAt,
+    signals: {
+      staticScan: security.signals.staticScan
+        ? {
+            status: security.signals.staticScan.status,
+            rawStatus: security.signals.staticScan.rawStatus,
+            reasonCodes: security.signals.staticScan.reasonCodes,
+            summary: security.signals.staticScan.summary,
+            engineVersion: security.signals.staticScan.engineVersion,
+            checkedAt: security.signals.staticScan.checkedAt,
+          }
+        : null,
+      virusTotal: security.signals.virusTotal
+        ? {
+            status: security.signals.virusTotal.status,
+            rawStatus: security.signals.virusTotal.rawStatus,
+            verdict: security.signals.virusTotal.verdict,
+            source: security.signals.virusTotal.source,
+            checkedAt: security.signals.virusTotal.checkedAt,
+          }
+        : null,
+      skillSpector: security.signals.skillSpector
+        ? {
+            status: security.signals.skillSpector.status,
+            rawStatus: security.signals.skillSpector.rawStatus,
+            score: security.signals.skillSpector.score,
+            severity: security.signals.skillSpector.severity,
+            recommendation: security.signals.skillSpector.recommendation,
+            issueCount: security.signals.skillSpector.issueCount,
+            scannerVersion: security.signals.skillSpector.scannerVersion,
+            checkedAt: security.signals.skillSpector.checkedAt,
+          }
+        : null,
+      dependencyRegistry: security.signals.dependencyRegistry
+        ? {
+            status: security.signals.dependencyRegistry.status,
+            rawStatus: security.signals.dependencyRegistry.rawStatus,
+            summary: security.signals.dependencyRegistry.summary,
+            checkedAt: security.signals.dependencyRegistry.checkedAt,
+          }
+        : null,
+    },
+  };
+}
+
+function isValidRequestedVersion(version: string) {
+  return version.length > 0 && version.length <= 128 && !/[\s/\\]/.test(version);
+}
+
+function parseSecurityVerdictItems(
+  payload: Record<string, unknown>,
+): { ok: true; items: SecurityVerdictRequestItem[] } | { ok: false; message: string } {
+  const items = payload.items;
+  if (!Array.isArray(items) || items.length < 1 || items.length > MAX_SECURITY_VERDICT_ITEMS) {
+    return { ok: false, message: `items must contain 1 to ${MAX_SECURITY_VERDICT_ITEMS} entries` };
+  }
+
+  const parsed: SecurityVerdictRequestItem[] = [];
+  const seen = new Set<string>();
+  for (const [index, item] of items.entries()) {
+    if (!item || typeof item !== "object") {
+      return { ok: false, message: `Invalid item at items[${index}]` };
+    }
+    const raw = item as Record<string, unknown>;
+    if (typeof raw.slug !== "string" || typeof raw.version !== "string") {
+      return { ok: false, message: `items[${index}] requires slug and version strings` };
+    }
+    if ("tag" in raw) {
+      return { ok: false, message: `items[${index}] uses version only; tag is not supported` };
+    }
+    const slug = raw.slug.trim().toLowerCase();
+    const version = raw.version.trim();
+    if (!validateSlug(slug)) {
+      return { ok: false, message: `Invalid slug at items[${index}]` };
+    }
+    if (!isValidRequestedVersion(version)) {
+      return { ok: false, message: `Invalid version at items[${index}]` };
+    }
+    const key = `${slug}@${version}`;
+    if (seen.has(key)) return { ok: false, message: `Duplicate item: ${key}` };
+    seen.add(key);
+    parsed.push({ slug, version });
+  }
+
+  return { ok: true, items: parsed };
+}
+
+function buildSkillPageUrl(request: Request, owner: GetBySlugOwner, slug: string) {
+  const origin = new URL(request.url).origin;
+  const ownerSegment = owner?.handle ?? owner?._id ?? null;
+  if (!ownerSegment) {
+    return new URL(`/api/v1/skills/${encodeURIComponent(slug)}`, origin).toString();
+  }
+  return new URL(
+    `/${encodeURIComponent(ownerSegment)}/${encodeURIComponent(slug)}`,
+    origin,
+  ).toString();
+}
+
+function buildSecurityAuditUrl(
+  request: Request,
+  owner: GetBySlugOwner,
+  slug: string,
+  version: string,
+) {
+  const ownerSegment = owner?.handle ?? owner?._id ?? null;
+  if (!ownerSegment) return null;
+
+  const url = new URL(
+    `/${encodeURIComponent(ownerSegment)}/${encodeURIComponent(slug)}/security-audit`,
+    new URL(request.url).origin,
+  );
+  url.searchParams.set("version", version);
+  return url.toString();
+}
+
+function buildSecurityVerdictError(
+  item: SecurityVerdictRequestItem,
+  code: string,
+  message: string,
+  reason: string,
+) {
+  return {
+    ok: false,
+    decision: "fail",
+    reasons: [reason],
+    requestedSlug: item.slug,
+    slug: item.slug,
+    requestedVersion: item.version,
+    version: null,
+    displayName: null,
+    publisherHandle: null,
+    publisherDisplayName: null,
+    createdAt: null,
+    checkedAt: null,
+    skillUrl: null,
+    securityAuditUrl: null,
+    security: null,
+    error: { code, message },
+  };
+}
+
+async function buildSecurityVerdictItem(
+  ctx: ActionCtx,
+  request: Request,
+  item: SecurityVerdictRequestItem,
+) {
+  const skillResult = (await ctx.runQuery(api.skills.getBySlug, {
+    slug: item.slug,
+  })) as GetBySlugResult;
+  if (!skillResult?.skill) {
+    return buildSecurityVerdictError(item, "skill_not_found", "Skill not found", "skill.not_found");
+  }
+
+  const version = (await ctx.runQuery(internal.skills.getVersionBySkillAndVersionInternal, {
+    skillId: skillResult.skill._id,
+    version: item.version,
+  })) as Doc<"skillVersions"> | null;
+  if (!version) {
+    return buildSecurityVerdictError(
+      item,
+      "version_not_found",
+      "Version not found",
+      "version.not_found",
+    );
+  }
+  if (version.softDeletedAt) {
+    return buildSecurityVerdictError(
+      item,
+      "version_unavailable",
+      "Version not available",
+      "version.unavailable",
+    );
+  }
+
+  const security = buildVerifySecurity(version);
+  const reasons = buildSecurityVerdictReasons({
+    isMalwareBlocked: skillResult.moderationInfo?.isMalwareBlocked ?? false,
+    securityPassed: security.passed,
+    securityStatus: security.status,
+  });
+
+  return {
+    ok: reasons.length === 0,
+    decision: reasons.length === 0 ? "pass" : "fail",
+    reasons,
+    requestedSlug: item.slug,
+    slug: skillResult.skill.slug,
+    displayName: skillResult.skill.displayName,
+    publisherHandle: skillResult.owner?.handle ?? null,
+    publisherDisplayName: skillResult.owner?.displayName ?? null,
+    requestedVersion: item.version,
+    version: version.version,
+    createdAt: version.createdAt,
+    checkedAt: getVerifySecurityCheckedAt(security),
+    skillUrl: buildSkillPageUrl(request, skillResult.owner, skillResult.skill.slug),
+    securityAuditUrl: buildSecurityAuditUrl(
+      request,
+      skillResult.owner,
+      skillResult.skill.slug,
+      version.version,
+    ),
+    security: buildSecurityVerdictSummary(security),
+  };
+}
+
+export async function skillSecurityVerdictsV1Handler(ctx: ActionCtx, request: Request) {
+  const rate = await applyRateLimit(ctx, request, "read");
+  if (!rate.ok) return rate.response;
+
+  const parsed = await parseJsonPayload(request, rate.headers);
+  if (!parsed.ok) return parsed.response;
+
+  const requestItems = parseSecurityVerdictItems(parsed.payload);
+  if (!requestItems.ok) return text(requestItems.message, 400, rate.headers);
+
+  const items = await chunkedParallel(requestItems.items, 20, (item) =>
+    buildSecurityVerdictItem(ctx, request, item),
+  );
+  return json({ schema: "clawhub.skill.security-verdicts.v1", items }, 200, rate.headers);
 }
 
 export async function searchSkillsV1Handler(ctx: ActionCtx, request: Request) {

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -176,7 +176,7 @@ type GetBySlugResult = {
     reason?: string;
   } | null;
 } | null;
-type GetBySlugOwner = NonNullable<GetBySlugResult>["owner"];
+type SkillUrlOwner = { _id: string; handle?: string | null } | null;
 
 type ListVersionsResult = {
   items: PublicSkillVersionResponse[];
@@ -275,6 +275,7 @@ const internalRefs = internal as unknown as {
     requestSkillRescanForUserInternal: unknown;
   };
   skills: {
+    getSecurityVerdictTargetInternal: unknown;
     reportSkillForUserInternal: unknown;
     listSkillReportsInternal: unknown;
     triageSkillReportForUserInternal: unknown;
@@ -444,6 +445,36 @@ type SecurityVerdictRequestItem = {
   version: string;
 };
 
+type VerifySecurityVersion = Pick<
+  Doc<"skillVersions">,
+  "staticScan" | "llmAnalysis" | "vtAnalysis" | "skillSpectorAnalysis" | "depRegistryAnalysis"
+>;
+
+type SecurityVerdictTargetResult = {
+  skill: {
+    _id: Id<"skills">;
+    slug: string;
+    displayName: string;
+  } | null;
+  owner: { _id: string; handle?: string | null; displayName?: string | null } | null;
+  moderationInfo?: {
+    isPendingScan: boolean;
+    isMalwareBlocked: boolean;
+    isSuspicious: boolean;
+    isHiddenByMod: boolean;
+    isRemoved: boolean;
+    verdict?: "clean" | "suspicious" | "malicious";
+    reasonCodes?: string[];
+    summary?: string;
+    engineVersion?: string;
+    updatedAt?: number;
+  } | null;
+  version:
+    | (VerifySecurityVersion &
+        Pick<Doc<"skillVersions">, "_id" | "version" | "createdAt" | "softDeletedAt">)
+    | null;
+} | null;
+
 function normalizeVerificationStatus(value: string | null | undefined): NormalizedSecurityStatus {
   const normalized = value?.trim().toLowerCase();
   if (!normalized) return "pending";
@@ -455,7 +486,7 @@ function normalizeVerificationStatus(value: string | null | undefined): Normaliz
   return normalizeSecurityStatus(normalized);
 }
 
-function buildVerifySecurity(version: Doc<"skillVersions">) {
+function buildVerifySecurity(version: VerifySecurityVersion) {
   const staticStatus = normalizeVerificationStatus(version.staticScan?.status);
   const clawRawStatus = version.llmAnalysis?.status ?? null;
   const clawStatus = normalizeVerificationStatus(version.llmAnalysis?.verdict ?? clawRawStatus);
@@ -659,9 +690,13 @@ function isValidRequestedVersion(version: string) {
 }
 
 function parseSecurityVerdictItems(
-  payload: Record<string, unknown>,
+  payload: unknown,
 ): { ok: true; items: SecurityVerdictRequestItem[] } | { ok: false; message: string } {
-  const items = payload.items;
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return { ok: false, message: "JSON body must be an object" };
+  }
+
+  const items = (payload as Record<string, unknown>).items;
   if (!Array.isArray(items) || items.length < 1 || items.length > MAX_SECURITY_VERDICT_ITEMS) {
     return { ok: false, message: `items must contain 1 to ${MAX_SECURITY_VERDICT_ITEMS} entries` };
   }
@@ -696,7 +731,7 @@ function parseSecurityVerdictItems(
   return { ok: true, items: parsed };
 }
 
-function buildSkillPageUrl(request: Request, owner: GetBySlugOwner, slug: string) {
+function buildSkillPageUrl(request: Request, owner: SkillUrlOwner, slug: string) {
   const origin = new URL(request.url).origin;
   const ownerSegment = owner?.handle ?? owner?._id ?? null;
   if (!ownerSegment) {
@@ -710,7 +745,7 @@ function buildSkillPageUrl(request: Request, owner: GetBySlugOwner, slug: string
 
 function buildSecurityAuditUrl(
   request: Request,
-  owner: GetBySlugOwner,
+  owner: SkillUrlOwner,
   slug: string,
   version: string,
 ) {
@@ -756,17 +791,19 @@ async function buildSecurityVerdictItem(
   request: Request,
   item: SecurityVerdictRequestItem,
 ) {
-  const skillResult = (await ctx.runQuery(api.skills.getBySlug, {
-    slug: item.slug,
-  })) as GetBySlugResult;
-  if (!skillResult?.skill) {
+  const result = await runQueryRef<SecurityVerdictTargetResult>(
+    ctx,
+    internalRefs.skills.getSecurityVerdictTargetInternal,
+    {
+      slug: item.slug,
+      version: item.version,
+    },
+  );
+  if (!result?.skill) {
     return buildSecurityVerdictError(item, "skill_not_found", "Skill not found", "skill.not_found");
   }
 
-  const version = (await ctx.runQuery(internal.skills.getVersionBySkillAndVersionInternal, {
-    skillId: skillResult.skill._id,
-    version: item.version,
-  })) as Doc<"skillVersions"> | null;
+  const version = result.version;
   if (!version) {
     return buildSecurityVerdictError(
       item,
@@ -786,7 +823,7 @@ async function buildSecurityVerdictItem(
 
   const security = buildVerifySecurity(version);
   const reasons = buildSecurityVerdictReasons({
-    isMalwareBlocked: skillResult.moderationInfo?.isMalwareBlocked ?? false,
+    isMalwareBlocked: result.moderationInfo?.isMalwareBlocked ?? false,
     securityPassed: security.passed,
     securityStatus: security.status,
   });
@@ -796,19 +833,19 @@ async function buildSecurityVerdictItem(
     decision: reasons.length === 0 ? "pass" : "fail",
     reasons,
     requestedSlug: item.slug,
-    slug: skillResult.skill.slug,
-    displayName: skillResult.skill.displayName,
-    publisherHandle: skillResult.owner?.handle ?? null,
-    publisherDisplayName: skillResult.owner?.displayName ?? null,
+    slug: result.skill.slug,
+    displayName: result.skill.displayName,
+    publisherHandle: result.owner?.handle ?? null,
+    publisherDisplayName: result.owner?.displayName ?? null,
     requestedVersion: item.version,
     version: version.version,
     createdAt: version.createdAt,
     checkedAt: getVerifySecurityCheckedAt(security),
-    skillUrl: buildSkillPageUrl(request, skillResult.owner, skillResult.skill.slug),
+    skillUrl: buildSkillPageUrl(request, result.owner, result.skill.slug),
     securityAuditUrl: buildSecurityAuditUrl(
       request,
-      skillResult.owner,
-      skillResult.skill.slug,
+      result.owner,
+      result.skill.slug,
       version.version,
     ),
     security: buildSecurityVerdictSummary(security),

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -2665,6 +2665,87 @@ export const getSkillBySlugInternal = internalQuery({
   },
 });
 
+export const getSecurityVerdictTargetInternal = internalQuery({
+  args: { slug: v.string(), version: v.string() },
+  handler: async (ctx, args) => {
+    const resolved = await resolveSkillBySlugOrAlias(ctx, args.slug);
+    const skill = resolved.skill;
+    if (!skill) return null;
+
+    const isMalwareBlocked = skill.moderationFlags?.includes("blocked.malware") ?? false;
+    const isSuspicious = skill.moderationFlags?.includes("flagged.suspicious") ?? false;
+    const isReviewFlagged = isSkillReviewFlagged(skill);
+    const overrideActive = Boolean(skill.manualOverride);
+    if (!isPublicSkillDoc(skill) && !isMalwareBlocked) return null;
+
+    const owner = toPublicPublisher(
+      await getOwnerPublisher(ctx, {
+        ownerPublisherId: skill.ownerPublisherId,
+        ownerUserId: skill.ownerUserId,
+      }),
+    );
+    if (!owner) return null;
+
+    const version = await ctx.db
+      .query("skillVersions")
+      .withIndex("by_skill_version", (q) => q.eq("skillId", skill._id).eq("version", args.version))
+      .unique();
+    const isPendingScan =
+      skill.moderationStatus === "hidden" && skill.moderationReason === "pending.scan";
+    const isHiddenByMod =
+      skill.moderationStatus === "hidden" && !isPendingScan && !isMalwareBlocked;
+    const isRemoved = skill.moderationStatus === "removed";
+    const showModerationInfo =
+      isMalwareBlocked || isSuspicious || isReviewFlagged || overrideActive;
+    const publicModerationSummary =
+      overrideActive && !isMalwareBlocked && !isSuspicious
+        ? "Security findings were reviewed by moderators and cleared for public use."
+        : skill.moderationSummary;
+
+    return {
+      skill: {
+        _id: skill._id,
+        slug: skill.slug,
+        displayName: skill.displayName,
+      },
+      owner: {
+        _id: owner._id,
+        handle: owner.handle ?? null,
+        displayName: owner.displayName ?? null,
+      },
+      moderationInfo: showModerationInfo
+        ? {
+            isPendingScan,
+            isMalwareBlocked,
+            isSuspicious,
+            isReviewFlagged,
+            isHiddenByMod,
+            isRemoved,
+            overrideActive,
+            verdict: skill.moderationVerdict,
+            reasonCodes: skill.moderationReasonCodes,
+            summary: publicModerationSummary,
+            engineVersion: skill.moderationEngineVersion,
+            updatedAt: skill.moderationEvaluatedAt,
+          }
+        : null,
+      version: version
+        ? {
+            _id: version._id,
+            version: version.version,
+            createdAt: version.createdAt,
+            softDeletedAt: version.softDeletedAt,
+            staticScan: version.staticScan,
+            llmAnalysis: version.llmAnalysis,
+            vtAnalysis: version.vtAnalysis,
+            skillSpectorAnalysis: version.skillSpectorAnalysis,
+            depRegistryAnalysis: version.depRegistryAnalysis,
+          }
+        : null,
+    };
+  },
+});
+
 export const getOwnerSkillActivityInternal = internalQuery({
   args: {
     ownerUserId: v.id("users"),

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -2665,6 +2665,90 @@ export const getSkillBySlugInternal = internalQuery({
   },
 });
 
+function compactSecurityVerdictVersion(version: Doc<"skillVersions">) {
+  return {
+    _id: version._id,
+    version: version.version,
+    createdAt: version.createdAt,
+    softDeletedAt: version.softDeletedAt,
+    ...(version.staticScan
+      ? {
+          staticScan: {
+            status: version.staticScan.status,
+            reasonCodes: version.staticScan.reasonCodes,
+            summary: version.staticScan.summary,
+            engineVersion: version.staticScan.engineVersion,
+            checkedAt: version.staticScan.checkedAt,
+          },
+        }
+      : {}),
+    ...(version.llmAnalysis
+      ? {
+          llmAnalysis: {
+            status: version.llmAnalysis.status,
+            ...(version.llmAnalysis.verdict !== undefined
+              ? { verdict: version.llmAnalysis.verdict }
+              : {}),
+            ...(version.llmAnalysis.confidence !== undefined
+              ? { confidence: version.llmAnalysis.confidence }
+              : {}),
+            ...(version.llmAnalysis.summary !== undefined
+              ? { summary: version.llmAnalysis.summary }
+              : {}),
+            ...(version.llmAnalysis.model !== undefined
+              ? { model: version.llmAnalysis.model }
+              : {}),
+            checkedAt: version.llmAnalysis.checkedAt,
+          },
+        }
+      : {}),
+    ...(version.vtAnalysis
+      ? {
+          vtAnalysis: {
+            status: version.vtAnalysis.status,
+            ...(version.vtAnalysis.verdict !== undefined
+              ? { verdict: version.vtAnalysis.verdict }
+              : {}),
+            ...(version.vtAnalysis.source !== undefined
+              ? { source: version.vtAnalysis.source }
+              : {}),
+            checkedAt: version.vtAnalysis.checkedAt,
+          },
+        }
+      : {}),
+    ...(version.skillSpectorAnalysis
+      ? {
+          skillSpectorAnalysis: {
+            status: version.skillSpectorAnalysis.status,
+            ...(version.skillSpectorAnalysis.score !== undefined
+              ? { score: version.skillSpectorAnalysis.score }
+              : {}),
+            ...(version.skillSpectorAnalysis.severity !== undefined
+              ? { severity: version.skillSpectorAnalysis.severity }
+              : {}),
+            ...(version.skillSpectorAnalysis.recommendation !== undefined
+              ? { recommendation: version.skillSpectorAnalysis.recommendation }
+              : {}),
+            issueCount: version.skillSpectorAnalysis.issueCount,
+            ...(version.skillSpectorAnalysis.scannerVersion !== undefined
+              ? { scannerVersion: version.skillSpectorAnalysis.scannerVersion }
+              : {}),
+            checkedAt: version.skillSpectorAnalysis.checkedAt,
+          },
+        }
+      : {}),
+    ...(version.depRegistryAnalysis
+      ? {
+          depRegistryAnalysis: {
+            status: version.depRegistryAnalysis.status,
+            summary: version.depRegistryAnalysis.summary,
+            checkedAt: version.depRegistryAnalysis.checkedAt,
+          },
+        }
+      : {}),
+  };
+}
+
 export const getSecurityVerdictTargetInternal = internalQuery({
   args: { slug: v.string(), version: v.string() },
   handler: async (ctx, args) => {
@@ -2729,19 +2813,7 @@ export const getSecurityVerdictTargetInternal = internalQuery({
             updatedAt: skill.moderationEvaluatedAt,
           }
         : null,
-      version: version
-        ? {
-            _id: version._id,
-            version: version.version,
-            createdAt: version.createdAt,
-            softDeletedAt: version.softDeletedAt,
-            staticScan: version.staticScan,
-            llmAnalysis: version.llmAnalysis,
-            vtAnalysis: version.vtAnalysis,
-            skillSpectorAnalysis: version.skillSpectorAnalysis,
-            depRegistryAnalysis: version.depRegistryAnalysis,
-          }
-        : null,
+      version: version ? compactSecurityVerdictVersion(version) : null,
     };
   },
 });

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -385,6 +385,74 @@ Notes:
 - `security.signals` contains supporting scanner evidence such as `staticScan`, `virusTotal`, `skillSpector`, and `dependencyRegistry`.
 - `provenance` is `server-resolved-github-import` only when ClawHub resolved and stored a GitHub repo/ref/commit/path during publish or import; otherwise it is `unavailable`.
 
+### `POST /api/v1/skills/-/security-verdicts`
+
+Returns current compact security verdicts for exact skill versions. This
+collection endpoint is intended for clients that already know which installed
+ClawHub skill versions they need to display, such as OpenClaw Control UI.
+
+Request:
+
+```json
+{
+  "items": [{ "slug": "gifgrep", "version": "1.2.3" }]
+}
+```
+
+Notes:
+
+- `items` must contain 1-100 unique `{ slug, version }` pairs.
+- Results are per item; one missing skill or version does not fail the whole response.
+- The response is security-only. It does not include Skill Card data, generated card status, artifact file lists, or detailed scanner payloads.
+- `security.signals` contains status-level supporting evidence only; use `/scan` or the ClawHub security-audit page for full scanner details.
+- Skill Card absence does not affect this endpoint's `ok`, `decision`, or `reasons`; clients should read installed `skill-card.md` locally when they need card content.
+- Use `/verify` when you need the single-skill Skill Card verification envelope, `/card` when you need generated card markdown, and `/scan` when you need detailed scanner data.
+
+Response:
+
+```json
+{
+  "schema": "clawhub.skill.security-verdicts.v1",
+  "items": [
+    {
+      "ok": true,
+      "decision": "pass",
+      "reasons": [],
+      "requestedSlug": "gifgrep",
+      "slug": "gifgrep",
+      "displayName": "GifGrep",
+      "publisherHandle": "steipete",
+      "publisherDisplayName": "Peter",
+      "requestedVersion": "1.2.3",
+      "version": "1.2.3",
+      "createdAt": 0,
+      "checkedAt": 0,
+      "skillUrl": "https://clawhub.ai/steipete/gifgrep",
+      "securityAuditUrl": "https://clawhub.ai/steipete/gifgrep/security-audit?version=1.2.3",
+      "security": {
+        "status": "clean",
+        "passed": true,
+        "signals": {
+          "staticScan": { "status": "clean", "reasonCodes": [] },
+          "virusTotal": null,
+          "skillSpector": null,
+          "dependencyRegistry": null
+        }
+      }
+    },
+    {
+      "ok": false,
+      "decision": "fail",
+      "reasons": ["version.not_found"],
+      "requestedSlug": "missing-version",
+      "requestedVersion": "1.0.0",
+      "error": { "code": "version_not_found", "message": "Version not found" },
+      "security": null
+    }
+  ]
+}
+```
+
 ### `GET /api/v1/skills/{slug}/file`
 
 Returns raw text content.


### PR DESCRIPTION
## Summary

- Add `POST /api/v1/skills/-/security-verdicts` for bulk exact-version ClawHub skill verdict lookup.
- Return compact top-level verdict metadata and status-level scanner signals without Skill Card data or detailed scan payloads.
- Document the new endpoint and preserve public `clawhub.ai` links for production Convex-site requests.

## Verification

- `bun run setup:worktree -- --quiet && bunx convex codegen` (tracked no-op)
- `bunx vitest run convex/httpApiV1.handlers.test.ts --testNamePattern "bulk skill security verdict|bulk verdict|staff-cleared|public site origin|malformed bulk|reports .* bulk|npm mirror falls back|npm mirror uses forwarded"`
- `bunx vitest run convex/httpApiV1.handlers.test.ts`
- `bunx tsc --noEmit --pretty false`
- `git diff --check`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

## Review Notes

- Fresh read-only subagent review found and verified fixes for null/scalar body handling and over-fetching via the public detail query.
- Repo-local `$autoreview` initially found three accepted findings: staff-cleared moderation override handling, production public URL generation, and scanner payload stripping. All three were fixed, then autoreview was rerun clean.

Linear: CLAW-190
