### PR TITLE
fix: use consistent installedAt timestamp for origin.json and lockfile

### DIFF
--- a/packages/clawhub/src/cli/commands/skills.test.ts
+++ b/packages/clawhub/src/cli/commands/skills.test.ts
@@ -798,6 +798,56 @@ describe("cmdUpdate", () => {
     expect(rm).not.toHaveBeenCalled();
     expect(mockSpinner.succeed).toHaveBeenCalledWith("demo: up to date (1.0.0)");
   });
+
+  it("writes identical installedAt to origin and lockfile on update", async () => {
+    mockApiRequest.mockResolvedValue({
+      skill: {
+        slug: "demo",
+        displayName: "Demo",
+        summary: null,
+        tags: {},
+        stats: {},
+        createdAt: 0,
+        updatedAt: 0,
+      },
+      latestVersion: { version: "2.0.0" },
+      owner: null,
+      moderation: null,
+    });
+    mockDownloadZip.mockResolvedValue(new Uint8Array([1, 2, 3]));
+    vi.mocked(readLockfile).mockResolvedValue({
+      version: 1,
+      skills: {
+        demo: { version: "1.0.0", installedAt: 100 },
+      },
+    });
+    vi.mocked(readSkillOrigin).mockResolvedValue({
+      version: 1,
+      registry: "https://clawhub.ai",
+      slug: "demo",
+      installedVersion: "1.0.0",
+      installedAt: 100,
+      fingerprint: "hash",
+    });
+    vi.mocked(writeLockfile).mockResolvedValue();
+    vi.mocked(writeSkillOrigin).mockResolvedValue();
+    vi.mocked(extractZipToDir).mockResolvedValue();
+    vi.mocked(listTextFiles).mockResolvedValue([
+      { relPath: "SKILL.md", bytes: new Uint8Array([1]) },
+    ]);
+    vi.mocked(hashSkillFiles).mockReturnValue({ fingerprint: "hash", files: [] });
+    vi.mocked(stat).mockResolvedValue({} as unknown as Awaited<ReturnType<typeof stat>>);
+    vi.mocked(rm).mockResolvedValue();
+
+    await cmdUpdate(makeOpts(), "demo", {}, false);
+
+    const originInstalledAt = vi.mocked(writeSkillOrigin).mock.calls[0]?.[1]?.installedAt;
+    const lockfileInstalledAt =
+      vi.mocked(writeLockfile).mock.calls[0]?.[1]?.skills?.demo?.installedAt;
+    expect(originInstalledAt).toBeDefined();
+    expect(lockfileInstalledAt).toBeDefined();
+    expect(originInstalledAt).toBe(lockfileInstalledAt);
+  });
 });
 
 describe("pin commands", () => {
@@ -1248,6 +1298,46 @@ describe("cmdInstall", () => {
     const rmOrder = vi.mocked(rm).mock.invocationCallOrder[0];
     const downloadOrder = mockDownloadZip.mock.invocationCallOrder[0];
     expect(rmOrder).toBeLessThan(downloadOrder);
+  });
+
+  it("writes identical installedAt to origin and lockfile on install", async () => {
+    mockApiRequest.mockImplementation(async (_registry, args) => {
+      if (args.path === LegacyApiRoutes.cliTelemetryInstall) return { ok: true };
+      return {
+        skill: {
+          slug: "demo",
+          displayName: "Demo",
+          summary: null,
+          tags: {},
+          stats: {},
+          createdAt: 0,
+          updatedAt: 0,
+        },
+        latestVersion: { version: "1.0.0" },
+        owner: null,
+        moderation: null,
+      };
+    });
+    mockDownloadZip.mockResolvedValue(new Uint8Array([1, 2, 3]));
+    vi.mocked(readLockfile).mockResolvedValue({ version: 1, skills: {} });
+    vi.mocked(writeLockfile).mockResolvedValue();
+    vi.mocked(writeSkillOrigin).mockResolvedValue();
+    vi.mocked(extractZipToDir).mockResolvedValue();
+    vi.mocked(listTextFiles).mockResolvedValue([
+      { relPath: "SKILL.md", bytes: new Uint8Array([1]) },
+    ]);
+    vi.mocked(hashSkillFiles).mockReturnValue({ fingerprint: "hash", files: [] });
+    vi.mocked(stat).mockRejectedValue(new Error("missing"));
+    vi.mocked(rm).mockResolvedValue();
+
+    await cmdInstall(makeOpts(), "demo");
+
+    const originInstalledAt = vi.mocked(writeSkillOrigin).mock.calls[0]?.[1]?.installedAt;
+    const lockfileInstalledAt =
+      vi.mocked(writeLockfile).mock.calls[0]?.[1]?.skills?.demo?.installedAt;
+    expect(originInstalledAt).toBeDefined();
+    expect(lockfileInstalledAt).toBeDefined();
+    expect(originInstalledAt).toBe(lockfileInstalledAt);
   });
 });
 

