### PR TITLE
Clarify ClawHub report scope

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+Use GitHub Security Advisories for vulnerabilities in ClawHub itself.
+
+Good ClawHub advisory reports include bugs in:
+
+- the ClawHub website, API, or CLI
+- registry publishing, downloads, installs, or artifact integrity
+- authentication, authorization, or API tokens
+- scanning, moderation, or report handling
+
+Do not use ClawHub advisories for vulnerabilities in a third-party skill or
+plugin's own source code. Report those directly to the publisher or source
+repository linked from the ClawHub listing.
+
+Use ClawHub's listing reports for genuinely malicious or deceptive marketplace
+content, such as malicious listings, misleading metadata, undeclared
+permissions, suspicious install instructions, scam comments, impersonation,
+trademark misuse, or policy violations.

--- a/docs/moderation.md
+++ b/docs/moderation.md
@@ -25,8 +25,9 @@ See also [Acceptable usage](./acceptable-usage.md).
 
 Signed-in users can report skills, plugins, packages, and comments.
 
-Good reports are specific and actionable. Useful reasons include:
+Use ClawHub reports only for unsafe marketplace content, such as:
 
+- malicious listings
 - misleading metadata
 - undeclared credentials or permission requirements
 - suspicious install instructions
@@ -34,7 +35,21 @@ Good reports are specific and actionable. Useful reasons include:
 - bad-faith registrations or trademark misuse
 - content that violates [Acceptable usage](./acceptable-usage.md)
 
-Abuse of reporting can itself lead to account action.
+Use the **Report skill** button on a skill page, or the package reporting
+command/API for packages.
+
+Do not use ClawHub reports for vulnerabilities in a third-party skill or
+plugin's own source code. Report those directly to the publisher or source
+repository linked from the listing. ClawHub does not maintain or patch
+third-party skill or plugin code.
+
+GitHub Security Advisories for `openclaw/clawhub` are for vulnerabilities in
+ClawHub itself. Examples include bugs in the website, API, CLI, registry, auth,
+scanning, moderation, or download/install trust boundaries. Do not use ClawHub
+advisories for vulnerabilities in third-party skills or plugins.
+
+Good reports are specific and actionable. Abuse of reporting can itself lead to
+account action.
 
 ## Moderation holds
 


### PR DESCRIPTION
## Summary

- Adds `SECURITY.md` to define which GitHub Security Advisories belong in `openclaw/clawhub`.
- Clarifies that ClawHub listing reports are only for unsafe marketplace content, such as malicious listings, deceptive listings, scams, impersonation, and policy violations.
- Directs vulnerabilities in third-party skill or plugin source code to the publisher or linked source repository instead of ClawHub reports or ClawHub GHSAs.

## Verification

- `bun run format:check docs/moderation.md SECURITY.md`
- `bun run lint`
