### PR TITLE
Flag context-padding scan evasion

### DIFF
--- a/convex/githubSkillSync.test.ts
+++ b/convex/githubSkillSync.test.ts
@@ -1636,6 +1636,110 @@ describe("applyGitHubSkillVerificationResultHandler", () => {
       updatedAt: 123,
     });
   });
+
+  it("retains padding-only static evidence while keeping GitHub installability clean", async () => {
+    const { db, tables } = createDb({
+      skills: [
+        {
+          _id: "skills:padded",
+          slug: "padded",
+          displayName: "Padded",
+          ownerUserId: "users:nvidia",
+          ownerPublisherId: "publishers:nvidia",
+          installKind: "github",
+          githubSourceId: "githubSkillSources:nvidia",
+          githubPath: "skills/padded",
+          githubCurrentCommit: "4".repeat(40),
+          githubCurrentContentHash: "padded-hash",
+          githubCurrentStatus: "present",
+          githubScanStatus: "pending",
+          tags: {},
+          stats: { downloads: 0, stars: 0, installsCurrent: 0, installsAllTime: 0, versions: 0 },
+          moderationStatus: "active",
+          moderationReason: "pending.scan",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      githubSkillSources: [
+        {
+          _id: "githubSkillSources:nvidia",
+          repo: "NVIDIA/skills",
+          ownerUserId: "users:nvidia",
+          ownerPublisherId: "publishers:nvidia",
+          defaultBranch: "main",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      globalStats: [
+        {
+          _id: "globalStats:default",
+          key: "default",
+          activeSkillsCount: 10,
+          updatedAt: 1,
+        },
+      ],
+    });
+
+    const staticScan = {
+      status: "suspicious" as const,
+      reasonCodes: ["suspicious.context_padding_truncation"],
+      findings: [
+        {
+          code: "suspicious.context_padding_truncation",
+          severity: "warn" as const,
+          file: "SKILL.md",
+          line: 2,
+          message:
+            "Extreme context padding hides later artifact content from context-limited review.",
+          evidence:
+            "2100 consecutive blank/whitespace-only lines before later artifact content; content resumes at line 2102.",
+        },
+      ],
+      summary: "Detected: suspicious.context_padding_truncation",
+      engineVersion: "test-engine",
+      checkedAt: 456,
+    };
+
+    const promoted = await applyGitHubSkillVerificationResultHandler({ db } as never, {
+      skillId: "skills:padded" as never,
+      contentHash: "padded-hash",
+      scanStatus: "clean",
+      staticScan,
+      now: 789,
+    });
+
+    expect(promoted).toEqual({ ok: true, promoted: true });
+    expect(tables.skills[0]).toMatchObject({
+      githubScanStatus: "clean",
+      moderationStatus: "active",
+      moderationReason: "scanner.aggregate.suspicious",
+      moderationVerdict: "suspicious",
+      moderationFlags: ["flagged.suspicious"],
+      moderationReasonCodes: ["suspicious.context_padding_truncation"],
+      moderationEvidence: [
+        expect.objectContaining({
+          code: "suspicious.context_padding_truncation",
+          file: "SKILL.md",
+        }),
+      ],
+      moderationSummary: "Detected: suspicious.context_padding_truncation",
+      moderationEngineVersion: "test-engine",
+      moderationEvaluatedAt: 456,
+      isSuspicious: true,
+    });
+    expect(resolveInstallFromTables(tables, "padded")).toMatchObject({
+      ok: true,
+      installKind: "github",
+      github: {
+        repo: "NVIDIA/skills",
+        path: "skills/padded",
+        commit: "4".repeat(40),
+        contentHash: "padded-hash",
+      },
+    });
+  });
 });
 
 describe("verifyGitHubSkillHandler", () => {
@@ -1769,6 +1873,16 @@ describe("verifyGitHubSkillHandler", () => {
         skillId: "skills:padded",
         contentHash,
         scanStatus: "clean",
+        staticScan: expect.objectContaining({
+          status: "suspicious",
+          reasonCodes: ["suspicious.context_padding_truncation"],
+          findings: [
+            expect.objectContaining({
+              code: "suspicious.context_padding_truncation",
+              file: "SKILL.md",
+            }),
+          ],
+        }),
       }),
     );
   });

--- a/convex/githubSkillSync.test.ts
+++ b/convex/githubSkillSync.test.ts
@@ -1704,6 +1704,74 @@ describe("verifyGitHubSkillHandler", () => {
       }),
     );
   });
