### PR TITLE
Add temporal publisher abuse scan

### DIFF
--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -71,6 +71,20 @@ crons.interval(
   { batchSize: 250, maxPages: 5, trigger: "cron" },
 );
 
+crons.interval(
+  "publisher-temporal-abuse-scan",
+  { hours: 24 },
+  internal.publisherAbuse.runTemporalPublisherAbuseScanInternal,
+  {
+    mode: "current",
+    dryRun: false,
+    candidateLimit: 1000,
+    batchSize: 50,
+    maxPages: 20,
+    trigger: "cron",
+  },
+);
+
 crons.interval("vt-pending-scans", { minutes: 5 }, internal.vt.pollPendingScans, {
   batchSize: 100,
 });

--- a/convex/lib/publisherAbuseScoring.test.ts
+++ b/convex/lib/publisherAbuseScoring.test.ts
@@ -2,7 +2,10 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  computeCurrentSkillTemporalAbuseScore,
+  computeHistoricalSkillTemporalAbuseScore,
   computePublisherAbuseRawScore,
+  computeTemporalPublisherAbuseZScore,
   DEFAULT_PUBLISHER_ABUSE_MODEL_CONFIG,
   labelForPublisherAbuseZScore,
   scorePublisherAbuseCohort,
@@ -16,6 +19,31 @@ describe("publisher abuse scoring", () => {
     expect(labelForPublisherAbuseZScore(2.5, DEFAULT_PUBLISHER_ABUSE_MODEL_CONFIG)).toBe(
       "potential_ban_candidate",
     );
+  });
+
+  it("maps temporal labels to review-compatible z-scores", () => {
+    const review = computeTemporalPublisherAbuseZScore({
+      label: "review",
+      highTemporalSkillCount: 1,
+      maxTemporalPressure: 20,
+    });
+    const potentialBan = computeTemporalPublisherAbuseZScore({
+      label: "potential_ban_candidate",
+      highTemporalSkillCount: 2,
+      maxTemporalPressure: 20,
+    });
+
+    expect(
+      computeTemporalPublisherAbuseZScore({
+        label: "pass",
+        highTemporalSkillCount: 0,
+        maxTemporalPressure: 0,
+      }),
+    ).toBe(0);
+    expect(review).toBeGreaterThanOrEqual(1.5);
+    expect(review).toBeLessThan(2.5);
+    expect(potentialBan).toBeGreaterThanOrEqual(2.5);
+    expect(potentialBan).toBeGreaterThan(review);
   });
 
   it("keeps a high-volume publisher with strong usage below low-engagement publishers", () => {
@@ -125,6 +153,75 @@ describe("publisher abuse scoring", () => {
       "pass",
     );
   });
+
+  it("flags a current 7-day download spike with flat installs", () => {
+    const todayDay = 100;
+    const score = computeCurrentSkillTemporalAbuseScore({
+      todayDay,
+      dailyStats: [
+        ...dailyRange(64, 30, { downloads: 5, installs: 0 }),
+        ...dailyRange(94, 7, { downloads: 200, installs: 0 }),
+      ],
+    });
+
+    expect(score.spike).toBe(true);
+    expect(score.sustained).toBe(false);
+    expect(score.recent7Downloads).toBe(1_400);
+    expect(score.recent7Installs).toBe(0);
+    expect(score.previous30Downloads).toBe(150);
+    expect(score.spikeMultiplier).toBeCloseTo(14);
+    expect(score.reasonCodes).toContain("temporal_download_spike_flat_installs");
+  });
+
+  it("flags sustained high downloads with flat installs", () => {
+    const todayDay = 100;
+    const score = computeCurrentSkillTemporalAbuseScore({
+      todayDay,
+      dailyStats: dailyRange(71, 30, { downloads: 120, installs: 0 }),
+    });
+
+    expect(score.spike).toBe(false);
+    expect(score.sustained).toBe(true);
+    expect(score.recent30Downloads).toBe(3_600);
+    expect(score.recent30Installs).toBe(0);
+    expect(score.downloadInstallRatio30).toBe(3_600);
+    expect(score.reasonCodes).toContain("temporal_sustained_downloads_flat_installs");
+  });
+
+  it("keeps ordinary steady download traffic below temporal thresholds", () => {
+    const todayDay = 100;
+    const score = computeCurrentSkillTemporalAbuseScore({
+      todayDay,
+      dailyStats: [
+        ...dailyRange(64, 30, { downloads: 80, installs: 1 }),
+        ...dailyRange(94, 7, { downloads: 85, installs: 1 }),
+      ],
+    });
+
+    expect(score.spike).toBe(false);
+    expect(score.sustained).toBe(false);
+    expect(score.pressure).toBe(0);
+    expect(score.reasonCodes).toEqual([]);
+  });
+
+  it("finds historical spike and sustained windows for backfill scans", () => {
+    const score = computeHistoricalSkillTemporalAbuseScore({
+      dailyStats: [
+        ...dailyRange(10, 30, { downloads: 3, installs: 0 }),
+        ...dailyRange(40, 7, { downloads: 220, installs: 0 }),
+        ...dailyRange(80, 30, { downloads: 150, installs: 0 }),
+      ],
+    });
+
+    expect(score.spike).toBe(true);
+    expect(score.sustained).toBe(true);
+    expect(score.spikeWindowStartDay).toBe(40);
+    expect(score.sustainedWindowStartDay).toBe(80);
+    expect(score.reasonCodes).toEqual([
+      "temporal_download_spike_flat_installs",
+      "temporal_sustained_downloads_flat_installs",
+    ]);
+  });
 });
 
 function publisher(
@@ -142,4 +239,16 @@ function publisher(
     ownerPublisherId: `publishers:${handleSnapshot}`,
     ...stats,
   };
+}
+
+function dailyRange(
+  startDay: number,
+  length: number,
+  stats: { downloads: number; installs: number },
+) {
+  return Array.from({ length }, (_, index) => ({
+    day: startDay + index,
+    downloads: stats.downloads,
+    installs: stats.installs,
+  }));
 }

--- a/convex/lib/publisherAbuseScoring.ts
+++ b/convex/lib/publisherAbuseScoring.ts
@@ -1,4 +1,5 @@
 export const PUBLISHER_ABUSE_MODEL_VERSION = "publisher-abuse-pressure.v1";
+export const PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION = "publisher-abuse-temporal.v1";
 
 export type PublisherAbuseLabel = "pass" | "review" | "potential_ban_candidate";
 
@@ -50,6 +51,31 @@ export type PublisherAbuseScore = PublisherAbuseRawScore & {
   zScore: number;
 };
 
