### PR TITLE
Remove homepage suggestion chips

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -102,13 +102,6 @@ function SkillsHome() {
     });
   };
 
-  const handleSuggestion = (term: string) => {
-    void navigate({
-      to: "/search",
-      search: { q: term },
-    });
-  };
-
   // Format stat numbers
   const formatStat = (n: number | undefined): string => {
     if (!n) return "0";
@@ -494,37 +487,6 @@ function SkillsHome() {
               <span className="home-v2-search-go-label">Search</span> <ArrowRight size={16} />
             </button>
           </form>
-        </div>
-
-        <div className="home-v2-suggestions">
-          <button
-            type="button"
-            className="home-v2-suggestion"
-            onClick={() => handleSuggestion("self-improving agent")}
-          >
-            self-improving agent
-          </button>
-          <button
-            type="button"
-            className="home-v2-suggestion"
-            onClick={() => handleSuggestion("GitHub integration")}
-          >
-            GitHub integration
-          </button>
-          <button
-            type="button"
-            className="home-v2-suggestion"
-            onClick={() => handleSuggestion("security soul")}
-          >
-            security soul
-          </button>
-          <button
-            type="button"
-            className="home-v2-suggestion"
-            onClick={() => handleSuggestion("dashboard builder")}
-          >
-            dashboard builder
-          </button>
         </div>
       </section>
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -14010,57 +14010,6 @@ a.publisher-profile-detail:hover {
   transform: scale(0.97);
 }
 
-/* Suggestions */
-.home-v2-suggestions {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  margin-top: 16px;
-  flex-wrap: wrap;
-}
-.home-v2-suggestion {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  color: var(--hv2-text-secondary);
-  font-size: 13px;
-  font-weight: 500;
-  padding: 6px 14px;
-  border-radius: 100px;
-  cursor: pointer;
-  transition:
-    color 0.15s,
-    background 0.15s,
-    border-color 0.15s;
-  border: 1px solid var(--hv2-border);
-  background: transparent;
-}
-.home-v2-suggestion:hover {
-  color: var(--hv2-text);
-  background: var(--hv2-surface-hover);
-  border-color: var(--hv2-border-hover);
-}
-.home-v2-suggestion svg {
-  color: var(--hv2-text-tertiary);
-}
-.home-v2-suggestion:hover svg {
-  color: var(--hv2-accent);
-}
-
-@media (max-width: 760px) {
-  .home-v2-suggestions {
-    gap: 6px;
-    margin-top: 12px;
-  }
-
-  .home-v2-suggestion {
-    font-size: 12px;
-    padding: 5px 10px;
-    gap: 4px;
-  }
-}
-
 /* ═══ CAROUSEL ═══ */
 .home-v2-carousel-section {
   padding: 48px 0 0;
@@ -14876,18 +14825,6 @@ a.publisher-profile-detail:hover {
   box-shadow: 0 0 20px rgba(196, 58, 47, 0.06);
 }
 
-/* Light — suggestion pills */
-[data-theme-resolved="light"] .home-v2-suggestion {
-  background: #fff8f2;
-  border-color: rgba(170, 125, 80, 0.18);
-  color: #6b5c4e;
-  box-shadow: inset 0 0 8px rgba(170, 125, 80, 0.03);
-}
-[data-theme-resolved="light"] .home-v2-suggestion:hover {
-  background: #fff4ea;
-  border-color: rgba(170, 125, 80, 0.3);
-}
-
 /* Light — category icons */
 [data-theme-resolved="light"] .home-v2-cat-icon {
   background: rgba(196, 58, 47, 0.06);
@@ -15011,11 +14948,6 @@ a.publisher-profile-detail:hover {
     0 0 0 3px var(--hv2-accent-glow);
 }
 
-/* Dark — suggestion pills */
-[data-theme-resolved="dark"] .home-v2-suggestion {
-  box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.12);
-}
-
 /* Dark — cat icons */
 [data-theme-resolved="dark"] .home-v2-cat-icon {
   box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.15);
@@ -15054,11 +14986,6 @@ a.publisher-profile-detail:hover {
 }
 .home-v2-cat-icon {
   border-radius: 8px;
-}
-
-/* Suggestion pills — were likely pill-shaped, soften */
-.home-v2-suggestion {
-  border-radius: 20px;
 }
 
 /* Hero rings — circles, keep as-is (border-radius: 50%) */


### PR DESCRIPTION
## Summary
- remove the hardcoded homepage suggestion chip buttons below the hero search
- delete the now-unused suggestion chip CSS, including theme and mobile overrides

## Tests
- `bun run format:check -- src/routes/index.tsx src/styles.css`
- `rg -n "self-improving agent|GitHub integration|security soul|dashboard builder|home-v2-suggestions|home-v2-suggestion|handleSuggestion" src/routes/index.tsx src/styles.css` (no matches)
- `git diff --check -- src/routes/index.tsx src/styles.css`
- Browser preview at `http://localhost:61305/`: homepage loads without the suggestion chip row

## Screenshot
![Homepage without suggestion chips](https://raw.githubusercontent.com/fuller-stack-dev/clawhub/codex/remove-homepage-chips-screenshot-20260610/screenshots/homepage-no-chips.png)
