### PR TITLE
fix: allow npm-compatible publisher handles

### DIFF
--- a/convex/lib/publishers.ts
+++ b/convex/lib/publishers.ts
@@ -6,6 +6,10 @@ export type PublisherRole = "owner" | "admin" | "publisher";
 
 type DbCtx = Pick<QueryCtx | MutationCtx, "db">;
 
+export const PUBLISHER_HANDLE_PATTERN = /^[a-z0-9](?:[a-z0-9._-]{0,38}[a-z0-9])?$/;
+export const PUBLISHER_HANDLE_REQUIREMENTS_MESSAGE =
+  "Handle must be 40 characters or fewer, start and end with a lowercase letter or number, and use only lowercase letters, numbers, hyphens, dots, or underscores";
+
 type PersonalPublisherAuditOptions = {
   actorUserId?: Id<"users">;
   source: string;

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -7701,7 +7701,7 @@ describe("packages public queries", () => {
 
   it("suggests publisher creation for missing npm-compatible package scopes", async () => {
     const runMutation = vi.fn(async () => {
-      throw new Error('Publisher "@bitrouter.ai" not found');
+      throw new Error('Publisher "@example.tools" not found');
     });
     const ctx = {
       runQuery: vi
@@ -7732,7 +7732,7 @@ describe("packages public queries", () => {
       publishPackageForUserInternalHandler(ctx as never, {
         actorUserId: "users:vincent",
         payload: {
-          name: "@bitrouter.ai/openclaw-plugin",
+          name: "@example.tools/demo-plugin",
           displayName: "Demo",
           family: "bundle-plugin",
           version: "1.0.0",
@@ -7741,7 +7741,7 @@ describe("packages public queries", () => {
           files: [],
         },
       }),
-    ).rejects.toThrow('Create it with "clawhub publisher create bitrouter.ai".');
+    ).rejects.toThrow('Create it with "clawhub publisher create example.tools".');
   });
 
   it("rejects scoped package publishes when --owner conflicts with the package scope", async () => {

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -7699,9 +7699,9 @@ describe("packages public queries", () => {
     );
   });
 
-  it("does not suggest publisher creation for package scopes that are invalid ClawHub handles", async () => {
+  it("suggests publisher creation for missing npm-compatible package scopes", async () => {
     const runMutation = vi.fn(async () => {
-      throw new Error('Publisher "@foo.bar" not found');
+      throw new Error('Publisher "@bitrouter.ai" not found');
     });
     const ctx = {
       runQuery: vi
@@ -7732,7 +7732,7 @@ describe("packages public queries", () => {
       publishPackageForUserInternalHandler(ctx as never, {
         actorUserId: "users:vincent",
         payload: {
-          name: "@foo.bar/demo-plugin",
+          name: "@bitrouter.ai/openclaw-plugin",
           displayName: "Demo",
           family: "bundle-plugin",
           version: "1.0.0",
@@ -7741,9 +7741,7 @@ describe("packages public queries", () => {
           files: [],
         },
       }),
-    ).rejects.toThrow(
-      'ClawHub publisher handles may only use lowercase letters, numbers, and hyphens. Rename package.json to a ClawHub-compatible scope, such as "@foo-bar/demo-plugin", then publish again.',
-    );
+    ).rejects.toThrow('Create it with "clawhub publisher create bitrouter.ai".');
   });
 
   it("rejects scoped package publishes when --owner conflicts with the package scope", async () => {

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -78,6 +78,7 @@ import {
   getPublisherMembership,
   isPublisherActive,
   isPublisherRoleAllowed,
+  PUBLISHER_HANDLE_PATTERN,
   normalizePublisherHandle,
 } from "./lib/publishers";
 import {
@@ -101,7 +102,6 @@ const MAX_OFFICIAL_MIGRATION_BLOCKERS = 20;
 const MAX_OFFICIAL_MIGRATION_FIELD_LENGTH = 300;
 const MAX_OFFICIAL_MIGRATION_NOTES_LENGTH = 2_000;
 const MAX_STORED_PACKAGE_METADATA_DEPTH = 10;
-const CLAWHUB_PUBLISHER_HANDLE_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$/;
 const REAL_BUNDLE_MANIFESTS = [
   { path: ".codex-plugin/plugin.json", format: "codex" },
   { path: ".claude-plugin/plugin.json", format: "claude" },
@@ -203,12 +203,12 @@ function getPackageSlugFromName(name: string) {
 function getClawHubPublisherHandleSuggestion(handle: string) {
   const suggestion = handle
     .toLowerCase()
-    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/[^a-z0-9._-]+/g, "-")
     .replace(/-+/g, "-")
-    .replace(/^-+|-+$/g, "")
+    .replace(/^[._-]+|[._-]+$/g, "")
     .slice(0, 40)
-    .replace(/-+$/g, "");
-  return CLAWHUB_PUBLISHER_HANDLE_PATTERN.test(suggestion) ? suggestion : null;
+    .replace(/[._-]+$/g, "");
+  return PUBLISHER_HANDLE_PATTERN.test(suggestion) ? suggestion : null;
 }
 
 function getScopedPackageMissingPublisherMessage(params: {
@@ -216,13 +216,13 @@ function getScopedPackageMissingPublisherMessage(params: {
   packageName: string;
   legacyPersonalOwnerHandle?: string;
 }) {
-  if (!CLAWHUB_PUBLISHER_HANDLE_PATTERN.test(params.scopedOwnerHandle)) {
+  if (!PUBLISHER_HANDLE_PATTERN.test(params.scopedOwnerHandle)) {
     const suggestedOwnerHandle = getClawHubPublisherHandleSuggestion(params.scopedOwnerHandle);
     const packageSlug = getPackageSlugFromName(params.packageName);
     const renameGuidance = suggestedOwnerHandle
       ? ` Rename package.json to a ClawHub-compatible scope, such as "@${suggestedOwnerHandle}/${packageSlug}", then publish again.`
-      : " Rename package.json to a ClawHub-compatible scope that uses lowercase letters, numbers, and hyphens, then publish again.";
-    return `Cannot publish ${params.packageName}: package.json name is scoped to "@${params.scopedOwnerHandle}", but ClawHub publisher handles may only use lowercase letters, numbers, and hyphens.${renameGuidance}`;
+      : " Rename package.json to a ClawHub-compatible scope that starts and ends with a lowercase letter or number and uses lowercase letters, numbers, hyphens, dots, or underscores, then publish again.";
+    return `Cannot publish ${params.packageName}: package.json name is scoped to "@${params.scopedOwnerHandle}", but ClawHub publisher handles must start and end with a lowercase letter or number and may only use lowercase letters, numbers, hyphens, dots, or underscores.${renameGuidance}`;
   }
   if (params.legacyPersonalOwnerHandle) {
     const displayName = params.scopedOwnerHandle

--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -3837,6 +3837,38 @@ describe("self-serve org publisher creation", () => {
     );
   });
 
+  it("creates org publishers for npm-compatible scoped package handles", async () => {
+    const examples = ["bitrouter.ai", "glin_1", "pluglab_thinkly", "souls_market"];
+
+    for (const handle of examples) {
+      const { ctx, inserts } = makeCreateOrgPublisherCtx({});
+
+      await expect(
+        createOrgPublisherForUserInternalHandler(ctx as never, {
+          actorUserId: "users:vincent",
+          handle,
+          displayName: handle,
+        }),
+      ).resolves.toMatchObject({
+        ok: true,
+        handle,
+        created: true,
+      });
+      expect(inserts).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            table: "publishers",
+            value: expect.objectContaining({
+              kind: "org",
+              handle,
+              displayName: handle,
+            }),
+          }),
+        ]),
+      );
+    }
+  });
+
   it("rejects creation when the org publisher already exists", async () => {
     const { ctx } = makeCreateOrgPublisherCtx({
       existingPublisher: { _id: "publishers:opik", kind: "org", handle: "opik" },

--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -3838,7 +3838,7 @@ describe("self-serve org publisher creation", () => {
   });
 
   it("creates org publishers for npm-compatible scoped package handles", async () => {
-    const examples = ["bitrouter.ai", "glin_1", "pluglab_thinkly", "souls_market"];
+    const examples = ["example.tools", "lab_1", "studio_tools", "market_square"];
 
     for (const handle of examples) {
       const { ctx, inserts } = makeCreateOrgPublisherCtx({});

--- a/convex/publishers.ts
+++ b/convex/publishers.ts
@@ -27,12 +27,13 @@ import {
   getPersonalPublisherForUserOrFallback,
   getPersonalPublisherForUser,
   isPublisherRoleAllowed,
+  PUBLISHER_HANDLE_PATTERN,
+  PUBLISHER_HANDLE_REQUIREMENTS_MESSAGE,
   normalizePublisherHandle,
 } from "./lib/publishers";
 import { isHandleReservedForAnotherUser } from "./lib/reservedHandles";
 import { readCanonicalStat } from "./lib/skillStats";
 
-const PUBLISHER_HANDLE_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,38}[a-z0-9])?$/;
 const MAX_PUBLIC_PUBLISHER_LIST_LIMIT = 500;
 const PUBLISHER_LIST_PREVIEW_LIMIT = 3;
 const publisherRoleValidator = v.union(
@@ -114,7 +115,7 @@ function validateHandle(rawHandle: string) {
   const handle = normalizePublisherHandle(rawHandle);
   if (!handle) throw new ConvexError("Handle is required");
   if (!PUBLISHER_HANDLE_PATTERN.test(handle)) {
-    throw new ConvexError("Handle must be lowercase, url-safe, and 2-40 characters");
+    throw new ConvexError(PUBLISHER_HANDLE_REQUIREMENTS_MESSAGE);
   }
   if (isReservedPublicOwnerHandle(handle)) {
     throw new ConvexError(formatReservedPublicOwnerHandleMessage(handle));
@@ -1777,7 +1778,7 @@ export const removeOrgPublisherMemberInternal = internalMutation({
 
     const handle = normalizePublisherHandle(args.handle);
     if (!handle || !PUBLISHER_HANDLE_PATTERN.test(handle)) {
-      throw new ConvexError("Handle must be lowercase, url-safe, and 2-40 characters");
+      throw new ConvexError(PUBLISHER_HANDLE_REQUIREMENTS_MESSAGE);
     }
     const memberHandle = normalizePublisherHandle(args.memberHandle);
     if (!memberHandle) throw new ConvexError("memberHandle is required");
@@ -1859,7 +1860,7 @@ export const deleteEmptyOrgPublisherInternal = internalMutation({
 
     const handle = normalizePublisherHandle(args.handle);
     if (!handle || !PUBLISHER_HANDLE_PATTERN.test(handle)) {
-      throw new ConvexError("Handle must be lowercase, url-safe, and 2-40 characters");
+      throw new ConvexError(PUBLISHER_HANDLE_REQUIREMENTS_MESSAGE);
     }
     const reason = args.reason.trim();
     if (!reason) throw new ConvexError("Reason is required");

--- a/docs/skill-format.md
+++ b/docs/skill-format.md
@@ -171,7 +171,8 @@ Limits (server-side):
 ## Slugs
 
 - Derived from folder name by default.
-- Must be lowercase and URL-safe: `^[a-z0-9][a-z0-9-]*$`.
+- Package scopes must match the ClawHub publisher handle exactly. Publisher handles can use lowercase letters, numbers, hyphens, dots, and underscores; they must start and end with a lowercase letter or number.
+- Package slugs must be lowercase and npm-safe, for example `@bitrouter.ai/openclaw-plugin` or `openclaw-plugin`.
 
 ## Versioning + tags
 

--- a/docs/skill-format.md
+++ b/docs/skill-format.md
@@ -172,7 +172,7 @@ Limits (server-side):
 
 - Derived from folder name by default.
 - Package scopes must match the ClawHub publisher handle exactly. Publisher handles can use lowercase letters, numbers, hyphens, dots, and underscores; they must start and end with a lowercase letter or number.
-- Package slugs must be lowercase and npm-safe, for example `@bitrouter.ai/openclaw-plugin` or `openclaw-plugin`.
+- Package slugs must be lowercase and npm-safe, for example `@example.tools/demo-plugin` or `demo-plugin`.
 
 ## Versioning + tags
 

--- a/packages/clawhub-admin/src/commands/orgs.test.ts
+++ b/packages/clawhub-admin/src/commands/orgs.test.ts
@@ -118,6 +118,40 @@ describe("cmdCreateOrg", () => {
     );
   });
 
+  it("creates org publishers with npm-compatible handles", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      ok: true,
+      publisherId: "publishers:bitrouter.ai",
+      handle: "bitrouter.ai",
+      created: true,
+      migrated: false,
+      trusted: false,
+      member: {
+        userId: "users:vincent",
+        handle: "vincentkoc",
+        role: "owner",
+      },
+    });
+
+    await cmdCreateOrg(makeGlobalOpts(), "@BitRouter.AI", {
+      displayName: "BitRouter AI",
+      member: "vincentkoc",
+      json: true,
+    });
+
+    expect(httpMocks.apiRequest).toHaveBeenCalledWith(
+      "https://clawhub.ai",
+      expect.objectContaining({
+        body: expect.objectContaining({
+          handle: "bitrouter.ai",
+          displayName: "BitRouter AI",
+          memberHandle: "vincentkoc",
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
   it("requires a valid org member role", async () => {
     await expect(
       cmdCreateOrg(makeGlobalOpts(), "opik", {
@@ -396,14 +430,14 @@ describe("cmdRepairScopedPackages", () => {
     const csv = await withCsv(
       [
         "packageName,intendedOrg,legacyOwner,orgDisplayName",
-        "@opik/opik-openclaw,opik,vincentkoc,Opik",
+        "@bitrouter.ai/openclaw-plugin,bitrouter.ai,vincentkoc,BitRouter AI",
       ].join("\n"),
     );
     httpMocks.apiRequest
       .mockResolvedValueOnce({
         ok: true,
-        publisherId: "publishers:opik",
-        handle: "opik",
+        publisherId: "publishers:bitrouter.ai",
+        handle: "bitrouter.ai",
         created: false,
         migrated: false,
         trusted: false,
@@ -413,49 +447,53 @@ describe("cmdRepairScopedPackages", () => {
         ok: true,
         dryRun: true,
         source: {
-          packageId: "packages:opik",
-          name: "@opik/opik-openclaw",
-          runtimeId: "opik-openclaw",
+          packageId: "packages:bitrouter",
+          name: "@bitrouter.ai/openclaw-plugin",
+          runtimeId: "openclaw-plugin",
           ownerUserId: "users:vincent",
           ownerPublisherId: "publishers:vincent",
           channel: "community",
           softDeletedAt: null,
         },
         target: {
-          packageId: "packages:opik",
-          name: "@opik/opik-openclaw",
-          runtimeId: "opik-openclaw",
+          packageId: "packages:bitrouter",
+          name: "@bitrouter.ai/openclaw-plugin",
+          runtimeId: "openclaw-plugin",
           ownerUserId: "users:vincent",
           ownerPublisherId: "publishers:vincent",
           channel: "community",
           softDeletedAt: null,
         },
         retiredName: null,
-        operations: [{ action: "transfer-owner", packageId: "packages:opik", owner: "opik" }],
+        operations: [
+          { action: "transfer-owner", packageId: "packages:bitrouter", owner: "bitrouter.ai" },
+        ],
       })
       .mockResolvedValueOnce({
         ok: true,
         dryRun: false,
         source: {
-          packageId: "packages:opik",
-          name: "@opik/opik-openclaw",
-          runtimeId: "opik-openclaw",
+          packageId: "packages:bitrouter",
+          name: "@bitrouter.ai/openclaw-plugin",
+          runtimeId: "openclaw-plugin",
           ownerUserId: "users:vincent",
           ownerPublisherId: "publishers:vincent",
           channel: "community",
           softDeletedAt: null,
         },
         target: {
-          packageId: "packages:opik",
-          name: "@opik/opik-openclaw",
-          runtimeId: "opik-openclaw",
+          packageId: "packages:bitrouter",
+          name: "@bitrouter.ai/openclaw-plugin",
+          runtimeId: "openclaw-plugin",
           ownerUserId: "users:vincent",
           ownerPublisherId: "publishers:vincent",
           channel: "community",
           softDeletedAt: null,
         },
         retiredName: null,
-        operations: [{ action: "transfer-owner", packageId: "packages:opik", owner: "opik" }],
+        operations: [
+          { action: "transfer-owner", packageId: "packages:bitrouter", owner: "bitrouter.ai" },
+        ],
       });
 
     try {
@@ -472,8 +510,8 @@ describe("cmdRepairScopedPackages", () => {
           method: "POST",
           path: "/api/v1/users/publisher",
           body: {
-            handle: "opik",
-            displayName: "Opik",
+            handle: "bitrouter.ai",
+            displayName: "BitRouter AI",
             memberHandle: "vincentkoc",
             memberRole: "owner",
           },
@@ -484,11 +522,11 @@ describe("cmdRepairScopedPackages", () => {
         2,
         "https://clawhub.ai",
         expect.objectContaining({
-          path: "/api/v1/packages/%40opik%2Fopik-openclaw/repair-name",
+          path: "/api/v1/packages/%40bitrouter.ai%2Fopenclaw-plugin/repair-name",
           body: {
-            nextName: "@opik/opik-openclaw",
-            owner: "opik",
-            reason: "Move legacy personal package into @opik",
+            nextName: "@bitrouter.ai/openclaw-plugin",
+            owner: "bitrouter.ai",
+            reason: "Move legacy personal package into @bitrouter.ai",
             dryRun: true,
           },
         }),
@@ -498,7 +536,7 @@ describe("cmdRepairScopedPackages", () => {
         3,
         "https://clawhub.ai",
         expect.objectContaining({
-          path: "/api/v1/packages/%40opik%2Fopik-openclaw/repair-name",
+          path: "/api/v1/packages/%40bitrouter.ai%2Fopenclaw-plugin/repair-name",
           body: expect.objectContaining({ dryRun: false }),
         }),
         expect.anything(),

--- a/packages/clawhub-admin/src/commands/orgs.test.ts
+++ b/packages/clawhub-admin/src/commands/orgs.test.ts
@@ -121,8 +121,8 @@ describe("cmdCreateOrg", () => {
   it("creates org publishers with npm-compatible handles", async () => {
     httpMocks.apiRequest.mockResolvedValueOnce({
       ok: true,
-      publisherId: "publishers:bitrouter.ai",
-      handle: "bitrouter.ai",
+      publisherId: "publishers:example.tools",
+      handle: "example.tools",
       created: true,
       migrated: false,
       trusted: false,
@@ -133,8 +133,8 @@ describe("cmdCreateOrg", () => {
       },
     });
 
-    await cmdCreateOrg(makeGlobalOpts(), "@BitRouter.AI", {
-      displayName: "BitRouter AI",
+    await cmdCreateOrg(makeGlobalOpts(), "@Example.Tools", {
+      displayName: "Example Tools",
       member: "vincentkoc",
       json: true,
     });
@@ -143,8 +143,8 @@ describe("cmdCreateOrg", () => {
       "https://clawhub.ai",
       expect.objectContaining({
         body: expect.objectContaining({
-          handle: "bitrouter.ai",
-          displayName: "BitRouter AI",
+          handle: "example.tools",
+          displayName: "Example Tools",
           memberHandle: "vincentkoc",
         }),
       }),
@@ -430,14 +430,14 @@ describe("cmdRepairScopedPackages", () => {
     const csv = await withCsv(
       [
         "packageName,intendedOrg,legacyOwner,orgDisplayName",
-        "@bitrouter.ai/openclaw-plugin,bitrouter.ai,vincentkoc,BitRouter AI",
+        "@example.tools/demo-plugin,example.tools,vincentkoc,Example Tools",
       ].join("\n"),
     );
     httpMocks.apiRequest
       .mockResolvedValueOnce({
         ok: true,
-        publisherId: "publishers:bitrouter.ai",
-        handle: "bitrouter.ai",
+        publisherId: "publishers:example.tools",
+        handle: "example.tools",
         created: false,
         migrated: false,
         trusted: false,
@@ -447,18 +447,18 @@ describe("cmdRepairScopedPackages", () => {
         ok: true,
         dryRun: true,
         source: {
-          packageId: "packages:bitrouter",
-          name: "@bitrouter.ai/openclaw-plugin",
-          runtimeId: "openclaw-plugin",
+          packageId: "packages:example-tools",
+          name: "@example.tools/demo-plugin",
+          runtimeId: "demo-plugin",
           ownerUserId: "users:vincent",
           ownerPublisherId: "publishers:vincent",
           channel: "community",
           softDeletedAt: null,
         },
         target: {
-          packageId: "packages:bitrouter",
-          name: "@bitrouter.ai/openclaw-plugin",
-          runtimeId: "openclaw-plugin",
+          packageId: "packages:example-tools",
+          name: "@example.tools/demo-plugin",
+          runtimeId: "demo-plugin",
           ownerUserId: "users:vincent",
           ownerPublisherId: "publishers:vincent",
           channel: "community",
@@ -466,25 +466,25 @@ describe("cmdRepairScopedPackages", () => {
         },
         retiredName: null,
         operations: [
-          { action: "transfer-owner", packageId: "packages:bitrouter", owner: "bitrouter.ai" },
+          { action: "transfer-owner", packageId: "packages:example-tools", owner: "example.tools" },
         ],
       })
       .mockResolvedValueOnce({
         ok: true,
         dryRun: false,
         source: {
-          packageId: "packages:bitrouter",
-          name: "@bitrouter.ai/openclaw-plugin",
-          runtimeId: "openclaw-plugin",
+          packageId: "packages:example-tools",
+          name: "@example.tools/demo-plugin",
+          runtimeId: "demo-plugin",
           ownerUserId: "users:vincent",
           ownerPublisherId: "publishers:vincent",
           channel: "community",
           softDeletedAt: null,
         },
         target: {
-          packageId: "packages:bitrouter",
-          name: "@bitrouter.ai/openclaw-plugin",
-          runtimeId: "openclaw-plugin",
+          packageId: "packages:example-tools",
+          name: "@example.tools/demo-plugin",
+          runtimeId: "demo-plugin",
           ownerUserId: "users:vincent",
           ownerPublisherId: "publishers:vincent",
           channel: "community",
@@ -492,7 +492,7 @@ describe("cmdRepairScopedPackages", () => {
         },
         retiredName: null,
         operations: [
-          { action: "transfer-owner", packageId: "packages:bitrouter", owner: "bitrouter.ai" },
+          { action: "transfer-owner", packageId: "packages:example-tools", owner: "example.tools" },
         ],
       });
 
@@ -510,8 +510,8 @@ describe("cmdRepairScopedPackages", () => {
           method: "POST",
           path: "/api/v1/users/publisher",
           body: {
-            handle: "bitrouter.ai",
-            displayName: "BitRouter AI",
+            handle: "example.tools",
+            displayName: "Example Tools",
             memberHandle: "vincentkoc",
             memberRole: "owner",
           },
@@ -522,11 +522,11 @@ describe("cmdRepairScopedPackages", () => {
         2,
         "https://clawhub.ai",
         expect.objectContaining({
-          path: "/api/v1/packages/%40bitrouter.ai%2Fopenclaw-plugin/repair-name",
+          path: "/api/v1/packages/%40example.tools%2Fdemo-plugin/repair-name",
           body: {
-            nextName: "@bitrouter.ai/openclaw-plugin",
-            owner: "bitrouter.ai",
-            reason: "Move legacy personal package into @bitrouter.ai",
+            nextName: "@example.tools/demo-plugin",
+            owner: "example.tools",
+            reason: "Move legacy personal package into @example.tools",
             dryRun: true,
           },
         }),
@@ -536,7 +536,7 @@ describe("cmdRepairScopedPackages", () => {
         3,
         "https://clawhub.ai",
         expect.objectContaining({
-          path: "/api/v1/packages/%40bitrouter.ai%2Fopenclaw-plugin/repair-name",
+          path: "/api/v1/packages/%40example.tools%2Fdemo-plugin/repair-name",
           body: expect.objectContaining({ dryRun: false }),
         }),
         expect.anything(),

--- a/packages/clawhub/src/cli.ts
+++ b/packages/clawhub/src/cli.ts
@@ -486,7 +486,7 @@ const publisherCmd = registerCommandGroup(program, ["publisher"])
 
 registerCommand(publisherCmd, ["publisher", "create"])
   .description("Create an org publisher you own")
-  .argument("<handle>", "Publisher handle, for example bitrouter.ai")
+  .argument("<handle>", "Publisher handle, for example example.tools")
   .option("--display-name <name>", "Publisher display name")
   .option("--json", "Output JSON")
   .action(async (handle, options) => {

--- a/packages/clawhub/src/cli.ts
+++ b/packages/clawhub/src/cli.ts
@@ -486,7 +486,7 @@ const publisherCmd = registerCommandGroup(program, ["publisher"])
 
 registerCommand(publisherCmd, ["publisher", "create"])
   .description("Create an org publisher you own")
-  .argument("<handle>", "Publisher handle, for example opik")
+  .argument("<handle>", "Publisher handle, for example bitrouter.ai")
   .option("--display-name <name>", "Publisher display name")
   .option("--json", "Output JSON")
   .action(async (handle, options) => {

--- a/src/__tests__/skill-route-loader.test.ts
+++ b/src/__tests__/skill-route-loader.test.ts
@@ -91,6 +91,11 @@ describe("skill route loader", () => {
     expect(() => runBeforeLoad({ owner: "123abc", slug: "weather" })).not.toThrow();
   });
 
+  it("allows npm-compatible dotted and underscored owner handles in beforeLoad", () => {
+    expect(() => runBeforeLoad({ owner: "bitrouter.ai", slug: "weather" })).not.toThrow();
+    expect(() => runBeforeLoad({ owner: "pluglab_thinkly", slug: "weather" })).not.toThrow();
+  });
+
   it("allows raw owner ids in beforeLoad", () => {
     expect(() => runBeforeLoad({ owner: "users:abc123", slug: "weather" })).not.toThrow();
   });
@@ -101,6 +106,10 @@ describe("skill route loader", () => {
 
   it("allows npm-style scopes in beforeLoad", () => {
     expect(() => runBeforeLoad({ owner: "@openclaw", slug: "codex" })).not.toThrow();
+  });
+
+  it("allows npm-style scopes with dotted owners in beforeLoad", () => {
+    expect(() => runBeforeLoad({ owner: "@bitrouter.ai", slug: "openclaw-plugin" })).not.toThrow();
   });
 
   beforeEach(() => {

--- a/src/__tests__/skill-route-loader.test.ts
+++ b/src/__tests__/skill-route-loader.test.ts
@@ -92,8 +92,8 @@ describe("skill route loader", () => {
   });
 
   it("allows npm-compatible dotted and underscored owner handles in beforeLoad", () => {
-    expect(() => runBeforeLoad({ owner: "bitrouter.ai", slug: "weather" })).not.toThrow();
-    expect(() => runBeforeLoad({ owner: "pluglab_thinkly", slug: "weather" })).not.toThrow();
+    expect(() => runBeforeLoad({ owner: "example.tools", slug: "weather" })).not.toThrow();
+    expect(() => runBeforeLoad({ owner: "studio_tools", slug: "weather" })).not.toThrow();
   });
 
   it("allows raw owner ids in beforeLoad", () => {
@@ -109,7 +109,7 @@ describe("skill route loader", () => {
   });
 
   it("allows npm-style scopes with dotted owners in beforeLoad", () => {
-    expect(() => runBeforeLoad({ owner: "@bitrouter.ai", slug: "openclaw-plugin" })).not.toThrow();
+    expect(() => runBeforeLoad({ owner: "@example.tools", slug: "demo-plugin" })).not.toThrow();
   });
 
   beforeEach(() => {

--- a/src/lib/ownerRoute.test.ts
+++ b/src/lib/ownerRoute.test.ts
@@ -7,15 +7,15 @@ import {
 
 describe("owner route segments", () => {
   it("accepts npm-compatible publisher handle characters", () => {
-    expect(isOwnerRouteHandleSegment("bitrouter.ai")).toBe(true);
-    expect(isOwnerRouteHandleSegment("glin_1")).toBe(true);
-    expect(isOwnerRouteHandleSegment("pluglab_thinkly")).toBe(true);
-    expect(isOwnerRouteHandleSegment("souls_market")).toBe(true);
+    expect(isOwnerRouteHandleSegment("example.tools")).toBe(true);
+    expect(isOwnerRouteHandleSegment("lab_1")).toBe(true);
+    expect(isOwnerRouteHandleSegment("studio_tools")).toBe(true);
+    expect(isOwnerRouteHandleSegment("market_square")).toBe(true);
   });
 
   it("keeps route segments bounded by alphanumeric characters", () => {
-    expect(isOwnerRouteHandleSegment(".bitrouter")).toBe(false);
-    expect(isOwnerRouteHandleSegment("bitrouter.")).toBe(false);
+    expect(isOwnerRouteHandleSegment(".example")).toBe(false);
+    expect(isOwnerRouteHandleSegment("example.")).toBe(false);
     expect(isOwnerRouteHandleSegment("_glin")).toBe(false);
     expect(isOwnerRouteHandleSegment("glin_")).toBe(false);
   });
@@ -34,7 +34,7 @@ describe("owner route segments", () => {
 
   it("accepts npm scope route aliases for the main skill route", () => {
     expect(isOwnerRouteScopeSegment("@openclaw")).toBe(true);
-    expect(isOwnerRouteScopeSegment("@bitrouter.ai")).toBe(true);
-    expect(isOwnerRouteScopeSegment("@glin_1")).toBe(true);
+    expect(isOwnerRouteScopeSegment("@example.tools")).toBe(true);
+    expect(isOwnerRouteScopeSegment("@lab_1")).toBe(true);
   });
 });

--- a/src/lib/ownerRoute.test.ts
+++ b/src/lib/ownerRoute.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  isOwnerRouteHandleOrIdSegment,
+  isOwnerRouteHandleSegment,
+  isOwnerRouteScopeSegment,
+} from "./ownerRoute";
+
+describe("owner route segments", () => {
+  it("accepts npm-compatible publisher handle characters", () => {
+    expect(isOwnerRouteHandleSegment("bitrouter.ai")).toBe(true);
+    expect(isOwnerRouteHandleSegment("glin_1")).toBe(true);
+    expect(isOwnerRouteHandleSegment("pluglab_thinkly")).toBe(true);
+    expect(isOwnerRouteHandleSegment("souls_market")).toBe(true);
+  });
+
+  it("keeps route segments bounded by alphanumeric characters", () => {
+    expect(isOwnerRouteHandleSegment(".bitrouter")).toBe(false);
+    expect(isOwnerRouteHandleSegment("bitrouter.")).toBe(false);
+    expect(isOwnerRouteHandleSegment("_glin")).toBe(false);
+    expect(isOwnerRouteHandleSegment("glin_")).toBe(false);
+  });
+
+  it("keeps route handles within the publisher handle length limit", () => {
+    expect(isOwnerRouteHandleSegment("a".repeat(40))).toBe(true);
+    expect(isOwnerRouteHandleSegment("a".repeat(41))).toBe(false);
+    expect(isOwnerRouteScopeSegment(`@${"a".repeat(40)}`)).toBe(true);
+    expect(isOwnerRouteScopeSegment(`@${"a".repeat(41)}`)).toBe(false);
+  });
+
+  it("accepts raw owner id route segments", () => {
+    expect(isOwnerRouteHandleOrIdSegment("users:abc123")).toBe(true);
+    expect(isOwnerRouteHandleOrIdSegment("publishers:abc123")).toBe(true);
+  });
+
+  it("accepts npm scope route aliases for the main skill route", () => {
+    expect(isOwnerRouteScopeSegment("@openclaw")).toBe(true);
+    expect(isOwnerRouteScopeSegment("@bitrouter.ai")).toBe(true);
+    expect(isOwnerRouteScopeSegment("@glin_1")).toBe(true);
+  });
+});

--- a/src/lib/ownerRoute.ts
+++ b/src/lib/ownerRoute.ts
@@ -1,0 +1,18 @@
+const OWNER_ROUTE_HANDLE_PATTERN = /^[a-zA-Z0-9](?:[a-zA-Z0-9._-]{0,38}[a-zA-Z0-9])?$/;
+const OWNER_ROUTE_SCOPE_PATTERN = /^@[a-zA-Z0-9](?:[a-zA-Z0-9._-]{0,38}[a-zA-Z0-9])?$/;
+
+function isOwnerRouteIdSegment(owner: string) {
+  return owner.startsWith("users:") || owner.startsWith("publishers:");
+}
+
+export function isOwnerRouteHandleSegment(owner: string) {
+  return OWNER_ROUTE_HANDLE_PATTERN.test(owner);
+}
+
+export function isOwnerRouteScopeSegment(owner: string) {
+  return OWNER_ROUTE_SCOPE_PATTERN.test(owner);
+}
+
+export function isOwnerRouteHandleOrIdSegment(owner: string) {
+  return isOwnerRouteHandleSegment(owner) || isOwnerRouteIdSegment(owner);
+}

--- a/src/routes/$owner/$slug.tsx
+++ b/src/routes/$owner/$slug.tsx
@@ -7,15 +7,13 @@ import {
 } from "@tanstack/react-router";
 import { SkillDetailPage } from "../../components/SkillDetailPage";
 import { buildSkillMeta } from "../../lib/og";
+import { isOwnerRouteHandleOrIdSegment, isOwnerRouteScopeSegment } from "../../lib/ownerRoute";
 import { fetchSkillPageData } from "../../lib/skillPage";
 import { resolveOpenClawPluginSlug } from "../../lib/slugRoute";
 
 export const Route = createFileRoute("/$owner/$slug")({
   beforeLoad: ({ params }) => {
-    const isHandle = /^[a-zA-Z0-9_][a-zA-Z0-9_-]*$/.test(params.owner);
-    const isScope = /^@[a-zA-Z0-9_][a-zA-Z0-9_-]*$/.test(params.owner);
-    const isOwnerId = params.owner.startsWith("users:") || params.owner.startsWith("publishers:");
-    if (!isHandle && !isScope && !isOwnerId) {
+    if (!isOwnerRouteHandleOrIdSegment(params.owner) && !isOwnerRouteScopeSegment(params.owner)) {
       throw notFound();
     }
   },

--- a/src/routes/$owner/$slug/security-audit.tsx
+++ b/src/routes/$owner/$slug/security-audit.tsx
@@ -6,15 +6,14 @@ import {
   SecurityAuditPageSkeleton,
 } from "../../../components/SecurityAuditPage";
 import { buildSkillMeta } from "../../../lib/og";
+import { isOwnerRouteHandleOrIdSegment } from "../../../lib/ownerRoute";
 import { isModerator } from "../../../lib/roles";
 import { fetchSkillPageData } from "../../../lib/skillPage";
 import { useAuthStatus } from "../../../lib/useAuthStatus";
 
 export const Route = createFileRoute("/$owner/$slug/security-audit")({
   beforeLoad: ({ params }) => {
-    const isHandle = /^[a-zA-Z0-9_][a-zA-Z0-9_-]*$/.test(params.owner);
-    const isOwnerId = params.owner.startsWith("users:") || params.owner.startsWith("publishers:");
-    if (!isHandle && !isOwnerId) throw notFound();
+    if (!isOwnerRouteHandleOrIdSegment(params.owner)) throw notFound();
   },
   loader: async ({ params }) => {
     const data = await fetchSkillPageData(params.slug);

--- a/src/routes/$owner/$slug/security/$scanner.tsx
+++ b/src/routes/$owner/$slug/security/$scanner.tsx
@@ -1,10 +1,9 @@
 import { createFileRoute, notFound, redirect } from "@tanstack/react-router";
+import { isOwnerRouteHandleOrIdSegment } from "../../../../lib/ownerRoute";
 
 export const Route = createFileRoute("/$owner/$slug/security/$scanner")({
   beforeLoad: ({ params }) => {
-    const isHandle = /^[a-zA-Z0-9_][a-zA-Z0-9_-]*$/.test(params.owner);
-    const isOwnerId = params.owner.startsWith("users:") || params.owner.startsWith("publishers:");
-    if (!isHandle && !isOwnerId) throw notFound();
+    if (!isOwnerRouteHandleOrIdSegment(params.owner)) throw notFound();
     throw redirect({
       to: "/$owner/$slug/security-audit",
       params: {

--- a/src/routes/$owner/$slug/settings.tsx
+++ b/src/routes/$owner/$slug/settings.tsx
@@ -1,13 +1,12 @@
 import { createFileRoute, notFound, redirect } from "@tanstack/react-router";
 import { SkillDetailPage } from "../../../components/SkillDetailPage";
 import { buildSkillMeta } from "../../../lib/og";
+import { isOwnerRouteHandleOrIdSegment } from "../../../lib/ownerRoute";
 import { fetchSkillPageData } from "../../../lib/skillPage";
 
 export const Route = createFileRoute("/$owner/$slug/settings")({
   beforeLoad: ({ params }) => {
-    const isHandle = /^[a-zA-Z0-9_][a-zA-Z0-9_-]*$/.test(params.owner);
-    const isOwnerId = params.owner.startsWith("users:") || params.owner.startsWith("publishers:");
-    if (!isHandle && !isOwnerId) {
+    if (!isOwnerRouteHandleOrIdSegment(params.owner)) {
       throw notFound();
     }
   },

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -755,7 +755,7 @@ export function Settings() {
                                   setOrgHandle(event.target.value);
                                   setCreateOrgError(null);
                                 }}
-                                placeholder="openclaw"
+                                placeholder="bitrouter.ai"
                               />
                             </Field>
                             <Field label="Display name" htmlFor="settings-org-display-name">
@@ -1151,7 +1151,7 @@ export function Settings() {
                                   setOrgHandle(event.target.value);
                                   setCreateOrgError(null);
                                 }}
-                                placeholder="openclaw"
+                                placeholder="bitrouter.ai"
                               />
                             </Field>
                             <Field label="Display name" htmlFor="settings-org-display-name-empty">

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -755,7 +755,7 @@ export function Settings() {
                                   setOrgHandle(event.target.value);
                                   setCreateOrgError(null);
                                 }}
-                                placeholder="bitrouter.ai"
+                                placeholder="example.tools"
                               />
                             </Field>
                             <Field label="Display name" htmlFor="settings-org-display-name">
@@ -1151,7 +1151,7 @@ export function Settings() {
                                   setOrgHandle(event.target.value);
                                   setCreateOrgError(null);
                                 }}
-                                placeholder="bitrouter.ai"
+                                placeholder="example.tools"
                               />
                             </Field>
                             <Field label="Display name" htmlFor="settings-org-display-name-empty">


### PR DESCRIPTION
## Summary
- Allow publisher/org handles to include npm-compatible `.` and `_` characters through shared validation.
- Preserve dotted and underscored package scopes in missing-publisher guidance, admin repair tests, and publisher create copy.
- Allow dotted and underscored publisher handles in owner skill routes and document exact package scope matching.
- Use neutral docs/test fixtures for scoped package examples rather than real affected package names.

## Proof
- `bun packages/clawhub/src/cli.ts publisher create --help` shows `Publisher handle, for example example.tools`.
- `bun run --cwd packages/clawhub build` regenerated the ignored package output with the updated help text.
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local` reported no accepted/actionable findings after the neutral-example cleanup.

## Tests
- `bunx vitest run convex/publishers.test.ts convex/packages.public.test.ts packages/clawhub-admin/src/commands/orgs.test.ts`
- `bunx vitest run src/lib/ownerRoute.test.ts src/__tests__/skill-route-loader.test.ts src/__tests__/skill-security-scanner-route.test.tsx`
- `bun run format:check -- convex/packages.public.test.ts convex/publishers.test.ts docs/skill-format.md packages/clawhub-admin/src/commands/orgs.test.ts packages/clawhub/src/cli.ts src/__tests__/skill-route-loader.test.ts src/lib/ownerRoute.test.ts src/routes/settings.tsx`
- `bun packages/clawhub/src/cli.ts publisher create --help`
- `bun run --cwd packages/clawhub build`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:packages`
