### PR TITLE
ci: make package publish artifacts matrix-safe

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -69,6 +69,16 @@ on:
         description: Optional path to the .tgz inside package_artifact_name. Defaults to the only .tgz in the artifact.
         required: false
         type: string
+      inspector_artifact_name:
+        description: Artifact name for plugin inspector reports. Set a unique value when calling this workflow from a matrix.
+        required: false
+        type: string
+        default: plugin-inspector-report
+      publish_json_artifact_name:
+        description: Artifact name for the package publish JSON output. Set a unique value when calling this workflow from a matrix.
+        required: false
+        type: string
+        default: clawhub-package-publish-json
     secrets:
       clawhub_token:
         required: false
@@ -383,9 +393,6 @@ jobs:
               source = f"{source}@{ref}"
           source_path = os.environ["INPUT_SOURCE_PATH"].strip()
           prebuilt_artifact_path = os.environ["PREBUILT_PACKAGE_ARTIFACT_PATH"].strip()
-          if source_path and prebuilt_artifact_path:
-              raise SystemExit("Prebuilt artifact mode does not accept source_path; publish the already-packed artifact instead.")
-
           inspect_checkout_repository = ""
           inspect_checkout_ref = ""
           inspect_local_root = str(Path(os.environ["GITHUB_WORKSPACE"]).resolve())
@@ -540,7 +547,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: plugin-inspector-report
+          name: ${{ inputs.inspector_artifact_name }}
           path: ${{ runner.temp }}/plugin-inspector
           if-no-files-found: ignore
 
@@ -573,6 +580,6 @@ jobs:
       - name: Upload publish JSON artifact
         uses: actions/upload-artifact@v7
         with:
-          name: clawhub-package-publish-json
+          name: ${{ inputs.publish_json_artifact_name }}
           path: ${{ runner.temp }}/package-publish.json
           if-no-files-found: error

--- a/src/__tests__/package-publish-workflow.test.ts
+++ b/src/__tests__/package-publish-workflow.test.ts
@@ -30,6 +30,8 @@ describe("package publish workflow", () => {
     expect(workflow).not.toContain("generated_config_path.write_text(str(config_path)");
     expect(workflow).not.toContain("cleanup_generated_inspector_config");
     expect(workflow).toContain("plugin-inspector-report");
+    expect(workflow).toContain("inspector_artifact_name:");
+    expect(workflow).toContain("name: ${{ inputs.inspector_artifact_name }}");
     expect(workflow).toContain("actions/upload-artifact");
   });
 
@@ -117,6 +119,8 @@ describe("package publish workflow", () => {
 
     expect(workflow).toContain("package_artifact_name:");
     expect(workflow).toContain("package_artifact_path:");
+    expect(workflow).toContain("publish_json_artifact_name:");
+    expect(workflow).toContain("name: ${{ inputs.publish_json_artifact_name }}");
     expect(workflow).toContain("actions: read");
     expect(workflow).toContain("Download prebuilt package artifact");
     expect(workflow).toContain("actions/download-artifact");
@@ -127,7 +131,6 @@ describe("package publish workflow", () => {
     expect(workflow).toContain("PREBUILT_PACKAGE_ARTIFACT_PATH");
     expect(workflow).toContain("tar -xzf");
     expect(workflow).toContain("cmd_source = prebuilt_artifact_path or source");
-    expect(workflow).toContain("if source_path and prebuilt_artifact_path:");
     expect(workflow).toContain("if prebuilt_artifact_path:");
     expect(workflow).toContain("if not source_repo and not source_commit:");
     expect(workflow).toContain('source_repo = os.environ["GITHUB_REPOSITORY"].strip()');
@@ -135,6 +138,7 @@ describe("package publish workflow", () => {
     expect(workflow).toContain(
       "Prebuilt artifact mode requires source_repo and source_commit together",
     );
-    expect(workflow).toContain("Prebuilt artifact mode does not accept source_path");
+    expect(workflow).not.toContain("Prebuilt artifact mode does not accept source_path");
+    expect(workflow).toContain('cmd += ["--source-path", source_path]');
   });
 });


### PR DESCRIPTION
## Summary

- add optional artifact-name inputs to the package publish reusable workflow so matrix callers can avoid upload-artifact name collisions
- allow prebuilt ClawPack publishes to pass `source_path` for source attribution while still validating the extracted artifact
- cover the reusable workflow contract in the package publish workflow test

## Verification

- `actionlint .github/workflows/package-publish.yml`
- `bun run test src/__tests__/package-publish-workflow.test.ts`
- `git diff --check`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode branch --fallback-reviewer none`

## Review notes

- `autoreview` reported clean: no accepted/actionable findings.
