### PR TITLE
Add shared download metering

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -17,6 +17,7 @@ import type * as crons from "../crons.js";
 import type * as depRegistryScan from "../depRegistryScan.js";
 import type * as devSeed from "../devSeed.js";
 import type * as devSeedExtra from "../devSeedExtra.js";
+import type * as downloadMetrics from "../downloadMetrics.js";
 import type * as downloads from "../downloads.js";
 import type * as functions from "../functions.js";
 import type * as githubAccountAgeBackfill from "../githubAccountAgeBackfill.js";
@@ -161,6 +162,7 @@ declare const fullApi: ApiFromModules<{
   depRegistryScan: typeof depRegistryScan;
   devSeed: typeof devSeed;
   devSeedExtra: typeof devSeedExtra;
+  downloadMetrics: typeof downloadMetrics;
   downloads: typeof downloads;
   functions: typeof functions;
   githubAccountAgeBackfill: typeof githubAccountAgeBackfill;

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -93,4 +93,11 @@ crons.interval(
   {},
 );
 
+crons.interval(
+  "download-metric-dedupe-prune",
+  { hours: 24 },
+  internal.downloadMetrics.pruneDownloadMetricDedupesInternal,
+  {},
+);
+
 export default crons;

--- a/convex/downloadMetrics.test.ts
+++ b/convex/downloadMetrics.test.ts
@@ -1,0 +1,249 @@
+/* @vitest-environment node */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __test,
+  pruneDownloadMetricDedupesInternal,
+  recordDownloadMetricInternal,
+} from "./downloadMetrics";
+
+type WrappedHandler<TArgs, TResult> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
+};
+
+const recordDownloadMetricHandler = (
+  recordDownloadMetricInternal as unknown as WrappedHandler<
+    {
+      target: { kind: "skill"; id: string } | { kind: "package"; id: string };
+      identityKind: "user" | "ip";
+      identityHash: string;
+      dayStart: number;
+      occurredAt?: number;
+    },
+    void
+  >
+)._handler;
+
+const pruneDownloadMetricDedupesHandler = (
+  pruneDownloadMetricDedupesInternal as unknown as WrappedHandler<
+    Record<string, never>,
+    { deleted: number; hasMore: boolean }
+  >
+)._handler;
+
+function makeQueryBuilder() {
+  const builder = {
+    eq: vi.fn(() => builder),
+    lt: vi.fn(() => builder),
+  };
+  return builder;
+}
+
+type QueryBuilder = ReturnType<typeof makeQueryBuilder>;
+
+function makeDb(
+  existingByTable: Record<string, unknown> = {},
+  rowsByTable: Record<string, Array<{ _id: string }>> = {},
+) {
+  const indexCalls: Array<{ table: string; indexName: string; builder: QueryBuilder }> = [];
+  const insert = vi.fn();
+  const unique = vi.fn(async function uniqueForTable(this: { table: string }) {
+    return existingByTable[this.table] ?? null;
+  });
+  const take = vi.fn(async function takeForTable(this: { table: string }, limit: number) {
+    return (rowsByTable[this.table] ?? []).slice(0, limit);
+  });
+  const query = vi.fn((table: string) => ({
+    withIndex: vi.fn((indexName: string, buildQuery: (q: unknown) => unknown) => {
+      const builder = makeQueryBuilder();
+      buildQuery(builder);
+      indexCalls.push({ table, indexName, builder });
+      return {
+        unique: unique.bind({ table }),
+        take: take.bind({ table }),
+      };
+    }),
+  }));
+  const delete_ = vi.fn();
+  return {
+    db: {
+      query,
+      get: vi.fn(),
+      insert,
+      patch: vi.fn(),
+      replace: vi.fn(),
+      delete: delete_,
+      normalizeId: vi.fn(),
+      system: {
+        get: vi.fn(),
+        query: vi.fn(),
+      },
+    },
+    insert,
+    delete_,
+    take,
+    indexCalls,
+  };
+}
+
+describe("download metric helpers", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("uses a day bucket for download dedupe", () => {
+    expect(__test.getDayStart(86_400_000 - 1)).toBe(0);
+    expect(__test.getDayStart(86_400_000)).toBe(86_400_000);
+  });
+
+  it("prefers user identity and falls back to IP identity", () => {
+    const request = new Request("https://example.com", {
+      headers: { "cf-connecting-ip": "203.0.113.10" },
+    });
+
+    expect(__test.getDownloadIdentity(request, "users:one")).toEqual({
+      identityKind: "user",
+      identityValue: "users:one",
+    });
+    expect(__test.getDownloadIdentity(request, null)).toEqual({
+      identityKind: "ip",
+      identityValue: "203.0.113.10",
+    });
+  });
+
+  it("does not create a metering identity when user and IP are missing", () => {
+    expect(__test.getDownloadIdentity(new Request("https://example.com"), null)).toBeNull();
+  });
+
+  it("records one authenticated skill download and emits the existing skill stat event", async () => {
+    const { db, insert, indexCalls } = makeDb();
+
+    await recordDownloadMetricHandler(
+      { db },
+      {
+        target: { kind: "skill", id: "skills:one" },
+        identityKind: "user",
+        identityHash: "hash-user",
+        dayStart: 86_400_000,
+        occurredAt: 86_500_000,
+      },
+    );
+
+    expect(indexCalls[0]?.table).toBe("downloadMetricDedupes");
+    expect(indexCalls[0]?.indexName).toBe("by_target_identity_day");
+    expect(indexCalls[0]?.builder.eq).toHaveBeenCalledWith("targetKind", "skill");
+    expect(indexCalls[0]?.builder.eq).toHaveBeenCalledWith("targetId", "skills:one");
+    expect(indexCalls[0]?.builder.eq).toHaveBeenCalledWith("identityKind", "user");
+    expect(indexCalls[0]?.builder.eq).toHaveBeenCalledWith("identityHash", "hash-user");
+    expect(indexCalls[0]?.builder.eq).toHaveBeenCalledWith("dayStart", 86_400_000);
+    expect(insert).toHaveBeenCalledWith(
+      "downloadMetricDedupes",
+      expect.objectContaining({
+        targetKind: "skill",
+        targetId: "skills:one",
+        identityKind: "user",
+        identityHash: "hash-user",
+        dayStart: 86_400_000,
+      }),
+    );
+    expect(insert).toHaveBeenCalledWith(
+      "skillStatEvents",
+      expect.objectContaining({
+        skillId: "skills:one",
+        kind: "download",
+        occurredAt: 86_500_000,
+      }),
+    );
+    expect(insert).not.toHaveBeenCalledWith("packageStatEvents", expect.anything());
+  });
+
+  it("records one anonymous package download and emits the existing package stat event", async () => {
+    const { db, insert } = makeDb();
+
+    await recordDownloadMetricHandler(
+      { db },
+      {
+        target: { kind: "package", id: "packages:one" },
+        identityKind: "ip",
+        identityHash: "hash-ip",
+        dayStart: 86_400_000,
+        occurredAt: 86_500_000,
+      },
+    );
+
+    expect(insert).toHaveBeenCalledWith(
+      "downloadMetricDedupes",
+      expect.objectContaining({
+        targetKind: "package",
+        targetId: "packages:one",
+        identityKind: "ip",
+        identityHash: "hash-ip",
+        dayStart: 86_400_000,
+      }),
+    );
+    expect(insert).toHaveBeenCalledWith(
+      "packageStatEvents",
+      expect.objectContaining({
+        packageId: "packages:one",
+        kind: "download",
+        occurredAt: 86_500_000,
+      }),
+    );
+    expect(insert).not.toHaveBeenCalledWith("skillStatEvents", expect.anything());
+  });
+
+  it("ignores duplicate identities in the same target/day bucket", async () => {
+    const { db, insert } = makeDb({
+      downloadMetricDedupes: { _id: "downloadMetricDedupes:existing" },
+    });
+
+    await recordDownloadMetricHandler(
+      { db },
+      {
+        target: { kind: "skill", id: "skills:one" },
+        identityKind: "ip",
+        identityHash: "hash-ip",
+        dayStart: 86_400_000,
+      },
+    );
+
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it("prunes stale dedupe rows by day bucket", async () => {
+    vi.setSystemTime(30 * 86_400_000);
+    const { db, delete_, take, indexCalls } = makeDb(
+      {},
+      {
+        downloadMetricDedupes: [
+          { _id: "downloadMetricDedupes:one" },
+          { _id: "downloadMetricDedupes:two" },
+        ],
+      },
+    );
+
+    const result = await pruneDownloadMetricDedupesHandler({ db }, {});
+
+    expect(result).toEqual({ deleted: 2, hasMore: false });
+    expect(indexCalls[0]?.table).toBe("downloadMetricDedupes");
+    expect(indexCalls[0]?.indexName).toBe("by_day");
+    expect(take).toHaveBeenCalledWith(200);
+    expect(delete_).toHaveBeenCalledWith("downloadMetricDedupes:one");
+    expect(delete_).toHaveBeenCalledWith("downloadMetricDedupes:two");
+  });
+
+  it("reschedules stale dedupe pruning when one bounded batch fills", async () => {
+    vi.setSystemTime(30 * 86_400_000);
+    const rows = Array.from({ length: 200 }, (_, index) => ({
+      _id: `downloadMetricDedupes:${index}`,
+    }));
+    const { db, delete_ } = makeDb({}, { downloadMetricDedupes: rows });
+    const runAfter = vi.fn();
+
+    const result = await pruneDownloadMetricDedupesHandler({ db, scheduler: { runAfter } }, {});
+
+    expect(result).toEqual({ deleted: 200, hasMore: true });
+    expect(delete_).toHaveBeenCalledTimes(200);
+    expect(runAfter).toHaveBeenCalledWith(0, expect.anything(), {});
+  });
+});

--- a/convex/downloadMetrics.ts
+++ b/convex/downloadMetrics.ts
@@ -1,0 +1,137 @@
+import { v } from "convex/values";
+import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { internalMutation } from "./functions";
+import { getClientIp } from "./lib/httpRateLimit";
+import { hashToken } from "./lib/tokens";
+import { insertStatEvent } from "./skillStatEvents";
+
+const DAY_MS = 86_400_000;
+const DEDUPE_RETENTION_MS = 14 * DAY_MS;
+const PRUNE_BATCH_SIZE = 200;
+
+const identityKindValidator = v.union(v.literal("user"), v.literal("ip"));
+
+const targetValidator = v.union(
+  v.object({ kind: v.literal("skill"), id: v.id("skills") }),
+  v.object({ kind: v.literal("package"), id: v.id("packages") }),
+);
+
+type DownloadIdentityKind = "user" | "ip";
+
+type DownloadIdentity = {
+  identityKind: DownloadIdentityKind;
+  identityValue: string;
+};
+
+export function getDownloadIdentity(
+  request: Request,
+  userId: string | null,
+): DownloadIdentity | null {
+  if (userId) return { identityKind: "user", identityValue: userId };
+  const ip = getClientIp(request);
+  if (!ip) return null;
+  return { identityKind: "ip", identityValue: ip };
+}
+
+export async function buildDownloadMetricArgs(params: {
+  target: { kind: "skill"; id: Id<"skills"> } | { kind: "package"; id: Id<"packages"> };
+  identity: DownloadIdentity;
+  now: number;
+}) {
+  return {
+    target: params.target,
+    identityKind: params.identity.identityKind,
+    identityHash: await hashToken(
+      `${params.identity.identityKind}:${params.identity.identityValue}`,
+    ),
+    dayStart: getDayStart(params.now),
+    occurredAt: params.now,
+  };
+}
+
+export const recordDownloadMetricInternal = internalMutation({
+  args: {
+    target: targetValidator,
+    identityKind: identityKindValidator,
+    identityHash: v.string(),
+    dayStart: v.number(),
+    occurredAt: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const targetId = args.target.id;
+    const existing = await ctx.db
+      .query("downloadMetricDedupes")
+      .withIndex("by_target_identity_day", (q) =>
+        q
+          .eq("targetKind", args.target.kind)
+          .eq("targetId", targetId)
+          .eq("identityKind", args.identityKind)
+          .eq("identityHash", args.identityHash)
+          .eq("dayStart", args.dayStart),
+      )
+      .unique();
+    if (existing) return;
+
+    const now = Date.now();
+    await ctx.db.insert("downloadMetricDedupes", {
+      targetKind: args.target.kind,
+      targetId,
+      identityKind: args.identityKind,
+      identityHash: args.identityHash,
+      dayStart: args.dayStart,
+      createdAt: now,
+    });
+
+    if (args.target.kind === "skill") {
+      await insertStatEvent(ctx, {
+        skillId: args.target.id,
+        kind: "download",
+        occurredAt: args.occurredAt,
+      });
+      return;
+    }
+
+    await ctx.db.insert("packageStatEvents", {
+      packageId: args.target.id,
+      kind: "download",
+      occurredAt: args.occurredAt ?? now,
+      processedAt: undefined,
+    });
+  },
+});
+
+export const pruneDownloadMetricDedupesInternal = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const cutoffDayStart = getDayStart(Date.now() - DEDUPE_RETENTION_MS);
+    const stale = await ctx.db
+      .query("downloadMetricDedupes")
+      .withIndex("by_day", (q) => q.lt("dayStart", cutoffDayStart))
+      .take(PRUNE_BATCH_SIZE);
+
+    for (const entry of stale) {
+      await ctx.db.delete(entry._id);
+    }
+
+    const hasMore = stale.length === PRUNE_BATCH_SIZE;
+    if (hasMore) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.downloadMetrics.pruneDownloadMetricDedupesInternal,
+        {},
+      );
+    }
+
+    return { deleted: stale.length, hasMore };
+  },
+});
+
+function getDayStart(timestamp: number) {
+  return Math.floor(timestamp / DAY_MS) * DAY_MS;
+}
+
+export const __test = {
+  getDayStart,
+  getDownloadIdentity,
+};

