### PR TITLE
feat(cli): print stored auth token

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -72,6 +72,12 @@ Override the path with:
 export CLAWHUB_CONFIG_PATH=/path/to/config.json
 ```
 
+Print the stored token for CI setup with:
+
+```bash
+clawhub token
+```
+
 ## Revocation
 
 You can revoke API tokens in the ClawHub web UI.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -89,6 +89,11 @@ Stores your API token + cached registry URL.
 
 - Verifies the stored token via `/api/v1/whoami`.
 
+### `token`
+
+- Prints the stored API token to stdout.
+- Useful for piping a local login token into CI secret setup commands.
+
 ### `star <slug>` / `unstar <slug>`
 
 - Adds/removes a skill from your highlights.

--- a/packages/clawhub/README.md
+++ b/packages/clawhub/README.md
@@ -24,6 +24,9 @@ clawhub login --device
 
 # or (token paste / headless)
 clawhub login --token clh_...
+
+# print the stored token for CI setup
+clawhub token
 ```
 
 Notes:

--- a/packages/clawhub/src/cli.ts
+++ b/packages/clawhub/src/cli.ts
@@ -4,7 +4,7 @@ import { join, resolve } from "node:path";
 import { Command } from "commander";
 import { getCliBuildLabel, getCliVersion } from "./cli/buildInfo.js";
 import { resolveClawdbotDefaultWorkspace } from "./cli/clawdbotConfig.js";
-import { cmdLoginFlow, cmdLogout, cmdWhoami } from "./cli/commands/auth.js";
+import { cmdLoginFlow, cmdLogout, cmdToken, cmdWhoami } from "./cli/commands/auth.js";
 import {
   cmdDeleteSkill,
   cmdHideSkill,
@@ -217,6 +217,12 @@ registerCommand(program, ["whoami"])
   .action(async () => {
     const opts = await resolveGlobalOpts();
     await cmdWhoami(opts);
+  });
+
+registerCommand(program, ["token"])
+  .description("Print stored API token")
+  .action(async () => {
+    await cmdToken();
   });
 
 const auth = registerCommandGroup(program, ["auth"])

--- a/packages/clawhub/src/cli/commands/auth.test.ts
+++ b/packages/clawhub/src/cli/commands/auth.test.ts
@@ -16,7 +16,7 @@ const registryMocks = createRegistryModuleMocks();
 const mockGetRegistry = registryMocks.getRegistry;
 vi.mock("../registry.js", () => registryMocks.moduleFactory());
 
-const { cmdLogout } = await import("./auth");
+const { cmdLogout, cmdToken } = await import("./auth");
 
 const mockLog = vi.spyOn(console, "log").mockImplementation(() => {});
 
@@ -52,5 +52,18 @@ describe("cmdLogout", () => {
       registry: "https://registry.example",
       token: undefined,
     });
+  });
+});
+
+describe("cmdToken", () => {
+  it("prints the stored token", async () => {
+    mockReadGlobalConfig.mockResolvedValueOnce({
+      registry: "https://clawhub.ai",
+      token: "clh_test",
+    });
+
+    await cmdToken();
+
+    expect(mockLog).toHaveBeenCalledWith("clh_test");
   });
 });

--- a/packages/clawhub/src/cli/commands/auth.ts
+++ b/packages/clawhub/src/cli/commands/auth.ts
@@ -98,6 +98,11 @@ export async function cmdWhoami(opts: GlobalOpts) {
   }
 }
 
+export async function cmdToken() {
+  const token = await requireAuthToken();
+  console.log(token);
+}
+
 /**
  * Device Flow login for headless environments.
  * Requests a device code, displays it to the user, then polls until authorized.


### PR DESCRIPTION
## Summary

Adds `clawhub token`, a top-level CLI command that prints the currently stored ClawHub API token to stdout.

This gives CI setup a simple, cross-platform path because it reuses the same config reader that `clawhub login` writes to, instead of asking users to know the OS-specific config file location.

Also updates the publishing docs so skill publishing starts with the CLI `clawhub sync` flow, then shows the manual GitHub Actions workflow shape for dry-runs, single-skill publishes, and full catalog publishes.

Example:

```bash
clawhub login --label "NVIDIA skills GitHub Actions"

gh secret set CLAWHUB_TOKEN \
  --repo NVIDIA/skills \
  --body "$(clawhub token)"
```

## Validation

- `bunx vitest run -c vitest.config.ts src/cli/commands/auth.test.ts`
- `CLAWHUB_CONFIG_PATH=<temp config> bun src/cli.ts token`
- `bun run format:check -- docs/cli.md docs/auth.md packages/clawhub/README.md packages/clawhub/src/cli.ts packages/clawhub/src/cli/commands/auth.ts packages/clawhub/src/cli/commands/auth.test.ts`
- `bun run format:check -- docs/publishing.md`
- `bun run --cwd packages/clawhub verify:build`
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests ""`
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD --parallel-tests ""`
- `bun run --cwd packages/clawhub verify`
