### PR TITLE
fix: serialize registry backup retry drains

### DIFF
--- a/convex/registryArtifactBackups.test.ts
+++ b/convex/registryArtifactBackups.test.ts
@@ -6,6 +6,8 @@ import {
   getRegistryArtifactBackupHealthHandler,
   getRegistryArtifactBackupPageInternal,
   getPackageRegistryArtifactBackupPageInternal,
+  releaseRegistryArtifactBackupRetryLeaseHandler,
+  tryAcquireRegistryArtifactBackupRetryLeaseHandler,
 } from "./registryArtifactBackups";
 import {
   backupPackageForPublishInternal,
@@ -59,6 +61,10 @@ beforeEach(() => {
   });
   registryBackupMocks.isRegistryArtifactBackupConfigured.mockReturnValue(true);
 });
+
+function retryLeaseRunMutation() {
+  return vi.fn().mockResolvedValueOnce({ acquired: true });
+}
 
 describe("publish-time registry artifact backups", () => {
   it("rehydrates skill backup args from current Convex state before writing", async () => {
@@ -601,6 +607,51 @@ describe("seedRegistryArtifactBackupsInternalHandler", () => {
 });
 
 describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
+  it("skips retry drain when another retry action holds the lease", async () => {
+    const runMutation = vi.fn().mockResolvedValueOnce({ acquired: false });
+    const runQuery = vi.fn();
+
+    const result = await processRegistryArtifactBackupRetriesInternalHandler(
+      { runQuery, runMutation } as never,
+      {},
+    );
+
+    expect(result.stats.retryJobsProcessed).toBe(0);
+    expect(runQuery).not.toHaveBeenCalled();
+    expect(registryBackupMocks.backupPackageReleaseToObjectStorage).not.toHaveBeenCalled();
+  });
+
+  it("releases the retry lease after draining jobs", async () => {
+    const runMutation = retryLeaseRunMutation();
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({ stale: 0, exhausted: 0 });
+
+    await processRegistryArtifactBackupRetriesInternalHandler(
+      { runQuery, runMutation } as never,
+      {},
+    );
+
+    const token = runMutation.mock.calls[0]?.[1]?.token;
+    expect(typeof token).toBe("string");
+    expect(runMutation.mock.calls.at(-1)?.[1]).toMatchObject({ token });
+  });
+
+  it("can force pending retry jobs regardless of nextRunAt for operator drains", async () => {
+    const runMutation = retryLeaseRunMutation();
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce({ stale: 0, exhausted: 0 });
+
+    await processRegistryArtifactBackupRetriesInternalHandler({ runQuery, runMutation } as never, {
+      forceDue: true,
+    });
+
+    expect(runQuery.mock.calls[0]?.[1]).toMatchObject({ ignoreNextRunAt: true });
+  });
+
   it("drains retry jobs without scanning the historical registry", async () => {
     const dueJob = {
       _id: "registryArtifactBackupJobs:demo",
@@ -641,7 +692,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
         deactivatedAt: undefined,
       })
       .mockResolvedValueOnce({ stale: 0, exhausted: 0 });
-    const runMutation = vi.fn();
+    const runMutation = retryLeaseRunMutation();
 
     const result = await processRegistryArtifactBackupRetriesInternalHandler(
       { runQuery, runMutation } as never,
@@ -665,19 +716,20 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
   });
 
   it("requests a larger retry batch so publish bursts drain promptly", async () => {
+    const runMutation = retryLeaseRunMutation();
     const runQuery = vi
       .fn()
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce({ stale: 0, exhausted: 0 });
 
     await processRegistryArtifactBackupRetriesInternalHandler(
-      { runQuery, runMutation: vi.fn() } as never,
+      { runQuery, runMutation } as never,
       {},
     );
 
     expect(runQuery.mock.calls[0]?.[1]).toMatchObject({
       includeExhaustedRepair: true,
-      limit: 200,
+      limit: 500,
       maxRepairAttempts: 16,
     });
   });
@@ -725,7 +777,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
       if ("staleAfterMs" in args) return { stale: 0, exhausted: 0 };
       throw new Error(`unexpected query ${JSON.stringify(args)}`);
     });
-    const runMutation = vi.fn();
+    const runMutation = retryLeaseRunMutation();
     registryBackupMocks.fetchSkillVersionBackupMeta.mockResolvedValue(null);
     registryBackupMocks.backupSkillVersionToObjectStorage.mockRejectedValueOnce(
       new Error("R2 still down"),
@@ -792,7 +844,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
       if ("staleAfterMs" in args) return { stale: 0, exhausted: 0 };
       throw new Error(`unexpected query ${JSON.stringify(args)}`);
     });
-    const runMutation = vi.fn();
+    const runMutation = retryLeaseRunMutation();
     registryBackupMocks.fetchSkillVersionBackupMeta.mockResolvedValueOnce({
       version: "1.0.0",
       restore: { versionId: "skillVersions:demo" },
@@ -857,7 +909,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
     );
 
     const result = await processRegistryArtifactBackupRetriesInternalHandler(
-      { runQuery, runMutation: vi.fn() } as never,
+      { runQuery, runMutation: retryLeaseRunMutation() } as never,
       {},
     );
 
@@ -921,7 +973,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
     );
 
     const result = await processRegistryArtifactBackupRetriesInternalHandler(
-      { runQuery, runMutation: vi.fn() } as never,
+      { runQuery, runMutation: retryLeaseRunMutation() } as never,
       {},
     );
 
@@ -993,7 +1045,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
     });
 
     const result = await processRegistryArtifactBackupRetriesInternalHandler(
-      { runQuery, runMutation: vi.fn() } as never,
+      { runQuery, runMutation: retryLeaseRunMutation() } as never,
       {},
     );
 