+
+  it("keeps context-padding-only findings from blocking GitHub-backed installs", async () => {
+    const commit = "4".repeat(40);
+    const zip = zipSync({
+      "skills-main/skills/padded/SKILL.md": new TextEncoder().encode(
+        `# Padded\n${"\n".repeat(2_100)}Use the configured API.\n`,
+      ),
+    });
+    const snapshot = await buildGitHubSkillSourceSnapshot({
+      repo: "NVIDIA/skills",
+      defaultBranch: "main",
+      commit,
+      entries: stripGitHubZipRoot(__test.unzipToEntries(zip)),
+    });
+    const contentHash = snapshot.skills[0]?.contentHash;
+    if (!contentHash) throw new Error("missing fixture hash");
+
+    const runMutation = vi.fn(async () => ({ ok: true, promoted: false }));
+    const ctx = {
+      runQuery: vi.fn(async () => ({
+        skill: {
+          _id: "skills:padded",
+          slug: "padded",
+          displayName: "Padded",
+          summary: "Padded skill",
+          githubPath: "skills/padded",
+          githubCurrentCommit: commit,
+          githubCurrentContentHash: contentHash,
+          githubCurrentStatus: "present",
+        },
+        source: {
+          _id: "githubSkillSources:nvidia",
+          repo: "NVIDIA/skills",
+          defaultBranch: "main",
+        },
+      })),
+      runMutation,
+    };
+    const fetcher = vi.fn(async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.startsWith("https://api.github.com/")) {
+        return new Response(JSON.stringify({ sha: commit }), {
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url.startsWith("https://codeload.github.com/")) {
+        return new Response(zip, { headers: { "content-length": String(zip.byteLength) } });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    const result = await verifyGitHubSkillHandler(
+      ctx as never,
+      { skillId: "skills:padded" as never, contentHash },
+      fetcher as unknown as typeof fetch,
+    );
+
+    expect(result).toMatchObject({ ok: true, scanStatus: "clean" });
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        skillId: "skills:padded",
+        contentHash,
+        scanStatus: "clean",
+      }),
+    );
+  });
 });
 
 describe("recordGitHubSkillSourceSyncAttemptHandler", () => {

--- a/convex/githubSkillSync.ts
+++ b/convex/githubSkillSync.ts
@@ -26,6 +26,7 @@ import { adjustGlobalPublicSkillsCount, getPublicSkillVisibilityDelta } from "./
 import { runStaticModerationScan } from "./lib/moderationEngine";
 import { Events, logErrorEvent, logEvent } from "./lib/observabilityEvents";
 import { isOfficialPublisher } from "./lib/officialPublishers";
+import { REASON_CODES } from "./lib/moderationReasonCodes";
 import { requirePublisherRole } from "./lib/publishers";
 import { isMacJunkPath, isTextFile, parseFrontmatter } from "./lib/skills";
 import { syncSkillSearchDigestForSkill } from "./lib/skillSearchDigest";
@@ -40,6 +41,17 @@ const MAX_STATIC_SCAN_TEXT_FILES = 200;
 const MAX_STATIC_SCAN_TEXT_FILE_BYTES = 256 * 1024;
 const DEFAULT_SOURCE_SYNC_BATCH_SIZE = 20;
 const MAX_SOURCE_SYNC_BATCH_SIZE = 50;
+
+function githubScanStatusFromStaticScan(staticScan: ReturnType<typeof runStaticModerationScan>) {
+  if (
+    staticScan.status === "suspicious" &&
+    staticScan.reasonCodes.length > 0 &&
+    staticScan.reasonCodes.every((code) => code === REASON_CODES.CONTEXT_PADDING_TRUNCATION)
+  ) {
+    return "clean" as const;
+  }
+  return staticScan.status;
+}
 
 type SourceForSync = Pick<
   Doc<"githubSkillSources">,
@@ -895,15 +907,17 @@ export async function verifyGitHubSkillHandler(
     fileContents: listGitHubSkillTextContents(entries, discovered.path),
   });
 
+  const scanStatus = githubScanStatusFromStaticScan(staticScan);
+
   await ctx.runMutation(internal.githubSkillSync.applyGitHubSkillVerificationResultInternal, {
     skillId: target.skill._id,
     contentHash: args.contentHash,
-    scanStatus: staticScan.status,
+    scanStatus,
   });
 
   return {
     ok: true as const,
-    scanStatus: staticScan.status,
+    scanStatus,
   };
 }
 

