### PR TITLE
Add cohort temporal abuse scoring

### DIFF
--- a/convex/lib/publisherAbuseScoring.test.ts
+++ b/convex/lib/publisherAbuseScoring.test.ts
@@ -5,8 +5,10 @@ import {
   computeCurrentSkillTemporalAbuseScore,
   computeHistoricalSkillTemporalAbuseScore,
   computePublisherAbuseRawScore,
+  computeTemporalAbuseCohortBenchmark,
   computeTemporalPublisherAbuseZScore,
   DEFAULT_PUBLISHER_ABUSE_MODEL_CONFIG,
+  labelForTemporalPublisherAbuse,
   labelForPublisherAbuseZScore,
   scorePublisherAbuseCohort,
 } from "./publisherAbuseScoring";
@@ -44,6 +46,15 @@ describe("publisher abuse scoring", () => {
     expect(review).toBeLessThan(2.5);
     expect(potentialBan).toBeGreaterThanOrEqual(2.5);
     expect(potentialBan).toBeGreaterThan(review);
+  });
+
+  it("escalates one P99 temporal hit as a potential ban candidate", () => {
+    expect(
+      labelForTemporalPublisherAbuse({ highTemporalSkillCount: 1, p99TemporalSkillCount: 1 }),
+    ).toBe("potential_ban_candidate");
+    expect(
+      labelForTemporalPublisherAbuse({ highTemporalSkillCount: 1, p99TemporalSkillCount: 0 }),
+    ).toBe("review");
   });
 
   it("keeps a high-volume publisher with strong usage below low-engagement publishers", () => {
@@ -158,6 +169,12 @@ describe("publisher abuse scoring", () => {
     const todayDay = 100;
     const score = computeCurrentSkillTemporalAbuseScore({
       todayDay,
+      benchmark: temporalBenchmark({
+        downloads30dP95: 2_000,
+        downloads30dP99: 5_000,
+        spikeMultiplier7dP95: 5,
+        spikeMultiplier7dP99: 20,
+      }),
       dailyStats: [
         ...dailyRange(64, 30, { downloads: 5, installs: 0 }),
         ...dailyRange(94, 7, { downloads: 200, installs: 0 }),
@@ -170,6 +187,7 @@ describe("publisher abuse scoring", () => {
     expect(score.recent7Installs).toBe(0);
     expect(score.previous30Downloads).toBe(150);
     expect(score.spikeMultiplier).toBeCloseTo(14);
+    expect(score.spikeMultiplierCohortBand).toBe("p95");
     expect(score.reasonCodes).toContain("temporal_download_spike_flat_installs");
   });
 
@@ -177,6 +195,12 @@ describe("publisher abuse scoring", () => {
     const todayDay = 100;
     const score = computeCurrentSkillTemporalAbuseScore({
       todayDay,
+      benchmark: temporalBenchmark({
+        downloads30dP95: 3_000,
+        downloads30dP99: 6_000,
+        spikeMultiplier7dP95: 20,
+        spikeMultiplier7dP99: 50,
+      }),
       dailyStats: dailyRange(71, 30, { downloads: 120, installs: 0 }),
     });
 
@@ -185,6 +209,7 @@ describe("publisher abuse scoring", () => {
     expect(score.recent30Downloads).toBe(3_600);
     expect(score.recent30Installs).toBe(0);
     expect(score.downloadInstallRatio30).toBe(3_600);
+    expect(score.downloads30dCohortBand).toBe("p95");
     expect(score.reasonCodes).toContain("temporal_sustained_downloads_flat_installs");
   });
 
@@ -192,6 +217,12 @@ describe("publisher abuse scoring", () => {
     const todayDay = 100;
     const score = computeCurrentSkillTemporalAbuseScore({
       todayDay,
+      benchmark: temporalBenchmark({
+        downloads30dP95: 4_000,
+        downloads30dP99: 8_000,
+        spikeMultiplier7dP95: 20,
+        spikeMultiplier7dP99: 50,
+      }),
       dailyStats: [
         ...dailyRange(64, 30, { downloads: 80, installs: 1 }),
         ...dailyRange(94, 7, { downloads: 85, installs: 1 }),
@@ -206,6 +237,12 @@ describe("publisher abuse scoring", () => {
 
   it("finds historical spike and sustained windows for backfill scans", () => {
     const score = computeHistoricalSkillTemporalAbuseScore({
+      benchmark: temporalBenchmark({
+        downloads30dP95: 3_000,
+        downloads30dP99: 10_000,
+        spikeMultiplier7dP95: 5,
+        spikeMultiplier7dP99: 25,
+      }),
       dailyStats: [
         ...dailyRange(10, 30, { downloads: 3, installs: 0 }),
         ...dailyRange(40, 7, { downloads: 220, installs: 0 }),
@@ -222,7 +259,34 @@ describe("publisher abuse scoring", () => {
       "temporal_sustained_downloads_flat_installs",
     ]);
   });
+
+  it("computes cohort benchmark percentiles from scanned skill windows", () => {
+    const benchmark = computeTemporalAbuseCohortBenchmark([
+      ...Array.from({ length: 95 }, () => ({ recent30Downloads: 100, spikeMultiplier: 1 })),
+      ...Array.from({ length: 4 }, () => ({ recent30Downloads: 500, spikeMultiplier: 2 })),
+      { recent30Downloads: 10_000, spikeMultiplier: 30 },
+    ]);
+
+    expect(benchmark.sampleSize).toBe(100);
+    expect(benchmark.downloads30dMedian).toBe(100);
+    expect(benchmark.downloads30dP95).toBe(100);
+    expect(benchmark.downloads30dP99).toBe(500);
+    expect(benchmark.spikeMultiplier7dP99).toBe(2);
+  });
 });
+
+function temporalBenchmark(overrides = {}) {
+  return {
+    sampleSize: 100,
+    downloads30dAverage: 500,
+    downloads30dMedian: 100,
+    downloads30dP95: 1_000,
+    downloads30dP99: 5_000,
+    spikeMultiplier7dP95: 5,
+    spikeMultiplier7dP99: 25,
+    ...overrides,
+  };
+}
 
 function publisher(
   handleSnapshot: string,

--- a/convex/lib/publisherAbuseScoring.ts
+++ b/convex/lib/publisherAbuseScoring.ts
@@ -69,11 +69,25 @@ export type SkillTemporalAbuseScore = {
   recent30Downloads: number;
   recent30Installs: number;
   downloadInstallRatio30: number;
+  downloads30dCohortBand?: "p95" | "p99";
+  spikeMultiplierCohortBand?: "p95" | "p99";
+  downloads30dVsPeerP95?: number;
+  spikeMultiplierVsPeerP95?: number;
   spikeWindowStartDay?: number;
   spikeWindowEndDay?: number;
   sustainedWindowStartDay?: number;
   sustainedWindowEndDay?: number;
   reasonCodes: string[];
+};
+
+export type TemporalAbuseCohortBenchmark = {
+  sampleSize: number;
+  downloads30dAverage: number;
+  downloads30dMedian: number;
+  downloads30dP95: number;
+  downloads30dP99: number;
+  spikeMultiplier7dP95: number;
+  spikeMultiplier7dP99: number;
 };
 
 export const DEFAULT_PUBLISHER_ABUSE_MODEL_CONFIG = {
@@ -99,12 +113,8 @@ const MIN_PRESSURE_FOR_LOG = 1e-9;
 const TEMPORAL_SPIKE_RECENT_DAYS = 7;
 const TEMPORAL_SPIKE_BASELINE_DAYS = 30;
 const TEMPORAL_SUSTAINED_DAYS = 30;
-const TEMPORAL_MIN_SPIKE_DOWNLOADS = 1_000;
 const TEMPORAL_MAX_SPIKE_INSTALLS = 2;
-const TEMPORAL_MIN_SPIKE_MULTIPLIER = 10;
-const TEMPORAL_MIN_SUSTAINED_DOWNLOADS = 3_000;
 const TEMPORAL_MAX_SUSTAINED_INSTALLS = 5;
-const TEMPORAL_MIN_SUSTAINED_DOWNLOAD_INSTALL_RATIO = 1_000;
 const TEMPORAL_MIN_BASELINE_7_DOWNLOADS = 100;
 
 export function labelForPublisherAbuseZScore(
@@ -258,17 +268,20 @@ export function summarizePublisherAbuseLogPressure(
 export function computeCurrentSkillTemporalAbuseScore(input: {
   todayDay: number;
   dailyStats: SkillTemporalAbuseDailyStat[];
+  benchmark?: TemporalAbuseCohortBenchmark;
 }): SkillTemporalAbuseScore {
   const statsByDay = aggregateSkillTemporalDailyStats(input.dailyStats);
-  return computeSkillTemporalAbuseScoreForWindows({
+  const score = computeSkillTemporalAbuseScoreForWindows({
     statsByDay,
     spikeStartDay: input.todayDay - TEMPORAL_SPIKE_RECENT_DAYS + 1,
     sustainedStartDay: input.todayDay - TEMPORAL_SUSTAINED_DAYS + 1,
   });
+  return classifySkillTemporalAbuseScore(score, input.benchmark);
 }
 
 export function computeHistoricalSkillTemporalAbuseScore(input: {
   dailyStats: SkillTemporalAbuseDailyStat[];
+  benchmark?: TemporalAbuseCohortBenchmark;
 }): SkillTemporalAbuseScore {
   const statsByDay = aggregateSkillTemporalDailyStats(input.dailyStats);
   const days = [...statsByDay.keys()];
@@ -281,23 +294,29 @@ export function computeHistoricalSkillTemporalAbuseScore(input: {
 
   for (let startDay = minDay; startDay <= maxDay; startDay += 1) {
     if (startDay + TEMPORAL_SPIKE_RECENT_DAYS - 1 <= maxDay) {
-      const score = computeSkillTemporalAbuseScoreForWindows({
-        statsByDay,
-        spikeStartDay: startDay,
-        sustainedStartDay: startDay,
-      });
+      const score = classifySkillTemporalAbuseScore(
+        computeSkillTemporalAbuseScoreForWindows({
+          statsByDay,
+          spikeStartDay: startDay,
+          sustainedStartDay: startDay,
+        }),
+        input.benchmark,
+      );
       if (score.spike && score.spikeMultiplier > bestSpike.spikeMultiplier) {
         bestSpike = score;
       }
     }
 
     if (startDay + TEMPORAL_SUSTAINED_DAYS - 1 <= maxDay) {
-      const score = computeSkillTemporalAbuseScoreForWindows({
-        statsByDay,
-        spikeStartDay: startDay,
-        sustainedStartDay: startDay,
-      });
-      if (score.sustained && score.downloadInstallRatio30 > bestSustained.downloadInstallRatio30) {
+      const score = classifySkillTemporalAbuseScore(
+        computeSkillTemporalAbuseScoreForWindows({
+          statsByDay,
+          spikeStartDay: startDay,
+          sustainedStartDay: startDay,
+        }),
+        input.benchmark,
+      );
+      if (score.sustained && score.recent30Downloads > bestSustained.recent30Downloads) {
         bestSustained = score;
       }
     }
@@ -308,10 +327,77 @@ export function computeHistoricalSkillTemporalAbuseScore(input: {
 
 export function labelForTemporalPublisherAbuse(input: {
   highTemporalSkillCount: number;
+  p99TemporalSkillCount?: number;
 }): PublisherAbuseLabel {
-  if (input.highTemporalSkillCount >= 2) return "potential_ban_candidate";
+  if ((input.p99TemporalSkillCount ?? 0) >= 1 || input.highTemporalSkillCount >= 2) {
+    return "potential_ban_candidate";
+  }
   if (input.highTemporalSkillCount >= 1) return "review";
   return "pass";
+}
+
+export function computeTemporalAbuseCohortBenchmark(
+  scores: Pick<SkillTemporalAbuseScore, "recent30Downloads" | "spikeMultiplier">[],
+): TemporalAbuseCohortBenchmark {
+  const downloads30d = scores.map((score) => nonNegative(score.recent30Downloads));
+  const spikeMultipliers = scores.map((score) => nonNegative(score.spikeMultiplier));
+  return {
+    sampleSize: scores.length,
+    downloads30dAverage: average(downloads30d),
+    downloads30dMedian: percentile(downloads30d, 0.5),
+    downloads30dP95: percentile(downloads30d, 0.95),
+    downloads30dP99: percentile(downloads30d, 0.99),
+    spikeMultiplier7dP95: percentile(spikeMultipliers, 0.95),
+    spikeMultiplier7dP99: percentile(spikeMultipliers, 0.99),
+  };
+}
+
+export function classifySkillTemporalAbuseScore(
+  score: SkillTemporalAbuseScore,
+  benchmark: TemporalAbuseCohortBenchmark | undefined,
+): SkillTemporalAbuseScore {
+  if (!benchmark || benchmark.sampleSize <= 0) return score;
+
+  const downloads30dVsPeerP95 = score.recent30Downloads / Math.max(1, benchmark.downloads30dP95);
+  const spikeMultiplierVsPeerP95 =
+    score.spikeMultiplier / Math.max(1, benchmark.spikeMultiplier7dP95);
+  const downloads30dCohortBand =
+    score.recent30Installs <= TEMPORAL_MAX_SUSTAINED_INSTALLS
+      ? percentileBand({
+          value: score.recent30Downloads,
+          p95: benchmark.downloads30dP95,
+          p99: benchmark.downloads30dP99,
+        })
+      : undefined;
+  const spikeMultiplierCohortBand =
+    score.recent7Installs <= TEMPORAL_MAX_SPIKE_INSTALLS && score.recent7Downloads > 0
+      ? percentileBand({
+          value: score.spikeMultiplier,
+          p95: benchmark.spikeMultiplier7dP95,
+          p99: benchmark.spikeMultiplier7dP99,
+        })
+      : undefined;
+  const spike = Boolean(spikeMultiplierCohortBand);
+  const sustained = Boolean(downloads30dCohortBand);
+  const reasonCodes: string[] = [];
+  if (spike) reasonCodes.push("temporal_download_spike_flat_installs");
+  if (sustained) reasonCodes.push("temporal_sustained_downloads_flat_installs");
+
+  return {
+    ...score,
+    spike,
+    sustained,
+    pressure: Math.max(spike ? spikeMultiplierVsPeerP95 : 0, sustained ? downloads30dVsPeerP95 : 0),
+    downloads30dCohortBand,
+    spikeMultiplierCohortBand,
+    downloads30dVsPeerP95,
+    spikeMultiplierVsPeerP95,
+    spikeWindowStartDay: spike ? score.spikeWindowStartDay : undefined,
+    spikeWindowEndDay: spike ? score.spikeWindowEndDay : undefined,
+    sustainedWindowStartDay: sustained ? score.sustainedWindowStartDay : undefined,
+    sustainedWindowEndDay: sustained ? score.sustainedWindowEndDay : undefined,
+    reasonCodes,
+  };
 }
 
 function reasonCodesForPublisher(input: {
@@ -363,22 +449,10 @@ function computeSkillTemporalAbuseScoreForWindows(input: {
   );
   const spikeMultiplier = baseline7Downloads > 0 ? recent7.downloads / baseline7Downloads : 0;
   const downloadInstallRatio30 = recent30.downloads / Math.max(1, recent30.installs);
-  const spike =
-    recent7.downloads >= TEMPORAL_MIN_SPIKE_DOWNLOADS &&
-    recent7.installs <= TEMPORAL_MAX_SPIKE_INSTALLS &&
-    spikeMultiplier >= TEMPORAL_MIN_SPIKE_MULTIPLIER;
-  const sustained =
-    recent30.downloads >= TEMPORAL_MIN_SUSTAINED_DOWNLOADS &&
-    recent30.installs <= TEMPORAL_MAX_SUSTAINED_INSTALLS &&
-    downloadInstallRatio30 >= TEMPORAL_MIN_SUSTAINED_DOWNLOAD_INSTALL_RATIO;
-  const reasonCodes: string[] = [];
-  if (spike) reasonCodes.push("temporal_download_spike_flat_installs");
-  if (sustained) reasonCodes.push("temporal_sustained_downloads_flat_installs");
-
   return {
-    spike,
-    sustained,
-    pressure: Math.max(spike ? spikeMultiplier : 0, sustained ? downloadInstallRatio30 / 1_000 : 0),
+    spike: false,
+    sustained: false,
+    pressure: 0,
     recent7Downloads: recent7.downloads,
     recent7Installs: recent7.installs,
     previous30Downloads: previous30.downloads,
@@ -387,11 +461,11 @@ function computeSkillTemporalAbuseScoreForWindows(input: {
     recent30Downloads: recent30.downloads,
     recent30Installs: recent30.installs,
     downloadInstallRatio30,
-    spikeWindowStartDay: spike ? input.spikeStartDay : undefined,
-    spikeWindowEndDay: spike ? spikeEndDay : undefined,
-    sustainedWindowStartDay: sustained ? input.sustainedStartDay : undefined,
-    sustainedWindowEndDay: sustained ? sustainedEndDay : undefined,
-    reasonCodes,
+    spikeWindowStartDay: input.spikeStartDay,
+    spikeWindowEndDay: spikeEndDay,
+    sustainedWindowStartDay: input.sustainedStartDay,
+    sustainedWindowEndDay: sustainedEndDay,
+    reasonCodes: [],
   };
 }
 
@@ -416,6 +490,10 @@ function mergeTemporalAbuseWindowScores(
     recent30Downloads: bestSustained.recent30Downloads,
     recent30Installs: bestSustained.recent30Installs,
     downloadInstallRatio30: bestSustained.downloadInstallRatio30,
+    downloads30dCohortBand: bestSustained.downloads30dCohortBand,
+    spikeMultiplierCohortBand: bestSpike.spikeMultiplierCohortBand,
+    downloads30dVsPeerP95: bestSustained.downloads30dVsPeerP95,
+    spikeMultiplierVsPeerP95: bestSpike.spikeMultiplierVsPeerP95,
     spikeWindowStartDay: bestSpike.spikeWindowStartDay,
     spikeWindowEndDay: bestSpike.spikeWindowEndDay,
     sustainedWindowStartDay: bestSustained.sustainedWindowStartDay,
@@ -477,6 +555,24 @@ function nonNegative(value: number) {
 function average(values: number[]) {
   if (values.length === 0) return 0;
   return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function percentile(values: number[], quantile: number) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = Math.max(0, Math.min(sorted.length - 1, Math.ceil(quantile * sorted.length) - 1));
+  return sorted[index] ?? 0;
+}
+
+function percentileBand(input: {
+  value: number;
+  p95: number;
+  p99: number;
+}): "p95" | "p99" | undefined {
+  if (input.value <= 0) return undefined;
+  if (input.p99 > 0 && input.value > input.p99) return "p99";
+  if (input.p95 > 0 && input.value > input.p95) return "p95";
+  return undefined;
 }
 
 function standardDeviation(values: number[], mean: number) {

--- a/convex/publisherAbuse.test.ts
+++ b/convex/publisherAbuse.test.ts
@@ -144,6 +144,7 @@ const persistTemporalHandler = (
       mode: "current" | "backfill";
       trigger: "cron" | "manual";
       scanComplete: boolean;
+      benchmark: ReturnType<typeof temporalBenchmark>;
       candidates: Array<{
         ownerKey: string;
         ownerPublisherId?: string;
@@ -3774,10 +3775,19 @@ describe("publisher abuse dry-run persistence", () => {
       dryRun: true,
       mode: "backfill",
       scannedSkills: 1,
-      highTemporalSkills: 1,
-      flaggedPublishers: 1,
+      highTemporalSkills: 0,
+      flaggedPublishers: 0,
       nominations: 0,
-      candidates: [candidate],
+      candidates: [],
+      benchmark: {
+        sampleSize: 1,
+        downloads30dAverage: 2_000,
+        downloads30dMedian: 2_000,
+        downloads30dP95: 2_000,
+        downloads30dP99: 2_000,
+        spikeMultiplier7dP95: 20,
+        spikeMultiplier7dP99: 20,
+      },
     });
 
     expect(ctx.runQuery).toHaveBeenCalledTimes(1);
@@ -3934,7 +3944,7 @@ describe("publisher abuse dry-run persistence", () => {
 
     expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 10 });
     expect(takeDailyStats).toHaveBeenCalledWith(730);
-    expect(ctx.db.get).not.toHaveBeenCalled();
+    expect(ctx.db.get).toHaveBeenCalledWith("publishers:quiet");
   });
 
   it("skips official org publishers during temporal candidate collection", async () => {
@@ -4106,6 +4116,7 @@ describe("publisher abuse dry-run persistence", () => {
         mode: "current",
         trigger: "cron",
         scanComplete: true,
+        benchmark: temporalBenchmark(),
         candidates: [
           temporalCandidate("skills:first", { slug: "first", displayName: "First" }),
           temporalCandidate("skills:second", { slug: "second", displayName: "Second" }),
@@ -4126,6 +4137,7 @@ describe("publisher abuse dry-run persistence", () => {
         temporalHighSkillCount: 2,
         temporalSpikeSkillCount: 2,
         temporalSustainedSkillCount: 0,
+        temporalBenchmark: temporalBenchmark(),
       }),
     );
     expect(insert).toHaveBeenCalledWith(
@@ -4186,6 +4198,7 @@ describe("publisher abuse dry-run persistence", () => {
         mode: "current",
         trigger: "cron",
         scanComplete: false,
+        benchmark: temporalBenchmark(),
         candidates: [],
       }),
     ).resolves.toEqual({
@@ -4295,6 +4308,7 @@ describe("publisher abuse dry-run persistence", () => {
         mode: "current",
         trigger: "cron",
         scanComplete: true,
+        benchmark: temporalBenchmark(),
         candidates: [],
       }),
     ).resolves.toEqual({
@@ -4356,5 +4370,17 @@ function temporalCandidate(skillId: string, skill: { slug: string; displayName: 
       spikeWindowEndDay: 100,
       reasonCodes: ["temporal_download_spike_flat_installs"],
     },
+  };
+}
+
+function temporalBenchmark() {
+  return {
+    sampleSize: 100,
+    downloads30dAverage: 900,
+    downloads30dMedian: 120,
+    downloads30dP95: 1_000,
+    downloads30dP99: 5_000,
+    spikeMultiplier7dP95: 5,
+    spikeMultiplier7dP99: 25,
   };
 }

--- a/convex/publisherAbuse.ts
+++ b/convex/publisherAbuse.ts
@@ -14,9 +14,11 @@ import { assertModerator, requireUser, requireUserFromAction } from "./lib/acces
 import { toDayKey } from "./lib/leaderboards";
 import { hasOfficialPublisherRow } from "./lib/officialPublishers";
 import {
+  classifySkillTemporalAbuseScore,
   computeCurrentSkillTemporalAbuseScore,
   computeHistoricalSkillTemporalAbuseScore,
   computePublisherAbuseRawScore,
+  computeTemporalAbuseCohortBenchmark,
   computeTemporalPublisherAbuseZScore,
   DEFAULT_PUBLISHER_ABUSE_MODEL_CONFIG,
   labelForTemporalPublisherAbuse,
@@ -26,6 +28,7 @@ import {
   type PublisherAbuseInput,
   type PublisherAbuseLabel,
   type SkillTemporalAbuseScore,
+  type TemporalAbuseCohortBenchmark,
 } from "./lib/publisherAbuseScoring";
 import { getSkillPublisherContribution } from "./lib/publisherStats";
 import { readCanonicalStat } from "./lib/skillStats";
@@ -123,6 +126,7 @@ type TemporalPublisherAggregate = {
   ownerUserId?: Id<"users">;
   handleSnapshot: string;
   highTemporalSkillCount: number;
+  p99TemporalSkillCount: number;
   spikeSkillCount: number;
   sustainedSkillCount: number;
   maxTemporalPressure: number;
@@ -131,6 +135,18 @@ type TemporalPublisherAggregate = {
   reasonCodes: string[];
   evidence: TemporalSkillCandidate[];
 };
+
+const temporalCohortBandValidator = v.union(v.literal("p95"), v.literal("p99"));
+
+const temporalAbuseCohortBenchmarkValidator = v.object({
+  sampleSize: v.number(),
+  downloads30dAverage: v.number(),
+  downloads30dMedian: v.number(),
+  downloads30dP95: v.number(),
+  downloads30dP99: v.number(),
+  spikeMultiplier7dP95: v.number(),
+  spikeMultiplier7dP99: v.number(),
+});
 
 const temporalScoreValidator = v.object({
   spike: v.boolean(),
@@ -144,6 +160,10 @@ const temporalScoreValidator = v.object({
   recent30Downloads: v.number(),
   recent30Installs: v.number(),
   downloadInstallRatio30: v.number(),
+  downloads30dCohortBand: v.optional(temporalCohortBandValidator),
+  spikeMultiplierCohortBand: v.optional(temporalCohortBandValidator),
+  downloads30dVsPeerP95: v.optional(v.number()),
+  spikeMultiplierVsPeerP95: v.optional(v.number()),
   spikeWindowStartDay: v.optional(v.number()),
   spikeWindowEndDay: v.optional(v.number()),
   sustainedWindowStartDay: v.optional(v.number()),
@@ -457,6 +477,7 @@ export const persistTemporalPublisherAbuseCandidatesInternal = internalMutation(
     trigger: v.union(v.literal("cron"), v.literal("manual")),
     actorUserId: v.optional(v.id("users")),
     candidates: v.array(temporalCandidateValidator),
+    benchmark: temporalAbuseCohortBenchmarkValidator,
     scanComplete: v.boolean(),
   },
   handler: persistTemporalPublisherAbuseCandidatesInternalHandler,
@@ -807,7 +828,6 @@ export async function collectTemporalPublisherAbuseSkillCandidatesPageInternalHa
       args.mode === "backfill"
         ? computeHistoricalSkillTemporalAbuseScore({ dailyStats })
         : computeCurrentSkillTemporalAbuseScore({ todayDay, dailyStats });
-    if (!temporalScore.spike && !temporalScore.sustained) continue;
 
     const publisher = await ctx.db.get(skill.ownerPublisherId);
     if (!publisher || (await isPublisherExcludedFromPublisherAbuse(ctx, publisher))) continue;
@@ -840,6 +860,7 @@ export async function persistTemporalPublisherAbuseCandidatesInternalHandler(
     trigger: "cron" | "manual";
     actorUserId?: Id<"users">;
     candidates: TemporalSkillCandidate[];
+    benchmark: TemporalAbuseCohortBenchmark;
     scanComplete: boolean;
   },
 ): Promise<{
@@ -851,6 +872,7 @@ export async function persistTemporalPublisherAbuseCandidatesInternalHandler(
   const runId = await createTemporalPublisherAbuseScoreRun(ctx, {
     trigger: args.trigger,
     actorUserId: args.actorUserId,
+    benchmark: args.benchmark,
   });
   const run = await ctx.db.get(runId);
   if (!run) throw new Error("Temporal publisher abuse score run not found");
@@ -868,6 +890,7 @@ export async function persistTemporalPublisherAbuseCandidatesInternalHandler(
     rank += 1;
     const label = labelForTemporalPublisherAbuse({
       highTemporalSkillCount: aggregate.highTemporalSkillCount,
+      p99TemporalSkillCount: aggregate.p99TemporalSkillCount,
     });
     if (label === "pass") continue;
     const pressure = 1_000 + aggregate.highTemporalSkillCount * 100 + aggregate.maxTemporalPressure;
@@ -900,6 +923,7 @@ export async function persistTemporalPublisherAbuseCandidatesInternalHandler(
       temporalSpikeSkillCount: aggregate.spikeSkillCount,
       temporalSustainedSkillCount: aggregate.sustainedSkillCount,
       temporalMaxPressure: aggregate.maxTemporalPressure,
+      temporalBenchmark: args.benchmark,
       temporalEvidence: aggregate.evidence
         .sort((left, right) => right.temporalScore.pressure - left.temporalScore.pressure)
         .slice(0, MAX_TEMPORAL_EVIDENCE_SKILLS)
@@ -932,10 +956,19 @@ export async function persistTemporalPublisherAbuseCandidatesInternalHandler(
     finalizedScores: sortedAggregates.length + clearedNominations,
     nominatedPublishers: nominations,
     passCount: clearedNominations,
-    reviewCount: sortedAggregates.filter((aggregate) => aggregate.highTemporalSkillCount === 1)
-      .length,
+    reviewCount: sortedAggregates.filter(
+      (aggregate) =>
+        labelForTemporalPublisherAbuse({
+          highTemporalSkillCount: aggregate.highTemporalSkillCount,
+          p99TemporalSkillCount: aggregate.p99TemporalSkillCount,
+        }) === "review",
+    ).length,
     potentialBanCandidateCount: sortedAggregates.filter(
-      (aggregate) => aggregate.highTemporalSkillCount >= 2,
+      (aggregate) =>
+        labelForTemporalPublisherAbuse({
+          highTemporalSkillCount: aggregate.highTemporalSkillCount,
+          p99TemporalSkillCount: aggregate.p99TemporalSkillCount,
+        }) === "potential_ban_candidate",
     ).length,
     completedAt: now,
     updatedAt: now,
@@ -966,6 +999,7 @@ export async function runTemporalPublisherAbuseScanInternalHandler(
   flaggedPublishers: number;
   nominations: number;
   candidates?: TemporalSkillCandidate[];
+  benchmark: TemporalAbuseCohortBenchmark;
 }> {
   const mode = args.mode ?? "current";
   const dryRun = args.dryRun ?? false;
@@ -1007,17 +1041,30 @@ export async function runTemporalPublisherAbuseScanInternalHandler(
     }
   }
 
-  const flaggedPublishers = aggregateTemporalPublisherCandidates(candidates).length;
-  if (dryRun || (mode !== "current" && candidates.length === 0)) {
+  const benchmark = computeTemporalAbuseCohortBenchmark(
+    candidates.map((candidate) => candidate.temporalScore),
+  );
+  const highTemporalCandidates = candidates
+    .map((candidate) => ({
+      ...candidate,
+      temporalScore: classifySkillTemporalAbuseScore(candidate.temporalScore, benchmark),
+    }))
+    .filter((candidate) => candidate.temporalScore.spike || candidate.temporalScore.sustained);
+
+  const flaggedPublishers = aggregateTemporalPublisherCandidates(highTemporalCandidates).length;
+  if (dryRun || (mode !== "current" && highTemporalCandidates.length === 0)) {
     return {
       ok: true,
       dryRun,
       mode,
       scannedSkills,
-      highTemporalSkills: candidates.length,
+      highTemporalSkills: highTemporalCandidates.length,
       flaggedPublishers,
       nominations: 0,
-      ...(dryRun ? { candidates: candidates.slice(0, MAX_TEMPORAL_DRY_RUN_CANDIDATES) } : {}),
+      benchmark,
+      ...(dryRun
+        ? { candidates: highTemporalCandidates.slice(0, MAX_TEMPORAL_DRY_RUN_CANDIDATES) }
+        : {}),
     };
   }
 
@@ -1027,7 +1074,8 @@ export async function runTemporalPublisherAbuseScanInternalHandler(
       mode,
       trigger: args.trigger ?? "cron",
       actorUserId: args.actorUserId,
-      candidates,
+      candidates: highTemporalCandidates,
+      benchmark,
       scanComplete,
     },
   );
@@ -1036,9 +1084,10 @@ export async function runTemporalPublisherAbuseScanInternalHandler(
     dryRun,
     mode,
     scannedSkills,
-    highTemporalSkills: candidates.length,
+    highTemporalSkills: highTemporalCandidates.length,
     flaggedPublishers: persisted.flaggedPublishers,
     nominations: persisted.nominations,
+    benchmark,
   };
 }
 
@@ -1142,6 +1191,7 @@ async function createTemporalPublisherAbuseScoreRun(
   args: {
     trigger: "cron" | "manual";
     actorUserId?: Id<"users">;
+    benchmark?: TemporalAbuseCohortBenchmark;
   },
 ) {
   const now = Date.now();
@@ -1163,6 +1213,7 @@ async function createTemporalPublisherAbuseScoreRun(
     potentialBanCandidateCount: 0,
     sumLogPressure: 0,
     sumSquaredLogPressure: 0,
+    temporalBenchmark: args.benchmark,
   });
 }
 
@@ -1175,6 +1226,7 @@ function aggregateTemporalPublisherCandidates(candidates: TemporalSkillCandidate
       ownerUserId: candidate.ownerUserId,
       handleSnapshot: candidate.handleSnapshot,
       highTemporalSkillCount: 0,
+      p99TemporalSkillCount: 0,
       spikeSkillCount: 0,
       sustainedSkillCount: 0,
       maxTemporalPressure: 0,
@@ -1184,6 +1236,12 @@ function aggregateTemporalPublisherCandidates(candidates: TemporalSkillCandidate
       evidence: [],
     };
     existing.highTemporalSkillCount += 1;
+    if (
+      candidate.temporalScore.downloads30dCohortBand === "p99" ||
+      candidate.temporalScore.spikeMultiplierCohortBand === "p99"
+    ) {
+      existing.p99TemporalSkillCount += 1;
+    }
     if (candidate.temporalScore.spike) existing.spikeSkillCount += 1;
     if (candidate.temporalScore.sustained) existing.sustainedSkillCount += 1;
     existing.maxTemporalPressure = Math.max(
@@ -1218,6 +1276,10 @@ function temporalEvidenceFromCandidate(candidate: TemporalSkillCandidate) {
     recent30Downloads: candidate.temporalScore.recent30Downloads,
     recent30Installs: candidate.temporalScore.recent30Installs,
     downloadInstallRatio30: candidate.temporalScore.downloadInstallRatio30,
+    downloads30dCohortBand: candidate.temporalScore.downloads30dCohortBand,
+    spikeMultiplierCohortBand: candidate.temporalScore.spikeMultiplierCohortBand,
+    downloads30dVsPeerP95: candidate.temporalScore.downloads30dVsPeerP95,
+    spikeMultiplierVsPeerP95: candidate.temporalScore.spikeMultiplierVsPeerP95,
     spikeWindowStartDay: candidate.temporalScore.spikeWindowStartDay,
     spikeWindowEndDay: candidate.temporalScore.spikeWindowEndDay,
     sustainedWindowStartDay: candidate.temporalScore.sustainedWindowStartDay,

--- a/convex/publisherAbuseDevSeed.test.ts
+++ b/convex/publisherAbuseDevSeed.test.ts
@@ -263,12 +263,13 @@ describe("publisherAbuseDevSeed.seed", () => {
       (doc) => doc.label === "review" && doc.status === "pending",
     );
 
-    expect(pendingBan).toHaveLength(15);
+    expect(pendingBan).toHaveLength(16);
     expect(pendingReview).toHaveLength(124);
     expect(result.inserted).toBe(nominations.length);
     // Every ban candidate links a demo user so the inspector ban action is
     // exercisable; review nominations do not create users.
-    expect(tables.users ?? []).toHaveLength(15);
+    expect(tables.users ?? []).toHaveLength(16);
+    expect(tables.skills?.some((doc) => doc.slug === "demo-temporal-download-burst")).toBe(true);
   });
 
   it("clears existing demo rows before inserting repeatable seed data", async () => {
@@ -318,8 +319,8 @@ describe("publisherAbuseDevSeed.seed", () => {
     );
     expect(tables.users.map((doc) => doc._id)).not.toContain("users:old-demo");
     expect(tables.users.filter((doc) => doc.handle === "demo-abuse-pub-01")).toHaveLength(1);
-    expect(tables.users).toHaveLength(15);
-    expect(tables.publisherAbuseReviewNominations).toHaveLength(145);
+    expect(tables.users).toHaveLength(16);
+    expect(tables.publisherAbuseReviewNominations).toHaveLength(146);
   });
 });
 

--- a/convex/publisherAbuseDevSeed.ts
+++ b/convex/publisherAbuseDevSeed.ts
@@ -11,6 +11,7 @@ import {
   computePublisherAbuseRawScore,
   DEFAULT_PUBLISHER_ABUSE_MODEL_CONFIG,
   PUBLISHER_ABUSE_MODEL_VERSION,
+  PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION,
   type PublisherAbuseLabel,
 } from "./lib/publisherAbuseScoring";
 
@@ -21,6 +22,9 @@ import {
 
 const DEMO_HANDLE_PREFIX = "demo-abuse-pub-";
 const DEMO_OWNER_KEY_PREFIX = "user:demo-";
+const TEMPORAL_DEMO_HANDLE = `${DEMO_HANDLE_PREFIX}temporal-cohort`;
+const TEMPORAL_DEMO_OWNER_KEY = `${DEMO_OWNER_KEY_PREFIX}temporal-cohort`;
+const TEMPORAL_DEMO_SKILL_SLUG = "demo-temporal-download-burst";
 const CLEAR_SEED_BATCH_SIZE = 100;
 
 type TriageStatus =
@@ -221,8 +225,14 @@ function demoOwnerKey(index: number): string {
   return `${DEMO_OWNER_KEY_PREFIX}${paddedIndex(index)}`;
 }
 
-const DEMO_HANDLES = SEED_PUBLISHERS.map((publisher) => demoHandle(publisher.index));
-const DEMO_OWNER_KEYS = SEED_PUBLISHERS.map((publisher) => demoOwnerKey(publisher.index));
+const DEMO_HANDLES = [
+  ...SEED_PUBLISHERS.map((publisher) => demoHandle(publisher.index)),
+  TEMPORAL_DEMO_HANDLE,
+];
+const DEMO_OWNER_KEYS = [
+  ...SEED_PUBLISHERS.map((publisher) => demoOwnerKey(publisher.index)),
+  TEMPORAL_DEMO_OWNER_KEY,
+];
 
 type ClearSeedCtx = Pick<MutationCtx, "db">;
 type ClearSeedResult = {
@@ -368,7 +378,9 @@ export const seed = internalMutation({
       });
     }
 
-    return { runId, inserted: SEED_PUBLISHERS.length };
+    await seedTemporalCohortDemoRows(ctx, { now });
+
+    return { runId, inserted: SEED_PUBLISHERS.length + 1 };
   },
 });
 
@@ -379,6 +391,176 @@ export const clearSeed = internalMutation({
     return await clearDemoRows(ctx);
   },
 });
+
+async function seedTemporalCohortDemoRows(ctx: ClearSeedCtx, args: { now: number }) {
+  const now = args.now;
+  const todayDay = Math.floor(now / DAY_MS);
+  const temporalBenchmark = {
+    sampleSize: 1000,
+    downloads30dAverage: 180,
+    downloads30dMedian: 45,
+    downloads30dP95: 900,
+    downloads30dP99: 3000,
+    spikeMultiplier7dP95: 4,
+    spikeMultiplier7dP99: 12,
+  };
+  const temporalUserId = await ctx.db.insert("users", {
+    handle: TEMPORAL_DEMO_HANDLE,
+    name: "Demo Temporal Abuse Publisher",
+    role: "user",
+    createdAt: now - DAY_MS,
+    updatedAt: now - DAY_MS,
+  });
+  const temporalPublisherId = await ctx.db.insert("publishers", {
+    kind: "user",
+    handle: TEMPORAL_DEMO_HANDLE,
+    displayName: "Demo Temporal Abuse Publisher",
+    linkedUserId: temporalUserId,
+    publishedSkills: 1,
+    publishedPackages: 0,
+    totalInstalls: 0,
+    totalDownloads: 16_200,
+    totalStars: 0,
+    skillTotalInstalls: 0,
+    skillTotalDownloads: 16_200,
+    skillTotalStars: 0,
+    createdAt: now - DAY_MS,
+    updatedAt: now - HOUR_MS,
+  });
+  const temporalSkillId = await ctx.db.insert("skills", {
+    slug: TEMPORAL_DEMO_SKILL_SLUG,
+    displayName: "Demo Temporal Download Burst",
+    summary: "Synthetic fixture: high 30-day downloads with zero installs.",
+    ownerUserId: temporalUserId,
+    ownerPublisherId: temporalPublisherId,
+    tags: {},
+    badges: {},
+    moderationStatus: "active",
+    statsDownloads: 16_200,
+    statsStars: 0,
+    statsInstallsCurrent: 0,
+    statsInstallsAllTime: 0,
+    stats: {
+      downloads: 16_200,
+      installsCurrent: 0,
+      installsAllTime: 0,
+      stars: 0,
+      versions: 1,
+      comments: 0,
+    },
+    createdAt: now - DAY_MS,
+    updatedAt: now - HOUR_MS,
+  });
+  for (let offset = 59; offset >= 30; offset -= 1) {
+    await ctx.db.insert("skillDailyStats", {
+      skillId: temporalSkillId,
+      day: todayDay - offset,
+      downloads: 4,
+      installs: 0,
+      updatedAt: now - HOUR_MS,
+    });
+  }
+  for (let offset = 29; offset >= 0; offset -= 1) {
+    await ctx.db.insert("skillDailyStats", {
+      skillId: temporalSkillId,
+      day: todayDay - offset,
+      downloads: 540,
+      installs: 0,
+      updatedAt: now - HOUR_MS,
+    });
+  }
+
+  const temporalStartedAt = now - 35 * 60_000;
+  const temporalCompletedAt = now - 30 * 60_000;
+  const temporalRunId = await ctx.db.insert("publisherAbuseScoreRuns", {
+    modelVersion: PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION,
+    modelConfig: DEFAULT_PUBLISHER_ABUSE_MODEL_CONFIG,
+    trigger: "manual",
+    status: "completed",
+    phase: "completed",
+    startedAt: temporalStartedAt,
+    completedAt: temporalCompletedAt,
+    updatedAt: temporalCompletedAt,
+    scannedPublishers: temporalBenchmark.sampleSize,
+    scoredPublishers: 1,
+    finalizedScores: 1,
+    nominatedPublishers: 1,
+    passCount: 0,
+    reviewCount: 0,
+    potentialBanCandidateCount: 1,
+    sumLogPressure: 0,
+    sumSquaredLogPressure: 0,
+    meanLogPressure: 0,
+    stdDevLogPressure: 0,
+    temporalBenchmark,
+  });
+  const temporalScoreId = await ctx.db.insert("publisherAbuseScores", {
+    runId: temporalRunId,
+    ownerKey: TEMPORAL_DEMO_OWNER_KEY,
+    ownerPublisherId: temporalPublisherId,
+    ownerUserId: temporalUserId,
+    handleSnapshot: TEMPORAL_DEMO_HANDLE,
+    modelVersion: PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION,
+    label: "potential_ban_candidate",
+    rank: 1,
+    pressure: 18,
+    logPressure: Math.log10(18),
+    zScore: 3.13,
+    publishedSkills: 1,
+    totalInstalls: 0,
+    totalStars: 0,
+    totalDownloads: 16_200,
+    installsPerSkill: 0,
+    starsPerSkill: 0,
+    downloadsPerSkill: 16_200,
+    reasonCodes: ["temporal_sustained_downloads_flat_installs"],
+    temporalHighSkillCount: 1,
+    temporalSpikeSkillCount: 0,
+    temporalSustainedSkillCount: 1,
+    temporalMaxPressure: 18,
+    temporalBenchmark,
+    temporalEvidence: [
+      {
+        skillId: temporalSkillId,
+        slug: TEMPORAL_DEMO_SKILL_SLUG,
+        displayName: "Demo Temporal Download Burst",
+        spike: false,
+        sustained: true,
+        pressure: 18,
+        recent7Downloads: 3_780,
+        recent7Installs: 0,
+        previous30Downloads: 120,
+        baseline7Downloads: 100,
+        spikeMultiplier: 8,
+        recent30Downloads: 16_200,
+        recent30Installs: 0,
+        downloadInstallRatio30: 16_200,
+        downloads30dCohortBand: "p99",
+        spikeMultiplierCohortBand: "p95",
+        downloads30dVsPeerP95: 18,
+        spikeMultiplierVsPeerP95: 2,
+        sustainedWindowStartDay: todayDay - 29,
+        sustainedWindowEndDay: todayDay,
+        reasonCodes: ["temporal_sustained_downloads_flat_installs"],
+      },
+    ],
+    createdAt: temporalCompletedAt,
+  });
+  await ctx.db.insert("publisherAbuseReviewNominations", {
+    ownerKey: TEMPORAL_DEMO_OWNER_KEY,
+    ownerPublisherId: temporalPublisherId,
+    ownerUserId: temporalUserId,
+    handleSnapshot: TEMPORAL_DEMO_HANDLE,
+    latestScoreId: temporalScoreId,
+    modelVersion: PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION,
+    label: "potential_ban_candidate",
+    status: "pending",
+    openedAt: temporalCompletedAt,
+    openedByRunId: temporalRunId,
+    lastScoredAt: temporalCompletedAt,
+    updatedAt: temporalCompletedAt,
+  });
+}
 
 async function clearDemoRows(ctx: ClearSeedCtx): Promise<ClearSeedResult> {
   let runs = 0;
@@ -423,6 +605,9 @@ async function clearDemoRows(ctx: ClearSeedCtx): Promise<ClearSeedResult> {
     }
   }
 
+  await clearTemporalDemoSkillRows(ctx);
+  await clearTemporalDemoPublisherRows(ctx);
+
   for (const runId of demoRunIds) {
     const run = await ctx.db.get(runId);
     if (!run) continue;
@@ -441,6 +626,33 @@ async function clearDemoRows(ctx: ClearSeedCtx): Promise<ClearSeedResult> {
   }
 
   return { runs, scores, nominations, events, users, hasMore };
+}
+
+async function clearTemporalDemoSkillRows(ctx: ClearSeedCtx) {
+  const rows = await ctx.db
+    .query("skills")
+    .withIndex("by_slug", (q) => q.eq("slug", TEMPORAL_DEMO_SKILL_SLUG))
+    .take(CLEAR_SEED_BATCH_SIZE);
+  for (const skill of rows) {
+    const dailyStats = await ctx.db
+      .query("skillDailyStats")
+      .withIndex("by_skill_day", (q) => q.eq("skillId", skill._id))
+      .take(CLEAR_SEED_BATCH_SIZE);
+    for (const stat of dailyStats) {
+      await ctx.db.delete(stat._id);
+    }
+    await ctx.db.delete(skill._id);
+  }
+}
+
+async function clearTemporalDemoPublisherRows(ctx: ClearSeedCtx) {
+  const rows = await ctx.db
+    .query("publishers")
+    .withIndex("by_handle", (q) => q.eq("handle", TEMPORAL_DEMO_HANDLE))
+    .take(CLEAR_SEED_BATCH_SIZE);
+  for (const publisher of rows) {
+    await ctx.db.delete(publisher._id);
+  }
 }
 
 async function queryDemoScoresPage(

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2122,6 +2122,17 @@ const publisherAbuseScoreRuns = defineTable({
   sumSquaredLogPressure: v.number(),
   meanLogPressure: v.optional(v.number()),
   stdDevLogPressure: v.optional(v.number()),
+  temporalBenchmark: v.optional(
+    v.object({
+      sampleSize: v.number(),
+      downloads30dAverage: v.number(),
+      downloads30dMedian: v.number(),
+      downloads30dP95: v.number(),
+      downloads30dP99: v.number(),
+      spikeMultiplier7dP95: v.number(),
+      spikeMultiplier7dP99: v.number(),
+    }),
+  ),
   errorMessage: v.optional(v.string()),
 })
   .index("by_status_and_updated_at", ["status", "updatedAt"])
@@ -2152,6 +2163,17 @@ const publisherAbuseScores = defineTable({
   temporalSpikeSkillCount: v.optional(v.number()),
   temporalSustainedSkillCount: v.optional(v.number()),
   temporalMaxPressure: v.optional(v.number()),
+  temporalBenchmark: v.optional(
+    v.object({
+      sampleSize: v.number(),
+      downloads30dAverage: v.number(),
+      downloads30dMedian: v.number(),
+      downloads30dP95: v.number(),
+      downloads30dP99: v.number(),
+      spikeMultiplier7dP95: v.number(),
+      spikeMultiplier7dP99: v.number(),
+    }),
+  ),
   temporalEvidence: v.optional(
     v.array(
       v.object({
@@ -2169,6 +2191,10 @@ const publisherAbuseScores = defineTable({
         recent30Downloads: v.number(),
         recent30Installs: v.number(),
         downloadInstallRatio30: v.number(),
+        downloads30dCohortBand: v.optional(v.union(v.literal("p95"), v.literal("p99"))),
+        spikeMultiplierCohortBand: v.optional(v.union(v.literal("p95"), v.literal("p99"))),
+        downloads30dVsPeerP95: v.optional(v.number()),
+        spikeMultiplierVsPeerP95: v.optional(v.number()),
         spikeWindowStartDay: v.optional(v.number()),
         spikeWindowEndDay: v.optional(v.number()),
         sustainedWindowStartDay: v.optional(v.number()),

--- a/src/routes/-management.test.tsx
+++ b/src/routes/-management.test.tsx
@@ -25,6 +25,7 @@ function makePublisherAbuseItem({
   ownerUserId = "users:spammy",
   openedByRun = null,
   rank = Number(id),
+  scoreOverrides = {},
   scoreRunId = "publisherAbuseScoreRuns:1",
   status = "pending",
   zScore = 3.1,
@@ -51,6 +52,7 @@ function makePublisherAbuseItem({
     downloadsPerSkill: 0.25,
     reasonCodes: ["extreme_volume_low_engagement", "low_installs_per_skill"],
     createdAt: 1716000000000,
+    ...scoreOverrides,
   };
   const nomination = {
     _id: `publisherAbuseReviewNominations:${id}`,
@@ -649,6 +651,78 @@ describe("Management", () => {
     expect(screen.getByText(/close to the ban line/i)).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Mark reviewed" })).toBeNull();
     expect(screen.queryByRole("button", { name: "False positive" })).toBeNull();
+  });
+
+  it("shows temporal download/install evidence in the abuse drawer", () => {
+    const item = makePublisherAbuseItem({
+      handle: "temporal-pub",
+      scoreOverrides: {
+        modelVersion: "publisher-abuse-temporal.v1",
+        reasonCodes: ["temporal_sustained_downloads_flat_installs"],
+        temporalBenchmark: {
+          sampleSize: 1000,
+          downloads30dAverage: 180,
+          downloads30dMedian: 45,
+          downloads30dP95: 900,
+          downloads30dP99: 3000,
+          spikeMultiplier7dP95: 4,
+          spikeMultiplier7dP99: 12,
+        },
+        temporalEvidence: [
+          {
+            skillId: "skills:burst",
+            slug: "download-burst",
+            displayName: "Download Burst",
+            spike: false,
+            sustained: true,
+            pressure: 18,
+            recent7Downloads: 5000,
+            recent7Installs: 0,
+            previous30Downloads: 120,
+            baseline7Downloads: 100,
+            spikeMultiplier: 8,
+            recent30Downloads: 16_200,
+            recent30Installs: 0,
+            downloadInstallRatio30: 16_200,
+            downloads30dCohortBand: "p99",
+            downloads30dVsPeerP95: 18,
+            spikeMultiplierVsPeerP95: 2,
+            sustainedWindowStartDay: 1,
+            sustainedWindowEndDay: 30,
+            reasonCodes: ["temporal_sustained_downloads_flat_installs"],
+          },
+        ],
+      },
+    });
+
+    useQueryMock.mockImplementation((query, args) => {
+      if (args === "skip") return undefined;
+      const name = getFunctionName(query);
+      if (name === "skills:listRecentVersions") return [];
+      if (name === "skills:listReportedSkills") return [];
+      if (name === "skills:listDuplicateCandidates") return [];
+      if (name === "publisherAbuse:listReviewDashboard") {
+        return {
+          latestRun: null,
+          pendingItems: [],
+          pendingPotentialBanCandidateItems: [item],
+          pendingReviewItems: [],
+          recentResolvedItems: [],
+        };
+      }
+      if (name === "users:list") return { items: [], total: 0 };
+      return undefined;
+    });
+
+    render(<Management />);
+
+    fireEvent.click(screen.getByText("temporal-pub"));
+
+    expect(screen.getByText("Temporal signal")).toBeTruthy();
+    expect(screen.getByText(/Compared with 1,000 scanned skills/)).toBeTruthy();
+    expect(screen.getByText("Download Burst")).toBeTruthy();
+    expect(screen.getByText("16,200")).toBeTruthy();
+    expect(screen.getByText("Peer 30d P95")).toBeTruthy();
   });
 
   it("marks the abuse nomination resolved after banning its linked user", async () => {

--- a/src/routes/-management/AbusePage.tsx
+++ b/src/routes/-management/AbusePage.tsx
@@ -385,6 +385,7 @@ export function AbusePage({
                       ratio
                     />
                   </div>
+                  <PublisherTemporalEvidence score={selectedScore} />
                 </section>
 
                 {detail?.scoreHistory.length ? (
@@ -526,6 +527,70 @@ function PublisherAbuseMetric({
   );
 }
 
+function PublisherTemporalEvidence({ score }: { score: PublisherAbuseReviewScore | null }) {
+  const evidence = score?.temporalEvidence ?? [];
+  if (!evidence.length) return null;
+
+  const benchmark = score?.temporalBenchmark;
+  return (
+    <div className="pa-activity-evidence">
+      <div className="pa-subsection-label">Temporal signal</div>
+      {benchmark ? (
+        <p className="pa-hint">
+          Compared with {formatWholeNumber(benchmark.sampleSize)} scanned skills: 30d download P95{" "}
+          {formatWholeNumber(benchmark.downloads30dP95)}, P99{" "}
+          {formatWholeNumber(benchmark.downloads30dP99)}.
+        </p>
+      ) : null}
+      <div className="pa-temporal-list">
+        {evidence.map((item) => (
+          <div key={`${item.skillId}:${item.slug}`} className="pa-temporal-card">
+            <div className="pa-temporal-head">
+              <div>
+                <strong>{item.displayName}</strong>
+                <small>{item.slug}</small>
+              </div>
+              <div className="pa-temporal-badges">
+                {item.downloads30dCohortBand ? (
+                  <Badge variant="compact">{item.downloads30dCohortBand.toUpperCase()} 30d</Badge>
+                ) : null}
+                {item.spikeMultiplierCohortBand ? (
+                  <Badge variant="compact">
+                    {item.spikeMultiplierCohortBand.toUpperCase()} spike
+                  </Badge>
+                ) : null}
+              </div>
+            </div>
+            <div className="pa-temporal-metrics">
+              <PublisherAbuseMetric label="30d downloads" value={item.recent30Downloads} />
+              {benchmark ? (
+                <PublisherAbuseMetric label="Peer 30d P95" value={benchmark.downloads30dP95} />
+              ) : null}
+              {benchmark ? (
+                <PublisherAbuseMetric label="Peer 30d P99" value={benchmark.downloads30dP99} />
+              ) : null}
+              <PublisherAbuseMetric label="30d vs P95" value={item.downloads30dVsPeerP95} ratio />
+              <PublisherAbuseMetric label="7d spike multiple" value={item.spikeMultiplier} ratio />
+              {benchmark ? (
+                <PublisherAbuseMetric
+                  label="Peer spike P95"
+                  value={benchmark.spikeMultiplier7dP95}
+                  ratio
+                />
+              ) : null}
+              <PublisherAbuseMetric
+                label="Spike vs P95"
+                value={item.spikeMultiplierVsPeerP95}
+                ratio
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function publisherAbuseLabelVariant(label: string) {
   if (label === "potential_ban_candidate") return "destructive" as const;
   if (label === "review") return "review" as const;
@@ -661,7 +726,12 @@ function formatReasonCode(reason: string) {
     .replace("Extreme / Volume / Low / Engagement", "Extreme Volume, Low Engagement")
     .replace("Low / Installs / Per / Skill", "Low Installs / Skill")
     .replace("Low / Stars / Per / Skill", "Low Stars / Skill")
-    .replace("Low / Downloads / Per / Skill", "Low Downloads / Skill");
+    .replace("Low / Downloads / Per / Skill", "Low Downloads / Skill")
+    .replace("Temporal / Download / Spike / Flat / Installs", "Temporal Spike, Flat Installs")
+    .replace(
+      "Temporal / Sustained / Downloads / Flat / Installs",
+      "Temporal Sustained Downloads, Flat Installs",
+    );
 }
 
 function describeReasonCode(reason: string) {
@@ -679,6 +749,12 @@ function describeReasonCode(reason: string) {
   }
   if (reason === "low_downloads_per_skill") {
     return "Downloads per skill are far below the platform median.";
+  }
+  if (reason === "temporal_download_spike_flat_installs") {
+    return "The skill's 7-day download spike is above the peer cohort while installs stayed flat.";
+  }
+  if (reason === "temporal_sustained_downloads_flat_installs") {
+    return "The skill's 30-day downloads are above the peer cohort while installs stayed flat.";
   }
   return "Model reason emitted by the publisher abuse scorer.";
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -8396,6 +8396,13 @@ code {
   text-transform: uppercase;
 }
 
+.pa-subsection-label {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+}
+
 .pa-reason-list {
   display: flex;
   flex-direction: column;
@@ -8416,6 +8423,72 @@ code {
   color: var(--ink-soft);
   font-size: var(--fs-xs);
   line-height: 1.45;
+}
+
+.pa-activity-evidence {
+  display: grid;
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--line);
+}
+
+.pa-temporal-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.pa-temporal-card {
+  display: grid;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  background: var(--surface-muted);
+}
+
+.pa-temporal-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.pa-temporal-head > div:first-child {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.pa-temporal-head strong {
+  overflow: hidden;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pa-temporal-head small {
+  overflow: hidden;
+  color: var(--ink-soft);
+  font-size: var(--fs-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pa-temporal-badges {
+  display: flex;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 4px;
+}
+
+.pa-temporal-metrics {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2px var(--space-4);
 }
 
 .pa-history {


### PR DESCRIPTION
## Overview

Adds cohort-relative temporal abuse scoring for publisher moderation. Instead of fixed download thresholds, each scan builds a benchmark from the scanned skill cohort and flags skills that are in the top P95/P99 for 30d downloads or 7d spike multiplier while installs stay near zero.

Publisher escalation now uses that temporal evidence:
- one P99 temporal hit becomes a potential ban candidate
- one P95 temporal hit becomes review
- multiple high temporal hits still escalate

The scan persists the cohort benchmark/evidence and the management drawer now renders the temporal signal inside Publisher activity so reviewers can see the suspicious 30d volume, spike multiplier, cohort band, and peer threshold.

## Test plan

- `bunx vitest run convex/lib/publisherAbuseScoring.test.ts convex/publisherAbuse.test.ts convex/publisherAbuseDevSeed.test.ts src/routes/-management.test.tsx`
- `bunx tsc --noEmit --pretty false`
- `bun run format:check -- convex/lib/publisherAbuseScoring.test.ts convex/lib/publisherAbuseScoring.ts convex/publisherAbuse.test.ts convex/publisherAbuse.ts convex/publisherAbuseDevSeed.test.ts convex/publisherAbuseDevSeed.ts convex/schema.ts src/routes/-management.test.tsx src/routes/-management/AbusePage.tsx src/styles.css`

## UI proof

Local screenshot captured at `.artifacts/screenshots/temporal-abuse-admin-panel-updated-metrics.png`.
