### PR TITLE
Export SkillSpector signals in security dataset

### DIFF
--- a/convex/securityDataset.ts
+++ b/convex/securityDataset.ts
@@ -4,13 +4,21 @@ import { internal } from "./_generated/api";
 import type { Doc } from "./_generated/dataModel";
 import type { ActionCtx, QueryCtx } from "./_generated/server";
 import { internalAction, internalQuery } from "./functions";
+import { getOwnerPublisher } from "./lib/publishers";
 
 const MAX_EXPORT_PAGE_SIZE = 50;
 const MAX_EXPORT_BATCH_PAGES = 20;
 const REDACTION_POLICY_VERSION = "public-signals-v1";
 const SOURCE_TABLES = ["skillVersions", "packageReleases"] as const;
-const SCANNER_SOURCES = ["static", "virustotal", "llm", "moderation_consensus"] as const;
+const SCANNER_SOURCES = [
+  "static",
+  "virustotal",
+  "skillspector",
+  "llm",
+  "moderation_consensus",
+] as const;
 type StoredVtAnalysis = Doc<"skillVersions">["vtAnalysis"];
+type StoredSkillSpectorAnalysis = Doc<"skillVersions">["skillSpectorAnalysis"];
 type StoredLlmAnalysis = Doc<"skillVersions">["llmAnalysis"];
 type ArtifactExportRow =
   | Awaited<ReturnType<typeof skillVersionPageToExportRows>>[number]
