### PR TITLE
Remove redundant ban email support note

### DIFF
--- a/.agents/skills/clawhub-moderation/SKILL.md
+++ b/.agents/skills/clawhub-moderation/SKILL.md
@@ -5,7 +5,7 @@ description: "Use for ClawHub staff moderation actions with the repo-local clawh
 
 # ClawHub Moderation
 
-Use the repo-local `clawhub-mod` tool from a checked-out ClawHub repo. It wraps
+Use the repo-local admin tool from a checked-out ClawHub repo. It wraps
 the existing ClawHub CLI auth/config and HTTP API surfaces. Do not call Convex
 internal mutations directly for staff actions.
 
@@ -24,61 +24,69 @@ internal mutations directly for staff actions.
 Run from the ClawHub repo root:
 
 ```sh
-bun run mod -- --help
+bun run admin -- --help
 ```
 
 Authenticate or validate the current token:
 
 ```sh
-bun run mod -- login
-bun run mod -- whoami
+bun run admin -- login
+bun run admin -- whoami
 ```
 
 Unhide a skill after moderator review:
 
 ```sh
-bun run mod -- skills unhide <slug> --reason "<reason>" --yes
+bun run admin -- skills unhide <slug> --reason "<reason>" --yes
 ```
 
 List and triage skill reports:
 
 ```sh
-bun run mod -- skills reports --status open
-bun run mod -- skills triage-report <report-id> --status confirmed --action hide --note "<note>" --yes
+bun run admin -- skills reports --status open
+bun run admin -- skills triage-report <report-id> --status confirmed --action hide --note "<note>" --yes
 ```
 
 Ban a user:
 
 ```sh
-bun run mod -- users ban <handleOrId> --reason "<reason>" --yes
+bun run admin -- users ban <handleOrId> --reason "<reason>" --yes
 ```
 
 Unban a user:
 
 ```sh
-bun run mod -- users unban <handleOrId> --reason "<reason>" --yes
+bun run admin -- users unban <handleOrId> --reason "<reason>" --yes
 ```
 
 Change a user role:
 
 ```sh
-bun run mod -- users set-role <handleOrId> <user|moderator|admin> --yes
+bun run admin -- users set-role <handleOrId> <user|moderator|admin> --yes
 ```
 
 Use `--id` when `<handleOrId>` is a user id. Use `--fuzzy` only when the user
 has asked for fuzzy handle resolution or the exact handle is ambiguous.
 
+Manage official org publishers:
+
+```sh
+bun run admin -- org official list
+bun run admin -- org official add <handle> --reason "<reason>" --yes
+bun run admin -- org official remove <handle> --reason "<reason>" --yes
+```
+
 The old top-level aliases still exist for user commands:
 
 ```sh
-bun run mod -- ban-user <handleOrId> --reason "<reason>" --yes
-bun run mod -- unban-user <handleOrId> --reason "<reason>" --yes
+bun run admin -- ban-user <handleOrId> --reason "<reason>" --yes
+bun run admin -- unban-user <handleOrId> --reason "<reason>" --yes
 ```
 
 ## Verification
 
 - For skills, inspect the page/API status after `skills unhide`.
-- For users, prefer `bun run mod -- whoami` for the current token and user
+- For users, prefer `bun run admin -- whoami` for the current token and user
   search/admin surfaces for target accounts where available.
 - If verification is blocked by auth or missing admin access, report the command
   result and the verification blocker plainly.

--- a/convex/lib/emails.test.ts
+++ b/convex/lib/emails.test.ts
@@ -32,6 +32,8 @@ describe("moderation notification email copy", () => {
     expect(email.text).not.toContain("To support your appeal, include scan results");
     expect(email.html).not.toContain("Include scan results with your appeal");
     expect(email.text).toContain("Appeal: https://appeals.openclaw.ai/");
+    expect(email.html).not.toContain("If you already appealed");
+    expect(email.html).not.toContain("separate support email");
     expect(email.text).not.toContain("clawhub scan ./my-skill --output clawhub-scan.zip");
     expect(email.text).not.toContain("https://docs.openclaw.ai/clawhub/cli#scan-path");
   });