--- a/convex/githubSkillSync.ts
+++ b/convex/githubSkillSync.ts
@@ -42,6 +42,26 @@ const MAX_STATIC_SCAN_TEXT_FILE_BYTES = 256 * 1024;
 const DEFAULT_SOURCE_SYNC_BATCH_SIZE = 20;
 const MAX_SOURCE_SYNC_BATCH_SIZE = 50;
 
+const githubStaticScanFindingValidator = v.object({
+  code: v.string(),
+  severity: v.union(v.literal("info"), v.literal("warn"), v.literal("critical")),
+  file: v.string(),
+  line: v.number(),
+  message: v.string(),
+  evidence: v.string(),
+});
+
+const githubStaticScanResultValidator = v.object({
+  status: v.union(v.literal("clean"), v.literal("suspicious"), v.literal("malicious")),
+  reasonCodes: v.array(v.string()),
+  findings: v.array(githubStaticScanFindingValidator),
+  summary: v.string(),
+  engineVersion: v.string(),
+  checkedAt: v.number(),
+});
+
+type GitHubStaticScanResult = ReturnType<typeof runStaticModerationScan>;
+
 function githubScanStatusFromStaticScan(staticScan: ReturnType<typeof runStaticModerationScan>) {
   if (
     staticScan.status === "suspicious" &&
@@ -51,6 +71,29 @@ function githubScanStatusFromStaticScan(staticScan: ReturnType<typeof runStaticM
     return "clean" as const;
   }
   return staticScan.status;
+}
+
+function retainedStaticScanModerationPatch(
+  staticScan: GitHubStaticScanResult | undefined,
+  scanStatus: GitHubSkillScanStatus,
+) {
+  if (!staticScan || staticScan.status === scanStatus || staticScan.reasonCodes.length === 0) {
+    return {};
+  }
+
+  return {
+    moderationReason: `scanner.aggregate.${staticScan.status}`,
+    moderationVerdict: staticScan.status,
+    moderationFlags:
+      staticScan.status === "malicious" ? ["blocked.malware"] : ["flagged.suspicious"],
+    moderationReasonCodes: staticScan.reasonCodes,
+    moderationEvidence: staticScan.findings.length ? staticScan.findings : undefined,
+    moderationSummary: staticScan.summary,
+    moderationEngineVersion: staticScan.engineVersion,
+    moderationEvaluatedAt: staticScan.checkedAt,
+    moderationSourceVersionId: undefined,
+    isSuspicious: staticScan.status !== "clean",
+  };
 }
 
 type SourceForSync = Pick<
@@ -820,6 +863,7 @@ export type ApplyGitHubSkillVerificationResultArgs = {
   skillId: Id<"skills">;
   contentHash: string;
   scanStatus: GitHubSkillScanStatus;
+  staticScan?: GitHubStaticScanResult;
   now?: number;
 };
 
@@ -846,11 +890,16 @@ export async function applyGitHubSkillVerificationResultHandler(
   const now = args.now ?? Date.now();
   const promote = args.scanStatus === "clean";
   const moderation = githubBackedSkillModeration(args.scanStatus);
+  const retainedStaticScanModeration = retainedStaticScanModerationPatch(
+    args.staticScan,
+    args.scanStatus,
+  );
   const previousSkill = { ...skill };
   const patch = {
     githubScanStatus: args.scanStatus,
     updatedAt: now,
     ...moderation,
+    ...retainedStaticScanModeration,
   };
   await ctx.db.patch(args.skillId, patch);
   const nextSkill = { ...previousSkill, ...patch };
@@ -865,6 +914,7 @@ export const applyGitHubSkillVerificationResultInternal = internalMutation({
     skillId: v.id("skills"),
     contentHash: v.string(),
     scanStatus: githubSkillScanStatusValidator,
+    staticScan: v.optional(githubStaticScanResultValidator),
     now: v.optional(v.number()),
   },
   handler: applyGitHubSkillVerificationResultHandler,
@@ -913,6 +963,7 @@ export async function verifyGitHubSkillHandler(
     skillId: target.skill._id,
     contentHash: args.contentHash,
     scanStatus,
+    staticScan,
   });
 
   return {

--- a/convex/githubSkillSync.ts
+++ b/convex/githubSkillSync.ts
@@ -24,9 +24,9 @@ import {
 } from "./lib/githubSkillSync";
 import { adjustGlobalPublicSkillsCount, getPublicSkillVisibilityDelta } from "./lib/globalStats";
 import { runStaticModerationScan } from "./lib/moderationEngine";
+import { REASON_CODES } from "./lib/moderationReasonCodes";
 import { Events, logErrorEvent, logEvent } from "./lib/observabilityEvents";
 import { isOfficialPublisher } from "./lib/officialPublishers";
-import { REASON_CODES } from "./lib/moderationReasonCodes";
 import { requirePublisherRole } from "./lib/publishers";
 import { isMacJunkPath, isTextFile, parseFrontmatter } from "./lib/skills";
 import { syncSkillSearchDigestForSkill } from "./lib/skillSearchDigest";

--- a/convex/lib/moderationEngine.test.ts
+++ b/convex/lib/moderationEngine.test.ts
@@ -23,6 +23,75 @@ describe("moderationEngine", () => {
     expect(result.status).toBe("clean");
   });
 
+  it("flags extreme blank-line context padding before later skill content", () => {
+    const content =
+      "# CSV Summarizer\n" +
+      "\n".repeat(2_500) +
+      "FAKE_PAYLOAD_MARKER: late instructions hidden after padding.\n";
+    const result = runStaticModerationScan({
+      slug: "csv-summarizer",
+      displayName: "CSV Summarizer",
+      summary: "Summarizes CSV files",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "SKILL.md", size: content.length }],
+      fileContents: [{ path: "SKILL.md", content }],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.context_padding_truncation");
+    expect(result.status).toBe("suspicious");
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({
+        code: "suspicious.context_padding_truncation",
+        file: "SKILL.md",
+        line: 2,
+        evidence: expect.stringContaining("2500 consecutive blank/whitespace-only lines"),
+      }),
+    );
+  });
+
+  it("flags long whitespace runs before later text content", () => {
+    const content =
+      "Visible setup notes" +
+      " ".repeat(40_000) +
+      "FAKE_PAYLOAD_MARKER: late content hidden on the same line.";
+    const result = runStaticModerationScan({
+      slug: "formatter",
+      displayName: "Formatter",
+      summary: "Formats text",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "notes.txt", size: content.length }],
+      fileContents: [{ path: "notes.txt", content }],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.context_padding_truncation");
+    expect(result.findings).toContainEqual(
+      expect.objectContaining({
+        code: "suspicious.context_padding_truncation",
+        file: "notes.txt",
+        line: 1,
+        evidence: expect.stringContaining("40000 consecutive whitespace characters"),
+      }),
+    );
+  });
+
+  it("does not flag ordinary sparse markdown spacing", () => {
+    const content = ["# Demo", ...Array.from({ length: 200 }, () => ""), "## Usage"].join("\n");
+    const result = runStaticModerationScan({
+      slug: "demo",
+      displayName: "Demo",
+      summary: "A normal integration skill",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "SKILL.md", size: content.length }],
+      fileContents: [{ path: "SKILL.md", content }],
+    });
+
+    expect(result.reasonCodes).not.toContain("suspicious.context_padding_truncation");
+    expect(result.status).toBe("clean");
+  });
+
   it("flags hardcoded API secrets in skill documentation and redacts every evidence copy", () => {
     const exposedSecret = "ak_live_1234567890abcdefSECRET";
     const result = runStaticModerationScan({

--- a/convex/lib/moderationEngine.ts
+++ b/convex/lib/moderationEngine.ts
@@ -83,6 +83,8 @@ const STANDARD_PORTS = new Set([80, 443, 8080, 8443, 3000]);
 const RAW_IP_URL_PATTERN = /https?:\/\/\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?(?:\/|["'])/i;
 const CGNAT_HTTP_URL_PATTERN =
   /http:\/\/100\.(?:6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d{1,3}\.\d{1,3}(?::\d+)?(?:\/[^\s"'`]*)?/i;
+const CONTEXT_PADDING_MIN_BLANK_LINES = 2_000;
+const CONTEXT_PADDING_MIN_WHITESPACE_CHARS = 32_768;
 const INSTALL_PACKAGE_PATTERN = /installer-package\s*:\s*https?:\/\/[^\s"'`]+/i;
 const GENERATED_SOURCE_PLACEHOLDER_PATTERN =
   /^\s*[A-Za-z_][A-Za-z0-9_]*\s*=.*["']\$\{[A-Za-z_][A-Za-z0-9_-]*\}["']/m;
@@ -362,6 +364,105 @@ function addFinding(
   finding: Omit<ModerationFinding, "evidence"> & { evidence: string },
 ) {
   findings.push({ ...finding, evidence: truncateEvidence(finding.evidence.trim()) });
+}
+
+type ContextPaddingHit = {
+  kind: "blank-lines" | "whitespace-run";
+  line: number;
+  hiddenLine: number;
+  blankLines?: number;
+  whitespaceChars?: number;
+};
+
+function isNonWhitespace(char: string) {
+  return /\S/.test(char);
+}
+
+function findExtremeBlankLinePadding(content: string): ContextPaddingHit | null {
+  let line = 1;
+  let lineHasContent = false;
+  let blankLines = 0;
+  let blankRunStartLine = 1;
+
+  for (let index = 0; index <= content.length; index += 1) {
+    const char = content[index];
+    if (index < content.length && char !== "\n") {
+      if (isNonWhitespace(char)) lineHasContent = true;
+      continue;
+    }
+
+    if (lineHasContent) {
+      if (blankLines >= CONTEXT_PADDING_MIN_BLANK_LINES) {
+        return {
+          kind: "blank-lines",
+          line: blankRunStartLine,
+          hiddenLine: line,
+          blankLines,
+        };
+      }
+      blankLines = 0;
+    } else {
+      if (blankLines === 0) blankRunStartLine = line;
+      blankLines += 1;
+    }
+
+    line += 1;
+    lineHasContent = false;
+  }
+
+  return null;
+}
+
+function findExtremeWhitespacePadding(content: string): ContextPaddingHit | null {
+  let line = 1;
+  let runStartLine = 1;
+  let whitespaceChars = 0;
+
+  for (let index = 0; index <= content.length; index += 1) {
+    const char = content[index];
+    if (index < content.length && /\s/.test(char)) {
+      if (whitespaceChars === 0) runStartLine = line;
+      whitespaceChars += 1;
+      if (char === "\n") line += 1;
+      continue;
+    }
+
+    if (whitespaceChars >= CONTEXT_PADDING_MIN_WHITESPACE_CHARS && index < content.length) {
+      return {
+        kind: "whitespace-run",
+        line: runStartLine,
+        hiddenLine: line,
+        whitespaceChars,
+      };
+    }
+
+    whitespaceChars = 0;
+  }
+
+  return null;
+}
+
+function findContextPaddingAbuse(content: string): ContextPaddingHit | null {
+  return findExtremeBlankLinePadding(content) ?? findExtremeWhitespacePadding(content);
+}
+
+function scanContextPadding(file: TextFile, findings: ModerationFinding[]) {
+  const hit = findContextPaddingAbuse(file.content);
+  if (!hit) return;
+
+  const quantity =
+    hit.kind === "blank-lines"
+      ? `${hit.blankLines ?? 0} consecutive blank/whitespace-only lines`
+      : `${hit.whitespaceChars ?? 0} consecutive whitespace characters`;
+
+  addFinding(findings, {
+    code: REASON_CODES.CONTEXT_PADDING_TRUNCATION,
+    severity: "warn",
+    file: file.path,
+    line: hit.line,
+    message: "Extreme context padding hides later artifact content from context-limited review.",
+    evidence: `${quantity} before later artifact content; content resumes at line ${hit.hiddenLine}.`,
+  });
 }
 
 function findFirstLine(content: string, pattern: RegExp) {
@@ -1150,6 +1251,7 @@ export function runStaticModerationScan(input: StaticScanInput): StaticScanResul
   const declaredEnvNames = collectDeclaredEnvNames(input);
 
   for (const file of files) {
+    scanContextPadding(file, findings);
     scanSecretLiteralFile(file.path, file.content, findings);
     scanPlaintextCgnatEndpointFile(file.path, file.content, findings);
     scanCodeFile(file.path, file.content, findings, declaredEnvNames);

--- a/convex/lib/moderationReasonCodes.ts
+++ b/convex/lib/moderationReasonCodes.ts
@@ -18,6 +18,7 @@ export const REASON_CODES = {
   LLM_REVIEW: "review.llm_review",
   DANGEROUS_EXEC: "suspicious.dangerous_exec",
   DYNAMIC_CODE: "suspicious.dynamic_code_execution",
+  CONTEXT_PADDING_TRUNCATION: "suspicious.context_padding_truncation",
   GENERATED_SOURCE_TEMPLATE: "suspicious.generated_source_template_injection",
   EXPOSED_RESOURCE_IDENTIFIER: "suspicious.exposed_resource_identifier",
   DESTRUCTIVE_DELETE_COMMAND: "suspicious.destructive_delete_command",

--- a/specs/github-backed-skills.md
+++ b/specs/github-backed-skills.md
@@ -132,6 +132,12 @@ When verification succeeds cleanly:
 - set `githubScanStatus: "clean"`
 - make the skill active/installable
 
+Context-padding-only static findings are a compatibility exception for
+GitHub-backed installability: they may map to `githubScanStatus: "clean"` so the
+exact upstream content remains installable, but ClawHub must retain the static
+reason codes, findings, summary, engine version, and evaluated timestamp on the
+skill's structured moderation fields for reviewer visibility.
+
 When verification fails, is suspicious, or is malicious:
 
 - keep/block the skill from normal install

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -257,6 +257,9 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
 - Static malware detection still records deterministic findings such as
   obfuscated shell payload prompts, but those findings are context for ClawScan,
   not a standalone hard block or uploader moderation trigger.
+- Extreme blank-line or whitespace padding before later artifact content is static
+  context-evasion evidence for ClawScan because it can hide payloads from
+  context-limited previews or model review.
 
 ## AI comment scam backfill
 


### PR DESCRIPTION
## Summary

This PR adds a deterministic static scan signal for extreme context padding in skill artifacts.

## Scenario this protects

If someone uploads a `SKILL.md` with normal-looking instructions near the top, then a very large whitespace gap, then important behavior after the gap, context-limited previews or model review may focus on the beginning and miss the later content.

ClawHub's static scan already reads the full text file. This PR teaches that deterministic layer to notice the evasive layout itself.

## What changed

- Adds `suspicious.context_padding_truncation` as a static scan reason code.
- Flags extreme blank-line runs before later artifact content.
- Flags extreme same-line whitespace runs before later artifact content.
- Keeps the signal as static evidence for ClawScan, not a standalone hard block.
- Adds regression tests for padded markdown, long whitespace padding, and ordinary sparse markdown that should remain clean.
- Updates the moderation spec with the intent of the rule.

## What maintainers should expect

A padded artifact can now produce a clear static finding that points reviewers and ClawScan to the evasion pattern. Ordinary markdown spacing should not be affected.

This does not change uploader bans, hide/unhide behavior, or final moderation policy by itself. It adds a signal the rest of the scan pipeline can use.

## Validation

- `bunx vitest run convex/lib/moderationEngine.test.ts --reporter=verbose` (88 passed)
- `bun run ci:static`
- `bun run ci:unit` (2,667 passed)
- `bun run ci:types-build`
- `git diff --check upstream/main...HEAD`

## Behavior proof

Copied output from executing `runStaticPublishScan` against a redacted uploaded `SKILL.md` fixture with 2,500 blank lines before later content:

```json
{
  "status": "suspicious",
  "reasonCodes": [
    "suspicious.context_padding_truncation"
  ],
  "findings": [
    {
      "code": "suspicious.context_padding_truncation",
      "severity": "warn",
      "file": "SKILL.md",
      "line": 2,
      "message": "Extreme context padding hides later artifact content from context-limited review.",
      "evidence": "2500 consecutive blank/whitespace-only lines before later artifact content; content resumes at line 2502."
    }
  ]
}
```
