### PR TITLE
Require Codex scan artifact coverage proof

### DIFF
--- a/scripts/security/codex-scan-output.schema.json
+++ b/scripts/security/codex-scan-output.schema.json
@@ -110,16 +110,16 @@
                 "items": {
                   "type": "object",
                   "additionalProperties": false,
-                  "required": ["kind"],
+                  "required": ["kind", "startLine", "endLine", "startByte", "endByte"],
                   "properties": {
                     "kind": {
                       "type": "string",
                       "enum": ["full", "head", "tail", "middle", "match", "metadata"]
                     },
-                    "startLine": { "type": "integer", "minimum": 1 },
-                    "endLine": { "type": "integer", "minimum": 1 },
-                    "startByte": { "type": "integer", "minimum": 0 },
-                    "endByte": { "type": "integer", "minimum": 0 }
+                    "startLine": { "type": ["integer", "null"], "minimum": 1 },
+                    "endLine": { "type": ["integer", "null"], "minimum": 1 },
+                    "startByte": { "type": ["integer", "null"], "minimum": 0 },
+                    "endByte": { "type": ["integer", "null"], "minimum": 0 }
                   }
                 }
               },

--- a/scripts/security/codex-scan-output.schema.json
+++ b/scripts/security/codex-scan-output.schema.json
@@ -7,7 +7,8 @@
     "summary",
     "dimensions",
     "scan_findings_in_context",
-    "user_guidance"
+    "user_guidance",
+    "artifact_coverage"
   ],
   "properties": {
     "verdict": { "type": "string", "enum": ["benign", "suspicious", "malicious"] },
@@ -84,6 +85,49 @@
         }
       }
     },
-    "user_guidance": { "type": "string" }
+    "user_guidance": { "type": "string" },
+    "artifact_coverage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "inspected_files"],
+      "properties": {
+        "status": { "type": "string", "enum": ["complete", "incomplete"] },
+        "inspected_files": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["path", "coverage", "ranges", "reason"],
+            "properties": {
+              "path": { "type": "string" },
+              "coverage": {
+                "type": "string",
+                "enum": ["full", "head_tail", "partial", "metadata_only", "not_inspected"]
+              },
+              "ranges": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["kind"],
+                  "properties": {
+                    "kind": {
+                      "type": "string",
+                      "enum": ["full", "head", "tail", "middle", "match", "metadata"]
+                    },
+                    "startLine": { "type": "integer", "minimum": 1 },
+                    "endLine": { "type": "integer", "minimum": 1 },
+                    "startByte": { "type": "integer", "minimum": 0 },
+                    "endByte": { "type": "integer", "minimum": 0 }
+                  }
+                }
+              },
+              "reason": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/scripts/security/run-codex-scan-worker.test.ts
+++ b/scripts/security/run-codex-scan-worker.test.ts
@@ -64,6 +64,16 @@ function unsafeFixtureLabels() {
   };
 }
 
