### PR TITLE
fix: normalize publisher recovery handle comparisons

### DIFF
--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -4166,6 +4166,7 @@ describe("legacy publisher migration", () => {
     options: {
       destinationHasResources?: boolean;
       legacyResources?: boolean;
+      mixedCaseUserHandles?: boolean;
       tooManyLegacySkills?: boolean;
       unexpectedResourceOwner?: boolean;
       unexpectedReservationOwner?: boolean;
@@ -4178,7 +4179,7 @@ describe("legacy publisher migration", () => {
         {
           _id: "users:legacy",
           role: "user",
-          handle: "gingiris",
+          handle: options.mixedCaseUserHandles ? "Gingiris" : "gingiris",
           personalPublisherId: "publishers:gingiris",
           publishedSkills: 5,
           totalDownloads: 100,
@@ -4191,7 +4192,7 @@ describe("legacy publisher migration", () => {
         {
           _id: "users:current",
           role: "user",
-          handle: "gingiris-1031",
+          handle: options.mixedCaseUserHandles ? "Gingiris-1031" : "gingiris-1031",
           personalPublisherId: "publishers:gingiris-1031",
           publishedSkills: 2,
           totalDownloads: 40,
@@ -4791,6 +4792,36 @@ describe("legacy publisher migration", () => {
         "reservedHandles:gingiris",
       ]),
     );
+  });
+
+  it("recovers users whose stored handles retain mixed-case GitHub casing", async () => {
+    const { ctx, users } = makePersonalPublisherRecoveryCtx({
+      mixedCaseUserHandles: true,
+    });
+
+    const result = await recoverPersonalPublisherInternalHandler(ctx as never, {
+      actorUserId: "users:admin",
+      publisherHandle: "gingiris",
+      previousGitHubProviderAccountId: "111",
+      nextGitHubProviderAccountId: "222",
+      nextUserHandle: "gingiris-1031",
+      reason: "Verified account continuity for issue #2555",
+      confirmIdentityVerified: true,
+      dryRun: false,
+    });
+
+    expect(result).toMatchObject({
+      previousUser: { nextHandle: "gingiris-recovered" },
+      nextUser: { nextHandle: "gingiris" },
+    });
+    expect(users.get("users:legacy")).toMatchObject({
+      handle: "gingiris-recovered",
+      personalPublisherId: undefined,
+    });
+    expect(users.get("users:current")).toMatchObject({
+      handle: "gingiris",
+      personalPublisherId: "publishers:gingiris",
+    });
   });
 
   it("fails closed when the destination personal publisher has resources", async () => {

--- a/convex/publishers.ts
+++ b/convex/publishers.ts
@@ -133,6 +133,12 @@ function validateHandle(rawHandle: string) {
   return handle;
 }
 
+function publisherHandlesMatch(left: string | undefined | null, right: string | undefined | null) {
+  const normalizedLeft = normalizePublisherHandle(left);
+  const normalizedRight = normalizePublisherHandle(right);
+  return Boolean(normalizedLeft && normalizedLeft === normalizedRight);
+}
+
 function assertOrgPublisherMembershipManagement(publisher: Doc<"publishers">) {
   if (publisher.kind !== "org") {
     throw new ConvexError("Personal publishers do not support member management");
@@ -1266,7 +1272,7 @@ export const recoverPersonalPublisherInternal = internalMutation({
     }
 
     const expectedNextHandle = normalizePublisherHandle(args.nextUserHandle);
-    if (expectedNextHandle && nextUser.handle !== expectedNextHandle) {
+    if (expectedNextHandle && !publisherHandlesMatch(nextUser.handle, expectedNextHandle)) {
       throw new ConvexError(`Next GitHub provider id does not belong to @${expectedNextHandle}`);
     }
 
@@ -1322,17 +1328,18 @@ export const recoverPersonalPublisherInternal = internalMutation({
 
     const retiredHandleBase =
       normalizePublisherHandle(args.retiredUserHandle) ?? `${publisher.handle}-recovered`;
-    const previousUserRetiredHandle =
-      previousUser.handle === publisher.handle
-        ? await resolveAvailableUserHandle(ctx, retiredHandleBase, previousUser._id)
-        : undefined;
-    const nextPreviousUserHandle =
-      previousUser.handle === publisher.handle
-        ? previousUserRetiredHandle
-        : (previousUser.handle ?? null);
+    const previousUserHasRecoveredHandle = publisherHandlesMatch(
+      previousUser.handle,
+      publisher.handle,
+    );
+    const previousUserRetiredHandle = previousUserHasRecoveredHandle
+      ? await resolveAvailableUserHandle(ctx, retiredHandleBase, previousUser._id)
+      : undefined;
+    const nextPreviousUserHandle = previousUserHasRecoveredHandle
+      ? previousUserRetiredHandle
+      : (previousUser.handle ?? null);
     const previousUserNeedsPatch =
-      previousUser.personalPublisherId === publisher._id ||
-      previousUser.handle === publisher.handle;
+      previousUser.personalPublisherId === publisher._id || previousUserHasRecoveredHandle;
     const nextUserPreviousHandle = nextUser.handle ?? null;
 
     if (!dryRun) {


### PR DESCRIPTION
## Summary
- compare stored recovery user handles using canonical publisher-handle normalization
- retire a legacy mixed-case user handle before assigning the recovered publisher handle
- cover the production-shaped mixed-case recovery regression

## Proof
- before fix, the focused regression failed with `Next GitHub provider id does not belong to @gingiris-1031`
- after fix, `bunx vitest run convex/publishers.test.ts` passes all 76 tests

## Tests
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bun run ci:packages`
- `bun run ci:e2e-http`
