### PR TITLE
fix: reserve docs owner handle

### DIFF
--- a/convex/lib/publicRouteReservations.test.ts
+++ b/convex/lib/publicRouteReservations.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { isReservedPublicOwnerHandle } from "./publicRouteReservations";
 
 describe("public route reservations", () => {
-  it.each(["admin", "clawhub", "plugins", "skills"])(
+  it.each(["admin", "clawhub", "docs", "plugins", "skills"])(
     "reserves @%s as a public owner handle",
     (handle) => {
       expect(isReservedPublicOwnerHandle(handle)).toBe(true);

--- a/convex/lib/publicRouteReservations.ts
+++ b/convex/lib/publicRouteReservations.ts
@@ -1,4 +1,4 @@
-const RESERVED_PUBLIC_OWNER_HANDLES = new Set(["admin", "clawhub", "plugins", "skills"]);
+const RESERVED_PUBLIC_OWNER_HANDLES = new Set(["admin", "clawhub", "docs", "plugins", "skills"]);
 const RESERVED_UNSCOPED_PACKAGE_NAMES = new Set(["publish"]);
 
 export function isReservedPublicOwnerHandle(handle: string | undefined | null) {

--- a/convex/lib/publishers.test.ts
+++ b/convex/lib/publishers.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import type { Doc } from "../_generated/dataModel";
+import { derivePersonalPublisherHandle } from "./publishers";
+
+function makeUser(overrides: Partial<Doc<"users">>): Doc<"users"> {
+  return {
+    _id: "users:docs",
+    _creationTime: 1,
+    name: "demo",
+    createdAt: 1,
+    ...overrides,
+  } as Doc<"users">;
+}
+
+describe("derivePersonalPublisherHandle", () => {
+  it("does not derive a reserved public owner handle", () => {
+    expect(derivePersonalPublisherHandle(makeUser({ name: "docs" }))).toBe("docs-2");
+  });
+});

--- a/convex/lib/publishers.ts
+++ b/convex/lib/publishers.ts
@@ -1,6 +1,7 @@
 import { ConvexError } from "convex/values";
 import type { Doc, Id } from "../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../_generated/server";
+import { isReservedPublicOwnerHandle } from "./publicRouteReservations";
 
 export type PublisherRole = "owner" | "admin" | "publisher";
 
@@ -29,7 +30,9 @@ function normalizeGeneratedPublisherHandle(handle: string | undefined | null) {
     ?.replace(/[^a-z0-9_-]+/g, "-")
     .replace(/-+/g, "-")
     .replace(/^[-_]+|[-_]+$/g, "");
-  return sanitized || undefined;
+  if (!sanitized) return undefined;
+  if (!isReservedPublicOwnerHandle(sanitized)) return sanitized;
+  return `${sanitized.slice(0, 38)}-2`;
 }
 
 export function derivePersonalPublisherHandle(user: Doc<"users">) {

--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -890,7 +890,7 @@ describe("publishers membership controls", () => {
     });
   });
 
-  it.each(["admin", "skills"])(
+  it.each(["admin", "docs", "skills"])(
     "rejects org handle %s reserved for public routes",
     async (handle) => {
       const ctx = {

--- a/convex/users.test.ts
+++ b/convex/users.test.ts
@@ -31,6 +31,7 @@ const {
   placeUserUnderModerationInternal,
   liftModerationHoldInternal,
   purgeSelfDeletedAccountRecoveryBatchInternal,
+  ensurePublisherHandleInternal,
   reserveHandleInternal,
   syncGitHubProfileInternal,
   updateProfile,
@@ -698,29 +699,32 @@ describe("ensureHandler", () => {
     });
   });
 
-  it("skips public route owner handles when deriving a handle", async () => {
-    const { ctx, patch } = makeCtx();
-    vi.mocked(requireUser).mockResolvedValue({
-      userId: "users:skills",
-      user: {
-        _creationTime: 1,
-        handle: undefined,
-        displayName: undefined,
-        name: "skills",
-        email: undefined,
-        role: "user",
-        createdAt: 1,
-      },
-    } as never);
+  it.each(["docs", "skills"])(
+    "skips public route owner handle %s when deriving a handle",
+    async (handle) => {
+      const { ctx, patch } = makeCtx();
+      vi.mocked(requireUser).mockResolvedValue({
+        userId: `users:${handle}`,
+        user: {
+          _creationTime: 1,
+          handle: undefined,
+          displayName: undefined,
+          name: handle,
+          email: undefined,
+          role: "user",
+          createdAt: 1,
+        },
+      } as never);
 
-    await ensureHandler(ctx);
+      await ensureHandler(ctx);
 
-    expect(patch).toHaveBeenCalledWith("users:skills", {
-      handle: "skills-2",
-      displayName: "skills-2",
-      updatedAt: expect.any(Number),
-    });
-  });
+      expect(patch).toHaveBeenCalledWith(`users:${handle}`, {
+        handle: `${handle}-2`,
+        displayName: `${handle}-2`,
+        updatedAt: expect.any(Number),
+      });
+    },
+  );
 
   it("repairs an existing handle that is no longer claimable", async () => {
     const { ctx, patch, query } = makeCtx();
@@ -1338,6 +1342,30 @@ describe("users.getByHandle", () => {
     expect(publisherUnique).toHaveBeenCalledOnce();
     expect(get).not.toHaveBeenCalled();
     expect(result).toBeNull();
+  });
+});
+
+describe("users.ensurePublisherHandleInternal", () => {
+  it("rejects public route owner handles", async () => {
+    const { ctx, get, insert } = makeCtx();
+    get.mockResolvedValue({ _id: "users:admin", role: "admin" });
+    const handler = (
+      ensurePublisherHandleInternal as unknown as {
+        _handler: (
+          ctx: unknown,
+          args: { actorUserId: string; handle: string; displayName?: string },
+        ) => Promise<unknown>;
+      }
+    )._handler;
+
+    await expect(
+      handler(ctx, {
+        actorUserId: "users:admin",
+        handle: "docs",
+        displayName: "Docs",
+      }),
+    ).rejects.toThrow('Handle "@docs" is reserved for ClawHub routes');
+    expect(insert).not.toHaveBeenCalled();
   });
 });
 

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -12,7 +12,10 @@ import {
 import { isLocalDevAuthEnabled } from "./lib/devAuth";
 import { syncGitHubProfile } from "./lib/githubAccount";
 import { toPublicUser } from "./lib/public";
-import { isReservedPublicOwnerHandle } from "./lib/publicRouteReservations";
+import {
+  formatReservedPublicOwnerHandleMessage,
+  isReservedPublicOwnerHandle,
+} from "./lib/publicRouteReservations";
 import {
   ensurePersonalPublisherForUser,
   getActiveUserByHandleOrPersonalPublisher,
@@ -1982,6 +1985,9 @@ async function ensurePublisherHandleWithActor(
 
   const normalizedHandle = normalizeReservedHandle(args.handle);
   if (!normalizedHandle) throw new Error("Handle required");
+  if (isReservedPublicOwnerHandle(normalizedHandle)) {
+    throw new ConvexError(formatReservedPublicOwnerHandleMessage(normalizedHandle));
+  }
 
   const existing = await ctx.db
     .query("users")


### PR DESCRIPTION
## Summary
- Reserve `docs` as a public owner handle for ClawHub route safety.
- Apply the reservation to org creation, personal publisher handle derivation, and admin ensured publisher handles.
- Add focused coverage for public route reservations and reserved-handle bypass paths.

## Tests
- `bunx vitest run convex/lib/publicRouteReservations.test.ts convex/lib/publishers.test.ts convex/publishers.test.ts convex/users.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`

## Review
- `codex exec --ignore-user-config --ignore-rules --sandbox read-only -C . ...` fallback review: `autoreview clean: no accepted/actionable findings reported`
- Native `codex review --commit HEAD` found the personal publisher bypass; fixed and covered.
- Fallback read-only review found the admin ensured-publisher bypass; fixed and covered.
