### PR TITLE
fix(httpApiV1): surface 400-class delete validation errors instead of opaque 500

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -10882,7 +10882,10 @@ describe("httpApiV1 handlers", () => {
       }),
     );
     expect(unknown.status).toBe(500);
-    expect(await unknown.text()).toBe("Internal Server Error");
+    // The 500 fallback now appends the cleaned underlying error message so CLI
+    // users get an actionable hint instead of an opaque "Internal Server
+    // Error". The status code stays 500 so monitoring is unaffected.
+    expect(await unknown.text()).toBe("Internal Server Error: boom");
   });
 
   // Regression: owner undelete gate throws a ConvexError prefixed with

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -10882,10 +10882,7 @@ describe("httpApiV1 handlers", () => {
       }),
     );
     expect(unknown.status).toBe(500);
-    // The 500 fallback now appends the cleaned underlying error message so CLI
-    // users get an actionable hint instead of an opaque "Internal Server
-    // Error". The status code stays 500 so monitoring is unaffected.
-    expect(await unknown.text()).toBe("Internal Server Error: boom");
+    expect(await unknown.text()).toBe("Internal Server Error");
   });
 
   // Regression: owner undelete gate throws a ConvexError prefixed with

--- a/convex/httpApiV1.shared.test.ts
+++ b/convex/httpApiV1.shared.test.ts
@@ -6,6 +6,7 @@ import {
   formatUserFacingErrorMessage,
   parseMultipartSkillScan,
   resolveVersionTagsBatch,
+  softDeleteErrorToResponse,
 } from "./httpApiV1/shared";
 
 function makeCtx() {
@@ -30,6 +31,28 @@ describe("http API v1 shared helpers", () => {
         "Request failed",
       ),
     ).toBe("Publisher not found");
+  });
+
+  it("maps soft-delete validation failures to 400 with cleaned messages", async () => {
+    const response = softDeleteErrorToResponse(
+      "package",
+      new Error(
+        "[CONVEX M] [Request ID: abc] Server Error Called by client Uncaught ConvexError: Package name must be lowercase and npm-safe (example: @scope/name or plugin-name)",
+      ),
+      {},
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.text()).resolves.toBe(
+      "Package name must be lowercase and npm-safe (example: @scope/name or plugin-name)",
+    );
+  });
+
+  it("keeps unknown soft-delete failures generic 500s", async () => {
+    const response = softDeleteErrorToResponse("soul", new Error("boom"), {});
+
+    expect(response.status).toBe(500);
+    await expect(response.text()).resolves.toBe("Internal Server Error");
   });
 
   it("resolves latest tags without reading version documents", async () => {

--- a/convex/httpApiV1/shared.ts
+++ b/convex/httpApiV1/shared.ts
@@ -546,16 +546,9 @@ export function softDeleteErrorToResponse(
     return text(cleaned, 400, headers);
   }
 
-  // Unknown: server-side failure. Keep status 500 but include the cleaned
-  // message in the body so CLI users get an actionable hint instead of a bare
-  // "Internal Server Error". The status code stays 500 so monitoring/alerting
-  // pipelines that key off the status are unaffected.
-  const fallback = "Internal Server Error";
-  const body =
-    cleaned && cleaned.toLowerCase() !== fallback.toLowerCase()
-      ? `${fallback}: ${cleaned}`
-      : fallback;
-  return text(body, 500, headers);
+  // Unknown: server-side failure. Keep the body generic; only known
+  // user-input validation failures above surface the cleaned mutation message.
+  return text("Internal Server Error", 500, headers);
 }
 
 export function cleanUserFacingErrorMessage(message: string) {

--- a/convex/httpApiV1/shared.ts
+++ b/convex/httpApiV1/shared.ts
@@ -514,23 +514,48 @@ export function parsePublishBody(body: unknown) {
   };
 }
 
+// Substrings that indicate user-input validation failures from the underlying
+// mutations (e.g. `normalizePackageName` ConvexErrors). These are surfaced as
+// 400s with the cleaned message so CLI/API clients can see the actual reason
+// instead of an opaque 500.
+const SOFT_DELETE_BAD_REQUEST_HINTS = [
+  "slug required",
+  "package name required",
+  "package name must be",
+  "must be lowercase",
+  "npm-safe",
+  "reserved",
+  "version required",
+] as const;
+
 export function softDeleteErrorToResponse(
   entity: "skill" | "soul" | "package",
   error: unknown,
   headers: HeadersInit,
 ) {
-  const message = error instanceof Error ? error.message : `${entity} delete failed`;
-  const lower = message.toLowerCase();
+  const rawMessage = error instanceof Error ? error.message : `${entity} delete failed`;
+  const cleaned = cleanUserFacingErrorMessage(rawMessage) || rawMessage;
+  const lower = cleaned.toLowerCase();
 
   if (lower.includes("unauthorized"))
     return text(formatAuthzMessage(error, "Unauthorized"), 401, headers);
   if (lower.includes("forbidden"))
     return text(formatAuthzMessage(error, "Forbidden"), 403, headers);
-  if (lower.includes("not found")) return text(message, 404, headers);
-  if (lower.includes("slug required")) return text("Slug required", 400, headers);
+  if (lower.includes("not found")) return text(cleaned, 404, headers);
+  if (SOFT_DELETE_BAD_REQUEST_HINTS.some((hint) => lower.includes(hint))) {
+    return text(cleaned, 400, headers);
+  }
 
-  // Unknown: server-side failure. Keep body generic.
-  return text("Internal Server Error", 500, headers);
+  // Unknown: server-side failure. Keep status 500 but include the cleaned
+  // message in the body so CLI users get an actionable hint instead of a bare
+  // "Internal Server Error". The status code stays 500 so monitoring/alerting
+  // pipelines that key off the status are unaffected.
+  const fallback = "Internal Server Error";
+  const body =
+    cleaned && cleaned.toLowerCase() !== fallback.toLowerCase()
+      ? `${fallback}: ${cleaned}`
+      : fallback;
+  return text(body, 500, headers);
 }
 
 export function cleanUserFacingErrorMessage(message: string) {


### PR DESCRIPTION
## Why

`DELETE /api/v1/packages/<name>` (and the parallel skill / soul soft-delete endpoints) currently return an opaque `500 Internal Server Error` with no body context whenever the underlying mutation throws anything outside a tiny keyword whitelist.

The case #2482  that surfaced this:

```
$ npx --yes clawhub package delete xrow/xrow-self-improvement --yes
✖ Internal Server Error (remaining: 2997/3000, reset in 24s)
```



Under the hood:

1. The CLI URL-encodes the name and the route resolves `packageName = "xrow/xrow-self-improvement"`.
2. `softDeletePackageInternal` calls `normalizePackageName`, whose regex `^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$` accepts either a bare name or `@scope/name`. Bare `scope/name` (no `@`) is rejected with `ConvexError("Package name must be lowercase and npm-safe (example: @scope/name or plugin-name)")`.
3. `softDeleteErrorToResponse` only knows four keywords (`unauthorized`, `forbidden`, `not found`, `slug required`); everything else is rewritten to literal `"Internal Server Error"` + 500. The actual reason is dropped.

That is a textbook silent-drop: a 4xx user-input error reported as 5xx with the diagnostic text discarded. CLI users have no way to recover without server logs.

## What

`convex/httpApiV1/shared.ts` — rewrite `softDeleteErrorToResponse`:

- Run the raw message through `cleanUserFacingErrorMessage` first so `[CONVEX]` / `ConvexError:` / `[Request ID:...]` prefixes don't hide the real text from the keyword check.
- New `SOFT_DELETE_BAD_REQUEST_HINTS` whitelist for input-validation failures (`slug required`, `package name required`, `package name must be`, `must be lowercase`, `npm-safe`, `reserved`, `version required`). Matches now return **400 + cleaned message** so the CLI / HTTP client sees the reason.
- The 500 fallback is unchanged on the wire: status `500` with the bare body `Internal Server Error`. The cleaned message is computed but intentionally **not** appended, so unexpected exceptions do not leak diagnostic detail across the public HTTP boundary.

`convex/httpApiV1.shared.test.ts` — adds dedicated regression coverage for both the new 400 path (cleaned validation message) and the unknown-failure generic-500 boundary, so the security-boundary contract is pinned.

No schema / route / CLI changes. The 401, 403, and 404 paths and `formatAuthzMessage` fallbacks are unchanged.

## Behavioral diff (HTTP)

| Trigger                                                | Before                                  | After                                                                            |
| ------------------------------------------------------ | --------------------------------------- | -------------------------------------------------------------------------------- |
| `DELETE /packages/xrow/xrow-self-improvement`          | `500 Internal Server Error`             | `400 Package name must be lowercase and npm-safe (example: @scope/name or ...)` |
| Mutation throws `Slug required`                        | `400 Slug required` (hard-coded body)   | `400 Slug required` (cleaned message, same status)                              |
| Mutation throws `Forbidden: hidden by moderation`      | `403 Forbidden: hidden by moderation`   | unchanged                                                                       |
| Mutation throws `Skill not found`                      | `404 Skill not found`                   | unchanged                                                                       |
| Mutation throws `new Error("boom")` (truly unexpected) | `500 Internal Server Error`             | `500 Internal Server Error` (unchanged)                                         |

## Tests

- `bunx oxfmt convex/httpApiV1/shared.ts convex/httpApiV1.shared.test.ts` — clean.
- `read_lints` on `shared.ts` — no findings.
- Local `bun run ci:static` + `bun run ci:types-build` + `bun run ci:unit` — all green on the squashed prep head before push.
- Repository CI on the PR head: `static`, `unit`, `e2e-http`, `types-build`, `packages`, `playwright-smoke`, `playwright-local-auth`, all `CodeQL Light` analyses, and `Scan for Verified Secrets` — all `SUCCESS`. Only the external `Vercel – clawhub` status is `FAILURE` (Vercel team authorization), which is not a required check.

## Risk

- `httpApiV1.handlers.test.ts` already had explicit cases for 401 / 403 / 404 / moderation 403 and a generic-500 `unknown` assertion; that 500 assertion still pins the bare `Internal Server Error` body, matching the on-the-wire contract.
- A grep for `"Internal Server Error"` across `convex/` finds only this test, the new `shared.ts` constant, and the new shared-helper regression — no other call site relies on the exact body string.
- Status codes for 401 / 403 / 404 / 500 are unchanged on the wire; the only behavioral change is that a previously-500-with-no-context class of input errors is reclassified to 400 with the cleaned message.

## Behavioral sweep

- **status**: pass
- **silentDropRisk**: this PR removes a documented silent drop in the soft-delete HTTP boundary; no new silent drops introduced.
- **Notes for reviewer**: there is a follow-up worth tracking — the keyword-substring routing in `softDeleteErrorToResponse` is itself fragile. A cleaner long-term shape would be to thread an explicit `code` field on the underlying ConvexErrors (e.g. `INVALID_INPUT`, `NOT_FOUND`) and route on that. Out of scope for this fix, which is intentionally minimal.

## Out of scope

- `normalizePackageName` itself is not changed. Whether bare `scope/name` should be auto-prefixed with `@` is a UX question for the CLI / schema packages, not for this HTTP-edge fix.

## Behavior proof (after fix)

ClawSweeper P1 asked for real post-fix behavior, not just unit asserts. The end-to-end output below was captured locally against the real `softDeleteErrorToResponse` driven by real `ConvexError`s from real `normalizePackageName(...)`. No mocks on the code under test.

> **Note on the captured transcript below.** The raw transcript was first captured on a working commit (`45448721`) that briefly enriched the 500 body with the cleaned message. ClawSweeper subsequently flagged that as a sensitive-diagnostic exposure across the public HTTP boundary; the final PR HEAD reverts the 500-body enrichment back to the bare `Internal Server Error`. The transcript's `unknown error 'boom'` row therefore shows `Internal Server Error: boom` — that is the **interim** behavior, not the final HEAD. The final HEAD returns the bare `Internal Server Error` for unknown 500s; this is asserted by the new `convex/httpApiV1.shared.test.ts` and by the existing `convex/httpApiV1.handlers.test.ts` `unknown` case. All other rows below (the 400 / 403 / 404 results that fix #2482) are accurate for the final HEAD.

### 1. End-to-end HTTP boundary — before vs after (final HEAD)

Driver script: [.local/proof-handler.ts](.local/proof-handler.ts) — calls real `normalizePackageName(badInput)` to throw a real `ConvexError`, hands it to real `softDeleteErrorToResponse("package", err, headers)`, then prints the real `Response.status` and `Response.body`.

| Trigger                                          | Before (`origin/main`)                | After (final HEAD)                                                                          |
| ------------------------------------------------ | ------------------------------------- | ------------------------------------------------------------------------------------------- |
| `DELETE /packages/xrow/xrow-self-improvement`    | `500 Internal Server Error`           | **`400 Package name must be lowercase and npm-safe (example: @scope/name or plugin-name)`** |
| empty package name                               | `500 Internal Server Error`           | **`400 Package name required`**                                                             |
| `ConvexError("Slug required")`                   | `400 Slug required`                   | `400 Slug required` _(unchanged)_                                                           |
| `ConvexError("Forbidden: hidden by moderation")` | `403 Forbidden: hidden by moderation` | `403 Forbidden: hidden by moderation` _(unchanged)_                                         |
| `ConvexError("Package not found")`               | `404 Package not found`               | `404 Package not found` _(unchanged)_                                                       |
| `new Error("boom")` (truly unexpected)           | `500 Internal Server Error`           | `500 Internal Server Error` _(unchanged on the wire)_                                       |

#### Raw transcript — interim capture (`45448721`, pre-revert; see note above)

```
$ bun .local/proof-handler.ts
HTTP behavioral proof — softDeleteErrorToResponse('package', err)
================================================================

=== xrow/xrow-self-improvement (the original 500 case) ===
  source error: Package name must be lowercase and npm-safe (example: @scope/name or plugin-name)
  HTTP status : 400
  HTTP body   : Package name must be lowercase and npm-safe (example: @scope/name or plugin-name)

=== empty package name ===
  source error: Package name required
  HTTP status : 400
  HTTP body   : Package name required

=== Slug required (pre-existing 400) ===
  source error: Slug required
  HTTP status : 400
  HTTP body   : Slug required

=== Forbidden: hidden by moderation (pre-existing 403) ===
  source error: Forbidden: hidden by moderation
  HTTP status : 403
  HTTP body   : Forbidden: hidden by moderation

=== Package not found (pre-existing 404) ===
  source error: Package not found
  HTTP status : 404
  HTTP body   : Package not found

=== unknown error 'boom' (truly unexpected 500) ===
  source error: boom
  HTTP status : 500
  HTTP body   : Internal Server Error: boom    <-- interim only; final HEAD returns "Internal Server Error"
```

#### Raw transcript — BEFORE (PR base, `origin/main`)

```
=== xrow/xrow-self-improvement (the original 500 case) ===
  source error: Package name must be lowercase and npm-safe (example: @scope/name or plugin-name)
  HTTP status : 500
  HTTP body   : Internal Server Error

=== empty package name ===
  source error: Package name required
  HTTP status : 500
  HTTP body   : Internal Server Error

=== Slug required (pre-existing 400) ===
  source error: Slug required
  HTTP status : 400
  HTTP body   : Slug required

=== Forbidden: hidden by moderation (pre-existing 403) ===
  source error: Forbidden: hidden by moderation
  HTTP status : 403
  HTTP body   : Forbidden: hidden by moderation

=== Package not found (pre-existing 404) ===
  source error: Package not found
  HTTP status : 404
  HTTP body   : Package not found

=== unknown error 'boom' (truly unexpected 500) ===
  source error: boom
  HTTP status : 500
  HTTP body   : Internal Server Error
```

### 2. Vitest regression run (final HEAD)

```
$ bun run ci:unit
...
✓ convex/httpApiV1.shared.test.ts (2 passed)
✓ convex/httpApiV1.handlers.test.ts (passed, including the `unknown` 500 case)
...
```

`convex/httpApiV1.shared.test.ts` adds two pinned assertions on the final HEAD:

1. The 400 path returns the cleaned validation message.
2. The unknown-failure path stays a generic 500 with body `"Internal Server Error"`.

The `convex/httpApiV1.handlers.test.ts` `unknown` 500 assertion continues to pin the bare `"Internal Server Error"` body, so the on-the-wire 500 contract is unchanged.

### Repro

```bash
# After (final HEAD)
git fetch origin pull/2488/head
git checkout FETCH_HEAD
bun .local/proof-handler.ts

# Before
git checkout origin/main -- convex/httpApiV1/shared.ts
bun .local/proof-handler.ts
git checkout FETCH_HEAD -- convex/httpApiV1/shared.ts
```
<img width="813" height="821" alt="Clipboard_Screenshot_1780545603" src="https://github.com/user-attachments/assets/e79a01d3-a6ce-4ad3-9514-623a72b9edcf" />


[proof-handler.ts](https://github.com/user-attachments/files/28579340/proof-handler.ts)
