### PR TITLE
fix: skip indexed registry backup retries

### DIFF
--- a/convex/lib/registryArtifactBackup.ts
+++ b/convex/lib/registryArtifactBackup.ts
@@ -275,6 +275,18 @@ export async function fetchSkillBackupIndex(
   return getJsonObject<SkillIndexFile>(context, path);
 }
 
+export async function fetchPackageBackupIndex(
+  context: RegistryArtifactBackupContext,
+  ownerHandle: string,
+  normalizedName: string,
+) {
+  const owner = normalizeOwner(ownerHandle);
+  const path = `${context.packagesRoot}/${owner}/${encodeBackupPathSegment(
+    normalizedName,
+  )}/${INDEX_FILENAME}`;
+  return getJsonObject<PackageIndexFile>(context, path);
+}
+
 export async function fetchPackageReleaseBackupMeta(
   context: RegistryArtifactBackupContext,
   ownerHandle: string,

--- a/convex/registryArtifactBackups.test.ts
+++ b/convex/registryArtifactBackups.test.ts
@@ -17,7 +17,9 @@ import {
 const registryBackupMocks = vi.hoisted(() => ({
   backupPackageReleaseToObjectStorage: vi.fn(),
   backupSkillVersionToObjectStorage: vi.fn(),
+  fetchPackageBackupIndex: vi.fn(),
   fetchPackageReleaseBackupMeta: vi.fn(),
+  fetchSkillBackupIndex: vi.fn(),
   fetchSkillVersionBackupMeta: vi.fn(),
   getRegistryArtifactBackupContext: vi.fn(),
   isRegistryArtifactBackupConfigured: vi.fn(),
@@ -825,7 +827,10 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
       ["skillVersions:demo-1", makeSkillVersion("skillVersions:demo-1", "skills:demo", "1.0.0")],
       ["skillVersions:demo-2", makeSkillVersion("skillVersions:demo-2", "skills:demo", "1.1.0")],
     ]);
-    const skill = makeSkill("skills:demo", "demo-skill");
+    const skill = {
+      ...makeSkill("skills:demo", "demo-skill"),
+      latestVersionId: "skillVersions:demo-2",
+    };
     const owner = {
       _id: "users:owner",
       handle: "alice",
@@ -939,6 +944,288 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
         }),
       ],
       expect.anything(),
+    );
+  });
+
+  it("marks skill index retries succeeded when the version is already indexed", async () => {
+    const jobs = [
+      makeSkillBackupJob("demo-1", "skillVersions:demo-1"),
+      makeSkillBackupJob("demo-2", "skillVersions:demo-2"),
+    ];
+    const versions = new Map([
+      ["skillVersions:demo-1", makeSkillVersion("skillVersions:demo-1", "skills:demo", "1.0.0")],
+      ["skillVersions:demo-2", makeSkillVersion("skillVersions:demo-2", "skills:demo", "1.1.0")],
+    ]);
+    const skill = {
+      ...makeSkill("skills:demo", "demo-skill"),
+      latestVersionId: "skillVersions:demo-2",
+    };
+    const owner = {
+      _id: "users:owner",
+      handle: "alice",
+      deletedAt: undefined,
+      deactivatedAt: undefined,
+    };
+    const runQuery = vi.fn(async (_ref, args) => {
+      if ("limit" in args) return jobs;
+      if (args.versionId) return versions.get(args.versionId) ?? null;
+      if (args.skillId === "skills:demo") return skill;
+      if (args.userId === "users:owner") return owner;
+      if ("staleAfterMs" in args) return { stale: 0, exhausted: 0 };
+      throw new Error(`unexpected query ${JSON.stringify(args)}`);
+    });
+    const versionIdsByVersion = new Map([
+      ["1.0.0", "skillVersions:demo-1"],
+      ["1.1.0", "skillVersions:demo-2"],
+    ]);
+    registryBackupMocks.fetchSkillVersionBackupMeta.mockImplementation(
+      async (_context, _ownerHandle, _slug, version) => ({
+        version,
+        restore: { versionId: versionIdsByVersion.get(version) },
+      }),
+    );
+    registryBackupMocks.fetchSkillBackupIndex.mockResolvedValueOnce({
+      latest: { version: "1.1.0", versionId: "skillVersions:demo-2", isLatest: true },
+      versions: [
+        { version: "1.0.0", versionId: "skillVersions:demo-1", isLatest: false },
+        { version: "1.1.0", versionId: "skillVersions:demo-2", isLatest: true },
+      ],
+    });
+
+    const result = await processRegistryArtifactBackupRetriesInternalHandler(
+      { runQuery, runMutation: vi.fn() } as never,
+      {},
+    );
+
+    expect(result.stats.retryJobsSucceeded).toBe(2);
+    expect(result.stats.retryJobsFailed).toBe(0);
+    expect(registryBackupMocks.repairSkillVersionBackupIndexes).not.toHaveBeenCalled();
+  });
+
+  it("repairs skill index retries when the indexed version has stale latest state", async () => {
+    const jobs = [makeSkillBackupJob("demo", "skillVersions:demo")];
+    const skill = {
+      ...makeSkill("skills:demo", "demo-skill"),
+      latestVersionId: "skillVersions:demo",
+    };
+    const owner = {
+      _id: "users:owner",
+      handle: "alice",
+      deletedAt: undefined,
+      deactivatedAt: undefined,
+    };
+    const runQuery = vi.fn(async (_ref, args) => {
+      if ("limit" in args) return jobs;
+      if (args.versionId) return makeSkillVersion("skillVersions:demo", "skills:demo", "1.0.0");
+      if (args.skillId === "skills:demo") return skill;
+      if (args.userId === "users:owner") return owner;
+      if ("staleAfterMs" in args) return { stale: 0, exhausted: 0 };
+      throw new Error(`unexpected query ${JSON.stringify(args)}`);
+    });
+    registryBackupMocks.fetchSkillVersionBackupMeta.mockResolvedValue({
+      version: "1.0.0",
+      restore: { versionId: "skillVersions:demo" },
+    });
+    registryBackupMocks.fetchSkillBackupIndex.mockResolvedValueOnce({
+      latest: { version: "0.9.0", versionId: "skillVersions:old", isLatest: true },
+      versions: [{ version: "1.0.0", versionId: "skillVersions:demo", isLatest: false }],
+    });
+
+    const result = await processRegistryArtifactBackupRetriesInternalHandler(
+      { runQuery, runMutation: vi.fn() } as never,
+      {},
+    );
+
+    expect(result.stats.retryJobsSucceeded).toBe(1);
+    expect(result.stats.retryJobsFailed).toBe(0);
+    expect(registryBackupMocks.repairSkillVersionBackupIndexes).toHaveBeenCalledOnce();
+  });
+
+  it("keeps indexed skill success marker failures isolated", async () => {
+    const jobs = [makeSkillBackupJob("demo", "skillVersions:demo")];
+    const skill = {
+      ...makeSkill("skills:demo", "demo-skill"),
+      latestVersionId: "skillVersions:demo",
+    };
+    const owner = {
+      _id: "users:owner",
+      handle: "alice",
+      deletedAt: undefined,
+      deactivatedAt: undefined,
+    };
+    const runQuery = vi.fn(async (_ref, args) => {
+      if ("limit" in args) return jobs;
+      if (args.versionId) return makeSkillVersion("skillVersions:demo", "skills:demo", "1.0.0");
+      if (args.skillId === "skills:demo") return skill;
+      if (args.userId === "users:owner") return owner;
+      if ("staleAfterMs" in args) return { stale: 0, exhausted: 0 };
+      throw new Error(`unexpected query ${JSON.stringify(args)}`);
+    });
+    const runMutation = vi.fn().mockRejectedValueOnce(new Error("status patch failed"));
+    registryBackupMocks.fetchSkillVersionBackupMeta.mockResolvedValue({
+      version: "1.0.0",
+      restore: { versionId: "skillVersions:demo" },
+    });
+    registryBackupMocks.fetchSkillBackupIndex.mockResolvedValueOnce({
+      latest: { version: "1.0.0", versionId: "skillVersions:demo", isLatest: true },
+      versions: [{ version: "1.0.0", versionId: "skillVersions:demo", isLatest: true }],
+    });
+
+    const result = await processRegistryArtifactBackupRetriesInternalHandler(
+      { runQuery, runMutation } as never,
+      {},
+    );
+
+    expect(result.stats.retryJobsSucceeded).toBe(0);
+    expect(result.stats.retryJobsFailed).toBe(1);
+    expect(registryBackupMocks.repairSkillVersionBackupIndexes).not.toHaveBeenCalled();
+    expect(runMutation).toHaveBeenCalledTimes(2);
+  });
+
+  it("marks package index retries succeeded when the release is already indexed", async () => {
+    const jobs = [
+      makePackageBackupJob("demo-1", "packageReleases:demo-1"),
+      makePackageBackupJob("demo-2", "packageReleases:demo-2"),
+    ];
+    const releases = new Map([
+      [
+        "packageReleases:demo-1",
+        makePackageRelease("packageReleases:demo-1", "packages:demo", "1.0.0"),
+      ],
+      [
+        "packageReleases:demo-2",
+        makePackageRelease("packageReleases:demo-2", "packages:demo", "1.1.0"),
+      ],
+    ]);
+    const pkg = {
+      ...makePackage("packages:demo", "@openclaw/demo"),
+      latestReleaseId: "packageReleases:demo-2",
+    };
+    const owner = {
+      _id: "users:owner",
+      handle: "alice",
+      deletedAt: undefined,
+      deactivatedAt: undefined,
+    };
+    const runQuery = vi.fn(async (_ref, args) => {
+      if ("limit" in args) return jobs;
+      if (args.releaseId) return releases.get(args.releaseId) ?? null;
+      if (args.packageId === "packages:demo") return pkg;
+      if (args.userId === "users:owner") return owner;
+      if ("staleAfterMs" in args) return { stale: 0, exhausted: 0 };
+      throw new Error(`unexpected query ${JSON.stringify(args)}`);
+    });
+    const releaseIdsByVersion = new Map([
+      ["1.0.0", "packageReleases:demo-1"],
+      ["1.1.0", "packageReleases:demo-2"],
+    ]);
+    const shaByVersion = new Map([
+      ["1.0.0", "sha:packageReleases:demo-1"],
+      ["1.1.0", "sha:packageReleases:demo-2"],
+    ]);
+    registryBackupMocks.fetchPackageReleaseBackupMeta.mockImplementation(
+      async (_context, _ownerHandle, _normalizedName, version) => ({
+        restore: { releaseId: releaseIdsByVersion.get(version) },
+        artifact: { sha256: shaByVersion.get(version) },
+      }),
+    );
+    registryBackupMocks.fetchPackageBackupIndex.mockResolvedValueOnce({
+      latest: { version: "1.1.0", releaseId: "packageReleases:demo-2", isLatest: true },
+      versions: [
+        { version: "1.0.0", releaseId: "packageReleases:demo-1", isLatest: false },
+        { version: "1.1.0", releaseId: "packageReleases:demo-2", isLatest: true },
+      ],
+    });
+
+    const result = await processRegistryArtifactBackupRetriesInternalHandler(
+      { runQuery, runMutation: vi.fn() } as never,
+      {},
+    );
+
+    expect(result.stats.retryJobsSucceeded).toBe(2);
+    expect(result.stats.retryJobsFailed).toBe(0);
+    expect(registryBackupMocks.repairPackageReleaseBackupIndexes).not.toHaveBeenCalled();
+  });
+
+  it("marks skill index retries failed when the index lookup fails", async () => {
+    const jobs = [makeSkillBackupJob("demo", "skillVersions:demo")];
+    const skill = makeSkill("skills:demo", "demo-skill");
+    const owner = {
+      _id: "users:owner",
+      handle: "alice",
+      deletedAt: undefined,
+      deactivatedAt: undefined,
+    };
+    const runQuery = vi.fn(async (_ref, args) => {
+      if ("limit" in args) return jobs;
+      if (args.versionId) return makeSkillVersion("skillVersions:demo", "skills:demo", "1.0.0");
+      if (args.skillId === "skills:demo") return skill;
+      if (args.userId === "users:owner") return owner;
+      if ("staleAfterMs" in args) return { stale: 0, exhausted: 0 };
+      throw new Error(`unexpected query ${JSON.stringify(args)}`);
+    });
+    const runMutation = vi.fn();
+    registryBackupMocks.fetchSkillVersionBackupMeta.mockResolvedValue({
+      version: "1.0.0",
+      restore: { versionId: "skillVersions:demo" },
+    });
+    registryBackupMocks.fetchSkillBackupIndex.mockRejectedValueOnce(new Error("R2 index read"));
+
+    const result = await processRegistryArtifactBackupRetriesInternalHandler(
+      { runQuery, runMutation } as never,
+      {},
+    );
+
+    expect(result.stats.retryJobsSucceeded).toBe(0);
+    expect(result.stats.retryJobsFailed).toBe(1);
+    expect(registryBackupMocks.repairSkillVersionBackupIndexes).not.toHaveBeenCalled();
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        jobId: "registryArtifactBackupJobs:demo",
+        error: "R2 index read",
+      }),
+    );
+  });
+
+  it("marks package index retries failed when the index lookup fails", async () => {
+    const jobs = [makePackageBackupJob("demo", "packageReleases:demo")];
+    const pkg = makePackage("packages:demo", "@openclaw/demo");
+    const owner = {
+      _id: "users:owner",
+      handle: "alice",
+      deletedAt: undefined,
+      deactivatedAt: undefined,
+    };
+    const runQuery = vi.fn(async (_ref, args) => {
+      if ("limit" in args) return jobs;
+      if (args.releaseId) return makePackageRelease("packageReleases:demo", "packages:demo");
+      if (args.packageId === "packages:demo") return pkg;
+      if (args.userId === "users:owner") return owner;
+      if ("staleAfterMs" in args) return { stale: 0, exhausted: 0 };
+      throw new Error(`unexpected query ${JSON.stringify(args)}`);
+    });
+    const runMutation = vi.fn();
+    registryBackupMocks.fetchPackageReleaseBackupMeta.mockResolvedValue({
+      restore: { releaseId: "packageReleases:demo" },
+      artifact: { sha256: "sha:packageReleases:demo" },
+    });
+    registryBackupMocks.fetchPackageBackupIndex.mockRejectedValueOnce(new Error("R2 index read"));
+
+    const result = await processRegistryArtifactBackupRetriesInternalHandler(
+      { runQuery, runMutation } as never,
+      {},
+    );
+
+    expect(result.stats.retryJobsSucceeded).toBe(0);
+    expect(result.stats.retryJobsFailed).toBe(1);
+    expect(registryBackupMocks.repairPackageReleaseBackupIndexes).not.toHaveBeenCalled();
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        jobId: "registryArtifactBackupJobs:demo",
+        error: "R2 index read",
+      }),
     );
   });
 

