### PR TITLE
test: cover account recreation after deletion

### DIFF
--- a/convex/devSeed.ts
+++ b/convex/devSeed.ts
@@ -3672,6 +3672,77 @@ export const getAccountDeletionFixtureState: ReturnType<typeof rawInternalMutati
     },
   });
 
+export const getAccountRecreationState: ReturnType<typeof rawInternalMutation> =
+  rawInternalMutation({
+    args: {
+      handle: v.string(),
+      previousUserId: v.id("users"),
+      previousPublisherId: v.id("publishers"),
+      previousSkillId: v.id("skills"),
+      previousPackageId: v.id("packages"),
+    },
+    handler: async (ctx, args) => {
+      const previousUser = await ctx.db.get(args.previousUserId);
+      const previousPublisher = await ctx.db.get(args.previousPublisherId);
+      const previousSkill = await ctx.db.get(args.previousSkillId);
+      const previousPackage = await ctx.db.get(args.previousPackageId);
+      const user = await ctx.db
+        .query("users")
+        .withIndex("handle", (q) => q.eq("handle", args.handle))
+        .unique();
+      const activeUser = user && !user.deletedAt && !user.deactivatedAt ? user : null;
+      const publisher = await ctx.db
+        .query("publishers")
+        .withIndex("by_handle", (q) => q.eq("handle", args.handle))
+        .unique();
+      const activePublisher =
+        publisher && !publisher.deletedAt && !publisher.deactivatedAt ? publisher : null;
+      const linkedPublisherUser = activePublisher?.linkedUserId
+        ? await ctx.db.get(activePublisher.linkedUserId)
+        : null;
+      const activePublisherUser =
+        linkedPublisherUser && !linkedPublisherUser.deletedAt && !linkedPublisherUser.deactivatedAt
+          ? linkedPublisherUser
+          : null;
+      const activeResolvedUser = activeUser ?? activePublisherUser;
+
+      return {
+        ok: true as const,
+        previousUser: previousUser
+          ? {
+              exists: true,
+              handle: previousUser.handle ?? null,
+              deactivatedAt: previousUser.deactivatedAt ?? null,
+              purgedAt: previousUser.purgedAt ?? null,
+              deletedAt: previousUser.deletedAt ?? null,
+            }
+          : { exists: false },
+        previousPublisherExists: Boolean(previousPublisher),
+        previousSkillActive: Boolean(previousSkill && !previousSkill.softDeletedAt),
+        previousPackageActive: Boolean(previousPackage && !previousPackage.softDeletedAt),
+        activeUser: activeResolvedUser
+          ? {
+              userId: activeResolvedUser._id,
+              handle: activeResolvedUser.handle ?? activePublisher?.handle ?? "",
+              deactivatedAt: activeResolvedUser.deactivatedAt ?? null,
+              purgedAt: activeResolvedUser.purgedAt ?? null,
+              deletedAt: activeResolvedUser.deletedAt ?? null,
+              personalPublisherId: activeResolvedUser.personalPublisherId ?? null,
+            }
+          : null,
+        activePublisher: activePublisher
+          ? {
+              publisherId: activePublisher._id,
+              handle: activePublisher.handle,
+              linkedUserId: activePublisher.linkedUserId ?? null,
+              deactivatedAt: activePublisher.deactivatedAt ?? null,
+              deletedAt: activePublisher.deletedAt ?? null,
+            }
+          : null,
+      };
+    },
+  });
+
 async function upsertRoleHelpFixtureUser(ctx: MutationCtx, user: RoleHelpFixtureUser) {
   const now = Date.now();
   const existing = await ctx.db

--- a/e2e/local-auth/delete-account-resources.pw.test.ts
+++ b/e2e/local-auth/delete-account-resources.pw.test.ts
@@ -97,6 +97,36 @@ type AccountDeletionFixtureState = {
   authSessionCount: number;
 };
 
+type AccountRecreationState = {
+  previousUser:
+    | {
+        exists: true;
+        handle: string | null;
+        deactivatedAt: number | null;
+        purgedAt: number | null;
+        deletedAt: number | null;
+      }
+    | { exists: false };
+  previousPublisherExists: boolean;
+  previousSkillActive: boolean;
+  previousPackageActive: boolean;
+  activeUser: {
+    userId: string;
+    handle: string;
+    deactivatedAt: number | null;
+    purgedAt: number | null;
+    deletedAt: number | null;
+    personalPublisherId: string | null;
+  } | null;
+  activePublisher: {
+    publisherId: string;
+    handle: string;
+    linkedUserId: string | null;
+    deactivatedAt: number | null;
+    deletedAt: number | null;
+  } | null;
+};
+
 function seedAccountDeletionFixture(args: {
   skillSlug: string;
   skillDisplayName: string;
@@ -112,6 +142,16 @@ function getAccountDeletionFixtureState(fixture: AccountDeletionFixture) {
     publisherId: fixture.publisherId,
     skillId: fixture.skillId,
     packageId: fixture.packageId,
+  });
+}
+
+function getAccountRecreationState(fixture: AccountDeletionFixture) {
+  return runDevSeed<AccountRecreationState>("devSeed:getAccountRecreationState", {
+    handle: fixture.handle,
+    previousUserId: fixture.userId,
+    previousPublisherId: fixture.publisherId,
+    previousSkillId: fixture.skillId,
+    previousPackageId: fixture.packageId,
   });
 }
 
@@ -216,6 +256,48 @@ test("users can permanently delete their account and personal publisher resource
     path: testInfo.outputPath("account-deletion-post-cleanup.png"),
     fullPage: true,
   });