+export type SkillTemporalAbuseDailyStat = {
+  day: number;
+  downloads: number;
+  installs: number;
+};
+
+export type SkillTemporalAbuseScore = {
+  spike: boolean;
+  sustained: boolean;
+  pressure: number;
+  recent7Downloads: number;
+  recent7Installs: number;
+  previous30Downloads: number;
+  baseline7Downloads: number;
+  spikeMultiplier: number;
+  recent30Downloads: number;
+  recent30Installs: number;
+  downloadInstallRatio30: number;
+  spikeWindowStartDay?: number;
+  spikeWindowEndDay?: number;
+  sustainedWindowStartDay?: number;
+  sustainedWindowEndDay?: number;
+  reasonCodes: string[];
+};
+
 export const DEFAULT_PUBLISHER_ABUSE_MODEL_CONFIG = {
   modelVersion: PUBLISHER_ABUSE_MODEL_VERSION,
   skillPivot: 100,
@@ -70,6 +96,16 @@ export const DEFAULT_PUBLISHER_ABUSE_MODEL_CONFIG = {
 } satisfies PublisherAbuseModelConfig;
 
 const MIN_PRESSURE_FOR_LOG = 1e-9;
+const TEMPORAL_SPIKE_RECENT_DAYS = 7;
+const TEMPORAL_SPIKE_BASELINE_DAYS = 30;
+const TEMPORAL_SUSTAINED_DAYS = 30;
+const TEMPORAL_MIN_SPIKE_DOWNLOADS = 1_000;
+const TEMPORAL_MAX_SPIKE_INSTALLS = 2;
+const TEMPORAL_MIN_SPIKE_MULTIPLIER = 10;
+const TEMPORAL_MIN_SUSTAINED_DOWNLOADS = 3_000;
+const TEMPORAL_MAX_SUSTAINED_INSTALLS = 5;
+const TEMPORAL_MIN_SUSTAINED_DOWNLOAD_INSTALL_RATIO = 1_000;
+const TEMPORAL_MIN_BASELINE_7_DOWNLOADS = 100;
 
 export function labelForPublisherAbuseZScore(
   zScore: number,
@@ -78,6 +114,21 @@ export function labelForPublisherAbuseZScore(
   if (zScore >= config.potentialBanCandidateZThreshold) return "potential_ban_candidate";
   if (zScore >= config.reviewZThreshold) return "review";
   return "pass";
+}
+
+export function computeTemporalPublisherAbuseZScore(input: {
+  label: PublisherAbuseLabel;
+  highTemporalSkillCount: number;
+  maxTemporalPressure: number;
+}): number {
+  if (input.label === "pass") return 0;
+
+  const pressureBoost = Math.log10(Math.max(input.maxTemporalPressure, 1) + 1) / 2;
+  const skillCountBoost = Math.max(0, input.highTemporalSkillCount - 2) * 0.2;
+  if (input.label === "potential_ban_candidate") {
+    return 2.5 + Math.min(2, pressureBoost + skillCountBoost);
+  }
+  return 1.5 + Math.min(0.99, pressureBoost);
 }
 
 export function computePublisherAbuseRawScore(
@@ -204,6 +255,65 @@ export function summarizePublisherAbuseLogPressure(
   };
 }
 
+export function computeCurrentSkillTemporalAbuseScore(input: {
+  todayDay: number;
+  dailyStats: SkillTemporalAbuseDailyStat[];
+}): SkillTemporalAbuseScore {
+  const statsByDay = aggregateSkillTemporalDailyStats(input.dailyStats);
+  return computeSkillTemporalAbuseScoreForWindows({
+    statsByDay,
+    spikeStartDay: input.todayDay - TEMPORAL_SPIKE_RECENT_DAYS + 1,
+    sustainedStartDay: input.todayDay - TEMPORAL_SUSTAINED_DAYS + 1,
+  });
+}
+
+export function computeHistoricalSkillTemporalAbuseScore(input: {
+  dailyStats: SkillTemporalAbuseDailyStat[];
+}): SkillTemporalAbuseScore {
+  const statsByDay = aggregateSkillTemporalDailyStats(input.dailyStats);
+  const days = [...statsByDay.keys()];
+  if (days.length === 0) return emptySkillTemporalAbuseScore();
+
+  const minDay = Math.min(...days);
+  const maxDay = Math.max(...days);
+  let bestSpike = emptySkillTemporalAbuseScore();
+  let bestSustained = emptySkillTemporalAbuseScore();
+
+  for (let startDay = minDay; startDay <= maxDay; startDay += 1) {
+    if (startDay + TEMPORAL_SPIKE_RECENT_DAYS - 1 <= maxDay) {
+      const score = computeSkillTemporalAbuseScoreForWindows({
+        statsByDay,
+        spikeStartDay: startDay,
+        sustainedStartDay: startDay,
+      });
+      if (score.spike && score.spikeMultiplier > bestSpike.spikeMultiplier) {
+        bestSpike = score;
+      }
+    }
+
+    if (startDay + TEMPORAL_SUSTAINED_DAYS - 1 <= maxDay) {
+      const score = computeSkillTemporalAbuseScoreForWindows({
+        statsByDay,
+        spikeStartDay: startDay,
+        sustainedStartDay: startDay,
+      });
+      if (score.sustained && score.downloadInstallRatio30 > bestSustained.downloadInstallRatio30) {
+        bestSustained = score;
+      }
+    }
+  }
+
+  return mergeTemporalAbuseWindowScores(bestSpike, bestSustained);
+}
+
+export function labelForTemporalPublisherAbuse(input: {
+  highTemporalSkillCount: number;
+}): PublisherAbuseLabel {
+  if (input.highTemporalSkillCount >= 2) return "potential_ban_candidate";
+  if (input.highTemporalSkillCount >= 1) return "review";
+  return "pass";
+}
+
 function reasonCodesForPublisher(input: {
   publishedSkills: number;
   installsPerSkill: number;
@@ -227,6 +337,137 @@ function reasonCodesForPublisher(input: {
     codes.push("extreme_volume_low_engagement");
   }
   return codes;
+}
+
+function computeSkillTemporalAbuseScoreForWindows(input: {
+  statsByDay: Map<number, { downloads: number; installs: number }>;
+  spikeStartDay: number;
+  sustainedStartDay: number;
+}): SkillTemporalAbuseScore {
+  const spikeEndDay = input.spikeStartDay + TEMPORAL_SPIKE_RECENT_DAYS - 1;
+  const sustainedEndDay = input.sustainedStartDay + TEMPORAL_SUSTAINED_DAYS - 1;
+  const recent7 = sumTemporalStatsRange(input.statsByDay, input.spikeStartDay, spikeEndDay);
+  const previous30 = sumTemporalStatsRange(
+    input.statsByDay,
+    input.spikeStartDay - TEMPORAL_SPIKE_BASELINE_DAYS,
+    input.spikeStartDay - 1,
+  );
+  const recent30 = sumTemporalStatsRange(
+    input.statsByDay,
+    input.sustainedStartDay,
+    sustainedEndDay,
+  );
+  const baseline7Downloads = Math.max(
+    TEMPORAL_MIN_BASELINE_7_DOWNLOADS,
+    (previous30.downloads / TEMPORAL_SPIKE_BASELINE_DAYS) * TEMPORAL_SPIKE_RECENT_DAYS,
+  );
+  const spikeMultiplier = baseline7Downloads > 0 ? recent7.downloads / baseline7Downloads : 0;
+  const downloadInstallRatio30 = recent30.downloads / Math.max(1, recent30.installs);
+  const spike =
+    recent7.downloads >= TEMPORAL_MIN_SPIKE_DOWNLOADS &&
+    recent7.installs <= TEMPORAL_MAX_SPIKE_INSTALLS &&
+    spikeMultiplier >= TEMPORAL_MIN_SPIKE_MULTIPLIER;
+  const sustained =
+    recent30.downloads >= TEMPORAL_MIN_SUSTAINED_DOWNLOADS &&
+    recent30.installs <= TEMPORAL_MAX_SUSTAINED_INSTALLS &&
+    downloadInstallRatio30 >= TEMPORAL_MIN_SUSTAINED_DOWNLOAD_INSTALL_RATIO;
+  const reasonCodes: string[] = [];
+  if (spike) reasonCodes.push("temporal_download_spike_flat_installs");
+  if (sustained) reasonCodes.push("temporal_sustained_downloads_flat_installs");
+
+  return {
+    spike,
+    sustained,
+    pressure: Math.max(spike ? spikeMultiplier : 0, sustained ? downloadInstallRatio30 / 1_000 : 0),
+    recent7Downloads: recent7.downloads,
+    recent7Installs: recent7.installs,
+    previous30Downloads: previous30.downloads,
+    baseline7Downloads,
+    spikeMultiplier,
+    recent30Downloads: recent30.downloads,
+    recent30Installs: recent30.installs,
+    downloadInstallRatio30,
+    spikeWindowStartDay: spike ? input.spikeStartDay : undefined,
+    spikeWindowEndDay: spike ? spikeEndDay : undefined,
+    sustainedWindowStartDay: sustained ? input.sustainedStartDay : undefined,
+    sustainedWindowEndDay: sustained ? sustainedEndDay : undefined,
+    reasonCodes,
+  };
+}
+
+function mergeTemporalAbuseWindowScores(
+  bestSpike: SkillTemporalAbuseScore,
+  bestSustained: SkillTemporalAbuseScore,
+): SkillTemporalAbuseScore {
+  if (!bestSpike.spike && !bestSustained.sustained) return emptySkillTemporalAbuseScore();
+  const reasonCodes: string[] = [];
+  if (bestSpike.spike) reasonCodes.push("temporal_download_spike_flat_installs");
+  if (bestSustained.sustained) reasonCodes.push("temporal_sustained_downloads_flat_installs");
+
+  return {
+    spike: bestSpike.spike,
+    sustained: bestSustained.sustained,
+    pressure: Math.max(bestSpike.pressure, bestSustained.pressure),
+    recent7Downloads: bestSpike.recent7Downloads,
+    recent7Installs: bestSpike.recent7Installs,
+    previous30Downloads: bestSpike.previous30Downloads,
+    baseline7Downloads: bestSpike.baseline7Downloads,
+    spikeMultiplier: bestSpike.spikeMultiplier,
+    recent30Downloads: bestSustained.recent30Downloads,
+    recent30Installs: bestSustained.recent30Installs,
+    downloadInstallRatio30: bestSustained.downloadInstallRatio30,
+    spikeWindowStartDay: bestSpike.spikeWindowStartDay,
+    spikeWindowEndDay: bestSpike.spikeWindowEndDay,
+    sustainedWindowStartDay: bestSustained.sustainedWindowStartDay,
+    sustainedWindowEndDay: bestSustained.sustainedWindowEndDay,
+    reasonCodes,
+  };
+}
+
+function aggregateSkillTemporalDailyStats(dailyStats: SkillTemporalAbuseDailyStat[]) {
+  const byDay = new Map<number, { downloads: number; installs: number }>();
+  for (const point of dailyStats) {
+    if (!Number.isFinite(point.day)) continue;
+    const day = Math.trunc(point.day);
+    const existing = byDay.get(day) ?? { downloads: 0, installs: 0 };
+    existing.downloads += nonNegative(point.downloads);
+    existing.installs += nonNegative(point.installs);
+    byDay.set(day, existing);
+  }
+  return byDay;
+}
+
+function sumTemporalStatsRange(
+  statsByDay: Map<number, { downloads: number; installs: number }>,
+  startDay: number,
+  endDay: number,
+) {
+  let downloads = 0;
+  let installs = 0;
+  for (let day = startDay; day <= endDay; day += 1) {
+    const point = statsByDay.get(day);
+    if (!point) continue;
+    downloads += point.downloads;
+    installs += point.installs;
+  }
+  return { downloads, installs };
+}
+
+function emptySkillTemporalAbuseScore(): SkillTemporalAbuseScore {
+  return {
+    spike: false,
+    sustained: false,
+    pressure: 0,
+    recent7Downloads: 0,
+    recent7Installs: 0,
+    previous30Downloads: 0,
+    baseline7Downloads: TEMPORAL_MIN_BASELINE_7_DOWNLOADS,
+    spikeMultiplier: 0,
+    recent30Downloads: 0,
+    recent30Installs: 0,
+    downloadInstallRatio30: 0,
+    reasonCodes: [],
+  };
 }
 
 function nonNegative(value: number) {

--- a/convex/publisherAbuse.test.ts
+++ b/convex/publisherAbuse.test.ts
@@ -21,10 +21,16 @@ vi.mock("./_generated/api", () => ({
   internal: {
     publisherAbuse: {
       collectPublisherAbuseScoresPageInternal: Symbol("collectPublisherAbuseScoresPageInternal"),
+      collectTemporalPublisherAbuseSkillCandidatesPageInternal: Symbol(
+        "collectTemporalPublisherAbuseSkillCandidatesPageInternal",
+      ),
       finalizePublisherAbuseScoresPageInternal: Symbol("finalizePublisherAbuseScoresPageInternal"),
       getOrStartPublisherAbuseScoreRunInternal: Symbol("getOrStartPublisherAbuseScoreRunInternal"),
       getPublisherAbuseScoreRunStateInternal: Symbol("getPublisherAbuseScoreRunStateInternal"),
       markPublisherAbuseScoreRunFailedInternal: Symbol("markPublisherAbuseScoreRunFailedInternal"),
+      persistTemporalPublisherAbuseCandidatesInternal: Symbol(
+        "persistTemporalPublisherAbuseCandidatesInternal",
+      ),
       runPublisherAbuseScoreRunInternal: Symbol("runPublisherAbuseScoreRunInternal"),
     },
     users: {
@@ -87,6 +93,88 @@ const startScoreRunHandler = (
   publisherAbuse.startPublisherAbuseScoreRun as unknown as Wrapped<
     Record<string, never>,
     { ok: true; runId: string; pages: number; isDone: boolean }
+  >
+)._handler;
+
+const temporalRunHandler = (
+  publisherAbuse.runTemporalPublisherAbuseScanInternal as unknown as Wrapped<
+    {
+      mode?: "current" | "backfill";
+      dryRun?: boolean;
+      candidateLimit?: number;
+      batchSize?: number;
+      maxPages?: number;
+      todayDay?: number;
+      lookbackDays?: number;
+      trigger?: "cron" | "manual";
+    },
+    {
+      ok: true;
+      dryRun: boolean;
+      mode: "current" | "backfill";
+      scannedSkills: number;
+      highTemporalSkills: number;
+      flaggedPublishers: number;
+      nominations: number;
+    }
+  >
+)._handler;
+
+const collectTemporalHandler = (
+  publisherAbuse.collectTemporalPublisherAbuseSkillCandidatesPageInternal as unknown as Wrapped<
+    {
+      mode: "current" | "backfill";
+      cursor?: string;
+      batchSize?: number;
+      todayDay?: number;
+      lookbackDays?: number;
+    },
+    {
+      cursor?: string;
+      isDone: boolean;
+      scannedSkills: number;
+      candidates: unknown[];
+    }
+  >
+)._handler;
+
+const persistTemporalHandler = (
+  publisherAbuse.persistTemporalPublisherAbuseCandidatesInternal as unknown as Wrapped<
+    {
+      mode: "current" | "backfill";
+      trigger: "cron" | "manual";
+      scanComplete: boolean;
+      candidates: Array<{
+        ownerKey: string;
+        ownerPublisherId?: string;
+        ownerUserId?: string;
+        handleSnapshot: string;
+        skillId: string;
+        slug: string;
+        displayName: string;
+        totalDownloads: number;
+        totalInstalls: number;
+        temporalScore: {
+          spike: boolean;
+          sustained: boolean;
+          pressure: number;
+          recent7Downloads: number;
+          recent7Installs: number;
+          previous30Downloads: number;
+          baseline7Downloads: number;
+          spikeMultiplier: number;
+          recent30Downloads: number;
+          recent30Installs: number;
+          downloadInstallRatio30: number;
+          spikeWindowStartDay?: number;
+          spikeWindowEndDay?: number;
+          sustainedWindowStartDay?: number;
+          sustainedWindowEndDay?: number;
+          reasonCodes: string[];
+        };
+      }>;
+    },
+    { runId: string; nominations: number; flaggedPublishers: number }
   >
 )._handler;
 
@@ -774,11 +862,26 @@ describe("publisher abuse dry-run persistence", () => {
     const query = vi.fn((table: string) => {
       if (table === "publisherAbuseScoreRuns") {
         return {
-          withIndex: () => ({
-            order: () => ({
-              first: async () => latestRun,
-            }),
-          }),
+          withIndex: (
+            indexName: string,
+            build: (q: { eq: (field: string, value: unknown) => unknown }) => unknown,
+          ) => {
+            expect(indexName).toBe("by_model_version_and_started_at");
+            const constraints: Record<string, unknown> = {};
+            const q = {
+              eq(field: string, value: unknown) {
+                constraints[field] = value;
+                return q;
+              },
+            };
+            build(q);
+            expect(constraints.modelVersion).toBe("publisher-abuse-pressure.v1");
+            return {
+              order: () => ({
+                first: async () => latestRun,
+              }),
+            };
+          },
         };
       }
       if (table === "publisherAbuseScores") {
@@ -3641,4 +3744,617 @@ describe("publisher abuse dry-run persistence", () => {
 
     expect(ctx.db.insert).not.toHaveBeenCalled();
   });
+
+  it("dry-runs the temporal backfill without persisting nominations", async () => {
+    const candidate = temporalCandidate("skills:polymarket-trade", {
+      slug: "polymarket-trade",
+      displayName: "Polymarket Trade",
+    });
+    const ctx = {
+      runQuery: vi.fn(async () => ({
+        cursor: undefined,
+        isDone: true,
+        scannedSkills: 1,
+        candidates: [candidate],
+      })),
+      runMutation: vi.fn(),
+    };
+
+    await expect(
+      temporalRunHandler(ctx, {
+        mode: "backfill",
+        dryRun: true,
+        candidateLimit: 1,
+        batchSize: 1,
+        maxPages: 1,
+        todayDay: 100,
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      dryRun: true,
+      mode: "backfill",
+      scannedSkills: 1,
+      highTemporalSkills: 1,
+      flaggedPublishers: 1,
+      nominations: 0,
+      candidates: [candidate],
+    });
+
+    expect(ctx.runQuery).toHaveBeenCalledTimes(1);
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it("caps temporal scan candidate limits below Convex array limits", async () => {
+    const ctx = {
+      runQuery: vi.fn(async (_query: unknown, args: { batchSize: number }) => ({
+        cursor: "next",
+        isDone: false,
+        scannedSkills: args.batchSize,
+        candidates: [],
+      })),
+      runMutation: vi.fn(),
+    };
+
+    await expect(
+      temporalRunHandler(ctx, {
+        mode: "current",
+        dryRun: true,
+        candidateLimit: 10_000,
+        batchSize: 100,
+        maxPages: 100,
+        todayDay: 100,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      dryRun: true,
+      mode: "current",
+      scannedSkills: 8_000,
+      highTemporalSkills: 0,
+      flaggedPublishers: 0,
+      nominations: 0,
+    });
+
+    expect(ctx.runQuery).toHaveBeenCalledTimes(80);
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it("persists an empty current temporal scan so stale nominations can clear", async () => {
+    const ctx = {
+      runQuery: vi.fn(async () => ({
+        cursor: undefined,
+        isDone: true,
+        scannedSkills: 12,
+        candidates: [],
+      })),
+      runMutation: vi.fn(async () => ({
+        flaggedPublishers: 0,
+        nominations: 0,
+      })),
+    };
+
+    await expect(
+      temporalRunHandler(ctx, {
+        mode: "current",
+        dryRun: false,
+        candidateLimit: 100,
+        batchSize: 50,
+        maxPages: 1,
+        todayDay: 100,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      dryRun: false,
+      mode: "current",
+      scannedSkills: 12,
+      highTemporalSkills: 0,
+      flaggedPublishers: 0,
+      nominations: 0,
+    });
+
+    expect(ctx.runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        mode: "current",
+        candidates: [],
+        scanComplete: true,
+      }),
+    );
+  });
+
+  it("caps backfill temporal page size by lookback read budget", async () => {
+    const indexBuilder = {
+      eq: vi.fn(() => indexBuilder),
+      gte: vi.fn(() => indexBuilder),
+      lte: vi.fn(() => indexBuilder),
+    };
+    const paginate = vi.fn(async () => ({
+      page: [
+        {
+          _id: "skills:quiet-old",
+          ownerPublisherId: "publishers:quiet",
+          slug: "quiet-old",
+          displayName: "Quiet Old",
+          softDeletedAt: undefined,
+          statsDownloads: 10,
+          statsInstallsAllTime: 0,
+          stats: {
+            downloads: 10,
+            stars: 0,
+            installsCurrent: 0,
+            installsAllTime: 0,
+          },
+        },
+      ],
+      isDone: true,
+      continueCursor: "",
+    }));
+    const takeDailyStats = vi.fn(async () => []);
+    const ctx = {
+      db: {
+        get: vi.fn(),
+        query: vi.fn((table: string) => {
+          if (table === "skills") {
+            return {
+              withIndex: (indexName: string, callback: (q: typeof indexBuilder) => unknown) => {
+                expect(indexName).toBe("by_active_stats_downloads");
+                callback(indexBuilder);
+                return {
+                  order: () => ({ paginate }),
+                };
+              },
+            };
+          }
+          if (table === "skillDailyStats") {
+            return {
+              withIndex: (indexName: string, callback: (q: typeof indexBuilder) => unknown) => {
+                expect(indexName).toBe("by_skill_day");
+                callback(indexBuilder);
+                return { take: takeDailyStats };
+              },
+            };
+          }
+          throw new Error(`unexpected table ${table}`);
+        }),
+      },
+    };
+
+    await expect(
+      collectTemporalHandler(ctx, {
+        mode: "backfill",
+        batchSize: 100,
+        lookbackDays: 730,
+        todayDay: 1000,
+      }),
+    ).resolves.toEqual({
+      cursor: undefined,
+      isDone: true,
+      scannedSkills: 1,
+      candidates: [],
+    });
+
+    expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 10 });
+    expect(takeDailyStats).toHaveBeenCalledWith(730);
+    expect(ctx.db.get).not.toHaveBeenCalled();
+  });
+
+  it("skips official org publishers during temporal candidate collection", async () => {
+    const indexBuilder = {
+      eq: vi.fn(() => indexBuilder),
+      gte: vi.fn(() => indexBuilder),
+      lte: vi.fn(() => indexBuilder),
+    };
+    const officialPublisher = {
+      _id: "publishers:openclaw",
+      kind: "org",
+      handle: "openclaw",
+      linkedUserId: "users:openclaw",
+    };
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === officialPublisher._id) return officialPublisher;
+          throw new Error(`unexpected get ${id}`);
+        }),
+        query: vi.fn((table: string) => {
+          if (table === "skills") {
+            return {
+              withIndex: (indexName: string, callback: (q: typeof indexBuilder) => unknown) => {
+                expect(indexName).toBe("by_active_stats_downloads");
+                callback(indexBuilder);
+                return {
+                  order: () => ({
+                    paginate: async () => ({
+                      page: [
+                        {
+                          _id: "skills:official-spike",
+                          ownerPublisherId: officialPublisher._id,
+                          slug: "official-spike",
+                          displayName: "Official Spike",
+                          softDeletedAt: undefined,
+                          statsDownloads: 10_000,
+                          statsInstallsAllTime: 0,
+                          stats: {
+                            downloads: 10_000,
+                            stars: 0,
+                            installsCurrent: 0,
+                            installsAllTime: 0,
+                          },
+                        },
+                      ],
+                      isDone: true,
+                      continueCursor: "",
+                    }),
+                  }),
+                };
+              },
+            };
+          }
+          if (table === "skillDailyStats") {
+            return {
+              withIndex: (indexName: string, callback: (q: typeof indexBuilder) => unknown) => {
+                expect(indexName).toBe("by_skill_day");
+                callback(indexBuilder);
+                return {
+                  take: async () =>
+                    Array.from({ length: 7 }, (_, index) => ({
+                      skillId: "skills:official-spike",
+                      day: 94 + index,
+                      downloads: 200,
+                      installs: 0,
+                      updatedAt: 1,
+                    })),
+                };
+              },
+            };
+          }
+          if (table === "officialPublishers") {
+            return {
+              withIndex: (indexName: string, callback: (q: typeof indexBuilder) => unknown) => {
+                expect(indexName).toBe("by_publisher");
+                callback(indexBuilder);
+                return {
+                  unique: async () => ({
+                    _id: "officialPublishers:openclaw",
+                    publisherId: officialPublisher._id,
+                  }),
+                };
+              },
+            };
+          }
+          throw new Error(`unexpected table ${table}`);
+        }),
+      },
+    };
+
+    await expect(
+      collectTemporalHandler(ctx, {
+        mode: "current",
+        batchSize: 1,
+        todayDay: 100,
+      }),
+    ).resolves.toEqual({
+      cursor: undefined,
+      isDone: true,
+      scannedSkills: 1,
+      candidates: [],
+    });
+  });
+
+  it("persists temporal abuse candidates into the existing publisher review queue", async () => {
+    const insert = vi.fn(async (table: string, _value?: unknown) => {
+      if (table === "publisherAbuseScoreRuns") return "publisherAbuseScoreRuns:temporal";
+      if (table === "publisherAbuseScores") return "publisherAbuseScores:temporal";
+      if (table === "publisherAbuseReviewNominations") {
+        return "publisherAbuseReviewNominations:temporal";
+      }
+      if (table === "publisherAbuseReviewEvents") return "publisherAbuseReviewEvents:temporal";
+      throw new Error(`unexpected insert ${table}`);
+    });
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "publisherAbuseScoreRuns:temporal") {
+            return {
+              _id: "publisherAbuseScoreRuns:temporal",
+              modelVersion: "publisher-abuse-temporal.v1",
+              modelConfig: TEST_MODEL_CONFIG,
+              trigger: "cron",
+              status: "running",
+              phase: "collecting",
+              scannedPublishers: 0,
+              scoredPublishers: 0,
+              finalizedScores: 0,
+              nominatedPublishers: 0,
+              passCount: 0,
+              reviewCount: 0,
+              potentialBanCandidateCount: 0,
+              sumLogPressure: 0,
+              sumSquaredLogPressure: 0,
+            };
+          }
+          throw new Error(`unexpected get ${id}`);
+        }),
+        insert,
+        patch: vi.fn(async () => null),
+        query: vi.fn((table: string) => {
+          if (table === "publisherAbuseReviewNominations") {
+            return {
+              withIndex: (indexName: string) => {
+                if (indexName === "by_owner_key_and_model_version") {
+                  return {
+                    first: async () => null,
+                  };
+                }
+                if (indexName === "by_status_and_model_version_and_label_and_last_scored_at") {
+                  return {
+                    order: () => ({
+                      take: async () => [],
+                    }),
+                  };
+                }
+                throw new Error(`unexpected nomination index ${indexName}`);
+              },
+            };
+          }
+          throw new Error(`unexpected query ${table}`);
+        }),
+      },
+    };
+
+    await expect(
+      persistTemporalHandler(ctx, {
+        mode: "current",
+        trigger: "cron",
+        scanComplete: true,
+        candidates: [
+          temporalCandidate("skills:first", { slug: "first", displayName: "First" }),
+          temporalCandidate("skills:second", { slug: "second", displayName: "Second" }),
+        ],
+      }),
+    ).resolves.toEqual({
+      runId: "publisherAbuseScoreRuns:temporal",
+      flaggedPublishers: 1,
+      nominations: 1,
+    });
+
+    expect(insert).toHaveBeenCalledWith(
+      "publisherAbuseScores",
+      expect.objectContaining({
+        ownerKey: "publisher:publishers:pollyreach",
+        label: "potential_ban_candidate",
+        zScore: expect.any(Number),
+        temporalHighSkillCount: 2,
+        temporalSpikeSkillCount: 2,
+        temporalSustainedSkillCount: 0,
+      }),
+    );
+    expect(insert).toHaveBeenCalledWith(
+      "publisherAbuseReviewNominations",
+      expect.objectContaining({
+        ownerKey: "publisher:publishers:pollyreach",
+        label: "potential_ban_candidate",
+        latestScoreId: "publisherAbuseScores:temporal",
+      }),
+    );
+    const scoreInsertPayload = insert.mock.calls.find(
+      ([table]) => table === "publisherAbuseScores",
+    )?.[1] as { zScore: number } | undefined;
+    expect(scoreInsertPayload).toEqual(expect.objectContaining({ zScore: expect.any(Number) }));
+    expect(scoreInsertPayload?.zScore).toBeGreaterThanOrEqual(2.5);
+  });
+
+  it("does not clear stale temporal nominations when the current scan is partial", async () => {
+    const insert = vi.fn(async (table: string) => {
+      if (table === "publisherAbuseScoreRuns") return "publisherAbuseScoreRuns:temporal";
+      throw new Error(`unexpected insert ${table}`);
+    });
+    const patch = vi.fn(async () => null);
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "publisherAbuseScoreRuns:temporal") {
+            return {
+              _id: "publisherAbuseScoreRuns:temporal",
+              modelVersion: "publisher-abuse-temporal.v1",
+              modelConfig: TEST_MODEL_CONFIG,
+              trigger: "cron",
+              status: "running",
+              phase: "collecting",
+              scannedPublishers: 0,
+              scoredPublishers: 0,
+              finalizedScores: 0,
+              nominatedPublishers: 0,
+              passCount: 0,
+              reviewCount: 0,
+              potentialBanCandidateCount: 0,
+              sumLogPressure: 0,
+              sumSquaredLogPressure: 0,
+            };
+          }
+          throw new Error(`unexpected get ${id}`);
+        }),
+        insert,
+        patch,
+        query: vi.fn(() => {
+          throw new Error("stale nominations must not be queried for a partial scan");
+        }),
+      },
+    };
+
+    await expect(
+      persistTemporalHandler(ctx, {
+        mode: "current",
+        trigger: "cron",
+        scanComplete: false,
+        candidates: [],
+      }),
+    ).resolves.toEqual({
+      runId: "publisherAbuseScoreRuns:temporal",
+      flaggedPublishers: 0,
+      nominations: 0,
+    });
+
+    expect(insert).toHaveBeenCalledTimes(1);
+    expect(patch).toHaveBeenCalledWith(
+      "publisherAbuseScoreRuns:temporal",
+      expect.objectContaining({
+        passCount: 0,
+        scoredPublishers: 0,
+        finalizedScores: 0,
+      }),
+    );
+  });
+
+  it("writes pass scores for stale temporal nominations when current signals clear", async () => {
+    const insert = vi.fn(async (table: string) => {
+      if (table === "publisherAbuseScoreRuns") return "publisherAbuseScoreRuns:temporal";
+      if (table === "publisherAbuseScores") return "publisherAbuseScores:pass";
+      if (table === "publisherAbuseReviewEvents") return "publisherAbuseReviewEvents:pass";
+      throw new Error(`unexpected insert ${table}`);
+    });
+    const patch = vi.fn(async () => null);
+    const staleNomination = {
+      _id: "publisherAbuseReviewNominations:stale",
+      ownerKey: "publisher:publishers:stale",
+      ownerPublisherId: "publishers:stale",
+      ownerUserId: "users:stale",
+      handleSnapshot: "stale-pub",
+      latestScoreId: "publisherAbuseScores:old",
+      modelVersion: "publisher-abuse-temporal.v1",
+      label: "review",
+      status: "pending",
+      openedAt: 1,
+      openedByRunId: "publisherAbuseScoreRuns:old",
+      lastScoredAt: 1,
+      updatedAt: 1,
+    };
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "publisherAbuseScoreRuns:temporal") {
+            return {
+              _id: "publisherAbuseScoreRuns:temporal",
+              modelVersion: "publisher-abuse-temporal.v1",
+              modelConfig: TEST_MODEL_CONFIG,
+              trigger: "cron",
+              status: "running",
+              phase: "collecting",
+              scannedPublishers: 0,
+              scoredPublishers: 0,
+              finalizedScores: 0,
+              nominatedPublishers: 0,
+              passCount: 0,
+              reviewCount: 0,
+              potentialBanCandidateCount: 0,
+              sumLogPressure: 0,
+              sumSquaredLogPressure: 0,
+            };
+          }
+          throw new Error(`unexpected get ${id}`);
+        }),
+        insert,
+        patch,
+        query: vi.fn((table: string) => {
+          if (table === "publisherAbuseReviewNominations") {
+            return {
+              withIndex: (
+                indexName: string,
+                build: (q: { eq: (field: string, value: unknown) => unknown }) => unknown,
+              ) => {
+                const constraints: Record<string, unknown> = {};
+                const q = {
+                  eq(field: string, value: unknown) {
+                    constraints[field] = value;
+                    return q;
+                  },
+                };
+                build(q);
+                if (indexName === "by_status_and_model_version_and_label_and_last_scored_at") {
+                  return {
+                    order: () => ({
+                      take: async () => (constraints.label === "review" ? [staleNomination] : []),
+                    }),
+                  };
+                }
+                if (indexName === "by_owner_key_and_model_version") {
+                  return {
+                    first: async () => staleNomination,
+                  };
+                }
+                throw new Error(`unexpected nomination index ${indexName}`);
+              },
+            };
+          }
+          throw new Error(`unexpected query ${table}`);
+        }),
+      },
+    };
+
+    await expect(
+      persistTemporalHandler(ctx, {
+        mode: "current",
+        trigger: "cron",
+        scanComplete: true,
+        candidates: [],
+      }),
+    ).resolves.toEqual({
+      runId: "publisherAbuseScoreRuns:temporal",
+      flaggedPublishers: 0,
+      nominations: 0,
+    });
+
+    expect(insert).toHaveBeenCalledWith(
+      "publisherAbuseScores",
+      expect.objectContaining({
+        ownerKey: staleNomination.ownerKey,
+        label: "pass",
+        temporalHighSkillCount: 0,
+      }),
+    );
+    expect(patch).toHaveBeenCalledWith(
+      staleNomination._id,
+      expect.objectContaining({
+        latestScoreId: "publisherAbuseScores:pass",
+        label: "pass",
+      }),
+    );
+    expect(patch).toHaveBeenCalledWith(
+      "publisherAbuseScoreRuns:temporal",
+      expect.objectContaining({
+        passCount: 1,
+        scoredPublishers: 1,
+        finalizedScores: 1,
+      }),
+    );
+  });
 });
