### PR TITLE
fix: exclude official orgs from publisher abuse

### DIFF
--- a/convex/lib/officialPublishers.test.ts
+++ b/convex/lib/officialPublishers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Doc } from "../_generated/dataModel";
-import { isOfficialPublisher } from "./officialPublishers";
+import { hasOfficialPublisherRow, isOfficialPublisher } from "./officialPublishers";
 
 function makePublisher(
   overrides: Partial<Record<keyof Doc<"publishers">, unknown>>,
@@ -103,5 +103,19 @@ describe("isOfficialPublisher", () => {
     const ctx = makeCtx({ officialPublisherIds: ["publishers:openclaw"] });
 
     await expect(isOfficialPublisher(ctx as never, personal)).resolves.toBe(false);
+  });
+
+  it("can check raw official rows independently from active publisher state", async () => {
+    const ctx = makeCtx({ officialPublisherIds: ["publishers:acme"] });
+
+    await expect(
+      isOfficialPublisher(
+        ctx as never,
+        makePublisher({ _id: "publishers:acme", handle: "acme", deactivatedAt: 123 }),
+      ),
+    ).resolves.toBe(false);
+    await expect(hasOfficialPublisherRow(ctx as never, "publishers:acme" as never)).resolves.toBe(
+      true,
+    );
   });
 });

--- a/convex/lib/officialPublishers.ts
+++ b/convex/lib/officialPublishers.ts
@@ -4,28 +4,23 @@ import { toPublicPublisher, type PublicPublisher } from "./public";
 
 type DbCtx = Pick<QueryCtx | MutationCtx, "db">;
 
-type OfficialPublisherCandidate = Pick<
-  Doc<"publishers">,
-  | "_id"
-  | "_creationTime"
-  | "kind"
-  | "handle"
-  | "displayName"
-  | "image"
-  | "bio"
-  | "linkedUserId"
-  | "deletedAt"
-  | "deactivatedAt"
->;
+type OfficialPublisherCandidate = Pick<Doc<"publishers">, "_id" | "deletedAt" | "deactivatedAt">;
 
 export async function isOfficialPublisher(
   ctx: DbCtx,
   publisher: OfficialPublisherCandidate | null | undefined,
 ): Promise<boolean> {
   if (!publisher || publisher.deletedAt || publisher.deactivatedAt) return false;
+  return await hasOfficialPublisherRow(ctx, publisher._id);
+}
+
+export async function hasOfficialPublisherRow(
+  ctx: DbCtx,
+  publisherId: Doc<"publishers">["_id"],
+): Promise<boolean> {
   const officialPublisher = await ctx.db
     .query("officialPublishers")
-    .withIndex("by_publisher", (q) => q.eq("publisherId", publisher._id))
+    .withIndex("by_publisher", (q) => q.eq("publisherId", publisherId))
     .unique();
   return Boolean(officialPublisher);
 }

--- a/convex/publisherAbuse.test.ts
+++ b/convex/publisherAbuse.test.ts
@@ -142,6 +142,7 @@ function makeScore(
   fields: Partial<{
     _id: string;
     ownerKey: string;
+    ownerPublisherId: string;
     rank: number;
     zScore: number;
     label: "potential_ban_candidate" | "review" | "pass";
@@ -151,7 +152,7 @@ function makeScore(
     _id: fields._id ?? "publisherAbuseScores:score",
     runId: "publisherAbuseScoreRuns:latest",
     ownerKey: fields.ownerKey ?? "user:owner",
-    ownerPublisherId: undefined,
+    ownerPublisherId: fields.ownerPublisherId,
     ownerUserId: undefined,
     handleSnapshot: (fields.ownerKey ?? "user:owner").replace("user:", ""),
     modelVersion: "publisher-abuse-pressure.v1",
@@ -176,19 +177,21 @@ function makeNomination(
   fields: Partial<{
     _id: string;
     ownerKey: string;
+    ownerPublisherId: string;
     ownerUserId: string;
     latestScoreId: string;
     handleSnapshot: string;
     label: "potential_ban_candidate" | "review" | "pass";
     status: PublisherAbuseTestTriageStatus;
     lastScoredAt: number;
+    reviewedAt: number;
     updatedAt: number;
   }> = {},
 ) {
   return {
     _id: fields._id ?? "publisherAbuseReviewNominations:nomination",
     ownerKey: fields.ownerKey ?? "user:owner",
-    ownerPublisherId: undefined,
+    ownerPublisherId: fields.ownerPublisherId,
     ownerUserId: fields.ownerUserId,
     handleSnapshot: fields.handleSnapshot ?? "owner",
     latestScoreId: fields.latestScoreId ?? "publisherAbuseScores:score",
@@ -198,7 +201,26 @@ function makeNomination(
     openedAt: 1,
     openedByRunId: "publisherAbuseScoreRuns:latest",
     lastScoredAt: fields.lastScoredAt ?? 1,
+    reviewedAt: fields.reviewedAt,
     updatedAt: fields.updatedAt ?? 1,
+  };
+}
+
+function makeEmptyOfficialPublishersQuery() {
+  return {
+    withIndex: (indexName: string) => {
+      if (indexName === "by_created") {
+        return {
+          paginate: async () => ({ page: [], isDone: true, continueCursor: "" }),
+        };
+      }
+      if (indexName === "by_publisher") {
+        return {
+          unique: async () => null,
+        };
+      }
+      throw new Error(`unexpected official publisher index ${indexName}`);
+    },
   };
 }
 
@@ -477,6 +499,73 @@ describe("publisher abuse dry-run persistence", () => {
         reason: "confirmed spam",
       }),
     ).rejects.toThrow(/pending/i);
+
+    expect(runMutation).not.toHaveBeenCalled();
+    expect(patch).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it("rejects direct ban actions for official org publisher nominations", async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:moderator",
+      user: { _id: "users:moderator", role: "moderator" },
+    } as never);
+    const runMutation = vi.fn(async () => ({ ok: true }));
+    const patch = vi.fn(async () => null);
+    const insert = vi.fn(async (table: string) => `${table}:new`);
+    const officialPublisher = {
+      _id: "publishers:openclaw",
+      kind: "org",
+      handle: "openclaw",
+      displayName: "OpenClaw",
+      linkedUserId: "users:owner",
+      deactivatedAt: 123,
+    };
+    const ctx = {
+      runMutation,
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "publisherAbuseReviewNominations:nomination") {
+            return makeNomination({
+              _id: "publisherAbuseReviewNominations:nomination",
+              ownerKey: "publisher:publishers:openclaw",
+              ownerPublisherId: officialPublisher._id,
+              ownerUserId: "users:owner",
+              label: "potential_ban_candidate",
+              status: "pending",
+              latestScoreId: "publisherAbuseScores:score",
+              updatedAt: 1,
+            });
+          }
+          if (id === officialPublisher._id) return officialPublisher;
+          return null;
+        }),
+        insert,
+        patch,
+        query: vi.fn((table: string) => {
+          if (table === "officialPublishers") {
+            return {
+              withIndex: () => ({
+                unique: async () => ({
+                  _id: "officialPublishers:openclaw",
+                  publisherId: officialPublisher._id,
+                }),
+              }),
+            };
+          }
+          throw new Error(`unexpected table ${table}`);
+        }),
+      },
+    };
+
+    await expect(
+      banPublisherAbuseOwnerHandler(ctx, {
+        nominationId: "publisherAbuseReviewNominations:nomination",
+        expectedLatestScoreId: "publisherAbuseScores:score",
+        expectedUpdatedAt: 1,
+        reason: "confirmed spam",
+      }),
+    ).rejects.toThrow(/official org/i);
 
     expect(runMutation).not.toHaveBeenCalled();
     expect(patch).not.toHaveBeenCalled();
