### PR TITLE
fix: backfill legacy publisher ownership

### DIFF
--- a/convex/crons.test.ts
+++ b/convex/crons.test.ts
@@ -38,6 +38,9 @@ vi.mock("./_generated/api", () => ({
       pruneExpiredSkillScanRequestsInternal: Symbol("skill-scan-request-prune"),
     },
     downloads: { pruneDownloadDedupesInternal: Symbol("download-dedupe-prune") },
+    downloadMetrics: {
+      pruneDownloadMetricDedupesInternal: Symbol("download-metric-dedupe-prune"),
+    },
   },
 }));
 

--- a/convex/lib/githubSkillSync.test.ts
+++ b/convex/lib/githubSkillSync.test.ts
@@ -237,7 +237,7 @@ describe("buildGitHubSkillSyncPlan", () => {
           githubCurrentCommit: "2".repeat(40),
           githubCurrentContentHash: snapshot.skills[0]?.contentHash,
           githubScanStatus: "pending",
-          moderationStatus: "active",
+          moderationStatus: "hidden",
           moderationReason: "pending.scan",
         }),
       }),
@@ -361,7 +361,7 @@ describe("buildGitHubSkillSyncPlan", () => {
       githubCurrentCommit: "3".repeat(40),
       githubCurrentContentHash: contentHash,
       githubScanStatus: "pending",
-      moderationStatus: "active",
+      moderationStatus: "hidden",
       moderationReason: "pending.scan",
     });
     expect(plan.stats.unchanged).toBe(1);

--- a/convex/lib/publishers.ts
+++ b/convex/lib/publishers.ts
@@ -32,7 +32,7 @@ function normalizeGeneratedPublisherHandle(handle: string | undefined | null) {
   return sanitized || undefined;
 }
 
