### PR TITLE
feat: show plugin download counts

### DIFF
--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -215,6 +215,31 @@ describe("plugin detail route", () => {
     expect(screen.queryByText("Verified")).toBeNull();
   });
 
+  it("renders plugin download counts in the metadata sidebar", async () => {
+    loaderDataMock = {
+      ...loaderDataMock,
+      detail: {
+        package: {
+          ...loaderDataMock.detail.package!,
+          latestVersion: "1.0.0",
+          stats: { downloads: 1_234, installs: 9, stars: 0, versions: 1 },
+        },
+        owner: null,
+      },
+    };
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    const downloadsLabel = screen.getByText("Downloads");
+    const currentVersionLabel = screen.getByText("Current version");
+    expect(downloadsLabel.compareDocumentPosition(currentVersionLabel)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(screen.getByText("1.2k")).toBeTruthy();
+  });
+
   it("shows plugin settings when the viewer can manage the plugin", async () => {
     useAuthStatusMock.mockReturnValue({
       isAuthenticated: true,
@@ -399,7 +424,7 @@ describe("plugin detail route", () => {
       label?.startsWith("Security audit"),
     );
     expect(securityAuditLabelIndex).toBeGreaterThanOrEqual(0);
-    expect(securityAuditLabelIndex).toBe(sidebarLabels.indexOf("Owner") + 1);
+    expect(securityAuditLabelIndex).toBeGreaterThan(sidebarLabels.indexOf("Downloads"));
     fireEvent.click(capabilitiesTab);
     expect(screen.getByText("Tags")).toBeTruthy();
   });

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -19,6 +19,7 @@ import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
 import { formatRetryDelay } from "../../lib/formatRetryDelay";
+import { formatCompactStat } from "../../lib/numberFormat";
 import { buildPluginMeta } from "../../lib/og";
 import { getOpenClawPackageCandidateNames } from "../../lib/openClawExtensionSlugs";
 import {
@@ -674,6 +675,11 @@ export function PluginDetailPage({
                   ariaLabel="Plugin metadata"
                   density="compact"
                   blocks={[
+                    {
+                      label: "Downloads",
+                      value: formatCompactStat(pkg.stats?.downloads ?? 0),
+                      large: true,
+                    },
                     { label: "Repository", value: sourceRepoLink },
                     { label: "Owner", value: ownerMetadataValue },
                     securitySummary


### PR DESCRIPTION
## Summary
- Show plugin download counts in plugin list/grid cards and expose stats on package list API/schema payloads.
- Add `Most downloaded` as a plugin browse/search sort, backed by `sort=downloads` on plugin/package list endpoints.
- Remove Code Plugin / Bundle Plugin family badges from plugin list and grid rows while keeping the official badge.
- Keep download-sorted package pagination filter-safe and use current package stats when digest rows are stale.

## Tests
- `bun run format:check -- src/components/PluginListItem.tsx`
- `bunx vitest run src/__tests__/packages-route.test.tsx --reporter=dot`
- `bunx vitest run convex/packages.public.test.ts convex/skills.packageCatalog.test.ts convex/httpApiV1.handlers.test.ts src/__tests__/packages-route.test.tsx src/lib/packageApi.test.ts --reporter=dot`
- `bunx tsc --noEmit --pretty false`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit --pretty false`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit --pretty false`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:packages`
- `git diff --check`

## Review
- Initial Codex autoreview reported 3 actionable findings; fixed stale stats, filtered download pagination, and mixed catalog downloads sorting.
- Final automated rerun was blocked locally by recursive `codex review` behavior and unavailable fallback reviewer auth/credits; completed manual diff review after the fixes.

## UI Proof

![Plugin list without family badges](https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-2484/2026-06-05-plugin-list-no-family-badges/candidate/plugin-list-no-family-badges.png)

Proof comment: https://github.com/openclaw/clawhub/pull/2484#issuecomment-4616940181