### PR TITLE
fix(web): add profile link to avatar menu

### DIFF
--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -6,6 +6,7 @@ import {
   listPublicPage,
   listPublic,
   listMine,
+  getMyProfileHandle,
   getProfileByHandle,
   listMembers,
   listPublishedPage,
@@ -145,6 +146,10 @@ const recoverPersonalPublisherInternalHandler = (
 
 const listMineHandler = (
   listMine as unknown as WrappedHandler<Record<string, never>, Array<unknown>>
+)._handler;
+
+const getMyProfileHandleHandler = (
+  getMyProfileHandle as unknown as WrappedHandler<Record<string, never>, string | null>
 )._handler;
 
 const listPublicHandler = (
@@ -3644,6 +3649,150 @@ describe("publisher bootstrap", () => {
         }),
       }),
     ]);
+  });
+
+  it("returns the linked personal publisher handle instead of a stale user handle", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:owner" as never);
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "users:owner") {
+            return {
+              _id: id,
+              handle: "stale-user-handle",
+              personalPublisherId: "publishers:stale",
+            };
+          }
+          if (id === "publishers:stale") {
+            return {
+              _id: id,
+              kind: "user",
+              handle: "old-profile",
+              linkedUserId: "users:previous-owner",
+            };
+          }
+          return null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table !== "publishers") throw new Error(`unexpected table ${table}`);
+          return {
+            withIndex: vi.fn((indexName: string, builder: (q: unknown) => unknown) => {
+              if (indexName !== "by_linked_user") throw new Error(`unexpected index ${indexName}`);
+              const values = new Map<string, unknown>();
+              builder({
+                eq: vi.fn((field: string, value: unknown) => {
+                  values.set(field, value);
+                  return {};
+                }),
+              });
+              return {
+                unique: vi.fn().mockResolvedValue(
+                  values.get("linkedUserId") === "users:owner"
+                    ? {
+                        _id: "publishers:current",
+                        kind: "user",
+                        handle: "real-profile",
+                        linkedUserId: "users:owner",
+                      }
+                    : null,
+                ),
+              };
+            }),
+          };
+        }),
+      },
+    };
+
+    await expect(getMyProfileHandleHandler(ctx as never, {})).resolves.toBe("real-profile");
+  });
+
+  it("keeps legacy personal publisher handles when the direct pointer is valid", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:legacy" as never);
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "users:legacy") {
+            return {
+              _id: id,
+              handle: "legacy-user",
+              personalPublisherId: "publishers:legacy-profile",
+            };
+          }
+          if (id === "publishers:legacy-profile") {
+            return {
+              _id: id,
+              kind: "user",
+              handle: "legacy-profile",
+              linkedUserId: undefined,
+            };
+          }
+          return null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table !== "publisherMembers") throw new Error(`unexpected table ${table}`);
+          return {
+            withIndex: vi.fn(() => ({
+              unique: vi.fn().mockResolvedValue({
+                publisherId: "publishers:legacy-profile",
+                userId: "users:legacy",
+                role: "owner",
+              }),
+            })),
+          };
+        }),
+      },
+    };
+
+    await expect(getMyProfileHandleHandler(ctx as never, {})).resolves.toBe("legacy-profile");
+  });
+
+  it("ignores stale legacy personal publisher pointers without owner membership", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:legacy" as never);
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "users:legacy") {
+            return {
+              _id: id,
+              personalPublisherId: "publishers:stale-legacy",
+            };
+          }
+          if (id === "publishers:stale-legacy") {
+            return {
+              _id: id,
+              kind: "user",
+              handle: "stale-legacy-profile",
+              linkedUserId: undefined,
+            };
+          }
+          return null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table === "publisherMembers") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue(null),
+              })),
+            };
+          }
+          if (table === "publishers") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue({
+                  _id: "publishers:linked",
+                  kind: "user",
+                  handle: "linked-profile",
+                  linkedUserId: "users:legacy",
+                }),
+              })),
+            };
+          }
+          throw new Error(`unexpected table ${table}`);
+        }),
+      },
+    };
+
+    await expect(getMyProfileHandleHandler(ctx as never, {})).resolves.toBe("linked-profile");
   });
 
   it("returns every published item for mine listings so deletion confirmations are complete", async () => {

--- a/convex/publishers.ts
+++ b/convex/publishers.ts
@@ -1834,6 +1834,34 @@ export const getByHandle = query({
     await toPublicPublisherWithLinkedImage(ctx, await getPublisherByHandle(ctx, args.handle)),
 });
 
+export const getMyProfileHandle = query({
+  args: {},
+  handler: async (ctx) => {
+    const userId = await getOptionalActiveAuthUserId(ctx);
+    if (!userId) return null;
+    const user = await ctx.db.get(userId);
+    if (!user || user.deletedAt || user.deactivatedAt) return null;
+
+    if (user.personalPublisherId) {
+      const directPublisher = await ctx.db.get(user.personalPublisherId);
+      if (directPublisher?.kind === "user" && isPublisherActive(directPublisher)) {
+        if (directPublisher.linkedUserId === user._id) return directPublisher.handle;
+        if (!directPublisher.linkedUserId) {
+          const legacyMembership = await getPublisherMembership(ctx, directPublisher._id, user._id);
+          if (legacyMembership?.role === "owner") return directPublisher.handle;
+        }
+      }
+    }
+
+    const linkedPublisher = await getPersonalPublisherForUser(ctx, user._id);
+    if (linkedPublisher?.kind === "user" && isPublisherActive(linkedPublisher)) {
+      return linkedPublisher.handle;
+    }
+
+    return null;
+  },
+});
+
 export const getProfileByHandle = query({
   args: { handle: v.string() },
   handler: async (ctx, args) => {

--- a/e2e/local-auth/header-profile-link.pw.test.ts
+++ b/e2e/local-auth/header-profile-link.pw.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+import { expectHealthyPage, trackRuntimeErrors, waitForHydration } from "../helpers/runtimeErrors";
+import { signInAsLocalPersona } from "./helpers";
+
+test.skip(
+  process.env.VITE_ENABLE_DEV_AUTH !== "1",
+  "local-auth header profile tests require the local dev auth runner",
+);
+
+test("signed-in avatar menu links to the user's public profile", async ({ page }) => {
+  const errors = trackRuntimeErrors(page);
+  const handle = await signInAsLocalPersona(page, "owner");
+
+  await page.keyboard.press("Escape");
+  await page.locator("header .user-trigger").click();
+
+  const profileLink = page.getByRole("menuitem", {
+    name: "Profile",
+  });
+  await expect(profileLink).toBeVisible();
+  await expect(profileLink).toHaveAttribute("href", `/user/${handle}`);
+
+  await profileLink.click();
+  await page.waitForURL(`**/user/${handle}`);
+  await waitForHydration(page);
+
+  await expect(page.getByRole("heading", { name: "Local Owner" })).toBeVisible();
+  await expectHealthyPage(page, errors);
+});

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -5,6 +5,7 @@ import { resolve } from "node:path";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type { AriaAttributes, ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../convex/_generated/api";
 
 type HeaderAuthStatus = {
   isAuthenticated: boolean;
@@ -13,8 +14,9 @@ type HeaderAuthStatus = {
 };
 
 const navigateMock = vi.fn();
-const { signInMock, useUnifiedSearchMock } = vi.hoisted(() => ({
+const { signInMock, useQueryMock, useUnifiedSearchMock } = vi.hoisted(() => ({
   signInMock: vi.fn(),
+  useQueryMock: vi.fn(),
   useUnifiedSearchMock: vi.fn(),
 }));
 
@@ -64,11 +66,23 @@ const defaultUnifiedSearchResult = {
 };
 
 vi.mock("@tanstack/react-router", () => ({
-  Link: (props: { children: ReactNode; className?: string; hash?: string; to?: string }) => (
-    <a href={`${props.to ?? "/"}${props.hash ? `#${props.hash}` : ""}`} className={props.className}>
-      {props.children}
-    </a>
-  ),
+  Link: (props: {
+    children: ReactNode;
+    className?: string;
+    hash?: string;
+    params?: Record<string, string>;
+    to?: string;
+  }) => {
+    let href = props.to ?? "/";
+    for (const [key, value] of Object.entries(props.params ?? {})) {
+      href = href.replace(`$${key}`, encodeURIComponent(value));
+    }
+    return (
+      <a href={`${href}${props.hash ? `#${props.hash}` : ""}`} className={props.className}>
+        {props.children}
+      </a>
+    );
+  },
   useLocation: () => ({ pathname: "/" }),
   useNavigate: () => navigateMock,
 }));
@@ -78,6 +92,10 @@ vi.mock("@convex-dev/auth/react", () => ({
     signIn: signInMock,
     signOut: vi.fn(),
   }),
+}));
+
+vi.mock("convex/react", () => ({
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
 }));
 
 const authStatusMock = vi.fn<() => HeaderAuthStatus>(() => ({
@@ -220,6 +238,7 @@ describe("Header", () => {
       me: null,
     });
     useUnifiedSearchMock.mockReturnValue(defaultUnifiedSearchResult);
+    useQueryMock.mockReturnValue(null);
     signInMock.mockReset();
     signInMock.mockResolvedValue({ signingIn: true });
   });
@@ -493,7 +512,8 @@ describe("Header", () => {
     expect(labels.slice(0, 4)).toEqual(["Home", "Skills", "Plugins", "Docs"]);
   });
 
-  it("links starred skills from the signed-in avatar menu", () => {
+  it("links account destinations from the signed-in avatar menu", () => {
+    useQueryMock.mockReturnValue("patrick-public");
     authStatusMock.mockReturnValue({
       isAuthenticated: true,
       isLoading: false,
@@ -508,6 +528,10 @@ describe("Header", () => {
 
     render(<Header />);
 
+    expect(useQueryMock).toHaveBeenCalledWith(api.publishers.getMyProfileHandle, {});
+    expect(screen.getByText("Profile").closest("a")?.getAttribute("href")).toBe(
+      "/user/patrick-public",
+    );
     expect(screen.getByText("Stars").closest("a")?.getAttribute("href")).toBe("/stars");
     expect(screen.getAllByText("Dashboard").length).toBeGreaterThan(0);
     expect(screen.getByText("Settings")).toBeTruthy();

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import { useAuthActions } from "@convex-dev/auth/react";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
+import { useQuery } from "convex/react";
 import {
   ArrowRight,
   ChevronDown,
@@ -11,8 +12,10 @@ import {
   Settings,
   Star,
   Sun,
+  User,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { api } from "../../convex/_generated/api";
 import {
   getUserFacingAuthError,
   isBannedAccountAuthError,
@@ -89,7 +92,12 @@ export default function Header() {
   const rawHandle = me?.handle ?? me?.displayName ?? "user";
   const handle = rawHandle.length > 25 ? `${rawHandle.slice(0, 25)}…` : rawHandle;
   const initial = (me?.displayName ?? me?.name ?? rawHandle).charAt(0).toUpperCase();
+  const hasResolvedUser = Boolean(me);
   const isAuthResolving = isLoading || (isAuthenticated && me === undefined);
+  const profileHandle = useQuery(
+    api.publishers.getMyProfileHandle,
+    hasResolvedUser ? {} : "skip",
+  ) as string | null | undefined;
   const signInRedirectTo = getCurrentRelativeUrl();
 
   const [navSearchQuery, setNavSearchQuery] = useState("");
@@ -411,6 +419,18 @@ export default function Header() {
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="user-dropdown-content">
+                  {profileHandle ? (
+                    <DropdownMenuItem asChild>
+                      <Link
+                        to="/user/$handle"
+                        params={{ handle: profileHandle }}
+                        className="flex items-center gap-2"
+                      >
+                        <User size={14} aria-hidden="true" />
+                        Profile
+                      </Link>
+                    </DropdownMenuItem>
+                  ) : null}
                   <DropdownMenuItem asChild>
                     <Link to="/dashboard" className="flex items-center gap-2">
                       <LayoutDashboard size={14} aria-hidden="true" />


### PR DESCRIPTION
## Summary

- Adds a Profile item to the signed-in avatar menu.
- Resolves the route from the active personal publisher handle instead of the user handle.
- Preserves legacy personal publishers only when the signed-in user is still an owner.

## Screenshots

![Signed-in avatar menu with Profile item](https://fancy-citrus-kvrj.here.now/droppie-2026-06-15T17-11-11Z.png)

- [x] Screenshots/recordings attached

## Behavioural Proof

Signed in with the local-auth Owner/User fixture, opened the avatar menu, followed **Profile**, and verified navigation to the matching public publisher page.

- [x] Behavioural proof included

## Security / Trust Impact

- [x] No security/trust impact

## Data / Deploy Impact

- [x] No schema, migration, or deploy sequencing impact

## Verification

- [x] `bun run ci:static`
- [x] `bun run test -- convex/publishers.test.ts src/__tests__/header.test.tsx`
- [x] `bun run ci:unit`
- [x] `bun run ci:types-build`
- [x] `bun run test:pw:local-auth -- --project=chromium e2e/local-auth/header-profile-link.pw.test.ts`
