### PR TITLE
Export skill bundle content for security datasets

### DIFF
--- a/convex/securityDataset.ts
+++ b/convex/securityDataset.ts
@@ -8,7 +8,10 @@ import { getOwnerPublisher } from "./lib/publishers";
 
 const MAX_EXPORT_PAGE_SIZE = 50;
 const MAX_EXPORT_BATCH_PAGES = 20;
-const REDACTION_POLICY_VERSION = "public-signals-v1";
+const MAX_REDACTED_BUNDLE_FILE_BYTES = 192 * 1024;
+const MAX_REDACTED_BUNDLE_BYTES_PER_ARTIFACT = 256 * 1024;
+const MAX_REDACTED_BUNDLE_BYTES_PER_RESPONSE = 256 * 1024;
+const REDACTION_POLICY_VERSION = "public-signals-v2-bundle-files";
 const SOURCE_TABLES = ["skillVersions", "packageReleases"] as const;
 const SCANNER_SOURCES = [
   "static",
@@ -297,17 +300,80 @@ function sanitizeFiles(files: Array<Doc<"skillVersions">["files"][number]>) {
 }
 
 async function enrichAndSanitizeArtifactRows(ctx: ActionCtx, rows: ArtifactExportRow[]) {
-  return await Promise.all(
-    rows.map(async (row) => {
-      const skillContent =
-        row.sourceKind === "skill" ? await readRedactedSkillMdContent(ctx, row.files) : null;
-      return {
-        ...row,
-        ...(skillContent ? { skillMdContentRedacted: skillContent } : {}),
-        files: row.files.map(({ storageId: _storageId, ...file }) => file),
-      };
-    }),
+  const enrichedRows = [];
+  let remainingBundleBytes = MAX_REDACTED_BUNDLE_BYTES_PER_RESPONSE;
+  for (const row of rows) {
+    const skillContent =
+      row.sourceKind === "skill" ? await readRedactedSkillMdContent(ctx, row.files) : null;
+    const bundleFiles =
+      row.sourceKind === "skill"
+        ? await readRedactedBundleFiles(ctx, row.files, remainingBundleBytes)
+        : [];
+    remainingBundleBytes -= totalBundleBytes(bundleFiles);
+    enrichedRows.push({
+      ...row,
+      ...(skillContent ? { skillMdContentRedacted: skillContent } : {}),
+      ...(bundleFiles.length > 0 ? { bundleFilesRedacted: bundleFiles } : {}),
+      files: row.files.map(({ storageId: _storageId, ...file }) => file),
+    });
+  }
+  return enrichedRows;
+}
+
+async function readRedactedBundleFiles(
+  ctx: Pick<ActionCtx, "storage">,
+  files: Array<{ path: string; size?: number; storageId?: unknown }>,
+  remainingResponseBytes: number,
+) {
+  const bundleFiles: Array<{ path: string; content: string }> = [];
+  let remainingArtifactBytes = Math.min(
+    remainingResponseBytes,
+    MAX_REDACTED_BUNDLE_BYTES_PER_ARTIFACT,
   );
+  for (const file of files) {
+    if (isExcludedSkillBundlePath(file.path) || typeof file.storageId !== "string") continue;
+    if (typeof file.size === "number" && file.size > MAX_REDACTED_BUNDLE_FILE_BYTES) continue;
+    if (remainingArtifactBytes <= 0) break;
+    const blob = await ctx.storage.get(file.storageId as never);
+    if (!blob) continue;
+    const content = redactBundleContent(await blob.text());
+    const contentBytes = utf8Bytes(content);
+    if (contentBytes > MAX_REDACTED_BUNDLE_FILE_BYTES || contentBytes > remainingArtifactBytes) {
+      continue;
+    }
+    bundleFiles.push({ path: file.path, content });
+    remainingArtifactBytes -= contentBytes;
+  }
+  return bundleFiles;
+}
+
+function isExcludedSkillBundlePath(path: string) {
+  return (
+    isPrimarySkillReadmePath(path) || normalizeBundlePathForComparison(path) === "skill-card.md"
+  );
+}
+
+function isPrimarySkillReadmePath(path: string) {
+  const normalized = normalizeBundlePathForComparison(path);
+  return normalized === "skill.md" || normalized === "skills.md";
+}
+
+function normalizeBundlePathForComparison(path: string) {
+  return path
+    .trim()
+    .replace(/^\/+/, "")
+    .split("/")
+    .filter((segment) => segment && segment !== ".")
+    .join("/")
+    .toLowerCase();
+}
+
+function totalBundleBytes(files: Array<{ content: string }>) {
+  return files.reduce((sum, file) => sum + utf8Bytes(file.content), 0);
+}
+
+function utf8Bytes(value: string) {
+  return new TextEncoder().encode(value).byteLength;
 }
 
 async function readRedactedSkillMdContent(
@@ -315,8 +381,7 @@ async function readRedactedSkillMdContent(
   files: Array<{ path: string; storageId?: unknown }>,
 ) {
   const skillFile = files.find((file) => {
-    const path = file.path.toLowerCase();
-    return path === "skill.md" || path.endsWith("/skill.md");
+    return isPrimarySkillReadmePath(file.path);
   });
   if (!skillFile || typeof skillFile.storageId !== "string") return null;
   const blob = await ctx.storage.get(skillFile.storageId as never);
@@ -334,6 +399,18 @@ function redactSkillContent(value: string) {
     redacted = redacted.replace(pattern, "[REDACTED_SECRET]");
   }
   return redacted.trim();
+}
+
+function redactBundleContent(value: string) {
+  let redacted = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    redacted += code < 32 && code !== 9 && code !== 10 && code !== 13 ? " " : value.charAt(index);
+  }
+  for (const pattern of SECRET_PATTERNS) {
+    redacted = redacted.replace(pattern, "[REDACTED_SECRET]");
+  }
+  return redacted;
 }
 
 function normalizeVtAnalysis(analysis: StoredVtAnalysis) {

--- a/convex/securityDatasetNode.ts
+++ b/convex/securityDatasetNode.ts
@@ -8,6 +8,9 @@ import type { ActionCtx } from "./_generated/server";
 import { internalAction } from "./functions";
 
 const MAX_EXPORT_BATCH_PAGES = 20;
+const MAX_REDACTED_BUNDLE_FILE_BYTES = 192 * 1024;
+const MAX_REDACTED_BUNDLE_BYTES_PER_ARTIFACT = 256 * 1024;
+const MAX_REDACTED_BUNDLE_BYTES_PER_RESPONSE = 256 * 1024;
 
 type ArtifactExportPage = {
   page: unknown[];
@@ -75,30 +78,102 @@ export const listArtifactExportBatchCompressedInternal = internalAction({
 });
 
 async function enrichAndSanitizeArtifactRows(ctx: ActionCtx, rows: unknown[]) {
-  return await Promise.all(
-    rows.map(async (row) => {
-      if (!isRecord(row)) return row;
-      const files = Array.isArray(row.files) ? row.files : [];
-      const skillContent =
-        row.sourceKind === "skill" ? await readRedactedSkillMdContent(ctx, files) : null;
-      return {
-        ...row,
-        ...(skillContent ? { skillMdContentRedacted: skillContent } : {}),
-        files: files.map((file) => {
-          if (!isRecord(file)) return file;
-          const { storageId: _storageId, ...rest } = file;
-          return rest;
-        }),
-      };
-    }),
+  const enrichedRows = [];
+  let remainingBundleBytes = MAX_REDACTED_BUNDLE_BYTES_PER_RESPONSE;
+  for (const row of rows) {
+    if (!isRecord(row)) {
+      enrichedRows.push(row);
+      continue;
+    }
+    const files = Array.isArray(row.files) ? row.files : [];
+    const skillContent =
+      row.sourceKind === "skill" ? await readRedactedSkillMdContent(ctx, files) : null;
+    const bundleFiles =
+      row.sourceKind === "skill"
+        ? await readRedactedBundleFiles(ctx, files, remainingBundleBytes)
+        : [];
+    remainingBundleBytes -= totalBundleBytes(bundleFiles);
+    enrichedRows.push({
+      ...row,
+      ...(skillContent ? { skillMdContentRedacted: skillContent } : {}),
+      ...(bundleFiles.length > 0 ? { bundleFilesRedacted: bundleFiles } : {}),
+      files: files.map((file) => {
+        if (!isRecord(file)) return file;
+        const { storageId: _storageId, ...rest } = file;
+        return rest;
+      }),
+    });
+  }
+  return enrichedRows;
+}
+
+async function readRedactedBundleFiles(
+  ctx: Pick<ActionCtx, "storage">,
+  files: unknown[],
+  remainingResponseBytes: number,
+) {
+  const bundleFiles: Array<{ path: string; content: string }> = [];
+  let remainingArtifactBytes = Math.min(
+    remainingResponseBytes,
+    MAX_REDACTED_BUNDLE_BYTES_PER_ARTIFACT,
   );
+  for (const file of files) {
+    if (
+      !isRecord(file) ||
+      typeof file.path !== "string" ||
+      typeof file.storageId !== "string" ||
+      isExcludedSkillBundlePath(file.path)
+    ) {
+      continue;
+    }
+    if (typeof file.size === "number" && file.size > MAX_REDACTED_BUNDLE_FILE_BYTES) continue;
+    if (remainingArtifactBytes <= 0) break;
+    const blob = await ctx.storage.get(file.storageId as never);
+    if (!blob) continue;
+    const content = redactBundleContent(await blob.text());
+    const contentBytes = utf8Bytes(content);
+    if (contentBytes > MAX_REDACTED_BUNDLE_FILE_BYTES || contentBytes > remainingArtifactBytes) {
+      continue;
+    }
+    bundleFiles.push({ path: file.path, content });
+    remainingArtifactBytes -= contentBytes;
+  }
+  return bundleFiles;
+}
+
+function isExcludedSkillBundlePath(path: string) {
+  return (
+    isPrimarySkillReadmePath(path) || normalizeBundlePathForComparison(path) === "skill-card.md"
+  );
+}
+
+function isPrimarySkillReadmePath(path: string) {
+  const normalized = normalizeBundlePathForComparison(path);
+  return normalized === "skill.md" || normalized === "skills.md";
+}
+
+function normalizeBundlePathForComparison(path: string) {
+  return path
+    .trim()
+    .replace(/^\/+/, "")
+    .split("/")
+    .filter((segment) => segment && segment !== ".")
+    .join("/")
+    .toLowerCase();
+}
+
+function totalBundleBytes(files: Array<{ content: string }>) {
+  return files.reduce((sum, file) => sum + utf8Bytes(file.content), 0);
+}
+
+function utf8Bytes(value: string) {
+  return new TextEncoder().encode(value).byteLength;
 }
 
 async function readRedactedSkillMdContent(ctx: Pick<ActionCtx, "storage">, files: unknown[]) {
   const skillFile = files.find((file) => {
     if (!isRecord(file) || typeof file.path !== "string") return false;
-    const path = file.path.toLowerCase();
-    return path === "skill.md" || path.endsWith("/skill.md");
+    return isPrimarySkillReadmePath(file.path);
   });
   if (!isRecord(skillFile) || typeof skillFile.storageId !== "string") return null;
   const blob = await ctx.storage.get(skillFile.storageId as never);
@@ -116,6 +191,18 @@ function redactSkillContent(value: string) {
     redacted = redacted.replace(pattern, "[REDACTED_SECRET]");
   }
   return redacted.trim();
+}
+
+function redactBundleContent(value: string) {
+  let redacted = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    redacted += code < 32 && code !== 9 && code !== 10 && code !== 13 ? " " : value.charAt(index);
+  }
+  for (const pattern of SECRET_PATTERNS) {
+    redacted = redacted.replace(pattern, "[REDACTED_SECRET]");
+  }
+  return redacted;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/scripts/security-dataset/convexExport.test.ts
+++ b/scripts/security-dataset/convexExport.test.ts
@@ -42,6 +42,34 @@ describe("Convex export dataset ingestion", () => {
               sha256: "file-sha",
               content: "Use this skill safely. password=supersecret123",
             },
+            {
+              path: "scripts/export.py",
+              size: 48,
+              sha256: "script-sha",
+              content: "import json\npassword=supersecret123\n",
+              contentType: "text/x-python",
+            },
+            {
+              path: "skill-card.md",
+              size: 16,
+              sha256: "card-sha",
+              content: "Generated card",
+              contentType: "text/markdown",
+            },
+            {
+              path: "references/skill-card.md",
+              size: 32,
+              sha256: "nested-card-sha",
+              content: "Author-authored card note",
+              contentType: "text/markdown",
+            },
+            {
+              path: "docs/SKILL.md",
+              size: 36,
+              sha256: "nested-skill-sha",
+              content: "Nested authored skill reference",
+              contentType: "text/markdown",
+            },
           ],
           llmAnalysis: {
             status: "suspicious",
@@ -167,6 +195,20 @@ describe("Convex export dataset ingestion", () => {
         issues: [{ issueId: "SDI-1" }],
       },
       skillMdContentRedacted: "Use this skill safely. [REDACTED_SECRET]",
+      bundleFilesRedacted: [
+        {
+          path: "scripts/export.py",
+          content: "import json\n[REDACTED_SECRET]\n",
+        },
+        {
+          path: "references/skill-card.md",
+          content: "Author-authored card note",
+        },
+        {
+          path: "docs/SKILL.md",
+          content: "Nested authored skill reference",
+        },
+      ],
     });
     expect(rows[1]?.llmAnalysis?.agenticRiskFindings).toMatchObject([
       {
@@ -215,6 +257,54 @@ describe("Convex export dataset ingestion", () => {
     } finally {
       await rm(directory, { recursive: true, force: true });
     }
+  });
+
+  it("treats root skills.md as primary skill content", () => {
+    const rows = artifactInputsFromConvexExportTables({
+      skills: [
+        {
+          _id: "skills:1",
+          displayName: "Plural Readme Skill",
+          slug: "plural-readme-skill",
+          ownerUserId: "users:owner",
+        },
+      ],
+      skillVersions: [
+        {
+          _id: "skillVersions:1",
+          skillId: "skills:1",
+          version: "1.0.0",
+          createdAt: 1,
+          files: [
+            {
+              path: "docs/skills.md",
+              size: 24,
+              sha256: "nested-skills-sha",
+              content: "Nested authored plural readme",
+            },
+            {
+              path: "skills.md",
+              size: 12,
+              sha256: "skills-sha",
+              content: "Primary readme token=supersecret123",
+            },
+          ],
+        },
+      ],
+      packages: [],
+      packageReleases: [],
+      users: [{ _id: "users:owner", handle: "owner" }],
+    });
+
+    expect(rows[0]).toMatchObject({
+      skillMdContentRedacted: "Primary readme [REDACTED_SECRET]",
+      bundleFilesRedacted: [
+        {
+          path: "docs/skills.md",
+          content: "Nested authored plural readme",
+        },
+      ],
+    });
   });
 
   it("ignores inactive owner handles from Convex export tables", () => {

--- a/scripts/security-dataset/convexExport.ts
+++ b/scripts/security-dataset/convexExport.ts
@@ -10,7 +10,7 @@ import type {
   StaticScanInput,
   VtAnalysisInput,
 } from "./normalize";
-import { redactSkillContent } from "./normalize";
+import { redactBundleContent, redactSkillContent } from "./normalize";
 
 type ConvexDoc = Record<string, unknown> & { _id?: unknown };
 
@@ -186,6 +186,7 @@ function skillVersionToExportRow(
       version: requiredString(version.version, "skillVersions.version"),
       artifactSha256: stringOrNull(version.sha256hash),
       skillMdContentRedacted: skillMdContentFromExport(version.files),
+      bundleFilesRedacted: bundleFilesFromExport(version.files),
       createdAt: numberValue(version.createdAt, "skillVersions.createdAt"),
       softDeletedAt: numberOrNull(version.softDeletedAt),
       files: filesFromExport(version.files),
@@ -295,8 +296,8 @@ function skillMdContentFromExport(value: unknown): string | null {
   if (!Array.isArray(value)) return null;
   for (const file of value) {
     if (!isRecord(file)) continue;
-    const path = stringValue(file.path).toLowerCase();
-    if (path !== "skill.md" && !path.endsWith("/skill.md")) continue;
+    const path = stringValue(file.path);
+    if (!isPrimarySkillReadmePath(path)) continue;
     const content =
       stringOrNull(file.contentRedacted) ??
       stringOrNull(file.content_redacted) ??
@@ -307,6 +308,43 @@ function skillMdContentFromExport(value: unknown): string | null {
     return redactSkillContent(content);
   }
   return null;
+}
+
+function bundleFilesFromExport(value: unknown) {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((file) => {
+    if (!isRecord(file)) return [];
+    const path = stringValue(file.path);
+    if (!path || isExcludedSkillBundlePath(path)) return [];
+    const content =
+      stringOrNull(file.contentRedacted) ??
+      stringOrNull(file.content_redacted) ??
+      stringOrNull(file.content) ??
+      stringOrNull(file.text);
+    if (!content) return [];
+    return [{ path, content: redactBundleContent(content) }];
+  });
+}
+
+function isExcludedSkillBundlePath(path: string) {
+  return (
+    isPrimarySkillReadmePath(path) || normalizeBundlePathForComparison(path) === "skill-card.md"
+  );
+}
+
+function isPrimarySkillReadmePath(path: string) {
+  const normalized = normalizeBundlePathForComparison(path);
+  return normalized === "skill.md" || normalized === "skills.md";
+}
+
+function normalizeBundlePathForComparison(path: string) {
+  return path
+    .trim()
+    .replace(/^\/+/, "")
+    .split("/")
+    .filter((segment) => segment && segment !== ".")
+    .join("/")
+    .toLowerCase();
 }
 
 function vtAnalysisFromExport(value: unknown): VtAnalysisInput | null {

--- a/scripts/security-dataset/export-snapshot.ts
+++ b/scripts/security-dataset/export-snapshot.ts
@@ -376,7 +376,7 @@ function buildManifest(input: {
     },
     scannerVersions: Array.from(state.scannerVersions).sort(),
     modelNames: Array.from(state.modelNames).sort(),
-    redactionPolicyVersion: "public-signals-v2",
+    redactionPolicyVersion: "public-signals-v2-bundle-files",
     sourceTables: ["skillVersions", "packageReleases"],
     timeWindow: options.timeWindow,
   });

--- a/scripts/security-dataset/normalize.test.ts
+++ b/scripts/security-dataset/normalize.test.ts
@@ -248,4 +248,43 @@ describe("security dataset normalizer", () => {
     );
     expect(rows.artifacts[0]?.skill_md_content_redacted).not.toContain("PRIVATE KEY");
   });
+
+  it("emits redacted authored bundle files with content hashes and sizes", () => {
+    const rows = normalizeArtifactExport([
+      {
+        ...baseArtifact,
+        bundleFilesRedacted: [
+          {
+            path: "scripts/export.py",
+            content: "import json\npassword=[REDACTED_SECRET]\n",
+          },
+        ],
+      },
+    ]);
+
+    expect(rows.artifacts[0]?.bundle_files_redacted).toEqual([
+      {
+        path: "scripts/export.py",
+        content: "import json\n[REDACTED_SECRET]\n",
+        sha256: hashString("import json\n[REDACTED_SECRET]\n"),
+        size_bytes: Buffer.byteLength("import json\n[REDACTED_SECRET]\n", "utf8"),
+      },
+    ]);
+  });
+
+  it("omits oversized redacted bundle files", () => {
+    const rows = normalizeArtifactExport([
+      {
+        ...baseArtifact,
+        bundleFilesRedacted: [
+          {
+            path: "scripts/large.py",
+            content: "x".repeat(600 * 1024),
+          },
+        ],
+      },
+    ]);
+
+    expect(rows.artifacts[0]?.bundle_files_redacted).toBeUndefined();
+  });
 });

--- a/scripts/security-dataset/normalize.ts
+++ b/scripts/security-dataset/normalize.ts
@@ -19,6 +19,11 @@ export type ExportFileInput = {
   contentType: string | null;
 };
 
+export type BundleFileInput = {
+  path: string;
+  content: string;
+};
+
 export type VtAnalysisInput = {
   status: string;
   verdict: string | null;
@@ -119,6 +124,7 @@ export type ArtifactExportInput = {
   version: string;
   artifactSha256: string | null;
   skillMdContentRedacted?: string | null;
+  bundleFilesRedacted?: BundleFileInput[] | null;
   createdAt: number;
   softDeletedAt: number | null;
   files: ExportFileInput[];
@@ -147,6 +153,12 @@ export type ArtifactRow = {
   version: string;
   artifact_sha256: string | null;
   skill_md_content_redacted?: string | null;
+  bundle_files_redacted?: Array<{
+    path: string;
+    content: string;
+    sha256: string;
+    size_bytes: number;
+  }>;
   created_at: number;
   created_month: string;
   soft_deleted: boolean;
@@ -247,6 +259,7 @@ export type NormalizedDatasetRows = {
 const SPLIT_VERSION = "sha256-v1";
 const MAX_REDACTED_TEXT_LENGTH = 240;
 const MAX_REDACTED_SKILL_CONTENT_LENGTH = 120_000;
+const MAX_REDACTED_BUNDLE_FILE_BYTES = 192 * 1024;
 const CLAWSCAN_SEVERITIES = new Set<ClawScanSeverity>([
   "none",
   "info",
@@ -332,6 +345,7 @@ export function assignSplit(splitKey: string): DatasetSplit {
 }
 
 function buildArtifactRow(input: ArtifactExportInput, artifactId: string): ArtifactRow {
+  const bundleFiles = buildBundleFileRows(input);
   return {
     artifact_id: artifactId,
     source_kind: input.sourceKind,
@@ -347,6 +361,7 @@ function buildArtifactRow(input: ArtifactExportInput, artifactId: string): Artif
     ...(input.sourceKind === "skill" && input.skillMdContentRedacted
       ? { skill_md_content_redacted: redactSkillContent(input.skillMdContentRedacted) }
       : {}),
+    ...(bundleFiles.length > 0 ? { bundle_files_redacted: bundleFiles } : {}),
     created_at: input.createdAt,
     created_month: createdMonth(input.createdAt),
     soft_deleted: input.softDeletedAt !== null,
@@ -364,6 +379,38 @@ function buildArtifactRow(input: ArtifactExportInput, artifactId: string): Artif
     has_static_scan: input.staticScan !== null,
     has_llm_scan: input.llmAnalysis !== null,
   };
+}
+
+function buildBundleFileRows(
+  input: ArtifactExportInput,
+): NonNullable<ArtifactRow["bundle_files_redacted"]> {
+  if (input.sourceKind !== "skill" || !Array.isArray(input.bundleFilesRedacted)) return [];
+  return input.bundleFilesRedacted.flatMap((file) => {
+    const path = file.path.trim();
+    if (!path || !file.content) return [];
+    const content = redactBundleContent(file.content);
+    if (Buffer.byteLength(content, "utf8") > MAX_REDACTED_BUNDLE_FILE_BYTES) return [];
+    return [
+      {
+        path,
+        content,
+        sha256: hashString(content),
+        size_bytes: Buffer.byteLength(content, "utf8"),
+      },
+    ];
+  });
+}
+
+export function redactBundleContent(value: string) {
+  let redacted = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    redacted += code < 32 && code !== 9 && code !== 10 && code !== 13 ? " " : value.charAt(index);
+  }
+  for (const pattern of SECRET_PATTERNS) {
+    redacted = redacted.replace(pattern, "[REDACTED_SECRET]");
+  }
+  return redacted;
 }
 
 function qualifiedPublicSlug(input: ArtifactExportInput) {


### PR DESCRIPTION
## Summary
- hydrate/redact authored skill bundle files during security dataset export
- exclude root `SKILL.md` / `skills.md` and generated root `skill-card.md`, while preserving nested authored files
- emit redacted bundle file content with `sha256` and `size_bytes`, capped to keep Convex snapshot output under CLI limits
- bump dataset redaction policy to `public-signals-v2-bundle-files`

## Tests
- `bun run ci:static`
- `bun run test -- scripts/security-dataset/convexExport.test.ts scripts/security-dataset/normalize.test.ts`
- `bunx tsc --noEmit --pretty false`
- `git diff --check`
- autoreview: clean, no accepted/actionable findings

## Notes
- True production snapshot smoke is blocked until these backend functions are deployed; prod currently lacks the new `securityDataset:*` functions.