--- a/packages/clawhub/src/cli/commands/skills.ts
+++ b/packages/clawhub/src/cli/commands/skills.ts
@@ -243,16 +243,17 @@ export async function cmdInstall(
     const installedFingerprint =
       installedFiles.length > 0 ? hashSkillFiles(installedFiles).fingerprint : undefined;
 
+    const installedAt = Date.now();
     await writeSkillOrigin(target, {
       version: 1,
       registry,
       slug: trimmed,
       installedVersion: resolvedVersion!,
-      installedAt: Date.now(),
+      installedAt: installedAt,
       fingerprint: installedFingerprint,
     });
 
-    lock.skills[trimmed] = withPinnedMetadata(resolvedVersion!, Date.now(), existingEntry);
+    lock.skills[trimmed] = withPinnedMetadata(resolvedVersion!, installedAt, existingEntry);
     await writeLockfile(opts.workdir, lock);
     await reportInstalledSkillsTelemetryIfEnabled({
       token,
@@ -421,16 +422,17 @@ export async function cmdUpdate(
           const installedFingerprint =
             installedFiles.length > 0 ? hashSkillFiles(installedFiles).fingerprint : undefined;
 
+          const installedAt = existingOrigin?.installedAt ?? Date.now();
           await writeSkillOrigin(target, {
             version: 1,
             registry: existingOrigin?.registry ?? registry,
             slug: entry,
             installedVersion: targetVersion,
-            installedAt: existingOrigin?.installedAt ?? Date.now(),
+            installedAt,
             fingerprint: installedFingerprint,
           });
 
-          lock.skills[entry] = withPinnedMetadata(targetVersion, Date.now(), lock.skills[entry]);
+          lock.skills[entry] = withPinnedMetadata(targetVersion, installedAt, lock.skills[entry]);
           spinner.succeed(`${entry}: updated -> ${formatGitHubVersion(targetVersion)}`);
           continue;
         }
@@ -510,16 +512,17 @@ export async function cmdUpdate(
       const installedFingerprint =
         installedFiles.length > 0 ? hashSkillFiles(installedFiles).fingerprint : undefined;
 
+      const installedAt = existingOrigin?.installedAt ?? Date.now();
       await writeSkillOrigin(target, {
         version: 1,
         registry: existingOrigin?.registry ?? registry,
         slug: existingOrigin?.slug ?? entry,
         installedVersion: targetVersion,
-        installedAt: existingOrigin?.installedAt ?? Date.now(),
+        installedAt,
         fingerprint: installedFingerprint,
       });
 
-      lock.skills[entry] = withPinnedMetadata(targetVersion, Date.now(), lock.skills[entry]);
+      lock.skills[entry] = withPinnedMetadata(targetVersion, installedAt, lock.skills[entry]);
       spinner.succeed(`${entry}: updated -> ${targetVersion}`);
     } catch (error) {
       spinner.fail(formatError(error));


### PR DESCRIPTION
## Problem

`clawhub install` and `clawhub update --force` write different `installedAt` timestamps to `.clawhub/origin.json` and `.clawhub/lock.json` (typically 1–3ms apart). OpenClaw's skill status validation compares these with strict `!==`, causing persistent "ClawHub link invalid" warnings.

See #2559 for full reproduction and evidence.

## Fix

Three call sites in `packages/clawhub/src/cli/commands/skills.ts`:

### 1. Install path (~line 246)
Before: two separate `Date.now()` calls
```typescript
await writeSkillOrigin(target, { installedAt: Date.now() });
lock.skills[trimmed] = withPinnedMetadata(version, Date.now(), existingEntry);
```
After: capture once, use for both
```typescript
const installedAt = Date.now();
await writeSkillOrigin(target, { installedAt });
lock.skills[trimmed] = withPinnedMetadata(version, installedAt, existingEntry);
```

### 2. GitHub archive update path (~line 425)
Before: origin preserves old timestamp, lockfile always gets new `Date.now()`
```typescript
installedAt: existingOrigin?.installedAt ?? Date.now(),
// ...
lock.skills[entry] = withPinnedMetadata(version, Date.now(), lock.skills[entry]);
```
After: capture once, use for both
```typescript
const installedAt = existingOrigin?.installedAt ?? Date.now();
// ...
lock.skills[entry] = withPinnedMetadata(version, installedAt, lock.skills[entry]);
```

### 3. URL/custom update path (~line 520)
Same pattern as #2, same fix.