### PR TITLE
fix: clarify scoped package publish access errors

### DIFF
--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -8111,6 +8111,56 @@ describe("packages public queries", () => {
     ).rejects.toThrow('Create it with "clawhub publisher create example.tools".');
   });
 
+  it("explains scoped package publish access failures from package.json", async () => {
+    const runMutation = vi.fn(async () => {
+      throw new Error('Forbidden: you do not have publish access to publisher "@openclaw"');
+    });
+    const ctx = {
+      runQuery: vi
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          _id: "users:steipete",
+          handle: "steipete",
+          githubCreatedAt: Date.now() - 20 * 24 * 60 * 60 * 1000,
+        })
+        .mockResolvedValueOnce({
+          _id: "users:steipete",
+          handle: "steipete",
+          role: "user",
+          githubCreatedAt: Date.now() - 20 * 24 * 60 * 60 * 1000,
+        }),
+      runMutation,
+      runAction: vi.fn(async () => makeCleanPackageInspectorResult()),
+      scheduler: {
+        runAfter: vi.fn(),
+      },
+      storage: {
+        get: vi.fn(),
+      },
+    };
+
+    await expect(
+      publishPackageForUserInternalHandler(ctx as never, {
+        actorUserId: "users:steipete",
+        payload: {
+          name: "@openclaw/discord",
+          displayName: "Discord",
+          family: "bundle-plugin",
+          version: "2026.5.3-beta.2",
+          changelog: "beta",
+          bundle: { hostTargets: ["desktop"] },
+          files: [],
+        },
+      }),
+    ).rejects.toThrow(
+      [
+        'Cannot publish @openclaw/discord: package.json name is scoped to "@openclaw", but your account does not have publish rights to the "@openclaw" ClawHub organization.',
+        "Create the matching ClawHub organization if it does not exist, get publish rights to that organization, or rename package.json name to use an organization scope you control.",
+      ].join("\n\n"),
+    );
+  });
+
   it("rejects scoped package publishes when --owner conflicts with the package scope", async () => {
     const runMutation = vi.fn();
     const ctx = {

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -329,6 +329,16 @@ function getScopedPackageMissingPublisherMessage(params: {
   return `Cannot publish ${params.packageName}: package.json name is scoped to "@${params.scopedOwnerHandle}", but ClawHub has no "@${params.scopedOwnerHandle}" publisher. Create it with "clawhub publisher create ${params.scopedOwnerHandle}".`;
 }
 
+function getScopedPackagePublishAccessMessage(params: {
+  scopedOwnerHandle: string;
+  packageName: string;
+}) {
+  return [
+    `Cannot publish ${params.packageName}: package.json name is scoped to "@${params.scopedOwnerHandle}", but your account does not have publish rights to the "@${params.scopedOwnerHandle}" ClawHub organization.`,
+    "Create the matching ClawHub organization if it does not exist, get publish rights to that organization, or rename package.json name to use an organization scope you control.",
+  ].join("\n\n");
+}
+
 function isTrustedOpenClawPluginPackage(params: {
   family: PackageFamily;
   normalizedName: string;
@@ -6214,7 +6224,7 @@ async function publishPackageImpl(
         }
         if (/forbidden|publish access/i.test(error.message)) {
           throw new ConvexError(
-            `This package name uses the "@${scopedOwnerHandle}" namespace, but you do not have publish access to that publisher. Ask an owner or admin of "@${scopedOwnerHandle}" to add you.`,
+            getScopedPackagePublishAccessMessage({ scopedOwnerHandle, packageName: name }),
           );
         }
       }


### PR DESCRIPTION
## Summary
- clarify the scoped package publish access error to say the scope comes from `package.json.name`
- explain that the missing permission is publish rights to the ClawHub organization
- list the valid fixes: create the org if missing, get publish rights, or rename the package scope
- add package publish coverage for the access-denied scoped package path

## Validation
- `bunx vitest run convex/packages.public.test.ts`
- `bun run format:check -- convex/packages.ts convex/packages.public.test.ts`
- `git diff --check`
- `bun run ci:static`
- `bun run ci:unit` (initially failed due to missing local `node_modules/mermaid` after latest `main`; `bun install` synced dependencies, rerun passed)
- `bun run ci:types-build`

## Review
- Subagent autoreview sidecar: clean, no accepted/actionable findings
