### PR TITLE
Add official org selector to GitHub sync settings

### DIFF
--- a/convex/githubSkillSources.ts
+++ b/convex/githubSkillSources.ts
@@ -1,10 +1,11 @@
 import { ConvexError, v } from "convex/values";
 import type { Doc, Id } from "./_generated/dataModel";
-import type { MutationCtx } from "./_generated/server";
+import type { MutationCtx, QueryCtx } from "./_generated/server";
 import { internalQuery, mutation, query } from "./functions";
 import { requireUser } from "./lib/access";
 import { adjustGlobalPublicSkillsCount, getPublicSkillVisibilityDelta } from "./lib/globalStats";
-import { requirePublisherRole } from "./lib/publishers";
+import { isOfficialPublisher } from "./lib/officialPublishers";
+import { isPublisherActive, isPublisherRoleAllowed, requirePublisherRole } from "./lib/publishers";
 
 type PublicGitHubSkillSource = Pick<
   Doc<"githubSkillSources">,
@@ -21,6 +22,7 @@ type PublicGitHubSkillSource = Pick<
   | "createdAt"
   | "updatedAt"
 > & {
+  ownerPublisher: Pick<Doc<"publishers">, "_id" | "handle" | "displayName"> | null;
   skills: Array<
     Pick<Doc<"skills">, "_id" | "slug" | "displayName" | "githubPath" | "githubCurrentStatus">
   >;
@@ -30,6 +32,50 @@ export const getByIdInternal = internalQuery({
   args: { sourceId: v.id("githubSkillSources") },
   handler: async (ctx, args) => ctx.db.get(args.sourceId),
 });
+
+async function toPublicGitHubSkillSource(
+  ctx: Pick<QueryCtx, "db">,
+  source: Doc<"githubSkillSources">,
+): Promise<PublicGitHubSkillSource> {
+  const skills = await ctx.db
+    .query("skills")
+    .withIndex("by_github_source", (q) => q.eq("githubSourceId", source._id))
+    .collect();
+  const visibleGitHubSkills = skills
+    .filter((skill) => skill.installKind === "github" && !skill.softDeletedAt)
+    .sort((a, b) => a.displayName.localeCompare(b.displayName))
+    .map((skill) => ({
+      _id: skill._id,
+      slug: skill.slug,
+      displayName: skill.displayName,
+      githubPath: skill.githubPath,
+      githubCurrentStatus: skill.githubCurrentStatus,
+    }));
+  const ownerPublisher = source.ownerPublisherId ? await ctx.db.get(source.ownerPublisherId) : null;
+
+  return {
+    _id: source._id as Id<"githubSkillSources">,
+    repo: source.repo,
+    ownerPublisher: ownerPublisher
+      ? {
+          _id: ownerPublisher._id,
+          handle: ownerPublisher.handle,
+          displayName: ownerPublisher.displayName,
+        }
+      : null,
+    defaultBranch: source.defaultBranch,
+    lastSyncStatus: source.lastSyncStatus,
+    lastSyncError: source.lastSyncError,
+    lastSyncErrorAt: source.lastSyncErrorAt,
+    displayManifestStatus: source.displayManifestStatus,
+    displayManifestFetchedAt: source.displayManifestFetchedAt,
+    displayManifestCommit: source.displayManifestCommit,
+    lastSyncInvalidSkills: source.lastSyncInvalidSkills,
+    createdAt: source.createdAt,
+    updatedAt: source.updatedAt,
+    skills: visibleGitHubSkills,
+  };
+}
 
 export const listForPublisher = query({
   args: { ownerPublisherId: v.id("publishers") },
@@ -45,40 +91,42 @@ export const listForPublisher = query({
       .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", args.ownerPublisherId))
       .collect();
     const sortedSources = sources.sort((a, b) => b.updatedAt - a.updatedAt);
-    return await Promise.all(
-      sortedSources.map(async (source) => {
-        const skills = await ctx.db
-          .query("skills")
-          .withIndex("by_github_source", (q) => q.eq("githubSourceId", source._id))
-          .collect();
-        const visibleGitHubSkills = skills
-          .filter((skill) => skill.installKind === "github" && !skill.softDeletedAt)
-          .sort((a, b) => a.displayName.localeCompare(b.displayName))
-          .map((skill) => ({
-            _id: skill._id,
-            slug: skill.slug,
-            displayName: skill.displayName,
-            githubPath: skill.githubPath,
-            githubCurrentStatus: skill.githubCurrentStatus,
-          }));
+    return await Promise.all(sortedSources.map((source) => toPublicGitHubSkillSource(ctx, source)));
+  },
+});
 
-        return {
-          _id: source._id as Id<"githubSkillSources">,
-          repo: source.repo,
-          defaultBranch: source.defaultBranch,
-          lastSyncStatus: source.lastSyncStatus,
-          lastSyncError: source.lastSyncError,
-          lastSyncErrorAt: source.lastSyncErrorAt,
-          displayManifestStatus: source.displayManifestStatus,
-          displayManifestFetchedAt: source.displayManifestFetchedAt,
-          displayManifestCommit: source.displayManifestCommit,
-          lastSyncInvalidSkills: source.lastSyncInvalidSkills,
-          createdAt: source.createdAt,
-          updatedAt: source.updatedAt,
-          skills: visibleGitHubSkills,
-        };
-      }),
+export const listForManageableOfficialPublishers = query({
+  args: {},
+  handler: async (ctx): Promise<PublicGitHubSkillSource[]> => {
+    const { userId } = await requireUser(ctx);
+    const memberships = await ctx.db
+      .query("publisherMembers")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .collect();
+    const ownerPublisherIds: Id<"publishers">[] = [];
+    for (const membership of memberships) {
+      if (!isPublisherRoleAllowed(membership.role, ["admin"])) continue;
+      const publisher = await ctx.db.get(membership.publisherId);
+      if (
+        !publisher ||
+        publisher.kind !== "org" ||
+        !isPublisherActive(publisher) ||
+        !(await isOfficialPublisher(ctx, publisher))
+      ) {
+        continue;
+      }
+      ownerPublisherIds.push(publisher._id);
+    }
+    const sourceGroups = await Promise.all(
+      ownerPublisherIds.map((ownerPublisherId) =>
+        ctx.db
+          .query("githubSkillSources")
+          .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", ownerPublisherId))
+          .collect(),
+      ),
     );
+    const sortedSources = sourceGroups.flat().sort((a, b) => b.updatedAt - a.updatedAt);
+    return await Promise.all(sortedSources.map((source) => toPublicGitHubSkillSource(ctx, source)));
   },
 });
 

--- a/src/routes/-settings.test.tsx
+++ b/src/routes/-settings.test.tsx
@@ -267,7 +267,7 @@ describe("Settings", () => {
     expect(screen.getByRole("heading", { name: "Sync GitHub skills repo" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Synced repositories" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "No synced repositories" })).toBeTruthy();
-    expect(screen.getByLabelText("ClawHub Org")).toBeTruthy();
+    expect(screen.getByLabelText("Publisher")).toBeTruthy();
     expect(screen.getByPlaceholderText("https://github.com/owner/repo")).toBeTruthy();
     expect(screen.queryByText(/Publishing as/i)).toBeNull();
     expect(screen.queryByText(/skills\.sh\.json/i)).toBeNull();

--- a/src/routes/-settings.test.tsx
+++ b/src/routes/-settings.test.tsx
@@ -108,6 +108,11 @@ function mockSignedInSettings({
   githubSources?: Array<{
     _id: string;
     repo: string;
+    ownerPublisher?: {
+      _id: string;
+      handle: string;
+      displayName: string;
+    } | null;
     defaultBranch?: string;
     lastSyncStatus?: "ok" | "failed" | "skipped";
     lastSyncError?: string;
@@ -144,7 +149,8 @@ function mockSignedInSettings({
     if (queryName === "tokens:listMine") return [];
     if (queryName === "publishers:listMine") return memberships;
     if (queryName === "publishers:listMembers") return members;
-    if (queryName === "githubSkillSources:listForPublisher") return githubSources;
+    if (queryName === "githubSkillSources:listForManageableOfficialPublishers")
+      return githubSources;
     if (args && typeof args === "object" && "publisherHandle" in args) return members;
     if (args && typeof args === "object") return [];
     return memberships;
@@ -261,6 +267,7 @@ describe("Settings", () => {
     expect(screen.getByRole("heading", { name: "Sync GitHub skills repo" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Synced repositories" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "No synced repositories" })).toBeTruthy();
+    expect(screen.getByLabelText("ClawHub Org")).toBeTruthy();
     expect(screen.getByPlaceholderText("https://github.com/owner/repo")).toBeTruthy();
     expect(screen.queryByText(/Publishing as/i)).toBeNull();
     expect(screen.queryByText(/skills\.sh\.json/i)).toBeNull();
@@ -293,6 +300,11 @@ describe("Settings", () => {
         {
           _id: "githubSkillSources:matt",
           repo: "mattpocock/skills",
+          ownerPublisher: {
+            _id: "publisher_openclaw",
+            handle: "openclaw",
+            displayName: "OpenClaw Team",
+          },
           defaultBranch: "main",
           lastSyncStatus: "ok",
           displayManifestStatus: "ok",

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -110,6 +110,11 @@ type OrgMembersResult = {
 type GitHubSkillSource = {
   _id: Id<"githubSkillSources">;
   repo: string;
+  ownerPublisher?: {
+    _id: Id<"publishers">;
+    handle: string;
+    displayName: string;
+  } | null;
   defaultBranch?: string;
   lastSyncStatus?: "ok" | "failed" | "skipped";
   lastSyncError?: string;
@@ -261,10 +266,8 @@ export function Settings() {
       : "skip",
   ) as OrgMembersResult | null | undefined;
   const githubSources = useQuery(
-    api.githubSkillSources.listForPublisher,
-    effectiveActiveView === "githubSources" && selectedSourcePublisher
-      ? { ownerPublisherId: selectedSourcePublisher.publisher._id }
-      : "skip",
+    api.githubSkillSources.listForManageableOfficialPublishers,
+    effectiveActiveView === "githubSources" && canConfigureGitHubSources ? {} : "skip",
   ) as GitHubSkillSource[] | undefined;
 
   useEffect(() => {
@@ -411,11 +414,12 @@ export function Settings() {
   }
 
   async function onDeleteGitHubSource(source: GitHubSkillSource) {
-    if (!selectedSourcePublisher) return;
+    const ownerPublisherId = source.ownerPublisher?._id ?? selectedSourcePublisher?.publisher._id;
+    if (!ownerPublisherId) return;
     setDeletingSourceId(source._id);
     try {
       const result = await deleteGitHubSource({
-        ownerPublisherId: selectedSourcePublisher.publisher._id,
+        ownerPublisherId,
         sourceId: source._id,
       });
       toast.success(
@@ -1131,7 +1135,6 @@ export function Settings() {
 
                 <GitHubSourceList
                   sources={githubSources}
-                  publisherHandle={selectedSourcePublisher?.publisher.handle}
                   deletingSourceId={deletingSourceId}
                   onDeleteSource={setSourceToDelete}
                 />
@@ -1509,12 +1512,10 @@ function OrgLogoSmall({
 
 function GitHubSourceList({
   sources,
-  publisherHandle,
   deletingSourceId,
   onDeleteSource,
 }: {
   sources: GitHubSkillSource[] | undefined;
-  publisherHandle: string | undefined;
   deletingSourceId: Id<"githubSkillSources"> | null;
   onDeleteSource: (source: GitHubSkillSource) => void;
 }) {
@@ -1553,6 +1554,11 @@ function GitHubSourceList({
                       >
                         {`https://github.com/${source.repo}`}
                       </a>
+                      {source.ownerPublisher ? (
+                        <div className="mt-1 truncate text-xs font-semibold text-[color:var(--ink-soft)]">
+                          @{source.ownerPublisher.handle}
+                        </div>
+                      ) : null}
                     </div>
                   </div>
                 </div>
@@ -1580,8 +1586,11 @@ function GitHubSourceList({
                           <div className="min-w-0">
                             <Link
                               to="/$owner/$slug"
-                              params={{ owner: publisherHandle ?? "", slug: skill.slug }}
-                              disabled={!publisherHandle}
+                              params={{
+                                owner: source.ownerPublisher?.handle ?? "",
+                                slug: skill.slug,
+                              }}
+                              disabled={!source.ownerPublisher}
                               className="block truncate text-sm font-semibold text-[color:var(--ink)] no-underline hover:text-[color:var(--accent)] hover:no-underline"
                             >
                               {skill.displayName}
@@ -1846,25 +1855,24 @@ function GitHubSourceForm({
   isSyncing: boolean;
 }) {
   return (
-    <form className="contents" onSubmit={onConfigure}>
-      {publisherOptions.length > 1 ? (
-        <Field label="Publisher" htmlFor="settings-github-source-publisher">
+    <form className="flex flex-col gap-3 sm:flex-row sm:items-end" onSubmit={onConfigure}>
+      <div className="min-w-0 sm:w-64 sm:shrink-0">
+        <Field label="ClawHub Org" htmlFor="settings-github-source-publisher">
           <Select value={selectedPublisherId} onValueChange={onPublisherChange}>
             <SelectTrigger id="settings-github-source-publisher">
-              <SelectValue />
+              <SelectValue placeholder="Select org" />
             </SelectTrigger>
             <SelectContent>
               {publisherOptions.map((entry) => (
                 <SelectItem key={entry.publisher._id} value={entry.publisher._id}>
-                  @{entry.publisher.handle} · {entry.role}
+                  @{entry.publisher.handle}
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
         </Field>
-      ) : null}
-
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col gap-3 sm:flex-row sm:items-end">
         <div className="min-w-0 flex-1">
           <Field label="GitHub repo URL" htmlFor="settings-github-repo">
             <Input

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -1857,7 +1857,7 @@ function GitHubSourceForm({
   return (
     <form className="flex flex-col gap-3 sm:flex-row sm:items-end" onSubmit={onConfigure}>
       <div className="min-w-0 sm:w-64 sm:shrink-0">
-        <Field label="ClawHub Org" htmlFor="settings-github-source-publisher">
+        <Field label="Publisher" htmlFor="settings-github-source-publisher">
           <Select value={selectedPublisherId} onValueChange={onPublisherChange}>
             <SelectTrigger id="settings-github-source-publisher">
               <SelectValue placeholder="Select org" />


### PR DESCRIPTION
## Summary
- add `clawhub-mod org official list/add/remove` support for managing official org publishers
- add a `ClawHub Org` selector to the GitHub skill sync settings form
- create GitHub sync sources under the selected official org publisher
- list synced repositories across all official orgs the user can administer, while preserving each source's owning org for links and deletion

## Screenshot
Captured locally at `http://localhost:3000/settings?view=githubSources` using the `officialOrgMember` dev persona.

<img src="https://github.com/openclaw/clawhub/releases/download/gh-attach-assets/clawhub-github-sync-org-select.png" width="900" alt="GitHub sync settings with ClawHub Org selector">

## Tests
- `bunx convex codegen`
- `bunx vitest run src/routes/-settings.test.tsx --reporter=dot`
- `bunx vitest run convex/httpApiV1.handlers.test.ts packages/clawhub-mod/src/commands/orgs.test.ts --reporter=dot`
- `bun run format:check -- src/routes/settings.tsx src/routes/-settings.test.tsx convex/githubSkillSources.ts`
- `bunx tsc --noEmit --pretty false`
- `bun run lint -- src/routes/settings.tsx src/routes/-settings.test.tsx convex/githubSkillSources.ts`
