### PR TITLE
chore: bump clawhub cli to 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.19.0 - 2026-06-03
+
+### Changes
+
+- CLI/API: add authenticated `clawhub scan` submit/poll support for ephemeral local skill bundles and owner-authorized published skill scans, including JSON output and report ZIP downloads (#2479).
+
 ### Fixes
 
 - Auth/Ops: keep GitHub account-age lookups on immutable numeric IDs, retry without auth when a configured GitHub token is rejected, and add an operator backfill for missing cached account ages.

--- a/bun.lock
+++ b/bun.lock
@@ -81,7 +81,7 @@
     },
     "packages/clawhub": {
       "name": "clawhub",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "bin": {
         "clawdhub": "bin/clawdhub.js",
         "clawhub": "bin/clawdhub.js",

--- a/packages/clawhub/package.json
+++ b/packages/clawhub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawhub",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "ClawHub CLI \\u2014 install, update, search, and publish skills plus OpenClaw packages.",
   "homepage": "https://clawhub.ai",
   "bugs": {


### PR DESCRIPTION
## Summary
- Bump the published `clawhub` CLI package from `0.18.0` to `0.19.0`.
- Add the `CHANGELOG.md` section that the release workflow extracts for `v0.19.0`.
- Keep the lockfile workspace package version in sync.

## Verification
- `npm view clawhub version` -> `0.18.0`
- `node scripts/clawhub-cli-npm-release-check.mjs --tag v0.19.0`
- `node scripts/extract-changelog-release.mjs --tag v0.19.0`
- `git diff --check`
- `bun run --cwd packages/clawhub verify:build`
- `bun run --cwd packages/clawhub build`
- `bun install --frozen-lockfile`

## Release
After merge, run the preflight from `main`:

```bash
gh workflow run clawhub-cli-npm-release.yml \
  --repo openclaw/clawhub \
  --ref main \
  -f tag=v0.19.0 \
  -f preflight_only=true
```

Then rerun with `preflight_only=false` and the successful `preflight_run_id`.

## Notes
- `bun run ci:packages` was attempted, but the `packages/clawhub` Vitest child became idle at 0% CPU and produced no output for over a minute, so I stopped that hung run and used the release-specific checks above.
