### PR TITLE
fix: tolerate duplicate github auth rows

### DIFF
--- a/convex/lib/githubIdentity.test.ts
+++ b/convex/lib/githubIdentity.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { canHealSkillOwnershipByGitHubProviderAccountId } from "./githubIdentity";
+import type { Doc, Id } from "../_generated/dataModel";
+import type { QueryCtx } from "../_generated/server";
+import {
+  canHealSkillOwnershipByGitHubProviderAccountId,
+  getGitHubProviderAccountId,
+} from "./githubIdentity";
 
 describe("canHealSkillOwnershipByGitHubProviderAccountId", () => {
   it("denies when either providerAccountId is missing", () => {
@@ -16,4 +21,80 @@ describe("canHealSkillOwnershipByGitHubProviderAccountId", () => {
   it("allows when providerAccountId matches", () => {
     expect(canHealSkillOwnershipByGitHubProviderAccountId("123", "123")).toBe(true);
   });
+});
+
+describe("getGitHubProviderAccountId", () => {
+  const userId = "users:github-user" as Id<"users">;
+
+  it("returns null when the user has no GitHub auth account", async () => {
+    const ctx = createQueryCtx([]);
+
+    await expect(getGitHubProviderAccountId(ctx, userId)).resolves.toBeNull();
+  });
+
+  it("returns the providerAccountId for duplicate rows with the same GitHub identity", async () => {
+    const ctx = createQueryCtx([
+      createAuthAccount("authAccounts:first", "123"),
+      createAuthAccount("authAccounts:second", "123"),
+    ]);
+
+    await expect(getGitHubProviderAccountId(ctx, userId)).resolves.toBe("123");
+  });
+
+  it("fails closed when duplicate rows disagree on the GitHub identity", async () => {
+    const ctx = createQueryCtx([
+      createAuthAccount("authAccounts:first", "123"),
+      createAuthAccount("authAccounts:second", "456"),
+    ]);
+
+    await expect(getGitHubProviderAccountId(ctx, userId)).rejects.toThrow(
+      "Conflicting GitHub auth accounts for user users:github-user: [authAccounts:first, authAccounts:second]",
+    );
+  });
+
+  it("fails closed when duplicate rows exceed the bounded reconciliation window", async () => {
+    const ctx = createQueryCtx(
+      Array.from({ length: 11 }, (_, index) =>
+        createAuthAccount(`authAccounts:${index + 1}`, "123"),
+      ),
+    );
+
+    await expect(getGitHubProviderAccountId(ctx, userId)).rejects.toThrow(
+      "Too many GitHub auth accounts for user users:github-user; manual reconciliation required: [authAccounts:1, authAccounts:2, authAccounts:3, authAccounts:4, authAccounts:5, authAccounts:6, authAccounts:7, authAccounts:8, authAccounts:9, authAccounts:10, authAccounts:11]",
+    );
+  });
+
+  function createAuthAccount(id: string, providerAccountId: string): Doc<"authAccounts"> {
+    return {
+      _id: id,
+      _creationTime: 1,
+      userId,
+      provider: "github",
+      providerAccountId,
+    } as unknown as Doc<"authAccounts">;
+  }
+
+  function createQueryCtx(accounts: Array<Doc<"authAccounts">>): Pick<QueryCtx, "db"> {
+    const builder = {
+      eq: () => builder,
+    };
+    const query = {
+      withIndex: (name: string, configure: (q: typeof builder) => typeof builder) => {
+        expect(name).toBe("userIdAndProvider");
+        configure(builder);
+        return {
+          take: async (limit: number) => accounts.slice(0, limit),
+        };
+      },
+    };
+
+    return {
+      db: {
+        query: (table: string) => {
+          expect(table).toBe("authAccounts");
+          return query;
+        },
+      },
+    } as unknown as Pick<QueryCtx, "db">;
+  }
 });

--- a/convex/lib/githubIdentity.ts
+++ b/convex/lib/githubIdentity.ts
@@ -1,5 +1,7 @@
-import type { Id } from "../_generated/dataModel";
+import type { Doc, Id } from "../_generated/dataModel";
 import type { QueryCtx } from "../_generated/server";
+
+const MAX_GITHUB_AUTH_ACCOUNTS_PER_USER = 10;
 
 export function canHealSkillOwnershipByGitHubProviderAccountId(
   ownerProviderAccountId: string | null | undefined,
@@ -14,9 +16,38 @@ export async function getGitHubProviderAccountId(
   ctx: Pick<QueryCtx, "db">,
   userId: Id<"users">,
 ): Promise<string | null> {
-  const account = await ctx.db
+  const accounts = await ctx.db
     .query("authAccounts")
     .withIndex("userIdAndProvider", (q) => q.eq("userId", userId).eq("provider", "github"))
-    .unique();
-  return account?.providerAccountId ?? null;
+    .take(MAX_GITHUB_AUTH_ACCOUNTS_PER_USER + 1);
+  if (accounts.length === 0) return null;
+  if (accounts.length > MAX_GITHUB_AUTH_ACCOUNTS_PER_USER) {
+    throw new Error(formatTooManyGitHubAuthAccountsError(userId, accounts));
+  }
+
+  const providerAccountId = accounts[0]?.providerAccountId;
+  if (
+    typeof providerAccountId !== "string" ||
+    accounts.some((account) => account.providerAccountId !== providerAccountId)
+  ) {
+    throw new Error(formatConflictingGitHubAuthAccountsError(userId, accounts));
+  }
+
+  return providerAccountId;
+}
+
+function formatConflictingGitHubAuthAccountsError(
+  userId: Id<"users">,
+  accounts: Array<Doc<"authAccounts">>,
+) {
+  const accountIds = accounts.map((account) => account._id).join(", ");
+  return `Conflicting GitHub auth accounts for user ${userId}: [${accountIds}]`;
+}
+
+function formatTooManyGitHubAuthAccountsError(
+  userId: Id<"users">,
+  accounts: Array<Doc<"authAccounts">>,
+) {
+  const accountIds = accounts.map((account) => account._id).join(", ");
+  return `Too many GitHub auth accounts for user ${userId}; manual reconciliation required: [${accountIds}]`;
 }

--- a/convex/skills.ownerMigration.test.ts
+++ b/convex/skills.ownerMigration.test.ts
@@ -314,7 +314,7 @@ function createMigrationFixture(params: {
       if (table === "authAccounts") {
         return {
           withIndex: () => ({
-            unique: async () => null,
+            take: async () => [],
           }),
         };
       }

--- a/convex/skills.rateLimit.test.ts
+++ b/convex/skills.rateLimit.test.ts
@@ -212,11 +212,11 @@ describe("skills anti-spam guards", () => {
             withIndex: (name: string) => {
               if (name !== "userIdAndProvider") throw new Error(`unexpected auth index ${name}`);
               return {
-                unique: async () => {
+                take: async () => {
                   authAccountLookupCount += 1;
                   return authAccountLookupCount === 1
-                    ? { providerAccountId: "owner-gh" }
-                    : { providerAccountId: "caller-gh" };
+                    ? [{ providerAccountId: "owner-gh" }]
+                    : [{ providerAccountId: "caller-gh" }];
                 },
               };
             },
@@ -293,11 +293,11 @@ describe("skills anti-spam guards", () => {
             withIndex: (name: string) => {
               if (name !== "userIdAndProvider") throw new Error(`unexpected auth index ${name}`);
               return {
-                unique: async () => {
+                take: async () => {
                   authAccountLookupCount += 1;
                   return authAccountLookupCount === 1
-                    ? { providerAccountId: "owner-gh" }
-                    : { providerAccountId: "caller-gh" };
+                    ? [{ providerAccountId: "owner-gh" }]
+                    : [{ providerAccountId: "caller-gh" }];
                 },
               };
             },
@@ -361,11 +361,11 @@ describe("skills anti-spam guards", () => {
             withIndex: (name: string) => {
               if (name !== "userIdAndProvider") throw new Error(`unexpected auth index ${name}`);
               return {
-                unique: async () => {
+                take: async () => {
                   authAccountLookupCount += 1;
                   return authAccountLookupCount === 1
-                    ? { providerAccountId: "owner-gh" }
-                    : { providerAccountId: "caller-gh" };
+                    ? [{ providerAccountId: "owner-gh" }]
+                    : [{ providerAccountId: "caller-gh" }];
                 },
               };
             },
@@ -777,7 +777,7 @@ describe("skills anti-spam guards", () => {
           return {
             withIndex: (name: string) => {
               if (name !== "userIdAndProvider") throw new Error(`unexpected auth index ${name}`);
-              return { unique: async () => null };
+              return { take: async () => [] };
             },
           };
         }
@@ -945,9 +945,9 @@ describe("skills anti-spam guards", () => {
             withIndex: (name: string) => {
               if (name !== "userIdAndProvider") throw new Error(`unexpected auth index ${name}`);
               return {
-                unique: async () => {
+                take: async () => {
                   authAccountLookupCount += 1;
-                  return authAccountLookupCount <= 2 ? { providerAccountId: "shared-gh" } : null;
+                  return authAccountLookupCount <= 2 ? [{ providerAccountId: "shared-gh" }] : [];
                 },
               };
             },

--- a/convex/skills.slugAvailability.test.ts
+++ b/convex/skills.slugAvailability.test.ts
@@ -268,16 +268,16 @@ function createCtx(options: {
               throw new Error(`unexpected authAccounts index ${name}`);
             }
             return {
-              unique: async () => {
+              take: async () => {
                 authAccountLookupCount += 1;
                 if (authAccountLookupCount === 1) {
                   return options.ownerProviderAccountId
-                    ? { providerAccountId: options.ownerProviderAccountId }
-                    : null;
+                    ? [{ providerAccountId: options.ownerProviderAccountId }]
+                    : [];
                 }
                 return options.callerProviderAccountId
-                  ? { providerAccountId: options.callerProviderAccountId }
-                  : null;
+                  ? [{ providerAccountId: options.callerProviderAccountId }]
+                  : [];
               },
             };
           },

--- a/specs/auth-identity.md
+++ b/specs/auth-identity.md
@@ -20,6 +20,14 @@ into strings such as `"undefined"` and used as `authAccounts.providerAccountId`.
 Malformed GitHub API responses during provider outages are authentication
 failures, not anonymous or linkable GitHub identities.
 
+When reading GitHub auth accounts for authorization-sensitive checks, duplicate
+`authAccounts` rows for the same ClawHub user may only be treated as recoverable
+when every row in a bounded reconciliation window has the same GitHub
+`providerAccountId`. Any disagreement or overflow beyond that bounded window
+means the account binding is ambiguous and must fail closed with
+operator-visible diagnostics instead of choosing by creation time or any other
+arbitrary tie breaker.
+
 `users.me`, protected mutations, ownership checks, and API token issuance must
 derive the actor server-side from Convex Auth (`getAuthUserId` via
 `requireUser`/`getOptionalActiveAuthUserId`). They must not accept client-supplied


### PR DESCRIPTION
## Summary

- make GitHub auth identity lookup tolerate duplicate `authAccounts` rows only when every row in a bounded reconciliation window has the same immutable GitHub `providerAccountId`
- keep ambiguous duplicate GitHub account rows and overflow beyond the bounded window fail-closed with operator-visible row ids instead of choosing an arbitrary row
- document the duplicate-row identity invariant and update affected test mocks for the new bounded `take()` lookup

Fixes #2588.

## Tests

- `bunx vitest run convex/lib/githubIdentity.test.ts convex/skills.slugAvailability.test.ts convex/skills.rateLimit.test.ts convex/skills.ownerMigration.test.ts`
- `bun run format:check -- convex/lib/githubIdentity.ts convex/lib/githubIdentity.test.ts convex/skills.slugAvailability.test.ts convex/skills.rateLimit.test.ts convex/skills.ownerMigration.test.ts specs/auth-identity.md`
- `bunx oxlint --type-aware --tsconfig ./tsconfig.oxlint.json convex/lib/githubIdentity.ts convex/lib/githubIdentity.test.ts convex/skills.slugAvailability.test.ts convex/skills.rateLimit.test.ts convex/skills.ownerMigration.test.ts`
- `bunx tsc --noEmit --pretty false`

`bun run ci:unit` was also run before the bounded follow-up. The GitHub identity and publishing-related failures are fixed; the remaining failure is unrelated to this change and comes from `scripts/skill-cards/run-skill-card-worker.test.ts` trying to read `/Users/mauriceniu/Documents/New%20project/clawhub-issue-2588/scripts/skill-cards/templates/clawhub-skill-card.md.j2`, where the local workspace path space is URL-encoded as `%20`.

## Real behavior proof

Local Convex proof against this branch (`ec66f1e6`) used a temporary proof-only Convex mutation (removed before commit) that inserted real local `users` and `authAccounts` rows, called the real `getGitHubProviderAccountId` helper, and cleaned the rows in `finally`.

- `bunx convex dev --once --typecheck=disable`
- `bunx convex run --no-push proofGithubIdentity:run '{"mode":"same"}'`
  - Result: `{ "authAccountCount": 2, "mode": "same", "providerAccountId": "2588", "result": "ok" }`
- `bunx convex run --no-push proofGithubIdentity:run '{"mode":"conflict"}'`
  - Result: real local Convex rows returned `result: "error"` with `Conflicting GitHub auth accounts for user ...: [<row id>, <row id>]`
- `bunx convex run --no-push proofGithubIdentity:run '{"mode":"overflow"}'`
  - Result: 11 real local auth rows returned `result: "error"` with `Too many GitHub auth accounts for user ...; manual reconciliation required: [<11 row ids>]`