-function derivePersonalPublisherHandle(user: Doc<"users">) {
+export function derivePersonalPublisherHandle(user: Doc<"users">) {
   const emailLocalPart = user.email?.split("@")[0];
   const userIdSuffix = String(user._id).split(":").pop();
   return (

--- a/convex/maintenance.test.ts
+++ b/convex/maintenance.test.ts
@@ -27,6 +27,7 @@ vi.mock("./_generated/api", () => ({
       nominateUserForEmptySkillSpamInternal: Symbol("nominateUserForEmptySkillSpamInternal"),
       cleanupEmptySkillsInternal: Symbol("cleanupEmptySkillsInternal"),
       nominateEmptySkillSpammersInternal: Symbol("nominateEmptySkillSpammersInternal"),
+      repairLegacyPublisherOwnership: Symbol("repairLegacyPublisherOwnership"),
     },
     skills: {
       backfillLatestSkillModerationInternal: Symbol("skills.backfillLatestSkillModerationInternal"),
@@ -54,6 +55,7 @@ const {
   backfillUserStatsInternalHandler,
   cleanupEmptySkillsInternalHandler,
   nominateEmptySkillSpammersInternalHandler,
+  repairLegacyPublisherOwnershipHandler,
   upsertSkillBadgeRecordInternal,
 } = await import("./maintenance");
 const { internal } = await import("./_generated/api");
@@ -62,6 +64,553 @@ const { generateSkillSummary } = await import("./lib/skillSummary");
 function makeBlob(text: string) {
   return { text: () => Promise.resolve(text) } as unknown as Blob;
 }
+
+type QueryEq = {
+  eq: (field: string, value: unknown) => QueryEq;
+};
+
+function makeLegacyPublisherOwnershipDb() {
+  const now = 1_717_456_000_000;
+  let nextPublisherId = 2;
+  let nextMemberId = 1;
+  const users = new Map<string, Record<string, unknown>>([
+    [
+      "users:legacy",
+      {
+        _id: "users:legacy",
+        _creationTime: now - 1000,
+        handle: "legacy-owner",
+        name: "Legacy Owner",
+        displayName: "Legacy Owner",
+        deletedAt: undefined,
+        deactivatedAt: undefined,
+        purgedAt: undefined,
+      },
+    ],
+    [
+      "users:deleted",
+      {
+        _id: "users:deleted",
+        _creationTime: now - 1000,
+        handle: "deleted-owner",
+        deletedAt: now - 10,
+        deactivatedAt: undefined,
+        purgedAt: undefined,
+      },
+    ],
+  ]);
+  const publishers = new Map<string, Record<string, unknown>>([
+    [
+      "publishers:existing",
+      {
+        _id: "publishers:existing",
+        _creationTime: now - 500,
+        kind: "user",
+        handle: "existing-owner",
+        displayName: "Existing Owner",
+        linkedUserId: "users:existing",
+        publishedSkills: 0,
+        publishedPackages: 0,
+        totalInstalls: 0,
+        totalDownloads: 0,
+        totalStars: 0,
+        skillTotalInstalls: 0,
+        skillTotalDownloads: 0,
+        skillTotalStars: 0,
+        createdAt: now - 500,
+        updatedAt: now - 500,
+      },
+    ],
+  ]);
+  const publisherMembers = new Map<string, Record<string, unknown>>();
+  const skills = new Map<string, Record<string, unknown>>([
+    [
+      "skills:legacy",
+      {
+        _id: "skills:legacy",
+        _creationTime: now - 400,
+        slug: "legacy-skill",
+        displayName: "Legacy Skill",
+        ownerUserId: "users:legacy",
+        ownerPublisherId: undefined,
+        latestVersionId: "skillVersions:legacy",
+        tags: { latest: "skillVersions:legacy" },
+        stats: {
+          downloads: 10,
+          stars: 3,
+          installsCurrent: 2,
+          installsAllTime: 5,
+          comments: 0,
+          versions: 1,
+        },
+        statsDownloads: 10,
+        statsStars: 3,
+        statsInstallsCurrent: 2,
+        statsInstallsAllTime: 5,
+        softDeletedAt: undefined,
+        moderationStatus: "active",
+        createdAt: now - 300,
+        updatedAt: now - 200,
+      },
+    ],
+    [
+      "skills:deleted-owner",
+      {
+        _id: "skills:deleted-owner",
+        _creationTime: now - 400,
+        slug: "deleted-owner-skill",
+        displayName: "Deleted Owner Skill",
+        ownerUserId: "users:deleted",
+        ownerPublisherId: undefined,
+        latestVersionId: "skillVersions:deleted-owner",
+        tags: { latest: "skillVersions:deleted-owner" },
+        stats: {
+          downloads: 1,
+          stars: 0,
+          installsCurrent: 0,
+          installsAllTime: 0,
+          comments: 0,
+          versions: 1,
+        },
+        softDeletedAt: undefined,
+        moderationStatus: "active",
+        createdAt: now - 300,
+        updatedAt: now - 200,
+      },
+    ],
+  ]);
+  const skillVersions = new Map<string, Record<string, unknown>>([
+    [
+      "skillVersions:legacy",
+      {
+        _id: "skillVersions:legacy",
+        skillId: "skills:legacy",
+        version: "1.0.0",
+        softDeletedAt: undefined,
+      },
+    ],
+    [
+      "skillVersions:deleted-owner",
+      {
+        _id: "skillVersions:deleted-owner",
+        skillId: "skills:deleted-owner",
+        version: "1.0.0",
+        softDeletedAt: undefined,
+      },
+    ],
+  ]);
+  const skillSlugAliases = new Map<string, Record<string, unknown>>([
+    [
+      "skillSlugAliases:legacy",
+      {
+        _id: "skillSlugAliases:legacy",
+        slug: "old-legacy-skill",
+        skillId: "skills:legacy",
+        ownerUserId: "users:legacy",
+        ownerPublisherId: undefined,
+        createdAt: now - 250,
+        updatedAt: now - 250,
+      },
+    ],
+  ]);
+  const skillEmbeddings = new Map<string, Record<string, unknown>>([
+    [
+      "skillEmbeddings:legacy",
+      {
+        _id: "skillEmbeddings:legacy",
+        skillId: "skills:legacy",
+        versionId: "skillVersions:legacy",
+        ownerId: "users:legacy",
+        ownerPublisherId: undefined,
+        embedding: [0.1, 0.2],
+        isLatest: true,
+        isApproved: true,
+        visibility: "public",
+        updatedAt: now - 200,
+      },
+    ],
+  ]);
+  const skillSearchDigest = new Map<string, Record<string, unknown>>([
+    [
+      "skillSearchDigest:legacy",
+      {
+        _id: "skillSearchDigest:legacy",
+        skillId: "skills:legacy",
+        slug: "legacy-skill",
+        displayName: "Legacy Skill",
+        ownerUserId: "users:legacy",
+        ownerPublisherId: undefined,
+        ownerHandle: "legacy-owner",
+        ownerKind: "user",
+        stats: {
+          downloads: 10,
+          stars: 3,
+          installsCurrent: 2,
+          installsAllTime: 5,
+          comments: 0,
+          versions: 1,
+        },
+        statsDownloads: 10,
+        statsStars: 3,
+        statsInstallsCurrent: 2,
+        statsInstallsAllTime: 5,
+        softDeletedAt: undefined,
+        moderationStatus: "active",
+        createdAt: now - 300,
+        updatedAt: now - 200,
+      },
+    ],
+  ]);
+  const packages = new Map<string, Record<string, unknown>>([
+    [
+      "packages:legacy",
+      {
+        _id: "packages:legacy",
+        _creationTime: now - 400,
+        name: "@legacy-owner/demo-plugin",
+        normalizedName: "@legacy-owner/demo-plugin",
+        displayName: "Demo Plugin",
+        family: "bundle-plugin",
+        channel: "community",
+        isOfficial: false,
+        ownerUserId: "users:legacy",
+        ownerPublisherId: undefined,
+        summary: "Demo package",
+        latestReleaseId: undefined,
+        tags: {},
+        compatibility: undefined,
+        capabilities: undefined,
+        verification: undefined,
+        scanStatus: "clean",
+        stats: { downloads: 7, installs: 4, stars: 2, versions: 1 },
+        softDeletedAt: undefined,
+        createdAt: now - 300,
+        updatedAt: now - 200,
+      },
+    ],
+  ]);
+  const packageSearchDigest = new Map<string, Record<string, unknown>>([
+    [
+      "packageSearchDigest:legacy",
+      {
+        _id: "packageSearchDigest:legacy",
+        packageId: "packages:legacy",
+        name: "@legacy-owner/demo-plugin",
+        normalizedName: "@legacy-owner/demo-plugin",
+        displayName: "Demo Plugin",
+        family: "bundle-plugin",
+        channel: "community",
+        isOfficial: false,
+        ownerUserId: "users:legacy",
+        ownerPublisherId: undefined,
+        ownerHandle: "legacy-owner",
+        ownerKind: "user",
+        summary: "Demo package",
+        scanStatus: "clean",
+        softDeletedAt: undefined,
+        createdAt: now - 300,
+        updatedAt: now - 200,
+      },
+    ],
+  ]);
+  const packageCapabilitySearchDigest = new Map<string, Record<string, unknown>>();
+  const packagePluginCategorySearchDigest = new Map<string, Record<string, unknown>>();
+
+  const tableMap: Record<string, Map<string, Record<string, unknown>>> = {
+    users,
+    publishers,
+    publisherMembers,
+    skills,
+    skillVersions,
+    skillSlugAliases,
+    skillEmbeddings,
+    skillSearchDigest,
+    packages,
+    packageSearchDigest,
+    packageCapabilitySearchDigest,
+    packagePluginCategorySearchDigest,
+  };
+  const patchCalls: Array<{ id: string; patch: Record<string, unknown> }> = [];
+  const insertCalls: Array<{ table: string; value: Record<string, unknown> }> = [];
+
+  const getRows = (table: string) => Array.from(tableMap[table]?.values() ?? []);
+  const getTableForId = (id: string) => id.split(":")[0];
+  const readField = (row: Record<string, unknown>, field: string) =>
+    field.split(".").reduce<unknown>((value, part) => {
+      if (!value || typeof value !== "object") return undefined;
+      return (value as Record<string, unknown>)[part];
+    }, row);
+  const makeQuery = (table: string, rows: Record<string, unknown>[]) => ({
+    collect: vi.fn(async () => rows),
+    unique: vi.fn(async () => rows[0] ?? null),
+    take: vi.fn(async (limit: number) => rows.slice(0, limit)),
+    order: vi.fn(() => ({
+      take: vi.fn(async (limit: number) => rows.slice(0, limit)),
+      paginate: vi.fn(async ({ cursor, numItems }: { cursor: string | null; numItems: number }) =>
+        paginateRows(rows, cursor, numItems),
+      ),
+    })),
+    paginate: vi.fn(async ({ cursor, numItems }: { cursor: string | null; numItems: number }) =>
+      paginateRows(rows, cursor, numItems),
+    ),
+    withIndex: vi.fn((indexName: string, build?: (q: QueryEq) => unknown) => {
+      const filters: Array<{ field: string; value: unknown }> = [];
+      const q: QueryEq = {
+        eq: (field, value) => {
+          filters.push({ field, value });
+          return q;
+        },
+      };
+      build?.(q);
+      let indexedRows = getRows(table).filter((row) =>
+        filters.every((filter) => readField(row, filter.field) === filter.value),
+      );
+      if (table === "users" && indexName === "by_active_handle") {
+        indexedRows = indexedRows.filter(
+          (row) => row.deletedAt === undefined && row.deactivatedAt === undefined,
+        );
+      }
+      return makeQuery(table, indexedRows);
+    }),
+  });
+
+  const db = {
+    get: vi.fn(async (id: string) => tableMap[getTableForId(id)]?.get(id) ?? null),
+    query: vi.fn((table: string) => makeQuery(table, getRows(table))),
+    patch: vi.fn(async (id: string, patch: Record<string, unknown>) => {
+      patchCalls.push({ id, patch });
+      const row = tableMap[getTableForId(id)]?.get(id);
+      if (row) Object.assign(row, patch);
+    }),
+    insert: vi.fn(async (table: string, value: Record<string, unknown>) => {
+      const id =
+        table === "publishers"
+          ? `publishers:created${nextPublisherId++}`
+          : table === "publisherMembers"
+            ? `publisherMembers:created${nextMemberId++}`
+            : `${table}:created`;
+      insertCalls.push({ table, value });
+      tableMap[table].set(id, { _id: id, _creationTime: now, ...value });
+      return id;
+    }),
+    delete: vi.fn(async (id: string) => {
+      tableMap[getTableForId(id)]?.delete(id);
+    }),
+    normalizeId: vi.fn(),
+  };
+
+  return {
+    db,
+    patchCalls,
+    insertCalls,
+    tableMap,
+  };
+}
+
+function paginateRows(rows: Record<string, unknown>[], cursor: string | null, numItems: number) {
+  const start = cursor ? Number(cursor) : 0;
+  const page = rows.slice(start, start + numItems);
+  const next = start + page.length;
+  return {
+    page,
+    continueCursor: next >= rows.length ? null : String(next),
+    isDone: next >= rows.length,
+  };
+}
+
+describe("maintenance legacy publisher ownership repair", () => {
+  it("dry-runs legacy publisher ownership repair without writes", async () => {
+    const { db, patchCalls, insertCalls } = makeLegacyPublisherOwnershipDb();
+
+    const result = await repairLegacyPublisherOwnershipHandler(
+      { db, scheduler: { runAfter: vi.fn() } } as never,
+      { phase: "users", dryRun: true, batchSize: 10, scheduleNext: false },
+    );
+
+    expect(result).toMatchObject({
+      phase: "users",
+      dryRun: true,
+      scanned: 1,
+      repaired: 1,
+      skipped: 0,
+      isDone: true,
+    });
+    expect(patchCalls).toEqual([]);
+    expect(insertCalls).toEqual([]);
+  });
+
+  it("reports dry-run personal publisher handle conflicts without writes", async () => {
+    const { db, tableMap, patchCalls, insertCalls } = makeLegacyPublisherOwnershipDb();
+    tableMap.users.set("users:conflict", {
+      _id: "users:conflict",
+      _creationTime: 1_717_456_000_000 - 1000,
+      handle: "existing-owner",
+      name: "Conflicting Owner",
+      displayName: "Conflicting Owner",
+      deletedAt: undefined,
+      deactivatedAt: undefined,
+      purgedAt: undefined,
+    });
+
+    const result = await repairLegacyPublisherOwnershipHandler(
+      { db, scheduler: { runAfter: vi.fn() } } as never,
+      { phase: "users", dryRun: true, batchSize: 10, scheduleNext: false },
+    );
+
+    expect(result).toMatchObject({
+      phase: "users",
+      dryRun: true,
+      scanned: 2,
+      repaired: 1,
+      skipped: 1,
+      isDone: true,
+      errors: ['user:users:conflict: Publisher handle "@existing-owner" is already claimed'],
+    });
+    expect(patchCalls).toEqual([]);
+    expect(insertCalls).toEqual([]);
+  });
+
+  it("repairs active legacy users, skills, aliases, embeddings, and packages", async () => {
+    const { db, tableMap, patchCalls, insertCalls } = makeLegacyPublisherOwnershipDb();
+    const scheduler = { runAfter: vi.fn() };
+
+    const usersResult = await repairLegacyPublisherOwnershipHandler({ db, scheduler } as never, {
+      phase: "users",
+      dryRun: false,
+      batchSize: 10,
+      scheduleNext: false,
+    });
+    const createdPublisher = Array.from(tableMap.publishers.values()).find(
+      (publisher) => publisher.handle === "legacy-owner",
+    );
+    expect(usersResult).toMatchObject({
+      phase: "users",
+      dryRun: false,
+      scanned: 1,
+      repaired: 1,
+      skipped: 0,
+      isDone: true,
+    });
+    expect(createdPublisher).toMatchObject({
+      kind: "user",
+      handle: "legacy-owner",
+      displayName: "Legacy Owner",
+      linkedUserId: "users:legacy",
+    });
+    expect(tableMap.users.get("users:legacy")).toMatchObject({
+      personalPublisherId: createdPublisher?._id,
+    });
+    expect(insertCalls.some((call) => call.table === "publisherMembers")).toBe(true);
+
+    const skillsResult = await repairLegacyPublisherOwnershipHandler({ db, scheduler } as never, {
+      phase: "skills",
+      dryRun: false,
+      batchSize: 10,
+      scheduleNext: false,
+    });
+    expect(skillsResult).toMatchObject({
+      phase: "skills",
+      dryRun: false,
+      scanned: 2,
+      repaired: 1,
+      skipped: 1,
+      isDone: true,
+    });
+    expect(tableMap.skills.get("skills:legacy")).toMatchObject({
+      ownerPublisherId: createdPublisher?._id,
+    });
+    expect(tableMap.skills.get("skills:deleted-owner")).toMatchObject({
+      ownerPublisherId: undefined,
+    });
+    expect(tableMap.skillSlugAliases.get("skillSlugAliases:legacy")).toMatchObject({
+      ownerPublisherId: createdPublisher?._id,
+    });
+    expect(tableMap.skillEmbeddings.get("skillEmbeddings:legacy")).toMatchObject({
+      ownerPublisherId: createdPublisher?._id,
+    });
+
+    const packagesResult = await repairLegacyPublisherOwnershipHandler({ db, scheduler } as never, {
+      phase: "packages",
+      dryRun: false,
+      batchSize: 10,
+      scheduleNext: false,
+    });
+    expect(packagesResult).toMatchObject({
+      phase: "packages",
+      dryRun: false,
+      scanned: 1,
+      repaired: 1,
+      skipped: 0,
+      isDone: true,
+    });
+    expect(tableMap.packages.get("packages:legacy")).toMatchObject({
+      ownerPublisherId: createdPublisher?._id,
+    });
+    expect(patchCalls.some((call) => call.id === "skillSearchDigest:legacy")).toBe(false);
+    expect(patchCalls.some((call) => call.id === "packageSearchDigest:legacy")).toBe(false);
+    expect(
+      patchCalls.some(
+        (call) =>
+          call.id === createdPublisher?._id &&
+          ("publishedSkills" in call.patch || "publishedPackages" in call.patch),
+      ),
+    ).toBe(false);
+  });
+
+  it("aborts apply-mode skill repair when owner projection sync fails", async () => {
+    const { db } = makeLegacyPublisherOwnershipDb();
+    const scheduler = { runAfter: vi.fn() };
+
+    await repairLegacyPublisherOwnershipHandler({ db, scheduler } as never, {
+      phase: "users",
+      dryRun: false,
+      batchSize: 10,
+      scheduleNext: false,
+    });
+
+    const patch = db.patch;
+    db.patch = vi.fn(async (id: string, value: Record<string, unknown>) => {
+      if (id === "skillEmbeddings:legacy") throw new Error("embedding sync failed");
+      await patch(id, value);
+    });
+
+    await expect(
+      repairLegacyPublisherOwnershipHandler({ db, scheduler } as never, {
+        phase: "skills",
+        dryRun: false,
+        batchSize: 10,
+        scheduleNext: false,
+      }),
+    ).rejects.toThrow("embedding sync failed");
+  });
+
+  it("propagates apply-mode package patch failures", async () => {
+    const { db } = makeLegacyPublisherOwnershipDb();
+    const scheduler = { runAfter: vi.fn() };
+
+    await repairLegacyPublisherOwnershipHandler({ db, scheduler } as never, {
+      phase: "users",
+      dryRun: false,
+      batchSize: 10,
+      scheduleNext: false,
+    });
+
+    const patch = db.patch;
+    db.patch = vi.fn(async (id: string, value: Record<string, unknown>) => {
+      if (id === "packages:legacy") throw new Error("package patch failed");
+      await patch(id, value);
+    });
+
+    await expect(
+      repairLegacyPublisherOwnershipHandler({ db, scheduler } as never, {
+        phase: "packages",
+        dryRun: false,
+        batchSize: 10,
+        scheduleNext: false,
+      }),
+    ).rejects.toThrow("package patch failed");
+  });
+});
 
 describe("maintenance backfill", () => {
   it("patches stale skill search digest rank stats from legacy skill stats", async () => {

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -1,10 +1,18 @@
 import { ConvexError, v } from "convex/values";
 import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
-import type { ActionCtx } from "./_generated/server";
+import type { ActionCtx, MutationCtx } from "./_generated/server";
 import { action, internalAction, internalMutation, internalQuery } from "./functions";
 import { assertRole, requireUserFromAction } from "./lib/access";
 import { extractPackageDigestFields, upsertPackageSearchDigest } from "./lib/packageSearchDigest";
+import {
+  derivePersonalPublisherHandle,
+  ensurePersonalPublisherForUser,
+  getPersonalPublisherForUser,
+  getPublisherByHandle,
+  getPublisherMembership,
+  isPublisherActive,
+} from "./lib/publishers";
 import { recomputePublisherStats } from "./lib/publisherStats";
 import { buildSkillSummaryBackfillPatch, type ParsedSkillData } from "./lib/skillBackfill";
 import { deriveSkillCapabilityTags } from "./lib/skillCapabilityTags";
@@ -91,6 +99,20 @@ type UserOwnedSkillsBackfillPageResult = {
   items: Array<Pick<Doc<"skills">, "stats" | "softDeletedAt">>;
   cursor: string | null;
   isDone: boolean;
+};
+
+type LegacyPublisherOwnershipPhase = "users" | "skills" | "packages";
+
+type LegacyPublisherOwnershipRepairResult = {
+  phase: LegacyPublisherOwnershipPhase;
+  dryRun: boolean;
+  scanned: number;
+  repaired: number;
+  skipped: number;
+  errors: string[];
+  cursor: string | null;
+  isDone: boolean;
+  nextPhase?: LegacyPublisherOwnershipPhase;
 };
 
 export const getSkillBackfillPageInternal = internalQuery({
@@ -2274,6 +2296,261 @@ export const backfillPackagePluginCategoryDigestsInternal = internalMutation({
 
     return { synced, isDone, scanned: page.length };
   },
+});
+
+function isActiveLegacyPublisherRepairUser(
+  user: Doc<"users"> | null | undefined,
+): user is Doc<"users"> {
+  return Boolean(user && !user.deletedAt && !user.deactivatedAt && !user.purgedAt);
+}
+
+function nextLegacyPublisherOwnershipPhase(
+  phase: LegacyPublisherOwnershipPhase,
+): LegacyPublisherOwnershipPhase | undefined {
+  if (phase === "users") return "skills";
+  if (phase === "skills") return "packages";
+  return undefined;
+}
+
+async function getExistingActivePersonalPublisher(
+  ctx: Pick<MutationCtx, "db">,
+  user: Doc<"users">,
+) {
+  if (user.personalPublisherId) {
+    const publisher = await ctx.db.get(user.personalPublisherId);
+    if (isPublisherActive(publisher)) return publisher;
+  }
+  const publisher = await getPersonalPublisherForUser(ctx, user._id);
+  return isPublisherActive(publisher) ? publisher : null;
+}
+
+async function needsPersonalPublisherRepair(ctx: Pick<MutationCtx, "db">, user: Doc<"users">) {
+  const publisher = await getExistingActivePersonalPublisher(ctx, user);
+  if (!publisher) return true;
+  if (user.personalPublisherId !== publisher._id) return true;
+  if (publisher.kind !== "user" || publisher.linkedUserId !== user._id) return true;
+  const member = await getPublisherMembership(ctx, publisher._id, user._id);
+  return !member;
+}
+
+function pushRepairError(errors: string[], label: string, error: unknown) {
+  if (errors.length >= 10) return;
+  const message = error instanceof Error ? error.message : String(error);
+  errors.push(`${label}: ${message}`);
+}
+
+async function resolvePersonalPublisherForOwnershipRepair(
+  ctx: Pick<MutationCtx, "db">,
+  user: Doc<"users">,
+  dryRun: boolean,
+) {
+  if (dryRun) {
+    const existing = await getExistingActivePersonalPublisher(ctx, user);
+    if (existing) return existing;
+    const handle = derivePersonalPublisherHandle(user);
+    const conflict = await getPublisherByHandle(ctx, handle);
+    if (conflict && conflict.linkedUserId !== user._id) {
+      throw new ConvexError(`Publisher handle "@${handle}" is already claimed`);
+    }
+    return null;
+  }
+  return await ensurePersonalPublisherForUser(ctx, user, {
+    source: "maintenance.legacy_publisher_ownership",
+  });
+}
+
+async function repairLegacySkillOwnerPublisher(
+  ctx: Pick<MutationCtx, "db">,
+  skill: Doc<"skills">,
+  dryRun: boolean,
+) {
+  if (skill.ownerPublisherId) return "skipped" as const;
+  const owner = await ctx.db.get(skill.ownerUserId);
+  if (!isActiveLegacyPublisherRepairUser(owner)) return "skipped" as const;
+
+  const publisher = await resolvePersonalPublisherForOwnershipRepair(ctx, owner, dryRun);
+  if (!dryRun && (!publisher || !isPublisherActive(publisher))) return "skipped" as const;
+  if (dryRun) return "repaired" as const;
+
+  // The trigger-wrapped mutation syncs skill search digest and publisher stats.
+  // This repair only patches owner projections that triggers do not own.
+  await ctx.db.patch(skill._id, { ownerPublisherId: publisher!._id });
+
+  const aliases = await ctx.db
+    .query("skillSlugAliases")
+    .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
+    .collect();
+  for (const alias of aliases) {
+    if (alias.ownerPublisherId === publisher!._id) continue;
+    await ctx.db.patch(alias._id, { ownerPublisherId: publisher!._id });
+  }
+
+  const embeddings = await ctx.db
+    .query("skillEmbeddings")
+    .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
+    .collect();
+  for (const embedding of embeddings) {
+    if (embedding.ownerPublisherId === publisher!._id) continue;
+    await ctx.db.patch(embedding._id, { ownerPublisherId: publisher!._id });
+  }
+
+  return "repaired" as const;
+}
+
+async function repairLegacyPackageOwnerPublisher(
+  ctx: Pick<MutationCtx, "db">,
+  pkg: Doc<"packages">,
+  dryRun: boolean,
+) {
+  if (pkg.ownerPublisherId) return "skipped" as const;
+  const owner = await ctx.db.get(pkg.ownerUserId);
+  if (!isActiveLegacyPublisherRepairUser(owner)) return "skipped" as const;
+
+  const publisher = await resolvePersonalPublisherForOwnershipRepair(ctx, owner, dryRun);
+  if (!dryRun && (!publisher || !isPublisherActive(publisher))) return "skipped" as const;
+  if (dryRun) return "repaired" as const;
+
+  // The trigger-wrapped mutation syncs package search digests and publisher stats.
+  await ctx.db.patch(pkg._id, { ownerPublisherId: publisher!._id });
+  return "repaired" as const;
+}
+
+export async function repairLegacyPublisherOwnershipHandler(
+  ctx: MutationCtx,
+  args: {
+    phase?: LegacyPublisherOwnershipPhase;
+    cursor?: string;
+    batchSize?: number;
+    delayMs?: number;
+    dryRun?: boolean;
+    scheduleNext?: boolean;
+  },
+): Promise<LegacyPublisherOwnershipRepairResult> {
+  const phase = args.phase ?? "users";
+  const dryRun = args.dryRun === true;
+  const batchSize = clampInt(args.batchSize ?? 50, 1, 200);
+  const delayMs = clampInt(args.delayMs ?? 500, 0, 60_000);
+  const errors: string[] = [];
+
+  let scanned = 0;
+  let repaired = 0;
+  let skipped = 0;
+  let continueCursor: string | null = null;
+  let isDone = true;
+
+  if (phase === "users") {
+    const page = await ctx.db
+      .query("users")
+      .withIndex("by_active_handle", (q) =>
+        q.eq("deletedAt", undefined).eq("deactivatedAt", undefined),
+      )
+      .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
+    continueCursor = page.continueCursor;
+    isDone = page.isDone;
+
+    for (const user of page.page) {
+      scanned++;
+      if (!isActiveLegacyPublisherRepairUser(user)) {
+        skipped++;
+        continue;
+      }
+      try {
+        if (!(await needsPersonalPublisherRepair(ctx, user))) continue;
+        if (dryRun) {
+          await resolvePersonalPublisherForOwnershipRepair(ctx, user, true);
+        } else {
+          await ensurePersonalPublisherForUser(ctx, user, {
+            source: "maintenance.legacy_publisher_ownership",
+          });
+        }
+        repaired++;
+      } catch (error) {
+        if (!dryRun) throw error;
+        skipped++;
+        pushRepairError(errors, `user:${user._id}`, error);
+      }
+    }
+  } else if (phase === "skills") {
+    const page = await ctx.db
+      .query("skills")
+      .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", undefined))
+      .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
+    continueCursor = page.continueCursor;
+    isDone = page.isDone;
+
+    for (const skill of page.page) {
+      scanned++;
+      try {
+        const result = await repairLegacySkillOwnerPublisher(ctx, skill, dryRun);
+        if (result === "repaired") repaired++;
+        else skipped++;
+      } catch (error) {
+        if (!dryRun) throw error;
+        skipped++;
+        pushRepairError(errors, `skill:${skill._id}`, error);
+      }
+    }
+  } else {
+    const page = await ctx.db
+      .query("packages")
+      .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", undefined))
+      .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
+    continueCursor = page.continueCursor;
+    isDone = page.isDone;
+
+    for (const pkg of page.page) {
+      scanned++;
+      try {
+        const result = await repairLegacyPackageOwnerPublisher(ctx, pkg, dryRun);
+        if (result === "repaired") repaired++;
+        else skipped++;
+      } catch (error) {
+        if (!dryRun) throw error;
+        skipped++;
+        pushRepairError(errors, `package:${pkg._id}`, error);
+      }
+    }
+  }
+
+  const nextPhase = isDone ? nextLegacyPublisherOwnershipPhase(phase) : phase;
+  if (!dryRun && args.scheduleNext !== false && nextPhase) {
+    await ctx.scheduler.runAfter(delayMs, internal.maintenance.repairLegacyPublisherOwnership, {
+      phase: nextPhase,
+      cursor: isDone ? undefined : (continueCursor ?? undefined),
+      batchSize: args.batchSize,
+      delayMs: args.delayMs,
+      scheduleNext: args.scheduleNext,
+    });
+  }
+
+  return {
+    phase,
+    dryRun,
+    scanned,
+    repaired,
+    skipped,
+    errors,
+    cursor: continueCursor,
+    isDone,
+    ...(nextPhase ? { nextPhase } : {}),
+  };
+}
+
+// Repair legacy personal publisher ownership after the publisher model rollout.
+// Dry run one phase:
+//   npx convex run maintenance:repairLegacyPublisherOwnership '{"phase":"skills","dryRun":true,"scheduleNext":false}' --prod
+// Apply all phases, scheduled batch-by-batch:
+//   npx convex run maintenance:repairLegacyPublisherOwnership '{"phase":"users","batchSize":50}' --prod
+export const repairLegacyPublisherOwnership = internalMutation({
+  args: {
+    phase: v.optional(v.union(v.literal("users"), v.literal("skills"), v.literal("packages"))),
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+    delayMs: v.optional(v.number()),
+    dryRun: v.optional(v.boolean()),
+    scheduleNext: v.optional(v.boolean()),
+  },
+  handler: repairLegacyPublisherOwnershipHandler,
 });
 
 const DIGEST_OWNER_BACKFILL_KEY = "digest-owner-backfill";

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -1142,6 +1142,37 @@ function makeInsertReleaseCtx(
             ),
           };
         }
+        if (table === "officialPublishers") {
+          return {
+            withIndex: vi.fn(
+              (
+                _indexName: string,
+                buildQuery?: (q: { eq: (field: string, value: unknown) => unknown }) => unknown,
+              ) => {
+                const filters = new Map<string, unknown>();
+                const query = {
+                  eq(field: string, value: unknown) {
+                    filters.set(field, value);
+                    return query;
+                  },
+                };
+                buildQuery?.(query);
+                const rawPublisherId = filters.get("publisherId");
+                const publisherId = typeof rawPublisherId === "string" ? rawPublisherId : "";
+                const publisher = recordsById[publisherId];
+                return {
+                  unique: vi
+                    .fn()
+                    .mockResolvedValue(
+                      publisher?.handle === "openclaw"
+                        ? { _id: "officialPublishers:openclaw", publisherId }
+                        : null,
+                    ),
+                };
+              },
+            ),
+          };
+        }
         throw new Error(`Unexpected table ${table}`);
       }),
       insert,
@@ -1258,9 +1289,34 @@ function makeTransferPackageOwnerCtx(options?: {
           }
           if (table === "officialPublishers") {
             return {
-              withIndex: vi.fn(() => ({
-                unique: vi.fn().mockResolvedValue(null),
-              })),
+              withIndex: vi.fn((_indexName: string, builder: (q: unknown) => unknown) => {
+                const terms: Record<string, unknown> = {};
+                builder({
+                  eq: (field: string, value: unknown) => {
+                    terms[field] = value;
+                    return {};
+                  },
+                });
+                const ownerPublisher =
+                  terms.publisherId === "publishers:openclaw"
+                    ? (options?.ownerPublisher ?? {
+                        _id: "publishers:openclaw",
+                        kind: "org",
+                        handle: "openclaw",
+                        displayName: "OpenClaw",
+                        trustedPublisher: true,
+                      })
+                    : null;
+                return {
+                  unique: vi
+                    .fn()
+                    .mockResolvedValue(
+                      ownerPublisher?.handle === "openclaw"
+                        ? { _id: "officialPublishers:openclaw", publisherId: terms.publisherId }
+                        : null,
+                    ),
+                };
+              }),
             };
           }
           if (
@@ -1412,6 +1468,13 @@ function makeUserTransferPackageOwnerCtx(options?: {
                     ),
                 };
               }),
+            };
+          }
+          if (table === "officialPublishers") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue(null),
+              })),
             };
           }
           throw new Error(`Unexpected table ${table}`);

