### PR TITLE
fix: slim package manage context

### DIFF
--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -376,7 +376,10 @@ const getPackageModerationStatusForUserInternalHandler = (
 const getManageContextHandler = (
   getManageContext as unknown as WrappedHandler<
     { name: string; candidateNames?: string[] },
-    { package: { name: string }; latestRelease: { version: string } } | null
+    {
+      package: { _id: string; name: string; displayName: string };
+      latestRelease: { _id: string; version: string };
+    } | null
   >
 )._handler;
 const submitPackageAppealForUserInternalHandler = (
@@ -7442,6 +7445,76 @@ describe("packages public queries", () => {
     );
 
     expect(result).toBeNull();
+  });
+
+  it("returns only slim package identifiers for package manage context", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:owner" as never);
+
+    const pkg = makePackageDoc({
+      name: "large-plugin",
+      displayName: "Large Plugin",
+      sourceRepo: "owner/large-plugin",
+      latestVersionSummary: {
+        version: "1.2.3",
+        changelog: "x".repeat(10_000),
+        artifact: { kind: "legacy-zip", sha256: "abc", format: "zip" },
+      },
+      tags: {
+        latest: "packageReleases:demo-1",
+        beta: "packageReleases:demo-beta",
+      },
+    });
+    const release = makeReleaseDoc({
+      version: "1.2.3",
+      files: [
+        {
+          path: "README.md",
+          size: 10_000,
+          sha256: "abc",
+          contentType: "text/plain; charset=utf-8",
+        },
+      ],
+      llmAnalysis: {
+        status: "clean",
+        checkedAt: 2,
+        findings: "x".repeat(10_000),
+      },
+    });
+
+    const result = await getManageContextHandler(
+      {
+        db: {
+          get: vi.fn(async (id: string) => {
+            if (id === "users:owner") return { _id: id, role: "user" };
+            if (id === "packageReleases:demo-1") return release;
+            return null;
+          }),
+          query: vi.fn((table: string) => {
+            if (table === "packages") {
+              return {
+                withIndex: vi.fn(() => ({
+                  unique: vi.fn().mockResolvedValue(pkg),
+                })),
+              };
+            }
+            throw new Error(`Unexpected table ${table}`);
+          }),
+        },
+      } as never,
+      { name: "large-plugin" },
+    );
+
+    expect(result).toEqual({
+      package: {
+        _id: "packages:demo",
+        name: "large-plugin",
+        displayName: "Large Plugin",
+      },
+      latestRelease: {
+        _id: "packageReleases:demo-1",
+        version: "1.2.3",
+      },
+    });
   });
 
   it("lists package appeals for moderators", async () => {

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -2012,6 +2012,28 @@ async function requireTrustedPublisherEditor(
   });
 }
 
+type PackageManageContext = {
+  package: Pick<Doc<"packages">, "_id" | "name" | "displayName">;
+  latestRelease: Pick<Doc<"packageReleases">, "_id" | "version">;
+};
+
+function toPackageManageContext(
+  pkg: Doc<"packages">,
+  latestRelease: Doc<"packageReleases">,
+): PackageManageContext {
+  return {
+    package: {
+      _id: pkg._id,
+      name: pkg.name,
+      displayName: pkg.displayName,
+    },
+    latestRelease: {
+      _id: latestRelease._id,
+      version: latestRelease.version,
+    },
+  };
+}
+
 export const getByName = query({
   args: { name: v.string() },
   handler: async (ctx, args) => {
@@ -2070,17 +2092,7 @@ export const getManageContext = query({
     const latestRelease = await ctx.db.get(pkg.latestReleaseId);
     if (!latestRelease || latestRelease.softDeletedAt) return null;
 
-    return {
-      package: {
-        _id: pkg._id,
-        name: pkg.name,
-        displayName: pkg.displayName,
-      },
-      latestRelease: {
-        _id: latestRelease._id,
-        version: latestRelease.version,
-      },
-    };
+    return toPackageManageContext(pkg, latestRelease);
   },
 });
 

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -2071,8 +2071,15 @@ export const getManageContext = query({
     if (!latestRelease || latestRelease.softDeletedAt) return null;
 
     return {
-      package: pkg,
-      latestRelease: toPublicPackageRelease(latestRelease),
+      package: {
+        _id: pkg._id,
+        name: pkg.name,
+        displayName: pkg.displayName,
+      },
+      latestRelease: {
+        _id: latestRelease._id,
+        version: latestRelease.version,
+      },
     };
   },
 });


### PR DESCRIPTION
## Summary
- return only package/release identifiers from packages.getManageContext
- avoid sending full package and release metadata to owner-management UI
- add regression coverage for large metadata staying out of manage context

## Tests
- bun run test -- convex/packages.public.test.ts src/__tests__/package-detail-route.test.tsx src/__tests__/plugin-security-audit-route.test.tsx
- bunx tsc -p convex/tsconfig.json --noEmit
- bunx tsc --noEmit
- bun run format:check -- convex/packages.ts convex/packages.public.test.ts