### PR TITLE
Fix Dependabot Bun update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,23 +7,11 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "America/Los_Angeles"
-    open-pull-requests-limit: 3
-    labels:
-      - dependencies
-      - needs-cli-release
-    allow:
-      - dependency-name: "@openclaw/plugin-inspector"
-
-  - package-ecosystem: "bun"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-      timezone: "America/Los_Angeles"
-    open-pull-requests-limit: 10
+    # Preserve the old total Bun capacity: 10 general updates plus the
+    # dedicated 3-PR Plugin Inspector queue that cannot remain as a duplicate
+    # root Bun config.
+    open-pull-requests-limit: 13
     ignore:
-      - dependency-name: "@openclaw/plugin-inspector"
       - dependency-name: "@auth/core"
         update-types:
           - "version-update:semver-minor"
@@ -32,6 +20,9 @@ updates:
         update-types:
           - "version-update:semver-major"
     groups:
+      plugin-inspector:
+        patterns:
+          - "@openclaw/plugin-inspector"
       production-minor-and-patch:
         dependency-type: "production"
         update-types:

--- a/scripts/github/barnacle-auto-response.mjs
+++ b/scripts/github/barnacle-auto-response.mjs
@@ -140,6 +140,7 @@ const badBarnacleLabel = "bad-barnacle";
 const maintainerAuthorLabel = "maintainer";
 const activePrLimitLabel = "r: too-many-prs";
 const activePrLimitOverrideLabel = "r: too-many-prs-override";
+const cliReleaseLabel = "needs-cli-release";
 const candidateLabelValues = Object.values(candidateLabels);
 const maintainerTeam = "maintainer";
 const mentionRegex = /@([A-Za-z0-9-]+)/g;
@@ -407,7 +408,27 @@ export function classifyPullRequestCandidateLabels(pullRequest, files) {
     labelsToAdd.push(candidateLabels.dirtyCandidate);
   }
 
+  if (isPluginInspectorDependabotPullRequest(pullRequest, files)) {
+    labelsToAdd.push(cliReleaseLabel);
+  }
+
   return [...new Set(labelsToAdd)];
+}
+
+export function isPluginInspectorDependabotPullRequest(pullRequest, files) {
+  const author = normalizeLogin(pullRequest.user?.login ?? pullRequest.author?.login ?? "");
+  if (author !== "dependabot[bot]" && author !== "dependabot") {
+    return false;
+  }
+
+  const text = `${pullRequest.title ?? ""}\n${pullRequest.body ?? ""}`;
+  if (!/(?:@openclaw\/plugin-inspector|plugin-inspector)/i.test(text)) {
+    return false;
+  }
+
+  return files.some((file) =>
+    /(^|\/)(?:package\.json|bun\.lockb?|bun\.lock)$/i.test(file.filename ?? ""),
+  );
 }
 
 async function ensureLabelSynced(github, context, name, color, description) {

--- a/scripts/github/barnacle-auto-response.test.mjs
+++ b/scripts/github/barnacle-auto-response.test.mjs
@@ -1,5 +1,7 @@
 /* @vitest-environment node */
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
 import {
   candidateLabels,
   classifyPullRequestCandidateLabels,
@@ -160,6 +162,27 @@ function barnacleGithub(files) {
 }
 
 describe("barnacle-auto-response", () => {
+  it("keeps one Bun root Dependabot config with Plugin Inspector grouped first", () => {
+    const config = parse(readFileSync(".github/dependabot.yml", "utf8"));
+    const bunRootUpdates = (config.updates ?? []).filter(
+      (update) => update["package-ecosystem"] === "bun" && update.directory === "/",
+    );
+
+    expect(bunRootUpdates).toHaveLength(1);
+
+    const [bunRootUpdate] = bunRootUpdates;
+    expect(bunRootUpdate["open-pull-requests-limit"]).toBe(13);
+
+    const groups = bunRootUpdate.groups ?? {};
+    expect(Object.keys(groups)[0]).toBe("plugin-inspector");
+    expect(groups["plugin-inspector"].patterns).toContain("@openclaw/plugin-inspector");
+
+    const ignoredDependencies = (bunRootUpdate.ignore ?? []).map(
+      (entry) => entry["dependency-name"],
+    );
+    expect(ignoredDependencies).not.toContain("@openclaw/plugin-inspector");
+  });
+
   it("keeps Barnacle-owned labels documented for ClawHub", () => {
     expect(managedLabelSpecs["r: support"].description).toContain("support requests");
     expect(managedLabelSpecs["r: direct-skill-content"].description).toContain("published");
@@ -204,6 +227,42 @@ describe("barnacle-auto-response", () => {
     ]);
 
     expect(labels).toContain(candidateLabels.directSkillContent);
+  });
+
+  it("labels Dependabot plugin-inspector bumps for CLI release follow-up", () => {
+    const labels = classifyPullRequestCandidateLabels(
+      {
+        ...pr("Bump the plugin-inspector group with 1 update"),
+        user: { login: "dependabot[bot]" },
+      },
+      [file("package.json"), file("packages/clawhub/package.json"), file("bun.lock")],
+    );
+
+    expect(labels).toContain("needs-cli-release");
+  });
+
+  it("does not label human Plugin Inspector mentions for CLI release follow-up", () => {
+    const labels = classifyPullRequestCandidateLabels(
+      {
+        ...pr("Update plugin-inspector docs and lockfile"),
+        user: { login: "contributor" },
+      },
+      [file("package.json"), file("bun.lock")],
+    );
+
+    expect(labels).not.toContain("needs-cli-release");
+  });
+
+  it("does not label unrelated Dependabot bumps for CLI release follow-up", () => {
+    const labels = classifyPullRequestCandidateLabels(
+      {
+        ...pr("Bump the production-minor-and-patch group with 3 updates"),
+        user: { login: "dependabot[bot]" },
+      },
+      [file("package.json"), file("bun.lock")],
+    );
+
+    expect(labels).not.toContain("needs-cli-release");
   });
 
   it("does not treat repo-local developer skills as published skill content", () => {


### PR DESCRIPTION
## Summary
- Removes the duplicate Bun root Dependabot update block that GitHub rejects.
- Keeps `@openclaw/plugin-inspector` separate by making it the first Bun dependency group.
- Preserves the old Plugin Inspector follow-up path through Barnacle auto-response adding `needs-cli-release` to matching Dependabot PRs.
- Preserves the old total Bun PR capacity by using one valid `open-pull-requests-limit: 13` config: 10 general update slots plus the previous 3 Plugin Inspector slots.
- Leaves normal production and development dependency groups in place.

## Why

GitHub rejects two Dependabot entries with the same `package-ecosystem`, `directory`, and implicit `target-branch`:

```text
package-ecosystem: bun
directory: /
target-branch: main
```

That made the `.github/dependabot.yml` check fail with:

```text
Ecosystem 'bun' has overlapping directories.
```

Dependabot groups use the first matching group, so `@openclaw/plugin-inspector` can stay separate without a second Bun root config. Because group-level labels are not available in Dependabot config, Barnacle now adds `needs-cli-release` to Dependabot Plugin Inspector PRs.

The previous config intended 13 total Bun PR slots: 3 for Plugin Inspector and 10 for the general Bun config. Since GitHub requires one root Bun config, this PR keeps that total capacity on the valid config.

## Validation
- Local YAML parse and duplicate-key validation passed: 2 unique update configs.
- `bunx vitest run scripts/github/barnacle-auto-response.test.mjs` passed: 1 file, 19 tests.
- `git diff --check` passed.
- `bun run format:check` passed.
- `bun run lint` passed.
