### PR TITLE
fix: tolerate duplicate CLI device user codes

### DIFF
--- a/convex/cliDeviceAuth.test.ts
+++ b/convex/cliDeviceAuth.test.ts
@@ -51,19 +51,19 @@ describe("cliDeviceAuth approval", () => {
     const now = Date.now();
     const { ctx, order, patch, take } = makeCtx([
       {
-        _id: "cliDeviceCodes:old",
-        _creationTime: now - 10_000,
-        status: "pending",
-        userCode: "Q639-NBSX",
-        createdAt: now - 10_000,
-        expiresAt: now + 60_000,
-      },
-      {
         _id: "cliDeviceCodes:new",
         _creationTime: now - 1_000,
         status: "pending",
         userCode: "Q639-NBSX",
         createdAt: now - 1_000,
+        expiresAt: now + 60_000,
+      },
+      {
+        _id: "cliDeviceCodes:old",
+        _creationTime: now - 10_000,
+        status: "pending",
+        userCode: "Q639-NBSX",
+        createdAt: now - 10_000,
         expiresAt: now + 60_000,
       },
     ]);
@@ -78,6 +78,36 @@ describe("cliDeviceAuth approval", () => {
     expect(order).toHaveBeenCalledWith("desc");
     expect(take).toHaveBeenCalledWith(50);
     expect(patch).toHaveBeenCalledTimes(1);
+    expect(patch).toHaveBeenCalledWith("cliDeviceCodes:new", {
+      status: "approved",
+      approvedByUserId: "users:approver",
+      approvedAt: now,
+    });
+  });
+
+  it("uses descending index order when duplicate creation timestamps disagree", async () => {
+    const now = Date.now();
+    const { ctx, patch } = makeCtx([
+      {
+        _id: "cliDeviceCodes:new",
+        _creationTime: now - 1_000,
+        status: "pending",
+        userCode: "Q639-NBSX",
+        createdAt: now - 20_000,
+        expiresAt: now + 60_000,
+      },
+      {
+        _id: "cliDeviceCodes:old",
+        _creationTime: now - 10_000,
+        status: "pending",
+        userCode: "Q639-NBSX",
+        createdAt: now - 500,
+        expiresAt: now + 60_000,
+      },
+    ]);
+
+    await approveHandler(ctx, { userCode: "Q639-NBSX" });
+
     expect(patch).toHaveBeenCalledWith("cliDeviceCodes:new", {
       status: "approved",
       approvedByUserId: "users:approver",
@@ -182,19 +212,19 @@ describe("cliDeviceAuth approval", () => {
     const now = Date.now();
     const { ctx, patch } = makeCtx([
       {
-        _id: "cliDeviceCodes:old",
-        _creationTime: now - 10_000,
-        status: "pending",
-        userCode: "Q639-NBSX",
-        createdAt: now - 10_000,
-        expiresAt: now + 60_000,
-      },
-      {
         _id: "cliDeviceCodes:new",
         _creationTime: now - 1_000,
         status: "pending",
         userCode: "Q639-NBSX",
         createdAt: now - 1_000,
+        expiresAt: now + 60_000,
+      },
+      {
+        _id: "cliDeviceCodes:old",
+        _creationTime: now - 10_000,
+        status: "pending",
+        userCode: "Q639-NBSX",
+        createdAt: now - 10_000,
         expiresAt: now + 60_000,
       },
     ]);

--- a/convex/cliDeviceAuth.test.ts
+++ b/convex/cliDeviceAuth.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./lib/access", () => ({
+  requireUser: vi.fn(),
+}));
+
+const { requireUser } = await import("./lib/access");
+const { approve, deny } = await import("./cliDeviceAuth");
+
+const approveHandler = (approve as unknown as { _handler: Function })._handler;
+const denyHandler = (deny as unknown as { _handler: Function })._handler;
+
+function makeCtx(rows: Array<Record<string, unknown>>) {
+  const collect = vi.fn().mockResolvedValue(rows);
+  const withIndex = vi.fn().mockReturnValue({ collect });
+  const query = vi.fn().mockReturnValue({ withIndex });
+  const get = vi.fn().mockResolvedValue(null);
+  const insert = vi.fn().mockResolvedValue("inserted:id");
+  const patch = vi.fn().mockResolvedValue(undefined);
+  const replace = vi.fn().mockResolvedValue(undefined);
+  const delete_ = vi.fn().mockResolvedValue(undefined);
+  const normalizeId = vi.fn().mockReturnValue(null);
+
+  return {
+    ctx: { db: { get, insert, query, patch, replace, delete: delete_, normalizeId } },
+    collect,
+    withIndex,
+    query,
+    patch,
+  };
+}
+
+describe("cliDeviceAuth approval", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-10T12:00:00Z"));
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:approver",
+      user: { _id: "users:approver" },
+    } as never);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.mocked(requireUser).mockReset();
+  });
+
+  it("approves the newest active pending row when duplicate user codes exist", async () => {
+    const now = Date.now();
+    const { ctx, patch } = makeCtx([
+      {
+        _id: "cliDeviceCodes:old",
+        _creationTime: now - 10_000,
+        status: "pending",
+        userCode: "Q639-NBSX",
+        createdAt: now - 10_000,
+        expiresAt: now + 60_000,
+      },
+      {
+        _id: "cliDeviceCodes:new",
+        _creationTime: now - 1_000,
+        status: "pending",
+        userCode: "Q639-NBSX",
+        createdAt: now - 1_000,
+        expiresAt: now + 60_000,
+      },
+    ]);
+
+    const result = await approveHandler(ctx, { userCode: "q639-nbsx" });
+
+    expect(result).toEqual({
+      ok: true,
+      userCode: "Q639-NBSX",
+      expiresAt: now + 60_000,
+    });
+    expect(patch).toHaveBeenCalledTimes(1);
+    expect(patch).toHaveBeenCalledWith("cliDeviceCodes:new", {
+      status: "approved",
+      approvedByUserId: "users:approver",
+      approvedAt: now,
+    });
+  });
+
+  it("expires stale duplicate rows before approving an active row", async () => {
+    const now = Date.now();
+    const { ctx, patch } = makeCtx([
+      {
+        _id: "cliDeviceCodes:expired",
+        _creationTime: now - 100_000,
+        status: "pending",
+        userCode: "Q639-NBSX",
+        createdAt: now - 100_000,
+        expiresAt: now - 1,
+      },
+      {
+        _id: "cliDeviceCodes:active",
+        _creationTime: now - 1_000,
+        status: "pending",
+        userCode: "Q639-NBSX",
+        createdAt: now - 1_000,
+        expiresAt: now + 60_000,
+      },
+    ]);
+
+    await approveHandler(ctx, { userCode: "Q639-NBSX" });
+
+    expect(patch).toHaveBeenNthCalledWith(1, "cliDeviceCodes:expired", { status: "expired" });
+    expect(patch).toHaveBeenNthCalledWith(2, "cliDeviceCodes:active", {
+      status: "approved",
+      approvedByUserId: "users:approver",
+      approvedAt: now,
+    });
+  });
+
+  it("denies the newest active pending row when duplicate user codes exist", async () => {
+    const now = Date.now();
+    const { ctx, patch } = makeCtx([
+      {
+        _id: "cliDeviceCodes:old",
+        _creationTime: now - 10_000,
+        status: "pending",
+        userCode: "Q639-NBSX",
+        createdAt: now - 10_000,
+        expiresAt: now + 60_000,
+      },
+      {
+        _id: "cliDeviceCodes:new",
+        _creationTime: now - 1_000,
+        status: "pending",
+        userCode: "Q639-NBSX",
+        createdAt: now - 1_000,
+        expiresAt: now + 60_000,
+      },
+    ]);
+
+    await expect(denyHandler(ctx, { userCode: "Q639-NBSX" })).resolves.toEqual({ ok: true });
+
+    expect(patch).toHaveBeenCalledTimes(1);
+    expect(patch).toHaveBeenCalledWith("cliDeviceCodes:new", {
+      status: "denied",
+      deniedAt: now,
+    });
+  });
+});

