### PR TITLE
Add org member removal to clawhub-mod

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -730,6 +730,50 @@ describe("httpApiV1 handlers", () => {
     );
   });
 
+  it("users/publisher-member removes an org publisher member for admin", async () => {
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      return {
+        ok: true,
+        publisherId: "publishers:opik",
+        handle: "opik",
+        removed: true,
+        member: {
+          userId: "users:patrick",
+          handle: "patrick-erichsen-2",
+          role: "owner",
+        },
+      };
+    });
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:admin",
+      user: { _id: "users:admin", role: "admin" },
+    } as never);
+
+    const response = await __handlers.usersPostRouterV1Handler(
+      makeCtx({ runQuery: vi.fn(), runAction: vi.fn(), runMutation }),
+      new Request("https://example.com/api/v1/users/publisher-member", {
+        method: "POST",
+        body: JSON.stringify({ handle: "Opik", memberHandle: "@patrick-erichsen-2" }),
+      }),
+    );
+    if (response.status !== 200) throw new Error(await response.text());
+
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      handle: "opik",
+      removed: true,
+    });
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        actorUserId: "users:admin",
+        handle: "opik",
+        memberHandle: "@patrick-erichsen-2",
+      }),
+    );
+  });
+
   it("publishers creates a self-serve org publisher for the authenticated user", async () => {
     const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
       if (isRateLimitArgs(args)) return okRate();

--- a/convex/httpApiV1/usersV1.ts
+++ b/convex/httpApiV1/usersV1.ts
@@ -13,6 +13,9 @@ import {
 } from "./shared";
 
 const usersV1InternalRefs = internal as unknown as {
+  publishers: {
+    removeOrgPublisherMemberInternal: unknown;
+  };
   users: {
     getByHandleInternal: unknown;
     remediateAutobansInternal: unknown;
@@ -54,7 +57,8 @@ export async function usersPostRouterV1Handler(ctx: ActionCtx, request: Request)
     action !== "reclassify-ban" &&
     action !== "reclaim" &&
     action !== "reserve" &&
-    action !== "publisher"
+    action !== "publisher" &&
+    action !== "publisher-member"
   ) {
     return text("Not found", 404, rate.headers);
   }
@@ -103,6 +107,12 @@ export async function usersPostRouterV1Handler(ctx: ActionCtx, request: Request)
     const admin = requireAdminOrResponse(actorUser, rate.headers);
     if (!admin.ok) return admin.response;
     return handleAdminEnsurePublisher(ctx, payload, actorUserId, rate.headers);
+  }
+
+  if (action === "publisher-member") {
+    const admin = requireAdminOrResponse(actorUser, rate.headers);
+    if (!admin.ok) return admin.response;
+    return handleAdminRemovePublisherMember(ctx, payload, actorUserId, rate.headers);
   }
 
   const handleRaw = typeof payload.handle === "string" ? payload.handle.trim() : "";
@@ -528,6 +538,41 @@ async function handleAdminEnsurePublisher(
     return json(result, 200, headers);
   } catch (error) {
     const message = error instanceof Error ? error.message : "Publisher ensure failed";
+    if (message.toLowerCase().includes("forbidden")) {
+      return text("Forbidden", 403, headers);
+    }
+    if (message.toLowerCase().includes("not found")) {
+      return text(message, 404, headers);
+    }
+    return text(message, 400, headers);
+  }
+}
+
+async function handleAdminRemovePublisherMember(
+  ctx: ActionCtx,
+  payload: Record<string, unknown>,
+  actorUserId: Id<"users">,
+  headers: HeadersInit,
+) {
+  const handle = typeof payload.handle === "string" ? payload.handle.trim().toLowerCase() : "";
+  const memberHandle =
+    typeof payload.memberHandle === "string" ? payload.memberHandle.trim().toLowerCase() : "";
+  if (!handle) return text("Missing handle", 400, headers);
+  if (!memberHandle) return text("Missing memberHandle", 400, headers);
+
+  try {
+    const result = await runUsersV1MutationRef(
+      ctx,
+      usersV1InternalRefs.publishers.removeOrgPublisherMemberInternal,
+      {
+        actorUserId,
+        handle,
+        memberHandle,
+      },
+    );
+    return json(result, 200, headers);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Publisher member removal failed";
     if (message.toLowerCase().includes("forbidden")) {
       return text("Forbidden", 403, headers);
     }

--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -9,6 +9,7 @@ import {
   listPublishedPage,
   migrateLegacyPublisherHandleToOrgInternal,
   ensureOrgPublisherHandleInternal,
+  removeOrgPublisherMemberInternal,
   createOrg,
   removeMember,
   createOrgPublisherForUserInternal,
@@ -72,6 +73,23 @@ const ensureOrgPublisherHandleInternalHandler = (
       handle: string;
       created: boolean;
       member?: { userId: string; handle: string; role: "owner" | "admin" | "publisher" };
+    }
+  >
+)._handler;
+
+const removeOrgPublisherMemberInternalHandler = (
+  removeOrgPublisherMemberInternal as unknown as WrappedHandler<
+    {
+      actorUserId: string;
+      handle: string;
+      memberHandle: string;
+    },
+    {
+      ok: true;
+      publisherId: string;
+      handle: string;
+      removed: boolean;
+      member: { userId: string; handle: string; role: "owner" | "admin" | "publisher" };
     }
   >
 )._handler;
@@ -2182,6 +2200,215 @@ describe("legacy publisher migration", () => {
         }),
       }),
     ]);
