### PR TITLE
fix: preserve Codex diagnostic messages

### DIFF
--- a/convex/securityScan.test.ts
+++ b/convex/securityScan.test.ts
@@ -107,6 +107,9 @@ type ScanJob = {
   waitForVtUntil: number;
   nextRunAt: number;
   attempts: number;
+  leaseToken?: string;
+  leaseExpiresAt?: number;
+  workerId?: string;
   createdAt: number;
   updatedAt: number;
 };
@@ -1348,9 +1351,9 @@ describe("securityScan", () => {
     ]);
   });
 
-  it("allows up to 64 active Codex scan claims", async () => {
+  it("caps each Codex scan claim request", async () => {
     const { ctx } = makeClaimCtx(
-      Array.from({ length: 70 }, (_, index) =>
+      Array.from({ length: 600 }, (_, index) =>
         makeScanJob({
           _id: `securityScanJobs:manual-${index}`,
           source: "manual",
@@ -1363,11 +1366,44 @@ describe("securityScan", () => {
 
     const claimed = await claimQueuedJobsInternalHandler(ctx, {
       workerId: "worker-1",
-      limit: 100,
+      limit: 10_000,
       leaseMs: 60_000,
     });
 
-    expect(claimed).toHaveLength(64);
+    expect(claimed).toHaveLength(512);
+  });
+
+  it("claims requested jobs even when many other scans are already active", async () => {
+    const activeJobs = Array.from({ length: 80 }, (_, index) =>
+      makeScanJob({
+        _id: `securityScanJobs:running-${index}`,
+        status: "running",
+        leaseExpiresAt: Date.now() + 60_000,
+        source: "bulk-rescan",
+      }),
+    );
+    const queuedJobs = Array.from({ length: 3 }, (_, index) =>
+      makeScanJob({
+        _id: `securityScanJobs:manual-${index}`,
+        source: "manual",
+        priority: 100,
+        createdAt: index,
+        nextRunAt: index,
+      }),
+    );
+    const { ctx } = makeClaimCtx([...activeJobs, ...queuedJobs]);
+
+    const claimed = await claimQueuedJobsInternalHandler(ctx, {
+      workerId: "worker-1",
+      limit: 3,
+      leaseMs: 60_000,
+    });
+
+    expect(claimed.map((job) => job._id)).toEqual([
+      "securityScanJobs:manual-0",
+      "securityScanJobs:manual-1",
+      "securityScanJobs:manual-2",
+    ]);
   });
 
   it("caps SkillSpector findings before storing completed scan results", async () => {

--- a/convex/securityScan.ts
+++ b/convex/securityScan.ts
@@ -8,10 +8,12 @@ import { normalizePackageName } from "./lib/packageRegistry";
 import { assertCanManageOwnedResource } from "./lib/publishers";
 import { sourceSkillVersionFiles } from "./lib/skillCards";
 
-const MAX_PARALLEL_CODEX_SCANS = 64;
 const DEFAULT_VT_WAIT_MS = 10 * 60 * 1000;
 const DEFAULT_LEASE_MS = 60 * 60 * 1000;
 const MAX_ATTEMPTS = 3;
+const DEFAULT_CODEX_SCAN_CLAIM_LIMIT = 64;
+const MAX_CODEX_SCAN_CLAIM_LIMIT = 512;
+const MAX_EXPIRED_CODEX_SCAN_LEASE_REQUEUES = 512;
 const DEFAULT_CANCEL_SCAN_LIMIT = 1000;
 const DEFAULT_CANCEL_DELETE_LIMIT = 500;
 const MAX_CANCEL_SCAN_LIMIT = 5000;
@@ -373,10 +375,10 @@ function hasArtifactBackedLlmAnalysis(analysis: ExistingLlmAnalysis | undefined)
 }
 
 function normalizeLimit(limit: number | undefined) {
-  return Math.max(
-    1,
-    Math.min(Math.floor(limit ?? MAX_PARALLEL_CODEX_SCANS), MAX_PARALLEL_CODEX_SCANS),
-  );
+  const normalized = Number.isFinite(limit)
+    ? Math.floor(limit ?? DEFAULT_CODEX_SCAN_CLAIM_LIMIT)
+    : DEFAULT_CODEX_SCAN_CLAIM_LIMIT;
+  return Math.max(1, Math.min(normalized, MAX_CODEX_SCAN_CLAIM_LIMIT));
 }
 
 function normalizeBulkRescanBatchSize(batchSize: number | undefined) {
@@ -1095,25 +1097,23 @@ export const claimQueuedJobsInternal = internalMutation({
     const limit = normalizeLimit(args.limit);
     const leaseMs = Math.max(60_000, Math.min(args.leaseMs ?? DEFAULT_LEASE_MS, 60 * 60 * 1000));
 
-    const running = await ctx.db
+    const expiredRunning = await ctx.db
       .query("securityScanJobs")
-      .withIndex("by_status_and_lease_expires_at", (q) => q.eq("status", "running"))
-      .take(MAX_PARALLEL_CODEX_SCANS * 4);
-    for (const job of running) {
-      if ((job.leaseExpiresAt ?? 0) <= now) {
-        await ctx.db.patch(job._id, {
-          status: "queued",
-          leaseToken: undefined,
-          leaseExpiresAt: undefined,
-          workerId: undefined,
-          nextRunAt: now,
-          updatedAt: now,
-        });
-      }
+      .withIndex("by_status_and_lease_expires_at", (q) =>
+        q.eq("status", "running").lte("leaseExpiresAt", now),
+      )
+      .take(MAX_EXPIRED_CODEX_SCAN_LEASE_REQUEUES);
+    for (const job of expiredRunning) {
+      await ctx.db.patch(job._id, {
+        status: "queued",
+        leaseToken: undefined,
+        leaseExpiresAt: undefined,
+        workerId: undefined,
+        nextRunAt: now,
+        updatedAt: now,
+      });
     }
-    const activeRunning = running.filter((job) => (job.leaseExpiresAt ?? 0) > now).length;
-    const capacity = Math.max(0, Math.min(limit, MAX_PARALLEL_CODEX_SCANS - activeRunning));
-    if (capacity === 0) return [];
+    const capacity = limit;
 
     const ready: Doc<"securityScanJobs">[] = [];
     const claimedIds = new Set<Id<"securityScanJobs">>();

--- a/scripts/security/run-codex-scan-worker.test.ts
+++ b/scripts/security/run-codex-scan-worker.test.ts
@@ -253,7 +253,7 @@ describe("run-codex-scan-worker diagnostics", () => {
           '{"verdict":"benign","scan_findings_in_context":[{"ruleId":"x","expected_for_purpose":true,"note":"quoted artifact payload should not persist"}]}',
         stderr: "workspace read failed https://signed.example.invalid/file?token=secret",
         stdout:
-          '{"type":"tool_call","status":"failed","api_key":"sk-short-secret","output":"read https://signed.example.invalid/file?token=secret","content":["quoted array artifact payload should not persist"]}\n',
+          '{"type":"error","message":"Codex CLI provider returned HTTP 429 for https://signed.example.invalid/file?token=secret with api_key=sk-short-secret"}\n{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"I could not inspect the artifact because the provider returned a transient error."}}\n{"type":"tool_call","status":"failed","api_key":"sk-short-secret","output":"read https://signed.example.invalid/file?token=secret","content":["quoted array artifact payload should not persist"]}\n',
       },
       skillSpector: {
         args: ["scan", "artifact", "--format", "json"],
@@ -308,12 +308,16 @@ describe("run-codex-scan-worker diagnostics", () => {
     const jobDir = join(diagnosticsRoot, "job123");
     const stdoutText = await readFile(join(jobDir, "codex.stdout.redacted.jsonl"), "utf8");
     expect(stdoutText).toContain('"tool_call"');
+    expect(stdoutText).toContain("Codex CLI provider returned HTTP 429");
+    expect(stdoutText).toContain(
+      "I could not inspect the artifact because the provider returned a transient error.",
+    );
     expect(stdoutText).not.toContain("token=secret");
     expect(stdoutText).not.toContain("signed.example.invalid");
     expect(stdoutText).not.toContain("sk-short-secret");
     expect(stdoutText).not.toContain("quoted array artifact payload");
-    expect(stdoutText).toContain('"api_key": "[redacted-secret]"');
-    expect(stdoutText).toContain('"content": "[redacted 1 item(s)]"');
+    expect(stdoutText).toContain('"api_key":"[redacted-secret]"');
+    expect(stdoutText).toContain('"content":"[redacted 1 item(s)]"');
     await expect(readFile(join(jobDir, "codex.stderr.redacted.log"), "utf8")).resolves.toContain(
       "workspace read failed",
     );

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -210,32 +210,42 @@ const DIAGNOSTIC_CONTENT_KEY_PATTERN =
   /^(code[_-]?snippet|content|detail|evidence|explanation|finding|findings|guidance|match|message|note|notes|output|rawResult|recommendation|result|snippet|stderr|stdout|summary|text|userImpact|user_impact)$/i;
 const DIAGNOSTIC_SECRET_KEY_PATTERN =
   /(api[_-]?key|authorization|password|secret|token|webhook|credential)/i;
+const CODEX_EVENT_DIAGNOSTIC_TEXT_KEYS = new Set(["message", "text"]);
 
-function redactDiagnosticValue(value: unknown, key = ""): unknown {
+function redactDiagnosticValue(value: unknown, key = "", preserveDiagnosticText = false): unknown {
   if (DIAGNOSTIC_SECRET_KEY_PATTERN.test(key)) return "[redacted-secret]";
   if (typeof value === "string") {
     const redacted = redactDiagnosticText(value, 2_000);
+    if (preserveDiagnosticText && CODEX_EVENT_DIAGNOSTIC_TEXT_KEYS.has(key)) return redacted;
     if (!DIAGNOSTIC_CONTENT_KEY_PATTERN.test(key)) return redacted;
     return `[redacted ${redacted.length} chars]`;
   }
   if (Array.isArray(value)) {
     if (DIAGNOSTIC_CONTENT_KEY_PATTERN.test(key)) return `[redacted ${value.length} item(s)]`;
-    return value.map((item) => redactDiagnosticValue(item));
+    return value.map((item) => redactDiagnosticValue(item, "", preserveDiagnosticText));
   }
   if (!value || typeof value !== "object") return value;
   return Object.fromEntries(
     Object.entries(value as Record<string, unknown>).map(([entryKey, entryValue]) => [
       entryKey,
-      redactDiagnosticValue(entryValue, entryKey),
+      redactDiagnosticValue(entryValue, entryKey, preserveDiagnosticText),
     ]),
   );
 }
 
-function redactStructuredDiagnosticText(value: string) {
+function redactStructuredDiagnosticText(
+  value: string,
+  options?: { preserveDiagnosticText?: boolean },
+) {
   const trimmed = value.trim();
+  const preserveDiagnosticText = options?.preserveDiagnosticText === true;
   if (!trimmed) return "";
   try {
-    return JSON.stringify(redactDiagnosticValue(JSON.parse(trimmed)), null, 2);
+    return JSON.stringify(
+      redactDiagnosticValue(JSON.parse(trimmed), "", preserveDiagnosticText),
+      null,
+      2,
+    );
   } catch {
     // Codex --json writes JSONL. Redact parseable lines structurally, then fall back to text redaction.
     const lines = value.split("\n");
@@ -244,7 +254,9 @@ function redactStructuredDiagnosticText(value: string) {
         .map((line) => {
           if (!line.trim()) return line;
           try {
-            return JSON.stringify(redactDiagnosticValue(JSON.parse(line)));
+            return JSON.stringify(
+              redactDiagnosticValue(JSON.parse(line), "", preserveDiagnosticText),
+            );
           } catch {
             return redactDiagnosticText(line, 2_000);
           }
@@ -293,7 +305,9 @@ function sanitizedTargetForArtifactContext(target: ClaimedJob["target"]) {
 
 async function writeDiagnosticText(jobDir: string, fileName: string, value: string | undefined) {
   if (value === undefined) return undefined;
-  const redacted = redactStructuredDiagnosticText(value);
+  const redacted = redactStructuredDiagnosticText(value, {
+    preserveDiagnosticText: fileName === "codex.stdout.redacted.jsonl",
+  });
   await writeFile(join(jobDir, fileName), redacted.endsWith("\n") ? redacted : `${redacted}\n`);
   return fileName;
 }

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -136,6 +136,10 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   hosted LLM call. Publishes enqueue a scan job that waits at most 10 minutes
   for VirusTotal telemetry, then Codex reviews the materialized artifact
   workspace with static and VT signals as context.
+- ClawScan worker concurrency is an operator-controlled compute concern. The
+  backend claim path must cap only a single worker claim size and must not impose
+  a global active-scan ceiling; horizontal capacity is controlled by worker
+  dispatch count, worker batch limit, provider quotas, and cost monitoring.
 - The Skill Card verification envelope exposes ClawScan as the top-level
   `security` verdict for install automation, with deterministic and third-party
   scanner evidence grouped under `security.signals`. Clients should key install


### PR DESCRIPTION
## Summary
- preserve Codex JSONL diagnostic `message` and agent `text` fields in `codex.stdout.redacted.jsonl`
- continue redacting signed URLs, secret-looking values, tool output/content, stderr, raw results, and SkillSpector diagnostics
- add coverage for provider-error and agent-message diagnostics while verifying artifact payloads still do not leak

## Tests
- `bun test scripts/security/run-codex-scan-worker.test.ts -t 'writes redacted Codex diagnostics'`
- `bun test scripts/security/run-codex-scan-worker.test.ts`
- `bun run format:check -- scripts/security/run-codex-scan-worker.ts scripts/security/run-codex-scan-worker.test.ts`
