### PR TITLE
feat: add NVIDIA as official publisher

### DIFF
--- a/convex/lib/officialPublishers.test.ts
+++ b/convex/lib/officialPublishers.test.ts
@@ -26,6 +26,14 @@ describe("isOfficialPublisher", () => {
     ).resolves.toBe(true);
   });
 
+  it("treats the nvidia org publisher as official", async () => {
+    const ctx = { db: { query: vi.fn() } };
+
+    await expect(
+      isOfficialPublisher(ctx as never, makePublisher({ handle: "nvidia" })),
+    ).resolves.toBe(true);
+  });
+
   it("treats personal publishers for openclaw org members as official", async () => {
     const openclaw = makePublisher({ _id: "publishers:openclaw", handle: "openclaw" });
     const personal = makePublisher({

--- a/convex/lib/officialPublishers.ts
+++ b/convex/lib/officialPublishers.ts
@@ -7,7 +7,8 @@ import {
   normalizePublisherHandle,
 } from "./publishers";
 
-const OFFICIAL_ORG_HANDLE = "openclaw";
+const OFFICIAL_ORG_HANDLES = ["openclaw", "nvidia"] as const;
+const OFFICIAL_ORG_HANDLE_SET = new Set<string>(OFFICIAL_ORG_HANDLES);
 
 type DbCtx = Pick<QueryCtx | MutationCtx, "db">;
 
@@ -31,15 +32,20 @@ export async function isOfficialPublisher(
 ): Promise<boolean> {
   if (!publisher || publisher.deletedAt || publisher.deactivatedAt) return false;
   if (publisher.kind === "org") {
-    return normalizePublisherHandle(publisher.handle) === OFFICIAL_ORG_HANDLE;
+    const handle = normalizePublisherHandle(publisher.handle);
+    return Boolean(handle && OFFICIAL_ORG_HANDLE_SET.has(handle));
   }
   if (!publisher.linkedUserId) return false;
 
-  const officialOrg = await getPublisherByHandle(ctx, OFFICIAL_ORG_HANDLE);
-  if (!officialOrg || officialOrg.deletedAt || officialOrg.deactivatedAt) return false;
+  for (const officialOrgHandle of OFFICIAL_ORG_HANDLES) {
+    const officialOrg = await getPublisherByHandle(ctx, officialOrgHandle);
+    if (!officialOrg || officialOrg.deletedAt || officialOrg.deactivatedAt) continue;
 
-  const membership = await getPublisherMembership(ctx, officialOrg._id, publisher.linkedUserId);
-  return Boolean(membership);
+    const membership = await getPublisherMembership(ctx, officialOrg._id, publisher.linkedUserId);
+    if (membership) return true;
+  }
+
+  return false;
 }
 
 export async function toPublicPublisherWithOfficial(

--- a/specs/official-publishers.md
+++ b/specs/official-publishers.md
@@ -1,17 +1,17 @@
 # Official Publishers
 
-`official` is a ClawHub publisher policy flag derived from hard-coded
-`openclaw` organization membership.
+`official` is a ClawHub publisher policy flag derived from the ClawHub-managed
+official organization allowlist.
 
 For now, Official means:
 
-- the `openclaw` org publisher is Official
-- personal publishers for current `openclaw` org members are Official
+- org publishers on the official allowlist are Official
+- personal publishers for current members of an official org are Official
 
 Official must not be accepted from uploaded skill or package metadata.
-Membership in any org other than `openclaw` does not make a personal publisher
-Official. There is no generic admin endpoint for marking arbitrary publishers
-Official.
+Membership in any org outside the official allowlist does not make a personal
+publisher Official. There is no generic admin endpoint for marking arbitrary
+publishers Official.
 
 The same policy signal appears in two places:
 


### PR DESCRIPTION
## Summary
- Add `nvidia` to the official publisher allowlist.
- Cover the new official org handle in `officialPublishers` tests.
- Keep the official publishers spec generic around the allowlist policy.

## Verification
- Verified GitHub org spelling with `gh api /orgs/nvidia --jq '{login,type,name}'` -> `login: NVIDIA`, `type: Organization`, `name: NVIDIA Corporation`.
- `bunx vitest run convex/lib/officialPublishers.test.ts`
- `bun run format:check -- convex/lib/officialPublishers.ts convex/lib/officialPublishers.test.ts specs/official-publishers.md`
- `bun run ci:static`
- `bun run ci:unit`