@@ -1032,7 +1084,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
     });
 
     const result = await processRegistryArtifactBackupRetriesInternalHandler(
-      { runQuery, runMutation: vi.fn() } as never,
+      { runQuery, runMutation: retryLeaseRunMutation() } as never,
       {},
     );
 
@@ -1061,7 +1113,9 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
       if ("staleAfterMs" in args) return { stale: 0, exhausted: 0 };
       throw new Error(`unexpected query ${JSON.stringify(args)}`);
     });
-    const runMutation = vi.fn().mockRejectedValueOnce(new Error("status patch failed"));
+    const runMutation = retryLeaseRunMutation().mockRejectedValueOnce(
+      new Error("status patch failed"),
+    );
     registryBackupMocks.fetchSkillVersionBackupMeta.mockResolvedValue({
       version: "1.0.0",
       restore: { versionId: "skillVersions:demo" },
@@ -1079,7 +1133,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
     expect(result.stats.retryJobsSucceeded).toBe(0);
     expect(result.stats.retryJobsFailed).toBe(1);
     expect(registryBackupMocks.repairSkillVersionBackupIndexes).not.toHaveBeenCalled();
-    expect(runMutation).toHaveBeenCalledTimes(2);
+    expect(runMutation).toHaveBeenCalledTimes(4);
   });
 
   it("marks package index retries succeeded when the release is already indexed", async () => {
@@ -1138,7 +1192,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
     });
 
     const result = await processRegistryArtifactBackupRetriesInternalHandler(
-      { runQuery, runMutation: vi.fn() } as never,
+      { runQuery, runMutation: retryLeaseRunMutation() } as never,
       {},
     );
 
@@ -1164,7 +1218,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
       if ("staleAfterMs" in args) return { stale: 0, exhausted: 0 };
       throw new Error(`unexpected query ${JSON.stringify(args)}`);
     });
-    const runMutation = vi.fn();
+    const runMutation = retryLeaseRunMutation();
     registryBackupMocks.fetchSkillVersionBackupMeta.mockResolvedValue({
       version: "1.0.0",
       restore: { versionId: "skillVersions:demo" },
@@ -1205,7 +1259,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
       if ("staleAfterMs" in args) return { stale: 0, exhausted: 0 };
       throw new Error(`unexpected query ${JSON.stringify(args)}`);
     });