+
+function temporalCandidate(skillId: string, skill: { slug: string; displayName: string }) {
+  return {
+    ownerKey: "publisher:publishers:pollyreach",
+    ownerPublisherId: "publishers:pollyreach",
+    ownerUserId: "users:joel",
+    handleSnapshot: "pollyreach",
+    skillId,
+    slug: skill.slug,
+    displayName: skill.displayName,
+    totalDownloads: 10_000,
+    totalInstalls: 0,
+    temporalScore: {
+      spike: true,
+      sustained: false,
+      pressure: 20,
+      recent7Downloads: 2_000,
+      recent7Installs: 0,
+      previous30Downloads: 100,
+      baseline7Downloads: 100,
+      spikeMultiplier: 20,
+      recent30Downloads: 2_000,
+      recent30Installs: 0,
+      downloadInstallRatio30: 2_000,
+      spikeWindowStartDay: 94,
+      spikeWindowEndDay: 100,
+      reasonCodes: ["temporal_download_spike_flat_installs"],
+    },
+  };
+}

--- a/convex/publisherAbuse.ts
+++ b/convex/publisherAbuse.ts
@@ -11,16 +11,24 @@ import {
   query,
 } from "./functions";
 import { assertModerator, requireUser, requireUserFromAction } from "./lib/access";