@@ -794,6 +883,250 @@ describe("publisher abuse dry-run persistence", () => {
     expect(scoreTakeLimit).toBe(32);
   });
 
+  it("hides stale official org nominations from dashboard lists and nomination detail", async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:moderator",
+      user: { _id: "users:moderator", role: "moderator" },
+    } as never);
+    const latestRun = {
+      _id: "publisherAbuseScoreRuns:latest",
+      modelVersion: "publisher-abuse-pressure.v1",
+      trigger: "manual",
+      status: "completed",
+      phase: "completed",
+      startedAt: 1,
+      updatedAt: 2,
+      completedAt: 2,
+      scannedPublishers: 200,
+      scoredPublishers: 198,
+      finalizedScores: 198,
+      nominatedPublishers: 2,
+      passCount: 196,
+      reviewCount: 0,
+      potentialBanCandidateCount: 2,
+    };
+    const officialPublisher = {
+      _id: "publishers:official-risk",
+      kind: "org",
+      handle: "official-risk",
+      displayName: "Official Risk",
+      linkedUserId: "users:official-risk",
+    };
+    const communityPublisher = {
+      _id: "publishers:community-risk",
+      kind: "org",
+      handle: "community-risk",
+      displayName: "Community Risk",
+      linkedUserId: "users:community-risk",
+    };
+    const officialScore = makeScore({
+      _id: "publisherAbuseScores:official-risk",
+      ownerKey: "publisher:publishers:official-risk",
+      ownerPublisherId: officialPublisher._id,
+      rank: 1,
+      zScore: 5,
+    });
+    const communityScore = makeScore({
+      _id: "publisherAbuseScores:community-risk",
+      ownerKey: "publisher:publishers:community-risk",
+      ownerPublisherId: communityPublisher._id,
+      rank: 2,
+      zScore: 4.5,
+    });
+    const officialNomination = makeNomination({
+      _id: "publisherAbuseReviewNominations:official-risk",
+      ownerKey: officialScore.ownerKey,
+      ownerPublisherId: officialPublisher._id,
+      ownerUserId: "users:official-risk",
+      latestScoreId: officialScore._id,
+      handleSnapshot: officialPublisher.handle,
+      lastScoredAt: 20,
+    });
+    const communityNomination = makeNomination({
+      _id: "publisherAbuseReviewNominations:community-risk",
+      ownerKey: communityScore.ownerKey,
+      ownerPublisherId: communityPublisher._id,
+      ownerUserId: "users:community-risk",
+      latestScoreId: communityScore._id,
+      handleSnapshot: communityPublisher.handle,
+      lastScoredAt: 19,
+    });
+    const officialResolvedNomination = makeNomination({
+      _id: "publisherAbuseReviewNominations:official-resolved",
+      ownerKey: officialScore.ownerKey,
+      ownerPublisherId: officialPublisher._id,
+      ownerUserId: "users:official-risk",
+      latestScoreId: officialScore._id,
+      handleSnapshot: officialPublisher.handle,
+      status: "reviewed_no_action",
+      reviewedAt: 30,
+    });
+    const communityResolvedNomination = makeNomination({
+      _id: "publisherAbuseReviewNominations:community-resolved",
+      ownerKey: communityScore.ownerKey,
+      ownerPublisherId: communityPublisher._id,
+      ownerUserId: "users:community-risk",
+      latestScoreId: communityScore._id,
+      handleSnapshot: communityPublisher.handle,
+      status: "reviewed_no_action",
+      reviewedAt: 29,
+    });
+    const nominations = new Map([
+      [officialScore.ownerKey, officialNomination],
+      [communityScore.ownerKey, communityNomination],
+    ]);
+    const docs = new Map<string, unknown>([
+      [latestRun._id, latestRun],
+      [officialScore._id, officialScore],
+      [communityScore._id, communityScore],
+      [officialNomination._id, officialNomination],
+      [communityNomination._id, communityNomination],
+      [officialResolvedNomination._id, officialResolvedNomination],
+      [communityResolvedNomination._id, communityResolvedNomination],
+      [officialPublisher._id, officialPublisher],
+      [communityPublisher._id, communityPublisher],
+      ["users:official-risk", { _id: "users:official-risk", handle: "official-risk" }],
+      ["users:community-risk", { _id: "users:community-risk", handle: "community-risk" }],
+    ]);
+    const query = vi.fn((table: string) => {
+      if (table === "publisherAbuseScoreRuns") {
+        return {
+          withIndex: () => ({
+            order: () => ({
+              first: async () => latestRun,
+            }),
+          }),
+        };
+      }
+      if (table === "publisherAbuseScores") {
+        return {
+          withIndex: () => ({
+            order: () => ({
+              take: async () => [officialScore, communityScore],
+            }),
+          }),
+        };
+      }
+      if (table === "publisherAbuseReviewNominations") {
+        return {
+          withIndex: (
+            indexName: string,
+            build: (q: { eq: (field: string, value: unknown) => unknown }) => unknown,
+          ) => {
+            const constraints: Record<string, unknown> = {};
+            const q = {
+              eq(field: string, value: unknown) {
+                constraints[field] = value;
+                return q;
+              },
+            };
+            build(q);
+            if (indexName === "by_owner_key_and_model_version") {
+              return {
+                first: async () => nominations.get(String(constraints.ownerKey)) ?? null,
+              };
+            }
+            if (indexName === "by_status_and_label_and_last_scored_at") {
+              return {
+                order: () => ({
+                  take: async () => [],
+                }),
+              };
+            }
+            if (indexName === "by_status_and_reviewed_at") {
+              return {
+                order: () => ({
+                  take: async () =>
+                    constraints.status === "reviewed_no_action"
+                      ? [officialResolvedNomination, communityResolvedNomination]
+                      : [],
+                }),
+              };
+            }
+            throw new Error(`unexpected nomination index ${indexName}`);
+          },
+        };
+      }
+      if (table === "officialPublishers") {
+        return {
+          withIndex: (
+            indexName: string,
+            build: (q: { eq: (field: string, value: unknown) => unknown }) => unknown,
+          ) => {
+            expect(indexName).toBe("by_publisher");
+            const constraints: Record<string, unknown> = {};
+            const q = {
+              eq(field: string, value: unknown) {
+                constraints[field] = value;
+                return q;
+              },
+            };
+            build(q);
+            return {
+              unique: async () =>
+                constraints.publisherId === officialPublisher._id
+                  ? {
+                      _id: "officialPublishers:official-risk",
+                      publisherId: officialPublisher._id,
+                    }
+                  : null,
+            };
+          },
+        };
+      }
+      if (table === "publisherAbuseReviewEvents") {
+        return {
+          withIndex: () => ({
+            order: () => ({
+              take: async () => [],
+            }),
+          }),
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    });
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => docs.get(id) ?? null),
+        query,
+      },
+    };
+
+    await expect(listDashboardHandler(ctx, { limit: 5 })).resolves.toEqual(
+      expect.objectContaining({
+        pendingPotentialBanCandidateItems: [
+          expect.objectContaining({
+            nomination: expect.objectContaining({
+              _id: communityNomination._id,
+              handleSnapshot: communityPublisher.handle,
+            }),
+          }),
+        ],
+        pendingReviewItems: [],
+        recentResolvedItems: [
+          expect.objectContaining({
+            nomination: expect.objectContaining({
+              _id: communityResolvedNomination._id,
+              handleSnapshot: communityPublisher.handle,
+            }),
+          }),
+        ],
+      }),
+    );
+    await expect(
+      getReviewNominationDetailHandler(ctx, { nominationId: officialNomination._id }),
+    ).resolves.toBeNull();
+    await expect(
+      getReviewNominationDetailHandler(ctx, { nominationId: communityNomination._id }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        item: expect.objectContaining({
+          nomination: expect.objectContaining({ _id: communityNomination._id }),
+        }),
+      }),
+    );
+  });
+
   it("uses nomination order while the latest score run is failed", async () => {
     vi.mocked(requireUser).mockResolvedValue({
       userId: "users:moderator",
@@ -1108,7 +1441,7 @@ describe("publisher abuse dry-run persistence", () => {
               return {
                 order: () => ({
                   take: async (limit: number) => {
-                    expect(limit).toBe(30);
+                    expect(limit).toBe(90);
                     return constraints.status === "reviewed_no_action"
                       ? [rescoredOldResolution, resolvedNomination]
                       : [];
@@ -1302,6 +1635,122 @@ describe("publisher abuse dry-run persistence", () => {
     expect(patch).not.toHaveBeenCalledWith(
       expect.stringMatching(/^(users|publishers|skills|skillSearchDigest):/),
       expect.anything(),
+    );
+  });
+
+  it("excludes official org publishers from abuse scoring even when they match abuse-pressure criteria", async () => {
+    const insert = vi.fn(async (table: string) => `${table}:new`);
+    const patch = vi.fn(async () => null);
+    const officialOrgPublisher = {
+      _id: "publishers:openclaw",
+      kind: "org",
+      handle: "openclaw",
+      displayName: "OpenClaw",
+      linkedUserId: "users:openclaw",
+      publishedSkills: 1_200,
+      publishedPackages: 0,
+      totalInstalls: 4,
+      totalStars: 0,
+      totalDownloads: 80,
+    };
+    const communityOrgPublisher = {
+      ...officialOrgPublisher,
+      _id: "publishers:community-bulk",
+      handle: "community-bulk",
+      displayName: "Community Bulk",
+      linkedUserId: "users:community-bulk",
+    };
+    const officialLookupIds: string[] = [];
+    const ctx = {
+      db: {
+        get: vi.fn(async () => ({
+          _id: "publisherAbuseScoreRuns:run",
+          modelVersion: TEST_MODEL_CONFIG.modelVersion,
+          modelConfig: TEST_MODEL_CONFIG,
+          status: "running",
+          phase: "collecting",
+          collectCursor: undefined,
+          scannedPublishers: 0,
+          scoredPublishers: 0,
+          sumLogPressure: 0,
+          sumSquaredLogPressure: 0,
+        })),
+        insert,
+        patch,
+        query: vi.fn((table: string) => {
+          if (table === "publishers") {
+            return {
+              withIndex: () => ({
+                paginate: async () => ({
+                  page: [officialOrgPublisher, communityOrgPublisher],
+                  isDone: true,
+                  continueCursor: "",
+                }),
+              }),
+            };
+          }
+          if (table === "officialPublishers") {
+            return {
+              withIndex: (
+                indexName: string,
+                build: (q: { eq: (field: string, value: unknown) => unknown }) => unknown,
+              ) => {
+                expect(indexName).toBe("by_publisher");
+                const constraints: Record<string, unknown> = {};
+                const q = {
+                  eq(field: string, value: unknown) {
+                    constraints[field] = value;
+                    return q;
+                  },
+                };
+                build(q);
+                officialLookupIds.push(String(constraints.publisherId));
+                return {
+                  unique: async () =>
+                    constraints.publisherId === officialOrgPublisher._id
+                      ? {
+                          _id: "officialPublishers:openclaw",
+                          publisherId: officialOrgPublisher._id,
+                        }
+                      : null,
+                };
+              },
+            };
+          }
+          throw new Error(`unexpected table ${table}`);
+        }),
+      },
+    };
+
+    await expect(collectHandler(ctx, { runId: "publisherAbuseScoreRuns:run" })).resolves.toEqual(
+      expect.objectContaining({ isDone: false, scanned: 2, phase: "finalizing" }),
+    );
+
+    expect(officialLookupIds).toEqual([officialOrgPublisher._id, communityOrgPublisher._id]);
+    expect(insert).toHaveBeenCalledTimes(1);
+    expect(insert).toHaveBeenCalledWith(
+      "publisherAbuseScores",
+      expect.objectContaining({
+        ownerPublisherId: communityOrgPublisher._id,
+        handleSnapshot: communityOrgPublisher.handle,
+        publishedSkills: officialOrgPublisher.publishedSkills,
+        totalInstalls: officialOrgPublisher.totalInstalls,
+        totalStars: officialOrgPublisher.totalStars,
+        totalDownloads: officialOrgPublisher.totalDownloads,
+      }),
+    );
+    expect(insert).not.toHaveBeenCalledWith(
+      "publisherAbuseScores",
+      expect.objectContaining({
+        ownerPublisherId: officialOrgPublisher._id,
+      }),
+    );
+    expect(patch).toHaveBeenCalledWith(
+      "publisherAbuseScoreRuns:run",
+      expect.objectContaining({
+        scannedPublishers: 2,
+        scoredPublishers: 1,
+      }),
     );
   });
 
@@ -2393,6 +2842,7 @@ describe("publisher abuse dry-run persistence", () => {
               }),
             };
           }
+          if (table === "officialPublishers") return makeEmptyOfficialPublishersQuery();
           throw new Error(`unexpected table ${table}`);
         }),
       },
@@ -2406,6 +2856,186 @@ describe("publisher abuse dry-run persistence", () => {
     expect(patch).toHaveBeenCalledWith(
       "publisherAbuseReviewNominations:existing",
       expect.objectContaining({ latestScoreId: "publisherAbuseScores:score" }),
+    );
+  });
+
+  it("does not create nominations for official org score rows left by an older run", async () => {
+    const insert = vi.fn(async (table: string) => `${table}:new`);
+    const patch = vi.fn(async () => null);
+    const officialPublisher = {
+      _id: "publishers:openclaw",
+      kind: "org",
+      handle: "openclaw",
+      linkedUserId: "users:openclaw",
+    };
+    const communityPublisher = {
+      _id: "publishers:community",
+      kind: "org",
+      handle: "community",
+      linkedUserId: "users:community",
+    };
+    const officialScore = {
+      _id: "publisherAbuseScores:official",
+      ownerKey: "publisher:publishers:openclaw",
+      ownerPublisherId: officialPublisher._id,
+      ownerUserId: "users:openclaw",
+      handleSnapshot: "openclaw",
+      modelVersion: "publisher-abuse-pressure.v1",
+      pressure: 1000,
+      logPressure: 6,
+      publishedSkills: 1200,
+      totalInstalls: 8,
+      totalStars: 0,
+      totalDownloads: 120,
+      installsPerSkill: 0.006,
+      starsPerSkill: 0,
+      downloadsPerSkill: 0.1,
+      reasonCodes: ["high_catalog_volume"],
+    };
+    const communityScore = {
+      _id: "publisherAbuseScores:community",
+      ownerKey: "publisher:publishers:community",
+      ownerPublisherId: communityPublisher._id,
+      ownerUserId: "users:community",
+      handleSnapshot: "community",
+      modelVersion: "publisher-abuse-pressure.v1",
+      pressure: 100,
+      logPressure: 2,
+      publishedSkills: 120,
+      totalInstalls: 20,
+      totalStars: 1,
+      totalDownloads: 500,
+      installsPerSkill: 0.16,
+      starsPerSkill: 0.008,
+      downloadsPerSkill: 4.16,
+      reasonCodes: ["high_catalog_volume"],
+    };
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "publisherAbuseScoreRuns:run") {
+            return {
+              _id: "publisherAbuseScoreRuns:run",
+              status: "running",
+              phase: "finalizing",
+              modelVersion: "publisher-abuse-pressure.v1",
+              modelConfig: TEST_MODEL_CONFIG,
+              scoredPublishers: 2,
+              finalizedScores: 0,
+              passCount: 0,
+              reviewCount: 0,
+              potentialBanCandidateCount: 0,
+              nominatedPublishers: 0,
+              sumLogPressure: officialScore.logPressure + communityScore.logPressure,
+              sumSquaredLogPressure:
+                officialScore.logPressure ** 2 + communityScore.logPressure ** 2,
+            };
+          }
+          if (id === officialPublisher._id) return officialPublisher;
+          if (id === communityPublisher._id) return communityPublisher;
+          return null;
+        }),
+        insert,
+        patch,
+        query: vi.fn((table: string) => {
+          if (table === "publisherAbuseScores") {
+            return {
+              withIndex: (indexName: string) => {
+                if (indexName === "by_run_and_pressure") {
+                  return {
+                    order: () => ({
+                      paginate: async () => ({
+                        page: [officialScore, communityScore],
+                        isDone: true,
+                        continueCursor: "",
+                      }),
+                    }),
+                  };
+                }
+                if (indexName === "by_run_and_owner_key") {
+                  return {
+                    first: async () => officialScore,
+                  };
+                }
+                throw new Error(`unexpected score index ${indexName}`);
+              },
+            };
+          }
+          if (table === "officialPublishers") {
+            return {
+              withIndex: (
+                indexName: string,
+                build?: (q: { eq: (field: string, value: unknown) => unknown }) => unknown,
+              ) => {
+                if (indexName === "by_created") {
+                  return {
+                    paginate: async () => ({
+                      page: [
+                        {
+                          _id: "officialPublishers:openclaw",
+                          publisherId: officialPublisher._id,
+                        },
+                      ],
+                      isDone: true,
+                      continueCursor: "",
+                    }),
+                  };
+                }
+                if (indexName === "by_publisher") {
+                  const constraints: Record<string, unknown> = {};
+                  const q = {
+                    eq(field: string, value: unknown) {
+                      constraints[field] = value;
+                      return q;
+                    },
+                  };
+                  build?.(q);
+                  return {
+                    unique: async () =>
+                      constraints.publisherId === officialPublisher._id
+                        ? {
+                            _id: "officialPublishers:openclaw",
+                            publisherId: officialPublisher._id,
+                          }
+                        : null,
+                  };
+                }
+                throw new Error(`unexpected official publisher index ${indexName}`);
+              },
+            };
+          }
+          if (table === "publisherAbuseReviewNominations") {
+            return {
+              withIndex: () => ({
+                first: async () => null,
+              }),
+            };
+          }
+          throw new Error(`unexpected table ${table}`);
+        }),
+      },
+    };
+
+    await expect(finalizeHandler(ctx, { runId: "publisherAbuseScoreRuns:run" })).resolves.toEqual(
+      expect.objectContaining({ isDone: true, finalized: 2, nominations: 0 }),
+    );
+
+    expect(insert).not.toHaveBeenCalledWith("publisherAbuseReviewNominations", expect.anything());
+    expect(patch).not.toHaveBeenCalledWith(
+      "publisherAbuseScores:official",
+      expect.objectContaining({ label: "potential_ban_candidate" }),
+    );
+    expect(patch).toHaveBeenCalledWith(
+      communityScore._id,
+      expect.objectContaining({ label: "pass", rank: 1, zScore: 0 }),
+    );
+    expect(patch).toHaveBeenCalledWith(
+      "publisherAbuseScoreRuns:run",
+      expect.objectContaining({
+        meanLogPressure: communityScore.logPressure,
+        stdDevLogPressure: 0,
+        passCount: 1,
+      }),
     );
   });
 
