### PR TITLE
fix: compact theme controls in profile menu

### DIFF
--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -3,7 +3,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
-import type { ReactNode } from "react";
+import type { AriaAttributes, ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type HeaderAuthStatus = {
@@ -142,9 +142,19 @@ vi.mock("../components/ui/dropdown-menu", () => ({
     children: ReactNode;
     className?: string;
     onClick?: () => void;
+    "aria-current"?: AriaAttributes["aria-current"];
+    "aria-label"?: string;
     "data-status"?: string;
+    title?: string;
   }) => (
-    <div className={className} data-status={props["data-status"]} onClick={onClick}>
+    <div
+      aria-current={props["aria-current"]}
+      aria-label={props["aria-label"]}
+      className={className}
+      data-status={props["data-status"]}
+      onClick={onClick}
+      title={props.title}
+    >
       {children}
     </div>
   ),
@@ -247,7 +257,7 @@ describe("Header", () => {
     expect(screen.queryByText("About")).toBeNull();
   });
 
-  it("moves theme mode controls into the signed-in profile menu", () => {
+  it("renders theme mode controls as a compact row between Settings and Sign out", () => {
     authStatusMock.mockReturnValue({
       isAuthenticated: true,
       isLoading: false,
@@ -263,16 +273,29 @@ describe("Header", () => {
     render(<Header />);
 
     expect(document.querySelector(".theme-mode-toggle")).toBeNull();
-    expect(screen.getByText("Theme")).toBeTruthy();
-    expect(
-      screen
-        .getByText("System theme")
-        .closest(".user-dropdown-theme-item")
-        ?.getAttribute("data-status"),
-    ).toBe("active");
-    fireEvent.click(screen.getByText("Light theme").closest(".user-dropdown-theme-item")!);
+    expect(screen.queryByText("Theme")).toBeNull();
+
+    const themeRow = document.querySelector(".user-dropdown-theme-row");
+    const settings = screen.getByText("Settings");
+    const signOut = screen.getByText("Sign out");
+
+    expect(themeRow).toBeTruthy();
+    expect(themeRow?.children).toHaveLength(3);
+    expect(settings.compareDocumentPosition(themeRow!) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(themeRow!.compareDocumentPosition(signOut) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(themeRow?.previousElementSibling?.tagName).toBe("HR");
+    expect(signOut.previousElementSibling?.tagName).toBe("HR");
+
+    expect(screen.getByLabelText("System theme").getAttribute("aria-current")).toBe("true");
+    expect(screen.getByLabelText("System theme").getAttribute("data-status")).toBe("active");
+    expect(screen.getByLabelText("Light theme").getAttribute("aria-current")).toBeNull();
+    fireEvent.click(screen.getByLabelText("Light theme"));
     expect(setModeMock).toHaveBeenCalledWith("light");
-    fireEvent.click(screen.getByText("Dark theme").closest(".user-dropdown-theme-item")!);
+    fireEvent.click(screen.getByLabelText("Dark theme"));
     expect(setModeMock).toHaveBeenCalledWith("dark");
   });
 

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -77,8 +77,8 @@ describe("restored UI design contract", () => {
     expect(headerSource).toContain('className="navbar-top"');
     expect(headerSource).toContain('className="navbar-top-links"');
     expect(headerSource).toContain('className="navbar-search-wrap"');
-    expect(headerSource).toContain('className="user-dropdown-section-label"');
-    expect(headerSource).toContain('className="user-dropdown-theme-item"');
+    expect(headerSource).toContain('className="user-dropdown-theme-row"');
+    expect(headerSource).toContain('className="user-dropdown-theme-button"');
     expect(headerSource).not.toContain('className="theme-mode-toggle"');
     expect(headerSource).toContain('className="github-sign-in-button"');
     expect(headerSource).toContain('className="sign-in-full-copy"');
@@ -107,8 +107,10 @@ describe("restored UI design contract", () => {
     expect(topRow).toContain(
       "grid-template-columns: max-content max-content minmax(220px, 1fr) auto",
     );
-    const themeItem = cssRule(css, ".user-dropdown-theme-item");
-    expect(themeItem).toContain("min-width: 220px");
+    const themeRow = cssRule(css, ".user-dropdown-theme-row");
+    expect(themeRow).toContain("grid-template-columns: repeat(3, minmax(0, 1fr))");
+    const themeButton = cssRule(css, ".user-dropdown-theme-button");
+    expect(themeButton).toContain("justify-content: center");
     expect(css).toContain("--r-btn: var(--r-sm)");
 
     const compact = cssMediaContaining(css, "(max-width: 760px)", [

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -411,22 +411,6 @@ export default function Header() {
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="user-dropdown-content">
-                  <div className="user-dropdown-section-label">Theme</div>
-                  {THEME_MODE_ITEMS.map(({ mode: themeMode, label, Icon }) => (
-                    <DropdownMenuItem
-                      key={themeMode}
-                      className="user-dropdown-theme-item"
-                      data-status={mode === themeMode ? "active" : undefined}
-                      onClick={() => setThemeMode(themeMode)}
-                    >
-                      <Icon size={14} aria-hidden="true" />
-                      <span>{label}</span>
-                      {mode === themeMode ? (
-                        <span className="user-dropdown-current">Current</span>
-                      ) : null}
-                    </DropdownMenuItem>
-                  ))}
-                  <DropdownMenuSeparator />
                   <DropdownMenuItem asChild>
                     <Link to="/dashboard" className="flex items-center gap-2">
                       <LayoutDashboard size={14} aria-hidden="true" />
@@ -445,6 +429,23 @@ export default function Header() {
                       Settings
                     </Link>
                   </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <div className="user-dropdown-theme-row" role="group" aria-label="Theme">
+                    {THEME_MODE_ITEMS.map(({ mode: themeMode, label, Icon }) => (
+                      <DropdownMenuItem
+                        key={themeMode}
+                        aria-label={label}
+                        aria-current={mode === themeMode ? "true" : undefined}
+                        className="user-dropdown-theme-button"
+                        data-status={mode === themeMode ? "active" : undefined}
+                        title={label}
+                        onClick={() => setThemeMode(themeMode)}
+                      >
+                        <Icon size={15} aria-hidden="true" />
+                        <span className="sr-only">{label}</span>
+                      </DropdownMenuItem>
+                    ))}
+                  </div>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem onClick={() => void signOut()}>Sign out</DropdownMenuItem>
                 </DropdownMenuContent>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1016,28 +1016,21 @@ code {
   outline: none;
 }
 
-.user-dropdown-section-label {
-  padding: 4px 8px 6px;
-  font-size: var(--fs-xs);
-  font-weight: 650;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--ink-soft);
+.user-dropdown-theme-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 4px;
 }
 
-.user-dropdown-theme-item {
-  min-width: 220px;
+.user-dropdown-theme-button {
+  min-width: 0;
+  justify-content: center;
+  padding-inline: 0;
 }
 
-.user-dropdown-theme-item[data-status="active"] {
+.user-dropdown-theme-button[data-status="active"] {
   background: color-mix(in srgb, var(--accent) 12%, transparent);
   color: var(--ink);
-}
-
-.user-dropdown-current {
-  margin-left: auto;
-  font-size: var(--fs-xs);
-  color: var(--ink-soft);
 }
 
 /* @deprecated — use <Button> from components/ui/button.tsx */


### PR DESCRIPTION
## Summary

- move theme controls below Settings into a compact three-button row
- keep matching separators above the theme row and Sign out
- preserve accessible labels and announce the active theme selection

## Proof

- Real signed-in local-auth browser proof captured and published in the UI proof comment.

## Tests

- `bunx vitest run src/__tests__/header.test.tsx src/__tests__/ui-design-contract.test.ts`
- `bun run test:ui-contract`
- `bun run ci:unit`
- `bun run ci:static`
- `bun run ci:types-build`
