### PR TITLE
fix: clean up publisher catalog rows

### DIFF
--- a/convex/githubSkillSync.test.ts
+++ b/convex/githubSkillSync.test.ts
@@ -1123,6 +1123,61 @@ describe("applyGitHubSkillSourceSyncHandler", () => {
     expect(tables.skills).toHaveLength(2);
   });
 
+  it("preserves an existing soft delete timestamp when upstream remains missing", async () => {
+    const snapshot = await buildGitHubSkillSourceSnapshot({
+      repo: "NVIDIA/skills",
+      defaultBranch: "main",
+      commit: "2".repeat(40),
+      entries: {},
+    });
+    const { db, tables } = createDb({
+      githubSkillSources: [
+        {
+          _id: "githubSkillSources:nvidia",
+          repo: "NVIDIA/skills",
+          ownerPublisherId: "publishers:nvidia",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      skills: [
+        {
+          _id: "skills:aiq-deploy",
+          slug: "aiq-deploy",
+          displayName: "AIQ Deploy",
+          ownerUserId: "users:nvidia",
+          ownerPublisherId: "publishers:nvidia",
+          installKind: "github",
+          githubSourceId: "githubSkillSources:nvidia",
+          githubPath: "skills/aiq-deploy",
+          githubCurrentStatus: "missing",
+          githubRemovedAt: 60,
+          softDeletedAt: 40,
+          githubScanStatus: "clean",
+          tags: {},
+          stats: { downloads: 0, stars: 0, installsCurrent: 0, installsAllTime: 0, versions: 0 },
+          createdAt: 1,
+          updatedAt: 60,
+        },
+      ],
+    });
+
+    await applyGitHubSkillSourceSyncHandler({ db } as never, {
+      sourceId: "githubSkillSources:nvidia" as never,
+      repo: "NVIDIA/skills",
+      ownerUserId: "users:nvidia" as never,
+      ownerPublisherId: "publishers:nvidia" as never,
+      snapshot,
+      now: 123,
+    });
+
+    expect(tables.skills[0]).toMatchObject({
+      githubCurrentStatus: "missing",
+      githubRemovedAt: 60,
+      softDeletedAt: 40,
+    });
+  });
+
   it("stores GitHub content for newly inserted source-backed skills without creating versions", async () => {
     const snapshot = await buildGitHubSkillSourceSnapshot({
       repo: "NVIDIA/skills",

--- a/convex/githubSkillSync.ts
+++ b/convex/githubSkillSync.ts
@@ -438,6 +438,7 @@ export async function applyGitHubSkillSourceSyncHandler(
       githubCurrentStatus: skill.githubCurrentStatus,
       githubScanStatus: skill.githubScanStatus,
       githubRemovedAt: skill.githubRemovedAt,
+      softDeletedAt: skill.softDeletedAt,
     })),
     snapshot: {
       ...args.snapshot,

--- a/convex/lib/githubSkillSync.ts
+++ b/convex/lib/githubSkillSync.ts
@@ -60,6 +60,7 @@ export type ExistingGitHubSkillForSync = {
   githubCurrentStatus?: GitHubCurrentStatus;
   githubScanStatus?: GitHubSkillScanStatus;
   githubRemovedAt?: number;
+  softDeletedAt?: number;
 };
 
 export type GitHubBackedSkillModeration = {

--- a/src/components/PublishedItemCard.test.tsx
+++ b/src/components/PublishedItemCard.test.tsx
@@ -114,6 +114,22 @@ describe("PublishedItemCard", () => {
       expect(screen.getByLabelText("Official")).toBeTruthy();
       expect(screen.queryByText("Official")).toBeNull();
     });
+
+    it("does not render artifact-kind prefixes as owner handles", () => {
+      render(<PublishedItemCard item={{ ...baseSkill, icon: null }} view="list" />);
+
+      expect(screen.queryByText("@skill")).toBeNull();
+      expect(screen.queryByText("/")).toBeNull();
+      expect(screen.getByText("Test Skill")).toBeTruthy();
+    });
+
+    it("does not render plugin artifact-kind prefixes as owner handles", () => {
+      render(<PublishedItemCard item={{ ...basePlugin, icon: null }} view="list" />);
+
+      expect(screen.queryByText("@plugin")).toBeNull();
+      expect(screen.queryByText("/")).toBeNull();
+      expect(screen.getByText("Test Plugin")).toBeTruthy();
+    });
   });
 });
 

--- a/src/routes/user/$handle.tsx
+++ b/src/routes/user/$handle.tsx
@@ -15,7 +15,7 @@ import { EmptyState } from "../../components/EmptyState";
 import { Container } from "../../components/layout/Container";
 import { MarketplaceIcon } from "../../components/MarketplaceIcon";
 import { OfficialBadge, OfficialTag } from "../../components/OfficialBadge";
-import { SkillCardSkeletonGrid } from "../../components/skeletons/SkillCardSkeleton";
+import { BrowseResultsSkeleton } from "../../components/skeletons/BrowseResultsSkeleton";
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
 import { Card, CardContent } from "../../components/ui/card";
@@ -142,7 +142,7 @@ function PublisherProfile() {
                 </div>
               </CardContent>
             </Card>
-            <SkillCardSkeletonGrid count={6} />
+            <BrowseResultsSkeleton count={6} variant="list" />
           </div>
         </Container>
       </main>
@@ -380,7 +380,7 @@ function PublisherProfile() {
               </div>
 
               {isLoadingCatalog ? (
-                <SkillCardSkeletonGrid count={6} />
+                <BrowseResultsSkeleton count={6} variant="list" />
               ) : activePublishedDisplay ? (
                 <PublishedCatalogSections display={activePublishedDisplay} view="list" />
               ) : activeItems.length > 0 ? (
@@ -547,8 +547,6 @@ export function PublishedItemCard({
       />
       <div className="skill-list-item-body">
         <span className="skill-list-item-main">
-          <span className="skill-list-item-owner">@{item.kind}</span>
-          <span className="skill-list-item-sep">/</span>
           <span className="skill-list-item-name">{item.displayName}</span>
           {item.isOfficial ? <OfficialBadge /> : null}
         </span>


### PR DESCRIPTION
## Summary
- remove the placeholder artifact-kind owner prefix from publisher catalog list rows so skills/plugins show their name directly
- switch publisher profile loading states to the shared row-style results skeleton
- carry the current main soft-delete sync fix through the PR merge ref by typing and forwarding `softDeletedAt`, with a regression test

## Validation
- `bun run format:check -- convex/githubSkillSync.ts convex/githubSkillSync.test.ts convex/lib/githubSkillSync.ts src/components/PublishedItemCard.test.tsx 'src/routes/user/$handle.tsx'`
- `bunx vitest run convex/githubSkillSync.test.ts convex/lib/githubSkillSync.test.ts src/components/PublishedItemCard.test.tsx`
- `bun run ci:types-build`
- `bun run ci:static`
- `bun run ci:unit`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode branch`

## Visual Proof
- Publisher catalog row: local browser verified 137 `.publisher-published-row` entries with no `@skill`, `@plugin`, or `.skill-list-item-owner` text in the row.
- Loading state: local browser verified row skeletons only (`statusLists: 1`, `rowSkeletons: 6`, `cardSkeletons: 0`).