@@ -2478,6 +3108,7 @@ describe("publisher abuse dry-run persistence", () => {
               }),
             };
           }
+          if (table === "officialPublishers") return makeEmptyOfficialPublishersQuery();
           throw new Error(`unexpected table ${table}`);
         }),
       },
@@ -2577,6 +3208,7 @@ describe("publisher abuse dry-run persistence", () => {
               }),
             };
           }
+          if (table === "officialPublishers") return makeEmptyOfficialPublishersQuery();
           throw new Error(`unexpected table ${table}`);
         }),
       },
@@ -2675,6 +3307,7 @@ describe("publisher abuse dry-run persistence", () => {
               }),
             };
           }
+          if (table === "officialPublishers") return makeEmptyOfficialPublishersQuery();
           throw new Error(`unexpected table ${table}`);
         }),
       },
@@ -2760,6 +3393,7 @@ describe("publisher abuse dry-run persistence", () => {
               }),
             };
           }
+          if (table === "officialPublishers") return makeEmptyOfficialPublishersQuery();
           throw new Error(`unexpected table ${table}`);
         }),
       },

--- a/convex/publisherAbuse.ts
+++ b/convex/publisherAbuse.ts
@@ -11,6 +11,7 @@ import {
   query,
 } from "./functions";
 import { assertModerator, requireUser, requireUserFromAction } from "./lib/access";