--- a/convex/cliDeviceAuth.test.ts
+++ b/convex/cliDeviceAuth.test.ts
@@ -11,8 +11,9 @@ const approveHandler = (approve as unknown as { _handler: Function })._handler;
 const denyHandler = (deny as unknown as { _handler: Function })._handler;
 
 function makeCtx(rows: Array<Record<string, unknown>>) {
-  const collect = vi.fn().mockResolvedValue(rows);
-  const withIndex = vi.fn().mockReturnValue({ collect });
+  const take = vi.fn().mockResolvedValue(rows);
+  const order = vi.fn().mockReturnValue({ take });
+  const withIndex = vi.fn().mockReturnValue({ order });
   const query = vi.fn().mockReturnValue({ withIndex });
   const get = vi.fn().mockResolvedValue(null);
   const insert = vi.fn().mockResolvedValue("inserted:id");
@@ -23,7 +24,8 @@ function makeCtx(rows: Array<Record<string, unknown>>) {
 
   return {
     ctx: { db: { get, insert, query, patch, replace, delete: delete_, normalizeId } },
-    collect,
+    order,
+    take,
     withIndex,
     query,
     patch,
@@ -47,7 +49,7 @@ describe("cliDeviceAuth approval", () => {
 
   it("approves the newest active pending row when duplicate user codes exist", async () => {
     const now = Date.now();
-    const { ctx, patch } = makeCtx([
+    const { ctx, order, patch, take } = makeCtx([
       {
         _id: "cliDeviceCodes:old",
         _creationTime: now - 10_000,
@@ -73,6 +75,8 @@ describe("cliDeviceAuth approval", () => {
       userCode: "Q639-NBSX",
       expiresAt: now + 60_000,
     });
+    expect(order).toHaveBeenCalledWith("desc");
+    expect(take).toHaveBeenCalledWith(50);
     expect(patch).toHaveBeenCalledTimes(1);
     expect(patch).toHaveBeenCalledWith("cliDeviceCodes:new", {
       status: "approved",
@@ -81,7 +85,7 @@ describe("cliDeviceAuth approval", () => {
     });
   });
 
-  it("expires stale duplicate rows before approving an active row", async () => {
+  it("expires stale pending rows before approving an active row", async () => {
     const now = Date.now();
     const { ctx, patch } = makeCtx([
       {
@@ -112,6 +116,68 @@ describe("cliDeviceAuth approval", () => {
     });
   });
 
+  it("preserves stale terminal rows while expiring stale pending duplicates", async () => {
+    const now = Date.now();
+    const { ctx, patch } = makeCtx([
+      {
+        _id: "cliDeviceCodes:approved",
+        _creationTime: now - 100_000,
+        status: "approved",
+        userCode: "Q639-NBSX",
+        createdAt: now - 100_000,
+        expiresAt: now - 1,
+        approvedAt: now - 90_000,
+        approvedByUserId: "users:previous",
+      },
+      {
+        _id: "cliDeviceCodes:denied",
+        _creationTime: now - 90_000,
+        status: "denied",
+        userCode: "Q639-NBSX",
+        createdAt: now - 90_000,
+        expiresAt: now - 1,
+        deniedAt: now - 80_000,
+      },
+      {
+        _id: "cliDeviceCodes:consumed",
+        _creationTime: now - 80_000,
+        status: "consumed",
+        userCode: "Q639-NBSX",
+        createdAt: now - 80_000,
+        expiresAt: now - 1,
+        consumedAt: now - 70_000,
+      },
+      {
+        _id: "cliDeviceCodes:expired",
+        _creationTime: now - 70_000,
+        status: "pending",
+        userCode: "Q639-NBSX",
+        createdAt: now - 70_000,
+        expiresAt: now - 1,
+      },
+      {
+        _id: "cliDeviceCodes:active",
+        _creationTime: now - 1_000,
+        status: "pending",
+        userCode: "Q639-NBSX",
+        createdAt: now - 1_000,
+        expiresAt: now + 60_000,
+      },
+    ]);
+
+    await approveHandler(ctx, { userCode: "Q639-NBSX" });
+
+    expect(patch).toHaveBeenNthCalledWith(1, "cliDeviceCodes:expired", { status: "expired" });
+    expect(patch).toHaveBeenNthCalledWith(2, "cliDeviceCodes:active", {
+      status: "approved",
+      approvedByUserId: "users:approver",
+      approvedAt: now,
+    });
+    expect(patch).not.toHaveBeenCalledWith("cliDeviceCodes:approved", expect.anything());
+    expect(patch).not.toHaveBeenCalledWith("cliDeviceCodes:denied", expect.anything());
+    expect(patch).not.toHaveBeenCalledWith("cliDeviceCodes:consumed", expect.anything());
+  });
+
   it("denies the newest active pending row when duplicate user codes exist", async () => {
     const now = Date.now();
     const { ctx, patch } = makeCtx([
@@ -137,6 +203,29 @@ describe("cliDeviceAuth approval", () => {
 
     expect(patch).toHaveBeenCalledTimes(1);
     expect(patch).toHaveBeenCalledWith("cliDeviceCodes:new", {
+      status: "denied",
+      deniedAt: now,
+    });
+  });
+
+  it("does not deny stale pending rows after expiring them", async () => {
+    const now = Date.now();
+    const { ctx, patch } = makeCtx([
+      {
+        _id: "cliDeviceCodes:expired",
+        _creationTime: now - 100_000,
+        status: "pending",
+        userCode: "Q639-NBSX",
+        createdAt: now - 100_000,
+        expiresAt: now - 1,
+      },
+    ]);
+
+    await expect(denyHandler(ctx, { userCode: "Q639-NBSX" })).resolves.toEqual({ ok: true });
+
+    expect(patch).toHaveBeenCalledTimes(1);
+    expect(patch).toHaveBeenCalledWith("cliDeviceCodes:expired", { status: "expired" });
+    expect(patch).not.toHaveBeenCalledWith("cliDeviceCodes:expired", {
       status: "denied",
       deniedAt: now,
     });

--- a/convex/cliDeviceAuth.ts
+++ b/convex/cliDeviceAuth.ts
@@ -164,15 +164,10 @@ function pickLatestRow(
   now?: number,
   status?: Doc<"cliDeviceCodes">["status"],
 ) {
-  const candidates = rows.filter(
+  return rows.find(
     (row) =>
       (now === undefined || row.expiresAt > now) && (status === undefined || row.status === status),
   );
-  return candidates.reduce<Doc<"cliDeviceCodes"> | null>((best, row) => {
-    if (!best) return row;
-    if (row.createdAt !== best.createdAt) return row.createdAt > best.createdAt ? row : best;
-    return row._creationTime > best._creationTime ? row : best;
-  }, null);
 }
 
 function generateUserCode() {

--- a/convex/cliDeviceAuth.ts
+++ b/convex/cliDeviceAuth.ts
@@ -1,4 +1,6 @@
 import { v } from "convex/values";
+import type { Doc } from "./_generated/dataModel";
+import type { MutationCtx } from "./_generated/server";
 import { internalMutation, mutation } from "./functions";
 import { requireUser } from "./lib/access";
 import { generateToken, hashToken } from "./lib/tokens";
@@ -88,17 +90,13 @@ export const approve = mutation({
     if (!normalized) throw new Error("Code required");
 
     const userCodeHash = await hashToken(normalized);
-    const row = await ctx.db
-      .query("cliDeviceCodes")
-      .withIndex("by_user_code_hash", (q) => q.eq("userCodeHash", userCodeHash))
-      .unique();
-    if (!row) throw new Error("Device code not found");
-
     const now = Date.now();
-    if (row.expiresAt <= now) {
-      if (row.status !== "expired") await ctx.db.patch(row._id, { status: "expired" });
-      throw new Error("Device code expired");
-    }
+    const rows = await getRowsByUserCodeHash(ctx, userCodeHash);
+    await expireStaleRows(ctx, rows, now);
+    const row =
+      pickLatestRow(rows, now, "pending") ?? pickLatestRow(rows, now) ?? pickLatestRow(rows);
+    if (!row) throw new Error("Device code not found");
+    if (row.expiresAt <= now) throw new Error("Device code expired");
     if (row.status === "consumed") throw new Error("Device code already used");
     if (row.status === "approved") throw new Error("Device code already authorized");
     if (row.status === "denied") throw new Error("Device code was denied");
@@ -119,12 +117,13 @@ export const deny = mutation({
     const normalized = normalizeUserCode(args.userCode);
     if (!normalized) throw new Error("Code required");
     const userCodeHash = await hashToken(normalized);
-    const row = await ctx.db
-      .query("cliDeviceCodes")
-      .withIndex("by_user_code_hash", (q) => q.eq("userCodeHash", userCodeHash))
-      .unique();
-    if (!row) throw new Error("Device code not found");
     const now = Date.now();
+    const rows = await getRowsByUserCodeHash(ctx, userCodeHash);
+    await expireStaleRows(ctx, rows, now);
+    const row =
+      pickLatestRow(rows, now, "pending") ?? pickLatestRow(rows, now) ?? pickLatestRow(rows);
+    if (!row) throw new Error("Device code not found");
+    if (row.expiresAt <= now) return { ok: true };
     if (row.status === "approved") throw new Error("Device code already authorized");
     if (row.status === "pending") {
       await ctx.db.patch(row._id, { status: "denied", deniedAt: now });
@@ -138,6 +137,37 @@ function normalizeUserCode(value: string) {
     .trim()
     .toUpperCase()
     .replace(/[^A-Z0-9]/g, "");
+}
+
+async function getRowsByUserCodeHash(ctx: MutationCtx, userCodeHash: string) {
+  return await ctx.db
+    .query("cliDeviceCodes")
+    .withIndex("by_user_code_hash", (q) => q.eq("userCodeHash", userCodeHash))
+    .collect();
+}
+
+async function expireStaleRows(ctx: MutationCtx, rows: Array<Doc<"cliDeviceCodes">>, now: number) {
+  for (const row of rows) {
+    if (row.expiresAt <= now && row.status !== "expired") {
+      await ctx.db.patch(row._id, { status: "expired" });
+    }
+  }
+}
+
+function pickLatestRow(
+  rows: Array<Doc<"cliDeviceCodes">>,
+  now?: number,
+  status?: Doc<"cliDeviceCodes">["status"],
+) {
+  const candidates = rows.filter(
+    (row) =>
+      (now === undefined || row.expiresAt > now) && (status === undefined || row.status === status),
+  );
+  return candidates.reduce<Doc<"cliDeviceCodes"> | null>((best, row) => {
+    if (!best) return row;
+    if (row.createdAt !== best.createdAt) return row.createdAt > best.createdAt ? row : best;
+    return row._creationTime > best._creationTime ? row : best;
+  }, null);
 }
 
 function generateUserCode() {

--- a/convex/cliDeviceAuth.ts
+++ b/convex/cliDeviceAuth.ts
@@ -7,6 +7,7 @@ import { generateToken, hashToken } from "./lib/tokens";
 
 const DEVICE_CODE_TTL_MS = 15 * 60_000;
 const DEVICE_POLL_INTERVAL_SECONDS = 5;
+const MAX_DUPLICATE_USER_CODE_ROWS = 50;
 const USER_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 
 export const createInternal = internalMutation({
@@ -91,12 +92,12 @@ export const approve = mutation({
 
     const userCodeHash = await hashToken(normalized);
     const now = Date.now();
-    const rows = await getRowsByUserCodeHash(ctx, userCodeHash);
-    await expireStaleRows(ctx, rows, now);
+    const rows = await expireStaleRows(ctx, await getRowsByUserCodeHash(ctx, userCodeHash), now);
     const row =
       pickLatestRow(rows, now, "pending") ?? pickLatestRow(rows, now) ?? pickLatestRow(rows);
     if (!row) throw new Error("Device code not found");
     if (row.expiresAt <= now) throw new Error("Device code expired");
+    if (row.status === "expired") throw new Error("Device code expired");
     if (row.status === "consumed") throw new Error("Device code already used");
     if (row.status === "approved") throw new Error("Device code already authorized");
     if (row.status === "denied") throw new Error("Device code was denied");
@@ -118,12 +119,10 @@ export const deny = mutation({
     if (!normalized) throw new Error("Code required");
     const userCodeHash = await hashToken(normalized);
     const now = Date.now();
-    const rows = await getRowsByUserCodeHash(ctx, userCodeHash);
-    await expireStaleRows(ctx, rows, now);
+    const rows = await expireStaleRows(ctx, await getRowsByUserCodeHash(ctx, userCodeHash), now);
     const row =
       pickLatestRow(rows, now, "pending") ?? pickLatestRow(rows, now) ?? pickLatestRow(rows);
     if (!row) throw new Error("Device code not found");
-    if (row.expiresAt <= now) return { ok: true };
     if (row.status === "approved") throw new Error("Device code already authorized");
     if (row.status === "pending") {
       await ctx.db.patch(row._id, { status: "denied", deniedAt: now });
@@ -143,15 +142,21 @@ async function getRowsByUserCodeHash(ctx: MutationCtx, userCodeHash: string) {
   return await ctx.db
     .query("cliDeviceCodes")
     .withIndex("by_user_code_hash", (q) => q.eq("userCodeHash", userCodeHash))
-    .collect();
+    .order("desc")
+    .take(MAX_DUPLICATE_USER_CODE_ROWS);
 }
 
 async function expireStaleRows(ctx: MutationCtx, rows: Array<Doc<"cliDeviceCodes">>, now: number) {
+  const nextRows: Array<Doc<"cliDeviceCodes">> = [];
   for (const row of rows) {
-    if (row.expiresAt <= now && row.status !== "expired") {
+    if (row.status === "pending" && row.expiresAt <= now) {
       await ctx.db.patch(row._id, { status: "expired" });
+      nextRows.push({ ...row, status: "expired" });
+    } else {
+      nextRows.push(row);
     }
   }
+  return nextRows;
 }
 
 function pickLatestRow(


### PR DESCRIPTION
## Summary

- Fix CLI device approval/denial to tolerate duplicate `userCodeHash` rows instead of relying on Convex `.unique()`.
- Expire stale matching rows, then approve or deny the newest active pending row so a stuck duplicate code no longer surfaces as a Convex server error.
- Add regression coverage for duplicate device user-code rows.

Fixes #2587

## Tests

- `bun run test convex/cliDeviceAuth.test.ts convex/httpApi.handlers.test.ts`
- `bunx tsc --noEmit --pretty false`
- `bun run format:check -- convex/cliDeviceAuth.ts convex/cliDeviceAuth.test.ts`
- `bun run lint`
