### PR TITLE
chore: release clawhub cli 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.21.0 - 2026-06-11
+
+### Changes
+
+- CLI/API: add public `clawhub package trusted-publisher set` and `clawhub package trusted-publisher delete` commands so package managers can configure or remove GitHub Actions OIDC trusted publishing for existing packages.
+
 ## 0.20.2 - 2026-06-11
 
 ### Changes

--- a/bun.lock
+++ b/bun.lock
@@ -87,7 +87,7 @@
     },
     "packages/clawhub": {
       "name": "clawhub",
-      "version": "0.20.2",
+      "version": "0.21.0",
       "bin": {
         "clawdhub": "bin/clawdhub.js",
         "clawhub": "bin/clawdhub.js",

--- a/packages/clawhub/package.json
+++ b/packages/clawhub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawhub",
-  "version": "0.20.2",
+  "version": "0.21.0",
   "description": "ClawHub CLI \\u2014 install, update, search, and publish skills plus OpenClaw packages.",
   "homepage": "https://clawhub.ai",
   "bugs": {


### PR DESCRIPTION
Summary
- Bump the `clawhub` CLI package metadata from `0.20.2` to `0.21.0`.
- Add `0.21.0` changelog notes for the public `package trusted-publisher set` and `delete` commands.
- Keep `bun.lock` workspace metadata in sync with the package version.

Proof
- `bun run --cwd packages/clawhub verify`
  - Source tests: 27 files, 296 tests passed.
  - Artifact tests: 1 file, 13 tests passed.
- `bun run ci:static`
  - Peer checks, audit, formatting, oxlint, and Knip dead-code checks passed.
- `node scripts/clawhub-cli-npm-release-check.mjs --tag v0.21.0`
  - `Release metadata OK for clawhub@0.21.0 (v0.21.0).`
- `node packages/clawhub/dist/cli.js package trusted-publisher set --help`
  ```text
  Usage: clawhub package trusted-publisher set [options] <name>

  Set trusted publisher config for a package

  Options:
    --repository <repo>         GitHub repository, for example openclaw/openclaw
    --workflow-filename <file>  GitHub Actions workflow filename
    --environment <name>        GitHub Actions environment name
    --json                      Output JSON
  ```
- `node packages/clawhub/dist/cli.js package trusted-publisher delete --help`
  ```text
  Usage: clawhub package trusted-publisher delete [options] <name>

  Delete trusted publisher config for a package

  Options:
    --json                      Output JSON
  ```
