### PR TITLE
ci: fan out skill card worker

### DIFF
--- a/.github/workflows/skill-card-worker.yml
+++ b/.github/workflows/skill-card-worker.yml
@@ -7,38 +7,41 @@ on:
   workflow_dispatch:
     inputs:
       batch-limit:
-        description: "Maximum Skill Card jobs to run in parallel per batch"
+        description: "Maximum Skill Card jobs to run in parallel per worker shard"
         required: true
-        default: "5"
+        default: "6"
       max-jobs:
-        description: "Optional total jobs cap for this run"
+        description: "Optional total jobs cap per worker shard"
         required: false
         default: ""
       max-runtime-minutes:
         description: "Stop claiming new batches after this many minutes"
         required: true
-        default: "30"
-
-concurrency:
-  group: skill-card-worker
-  cancel-in-progress: false
+        default: "40"
 
 permissions:
   contents: read
 
 jobs:
   skill-card-worker:
+    name: Skill Card worker shard ${{ matrix.shard }}
     runs-on: blacksmith-8vcpu-ubuntu-2404
-    timeout-minutes: 45
+    timeout-minutes: 60
     environment: Production
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
     env:
       CONVEX_URL: ${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}
       # Shared Convex worker credential used by security and Skill Card workers.
       SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}
-      SKILL_CARD_WORKER_LIMIT: ${{ github.event.inputs['batch-limit'] || '5' }}
+      SKILL_CARD_WORKER_LIMIT: ${{ github.event.inputs['batch-limit'] || '6' }}
       SKILL_CARD_WORKER_MAX_JOBS: ${{ github.event.inputs['max-jobs'] || '' }}
-      SKILL_CARD_WORKER_MAX_RUNTIME_MINUTES: ${{ github.event.inputs['max-runtime-minutes'] || '30' }}
-      SKILL_CARD_WORKER_LEASE_MINUTES: "30"
+      SKILL_CARD_WORKER_MAX_RUNTIME_MINUTES: ${{ github.event.inputs['max-runtime-minutes'] || '40' }}
+      SKILL_CARD_WORKER_LEASE_MINUTES: "60"
+      SKILL_CARD_WORKER_SHARD: ${{ matrix.shard }}
+      SKILL_CARD_WORKER_ID: "github-actions:${{ github.run_id }}:${{ github.run_attempt }}:${{ matrix.shard }}"
       NVIDIA_TRUSTWORTHY_AI_DIR: ${{ github.workspace }}/.artifacts/nvidia-trustworthy-ai
     steps:
       - uses: actions/checkout@v6

--- a/convex/skillCards.test.ts
+++ b/convex/skillCards.test.ts
@@ -514,6 +514,135 @@ describe("skillCards queue", () => {
     );
   });
 
