### PR TITLE
fix: surface organization creation errors

### DIFF
--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -2,6 +2,7 @@
 
 import { getAuthUserId } from "@convex-dev/auth/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { MAX_PUBLISH_FILE_BYTES } from "./lib/publishLimits";
 import {
   backfillLatestPackageScanStatusInternal,
   backfillPackageReleaseScansInternal,
@@ -43,7 +44,6 @@ import {
   searchForViewerInternal,
   searchPublic,
 } from "./packages";
-import { MAX_PUBLISH_FILE_BYTES } from "./lib/publishLimits";
 
 vi.mock("@convex-dev/auth/server", () => ({
   getAuthUserId: vi.fn(),

--- a/src/routes/-settings.test.tsx
+++ b/src/routes/-settings.test.tsx
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { api } from "../../convex/_generated/api";
 import { Settings } from "./settings";
@@ -27,6 +28,13 @@ vi.mock("@tanstack/react-router", () => ({
   Link: ({ children, to }: { children: ReactNode; to: string }) => <a href={to}>{children}</a>,
   useNavigate: () => navigateMock,
   useSearch: () => searchMock(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
 }));
 
 const signedInUser = {
@@ -95,6 +103,8 @@ describe("Settings", () => {
     searchMock.mockReset();
     searchMock.mockReturnValue({});
     useMutationMock.mockReturnValue(vi.fn());
+    vi.mocked(toast.error).mockReset();
+    vi.mocked(toast.success).mockReset();
     useAuthActionsMock.mockReturnValue({
       signIn: vi.fn(),
     });
@@ -162,6 +172,37 @@ describe("Settings", () => {
     expect(useQueryMock).toHaveBeenCalledWith(api.publishers.listMembers, {
       publisherHandle: "openclaw",
     });
+  });
+
+  it("shows create organization mutation errors to the user", async () => {
+    const createOrg = vi
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          '[CONVEX M(publishers:createOrg)] [Request ID: test] Server Error Called by client ConvexError: Handle "@romneyda" is already used by a user or personal publisher',
+        ),
+      );
+    mockSignedInSettings({ search: { view: "organizations" }, memberships: [] });
+    useMutationMock.mockReturnValue(createOrg);
+
+    render(<Settings />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Create org" }));
+    fireEvent.change(screen.getByLabelText("Handle"), { target: { value: "romneyda" } });
+    fireEvent.change(screen.getByLabelText("Display name"), {
+      target: { value: "Dallin Romney @ OpenClaw" },
+    });
+    const createOrgButtons = screen.getAllByRole("button", { name: "Create org" });
+    fireEvent.click(createOrgButtons[createOrgButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toContain(
+        'Handle "@romneyda" is already used by a user or personal publisher',
+      );
+    });
+    expect(toast.error).toHaveBeenCalledWith(
+      'Handle "@romneyda" is already used by a user or personal publisher',
+    );
   });
 
   it("migrates legacy hash settings URLs to focused query params", () => {

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -51,6 +51,7 @@ import {
 import { Separator } from "../components/ui/separator";
 import { Textarea } from "../components/ui/textarea";
 import { ToggleGroup, ToggleGroupItem } from "../components/ui/toggle-group";
+import { getUserFacingConvexError } from "../lib/convexError";
 import { useThemeMode } from "../lib/theme";
 
 const settingsViews = ["account", "organizations", "tokens", "danger"] as const;
@@ -159,6 +160,8 @@ export function Settings() {
   const [newToken, setNewToken] = useState<string | null>(null);
   const [orgHandle, setOrgHandle] = useState("");
   const [orgDisplayName, setOrgDisplayName] = useState("");
+  const [createOrgError, setCreateOrgError] = useState<string | null>(null);
+  const [isCreatingOrg, setIsCreatingOrg] = useState(false);
   const [selectedOrgHandle, setSelectedOrgHandle] = useState("");
   const [selectedOrgDisplayName, setSelectedOrgDisplayName] = useState("");
   const [selectedOrgBio, setSelectedOrgBio] = useState("");
@@ -248,16 +251,27 @@ export function Settings() {
   }
 
   async function onCreateOrg() {
-    const result = await createOrg({
-      handle: orgHandle.trim(),
-      displayName: orgDisplayName.trim() || orgHandle.trim(),
-      bio: undefined,
-    });
-    if (result?.publisher?.handle) {
-      setSelectedOrgHandle(result.publisher.handle);
-      setOrgHandle("");
-      setOrgDisplayName("");
-      setCreateOrgDialogOpen(false);
+    setCreateOrgError(null);
+    setIsCreatingOrg(true);
+    try {
+      const result = await createOrg({
+        handle: orgHandle.trim(),
+        displayName: orgDisplayName.trim() || orgHandle.trim(),
+        bio: undefined,
+      });
+      if (result?.publisher?.handle) {
+        setSelectedOrgHandle(result.publisher.handle);
+        setOrgHandle("");
+        setOrgDisplayName("");
+        setCreateOrgDialogOpen(false);
+        toast.success("Organization created");
+      }
+    } catch (error) {
+      const message = getUserFacingConvexError(error, "Organization could not be created.");
+      setCreateOrgError(message);
+      toast.error(message);
+    } finally {
+      setIsCreatingOrg(false);
     }
   }
 
@@ -509,7 +523,13 @@ export function Settings() {
                           ))}
                         </SelectContent>
                       </Select>
-                      <Dialog open={createOrgDialogOpen} onOpenChange={setCreateOrgDialogOpen}>
+                      <Dialog
+                        open={createOrgDialogOpen}
+                        onOpenChange={(open) => {
+                          setCreateOrgDialogOpen(open);
+                          if (open) setCreateOrgError(null);
+                        }}
+                      >
                         <DialogTrigger asChild>
                           <Button variant="outline" type="button" className="h-12 sm:w-auto">
                             <Plus size={16} />
@@ -528,7 +548,10 @@ export function Settings() {
                               <Input
                                 id="settings-org-handle"
                                 value={orgHandle}
-                                onChange={(event) => setOrgHandle(event.target.value)}
+                                onChange={(event) => {
+                                  setOrgHandle(event.target.value);
+                                  setCreateOrgError(null);
+                                }}
                                 placeholder="openclaw"
                               />
                             </Field>
@@ -536,11 +559,22 @@ export function Settings() {
                               <Input
                                 id="settings-org-display-name"
                                 value={orgDisplayName}
-                                onChange={(event) => setOrgDisplayName(event.target.value)}
+                                onChange={(event) => {
+                                  setOrgDisplayName(event.target.value);
+                                  setCreateOrgError(null);
+                                }}
                                 placeholder="OpenClaw"
                               />
                             </Field>
                           </div>
+                          {createOrgError ? (
+                            <p
+                              className="text-sm font-medium text-red-600 dark:text-red-400"
+                              role="alert"
+                            >
+                              {createOrgError}
+                            </p>
+                          ) : null}
                           <DialogFooter>
                             <Button variant="ghost" onClick={() => setCreateOrgDialogOpen(false)}>
                               Cancel
@@ -548,11 +582,11 @@ export function Settings() {
                             <Button
                               variant="primary"
                               type="button"
-                              disabled={!orgHandle.trim()}
+                              disabled={!orgHandle.trim() || isCreatingOrg}
                               onClick={() => void onCreateOrg()}
                             >
                               <Building2 size={16} />
-                              Create org
+                              {isCreatingOrg ? "Creating..." : "Create org"}
                             </Button>
                           </DialogFooter>
                         </DialogContent>
@@ -826,7 +860,13 @@ export function Settings() {
                           </p>
                         </div>
                       </div>
-                      <Dialog open={createOrgDialogOpen} onOpenChange={setCreateOrgDialogOpen}>
+                      <Dialog
+                        open={createOrgDialogOpen}
+                        onOpenChange={(open) => {
+                          setCreateOrgDialogOpen(open);
+                          if (open) setCreateOrgError(null);
+                        }}
+                      >
                         <DialogTrigger asChild>
                           <Button variant="primary" type="button" className="lg:w-auto">
                             <Building2 size={16} />
@@ -845,7 +885,10 @@ export function Settings() {
                               <Input
                                 id="settings-org-handle-empty"
                                 value={orgHandle}
-                                onChange={(event) => setOrgHandle(event.target.value)}
+                                onChange={(event) => {
+                                  setOrgHandle(event.target.value);
+                                  setCreateOrgError(null);
+                                }}
                                 placeholder="openclaw"
                               />
                             </Field>
@@ -853,11 +896,22 @@ export function Settings() {
                               <Input
                                 id="settings-org-display-name-empty"
                                 value={orgDisplayName}
-                                onChange={(event) => setOrgDisplayName(event.target.value)}
+                                onChange={(event) => {
+                                  setOrgDisplayName(event.target.value);
+                                  setCreateOrgError(null);
+                                }}
                                 placeholder="OpenClaw"
                               />
                             </Field>
                           </div>
+                          {createOrgError ? (
+                            <p
+                              className="text-sm font-medium text-red-600 dark:text-red-400"
+                              role="alert"
+                            >
+                              {createOrgError}
+                            </p>
+                          ) : null}
                           <DialogFooter>
                             <Button variant="ghost" onClick={() => setCreateOrgDialogOpen(false)}>
                               Cancel
@@ -865,11 +919,11 @@ export function Settings() {
                             <Button
                               variant="primary"
                               type="button"
-                              disabled={!orgHandle.trim()}
+                              disabled={!orgHandle.trim() || isCreatingOrg}
                               onClick={() => void onCreateOrg()}
                             >
                               <Building2 size={16} />
-                              Create org
+                              {isCreatingOrg ? "Creating..." : "Create org"}
                             </Button>
                           </DialogFooter>
                         </DialogContent>


### PR DESCRIPTION
## Summary
- Surface create-organization mutation failures in the settings dialog instead of silently dropping them.
- Disable the create button while the mutation is pending and clear stale errors when editing/reopening the dialog.
- Add a settings regression test for duplicate-handle Convex errors.
- Apply a formatter-only import reorder in `convex/packages.public.test.ts` so the full static gate passes.

## Tests
- `VITE_CONVEX_URL=https://example.invalid bunx vitest run src/routes/-settings.test.tsx`
- `bun run ci:static`
- `bun run ci:unit`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local`
