### PR TITLE
docs: add org namespace claim form

### DIFF
--- a/.github/ISSUE_TEMPLATE/org-namespace-claim.yml
+++ b/.github/ISSUE_TEMPLATE/org-namespace-claim.yml
@@ -1,0 +1,117 @@
+name: Org / Namespace Claim
+description: Request review for an org, brand, package scope, or namespace ownership dispute.
+title: "Org claim: "
+labels:
+  - "area: moderation"
+  - "area: security"
+  - "status: review"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form when you believe a ClawHub org, owner handle, package scope, skill slug, plugin package, or related namespace should be reserved, transferred, renamed, hidden, quarantined, aliased, or reviewed because of real-world project, brand, or organizational ownership.
+
+        Public GitHub issues must not include secrets, private documents, private legal files, personal identity documents, API tokens, DNS control tokens, or other sensitive material. Share public, non-sensitive proof here and tell us below if staff needs to arrange a private channel for sensitive evidence.
+
+        This is not the ban/account appeal flow. If your ClawHub account was banned, disabled, or cannot sign in because of account standing, use the ClawHub appeal form instead: https://appeals.openclaw.ai/
+
+        Related policy discussion: https://github.com/openclaw/clawhub/issues/2320
+  - type: input
+    id: claimed_namespace
+    attributes:
+      label: Claimed owner, org, scope, or namespace
+      description: Which ClawHub owner handle, org handle, package scope, skill slug, or package namespace are you claiming?
+      placeholder: "@example-org, example-org, @example-org/example-plugin, or example-skill"
+    validations:
+      required: true
+  - type: textarea
+    id: disputed_resources
+    attributes:
+      label: Disputed ClawHub resources
+      description: Link every relevant ClawHub URL, package name, skill slug, owner page, or related GitHub issue.
+      placeholder: |
+        - https://clawhub.ai/example-org/example-skill
+        - https://clawhub.ai/plugins/@example-org/example-plugin
+        - Package or skill names involved:
+    validations:
+      required: true
+  - type: textarea
+    id: claimant_relationship
+    attributes:
+      label: Claimant identity and relationship
+      description: Explain who is making the request and how they are connected to the org, project, package, or brand. Keep it public-safe.
+      placeholder: |
+        I maintain the upstream project at...
+        I am an admin/owner/member of...
+        Public profile or docs showing that relationship:
+    validations:
+      required: true
+  - type: dropdown
+    id: requested_outcome
+    attributes:
+      label: Requested outcome
+      description: Pick every outcome that would resolve the claim.
+      multiple: true
+      options:
+        - Reserve namespace or package
+        - Transfer ownership
+        - Rename existing resource
+        - Hide or quarantine current resource
+        - Add alias or redirect
+        - Review only / need staff guidance
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: public_proof
+    attributes:
+      label: Public proof links and explanation
+      description: Add public links and explain what each proves. Useful proof includes GitHub org/repo control, domain or official email-domain proof, package-registry scope control, trademark or brand evidence, source repo history, package history, and public project docs. Do not paste secrets, tokens, private documents, or private legal files.
+      placeholder: |
+        - https://github.com/example-org/example-project proves...
+        - https://example.org/docs/clawhub proves...
+        - https://www.npmjs.com/org/example-org proves...
+    validations:
+      required: true
+  - type: textarea
+    id: current_owner_context
+    attributes:
+      label: Current owner, history, or context
+      description: Share what you know about the current ClawHub owner, prior transfers, project rename history, or attempted contact.
+      placeholder: |
+        The current listing appears to be owned by...
+        We contacted...
+        The project was renamed from...
+  - type: textarea
+    id: urgency_context
+    attributes:
+      label: User harm or urgency
+      description: Explain impact, affected users, install paths, or other facts that should affect triage priority. Say "No urgent user harm known" if this is not urgent.
+      placeholder: |
+        Users are being directed from...
+        The package is referenced by...
+        We believe this is urgent because...
+    validations:
+      required: true
+  - type: textarea
+    id: sensitive_evidence
+    attributes:
+      label: Sensitive evidence or private staff channel
+      description: Say whether public evidence is enough or whether staff needs to arrange a private channel. Summarize the kind of private evidence without including the sensitive material itself.
+      placeholder: |
+        Public evidence is enough.
+
+        Or:
+
+        We need a private staff channel for DNS challenge proof, private legal documents, or other sensitive evidence.
+    validations:
+      required: true
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Acknowledgements
+      options:
+        - label: I have not included secrets, API tokens, private documents, private legal files, personal identity documents, or other sensitive material in this public issue.
+          required: true
+        - label: I understand this public issue may be linked from ClawHub moderation or namespace policy discussions.
+          required: true

--- a/docs/moderation.md
+++ b/docs/moderation.md
@@ -53,6 +53,24 @@ advisories for vulnerabilities in third-party skills or plugins.
 Good reports are specific and actionable. Abuse of reporting can itself lead to
 account action.
 
