### PR TITLE
fix: remove global ClawScan claim ceiling

### DIFF
--- a/convex/securityScan.test.ts
+++ b/convex/securityScan.test.ts
@@ -107,6 +107,9 @@ type ScanJob = {
   waitForVtUntil: number;
   nextRunAt: number;
   attempts: number;
+  leaseToken?: string;
+  leaseExpiresAt?: number;
+  workerId?: string;
   createdAt: number;
   updatedAt: number;
 };
@@ -1348,9 +1351,9 @@ describe("securityScan", () => {
     ]);
   });
 
-  it("allows up to 64 active Codex scan claims", async () => {
+  it("caps each Codex scan claim request", async () => {
     const { ctx } = makeClaimCtx(
-      Array.from({ length: 70 }, (_, index) =>
+      Array.from({ length: 600 }, (_, index) =>
         makeScanJob({
           _id: `securityScanJobs:manual-${index}`,
           source: "manual",
@@ -1363,11 +1366,44 @@ describe("securityScan", () => {
 
     const claimed = await claimQueuedJobsInternalHandler(ctx, {
       workerId: "worker-1",
-      limit: 100,
+      limit: 10_000,
       leaseMs: 60_000,
     });
 
-    expect(claimed).toHaveLength(64);
+    expect(claimed).toHaveLength(512);
+  });
+
+  it("claims requested jobs even when many other scans are already active", async () => {
+    const activeJobs = Array.from({ length: 80 }, (_, index) =>
+      makeScanJob({
+        _id: `securityScanJobs:running-${index}`,
+        status: "running",
+        leaseExpiresAt: Date.now() + 60_000,
+        source: "bulk-rescan",
+      }),
+    );
+    const queuedJobs = Array.from({ length: 3 }, (_, index) =>
+      makeScanJob({
+        _id: `securityScanJobs:manual-${index}`,
+        source: "manual",
+        priority: 100,
+        createdAt: index,
+        nextRunAt: index,
+      }),
+    );
+    const { ctx } = makeClaimCtx([...activeJobs, ...queuedJobs]);
+
+    const claimed = await claimQueuedJobsInternalHandler(ctx, {
+      workerId: "worker-1",
+      limit: 3,
+      leaseMs: 60_000,
+    });
+
+    expect(claimed.map((job) => job._id)).toEqual([
+      "securityScanJobs:manual-0",
+      "securityScanJobs:manual-1",
+      "securityScanJobs:manual-2",
+    ]);
   });
 
   it("caps SkillSpector findings before storing completed scan results", async () => {

--- a/convex/securityScan.ts
+++ b/convex/securityScan.ts
@@ -8,10 +8,12 @@ import { normalizePackageName } from "./lib/packageRegistry";
 import { assertCanManageOwnedResource } from "./lib/publishers";
 import { sourceSkillVersionFiles } from "./lib/skillCards";
 
-const MAX_PARALLEL_CODEX_SCANS = 64;
 const DEFAULT_VT_WAIT_MS = 10 * 60 * 1000;
 const DEFAULT_LEASE_MS = 60 * 60 * 1000;
 const MAX_ATTEMPTS = 3;
+const DEFAULT_CODEX_SCAN_CLAIM_LIMIT = 64;
+const MAX_CODEX_SCAN_CLAIM_LIMIT = 512;
+const MAX_EXPIRED_CODEX_SCAN_LEASE_REQUEUES = 512;
 const DEFAULT_CANCEL_SCAN_LIMIT = 1000;
 const DEFAULT_CANCEL_DELETE_LIMIT = 500;
 const MAX_CANCEL_SCAN_LIMIT = 5000;
@@ -373,10 +375,10 @@ function hasArtifactBackedLlmAnalysis(analysis: ExistingLlmAnalysis | undefined)
 }
 
 function normalizeLimit(limit: number | undefined) {
-  return Math.max(
-    1,
-    Math.min(Math.floor(limit ?? MAX_PARALLEL_CODEX_SCANS), MAX_PARALLEL_CODEX_SCANS),
-  );
+  const normalized = Number.isFinite(limit)
+    ? Math.floor(limit ?? DEFAULT_CODEX_SCAN_CLAIM_LIMIT)
+    : DEFAULT_CODEX_SCAN_CLAIM_LIMIT;
+  return Math.max(1, Math.min(normalized, MAX_CODEX_SCAN_CLAIM_LIMIT));
 }
 
 function normalizeBulkRescanBatchSize(batchSize: number | undefined) {
@@ -1095,25 +1097,23 @@ export const claimQueuedJobsInternal = internalMutation({
     const limit = normalizeLimit(args.limit);
     const leaseMs = Math.max(60_000, Math.min(args.leaseMs ?? DEFAULT_LEASE_MS, 60 * 60 * 1000));
 
-    const running = await ctx.db
+    const expiredRunning = await ctx.db
       .query("securityScanJobs")
-      .withIndex("by_status_and_lease_expires_at", (q) => q.eq("status", "running"))
-      .take(MAX_PARALLEL_CODEX_SCANS * 4);
-    for (const job of running) {
-      if ((job.leaseExpiresAt ?? 0) <= now) {
-        await ctx.db.patch(job._id, {
-          status: "queued",
-          leaseToken: undefined,
-          leaseExpiresAt: undefined,
-          workerId: undefined,
-          nextRunAt: now,
-          updatedAt: now,
-        });
-      }
+      .withIndex("by_status_and_lease_expires_at", (q) =>
+        q.eq("status", "running").lte("leaseExpiresAt", now),
+      )
+      .take(MAX_EXPIRED_CODEX_SCAN_LEASE_REQUEUES);
+    for (const job of expiredRunning) {
+      await ctx.db.patch(job._id, {
+        status: "queued",
+        leaseToken: undefined,
+        leaseExpiresAt: undefined,
+        workerId: undefined,
+        nextRunAt: now,
+        updatedAt: now,
+      });
     }
-    const activeRunning = running.filter((job) => (job.leaseExpiresAt ?? 0) > now).length;
-    const capacity = Math.max(0, Math.min(limit, MAX_PARALLEL_CODEX_SCANS - activeRunning));
-    if (capacity === 0) return [];
+    const capacity = limit;
 
     const ready: Doc<"securityScanJobs">[] = [];
     const claimedIds = new Set<Id<"securityScanJobs">>();

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -136,6 +136,10 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   hosted LLM call. Publishes enqueue a scan job that waits at most 10 minutes
   for VirusTotal telemetry, then Codex reviews the materialized artifact
   workspace with static and VT signals as context.
+- ClawScan worker concurrency is an operator-controlled compute concern. The
+  backend claim path must cap only a single worker claim size and must not impose
+  a global active-scan ceiling; horizontal capacity is controlled by worker
+  dispatch count, worker batch limit, provider quotas, and cost monitoring.
 - The Skill Card verification envelope exposes ClawScan as the top-level
   `security` verdict for install automation, with deterministic and third-party
   scanner evidence grouped under `security.signals`. Clients should key install


### PR DESCRIPTION
## Summary
- remove the global active ClawScan claim ceiling so Blacksmith worker fan-out can scale horizontally
- keep a per-claim cap of 512 jobs to prevent a single worker from leasing an unbounded batch
- preserve source priority and lease-expiry requeue behavior, and document the concurrency invariant in the security moderation spec

## Tests
- `bunx vitest run convex/securityScan.test.ts`
- `bun run format:check -- convex/securityScan.ts convex/securityScan.test.ts specs/security-moderation.md`
- `bunx tsc --noEmit`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bun run --cwd packages/clawhub-mod typecheck`

Note: skipped autoreview at maintainer request.