-    const runMutation = vi.fn();
+    const runMutation = retryLeaseRunMutation();
     registryBackupMocks.fetchPackageReleaseBackupMeta.mockResolvedValue({
       restore: { releaseId: "packageReleases:demo" },
       artifact: { sha256: "sha:packageReleases:demo" },
@@ -1278,7 +1332,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
     });
 
     const result = await processRegistryArtifactBackupRetriesInternalHandler(
-      { runQuery, runMutation: vi.fn() } as never,
+      { runQuery, runMutation: retryLeaseRunMutation() } as never,
       {},
     );
 
@@ -1329,7 +1383,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
     });
 
     const result = await processRegistryArtifactBackupRetriesInternalHandler(
-      { runQuery, runMutation: vi.fn() } as never,
+      { runQuery, runMutation: retryLeaseRunMutation() } as never,
       {},
     );
 
@@ -1359,7 +1413,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
       if ("staleAfterMs" in args) return { stale: 0, exhausted: 0 };
       throw new Error(`unexpected query ${JSON.stringify(args)}`);
     });
-    const runMutation = vi.fn();
+    const runMutation = retryLeaseRunMutation();
     registryBackupMocks.fetchSkillVersionBackupMeta.mockResolvedValue(null);
 
     const result = await processRegistryArtifactBackupRetriesInternalHandler(
@@ -1413,7 +1467,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
         moderationStatus: "hidden",
       })
       .mockResolvedValueOnce({ stale: 0, exhausted: 0 });
