### PR TITLE
feat: expose package trusted publisher CLI commands

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -700,6 +700,64 @@ Notes:
 - Keep `clawhub_token` available for first publish, untrusted packages, or break-glass publishes.
 - The workflow uploads the JSON result as an artifact and exposes it as workflow outputs.
 
+### `package trusted-publisher get <name>`
+
+- Shows the GitHub Actions trusted publisher config for a package.
+- Use this after setting config to confirm the repository, workflow filename,
+  and optional environment pin.
+- Flags:
+  - `--json`: machine-readable output.
+
+Example:
+
+```bash
+clawhub package trusted-publisher get @openclaw/example-plugin
+```
+
+### `package trusted-publisher set <name>`
+
+- Attaches or replaces GitHub Actions trusted publisher config for an existing
+  package.
+- The package must be created first through normal manual or token-authenticated
+  `clawhub package publish`.
+- After config is set, future supported GitHub Actions publishes can use
+  OIDC/trusted publishing without a long-lived ClawHub token.
+- `--repository <repo>` must be `owner/repo`.
+- `--workflow-filename <file>` must match the workflow file name in
+  `.github/workflows/`.
+- `--environment <name>` is optional. When configured, the GitHub Actions
+  environment in the OIDC claim must match exactly.
+- Flags:
+  - `--repository <repo>`: GitHub repository, for example `openclaw/example-plugin`.
+  - `--workflow-filename <file>`: workflow file name, for example `package-publish.yml`.
+  - `--environment <name>`: optional exact-match GitHub Actions environment.
+  - `--json`: machine-readable output.
+
+Example:
+
+```bash
+clawhub package trusted-publisher set @openclaw/example-plugin \
+  --repository openclaw/example-plugin \
+  --workflow-filename package-publish.yml \
+  --environment release
+```
+
+### `package trusted-publisher delete <name>`
+
+- Removes trusted publisher config from a package.
+- Use this as rollback if the workflow, repository, or environment pin needs to
+  be disabled or re-created.
+- Future real publishes must use normal authenticated publishing until config is
+  set again.
+- Flags:
+  - `--json`: machine-readable output.
+
+Example:
+
+```bash
+clawhub package trusted-publisher delete @openclaw/example-plugin
+```
+
 ### `sync`
 
 - Scans for local skill folders and publishes new/changed ones.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -177,6 +177,43 @@ not control.
 - Expect new releases to stay out of public install surfaces until automated
   security checks and verification finish.
 
+### Trusted Publishing for Packages
+
+Package trusted publishing is a two-step setup:
+
+1. Publish the package once through normal manual or token-authenticated
+   `clawhub package publish`. This creates the package row and establishes the
+   package managers who can change its trusted publisher config.
+2. A package manager sets the GitHub Actions trusted publisher config:
+
+```bash
+clawhub package trusted-publisher set @owner/package-name \
+  --repository owner/repo \
+  --workflow-filename package-publish.yml
+```
+
+After config is set, future supported GitHub Actions publishes can use
+OIDC/trusted publishing without storing a long-lived ClawHub token in the
+repository. The configured repository and workflow filename must match the
+GitHub Actions OIDC claim. If you also pass `--environment <name>`, the GitHub
+Actions environment claim must match that name exactly.
+
+The current reusable package publish workflow supports secretless trusted
+publishing for `workflow_dispatch` publishes when `id-token: write` is
+available. Tag-push real publishes still need `clawhub_token`, so keep
+`CLAWHUB_TOKEN` available for tag releases, first publishes, untrusted packages,
+or break-glass publishes.
+
+Inspect or remove the config with:
+
+```bash
+clawhub package trusted-publisher get @owner/package-name
+clawhub package trusted-publisher delete @owner/package-name
+```
+
+Deleting trusted publisher config is the rollback path. It disables future
+trusted publish token minting until a package manager sets config again.
+
 ## FAQ
 
 ### Package scope must match selected owner

