### PR TITLE
fix: point account recovery to GitHub issues

### DIFF
--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -9,7 +9,7 @@ import { isLocalDevAuthEnabled } from "./lib/devAuth";
 import { shouldScheduleGitHubProfileSync } from "./lib/githubProfileSync";
 
 export const BANNED_REAUTH_MESSAGE =
-  "This account has been banned and cannot sign in. If you believe this is a mistake, please contact security@openclaw.ai and we will review it.";
+  "This account has been banned and cannot sign in. If you believe this is a mistake, open a GitHub issue: https://github.com/openclaw/clawhub/issues/new.";
 export const DELETED_ACCOUNT_REAUTH_MESSAGE =
   "This account has been permanently deleted and cannot be restored.";
 

--- a/convex/httpApi.handlers.test.ts
+++ b/convex/httpApi.handlers.test.ts
@@ -240,7 +240,7 @@ describe("httpApi handlers", () => {
   it("cliWhoamiHttp returns 401 on auth failure", async () => {
     vi.mocked(requireApiTokenUser).mockRejectedValueOnce(
       new Error(
-        "Unauthorized: This ClawHub account is not in good standing and cannot use API tokens. If you believe this is a mistake, contact security@openclaw.ai.",
+        "Unauthorized: This ClawHub account is not in good standing and cannot use API tokens. If you believe this is a mistake, open a GitHub issue: https://github.com/openclaw/clawhub/issues/new.",
       ),
     );
     const response = await __handlers.cliWhoamiHandler(

--- a/convex/lib/apiTokenAuth.ts
+++ b/convex/lib/apiTokenAuth.ts
@@ -34,7 +34,7 @@ export const MISSING_API_TOKEN_MESSAGE =
 export const INVALID_API_TOKEN_MESSAGE =
   "Unauthorized: API token is invalid or revoked. Run `clawhub login` again.";
 export const BLOCKED_API_TOKEN_ACCOUNT_MESSAGE =
-  "Unauthorized: This ClawHub account is not in good standing and cannot use API tokens. If you believe this is a mistake, contact security@openclaw.ai.";
+  "Unauthorized: This ClawHub account is not in good standing and cannot use API tokens. If you believe this is a mistake, open a GitHub issue: https://github.com/openclaw/clawhub/issues/new.";
 
 export async function requireApiTokenUser(
   ctx: ActionCtx,

--- a/convex/skills.rateLimit.test.ts
+++ b/convex/skills.rateLimit.test.ts
@@ -384,7 +384,7 @@ describe("skills anti-spam guards", () => {
       ),
     ).rejects.toThrow(
       "This slug is locked to a deleted or banned account. " +
-        "If you believe you are the rightful owner, please contact security@openclaw.ai to reclaim it.",
+        "If you believe you are the rightful owner, open a GitHub issue to reclaim it: https://github.com/openclaw/clawhub/issues/new.",
     );
   });
 

--- a/convex/skills.slugAvailability.test.ts
+++ b/convex/skills.slugAvailability.test.ts
@@ -947,7 +947,7 @@ describe("skills.checkSlugAvailability", () => {
       reason: "taken",
       message:
         "This slug is locked to a deleted or banned account. " +
-        "If you believe you are the rightful owner, please contact security@openclaw.ai to reclaim it.",
+        "If you believe you are the rightful owner, open a GitHub issue to reclaim it: https://github.com/openclaw/clawhub/issues/new.",
       url: null,
     });
   });
@@ -985,7 +985,7 @@ describe("skills.checkSlugAvailability", () => {
       reason: "taken",
       message:
         "This slug is locked to a deleted or banned account. " +
-        "If you believe you are the rightful owner, please contact security@openclaw.ai to reclaim it.",
+        "If you believe you are the rightful owner, open a GitHub issue to reclaim it: https://github.com/openclaw/clawhub/issues/new.",
       url: null,
     });
   });

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -832,7 +832,7 @@ function buildSlugTakenErrorMessage(skill: Doc<"skills">, owner: SkillOwnerRef) 
   if (!owner || owner.deletedAt || owner.deactivatedAt) {
     return (
       "This slug is locked to a deleted or banned account. " +
-      "If you believe you are the rightful owner, please contact security@openclaw.ai to reclaim it."
+      "If you believe you are the rightful owner, open a GitHub issue to reclaim it: https://github.com/openclaw/clawhub/issues/new."
     );
   }
   const base = "Slug is already taken. Choose a different slug.";
