### PR TITLE
Temporarily disable plugin inspector nightly schedule

### DIFF
--- a/.github/workflows/plugin-inspector-nightly.yml
+++ b/.github/workflows/plugin-inspector-nightly.yml
@@ -16,8 +16,9 @@ on:
         description: "Maximum preview batches to scan when dry_run is enabled"
         required: false
         default: "20"
-  schedule:
-    - cron: "41 8 * * *"
+  # Temporarily disabled; keep workflow_dispatch available for manual dry runs.
+  # schedule:
+  #   - cron: "41 8 * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- temporarily disable the scheduled trigger for Plugin Inspector Nightly
- keep `workflow_dispatch` enabled so maintainers can still run manual dry runs/scans

## Test Plan
- `git diff --check`

## Revert
- Re-enable the commented `schedule` block in `.github/workflows/plugin-inspector-nightly.yml`.