+import { toDayKey } from "./lib/leaderboards";
 import { hasOfficialPublisherRow } from "./lib/officialPublishers";
 import {
+  computeCurrentSkillTemporalAbuseScore,
+  computeHistoricalSkillTemporalAbuseScore,
   computePublisherAbuseRawScore,
+  computeTemporalPublisherAbuseZScore,
   DEFAULT_PUBLISHER_ABUSE_MODEL_CONFIG,
+  labelForTemporalPublisherAbuse,
   labelForPublisherAbuseZScore,
+  PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION,
   summarizePublisherAbuseLogPressure,
   type PublisherAbuseInput,
   type PublisherAbuseLabel,
+  type SkillTemporalAbuseScore,
 } from "./lib/publisherAbuseScoring";
 import { getSkillPublisherContribution } from "./lib/publisherStats";
+import { readCanonicalStat } from "./lib/skillStats";
 
 const DEFAULT_BATCH_SIZE = 250;
 const MAX_BATCH_SIZE = 1000;
@@ -33,11 +41,25 @@ const MAX_REVIEW_DASHBOARD_SCAN_MULTIPLIER = 3;
 const MAX_REVIEW_DASHBOARD_SCORE_SCAN_MULTIPLIER = 32;
 const MAX_REVIEW_DASHBOARD_SCORE_SCAN = 2000;
 const MAX_BAN_REASON_LENGTH = 500;
