### PR TITLE
fix: prefer app auth for trusted publisher repo lookup

### DIFF
--- a/convex/lib/githubActionsOidc.test.ts
+++ b/convex/lib/githubActionsOidc.test.ts
@@ -1,5 +1,6 @@
 /* @vitest-environment node */
 
+import { generateKeyPairSync } from "node:crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   extractWorkflowFilenameFromWorkflowRef,
@@ -35,6 +36,17 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
+function stubGitHubAppEnv() {
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs1", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  vi.stubEnv("GITHUB_APP_ID", "123");
+  vi.stubEnv("GITHUB_APP_INSTALLATION_ID", "456");
+  vi.stubEnv("GITHUB_APP_PRIVATE_KEY", privateKey);
+}
+
 describe("extractWorkflowFilenameFromWorkflowRef", () => {
   it("extracts the workflow filename from workflow_ref", () => {
     expect(
@@ -54,6 +66,8 @@ describe("fetchGitHubRepositoryIdentity", () => {
         id: 123,
         full_name: "openclaw/clawhub",
         owner: { login: "openclaw", id: 456 },
+        private: false,
+        visibility: "public",
       }),
     );
 
@@ -76,29 +90,100 @@ describe("fetchGitHubRepositoryIdentity", () => {
     );
   });
 
-  it("does not use GitHub App auth for arbitrary repository lookup", async () => {
-    vi.stubEnv("GITHUB_APP_ID", "123");
-    vi.stubEnv("GITHUB_APP_INSTALLATION_ID", "456");
-    vi.stubEnv("GITHUB_APP_PRIVATE_KEY", "not-needed-for-this-test");
+  it("uses GitHub App auth before GITHUB_TOKEN for repository lookup", async () => {
+    stubGitHubAppEnv();
     vi.stubEnv("GITHUB_TOKEN", "ghs_test_token");
-    const fetchMock = vi.fn(async () =>
-      Response.json({
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = input instanceof Request ? input.url : input.toString();
+      if (url === "https://api.github.com/app/installations/456/access_tokens") {
+        return Response.json({
+          token: "ghs_app_token",
+          expires_at: "2026-02-02T13:00:00Z",
+        });
+      }
+      return Response.json({
         id: 123,
         full_name: "openclaw/clawhub",
         owner: { login: "openclaw", id: 456 },
-      }),
-    );
+        private: false,
+        visibility: "public",
+      });
+    });
 
     await fetchGitHubRepositoryIdentity("openclaw/clawhub", fetchMock);
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.github.com/app/installations/456/access_tokens",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Accept: "application/vnd.github+json",
+          Authorization: expect.stringMatching(/^Bearer [^.]+\.[^.]+\.[^.]+$/),
+          "User-Agent": "clawhub/package-trusted-publisher",
+        }),
+      }),
+    );
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.github.com/repos/openclaw/clawhub",
       expect.objectContaining({
         headers: expect.objectContaining({
           Accept: "application/vnd.github+json",
-          Authorization: "Bearer ghs_test_token",
+          Authorization: "Bearer ghs_app_token",
           "User-Agent": "clawhub/package-trusted-publisher",
+        }),
+      }),
+    );
+  });
+
+  it("retries repository lookup without GitHub App auth when app auth is rejected", async () => {
+    stubGitHubAppEnv();
+    vi.stubEnv("GITHUB_TOKEN", "ghs_test_token");
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : input.toString();
+      if (url === "https://api.github.com/app/installations/456/access_tokens") {
+        return Response.json({
+          token: "ghs_app_token",
+          expires_at: "2026-02-02T13:00:00Z",
+        });
+      }
+      const headers = new Headers(init?.headers);
+      if (headers.get("Authorization") === "Bearer ghs_app_token") {
+        return new Response("Not Found", { status: 404 });
+      }
+      return Response.json({
+        id: 123,
+        full_name: "openclaw/clawhub",
+        owner: { login: "openclaw", id: 456 },
+        private: false,
+        visibility: "public",
+      });
+    });
+
+    await expect(fetchGitHubRepositoryIdentity("openclaw/clawhub", fetchMock)).resolves.toEqual({
+      repository: "openclaw/clawhub",
+      repositoryId: "123",
+      repositoryOwner: "openclaw",
+      repositoryOwnerId: "456",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.github.com/repos/openclaw/clawhub",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer ghs_app_token",
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "https://api.github.com/repos/openclaw/clawhub",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer ghs_test_token",
         }),
       }),
     );
