### PR TITLE
Add security audit download export

### DIFF
--- a/src/__tests__/plugin-security-audit-route.test.tsx
+++ b/src/__tests__/plugin-security-audit-route.test.tsx
@@ -61,6 +61,7 @@ describe("plugin security audit route", () => {
 
     render(<PluginSecurityAuditPage name="demo-plugin" loaderData={makeLoaderData() as never} />);
 
+    expect(screen.getByRole("button", { name: "Download security audit" })).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Rescan" }));
 
     await waitFor(() =>
@@ -77,5 +78,6 @@ describe("plugin security audit route", () => {
     render(<PluginSecurityAuditPage name="demo-plugin" loaderData={makeLoaderData() as never} />);
 
     expect(screen.queryByRole("button", { name: "Rescan" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Download security audit" })).toBeNull();
   });
 });

--- a/src/__tests__/skill-security-scanner-route.test.tsx
+++ b/src/__tests__/skill-security-scanner-route.test.tsx
@@ -124,6 +124,7 @@ describe("skill security audit route", () => {
 
     render(<Component />);
 
+    expect(screen.getByRole("button", { name: "Download security audit" })).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Rescan" }));
 
     await waitFor(() =>

--- a/src/components/SecurityAuditPage.tsx
+++ b/src/components/SecurityAuditPage.tsx
@@ -1,7 +1,12 @@
-import { Check, Clock, ExternalLink, Info, RefreshCw, TriangleAlert } from "lucide-react";
+import { Check, Clock, Download, ExternalLink, Info, RefreshCw, TriangleAlert } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { Id } from "../../convex/_generated/dataModel";
 import { getRuntimeEnv } from "../lib/runtimeEnv";
+import {
+  buildSecurityAuditExportFilename,
+  buildSecurityAuditExportZip,
+  type StaticScan,
+} from "../lib/securityAuditExport";
 import {
   aggregateAuditVerdict,
   AUDIT_SCANNER_LABELS,
@@ -51,6 +56,7 @@ type SecurityAuditPageProps = {
   vtAnalysis?: VtAnalysis | null;
   llmAnalysis?: LlmAnalysis | null;
   skillSpectorAnalysis?: SkillSpectorAnalysis | null;
+  staticScan?: StaticScan | null;
   source?: Record<string, unknown> | null;
   canManageArtifact?: boolean;
   onRequestRescan?: (() => Promise<unknown>) | null;
@@ -733,6 +739,20 @@ function SecurityAuditSidebar(props: SecurityAuditPageProps) {
     }
   }
 
+  function downloadAuditExport() {
+    if (!showRescanButton || typeof document === "undefined" || typeof URL === "undefined") return;
+    const zipBytes = buildSecurityAuditExportZip(props);
+    const filename = buildSecurityAuditExportFilename(props);
+    const url = URL.createObjectURL(new Blob([zipBytes], { type: "application/zip" }));
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.append(anchor);
+    anchor.click();
+    anchor.remove();
+    window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+
   const versionValue = (
     <div className="security-audit-version-stack">
       <span>{props.entity.version ?? "Latest"}</span>
@@ -751,6 +771,16 @@ function SecurityAuditSidebar(props: SecurityAuditPageProps) {
               <RefreshCw className="security-audit-rescan-icon" aria-hidden="true" />
             ) : null}
             <span>{isRescanBusy ? "Scanning" : "Rescan"}</span>
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            className="skill-sidebar-action-button security-audit-download-button"
+            onClick={downloadAuditExport}
+            aria-label="Download security audit"
+          >
+            <Download className="security-audit-action-icon" aria-hidden="true" />
+            <span>Download</span>
           </Button>
           {rescanState === "error" ? (
             <span className="security-audit-rescan-error" role="status">

--- a/src/components/SkillSecurityScanResults.test.tsx
+++ b/src/components/SkillSecurityScanResults.test.tsx
@@ -1,11 +1,18 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { unzipSync } from "fflate";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildSecurityAuditExportEntries,
+  buildSecurityAuditExportZip,
+  type StaticScan,
+} from "../lib/securityAuditExport";
 import { SecurityAuditPage } from "./SecurityAuditPage";
 import {
   getSkillSpectorIssueCount,
   SecurityScanResults,
   type LlmAnalysis,
   type SkillSpectorAnalysis,
+  type VtAnalysis,
 } from "./SkillSecurityScanResults";
 
 const clawScanAnalysis: LlmAnalysis = {
@@ -157,6 +164,37 @@ const skillSpectorAnalysis: SkillSpectorAnalysis = {
         "Make the manifest and body accurately describe the same skill, and reject deceptive metadata.",
     },
   ],
+};
+
+const staticScan: StaticScan = {
+  status: "suspicious",
+  reasonCodes: ["static.network_request"],
+  findings: [
+    {
+      code: "static.network_request",
+      severity: "warn",
+      file: "SKILL.md",
+      line: 12,
+      message: "Network request found in skill instructions.",
+      evidence: "curl https://collect.example/upload",
+    },
+  ],
+  summary: "Static analysis found an external network request.",
+  engineVersion: "static-publish-scan@1",
+  checkedAt: Date.now(),
+};
+
+const vtAnalysis: VtAnalysis = {
+  status: "suspicious",
+  verdict: "engines",
+  source: "engines",
+  engineStats: {
+    malicious: 1,
+    suspicious: 1,
+    harmless: 2,
+    undetected: 58,
+  },
+  checkedAt: Date.now(),
 };
 
 const originalFetch = globalThis.fetch;
@@ -1026,6 +1064,55 @@ describe("SecurityScanResults static guidance", () => {
     ).toEqual(["Overview", "SkillSpector", "VirusTotal"]);
   });
 
+  it("builds a security audit ZIP with scanner outcome files", () => {
+    const input = {
+      entity: {
+        kind: "skill" as const,
+        title: "Pattern Guard",
+        name: "pattern-guard",
+        version: "1.2.3",
+        detailPath: "/local/pattern-guard",
+      },
+      sha256hash: "a".repeat(64),
+      llmAnalysis: clawScanAnalysis,
+      skillSpectorAnalysis,
+      staticScan,
+      vtAnalysis,
+      exportedAt: "2026-06-02T15:00:00.000Z",
+    };
+
+    expect(buildSecurityAuditExportEntries(input).map((entry) => entry.path)).toEqual([
+      "manifest.json",
+      "clawscan.json",
+      "skillspector.json",
+      "static-analysis.json",
+      "virustotal.json",
+    ]);
+
+    const zipEntries = unzipSync(buildSecurityAuditExportZip(input));
+    const decode = (path: string) => new TextDecoder().decode(zipEntries[path]);
+
+    expect(Object.keys(zipEntries).sort()).toEqual([
+      "README.md",
+      "clawscan.json",
+      "manifest.json",
+      "skillspector.json",
+      "static-analysis.json",
+      "virustotal.json",
+    ]);
+    expect(JSON.parse(decode("manifest.json")).scanners).toEqual({
+      clawscan: "suspicious",
+      skillspector: "suspicious",
+      staticAnalysis: "suspicious",
+      virustotal: "suspicious",
+    });
+    expect(JSON.parse(decode("skillspector.json")).issues[0].issueId).toBe("SDI-1");
+    expect(JSON.parse(decode("static-analysis.json")).findings[0].code).toBe(
+      "static.network_request",
+    );
+    expect(JSON.parse(decode("virustotal.json")).engineStats.malicious).toBe(1);
+  });
+
   it("shows plugins with legacy ClawScan analysis in the new ClawScan report shell", () => {
     render(
       <SecurityAuditPage
@@ -1164,10 +1251,28 @@ describe("SecurityScanResults static guidance", () => {
       />,
     );
 
+    expect(screen.getByRole("button", { name: "Download security audit" })).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Rescan" }));
 
     await waitFor(() => expect(requestRescan).toHaveBeenCalledTimes(1));
     expect(screen.getByRole("button", { name: "Scanning" })).toHaveProperty("disabled", true);
+  });
+
+  it("hides security audit downloads when rescans are not available", () => {
+    render(
+      <SecurityAuditPage
+        entity={{
+          kind: "skill",
+          title: "Public Guard",
+          name: "public-guard",
+          version: "1.0.0",
+          detailPath: "/local/public-guard",
+        }}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Rescan" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Download security audit" })).toBeNull();
   });
 
   it("lets plugin managers use the shared security rescan control", async () => {

--- a/src/lib/securityAuditExport.ts
+++ b/src/lib/securityAuditExport.ts
@@ -1,0 +1,124 @@
+import { strToU8, zipSync } from "fflate";
+import type {
+  LlmAnalysis,
+  SkillSpectorAnalysis,
+  VtAnalysis,
+} from "../components/SkillSecurityScanResults";
+
+type SecurityAuditExportEntity = {
+  kind: "skill" | "plugin";
+  title: string;
+  name: string;
+  version?: string | null;
+  detailPath: string;
+};
+
+type StaticScanFinding = {
+  code: string;
+  severity: string;
+  file: string;
+  line: number;
+  message: string;
+  evidence: string;
+};
+
+export type StaticScan = {
+  status: string;
+  reasonCodes: string[];
+  findings: StaticScanFinding[];
+  summary: string;
+  engineVersion: string;
+  checkedAt: number;
+};
+
+type SecurityAuditExportInput = {
+  entity: SecurityAuditExportEntity;
+  sha256hash?: string | null;
+  vtAnalysis?: VtAnalysis | null;
+  llmAnalysis?: LlmAnalysis | null;
+  skillSpectorAnalysis?: SkillSpectorAnalysis | null;
+  staticScan?: StaticScan | null;
+  exportedAt?: string;
+};
+
+type SecurityAuditExportEntry = {
+  path: string;
+  value: unknown;
+};
+
+const EXPORT_README = `# ClawHub Security Audit Export
+
+This archive contains stored scanner outcomes for one ClawHub artifact version.
+
+- manifest.json: artifact metadata for the export
+- clawscan.json: ClawScan risk review and final audit verdict material
+- skillspector.json: SkillSpector agentic-risk findings
+- static-analysis.json: deterministic static scan context
+- virustotal.json: VirusTotal engine telemetry
+`;
+
+function sanitizeFilenameSegment(value: string) {
+  return (
+    value
+      .trim()
+      .replace(/^@/, "")
+      .replace(/[/\\:]+/g, "-")
+      .replace(/[^a-zA-Z0-9._-]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 120) || "artifact"
+  );
+}
+
+export function buildSecurityAuditExportFilename(input: SecurityAuditExportInput) {
+  const name = sanitizeFilenameSegment(input.entity.name);
+  const version = sanitizeFilenameSegment(input.entity.version ?? "latest");
+  return `${name}-${version}-security-audit.zip`;
+}
+
+function toPrettyJson(value: unknown) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+export function buildSecurityAuditExportEntries(input: SecurityAuditExportInput) {
+  const exportedAt = input.exportedAt ?? new Date().toISOString();
+  const entries: SecurityAuditExportEntry[] = [
+    {
+      path: "manifest.json",
+      value: {
+        exportedAt,
+        artifact: {
+          kind: input.entity.kind,
+          title: input.entity.title,
+          name: input.entity.name,
+          version: input.entity.version ?? null,
+          detailPath: input.entity.detailPath,
+          sha256hash: input.sha256hash ?? null,
+        },
+        scanners: {
+          clawscan: input.llmAnalysis?.status ?? null,
+          skillspector: input.skillSpectorAnalysis?.status ?? null,
+          staticAnalysis: input.staticScan?.status ?? null,
+          virustotal: input.vtAnalysis?.status ?? null,
+        },
+      },
+    },
+    { path: "clawscan.json", value: input.llmAnalysis ?? null },
+    { path: "skillspector.json", value: input.skillSpectorAnalysis ?? null },
+    { path: "static-analysis.json", value: input.staticScan ?? null },
+    { path: "virustotal.json", value: input.vtAnalysis ?? null },
+  ];
+
+  return entries;
+}
+
+export function buildSecurityAuditExportZip(input: SecurityAuditExportInput) {
+  const zipEntries: Record<string, Uint8Array> = {
+    "README.md": strToU8(EXPORT_README),
+  };
+
+  for (const entry of buildSecurityAuditExportEntries(input)) {
+    zipEntries[entry.path] = strToU8(toPrettyJson(entry.value));
+  }
+
+  return Uint8Array.from(zipSync(zipEntries, { level: 6 }));
+}

--- a/src/routes/$owner/$slug/security-audit.tsx
+++ b/src/routes/$owner/$slug/security-audit.tsx
@@ -113,6 +113,7 @@ function SkillSecurityAuditRoute() {
       vtAnalysis={latestVersion.vtAnalysis ?? null}
       llmAnalysis={latestVersion.llmAnalysis ?? null}
       skillSpectorAnalysis={latestVersion.skillSpectorAnalysis ?? null}
+      staticScan={latestVersion.staticScan ?? null}
       canManageArtifact={canManageArtifact}
       onRequestRescan={
         canManageArtifact

--- a/src/routes/plugins/$name/security-audit.tsx
+++ b/src/routes/plugins/$name/security-audit.tsx
@@ -149,6 +149,7 @@ export function PluginSecurityAuditPage({
       vtAnalysis={release.vtAnalysis ?? null}
       llmAnalysis={release.llmAnalysis ?? null}
       skillSpectorAnalysis={release.skillSpectorAnalysis ?? null}
+      staticScan={release.staticScan ?? null}
       canManageArtifact={Boolean(manageContext)}
       onRequestRescan={
         manageContext

--- a/src/styles.css
+++ b/src/styles.css
@@ -4680,6 +4680,7 @@ code {
   margin-top: 4px;
 }
 
+.security-audit-action-icon,
 .security-audit-rescan-icon {
   width: 14px;
   height: 14px;


### PR DESCRIPTION
## Summary
- Add a manager-only Download button under Rescan on security audit pages.
- Generate a ZIP export containing manifest, ClawScan, SkillSpector, static analysis, and VirusTotal JSON outcomes.
- Thread static scan outcomes into skill/plugin audit pages and cover visibility/export behavior with tests.

## Verification
- `bun run test src/components/SkillSecurityScanResults.test.tsx src/__tests__/plugin-security-audit-route.test.tsx src/__tests__/skill-security-scanner-route.test.tsx`
- `bunx tsc --noEmit --pretty false`
- `bun run ci:static`
- `bun run ci:unit`
- `$autoreview` final pass: clean, no accepted/actionable findings

## UI Proof
- Verified locally in the Codex in-app browser at `http://127.0.0.1:3000/plugins/local-scanned-runtime-plugin/security-audit` with owner persona: Rescan and Download are both visible for authorized users.
- Generated a sample ZIP locally with `README.md`, `manifest.json`, `clawscan.json`, `skillspector.json`, `static-analysis.json`, and `virustotal.json`.
