### PR TITLE
fix(web): polish skill and plugin upload forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Fixes
 
 - API/CLI: report Skill Card verification with flattened skill/version metadata, ClawScan verdict fields at `security.*`, and supporting scanner evidence under `security.signals`.
-- Web: polish skill and plugin publish upload forms with clearer post-upload file states, validation feedback, and submit gating (#2377) (thanks @vyctorbrzezowski).
 
 ## 0.18.0 - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - API/CLI: report Skill Card verification with flattened skill/version metadata, ClawScan verdict fields at `security.*`, and supporting scanner evidence under `security.signals`.
+- Web: polish skill and plugin publish upload forms with clearer post-upload file states, validation feedback, and submit gating (#2377) (thanks @vyctorbrzezowski).
 
 ## 0.18.0 - 2026-05-25
 

--- a/e2e/local-auth/helpers.ts
+++ b/e2e/local-auth/helpers.ts
@@ -75,28 +75,62 @@ export async function signInAsLocalOwner(page: Page) {
   return await signInAsLocalPublisher(page, "owner");
 }
 
+function parseOwnerHandle(text: string) {
+  return text.match(/@([a-z0-9][a-z0-9-]*)/i)?.[1] ?? "";
+}
+
+async function isNativeOwnerSelect(page: Page, selector: string) {
+  const ownerControl = page.locator(selector);
+  await ownerControl.waitFor({ state: "attached" });
+  return await ownerControl.evaluate((node) => node.tagName.toLowerCase() === "select");
+}
+
+async function getSelectedOwnerHandle(page: Page, selector: string) {
+  const ownerControl = page.locator(selector);
+  if (await isNativeOwnerSelect(page, selector)) {
+    return await ownerControl.inputValue();
+  }
+  return parseOwnerHandle(await ownerControl.innerText());
+}
+
+export async function expectOwnerHandleSelected(page: Page, selector: string, ownerHandle: string) {
+  await expect
+    .poll(async () => await getSelectedOwnerHandle(page, selector), { timeout: 15_000 })
+    .toBe(ownerHandle);
+}
+
+export async function selectOwnerHandle(page: Page, selector: string, ownerHandle: string) {
+  const ownerControl = page.locator(selector);
+  if (await isNativeOwnerSelect(page, selector)) {
+    await ownerControl.selectOption(ownerHandle);
+  } else {
+    await ownerControl.click();
+    await page
+      .getByRole("option", {
+        name: new RegExp(`@${escapeRegExp(ownerHandle)}(?:\\b|\\s|·)`, "i"),
+      })
+      .click();
+  }
+  await expectOwnerHandleSelected(page, selector, ownerHandle);
+}
+
 export async function signInAsLocalPublisher(page: Page, persona: DevPersona) {
   await signInAsLocalPersona(page, persona);
   await page.goto("/skills/publish", { waitUntil: "domcontentloaded" });
   await expect(page.getByRole("heading", { name: "Publish a skill" })).toBeVisible();
-  const ownerSelect = page.locator("#ownerHandle");
   await expect
     .poll(
       async () => {
-        const value = await ownerSelect.inputValue();
-        const optionValues = await ownerSelect
-          .locator("option")
-          .evaluateAll((options) => options.map((option) => (option as HTMLOptionElement).value));
-        const isCurrentOption = value ? optionValues.includes(value) : false;
+        const value = await getSelectedOwnerHandle(page, "#ownerHandle");
         // The owner persona can briefly render the user handle before the
         // personal publisher subscription reconciles to the publishable handle.
-        if (!isCurrentOption || (persona === "owner" && value === "local")) return "";
+        if (!value || (persona === "owner" && value === "local")) return "";
         return value;
       },
       { timeout: 15_000 },
     )
     .not.toBe("");
-  const ownerHandle = await ownerSelect.inputValue();
+  const ownerHandle = await getSelectedOwnerHandle(page, "#ownerHandle");
   expect(ownerHandle.toLowerCase()).toContain("local");
   return ownerHandle;
 }
@@ -125,19 +159,21 @@ export async function publishSkillVersion(
     "utf8",
   );
 
-  const ownerSelect = page.locator("#ownerHandle");
-  await ownerSelect.selectOption(args.ownerHandle);
-  await expect(ownerSelect).toHaveValue(args.ownerHandle);
+  await selectOwnerHandle(page, "#ownerHandle", args.ownerHandle);
   await page.locator("#slug").fill(args.slug);
   await page.locator("#displayName").fill(args.displayName);
   await page.locator("#version").fill(args.version);
   await page.locator("#tags").fill("latest, stable");
-  await page.locator("#changelog").fill(args.changelog);
-  await page.getByLabel(/i have the rights to this skill/i).check();
+  const changelog = page.locator("#changelog");
+  if ((await changelog.count()) > 0) {
+    await changelog.fill(args.changelog);
+  }
+  await page.getByLabel(/i have the rights to publish this skill/i).check();
   await page.getByTestId("upload-input").setInputFiles(skillDir);
 
-  await expect(page.getByText("All checks passed.")).toBeVisible();
-  await page.getByRole("button", { name: "Publish skill" }).click();
+  const publishButton = page.getByRole("button", { name: "Publish skill" });
+  await expect(publishButton).toBeEnabled();
+  await publishButton.click();
   await expect(page).toHaveURL(new RegExp(`/[^/]+/${escapeRegExp(args.slug)}$`), {
     timeout: 60_000,
   });

--- a/e2e/local-auth/publish-skill-lifecycle.pw.test.ts
+++ b/e2e/local-auth/publish-skill-lifecycle.pw.test.ts
@@ -3,7 +3,7 @@ import convexBrowser from "convex/browser";
 import { api } from "../../convex/_generated/api";
 import type { Id } from "../../convex/_generated/dataModel";
 import { expectHealthyPage, trackRuntimeErrors, waitForHydration } from "../helpers/runtimeErrors";
-import { publishSkillVersion, signInAsLocalPublisher } from "./helpers";
+import { expectOwnerHandleSelected, publishSkillVersion, signInAsLocalPublisher } from "./helpers";
 
 test.skip(
   process.env.VITE_ENABLE_DEV_AUTH !== "1",
@@ -198,7 +198,7 @@ test("skill publishers can create a skill and publish a new version", async ({
   await expect(page.locator("#slug")).toHaveValue(slug);
   await expect(page.locator("#displayName")).toHaveValue(displayName);
   await expect(page.locator("#version")).toHaveValue("1.0.1");
-  await expect(page.locator("#ownerHandle")).toHaveValue(ownerHandle);
+  await expectOwnerHandleSelected(page, "#ownerHandle", ownerHandle);
 
   await publishSkillVersion(page, testInfo, {
     ownerHandle,

--- a/src/__tests__/plugins-publish-route.test.tsx
+++ b/src/__tests__/plugins-publish-route.test.tsx
@@ -636,6 +636,6 @@ describe("plugins publish route", () => {
     ).toBeTruthy();
     expect(
       screen.getByRole("button", { name: "Publish plugin" }).getAttribute("disabled"),
-    ).toBeNull();
+    ).not.toBeNull();
   });
 });

--- a/src/__tests__/plugins-publish-route.test.tsx
+++ b/src/__tests__/plugins-publish-route.test.tsx
@@ -230,7 +230,7 @@ describe("plugins publish route", () => {
       expect(screen.getByDisplayValue("1.2.3")).toBeTruthy();
       expect(screen.getByDisplayValue("openclaw/demo-plugin")).toBeTruthy();
       expect(screen.getByPlaceholderText("Plugin name").getAttribute("disabled")).toBeNull();
-      expect(screen.getByText("Commit SHA is required.")).toBeTruthy();
+      expect(screen.getByText(/Complete commit SHA to publish/i)).toBeTruthy();
     });
 
     fireEvent.change(screen.getByPlaceholderText("Full commit SHA"), {
@@ -310,15 +310,12 @@ describe("plugins publish route", () => {
     fireEvent.change(getFileInput(), { target: { files: [packageJson, manifest] } });
 
     await waitFor(() => {
-      expect(screen.getByText(/Missing required OpenClaw package metadata:/i)).toBeTruthy();
+      expect(screen.getByText(/Fix package metadata:/i)).toBeTruthy();
     });
 
     expect(screen.getByText(/openclaw\.compat\.pluginApi/i)).toBeTruthy();
     expect(screen.getByText(/openclaw\.build\.openclawVersion/i)).toBeTruthy();
-    const docsLink = screen.getByRole("link", { name: /Plugin Setup and Config/i });
-    expect(docsLink.getAttribute("href")).toBe(DocsLinks.openclaw.pluginPackageMetadata);
-    expect(docsLink.getAttribute("target")).toBe("_blank");
-    expect(docsLink.getAttribute("rel")).toBe("noopener noreferrer");
+    expect(screen.getByText("Missing metadata")).toBeTruthy();
     expect(
       screen.getByRole("button", { name: "Publish plugin" }).getAttribute("disabled"),
     ).not.toBeNull();
@@ -353,8 +350,9 @@ describe("plugins publish route", () => {
     await waitFor(() => {
       expect(screen.getByDisplayValue("@openclaw/dronzer")).toBeTruthy();
       expect(
-        screen.getByText(/Package scope "@openclaw" must match selected owner "@vintageayu"/i),
-      ).toBeTruthy();
+        screen.getAllByText(/Package scope "@openclaw" must match selected owner "@vintageayu"/i)
+          .length,
+      ).toBeGreaterThan(0);
     });
 
     const docsLink = screen.getByRole("link", { name: /Learn how publishing works/i });
@@ -377,10 +375,10 @@ describe("plugins publish route", () => {
     fireEvent.change(getFileInput(), { target: { files: [bigFile] } });
 
     await waitFor(() => {
-      expect(screen.getByText(/Each file must be 10MB or smaller/i)).toBeTruthy();
+      expect(screen.getAllByText(/Each file must be 10MB or smaller/i).length).toBeGreaterThan(0);
     });
 
-    const summaryBorders = document.querySelectorAll(".border-emerald-300\\/40");
+    const summaryBorders = document.querySelectorAll(".border-emerald-300\\/45");
     expect(summaryBorders.length).toBe(0);
   });
 
@@ -426,8 +424,8 @@ describe("plugins publish route", () => {
       expect(screen.queryByText("Bundle plugin")).toBeNull();
       expect(screen.getByText("Agent metadata")).toBeTruthy();
       expect(screen.queryByPlaceholderText("Bundle format")).toBeNull();
-      expect(screen.getByText(/Choose archive/i)).toBeTruthy();
-      expect(screen.getByText(/Choose folder/i)).toBeTruthy();
+      expect(screen.getByText(/Replace package/i)).toBeTruthy();
+      expect(screen.getByText(/Clear package/i)).toBeTruthy();
     });
     expect(publishRelease).not.toHaveBeenCalled();
   });
@@ -476,12 +474,8 @@ describe("plugins publish route", () => {
       expect(screen.getByDisplayValue("0.2.9")).toBeTruthy();
       expect(screen.getByDisplayValue("comet-ml/opik-openclaw")).toBeTruthy();
       expect(screen.getByText(/Package detected/i)).toBeTruthy();
-      expect(
-        screen.getByText(
-          /Autofilled: package type, plugin name, display name, version, source repo, compatibility\./i,
-        ),
-      ).toBeTruthy();
       expect(screen.queryByText(/^Compatibility:/i)).toBeNull();
+      expect(screen.queryByText("Compatibility")).toBeNull();
       expect(screen.getByText("Package manifest")).toBeTruthy();
       expect(screen.getByText("Plugin manifest")).toBeTruthy();
       expect(screen.queryByText("opik-openclaw-0.2.9/package.json")).toBeNull();
@@ -527,7 +521,7 @@ describe("plugins publish route", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText(/Ignored 1 package files/i)).toBeTruthy();
+      expect(screen.getByText(/Ignored: node_modules\/dep\/index\.js/i)).toBeTruthy();
     });
 
     fireEvent.change(screen.getByLabelText("ClawScan note"), {
@@ -592,7 +586,9 @@ describe("plugins publish route", () => {
     fireEvent.change(getFileInput(), { target: { files: [packageJson, manifest, huge] } });
 
     await waitFor(() => {
-      expect(screen.getByText(/Each file must be 10MB or smaller: plugin\.wasm/i)).toBeTruthy();
+      expect(
+        screen.getAllByText(/Each file must be 10MB or smaller: plugin\.wasm/i).length,
+      ).toBeGreaterThan(0);
     });
     expect(
       screen.getByRole("button", { name: "Publish plugin" }).getAttribute("disabled"),

--- a/src/__tests__/plugins-publish-route.test.tsx
+++ b/src/__tests__/plugins-publish-route.test.tsx
@@ -101,6 +101,7 @@ describe("plugins publish route", () => {
           handle: "vintageayu",
           displayName: "VintageAyu",
           kind: "user",
+          image: "https://example.com/vintageayu.png",
         },
         role: "owner",
       },
@@ -157,6 +158,8 @@ describe("plugins publish route", () => {
     expect(screen.getByPlaceholderText("Display name").getAttribute("disabled")).not.toBeNull();
     expect(screen.getByPlaceholderText("Version").getAttribute("disabled")).not.toBeNull();
     expect(screen.getByPlaceholderText("Changelog").getAttribute("disabled")).not.toBeNull();
+    expect(screen.getByLabelText("Owner").textContent).toContain("@vintageayu · VintageAyu");
+    expect(document.querySelector('img[src="https://example.com/vintageayu.png"]')).toBeTruthy();
     expect(screen.getByRole("button", { name: "Publish" }).getAttribute("disabled")).not.toBeNull();
   });
 
@@ -175,7 +178,7 @@ describe("plugins publish route", () => {
     expect(archiveClick).not.toHaveBeenCalled();
   });
 
-  it("opens only the archive picker when clicking Browse files", () => {
+  it("opens only the archive picker when clicking Choose archive", () => {
     renderPublishRoute();
 
     const [archiveInput, directoryInput] = getFileInputs();
@@ -184,7 +187,7 @@ describe("plugins publish route", () => {
     archiveInput.click = archiveClick;
     directoryInput.click = directoryClick;
 
-    fireEvent.click(screen.getByRole("button", { name: "Browse files" }));
+    fireEvent.click(screen.getByRole("button", { name: "Choose archive" }));
 
     expect(archiveClick).toHaveBeenCalledTimes(1);
     expect(directoryClick).not.toHaveBeenCalled();
@@ -225,6 +228,7 @@ describe("plugins publish route", () => {
       expect(screen.getByDisplayValue("1.2.3")).toBeTruthy();
       expect(screen.getByDisplayValue("openclaw/demo-plugin")).toBeTruthy();
       expect(screen.getByPlaceholderText("Plugin name").getAttribute("disabled")).toBeNull();
+      expect(screen.getByText("Source commit is required.")).toBeTruthy();
     });
 
     fireEvent.change(screen.getByPlaceholderText("Changelog"), {
@@ -415,11 +419,11 @@ describe("plugins publish route", () => {
       expect(screen.getByDisplayValue("demo-bundle")).toBeTruthy();
       expect(screen.getByDisplayValue("Demo Bundle")).toBeTruthy();
       expect(screen.getByDisplayValue("0.4.0")).toBeTruthy();
-      expect(screen.getAllByRole("combobox")[0].textContent).toBe("Code plugin");
+      expect(screen.getByText("Code plugin")).toBeTruthy();
       expect(screen.queryByText("Bundle plugin")).toBeNull();
       expect(screen.getByText("Agent metadata")).toBeTruthy();
       expect(screen.queryByPlaceholderText("Bundle format")).toBeNull();
-      expect(screen.getByText(/Browse files/i)).toBeTruthy();
+      expect(screen.getByText(/Choose archive/i)).toBeTruthy();
       expect(screen.getByText(/Choose folder/i)).toBeTruthy();
     });
     expect(publishRelease).not.toHaveBeenCalled();
@@ -519,7 +523,7 @@ describe("plugins publish route", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText(/Ignored 1 files/i)).toBeTruthy();
+      expect(screen.getByText(/Ignored 1 package files/i)).toBeTruthy();
     });
 
     fireEvent.change(screen.getByPlaceholderText("Changelog"), {

--- a/src/__tests__/plugins-publish-route.test.tsx
+++ b/src/__tests__/plugins-publish-route.test.tsx
@@ -101,7 +101,7 @@ describe("plugins publish route", () => {
           handle: "vintageayu",
           displayName: "VintageAyu",
           kind: "user",
-          image: "https://example.com/vintageayu.png",
+          image: "/clawd-logo.png",
         },
         role: "owner",
       },
@@ -159,7 +159,7 @@ describe("plugins publish route", () => {
     expect(screen.getByPlaceholderText("Version").getAttribute("disabled")).not.toBeNull();
     expect(screen.queryByPlaceholderText("Describe what changed in this release...")).toBeNull();
     expect(screen.getByLabelText("Owner").textContent).toContain("@vintageayu · VintageAyu");
-    expect(document.querySelector('img[src="https://example.com/vintageayu.png"]')).toBeTruthy();
+    expect(document.querySelector('img[src="/clawd-logo.png"]')).toBeTruthy();
     expect(
       screen.getByRole("button", { name: "Publish plugin" }).getAttribute("disabled"),
     ).not.toBeNull();

--- a/src/__tests__/plugins-publish-route.test.tsx
+++ b/src/__tests__/plugins-publish-route.test.tsx
@@ -146,21 +146,23 @@ describe("plugins publish route", () => {
     expect(
       screen.getByText("You need to be signed in to publish plugins on ClawHub."),
     ).toBeTruthy();
-    expect(screen.queryByText(/Upload plugin code to detect the package shape/i)).toBeNull();
+    expect(screen.queryByText(/Upload plugin code first/i)).toBeNull();
     expect(screen.queryByPlaceholderText("Plugin name")).toBeNull();
   });
 
   it("keeps metadata inputs locked until plugin code is uploaded", () => {
     renderPublishRoute();
 
-    expect(screen.getByText(/Upload plugin code to detect the package shape/i)).toBeTruthy();
+    expect(screen.getByText(/Upload plugin code first/i)).toBeTruthy();
     expect(screen.getByPlaceholderText("Plugin name").getAttribute("disabled")).not.toBeNull();
     expect(screen.getByPlaceholderText("Display name").getAttribute("disabled")).not.toBeNull();
     expect(screen.getByPlaceholderText("Version").getAttribute("disabled")).not.toBeNull();
-    expect(screen.getByPlaceholderText("Changelog").getAttribute("disabled")).not.toBeNull();
+    expect(screen.queryByPlaceholderText("Describe what changed in this release...")).toBeNull();
     expect(screen.getByLabelText("Owner").textContent).toContain("@vintageayu · VintageAyu");
     expect(document.querySelector('img[src="https://example.com/vintageayu.png"]')).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Publish" }).getAttribute("disabled")).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Publish plugin" }).getAttribute("disabled"),
+    ).not.toBeNull();
   });
 
   it("opens only the directory picker when clicking Choose folder", () => {
@@ -228,20 +230,17 @@ describe("plugins publish route", () => {
       expect(screen.getByDisplayValue("1.2.3")).toBeTruthy();
       expect(screen.getByDisplayValue("openclaw/demo-plugin")).toBeTruthy();
       expect(screen.getByPlaceholderText("Plugin name").getAttribute("disabled")).toBeNull();
-      expect(screen.getByText("Source commit is required.")).toBeTruthy();
+      expect(screen.getByText("Commit SHA is required.")).toBeTruthy();
     });
 
-    fireEvent.change(screen.getByPlaceholderText("Changelog"), {
-      target: { value: "Initial release" },
-    });
-    fireEvent.change(screen.getByPlaceholderText("Source commit"), {
+    fireEvent.change(screen.getByPlaceholderText("Full commit SHA"), {
       target: { value: "abc123" },
     });
-    fireEvent.change(screen.getByPlaceholderText("Source ref (tag or branch)"), {
+    fireEvent.change(screen.getByPlaceholderText("v1.0.0 or main"), {
       target: { value: "refs/tags/v1.2.3" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Publish" }));
+    fireEvent.click(screen.getByRole("button", { name: "Publish plugin" }));
 
     await waitFor(() => {
       expect(publishRelease).toHaveBeenCalledTimes(1);
@@ -255,7 +254,7 @@ describe("plugins publish route", () => {
         displayName: "Demo Plugin",
         family: "code-plugin",
         version: "1.2.3",
-        changelog: "Initial release",
+        changelog: "",
         source: expect.objectContaining({
           kind: "github",
           repo: "openclaw/demo-plugin",
@@ -320,7 +319,9 @@ describe("plugins publish route", () => {
     expect(docsLink.getAttribute("href")).toBe(DocsLinks.openclaw.pluginPackageMetadata);
     expect(docsLink.getAttribute("target")).toBe("_blank");
     expect(docsLink.getAttribute("rel")).toBe("noopener noreferrer");
-    expect(screen.getByRole("button", { name: "Publish" }).getAttribute("disabled")).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Publish plugin" }).getAttribute("disabled"),
+    ).not.toBeNull();
     expect(publishRelease).not.toHaveBeenCalled();
   });
 
@@ -360,7 +361,9 @@ describe("plugins publish route", () => {
     expect(docsLink.getAttribute("href")).toBe(DocsLinks.clawhub.packageScopeFaq);
     expect(docsLink.getAttribute("target")).toBe("_blank");
     expect(docsLink.getAttribute("rel")).toBe("noopener noreferrer");
-    expect(screen.getByRole("button", { name: "Publish" }).getAttribute("disabled")).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Publish plugin" }).getAttribute("disabled"),
+    ).not.toBeNull();
     expect(publishRelease).not.toHaveBeenCalled();
   });
 
@@ -472,12 +475,13 @@ describe("plugins publish route", () => {
       expect(screen.getByDisplayValue("Opik")).toBeTruthy();
       expect(screen.getByDisplayValue("0.2.9")).toBeTruthy();
       expect(screen.getByDisplayValue("comet-ml/opik-openclaw")).toBeTruthy();
-      expect(screen.getByText(/Metadata detected and prefilled/i)).toBeTruthy();
+      expect(screen.getByText(/Package detected/i)).toBeTruthy();
       expect(
         screen.getByText(
-          /Autofilled package type, plugin name, display name, version, source repo, compatibility\./i,
+          /Autofilled: package type, plugin name, display name, version, source repo, compatibility\./i,
         ),
       ).toBeTruthy();
+      expect(screen.queryByText(/^Compatibility:/i)).toBeNull();
       expect(screen.getByText("Package manifest")).toBeTruthy();
       expect(screen.getByText("Plugin manifest")).toBeTruthy();
       expect(screen.queryByText("opik-openclaw-0.2.9/package.json")).toBeNull();
@@ -526,20 +530,17 @@ describe("plugins publish route", () => {
       expect(screen.getByText(/Ignored 1 package files/i)).toBeTruthy();
     });
 
-    fireEvent.change(screen.getByPlaceholderText("Changelog"), {
-      target: { value: "Initial release" },
-    });
     fireEvent.change(screen.getByLabelText("ClawScan note"), {
       target: { value: "Native host access is limited to the OpenClaw extension bridge." },
     });
-    fireEvent.change(screen.getByPlaceholderText("Source repo (owner/repo)"), {
+    fireEvent.change(screen.getByPlaceholderText("owner/repo"), {
       target: { value: "openclaw/demo-plugin" },
     });
-    fireEvent.change(screen.getByPlaceholderText("Source commit"), {
+    fireEvent.change(screen.getByPlaceholderText("Full commit SHA"), {
       target: { value: "abc123" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Publish" }));
+    fireEvent.click(screen.getByRole("button", { name: "Publish plugin" }));
 
     await waitFor(() => {
       expect(publishRelease).toHaveBeenCalledTimes(1);
@@ -593,7 +594,9 @@ describe("plugins publish route", () => {
     await waitFor(() => {
       expect(screen.getByText(/Each file must be 10MB or smaller: plugin\.wasm/i)).toBeTruthy();
     });
-    expect(screen.getByRole("button", { name: "Publish" }).getAttribute("disabled")).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Publish plugin" }).getAttribute("disabled"),
+    ).not.toBeNull();
     expect(publishRelease).not.toHaveBeenCalled();
   });
 
@@ -623,17 +626,14 @@ describe("plugins publish route", () => {
     await waitFor(() => {
       expect(screen.getByDisplayValue("demo-plugin")).toBeTruthy();
     });
-    fireEvent.change(screen.getByPlaceholderText("Changelog"), {
-      target: { value: "Initial release" },
-    });
-    fireEvent.change(screen.getByPlaceholderText("Source repo (owner/repo)"), {
+    fireEvent.change(screen.getByPlaceholderText("owner/repo"), {
       target: { value: "openclaw/demo-plugin" },
     });
-    fireEvent.change(screen.getByPlaceholderText("Source commit"), {
+    fireEvent.change(screen.getByPlaceholderText("Full commit SHA"), {
       target: { value: "abc123" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Publish" }));
+    fireEvent.click(screen.getByRole("button", { name: "Publish plugin" }));
 
     expect(
       await screen.findByText(/Pending security checks and verification before public listing\./i),

--- a/src/__tests__/plugins-publish-route.test.tsx
+++ b/src/__tests__/plugins-publish-route.test.tsx
@@ -634,5 +634,8 @@ describe("plugins publish route", () => {
     expect(
       await screen.findByText(/Pending security checks and verification before public listing\./i),
     ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Publish plugin" }).getAttribute("disabled"),
+    ).toBeNull();
   });
 });

--- a/src/__tests__/skills-publish-route.test.tsx
+++ b/src/__tests__/skills-publish-route.test.tsx
@@ -251,7 +251,7 @@ describe("Upload route", () => {
     ).toBeGreaterThan(0);
     expect(screen.getByText("screenshot.png")).toBeTruthy();
 
-    fireEvent.click(screen.getByRole("button", { name: "Remove unsupported files" }));
+    fireEvent.click(screen.getByRole("button", { name: "Remove unsupported" }));
 
     await waitFor(() => {
       expect(screen.queryByText("screenshot.png")).toBeNull();
@@ -265,7 +265,8 @@ describe("Upload route", () => {
     const input = screen.getByTestId("upload-input") as HTMLInputElement;
     fireEvent.change(input, { target: { files: [notes] } });
 
-    expect(await screen.findByText("SKILL.md is required.")).toBeTruthy();
+    expect(await screen.findByText("Missing")).toBeTruthy();
+    expect(screen.getAllByText("SKILL.md").length).toBeGreaterThan(0);
   });
 
   it("shows a validation error when a skill file exceeds 10MB", async () => {
@@ -442,7 +443,11 @@ describe("Upload route", () => {
     ).toBeGreaterThan(0);
     expect(screen.queryByText("Taken")).toBeNull();
     expect(screen.getByLabelText("Slug unavailable")).toBeTruthy();
-    expect(screen.getByRole("link", { name: "/alice/taken-skill" })).toBeTruthy();
+    const existingSkillLink = screen.getByRole("link", {
+      name: "Open existing skill in a new tab",
+    });
+    expect(existingSkillLink).toBeTruthy();
+    expect(existingSkillLink.getAttribute("href")).toBe("/alice/taken-skill");
     expect(
       screen.getByRole("button", { name: /publish skill/i }).getAttribute("disabled"),
     ).not.toBeNull();

--- a/src/__tests__/skills-publish-route.test.tsx
+++ b/src/__tests__/skills-publish-route.test.tsx
@@ -87,7 +87,18 @@ describe("Upload route", () => {
   it("keeps required validation quiet before submit", async () => {
     render(<Upload />);
     const publishButton = screen.getByRole("button", { name: /publish/i });
+    const slugInput = screen.getByPlaceholderText("skill-name");
+    const displayNameInput = screen.getByPlaceholderText("My skill");
+
     expect(publishButton.getAttribute("disabled")).not.toBeNull();
+    expect(screen.queryByText(/Slug is required/i)).toBeNull();
+    expect(screen.queryByText(/Display name is required/i)).toBeNull();
+
+    fireEvent.focus(slugInput);
+    fireEvent.blur(slugInput);
+    fireEvent.focus(displayNameInput);
+    fireEvent.blur(displayNameInput);
+
     expect(screen.queryByText(/Slug is required/i)).toBeNull();
     expect(screen.queryByText(/Display name is required/i)).toBeNull();
 
@@ -95,6 +106,18 @@ describe("Upload route", () => {
 
     expect(await screen.findAllByText(/Slug is required/i)).not.toHaveLength(0);
     expect(await screen.findAllByText(/Display name is required/i)).not.toHaveLength(0);
+  });
+
+  it("does not duplicate inline required field errors in the metadata footer", () => {
+    render(<Upload />);
+    const displayNameInput = screen.getByPlaceholderText("My skill");
+
+    fireEvent.change(displayNameInput, { target: { value: "Temporary skill" } });
+    fireEvent.change(displayNameInput, { target: { value: "" } });
+
+    const messages = screen.getAllByText(/Display name is required\./i);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.id).toBe("display-name-validation-error");
   });
 
   it("marks the input for folder uploads", async () => {

--- a/src/__tests__/skills-publish-route.test.tsx
+++ b/src/__tests__/skills-publish-route.test.tsx
@@ -84,12 +84,17 @@ describe("Upload route", () => {
     vi.unstubAllGlobals();
   });
 
-  it("shows validation issues before submit", async () => {
+  it("keeps required validation quiet before submit", async () => {
     render(<Upload />);
     const publishButton = screen.getByRole("button", { name: /publish/i });
     expect(publishButton.getAttribute("disabled")).not.toBeNull();
-    expect(screen.getAllByText(/Slug is required/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/Display name is required/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/Slug is required/i)).toBeNull();
+    expect(screen.queryByText(/Display name is required/i)).toBeNull();
+
+    fireEvent.submit(publishButton.closest("form") as HTMLFormElement);
+
+    expect(await screen.findAllByText(/Slug is required/i)).not.toHaveLength(0);
+    expect(await screen.findAllByText(/Display name is required/i)).not.toHaveLength(0);
   });
 
   it("marks the input for folder uploads", async () => {
@@ -120,13 +125,14 @@ describe("Upload route", () => {
     fireEvent.change(input, { target: { files: [file] } });
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /i have the rights to this skill and agree to publish it under mit-0/i,
+        name: /i have the rights to publish this skill under mit-0/i,
       }),
     );
 
     const publishButton = screen.getByRole("button", { name: /publish/i }) as HTMLButtonElement;
-    expect(await screen.findByText(/All checks passed/i)).toBeTruthy();
-    expect(publishButton.getAttribute("disabled")).toBeNull();
+    await waitFor(() => {
+      expect(publishButton.getAttribute("disabled")).toBeNull();
+    });
   });
 
   it("extracts zip uploads and unwraps top-level folders", async () => {
@@ -155,13 +161,15 @@ describe("Upload route", () => {
     fireEvent.change(input, { target: { files: [zipFile] } });
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /i have the rights to this skill and agree to publish it under mit-0/i,
+        name: /i have the rights to publish this skill under mit-0/i,
       }),
     );
 
     expect(await screen.findByText("notes.txt", {}, { timeout: 3000 })).toBeTruthy();
     expect(screen.getByText("SKILL.md")).toBeTruthy();
-    expect(await screen.findByText(/All checks passed/i, {}, { timeout: 3000 })).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /publish/i }).getAttribute("disabled")).toBeNull();
+    });
   });
 
   it("unwraps folder uploads so SKILL.md can be at the top-level", async () => {
@@ -191,12 +199,14 @@ describe("Upload route", () => {
     fireEvent.change(input, { target: { files: [file] } });
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /i have the rights to this skill and agree to publish it under mit-0/i,
+        name: /i have the rights to publish this skill under mit-0/i,
       }),
     );
 
     expect(await screen.findByText("SKILL.md")).toBeTruthy();
-    expect(await screen.findByText(/All checks passed/i)).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /publish/i }).getAttribute("disabled")).toBeNull();
+    });
 
     fireEvent.click(screen.getByRole("button", { name: /publish/i }));
     await waitFor(() => {
@@ -236,11 +246,16 @@ describe("Upload route", () => {
     fireEvent.change(input, { target: { files: [skill, png] } });
 
     expect(await screen.findByText("screenshot.png")).toBeTruthy();
-    fireEvent.click(screen.getByRole("button", { name: /publish/i }));
     expect(
-      (await screen.findAllByText(/Remove non-text files: screenshot\.png/i)).length,
+      (await screen.findAllByText(/Remove unsupported files: screenshot\.png/i)).length,
     ).toBeGreaterThan(0);
     expect(screen.getByText("screenshot.png")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove unsupported files" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("screenshot.png")).toBeNull();
+    });
   });
 
   it("surfaces file validation next to the upload input", async () => {
@@ -286,7 +301,7 @@ describe("Upload route", () => {
     ).not.toBeNull();
   });
 
-  it("shows an informational note when mac junk files are ignored", async () => {
+  it("shows an informational note when local metadata files are ignored", async () => {
     render(<Upload />);
     fireEvent.change(screen.getByPlaceholderText("skill-name"), {
       target: { value: "cool-skill" },
@@ -307,14 +322,38 @@ describe("Upload route", () => {
     fireEvent.change(input, { target: { files: [skill, junk] } });
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /i have the rights to this skill and agree to publish it under mit-0/i,
+        name: /i have the rights to publish this skill under mit-0/i,
       }),
     );
 
     expect(await screen.findByText("SKILL.md")).toBeTruthy();
     expect(screen.queryByText(".DS_Store")).toBeNull();
-    expect(await screen.findByText(/Ignored 1 macOS junk file/i)).toBeTruthy();
-    expect(await screen.findByText(/All checks passed/i)).toBeTruthy();
+    expect(await screen.findByText(/Ignored 1 local metadata file/i)).toBeTruthy();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /publish skill/i }).getAttribute("disabled"),
+      ).toBeNull();
+    });
+  });
+
+  it("ignores git metadata from dropped skill folders", async () => {
+    render(<Upload />);
+
+    const skill = new File(["hello"], "SKILL.md", { type: "text/markdown" });
+    Object.defineProperty(skill, "webkitRelativePath", {
+      value: "codex-run-to-completion/SKILL.md",
+    });
+    const gitConfig = new File(["[core]\n"], "config", { type: "text/plain" });
+    Object.defineProperty(gitConfig, "webkitRelativePath", {
+      value: "codex-run-to-completion/.git/config",
+    });
+    const input = screen.getByTestId("upload-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [skill, gitConfig] } });
+
+    expect(await screen.findByDisplayValue("codex-run-to-completion")).toBeTruthy();
+    expect(await screen.findByDisplayValue("Codex Run To Completion")).toBeTruthy();
+    expect(screen.queryByText(/\.git\/config/i)).toBeNull();
+    expect(await screen.findByText(/Ignored 1 local metadata file/i)).toBeTruthy();
   });
 
   it("surfaces publish errors and stays on page", async () => {
@@ -333,19 +372,18 @@ describe("Upload route", () => {
     fireEvent.change(screen.getByPlaceholderText("latest, stable"), {
       target: { value: "latest" },
     });
-    fireEvent.change(screen.getByPlaceholderText("Describe what changed in this skill..."), {
-      target: { value: "Initial drop." },
-    });
     const file = new File(["hello"], "SKILL.md", { type: "text/markdown" });
     const input = screen.getByTestId("upload-input") as HTMLInputElement;
     fireEvent.change(input, { target: { files: [file] } });
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /i have the rights to this skill and agree to publish it under mit-0/i,
+        name: /i have the rights to publish this skill under mit-0/i,
       }),
     );
     const publishButton = screen.getByRole("button", { name: /publish/i }) as HTMLButtonElement;
-    await screen.findByText(/All checks passed/i);
+    await waitFor(() => {
+      expect(publishButton.getAttribute("disabled")).toBeNull();
+    });
     fireEvent.click(publishButton);
     expect(await screen.findByText(/Changelog is required/i)).toBeTruthy();
   });
@@ -395,9 +433,6 @@ describe("Upload route", () => {
     fireEvent.change(screen.getByPlaceholderText("latest, stable"), {
       target: { value: "latest" },
     });
-    fireEvent.change(screen.getByPlaceholderText("Describe what changed in this skill..."), {
-      target: { value: "Initial drop." },
-    });
     const file = new File(["hello"], "SKILL.md", { type: "text/markdown" });
     const input = screen.getByTestId("upload-input") as HTMLInputElement;
     fireEvent.change(input, { target: { files: [file] } });
@@ -405,6 +440,8 @@ describe("Upload route", () => {
     expect(
       (await screen.findAllByText(/Slug is already taken\. Choose a different slug\./i)).length,
     ).toBeGreaterThan(0);
+    expect(screen.queryByText("Taken")).toBeNull();
+    expect(screen.getByLabelText("Slug unavailable")).toBeTruthy();
     expect(screen.getByRole("link", { name: "/alice/taken-skill" })).toBeTruthy();
     expect(
       screen.getByRole("button", { name: /publish skill/i }).getAttribute("disabled"),
@@ -435,6 +472,7 @@ describe("Upload route", () => {
             handle: "clawkit",
             displayName: "ClawKit",
             kind: "org",
+            image: "https://example.com/clawkit.png",
           },
           role: "admin",
         },
@@ -446,7 +484,10 @@ describe("Upload route", () => {
       target: { value: "org-skill" },
     });
 
-    expect((screen.getByLabelText("Owner") as HTMLSelectElement).value).toBe("clawkit");
+    expect(screen.getByLabelText("Owner").textContent).toContain("@clawkit · ClawKit · admin");
+    expect(document.querySelector('img[src="https://example.com/clawkit.png"]')).toBeTruthy();
+    expect(screen.queryByText("Available")).toBeNull();
+    expect(await screen.findByLabelText("Slug available")).toBeTruthy();
     await waitFor(() => {
       expect(useQueryMock).toHaveBeenCalledWith(expect.anything(), {
         slug: "org-skill",
@@ -485,7 +526,7 @@ describe("Upload route", () => {
     const { rerender } = render(<Upload />);
 
     await waitFor(() => {
-      expect((screen.getByLabelText("Owner") as HTMLSelectElement).value).toBe("local");
+      expect(screen.getByLabelText("Owner").textContent).toContain("@local");
     });
 
     memberships = [
@@ -502,7 +543,7 @@ describe("Upload route", () => {
     rerender(<Upload />);
 
     await waitFor(() => {
-      expect((screen.getByLabelText("Owner") as HTMLSelectElement).value).toBe("local-owner");
+      expect(screen.getByLabelText("Owner").textContent).toContain("@local-owner");
     });
 
     fireEvent.change(screen.getByPlaceholderText("skill-name"), {
@@ -545,12 +586,15 @@ describe("Upload route", () => {
     fireEvent.change(input, { target: { files: [file] } });
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /i have the rights to this skill and agree to publish it under mit-0/i,
+        name: /i have the rights to publish this skill under mit-0/i,
       }),
     );
 
-    await screen.findByText(/All checks passed/i);
-    fireEvent.click(screen.getByRole("button", { name: /publish skill/i }));
+    const publishButton = screen.getByRole("button", { name: /publish skill/i });
+    await waitFor(() => {
+      expect(publishButton.getAttribute("disabled")).toBeNull();
+    });
+    fireEvent.click(publishButton);
 
     await waitFor(() => {
       expect(
@@ -592,12 +636,15 @@ describe("Upload route", () => {
     fireEvent.change(input, { target: { files: [file] } });
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /i have the rights to this skill and agree to publish it under mit-0/i,
+        name: /i have the rights to publish this skill under mit-0/i,
       }),
     );
 
-    await screen.findByText(/All checks passed/i);
-    fireEvent.click(screen.getByRole("button", { name: /publish skill/i }));
+    const publishButton = screen.getByRole("button", { name: /publish skill/i });
+    await waitFor(() => {
+      expect(publishButton.getAttribute("disabled")).toBeNull();
+    });
+    fireEvent.click(publishButton);
 
     await waitFor(() => {
       expect(
@@ -667,12 +714,15 @@ describe("Upload route", () => {
     fireEvent.change(input, { target: { files: [file] } });
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /i have the rights to this skill and agree to publish it under mit-0/i,
+        name: /i have the rights to publish this skill under mit-0/i,
       }),
     );
 
-    await screen.findByText(/All checks passed/i);
-    fireEvent.click(screen.getByRole("button", { name: /publish skill/i }));
+    const publishButton = screen.getByRole("button", { name: /publish skill/i });
+    await waitFor(() => {
+      expect(publishButton.getAttribute("disabled")).toBeNull();
+    });
+    fireEvent.click(publishButton);
 
     await waitFor(() => {
       expect(
@@ -740,12 +790,15 @@ describe("Upload route", () => {
     fireEvent.change(input, { target: { files: [file] } });
     fireEvent.click(
       screen.getByRole("checkbox", {
-        name: /i have the rights to this skill and agree to publish it under mit-0/i,
+        name: /i have the rights to publish this skill under mit-0/i,
       }),
     );
 
-    await screen.findByText(/All checks passed/i);
-    fireEvent.click(screen.getByRole("button", { name: /publish skill/i }));
+    const publishButton = screen.getByRole("button", { name: /publish skill/i });
+    await waitFor(() => {
+      expect(publishButton.getAttribute("disabled")).toBeNull();
+    });
+    fireEvent.click(publishButton);
 
     await waitFor(() => {
       expect(

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -90,6 +90,7 @@ export default function Header() {
   const initial = (me?.displayName ?? me?.name ?? rawHandle).charAt(0).toUpperCase();
   const isStaff = isModerator(me);
   const hasResolvedUser = Boolean(me);
+  const isAuthResolving = isLoading || (isAuthenticated && me === undefined);
   const navCtx = useMemo(
     () => ({ isSoulMode, isAuthenticated: hasResolvedUser, isStaff }),
     [hasResolvedUser, isSoulMode, isStaff],
@@ -486,6 +487,8 @@ export default function Header() {
                   <DropdownMenuItem onClick={() => void signOut()}>Sign out</DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
+            ) : isAuthResolving ? (
+              <div className="github-sign-in-button auth-loading-placeholder" aria-hidden="true" />
             ) : (
               <>
                 {authError ? (

--- a/src/components/PackageSourceChooser.tsx
+++ b/src/components/PackageSourceChooser.tsx
@@ -7,6 +7,7 @@ import { formatBytes } from "../routes/upload/-utils";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import { Card } from "./ui/card";
+import { UploadDropzoneDecor } from "./UploadDropzoneDecor";
 
 export function PackageSourceChooser(props: {
   files: File[];
@@ -44,6 +45,7 @@ export function PackageSourceChooser(props: {
         accept=".zip,.tgz,.tar.gz,application/zip,application/gzip,application/x-gzip,application/x-tar"
         onChange={(event) => {
           const selected = Array.from(event.target.files ?? []);
+          event.target.value = "";
           void props.onPickFiles(selected);
         }}
       />
@@ -54,11 +56,12 @@ export function PackageSourceChooser(props: {
         multiple
         onChange={(event) => {
           const selected = Array.from(event.target.files ?? []);
+          event.target.value = "";
           void props.onPickFiles(selected);
         }}
       />
       <div
-        className={`flex flex-col items-center gap-4 rounded-[var(--radius-md)] border-2 border-dashed p-8 text-center transition-colors ${
+        className={`relative flex flex-col items-center gap-4 overflow-hidden rounded-[var(--radius-md)] border-2 border-dashed p-8 text-center transition-colors ${
           isDragging
             ? "border-[color:var(--accent)] bg-[rgba(255,107,74,0.06)]"
             : "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
@@ -79,18 +82,21 @@ export function PackageSourceChooser(props: {
           })();
         }}
       >
+        <UploadDropzoneDecor kind="plugin" />
         <div
-          className="flex h-14 w-14 items-center justify-center rounded-full bg-[color:var(--surface)]"
+          className="relative z-10 flex h-14 w-14 items-center justify-center rounded-full bg-[color:var(--surface)]"
           aria-hidden="true"
         >
           <Package size={28} className="text-[color:var(--ink-soft)]" />
         </div>
-        <div className="flex flex-col items-center gap-2">
+        <div className="relative z-10 flex flex-col items-center gap-2">
           <div className="flex flex-wrap items-center justify-center gap-2">
             <strong className="text-[color:var(--ink)]">Upload plugin code first</strong>
-            <span className="text-xs text-[color:var(--ink-soft)]">
-              {props.files.length} files &middot; {formatBytes(props.totalBytes)}
-            </span>
+            {props.files.length > 0 ? (
+              <span className="text-xs text-[color:var(--ink-soft)]">
+                {props.files.length} files &middot; {formatBytes(props.totalBytes)}
+              </span>
+            ) : null}
           </div>
           <span className="max-w-md text-sm text-[color:var(--ink-soft)]">
             Drag a folder, zip, or tgz here. We inspect the package to unlock and prefill the rest
@@ -98,7 +104,7 @@ export function PackageSourceChooser(props: {
           </span>
           <div className="flex gap-2 pt-2">
             <Button variant="outline" size="sm" onClick={() => archiveInputRef.current?.click()}>
-              Browse files
+              Choose archive
             </Button>
             <Button variant="ghost" size="sm" onClick={() => directoryInputRef.current?.click()}>
               Choose folder
@@ -107,19 +113,15 @@ export function PackageSourceChooser(props: {
         </div>
       </div>
 
-      <div
-        className={`rounded-[var(--radius-sm)] border px-4 py-3 transition-colors ${
-          isMetadataLocked
-            ? "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
-            : "border-emerald-300/40 bg-emerald-50 dark:border-emerald-500/30 dark:bg-emerald-950/30"
-        }`}
-      >
-        {props.normalizedPaths.length === 0 ? (
-          <div className="text-sm text-[color:var(--ink-soft)]">
-            No plugin package selected yet.
-          </div>
-        ) : (
-          <>
+      {props.normalizedPaths.length > 0 ? (
+        <div
+          className={`rounded-[var(--radius-sm)] border px-4 py-3 transition-colors ${
+            isMetadataLocked
+              ? "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
+              : "border-emerald-300/40 bg-emerald-50 dark:border-emerald-500/30 dark:bg-emerald-950/30"
+          }`}
+        >
+          <div>
             <div className="flex items-center justify-between">
               <strong className="text-sm text-[color:var(--ink)]">Package detected</strong>
               <span className="text-xs text-[color:var(--ink-soft)]">
@@ -146,15 +148,21 @@ export function PackageSourceChooser(props: {
                 <Badge>README</Badge>
               ) : null}
               {props.ignoredPaths.length > 0 ? (
-                <Badge>Ignored {props.ignoredPaths.length} files</Badge>
+                <Badge>Ignored {props.ignoredPaths.length} package files</Badge>
               ) : null}
             </div>
-          </>
-        )}
-      </div>
-      {props.validationError ? <Badge variant="accent">{props.validationError}</Badge> : null}
+            {props.ignoredPaths.length > 0 ? (
+              <p className="mt-2 text-xs text-[color:var(--ink-soft)]">
+                Ignored: {props.ignoredPaths.slice(0, 4).join(", ")}
+                {props.ignoredPaths.length > 4 ? ", ..." : ""}
+              </p>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+      {props.validationError ? <Badge variant="warning">{props.validationError}</Badge> : null}
       {props.family === "code-plugin" && props.codePluginFieldIssues.length > 0 ? (
-        <Badge variant="accent">
+        <Badge variant="warning">
           Missing required OpenClaw package metadata: {props.codePluginFieldIssues.join(", ")}. Add
           these fields to <code>package.json</code> before publishing. See{" "}
           <a

--- a/src/components/PackageSourceChooser.tsx
+++ b/src/components/PackageSourceChooser.tsx
@@ -9,8 +9,6 @@ import { UploadDropzoneDecor } from "./UploadDropzoneDecor";
 
 const PACKAGE_FILE_LIST_LIMIT = 8;
 export type PackagePickSource = "archive" | "folder";
-const PACKAGE_FILE_BADGE_CLASS =
-  "rounded-[var(--radius-sm)] px-2 py-0.5 text-[11px] font-medium leading-4";
 const PACKAGE_PATH_PRIORITY = new Map(
   [
     "package.json",
@@ -57,7 +55,7 @@ function getPackagePathBadges(
 
   if (lowerPath === "package.json") {
     badges.push(
-      <Badge key="package" variant="compact" className={PACKAGE_FILE_BADGE_CLASS}>
+      <Badge key="package" variant="compact" size="sm">
         Package manifest
       </Badge>,
     );
@@ -66,7 +64,7 @@ function getPackagePathBadges(
         <Badge
           key="metadata-missing"
           variant="destructive"
-          className={PACKAGE_FILE_BADGE_CLASS}
+          size="sm"
           title="Missing OpenClaw compatibility metadata"
         >
           Missing metadata
@@ -79,7 +77,7 @@ function getPackagePathBadges(
 
   if (lowerPath === "openclaw.plugin.json") {
     badges.push(
-      <Badge key="plugin" variant="compact" className={PACKAGE_FILE_BADGE_CLASS}>
+      <Badge key="plugin" variant="compact" size="sm">
         Plugin manifest
       </Badge>,
     );
@@ -91,7 +89,7 @@ function getPackagePathBadges(
     lowerPath === ".cursor-plugin/plugin.json"
   ) {
     badges.push(
-      <Badge key="agent" variant="compact" className={PACKAGE_FILE_BADGE_CLASS}>
+      <Badge key="agent" variant="compact" size="sm">
         Agent metadata
       </Badge>,
     );
@@ -99,7 +97,7 @@ function getPackagePathBadges(
 
   if (lowerPath === "readme.md" || lowerPath === "readme.mdx") {
     badges.push(
-      <Badge key="readme" variant="compact" className={PACKAGE_FILE_BADGE_CLASS}>
+      <Badge key="readme" variant="compact" size="sm">
         README
       </Badge>,
     );
@@ -138,6 +136,17 @@ export function PackageSourceChooser(props: {
   const replaceLabel = replaceSourceKind === "folder" ? "Replace folder" : "Replace package";
   const hasMetadataIssues =
     props.family === "code-plugin" && props.codePluginFieldIssues.length > 0;
+  const hasPackagePanelFooter = props.ignoredPaths.length > 0 || Boolean(props.validationError);
+  const selectedPackagePanelToneClass = isDragging
+    ? "border-[color:var(--accent)] bg-[rgba(255,107,74,0.06)]"
+    : isMetadataLocked
+      ? "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
+      : "border-emerald-300/45 bg-emerald-50/80 dark:border-emerald-500/30 dark:bg-emerald-950/25";
+  const selectedPackagePanelBgClass = isDragging
+    ? "bg-[rgba(255,107,74,0.06)]"
+    : isMetadataLocked
+      ? "bg-[color:var(--surface-muted)]"
+      : "bg-emerald-50/80 dark:bg-emerald-950/25";
 
   const setDirectoryInputRef = (node: HTMLInputElement | null) => {
     directoryInputRef.current = node;
@@ -184,13 +193,7 @@ export function PackageSourceChooser(props: {
       />
       {hasSelectedPackage ? (
         <div
-          className={`mb-5 overflow-hidden rounded-[var(--radius-md)] border transition-colors ${
-            isDragging
-              ? "border-[color:var(--accent)] bg-[rgba(255,107,74,0.06)]"
-              : isMetadataLocked
-                ? "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
-                : "border-emerald-300/45 bg-emerald-50/80 dark:border-emerald-500/30 dark:bg-emerald-950/25"
-          }`}
+          className={`mb-5 overflow-hidden rounded-[var(--radius-md)] border transition-colors ${selectedPackagePanelToneClass}`}
           onDragOver={(event) => {
             event.preventDefault();
             setIsDragging(true);
@@ -213,12 +216,6 @@ export function PackageSourceChooser(props: {
                   </strong>
                   <span className="text-xs text-[color:var(--ink-soft)]">{fileSummary}</span>
                 </div>
-                {props.ignoredPaths.length > 0 ? (
-                  <p className="mt-2 text-xs text-[color:var(--ink-soft)]">
-                    Ignored: {props.ignoredPaths.slice(0, 4).join(", ")}
-                    {props.ignoredPaths.length > 4 ? ", ..." : ""}
-                  </p>
-                ) : null}
               </div>
             </div>
             <div className="flex shrink-0 items-center gap-4 md:justify-end">
@@ -247,8 +244,8 @@ export function PackageSourceChooser(props: {
               </button>
             </div>
           </div>
-          <div className="mt-2 rounded-t-[calc(var(--radius-md)+8px)] border-t border-[color:var(--line)] bg-[color:var(--surface)] p-3">
-            <div className="flex max-h-[300px] flex-col gap-1 overflow-y-auto">
+          <div className="mt-2 overflow-hidden rounded-t-[calc(var(--radius-md)+8px)] border-t border-[color:var(--line)] bg-[color:var(--surface)]">
+            <div className="flex max-h-[300px] flex-col gap-1 overflow-y-auto p-3">
               {visiblePackagePaths.map((path, index) => {
                 const badges = getPackagePathBadges(path, {
                   hasMetadataIssues,
@@ -273,9 +270,21 @@ export function PackageSourceChooser(props: {
                 </div>
               ) : null}
             </div>
-            {props.validationError ? (
-              <div className="mt-2">
-                <Badge variant="destructive">{props.validationError}</Badge>
+            {hasPackagePanelFooter ? (
+              <div
+                className={`border-t border-[color:var(--line)] px-3 py-2 text-xs text-[color:var(--ink-soft)] ${selectedPackagePanelBgClass}`}
+              >
+                <div className="flex flex-col gap-1">
+                  {props.ignoredPaths.length > 0 ? (
+                    <p>
+                      Ignored: {props.ignoredPaths.slice(0, 4).join(", ")}
+                      {props.ignoredPaths.length > 4 ? ", ..." : ""}
+                    </p>
+                  ) : null}
+                  {props.validationError ? (
+                    <p className="text-status-error-fg">{props.validationError}</p>
+                  ) : null}
+                </div>
               </div>
             ) : null}
           </div>

--- a/src/components/PackageSourceChooser.tsx
+++ b/src/components/PackageSourceChooser.tsx
@@ -1,5 +1,4 @@
-import { DocsLinks } from "clawhub-schema";
-import { Package } from "lucide-react";
+import { Package, Upload } from "lucide-react";
 import { type DragEvent, useRef, useState } from "react";
 import { expandDroppedItems } from "../lib/uploadFiles";
 import { formatBytes } from "../routes/upload/-utils";
@@ -8,17 +7,119 @@ import { Button } from "./ui/button";
 import { Card } from "./ui/card";
 import { UploadDropzoneDecor } from "./UploadDropzoneDecor";
 
+const PACKAGE_FILE_LIST_LIMIT = 8;
+export type PackagePickSource = "archive" | "folder";
+const PACKAGE_FILE_BADGE_CLASS =
+  "rounded-[var(--radius-sm)] px-2 py-0.5 text-[11px] font-medium leading-4";
+const PACKAGE_PATH_PRIORITY = new Map(
+  [
+    "package.json",
+    "openclaw.plugin.json",
+    ".codex-plugin/plugin.json",
+    ".claude-plugin/plugin.json",
+    ".cursor-plugin/plugin.json",
+    "readme.md",
+    "readme.mdx",
+  ].map((path, index) => [path, index]),
+);
+
+function sortPackagePaths(paths: string[]) {
+  return [...paths].sort((a, b) => {
+    const aPriority = PACKAGE_PATH_PRIORITY.get(a.toLowerCase()) ?? Number.POSITIVE_INFINITY;
+    const bPriority = PACKAGE_PATH_PRIORITY.get(b.toLowerCase()) ?? Number.POSITIVE_INFINITY;
+    if (aPriority !== bPriority) return aPriority - bPriority;
+
+    const aDepth = a.split("/").length;
+    const bDepth = b.split("/").length;
+    if (aDepth !== bDepth) return aDepth - bDepth;
+
+    return a.localeCompare(b);
+  });
+}
+
+function isArchiveUpload(file: File) {
+  const lowerName = file.name.toLowerCase();
+  return lowerName.endsWith(".zip") || lowerName.endsWith(".tgz") || lowerName.endsWith(".tar.gz");
+}
+
+function inferPackagePickSource(selected: File[]): PackagePickSource {
+  return selected.some(isArchiveUpload) ? "archive" : "folder";
+}
+
+function getPackagePathBadges(
+  path: string,
+  options: {
+    hasMetadataIssues: boolean;
+  },
+) {
+  const lowerPath = path.toLowerCase();
+  const badges = [];
+
+  if (lowerPath === "package.json") {
+    badges.push(
+      <Badge key="package" variant="compact" className={PACKAGE_FILE_BADGE_CLASS}>
+        Package manifest
+      </Badge>,
+    );
+    if (options.hasMetadataIssues) {
+      badges.push(
+        <Badge
+          key="metadata-missing"
+          variant="destructive"
+          className={PACKAGE_FILE_BADGE_CLASS}
+          title="Missing OpenClaw compatibility metadata"
+        >
+          Missing metadata
+        </Badge>,
+      );
+    }
+    // Do not show a "Compatibility" badge for metadata presence alone.
+    // This upload flow does not validate semantic version/range compatibility yet.
+  }
+
+  if (lowerPath === "openclaw.plugin.json") {
+    badges.push(
+      <Badge key="plugin" variant="compact" className={PACKAGE_FILE_BADGE_CLASS}>
+        Plugin manifest
+      </Badge>,
+    );
+  }
+
+  if (
+    lowerPath === ".codex-plugin/plugin.json" ||
+    lowerPath === ".claude-plugin/plugin.json" ||
+    lowerPath === ".cursor-plugin/plugin.json"
+  ) {
+    badges.push(
+      <Badge key="agent" variant="compact" className={PACKAGE_FILE_BADGE_CLASS}>
+        Agent metadata
+      </Badge>,
+    );
+  }
+
+  if (lowerPath === "readme.md" || lowerPath === "readme.mdx") {
+    badges.push(
+      <Badge key="readme" variant="compact" className={PACKAGE_FILE_BADGE_CLASS}>
+        README
+      </Badge>,
+    );
+  }
+
+  return badges;
+}
+
 export function PackageSourceChooser(props: {
   files: File[];
   totalBytes: number;
   normalizedPaths: string[];
   normalizedPathSet: Set<string>;
+  selectedSourceKind: PackagePickSource | null;
   ignoredPaths: string[];
   detectedPrefillFields: string[];
   family: "code-plugin" | "bundle-plugin";
   validationError: string | null;
   codePluginFieldIssues: string[];
-  onPickFiles: (selected: File[]) => Promise<void>;
+  onPickFiles: (selected: File[], sourceKind: PackagePickSource) => Promise<void>;
   onClearFiles: () => void;
 }) {
   const [isDragging, setIsDragging] = useState(false);
@@ -27,10 +128,16 @@ export function PackageSourceChooser(props: {
   const isMetadataLocked = props.files.length === 0 || Boolean(props.validationError);
   const hasSelectedPackage = props.normalizedPaths.length > 0;
   const fileSummary = `${props.files.length} files \u00b7 ${formatBytes(props.totalBytes)}`;
-  const prefillSummary =
-    props.detectedPrefillFields.length > 0
-      ? `Autofilled: ${props.detectedPrefillFields.join(", ")}.`
-      : "Review and fill the release details below.";
+  const sortedPackagePaths = sortPackagePaths(props.normalizedPaths);
+  const visiblePackagePaths = sortedPackagePaths.slice(0, PACKAGE_FILE_LIST_LIMIT);
+  const hiddenPackagePathCount = Math.max(
+    sortedPackagePaths.length - visiblePackagePaths.length,
+    0,
+  );
+  const replaceSourceKind = props.selectedSourceKind ?? "archive";
+  const replaceLabel = replaceSourceKind === "folder" ? "Replace folder" : "Replace package";
+  const hasMetadataIssues =
+    props.family === "code-plugin" && props.codePluginFieldIssues.length > 0;
 
   const setDirectoryInputRef = (node: HTMLInputElement | null) => {
     directoryInputRef.current = node;
@@ -46,22 +153,12 @@ export function PackageSourceChooser(props: {
       const dropped = event.dataTransfer.items?.length
         ? await expandDroppedItems(event.dataTransfer.items)
         : Array.from(event.dataTransfer.files);
-      await props.onPickFiles(dropped);
+      await props.onPickFiles(dropped, inferPackagePickSource(dropped));
     })();
   };
 
   return (
-    <Card
-      className={`mb-5 ${
-        hasSelectedPackage
-          ? isDragging
-            ? "border-[color:var(--accent)] bg-[rgba(255,107,74,0.06)]"
-            : isMetadataLocked
-              ? "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
-              : "border-emerald-300/45 bg-emerald-50/80 dark:border-emerald-500/30 dark:bg-emerald-950/25"
-          : ""
-      }`}
-    >
+    <>
       <input
         ref={archiveInputRef}
         className="hidden"
@@ -71,7 +168,7 @@ export function PackageSourceChooser(props: {
         onChange={(event) => {
           const selected = Array.from(event.target.files ?? []);
           event.target.value = "";
-          void props.onPickFiles(selected);
+          void props.onPickFiles(selected, "archive");
         }}
       />
       <input
@@ -82,12 +179,18 @@ export function PackageSourceChooser(props: {
         onChange={(event) => {
           const selected = Array.from(event.target.files ?? []);
           event.target.value = "";
-          void props.onPickFiles(selected);
+          void props.onPickFiles(selected, "folder");
         }}
       />
       {hasSelectedPackage ? (
         <div
-          className="transition-colors"
+          className={`mb-5 overflow-hidden rounded-[var(--radius-md)] border transition-colors ${
+            isDragging
+              ? "border-[color:var(--accent)] bg-[rgba(255,107,74,0.06)]"
+              : isMetadataLocked
+                ? "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
+                : "border-emerald-300/45 bg-emerald-50/80 dark:border-emerald-500/30 dark:bg-emerald-950/25"
+          }`}
           onDragOver={(event) => {
             event.preventDefault();
             setIsDragging(true);
@@ -95,13 +198,13 @@ export function PackageSourceChooser(props: {
           onDragLeave={() => setIsDragging(false)}
           onDrop={handleDrop}
         >
-          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-            <div className="flex min-w-0 gap-3">
+          <div className="flex flex-col gap-4 px-4 pt-4 pb-2 md:flex-row md:items-center md:justify-between">
+            <div className="flex min-w-0 items-center gap-3">
               <div
-                className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)]"
+                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)]"
                 aria-hidden="true"
               >
-                <Package size={20} className="text-[color:var(--ink-soft)]" />
+                <Package size={16} className="text-[color:var(--ink-soft)]" />
               </div>
               <div className="min-w-0">
                 <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
@@ -109,29 +212,6 @@ export function PackageSourceChooser(props: {
                     {isMetadataLocked ? "Package selected" : "Package detected"}
                   </strong>
                   <span className="text-xs text-[color:var(--ink-soft)]">{fileSummary}</span>
-                </div>
-                <p className="mt-1 text-sm text-[color:var(--ink-soft)]">{prefillSummary}</p>
-                <div className="mt-3 flex flex-wrap gap-1.5">
-                  {props.normalizedPathSet.has("package.json") ? (
-                    <Badge variant="compact">Package manifest</Badge>
-                  ) : null}
-                  {props.normalizedPathSet.has("openclaw.plugin.json") ? (
-                    <Badge variant="compact">Plugin manifest</Badge>
-                  ) : null}
-                  {props.normalizedPathSet.has(".codex-plugin/plugin.json") ||
-                  props.normalizedPathSet.has(".claude-plugin/plugin.json") ||
-                  props.normalizedPathSet.has(".cursor-plugin/plugin.json") ? (
-                    <Badge variant="compact">Agent metadata</Badge>
-                  ) : null}
-                  {props.normalizedPathSet.has("readme.md") ||
-                  props.normalizedPathSet.has("readme.mdx") ? (
-                    <Badge variant="compact">README</Badge>
-                  ) : null}
-                  {props.ignoredPaths.length > 0 ? (
-                    <Badge variant="compact">
-                      Ignored {props.ignoredPaths.length} package files
-                    </Badge>
-                  ) : null}
                 </div>
                 {props.ignoredPaths.length > 0 ? (
                   <p className="mt-2 text-xs text-[color:var(--ink-soft)]">
@@ -141,73 +221,110 @@ export function PackageSourceChooser(props: {
                 ) : null}
               </div>
             </div>
-            <div className="flex shrink-0 flex-wrap gap-2 md:justify-end">
-              <Button variant="outline" size="sm" onClick={() => archiveInputRef.current?.click()}>
-                Replace archive
+            <div className="flex shrink-0 items-center gap-4 md:justify-end">
+              <Button
+                variant="outline"
+                size="sm"
+                type="button"
+                onClick={() => {
+                  if (replaceSourceKind === "folder") {
+                    directoryInputRef.current?.click();
+                    return;
+                  }
+                  archiveInputRef.current?.click();
+                }}
+              >
+                {replaceLabel}
               </Button>
-              <Button variant="ghost" size="sm" onClick={() => directoryInputRef.current?.click()}>
-                Replace folder
-              </Button>
-              <Button variant="ghost" size="sm" onClick={props.onClearFiles}>
+              <button
+                type="button"
+                className="cursor-pointer text-xs font-medium text-[color:var(--ink-soft)] transition-colors hover:text-[color:var(--ink)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)]/35 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--bg)]"
+                onClick={() => {
+                  props.onClearFiles();
+                }}
+              >
                 Clear package
-              </Button>
+              </button>
             </div>
+          </div>
+          <div className="mt-2 rounded-t-[calc(var(--radius-md)+8px)] border-t border-[color:var(--line)] bg-[color:var(--surface)] p-3">
+            <div className="flex max-h-[300px] flex-col gap-1 overflow-y-auto">
+              {visiblePackagePaths.map((path, index) => {
+                const badges = getPackagePathBadges(path, {
+                  hasMetadataIssues,
+                });
+                return (
+                  <div
+                    key={`${index}:${path}`}
+                    className="flex items-center gap-2 rounded-[var(--radius-sm)] bg-[color:var(--surface-muted)] px-3 py-1.5 text-sm text-[color:var(--ink-soft)]"
+                  >
+                    <span className="min-w-0 flex-1 truncate font-mono" title={path}>
+                      {path}
+                    </span>
+                    {badges.length > 0 ? (
+                      <div className="flex shrink-0 flex-wrap justify-end gap-1.5">{badges}</div>
+                    ) : null}
+                  </div>
+                );
+              })}
+              {hiddenPackagePathCount > 0 ? (
+                <div className="px-3 py-1.5 text-xs text-[color:var(--ink-soft)]">
+                  +{hiddenPackagePathCount} more
+                </div>
+              ) : null}
+            </div>
+            {props.validationError ? (
+              <div className="mt-2">
+                <Badge variant="destructive">{props.validationError}</Badge>
+              </div>
+            ) : null}
           </div>
         </div>
       ) : (
-        <div
-          className={`relative flex flex-col items-center gap-4 overflow-hidden rounded-[var(--radius-md)] border-2 border-dashed p-8 text-center transition-colors ${
-            isDragging
-              ? "border-[color:var(--accent)] bg-[rgba(255,107,74,0.06)]"
-              : "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
-          }`}
-          onDragOver={(event) => {
-            event.preventDefault();
-            setIsDragging(true);
-          }}
-          onDragLeave={() => setIsDragging(false)}
-          onDrop={handleDrop}
-        >
-          <UploadDropzoneDecor kind="plugin" />
+        <Card className="mb-5">
           <div
-            className="relative z-[1] flex h-14 w-14 items-center justify-center rounded-full bg-[color:var(--surface)]"
-            aria-hidden="true"
+            className={`relative flex flex-col items-center gap-4 overflow-hidden rounded-[var(--radius-md)] border-2 border-dashed p-8 text-center transition-colors ${
+              isDragging
+                ? "border-[color:var(--accent)] bg-[rgba(255,107,74,0.06)]"
+                : "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
+            }`}
+            onDragOver={(event) => {
+              event.preventDefault();
+              setIsDragging(true);
+            }}
+            onDragLeave={() => setIsDragging(false)}
+            onDrop={handleDrop}
           >
-            <Package size={28} className="text-[color:var(--ink-soft)]" />
-          </div>
-          <div className="relative z-[1] flex flex-col items-center gap-2">
-            <strong className="text-[color:var(--ink)]">Upload plugin code first</strong>
-            <span className="max-w-md text-sm text-[color:var(--ink-soft)]">
-              Drag a folder, zip, or tgz here. We inspect the package to unlock and prefill the rest
-              of the form.
-            </span>
-            <div className="flex gap-2 pt-2">
-              <Button variant="outline" size="sm" onClick={() => archiveInputRef.current?.click()}>
-                Choose archive
-              </Button>
-              <Button variant="ghost" size="sm" onClick={() => directoryInputRef.current?.click()}>
-                Choose folder
-              </Button>
+            <UploadDropzoneDecor active={isDragging} kind="plugin" />
+            <div className="relative z-[1] flex flex-col items-center gap-2">
+              <div className="flex items-center gap-3">
+                <Upload className="h-5 w-5 text-[color:var(--ink-soft)]" aria-hidden="true" />
+                <strong className="text-[color:var(--ink)]">Upload plugin code first</strong>
+              </div>
+              <span className="max-w-md text-sm text-[color:var(--ink-soft)]">
+                Drag a folder, zip, or tgz here. We inspect the package to unlock and prefill the
+                rest of the form.
+              </span>
+              <div className="flex gap-2 pt-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => archiveInputRef.current?.click()}
+                >
+                  Choose archive
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => directoryInputRef.current?.click()}
+                >
+                  Choose folder
+                </Button>
+              </div>
             </div>
           </div>
-        </div>
+        </Card>
       )}
-      {props.validationError ? <Badge variant="warning">{props.validationError}</Badge> : null}
-      {props.family === "code-plugin" && props.codePluginFieldIssues.length > 0 ? (
-        <Badge variant="warning">
-          Missing required OpenClaw package metadata: {props.codePluginFieldIssues.join(", ")}. Add
-          these fields to <code>package.json</code> before publishing. See{" "}
-          <a
-            href={DocsLinks.openclaw.pluginPackageMetadata}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline"
-          >
-            Plugin Setup and Config
-          </a>
-          .
-        </Badge>
-      ) : null}
-    </Card>
+    </>
   );
 }

--- a/src/components/PackageSourceChooser.tsx
+++ b/src/components/PackageSourceChooser.tsx
@@ -1,7 +1,6 @@
-import { DocsLinks, type PackageCompatibility } from "clawhub-schema";
+import { DocsLinks } from "clawhub-schema";
 import { Package } from "lucide-react";
-import { useRef, useState } from "react";
-import { formatPackageCompatibility } from "../lib/pluginPublishPrefill";
+import { type DragEvent, useRef, useState } from "react";
 import { expandDroppedItems } from "../lib/uploadFiles";
 import { formatBytes } from "../routes/upload/-utils";
 import { Badge } from "./ui/badge";
@@ -19,13 +18,19 @@ export function PackageSourceChooser(props: {
   family: "code-plugin" | "bundle-plugin";
   validationError: string | null;
   codePluginFieldIssues: string[];
-  codePluginCompatibility: PackageCompatibility | null;
   onPickFiles: (selected: File[]) => Promise<void>;
+  onClearFiles: () => void;
 }) {
   const [isDragging, setIsDragging] = useState(false);
   const archiveInputRef = useRef<HTMLInputElement | null>(null);
   const directoryInputRef = useRef<HTMLInputElement | null>(null);
   const isMetadataLocked = props.files.length === 0 || Boolean(props.validationError);
+  const hasSelectedPackage = props.normalizedPaths.length > 0;
+  const fileSummary = `${props.files.length} files \u00b7 ${formatBytes(props.totalBytes)}`;
+  const prefillSummary =
+    props.detectedPrefillFields.length > 0
+      ? `Autofilled: ${props.detectedPrefillFields.join(", ")}.`
+      : "Review and fill the release details below.";
 
   const setDirectoryInputRef = (node: HTMLInputElement | null) => {
     directoryInputRef.current = node;
@@ -34,9 +39,29 @@ export function PackageSourceChooser(props: {
       node.setAttribute("directory", "");
     }
   };
+  const handleDrop = (event: DragEvent<HTMLElement>) => {
+    event.preventDefault();
+    setIsDragging(false);
+    void (async () => {
+      const dropped = event.dataTransfer.items?.length
+        ? await expandDroppedItems(event.dataTransfer.items)
+        : Array.from(event.dataTransfer.files);
+      await props.onPickFiles(dropped);
+    })();
+  };
 
   return (
-    <Card className="mb-5">
+    <Card
+      className={`mb-5 ${
+        hasSelectedPackage
+          ? isDragging
+            ? "border-[color:var(--accent)] bg-[rgba(255,107,74,0.06)]"
+            : isMetadataLocked
+              ? "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
+              : "border-emerald-300/45 bg-emerald-50/80 dark:border-emerald-500/30 dark:bg-emerald-950/25"
+          : ""
+      }`}
+    >
       <input
         ref={archiveInputRef}
         className="hidden"
@@ -60,106 +85,113 @@ export function PackageSourceChooser(props: {
           void props.onPickFiles(selected);
         }}
       />
-      <div
-        className={`relative flex flex-col items-center gap-4 overflow-hidden rounded-[var(--radius-md)] border-2 border-dashed p-8 text-center transition-colors ${
-          isDragging
-            ? "border-[color:var(--accent)] bg-[rgba(255,107,74,0.06)]"
-            : "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
-        }`}
-        onDragOver={(event) => {
-          event.preventDefault();
-          setIsDragging(true);
-        }}
-        onDragLeave={() => setIsDragging(false)}
-        onDrop={(event) => {
-          event.preventDefault();
-          setIsDragging(false);
-          void (async () => {
-            const dropped = event.dataTransfer.items?.length
-              ? await expandDroppedItems(event.dataTransfer.items)
-              : Array.from(event.dataTransfer.files);
-            await props.onPickFiles(dropped);
-          })();
-        }}
-      >
-        <UploadDropzoneDecor kind="plugin" />
+      {hasSelectedPackage ? (
         <div
-          className="relative z-10 flex h-14 w-14 items-center justify-center rounded-full bg-[color:var(--surface)]"
-          aria-hidden="true"
+          className="transition-colors"
+          onDragOver={(event) => {
+            event.preventDefault();
+            setIsDragging(true);
+          }}
+          onDragLeave={() => setIsDragging(false)}
+          onDrop={handleDrop}
         >
-          <Package size={28} className="text-[color:var(--ink-soft)]" />
-        </div>
-        <div className="relative z-10 flex flex-col items-center gap-2">
-          <div className="flex flex-wrap items-center justify-center gap-2">
-            <strong className="text-[color:var(--ink)]">Upload plugin code first</strong>
-            {props.files.length > 0 ? (
-              <span className="text-xs text-[color:var(--ink-soft)]">
-                {props.files.length} files &middot; {formatBytes(props.totalBytes)}
-              </span>
-            ) : null}
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div className="flex min-w-0 gap-3">
+              <div
+                className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)]"
+                aria-hidden="true"
+              >
+                <Package size={20} className="text-[color:var(--ink-soft)]" />
+              </div>
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                  <strong className="text-sm text-[color:var(--ink)]">
+                    {isMetadataLocked ? "Package selected" : "Package detected"}
+                  </strong>
+                  <span className="text-xs text-[color:var(--ink-soft)]">{fileSummary}</span>
+                </div>
+                <p className="mt-1 text-sm text-[color:var(--ink-soft)]">{prefillSummary}</p>
+                <div className="mt-3 flex flex-wrap gap-1.5">
+                  {props.normalizedPathSet.has("package.json") ? (
+                    <Badge variant="compact">Package manifest</Badge>
+                  ) : null}
+                  {props.normalizedPathSet.has("openclaw.plugin.json") ? (
+                    <Badge variant="compact">Plugin manifest</Badge>
+                  ) : null}
+                  {props.normalizedPathSet.has(".codex-plugin/plugin.json") ||
+                  props.normalizedPathSet.has(".claude-plugin/plugin.json") ||
+                  props.normalizedPathSet.has(".cursor-plugin/plugin.json") ? (
+                    <Badge variant="compact">Agent metadata</Badge>
+                  ) : null}
+                  {props.normalizedPathSet.has("readme.md") ||
+                  props.normalizedPathSet.has("readme.mdx") ? (
+                    <Badge variant="compact">README</Badge>
+                  ) : null}
+                  {props.ignoredPaths.length > 0 ? (
+                    <Badge variant="compact">
+                      Ignored {props.ignoredPaths.length} package files
+                    </Badge>
+                  ) : null}
+                </div>
+                {props.ignoredPaths.length > 0 ? (
+                  <p className="mt-2 text-xs text-[color:var(--ink-soft)]">
+                    Ignored: {props.ignoredPaths.slice(0, 4).join(", ")}
+                    {props.ignoredPaths.length > 4 ? ", ..." : ""}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+            <div className="flex shrink-0 flex-wrap gap-2 md:justify-end">
+              <Button variant="outline" size="sm" onClick={() => archiveInputRef.current?.click()}>
+                Replace archive
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => directoryInputRef.current?.click()}>
+                Replace folder
+              </Button>
+              <Button variant="ghost" size="sm" onClick={props.onClearFiles}>
+                Clear package
+              </Button>
+            </div>
           </div>
-          <span className="max-w-md text-sm text-[color:var(--ink-soft)]">
-            Drag a folder, zip, or tgz here. We inspect the package to unlock and prefill the rest
-            of the form.
-          </span>
-          <div className="flex gap-2 pt-2">
-            <Button variant="outline" size="sm" onClick={() => archiveInputRef.current?.click()}>
-              Choose archive
-            </Button>
-            <Button variant="ghost" size="sm" onClick={() => directoryInputRef.current?.click()}>
-              Choose folder
-            </Button>
-          </div>
         </div>
-      </div>
-
-      {props.normalizedPaths.length > 0 ? (
+      ) : (
         <div
-          className={`rounded-[var(--radius-sm)] border px-4 py-3 transition-colors ${
-            isMetadataLocked
-              ? "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
-              : "border-emerald-300/40 bg-emerald-50 dark:border-emerald-500/30 dark:bg-emerald-950/30"
+          className={`relative flex flex-col items-center gap-4 overflow-hidden rounded-[var(--radius-md)] border-2 border-dashed p-8 text-center transition-colors ${
+            isDragging
+              ? "border-[color:var(--accent)] bg-[rgba(255,107,74,0.06)]"
+              : "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
           }`}
+          onDragOver={(event) => {
+            event.preventDefault();
+            setIsDragging(true);
+          }}
+          onDragLeave={() => setIsDragging(false)}
+          onDrop={handleDrop}
         >
-          <div>
-            <div className="flex items-center justify-between">
-              <strong className="text-sm text-[color:var(--ink)]">Package detected</strong>
-              <span className="text-xs text-[color:var(--ink-soft)]">
-                {props.files.length} files &middot; {formatBytes(props.totalBytes)}
-              </span>
+          <UploadDropzoneDecor kind="plugin" />
+          <div
+            className="relative z-[1] flex h-14 w-14 items-center justify-center rounded-full bg-[color:var(--surface)]"
+            aria-hidden="true"
+          >
+            <Package size={28} className="text-[color:var(--ink-soft)]" />
+          </div>
+          <div className="relative z-[1] flex flex-col items-center gap-2">
+            <strong className="text-[color:var(--ink)]">Upload plugin code first</strong>
+            <span className="max-w-md text-sm text-[color:var(--ink-soft)]">
+              Drag a folder, zip, or tgz here. We inspect the package to unlock and prefill the rest
+              of the form.
+            </span>
+            <div className="flex gap-2 pt-2">
+              <Button variant="outline" size="sm" onClick={() => archiveInputRef.current?.click()}>
+                Choose archive
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => directoryInputRef.current?.click()}>
+                Choose folder
+              </Button>
             </div>
-            <p className="mt-1 text-sm text-[color:var(--ink-soft)]">
-              {props.detectedPrefillFields.length > 0
-                ? `Autofilled ${props.detectedPrefillFields.join(", ")}.`
-                : "Package files were detected. Review and fill the release details below."}
-            </p>
-            <div className="mt-2 flex flex-wrap gap-1.5">
-              {props.normalizedPathSet.has("package.json") ? <Badge>Package manifest</Badge> : null}
-              {props.normalizedPathSet.has("openclaw.plugin.json") ? (
-                <Badge>Plugin manifest</Badge>
-              ) : null}
-              {props.normalizedPathSet.has(".codex-plugin/plugin.json") ||
-              props.normalizedPathSet.has(".claude-plugin/plugin.json") ||
-              props.normalizedPathSet.has(".cursor-plugin/plugin.json") ? (
-                <Badge>Agent metadata</Badge>
-              ) : null}
-              {props.normalizedPathSet.has("readme.md") ||
-              props.normalizedPathSet.has("readme.mdx") ? (
-                <Badge>README</Badge>
-              ) : null}
-              {props.ignoredPaths.length > 0 ? (
-                <Badge>Ignored {props.ignoredPaths.length} package files</Badge>
-              ) : null}
-            </div>
-            {props.ignoredPaths.length > 0 ? (
-              <p className="mt-2 text-xs text-[color:var(--ink-soft)]">
-                Ignored: {props.ignoredPaths.slice(0, 4).join(", ")}
-                {props.ignoredPaths.length > 4 ? ", ..." : ""}
-              </p>
-            ) : null}
           </div>
         </div>
-      ) : null}
+      )}
       {props.validationError ? <Badge variant="warning">{props.validationError}</Badge> : null}
       {props.family === "code-plugin" && props.codePluginFieldIssues.length > 0 ? (
         <Badge variant="warning">
@@ -175,11 +207,6 @@ export function PackageSourceChooser(props: {
           </a>
           .
         </Badge>
-      ) : null}
-      {props.family === "code-plugin" && props.codePluginCompatibility ? (
-        <p className="text-sm text-[color:var(--ink-soft)]">
-          Compatibility: {formatPackageCompatibility(props.codePluginCompatibility)}
-        </p>
       ) : null}
     </Card>
   );

--- a/src/components/PublishFormSkeleton.tsx
+++ b/src/components/PublishFormSkeleton.tsx
@@ -1,0 +1,40 @@
+import { Container } from "./layout/Container";
+import { Card, CardContent } from "./ui/card";
+import { Skeleton } from "./ui/skeleton";
+
+export function PublishFormSkeleton() {
+  return (
+    <main className="py-10" aria-busy="true" aria-label="Loading publish form">
+      <Container size="narrow">
+        <div className="mb-6 flex flex-col gap-2">
+          <Skeleton className="h-9 w-56" />
+          <Skeleton className="h-5 w-[min(520px,80%)]" />
+        </div>
+        <div className="flex flex-col gap-6">
+          <Card>
+            <CardContent>
+              <div className="flex min-h-[220px] flex-col items-center justify-center gap-4 rounded-[var(--radius-md)] border-2 border-dashed border-[color:var(--line)] bg-[color:var(--surface-muted)]">
+                <Skeleton className="h-6 w-44" />
+                <Skeleton className="h-4 w-72 max-w-[70%]" />
+                <Skeleton className="h-10 w-32" />
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent>
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-11 w-full" />
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-11 w-full" />
+              <Skeleton className="h-4 w-16" />
+              <Skeleton className="h-11 w-full" />
+            </CardContent>
+          </Card>
+          <div className="flex justify-end">
+            <Skeleton className="h-13 w-40 rounded-[var(--r-btn)]" />
+          </div>
+        </div>
+      </Container>
+    </main>
+  );
+}

--- a/src/components/PublisherOwnerSelect.tsx
+++ b/src/components/PublisherOwnerSelect.tsx
@@ -69,8 +69,8 @@ export function PublisherOwnerSelect({
 function PublisherOwnerOption({ membership }: { membership: PublisherOwnerMembership }) {
   const { publisher, role } = membership;
   return (
-    <span className="flex min-w-0 items-center gap-2">
-      <span className="inline-flex h-6 w-6 shrink-0 overflow-hidden rounded-full">
+    <span className="flex min-w-0 items-center gap-2 leading-none">
+      <span className="inline-flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-full">
         <MarketplaceIcon
           kind={publisher.kind}
           label={publisher.displayName || publisher.handle}

--- a/src/components/PublisherOwnerSelect.tsx
+++ b/src/components/PublisherOwnerSelect.tsx
@@ -1,0 +1,86 @@
+import { MarketplaceIcon } from "./MarketplaceIcon";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
+
+export type PublisherOwnerMembership = {
+  publisher: {
+    _id: string;
+    handle: string;
+    displayName: string;
+    kind: "user" | "org";
+    image?: string | null;
+  };
+  role: "owner" | "admin" | "publisher";
+};
+
+type PublisherOwnerSelectProps = {
+  id: string;
+  value: string;
+  memberships: PublisherOwnerMembership[] | undefined;
+  disabled?: boolean;
+  onValueChange: (value: string) => void;
+};
+
+export function PublisherOwnerSelect({
+  id,
+  value,
+  memberships,
+  disabled,
+  onValueChange,
+}: PublisherOwnerSelectProps) {
+  const availableMemberships = memberships ?? [];
+  const selected = availableMemberships.find((entry) => entry.publisher.handle === value) ?? null;
+
+  if (availableMemberships.length === 0) {
+    return (
+      <button
+        id={id}
+        type="button"
+        aria-label="Owner"
+        disabled
+        className="flex w-full min-h-[44px] items-center justify-between rounded-[var(--radius-sm)] border border-input-border bg-input-bg px-3.5 py-space-3 text-sm text-[color:var(--ink)] opacity-60"
+      >
+        <span className="truncate">{value ? `@${value}` : "Select owner"}</span>
+      </button>
+    );
+  }
+
+  return (
+    <Select value={value} onValueChange={onValueChange} disabled={disabled}>
+      <SelectTrigger id={id} aria-label="Owner">
+        {selected ? (
+          <PublisherOwnerOption membership={selected} />
+        ) : value ? (
+          <span className="truncate">@{value}</span>
+        ) : (
+          <SelectValue placeholder="Select owner" />
+        )}
+      </SelectTrigger>
+      <SelectContent>
+        {availableMemberships.map((entry) => (
+          <SelectItem key={entry.publisher._id} value={entry.publisher.handle}>
+            <PublisherOwnerOption membership={entry} />
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function PublisherOwnerOption({ membership }: { membership: PublisherOwnerMembership }) {
+  const { publisher, role } = membership;
+  return (
+    <span className="flex min-w-0 items-center gap-2">
+      <span className="inline-flex h-6 w-6 shrink-0 overflow-hidden rounded-full">
+        <MarketplaceIcon
+          kind={publisher.kind}
+          label={publisher.displayName || publisher.handle}
+          imageUrl={publisher.image}
+          size="xs"
+        />
+      </span>
+      <span className="min-w-0 truncate">
+        @{publisher.handle} · {publisher.displayName} · {role}
+      </span>
+    </span>
+  );
+}

--- a/src/components/SkillIconPicker.test.tsx
+++ b/src/components/SkillIconPicker.test.tsx
@@ -42,11 +42,11 @@ describe("SkillIconPicker", () => {
     expect(onChange).toHaveBeenCalledWith(null);
   });
 
-  it("shows a contextual hint that mirrors the current selection", () => {
+  it("does not duplicate the selected state in helper copy", () => {
     const { rerender } = render(<SkillIconPicker value={null} onChange={() => {}} />);
-    expect(screen.getByText(/Pick an icon shown on the skill card/i)).toBeTruthy();
+    expect(screen.queryByText(/Pick an icon shown on the skill card/i)).toBeNull();
 
     rerender(<SkillIconPicker value="Plug" onChange={() => {}} />);
-    expect(screen.getByText(/Selected: Plug/)).toBeTruthy();
+    expect(screen.queryByText(/Selected: Plug/)).toBeNull();
   });
 });

--- a/src/components/SkillIconPicker.tsx
+++ b/src/components/SkillIconPicker.tsx
@@ -1,4 +1,5 @@
 import { Check } from "lucide-react";
+import type { ReactNode } from "react";
 import { ALLOWED_LUCIDE_ICON_NAMES, ALLOWED_LUCIDE_ICONS } from "../lib/skillIcon";
 
 type SkillIconPickerProps = {
@@ -50,7 +51,7 @@ function IconButton({
   label: string;
   isSelected: boolean;
   onSelect: () => void;
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   return (
     <button
@@ -61,7 +62,7 @@ function IconButton({
       title={label}
       onClick={onSelect}
       className={[
-        "relative flex h-11 w-11 items-center justify-center rounded-[var(--radius-sm)] border transition-all",
+        "relative flex h-11 w-11 cursor-pointer items-center justify-center rounded-[var(--radius-sm)] border transition-all",
         isSelected
           ? "border-[color:var(--accent)] bg-[color:var(--accent)]/10 shadow-[0_0_0_2px_color-mix(in_srgb,var(--accent)_30%,transparent)]"
           : "border-[rgba(29,59,78,0.18)] bg-[rgba(255,255,255,0.94)] hover:border-[color:var(--accent)]/60 dark:border-[rgba(255,255,255,0.12)] dark:bg-[rgba(14,28,37,0.84)]",

--- a/src/components/SkillIconPicker.tsx
+++ b/src/components/SkillIconPicker.tsx
@@ -37,11 +37,6 @@ export function SkillIconPicker({ value, onChange }: SkillIconPickerProps) {
           );
         })}
       </div>
-      <p className="text-xs text-[color:var(--ink-soft)]">
-        {value
-          ? `Selected: ${value}. Click again to change, or pick "None" to use the default icon.`
-          : "Optional. Pick an icon shown on the skill card and listings."}
-      </p>
     </div>
   );
 }

--- a/src/components/UploadDropzoneDecor.tsx
+++ b/src/components/UploadDropzoneDecor.tsx
@@ -1,0 +1,54 @@
+import { Archive, Code2, FileText, Folder, Package, Wrench } from "lucide-react";
+import type { ComponentType } from "react";
+
+type DecorIconProps = {
+  icon: ComponentType<{ className?: string; strokeWidth?: number }>;
+  className: string;
+};
+
+const decorIconsByKind = {
+  skill: [
+    { icon: FileText, className: "left-[9%] top-[18%] -rotate-12" },
+    { icon: Code2, className: "left-[13%] bottom-[18%] rotate-8" },
+    { icon: Wrench, className: "right-[9%] top-[18%] rotate-12" },
+    { icon: Package, className: "right-[13%] bottom-[18%] -rotate-10" },
+  ],
+  plugin: [
+    { icon: Package, className: "left-[9%] top-[18%] -rotate-12" },
+    { icon: Archive, className: "left-[13%] bottom-[18%] rotate-8" },
+    { icon: Folder, className: "right-[9%] top-[18%] rotate-12" },
+    { icon: Code2, className: "right-[13%] bottom-[18%] -rotate-10" },
+  ],
+} as const;
+
+export function UploadDropzoneDecor({ kind = "skill" }: { kind?: keyof typeof decorIconsByKind }) {
+  const decorIcons = decorIconsByKind[kind];
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 overflow-hidden rounded-[inherit]"
+    >
+      <div
+        className="absolute inset-x-0 -inset-y-8 opacity-60"
+        style={{
+          background:
+            "radial-gradient(ellipse at center, color-mix(in srgb, var(--accent) 10%, transparent), transparent 72%)",
+        }}
+      />
+      {decorIcons.map((item) => (
+        <DecorIcon key={item.className} icon={item.icon} className={item.className} />
+      ))}
+    </div>
+  );
+}
+
+function DecorIcon({ icon: Icon, className }: DecorIconProps) {
+  return (
+    <span
+      className={`absolute hidden h-11 w-11 items-center justify-center rounded-[var(--radius-md)] border border-[color:var(--line)] bg-[color:var(--surface)]/70 text-[color:var(--ink-soft)] opacity-45 shadow-sm sm:flex ${className}`}
+    >
+      <Icon className="h-5 w-5" strokeWidth={1.8} />
+    </span>
+  );
+}

--- a/src/components/UploadDropzoneDecor.tsx
+++ b/src/components/UploadDropzoneDecor.tsx
@@ -4,6 +4,7 @@ import type { ComponentType } from "react";
 type DecorIconProps = {
   icon: ComponentType<{ className?: string; strokeWidth?: number }>;
   className: string;
+  active: boolean;
 };
 
 const decorIconsByKind = {
@@ -21,7 +22,13 @@ const decorIconsByKind = {
   ],
 } as const;
 
-export function UploadDropzoneDecor({ kind = "skill" }: { kind?: keyof typeof decorIconsByKind }) {
+export function UploadDropzoneDecor({
+  active = false,
+  kind = "skill",
+}: {
+  active?: boolean;
+  kind?: keyof typeof decorIconsByKind;
+}) {
   const decorIcons = decorIconsByKind[kind];
 
   return (
@@ -37,16 +44,22 @@ export function UploadDropzoneDecor({ kind = "skill" }: { kind?: keyof typeof de
         }}
       />
       {decorIcons.map((item) => (
-        <DecorIcon key={item.className} icon={item.icon} className={item.className} />
+        <DecorIcon
+          key={item.className}
+          active={active}
+          icon={item.icon}
+          className={item.className}
+        />
       ))}
     </div>
   );
 }
 
-function DecorIcon({ icon: Icon, className }: DecorIconProps) {
+function DecorIcon({ active, icon: Icon, className }: DecorIconProps) {
   return (
     <span
-      className={`absolute hidden h-11 w-11 items-center justify-center rounded-[var(--radius-md)] border border-[color:var(--line)] bg-[color:var(--surface)]/70 text-[color:var(--ink-soft)] opacity-45 shadow-sm sm:flex ${className}`}
+      data-active={active ? "true" : undefined}
+      className={`absolute hidden h-11 w-11 items-center justify-center rounded-[var(--radius-md)] border border-[color:var(--line)] bg-[color:var(--surface)]/70 text-[color:var(--ink-soft)] opacity-45 shadow-sm data-[active=true]:animate-[upload-decor-jiggle_0.44s_ease-in-out_infinite] sm:flex ${className}`}
     >
       <Icon className="h-5 w-5" strokeWidth={1.8} />
     </span>

--- a/src/components/VersionInput.tsx
+++ b/src/components/VersionInput.tsx
@@ -1,0 +1,66 @@
+import { ChevronDown, ChevronUp } from "lucide-react";
+import type * as React from "react";
+import semver from "semver";
+import { cn } from "../lib/utils";
+import { Input } from "./ui/input";
+
+type VersionInputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, "onChange" | "value"> & {
+  value: string;
+  onValueChange: (value: string) => void;
+};
+
+export function VersionInput({
+  value,
+  onValueChange,
+  className,
+  disabled,
+  ...props
+}: VersionInputProps) {
+  const baseVersion = getBaseVersion(value);
+  const canStepDown = Boolean(baseVersion && baseVersion.patch > 0);
+
+  const stepPatch = (delta: 1 | -1) => {
+    const base = getBaseVersion(value) ?? semver.parse("0.0.0");
+    if (!base) return;
+    const nextPatch = Math.max(0, base.patch + delta);
+    onValueChange(`${base.major}.${base.minor}.${nextPatch}`);
+  };
+
+  return (
+    <div className="relative">
+      <Input
+        {...props}
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onValueChange(event.target.value)}
+        className={cn("pr-12", className)}
+      />
+      <div className="absolute right-2 top-1/2 flex -translate-y-1/2 flex-col">
+        <button
+          type="button"
+          aria-label="Increase patch version"
+          className="flex h-5 w-7 items-center justify-center rounded-[var(--radius-sm)] text-[color:var(--ink-soft)] transition-colors hover:bg-[color:var(--surface-muted)] hover:text-[color:var(--ink)] disabled:pointer-events-none disabled:opacity-40"
+          disabled={disabled}
+          onClick={() => stepPatch(1)}
+        >
+          <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          aria-label="Decrease patch version"
+          className="flex h-5 w-7 items-center justify-center rounded-[var(--radius-sm)] text-[color:var(--ink-soft)] transition-colors hover:bg-[color:var(--surface-muted)] hover:text-[color:var(--ink)] disabled:pointer-events-none disabled:opacity-40"
+          disabled={disabled || !canStepDown}
+          onClick={() => stepPatch(-1)}
+        >
+          <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function getBaseVersion(value: string) {
+  const trimmed = value.trim();
+  const valid = semver.valid(trimmed);
+  return semver.parse(valid ?? semver.coerce(trimmed)?.version ?? "0.0.0");
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { cn } from "../../lib/utils";
 
 export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  size?: "default" | "sm";
   variant?:
     | "default"
     | "accent"
@@ -15,7 +16,7 @@ export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
 }
 
 const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
-  ({ className, variant = "default", ...props }, ref) => (
+  ({ className, size = "default", variant = "default", ...props }, ref) => (
     <span
       ref={ref}
       className={cn(
@@ -37,6 +38,8 @@ const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
           "bg-[color:color-mix(in_srgb,#6aa9ff_16%,transparent)] px-3 py-1 text-[#6aa9ff] border border-[color:color-mix(in_srgb,#6aa9ff_24%,var(--line))]",
         variant === "destructive" &&
           "bg-status-error-bg px-3 py-1 text-status-error-fg border border-line",
+        size === "sm" &&
+          "rounded-[var(--radius-pill)] px-2 py-0.5 text-[11px] font-medium leading-4",
         className,
       )}
       {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -18,7 +18,7 @@ const SelectTrigger = React.forwardRef<
     data-size={size}
     className={cn(
       // Matches form input token styling
-      "flex w-full min-h-[44px] items-center justify-between rounded-[var(--radius-sm)] border px-3.5 py-space-3 text-sm text-[color:var(--ink)] transition-all duration-[180ms] ease-out",
+      "flex w-full min-h-[44px] cursor-pointer items-center justify-between rounded-[var(--radius-sm)] border px-3.5 py-space-3 text-sm text-[color:var(--ink)] transition-all duration-[180ms] ease-out",
       "data-[size=sm]:min-h-8 data-[size=sm]:px-2.5 data-[size=sm]:py-1 data-[size=sm]:text-xs",
       "border-input-border bg-input-bg",
       "placeholder:text-input-placeholder",

--- a/src/lib/pluginPublishPrefill.ts
+++ b/src/lib/pluginPublishPrefill.ts
@@ -156,16 +156,3 @@ export function listPrefilledFields(prefill: PluginPublishPrefill) {
   if (prefill.hostTargets) fields.push("host targets");
   return fields;
 }
-
-export function formatPackageCompatibility(compatibility: PackageCompatibility) {
-  return [
-    compatibility.pluginApiRange ? `pluginApi=${compatibility.pluginApiRange}` : null,
-    compatibility.builtWithOpenClawVersion
-      ? `builtWith=${compatibility.builtWithOpenClawVersion}`
-      : null,
-    compatibility.pluginSdkVersion ? `sdk=${compatibility.pluginSdkVersion}` : null,
-    compatibility.minGatewayVersion ? `minGateway=${compatibility.minGatewayVersion}` : null,
-  ]
-    .filter(Boolean)
-    .join(", ");
-}

--- a/src/lib/slugCollision.test.ts
+++ b/src/lib/slugCollision.test.ts
@@ -45,6 +45,24 @@ describe("getPublicSlugCollision", () => {
     });
   });
 
+  it("does not duplicate the conflicting skill URL in the public message", () => {
+    expect(
+      getPublicSlugCollision({
+        isSoulMode: false,
+        slug: "demo",
+        result: {
+          available: false,
+          reason: "taken",
+          message: "Slug is already taken. Choose a different slug. Existing skill: /alice/demo",
+          url: "/alice/demo",
+        },
+      }),
+    ).toEqual({
+      message: "Slug is already taken. Choose a different slug.",
+      url: "/alice/demo",
+    });
+  });
+
   it("returns generic collision message when backend message is empty", () => {
     expect(
       getPublicSlugCollision({

--- a/src/lib/slugCollision.ts
+++ b/src/lib/slugCollision.ts
@@ -10,6 +10,14 @@ type PublicSlugCollision = {
   url: string | null;
 };
 
+const DEFAULT_COLLISION_MESSAGE = "Slug is already taken. Choose a different slug.";
+
+function publicCollisionMessage(message: string | null) {
+  const trimmed = message?.trim();
+  if (!trimmed) return DEFAULT_COLLISION_MESSAGE;
+  return trimmed.replace(/\s+Existing skill:\s+\S+\s*$/u, "");
+}
+
 export function getPublicSlugCollision(params: {
   isSoulMode: boolean;
   slug: string;
@@ -20,7 +28,7 @@ export function getPublicSlugCollision(params: {
   if (!normalizedSlug) return null;
   if (!params.result || params.result.available) return null;
   return {
-    message: params.result.message?.trim() || "Slug is already taken. Choose a different slug.",
+    message: publicCollisionMessage(params.result.message),
     url: params.result.url ?? null,
   };
 }

--- a/src/lib/uploadFiles.jsdom.test.ts
+++ b/src/lib/uploadFiles.jsdom.test.ts
@@ -34,14 +34,14 @@ describe("expandFiles (jsdom)", () => {
     expect(expanded.map((file) => file.name)).toEqual(["SKILL.md", "notes.txt"]);
   });
 
-  it("filters mac junk files and returns ignored paths", async () => {
+  it("filters local metadata files and returns ignored paths", async () => {
     const report = await expandFilesWithReport([
       new File(["hello"], "SKILL.md", { type: "text/markdown" }),
       new File(["junk"], ".DS_Store", { type: "application/octet-stream" }),
     ]);
 
     expect(report.files.map((file) => file.name)).toEqual(["SKILL.md"]);
-    expect(report.ignoredMacJunkPaths).toEqual([".DS_Store"]);
+    expect(report.ignoredLocalMetadataPaths).toEqual([".DS_Store"]);
   });
 });
 

--- a/src/lib/uploadFiles.test.ts
+++ b/src/lib/uploadFiles.test.ts
@@ -106,15 +106,20 @@ describe("expandFiles", () => {
     expect(report.files.map((file) => file.name)).toEqual(["package.json", "dist/module.wasm"]);
   });
 
-  it("filters mac junk files and reports ignored paths", async () => {
+  it("filters local metadata files and reports ignored paths", async () => {
     const report = await expandFilesWithReport([
       new File(["hello"], "SKILL.md", { type: "text/markdown" }),
       new File(["junk"], ".DS_Store", { type: "application/octet-stream" }),
       new File(["junk"], "._notes.md", { type: "text/plain" }),
+      new File(["junk"], "demo/.git/config", { type: "text/plain" }),
     ]);
 
     expect(report.files.map((file) => file.name)).toEqual(["SKILL.md"]);
-    expect(report.ignoredMacJunkPaths).toEqual([".DS_Store", "._notes.md"]);
+    expect(report.ignoredLocalMetadataPaths).toEqual([
+      ".DS_Store",
+      "._notes.md",
+      "demo/.git/config",
+    ]);
   });
 
   it("expands gzipped tar archives into files", async () => {

--- a/src/lib/uploadFiles.ts
+++ b/src/lib/uploadFiles.ts
@@ -20,7 +20,7 @@ const TEXT_TYPES = new Map([
 
 type ExpandFilesReport = {
   files: File[];
-  ignoredMacJunkPaths: string[];
+  ignoredLocalMetadataPaths: string[];
 };
 
 type ExpandFilesOptions = {
@@ -32,14 +32,14 @@ export async function expandFilesWithReport(
   options: ExpandFilesOptions = {},
 ): Promise<ExpandFilesReport> {
   const expanded: File[] = [];
-  const ignoredMacJunkPaths: string[] = [];
+  const ignoredLocalMetadataPaths: string[] = [];
   for (const file of selected) {
     const lower = file.name.toLowerCase();
     if (lower.endsWith(".zip")) {
       const entries = unzipSync(new Uint8Array(await readArrayBuffer(file)));
       pushArchiveEntries(
         expanded,
-        ignoredMacJunkPaths,
+        ignoredLocalMetadataPaths,
         Object.entries(entries).map(([path, data]) => ({ path, data })),
         options,
       );
@@ -47,28 +47,28 @@ export async function expandFilesWithReport(
     }
     if (lower.endsWith(".tar.gz") || lower.endsWith(".tgz")) {
       const unpacked = gunzipSync(new Uint8Array(await readArrayBuffer(file)));
-      pushArchiveEntries(expanded, ignoredMacJunkPaths, untar(unpacked), options);
+      pushArchiveEntries(expanded, ignoredLocalMetadataPaths, untar(unpacked), options);
       continue;
     }
     if (lower.endsWith(".gz")) {
       const unpacked = gunzipSync(new Uint8Array(await readArrayBuffer(file)));
       const name = file.name.replace(/\.gz$/i, "");
       const normalizedName = normalizePath(name);
-      if (isMacJunkPath(normalizedName)) {
-        ignoredMacJunkPaths.push(normalizedName || name);
+      if (isLocalMetadataPath(normalizedName)) {
+        ignoredLocalMetadataPaths.push(normalizedName || name);
         continue;
       }
       expanded.push(new File([toArrayBuffer(unpacked)], name, { type: guessContentType(name) }));
       continue;
     }
     const path = getFilePath(file);
-    if (path && isMacJunkPath(path)) {
-      ignoredMacJunkPaths.push(path);
+    if (path && isLocalMetadataPath(path)) {
+      ignoredLocalMetadataPaths.push(path);
       continue;
     }
     expanded.push(file);
   }
-  return { files: expanded, ignoredMacJunkPaths };
+  return { files: expanded, ignoredLocalMetadataPaths };
 }
 
 export async function expandFiles(selected: File[]) {
@@ -137,7 +137,7 @@ async function readAllEntries(reader: FileSystemDirectoryReader) {
 
 function pushArchiveEntries(
   target: File[],
-  ignoredMacJunkPaths: string[],
+  ignoredLocalMetadataPaths: string[],
   entries: Array<{ path: string; data: Uint8Array }>,
   options: ExpandFilesOptions = {},
 ) {
@@ -146,8 +146,8 @@ function pushArchiveEntries(
   for (const entry of entries) {
     const path = normalizePath(entry.path);
     if (!path || path.endsWith("/")) continue;
-    if (isMacJunkPath(path)) {
-      ignoredMacJunkPaths.push(path);
+    if (isLocalMetadataPath(path)) {
+      ignoredLocalMetadataPaths.push(path);
       continue;
     }
     if (!options.includeBinaryArchiveFiles && !isTextPath(path)) continue;
@@ -260,10 +260,11 @@ function unwrapSingleTopLevelFolder<T extends { path: string }>(entries: T[]) {
   }));
 }
 
-function isMacJunkPath(path: string) {
+function isLocalMetadataPath(path: string) {
   const normalized = normalizePath(path).toLowerCase();
   if (!normalized) return false;
   const segments = normalized.split("/").filter(Boolean);
+  if (segments.includes(".git")) return true;
   if (segments.includes("__macosx")) return true;
   const basename = segments.at(-1) ?? "";
   if (basename === ".ds_store") return true;

--- a/src/routes/plugins/publish.tsx
+++ b/src/routes/plugins/publish.tsx
@@ -15,6 +15,11 @@ import { MAX_PUBLISH_FILE_BYTES, MAX_PUBLISH_TOTAL_BYTES } from "../../../convex
 import { EmptyState } from "../../components/EmptyState";
 import { Container } from "../../components/layout/Container";
 import { PackageSourceChooser } from "../../components/PackageSourceChooser";
+import {
+  PublisherOwnerSelect,
+  type PublisherOwnerMembership,
+} from "../../components/PublisherOwnerSelect";
+import { PublishFormSkeleton } from "../../components/PublishFormSkeleton";
 import { SignInButton } from "../../components/SignInButton";
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
@@ -22,6 +27,7 @@ import { Card } from "../../components/ui/card";
 import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
 import { Textarea } from "../../components/ui/textarea";
+import { VersionInput } from "../../components/VersionInput";
 import {
   buildPackageUploadEntries,
   filterIgnoredPackageFiles,
@@ -54,17 +60,9 @@ const apiRefs = api as unknown as {
 const SHOW_CLAWPACK_ONBOARDING_BANNER = false;
 export function PublishPluginRoute() {
   const search = useSearch({ from: "/plugins/publish" });
-  const { isAuthenticated } = useAuthStatus();
+  const { isAuthenticated, isLoading: isAuthLoading } = useAuthStatus();
   const publishers = useQuery(api.publishers.listMine) as
-    | Array<{
-        publisher: {
-          _id: string;
-          handle: string;
-          displayName: string;
-          kind: "user" | "org";
-        };
-        role: "owner" | "admin" | "publisher";
-      }>
+    | Array<PublisherOwnerMembership>
     | undefined;
   const existingPackage = useQuery(
     apiRefs.packages.getByName as never,
@@ -138,6 +136,19 @@ export function PublishPluginRoute() {
   const ownerScopeError = useMemo(() => {
     return getPackageScopeOwnerMismatch(name, ownerHandle)?.message ?? null;
   }, [name, ownerHandle]);
+  const submitBlockers = useMemo(() => {
+    if (isMetadataLocked) return [];
+    const blockers: string[] = [];
+    if (!name.trim()) blockers.push("Plugin name is required.");
+    if (!version.trim()) blockers.push("Version is required.");
+    if (family === "code-plugin") {
+      if (!sourceRepo.trim()) blockers.push("Source repo is required.");
+      if (!sourceCommit.trim()) blockers.push("Source commit is required.");
+    }
+    return blockers;
+  }, [family, isMetadataLocked, name, sourceCommit, sourceRepo, version]);
+  const hasPackageBlocker =
+    Boolean(validationError) || Boolean(ownerScopeError) || codePluginFieldIssues.length > 0;
 
   const onPickFiles = async (selected: File[]) => {
     const expanded = await expandFilesWithReport(selected, {
@@ -146,7 +157,7 @@ export function PublishPluginRoute() {
     const filtered = await filterIgnoredPackageFiles(expanded.files);
     const normalized = normalizePackageUploadFiles(filtered.files);
     const nextIgnoredPaths = [
-      ...new Set([...expanded.ignoredMacJunkPaths, ...filtered.ignoredPaths]),
+      ...new Set([...expanded.ignoredLocalMetadataPaths, ...filtered.ignoredPaths]),
     ];
     setFiles(filtered.files);
     setIgnoredPaths(nextIgnoredPaths);
@@ -178,6 +189,10 @@ export function PublishPluginRoute() {
     setClawScanNote(existingPackage?.latestRelease?.clawScanNote ?? "");
   }, [existingPackage?.latestRelease?.clawScanNote]);
 
+  if (isAuthLoading) {
+    return <PublishFormSkeleton />;
+  }
+
   if (!isAuthenticated) {
     return (
       <main className="py-10">
@@ -195,7 +210,7 @@ export function PublishPluginRoute() {
 
   return (
     <main className="py-10">
-      <Container>
+      <Container size="narrow">
         <header className="mb-6">
           <h1 className="mb-2 font-display text-2xl font-bold text-[color:var(--ink)]">
             {search.name ? "Publish Plugin Release" : "Publish Plugin"}
@@ -252,22 +267,23 @@ export function PublishPluginRoute() {
                 ? "Upload plugin code to detect the package shape and unlock the release form."
                 : "Metadata detected and prefilled. Review it, then fill any missing release details."}
             </p>
-            <select
-              className="min-h-[44px] w-full rounded-[var(--radius-sm)] border border-[rgba(29,59,78,0.22)] bg-[rgba(255,255,255,0.94)] px-3.5 py-[13px] text-sm text-[color:var(--ink)] disabled:cursor-not-allowed disabled:opacity-60 dark:border-[rgba(255,255,255,0.12)] dark:bg-[rgba(14,28,37,0.84)]"
-              value={family}
-              disabled={metadataDisabled}
-              onChange={(event) => setFamily(event.target.value as never)}
+            <Label htmlFor="pluginFamily">Package type</Label>
+            <div
+              id="pluginFamily"
+              className="min-h-[44px] w-full rounded-[var(--radius-sm)] border border-[rgba(29,59,78,0.22)] bg-[rgba(255,255,255,0.94)] px-3.5 py-[13px] text-sm text-[color:var(--ink)] dark:border-[rgba(255,255,255,0.12)] dark:bg-[rgba(14,28,37,0.84)]"
             >
-              <option value="code-plugin">Code plugin</option>
-            </select>
+              {family === "code-plugin" ? "Code plugin" : "Bundle plugin"}
+            </div>
+            <Label htmlFor="pluginName">Plugin name</Label>
             <Input
+              id="pluginName"
               placeholder="Plugin name"
               value={name}
               disabled={metadataDisabled}
               onChange={(event) => setName(event.target.value)}
             />
             {ownerScopeError ? (
-              <Badge variant="accent">
+              <Badge variant="warning">
                 <span>{ownerScopeError}</span>
                 <a
                   href={DocsLinks.clawhub.packageScopeFaq}
@@ -279,31 +295,33 @@ export function PublishPluginRoute() {
                 </a>
               </Badge>
             ) : null}
+            <Label htmlFor="pluginDisplayName">Display name</Label>
             <Input
+              id="pluginDisplayName"
               placeholder="Display name"
               value={displayName}
               disabled={metadataDisabled}
               onChange={(event) => setDisplayName(event.target.value)}
             />
-            <select
-              className="min-h-[44px] w-full rounded-[var(--radius-sm)] border border-[rgba(29,59,78,0.22)] bg-[rgba(255,255,255,0.94)] px-3.5 py-[13px] text-sm text-[color:var(--ink)] disabled:cursor-not-allowed disabled:opacity-60 dark:border-[rgba(255,255,255,0.12)] dark:bg-[rgba(14,28,37,0.84)]"
+            <Label htmlFor="pluginOwner">Owner</Label>
+            <PublisherOwnerSelect
+              id="pluginOwner"
               value={ownerHandle}
+              memberships={publishers}
               disabled={metadataDisabled}
-              onChange={(event) => setOwnerHandle(event.target.value)}
-            >
-              {(publishers ?? []).map((entry) => (
-                <option key={entry.publisher._id} value={entry.publisher.handle}>
-                  @{entry.publisher.handle} &middot; {entry.publisher.displayName}
-                </option>
-              ))}
-            </select>
-            <Input
+              onValueChange={setOwnerHandle}
+            />
+            <Label htmlFor="pluginVersion">Version</Label>
+            <VersionInput
+              id="pluginVersion"
               placeholder="Version"
               value={version}
               disabled={metadataDisabled}
-              onChange={(event) => setVersion(event.target.value)}
+              onValueChange={setVersion}
             />
+            <Label htmlFor="pluginChangelog">Changelog</Label>
             <Textarea
+              id="pluginChangelog"
               placeholder="Changelog"
               rows={4}
               value={changelog}
@@ -323,25 +341,33 @@ export function PublishPluginRoute() {
                 setClawScanNote(event.target.value);
               }}
             />
+            <Label htmlFor="pluginSourceRepo">Source repo</Label>
             <Input
+              id="pluginSourceRepo"
               placeholder="Source repo (owner/repo)"
               value={sourceRepo}
               disabled={metadataDisabled}
               onChange={(event) => setSourceRepo(event.target.value)}
             />
+            <Label htmlFor="pluginSourceCommit">Source commit</Label>
             <Input
+              id="pluginSourceCommit"
               placeholder="Source commit"
               value={sourceCommit}
               disabled={metadataDisabled}
               onChange={(event) => setSourceCommit(event.target.value)}
             />
+            <Label htmlFor="pluginSourceRef">Source ref</Label>
             <Input
+              id="pluginSourceRef"
               placeholder="Source ref (tag or branch)"
               value={sourceRef}
               disabled={metadataDisabled}
               onChange={(event) => setSourceRef(event.target.value)}
             />
+            <Label htmlFor="pluginSourcePath">Source path</Label>
             <Input
+              id="pluginSourcePath"
               placeholder="Source path"
               value={sourcePath}
               disabled={metadataDisabled}
@@ -349,13 +375,17 @@ export function PublishPluginRoute() {
             />
             {family === "bundle-plugin" ? (
               <>
+                <Label htmlFor="pluginBundleFormat">Bundle format</Label>
                 <Input
+                  id="pluginBundleFormat"
                   placeholder="Bundle format"
                   value={bundleFormat}
                   disabled={metadataDisabled}
                   onChange={(event) => setBundleFormat(event.target.value)}
                 />
+                <Label htmlFor="pluginHostTargets">Host targets</Label>
                 <Input
+                  id="pluginHostTargets"
                   placeholder="Host targets (comma separated)"
                   value={hostTargets}
                   disabled={metadataDisabled}
@@ -372,14 +402,9 @@ export function PublishPluginRoute() {
             disabled={
               !isAuthenticated ||
               isMetadataLocked ||
-              !name.trim() ||
-              !version.trim() ||
-              files.length === 0 ||
-              Boolean(validationError) ||
-              Boolean(ownerScopeError) ||
-              isSubmitting ||
-              (family === "code-plugin" &&
-                (!sourceRepo.trim() || !sourceCommit.trim() || codePluginFieldIssues.length > 0))
+              hasPackageBlocker ||
+              submitBlockers.length > 0 ||
+              isSubmitting
             }
             onClick={() => {
               startTransition(() => {
@@ -458,7 +483,14 @@ export function PublishPluginRoute() {
           >
             {status ?? "Publish"}
           </Button>
-          {error ? <Badge variant="accent">{error}</Badge> : null}
+          {submitBlockers.length > 0 ? (
+            <ul className="flex flex-col gap-1 list-disc pl-5 text-sm text-[color:var(--ink-soft)]">
+              {submitBlockers.map((blocker) => (
+                <li key={blocker}>{blocker}</li>
+              ))}
+            </ul>
+          ) : null}
+          {error ? <Badge variant="destructive">{error}</Badge> : null}
         </div>
       </Container>
     </main>

--- a/src/routes/plugins/publish.tsx
+++ b/src/routes/plugins/publish.tsx
@@ -4,10 +4,10 @@ import {
   getPackageScopeOwnerMismatch,
   MAX_CLAWSCAN_NOTE_CHARS,
   normalizeClawScanNote,
-  type PackageCompatibility,
 } from "clawhub-schema";
 import { useAction, useMutation, useQuery } from "convex/react";
-import { startTransition, useEffect, useMemo, useRef, useState } from "react";
+import { Info, Lock } from "lucide-react";
+import { type ReactNode, startTransition, useEffect, useMemo, useRef, useState } from "react";
 import semver from "semver";
 import { toast } from "sonner";
 import { api } from "../../../convex/_generated/api";
@@ -94,11 +94,10 @@ export function PublishPluginRoute() {
   const [ignoredPaths, setIgnoredPaths] = useState<string[]>([]);
   const [detectedPrefillFields, setDetectedPrefillFields] = useState<string[]>([]);
   const [codePluginFieldIssues, setCodePluginFieldIssues] = useState<string[]>([]);
-  const [codePluginCompatibility, setCodePluginCompatibility] =
-    useState<PackageCompatibility | null>(null);
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const clawScanNoteTouchedRef = useRef(false);
+  const showChangelogField = Boolean(search.name);
 
   const totalBytes = useMemo(() => files.reduce((sum, file) => sum + file.size, 0), [files]);
   const normalizedPaths = useMemo(
@@ -142,13 +141,43 @@ export function PublishPluginRoute() {
     if (!name.trim()) blockers.push("Plugin name is required.");
     if (!version.trim()) blockers.push("Version is required.");
     if (family === "code-plugin") {
-      if (!sourceRepo.trim()) blockers.push("Source repo is required.");
-      if (!sourceCommit.trim()) blockers.push("Source commit is required.");
+      if (!sourceRepo.trim()) blockers.push("GitHub repository is required.");
+      if (!sourceCommit.trim()) blockers.push("Commit SHA is required.");
     }
     return blockers;
   }, [family, isMetadataLocked, name, sourceCommit, sourceRepo, version]);
   const hasPackageBlocker =
     Boolean(validationError) || Boolean(ownerScopeError) || codePluginFieldIssues.length > 0;
+  const isPublishDisabled =
+    !isAuthenticated ||
+    isMetadataLocked ||
+    hasPackageBlocker ||
+    submitBlockers.length > 0 ||
+    isSubmitting;
+  const publishBlockerSummary = useMemo(() => {
+    if (isSubmitting) return null;
+    if (!isAuthenticated) return "Sign in to publish.";
+    if (isMetadataLocked) return "Complete plugin files to publish.";
+    if (validationError) return `Fix: ${validationError}`;
+    if (ownerScopeError) return `Fix: ${ownerScopeError}`;
+    if (codePluginFieldIssues.length > 0) {
+      return `Fix package metadata: ${formatInlineList(codePluginFieldIssues)}.`;
+    }
+    const missing = submitBlockers.flatMap(missingPluginPublishLabel);
+    const uniqueMissing = [...new Set(missing)];
+    if (uniqueMissing.length > 0) {
+      return `Complete ${formatInlineList(uniqueMissing)} to publish.`;
+    }
+    return null;
+  }, [
+    codePluginFieldIssues,
+    isAuthenticated,
+    isMetadataLocked,
+    isSubmitting,
+    ownerScopeError,
+    submitBlockers,
+    validationError,
+  ]);
 
   const onPickFiles = async (selected: File[]) => {
     const expanded = await expandFilesWithReport(selected, {
@@ -165,7 +194,6 @@ export function PublishPluginRoute() {
     const prefill = await derivePluginPrefill(normalized);
     setDetectedPrefillFields(listPrefilledFields(prefill));
     setCodePluginFieldIssues(prefill.missingRequiredFields ?? []);
-    setCodePluginCompatibility(prefill.compatibility ?? null);
     if (prefill.family === "code-plugin") setFamily(prefill.family);
     if (prefill.name) setName(prefill.name);
     if (prefill.displayName) setDisplayName(prefill.displayName);
@@ -173,6 +201,14 @@ export function PublishPluginRoute() {
     if (prefill.sourceRepo) setSourceRepo(prefill.sourceRepo);
     if (prefill.bundleFormat) setBundleFormat(prefill.bundleFormat);
     if (prefill.hostTargets) setHostTargets(prefill.hostTargets);
+  };
+
+  const clearSelectedFiles = () => {
+    setFiles([]);
+    setIgnoredPaths([]);
+    setDetectedPrefillFields([]);
+    setCodePluginFieldIssues([]);
+    setError(null);
   };
 
   useEffect(() => {
@@ -253,8 +289,8 @@ export function PublishPluginRoute() {
           family={family}
           validationError={validationError}
           codePluginFieldIssues={codePluginFieldIssues}
-          codePluginCompatibility={codePluginCompatibility}
           onPickFiles={onPickFiles}
+          onClearFiles={clearSelectedFiles}
         />
 
         <Card
@@ -262,150 +298,238 @@ export function PublishPluginRoute() {
           aria-disabled={isMetadataLocked}
         >
           <div className="flex flex-col gap-3">
-            <p className="text-sm text-[color:var(--ink-soft)]">
-              {isMetadataLocked
-                ? "Upload plugin code to detect the package shape and unlock the release form."
-                : "Metadata detected and prefilled. Review it, then fill any missing release details."}
-            </p>
-            <Label htmlFor="pluginFamily">Package type</Label>
-            <div
-              id="pluginFamily"
-              className="min-h-[44px] w-full rounded-[var(--radius-sm)] border border-[rgba(29,59,78,0.22)] bg-[rgba(255,255,255,0.94)] px-3.5 py-[13px] text-sm text-[color:var(--ink)] dark:border-[rgba(255,255,255,0.12)] dark:bg-[rgba(14,28,37,0.84)]"
-            >
-              {family === "code-plugin" ? "Code plugin" : "Bundle plugin"}
-            </div>
-            <Label htmlFor="pluginName">Plugin name</Label>
-            <Input
-              id="pluginName"
-              placeholder="Plugin name"
-              value={name}
-              disabled={metadataDisabled}
-              onChange={(event) => setName(event.target.value)}
-            />
-            {ownerScopeError ? (
-              <Badge variant="warning">
-                <span>{ownerScopeError}</span>
-                <a
-                  href={DocsLinks.clawhub.packageScopeFaq}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline underline-offset-2"
+            <div className="grid gap-x-4 gap-y-3 md:grid-cols-2">
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="pluginFamily">Package type</Label>
+                <div
+                  id="pluginFamily"
+                  className="min-h-[44px] w-full rounded-[var(--radius-sm)] border border-[rgba(29,59,78,0.22)] bg-[rgba(255,255,255,0.94)] px-3.5 py-[13px] text-sm text-[color:var(--ink)] dark:border-[rgba(255,255,255,0.12)] dark:bg-[rgba(14,28,37,0.84)]"
                 >
-                  Learn how publishing works
-                </a>
-              </Badge>
-            ) : null}
-            <Label htmlFor="pluginDisplayName">Display name</Label>
-            <Input
-              id="pluginDisplayName"
-              placeholder="Display name"
-              value={displayName}
-              disabled={metadataDisabled}
-              onChange={(event) => setDisplayName(event.target.value)}
-            />
-            <Label htmlFor="pluginOwner">Owner</Label>
-            <PublisherOwnerSelect
-              id="pluginOwner"
-              value={ownerHandle}
-              memberships={publishers}
-              disabled={metadataDisabled}
-              onValueChange={setOwnerHandle}
-            />
-            <Label htmlFor="pluginVersion">Version</Label>
-            <VersionInput
-              id="pluginVersion"
-              placeholder="Version"
-              value={version}
-              disabled={metadataDisabled}
-              onValueChange={setVersion}
-            />
-            <Label htmlFor="pluginChangelog">Changelog</Label>
+                  {family === "code-plugin" ? "Code plugin" : "Bundle plugin"}
+                </div>
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="pluginName">Plugin name</Label>
+                <Input
+                  id="pluginName"
+                  placeholder="Plugin name"
+                  value={name}
+                  disabled={metadataDisabled}
+                  onChange={(event) => setName(event.target.value)}
+                />
+              </div>
+              {ownerScopeError ? (
+                <Badge variant="warning" className="md:col-span-2">
+                  <span>{ownerScopeError}</span>
+                  <a
+                    href={DocsLinks.clawhub.packageScopeFaq}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline underline-offset-2"
+                  >
+                    Learn how publishing works
+                  </a>
+                </Badge>
+              ) : null}
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="pluginDisplayName">Display name</Label>
+                <Input
+                  id="pluginDisplayName"
+                  placeholder="Display name"
+                  value={displayName}
+                  disabled={metadataDisabled}
+                  onChange={(event) => setDisplayName(event.target.value)}
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="pluginOwner">Owner</Label>
+                <PublisherOwnerSelect
+                  id="pluginOwner"
+                  value={ownerHandle}
+                  memberships={publishers}
+                  disabled={metadataDisabled}
+                  onValueChange={setOwnerHandle}
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="pluginVersion">Version</Label>
+                <VersionInput
+                  id="pluginVersion"
+                  placeholder="Version"
+                  value={version}
+                  disabled={metadataDisabled}
+                  onValueChange={setVersion}
+                />
+              </div>
+              <div className="flex flex-col gap-2 md:col-span-2">
+                <Label htmlFor="pluginClawScanNote">ClawScan note</Label>
+                <Textarea
+                  id="pluginClawScanNote"
+                  placeholder="Optional context for ClawScan, e.g. why this release needs native host access."
+                  rows={4}
+                  value={clawScanNote}
+                  maxLength={MAX_CLAWSCAN_NOTE_CHARS + 1}
+                  disabled={metadataDisabled}
+                  onChange={(event) => {
+                    clawScanNoteTouchedRef.current = true;
+                    setClawScanNote(event.target.value);
+                  }}
+                />
+              </div>
+              {family === "bundle-plugin" ? (
+                <>
+                  <div className="flex flex-col gap-2">
+                    <Label htmlFor="pluginBundleFormat">Bundle format</Label>
+                    <Input
+                      id="pluginBundleFormat"
+                      placeholder="Bundle format"
+                      value={bundleFormat}
+                      disabled={metadataDisabled}
+                      onChange={(event) => setBundleFormat(event.target.value)}
+                    />
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    <Label htmlFor="pluginHostTargets">Host targets</Label>
+                    <Input
+                      id="pluginHostTargets"
+                      placeholder="Host targets (comma separated)"
+                      value={hostTargets}
+                      disabled={metadataDisabled}
+                      onChange={(event) => setHostTargets(event.target.value)}
+                    />
+                  </div>
+                </>
+              ) : null}
+            </div>
+          </div>
+        </Card>
+
+        <Card
+          className={`mt-5 ${isMetadataLocked ? "pointer-events-none opacity-60" : ""}`}
+          aria-disabled={isMetadataLocked}
+        >
+          <div className="flex flex-col gap-3">
+            <div>
+              <h2 className="font-display text-lg font-bold leading-tight text-[color:var(--ink)]">
+                Source
+              </h2>
+              <p className="mt-1 text-sm text-[color:var(--ink-soft)]">
+                Required for code plugins: the GitHub repository and exact commit that produced this
+                upload.
+              </p>
+            </div>
+            <div className="grid gap-x-4 gap-y-3 md:grid-cols-2">
+              <div className="flex flex-col gap-2">
+                <FieldLabelWithHelp
+                  htmlFor="pluginSourceRepo"
+                  help="Use owner/repo, for example openclaw/demo-plugin."
+                >
+                  GitHub repository
+                </FieldLabelWithHelp>
+                <Input
+                  id="pluginSourceRepo"
+                  placeholder="owner/repo"
+                  value={sourceRepo}
+                  disabled={metadataDisabled}
+                  onChange={(event) => setSourceRepo(event.target.value)}
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <FieldLabelWithHelp
+                  htmlFor="pluginSourceCommit"
+                  help="Use the exact Git commit SHA for this release, preferably the full hash."
+                >
+                  Commit SHA
+                </FieldLabelWithHelp>
+                <Input
+                  id="pluginSourceCommit"
+                  placeholder="Full commit SHA"
+                  value={sourceCommit}
+                  disabled={metadataDisabled}
+                  onChange={(event) => setSourceCommit(event.target.value)}
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <FieldLabelWithHelp
+                  htmlFor="pluginSourceRef"
+                  help="Optional tag or branch that points at the release source."
+                >
+                  Tag or branch
+                </FieldLabelWithHelp>
+                <Input
+                  id="pluginSourceRef"
+                  placeholder="v1.0.0 or main"
+                  value={sourceRef}
+                  disabled={metadataDisabled}
+                  onChange={(event) => setSourceRef(event.target.value)}
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <FieldLabelWithHelp
+                  htmlFor="pluginSourcePath"
+                  help="Use . when the package is at the repo root; otherwise use its subfolder path."
+                >
+                  Package path
+                </FieldLabelWithHelp>
+                <Input
+                  id="pluginSourcePath"
+                  placeholder="."
+                  value={sourcePath}
+                  disabled={metadataDisabled}
+                  onChange={(event) => setSourcePath(event.target.value)}
+                />
+              </div>
+            </div>
+          </div>
+        </Card>
+
+        {showChangelogField ? (
+          <Card
+            className={`mt-5 ${isMetadataLocked ? "pointer-events-none opacity-60" : ""}`}
+            aria-disabled={isMetadataLocked}
+          >
+            <div>
+              <h2 className="font-display text-lg font-bold leading-tight text-[color:var(--ink)]">
+                Changelog
+              </h2>
+              <p className="mt-1 text-sm text-[color:var(--ink-soft)]">
+                Summarize what changed in this release.
+              </p>
+            </div>
+            <Label htmlFor="pluginChangelog" className="sr-only">
+              Changelog
+            </Label>
             <Textarea
               id="pluginChangelog"
-              placeholder="Changelog"
+              placeholder="Describe what changed in this release..."
               rows={4}
               value={changelog}
               disabled={metadataDisabled}
               onChange={(event) => setChangelog(event.target.value)}
             />
-            <Label htmlFor="pluginClawScanNote">ClawScan note</Label>
-            <Textarea
-              id="pluginClawScanNote"
-              placeholder="Optional context for ClawScan, e.g. why this release needs native host access."
-              rows={4}
-              value={clawScanNote}
-              maxLength={MAX_CLAWSCAN_NOTE_CHARS + 1}
-              disabled={metadataDisabled}
-              onChange={(event) => {
-                clawScanNoteTouchedRef.current = true;
-                setClawScanNote(event.target.value);
-              }}
-            />
-            <Label htmlFor="pluginSourceRepo">Source repo</Label>
-            <Input
-              id="pluginSourceRepo"
-              placeholder="Source repo (owner/repo)"
-              value={sourceRepo}
-              disabled={metadataDisabled}
-              onChange={(event) => setSourceRepo(event.target.value)}
-            />
-            <Label htmlFor="pluginSourceCommit">Source commit</Label>
-            <Input
-              id="pluginSourceCommit"
-              placeholder="Source commit"
-              value={sourceCommit}
-              disabled={metadataDisabled}
-              onChange={(event) => setSourceCommit(event.target.value)}
-            />
-            <Label htmlFor="pluginSourceRef">Source ref</Label>
-            <Input
-              id="pluginSourceRef"
-              placeholder="Source ref (tag or branch)"
-              value={sourceRef}
-              disabled={metadataDisabled}
-              onChange={(event) => setSourceRef(event.target.value)}
-            />
-            <Label htmlFor="pluginSourcePath">Source path</Label>
-            <Input
-              id="pluginSourcePath"
-              placeholder="Source path"
-              value={sourcePath}
-              disabled={metadataDisabled}
-              onChange={(event) => setSourcePath(event.target.value)}
-            />
-            {family === "bundle-plugin" ? (
-              <>
-                <Label htmlFor="pluginBundleFormat">Bundle format</Label>
-                <Input
-                  id="pluginBundleFormat"
-                  placeholder="Bundle format"
-                  value={bundleFormat}
-                  disabled={metadataDisabled}
-                  onChange={(event) => setBundleFormat(event.target.value)}
-                />
-                <Label htmlFor="pluginHostTargets">Host targets</Label>
-                <Input
-                  id="pluginHostTargets"
-                  placeholder="Host targets (comma separated)"
-                  value={hostTargets}
-                  disabled={metadataDisabled}
-                  onChange={(event) => setHostTargets(event.target.value)}
-                />
-              </>
+          </Card>
+        ) : null}
+
+        <div className="mt-5 flex items-center justify-between gap-4">
+          <div className="flex flex-col gap-2">
+            {error ? (
+              <div className="text-sm font-medium text-red-600 dark:text-red-400" role="alert">
+                {error}
+              </div>
+            ) : null}
+            {status ? <div className="text-sm text-[color:var(--ink-soft)]">{status}</div> : null}
+            {publishBlockerSummary ? (
+              <div className="text-sm font-medium text-status-error-fg">
+                {publishBlockerSummary}
+              </div>
             ) : null}
           </div>
-        </Card>
-
-        <div className="flex flex-col gap-3">
           <Button
             variant="primary"
-            disabled={
-              !isAuthenticated ||
-              isMetadataLocked ||
-              hasPackageBlocker ||
-              submitBlockers.length > 0 ||
-              isSubmitting
-            }
+            size="lg"
+            type="button"
+            disabled={isPublishDisabled}
+            loading={isSubmitting}
             onClick={() => {
               startTransition(() => {
                 void (async () => {
@@ -481,18 +605,44 @@ export function PublishPluginRoute() {
               });
             }}
           >
-            {status ?? "Publish"}
+            {isPublishDisabled && !isSubmitting ? (
+              <Lock className="h-4 w-4" aria-hidden="true" />
+            ) : null}
+            Publish plugin
           </Button>
-          {submitBlockers.length > 0 ? (
-            <ul className="flex flex-col gap-1 list-disc pl-5 text-sm text-[color:var(--ink-soft)]">
-              {submitBlockers.map((blocker) => (
-                <li key={blocker}>{blocker}</li>
-              ))}
-            </ul>
-          ) : null}
-          {error ? <Badge variant="destructive">{error}</Badge> : null}
         </div>
       </Container>
     </main>
   );
+}
+
+function FieldLabelWithHelp(props: { htmlFor: string; help: string; children: ReactNode }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <Label htmlFor={props.htmlFor}>{props.children}</Label>
+      <span
+        tabIndex={0}
+        role="img"
+        aria-label={`Help: ${props.help}`}
+        title={props.help}
+        className="inline-flex cursor-help text-[color:var(--ink-soft)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)]/35"
+      >
+        <Info className="h-3.5 w-3.5" aria-hidden="true" />
+      </span>
+    </div>
+  );
+}
+
+function formatInlineList(items: string[]) {
+  if (items.length <= 1) return items[0] ?? "";
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items.at(-1)}`;
+}
+
+function missingPluginPublishLabel(issue: string) {
+  if (issue === "Plugin name is required.") return ["plugin name"];
+  if (issue === "Version is required.") return ["version"];
+  if (issue === "GitHub repository is required.") return ["GitHub repository"];
+  if (issue === "Commit SHA is required.") return ["commit SHA"];
+  return [];
 }

--- a/src/routes/plugins/publish.tsx
+++ b/src/routes/plugins/publish.tsx
@@ -152,12 +152,14 @@ export function PublishPluginRoute() {
   }, [family, isMetadataLocked, name, sourceCommit, sourceRepo, version]);
   const hasPackageBlocker =
     Boolean(validationError) || Boolean(ownerScopeError) || codePluginFieldIssues.length > 0;
+  const hasPublished = status?.startsWith("Published.") ?? false;
   const isPublishDisabled =
     !isAuthenticated ||
     isMetadataLocked ||
     hasPackageBlocker ||
     submitBlockers.length > 0 ||
-    isSubmitting;
+    isSubmitting ||
+    hasPublished;
   const publishBlockerSummary = useMemo(() => {
     if (isSubmitting) return null;
     if (!isAuthenticated) return "Sign in to publish.";

--- a/src/routes/plugins/publish.tsx
+++ b/src/routes/plugins/publish.tsx
@@ -14,7 +14,10 @@ import { api } from "../../../convex/_generated/api";
 import { MAX_PUBLISH_FILE_BYTES, MAX_PUBLISH_TOTAL_BYTES } from "../../../convex/lib/publishLimits";
 import { EmptyState } from "../../components/EmptyState";
 import { Container } from "../../components/layout/Container";
-import { PackageSourceChooser } from "../../components/PackageSourceChooser";
+import {
+  PackageSourceChooser,
+  type PackagePickSource,
+} from "../../components/PackageSourceChooser";
 import {
   PublisherOwnerSelect,
   type PublisherOwnerMembership,
@@ -91,6 +94,7 @@ export function PublishPluginRoute() {
   const [bundleFormat, setBundleFormat] = useState("");
   const [hostTargets, setHostTargets] = useState("");
   const [files, setFiles] = useState<File[]>([]);
+  const [packageSourceKind, setPackageSourceKind] = useState<PackagePickSource | null>(null);
   const [ignoredPaths, setIgnoredPaths] = useState<string[]>([]);
   const [detectedPrefillFields, setDetectedPrefillFields] = useState<string[]>([]);
   const [codePluginFieldIssues, setCodePluginFieldIssues] = useState<string[]>([]);
@@ -179,7 +183,7 @@ export function PublishPluginRoute() {
     validationError,
   ]);
 
-  const onPickFiles = async (selected: File[]) => {
+  const onPickFiles = async (selected: File[], sourceKind: PackagePickSource) => {
     const expanded = await expandFilesWithReport(selected, {
       includeBinaryArchiveFiles: true,
     });
@@ -189,6 +193,7 @@ export function PublishPluginRoute() {
       ...new Set([...expanded.ignoredLocalMetadataPaths, ...filtered.ignoredPaths]),
     ];
     setFiles(filtered.files);
+    setPackageSourceKind(sourceKind);
     setIgnoredPaths(nextIgnoredPaths);
     setError(null);
     const prefill = await derivePluginPrefill(normalized);
@@ -205,6 +210,7 @@ export function PublishPluginRoute() {
 
   const clearSelectedFiles = () => {
     setFiles([]);
+    setPackageSourceKind(null);
     setIgnoredPaths([]);
     setDetectedPrefillFields([]);
     setCodePluginFieldIssues([]);
@@ -252,10 +258,7 @@ export function PublishPluginRoute() {
             {search.name ? "Publish Plugin Release" : "Publish Plugin"}
           </h1>
           <p className="text-sm text-[color:var(--ink-soft)]">
-            Publish a native code plugin release.
-          </p>
-          <p className="text-sm text-[color:var(--ink-soft)]">
-            New releases stay private until automated security checks and verification finish.
+            Upload a plugin folder, zip, or tgz.
           </p>
           {search.name ? (
             <p className="text-sm text-[color:var(--ink-soft)]">
@@ -284,6 +287,7 @@ export function PublishPluginRoute() {
           totalBytes={totalBytes}
           normalizedPaths={normalizedPaths}
           normalizedPathSet={normalizedPathSet}
+          selectedSourceKind={packageSourceKind}
           ignoredPaths={ignoredPaths}
           detectedPrefillFields={detectedPrefillFields}
           family={family}
@@ -293,323 +297,344 @@ export function PublishPluginRoute() {
           onClearFiles={clearSelectedFiles}
         />
 
-        <Card
-          className={isMetadataLocked ? "pointer-events-none opacity-60" : ""}
-          aria-disabled={isMetadataLocked}
+        <div
+          className={
+            isMetadataLocked
+              ? "relative max-h-[540px] overflow-hidden md:max-h-[600px]"
+              : "contents"
+          }
         >
-          <div className="flex flex-col gap-3">
-            <div className="grid gap-x-4 gap-y-3 md:grid-cols-2">
-              <div className="flex flex-col gap-2">
-                <Label htmlFor="pluginFamily">Package type</Label>
-                <div
-                  id="pluginFamily"
-                  className="min-h-[44px] w-full rounded-[var(--radius-sm)] border border-[rgba(29,59,78,0.22)] bg-[rgba(255,255,255,0.94)] px-3.5 py-[13px] text-sm text-[color:var(--ink)] dark:border-[rgba(255,255,255,0.12)] dark:bg-[rgba(14,28,37,0.84)]"
-                >
-                  {family === "code-plugin" ? "Code plugin" : "Bundle plugin"}
+          <Card
+            className={isMetadataLocked ? "pointer-events-none opacity-60" : ""}
+            aria-disabled={isMetadataLocked}
+          >
+            <div className="flex flex-col gap-5">
+              <div className="grid gap-x-4 gap-y-4 md:grid-cols-2">
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="pluginName">Plugin name</Label>
+                  <Input
+                    id="pluginName"
+                    placeholder="Plugin name"
+                    value={name}
+                    disabled={metadataDisabled}
+                    onChange={(event) => setName(event.target.value)}
+                  />
                 </div>
-              </div>
-              <div className="flex flex-col gap-2">
-                <Label htmlFor="pluginName">Plugin name</Label>
-                <Input
-                  id="pluginName"
-                  placeholder="Plugin name"
-                  value={name}
-                  disabled={metadataDisabled}
-                  onChange={(event) => setName(event.target.value)}
-                />
-              </div>
-              {ownerScopeError ? (
-                <Badge variant="warning" className="md:col-span-2">
-                  <span>{ownerScopeError}</span>
-                  <a
-                    href={DocsLinks.clawhub.packageScopeFaq}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="underline underline-offset-2"
+                {ownerScopeError ? (
+                  <Badge variant="warning" className="md:col-span-2">
+                    <span>{ownerScopeError}</span>
+                    <a
+                      href={DocsLinks.clawhub.packageScopeFaq}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline underline-offset-2"
+                    >
+                      Learn how publishing works
+                    </a>
+                  </Badge>
+                ) : null}
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="pluginDisplayName">Display name</Label>
+                  <Input
+                    id="pluginDisplayName"
+                    placeholder="Display name"
+                    value={displayName}
+                    disabled={metadataDisabled}
+                    onChange={(event) => setDisplayName(event.target.value)}
+                  />
+                </div>
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="pluginFamily">Package type</Label>
+                  <div
+                    id="pluginFamily"
+                    className="min-h-[44px] w-full rounded-[var(--radius-sm)] border border-[rgba(29,59,78,0.22)] bg-[rgba(255,255,255,0.94)] px-3.5 py-[13px] text-sm text-[color:var(--ink)] dark:border-[rgba(255,255,255,0.12)] dark:bg-[rgba(14,28,37,0.84)]"
                   >
-                    Learn how publishing works
-                  </a>
-                </Badge>
-              ) : null}
-              <div className="flex flex-col gap-2">
-                <Label htmlFor="pluginDisplayName">Display name</Label>
-                <Input
-                  id="pluginDisplayName"
-                  placeholder="Display name"
-                  value={displayName}
-                  disabled={metadataDisabled}
-                  onChange={(event) => setDisplayName(event.target.value)}
-                />
-              </div>
-              <div className="flex flex-col gap-2">
-                <Label htmlFor="pluginOwner">Owner</Label>
-                <PublisherOwnerSelect
-                  id="pluginOwner"
-                  value={ownerHandle}
-                  memberships={publishers}
-                  disabled={metadataDisabled}
-                  onValueChange={setOwnerHandle}
-                />
-              </div>
-              <div className="flex flex-col gap-2">
-                <Label htmlFor="pluginVersion">Version</Label>
-                <VersionInput
-                  id="pluginVersion"
-                  placeholder="Version"
-                  value={version}
-                  disabled={metadataDisabled}
-                  onValueChange={setVersion}
-                />
-              </div>
-              <div className="flex flex-col gap-2 md:col-span-2">
-                <Label htmlFor="pluginClawScanNote">ClawScan note</Label>
-                <Textarea
-                  id="pluginClawScanNote"
-                  placeholder="Optional context for ClawScan, e.g. why this release needs native host access."
-                  rows={4}
-                  value={clawScanNote}
-                  maxLength={MAX_CLAWSCAN_NOTE_CHARS + 1}
-                  disabled={metadataDisabled}
-                  onChange={(event) => {
-                    clawScanNoteTouchedRef.current = true;
-                    setClawScanNote(event.target.value);
-                  }}
-                />
-              </div>
-              {family === "bundle-plugin" ? (
-                <>
-                  <div className="flex flex-col gap-2">
-                    <Label htmlFor="pluginBundleFormat">Bundle format</Label>
-                    <Input
-                      id="pluginBundleFormat"
-                      placeholder="Bundle format"
-                      value={bundleFormat}
-                      disabled={metadataDisabled}
-                      onChange={(event) => setBundleFormat(event.target.value)}
-                    />
+                    {family === "code-plugin" ? "Code plugin" : "Bundle plugin"}
                   </div>
-                  <div className="flex flex-col gap-2">
-                    <Label htmlFor="pluginHostTargets">Host targets</Label>
-                    <Input
-                      id="pluginHostTargets"
-                      placeholder="Host targets (comma separated)"
-                      value={hostTargets}
-                      disabled={metadataDisabled}
-                      onChange={(event) => setHostTargets(event.target.value)}
-                    />
-                  </div>
-                </>
-              ) : null}
+                </div>
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="pluginOwner">Owner</Label>
+                  <PublisherOwnerSelect
+                    id="pluginOwner"
+                    value={ownerHandle}
+                    memberships={publishers}
+                    disabled={metadataDisabled}
+                    onValueChange={setOwnerHandle}
+                  />
+                </div>
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="pluginVersion">Version</Label>
+                  <VersionInput
+                    id="pluginVersion"
+                    placeholder="Version"
+                    value={version}
+                    disabled={metadataDisabled}
+                    onValueChange={setVersion}
+                  />
+                </div>
+                <div className="flex flex-col gap-2 md:col-span-2">
+                  <Label htmlFor="pluginClawScanNote">ClawScan note</Label>
+                  <Textarea
+                    id="pluginClawScanNote"
+                    placeholder="Optional context for ClawScan, e.g. why this release needs native host access."
+                    rows={4}
+                    value={clawScanNote}
+                    maxLength={MAX_CLAWSCAN_NOTE_CHARS + 1}
+                    disabled={metadataDisabled}
+                    onChange={(event) => {
+                      clawScanNoteTouchedRef.current = true;
+                      setClawScanNote(event.target.value);
+                    }}
+                  />
+                </div>
+                {family === "bundle-plugin" ? (
+                  <>
+                    <div className="flex flex-col gap-2">
+                      <Label htmlFor="pluginBundleFormat">Bundle format</Label>
+                      <Input
+                        id="pluginBundleFormat"
+                        placeholder="Bundle format"
+                        value={bundleFormat}
+                        disabled={metadataDisabled}
+                        onChange={(event) => setBundleFormat(event.target.value)}
+                      />
+                    </div>
+                    <div className="flex flex-col gap-2">
+                      <Label htmlFor="pluginHostTargets">Host targets</Label>
+                      <Input
+                        id="pluginHostTargets"
+                        placeholder="Host targets (comma separated)"
+                        value={hostTargets}
+                        disabled={metadataDisabled}
+                        onChange={(event) => setHostTargets(event.target.value)}
+                      />
+                    </div>
+                  </>
+                ) : null}
+              </div>
             </div>
-          </div>
-        </Card>
+          </Card>
 
-        <Card
-          className={`mt-5 ${isMetadataLocked ? "pointer-events-none opacity-60" : ""}`}
-          aria-disabled={isMetadataLocked}
-        >
-          <div className="flex flex-col gap-3">
-            <div>
-              <h2 className="font-display text-lg font-bold leading-tight text-[color:var(--ink)]">
-                Source
-              </h2>
-              <p className="mt-1 text-sm text-[color:var(--ink-soft)]">
-                Required for code plugins: the GitHub repository and exact commit that produced this
-                upload.
-              </p>
-            </div>
-            <div className="grid gap-x-4 gap-y-3 md:grid-cols-2">
-              <div className="flex flex-col gap-2">
-                <FieldLabelWithHelp
-                  htmlFor="pluginSourceRepo"
-                  help="Use owner/repo, for example openclaw/demo-plugin."
-                >
-                  GitHub repository
-                </FieldLabelWithHelp>
-                <Input
-                  id="pluginSourceRepo"
-                  placeholder="owner/repo"
-                  value={sourceRepo}
-                  disabled={metadataDisabled}
-                  onChange={(event) => setSourceRepo(event.target.value)}
-                />
-              </div>
-              <div className="flex flex-col gap-2">
-                <FieldLabelWithHelp
-                  htmlFor="pluginSourceCommit"
-                  help="Use the exact Git commit SHA for this release, preferably the full hash."
-                >
-                  Commit SHA
-                </FieldLabelWithHelp>
-                <Input
-                  id="pluginSourceCommit"
-                  placeholder="Full commit SHA"
-                  value={sourceCommit}
-                  disabled={metadataDisabled}
-                  onChange={(event) => setSourceCommit(event.target.value)}
-                />
-              </div>
-              <div className="flex flex-col gap-2">
-                <FieldLabelWithHelp
-                  htmlFor="pluginSourceRef"
-                  help="Optional tag or branch that points at the release source."
-                >
-                  Tag or branch
-                </FieldLabelWithHelp>
-                <Input
-                  id="pluginSourceRef"
-                  placeholder="v1.0.0 or main"
-                  value={sourceRef}
-                  disabled={metadataDisabled}
-                  onChange={(event) => setSourceRef(event.target.value)}
-                />
-              </div>
-              <div className="flex flex-col gap-2">
-                <FieldLabelWithHelp
-                  htmlFor="pluginSourcePath"
-                  help="Use . when the package is at the repo root; otherwise use its subfolder path."
-                >
-                  Package path
-                </FieldLabelWithHelp>
-                <Input
-                  id="pluginSourcePath"
-                  placeholder="."
-                  value={sourcePath}
-                  disabled={metadataDisabled}
-                  onChange={(event) => setSourcePath(event.target.value)}
-                />
-              </div>
-            </div>
-          </div>
-        </Card>
-
-        {showChangelogField ? (
           <Card
             className={`mt-5 ${isMetadataLocked ? "pointer-events-none opacity-60" : ""}`}
             aria-disabled={isMetadataLocked}
           >
-            <div>
-              <h2 className="font-display text-lg font-bold leading-tight text-[color:var(--ink)]">
-                Changelog
-              </h2>
-              <p className="mt-1 text-sm text-[color:var(--ink-soft)]">
-                Summarize what changed in this release.
-              </p>
+            <div className="flex flex-col gap-5">
+              <div>
+                <h2 className="font-display text-lg font-bold leading-tight text-[color:var(--ink)]">
+                  Source
+                </h2>
+              </div>
+              <div className="grid gap-x-4 gap-y-4 md:grid-cols-2">
+                <div className="flex flex-col gap-2">
+                  <FieldLabelWithHelp
+                    htmlFor="pluginSourceRepo"
+                    help="Use owner/repo, for example openclaw/demo-plugin."
+                  >
+                    GitHub repository
+                  </FieldLabelWithHelp>
+                  <Input
+                    id="pluginSourceRepo"
+                    placeholder="owner/repo"
+                    value={sourceRepo}
+                    disabled={metadataDisabled}
+                    onChange={(event) => setSourceRepo(event.target.value)}
+                  />
+                </div>
+                <div className="flex flex-col gap-2">
+                  <FieldLabelWithHelp
+                    htmlFor="pluginSourceCommit"
+                    help="Use the exact Git commit SHA for this release, preferably the full hash."
+                  >
+                    Commit SHA
+                  </FieldLabelWithHelp>
+                  <Input
+                    id="pluginSourceCommit"
+                    placeholder="Full commit SHA"
+                    value={sourceCommit}
+                    disabled={metadataDisabled}
+                    onChange={(event) => setSourceCommit(event.target.value)}
+                  />
+                </div>
+                <div className="flex flex-col gap-2">
+                  <FieldLabelWithHelp
+                    htmlFor="pluginSourceRef"
+                    help="Optional tag or branch that points at the release source."
+                  >
+                    Tag or branch
+                  </FieldLabelWithHelp>
+                  <Input
+                    id="pluginSourceRef"
+                    placeholder="v1.0.0 or main"
+                    value={sourceRef}
+                    disabled={metadataDisabled}
+                    onChange={(event) => setSourceRef(event.target.value)}
+                  />
+                </div>
+                <div className="flex flex-col gap-2">
+                  <FieldLabelWithHelp
+                    htmlFor="pluginSourcePath"
+                    help="Use . when the package is at the repo root; otherwise use its subfolder path."
+                  >
+                    Package path
+                  </FieldLabelWithHelp>
+                  <Input
+                    id="pluginSourcePath"
+                    placeholder="."
+                    value={sourcePath}
+                    disabled={metadataDisabled}
+                    onChange={(event) => setSourcePath(event.target.value)}
+                  />
+                </div>
+              </div>
             </div>
-            <Label htmlFor="pluginChangelog" className="sr-only">
-              Changelog
-            </Label>
-            <Textarea
-              id="pluginChangelog"
-              placeholder="Describe what changed in this release..."
-              rows={4}
-              value={changelog}
-              disabled={metadataDisabled}
-              onChange={(event) => setChangelog(event.target.value)}
-            />
           </Card>
-        ) : null}
 
-        <div className="mt-5 flex items-center justify-between gap-4">
-          <div className="flex flex-col gap-2">
-            {error ? (
-              <div className="text-sm font-medium text-red-600 dark:text-red-400" role="alert">
-                {error}
+          {showChangelogField ? (
+            <Card
+              className={`mt-5 ${isMetadataLocked ? "pointer-events-none opacity-60" : ""}`}
+              aria-disabled={isMetadataLocked}
+            >
+              <div>
+                <h2 className="font-display text-lg font-bold leading-tight text-[color:var(--ink)]">
+                  Changelog
+                </h2>
+                <p className="mt-1 text-sm text-[color:var(--ink-soft)]">
+                  Summarize what changed in this release.
+                </p>
               </div>
-            ) : null}
-            {status ? <div className="text-sm text-[color:var(--ink-soft)]">{status}</div> : null}
-            {publishBlockerSummary ? (
-              <div className="text-sm font-medium text-status-error-fg">
-                {publishBlockerSummary}
-              </div>
-            ) : null}
-          </div>
-          <Button
-            variant="primary"
-            size="lg"
-            type="button"
-            disabled={isPublishDisabled}
-            loading={isSubmitting}
-            onClick={() => {
-              startTransition(() => {
-                void (async () => {
-                  try {
-                    if (validationError) {
-                      toast.error(validationError);
-                      return;
-                    }
-                    if (ownerScopeError) {
-                      toast.error(ownerScopeError);
-                      return;
-                    }
-                    if (family === "code-plugin" && codePluginFieldIssues.length > 0) {
-                      toast.error(
-                        `Missing required OpenClaw package metadata: ${codePluginFieldIssues.join(", ")}`,
+              <Label htmlFor="pluginChangelog" className="sr-only">
+                Changelog
+              </Label>
+              <Textarea
+                id="pluginChangelog"
+                placeholder="Describe what changed in this release..."
+                rows={4}
+                value={changelog}
+                disabled={metadataDisabled}
+                onChange={(event) => setChangelog(event.target.value)}
+              />
+            </Card>
+          ) : null}
+
+          <div className="mt-5 flex items-center justify-between gap-4">
+            <div className="flex flex-col gap-2">
+              {error ? (
+                <div className="text-sm font-medium text-red-600 dark:text-red-400" role="alert">
+                  {error}
+                </div>
+              ) : null}
+              {status ? <div className="text-sm text-[color:var(--ink-soft)]">{status}</div> : null}
+              {!status ? (
+                <div className="text-sm text-[color:var(--ink-soft)]">
+                  New releases stay private until automated security checks and verification finish.
+                </div>
+              ) : null}
+              {publishBlockerSummary ? (
+                <div className="text-sm font-medium text-status-error-fg">
+                  {publishBlockerSummary}
+                </div>
+              ) : null}
+            </div>
+            <Button
+              variant="primary"
+              size="lg"
+              type="button"
+              disabled={isPublishDisabled}
+              loading={isSubmitting}
+              onClick={() => {
+                startTransition(() => {
+                  void (async () => {
+                    try {
+                      if (validationError) {
+                        toast.error(validationError);
+                        return;
+                      }
+                      if (ownerScopeError) {
+                        toast.error(ownerScopeError);
+                        return;
+                      }
+                      if (family === "code-plugin" && codePluginFieldIssues.length > 0) {
+                        toast.error(
+                          `Missing required OpenClaw package metadata: ${codePluginFieldIssues.join(", ")}`,
+                        );
+                        return;
+                      }
+                      setStatus("Uploading files...");
+                      setError(null);
+                      const uploaded = await buildPackageUploadEntries(files, {
+                        generateUploadUrl,
+                        hashFile,
+                        uploadFile,
+                      });
+                      setStatus("Publishing release...");
+                      await publishRelease({
+                        payload: {
+                          name: name.trim(),
+                          displayName: displayName.trim() || undefined,
+                          ownerHandle: ownerHandle || undefined,
+                          family,
+                          version: version.trim(),
+                          changelog: changelog.trim(),
+                          ...(normalizedClawScanNote
+                            ? { clawScanNote: normalizedClawScanNote }
+                            : {}),
+                          ...(sourceRepo.trim() && sourceCommit.trim()
+                            ? {
+                                source: {
+                                  kind: "github" as const,
+                                  repo: sourceRepo.trim(),
+                                  url: sourceRepo.trim().startsWith("http")
+                                    ? sourceRepo.trim()
+                                    : `https://github.com/${sourceRepo.trim().replace(/^\/+|\/+$/g, "")}`,
+                                  ref: sourceRef.trim() || sourceCommit.trim(),
+                                  commit: sourceCommit.trim(),
+                                  path: sourcePath.trim() || ".",
+                                  importedAt: Date.now(),
+                                },
+                              }
+                            : {}),
+                          ...(family === "bundle-plugin"
+                            ? {
+                                bundle: {
+                                  format: bundleFormat.trim() || undefined,
+                                  hostTargets: hostTargets
+                                    .split(",")
+                                    .map((entry) => entry.trim())
+                                    .filter(Boolean),
+                                },
+                              }
+                            : {}),
+                          files: uploaded,
+                        },
+                      });
+                      setStatus(
+                        "Published. Pending security checks and verification before public listing.",
                       );
-                      return;
+                    } catch (publishError) {
+                      toast.error(formatPublishError(publishError));
+                      setStatus(null);
                     }
-                    setStatus("Uploading files...");
-                    setError(null);
-                    const uploaded = await buildPackageUploadEntries(files, {
-                      generateUploadUrl,
-                      hashFile,
-                      uploadFile,
-                    });
-                    setStatus("Publishing release...");
-                    await publishRelease({
-                      payload: {
-                        name: name.trim(),
-                        displayName: displayName.trim() || undefined,
-                        ownerHandle: ownerHandle || undefined,
-                        family,
-                        version: version.trim(),
-                        changelog: changelog.trim(),
-                        ...(normalizedClawScanNote ? { clawScanNote: normalizedClawScanNote } : {}),
-                        ...(sourceRepo.trim() && sourceCommit.trim()
-                          ? {
-                              source: {
-                                kind: "github" as const,
-                                repo: sourceRepo.trim(),
-                                url: sourceRepo.trim().startsWith("http")
-                                  ? sourceRepo.trim()
-                                  : `https://github.com/${sourceRepo.trim().replace(/^\/+|\/+$/g, "")}`,
-                                ref: sourceRef.trim() || sourceCommit.trim(),
-                                commit: sourceCommit.trim(),
-                                path: sourcePath.trim() || ".",
-                                importedAt: Date.now(),
-                              },
-                            }
-                          : {}),
-                        ...(family === "bundle-plugin"
-                          ? {
-                              bundle: {
-                                format: bundleFormat.trim() || undefined,
-                                hostTargets: hostTargets
-                                  .split(",")
-                                  .map((entry) => entry.trim())
-                                  .filter(Boolean),
-                              },
-                            }
-                          : {}),
-                        files: uploaded,
-                      },
-                    });
-                    setStatus(
-                      "Published. Pending security checks and verification before public listing.",
-                    );
-                  } catch (publishError) {
-                    toast.error(formatPublishError(publishError));
-                    setStatus(null);
-                  }
-                })();
-              });
-            }}
-          >
-            {isPublishDisabled && !isSubmitting ? (
-              <Lock className="h-4 w-4" aria-hidden="true" />
-            ) : null}
-            Publish plugin
-          </Button>
+                  })();
+                });
+              }}
+            >
+              {isPublishDisabled && !isSubmitting ? (
+                <Lock className="h-4 w-4" aria-hidden="true" />
+              ) : null}
+              Publish plugin
+            </Button>
+          </div>
+
+          {isMetadataLocked ? (
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-x-0 bottom-0 h-44"
+              style={{
+                background: "linear-gradient(to bottom, transparent, var(--bg) 88%)",
+              }}
+            />
+          ) : null}
         </div>
       </Container>
     </main>

--- a/src/routes/plugins/publish.tsx
+++ b/src/routes/plugins/publish.tsx
@@ -99,6 +99,7 @@ export function PublishPluginRoute() {
   const [detectedPrefillFields, setDetectedPrefillFields] = useState<string[]>([]);
   const [codePluginFieldIssues, setCodePluginFieldIssues] = useState<string[]>([]);
   const [status, setStatus] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const clawScanNoteTouchedRef = useRef(false);
   const showChangelogField = Boolean(search.name);
@@ -134,7 +135,6 @@ export function PublishPluginRoute() {
       ? normalizeClawScanNote(clawScanNote)
       : undefined;
   const isMetadataLocked = files.length === 0;
-  const isSubmitting = status !== null;
   const metadataDisabled = isMetadataLocked || isSubmitting;
   const ownerScopeError = useMemo(() => {
     return getPackageScopeOwnerMismatch(name, ownerHandle)?.message ?? null;
@@ -196,6 +196,7 @@ export function PublishPluginRoute() {
     setPackageSourceKind(sourceKind);
     setIgnoredPaths(nextIgnoredPaths);
     setError(null);
+    setStatus(null);
     const prefill = await derivePluginPrefill(normalized);
     setDetectedPrefillFields(listPrefilledFields(prefill));
     setCodePluginFieldIssues(prefill.missingRequiredFields ?? []);
@@ -215,6 +216,7 @@ export function PublishPluginRoute() {
     setDetectedPrefillFields([]);
     setCodePluginFieldIssues([]);
     setError(null);
+    setStatus(null);
   };
 
   useEffect(() => {
@@ -560,6 +562,7 @@ export function PublishPluginRoute() {
                         );
                         return;
                       }
+                      setIsSubmitting(true);
                       setStatus("Uploading files...");
                       setError(null);
                       const uploaded = await buildPackageUploadEntries(files, {
@@ -614,6 +617,8 @@ export function PublishPluginRoute() {
                     } catch (publishError) {
                       toast.error(formatPublishError(publishError));
                       setStatus(null);
+                    } finally {
+                      setIsSubmitting(false);
                     }
                   })();
                 });

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -551,6 +551,7 @@ export function Upload() {
     if (issue.startsWith("Total file size")) return shouldShowFileIssues;
     return false;
   });
+  const hasFilePanelFooter = Boolean(ignoredLocalMetadataNote || visibleFileIssues.length > 0);
   const publishBlockerSummary =
     !validation.ready && !isSubmitting
       ? summarizePublishBlockers(validation.issues, requiredFileLabel)
@@ -793,164 +794,167 @@ export function Upload() {
           />
 
           {files.length > 0 ? (
-            <>
-              <div
-                className={`overflow-hidden rounded-[var(--radius-md)] border transition-colors ${
-                  isDragging
-                    ? "border-[color:var(--accent)] bg-[color:var(--accent)]/5"
-                    : "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
-                }`}
-                onDragOver={(event) => {
-                  event.preventDefault();
-                  setIsDragging(true);
-                }}
-                onDragLeave={() => setIsDragging(false)}
-                onDrop={handleFilesDrop}
-              >
-                <div className="flex flex-col gap-4 px-4 pt-4 pb-2 md:flex-row md:items-center md:justify-between">
-                  <div className="flex min-w-0 items-center gap-3">
-                    <div
-                      className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)]"
-                      aria-hidden="true"
-                    >
-                      <FolderOpen className="h-4 w-4 text-[color:var(--ink-soft)]" />
-                    </div>
-                    <div className="min-w-0">
-                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                        <strong className="text-sm text-[color:var(--ink)]">
-                          Skill folder selected
-                        </strong>
-                        <span className="text-xs text-[color:var(--ink-soft)]">
-                          {files.length} files · {sizeLabel}
-                        </span>
-                      </div>
-                      {unsupportedFileEntries.length > 0 ? (
-                        <div className="mt-3 flex flex-wrap gap-1.5">
-                          <Badge variant="warning">
-                            {unsupportedFileEntries.length} unsupported
-                          </Badge>
-                        </div>
-                      ) : null}
-                    </div>
+            <div
+              className={`overflow-hidden rounded-[var(--radius-md)] border transition-colors ${
+                isDragging
+                  ? "border-[color:var(--accent)] bg-[color:var(--accent)]/5"
+                  : "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
+              }`}
+              onDragOver={(event) => {
+                event.preventDefault();
+                setIsDragging(true);
+              }}
+              onDragLeave={() => setIsDragging(false)}
+              onDrop={handleFilesDrop}
+            >
+              <div className="flex flex-col gap-4 px-4 pt-4 pb-2 md:flex-row md:items-center md:justify-between">
+                <div className="flex min-w-0 items-center gap-3">
+                  <div
+                    className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)]"
+                    aria-hidden="true"
+                  >
+                    <FolderOpen className="h-4 w-4 text-[color:var(--ink-soft)]" />
                   </div>
-                  <div className="flex shrink-0 flex-wrap items-center gap-4 md:justify-end">
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                      <strong className="text-sm text-[color:var(--ink)]">
+                        Skill folder selected
+                      </strong>
+                      <span className="text-xs text-[color:var(--ink-soft)]">
+                        {files.length} files · {sizeLabel}
+                      </span>
+                    </div>
                     {unsupportedFileEntries.length > 0 ? (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        type="button"
-                        onClick={removeUnsupportedFiles}
-                      >
-                        Remove unsupported
-                      </Button>
+                      <div className="mt-3 flex flex-wrap gap-1.5">
+                        <Badge variant="warning" size="sm">
+                          {unsupportedFileEntries.length} unsupported
+                        </Badge>
+                      </div>
                     ) : null}
+                  </div>
+                </div>
+                <div className="flex shrink-0 flex-wrap items-center gap-4 md:justify-end">
+                  {unsupportedFileEntries.length > 0 ? (
                     <Button
                       variant="outline"
                       size="sm"
                       type="button"
-                      onClick={() => fileInputRef.current?.click()}
+                      onClick={removeUnsupportedFiles}
                     >
-                      Replace folder
+                      Remove unsupported
                     </Button>
-                    <button
-                      type="button"
-                      className="cursor-pointer text-xs font-medium text-[color:var(--ink-soft)] transition-colors hover:text-[color:var(--ink)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)]/35 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--bg)]"
-                      onClick={clearSelectedFiles}
-                    >
-                      Clear files
-                    </button>
-                  </div>
+                  ) : null}
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    Replace folder
+                  </Button>
+                  <button
+                    type="button"
+                    className="cursor-pointer text-xs font-medium text-[color:var(--ink-soft)] transition-colors hover:text-[color:var(--ink)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)]/35 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--bg)]"
+                    onClick={clearSelectedFiles}
+                  >
+                    Clear files
+                  </button>
                 </div>
-                <div className="mt-2 rounded-t-[calc(var(--radius-md)+8px)] border-t border-[color:var(--line)] bg-[color:var(--surface)] p-3">
-                  <div className="flex max-h-[300px] flex-col gap-1 overflow-y-auto">
-                    {!hasRequiredFile ? (
-                      <div className="flex items-center gap-2 rounded-[var(--radius-sm)] border border-status-error-fg/35 bg-status-error-bg px-3 py-1.5 text-sm text-status-error-fg">
-                        <span className="min-w-0 flex-1 truncate font-mono">
-                          {requiredFileLabel}
+              </div>
+              <div className="mt-2 overflow-hidden rounded-t-[calc(var(--radius-md)+8px)] border-t border-[color:var(--line)] bg-[color:var(--surface)]">
+                <div className="flex max-h-[300px] flex-col gap-1 overflow-y-auto p-3">
+                  {!hasRequiredFile ? (
+                    <div className="flex items-center gap-2 rounded-[var(--radius-sm)] border border-status-error-fg/35 bg-status-error-bg px-3 py-1.5 text-sm text-status-error-fg">
+                      <span className="min-w-0 flex-1 truncate font-mono">{requiredFileLabel}</span>
+                      <Badge variant="destructive" size="sm">
+                        Missing
+                      </Badge>
+                    </div>
+                  ) : null}
+                  {visibleFileEntries.map(({ file, index, path }) => {
+                    const isUnsupported = !isTextFile(file);
+                    const isConfirmingRemoval = pendingFileRemovalIndex === index;
+                    return (
+                      <div
+                        key={`${index}:${path}`}
+                        className={[
+                          "flex items-center gap-2 rounded-[var(--radius-sm)] px-3 py-1.5 text-sm bg-[color:var(--surface-muted)]",
+                          isUnsupported ? "text-status-error-fg" : "text-[color:var(--ink-soft)]",
+                        ].join(" ")}
+                      >
+                        <span className="min-w-0 flex-1 truncate font-mono" title={path}>
+                          {path}
                         </span>
-                        <Badge
-                          variant="destructive"
-                          className="rounded-[var(--radius-pill)] px-2 py-0.5 text-[11px] font-medium leading-4"
-                        >
-                          Missing
-                        </Badge>
-                      </div>
-                    ) : null}
-                    {visibleFileEntries.map(({ file, index, path }) => {
-                      const isUnsupported = !isTextFile(file);
-                      const isConfirmingRemoval = pendingFileRemovalIndex === index;
-                      return (
-                        <div
-                          key={`${index}:${path}`}
-                          className={[
-                            "flex items-center gap-2 rounded-[var(--radius-sm)] px-3 py-1.5 text-sm bg-[color:var(--surface-muted)]",
-                            isUnsupported ? "text-status-error-fg" : "text-[color:var(--ink-soft)]",
-                          ].join(" ")}
-                        >
-                          <span className="min-w-0 flex-1 truncate font-mono" title={path}>
-                            {path}
-                          </span>
-                          {isUnsupported ? <Badge variant="warning">Unsupported</Badge> : null}
-                          {isConfirmingRemoval ? (
-                            <div className="flex shrink-0 items-center gap-1">
-                              <span className="text-xs font-medium text-status-error-fg">
-                                Remove?
-                              </span>
-                              <Button
-                                aria-label={`Cancel removing ${path}`}
-                                title={`Cancel removing ${path}`}
-                                variant="ghost"
-                                size="icon-xs"
-                                type="button"
-                                className="hover:not-disabled:bg-[color:var(--surface)]"
-                                onClick={() => setPendingFileRemovalIndex(null)}
-                              >
-                                <X className="h-3.5 w-3.5" aria-hidden="true" />
-                              </Button>
-                              <Button
-                                aria-label={`Confirm removing ${path}`}
-                                title={`Confirm removing ${path}`}
-                                variant="ghost"
-                                size="icon-xs"
-                                type="button"
-                                className="text-status-error-fg hover:not-disabled:bg-status-error-bg hover:not-disabled:text-status-error-fg"
-                                onClick={() => removeFileAtIndex(index)}
-                              >
-                                <Check className="h-3.5 w-3.5" aria-hidden="true" />
-                              </Button>
-                            </div>
-                          ) : (
+                        {isUnsupported ? (
+                          <Badge variant="warning" size="sm">
+                            Unsupported
+                          </Badge>
+                        ) : null}
+                        {isConfirmingRemoval ? (
+                          <div className="flex shrink-0 items-center gap-1">
+                            <span className="text-xs font-medium text-status-error-fg">
+                              Remove?
+                            </span>
                             <Button
-                              aria-label={`Remove ${path}`}
-                              title={`Remove ${path}`}
+                              aria-label={`Cancel removing ${path}`}
+                              title={`Cancel removing ${path}`}
                               variant="ghost"
                               size="icon-xs"
                               type="button"
-                              onClick={() => setPendingFileRemovalIndex(index)}
+                              className="hover:not-disabled:bg-[color:var(--surface)]"
+                              onClick={() => setPendingFileRemovalIndex(null)}
                             >
                               <X className="h-3.5 w-3.5" aria-hidden="true" />
                             </Button>
-                          )}
-                        </div>
-                      );
-                    })}
+                            <Button
+                              aria-label={`Confirm removing ${path}`}
+                              title={`Confirm removing ${path}`}
+                              variant="ghost"
+                              size="icon-xs"
+                              type="button"
+                              className="text-status-error-fg hover:not-disabled:bg-status-error-bg hover:not-disabled:text-status-error-fg"
+                              onClick={() => removeFileAtIndex(index)}
+                            >
+                              <Check className="h-3.5 w-3.5" aria-hidden="true" />
+                            </Button>
+                          </div>
+                        ) : (
+                          <Button
+                            aria-label={`Remove ${path}`}
+                            title={`Remove ${path}`}
+                            variant="ghost"
+                            size="icon-xs"
+                            type="button"
+                            onClick={() => setPendingFileRemovalIndex(index)}
+                          >
+                            <X className="h-3.5 w-3.5" aria-hidden="true" />
+                          </Button>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+                {hasFilePanelFooter ? (
+                  <div className="border-t border-[color:var(--line)] bg-[color:var(--surface-muted)] px-3 py-2 text-xs text-[color:var(--ink-soft)]">
+                    <div className="flex flex-col gap-1">
+                      {ignoredLocalMetadataNote ? <p>{ignoredLocalMetadataNote}</p> : null}
+                      {visibleFileIssues.map((issue) => (
+                        <p
+                          key={issue}
+                          className={
+                            issue.startsWith("Remove unsupported files")
+                              ? "text-status-error-fg"
+                              : undefined
+                          }
+                        >
+                          {issue}
+                        </p>
+                      ))}
+                    </div>
                   </div>
-                </div>
+                ) : null}
               </div>
-
-              {ignoredLocalMetadataNote ? (
-                <div className="text-sm text-[color:var(--ink-soft)]">
-                  {ignoredLocalMetadataNote}
-                </div>
-              ) : null}
-              {visibleFileIssues.length > 0 ? (
-                <ul className="flex flex-col gap-1 list-disc pl-5 text-sm text-[color:var(--ink-soft)]">
-                  {visibleFileIssues.map((issue) => (
-                    <li key={issue}>{issue}</li>
-                  ))}
-                </ul>
-              ) : null}
-            </>
+            </div>
           ) : (
             <Card>
               <CardContent>

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -12,6 +12,7 @@ import {
   CircleX,
   ExternalLink,
   FolderOpen,
+  Info,
   Lock,
   Upload as UploadIcon,
   X,
@@ -544,7 +545,7 @@ export function Upload() {
   });
   const visibleFileIssues = validation.issues.filter((issue) => {
     if (issue.startsWith("Add at least one file")) return hasAttempted;
-    if (issue === `${requiredFileLabel} is required.`) return shouldShowFileIssues;
+    if (issue === `${requiredFileLabel} is required.`) return false;
     if (issue.startsWith("Remove unsupported files")) return shouldShowFileIssues;
     if (issue.startsWith("Each file")) return shouldShowFileIssues;
     if (issue.startsWith("Total file size")) return shouldShowFileIssues;
@@ -778,130 +779,104 @@ export function Upload() {
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-6">
           {/* File upload panel */}
-          <Card>
-            <CardContent>
-              <input
-                ref={setFileInputRef}
-                className="sr-only"
-                id="upload-files"
-                data-testid="upload-input"
-                type="file"
-                multiple
-                onChange={(event) => {
-                  const picked = Array.from(event.target.files ?? []);
-                  void applyExpandedFiles(picked);
-                }}
-              />
+          <input
+            ref={setFileInputRef}
+            className="sr-only"
+            id="upload-files"
+            data-testid="upload-input"
+            type="file"
+            multiple
+            onChange={(event) => {
+              const picked = Array.from(event.target.files ?? []);
+              void applyExpandedFiles(picked);
+            }}
+          />
 
-              {files.length > 0 ? (
-                <div
-                  className={`rounded-[var(--radius-sm)] border px-4 py-4 transition-colors ${
-                    isDragging
-                      ? "border-[color:var(--accent)] bg-[color:var(--accent)]/5"
-                      : "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
-                  }`}
-                  onDragOver={(event) => {
-                    event.preventDefault();
-                    setIsDragging(true);
-                  }}
-                  onDragLeave={() => setIsDragging(false)}
-                  onDrop={handleFilesDrop}
-                >
-                  <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-                    <div className="flex min-w-0 gap-3">
-                      <div
-                        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)]"
-                        aria-hidden="true"
-                      >
-                        <FolderOpen className="h-5 w-5 text-[color:var(--ink-soft)]" />
-                      </div>
-                      <div className="min-w-0">
-                        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                          <strong className="text-sm text-[color:var(--ink)]">
-                            Skill folder selected
-                          </strong>
-                          <span className="text-xs text-[color:var(--ink-soft)]">
-                            {files.length} files · {sizeLabel}
-                          </span>
-                        </div>
-                        <p className="mt-1 text-sm text-[color:var(--ink-soft)]">
-                          Inner paths are preserved; the top-level folder is removed.
-                        </p>
-                        <div className="mt-3 flex flex-wrap gap-1.5">
-                          <Badge variant={hasRequiredFile ? "compact" : "warning"}>
-                            {hasRequiredFile ? requiredFileLabel : `Missing ${requiredFileLabel}`}
-                          </Badge>
-                          {unsupportedFileEntries.length > 0 ? (
-                            <Badge variant="warning">
-                              {unsupportedFileEntries.length} unsupported
-                            </Badge>
-                          ) : null}
-                        </div>
-                      </div>
+          {files.length > 0 ? (
+            <>
+              <div
+                className={`overflow-hidden rounded-[var(--radius-md)] border transition-colors ${
+                  isDragging
+                    ? "border-[color:var(--accent)] bg-[color:var(--accent)]/5"
+                    : "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
+                }`}
+                onDragOver={(event) => {
+                  event.preventDefault();
+                  setIsDragging(true);
+                }}
+                onDragLeave={() => setIsDragging(false)}
+                onDrop={handleFilesDrop}
+              >
+                <div className="flex flex-col gap-4 px-4 pt-4 pb-2 md:flex-row md:items-center md:justify-between">
+                  <div className="flex min-w-0 items-center gap-3">
+                    <div
+                      className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)]"
+                      aria-hidden="true"
+                    >
+                      <FolderOpen className="h-4 w-4 text-[color:var(--ink-soft)]" />
                     </div>
-                    <div className="flex shrink-0 flex-wrap gap-2 md:justify-end">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                        <strong className="text-sm text-[color:var(--ink)]">
+                          Skill folder selected
+                        </strong>
+                        <span className="text-xs text-[color:var(--ink-soft)]">
+                          {files.length} files · {sizeLabel}
+                        </span>
+                      </div>
                       {unsupportedFileEntries.length > 0 ? (
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          type="button"
-                          onClick={removeUnsupportedFiles}
-                        >
-                          Remove unsupported
-                        </Button>
+                        <div className="mt-3 flex flex-wrap gap-1.5">
+                          <Badge variant="warning">
+                            {unsupportedFileEntries.length} unsupported
+                          </Badge>
+                        </div>
                       ) : null}
+                    </div>
+                  </div>
+                  <div className="flex shrink-0 flex-wrap items-center gap-4 md:justify-end">
+                    {unsupportedFileEntries.length > 0 ? (
                       <Button
                         variant="outline"
                         size="sm"
                         type="button"
-                        onClick={() => fileInputRef.current?.click()}
+                        onClick={removeUnsupportedFiles}
                       >
-                        Replace folder
+                        Remove unsupported
                       </Button>
-                      <Button variant="ghost" size="sm" type="button" onClick={clearSelectedFiles}>
-                        Clear files
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-              ) : (
-                <div
-                  className={`relative flex flex-col items-center gap-3 overflow-hidden rounded-[var(--radius-md)] border-2 border-dashed p-8 transition-colors ${
-                    isDragging
-                      ? "border-[color:var(--accent)] bg-[color:var(--accent)]/5"
-                      : "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
-                  }`}
-                  onDragOver={(event) => {
-                    event.preventDefault();
-                    setIsDragging(true);
-                  }}
-                  onDragLeave={() => setIsDragging(false)}
-                  onDrop={handleFilesDrop}
-                >
-                  <UploadDropzoneDecor kind="skill" />
-                  <div className="relative z-[1] flex flex-col items-center gap-2 text-center">
-                    <div className="flex items-center gap-3">
-                      <UploadIcon className="h-5 w-5 text-[color:var(--ink-soft)]" />
-                      <strong>Drop a skill folder</strong>
-                    </div>
-                    <span className="text-xs text-[color:var(--ink-soft)]">
-                      We keep inner paths and remove the top-level folder automatically.
-                    </span>
+                    ) : null}
                     <Button
                       variant="outline"
                       size="sm"
                       type="button"
                       onClick={() => fileInputRef.current?.click()}
                     >
-                      Choose folder
+                      Replace folder
                     </Button>
+                    <button
+                      type="button"
+                      className="cursor-pointer text-xs font-medium text-[color:var(--ink-soft)] transition-colors hover:text-[color:var(--ink)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)]/35 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--bg)]"
+                      onClick={clearSelectedFiles}
+                    >
+                      Clear files
+                    </button>
                   </div>
                 </div>
-              )}
-
-              <div className="flex flex-col gap-1 max-h-[300px] overflow-y-auto">
-                {files.length > 0
-                  ? visibleFileEntries.map(({ file, index, path }) => {
+                <div className="mt-2 rounded-t-[calc(var(--radius-md)+8px)] border-t border-[color:var(--line)] bg-[color:var(--surface)] p-3">
+                  <div className="flex max-h-[300px] flex-col gap-1 overflow-y-auto">
+                    {!hasRequiredFile ? (
+                      <div className="flex items-center gap-2 rounded-[var(--radius-sm)] border border-status-error-fg/35 bg-status-error-bg px-3 py-1.5 text-sm text-status-error-fg">
+                        <span className="min-w-0 flex-1 truncate font-mono">
+                          {requiredFileLabel}
+                        </span>
+                        <Badge
+                          variant="destructive"
+                          className="rounded-[var(--radius-pill)] px-2 py-0.5 text-[11px] font-medium leading-4"
+                        >
+                          Missing
+                        </Badge>
+                      </div>
+                    ) : null}
+                    {visibleFileEntries.map(({ file, index, path }) => {
                       const isUnsupported = !isTextFile(file);
                       const isConfirmingRemoval = pendingFileRemovalIndex === index;
                       return (
@@ -927,6 +902,7 @@ export function Upload() {
                                 variant="ghost"
                                 size="icon-xs"
                                 type="button"
+                                className="hover:not-disabled:bg-[color:var(--surface)]"
                                 onClick={() => setPendingFileRemovalIndex(null)}
                               >
                                 <X className="h-3.5 w-3.5" aria-hidden="true" />
@@ -937,7 +913,7 @@ export function Upload() {
                                 variant="ghost"
                                 size="icon-xs"
                                 type="button"
-                                className="text-status-error-fg hover:not-disabled:bg-status-error-bg"
+                                className="text-status-error-fg hover:not-disabled:bg-status-error-bg hover:not-disabled:text-status-error-fg"
                                 onClick={() => removeFileAtIndex(index)}
                               >
                                 <Check className="h-3.5 w-3.5" aria-hidden="true" />
@@ -957,9 +933,11 @@ export function Upload() {
                           )}
                         </div>
                       );
-                    })
-                  : null}
+                    })}
+                  </div>
+                </div>
               </div>
+
               {ignoredLocalMetadataNote ? (
                 <div className="text-sm text-[color:var(--ink-soft)]">
                   {ignoredLocalMetadataNote}
@@ -972,13 +950,50 @@ export function Upload() {
                   ))}
                 </ul>
               ) : null}
-            </CardContent>
-          </Card>
+            </>
+          ) : (
+            <Card>
+              <CardContent>
+                <div
+                  className={`relative flex flex-col items-center gap-3 overflow-hidden rounded-[var(--radius-md)] border-2 border-dashed p-8 transition-colors ${
+                    isDragging
+                      ? "border-[color:var(--accent)] bg-[color:var(--accent)]/5"
+                      : "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
+                  }`}
+                  onDragOver={(event) => {
+                    event.preventDefault();
+                    setIsDragging(true);
+                  }}
+                  onDragLeave={() => setIsDragging(false)}
+                  onDrop={handleFilesDrop}
+                >
+                  <UploadDropzoneDecor active={isDragging} kind="skill" />
+                  <div className="relative z-[1] flex flex-col items-center gap-2 text-center">
+                    <div className="flex items-center gap-3">
+                      <UploadIcon className="h-5 w-5 text-[color:var(--ink-soft)]" />
+                      <strong>Drop a skill folder</strong>
+                    </div>
+                    <span className="text-xs text-[color:var(--ink-soft)]">
+                      We keep inner paths and remove the top-level folder automatically.
+                    </span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      type="button"
+                      onClick={() => fileInputRef.current?.click()}
+                    >
+                      Choose folder
+                    </Button>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          )}
 
           {/* Metadata panel */}
           <Card>
-            <CardContent>
-              <div className="grid gap-x-4 gap-y-3 md:grid-cols-2">
+            <CardContent className="gap-5">
+              <div className="grid gap-x-4 gap-y-4 md:grid-cols-2">
                 <div className="flex flex-col gap-2">
                   <Label htmlFor="displayName">Display name</Label>
                   <Input
@@ -1048,11 +1063,17 @@ export function Upload() {
                 </div>
               </div>
               {metadataPrefillNote ? (
-                <p className="text-sm text-[color:var(--ink-soft)]">{metadataPrefillNote}</p>
+                <p
+                  className="flex items-center gap-1.5 text-sm leading-5 text-[#1f6feb] dark:text-[#8fbdff]"
+                  role="status"
+                >
+                  <Info className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                  <span className="leading-5">{metadataPrefillNote}</span>
+                </p>
               ) : null}
 
               {!isSoulMode ? (
-                <>
+                <div className="flex flex-col gap-3">
                   {/* The picker is a custom radiogroup; the visible "Icon"
                       heading is decorative and does not need `htmlFor` —
                       `SkillIconPicker` exposes its own `aria-label`. */}
@@ -1068,11 +1089,11 @@ export function Upload() {
                       setIconName(next);
                     }}
                   />
-                </>
+                </div>
               ) : null}
 
               {!isSoulMode ? (
-                <>
+                <div className="flex flex-col gap-2">
                   <Label htmlFor="ownerHandle">Owner</Label>
                   <PublisherOwnerSelect
                     id="ownerHandle"
@@ -1105,38 +1126,42 @@ export function Upload() {
                     </label>
                   ) : null}
                   <InlineValidationMessage id="owner-validation-error" message={ownerIssue} />
-                </>
+                </div>
               ) : null}
 
-              <Label htmlFor="version">Version</Label>
-              <VersionInput
-                id="version"
-                value={version}
-                aria-invalid={Boolean(versionIssue)}
-                aria-describedby={versionIssue ? "version-validation-error" : undefined}
-                onValueChange={(nextVersion) => {
-                  markFieldTouched("version");
-                  setVersion(nextVersion);
-                }}
-                onBlur={() => markFieldTouched("version")}
-                placeholder="1.0.0"
-              />
-              <InlineValidationMessage id="version-validation-error" message={versionIssue} />
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="version">Version</Label>
+                <VersionInput
+                  id="version"
+                  value={version}
+                  aria-invalid={Boolean(versionIssue)}
+                  aria-describedby={versionIssue ? "version-validation-error" : undefined}
+                  onValueChange={(nextVersion) => {
+                    markFieldTouched("version");
+                    setVersion(nextVersion);
+                  }}
+                  onBlur={() => markFieldTouched("version")}
+                  placeholder="1.0.0"
+                />
+                <InlineValidationMessage id="version-validation-error" message={versionIssue} />
+              </div>
 
-              <Label htmlFor="tags">Tags</Label>
-              <Input
-                id="tags"
-                value={tags}
-                onChange={(event) => {
-                  markFieldTouched("tags");
-                  setTags(event.target.value);
-                }}
-                onBlur={() => markFieldTouched("tags")}
-                placeholder="latest, stable"
-              />
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="tags">Tags</Label>
+                <Input
+                  id="tags"
+                  value={tags}
+                  onChange={(event) => {
+                    markFieldTouched("tags");
+                    setTags(event.target.value);
+                  }}
+                  onBlur={() => markFieldTouched("tags")}
+                  placeholder="latest, stable"
+                />
+              </div>
 
               {!isSoulMode ? (
-                <>
+                <div className="flex flex-col gap-2">
                   <Label htmlFor="clawScanNote">ClawScan note</Label>
                   <Textarea
                     id="clawScanNote"
@@ -1151,7 +1176,7 @@ export function Upload() {
                     onBlur={() => markFieldTouched("clawScanNote")}
                     placeholder="Optional context for ClawScan, e.g. why this version needs network access."
                   />
-                </>
+                </div>
               ) : null}
               {visibleMetadataIssues.length > 0 ? (
                 <ul className="flex flex-col gap-1 list-disc pl-5 text-sm text-[color:var(--ink-soft)]">

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -7,7 +7,7 @@ import {
 } from "clawhub-schema/licenseConstants";
 import { normalizeTextContentType } from "clawhub-schema/textFiles";
 import { useAction, useMutation, useQuery } from "convex/react";
-import { Upload as UploadIcon } from "lucide-react";
+import { Check, CircleX, FolderOpen, Lock, Upload as UploadIcon, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import semver from "semver";
 import { toast } from "sonner";
@@ -15,6 +15,11 @@ import { api } from "../../../convex/_generated/api";
 import { MAX_PUBLISH_FILE_BYTES, MAX_PUBLISH_TOTAL_BYTES } from "../../../convex/lib/publishLimits";
 import { EmptyState } from "../../components/EmptyState";
 import { Container } from "../../components/layout/Container";
+import {
+  PublisherOwnerSelect,
+  type PublisherOwnerMembership,
+} from "../../components/PublisherOwnerSelect";
+import { PublishFormSkeleton } from "../../components/PublishFormSkeleton";
 import { SignInButton } from "../../components/SignInButton";
 import { SkillIconPicker } from "../../components/SkillIconPicker";
 import { Badge } from "../../components/ui/badge";
@@ -23,6 +28,8 @@ import { Card, CardContent, CardTitle } from "../../components/ui/card";
 import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
 import { Textarea } from "../../components/ui/textarea";
+import { UploadDropzoneDecor } from "../../components/UploadDropzoneDecor";
+import { VersionInput } from "../../components/VersionInput";
 import { getSiteMode } from "../../lib/site";
 import { ALLOWED_LUCIDE_ICONS, makeLucideIconValue, parseSkillIcon } from "../../lib/skillIcon";
 import { getPublicSlugCollision } from "../../lib/slugCollision";
@@ -39,15 +46,7 @@ import {
 
 const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
-type PublisherMembership = {
-  publisher: {
-    _id: string;
-    handle: string;
-    displayName: string;
-    kind: "user" | "org";
-  };
-  role: "owner" | "admin" | "publisher";
-};
+type SkillPublishField = "slug" | "displayName" | "version" | "tags" | "clawScanNote" | "license";
 
 export const Route = createFileRoute("/skills/publish")({
   validateSearch: (search) => ({
@@ -58,12 +57,13 @@ export const Route = createFileRoute("/skills/publish")({
 });
 
 export function Upload() {
-  const { isAuthenticated, me } = useAuthStatus();
+  const { isAuthenticated, isLoading: isAuthLoading, me } = useAuthStatus();
   const { updateSlug, ownerHandle: searchOwnerHandle } = useSearch({ from: "/skills/publish" });
   const siteMode = getSiteMode();
   const isSoulMode = siteMode === "souls";
   const requiredFileLabel = isSoulMode ? "SOUL.md" : "SKILL.md";
   const contentLabel = isSoulMode ? "soul" : "skill";
+  const showChangelogField = Boolean(updateSlug);
 
   const generateUploadUrl = useMutation(api.uploads.generateUploadUrl);
   const publishVersion = useAction(
@@ -95,9 +95,18 @@ export function Upload() {
 
   const [hasAttempted, setHasAttempted] = useState(false);
   const [files, setFiles] = useState<File[]>([]);
-  const [ignoredMacJunkPaths, setIgnoredMacJunkPaths] = useState<string[]>([]);
+  const [ignoredLocalMetadataPaths, setIgnoredLocalMetadataPaths] = useState<string[]>([]);
   const [slug, setSlug] = useState(updateSlug ?? "");
   const [displayName, setDisplayName] = useState("");
+  const [touchedFields, setTouchedFields] = useState<Record<SkillPublishField, boolean>>({
+    slug: false,
+    displayName: false,
+    version: false,
+    tags: false,
+    clawScanNote: false,
+    license: false,
+  });
+  const [metadataPrefillNote, setMetadataPrefillNote] = useState<string | null>(null);
   // Selected lucide icon name (e.g. `Plug`) or null when "no icon". Skills only;
   // souls don't expose a custom icon yet.
   const [iconName, setIconName] = useState<string | null>(null);
@@ -128,7 +137,7 @@ export function Upload() {
   const isSubmitting = status !== null;
   const [error, setError] = useState<string | null>(null);
   const publisherMemberships = useQuery(api.publishers.listMine) as
-    | PublisherMembership[]
+    | PublisherOwnerMembership[]
     | undefined;
   const [ownerHandle, setOwnerHandle] = useState(searchOwnerHandle ?? "");
   const ownerTouchedRef = useRef(false);
@@ -148,6 +157,18 @@ export function Upload() {
     }
   };
   const navigate = useNavigate();
+
+  function markFieldTouched(field: SkillPublishField) {
+    setTouchedFields((current) => {
+      if (current[field]) return current;
+      return { ...current, [field]: true };
+    });
+  }
+
+  function resetFileInput() {
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }
+
   const totalBytes = useMemo(() => files.reduce((sum, file) => sum + file.size, 0), [files]);
   const stripRoot = useMemo(() => {
     if (files.length === 0) return null;
@@ -169,6 +190,19 @@ export function Upload() {
       }),
     [files, stripRoot],
   );
+  const normalizedFileEntries = useMemo(
+    () =>
+      files.map((file, index) => ({
+        file,
+        index,
+        path: normalizedPaths[index] ?? file.name,
+      })),
+    [files, normalizedPaths],
+  );
+  const unsupportedFileEntries = useMemo(
+    () => normalizedFileEntries.filter((entry) => !isTextFile(entry.file)),
+    [normalizedFileEntries],
+  );
   const hasRequiredFile = useMemo(
     () =>
       normalizedPaths.some((path) => {
@@ -186,15 +220,15 @@ export function Upload() {
     () => oversizedFiles.slice(0, 3).map((file) => file.name),
     [oversizedFiles],
   );
-  const ignoredMacJunkNote = useMemo(() => {
-    if (ignoredMacJunkPaths.length === 0) return null;
+  const ignoredLocalMetadataNote = useMemo(() => {
+    if (ignoredLocalMetadataPaths.length === 0) return null;
     const labels = Array.from(
-      new Set(ignoredMacJunkPaths.map((path) => path.split("/").at(-1) ?? path)),
+      new Set(ignoredLocalMetadataPaths.map((path) => path.split("/").at(-1) ?? path)),
     ).slice(0, 3);
-    const suffix = ignoredMacJunkPaths.length > 3 ? ", ..." : "";
-    const count = ignoredMacJunkPaths.length;
-    return `Ignored ${count} macOS junk file${count === 1 ? "" : "s"} (${labels.join(", ")}${suffix})`;
-  }, [ignoredMacJunkPaths]);
+    const suffix = ignoredLocalMetadataPaths.length > 3 ? ", ..." : "";
+    const count = ignoredLocalMetadataPaths.length;
+    return `Ignored ${count} local metadata file${count === 1 ? "" : "s"} (${labels.join(", ")}${suffix})`;
+  }, [ignoredLocalMetadataPaths]);
   const trimmedSlug = slug.trim();
   const trimmedName = displayName.trim();
   const trimmedChangelog = changelog.trim();
@@ -293,6 +327,7 @@ export function Upload() {
   }, [ownerHandle, publisherMemberships, existing?.owner?.handle, updateSlug, isSoulMode]);
 
   useEffect(() => {
+    if (!showChangelogField) return;
     if (changelogTouchedRef.current) return;
     if (trimmedChangelog) return;
     if (!trimmedSlug || !SLUG_PATTERN.test(trimmedSlug)) return;
@@ -343,6 +378,7 @@ export function Upload() {
     hasRequiredFile,
     isSoulMode,
     normalizedPaths,
+    showChangelogField,
     trimmedChangelog,
     trimmedSlug,
     trimmedVersion,
@@ -404,13 +440,12 @@ export function Upload() {
         `Confirm the ownership move from @${existingOwnerHandle} to @${ownerHandle} to publish.`,
       );
     }
-    const invalidFiles = files.filter((file) => !isTextFile(file));
-    if (invalidFiles.length > 0) {
+    if (unsupportedFileEntries.length > 0) {
       issues.push(
-        `Remove non-text files: ${invalidFiles
+        `Remove unsupported files: ${unsupportedFileEntries
           .slice(0, 3)
-          .map((file) => file.name)
-          .join(", ")}`,
+          .map((entry) => entry.path)
+          .join(", ")}${unsupportedFileEntries.length > 3 ? ", ..." : ""}`,
       );
     }
     if (oversizedFiles.length > 0) {
@@ -434,6 +469,7 @@ export function Upload() {
     parsedTags.length,
     acceptedLicenseTerms,
     files,
+    unsupportedFileEntries,
     hasRequiredFile,
     isSoulMode,
     totalBytes,
@@ -446,18 +482,67 @@ export function Upload() {
     existingOwnerHandle,
     ownerHandle,
   ]);
-  const slugIssue = validation.issues.find(
-    (issue) =>
-      issue === "Slug is required." ||
-      issue.startsWith("Slug must ") ||
-      issue === effectiveSlugCollision?.message,
-  );
-  const displayNameIssue = validation.issues.find((issue) => issue === "Display name is required.");
-  const versionIssue = validation.issues.find((issue) => issue.startsWith("Version must "));
+  const shouldShowSlugIssue = hasAttempted || touchedFields.slug;
+  const shouldShowDisplayNameIssue = hasAttempted || touchedFields.displayName;
+  const shouldShowVersionIssue = hasAttempted || touchedFields.version;
+  const shouldShowTagsIssue = hasAttempted || touchedFields.tags;
+  const shouldShowClawScanIssue = hasAttempted || touchedFields.clawScanNote;
+  const shouldShowFileIssues = hasAttempted || files.length > 0;
+
+  const slugIssue = shouldShowSlugIssue
+    ? validation.issues.find(
+        (issue) =>
+          issue === "Slug is required." ||
+          issue.startsWith("Slug must ") ||
+          issue === effectiveSlugCollision?.message,
+      )
+    : undefined;
+  const slugCollisionIssue =
+    effectiveSlugCollision && slugIssue === effectiveSlugCollision.message
+      ? effectiveSlugCollision
+      : null;
+  const showSlugAvailableIcon =
+    Boolean(trimmedSlug) &&
+    SLUG_PATTERN.test(trimmedSlug) &&
+    slugAvailability?.available === true &&
+    !slugIssue;
+  const showSlugUnavailableIcon = Boolean(slugCollisionIssue);
+  const showSlugStatusIcon = showSlugAvailableIcon || showSlugUnavailableIcon;
+  const displayNameIssue = shouldShowDisplayNameIssue
+    ? validation.issues.find((issue) => issue === "Display name is required.")
+    : undefined;
+  const versionIssue = shouldShowVersionIssue
+    ? validation.issues.find((issue) => issue.startsWith("Version must "))
+    : undefined;
   const ownerIssue = validation.issues.find((issue) => issue.startsWith("Confirm the ownership "));
+  const visibleMetadataIssues = validation.issues.filter((issue) => {
+    if (issue.startsWith("Slug")) return shouldShowSlugIssue;
+    if (issue.startsWith("Display name")) return shouldShowDisplayNameIssue;
+    if (issue.startsWith("Version")) return shouldShowVersionIssue;
+    if (issue.startsWith("At least one tag")) return shouldShowTagsIssue;
+    if (issue.startsWith("ClawScan note")) return shouldShowClawScanIssue;
+    if (issue.includes("already exists")) return Boolean(trimmedSlug);
+    return false;
+  });
+  const visibleFileIssues = validation.issues.filter((issue) => {
+    if (issue.startsWith("Add at least one file")) return hasAttempted;
+    if (issue === `${requiredFileLabel} is required.`) return shouldShowFileIssues;
+    if (issue.startsWith("Remove unsupported files")) return shouldShowFileIssues;
+    if (issue.startsWith("Each file")) return shouldShowFileIssues;
+    if (issue.startsWith("Total file size")) return shouldShowFileIssues;
+    return false;
+  });
+  const publishBlockerSummary =
+    !validation.ready && !isSubmitting
+      ? summarizePublishBlockers(validation.issues, requiredFileLabel)
+      : null;
 
   // webkitdirectory/directory attributes are set via the ref callback (setFileInputRef)
   // to ensure they persist across hydration and re-renders (#58)
+
+  if (isAuthLoading) {
+    return <PublishFormSkeleton />;
+  }
 
   if (!isAuthenticated) {
     return (
@@ -477,7 +562,46 @@ export function Upload() {
   async function applyExpandedFiles(selected: File[]) {
     const report = await expandFilesWithReport(selected);
     setFiles(report.files);
-    setIgnoredMacJunkPaths(report.ignoredMacJunkPaths);
+    setIgnoredLocalMetadataPaths(report.ignoredLocalMetadataPaths);
+    setMetadataPrefillNote(null);
+    resetFileInput();
+
+    if (updateSlug) return;
+
+    const folderName = getSharedTopLevelFolderName(report.files);
+    if (!folderName) return;
+
+    const nextSlug = slugFromFolderName(folderName);
+    const nextDisplayName = displayNameFromFolderName(folderName);
+    const prefilled: string[] = [];
+    if (nextSlug && !touchedFields.slug && !trimmedSlug) {
+      setSlug(nextSlug);
+      prefilled.push("slug");
+    }
+    if (nextDisplayName && !touchedFields.displayName && !trimmedName) {
+      setDisplayName(nextDisplayName);
+      prefilled.push("display name");
+    }
+    if (prefilled.length > 0) {
+      setMetadataPrefillNote(`Suggested ${prefilled.join(" and ")} from the selected folder.`);
+    }
+  }
+
+  function clearSelectedFiles() {
+    setFiles([]);
+    setIgnoredLocalMetadataPaths([]);
+    setMetadataPrefillNote(null);
+    resetFileInput();
+  }
+
+  function removeFileAtIndex(index: number) {
+    setFiles((current) => current.filter((_, currentIndex) => currentIndex !== index));
+    resetFileInput();
+  }
+
+  function removeUnsupportedFiles() {
+    setFiles((current) => current.filter((file) => isTextFile(file)));
+    resetFileInput();
   }
 
   async function handleSubmit(event: React.FormEvent) {
@@ -619,177 +743,11 @@ export function Upload() {
         </header>
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          {/* Metadata panel */}
-          <Card>
-            <CardContent>
-              <Label htmlFor="slug">Slug</Label>
-              <div className="flex items-center gap-2">
-                <Input
-                  id="slug"
-                  value={slug}
-                  onChange={(event) => setSlug(event.target.value)}
-                  placeholder={`${contentLabel}-name`}
-                />
-                {trimmedSlug && SLUG_PATTERN.test(trimmedSlug) && slugAvailability ? (
-                  <Badge variant={slugAvailability.available ? "success" : "destructive"}>
-                    {slugAvailability.available ? "Available" : "Taken"}
-                  </Badge>
-                ) : null}
-              </div>
-              <InlineValidationMessage id="slug-validation-error" message={slugIssue} />
-
-              <Label htmlFor="displayName">Display name</Label>
-              <Input
-                id="displayName"
-                value={displayName}
-                onChange={(event) => setDisplayName(event.target.value)}
-                placeholder={`My ${contentLabel}`}
-              />
-              <InlineValidationMessage
-                id="display-name-validation-error"
-                message={displayNameIssue}
-              />
-
-              {!isSoulMode ? (
-                <>
-                  {/* The picker is a custom radiogroup; the visible "Icon"
-                      heading is decorative and does not need `htmlFor` —
-                      `SkillIconPicker` exposes its own `aria-label`. */}
-                  <Label>Icon</Label>
-                  <SkillIconPicker
-                    value={iconName}
-                    onChange={(next) => {
-                      // Mark the picker as user-touched so the submit
-                      // handler knows it can forward the resulting value
-                      // (including `null` → "") instead of falling back
-                      // to the omit-key branch.
-                      iconTouchedRef.current = true;
-                      setIconName(next);
-                    }}
-                  />
-                </>
-              ) : null}
-
-              {!isSoulMode ? (
-                <>
-                  <Label htmlFor="ownerHandle">Owner</Label>
-                  <select
-                    className="w-full min-h-[44px] rounded-[var(--radius-sm)] border px-3.5 py-[13px] text-[color:var(--ink)] transition-all duration-[180ms] ease-out border-[rgba(29,59,78,0.22)] bg-[rgba(255,255,255,0.94)] focus:outline-none focus:border-[color-mix(in_srgb,var(--accent)_70%,white)] focus:shadow-[0_0_0_3px_color-mix(in_srgb,var(--accent)_22%,transparent)] dark:border-[rgba(255,255,255,0.12)] dark:bg-[rgba(14,28,37,0.84)]"
-                    id="ownerHandle"
-                    value={ownerHandle}
-                    onChange={(event) => {
-                      ownerTouchedRef.current = true;
-                      setOwnerHandle(event.target.value);
-                      // Reset the migration confirmation any time the Owner
-                      // selector changes; the user must re-acknowledge the move
-                      // after picking a different target to avoid a stale tick
-                      // turning into a silent transfer.
-                      setConfirmMigrateOwner(false);
-                    }}
-                  >
-                    {(publisherMemberships ?? []).map((entry) => (
-                      <option key={entry.publisher._id} value={entry.publisher.handle}>
-                        @{entry.publisher.handle} · {entry.publisher.displayName}
-                      </option>
-                    ))}
-                  </select>
-                  {isOwnerMigration ? (
-                    <label className="flex items-start gap-2 text-sm cursor-pointer mt-2">
-                      <input
-                        type="checkbox"
-                        className="mt-0.5"
-                        checked={confirmMigrateOwner}
-                        onChange={(event) => setConfirmMigrateOwner(event.target.checked)}
-                      />
-                      <span>
-                        Move ownership of <strong>{trimmedSlug || "this skill"}</strong> from{" "}
-                        <strong>@{existingOwnerHandle}</strong> to <strong>@{ownerHandle}</strong>.
-                        Versions, tags, stats, comments and stars are preserved; the old URL
-                        redirects to the new one.
-                      </span>
-                    </label>
-                  ) : null}
-                  <InlineValidationMessage id="owner-validation-error" message={ownerIssue} />
-                </>
-              ) : null}
-
-              <Label htmlFor="version">Version</Label>
-              <Input
-                id="version"
-                value={version}
-                onChange={(event) => setVersion(event.target.value)}
-                placeholder="1.0.0"
-              />
-              <InlineValidationMessage id="version-validation-error" message={versionIssue} />
-
-              <Label htmlFor="tags">Tags</Label>
-              <Input
-                id="tags"
-                value={tags}
-                onChange={(event) => setTags(event.target.value)}
-                placeholder="latest, stable"
-              />
-
-              {!isSoulMode ? (
-                <>
-                  <Label htmlFor="clawScanNote">ClawScan note</Label>
-                  <Textarea
-                    id="clawScanNote"
-                    rows={4}
-                    value={clawScanNote}
-                    maxLength={MAX_CLAWSCAN_NOTE_CHARS + 1}
-                    onChange={(event) => {
-                      clawScanNoteTouchedRef.current = true;
-                      setClawScanNote(event.target.value);
-                    }}
-                    placeholder="Optional context for ClawScan, e.g. why this version needs network access."
-                  />
-                </>
-              ) : null}
-              {validation.issues.some(
-                (issue) =>
-                  issue.startsWith("Slug") ||
-                  issue.startsWith("Display name") ||
-                  issue.startsWith("Version") ||
-                  issue.startsWith("At least one tag") ||
-                  issue.startsWith("ClawScan note") ||
-                  issue.includes("already exists"),
-              ) ? (
-                <ul className="flex flex-col gap-1 list-disc pl-5 text-sm text-[color:var(--ink-soft)]">
-                  {validation.issues
-                    .filter(
-                      (issue) =>
-                        issue.startsWith("Slug") ||
-                        issue.startsWith("Display name") ||
-                        issue.startsWith("Version") ||
-                        issue.startsWith("At least one tag") ||
-                        issue.startsWith("ClawScan note") ||
-                        issue.includes("already exists"),
-                    )
-                    .map((issue) => (
-                      <li key={issue}>{issue}</li>
-                    ))}
-                </ul>
-              ) : null}
-              {effectiveSlugCollision?.url ? (
-                <div className="text-sm text-[color:var(--ink-soft)]">
-                  Existing skill:{" "}
-                  <a
-                    href={effectiveSlugCollision.url}
-                    className="text-[color:var(--accent)] hover:underline"
-                  >
-                    {effectiveSlugCollision.url}
-                  </a>
-                </div>
-              ) : null}
-            </CardContent>
-          </Card>
-
           {/* File upload panel */}
           <Card>
             <CardContent>
-              <label
-                className={`flex flex-col items-center gap-3 rounded-[var(--radius-md)] border-2 border-dashed p-8 transition-colors cursor-pointer ${
+              <div
+                className={`relative flex flex-col items-center gap-3 overflow-hidden rounded-[var(--radius-md)] border-2 border-dashed p-8 transition-colors ${
                   isDragging
                     ? "border-[color:var(--accent)] bg-[color:var(--accent)]/5"
                     : "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
@@ -823,13 +781,16 @@ export function Upload() {
                     void applyExpandedFiles(picked);
                   }}
                 />
-                <div className="flex flex-col items-center gap-2 text-center">
+                <UploadDropzoneDecor kind="skill" />
+                <div className="relative z-10 flex flex-col items-center gap-2 text-center">
                   <div className="flex items-center gap-3">
                     <UploadIcon className="h-5 w-5 text-[color:var(--ink-soft)]" />
-                    <strong>Drop a folder</strong>
-                    <span className="text-xs font-medium text-[color:var(--ink-soft)]">
-                      {files.length} files · {sizeLabel}
-                    </span>
+                    <strong>Drop a skill folder</strong>
+                    {files.length > 0 ? (
+                      <span className="text-xs font-medium text-[color:var(--ink-soft)]">
+                        {files.length} files · {sizeLabel}
+                      </span>
+                    ) : null}
                   </div>
                   <span className="text-xs text-[color:var(--ink-soft)]">
                     We keep folder paths and flatten the outer wrapper automatically.
@@ -840,49 +801,250 @@ export function Upload() {
                     type="button"
                     onClick={() => fileInputRef.current?.click()}
                   >
+                    <FolderOpen className="h-4 w-4" aria-hidden="true" />
                     Choose folder
                   </Button>
                 </div>
-              </label>
+              </div>
+
+              {files.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {unsupportedFileEntries.length > 0 ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      type="button"
+                      onClick={removeUnsupportedFiles}
+                    >
+                      Remove unsupported files
+                    </Button>
+                  ) : null}
+                  <Button variant="ghost" size="sm" type="button" onClick={clearSelectedFiles}>
+                    Clear files
+                  </Button>
+                </div>
+              ) : null}
 
               <div className="flex flex-col gap-1 max-h-[300px] overflow-y-auto">
-                {files.length === 0 ? (
-                  <div className="text-sm text-[color:var(--ink-soft)]">No files selected.</div>
-                ) : (
-                  normalizedPaths.map((path) => (
-                    <div
-                      key={path}
-                      className="flex items-center gap-2 rounded-[var(--radius-sm)] px-3 py-1.5 text-sm font-mono text-[color:var(--ink-soft)] bg-[color:var(--surface-muted)]"
-                    >
-                      <span>{path}</span>
-                    </div>
-                  ))
-                )}
+                {files.length > 0
+                  ? normalizedFileEntries.map(({ file, index, path }) => {
+                      const isUnsupported = !isTextFile(file);
+                      return (
+                        <div
+                          key={`${index}:${path}`}
+                          className={[
+                            "flex items-center gap-2 rounded-[var(--radius-sm)] px-3 py-1.5 text-sm bg-[color:var(--surface-muted)]",
+                            isUnsupported ? "text-status-error-fg" : "text-[color:var(--ink-soft)]",
+                          ].join(" ")}
+                        >
+                          <span className="min-w-0 flex-1 truncate font-mono" title={path}>
+                            {path}
+                          </span>
+                          {isUnsupported ? <Badge variant="warning">Unsupported</Badge> : null}
+                          <Button
+                            aria-label={`Remove ${path}`}
+                            title={`Remove ${path}`}
+                            variant="ghost"
+                            size="icon-xs"
+                            type="button"
+                            onClick={() => removeFileAtIndex(index)}
+                          >
+                            <X className="h-3.5 w-3.5" aria-hidden="true" />
+                          </Button>
+                        </div>
+                      );
+                    })
+                  : null}
               </div>
-              {ignoredMacJunkNote ? (
-                <div className="text-sm text-[color:var(--ink-soft)]">{ignoredMacJunkNote}</div>
+              {ignoredLocalMetadataNote ? (
+                <div className="text-sm text-[color:var(--ink-soft)]">
+                  {ignoredLocalMetadataNote}
+                </div>
               ) : null}
-              {validation.issues.some(
-                (issue) =>
-                  issue.startsWith("Add at least one file") ||
-                  issue === `${requiredFileLabel} is required.` ||
-                  issue.startsWith("Remove non-text files") ||
-                  issue.startsWith("Each file") ||
-                  issue.startsWith("Total file size"),
-              ) ? (
+              {visibleFileIssues.length > 0 ? (
                 <ul className="flex flex-col gap-1 list-disc pl-5 text-sm text-[color:var(--ink-soft)]">
-                  {validation.issues
-                    .filter(
-                      (issue) =>
-                        issue.startsWith("Add at least one file") ||
-                        issue === `${requiredFileLabel} is required.` ||
-                        issue.startsWith("Remove non-text files") ||
-                        issue.startsWith("Each file") ||
-                        issue.startsWith("Total file size"),
-                    )
-                    .map((issue) => (
-                      <li key={issue}>{issue}</li>
-                    ))}
+                  {visibleFileIssues.map((issue) => (
+                    <li key={issue}>{issue}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </CardContent>
+          </Card>
+
+          {/* Metadata panel */}
+          <Card>
+            <CardContent>
+              <Label htmlFor="slug">Slug</Label>
+              <div className="relative">
+                <Input
+                  id="slug"
+                  value={slug}
+                  aria-invalid={Boolean(slugIssue)}
+                  aria-describedby={slugIssue ? "slug-validation-error" : undefined}
+                  className={showSlugStatusIcon ? "pr-10" : undefined}
+                  onChange={(event) => {
+                    markFieldTouched("slug");
+                    setMetadataPrefillNote(null);
+                    setSlug(event.target.value);
+                  }}
+                  onBlur={() => markFieldTouched("slug")}
+                  placeholder={`${contentLabel}-name`}
+                />
+                {showSlugAvailableIcon ? (
+                  <Check
+                    aria-label="Slug available"
+                    className="pointer-events-none absolute right-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-status-success-fg"
+                  />
+                ) : null}
+                {showSlugUnavailableIcon ? (
+                  <CircleX
+                    aria-label="Slug unavailable"
+                    className="pointer-events-none absolute right-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-status-error-fg"
+                  />
+                ) : null}
+              </div>
+              <InlineValidationMessage id="slug-validation-error" message={slugIssue} />
+              {slugCollisionIssue?.url ? (
+                <div className="text-sm text-[color:var(--ink-soft)]">
+                  Existing skill:{" "}
+                  <a
+                    href={slugCollisionIssue.url}
+                    className="text-[color:var(--accent)] hover:underline"
+                  >
+                    {slugCollisionIssue.url}
+                  </a>
+                </div>
+              ) : null}
+
+              <Label htmlFor="displayName">Display name</Label>
+              <Input
+                id="displayName"
+                value={displayName}
+                aria-invalid={Boolean(displayNameIssue)}
+                aria-describedby={displayNameIssue ? "display-name-validation-error" : undefined}
+                onChange={(event) => {
+                  markFieldTouched("displayName");
+                  setMetadataPrefillNote(null);
+                  setDisplayName(event.target.value);
+                }}
+                onBlur={() => markFieldTouched("displayName")}
+                placeholder={`My ${contentLabel}`}
+              />
+              <InlineValidationMessage
+                id="display-name-validation-error"
+                message={displayNameIssue}
+              />
+              {metadataPrefillNote ? (
+                <p className="text-sm text-[color:var(--ink-soft)]">{metadataPrefillNote}</p>
+              ) : null}
+
+              {!isSoulMode ? (
+                <>
+                  {/* The picker is a custom radiogroup; the visible "Icon"
+                      heading is decorative and does not need `htmlFor` —
+                      `SkillIconPicker` exposes its own `aria-label`. */}
+                  <Label>Icon</Label>
+                  <SkillIconPicker
+                    value={iconName}
+                    onChange={(next) => {
+                      // Mark the picker as user-touched so the submit
+                      // handler knows it can forward the resulting value
+                      // (including `null` → "") instead of falling back
+                      // to the omit-key branch.
+                      iconTouchedRef.current = true;
+                      setIconName(next);
+                    }}
+                  />
+                </>
+              ) : null}
+
+              {!isSoulMode ? (
+                <>
+                  <Label htmlFor="ownerHandle">Owner</Label>
+                  <PublisherOwnerSelect
+                    id="ownerHandle"
+                    value={ownerHandle}
+                    memberships={publisherMemberships}
+                    onValueChange={(nextOwnerHandle) => {
+                      ownerTouchedRef.current = true;
+                      setOwnerHandle(nextOwnerHandle);
+                      // Reset the migration confirmation any time the Owner
+                      // selector changes; the user must re-acknowledge the move
+                      // after picking a different target to avoid a stale tick
+                      // turning into a silent transfer.
+                      setConfirmMigrateOwner(false);
+                    }}
+                  />
+                  {isOwnerMigration ? (
+                    <label className="flex items-start gap-2 text-sm cursor-pointer mt-2">
+                      <input
+                        type="checkbox"
+                        className="mt-0.5"
+                        checked={confirmMigrateOwner}
+                        onChange={(event) => setConfirmMigrateOwner(event.target.checked)}
+                      />
+                      <span>
+                        Move ownership of <strong>{trimmedSlug || "this skill"}</strong> from{" "}
+                        <strong>@{existingOwnerHandle}</strong> to <strong>@{ownerHandle}</strong>.
+                        Versions, tags, stats, comments and stars are preserved; the old URL
+                        redirects to the new one.
+                      </span>
+                    </label>
+                  ) : null}
+                  <InlineValidationMessage id="owner-validation-error" message={ownerIssue} />
+                </>
+              ) : null}
+
+              <Label htmlFor="version">Version</Label>
+              <VersionInput
+                id="version"
+                value={version}
+                aria-invalid={Boolean(versionIssue)}
+                aria-describedby={versionIssue ? "version-validation-error" : undefined}
+                onValueChange={(nextVersion) => {
+                  markFieldTouched("version");
+                  setVersion(nextVersion);
+                }}
+                onBlur={() => markFieldTouched("version")}
+                placeholder="1.0.0"
+              />
+              <InlineValidationMessage id="version-validation-error" message={versionIssue} />
+
+              <Label htmlFor="tags">Tags</Label>
+              <Input
+                id="tags"
+                value={tags}
+                onChange={(event) => {
+                  markFieldTouched("tags");
+                  setTags(event.target.value);
+                }}
+                onBlur={() => markFieldTouched("tags")}
+                placeholder="latest, stable"
+              />
+
+              {!isSoulMode ? (
+                <>
+                  <Label htmlFor="clawScanNote">ClawScan note</Label>
+                  <Textarea
+                    id="clawScanNote"
+                    rows={4}
+                    value={clawScanNote}
+                    maxLength={MAX_CLAWSCAN_NOTE_CHARS + 1}
+                    onChange={(event) => {
+                      markFieldTouched("clawScanNote");
+                      clawScanNoteTouchedRef.current = true;
+                      setClawScanNote(event.target.value);
+                    }}
+                    onBlur={() => markFieldTouched("clawScanNote")}
+                    placeholder="Optional context for ClawScan, e.g. why this version needs network access."
+                  />
+                </>
+              ) : null}
+              {visibleMetadataIssues.length > 0 ? (
+                <ul className="flex flex-col gap-1 list-disc pl-5 text-sm text-[color:var(--ink-soft)]">
+                  {visibleMetadataIssues.map((issue) => (
+                    <li key={issue}>{issue}</li>
+                  ))}
                 </ul>
               ) : null}
             </CardContent>
@@ -890,87 +1052,93 @@ export function Upload() {
 
           {!isSoulMode ? (
             <Card>
-              <CardContent>
-                <CardTitle>License</CardTitle>
-                <div className="flex flex-col gap-3">
-                  <Badge variant="accent">
-                    {PLATFORM_SKILL_LICENSE} · {PLATFORM_SKILL_LICENSE_NAME}
-                  </Badge>
+              <CardContent className="gap-4">
+                <div>
+                  <CardTitle>License</CardTitle>
                   <p className="text-sm text-[color:var(--ink-soft)]">
+                    {PLATFORM_SKILL_LICENSE} · {PLATFORM_SKILL_LICENSE_NAME}
+                  </p>
+                </div>
+                <div className="flex flex-col gap-1 text-sm text-[color:var(--ink-soft)]">
+                  <p>
                     All skills published on ClawHub are licensed under {PLATFORM_SKILL_LICENSE}.{" "}
                     {PLATFORM_SKILL_LICENSE_SUMMARY}
                   </p>
-                  <p className="text-sm text-[color:var(--ink-soft)]">
+                  <p>
                     ClawHub does not support paid skills, per-skill pricing, or paywalled releases.
                   </p>
-                  <label className="flex items-start gap-2 text-sm cursor-pointer">
+                </div>
+                <div className="flex flex-col gap-2">
+                  <label className="flex cursor-pointer items-start gap-3 rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface-muted)] p-3 text-sm">
                     <input
                       type="checkbox"
-                      className="mt-0.5"
+                      className="mt-0.5 h-4 w-4 accent-[color:var(--accent)]"
                       checked={acceptedLicenseTerms}
-                      onChange={(event) => setAcceptedLicenseTerms(event.target.checked)}
+                      onChange={(event) => {
+                        setAcceptedLicenseTerms(event.target.checked);
+                      }}
                     />
                     <span>
-                      I have the rights to this skill and agree to publish it under{" "}
-                      {PLATFORM_SKILL_LICENSE}.
+                      I have the rights to publish this skill under {PLATFORM_SKILL_LICENSE}.
                     </span>
                   </label>
-                  {!acceptedLicenseTerms ? (
-                    <div className="text-sm text-[color:var(--ink-soft)]">
-                      Accept the MIT-0 license terms to publish this skill.
-                    </div>
-                  ) : null}
                 </div>
               </CardContent>
             </Card>
           ) : null}
 
-          <Card>
-            <CardContent>
-              <CardTitle>Changelog</CardTitle>
-              <Label htmlFor="changelog">Changelog</Label>
-              <Textarea
-                id="changelog"
-                rows={6}
-                value={changelog}
-                onChange={(event) => {
-                  changelogTouchedRef.current = true;
-                  setChangelogSource("user");
-                  setChangelog(event.target.value);
-                }}
-                placeholder={`Describe what changed in this ${contentLabel}...`}
-              />
-              {changelogStatus === "loading" ? (
-                <div className="text-sm text-[color:var(--ink-soft)]">Generating changelog…</div>
-              ) : null}
-              {changelogStatus === "error" ? (
-                <div className="text-sm text-[color:var(--ink-soft)]">
-                  Could not auto-generate changelog.
+          {showChangelogField ? (
+            <Card>
+              <CardContent>
+                <div>
+                  <CardTitle>Changelog</CardTitle>
+                  <p className="text-sm text-[color:var(--ink-soft)]">
+                    Summarize what changed in this version.
+                  </p>
                 </div>
-              ) : null}
-              {changelogSource === "auto" && changelog ? (
-                <div className="text-sm text-[color:var(--ink-soft)]">
-                  Auto-generated changelog (edit as needed).
-                </div>
-              ) : null}
-            </CardContent>
-          </Card>
+                <Label htmlFor="changelog" className="sr-only">
+                  Changelog
+                </Label>
+                <Textarea
+                  id="changelog"
+                  rows={4}
+                  value={changelog}
+                  onChange={(event) => {
+                    changelogTouchedRef.current = true;
+                    setChangelogSource("user");
+                    setChangelog(event.target.value);
+                  }}
+                  placeholder={`Describe what changed in this ${contentLabel}...`}
+                />
+                {changelogStatus === "loading" ? (
+                  <div className="text-sm text-[color:var(--ink-soft)]">Generating changelog…</div>
+                ) : null}
+                {changelogStatus === "error" ? (
+                  <div className="text-sm text-[color:var(--ink-soft)]">
+                    Could not auto-generate changelog.
+                  </div>
+                ) : null}
+                {changelogSource === "auto" && changelog ? (
+                  <div className="text-sm text-[color:var(--ink-soft)]">
+                    Auto-generated changelog (edit as needed).
+                  </div>
+                ) : null}
+              </CardContent>
+            </Card>
+          ) : null}
 
           {/* Submit row */}
           <div className="flex items-center justify-between gap-4">
             <div className="flex flex-col gap-2">
-              {validation.ready ? (
-                <div className="text-sm text-[color:var(--ink-soft)]">All checks passed.</div>
-              ) : null}
               {error ? (
                 <div className="text-sm font-medium text-red-600 dark:text-red-400" role="alert">
                   {error}
                 </div>
               ) : null}
               {status ? <div className="text-sm text-[color:var(--ink-soft)]">{status}</div> : null}
-              {hasAttempted && !validation.ready ? (
-                <div className="text-sm text-[color:var(--ink-soft)]">
-                  Fix validation issues to continue.
+              {publishBlockerSummary ? (
+                <div className="text-sm font-medium text-status-error-fg">
+                  {publishBlockerSummary}
                 </div>
               ) : null}
             </div>
@@ -981,6 +1149,9 @@ export function Upload() {
               disabled={!validation.ready || isSubmitting}
               loading={isSubmitting}
             >
+              {!validation.ready && !isSubmitting ? (
+                <Lock className="h-4 w-4" aria-hidden="true" />
+              ) : null}
               Publish {contentLabel}
             </Button>
           </div>
@@ -997,4 +1168,61 @@ function InlineValidationMessage(props: { id: string; message?: string }) {
       {props.message}
     </p>
   );
+}
+
+function summarizePublishBlockers(issues: string[], requiredFileLabel: string) {
+  const missing = issues.flatMap((issue) => missingPublishLabel(issue, requiredFileLabel));
+  const uniqueMissing = [...new Set(missing)];
+  if (uniqueMissing.length > 0) {
+    return `Complete ${formatInlineList(uniqueMissing)} to publish.`;
+  }
+  return `Fix: ${issues[0] ?? "validation issues"}`;
+}
+
+function formatInlineList(items: string[]) {
+  if (items.length <= 1) return items[0] ?? "";
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items.at(-1)}`;
+}
+
+function missingPublishLabel(issue: string, requiredFileLabel: string) {
+  if (issue === "Slug is required.") return ["slug"];
+  if (issue === "Display name is required.") return ["display name"];
+  if (issue === "At least one tag is required.") return ["tags"];
+  if (issue === "Accept the MIT-0 license terms to publish this skill.") {
+    return ["MIT-0 acceptance"];
+  }
+  if (issue === "Add at least one file.") return ["files"];
+  if (issue === `${requiredFileLabel} is required.`) return [requiredFileLabel];
+  return [];
+}
+
+function getSharedTopLevelFolderName(files: File[]) {
+  if (files.length === 0) return null;
+  const paths = files
+    .map((file) => (file.webkitRelativePath || file.name).replace(/^\.\//, ""))
+    .filter(Boolean);
+  if (paths.length === 0 || paths.some((path) => !path.includes("/"))) return null;
+  const firstSegment = paths[0]?.split("/").filter(Boolean)[0];
+  if (!firstSegment) return null;
+  return paths.every((path) => path.startsWith(`${firstSegment}/`)) ? firstSegment : null;
+}
+
+function slugFromFolderName(name: string) {
+  return name
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+}
+
+function displayNameFromFolderName(name: string) {
+  return name
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[-_]+/g, " ")
+    .replace(/\s+/g, " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
 }

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -108,7 +108,7 @@ export function Upload() {
   const [pendingFileRemovalIndex, setPendingFileRemovalIndex] = useState<number | null>(null);
   const [slug, setSlug] = useState(updateSlug ?? "");
   const [displayName, setDisplayName] = useState("");
-  const [touchedFields, setTouchedFields] = useState<Record<SkillPublishField, boolean>>({
+  const [dirtyFields, setDirtyFields] = useState<Record<SkillPublishField, boolean>>({
     slug: false,
     displayName: false,
     version: false,
@@ -168,8 +168,8 @@ export function Upload() {
   };
   const navigate = useNavigate();
 
-  function markFieldTouched(field: SkillPublishField) {
-    setTouchedFields((current) => {
+  function markFieldDirty(field: SkillPublishField) {
+    setDirtyFields((current) => {
       if (current[field]) return current;
       return { ...current, [field]: true };
     });
@@ -501,11 +501,11 @@ export function Upload() {
     existingOwnerHandle,
     ownerHandle,
   ]);
-  const shouldShowSlugIssue = hasAttempted || touchedFields.slug;
-  const shouldShowDisplayNameIssue = hasAttempted || touchedFields.displayName;
-  const shouldShowVersionIssue = hasAttempted || touchedFields.version;
-  const shouldShowTagsIssue = hasAttempted || touchedFields.tags;
-  const shouldShowClawScanIssue = hasAttempted || touchedFields.clawScanNote;
+  const shouldShowSlugIssue = hasAttempted || dirtyFields.slug || Boolean(trimmedSlug);
+  const shouldShowDisplayNameIssue = hasAttempted || dirtyFields.displayName;
+  const shouldShowVersionIssue = hasAttempted || dirtyFields.version;
+  const shouldShowTagsIssue = hasAttempted || dirtyFields.tags;
+  const shouldShowClawScanIssue = hasAttempted || dirtyFields.clawScanNote;
   const shouldShowFileIssues = hasAttempted || files.length > 0;
 
   const slugIssue = shouldShowSlugIssue
@@ -535,12 +535,12 @@ export function Upload() {
     : undefined;
   const ownerIssue = validation.issues.find((issue) => issue.startsWith("Confirm the ownership "));
   const visibleMetadataIssues = validation.issues.filter((issue) => {
-    if (issue.startsWith("Slug")) return shouldShowSlugIssue;
-    if (issue.startsWith("Display name")) return shouldShowDisplayNameIssue;
-    if (issue.startsWith("Version")) return shouldShowVersionIssue;
+    if (issue.startsWith("Slug")) return false;
+    if (issue.startsWith("Display name")) return false;
+    if (issue.startsWith("Version")) return false;
     if (issue.startsWith("At least one tag")) return shouldShowTagsIssue;
     if (issue.startsWith("ClawScan note")) return shouldShowClawScanIssue;
-    if (issue.includes("already exists")) return Boolean(trimmedSlug);
+    if (issue === effectiveSlugCollision?.message) return false;
     return false;
   });
   const visibleFileIssues = validation.issues.filter((issue) => {
@@ -595,11 +595,11 @@ export function Upload() {
     const nextSlug = slugFromFolderName(folderName);
     const nextDisplayName = displayNameFromFolderName(folderName);
     const prefilled: string[] = [];
-    if (nextSlug && !touchedFields.slug && !trimmedSlug) {
+    if (nextSlug && !dirtyFields.slug && !trimmedSlug) {
       setSlug(nextSlug);
       prefilled.push("slug");
     }
-    if (nextDisplayName && !touchedFields.displayName && !trimmedName) {
+    if (nextDisplayName && !dirtyFields.displayName && !trimmedName) {
       setDisplayName(nextDisplayName);
       prefilled.push("display name");
     }
@@ -1008,11 +1008,10 @@ export function Upload() {
                       displayNameIssue ? "display-name-validation-error" : undefined
                     }
                     onChange={(event) => {
-                      markFieldTouched("displayName");
+                      markFieldDirty("displayName");
                       setMetadataPrefillNote(null);
                       setDisplayName(event.target.value);
                     }}
-                    onBlur={() => markFieldTouched("displayName")}
                     placeholder={`My ${contentLabel}`}
                   />
                   <InlineValidationMessage
@@ -1031,11 +1030,10 @@ export function Upload() {
                       aria-describedby={slugIssue ? "slug-validation-error" : undefined}
                       className={showSlugStatusIcon ? "pr-10" : undefined}
                       onChange={(event) => {
-                        markFieldTouched("slug");
+                        markFieldDirty("slug");
                         setMetadataPrefillNote(null);
                         setSlug(event.target.value);
                       }}
-                      onBlur={() => markFieldTouched("slug")}
                       placeholder={`${contentLabel}-name`}
                     />
                     {showSlugAvailableIcon ? (
@@ -1141,10 +1139,9 @@ export function Upload() {
                   aria-invalid={Boolean(versionIssue)}
                   aria-describedby={versionIssue ? "version-validation-error" : undefined}
                   onValueChange={(nextVersion) => {
-                    markFieldTouched("version");
+                    markFieldDirty("version");
                     setVersion(nextVersion);
                   }}
-                  onBlur={() => markFieldTouched("version")}
                   placeholder="1.0.0"
                 />
                 <InlineValidationMessage id="version-validation-error" message={versionIssue} />
@@ -1156,10 +1153,9 @@ export function Upload() {
                   id="tags"
                   value={tags}
                   onChange={(event) => {
-                    markFieldTouched("tags");
+                    markFieldDirty("tags");
                     setTags(event.target.value);
                   }}
-                  onBlur={() => markFieldTouched("tags")}
                   placeholder="latest, stable"
                 />
               </div>
@@ -1173,11 +1169,10 @@ export function Upload() {
                     value={clawScanNote}
                     maxLength={MAX_CLAWSCAN_NOTE_CHARS + 1}
                     onChange={(event) => {
-                      markFieldTouched("clawScanNote");
+                      markFieldDirty("clawScanNote");
                       clawScanNoteTouchedRef.current = true;
                       setClawScanNote(event.target.value);
                     }}
-                    onBlur={() => markFieldTouched("clawScanNote")}
                     placeholder="Optional context for ClawScan, e.g. why this version needs network access."
                   />
                 </div>

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -7,7 +7,15 @@ import {
 } from "clawhub-schema/licenseConstants";
 import { normalizeTextContentType } from "clawhub-schema/textFiles";
 import { useAction, useMutation, useQuery } from "convex/react";
-import { Check, CircleX, FolderOpen, Lock, Upload as UploadIcon, X } from "lucide-react";
+import {
+  Check,
+  CircleX,
+  ExternalLink,
+  FolderOpen,
+  Lock,
+  Upload as UploadIcon,
+  X,
+} from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import semver from "semver";
 import { toast } from "sonner";
@@ -96,6 +104,7 @@ export function Upload() {
   const [hasAttempted, setHasAttempted] = useState(false);
   const [files, setFiles] = useState<File[]>([]);
   const [ignoredLocalMetadataPaths, setIgnoredLocalMetadataPaths] = useState<string[]>([]);
+  const [pendingFileRemovalIndex, setPendingFileRemovalIndex] = useState<number | null>(null);
   const [slug, setSlug] = useState(updateSlug ?? "");
   const [displayName, setDisplayName] = useState("");
   const [touchedFields, setTouchedFields] = useState<Record<SkillPublishField, boolean>>({
@@ -198,6 +207,15 @@ export function Upload() {
         path: normalizedPaths[index] ?? file.name,
       })),
     [files, normalizedPaths],
+  );
+  const visibleFileEntries = useMemo(
+    () =>
+      [...normalizedFileEntries].sort((left, right) => {
+        const leftRank = requiredFileSortRank(left.path, isSoulMode);
+        const rightRank = requiredFileSortRank(right.path, isSoulMode);
+        return leftRank === rightRank ? left.index - right.index : leftRank - rightRank;
+      }),
+    [isSoulMode, normalizedFileEntries],
   );
   const unsupportedFileEntries = useMemo(
     () => normalizedFileEntries.filter((entry) => !isTextFile(entry.file)),
@@ -563,6 +581,7 @@ export function Upload() {
     const report = await expandFilesWithReport(selected);
     setFiles(report.files);
     setIgnoredLocalMetadataPaths(report.ignoredLocalMetadataPaths);
+    setPendingFileRemovalIndex(null);
     setMetadataPrefillNote(null);
     resetFileInput();
 
@@ -587,20 +606,35 @@ export function Upload() {
     }
   }
 
+  function handleFilesDrop(event: React.DragEvent<HTMLDivElement>) {
+    event.preventDefault();
+    setIsDragging(false);
+    const items = event.dataTransfer.items;
+    void (async () => {
+      const dropped = items?.length
+        ? await expandDroppedItems(items)
+        : Array.from(event.dataTransfer.files);
+      await applyExpandedFiles(dropped);
+    })();
+  }
+
   function clearSelectedFiles() {
     setFiles([]);
     setIgnoredLocalMetadataPaths([]);
+    setPendingFileRemovalIndex(null);
     setMetadataPrefillNote(null);
     resetFileInput();
   }
 
   function removeFileAtIndex(index: number) {
     setFiles((current) => current.filter((_, currentIndex) => currentIndex !== index));
+    setPendingFileRemovalIndex(null);
     resetFileInput();
   }
 
   function removeUnsupportedFiles() {
     setFiles((current) => current.filter((file) => isTextFile(file)));
+    setPendingFileRemovalIndex(null);
     resetFileInput();
   }
 
@@ -746,89 +780,130 @@ export function Upload() {
           {/* File upload panel */}
           <Card>
             <CardContent>
-              <div
-                className={`relative flex flex-col items-center gap-3 overflow-hidden rounded-[var(--radius-md)] border-2 border-dashed p-8 transition-colors ${
-                  isDragging
-                    ? "border-[color:var(--accent)] bg-[color:var(--accent)]/5"
-                    : "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
-                }`}
-                onDragOver={(event) => {
-                  event.preventDefault();
-                  setIsDragging(true);
+              <input
+                ref={setFileInputRef}
+                className="sr-only"
+                id="upload-files"
+                data-testid="upload-input"
+                type="file"
+                multiple
+                onChange={(event) => {
+                  const picked = Array.from(event.target.files ?? []);
+                  void applyExpandedFiles(picked);
                 }}
-                onDragLeave={() => setIsDragging(false)}
-                onDrop={(event) => {
-                  event.preventDefault();
-                  setIsDragging(false);
-                  const items = event.dataTransfer.items;
-                  void (async () => {
-                    const dropped = items?.length
-                      ? await expandDroppedItems(items)
-                      : Array.from(event.dataTransfer.files);
-                    await applyExpandedFiles(dropped);
-                  })();
-                }}
-              >
-                <input
-                  ref={setFileInputRef}
-                  className="sr-only"
-                  id="upload-files"
-                  data-testid="upload-input"
-                  type="file"
-                  multiple
-                  onChange={(event) => {
-                    const picked = Array.from(event.target.files ?? []);
-                    void applyExpandedFiles(picked);
-                  }}
-                />
-                <UploadDropzoneDecor kind="skill" />
-                <div className="relative z-10 flex flex-col items-center gap-2 text-center">
-                  <div className="flex items-center gap-3">
-                    <UploadIcon className="h-5 w-5 text-[color:var(--ink-soft)]" />
-                    <strong>Drop a skill folder</strong>
-                    {files.length > 0 ? (
-                      <span className="text-xs font-medium text-[color:var(--ink-soft)]">
-                        {files.length} files · {sizeLabel}
-                      </span>
-                    ) : null}
-                  </div>
-                  <span className="text-xs text-[color:var(--ink-soft)]">
-                    We keep folder paths and flatten the outer wrapper automatically.
-                  </span>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    type="button"
-                    onClick={() => fileInputRef.current?.click()}
-                  >
-                    <FolderOpen className="h-4 w-4" aria-hidden="true" />
-                    Choose folder
-                  </Button>
-                </div>
-              </div>
+              />
 
               {files.length > 0 ? (
-                <div className="flex flex-wrap gap-2">
-                  {unsupportedFileEntries.length > 0 ? (
+                <div
+                  className={`rounded-[var(--radius-sm)] border px-4 py-4 transition-colors ${
+                    isDragging
+                      ? "border-[color:var(--accent)] bg-[color:var(--accent)]/5"
+                      : "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
+                  }`}
+                  onDragOver={(event) => {
+                    event.preventDefault();
+                    setIsDragging(true);
+                  }}
+                  onDragLeave={() => setIsDragging(false)}
+                  onDrop={handleFilesDrop}
+                >
+                  <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                    <div className="flex min-w-0 gap-3">
+                      <div
+                        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)]"
+                        aria-hidden="true"
+                      >
+                        <FolderOpen className="h-5 w-5 text-[color:var(--ink-soft)]" />
+                      </div>
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                          <strong className="text-sm text-[color:var(--ink)]">
+                            Skill folder selected
+                          </strong>
+                          <span className="text-xs text-[color:var(--ink-soft)]">
+                            {files.length} files · {sizeLabel}
+                          </span>
+                        </div>
+                        <p className="mt-1 text-sm text-[color:var(--ink-soft)]">
+                          Inner paths are preserved; the top-level folder is removed.
+                        </p>
+                        <div className="mt-3 flex flex-wrap gap-1.5">
+                          <Badge variant={hasRequiredFile ? "compact" : "warning"}>
+                            {hasRequiredFile ? requiredFileLabel : `Missing ${requiredFileLabel}`}
+                          </Badge>
+                          {unsupportedFileEntries.length > 0 ? (
+                            <Badge variant="warning">
+                              {unsupportedFileEntries.length} unsupported
+                            </Badge>
+                          ) : null}
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex shrink-0 flex-wrap gap-2 md:justify-end">
+                      {unsupportedFileEntries.length > 0 ? (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          type="button"
+                          onClick={removeUnsupportedFiles}
+                        >
+                          Remove unsupported
+                        </Button>
+                      ) : null}
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        type="button"
+                        onClick={() => fileInputRef.current?.click()}
+                      >
+                        Replace folder
+                      </Button>
+                      <Button variant="ghost" size="sm" type="button" onClick={clearSelectedFiles}>
+                        Clear files
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div
+                  className={`relative flex flex-col items-center gap-3 overflow-hidden rounded-[var(--radius-md)] border-2 border-dashed p-8 transition-colors ${
+                    isDragging
+                      ? "border-[color:var(--accent)] bg-[color:var(--accent)]/5"
+                      : "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
+                  }`}
+                  onDragOver={(event) => {
+                    event.preventDefault();
+                    setIsDragging(true);
+                  }}
+                  onDragLeave={() => setIsDragging(false)}
+                  onDrop={handleFilesDrop}
+                >
+                  <UploadDropzoneDecor kind="skill" />
+                  <div className="relative z-[1] flex flex-col items-center gap-2 text-center">
+                    <div className="flex items-center gap-3">
+                      <UploadIcon className="h-5 w-5 text-[color:var(--ink-soft)]" />
+                      <strong>Drop a skill folder</strong>
+                    </div>
+                    <span className="text-xs text-[color:var(--ink-soft)]">
+                      We keep inner paths and remove the top-level folder automatically.
+                    </span>
                     <Button
                       variant="outline"
                       size="sm"
                       type="button"
-                      onClick={removeUnsupportedFiles}
+                      onClick={() => fileInputRef.current?.click()}
                     >
-                      Remove unsupported files
+                      Choose folder
                     </Button>
-                  ) : null}
-                  <Button variant="ghost" size="sm" type="button" onClick={clearSelectedFiles}>
-                    Clear files
-                  </Button>
+                  </div>
                 </div>
-              ) : null}
+              )}
 
               <div className="flex flex-col gap-1 max-h-[300px] overflow-y-auto">
                 {files.length > 0
-                  ? normalizedFileEntries.map(({ file, index, path }) => {
+                  ? visibleFileEntries.map(({ file, index, path }) => {
                       const isUnsupported = !isTextFile(file);
+                      const isConfirmingRemoval = pendingFileRemovalIndex === index;
                       return (
                         <div
                           key={`${index}:${path}`}
@@ -841,16 +916,45 @@ export function Upload() {
                             {path}
                           </span>
                           {isUnsupported ? <Badge variant="warning">Unsupported</Badge> : null}
-                          <Button
-                            aria-label={`Remove ${path}`}
-                            title={`Remove ${path}`}
-                            variant="ghost"
-                            size="icon-xs"
-                            type="button"
-                            onClick={() => removeFileAtIndex(index)}
-                          >
-                            <X className="h-3.5 w-3.5" aria-hidden="true" />
-                          </Button>
+                          {isConfirmingRemoval ? (
+                            <div className="flex shrink-0 items-center gap-1">
+                              <span className="text-xs font-medium text-status-error-fg">
+                                Remove?
+                              </span>
+                              <Button
+                                aria-label={`Cancel removing ${path}`}
+                                title={`Cancel removing ${path}`}
+                                variant="ghost"
+                                size="icon-xs"
+                                type="button"
+                                onClick={() => setPendingFileRemovalIndex(null)}
+                              >
+                                <X className="h-3.5 w-3.5" aria-hidden="true" />
+                              </Button>
+                              <Button
+                                aria-label={`Confirm removing ${path}`}
+                                title={`Confirm removing ${path}`}
+                                variant="ghost"
+                                size="icon-xs"
+                                type="button"
+                                className="text-status-error-fg hover:not-disabled:bg-status-error-bg"
+                                onClick={() => removeFileAtIndex(index)}
+                              >
+                                <Check className="h-3.5 w-3.5" aria-hidden="true" />
+                              </Button>
+                            </div>
+                          ) : (
+                            <Button
+                              aria-label={`Remove ${path}`}
+                              title={`Remove ${path}`}
+                              variant="ghost"
+                              size="icon-xs"
+                              type="button"
+                              onClick={() => setPendingFileRemovalIndex(index)}
+                            >
+                              <X className="h-3.5 w-3.5" aria-hidden="true" />
+                            </Button>
+                          )}
                         </div>
                       );
                     })
@@ -874,66 +978,75 @@ export function Upload() {
           {/* Metadata panel */}
           <Card>
             <CardContent>
-              <Label htmlFor="slug">Slug</Label>
-              <div className="relative">
-                <Input
-                  id="slug"
-                  value={slug}
-                  aria-invalid={Boolean(slugIssue)}
-                  aria-describedby={slugIssue ? "slug-validation-error" : undefined}
-                  className={showSlugStatusIcon ? "pr-10" : undefined}
-                  onChange={(event) => {
-                    markFieldTouched("slug");
-                    setMetadataPrefillNote(null);
-                    setSlug(event.target.value);
-                  }}
-                  onBlur={() => markFieldTouched("slug")}
-                  placeholder={`${contentLabel}-name`}
-                />
-                {showSlugAvailableIcon ? (
-                  <Check
-                    aria-label="Slug available"
-                    className="pointer-events-none absolute right-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-status-success-fg"
+              <div className="grid gap-x-4 gap-y-3 md:grid-cols-2">
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="displayName">Display name</Label>
+                  <Input
+                    id="displayName"
+                    value={displayName}
+                    aria-invalid={Boolean(displayNameIssue)}
+                    aria-describedby={
+                      displayNameIssue ? "display-name-validation-error" : undefined
+                    }
+                    onChange={(event) => {
+                      markFieldTouched("displayName");
+                      setMetadataPrefillNote(null);
+                      setDisplayName(event.target.value);
+                    }}
+                    onBlur={() => markFieldTouched("displayName")}
+                    placeholder={`My ${contentLabel}`}
                   />
-                ) : null}
-                {showSlugUnavailableIcon ? (
-                  <CircleX
-                    aria-label="Slug unavailable"
-                    className="pointer-events-none absolute right-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-status-error-fg"
+                  <InlineValidationMessage
+                    id="display-name-validation-error"
+                    message={displayNameIssue}
                   />
-                ) : null}
-              </div>
-              <InlineValidationMessage id="slug-validation-error" message={slugIssue} />
-              {slugCollisionIssue?.url ? (
-                <div className="text-sm text-[color:var(--ink-soft)]">
-                  Existing skill:{" "}
-                  <a
-                    href={slugCollisionIssue.url}
-                    className="text-[color:var(--accent)] hover:underline"
-                  >
-                    {slugCollisionIssue.url}
-                  </a>
                 </div>
-              ) : null}
 
-              <Label htmlFor="displayName">Display name</Label>
-              <Input
-                id="displayName"
-                value={displayName}
-                aria-invalid={Boolean(displayNameIssue)}
-                aria-describedby={displayNameIssue ? "display-name-validation-error" : undefined}
-                onChange={(event) => {
-                  markFieldTouched("displayName");
-                  setMetadataPrefillNote(null);
-                  setDisplayName(event.target.value);
-                }}
-                onBlur={() => markFieldTouched("displayName")}
-                placeholder={`My ${contentLabel}`}
-              />
-              <InlineValidationMessage
-                id="display-name-validation-error"
-                message={displayNameIssue}
-              />
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="slug">Slug</Label>
+                  <div className="relative">
+                    <Input
+                      id="slug"
+                      value={slug}
+                      aria-invalid={Boolean(slugIssue)}
+                      aria-describedby={slugIssue ? "slug-validation-error" : undefined}
+                      className={showSlugStatusIcon ? "pr-10" : undefined}
+                      onChange={(event) => {
+                        markFieldTouched("slug");
+                        setMetadataPrefillNote(null);
+                        setSlug(event.target.value);
+                      }}
+                      onBlur={() => markFieldTouched("slug")}
+                      placeholder={`${contentLabel}-name`}
+                    />
+                    {showSlugAvailableIcon ? (
+                      <Check
+                        aria-label="Slug available"
+                        className="pointer-events-none absolute right-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-status-success-fg"
+                      />
+                    ) : null}
+                    {showSlugUnavailableIcon ? (
+                      <CircleX
+                        aria-label="Slug unavailable"
+                        className="pointer-events-none absolute right-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-status-error-fg"
+                      />
+                    ) : null}
+                  </div>
+                  <InlineValidationMessage id="slug-validation-error" message={slugIssue} />
+                  {slugCollisionIssue?.url ? (
+                    <a
+                      href={slugCollisionIssue.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      aria-label="Open existing skill in a new tab"
+                      className="inline-flex w-fit items-center gap-1 text-sm text-[color:var(--ink-soft)] hover:text-[color:var(--accent)] hover:underline"
+                    >
+                      View existing skill
+                      <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                    </a>
+                  ) : null}
+                </div>
+              </div>
               {metadataPrefillNote ? (
                 <p className="text-sm text-[color:var(--ink-soft)]">{metadataPrefillNote}</p>
               ) : null}
@@ -1195,6 +1308,14 @@ function missingPublishLabel(issue: string, requiredFileLabel: string) {
   if (issue === "Add at least one file.") return ["files"];
   if (issue === `${requiredFileLabel} is required.`) return [requiredFileLabel];
   return [];
+}
+
+function requiredFileSortRank(path: string, isSoulMode: boolean) {
+  const normalized = path.trim().toLowerCase();
+  if (isSoulMode) return normalized === "soul.md" ? 0 : 1;
+  if (normalized === "skill.md") return 0;
+  if (normalized === "skills.md") return 1;
+  return 2;
 }
 
 function getSharedTopLevelFolderName(files: File[]) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1036,6 +1036,16 @@ code {
   height: 18px;
 }
 
+.auth-loading-placeholder {
+  display: inline-flex;
+  width: 150px;
+  border: 1px solid var(--border-ui) !important;
+  border-radius: var(--r-btn);
+  background: var(--surface-muted) !important;
+  pointer-events: none;
+  opacity: 0.45;
+}
+
 .sign-in-full-copy {
   display: inline-block;
   white-space: nowrap;

--- a/src/styles.css
+++ b/src/styles.css
@@ -7408,6 +7408,22 @@ code {
   }
 }
 
+@keyframes upload-decor-jiggle {
+  0%,
+  100% {
+    rotate: 0deg;
+  }
+  25% {
+    rotate: -3deg;
+  }
+  50% {
+    rotate: 3deg;
+  }
+  75% {
+    rotate: -2deg;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,


### PR DESCRIPTION
## Summary

Polishes the skill and plugin publish flows so upload is the first decision, post-upload state is easier to scan, and validation appears where users can act on it.

This keeps the existing publish contracts intact: no new categories, no source provenance removal, no feature expansion. The changes are UI, interaction, validation display, and test coverage for the existing surfaces.

Closes #2377.

## Major decisions

- Move upload/drop areas to the top of both publish flows so the required package/folder comes before metadata fields.
- Replace the large drop area after selection with a compact selected-package/folder summary plus a file list.
- Keep file removal local and reversible with an inline confirmation state before deleting a selected file from the upload list.
- Represent missing `SKILL.md` and unsupported skill files inside the file-list grammar, instead of duplicating separate warning blocks.
- Keep plugin source provenance fields, but give them their own clearer section and shorter field-level explanations.
- Narrow the plugin publish layout to match the skill publish reading width and reduce full-width drift.
- Add a pre-upload fade/locked form treatment so disabled fields read as intentionally gated by the upload step.
- Align shared publish controls across skills and plugins: owner picker, version input, upload decoration, skeleton/auth loading, submit gating, and compact badges.
- Move slug availability/error state into the input affordance and avoid repeated collision links inside the form.
- Keep changelog out of initial publish and only show it on update flows.
- Reduce persistent explanatory copy where the interface already explains itself, especially license, upload, changelog, and package detection copy.
- Preserve light/dark behavior and make validation/helper text contrast work in both themes.

## Screenshots

Full screenshot gallery: https://stellar-pulsar-nm5z.here.now/

| Decision / element | Before dark | After dark | Before light | After light |
| --- | --- | --- | --- | --- |
| Upload step moved to the top and simplified | <img width="180" src="https://stellar-pulsar-nm5z.here.now/03-before-dark-skill-empty-drop-area.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/17-after-dark-skill-empty-drop-area.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/33-before-light-skill-empty-drop-area.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/47-after-light-skill-empty-drop-area.png" /> |
| Drag-active feedback and upload decoration | <img width="180" src="https://stellar-pulsar-nm5z.here.now/04-before-dark-skill-empty-drag-active.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/18-after-dark-skill-empty-drag-active.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/34-before-light-skill-empty-drag-active.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/48-after-light-skill-empty-drag-active.png" /> |
| Post-upload selected folder state and file list | <img width="180" src="https://stellar-pulsar-nm5z.here.now/05-before-dark-skill-selected-files-panel.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/19-after-dark-skill-selected-files-panel.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/35-before-light-skill-selected-files-panel.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/49-after-light-skill-selected-files-panel.png" /> |
| Inline remove confirmation | <img width="180" src="https://stellar-pulsar-nm5z.here.now/05-before-dark-skill-selected-files-panel.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/22-after-dark-skill-remove-confirmation.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/35-before-light-skill-selected-files-panel.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/52-after-light-skill-remove-confirmation.png" /> |
| Missing and unsupported file validation | <img width="180" src="https://stellar-pulsar-nm5z.here.now/08-before-dark-skill-missing-unsupported-footer.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/23-after-dark-skill-missing-unsupported-footer.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/38-before-light-skill-missing-unsupported-footer.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/53-after-light-skill-missing-unsupported-footer.png" /> |
| Metadata order, field spacing, and inline validation | <img width="180" src="https://stellar-pulsar-nm5z.here.now/06-before-dark-skill-metadata-fields.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/20-after-dark-skill-metadata-fields.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/36-before-light-skill-metadata-fields.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/50-after-light-skill-metadata-fields.png" /> |
| License copy and acknowledgement treatment | <img width="180" src="https://stellar-pulsar-nm5z.here.now/07-before-dark-skill-license.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/21-after-dark-skill-license.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/37-before-light-skill-license.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/51-after-light-skill-license.png" /> |
| Auth hydration skeleton instead of signed-out flash | <img width="180" src="https://stellar-pulsar-nm5z.here.now/01-before-dark-auth-loading-or-signed-out-state.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/15-after-dark-auth-loading-or-signed-out-state.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/31-before-light-auth-loading-or-signed-out-state.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/45-after-light-auth-loading-or-signed-out-state.png" /> |
| Plugin pre-upload gating and narrower layout | <img width="180" src="https://stellar-pulsar-nm5z.here.now/11-before-dark-plugin-empty-upload-and-fade.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/26-after-dark-plugin-empty-upload-and-fade.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/41-before-light-plugin-empty-upload-and-fade.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/56-after-light-plugin-empty-upload-and-fade.png" /> |
| Plugin post-upload package summary and file list | <img width="180" src="https://stellar-pulsar-nm5z.here.now/13-before-dark-plugin-selected-package-panel.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/28-after-dark-plugin-selected-package-panel.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/43-before-light-plugin-selected-package-panel.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/58-after-light-plugin-selected-package-panel.png" /> |
| Plugin source provenance and submit gating | <img width="180" src="https://stellar-pulsar-nm5z.here.now/14-before-dark-plugin-missing-metadata.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/29-after-dark-plugin-source-and-submit.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/44-before-light-plugin-missing-metadata.png" /> | <img width="180" src="https://stellar-pulsar-nm5z.here.now/59-after-light-plugin-source-and-submit.png" /> |

## Validation

- `git diff --check upstream/main...HEAD`
- `bun run format:check -- <touched files>`
- `bun run lint -- <touched files>`
- `bunx vitest run src/__tests__/plugins-publish-route.test.tsx src/__tests__/skills-publish-route.test.tsx src/lib/uploadFiles.test.ts src/lib/uploadFiles.jsdom.test.ts src/lib/slugCollision.test.ts src/components/SkillIconPicker.test.tsx`
- `bunx tsc --noEmit`
- `bun run ci:static`
- `VITE_CONVEX_URL=https://example.invalid bun run ci:unit`
- `bun run ci:types-build`
- Autoreview branch pass against `upstream/main`: no accepted/actionable findings.
- Manual visual pass in Chrome with local auth owner across skill/plugin publish flows, light/dark themes, selected-package states, removal confirmation, missing/unsupported file states, and auth hydration skeleton.
