### PR TITLE
fix: make account recovery purge idempotent

### DIFF
--- a/convex/users.test.ts
+++ b/convex/users.test.ts
@@ -1844,6 +1844,146 @@ describe("users.purgeSelfDeletedAccountRecoveryBatchInternal", () => {
     expect(runMutation).not.toHaveBeenCalled();
   });
 
+  it("skips already-cleaned self-delete tombstones without auth locks", async () => {
+    const users = [
+      {
+        _id: "users:recovery-purged",
+        _creationTime: 1,
+        deactivatedAt: 1_700_000_000_000,
+        purgedAt: 1_700_000_000_000,
+        deletedAt: undefined,
+        banReason: undefined,
+        handle: undefined,
+        displayName: undefined,
+        name: undefined,
+        email: undefined,
+        personalPublisherId: undefined,
+      },
+      {
+        _id: "users:modern-cleanup",
+        _creationTime: 2,
+        deactivatedAt: 1_700_000_000_001,
+        purgedAt: 1_700_000_000_001,
+        deletedAt: undefined,
+        banReason: undefined,
+        handle: undefined,
+        displayName: undefined,
+        name: undefined,
+        email: undefined,
+        personalPublisherId: undefined,
+      },
+    ];
+    const logsByUser = new Map([
+      [
+        "users:recovery-purged",
+        [
+          {
+            _id: "auditLogs:self-delete",
+            actorUserId: "users:recovery-purged",
+            action: "user.delete",
+            targetType: "user",
+            targetId: "users:recovery-purged",
+            metadata: { previous: { handle: "gone" } },
+          },
+          {
+            _id: "auditLogs:recovery-purge",
+            actorUserId: "users:recovery-purged",
+            action: "user.recovery_purge",
+            targetType: "user",
+            targetId: "users:recovery-purged",
+            metadata: { source: "backfill" },
+          },
+        ],
+      ],
+      [
+        "users:modern-cleanup",
+        [
+          {
+            _id: "auditLogs:modern-delete",
+            actorUserId: "users:modern-cleanup",
+            action: "user.delete",
+            targetType: "user",
+            targetId: "users:modern-cleanup",
+            metadata: { cleanup: { authAccounts: 1 } },
+          },
+        ],
+      ],
+    ]);
+    const query = vi.fn((table: string) => {
+      if (table === "users") {
+        return {
+          withIndex: vi.fn((indexName: string) => {
+            if (indexName !== "by_deactivated_purged_at") {
+              throw new Error(`Unexpected users index ${indexName}`);
+            }
+            return {
+              paginate: vi.fn(async () => ({
+                page: users,
+                isDone: true,
+                continueCursor: "",
+              })),
+            };
+          }),
+        };
+      }
+      if (table === "auditLogs") {
+        return {
+          withIndex: vi.fn((_indexName: string, buildQuery: (q: unknown) => unknown) => {
+            const fields: Record<string, string> = {};
+            const q = {
+              eq: (field: string, value: string) => {
+                fields[field] = value;
+                return q;
+              },
+            };
+            buildQuery(q);
+            return {
+              collect: vi.fn(async () => logsByUser.get(fields.targetId) ?? []),
+            };
+          }),
+        };
+      }
+      if (table === "authAccounts") {
+        return {
+          withIndex: vi.fn((_indexName: string) => ({
+            collect: vi.fn(async () => []),
+          })),
+        };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const result = (await purgeSelfDeletedAccountRecoveryBatchInternalHandler(
+      {
+        db: {
+          query,
+          patch: vi.fn(),
+          insert: vi.fn(),
+          delete: vi.fn(),
+          get: vi.fn(),
+          normalizeId: vi.fn(),
+        },
+        runMutation: vi.fn(),
+      } as never,
+      { dryRun: true, mode: "deactivated", limit: 10 },
+    )) as {
+      dryRun: boolean;
+      eligible: number;
+      candidates: Array<Record<string, unknown>>;
+      skipped: Array<Record<string, unknown>>;
+    };
+
+    expect(result).toMatchObject({
+      dryRun: true,
+      eligible: 0,
+      candidates: [],
+      skipped: [
+        { userId: "users:recovery-purged", reason: "not_self_deleted_or_security_blocked" },
+        { userId: "users:modern-cleanup", reason: "not_self_deleted_or_security_blocked" },
+      ],
+    });
+  });
+
   it("dry-runs auth-locked purged users without self-delete audit proof", async () => {
     const users = [
       {

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -1076,7 +1076,11 @@ async function getSelfDeletedAccountEligibility(
   const selfDeleteAuditLog =
     logs.find((log) => log.action === "user.delete" && log.actorUserId === user._id) ?? null;
   const hasBanAudit = logs.some((log) => BAN_AUDIT_ACTIONS.has(log.action));
-  if (selfDeleteAuditLog && !hasBanAudit) {
+  const hasRecoveryPurgeAudit = logs.some((log) => log.action === "user.recovery_purge");
+  const selfDeleteAuditAlreadyCleaned = Boolean(
+    asRecord(selfDeleteAuditLog?.metadata)?.cleanup || hasRecoveryPurgeAudit,
+  );
+  if (selfDeleteAuditLog && !hasBanAudit && !selfDeleteAuditAlreadyCleaned) {
     return {
       eligible: true,
       reason: "self_delete_audit" as const,


### PR DESCRIPTION
## Summary
- Make the account recovery purge eligibility idempotent for already-cleaned self-delete tombstones.
- Stop treating a self-delete audit as a fresh purge candidate when either a recovery purge audit already exists or the original delete audit includes cleanup metadata.
- Add regression coverage for already-cleaned tombstones without auth locks.

## Tests
- `bunx vitest run convex/users.test.ts -t "skips already-cleaned self-delete tombstones"`
- `bunx vitest run convex/users.test.ts`
- `bun run format:check -- convex/users.ts convex/users.test.ts`
- `bunx tsc --noEmit`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bun run ci:static`