--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -256,6 +256,17 @@ function indexedRows<T>(rows: T[]) {
   };
 }
 
+function emptyOfficialPublishersQuery() {
+  return {
+    withIndex: vi.fn((indexName: string) => {
+      if (indexName !== "by_publisher") {
+        throw new Error(`unexpected officialPublishers index ${indexName}`);
+      }
+      return { unique: vi.fn(async () => null) };
+    }),
+  };
+}
+
 function makeResolvePublishTargetCtx(options: {
   targetPublisher: Record<string, unknown>;
   targetMembership?: Record<string, unknown> | null;
@@ -523,6 +534,9 @@ describe("publishers membership controls", () => {
                 packageRows.filter((pkg) => pkg.ownerPublisherId === fields.ownerPublisherId),
               );
             }
+            if (table === "officialPublishers" && indexName === "by_publisher") {
+              return { unique: vi.fn(async () => null) };
+            }
             throw new Error(`unexpected ${table} index ${indexName}`);
           }),
         })),
@@ -599,6 +613,9 @@ describe("publishers membership controls", () => {
               indexName === "by_owner_publisher_active_installs"
             ) {
               return indexedRows([]);
+            }
+            if (table === "officialPublishers" && indexName === "by_publisher") {
+              return { unique: vi.fn(async () => null) };
             }
             throw new Error(`unexpected ${table} index ${indexName}`);
           }),