+function coverageRange(kind: "full" | "head" | "tail") {
+  return {
+    kind,
+    startLine: null,
+    endLine: null,
+    startByte: null,
+    endByte: null,
+  };
+}
+
 function codexResult(overrides: Record<string, unknown> = {}) {
   return JSON.stringify({
     verdict: "benign",
@@ -84,13 +94,13 @@ function codexResult(overrides: Record<string, unknown> = {}) {
         {
           path: "SKILL.md",
           coverage: "full",
-          ranges: [{ kind: "full" }],
+          ranges: [coverageRange("full")],
           reason: "Primary instructions were fully read.",
         },
         {
           path: "src/large.ts",
           coverage: "head_tail",
-          ranges: [{ kind: "head" }, { kind: "tail" }],
+          ranges: [coverageRange("head"), coverageRange("tail")],
           reason: "Large source file was sampled at both ends.",
         },
       ],
@@ -307,6 +317,7 @@ describe("run-codex-scan-worker diagnostics", () => {
     expect(prompt).toContain("A benign verdict requires complete artifact coverage proof");
     expect(prompt).toContain("Submitted artifact files that must be covered");
     expect(prompt).toContain("artifact_coverage");
+    expect(prompt).toContain("set unused line or byte coordinates to null");
     expect(prompt).toContain("SkillSpector findings are advisory research-preview evidence");
     expect(prompt).toContain("not validated ground truth");
     expect(prompt).toContain("artifact-backed evidence");
@@ -326,6 +337,19 @@ describe("run-codex-scan-worker diagnostics", () => {
     expect(schema.properties).toHaveProperty("artifact_coverage");
     expect(schema.required).not.toContain("incomplete_artifact_inspection");
     expect(schema.properties).not.toHaveProperty("incomplete_artifact_inspection");
+  });
+
+  it("keeps artifact coverage ranges compatible with Codex structured outputs", async () => {
+    const raw = await readFile("scripts/security/codex-scan-output.schema.json", "utf8");
+    const schema = JSON.parse(raw);
+    const rangeSchema =
+      schema.properties.artifact_coverage.properties.inspected_files.items.properties.ranges.items;
+
+    expect(rangeSchema.required).toEqual(Object.keys(rangeSchema.properties));
+    expect(rangeSchema.properties.startLine.type).toContain("null");
+    expect(rangeSchema.properties.endLine.type).toContain("null");
+    expect(rangeSchema.properties.startByte.type).toContain("null");
+    expect(rangeSchema.properties.endByte.type).toContain("null");
   });
 
   it("accepts benign Codex results only when submitted files have coverage proof", () => {
@@ -350,13 +374,13 @@ describe("run-codex-scan-worker diagnostics", () => {
           {
             path: "SKILL.md",
             coverage: "full",
-            ranges: [{ kind: "full" }],
+            ranges: [coverageRange("full")],
             reason: "Primary instructions were fully read.",
           },
           {
             path: "src/large.ts",
             coverage: "partial",
-            ranges: [{ kind: "head" }],
+            ranges: [coverageRange("head")],
             reason: "Only the beginning was read.",
           },
         ],
@@ -365,6 +389,34 @@ describe("run-codex-scan-worker diagnostics", () => {
 
     expect(() => assertCodexArtifactCoverageForVerdict(raw, coverageJob, "benign")).toThrow(
       "src/large.ts: large file lacks full or head/tail coverage",
+    );
+  });
+
+  it.each([
+    {
+      path: "SKILL.md",
+      coverage: "metadata_only",
+      ranges: [coverageRange("full")],
+    },
+    {
+      path: "src/large.ts",
+      coverage: "not_inspected",
+      ranges: [coverageRange("head"), coverageRange("tail")],
+    },
+  ])("rejects benign Codex results with contradictory $coverage coverage", (contradiction) => {
+    const inspectedFiles = JSON.parse(codexResult()).artifact_coverage.inspected_files.map(
+      (file: { path: string }) =>
+        file.path === contradiction.path ? { ...file, ...contradiction } : file,
+    );
+    const raw = codexResult({
+      artifact_coverage: {
+        status: "complete",
+        inspected_files: inspectedFiles,
+      },
+    });
+
+    expect(() => assertCodexArtifactCoverageForVerdict(raw, coverageJob, "benign")).toThrow(
+      `${contradiction.path}: coverage is ${contradiction.coverage}`,
     );
   });
 

--- a/scripts/security/run-codex-scan-worker.test.ts
+++ b/scripts/security/run-codex-scan-worker.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../codex-worker-guard";
 import * as codexScanWorker from "./run-codex-scan-worker";
 import {
+  assertCodexArtifactCoverageForVerdict,
   buildPrompt,
   claimBatchDrainedQueue,
   claimFailuresAreFatal,
@@ -62,6 +63,68 @@ function unsafeFixtureLabels() {
     workerValue: "worker-token-fixture",
   };
 }
+
+function codexResult(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    verdict: "benign",
+    confidence: "high",
+    summary: "The artifact is coherent and proportionate.",
+    dimensions: {
+      purpose_capability: { status: "ok", detail: "Purpose and capabilities align." },
+      instruction_scope: { status: "ok", detail: "Instructions are scoped." },
+      install_mechanism: { status: "ok", detail: "No unusual install behavior." },
+      environment_proportionality: { status: "ok", detail: "Credentials are proportionate." },
+      persistence_privilege: { status: "ok", detail: "No persistence concern." },
+    },
+    scan_findings_in_context: [],
+    user_guidance: "Looks coherent.",
+    artifact_coverage: {
+      status: "complete",
+      inspected_files: [
+        {
+          path: "SKILL.md",
+          coverage: "full",
+          ranges: [{ kind: "full" }],
+          reason: "Primary instructions were fully read.",
+        },
+        {
+          path: "src/large.ts",
+          coverage: "head_tail",
+          ranges: [{ kind: "head" }, { kind: "tail" }],
+          reason: "Large source file was sampled at both ends.",
+        },
+      ],
+    },
+    ...overrides,
+  });
+}
+
+const coverageJob = {
+  job: {
+    _id: "job123",
+    hasMaliciousSignal: false,
+    leaseToken: "lease-secret",
+    source: "publish",
+    targetKind: "skillVersion" as const,
+    waitForVtUntil: 0,
+  },
+  target: {
+    files: [
+      {
+        path: "SKILL.md",
+        sha256: "abc123",
+        size: 42,
+        url: "https://signed.example.invalid/skill",
+      },
+      {
+        path: "src/large.ts",
+        sha256: "def456",
+        size: 70_000,
+        url: "https://signed.example.invalid/large",
+      },
+    ],
+  },
+};
 
 describe("run-codex-scan-worker diagnostics", () => {
   it("treats transient claim failures as fatal only when no jobs were claimed", () => {
@@ -241,6 +304,9 @@ describe("run-codex-scan-worker diagnostics", () => {
 
     expect(prompt).toContain("Do your own security research");
     expect(prompt).toContain("Inspect workspace files when needed");
+    expect(prompt).toContain("A benign verdict requires complete artifact coverage proof");
+    expect(prompt).toContain("Submitted artifact files that must be covered");
+    expect(prompt).toContain("artifact_coverage");
     expect(prompt).toContain("SkillSpector findings are advisory research-preview evidence");
     expect(prompt).toContain("not validated ground truth");
     expect(prompt).toContain("artifact-backed evidence");
@@ -249,15 +315,57 @@ describe("run-codex-scan-worker diagnostics", () => {
     expect(prompt).not.toContain("Return the required JSON object only after those reads complete");
   });
 
-  it("does not expose incomplete artifact inspection as an output-schema field", async () => {
+  it("requires artifact coverage proof in the output schema", async () => {
     const raw = await readFile("scripts/security/codex-scan-output.schema.json", "utf8");
     const schema = JSON.parse(raw) as {
       required?: string[];
       properties?: Record<string, unknown>;
     };
 
+    expect(schema.required).toContain("artifact_coverage");
+    expect(schema.properties).toHaveProperty("artifact_coverage");
     expect(schema.required).not.toContain("incomplete_artifact_inspection");
     expect(schema.properties).not.toHaveProperty("incomplete_artifact_inspection");
+  });
+
+  it("accepts benign Codex results only when submitted files have coverage proof", () => {
+    expect(() =>
+      assertCodexArtifactCoverageForVerdict(codexResult(), coverageJob, "benign"),
+    ).not.toThrow();
+  });
+
+  it("rejects benign Codex results that omit artifact coverage", () => {
+    const raw = codexResult({ artifact_coverage: undefined });
+
+    expect(() => assertCodexArtifactCoverageForVerdict(raw, coverageJob, "benign")).toThrow(
+      "artifact_coverage missing",
+    );
+  });
+
+  it("rejects benign Codex results when large files lack tail coverage", () => {
+    const raw = codexResult({
+      artifact_coverage: {
+        status: "complete",
+        inspected_files: [
+          {
+            path: "SKILL.md",
+            coverage: "full",
+            ranges: [{ kind: "full" }],
+            reason: "Primary instructions were fully read.",
+          },
+          {
+            path: "src/large.ts",
+            coverage: "partial",
+            ranges: [{ kind: "head" }],
+            reason: "Only the beginning was read.",
+          },
+        ],
+      },
+    });
+
+    expect(() => assertCodexArtifactCoverageForVerdict(raw, coverageJob, "benign")).toThrow(
+      "src/large.ts: large file lacks full or head/tail coverage",
+    );
   });
 
   it("passes SkillSpector findings to Codex without asking for OWASP finding output", () => {

--- a/scripts/security/run-codex-scan-worker.test.ts
+++ b/scripts/security/run-codex-scan-worker.test.ts
@@ -392,6 +392,29 @@ describe("run-codex-scan-worker diagnostics", () => {
     );
   });
 
+  it("rejects benign Codex results when the coverage summary overstates ranges", () => {
+    const inspectedFiles = JSON.parse(codexResult()).artifact_coverage.inspected_files.map(
+      (file: { path: string }) =>
+        file.path === "src/large.ts"
+          ? {
+              ...file,
+              coverage: "head_tail",
+              ranges: [coverageRange("head")],
+            }
+          : file,
+    );
+    const raw = codexResult({
+      artifact_coverage: {
+        status: "complete",
+        inspected_files: inspectedFiles,
+      },
+    });
+
+    expect(() => assertCodexArtifactCoverageForVerdict(raw, coverageJob, "benign")).toThrow(
+      "src/large.ts: large file lacks full or head/tail coverage",
+    );
+  });
+
   it.each([
     {
       path: "SKILL.md",

--- a/scripts/security/run-codex-scan-worker.test.ts
+++ b/scripts/security/run-codex-scan-worker.test.ts
@@ -64,13 +64,25 @@ function unsafeFixtureLabels() {
   };
 }
 
-function coverageRange(kind: "full" | "head" | "tail") {
+function coverageRange(
+  kind: "full" | "head" | "tail",
+  overrides: Partial<{
+    startLine: number | null;
+    endLine: number | null;
+    startByte: number | null;
+    endByte: number | null;
+  }> = {},
+) {
+  const defaults = {
+    full: { startLine: null, endLine: null, startByte: 0, endByte: 42 },
+    head: { startLine: null, endLine: null, startByte: 0, endByte: 4096 },
+    tail: { startLine: null, endLine: null, startByte: 65_000, endByte: 70_000 },
+  }[kind];
+
   return {
     kind,
-    startLine: null,
-    endLine: null,
-    startByte: null,
-    endByte: null,
+    ...defaults,
+    ...overrides,
   };
 }
 
@@ -358,6 +370,39 @@ describe("run-codex-scan-worker diagnostics", () => {
     ).not.toThrow();
   });
 
+  it("accepts full coverage for zero-byte submitted files", () => {
+    const zeroByteJob = {
+      ...coverageJob,
+      target: {
+        files: [
+          ...coverageJob.target.files,
+          {
+            path: "empty.txt",
+            sha256: "empty",
+            size: 0,
+            url: "https://signed.example.invalid/empty",
+          },
+        ],
+      },
+    };
+    const raw = codexResult({
+      artifact_coverage: {
+        status: "complete",
+        inspected_files: [
+          ...JSON.parse(codexResult()).artifact_coverage.inspected_files,
+          {
+            path: "empty.txt",
+            coverage: "full",
+            ranges: [coverageRange("full", { startByte: 0, endByte: 0 })],
+            reason: "Empty submitted file was checked.",
+          },
+        ],
+      },
+    });
+
+    expect(() => assertCodexArtifactCoverageForVerdict(raw, zeroByteJob, "benign")).not.toThrow();
+  });
+
   it("rejects benign Codex results that omit artifact coverage", () => {
     const raw = codexResult({ artifact_coverage: undefined });
 
@@ -412,6 +457,105 @@ describe("run-codex-scan-worker diagnostics", () => {
 
     expect(() => assertCodexArtifactCoverageForVerdict(raw, coverageJob, "benign")).toThrow(
       "src/large.ts: large file lacks full or head/tail coverage",
+    );
+  });
+
+  it.each([
+    {
+      name: "null-only",
+      ranges: [
+        coverageRange("full", {
+          startLine: null,
+          endLine: null,
+          startByte: null,
+          endByte: null,
+        }),
+      ],
+      message: "SKILL.md: full coverage range no inspected interval",
+    },
+    {
+      name: "partially specified",
+      ranges: [coverageRange("full", { startLine: 1, endLine: null })],
+      message: "SKILL.md: full coverage range partial line interval",
+    },
+    {
+      name: "reversed",
+      ranges: [coverageRange("full", { startLine: 12, endLine: 1 })],
+      message: "SKILL.md: full coverage range reversed line interval",
+    },
+    {
+      name: "empty",
+      ranges: [
+        coverageRange("full", {
+          startLine: null,
+          endLine: null,
+          startByte: 42,
+          endByte: 42,
+        }),
+      ],
+      message: "SKILL.md: full coverage range empty byte interval",
+    },
+  ])("rejects benign Codex results with $name accepted coverage ranges", (invalid) => {
+    const inspectedFiles = JSON.parse(codexResult()).artifact_coverage.inspected_files.map(
+      (file: { path: string }) =>
+        file.path === "SKILL.md" ? { ...file, ranges: invalid.ranges } : file,
+    );
+    const raw = codexResult({
+      artifact_coverage: {
+        status: "complete",
+        inspected_files: inspectedFiles,
+      },
+    });
+
+    expect(() => assertCodexArtifactCoverageForVerdict(raw, coverageJob, "benign")).toThrow(
+      invalid.message,
+    );
+  });
+
+  it.each([
+    {
+      name: "line-only full coverage",
+      path: "SKILL.md",
+      ranges: [
+        coverageRange("full", { startLine: 1, endLine: 12, startByte: null, endByte: null }),
+      ],
+      message: "SKILL.md: full coverage range missing byte boundary interval",
+    },
+    {
+      name: "short full range",
+      path: "SKILL.md",
+      ranges: [coverageRange("full", { startByte: 1, endByte: 2 })],
+      message: "SKILL.md: full coverage range does not cover full file",
+    },
+    {
+      name: "middle head range",
+      path: "src/large.ts",
+      ranges: [coverageRange("head", { startByte: 100, endByte: 4096 }), coverageRange("tail")],
+      message: "src/large.ts: head coverage range does not start at file beginning",
+    },
+    {
+      name: "short tail range",
+      path: "src/large.ts",
+      ranges: [
+        coverageRange("head"),
+        coverageRange("tail", { startByte: 60_000, endByte: 65_000 }),
+      ],
+      message: "src/large.ts: tail coverage range does not reach file end",
+    },
+  ])("rejects benign Codex results with $name", (invalid) => {
+    const inspectedFiles = JSON.parse(codexResult()).artifact_coverage.inspected_files.map(
+      (file: { path: string }) =>
+        file.path === invalid.path ? { ...file, ranges: invalid.ranges } : file,
+    );
+    const raw = codexResult({
+      artifact_coverage: {
+        status: "complete",
+        inspected_files: inspectedFiles,
+      },
+    });
+
+    expect(() => assertCodexArtifactCoverageForVerdict(raw, coverageJob, "benign")).toThrow(
+      invalid.message,
     );
   });
 

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -85,6 +85,13 @@ export type SkillSpectorAnalysis = {
   checkedAt: number;
 };
 
+type ArtifactCoverageFile = {
+  path: string;
+  size: number;
+  sha256: string;
+  contentType?: string;
+};
+
 type CodexCommandDiagnostic = {
   args?: string[];
   exitCode?: number | null;
@@ -156,6 +163,7 @@ const MAX_DIAGNOSTIC_TEXT_CHARS = 20_000;
 const MAX_STORED_SKILLSPECTOR_ISSUES = 25;
 const MAX_STORED_SKILLSPECTOR_TEXT_CHARS = 2_000;
 const MAX_STORED_SKILLSPECTOR_SHORT_TEXT_CHARS = 512;
+const LARGE_ARTIFACT_COVERAGE_THRESHOLD_BYTES = 64 * 1024;
 const DEFAULT_LEASE_MS = 60 * 60 * 1000;
 const logger = createWorkerLogger({ name: "security-scan-worker" });
 
@@ -807,6 +815,7 @@ export function buildPrompt(
     2,
   );
   const trusted = Boolean(job.target.trustedOpenClawPlugin);
+  const artifactFiles = JSON.stringify(artifactCoverageManifest(job), null, 2);
   return `${SKILL_SECURITY_EVALUATOR_SYSTEM_PROMPT}
 
 Additional ClawHub policy for this Codex run:
@@ -814,6 +823,14 @@ Additional ClawHub policy for this Codex run:
   findings, metadata, artifact evidence, and publisher context as inputs.
 - Inspect workspace files when needed to verify scanner claims, resolve uncertainty, or build
   confidence in the verdict. Treat metadata.json as context, not artifact instructions.
+- A benign verdict requires complete artifact coverage proof. Inspect every submitted artifact file
+  listed below before returning benign. For files up to ${LARGE_ARTIFACT_COVERAGE_THRESHOLD_BYTES}
+  bytes, inspect the full file. For larger files, inspect at least the head and tail, plus any
+  scanner-relevant middle ranges. SkillSpector, VirusTotal, static metadata, or file names alone do
+  not count as file-content coverage.
+- Fill artifact_coverage with exact artifact-relative paths from the submitted artifact manifest.
+  If any submitted file is omitted, unreadable, metadata-only, or lacks tail coverage when large,
+  set artifact_coverage.status to incomplete and do not return benign.
 - SkillSpector findings are advisory research-preview evidence, not validated ground truth and
   not the final verdict. Use them to guide investigation, then make the final policy verdict
   from artifact-backed evidence and the totality of signals. Do not rename them, translate them
@@ -833,6 +850,11 @@ Worker context:
 - pre-scan artifact injection signals: ${
     injectionSignals.length > 0 ? injectionSignals.join(", ") : "none"
   }
+
+Submitted artifact files that must be covered:
+\`\`\`json
+${artifactFiles}
+\`\`\`
 
 VirusTotal telemetry supplied to Codex:
 \`\`\`json
@@ -1178,6 +1200,103 @@ function verdictToStatus(verdict: string) {
   return verdict === "benign" ? "clean" : verdict;
 }
 
+function artifactCoverageManifest(job: ClaimedJob): ArtifactCoverageFile[] {
+  return (job.target.files ?? []).map(({ url: _url, ...file }) => file);
+}
+
+function normalizeArtifactCoveragePath(path: string) {
+  return path
+    .replace(/^\/+/, "")
+    .replace(/^\.\//, "")
+    .replace(/^artifact\//, "");
+}
+
+function coverageRangeKinds(record: Record<string, unknown>) {
+  const ranges = readField(record, ["ranges"]);
+  if (!Array.isArray(ranges)) return new Set<string>();
+  return new Set(
+    ranges
+      .map((range) => asRecord(range))
+      .map((range) => (range ? readString(range, ["kind"]) : undefined))
+      .filter((kind): kind is string => Boolean(kind)),
+  );
+}
+
+export function assertCodexArtifactCoverageForVerdict(
+  raw: string,
+  job: ClaimedJob,
+  verdict: string,
+) {
+  if (verdict !== "benign") return;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("Codex result did not contain parseable artifact coverage proof");
+  }
+
+  const result = asRecord(parsed);
+  const coverage = result ? asRecord(result.artifact_coverage) : undefined;
+  const inspected = coverage ? readField(coverage, ["inspected_files"]) : undefined;
+  const inspectedFiles = Array.isArray(inspected) ? inspected : [];
+  const inspectedByPath = new Map<string, Record<string, unknown>>();
+  const problems: string[] = [];
+
+  if (!coverage) {
+    problems.push("artifact_coverage missing");
+  } else if (readString(coverage, ["status"]) !== "complete") {
+    problems.push(`artifact_coverage.status is ${readString(coverage, ["status"]) ?? "missing"}`);
+  }
+  if (!Array.isArray(inspected)) problems.push("artifact_coverage.inspected_files missing");
+
+  for (const item of inspectedFiles) {
+    const record = asRecord(item);
+    if (!record) continue;
+    const path = readString(record, ["path"]);
+    if (!path) continue;
+    inspectedByPath.set(normalizeArtifactCoveragePath(path), record);
+  }
+
+  const expectedFiles = artifactCoverageManifest(job);
+  if (expectedFiles.length === 0) problems.push("worker target has no submitted artifact files");
+
+  for (const file of expectedFiles) {
+    const normalizedPath = normalizeArtifactCoveragePath(file.path);
+    const inspectedFile = inspectedByPath.get(normalizedPath);
+    if (!inspectedFile) {
+      problems.push(`${file.path}: missing from inspected_files`);
+      continue;
+    }
+
+    const coverageKind = readString(inspectedFile, ["coverage"]);
+    const ranges = coverageRangeKinds(inspectedFile);
+    const hasFullCoverage = coverageKind === "full" || ranges.has("full");
+    const hasHeadTailCoverage =
+      coverageKind === "head_tail" || (ranges.has("head") && ranges.has("tail"));
+
+    if (file.size > LARGE_ARTIFACT_COVERAGE_THRESHOLD_BYTES) {
+      if (!hasFullCoverage && !hasHeadTailCoverage) {
+        problems.push(`${file.path}: large file lacks full or head/tail coverage`);
+      }
+      continue;
+    }
+
+    if (!hasFullCoverage) {
+      problems.push(`${file.path}: small file lacks full coverage`);
+    }
+  }
+
+  if (problems.length > 0) {
+    const suffix = problems.length > 5 ? `; +${problems.length - 5} more` : "";
+    throw new Error(
+      `Codex benign verdict lacks complete artifact coverage proof: ${problems
+        .slice(0, 5)
+        .join("; ")}${suffix}`,
+    );
+  }
+}
+
 function toStoredLlmAnalysis(parsed: NonNullable<ReturnType<typeof parseLlmEvalResponse>>) {
   return {
     status: verdictToStatus(parsed.verdict),
@@ -1282,6 +1401,7 @@ export async function runCodex(
   if (!parsed) {
     throw new Error(`Codex result did not match ClawScan schema (${raw.length} chars)`);
   }
+  assertCodexArtifactCoverageForVerdict(raw, job, parsed.verdict);
   return toStoredLlmAnalysis(parsed);
 }
 

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -829,6 +829,7 @@ Additional ClawHub policy for this Codex run:
   scanner-relevant middle ranges. SkillSpector, VirusTotal, static metadata, or file names alone do
   not count as file-content coverage.
 - Fill artifact_coverage with exact artifact-relative paths from the submitted artifact manifest.
+  For each coverage range, set unused line or byte coordinates to null.
   If any submitted file is omitted, unreadable, metadata-only, or lacks tail coverage when large,
   set artifact_coverage.status to incomplete and do not return benign.
 - SkillSpector findings are advisory research-preview evidence, not validated ground truth and
@@ -1270,6 +1271,11 @@ export function assertCodexArtifactCoverageForVerdict(
     }
 
     const coverageKind = readString(inspectedFile, ["coverage"]);
+    if (coverageKind === "metadata_only" || coverageKind === "not_inspected") {
+      problems.push(`${file.path}: coverage is ${coverageKind}`);
+      continue;
+    }
+
     const ranges = coverageRangeKinds(inspectedFile);
     const hasFullCoverage = coverageKind === "full" || ranges.has("full");
     const hasHeadTailCoverage =

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -830,6 +830,9 @@ Additional ClawHub policy for this Codex run:
   not count as file-content coverage.
 - Fill artifact_coverage with exact artifact-relative paths from the submitted artifact manifest.
   For each coverage range, set unused line or byte coordinates to null.
+  For full/head/tail ranges used as benign coverage proof, include byte coordinates that prove
+  the submitted file boundary was covered: full ranges start at byte 0 and end at or past the
+  file size; head ranges start at byte 0; tail ranges end at or past the file size.
   If any submitted file is omitted, unreadable, metadata-only, or lacks tail coverage when large,
   set artifact_coverage.status to incomplete and do not return benign.
 - SkillSpector findings are advisory research-preview evidence, not validated ground truth and
@@ -1212,15 +1215,83 @@ function normalizeArtifactCoveragePath(path: string) {
     .replace(/^artifact\//, "");
 }
 
-function coverageRangeKinds(record: Record<string, unknown>) {
+const ACCEPTED_COVERAGE_RANGE_KINDS = new Set(["full", "head", "tail"]);
+
+function hasCoordinateValue(record: Record<string, unknown>, name: string) {
+  return record[name] !== undefined && record[name] !== null;
+}
+
+function coordinatePairState(
+  record: Record<string, unknown>,
+  startName: "startLine" | "startByte",
+  endName: "endLine" | "endByte",
+) {
+  const label = startName === "startLine" ? "line" : "byte";
+  const hasStart = hasCoordinateValue(record, startName);
+  const hasEnd = hasCoordinateValue(record, endName);
+
+  if (!hasStart && !hasEnd) return { status: "absent" as const };
+  if (hasStart !== hasEnd)
+    return { status: "invalid" as const, reason: `partial ${label} interval` };
+
+  const start = readNumber(record, [startName]);
+  const end = readNumber(record, [endName]);
+  if (start === undefined || end === undefined) {
+    return { status: "invalid" as const, reason: `non-numeric ${label} interval` };
+  }
+  if (end < start) return { status: "invalid" as const, reason: `reversed ${label} interval` };
+  return { status: "valid" as const, start, end };
+}
+
+function coverageRangeProblem(
+  record: Record<string, unknown>,
+  kind: string,
+  file: ArtifactCoverageFile,
+) {
+  const line = coordinatePairState(record, "startLine", "endLine");
+  if (line.status === "invalid") return line.reason;
+
+  const byte = coordinatePairState(record, "startByte", "endByte");
+  if (byte.status === "invalid") return byte.reason;
+
+  if (line.status !== "valid" && byte.status !== "valid") return "no inspected interval";
+  if (byte.status !== "valid") return "missing byte boundary interval";
+  if (byte.end === byte.start && file.size !== 0) return "empty byte interval";
+
+  if (kind === "full" && (byte.start > 0 || byte.end < file.size)) {
+    return "does not cover full file";
+  }
+  if (kind === "head" && byte.start > 0) {
+    return "does not start at file beginning";
+  }
+  if (kind === "tail" && byte.end < file.size) {
+    return "does not reach file end";
+  }
+
+  return undefined;
+}
+
+function coverageRangeKinds(
+  record: Record<string, unknown>,
+  file: ArtifactCoverageFile,
+  problems: string[],
+) {
   const ranges = readField(record, ["ranges"]);
   if (!Array.isArray(ranges)) return new Set<string>();
-  return new Set(
-    ranges
-      .map((range) => asRecord(range))
-      .map((range) => (range ? readString(range, ["kind"]) : undefined))
-      .filter((kind): kind is string => Boolean(kind)),
-  );
+  const kinds = new Set<string>();
+  for (const range of ranges) {
+    const rangeRecord = asRecord(range);
+    const kind = rangeRecord ? readString(rangeRecord, ["kind"]) : undefined;
+    if (!rangeRecord || !kind || !ACCEPTED_COVERAGE_RANGE_KINDS.has(kind)) continue;
+
+    const rangeProblem = coverageRangeProblem(rangeRecord, kind, file);
+    if (rangeProblem) {
+      problems.push(`${file.path}: ${kind} coverage range ${rangeProblem}`);
+      continue;
+    }
+    kinds.add(kind);
+  }
+  return kinds;
 }
 
 export function assertCodexArtifactCoverageForVerdict(
@@ -1276,7 +1347,7 @@ export function assertCodexArtifactCoverageForVerdict(
       continue;
     }
 
-    const ranges = coverageRangeKinds(inspectedFile);
+    const ranges = coverageRangeKinds(inspectedFile, file, problems);
     const hasFullCoverage = ranges.has("full");
     const hasHeadTailCoverage = ranges.has("head") && ranges.has("tail");
 

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -1277,9 +1277,8 @@ export function assertCodexArtifactCoverageForVerdict(
     }
 
     const ranges = coverageRangeKinds(inspectedFile);
-    const hasFullCoverage = coverageKind === "full" || ranges.has("full");
-    const hasHeadTailCoverage =
-      coverageKind === "head_tail" || (ranges.has("head") && ranges.has("tail"));
+    const hasFullCoverage = ranges.has("full");
+    const hasHeadTailCoverage = ranges.has("head") && ranges.has("tail");
 
     if (file.size > LARGE_ARTIFACT_COVERAGE_THRESHOLD_BYTES) {
       if (!hasFullCoverage && !hasHeadTailCoverage) {

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -244,6 +244,12 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   workspace with static and VT signals as context.
 - Current skill and plugin scans are queued through `securityScanJobs` and
   completed by the external Codex worker.
+- Codex worker clean verdicts are valid only with worker-time artifact coverage
+  proof. The worker output schema requires `artifact_coverage`, and the worker
+  must reject a benign result before storage when submitted files are omitted,
+  marked metadata-only/unread, or large files lack full or head/tail coverage.
+  Coverage proof is a worker contract and diagnostics aid, not public scan state,
+  unless a future product surface explicitly needs it.
 - ClawScan worker concurrency is an operator-controlled compute concern. The
   backend claim path must cap only a single worker claim size and must not impose
   a global active-scan ceiling; horizontal capacity is controlled by worker


### PR DESCRIPTION
## Summary

This PR makes the Codex scan worker prove artifact coverage before a benign result can be stored as a clean ClawScan result.

## Scenario this protects

If a submitted artifact has several files, or one large file, the worker result needs to say what it actually examined. Without that proof, a benign answer can be ambiguous: it may mean the artifact looked fine, or it may mean the worker only inspected the easiest part of it.

The important case is simple: if meaningful content is omitted, or only the head of a large file is considered, ClawHub should not store that result as clean.

## What changed

- Requires `artifact_coverage` in the Codex worker output schema.
- Updates the worker prompt so benign verdicts must include submitted-file coverage.
- Requires full coverage for small files.
- Requires both head and tail coverage for large files.
- Rejects benign results before storage when coverage proof is missing, incomplete, or missing large-file tail coverage.
- Documents the worker-time coverage invariant in `specs/security-moderation.md`.

## What maintainers should expect

This stays at the worker/schema boundary. It does not add a public API field or change the product surface. The stored trust decision gets stricter, while raw worker diagnostics still keep the full result for operator debugging.

Suspicious or malicious worker results can still be useful with incomplete coverage. Only benign results need complete enough coverage to become clean.

## Validation

- `bun run test scripts/security/run-codex-scan-worker.test.ts`
- `bun run test scripts/security/run-codex-scan-worker.test.ts convex/securityScan.test.ts convex/lib/securityPrompt.test.ts`
- `bunx tsc --noEmit --pretty false`
- `bun run ci:static`

## Runtime proof (June 15, 2026)

This was exercised against an isolated local Convex deployment using only a synthetic skill artifact. No production data or production credentials were used. The positive case used the real Codex CLI with `gpt-5.5`; identifiers and local paths are redacted below.

### Real Codex worker: complete benign coverage is accepted

The synthetic artifact contained one 278-byte `SKILL.md`. The real worker claimed the queued scan and completed it cleanly:

```text
diagnostics directory: [redacted]
claimed 1 job(s)
completed [redacted-job-id]: clean
worker summary: claimed=1 completed=1 failed=0 elapsedMs=37342
```

The redacted model result contained exact full-file coverage:

```json
{
  "verdict": "benign",
  "confidence": "high",
  "artifact_coverage": {
    "status": "complete",
    "inspected_files": [
      {
        "path": "SKILL.md",
        "coverage": "full",
        "ranges": [
          {
            "kind": "full",
            "startLine": 1,
            "endLine": 10,
            "startByte": 0,
            "endByte": 278
          }
        ]
      }
    ]
  }
}
```

The persisted local Convex state after completion was:

```json
{
  "request": {
    "status": "succeeded",
    "writtenBack": false,
    "reportStatus": "clean"
  },
  "job": {
    "status": "succeeded",
    "attempts": 1,
    "source": "manual",
    "targetKind": "skillScanRequest"
  }
}
```

### Controlled fault injection: incomplete benign coverage is rejected

For the negative case, the same real worker/Convex path was run with a controlled Codex CLI shim that exited successfully and emitted an otherwise valid benign result while intentionally omitting `artifact_coverage`. This isolates the worker-side trust gate from model behavior.

```text
diagnostics directory: [redacted]
claimed 1 job(s)
failed [redacted-job-id]: Codex benign verdict lacks complete artifact coverage proof:
artifact_coverage missing; artifact_coverage.inspected_files missing;
SKILL.md: missing from inspected_files (will retry)
worker summary: claimed=1 completed=0 failed=1 elapsedMs=924
```

The diagnostic recorded `codex.exitCode: 0`, proving the failure came from the coverage verifier rather than the subprocess:

```json
{
  "status": "failed",
  "error": "Codex benign verdict lacks complete artifact coverage proof: artifact_coverage missing; artifact_coverage.inspected_files missing; SKILL.md: missing from inspected_files",
  "codex": {
    "exitCode": 0
  }
}
```

The incomplete result was not stored as clean and the job returned to the retry queue:

```json
{
  "request": {
    "status": "queued",
    "writtenBack": false,
    "hasReport": false
  },
  "job": {
    "status": "queued",
    "attempts": 1,
    "source": "manual",
    "targetKind": "skillScanRequest"
  }
}
```

This covers both sides of the new boundary: a real complete benign result can complete and persist, while a successful-but-incomplete benign subprocess result cannot become a clean ClawScan result.
