### PR TITLE
Reserve admin as a platform owner handle

### DIFF
--- a/convex/lib/publicRouteReservations.test.ts
+++ b/convex/lib/publicRouteReservations.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { isReservedPublicOwnerHandle } from "./publicRouteReservations";
+
+describe("public route reservations", () => {
+  it.each(["admin", "plugins", "skills"])("reserves @%s as a public owner handle", (handle) => {
+    expect(isReservedPublicOwnerHandle(handle)).toBe(true);
+  });
+});

--- a/convex/lib/publicRouteReservations.ts
+++ b/convex/lib/publicRouteReservations.ts
@@ -1,4 +1,4 @@
-const RESERVED_PUBLIC_OWNER_HANDLES = new Set(["plugins", "skills"]);
+const RESERVED_PUBLIC_OWNER_HANDLES = new Set(["admin", "plugins", "skills"]);
 const RESERVED_UNSCOPED_PACKAGE_NAMES = new Set(["publish"]);
 
 export function isReservedPublicOwnerHandle(handle: string | undefined | null) {

--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -890,28 +890,31 @@ describe("publishers membership controls", () => {
     });
   });
 
-  it("rejects org handles reserved for public routes", async () => {
-    const ctx = {
-      db: {
-        get: vi.fn(async (id: string) =>
-          id === "users:admin" ? { _id: id, role: "admin" } : null,
-        ),
-        query: vi.fn(),
-        insert: vi.fn(),
-        patch: vi.fn(),
-        delete: vi.fn(),
-        replace: vi.fn(),
-        normalizeId: vi.fn(),
-      },
-    };
+  it.each(["admin", "skills"])(
+    "rejects org handle %s reserved for public routes",
+    async (handle) => {
+      const ctx = {
+        db: {
+          get: vi.fn(async (id: string) =>
+            id === "users:admin" ? { _id: id, role: "admin" } : null,
+          ),
+          query: vi.fn(),
+          insert: vi.fn(),
+          patch: vi.fn(),
+          delete: vi.fn(),
+          replace: vi.fn(),
+          normalizeId: vi.fn(),
+        },
+      };
 
-    await expect(
-      migrateLegacyPublisherHandleToOrgInternalHandler(ctx, {
-        actorUserId: "users:admin",
-        handle: "skills",
-      }),
-    ).rejects.toThrow('Handle "@skills" is reserved for ClawHub routes');
-  });
+      await expect(
+        migrateLegacyPublisherHandleToOrgInternalHandler(ctx, {
+          actorUserId: "users:admin",
+          handle,
+        }),
+      ).rejects.toThrow(`Handle "@${handle}" is reserved for ClawHub routes`);
+    },
+  );
 
   it("lists individual and org publishers ranked by aggregate downloads", async () => {
     const publisherRows = [

--- a/specs/orgs.md
+++ b/specs/orgs.md
@@ -206,6 +206,10 @@ Handle reservation must move from user-centric to publisher-centric.
 Current reservation logic is anchored to rightful owner user id. Replace with
 publisher-aware reservations so org handles are first-class.
 
+Platform route/system handles such as `admin`, `plugins`, and `skills` are not
+owned by users or orgs. They must be blocked by route reservation policy instead
+of represented as empty publisher rows.
+
 ## Routing
 
 ### Web routes


### PR DESCRIPTION
## Summary
- reserve `@admin` alongside other platform owner handles so it cannot be claimed as an org/user publisher
- add direct reservation coverage plus publisher migration coverage for the `admin` handle
- document that platform route/system handles should be blocked by route reservation policy, not empty publisher rows

## Tests
- `bunx vitest run convex/lib/publicRouteReservations.test.ts convex/publishers.test.ts --testNamePattern "public route reservations|rejects org handle"`
- `bun run ci:static`
- `bun run ci:unit`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
