### PR TITLE
Normalize ClawScan review visibility

### DIFF
--- a/convex/functions.test.ts
+++ b/convex/functions.test.ts
@@ -58,6 +58,20 @@ describe("package digest sync", () => {
     expect(
       isGitHubMirrorEligibleSkillDoc({
         softDeletedAt: undefined,
+        moderationStatus: "active",
+        moderationVerdict: "malicious",
+      }),
+    ).toBe(false);
+    expect(
+      isGitHubMirrorEligibleSkillDoc({
+        softDeletedAt: undefined,
+        moderationStatus: "active",
+        moderationFlags: ["blocked.malware"],
+      }),
+    ).toBe(false);
+    expect(
+      isGitHubMirrorEligibleSkillDoc({
+        softDeletedAt: undefined,
         moderationStatus: "hidden",
       }),
     ).toBe(false);

--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -14,6 +14,7 @@ import {
   httpAction,
 } from "./_generated/server";
 import type { MutationCtx } from "./_generated/server";
+import { isPublicSkillDoc } from "./lib/globalStats";
 import {
   deletePackageSearchDigests,
   extractPackageDigestFields,
@@ -229,21 +230,28 @@ async function syncSkillSearchDigestForSkill(
 }
 
 export function isGitHubMirrorEligibleSkillDoc(
-  skill: Pick<Doc<"skills">, "softDeletedAt" | "moderationStatus"> | null | undefined,
+  skill:
+    | Pick<
+        Doc<"skills">,
+        "softDeletedAt" | "moderationStatus" | "moderationFlags" | "moderationVerdict"
+      >
+    | null
+    | undefined,
 ) {
-  if (!skill || skill.softDeletedAt) return false;
-  return (
-    skill.moderationStatus === undefined ||
-    skill.moderationStatus === null ||
-    skill.moderationStatus === "active"
-  );
+  return isPublicSkillDoc(skill);
 }
 
 export async function scheduleGitHubBackupDeletionForSkill(
   ctx: GitHubBackupDeletionCtx,
   skill: Pick<
     Doc<"skills">,
-    "slug" | "ownerPublisherId" | "ownerUserId" | "softDeletedAt" | "moderationStatus"
+    | "slug"
+    | "ownerPublisherId"
+    | "ownerUserId"
+    | "softDeletedAt"
+    | "moderationStatus"
+    | "moderationFlags"
+    | "moderationVerdict"
   >,
 ) {
   const owner = await getOwnerPublisher(ctx, {

--- a/convex/githubBackups.ts
+++ b/convex/githubBackups.ts
@@ -1,8 +1,9 @@
 import { v } from "convex/values";
 import { internal } from "./_generated/api";
-import type { Id } from "./_generated/dataModel";
+import type { Doc, Id } from "./_generated/dataModel";
 import { action, internalMutation, internalQuery } from "./functions";
 import { assertRole, requireUserFromAction } from "./lib/access";
+import { isPublicSkillDoc } from "./lib/globalStats";
 
 const DEFAULT_BATCH_SIZE = 50;
 const MAX_BATCH_SIZE = 200;
@@ -104,16 +105,13 @@ export const getGitHubBackupPageInternal = internalQuery({
   },
 });
 
-function isPubliclyAvailableSkill(skill: {
-  softDeletedAt?: number;
-  moderationStatus?: string | null;
-}) {
-  if (skill.softDeletedAt) return false;
-  return (
-    skill.moderationStatus === undefined ||
-    skill.moderationStatus === null ||
-    skill.moderationStatus === "active"
-  );
+function isPubliclyAvailableSkill(
+  skill: Pick<
+    Doc<"skillSearchDigest">,
+    "softDeletedAt" | "moderationStatus" | "moderationFlags" | "moderationVerdict"
+  >,
+) {
+  return isPublicSkillDoc(skill);
 }
 
 function isStaleCursorError(error: unknown) {

--- a/convex/githubBackupsNode.ts
+++ b/convex/githubBackupsNode.ts
@@ -14,6 +14,7 @@ import {
   listGitHubSkillBackupEntries,
   normalizeOwner,
 } from "./lib/githubBackup";
+import { isPublicSkillDoc } from "./lib/globalStats";
 
 const DEFAULT_BATCH_SIZE = 50;
 const MAX_BATCH_SIZE = 200;
@@ -273,12 +274,7 @@ async function pruneDeletedSkillBackups(
 }
 
 function isMirrorEligibleSkill(skill: Doc<"skills"> | null): skill is Doc<"skills"> {
-  if (!skill || skill.softDeletedAt) return false;
-  return (
-    skill.moderationStatus === undefined ||
-    skill.moderationStatus === null ||
-    skill.moderationStatus === "active"
-  );
+  return isPublicSkillDoc(skill);
 }
 
 async function deleteBackupIfNeeded(

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -5420,6 +5420,7 @@ describe("httpApiV1 handlers", () => {
     expect(json.ok).toBe(false);
     expect(json.decision).toBe("fail");
     expect(json.reasons).toEqual(["moderation.malware_blocked"]);
+    expect(json.card).toMatchObject({ available: false, url: null });
     expect(json.security).toMatchObject({ status: "clean", passed: true });
   });
 

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -2856,6 +2856,7 @@ type PackageExactVersionModeratedSkill = Pick<
   | "moderationStatus"
   | "moderationReason"
   | "moderationFlags"
+  | "moderationVerdict"
   | "moderationSourceVersionId"
 >;
 

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -311,6 +311,7 @@ const internalRefs = internal as unknown as {
   };
   skills: {
     getSecurityVerdictTargetInternal: unknown;
+    getVerifyTargetBySlugInternal: unknown;
     getSkillBySlugInternal: unknown;
     getVersionByIdInternal: unknown;
     getVersionBySkillAndVersionInternal: unknown;
@@ -801,7 +802,7 @@ function buildVerifyReasons(args: {
   securityStatus: NormalizedSecurityStatus;
 }) {
   const reasons: string[] = [];
-  if (!args.cardAvailable) reasons.push("card.missing");
+  if (!args.cardAvailable && !args.isMalwareBlocked) reasons.push("card.missing");
   reasons.push(
     ...buildSecurityVerdictReasons({
       isMalwareBlocked: args.isMalwareBlocked,
@@ -1505,6 +1506,7 @@ type ExactVersionModeratedSkill = Pick<
   | "moderationStatus"
   | "moderationReason"
   | "moderationFlags"
+  | "moderationVerdict"
   | "moderationSourceVersionId"
 >;
 
@@ -2002,7 +2004,11 @@ export async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request)
     const tagParam = url.searchParams.get("tag")?.trim();
     if (versionParam && tagParam) return text("Use either version or tag", 400, rate.headers);
 
-    const skillResult = (await ctx.runQuery(api.skills.getBySlug, { slug })) as GetBySlugResult;
+    const skillResult = (await runQueryRef<GetBySlugResult>(
+      ctx,
+      internalRefs.skills.getVerifyTargetBySlugInternal,
+      { slug },
+    )) as GetBySlugResult;
     if (!skillResult?.skill) {
       const hidden = await describeOwnerVisibleSkillState(ctx, request, slug);
       if (hidden) return text(hidden.message, hidden.status, rate.headers);
@@ -2041,11 +2047,14 @@ export async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request)
     const bundleFingerprints = fingerprintEntries
       .filter((entry) => entry.kind === "generated-bundle")
       .map((entry) => entry.fingerprint);
-    const generatedCardFile = await selectGeneratedSkillCardFile(version.files, bundleFingerprints);
+    const isMalwareBlocked = skillResult.moderationInfo?.isMalwareBlocked ?? false;
+    const generatedCardFile = isMalwareBlocked
+      ? null
+      : await selectGeneratedSkillCardFile(version.files, bundleFingerprints);
     const security = buildVerifySecurity(version);
     const reasons = buildVerifyReasons({
       cardAvailable: Boolean(generatedCardFile),
-      isMalwareBlocked: skillResult.moderationInfo?.isMalwareBlocked ?? false,
+      isMalwareBlocked,
       securityPassed: security.passed,
       securityStatus: security.status,
     });
@@ -2082,7 +2091,9 @@ export async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request)
           : {
               available: false,
               path: "skill-card.md",
-              url: buildCardUrl(request, skillResult.skill.slug, version.version),
+              url: isMalwareBlocked
+                ? null
+                : buildCardUrl(request, skillResult.skill.slug, version.version),
               sha256: null,
               size: null,
               contentType: null,

--- a/convex/lib/globalStats.ts
+++ b/convex/lib/globalStats.ts
@@ -6,7 +6,8 @@ export const GLOBAL_STATS_KEY = "default";
 type SkillVisibilityFields = Pick<
   Doc<"skills">,
   "softDeletedAt" | "moderationStatus" | "moderationFlags"
->;
+> &
+  Partial<Pick<Doc<"skills">, "moderationVerdict">>;
 
 type GlobalStatsReadCtx = Pick<MutationCtx | QueryCtx, "db">;
 type GlobalStatsWriteCtx = Pick<MutationCtx, "db">;
@@ -16,6 +17,7 @@ export function isPublicSkillDoc<T extends SkillVisibilityFields>(
 ): skill is T {
   if (!skill || skill.softDeletedAt) return false;
   if (skill.moderationStatus && skill.moderationStatus !== "active") return false;
+  if (skill.moderationVerdict === "malicious") return false;
   if (skill.moderationFlags?.includes("blocked.malware")) return false;
   return true;
 }

--- a/convex/lib/public.test.ts
+++ b/convex/lib/public.test.ts
@@ -109,6 +109,14 @@ describe("public skill mapping", () => {
     });
     expect(toPublicSkill(skill)).toBeNull();
   });
+
+  it("filters out skills with a malicious moderation verdict", () => {
+    const skill = makeSkill({
+      moderationStatus: "active",
+      moderationVerdict: "malicious",
+    });
+    expect(toPublicSkill(skill)).toBeNull();
+  });
 });
 
 describe("public publisher mapping", () => {

--- a/convex/lib/public.ts
+++ b/convex/lib/public.ts
@@ -76,6 +76,7 @@ export type HydratableSkill = Pick<
   | "softDeletedAt"
   | "moderationStatus"
   | "moderationFlags"
+  | "moderationVerdict"
   | "moderationReason"
   | "isSuspicious"
   | "createdAt"

--- a/convex/lib/skillFileAccess.test.ts
+++ b/convex/lib/skillFileAccess.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  getPublicSkillFileAccessBlock,
+  getSkillFileModerationInfoFromSkill,
+} from "./skillFileAccess";
+
+describe("skill file moderation access", () => {
+  it("blocks skills whose current moderation verdict is malicious", () => {
+    const moderationInfo = getSkillFileModerationInfoFromSkill({
+      moderationStatus: "hidden",
+      moderationReason: "scanner.llm.malicious",
+      moderationFlags: [],
+      moderationVerdict: "malicious",
+    });
+
+    expect(moderationInfo.isMalwareBlocked).toBe(true);
+    expect(getPublicSkillFileAccessBlock(moderationInfo)).toMatchObject({
+      status: 403,
+      message: expect.stringContaining("malicious"),
+    });
+  });
+});

--- a/convex/lib/skillFileAccess.ts
+++ b/convex/lib/skillFileAccess.ts
@@ -12,6 +12,7 @@ type SkillModerationSource = {
   moderationStatus?: string | null;
   moderationReason?: string | null;
   moderationFlags?: string[] | null;
+  moderationVerdict?: string | null;
   moderationSourceVersionId?: Id<"skillVersions"> | string | null;
 };
 
@@ -35,7 +36,9 @@ export function getSkillFileModerationInfoFromSkill(
 ): SkillFileModerationInfo {
   const isPendingScan =
     skill.moderationStatus === "hidden" && isPendingSkillModerationReason(skill.moderationReason);
-  const isMalwareBlocked = skill.moderationFlags?.includes("blocked.malware") ?? false;
+  const isMalwareBlocked =
+    skill.moderationVerdict === "malicious" ||
+    (skill.moderationFlags?.includes("blocked.malware") ?? false);
   return {
     isPendingScan,
     isMalwareBlocked,

--- a/convex/lib/skillSearchDigest.test.ts
+++ b/convex/lib/skillSearchDigest.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment node */
 
 import { describe, expect, it } from "vitest";
+import { toPublicSkill } from "./public";
 import {
   digestToHydratableSkill,
   extractDigestFields,
@@ -90,6 +91,7 @@ describe("extractDigestFields", () => {
       comments: 1,
     });
     expect(digest.moderationFlags).toEqual(["flagged.test"]);
+    expect(digest.moderationVerdict).toBeUndefined();
     expect(digest.isSuspicious).toBe(false);
     expect(digest.createdAt).toBe(1000);
     expect(digest.updatedAt).toBe(2000);
@@ -176,6 +178,14 @@ describe("extractDigestFields", () => {
     const hydratable = digestToHydratableSkill(digest as never);
 
     expect(hydratable.isSuspicious).toBe(true);
+  });
+
+  it("preserves malicious moderation verdicts through digest hydration", () => {
+    const digest = extractDigestFields(makeSkillDoc({ moderationVerdict: "malicious" }) as never);
+    const hydratable = digestToHydratableSkill(digest as never);
+
+    expect(hydratable.moderationVerdict).toBe("malicious");
+    expect(toPublicSkill(hydratable)).toBeNull();
   });
 });
 

--- a/convex/lib/skillSearchDigest.ts
+++ b/convex/lib/skillSearchDigest.ts
@@ -42,6 +42,7 @@ const SHARED_KEYS = [
   "softDeletedAt",
   "moderationStatus",
   "moderationFlags",
+  "moderationVerdict",
   "moderationReason",
   "isSuspicious",
   "createdAt",

--- a/convex/maintenance.test.ts
+++ b/convex/maintenance.test.ts
@@ -25,6 +25,9 @@ vi.mock("./_generated/api", () => ({
       backfillSkillFingerprintsInternal: Symbol("backfillSkillFingerprintsInternal"),
       applySkillCapabilityTagsInternal: Symbol("applySkillCapabilityTagsInternal"),
       backfillSkillCapabilityTagsInternal: Symbol("backfillSkillCapabilityTagsInternal"),
+      backfillSkillSearchDigestModerationVerdictsInternal: Symbol(
+        "backfillSkillSearchDigestModerationVerdictsInternal",
+      ),
       getEmptySkillCleanupPageInternal: Symbol("getEmptySkillCleanupPageInternal"),
       applyEmptySkillCleanupInternal: Symbol("applyEmptySkillCleanupInternal"),
       nominateUserForEmptySkillSpamInternal: Symbol("nominateUserForEmptySkillSpamInternal"),
@@ -49,6 +52,7 @@ vi.mock("./lib/skillSummary", () => ({
 const {
   applySkillCapabilityTagsInternal,
   backfillLatestVersionSummaryInternal,
+  backfillSkillSearchDigestModerationVerdictsInternal,
   backfillPublisherStatsInternalHandler,
   backfillSkillFingerprintsInternalHandler,
   backfillSkillSummariesInternalHandler,
@@ -1121,6 +1125,125 @@ describe("maintenance capability tag backfill", () => {
       capabilityTags: ["financial-authority", "can-make-purchases"],
       updatedAt: 987,
     });
+  });
+});
+
+describe("skill search digest moderation verdict backfill", () => {
+  it("patches digest moderation verdicts from canonical skill rows and schedules the next page", async () => {
+    const paginate = vi.fn().mockResolvedValue({
+      page: [
+        {
+          _id: "skillSearchDigest:malicious",
+          skillId: "skills:malicious",
+          moderationVerdict: undefined,
+        },
+        {
+          _id: "skillSearchDigest:clean",
+          skillId: "skills:clean",
+          moderationVerdict: "clean",
+        },
+        {
+          _id: "skillSearchDigest:missing",
+          skillId: "skills:missing",
+          moderationVerdict: undefined,
+        },
+      ],
+      continueCursor: "next-page",
+      isDone: false,
+    });
+    const query = vi.fn().mockReturnValue({ paginate });
+    const get = vi
+      .fn()
+      .mockResolvedValueOnce({
+        _id: "skills:malicious",
+        moderationVerdict: "malicious",
+        updatedAt: 123,
+      })
+      .mockResolvedValueOnce({
+        _id: "skills:clean",
+        moderationVerdict: "clean",
+        updatedAt: 456,
+      })
+      .mockResolvedValueOnce(null);
+    const patch = vi.fn().mockResolvedValue(undefined);
+    const runAfter = vi.fn().mockResolvedValue(undefined);
+
+    const result = await (
+      backfillSkillSearchDigestModerationVerdictsInternal as unknown as { _handler: Function }
+    )._handler(
+      {
+        db: { query, get, patch, normalizeId: vi.fn() },
+        scheduler: { runAfter },
+      } as never,
+      { cursor: "start", batchSize: 25 },
+    );
+
+    expect(result).toEqual({
+      scanned: 3,
+      patched: 1,
+      missingSkills: 1,
+      cursor: "next-page",
+      isDone: false,
+      dryRun: false,
+    });
+    expect(query).toHaveBeenCalledWith("skillSearchDigest");
+    expect(paginate).toHaveBeenCalledWith({ cursor: "start", numItems: 25 });
+    expect(patch).toHaveBeenCalledWith("skillSearchDigest:malicious", {
+      moderationVerdict: "malicious",
+      updatedAt: 123,
+    });
+    expect(runAfter).toHaveBeenCalledWith(
+      0,
+      internal.maintenance.backfillSkillSearchDigestModerationVerdictsInternal,
+      {
+        cursor: "next-page",
+        batchSize: 25,
+        dryRun: false,
+      },
+    );
+  });
+
+  it("reports would-be patches without writing or scheduling in dry run mode", async () => {
+    const paginate = vi.fn().mockResolvedValue({
+      page: [
+        {
+          _id: "skillSearchDigest:malicious",
+          skillId: "skills:malicious",
+          moderationVerdict: undefined,
+        },
+      ],
+      continueCursor: "next-page",
+      isDone: false,
+    });
+    const query = vi.fn().mockReturnValue({ paginate });
+    const get = vi.fn().mockResolvedValue({
+      _id: "skills:malicious",
+      moderationVerdict: "malicious",
+      updatedAt: 123,
+    });
+    const patch = vi.fn().mockResolvedValue(undefined);
+    const runAfter = vi.fn().mockResolvedValue(undefined);
+
+    const result = await (
+      backfillSkillSearchDigestModerationVerdictsInternal as unknown as { _handler: Function }
+    )._handler(
+      {
+        db: { query, get, patch, normalizeId: vi.fn() },
+        scheduler: { runAfter },
+      } as never,
+      { batchSize: 25, dryRun: true },
+    );
+
+    expect(result).toEqual({
+      scanned: 1,
+      patched: 1,
+      missingSkills: 0,
+      cursor: "next-page",
+      isDone: false,
+      dryRun: true,
+    });
+    expect(patch).not.toHaveBeenCalled();
+    expect(runAfter).not.toHaveBeenCalled();
   });
 });
 

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -2137,6 +2137,77 @@ export const backfillLatestVersionSummaryInternal = internalMutation({
   },
 });
 
+export const backfillSkillSearchDigestModerationVerdictsInternal = internalMutation({
+  args: {
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const batchSize = clampInt(args.batchSize ?? 100, 10, 200);
+    const dryRun = args.dryRun ?? false;
+    const { page, continueCursor, isDone } = await ctx.db
+      .query("skillSearchDigest")
+      .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
+
+    let patched = 0;
+    let missingSkills = 0;
+    for (const digest of page) {
+      const skill = await ctx.db.get(digest.skillId);
+      if (!skill) {
+        missingSkills++;
+        continue;
+      }
+      if (digest.moderationVerdict === skill.moderationVerdict) continue;
+
+      patched++;
+      if (!dryRun) {
+        await ctx.db.patch(digest._id, {
+          moderationVerdict: skill.moderationVerdict,
+          updatedAt: skill.updatedAt,
+        });
+      }
+    }
+
+    if (!dryRun && !isDone) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.maintenance.backfillSkillSearchDigestModerationVerdictsInternal,
+        {
+          cursor: continueCursor,
+          batchSize: args.batchSize,
+          dryRun,
+        },
+      );
+    }
+
+    return {
+      scanned: page.length,
+      patched,
+      missingSkills,
+      cursor: continueCursor,
+      isDone,
+      dryRun,
+    };
+  },
+});
+
+export const backfillSkillSearchDigestModerationVerdicts: ReturnType<typeof action> = action({
+  args: {
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const { user } = await requireUserFromAction(ctx);
+    assertRole(user, ["admin"]);
+    return await ctx.runMutation(
+      internal.maintenance.backfillSkillSearchDigestModerationVerdictsInternal,
+      args,
+    );
+  },
+});
+
 // Repair stale skill-level moderation that was sourced from a non-latest version.
 // Run once after deploying the latest-version moderation fix:
 //   npx convex run maintenance:backfillLatestSkillModeration --prod

--- a/convex/publishers.ts
+++ b/convex/publishers.ts
@@ -5,6 +5,7 @@ import type { Doc, Id } from "./_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "./_generated/server";
 import { internalMutation, internalQuery, mutation, query } from "./functions";
 import { assertAdmin, getOptionalActiveAuthUserId, requireUser } from "./lib/access";
+import { isPublicSkillDoc } from "./lib/globalStats";
 import { isOfficialPublisher, toPublicPublisherWithOfficial } from "./lib/officialPublishers";
 import { toPublicPublisher } from "./lib/public";
 import {
@@ -99,7 +100,7 @@ type PublisherListSummary = {
 };
 
 function isPublicPublishedSkill(skill: Doc<"skills">) {
-  return !skill.softDeletedAt && (!skill.moderationStatus || skill.moderationStatus === "active");
+  return isPublicSkillDoc(skill);
 }
 
 type PublicPublisherKindFilter = "user" | "org";

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1069,6 +1069,9 @@ const skillSearchDigest = defineTable({
   softDeletedAt: v.optional(v.number()),
   moderationStatus: moderationStatusValidator,
   moderationFlags: v.optional(v.array(v.string())),
+  moderationVerdict: v.optional(
+    v.union(v.literal("clean"), v.literal("suspicious"), v.literal("malicious")),
+  ),
   moderationReason: v.optional(v.string()),
   isSuspicious: v.optional(v.boolean()),
   createdAt: v.number(),

--- a/convex/skills.public.test.ts
+++ b/convex/skills.public.test.ts
@@ -16,6 +16,7 @@ const { getAuthUserId } = await import("@convex-dev/auth/server");
 const { getSkillBadgeMap } = await import("./lib/badges");
 const {
   getBySlug,
+  getVerifyTargetBySlugInternal,
   listSkillReportsInternal,
   resolveVersionByHash,
   resolveSkillAppealForUserInternal,
@@ -71,6 +72,23 @@ const getBySlugHandler = (
           handle: string | null;
           userId: string | null;
         };
+      } | null;
+    } | null
+  >
+)._handler;
+
+const getVerifyTargetBySlugInternalHandler = (
+  getVerifyTargetBySlugInternal as unknown as WrappedHandler<
+    {
+      slug: string;
+    },
+    {
+      skill?: {
+        slug: string;
+        displayName: string;
+      } | null;
+      moderationInfo?: {
+        isMalwareBlocked: boolean;
       } | null;
     } | null
   >
@@ -715,6 +733,54 @@ describe("skills.getBySlug", () => {
     const result = await getBySlugHandler(ctx, { slug: "demo" } as never);
 
     expect(result?.latestVersion).toBeNull();
+  });
+
+  it("hides malware-blocked skills from the public detail query", async () => {
+    const ctx = makeCtx({
+      skill: makeSkill({
+        moderationStatus: "hidden",
+        moderationVerdict: "malicious",
+        moderationFlags: ["blocked.malware"],
+      }),
+      owner: makeOwner("users:1", "demo-owner"),
+    });
+
+    const result = await getBySlugHandler(ctx, { slug: "demo" } as never);
+
+    expect(result).toBeNull();
+  });
+
+  it("hides active skills with a malicious moderation verdict from owners too", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:1" as never);
+    const ctx = makeCtx({
+      skill: makeSkill({
+        moderationStatus: "active",
+        moderationVerdict: "malicious",
+      }),
+      owner: makeOwner("users:1", "demo-owner"),
+      ownersById: {
+        "users:1": makeOwner("users:1", "demo-owner"),
+      },
+    });
+
+    const result = await getBySlugHandler(ctx, { slug: "demo" } as never);
+
+    expect(result).toBeNull();
+  });
+
+  it("keeps malware-blocked skills available to verification lookups", async () => {
+    const ctx = makeCtx({
+      skill: makeSkill({
+        moderationStatus: "active",
+        moderationVerdict: "malicious",
+      }),
+      owner: makeOwner("users:1", "demo-owner"),
+    });
+
+    const result = await getVerifyTargetBySlugInternalHandler(ctx, { slug: "demo" } as never);
+
+    expect(result?.skill?.slug).toBe("demo");
+    expect(result?.moderationInfo?.isMalwareBlocked).toBe(true);
   });
 });
 

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -2542,16 +2542,19 @@ export const getBySlug = query({
     const overrideActive = Boolean(skill.manualOverride);
     const isPendingScan =
       skill.moderationStatus === "hidden" && skill.moderationReason === "pending.scan";
-    const isMalwareBlocked = skill.moderationFlags?.includes("blocked.malware") ?? false;
+    const isMalwareBlocked =
+      skill.moderationVerdict === "malicious" ||
+      (skill.moderationFlags?.includes("blocked.malware") ?? false);
     const isSuspicious = skill.moderationFlags?.includes("flagged.suspicious") ?? false;
     const isReviewFlagged = isSkillReviewFlagged(skill);
     const isHiddenByMod =
       skill.moderationStatus === "hidden" && !isPendingScan && !isMalwareBlocked;
     const isRemoved = skill.moderationStatus === "removed";
 
-    // Non-owners can see malware-blocked skills (transparency), but not other hidden states
-    // Owners can see all their moderated skills
-    if (!publicSkill && !isOwner && !isMalwareBlocked) return null;
+    if (isMalwareBlocked) return null;
+
+    // Owners can see their non-malicious moderated skills.
+    if (!publicSkill && !isOwner) return null;
 
     // For owners viewing their moderated skill, construct the response manually
     const skillData = publicSkill ?? {
@@ -2644,6 +2647,70 @@ export const getBySlug = query({
             },
           }
         : null,
+    };
+  },
+});
+
+export const getVerifyTargetBySlugInternal = internalQuery({
+  args: { slug: v.string() },
+  handler: async (ctx, args) => {
+    const resolved = await resolveSkillBySlugOrAlias(ctx, args.slug);
+    const skill = resolved.skill;
+    if (!skill) return null;
+
+    const isMalwareBlocked =
+      skill.moderationVerdict === "malicious" ||
+      (skill.moderationFlags?.includes("blocked.malware") ?? false);
+    if (!isMalwareBlocked && !isPublicSkillDoc(skill)) return null;
+
+    const owner = toPublicPublisher(
+      await getOwnerPublisher(ctx, {
+        ownerPublisherId: skill.ownerPublisherId,
+        ownerUserId: skill.ownerUserId,
+      }),
+    );
+    if (!owner) return null;
+
+    const isPendingScan =
+      skill.moderationStatus === "hidden" && skill.moderationReason === "pending.scan";
+    const isSuspicious = skill.moderationFlags?.includes("flagged.suspicious") ?? false;
+    const isReviewFlagged = isSkillReviewFlagged(skill);
+    const overrideActive = Boolean(skill.manualOverride);
+    const isHiddenByMod =
+      skill.moderationStatus === "hidden" && !isPendingScan && !isMalwareBlocked;
+    const isRemoved = skill.moderationStatus === "removed";
+
+    return {
+      requestedSlug: resolved.requestedSlug,
+      resolvedSlug: resolved.resolvedSlug,
+      skill: {
+        _id: skill._id,
+        slug: skill.slug,
+        displayName: skill.displayName,
+        summary: skill.summary,
+        tags: skill.tags,
+        stats: skill.stats,
+        createdAt: skill.createdAt,
+        updatedAt: skill.updatedAt,
+        latestVersionId: skill.latestVersionId,
+      },
+      latestVersion: null,
+      owner,
+      moderationInfo: {
+        isPendingScan,
+        isMalwareBlocked,
+        isSuspicious,
+        isReviewFlagged,
+        isHiddenByMod,
+        isRemoved,
+        overrideActive,
+        verdict: skill.moderationVerdict,
+        reasonCodes: skill.moderationReasonCodes,
+        summary: skill.moderationSummary,
+        engineVersion: skill.moderationEngineVersion,
+        updatedAt: skill.moderationEvaluatedAt,
+        sourceVersionId: skill.moderationSourceVersionId ?? null,
+      },
     };
   },
 });
@@ -3068,11 +3135,13 @@ export const getSecurityVerdictTargetInternal = internalQuery({
     const skill = resolved.skill;
     if (!skill) return null;
 
-    const isMalwareBlocked = skill.moderationFlags?.includes("blocked.malware") ?? false;
+    const isMalwareBlocked =
+      skill.moderationVerdict === "malicious" ||
+      (skill.moderationFlags?.includes("blocked.malware") ?? false);
     const isSuspicious = skill.moderationFlags?.includes("flagged.suspicious") ?? false;
     const isReviewFlagged = isSkillReviewFlagged(skill);
     const overrideActive = Boolean(skill.manualOverride);
-    if (!isPublicSkillDoc(skill) && !isMalwareBlocked) return null;
+    if (!isMalwareBlocked && !isPublicSkillDoc(skill)) return null;
 
     const owner = toPublicPublisher(
       await getOwnerPublisher(ctx, {

--- a/src/components/DetailSecuritySummary.test.tsx
+++ b/src/components/DetailSecuritySummary.test.tsx
@@ -32,8 +32,8 @@ describe("DetailSecuritySummary", () => {
     expect(
       screen.queryByText("Security checks across malware telemetry and agentic risk"),
     ).toBeNull();
-    expect(document.querySelector(".security-audit-meter")?.getAttribute("data-level")).toBe("4");
-    expect(document.querySelectorAll(".security-audit-meter span")).toHaveLength(4);
+    expect(document.querySelector(".security-audit-meter")?.getAttribute("data-level")).toBe("3");
+    expect(document.querySelectorAll(".security-audit-meter span")).toHaveLength(3);
   });
 
   it("renders GitHub-backed scan status when no version-backed scan exists", () => {
@@ -125,7 +125,8 @@ describe("DetailSecuritySummary", () => {
       />,
     );
 
-    expect(screen.getAllByText("Warn").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Review").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Warn")).toBeNull();
     expect(screen.queryByText("Suspicious")).toBeNull();
   });
 
@@ -140,7 +141,7 @@ describe("DetailSecuritySummary", () => {
 
     expect(screen.getByText("Pass")).toBeTruthy();
     expect(screen.queryByText("Benign")).toBeNull();
-    expect(document.querySelector(".security-audit-meter")?.getAttribute("data-level")).toBe("4");
+    expect(document.querySelector(".security-audit-meter")?.getAttribute("data-level")).toBe("3");
   });
 
   it("renders malicious ClawScan outcomes with the lowest safety meter level", () => {

--- a/src/components/DetailSecuritySummary.tsx
+++ b/src/components/DetailSecuritySummary.tsx
@@ -18,13 +18,12 @@ function auditVerdictMeterLevel(status: string) {
     case "warn":
     case "warning":
     case "suspicious":
-      return 2;
     case "review":
-      return 3;
+      return 2;
     case "benign":
     case "clean":
     case "cleared":
-      return 4;
+      return 3;
     default:
       return 0;
   }
@@ -54,7 +53,6 @@ export function DetailSecuritySummary({
           {auditVerdictInfo.label}
         </span>
         <div className="security-audit-meter" data-level={meterLevel} aria-hidden="true">
-          <span />
           <span />
           <span />
           <span />

--- a/src/components/SkillSecurityScanResults.test.tsx
+++ b/src/components/SkillSecurityScanResults.test.tsx
@@ -322,10 +322,10 @@ describe("SecurityScanResults static guidance", () => {
     expect(screen.queryByText(/Confidence/i)).toBeNull();
   });
 
-  it("shows the ClawScan verdict without a rolled-up risk level in the scan panel", () => {
+  it("shows suspicious ClawScan verdicts as review without a rolled-up risk level", () => {
     render(<SecurityScanResults llmAnalysis={clawScanAnalysis} />);
 
-    expect(screen.getByText("Warn")).toBeTruthy();
+    expect(screen.getByText("Review")).toBeTruthy();
     expect(screen.queryByText("High")).toBeNull();
     expect(screen.queryByText(/high confidence/i)).toBeNull();
     expect(screen.queryByText(/Suspicious/i)).toBeNull();
@@ -465,7 +465,7 @@ describe("SecurityScanResults static guidance", () => {
     );
 
     expect(screen.getByRole("heading", { name: "Todo Guard" })).toBeTruthy();
-    expect(screen.getAllByText("Warn").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Review").length).toBeGreaterThan(0);
     expect(screen.queryByText("Risk")).toBeNull();
     expect(screen.queryByText("ClawScan risk")).toBeNull();
     expect(

--- a/src/components/SkillSecurityScanResults.tsx
+++ b/src/components/SkillSecurityScanResults.tsx
@@ -175,10 +175,10 @@ export function getScanStatusInfo(status: string) {
         badgeVariant: "destructive",
       };
     case "review":
-      return { label: "Review", className: "scan-status-review", badgeVariant: "review" };
+    case "suspicious":
+      return { label: "Review", className: "scan-status-warn", badgeVariant: "warning" };
     case "warn":
     case "warning":
-    case "suspicious":
       return { label: "Warn", className: "scan-status-warn", badgeVariant: "warning" };
     case "advisory":
       return { label: "Advisory", className: "scan-status-unknown", badgeVariant: "compact" };
@@ -237,7 +237,7 @@ export function getClawScanDisplayStatus(analysis?: LlmAnalysis | null) {
   if (!status) return "pending";
   const highestSeverity = highestVisibleFindingSeverityRank(analysis);
   if (status === "suspicious") {
-    return highestSeverity >= severityRank("high") ? "warn" : "review";
+    return "review";
   }
   if ((status === "clean" || status === "benign") && highestSeverity >= severityRank("medium")) {
     return "review";
@@ -276,16 +276,13 @@ export function ScanResultBadge({
   status,
   label,
   className,
-  tone,
 }: {
   status: string;
   label?: string;
   className?: string;
-  tone?: "review";
 }) {
   const statusInfo = getScanStatusInfo(status);
-  const variant =
-    tone === "review" && statusInfo.label === "Review" ? "review" : statusInfo.badgeVariant;
+  const variant = statusInfo.badgeVariant;
   return (
     <Badge
       variant={variant as BadgeProps["variant"]}
@@ -712,7 +709,7 @@ export function SecurityScanResults({
         {llmStatusInfo ? (
           <div className="version-scan-badge">
             <ClawScanIcon className="version-scan-icon version-scan-icon-oc" />
-            <ScanResultBadge status={llmDisplayStatus} tone="review" />
+            <ScanResultBadge status={llmDisplayStatus} />
           </div>
         ) : null}
       </>
@@ -764,7 +761,7 @@ export function SecurityScanResults({
               <ClawScanIcon className="scan-result-icon scan-result-icon-oc" />
               <span className="scan-result-scanner-name">ClawScan</span>
             </div>
-            <ScanResultBadge status={llmDisplayStatus} tone="review" />
+            <ScanResultBadge status={llmDisplayStatus} />
           </div>
         ) : null}
         {llmAnalysis &&

--- a/src/styles.css
+++ b/src/styles.css
@@ -4700,7 +4700,7 @@ code {
 
 .security-audit-meter {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 6px;
   height: 6px;
 }
@@ -4718,11 +4718,7 @@ code {
   background: #f1b85a;
 }
 
-.security-audit-meter[data-level="3"] span:nth-child(-n + 3) {
-  background: #6aa9ff;
-}
-
-.security-audit-meter[data-level="4"] span {
+.security-audit-meter[data-level="3"] span {
   background: #79e68e;
 }
 


### PR DESCRIPTION
## Summary

- Hide `malicious` ClawScan/moderation verdict skills from public detail, list, search, export, and mirror surfaces using the shared visibility predicate.
- Keep verification/security-verdict APIs explicit for blocked skills, including suppressing dead skill-card URLs for malware-blocked verify responses.
- Normalize suspicious/review UI to a 3-bar audit meter with a yellow `Review` label instead of a fourth warn state.
- Add a cursor/dry-run maintenance backfill for `skillSearchDigest.moderationVerdict` so existing digest rows can participate in the new visibility filter.

## Validation

- `bunx convex codegen`
- `bunx vitest run convex/lib/skillFileAccess.test.ts convex/maintenance.test.ts convex/functions.test.ts convex/lib/skillSearchDigest.test.ts convex/lib/public.test.ts convex/skills.public.test.ts convex/httpApiV1.handlers.test.ts src/components/DetailSecuritySummary.test.tsx src/components/SkillSecurityScanResults.test.tsx`
- `bunx tsc --noEmit`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bun run ci:packages`

## Deployment note

- After backend deploy, run the new digest moderation-verdict backfill first as a dry run and then apply it so existing `skillSearchDigest` rows mirror their canonical `skills.moderationVerdict` values.