+  });
+
+  it("lets an admin remove one org owner when another owner remains", async () => {
+    const publisherMembers = [
+      {
+        _id: "publisherMembers:patrick",
+        publisherId: "publishers:opik",
+        userId: "users:patrick",
+        role: "owner",
+      },
+      {
+        _id: "publisherMembers:vincent",
+        publisherId: "publishers:opik",
+        userId: "users:vincent",
+        role: "owner",
+      },
+    ];
+    const deleted: string[] = [];
+    const inserts: Array<{ table: string; value: Record<string, unknown> }> = [];
+    const query = vi.fn((table: string) => {
+      if (table === "users") {
+        return {
+          withIndex: vi.fn(
+            (
+              _indexName: string,
+              builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown,
+            ) => {
+              let handle = "";
+              const q = {
+                eq: (field: string, value: string) => {
+                  if (field === "handle") handle = value;
+                  return q;
+                },
+              };
+              builder?.(q);
+              return {
+                unique: vi.fn(async () =>
+                  handle === "patrick-erichsen-2"
+                    ? { _id: "users:patrick", handle: "patrick-erichsen-2" }
+                    : null,
+                ),
+              };
+            },
+          ),
+        };
+      }
+      if (table === "publishers") {
+        return {
+          withIndex: vi.fn(
+            (
+              _indexName: string,
+              builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown,
+            ) => {
+              let handle = "";
+              const q = {
+                eq: (field: string, value: string) => {
+                  if (field === "handle") handle = value;
+                  return q;
+                },
+              };
+              builder?.(q);
+              return {
+                unique: vi.fn(async () =>
+                  handle === "opik" ? { _id: "publishers:opik", kind: "org", handle } : null,
+                ),
+              };
+            },
+          ),
+        };
+      }
+      if (table === "publisherMembers") {
+        return {
+          withIndex: vi.fn(
+            (
+              indexName: string,
+              builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown,
+            ) => {
+              let publisherId = "";
+              let userId = "";
+              const q = {
+                eq: (field: string, value: string) => {
+                  if (field === "publisherId") publisherId = value;
+                  if (field === "userId") userId = value;
+                  return q;
+                },
+              };
+              builder?.(q);
+              return {
+                unique: vi.fn(async () => {
+                  if (indexName !== "by_publisher_user") return null;
+                  return (
+                    publisherMembers.find(
+                      (member) => member.publisherId === publisherId && member.userId === userId,
+                    ) ?? null
+                  );
+                }),
+                collect: vi.fn(async () =>
+                  publisherMembers.filter((member) => member.publisherId === publisherId),
+                ),
+              };
+            },
+          ),
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    });
+
+    const result = await removeOrgPublisherMemberInternalHandler(
+      {
+        db: {
+          get: vi.fn(async (id: string) =>
+            id === "users:admin" ? { _id: id, role: "admin" } : null,
+          ),
+          query,
+          insert: vi.fn(async (table: string, value: Record<string, unknown>) => {
+            inserts.push({ table, value });
+            return `${table}:audit`;
+          }),
+          patch: vi.fn(),
+          delete: vi.fn(async (id: string) => {
+            deleted.push(id);
+          }),
+          replace: vi.fn(),
+          normalizeId: vi.fn(),
+        },
+      } as never,
+      {
+        actorUserId: "users:admin",
+        handle: "opik",
+        memberHandle: "patrick-erichsen-2",
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      handle: "opik",
+      removed: true,
+      member: { handle: "patrick-erichsen-2", role: "owner" },
+    });
+    expect(deleted).toEqual(["publisherMembers:patrick"]);
+    expect(inserts).toContainEqual(
+      expect.objectContaining({
+        table: "auditLogs",
+        value: expect.objectContaining({
+          actorUserId: "users:admin",
+          action: "publisher.member.remove",
+          targetId: "publishers:opik",
+        }),
+      }),
+    );
+  });
+
+  it("rejects removing the last org owner", async () => {
+    const publisherMembers = [
+      {
+        _id: "publisherMembers:patrick",
+        publisherId: "publishers:opik",
+        userId: "users:patrick",
+        role: "owner",
+      },
+    ];
+    const query = vi.fn((table: string) => {
+      if (table === "users") {
+        return {
+          withIndex: vi.fn(() => ({
+            unique: vi.fn(async () => ({ _id: "users:patrick", handle: "patrick-erichsen-2" })),
+          })),
+        };
+      }
+      if (table === "publishers") {
+        return {
+          withIndex: vi.fn(() => ({
+            unique: vi.fn(async () => ({ _id: "publishers:opik", kind: "org", handle: "opik" })),
+          })),
+        };
+      }
+      if (table === "publisherMembers") {
+        return {
+          withIndex: vi.fn(() => ({
+            unique: vi.fn(async () => publisherMembers[0]),
+            collect: vi.fn(async () => publisherMembers),
+          })),
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    });
+
+    await expect(
+      removeOrgPublisherMemberInternalHandler(
+        {
+          db: {
+            get: vi.fn(async (id: string) =>
+              id === "users:admin" ? { _id: id, role: "admin" } : null,
+            ),
+            query,
+            insert: vi.fn(),
+            patch: vi.fn(),
+            delete: vi.fn(),
+            replace: vi.fn(),
+            normalizeId: vi.fn(),
+          },
+        } as never,
+        {
+          actorUserId: "users:admin",
+          handle: "opik",
+          memberHandle: "patrick-erichsen-2",
+        },
+      ),
+    ).rejects.toThrow("Publisher must have at least one owner");
   });
 
   it("converts a legacy personal publisher into an org and rehomes package ownership", async () => {

--- a/convex/publishers.ts
+++ b/convex/publishers.ts
@@ -1393,6 +1393,87 @@ export const ensureOrgPublisherHandleInternal = internalMutation({
   handler: async (ctx, args) => await ensureOrgPublisherHandleWithActor(ctx, args),
 });
 
+export const removeOrgPublisherMemberInternal = internalMutation({
+  args: {
+    actorUserId: v.id("users"),
+    handle: v.string(),
+    memberHandle: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const actor = await ctx.db.get(args.actorUserId);
+    if (!actor || actor.deletedAt || actor.deactivatedAt) throw new ConvexError("Unauthorized");
+    assertAdmin(actor);
+
+    const handle = normalizePublisherHandle(args.handle);
+    if (!handle || !PUBLISHER_HANDLE_PATTERN.test(handle)) {
+      throw new ConvexError("Handle must be lowercase, url-safe, and 2-40 characters");
+    }
+    const memberHandle = normalizePublisherHandle(args.memberHandle);
+    if (!memberHandle) throw new ConvexError("memberHandle is required");
+
+    const publisher = await getPublisherByHandle(ctx, handle);
+    if (!publisher || publisher.kind !== "org" || publisher.deletedAt || publisher.deactivatedAt) {
+      throw new ConvexError("Publisher not found");
+    }
+
+    const targetUser = await getActiveUserByHandleOrPersonalPublisher(ctx, memberHandle);
+    if (!targetUser) throw new ConvexError(`User "@${memberHandle}" not found`);
+
+    const targetMembership = await getPublisherMembership(ctx, publisher._id, targetUser._id);
+    const member = {
+      userId: targetUser._id,
+      handle: targetUser.handle ?? memberHandle,
+      role: targetMembership?.role ?? ("publisher" as const),
+    };
+    if (!targetMembership) {
+      return {
+        ok: true as const,
+        publisherId: publisher._id,
+        handle,
+        removed: false,
+        member,
+      };
+    }
+
+    if (targetMembership.role === "owner") {
+      const members = await ctx.db
+        .query("publisherMembers")
+        .withIndex("by_publisher", (q) => q.eq("publisherId", publisher._id))
+        .collect();
+      const remainingOwners = members.filter(
+        (publisherMember) =>
+          publisherMember.role === "owner" && publisherMember.userId !== targetUser._id,
+      );
+      if (remainingOwners.length === 0) {
+        throw new ConvexError("Publisher must have at least one owner");
+      }
+    }
+
+    await ctx.db.delete(targetMembership._id);
+    await ctx.db.insert("auditLogs", {
+      actorUserId: args.actorUserId,
+      action: "publisher.member.remove",
+      targetType: "publisher",
+      targetId: publisher._id,
+      metadata: {
+        memberUserId: targetUser._id,
+        memberHandle: targetUser.handle ?? memberHandle,
+        role: targetMembership.role,
+        source: "publisher.org.mod",
+      },
+      createdAt: Date.now(),
+    });
+
+    return {
+      ok: true as const,
+      publisherId: publisher._id,
+      handle,
+      removed: true,
+      member,
+    };
+  },
+});
+
 export const createOrgPublisherForUserInternal = internalMutation({
   args: {
     actorUserId: v.id("users"),

--- a/packages/clawhub-mod/src/cli.ts
+++ b/packages/clawhub-mod/src/cli.ts
@@ -30,7 +30,7 @@ import {
   cmdSetRole,
   cmdUnbanUser,
 } from "./commands/moderation.js";
-import { cmdCreateOrg } from "./commands/orgs.js";
+import { cmdCreateOrg, cmdRemoveOrgMember, cmdRepairScopedPackages } from "./commands/orgs.js";
 import {
   cmdBackfillPackageArtifacts,
   cmdDeletePackageTrustedPublisher,
@@ -357,6 +357,34 @@ function registerOrgCommands(command: Command) {
     .action(async (handle, options) => {
       const opts = await resolveGlobalOpts();
       await cmdCreateOrg(opts, handle, options);
+    });
+
+  command
+    .command("remove-member")
+    .description("Remove a user from an org publisher")
+    .argument("<handle>", "Org publisher handle")
+    .argument("<member>", "User handle to remove")
+    .option("--json", "Output JSON")
+    .action(async (handle, member, options) => {
+      const opts = await resolveGlobalOpts();
+      await cmdRemoveOrgMember(opts, handle, member, options);
+    });
+
+  command
+    .command("repair-scoped-packages")
+    .description("Batch-create org publishers and transfer scoped packages from a CSV")
+    .argument("<csv>", "CSV with packageName,intendedOrg,legacyOwner[,orgDisplayName]")
+    .option("--apply", "Write changes; defaults to dry-run")
+    .option("--start <n>", "Start at zero-based CSV row offset", (value) =>
+      Number.parseInt(value, 10),
+    )
+    .option("--limit <n>", "Limit rows processed", (value) => Number.parseInt(value, 10))
+    .option("--reason <reason>", "Override audit reason for all rows")
+    .option("--result-file <path>", "Write JSON result report")
+    .option("--json", "Output JSON")
+    .action(async (csv, options) => {
+      const opts = await resolveGlobalOpts();
+      await cmdRepairScopedPackages(opts, csv, options);
     });
 }
 

--- a/packages/clawhub-mod/src/commands/orgs.test.ts
+++ b/packages/clawhub-mod/src/commands/orgs.test.ts
@@ -1,5 +1,8 @@
 /* @vitest-environment node */
 
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createAuthTokenModuleMocks,
@@ -19,11 +22,23 @@ vi.mock("../../../clawhub/src/cli/registry.js", () => registryMocks.moduleFactor
 vi.mock("../../../clawhub/src/http.js", () => httpMocks.moduleFactory());
 vi.mock("../../../clawhub/src/cli/ui.js", () => uiMocks.moduleFactory());
 
-const { cmdCreateOrg } = await import("./orgs");
+const { cmdCreateOrg, cmdRemoveOrgMember, cmdRepairScopedPackages } = await import("./orgs");
 
 afterEach(() => {
   vi.clearAllMocks();
 });
+
+async function withCsv(content: string) {
+  const dir = await mkdtemp(join(tmpdir(), "clawhub-mod-orgs-"));
+  const path = join(dir, "repairs.csv");
+  await writeFile(path, content, "utf8");
+  return {
+    path,
+    async cleanup() {
+      await rm(dir, { force: true, recursive: true });
+    },
+  };
+}
 
 describe("cmdCreateOrg", () => {
   it("creates an org publisher and adds the legacy owner as owner by default", async () => {
@@ -108,5 +123,237 @@ describe("cmdCreateOrg", () => {
   it("requires an explicit member so the moderator is not added as owner", async () => {
     await expect(cmdCreateOrg(makeGlobalOpts(), "opik", {})).rejects.toThrow(/--member required/i);
     expect(httpMocks.apiRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe("cmdRemoveOrgMember", () => {
+  it("removes a user from an org publisher by handle", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      ok: true,
+      publisherId: "publishers:opik",
+      handle: "opik",
+      removed: true,
+      member: {
+        userId: "users:patrick",
+        handle: "patrick-erichsen-2",
+        role: "owner",
+      },
+    });
+
+    const result = await cmdRemoveOrgMember(makeGlobalOpts(), "Opik", "@patrick-erichsen-2", {
+      json: true,
+    });
+
+    expect(result).toMatchObject({ ok: true, handle: "opik", removed: true });
+    expect(authTokenMocks.requireAuthToken).toHaveBeenCalled();
+    expect(httpMocks.apiRequest).toHaveBeenCalledWith(
+      "https://clawhub.ai",
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/v1/users/publisher-member",
+        token: "tkn",
+        body: {
+          handle: "opik",
+          memberHandle: "patrick-erichsen-2",
+        },
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("requires an explicit member handle", async () => {
+    await expect(cmdRemoveOrgMember(makeGlobalOpts(), "opik", "  ")).rejects.toThrow(
+      /Member handle required/i,
+    );
+    expect(httpMocks.apiRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe("cmdRepairScopedPackages", () => {
+  it("plans scoped package repairs from CSV without touching the API by default", async () => {
+    const csv = await withCsv(
+      [
+        "packageName,intendedOrg,legacyOwner,orgDisplayName",
+        "@opik/opik-openclaw,opik,vincentkoc,Opik",
+      ].join("\n"),
+    );
+    try {
+      const result = await cmdRepairScopedPackages(makeGlobalOpts(), csv.path, { json: true });
+
+      expect(result).toMatchObject({
+        ok: true,
+        dryRun: true,
+        total: 1,
+        planned: 1,
+        applied: 0,
+        failed: 0,
+      });
+      expect(httpMocks.apiRequest).not.toHaveBeenCalled();
+      expect(authTokenMocks.requireAuthToken).not.toHaveBeenCalled();
+    } finally {
+      await csv.cleanup();
+    }
+  });
+
+  it("applies each row by ensuring the org owner then guarded transfer", async () => {
+    const csv = await withCsv(
+      [
+        "packageName,intendedOrg,legacyOwner,orgDisplayName",
+        "@opik/opik-openclaw,opik,vincentkoc,Opik",
+      ].join("\n"),
+    );
+    httpMocks.apiRequest
+      .mockResolvedValueOnce({
+        ok: true,
+        publisherId: "publishers:opik",
+        handle: "opik",
+        created: false,
+        migrated: false,
+        trusted: false,
+        member: { userId: "users:vincent", handle: "vincentkoc", role: "owner" },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        dryRun: true,
+        source: {
+          packageId: "packages:opik",
+          name: "@opik/opik-openclaw",
+          runtimeId: "opik-openclaw",
+          ownerUserId: "users:vincent",
+          ownerPublisherId: "publishers:vincent",
+          channel: "community",
+          softDeletedAt: null,
+        },
+        target: {
+          packageId: "packages:opik",
+          name: "@opik/opik-openclaw",
+          runtimeId: "opik-openclaw",
+          ownerUserId: "users:vincent",
+          ownerPublisherId: "publishers:vincent",
+          channel: "community",
+          softDeletedAt: null,
+        },
+        retiredName: null,
+        operations: [{ action: "transfer-owner", packageId: "packages:opik", owner: "opik" }],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        dryRun: false,
+        source: {
+          packageId: "packages:opik",
+          name: "@opik/opik-openclaw",
+          runtimeId: "opik-openclaw",
+          ownerUserId: "users:vincent",
+          ownerPublisherId: "publishers:vincent",
+          channel: "community",
+          softDeletedAt: null,
+        },
+        target: {
+          packageId: "packages:opik",
+          name: "@opik/opik-openclaw",
+          runtimeId: "opik-openclaw",
+          ownerUserId: "users:vincent",
+          ownerPublisherId: "publishers:vincent",
+          channel: "community",
+          softDeletedAt: null,
+        },
+        retiredName: null,
+        operations: [{ action: "transfer-owner", packageId: "packages:opik", owner: "opik" }],
+      });
+
+    try {
+      const result = await cmdRepairScopedPackages(makeGlobalOpts(), csv.path, {
+        apply: true,
+        json: true,
+      });
+
+      expect(result).toMatchObject({ ok: true, dryRun: false, applied: 1, failed: 0 });
+      expect(httpMocks.apiRequest).toHaveBeenNthCalledWith(
+        1,
+        "https://clawhub.ai",
+        expect.objectContaining({
+          method: "POST",
+          path: "/api/v1/users/publisher",
+          body: {
+            handle: "opik",
+            displayName: "Opik",
+            memberHandle: "vincentkoc",
+            memberRole: "owner",
+          },
+        }),
+        expect.anything(),
+      );
+      expect(httpMocks.apiRequest).toHaveBeenNthCalledWith(
+        2,
+        "https://clawhub.ai",
+        expect.objectContaining({
+          path: "/api/v1/packages/%40opik%2Fopik-openclaw/repair-name",
+          body: {
+            nextName: "@opik/opik-openclaw",
+            owner: "opik",
+            reason: "Move legacy personal package into @opik",
+            dryRun: true,
+          },
+        }),
+        expect.anything(),
+      );
+      expect(httpMocks.apiRequest).toHaveBeenNthCalledWith(
+        3,
+        "https://clawhub.ai",
+        expect.objectContaining({
+          path: "/api/v1/packages/%40opik%2Fopik-openclaw/repair-name",
+          body: expect.objectContaining({ dryRun: false }),
+        }),
+        expect.anything(),
+      );
+    } finally {
+      await csv.cleanup();
+    }
+  });
+
+  it("refuses to apply when transfer dry-run plans anything other than owner transfer", async () => {
+    const csv = await withCsv(
+      [
+        "packageName,intendedOrg,legacyOwner,orgDisplayName",
+        "@opik/opik-openclaw,opik,vincentkoc,Opik",
+      ].join("\n"),
+    );
+    httpMocks.apiRequest
+      .mockResolvedValueOnce({
+        ok: true,
+        publisherId: "publishers:opik",
+        handle: "opik",
+        created: false,
+        migrated: false,
+        trusted: false,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        dryRun: true,
+        source: {
+          packageId: "packages:opik",
+          name: "@opik/opik-openclaw",
+          runtimeId: "opik-openclaw",
+          ownerUserId: "users:vincent",
+          ownerPublisherId: "publishers:vincent",
+          channel: "community",
+          softDeletedAt: null,
+        },
+        target: null,
+        retiredName: null,
+        operations: [{ action: "rename-source", from: "old", to: "new" }],
+      });
+
+    try {
+      const result = await cmdRepairScopedPackages(makeGlobalOpts(), csv.path, {
+        apply: true,
+        json: true,
+      });
+
+      expect(result).toMatchObject({ ok: false, dryRun: false, applied: 0, failed: 1 });
+      expect(httpMocks.apiRequest).toHaveBeenCalledTimes(2);
+    } finally {
+      await csv.cleanup();
+    }
   });
 });

--- a/packages/clawhub-mod/src/commands/orgs.ts
+++ b/packages/clawhub-mod/src/commands/orgs.ts
@@ -1,11 +1,15 @@
+import { readFile, writeFile } from "node:fs/promises";
 import { requireAuthToken } from "../../../clawhub/src/cli/authToken.js";
 import { getRegistry } from "../../../clawhub/src/cli/registry.js";
 import type { GlobalOpts } from "../../../clawhub/src/cli/types.js";
 import { createSpinner, fail, formatError } from "../../../clawhub/src/cli/ui.js";
 import { apiRequest } from "../../../clawhub/src/http.js";
+import type { ApiV1PackageRepairNameResponse } from "../../../clawhub/src/schema/index.js";
 import {
+  ApiV1PackageRepairNameResponseSchema,
   ApiRoutes,
   ApiV1PublisherEnsureResponseSchema,
+  ApiV1PublisherRemoveMemberResponseSchema,
 } from "../../../clawhub/src/schema/index.js";
 
 type OrgMemberRole = "owner" | "admin" | "publisher";
@@ -16,6 +20,44 @@ type OrgCreateOptions = {
   role?: string;
   trusted?: boolean;
   json?: boolean;
+};
+
+type OrgRemoveMemberOptions = {
+  json?: boolean;
+};
+
+type ScopedPackageRepairOptions = {
+  apply?: boolean;
+  json?: boolean;
+  limit?: number;
+  start?: number;
+  reason?: string;
+  resultFile?: string;
+};
+
+type ScopedPackageRepairRow = {
+  packageName: string;
+  intendedOrg: string;
+  legacyOwner: string;
+  orgDisplayName?: string;
+};
+
+type ScopedPackageRepairItemResult = {
+  packageName: string;
+  intendedOrg: string;
+  legacyOwner: string;
+  status: "planned" | "applied" | "failed";
+  error?: string;
+};
+
+type ScopedPackageRepairSummary = {
+  ok: boolean;
+  dryRun: boolean;
+  total: number;
+  planned: number;
+  applied: number;
+  failed: number;
+  items: ScopedPackageRepairItemResult[];
 };
 
 function normalizeHandleOrFail(handle: string, label: string) {
@@ -73,5 +115,270 @@ export async function cmdCreateOrg(opts: GlobalOpts, handle: string, options: Or
   } catch (error) {
     spinner?.fail(formatError(error));
     throw error;
+  }
+}
+
+export async function cmdRemoveOrgMember(
+  opts: GlobalOpts,
+  handle: string,
+  memberHandle: string,
+  options: OrgRemoveMemberOptions = {},
+) {
+  const orgHandle = normalizeHandleOrFail(handle, "Org handle");
+  const normalizedMemberHandle = normalizeHandleOrFail(memberHandle, "Member handle");
+
+  const token = await requireAuthToken();
+  const registry = await getRegistry(opts, { cache: true });
+  const spinner = options.json
+    ? null
+    : createSpinner(`Removing @${normalizedMemberHandle} from @${orgHandle}`);
+  try {
+    const result = await apiRequest(
+      registry,
+      {
+        method: "POST",
+        path: `${ApiRoutes.users}/publisher-member`,
+        token,
+        body: {
+          handle: orgHandle,
+          memberHandle: normalizedMemberHandle,
+        },
+      },
+      ApiV1PublisherRemoveMemberResponseSchema,
+    );
+
+    spinner?.succeed(
+      result.removed
+        ? `Removed @${result.member.handle} from @${result.handle}`
+        : `@${result.member.handle} is not a member of @${result.handle}`,
+    );
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    }
+    return result;
+  } catch (error) {
+    spinner?.fail(formatError(error));
+    throw error;
+  }
+}
+
+export async function cmdRepairScopedPackages(
+  opts: GlobalOpts,
+  csvPath: string,
+  options: ScopedPackageRepairOptions = {},
+) {
+  const rows = parseScopedPackageRepairCsv(await readFile(csvPath, "utf8"));
+  const start = Math.max(0, options.start ?? 0);
+  const limit = options.limit && options.limit > 0 ? options.limit : rows.length;
+  const selectedRows = rows.slice(start, start + limit);
+  const dryRun = options.apply !== true;
+  const defaultReason = (intendedOrg: string) =>
+    `Move legacy personal package into @${intendedOrg}`;
+  const items: ScopedPackageRepairItemResult[] = [];
+
+  const spinner = options.json
+    ? null
+    : createSpinner(`${dryRun ? "Planning" : "Applying"} scoped package repairs`);
+
+  try {
+    if (dryRun) {
+      for (const row of selectedRows) {
+        items.push({
+          packageName: row.packageName,
+          intendedOrg: row.intendedOrg,
+          legacyOwner: row.legacyOwner,
+          status: "planned",
+        });
+      }
+    } else {
+      const token = await requireAuthToken();
+      const registry = await getRegistry(opts, { cache: true });
+      for (const row of selectedRows) {
+        try {
+          await apiRequest(
+            registry,
+            {
+              method: "POST",
+              path: `${ApiRoutes.users}/publisher`,
+              token,
+              body: {
+                handle: row.intendedOrg,
+                ...(row.orgDisplayName ? { displayName: row.orgDisplayName } : {}),
+                memberHandle: row.legacyOwner,
+                memberRole: "owner",
+              },
+            },
+            ApiV1PublisherEnsureResponseSchema,
+          );
+
+          const reason = options.reason?.trim() || defaultReason(row.intendedOrg);
+          const dryRunResult = await apiRequest(
+            registry,
+            {
+              method: "POST",
+              path: `${ApiRoutes.packages}/${encodeURIComponent(row.packageName)}/repair-name`,
+              token,
+              body: {
+                nextName: row.packageName,
+                owner: row.intendedOrg,
+                reason,
+                dryRun: true,
+              },
+            },
+            ApiV1PackageRepairNameResponseSchema,
+          );
+          assertSafeScopedPackageTransfer(row, dryRunResult);
+          await apiRequest(
+            registry,
+            {
+              method: "POST",
+              path: `${ApiRoutes.packages}/${encodeURIComponent(row.packageName)}/repair-name`,
+              token,
+              body: {
+                nextName: row.packageName,
+                owner: row.intendedOrg,
+                reason,
+                dryRun: false,
+              },
+            },
+            ApiV1PackageRepairNameResponseSchema,
+          );
+          items.push({
+            packageName: row.packageName,
+            intendedOrg: row.intendedOrg,
+            legacyOwner: row.legacyOwner,
+            status: "applied",
+          });
+        } catch (error) {
+          items.push({
+            packageName: row.packageName,
+            intendedOrg: row.intendedOrg,
+            legacyOwner: row.legacyOwner,
+            status: "failed",
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+
+    const summary = summarizeScopedPackageRepairs(dryRun, rows.length, items);
+    if (options.resultFile) {
+      await writeFile(options.resultFile, `${JSON.stringify(summary, null, 2)}\n`);
+    }
+    spinner?.succeed(
+      `${dryRun ? "Planned" : "Applied"} scoped package repairs: ${summary.planned || summary.applied} ok, ${summary.failed} failed`,
+    );
+    if (options.json) process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+    return summary;
+  } catch (error) {
+    spinner?.fail(formatError(error));
+    throw error;
+  }
+}
+
+function summarizeScopedPackageRepairs(
+  dryRun: boolean,
+  total: number,
+  items: ScopedPackageRepairItemResult[],
+): ScopedPackageRepairSummary {
+  const planned = items.filter((item) => item.status === "planned").length;
+  const applied = items.filter((item) => item.status === "applied").length;
+  const failed = items.filter((item) => item.status === "failed").length;
+  return { ok: failed === 0, dryRun, total, planned, applied, failed, items };
+}
+
+function parseScopedPackageRepairCsv(content: string): ScopedPackageRepairRow[] {
+  const records = parseCsvRecords(content).filter((record) =>
+    record.some((cell) => cell.trim().length > 0),
+  );
+  const header = records.shift()?.map((cell) => cell.trim()) ?? [];
+  const required = ["packageName", "intendedOrg", "legacyOwner"];
+  for (const name of required) {
+    if (!header.includes(name)) fail(`CSV missing required column: ${name}`);
+  }
+  return records.map((record, index) => {
+    const row = Object.fromEntries(
+      header.map((name, columnIndex) => [name, record[columnIndex]?.trim() ?? ""]),
+    );
+    const packageName = row.packageName;
+    const intendedOrg = normalizeHandleOrFail(
+      row.intendedOrg ?? "",
+      `row ${index + 2} intendedOrg`,
+    );
+    const legacyOwner = normalizeHandleOrFail(
+      row.legacyOwner ?? "",
+      `row ${index + 2} legacyOwner`,
+    );
+    const scopedOrg = getScopedPackageOwner(packageName);
+    if (!scopedOrg) fail(`row ${index + 2} packageName must be scoped`);
+    if (scopedOrg !== intendedOrg) {
+      fail(`row ${index + 2} intendedOrg must match package scope @${scopedOrg}`);
+    }
+    if (legacyOwner === intendedOrg) {
+      fail(`row ${index + 2} legacyOwner already matches intendedOrg`);
+    }
+    return {
+      packageName,
+      intendedOrg,
+      legacyOwner,
+      orgDisplayName: row.orgDisplayName?.trim() || undefined,
+    };
+  });
+}
+
+function parseCsvRecords(content: string) {
+  const records: string[][] = [];
+  let current = "";
+  let row: string[] = [];
+  let quoted = false;
+  for (let index = 0; index < content.length; index += 1) {
+    const char = content[index];
+    const next = content[index + 1];
+    if (quoted && char === '"' && next === '"') {
+      current += '"';
+      index += 1;
+    } else if (char === '"') {
+      quoted = !quoted;
+    } else if (!quoted && char === ",") {
+      row.push(current);
+      current = "";
+    } else if (!quoted && (char === "\n" || char === "\r")) {
+      if (char === "\r" && next === "\n") index += 1;
+      row.push(current);
+      records.push(row);
+      row = [];
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  if (current.length > 0 || row.length > 0) {
+    row.push(current);
+    records.push(row);
+  }
+  return records;
+}
+
+function getScopedPackageOwner(packageName: string) {
+  const match = packageName.trim().match(/^@([^/]+)\//);
+  return match ? normalizeHandleOrFail(match[1] ?? "", "package scope") : undefined;
+}
+
+function assertSafeScopedPackageTransfer(
+  row: ScopedPackageRepairRow,
+  result: ApiV1PackageRepairNameResponse,
+) {
+  const operations = result.operations ?? [];
+  const operation = operations[0];
+  if (
+    !result.dryRun ||
+    result.retiredName ||
+    operations.length !== 1 ||
+    operation?.action !== "transfer-owner" ||
+    operation.owner !== row.intendedOrg ||
+    result.source.name !== row.packageName ||
+    result.target?.packageId !== result.source.packageId
+  ) {
+    throw new Error(`Unsafe transfer plan for ${row.packageName}`);
   }
 }

--- a/packages/clawhub/src/schema/schemas.ts
+++ b/packages/clawhub/src/schema/schemas.ts
@@ -180,6 +180,20 @@ export const ApiV1PublisherEnsureResponseSchema = type({
 });
 export type ApiV1PublisherEnsureResponse = (typeof ApiV1PublisherEnsureResponseSchema)[inferred];
 
+export const ApiV1PublisherRemoveMemberResponseSchema = type({
+  ok: "true",
+  publisherId: "string",
+  handle: "string",
+  removed: "boolean",
+  member: type({
+    userId: "string",
+    handle: "string",
+    role: '"owner"|"admin"|"publisher"',
+  }),
+});
+export type ApiV1PublisherRemoveMemberResponse =
+  (typeof ApiV1PublisherRemoveMemberResponseSchema)[inferred];
+
 export const ApiV1SearchResponseSchema = type({
   results: type({
     slug: "string?",


### PR DESCRIPTION
## Summary
- add a staff-only API path for removing a member from an org publisher
- add `clawhub-mod org remove-member <org> <member>` with JSON output support
- preserve org safety by rejecting removal of the last owner

## Tests
- `bun test packages/clawhub-mod/src/commands/orgs.test.ts`
- `bun test convex/publishers.test.ts -t "remove one org owner|last org owner"`
- `bunx vitest run convex/httpApiV1.handlers.test.ts -t "users/publisher"`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub-mod/tsconfig.json --noEmit`
- `git diff --check`

## Review
- Ran `.agents/skills/autoreview/scripts/autoreview --mode local` with `AUTOREVIEW_AUTO_TESTS=0`; it reran the focused CLI and Convex tests, then the nested review process stalled after inspection, so I stopped it rather than leaving it running.
