### PR TITLE
fix(cli): report unknown root commands

### DIFF
--- a/packages/clawhub/src/cli.ts
+++ b/packages/clawhub/src/cli.ts
@@ -92,6 +92,55 @@ function registerCommandGroup(parent: Command, path: readonly string[]) {
   return parent.command(path.at(-1) ?? "");
 }
 
+function validateTopLevelCommand(args: string[]) {
+  if (hasTerminalGlobalFlag(args)) return;
+  const commandName = findFirstTopLevelOperand(args);
+  if (!commandName) return;
+  const knownCommands = new Set([
+    "help",
+    ...program.commands.flatMap((command) => [command.name(), ...command.aliases()]),
+  ]);
+  if (knownCommands.has(commandName)) return;
+  program.error(`error: unknown command '${commandName}'`, { code: "commander.unknownCommand" });
+}
+
+function hasTerminalGlobalFlag(args: string[]) {
+  return args.some(
+    (arg) => arg === "--help" || arg === "-h" || arg === "--cli-version" || arg === "-V",
+  );
+}
+
+function findFirstTopLevelOperand(args: string[]) {
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg) continue;
+    if (arg === "--") return args[index + 1];
+    if (arg.startsWith("--")) {
+      if (arg === "--workdir" || arg === "--dir" || arg === "--site" || arg === "--registry") {
+        index += 1;
+        continue;
+      }
+      if (
+        arg.startsWith("--workdir=") ||
+        arg.startsWith("--dir=") ||
+        arg.startsWith("--site=") ||
+        arg.startsWith("--registry=")
+      ) {
+        continue;
+      }
+      if (arg === "--help" || arg === "--cli-version") return undefined;
+      if (arg === "--no-input") continue;
+      return undefined;
+    }
+    if (arg.startsWith("-")) {
+      if (arg === "-h" || arg === "-V") return undefined;
+      return undefined;
+    }
+    return arg;
+  }
+  return undefined;
+}
+
 async function resolveGlobalOpts(): Promise<GlobalOpts> {
   const raw = program.opts<{ workdir?: string; dir?: string; site?: string; registry?: string }>();
   const workdir = await resolveWorkdir(raw.workdir);
@@ -740,6 +789,8 @@ program.action(async () => {
   program.outputHelp();
   process.exitCode = 0;
 });
+
+validateTopLevelCommand(process.argv.slice(2));
 
 void program.parseAsync(process.argv).catch((error) => {
   const message = error instanceof Error ? error.message : String(error);

--- a/packages/clawhub/test-artifact/cli.artifact.test.ts
+++ b/packages/clawhub/test-artifact/cli.artifact.test.ts
@@ -54,6 +54,42 @@ describe("built CLI artifact", () => {
     expect(result.stdout).toContain("ClawHub CLI");
   });
 
+  it("reports unknown top-level commands clearly", async () => {
+    const result = runNode([binPath, "nope"]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("error: unknown command 'nope'");
+    expect(result.stderr).not.toContain("too many arguments");
+  });
+
+  it("reports unknown top-level commands after global options", async () => {
+    const result = runNode([binPath, "--registry", "https://clawhub.ai", "nope"]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("error: unknown command 'nope'");
+    expect(result.stderr).not.toContain("too many arguments");
+  });
+
+  it("does not mask unknown global options", async () => {
+    const result = runNode([binPath, "--bad", "nope"]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("error: unknown option '--bad'");
+    expect(result.stderr).not.toContain("unknown command 'nope'");
+  });
+
+  it("keeps help and version flags terminal", async () => {
+    const helpResult = runNode([binPath, "nope", "--help"]);
+    const versionResult = runNode([binPath, "--cli-version", "nope"]);
+
+    expect(helpResult.status).toBe(0);
+    expect(helpResult.stderr).toBe("");
+    expect(helpResult.stdout).toContain("ClawHub CLI");
+    expect(versionResult.status).toBe(0);
+    expect(versionResult.stderr).toBe("");
+    expect(versionResult.stdout).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
   it("publishes a local code plugin in dry-run json mode from built output", async () => {
     const root = await makeTmpDir("clawhub-artifact-");
     const pluginDir = join(root, "demo-plugin");


### PR DESCRIPTION
## Summary

- What changed: unknown top-level CLI commands now report `error: unknown command '<name>'` before the root default action can treat the operand as an excess argument.
- Why: `clawhub nope` previously surfaced Commander's excess-argument error (`too many arguments`) instead of the clearer unknown-command error.

## Linked Issue

- Closes N/A
- Related N/A

## Screenshots

N/A, CLI-only behavior change.

- [x] Screenshots/recordings attached, or `N/A`

## Behavioural Proof

Before:

```console
$ clawhub nope
error: too many arguments. Expected 0 arguments but got 1.

Usage: clawhub [options] [command]
```

After:

```console
$ clawhub nope
error: unknown command 'nope'

Usage: clawhub [options] [command]
```

Global options before an unknown command still reach the same unknown-command path:

```console
$ clawhub --registry https://clawhub.ai nope
error: unknown command 'nope'

Usage: clawhub [options] [command]
```

Unknown global options are still reported as option errors:

```console
$ clawhub --bad nope
error: unknown option '--bad'

Usage: clawhub [options] [command]
```

Known subcommand validation is still owned by the subcommand:

```console
$ clawhub search
error: missing required argument 'query'

Usage: clawhub search [options] <query...>
```

Terminal help/version flags still take precedence:

```console
$ clawhub nope --help
Usage: clawhub [options] [command]

$ clawhub --cli-version nope
0.18.0
```

- [x] Behavioural proof included, or `N/A`

## Security / Trust Impact

- [x] No security/trust impact
- [ ] Security/trust impact explained

## Data / Deploy Impact

- [x] No data/deploy impact
- [ ] Data/deploy impact explained

## Verification

- [x] `bun run ci:static`
  - `No vulnerabilities found`
  - `All matched files use the correct format.`
  - `lint`, `deadcode:files`, `deadcode:dependencies`, and `deadcode:exports` completed successfully.
- [x] Focused tests for touched behavior:
  - `bunx vitest run -c vitest.artifact.config.ts test-artifact/cli.artifact.test.ts`
  - Output: `Test Files 1 passed (1)`, `Tests 7 passed (7)`.
- [x] `bun run ci:unit`:
  - Output: `Test Files 233 passed (233)`, `Tests 2547 passed (2547)`.
  - Coverage summary: statements `86.55%`, branches `75.21%`, functions `87.77%`, lines `90.19%`.
- [x] Broader gate when required:
  - `bunx tsc -p packages/schema/tsconfig.json --noEmit`
  - `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
  - `bun run --cwd packages/clawhub build`
- [x] Other:
  - `bun run format:check -- packages/clawhub/src/cli.ts packages/clawhub/test-artifact/cli.artifact.test.ts`
  - `git diff --check`
