### PR TITLE
fix: block moderated skill version metadata

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -3188,6 +3188,45 @@ describe("httpApiV1 handlers", () => {
     expect(json.version.files[0].path).toBe("SKILL.md");
   });
 
+  it("blocks version detail for moderated skills", async () => {
+    let slugLookupCount = 0;
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("slug" in args) {
+        slugLookupCount += 1;
+        if (slugLookupCount === 1) return null;
+        return {
+          _id: "skills:1",
+          slug: "demo",
+          displayName: "Demo",
+          tags: { latest: "skillVersions:1" },
+          moderationStatus: "removed",
+          moderationReason: "policy.violation",
+          moderationFlags: [],
+          moderationSourceVersionId: "skillVersions:1",
+        };
+      }
+      if ("skillId" in args && "version" in args) {
+        return {
+          _id: "skillVersions:1",
+          skillId: "skills:1",
+          version: "1.0.0",
+          createdAt: 1,
+          changelog: "c",
+          changelogSource: "auto",
+          files: [],
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const response = await __handlers.skillsGetRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/demo/versions/1.0.0"),
+    );
+    expect(response.status).toBe(410);
+    expect(await response.text()).toBe("This skill has been removed by a moderator.");
+  });
+
   it("returns 404 for version detail when the owner is banned", async () => {
     const runQuery = vi.fn(async () => null);
     const runMutation = vi.fn().mockResolvedValue(okRate());
@@ -3549,6 +3588,89 @@ describe("httpApiV1 handlers", () => {
     expect(json.security.scanners.llm.normalizedStatus).toBe("error");
   });
 
+  it("blocks latest scan status while security review is pending", async () => {
+    let slugLookupCount = 0;
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("slug" in args) {
+        slugLookupCount += 1;
+        if (slugLookupCount === 1) return null;
+        return {
+          _id: "skills:1",
+          slug: "demo",
+          displayName: "Demo",
+          latestVersionId: "skillVersions:1",
+          tags: { latest: "skillVersions:1" },
+          moderationStatus: "hidden",
+          moderationReason: "pending.scan",
+          moderationFlags: [],
+          moderationSourceVersionId: "skillVersions:1",
+        };
+      }
+      if ("versionId" in args) {
+        return {
+          _id: "skillVersions:1",
+          skillId: "skills:1",
+          version: "1.0.0",
+          createdAt: 1,
+          changelog: "c",
+          changelogSource: "auto",
+          capabilityTags: ["posts-externally", "requires-oauth-token"],
+          files: [],
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const response = await __handlers.skillsGetRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/demo/scan"),
+    );
+    expect(response.status).toBe(423);
+    expect(await response.text()).toContain("pending a ClawScan security review");
+  });
+
+  for (const moderationReason of ["pending.scan.stale", "scanner.llm.pending"] as const) {
+    it(`blocks latest scan status for ${moderationReason} when unavailable publicly`, async () => {
+      let slugLookupCount = 0;
+      const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+        if ("slug" in args) {
+          slugLookupCount += 1;
+          if (slugLookupCount === 1) return null;
+          return {
+            _id: "skills:1",
+            slug: "demo",
+            displayName: "Demo",
+            latestVersionId: "skillVersions:1",
+            tags: { latest: "skillVersions:1" },
+            moderationStatus: "hidden",
+            moderationReason,
+            moderationFlags: [],
+            moderationSourceVersionId: "skillVersions:1",
+          };
+        }
+        if ("versionId" in args) {
+          return {
+            _id: "skillVersions:1",
+            skillId: "skills:1",
+            version: "1.0.0",
+            createdAt: 1,
+            changelog: "c",
+            changelogSource: "auto",
+            files: [],
+          };
+        }
+        return null;
+      });
+      const runMutation = vi.fn().mockResolvedValue(okRate());
+      const response = await __handlers.skillsGetRouterV1Handler(
+        makeCtx({ runQuery, runMutation }),
+        new Request("https://example.com/api/v1/skills/demo/scan"),
+      );
+      expect(response.status).toBe(423);
+      expect(await response.text()).toContain("pending a ClawScan security review");
+    });
+  }
+
   it("returns capability tags even when no scanner result exists yet", async () => {
     const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
       if ("slug" in args) {
@@ -3558,7 +3680,7 @@ describe("httpApiV1 handlers", () => {
             slug: "demo",
             displayName: "Demo",
             summary: "s",
-            tags: { latest: "versions:1" },
+            tags: { latest: "skillVersions:1" },
             stats: {},
             createdAt: 1,
             updatedAt: 2,
@@ -3575,7 +3697,7 @@ describe("httpApiV1 handlers", () => {
           },
           owner: { _id: "users:1", handle: "owner", displayName: "Owner" },
           moderationInfo: {
-            isPendingScan: true,
+            isPendingScan: false,
             isMalwareBlocked: false,
             isSuspicious: false,
             isHiddenByMod: false,
@@ -3594,6 +3716,277 @@ describe("httpApiV1 handlers", () => {
     const json = await response.json();
     expect(json.security.capabilityTags).toEqual(["posts-externally", "requires-oauth-token"]);
     expect(json.security.hasScanResult).toBe(false);
+  });
+
+  it("blocks exact scan status for moderated skills", async () => {
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("slug" in args) {
+        return {
+          skill: {
+            _id: "skills:1",
+            slug: "demo",
+            displayName: "Demo",
+            summary: "s",
+            latestVersionId: "skillVersions:2",
+            tags: { latest: "skillVersions:2" },
+            stats: {},
+            createdAt: 1,
+            updatedAt: 2,
+          },
+          latestVersion: {
+            _id: "skillVersions:2",
+            skillId: "skills:1",
+            version: "2.0.0",
+            createdAt: 2,
+            changelog: "c2",
+            changelogSource: "auto",
+            files: [],
+          },
+          owner: { _id: "users:1", handle: "owner", displayName: "Owner" },
+          moderationInfo: {
+            isPendingScan: false,
+            isMalwareBlocked: true,
+            isSuspicious: false,
+            isHiddenByMod: false,
+            isRemoved: false,
+            sourceVersionId: "skillVersions:1",
+          },
+        };
+      }
+      if ("skillId" in args && "version" in args) {
+        return {
+          _id: "skillVersions:1",
+          skillId: "skills:1",
+          version: "1.0.0",
+          createdAt: 1,
+          changelog: "c1",
+          changelogSource: "auto",
+          files: [],
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const response = await __handlers.skillsGetRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/demo/scan?version=1.0.0"),
+    );
+    expect(response.status).toBe(403);
+    expect(await response.text()).toContain("flagged as malicious");
+  });
+
+  it("blocks exact scan status when the moderated skill is unavailable publicly", async () => {
+    let slugLookupCount = 0;
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("slug" in args) {
+        slugLookupCount += 1;
+        if (slugLookupCount === 1) return null;
+        return {
+          _id: "skills:1",
+          slug: "demo",
+          displayName: "Demo",
+          latestVersionId: "skillVersions:1",
+          tags: { latest: "skillVersions:1" },
+          moderationStatus: "hidden",
+          moderationReason: "pending.scan",
+          moderationFlags: [],
+          moderationSourceVersionId: "skillVersions:1",
+        };
+      }
+      if ("skillId" in args && "version" in args) {
+        return {
+          _id: "skillVersions:1",
+          skillId: "skills:1",
+          version: "1.0.0",
+          createdAt: 1,
+          changelog: "c1",
+          changelogSource: "auto",
+          files: [],
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const response = await __handlers.skillsGetRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/demo/scan?version=1.0.0"),
+    );
+    expect(response.status).toBe(423);
+    expect(await response.text()).toContain("pending a ClawScan security review");
+  });
+
+  it("blocks tagged scan status when the moderated skill is unavailable publicly", async () => {
+    let slugLookupCount = 0;
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("slug" in args) {
+        slugLookupCount += 1;
+        if (slugLookupCount === 1) return null;
+        return {
+          _id: "skills:1",
+          slug: "demo",
+          displayName: "Demo",
+          latestVersionId: "skillVersions:2",
+          tags: { latest: "skillVersions:2", old: "skillVersions:1" },
+          moderationStatus: "hidden",
+          moderationReason: "pending.scan",
+          moderationFlags: [],
+          moderationSourceVersionId: "skillVersions:1",
+        };
+      }
+      if ("versionId" in args) {
+        return {
+          _id: "skillVersions:1",
+          skillId: "skills:1",
+          version: "1.0.0",
+          createdAt: 1,
+          changelog: "c1",
+          changelogSource: "auto",
+          files: [],
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const response = await __handlers.skillsGetRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/demo/scan?tag=old"),
+    );
+    expect(response.status).toBe(423);
+    expect(await response.text()).toContain("pending a ClawScan security review");
+  });
+
+  it("keeps historical scan status available when latest-version moderation is blocked", async () => {
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("slug" in args) {
+        return {
+          skill: {
+            _id: "skills:1",
+            slug: "demo",
+            displayName: "Demo",
+            summary: "s",
+            latestVersionId: "skillVersions:2",
+            tags: { latest: "skillVersions:2" },
+            stats: {},
+            createdAt: 1,
+            updatedAt: 2,
+          },
+          latestVersion: {
+            _id: "skillVersions:2",
+            skillId: "skills:1",
+            version: "2.0.0",
+            createdAt: 2,
+            changelog: "c2",
+            changelogSource: "auto",
+            files: [],
+          },
+          owner: { _id: "users:1", handle: "owner", displayName: "Owner" },
+          moderationInfo: {
+            isPendingScan: false,
+            isMalwareBlocked: true,
+            isSuspicious: false,
+            isHiddenByMod: false,
+            isRemoved: false,
+          },
+        };
+      }
+      if ("skillId" in args && "version" in args) {
+        return {
+          _id: "skillVersions:1",
+          skillId: "skills:1",
+          version: "1.0.0",
+          createdAt: 1,
+          changelog: "c1",
+          changelogSource: "auto",
+          sha256hash: "f".repeat(64),
+          vtAnalysis: {
+            status: "clean",
+            checkedAt: 123,
+          },
+          llmAnalysis: {
+            status: "completed",
+            verdict: "benign",
+            checkedAt: 124,
+          },
+          files: [],
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const response = await __handlers.skillsGetRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/demo/scan?version=1.0.0"),
+    );
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.version.version).toBe("1.0.0");
+    expect(json.security.status).toBe("clean");
+    expect(json.moderation.matchesRequestedVersion).toBe(false);
+  });
+
+  it("reports the moderation source version for historical scan matches", async () => {
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("slug" in args) {
+        return {
+          skill: {
+            _id: "skills:1",
+            slug: "demo",
+            displayName: "Demo",
+            summary: "s",
+            latestVersionId: "skillVersions:2",
+            tags: { latest: "skillVersions:2" },
+            stats: {},
+            createdAt: 1,
+            updatedAt: 2,
+          },
+          latestVersion: {
+            _id: "skillVersions:2",
+            skillId: "skills:1",
+            version: "2.0.0",
+            createdAt: 2,
+            changelog: "c2",
+            changelogSource: "auto",
+            files: [],
+          },
+          owner: { _id: "users:1", handle: "owner", displayName: "Owner" },
+          moderationInfo: {
+            isPendingScan: false,
+            isMalwareBlocked: false,
+            isSuspicious: true,
+            isHiddenByMod: false,
+            isRemoved: false,
+            sourceVersionId: "skillVersions:1",
+          },
+        };
+      }
+      if ("skillId" in args && "version" in args) {
+        return {
+          _id: "skillVersions:1",
+          skillId: "skills:1",
+          version: "1.0.0",
+          createdAt: 1,
+          changelog: "c1",
+          changelogSource: "auto",
+          sha256hash: "f".repeat(64),
+          llmAnalysis: {
+            status: "completed",
+            verdict: "suspicious",
+            checkedAt: 123,
+          },
+          files: [],
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const response = await __handlers.skillsGetRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/demo/scan?version=1.0.0"),
+    );
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.moderation.sourceVersion).toEqual({ version: "1.0.0", createdAt: 1 });
+    expect(json.moderation.matchesRequestedVersion).toBe(true);
   });
 
   it("keeps hasScanResult true when one scanner returns a definitive verdict", async () => {
@@ -8011,6 +8404,98 @@ describe("httpApiV1 handlers", () => {
         },
       },
     });
+  });
+
+  it("packages version detail blocks skill compatibility metadata for malware-blocked skills", async () => {
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("name" in args) return null;
+      if ("slug" in args) {
+        return {
+          skill: {
+            _id: "skills:demo",
+            slug: "demo",
+            displayName: "Demo Skill",
+            summary: "Skill summary",
+            latestVersionId: "skillVersions:demo-2",
+            tags: { latest: "skillVersions:demo-2" },
+            badges: {},
+            createdAt: 1,
+            updatedAt: 2,
+          },
+          latestVersion: null,
+          owner: { handle: "steipete" },
+          moderationInfo: {
+            isPendingScan: false,
+            isMalwareBlocked: true,
+            isHiddenByMod: false,
+            isRemoved: false,
+            sourceVersionId: "skillVersions:demo-1",
+          },
+        };
+      }
+      if ("skillId" in args && "version" in args) {
+        return {
+          _id: "skillVersions:demo-1",
+          skillId: "skills:demo",
+          version: "1.0.0",
+          createdAt: 3,
+          changelog: "init",
+          files: [],
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.packagesGetRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/packages/demo/versions/1.0.0"),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toContain("flagged as malicious");
+  });
+
+  it("packages version detail blocks moderated skills that are unavailable publicly", async () => {
+    let slugLookupCount = 0;
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("name" in args) return null;
+      if ("slug" in args) {
+        slugLookupCount += 1;
+        if (slugLookupCount === 1) return null;
+        return {
+          _id: "skills:demo",
+          slug: "demo",
+          displayName: "Demo Skill",
+          latestVersionId: "skillVersions:demo-1",
+          tags: { latest: "skillVersions:demo-1" },
+          moderationStatus: "hidden",
+          moderationReason: "pending.scan",
+          moderationFlags: [],
+          moderationSourceVersionId: "skillVersions:demo-1",
+        };
+      }
+      if ("skillId" in args && "version" in args) {
+        return {
+          _id: "skillVersions:demo-1",
+          skillId: "skills:demo",
+          version: "1.0.0",
+          createdAt: 3,
+          changelog: "init",
+          files: [],
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.packagesGetRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/packages/demo/versions/1.0.0"),
+    );
+
+    expect(response.status).toBe(423);
+    expect(await response.text()).toContain("pending a ClawScan security review");
   });
 
   it("packages version detail returns ClawPack artifact metadata", async () => {

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -54,7 +54,12 @@ import {
   MAX_PUBLISH_FILE_BYTES,
   MAX_PUBLISH_TOTAL_BYTES,
 } from "../lib/publishLimits";
-import { getPublicSkillFileAccessBlock, isSkillVersionForSkill } from "../lib/skillFileAccess";
+import {
+  getPublicSkillFileAccessBlock,
+  getPublicSkillVersionAccessBlock,
+  getSkillFileModerationInfoFromSkill,
+  isSkillVersionForSkill,
+} from "../lib/skillFileAccess";
 import { isMacJunkPath, isTextFile } from "../lib/skills";
 import {
   buildDeterministicPackageZip,
@@ -2875,8 +2880,47 @@ async function getSkillDetailForRequest(ctx: ActionCtx, slug: string) {
       isMalwareBlocked?: boolean | null;
       isHiddenByMod?: boolean | null;
       isRemoved?: boolean | null;
+      sourceVersionId?: Id<"skillVersions"> | null;
     } | null;
   } | null;
+}
+
+type PackageExactVersionModeratedSkill = Pick<
+  Doc<"skills">,
+  | "_id"
+  | "softDeletedAt"
+  | "latestVersionId"
+  | "tags"
+  | "moderationStatus"
+  | "moderationReason"
+  | "moderationFlags"
+  | "moderationSourceVersionId"
+>;
+
+async function getUnavailableSkillPackageVersionBlock(
+  ctx: ActionCtx,
+  slug: string,
+  versionName: string,
+) {
+  const skill = await runQueryRef<PackageExactVersionModeratedSkill | null>(
+    ctx,
+    internalRefs.skills.getSkillBySlugInternal,
+    { slug },
+  );
+  if (!skill || skill.softDeletedAt) return null;
+
+  const version = (await runQueryRef(ctx, internalRefs.skills.getVersionBySkillAndVersionInternal, {
+    skillId: skill._id,
+    version: versionName,
+  })) as SkillVersionLike | null;
+  if (!version || !isSkillVersionForSkill(version, skill._id)) return null;
+  if (version.softDeletedAt) return { status: 410, message: "Version not available" };
+
+  return getPublicSkillVersionAccessBlock(
+    getSkillFileModerationInfoFromSkill(skill),
+    version._id,
+    skill.latestVersionId ?? skill.tags?.latest,
+  );
 }
 
 async function getSkillVersionForRequest(
@@ -3238,7 +3282,21 @@ export async function packagesGetRouterV1Handler(ctx: ActionCtx, request: Reques
   const skillDetail = detail?.package
     ? null
     : await getSkillDetailForRequest(ctx, normalizedPackageName);
-  if (!detail?.package && !skillDetail?.skill) return text("Package not found", 404, rate.headers);
+  const isExactVersionRequest =
+    packageSegments[0] === "versions" && packageSegments[1] && packageSegments.length === 2;
+  if (!detail?.package && !skillDetail?.skill) {
+    if (isExactVersionRequest) {
+      const moderationBlock = await getUnavailableSkillPackageVersionBlock(
+        ctx,
+        normalizedPackageName,
+        packageSegments[1],
+      );
+      if (moderationBlock) {
+        return text(moderationBlock.message, moderationBlock.status, rate.headers);
+      }
+    }
+    return text("Package not found", 404, rate.headers);
+  }
   const packageDetail = detail?.package ? detail : null;
   const publicPackage = packageDetail?.package ?? null;
   const packageOwner = packageDetail?.owner ?? null;
@@ -3420,6 +3478,15 @@ export async function packagesGetRouterV1Handler(ctx: ActionCtx, request: Reques
         },
       )) as SkillVersionLike | null;
       if (!version || version.softDeletedAt) return text("Version not found", 404, rate.headers);
+      const effectiveLatestVersionId =
+        skillDetail.skill.latestVersionId ?? skillDetail.skill.tags?.latest;
+      const moderationBlock = getPublicSkillVersionAccessBlock(
+        skillDetail.moderationInfo,
+        version._id,
+        effectiveLatestVersionId,
+      );
+      if (moderationBlock)
+        return text(moderationBlock.message, moderationBlock.status, rate.headers);
       const tags = await resolveSkillTags(ctx, skillDetail.skill._id, skillDetail.skill.tags);
       return json(
         {

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -33,7 +33,12 @@ import type {
   LlmRiskSummary,
 } from "../lib/securityPrompt";
 import { selectGeneratedSkillCardFile, sourceSkillVersionFiles } from "../lib/skillCards";
-import { getPublicSkillFileAccessBlock, isSkillVersionForSkill } from "../lib/skillFileAccess";
+import {
+  getPublicSkillFileAccessBlock,
+  getPublicSkillVersionAccessBlock,
+  getSkillFileModerationInfoFromSkill,
+  isSkillVersionForSkill,
+} from "../lib/skillFileAccess";
 import {
   buildDeterministicZip,
   buildMergedExportZip,
@@ -191,6 +196,7 @@ type GetBySlugResult = {
     summary?: string;
     engineVersion?: string;
     updatedAt?: number;
+    sourceVersionId?: Id<"skillVersions"> | null;
     reason?: string;
   } | null;
 } | null;
@@ -306,6 +312,8 @@ const internalRefs = internal as unknown as {
   skills: {
     getSecurityVerdictTargetInternal: unknown;
     getSkillBySlugInternal: unknown;
+    getVersionByIdInternal: unknown;
+    getVersionBySkillAndVersionInternal: unknown;
     reportSkillForUserInternal: unknown;
     listSkillReportsInternal: unknown;
     triageSkillReportForUserInternal: unknown;
@@ -1518,6 +1526,60 @@ function shouldExposeHiddenGitHubInstallBlock(
   );
 }
 
+type ExactVersionModeratedSkill = Pick<
+  Doc<"skills">,
+  | "_id"
+  | "softDeletedAt"
+  | "latestVersionId"
+  | "tags"
+  | "moderationStatus"
+  | "moderationReason"
+  | "moderationFlags"
+  | "moderationSourceVersionId"
+>;
+
+async function getUnavailableSkillVersionBlock(
+  ctx: ActionCtx,
+  slug: string,
+  selector?: { versionName?: string; tagName?: string },
+) {
+  const skill = await runQueryRef<ExactVersionModeratedSkill | null>(
+    ctx,
+    internalRefs.skills.getSkillBySlugInternal,
+    { slug },
+  );
+  if (!skill || skill.softDeletedAt) return null;
+
+  const latestVersionId = skill.latestVersionId ?? skill.tags?.latest;
+  const selectedVersionId = selector?.tagName ? skill.tags?.[selector.tagName] : latestVersionId;
+  if (!selector?.versionName && !selectedVersionId) return null;
+
+  const version = selector?.versionName
+    ? await runQueryRef<PublicSkillVersionResponse | null>(
+        ctx,
+        internalRefs.skills.getVersionBySkillAndVersionInternal,
+        {
+          skillId: skill._id,
+          version: selector.versionName,
+        },
+      )
+    : await runQueryRef<PublicSkillVersionResponse | null>(
+        ctx,
+        internalRefs.skills.getVersionByIdInternal,
+        {
+          versionId: selectedVersionId,
+        },
+      );
+  if (!version || !isSkillVersionForSkill(version, skill._id)) return null;
+  if (version.softDeletedAt) return { status: 410, message: "Version not available" };
+
+  return getPublicSkillVersionAccessBlock(
+    getSkillFileModerationInfoFromSkill(skill),
+    version._id,
+    skill.latestVersionId ?? skill.tags?.latest,
+  );
+}
+
 export async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request) {
   const rate = await applyRateLimit(ctx, request, "read");
   if (!rate.ok) return rate.response;
@@ -1810,7 +1872,15 @@ export async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request)
 
   if (second === "versions" && third && segments.length === 3) {
     const skillResult = (await ctx.runQuery(api.skills.getBySlug, { slug })) as GetBySlugResult;
-    if (!skillResult?.skill) return text("Skill not found", 404, rate.headers);
+    if (!skillResult?.skill) {
+      const moderationBlock = await getUnavailableSkillVersionBlock(ctx, slug, {
+        versionName: third,
+      });
+      if (moderationBlock) {
+        return text(moderationBlock.message, moderationBlock.status, rate.headers);
+      }
+      return text("Skill not found", 404, rate.headers);
+    }
 
     const version = (await ctx.runQuery(api.skills.getVersionBySkillAndVersion, {
       skillId: skillResult.skill._id,
@@ -1818,6 +1888,16 @@ export async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request)
     })) as PublicSkillVersionResponse | null;
     if (!version) return text("Version not found", 404, rate.headers);
     if (version.softDeletedAt) return text("Version not available", 410, rate.headers);
+    const effectiveLatestVersionId =
+      skillResult.skill.latestVersionId ?? skillResult.skill.tags?.latest;
+    const moderationBlock = getPublicSkillVersionAccessBlock(
+      skillResult.moderationInfo,
+      version._id,
+      effectiveLatestVersionId,
+    );
+    if (moderationBlock) {
+      return text(moderationBlock.message, moderationBlock.status, rate.headers);
+    }
     const security = buildSkillSecuritySnapshot(version);
 
     return json(
@@ -1850,6 +1930,13 @@ export async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request)
 
     const result = (await ctx.runQuery(api.skills.getBySlug, { slug })) as GetBySlugResult;
     if (!result?.skill) {
+      const moderationBlock = await getUnavailableSkillVersionBlock(ctx, slug, {
+        versionName: versionParam,
+        tagName: tagParam,
+      });
+      if (moderationBlock) {
+        return text(moderationBlock.message, moderationBlock.status, rate.headers);
+      }
       const hidden = await describeOwnerVisibleSkillState(ctx, request, slug);
       if (hidden) return text(hidden.message, hidden.status, rate.headers);
       return text("Skill not found", 404, rate.headers);
@@ -1875,9 +1962,33 @@ export async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request)
     }
     if (version.softDeletedAt) return text("Version not available", 410, rate.headers);
 
+    const effectiveLatestVersionId = result.skill.latestVersionId ?? result.skill.tags?.latest;
+    const moderationBlock = getPublicSkillVersionAccessBlock(
+      result.moderationInfo,
+      version._id,
+      effectiveLatestVersionId,
+    );
+    if (moderationBlock) {
+      return text(moderationBlock.message, moderationBlock.status, rate.headers);
+    }
+
+    let moderationSourceVersion: PublicSkillVersionResponse | null = result.latestVersion;
+    const moderationSourceVersionId = result.moderationInfo?.sourceVersionId;
+    if (moderationSourceVersionId) {
+      if (version._id === moderationSourceVersionId) {
+        moderationSourceVersion = version;
+      } else if (result.latestVersion?._id !== moderationSourceVersionId) {
+        const sourceVersion = (await ctx.runQuery(api.skills.getVersionById, {
+          versionId: moderationSourceVersionId,
+        })) as PublicSkillVersionResponse | null;
+        moderationSourceVersion = isSkillVersionForSkill(sourceVersion, result.skill._id)
+          ? sourceVersion
+          : null;
+      }
+    }
     const security = buildSkillSecuritySnapshot(version);
     const moderationMatchesRequestedVersion = Boolean(
-      result.latestVersion && result.latestVersion._id === version._id,
+      moderationSourceVersion && moderationSourceVersion._id === version._id,
     );
 
     return json(
@@ -1894,10 +2005,10 @@ export async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request)
         moderation: result.moderationInfo
           ? {
               scope: "skill",
-              sourceVersion: result.latestVersion
+              sourceVersion: moderationSourceVersion
                 ? {
-                    version: result.latestVersion.version,
-                    createdAt: result.latestVersion.createdAt,
+                    version: moderationSourceVersion.version,
+                    createdAt: moderationSourceVersion.createdAt,
                   }
                 : null,
               matchesRequestedVersion: moderationMatchesRequestedVersion,

--- a/convex/lib/skillFileAccess.ts
+++ b/convex/lib/skillFileAccess.ts
@@ -1,16 +1,49 @@
 import type { Id } from "../_generated/dataModel";
 
-type SkillFileModerationInfo = {
+export type SkillFileModerationInfo = {
   isPendingScan?: boolean | null;
   isMalwareBlocked?: boolean | null;
   isHiddenByMod?: boolean | null;
   isRemoved?: boolean | null;
+  sourceVersionId?: Id<"skillVersions"> | string | null;
+};
+
+type SkillModerationSource = {
+  moderationStatus?: string | null;
+  moderationReason?: string | null;
+  moderationFlags?: string[] | null;
+  moderationSourceVersionId?: Id<"skillVersions"> | string | null;
 };
 
 type SkillFileAccessBlock = {
   status: number;
   message: string;
 };
+
+function isPendingSkillModerationReason(reason: string | null | undefined) {
+  const normalized = reason?.trim().toLowerCase();
+  return (
+    normalized === "pending.scan" ||
+    normalized === "pending.scan.stale" ||
+    normalized === "scanner.vt.pending" ||
+    normalized === "scanner.llm.pending"
+  );
+}
+
+export function getSkillFileModerationInfoFromSkill(
+  skill: SkillModerationSource,
+): SkillFileModerationInfo {
+  const isPendingScan =
+    skill.moderationStatus === "hidden" && isPendingSkillModerationReason(skill.moderationReason);
+  const isMalwareBlocked = skill.moderationFlags?.includes("blocked.malware") ?? false;
+  return {
+    isPendingScan,
+    isMalwareBlocked,
+    isHiddenByMod: skill.moderationStatus === "hidden" && !isPendingScan && !isMalwareBlocked,
+    isRemoved: skill.moderationStatus === "removed",
+    sourceVersionId: skill.moderationSourceVersionId ?? null,
+  };
+}
 
 export function getPublicSkillFileAccessBlock(
   moderationInfo: SkillFileModerationInfo | null | undefined,
@@ -36,6 +69,19 @@ export function getPublicSkillFileAccessBlock(
     return { status: 403, message: "This skill is currently unavailable." };
   }
   return null;
+}
+
+export function getPublicSkillVersionAccessBlock(
+  moderationInfo: SkillFileModerationInfo | null | undefined,
+  versionId: Id<"skillVersions"> | string,
+  fallbackModeratedVersionId?: Id<"skillVersions"> | string | null,
+): SkillFileAccessBlock | null {
+  const block = getPublicSkillFileAccessBlock(moderationInfo);
+  if (!block) return null;
+  if (moderationInfo?.isRemoved || moderationInfo?.isHiddenByMod) return block;
+
+  const moderatedVersionId = moderationInfo?.sourceVersionId ?? fallbackModeratedVersionId;
+  return moderatedVersionId === versionId ? block : null;
 }
 
 export function isSkillVersionForSkill(

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -2599,6 +2599,7 @@ export const getBySlug = query({
           summary: publicModerationSummary,
           engineVersion: skill.moderationEngineVersion,
           updatedAt: skill.moderationEvaluatedAt,
+          sourceVersionId: skill.moderationSourceVersionId ?? null,
           reason: isOwner ? skill.moderationReason : undefined,
         }
       : null;
@@ -3119,6 +3120,7 @@ export const getSecurityVerdictTargetInternal = internalQuery({
             summary: publicModerationSummary,
             engineVersion: skill.moderationEngineVersion,
             updatedAt: skill.moderationEvaluatedAt,
+            sourceVersionId: skill.moderationSourceVersionId ?? null,
           }
         : null,
       version: version ? compactSecurityVerdictVersion(version) : null,

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -146,7 +146,9 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
 - Public skill raw-file, README, package-compat file, and zip download reads must
   honor the same malware/pending/hidden/removed download block. Metadata routes
   may keep exposing malware-blocked skill summaries for transparency, but they
-  must not serve the blocked artifact payload to public callers.
+  must not serve the blocked artifact payload to public callers. Exact-version
+  skill and package metadata routes must also block when the requested version is
+  the moderated source version.
 - Skill version tags and `latestVersionId` are only valid when the referenced
   `skillVersions` row belongs to the same skill and is not soft-deleted. Writers
   must reject cross-skill tag targets, and public readers should treat stale


### PR DESCRIPTION
## Summary
- block exact skill-version metadata and scan responses when the requested version is the moderated source version
- apply the same source-version moderation guard to package-compatible skill version metadata
- cover hidden public-null scan/version fallbacks, source-version scan reporting, and pending moderation reason variants

## Verification
- `bun run test convex/httpApiV1.handlers.test.ts`
- `bun run format:check -- convex/lib/skillFileAccess.ts convex/skills.ts convex/httpApiV1/skillsV1.ts convex/httpApiV1/packagesV1.ts convex/httpApiV1.handlers.test.ts specs/security-moderation.md`
- `git diff --check`
- final autoreview: no findings
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
