### PR TITLE
chore: release clawhub cli 0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.19.1 - 2026-06-05
+
+### Fixes
+
+- CLI: install source-backed GitHub skills from the deployed `/api/v1/skills/:slug/install` resolver so `clawhub install` works for skills without hosted ClawHub versions.
+
 ## 0.19.0 - 2026-06-03
 
 ### Changes

--- a/bun.lock
+++ b/bun.lock
@@ -81,7 +81,7 @@
     },
     "packages/clawhub": {
       "name": "clawhub",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "bin": {
         "clawdhub": "bin/clawdhub.js",
         "clawhub": "bin/clawdhub.js",

--- a/packages/clawhub/package.json
+++ b/packages/clawhub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawhub",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "ClawHub CLI \\u2014 install, update, search, and publish skills plus OpenClaw packages.",
   "homepage": "https://clawhub.ai",
   "bugs": {


### PR DESCRIPTION
## Summary

- bump `clawhub` CLI package to `0.19.1`
- add changelog notes for GitHub-backed skill installs through the deployed `/api/v1/skills/:slug/install` resolver
- update `bun.lock` workspace package version

## Why

`clawhub@0.19.0` is already published, but the published CLI still fails for GitHub-backed skills with no hosted ClawHub version:

```text
Error: Could not resolve latest version
```

The deployed ClawHub API resolver is live and returns the expected `installKind: "github"` descriptor, so we need a new npm version to ship the CLI support currently on `main`.

## Validation

- `bun run release:clawhub:cli:npm:check -- --tag v0.19.1`
- `bun run --cwd packages/clawhub verify`
- `npm view clawhub@0.19.1 version --json` returns 404, confirming the version is unpublished
