### PR TITLE
docs: add clawhub 0.20.2 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## Unreleased
+## 0.20.2 - 2026-06-11
 
 ### Changes
 
 - CLI packages now require Node.js 22 or newer, dropping the EOL Node 20 runtime floor.
+- CLI: add `clawhub package validate <source>` for local plugin validation with author-facing Plugin Inspector findings, remediation text, and report artifacts.
 
 ## 0.20.0 - 2026-06-06
 


### PR DESCRIPTION
## Summary
- add the missing 0.20.2 changelog section required by the CLI npm release workflow

## Tests
- `node scripts/extract-changelog-release.mjs --tag v0.20.2 --changelog CHANGELOG.md`
- `RELEASE_TAG=v0.20.2 RELEASE_SHA=553bb85a4f463a3a19d8671f9f3cab0905040218 RELEASE_MAIN_REF=origin/main node scripts/clawhub-cli-npm-release-check.mjs`