--- a/convex/downloads.test.ts
+++ b/convex/downloads.test.ts
@@ -21,6 +21,19 @@ const okRate = () => ({
   resetAt: Date.now() + 60_000,
 });
 
+function stubZipResponse() {
+  class MockResponse {
+    status: number;
+    headers: Headers;
+
+    constructor(_body?: BodyInit | null, init?: ResponseInit) {
+      this.status = init?.status ?? 200;
+      this.headers = new Headers(init?.headers);
+    }
+  }
+  vi.stubGlobal("Response", MockResponse as unknown as typeof Response);
+}
+
 describe("downloads helpers", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
@@ -63,16 +76,7 @@ describe("downloads helpers", () => {
   });
 
   it("schedules zip download stats outside the response path", async () => {
-    class MockResponse {
-      status: number;
-      headers: Headers;
-
-      constructor(_body?: BodyInit | null, init?: ResponseInit) {
-        this.status = init?.status ?? 200;
-        this.headers = new Headers(init?.headers);
-      }
-    }
-    vi.stubGlobal("Response", MockResponse as unknown as typeof Response);
+    stubZipResponse();
 
     const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
       if (isRateLimitArgs(args)) return okRate();
@@ -127,9 +131,10 @@ describe("downloads helpers", () => {
       if (!args || typeof args !== "object") return false;
       const value = args as Record<string, unknown>;
       return (
-        value.skillId === "skills:1" &&
+        typeof value.target === "object" &&
         typeof value.identityHash === "string" &&
-        typeof value.hourStart === "number"
+        value.identityKind === "ip" &&
+        typeof value.dayStart === "number"
       );
     });
     expect(recordCalls).toHaveLength(1);
@@ -137,9 +142,11 @@ describe("downloads helpers", () => {
     expect(recordCalls[0]?.[0]).toBeGreaterThanOrEqual(0);
     expect(recordCalls[0]?.[0]).toBeLessThan(60_000);
     expect(recordCalls[0]?.[2]).toEqual({
-      skillId: "skills:1",
+      target: { kind: "skill", id: "skills:1" },
+      identityKind: "ip",
       identityHash: expect.any(String),
-      hourStart: expect.any(Number),
+      dayStart: expect.any(Number),
+      occurredAt: expect.any(Number),
     });
   });
 
@@ -201,5 +208,134 @@ describe("downloads helpers", () => {
     expect(response.status).toBe(404);
     expect(await response.text()).toBe("Version not found");
     expect(storageGet).not.toHaveBeenCalled();
+  });
+
+  it("uses API token user identity for zip download stats when present", async () => {
+    stubZipResponse();
+
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      if ("tokenHash" in args) {
+        return { _id: "apiTokens:1", revokedAt: undefined };
+      }
+      if ("tokenId" in args) {
+        return { _id: "users:token", deletedAt: undefined, deactivatedAt: undefined };
+      }
+      if ("slug" in args) {
+        return {
+          skill: {
+            _id: "skills:1",
+            ownerUserId: "users:1",
+            slug: "demo",
+            tags: {},
+            latestVersionId: "skillVersions:1",
+          },
+          moderationInfo: null,
+        };
+      }
+      if ("versionId" in args) {
+        return {
+          _id: "skillVersions:1",
+          skillId: "skills:1",
+          version: "1.0.0",
+          createdAt: 3,
+          files: [{ path: "SKILL.md", storageId: "_storage:1" }],
+          softDeletedAt: undefined,
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      return { tokenTouched: "tokenId" in args };
+    });
+    const runAfter = vi.fn();
+    const storageGet = vi.fn().mockResolvedValue(new Blob(["hello"], { type: "text/markdown" }));
+
+    const response = await downloadZipHandler(
+      {
+        runQuery,
+        runMutation,
+        scheduler: { runAfter },
+        storage: { get: storageGet },
+      } as unknown as ActionCtx,
+      new Request("https://example.com/api/v1/download?slug=demo", {
+        headers: {
+          authorization: "Bearer clh_test",
+          "cf-connecting-ip": "1.2.3.4",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runAfter).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.anything(),
+      expect.objectContaining({
+        target: { kind: "skill", id: "skills:1" },
+        identityKind: "user",
+        identityHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+      }),
+    );
+  });
+
+  it("returns zip downloads when download metering is scheduled", async () => {
+    stubZipResponse();
+
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      if ("slug" in args) {
+        return {
+          skill: {
+            _id: "skills:1",
+            ownerUserId: "users:1",
+            slug: "demo",
+            tags: {},
+            latestVersionId: "skillVersions:1",
+          },
+          moderationInfo: null,
+        };
+      }
+      if ("versionId" in args) {
+        return {
+          _id: "skillVersions:1",
+          skillId: "skills:1",
+          version: "1.0.0",
+          createdAt: 3,
+          files: [{ path: "SKILL.md", storageId: "_storage:1" }],
+          softDeletedAt: undefined,
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      return { mutationRecorded: true };
+    });
+    const runAfter = vi.fn();
+    const storageGet = vi.fn().mockResolvedValue(new Blob(["hello"], { type: "text/markdown" }));
+
+    const response = await downloadZipHandler(
+      {
+        runQuery,
+        runMutation,
+        scheduler: { runAfter },
+        storage: { get: storageGet },
+      } as unknown as ActionCtx,
+      new Request("https://example.com/api/v1/download?slug=demo", {
+        headers: { "cf-connecting-ip": "1.2.3.4" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runAfter).toHaveBeenCalledWith(
+      expect.any(Number),
+      expect.anything(),
+      expect.objectContaining({
+        target: { kind: "skill", id: "skills:1" },
+        identityKind: "ip",
+        identityHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+      }),
+    );
   });
 });

--- a/convex/downloads.ts
+++ b/convex/downloads.ts
@@ -1,12 +1,14 @@
 import { v } from "convex/values";
 import { api, internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { buildDownloadMetricArgs, getDownloadIdentity } from "./downloadMetrics";
 import { httpAction, internalMutation } from "./functions";
+import { getOptionalActiveAuthUserIdFromAction } from "./lib/access";
 import { getOptionalApiTokenUserId } from "./lib/apiTokenAuth";
 import { corsHeaders, mergeHeaders } from "./lib/httpHeaders";
 import { applyRateLimit, getClientIp } from "./lib/httpRateLimit";
 import { getPublicSkillFileAccessBlock, isSkillVersionForSkill } from "./lib/skillFileAccess";
 import { buildDeterministicZip } from "./lib/skillZip";
-import { hashToken } from "./lib/tokens";
 import { insertStatEvent } from "./skillStatEvents";
 
 const HOUR_MS = 3_600_000;
@@ -98,17 +100,17 @@ export async function downloadZipHandler(
   const zipBlob = new Blob([zipArray], { type: "application/zip" });
 
   try {
-    const userId = await getOptionalApiTokenUserId(ctx, request);
-    const identity = getDownloadIdentityValue(request, userId ? String(userId) : null);
+    const userId = await getOptionalDownloadUserId(ctx, request);
+    const identity = getDownloadIdentity(request, userId ? String(userId) : null);
     if (identity) {
       await ctx.scheduler.runAfter(
         Math.floor(Math.random() * DOWNLOAD_STAT_JITTER_MS),
-        internal.downloads.recordDownloadInternal,
-        {
-          skillId: skill._id,
-          identityHash: await hashToken(identity),
-          hourStart: getHourStart(Date.now()),
-        },
+        internal.downloadMetrics.recordDownloadMetricInternal,
+        await buildDownloadMetricArgs({
+          target: { kind: "skill", id: skill._id },
+          identity,
+          now: Date.now(),
+        }),
       );
     }
   } catch {
@@ -194,6 +196,15 @@ export function getDownloadIdentityValue(request: Request, userId: string | null
   const ip = getClientIp(request);
   if (!ip) return null;
   return `ip:${ip}`;
+}
+
+async function getOptionalDownloadUserId(
+  ctx: Parameters<Parameters<typeof httpAction>[0]>[0],
+  request: Request,
+): Promise<Id<"users"> | null> {
+  const apiTokenUserId = await getOptionalApiTokenUserId(ctx, request);
+  if (apiTokenUserId) return apiTokenUserId;
+  return (await getOptionalActiveAuthUserIdFromAction(ctx)) ?? null;
 }
 
 export const __test = {

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -64,6 +64,15 @@ function hasPackageNameArgs(args: unknown): args is { name: string } {
   return typeof value.name === "string";
 }
 
+function hasPackageDownloadMetricTarget(args: unknown, packageId: string) {
+  if (!args || typeof args !== "object") return false;
+  const value = args as Record<string, unknown>;
+  const target = value.target;
+  if (!target || typeof target !== "object") return false;
+  const targetValue = target as Record<string, unknown>;
+  return targetValue.kind === "package" && targetValue.id === packageId;
+}
+
 function findRateLimitCallArgs(mock: ReturnType<typeof vi.fn>) {
   return mock.mock.calls.map(([, args]) => args).find(isRateLimitArgs);
 }
@@ -8743,7 +8752,7 @@ describe("httpApiV1 handlers", () => {
     });
   });
 
-  it("npm mirror tarball downloads record package installs", async () => {
+  it("npm mirror tarball downloads record package installs and download metrics", async () => {
     const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
       if ("name" in args && !("paginationOpts" in args)) {
         return {
@@ -8798,13 +8807,25 @@ describe("httpApiV1 handlers", () => {
           get: vi.fn(async () => new Blob(["tarball"], { type: "application/octet-stream" })),
         },
       }),
-      new Request("https://example.com/api/npm/demo-plugin/-/demo-plugin-1.0.0.tgz"),
+      new Request("https://example.com/api/npm/demo-plugin/-/demo-plugin-1.0.0.tgz", {
+        headers: { "cf-connecting-ip": "203.0.113.10" },
+      }),
     );
 
     expect(response.status).toBe(200);
     expect(runMutation).toHaveBeenCalledWith(internal.packages.recordPackageInstallInternal, {
       packageId: "packages:demo-plugin",
     });
+    expect(runMutation).toHaveBeenCalledWith(
+      internal.downloadMetrics.recordDownloadMetricInternal,
+      expect.objectContaining({
+        target: { kind: "package", id: "packages:demo-plugin" },
+        identityKind: "ip",
+        identityHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+        dayStart: expect.any(Number),
+        occurredAt: expect.any(Number),
+      }),
+    );
   });
 
   it("npm mirror returns not found for invalid package lookup names", async () => {
@@ -9202,7 +9223,9 @@ describe("httpApiV1 handlers", () => {
           }),
         },
       }),
-      new Request("https://example.com/api/v1/packages/demo-plugin/download"),
+      new Request("https://example.com/api/v1/packages/demo-plugin/download", {
+        headers: { "cf-connecting-ip": "203.0.113.20" },
+      }),
     );
 
     const zipEntries = unzipSync(new Uint8Array(await response.arrayBuffer()));
@@ -9211,9 +9234,147 @@ describe("httpApiV1 handlers", () => {
       "package/package.json",
     ]);
     expect(zipEntries["_meta.json"]).toBeUndefined();
-    expect(runMutation).toHaveBeenCalledWith(internal.packages.recordPackageDownloadInternal, {
-      packageId: "packages:1",
+    expect(runMutation).toHaveBeenCalledWith(
+      internal.downloadMetrics.recordDownloadMetricInternal,
+      {
+        target: { kind: "package", id: "packages:1" },
+        identityKind: "ip",
+        identityHash: expect.any(String),
+        dayStart: expect.any(Number),
+        occurredAt: expect.any(Number),
+      },
+    );
+  });
+
+  it("package download metrics prefer API token user identity over IP", async () => {
+    vi.mocked(getOptionalApiTokenUserId).mockResolvedValue("users:viewer" as never);
+
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("name" in args) {
+        return {
+          package: {
+            _id: "packages:1",
+            name: "demo-plugin",
+            displayName: "Demo Plugin",
+            family: "code-plugin",
+            tags: {},
+            latestReleaseId: "packageReleases:1",
+            channel: "community",
+            isOfficial: false,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+          latestRelease: null,
+          owner: { _id: "users:owner", handle: "owner" },
+        };
+      }
+      if ("releaseId" in args) {
+        return {
+          _id: "packageReleases:1",
+          version: "1.0.0",
+          createdAt: 1,
+          changelog: "init",
+          files: [
+            {
+              path: "package.json",
+              size: 2,
+              sha256: "a".repeat(64),
+              storageId: "storage:1",
+              contentType: "application/json",
+            },
+          ],
+        };
+      }
+      return null;
     });
+
+    const response = await __handlers.packagesGetRouterV1Handler(
+      makeCtx({
+        runQuery,
+        runMutation,
+        storage: {
+          get: vi.fn(async () => new Blob(["{}"], { type: "application/json" })),
+        },
+      }),
+      new Request("https://example.com/api/v1/packages/demo-plugin/download", {
+        headers: {
+          authorization: "Bearer clh_test",
+          "cf-connecting-ip": "203.0.113.20",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runMutation).toHaveBeenCalledWith(
+      internal.downloadMetrics.recordDownloadMetricInternal,
+      expect.objectContaining({
+        target: { kind: "package", id: "packages:1" },
+        identityKind: "user",
+        identityHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+      }),
+    );
+  });
+
+  it("package downloads succeed and record download metrics", async () => {
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("name" in args) {
+        return {
+          package: {
+            _id: "packages:1",
+            name: "demo-plugin",
+            displayName: "Demo Plugin",
+            family: "code-plugin",
+            tags: {},
+            latestReleaseId: "packageReleases:1",
+            channel: "community",
+            isOfficial: false,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+          latestRelease: null,
+          owner: { _id: "users:owner", handle: "owner" },
+        };
+      }
+      if ("releaseId" in args) {
+        return {
+          _id: "packageReleases:1",
+          version: "1.0.0",
+          createdAt: 1,
+          changelog: "init",
+          files: [
+            {
+              path: "package.json",
+              size: 2,
+              sha256: "a".repeat(64),
+              storageId: "storage:1",
+              contentType: "application/json",
+            },
+          ],
+        };
+      }
+      return null;
+    });
+
+    const response = await __handlers.packagesGetRouterV1Handler(
+      makeCtx({
+        runQuery,
+        runMutation,
+        storage: {
+          get: vi.fn(async () => new Blob(["{}"], { type: "application/json" })),
+        },
+      }),
+      new Request("https://example.com/api/v1/packages/demo-plugin/download", {
+        headers: { "cf-connecting-ip": "203.0.113.20" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const mutationArgs = runMutation.mock.calls.map(([, args]) => args);
+    expect(
+      mutationArgs.filter((args) => hasPackageDownloadMetricTarget(args, "packages:1")),
+    ).toHaveLength(1);
   });
 
   it("package download fails when any stored file is missing", async () => {

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -27,6 +27,7 @@ import {
 import { api, internal } from "../_generated/api";
 import type { Doc, Id } from "../_generated/dataModel";
 import type { ActionCtx } from "../_generated/server";
+import { buildDownloadMetricArgs, getDownloadIdentity } from "../downloadMetrics";
 import { getOptionalActiveAuthUserIdFromAction } from "../lib/access";
 import { getOptionalApiTokenUserId } from "../lib/apiTokenAuth";
 import { parseClawPack, sha256Base64, sha256Hex } from "../lib/clawpack";
@@ -122,6 +123,9 @@ const internalRefs = internal as unknown as {
     upsertOfficialPluginMigrationForUserInternal: unknown;
     backfillPackageArtifactKindsInternal: unknown;
     listPackageModerationQueueInternal: unknown;
+  };
+  downloadMetrics: {
+    recordDownloadMetricInternal: unknown;
   };
   packagePublishTokens: {
     createInternal: unknown;
@@ -643,9 +647,11 @@ function releaseArtifactUrls(request: Request, packageName: string, release: Rel
 
 async function streamClawPackRelease(
   ctx: ActionCtx,
+  request: Request,
   rateHeaders: HeadersInit,
   pkg: PublicPackageDocLike,
   release: ReleaseLike,
+  viewerUserId: Id<"users"> | null,
   statKind: "download" | "install" = "download",
 ) {
   const securityBlock = getReleaseSecurityBlock(release);
@@ -656,13 +662,24 @@ async function streamClawPackRelease(
   const blob = await ctx.storage.get(release.clawpackStorageId);
   if (!blob) return text("ClawPack artifact not found", 404, rateHeaders);
   try {
-    const statMutation =
-      statKind === "install"
-        ? internalRefs.packages.recordPackageInstallInternal
-        : internalRefs.packages.recordPackageDownloadInternal;
-    await runMutationRef(ctx, statMutation, {
-      packageId: pkg._id,
-    });
+    if (statKind === "install") {
+      await runMutationRef(ctx, internalRefs.packages.recordPackageInstallInternal, {
+        packageId: pkg._id,
+      });
+    }
+
+    const identity = getDownloadIdentity(request, viewerUserId ? String(viewerUserId) : null);
+    if (identity) {
+      await runMutationRef(
+        ctx,
+        internalRefs.downloadMetrics.recordDownloadMetricInternal,
+        await buildDownloadMetricArgs({
+          target: { kind: "package", id: pkg._id },
+          identity,
+          now: Date.now(),
+        }),
+      );
+    }
   } catch {
     // Best-effort metric path; never fail package downloads.
   }
@@ -2906,7 +2923,14 @@ export async function packagesGetRouterV1Handler(ctx: ActionCtx, request: Reques
     if (!release) return text("Version not found", 404, rate.headers);
     if (packageSegments[3] === "download") {
       if (release.artifactKind === "npm-pack") {
-        return await streamClawPackRelease(ctx, rate.headers, publicPackage!, release);
+        return await streamClawPackRelease(
+          ctx,
+          request,
+          rate.headers,
+          publicPackage!,
+          release,
+          viewerUserId ?? null,
+        );
       }
       const url = new URL(
         `/api/v1/packages/${encodePackagePath(publicPackage!.name)}/download`,
@@ -3105,9 +3129,18 @@ export async function packagesGetRouterV1Handler(ctx: ActionCtx, request: Reques
     const zip = buildDeterministicPackageZip(entries);
     const [zipSha256, zipSha256Base64] = await Promise.all([sha256Hex(zip), sha256Base64(zip)]);
     try {
-      await runMutationRef(ctx, internalRefs.packages.recordPackageDownloadInternal, {
-        packageId: publicPackage!._id,
-      });
+      const identity = getDownloadIdentity(request, viewerUserId ? String(viewerUserId) : null);
+      if (identity) {
+        await runMutationRef(
+          ctx,
+          internalRefs.downloadMetrics.recordDownloadMetricInternal,
+          await buildDownloadMetricArgs({
+            target: { kind: "package", id: publicPackage!._id },
+            identity,
+            now: Date.now(),
+          }),
+        );
+      }
     } catch {
       // Best-effort metric path; never fail package downloads.
     }
@@ -3253,7 +3286,15 @@ export async function npmMirrorGetHandler(ctx: ActionCtx, request: Request) {
     const tarballName = path.rest[1]!;
     const release = releases.find((candidate) => candidate.npmTarballName === tarballName);
     if (!release) return text("ClawPack artifact not found", 404, rate.headers);
-    return await streamClawPackRelease(ctx, rate.headers, detail.package, release, "install");
+    return await streamClawPackRelease(
+      ctx,
+      request,
+      rate.headers,
+      detail.package,
+      release,
+      viewerUserId ?? null,
+      "install",
+    );
   }
   if (path.rest.length > 0) return text("Not found", 404, rate.headers);
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2144,6 +2144,26 @@ const downloadDedupes = defineTable({
   .index("by_skill_identity_hour", ["skillId", "identityHash", "hourStart"])
   .index("by_hour", ["hourStart"]);
 
+const downloadMetricTargetKind = v.union(v.literal("skill"), v.literal("package"));
+const downloadMetricIdentityKind = v.union(v.literal("user"), v.literal("ip"));
+
+const downloadMetricDedupes = defineTable({
+  targetKind: downloadMetricTargetKind,
+  targetId: v.string(),
+  identityKind: downloadMetricIdentityKind,
+  identityHash: v.string(),
+  dayStart: v.number(),
+  createdAt: v.number(),
+})
+  .index("by_target_identity_day", [
+    "targetKind",
+    "targetId",
+    "identityKind",
+    "identityHash",
+    "dayStart",
+  ])
+  .index("by_day", ["dayStart"]);
+
 const reservedSlugs = defineTable({
   slug: v.string(),
   originalOwnerUserId: v.id("users"),
@@ -2297,6 +2317,7 @@ export default defineSchema({
   rateLimits,
   rateLimitShards,
   downloadDedupes,
+  downloadMetricDedupes,
   reservedSlugs,
   reservedHandles,
   githubBackupSyncState,

--- a/specs/download-metering.md
+++ b/specs/download-metering.md
@@ -1,0 +1,33 @@
+# Download Metering
+
+## Intent
+
+Download metrics are collected without storing raw IP addresses and without
+rewriting historical download counts.
+
+New skill and package downloads use one shared metering path. The path records
+one counted download per target, identity kind, identity hash, and UTC day.
+
+## Identity Hashing
+
+The identity hash input includes the identity kind:
+
+```text
+user:<user id>
+ip:<client ip>
+```
+
+This keeps a user id and IP with the same visible string in separate hash
+domains for dedupe and local diagnostics.
+
+## Counters
+
+The dedupe table does not store user-vs-IP counters. It only gates whether a
+download should emit the existing skill or package stat event. Public counters
+still store one total:
+
+```text
+downloads
+```
+
+Existing historical counts are not estimated or rewritten in this phase.


### PR DESCRIPTION
## Summary

This PR makes skill downloads and package/plugin downloads use the same daily dedupe rule before they update public download counters.

Before:

- skill ZIP downloads were deduped by skill + identity + hour
- package/plugin downloads wrote raw package stat events, so repeated downloads could each count

After:

- both paths dedupe by target + identity + UTC day
- the target is either `skill:<skillId>` or `package:<packageId>`
- the identity is a user id when available, otherwise the client IP
- the stored identity is hashed
- after dedupe, existing stat-event pipelines still update the public counters

## Behavior

A repeated download from the same user/IP for the same skill or package on the same UTC day counts once.

Examples:

```text
same user downloads same plugin 5 times today -> 1 download
same user downloads it again tomorrow -> 1 more download
same user downloads a different plugin today -> counts separately
```

The visible count remains one total:

```text
downloads
```

The user/IP distinction is only dedupe metadata:

```text
identityKind: "user" | "ip"
identityHash: string
```

This does not add user-vs-IP reporting buckets, historical backfill, or estimated historical counts.

## Data Model

Adds one new table:

- `downloadMetricDedupes`

The existing `downloadDedupes` table is skill/hour-specific, so this PR leaves it in place and uses the new table for the shared skill/package daily rule.

This PR does not add daily rollup tables, weekly snapshot tables, new reporting crons, or a new metering secret.

## Routes Updated

- skill ZIP downloads now schedule `downloadMetrics.recordDownloadMetricInternal`
- package legacy ZIP downloads now record through the shared dedupe path
- ClawPack/npm tarball downloads now record through the shared dedupe path
- npm-style package installs still record installs, and the downloaded tarball also contributes to deduped download metrics

## Tests

- `bun run test -- convex/downloadMetrics.test.ts convex/downloads.test.ts convex/httpApiV1.handlers.test.ts`
- `git diff --check origin/main...HEAD`
- `bun run format:check`
- `bun run lint`
- `bunx tsc --noEmit`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`

Not run:

- `bun run test`
- `bun run build`
- `bun run coverage`
- `bunx convex deploy`