@@ -816,6 +833,9 @@ describe("publishers membership controls", () => {
             ) {
               return indexedRows([]);
             }
+            if (table === "officialPublishers" && indexName === "by_publisher") {
+              return { unique: vi.fn(async () => null) };
+            }
             throw new Error(`unexpected ${table} index ${indexName}`);
           }),
         })),
@@ -1023,6 +1043,9 @@ describe("publishers membership controls", () => {
               ownerPublisherQueries.push(String(fields.ownerPublisherId));
               return indexedRows([]);
             }
+            if (table === "officialPublishers" && indexName === "by_publisher") {
+              return { unique: vi.fn(async () => null) };
+            }
             throw new Error(`unexpected ${table} index ${indexName}`);
           }),
         })),
@@ -1136,6 +1159,9 @@ describe("publishers membership controls", () => {
                 },
               ]);
             }
+            if (table === "officialPublishers" && indexName === "by_publisher") {
+              return { unique: vi.fn(async () => null) };
+            }
             throw new Error(`unexpected ${table} index ${indexName}`);
           }),
         })),
@@ -1225,6 +1251,9 @@ describe("publishers membership controls", () => {
             }
             if (table === "packages" && indexName === "by_owner_publisher_active_updated") {
               return indexedRows([]);
+            }
+            if (table === "officialPublishers" && indexName === "by_publisher") {
+              return { unique: vi.fn(async () => null) };
             }
             throw new Error(`unexpected ${table} index ${indexName}`);
           }),
