### PR TITLE
fix: retry incomplete GitHub sign-ins

### DIFF
--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -113,11 +113,8 @@ vi.mock("../lib/theme-transition", () => ({
 }));
 
 vi.mock("../lib/useAuthError", () => ({
+  clearAuthError: vi.fn(),
   setAuthError: vi.fn(),
-  useAuthError: () => ({
-    error: null,
-    clear: vi.fn(),
-  }),
 }));
 
 vi.mock("../lib/roles", () => ({

--- a/src/components/AppProviders.test.tsx
+++ b/src/components/AppProviders.test.tsx
@@ -1,5 +1,5 @@
 /* @vitest-environment jsdom */
-import { render, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ACCESS_DENIED_SIGN_IN_MESSAGE,
@@ -7,10 +7,20 @@ import {
   BANNED_SIGN_IN_MESSAGE,
   DELETED_SIGN_IN_MESSAGE,
 } from "../lib/authErrorMessage";
-import { getAuthErrorSnapshot, clearAuthError } from "../lib/useAuthError";
-import { AuthCodeHandler, AuthErrorHandler } from "./AppProviders";
+import { getAuthErrorSnapshot, clearAuthError, setAuthError } from "../lib/useAuthError";
+import { AuthCodeHandler, AuthErrorHandler, AuthErrorToast } from "./AppProviders";
 
 const signInMock = vi.fn();
+const { toastErrorMock } = vi.hoisted(() => ({
+  toastErrorMock: vi.fn(),
+}));
+let consoleLogMock: ReturnType<typeof vi.spyOn>;
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: toastErrorMock,
+  },
+}));
 
 vi.mock("@convex-dev/auth/react", () => ({
   ConvexAuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -30,17 +40,23 @@ vi.mock("./UserBootstrap", () => ({
 describe("AuthCodeHandler", () => {
   beforeEach(() => {
     signInMock.mockReset();
+    consoleLogMock = vi.spyOn(console, "log").mockImplementation(() => {});
     clearAuthError();
     window.history.replaceState(null, "", "/sign-in");
   });
 
   afterEach(() => {
     clearAuthError();
+    consoleLogMock.mockRestore();
   });
 
-  it("consumes the auth code and strips it from the URL", async () => {
+  it("strips the auth code from the URL after a session is created", async () => {
     signInMock.mockResolvedValue({ signingIn: true });
-    window.history.replaceState(null, "", "/sign-in?code=abc123&next=%2Fdashboard#section");
+    window.history.replaceState(
+      null,
+      "",
+      "/sign-in?code=abc123&auth_retry=1&next=%2Fdashboard#section",
+    );
 
     render(<AuthCodeHandler />);
 
@@ -52,6 +68,24 @@ describe("AuthCodeHandler", () => {
       "/sign-in?next=%2Fdashboard#section",
     );
     expect(getAuthErrorSnapshot()).toBeNull();
+  });
+
+  it("strips the auth code before waiting for code verification", async () => {
+    signInMock.mockReturnValue(new Promise(() => {}));
+    window.history.replaceState(
+      null,
+      "",
+      "/docs/auth?code=abc123&return_to=https%3A%2F%2Fdocs.openclaw.ai%2Fask#molty",
+    );
+
+    render(<AuthCodeHandler />);
+
+    await waitFor(() => {
+      expect(signInMock).toHaveBeenCalledWith(undefined, { code: "abc123" });
+    });
+    expect(`${window.location.pathname}${window.location.search}${window.location.hash}`).toBe(
+      "/docs/auth?return_to=https%3A%2F%2Fdocs.openclaw.ai%2Fask&auth_retry=1#molty",
+    );
   });
 
   it("surfaces user-facing sign-in errors from code verification", async () => {
@@ -67,15 +101,56 @@ describe("AuthCodeHandler", () => {
     });
   });
 
-  it("warns about blocked accounts when sign-in finishes without a session", async () => {
+  it("restarts GitHub sign-in once when code verification finishes without a session", async () => {
+    signInMock.mockResolvedValueOnce({ signingIn: false }).mockResolvedValueOnce({
+      signingIn: false,
+      redirect: new URL("https://github.com/login/oauth/authorize"),
+    });
+    window.history.replaceState(
+      null,
+      "",
+      "/docs/auth?code=abc123&return_to=https%3A%2F%2Fdocs.openclaw.ai%2Fask#molty",
+    );
+
+    render(<AuthCodeHandler />);
+
+    await waitFor(() => {
+      expect(signInMock).toHaveBeenNthCalledWith(1, undefined, { code: "abc123" });
+      expect(signInMock).toHaveBeenNthCalledWith(2, "github", {
+        redirectTo: "/docs/auth?return_to=https%3A%2F%2Fdocs.openclaw.ai%2Fask&auth_retry=1#molty",
+      });
+    });
+
+    expect(consoleLogMock).toHaveBeenCalledWith(
+      "[ClawHub auth] GitHub code sign-in did not create a session",
+      {
+        path: "/docs/auth",
+        retrying: true,
+        hadRetryMarker: false,
+        hasReturnTo: true,
+      },
+    );
+    expect(getAuthErrorSnapshot()).toBeNull();
+  });
+
+  it("shows a generic error when the retried code still finishes without a session", async () => {
     signInMock.mockResolvedValue({ signingIn: false });
-    window.history.replaceState(null, "", "/sign-in?code=abc123");
+    window.history.replaceState(
+      null,
+      "",
+      "/docs/auth?code=abc123&return_to=https%3A%2F%2Fdocs.openclaw.ai%2Fask&auth_retry=1#molty",
+    );
 
     render(<AuthCodeHandler />);
 
     await waitFor(() => {
       expect(getAuthErrorSnapshot()).toBe(AUTH_CODE_NO_SESSION_MESSAGE);
     });
+
+    expect(signInMock).toHaveBeenCalledTimes(1);
+    expect(`${window.location.pathname}${window.location.search}${window.location.hash}`).toBe(
+      "/docs/auth?return_to=https%3A%2F%2Fdocs.openclaw.ai%2Fask#molty",
+    );
   });
 
   it("surfaces deleted-account errors from code verification", async () => {
@@ -155,5 +230,28 @@ describe("AuthErrorHandler", () => {
     expect(`${window.location.pathname}${window.location.search}${window.location.hash}`).toBe(
       "/sign-in",
     );
+  });
+});
+
+describe("AuthErrorToast", () => {
+  beforeEach(() => {
+    toastErrorMock.mockReset();
+    clearAuthError();
+  });
+
+  afterEach(() => {
+    clearAuthError();
+  });
+
+  it("surfaces global auth errors as toasts", async () => {
+    render(<AuthErrorToast />);
+
+    act(() => {
+      setAuthError("Sign in failed. Please open a GitHub issue.");
+    });
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(expect.anything(), { id: "auth-error" });
+    });
   });
 });

--- a/src/components/AppProviders.tsx
+++ b/src/components/AppProviders.tsx
@@ -1,12 +1,14 @@
 import { ConvexAuthProvider, useAuthActions } from "@convex-dev/auth/react";
 import { useEffect, useRef } from "react";
+import { toast } from "sonner";
 import { convex } from "../convex/client";
 import {
   AUTH_CODE_NO_SESSION_MESSAGE,
   getUserFacingAuthError,
   normalizeAuthErrorMessage,
 } from "../lib/authErrorMessage";
-import { clearAuthError, setAuthError } from "../lib/useAuthError";
+import { clearAuthError, setAuthError, useAuthError } from "../lib/useAuthError";
+import { AuthErrorMessage } from "./AuthErrorMessage";
 import { ClientOnly } from "./ClientOnly";
 import { DevPersonaFab } from "./DevPersonaFab";
 import { TooltipProvider } from "./ui/tooltip";
@@ -17,20 +19,27 @@ function getPendingAuthCode() {
   const url = new URL(window.location.href);
   const code = url.searchParams.get("code");
   if (!code) return null;
+  const isRetry = url.searchParams.get("auth_retry") === "1";
+  const retryUrl = new URL(window.location.href);
+  retryUrl.searchParams.delete("code");
+  retryUrl.searchParams.set("auth_retry", "1");
   url.searchParams.delete("code");
+  url.searchParams.delete("auth_retry");
   return {
     code,
+    isRetry,
     relativeUrl: `${url.pathname}${url.search}${url.hash}`,
+    retryRelativeUrl: `${retryUrl.pathname}${retryUrl.search}${retryUrl.hash}`,
   };
 }
 
 export function AuthCodeHandler() {
   const { signIn } = useAuthActions();
   const handledCodeRef = useRef<string | null>(null);
-  const signInWithCode = signIn as (
+  const signInWithGitHub = signIn as (
     provider: string | undefined,
-    params: { code: string },
-  ) => Promise<{ signingIn: boolean }>;
+    params: { code: string } | { redirectTo: string },
+  ) => Promise<{ signingIn: boolean; redirect?: URL }>;
 
   useEffect(() => {
     const pending = getPendingAuthCode();
@@ -39,18 +48,50 @@ export function AuthCodeHandler() {
     handledCodeRef.current = pending.code;
 
     clearAuthError();
-    window.history.replaceState(null, "", pending.relativeUrl);
+    window.history.replaceState(
+      null,
+      "",
+      pending.isRetry ? pending.relativeUrl : pending.retryRelativeUrl,
+    );
 
-    void signInWithCode(undefined, { code: pending.code })
+    void signInWithGitHub(undefined, { code: pending.code })
       .then((result) => {
-        if (result.signingIn === false) {
-          setAuthError(AUTH_CODE_NO_SESSION_MESSAGE);
+        if (result.signingIn !== false) {
+          window.history.replaceState(null, "", pending.relativeUrl);
+          return;
         }
+
+        console.log("[ClawHub auth] GitHub code sign-in did not create a session", {
+          path: window.location.pathname,
+          retrying: !pending.isRetry,
+          hadRetryMarker: pending.isRetry,
+          hasReturnTo: new URL(window.location.href).searchParams.has("return_to"),
+        });
+
+        if (!pending.isRetry) {
+          window.history.replaceState(null, "", pending.retryRelativeUrl);
+          void signInWithGitHub("github", { redirectTo: pending.retryRelativeUrl })
+            .then((retryResult) => {
+              if (retryResult?.signingIn === false && !retryResult.redirect) {
+                window.history.replaceState(null, "", pending.relativeUrl);
+                setAuthError(AUTH_CODE_NO_SESSION_MESSAGE);
+              }
+            })
+            .catch((error) => {
+              window.history.replaceState(null, "", pending.relativeUrl);
+              setAuthError(getUserFacingAuthError(error, "Sign in failed. Please try again."));
+            });
+          return;
+        }
+
+        window.history.replaceState(null, "", pending.relativeUrl);
+        setAuthError(AUTH_CODE_NO_SESSION_MESSAGE);
       })
       .catch((error) => {
+        window.history.replaceState(null, "", pending.relativeUrl);
         setAuthError(getUserFacingAuthError(error, "Sign in failed. Please try again."));
       });
-  }, [signInWithCode]);
+  }, [signInWithGitHub]);
 
   return null;
 }
@@ -86,12 +127,31 @@ export function AuthErrorHandler() {
   return null;
 }
 
+export function AuthErrorToast() {
+  const { error } = useAuthError();
+  const lastShownRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!error) {
+      lastShownRef.current = null;
+      return;
+    }
+    if (lastShownRef.current === error) return;
+    lastShownRef.current = error;
+
+    toast.error(<AuthErrorMessage message={error} />, { id: "auth-error" });
+  }, [error]);
+
+  return null;
+}
+
 export function AppProviders({ children }: { children: React.ReactNode }) {
   return (
     <ConvexAuthProvider client={convex} shouldHandleCode={false}>
       <TooltipProvider delayDuration={400}>
         <AuthCodeHandler />
         <AuthErrorHandler />
+        <AuthErrorToast />
         <UserBootstrap />
         {children}
         <ClientOnly>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,14 +20,13 @@ import { filterNavItems, PRIMARY_NAV_ITEMS, SECONDARY_NAV_ITEMS } from "../lib/n
 import { isModerator } from "../lib/roles";
 import { getClawHubSiteUrl, getSiteMode, getSiteName } from "../lib/site";
 import { applyTheme, useThemeMode } from "../lib/theme";
-import { setAuthError, useAuthError } from "../lib/useAuthError";
+import { clearAuthError, setAuthError } from "../lib/useAuthError";
 import { useAuthStatus } from "../lib/useAuthStatus";
 import {
   useUnifiedSearch,
   type UnifiedPluginResult,
   type UnifiedSkillResult,
 } from "../lib/useUnifiedSearch";
-import { AuthErrorMessage } from "./AuthErrorMessage";
 import { Button } from "./ui/button";
 import {
   DropdownMenu,
@@ -98,7 +97,6 @@ export default function Header() {
   );
   const primaryItems = useMemo(() => filterNavItems(PRIMARY_NAV_ITEMS, navCtx), [navCtx]);
   const secondaryItems = useMemo(() => filterNavItems(SECONDARY_NAV_ITEMS, navCtx), [navCtx]);
-  const { error: authError, clear: clearAuthError } = useAuthError();
   const signInRedirectTo = getCurrentRelativeUrl();
 
   const [navSearchQuery, setNavSearchQuery] = useState("");
@@ -492,19 +490,6 @@ export default function Header() {
               <div className="github-sign-in-button auth-loading-placeholder" aria-hidden="true" />
             ) : (
               <>
-                {authError ? (
-                  <div className="error mr-2 text-[0.85rem]" role="alert">
-                    <AuthErrorMessage message={authError} />{" "}
-                    <button
-                      type="button"
-                      onClick={clearAuthError}
-                      aria-label="Dismiss"
-                      className="cursor-pointer border-none bg-transparent px-0.5 py-0 text-inherit"
-                    >
-                      &times;
-                    </button>
-                  </div>
-                ) : null}
                 <Button
                   variant="outline"
                   size="sm"

--- a/src/lib/authErrorMessage.ts
+++ b/src/lib/authErrorMessage.ts
@@ -6,8 +6,8 @@ export const CLAWHUB_ACCOUNT_ISSUE_LINK_TEXT = "open a GitHub issue";
 export const BANNED_SIGN_IN_MESSAGE = `This ClawHub account is not in good standing and cannot sign in. Please ${CLAWHUB_ACCOUNT_ISSUE_LINK_TEXT} if you believe this is a mistake.`;
 export const DELETED_SIGN_IN_MESSAGE =
   "This ClawHub account was permanently deleted and cannot sign in again.";
-export const ACCESS_DENIED_SIGN_IN_MESSAGE = `Sign in was denied. Please ${CLAWHUB_ACCOUNT_ISSUE_LINK_TEXT} if this ClawHub account was disabled or banned in error.`;
-export const AUTH_CODE_NO_SESSION_MESSAGE = `Sign in did not create a session. If this ClawHub account was deleted, banned, or disabled, it cannot sign in. Please ${CLAWHUB_ACCOUNT_ISSUE_LINK_TEXT} if you believe this is a mistake.`;
+export const ACCESS_DENIED_SIGN_IN_MESSAGE = `Sign in was denied. Please try signing in with GitHub again. If this keeps happening, please ${CLAWHUB_ACCOUNT_ISSUE_LINK_TEXT}.`;
+export const AUTH_CODE_NO_SESSION_MESSAGE = `Sign in did not complete. Please try signing in with GitHub again. If this keeps happening, please ${CLAWHUB_ACCOUNT_ISSUE_LINK_TEXT}.`;
 
 export function normalizeAuthErrorMessage(message: string | null | undefined, fallback: string) {
   const normalized = message?.trim();


### PR DESCRIPTION
## Summary

- Retry incomplete GitHub callback sign-ins once with a fresh OAuth redirect while preserving the relative return URL.
- Strip OAuth `code` from the URL immediately, add temporary `console.log` diagnostics for no-session callbacks, and only show banned/deleted copy when the auth error explicitly says that.
- Move global auth-error display to a Sonner toast and stop rendering the header inline auth alert.

## Screenshot

![New auth toast message](https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/manual/pr-auth-callback-retry-toast/ac593d88/account-issue-link.png)

## Tests

- `bunx vitest run src/components/AppProviders.test.tsx src/__tests__/header.test.tsx src/components/SignInPrompt.test.tsx src/components/SignInButton.test.tsx src/routes/docs/-auth.test.tsx`
- `bun run format:check -- src/components/AppProviders.tsx src/components/AppProviders.test.tsx src/components/Header.tsx src/__tests__/header.test.tsx src/lib/authErrorMessage.ts`
- `bun run ci:static`
- `bun run ci:unit`
