### PR TITLE
fix: keep pending github skills visible

### DIFF
--- a/convex/githubSkillSync.test.ts
+++ b/convex/githubSkillSync.test.ts
@@ -811,7 +811,7 @@ description: Install from a GitHub-backed source.
         githubCurrentCommit: "a".repeat(40),
         githubCurrentStatus: "present",
         githubScanStatus: "pending",
-        moderationStatus: "hidden",
+        moderationStatus: "active",
       });
       expect(resolveInstallFromTables(tables, "demo-source")).toMatchObject({
         ok: false,
@@ -872,7 +872,7 @@ description: Install from a GitHub-backed source.
         githubCurrentCommit: "b".repeat(40),
         githubCurrentStatus: "present",
         githubScanStatus: "pending",
-        moderationStatus: "hidden",
+        moderationStatus: "active",
       });
       expect(skill.githubCurrentContentHash).not.toBe(commitAContentHash);
       expect(tables.githubSkillContents[0]).toMatchObject({
@@ -1094,7 +1094,7 @@ describe("applyGitHubSkillSourceSyncHandler", () => {
     expect(tables.skills.find((skill) => skill._id === "skills:aiq-deploy")).toMatchObject({
       githubCurrentCommit: "2".repeat(40),
       githubScanStatus: "pending",
-      moderationStatus: "hidden",
+      moderationStatus: "active",
     });
     expect(tables.githubSkillContents).toEqual([
       expect.objectContaining({
@@ -1112,8 +1112,8 @@ describe("applyGitHubSkillSourceSyncHandler", () => {
       }),
     ]);
     expect(tables.globalStats[0]).toMatchObject({
-      activeSkillsCount: 9,
-      updatedAt: 123,
+      activeSkillsCount: 10,
+      updatedAt: 1,
     });
     const conflict = tables.skills.find((skill) => skill._id === "skills:vision-helper-conflict");
     expect(conflict).toMatchObject({
@@ -1259,7 +1259,7 @@ describe("applyGitHubSkillSourceSyncHandler", () => {
       githubCurrentStatus: "present",
       githubCurrentContentHash: snapshot.skills[0]?.contentHash,
       githubScanStatus: "pending",
-      moderationStatus: "hidden",
+      moderationStatus: "active",
       moderationReason: "pending.scan",
       statsDownloads: 7,
       statsStars: 3,

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -2033,14 +2033,13 @@ describe("httpApiV1 handlers", () => {
     });
   });
 
-  it("skill install resolver returns structured GitHub blocks for hidden stale source-backed skills", async () => {
+  it("skill install resolver returns structured GitHub blocks for pending source-backed skills", async () => {
     const runQuery = makeInstallResolverRunQuery({
-      publicVisible: false,
       skill: {
         _id: "skills:aiq-deploy",
         slug: "aiq-deploy",
         displayName: "AIQ Deploy",
-        moderationStatus: "hidden",
+        moderationStatus: "active",
         moderationReason: "pending.scan",
         installKind: "github",
         githubSourceId: "githubSkillSources:nvidia",

--- a/convex/lib/githubSkillSync.test.ts
+++ b/convex/lib/githubSkillSync.test.ts
@@ -237,7 +237,7 @@ describe("buildGitHubSkillSyncPlan", () => {
           githubCurrentCommit: "2".repeat(40),
           githubCurrentContentHash: snapshot.skills[0]?.contentHash,
           githubScanStatus: "pending",
-          moderationStatus: "hidden",
+          moderationStatus: "active",
           moderationReason: "pending.scan",
         }),
       }),
@@ -361,7 +361,7 @@ describe("buildGitHubSkillSyncPlan", () => {
       githubCurrentCommit: "3".repeat(40),
       githubCurrentContentHash: contentHash,
       githubScanStatus: "pending",
-      moderationStatus: "hidden",
+      moderationStatus: "active",
       moderationReason: "pending.scan",
     });
     expect(plan.stats.unchanged).toBe(1);

--- a/convex/lib/githubSkillSync.ts
+++ b/convex/lib/githubSkillSync.ts
@@ -451,7 +451,7 @@ export function githubBackedSkillModeration(
   }
   if (scanStatus === "pending") {
     return {
-      moderationStatus: "hidden",
+      moderationStatus: "active",
       moderationReason: "pending.scan",
       moderationVerdict: undefined,
       moderationFlags: [],

--- a/convex/lib/public.ts
+++ b/convex/lib/public.ts
@@ -161,6 +161,8 @@ export function toPublicSkill(skill: HydratableSkill | null | undefined): Public
     installKind: skill.installKind,
     githubPath: skill.githubPath,
     githubCurrentCommit: skill.githubCurrentCommit,
+    githubCurrentStatus: skill.githubCurrentStatus,
+    githubScanStatus: skill.githubScanStatus,
     githubHasSkillCard: skill.githubHasSkillCard,
     tags: skill.tags,
     capabilityTags: skill.capabilityTags,

--- a/specs/github-backed-skills.md
+++ b/specs/github-backed-skills.md
@@ -175,7 +175,8 @@ For clean GitHub-backed skills, ClawHub returns:
 OpenClaw downloads the GitHub archive for that commit and extracts only the skill
 path. The local lock/origin version is the commit SHA.
 
-For pending verification, ClawHub returns a structured block:
+Pending verification keeps the skill visible in ClawHub search and detail UI,
+but normal install/update returns a structured block:
 
 ```json
 {

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -172,6 +172,7 @@ describe("SkillDetailPage", () => {
   it("does not spin forever when a source-backed skill has no stored version", async () => {
     useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
       if (args === "skip") return undefined;
+      if (args && typeof args === "object" && "kind" in args) return null;
       return undefined;
     });
 
@@ -188,6 +189,8 @@ describe("SkillDetailPage", () => {
               summary: "Deploy AgentIQ workflows.",
               ownerUserId: ownerId,
               ownerPublisherId,
+              installKind: "github",
+              githubScanStatus: "pending",
               tags: {},
               badges: {},
               stats: {
@@ -219,7 +222,8 @@ describe("SkillDetailPage", () => {
       />,
     );
 
-    expect(await screen.findByText("No README available")).toBeTruthy();
+    expect(await screen.findByText("Pending")).toBeTruthy();
+    expect(screen.getByText("Security audit")).toBeTruthy();
     expect(screen.queryByText("Loading README...")).toBeNull();
   });
 

--- a/src/components/DetailSecuritySummary.test.tsx
+++ b/src/components/DetailSecuritySummary.test.tsx
@@ -36,6 +36,18 @@ describe("DetailSecuritySummary", () => {
     expect(document.querySelectorAll(".security-audit-meter span")).toHaveLength(4);
   });
 
+  it("renders GitHub-backed scan status when no version-backed scan exists", () => {
+    render(
+      <DetailSecuritySummary
+        auditHref="/nvidia/aiq-deploy/security-audit"
+        githubScanStatus="pending"
+      />,
+    );
+
+    expect(screen.getByText("Pending")).toBeTruthy();
+    expect(document.querySelector(".security-audit-meter")?.getAttribute("data-level")).toBe("0");
+  });
+
   it("shows staff-cleared public scan summaries as cleared", () => {
     render(
       <DetailSecuritySummary

--- a/src/components/DetailSecuritySummary.tsx
+++ b/src/components/DetailSecuritySummary.tsx
@@ -7,6 +7,7 @@ type DetailSecuritySummaryProps = {
   auditHref: string;
   vtAnalysis?: VtAnalysis | null;
   llmAnalysis?: LlmAnalysis | null;
+  githubScanStatus?: string | null;
   suppressScanResults?: boolean;
 };
 
@@ -33,13 +34,17 @@ export function DetailSecuritySummary({
   auditHref,
   vtAnalysis,
   llmAnalysis,
+  githubScanStatus,
   suppressScanResults = false,
 }: DetailSecuritySummaryProps) {
-  const auditVerdict = aggregateAuditVerdict({
-    vtAnalysis,
-    llmAnalysis,
-    suppressScanResults,
-  });
+  const hasVersionScanResult = Boolean(vtAnalysis || llmAnalysis);
+  const auditVerdict = hasVersionScanResult
+    ? aggregateAuditVerdict({
+        vtAnalysis,
+        llmAnalysis,
+        suppressScanResults,
+      })
+    : (githubScanStatus ?? "pending");
   const auditVerdictInfo = getScanStatusInfo(auditVerdict);
   const meterLevel = auditVerdictMeterLevel(auditVerdict);
   return (

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -54,6 +54,7 @@ type SkillDetailVersion = NonNullable<NonNullable<SkillBySlugResult>["latestVers
 type GitHubBackedSkillFields = {
   installKind?: "github";
   githubHasSkillCard?: boolean;
+  githubScanStatus?: string | null;
 };
 
 const SHOW_SKILL_COMMENTS = false;
@@ -702,16 +703,22 @@ export function SkillDetailPage({
     return <GenericNotFoundPage />;
   }
 
-  const securitySummary = latestVersion ? (
-    <DetailSecuritySummary
-      auditHref={`/${encodeURIComponent(ownerParam ?? ownerHandle ?? "unknown")}/${encodeURIComponent(
-        skill.slug,
-      )}/security-audit`}
-      vtAnalysis={latestVersion.vtAnalysis ?? null}
-      llmAnalysis={latestVersion.llmAnalysis ?? null}
-      suppressScanResults={suppressVersionScanResults}
-    />
-  ) : null;
+  const githubScanStatus =
+    !latestVersion && (displayedSkill as GitHubBackedSkillFields).installKind === "github"
+      ? (displayedSkill as GitHubBackedSkillFields).githubScanStatus
+      : null;
+  const securitySummary =
+    latestVersion || githubScanStatus ? (
+      <DetailSecuritySummary
+        auditHref={`/${encodeURIComponent(ownerParam ?? ownerHandle ?? "unknown")}/${encodeURIComponent(
+          skill.slug,
+        )}/security-audit`}
+        vtAnalysis={latestVersion?.vtAnalysis ?? null}
+        llmAnalysis={latestVersion?.llmAnalysis ?? null}
+        githubScanStatus={githubScanStatus}
+        suppressScanResults={suppressVersionScanResults}
+      />
+    ) : null;
   const staffVisibilityAlert = staffModerationNote ? (
     <Alert variant="warn" className="skill-visibility-alert" role="status">
       <TriangleAlert size={18} aria-hidden="true" />

--- a/src/lib/publicUser.ts
+++ b/src/lib/publicUser.ts
@@ -85,6 +85,8 @@ export type PublicSkill = Pick<
   | "installKind"
   | "githubPath"
   | "githubCurrentCommit"
+  | "githubCurrentStatus"
+  | "githubScanStatus"
   | "githubHasSkillCard"
   | "tags"
   | "capabilityTags"


### PR DESCRIPTION
## Summary
- Keep GitHub-backed skills public/active while their ClawHub scan is pending so they appear in search/detail UI.
- Show pending GitHub scan status in the skill detail security sidebar even when no hosted version exists.
- Preserve install/update blocking for normal pending scans with `github_verification_pending`.

## Tests
- `bun test convex/githubSkillSync.test.ts convex/githubSkillSync.live.test.ts convex/lib/githubSkillSync.test.ts convex/lib/installResolver.test.ts --runInBand`
- `bunx vitest run convex/httpApiV1.handlers.test.ts src/components/DetailSecuritySummary.test.tsx src/__tests__/skill-detail-page.test.tsx`
- `(cd packages/clawhub && bunx vitest run -c vitest.config.ts src/cli/commands/skills.test.ts)`
- `bun run ci:static`
- `bun run ci:unit`