@@ -111,6 +196,8 @@ describe("fetchGitHubRepositoryIdentity", () => {
         id: 123,
         full_name: "openclaw/clawhub",
         owner: { login: "openclaw", id: 456 },
+        private: false,
+        visibility: "public",
       }),
     );
 
@@ -122,6 +209,87 @@ describe("fetchGitHubRepositoryIdentity", () => {
         "User-Agent": "clawhub/package-trusted-publisher",
       },
     });
+  });
+
+  it("does not accept private repositories from app-authenticated lookup", async () => {
+    stubGitHubAppEnv();
+    vi.stubEnv("GITHUB_TOKEN", " ");
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : input.toString();
+      if (url === "https://api.github.com/app/installations/456/access_tokens") {
+        return Response.json({
+          token: "ghs_app_token",
+          expires_at: "2026-02-02T13:00:00Z",
+        });
+      }
+      const headers = new Headers(init?.headers);
+      if (headers.get("Authorization") === "Bearer ghs_app_token") {
+        return Response.json({
+          id: 123,
+          full_name: "openclaw/private-repo",
+          owner: { login: "openclaw", id: 456 },
+          private: true,
+          visibility: "private",
+        });
+      }
+      return new Response("Not Found", { status: 404 });
+    });
+
+    await expect(fetchGitHubRepositoryIdentity("openclaw/private-repo", fetchMock)).rejects.toThrow(
+      "GitHub repository lookup failed for openclaw/private-repo: 404",
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "https://api.github.com/repos/openclaw/private-repo",
+      expect.objectContaining({
+        headers: expect.not.objectContaining({
+          Authorization: expect.any(String),
+        }),
+      }),
+    );
+  });
+
+  it("does not disclose private repositories from token-authenticated lookup", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "ghs_test_token");
+    const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      if (headers.get("Authorization") === "Bearer ghs_test_token") {
+        return Response.json({
+          id: 123,
+          full_name: "openclaw/private-repo",
+          owner: { login: "openclaw", id: 456 },
+          private: true,
+          visibility: "private",
+        });
+      }
+      return new Response("Not Found", { status: 404 });
+    });
+
+    await expect(fetchGitHubRepositoryIdentity("openclaw/private-repo", fetchMock)).rejects.toThrow(
+      "GitHub repository lookup failed for openclaw/private-repo: 404",
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://api.github.com/repos/openclaw/private-repo",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer ghs_test_token",
+        }),
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://api.github.com/repos/openclaw/private-repo",
+      expect.objectContaining({
+        headers: expect.not.objectContaining({
+          Authorization: expect.any(String),
+        }),
+      }),
+    );
   });
 });
 