--- a/convex/lib/emails.ts
+++ b/convex/lib/emails.ts
@@ -261,7 +261,6 @@ export function buildBanNotificationEmail(args: BanNotificationEmailArgs): Trans
       sectionHeading("What changed"),
       bulletList(impactItems),
       `<p style="margin:0 0 14px;font-size:15px;line-height:22px;color:#1f2328;">You can ${textLink(APPEALS_URL, "appeal this decision")} if you believe this was a mistake.</p>`,
-      `<p style="margin:18px 0 0;color:#6a737d;font-size:13px;line-height:20px;">If you already appealed, you do not need to send a separate support email.</p>`,
       paragraph("ClawHub Security"),
     ].join(""),
   });

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "type": "module",
   "scripts": {
+    "admin": "bun packages/clawhub-mod/src/cli.ts",
     "build": "vite build && bun scripts/copy-og-assets.ts",
     "check": "bun run lint",
     "check:peers": "bun scripts/check-peer-deps.ts",

--- a/packages/clawhub-mod/README.md
+++ b/packages/clawhub-mod/README.md
@@ -17,13 +17,13 @@ From the repo root:
 
 ```bash
 bun install
-bun run mod -- --help
+bun run admin -- --help
 ```
 
 Example:
 
 ```bash
-bun run mod -- skills unhide maxhub-pipixia --reason "VT false positive; reanalysis clean" --yes
+bun run admin -- skills unhide maxhub-pipixia --reason "VT false positive; reanalysis clean" --yes
 ```
 
 ## Build and Verify
@@ -52,9 +52,9 @@ Point `--registry` at the Convex HTTP actions URL, usually
 `VITE_CONVEX_SITE_URL`, not the Vite frontend URL:
 
 ```bash
-bun run mod -- --registry http://127.0.0.1:3211 login --token <local-token> --no-browser
-bun run mod -- --registry http://127.0.0.1:3211 whoami
-bun run mod -- --registry http://127.0.0.1:3211 plugins queue --json
+bun run admin -- --registry http://127.0.0.1:3211 login --token <local-token> --no-browser
+bun run admin -- --registry http://127.0.0.1:3211 whoami
+bun run admin -- --registry http://127.0.0.1:3211 plugins queue --json
 ```
 
 For a fresh anonymous local Convex deployment in a disposable worktree:
@@ -75,32 +75,35 @@ CONVEX_AGENT_MODE=anonymous bunx convex run --no-push devSeed:seedCliRoleHelpFix
 Authentication uses the same ClawHub token/config path as the public CLI:
 
 ```bash
-bun run mod -- login
-bun run mod -- whoami
+bun run admin -- login
+bun run admin -- whoami
 ```
 
 User administration:
 
 ```bash
-bun run mod -- users ban <handleOrId> [--id] [--fuzzy] [--reason <text>] [--yes]
-bun run mod -- users unban <handleOrId> [--id] [--fuzzy] [--reason <text>] [--yes]
-bun run mod -- users set-role <handleOrId> <user|moderator|admin> [--id] [--fuzzy] [--yes]
-bun run mod -- users reclassify-ban <handleOrId> --reason <text> [--id] [--fuzzy] [--dry-run|--apply] [--yes] [--json]
-bun run mod -- users remediate-autobans [--dry-run|--apply] [--user <handleOrId>] [--id] [--since <date>] [--limit <n>] [--cursor <cursor>] [--all] [--json]
+bun run admin -- users ban <handleOrId> [--id] [--fuzzy] [--reason <text>] [--yes]
+bun run admin -- users unban <handleOrId> [--id] [--fuzzy] [--reason <text>] [--yes]
+bun run admin -- users set-role <handleOrId> <user|moderator|admin> [--id] [--fuzzy] [--yes]
+bun run admin -- users reclassify-ban <handleOrId> --reason <text> [--id] [--fuzzy] [--dry-run|--apply] [--yes] [--json]
+bun run admin -- users remediate-autobans [--dry-run|--apply] [--user <handleOrId>] [--id] [--since <date>] [--limit <n>] [--cursor <cursor>] [--all] [--json]
 ```
 
 The old top-level names are also available on the moderator binary:
 
 ```bash
-bun run mod -- ban-user <handleOrId>
-bun run mod -- unban-user <handleOrId>
-bun run mod -- set-role <handleOrId> <user|moderator|admin>
+bun run admin -- ban-user <handleOrId>
+bun run admin -- unban-user <handleOrId>
+bun run admin -- set-role <handleOrId> <user|moderator|admin>
 ```
 
 Org publisher administration:
 
 ```bash
-bun run mod -- org create <handle> --member <handle> [--display-name <name>] [--role owner|admin|publisher] [--trusted] [--json]
+bun run admin -- org create <handle> --member <handle> [--display-name <name>] [--role owner|admin|publisher] [--trusted] [--json]
+bun run admin -- org official list [--json]
+bun run admin -- org official add <handle> --reason <text> [--yes] [--json]
+bun run admin -- org official remove <handle> --reason <text> [--yes] [--json]
 ```
 
 `org create` requires `--member` and defaults that member to `owner`; it does
@@ -109,24 +112,24 @@ not add the moderator running the command as an org member.
 Package moderation and operations:
 
 ```bash
-bun run mod -- skills reports [--status open|confirmed|dismissed|all]
-bun run mod -- skills rescan <slug> [--version <version>] [--yes] [--json]
-bun run mod -- skills unhide <slug> --reason <text> [--yes]
-bun run mod -- skills triage-report <report-id> --status open|confirmed|dismissed [--note <text>] [--action none|hide] [--yes]
+bun run admin -- skills reports [--status open|confirmed|dismissed|all]
+bun run admin -- skills rescan <slug> [--version <version>] [--yes] [--json]
+bun run admin -- skills unhide <slug> --reason <text> [--yes]
+bun run admin -- skills triage-report <report-id> --status open|confirmed|dismissed [--note <text>] [--action none|hide] [--yes]
 
-bun run mod -- plugins moderate <name> --version <version> --state approved|quarantined|revoked --reason <text>
-bun run mod -- plugins status <name>
-bun run mod -- plugins queue [--status open|blocked|manual|all]
-bun run mod -- plugins reports [--status open|confirmed|dismissed|all]
-bun run mod -- plugins triage-report <report-id> --status open|confirmed|dismissed [--note <text>] [--action none|quarantine|revoke] [--yes]
+bun run admin -- plugins moderate <name> --version <version> --state approved|quarantined|revoked --reason <text>
+bun run admin -- plugins status <name>
+bun run admin -- plugins queue [--status open|blocked|manual|all]
+bun run admin -- plugins reports [--status open|confirmed|dismissed|all]
+bun run admin -- plugins triage-report <report-id> --status open|confirmed|dismissed [--note <text>] [--action none|quarantine|revoke] [--yes]
 
-bun run mod -- plugins migrations [--phase <phase>]
-bun run mod -- plugins set-migration <bundled-plugin-id> --package <name>
-bun run mod -- plugins backfill-artifacts [--all] [--apply]
-bun run mod -- plugins repair-name <name> --next-name <name> --reason <text> [--retire-target] [--owner <handle>] [--apply]
-bun run mod -- plugins trusted-publisher get <name>
-bun run mod -- plugins trusted-publisher set <name> --repository <owner/repo> --workflow-filename <file>
-bun run mod -- plugins trusted-publisher delete <name>
+bun run admin -- plugins migrations [--phase <phase>]
+bun run admin -- plugins set-migration <bundled-plugin-id> --package <name>
+bun run admin -- plugins backfill-artifacts [--all] [--apply]
+bun run admin -- plugins repair-name <name> --next-name <name> --reason <text> [--retire-target] [--owner <handle>] [--apply]
+bun run admin -- plugins trusted-publisher get <name>
+bun run admin -- plugins trusted-publisher set <name> --repository <owner/repo> --workflow-filename <file>
+bun run admin -- plugins trusted-publisher delete <name>
 ```
 
 All skill and plugin commands accept `--json` where the underlying endpoint supports machine-readable output.


### PR DESCRIPTION
## Summary
- remove the redundant "If you already appealed... separate support email" paragraph from banned-account notification HTML
- add regression coverage so that support-email sentence stays out of the ban email

## Tests
- `bunx vitest run convex/lib/emails.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local`