@@ -2591,7 +2591,7 @@ export const checkSlugAvailability = query({
         reason: "taken" as const,
         message:
           "This slug is locked to a deleted or banned account. " +
-          "If you believe you are the rightful owner, please contact security@openclaw.ai to reclaim it.",
+          "If you believe you are the rightful owner, open a GitHub issue to reclaim it: https://github.com/openclaw/clawhub/issues/new.",
         url: null,
       };
     }

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -17,7 +17,8 @@ Use GitHub to sign in at [clawhub.ai](https://clawhub.ai).
 
 Deleted, banned, or disabled accounts cannot complete normal ClawHub sign-in.
 If sign-in returns you to a logged-out state, your account may not be in good
-standing.
+standing. [Open a GitHub issue](https://github.com/openclaw/clawhub/issues/new)
+if you believe this is a mistake.
 
 ## CLI login
 
@@ -86,3 +87,4 @@ Revoked, invalid, or missing tokens return `401 Unauthorized`. Sign in again
 with `clawhub login` or provide a fresh token with `clawhub login --token`.
 
 Deleted, banned, or disabled accounts cannot continue using existing API tokens.
+If you believe this is a mistake, [open a GitHub issue](https://github.com/openclaw/clawhub/issues/new).

--- a/docs/moderation.md
+++ b/docs/moderation.md
@@ -79,8 +79,9 @@ result in account bans, token revocation, hidden content, or removed listings.
 
 Deleted, banned, or disabled accounts cannot use ClawHub API tokens. If CLI auth
 starts failing after account action, sign in to the web UI to review account
-state. If sign-in or normal CLI access is blocked, contact security@openclaw.ai
-for recovery review.
+state. If sign-in or normal CLI access is blocked,
+[open a GitHub issue](https://github.com/openclaw/clawhub/issues/new) for
+recovery review.
 
 ## Publisher guidance
 

--- a/packages/clawhub/src/cli/commands/sync.test.ts
+++ b/packages/clawhub/src/cli/commands/sync.test.ts
@@ -691,7 +691,7 @@ describe("cmdSync", () => {
       const { slug } = options as { slug: string };
       if (slug === "new-skill") {
         throw new Error(
-          "This slug is locked to a deleted or banned account. If you believe you are the rightful owner, please contact security@openclaw.ai to reclaim it.",
+          "This slug is locked to a deleted or banned account. If you believe you are the rightful owner, open a GitHub issue to reclaim it: https://github.com/openclaw/clawhub/issues/new.",
         );
       }
     });

--- a/src/components/AuthErrorMessage.tsx
+++ b/src/components/AuthErrorMessage.tsx
@@ -1,0 +1,27 @@
+import {
+  CLAWHUB_ACCOUNT_ISSUE_LINK_TEXT,
+  CLAWHUB_ACCOUNT_ISSUE_URL,
+} from "../lib/authErrorMessage";
+
+export function AuthErrorMessage({ message }: { message: string }) {
+  const linkStart = message.indexOf(CLAWHUB_ACCOUNT_ISSUE_LINK_TEXT);
+  if (linkStart === -1) return <>{message}</>;
+
+  const before = message.slice(0, linkStart);
+  const after = message.slice(linkStart + CLAWHUB_ACCOUNT_ISSUE_LINK_TEXT.length);
+
+  return (
+    <>
+      {before}
+      <a
+        href={CLAWHUB_ACCOUNT_ISSUE_URL}
+        target="_blank"
+        rel="noreferrer"
+        className="font-medium underline underline-offset-2"
+      >
+        {CLAWHUB_ACCOUNT_ISSUE_LINK_TEXT}
+      </a>
+      {after}
+    </>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -27,6 +27,7 @@ import {
   type UnifiedPluginResult,
   type UnifiedSkillResult,
 } from "../lib/useUnifiedSearch";
+import { AuthErrorMessage } from "./AuthErrorMessage";
 import { Button } from "./ui/button";
 import {
   DropdownMenu,
@@ -493,7 +494,7 @@ export default function Header() {
               <>
                 {authError ? (
                   <div className="error mr-2 text-[0.85rem]" role="alert">
-                    {authError}{" "}
+                    <AuthErrorMessage message={authError} />{" "}
                     <button
                       type="button"
                       onClick={clearAuthError}

--- a/src/components/SignInPrompt.test.tsx
+++ b/src/components/SignInPrompt.test.tsx
@@ -21,6 +21,8 @@ vi.mock("../lib/useAuthError", () => ({
 }));
 
 vi.mock("../lib/authErrorMessage", () => ({
+  CLAWHUB_ACCOUNT_ISSUE_LINK_TEXT: "open a GitHub issue",
+  CLAWHUB_ACCOUNT_ISSUE_URL: "https://github.com/openclaw/clawhub/issues/new",
   getUserFacingAuthError: (_error: unknown, fallback: string) => fallback,
 }));
 
@@ -54,6 +56,18 @@ describe("SignInPrompt", () => {
     const dismissBtn = screen.getByRole("button", { name: "Dismiss" });
     fireEvent.click(dismissBtn);
     expect(onDismissError).toHaveBeenCalledTimes(1);
+  });
+
+  it("links account issue guidance in auth errors", () => {
+    render(
+      <SignInPrompt
+        title="Sign in"
+        error="Sign in failed. Please open a GitHub issue if you believe this is a mistake."
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: "open a GitHub issue" });
+    expect(link.getAttribute("href")).toBe("https://github.com/openclaw/clawhub/issues/new");
   });
 
   it("does not render dismiss button when onDismissError is missing", () => {

--- a/src/components/SignInPrompt.tsx
+++ b/src/components/SignInPrompt.tsx
@@ -1,6 +1,7 @@
 import type { LucideIcon } from "lucide-react";
 import { LockKeyhole } from "lucide-react";
 import type { ReactNode } from "react";
+import { AuthErrorMessage } from "./AuthErrorMessage";
 import { SignInButton } from "./SignInButton";
 
 interface SignInPromptProps {
@@ -78,7 +79,7 @@ export function SignInPrompt({
                 className="mt-3 rounded-[var(--radius-sm)] border border-red-300/40 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-500/30 dark:bg-red-950/50 dark:text-red-300"
                 role="alert"
               >
-                {error}{" "}
+                <AuthErrorMessage message={error} />{" "}
                 {onDismissError ? (
                   <button
                     type="button"

--- a/src/lib/authErrorMessage.ts
+++ b/src/lib/authErrorMessage.ts
@@ -1,13 +1,13 @@
 import { getUserFacingConvexError } from "./convexError";
 
-export const BANNED_SIGN_IN_MESSAGE =
-  "This ClawHub account is not in good standing and cannot sign in. If you believe this is a mistake, please contact security@openclaw.ai and we will review it.";
+export const CLAWHUB_ACCOUNT_ISSUE_URL = "https://github.com/openclaw/clawhub/issues/new";
+export const CLAWHUB_ACCOUNT_ISSUE_LINK_TEXT = "open a GitHub issue";
+
+export const BANNED_SIGN_IN_MESSAGE = `This ClawHub account is not in good standing and cannot sign in. Please ${CLAWHUB_ACCOUNT_ISSUE_LINK_TEXT} if you believe this is a mistake.`;
 export const DELETED_SIGN_IN_MESSAGE =
   "This ClawHub account was permanently deleted and cannot sign in again.";
-export const ACCESS_DENIED_SIGN_IN_MESSAGE =
-  "Sign in was denied. If this ClawHub account was disabled or banned in error, please contact security@openclaw.ai.";
-export const AUTH_CODE_NO_SESSION_MESSAGE =
-  "Sign in did not create a session. If this ClawHub account was deleted, banned, or disabled, it cannot sign in. Please contact security@openclaw.ai if you believe this is a mistake.";
+export const ACCESS_DENIED_SIGN_IN_MESSAGE = `Sign in was denied. Please ${CLAWHUB_ACCOUNT_ISSUE_LINK_TEXT} if this ClawHub account was disabled or banned in error.`;
+export const AUTH_CODE_NO_SESSION_MESSAGE = `Sign in did not create a session. If this ClawHub account was deleted, banned, or disabled, it cannot sign in. Please ${CLAWHUB_ACCOUNT_ISSUE_LINK_TEXT} if you believe this is a mistake.`;
 
 export function normalizeAuthErrorMessage(message: string | null | undefined, fallback: string) {
   const normalized = message?.trim();


### PR DESCRIPTION
## Summary

- Replace account recovery guidance that pointed to `security@openclaw.ai` with GitHub issue guidance.
- Render `open a GitHub issue` as a clickable link in shared auth error UI.
- Update API/CLI slug-reclaim and account-standing messages plus docs/tests to use the same recovery path.

## Screenshot

![Updated account issue guidance](https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/manual/pr-account-issue-link/b3913d43/account-issue-link.png)

## Tests

- `bun run format:check -- src/lib/authErrorMessage.ts src/components/AuthErrorMessage.tsx src/components/SignInPrompt.tsx src/components/Header.tsx convex/auth.ts convex/lib/apiTokenAuth.ts convex/skills.ts docs/auth.md docs/moderation.md src/components/SignInPrompt.test.tsx convex/skills.slugAvailability.test.ts convex/skills.rateLimit.test.ts convex/httpApi.handlers.test.ts packages/clawhub/src/cli/commands/sync.test.ts`
- `bun run test src/components/SignInPrompt.test.tsx src/components/AppProviders.test.tsx convex/lib/apiTokenAuth.test.ts convex/httpApi.handlers.test.ts convex/skills.slugAvailability.test.ts convex/skills.rateLimit.test.ts packages/clawhub/src/cli/commands/sync.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
