### PR TITLE
Delegate browser automation scanning to SkillSpector

### DIFF
--- a/convex/lib/moderationEngine.test.ts
+++ b/convex/lib/moderationEngine.test.ts
@@ -223,7 +223,7 @@ describe("moderationEngine", () => {
     expect(result.status).toBe("suspicious");
   });
 
-  it("flags browser automation that puts passwords in argv", () => {
+  it("does not duplicate SkillSpector credential-browser automation analysis", () => {
     const result = runStaticModerationScan({
       slug: "email-daily-summary",
       displayName: "Email Daily Summary",
@@ -242,11 +242,11 @@ describe("moderationEngine", () => {
       ],
     });
 
-    expect(result.reasonCodes).toContain("suspicious.browser_credential_automation");
-    expect(result.status).toBe("suspicious");
+    expect(result.reasonCodes).not.toContain("suspicious.browser_credential_automation");
+    expect(result.status).toBe("clean");
   });
 
-  it("flags persisted browser-use eval against authenticated mail contexts", () => {
+  it("does not duplicate SkillSpector persisted browser eval analysis", () => {
     const result = runStaticModerationScan({
       slug: "email-daily-summary",
       displayName: "Email Daily Summary",
@@ -266,8 +266,8 @@ describe("moderationEngine", () => {
       ],
     });
 
-    expect(result.reasonCodes).toContain("suspicious.browser_credential_automation");
-    expect(result.status).toBe("suspicious");
+    expect(result.reasonCodes).not.toContain("suspicious.browser_credential_automation");
+    expect(result.status).toBe("clean");
   });
 
   it("does not flag ordinary browser-use navigation docs", () => {
@@ -290,7 +290,7 @@ describe("moderationEngine", () => {
     expect(result.status).toBe("clean");
   });
 
-  it("blocks stealth browser automation that advertises bot-protection bypass and persistent sessions", () => {
+  it("does not duplicate SkillSpector browser automation analysis in the static scanner", () => {
     const result = runStaticModerationScan({
       slug: "stealth-browser",
       displayName: "Stealth Browser",
@@ -311,8 +311,8 @@ describe("moderationEngine", () => {
       ],
     });
 
-    expect(result.reasonCodes).toContain("malicious.stealth_browser_abuse");
-    expect(result.status).toBe("malicious");
+    expect(result.reasonCodes).not.toContain("malicious.stealth_browser_abuse");
+    expect(result.status).toBe("clean");
   });
 
   it("flags wallet mnemonics passed as CLI argv", () => {
@@ -497,7 +497,7 @@ describe("moderationEngine", () => {
     expect(result.status).toBe("suspicious");
   });
 
-  it("flags Playwright file URL renders of interpolated SVG", () => {
+  it("does not duplicate SkillSpector browser file-render analysis", () => {
     const result = runStaticModerationScan({
       slug: "office-quotes",
       displayName: "Office Quotes",
@@ -520,8 +520,8 @@ describe("moderationEngine", () => {
       ],
     });
 
-    expect(result.reasonCodes).toContain("suspicious.browser_file_render");
-    expect(result.status).toBe("suspicious");
+    expect(result.reasonCodes).not.toContain("suspicious.browser_file_render");
+    expect(result.status).toBe("clean");
   });
 
   it("does not flag Playwright file renders with JavaScript disabled", () => {
@@ -1754,7 +1754,7 @@ describe("moderationEngine", () => {
     expect(result.status).toBe("clean");
   });
 
-  it("flags shell positional input passed directly to browser typing", () => {
+  it("does not duplicate SkillSpector browser typing analysis", () => {
     const result = runStaticModerationScan({
       slug: "wechat-helper",
       displayName: "WeChat Helper",
@@ -1775,11 +1775,11 @@ describe("moderationEngine", () => {
       ],
     });
 
-    expect(result.reasonCodes).toContain("suspicious.unsafe_browser_text_input");
-    expect(result.status).toBe("suspicious");
+    expect(result.reasonCodes).not.toContain("suspicious.unsafe_browser_text_input");
+    expect(result.status).toBe("clean");
   });
 
-  it("checks every positional shell assignment before browser typing", () => {
+  it("does not inspect shell positional assignments for browser typing", () => {
     const result = runStaticModerationScan({
       slug: "wechat-helper",
       displayName: "WeChat Helper",
@@ -1799,8 +1799,8 @@ describe("moderationEngine", () => {
       ],
     });
 
-    expect(result.reasonCodes).toContain("suspicious.unsafe_browser_text_input");
-    expect(result.status).toBe("suspicious");
+    expect(result.reasonCodes).not.toContain("suspicious.unsafe_browser_text_input");
+    expect(result.status).toBe("clean");
   });
 
   it("allows browser typing after basic shell input validation", () => {

--- a/convex/lib/moderationEngine.ts
+++ b/convex/lib/moderationEngine.ts
@@ -94,8 +94,6 @@ const GOOGLE_SHEETS_SPREADSHEET_URL_PATTERN =
   /https?:\/\/[^\s"'`]*\/spreadsheets\/([A-Za-z0-9_-]{20,})\/[^\s"'`]*/i;
 const DESTRUCTIVE_DELETE_PATTERN =
   /\brm\s+-[A-Za-z]*r[A-Za-z]*f[A-Za-z]*\s+(["']?)(\/root\/\.openclaw\/|\/home\/[^/\s"'`]+\/\.openclaw\/|\/Users\/[^/\s"'`]+\/\.openclaw\/|~\/\.openclaw\/|\$HOME\/\.openclaw\/|\$\{HOME\}\/\.openclaw\/|\/etc\/|\/usr\/|\/opt\/|\/Library\/|\/Applications\/)[^\s"'`;|&)]*\1/i;
-const SHELL_POSITIONAL_ASSIGNMENT_PATTERN =
-  /^\s*([A-Z_][A-Z0-9_]*)=(["']?)\$(?:[1-9][0-9]*|@|\*)\2\s*(?:#.*)?$/gm;
 const SECRET_ASSIGNMENT_PATTERN =
   /\b(?:[A-Za-z0-9]+[_\s-]+)*(?:(?:api|client|consumer)[_\s-]?(?:secret|key|token)|secret[_\s-]?key|access[_\s-]?(?:token|key|secret|grant)|auth[_\s-]?token|bearer(?:[_\s-]?token)?|private[_\s-]?key|service[_\s-]?role[_\s-]?key|github[_\s-]?(?:pat|token)|(?:openrouter|supabase|storj)[_\s-]?(?:key|token|secret|access[_\s-]?grant)|password)\b\s*[:=]\s*["'`]?([A-Za-z0-9][A-Za-z0-9._~+/=-]{15,})["'`]?/i;
 const AUTH_HEADER_SECRET_PATTERN =
@@ -111,12 +109,6 @@ const HOST_PLATFORM_SOURCE_CONTEXT_PATTERN =
 const HOST_PLATFORM_PATCH_COMMAND_PATTERN =
   /\b(?:sed\s+-i|perl\s+-0?pi|cp\s+|cat\s+>|python3?\b.{0,120}(?:write|replace))/i;
 const HOST_PLATFORM_REBUILD_PATTERN = /\b(?:pnpm\s+build|npm\s+run\s+build|bun\s+run\s+build)\b/i;
-const BROWSER_USE_PASSWORD_ARGV_PATTERN =
-  /\bbrowser-use\s+input\b[^\n]*(?:password|passwd|\$[A-Z_]*(?:PASSWORD|PASS|PWD)[A-Z0-9_]*|<password>|\{password\})/i;
-const BROWSER_USE_AUTH_EVAL_PATTERN = /\bbrowser-use\s+(?:eval|python)\b/i;
-const AUTHENTICATED_MAIL_CONTEXT_PATTERN = /\b(?:mail\.google\.com|gmail|webmail|mailbox|inbox)\b/i;
-const PERSISTENCE_SCHEDULER_PATTERN =
-  /\b(?:launchctl\s+load|crontab\b|LaunchAgents\/|systemctl\s+(?:--user\s+)?enable)\b/i;
 const SECRET_ARGV_WARNING_PATTERN =
   /\b(?:do\s+not|don't|avoid|never|reject)\b[^\n]{0,120}\b(?:argv|argument|from-mnemonic|private[-_\s]?key|seed[-\s]?phrase|mnemonic)\b/i;
 const FROM_MNEMONIC_ARGV_PATTERN =
@@ -135,17 +127,6 @@ const PYTHON_BASE64_FILE_READ_PATTERN =
   /base64\.b64encode\s*\(\s*(?:[A-Za-z_][A-Za-z0-9_]*\.read_bytes\s*\(\s*\)|Path\s*\([^)]*\)\.read_bytes\s*\(\s*\)|open\s*\([^)]*["']rb["'][\s\S]{0,120}\.read\s*\(\s*\))/i;
 const PYTHON_NETWORK_UPLOAD_PATTERN =
   /\b(?:requests|session|self\.session|client|httpx\.(?:post|request))\.post\s*\([\s\S]{0,1600}(?:json\s*=|data\s*=|files\s*=|headers\s*=|Authorization)/i;
-const PLAYWRIGHT_CHROMIUM_PATTERN = /\b(?:playwright\.)?chromium\.launch\s*\(/i;
-const FILE_URL_BROWSER_NAVIGATION_PATTERN = /\bpage\.goto\s*\([^)]*file:\/\//i;
-const SVG_HTML_INTERPOLATION_PATTERN =
-  /(?:<body>[\s\S]{0,240}\$\{[^}]*svg[^}]*\}|writeFile(?:Sync)?\s*\([^)]*\.html[^)]*\$\{[^}]*svg[^}]*\}|\$\{[^}]*svg[^}]*\}[\s\S]{0,240}<\/body>)/i;
-const BROWSER_JS_DISABLED_PATTERN =
-  /javaScriptEnabled\s*:\s*false|Content-Security-Policy|script-src\s+['"]?none/i;
-const STEALTH_BROWSER_CONTEXT_PATTERN =
-  /\b(?:stealth|anti[-\s]?detect|undetected|fingerprint spoof|navigator\.webdriver)\b/i;
-const BOT_PROTECTION_BYPASS_PATTERN = /\b(?:captcha|cloudflare|turnstile|bot detection|waf)\b/i;
-const BROWSER_SESSION_PERSISTENCE_PATTERN =
-  /\b(?:persistent_context|userDataDir|storageState|session persistence|persist(?:ed)? cookies?)\b/i;
 const AGENT_OUTPUT_DIR_ARGUMENT_PATTERN =
   /add_argument\s*\(\s*["']--outdir["']|args\.outdir|output_path\s*=\s*Path\s*\(\s*args\.outdir\s*\)/i;
 const FFMPEG_FORCE_OUTPUT_PATTERN =
@@ -268,31 +249,6 @@ function findCredentialExposureInstruction(content: string) {
   return null;
 }
 
-function findBrowserCredentialAutomation(content: string) {
-  const lines = content.split("\n");
-  for (let i = 0; i < lines.length; i += 1) {
-    const line = lines[i] ?? "";
-    if (BROWSER_USE_PASSWORD_ARGV_PATTERN.test(line)) {
-      return { line: i + 1, text: line };
-    }
-  }
-
-  if (
-    BROWSER_USE_AUTH_EVAL_PATTERN.test(content) &&
-    AUTHENTICATED_MAIL_CONTEXT_PATTERN.test(content) &&
-    PERSISTENCE_SCHEDULER_PATTERN.test(content)
-  ) {
-    for (let i = 0; i < lines.length; i += 1) {
-      const line = lines[i] ?? "";
-      if (BROWSER_USE_AUTH_EVAL_PATTERN.test(line) || PERSISTENCE_SCHEDULER_PATTERN.test(line)) {
-        return { line: i + 1, text: line };
-      }
-    }
-  }
-
-  return null;
-}
-
 function redactSecretArgvEvidence(line: string) {
   return line.replace(SECRET_ARGV_REDACTION_PATTERN, "$1$2[REDACTED]$2");
 }
@@ -399,49 +355,6 @@ function isScopedOpenClawDelete(line: string, slug?: string) {
     return true;
   }
   return false;
-}
-
-function hasShellVariableValidation(content: string, variable: string, useIndex: number) {
-  const escaped = variable.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const beforeUse = content.slice(0, useIndex);
-  const variableReference = String.raw`(?:\$\{${escaped}\}|\$${escaped})`;
-  const lengthCheck = new RegExp(
-    String.raw`\$\{#${escaped}\}\s*(?:-[a-z]\s+)?(?:[<>!=]=?|-[gl][te])`,
-    "m",
-  );
-  const controlCharStrip = new RegExp(
-    String.raw`(?:tr\s+-d\s+["']?\\(?:000|x00).{0,80}\\(?:037|x1[fF]|177|x7[fF])|${escaped}\s*=.*tr\s+-d)`,
-    "s",
-  );
-  const explicitValidation = new RegExp(
-    String.raw`(?:validate|sanitize|strip|clean)[A-Za-z0-9_ -]{0,60}${variableReference}|${variableReference}.{0,60}(?:validate|sanitize|strip|clean)`,
-    "is",
-  );
-
-  return (
-    lengthCheck.test(beforeUse) ||
-    controlCharStrip.test(beforeUse) ||
-    explicitValidation.test(beforeUse)
-  );
-}
-
-function findUnsafeBrowserTextInput(content: string) {
-  for (const assignment of content.matchAll(SHELL_POSITIONAL_ASSIGNMENT_PATTERN)) {
-    const variable = assignment[1];
-    if (!variable) continue;
-
-    const escaped = variable.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const browserTextPattern = new RegExp(
-      String.raw`\bbrowser\s+action=act\b[^\n]*\bkind=["']?type["']?[^\n]*\btext=(?:"\$${escaped}"|'\$${escaped}'|\$${escaped})(?![A-Za-z0-9_])`,
-      "i",
-    );
-    const match = content.match(browserTextPattern);
-    if (!match || match.index === undefined) continue;
-    if (hasShellVariableValidation(content, variable, match.index)) continue;
-
-    return findLineAtIndex(content, match.index);
-  }
-  return null;
 }
 
 function addFinding(
@@ -600,21 +513,6 @@ function findJsSensitiveFileNetworkSend(content: string) {
   }
 
   return null;
-}
-
-function findUnsafeBrowserFileRender(content: string) {
-  if (!PLAYWRIGHT_CHROMIUM_PATTERN.test(content)) return null;
-  if (!FILE_URL_BROWSER_NAVIGATION_PATTERN.test(content)) return null;
-  if (!SVG_HTML_INTERPOLATION_PATTERN.test(content)) return null;
-  if (BROWSER_JS_DISABLED_PATTERN.test(content)) return null;
-  return findFirstLine(content, FILE_URL_BROWSER_NAVIGATION_PATTERN);
-}
-
-function findStealthBrowserAbuse(content: string) {
-  if (!STEALTH_BROWSER_CONTEXT_PATTERN.test(content)) return null;
-  if (!BOT_PROTECTION_BYPASS_PATTERN.test(content)) return null;
-  if (!BROWSER_SESSION_PERSISTENCE_PATTERN.test(content)) return null;
-  return findFirstLine(content, STEALTH_BROWSER_CONTEXT_PATTERN);
 }
 
 function findUnsafeAgentControlledFileWrite(content: string) {
@@ -836,18 +734,6 @@ function scanCodeFile(
     });
   }
 
-  const unsafeBrowserTextInput = findUnsafeBrowserTextInput(content);
-  if (unsafeBrowserTextInput) {
-    addFinding(findings, {
-      code: REASON_CODES.UNSAFE_BROWSER_TEXT_INPUT,
-      severity: "warn",
-      file: path,
-      line: unsafeBrowserTextInput.line,
-      message: "Shell positional input is typed into browser automation without validation.",
-      evidence: unsafeBrowserTextInput.text,
-    });
-  }
-
   const hostPlatformSourcePatch = findHostPlatformSourcePatch(content);
   if (hostPlatformSourcePatch) {
     addFinding(findings, {
@@ -857,32 +743,6 @@ function scanCodeFile(
       line: hostPlatformSourcePatch.line,
       message: "Install code patches host platform source and rebuilds without confirmation.",
       evidence: hostPlatformSourcePatch.text,
-    });
-  }
-
-  const unsafeBrowserFileRender = findUnsafeBrowserFileRender(content);
-  if (unsafeBrowserFileRender) {
-    addFinding(findings, {
-      code: REASON_CODES.BROWSER_FILE_RENDER,
-      severity: "critical",
-      file: path,
-      line: unsafeBrowserFileRender.line,
-      message:
-        "Browser automation renders interpolated SVG/HTML from a file URL with JavaScript enabled.",
-      evidence: unsafeBrowserFileRender.text,
-    });
-  }
-
-  const stealthBrowserAbuse = findStealthBrowserAbuse(content);
-  if (stealthBrowserAbuse) {
-    addFinding(findings, {
-      code: REASON_CODES.STEALTH_BROWSER_ABUSE,
-      severity: "critical",
-      file: path,
-      line: stealthBrowserAbuse.line,
-      message:
-        "Browser automation advertises stealth/anti-detection behavior with bot-protection bypass and persistent sessions.",
-      evidence: stealthBrowserAbuse.text,
     });
   }
 
@@ -1085,18 +945,6 @@ function scanMarkdownFile(
     });
   }
 
-  const browserCredentialAutomation = findBrowserCredentialAutomation(content);
-  if (browserCredentialAutomation) {
-    addFinding(findings, {
-      code: REASON_CODES.BROWSER_CREDENTIAL_AUTOMATION,
-      severity: "critical",
-      file: path,
-      line: browserCredentialAutomation.line,
-      message: "Browser automation instructions expose credentials or persist authenticated eval.",
-      evidence: browserCredentialAutomation.text,
-    });
-  }
-
   const secretArgvExposure = findSecretArgvExposure(content);
   if (secretArgvExposure) {
     addFinding(findings, {
@@ -1119,19 +967,6 @@ function scanMarkdownFile(
       message:
         "Hardcoded operator endpoint combines OAuth credentials with Lightning billing calls.",
       evidence: hardcodedOperatorBilling.text,
-    });
-  }
-
-  const stealthBrowserAbuse = findStealthBrowserAbuse(content);
-  if (stealthBrowserAbuse) {
-    addFinding(findings, {
-      code: REASON_CODES.STEALTH_BROWSER_ABUSE,
-      severity: "critical",
-      file: path,
-      line: stealthBrowserAbuse.line,
-      message:
-        "Browser automation advertises stealth/anti-detection behavior with bot-protection bypass and persistent sessions.",
-      evidence: stealthBrowserAbuse.text,
     });
   }
 
@@ -1160,18 +995,6 @@ function scanMarkdownFile(
       message:
         "Documentation contains a destructive delete command without an explicit confirmation gate.",
       evidence: destructiveDelete.text,
-    });
-  }
-
-  const unsafeBrowserTextInput = findUnsafeBrowserTextInput(content);
-  if (unsafeBrowserTextInput) {
-    addFinding(findings, {
-      code: REASON_CODES.UNSAFE_BROWSER_TEXT_INPUT,
-      severity: "warn",
-      file: path,
-      line: unsafeBrowserTextInput.line,
-      message: "Shell positional input is typed into browser automation without validation.",
-      evidence: unsafeBrowserTextInput.text,
     });
   }
 

--- a/convex/lib/moderationReasonCodes.ts
+++ b/convex/lib/moderationReasonCodes.ts
@@ -12,7 +12,7 @@ export type ModerationFinding = {
   evidence: string;
 };
 
-export const MODERATION_ENGINE_VERSION = "v2.4.24";
+export const MODERATION_ENGINE_VERSION = "v2.4.25";
 
 export const REASON_CODES = {
   LLM_REVIEW: "review.llm_review",
@@ -21,13 +21,10 @@ export const REASON_CODES = {
   GENERATED_SOURCE_TEMPLATE: "suspicious.generated_source_template_injection",
   EXPOSED_RESOURCE_IDENTIFIER: "suspicious.exposed_resource_identifier",
   DESTRUCTIVE_DELETE_COMMAND: "suspicious.destructive_delete_command",
-  UNSAFE_BROWSER_TEXT_INPUT: "suspicious.unsafe_browser_text_input",
   EXPOSED_SECRET_LITERAL: "suspicious.exposed_secret_literal",
   CREDENTIAL_EXPOSURE_INSTRUCTIONS: "suspicious.credential_exposure_instructions",
-  BROWSER_CREDENTIAL_AUTOMATION: "suspicious.browser_credential_automation",
   SECRET_ARGV_EXPOSURE: "suspicious.secret_argv_exposure",
   HOST_PLATFORM_SOURCE_PATCH: "suspicious.host_platform_source_patch",
-  BROWSER_FILE_RENDER: "suspicious.browser_file_render",
   UNSAFE_FILE_WRITE: "suspicious.unsafe_file_write",
   INSECURE_TLS_VERIFICATION: "suspicious.insecure_tls_verification",
   AUTONOMOUS_CREDENTIAL_EGRESS: "suspicious.autonomous_credential_egress",
@@ -44,14 +41,12 @@ export const REASON_CODES = {
   MANIFEST_PRIVILEGED_ALWAYS: "suspicious.privileged_always",
   MALICIOUS_INSTALL_PROMPT: "malicious.install_terminal_payload",
   KNOWN_BLOCKED_SIGNATURE: "malicious.known_blocked_signature",
-  STEALTH_BROWSER_ABUSE: "malicious.stealth_browser_abuse",
 } as const;
 
 const MALICIOUS_CODES = new Set<string>([
   REASON_CODES.CRYPTO_MINING,
   REASON_CODES.MALICIOUS_INSTALL_PROMPT,
   REASON_CODES.KNOWN_BLOCKED_SIGNATURE,
-  REASON_CODES.STEALTH_BROWSER_ABUSE,
 ]);
 
 const EXTERNALLY_CLEARABLE_SUSPICIOUS_CODES = new Set<string>([REASON_CODES.CREDENTIAL_HARVEST]);

--- a/docs/acceptable-usage.md
+++ b/docs/acceptable-usage.md
@@ -10,7 +10,7 @@ read_when:
 
 This page describes the kinds of skills and content ClawHub is okay with, and the abuse workflows it will not host.
 
-These rules are intentionally practical. We care most about end-to-end abuse workflows, not just isolated keywords. If a skill is built to evade defenses, abuse platforms, scam people, invade privacy, or enable non-consensual behavior, it does not belong on ClawHub.
+These rules are intentionally practical. We care most about end-to-end abuse workflows, not just isolated keywords. If a skill is built to gain unauthorized access, abuse platforms, scam people, invade privacy, or enable non-consensual behavior, it does not belong on ClawHub.
 
 ## Recent patterns we are explicitly okay with
 
@@ -24,7 +24,7 @@ These rules are intentionally practical. We care most about end-to-end abuse wor
 ## Not okay
 
 - Security-bypass or unauthorized-access workflows.
-  - Examples: auth bypass, account takeover, CAPTCHA bypass, Cloudflare or anti-bot evasion, rate-limit bypass, stealth scraping designed to defeat protections, live call or agent takeover, reusable session theft, auto-approving pairing flows for unapproved users.
+  - Examples: auth bypass, account takeover, rate-limit abuse, live call or agent takeover, reusable session theft, auto-approving pairing flows for unapproved users.
 
 - Platform abuse and ban evasion.
   - Examples: stealth accounts after bans, account warming/farming, fake engagement, karma or follower cultivation, multi-account automation, mass posting, spam bots, marketplace or social automation built to avoid detection.
@@ -32,8 +32,8 @@ These rules are intentionally practical. We care most about end-to-end abuse wor
 - Fraud, scams, and deceptive financial workflows.
   - Examples: fake certificates, fake invoices, deceptive payment flows, scam outreach, fake social proof, tools that enable spending or charging without clear human approval and transparent controls, or synthetic-identity workflows built to create accounts for fraud.
 
-- Privacy-invasive scraping, enrichment, or surveillance.
-  - Examples: scraping contact details at scale for spam, doxxing, stalking, lead extraction paired with unsolicited outreach, covert monitoring, face search or biometric matching used without clear consent, or buying, publishing, downloading, or operationalizing leaked data or breach dumps.
+- Privacy-invasive enrichment or surveillance.
+  - Examples: collecting contact details at scale for spam, doxxing, stalking, lead extraction paired with unsolicited outreach, covert monitoring, face search or biometric matching used without clear consent, or buying, publishing, downloading, or operationalizing leaked data or breach dumps.
 
 - Non-consensual impersonation or deceptive identity manipulation.
   - Examples: face swap, digital twins, fake personas, cloned influencers, or other identity-manipulation tooling used to impersonate or mislead.
@@ -51,14 +51,14 @@ These rules are intentionally practical. We care most about end-to-end abuse wor
 - “Cultivate Reddit/Twitter accounts with undetectable automation.”
 - “Generate professional certificates or invoices for arbitrary use.”
 - “Generate NSFW content with safety checks disabled.”
-- “Scrape leads, enrich contacts, and launch cold outreach at scale.”
+- “Harvest leads, enrich contacts, and launch cold outreach at scale.”
 - “Buy, publish, or download leaked data or breach dumps.”
-- “Bulk-create email or social accounts with synthetic identities or CAPTCHA solving.”
+- “Bulk-create email or social accounts with synthetic identities.”
 
 ## Notes for reviewers
 
 - Context matters. The same topic can be legitimate in a narrow defensive or consent-based setting and unacceptable when packaged as an abuse workflow.
-- We should bias toward action when a skill is clearly optimized for evasion, deception, or non-consensual use.
+- We should bias toward action when a skill is clearly optimized for unauthorized access, platform abuse, deception, or non-consensual use.
 - Repeated uploads in these categories are grounds for hiding content and banning the account.
 
 ## Enforcement

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -258,7 +258,7 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   - user-directed provider uploads are not exfiltration unless the source is broad/private/sensitive, automatic, or sent to an unrelated/hidden destination.
   - Basic Auth/base64 credential encoding and provider-response base64 decoding are normal integration behavior.
   - scoped uninstall cleanup under a skill-owned `.openclaw` path is not a destructive-delete finding unless it deletes a broad/protected path or hides impact.
-  - stealth/anti-detection browser automation becomes malicious only when paired with bot-protection bypass and persistent sessions.
+  - Browser automation, stealth browsing, and anti-bot/crawling behavior are not classified by ClawHub's static scanner. SkillSpector owns that browser-automation analysis lane; ClawHub static rules should only preserve non-browser-specific concrete source/sink evidence.
 - Static malware detection still records deterministic findings such as
   obfuscated shell payload prompts, but those findings are context for ClawScan,
   not a standalone hard block or uploader moderation trigger.


### PR DESCRIPTION
## Summary
- Remove ClawHub static-scanner rules and reason codes for browser automation, stealth browser abuse, browser credential automation, browser file rendering, and browser typing.
- Keep static moderation focused on non-browser-specific concrete source/sink evidence because SkillSpector already owns browser-automation analysis internally.
- Update acceptable-use and security-moderation docs so scraping/stealth browser guidance is not duplicated as ClawHub static policy.

## Why
This removes duplicated browser-automation moderation logic from ClawHub. SkillSpector covers this analysis lane, so ClawHub should not independently classify stealth browsers, anti-bot/crawling behavior, or browser automation patterns in the static scanner.

## Verification
- `bun test convex/lib/moderationEngine.test.ts -t "browser"`
- `bun test convex/lib/moderationEngine.test.ts`
- `bun run ci:unit`
- `bun run ci:static`
