### PR TITLE
Add owner skill deletion to settings

### DIFF
--- a/convex/skills.rateLimit.test.ts
+++ b/convex/skills.rateLimit.test.ts
@@ -639,7 +639,7 @@ describe("skills anti-spam guards", () => {
     );
   });
 
-  it("does not release a stale owner reservation after moderation owns the current hide", async () => {
+  it("does not release a moderated hidden skill without an unpublished reservation", async () => {
     const now = Date.now();
     const storedSkills = new Map<string, Record<string, unknown>>([
       [
@@ -652,7 +652,6 @@ describe("skills anti-spam guards", () => {
           ownerPublisherId: "publishers:previous",
           softDeletedAt: now - 31 * 24 * 60 * 60 * 1000,
           hiddenBy: undefined,
-          unpublishedSlugReservedUntil: now - 1_000,
           moderationStatus: "hidden",
           moderationFlags: ["blocked.malware"],
           moderationVerdict: "malicious",

--- a/convex/skills.slugAvailability.test.ts
+++ b/convex/skills.slugAvailability.test.ts
@@ -22,7 +22,9 @@ type SkillDoc = {
   hiddenBy?: string;
   unpublishedSlugReservedUntil?: number;
   moderationStatus?: "active" | "hidden" | "removed";
+  moderationReason?: string;
   moderationFlags?: string[];
+  moderationVerdict?: "clean" | "suspicious" | "malicious";
 };
 
 type ReservationDoc = {
@@ -74,6 +76,7 @@ function createCtx(options: {
   } | null;
   ownerProviderAccountId?: string | null;
   callerProviderAccountId?: string | null;
+  usersById?: Record<string, Record<string, unknown>>;
 }) {
   const callerId = options.callerId ?? "users:caller";
   let authAccountLookupCount = 0;
@@ -136,6 +139,7 @@ function createCtx(options: {
     get: vi.fn(async (id: string) => {
       if (options.publisher && id === options.publisher._id) return options.publisher;
       if (options.owner && id === options.owner._id) return options.owner;
+      if (options.usersById?.[id]) return options.usersById[id];
       if (id === callerId) {
         return { _id: callerId, deletedAt: undefined, deactivatedAt: undefined };
       }
@@ -404,7 +408,7 @@ describe("skills.checkSlugAvailability", () => {
     });
   });
 
-  it("returns taken when a stale owner reservation remains on a moderation hide", async () => {
+  it("returns taken when a moderation hide has no unpublished reservation", async () => {
     const now = 1_700_000_000_000;
     vi.spyOn(Date, "now").mockReturnValue(now);
     vi.mocked(getAuthUserId).mockResolvedValue("users:caller" as never);
@@ -417,6 +421,43 @@ describe("skills.checkSlugAvailability", () => {
           ownerUserId: "users:owner",
           softDeletedAt: now - 120_000,
           hiddenBy: undefined,
+          moderationStatus: "hidden",
+          moderationFlags: ["blocked.malware"],
+        },
+        owner: {
+          _id: "users:owner",
+          handle: "owner",
+        },
+      }) as never,
+      { slug: "moderated-skill" } as never,
+    )) as {
+      available: boolean;
+      reason: string;
+      message: string;
+      url: string | null;
+    };
+
+    expect(result).toEqual({
+      available: false,
+      reason: "taken",
+      message: "Slug is already taken. Choose a different slug.",
+      url: null,
+    });
+  });
+
+  it("returns taken when moderation owns a stale unpublished reservation", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    vi.mocked(getAuthUserId).mockResolvedValue("users:caller" as never);
+
+    const result = (await checkSlugAvailabilityHandler(
+      createCtx({
+        skill: {
+          _id: "skills:1",
+          slug: "moderated-skill",
+          ownerUserId: "users:owner",
+          softDeletedAt: now - 120_000,
+          hiddenBy: "users:owner",
           unpublishedSlugReservedUntil: now - 60_000,
           moderationStatus: "hidden",
           moderationFlags: ["blocked.malware"],
@@ -438,6 +479,205 @@ describe("skills.checkSlugAvailability", () => {
       available: false,
       reason: "taken",
       message: "Slug is already taken. Choose a different slug.",
+      url: null,
+    });
+  });
+
+  it("returns taken when a moderator re-hides a skill with a stale unpublished reservation", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    vi.mocked(getAuthUserId).mockResolvedValue("users:caller" as never);
+
+    const result = (await checkSlugAvailabilityHandler(
+      createCtx({
+        skill: {
+          _id: "skills:1",
+          slug: "moderated-skill",
+          ownerUserId: "users:owner",
+          softDeletedAt: now - 120_000,
+          hiddenBy: "users:mod",
+          unpublishedSlugReservedUntil: now - 60_000,
+          moderationStatus: "hidden",
+        },
+        owner: {
+          _id: "users:owner",
+          handle: "owner",
+        },
+        usersById: {
+          "users:mod": { _id: "users:mod", role: "moderator" },
+        },
+      }) as never,
+      { slug: "moderated-skill" } as never,
+    )) as {
+      available: boolean;
+      reason: string;
+      message: string;
+      url: string | null;
+    };
+
+    expect(result).toEqual({
+      available: false,
+      reason: "taken",
+      message: "Slug is already taken. Choose a different slug.",
+      url: null,
+    });
+  });
+
+  it("returns taken when a malicious verdict owns a stale unpublished reservation", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    vi.mocked(getAuthUserId).mockResolvedValue("users:caller" as never);
+
+    const result = (await checkSlugAvailabilityHandler(
+      createCtx({
+        skill: {
+          _id: "skills:1",
+          slug: "malicious-skill",
+          ownerUserId: "users:owner",
+          softDeletedAt: now - 120_000,
+          hiddenBy: "users:owner",
+          unpublishedSlugReservedUntil: now - 60_000,
+          moderationStatus: "hidden",
+          moderationVerdict: "malicious",
+        },
+        owner: {
+          _id: "users:owner",
+          handle: "owner",
+        },
+      }) as never,
+      { slug: "malicious-skill" } as never,
+    )) as {
+      available: boolean;
+      reason: string;
+      message: string;
+      url: string | null;
+    };
+
+    expect(result).toEqual({
+      available: false,
+      reason: "taken",
+      message: "Slug is already taken. Choose a different slug.",
+      url: null,
+    });
+  });
+
+  it("returns available when an owner-deleted reservation with non-blocking flags expires", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    vi.mocked(getAuthUserId).mockResolvedValue("users:caller" as never);
+
+    const result = (await checkSlugAvailabilityHandler(
+      createCtx({
+        skill: {
+          _id: "skills:1",
+          slug: "reviewed-skill",
+          ownerUserId: "users:owner",
+          softDeletedAt: now - 120_000,
+          hiddenBy: "users:owner",
+          unpublishedSlugReservedUntil: now - 60_000,
+          moderationStatus: "hidden",
+          moderationFlags: ["flagged.suspicious"],
+        },
+        owner: {
+          _id: "users:owner",
+          handle: "owner",
+        },
+      }) as never,
+      { slug: "reviewed-skill" } as never,
+    )) as {
+      available: boolean;
+      reason: string;
+      message: string | null;
+      url: string | null;
+    };
+
+    expect(result).toEqual({
+      available: true,
+      reason: "available",
+      message: null,
+      url: null,
+    });
+  });
+
+  it("returns available when an owner-deleted reservation with a stale benign reason expires", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    vi.mocked(getAuthUserId).mockResolvedValue("users:caller" as never);
+
+    const result = (await checkSlugAvailabilityHandler(
+      createCtx({
+        skill: {
+          _id: "skills:1",
+          slug: "reviewed-skill",
+          ownerUserId: "users:owner",
+          softDeletedAt: now - 120_000,
+          hiddenBy: "users:owner",
+          unpublishedSlugReservedUntil: now - 60_000,
+          moderationStatus: "hidden",
+          moderationReason: "scanner.aggregate.clean",
+        },
+        owner: {
+          _id: "users:owner",
+          handle: "owner",
+        },
+      }) as never,
+      { slug: "reviewed-skill" } as never,
+    )) as {
+      available: boolean;
+      reason: string;
+      message: string | null;
+      url: string | null;
+    };
+
+    expect(result).toEqual({
+      available: true,
+      reason: "available",
+      message: null,
+      url: null,
+    });
+  });
+
+  it("returns available when an org-owner reservation expires after the deleting admin is removed", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    vi.mocked(getAuthUserId).mockResolvedValue("users:caller" as never);
+
+    const result = (await checkSlugAvailabilityHandler(
+      createCtx({
+        skill: {
+          _id: "skills:1",
+          slug: "org-skill",
+          ownerUserId: "users:owner",
+          ownerPublisherId: "publishers:org",
+          softDeletedAt: now - 120_000,
+          hiddenBy: "users:former-admin",
+          unpublishedSlugReservedUntil: now - 60_000,
+          moderationStatus: "hidden",
+        },
+        owner: {
+          _id: "users:owner",
+          handle: "owner",
+        },
+        usersById: {
+          "users:former-admin": {
+            _id: "users:former-admin",
+            role: "user",
+            deactivatedAt: now - 30_000,
+          },
+        },
+      }) as never,
+      { slug: "org-skill" } as never,
+    )) as {
+      available: boolean;
+      reason: string;
+      message: string | null;
+      url: string | null;
+    };
+
+    expect(result).toEqual({
+      available: true,
+      reason: "available",
+      message: null,
       url: null,
     });
   });

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -1061,18 +1061,50 @@ function formatUnpublishedSlugReservationMessage(slug: string, expiresAt: number
   );
 }
 
-function getUnpublishedSlugReservationExpiresAt(
+async function getUnpublishedSlugReservationExpiresAt(
+  ctx: QueryCtx | MutationCtx,
   skill: Pick<
     Doc<"skills">,
-    "softDeletedAt" | "hiddenBy" | "ownerUserId" | "unpublishedSlugReservedUntil"
+    | "softDeletedAt"
+    | "hiddenBy"
+    | "ownerUserId"
+    | "ownerPublisherId"
+    | "moderationFlags"
+    | "moderationStatus"
+    | "moderationVerdict"
+    | "unpublishedSlugReservedUntil"
   >,
 ) {
   if (!skill.softDeletedAt) return null;
-  if (skill.hiddenBy !== skill.ownerUserId) return null;
+  if (!skill.hiddenBy) return null;
   if (typeof skill.unpublishedSlugReservedUntil === "number") {
+    if (skill.moderationStatus === "removed") return null;
+    if (skill.moderationVerdict === "malicious") return null;
+    if (skill.moderationFlags?.includes("blocked.malware")) return null;
+    if (await isKnownPlatformModeratorSkillHide(ctx, skill)) return null;
     return skill.unpublishedSlugReservedUntil;
   }
+  if (skill.hiddenBy !== skill.ownerUserId) return null;
   return skill.softDeletedAt + UNPUBLISHED_SLUG_RESERVATION_MS;
+}
+
+async function isKnownPlatformModeratorSkillHide(
+  ctx: QueryCtx | MutationCtx,
+  skill: Pick<Doc<"skills">, "hiddenBy">,
+) {
+  if (!skill.hiddenBy) return true;
+  const hiddenBy = await ctx.db.get(skill.hiddenBy);
+  return hiddenBy?.role === "admin" || hiddenBy?.role === "moderator";
+}
+
+async function canUserManageSkillOwner(
+  ctx: QueryCtx | MutationCtx,
+  skill: Pick<Doc<"skills">, "ownerUserId" | "ownerPublisherId">,
+  userId: Id<"users">,
+) {
+  const user = await ctx.db.get(userId);
+  if (!user || user.deletedAt || user.deactivatedAt) return false;
+  return canManageSkillOwnerForActor(ctx, user, skill);
 }
 
 function buildReleasedUnpublishedSkillSlug(skill: Pick<Doc<"skills">, "_id">, attempt = 0) {
@@ -1327,7 +1359,7 @@ async function releaseExpiredUnpublishedSkillSlug(
   now: number,
   actorUserId: Id<"users">,
 ) {
-  const reservedUntil = getUnpublishedSlugReservationExpiresAt(skill);
+  const reservedUntil = await getUnpublishedSlugReservationExpiresAt(ctx, skill);
   if (reservedUntil === null || reservedUntil > now) return false;
 
   let releasedSlug: string | null = null;
@@ -2733,11 +2765,17 @@ export const checkSlugAvailability = query({
       };
     }
 
-    const unpublishedReservationExpiresAt = getUnpublishedSlugReservationExpiresAt(skill);
+    const unpublishedReservationExpiresAt = await getUnpublishedSlugReservationExpiresAt(
+      ctx,
+      skill,
+    );
+    const viewerCanManageReservation = userId
+      ? await canUserManageSkillOwner(ctx, skill, userId)
+      : false;
     if (
       skill.softDeletedAt &&
       unpublishedReservationExpiresAt !== null &&
-      (!userId || skill.ownerUserId !== userId)
+      !viewerCanManageReservation
     ) {
       if (unpublishedReservationExpiresAt <= Date.now()) {
         try {
@@ -9349,6 +9387,28 @@ export const mergeOwnedSkillIntoCanonical = mutation({
   },
 });
 
+export const setOwnedSkillSoftDeleted = mutation({
+  args: {
+    skillId: v.id("skills"),
+  },
+  handler: async (ctx, args) => {
+    const { user } = await requireUser(ctx);
+    const skill = await ctx.db.get(args.skillId);
+    if (!skill) throw new ConvexError("Skill not found");
+    await assertCanManageOwnedResource(ctx, {
+      actor: user,
+      ownerUserId: skill.ownerUserId,
+      ownerPublisherId: skill.ownerPublisherId,
+      allowedPublisherRoles: ["admin"],
+    });
+    return setSkillSoftDeletedByActor(ctx, {
+      userId: user._id,
+      skillId: skill._id,
+      deleted: true,
+    });
+  },
+});
+
 export const renameOwnedSkillInternal = internalMutation({
   args: {
     actorUserId: v.id("users"),
@@ -9377,7 +9437,7 @@ export const mergeOwnedSkillIntoCanonicalInternal = internalMutation({
 });
 
 async function canManageSkillOwnerForActor(
-  ctx: MutationCtx,
+  ctx: QueryCtx | MutationCtx,
   actor: Doc<"users">,
   skill: Pick<Doc<"skills">, "ownerUserId" | "ownerPublisherId">,
 ) {
@@ -10537,8 +10597,11 @@ export const insertVersion = internalMutation({
       .withIndex("by_slug", (q) => q.eq("slug", normalizedSlug))
       .unique();
 
-    if (skill && skill.softDeletedAt && skill.ownerUserId !== userId) {
-      const unpublishedReservationExpiresAt = getUnpublishedSlugReservationExpiresAt(skill);
+    if (skill && skill.softDeletedAt && !(await canUserManageSkillOwner(ctx, skill, userId))) {
+      const unpublishedReservationExpiresAt = await getUnpublishedSlugReservationExpiresAt(
+        ctx,
+        skill,
+      );
       if (unpublishedReservationExpiresAt !== null) {
         if (unpublishedReservationExpiresAt > now) {
           throw new ConvexError(
@@ -11137,245 +11200,262 @@ export const setSkillSoftDeletedInternal = internalMutation({
     reason: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const user = await ctx.db.get(args.userId);
-    if (!user || user.deletedAt || user.deactivatedAt) throw new Error("User not found");
-
-    const slug = args.slug.trim().toLowerCase();
-    if (!slug) throw new Error("Slug required");
-
-    const skill = await ctx.db
-      .query("skills")
-      .withIndex("by_slug", (q) => q.eq("slug", slug))
-      .unique();
-    if (!skill) throw new Error("Skill not found");
-
-    const isModeratorOrAdmin = user.role === "admin" || user.role === "moderator";
-    let isOwner = skill.ownerUserId === args.userId;
-
-    if (!isOwner) {
-      try {
-        await assertCanManageOwnedResource(ctx, {
-          actor: user,
-          ownerUserId: skill.ownerUserId,
-          ownerPublisherId: skill.ownerPublisherId,
-          allowedPublisherRoles: ["admin"],
-        });
-        isOwner = true;
-      } catch {
-        if (!isModeratorOrAdmin) {
-          // Preserve legacy behavior: delegate to assertModerator to produce the
-          // standard "Forbidden" error for non-owners without elevated roles.
-          assertModerator(user);
-        }
-      }
-    }
-
-    // Owner-delete provenance guard: an owner must NOT be able to "re-delete"
-    // a skill that is currently in a non-owner-initiated hidden state. Such
-    // a re-delete would rewrite `hiddenBy` to the owner (and clear
-    // `moderationReason` via the data-hygiene reset below), erasing the
-    // moderator/system provenance of the current hide and letting a
-    // subsequent owner-undelete succeed — a privilege-escalation path where
-    // the owner reverses moderator actions in two calls (delete, then
-    // undelete).
-    //
-    // We only guard against hides whose current source is NOT the owner:
-    //   - skill.hiddenBy === owner: the current hide was owner-initiated
-    //     (e.g. a prior `clawhub delete`); re-delete is effectively a
-    //     no-op and must remain idempotent.
-    //   - skill.hiddenBy is some moderator/admin/system actor, OR is
-    //     undefined while the row is hidden (e.g. `auto.reports` does not
-    //     write hiddenBy): the hide is not owner-initiated, so block the
-    //     owner from re-delete. Moderators/admins keep full access via the
-    //     existing `isModeratorOrAdmin` branch.
-    //
-    // Staleness note: if a moderator previously restored the row
-    // (`setSoftDeleted(deleted=false)`), `hiddenBy` is cleared and
-    // `moderationStatus === "active"`, so this guard does NOT fire on
-    // active rows — the existing data-hygiene reset continues to handle
-    // stale `moderationReason` on active rows.
-    if (args.deleted && isOwner && !isModeratorOrAdmin) {
-      const isCurrentlyHidden = Boolean(skill.softDeletedAt) || skill.moderationStatus === "hidden";
-      const isOwnerInitiatedHide = await isOwnerInitiatedSkillHideForActor(ctx, skill, args.userId);
-      if (isCurrentlyHidden && !isOwnerInitiatedHide) {
-        // Prefix with "Forbidden:" so HTTP boundary mappers
-        // (softDeleteErrorToResponse) deterministically return 403 instead of
-        // falling through to 500.
-        throw new ConvexError(
-          "Forbidden: This skill is currently hidden by moderation and cannot be re-deleted by the owner. Please contact a moderator.",
-        );
-      }
-    }
-
-    // gate: when an owner (without moderator/admin privileges) attempts to
-    // undelete a skill, only allow it if the current hidden state was produced
-    // by the owner themselves (i.e. via `clawhub delete`). Any other hidden
-    // state originates from moderation, scanning, merges, bans, or security
-    // redaction — only moderators/admins may lift those.
-    //
-    // Authorization is based on the *source of the current hide* (`hiddenBy`),
-    // plus a small deny list of `moderationReason` values that are truly
-    // bound to a non-owner current hide and therefore cannot be stale from
-    // historical moderation metadata.
-    //
-    //   - `hiddenBy === args.userId` is the necessary baseline. A moderator
-    //     hiding via `setSoftDeleted` records `hiddenBy = mod._id`, so the
-    //     owner simply fails this check. A security redaction / auto-ban
-    //     likewise records an admin/system actor, so those naturally fail.
-    //   - The deny list below is intentionally narrow: each entry is a
-    //     reason that is *only* set atomically with the current hide it
-    //     describes, so it cannot be leftover historical metadata:
-    //       * "owner.merged": merge mutation writes moderationReason,
-    //         softDeletedAt, and hiddenBy as a single atomic patch; there
-    //         is no flow that later restores the row while leaving this
-    //         reason stale.
-    //       * "user.banned": only written by the ban batch with
-    //         hiddenBy = admin; unban clears softDeletedAt and rewrites
-    //         moderationReason to "restored.unban", so a banned row never
-    //         survives into an active state with this reason.
-    //       * "security.redaction": paired with hiddenBy = security-admin;
-    //         there is no owner-reachable path that lifts redaction while
-    //         leaving this reason in place.
-    //     Notably EXCLUDED:
-    //       * "auto.reports" / "manual.report" — set by auto-hide or the
-    //         moderator report-triage flow, but `setSoftDeleted(deleted=
-    //         false)` (moderator restore) does NOT clear moderationReason.
-    //         That means a row can be `moderationStatus="active"` with a
-    //         stale `"auto.reports"` reason; if the owner later does a
-    //         normal self-delete, `hiddenBy` becomes the owner and the
-    //         current hide is owner-initiated, but the stale reason would
-    //         still block self-undelete. These are therefore enforced
-    //         solely via `hiddenBy !== owner` (auto.reports does not write
-    //         hiddenBy; manual.report writes hiddenBy = mod._id).
-    //       * "pending.scan.stale" / "pending.scan" / "scanner.*.*" — these
-    //         describe the skill's moderation state, not the cause of the
-    //         current hide, and must never block owner self-restore.
-    //   - Benign scanner / pipeline reasons such as `pending.scan`,
-    //     `scanner.aggregate.clean`, or `scanner.<scanner>.clean` describe
-    //     the skill's moderation state, not the cause of the current hide,
-    //     so they must NOT block owner self-restore.
-    //   - If `hiddenBy` is somehow missing (legacy rows, manual override
-    //     pathways that cleared it), fail closed and route the caller to a
-    //     moderator.
-    if (!args.deleted && isOwner && !isModeratorOrAdmin) {
-      // Defense-in-depth: regardless of `hiddenBy`/`moderationReason`
-      // provenance, an owner must NEVER be able to restore a skill that any
-      // scanner has marked malicious. This closes a class of bugs where a
-      // stale owner-initiated hide is left in place while a later scanner
-      // escalation upgrades the verdict to malicious without rewriting
-      // provenance fields (e.g. the VT-only escalation path intentionally
-      // does not overwrite `moderationReason` to preserve the LLM verdict).
-      const moderationFlags = (skill.moderationFlags as string[] | undefined) ?? [];
-      const isMaliciousBlocked =
-        moderationFlags.includes("blocked.malware") || skill.moderationVerdict === "malicious";
-      if (isMaliciousBlocked) {
-        throw new ConvexError(
-          "Forbidden: This skill was blocked by automated malware detection and cannot be restored by the owner. Please contact a moderator.",
-        );
-      }
-
-      // Reasons that are atomically bound to a non-owner current hide and
-      // therefore cannot survive as stale historical metadata on an
-      // owner-initiated hide. See the block comment above for why each is
-      // included, and why report-related reasons are intentionally NOT.
-      const OWNER_UNDELETE_DENIED_REASONS = new Set<string>([
-        "owner.merged",
-        "user.banned",
-        "security.redaction",
-      ]);
-      const reason = skill.moderationReason as string | undefined;
-      const ownerInitiatedHide =
-        (await isOwnerInitiatedSkillHideForActor(ctx, skill, args.userId)) &&
-        (reason === undefined || !OWNER_UNDELETE_DENIED_REASONS.has(reason));
-      if (!ownerInitiatedHide) {
-        // Prefix with "Forbidden:" so HTTP boundary mappers
-        // (softDeleteErrorToResponse) deterministically return 403 instead of
-        // falling through to 500. The suffix is preserved for clients that
-        // surface a human-readable reason.
-        throw new ConvexError(
-          "Forbidden: This skill was hidden by moderation and cannot be restored by the owner. Please contact a moderator.",
-        );
-      }
-    }
-
-    const now = Date.now();
-    const note = args.reason ? trimManualOverrideNote(args.reason) : undefined;
-    const slugReservedUntil =
-      args.deleted && isOwner ? now + UNPUBLISHED_SLUG_RESERVATION_MS : undefined;
-    const patch: Partial<Doc<"skills">> = {
-      softDeletedAt: args.deleted ? now : undefined,
-      moderationStatus: args.deleted ? "hidden" : "active",
-      hiddenAt: args.deleted ? now : undefined,
-      hiddenBy: args.deleted ? args.userId : undefined,
-      unpublishedSlugReservedUntil: slugReservedUntil,
-      unpublishedSlugReleasedAt: undefined,
-      unpublishedOriginalSlug: undefined,
-      lastReviewedAt: now,
-      updatedAt: now,
-    };
-    if (note) patch.moderationNotes = note;
-    if (!args.deleted && isModeratorOrAdmin && note) {
-      const manualOverride = buildManualOverrideRecord({
-        note,
-        reviewerUserId: user._id,
-        updatedAt: now,
-      });
-      Object.assign(
-        patch,
-        applyManualOverrideToSkillPatch({
-          basePatch: {
-            ...patch,
-            moderationReasonCodes: undefined,
-            moderationEvidence: undefined,
-            moderationSummary: undefined,
-            moderationEngineVersion: undefined,
-            moderationEvaluatedAt: undefined,
-            moderationSourceVersionId: undefined,
-          },
-          override: manualOverride,
-          now,
-        }),
-        {
-          manualOverride,
-          moderationNotes: note,
-        },
-      );
-    }
-    // Data hygiene: when the owner self-deletes (not a moderator/admin acting
-    // via this internal entry point), reset any stale `moderationReason`
-    // that may have survived from prior moderation metadata (e.g. an
-    // `auto.reports` or `manual.report` reason that a moderator restore
-    // never cleared). This keeps the row's provenance fields consistent
-    // with the current hide (owner-initiated) and prevents a future
-    // owner-undelete from tripping on historical reasons.
-    if (args.deleted && isOwner && !isModeratorOrAdmin) {
-      patch.moderationReason = undefined;
-    }
-    const nextSkill = { ...skill, ...patch };
-    await ctx.db.patch(skill._id, patch);
-    await adjustGlobalPublicCountForSkillChange(ctx, skill, nextSkill);
-    await adjustUserSkillStatsForSkillChange(ctx, skill, nextSkill);
-
-    await setSkillEmbeddingsSoftDeleted(ctx, skill._id, args.deleted, now);
-
-    await ctx.db.insert("auditLogs", {
-      actorUserId: args.userId,
-      action: args.deleted ? "skill.delete" : "skill.undelete",
-      targetType: "skill",
-      targetId: skill._id,
-      metadata: {
-        slug,
-        softDeletedAt: args.deleted ? now : null,
-        actorRole: user.role ?? "user",
-        ...(slugReservedUntil ? { slugReservedUntil } : {}),
-        ...(note ? { reason: note } : {}),
-      },
-      createdAt: now,
-    });
-
-    return slugReservedUntil ? { ok: true as const, slugReservedUntil } : { ok: true as const };
+    return setSkillSoftDeletedByActor(ctx, args);
   },
 });
+
+async function setSkillSoftDeletedByActor(
+  ctx: MutationCtx,
+  args: {
+    userId: Id<"users">;
+    slug?: string;
+    skillId?: Id<"skills">;
+    deleted: boolean;
+    reason?: string;
+  },
+) {
+  const user = await ctx.db.get(args.userId);
+  if (!user || user.deletedAt || user.deactivatedAt) throw new Error("User not found");
+
+  const requestedSlug = args.slug?.trim().toLowerCase();
+  if (!args.skillId && !requestedSlug) throw new Error("Slug required");
+
+  const skill = args.skillId
+    ? await ctx.db.get(args.skillId)
+    : await ctx.db
+        .query("skills")
+        .withIndex("by_slug", (q) => q.eq("slug", requestedSlug!))
+        .unique();
+  if (!skill) throw new Error("Skill not found");
+  const slug = skill.slug;
+
+  const isModeratorOrAdmin = user.role === "admin" || user.role === "moderator";
+  let isOwner = skill.ownerUserId === args.userId;
+
+  if (!isOwner) {
+    try {
+      await assertCanManageOwnedResource(ctx, {
+        actor: user,
+        ownerUserId: skill.ownerUserId,
+        ownerPublisherId: skill.ownerPublisherId,
+        allowedPublisherRoles: ["admin"],
+      });
+      isOwner = true;
+    } catch {
+      if (!isModeratorOrAdmin) {
+        // Preserve legacy behavior: delegate to assertModerator to produce the
+        // standard "Forbidden" error for non-owners without elevated roles.
+        assertModerator(user);
+      }
+    }
+  }
+  if (args.deleted && skill.moderationStatus === "removed") {
+    throw new ConvexError("Forbidden: Removed skills cannot be deleted.");
+  }
+
+  // Owner-delete provenance guard: an owner must NOT be able to "re-delete"
+  // a skill that is currently in a non-owner-initiated hidden state. Such
+  // a re-delete would rewrite `hiddenBy` to the owner (and clear
+  // `moderationReason` via the data-hygiene reset below), erasing the
+  // moderator/system provenance of the current hide and letting a
+  // subsequent owner-undelete succeed — a privilege-escalation path where
+  // the owner reverses moderator actions in two calls (delete, then
+  // undelete).
+  //
+  // We only guard against hides whose current source is NOT the owner:
+  //   - skill.hiddenBy === owner: the current hide was owner-initiated
+  //     (e.g. a prior `clawhub delete`); re-delete is effectively a
+  //     no-op and must remain idempotent.
+  //   - skill.hiddenBy is some moderator/admin/system actor, OR is
+  //     undefined while the row is hidden (e.g. `auto.reports` does not
+  //     write hiddenBy): the hide is not owner-initiated, so block the
+  //     owner from re-delete. Moderators/admins keep full access via the
+  //     existing `isModeratorOrAdmin` branch.
+  //
+  // Staleness note: if a moderator previously restored the row
+  // (`setSoftDeleted(deleted=false)`), `hiddenBy` is cleared and
+  // `moderationStatus === "active"`, so this guard does NOT fire on
+  // active rows — the existing data-hygiene reset continues to handle
+  // stale `moderationReason` on active rows.
+  if (args.deleted && isOwner && !isModeratorOrAdmin) {
+    const isCurrentlyHidden = Boolean(skill.softDeletedAt) || skill.moderationStatus === "hidden";
+    const isOwnerInitiatedHide = await isOwnerInitiatedSkillHideForActor(ctx, skill, args.userId);
+    if (isCurrentlyHidden && !isOwnerInitiatedHide) {
+      // Prefix with "Forbidden:" so HTTP boundary mappers
+      // (softDeleteErrorToResponse) deterministically return 403 instead of
+      // falling through to 500.
+      throw new ConvexError(
+        "Forbidden: This skill is currently hidden by moderation and cannot be re-deleted by the owner. Please contact a moderator.",
+      );
+    }
+  }
+
+  // gate: when an owner (without moderator/admin privileges) attempts to
+  // undelete a skill, only allow it if the current hidden state was produced
+  // by the owner themselves (i.e. via `clawhub delete`). Any other hidden
+  // state originates from moderation, scanning, merges, bans, or security
+  // redaction — only moderators/admins may lift those.
+  //
+  // Authorization is based on the *source of the current hide* (`hiddenBy`),
+  // plus a small deny list of `moderationReason` values that are truly
+  // bound to a non-owner current hide and therefore cannot be stale from
+  // historical moderation metadata.
+  //
+  //   - `hiddenBy === args.userId` is the necessary baseline. A moderator
+  //     hiding via `setSoftDeleted` records `hiddenBy = mod._id`, so the
+  //     owner simply fails this check. A security redaction / auto-ban
+  //     likewise records an admin/system actor, so those naturally fail.
+  //   - The deny list below is intentionally narrow: each entry is a
+  //     reason that is *only* set atomically with the current hide it
+  //     describes, so it cannot be leftover historical metadata:
+  //       * "owner.merged": merge mutation writes moderationReason,
+  //         softDeletedAt, and hiddenBy as a single atomic patch; there
+  //         is no flow that later restores the row while leaving this
+  //         reason stale.
+  //       * "user.banned": only written by the ban batch with
+  //         hiddenBy = admin; unban clears softDeletedAt and rewrites
+  //         moderationReason to "restored.unban", so a banned row never
+  //         survives into an active state with this reason.
+  //       * "security.redaction": paired with hiddenBy = security-admin;
+  //         there is no owner-reachable path that lifts redaction while
+  //         leaving this reason in place.
+  //     Notably EXCLUDED:
+  //       * "auto.reports" / "manual.report" — set by auto-hide or the
+  //         moderator report-triage flow, but `setSoftDeleted(deleted=
+  //         false)` (moderator restore) does NOT clear moderationReason.
+  //         That means a row can be `moderationStatus="active"` with a
+  //         stale `"auto.reports"` reason; if the owner later does a
+  //         normal self-delete, `hiddenBy` becomes the owner and the
+  //         current hide is owner-initiated, but the stale reason would
+  //         still block self-undelete. These are therefore enforced
+  //         solely via `hiddenBy !== owner` (auto.reports does not write
+  //         hiddenBy; manual.report writes hiddenBy = mod._id).
+  //       * "pending.scan.stale" / "pending.scan" / "scanner.*.*" — these
+  //         describe the skill's moderation state, not the cause of the
+  //         current hide, and must never block owner self-restore.
+  //   - Benign scanner / pipeline reasons such as `pending.scan`,
+  //     `scanner.aggregate.clean`, or `scanner.<scanner>.clean` describe
+  //     the skill's moderation state, not the cause of the current hide,
+  //     so they must NOT block owner self-restore.
+  //   - If `hiddenBy` is somehow missing (legacy rows, manual override
+  //     pathways that cleared it), fail closed and route the caller to a
+  //     moderator.
+  if (!args.deleted && isOwner && !isModeratorOrAdmin) {
+    // Defense-in-depth: regardless of `hiddenBy`/`moderationReason`
+    // provenance, an owner must NEVER be able to restore a skill that any
+    // scanner has marked malicious. This closes a class of bugs where a
+    // stale owner-initiated hide is left in place while a later scanner
+    // escalation upgrades the verdict to malicious without rewriting
+    // provenance fields (e.g. the VT-only escalation path intentionally
+    // does not overwrite `moderationReason` to preserve the LLM verdict).
+    const moderationFlags = (skill.moderationFlags as string[] | undefined) ?? [];
+    const isMaliciousBlocked =
+      moderationFlags.includes("blocked.malware") || skill.moderationVerdict === "malicious";
+    if (isMaliciousBlocked) {
+      throw new ConvexError(
+        "Forbidden: This skill was blocked by automated malware detection and cannot be restored by the owner. Please contact a moderator.",
+      );
+    }
+
+    // Reasons that are atomically bound to a non-owner current hide and
+    // therefore cannot survive as stale historical metadata on an
+    // owner-initiated hide. See the block comment above for why each is
+    // included, and why report-related reasons are intentionally NOT.
+    const OWNER_UNDELETE_DENIED_REASONS = new Set<string>([
+      "owner.merged",
+      "user.banned",
+      "security.redaction",
+    ]);
+    const reason = skill.moderationReason as string | undefined;
+    const ownerInitiatedHide =
+      (await isOwnerInitiatedSkillHideForActor(ctx, skill, args.userId)) &&
+      (reason === undefined || !OWNER_UNDELETE_DENIED_REASONS.has(reason));
+    if (!ownerInitiatedHide) {
+      // Prefix with "Forbidden:" so HTTP boundary mappers
+      // (softDeleteErrorToResponse) deterministically return 403 instead of
+      // falling through to 500. The suffix is preserved for clients that
+      // surface a human-readable reason.
+      throw new ConvexError(
+        "Forbidden: This skill was hidden by moderation and cannot be restored by the owner. Please contact a moderator.",
+      );
+    }
+  }
+
+  const now = Date.now();
+  const note = args.reason ? trimManualOverrideNote(args.reason) : undefined;
+  const slugReservedUntil =
+    args.deleted && isOwner ? now + UNPUBLISHED_SLUG_RESERVATION_MS : undefined;
+  const patch: Partial<Doc<"skills">> = {
+    softDeletedAt: args.deleted ? now : undefined,
+    moderationStatus: args.deleted ? "hidden" : "active",
+    hiddenAt: args.deleted ? now : undefined,
+    hiddenBy: args.deleted ? args.userId : undefined,
+    unpublishedSlugReservedUntil: slugReservedUntil,
+    unpublishedSlugReleasedAt: undefined,
+    unpublishedOriginalSlug: undefined,
+    lastReviewedAt: now,
+    updatedAt: now,
+  };
+  if (note) patch.moderationNotes = note;
+  if (!args.deleted && isModeratorOrAdmin && note) {
+    const manualOverride = buildManualOverrideRecord({
+      note,
+      reviewerUserId: user._id,
+      updatedAt: now,
+    });
+    Object.assign(
+      patch,
+      applyManualOverrideToSkillPatch({
+        basePatch: {
+          ...patch,
+          moderationReasonCodes: undefined,
+          moderationEvidence: undefined,
+          moderationSummary: undefined,
+          moderationEngineVersion: undefined,
+          moderationEvaluatedAt: undefined,
+          moderationSourceVersionId: undefined,
+        },
+        override: manualOverride,
+        now,
+      }),
+      {
+        manualOverride,
+        moderationNotes: note,
+      },
+    );
+  }
+  // Data hygiene: when an owner/org manager deletes, reset any stale
+  // `moderationReason` that may have survived from prior moderation metadata.
+  // This keeps the row's provenance fields consistent with the current hide
+  // (owner-initiated) and prevents future restore/reservation checks from
+  // tripping on historical reasons.
+  if (args.deleted && isOwner) {
+    patch.moderationReason = undefined;
+  }
+  const nextSkill = { ...skill, ...patch };
+  await ctx.db.patch(skill._id, patch);
+  await adjustGlobalPublicCountForSkillChange(ctx, skill, nextSkill);
+  await adjustUserSkillStatsForSkillChange(ctx, skill, nextSkill);
+
+  await setSkillEmbeddingsSoftDeleted(ctx, skill._id, args.deleted, now);
+
+  await ctx.db.insert("auditLogs", {
+    actorUserId: args.userId,
+    action: args.deleted ? "skill.delete" : "skill.undelete",
+    targetType: "skill",
+    targetId: skill._id,
+    metadata: {
+      slug,
+      softDeletedAt: args.deleted ? now : null,
+      actorRole: user.role ?? "user",
+      ...(slugReservedUntil ? { slugReservedUntil } : {}),
+      ...(note ? { reason: note } : {}),
+    },
+    createdAt: now,
+  });
+
+  return slugReservedUntil ? { ok: true as const, slugReservedUntil } : { ok: true as const };
+}
 
 export const hideSkillForSecurityRedactionInternal = internalMutation({
   args: {

--- a/convex/skills.undeleteGate.test.ts
+++ b/convex/skills.undeleteGate.test.ts
@@ -5,7 +5,8 @@ vi.mock("@convex-dev/auth/server", () => ({
   authTables: {},
 }));
 
-import { setSkillSoftDeletedInternal } from "./skills";
+import { getAuthUserId } from "@convex-dev/auth/server";
+import { setOwnedSkillSoftDeleted, setSkillSoftDeletedInternal } from "./skills";
 
 type WrappedHandler<TArgs> = {
   _handler: (ctx: unknown, args: TArgs) => Promise<unknown>;
@@ -17,6 +18,11 @@ const setSkillSoftDeletedInternalHandler = (
     slug: string;
     deleted: boolean;
     reason?: string;
+  }>
+)._handler;
+const setOwnedSkillSoftDeletedHandler = (
+  setOwnedSkillSoftDeleted as unknown as WrappedHandler<{
+    skillId: string;
   }>
 )._handler;
 
@@ -59,6 +65,7 @@ function makeCtx({
     get: vi.fn(async (id: string) => {
       if (id === actor._id) return actor;
       if (hiddenBy && id === hiddenBy._id) return hiddenBy;
+      if (skill && id === skill._id) return skill;
       return null;
     }),
     query: vi.fn((table: string) => {
@@ -100,6 +107,97 @@ function makeCtx({
 }
 
 describe("setSkillSoftDeletedInternal B1 undelete gate", () => {
+  it("allows direct owners to delete through the public owner settings mutation", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    vi.mocked(getAuthUserId).mockResolvedValue("users:owner" as never);
+    const skill = makeSkill({
+      moderationStatus: "active",
+      softDeletedAt: undefined,
+      hiddenAt: undefined,
+      hiddenBy: undefined,
+      moderationReason: undefined,
+    });
+    const { ctx, patch } = makeCtx({
+      skill,
+      actor: { _id: "users:owner", role: "user" },
+    });
+
+    await expect(
+      setOwnedSkillSoftDeletedHandler(ctx, {
+        skillId: "skills:1",
+      }),
+    ).resolves.toEqual({ ok: true, slugReservedUntil: now + 30 * 24 * 60 * 60 * 1000 });
+
+    expect(patch).toHaveBeenCalledWith(
+      "skills:1",
+      expect.objectContaining({
+        moderationStatus: "hidden",
+        hiddenBy: "users:owner",
+        unpublishedSlugReservedUntil: now + 30 * 24 * 60 * 60 * 1000,
+      }),
+    );
+  });
+
+  it("rejects non-owner moderators through the public owner settings mutation", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:mod" as never);
+    const skill = makeSkill({
+      moderationStatus: "active",
+      softDeletedAt: undefined,
+      hiddenAt: undefined,
+      hiddenBy: undefined,
+      moderationReason: undefined,
+    });
+    const { ctx, patch, insert } = makeCtx({
+      skill,
+      actor: { _id: "users:mod", role: "moderator" },
+    });
+
+    await expect(
+      setOwnedSkillSoftDeletedHandler(ctx, {
+        skillId: "skills:1",
+      }),
+    ).rejects.toThrow(/forbidden/i);
+
+    expect(patch).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it("allows org admins to delete org-owned skills through the public owner settings mutation", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    vi.mocked(getAuthUserId).mockResolvedValue("users:org-admin" as never);
+    const skill = makeSkill({
+      ownerUserId: "users:creator",
+      ownerPublisherId: "publishers:org",
+      moderationStatus: "active",
+      softDeletedAt: undefined,
+      hiddenAt: undefined,
+      hiddenBy: undefined,
+      moderationReason: undefined,
+    });
+    const { ctx, patch } = makeCtx({
+      skill,
+      actor: { _id: "users:org-admin", role: "user" },
+      membership: { _id: "publisherMembers:1", role: "admin" },
+    });
+
+    await expect(
+      setOwnedSkillSoftDeletedHandler(ctx, {
+        skillId: "skills:1",
+      }),
+    ).resolves.toEqual({ ok: true, slugReservedUntil: now + 30 * 24 * 60 * 60 * 1000 });
+
+    expect(patch).toHaveBeenCalledWith(
+      "skills:1",
+      expect.objectContaining({
+        moderationStatus: "hidden",
+        hiddenBy: "users:org-admin",
+        unpublishedSlugReservedUntil: now + 30 * 24 * 60 * 60 * 1000,
+      }),
+    );
+  });
+
   it("allows org publisher admins to restore org-admin hidden skills", async () => {
     const skill = makeSkill({
       ownerUserId: "users:creator",
@@ -739,6 +837,58 @@ describe("setSkillSoftDeletedInternal B1 undelete gate", () => {
         unpublishedSlugReservedUntil: now + 30 * 24 * 60 * 60 * 1000,
       }),
     );
+  });
+
+  it("rejects delete attempts for removed skills without downgrading them to hidden", async () => {
+    const skill = makeSkill({
+      moderationStatus: "removed",
+      softDeletedAt: 1_000,
+      hiddenAt: 1_000,
+      hiddenBy: "users:mod",
+      moderationReason: "user.banned",
+    });
+    const { ctx, patch, insert } = makeCtx({
+      skill,
+      actor: { _id: "users:mod", role: "moderator" },
+      hiddenBy: { _id: "users:mod", role: "moderator" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:mod",
+        slug: "demo",
+        deleted: true,
+      }),
+    ).rejects.toThrow(/removed skills cannot be deleted/i);
+
+    expect(patch).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it("does not reveal removed-skill state before authorization", async () => {
+    const skill = makeSkill({
+      moderationStatus: "removed",
+      softDeletedAt: 1_000,
+      hiddenAt: 1_000,
+      hiddenBy: "users:mod",
+      moderationReason: "user.banned",
+    });
+    const { ctx, patch, insert } = makeCtx({
+      skill,
+      actor: { _id: "users:stranger", role: "user" },
+      hiddenBy: { _id: "users:mod", role: "moderator" },
+    });
+
+    await expect(
+      setSkillSoftDeletedInternalHandler(ctx, {
+        userId: "users:stranger",
+        slug: "demo",
+        deleted: true,
+      }),
+    ).rejects.toThrow(/forbidden/i);
+
+    expect(patch).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
   });
 
   // BLOCKER regression: the owner MUST NOT be able to "re-delete" a skill

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -1,5 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { getFunctionName } from "convex/server";
 import type { ReactNode } from "react";
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Id } from "../../convex/_generated/dataModel";
 import { SkillDetailPage } from "../components/SkillDetailPage";
@@ -40,6 +42,13 @@ vi.mock("convex/react", () => ({
   useAction: () => getReadmeMock,
 }));
 
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
 vi.mock("../lib/useAuthStatus", () => ({
   useAuthStatus: () => useAuthStatusMock(),
 }));
@@ -71,6 +80,7 @@ describe("SkillDetailPage", () => {
     useAuthStatusMock.mockReset();
     getReadmeMock.mockResolvedValue({ text: "" });
     useMutationMock.mockReturnValue(vi.fn());
+    vi.mocked(toast.success).mockReset();
     useAuthStatusMock.mockReturnValue({
       isAuthenticated: false,
       isLoading: false,
@@ -1557,6 +1567,158 @@ describe("SkillDetailPage", () => {
     );
     expect(screen.getByText("Rename slug")).toBeTruthy();
     expect(screen.getByText("Merge listing")).toBeTruthy();
+  });
+
+  it("lets owners confirm skill deletion from settings", async () => {
+    const deleteSkill = vi.fn().mockResolvedValue({
+      ok: true,
+      slugReservedUntil: Date.UTC(2026, 6, 7),
+    });
+    useMutationMock.mockImplementation((mutation) =>
+      getFunctionName(mutation) === "skills:setOwnedSkillSoftDeleted" ? deleteSkill : vi.fn(),
+    );
+    useAuthStatusMock.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      me: { _id: "users:1", role: "user" },
+    });
+    useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
+      if (args === "skip") return undefined;
+      if (
+        args &&
+        typeof args === "object" &&
+        ("ownerUserId" in args || "ownerPublisherId" in args)
+      ) {
+        return [{ _id: "skills:1", slug: "weather", displayName: "Weather" }];
+      }
+      if (args && typeof args === "object" && "skillId" in args) return [];
+      if (args && typeof args === "object" && "slug" in args) {
+        return {
+          skill: {
+            _id: "skills:1",
+            slug: "weather",
+            displayName: "Weather",
+            summary: "Get current weather.",
+            ownerUserId: "users:1",
+            ownerPublisherId: "publishers:steipete",
+            tags: {},
+            stats: { stars: 0, downloads: 0 },
+          },
+          owner: {
+            _id: "publishers:steipete",
+            _creationTime: 0,
+            kind: "user",
+            handle: "steipete",
+            displayName: "Peter",
+            linkedUserId: "users:1",
+          },
+          latestVersion: { _id: "skillVersions:1", version: "1.0.0", parsed: {}, files: [] },
+        };
+      }
+      return undefined;
+    });
+
+    render(<SkillDetailPage slug="weather" mode="settings" />);
+
+    expect(await screen.findByRole("heading", { name: /Skill settings/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Delete skill" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Delete skill" }));
+
+    expect(deleteSkill).not.toHaveBeenCalled();
+    expect(screen.getByRole("heading", { name: "Delete skill" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete skill" }));
+
+    await waitFor(() => {
+      expect(deleteSkill).toHaveBeenCalledWith({ skillId });
+    });
+    expect(toast.success).toHaveBeenCalledWith(
+      expect.stringMatching(/^Deleted weather\. Slug reserved until /),
+    );
+    expect(navigateMock).toHaveBeenCalledWith({ to: "/", replace: true });
+  });
+
+  it("does not show the owner delete action to staff-only settings viewers", async () => {
+    useAuthStatusMock.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      me: { _id: "users:moderator", role: "moderator" },
+    });
+    useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
+      if (args === "skip") return undefined;
+      if (args && typeof args === "object" && "skillId" in args) return [];
+      if (args && typeof args === "object" && "slug" in args) {
+        return {
+          skill: {
+            _id: "skills:1",
+            slug: "weather",
+            displayName: "Weather",
+            summary: "Get current weather.",
+            ownerUserId: "users:1",
+            ownerPublisherId: "publishers:steipete",
+            tags: {},
+            stats: { stars: 0, downloads: 0 },
+          },
+          owner: {
+            _id: "publishers:steipete",
+            _creationTime: 0,
+            kind: "user",
+            handle: "steipete",
+            displayName: "Peter",
+            linkedUserId: "users:1",
+          },
+          latestVersion: { _id: "skillVersions:1", version: "1.0.0", parsed: {}, files: [] },
+        };
+      }
+      return undefined;
+    });
+
+    render(<SkillDetailPage slug="weather" mode="settings" />);
+
+    expect(await screen.findByRole("heading", { name: /Skill settings/i })).toBeTruthy();
+    expect(screen.getByText("Rename slug")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Delete skill" })).toBeNull();
+  });
+
+  it("does not show the owner delete action to org skill creators without org admin access", async () => {
+    useAuthStatusMock.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      me: { _id: "users:creator", role: "user" },
+    });
+    useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
+      if (args === "skip") return undefined;
+      if (args && typeof args === "object" && "skillId" in args) return [];
+      if (args && typeof args === "object" && "slug" in args) {
+        return {
+          skill: {
+            _id: "skills:1",
+            slug: "weather",
+            displayName: "Weather",
+            summary: "Get current weather.",
+            ownerUserId: "users:creator",
+            ownerPublisherId: "publishers:org",
+            tags: {},
+            stats: { stars: 0, downloads: 0 },
+          },
+          owner: {
+            _id: "publishers:org",
+            _creationTime: 0,
+            kind: "org",
+            handle: "weather-org",
+            displayName: "Weather Org",
+          },
+          latestVersion: { _id: "skillVersions:1", version: "1.0.0", parsed: {}, files: [] },
+        };
+      }
+      return undefined;
+    });
+
+    render(<SkillDetailPage slug="weather" mode="settings" />);
+
+    expect(await screen.findByRole("heading", { name: /Skill settings/i })).toBeTruthy();
+    expect(screen.getByText("Rename slug")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Delete skill" })).toBeNull();
   });
 
   it("does not expose settings to publisher members without admin access", async () => {

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -299,6 +299,17 @@ export function SkillDetailPage({
     Boolean(me && skill && me._id === skill.ownerUserId) ||
     isStaff ||
     Boolean(skill?.ownerPublisherId && myManagePublisherIds.has(skill.ownerPublisherId));
+  const canManagePersonalPublisherSkill =
+    Boolean(me && skill && !skill.ownerPublisherId && me._id === skill.ownerUserId) ||
+    Boolean(
+      me &&
+      skill?.ownerPublisherId &&
+      owner?.kind === "user" &&
+      (owner.linkedUserId ? owner.linkedUserId === me._id : me._id === skill.ownerUserId),
+    );
+  const canDeleteSkillFromSettings =
+    canManagePersonalPublisherSkill ||
+    Boolean(skill?.ownerPublisherId && myManagePublisherIds.has(skill.ownerPublisherId));
   const ownedSkills = useQuery(
     api.skills.list,
     canAccessSettings && skill
@@ -744,6 +755,7 @@ export function SkillDetailPage({
         ownedSkills={(ownedSkills ?? []).filter((entry) => entry._id !== skill._id)}
         summary={skill.summary ?? ""}
         onSaveSummary={canAccessSettings ? submitSummary : null}
+        canDeleteSkill={canDeleteSkillFromSettings}
       />
     ) : null;
 

--- a/src/components/SkillOwnershipPanel.tsx
+++ b/src/components/SkillOwnershipPanel.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "@tanstack/react-router";
 import { useMutation } from "convex/react";
+import { ShieldAlert, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { api } from "../../convex/_generated/api";
@@ -33,6 +34,7 @@ type SkillOwnershipPanelProps = {
   ownedSkills: OwnedSkillOption[];
   summary?: string | null;
   onSaveSummary?: ((summary: string) => Promise<void>) | null;
+  canDeleteSkill: boolean;
 };
 
 function formatMutationError(error: unknown) {
@@ -101,10 +103,12 @@ export function SkillOwnershipPanel({
   ownedSkills,
   summary,
   onSaveSummary,
+  canDeleteSkill,
 }: SkillOwnershipPanelProps) {
   const navigate = useNavigate();
   const renameOwnedSkill = useMutation(api.skills.renameOwnedSkill);
   const mergeOwnedSkillIntoCanonical = useMutation(api.skills.mergeOwnedSkillIntoCanonical);
+  const setOwnedSkillSoftDeleted = useMutation(api.skills.setOwnedSkillSoftDeleted);
 
   const [renameSlug, setRenameSlug] = useState(slug);
   const [mergeTargetSlug, setMergeTargetSlug] = useState(ownedSkills[0]?.slug ?? "");
@@ -112,6 +116,7 @@ export function SkillOwnershipPanel({
   const [error, setError] = useState<string | null>(null);
   const [confirmRename, setConfirmRename] = useState(false);
   const [confirmMerge, setConfirmMerge] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
 
   // When ownedSkills first arrives from the server, default the merge target to
   // the first available skill so the Select is never blank.
@@ -165,6 +170,30 @@ export function SkillOwnershipPanel({
       });
     } catch (mergeError) {
       setError(formatMutationError(mergeError));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const result = await setOwnedSkillSoftDeleted({
+        skillId,
+      });
+      const reservedUntil =
+        result && "slugReservedUntil" in result && typeof result.slugReservedUntil === "number"
+          ? new Date(result.slugReservedUntil).toLocaleDateString()
+          : null;
+      toast.success(
+        reservedUntil
+          ? `Deleted ${slug}. Slug reserved until ${reservedUntil}.`
+          : `Deleted ${slug}.`,
+      );
+      await navigate({ to: "/", replace: true });
+    } catch (deleteError) {
+      setError(formatMutationError(deleteError));
     } finally {
       setIsSubmitting(false);
     }
@@ -248,6 +277,35 @@ export function SkillOwnershipPanel({
           </div>
         </SettingsActionRow>
 
+        {canDeleteSkill ? (
+          <div className="mt-8 rounded-[var(--radius-md)] border border-red-300/50 bg-red-500/[0.035] p-4 dark:border-red-500/35 dark:bg-red-500/[0.045] sm:p-5">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex min-w-0 items-center gap-3">
+                <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-red-300/40 bg-red-500/10 text-red-700 dark:border-red-500/30 dark:text-red-300">
+                  <ShieldAlert size={17} aria-hidden="true" />
+                </span>
+                <div className="min-w-0">
+                  <h3 className="text-sm font-bold text-red-700 dark:text-red-300">Delete skill</h3>
+                  <p className="text-sm text-[color:var(--ink-soft)]">
+                    Hide this skill from search, browse, and public install surfaces. The slug stays
+                    reserved for 30 days.
+                  </p>
+                </div>
+              </div>
+              <Button
+                variant="destructive"
+                type="button"
+                className="sm:w-auto"
+                onClick={() => setConfirmDelete(true)}
+                disabled={isSubmitting}
+              >
+                <Trash2 size={16} aria-hidden="true" />
+                Delete skill
+              </Button>
+            </div>
+          </div>
+        ) : null}
+
         {error ? (
           <p className="text-sm font-medium text-red-600 dark:text-red-400">{error}</p>
         ) : null}
@@ -304,6 +362,34 @@ export function SkillOwnershipPanel({
               }}
             >
               Merge and hide
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirmation dialog */}
+      <Dialog open={canDeleteSkill && confirmDelete} onOpenChange={setConfirmDelete}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete skill</DialogTitle>
+            <DialogDescription>
+              Delete <strong>{slug}</strong> from public ClawHub surfaces. The slug stays reserved
+              for 30 days so accidental deletes can be restored.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setConfirmDelete(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              loading={isSubmitting}
+              onClick={() => {
+                void handleDelete().finally(() => setConfirmDelete(false));
+              }}
+            >
+              <Trash2 size={16} aria-hidden="true" />
+              Delete skill
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## Summary
- Adds an org-style red danger delete action to skill settings, with a confirmation dialog before hiding the skill.
- Adds a delete-only owner/org-admin Convex mutation scoped by skill id, and hides the action from staff-only or non-admin creator views.
- Preserves moderation, removed, malicious, and slug-reservation safeguards for owner/org-admin soft deletes.


## Screenshots
- UI proof will be posted by `bun run proof:publish` after PR creation.
- Local proof source: `.artifacts/clawhub-ui-proof/skill-delete-settings`


## Tests
- `bunx vitest run convex/skills.slugAvailability.test.ts convex/skills.rateLimit.test.ts convex/skills.undeleteGate.test.ts src/__tests__/skill-detail-page.test.tsx`
- `bun run format:check -- convex/skills.ts convex/skills.slugAvailability.test.ts convex/skills.rateLimit.test.ts convex/skills.undeleteGate.test.ts src/components/SkillDetailPage.tsx src/components/SkillOwnershipPanel.tsx src/__tests__/skill-detail-page.test.tsx`
- `bun run lint -- convex/skills.ts convex/skills.slugAvailability.test.ts convex/skills.rateLimit.test.ts convex/skills.undeleteGate.test.ts src/components/SkillDetailPage.tsx src/components/SkillOwnershipPanel.tsx src/__tests__/skill-detail-page.test.tsx`
- `bunx tsc --noEmit`
- `bun run ci:static`
- `bun run ci:unit`
- `$autoreview` clean: no accepted/actionable findings reported
