### PR TITLE
fix: skip publisher handle conflicts in ownership repair

### DIFF
--- a/convex/maintenance.test.ts
+++ b/convex/maintenance.test.ts
@@ -470,6 +470,46 @@ describe("maintenance legacy publisher ownership repair", () => {
     expect(insertCalls).toEqual([]);
   });
 
+  it("skips apply-mode personal publisher handle conflicts while repairing other users", async () => {
+    const { db, tableMap } = makeLegacyPublisherOwnershipDb();
+    tableMap.users.set("users:conflict", {
+      _id: "users:conflict",
+      _creationTime: 1_717_456_000_000 - 1000,
+      handle: "existing-owner",
+      name: "Conflicting Owner",
+      displayName: "Conflicting Owner",
+      deletedAt: undefined,
+      deactivatedAt: undefined,
+      purgedAt: undefined,
+    });
+
+    const result = await repairLegacyPublisherOwnershipHandler(
+      { db, scheduler: { runAfter: vi.fn() } } as never,
+      { phase: "users", dryRun: false, batchSize: 10, scheduleNext: false },
+    );
+
+    const createdPublisher = Array.from(tableMap.publishers.values()).find(
+      (publisher) => publisher.handle === "legacy-owner",
+    );
+    expect(result).toMatchObject({
+      phase: "users",
+      dryRun: false,
+      scanned: 2,
+      repaired: 1,
+      skipped: 1,
+      isDone: true,
+      errors: ['user:users:conflict: Publisher handle "@existing-owner" is already claimed'],
+    });
+    expect(createdPublisher).toMatchObject({
+      kind: "user",
+      linkedUserId: "users:legacy",
+    });
+    expect(tableMap.users.get("users:legacy")).toMatchObject({
+      personalPublisherId: createdPublisher?._id,
+    });
+    expect(tableMap.users.get("users:conflict")).not.toHaveProperty("personalPublisherId");
+  });
+
   it("repairs active legacy users, skills, aliases, embeddings, and packages", async () => {
     const { db, tableMap, patchCalls, insertCalls } = makeLegacyPublisherOwnershipDb();
     const scheduler = { runAfter: vi.fn() };

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -2339,6 +2339,11 @@ function pushRepairError(errors: string[], label: string, error: unknown) {
   errors.push(`${label}: ${message}`);
 }
 
+function isPublisherHandleConflictError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  return /Publisher handle "@[^"]+" is already claimed/.test(message);
+}
+
 async function resolvePersonalPublisherForOwnershipRepair(
   ctx: Pick<MutationCtx, "db">,
   user: Doc<"users">,
@@ -2465,7 +2470,7 @@ export async function repairLegacyPublisherOwnershipHandler(
         }
         repaired++;
       } catch (error) {
-        if (!dryRun) throw error;
+        if (!dryRun && !isPublisherHandleConflictError(error)) throw error;
         skipped++;
         pushRepairError(errors, `user:${user._id}`, error);
       }
@@ -2485,7 +2490,7 @@ export async function repairLegacyPublisherOwnershipHandler(
         if (result === "repaired") repaired++;
         else skipped++;
       } catch (error) {
-        if (!dryRun) throw error;
+        if (!dryRun && !isPublisherHandleConflictError(error)) throw error;
         skipped++;
         pushRepairError(errors, `skill:${skill._id}`, error);
       }
@@ -2505,7 +2510,7 @@ export async function repairLegacyPublisherOwnershipHandler(
         if (result === "repaired") repaired++;
         else skipped++;
       } catch (error) {
-        if (!dryRun) throw error;
+        if (!dryRun && !isPublisherHandleConflictError(error)) throw error;
         skipped++;
         pushRepairError(errors, `package:${pkg._id}`, error);
       }


### PR DESCRIPTION
## Summary
- Skip and report publisher-handle conflicts during apply-mode legacy ownership repair instead of aborting the whole batch.
- Keep unexpected apply-mode errors fatal.
- Add a regression test for repairing normal users while skipping a conflicting user.

## Validation
- bun run test convex/maintenance.test.ts convex/lib/publisherStats.test.ts
- bun run format:check -- convex/maintenance.ts convex/maintenance.test.ts
- bun run ci:static

## Production context
- Initial production dry-run found user kn78cbe57158vpzxc0wwd5p5w57zyct8 derives publisher handle f, but org publisher f already exists. This follow-up lets the backfill continue while reporting that conflict.