+const DEFAULT_TEMPORAL_BATCH_SIZE = 50;
+const MAX_TEMPORAL_BATCH_SIZE = 100;
+const DEFAULT_TEMPORAL_CANDIDATE_LIMIT = 1000;
+const MAX_TEMPORAL_CANDIDATE_LIMIT = 8_000;
+const DEFAULT_TEMPORAL_MAX_PAGES = 20;
+const MAX_TEMPORAL_MAX_PAGES = 100;
+const CURRENT_TEMPORAL_LOOKBACK_DAYS = 37;
+const DEFAULT_BACKFILL_TEMPORAL_LOOKBACK_DAYS = 365;
+const MAX_BACKFILL_TEMPORAL_LOOKBACK_DAYS = 730;
+const MAX_TEMPORAL_DAILY_STAT_READS_PER_PAGE = 8_000;
+const MAX_TEMPORAL_DRY_RUN_CANDIDATES = 50;
+const MAX_TEMPORAL_EVIDENCE_SKILLS = 5;
+const MAX_TEMPORAL_STALE_NOMINATION_CLEARS = 250;
 
 type TriageStatus = Doc<"publisherAbuseReviewNominations">["status"];
 type ScoreRun = Doc<"publisherAbuseScoreRuns">;
 type ScoreDoc = Doc<"publisherAbuseScores">;
 type RunPhase = ScoreRun["phase"];
