### PR TITLE
chore: add ClawScan cleanup migration

### DIFF
--- a/convex/maintenance.test.ts
+++ b/convex/maintenance.test.ts
@@ -33,6 +33,12 @@ vi.mock("./_generated/api", () => ({
       nominateUserForEmptySkillSpamInternal: Symbol("nominateUserForEmptySkillSpamInternal"),
       cleanupEmptySkillsInternal: Symbol("cleanupEmptySkillsInternal"),
       nominateEmptySkillSpammersInternal: Symbol("nominateEmptySkillSpammersInternal"),
+      cleanupDeprecatedClawScanNoteFieldsBatchInternal: Symbol(
+        "cleanupDeprecatedClawScanNoteFieldsBatchInternal",
+      ),
+      cleanupDeprecatedClawScanJobSourcesBatchInternal: Symbol(
+        "cleanupDeprecatedClawScanJobSourcesBatchInternal",
+      ),
     },
     skills: {
       backfillLatestSkillModerationInternal: Symbol("skills.backfillLatestSkillModerationInternal"),
@@ -57,6 +63,10 @@ const {
   backfillSkillFingerprintsInternalHandler,
   backfillSkillSummariesInternalHandler,
   backfillUserStatsInternalHandler,
+  cleanupDeprecatedClawScanNoteFieldsBatchHandler,
+  cleanupDeprecatedClawScanNoteFieldsInternalHandler,
+  cleanupDeprecatedClawScanJobSourcesBatchHandler,
+  cleanupDeprecatedClawScanJobSourcesInternalHandler,
   cleanupEmptySkillsInternalHandler,
   nominateEmptySkillSpammersInternalHandler,
   repairLegacyPublisherOwnershipForUserHandler,
@@ -542,6 +552,254 @@ describe("maintenance legacy publisher ownership repair", () => {
 });
 
 describe("maintenance backfill", () => {
+  it("dry-runs deprecated ClawScan note cleanup without patching rows", async () => {
+    const paginate = vi.fn().mockResolvedValue({
+      page: [
+        { _id: "packageReleases:1", clawScanNote: "old note", clawScanNoteUpdatedAt: 123 },
+        { _id: "packageReleases:2" },
+      ],
+      continueCursor: "next",
+      isDone: false,
+    });
+    const patch = vi.fn();
+    const ctx = {
+      db: {
+        query: vi.fn(() => ({ order: vi.fn(() => ({ paginate })) })),
+        patch,
+      },
+    } as never;
+
+    const result = await cleanupDeprecatedClawScanNoteFieldsBatchHandler(ctx, {
+      table: "packageReleases",
+      dryRun: true,
+      batchSize: 10,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      table: "packageReleases",
+      dryRun: true,
+      stats: {
+        rowsScanned: 2,
+        rowsWithDeprecatedFields: 1,
+        rowsPatched: 0,
+      },
+      isDone: false,
+      cursor: "next",
+    });
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("removes deprecated ClawScan note fields from matching rows only", async () => {
+    const paginate = vi.fn().mockResolvedValue({
+      page: [
+        { _id: "skillVersions:1", clawScanNote: "old note" },
+        { _id: "skillVersions:2", clawScanNoteUpdatedAt: 456 },
+        { _id: "skillVersions:3" },
+      ],
+      continueCursor: null,
+      isDone: true,
+    });
+    const patch = vi.fn();
+    const ctx = {
+      db: {
+        query: vi.fn(() => ({ order: vi.fn(() => ({ paginate })) })),
+        patch,
+      },
+    } as never;
+
+    const result = await cleanupDeprecatedClawScanNoteFieldsBatchHandler(ctx, {
+      table: "skillVersions",
+      dryRun: false,
+      batchSize: 10,
+    });
+
+    expect(result.stats).toEqual({
+      rowsScanned: 3,
+      rowsWithDeprecatedFields: 2,
+      rowsPatched: 2,
+    });
+    expect(patch).toHaveBeenNthCalledWith(1, "skillVersions:1", {
+      clawScanNote: undefined,
+      clawScanNoteUpdatedAt: undefined,
+    });
+    expect(patch).toHaveBeenNthCalledWith(2, "skillVersions:2", {
+      clawScanNote: undefined,
+      clawScanNoteUpdatedAt: undefined,
+    });
+  });
+
+  it("runs deprecated ClawScan note cleanup batches until done or maxBatches", async () => {
+    const runMutation = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        table: "packageReleases",
+        dryRun: false,
+        stats: { rowsScanned: 2, rowsWithDeprecatedFields: 1, rowsPatched: 1 },
+        isDone: false,
+        cursor: "next",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        table: "packageReleases",
+        dryRun: false,
+        stats: { rowsScanned: 1, rowsWithDeprecatedFields: 0, rowsPatched: 0 },
+        isDone: true,
+        cursor: null,
+      });
+
+    const result = await cleanupDeprecatedClawScanNoteFieldsInternalHandler(
+      { runMutation } as never,
+      { table: "packageReleases", dryRun: false, batchSize: 2, maxBatches: 5 },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      table: "packageReleases",
+      dryRun: false,
+      stats: { rowsScanned: 3, rowsWithDeprecatedFields: 1, rowsPatched: 1 },
+      isDone: true,
+      cursor: null,
+    });
+    expect(runMutation).toHaveBeenNthCalledWith(
+      1,
+      internal.maintenance.cleanupDeprecatedClawScanNoteFieldsBatchInternal,
+      {
+        table: "packageReleases",
+        dryRun: false,
+        batchSize: 2,
+        cursor: undefined,
+      },
+    );
+    expect(runMutation).toHaveBeenNthCalledWith(
+      2,
+      internal.maintenance.cleanupDeprecatedClawScanNoteFieldsBatchInternal,
+      {
+        table: "packageReleases",
+        dryRun: false,
+        batchSize: 2,
+        cursor: "next",
+      },
+    );
+  });
+
+  it("dry-runs deprecated ClawScan job source cleanup without patching rows", async () => {
+    const paginate = vi.fn().mockResolvedValue({
+      page: [
+        { _id: "securityScanJobs:1", source: "clawscan-note" },
+        { _id: "securityScanJobs:2", source: "manual" },
+      ],
+      continueCursor: null,
+      isDone: true,
+    });
+    const patch = vi.fn();
+    const ctx = {
+      db: {
+        query: vi.fn(() => ({ order: vi.fn(() => ({ paginate })) })),
+        patch,
+      },
+    } as never;
+
+    const result = await cleanupDeprecatedClawScanJobSourcesBatchHandler(ctx, {
+      dryRun: true,
+      batchSize: 10,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      dryRun: true,
+      stats: {
+        rowsScanned: 2,
+        rowsWithDeprecatedSource: 1,
+        rowsPatched: 0,
+      },
+      isDone: true,
+      cursor: null,
+    });
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("maps deprecated ClawScan job source rows to manual", async () => {
+    const paginate = vi.fn().mockResolvedValue({
+      page: [
+        { _id: "securityScanJobs:1", source: "clawscan-note" },
+        { _id: "securityScanJobs:2", source: "publish" },
+      ],
+      continueCursor: null,
+      isDone: true,
+    });
+    const patch = vi.fn();
+    const ctx = {
+      db: {
+        query: vi.fn(() => ({ order: vi.fn(() => ({ paginate })) })),
+        patch,
+      },
+    } as never;
+
+    const result = await cleanupDeprecatedClawScanJobSourcesBatchHandler(ctx, {
+      dryRun: false,
+      batchSize: 10,
+    });
+
+    expect(result.stats).toEqual({
+      rowsScanned: 2,
+      rowsWithDeprecatedSource: 1,
+      rowsPatched: 1,
+    });
+    expect(patch).toHaveBeenCalledWith("securityScanJobs:1", { source: "manual" });
+  });
+
+  it("runs deprecated ClawScan job source cleanup batches until done or maxBatches", async () => {
+    const runMutation = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        dryRun: false,
+        stats: { rowsScanned: 2, rowsWithDeprecatedSource: 1, rowsPatched: 1 },
+        isDone: false,
+        cursor: "next",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        dryRun: false,
+        stats: { rowsScanned: 1, rowsWithDeprecatedSource: 0, rowsPatched: 0 },
+        isDone: true,
+        cursor: null,
+      });
+
+    const result = await cleanupDeprecatedClawScanJobSourcesInternalHandler(
+      { runMutation } as never,
+      { dryRun: false, batchSize: 2, maxBatches: 5 },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      dryRun: false,
+      stats: { rowsScanned: 3, rowsWithDeprecatedSource: 1, rowsPatched: 1 },
+      isDone: true,
+      cursor: null,
+    });
+    expect(runMutation).toHaveBeenNthCalledWith(
+      1,
+      internal.maintenance.cleanupDeprecatedClawScanJobSourcesBatchInternal,
+      {
+        dryRun: false,
+        batchSize: 2,
+        cursor: undefined,
+      },
+    );
+    expect(runMutation).toHaveBeenNthCalledWith(
+      2,
+      internal.maintenance.cleanupDeprecatedClawScanJobSourcesBatchInternal,
+      {
+        dryRun: false,
+        batchSize: 2,
+        cursor: "next",
+      },
+    );
+  });
+
   it("repairs summary + parsed by reparsing SKILL.md", async () => {
     const runQuery = vi.fn().mockResolvedValue({
       items: [

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -111,6 +111,37 @@ type LegacyPublisherOwnershipForUserRepairResult = {
   nextPhase?: LegacyPublisherOwnershipTargetPhase;
 };
 
+type DeprecatedClawScanNoteCleanupTable = "skillVersions" | "packageReleases";
+
+type DeprecatedClawScanNoteCleanupStats = {
+  rowsScanned: number;
+  rowsWithDeprecatedFields: number;
+  rowsPatched: number;
+};
+
+type DeprecatedClawScanNoteCleanupResult = {
+  ok: true;
+  table: DeprecatedClawScanNoteCleanupTable;
+  dryRun: boolean;
+  stats: DeprecatedClawScanNoteCleanupStats;
+  isDone: boolean;
+  cursor: string | null;
+};
+
+type DeprecatedClawScanJobSourceCleanupStats = {
+  rowsScanned: number;
+  rowsWithDeprecatedSource: number;
+  rowsPatched: number;
+};
+
+type DeprecatedClawScanJobSourceCleanupResult = {
+  ok: true;
+  dryRun: boolean;
+  stats: DeprecatedClawScanJobSourceCleanupStats;
+  isDone: boolean;
+  cursor: string | null;
+};
+
 export const getSkillBackfillPageInternal = internalQuery({
   args: {
     cursor: v.optional(v.string()),
@@ -324,6 +355,224 @@ export type PublisherStatsBackfillActionResult = {
   isDone: boolean;
   cursor: string | null;
 };
+
+function hasDeprecatedClawScanNoteFields(
+  doc: Pick<
+    Doc<"skillVersions"> | Doc<"packageReleases">,
+    "clawScanNote" | "clawScanNoteUpdatedAt"
+  >,
+) {
+  return doc.clawScanNote !== undefined || doc.clawScanNoteUpdatedAt !== undefined;
+}
+
+export async function cleanupDeprecatedClawScanNoteFieldsBatchHandler(
+  ctx: MutationCtx,
+  args: {
+    table: DeprecatedClawScanNoteCleanupTable;
+    cursor?: string;
+    batchSize?: number;
+    dryRun?: boolean;
+  },
+): Promise<DeprecatedClawScanNoteCleanupResult> {
+  const dryRun = args.dryRun === true;
+  const batchSize = clampInt(args.batchSize ?? DEFAULT_BATCH_SIZE, 1, MAX_BATCH_SIZE);
+  const stats: DeprecatedClawScanNoteCleanupStats = {
+    rowsScanned: 0,
+    rowsWithDeprecatedFields: 0,
+    rowsPatched: 0,
+  };
+
+  if (args.table === "skillVersions") {
+    const page = await ctx.db
+      .query("skillVersions")
+      .order("asc")
+      .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
+
+    for (const version of page.page) {
+      stats.rowsScanned++;
+      if (!hasDeprecatedClawScanNoteFields(version)) continue;
+      stats.rowsWithDeprecatedFields++;
+      if (dryRun) continue;
+      await ctx.db.patch(version._id, {
+        clawScanNote: undefined,
+        clawScanNoteUpdatedAt: undefined,
+      });
+      stats.rowsPatched++;
+    }
+
+    return {
+      ok: true as const,
+      table: args.table,
+      dryRun,
+      stats,
+      isDone: page.isDone,
+      cursor: page.continueCursor,
+    };
+  }
+
+  const page = await ctx.db
+    .query("packageReleases")
+    .order("asc")
+    .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
+
+  for (const release of page.page) {
+    stats.rowsScanned++;
+    if (!hasDeprecatedClawScanNoteFields(release)) continue;
+    stats.rowsWithDeprecatedFields++;
+    if (dryRun) continue;
+    await ctx.db.patch(release._id, {
+      clawScanNote: undefined,
+      clawScanNoteUpdatedAt: undefined,
+    });
+    stats.rowsPatched++;
+  }
+
+  return {
+    ok: true as const,
+    table: args.table,
+    dryRun,
+    stats,
+    isDone: page.isDone,
+    cursor: page.continueCursor,
+  };
+}
+
+export async function cleanupDeprecatedClawScanNoteFieldsInternalHandler(
+  ctx: ActionCtx,
+  args: {
+    table: DeprecatedClawScanNoteCleanupTable;
+    cursor?: string;
+    batchSize?: number;
+    maxBatches?: number;
+    dryRun?: boolean;
+  },
+): Promise<DeprecatedClawScanNoteCleanupResult> {
+  const dryRun = args.dryRun === true;
+  const batchSize = clampInt(args.batchSize ?? DEFAULT_BATCH_SIZE, 1, MAX_BATCH_SIZE);
+  const maxBatches = clampInt(args.maxBatches ?? DEFAULT_MAX_BATCHES, 1, MAX_MAX_BATCHES);
+  const stats: DeprecatedClawScanNoteCleanupStats = {
+    rowsScanned: 0,
+    rowsWithDeprecatedFields: 0,
+    rowsPatched: 0,
+  };
+
+  let cursor: string | null = args.cursor ?? null;
+  let isDone = false;
+
+  for (let i = 0; i < maxBatches; i++) {
+    const result = (await ctx.runMutation(
+      internal.maintenance.cleanupDeprecatedClawScanNoteFieldsBatchInternal,
+      {
+        table: args.table,
+        dryRun,
+        batchSize,
+        cursor: cursor ?? undefined,
+      },
+    )) as DeprecatedClawScanNoteCleanupResult;
+
+    stats.rowsScanned += result.stats.rowsScanned;
+    stats.rowsWithDeprecatedFields += result.stats.rowsWithDeprecatedFields;
+    stats.rowsPatched += result.stats.rowsPatched;
+    cursor = result.cursor;
+    isDone = result.isDone;
+    if (isDone) break;
+  }
+
+  return {
+    ok: true as const,
+    table: args.table,
+    dryRun,
+    stats,
+    isDone,
+    cursor,
+  };
+}
+
+export async function cleanupDeprecatedClawScanJobSourcesBatchHandler(
+  ctx: MutationCtx,
+  args: {
+    cursor?: string;
+    batchSize?: number;
+    dryRun?: boolean;
+  },
+): Promise<DeprecatedClawScanJobSourceCleanupResult> {
+  const dryRun = args.dryRun === true;
+  const batchSize = clampInt(args.batchSize ?? DEFAULT_BATCH_SIZE, 1, MAX_BATCH_SIZE);
+  const stats: DeprecatedClawScanJobSourceCleanupStats = {
+    rowsScanned: 0,
+    rowsWithDeprecatedSource: 0,
+    rowsPatched: 0,
+  };
+  const page = await ctx.db
+    .query("securityScanJobs")
+    .order("asc")
+    .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
+
+  for (const job of page.page) {
+    stats.rowsScanned++;
+    if (job.source !== "clawscan-note") continue;
+    stats.rowsWithDeprecatedSource++;
+    if (dryRun) continue;
+    await ctx.db.patch(job._id, { source: "manual" });
+    stats.rowsPatched++;
+  }
+
+  return {
+    ok: true as const,
+    dryRun,
+    stats,
+    isDone: page.isDone,
+    cursor: page.continueCursor,
+  };
+}
+
+export async function cleanupDeprecatedClawScanJobSourcesInternalHandler(
+  ctx: ActionCtx,
+  args: {
+    cursor?: string;
+    batchSize?: number;
+    maxBatches?: number;
+    dryRun?: boolean;
+  },
+): Promise<DeprecatedClawScanJobSourceCleanupResult> {
+  const dryRun = args.dryRun === true;
+  const batchSize = clampInt(args.batchSize ?? DEFAULT_BATCH_SIZE, 1, MAX_BATCH_SIZE);
+  const maxBatches = clampInt(args.maxBatches ?? DEFAULT_MAX_BATCHES, 1, MAX_MAX_BATCHES);
+  const stats: DeprecatedClawScanJobSourceCleanupStats = {
+    rowsScanned: 0,
+    rowsWithDeprecatedSource: 0,
+    rowsPatched: 0,
+  };
+
+  let cursor: string | null = args.cursor ?? null;
+  let isDone = false;
+
+  for (let i = 0; i < maxBatches; i++) {
+    const result = (await ctx.runMutation(
+      internal.maintenance.cleanupDeprecatedClawScanJobSourcesBatchInternal,
+      {
+        dryRun,
+        batchSize,
+        cursor: cursor ?? undefined,
+      },
+    )) as DeprecatedClawScanJobSourceCleanupResult;
+
+    stats.rowsScanned += result.stats.rowsScanned;
+    stats.rowsWithDeprecatedSource += result.stats.rowsWithDeprecatedSource;
+    stats.rowsPatched += result.stats.rowsPatched;
+    cursor = result.cursor;
+    isDone = result.isDone;
+    if (isDone) break;
+  }
+
+  return {
+    ok: true as const,
+    dryRun,
+    stats,
+    isDone,
+    cursor,
+  };
+}
 
 export async function backfillSkillSummariesInternalHandler(
   ctx: ActionCtx,
@@ -555,6 +804,46 @@ export const backfillPublisherStatsInternal = internalAction({
     cursor: v.optional(v.string()),
   },
   handler: backfillPublisherStatsInternalHandler,
+});
+
+export const cleanupDeprecatedClawScanNoteFieldsBatchInternal = internalMutation({
+  args: {
+    table: v.union(v.literal("skillVersions"), v.literal("packageReleases")),
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: cleanupDeprecatedClawScanNoteFieldsBatchHandler,
+});
+
+export const cleanupDeprecatedClawScanNoteFieldsInternal = internalAction({
+  args: {
+    table: v.union(v.literal("skillVersions"), v.literal("packageReleases")),
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+    maxBatches: v.optional(v.number()),
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: cleanupDeprecatedClawScanNoteFieldsInternalHandler,
+});
+
+export const cleanupDeprecatedClawScanJobSourcesBatchInternal = internalMutation({
+  args: {
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: cleanupDeprecatedClawScanJobSourcesBatchHandler,
+});
+
+export const cleanupDeprecatedClawScanJobSourcesInternal = internalAction({
+  args: {
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+    maxBatches: v.optional(v.number()),
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: cleanupDeprecatedClawScanJobSourcesInternalHandler,
 });
 
 export const backfillSkillSummaries: ReturnType<typeof action> = action({

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -578,6 +578,8 @@ const securityScanJobSourceValidator = v.union(
   v.literal("backfill"),
   v.literal("bulk-rescan"),
   v.literal("manual"),
+  // Deprecated source retained temporarily for production cleanup.
+  v.literal("clawscan-note"),
 );
 const skillCardGenerationJobStatusValidator = v.union(
   v.literal("queued"),
@@ -812,6 +814,9 @@ const skillVersions = defineTable({
   }),
   createdBy: v.id("users"),
   createdAt: v.number(),
+  // Deprecated persisted fields retained temporarily for production cleanup.
+  clawScanNote: v.optional(v.string()),
+  clawScanNoteUpdatedAt: v.optional(v.number()),
   softDeletedAt: v.optional(v.number()),
   sha256hash: v.optional(v.string()),
   vtAnalysis: v.optional(vtAnalysisValidator),
@@ -1240,6 +1245,9 @@ const packageReleases = defineTable({
   createdBy: v.id("users"),
   publishActor: packagePublishActorValidator,
   createdAt: v.number(),
+  // Deprecated persisted fields retained temporarily for production cleanup.
+  clawScanNote: v.optional(v.string()),
+  clawScanNoteUpdatedAt: v.optional(v.number()),
   softDeletedAt: v.optional(v.number()),
 })
   .index("by_package", ["packageId"])

--- a/convex/securityScan.ts
+++ b/convex/securityScan.ts
@@ -96,9 +96,16 @@ const jobSourceValidator = v.union(
   v.literal("backfill"),
   v.literal("bulk-rescan"),
   v.literal("manual"),
+  v.literal("clawscan-note"),
 );
 
-type SecurityScanJobSource = "publish" | "vt-update" | "backfill" | "bulk-rescan" | "manual";
+type SecurityScanJobSource =
+  | "publish"
+  | "vt-update"
+  | "backfill"
+  | "bulk-rescan"
+  | "manual"
+  | "clawscan-note";
 
 const CLAIM_SOURCE_ORDER: SecurityScanJobSource[] = [
   "backfill",


### PR DESCRIPTION
## Summary
- Temporarily re-allow deprecated ClawScan note fields and the old `clawscan-note` scan job source so production can accept a cleanup deploy.
- Add internal maintenance actions to clear `clawScanNote` / `clawScanNoteUpdatedAt` from `packageReleases` and `skillVersions`.
- Add an internal maintenance action to map old `securityScanJobs.source = "clawscan-note"` rows to `manual` so the final narrowed schema can deploy.

## Tests
- `bunx vitest run convex/maintenance.test.ts --testNamePattern "deprecated ClawScan"`
- `bunx vitest run convex/maintenance.test.ts`
- `bunx convex codegen`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit && bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bun run ci:packages`
- `bun run ci:static`
- `bun run ci:unit`
- `bunx convex deploy --dry-run --typecheck=disable -y`

## Rollout
1. Merge and deploy this temporary widened schema.
2. Run dry-run/apply cleanup actions for `packageReleases`, `skillVersions`, and `securityScanJobs`.
3. Verify no deprecated data remains.
4. Deploy current `main` narrow schema again.
