### PR TITLE
fix: stop copying publisher ids to skill embeddings

### DIFF
--- a/convex/devSeed.localFixtures.test.ts
+++ b/convex/devSeed.localFixtures.test.ts
@@ -7,6 +7,7 @@ import {
   seedGitHubBackedSkillSourceMutation,
   seedLocalFixtures,
   seedLocalModerationFixturesHandler,
+  seedPublicCorpusBatchMutation,
   seedSkillMutation,
 } from "./devSeed";
 
@@ -25,6 +26,9 @@ const seedGitHubBackedSkillSourceHandler = (
 )._handler;
 const seedLocalFixturesHandler = (
   seedLocalFixtures as unknown as WrappedHandler<{ reset?: boolean }>
+)._handler;
+const seedPublicCorpusBatchHandler = (
+  seedPublicCorpusBatchMutation as unknown as WrappedHandler<Record<string, unknown>>
 )._handler;
 
 function chainEq(constraints: Record<string, unknown>) {
@@ -223,6 +227,40 @@ describe("devSeed local fixtures", () => {
         ownerPublisherId: tables.publishers?.[0]?._id,
       }),
     );
+  });
+
+  it("does not copy publisher ownership onto public corpus skill embeddings", async () => {
+    const { db, tables } = createDb();
+
+    await seedPublicCorpusBatchHandler(
+      createMutationCtx(db) as never,
+      {
+        rows: [
+          {
+            kind: "skill",
+            slug: "corpus-demo",
+            displayName: "Corpus Demo",
+            version: "0.1.0",
+            skillMd: "---\ndescription: Corpus demo\n---\n# Corpus demo",
+            storageId: "storage:corpus-demo",
+            embedding: [0, 1, 2],
+            dummyOwner: {
+              handle: "corpus-owner",
+              displayName: "Corpus Owner",
+              image: "https://example.invalid/avatar.png",
+            },
+          },
+        ],
+      } as never,
+    );
+
+    expect(tables.skills?.[0]).toEqual(
+      expect.objectContaining({
+        slug: "corpus-demo",
+        ownerPublisherId: tables.publishers?.[0]?._id,
+      }),
+    );
+    expect(tables.skillEmbeddings?.[0]).not.toHaveProperty("ownerPublisherId");
   });
 
   it("seeds a GitHub-backed source and skills without creating mirrored versions", async () => {

--- a/convex/devSeed.ts
+++ b/convex/devSeed.ts
@@ -933,7 +933,6 @@ export const seedPublicCorpusBatchMutation = internalMutation({
           skillId,
           versionId,
           ownerId: userId,
-          ownerPublisherId: publisherId,
           embedding: row.embedding,
           isLatest: true,
           isApproved: true,

--- a/convex/maintenance.test.ts
+++ b/convex/maintenance.test.ts
@@ -566,9 +566,10 @@ describe("maintenance legacy publisher ownership repair", () => {
     expect(tableMap.skillSlugAliases.get("skillSlugAliases:legacy")).toMatchObject({
       ownerPublisherId: createdPublisher?._id,
     });
-    expect(tableMap.skillEmbeddings.get("skillEmbeddings:legacy")).toMatchObject({
-      ownerPublisherId: createdPublisher?._id,
-    });
+    expect(tableMap.skillEmbeddings.get("skillEmbeddings:legacy")).not.toHaveProperty(
+      "ownerPublisherId",
+      createdPublisher?._id,
+    );
 
     const packagesResult = await repairLegacyPublisherOwnershipHandler({ db, scheduler } as never, {
       phase: "packages",
@@ -641,9 +642,10 @@ describe("maintenance legacy publisher ownership repair", () => {
     expect(tableMap.skillSlugAliases.get("skillSlugAliases:legacy")).toMatchObject({
       ownerPublisherId: createdPublisher?._id,
     });
-    expect(tableMap.skillEmbeddings.get("skillEmbeddings:legacy")).toMatchObject({
-      ownerPublisherId: createdPublisher?._id,
-    });
+    expect(tableMap.skillEmbeddings.get("skillEmbeddings:legacy")).not.toHaveProperty(
+      "ownerPublisherId",
+      createdPublisher?._id,
+    );
 
     const packagesResult = await repairLegacyPublisherOwnershipForUserHandler(
       { db, scheduler } as never,
@@ -670,7 +672,7 @@ describe("maintenance legacy publisher ownership repair", () => {
     });
   });
 
-  it("aborts apply-mode skill repair when owner projection sync fails", async () => {
+  it("does not touch skill embeddings during apply-mode skill repair", async () => {
     const { db } = makeLegacyPublisherOwnershipDb();
     const scheduler = { runAfter: vi.fn() };
 
@@ -694,7 +696,10 @@ describe("maintenance legacy publisher ownership repair", () => {
         batchSize: 10,
         scheduleNext: false,
       }),
-    ).rejects.toThrow("embedding sync failed");
+    ).resolves.toMatchObject({
+      phase: "skills",
+      repaired: 1,
+    });
   });
 
   it("propagates apply-mode package patch failures", async () => {

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -2397,7 +2397,7 @@ async function repairLegacySkillOwnerPublisher(
   if (dryRun) return "repaired" as const;
 
   // The trigger-wrapped mutation syncs skill search digest and publisher stats.
-  // This repair only patches owner projections that triggers do not own.
+  // This repair only patches owner projections that remain source-of-truth.
   await ctx.db.patch(skill._id, { ownerPublisherId: publisher!._id });
 
   const aliases = await ctx.db
@@ -2407,15 +2407,6 @@ async function repairLegacySkillOwnerPublisher(
   for (const alias of aliases) {
     if (alias.ownerPublisherId === publisher!._id) continue;
     await ctx.db.patch(alias._id, { ownerPublisherId: publisher!._id });
-  }
-
-  const embeddings = await ctx.db
-    .query("skillEmbeddings")
-    .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
-    .collect();
-  for (const embedding of embeddings) {
-    if (embedding.ownerPublisherId === publisher!._id) continue;
-    await ctx.db.patch(embedding._id, { ownerPublisherId: publisher!._id });
   }
 
   return "repaired" as const;
@@ -2465,15 +2456,6 @@ async function patchLegacySkillOwnerPublisher(
   for (const alias of aliases) {
     if (alias.ownerPublisherId === publisherId) continue;
     await ctx.db.patch(alias._id, { ownerPublisherId: publisherId });
-  }
-
-  const embeddings = await ctx.db
-    .query("skillEmbeddings")
-    .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
-    .collect();
-  for (const embedding of embeddings) {
-    if (embedding.ownerPublisherId === publisherId) continue;
-    await ctx.db.patch(embedding._id, { ownerPublisherId: publisherId });
   }
 }
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -991,6 +991,8 @@ const skillEmbeddings = defineTable({
   skillId: v.id("skills"),
   versionId: v.id("skillVersions"),
   ownerId: v.id("users"),
+  // Deprecated compatibility field. Ownership lives on skills/search digests;
+  // keep this optional until old rows are pruned or migrated away.
   ownerPublisherId: v.optional(v.id("publishers")),
   embedding: v.array(v.number()),
   isLatest: v.boolean(),


### PR DESCRIPTION
## Summary
- Stop writing `ownerPublisherId` onto new public-corpus `skillEmbeddings` rows.
- Stop legacy publisher ownership repair from patching `skillEmbeddings.ownerPublisherId`.
- Keep the optional schema field as deprecated compatibility so existing rows do not block Convex schema validation.

## Tests
- `bunx vitest run convex/maintenance.test.ts convex/devSeed.localFixtures.test.ts convex/search.test.ts convex/skillTransfers.test.ts`
- `bun run format:check -- convex/schema.ts convex/devSeed.ts convex/devSeed.localFixtures.test.ts convex/maintenance.ts convex/maintenance.test.ts`
- `bun run lint -- convex/schema.ts convex/devSeed.ts convex/devSeed.localFixtures.test.ts convex/maintenance.ts convex/maintenance.test.ts`
- `bunx tsc -p convex/tsconfig.json --noEmit`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bun run ci:static`
- `bun run ci:unit`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local`