--- a/packages/clawhub/README.md
+++ b/packages/clawhub/README.md
@@ -131,6 +131,24 @@ such as `workflow_dispatch` or tag pushes with a `CLAWHUB_TOKEN` secret.
 For monorepos, pass `source_path` to publish the plugin package folder, for
 example `source_path: extensions/codex`.
 
+Package trusted publishing starts after the first normal authenticated publish
+creates the package row. Then a package manager can attach GitHub Actions OIDC
+config for future supported publishes:
+
+```bash
+clawhub package trusted-publisher set @openclaw/example-plugin \
+  --repository openclaw/example-plugin \
+  --workflow-filename package-publish.yml \
+  --environment release
+
+clawhub package trusted-publisher get @openclaw/example-plugin
+clawhub package trusted-publisher delete @openclaw/example-plugin
+```
+
+`--environment` is optional and exact-match sensitive. If configured, the
+GitHub Actions environment in the OIDC claim must match. Tag-push real publishes
+still need `clawhub_token` unless the reusable workflow adds tag OIDC support.
+
 ## Maintainers
 
 The `clawhub` npm package is released separately from the ClawHub app deploy.

--- a/packages/clawhub/src/cli.ts
+++ b/packages/clawhub/src/cli.ts
@@ -15,6 +15,7 @@ import { cmdInspect, cmdVerifySkill } from "./cli/commands/inspect.js";
 import { cmdMergeSkill, cmdRenameSkill } from "./cli/commands/ownership.js";
 import {
   cmdDeletePackage,
+  cmdDeletePackageTrustedPublisher,
   cmdDownloadPackage,
   cmdExplorePackages,
   cmdGetPackageTrustedPublisher,
@@ -25,6 +26,7 @@ import {
   cmdPackPackage,
   cmdPublishPackage,
   cmdReportPackage,
+  cmdSetPackageTrustedPublisher,
   cmdTransferPackage,
   cmdUndeletePackage,
   cmdValidatePackage,
@@ -706,6 +708,27 @@ registerCommand(trustedPublisherCmd, ["package", "trusted-publisher", "get"])
   .action(async (name, options) => {
     const opts = await resolveGlobalOpts();
     await cmdGetPackageTrustedPublisher(opts, name, options);
+  });
+
+registerCommand(trustedPublisherCmd, ["package", "trusted-publisher", "set"])
+  .description("Set trusted publisher config for a package")
+  .argument("<name>", "Package name")
+  .requiredOption("--repository <repo>", "GitHub repository, for example openclaw/openclaw")
+  .requiredOption("--workflow-filename <file>", "GitHub Actions workflow filename")
+  .option("--environment <name>", "GitHub Actions environment name")
+  .option("--json", "Output JSON")
+  .action(async (name, options) => {
+    const opts = await resolveGlobalOpts();
+    await cmdSetPackageTrustedPublisher(opts, name, options);
+  });
+
+registerCommand(trustedPublisherCmd, ["package", "trusted-publisher", "delete"])
+  .description("Delete trusted publisher config for a package")
+  .argument("<name>", "Package name")
+  .option("--json", "Output JSON")
+  .action(async (name, options) => {
+    const opts = await resolveGlobalOpts();
+    await cmdDeletePackageTrustedPublisher(opts, name, options);
   });
 
 registerCommand(skill, ["skill", "rename"])

--- a/packages/clawhub/src/cli/commands/packages.test.ts
+++ b/packages/clawhub/src/cli/commands/packages.test.ts
@@ -42,6 +42,7 @@ vi.mock("@openclaw/plugin-inspector", () => inspectorMocks);
 
 const {
   cmdDeletePackage,
+  cmdDeletePackageTrustedPublisher,
   cmdDownloadPackage,
   cmdExplorePackages,
   cmdGetPackageTrustedPublisher,
@@ -52,18 +53,17 @@ const {
   cmdPackPackage,
   cmdPublishPackage,
   cmdReportPackage,
+  cmdSetPackageTrustedPublisher,
   cmdTransferPackage,
   cmdUndeletePackage,
   cmdValidatePackage,
   cmdVerifyPackage,
 } = await import("./packages");
 const {
-  cmdDeletePackageTrustedPublisher,
   cmdListPackageMigrations,
   cmdListPackageReports,
   cmdModeratePackageRelease,
   cmdPackageModerationQueue,
-  cmdSetPackageTrustedPublisher,
   cmdTriagePackageReport,
   cmdUpsertPackageMigration,
 } = await import("../../../../clawhub-mod/src/commands/packages");
@@ -2938,6 +2938,23 @@ describe("package commands", () => {
     expect(mockLog).not.toHaveBeenCalledWith(expect.stringContaining("Environment:"));
   });
 
+  it("owns trusted publisher set and delete commands in the public package CLI", async () => {
+    const testSource = await readFile(new URL("./packages.test.ts", import.meta.url), "utf8");
+    const cliSource = await readFile(new URL("../../cli.ts", import.meta.url), "utf8");
+    const modImportPrefix = testSource.split(
+      '} = await import("../../../../clawhub-mod/src/commands/packages");',
+    )[0];
+    const modImportBlock = modImportPrefix ? (modImportPrefix.split("const {").at(-1) ?? "") : "";
+
+    expect(modImportBlock).not.toEqual("");
+    expect(modImportBlock).not.toContain("cmdSetPackageTrustedPublisher");
+    expect(modImportBlock).not.toContain("cmdDeletePackageTrustedPublisher");
+    expect(cliSource).toContain('["package", "trusted-publisher", "set"]');
+    expect(cliSource).toContain('["package", "trusted-publisher", "delete"]');
+    expect(cliSource).toContain("cmdSetPackageTrustedPublisher(opts, name, options)");
+    expect(cliSource).toContain("cmdDeletePackageTrustedPublisher(opts, name, options)");
+  });
+
   it("sets trusted publisher config for a package", async () => {
     httpMocks.apiRequest.mockResolvedValueOnce({
       trustedPublisher: {
@@ -2972,6 +2989,11 @@ describe("package commands", () => {
       }),
       expect.anything(),
     );
+    expect(mockLog).toHaveBeenCalledWith("Trusted publisher saved for @openclaw/zalo.");
+    expect(mockLog).toHaveBeenCalledWith("Provider: github-actions");
+    expect(mockLog).toHaveBeenCalledWith("Repository: openclaw/openclaw");
+    expect(mockLog).toHaveBeenCalledWith("Workflow: plugin-clawhub-release.yml");
+    expect(mockLog).toHaveBeenCalledWith("Environment: clawhub-release");
   });
 
   it("sets trusted publisher config for a package without environment", async () => {
@@ -3020,8 +3042,9 @@ describe("package commands", () => {
         path: "/api/v1/packages/%40openclaw%2Fzalo/trusted-publisher",
         token: "tkn",
       }),
-      undefined,
+      expect.anything(),
     );
+    expect(mockLog).toHaveBeenCalledWith("Trusted publisher deleted for @openclaw/zalo.");
   });
 
   it("soft-deletes a package with confirmation bypass", async () => {

--- a/packages/clawhub/src/cli/commands/packages.ts
+++ b/packages/clawhub/src/cli/commands/packages.ts
@@ -211,6 +211,17 @@ type PackageTrustedPublisherGetOptions = {
   json?: boolean;
 };
 
+type PackageTrustedPublisherSetOptions = {
+  repository?: string;
+  workflowFilename?: string;
+  environment?: string;
+  json?: boolean;
+};
+
+type PackageTrustedPublisherDeleteOptions = {
+  json?: boolean;
+};
+
 type PackageDeleteOptions = {
   yes?: boolean;
   json?: boolean;
@@ -545,6 +556,82 @@ export async function cmdGetPackageTrustedPublisher(
       return;
     }
     printTrustedPublisher(result.trustedPublisher);
+  } catch (error) {
+    spinner.fail(formatError(error));
+    throw error;
+  }
+}
+
+export async function cmdSetPackageTrustedPublisher(
+  opts: GlobalOpts,
+  packageName: string,
+  options: PackageTrustedPublisherSetOptions,
+) {
+  const trimmed = normalizePackageNameOrFail(packageName);
+  const repository = options.repository?.trim();
+  const workflowFilename = options.workflowFilename?.trim();
+  const environment = options.environment?.trim() || undefined;
+  if (!repository) fail("--repository required");
+  if (!workflowFilename) fail("--workflow-filename required");
+
+  const token = await requireAuthToken();
+  const registry = await getRegistry(opts, { cache: true });
+  const spinner = createSpinner("Saving trusted publisher");
+  try {
+    const result = await apiRequest(
+      registry,
+      {
+        method: "POST",
+        path: `${ApiRoutes.packages}/${encodeURIComponent(trimmed)}/trusted-publisher`,
+        token,
+        body: {
+          repository,
+          workflowFilename,
+          ...(environment ? { environment } : {}),
+        },
+      },
+      ApiV1PackageTrustedPublisherResponseSchema,
+    );
+    spinner.stop();
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return;
+    }
+    console.log(`Trusted publisher saved for ${trimmed}.`);
+    if (result.trustedPublisher) {
+      printTrustedPublisher(result.trustedPublisher);
+    }
+  } catch (error) {
+    spinner.fail(formatError(error));
+    throw error;
+  }
+}
+
+export async function cmdDeletePackageTrustedPublisher(
+  opts: GlobalOpts,
+  packageName: string,
+  options: PackageTrustedPublisherDeleteOptions = {},
+) {
+  const trimmed = normalizePackageNameOrFail(packageName);
+  const token = await requireAuthToken();
+  const registry = await getRegistry(opts, { cache: true });
+  const spinner = createSpinner("Deleting trusted publisher");
+  try {
+    const result = await apiRequest(
+      registry,
+      {
+        method: "DELETE",
+        path: `${ApiRoutes.packages}/${encodeURIComponent(trimmed)}/trusted-publisher`,
+        token,
+      },
+      ApiV1DeleteResponseSchema,
+    );
+    spinner.stop();
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      return;
+    }
+    console.log(`Trusted publisher deleted for ${trimmed}.`);
   } catch (error) {
     spinner.fail(formatError(error));
     throw error;

--- a/packages/clawhub/test-artifact/cli.artifact.test.ts
+++ b/packages/clawhub/test-artifact/cli.artifact.test.ts
@@ -232,7 +232,8 @@ describe("built CLI artifact", () => {
   });
 
   it("prints help by default", async () => {
-    const result = runNode([binPath]);
+    const workdir = await makeTmpDir("clawhub-artifact-default-help-");
+    const result = runNode([binPath], { CLAWHUB_CONFIG_PATH: join(workdir, "config.json") });
 
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");


### PR DESCRIPTION
## Summary
- add public `clawhub package trusted-publisher set/delete` commands for package managers
- document the first-publish bootstrap then trusted-publishing setup flow
- isolate the built CLI default-help artifact test from a developer's real local ClawHub login

## Tests
- `bun run --cwd packages/clawhub test:src -- packages.test.ts`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bun run --cwd packages/clawhub build`
- `bun run --cwd packages/clawhub test:artifact`
- `bun run format:check -- docs/cli.md docs/publishing.md packages/clawhub/README.md packages/clawhub/src/cli.ts packages/clawhub/src/cli/commands/packages.ts packages/clawhub/src/cli/commands/packages.test.ts packages/clawhub/test-artifact/cli.artifact.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:packages`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode branch --fallback-reviewer none`

## Notes
- No production trusted-publisher config was mutated.
- This unblocks OpenClaw's CLAW-277 workflow ref bump once merged.