@@ -1324,6 +1353,9 @@ describe("publishers membership controls", () => {
                   updatedAt: 4,
                 },
               ]);
+            }
+            if (table === "officialPublishers" && indexName === "by_publisher") {
+              return { unique: vi.fn(async () => null) };
             }
             throw new Error(`unexpected ${table} index ${indexName}`);
           }),
@@ -1453,6 +1485,9 @@ describe("publishers membership controls", () => {
             if (table === "githubSkillSources" && indexName === "by_owner_publisher") {
               return indexedRows([githubSource]);
             }
+            if (table === "officialPublishers" && indexName === "by_publisher") {
+              return { unique: vi.fn(async () => null) };
+            }
             throw new Error(`unexpected ${table} index ${indexName}`);
           }),
         })),
@@ -1544,6 +1579,9 @@ describe("publishers membership controls", () => {
                   displayManifestStatus: "invalid",
                 },
               ]);
+            }
+            if (table === "officialPublishers" && indexName === "by_publisher") {
+              return { unique: vi.fn(async () => null) };
             }
             throw new Error(`unexpected ${table} index ${indexName}`);
           }),
@@ -2213,6 +2251,9 @@ describe("publishers membership controls", () => {
               })),
             };
           }
+          if (table === "officialPublishers") {
+            return emptyOfficialPublishersQuery();
+          }
           throw new Error(`unexpected table ${table}`);
         }),
         patch,
