### PR TITLE
Fix stale plugin validation findings

### DIFF
--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -7519,6 +7519,57 @@ describe("packages public queries", () => {
     });
   });
 
+  it("summarizes only latest-release plugin inspector findings", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue(null);
+    const warningIndexEq = vi.fn(() => ({}));
+    const warningWithIndex = vi.fn(
+      (_indexName: string, build: (q: { eq: typeof warningIndexEq }) => unknown) => {
+        build({ eq: warningIndexEq });
+        return {
+          order: vi.fn(() => ({
+            take: vi.fn().mockResolvedValue([]),
+          })),
+        };
+      },
+    );
+    const ctx = {
+      db: {
+        get: vi.fn(),
+        query: vi.fn((table: string) => {
+          if (table === "packages") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue({
+                  _id: "packages:demo",
+                  name: "demo-plugin",
+                  normalizedName: "demo-plugin",
+                  family: "code-plugin",
+                  latestReleaseId: "packageReleases:demo-2",
+                }),
+              })),
+            };
+          }
+          if (table === "packageInspectorWarnings") {
+            return { withIndex: warningWithIndex };
+          }
+          throw new Error(`Unexpected table ${table}`);
+        }),
+      },
+    };
+
+    await expect(
+      getPackageInspectorValidationSummaryPublicHandler(ctx as never, { name: "demo-plugin" }),
+    ).resolves.toEqual({
+      findingCount: 0,
+      errorCount: 0,
+      warningCount: 0,
+      incompatibleAfterOpenClawVersion: null,
+    });
+    expect(warningWithIndex).toHaveBeenCalledWith("by_release_created", expect.any(Function));
+    expect(warningIndexEq).toHaveBeenCalledWith("releaseId", "packageReleases:demo-2");
+    expect(warningIndexEq).not.toHaveBeenCalledWith("packageId", "packages:demo");
+  });
+
   it("does not list detailed plugin inspector findings for signed-out viewers", async () => {
     vi.mocked(getAuthUserId).mockResolvedValue(null);
     const ctx = {
@@ -8072,6 +8123,71 @@ describe("packages public queries", () => {
       }),
     ).resolves.toEqual([]);
     expect(ctx.db.query).not.toHaveBeenCalled();
+  });
+
+  it("lists manager plugin inspector findings only for the latest release", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:owner" as never);
+    const warningIndexEq = vi.fn(() => ({}));
+    const warningWithIndex = vi.fn(
+      (_indexName: string, build: (q: { eq: typeof warningIndexEq }) => unknown) => {
+        build({ eq: warningIndexEq });
+        return {
+          order: vi.fn(() => ({
+            take: vi.fn().mockResolvedValue([
+              {
+                _id: "packageInspectorWarnings:latest",
+                packageName: "demo-plugin",
+                version: "2.0.0",
+                findingKind: "warning",
+                code: "latest-warning",
+                message: "latest release warning",
+                createdAt: 2,
+                authorRemediation: {
+                  summary: "Update the plugin API usage.",
+                },
+              },
+            ]),
+          })),
+        };
+      },
+    );
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "users:owner") return { _id: "users:owner", role: "user" };
+          return null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table === "packages") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue({
+                  _id: "packages:demo",
+                  name: "demo-plugin",
+                  normalizedName: "demo-plugin",
+                  family: "code-plugin",
+                  ownerUserId: "users:owner",
+                  latestReleaseId: "packageReleases:demo-2",
+                }),
+              })),
+            };
+          }
+          if (table === "packageInspectorWarnings") {
+            return { withIndex: warningWithIndex };
+          }
+          throw new Error(`Unexpected table ${table}`);
+        }),
+      },
+    };
+
+    await expect(
+      listPackageInspectorWarningsForManagerHandler(ctx as never, {
+        name: "demo-plugin",
+      }),
+    ).resolves.toMatchObject([{ code: "latest-warning", version: "2.0.0" }]);
+    expect(warningWithIndex).toHaveBeenCalledWith("by_release_created", expect.any(Function));
+    expect(warningIndexEq).toHaveBeenCalledWith("releaseId", "packageReleases:demo-2");
+    expect(warningIndexEq).not.toHaveBeenCalledWith("packageId", "packages:demo");
   });
 
   it("infers owner handle from scoped package names for user package publishes", async () => {

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -1240,7 +1240,7 @@ async function toDashboardPackageListItem(
 ): Promise<DashboardPackageListItem | null> {
   if (pkg.softDeletedAt) return null;
   const latestRelease = pkg.latestReleaseId ? await ctx.db.get(pkg.latestReleaseId) : null;
-  const inspectorWarningCount = await countPackageInspectorFindings(ctx, pkg._id);
+  const inspectorWarningCount = await countPackageInspectorFindings(ctx, pkg.latestReleaseId);
   return {
     _id: pkg._id,
     name: pkg.name,
@@ -1274,9 +1274,13 @@ async function toDashboardPackageListItem(
   };
 }
 
-async function countPackageInspectorFindings(ctx: DbReaderCtx, packageId: Id<"packages">) {
-  const authorFindings = await takeAuthorRemediationWarningsByPackage(ctx, packageId, 101);
-  return authorFindings.length > 100 ? 100 : authorFindings.length;
+async function countPackageInspectorFindings(
+  ctx: DbReaderCtx,
+  latestReleaseId?: Id<"packageReleases">,
+) {
+  if (!latestReleaseId) return 0;
+  const findings = await takeAuthorRemediationWarningsByRelease(ctx, latestReleaseId, 101);
+  return findings.length > 100 ? 100 : findings.length;
 }
 
 async function listDashboardPackagesForOwnerPublisher(
@@ -1979,8 +1983,9 @@ export const listPackageInspectorFindingsPublic = query({
       if (!canManage) return [];
     }
 
+    if (!pkg.latestReleaseId) return [];
     const limit = Math.max(1, Math.min(args.limit ?? 50, 100));
-    const warnings = await takeAuthorRemediationWarningsByPackage(ctx, pkg._id, limit);
+    const warnings = await takeAuthorRemediationWarningsByRelease(ctx, pkg.latestReleaseId, limit);
     return warnings.map(toPublicPackageInspectorFinding);
   },
 });
@@ -2001,7 +2006,9 @@ export const getPackageInspectorValidationSummaryPublic = query({
       };
     }
 
-    const findings = await takeAuthorRemediationWarningsByPackage(ctx, pkg._id, 100);
+    const findings = pkg.latestReleaseId
+      ? await takeAuthorRemediationWarningsByRelease(ctx, pkg.latestReleaseId, 100)
+      : [];
     const errorFindings = findings.filter((finding) => {
       const kind =
         finding.findingKind ??
@@ -2035,24 +2042,12 @@ export const listPackageInspectorWarningsForManager = query({
       const canManage = await viewerCanManagePackageOwner(ctx, pkg, viewerUserId);
       if (!canManage) return [];
     }
+    if (!pkg.latestReleaseId) return [];
     const limit = Math.max(1, Math.min(args.limit ?? 50, 100));
-    const warnings = await takeAuthorRemediationWarningsByPackage(ctx, pkg._id, limit);
+    const warnings = await takeAuthorRemediationWarningsByRelease(ctx, pkg.latestReleaseId, limit);
     return warnings.map(toPublicPackageInspectorFinding);
   },
 });
-
-async function takeAuthorRemediationWarningsByPackage(
-  ctx: DbReaderCtx,
-  packageId: Id<"packages">,
-  limit: number,
-) {
-  const findings = await ctx.db
-    .query("packageInspectorWarnings")
-    .withIndex("by_package_created", (q) => q.eq("packageId", packageId))
-    .order("desc")
-    .take(authorRemediationScanLimit(limit));
-  return findings.filter(hasStoredAuthorRemediation).slice(0, limit);
-}
 
 async function takeAuthorRemediationWarningsByRelease(
   ctx: DbReaderCtx,


### PR DESCRIPTION
## Summary
- Scope plugin validation summary/count/detail queries to the package's current latest release.
- Keep dashboard validation counts from showing stale findings after a plugin publishes a newer clean version.
- Preserve author-remediation filtering while using the `by_release_created` index.
- Add regression coverage for signed-out summary and manager detail queries using `by_release_created`.

## Review context
Follow-up from autoreview of merged PR #2525. The merged implementation stored findings per release, but the plugin detail/dashboard reads were by package, so findings from older releases could continue to drive the current plugin validation alert/count after a newer version was published.

## Test Plan
- `bunx vitest run convex/packages.public.test.ts`
- `bun run format:check -- convex/packages.ts convex/packages.public.test.ts`
- `bunx convex run --push --typecheck=disable --inline-query 'const rows = await ctx.db.query("packageInspectorWarnings").withIndex("by_release_created").order("desc").take(1); return { count: rows.length, hasReleaseId: rows[0]?.releaseId !== undefined };'`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bunx convex run --push --typecheck=enable --inline-query 'const rows = await ctx.db.query("packageInspectorWarnings").withIndex("by_release_created").order("desc").take(1); return { count: rows.length, hasReleaseId: rows[0]?.releaseId !== undefined };'`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
