### PR TITLE
fix: soft delete removed github skills

### DIFF
--- a/convex/githubSkillSync.test.ts
+++ b/convex/githubSkillSync.test.ts
@@ -922,6 +922,7 @@ description: Install from a GitHub-backed source.
         githubCurrentCommit: "c".repeat(40),
         githubCurrentStatus: "missing",
         githubRemovedAt: 300,
+        softDeletedAt: 300,
         moderationStatus: "hidden",
         moderationReason: "github.upstream.removed",
       });

--- a/convex/lib/githubSkillSync.test.ts
+++ b/convex/lib/githubSkillSync.test.ts
@@ -514,6 +514,7 @@ describe("buildGitHubSkillSyncPlan", () => {
           githubCurrentCommit: "2".repeat(40),
           githubCurrentStatus: "missing",
           githubRemovedAt: 123,
+          softDeletedAt: 123,
           moderationStatus: "hidden",
           moderationReason: "github.upstream.removed",
         }),

--- a/convex/lib/githubSkillSync.ts
+++ b/convex/lib/githubSkillSync.ts
@@ -411,6 +411,7 @@ export function buildGitHubSkillSyncPlan({
         githubCurrentStatus: "missing",
         githubCurrentCheckedAt: now,
         githubRemovedAt: removedAt,
+        softDeletedAt: existing.softDeletedAt ?? removedAt,
         ...(wasAlreadyRemoved ? {} : { updatedAt: now }),
         ...moderation,
       },


### PR DESCRIPTION
## Summary

- Soft-delete GitHub-backed skills when they disappear upstream instead of only hiding them via moderation state.
- Preserve the existing removal timestamp when a previously removed skill is seen again as missing.
- Add regression coverage in both the sync-plan unit test and the GitHub-backed lifecycle test.

## Verification

- `bun test convex/lib/githubSkillSync.test.ts --runInBand`
- `bun test convex/githubSkillSync.test.ts --runInBand`
- `bun run ci:static`
- `bun run ci:unit`

## Production note

This fixes the observed state where an upstream-removed GitHub skill had `githubCurrentStatus: "missing"` and `moderationReason: "github.upstream.removed"`, but `softDeletedAt` was still unset, so owner-scoped UI routes could continue rendering it as a hidden/moderated skill.
