### PR TITLE
feat: add official org mod commands

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -51,6 +51,7 @@ import {
   starsPostRouterV1Http,
   transfersGetRouterV1Http,
   banAppealContextV1Http,
+  usersGetRouterV1Http,
   usersListV1Http,
   usersPostRouterV1Http,
   verifyDocsSessionV1Http,
@@ -270,6 +271,12 @@ http.route({
   path: "/api/v1/users/ban-appeal-context",
   method: "GET",
   handler: banAppealContextV1Http,
+});
+
+http.route({
+  pathPrefix: `${ApiRoutes.users}/`,
+  method: "GET",
+  handler: usersGetRouterV1Http,
 });
 
 http.route({

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -936,6 +936,130 @@ describe("httpApiV1 handlers", () => {
     );
   });
 
+  it("users/publisher-official lists official publishers for admin", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:admin",
+      user: { _id: "users:admin", role: "admin" },
+    } as never);
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      return {
+        ok: true,
+        items: [
+          {
+            officialPublisherId: "officialPublishers:openclaw",
+            publisherId: "publishers:openclaw",
+            handle: "openclaw",
+            displayName: "OpenClaw",
+            kind: "org",
+            active: true,
+            reason: "platform-owned publisher",
+            createdByUserId: "users:admin",
+            createdByHandle: "patrick-erichsen-2",
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ],
+      };
+    });
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      return null;
+    });
+
+    const response = await __handlers.usersGetRouterV1Handler(
+      makeCtx({ runQuery, runAction: vi.fn(), runMutation }),
+      new Request("https://example.com/api/v1/users/publisher-official", {
+        headers: { Authorization: "Bearer clh_test" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      items: [{ handle: "openclaw" }],
+    });
+    expect(runQuery).toHaveBeenCalledWith(internal.publishers.listOfficialPublishersInternal, {
+      actorUserId: "users:admin",
+    });
+  });
+
+  it("users/publisher-official adds official org publishers for admin", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:admin",
+      user: { _id: "users:admin", role: "admin" },
+    } as never);
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      return {
+        ok: true,
+        publisherId: "publishers:nvidia",
+        handle: "nvidia",
+        added: true,
+        officialPublisherId: "officialPublishers:nvidia",
+      };
+    });
+
+    const response = await __handlers.usersPostRouterV1Handler(
+      makeCtx({ runQuery: vi.fn(), runAction: vi.fn(), runMutation }),
+      new Request("https://example.com/api/v1/users/publisher-official", {
+        method: "POST",
+        headers: { Authorization: "Bearer clh_test" },
+        body: JSON.stringify({
+          action: "add",
+          handle: "NVIDIA",
+          reason: "NVIDIA source-backed catalog",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ ok: true, added: true });
+    expect(runMutation).toHaveBeenCalledWith(internal.publishers.addOfficialPublisherInternal, {
+      actorUserId: "users:admin",
+      handle: "nvidia",
+      reason: "NVIDIA source-backed catalog",
+    });
+  });
+
+  it("users/publisher-official removes official org publishers for admin", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:admin",
+      user: { _id: "users:admin", role: "admin" },
+    } as never);
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      return {
+        ok: true,
+        publisherId: "publishers:nvidia",
+        handle: "nvidia",
+        removed: true,
+        officialPublisherId: "officialPublishers:nvidia",
+      };
+    });
+
+    const response = await __handlers.usersPostRouterV1Handler(
+      makeCtx({ runQuery: vi.fn(), runAction: vi.fn(), runMutation }),
+      new Request("https://example.com/api/v1/users/publisher-official", {
+        method: "POST",
+        headers: { Authorization: "Bearer clh_test" },
+        body: JSON.stringify({
+          action: "remove",
+          handle: "NVIDIA",
+          reason: "requested by publisher",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ ok: true, removed: true });
+    expect(runMutation).toHaveBeenCalledWith(internal.publishers.removeOfficialPublisherInternal, {
+      actorUserId: "users:admin",
+      handle: "nvidia",
+      reason: "requested by publisher",
+    });
+  });
+
   it("publishers creates a self-serve org publisher for the authenticated user", async () => {
     const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
       if (isRateLimitArgs(args)) return okRate();

--- a/convex/httpApiV1.ts
+++ b/convex/httpApiV1.ts
@@ -40,6 +40,7 @@ import { starsDeleteRouterV1Handler, starsPostRouterV1Handler } from "./httpApiV
 import { transfersGetRouterV1Handler } from "./httpApiV1/transfersV1";
 import {
   banAppealContextV1Handler,
+  usersGetRouterV1Handler,
   usersListV1Handler,
   usersPostRouterV1Handler,
 } from "./httpApiV1/usersV1";
@@ -84,6 +85,7 @@ export const starsDeleteRouterV1Http = httpAction(starsDeleteRouterV1Handler);
 export const transfersGetRouterV1Http = httpAction(transfersGetRouterV1Handler);
 
 export const whoamiV1Http = httpAction(whoamiV1Handler);
+export const usersGetRouterV1Http = httpAction(usersGetRouterV1Handler);
 export const usersPostRouterV1Http = httpAction(usersPostRouterV1Handler);
 export const usersListV1Http = httpAction(usersListV1Handler);
 export const banAppealContextV1Http = httpAction(banAppealContextV1Handler);
@@ -120,6 +122,7 @@ export const __handlers = {
   starsDeleteRouterV1Handler,
   transfersGetRouterV1Handler,
   whoamiV1Handler,
+  usersGetRouterV1Handler,
   usersPostRouterV1Handler,
   usersListV1Handler,
   banAppealContextV1Handler,

--- a/convex/httpApiV1/usersV1.ts
+++ b/convex/httpApiV1/usersV1.ts
@@ -14,7 +14,10 @@ import {
 
 const usersV1InternalRefs = internal as unknown as {
   publishers: {
+    addOfficialPublisherInternal: unknown;
+    listOfficialPublishersInternal: unknown;
     removeOrgPublisherMemberInternal: unknown;
+    removeOfficialPublisherInternal: unknown;
   };
   users: {
     getBanAppealContextByGitHubProviderAccountIdInternal: unknown;
@@ -84,6 +87,7 @@ export async function usersPostRouterV1Handler(ctx: ActionCtx, request: Request)
     action !== "reclaim" &&
     action !== "reserve" &&
     action !== "publisher" &&
+    action !== "publisher-official" &&
     action !== "publisher-member"
   ) {
     return text("Not found", 404, rate.headers);
@@ -137,6 +141,12 @@ export async function usersPostRouterV1Handler(ctx: ActionCtx, request: Request)
     const admin = requireAdminOrResponse(actorUser, rate.headers);
     if (!admin.ok) return admin.response;
     return handleAdminEnsurePublisher(ctx, payload, actorUserId, rate.headers);
+  }
+
+  if (action === "publisher-official") {
+    const admin = requireAdminOrResponse(actorUser, rate.headers);
+    if (!admin.ok) return admin.response;
+    return handleAdminOfficialPublisherPost(ctx, payload, actorUserId, rate.headers);
   }
 
   if (action === "publisher-member") {
@@ -352,6 +362,37 @@ async function handleAdminRemediateAutobans(
   }
 }
 
+export async function usersGetRouterV1Handler(ctx: ActionCtx, request: Request) {
+  const rate = await applyRateLimit(ctx, request, "read");
+  if (!rate.ok) return rate.response;
+
+  const segments = getPathSegments(request, "/api/v1/users/");
+  if (segments.length !== 1 || segments[0] !== "publisher-official") {
+    return text("Not found", 404, rate.headers);
+  }
+
+  const authResult = await requireApiTokenUserOrResponse(ctx, request, rate.headers);
+  if (!authResult.ok) return authResult.response;
+  const admin = requireAdminOrResponse(authResult.user, rate.headers);
+  if (!admin.ok) return admin.response;
+
+  try {
+    const result = await runUsersV1QueryRef(
+      ctx,
+      usersV1InternalRefs.publishers.listOfficialPublishersInternal,
+      { actorUserId: authResult.userId },
+    );
+    return json(result, 200, rate.headers);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Official publisher list failed";
+    if (message.toLowerCase().includes("forbidden")) return text("Forbidden", 403, rate.headers);
+    if (message.toLowerCase().includes("unauthorized")) {
+      return text("Unauthorized", 401, rate.headers);
+    }
+    return text(message, 400, rate.headers);
+  }
+}
+
 /**
  * POST /api/v1/users/restore
  * Admin-only: restore skills from GitHub backup for a user.
@@ -530,6 +571,42 @@ async function handleAdminReserve(
   const failed = results.filter((r) => !r.ok).length;
 
   return json({ ok: true, results, succeeded, failed }, 200, headers);
+}
+
+async function handleAdminOfficialPublisherPost(
+  ctx: ActionCtx,
+  payload: Record<string, unknown>,
+  actorUserId: Id<"users">,
+  headers: HeadersInit,
+) {
+  const action = typeof payload.action === "string" ? payload.action.trim().toLowerCase() : "";
+  const handle = typeof payload.handle === "string" ? payload.handle.trim().toLowerCase() : "";
+  const reason = typeof payload.reason === "string" ? payload.reason.trim() : "";
+  if (action !== "add" && action !== "remove") return text("Invalid action", 400, headers);
+  if (!handle) return text("Missing handle", 400, headers);
+  if (!reason) return text("Missing reason", 400, headers);
+  if (reason.length > 500) return text("Reason too long (max 500 chars)", 400, headers);
+
+  try {
+    const result = await runUsersV1MutationRef(
+      ctx,
+      action === "add"
+        ? usersV1InternalRefs.publishers.addOfficialPublisherInternal
+        : usersV1InternalRefs.publishers.removeOfficialPublisherInternal,
+      {
+        actorUserId,
+        handle,
+        reason,
+      },
+    );
+    return json(result, 200, headers);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Official publisher update failed";
+    if (message.toLowerCase().includes("forbidden")) return text("Forbidden", 403, headers);
+    if (message.toLowerCase().includes("unauthorized")) return text("Unauthorized", 401, headers);
+    if (message.toLowerCase().includes("not found")) return text(message, 404, headers);
+    return text(message, 400, headers);
+  }
 }
 
 async function handleAdminEnsurePublisher(

--- a/convex/publishers.ts
+++ b/convex/publishers.ts
@@ -1632,6 +1632,174 @@ export const removeOrgPublisherMemberInternal = internalMutation({
   },
 });
 
+export const listOfficialPublishersInternal = internalQuery({
+  args: {
+    actorUserId: v.id("users"),
+  },
+  handler: async (ctx, args) => {
+    const actor = await ctx.db.get(args.actorUserId);
+    if (!actor || actor.deletedAt || actor.deactivatedAt) throw new ConvexError("Unauthorized");
+    assertAdmin(actor);
+
+    const rows = await ctx.db
+      .query("officialPublishers")
+      .withIndex("by_created", (q) => q)
+      .order("asc")
+      .collect();
+    const items = await Promise.all(
+      rows.map(async (row) => {
+        const [publisher, createdBy] = await Promise.all([
+          ctx.db.get(row.publisherId),
+          row.createdByUserId ? ctx.db.get(row.createdByUserId) : Promise.resolve(null),
+        ]);
+        return {
+          officialPublisherId: row._id,
+          publisherId: row.publisherId,
+          handle: publisher?.handle ?? null,
+          displayName: publisher?.displayName ?? null,
+          kind: publisher?.kind ?? null,
+          active: Boolean(publisher && !publisher.deletedAt && !publisher.deactivatedAt),
+          reason: row.reason ?? null,
+          createdByUserId: row.createdByUserId ?? null,
+          createdByHandle: createdBy?.handle ?? null,
+          createdAt: row.createdAt,
+          updatedAt: row.updatedAt,
+        };
+      }),
+    );
+    return { ok: true as const, items };
+  },
+});
+
+export const addOfficialPublisherInternal = internalMutation({
+  args: {
+    actorUserId: v.id("users"),
+    handle: v.string(),
+    reason: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const actor = await ctx.db.get(args.actorUserId);
+    if (!actor || actor.deletedAt || actor.deactivatedAt) throw new ConvexError("Unauthorized");
+    assertAdmin(actor);
+
+    const handle = normalizePublisherHandle(args.handle);
+    if (!handle) throw new ConvexError("Publisher handle is required");
+    const reason = args.reason.trim();
+    if (!reason) throw new ConvexError("Reason is required");
+    if (reason.length > 500) throw new ConvexError("Reason too long (max 500 chars)");
+
+    const publisher = await getPublisherByHandle(ctx, handle);
+    if (!publisher || publisher.deletedAt || publisher.deactivatedAt) {
+      throw new ConvexError(`Publisher "@${handle}" not found`);
+    }
+    if (publisher.kind !== "org") {
+      throw new ConvexError("Only org publishers can be marked official");
+    }
+
+    const existing = await ctx.db
+      .query("officialPublishers")
+      .withIndex("by_publisher", (q) => q.eq("publisherId", publisher._id))
+      .unique();
+    if (existing) {
+      return {
+        ok: true as const,
+        added: false,
+        publisherId: publisher._id,
+        handle: publisher.handle,
+        officialPublisherId: existing._id,
+      };
+    }
+
+    const now = Date.now();
+    const officialPublisherId = await ctx.db.insert("officialPublishers", {
+      publisherId: publisher._id,
+      reason,
+      createdByUserId: args.actorUserId,
+      createdAt: now,
+      updatedAt: now,
+    });
+    await ctx.db.insert("auditLogs", {
+      actorUserId: args.actorUserId,
+      action: "publisher.official.add",
+      targetType: "publisher",
+      targetId: publisher._id,
+      metadata: {
+        handle: publisher.handle,
+        reason,
+      },
+      createdAt: now,
+    });
+
+    return {
+      ok: true as const,
+      added: true,
+      publisherId: publisher._id,
+      handle: publisher.handle,
+      officialPublisherId,
+    };
+  },
+});
+
+export const removeOfficialPublisherInternal = internalMutation({
+  args: {
+    actorUserId: v.id("users"),
+    handle: v.string(),
+    reason: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const actor = await ctx.db.get(args.actorUserId);
+    if (!actor || actor.deletedAt || actor.deactivatedAt) throw new ConvexError("Unauthorized");
+    assertAdmin(actor);
+
+    const handle = normalizePublisherHandle(args.handle);
+    if (!handle) throw new ConvexError("Publisher handle is required");
+    const reason = args.reason.trim();
+    if (!reason) throw new ConvexError("Reason is required");
+    if (reason.length > 500) throw new ConvexError("Reason too long (max 500 chars)");
+
+    const publisher = await getPublisherByHandle(ctx, handle);
+    if (!publisher || publisher.deletedAt || publisher.deactivatedAt) {
+      throw new ConvexError(`Publisher "@${handle}" not found`);
+    }
+
+    const existing = await ctx.db
+      .query("officialPublishers")
+      .withIndex("by_publisher", (q) => q.eq("publisherId", publisher._id))
+      .unique();
+    if (!existing) {
+      return {
+        ok: true as const,
+        removed: false,
+        publisherId: publisher._id,
+        handle: publisher.handle,
+      };
+    }
+
+    const now = Date.now();
+    await ctx.db.delete(existing._id);
+    await ctx.db.insert("auditLogs", {
+      actorUserId: args.actorUserId,
+      action: "publisher.official.remove",
+      targetType: "publisher",
+      targetId: publisher._id,
+      metadata: {
+        handle: publisher.handle,
+        reason,
+        officialPublisherId: existing._id,
+      },
+      createdAt: now,
+    });
+
+    return {
+      ok: true as const,
+      removed: true,
+      publisherId: publisher._id,
+      handle: publisher.handle,
+      officialPublisherId: existing._id,
+    };
+  },
+});
+
 export const createOrgPublisherForUserInternal = internalMutation({
   args: {
     actorUserId: v.id("users"),

--- a/packages/clawhub-mod/src/cli.ts
+++ b/packages/clawhub-mod/src/cli.ts
@@ -32,7 +32,14 @@ import {
   cmdSetRole,
   cmdUnbanUser,
 } from "./commands/moderation.js";
-import { cmdCreateOrg, cmdRemoveOrgMember, cmdRepairScopedPackages } from "./commands/orgs.js";
+import {
+  cmdAddOfficialOrg,
+  cmdCreateOrg,
+  cmdListOfficialOrgs,
+  cmdRemoveOfficialOrg,
+  cmdRemoveOrgMember,
+  cmdRepairScopedPackages,
+} from "./commands/orgs.js";
 import {
   cmdBackfillPackageArtifacts,
   cmdDeletePackageTrustedPublisher,
@@ -347,6 +354,45 @@ registerOrgCommands(org);
 registerSkillModerationCommands(skills);
 
 function registerOrgCommands(command: Command) {
+  const official = command
+    .command("official")
+    .description("Manage official org publishers")
+    .showHelpAfterError()
+    .showSuggestionAfterError();
+
+  official
+    .command("list")
+    .description("List official org publishers")
+    .option("--json", "Output JSON")
+    .action(async (options) => {
+      const opts = await resolveGlobalOpts();
+      await cmdListOfficialOrgs(opts, options);
+    });
+
+  official
+    .command("add")
+    .description("Mark an org publisher as official")
+    .argument("<handle>", "Org publisher handle")
+    .requiredOption("--reason <reason>", "Audit reason")
+    .option("--yes", "Skip confirmation")
+    .option("--json", "Output JSON")
+    .action(async (handle, options) => {
+      const opts = await resolveGlobalOpts();
+      await cmdAddOfficialOrg(opts, handle, options, isInputAllowed());
+    });
+
+  official
+    .command("remove")
+    .description("Remove an org publisher from the official list")
+    .argument("<handle>", "Org publisher handle")
+    .requiredOption("--reason <reason>", "Audit reason")
+    .option("--yes", "Skip confirmation")
+    .option("--json", "Output JSON")
+    .action(async (handle, options) => {
+      const opts = await resolveGlobalOpts();
+      await cmdRemoveOfficialOrg(opts, handle, options, isInputAllowed());
+    });
+
   command
     .command("create")
     .description("Create or update an org publisher")

--- a/packages/clawhub-mod/src/commands/orgs.test.ts
+++ b/packages/clawhub-mod/src/commands/orgs.test.ts
@@ -22,7 +22,14 @@ vi.mock("../../../clawhub/src/cli/registry.js", () => registryMocks.moduleFactor
 vi.mock("../../../clawhub/src/http.js", () => httpMocks.moduleFactory());
 vi.mock("../../../clawhub/src/cli/ui.js", () => uiMocks.moduleFactory());
 
-const { cmdCreateOrg, cmdRemoveOrgMember, cmdRepairScopedPackages } = await import("./orgs");
+const {
+  cmdAddOfficialOrg,
+  cmdCreateOrg,
+  cmdListOfficialOrgs,
+  cmdRemoveOfficialOrg,
+  cmdRemoveOrgMember,
+  cmdRepairScopedPackages,
+} = await import("./orgs");
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -166,6 +173,121 @@ describe("cmdRemoveOrgMember", () => {
       /Member handle required/i,
     );
     expect(httpMocks.apiRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe("official org commands", () => {
+  it("lists official org publishers", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      ok: true,
+      items: [
+        {
+          officialPublisherId: "officialPublishers:1",
+          publisherId: "publishers:openclaw",
+          handle: "openclaw",
+          displayName: "OpenClaw",
+          kind: "org",
+          active: true,
+          reason: "platform-owned publisher",
+          createdByUserId: "users:admin",
+          createdByHandle: "patrick-erichsen-2",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+    });
+
+    const result = await cmdListOfficialOrgs(makeGlobalOpts(), { json: true });
+
+    expect(result.items).toHaveLength(1);
+    expect(authTokenMocks.requireAuthToken).toHaveBeenCalled();
+    expect(httpMocks.apiRequest).toHaveBeenCalledWith(
+      "https://clawhub.ai",
+      expect.objectContaining({
+        method: "GET",
+        path: "/api/v1/users/publisher-official",
+        token: "tkn",
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("requires --yes to add an official org when input is disabled", async () => {
+    await expect(
+      cmdAddOfficialOrg(
+        makeGlobalOpts(),
+        "nvidia",
+        { reason: "NVIDIA source-backed catalog" },
+        false,
+      ),
+    ).rejects.toThrow(/--yes/i);
+    expect(httpMocks.apiRequest).not.toHaveBeenCalled();
+  });
+
+  it("marks an org publisher official", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      ok: true,
+      publisherId: "publishers:nvidia",
+      handle: "nvidia",
+      added: true,
+      officialPublisherId: "officialPublishers:nvidia",
+    });
+
+    const result = await cmdAddOfficialOrg(
+      makeGlobalOpts(),
+      "@NVIDIA",
+      { reason: "NVIDIA source-backed catalog", yes: true, json: true },
+      false,
+    );
+
+    expect(result).toMatchObject({ ok: true, handle: "nvidia", added: true });
+    expect(httpMocks.apiRequest).toHaveBeenCalledWith(
+      "https://clawhub.ai",
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/v1/users/publisher-official",
+        token: "tkn",
+        body: {
+          action: "add",
+          handle: "nvidia",
+          reason: "NVIDIA source-backed catalog",
+        },
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("removes an org publisher from the official list", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      ok: true,
+      publisherId: "publishers:nvidia",
+      handle: "nvidia",
+      removed: true,
+      officialPublisherId: "officialPublishers:nvidia",
+    });
+
+    const result = await cmdRemoveOfficialOrg(
+      makeGlobalOpts(),
+      "nvidia",
+      { reason: "requested by publisher", yes: true, json: true },
+      false,
+    );
+
+    expect(result).toMatchObject({ ok: true, handle: "nvidia", removed: true });
+    expect(httpMocks.apiRequest).toHaveBeenCalledWith(
+      "https://clawhub.ai",
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/v1/users/publisher-official",
+        token: "tkn",
+        body: {
+          action: "remove",
+          handle: "nvidia",
+          reason: "requested by publisher",
+        },
+      }),
+      expect.anything(),
+    );
   });
 });
 

--- a/packages/clawhub-mod/src/commands/orgs.ts
+++ b/packages/clawhub-mod/src/commands/orgs.ts
@@ -2,10 +2,18 @@ import { readFile, writeFile } from "node:fs/promises";
 import { requireAuthToken } from "../../../clawhub/src/cli/authToken.js";
 import { getRegistry } from "../../../clawhub/src/cli/registry.js";
 import type { GlobalOpts } from "../../../clawhub/src/cli/types.js";
-import { createSpinner, fail, formatError } from "../../../clawhub/src/cli/ui.js";
+import {
+  createSpinner,
+  fail,
+  formatError,
+  isInteractive,
+  promptConfirm,
+} from "../../../clawhub/src/cli/ui.js";
 import { apiRequest } from "../../../clawhub/src/http.js";
 import type { ApiV1PackageRepairNameResponse } from "../../../clawhub/src/schema/index.js";
 import {
+  ApiV1OfficialPublisherListResponseSchema,
+  ApiV1OfficialPublisherUpdateResponseSchema,
   ApiV1PackageRepairNameResponseSchema,
   ApiRoutes,
   ApiV1PublisherEnsureResponseSchema,
@@ -23,6 +31,16 @@ type OrgCreateOptions = {
 };
 
 type OrgRemoveMemberOptions = {
+  json?: boolean;
+};
+
+type OrgOfficialListOptions = {
+  json?: boolean;
+};
+
+type OrgOfficialWriteOptions = {
+  reason?: string;
+  yes?: boolean;
   json?: boolean;
 };
 
@@ -162,6 +180,143 @@ export async function cmdRemoveOrgMember(
   }
 }
 
+export async function cmdListOfficialOrgs(opts: GlobalOpts, options: OrgOfficialListOptions = {}) {
+  const token = await requireAuthToken();
+  const registry = await getRegistry(opts, { cache: true });
+  const spinner = options.json ? null : createSpinner("Listing official org publishers");
+  try {
+    const result = await apiRequest(
+      registry,
+      {
+        method: "GET",
+        path: `${ApiRoutes.users}/publisher-official`,
+        token,
+      },
+      ApiV1OfficialPublisherListResponseSchema,
+    );
+
+    spinner?.stop();
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return result;
+    }
+
+    const items = result.items.filter((item) => item.kind === "org" && item.active);
+    if (items.length === 0) {
+      console.log("No official org publishers.");
+      return result;
+    }
+
+    for (const item of items) {
+      const handle = item.handle ? `@${item.handle}` : item.publisherId;
+      const displayName =
+        item.displayName && item.displayName !== item.handle ? item.displayName : "";
+      const reason = item.reason ? ` - ${item.reason}` : "";
+      console.log([handle, displayName].filter(Boolean).join("  ") + reason);
+    }
+    return result;
+  } catch (error) {
+    spinner?.fail(formatError(error));
+    throw error;
+  }
+}
+
+export async function cmdAddOfficialOrg(
+  opts: GlobalOpts,
+  handle: string,
+  options: OrgOfficialWriteOptions = {},
+  inputAllowed: boolean,
+) {
+  const orgHandle = normalizeHandleOrFail(handle, "Org handle");
+  const reason = normalizeReasonOrFail(options.reason);
+  await confirmOfficialOrgUpdate(
+    `Mark @${orgHandle} official? (admin only; affects official badge and GitHub sync eligibility)`,
+    options,
+    inputAllowed,
+  );
+
+  const token = await requireAuthToken();
+  const registry = await getRegistry(opts, { cache: true });
+  const spinner = options.json ? null : createSpinner(`Marking @${orgHandle} official`);
+  try {
+    const result = await apiRequest(
+      registry,
+      {
+        method: "POST",
+        path: `${ApiRoutes.users}/publisher-official`,
+        token,
+        body: {
+          action: "add",
+          handle: orgHandle,
+          reason,
+        },
+      },
+      ApiV1OfficialPublisherUpdateResponseSchema,
+    );
+
+    spinner?.succeed(
+      result.added ? `Marked @${result.handle} official` : `@${result.handle} is already official`,
+    );
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    }
+    return result;
+  } catch (error) {
+    spinner?.fail(formatError(error));
+    throw error;
+  }
+}
+
+export async function cmdRemoveOfficialOrg(
+  opts: GlobalOpts,
+  handle: string,
+  options: OrgOfficialWriteOptions = {},
+  inputAllowed: boolean,
+) {
+  const orgHandle = normalizeHandleOrFail(handle, "Org handle");
+  const reason = normalizeReasonOrFail(options.reason);
+  await confirmOfficialOrgUpdate(
+    `Remove @${orgHandle} from official org publishers? (admin only)`,
+    options,
+    inputAllowed,
+  );
+
+  const token = await requireAuthToken();
+  const registry = await getRegistry(opts, { cache: true });
+  const spinner = options.json
+    ? null
+    : createSpinner(`Removing @${orgHandle} from official org publishers`);
+  try {
+    const result = await apiRequest(
+      registry,
+      {
+        method: "POST",
+        path: `${ApiRoutes.users}/publisher-official`,
+        token,
+        body: {
+          action: "remove",
+          handle: orgHandle,
+          reason,
+        },
+      },
+      ApiV1OfficialPublisherUpdateResponseSchema,
+    );
+
+    spinner?.succeed(
+      result.removed
+        ? `Removed @${result.handle} from official org publishers`
+        : `@${result.handle} was not official`,
+    );
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    }
+    return result;
+  } catch (error) {
+    spinner?.fail(formatError(error));
+    throw error;
+  }
+}
+
 export async function cmdRepairScopedPackages(
   opts: GlobalOpts,
   csvPath: string,
@@ -285,6 +440,24 @@ function summarizeScopedPackageRepairs(
   const applied = items.filter((item) => item.status === "applied").length;
   const failed = items.filter((item) => item.status === "failed").length;
   return { ok: failed === 0, dryRun, total, planned, applied, failed, items };
+}
+
+function normalizeReasonOrFail(rawReason: string | undefined) {
+  const reason = rawReason?.trim();
+  if (!reason) fail("--reason required");
+  if (reason.length > 500) fail("--reason must be 500 characters or fewer");
+  return reason;
+}
+
+async function confirmOfficialOrgUpdate(
+  prompt: string,
+  options: OrgOfficialWriteOptions,
+  inputAllowed: boolean,
+) {
+  if (options.yes) return;
+  if (!isInteractive() || inputAllowed === false) fail("Pass --yes (no input)");
+  const confirmed = await promptConfirm(prompt);
+  if (!confirmed) fail("Canceled");
 }
 
 function parseScopedPackageRepairCsv(content: string): ScopedPackageRepairRow[] {

--- a/packages/clawhub/src/schema/schemas.ts
+++ b/packages/clawhub/src/schema/schemas.ts
@@ -226,6 +226,36 @@ export const ApiV1PublisherRemoveMemberResponseSchema = type({
 export type ApiV1PublisherRemoveMemberResponse =
   (typeof ApiV1PublisherRemoveMemberResponseSchema)[inferred];
 
+export const ApiV1OfficialPublisherListResponseSchema = type({
+  ok: "true",
+  items: type({
+    officialPublisherId: "string",
+    publisherId: "string",
+    handle: "string|null",
+    displayName: "string|null",
+    kind: '"user"|"org"|null',
+    active: "boolean",
+    reason: "string|null",
+    createdByUserId: "string|null",
+    createdByHandle: "string|null",
+    createdAt: "number",
+    updatedAt: "number",
+  }).array(),
+});
+export type ApiV1OfficialPublisherListResponse =
+  (typeof ApiV1OfficialPublisherListResponseSchema)[inferred];
+
+export const ApiV1OfficialPublisherUpdateResponseSchema = type({
+  ok: "true",
+  publisherId: "string",
+  handle: "string",
+  "added?": "boolean",
+  "removed?": "boolean",
+  "officialPublisherId?": "string",
+});
+export type ApiV1OfficialPublisherUpdateResponse =
+  (typeof ApiV1OfficialPublisherUpdateResponseSchema)[inferred];
+
 export const ApiV1SearchResponseSchema = type({
   results: type({
     slug: "string?",

--- a/specs/github-backed-skills.md
+++ b/specs/github-backed-skills.md
@@ -230,4 +230,3 @@ Keep coverage for:
 - cached `SKILL.md` and `skill-card.md` display content
 - no `skillVersions` for GitHub-backed skills
 - OpenClaw installing the pinned GitHub commit/path rather than ClawHub bytes
-


### PR DESCRIPTION
## Summary

- add audited admin mutations/API routes to list, add, and remove official org publishers
- add `clawhub-mod org official list|add|remove` with required audit reasons and confirmation/`--yes` for writes
- add shared API response schemas and focused handler/CLI tests

## Tests

- `bunx vitest run convex/httpApiV1.handlers.test.ts packages/clawhub-mod/src/commands/orgs.test.ts --reporter=dot`
- `bun run ci:static`
- `bun run mod -- org official --help`

## Notes

Autoreview was started but got stuck/long-running; per Patrick, opening the PR now and review will happen after.
