### PR TITLE
feat: add publish flow guidance shortcuts

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -83,6 +83,17 @@ The scope must match the selected publish owner. If your package is named
 This prevents a package from claiming an org namespace that the publisher does
 not control.
 
+### Before Publishing a Plugin
+
+- Pick an owner that matches the package scope.
+- Include `openclaw.plugin.json`. Code plugins also need `package.json` with
+  `openclaw.compat.pluginApi` and `openclaw.build.openclawVersion`.
+- Include source repository and exact commit metadata, or use the CLI from a
+  GitHub-backed checkout so it can detect them.
+- Run `clawhub package publish <source> --dry-run` before creating a release.
+- Expect new releases to stay out of public install surfaces until automated
+  security checks and verification finish.
+
 ## Release Flow
 
 1. The UI, CLI, or GitHub workflow gathers package metadata and files.

--- a/src/__tests__/plugins-publish-route.test.tsx
+++ b/src/__tests__/plugins-publish-route.test.tsx
@@ -133,6 +133,16 @@ describe("plugins publish route", () => {
     expect(Route).toBeTruthy();
   });
 
+  it("links to the plugin publishing guide", () => {
+    renderPublishRoute();
+
+    const guideLink = screen.getByRole("link", { name: /Plugin publishing guide/i });
+    expect(guideLink.getAttribute("href")).toBe(
+      "https://docs.openclaw.ai/clawhub/publishing#plugins",
+    );
+    expect(guideLink.getAttribute("target")).toBe("_blank");
+  });
+
   it("requires sign-in before showing the plugin publish form", () => {
     useAuthStatusMock.mockReturnValue({
       isAuthenticated: false,

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -1299,7 +1299,7 @@ describe("SkillDetailPage", () => {
     render(<SkillDetailPage slug="weather" mode="settings" />);
 
     expect(await screen.findByRole("heading", { name: /Skill settings/i })).toBeTruthy();
-    const newVersionLink = screen.getByRole("link", { name: /New version/i });
+    const newVersionLink = screen.getByRole("link", { name: /Update skill files/i });
     expect(newVersionLink.getAttribute("href")).toBe(
       "/skills/publish?updateSlug=weather&ownerHandle=steipete",
     );
@@ -1351,7 +1351,7 @@ describe("SkillDetailPage", () => {
 
     render(<SkillDetailPage slug="weather" mode="settings" />);
     expect(await screen.findByRole("heading", { name: /Settings unavailable/i })).toBeTruthy();
-    expect(screen.queryByRole("link", { name: /New version/i })).toBeNull();
+    expect(screen.queryByRole("link", { name: /Update skill files/i })).toBeNull();
   });
 
   it("does not render version tag cards on the simplified public detail surface", async () => {

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -1299,8 +1299,10 @@ describe("SkillDetailPage", () => {
     render(<SkillDetailPage slug="weather" mode="settings" />);
 
     expect(await screen.findByRole("heading", { name: /Skill settings/i })).toBeTruthy();
-    expect(screen.queryByText("Publish a new version")).toBeNull();
-    expect(screen.queryByRole("link", { name: "New Version" })).toBeNull();
+    const newVersionLink = screen.getByRole("link", { name: /New version/i });
+    expect(newVersionLink.getAttribute("href")).toBe(
+      "/skills/publish?updateSlug=weather&ownerHandle=steipete",
+    );
     expect(screen.getByText("Rename slug")).toBeTruthy();
     expect(screen.getByText("Merge listing")).toBeTruthy();
   });
@@ -1349,6 +1351,7 @@ describe("SkillDetailPage", () => {
 
     render(<SkillDetailPage slug="weather" mode="settings" />);
     expect(await screen.findByRole("heading", { name: /Settings unavailable/i })).toBeTruthy();
+    expect(screen.queryByRole("link", { name: /New version/i })).toBeNull();
   });
 
   it("does not render version tag cards on the simplified public detail surface", async () => {

--- a/src/__tests__/skills-publish-route.test.tsx
+++ b/src/__tests__/skills-publish-route.test.tsx
@@ -20,6 +20,7 @@ const generateChangelogPreview = vi.fn();
 const fetchMock = vi.fn();
 const useQueryMock = vi.fn();
 const useAuthStatusMock = vi.fn();
+const getSiteModeMock = vi.fn();
 // Allows individual test cases to drive the value `useSearch` returns.
 // The `updateSlug` search param triggers the form's "update existing"
 // branch and is required by the F1 regression cases below.
@@ -40,6 +41,10 @@ vi.mock("../lib/useAuthStatus", () => ({
   useAuthStatus: () => useAuthStatusMock(),
 }));
 
+vi.mock("../lib/site", () => ({
+  getSiteMode: () => getSiteModeMock(),
+}));
+
 describe("Upload route", () => {
   beforeEach(() => {
     generateUploadUrl.mockReset();
@@ -48,6 +53,8 @@ describe("Upload route", () => {
     fetchMock.mockReset();
     useQueryMock.mockReset();
     useAuthStatusMock.mockReset();
+    getSiteModeMock.mockReset();
+    getSiteModeMock.mockReturnValue("skills");
     useSearchMock.mockReset();
     useSearchMock.mockReturnValue({ updateSlug: undefined, ownerHandle: undefined });
     useActionCallCount = 0;
@@ -89,6 +96,17 @@ describe("Upload route", () => {
 
     const guideLink = screen.getByRole("link", { name: /Skill publishing guide/i });
     expect(guideLink.getAttribute("href")).toBe("https://docs.openclaw.ai/clawhub/skill-format");
+    expect(guideLink.getAttribute("target")).toBe("_blank");
+  });
+
+  it("links to the soul publishing guide in SoulHub mode", () => {
+    getSiteModeMock.mockReturnValue("souls");
+    render(<Upload />);
+
+    expect(screen.getByRole("heading", { name: /Publish a soul/i })).toBeTruthy();
+    expect(screen.getByText("Drop or select a soul folder")).toBeTruthy();
+    const guideLink = screen.getByRole("link", { name: /Soul publishing guide/i });
+    expect(guideLink.getAttribute("href")).toBe("https://docs.openclaw.ai/clawhub/soul-format");
     expect(guideLink.getAttribute("target")).toBe("_blank");
   });
 

--- a/src/__tests__/skills-publish-route.test.tsx
+++ b/src/__tests__/skills-publish-route.test.tsx
@@ -84,6 +84,14 @@ describe("Upload route", () => {
     vi.unstubAllGlobals();
   });
 
+  it("links to the skill publishing guide", () => {
+    render(<Upload />);
+
+    const guideLink = screen.getByRole("link", { name: /Skill publishing guide/i });
+    expect(guideLink.getAttribute("href")).toBe("https://docs.openclaw.ai/clawhub/skill-format");
+    expect(guideLink.getAttribute("target")).toBe("_blank");
+  });
+
   it("keeps required validation quiet before submit", async () => {
     render(<Upload />);
     const publishButton = screen.getByRole("button", { name: /publish/i });

--- a/src/components/PublisherNoteSettingsEditor.tsx
+++ b/src/components/PublisherNoteSettingsEditor.tsx
@@ -45,21 +45,21 @@ export function PublisherNoteSettingsEditor({
         onChange={(event) => setValue(event.target.value)}
         placeholder="Optional context for ClawScan, e.g. why this version needs network access."
       />
-      <div className="publisher-note-settings-meta">
-        <span>
+      <div className="publisher-note-settings-footer">
+        <span className="publisher-note-settings-meta">
           {trimmedLength}/{MAX_CLAWSCAN_NOTE_CHARS}
         </span>
+        <Button
+          type="button"
+          variant="outline"
+          loading={isSaving}
+          disabled={Boolean(disabledReason)}
+          title={disabledReason ?? undefined}
+          onClick={() => void handleSave()}
+        >
+          {isSaving ? "Rescanning" : "Save & Rescan"}
+        </Button>
       </div>
-      <Button
-        type="button"
-        variant="outline"
-        loading={isSaving}
-        disabled={Boolean(disabledReason)}
-        title={disabledReason ?? undefined}
-        onClick={() => void handleSave()}
-      >
-        {isSaving ? "Rescanning" : "Save & Rescan"}
-      </Button>
       {error ? <p className="publisher-note-settings-error">{error}</p> : null}
     </div>
   );

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -2,7 +2,7 @@ import { useAuthActions } from "@convex-dev/auth/react";
 import { useNavigate, useRouter } from "@tanstack/react-router";
 import type { ClawdisSkillMetadata } from "clawhub-schema";
 import { useAction, useMutation, useQuery } from "convex/react";
-import { ArrowLeft, TriangleAlert } from "lucide-react";
+import { ArrowLeft, TriangleAlert, Upload } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { api } from "../../convex/_generated/api";
@@ -35,6 +35,7 @@ import { SkillOwnershipPanel } from "./SkillOwnershipPanel";
 import { SkillRelatedSection, type RelatedSkillEntry } from "./SkillRelatedSection";
 import { SkillReportDialog } from "./SkillReportDialog";
 import { Alert, AlertDescription } from "./ui/alert";
+import { Button } from "./ui/button";
 import { Card } from "./ui/card";
 
 type SkillDetailPageProps = {
@@ -702,9 +703,23 @@ export function SkillDetailPage({
               <ArrowLeft size={16} aria-hidden="true" />
               Back to {skill.displayName}
             </a>
-            <div>
+            <div className="skill-settings-page-title-row">
               <h1 className="skill-settings-page-title">Skill settings</h1>
+              {newVersionHref ? (
+                <Button
+                  asChild
+                  variant="outline"
+                  size="sm"
+                  className="skill-settings-new-version-button"
+                >
+                  <a href={newVersionHref}>
+                    <Upload size={14} aria-hidden="true" />
+                    New version
+                  </a>
+                </Button>
+              ) : null}
             </div>
+            <hr className="skill-settings-page-divider" />
           </div>
           <DetailBody>
             {settingsPanel ? (

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -706,15 +706,10 @@ export function SkillDetailPage({
             <div className="skill-settings-page-title-row">
               <h1 className="skill-settings-page-title">Skill settings</h1>
               {newVersionHref ? (
-                <Button
-                  asChild
-                  variant="outline"
-                  size="sm"
-                  className="skill-settings-new-version-button"
-                >
+                <Button asChild variant="outline" className="skill-settings-new-version-button">
                   <a href={newVersionHref}>
                     <Upload size={14} aria-hidden="true" />
-                    New version
+                    Update skill files
                   </a>
                 </Button>
               ) : null}

--- a/src/components/SkillOwnershipPanel.tsx
+++ b/src/components/SkillOwnershipPanel.tsx
@@ -80,12 +80,17 @@ function SummarySettingsEditor({
         onChange={(event) => setValue(event.target.value)}
         placeholder="Enter a brief description..."
       />
-      <div className="publisher-note-settings-meta">
-        <span>{value.trim().length}/500</span>
+      <div className="publisher-note-settings-footer">
+        <span className="publisher-note-settings-meta">{value.trim().length}/500</span>
+        <Button
+          type="button"
+          variant="outline"
+          loading={isSaving}
+          onClick={() => void handleSave()}
+        >
+          {isSaving ? "Saving" : "Save"}
+        </Button>
       </div>
-      <Button type="button" variant="outline" loading={isSaving} onClick={() => void handleSave()}>
-        {isSaving ? "Saving" : "Save"}
-      </Button>
       {error ? <p className="publisher-note-settings-error">{error}</p> : null}
     </div>
   );
@@ -184,7 +189,7 @@ export function SkillOwnershipPanel({
 
         <SettingsActionRow
           title="Publisher note"
-          description="Optional context ClawScan can use when reviewing the latest release."
+          description="Help ClawScan understand unusual access or behavior."
         >
           {onSavePublisherNoteAndRescan ? (
             <PublisherNoteSettingsEditor

--- a/src/routes/plugins/publish.tsx
+++ b/src/routes/plugins/publish.tsx
@@ -265,7 +265,7 @@ export function PublishPluginRoute() {
               {search.name ? "Publish Plugin Release" : "Publish Plugin"}
             </h1>
             <p className="text-sm text-[color:var(--ink-soft)]">
-              Upload a plugin folder, zip, or tgz.
+              Drop or select a plugin folder, .zip, or .tgz
             </p>
             {search.name ? (
               <p className="text-sm text-[color:var(--ink-soft)]">

--- a/src/routes/plugins/publish.tsx
+++ b/src/routes/plugins/publish.tsx
@@ -6,7 +6,7 @@ import {
   normalizeClawScanNote,
 } from "clawhub-schema";
 import { useAction, useMutation, useQuery } from "convex/react";
-import { Info, Lock } from "lucide-react";
+import { ExternalLink, Info, Lock } from "lucide-react";
 import { type ReactNode, startTransition, useEffect, useMemo, useRef, useState } from "react";
 import semver from "semver";
 import { toast } from "sonner";
@@ -61,6 +61,8 @@ const apiRefs = api as unknown as {
 };
 
 const SHOW_CLAWPACK_ONBOARDING_BANNER = false;
+const PLUGIN_PUBLISHING_GUIDE_URL = "https://docs.openclaw.ai/clawhub/publishing#plugins";
+
 export function PublishPluginRoute() {
   const search = useSearch({ from: "/plugins/publish" });
   const { isAuthenticated, isLoading: isAuthLoading } = useAuthStatus();
@@ -257,21 +259,29 @@ export function PublishPluginRoute() {
   return (
     <main className="py-10">
       <Container size="narrow">
-        <header className="mb-6">
-          <h1 className="mb-2 font-display text-2xl font-bold text-[color:var(--ink)]">
-            {search.name ? "Publish Plugin Release" : "Publish Plugin"}
-          </h1>
-          <p className="text-sm text-[color:var(--ink-soft)]">
-            Upload a plugin folder, zip, or tgz.
-          </p>
-          {search.name ? (
+        <header className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="mb-2 font-display text-2xl font-bold text-[color:var(--ink)]">
+              {search.name ? "Publish Plugin Release" : "Publish Plugin"}
+            </h1>
             <p className="text-sm text-[color:var(--ink-soft)]">
-              Prefilled for {search.displayName ?? search.name}
-              {search.nextVersion && semver.valid(search.nextVersion)
-                ? ` \u00b7 suggested ${search.nextVersion}`
-                : ""}
+              Upload a plugin folder, zip, or tgz.
             </p>
-          ) : null}
+            {search.name ? (
+              <p className="text-sm text-[color:var(--ink-soft)]">
+                Prefilled for {search.displayName ?? search.name}
+                {search.nextVersion && semver.valid(search.nextVersion)
+                  ? ` \u00b7 suggested ${search.nextVersion}`
+                  : ""}
+              </p>
+            ) : null}
+          </div>
+          <Button asChild variant="outline" size="sm" className="w-fit">
+            <a href={PLUGIN_PUBLISHING_GUIDE_URL} target="_blank" rel="noreferrer">
+              Plugin publishing guide
+              <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+            </a>
+          </Button>
         </header>
 
         {SHOW_CLAWPACK_ONBOARDING_BANNER ? (

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -55,6 +55,7 @@ import {
 
 const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const SKILL_PUBLISHING_GUIDE_URL = "https://docs.openclaw.ai/clawhub/skill-format";
+const SOUL_PUBLISHING_GUIDE_URL = "https://docs.openclaw.ai/clawhub/soul-format";
 
 type SkillPublishField = "slug" | "displayName" | "version" | "tags" | "clawScanNote" | "license";
 
@@ -73,6 +74,8 @@ export function Upload() {
   const isSoulMode = siteMode === "souls";
   const requiredFileLabel = isSoulMode ? "SOUL.md" : "SKILL.md";
   const contentLabel = isSoulMode ? "soul" : "skill";
+  const publishingGuideUrl = isSoulMode ? SOUL_PUBLISHING_GUIDE_URL : SKILL_PUBLISHING_GUIDE_URL;
+  const publishingGuideLabel = isSoulMode ? "Soul publishing guide" : "Skill publishing guide";
   const showChangelogField = Boolean(updateSlug);
 
   const generateUploadUrl = useMutation(api.uploads.generateUploadUrl);
@@ -778,8 +781,8 @@ export function Upload() {
             </p>
           </div>
           <Button asChild variant="outline" size="sm" className="w-fit">
-            <a href={SKILL_PUBLISHING_GUIDE_URL} target="_blank" rel="noreferrer">
-              Skill publishing guide
+            <a href={publishingGuideUrl} target="_blank" rel="noreferrer">
+              {publishingGuideLabel}
               <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
             </a>
           </Button>

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -54,6 +54,7 @@ import {
 } from "../upload/-utils";
 
 const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const SKILL_PUBLISHING_GUIDE_URL = "https://docs.openclaw.ai/clawhub/skill-format";
 
 type SkillPublishField = "slug" | "displayName" | "version" | "tags" | "clawScanNote" | "license";
 
@@ -767,7 +768,7 @@ export function Upload() {
   return (
     <main className="py-10">
       <Container size="narrow">
-        <header className="flex flex-col gap-2 mb-6">
+        <header className="flex flex-col gap-3 mb-6 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h1 className="font-display text-2xl font-bold text-[color:var(--ink)]">
               Publish a {contentLabel}
@@ -776,6 +777,12 @@ export function Upload() {
               Drop a folder with {requiredFileLabel} and text files. We will handle the rest.
             </p>
           </div>
+          <Button asChild variant="outline" size="sm" className="w-fit">
+            <a href={SKILL_PUBLISHING_GUIDE_URL} target="_blank" rel="noreferrer">
+              Skill publishing guide
+              <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+            </a>
+          </Button>
         </header>
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-6">

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -774,7 +774,7 @@ export function Upload() {
               Publish a {contentLabel}
             </h1>
             <p className="text-sm text-[color:var(--ink-soft)]">
-              Drop a folder with {requiredFileLabel} and text files. We will handle the rest.
+              Drop or select a {contentLabel} folder
             </p>
           </div>
           <Button asChild variant="outline" size="sm" className="w-fit">

--- a/src/styles.css
+++ b/src/styles.css
@@ -4047,7 +4047,7 @@ code {
   grid-template-columns: minmax(0, 1fr) minmax(320px, 50%);
   gap: clamp(32px, 5vw, 96px);
   align-items: start;
-  padding: 24px 0;
+  padding: 34px 0;
   border-bottom: 1px solid var(--line);
 }
 
@@ -4099,7 +4099,7 @@ code {
 
 .publisher-note-settings-editor {
   display: grid;
-  gap: 10px;
+  gap: 8px;
   min-width: 0;
   justify-self: end;
   width: 100%;
@@ -4109,17 +4109,17 @@ code {
   min-height: 96px;
 }
 
-.publisher-note-settings-meta {
+.publisher-note-settings-footer {
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.publisher-note-settings-meta {
   color: var(--ink-muted);
   font-size: 0.78rem;
   line-height: 1.3;
-}
-
-.publisher-note-settings-editor > [data-slot="button"] {
-  justify-self: end;
-  margin-left: auto;
 }
 
 .publisher-note-settings-error {
@@ -4156,6 +4156,11 @@ code {
   .publisher-note-settings-editor {
     justify-self: stretch;
     width: 100%;
+  }
+
+  .publisher-note-settings-footer {
+    align-items: flex-start;
+    flex-direction: column;
   }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -3740,6 +3740,25 @@ code {
   line-height: 1.05;
 }
 
+.skill-settings-page-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.skill-settings-new-version-button {
+  width: fit-content;
+}
+
+.skill-settings-page-divider {
+  width: 100%;
+  margin: 0;
+  border: 0;
+  border-top: 1px solid var(--line);
+}
+
 .skill-hero {
   display: grid;
   gap: 16px;


### PR DESCRIPTION
## Summary

- Add compact publishing-guide links to the skill/soul and plugin publish headers.
- Add an `Update skill files` action directly to skill settings so owners can start the new-version flow from the management surface.
- Tighten skill settings layout: clearer section separation, aligned field footers, and shorter publisher-note copy.
- Add a short plugin pre-publish checklist to the docs page linked from the plugin publish flow.

## Major decisions

- Keep guide links secondary and out of the main upload flow; they are there for users who need format/review guidance without turning the form into docs.
- Route the shared skill/soul publish header to the right guide for the active site mode.
- Treat skill settings as a management surface: update publishing should be reachable there, not only from the public skill page.
- Keep settings rows flat and scannable, with counters and save actions grouped as part of the field they affect.
- Preserve existing publish contracts, permissions, upload behavior, and release semantics.

## Guide links

- Skill publishing guide: https://docs.openclaw.ai/clawhub/skill-format
- Soul publishing guide: https://docs.openclaw.ai/clawhub/soul-format
- Plugin publishing guide: https://docs.openclaw.ai/clawhub/publishing#plugins

## Screenshots

| Element | Screenshot |
| --- | --- |
| Skill publish header guide link and simplified subtitle | ![Skill publish header guide link](https://ebony-cottage-kjhs.here.now/droppie-2026-05-27T22-50-17Z.png) |
| Plugin publish header guide link and simplified subtitle | ![Plugin publish header guide link](https://poppy-fennel-cawa.here.now/droppie-2026-05-27T22-50-24Z.png) |
| Skill settings header with update action | ![Skill settings update action](https://wander-nirvana-z78w.here.now/droppie-2026-05-27T22-50-46Z.png) |
| Skill settings field/footer layout polish | ![Skill settings layout polish](https://mystic-meadow-kwj9.here.now/droppie-2026-05-27T22-52-25Z.png) |

## Validation

- `bun run format:check -- src/routes/skills/publish.tsx src/routes/plugins/publish.tsx src/components/SkillDetailPage.tsx src/components/SkillOwnershipPanel.tsx src/components/PublisherNoteSettingsEditor.tsx src/styles.css src/__tests__/skill-detail-page.test.tsx docs/publishing.md src/__tests__/skills-publish-route.test.tsx src/__tests__/plugins-publish-route.test.tsx`
- `bun run lint -- src/routes/skills/publish.tsx src/routes/plugins/publish.tsx src/components/SkillDetailPage.tsx src/components/SkillOwnershipPanel.tsx src/components/PublisherNoteSettingsEditor.tsx src/styles.css src/__tests__/skill-detail-page.test.tsx src/__tests__/skills-publish-route.test.tsx src/__tests__/plugins-publish-route.test.tsx`
- `bunx vitest run src/__tests__/skill-detail-page.test.tsx src/__tests__/skills-publish-route.test.tsx src/__tests__/plugins-publish-route.test.tsx` — 57 tests passed
- `codex review --base upstream/main` — found the shared skill/soul guide-link issue; fixed in `5f686fa7` with coverage. Final rerun was interrupted locally by Codex usage limits after the fix.