-    const runMutation = vi.fn();
+    const runMutation = retryLeaseRunMutation();
 
     const result = await processRegistryArtifactBackupRetriesInternalHandler(
       { runQuery, runMutation } as never,
@@ -1510,6 +1564,50 @@ function makePackage(id: string, name: string) {
 }
 
 describe("registry artifact backup jobs", () => {
+  it("can force pending jobs without waiting for nextRunAt", async () => {
+    const now = 1_700_000_000_000;
+    const pendingJobs = [
+      {
+        _id: "registryArtifactBackupJobs:future",
+        status: "pending",
+        attempts: 1,
+        nextRunAt: now + 60 * 60 * 1000,
+      },
+    ];
+    const take = vi.fn((limit: number) => Promise.resolve(pendingJobs.slice(0, limit)));
+    const lte = vi.fn();
+    const withIndex = vi.fn(
+      (
+        _indexName: string,
+        buildIndex: (q: {
+          eq: (field: string, value: unknown) => { lte: (field: string, value: number) => unknown };
+        }) => unknown,
+      ) => {
+        buildIndex({
+          eq: () => ({
+            lte,
+          }),
+        });
+        return { take };
+      },
+    );
+    const ctx = {
+      db: {
+        query: vi.fn(() => ({ withIndex })),
+      },
+    };
+
+    const result = await dueJobsHandler(ctx as never, {
+      ignoreNextRunAt: true,
+      limit: 3,
+      now,
+    });
+
+    expect(result).toEqual(pendingJobs);
+    expect(lte).not.toHaveBeenCalled();
+    expect(take).toHaveBeenCalledWith(3);
+  });
+
   it("can include exhausted jobs that still have repair attempts left", async () => {
     const now = 1_700_000_000_000;
     const pendingJobs = [
@@ -1589,6 +1687,156 @@ describe("registry artifact backup jobs", () => {
     expect(withIndex).toHaveBeenNthCalledWith(2, "by_status_attempts", expect.any(Function));
     expect(pendingTake).toHaveBeenCalledWith(3);
     expect(exhaustedTake).toHaveBeenCalledWith(2);
+  });
+
+  it("acquires a retry lease when no active lease exists", async () => {
+    const now = 1_700_000_000_000;
+    const insert = vi.fn();
+    const ctx = {
+      db: {
+        query: vi.fn(() => ({
+          withIndex: vi.fn(() => ({ unique: vi.fn().mockResolvedValue(null) })),
+        })),
+        insert,
+        patch: vi.fn(),
+      },
+    };
+
+    const result = await tryAcquireRegistryArtifactBackupRetryLeaseHandler(ctx as never, {
+      now,
+      token: "lease-token",
+      ttlMs: 60_000,
+    });
+
+    expect(result).toEqual({ acquired: true });
+    expect(insert).toHaveBeenCalledWith("registryArtifactBackupSyncState", {
+      key: "retryLease",
+      cursor: "lease-token",
+      updatedAt: now,
+    });
+  });
+
+  it("refuses a retry lease while a fresh lease exists", async () => {
+    const now = 1_700_000_000_000;
+    const existing = {
+      _id: "registryArtifactBackupSyncState:lease",
+      key: "retryLease",
+      cursor: "other-token",
+      updatedAt: now - 1_000,
+    };
+    const patch = vi.fn();
+    const ctx = {
+      db: {
+        query: vi.fn(() => ({
+          withIndex: vi.fn(() => ({ unique: vi.fn().mockResolvedValue(existing) })),
+        })),
+        insert: vi.fn(),
+        patch,
+      },
+    };
+
+    const result = await tryAcquireRegistryArtifactBackupRetryLeaseHandler(ctx as never, {
+      now,
+      token: "lease-token",
+      ttlMs: 60_000,
+    });
+
+    expect(result).toEqual({ acquired: false, holderUpdatedAt: existing.updatedAt });
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("acquires a retry lease after the previous lease was released", async () => {
+    const now = 1_700_000_000_000;
+    const existing = {
+      _id: "registryArtifactBackupSyncState:lease",
+      key: "retryLease",
+      cursor: undefined,
+      updatedAt: now - 1_000,
+    };
+    const patch = vi.fn();
+    const ctx = {
+      db: {
+        query: vi.fn(() => ({
+          withIndex: vi.fn(() => ({ unique: vi.fn().mockResolvedValue(existing) })),
+        })),
+        insert: vi.fn(),
+        patch,
+      },
+    };
+
+    const result = await tryAcquireRegistryArtifactBackupRetryLeaseHandler(ctx as never, {
+      now,
+      token: "new-token",
+      ttlMs: 60_000,
+    });
+
+    expect(result).toEqual({ acquired: true });
+    expect(patch).toHaveBeenCalledWith("registryArtifactBackupSyncState:lease", {
+      cursor: "new-token",
+      updatedAt: now,
+    });
+  });
+
+  it("reclaims a stale retry lease", async () => {
+    const now = 1_700_000_000_000;
+    const existing = {
+      _id: "registryArtifactBackupSyncState:lease",
+      key: "retryLease",
+      cursor: "old-token",
+      updatedAt: now - 120_000,
+    };
+    const patch = vi.fn();
+    const ctx = {
+      db: {
+        query: vi.fn(() => ({
+          withIndex: vi.fn(() => ({ unique: vi.fn().mockResolvedValue(existing) })),
+        })),
+        insert: vi.fn(),
+        patch,
+      },
+    };
+
+    const result = await tryAcquireRegistryArtifactBackupRetryLeaseHandler(ctx as never, {
+      now,
+      token: "lease-token",
+      ttlMs: 60_000,
+    });
+
+    expect(result).toEqual({ acquired: true });
+    expect(patch).toHaveBeenCalledWith("registryArtifactBackupSyncState:lease", {
+      cursor: "lease-token",
+      updatedAt: now,
+    });
+  });
+
+  it("releases only the matching retry lease token", async () => {
+    const now = 1_700_000_000_000;
+    const existing = {
+      _id: "registryArtifactBackupSyncState:lease",
+      key: "retryLease",
+      cursor: "lease-token",
+      updatedAt: now - 1_000,
+    };
+    const patch = vi.fn();
+    const ctx = {
+      db: {
+        query: vi.fn(() => ({
+          withIndex: vi.fn(() => ({ unique: vi.fn().mockResolvedValue(existing) })),
+        })),
+        patch,
+      },
+    };
+
+    const result = await releaseRegistryArtifactBackupRetryLeaseHandler(ctx as never, {
+      now,
+      token: "lease-token",
+    });
+
+    expect(result).toEqual({ released: true });
+    expect(patch).toHaveBeenCalledWith("registryArtifactBackupSyncState:lease", {
+      cursor: undefined,
+      updatedAt: now,
+    });
   });
 
   it("upserts package release backup failures into a retryable backlog", async () => {

--- a/convex/registryArtifactBackups.ts
+++ b/convex/registryArtifactBackups.ts
@@ -11,12 +11,15 @@ const DEFAULT_BATCH_SIZE = 50;
 const MAX_BATCH_SIZE = 200;
 const SYNC_STATE_KEY = "default";
 const PACKAGE_SYNC_STATE_KEY = "packageReleases";
+const RETRY_LEASE_KEY = "retryLease";
 const MAX_BACKUP_JOB_ERROR_LENGTH = 4000;
 const DEFAULT_BACKUP_HEALTH_SAMPLE_LIMIT = 500;
 const MAX_BACKUP_HEALTH_SAMPLE_LIMIT = 1000;
 const DEFAULT_BACKUP_JOB_LIMIT = 25;
-const MAX_BACKUP_JOB_LIMIT = 200;
+const MAX_BACKUP_JOB_LIMIT = 500;
 const DEFAULT_BACKUP_JOB_REPAIR_ATTEMPTS = 16;
+const DEFAULT_RETRY_LEASE_TTL_MS = 20 * 60 * 1000;
+const MAX_RETRY_LEASE_TTL_MS = 60 * 60 * 1000;
 
 type BackupPageItem =
   | {
@@ -342,6 +345,71 @@ export const setPackageRegistryArtifactBackupSyncStateInternal = internalMutatio
   },
 });
 
+export async function tryAcquireRegistryArtifactBackupRetryLeaseHandler(
+  ctx: Pick<MutationCtx, "db">,
+  args: { now?: number; token: string; ttlMs?: number },
+) {
+  const now = args.now ?? Date.now();
+  const ttlMs = clampInt(args.ttlMs ?? DEFAULT_RETRY_LEASE_TTL_MS, 1_000, MAX_RETRY_LEASE_TTL_MS);
+  const state = await ctx.db
+    .query("registryArtifactBackupSyncState")
+    .withIndex("by_key", (q) => q.eq("key", RETRY_LEASE_KEY))
+    .unique();
+  if (state?.cursor && state.updatedAt + ttlMs > now) {
+    return { acquired: false as const, holderUpdatedAt: state.updatedAt };
+  }
+
+  if (!state) {
+    await ctx.db.insert("registryArtifactBackupSyncState", {
+      key: RETRY_LEASE_KEY,
+      cursor: args.token,
+      updatedAt: now,
+    });
+    return { acquired: true as const };
+  }
+
+  await ctx.db.patch(state._id, {
+    cursor: args.token,
+    updatedAt: now,
+  });
+  return { acquired: true as const };
+}
+
+export const tryAcquireRegistryArtifactBackupRetryLeaseInternal = internalMutation({
+  args: {
+    now: v.optional(v.number()),
+    token: v.string(),
+    ttlMs: v.optional(v.number()),
+  },
+  handler: tryAcquireRegistryArtifactBackupRetryLeaseHandler,
+});
+
+export async function releaseRegistryArtifactBackupRetryLeaseHandler(
+  ctx: Pick<MutationCtx, "db">,
+  args: { now?: number; token: string },
+) {
+  const now = args.now ?? Date.now();
+  const state = await ctx.db
+    .query("registryArtifactBackupSyncState")
+    .withIndex("by_key", (q) => q.eq("key", RETRY_LEASE_KEY))
+    .unique();
+  if (!state || state.cursor !== args.token) return { released: false as const };
+
+  await ctx.db.patch(state._id, {
+    cursor: undefined,
+    updatedAt: now,
+  });
+  return { released: true as const };
+}
+
+export const releaseRegistryArtifactBackupRetryLeaseInternal = internalMutation({
+  args: {
+    now: v.optional(v.number()),
+    token: v.string(),
+  },
+  handler: releaseRegistryArtifactBackupRetryLeaseHandler,
+});
+
 const registryArtifactBackupTargetKindValidator = v.union(
   v.literal("skillVersion"),
   v.literal("packageRelease"),
@@ -411,6 +479,7 @@ export const markRegistryArtifactBackupJobFailedInternal = internalMutation({
 export const getDueRegistryArtifactBackupJobsInternal = internalQuery({
   args: {
     includeExhaustedRepair: v.optional(v.boolean()),
+    ignoreNextRunAt: v.optional(v.boolean()),
     maxRepairAttempts: v.optional(v.number()),
     now: v.optional(v.number()),
     limit: v.optional(v.number()),
@@ -420,7 +489,10 @@ export const getDueRegistryArtifactBackupJobsInternal = internalQuery({
     const limit = clampInt(args.limit ?? DEFAULT_BACKUP_JOB_LIMIT, 1, MAX_BACKUP_JOB_LIMIT);
     const pending = await ctx.db
       .query("registryArtifactBackupJobs")
-      .withIndex("by_status_nextRunAt", (q) => q.eq("status", "pending").lte("nextRunAt", now))
+      .withIndex("by_status_nextRunAt", (q) => {
+        const byStatus = q.eq("status", "pending");
+        return args.ignoreNextRunAt ? byStatus : byStatus.lte("nextRunAt", now);
+      })
       .take(limit);
     if (!args.includeExhaustedRepair || pending.length >= limit) return pending;
 

--- a/convex/registryArtifactBackupsNode.ts
+++ b/convex/registryArtifactBackupsNode.ts
@@ -24,13 +24,14 @@ const DEFAULT_BATCH_SIZE = 50;
 const MAX_BATCH_SIZE = 200;
 const DEFAULT_MAX_BATCHES = 5;
 const MAX_MAX_BATCHES = 200;
-const DEFAULT_JOB_BATCH_SIZE = 200;
+const DEFAULT_JOB_BATCH_SIZE = 500;
 const MAX_RETRY_REPAIR_ATTEMPTS = 16;
-const MAX_PARALLEL_RETRY_ROOTS = 25;
+const MAX_PARALLEL_RETRY_ROOTS = 50;
 const UNKNOWN_PACKAGE_ARTIFACT_BYTES = 120 * 1024 * 1024;
 const UNKNOWN_SKILL_ARTIFACT_BYTES = 50 * 1024 * 1024;
 const MAX_PARALLEL_RETRY_ARTIFACT_BYTES = UNKNOWN_PACKAGE_ARTIFACT_BYTES;
 const STALE_BACKUP_JOB_MS = 24 * 60 * 60 * 1000;
+const RETRY_LEASE_TTL_MS = 20 * 60 * 1000;
 
 type BackupPageItem =
   | {
@@ -119,6 +120,11 @@ export type SeedRegistryArtifactBackupsInternalResult = {
 
 export type ProcessRegistryArtifactBackupRetriesInternalResult = {
   stats: RegistryArtifactBackupSyncStats;
+};
+
+export type ProcessRegistryArtifactBackupRetriesInternalArgs = {
+  dryRun?: boolean;
+  forceDue?: boolean;
 };
 
 export const backupSkillForPublishInternal = internalAction({
@@ -466,12 +472,14 @@ async function processDueRegistryArtifactBackupJobs(
   context: RegistryArtifactBackupContext,
   dryRun: boolean,
   stats: RegistryArtifactBackupSyncStats,
+  options: { forceDue?: boolean } = {},
 ) {
   if (dryRun) return;
   const jobs = (await ctx.runQuery(
     internal.registryArtifactBackups.getDueRegistryArtifactBackupJobsInternal,
     {
       includeExhaustedRepair: true,
+      ignoreNextRunAt: options.forceDue,
       limit: DEFAULT_JOB_BATCH_SIZE,
       maxRepairAttempts: MAX_RETRY_REPAIR_ATTEMPTS,
     },
@@ -992,7 +1000,7 @@ async function alertOnUnhealthyBackupBacklog(
 
 export async function processRegistryArtifactBackupRetriesInternalHandler(
   ctx: ActionCtx,
-  args: { dryRun?: boolean },
+  args: ProcessRegistryArtifactBackupRetriesInternalArgs,
 ): Promise<ProcessRegistryArtifactBackupRetriesInternalResult> {
   const stats = initialRegistryArtifactBackupSyncStats();
 
@@ -1001,8 +1009,35 @@ export async function processRegistryArtifactBackupRetriesInternalHandler(
   }
 
   const context = getRegistryArtifactBackupContext();
-  await processDueRegistryArtifactBackupJobs(ctx, context, Boolean(args.dryRun), stats);
-  await alertOnUnhealthyBackupBacklog(ctx, stats);
+  if (args.dryRun) {
+    await processDueRegistryArtifactBackupJobs(ctx, context, true, stats);
+    await alertOnUnhealthyBackupBacklog(ctx, stats);
+    return { stats };
+  }
+
+  const token = `retry-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const lease = (await ctx.runMutation(
+    internal.registryArtifactBackups.tryAcquireRegistryArtifactBackupRetryLeaseInternal,
+    {
+      token,
+      ttlMs: RETRY_LEASE_TTL_MS,
+    },
+  )) as { acquired: boolean };
+  if (!lease.acquired) return { stats };
+
+  try {
+    await processDueRegistryArtifactBackupJobs(ctx, context, false, stats, {
+      forceDue: args.forceDue,
+    });
+    await alertOnUnhealthyBackupBacklog(ctx, stats);
+  } finally {
+    await ctx.runMutation(
+      internal.registryArtifactBackups.releaseRegistryArtifactBackupRetryLeaseInternal,
+      {
+        token,
+      },
+    );
+  }
   return { stats };
 }
 
@@ -1018,6 +1053,7 @@ export const seedRegistryArtifactBackupsInternal = internalAction({
 export const processRegistryArtifactBackupRetriesInternal = internalAction({
   args: {
     dryRun: v.optional(v.boolean()),
+    forceDue: v.optional(v.boolean()),
   },
   handler: processRegistryArtifactBackupRetriesInternalHandler,
 });


### PR DESCRIPTION
## Summary
- add a single-flight lease around registry artifact retry drains so cron/manual retry actions do not process the same due jobs concurrently
- add a `forceDue` internal retry option for operator drains after bad retry attempts pushed jobs into the future
- raise retry throughput from 200 jobs / 25 parallel roots to 500 jobs / 50 parallel roots, while preserving the byte guard for large artifact work

## Validation
- `bunx convex codegen`
- `bunx vitest run convex/registryArtifactBackups.test.ts convex/lib/registryArtifactBackup.test.ts convex/crons.test.ts`
- `bunx tsc --noEmit --pretty false`
- `git diff --check`
- `bun run ci:static`
- `VITE_CONVEX_URL=https://example.invalid bun run coverage`
- `bun run ci:types-build`

## Review
- `.agents/skills/autoreview/scripts/autoreview --mode local --no-yolo --fallback-reviewer none` is still blocked by `codex_args[@]: unbound variable`.
- Direct `codex review --uncommitted` found one accepted P2: released lease rows still blocked reacquisition for the TTL. Fixed with a regression test.
- A second direct review reran focused tests and full coverage after the fix, then got stuck in extra analysis without producing another concrete finding; the lingering process was terminated.
