### PR TITLE
Preserve vector scores for direct lexical skill matches

### DIFF
--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -1521,6 +1521,46 @@ describe("search helpers", () => {
     expect(resultA).toBeDefined();
     expect(resultA!.score).toBeGreaterThan(1.0);
   });
+
+  it("preserves vector scores when a direct lexical match shadows the hydrated candidate", async () => {
+    generateEmbeddingMock.mockResolvedValueOnce([0, 1, 2]);
+
+    const lexicalEntry = {
+      skill: makePublicSkill({
+        id: "skills:the-news",
+        slug: "the-news",
+        displayName: "The News",
+      }),
+      version: null,
+      ownerHandle: "owner",
+      owner: null,
+    };
+    const vectorEntry = {
+      ...lexicalEntry,
+      embeddingId: "skillEmbeddings:the-news",
+    };
+
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce(null) // getExactSkillSlugMatch
+      .mockResolvedValueOnce([lexicalEntry]) // directPrefixSkillMatches
+      .mockResolvedValueOnce([vectorEntry]) // hydrateResults
+      .mockResolvedValueOnce([]); // lexicalFallbackSkills
+
+    const result = await searchSkillsHandler(
+      {
+        vectorSearch: vi
+          .fn()
+          .mockResolvedValueOnce([{ _id: "skillEmbeddings:the-news", _score: 0.33 }]),
+        runQuery,
+      },
+      { query: "news", limit: 10 },
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].skill.slug).toBe("the-news");
+    expect(result[0].score).toBeGreaterThan(2.8);
+  });
 });
 
 describe("soul search", () => {

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -289,6 +289,7 @@ export const searchSkills: ReturnType<typeof action> = action({
     let hydrated: SkillSearchEntry[] = [];
     const seenEmbeddingIds = new Set<Id<"skillEmbeddings">>();
     let scoreById = new Map<Id<"skillEmbeddings">, number>();
+    const scoreBySkillId = new Map<Id<"skills">, number>();
     let exactMatches: SkillSearchEntry[] = [];
 
     if (vector) {
@@ -315,6 +316,12 @@ export const searchSkills: ReturnType<typeof action> = action({
 
         for (const result of results) {
           scoreById.set(result._id, result._score);
+        }
+
+        for (const entry of hydrated) {
+          if (!entry.embeddingId) continue;
+          const score = scoreById.get(entry.embeddingId);
+          if (score !== undefined) scoreBySkillId.set(entry.skill._id, score);
         }
 
         // Skills already have badges from their docs (via toPublicSkill).
@@ -367,7 +374,9 @@ export const searchSkills: ReturnType<typeof action> = action({
 
     const rankedMatches = mergedMatches
       .map((entry): SearchResult | null => {
-        const vectorScore = entry.embeddingId ? (scoreById.get(entry.embeddingId) ?? 0) : 0;
+        const vectorScore = entry.embeddingId
+          ? (scoreById.get(entry.embeddingId) ?? scoreBySkillId.get(entry.skill._id) ?? 0)
+          : (scoreBySkillId.get(entry.skill._id) ?? 0);
         const match = classifySkillMatch(query, queryTokens, entry.skill);
         if (!match) return null;
         return {


### PR DESCRIPTION
## Summary
- preserve a skill's vector score by skill id when the same skill is also recalled through direct lexical search
- keep existing merge/recall ordering intact while allowing lexical-retained entries to receive their vector contribution
- add a regression test for a direct lexical match shadowing a hydrated vector candidate

## Context
This addresses the ranking failure discussed in #2374. For searches like `news`, a skill can be recalled first through `directPrefixSkillMatches` without an `embeddingId`, then also appear as a vector-hydrated candidate with an `embeddingId`. The current merge keeps the direct lexical entry and drops the hydrated duplicate, so scoring falls back to a zero vector score.

The fix stores vector scores by skill id as hydrated candidates are seen, then uses that map when the retained entry does not carry `embeddingId`.

## Tests
- `bunx vitest run convex/search.test.ts`
- `bunx oxfmt --check convex/search.ts convex/search.test.ts`
- `bunx oxlint --type-aware --tsconfig ./tsconfig.oxlint.json convex/search.ts convex/search.test.ts`
