### PR TITLE
fix: split dependency cleanup pagination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ Specialized corpus, scanner, security-worker, UI proof, proof publishing, Crabbo
 - Tests live in `src/**` and `convex/lib/**`.
 - Coverage threshold: 80% global (lines/functions/branches/statements).
 - Example: `convex/lib/skills.test.ts`.
+- When adding or changing Convex functions, do not rely only on mocked `ctx` tests for behavior that depends on Convex runtime semantics such as pagination, indexes, validators, auth identity, internal/public function boundaries, scheduler/cron behavior, actions calling queries/mutations, HTTP actions, storage, or OCC/transaction behavior. Add or run a real Convex validation path, such as `convex dev --once`, `convex run`, an HTTP action smoke, or a local-auth Playwright flow, covering the changed behavior. Mocked `ctx.db` / `ctx.runQuery` tests are still fine for pure business logic, but they do not count as Convex runtime validation.
 - For local UI state testing, prefer creating realistic backend state through seed logic plus a DevPersonaFab entry for the associated test user. Avoid one-off manual DB edits when the state is likely to be reused, such as org membership, official publisher access, moderation holds, or publishing permissions.
 
 ## Commit & Pull Request Guidelines

--- a/convex/maintenance.test.ts
+++ b/convex/maintenance.test.ts
@@ -25,8 +25,14 @@ vi.mock("./_generated/api", () => ({
       backfillSkillFingerprintsInternal: Symbol("backfillSkillFingerprintsInternal"),
       applySkillCapabilityTagsInternal: Symbol("applySkillCapabilityTagsInternal"),
       backfillSkillCapabilityTagsInternal: Symbol("backfillSkillCapabilityTagsInternal"),
-      getDependencyRegistryScanCleanupPageInternal: Symbol(
-        "getDependencyRegistryScanCleanupPageInternal",
+      getDependencyRegistryScanCleanupVersionPageInternal: Symbol(
+        "getDependencyRegistryScanCleanupVersionPageInternal",
+      ),
+      getDependencyRegistryScanCleanupSkillPageInternal: Symbol(
+        "getDependencyRegistryScanCleanupSkillPageInternal",
+      ),
+      getDependencyRegistryScanCleanupCachePageInternal: Symbol(
+        "getDependencyRegistryScanCleanupCachePageInternal",
       ),
       applyDependencyRegistryScanCleanupInternal: Symbol(
         "applyDependencyRegistryScanCleanupInternal",
@@ -91,6 +97,50 @@ function makeBlob(text: string) {
   return { text: () => Promise.resolve(text) } as unknown as Blob;
 }
 
+function makeDependencyRegistryCleanupRunQuery({
+  user,
+  versionPage,
+  skillPage,
+  cachePage,
+}: {
+  user?: Record<string, unknown>;
+  versionPage?: Record<string, unknown>;
+  skillPage?: Record<string, unknown>;
+  cachePage?: Record<string, unknown>;
+}) {
+  return vi.fn(async (query: unknown, args: Record<string, unknown>) => {
+    if ("userId" in args) return user ?? null;
+    if (query === internal.maintenance.getDependencyRegistryScanCleanupVersionPageInternal) {
+      return (
+        versionPage ?? {
+          versionItems: [],
+          versionCursor: null,
+          versionsDone: true,
+        }
+      );
+    }
+    if (query === internal.maintenance.getDependencyRegistryScanCleanupSkillPageInternal) {
+      return (
+        skillPage ?? {
+          skillItems: [],
+          skillCursor: null,
+          skillsDone: true,
+        }
+      );
+    }
+    if (query === internal.maintenance.getDependencyRegistryScanCleanupCachePageInternal) {
+      return (
+        cachePage ?? {
+          cacheRowIds: [],
+          cacheCursor: null,
+          cacheDone: true,
+        }
+      );
+    }
+    throw new Error(`Unexpected query ${String(query)}`);
+  });
+}
+
 describe("maintenance dependency registry scan cleanup", () => {
   it("rejects non-admin public cleanup before scanning cleanup targets", async () => {
     vi.mocked(getAuthUserId).mockResolvedValue("users:caller" as never);
@@ -114,26 +164,13 @@ describe("maintenance dependency registry scan cleanup", () => {
 
   it("allows admin public cleanup to delegate to the internal cleanup runner", async () => {
     vi.mocked(getAuthUserId).mockResolvedValue("users:admin" as never);
-    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
-      if ("userId" in args) {
-        return {
-          _id: "users:admin",
-          role: "admin",
-          deletedAt: undefined,
-          deactivatedAt: undefined,
-        };
-      }
-      return {
-        versionItems: [],
-        skillItems: [],
-        cacheRowIds: [],
-        versionCursor: null,
-        skillCursor: null,
-        cacheCursor: null,
-        versionsDone: true,
-        skillsDone: true,
-        cacheDone: true,
-      };
+    const runQuery = makeDependencyRegistryCleanupRunQuery({
+      user: {
+        _id: "users:admin",
+        role: "admin",
+        deletedAt: undefined,
+        deactivatedAt: undefined,
+      },
     });
     const runMutation = vi.fn();
 
@@ -143,29 +180,35 @@ describe("maintenance dependency registry scan cleanup", () => {
     );
 
     expect(result).toMatchObject({ ok: true, dryRun: true, isDone: true });
-    expect(runQuery).toHaveBeenCalledTimes(2);
+    expect(runQuery).toHaveBeenCalledTimes(4);
     expect(runMutation).not.toHaveBeenCalled();
   });
 
   it("dry-runs by default and does not write", async () => {
-    const runQuery = vi.fn(async () => ({
-      versionItems: [
-        {
-          id: "skillVersions:legacy",
-          hasDepRegistryAnalysis: true,
-          hasDepRegistryScanStatus: true,
-          hasLegacyStaticScan: true,
-        },
-      ],
-      skillItems: [{ id: "skills:legacy", hasLegacyModeration: true }],
-      cacheRowIds: ["depRegistryCache:1"],
-      versionCursor: null,
-      skillCursor: null,
-      cacheCursor: null,
-      versionsDone: true,
-      skillsDone: true,
-      cacheDone: true,
-    }));
+    const runQuery = makeDependencyRegistryCleanupRunQuery({
+      versionPage: {
+        versionItems: [
+          {
+            id: "skillVersions:legacy",
+            hasDepRegistryAnalysis: true,
+            hasDepRegistryScanStatus: true,
+            hasLegacyStaticScan: true,
+          },
+        ],
+        versionCursor: null,
+        versionsDone: true,
+      },
+      skillPage: {
+        skillItems: [{ id: "skills:legacy", hasLegacyModeration: true }],
+        skillCursor: null,
+        skillsDone: true,
+      },
+      cachePage: {
+        cacheRowIds: ["depRegistryCache:1"],
+        cacheCursor: null,
+        cacheDone: true,
+      },
+    });
     const runMutation = vi.fn();
 
     const result = await cleanupDependencyRegistryScanDataInternalHandler(
@@ -198,6 +241,29 @@ describe("maintenance dependency registry scan cleanup", () => {
     expect(runMutation).not.toHaveBeenCalled();
   });
 
+  it("scans cleanup targets with separate paginated Convex queries", async () => {
+    const runQuery = makeDependencyRegistryCleanupRunQuery({});
+    const runMutation = vi.fn();
+
+    await cleanupDependencyRegistryScanDataInternalHandler({ runQuery, runMutation } as never, {
+      batchSize: 25,
+      maxBatches: 1,
+    });
+
+    expect(runQuery).toHaveBeenCalledWith(
+      internal.maintenance.getDependencyRegistryScanCleanupVersionPageInternal,
+      { cursor: undefined, batchSize: 25 },
+    );
+    expect(runQuery).toHaveBeenCalledWith(
+      internal.maintenance.getDependencyRegistryScanCleanupSkillPageInternal,
+      { cursor: undefined, batchSize: 25 },
+    );
+    expect(runQuery).toHaveBeenCalledWith(
+      internal.maintenance.getDependencyRegistryScanCleanupCachePageInternal,
+      { cursor: undefined, batchSize: 25 },
+    );
+  });
+
   it("requires the confirmation token before applying", async () => {
     await expect(
       cleanupDependencyRegistryScanDataInternalHandler({ runQuery: vi.fn() } as never, {
@@ -207,33 +273,39 @@ describe("maintenance dependency registry scan cleanup", () => {
   });
 
   it("applies only matched dependency registry cleanup targets", async () => {
-    const runQuery = vi.fn(async () => ({
-      versionItems: [
-        {
-          id: "skillVersions:legacy",
-          hasDepRegistryAnalysis: true,
-          hasDepRegistryScanStatus: true,
-          hasLegacyStaticScan: false,
-        },
-        {
-          id: "skillVersions:clean",
-          hasDepRegistryAnalysis: false,
-          hasDepRegistryScanStatus: false,
-          hasLegacyStaticScan: false,
-        },
-      ],
-      skillItems: [
-        { id: "skills:legacy", hasLegacyModeration: true },
-        { id: "skills:clean", hasLegacyModeration: false },
-      ],
-      cacheRowIds: ["depRegistryCache:1"],
-      versionCursor: "next-version",
-      skillCursor: "next-skill",
-      cacheCursor: null,
-      versionsDone: false,
-      skillsDone: false,
-      cacheDone: true,
-    }));
+    const runQuery = makeDependencyRegistryCleanupRunQuery({
+      versionPage: {
+        versionItems: [
+          {
+            id: "skillVersions:legacy",
+            hasDepRegistryAnalysis: true,
+            hasDepRegistryScanStatus: true,
+            hasLegacyStaticScan: false,
+          },
+          {
+            id: "skillVersions:clean",
+            hasDepRegistryAnalysis: false,
+            hasDepRegistryScanStatus: false,
+            hasLegacyStaticScan: false,
+          },
+        ],
+        versionCursor: "next-version",
+        versionsDone: false,
+      },
+      skillPage: {
+        skillItems: [
+          { id: "skills:legacy", hasLegacyModeration: true },
+          { id: "skills:clean", hasLegacyModeration: false },
+        ],
+        skillCursor: "next-skill",
+        skillsDone: false,
+      },
+      cachePage: {
+        cacheRowIds: ["depRegistryCache:1"],
+        cacheCursor: null,
+        cacheDone: true,
+      },
+    });
     const runMutation = vi.fn(async () => ({
       versionRowsPatched: 1,
       staticScansRewritten: 0,

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -164,6 +164,24 @@ type DependencyRegistryCleanupPageResult = {
   cacheDone: boolean;
 };
 
+type DependencyRegistryCleanupVersionPageResult = {
+  versionItems: DependencyRegistryCleanupVersionItem[];
+  versionCursor: string | null;
+  versionsDone: boolean;
+};
+
+type DependencyRegistryCleanupSkillPageResult = {
+  skillItems: DependencyRegistryCleanupSkillItem[];
+  skillCursor: string | null;
+  skillsDone: boolean;
+};
+
+type DependencyRegistryCleanupCachePageResult = {
+  cacheRowIds: Id<"depRegistryCache">[];
+  cacheCursor: string | null;
+  cacheDone: boolean;
+};
+
 type DependencyRegistryCleanupStats = {
   versionRowsScanned: number;
   versionRowsMatched: number;
@@ -425,56 +443,70 @@ function stripDependencyRegistrySkillModeration(
   return patch;
 }
 
-export const getDependencyRegistryScanCleanupPageInternal = internalQuery({
+export const getDependencyRegistryScanCleanupVersionPageInternal = internalQuery({
   args: {
-    versionCursor: v.optional(v.string()),
-    skillCursor: v.optional(v.string()),
-    cacheCursor: v.optional(v.string()),
+    cursor: v.optional(v.string()),
     batchSize: v.optional(v.number()),
-    skipVersions: v.optional(v.boolean()),
-    skipSkills: v.optional(v.boolean()),
-    skipCache: v.optional(v.boolean()),
   },
-  handler: async (ctx, args): Promise<DependencyRegistryCleanupPageResult> => {
+  handler: async (ctx, args): Promise<DependencyRegistryCleanupVersionPageResult> => {
     const batchSize = clampInt(args.batchSize ?? DEFAULT_BATCH_SIZE, 1, MAX_BATCH_SIZE);
-
-    const versionResult = args.skipVersions
-      ? { page: [], continueCursor: null, isDone: true }
-      : await ctx.db
-          .query("skillVersions")
-          .order("asc")
-          .paginate({ cursor: args.versionCursor ?? null, numItems: batchSize });
-    const skillResult = args.skipSkills
-      ? { page: [], continueCursor: null, isDone: true }
-      : await ctx.db
-          .query("skills")
-          .order("asc")
-          .paginate({ cursor: args.skillCursor ?? null, numItems: batchSize });
-    const cacheResult = args.skipCache
-      ? { page: [], continueCursor: null, isDone: true }
-      : await ctx.db
-          .query("depRegistryCache")
-          .order("asc")
-          .paginate({ cursor: args.cacheCursor ?? null, numItems: batchSize });
+    const result = await ctx.db
+      .query("skillVersions")
+      .order("asc")
+      .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
 
     return {
-      versionItems: versionResult.page.map((version) => ({
+      versionItems: result.page.map((version) => ({
         id: version._id,
         hasDepRegistryAnalysis: version.depRegistryAnalysis !== undefined,
         hasDepRegistryScanStatus: version.depRegistryScanStatus !== undefined,
         hasLegacyStaticScan: hasLegacyDependencyRegistryStaticScan(version.staticScan),
       })),
-      skillItems: skillResult.page.map((skill) => ({
+      versionCursor: result.continueCursor,
+      versionsDone: result.isDone,
+    };
+  },
+});
+
+export const getDependencyRegistryScanCleanupSkillPageInternal = internalQuery({
+  args: {
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<DependencyRegistryCleanupSkillPageResult> => {
+    const batchSize = clampInt(args.batchSize ?? DEFAULT_BATCH_SIZE, 1, MAX_BATCH_SIZE);
+    const result = await ctx.db
+      .query("skills")
+      .order("asc")
+      .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
+
+    return {
+      skillItems: result.page.map((skill) => ({
         id: skill._id,
         hasLegacyModeration: hasLegacyDependencyRegistrySkillModeration(skill),
       })),
-      cacheRowIds: cacheResult.page.map((row) => row._id),
-      versionCursor: versionResult.continueCursor,
-      skillCursor: skillResult.continueCursor,
-      cacheCursor: cacheResult.continueCursor,
-      versionsDone: versionResult.isDone,
-      skillsDone: skillResult.isDone,
-      cacheDone: cacheResult.isDone,
+      skillCursor: result.continueCursor,
+      skillsDone: result.isDone,
+    };
+  },
+});
+
+export const getDependencyRegistryScanCleanupCachePageInternal = internalQuery({
+  args: {
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<DependencyRegistryCleanupCachePageResult> => {
+    const batchSize = clampInt(args.batchSize ?? DEFAULT_BATCH_SIZE, 1, MAX_BATCH_SIZE);
+    const result = await ctx.db
+      .query("depRegistryCache")
+      .order("asc")
+      .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
+
+    return {
+      cacheRowIds: result.page.map((row) => row._id),
+      cacheCursor: result.continueCursor,
+      cacheDone: result.isDone,
     };
   },
 });
@@ -593,18 +625,56 @@ export async function cleanupDependencyRegistryScanDataInternalHandler(
   let cacheCursor = cacheDone ? null : (args.cacheCursor ?? null);
 
   for (let batchIndex = 0; batchIndex < maxBatches; batchIndex++) {
-    const page = (await ctx.runQuery(
-      internal.maintenance.getDependencyRegistryScanCleanupPageInternal,
-      {
-        versionCursor: versionCursor ?? undefined,
-        skillCursor: skillCursor ?? undefined,
-        cacheCursor: dryRun ? (cacheCursor ?? undefined) : undefined,
-        batchSize,
-        skipVersions: versionsDone,
-        skipSkills: skillsDone,
-        skipCache: cacheDone,
-      },
-    )) as DependencyRegistryCleanupPageResult;
+    const page: DependencyRegistryCleanupPageResult = {
+      versionItems: [],
+      skillItems: [],
+      cacheRowIds: [],
+      versionCursor,
+      skillCursor,
+      cacheCursor,
+      versionsDone,
+      skillsDone,
+      cacheDone,
+    };
+
+    if (!versionsDone) {
+      const result = (await ctx.runQuery(
+        internal.maintenance.getDependencyRegistryScanCleanupVersionPageInternal,
+        {
+          cursor: versionCursor ?? undefined,
+          batchSize,
+        },
+      )) as DependencyRegistryCleanupVersionPageResult;
+      page.versionItems = result.versionItems;
+      page.versionCursor = result.versionCursor;
+      page.versionsDone = result.versionsDone;
+    }
+
+    if (!skillsDone) {
+      const result = (await ctx.runQuery(
+        internal.maintenance.getDependencyRegistryScanCleanupSkillPageInternal,
+        {
+          cursor: skillCursor ?? undefined,
+          batchSize,
+        },
+      )) as DependencyRegistryCleanupSkillPageResult;
+      page.skillItems = result.skillItems;
+      page.skillCursor = result.skillCursor;
+      page.skillsDone = result.skillsDone;
+    }
+
+    if (!cacheDone) {
+      const result = (await ctx.runQuery(
+        internal.maintenance.getDependencyRegistryScanCleanupCachePageInternal,
+        {
+          cursor: dryRun ? (cacheCursor ?? undefined) : undefined,
+          batchSize,
+        },
+      )) as DependencyRegistryCleanupCachePageResult;
+      page.cacheRowIds = result.cacheRowIds;
+      page.cacheCursor = result.cacheCursor;
+      page.cacheDone = result.cacheDone;
+    }
 
     stats.versionRowsScanned += page.versionItems.length;
     stats.skillRowsScanned += page.skillItems.length;


### PR DESCRIPTION
## Summary
- Add an AGENTS.md rule requiring real Convex validation for behavior that depends on Convex runtime semantics.
- Split dependency-registry cleanup scans into separate version, skill, and cache page queries so each Convex query performs only one `.paginate()` call.
- Update cleanup tests to assert separate page-query orchestration and preserve dry-run/apply behavior.

## Validation
- `bunx vitest run convex/maintenance.test.ts --testNamePattern "maintenance dependency registry scan cleanup"`
- `bunx vitest run convex/maintenance.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bunx tsc --noEmit`

## Notes
- Local `convex dev --once` was blocked by an existing long-running local backend on port 3210 from another dirty worktree, so I did not stop it. The post-deploy production dry run will provide the real Convex runtime proof for this change.
- Autoreview was attempted: Codex review hung without returning findings, Claude fallback reported low credit, and Copilot/Pi fallbacks were unavailable. Local gates above are green.
