### PR TITLE
fix: preserve single-row ClawHub header

### DIFF
--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -130,8 +130,24 @@ vi.mock("../lib/useUnifiedSearch", () => ({
 
 vi.mock("../components/ui/dropdown-menu", () => ({
   DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  DropdownMenuItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children, className }: { children: ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    className,
+    onClick,
+    ...props
+  }: {
+    children: ReactNode;
+    className?: string;
+    onClick?: () => void;
+    "data-status"?: string;
+  }) => (
+    <div className={className} data-status={props["data-status"]} onClick={onClick}>
+      {children}
+    </div>
+  ),
   DropdownMenuSeparator: () => <hr />,
   DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
@@ -198,41 +214,66 @@ describe("Header", () => {
     signInMock.mockResolvedValue({ signingIn: true });
   });
 
-  it("renders restored desktop nav rows and segmented theme controls", () => {
+  it("renders text-only content links in the top navbar", () => {
     setModeMock.mockClear();
 
     render(<Header />);
 
-    expect(document.querySelector(".navbar-tabs")).toBeTruthy();
-    expect(document.querySelector(".navbar-tabs-secondary")).toBeTruthy();
-    expect(document.querySelector(".theme-mode-toggle")).toBeTruthy();
-    expect(screen.getByLabelText("Theme mode").className).toContain("theme-mode-toggle");
-    expect(screen.getByRole("button", { name: /Cycle theme mode/i })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "System theme" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Light theme" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Dark theme" })).toBeTruthy();
+    const topNav = screen.getByRole("navigation", { name: "Primary navigation" });
+    expect(document.querySelector(".navbar-top-links")).toBeTruthy();
+    expect(document.querySelector(".navbar-tabs")).toBeNull();
+    expect(document.querySelector(".theme-mode-toggle")).toBeNull();
+    expect(within(topNav).getByText("Skills").closest("a")?.querySelector("svg")).toBeNull();
+    expect(within(topNav).getByText("Plugins").closest("a")?.querySelector("svg")).toBeNull();
+    expect(within(topNav).getByText("Docs").closest("a")?.getAttribute("href")).toBe(
+      "https://docs.openclaw.ai/clawhub/",
+    );
     expect(screen.getAllByText("Skills")).toHaveLength(1);
     expect(screen.getAllByText("Plugins")).toHaveLength(1);
-    expect(screen.getAllByText("Publishers")).toHaveLength(1);
+    expect(screen.queryByText("Publishers")).toBeNull();
     expect(screen.getAllByText("Docs")).toHaveLength(1);
     expect(screen.queryByText("About")).toBeNull();
     expect(screen.queryByText("Dashboard")).toBeNull();
     expect(screen.queryByText("Manage")).toBeNull();
     expect(screen.getByPlaceholderText("Search skills and plugins")).toBeTruthy();
-    expect(document.querySelector(".navbar-tabs")?.textContent).toContain("Publishers");
-    expect(document.querySelector(".navbar-tabs-secondary")?.textContent).toBe("Docs");
-
-    fireEvent.click(screen.getByRole("button", { name: /Cycle theme mode/i }));
-    expect(setModeMock).toHaveBeenCalledWith("light");
 
     fireEvent.click(screen.getByRole("button", { name: "Open menu" }));
 
     expect(screen.getAllByText("Home")).toHaveLength(1);
     expect(screen.getAllByText("Skills")).toHaveLength(2);
     expect(screen.getAllByText("Plugins")).toHaveLength(2);
-    expect(screen.getAllByText("Publishers")).toHaveLength(2);
+    expect(screen.queryByText("Publishers")).toBeNull();
     expect(screen.getAllByText("Docs")).toHaveLength(2);
     expect(screen.queryByText("About")).toBeNull();
+  });
+
+  it("moves theme mode controls into the signed-in profile menu", () => {
+    authStatusMock.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      me: {
+        displayName: "Patrick",
+        email: "patrick@example.com",
+        handle: "patrick",
+        image: null,
+        name: "Patrick",
+      },
+    });
+
+    render(<Header />);
+
+    expect(document.querySelector(".theme-mode-toggle")).toBeNull();
+    expect(screen.getByText("Theme")).toBeTruthy();
+    expect(
+      screen
+        .getByText("System theme")
+        .closest(".user-dropdown-theme-item")
+        ?.getAttribute("data-status"),
+    ).toBe("active");
+    fireEvent.click(screen.getByText("Light theme").closest(".user-dropdown-theme-item")!);
+    expect(setModeMock).toHaveBeenCalledWith("light");
+    fireEvent.click(screen.getByText("Dark theme").closest(".user-dropdown-theme-item")!);
+    expect(setModeMock).toHaveBeenCalledWith("dark");
   });
 
   it("renders the GitHub sign-in button with desktop and compact labels", () => {
@@ -426,8 +467,7 @@ describe("Header", () => {
       .map((element) => element.textContent?.trim())
       .filter((label): label is string => Boolean(label));
 
-    expect(labels.slice(0, 4)).toEqual(["Home", "Skills", "Plugins", "Publishers"]);
-    expect(labels[4]).toBe("Docs");
+    expect(labels.slice(0, 4)).toEqual(["Home", "Skills", "Plugins", "Docs"]);
   });
 
   it("links starred skills from the signed-in avatar menu", () => {

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -68,25 +68,31 @@ describe("restored UI design contract", () => {
   const styles = () => read("src/styles.css");
   const theme = () => read("src/lib/theme.ts");
 
-  it("requires the restored two-row header, full-width search, public nav, and theme control", () => {
+  it("requires the single-row header, full-width search, public nav, and profile theme control", () => {
     const headerSource = header();
     const navSource = navItems();
     const css = styles();
 
     expect(headerSource).toContain("Row 1: Brand + Search + Actions");
     expect(headerSource).toContain('className="navbar-top"');
+    expect(headerSource).toContain('className="navbar-top-links"');
     expect(headerSource).toContain('className="navbar-search-wrap"');
-    expect(headerSource).toContain('className="theme-mode-toggle"');
+    expect(headerSource).toContain('className="user-dropdown-section-label"');
+    expect(headerSource).toContain('className="user-dropdown-theme-item"');
+    expect(headerSource).not.toContain('className="theme-mode-toggle"');
     expect(headerSource).toContain('className="github-sign-in-button"');
     expect(headerSource).toContain('className="sign-in-full-copy"');
     expect(headerSource).toContain('className="sign-in-compact-copy"');
     expect(headerSource).toContain("Search skills and plugins");
-    expect(headerSource).toContain('className="navbar-tabs-primary"');
-    expect(headerSource).toContain('className="navbar-tabs-secondary"');
+    expect(headerSource).not.toContain('className="navbar-tabs-primary"');
+    expect(headerSource).not.toContain('className="navbar-tabs-secondary"');
 
     expect(navSource).toContain("export const SECONDARY_NAV_ITEMS");
-    expect(navSource).toContain('label: "Publishers"');
+    expect(navSource).not.toContain('label: "Publishers"');
     expect(navSource).toContain('label: "Docs"');
+    expect(navSource).toContain('href: "https://docs.openclaw.ai/clawhub/"');
+    expect(navSource).not.toContain('icon: "wrench"');
+    expect(navSource).not.toContain('icon: "plug"');
     expect(navSource).not.toContain('label: "About"');
     expect(navSource).not.toContain('label: "Stars"');
     expect(navSource).not.toContain('label: "Management"');
@@ -95,16 +101,20 @@ describe("restored UI design contract", () => {
     expect(headerShell).toContain("max-width: var(--page-max)");
     expect(headerShell).toContain("padding: 0 var(--space-5)");
 
-    const themeControl = cssRule(css, ".theme-mode-toggle");
-    expect(themeControl).toContain("min-width: 124px");
-    expect(themeControl).toContain("min-height: 32px");
-    expect(themeControl).toContain("border: 1px solid var(--line)");
+    const topLinks = cssRule(css, ".navbar-top-links");
+    expect(topLinks).toContain("display: inline-flex");
+    const topRow = cssRule(css, ".navbar-top");
+    expect(topRow).toContain(
+      "grid-template-columns: max-content max-content minmax(220px, 1fr) auto",
+    );
+    const themeItem = cssRule(css, ".user-dropdown-theme-item");
+    expect(themeItem).toContain("min-width: 220px");
     expect(css).toContain("--r-btn: var(--r-sm)");
 
     const compact = cssMediaContaining(css, "(max-width: 760px)", [
       "grid-template-columns: 40px minmax(0, 1fr) 40px",
       ".navbar-search {\n    display: flex;",
-      ".navbar-tabs {\n    display: none;",
+      ".navbar-top-links {\n    display: none;",
       ".nav-mobile {\n    display: inline-flex;",
     ]);
     expect(compact).not.toContain(".navbar-search {\n    display: none;");

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -19,7 +19,6 @@ import {
   routeToBannedAccountPage,
 } from "../lib/authErrorMessage";
 import { gravatarUrl } from "../lib/gravatar";
-import { NAV_ICONS } from "../lib/marketplaceIcons";
 import { PRIMARY_NAV_ITEMS, SECONDARY_NAV_ITEMS } from "../lib/nav-items";
 import { SITE_NAME } from "../lib/site";
 import { applyTheme, useThemeMode } from "../lib/theme";
@@ -46,9 +45,12 @@ import {
   SheetHeader,
   SheetTitle,
 } from "./ui/sheet";
-import { ToggleGroup, ToggleGroupItem } from "./ui/toggle-group";
 
-const THEME_MODE_SEQUENCE: Array<"system" | "light" | "dark"> = ["system", "light", "dark"];
+const THEME_MODE_ITEMS = [
+  { mode: "system", label: "System theme", Icon: Monitor },
+  { mode: "light", label: "Light theme", Icon: Sun },
+  { mode: "dark", label: "Dark theme", Icon: Moon },
+] as const;
 
 function GitHubLogo({ className }: { className?: string }) {
   return (
@@ -96,7 +98,6 @@ export default function Header() {
   const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const searchWrapRef = useRef<HTMLDivElement | null>(null);
-  const ThemeModeIcon = getThemeModeIcon(mode);
   const trimmedNavSearchQuery = navSearchQuery.trim();
   const showTypeahead = typeaheadOpen && trimmedNavSearchQuery.length > 0;
   const {
@@ -161,11 +162,6 @@ export default function Header() {
   const setThemeMode = (next: "system" | "light" | "dark") => {
     applyTheme(next, theme);
     setMode(next);
-  };
-
-  const cycleThemeMode = () => {
-    const currentIndex = Math.max(0, THEME_MODE_SEQUENCE.indexOf(mode));
-    setThemeMode(THEME_MODE_SEQUENCE[(currentIndex + 1) % THEME_MODE_SEQUENCE.length] ?? "system");
   };
 
   const handleNavSearch = (e: React.FormEvent) => {
@@ -272,9 +268,7 @@ export default function Header() {
                       <span className="mobile-nav-brand-name">{SITE_NAME}</span>
                     </span>
                   </SheetTitle>
-                  <SheetDescription>
-                    Browse sections, switch theme, and access account actions.
-                  </SheetDescription>
+                  <SheetDescription>Browse sections and access account actions.</SheetDescription>
                 </SheetHeader>
                 <div className="mobile-nav-section">
                   <SheetClose asChild>
@@ -311,20 +305,6 @@ export default function Header() {
                     </SheetClose>
                   ))}
                 </div>
-                <div className="mobile-nav-section">
-                  <div className="mobile-nav-section-title">Theme</div>
-                  <button
-                    className="mobile-nav-link"
-                    type="button"
-                    onClick={() => {
-                      cycleThemeMode();
-                      setMobileMenuOpen(false);
-                    }}
-                  >
-                    <ThemeModeIcon className="h-4 w-4" aria-hidden="true" />
-                    {mode === "system" ? "System theme" : `${mode} theme`}
-                  </button>
-                </div>
               </SheetContent>
             </Sheet>
           </div>
@@ -339,6 +319,34 @@ export default function Header() {
             </span>
             <span className="brand-name brand-name-responsive">{SITE_NAME}</span>
           </Link>
+
+          <nav className="navbar-top-links" aria-label="Primary navigation">
+            {[...PRIMARY_NAV_ITEMS, ...SECONDARY_NAV_ITEMS].map((item) => {
+              const isActiveByPrefix = item.activePathPrefixes?.some((prefix) =>
+                location.pathname.startsWith(prefix),
+              );
+              return item.href ? (
+                <a
+                  key={item.href + item.label}
+                  href={item.href}
+                  className="navbar-tab"
+                  data-status={isActiveByPrefix ? "active" : undefined}
+                >
+                  {item.label}
+                </a>
+              ) : (
+                <Link
+                  key={item.to + item.label}
+                  to={item.to}
+                  className="navbar-tab"
+                  search={(item.search ?? {}) as never}
+                  data-status={isActiveByPrefix ? "active" : undefined}
+                >
+                  {item.label}
+                </Link>
+              );
+            })}
+          </nav>
 
           <div className="navbar-search-wrap" ref={searchWrapRef}>
             <form
@@ -389,42 +397,6 @@ export default function Header() {
             >
               <Search size={18} aria-hidden="true" />
             </button>
-            <div className="theme-toggle">
-              <div className="theme-cycle-group" aria-label="Theme controls">
-                <button
-                  type="button"
-                  className="theme-cycle-button theme-cycle-button-mode"
-                  onClick={cycleThemeMode}
-                  aria-label={`Cycle theme mode. Current: ${mode}`}
-                  title={`Theme mode: ${mode}`}
-                >
-                  <ThemeModeIcon className="h-4 w-4" aria-hidden="true" />
-                </button>
-              </div>
-              <ToggleGroup
-                className="theme-mode-toggle"
-                type="single"
-                value={mode}
-                onValueChange={(value) => {
-                  if (!value) return;
-                  setThemeMode(value as "system" | "light" | "dark");
-                }}
-                aria-label="Theme mode"
-              >
-                <ToggleGroupItem value="system" aria-label="System theme">
-                  <Monitor className="h-4 w-4" aria-hidden="true" />
-                  <span className="sr-only">System</span>
-                </ToggleGroupItem>
-                <ToggleGroupItem value="light" aria-label="Light theme">
-                  <Sun className="h-4 w-4" aria-hidden="true" />
-                  <span className="sr-only">Light</span>
-                </ToggleGroupItem>
-                <ToggleGroupItem value="dark" aria-label="Dark theme">
-                  <Moon className="h-4 w-4" aria-hidden="true" />
-                  <span className="sr-only">Dark</span>
-                </ToggleGroupItem>
-              </ToggleGroup>
-            </div>
             {isAuthenticated && me ? (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -439,6 +411,22 @@ export default function Header() {
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="user-dropdown-content">
+                  <div className="user-dropdown-section-label">Theme</div>
+                  {THEME_MODE_ITEMS.map(({ mode: themeMode, label, Icon }) => (
+                    <DropdownMenuItem
+                      key={themeMode}
+                      className="user-dropdown-theme-item"
+                      data-status={mode === themeMode ? "active" : undefined}
+                      onClick={() => setThemeMode(themeMode)}
+                    >
+                      <Icon size={14} aria-hidden="true" />
+                      <span>{label}</span>
+                      {mode === themeMode ? (
+                        <span className="user-dropdown-current">Current</span>
+                      ) : null}
+                    </DropdownMenuItem>
+                  ))}
+                  <DropdownMenuSeparator />
                   <DropdownMenuItem asChild>
                     <Link to="/dashboard" className="flex items-center gap-2">
                       <LayoutDashboard size={14} aria-hidden="true" />
@@ -523,55 +511,6 @@ export default function Header() {
             />
           </form>
         ) : null}
-
-        <nav className="navbar-tabs" aria-label="Content types">
-          <div className="navbar-tabs-primary">
-            {PRIMARY_NAV_ITEMS.map((item) => {
-              const Icon = item.icon ? NAV_ICONS[item.icon] : null;
-              const isActiveByPrefix = item.activePathPrefixes?.some((prefix) =>
-                location.pathname.startsWith(prefix),
-              );
-              return (
-                <Link
-                  key={item.to + item.label}
-                  to={item.to}
-                  className="navbar-tab"
-                  search={(item.search ?? {}) as never}
-                  data-status={isActiveByPrefix ? "active" : undefined}
-                >
-                  {Icon ? <Icon size={14} className="opacity-50" aria-hidden="true" /> : null}
-                  {item.label}
-                </Link>
-              );
-            })}
-          </div>
-          <div className="navbar-tabs-secondary">
-            {SECONDARY_NAV_ITEMS.map((item) => {
-              const isActiveByPrefix = item.activePathPrefixes?.some((prefix) =>
-                location.pathname.startsWith(prefix),
-              );
-              return item.href ? (
-                <a
-                  key={item.href + item.label}
-                  href={item.href}
-                  className="navbar-tab navbar-tab-secondary"
-                >
-                  {item.label}
-                </a>
-              ) : (
-                <Link
-                  key={(item.to ?? "") + item.label}
-                  to={item.to}
-                  search={(item.search ?? {}) as never}
-                  className="navbar-tab navbar-tab-secondary"
-                  data-status={isActiveByPrefix ? "active" : undefined}
-                >
-                  {item.label}
-                </Link>
-              );
-            })}
-          </div>
-        </nav>
       </div>
     </header>
   );
@@ -752,16 +691,4 @@ function getTypeaheadRowBody(item: TypeaheadItem) {
 function getCurrentRelativeUrl() {
   if (typeof window === "undefined") return "/";
   return `${window.location.pathname}${window.location.search}${window.location.hash}`;
-}
-
-function getThemeModeIcon(mode: "system" | "light" | "dark") {
-  switch (mode) {
-    case "light":
-      return Sun;
-    case "dark":
-      return Moon;
-    case "system":
-    default:
-      return Monitor;
-  }
 }

--- a/src/lib/marketplaceIcons.ts
+++ b/src/lib/marketplaceIcons.ts
@@ -11,11 +11,5 @@ export const MARKETPLACE_KIND_ICONS = {
   org: Building2,
 } as const satisfies Record<MarketplaceIconKind, MarketplaceIconComponent>;
 
-export const NAV_ICONS = {
-  wrench: Wrench,
-  plug: MARKETPLACE_KIND_ICONS.plugin,
-  user: MARKETPLACE_KIND_ICONS.user,
-} as const satisfies Record<string, MarketplaceIconComponent>;
-
 export const SKILL_NAV_ICON = Wrench;
 export const PLUGIN_NAV_ICON = MARKETPLACE_KIND_ICONS.plugin;

--- a/src/lib/nav-items.ts
+++ b/src/lib/nav-items.ts
@@ -3,9 +3,6 @@
  * triple duplication of nav link definitions.
  */
 
-/** Lucide icon name used as a key to look up the component at render time. */
-type NavIconName = "wrench" | "plug" | "user";
-
 interface NavItemBase {
   /** Visible link text */
   label: string;
@@ -19,16 +16,13 @@ interface RouteNavItem extends NavItemBase {
   href?: never;
   /** Optional search params object passed to `<Link search>` */
   search?: Record<string, unknown>;
-  /** Optional lucide icon name shown beside the label in navbar tabs */
-  icon?: NavIconName;
 }
 
 interface ExternalNavItem extends NavItemBase {
-  /** External URL rendered as a normal anchor */
+  /** URL rendered as a normal anchor, including external and static app paths. */
   href: string;
   to?: never;
   search?: never;
-  icon?: never;
 }
 
 type NavItem = RouteNavItem | ExternalNavItem;
@@ -46,8 +40,6 @@ const SKILLS_SEARCH = {
   focus: undefined,
 } as const;
 
-const PUBLISHERS_SEARCH = { q: undefined } as const;
-
 // ---------------------------------------------------------------------------
 // Primary nav items (desktop tabs row + mobile dropdown top section)
 // These map to the content-type tabs: Skills | Plugins | Publishers
@@ -58,20 +50,12 @@ export const PRIMARY_NAV_ITEMS: NavItem[] = [
     label: "Skills",
     to: "/skills",
     search: SKILLS_SEARCH,
-    icon: "wrench",
     activePathPrefixes: ["/skill/"],
   },
   {
     label: "Plugins",
     to: "/plugins",
-    icon: "plug",
     activePathPrefixes: ["/plugin/"],
-  },
-  {
-    label: "Publishers",
-    to: "/publishers",
-    search: PUBLISHERS_SEARCH,
-    icon: "user",
   },
 ];
 
@@ -83,6 +67,7 @@ export const SECONDARY_NAV_ITEMS: NavItem[] = [
   {
     label: "Docs",
     href: "https://docs.openclaw.ai/clawhub/",
+    activePathPrefixes: ["/docs"],
   },
 ];
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -427,9 +427,10 @@ code {
 
 .navbar-top {
   display: grid;
-  grid-template-columns: minmax(148px, auto) minmax(240px, 1fr) auto;
+  grid-template-columns: max-content max-content minmax(220px, 1fr) auto;
   align-items: center;
-  gap: 16px;
+  column-gap: 16px;
+  row-gap: 10px;
   padding: 12px 0;
   min-height: 62px;
 }
@@ -653,12 +654,17 @@ code {
 }
 
 .navbar-top-links {
-  display: none;
+  display: inline-flex;
   align-items: center;
   justify-content: flex-start;
   gap: 4px;
   min-width: 0;
   white-space: nowrap;
+}
+
+.navbar-top-links .navbar-tab {
+  min-height: 32px;
+  padding: 7px 10px;
 }
 
 .navbar-tabs-primary,
@@ -914,103 +920,6 @@ code {
   min-width: 0;
 }
 
-.theme-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  flex: 0 0 auto;
-  min-width: 0;
-  justify-content: flex-end;
-}
-
-.theme-cycle-group {
-  display: none;
-  align-items: center;
-  gap: 8px;
-  width: 72px;
-  min-width: 72px;
-  grid-template-columns: repeat(2, 32px);
-  justify-content: end;
-}
-
-.theme-cycle-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  border: 1px solid var(--line);
-  border-radius: var(--r-btn);
-  background: var(--surface);
-  color: var(--ink-soft);
-  cursor: pointer;
-  transition:
-    border-color 0.15s ease,
-    background 0.15s ease,
-    color 0.15s ease,
-    box-shadow 0.15s ease;
-}
-
-.theme-cycle-button:hover {
-  color: var(--ink);
-  border-color: var(--border-ui-hover);
-  background: var(--surface-muted);
-}
-
-.theme-cycle-button:focus-visible {
-  outline: 2px solid var(--input-focus-border);
-  outline-offset: 2px;
-}
-
-.theme-mode-toggle {
-  min-width: 124px;
-  height: 32px;
-  min-height: 32px;
-  padding: 0 8px;
-  gap: 8px;
-  border: 1px solid var(--line);
-  background: var(--surface);
-  justify-content: center;
-  border-radius: var(--r-btn);
-}
-
-.theme-mode-toggle button {
-  all: unset;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  border-radius: var(--r-btn);
-  cursor: pointer;
-  color: var(--ink-soft);
-  opacity: 0.5;
-  transition:
-    opacity 0.15s ease,
-    color 0.15s ease,
-    background 0.15s ease;
-}
-
-.theme-mode-toggle button svg {
-  width: 16px;
-  height: 16px;
-}
-
-.theme-mode-toggle button:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
-.theme-mode-toggle button:hover {
-  opacity: 0.8;
-}
-
-.theme-mode-toggle button[data-state="on"] {
-  opacity: 1;
-  color: var(--ink);
-  background: transparent;
-}
-
 .github-sign-in-button {
   height: 32px !important;
   min-height: 32px !important;
@@ -1105,6 +1014,30 @@ code {
 
 .user-dropdown-content [data-slot="dropdown-menu-item"]:focus-visible {
   outline: none;
+}
+
+.user-dropdown-section-label {
+  padding: 4px 8px 6px;
+  font-size: var(--fs-xs);
+  font-weight: 650;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+.user-dropdown-theme-item {
+  min-width: 220px;
+}
+
+.user-dropdown-theme-item[data-status="active"] {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--ink);
+}
+
+.user-dropdown-current {
+  margin-left: auto;
+  font-size: var(--fs-xs);
+  color: var(--ink-soft);
 }
 
 /* @deprecated — use <Button> from components/ui/button.tsx */
@@ -6616,10 +6549,6 @@ code {
   }
 
   .brand {
-    display: none;
-  }
-
-  .theme-toggle {
     display: none;
   }
 
@@ -13485,16 +13414,34 @@ a.publisher-profile-detail:hover {
 }
 
 @media (max-width: 1100px) and (min-width: 761px) {
-  .theme-mode-toggle {
-    min-width: 112px;
-    height: 40px;
-    min-height: 40px;
-    padding: 0 8px;
-    gap: 6px;
+  .navbar-top {
+    grid-template-columns: max-content max-content minmax(180px, 1fr) auto;
+    gap: 10px;
   }
 
-  .theme-cycle-group {
+  .brand-name-responsive {
     display: none;
+  }
+
+  .navbar-top-links {
+    gap: 0;
+  }
+
+  .navbar-top-links .navbar-tab {
+    padding: 7px 8px;
+  }
+
+  .github-sign-in-button,
+  .auth-loading-placeholder {
+    width: 92px !important;
+  }
+
+  .sign-in-full-copy {
+    display: none;
+  }
+
+  .sign-in-compact-copy {
+    display: inline-block;
   }
 }
 
@@ -15020,13 +14967,6 @@ a.publisher-profile-detail:hover {
   border-radius: var(--r-btn) !important;
 }
 .skills-view button {
-  border-radius: var(--r-btn) !important;
-}
-
-/* Theme toggle buttons */
-.theme-cycle-button,
-.theme-mode-toggle button,
-.theme-mode-toggle {
   border-radius: var(--r-btn) !important;
 }
 


### PR DESCRIPTION
## Summary
- restore the newer single-row ClawHub header layout
- keep the Docs navigation target on `https://docs.openclaw.ai/clawhub/`
- update header/design regression tests for the preserved header shape

## Tests
- `bun x vitest run src/__tests__/header.test.tsx src/__tests__/ui-design-contract.test.ts`
- `bun x tsc --noEmit --pretty false`
- touched-file docs link scan for `docs.clawhub.ai` / `clawhub.ai/docs`