+type TemporalAbuseMode = "current" | "backfill";
 
 type RunState = {
   runId: Id<"publisherAbuseScoreRuns">;
@@ -74,6 +96,73 @@ type PublisherAbuseExclusionPublisher = Pick<
   Doc<"publishers">,
   "_id" | "kind" | "deletedAt" | "deactivatedAt"
 >;
+
+type TemporalSkillCandidate = {
+  ownerKey: string;
+  ownerPublisherId?: Id<"publishers">;
+  ownerUserId?: Id<"users">;
+  handleSnapshot: string;
+  skillId: Id<"skills">;
+  slug: string;
+  displayName: string;
+  totalDownloads: number;
+  totalInstalls: number;
+  temporalScore: SkillTemporalAbuseScore;
+};
+
+type TemporalSkillCandidatesPage = {
+  cursor?: string;
+  isDone: boolean;
+  scannedSkills: number;
+  candidates: TemporalSkillCandidate[];
+};
+
+type TemporalPublisherAggregate = {
+  ownerKey: string;
+  ownerPublisherId?: Id<"publishers">;
+  ownerUserId?: Id<"users">;
+  handleSnapshot: string;
+  highTemporalSkillCount: number;
+  spikeSkillCount: number;
+  sustainedSkillCount: number;
+  maxTemporalPressure: number;
+  totalDownloads: number;
+  totalInstalls: number;
+  reasonCodes: string[];
+  evidence: TemporalSkillCandidate[];
+};
+
+const temporalScoreValidator = v.object({
+  spike: v.boolean(),
+  sustained: v.boolean(),
+  pressure: v.number(),
+  recent7Downloads: v.number(),
+  recent7Installs: v.number(),
+  previous30Downloads: v.number(),
+  baseline7Downloads: v.number(),
+  spikeMultiplier: v.number(),
+  recent30Downloads: v.number(),
+  recent30Installs: v.number(),
+  downloadInstallRatio30: v.number(),
+  spikeWindowStartDay: v.optional(v.number()),
+  spikeWindowEndDay: v.optional(v.number()),
+  sustainedWindowStartDay: v.optional(v.number()),
+  sustainedWindowEndDay: v.optional(v.number()),
+  reasonCodes: v.array(v.string()),
+});
+
+const temporalCandidateValidator = v.object({
+  ownerKey: v.string(),
+  ownerPublisherId: v.optional(v.id("publishers")),
+  ownerUserId: v.optional(v.id("users")),
+  handleSnapshot: v.string(),
+  skillId: v.id("skills"),
+  slug: v.string(),
+  displayName: v.string(),
+  totalDownloads: v.number(),
+  totalInstalls: v.number(),
+  temporalScore: temporalScoreValidator,
+});
 
 type PublisherSkillMetricsOptions =
   | {
@@ -349,6 +438,43 @@ export const runPublisherAbuseScoreRunInternal = internalAction({
     actorUserId: v.optional(v.id("users")),
   },
   handler: runPublisherAbuseScoreRunInternalHandler,
+});
+
+export const collectTemporalPublisherAbuseSkillCandidatesPageInternal = internalQuery({
+  args: {
+    mode: v.union(v.literal("current"), v.literal("backfill")),
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+    todayDay: v.optional(v.number()),
+    lookbackDays: v.optional(v.number()),
+  },
+  handler: collectTemporalPublisherAbuseSkillCandidatesPageInternalHandler,
+});
+
+export const persistTemporalPublisherAbuseCandidatesInternal = internalMutation({
+  args: {
+    mode: v.union(v.literal("current"), v.literal("backfill")),
+    trigger: v.union(v.literal("cron"), v.literal("manual")),
+    actorUserId: v.optional(v.id("users")),
+    candidates: v.array(temporalCandidateValidator),
+    scanComplete: v.boolean(),
+  },
+  handler: persistTemporalPublisherAbuseCandidatesInternalHandler,
+});
+
+export const runTemporalPublisherAbuseScanInternal = internalAction({
+  args: {
+    mode: v.optional(v.union(v.literal("current"), v.literal("backfill"))),
+    dryRun: v.optional(v.boolean()),
+    candidateLimit: v.optional(v.number()),
+    batchSize: v.optional(v.number()),
+    maxPages: v.optional(v.number()),
+    todayDay: v.optional(v.number()),
+    lookbackDays: v.optional(v.number()),
+    trigger: v.optional(v.union(v.literal("cron"), v.literal("manual"))),
+    actorUserId: v.optional(v.id("users")),
+  },
+  handler: runTemporalPublisherAbuseScanInternalHandler,
 });
 
 export async function collectPublisherAbuseScoresPageInternalHandler(
@@ -638,6 +764,350 @@ export async function runPublisherAbuseScoreRunInternalHandler(
   return { ok: true, runId: state.runId, pages, isDone: false };
 }
 
+export async function collectTemporalPublisherAbuseSkillCandidatesPageInternalHandler(
+  ctx: QueryCtx,
+  args: {
+    mode: TemporalAbuseMode;
+    cursor?: string;
+    batchSize?: number;
+    todayDay?: number;
+    lookbackDays?: number;
+  },
+): Promise<TemporalSkillCandidatesPage> {
+  const todayDay = args.todayDay ?? toDayKey(Date.now());
+  const lookbackDays =
+    args.mode === "backfill"
+      ? clampInt(
+          args.lookbackDays ?? DEFAULT_BACKFILL_TEMPORAL_LOOKBACK_DAYS,
+          CURRENT_TEMPORAL_LOOKBACK_DAYS,
+          MAX_BACKFILL_TEMPORAL_LOOKBACK_DAYS,
+        )
+      : CURRENT_TEMPORAL_LOOKBACK_DAYS;
+  const batchSize = temporalBatchSizeForLookback(
+    args.batchSize ?? DEFAULT_TEMPORAL_BATCH_SIZE,
+    lookbackDays,
+  );
+  const startDay = todayDay - lookbackDays + 1;
+  const page = await ctx.db
+    .query("skills")
+    .withIndex("by_active_stats_downloads", (q) => q.eq("softDeletedAt", undefined))
+    .order("desc")
+    .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
+
+  const candidates: TemporalSkillCandidate[] = [];
+  for (const skill of page.page) {
+    if (!skill.ownerPublisherId) continue;
+    const dailyStats = await ctx.db
+      .query("skillDailyStats")
+      .withIndex("by_skill_day", (q) =>
+        q.eq("skillId", skill._id).gte("day", startDay).lte("day", todayDay),
+      )
+      .take(lookbackDays);
+    const temporalScore =
+      args.mode === "backfill"
+        ? computeHistoricalSkillTemporalAbuseScore({ dailyStats })
+        : computeCurrentSkillTemporalAbuseScore({ todayDay, dailyStats });
+    if (!temporalScore.spike && !temporalScore.sustained) continue;
+
+    const publisher = await ctx.db.get(skill.ownerPublisherId);
+    if (!publisher || (await isPublisherExcludedFromPublisherAbuse(ctx, publisher))) continue;
+    candidates.push({
+      ownerKey: `publisher:${publisher._id}`,
+      ownerPublisherId: publisher._id,
+      ownerUserId: publisher.linkedUserId,
+      handleSnapshot: publisher.handle,
+      skillId: skill._id,
+      slug: skill.slug,
+      displayName: skill.displayName,
+      totalDownloads: readCanonicalStat(skill, "downloads"),
+      totalInstalls: readCanonicalStat(skill, "installsAllTime"),
+      temporalScore,
+    });
+  }
+
+  return {
+    cursor: page.isDone ? undefined : page.continueCursor,
+    isDone: page.isDone,
+    scannedSkills: page.page.length,
+    candidates,
+  };
+}
+
+export async function persistTemporalPublisherAbuseCandidatesInternalHandler(
+  ctx: MutationCtx,
+  args: {
+    mode: TemporalAbuseMode;
+    trigger: "cron" | "manual";
+    actorUserId?: Id<"users">;
+    candidates: TemporalSkillCandidate[];
+    scanComplete: boolean;
+  },
+): Promise<{
+  runId: Id<"publisherAbuseScoreRuns">;
+  nominations: number;
+  flaggedPublishers: number;
+}> {
+  const aggregates = aggregateTemporalPublisherCandidates(args.candidates);
+  const runId = await createTemporalPublisherAbuseScoreRun(ctx, {
+    trigger: args.trigger,
+    actorUserId: args.actorUserId,
+  });
+  const run = await ctx.db.get(runId);
+  if (!run) throw new Error("Temporal publisher abuse score run not found");
+
+  const now = Date.now();
+  let nominations = 0;
+  let rank = 0;
+  const sortedAggregates = [...aggregates].sort(
+    (left, right) =>
+      right.highTemporalSkillCount - left.highTemporalSkillCount ||
+      right.maxTemporalPressure - left.maxTemporalPressure ||
+      left.handleSnapshot.localeCompare(right.handleSnapshot),
+  );
+  for (const aggregate of sortedAggregates) {
+    rank += 1;
+    const label = labelForTemporalPublisherAbuse({
+      highTemporalSkillCount: aggregate.highTemporalSkillCount,
+    });
+    if (label === "pass") continue;
+    const pressure = 1_000 + aggregate.highTemporalSkillCount * 100 + aggregate.maxTemporalPressure;
+    const zScore = computeTemporalPublisherAbuseZScore({
+      label,
+      highTemporalSkillCount: aggregate.highTemporalSkillCount,
+      maxTemporalPressure: aggregate.maxTemporalPressure,
+    });
+    const scoreData = {
+      runId,
+      ownerKey: aggregate.ownerKey,
+      ownerPublisherId: aggregate.ownerPublisherId,
+      ownerUserId: aggregate.ownerUserId,
+      handleSnapshot: aggregate.handleSnapshot,
+      modelVersion: PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION,
+      label,
+      rank,
+      pressure,
+      logPressure: Math.log10(Math.max(pressure, 1)),
+      zScore,
+      publishedSkills: aggregate.highTemporalSkillCount,
+      totalInstalls: aggregate.totalInstalls,
+      totalStars: 0,
+      totalDownloads: aggregate.totalDownloads,
+      installsPerSkill: aggregate.totalInstalls / Math.max(1, aggregate.highTemporalSkillCount),
+      starsPerSkill: 0,
+      downloadsPerSkill: aggregate.totalDownloads / Math.max(1, aggregate.highTemporalSkillCount),
+      reasonCodes: aggregate.reasonCodes,
+      temporalHighSkillCount: aggregate.highTemporalSkillCount,
+      temporalSpikeSkillCount: aggregate.spikeSkillCount,
+      temporalSustainedSkillCount: aggregate.sustainedSkillCount,
+      temporalMaxPressure: aggregate.maxTemporalPressure,
+      temporalEvidence: aggregate.evidence
+        .sort((left, right) => right.temporalScore.pressure - left.temporalScore.pressure)
+        .slice(0, MAX_TEMPORAL_EVIDENCE_SKILLS)
+        .map(temporalEvidenceFromCandidate),
+      createdAt: now,
+    };
+    const scoreId = await ctx.db.insert("publisherAbuseScores", scoreData);
+    await upsertPublisherAbuseReviewNomination(ctx, {
+      score: { _id: scoreId, _creationTime: now, ...scoreData } as ScoreDoc,
+      run,
+      now,
+    });
+    nominations += 1;
+  }
+  const clearedNominations =
+    args.mode === "current" && args.scanComplete
+      ? await clearStaleTemporalPublisherAbuseNominations(ctx, {
+          run,
+          activeOwnerKeys: new Set(sortedAggregates.map((aggregate) => aggregate.ownerKey)),
+          startingRank: sortedAggregates.length,
+          now,
+        })
+      : 0;
+
+  await ctx.db.patch(runId, {
+    status: "completed",
+    phase: "completed",
+    scannedPublishers: sortedAggregates.length + clearedNominations,
+    scoredPublishers: sortedAggregates.length + clearedNominations,
+    finalizedScores: sortedAggregates.length + clearedNominations,
+    nominatedPublishers: nominations,
+    passCount: clearedNominations,
+    reviewCount: sortedAggregates.filter((aggregate) => aggregate.highTemporalSkillCount === 1)
+      .length,
+    potentialBanCandidateCount: sortedAggregates.filter(
+      (aggregate) => aggregate.highTemporalSkillCount >= 2,
+    ).length,
+    completedAt: now,
+    updatedAt: now,
+  });
+
+  return { runId, nominations, flaggedPublishers: sortedAggregates.length };
+}
+
+export async function runTemporalPublisherAbuseScanInternalHandler(
+  ctx: ActionCtx,
+  args: {
+    mode?: TemporalAbuseMode;
+    dryRun?: boolean;
+    candidateLimit?: number;
+    batchSize?: number;
+    maxPages?: number;
+    todayDay?: number;
+    lookbackDays?: number;
+    trigger?: "cron" | "manual";
+    actorUserId?: Id<"users">;
+  },
+): Promise<{
+  ok: true;
+  dryRun: boolean;
+  mode: TemporalAbuseMode;
+  scannedSkills: number;
+  highTemporalSkills: number;
+  flaggedPublishers: number;
+  nominations: number;
+  candidates?: TemporalSkillCandidate[];
+}> {
+  const mode = args.mode ?? "current";
+  const dryRun = args.dryRun ?? false;
+  const candidateLimit = clampInt(
+    args.candidateLimit ?? DEFAULT_TEMPORAL_CANDIDATE_LIMIT,
+    1,
+    MAX_TEMPORAL_CANDIDATE_LIMIT,
+  );
+  const batchSize = clampInt(
+    args.batchSize ?? DEFAULT_TEMPORAL_BATCH_SIZE,
+    1,
+    MAX_TEMPORAL_BATCH_SIZE,
+  );
+  const maxPages = clampInt(args.maxPages ?? DEFAULT_TEMPORAL_MAX_PAGES, 1, MAX_TEMPORAL_MAX_PAGES);
+
+  let cursor: string | undefined;
+  let scannedSkills = 0;
+  let pages = 0;
+  let scanComplete = false;
+  const candidates: TemporalSkillCandidate[] = [];
+  while (pages < maxPages && scannedSkills < candidateLimit) {
+    const result: TemporalSkillCandidatesPage = await ctx.runQuery(
+      internal.publisherAbuse.collectTemporalPublisherAbuseSkillCandidatesPageInternal,
+      {
+        mode,
+        cursor,
+        batchSize: Math.min(batchSize, candidateLimit - scannedSkills),
+        todayDay: args.todayDay,
+        lookbackDays: args.lookbackDays,
+      },
+    );
+    pages += 1;
+    scannedSkills += result.scannedSkills;
+    candidates.push(...result.candidates);
+    cursor = result.cursor;
+    if (result.isDone || !cursor) {
+      scanComplete = true;
+      break;
+    }
+  }
+
+  const flaggedPublishers = aggregateTemporalPublisherCandidates(candidates).length;
+  if (dryRun || (mode !== "current" && candidates.length === 0)) {
+    return {
+      ok: true,
+      dryRun,
+      mode,
+      scannedSkills,
+      highTemporalSkills: candidates.length,
+      flaggedPublishers,
+      nominations: 0,
+      ...(dryRun ? { candidates: candidates.slice(0, MAX_TEMPORAL_DRY_RUN_CANDIDATES) } : {}),
+    };
+  }
+
+  const persisted: { nominations: number; flaggedPublishers: number } = await ctx.runMutation(
+    internal.publisherAbuse.persistTemporalPublisherAbuseCandidatesInternal,
+    {
+      mode,
+      trigger: args.trigger ?? "cron",
+      actorUserId: args.actorUserId,
+      candidates,
+      scanComplete,
+    },
+  );
+  return {
+    ok: true,
+    dryRun,
+    mode,
+    scannedSkills,
+    highTemporalSkills: candidates.length,
+    flaggedPublishers: persisted.flaggedPublishers,
+    nominations: persisted.nominations,
+  };
+}
+
+async function clearStaleTemporalPublisherAbuseNominations(
+  ctx: Pick<MutationCtx, "db">,
+  args: {
+    run: ScoreRun;
+    activeOwnerKeys: Set<string>;
+    startingRank: number;
+    now: number;
+  },
+) {
+  let cleared = 0;
+  for (const label of [
+    "potential_ban_candidate",
+    "review",
+  ] satisfies PendingPublisherAbuseReviewLabel[]) {
+    const nominations = await ctx.db
+      .query("publisherAbuseReviewNominations")
+      .withIndex("by_status_and_model_version_and_label_and_last_scored_at", (q) =>
+        q
+          .eq("status", "pending")
+          .eq("modelVersion", PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION)
+          .eq("label", label),
+      )
+      .order("desc")
+      .take(MAX_TEMPORAL_STALE_NOMINATION_CLEARS - cleared);
+    for (const nomination of nominations) {
+      if (args.activeOwnerKeys.has(nomination.ownerKey)) continue;
+      const scoreData = {
+        runId: args.run._id,
+        ownerKey: nomination.ownerKey,
+        ownerPublisherId: nomination.ownerPublisherId,
+        ownerUserId: nomination.ownerUserId,
+        handleSnapshot: nomination.handleSnapshot,
+        modelVersion: PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION,
+        label: "pass" as const,
+        rank: args.startingRank + cleared + 1,
+        pressure: 0,
+        logPressure: 0,
+        zScore: 0,
+        publishedSkills: 0,
+        totalInstalls: 0,
+        totalStars: 0,
+        totalDownloads: 0,
+        installsPerSkill: 0,
+        starsPerSkill: 0,
+        downloadsPerSkill: 0,
+        reasonCodes: [],
+        temporalHighSkillCount: 0,
+        temporalSpikeSkillCount: 0,
+        temporalSustainedSkillCount: 0,
+        temporalMaxPressure: 0,
+        temporalEvidence: [],
+        createdAt: args.now,
+      };
+      const scoreId = await ctx.db.insert("publisherAbuseScores", scoreData);
+      await updateExistingPublisherAbuseReviewNominationForPass(ctx, {
+        score: { _id: scoreId, _creationTime: args.now, ...scoreData } as ScoreDoc,
+        run: args.run,
+        now: args.now,
+      });
+      cleared += 1;
+      if (cleared >= MAX_TEMPORAL_STALE_NOMINATION_CLEARS) return cleared;
+    }
+  }
+  return cleared;
+}
+
 async function createPublisherAbuseScoreRun(
   ctx: Pick<MutationCtx, "db">,
   args: {
@@ -665,6 +1135,99 @@ async function createPublisherAbuseScoreRun(
     sumLogPressure: 0,
     sumSquaredLogPressure: 0,
   });
+}
+
+async function createTemporalPublisherAbuseScoreRun(
+  ctx: Pick<MutationCtx, "db">,
+  args: {
+    trigger: "cron" | "manual";
+    actorUserId?: Id<"users">;
+  },
+) {
+  const now = Date.now();
+  return await ctx.db.insert("publisherAbuseScoreRuns", {
+    modelVersion: PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION,
+    modelConfig: DEFAULT_PUBLISHER_ABUSE_MODEL_CONFIG,
+    trigger: args.trigger,
+    actorUserId: args.actorUserId,
+    status: "running",
+    phase: "collecting",
+    startedAt: now,
+    updatedAt: now,
+    scannedPublishers: 0,
+    scoredPublishers: 0,
+    finalizedScores: 0,
+    nominatedPublishers: 0,
+    passCount: 0,
+    reviewCount: 0,
+    potentialBanCandidateCount: 0,
+    sumLogPressure: 0,
+    sumSquaredLogPressure: 0,
+  });
+}
+
+function aggregateTemporalPublisherCandidates(candidates: TemporalSkillCandidate[]) {
+  const byOwner = new Map<string, TemporalPublisherAggregate>();
+  for (const candidate of candidates) {
+    const existing = byOwner.get(candidate.ownerKey) ?? {
+      ownerKey: candidate.ownerKey,
+      ownerPublisherId: candidate.ownerPublisherId,
+      ownerUserId: candidate.ownerUserId,
+      handleSnapshot: candidate.handleSnapshot,
+      highTemporalSkillCount: 0,
+      spikeSkillCount: 0,
+      sustainedSkillCount: 0,
+      maxTemporalPressure: 0,
+      totalDownloads: 0,
+      totalInstalls: 0,
+      reasonCodes: [],
+      evidence: [],
+    };
+    existing.highTemporalSkillCount += 1;
+    if (candidate.temporalScore.spike) existing.spikeSkillCount += 1;
+    if (candidate.temporalScore.sustained) existing.sustainedSkillCount += 1;
+    existing.maxTemporalPressure = Math.max(
+      existing.maxTemporalPressure,
+      candidate.temporalScore.pressure,
+    );
+    existing.totalDownloads += nonNegative(candidate.totalDownloads);
+    existing.totalInstalls += nonNegative(candidate.totalInstalls);
+    existing.reasonCodes = uniqueStrings([
+      ...existing.reasonCodes,
+      ...candidate.temporalScore.reasonCodes,
+    ]);
+    existing.evidence.push(candidate);
+    byOwner.set(candidate.ownerKey, existing);
+  }
+  return [...byOwner.values()];
+}
+
+function temporalEvidenceFromCandidate(candidate: TemporalSkillCandidate) {
+  return {
+    skillId: candidate.skillId,
+    slug: candidate.slug,
+    displayName: candidate.displayName,
+    spike: candidate.temporalScore.spike,
+    sustained: candidate.temporalScore.sustained,
+    pressure: candidate.temporalScore.pressure,
+    recent7Downloads: candidate.temporalScore.recent7Downloads,
+    recent7Installs: candidate.temporalScore.recent7Installs,
+    previous30Downloads: candidate.temporalScore.previous30Downloads,
+    baseline7Downloads: candidate.temporalScore.baseline7Downloads,
+    spikeMultiplier: candidate.temporalScore.spikeMultiplier,
+    recent30Downloads: candidate.temporalScore.recent30Downloads,
+    recent30Installs: candidate.temporalScore.recent30Installs,
+    downloadInstallRatio30: candidate.temporalScore.downloadInstallRatio30,
+    spikeWindowStartDay: candidate.temporalScore.spikeWindowStartDay,
+    spikeWindowEndDay: candidate.temporalScore.spikeWindowEndDay,
+    sustainedWindowStartDay: candidate.temporalScore.sustainedWindowStartDay,
+    sustainedWindowEndDay: candidate.temporalScore.sustainedWindowEndDay,
+    reasonCodes: candidate.temporalScore.reasonCodes,
+  };
+}
+
+function uniqueStrings(values: string[]) {
+  return [...new Set(values)];
 }
 
 async function getActivePublisherAbuseScoreRun(ctx: Pick<MutationCtx, "db">) {
@@ -1152,7 +1715,9 @@ async function getPendingPublisherAbuseReviewItemsForLabelFromLastScoredAt(
 async function getLatestPublisherAbuseScoreRun(ctx: QueryCtx) {
   return await ctx.db
     .query("publisherAbuseScoreRuns")
-    .withIndex("by_started_at")
+    .withIndex("by_model_version_and_started_at", (q) =>
+      q.eq("modelVersion", DEFAULT_PUBLISHER_ABUSE_MODEL_CONFIG.modelVersion),
+    )
     .order("desc")
     .first();
 }
@@ -1316,4 +1881,12 @@ function nonNegative(value: number | undefined) {
 function clampInt(value: number, min: number, max: number) {
   if (!Number.isFinite(value)) return min;
   return Math.min(max, Math.max(min, Math.trunc(value)));
+}
+
+function temporalBatchSizeForLookback(requestedBatchSize: number, lookbackDays: number) {
+  const maxBatchForLookback = Math.max(
+    1,
+    Math.floor(MAX_TEMPORAL_DAILY_STAT_READS_PER_PAGE / Math.max(1, lookbackDays)),
+  );
+  return clampInt(requestedBatchSize, 1, Math.min(MAX_TEMPORAL_BATCH_SIZE, maxBatchForLookback));
 }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2116,6 +2116,7 @@ const publisherAbuseScoreRuns = defineTable({
   errorMessage: v.optional(v.string()),
 })
   .index("by_status_and_updated_at", ["status", "updatedAt"])
+  .index("by_model_version_and_started_at", ["modelVersion", "startedAt"])
   .index("by_started_at", ["startedAt"]);
 
 const publisherAbuseScores = defineTable({
@@ -2138,6 +2139,35 @@ const publisherAbuseScores = defineTable({
   starsPerSkill: v.number(),
   downloadsPerSkill: v.number(),
   reasonCodes: v.array(v.string()),
+  temporalHighSkillCount: v.optional(v.number()),
+  temporalSpikeSkillCount: v.optional(v.number()),
+  temporalSustainedSkillCount: v.optional(v.number()),
+  temporalMaxPressure: v.optional(v.number()),
+  temporalEvidence: v.optional(
+    v.array(
+      v.object({
+        skillId: v.id("skills"),
+        slug: v.string(),
+        displayName: v.string(),
+        spike: v.boolean(),
+        sustained: v.boolean(),
+        pressure: v.number(),
+        recent7Downloads: v.number(),
+        recent7Installs: v.number(),
+        previous30Downloads: v.number(),
+        baseline7Downloads: v.number(),
+        spikeMultiplier: v.number(),
+        recent30Downloads: v.number(),
+        recent30Installs: v.number(),
+        downloadInstallRatio30: v.number(),
+        spikeWindowStartDay: v.optional(v.number()),
+        spikeWindowEndDay: v.optional(v.number()),
+        sustainedWindowStartDay: v.optional(v.number()),
+        sustainedWindowEndDay: v.optional(v.number()),
+        reasonCodes: v.array(v.string()),
+      }),
+    ),
+  ),
   createdAt: v.number(),
 })
   .index("by_run_and_rank", ["runId", "rank"])
@@ -2170,6 +2200,12 @@ const publisherAbuseReviewNominations = defineTable({
   .index("by_status_and_updated_at", ["status", "updatedAt"])
   .index("by_status_and_reviewed_at", ["status", "reviewedAt"])
   .index("by_status_and_label_and_last_scored_at", ["status", "label", "lastScoredAt"])
+  .index("by_status_and_model_version_and_label_and_last_scored_at", [
+    "status",
+    "modelVersion",
+    "label",
+    "lastScoredAt",
+  ])
   .index("by_label_and_status_and_last_scored_at", ["label", "status", "lastScoredAt"])
   .index("by_last_scored_at", ["lastScoredAt"]);
 


### PR DESCRIPTION
## Summary
- Add a temporal publisher abuse scan that detects high-download/flat-install manipulation from recent `skillDailyStats` windows.
- Run the current-window scan nightly over top download-ranked active skills and persist results into the existing publisher abuse review queue.
- Add a manual backfill mode with `dryRun` support for historical rolling-window scans.

## Algorithm Overview
The scan evaluates each candidate skill with two independent signals:
- **Spike:** latest 7-day downloads >= 1,000, latest 7-day installs <= 2, and downloads are at least 10x the 7-day baseline derived from the previous 30 days (`max(100, prev30Downloads / 30 * 7)`).
- **Sustained:** latest/historical 30-day downloads >= 3,000, installs <= 5, and downloads per install >= 1,000.

Current nightly mode evaluates the latest windows. Backfill mode scans rolling historical windows over the configured lookback and supports `dryRun: true`.

Publisher rollup:
- 1 flagged skill => `review`
- 2+ flagged skills => `potential_ban_candidate`

Temporal rows store capped skill-level evidence and reuse the existing publisher abuse nomination/event flow. Official org publishers are excluded using the same exclusion path as aggregate publisher abuse scoring. Current-mode scans only clear stale temporal nominations after a complete scan, and temporal rows receive review-compatible severity z-scores so existing queue ordering/coloring remains useful.

## Tests
- `bunx vitest run convex/publisherAbuse.test.ts convex/lib/publisherAbuseScoring.test.ts`
- `bunx tsc --noEmit`
- `bun run ci:unit`
- `bun run ci:static`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local --fallback-reviewer none`