+  it("caps global running Skill Card claims at security-worker parity", async () => {
+    const now = Date.now();
+    const queuedJobs = Array.from({ length: 80 }, (_, index) => ({
+      _id: `skillCardGenerationJobs:${index}`,
+      skillId: `skills:${index}`,
+      skillVersionId: `skillVersions:${index}`,
+      status: "queued",
+      source: "scan",
+      priority: 0,
+      nextRunAt: now - index - 1,
+      attempts: 0,
+      createdAt: now - index - 1,
+      updatedAt: now - index - 1,
+    }));
+    const patch = vi.fn(async () => undefined);
+    const ctx = {
+      db: completeDb({
+        patch,
+        query: vi.fn(() => ({
+          withIndex: vi.fn(
+            (
+              name: string,
+              build: (q: {
+                eq: (...args: unknown[]) => unknown;
+                lte: (...args: unknown[]) => unknown;
+              }) => unknown,
+            ) => {
+              const q = {
+                eq: vi.fn(function (this: unknown) {
+                  return this;
+                }),
+                lte: vi.fn(function (this: unknown) {
+                  return this;
+                }),
+              };
+              build(q);
+              if (name === "by_status_and_lease_expires_at") {
+                return { take: vi.fn(async () => []) };
+              }
+              return {
+                order: vi.fn(() => ({
+                  take: vi.fn(async () => queuedJobs),
+                })),
+              };
+            },
+          ),
+        })),
+      }),
+    };
+
+    const claimed = await claimQueuedHandler(ctx, {
+      workerId: "worker",
+      limit: 80,
+      leaseMs: 60_000,
+    });
+
+    expect(claimed).toHaveLength(64);
+    expect(patch).toHaveBeenCalledTimes(64);
+  });
+
+  it("uses the same default queued job lease as the security worker", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-27T12:00:00.000Z"));
+    const now = Date.now();
+    const queuedJob = {
+      _id: "skillCardGenerationJobs:queued",
+      skillId: "skills:1",
+      skillVersionId: "skillVersions:1",
+      status: "queued",
+      source: "scan",
+      priority: 0,
+      nextRunAt: now - 1,
+      attempts: 0,
+      createdAt: now - 1,
+      updatedAt: now - 1,
+    };
+    const patch = vi.fn(async () => undefined);
+    const ctx = {
+      db: completeDb({
+        patch,
+        query: vi.fn(() => ({
+          withIndex: vi.fn(
+            (
+              name: string,
+              build: (q: {
+                eq: (...args: unknown[]) => unknown;
+                lte: (...args: unknown[]) => unknown;
+              }) => unknown,
+            ) => {
+              const q = {
+                eq: vi.fn(function (this: unknown) {
+                  return this;
+                }),
+                lte: vi.fn(function (this: unknown) {
+                  return this;
+                }),
+              };
+              build(q);
+              if (name === "by_status_and_lease_expires_at") {
+                return { take: vi.fn(async () => []) };
+              }
+              return {
+                order: vi.fn(() => ({
+                  take: vi.fn(async () => [queuedJob]),
+                })),
+              };
+            },
+          ),
+        })),
+      }),
+    };
+
+    try {
+      await claimQueuedHandler(ctx, {
+        workerId: "worker",
+        limit: 1,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(patch).toHaveBeenCalledWith(
+      "skillCardGenerationJobs:queued",
+      expect.objectContaining({
+        leaseExpiresAt: now + 60 * 60 * 1000,
+      }),
+    );
+  });
+
   it("generation failure is non-blocking and retryable", async () => {
     const patch = vi.fn(async () => undefined);
     const ctx = {

--- a/convex/skillCards.ts
+++ b/convex/skillCards.ts
@@ -12,8 +12,9 @@ import {
   sourceSkillVersionFiles,
 } from "./lib/skillCards";
 
-const DEFAULT_LEASE_MS = 30 * 60 * 1000;
-const MAX_PARALLEL_SKILL_CARD_JOBS = 10;
+const DEFAULT_LEASE_MS = 60 * 60 * 1000;
+const DEFAULT_SKILL_CARD_CLAIM_LIMIT = 6;
+const MAX_PARALLEL_SKILL_CARD_JOBS = 64;
 const MAX_ATTEMPTS = 3;
 
 const jobSourceValidator = v.union(v.literal("publish"), v.literal("scan"), v.literal("manual"));
@@ -63,7 +64,10 @@ function assertWorkerToken(token: string) {
 }
 
 function normalizeLimit(limit: number | undefined) {
-  return Math.max(1, Math.min(Math.floor(limit ?? 5), 25));
+  return Math.max(
+    1,
+    Math.min(Math.floor(limit ?? DEFAULT_SKILL_CARD_CLAIM_LIMIT), MAX_PARALLEL_SKILL_CARD_JOBS),
+  );
 }
 
 function generatedBundleFingerprints(

--- a/scripts/skill-cards/run-skill-card-worker.test.ts
+++ b/scripts/skill-cards/run-skill-card-worker.test.ts
@@ -7,8 +7,12 @@ import {
   applyServerPublisherToContext,
   assertPublicSkillCardMarkdown,
   buildPrompt,
+  DEFAULT_BATCH_LIMIT,
+  DEFAULT_LEASE_MS,
+  DEFAULT_MAX_RUNTIME_MS,
   neutralTemplatePath,
   prepareNvidiaSkillCardSkill,
+  skillCardWorkerId,
   trustedRendererPath,
 } from "./run-skill-card-worker";
 
@@ -25,6 +29,29 @@ async function tempDir() {
 }
 
 describe("run-skill-card-worker Codex skill setup", () => {
+  it("uses the same batch, runtime, and lease defaults as the security worker", () => {
+    expect(DEFAULT_BATCH_LIMIT).toBe(6);
+    expect(DEFAULT_MAX_RUNTIME_MS).toBe(40 * 60 * 1000);
+    expect(DEFAULT_LEASE_MS).toBe(60 * 60 * 1000);
+  });
+
+  it("builds shard-aware worker ids like the security scan worker", () => {
+    expect(
+      skillCardWorkerId({
+        GITHUB_RUN_ID: "123",
+        GITHUB_RUN_ATTEMPT: "2",
+        SKILL_CARD_WORKER_SHARD: "7",
+      } as NodeJS.ProcessEnv),
+    ).toBe("github-actions:123:2:7");
+    expect(
+      skillCardWorkerId({
+        SKILL_CARD_WORKER_ID: "custom-worker",
+        GITHUB_RUN_ID: "123",
+        SKILL_CARD_WORKER_SHARD: "7",
+      } as NodeJS.ProcessEnv),
+    ).toBe("custom-worker");
+  });
+
   it("wraps NVIDIA's automation folder as a project-local Codex skill", async () => {
     const workspace = await tempDir();
     const toolDir = await tempDir();

--- a/scripts/skill-cards/run-skill-card-worker.ts
+++ b/scripts/skill-cards/run-skill-card-worker.ts
@@ -35,9 +35,9 @@ type CommandResult = {
 
 type JsonRecord = Record<string, unknown>;
 
-const DEFAULT_BATCH_LIMIT = 5;
-const DEFAULT_MAX_RUNTIME_MS = 30 * 60 * 1000;
-const DEFAULT_LEASE_MS = 30 * 60 * 1000;
+export const DEFAULT_BATCH_LIMIT = 6;
+export const DEFAULT_MAX_RUNTIME_MS = 40 * 60 * 1000;
+export const DEFAULT_LEASE_MS = 60 * 60 * 1000;
 const DEFAULT_CODEX_TIMEOUT_MS = 15 * 60 * 1000;
 const root = resolve(new URL("../..", import.meta.url).pathname);
 const NVIDIA_AUTOMATION_DIR = "AI Transparency Card Automation";
@@ -108,6 +108,15 @@ function requireEnv(name: string) {
 function workerToken() {
   // Reuse the existing shared Convex worker credential; do not require a Skill Card-specific token.
   return requireEnv("SECURITY_SCAN_WORKER_TOKEN");
+}
+
+export function skillCardWorkerId(env: NodeJS.ProcessEnv = process.env) {
+  return (
+    env.SKILL_CARD_WORKER_ID ??
+    `github-actions:${env.GITHUB_RUN_ID ?? process.pid}:${env.GITHUB_RUN_ATTEMPT ?? "1"}:${
+      env.SKILL_CARD_WORKER_SHARD ?? env.GITHUB_JOB ?? "0"
+    }`
+  );
 }
 
 function safeOutputPath(workspace: string, artifactPath: string) {
@@ -437,7 +446,7 @@ async function main() {
   if (!convexUrl) throw new Error("CONVEX_URL or VITE_CONVEX_URL is required");
   const token = workerToken();
   const client = new ConvexHttpClient(convexUrl);
-  const workerId = `skill-card:${process.env.GITHUB_RUN_ID ?? process.pid}`;
+  const workerId = skillCardWorkerId();
   const startedAt = Date.now();
   const claimDeadline = startedAt + maxRuntimeMs;
   let totalClaimed = 0;

--- a/scripts/skill-cards/skill-card-worker-workflow.test.ts
+++ b/scripts/skill-cards/skill-card-worker-workflow.test.ts
@@ -11,12 +11,36 @@ describe("skill-card-worker workflow", () => {
       jobs: {
         "skill-card-worker": {
           env?: Record<string, unknown>;
+          "timeout-minutes"?: number;
+          strategy?: { matrix?: { shard?: number[] } };
           steps: Array<{ name?: string; env?: Record<string, unknown> }>;
+        };
+      };
+      concurrency?: unknown;
+      on?: {
+        workflow_dispatch?: {
+          inputs?: Record<string, { default?: string }>;
         };
       };
     };
     const job = workflow.jobs["skill-card-worker"];
 
+    expect(workflow.on?.workflow_dispatch?.inputs?.["batch-limit"]?.default).toBe("6");
+    expect(workflow.on?.workflow_dispatch?.inputs?.["max-runtime-minutes"]?.default).toBe("40");
+    expect(workflow.concurrency).toBeUndefined();
+    expect(job["timeout-minutes"]).toBe(60);
+    expect(job.strategy?.matrix?.shard).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+    expect(job.env?.SKILL_CARD_WORKER_LIMIT).toBe(
+      "${{ github.event.inputs['batch-limit'] || '6' }}",
+    );
+    expect(job.env?.SKILL_CARD_WORKER_MAX_RUNTIME_MINUTES).toBe(
+      "${{ github.event.inputs['max-runtime-minutes'] || '40' }}",
+    );
+    expect(job.env?.SKILL_CARD_WORKER_LEASE_MINUTES).toBe("60");
+    expect(job.env?.SKILL_CARD_WORKER_SHARD).toBe("${{ matrix.shard }}");
+    expect(job.env?.SKILL_CARD_WORKER_ID).toBe(
+      "github-actions:${{ github.run_id }}:${{ github.run_attempt }}:${{ matrix.shard }}",
+    );
     expect(job.env).not.toHaveProperty("OPENAI_API_KEY");
     expect(job.steps.find((step) => step.name === "Authenticate Codex CLI")?.env).toHaveProperty(
       "OPENAI_API_KEY",


### PR DESCRIPTION
## Summary
- fan out the Skill Card worker with the same 8-shard matrix as the security scan worker
- align batch/runtime/lease/timeout defaults with the security worker and remove the single-run concurrency lock
- raise the Skill Card claim cap to 64 and add shard-aware worker IDs plus workflow/worker/Convex tests

## Verification
- `bun run test -- convex/skillCards.test.ts scripts/skill-cards/run-skill-card-worker.test.ts scripts/skill-cards/skill-card-worker-workflow.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --reviewer codex --fallback-reviewer none`
