### PR TITLE
fix: serve docs subdomain root

### DIFF
--- a/scripts/docs-smoke.mjs
+++ b/scripts/docs-smoke.mjs
@@ -120,6 +120,35 @@ assert(
 assert(
   vercelConfig.rewrites?.some(
     (route) =>
+      route.source === "/" &&
+      route.destination === "/docs" &&
+      route.has?.some(
+        (condition) =>
+          condition.type === "header" &&
+          condition.key === "host" &&
+          condition.value === "docs.clawhub.ai",
+      ),
+  ),
+  "docs.clawhub.ai root should serve the generated docs artifact",
+);
+assert(
+  vercelConfig.redirects?.some(
+    (route) =>
+      route.source === "/docs/:path*" &&
+      route.destination === "https://docs.clawhub.ai/:path*" &&
+      route.statusCode === 308 &&
+      route.has?.some(
+        (condition) =>
+          condition.type === "header" &&
+          condition.key === "host" &&
+          condition.value === "docs.clawhub.ai",
+      ),
+  ),
+  "docs.clawhub.ai/docs paths should redirect to root docs paths",
+);
+assert(
+  vercelConfig.rewrites?.some(
+    (route) =>
       route.source === "/:path*" &&
       route.destination === "/docs/:path*" &&
       route.has?.some(

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -225,7 +225,9 @@ describe("Header", () => {
     expect(document.querySelector(".theme-mode-toggle")).toBeNull();
     expect(within(topNav).getByText("Skills").closest("a")?.querySelector("svg")).toBeNull();
     expect(within(topNav).getByText("Plugins").closest("a")?.querySelector("svg")).toBeNull();
-    expect(within(topNav).getByText("Docs").closest("a")?.getAttribute("href")).toBe("/docs");
+    expect(within(topNav).getByText("Docs").closest("a")?.getAttribute("href")).toBe(
+      "https://docs.clawhub.ai/",
+    );
     expect(screen.getAllByText("Skills")).toHaveLength(1);
     expect(screen.getAllByText("Plugins")).toHaveLength(1);
     expect(screen.queryByText("Publishers")).toBeNull();

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -90,7 +90,7 @@ describe("restored UI design contract", () => {
     expect(navSource).toContain("export const SECONDARY_NAV_ITEMS");
     expect(navSource).not.toContain('label: "Publishers"');
     expect(navSource).toContain('label: "Docs"');
-    expect(navSource).toContain('href: "/docs"');
+    expect(navSource).toContain('href: "https://docs.clawhub.ai/"');
     expect(navSource).not.toContain('icon: "wrench"');
     expect(navSource).not.toContain('icon: "plug"');
     expect(navSource).not.toContain('label: "About"');

--- a/src/lib/nav-items.ts
+++ b/src/lib/nav-items.ts
@@ -66,7 +66,7 @@ export const PRIMARY_NAV_ITEMS: NavItem[] = [
 export const SECONDARY_NAV_ITEMS: NavItem[] = [
   {
     label: "Docs",
-    href: "/docs",
+    href: "https://docs.clawhub.ai/",
     activePathPrefixes: ["/docs"],
   },
 ];

--- a/vercel.json
+++ b/vercel.json
@@ -27,6 +27,54 @@
         {
           "type": "header",
           "key": "host",
+          "value": "docs.clawhub.ai"
+        }
+      ],
+      "destination": "https://docs.clawhub.ai/",
+      "statusCode": 308
+    },
+    {
+      "source": "/docs/",
+      "has": [
+        {
+          "type": "header",
+          "key": "host",
+          "value": "docs.clawhub.ai"
+        }
+      ],
+      "destination": "https://docs.clawhub.ai/",
+      "statusCode": 308
+    },
+    {
+      "source": "/docs/:path*",
+      "has": [
+        {
+          "type": "header",
+          "key": "host",
+          "value": "docs.clawhub.ai"
+        }
+      ],
+      "destination": "https://docs.clawhub.ai/:path*",
+      "statusCode": 308
+    },
+    {
+      "source": "/docs/:path*/",
+      "has": [
+        {
+          "type": "header",
+          "key": "host",
+          "value": "docs.clawhub.ai"
+        }
+      ],
+      "destination": "https://docs.clawhub.ai/:path*/",
+      "statusCode": 308
+    },
+    {
+      "source": "/docs",
+      "has": [
+        {
+          "type": "header",
+          "key": "host",
           "value": "clawhub.ai"
         }
       ],
@@ -95,6 +143,17 @@
     }
   ],
   "rewrites": [
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "header",
+          "key": "host",
+          "value": "docs.clawhub.ai"
+        }
+      ],
+      "destination": "/docs"
+    },
     {
       "source": "/ask-molty/:path*",
       "has": [


### PR DESCRIPTION
## Summary
- Point ClawHub's Docs nav item at `https://docs.clawhub.ai/`.
- Rewrite `docs.clawhub.ai/` to the generated docs artifact instead of the app homepage.
- Redirect `docs.clawhub.ai/docs/*` to canonical root docs paths.

## Tests
- `bunx vitest run src/__tests__/ui-design-contract.test.ts src/__tests__/header.test.tsx scripts/docs-builder.test.mjs`
- `bun run docs:build && bun run docs:smoke`
- `bun run format:check -- src/lib/nav-items.ts src/__tests__/ui-design-contract.test.ts src/__tests__/header.test.tsx scripts/docs-smoke.mjs vercel.json`
- `git diff --check`
- `bun run ci:static`
- `bun run ci:types-build`

## Review
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local`
- Result: nested `codex review` reported no correctness issues; wrapper was interrupted after emitting the clean result.
