### PR TITLE
Fix registry backup retry drain throughput

### DIFF
--- a/convex/crons.test.ts
+++ b/convex/crons.test.ts
@@ -48,12 +48,12 @@ vi.mock("./_generated/api", () => ({
 }));
 
 describe("crons", () => {
-  it("drains registry artifact backup retries every 30 minutes", async () => {
+  it("drains registry artifact backup retries frequently enough for publish bursts", async () => {
     await import("./crons");
 
     expect(mocks.interval).toHaveBeenCalledWith(
       "registry-artifact-backup-retries",
-      { minutes: 30 },
+      { minutes: 5 },
       mocks.registryArtifactBackupRetryRef,
       {},
     );

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -5,7 +5,7 @@ const crons = cronJobs();
 
 crons.interval(
   "registry-artifact-backup-retries",
-  { minutes: 30 },
+  { minutes: 5 },
   internal.registryArtifactBackupsNode.processRegistryArtifactBackupRetriesInternal,
   {},
 );

--- a/convex/lib/registryArtifactBackup.ts
+++ b/convex/lib/registryArtifactBackup.ts
@@ -11,6 +11,8 @@ const DEFAULT_PACKAGES_ROOT = "packages";
 const META_FILENAME = "_meta.json";
 const INDEX_FILENAME = "_index.json";
 const MAX_INDEX_WRITE_ATTEMPTS = 5;
+const MIN_INDEX_WRITE_RETRY_DELAY_MS = 25;
+const MAX_INDEX_WRITE_RETRY_DELAY_MS = 250;
 
 type BackupFile = {
   path: string;
@@ -183,6 +185,34 @@ export async function backupPackageReleaseToObjectStorage(
   });
 
   await putJsonObject(context, planned.metaPath, planned.meta);
+  await putMergedJsonIndex(context, planned.indexPath, (existingIndex: PackageIndexFile | null) =>
+    buildPackageIndexFile(planned, existingIndex),
+  );
+}
+
+export async function repairSkillVersionBackupIndex(
+  _ctx: Pick<ActionCtx, "storage">,
+  params: SkillBackupParams & { root?: string },
+  context: RegistryArtifactBackupContext = getRegistryArtifactBackupContext(),
+) {
+  const planned = buildSkillVersionBackupManifest({
+    root: params.root ?? context.skillsRoot,
+    ...params,
+  });
+  await putMergedJsonIndex(context, planned.indexPath, (existingIndex: SkillIndexFile | null) =>
+    buildSkillIndexFile(planned, existingIndex),
+  );
+}
+
+export async function repairPackageReleaseBackupIndex(
+  _ctx: Pick<ActionCtx, "storage">,
+  params: PackageBackupParams & { root?: string },
+  context: RegistryArtifactBackupContext = getRegistryArtifactBackupContext(),
+) {
+  const planned = buildPackageReleaseBackupManifest({
+    root: params.root ?? context.packagesRoot,
+    ...params,
+  });
   await putMergedJsonIndex(context, planned.indexPath, (existingIndex: PackageIndexFile | null) =>
     buildPackageIndexFile(planned, existingIndex),
   );
@@ -534,9 +564,22 @@ async function putMergedJsonIndex<T>(
       },
     );
     if (result === "ok") return;
+    await sleep(indexWriteRetryDelayMs(attempt));
   }
 
   throw new Error(`Registry artifact backup index ${key} changed too frequently`);
+}
+
+function indexWriteRetryDelayMs(attempt: number) {
+  const base = Math.min(
+    MAX_INDEX_WRITE_RETRY_DELAY_MS,
+    MIN_INDEX_WRITE_RETRY_DELAY_MS * 2 ** attempt,
+  );
+  return base + Math.floor(Math.random() * MIN_INDEX_WRITE_RETRY_DELAY_MS);
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function putObject(

--- a/convex/registryArtifactBackups.test.ts
+++ b/convex/registryArtifactBackups.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Id } from "./_generated/dataModel";
 import {
   enqueueRegistryArtifactBackupJobHandler,
+  getDueRegistryArtifactBackupJobsInternal,
   getRegistryArtifactBackupHealthHandler,
   getRegistryArtifactBackupPageInternal,
   getPackageRegistryArtifactBackupPageInternal,
@@ -20,6 +21,8 @@ const registryBackupMocks = vi.hoisted(() => ({
   fetchSkillVersionBackupMeta: vi.fn(),
   getRegistryArtifactBackupContext: vi.fn(),
   isRegistryArtifactBackupConfigured: vi.fn(),
+  repairPackageReleaseBackupIndex: vi.fn(),
+  repairSkillVersionBackupIndex: vi.fn(),
 }));
 
 vi.mock("./lib/registryArtifactBackup", () => registryBackupMocks);
@@ -28,6 +31,9 @@ const handler = (getRegistryArtifactBackupPageInternal as unknown as { _handler:
   ._handler;
 const packagePageHandler = (
   getPackageRegistryArtifactBackupPageInternal as unknown as { _handler: Function }
+)._handler;
+const dueJobsHandler = (
+  getDueRegistryArtifactBackupJobsInternal as unknown as { _handler: Function }
 )._handler;
 const backupSkillForPublishHandler = (
   backupSkillForPublishInternal as unknown as { _handler: Function }
@@ -654,6 +660,309 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
     );
   });
 
+  it("requests a larger retry batch so publish bursts drain promptly", async () => {
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({ stale: 0, exhausted: 0 });
+
+    await processRegistryArtifactBackupRetriesInternalHandler(
+      { runQuery, runMutation: vi.fn() } as never,
+      {},
+    );
+
+    expect(runQuery.mock.calls[0]?.[1]).toMatchObject({
+      includeExhaustedRepair: true,
+      limit: 200,
+      maxRepairAttempts: 16,
+    });
+  });
+
+  it("gives repaired exhausted jobs a finite second retry budget", async () => {
+    const dueJob = {
+      _id: "registryArtifactBackupJobs:demo",
+      targetKind: "skillVersion",
+      skillVersionId: "skillVersions:demo",
+      status: "exhausted",
+      attempts: 8,
+      nextRunAt: 1,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const version = {
+      _id: "skillVersions:demo",
+      skillId: "skills:demo",
+      version: "1.0.0",
+      createdAt: 1,
+      files: [{ path: "SKILL.md", size: 5, storageId: "storage:skill", sha256: "sha" }],
+      softDeletedAt: undefined,
+    };
+    const skill = {
+      _id: "skills:demo",
+      ownerUserId: "users:owner",
+      ownerPublisherId: undefined,
+      slug: "demo-skill",
+      displayName: "Demo Skill",
+      latestVersionId: "skillVersions:demo",
+      softDeletedAt: undefined,
+      moderationStatus: "active",
+    };
+    const owner = {
+      _id: "users:owner",
+      handle: "alice",
+      deletedAt: undefined,
+      deactivatedAt: undefined,
+    };
+    const runQuery = vi.fn(async (_ref, args) => {
+      if ("limit" in args) return [dueJob];
+      if (args.versionId === "skillVersions:demo") return version;
+      if (args.skillId === "skills:demo") return skill;
+      if (args.userId === "users:owner") return owner;
+      if ("staleAfterMs" in args) return { stale: 0, exhausted: 0 };
+      throw new Error(`unexpected query ${JSON.stringify(args)}`);
+    });
+    const runMutation = vi.fn();
+    registryBackupMocks.fetchSkillVersionBackupMeta.mockResolvedValue(null);
+    registryBackupMocks.backupSkillVersionToObjectStorage.mockRejectedValueOnce(
+      new Error("R2 still down"),
+    );
+
+    const result = await processRegistryArtifactBackupRetriesInternalHandler(
+      { runQuery, runMutation } as never,
+      {},
+    );
+
+    expect(result.stats.retryJobsFailed).toBe(1);
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        jobId: "registryArtifactBackupJobs:demo",
+        error: "R2 still down",
+        maxAttempts: 16,
+      }),
+    );
+  });
+
+  it("repairs the index without reuploading skill files when retry metadata already exists", async () => {
+    const dueJob = {
+      _id: "registryArtifactBackupJobs:demo",
+      targetKind: "skillVersion",
+      skillVersionId: "skillVersions:demo",
+      status: "pending",
+      attempts: 1,
+      nextRunAt: 1,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const version = {
+      _id: "skillVersions:demo",
+      skillId: "skills:demo",
+      version: "1.0.0",
+      createdAt: 1,
+      files: [{ path: "SKILL.md", size: 5, storageId: "storage:skill", sha256: "sha" }],
+      softDeletedAt: undefined,
+    };
+    const skill = {
+      _id: "skills:demo",
+      ownerUserId: "users:owner",
+      ownerPublisherId: undefined,
+      slug: "demo-skill",
+      displayName: "Demo Skill",
+      latestVersionId: "skillVersions:demo",
+      softDeletedAt: undefined,
+      moderationStatus: "active",
+    };
+    const owner = {
+      _id: "users:owner",
+      handle: "alice",
+      deletedAt: undefined,
+      deactivatedAt: undefined,
+    };
+    const runQuery = vi.fn(async (_ref, args) => {
+      if ("limit" in args) return [dueJob];
+      if (args.versionId === "skillVersions:demo") {
+        return version;
+      }
+      if (args.skillId === "skills:demo") return skill;
+      if (args.userId === "users:owner") return owner;
+      if ("staleAfterMs" in args) return { stale: 0, exhausted: 0 };
+      throw new Error(`unexpected query ${JSON.stringify(args)}`);
+    });
+    const runMutation = vi.fn();
+    registryBackupMocks.fetchSkillVersionBackupMeta.mockResolvedValueOnce({
+      version: "1.0.0",
+      restore: { versionId: "skillVersions:demo" },
+    });
+
+    const result = await processRegistryArtifactBackupRetriesInternalHandler(
+      { runQuery, runMutation } as never,
+      {},
+    );
+
+    expect(result.stats.retryJobsSucceeded).toBe(1);
+    expect(registryBackupMocks.backupSkillVersionToObjectStorage).not.toHaveBeenCalled();
+    expect(registryBackupMocks.repairSkillVersionBackupIndex).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        slug: "demo-skill",
+        version: "1.0.0",
+        ownerHandle: "alice",
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("processes different retry roots in parallel while keeping one root sequential", async () => {
+    const jobs = [
+      makeSkillBackupJob("same-1", "skillVersions:same-1"),
+      makeSkillBackupJob("same-2", "skillVersions:same-2"),
+      makeSkillBackupJob("other", "skillVersions:other"),
+    ];
+    const versions = new Map([
+      ["skillVersions:same-1", makeSkillVersion("skillVersions:same-1", "skills:same", "1.0.0")],
+      ["skillVersions:same-2", makeSkillVersion("skillVersions:same-2", "skills:same", "1.1.0")],
+      ["skillVersions:other", makeSkillVersion("skillVersions:other", "skills:other", "1.0.0")],
+    ]);
+    const skills = new Map([
+      ["skills:same", makeSkill("skills:same", "same-root")],
+      ["skills:other", makeSkill("skills:other", "other-root")],
+    ]);
+    const owner = {
+      _id: "users:owner",
+      handle: "alice",
+      deletedAt: undefined,
+      deactivatedAt: undefined,
+    };
+    const runQuery = vi.fn(async (_ref, args) => {
+      if ("limit" in args) return jobs;
+      if (args.versionId) return versions.get(args.versionId) ?? null;
+      if (args.skillId) return skills.get(args.skillId) ?? null;
+      if (args.userId) return owner;
+      if ("staleAfterMs" in args) return { stale: 0, exhausted: 0 };
+      throw new Error(`unexpected query ${JSON.stringify(args)}`);
+    });
+    registryBackupMocks.fetchSkillVersionBackupMeta.mockResolvedValue(null);
+
+    const activeByRoot = new Map<string, number>();
+    let maxActiveTotal = 0;
+    let activeTotal = 0;
+    registryBackupMocks.backupSkillVersionToObjectStorage.mockImplementation(async (_ctx, item) => {
+      const root = `${item.ownerHandle}/${item.slug}`;
+      const active = activeByRoot.get(root) ?? 0;
+      if (active > 0) {
+        throw new Error(`same root overlapped: ${root}`);
+      }
+      activeByRoot.set(root, active + 1);
+      activeTotal += 1;
+      maxActiveTotal = Math.max(maxActiveTotal, activeTotal);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      activeTotal -= 1;
+      activeByRoot.set(root, active);
+    });
+
+    const result = await processRegistryArtifactBackupRetriesInternalHandler(
+      { runQuery, runMutation: vi.fn() } as never,
+      {},
+    );
+
+    expect(result.stats.retryJobsSucceeded).toBe(3);
+    expect(result.stats.retryJobsFailed).toBe(0);
+    expect(maxActiveTotal).toBeGreaterThan(1);
+  });
+
+  it("caps parallel full-artifact retry work by estimated bytes", async () => {
+    const jobs = [
+      makePackageBackupJob("one", "packageReleases:one"),
+      makePackageBackupJob("two", "packageReleases:two"),
+      makePackageBackupJob("three", "packageReleases:three"),
+    ];
+    const releases = new Map([
+      ["packageReleases:one", makePackageRelease("packageReleases:one", "packages:one")],
+      ["packageReleases:two", makePackageRelease("packageReleases:two", "packages:two")],
+      ["packageReleases:three", makePackageRelease("packageReleases:three", "packages:three")],
+    ]);
+    const packages = new Map([
+      ["packages:one", makePackage("packages:one", "@openclaw/one")],
+      ["packages:two", makePackage("packages:two", "@openclaw/two")],
+      ["packages:three", makePackage("packages:three", "@openclaw/three")],
+    ]);
+    const owner = {
+      _id: "users:owner",
+      handle: "alice",
+      deletedAt: undefined,
+      deactivatedAt: undefined,
+    };
+    const runQuery = vi.fn(async (_ref, args) => {
+      if ("limit" in args) return jobs;
+      if (args.releaseId) return releases.get(args.releaseId) ?? null;
+      if (args.packageId) return packages.get(args.packageId) ?? null;
+      if (args.userId) return owner;
+      if ("staleAfterMs" in args) return { stale: 0, exhausted: 0 };
+      throw new Error(`unexpected query ${JSON.stringify(args)}`);
+    });
+    registryBackupMocks.fetchPackageReleaseBackupMeta.mockResolvedValue(null);
+
+    let activeTotal = 0;
+    let maxActiveTotal = 0;
+    registryBackupMocks.backupPackageReleaseToObjectStorage.mockImplementation(async () => {
+      activeTotal += 1;
+      maxActiveTotal = Math.max(maxActiveTotal, activeTotal);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      activeTotal -= 1;
+    });
+
+    const result = await processRegistryArtifactBackupRetriesInternalHandler(
+      { runQuery, runMutation: vi.fn() } as never,
+      {},
+    );
+
+    expect(result.stats.retryJobsSucceeded).toBe(3);
+    expect(maxActiveTotal).toBe(1);
+  });
+
+  it("keeps retry source lookup failures isolated to their own jobs", async () => {
+    const jobs = [
+      makeSkillBackupJob("bad", "skillVersions:bad"),
+      makeSkillBackupJob("good", "skillVersions:good"),
+    ];
+    const goodVersion = makeSkillVersion("skillVersions:good", "skills:good", "1.0.0");
+    const goodSkill = makeSkill("skills:good", "good-root");
+    const owner = {
+      _id: "users:owner",
+      handle: "alice",
+      deletedAt: undefined,
+      deactivatedAt: undefined,
+    };
+    const runQuery = vi.fn(async (_ref, args) => {
+      if ("limit" in args) return jobs;
+      if (args.versionId === "skillVersions:bad") throw new Error("lookup failed");
+      if (args.versionId === "skillVersions:good") return goodVersion;
+      if (args.skillId === "skills:good") return goodSkill;
+      if (args.userId === "users:owner") return owner;
+      if ("staleAfterMs" in args) return { stale: 0, exhausted: 0 };
+      throw new Error(`unexpected query ${JSON.stringify(args)}`);
+    });
+    const runMutation = vi.fn();
+    registryBackupMocks.fetchSkillVersionBackupMeta.mockResolvedValue(null);
+
+    const result = await processRegistryArtifactBackupRetriesInternalHandler(
+      { runQuery, runMutation } as never,
+      {},
+    );
+
+    expect(result.stats.retryJobsProcessed).toBe(2);
+    expect(result.stats.retryJobsSucceeded).toBe(1);
+    expect(result.stats.retryJobsFailed).toBe(1);
+    expect(registryBackupMocks.backupSkillVersionToObjectStorage).toHaveBeenCalledOnce();
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        jobId: "registryArtifactBackupJobs:bad",
+        error: "lookup failed",
+      }),
+    );
+  });
+
   it("skips queued skill version retries after the skill is no longer public", async () => {
     const dueJob = {
       _id: "registryArtifactBackupJobs:hidden",
@@ -704,7 +1013,167 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
   });
 });
 
+function makeSkillBackupJob(suffix: string, skillVersionId: string) {
+  return {
+    _id: `registryArtifactBackupJobs:${suffix}`,
+    targetKind: "skillVersion",
+    skillVersionId,
+    status: "pending",
+    attempts: 0,
+    nextRunAt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function makeSkillVersion(id: string, skillId: string, version: string) {
+  return {
+    _id: id,
+    skillId,
+    version,
+    createdAt: 1,
+    files: [{ path: "SKILL.md", size: 5, storageId: `storage:${id}`, sha256: `sha:${id}` }],
+    softDeletedAt: undefined,
+  };
+}
+
+function makeSkill(id: string, slug: string) {
+  return {
+    _id: id,
+    ownerUserId: "users:owner",
+    ownerPublisherId: undefined,
+    slug,
+    displayName: slug,
+    latestVersionId: "skillVersions:latest",
+    softDeletedAt: undefined,
+    moderationStatus: "active",
+  };
+}
+
+function makePackageBackupJob(suffix: string, packageReleaseId: string) {
+  return {
+    _id: `registryArtifactBackupJobs:${suffix}`,
+    targetKind: "packageRelease",
+    packageReleaseId,
+    status: "pending",
+    attempts: 0,
+    nextRunAt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function makePackageRelease(id: string, packageId: string) {
+  return {
+    _id: id,
+    packageId,
+    version: "1.0.0",
+    createdAt: 1,
+    files: [],
+    clawpackStorageId: `storage:${id}`,
+    clawpackSha256: `sha:${id}`,
+    clawpackSize: 120 * 1024 * 1024,
+    clawpackFormat: "tgz",
+    softDeletedAt: undefined,
+  };
+}
+
+function makePackage(id: string, name: string) {
+  return {
+    _id: id,
+    ownerUserId: "users:owner",
+    ownerPublisherId: undefined,
+    name,
+    normalizedName: name,
+    displayName: name,
+    family: "code-plugin",
+    latestReleaseId: "packageReleases:latest",
+    softDeletedAt: undefined,
+  };
+}
+
 describe("registry artifact backup jobs", () => {
+  it("can include exhausted jobs that still have repair attempts left", async () => {
+    const now = 1_700_000_000_000;
+    const pendingJobs = [
+      {
+        _id: "registryArtifactBackupJobs:pending",
+        status: "pending",
+        attempts: 1,
+        nextRunAt: now - 1000,
+      },
+    ];
+    const exhaustedJobs = [
+      {
+        _id: "registryArtifactBackupJobs:maxed",
+        status: "exhausted",
+        attempts: 16,
+        nextRunAt: now - 1000,
+      },
+      {
+        _id: "registryArtifactBackupJobs:repairable",
+        status: "exhausted",
+        attempts: 8,
+        nextRunAt: now - 1000,
+      },
+    ];
+    let repairAttemptLimit = Number.POSITIVE_INFINITY;
+    const pendingTake = vi.fn((limit: number) => Promise.resolve(pendingJobs.slice(0, limit)));
+    const exhaustedTake = vi.fn((limit: number) =>
+      Promise.resolve(
+        exhaustedJobs.filter((job) => job.attempts < repairAttemptLimit).slice(0, limit),
+      ),
+    );
+    const withIndex = vi.fn(
+      (
+        indexName: string,
+        buildIndex:
+          | ((q: {
+              eq: (
+                field: string,
+                value: unknown,
+              ) => {
+                lt: (field: string, value: number) => unknown;
+                lte: (field: string, value: number) => unknown;
+              };
+            }) => unknown)
+          | undefined,
+      ) => {
+        buildIndex?.({
+          eq: () => ({
+            lt: (_field: string, value: number) => {
+              repairAttemptLimit = value;
+              return {};
+            },
+            lte: () => ({}),
+          }),
+        });
+        return { take: indexName === "by_status_attempts" ? exhaustedTake : pendingTake };
+      },
+    );
+    const ctx = {
+      db: {
+        query: vi.fn(() => ({ withIndex })),
+      },
+    };
+
+    const result = await dueJobsHandler(ctx as never, {
+      includeExhaustedRepair: true,
+      limit: 3,
+      maxRepairAttempts: 16,
+      now,
+    });
+
+    expect(result.map((job: { _id: string }) => job._id)).toEqual([
+      "registryArtifactBackupJobs:pending",
+      "registryArtifactBackupJobs:repairable",
+    ]);
+    expect(withIndex).toHaveBeenNthCalledWith(1, "by_status_nextRunAt", expect.any(Function));
+    expect(withIndex).toHaveBeenNthCalledWith(2, "by_status_attempts", expect.any(Function));
+    expect(pendingTake).toHaveBeenCalledWith(3);
+    expect(exhaustedTake).toHaveBeenCalledWith(2);
+  });
+
   it("upserts package release backup failures into a retryable backlog", async () => {
     const now = 1_700_000_000_000;
     const existing = {

--- a/convex/registryArtifactBackups.ts
+++ b/convex/registryArtifactBackups.ts
@@ -14,6 +14,9 @@ const PACKAGE_SYNC_STATE_KEY = "packageReleases";
 const MAX_BACKUP_JOB_ERROR_LENGTH = 4000;
 const DEFAULT_BACKUP_HEALTH_SAMPLE_LIMIT = 500;
 const MAX_BACKUP_HEALTH_SAMPLE_LIMIT = 1000;
+const DEFAULT_BACKUP_JOB_LIMIT = 25;
+const MAX_BACKUP_JOB_LIMIT = 200;
+const DEFAULT_BACKUP_JOB_REPAIR_ATTEMPTS = 16;
 
 type BackupPageItem =
   | {
@@ -407,16 +410,33 @@ export const markRegistryArtifactBackupJobFailedInternal = internalMutation({
 
 export const getDueRegistryArtifactBackupJobsInternal = internalQuery({
   args: {
+    includeExhaustedRepair: v.optional(v.boolean()),
+    maxRepairAttempts: v.optional(v.number()),
     now: v.optional(v.number()),
     limit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const now = args.now ?? Date.now();
-    const limit = clampInt(args.limit ?? 25, 1, 100);
-    return await ctx.db
+    const limit = clampInt(args.limit ?? DEFAULT_BACKUP_JOB_LIMIT, 1, MAX_BACKUP_JOB_LIMIT);
+    const pending = await ctx.db
       .query("registryArtifactBackupJobs")
       .withIndex("by_status_nextRunAt", (q) => q.eq("status", "pending").lte("nextRunAt", now))
       .take(limit);
+    if (!args.includeExhaustedRepair || pending.length >= limit) return pending;
+
+    const maxRepairAttempts = Math.max(
+      1,
+      Math.floor(args.maxRepairAttempts ?? DEFAULT_BACKUP_JOB_REPAIR_ATTEMPTS),
+    );
+    const remaining = limit - pending.length;
+    const exhausted = await ctx.db
+      .query("registryArtifactBackupJobs")
+      .withIndex("by_status_attempts", (q) =>
+        q.eq("status", "exhausted").lt("attempts", maxRepairAttempts),
+      )
+      .take(remaining);
+
+    return [...pending, ...exhausted];
   },
 });
 

--- a/convex/registryArtifactBackupsNode.ts
+++ b/convex/registryArtifactBackupsNode.ts
@@ -13,6 +13,8 @@ import {
   fetchSkillVersionBackupMeta,
   getRegistryArtifactBackupContext,
   isRegistryArtifactBackupConfigured,
+  repairPackageReleaseBackupIndex,
+  repairSkillVersionBackupIndex,
   type RegistryArtifactBackupContext,
 } from "./lib/registryArtifactBackup";
 
@@ -20,7 +22,12 @@ const DEFAULT_BATCH_SIZE = 50;
 const MAX_BATCH_SIZE = 200;
 const DEFAULT_MAX_BATCHES = 5;
 const MAX_MAX_BATCHES = 200;
-const DEFAULT_JOB_BATCH_SIZE = 25;
+const DEFAULT_JOB_BATCH_SIZE = 200;
+const MAX_RETRY_REPAIR_ATTEMPTS = 16;
+const MAX_PARALLEL_RETRY_ROOTS = 25;
+const UNKNOWN_PACKAGE_ARTIFACT_BYTES = 120 * 1024 * 1024;
+const UNKNOWN_SKILL_ARTIFACT_BYTES = 50 * 1024 * 1024;
+const MAX_PARALLEL_RETRY_ARTIFACT_BYTES = UNKNOWN_PACKAGE_ARTIFACT_BYTES;
 const STALE_BACKUP_JOB_MS = 24 * 60 * 60 * 1000;
 
 type BackupPageItem =
@@ -462,38 +469,228 @@ async function processDueRegistryArtifactBackupJobs(
   const jobs = (await ctx.runQuery(
     internal.registryArtifactBackups.getDueRegistryArtifactBackupJobsInternal,
     {
+      includeExhaustedRepair: true,
       limit: DEFAULT_JOB_BATCH_SIZE,
+      maxRepairAttempts: MAX_RETRY_REPAIR_ATTEMPTS,
     },
   )) as Array<Doc<"registryArtifactBackupJobs">>;
 
+  const groups = await groupRetryJobsByRoot(ctx, jobs);
+  const chunks = chunkRetryJobGroups(groups);
+  for (const chunk of chunks) {
+    const results = await Promise.all(
+      chunk.map((group) => processRetryJobGroup(ctx, context, group)),
+    );
+    for (const result of results) {
+      stats.retryJobsProcessed += result.processed;
+      stats.retryJobsSucceeded += result.succeeded;
+      stats.retryJobsFailed += result.failed;
+    }
+  }
+}
+
+type RetryJobWorkItem =
+  | {
+      error: unknown;
+      kind: "lookupFailed";
+      job: Doc<"registryArtifactBackupJobs">;
+    }
+  | {
+      kind: "missing";
+      job: Doc<"registryArtifactBackupJobs">;
+    }
+  | {
+      kind: "packageRelease";
+      job: Doc<"registryArtifactBackupJobs">;
+      item: Extract<PackageBackupPageItem, { kind: "ok" }>;
+      rootKey: string;
+      estimatedBytes: number;
+    }
+  | {
+      kind: "skillVersion";
+      job: Doc<"registryArtifactBackupJobs">;
+      item: Parameters<typeof backupSkillVersionToObjectStorage>[1];
+      rootKey: string;
+      estimatedBytes: number;
+    };
+
+type RetryJobGroup = {
+  estimatedBytes: number;
+  items: RetryJobWorkItem[];
+};
+
+async function groupRetryJobsByRoot(
+  ctx: ActionCtx,
+  jobs: Array<Doc<"registryArtifactBackupJobs">>,
+) {
+  const groups = new Map<string, RetryJobGroup>();
   for (const job of jobs) {
-    stats.retryJobsProcessed += 1;
+    const workItem = await toRetryJobWorkItem(ctx, job).catch((error: unknown) => ({
+      error,
+      kind: "lookupFailed" as const,
+      job,
+    }));
+    const rootKey =
+      workItem.kind === "missing" || workItem.kind === "lookupFailed"
+        ? `${workItem.kind}:${job._id}`
+        : workItem.rootKey;
+    const group = groups.get(rootKey);
+    const estimatedBytes = estimatedRetryJobBytes(workItem);
+    if (group) {
+      group.items.push(workItem);
+      group.estimatedBytes = Math.max(group.estimatedBytes, estimatedBytes);
+    } else {
+      groups.set(rootKey, { estimatedBytes, items: [workItem] });
+    }
+  }
+  return Array.from(groups.values());
+}
+
+async function toRetryJobWorkItem(
+  ctx: ActionCtx,
+  job: Doc<"registryArtifactBackupJobs">,
+): Promise<RetryJobWorkItem> {
+  if (job.targetKind === "packageRelease" && job.packageReleaseId) {
+    const item = await getPackageBackupItemForRelease(ctx, job.packageReleaseId);
+    if (!item) return { kind: "missing", job };
+    return {
+      estimatedBytes: item.artifactSize ?? UNKNOWN_PACKAGE_ARTIFACT_BYTES,
+      kind: "packageRelease",
+      job,
+      item,
+      rootKey: `package:${item.ownerHandle}/${item.normalizedName}`,
+    };
+  }
+  if (job.targetKind === "skillVersion" && job.skillVersionId) {
+    const item = await getSkillBackupItemForVersion(ctx, job.skillVersionId);
+    if (!item) return { kind: "missing", job };
+    return {
+      estimatedBytes: estimateSkillBackupBytes(item),
+      kind: "skillVersion",
+      job,
+      item,
+      rootKey: `skill:${item.ownerHandle}/${item.slug}`,
+    };
+  }
+  return { kind: "missing", job };
+}
+
+async function processRetryJobGroup(
+  ctx: ActionCtx,
+  context: RegistryArtifactBackupContext,
+  group: RetryJobGroup,
+) {
+  const result = { processed: 0, succeeded: 0, failed: 0 };
+  for (const workItem of group.items) {
+    result.processed += 1;
     try {
-      if (job.targetKind === "packageRelease" && job.packageReleaseId) {
-        const item = await getPackageBackupItemForRelease(ctx, job.packageReleaseId);
-        if (item) await backupPackageReleaseToObjectStorage(ctx, item, context);
-      } else if (job.targetKind === "skillVersion" && job.skillVersionId) {
-        const item = await getSkillBackupItemForVersion(ctx, job.skillVersionId);
-        if (item) await backupSkillVersionToObjectStorage(ctx, item, context);
+      if (workItem.kind === "lookupFailed") {
+        throw workItem.error;
+      } else if (workItem.kind === "missing") {
+        await markRetryJobSucceeded(ctx, workItem.job);
+      } else if (workItem.kind === "packageRelease") {
+        if (await hasMatchingPackageReleaseMeta(context, workItem.item)) {
+          await repairPackageReleaseBackupIndex(ctx, workItem.item, context);
+        } else {
+          await backupPackageReleaseToObjectStorage(ctx, workItem.item, context);
+        }
+        await markRetryJobSucceeded(ctx, workItem.job);
+      } else {
+        if (await hasMatchingSkillVersionMeta(context, workItem.item)) {
+          await repairSkillVersionBackupIndex(ctx, workItem.item, context);
+        } else {
+          await backupSkillVersionToObjectStorage(ctx, workItem.item, context);
+        }
+        await markRetryJobSucceeded(ctx, workItem.job);
       }
-      await ctx.runMutation(
-        internal.registryArtifactBackups.markRegistryArtifactBackupJobSucceededInternal,
-        {
-          jobId: job._id,
-        },
-      );
-      stats.retryJobsSucceeded += 1;
+      result.succeeded += 1;
     } catch (error) {
-      stats.retryJobsFailed += 1;
+      result.failed += 1;
       await ctx.runMutation(
         internal.registryArtifactBackups.markRegistryArtifactBackupJobFailedInternal,
         {
-          jobId: job._id,
+          jobId: workItem.job._id,
           error: errorMessage(error),
+          maxAttempts: MAX_RETRY_REPAIR_ATTEMPTS,
         },
       );
     }
   }
+  return result;
+}
+
+async function markRetryJobSucceeded(ctx: ActionCtx, job: Doc<"registryArtifactBackupJobs">) {
+  await ctx.runMutation(
+    internal.registryArtifactBackups.markRegistryArtifactBackupJobSucceededInternal,
+    {
+      jobId: job._id,
+    },
+  );
+}
+
+async function hasMatchingSkillVersionMeta(
+  context: RegistryArtifactBackupContext,
+  item: Parameters<typeof backupSkillVersionToObjectStorage>[1],
+) {
+  const meta = await fetchSkillVersionBackupMeta(
+    context,
+    item.ownerHandle,
+    item.slug,
+    item.version,
+  );
+  return meta?.version === item.version && meta.restore.versionId === item.versionId;
+}
+
+async function hasMatchingPackageReleaseMeta(
+  context: RegistryArtifactBackupContext,
+  item: Extract<PackageBackupPageItem, { kind: "ok" }>,
+) {
+  const meta = await fetchPackageReleaseBackupMeta(
+    context,
+    item.ownerHandle,
+    item.normalizedName,
+    item.version,
+  );
+  return (
+    meta?.restore?.releaseId === item.releaseId && meta.artifact.sha256 === item.artifactSha256
+  );
+}
+
+function estimatedRetryJobBytes(workItem: RetryJobWorkItem) {
+  if (workItem.kind === "packageRelease" || workItem.kind === "skillVersion") {
+    return workItem.estimatedBytes;
+  }
+  return 0;
+}
+
+function estimateSkillBackupBytes(item: Parameters<typeof backupSkillVersionToObjectStorage>[1]) {
+  const total = item.files.reduce((sum, file) => sum + file.size, 0);
+  return total || UNKNOWN_SKILL_ARTIFACT_BYTES;
+}
+
+function chunkRetryJobGroups(groups: RetryJobGroup[]) {
+  const chunks: RetryJobGroup[][] = [];
+  let current: RetryJobGroup[] = [];
+  let currentBytes = 0;
+
+  for (const group of groups) {
+    const groupBytes = group.estimatedBytes;
+    const wouldExceedRootLimit = current.length >= MAX_PARALLEL_RETRY_ROOTS;
+    const wouldExceedByteLimit =
+      current.length > 0 && currentBytes + groupBytes > MAX_PARALLEL_RETRY_ARTIFACT_BYTES;
+    if (wouldExceedRootLimit || wouldExceedByteLimit) {
+      chunks.push(current);
+      current = [];
+      currentBytes = 0;
+    }
+    current.push(group);
+    currentBytes += groupBytes;
+  }
+
+  if (current.length > 0) {
+    chunks.push(current);
+  }
+  return chunks;
 }
 
 async function getPackageBackupItemForRelease(

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2439,6 +2439,7 @@ const registryArtifactBackupJobs = defineTable({
   updatedAt: v.number(),
 })
   .index("by_status_nextRunAt", ["status", "nextRunAt"])
+  .index("by_status_attempts", ["status", "attempts"])
   .index("by_skill_version", ["skillVersionId"])
   .index("by_package_release", ["packageReleaseId"])
   .index("by_updatedAt", ["updatedAt"]);


### PR DESCRIPTION
## Summary
- Increase registry artifact retry cron cadence to every 5 minutes and drain up to 200 jobs per pass.
- Include repairable exhausted jobs, repair existing R2 indexes without reuploading already-backed-up artifacts, and retry index writes with bounded backoff.
- Process retry roots in parallel while keeping the same skill/package root sequential and capping full-artifact concurrency so max-size package uploads run one at a time.
- Add an indexed exhausted-job repair query so maxed-out exhausted rows cannot starve still-repairable jobs.

## Validation
- `PATH="$HOME/.bun/bin:$PATH" bunx vitest run convex/registryArtifactBackups.test.ts convex/lib/registryArtifactBackup.test.ts convex/crons.test.ts`
- `PATH="$HOME/.bun/bin:$PATH" bun run ci:static`
- `PATH="$HOME/.bun/bin:$PATH" VITE_CONVEX_URL=https://example.invalid bun run ci:unit`
- `PATH="$HOME/.bun/bin:$PATH" bun run ci:types-build`
- `git diff --check`
- `PATH="$HOME/.bun/bin:$PATH" bunx convex codegen`

## Review Notes
- Autoreview found and we fixed exhausted-job starvation and full-artifact memory budget issues.
- A final autoreview rerun recursed into another autoreview process instead of producing a clean verdict, so it was stopped after the accepted findings were addressed and the full local gates passed.