@@ -2563,6 +2604,9 @@ describe("publisher bootstrap", () => {
               }),
             };
           }
+          if (table === "officialPublishers") {
+            return emptyOfficialPublishersQuery();
+          }
           throw new Error(`unexpected table ${table}`);
         }),
       },
@@ -2606,6 +2650,9 @@ describe("publisher bootstrap", () => {
                 return { unique: vi.fn().mockResolvedValue(null) };
               }),
             };
+          }
+          if (table === "officialPublishers") {
+            return emptyOfficialPublishersQuery();
           }
           throw new Error(`unexpected table ${table}`);
         }),
@@ -2661,6 +2708,9 @@ describe("publisher bootstrap", () => {
                 return { unique: vi.fn().mockResolvedValue(null) };
               }),
             };
+          }
+          if (table === "officialPublishers") {
+            return emptyOfficialPublishersQuery();
           }
           throw new Error(`unexpected table ${table}`);
         }),
@@ -2797,6 +2847,9 @@ describe("publisher bootstrap", () => {
               }),
             };
           }
+          if (table === "officialPublishers") {
+            return emptyOfficialPublishersQuery();
+          }
           throw new Error(`unexpected table ${table}`);
         }),
       },
@@ -2864,6 +2917,9 @@ describe("self-serve org publisher creation", () => {
             };
           }),
         };
