### PR TITLE
fix: add guarded personal publisher recovery

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -1375,6 +1375,73 @@ describe("httpApiV1 handlers", () => {
     );
   });
 
+  it("users/publisher-recovery plans personal publisher recovery for admin", async () => {
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      return {
+        ok: true,
+        dryRun: true,
+        recovered: false,
+        publisherId: "publishers:gingiris",
+        handle: "gingiris",
+        previousUser: {
+          userId: "users:legacy",
+          handle: "gingiris",
+          nextHandle: "gingiris-recovered",
+          githubProviderAccountId: "111",
+          authAccountCount: 1,
+        },
+        nextUser: {
+          userId: "users:current",
+          handle: "gingiris-1031",
+          nextHandle: "gingiris",
+          githubProviderAccountId: "222",
+          authAccountCount: 1,
+        },
+        retiredPersonalPublisher: null,
+        identityVerified: false,
+        reason: "Verified account continuity for issue #2555",
+      };
+    });
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:admin",
+      user: { _id: "users:admin", role: "admin" },
+    } as never);
+
+    const response = await __handlers.usersPostRouterV1Handler(
+      makeCtx({ runQuery: vi.fn(), runAction: vi.fn(), runMutation }),
+      new Request("https://example.com/api/v1/users/publisher-recovery", {
+        method: "POST",
+        body: JSON.stringify({
+          handle: "@Gingiris",
+          nextUserHandle: "@Gingiris-1031",
+          previousGitHubProviderAccountId: "111",
+          nextGitHubProviderAccountId: "222",
+          reason: "Verified account continuity for issue #2555",
+        }),
+      }),
+    );
+    if (response.status !== 200) throw new Error(await response.text());
+
+    expect(await response.json()).toMatchObject({
+      ok: true,
+      dryRun: true,
+      handle: "gingiris",
+    });
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        actorUserId: "users:admin",
+        publisherHandle: "gingiris",
+        nextUserHandle: "gingiris-1031",
+        previousGitHubProviderAccountId: "111",
+        nextGitHubProviderAccountId: "222",
+        confirmIdentityVerified: false,
+        dryRun: true,
+      }),
+    );
+  });
+
   it("users/publisher-official lists official publishers for admin", async () => {
     vi.mocked(requireApiTokenUser).mockResolvedValue({
       userId: "users:admin",

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -1406,6 +1406,7 @@ describe("httpApiV1 handlers", () => {
           packages: 0,
           packageInspectorWarnings: 0,
           githubSourcesChecked: 1,
+          handleReservations: 1,
         },
         identityVerified: false,
         reason: "Verified account continuity for issue #2555",

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -1399,6 +1399,14 @@ describe("httpApiV1 handlers", () => {
           authAccountCount: 1,
         },
         retiredPersonalPublisher: null,
+        resourceOwnerMigration: {
+          limitPerTable: 100,
+          skills: 1,
+          skillSlugAliases: 1,
+          packages: 0,
+          packageInspectorWarnings: 0,
+          githubSourcesChecked: 1,
+        },
         identityVerified: false,
         reason: "Verified account continuity for issue #2555",
       };

--- a/convex/httpApiV1/usersV1.ts
+++ b/convex/httpApiV1/usersV1.ts
@@ -22,6 +22,7 @@ const usersV1InternalRefs = internal as unknown as {
     listOfficialPublishersInternal: unknown;
     removeOrgPublisherMemberInternal: unknown;
     removeOfficialPublisherInternal: unknown;
+    recoverPersonalPublisherInternal: unknown;
   };
   users: {
     getBanAppealContextByGitHubProviderAccountIdInternal: unknown;
@@ -94,7 +95,8 @@ export async function usersPostRouterV1Handler(ctx: ActionCtx, request: Request)
     action !== "publisher" &&
     action !== "publisher-delete" &&
     action !== "publisher-official" &&
-    action !== "publisher-member"
+    action !== "publisher-member" &&
+    action !== "publisher-recovery"
   ) {
     return text("Not found", 404, rate.headers);
   }
@@ -165,6 +167,12 @@ export async function usersPostRouterV1Handler(ctx: ActionCtx, request: Request)
     const admin = requireAdminOrResponse(actorUser, rate.headers);
     if (!admin.ok) return admin.response;
     return handleAdminRemovePublisherMember(ctx, payload, actorUserId, rate.headers);
+  }
+
+  if (action === "publisher-recovery") {
+    const admin = requireAdminOrResponse(actorUser, rate.headers);
+    if (!admin.ok) return admin.response;
+    return handleAdminRecoverPersonalPublisher(ctx, payload, actorUserId, rate.headers);
   }
 
   const handleRaw = typeof payload.handle === "string" ? payload.handle.trim() : "";
@@ -755,6 +763,81 @@ async function handleAdminOfficialPublisherPost(
     return json(result, 200, headers);
   } catch (error) {
     const message = error instanceof Error ? error.message : "Official publisher update failed";
+    if (message.toLowerCase().includes("forbidden")) return text("Forbidden", 403, headers);
+    if (message.toLowerCase().includes("unauthorized")) return text("Unauthorized", 401, headers);
+    if (message.toLowerCase().includes("not found")) return text(message, 404, headers);
+    return text(message, 400, headers);
+  }
+}
+
+async function handleAdminRecoverPersonalPublisher(
+  ctx: ActionCtx,
+  payload: Record<string, unknown>,
+  actorUserId: Id<"users">,
+  headers: HeadersInit,
+) {
+  const publisherHandle =
+    typeof payload.handle === "string"
+      ? payload.handle.trim().replace(/^@+/, "").toLowerCase()
+      : "";
+  const nextUserHandle =
+    typeof payload.nextUserHandle === "string"
+      ? payload.nextUserHandle.trim().replace(/^@+/, "").toLowerCase()
+      : "";
+  const previousGitHubProviderAccountId =
+    typeof payload.previousGitHubProviderAccountId === "string"
+      ? payload.previousGitHubProviderAccountId.trim()
+      : "";
+  const nextGitHubProviderAccountId =
+    typeof payload.nextGitHubProviderAccountId === "string"
+      ? payload.nextGitHubProviderAccountId.trim()
+      : "";
+  const retiredUserHandle =
+    typeof payload.retiredUserHandle === "string"
+      ? payload.retiredUserHandle.trim().replace(/^@+/, "").toLowerCase()
+      : "";
+  const reason = typeof payload.reason === "string" ? payload.reason.trim() : "";
+  const dryRun = payload.dryRun !== false;
+  const confirmIdentityVerified = payload.confirmIdentityVerified === true;
+
+  if (!publisherHandle) return text("Missing handle", 400, headers);
+  if (!previousGitHubProviderAccountId) {
+    return text("Missing previousGitHubProviderAccountId", 400, headers);
+  }
+  if (!nextGitHubProviderAccountId) {
+    return text("Missing nextGitHubProviderAccountId", 400, headers);
+  }
+  if (!/^\d+$/.test(previousGitHubProviderAccountId)) {
+    return text("previousGitHubProviderAccountId must be numeric", 400, headers);
+  }
+  if (!/^\d+$/.test(nextGitHubProviderAccountId)) {
+    return text("nextGitHubProviderAccountId must be numeric", 400, headers);
+  }
+  if (!reason) return text("Missing reason", 400, headers);
+  if (reason.length > 500) return text("Reason too long (max 500 chars)", 400, headers);
+  if (!dryRun && !confirmIdentityVerified) {
+    return text("confirmIdentityVerified is required when dryRun is false", 400, headers);
+  }
+
+  try {
+    const result = await runUsersV1MutationRef(
+      ctx,
+      usersV1InternalRefs.publishers.recoverPersonalPublisherInternal,
+      {
+        actorUserId,
+        publisherHandle,
+        previousGitHubProviderAccountId,
+        nextGitHubProviderAccountId,
+        ...(nextUserHandle ? { nextUserHandle } : {}),
+        ...(retiredUserHandle ? { retiredUserHandle } : {}),
+        reason,
+        confirmIdentityVerified,
+        dryRun,
+      },
+    );
+    return json(result, 200, headers);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Publisher recovery failed";
     if (message.toLowerCase().includes("forbidden")) return text("Forbidden", 403, headers);
     if (message.toLowerCase().includes("unauthorized")) return text("Unauthorized", 401, headers);
     if (message.toLowerCase().includes("not found")) return text(message, 404, headers);

--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -137,6 +137,7 @@ const recoverPersonalPublisherInternalHandler = (
         packages: number;
         packageInspectorWarnings: number;
         githubSourcesChecked: number;
+        handleReservations: number;
       };
     }
   >
@@ -4167,6 +4168,7 @@ describe("legacy publisher migration", () => {
       legacyResources?: boolean;
       tooManyLegacySkills?: boolean;
       unexpectedResourceOwner?: boolean;
+      unexpectedReservationOwner?: boolean;
     } = {},
   ) {
     const users = new Map<string, Record<string, unknown>>([
@@ -4406,6 +4408,24 @@ describe("legacy publisher migration", () => {
           ]
         : [],
     );
+    const reservedHandles = new Map<string, Record<string, unknown>>(
+      options.legacyResources
+        ? [
+            [
+              "reservedHandles:gingiris",
+              {
+                _id: "reservedHandles:gingiris",
+                handle: "gingiris",
+                rightfulOwnerUserId: options.unexpectedReservationOwner
+                  ? "users:someone-else"
+                  : "users:legacy",
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            ],
+          ]
+        : [],
+    );
     const inserts: Array<{ table: string; value: Record<string, unknown> }> = [];
     const patches: Array<{ id: string; patch: Record<string, unknown> }> = [];
     const deletes: string[] = [];
@@ -4423,6 +4443,7 @@ describe("legacy publisher migration", () => {
       packagePluginCategorySearchDigest,
       packageInspectorWarnings,
       githubSkillSources,
+      reservedHandles,
     ];
     const get = vi.fn(async (id: string) => {
       return allRows.map((rows) => rows.get(id)).find(Boolean) ?? null;
@@ -4455,17 +4476,17 @@ describe("legacy publisher migration", () => {
       withIndex: vi.fn(
         (
           _indexName: string,
-          builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown,
+          builder?: (q: { eq: (field: string, value: unknown) => unknown }) => unknown,
         ) => {
-          const fields: Record<string, string> = {};
+          const fields: Record<string, unknown> = {};
           const q = {
-            eq: (field: string, value: string) => {
+            eq: (field: string, value: unknown) => {
               fields[field] = value;
               return q;
             },
           };
           builder?.(q);
-          return {
+          const indexedQuery = {
             unique: vi.fn(async () => {
               if (table === "users") {
                 return [...users.values()].find((user) => user.handle === fields.handle) ?? null;
@@ -4511,6 +4532,13 @@ describe("legacy publisher migration", () => {
               if (table === "publisherMembers") {
                 return [...publisherMembers.values()].filter(
                   (member) => member.publisherId === fields.publisherId,
+                );
+              }
+              if (table === "reservedHandles") {
+                return [...reservedHandles.values()].filter(
+                  (reservation) =>
+                    reservation.handle === fields.handle &&
+                    reservation.releasedAt === fields.releasedAt,
                 );
               }
               if (table === "skills" && fields.ownerPublisherId === "publishers:gingiris") {
@@ -4560,6 +4588,10 @@ describe("legacy publisher migration", () => {
               return [];
             }),
           };
+          return {
+            ...indexedQuery,
+            order: vi.fn(() => indexedQuery),
+          };
         },
       ),
     }));
@@ -4588,6 +4620,7 @@ describe("legacy publisher migration", () => {
       packageCapabilitySearchDigest,
       packageInspectorWarnings,
       githubSkillSources,
+      reservedHandles,
     };
   }
 
@@ -4607,6 +4640,7 @@ describe("legacy publisher migration", () => {
       packageSearchDigest,
       packageCapabilitySearchDigest,
       packageInspectorWarnings,
+      reservedHandles,
     } = makePersonalPublisherRecoveryCtx({ legacyResources: true });
 
     const result = await recoverPersonalPublisherInternalHandler(ctx as never, {
@@ -4638,6 +4672,7 @@ describe("legacy publisher migration", () => {
         packages: 1,
         packageInspectorWarnings: 1,
         githubSourcesChecked: 1,
+        handleReservations: 1,
       },
     });
     expect(users.get("users:legacy")).toMatchObject({
@@ -4690,6 +4725,10 @@ describe("legacy publisher migration", () => {
     expect(packageInspectorWarnings.get("packageInspectorWarnings:legacy")).toMatchObject({
       ownerUserId: "users:current",
     });
+    expect(reservedHandles.get("reservedHandles:gingiris")).toMatchObject({
+      rightfulOwnerUserId: "users:current",
+      updatedAt: 1_700_000_000_000,
+    });
     expect(deletes).toContain("publisherMembers:legacy");
     expect(inserts).toContainEqual(
       expect.objectContaining({
@@ -4735,6 +4774,7 @@ describe("legacy publisher migration", () => {
         "packageSearchDigest:legacy",
         "packageCapabilitySearchDigest:legacy-tools",
         "packageInspectorWarnings:legacy",
+        "reservedHandles:gingiris",
       ]),
     );
   });
@@ -4778,6 +4818,28 @@ describe("legacy publisher migration", () => {
         dryRun: false,
       }),
     ).rejects.toThrow(/another user/i);
+    expect(patches).toHaveLength(0);
+    expect(inserts).toHaveLength(0);
+  });
+
+  it("fails closed when the recovered handle reservation belongs to another user", async () => {
+    const { ctx, inserts, patches } = makePersonalPublisherRecoveryCtx({
+      legacyResources: true,
+      unexpectedReservationOwner: true,
+    });
+
+    await expect(
+      recoverPersonalPublisherInternalHandler(ctx as never, {
+        actorUserId: "users:admin",
+        publisherHandle: "gingiris",
+        previousGitHubProviderAccountId: "111",
+        nextGitHubProviderAccountId: "222",
+        nextUserHandle: "gingiris-1031",
+        reason: "Verified account continuity for issue #2555",
+        confirmIdentityVerified: true,
+        dryRun: false,
+      }),
+    ).rejects.toThrow(/reservation .* belongs to another user/i);
     expect(patches).toHaveLength(0);
     expect(inserts).toHaveLength(0);
   });

--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -14,6 +14,7 @@ import {
   migrateLegacyPublisherHandleToOrgInternal,
   ensureOrgPublisherHandleInternal,
   removeOrgPublisherMemberInternal,
+  recoverPersonalPublisherInternal,
   createOrg,
   deleteOrg,
   removeMember,
@@ -97,6 +98,38 @@ const removeOrgPublisherMemberInternalHandler = (
       handle: string;
       removed: boolean;
       member: { userId: string; handle: string; role: "owner" | "admin" | "publisher" };
+    }
+  >
+)._handler;
+
+const recoverPersonalPublisherInternalHandler = (
+  recoverPersonalPublisherInternal as unknown as WrappedHandler<
+    {
+      actorUserId: string;
+      publisherHandle: string;
+      previousGitHubProviderAccountId: string;
+      nextGitHubProviderAccountId: string;
+      nextUserHandle?: string;
+      retiredUserHandle?: string;
+      reason: string;
+      confirmIdentityVerified: boolean;
+      dryRun?: boolean;
+    },
+    {
+      ok: true;
+      dryRun: boolean;
+      recovered: boolean;
+      publisherId: string;
+      handle: string;
+      previousUser: { userId: string; handle: string | null; nextHandle: string | null };
+      nextUser: { userId: string; handle: string | null; nextHandle: string };
+      retiredPersonalPublisher: {
+        publisherId: string;
+        handle: string;
+        skills: number;
+        packages: number;
+        githubSources: number;
+      } | null;
     }
   >
 )._handler;
@@ -4120,6 +4153,296 @@ describe("self-serve org publisher creation", () => {
 });
 
 describe("legacy publisher migration", () => {
+  function makePersonalPublisherRecoveryCtx(options: { destinationHasResources?: boolean } = {}) {
+    const users = new Map<string, Record<string, unknown>>([
+      ["users:admin", { _id: "users:admin", role: "admin", handle: "admin" }],
+      [
+        "users:legacy",
+        {
+          _id: "users:legacy",
+          role: "user",
+          handle: "gingiris",
+          personalPublisherId: "publishers:gingiris",
+          updatedAt: 1,
+        },
+      ],
+      [
+        "users:current",
+        {
+          _id: "users:current",
+          role: "user",
+          handle: "gingiris-1031",
+          personalPublisherId: "publishers:gingiris-1031",
+          updatedAt: 1,
+        },
+      ],
+    ]);
+    const publishers = new Map<string, Record<string, unknown>>([
+      [
+        "publishers:gingiris",
+        {
+          _id: "publishers:gingiris",
+          kind: "user",
+          handle: "gingiris",
+          displayName: "gingiris",
+          linkedUserId: "users:legacy",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      [
+        "publishers:gingiris-1031",
+        {
+          _id: "publishers:gingiris-1031",
+          kind: "user",
+          handle: "gingiris-1031",
+          displayName: "gingiris-1031",
+          linkedUserId: "users:current",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+    ]);
+    const authAccounts = [
+      {
+        _id: "authAccounts:legacy",
+        provider: "github",
+        providerAccountId: "111",
+        userId: "users:legacy",
+      },
+      {
+        _id: "authAccounts:current",
+        provider: "github",
+        providerAccountId: "222",
+        userId: "users:current",
+      },
+    ];
+    const publisherMembers = new Map<string, Record<string, unknown>>([
+      [
+        "publisherMembers:legacy",
+        {
+          _id: "publisherMembers:legacy",
+          publisherId: "publishers:gingiris",
+          userId: "users:legacy",
+          role: "owner",
+        },
+      ],
+      [
+        "publisherMembers:current",
+        {
+          _id: "publisherMembers:current",
+          publisherId: "publishers:gingiris-1031",
+          userId: "users:current",
+          role: "owner",
+        },
+      ],
+    ]);
+    const inserts: Array<{ table: string; value: Record<string, unknown> }> = [];
+    const patches: Array<{ id: string; patch: Record<string, unknown> }> = [];
+    const deletes: string[] = [];
+
+    const get = vi.fn(async (id: string) => {
+      return users.get(id) ?? publishers.get(id) ?? publisherMembers.get(id) ?? null;
+    });
+    const patch = vi.fn(async (id: string, patchValue: Record<string, unknown>) => {
+      patches.push({ id, patch: patchValue });
+      const row = users.get(id) ?? publishers.get(id) ?? publisherMembers.get(id);
+      if (row) Object.assign(row, patchValue);
+    });
+    const insert = vi.fn(async (table: string, value: Record<string, unknown>) => {
+      const id = `${table}:inserted-${inserts.length + 1}`;
+      const row = { _id: id, ...value };
+      inserts.push({ table, value: row });
+      if (table === "publisherMembers") publisherMembers.set(id, row);
+      return id;
+    });
+    const deleteFn = vi.fn(async (id: string) => {
+      deletes.push(id);
+      publisherMembers.delete(id);
+    });
+    const query = vi.fn((table: string) => ({
+      withIndex: vi.fn(
+        (
+          _indexName: string,
+          builder?: (q: { eq: (field: string, value: string) => unknown }) => unknown,
+        ) => {
+          const fields: Record<string, string> = {};
+          const q = {
+            eq: (field: string, value: string) => {
+              fields[field] = value;
+              return q;
+            },
+          };
+          builder?.(q);
+          return {
+            unique: vi.fn(async () => {
+              if (table === "users") {
+                return [...users.values()].find((user) => user.handle === fields.handle) ?? null;
+              }
+              if (table === "publishers" && fields.handle) {
+                return (
+                  [...publishers.values()].find(
+                    (publisher) => publisher.handle === fields.handle,
+                  ) ?? null
+                );
+              }
+              if (table === "publishers" && fields.linkedUserId) {
+                return (
+                  [...publishers.values()].find(
+                    (publisher) => publisher.linkedUserId === fields.linkedUserId,
+                  ) ?? null
+                );
+              }
+              return null;
+            }),
+            take: vi.fn(async () => {
+              if (table === "authAccounts") {
+                return authAccounts.filter(
+                  (account) =>
+                    account.provider === fields.provider &&
+                    account.providerAccountId === fields.providerAccountId,
+                );
+              }
+              if (table === "publisherMembers") {
+                return [...publisherMembers.values()].filter(
+                  (member) => member.publisherId === fields.publisherId,
+                );
+              }
+              if (
+                options.destinationHasResources &&
+                (table === "skills" || table === "packages" || table === "githubSkillSources") &&
+                fields.ownerPublisherId === "publishers:gingiris-1031"
+              ) {
+                return [{ _id: `${table}:resource` }];
+              }
+              return [];
+            }),
+          };
+        },
+      ),
+    }));
+
+    return {
+      ctx: {
+        db: {
+          get,
+          patch,
+          insert,
+          delete: deleteFn,
+          query,
+          normalizeId: vi.fn(),
+        },
+      },
+      users,
+      publishers,
+      inserts,
+      patches,
+      deletes,
+    };
+  }
+
+  it("recovers a personal publisher for a verified replacement GitHub principal", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    const { ctx, users, publishers, inserts, patches, deletes } =
+      makePersonalPublisherRecoveryCtx();
+
+    const result = await recoverPersonalPublisherInternalHandler(ctx as never, {
+      actorUserId: "users:admin",
+      publisherHandle: "gingiris",
+      previousGitHubProviderAccountId: "111",
+      nextGitHubProviderAccountId: "222",
+      nextUserHandle: "gingiris-1031",
+      reason: "Verified account continuity for issue #2555",
+      confirmIdentityVerified: true,
+      dryRun: false,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      dryRun: false,
+      recovered: true,
+      publisherId: "publishers:gingiris",
+      handle: "gingiris",
+      previousUser: { userId: "users:legacy", nextHandle: "gingiris-recovered" },
+      nextUser: { userId: "users:current", nextHandle: "gingiris" },
+      retiredPersonalPublisher: {
+        publisherId: "publishers:gingiris-1031",
+        handle: "gingiris-1031",
+      },
+    });
+    expect(users.get("users:legacy")).toMatchObject({
+      handle: "gingiris-recovered",
+      personalPublisherId: undefined,
+    });
+    expect(users.get("users:current")).toMatchObject({
+      handle: "gingiris",
+      personalPublisherId: "publishers:gingiris",
+    });
+    expect(publishers.get("publishers:gingiris")).toMatchObject({
+      linkedUserId: "users:current",
+    });
+    expect(publishers.get("publishers:gingiris-1031")).toMatchObject({
+      linkedUserId: undefined,
+      deactivatedAt: 1_700_000_000_000,
+    });
+    expect(deletes).toContain("publisherMembers:legacy");
+    expect(inserts).toContainEqual(
+      expect.objectContaining({
+        table: "publisherMembers",
+        value: expect.objectContaining({
+          publisherId: "publishers:gingiris",
+          userId: "users:current",
+          role: "owner",
+        }),
+      }),
+    );
+    expect(inserts).toContainEqual(
+      expect.objectContaining({
+        table: "auditLogs",
+        value: expect.objectContaining({
+          actorUserId: "users:admin",
+          action: "publisher.personal.recover",
+          targetType: "publisher",
+          targetId: "publishers:gingiris",
+          metadata: expect.objectContaining({
+            previousGitHubProviderAccountId: "111",
+            nextGitHubProviderAccountId: "222",
+            identityVerified: true,
+          }),
+        }),
+      }),
+    );
+    expect(patches.map((entry) => entry.id)).toEqual(
+      expect.arrayContaining([
+        "publishers:gingiris-1031",
+        "users:legacy",
+        "users:current",
+        "publishers:gingiris",
+      ]),
+    );
+  });
+
+  it("fails closed when the destination personal publisher has resources", async () => {
+    const { ctx, inserts, patches } = makePersonalPublisherRecoveryCtx({
+      destinationHasResources: true,
+    });
+
+    await expect(
+      recoverPersonalPublisherInternalHandler(ctx as never, {
+        actorUserId: "users:admin",
+        publisherHandle: "gingiris",
+        previousGitHubProviderAccountId: "111",
+        nextGitHubProviderAccountId: "222",
+        nextUserHandle: "gingiris-1031",
+        reason: "Verified account continuity for issue #2555",
+        confirmIdentityVerified: true,
+        dryRun: false,
+      }),
+    ).rejects.toThrow(/has resources/i);
+    expect(patches).toHaveLength(0);
+    expect(inserts).toHaveLength(0);
+  });
+
   it("lets admins create a missing org publisher with only the legacy package owner as owner", async () => {
     vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
 

--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -4180,6 +4180,9 @@ describe("legacy publisher migration", () => {
           role: "user",
           handle: "gingiris",
           personalPublisherId: "publishers:gingiris",
+          publishedSkills: 5,
+          totalDownloads: 100,
+          totalStars: 20,
           updatedAt: 1,
         },
       ],
@@ -4190,6 +4193,9 @@ describe("legacy publisher migration", () => {
           role: "user",
           handle: "gingiris-1031",
           personalPublisherId: "publishers:gingiris-1031",
+          publishedSkills: 2,
+          totalDownloads: 40,
+          totalStars: 4,
           updatedAt: 1,
         },
       ],
@@ -4265,12 +4271,14 @@ describe("legacy publisher migration", () => {
       tags: {},
       badges: {},
       stats: {
-        downloads: 0,
-        stars: 0,
+        downloads: 99,
+        stars: 19,
         comments: 0,
         installsCurrent: 0,
         installsAllTime: 0,
       },
+      statsDownloads: 12,
+      statsStars: 3,
       moderationStatus: "approved",
       createdAt: 1,
       updatedAt: 1,
@@ -4678,10 +4686,16 @@ describe("legacy publisher migration", () => {
     expect(users.get("users:legacy")).toMatchObject({
       handle: "gingiris-recovered",
       personalPublisherId: undefined,
+      publishedSkills: 4,
+      totalDownloads: 88,
+      totalStars: 17,
     });
     expect(users.get("users:current")).toMatchObject({
       handle: "gingiris",
       personalPublisherId: "publishers:gingiris",
+      publishedSkills: 3,
+      totalDownloads: 52,
+      totalStars: 7,
     });
     expect(publishers.get("publishers:gingiris")).toMatchObject({
       linkedUserId: "users:current",

--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -130,6 +130,14 @@ const recoverPersonalPublisherInternalHandler = (
         packages: number;
         githubSources: number;
       } | null;
+      resourceOwnerMigration: {
+        limitPerTable: number;
+        skills: number;
+        skillSlugAliases: number;
+        packages: number;
+        packageInspectorWarnings: number;
+        githubSourcesChecked: number;
+      };
     }
   >
 )._handler;
@@ -4153,7 +4161,14 @@ describe("self-serve org publisher creation", () => {
 });
 
 describe("legacy publisher migration", () => {
-  function makePersonalPublisherRecoveryCtx(options: { destinationHasResources?: boolean } = {}) {
+  function makePersonalPublisherRecoveryCtx(
+    options: {
+      destinationHasResources?: boolean;
+      legacyResources?: boolean;
+      tooManyLegacySkills?: boolean;
+      unexpectedResourceOwner?: boolean;
+    } = {},
+  ) {
     const users = new Map<string, Record<string, unknown>>([
       ["users:admin", { _id: "users:admin", role: "admin", handle: "admin" }],
       [
@@ -4237,16 +4252,184 @@ describe("legacy publisher migration", () => {
         },
       ],
     ]);
+    const baseSkill = {
+      _id: "skills:legacy-skill",
+      slug: "demo-skill",
+      displayName: "Demo Skill",
+      summary: "Recovered skill",
+      ownerUserId: options.unexpectedResourceOwner ? "users:someone-else" : "users:legacy",
+      ownerPublisherId: "publishers:gingiris",
+      forkOf: undefined,
+      tags: {},
+      badges: {},
+      stats: {
+        downloads: 0,
+        stars: 0,
+        comments: 0,
+        installsCurrent: 0,
+        installsAllTime: 0,
+      },
+      moderationStatus: "approved",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const skills = new Map<string, Record<string, unknown>>(
+      options.legacyResources
+        ? [["skills:legacy-skill", baseSkill]]
+        : options.tooManyLegacySkills
+          ? Array.from({ length: 101 }, (_, index) => [
+              `skills:legacy-${index}`,
+              {
+                ...baseSkill,
+                _id: `skills:legacy-${index}`,
+                slug: `demo-skill-${index}`,
+              },
+            ])
+          : [],
+    );
+    const skillSlugAliases = new Map<string, Record<string, unknown>>(
+      options.legacyResources
+        ? [
+            [
+              "skillSlugAliases:legacy",
+              {
+                _id: "skillSlugAliases:legacy",
+                slug: "old-demo-skill",
+                skillId: "skills:legacy-skill",
+                ownerUserId: "users:legacy",
+                ownerPublisherId: "publishers:gingiris",
+                createdAt: 1,
+                updatedAt: 1,
+              },
+            ],
+          ]
+        : [],
+    );
+    const skillSearchDigest = new Map<string, Record<string, unknown>>(
+      options.legacyResources
+        ? [
+            [
+              "skillSearchDigest:legacy",
+              {
+                _id: "skillSearchDigest:legacy",
+                skillId: "skills:legacy-skill",
+                ownerUserId: "users:legacy",
+                ownerPublisherId: "publishers:gingiris",
+              },
+            ],
+          ]
+        : [],
+    );
+    const basePackage = {
+      _id: "packages:legacy-package",
+      name: "@gingiris/demo-plugin",
+      normalizedName: "@gingiris/demo-plugin",
+      displayName: "Demo Plugin",
+      ownerUserId: "users:legacy",
+      ownerPublisherId: "publishers:gingiris",
+      family: "code-plugin",
+      channel: "community",
+      isOfficial: false,
+      tags: {},
+      capabilityTags: ["tools"],
+      compatibility: {},
+      capabilities: {},
+      verification: {},
+      scanStatus: "pending",
+      stats: { downloads: 0, installs: 0, stars: 0, versions: 1 },
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const packages = new Map<string, Record<string, unknown>>(
+      options.legacyResources ? [["packages:legacy-package", basePackage]] : [],
+    );
+    const packageSearchDigest = new Map<string, Record<string, unknown>>(
+      options.legacyResources
+        ? [
+            [
+              "packageSearchDigest:legacy",
+              {
+                _id: "packageSearchDigest:legacy",
+                packageId: "packages:legacy-package",
+                ownerUserId: "users:legacy",
+                ownerPublisherId: "publishers:gingiris",
+              },
+            ],
+          ]
+        : [],
+    );
+    const packageCapabilitySearchDigest = new Map<string, Record<string, unknown>>(
+      options.legacyResources
+        ? [
+            [
+              "packageCapabilitySearchDigest:legacy-tools",
+              {
+                _id: "packageCapabilitySearchDigest:legacy-tools",
+                packageId: "packages:legacy-package",
+                capabilityTag: "tools",
+                ownerUserId: "users:legacy",
+                ownerPublisherId: "publishers:gingiris",
+              },
+            ],
+          ]
+        : [],
+    );
+    const packagePluginCategorySearchDigest = new Map<string, Record<string, unknown>>();
+    const packageInspectorWarnings = new Map<string, Record<string, unknown>>(
+      options.legacyResources
+        ? [
+            [
+              "packageInspectorWarnings:legacy",
+              {
+                _id: "packageInspectorWarnings:legacy",
+                packageId: "packages:legacy-package",
+                releaseId: "packageReleases:legacy",
+                ownerUserId: "users:legacy",
+                ownerPublisherId: "publishers:gingiris",
+                createdAt: 1,
+              },
+            ],
+          ]
+        : [],
+    );
+    const githubSkillSources = new Map<string, Record<string, unknown>>(
+      options.legacyResources
+        ? [
+            [
+              "githubSkillSources:legacy",
+              {
+                _id: "githubSkillSources:legacy",
+                repo: "gingiris/skills",
+                ownerPublisherId: "publishers:gingiris",
+              },
+            ],
+          ]
+        : [],
+    );
     const inserts: Array<{ table: string; value: Record<string, unknown> }> = [];
     const patches: Array<{ id: string; patch: Record<string, unknown> }> = [];
     const deletes: string[] = [];
 
+    const allRows = [
+      users,
+      publishers,
+      publisherMembers,
+      skills,
+      skillSlugAliases,
+      skillSearchDigest,
+      packages,
+      packageSearchDigest,
+      packageCapabilitySearchDigest,
+      packagePluginCategorySearchDigest,
+      packageInspectorWarnings,
+      githubSkillSources,
+    ];
     const get = vi.fn(async (id: string) => {
-      return users.get(id) ?? publishers.get(id) ?? publisherMembers.get(id) ?? null;
+      return allRows.map((rows) => rows.get(id)).find(Boolean) ?? null;
     });
     const patch = vi.fn(async (id: string, patchValue: Record<string, unknown>) => {
       patches.push({ id, patch: patchValue });
-      const row = users.get(id) ?? publishers.get(id) ?? publisherMembers.get(id);
+      const row = allRows.map((rows) => rows.get(id)).find(Boolean);
       if (row) Object.assign(row, patchValue);
     });
     const insert = vi.fn(async (table: string, value: Record<string, unknown>) => {
@@ -4254,11 +4437,19 @@ describe("legacy publisher migration", () => {
       const row = { _id: id, ...value };
       inserts.push({ table, value: row });
       if (table === "publisherMembers") publisherMembers.set(id, row);
+      if (table === "skillSearchDigest") skillSearchDigest.set(id, row);
+      if (table === "packageSearchDigest") packageSearchDigest.set(id, row);
+      if (table === "packageCapabilitySearchDigest") packageCapabilitySearchDigest.set(id, row);
+      if (table === "packagePluginCategorySearchDigest") {
+        packagePluginCategorySearchDigest.set(id, row);
+      }
       return id;
     });
     const deleteFn = vi.fn(async (id: string) => {
       deletes.push(id);
       publisherMembers.delete(id);
+      packageCapabilitySearchDigest.delete(id);
+      packagePluginCategorySearchDigest.delete(id);
     });
     const query = vi.fn((table: string) => ({
       withIndex: vi.fn(
@@ -4293,6 +4484,20 @@ describe("legacy publisher migration", () => {
                   ) ?? null
                 );
               }
+              if (table === "skillSearchDigest" && fields.skillId) {
+                return (
+                  [...skillSearchDigest.values()].find(
+                    (digest) => digest.skillId === fields.skillId,
+                  ) ?? null
+                );
+              }
+              if (table === "packageSearchDigest" && fields.packageId) {
+                return (
+                  [...packageSearchDigest.values()].find(
+                    (digest) => digest.packageId === fields.packageId,
+                  ) ?? null
+                );
+              }
               return null;
             }),
             take: vi.fn(async () => {
@@ -4308,12 +4513,49 @@ describe("legacy publisher migration", () => {
                   (member) => member.publisherId === fields.publisherId,
                 );
               }
+              if (table === "skills" && fields.ownerPublisherId === "publishers:gingiris") {
+                return [...skills.values()];
+              }
+              if (
+                table === "skillSlugAliases" &&
+                fields.ownerPublisherId === "publishers:gingiris"
+              ) {
+                return [...skillSlugAliases.values()];
+              }
+              if (table === "packages" && fields.ownerPublisherId === "publishers:gingiris") {
+                return [...packages.values()];
+              }
+              if (
+                table === "packageInspectorWarnings" &&
+                fields.ownerPublisherId === "publishers:gingiris"
+              ) {
+                return [...packageInspectorWarnings.values()];
+              }
+              if (
+                table === "githubSkillSources" &&
+                fields.ownerPublisherId === "publishers:gingiris"
+              ) {
+                return [...githubSkillSources.values()];
+              }
               if (
                 options.destinationHasResources &&
                 (table === "skills" || table === "packages" || table === "githubSkillSources") &&
                 fields.ownerPublisherId === "publishers:gingiris-1031"
               ) {
                 return [{ _id: `${table}:resource` }];
+              }
+              return [];
+            }),
+            collect: vi.fn(async () => {
+              if (table === "packageCapabilitySearchDigest" && fields.packageId) {
+                return [...packageCapabilitySearchDigest.values()].filter(
+                  (digest) => digest.packageId === fields.packageId,
+                );
+              }
+              if (table === "packagePluginCategorySearchDigest" && fields.packageId) {
+                return [...packagePluginCategorySearchDigest.values()].filter(
+                  (digest) => digest.packageId === fields.packageId,
+                );
               }
               return [];
             }),
@@ -4338,13 +4580,34 @@ describe("legacy publisher migration", () => {
       inserts,
       patches,
       deletes,
+      skills,
+      skillSlugAliases,
+      skillSearchDigest,
+      packages,
+      packageSearchDigest,
+      packageCapabilitySearchDigest,
+      packageInspectorWarnings,
+      githubSkillSources,
     };
   }
 
   it("recovers a personal publisher for a verified replacement GitHub principal", async () => {
     vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
-    const { ctx, users, publishers, inserts, patches, deletes } =
-      makePersonalPublisherRecoveryCtx();
+    const {
+      ctx,
+      users,
+      publishers,
+      inserts,
+      patches,
+      deletes,
+      skills,
+      skillSlugAliases,
+      skillSearchDigest,
+      packages,
+      packageSearchDigest,
+      packageCapabilitySearchDigest,
+      packageInspectorWarnings,
+    } = makePersonalPublisherRecoveryCtx({ legacyResources: true });
 
     const result = await recoverPersonalPublisherInternalHandler(ctx as never, {
       actorUserId: "users:admin",
@@ -4369,6 +4632,13 @@ describe("legacy publisher migration", () => {
         publisherId: "publishers:gingiris-1031",
         handle: "gingiris-1031",
       },
+      resourceOwnerMigration: {
+        skills: 1,
+        skillSlugAliases: 1,
+        packages: 1,
+        packageInspectorWarnings: 1,
+        githubSourcesChecked: 1,
+      },
     });
     expect(users.get("users:legacy")).toMatchObject({
       handle: "gingiris-recovered",
@@ -4384,6 +4654,41 @@ describe("legacy publisher migration", () => {
     expect(publishers.get("publishers:gingiris-1031")).toMatchObject({
       linkedUserId: undefined,
       deactivatedAt: 1_700_000_000_000,
+    });
+    expect(skills.get("skills:legacy-skill")).toMatchObject({
+      ownerUserId: "users:current",
+      updatedAt: 1_700_000_000_000,
+    });
+    expect(skillSlugAliases.get("skillSlugAliases:legacy")).toMatchObject({
+      ownerUserId: "users:current",
+      updatedAt: 1_700_000_000_000,
+    });
+    expect(skillSearchDigest.get("skillSearchDigest:legacy")).toMatchObject({
+      ownerUserId: "users:current",
+      ownerPublisherId: "publishers:gingiris",
+      ownerHandle: "gingiris",
+      ownerKind: "user",
+    });
+    expect(packages.get("packages:legacy-package")).toMatchObject({
+      ownerUserId: "users:current",
+      updatedAt: 1_700_000_000_000,
+    });
+    expect(packageSearchDigest.get("packageSearchDigest:legacy")).toMatchObject({
+      ownerUserId: "users:current",
+      ownerPublisherId: "publishers:gingiris",
+      ownerHandle: "gingiris",
+      ownerKind: "user",
+    });
+    expect(
+      packageCapabilitySearchDigest.get("packageCapabilitySearchDigest:legacy-tools"),
+    ).toMatchObject({
+      ownerUserId: "users:current",
+      ownerPublisherId: "publishers:gingiris",
+      ownerHandle: "gingiris",
+      ownerKind: "user",
+    });
+    expect(packageInspectorWarnings.get("packageInspectorWarnings:legacy")).toMatchObject({
+      ownerUserId: "users:current",
     });
     expect(deletes).toContain("publisherMembers:legacy");
     expect(inserts).toContainEqual(
@@ -4408,6 +4713,11 @@ describe("legacy publisher migration", () => {
             previousGitHubProviderAccountId: "111",
             nextGitHubProviderAccountId: "222",
             identityVerified: true,
+            resourceOwnerMigration: expect.objectContaining({
+              skills: 1,
+              packages: 1,
+              packageInspectorWarnings: 1,
+            }),
           }),
         }),
       }),
@@ -4418,6 +4728,13 @@ describe("legacy publisher migration", () => {
         "users:legacy",
         "users:current",
         "publishers:gingiris",
+        "skills:legacy-skill",
+        "skillSearchDigest:legacy",
+        "skillSlugAliases:legacy",
+        "packages:legacy-package",
+        "packageSearchDigest:legacy",
+        "packageCapabilitySearchDigest:legacy-tools",
+        "packageInspectorWarnings:legacy",
       ]),
     );
   });
@@ -4439,6 +4756,49 @@ describe("legacy publisher migration", () => {
         dryRun: false,
       }),
     ).rejects.toThrow(/has resources/i);
+    expect(patches).toHaveLength(0);
+    expect(inserts).toHaveLength(0);
+  });
+
+  it("fails closed when recovered publisher resources belong to another user", async () => {
+    const { ctx, inserts, patches } = makePersonalPublisherRecoveryCtx({
+      legacyResources: true,
+      unexpectedResourceOwner: true,
+    });
+
+    await expect(
+      recoverPersonalPublisherInternalHandler(ctx as never, {
+        actorUserId: "users:admin",
+        publisherHandle: "gingiris",
+        previousGitHubProviderAccountId: "111",
+        nextGitHubProviderAccountId: "222",
+        nextUserHandle: "gingiris-1031",
+        reason: "Verified account continuity for issue #2555",
+        confirmIdentityVerified: true,
+        dryRun: false,
+      }),
+    ).rejects.toThrow(/another user/i);
+    expect(patches).toHaveLength(0);
+    expect(inserts).toHaveLength(0);
+  });
+
+  it("fails closed when recovered publisher resource migration exceeds the bounded batch", async () => {
+    const { ctx, inserts, patches } = makePersonalPublisherRecoveryCtx({
+      tooManyLegacySkills: true,
+    });
+
+    await expect(
+      recoverPersonalPublisherInternalHandler(ctx as never, {
+        actorUserId: "users:admin",
+        publisherHandle: "gingiris",
+        previousGitHubProviderAccountId: "111",
+        nextGitHubProviderAccountId: "222",
+        nextUserHandle: "gingiris-1031",
+        reason: "Verified account continuity for issue #2555",
+        confirmIdentityVerified: true,
+        dryRun: false,
+      }),
+    ).rejects.toThrow(/resumable owner migration/i);
     expect(patches).toHaveLength(0);
     expect(inserts).toHaveLength(0);
   });

--- a/convex/publishers.ts
+++ b/convex/publishers.ts
@@ -26,6 +26,7 @@ import {
   getPublisherMembership,
   getPersonalPublisherForUserOrFallback,
   getPersonalPublisherForUser,
+  isPublisherActive,
   isPublisherRoleAllowed,
   PUBLISHER_HANDLE_PATTERN,
   PUBLISHER_HANDLE_REQUIREMENTS_MESSAGE,
@@ -36,6 +37,7 @@ import { readCanonicalStat } from "./lib/skillStats";
 
 const MAX_PUBLIC_PUBLISHER_LIST_LIMIT = 500;
 const PUBLISHER_LIST_PREVIEW_LIMIT = 3;
+const GITHUB_AUTH_ACCOUNT_RECOVERY_MATCH_LIMIT = 10;
 const publisherRoleValidator = v.union(
   v.literal("owner"),
   v.literal("admin"),
@@ -966,6 +968,327 @@ async function ensureOrgPublisherMemberWithActor(
     role,
   };
 }
+
+function normalizeGitHubProviderAccountId(providerAccountId: string) {
+  const normalized = providerAccountId.trim();
+  if (!/^\d+$/.test(normalized)) {
+    throw new ConvexError("GitHub provider account id must be numeric");
+  }
+  return normalized;
+}
+
+async function getUniqueUserForGitHubProviderAccountId(
+  ctx: Pick<MutationCtx, "db">,
+  providerAccountId: string,
+) {
+  const accounts = await ctx.db
+    .query("authAccounts")
+    .withIndex("providerAndAccountId", (q) =>
+      q.eq("provider", "github").eq("providerAccountId", providerAccountId),
+    )
+    .take(GITHUB_AUTH_ACCOUNT_RECOVERY_MATCH_LIMIT + 1);
+  if (accounts.length === 0) {
+    throw new ConvexError(`No GitHub auth account found for provider id ${providerAccountId}`);
+  }
+  if (accounts.length > GITHUB_AUTH_ACCOUNT_RECOVERY_MATCH_LIMIT) {
+    throw new ConvexError(
+      `Too many GitHub auth accounts match provider id ${providerAccountId}; manual reconciliation required`,
+    );
+  }
+
+  const userId = accounts[0]?.userId;
+  if (!userId || accounts.some((account) => account.userId !== userId)) {
+    throw new ConvexError(
+      `GitHub provider id ${providerAccountId} maps to multiple ClawHub users; manual reconciliation required`,
+    );
+  }
+
+  return {
+    userId,
+    accountCount: accounts.length,
+  };
+}
+
+async function getPublisherResourceCounts(
+  ctx: Pick<MutationCtx, "db">,
+  publisherId: Id<"publishers">,
+) {
+  const [skills, packages, githubSources] = await Promise.all([
+    ctx.db
+      .query("skills")
+      .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", publisherId))
+      .take(1),
+    ctx.db
+      .query("packages")
+      .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", publisherId))
+      .take(1),
+    ctx.db
+      .query("githubSkillSources")
+      .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", publisherId))
+      .take(1),
+  ]);
+  return {
+    skills: skills.length,
+    packages: packages.length,
+    githubSources: githubSources.length,
+    total: skills.length + packages.length + githubSources.length,
+  };
+}
+
+async function getRecoveryPersonalPublisherForUser(
+  ctx: Pick<MutationCtx, "db">,
+  user: Doc<"users">,
+) {
+  if (user.personalPublisherId) {
+    const publisher = await ctx.db.get(user.personalPublisherId);
+    if (publisher) return publisher;
+  }
+  return await getPersonalPublisherForUser(ctx, user._id);
+}
+
+export const recoverPersonalPublisherInternal = internalMutation({
+  args: {
+    actorUserId: v.id("users"),
+    publisherHandle: v.string(),
+    previousGitHubProviderAccountId: v.string(),
+    nextGitHubProviderAccountId: v.string(),
+    nextUserHandle: v.optional(v.string()),
+    retiredUserHandle: v.optional(v.string()),
+    reason: v.string(),
+    confirmIdentityVerified: v.boolean(),
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const actor = await ctx.db.get(args.actorUserId);
+    if (!actor || actor.deletedAt || actor.deactivatedAt) throw new ConvexError("Unauthorized");
+    assertAdmin(actor);
+
+    const publisherHandle = validateHandle(args.publisherHandle);
+    const previousGitHubProviderAccountId = normalizeGitHubProviderAccountId(
+      args.previousGitHubProviderAccountId,
+    );
+    const nextGitHubProviderAccountId = normalizeGitHubProviderAccountId(
+      args.nextGitHubProviderAccountId,
+    );
+    if (previousGitHubProviderAccountId === nextGitHubProviderAccountId) {
+      throw new ConvexError("Previous and next GitHub provider ids must differ");
+    }
+
+    const reason = args.reason.trim();
+    if (!reason) throw new ConvexError("Reason required");
+    if (reason.length > 500) throw new ConvexError("Reason too long (max 500 chars)");
+
+    const dryRun = args.dryRun !== false;
+    if (!dryRun && !args.confirmIdentityVerified) {
+      throw new ConvexError("Identity verification confirmation required before applying recovery");
+    }
+
+    const publisher = await getPublisherByHandle(ctx, publisherHandle);
+    if (!publisher || publisher.deletedAt || publisher.deactivatedAt) {
+      throw new ConvexError(`Publisher "@${publisherHandle}" not found`);
+    }
+    if (publisher.kind !== "user") {
+      throw new ConvexError("Only personal publishers can be recovered through this operation");
+    }
+
+    const previousLookup = await getUniqueUserForGitHubProviderAccountId(
+      ctx,
+      previousGitHubProviderAccountId,
+    );
+    const nextLookup = await getUniqueUserForGitHubProviderAccountId(
+      ctx,
+      nextGitHubProviderAccountId,
+    );
+    if (previousLookup.userId === nextLookup.userId) {
+      throw new ConvexError("Previous and next GitHub provider ids resolve to the same user");
+    }
+
+    const previousUser = await ctx.db.get(previousLookup.userId);
+    const nextUser = await ctx.db.get(nextLookup.userId);
+    if (!previousUser || previousUser.deletedAt || previousUser.deactivatedAt) {
+      throw new ConvexError("Previous user must exist and be active before publisher recovery");
+    }
+    if (!nextUser || nextUser.deletedAt || nextUser.deactivatedAt) {
+      throw new ConvexError("Next user must exist and be active before publisher recovery");
+    }
+
+    const expectedNextHandle = normalizePublisherHandle(args.nextUserHandle);
+    if (expectedNextHandle && nextUser.handle !== expectedNextHandle) {
+      throw new ConvexError(`Next GitHub provider id does not belong to @${expectedNextHandle}`);
+    }
+
+    const publisherOwnedByPrevious = publisher.linkedUserId
+      ? publisher.linkedUserId === previousUser._id
+      : previousUser.personalPublisherId === publisher._id;
+    if (!publisherOwnedByPrevious) {
+      throw new ConvexError(
+        `Publisher "@${publisherHandle}" is not currently linked to the previous GitHub principal`,
+      );
+    }
+
+    const userAtRecoveredHandle = await getUserByHandle(ctx, publisher.handle);
+    if (
+      userAtRecoveredHandle &&
+      userAtRecoveredHandle._id !== previousUser._id &&
+      userAtRecoveredHandle._id !== nextUser._id
+    ) {
+      throw new ConvexError(`User handle "@${publisher.handle}" is claimed by another user`);
+    }
+
+    const nextPersonalPublisher = await getRecoveryPersonalPublisherForUser(ctx, nextUser);
+    const retiredPersonalPublisher =
+      nextPersonalPublisher &&
+      nextPersonalPublisher._id !== publisher._id &&
+      isPublisherActive(nextPersonalPublisher)
+        ? nextPersonalPublisher
+        : null;
+    const retiredPersonalPublisherCounts = retiredPersonalPublisher
+      ? await getPublisherResourceCounts(ctx, retiredPersonalPublisher._id)
+      : null;
+    if (retiredPersonalPublisherCounts && retiredPersonalPublisherCounts.total > 0) {
+      throw new ConvexError(
+        `Destination user has resources under @${retiredPersonalPublisher?.handle}; transfer or remove them before recovery`,
+      );
+    }
+
+    const retiredHandleBase =
+      normalizePublisherHandle(args.retiredUserHandle) ?? `${publisher.handle}-recovered`;
+    const previousUserRetiredHandle =
+      previousUser.handle === publisher.handle
+        ? await resolveAvailableUserHandle(ctx, retiredHandleBase, previousUser._id)
+        : undefined;
+    const nextPreviousUserHandle =
+      previousUser.handle === publisher.handle
+        ? previousUserRetiredHandle
+        : (previousUser.handle ?? null);
+    const previousUserNeedsPatch =
+      previousUser.personalPublisherId === publisher._id ||
+      previousUser.handle === publisher.handle;
+    const nextUserPreviousHandle = nextUser.handle ?? null;
+
+    if (!dryRun) {
+      const now = Date.now();
+      if (retiredPersonalPublisher) {
+        await ctx.db.patch(retiredPersonalPublisher._id, {
+          linkedUserId: undefined,
+          deactivatedAt: retiredPersonalPublisher.deactivatedAt ?? now,
+          updatedAt: now,
+        });
+      }
+
+      if (previousUserNeedsPatch) {
+        await ctx.db.patch(previousUser._id, {
+          ...(previousUserRetiredHandle ? { handle: previousUserRetiredHandle } : {}),
+          ...(previousUser.personalPublisherId === publisher._id
+            ? { personalPublisherId: undefined }
+            : {}),
+          updatedAt: now,
+        });
+      }
+
+      await ctx.db.patch(nextUser._id, {
+        handle: publisher.handle,
+        personalPublisherId: publisher._id,
+        updatedAt: now,
+      });
+      await ctx.db.patch(publisher._id, {
+        linkedUserId: nextUser._id,
+        updatedAt: now,
+      });
+
+      const members = await ctx.db
+        .query("publisherMembers")
+        .withIndex("by_publisher", (q) => q.eq("publisherId", publisher._id))
+        .take(101);
+      if (members.length > 100) {
+        throw new ConvexError(
+          "Too many personal publisher members; manual reconciliation required",
+        );
+      }
+
+      let ensuredNextOwner = false;
+      for (const member of members) {
+        if (member.userId === nextUser._id) {
+          ensuredNextOwner = true;
+          if (member.role !== "owner") {
+            await ctx.db.patch(member._id, { role: "owner", updatedAt: now });
+          }
+        } else {
+          await ctx.db.delete(member._id);
+        }
+      }
+      if (!ensuredNextOwner) {
+        await ctx.db.insert("publisherMembers", {
+          publisherId: publisher._id,
+          userId: nextUser._id,
+          role: "owner",
+          createdAt: now,
+          updatedAt: now,
+        });
+      }
+
+      await ctx.db.insert("auditLogs", {
+        actorUserId: actor._id,
+        action: "publisher.personal.recover",
+        targetType: "publisher",
+        targetId: publisher._id,
+        metadata: {
+          handle: publisher.handle,
+          previousUserId: previousUser._id,
+          nextUserId: nextUser._id,
+          previousGitHubProviderAccountId,
+          nextGitHubProviderAccountId,
+          reason,
+          identityVerified: args.confirmIdentityVerified,
+          previousUserPreviousHandle: previousUser.handle ?? null,
+          previousUserNextHandle: nextPreviousUserHandle,
+          nextUserPreviousHandle,
+          nextUserNextHandle: publisher.handle,
+          retiredPersonalPublisher: retiredPersonalPublisher
+            ? {
+                publisherId: retiredPersonalPublisher._id,
+                handle: retiredPersonalPublisher.handle,
+              }
+            : null,
+        },
+        createdAt: now,
+      });
+    }
+
+    return {
+      ok: true as const,
+      dryRun,
+      recovered: !dryRun,
+      publisherId: publisher._id,
+      handle: publisher.handle,
+      previousUser: {
+        userId: previousUser._id,
+        handle: previousUser.handle ?? null,
+        nextHandle: nextPreviousUserHandle,
+        githubProviderAccountId: previousGitHubProviderAccountId,
+        authAccountCount: previousLookup.accountCount,
+      },
+      nextUser: {
+        userId: nextUser._id,
+        handle: nextUser.handle ?? null,
+        nextHandle: publisher.handle,
+        githubProviderAccountId: nextGitHubProviderAccountId,
+        authAccountCount: nextLookup.accountCount,
+      },
+      retiredPersonalPublisher: retiredPersonalPublisher
+        ? {
+            publisherId: retiredPersonalPublisher._id,
+            handle: retiredPersonalPublisher.handle,
+            skills: retiredPersonalPublisherCounts?.skills ?? 0,
+            packages: retiredPersonalPublisherCounts?.packages ?? 0,
+            githubSources: retiredPersonalPublisherCounts?.githubSources ?? 0,
+          }
+        : null,
+      identityVerified: args.confirmIdentityVerified,
+      reason,
+    };
+  },
+});
 
 async function createOrgPublisherForUser(
   ctx: MutationCtx,

--- a/convex/publishers.ts
+++ b/convex/publishers.ts
@@ -40,6 +40,7 @@ import {
 } from "./lib/reservedHandles";
 import { syncSkillSearchDigestForSkill } from "./lib/skillSearchDigest";
 import { readCanonicalStat } from "./lib/skillStats";
+import { adjustUserSkillStatsForSkillChange } from "./lib/userSkillStats";
 
 const MAX_PUBLIC_PUBLISHER_LIST_LIMIT = 500;
 const PUBLISHER_LIST_PREVIEW_LIMIT = 3;
@@ -1165,8 +1166,10 @@ async function applyPersonalPublisherRecoveryOwnerMigration(
   now: number,
 ) {
   for (const skill of plan.skills) {
+    const previousSkill = { ...skill };
     const nextSkill = { ...skill, ownerUserId: nextUserId, updatedAt: now };
     await ctx.db.patch(skill._id, { ownerUserId: nextUserId, updatedAt: now });
+    await adjustUserSkillStatsForSkillChange(ctx, previousSkill, nextSkill);
     await syncSkillSearchDigestForSkill(ctx, nextSkill);
   }
   for (const alias of plan.skillSlugAliases) {

--- a/convex/publishers.ts
+++ b/convex/publishers.ts
@@ -7,6 +7,7 @@ import { internalMutation, internalQuery, mutation, query } from "./functions";
 import { assertAdmin, getOptionalActiveAuthUserId, requireUser } from "./lib/access";
 import { isPublicSkillDoc } from "./lib/globalStats";
 import { isOfficialPublisher, toPublicPublisherWithOfficial } from "./lib/officialPublishers";
+import { extractPackageDigestFields, upsertPackageSearchDigest } from "./lib/packageSearchDigest";
 import { toPublicPublisher } from "./lib/public";
 import {
   formatReservedPublicOwnerHandleMessage,
@@ -22,6 +23,7 @@ import {
   canAccessPublisherOwnerScope,
   ensurePersonalPublisherForUser,
   getActiveUserByHandleOrPersonalPublisher,
+  getOwnerPublisher,
   getPublisherByHandle,
   getPublisherMembership,
   getPersonalPublisherForUserOrFallback,
@@ -33,11 +35,13 @@ import {
   normalizePublisherHandle,
 } from "./lib/publishers";
 import { isHandleReservedForAnotherUser } from "./lib/reservedHandles";
+import { syncSkillSearchDigestForSkill } from "./lib/skillSearchDigest";
 import { readCanonicalStat } from "./lib/skillStats";
 
 const MAX_PUBLIC_PUBLISHER_LIST_LIMIT = 500;
 const PUBLISHER_LIST_PREVIEW_LIMIT = 3;
 const GITHUB_AUTH_ACCOUNT_RECOVERY_MATCH_LIMIT = 10;
+const PERSONAL_PUBLISHER_RECOVERY_OWNER_MIGRATION_LIMIT = 100;
 const publisherRoleValidator = v.union(
   v.literal("owner"),
   v.literal("admin"),
@@ -1046,6 +1050,128 @@ async function getRecoveryPersonalPublisherForUser(
   return await getPersonalPublisherForUser(ctx, user._id);
 }
 
+function getUnexpectedRecoveryOwnerRows(
+  table: "skills" | "skillSlugAliases" | "packages" | "packageInspectorWarnings",
+  rows: Array<{ _id: string; ownerUserId: Id<"users"> }>,
+  previousUserId: Id<"users">,
+  nextUserId: Id<"users">,
+) {
+  return rows
+    .filter((row) => row.ownerUserId !== previousUserId && row.ownerUserId !== nextUserId)
+    .map((row) => ({ table, id: row._id, ownerUserId: row.ownerUserId }));
+}
+
+async function getPersonalPublisherRecoveryOwnerMigrationPlan(
+  ctx: Pick<MutationCtx, "db">,
+  publisherId: Id<"publishers">,
+  previousUserId: Id<"users">,
+  nextUserId: Id<"users">,
+) {
+  const limit = PERSONAL_PUBLISHER_RECOVERY_OWNER_MIGRATION_LIMIT;
+  const takeLimit = limit + 1;
+  const [skills, skillSlugAliases, packages, packageInspectorWarnings, githubSources] =
+    await Promise.all([
+      ctx.db
+        .query("skills")
+        .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", publisherId))
+        .take(takeLimit),
+      ctx.db
+        .query("skillSlugAliases")
+        .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", publisherId))
+        .take(takeLimit),
+      ctx.db
+        .query("packages")
+        .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", publisherId))
+        .take(takeLimit),
+      ctx.db
+        .query("packageInspectorWarnings")
+        .withIndex("by_owner_publisher_created", (q) => q.eq("ownerPublisherId", publisherId))
+        .take(takeLimit),
+      ctx.db
+        .query("githubSkillSources")
+        .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", publisherId))
+        .take(takeLimit),
+    ]);
+  const overflowTables = [
+    skills.length > limit ? "skills" : null,
+    skillSlugAliases.length > limit ? "skillSlugAliases" : null,
+    packages.length > limit ? "packages" : null,
+    packageInspectorWarnings.length > limit ? "packageInspectorWarnings" : null,
+    githubSources.length > limit ? "githubSkillSources" : null,
+  ].filter((table): table is string => table !== null);
+  if (overflowTables.length > 0) {
+    throw new ConvexError(
+      `Publisher has more than ${limit} rows in ${overflowTables.join(", ")}; use a resumable owner migration before recovery`,
+    );
+  }
+
+  const unexpectedOwnerRows = [
+    ...getUnexpectedRecoveryOwnerRows("skills", skills, previousUserId, nextUserId),
+    ...getUnexpectedRecoveryOwnerRows(
+      "skillSlugAliases",
+      skillSlugAliases,
+      previousUserId,
+      nextUserId,
+    ),
+    ...getUnexpectedRecoveryOwnerRows("packages", packages, previousUserId, nextUserId),
+    ...getUnexpectedRecoveryOwnerRows(
+      "packageInspectorWarnings",
+      packageInspectorWarnings,
+      previousUserId,
+      nextUserId,
+    ),
+  ];
+  if (unexpectedOwnerRows.length > 0) {
+    const first = unexpectedOwnerRows[0];
+    throw new ConvexError(
+      `Publisher resource ${first.table}:${first.id} belongs to another user; manual reconciliation required`,
+    );
+  }
+
+  return {
+    limitPerTable: limit,
+    skills: skills.filter((row) => row.ownerUserId === previousUserId),
+    skillSlugAliases: skillSlugAliases.filter((row) => row.ownerUserId === previousUserId),
+    packages: packages.filter((row) => row.ownerUserId === previousUserId),
+    packageInspectorWarnings: packageInspectorWarnings.filter(
+      (row) => row.ownerUserId === previousUserId,
+    ),
+    githubSources,
+  };
+}
+
+async function applyPersonalPublisherRecoveryOwnerMigration(
+  ctx: Pick<MutationCtx, "db">,
+  plan: Awaited<ReturnType<typeof getPersonalPublisherRecoveryOwnerMigrationPlan>>,
+  nextUserId: Id<"users">,
+  now: number,
+) {
+  for (const skill of plan.skills) {
+    const nextSkill = { ...skill, ownerUserId: nextUserId, updatedAt: now };
+    await ctx.db.patch(skill._id, { ownerUserId: nextUserId, updatedAt: now });
+    await syncSkillSearchDigestForSkill(ctx, nextSkill);
+  }
+  for (const alias of plan.skillSlugAliases) {
+    await ctx.db.patch(alias._id, { ownerUserId: nextUserId, updatedAt: now });
+  }
+  for (const pkg of plan.packages) {
+    const nextPackage = { ...pkg, ownerUserId: nextUserId, updatedAt: now };
+    await ctx.db.patch(pkg._id, { ownerUserId: nextUserId, updatedAt: now });
+    const owner = await getOwnerPublisher(ctx, {
+      ownerPublisherId: nextPackage.ownerPublisherId,
+      ownerUserId: nextPackage.ownerUserId,
+    });
+    await upsertPackageSearchDigest(ctx, {
+      ...extractPackageDigestFields(nextPackage),
+      ownerHandle: owner?.handle ?? "",
+      ownerKind: owner?.kind,
+    });
+  }
+  for (const warning of plan.packageInspectorWarnings) {
+    await ctx.db.patch(warning._id, { ownerUserId: nextUserId });
+  }
+}
+
 export const recoverPersonalPublisherInternal = internalMutation({
   args: {
     actorUserId: v.id("users"),
@@ -1150,6 +1276,20 @@ export const recoverPersonalPublisherInternal = internalMutation({
         `Destination user has resources under @${retiredPersonalPublisher?.handle}; transfer or remove them before recovery`,
       );
     }
+    const resourceOwnerMigrationPlan = await getPersonalPublisherRecoveryOwnerMigrationPlan(
+      ctx,
+      publisher._id,
+      previousUser._id,
+      nextUser._id,
+    );
+    const resourceOwnerMigration = {
+      limitPerTable: resourceOwnerMigrationPlan.limitPerTable,
+      skills: resourceOwnerMigrationPlan.skills.length,
+      skillSlugAliases: resourceOwnerMigrationPlan.skillSlugAliases.length,
+      packages: resourceOwnerMigrationPlan.packages.length,
+      packageInspectorWarnings: resourceOwnerMigrationPlan.packageInspectorWarnings.length,
+      githubSourcesChecked: resourceOwnerMigrationPlan.githubSources.length,
+    };
 
     const retiredHandleBase =
       normalizePublisherHandle(args.retiredUserHandle) ?? `${publisher.handle}-recovered`;
@@ -1195,6 +1335,12 @@ export const recoverPersonalPublisherInternal = internalMutation({
         linkedUserId: nextUser._id,
         updatedAt: now,
       });
+      await applyPersonalPublisherRecoveryOwnerMigration(
+        ctx,
+        resourceOwnerMigrationPlan,
+        nextUser._id,
+        now,
+      );
 
       const members = await ctx.db
         .query("publisherMembers")
@@ -1244,6 +1390,7 @@ export const recoverPersonalPublisherInternal = internalMutation({
           previousUserNextHandle: nextPreviousUserHandle,
           nextUserPreviousHandle,
           nextUserNextHandle: publisher.handle,
+          resourceOwnerMigration,
           retiredPersonalPublisher: retiredPersonalPublisher
             ? {
                 publisherId: retiredPersonalPublisher._id,
@@ -1284,6 +1431,7 @@ export const recoverPersonalPublisherInternal = internalMutation({
             githubSources: retiredPersonalPublisherCounts?.githubSources ?? 0,
           }
         : null,
+      resourceOwnerMigration,
       identityVerified: args.confirmIdentityVerified,
       reason,
     };

--- a/convex/publishers.ts
+++ b/convex/publishers.ts
@@ -34,7 +34,10 @@ import {
   PUBLISHER_HANDLE_REQUIREMENTS_MESSAGE,
   normalizePublisherHandle,
 } from "./lib/publishers";
-import { isHandleReservedForAnotherUser } from "./lib/reservedHandles";
+import {
+  getLatestActiveReservedHandle,
+  isHandleReservedForAnotherUser,
+} from "./lib/reservedHandles";
 import { syncSkillSearchDigestForSkill } from "./lib/skillSearchDigest";
 import { readCanonicalStat } from "./lib/skillStats";
 
@@ -1062,8 +1065,9 @@ function getUnexpectedRecoveryOwnerRows(
 }
 
 async function getPersonalPublisherRecoveryOwnerMigrationPlan(
-  ctx: Pick<MutationCtx, "db">,
+  ctx: MutationCtx,
   publisherId: Id<"publishers">,
+  publisherHandle: string,
   previousUserId: Id<"users">,
   nextUserId: Id<"users">,
 ) {
@@ -1092,6 +1096,7 @@ async function getPersonalPublisherRecoveryOwnerMigrationPlan(
         .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", publisherId))
         .take(takeLimit),
     ]);
+  const activeHandleReservation = await getLatestActiveReservedHandle(ctx, publisherHandle);
   const overflowTables = [
     skills.length > limit ? "skills" : null,
     skillSlugAliases.length > limit ? "skillSlugAliases" : null,
@@ -1127,6 +1132,15 @@ async function getPersonalPublisherRecoveryOwnerMigrationPlan(
       `Publisher resource ${first.table}:${first.id} belongs to another user; manual reconciliation required`,
     );
   }
+  if (
+    activeHandleReservation &&
+    activeHandleReservation.rightfulOwnerUserId !== previousUserId &&
+    activeHandleReservation.rightfulOwnerUserId !== nextUserId
+  ) {
+    throw new ConvexError(
+      `Handle reservation ${activeHandleReservation._id} belongs to another user; manual reconciliation required`,
+    );
+  }
 
   return {
     limitPerTable: limit,
@@ -1137,6 +1151,10 @@ async function getPersonalPublisherRecoveryOwnerMigrationPlan(
       (row) => row.ownerUserId === previousUserId,
     ),
     githubSources,
+    activeHandleReservation:
+      activeHandleReservation?.rightfulOwnerUserId === previousUserId
+        ? activeHandleReservation
+        : null,
   };
 }
 
@@ -1169,6 +1187,12 @@ async function applyPersonalPublisherRecoveryOwnerMigration(
   }
   for (const warning of plan.packageInspectorWarnings) {
     await ctx.db.patch(warning._id, { ownerUserId: nextUserId });
+  }
+  if (plan.activeHandleReservation) {
+    await ctx.db.patch(plan.activeHandleReservation._id, {
+      rightfulOwnerUserId: nextUserId,
+      updatedAt: now,
+    });
   }
 }
 
@@ -1279,6 +1303,7 @@ export const recoverPersonalPublisherInternal = internalMutation({
     const resourceOwnerMigrationPlan = await getPersonalPublisherRecoveryOwnerMigrationPlan(
       ctx,
       publisher._id,
+      publisher.handle,
       previousUser._id,
       nextUser._id,
     );
@@ -1289,6 +1314,7 @@ export const recoverPersonalPublisherInternal = internalMutation({
       packages: resourceOwnerMigrationPlan.packages.length,
       packageInspectorWarnings: resourceOwnerMigrationPlan.packageInspectorWarnings.length,
       githubSourcesChecked: resourceOwnerMigrationPlan.githubSources.length,
+      handleReservations: resourceOwnerMigrationPlan.activeHandleReservation ? 1 : 0,
     };
 
     const retiredHandleBase =

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -1377,9 +1377,14 @@ The endpoint defaults to dry-run. Applying recovery requires `dryRun: false` and
 `confirmIdentityVerified: true` after staff independently verify continuity between both
 GitHub principals. Recovery fails closed when the destination user's current personal
 publisher has skills, packages, or GitHub skill sources.
+Recovery also migrates legacy `ownerUserId` fields for the recovered publisher's skills,
+skill slug aliases, packages, package inspector warnings, and derived search digest rows so
+direct-owner paths agree with the new publisher authority. Each primary table is bounded to
+100 rows per apply transaction; larger recoveries must first use a resumable owner migration.
+GitHub skill sources are publisher-scoped and reported as checked rather than rewritten.
 
 - Body: `{ "handle": "gingiris", "nextUserHandle": "gingiris-1031", "previousGitHubProviderAccountId": "123", "nextGitHubProviderAccountId": "456", "reason": "Verified account continuity for issue #2555", "confirmIdentityVerified": true, "dryRun": false }`
-- Response: `{ "ok": true, "dryRun": false, "recovered": true, "publisherId": "...", "handle": "gingiris", "previousUser": { "userId": "...", "handle": "gingiris", "nextHandle": "gingiris-recovered", "githubProviderAccountId": "123", "authAccountCount": 1 }, "nextUser": { "userId": "...", "handle": "gingiris-1031", "nextHandle": "gingiris", "githubProviderAccountId": "456", "authAccountCount": 1 }, "retiredPersonalPublisher": null, "identityVerified": true, "reason": "Verified account continuity for issue #2555" }`
+- Response: `{ "ok": true, "dryRun": false, "recovered": true, "publisherId": "...", "handle": "gingiris", "previousUser": { "userId": "...", "handle": "gingiris", "nextHandle": "gingiris-recovered", "githubProviderAccountId": "123", "authAccountCount": 1 }, "nextUser": { "userId": "...", "handle": "gingiris-1031", "nextHandle": "gingiris", "githubProviderAccountId": "456", "authAccountCount": 1 }, "retiredPersonalPublisher": null, "resourceOwnerMigration": { "limitPerTable": 100, "skills": 1, "skillSlugAliases": 1, "packages": 0, "packageInspectorWarnings": 0, "githubSourcesChecked": 1 }, "identityVerified": true, "reason": "Verified account continuity for issue #2555" }`
 
 ### Owner slug management endpoints
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -1379,12 +1379,14 @@ GitHub principals. Recovery fails closed when the destination user's current per
 publisher has skills, packages, or GitHub skill sources.
 Recovery also migrates legacy `ownerUserId` fields for the recovered publisher's skills,
 skill slug aliases, packages, package inspector warnings, and derived search digest rows so
-direct-owner paths agree with the new publisher authority. Each primary table is bounded to
+direct-owner paths agree with the new publisher authority. An active protected-handle
+reservation for the recovered handle is also reassigned to the replacement user so later
+profile synchronization cannot restore the former user's competing authority. Each primary table is bounded to
 100 rows per apply transaction; larger recoveries must first use a resumable owner migration.
 GitHub skill sources are publisher-scoped and reported as checked rather than rewritten.
 
 - Body: `{ "handle": "gingiris", "nextUserHandle": "gingiris-1031", "previousGitHubProviderAccountId": "123", "nextGitHubProviderAccountId": "456", "reason": "Verified account continuity for issue #2555", "confirmIdentityVerified": true, "dryRun": false }`
-- Response: `{ "ok": true, "dryRun": false, "recovered": true, "publisherId": "...", "handle": "gingiris", "previousUser": { "userId": "...", "handle": "gingiris", "nextHandle": "gingiris-recovered", "githubProviderAccountId": "123", "authAccountCount": 1 }, "nextUser": { "userId": "...", "handle": "gingiris-1031", "nextHandle": "gingiris", "githubProviderAccountId": "456", "authAccountCount": 1 }, "retiredPersonalPublisher": null, "resourceOwnerMigration": { "limitPerTable": 100, "skills": 1, "skillSlugAliases": 1, "packages": 0, "packageInspectorWarnings": 0, "githubSourcesChecked": 1 }, "identityVerified": true, "reason": "Verified account continuity for issue #2555" }`
+- Response: `{ "ok": true, "dryRun": false, "recovered": true, "publisherId": "...", "handle": "gingiris", "previousUser": { "userId": "...", "handle": "gingiris", "nextHandle": "gingiris-recovered", "githubProviderAccountId": "123", "authAccountCount": 1 }, "nextUser": { "userId": "...", "handle": "gingiris-1031", "nextHandle": "gingiris", "githubProviderAccountId": "456", "authAccountCount": 1 }, "retiredPersonalPublisher": null, "resourceOwnerMigration": { "limitPerTable": 100, "skills": 1, "skillSlugAliases": 1, "packages": 0, "packageInspectorWarnings": 0, "githubSourcesChecked": 1, "handleReservations": 1 }, "identityVerified": true, "reason": "Verified account continuity for issue #2555" }`
 
 ### Owner slug management endpoints
 

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -1367,6 +1367,20 @@ owner can later publish the real code-plugin or bundle-plugin release into that 
 - Body: `{ "handle": "openclaw", "slugs": ["diffs"], "packageNames": ["@openclaw/diffs"], "reason": "reserved for official OpenClaw plugin" }`
 - Response: `{ "ok": true, "succeeded": 2, "failed": 0, "results": [{ "kind": "slug", "name": "diffs", "ok": true, "action": "reserved" }] }`
 
+### `POST /api/v1/users/publisher-recovery`
+
+Admin-only. Recovers a personal publisher for a verified replacement GitHub OAuth principal
+without editing Convex Auth account rows. The request must name both immutable GitHub
+provider account ids; mutable handles are only used as an operator-facing guard.
+
+The endpoint defaults to dry-run. Applying recovery requires `dryRun: false` and
+`confirmIdentityVerified: true` after staff independently verify continuity between both
+GitHub principals. Recovery fails closed when the destination user's current personal
+publisher has skills, packages, or GitHub skill sources.
+
+- Body: `{ "handle": "gingiris", "nextUserHandle": "gingiris-1031", "previousGitHubProviderAccountId": "123", "nextGitHubProviderAccountId": "456", "reason": "Verified account continuity for issue #2555", "confirmIdentityVerified": true, "dryRun": false }`
+- Response: `{ "ok": true, "dryRun": false, "recovered": true, "publisherId": "...", "handle": "gingiris", "previousUser": { "userId": "...", "handle": "gingiris", "nextHandle": "gingiris-recovered", "githubProviderAccountId": "123", "authAccountCount": 1 }, "nextUser": { "userId": "...", "handle": "gingiris-1031", "nextHandle": "gingiris", "githubProviderAccountId": "456", "authAccountCount": 1 }, "retiredPersonalPublisher": null, "identityVerified": true, "reason": "Verified account continuity for issue #2555" }`
+
 ### Owner slug management endpoints
 
 - `POST /api/v1/skills/{slug}/rename`

--- a/packages/clawhub-admin/README.md
+++ b/packages/clawhub-admin/README.md
@@ -86,6 +86,7 @@ bun run admin -- users ban <handleOrId> [--id] [--fuzzy] [--reason <text>] [--ye
 bun run admin -- users unban <handleOrId> [--id] [--fuzzy] [--reason <text>] [--yes]
 bun run admin -- users set-role <handleOrId> <user|moderator|admin> [--id] [--fuzzy] [--yes]
 bun run admin -- users reclassify-ban <handleOrId> --reason <text> [--id] [--fuzzy] [--dry-run|--apply] [--yes] [--json]
+bun run admin -- users recover-publisher <handle> --to <handle> --previous-github-id <id> --next-github-id <id> --reason <text> [--retired-handle <handle>] [--verified] [--apply] [--yes] [--json]
 ```
 
 Org publisher administration:

--- a/packages/clawhub-admin/src/cli.ts
+++ b/packages/clawhub-admin/src/cli.ts
@@ -25,6 +25,7 @@ import { getAdminCliBuildLabel, getAdminCliVersion } from "./buildInfo.js";
 import { cmdSendStaffEmail } from "./commands/email.js";
 import {
   cmdBanUser,
+  cmdRecoverPersonalPublisher,
   cmdReclassifyBan,
   cmdRepairVtPendingSkills,
   cmdRescanAllSkills,
@@ -258,6 +259,24 @@ users
   .action(async (handleOrId, options) => {
     const opts = await resolveGlobalOpts();
     await cmdReclassifyBan(opts, handleOrId, options, isInputAllowed());
+  });
+
+users
+  .command("recover-publisher")
+  .description("Recover a personal publisher for a verified current GitHub account")
+  .argument("<handle>", "Personal publisher handle to recover")
+  .requiredOption("--to <handle>", "Destination current ClawHub user handle")
+  .requiredOption("--previous-github-id <id>", "Previous immutable GitHub provider account id")
+  .requiredOption("--next-github-id <id>", "Next immutable GitHub provider account id")
+  .requiredOption("--reason <reason>", "Audit reason")
+  .option("--retired-handle <handle>", "Handle for retiring the previous ClawHub user")
+  .option("--verified", "Confirm staff verified continuity between both GitHub principals")
+  .option("--apply", "Write changes; defaults to dry-run")
+  .option("--yes", "Skip confirmation for --apply")
+  .option("--json", "Output JSON")
+  .action(async (handle, options) => {
+    const opts = await resolveGlobalOpts();
+    await cmdRecoverPersonalPublisher(opts, handle, options, isInputAllowed());
   });
 
 const plugins = program

--- a/packages/clawhub-admin/src/commands/moderation.test.ts
+++ b/packages/clawhub-admin/src/commands/moderation.test.ts
@@ -577,6 +577,7 @@ describe("cmdRecoverPersonalPublisher", () => {
         packages: 0,
         packageInspectorWarnings: 0,
         githubSourcesChecked: 1,
+        handleReservations: 1,
       },
       identityVerified: false,
       reason: "Verified account continuity",

--- a/packages/clawhub-admin/src/commands/moderation.test.ts
+++ b/packages/clawhub-admin/src/commands/moderation.test.ts
@@ -21,6 +21,7 @@ vi.mock("../../../clawhub/src/cli/ui.js", () => uiMocks.moduleFactory());
 
 const {
   cmdBanUser,
+  cmdRecoverPersonalPublisher,
   cmdReclassifyBan,
   cmdRepairVtPendingSkills,
   cmdRescanAllSkills,
@@ -543,6 +544,85 @@ describe("cmdRepairVtPendingSkills", () => {
       }),
       expect.anything(),
     );
+  });
+});
+
+describe("cmdRecoverPersonalPublisher", () => {
+  it("plans publisher recovery by default", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      ok: true,
+      dryRun: true,
+      recovered: false,
+      publisherId: "publishers:gingiris",
+      handle: "gingiris",
+      previousUser: {
+        userId: "users:legacy",
+        handle: "gingiris",
+        nextHandle: "gingiris-recovered",
+        githubProviderAccountId: "111",
+        authAccountCount: 1,
+      },
+      nextUser: {
+        userId: "users:current",
+        handle: "gingiris-1031",
+        nextHandle: "gingiris",
+        githubProviderAccountId: "222",
+        authAccountCount: 1,
+      },
+      retiredPersonalPublisher: null,
+      identityVerified: false,
+      reason: "Verified account continuity",
+    });
+
+    await cmdRecoverPersonalPublisher(
+      makeGlobalOpts(),
+      "@Gingiris",
+      {
+        to: "@Gingiris-1031",
+        previousGithubId: "111",
+        nextGithubId: "222",
+        reason: "Verified account continuity",
+      },
+      false,
+    );
+
+    expect(httpMocks.apiRequest).toHaveBeenCalledWith(
+      "https://clawhub.ai",
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/v1/users/publisher-recovery",
+        token: "tkn",
+        body: {
+          handle: "gingiris",
+          nextUserHandle: "gingiris-1031",
+          previousGitHubProviderAccountId: "111",
+          nextGitHubProviderAccountId: "222",
+          reason: "Verified account continuity",
+          confirmIdentityVerified: false,
+          dryRun: true,
+        },
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("requires --verified before applying recovery", async () => {
+    await expect(
+      cmdRecoverPersonalPublisher(
+        makeGlobalOpts(),
+        "gingiris",
+        {
+          to: "gingiris-1031",
+          previousGithubId: "111",
+          nextGithubId: "222",
+          reason: "Verified account continuity",
+          apply: true,
+          yes: true,
+        },
+        false,
+      ),
+    ).rejects.toThrow(/--verified/i);
+    expect(httpMocks.apiRequest).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/clawhub-admin/src/commands/moderation.test.ts
+++ b/packages/clawhub-admin/src/commands/moderation.test.ts
@@ -633,6 +633,77 @@ describe("cmdRecoverPersonalPublisher", () => {
     ).rejects.toThrow(/--verified/i);
     expect(httpMocks.apiRequest).not.toHaveBeenCalled();
   });
+
+  it("sends verified recovery details when applying", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      ok: true,
+      dryRun: false,
+      recovered: true,
+      publisherId: "publishers:gingiris",
+      handle: "gingiris",
+      previousUser: {
+        userId: "users:legacy",
+        handle: "gingiris-recovered",
+        nextHandle: "gingiris-recovered",
+        githubProviderAccountId: "111",
+        authAccountCount: 1,
+      },
+      nextUser: {
+        userId: "users:current",
+        handle: "gingiris",
+        nextHandle: "gingiris",
+        githubProviderAccountId: "222",
+        authAccountCount: 1,
+      },
+      retiredPersonalPublisher: null,
+      resourceOwnerMigration: {
+        limitPerTable: 100,
+        skills: 1,
+        skillSlugAliases: 1,
+        packages: 0,
+        packageInspectorWarnings: 0,
+        githubSourcesChecked: 1,
+        handleReservations: 1,
+      },
+      identityVerified: true,
+      reason: "Verified account continuity",
+    });
+
+    await cmdRecoverPersonalPublisher(
+      makeGlobalOpts(),
+      "gingiris",
+      {
+        to: "gingiris-1031",
+        previousGithubId: "111",
+        nextGithubId: "222",
+        retiredHandle: "gingiris-recovered",
+        reason: "Verified account continuity",
+        apply: true,
+        verified: true,
+        yes: true,
+      },
+      false,
+    );
+
+    expect(httpMocks.apiRequest).toHaveBeenCalledWith(
+      "https://clawhub.ai",
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/v1/users/publisher-recovery",
+        body: {
+          handle: "gingiris",
+          nextUserHandle: "gingiris-1031",
+          previousGitHubProviderAccountId: "111",
+          nextGitHubProviderAccountId: "222",
+          retiredUserHandle: "gingiris-recovered",
+          reason: "Verified account continuity",
+          confirmIdentityVerified: true,
+          dryRun: false,
+        },
+      }),
+      expect.anything(),
+    );
+  });
 });
 
 describe("cmdSetRole", () => {

--- a/packages/clawhub-admin/src/commands/moderation.test.ts
+++ b/packages/clawhub-admin/src/commands/moderation.test.ts
@@ -570,6 +570,14 @@ describe("cmdRecoverPersonalPublisher", () => {
         authAccountCount: 1,
       },
       retiredPersonalPublisher: null,
+      resourceOwnerMigration: {
+        limitPerTable: 100,
+        skills: 1,
+        skillSlugAliases: 1,
+        packages: 0,
+        packageInspectorWarnings: 0,
+        githubSourcesChecked: 1,
+      },
       identityVerified: false,
       reason: "Verified account continuity",
     });

--- a/packages/clawhub-admin/src/commands/moderation.ts
+++ b/packages/clawhub-admin/src/commands/moderation.ts
@@ -273,8 +273,12 @@ export async function cmdRecoverPersonalPublisher(
     );
     if (options.json) {
       process.stdout.write(`${JSON.stringify(parsed, null, 2)}\n`);
-    } else if (dryRun) {
-      console.log("Re-run with --apply --verified --yes to write this recovery.");
+    } else {
+      const migration = parsed.resourceOwnerMigration;
+      console.log(
+        `Owner rows: ${migration.skills} skills, ${migration.skillSlugAliases} skill aliases, ${migration.packages} packages, ${migration.packageInspectorWarnings} package warnings (${migration.githubSourcesChecked} GitHub sources checked; limit ${migration.limitPerTable}/table).`,
+      );
+      if (dryRun) console.log("Re-run with --apply --verified --yes to write this recovery.");
     }
     return parsed;
   } catch (error) {

--- a/packages/clawhub-admin/src/commands/moderation.ts
+++ b/packages/clawhub-admin/src/commands/moderation.ts
@@ -13,6 +13,7 @@ import { apiRequest, registryUrl } from "../../../clawhub/src/http.js";
 import {
   ApiRoutes,
   ApiV1BanUserResponseSchema,
+  ApiV1PublisherRecoveryResponseSchema,
   ApiV1ReclassifyBanResponseSchema,
   ApiV1SetRoleResponseSchema,
   ApiV1SkillScanBatchResponseSchema,
@@ -187,6 +188,97 @@ export async function cmdSetRole(
     return parsed;
   } catch (error) {
     spinner.fail(formatError(error));
+    throw error;
+  }
+}
+
+export async function cmdRecoverPersonalPublisher(
+  opts: GlobalOpts,
+  handleArg: string,
+  options: {
+    to?: string;
+    previousGithubId?: string;
+    nextGithubId?: string;
+    retiredHandle?: string;
+    reason?: string;
+    apply?: boolean;
+    verified?: boolean;
+    yes?: boolean;
+    json?: boolean;
+  },
+  inputAllowed: boolean,
+) {
+  const handle = normalizeRequiredHandle(handleArg, "Publisher handle");
+  const nextUserHandle = normalizeRequiredHandle(options.to ?? "", "--to");
+  const previousGitHubProviderAccountId = normalizeGitHubProviderId(
+    options.previousGithubId,
+    "--previous-github-id",
+  );
+  const nextGitHubProviderAccountId = normalizeGitHubProviderId(
+    options.nextGithubId,
+    "--next-github-id",
+  );
+  const retiredUserHandle = options.retiredHandle
+    ? normalizeRequiredHandle(options.retiredHandle, "--retired-handle")
+    : undefined;
+  const reason = options.reason?.trim();
+  if (!reason) fail("--reason required");
+  if (reason.length > 500) fail("--reason must be 500 characters or fewer");
+
+  const dryRun = options.apply !== true;
+  const confirmIdentityVerified = options.verified === true;
+  if (!dryRun && !confirmIdentityVerified) fail("--verified required with --apply");
+  if (!dryRun && !options.yes) {
+    if (!isInteractive() || inputAllowed === false) fail("Pass --yes (no input)");
+    const ok = await promptConfirm(
+      `Recover @${handle} for @${nextUserHandle}? This changes personal publisher control.`,
+    );
+    if (!ok) return undefined;
+  }
+
+  const token = await requireAuthToken();
+  const registry = await getRegistry(opts, { cache: true });
+  const spinner = options.json
+    ? null
+    : createSpinner(`${dryRun ? "Planning" : "Applying"} publisher recovery for @${handle}`);
+  try {
+    const result = await apiRequest(
+      registry,
+      {
+        method: "POST",
+        path: `${ApiRoutes.users}/publisher-recovery`,
+        token,
+        body: {
+          handle,
+          nextUserHandle,
+          previousGitHubProviderAccountId,
+          nextGitHubProviderAccountId,
+          ...(retiredUserHandle ? { retiredUserHandle } : {}),
+          reason,
+          confirmIdentityVerified,
+          dryRun,
+        },
+      },
+      ApiV1PublisherRecoveryResponseSchema,
+    );
+    const parsed = parseArk(
+      ApiV1PublisherRecoveryResponseSchema,
+      result,
+      "Publisher recovery response",
+    );
+    spinner?.succeed(
+      parsed.recovered
+        ? `Recovered @${parsed.handle} for @${parsed.nextUser.nextHandle}`
+        : `Dry run OK for @${parsed.handle}; @${parsed.previousUser.handle ?? parsed.previousUser.userId} would retire to @${parsed.previousUser.nextHandle}`,
+    );
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(parsed, null, 2)}\n`);
+    } else if (dryRun) {
+      console.log("Re-run with --apply --verified --yes to write this recovery.");
+    }
+    return parsed;
+  } catch (error) {
+    spinner?.fail(formatError(error));
     throw error;
   }
 }
@@ -660,6 +752,19 @@ export async function cmdReclassifyBan(
 function normalizeHandle(value: string) {
   const trimmed = value.trim();
   return trimmed.startsWith("@") ? trimmed.slice(1).toLowerCase() : trimmed.toLowerCase();
+}
+
+function normalizeRequiredHandle(value: string, label: string) {
+  const handle = normalizeHandle(value);
+  if (!handle) fail(`${label} required`);
+  return handle;
+}
+
+function normalizeGitHubProviderId(value: string | undefined, label: string) {
+  const providerId = value?.trim() ?? "";
+  if (!providerId) fail(`${label} required`);
+  if (!/^\d+$/.test(providerId)) fail(`${label} must be a numeric GitHub provider account id`);
+  return providerId;
 }
 
 function normalizeSkillSlug(value: string) {

--- a/packages/clawhub-admin/src/commands/moderation.ts
+++ b/packages/clawhub-admin/src/commands/moderation.ts
@@ -276,7 +276,7 @@ export async function cmdRecoverPersonalPublisher(
     } else {
       const migration = parsed.resourceOwnerMigration;
       console.log(
-        `Owner rows: ${migration.skills} skills, ${migration.skillSlugAliases} skill aliases, ${migration.packages} packages, ${migration.packageInspectorWarnings} package warnings (${migration.githubSourcesChecked} GitHub sources checked; limit ${migration.limitPerTable}/table).`,
+        `Owner rows: ${migration.skills} skills, ${migration.skillSlugAliases} skill aliases, ${migration.packages} packages, ${migration.packageInspectorWarnings} package warnings, ${migration.handleReservations} handle reservations (${migration.githubSourcesChecked} GitHub sources checked; limit ${migration.limitPerTable}/table).`,
       );
       if (dryRun) console.log("Re-run with --apply --verified --yes to write this recovery.");
     }

--- a/packages/clawhub/src/schema/schemas.ts
+++ b/packages/clawhub/src/schema/schemas.ts
@@ -235,6 +235,39 @@ export const ApiV1PublisherDeleteResponseSchema = type({
 });
 export type ApiV1PublisherDeleteResponse = (typeof ApiV1PublisherDeleteResponseSchema)[inferred];
 
+export const ApiV1PublisherRecoveryResponseSchema = type({
+  ok: "true",
+  dryRun: "boolean",
+  recovered: "boolean",
+  publisherId: "string",
+  handle: "string",
+  previousUser: {
+    userId: "string",
+    handle: "string|null",
+    nextHandle: "string|null",
+    githubProviderAccountId: "string",
+    authAccountCount: "number",
+  },
+  nextUser: {
+    userId: "string",
+    handle: "string|null",
+    nextHandle: "string",
+    githubProviderAccountId: "string",
+    authAccountCount: "number",
+  },
+  retiredPersonalPublisher: type({
+    publisherId: "string",
+    handle: "string",
+    skills: "number",
+    packages: "number",
+    githubSources: "number",
+  }).or("null"),
+  identityVerified: "boolean",
+  reason: "string",
+});
+export type ApiV1PublisherRecoveryResponse =
+  (typeof ApiV1PublisherRecoveryResponseSchema)[inferred];
+
 export const ApiV1OfficialPublisherListResponseSchema = type({
   ok: "true",
   items: type({

--- a/packages/clawhub/src/schema/schemas.ts
+++ b/packages/clawhub/src/schema/schemas.ts
@@ -262,6 +262,14 @@ export const ApiV1PublisherRecoveryResponseSchema = type({
     packages: "number",
     githubSources: "number",
   }).or("null"),
+  resourceOwnerMigration: {
+    limitPerTable: "number",
+    skills: "number",
+    skillSlugAliases: "number",
+    packages: "number",
+    packageInspectorWarnings: "number",
+    githubSourcesChecked: "number",
+  },
   identityVerified: "boolean",
   reason: "string",
 });

--- a/packages/clawhub/src/schema/schemas.ts
+++ b/packages/clawhub/src/schema/schemas.ts
@@ -269,6 +269,7 @@ export const ApiV1PublisherRecoveryResponseSchema = type({
     packages: "number",
     packageInspectorWarnings: "number",
     githubSourcesChecked: "number",
+    handleReservations: "number",
   },
   identityVerified: "boolean",
   reason: "string",

--- a/specs/auth-identity.md
+++ b/specs/auth-identity.md
@@ -42,6 +42,9 @@ continuity verification, moves the previous user's handle/personal-publisher
 pointer out of the way, links the publisher to the verified replacement user,
 updates every bounded legacy `ownerUserId` row that remains authoritative for the
 recovered publisher's direct-owner workflows, and writes an audit log. Recovery
+must also transfer any active protected-handle reservation for the recovered
+handle to the replacement user so subsequent profile synchronization cannot
+reassert the former user's authority over that handle. Recovery
 must fail closed if the replacement user's current personal publisher has content
 or GitHub source state that would be orphaned by the handoff. It must also fail
 closed if recovered publisher resources are already attributed to a third user,

--- a/specs/auth-identity.md
+++ b/specs/auth-identity.md
@@ -39,7 +39,11 @@ supported permanent recovery path is an admin-only personal publisher recovery
 operation that requires both immutable GitHub `providerAccountId` values, verifies
 that each maps unambiguously to exactly one ClawHub user, confirms staff identity
 continuity verification, moves the previous user's handle/personal-publisher
-pointer out of the way, links the publisher to the verified replacement user, and
-writes an audit log. Recovery must fail closed if the replacement user's current
-personal publisher has content or GitHub source state that would be orphaned by
-the handoff.
+pointer out of the way, links the publisher to the verified replacement user,
+updates every bounded legacy `ownerUserId` row that remains authoritative for the
+recovered publisher's direct-owner workflows, and writes an audit log. Recovery
+must fail closed if the replacement user's current personal publisher has content
+or GitHub source state that would be orphaned by the handoff. It must also fail
+closed if recovered publisher resources are already attributed to a third user,
+or if the affected primary resource rows exceed the bounded single-transaction
+limit; those cases require an explicit resumable migration before recovery.

--- a/specs/auth-identity.md
+++ b/specs/auth-identity.md
@@ -32,3 +32,14 @@ arbitrary tie breaker.
 derive the actor server-side from Convex Auth (`getAuthUserId` via
 `requireUser`/`getOptionalActiveAuthUserId`). They must not accept client-supplied
 user ids, usernames, handles, or emails for authorization.
+
+Staff recovery for a personal publisher whose GitHub principal is no longer
+accessible must not rewrite or merge Convex Auth `authAccounts` rows. The only
+supported permanent recovery path is an admin-only personal publisher recovery
+operation that requires both immutable GitHub `providerAccountId` values, verifies
+that each maps unambiguously to exactly one ClawHub user, confirms staff identity
+continuity verification, moves the previous user's handle/personal-publisher
+pointer out of the way, links the publisher to the verified replacement user, and
+writes an audit log. Recovery must fail closed if the replacement user's current
+personal publisher has content or GitHub source state that would be orphaned by
+the handoff.


### PR DESCRIPTION
Addresses #2555

## Summary

- Confirmed the reported recovery problem exists: personal publisher ownership is tied to immutable GitHub OAuth principals, so a replacement GitHub account cannot publish under a legacy personal publisher handle without staff intervention.
- Added an admin-only publisher recovery path that requires both old and new immutable GitHub provider IDs, an explicit identity-verification confirmation for apply mode, dry-run-by-default behavior, audit logging, and fail-closed checks when the destination account's current personal publisher already has resources.
- Added `clawhub-admin users recover-publisher <handle>` plus API schema, HTTP docs, auth identity invariants, and regression coverage for the recovery and fail-closed paths.

## Tests

- `bunx vitest run convex/publishers.test.ts convex/httpApiV1.handlers.test.ts packages/clawhub-admin/src/commands/moderation.test.ts` ✅
- `bun run ci:static` ✅
- `bunx tsc --noEmit` ✅
- `bunx tsc -p packages/schema/tsconfig.json --noEmit` ✅
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit` ✅
- `bun run --cwd packages/clawhub-admin typecheck` ✅
- `git diff --check` ✅
- `bun run ci:unit` ⚠️ failed on an existing local path-encoding issue: `scripts/skill-cards/run-skill-card-worker.test.ts > keeps the neutral template close to NVIDIA's public card shape` hit `ENOENT` for `/Users/mauriceniu/Documents/New%20project/clawhub/scripts/skill-cards/templates/clawhub-skill-card.md.j2`; 3040 tests passed, 1 failed, 1 skipped.
- `bunx convex codegen` ⚠️ not completed: the escalation was rejected because the command downloads deployment state and uploads functions/code to Convex. No generated files changed.


## Behavior proof

Real local Convex proof was added in https://github.com/openclaw/clawhub/pull/2613#issuecomment-4689318296 and covers dry-run, apply, post-transfer owner/publish authorization, and destination-resource rejection.
