### PR TITLE
chore: remove clawscan note remnants

### DIFF
--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -929,21 +929,11 @@ function toPublicPackage(
   };
 }
 
-function omitDeprecatedScanNoteFields(release: Doc<"packageReleases">) {
-  const {
-    clawScanNote: _deprecatedScanNote,
-    clawScanNoteUpdatedAt: _deprecatedScanNoteUpdatedAt,
-    ...publicRelease
-  } = release;
-  return publicRelease;
-}
-
 function toPublicPackageRelease(release: Doc<"packageReleases">) {
-  const publicRelease = omitDeprecatedScanNoteFields(release);
   const sourcePath = release.verification?.sourcePath ?? getReleaseSourcePath(release);
-  if (!release.verification || !sourcePath) return publicRelease;
+  if (!release.verification || !sourcePath) return release;
   return {
-    ...publicRelease,
+    ...release,
     verification: {
       ...release.verification,
       sourcePath,
@@ -2418,10 +2408,7 @@ export const listVersions = query({
       )
       .order("desc")
       .paginate(args.paginationOpts);
-    return {
-      ...result,
-      page: result.page.map(omitDeprecatedScanNoteFields),
-    };
+    return result;
   },
 });
 
@@ -2441,10 +2428,7 @@ export const listVersionsForViewerInternal = internalQuery({
       )
       .order("desc")
       .paginate(args.paginationOpts);
-    return {
-      ...result,
-      page: result.page.map(omitDeprecatedScanNoteFields),
-    };
+    return result;
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -578,8 +578,6 @@ const securityScanJobSourceValidator = v.union(
   v.literal("backfill"),
   v.literal("bulk-rescan"),
   v.literal("manual"),
-  // Deprecated source retained so old queued jobs can drain after feature removal.
-  v.literal("clawscan-note"),
 );
 const skillCardGenerationJobStatusValidator = v.union(
   v.literal("queued"),
@@ -814,10 +812,6 @@ const skillVersions = defineTable({
   }),
   createdBy: v.id("users"),
   createdAt: v.number(),
-  // Deprecated persisted fields from the removed publisher scan-note flow.
-  // Keep until a production cleanup removes them from stored documents.
-  clawScanNote: v.optional(v.string()),
-  clawScanNoteUpdatedAt: v.optional(v.number()),
   softDeletedAt: v.optional(v.number()),
   sha256hash: v.optional(v.string()),
   vtAnalysis: v.optional(vtAnalysisValidator),
@@ -1246,10 +1240,6 @@ const packageReleases = defineTable({
   createdBy: v.id("users"),
   publishActor: packagePublishActorValidator,
   createdAt: v.number(),
-  // Deprecated persisted fields from the removed publisher scan-note flow.
-  // Keep until a production cleanup removes them from stored documents.
-  clawScanNote: v.optional(v.string()),
-  clawScanNoteUpdatedAt: v.optional(v.number()),
   softDeletedAt: v.optional(v.number()),
 })
   .index("by_package", ["packageId"])

--- a/convex/securityScan.test.ts
+++ b/convex/securityScan.test.ts
@@ -1859,12 +1859,6 @@ describe("securityScan", () => {
         createdAt: 100,
         nextRunAt: 100,
       }),
-      makeScanJob({
-        _id: "securityScanJobs:legacy-clawscan-note",
-        source: "clawscan-note",
-        createdAt: 200,
-        nextRunAt: 200,
-      }),
     ]);
 
     const claimed = await claimQueuedJobsInternalHandler(ctx, {
@@ -1879,7 +1873,6 @@ describe("securityScan", () => {
       "securityScanJobs:publish",
       "securityScanJobs:vt-update",
       "securityScanJobs:bulk-rescan",
-      "securityScanJobs:legacy-clawscan-note",
     ]);
   });
 

--- a/convex/securityScan.ts
+++ b/convex/securityScan.ts
@@ -96,24 +96,15 @@ const jobSourceValidator = v.union(
   v.literal("backfill"),
   v.literal("bulk-rescan"),
   v.literal("manual"),
-  // Deprecated source retained so old queued jobs can drain after feature removal.
-  v.literal("clawscan-note"),
 );
 
-type SecurityScanJobSource =
-  | "publish"
-  | "vt-update"
-  | "backfill"
-  | "bulk-rescan"
-  | "manual"
-  | "clawscan-note";
+type SecurityScanJobSource = "publish" | "vt-update" | "backfill" | "bulk-rescan" | "manual";
 
 const CLAIM_SOURCE_ORDER: SecurityScanJobSource[] = [
   "backfill",
   "publish",
   "vt-update",
   "bulk-rescan",
-  "clawscan-note",
 ];
 
 type EnqueueSkillVersionScanArgs = {

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -1994,25 +1994,9 @@ type PublicSkillVersion = {
 
 type ManagementSkillEntry = {
   skill: Doc<"skills">;
-  latestVersion: SkillVersionWithoutDeprecatedScanNote | null;
+  latestVersion: Doc<"skillVersions"> | null;
   owner: Doc<"users"> | null;
 };
-
-type SkillVersionWithoutDeprecatedScanNote = Omit<
-  Doc<"skillVersions">,
-  "clawScanNote" | "clawScanNoteUpdatedAt"
->;
-
-function omitDeprecatedScanNoteFields(
-  version: Doc<"skillVersions">,
-): SkillVersionWithoutDeprecatedScanNote {
-  const {
-    clawScanNote: _deprecatedScanNote,
-    clawScanNoteUpdatedAt: _deprecatedScanNoteUpdatedAt,
-    ...publicVersion
-  } = version;
-  return publicVersion;
-}
 
 type DashboardSkillListItem = {
   _id: Id<"skills">;
@@ -2340,7 +2324,7 @@ async function buildManagementSkillEntries(ctx: QueryCtx, skills: Doc<"skills">[
       const badges = badgeMapBySkillId.get(skill._id) ?? {};
       return {
         skill: { ...skill, badges },
-        latestVersion: latestVersion ? omitDeprecatedScanNoteFields(latestVersion) : null,
+        latestVersion,
         owner,
       };
     }),
@@ -2980,9 +2964,7 @@ export const getBySlugForStaff = query({
       requestedSlug: resolved.requestedSlug,
       resolvedSlug: resolved.resolvedSlug,
       skill: { ...skill, badges },
-      latestVersion: latestVersion
-        ? { ...omitDeprecatedScanNoteFields(latestVersion), generatedSkillCard }
-        : null,
+      latestVersion: latestVersion ? { ...latestVersion, generatedSkillCard } : null,
       owner,
       overrideReviewer,
       auditLogs,
@@ -3816,7 +3798,7 @@ export const listRecentVersions = query({
     const entries = versions.filter((version) => !version.softDeletedAt).slice(0, limit);
 
     const results: Array<{
-      version: SkillVersionWithoutDeprecatedScanNote;
+      version: Doc<"skillVersions">;
       skill: Doc<"skills"> | null;
       owner: Doc<"users"> | null;
     }> = [];
@@ -3824,11 +3806,11 @@ export const listRecentVersions = query({
     for (const version of entries) {
       const skill = await ctx.db.get(version.skillId);
       if (!skill) {
-        results.push({ version: omitDeprecatedScanNoteFields(version), skill: null, owner: null });
+        results.push({ version, skill: null, owner: null });
         continue;
       }
       const owner = await ctx.db.get(skill.ownerUserId);
-      results.push({ version: omitDeprecatedScanNoteFields(version), skill, owner });
+      results.push({ version, skill, owner });
     }
 
     return results;
@@ -3895,7 +3877,7 @@ export const listDuplicateCandidates = query({
 
     const results: Array<{
       skill: Doc<"skills">;
-      latestVersion: SkillVersionWithoutDeprecatedScanNote | null;
+      latestVersion: Doc<"skillVersions"> | null;
       fingerprint: string | null;
       matches: Array<{ skill: Doc<"skills">; owner: Doc<"users"> | null }>;
       owner: Doc<"users"> | null;
@@ -3936,7 +3918,7 @@ export const listDuplicateCandidates = query({
       const owner = isUserId(skill.ownerUserId) ? await ctx.db.get(skill.ownerUserId) : null;
       results.push({
         skill,
-        latestVersion: latestVersion ? omitDeprecatedScanNoteFields(latestVersion) : null,
+        latestVersion,
         fingerprint,
         matches: matchEntries,
         owner,

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -121,11 +121,6 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   owner is deleted/deactivated or when the skill is malicious, hidden, or
   removed. The accept path is the final shared gate before ownership changes,
   so it must cancel the pending transfer before reporting the rejection.
-- Publisher-authored scan notes are no longer part of the ClawScan input
-  contract. ClawScan decisions must be based on submitted artifacts, scanner
-  signals, and staff moderation state, not publisher-supplied explanatory text.
-  Legacy persisted note fields may exist on old rows for schema compatibility,
-  but publish, rescan, API, UI, and prompt paths must ignore them.
 - User-submitted `POST /api/v1/skills/-/scan` upload scans are authenticated but
   ephemeral. They store uploaded files only on `skillScanRequests`, feed the
   normal ClawScan worker, and must never create or patch public `skills`,


### PR DESCRIPTION
## Summary
- remove the remaining `clawscan-note` scan job source compatibility path
- remove `clawScanNote` schema fields and response-stripping helpers
- remove the stale legacy scan-note test fixture and spec text

## Verification
- `rg -n "clawscan-note|clawScanNote|scan note|scan-note|scanNote|scan notes|note fields|publisher-supplied explanatory text|Legacy persisted note|Deprecated source retained|deprecated scan note" .` returned no matches
- `bunx convex codegen`
- `bunx vitest run convex/securityScan.test.ts convex/httpApiV1.handlers.test.ts packages/clawhub-admin/src/commands/moderation.test.ts packages/clawhub/src/cli/commands/publish.test.ts packages/clawhub/src/cli/commands/packages.test.ts src/__tests__/skills-publish-route.test.tsx src/__tests__/plugins-publish-route.test.tsx convex/lib/securityPrompt.test.ts`
- `bun run ci:types-build`
- `bun run ci:static`