--- a/convex/registryArtifactBackupsNode.ts
+++ b/convex/registryArtifactBackupsNode.ts
@@ -9,7 +9,9 @@ import { isPublicSkillDoc } from "./lib/globalStats";
 import {
   backupPackageReleaseToObjectStorage,
   backupSkillVersionToObjectStorage,
+  fetchPackageBackupIndex,
   fetchPackageReleaseBackupMeta,
+  fetchSkillBackupIndex,
   fetchSkillVersionBackupMeta,
   getRegistryArtifactBackupContext,
   isRegistryArtifactBackupConfigured,
@@ -636,19 +638,35 @@ async function flushPackageIndexRepairs(
   result: { succeeded: number; failed: number },
 ) {
   if (workItems.length === 0) return;
+  let splitItems: {
+    indexed: Array<Extract<RetryJobWorkItem, { kind: "packageRelease" }>>;
+    missing: Array<Extract<RetryJobWorkItem, { kind: "packageRelease" }>>;
+  };
   try {
-    await repairPackageReleaseBackupIndexes(
-      ctx,
-      workItems.map((workItem) => workItem.item),
-      context,
-    );
-    for (const workItem of workItems) {
-      await markRetryJobSucceeded(ctx, workItem.job);
-    }
-    result.succeeded += workItems.length;
+    splitItems = await splitPackageIndexRepairItems(context, workItems);
   } catch (error) {
     result.failed += workItems.length;
     await markRetryJobsFailed(ctx, workItems, error);
+    return;
+  }
+
+  const { indexed, missing } = splitItems;
+  await markIndexedRetryJobsSucceeded(ctx, indexed, result);
+  if (missing.length === 0) return;
+
+  try {
+    await repairPackageReleaseBackupIndexes(
+      ctx,
+      missing.map((workItem) => workItem.item),
+      context,
+    );
+    for (const workItem of missing) {
+      await markRetryJobSucceeded(ctx, workItem.job);
+    }
+    result.succeeded += missing.length;
+  } catch (error) {
+    result.failed += missing.length;
+    await markRetryJobsFailed(ctx, missing, error);
   }
 }
 
@@ -659,19 +677,121 @@ async function flushSkillIndexRepairs(
   result: { succeeded: number; failed: number },
 ) {
   if (workItems.length === 0) return;
+  let splitItems: {
+    indexed: Array<Extract<RetryJobWorkItem, { kind: "skillVersion" }>>;
+    missing: Array<Extract<RetryJobWorkItem, { kind: "skillVersion" }>>;
+  };
   try {
-    await repairSkillVersionBackupIndexes(
-      ctx,
-      workItems.map((workItem) => workItem.item),
-      context,
-    );
-    for (const workItem of workItems) {
-      await markRetryJobSucceeded(ctx, workItem.job);
-    }
-    result.succeeded += workItems.length;
+    splitItems = await splitSkillIndexRepairItems(context, workItems);
   } catch (error) {
     result.failed += workItems.length;
     await markRetryJobsFailed(ctx, workItems, error);
+    return;
+  }
+
+  const { indexed, missing } = splitItems;
+  await markIndexedRetryJobsSucceeded(ctx, indexed, result);
+  if (missing.length === 0) return;
+
+  try {
+    await repairSkillVersionBackupIndexes(
+      ctx,
+      missing.map((workItem) => workItem.item),
+      context,
+    );
+    for (const workItem of missing) {
+      await markRetryJobSucceeded(ctx, workItem.job);
+    }
+    result.succeeded += missing.length;
+  } catch (error) {
+    result.failed += missing.length;
+    await markRetryJobsFailed(ctx, missing, error);
+  }
+}
+
+async function splitPackageIndexRepairItems(
+  context: RegistryArtifactBackupContext,
+  workItems: Array<Extract<RetryJobWorkItem, { kind: "packageRelease" }>>,
+) {
+  const first = workItems[0];
+  const index = first
+    ? await fetchPackageBackupIndex(context, first.item.ownerHandle, first.item.normalizedName)
+    : null;
+  const indexed: Array<Extract<RetryJobWorkItem, { kind: "packageRelease" }>> = [];
+  const missing: Array<Extract<RetryJobWorkItem, { kind: "packageRelease" }>> = [];
+  for (const workItem of workItems) {
+    const present = packageIndexEntryMatchesRetry(index, workItem.item);
+    (present ? indexed : missing).push(workItem);
+  }
+  return { indexed, missing };
+}
+
+async function splitSkillIndexRepairItems(
+  context: RegistryArtifactBackupContext,
+  workItems: Array<Extract<RetryJobWorkItem, { kind: "skillVersion" }>>,
+) {
+  const first = workItems[0];
+  const index = first
+    ? await fetchSkillBackupIndex(context, first.item.ownerHandle, first.item.slug)
+    : null;
+  const indexed: Array<Extract<RetryJobWorkItem, { kind: "skillVersion" }>> = [];
+  const missing: Array<Extract<RetryJobWorkItem, { kind: "skillVersion" }>> = [];
+  for (const workItem of workItems) {
+    const present = skillIndexEntryMatchesRetry(index, workItem.item);
+    (present ? indexed : missing).push(workItem);
+  }
+  return { indexed, missing };
+}
+
+function packageIndexEntryMatchesRetry(
+  index: Awaited<ReturnType<typeof fetchPackageBackupIndex>>,
+  item: Extract<RetryJobWorkItem, { kind: "packageRelease" }>["item"],
+) {
+  const entry = index?.versions.find(
+    (candidate) => candidate.releaseId === item.releaseId && candidate.version === item.version,
+  );
+  if (!entry) return false;
+  if (typeof item.isLatest !== "boolean") return true;
+  if (entry.isLatest !== item.isLatest) return false;
+  const latestMatches = Boolean(
+    index && index.latest.releaseId === item.releaseId && index.latest.version === item.version,
+  );
+  return item.isLatest ? latestMatches : !latestMatches;
+}
+
+function skillIndexEntryMatchesRetry(
+  index: Awaited<ReturnType<typeof fetchSkillBackupIndex>>,
+  item: Extract<RetryJobWorkItem, { kind: "skillVersion" }>["item"],
+) {
+  const entry = index?.versions.find(
+    (candidate) => candidate.versionId === item.versionId && candidate.version === item.version,
+  );
+  if (!entry) return false;
+  if (typeof item.isLatest !== "boolean") return true;
+  if (entry.isLatest !== item.isLatest) return false;
+  const latestMatches = Boolean(
+    index && index.latest.versionId === item.versionId && index.latest.version === item.version,
+  );
+  return item.isLatest ? latestMatches : !latestMatches;
+}
+
+async function markIndexedRetryJobsSucceeded(
+  ctx: ActionCtx,
+  workItems: ArtifactRetryJobWorkItem[],
+  result: { succeeded: number; failed: number },
+) {
+  for (const workItem of workItems) {
+    try {
+      await markRetryJobSucceeded(ctx, workItem.job);
+      result.succeeded += 1;
+    } catch (error) {
+      result.failed += 1;
+      try {
+        await markRetryJobsFailed(ctx, [workItem], error);
+      } catch (markFailedError) {
+        console.error("Registry artifact backup retry status update failed", markFailedError);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- fetch package backup indexes so retry repair can inspect package root catalogs the same way it inspects skill catalogs
- short-circuit retry jobs whose `_meta.json` and `_index.json` already agree with Convex, including latest-pointer state
- keep index-read/status-update failures inside retry job accounting so one bad job does not abort the whole retry action

## Production context
- PR #2634 increased retry throughput, but production still failed 24/24 due `_index.json changed too frequently`
- PR #2635 batched same-root index writes, but production retries still failed on already-contended `_index.json` writes
- this hotfix targets retry jobs where another attempt already updated the restore catalog, so the backlog can be marked succeeded without another no-op conditional PUT

## Proof
- `PATH="$HOME/.bun/bin:$PATH" bunx convex codegen`
- `PATH="$HOME/.bun/bin:$PATH" bunx vitest run convex/registryArtifactBackups.test.ts convex/lib/registryArtifactBackup.test.ts convex/crons.test.ts`
- `PATH="$HOME/.bun/bin:$PATH" bunx tsc --noEmit --pretty false`
- `PATH="$HOME/.bun/bin:$PATH" bun run ci:static`
- `PATH="$HOME/.bun/bin:$PATH" VITE_CONVEX_URL=https://example.invalid bun run ci:unit`
- `PATH="$HOME/.bun/bin:$PATH" bun run ci:types-build`
- `git diff --check`

## Review
- `codex review --uncommitted` found and I fixed index-read failure accounting, latest-pointer stale short-circuiting, and indexed-job success-marker failure isolation.
- The repo helper path still has `codex_args[@]: unbound variable`, so I used direct `codex review --uncommitted` plus the local gates above.