@@ -205,11 +213,13 @@ async function skillVersionPageToExportRows(ctx: QueryCtx, versions: Array<Doc<"
   for (const version of versions) {
     const skill = await ctx.db.get(version.skillId);
     if (!skill || skill.softDeletedAt) continue;
+    const publicOwnerHandle = await getPublicOwnerHandle(ctx, skill);
     rows.push({
       sourceKind: "skill" as const,
       sourceDocId: version._id,
       parentDocId: skill._id,
       publicName: skill.displayName,
+      publicOwnerHandle,
       publicSlug: skill.slug,
       version: version.version,
       artifactSha256: version.sha256hash ?? null,
@@ -222,6 +232,7 @@ async function skillVersionPageToExportRows(ctx: QueryCtx, versions: Array<Doc<"
       packageExecutesCode: null,
       sourceRepoHost: null,
       vtAnalysis: normalizeVtAnalysis(version.vtAnalysis),
+      skillSpectorAnalysis: normalizeSkillSpectorAnalysis(version.skillSpectorAnalysis),
       staticScan: version.staticScan ?? null,
       llmAnalysis: normalizeLlmAnalysis(version.llmAnalysis),
       moderationConsensus:
@@ -247,11 +258,13 @@ async function packageReleasePageToExportRows(
   for (const release of releases) {
     const pkg = await ctx.db.get(release.packageId);
     if (!pkg || pkg.softDeletedAt || pkg.channel === "private") continue;
+    const publicOwnerHandle = await getPublicOwnerHandle(ctx, pkg);
     rows.push({
       sourceKind: "package" as const,
       sourceDocId: release._id,
       parentDocId: pkg._id,
       publicName: pkg.displayName,
+      publicOwnerHandle,
       publicSlug: pkg.name,
       version: release.version,
       artifactSha256: release.sha256hash ?? release.integritySha256,
@@ -264,6 +277,7 @@ async function packageReleasePageToExportRows(
       packageExecutesCode: pkg.executesCode ?? null,
       sourceRepoHost: sourceRepoHost(pkg.sourceRepo),
       vtAnalysis: normalizeVtAnalysis(release.vtAnalysis),
+      skillSpectorAnalysis: normalizeSkillSpectorAnalysis(release.skillSpectorAnalysis),
       staticScan: release.staticScan ?? null,
       llmAnalysis: normalizeLlmAnalysis(release.llmAnalysis),
       moderationConsensus: null,
@@ -335,6 +349,27 @@ function normalizeVtAnalysis(analysis: StoredVtAnalysis) {
   };
 }
 
+function normalizeSkillSpectorAnalysis(analysis: StoredSkillSpectorAnalysis) {
+  if (!analysis) return null;
+  return {
+    status: analysis.status,
+    score: analysis.score ?? null,
+    severity: analysis.severity ?? null,
+    recommendation: analysis.recommendation ?? null,
+    issueCount: analysis.issueCount,
+    issues: analysis.issues.map((issue) => ({
+      issueId: issue.issueId,
+      severity: issue.severity,
+      confidence: issue.confidence ?? null,
+      explanation: issue.explanation,
+    })),
+    scannerVersion: analysis.scannerVersion ?? null,
+    summary: analysis.summary ?? null,
+    error: analysis.error ?? null,
+    checkedAt: analysis.checkedAt,
+  };
+}
+
 function normalizeLlmAnalysis(analysis: StoredLlmAnalysis) {
   if (!analysis) return null;
   return {
@@ -349,6 +384,17 @@ function normalizeLlmAnalysis(analysis: StoredLlmAnalysis) {
     model: analysis.model ?? null,
     checkedAt: analysis.checkedAt,
   };
+}
+
+async function getPublicOwnerHandle(
+  ctx: QueryCtx,
+  source: Pick<Doc<"skills"> | Doc<"packages">, "ownerPublisherId" | "ownerUserId">,
+) {
+  const owner = await getOwnerPublisher(ctx, {
+    ownerPublisherId: source.ownerPublisherId,
+    ownerUserId: source.ownerUserId,
+  });
+  return owner?.handle ?? null;
 }
 
 function sourceRepoHost(sourceRepo: string | undefined) {

--- a/scripts/security-dataset/convexExport.test.ts
+++ b/scripts/security-dataset/convexExport.test.ts
@@ -17,6 +17,8 @@ describe("Convex export dataset ingestion", () => {
           _id: "skills:1",
           displayName: "Demo Skill",
           slug: "demo-skill",
+          ownerPublisherId: "publishers:openclaw",
+          ownerUserId: "users:owner",
           capabilityTags: ["filesystem"],
           moderationSourceVersionId: "skillVersions:1",
           moderationVerdict: "suspicious",
@@ -91,6 +93,7 @@ describe("Convex export dataset ingestion", () => {
           _id: "packages:public",
           displayName: "Demo Package",
           name: "@demo/pkg",
+          ownerUserId: "users:owner",
           channel: "community",
           family: "code-plugin",
           sourceRepo: "git@github.com:demo/pkg.git",
@@ -101,6 +104,7 @@ describe("Convex export dataset ingestion", () => {
           _id: "packages:private",
           displayName: "Private Package",
           name: "@demo/private",
+          ownerUserId: "users:owner",
           channel: "private",
           family: "code-plugin",
         },
@@ -131,6 +135,8 @@ describe("Convex export dataset ingestion", () => {
           files: [],
         },
       ],
+      users: [{ _id: "users:owner", handle: "alice" }],
+      publishers: [{ _id: "publishers:openclaw", handle: "openclaw" }],
     });
 
     expect(rows).toHaveLength(2);
@@ -139,6 +145,7 @@ describe("Convex export dataset ingestion", () => {
       sourceKind: "package",
       sourceDocId: "packageReleases:1",
       artifactSha256: "pkg-sha",
+      publicOwnerHandle: "alice",
       packageChannel: "community",
       sourceRepoHost: "github.com",
       staticScan: { status: "clean" },
@@ -147,6 +154,8 @@ describe("Convex export dataset ingestion", () => {
       sourceKind: "skill",
       sourceDocId: "skillVersions:1",
       artifactSha256: "skill-sha",
+      publicOwnerHandle: "openclaw",
+      publicSlug: "demo-skill",
       moderationConsensus: {
         verdict: "suspicious",
         reasonCodes: ["network.exfiltration"],
@@ -175,7 +184,12 @@ describe("Convex export dataset ingestion", () => {
   it("reads table JSONL files from a Convex export zip", async () => {
     const zip = zipSync({
       "tables/skills.jsonl": strToU8(
-        `${JSON.stringify({ _id: "skills:1", displayName: "S", slug: "s" })}\n`,
+        `${JSON.stringify({
+          _id: "skills:1",
+          displayName: "S",
+          slug: "s",
+          ownerUserId: "users:owner",
+        })}\n`,
       ),
       "tables/skillVersions.jsonl": strToU8(
         `${JSON.stringify({
@@ -188,6 +202,7 @@ describe("Convex export dataset ingestion", () => {
       ),
       "tables/packages.jsonl": strToU8(""),
       "tables/packageReleases.jsonl": strToU8(""),
+      "tables/users.jsonl": strToU8(`${JSON.stringify({ _id: "users:owner", handle: "owner" })}\n`),
     });
     const directory = await mkdtemp(join(tmpdir(), "clawhub-convex-export-"));
     try {
@@ -195,10 +210,81 @@ describe("Convex export dataset ingestion", () => {
       await writeFile(path, Buffer.from(zip));
 
       await expect(artifactInputsFromConvexExportZip(path)).resolves.toMatchObject([
-        { sourceKind: "skill", sourceDocId: "skillVersions:1" },
+        { sourceKind: "skill", sourceDocId: "skillVersions:1", publicOwnerHandle: "owner" },
       ]);
     } finally {
       await rm(directory, { recursive: true, force: true });
     }
+  });
+
+  it("ignores inactive owner handles from Convex export tables", () => {
+    const rows = artifactInputsFromConvexExportTables({
+      skills: [
+        {
+          _id: "skills:1",
+          displayName: "Demo Skill",
+          slug: "demo-skill",
+          ownerPublisherId: "publishers:inactive",
+          ownerUserId: "users:owner",
+        },
+        {
+          _id: "skills:2",
+          displayName: "Deleted Owner Skill",
+          slug: "deleted-owner-skill",
+          ownerUserId: "users:deleted",
+        },
+        {
+          _id: "skills:3",
+          displayName: "Linked Personal Publisher Skill",
+          slug: "linked-personal-publisher-skill",
+          ownerUserId: "users:linked",
+        },
+      ],
+      skillVersions: [
+        {
+          _id: "skillVersions:1",
+          skillId: "skills:1",
+          version: "1.0.0",
+          createdAt: 1,
+          files: [],
+        },
+        {
+          _id: "skillVersions:2",
+          skillId: "skills:2",
+          version: "1.0.0",
+          createdAt: 2,
+          files: [],
+        },
+        {
+          _id: "skillVersions:3",
+          skillId: "skills:3",
+          version: "1.0.0",
+          createdAt: 3,
+          files: [],
+        },
+      ],
+      packages: [],
+      packageReleases: [],
+      users: [
+        {
+          _id: "users:owner",
+          handle: "fallback-owner",
+          personalPublisherId: "publishers:personal",
+        },
+        { _id: "users:deleted", handle: "deleted-owner", deletedAt: 123 },
+        { _id: "users:linked", handle: "legacy-user" },
+      ],
+      publishers: [
+        { _id: "publishers:inactive", handle: "inactive-org", deactivatedAt: 456 },
+        { _id: "publishers:personal", handle: "personal-owner" },
+        { _id: "publishers:linked", handle: "linked-personal", linkedUserId: "users:linked" },
+      ],
+    });
+
+    expect(rows).toMatchObject([
+      { sourceDocId: "skillVersions:1", publicOwnerHandle: "personal-owner" },
+      { sourceDocId: "skillVersions:2", publicOwnerHandle: null },
+      { sourceDocId: "skillVersions:3", publicOwnerHandle: "linked-personal" },
+    ]);
   });
 });

--- a/scripts/security-dataset/convexExport.ts
+++ b/scripts/security-dataset/convexExport.ts
@@ -19,18 +19,22 @@ type ConvexExportTables = {
   skillVersions: ConvexDoc[];
   packages: ConvexDoc[];
   packageReleases: ConvexDoc[];
+  users?: ConvexDoc[];
+  publishers?: ConvexDoc[];
 };
 
 const REQUIRED_TABLES = ["skills", "skillVersions", "packages", "packageReleases"] as const;
+const OPTIONAL_TABLES = ["users", "publishers"] as const;
 
 export async function artifactInputsFromConvexExportZip(
   zipPath: string,
 ): Promise<ArtifactExportInput[]> {
   const zipBytes = new Uint8Array(await readFile(zipPath));
   const entries = unzipSync(zipBytes);
-  const tables = Object.fromEntries(
-    REQUIRED_TABLES.map((table) => [table, readExportTable(entries, table)]),
-  ) as ConvexExportTables;
+  const tables = Object.fromEntries([
+    ...REQUIRED_TABLES.map((table) => [table, readExportTable(entries, table)] as const),
+    ...OPTIONAL_TABLES.map((table) => [table, readOptionalExportTable(entries, table)] as const),
+  ]) as ConvexExportTables;
   return artifactInputsFromConvexExportTables(tables);
 }
 
@@ -39,10 +43,27 @@ export function artifactInputsFromConvexExportTables(
 ): ArtifactExportInput[] {
   const skillsById = buildIdMap(tables.skills);
   const packagesById = buildIdMap(tables.packages);
+  const usersById = buildIdMap(tables.users ?? []);
+  const publishersById = buildIdMap(tables.publishers ?? []);
+  const publishersByLinkedUserId = buildLinkedUserPublisherMap(tables.publishers ?? []);
   const rows = [
-    ...tables.skillVersions.flatMap((version) => skillVersionToExportRow(version, skillsById)),
+    ...tables.skillVersions.flatMap((version) =>
+      skillVersionToExportRow(
+        version,
+        skillsById,
+        usersById,
+        publishersById,
+        publishersByLinkedUserId,
+      ),
+    ),
     ...tables.packageReleases.flatMap((release) =>
-      packageReleaseToExportRow(release, packagesById),
+      packageReleaseToExportRow(
+        release,
+        packagesById,
+        usersById,
+        publishersById,
+        publishersByLinkedUserId,
+      ),
     ),
   ];
   return rows.sort((left, right) => {
@@ -68,7 +89,30 @@ function readExportTable(
     .map((line) => JSON.parse(line) as ConvexDoc);
 }
 
+function readOptionalExportTable(
+  entries: Record<string, Uint8Array>,
+  table: (typeof OPTIONAL_TABLES)[number],
+): ConvexDoc[] {
+  const entryName = findOptionalExportTableEntry(Object.keys(entries), table);
+  if (!entryName) return [];
+  const bytes = entries[entryName];
+  if (!bytes) throw new Error(`Convex export table entry disappeared: ${entryName}`);
+  const text = strFromU8(bytes);
+  return text
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as ConvexDoc);
+}
+
 function findExportTableEntry(entryNames: string[], table: string) {
+  const entryName = findOptionalExportTableEntry(entryNames, table);
+  if (entryName) return entryName;
+  throw new Error(
+    `Missing ${table} JSONL table in Convex export. Entries: ${entryNamePreview(entryNames)}`,
+  );
+}
+
+function findOptionalExportTableEntry(entryNames: string[], table: string) {
   const normalized = entryNames.map((name) => ({ name, parts: name.split("/") }));
   const exactJsonl = normalized.find(({ name }) => name === `${table}.jsonl`);
   if (exactJsonl) return exactJsonl.name;
@@ -82,9 +126,7 @@ function findExportTableEntry(entryNames: string[], table: string) {
     ({ parts }) => parts.includes(table) && parts.at(-1)?.endsWith(".jsonl"),
   );
   if (tableJsonl) return tableJsonl.name;
-  throw new Error(
-    `Missing ${table} JSONL table in Convex export. Entries: ${entryNamePreview(entryNames)}`,
-  );
+  return null;
 }
 
 function entryNamePreview(entryNames: string[]) {
@@ -102,9 +144,23 @@ function buildIdMap(rows: ConvexDoc[]) {
   return map;
 }
 
+function buildLinkedUserPublisherMap(rows: ConvexDoc[]) {
+  const map = new Map<string, ConvexDoc>();
+  for (const row of rows) {
+    const linkedUserId = stringValue(row.linkedUserId);
+    if (linkedUserId && isActiveExportOwner(row) && !map.has(linkedUserId)) {
+      map.set(linkedUserId, row);
+    }
+  }
+  return map;
+}
+
 function skillVersionToExportRow(
   version: ConvexDoc,
   skillsById: Map<string, ConvexDoc>,
+  usersById: Map<string, ConvexDoc>,
+  publishersById: Map<string, ConvexDoc>,
+  publishersByLinkedUserId: Map<string, ConvexDoc>,
 ): ArtifactExportInput[] {
   if (numberOrNull(version.softDeletedAt) !== null) return [];
   const skill = skillsById.get(stringValue(version.skillId));
@@ -120,6 +176,12 @@ function skillVersionToExportRow(
       sourceDocId: versionId,
       parentDocId: requiredString(skill._id, "skills._id"),
       publicName: requiredString(skill.displayName, "skills.displayName"),
+      publicOwnerHandle: publicOwnerHandleFromExport(
+        skill,
+        usersById,
+        publishersById,
+        publishersByLinkedUserId,
+      ),
       publicSlug: stringOrNull(skill.slug),
       version: requiredString(version.version, "skillVersions.version"),
       artifactSha256: stringOrNull(version.sha256hash),
@@ -144,6 +206,9 @@ function skillVersionToExportRow(
 function packageReleaseToExportRow(
   release: ConvexDoc,
   packagesById: Map<string, ConvexDoc>,
+  usersById: Map<string, ConvexDoc>,
+  publishersById: Map<string, ConvexDoc>,
+  publishersByLinkedUserId: Map<string, ConvexDoc>,
 ): ArtifactExportInput[] {
   if (numberOrNull(release.softDeletedAt) !== null) return [];
   const pkg = packagesById.get(stringValue(release.packageId));
@@ -154,6 +219,12 @@ function packageReleaseToExportRow(
       sourceDocId: requiredString(release._id, "packageReleases._id"),
       parentDocId: requiredString(pkg._id, "packages._id"),
       publicName: requiredString(pkg.displayName, "packages.displayName"),
+      publicOwnerHandle: publicOwnerHandleFromExport(
+        pkg,
+        usersById,
+        publishersById,
+        publishersByLinkedUserId,
+      ),
       publicSlug: stringOrNull(pkg.name),
       version: requiredString(release.version, "packageReleases.version"),
       artifactSha256: stringOrNull(release.sha256hash) ?? stringOrNull(release.integritySha256),
@@ -172,6 +243,40 @@ function packageReleaseToExportRow(
       moderationConsensus: null,
     },
   ];
+}
+
+function publicOwnerHandleFromExport(
+  source: ConvexDoc,
+  usersById: Map<string, ConvexDoc>,
+  publishersById: Map<string, ConvexDoc>,
+  publishersByLinkedUserId: Map<string, ConvexDoc>,
+) {
+  const publisherId = stringValue(source.ownerPublisherId);
+  const publisher = publisherId ? publishersById.get(publisherId) : undefined;
+  const publisherHandle = isActiveExportOwner(publisher) ? stringOrNull(publisher.handle) : null;
+  if (publisherHandle) return publisherHandle;
+
+  const userId = stringValue(source.ownerUserId);
+  const user = userId ? usersById.get(userId) : undefined;
+  if (!isActiveExportOwner(user)) return null;
+
+  const personalPublisherId = stringValue(user.personalPublisherId);
+  const personalPublisher = personalPublisherId
+    ? publishersById.get(personalPublisherId)
+    : undefined;
+  const activePersonalPublisher = isActiveExportOwner(personalPublisher)
+    ? personalPublisher
+    : publishersByLinkedUserId.get(userId);
+  const personalPublisherHandle = isActiveExportOwner(activePersonalPublisher)
+    ? stringOrNull(activePersonalPublisher.handle)
+    : null;
+  return personalPublisherHandle ?? stringOrNull(user.handle);
+}
+
+function isActiveExportOwner(owner: ConvexDoc | undefined): owner is ConvexDoc {
+  return Boolean(
+    owner && numberOrNull(owner.deletedAt) === null && numberOrNull(owner.deactivatedAt) === null,
+  );
 }
 
 function filesFromExport(value: unknown): ExportFileInput[] {

--- a/scripts/security-dataset/normalize.test.ts
+++ b/scripts/security-dataset/normalize.test.ts
@@ -12,6 +12,7 @@ const baseArtifact: ArtifactExportInput = {
   sourceDocId: "skillVersionDoc123",
   parentDocId: "skillDoc123",
   publicName: "Suspicious Demo",
+  publicOwnerHandle: "openclaw",
   publicSlug: "suspicious-demo",
   version: "1.0.0",
   artifactSha256: "a".repeat(64),
@@ -149,7 +150,9 @@ describe("security dataset normalizer", () => {
       artifact_id: `skill:${"a".repeat(64)}`,
       source_kind: "skill",
       source_table: "skillVersions",
+      public_owner_handle: "openclaw",
       public_slug: "suspicious-demo",
+      public_qualified_slug: "openclaw/suspicious-demo",
       skill_md_content_redacted:
         "# Suspicious Demo Use this skill to inspect shell scripts. Contact [REDACTED_SECRET] with [REDACTED_SECRET]",
       created_month: "2026-04",

--- a/scripts/security-dataset/normalize.ts
+++ b/scripts/security-dataset/normalize.ts
@@ -113,6 +113,7 @@ export type ArtifactExportInput = {
   sourceDocId: string;
   parentDocId: string;
   publicName: string;
+  publicOwnerHandle: string | null;
   publicSlug: string | null;
   version: string;
   artifactSha256: string | null;
@@ -139,7 +140,9 @@ export type ArtifactRow = {
   source_doc_id_hash: string;
   parent_doc_id_hash: string;
   public_name: string;
+  public_owner_handle: string | null;
   public_slug: string | null;
+  public_qualified_slug: string | null;
   version: string;
   artifact_sha256: string | null;
   skill_md_content_redacted?: string | null;
@@ -326,7 +329,9 @@ function buildArtifactRow(input: ArtifactExportInput, artifactId: string): Artif
     source_doc_id_hash: hashString(input.sourceDocId),
     parent_doc_id_hash: hashString(input.parentDocId),
     public_name: input.publicName,
+    public_owner_handle: input.publicOwnerHandle,
     public_slug: input.publicSlug,
+    public_qualified_slug: qualifiedPublicSlug(input),
     version: input.version,
     artifact_sha256: input.artifactSha256,
     ...(input.sourceKind === "skill" && input.skillMdContentRedacted
@@ -349,6 +354,12 @@ function buildArtifactRow(input: ArtifactExportInput, artifactId: string): Artif
     has_static_scan: input.staticScan !== null,
     has_llm_scan: input.llmAnalysis !== null,
   };
+}
+
+function qualifiedPublicSlug(input: ArtifactExportInput) {
+  if (input.sourceKind !== "skill") return null;
+  if (!input.publicOwnerHandle || !input.publicSlug) return null;
+  return `${input.publicOwnerHandle}/${input.publicSlug}`;
 }
 
 function buildScanResultRows(input: ArtifactExportInput, artifactId: string): ScanResultRow[] {


### PR DESCRIPTION
## Summary
- include SkillSpector analysis in the Convex security dataset export path
- add public owner handle and owner-qualified skill slug fields to normalized artifacts
- teach Convex export ZIP ingestion to read optional users/publishers tables and resolve active, personal, and linked publisher handles

## Verification
- `bun test scripts/security-dataset/convexExport.test.ts scripts/security-dataset/normalize.test.ts`
- `bunx tsc --noEmit`
- `bun run ci:static`
- `bun run ci:types-build`
- `bun run ci:unit`
- synthetic Convex export ZIP snapshot smoke confirmed `public_qualified_slug=openclaw/smoke-skill` and SkillSpector scanner fields
- `$autoreview` final run: clean, no accepted/actionable findings reported