+
+  await signInAsLocalPersona(page, "user");
+  await expect
+    .poll(() => getAccountRecreationState(fixture), {
+      timeout: 30_000,
+      intervals: [500, 1_000, 2_000],
+    })
+    .toMatchObject({
+      previousUser: {
+        exists: true,
+        handle: null,
+        deletedAt: null,
+      },
+      previousPublisherExists: false,
+      previousSkillActive: false,
+      previousPackageActive: false,
+      activeUser: {
+        deactivatedAt: null,
+        purgedAt: null,
+        deletedAt: null,
+      },
+      activePublisher: {
+        handle: fixture.handle,
+        deactivatedAt: null,
+        deletedAt: null,
+      },
+    });
+  const recreationState = getAccountRecreationState(fixture);
+  expect(recreationState.activeUser?.userId).toBeTruthy();
+  expect(recreationState.activeUser?.userId).not.toBe(fixture.userId);
+  expect(recreationState.activePublisher?.publisherId).toBeTruthy();
+  expect(recreationState.activePublisher?.publisherId).not.toBe(fixture.publisherId);
+  expect(recreationState.activePublisher?.linkedUserId).toBe(recreationState.activeUser?.userId);
+  expect(recreationState.activeUser?.personalPublisherId).toBe(
+    recreationState.activePublisher?.publisherId,
+  );
+
+  await page.goto(`/user/${fixture.handle}`, { waitUntil: "domcontentloaded" });
+  await waitForHydration(page);
+  await expect(page.getByRole("heading", { name: "Local User" })).toBeVisible();
+  await expect(page.getByText(skillDisplayName)).toHaveCount(0);
+  await expect(page.getByText(packageDisplayName)).toHaveCount(0);
 
   await expectNoFatalErrorUi(page);
   expect(errors.filter((error) => !isExpectedAccountDeletionRuntimeError(error))).toEqual([]);


### PR DESCRIPTION
## Summary
- extends the local-auth account deletion e2e to sign back in after deletion
- verifies a new active user and personal publisher are created, linked, and using the reclaimed handle
- verifies the old publisher is gone and the old skill/package no longer appear on the recreated profile

## Verification
- `bun run format:check -- convex/devSeed.ts e2e/local-auth/delete-account-resources.pw.test.ts`
- `bunx tsc --noEmit`
- `bun run ci:static`
- `PLAYWRIGHT_LOCAL_AUTH_CONVEX_URL=http://127.0.0.1:3216 PLAYWRIGHT_LOCAL_AUTH_CONVEX_SITE_URL=http://127.0.0.1:3217 bun run test:pw:local-auth -- --project=chromium e2e/local-auth/delete-account-resources.pw.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local` with no accepted/actionable findings

No live migration was run.