+      }
+      if (table === "officialPublishers") {
+        return emptyOfficialPublishersQuery();
       }
       throw new Error(`unexpected table ${table}`);
     });
@@ -3095,6 +3151,9 @@ describe("self-serve org publisher creation", () => {
             };
           }),
         };
+      }
+      if (table === "officialPublishers") {
+        return emptyOfficialPublishersQuery();
       }
       throw new Error(`unexpected table ${table}`);
     });

--- a/specs/github-backed-skills.md
+++ b/specs/github-backed-skills.md
@@ -230,4 +230,3 @@ Keep coverage for:
 - cached `SKILL.md` and `skill-card.md` display content
 - no `skillVersions` for GitHub-backed skills
 - OpenClaw installing the pinned GitHub commit/path rather than ClawHub bytes
-

--- a/specs/orgs.md
+++ b/specs/orgs.md
@@ -420,6 +420,23 @@ necessary. Keep digest-first reads.
 - backfill digest owner publisher fields
 - backfill alias tables if needed
 
+Production cleanup is handled by `maintenance:repairLegacyPublisherOwnership`.
+It runs in three cursor-batched phases:
+
+1. `users` ensures active users have a linked personal publisher and owner
+   membership.
+2. `skills` patches legacy skills with missing `ownerPublisherId`, plus slug
+   aliases and embeddings. The trigger-wrapped skill patch syncs
+   `skillSearchDigest` and publisher stats.
+3. `packages` patches legacy packages with missing `ownerPublisherId`. The
+   trigger-wrapped package patch syncs package digests and publisher stats.
+
+Run with `dryRun: true` and `scheduleNext: false` before apply. The repair must
+skip deleted, deactivated, and purged users. Dry-runs should report per-row
+conflicts without aborting the whole batch. Apply-mode failures should abort the
+current mutation so Convex rolls back any partial owner projection, trigger-owned
+digest/stat, or content updates for that batch.
+
 ### Phase 3: dual read/write
 
 - all writes set both old and new ownership fields


### PR DESCRIPTION
## Summary
- add a cursor-batched production maintenance repair for legacy publisher ownership across users, skills, and packages
- repair skill slug aliases and embeddings owner publisher projections while relying on existing Convex triggers for digest/stat sync
- make dry-run surface personal publisher handle conflicts before apply and document the cleanup flow in specs/orgs.md

## Validation
- bun run format:check -- convex/lib/publishers.ts convex/maintenance.ts convex/maintenance.test.ts specs/orgs.md
- bun run test convex/maintenance.test.ts convex/lib/publisherStats.test.ts
- bunx tsc --noEmit --pretty false
- bun run ci:unit
- bun run ci:types-build
- bun run ci:static (via autoreview helper; also rerun during fallback attempts)

## Review notes
- Codex review found and I fixed trigger double-counting for publisher stats/digests.
- Codex review found and I fixed dry-run handle-conflict reporting.
- A final Codex autoreview pass started recursing into nested autoreview helpers; Claude fallback had insufficient credits and Droid fallback was unauthenticated, so the PR relies on the fixed Codex findings plus the green local gates above.
