### PR TITLE
fix(auth): avoid false sign-in failure on redirect

### DIFF
--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -197,6 +197,7 @@ function compactHeaderCss() {
 
 describe("Header", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     authStatusMock.mockReturnValue({
       isAuthenticated: false,
       isLoading: false,
@@ -279,6 +280,23 @@ describe("Header", () => {
     await waitFor(() => {
       expect(setAuthError).toHaveBeenCalledWith("Sign in failed. Please try again.");
     });
+  });
+
+  it("does not show an auth error when GitHub sign-in starts a redirect", async () => {
+    const { setAuthError } = await import("../lib/useAuthError");
+    siteModeMock.mockReturnValue("skills");
+    signInMock.mockResolvedValue({
+      signingIn: false,
+      redirect: new URL("https://github.com/login/oauth/authorize"),
+    });
+
+    render(<Header />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign in with GitHub" }));
+
+    expect(signInMock).toHaveBeenCalledWith("github", { redirectTo: "/" });
+    await Promise.resolve();
+    expect(setAuthError).not.toHaveBeenCalled();
   });
 
   it("keeps inline search and moves content nav into the compact menu", () => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -518,7 +518,7 @@ export default function Header() {
                       signInRedirectTo ? { redirectTo: signInRedirectTo } : undefined,
                     )
                       .then((result) => {
-                        if (result?.signingIn === false) {
+                        if (result?.signingIn === false && !result.redirect) {
                           setAuthError("Sign in failed. Please try again.");
                         }
                       })

--- a/src/components/SignInButton.test.tsx
+++ b/src/components/SignInButton.test.tsx
@@ -54,6 +54,24 @@ describe("SignInButton", () => {
     expect(setAuthErrorMock).not.toHaveBeenCalled();
   });
 
+  it("does not show an error when GitHub sign-in starts a redirect", async () => {
+    signInMock.mockResolvedValue({
+      signingIn: false,
+      redirect: new URL("https://github.com/login/oauth/authorize"),
+    });
+
+    render(<SignInButton />);
+    fireEvent.click(screen.getByRole("button", { name: "Sign In" }));
+
+    await waitFor(() => {
+      expect(signInMock).toHaveBeenCalledWith("github", {
+        redirectTo: "/skills?q=test#top",
+      });
+    });
+    await Promise.resolve();
+    expect(setAuthErrorMock).not.toHaveBeenCalled();
+  });
+
   it("surfaces a generic error when sign-in resolves without redirecting", async () => {
     signInMock.mockResolvedValue({ signingIn: false });
 

--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -23,7 +23,7 @@ export function SignInButton({ redirectTo, children = "Sign In", ...props }: Sig
         const next = redirectTo ?? getCurrentRelativeUrl();
         void signIn("github", next ? { redirectTo: next } : undefined)
           .then((result) => {
-            if (result?.signingIn === false) {
+            if (result?.signingIn === false && !result.redirect) {
               setAuthError("Sign in failed. Please try again.");
             }
           })


### PR DESCRIPTION
## Summary
- Treat Convex Auth redirect results as a started GitHub OAuth flow instead of a failed sign-in.
- Keep the generic sign-in failure message for non-redirect `signingIn: false` results.
- Add regression coverage for the shared sign-in button and header sign-in button.

## Test Plan
- `bunx vitest run src/components/SignInButton.test.tsx src/__tests__/header.test.tsx`
- `bun run ci:static`
- `bun run ci:unit`
- `bunx tsc --noEmit`
