### PR TITLE
fix: block malicious skill versions on download

### DIFF
--- a/convex/downloads.test.ts
+++ b/convex/downloads.test.ts
@@ -210,6 +210,83 @@ describe("downloads helpers", () => {
     expect(storageGet).not.toHaveBeenCalled();
   });
 
+  it("blocks the exact requested skill version when its ClawScan verdict is malicious", async () => {
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      if ("slug" in args) {
+        return {
+          skill: {
+            _id: "skills:1",
+            ownerUserId: "users:1",
+            slug: "demo",
+            tags: {},
+            latestVersionId: "skillVersions:2",
+          },
+          moderationInfo: {
+            isMalwareBlocked: false,
+            isPendingScan: false,
+            isHiddenByMod: false,
+            isRemoved: false,
+          },
+        };
+      }
+      if ("skillId" in args && "version" in args) {
+        return {
+          _id: "skillVersions:1",
+          skillId: "skills:1",
+          version: "1.0.0",
+          createdAt: 3,
+          files: [{ path: "SKILL.md", storageId: "_storage:bad" }],
+          softDeletedAt: undefined,
+          llmAnalysis: {
+            status: "completed",
+            verdict: "malicious",
+            checkedAt: 4,
+          },
+        };
+      }
+      if (args.versionId === "skillVersions:2") {
+        return {
+          _id: "skillVersions:2",
+          skillId: "skills:1",
+          version: "1.0.1",
+          createdAt: 5,
+          files: [],
+          softDeletedAt: undefined,
+          llmAnalysis: {
+            status: "completed",
+            verdict: "clean",
+            checkedAt: 6,
+          },
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      return null;
+    });
+    const storageGet = vi.fn();
+
+    const response = await downloadZipHandler(
+      {
+        runQuery,
+        runMutation,
+        scheduler: { runAfter: vi.fn() },
+        storage: { get: storageGet },
+      } as unknown as ActionCtx,
+      new Request("https://example.com/api/v1/download?slug=demo&version=1.0.0", {
+        headers: { "cf-connecting-ip": "1.2.3.4" },
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe(
+      "Blocked: this skill version has been flagged as malicious by ClawScan and cannot be downloaded.",
+    );
+    expect(storageGet).not.toHaveBeenCalled();
+  });
+
   it("uses API token user identity for zip download stats when present", async () => {
     stubZipResponse();
 

--- a/convex/downloads.ts
+++ b/convex/downloads.ts
@@ -7,7 +7,7 @@ import { getOptionalActiveAuthUserIdFromAction } from "./lib/access";
 import { getOptionalApiTokenUserId } from "./lib/apiTokenAuth";
 import { corsHeaders, mergeHeaders } from "./lib/httpHeaders";
 import { applyRateLimit, getClientIp } from "./lib/httpRateLimit";
-import { getPublicSkillFileAccessBlock, isSkillVersionForSkill } from "./lib/skillFileAccess";
+import { getPublicSkillVersionDownloadBlock, isSkillVersionForSkill } from "./lib/skillFileAccess";
 import { buildDeterministicZip } from "./lib/skillZip";
 import { insertStatEvent } from "./skillStatEvents";
 
@@ -44,14 +44,6 @@ export async function downloadZipHandler(
     });
   }
 
-  const moderationBlock = getPublicSkillFileAccessBlock(skillResult.moderationInfo);
-  if (moderationBlock) {
-    return new Response(moderationBlock.message, {
-      status: moderationBlock.status,
-      headers: mergeHeaders(rate.headers, corsHeaders()),
-    });
-  }
-
   const skill = skillResult.skill;
   let version = skill.latestVersionId
     ? await ctx.runQuery(internal.skills.getVersionByIdInternal, {
@@ -80,6 +72,18 @@ export async function downloadZipHandler(
   if (version.softDeletedAt) {
     return new Response("Version not available", {
       status: 410,
+      headers: mergeHeaders(rate.headers, corsHeaders()),
+    });
+  }
+
+  const moderationBlock = getPublicSkillVersionDownloadBlock(
+    skillResult.moderationInfo,
+    version,
+    skill.latestVersionId ?? skill.tags.latest,
+  );
+  if (moderationBlock) {
+    return new Response(moderationBlock.message, {
+      status: moderationBlock.status,
       headers: mergeHeaders(rate.headers, corsHeaders()),
     });
   }

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -4314,6 +4314,15 @@ describe("httpApiV1 handlers", () => {
           },
         };
       }
+      if (args.versionId === "skillVersions:1") {
+        return {
+          _id: "skillVersions:1",
+          skillId: "skills:1",
+          version: "1.0.0",
+          files: [{ path: "SKILL.md", size: 5, storageId: "storage:1", sha256: "abcd" }],
+          softDeletedAt: undefined,
+        };
+      }
       throw new Error("unexpected version lookup");
     });
     const runMutation = vi.fn().mockResolvedValue(okRate());
@@ -4459,6 +4468,15 @@ describe("httpApiV1 handlers", () => {
             isHiddenByMod: false,
             isRemoved: false,
           },
+        };
+      }
+      if (args.versionId === "skillVersions:1") {
+        return {
+          _id: "skillVersions:1",
+          skillId: "skills:1",
+          version: "1.0.0",
+          files: [{ path: "skill-card.md", size: 5, storageId: "storage:card", sha256: "card" }],
+          softDeletedAt: undefined,
         };
       }
       throw new Error("unexpected version lookup");
@@ -8135,6 +8153,15 @@ describe("httpApiV1 handlers", () => {
             isHiddenByMod: false,
             isRemoved: false,
           },
+        };
+      }
+      if (args.versionId === "skillVersions:demo-1") {
+        return {
+          _id: "skillVersions:demo-1",
+          skillId: "skills:demo",
+          version: "1.0.0",
+          files: [{ path: "SKILL.md", size: 5, storageId: "storage:skill", sha256: "skill" }],
+          softDeletedAt: undefined,
         };
       }
       throw new Error("unexpected version lookup");

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -54,8 +54,8 @@ import {
   MAX_PUBLISH_TOTAL_BYTES,
 } from "../lib/publishLimits";
 import {
-  getPublicSkillFileAccessBlock,
   getPublicSkillVersionAccessBlock,
+  getPublicSkillVersionDownloadBlock,
   getSkillFileModerationInfoFromSkill,
   isSkillVersionForSkill,
 } from "../lib/skillFileAccess";
@@ -3530,11 +3530,17 @@ export async function packagesGetRouterV1Handler(ctx: ActionCtx, request: Reques
     const path = new URL(request.url).searchParams.get("path")?.trim();
     if (!path) return text("Missing path", 400, rate.headers);
     if (skillDetail?.skill) {
-      const moderationBlock = getPublicSkillFileAccessBlock(skillDetail.moderationInfo);
-      if (moderationBlock)
-        return text(moderationBlock.message, moderationBlock.status, rate.headers);
       const version = await getSkillVersionForRequest(ctx, skillDetail.skill, request);
       if (!version || version.softDeletedAt) return text("Version not found", 404, rate.headers);
+      const effectiveLatestVersionId =
+        skillDetail.skill.latestVersionId ?? skillDetail.skill.tags?.latest;
+      const moderationBlock = getPublicSkillVersionDownloadBlock(
+        skillDetail.moderationInfo,
+        version,
+        effectiveLatestVersionId,
+      );
+      if (moderationBlock)
+        return text(moderationBlock.message, moderationBlock.status, rate.headers);
       const file = resolveSkillFilePath(version, path);
       if (!file) return text("File not found", 404, rate.headers);
       if (!("storageId" in file) || !file.storageId)

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -34,8 +34,8 @@ import type {
 } from "../lib/securityPrompt";
 import { selectGeneratedSkillCardFile, sourceSkillVersionFiles } from "../lib/skillCards";
 import {
-  getPublicSkillFileAccessBlock,
   getPublicSkillVersionAccessBlock,
+  getPublicSkillVersionDownloadBlock,
   getSkillFileModerationInfoFromSkill,
   isSkillVersionForSkill,
 } from "../lib/skillFileAccess";
@@ -2122,10 +2122,6 @@ export async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request)
       if (hidden) return text(hidden.message, hidden.status, rate.headers);
       return text("Skill not found", 404, rate.headers);
     }
-    const moderationBlock = getPublicSkillFileAccessBlock(skillResult.moderationInfo);
-    if (moderationBlock) {
-      return text(moderationBlock.message, moderationBlock.status, rate.headers);
-    }
 
     let version: Doc<"skillVersions"> | null = skillResult.skill.latestVersionId
       ? await ctx.runQuery(internal.skills.getVersionByIdInternal, {
@@ -2148,6 +2144,16 @@ export async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request)
       return text("Version not found", 404, rate.headers);
     }
     if (version.softDeletedAt) return text("Version not available", 410, rate.headers);
+    const effectiveLatestVersionId =
+      skillResult.skill.latestVersionId ?? skillResult.skill.tags?.latest;
+    const moderationBlock = getPublicSkillVersionDownloadBlock(
+      skillResult.moderationInfo,
+      version,
+      effectiveLatestVersionId,
+    );
+    if (moderationBlock) {
+      return text(moderationBlock.message, moderationBlock.status, rate.headers);
+    }
 
     const fingerprintEntries = ((await ctx.runQuery(
       internal.skills.listVersionFingerprintsInternal,
@@ -2181,10 +2187,6 @@ export async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request)
 
     const skillResult = (await ctx.runQuery(api.skills.getBySlug, { slug })) as GetBySlugResult;
     if (!skillResult?.skill) return text("Skill not found", 404, rate.headers);
-    const moderationBlock = getPublicSkillFileAccessBlock(skillResult.moderationInfo);
-    if (moderationBlock) {
-      return text(moderationBlock.message, moderationBlock.status, rate.headers);
-    }
 
     let version: Doc<"skillVersions"> | null = skillResult.skill.latestVersionId
       ? await ctx.runQuery(internal.skills.getVersionByIdInternal, {
@@ -2207,6 +2209,16 @@ export async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request)
       return text("Version not found", 404, rate.headers);
     }
     if (version.softDeletedAt) return text("Version not available", 410, rate.headers);
+    const effectiveLatestVersionId =
+      skillResult.skill.latestVersionId ?? skillResult.skill.tags?.latest;
+    const moderationBlock = getPublicSkillVersionDownloadBlock(
+      skillResult.moderationInfo,
+      version,
+      effectiveLatestVersionId,
+    );
+    if (moderationBlock) {
+      return text(moderationBlock.message, moderationBlock.status, rate.headers);
+    }
 
     const normalized = path.trim();
     const normalizedLower = normalized.toLowerCase();

--- a/convex/lib/skillFileAccess.ts
+++ b/convex/lib/skillFileAccess.ts
@@ -8,6 +8,14 @@ export type SkillFileModerationInfo = {
   sourceVersionId?: Id<"skillVersions"> | string | null;
 };
 
+type SkillVersionSecuritySource = {
+  _id: Id<"skillVersions"> | string;
+  llmAnalysis?: {
+    status?: string | null;
+    verdict?: string | null;
+  } | null;
+};
+
 type SkillModerationSource = {
   moderationStatus?: string | null;
   moderationReason?: string | null;
@@ -28,6 +36,15 @@ function isPendingSkillModerationReason(reason: string | null | undefined) {
     normalized === "scanner.vt.pending" ||
     normalized === "scanner.llm.pending"
   );
+}
+
+function normalizeSkillScanStatus(status: string | null | undefined) {
+  const normalized = status?.trim().toLowerCase();
+  if (normalized === "benign") return "clean";
+  if (normalized === "clean" || normalized === "suspicious" || normalized === "malicious") {
+    return normalized;
+  }
+  return null;
 }
 
 export function getSkillFileModerationInfoFromSkill(
@@ -82,6 +99,32 @@ export function getPublicSkillVersionAccessBlock(
 
   const moderatedVersionId = moderationInfo?.sourceVersionId ?? fallbackModeratedVersionId;
   return moderatedVersionId === versionId ? block : null;
+}
+
+export function getPublicSkillVersionDownloadBlock(
+  moderationInfo: SkillFileModerationInfo | null | undefined,
+  version: SkillVersionSecuritySource,
+  fallbackModeratedVersionId?: Id<"skillVersions"> | string | null,
+): SkillFileAccessBlock | null {
+  const moderationBlock = getPublicSkillVersionAccessBlock(
+    moderationInfo,
+    version._id,
+    fallbackModeratedVersionId,
+  );
+  if (moderationBlock) return moderationBlock;
+
+  const scanStatus = normalizeSkillScanStatus(
+    version.llmAnalysis?.verdict ?? version.llmAnalysis?.status,
+  );
+  if (scanStatus === "malicious") {
+    return {
+      status: 403,
+      message:
+        "Blocked: this skill version has been flagged as malicious by ClawScan and cannot be downloaded.",
+    };
+  }
+
+  return null;
 }
 
 export function isSkillVersionForSkill(


### PR DESCRIPTION
## Summary

- Gate skill ZIP downloads, raw file reads, Skill Card reads, and package-compatible skill file reads against the exact requested skill version.
- Preserve plugin behavior: package downloads/files continue to use release-level security blocking.
- Add regression coverage for an older malicious skill version remaining blocked after the current skill-level moderation state is clean.

## Tests

- `bunx vitest run convex/downloads.test.ts`
- `bunx vitest run convex/httpApiV1.handlers.test.ts`
- `bunx vitest run convex/lib/packageSecurity.test.ts`
- `VITE_CONVEX_URL=https://example.invalid bun run coverage`
- `bun run ci:static`
- `bunx tsc --noEmit`
- `bun run ci:types-build`

## Review Notes

- Autoreview was requested, then explicitly waived. Codex review entered a recursive review loop; Claude and Droid fallback reviewers were unavailable due account/auth issues.