+## Org and namespace claims
+
+Org, brand, package-scope, owner-handle, or namespace ownership disputes should
+use the
+[Org / Namespace Claim issue form](https://github.com/openclaw/clawhub/issues/new?template=org-namespace-claim.yml),
+not the in-product report flow or the account appeal form.
+
+Use that form when you need ClawHub staff to review non-sensitive proof that a
+namespace should be reserved, transferred, renamed, hidden, quarantined, aliased,
+or otherwise reviewed. Useful public evidence includes GitHub org or repo
+control, domain or official email-domain proof, package-registry scope control,
+trademark or brand evidence, source repo history, package history, and public
+project docs.
+
+Do not include secrets, private documents, private legal files, personal identity
+documents, API tokens, or DNS challenge tokens in a public issue. The issue form
+asks whether sensitive evidence needs a private staff channel.
+
 ## Moderation holds
 
 Some severe findings or policy issues can place a publisher or listing under a

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -68,6 +68,12 @@ The scope must match the selected publish owner. If your package is named
 This prevents a package from claiming an org namespace that the publisher does
 not control.
 
+If you are the rightful owner of an org, brand, package scope, owner handle, or
+namespace that is already claimed or reserved on ClawHub, open an
+[Org / Namespace Claim issue](https://github.com/openclaw/clawhub/issues/new?template=org-namespace-claim.yml)
+with public, non-sensitive proof. Do not use the account appeal form for
+namespace claims.
+
 ### Before Publishing a Plugin
 
 - Pick an owner that matches the package scope.
@@ -150,6 +156,11 @@ clawhub package transfer @opik/opik-openclaw --to opik
 Use package or skill transfer only when you have admin access to both the
 current owner and the destination publisher. Package transfer does not let you
 publish into a scope you cannot manage.
+
+If you do not have access to the current owner but believe your org, project, or
+brand is the rightful namespace owner, open an
+[Org / Namespace Claim issue](https://github.com/openclaw/clawhub/issues/new?template=org-namespace-claim.yml)
+with public, non-sensitive proof for staff review.
 
 This protects org namespaces. A package named `@openclaw/dronzer` claims the
 `@openclaw` namespace, so only publishers with access to the `@openclaw` owner

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -87,6 +87,36 @@ publishers.
 - Check that the source URL is public or accessible to ClawHub.
 - For GitHub sources, use `owner/repo`, `owner/repo@ref`, or a full GitHub URL.
 
+## Publish fails because a namespace is claimed or reserved
+
+If a publish fails because the owner handle, org namespace, package scope, skill
+slug, or package name is already claimed or reserved, first confirm that you are
+publishing with the owner that matches the namespace. For plugin packages,
+scoped names such as `@example-org/example-plugin` must be published as the
+matching `example-org` owner.
+
+If you believe your org, project, or brand is the rightful namespace owner but
+you cannot manage the current ClawHub owner, open an
+[Org / Namespace Claim issue](https://github.com/openclaw/clawhub/issues/new?template=org-namespace-claim.yml)
+with public, non-sensitive proof. Do not include secrets, private documents,
+DNS challenge tokens, or private legal files in the public issue.
+
+## `sync` says no skills were found
+
+`sync` looks for folders containing `SKILL.md` or `skill.md`.
+
+Point it at the roots you want to scan:
+
+```bash
+clawhub sync --root /path/to/skills
+```
+
+Preview first if you are unsure what will publish:
+
+```bash
+clawhub sync --all --dry-run --no-input
+```
+
 ## `update` refuses because of local changes
 
 The local files do not match any version ClawHub knows about. Choose one:


### PR DESCRIPTION
## Summary

- Add an `Org / Namespace Claim` GitHub issue form for public org, brand, owner-handle, package-scope, skill-slug, and namespace disputes.
- Point moderation, publishing, and troubleshooting docs to the new form while keeping ban/account recovery on `appeals.openclaw.ai`.
- Keep public claim intake limited to non-sensitive proof, with private-channel handoff requested only by summary.

## Proof / validation

- `ruby -e 'require "yaml"; d=YAML.load_file(".github/ISSUE_TEMPLATE/org-namespace-claim.yml"); abort("expected <= 10 body elements, got #{d["body"].length}") if d["body"].length > 10; puts "issue form yaml ok: #{d["body"].length} body elements"'`
  - Result: `issue form yaml ok: 10 body elements`
- `bunx --bun ajv-cli validate -s /tmp/github-issue-forms.schema.json -d .github/ISSUE_TEMPLATE/org-namespace-claim.yml`
  - Result: `.github/ISSUE_TEMPLATE/org-namespace-claim.yml valid`
- `git diff --check origin/main..HEAD`
  - Result: passed
- `bun run ci:static`
  - Result: passed

## Review notes

- Docs/template-only change; `ci:unit` not run because no source/test behavior changed.
- Codex autoreview flagged an earlier 13-element issue form as too large; the final form was consolidated to 10 body elements and revalidated.
