### PR TITLE
fix: sort plugins by downloads with family index

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -7520,6 +7520,92 @@ describe("httpApiV1 handlers", () => {
     ]);
   });
 
+  it("plugins list resets source offsets when package cursors reset", async () => {
+    const stalePackageCursor = `pkgpage:${JSON.stringify({
+      cursor: "legacy-code-cursor",
+      offset: 0,
+      pageSize: 50,
+      done: false,
+    })}`;
+    const stalePluginCursor = `pkgplugins:${JSON.stringify({
+      codePlugins: { cursor: stalePackageCursor, offset: 1, pageSize: 2, done: false },
+      bundlePlugins: { cursor: null, offset: 0, pageSize: 2, done: true },
+    })}`;
+    const codeNewest = makeCatalogItem("code-newest", {
+      family: "code-plugin",
+      updatedAt: 300,
+    });
+    const codeOlder = makeCatalogItem("code-older", {
+      family: "code-plugin",
+      updatedAt: 100,
+    });
+    const runQuery = vi.fn((_, args: Record<string, unknown>) => {
+      const pagination = args.paginationOpts as { cursor: string | null };
+      expect(args.family).toBe("code-plugin");
+      expect(pagination.cursor).toBe(stalePackageCursor);
+      return {
+        page: [codeNewest, codeOlder],
+        isDone: false,
+        continueCursor: "fresh-code-cursor",
+        cursorReset: true,
+      };
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.listPluginsV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request(
+        `https://example.com/api/v1/plugins?limit=1&cursor=${encodeURIComponent(stalePluginCursor)}`,
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.items.map((entry: { name: string }) => entry.name)).toEqual(["code-newest"]);
+  });
+
+  it("plugins list reopens stale completed sources when the query changes", async () => {
+    const stalePluginCursor = `pkgplugins:${JSON.stringify({
+      codePlugins: { cursor: "code-cursor", offset: 0, pageSize: 2, done: true },
+      bundlePlugins: { cursor: null, offset: 0, pageSize: 2, done: true },
+    })}`;
+    const codeNewest = makeCatalogItem("code-newest", {
+      family: "code-plugin",
+      updatedAt: 300,
+    });
+    const runQuery = vi.fn((_, args: Record<string, unknown>) => {
+      const pagination = args.paginationOpts as { cursor: string | null };
+      expect(pagination.cursor).toBeNull();
+      if (args.family === "code-plugin") {
+        return {
+          page: [codeNewest],
+          isDone: true,
+          continueCursor: "",
+        };
+      }
+      if (args.family === "bundle-plugin") {
+        return {
+          page: [],
+          isDone: true,
+          continueCursor: "",
+        };
+      }
+      throw new Error(`unexpected args ${JSON.stringify(args)}`);
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.listPluginsV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request(
+        `https://example.com/api/v1/plugins?sort=downloads&limit=1&cursor=${encodeURIComponent(stalePluginCursor)}`,
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.items.map((entry: { name: string }) => entry.name)).toEqual(["code-newest"]);
+  });
+
   it("plugins list ignores stale plugin search cursors", async () => {
     const runQuery = vi.fn().mockResolvedValue({ page: [], isDone: true, continueCursor: "" });
     const runMutation = vi.fn().mockResolvedValue(okRate());

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -800,6 +800,7 @@ type CatalogSourceCursorState = {
   offset: number;
   pageSize: number | null;
   done: boolean;
+  queryKey?: string;
 };
 
 type UnifiedCatalogCursorState = {
@@ -816,6 +817,7 @@ type CatalogPageResult<T> = {
   page: T[];
   isDone: boolean;
   continueCursor: string;
+  cursorReset?: boolean;
 };
 
 type CatalogSourceState<T> = {
@@ -827,6 +829,7 @@ type CatalogSourceState<T> = {
 
 const UNIFIED_CATALOG_CURSOR_PREFIX = "pkgcatalog:";
 const PLUGIN_CATALOG_CURSOR_PREFIX = "pkgplugins:";
+const CATALOG_SOURCE_CURSOR_KEY_PREFIX = "catalog-source:";
 const LEGACY_PLUGIN_SEARCH_CURSOR_PREFIX = "pkgpluginsearch:";
 const SKILL_CATALOG_CURSOR_PREFIX = "skillcat:";
 const PACKAGE_PAGE_CURSOR_PREFIX = "pkgpage:";
@@ -838,8 +841,54 @@ const CATALOG_CURSOR_PREFIXES = [
   PACKAGE_PAGE_CURSOR_PREFIX,
 ];
 
-function defaultCatalogSourceCursorState(): CatalogSourceCursorState {
-  return { cursor: null, offset: 0, pageSize: null, done: false };
+type CatalogSourceCursorQueryArgs = {
+  source: "packages" | "skills" | "code-plugin" | "bundle-plugin";
+  sort?: (typeof PACKAGE_LIST_SORT_VALUES)[number];
+  channel?: (typeof PACKAGE_CHANNEL_VALUES)[number];
+  isOfficial?: boolean;
+  highlightedOnly?: boolean;
+  executesCode?: boolean;
+  capabilityTag?: string;
+  category?: string;
+};
+
+function defaultCatalogSourceCursorState(queryKey?: string): CatalogSourceCursorState {
+  return { cursor: null, offset: 0, pageSize: null, done: false, queryKey };
+}
+
+function getCatalogSourceCursorQueryKey(args: CatalogSourceCursorQueryArgs) {
+  return `${CATALOG_SOURCE_CURSOR_KEY_PREFIX}${JSON.stringify({
+    source: args.source,
+    sort: args.sort ?? "updated",
+    channel: args.channel ?? null,
+    isOfficial: args.isOfficial ?? null,
+    highlightedOnly: args.highlightedOnly === true,
+    executesCode: args.executesCode ?? null,
+    capabilityTag: args.capabilityTag ?? null,
+    category: args.category ?? null,
+  })}`;
+}
+
+function acceptsLegacyUnkeyedCatalogSourceCursor(args: CatalogSourceCursorQueryArgs) {
+  return (
+    (args.sort ?? "updated") === "updated" &&
+    !args.channel &&
+    typeof args.isOfficial !== "boolean" &&
+    args.highlightedOnly !== true &&
+    typeof args.executesCode !== "boolean" &&
+    !args.capabilityTag &&
+    !args.category
+  );
+}
+
+function normalizeCatalogSourceCursorForQuery(
+  state: CatalogSourceCursorState,
+  queryKey: string,
+  options?: { acceptLegacyUnkeyed?: boolean },
+) {
+  if (state.queryKey === queryKey) return state;
+  if (!state.queryKey && options?.acceptLegacyUnkeyed) return { ...state, queryKey };
+  return defaultCatalogSourceCursorState(queryKey);
 }
 
 function encodeUnifiedCatalogCursor(state: UnifiedCatalogCursorState) {
@@ -871,6 +920,7 @@ function decodeUnifiedCatalogCursor(raw: string | null | undefined): UnifiedCata
       offset: typeof input?.offset === "number" && input.offset > 0 ? input.offset : 0,
       pageSize: typeof input?.pageSize === "number" && input.pageSize > 0 ? input.pageSize : null,
       done: input?.done === true,
+      queryKey: typeof input?.queryKey === "string" ? input.queryKey : undefined,
     });
     return {
       packages: normalize(parsed.packages),
@@ -899,6 +949,7 @@ function decodeMultiPluginCursor(
     offset: typeof input?.offset === "number" && input.offset > 0 ? input.offset : 0,
     pageSize: typeof input?.pageSize === "number" && input.pageSize > 0 ? input.pageSize : null,
     done: input?.done === true,
+    queryKey: typeof input?.queryKey === "string" ? input.queryKey : undefined,
   });
 
   if (!raw?.startsWith(prefix)) {
@@ -928,12 +979,19 @@ function decodePluginCatalogCursor(raw: string | null | undefined): PluginCatalo
   return decodeMultiPluginCursor(raw, PLUGIN_CATALOG_CURSOR_PREFIX);
 }
 
-function initCatalogSource<T>(state: CatalogSourceCursorState): CatalogSourceState<T> {
+function initCatalogSource<T>(
+  state: CatalogSourceCursorState,
+  queryArgs: CatalogSourceCursorQueryArgs,
+): CatalogSourceState<T> {
+  const queryKey = getCatalogSourceCursorQueryKey(queryArgs);
+  const normalizedState = normalizeCatalogSourceCursorForQuery(state, queryKey, {
+    acceptLegacyUnkeyed: acceptsLegacyUnkeyedCatalogSourceCursor(queryArgs),
+  });
   return {
-    state: { ...state },
+    state: { ...normalizedState },
     page: null,
-    pageCursor: state.cursor,
-    index: state.offset,
+    pageCursor: normalizedState.cursor,
+    index: normalizedState.offset,
   };
 }
 
@@ -945,6 +1003,7 @@ function finalizeCatalogSource<T>(source: CatalogSourceState<T>): CatalogSourceC
       offset: source.index,
       pageSize: source.state.pageSize,
       done: false,
+      queryKey: source.state.queryKey,
     };
   }
   return {
@@ -952,6 +1011,7 @@ function finalizeCatalogSource<T>(source: CatalogSourceState<T>): CatalogSourceC
     offset: 0,
     pageSize: source.state.pageSize,
     done: source.page.isDone,
+    queryKey: source.state.queryKey,
   };
 }
 
@@ -966,6 +1026,11 @@ async function ensureCatalogSourcePage<T>(
       const effectivePageSize = source.state.pageSize ?? pageSize;
       source.pageCursor = source.state.cursor;
       source.page = await fetchPage(source.pageCursor, effectivePageSize);
+      if (source.page.cursorReset) {
+        source.state.cursor = null;
+        source.state.offset = 0;
+        source.pageCursor = null;
+      }
       source.state.pageSize = effectivePageSize;
       source.index = source.state.offset;
     }
@@ -1456,9 +1521,28 @@ async function listPackages(
   if (!effectiveFamily && includeSkills) {
     const packageSource = initCatalogSource<CatalogListItem>(
       decodeUnifiedCatalogCursor(cursor).packages,
+      {
+        source: "packages",
+        channel: channelParam.value,
+        isOfficial: isOfficial.value,
+        highlightedOnly,
+        executesCode: executesCode.value,
+        capabilityTag,
+        category,
+        sort: sortParam.value,
+      },
     );
     const skillSource = initCatalogSource<CatalogListItem>(
       decodeUnifiedCatalogCursor(cursor).skills,
+      {
+        source: "skills",
+        channel: channelParam.value,
+        isOfficial: isOfficial.value,
+        highlightedOnly,
+        executesCode: executesCode.value,
+        capabilityTag,
+        sort: sortParam.value,
+      },
     );
     const pageSize = limit;
     const items: CatalogListItem[] = [];
@@ -1470,6 +1554,7 @@ async function listPackages(
             page: CatalogListItem[];
             isDone: boolean;
             continueCursor: string | null;
+            cursorReset?: boolean;
           }>(ctx, internalRefs.packages.listPageForViewerInternal, {
             channel: channelParam.value,
             isOfficial: isOfficial.value,
@@ -1485,6 +1570,7 @@ async function listPackages(
             page: result.page,
             isDone: result.isDone,
             continueCursor: result.continueCursor ?? "",
+            cursorReset: result.cursorReset,
           };
         }),
         ensureCatalogSourcePage(skillSource, pageSize, async (pageCursor, numItems) => {
@@ -1544,8 +1630,26 @@ async function listPackages(
 
   if (!effectiveFamily && options?.pluginFamilies?.length) {
     const decodedCursor = decodePluginCatalogCursor(cursor);
-    const codePluginSource = initCatalogSource<CatalogListItem>(decodedCursor.codePlugins);
-    const bundlePluginSource = initCatalogSource<CatalogListItem>(decodedCursor.bundlePlugins);
+    const codePluginSource = initCatalogSource<CatalogListItem>(decodedCursor.codePlugins, {
+      source: "code-plugin",
+      channel: channelParam.value,
+      isOfficial: isOfficial.value,
+      highlightedOnly,
+      executesCode: executesCode.value,
+      capabilityTag,
+      category,
+      sort: sortParam.value,
+    });
+    const bundlePluginSource = initCatalogSource<CatalogListItem>(decodedCursor.bundlePlugins, {
+      source: "bundle-plugin",
+      channel: channelParam.value,
+      isOfficial: isOfficial.value,
+      highlightedOnly,
+      executesCode: executesCode.value,
+      capabilityTag,
+      category,
+      sort: sortParam.value,
+    });
     const pageSize = limit;
     const items: CatalogListItem[] = [];
     const fetchPluginPage = async (
@@ -1557,6 +1661,7 @@ async function listPackages(
         page: CatalogListItem[];
         isDone: boolean;
         continueCursor: string | null;
+        cursorReset?: boolean;
       }>(ctx, internalRefs.packages.listPageForViewerInternal, {
         family: pluginFamily,
         channel: channelParam.value,
@@ -1573,6 +1678,7 @@ async function listPackages(
         page: result.page,
         isDone: result.isDone,
         continueCursor: result.continueCursor ?? "",
+        cursorReset: result.cursorReset,
       };
     };
 

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -1098,7 +1098,10 @@ function makeDigestCtx(options: {
                     },
                   };
                   builder?.(queryBuilder);
-                  if (indexName === "by_active_downloads") {
+                  if (
+                    indexName === "by_active_downloads" ||
+                    indexName === "by_active_family_downloads"
+                  ) {
                     return withIndex(table, indexName);
                   }
                   if (indexName !== "by_name" && indexName !== "by_runtime_id") {
@@ -2201,32 +2204,26 @@ describe("packages public queries", () => {
     expect((result.page[0] as { stats?: unknown }).stats).toEqual(currentStats);
   });
 
-  it("continues scanning download-sorted pages until filtered public results are filled", async () => {
-    const { ctx, paginate } = makeDigestCtx({
+  it("uses a family-scoped downloads index for download-sorted family pages", async () => {
+    const { ctx, indexNames, paginate } = makeDigestCtx({
       packagePages: [
         {
           page: [
             makePackageDoc({
-              _id: "packages:bundle-plugin",
-              name: "bundle-plugin",
-              normalizedName: "bundle-plugin",
-              displayName: "Bundle Plugin",
-              family: "bundle-plugin",
-              stats: { downloads: 500, installs: 0, stars: 0, versions: 1 },
-            }),
-          ],
-          isDone: false,
-          continueCursor: "cursor:next",
-        },
-        {
-          page: [
-            makePackageDoc({
-              _id: "packages:code-plugin",
-              name: "code-plugin",
-              normalizedName: "code-plugin",
-              displayName: "Code Plugin",
+              _id: "packages:code-plugin-a",
+              name: "code-plugin-a",
+              normalizedName: "code-plugin-a",
+              displayName: "Code Plugin A",
               family: "code-plugin",
               stats: { downloads: 200, installs: 0, stars: 0, versions: 1 },
+            }),
+            makePackageDoc({
+              _id: "packages:code-plugin-b",
+              name: "code-plugin-b",
+              normalizedName: "code-plugin-b",
+              displayName: "Code Plugin B",
+              family: "code-plugin",
+              stats: { downloads: 100, installs: 0, stars: 0, versions: 1 },
             }),
           ],
           isDone: true,
@@ -2241,8 +2238,58 @@ describe("packages public queries", () => {
       paginationOpts: { cursor: null, numItems: 1 },
     });
 
+    expect(result.page.map((entry) => entry.name)).toEqual(["code-plugin-a"]);
+    expect(result.isDone).toBe(false);
+    expect(indexNames).toEqual(["by_active_family_downloads"]);
+    expect(paginate).toHaveBeenCalledTimes(1);
+    expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 50 });
+  });
+
+  it("continues scanning global download-sorted pages for non-indexed filters", async () => {
+    const { ctx, indexNames, paginate } = makeDigestCtx({
+      packagePages: [
+        {
+          page: [
+            makePackageDoc({
+              _id: "packages:bundle-plugin",
+              name: "bundle-plugin",
+              normalizedName: "bundle-plugin",
+              displayName: "Bundle Plugin",
+              family: "bundle-plugin",
+              executesCode: false,
+              stats: { downloads: 500, installs: 0, stars: 0, versions: 1 },
+            }),
+          ],
+          isDone: false,
+          continueCursor: "cursor:next",
+        },
+        {
+          page: [
+            makePackageDoc({
+              _id: "packages:code-plugin",
+              name: "code-plugin",
+              normalizedName: "code-plugin",
+              displayName: "Code Plugin",
+              family: "code-plugin",
+              executesCode: true,
+              stats: { downloads: 200, installs: 0, stars: 0, versions: 1 },
+            }),
+          ],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+    });
+
+    const result = await listPublicPageHandler(ctx, {
+      executesCode: true,
+      sort: "downloads",
+      paginationOpts: { cursor: null, numItems: 1 },
+    });
+
     expect(result.page.map((entry) => entry.name)).toEqual(["code-plugin"]);
     expect(result.isDone).toBe(true);
+    expect(indexNames).toEqual(["by_active_downloads", "by_active_downloads"]);
     expect(paginate).toHaveBeenCalledTimes(2);
   });
 

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -917,6 +917,39 @@ function makePackageDoc(overrides: Partial<Record<string, unknown>> = {}) {
   };
 }
 
+function makePackageListCursorQueryKey(
+  overrides: Partial<{
+    source: string;
+    sort: "updated" | "downloads";
+    family: string | null;
+    channel: string | null;
+    isOfficial: boolean | null;
+    executesCode: boolean | null;
+    capabilityTag: string | null;
+    category: string | null;
+  }> = {},
+) {
+  return `packages-list:${JSON.stringify({
+    source: "packageSearchDigest",
+    sort: "updated",
+    family: null,
+    channel: null,
+    isOfficial: null,
+    executesCode: null,
+    capabilityTag: null,
+    category: null,
+    ...overrides,
+  })}`;
+}
+
+function readPackageListCursorQueryKey(cursor: string) {
+  expect(cursor.startsWith("pkgpage:")).toBe(true);
+  const parsed: unknown = JSON.parse(cursor.slice("pkgpage:".length));
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+  const queryKey = Object.getOwnPropertyDescriptor(parsed, "queryKey")?.value;
+  return typeof queryKey === "string" ? queryKey : undefined;
+}
+
 function makeReleaseDoc(overrides: Partial<Record<string, unknown>> = {}) {
   return {
     _id: "packageReleases:demo-1",
@@ -969,6 +1002,10 @@ function makeDigestCtx(options: {
   >();
   const rowsByTable = new Map<string, Array<Record<string, unknown>>>();
   const indexNames: string[] = [];
+  const indexFilters: Array<{
+    indexName: string;
+    filters: Array<{ field: string; value: string | undefined }>;
+  }> = [];
   const tableNames: string[] = [];
 
   const setPages = (
@@ -1056,6 +1093,7 @@ function makeDigestCtx(options: {
 
   return {
     indexNames,
+    indexFilters,
     tableNames,
     paginate,
     take,
@@ -1075,7 +1113,7 @@ function makeDigestCtx(options: {
                 (
                   indexName: string,
                   builder?: (q: {
-                    eq: (field: string, value: string) => unknown;
+                    eq: (field: string, value: string | undefined) => unknown;
                     gte: (field: string, value: string) => unknown;
                     lt: (field: string, value: string) => unknown;
                   }) => unknown,
@@ -1083,9 +1121,11 @@ function makeDigestCtx(options: {
                   let matchedValue = "";
                   let lowerBound = "";
                   let upperBound = "";
+                  const filters: Array<{ field: string; value: string | undefined }> = [];
                   const queryBuilder = {
-                    eq: (_field: string, value: string) => {
-                      matchedValue = value;
+                    eq: (field: string, value: string | undefined) => {
+                      filters.push({ field, value });
+                      matchedValue = value ?? "";
                       return queryBuilder;
                     },
                     gte: (_field: string, value: string) => {
@@ -1102,6 +1142,7 @@ function makeDigestCtx(options: {
                     indexName === "by_active_downloads" ||
                     indexName === "by_active_family_downloads"
                   ) {
+                    indexFilters.push({ indexName, filters });
                     return withIndex(table, indexName);
                   }
                   if (indexName !== "by_name" && indexName !== "by_runtime_id") {
@@ -2205,7 +2246,7 @@ describe("packages public queries", () => {
   });
 
   it("uses a family-scoped downloads index for download-sorted family pages", async () => {
-    const { ctx, indexNames, paginate } = makeDigestCtx({
+    const { ctx, indexFilters, indexNames, paginate } = makeDigestCtx({
       packagePages: [
         {
           page: [
@@ -2240,9 +2281,188 @@ describe("packages public queries", () => {
 
     expect(result.page.map((entry) => entry.name)).toEqual(["code-plugin-a"]);
     expect(result.isDone).toBe(false);
+    expect(readPackageListCursorQueryKey(result.continueCursor)).toBe(
+      makePackageListCursorQueryKey({
+        source: "packages.by_active_family_downloads",
+        sort: "downloads",
+        family: "code-plugin",
+      }),
+    );
     expect(indexNames).toEqual(["by_active_family_downloads"]);
+    expect(indexFilters).toEqual([
+      {
+        indexName: "by_active_family_downloads",
+        filters: [
+          { field: "softDeletedAt", value: undefined },
+          { field: "family", value: "code-plugin" },
+        ],
+      },
+    ]);
     expect(paginate).toHaveBeenCalledTimes(1);
     expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 50 });
+  });
+
+  it("resets legacy download cursors before using the family-scoped downloads index", async () => {
+    const legacyDownloadsCursor = `pkgpage:${JSON.stringify({
+      cursor: "cursor:old-global-downloads",
+      offset: 0,
+      pageSize: 50,
+      done: false,
+    })}`;
+    const { ctx, paginate } = makeDigestCtx({
+      packagePages: [
+        {
+          page: [
+            makePackageDoc({
+              _id: "packages:code-plugin-a",
+              name: "code-plugin-a",
+              normalizedName: "code-plugin-a",
+              displayName: "Code Plugin A",
+              family: "code-plugin",
+              stats: { downloads: 200, installs: 0, stars: 0, versions: 1 },
+            }),
+          ],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+    });
+
+    const result = await listPublicPageHandler(ctx, {
+      family: "code-plugin",
+      sort: "downloads",
+      paginationOpts: { cursor: legacyDownloadsCursor, numItems: 1 },
+    });
+
+    expect(result.page.map((entry) => entry.name)).toEqual(["code-plugin-a"]);
+    expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 50 });
+  });
+
+  it("resets family-scoped download cursors before using the global downloads index", async () => {
+    const familyDownloadsCursor = `pkgpage:${JSON.stringify({
+      cursor: "cursor:family-downloads",
+      offset: 0,
+      pageSize: 50,
+      done: false,
+      queryKey: makePackageListCursorQueryKey({
+        source: "packages.by_active_family_downloads",
+        sort: "downloads",
+        family: "code-plugin",
+      }),
+    })}`;
+    const { ctx, paginate } = makeDigestCtx({
+      packagePages: [
+        {
+          page: [
+            makePackageDoc({
+              _id: "packages:skill-a",
+              name: "skill-a",
+              normalizedName: "skill-a",
+              displayName: "Skill A",
+              family: "skill",
+              stats: { downloads: 300, installs: 0, stars: 0, versions: 1 },
+            }),
+          ],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+    });
+
+    const result = await listPublicPageHandler(ctx, {
+      sort: "downloads",
+      paginationOpts: { cursor: familyDownloadsCursor, numItems: 1 },
+    });
+
+    expect(result.page.map((entry) => entry.name)).toEqual(["skill-a"]);
+    expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 50 });
+  });
+
+  it("resets global download cursors before using updated digest pages", async () => {
+    const globalDownloadsCursor = `pkgpage:${JSON.stringify({
+      cursor: "cursor:global-downloads",
+      offset: 0,
+      pageSize: 50,
+      done: false,
+      queryKey: makePackageListCursorQueryKey({
+        source: "packages.by_active_downloads",
+        sort: "downloads",
+      }),
+    })}`;
+    const { ctx, paginate } = makeDigestCtx({
+      pages: [
+        {
+          page: [makeDigest("updated-plugin")],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+    });
+
+    const result = await listPublicPageHandler(ctx, {
+      paginationOpts: { cursor: globalDownloadsCursor, numItems: 1 },
+    });
+
+    expect(result.page.map((entry) => entry.name)).toEqual(["updated-plugin"]);
+    expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 1 });
+  });
+
+  it("resets updated-list cursors before using category digest pages", async () => {
+    const updatedCursor = `pkgpage:${JSON.stringify({
+      cursor: "cursor:updated",
+      offset: 0,
+      pageSize: 1,
+      done: false,
+      queryKey: makePackageListCursorQueryKey(),
+    })}`;
+    const { ctx, paginate } = makeDigestCtx({
+      categoryPages: [
+        {
+          page: [makeDigest("category-plugin", { pluginCategory: "data" })],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+    });
+
+    const result = await listPublicPageHandler(ctx, {
+      family: "code-plugin",
+      category: "data",
+      paginationOpts: { cursor: updatedCursor, numItems: 1 },
+    });
+
+    expect(result.page.map((entry) => entry.name)).toEqual(["category-plugin"]);
+    expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 1 });
+  });
+
+  it("preserves legacy updated-list cursors for updated digest pages", async () => {
+    const legacyUpdatedCursor = `pkgpage:${JSON.stringify({
+      cursor: "cursor:updated",
+      offset: 0,
+      pageSize: 1,
+      done: false,
+    })}`;
+    const { ctx, paginate } = makeDigestCtx({
+      pages: [
+        {
+          page: [makeDigest("first-page-plugin")],
+          isDone: false,
+          continueCursor: "cursor:updated",
+        },
+        {
+          page: [makeDigest("second-page-plugin")],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+    });
+
+    const result = await listPublicPageHandler(ctx, {
+      paginationOpts: { cursor: legacyUpdatedCursor, numItems: 1 },
+    });
+
+    expect(result.page.map((entry) => entry.name)).toEqual(["second-page-plugin"]);
+    expect(paginate).toHaveBeenCalledWith({ cursor: "cursor:updated", numItems: 1 });
   });
 
   it("continues scanning global download-sorted pages for non-indexed filters", async () => {

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -3086,6 +3086,16 @@ async function listPackagePageImpl(
     let pageOffset = offset;
     let pageSize: number | null = decodedCursor.pageSize ?? null;
     let done = decodedCursor.done;
+    const buildDownloadsQuery = () =>
+      family
+        ? ctx.db
+            .query("packages")
+            .withIndex("by_active_family_downloads", (q) =>
+              q.eq("softDeletedAt", undefined).eq("family", family),
+            )
+        : ctx.db
+            .query("packages")
+            .withIndex("by_active_downloads", (q) => q.eq("softDeletedAt", undefined));
 
     while ((pageOffset > 0 || !done) && collected.length < targetCount) {
       const scanPageSize = Math.min(
@@ -3095,9 +3105,7 @@ async function listPackagePageImpl(
           : Math.max(targetCount * 5, targetCount, 50),
       );
       const currentCursor = cursor;
-      const page = await ctx.db
-        .query("packages")
-        .withIndex("by_active_downloads", (q) => q.eq("softDeletedAt", undefined))
+      const page = await buildDownloadsQuery()
         .order("desc")
         .paginate({ cursor: currentCursor, numItems: scanPageSize });
 

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -676,8 +676,56 @@ type PublicPageCursorState = {
   offset: number;
   pageSize: number | null;
   done: boolean;
+  queryKey?: string;
 };
 const PUBLIC_PAGE_CURSOR_PREFIX = "pkgpage:";
+const PACKAGE_LIST_CURSOR_KEY_PREFIX = "packages-list:";
+
+type PublicPackageListCursorQueryArgs = {
+  family?: PackageFamily;
+  channel?: PackageChannel;
+  isOfficial?: boolean;
+  executesCode?: boolean;
+  capabilityTag?: string;
+  category?: PluginCategorySlug;
+  sort?: "updated" | "downloads";
+};
+
+function getPublicPackageListCursorQueryKey(args: PublicPackageListCursorQueryArgs) {
+  const sort = args.sort ?? "updated";
+  const source =
+    sort === "downloads"
+      ? args.family
+        ? "packages.by_active_family_downloads"
+        : "packages.by_active_downloads"
+      : args.category
+        ? "packagePluginCategorySearchDigest"
+        : args.capabilityTag
+          ? "packageCapabilitySearchDigest"
+          : "packageSearchDigest";
+  return `${PACKAGE_LIST_CURSOR_KEY_PREFIX}${JSON.stringify({
+    source,
+    sort,
+    family: args.family ?? null,
+    channel: args.channel ?? null,
+    isOfficial: args.isOfficial ?? null,
+    executesCode: args.executesCode ?? null,
+    capabilityTag: args.capabilityTag ?? null,
+    category: args.category ?? null,
+  })}`;
+}
+
+function acceptsLegacyUnkeyedPublicPageCursor(args: PublicPackageListCursorQueryArgs) {
+  return (
+    (args.sort ?? "updated") === "updated" &&
+    !args.family &&
+    !args.channel &&
+    typeof args.isOfficial !== "boolean" &&
+    typeof args.executesCode !== "boolean" &&
+    !args.capabilityTag &&
+    !args.category
+  );
+}
 
 async function runQueryRef<T>(
   ctx: { runQuery: (ref: never, args: never) => Promise<unknown> },
@@ -1355,10 +1403,27 @@ function decodePublicPageCursor(raw: string | null | undefined): PublicPageCurso
       offset: typeof parsed.offset === "number" && parsed.offset > 0 ? parsed.offset : 0,
       pageSize: typeof parsed.pageSize === "number" && parsed.pageSize > 0 ? parsed.pageSize : null,
       done: parsed.done === true,
+      queryKey: typeof parsed.queryKey === "string" ? parsed.queryKey : undefined,
     };
   } catch {
     return { cursor: null, offset: 0, pageSize: null, done: false };
   }
+}
+
+function initialPublicPageCursorState(queryKey?: string): PublicPageCursorState {
+  return { cursor: null, offset: 0, pageSize: null, done: false, queryKey };
+}
+
+function normalizePublicPageCursorForQuery(
+  state: PublicPageCursorState,
+  queryKey: string,
+  options?: { acceptLegacyUnkeyed?: boolean },
+) {
+  if (state.queryKey === queryKey) return { state, reset: false };
+  if (!state.queryKey && options?.acceptLegacyUnkeyed) {
+    return { state: { ...state, queryKey }, reset: false };
+  }
+  return { state: initialPublicPageCursorState(queryKey), reset: true };
 }
 
 async function getOptionalViewerUserId(ctx: QueryCtx | MutationCtx) {
@@ -3042,10 +3107,10 @@ async function listPackagePageImpl(
   },
 ) {
   if (args.channel === "private" && !args.viewerUserId) {
-    return { page: [], isDone: true, continueCursor: "" };
+    return { page: [], isDone: true, continueCursor: "", cursorReset: false };
   }
   if (args.category && !isPluginCategorySlug(args.category)) {
-    return { page: [], isDone: true, continueCursor: "" };
+    return { page: [], isDone: true, continueCursor: "", cursorReset: false };
   }
   const viewerUserId = args.viewerUserId;
   const membershipCache = new Map<string, Promise<boolean>>();
@@ -3058,13 +3123,39 @@ async function listPackagePageImpl(
       ...args,
       numItems: targetCount,
     });
-    return { page, isDone: true, continueCursor: "" };
+    return { page, isDone: true, continueCursor: "", cursorReset: false };
   }
 
   const collected: PublicPackageListItem[] = [];
-  const decodedCursor = decodePublicPageCursor(args.paginationOpts.cursor);
+  const family = args.family;
+  const channel = args.channel;
+  const isOfficial = args.isOfficial;
+  const category = isPluginCategorySlug(args.category) ? args.category : undefined;
+  const cursorQueryKey = getPublicPackageListCursorQueryKey({
+    family,
+    channel,
+    isOfficial,
+    executesCode: args.executesCode,
+    capabilityTag: args.capabilityTag,
+    category,
+    sort: args.sort,
+  });
+  const requestedCursor = decodePublicPageCursor(args.paginationOpts.cursor);
+  const normalizedCursor = normalizePublicPageCursorForQuery(requestedCursor, cursorQueryKey, {
+    acceptLegacyUnkeyed: acceptsLegacyUnkeyedPublicPageCursor({
+      family,
+      channel,
+      isOfficial,
+      executesCode: args.executesCode,
+      capabilityTag: args.capabilityTag,
+      category,
+      sort: args.sort,
+    }),
+  });
+  const cursorReset = Boolean(args.paginationOpts.cursor) && normalizedCursor.reset;
+  const decodedCursor = normalizedCursor.state;
   if (decodedCursor.done && decodedCursor.offset === 0) {
-    return { page: collected, isDone: true, continueCursor: "" };
+    return { page: collected, isDone: true, continueCursor: "", cursorReset };
   }
   const pageCursor = decodedCursor.cursor;
   const offset = decodedCursor.offset;
@@ -3076,10 +3167,6 @@ async function listPackagePageImpl(
       offset > 0 ? offset + targetCount : targetCount,
     ),
   );
-  const family = args.family;
-  const channel = args.channel;
-  const isOfficial = args.isOfficial;
-  const category = isPluginCategorySlug(args.category) ? args.category : undefined;
 
   if (args.sort === "downloads") {
     let cursor = pageCursor;
@@ -3123,17 +3210,20 @@ async function listPackagePageImpl(
                   offset: nextOffset,
                   pageSize: scanPageSize,
                   done: page.isDone,
+                  queryKey: cursorQueryKey,
                 }
               : {
                   cursor: page.continueCursor,
                   offset: 0,
                   pageSize: scanPageSize,
                   done: page.isDone,
+                  queryKey: cursorQueryKey,
                 };
           return {
             page: collected,
             isDone: nextState.done && nextState.offset === 0,
             continueCursor: encodePublicPageCursor(nextState),
+            cursorReset,
           };
         }
       }
@@ -3147,7 +3237,14 @@ async function listPackagePageImpl(
     return {
       page: collected,
       isDone: done,
-      continueCursor: encodePublicPageCursor({ cursor, offset: pageOffset, pageSize, done }),
+      continueCursor: encodePublicPageCursor({
+        cursor,
+        offset: pageOffset,
+        pageSize,
+        done,
+        queryKey: cursorQueryKey,
+      }),
+      cursorReset,
     };
   }
 
@@ -3196,17 +3293,20 @@ async function listPackagePageImpl(
               offset: nextOffset,
               pageSize: effectivePageSize,
               done: page.isDone,
+              queryKey: cursorQueryKey,
             }
           : {
               cursor: page.continueCursor,
               offset: 0,
               pageSize: effectivePageSize,
               done: page.isDone,
+              queryKey: cursorQueryKey,
             };
       return {
         page: collected,
         isDone: nextState.done && nextState.offset === 0,
         continueCursor: encodePublicPageCursor(nextState),
+        cursorReset,
       };
     }
   }
@@ -3219,7 +3319,9 @@ async function listPackagePageImpl(
       offset: 0,
       pageSize: effectivePageSize,
       done: page.isDone,
+      queryKey: cursorQueryKey,
     }),
+    cursorReset,
   };
 }
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1218,7 +1218,8 @@ const packages = defineTable({
   .index("by_family_official_updated", ["family", "isOfficial", "updatedAt"])
   .index("by_runtime_id", ["runtimeId"])
   .index("by_active_updated", ["softDeletedAt", "updatedAt"])
-  .index("by_active_downloads", ["softDeletedAt", "stats.downloads", "updatedAt"]);
+  .index("by_active_downloads", ["softDeletedAt", "stats.downloads", "updatedAt"])
+  .index("by_active_family_downloads", ["softDeletedAt", "family", "stats.downloads", "updatedAt"]);
 
 const packageReleases = defineTable({
   packageId: v.id("packages"),


### PR DESCRIPTION
## Summary

- add a family-scoped downloads index for package listings
- use that index when plugin family pages are sorted by downloads
- add regression coverage proving family-scoped download sorting uses one paginated query while non-indexed filters retain the existing global scan behavior

## Root Cause

`/plugins?sort=downloads` maps to family-scoped package listings. The old query used the global `by_active_downloads` index and filtered the requested family in application code. When sparse family rows appeared after many higher-download rows from other families, Convex needed a second `.paginate()` call inside one query function to fill the requested page. Convex rejects multiple paginated queries in one function, producing HTTP 500s.

## Behavioral Proof

Live production symptom before the fix:

- `https://clawhub.ai/api/v1/plugins?sort=downloads&limit=5` returned HTTP 500
- `https://clawhub.ai/api/v1/code-plugins?sort=downloads&limit=5` returned HTTP 200
- `https://clawhub.ai/api/v1/bundle-plugins?sort=downloads&limit=4` returned HTTP 200
- `https://clawhub.ai/api/v1/bundle-plugins?sort=downloads&limit=5` returned HTTP 500

Live local Convex proof used deployment `https://greedy-chameleon-609.convex.cloud` / site `https://greedy-chameleon-609.convex.site`. I temporarily seeded 60 high-download code plugin rows and 6 lower-download bundle plugin rows to force the sparse-family pagination boundary.

Before deploying this fix to the local Convex deployment, the old query failed against the seeded data:

- `GET /api/v1/bundle-plugins?sort=downloads&limit=5` returned HTTP 500, request ID `e5c5fd3893981a53`
- `GET /api/v1/plugins?sort=downloads&limit=5` returned HTTP 500, request ID `b5df35dca913356d`
- Convex error: `This query or mutation function ran multiple paginated queries. Convex only supports a single paginated query in each function.`

After deploying this fix to the same local Convex deployment and using the same seeded data:

- `GET /api/v1/bundle-plugins?sort=downloads&limit=5` returned HTTP 200 with the top five seeded bundle rows:
  - `clawhub-download-sort-proof-bundle-001`, downloads `9999`
  - `clawhub-download-sort-proof-bundle-002`, downloads `9998`
  - `clawhub-download-sort-proof-bundle-003`, downloads `9997`
  - `clawhub-download-sort-proof-bundle-004`, downloads `9996`
  - `clawhub-download-sort-proof-bundle-005`, downloads `9995`
- `GET /api/v1/plugins?sort=downloads&limit=5` returned HTTP 200 with the top five seeded code plugin rows, `clawhub-download-sort-proof-code-001` through `clawhub-download-sort-proof-code-005`, ordered by downloads `99999` through `99995`

Cleanup was verified after proof collection:

- temporary seed mutation was removed from source and redeployed
- proof rows were deleted; `GET /api/v1/plugins?sort=downloads&limit=10` reported `proofItems: 0`
- temporary `DEV_AUTH_ENABLED` was removed; `bunx convex env get DEV_AUTH_ENABLED` reported the variable was not found

## Validation

- `bun run test convex/packages.public.test.ts --testNamePattern "family-scoped downloads|global download-sorted"`
- `bun run test -- convex/packages.public.test.ts`
- `bun run format:check -- convex/devSeed.ts convex/packages.ts convex/schema.ts convex/packages.public.test.ts`
- `bunx convex codegen`
- `bun run ci:packages`
- `bun run ci:unit`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local --reviewer codex --fallback-reviewer none` reported no actionable findings
