### PR TITLE
fix: add targeted legacy publisher ownership repair

### DIFF
--- a/convex/maintenance.test.ts
+++ b/convex/maintenance.test.ts
@@ -55,6 +55,7 @@ const {
   backfillUserStatsInternalHandler,
   cleanupEmptySkillsInternalHandler,
   nominateEmptySkillSpammersInternalHandler,
+  repairLegacyPublisherOwnershipForUserHandler,
   repairLegacyPublisherOwnershipHandler,
   upsertSkillBadgeRecordInternal,
 } = await import("./maintenance");
@@ -595,6 +596,78 @@ describe("maintenance legacy publisher ownership repair", () => {
           ("publishedSkills" in call.patch || "publishedPackages" in call.patch),
       ),
     ).toBe(false);
+  });
+
+  it("repairs legacy owner projections for one targeted user by handle", async () => {
+    const { db, tableMap } = makeLegacyPublisherOwnershipDb();
+    const scheduler = { runAfter: vi.fn() };
+
+    await repairLegacyPublisherOwnershipHandler({ db, scheduler } as never, {
+      phase: "users",
+      dryRun: false,
+      batchSize: 10,
+      scheduleNext: false,
+    });
+    const createdPublisher = Array.from(tableMap.publishers.values()).find(
+      (publisher) => publisher.handle === "legacy-owner",
+    );
+
+    const skillsResult = await repairLegacyPublisherOwnershipForUserHandler(
+      { db, scheduler } as never,
+      {
+        handle: "legacy-owner",
+        phase: "skills",
+        dryRun: false,
+        batchSize: 10,
+        scheduleNext: false,
+      },
+    );
+    expect(skillsResult).toMatchObject({
+      phase: "skills",
+      dryRun: false,
+      userId: "users:legacy",
+      publisherId: createdPublisher?._id,
+      scanned: 1,
+      repaired: 1,
+      skipped: 0,
+      isDone: true,
+    });
+    expect(tableMap.skills.get("skills:legacy")).toMatchObject({
+      ownerPublisherId: createdPublisher?._id,
+    });
+    expect(tableMap.skills.get("skills:deleted-owner")).toMatchObject({
+      ownerPublisherId: undefined,
+    });
+    expect(tableMap.skillSlugAliases.get("skillSlugAliases:legacy")).toMatchObject({
+      ownerPublisherId: createdPublisher?._id,
+    });
+    expect(tableMap.skillEmbeddings.get("skillEmbeddings:legacy")).toMatchObject({
+      ownerPublisherId: createdPublisher?._id,
+    });
+
+    const packagesResult = await repairLegacyPublisherOwnershipForUserHandler(
+      { db, scheduler } as never,
+      {
+        handle: "legacy-owner",
+        phase: "packages",
+        dryRun: false,
+        batchSize: 10,
+        scheduleNext: false,
+      },
+    );
+    expect(packagesResult).toMatchObject({
+      phase: "packages",
+      dryRun: false,
+      userId: "users:legacy",
+      publisherId: createdPublisher?._id,
+      scanned: 1,
+      repaired: 1,
+      skipped: 0,
+      isDone: true,
+    });
+    expect(tableMap.packages.get("packages:legacy")).toMatchObject({
+      ownerPublisherId: createdPublisher?._id,
+    });
   });
 
   it("aborts apply-mode skill repair when owner projection sync fails", async () => {

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -11,6 +11,7 @@ import {
   getPersonalPublisherForUser,
   getPublisherByHandle,
   getPublisherMembership,
+  getUserByHandleOrPersonalPublisher,
   isPublisherActive,
 } from "./lib/publishers";
 import { recomputePublisherStats } from "./lib/publisherStats";
@@ -102,6 +103,7 @@ type UserOwnedSkillsBackfillPageResult = {
 };
 
 type LegacyPublisherOwnershipPhase = "users" | "skills" | "packages";
+type LegacyPublisherOwnershipTargetPhase = Exclude<LegacyPublisherOwnershipPhase, "users">;
 
 type LegacyPublisherOwnershipRepairResult = {
   phase: LegacyPublisherOwnershipPhase;
@@ -113,6 +115,17 @@ type LegacyPublisherOwnershipRepairResult = {
   cursor: string | null;
   isDone: boolean;
   nextPhase?: LegacyPublisherOwnershipPhase;
+};
+
+type LegacyPublisherOwnershipForUserRepairResult = Omit<
+  LegacyPublisherOwnershipRepairResult,
+  "phase" | "nextPhase"
+> & {
+  phase: LegacyPublisherOwnershipTargetPhase;
+  userId: Id<"users">;
+  handle?: string;
+  publisherId: Id<"publishers"> | null;
+  nextPhase?: LegacyPublisherOwnershipTargetPhase;
 };
 
 export const getSkillBackfillPageInternal = internalQuery({
@@ -2312,6 +2325,12 @@ function nextLegacyPublisherOwnershipPhase(
   return undefined;
 }
 
+function nextLegacyPublisherOwnershipTargetPhase(
+  phase: LegacyPublisherOwnershipTargetPhase,
+): LegacyPublisherOwnershipTargetPhase | undefined {
+  return phase === "skills" ? "packages" : undefined;
+}
+
 async function getExistingActivePersonalPublisher(
   ctx: Pick<MutationCtx, "db">,
   user: Doc<"users">,
@@ -2418,6 +2437,52 @@ async function repairLegacyPackageOwnerPublisher(
   // The trigger-wrapped mutation syncs package search digests and publisher stats.
   await ctx.db.patch(pkg._id, { ownerPublisherId: publisher!._id });
   return "repaired" as const;
+}
+
+async function resolveLegacyPublisherOwnershipTargetUser(
+  ctx: Pick<MutationCtx, "db">,
+  args: { userId?: Id<"users">; handle?: string },
+) {
+  const user = args.userId
+    ? await ctx.db.get(args.userId)
+    : await getUserByHandleOrPersonalPublisher(ctx, args.handle);
+  if (!user) throw new ConvexError("Target user not found");
+  if (!isActiveLegacyPublisherRepairUser(user)) throw new ConvexError("Target user is inactive");
+  return user;
+}
+
+async function patchLegacySkillOwnerPublisher(
+  ctx: Pick<MutationCtx, "db">,
+  skill: Doc<"skills">,
+  publisherId: Id<"publishers">,
+) {
+  await ctx.db.patch(skill._id, { ownerPublisherId: publisherId });
+
+  const aliases = await ctx.db
+    .query("skillSlugAliases")
+    .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
+    .collect();
+  for (const alias of aliases) {
+    if (alias.ownerPublisherId === publisherId) continue;
+    await ctx.db.patch(alias._id, { ownerPublisherId: publisherId });
+  }
+
+  const embeddings = await ctx.db
+    .query("skillEmbeddings")
+    .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
+    .collect();
+  for (const embedding of embeddings) {
+    if (embedding.ownerPublisherId === publisherId) continue;
+    await ctx.db.patch(embedding._id, { ownerPublisherId: publisherId });
+  }
+}
+
+async function patchLegacyPackageOwnerPublisher(
+  ctx: Pick<MutationCtx, "db">,
+  pkg: Doc<"packages">,
+  publisherId: Id<"publishers">,
+) {
+  await ctx.db.patch(pkg._id, { ownerPublisherId: publisherId });
 }
 
 export async function repairLegacyPublisherOwnershipHandler(
@@ -2541,6 +2606,94 @@ export async function repairLegacyPublisherOwnershipHandler(
   };
 }
 
+export async function repairLegacyPublisherOwnershipForUserHandler(
+  ctx: MutationCtx,
+  args: {
+    userId?: Id<"users">;
+    handle?: string;
+    phase?: LegacyPublisherOwnershipTargetPhase;
+    cursor?: string;
+    batchSize?: number;
+    delayMs?: number;
+    dryRun?: boolean;
+    scheduleNext?: boolean;
+  },
+): Promise<LegacyPublisherOwnershipForUserRepairResult> {
+  const phase = args.phase ?? "skills";
+  const dryRun = args.dryRun === true;
+  const batchSize = clampInt(args.batchSize ?? 50, 1, 200);
+  const delayMs = clampInt(args.delayMs ?? 500, 0, 60_000);
+  const user = await resolveLegacyPublisherOwnershipTargetUser(ctx, args);
+  const publisher = await resolvePersonalPublisherForOwnershipRepair(ctx, user, dryRun);
+  if (!dryRun && !isPublisherActive(publisher)) {
+    throw new ConvexError("Target personal publisher could not be repaired");
+  }
+
+  let scanned = 0;
+  let repaired = 0;
+  let skipped = 0;
+
+  const page =
+    phase === "skills"
+      ? await ctx.db
+          .query("skills")
+          .withIndex("by_owner", (q) => q.eq("ownerUserId", user._id))
+          .paginate({ cursor: args.cursor ?? null, numItems: batchSize })
+      : await ctx.db
+          .query("packages")
+          .withIndex("by_owner", (q) => q.eq("ownerUserId", user._id))
+          .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
+
+  for (const item of page.page) {
+    scanned++;
+    if (item.ownerPublisherId) {
+      skipped++;
+      continue;
+    }
+    if (dryRun) {
+      repaired++;
+      continue;
+    }
+    if (phase === "skills") {
+      await patchLegacySkillOwnerPublisher(ctx, item as Doc<"skills">, publisher!._id);
+    } else {
+      await patchLegacyPackageOwnerPublisher(ctx, item as Doc<"packages">, publisher!._id);
+    }
+    repaired++;
+  }
+
+  const nextPhase = page.isDone ? nextLegacyPublisherOwnershipTargetPhase(phase) : phase;
+  if (!dryRun && args.scheduleNext !== false && nextPhase) {
+    await ctx.scheduler.runAfter(
+      delayMs,
+      internal.maintenance.repairLegacyPublisherOwnershipForUser,
+      {
+        userId: user._id,
+        phase: nextPhase,
+        cursor: page.isDone ? undefined : (page.continueCursor ?? undefined),
+        batchSize: args.batchSize,
+        delayMs: args.delayMs,
+        scheduleNext: args.scheduleNext,
+      },
+    );
+  }
+
+  return {
+    phase,
+    dryRun,
+    userId: user._id,
+    handle: user.handle,
+    publisherId: publisher?._id ?? null,
+    scanned,
+    repaired,
+    skipped,
+    errors: [],
+    cursor: page.continueCursor,
+    isDone: page.isDone,
+    ...(nextPhase ? { nextPhase } : {}),
+  };
+}
+
 // Repair legacy personal publisher ownership after the publisher model rollout.
 // Dry run one phase:
 //   npx convex run maintenance:repairLegacyPublisherOwnership '{"phase":"skills","dryRun":true,"scheduleNext":false}' --prod
@@ -2556,6 +2709,23 @@ export const repairLegacyPublisherOwnership = internalMutation({
     scheduleNext: v.optional(v.boolean()),
   },
   handler: repairLegacyPublisherOwnershipHandler,
+});
+
+// Targeted variant for production canaries and one-off account repair.
+// Example:
+//   npx convex run maintenance:repairLegacyPublisherOwnershipForUser '{"handle":"harrylabsj","dryRun":true,"scheduleNext":false}' --prod
+export const repairLegacyPublisherOwnershipForUser = internalMutation({
+  args: {
+    userId: v.optional(v.id("users")),
+    handle: v.optional(v.string()),
+    phase: v.optional(v.union(v.literal("skills"), v.literal("packages"))),
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+    delayMs: v.optional(v.number()),
+    dryRun: v.optional(v.boolean()),
+    scheduleNext: v.optional(v.boolean()),
+  },
+  handler: repairLegacyPublisherOwnershipForUserHandler,
 });
 
 const DIGEST_OWNER_BACKFILL_KEY = "digest-owner-backfill";


### PR DESCRIPTION
## Summary
- Add a targeted maintenance mutation for repairing legacy ownerPublisherId projections for one user by handle or user id.
- Page by ownerUserId so production canaries do not touch unrelated legacy rows.
- Cover targeted skill/package repair, aliases, and embeddings in maintenance tests.

## Tests
- bunx vitest run convex/maintenance.test.ts
- bun run format:check -- convex/maintenance.ts convex/maintenance.test.ts
- bun run lint -- convex/maintenance.ts convex/maintenance.test.ts
- bunx tsc -p convex/tsconfig.json --noEmit
- bun run ci:static
- bun run ci:unit
- bunx tsc -p packages/schema/tsconfig.json --noEmit
- bunx tsc -p packages/clawhub/tsconfig.json --noEmit
- AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local