### PR TITLE
Fix skill card metadata layout

### DIFF
--- a/src/components/SkillCard.tsx
+++ b/src/components/SkillCard.tsx
@@ -38,6 +38,11 @@ export function SkillCard({
 
   return (
     <Link to={link} className={["card skill-card", className].filter(Boolean).join(" ")}>
+      <div className="skill-card-header">
+        <MarketplaceIcon kind="skill" label={skill.displayName} icon={skill.icon} size="md" />
+        <h3 className="skill-card-title">{skill.displayName}</h3>
+      </div>
+      <p className="skill-card-summary">{skill.summary ?? summaryFallback}</p>
       {hasTags ? (
         <div className="skill-card-tags">
           {badges.map((label) =>
@@ -56,11 +61,6 @@ export function SkillCard({
           <ApiKeyRequiredBadge apiKeyRequired={apiKeyRequired} />
         </div>
       ) : null}
-      <div className="skill-card-header">
-        <MarketplaceIcon kind="skill" label={skill.displayName} icon={skill.icon} size="md" />
-        <h3 className="skill-card-title">{skill.displayName}</h3>
-      </div>
-      <p className="skill-card-summary">{skill.summary ?? summaryFallback}</p>
       <div className="skill-card-footer">{meta}</div>
     </Link>
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -3195,9 +3195,7 @@ code {
 }
 
 .skill-card-spaced-footer .skill-card-footer {
-  display: flex;
-  flex: 1;
-  margin-top: 0;
+  margin-top: auto;
 }
 
 .skill-card-footer-inline {
@@ -3216,8 +3214,8 @@ code {
 
 .skill-card-spaced-footer .skill-card-footer-rows {
   display: flex;
-  flex: 1;
   flex-direction: column;
+  gap: 8px;
 }
 
 .skill-card-footer-rows .stat {
@@ -3226,8 +3224,8 @@ code {
 
 .skill-card-spaced-footer .skill-card-footer-rows .stat {
   align-self: stretch;
-  margin-top: auto;
-  padding-top: 8px;
+  margin-top: 0;
+  padding-top: 0;
 }
 
 .skill-card-statline,


### PR DESCRIPTION
## Summary

- Move skill card tag/platform pills below the description.
- Keep the author and updated/stat rows grouped together at the bottom of grid cards.

## Linked Issue

- N/A

## Screenshots

| Before (origin/main) | After (this PR) |
| --- | --- |
| <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-2465/skill-card-grid-context-1780331337362/baseline/desktop-grid-context.png" width="420" alt="Before desktop skills grid with nearby cards and tags above the description"> | <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-2465/skill-card-grid-context-1780331337362/candidate/desktop-grid-context.png" width="420" alt="After desktop skills grid with nearby cards and tags below the description"> |
| <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-2465/skill-card-grid-context-1780331337362/baseline/mobile-grid-context.png" width="420" alt="Before mobile skills grid with nearby cards and tags above the description"> | <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-2465/skill-card-grid-context-1780331337362/candidate/mobile-grid-context.png" width="420" alt="After mobile skills grid with nearby cards and tags below the description"> |

Raw proof files: https://github.com/openclaw/clawhub/tree/qa-artifacts/clawhub-ui-proof/pr-2465/skill-card-grid-context-1780331337362

- [x] Screenshots/recordings attached, or `N/A`

## Behavioural Proof

Tested `/skills?view=grid` against the `Self-Improving + Proactive Agent` card in desktop and mobile grid context, with nearby skill cards visible. The candidate layout renders title, description, platform pills, then the grouped author/update footer.

- [x] Behavioural proof included, or `N/A`

## Security / Trust Impact

- [x] No security/trust impact
- [ ] Security/trust impact explained

## Data / Deploy Impact

- [x] No data/deploy impact
- [ ] Data/deploy impact explained

## Verification

- [ ] `bun run ci:static`
- [x] Focused adjacent tests: `bun run test src/__tests__/ui-design-contract.test.ts src/components/SkillCard.test.tsx`
- [ ] `bun run ci:unit` or `N/A` for docs/config-only: N/A, focused UI tests only
- [ ] Broader gate when required (`ci:types-build`, `ci:packages`, `ci:e2e-http`, `ci:playwright-smoke`, `test:pw:local-auth`, `proof:ui`): N/A for scoped card layout change
- [x] Other: `bun run lint`; `bun run format:check`; local before/after Playwright screenshots at 390px and 1440px widths