+import { hasOfficialPublisherRow } from "./lib/officialPublishers";
 import {
   computePublisherAbuseRawScore,
   DEFAULT_PUBLISHER_ABUSE_MODEL_CONFIG,
@@ -54,8 +55,11 @@ type PageResult = RunState & {
 type PublisherMetricsDoc = Pick<
   Doc<"publishers">,
   | "_id"
+  | "kind"
   | "handle"
   | "linkedUserId"
+  | "deletedAt"
+  | "deactivatedAt"
   | "publishedSkills"
   | "publishedPackages"
   | "totalInstalls"
@@ -64,6 +68,11 @@ type PublisherMetricsDoc = Pick<
   | "skillTotalInstalls"
   | "skillTotalStars"
   | "skillTotalDownloads"
+>;
+
+type PublisherAbuseExclusionPublisher = Pick<
+  Doc<"publishers">,
+  "_id" | "kind" | "deletedAt" | "deactivatedAt"
 >;
 
 type PublisherSkillMetricsOptions =
@@ -133,6 +142,7 @@ export const getReviewNominationDetail = query({
     if (!nomination) return null;
 
     const item = await summarizePublisherAbuseReviewNomination(ctx, nomination);
+    if (await isPublisherAbuseExcludedReviewItem(ctx, item)) return null;
     const scoreHistory = await ctx.db
       .query("publisherAbuseScores")
       .withIndex("by_owner_key_and_created_at", (q) => q.eq("ownerKey", nomination.ownerKey))
@@ -172,6 +182,7 @@ export const banPublisherAbuseOwner = mutation({
     if (!nomination.ownerUserId) {
       throw new Error("Cannot ban publisher abuse nomination without a linked user");
     }
+    await requirePublisherAbuseNominationNotExcluded(ctx, nomination);
 
     const reason = normalizeBanReason(args.reason);
     await ctx.runMutation(internal.users.banUserInternal, {
@@ -383,6 +394,7 @@ export async function collectPublisherAbuseScoresPageInternalHandler(
           activeSkillFallbackBudget,
         };
   for (const publisher of page.page) {
+    if (await isPublisherExcludedFromPublisherAbuse(ctx, publisher)) continue;
     const input = await publisherInputFromPublisher(ctx, publisher, publisherSkillMetricsOptions);
     if (!input) continue;
     const rawScore = computePublisherAbuseRawScore(input, modelConfig);
@@ -449,10 +461,11 @@ export async function finalizePublisherAbuseScoresPageInternalHandler(
 
   const batchSize = clampInt(args.batchSize ?? DEFAULT_BATCH_SIZE, 1, MAX_BATCH_SIZE);
   const now = Date.now();
+  const cohortStats = await summarizePublisherAbuseFinalizationCohort(ctx, run);
   const { meanLogPressure, stdDevLogPressure } = summarizePublisherAbuseLogPressure(
-    run.sumLogPressure,
-    run.sumSquaredLogPressure,
-    run.scoredPublishers,
+    cohortStats.sumLogPressure,
+    cohortStats.sumSquaredLogPressure,
+    cohortStats.scoredPublishers,
   );
   const safeStdDev = stdDevLogPressure === 0 ? 1 : stdDevLogPressure;
   const page = await ctx.db
@@ -468,12 +481,19 @@ export async function finalizePublisherAbuseScoresPageInternalHandler(
   };
   let nominations = 0;
   let finalized = 0;
+  let ranked = 0;
+  const rankedScoresSoFar = run.passCount + run.reviewCount + run.potentialBanCandidateCount;
   const modelConfig = run.modelConfig;
   for (const score of page.page) {
+    if (await isPublisherAbuseScoreExcluded(ctx, score)) {
+      finalized += 1;
+      continue;
+    }
     const zScore = (score.logPressure - meanLogPressure) / safeStdDev;
     const label = labelForPublisherAbuseZScore(zScore, modelConfig);
-    const rank = run.finalizedScores + finalized + 1;
+    const rank = rankedScoresSoFar + ranked + 1;
     labelCounts[label] += 1;
+    ranked += 1;
     finalized += 1;
 
     await ctx.db.patch(score._id, { zScore, label, rank });
@@ -693,6 +713,84 @@ async function publisherInputFromPublisher(
     totalStars: skillMetrics.totalStars,
     totalDownloads: skillMetrics.totalDownloads,
   };
+}
+
+async function isPublisherExcludedFromPublisherAbuse(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  publisher: PublisherAbuseExclusionPublisher | null | undefined,
+) {
+  if (!publisher || publisher.kind !== "org") return false;
+  return await hasOfficialPublisherRow(ctx, publisher._id);
+}
+
+async function isPublisherAbuseExcludedReviewItem(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  item: PublisherAbuseReviewItem,
+) {
+  return await isPublisherExcludedFromPublisherAbuse(ctx, item.publisher);
+}
+
+async function isPublisherAbuseScoreExcluded(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  score: Pick<ScoreDoc, "ownerPublisherId">,
+) {
+  if (!score.ownerPublisherId) return false;
+  const publisher = await ctx.db.get(score.ownerPublisherId);
+  return await isPublisherExcludedFromPublisherAbuse(ctx, publisher);
+}
+
+async function requirePublisherAbuseNominationNotExcluded(
+  ctx: Pick<MutationCtx, "db">,
+  nomination: Doc<"publisherAbuseReviewNominations">,
+) {
+  if (!nomination.ownerPublisherId) return;
+  const publisher = await ctx.db.get(nomination.ownerPublisherId);
+  if (!(await isPublisherExcludedFromPublisherAbuse(ctx, publisher))) return;
+  throw new Error("Official org publisher abuse nominations cannot be acted on.");
+}
+
+async function summarizePublisherAbuseFinalizationCohort(ctx: MutationCtx, run: ScoreRun) {
+  const exclusions = await summarizeOfficialPublisherAbuseScoreExclusions(ctx, run);
+  const scoredPublishers = Math.max(0, run.scoredPublishers - exclusions.scoredPublishers);
+  if (scoredPublishers === 0) {
+    return { scoredPublishers, sumLogPressure: 0, sumSquaredLogPressure: 0 };
+  }
+  return {
+    scoredPublishers,
+    sumLogPressure: run.sumLogPressure - exclusions.sumLogPressure,
+    sumSquaredLogPressure: run.sumSquaredLogPressure - exclusions.sumSquaredLogPressure,
+  };
+}
+
+async function summarizeOfficialPublisherAbuseScoreExclusions(ctx: MutationCtx, run: ScoreRun) {
+  let cursor: string | null = null;
+  let scoredPublishers = 0;
+  let sumLogPressure = 0;
+  let sumSquaredLogPressure = 0;
+
+  do {
+    const page = await ctx.db
+      .query("officialPublishers")
+      .withIndex("by_created")
+      .paginate({ cursor, numItems: MAX_BATCH_SIZE });
+    for (const officialPublisher of page.page) {
+      const publisher = await ctx.db.get(officialPublisher.publisherId);
+      if (!publisher || publisher.kind !== "org") continue;
+      const score = await ctx.db
+        .query("publisherAbuseScores")
+        .withIndex("by_run_and_owner_key", (q) =>
+          q.eq("runId", run._id).eq("ownerKey", `publisher:${officialPublisher.publisherId}`),
+        )
+        .first();
+      if (!score || score.publishedSkills <= 0) continue;
+      scoredPublishers += 1;
+      sumLogPressure += score.logPressure;
+      sumSquaredLogPressure += score.logPressure ** 2;
+    }
+    cursor = page.isDone ? null : page.continueCursor;
+  } while (cursor);
+
+  return { scoredPublishers, sumLogPressure, sumSquaredLogPressure };
 }
 
 type SkillMetricsForScoring = Pick<
@@ -1022,7 +1120,7 @@ async function getPendingPublisherAbuseReviewItemsForLabelFromScoreRank(
       continue;
     }
     const item = await summarizePublisherAbuseReviewNomination(ctx, nomination);
-    if (!isVisiblePublisherAbuseReviewItem(item)) continue;
+    if (!(await isVisiblePublisherAbuseReviewItem(ctx, item))) continue;
     items.push(item);
     if (items.length >= args.limit) break;
   }
@@ -1044,7 +1142,7 @@ async function getPendingPublisherAbuseReviewItemsForLabelFromLastScoredAt(
     .take(scanLimit);
   const pageItems = await summarizePublisherAbuseReviewNominations(ctx, nominations);
   for (const item of pageItems) {
-    if (!isVisiblePublisherAbuseReviewItem(item)) continue;
+    if (!(await isVisiblePublisherAbuseReviewItem(ctx, item))) continue;
     items.push(item);
     if (items.length >= args.limit) break;
   }
@@ -1073,11 +1171,11 @@ async function getRecentResolvedPublisherAbuseReviewItems(ctx: QueryCtx, limit: 
       .query("publisherAbuseReviewNominations")
       .withIndex("by_status_and_reviewed_at", (q) => q.eq("status", status))
       .order("desc")
-      .take(limit);
+      .take(limit * MAX_REVIEW_DASHBOARD_SCAN_MULTIPLIER);
     nominations.push(...page);
   }
   nominations.sort((left, right) => (right.reviewedAt ?? 0) - (left.reviewedAt ?? 0));
-  return await summarizePublisherAbuseReviewNominations(ctx, nominations.slice(0, limit));
+  return await summarizeVisiblePublisherAbuseReviewNominations(ctx, nominations, limit);
 }
 
 async function summarizePublisherAbuseReviewNominations(
@@ -1087,6 +1185,20 @@ async function summarizePublisherAbuseReviewNominations(
   const items = [];
   for (const nomination of nominations) {
     items.push(await summarizePublisherAbuseReviewNomination(ctx, nomination));
+  }
+  return items;
+}
+
+async function summarizeVisiblePublisherAbuseReviewNominations(
+  ctx: QueryCtx,
+  nominations: Doc<"publisherAbuseReviewNominations">[],
+  limit?: number,
+) {
+  const items = [];
+  for (const nomination of nominations) {
+    const item = await summarizePublisherAbuseReviewNomination(ctx, nomination);
+    if (await isVisiblePublisherAbuseReviewItem(ctx, item)) items.push(item);
+    if (limit && items.length >= limit) break;
   }
   return items;
 }
@@ -1111,13 +1223,14 @@ async function summarizePublisherAbuseReviewNomination(
   };
 }
 
-function isVisiblePublisherAbuseReviewItem(item: PublisherAbuseReviewItem) {
+async function isVisiblePublisherAbuseReviewItem(ctx: QueryCtx, item: PublisherAbuseReviewItem) {
   return (
     item.nomination.label !== "pass" &&
     !item.ownerUser?.deletedAt &&
     !item.ownerUser?.deactivatedAt &&
     !item.publisher?.deletedAt &&
-    !item.publisher?.deactivatedAt
+    !item.publisher?.deactivatedAt &&
+    !(await isPublisherAbuseExcludedReviewItem(ctx, item))
   );
 }
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2137,6 +2137,7 @@ const publisherAbuseScores = defineTable({
   .index("by_run_and_rank", ["runId", "rank"])
   .index("by_run_and_label_and_rank", ["runId", "label", "rank"])
   .index("by_run_and_pressure", ["runId", "pressure"])
+  .index("by_run_and_owner_key", ["runId", "ownerKey"])
   .index("by_owner_key_and_created_at", ["ownerKey", "createdAt"])
   .index("by_owner_key_and_model_version", ["ownerKey", "modelVersion"])
   .index("by_label_and_z_score", ["label", "zScore"]);

--- a/specs/official-publishers.md
+++ b/specs/official-publishers.md
@@ -15,13 +15,15 @@ Membership in an official org does not make a member's personal publisher
 Official. There is no generic public endpoint for marking arbitrary publishers
 Official.
 
-The same policy signal appears in two places:
+The same policy signal appears in several places:
 
 - Publisher/profile UI: official publishers show an `Official` badge.
 - Owned package UI: new public packages from Official publishers use the
   `official` channel; private packages stay private.
 - GitHub Skill Sync UI/backend: only manageable Official publishers can
   configure source-backed GitHub skill sync.
+- Publisher abuse scoring: Official org publishers are excluded from bulk
+  publisher-abuse scoring, nomination queues, and stale nomination actions.
 
 `trustedPublisher` is an internal automated-publish permission. It does not make
 a publisher or package Official.

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -26,6 +26,19 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
 - Restore pages only clear the exact `softDeletedAt` timestamp from the ban
   being lifted and only for skills hidden with `moderationReason = "user.banned"`.
 
+## Publisher abuse scoring
+
+- Publisher abuse scoring is a staff review signal for bulk-publishing abuse.
+  It must not directly ban users; staff action goes through the publisher abuse
+  nomination review path.
+- Official org publishers are excluded from publisher abuse scoring and
+  enforcement. An excluded publisher must not contribute to score-run cohort
+  statistics, receive a score label/rank, open or update a nomination, appear in
+  the dashboard/detail state, or be actionable through a stale nomination id.
+- The exclusion is backend-enforced. The management UI must derive its publisher
+  abuse list from the filtered backend dashboard state instead of applying a
+  separate client-side official-org filter.
+
 ## Reporting + auto-hide
 
 - Reports are unique per user + target (skill/comment/package).


### PR DESCRIPTION
## Summary
- Exclude official org publishers from publisher-abuse collection, finalization, dashboard/detail state, and stale ban actions.
- Keep the UI derived from filtered backend dashboard/detail state, with shared backend exclusion helpers and an official-row policy lookup for stale/inactive official orgs.
- Adjust finalization cohort stats for stale official score rows and add regression coverage plus spec updates for the intended behavior.

## Autoreview
- Ran `codex review --uncommitted`; accepted and fixed two P2 findings:
  - stale official score rows could still affect cohort mean/stddev
  - inactive official org rows could fail open through active-only official checks
- Final `codex review --uncommitted` pass exited 0 with no accepted/actionable findings reported.

## Tests
- `bunx vitest run convex/publisherAbuse.test.ts convex/lib/officialPublishers.test.ts`
- `bun run format:check -- convex/lib/officialPublishers.ts convex/lib/officialPublishers.test.ts convex/schema.ts convex/publisherAbuse.ts convex/publisherAbuse.test.ts specs/official-publishers.md specs/security-moderation.md && git diff --check`
- `bunx tsc --noEmit --pretty false`
- `bun run ci:static`
- `bun run ci:unit`
- `bunx tsc --noEmit --pretty false && bunx tsc -p convex/tsconfig.json --noEmit --pretty false`
