### PR TITLE
docs: recommend pinned package publish workflow

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -672,7 +672,7 @@ on:
 jobs:
   dry-run:
     if: github.event_name == 'pull_request'
-    uses: openclaw/clawhub/.github/workflows/package-publish.yml@v0.12.0
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@{{CLAWHUB_NPM_RELEASE_TAG}}
     with:
       dry_run: true
 
@@ -681,19 +681,35 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: openclaw/clawhub/.github/workflows/package-publish.yml@v0.12.0
+    uses: openclaw/clawhub/.github/workflows/package-publish.yml@{{CLAWHUB_NPM_RELEASE_TAG}}
     with:
       dry_run: false
     secrets:
       clawhub_token: ${{ secrets.CLAWHUB_TOKEN }}
 ```
 
+Dependabot updates:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+
+Enable GitHub Actions Dependabot updates so your repository gets a Dependabot PR
+when ClawHub publishes a newer official workflow version.
+
 Notes:
 
+- `{{CLAWHUB_NPM_RELEASE_TAG}}` is filled by the docs sync from the current
+  `packages/clawhub/package.json` version with a `v` prefix.
 - The reusable workflow defaults `source` to the caller repo.
 - For monorepos, pass `source_path` so the workflow publishes the plugin
   package folder, for example `source_path: extensions/codex`.
-- Pin the reusable workflow to a stable tag or full commit SHA. Do not run release publishing from `@main`.
+- Pin the reusable workflow to a stable ClawHub release tag. Do not run release publishing from `@main`.
 - `pull_request` should use `dry_run: true` so CI stays non-polluting.
 - Real publishes should be limited to trusted events such as `workflow_dispatch` or tag pushes.
 - Trusted publishing without a secret only works on `workflow_dispatch`; tag pushes still need `clawhub_token`.

--- a/packages/clawhub/README.md
+++ b/packages/clawhub/README.md
@@ -120,17 +120,6 @@ Minimal example:
 `openclaw.build.pluginSdkVersion` when you want richer compatibility metadata,
 but they are not required for publish.
 
-## GitHub Actions
-
-This repo also provides an official reusable workflow for plugin repos:
-
-- [`.github/workflows/package-publish.yml`](../../.github/workflows/package-publish.yml)
-
-Use `dry_run: true` on pull requests and reserve real publishes for trusted events
-such as `workflow_dispatch` or tag pushes with a `CLAWHUB_TOKEN` secret.
-For monorepos, pass `source_path` to publish the plugin package folder, for
-example `source_path: extensions/codex`.
-
 ## Maintainers
 
 The `clawhub` npm package is released separately from the ClawHub app deploy.


### PR DESCRIPTION
## Summary

- update the package publish workflow example to use `{{CLAWHUB_NPM_RELEASE_TAG}}`, which is interpolated by OpenClaw docs sync from `packages/clawhub/package.json`
- add Dependabot `github-actions` setup guidance so publishers get update PRs for newer official workflow releases
- remove the GitHub Actions workflow section from the npm package README so the package README does not carry stale workflow setup docs

## Dependency

- Requires OpenClaw docs sync support: https://github.com/openclaw/openclaw/pull/92252

## Tests

- `git diff --check origin/main -- docs/cli.md packages/clawhub/README.md`
- `bun run format:check -- docs/cli.md packages/clawhub/README.md`
- OpenClaw docs sync smoke rendered `{{CLAWHUB_NPM_RELEASE_TAG}}` to `v0.20.2`