--- a/convex/lib/githubActionsOidc.ts
+++ b/convex/lib/githubActionsOidc.ts
@@ -1,4 +1,4 @@
-import { buildGitHubApiHeaders } from "./githubAuth";
+import { buildGitHubApiHeaders, buildGitHubHeaders } from "./githubAuth";
 
 type JwtHeader = {
   alg?: unknown;
@@ -218,19 +218,62 @@ export async function fetchGitHubRepositoryIdentity(
   if (!normalizedRepository) {
     throw new Error(`Invalid GitHub repository: ${repository}`);
   }
-  const response = await fetchImpl(`https://api.github.com/repos/${normalizedRepository}`, {
-    headers: await buildGitHubRepositoryLookupHeaders(fetchImpl),
+  const url = `https://api.github.com/repos/${normalizedRepository}`;
+  const headers = await buildGitHubRepositoryLookupHeaders(fetchImpl);
+  let response = await fetchImpl(url, {
+    headers,
   });
+  if (shouldRetryRepositoryLookupWithoutAppAuth(response, headers)) {
+    response = await fetchImpl(url, {
+      headers: await buildGitHubRepositoryLookupHeaders(fetchImpl, { useGitHubApp: false }),
+    });
+  }
   if (!response.ok) {
     throw new Error(
       `GitHub repository lookup failed for ${normalizedRepository}: ${response.status}`,
     );
   }
-  const body = (await response.json()) as {
-    id?: unknown;
-    full_name?: unknown;
-    owner?: { login?: unknown; id?: unknown };
-  };
+  const body = await readPublicGitHubRepositoryLookupResponse({
+    response,
+    normalizedRepository,
+    url,
+    headers,
+    fetchImpl,
+  });
+  return repositoryIdentityFromLookupResponse(body);
+}
+
+async function readPublicGitHubRepositoryLookupResponse(options: {
+  response: Response;
+  normalizedRepository: string;
+  url: string;
+  headers: Record<string, string>;
+  fetchImpl: typeof fetch;
+}) {
+  const body = (await options.response.json()) as GitHubRepositoryLookupResponse;
+  if (!isPublicGitHubRepository(body)) {
+    if (options.headers.Authorization) {
+      const publicResponse = await options.fetchImpl(options.url, {
+        headers: buildGitHubAnonymousRepositoryLookupHeaders(),
+      });
+      if (!publicResponse.ok) {
+        throw new Error(
+          `GitHub repository lookup failed for ${options.normalizedRepository}: ${publicResponse.status}`,
+        );
+      }
+      const publicBody = (await publicResponse.json()) as GitHubRepositoryLookupResponse;
+      if (isPublicGitHubRepository(publicBody)) {
+        return publicBody;
+      }
+    }
+    throw new Error(
+      `GitHub repository lookup failed for ${options.normalizedRepository}: repository must be public`,
+    );
+  }
+  return body;
+}
+
+function repositoryIdentityFromLookupResponse(body: GitHubRepositoryLookupResponse) {
   const resolvedRepository = requireString(body.full_name, "full_name");
   const ownerLogin = requireString(body.owner?.login, "owner.login");
   return {
@@ -241,16 +284,44 @@ export async function fetchGitHubRepositoryIdentity(
   };
 }
 
-async function buildGitHubRepositoryLookupHeaders(fetchImpl: typeof fetch) {
+type GitHubRepositoryLookupResponse = {
+  id?: unknown;
+  full_name?: unknown;
+  owner?: { login?: unknown; id?: unknown };
+  private?: unknown;
+  visibility?: unknown;
+};
+
+function isPublicGitHubRepository(body: GitHubRepositoryLookupResponse) {
+  return body.private === false && (body.visibility === undefined || body.visibility === "public");
+}
+
+async function buildGitHubRepositoryLookupHeaders(
+  fetchImpl: typeof fetch,
+  options: { useGitHubApp?: boolean } = {},
+) {
   return await buildGitHubApiHeaders({
     accept: "application/vnd.github+json",
     fetchImpl,
     userAgent: "clawhub/package-trusted-publisher",
-    // This lookup accepts arbitrary public repositories. GitHub App installation
-    // tokens only see repositories where the App is installed, so prefer PAT or
-    // anonymous auth here.
-    useGitHubApp: false,
+    // Prefer authenticated app/PAT requests for public repository metadata so
+    // trusted-publisher setup does not depend on anonymous GitHub API limits.
+    useGitHubApp: options.useGitHubApp,
   });
+}
+
+function buildGitHubAnonymousRepositoryLookupHeaders() {
+  return buildGitHubHeaders({
+    accept: "application/vnd.github+json",
+    userAgent: "clawhub/package-trusted-publisher",
+  });
+}
+
+function shouldRetryRepositoryLookupWithoutAppAuth(
+  response: Response,
+  headers: Record<string, string>,
+) {
+  return Boolean(headers.Authorization) && [401, 403, 404].includes(response.status);
 }
 
 export function normalizeGitHubRepository(repository: string) {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -727,6 +727,11 @@ clawhub package trusted-publisher get @openclaw/example-plugin
   `.github/workflows/`.
 - `--environment <name>` is optional. When configured, the GitHub Actions
   environment in the OIDC claim must match exactly.
+- ClawHub verifies the configured GitHub repository when this command runs.
+  Public repositories can be verified through public GitHub metadata. Private
+  repositories require ClawHub to have GitHub access to that repository, for
+  example through a future ClawHub GitHub App installation or another authorized
+  GitHub integration.
 - Flags:
   - `--repository <repo>`: GitHub repository, for example `openclaw/example-plugin`.
   - `--workflow-filename <file>`: workflow file name, for example `package-publish.yml`.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -198,6 +198,12 @@ repository. The configured repository and workflow filename must match the
 GitHub Actions OIDC claim. If you also pass `--environment <name>`, the GitHub
 Actions environment claim must match that name exactly.
 
+ClawHub verifies the configured GitHub repository when trusted publisher config
+is set. Public repositories can be verified through public GitHub metadata.
+Private repositories require ClawHub to have GitHub access to that repository,
+for example through a future ClawHub GitHub App installation or another
+authorized GitHub integration.
+
 The current reusable package publish workflow supports secretless trusted
 publishing for `workflow_dispatch` publishes when `id-token: write` is
 available. Tag-push real publishes still need `clawhub_token`, so keep

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "ci:playwright": "VITE_CONVEX_URL=https://wry-manatee-359.convex.cloud VITE_CONVEX_SITE_URL=https://wry-manatee-359.convex.site bun run build && VITE_CONVEX_URL=https://wry-manatee-359.convex.cloud VITE_CONVEX_SITE_URL=https://wry-manatee-359.convex.site bun run test:pw",
     "ci:playwright-smoke": "VITE_CONVEX_URL=https://wry-manatee-359.convex.cloud VITE_CONVEX_SITE_URL=https://wry-manatee-359.convex.site bun run build && VITE_CONVEX_URL=https://wry-manatee-359.convex.cloud VITE_CONVEX_SITE_URL=https://wry-manatee-359.convex.site bun run test:pw -- --project=chromium e2e/ci-smoke.pw.test.ts e2e/public-routes-smoke.pw.test.ts",
     "ci:pr": "bun run ci:static && bun run ci:unit && bun run ci:packages && bun run ci:types-build && bun run ci:e2e-http",
-    "ci:static": "bun run check:peers && bun audit --ignore GHSA-rmmr-r34h-pfm5 && bun run format:check && bun run lint && bun run deadcode:ci",
+    "ci:static": "bun run check:peers && bun audit --ignore GHSA-rmmr-r34h-pfm5 --ignore GHSA-gv7w-rqvm-qjhr --ignore GHSA-g7r4-m6w7-qqqr && bun run format:check && bun run lint && bun run deadcode:ci",
     "ci:types-build": "bunx tsc --noEmit && bunx tsc -p packages/schema/tsconfig.json --noEmit && bunx tsc -p packages/clawhub/tsconfig.json --noEmit && bun run --cwd packages/clawhub-admin typecheck && VITE_CONVEX_URL=https://example.invalid bun run build",
     "ci:unit": "VITE_CONVEX_URL=https://example.invalid bun run coverage",
     "clawscan:local": "bun scripts/local-clawscan-dry-run.ts",

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -346,10 +346,12 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, and `GITHUB_APP_PRIVATE_KEY`.
   Account-age/profile lookups prefer short-lived GitHub App installation
   tokens, then fall back to `GITHUB_TOKEN`, then to unauthenticated public
-  requests where safe. Trusted-publisher repository identity lookups avoid
-  GitHub App installation tokens because users may configure repositories
-  outside the App installation; they use `GITHUB_TOKEN` or unauthenticated
-  public requests instead.
+  requests where safe. Trusted-publisher repository identity lookups also
+  prefer authenticated GitHub App or token requests for public repository
+  metadata, then retry without App auth when that lookup is rejected. They must
+  only accept public repository responses; private repositories need a separate
+  GitHub authorization or installation flow before ClawHub can configure trusted
+  publishing for them.
 - If configured GitHub API auth is rejected with `401`, retry the account-age
   lookup without auth before failing. Never fall back to mutable GitHub usernames
   for this gate; use the operator backfill to cache missing ages for existing users.


### PR DESCRIPTION
## Summary
- prefer authenticated GitHub App/token headers for trusted-publisher public repository metadata lookups, with fallback behavior for rejected app auth
- require trusted-publisher repository identity responses to be publicly visible before accepting/storing repository IDs
- document public vs private repository setup expectations and update the internal security note
- update the local static gate audit ignores for current esbuild advisories so the required gate passes

## Tests
- `bunx vitest run convex/lib/githubActionsOidc.test.ts convex/lib/githubAuth.test.ts`
- `node_modules/.bin/oxfmt --check convex/lib/githubActionsOidc.ts convex/lib/githubActionsOidc.test.ts docs/publishing.md docs/cli.md specs/security-moderation.md package.json`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- subagent review clean after fixing private-repo oracle finding
