### PR TITLE
test: limit local-auth Playwright retries

### DIFF
--- a/scripts/playwright-local-auth-config.test.ts
+++ b/scripts/playwright-local-auth-config.test.ts
@@ -28,11 +28,25 @@ describe("playwright local-auth runner config", () => {
 
   it("passes explicit Playwright args and defaults to the local-auth suite", () => {
     expect(resolveLocalAuthRunnerConfig({}, ["--", "e2e/example.pw.test.ts"])).toMatchObject({
-      playwrightArgs: ["e2e/example.pw.test.ts"],
+      playwrightArgs: ["--retries=1", "e2e/example.pw.test.ts"],
     });
     expect(resolveLocalAuthRunnerConfig({}).playwrightArgs).toEqual([
+      "--retries=1",
       "--project=chromium",
       "e2e/local-auth",
     ]);
+  });
+
+  it("preserves an explicit Playwright retries override", () => {
+    expect(
+      resolveLocalAuthRunnerConfig({}, ["--", "--retries=0", "e2e/example.pw.test.ts"]),
+    ).toMatchObject({
+      playwrightArgs: ["--retries=0", "e2e/example.pw.test.ts"],
+    });
+    expect(
+      resolveLocalAuthRunnerConfig({}, ["--", "--retries", "2", "e2e/example.pw.test.ts"]),
+    ).toMatchObject({
+      playwrightArgs: ["--retries", "2", "e2e/example.pw.test.ts"],
+    });
   });
 });

--- a/scripts/playwright-local-auth-config.ts
+++ b/scripts/playwright-local-auth-config.ts
@@ -1,6 +1,7 @@
 const DEFAULT_CONVEX_URL = "http://127.0.0.1:3210";
 const DEFAULT_CONVEX_SITE_URL = "http://127.0.0.1:3211";
 const DEFAULT_PLAYWRIGHT_ARGS = ["--project=chromium", "e2e/local-auth"];
+const DEFAULT_PLAYWRIGHT_RETRIES = "1";
 
 type RunnerEnv = Record<string, string | undefined>;
 
@@ -15,6 +16,13 @@ function stripPackageManagerSeparator(args: string[]) {
   return args[0] === "--" ? args.slice(1) : args;
 }
 
+function withDefaultRetries(args: string[]) {
+  if (args.some((arg) => arg === "--retries" || arg.startsWith("--retries="))) {
+    return args;
+  }
+  return [`--retries=${DEFAULT_PLAYWRIGHT_RETRIES}`, ...args];
+}
+
 export function resolveLocalAuthRunnerConfig(
   env: RunnerEnv = process.env,
   argv: string[] = process.argv.slice(2),
@@ -24,6 +32,8 @@ export function resolveLocalAuthRunnerConfig(
     convexDeployment: env.PLAYWRIGHT_LOCAL_AUTH_CONVEX_DEPLOYMENT,
     convexSiteUrl: env.PLAYWRIGHT_LOCAL_AUTH_CONVEX_SITE_URL ?? DEFAULT_CONVEX_SITE_URL,
     convexUrl: env.PLAYWRIGHT_LOCAL_AUTH_CONVEX_URL ?? DEFAULT_CONVEX_URL,
-    playwrightArgs: playwrightArgs.length > 0 ? playwrightArgs : DEFAULT_PLAYWRIGHT_ARGS,
+    playwrightArgs: withDefaultRetries(
+      playwrightArgs.length > 0 ? playwrightArgs : DEFAULT_PLAYWRIGHT_ARGS,
+    ),
   };
 }


### PR DESCRIPTION
## Summary
- default the local-auth Playwright runner to one retry
- preserve explicit `--retries` overrides for local debugging
- cover the retry argument behavior in the runner config test

## Tests
- `bunx vitest run scripts/playwright-local-auth-config.test.ts` ✅
- `bun run ci:static` ✅
- `bun run ci:unit` ❌ failed in unrelated existing suites:
  - `convex/packages.public.test.ts` expected `revokedTokenCount: 1`, received `0`
  - `convex/skills.banBatches.test.ts` mock rejected unexpected `skillVersions` table
  - `src/__tests__/ui-design-contract.test.ts` matched existing `compact`/settings source text
