### PR TITLE
feat: add plugin versions tab

### DIFF
--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -228,11 +228,220 @@ describe("plugin detail route", () => {
     expect(screen.getByText("stable")).toBeTruthy();
     expect(screen.getByText("beta")).toBeTruthy();
     expect(
-      screen.getAllByRole("link", { name: "Zip" }).map((link) => link.getAttribute("href")),
+      screen
+        .getAllByRole("link", { name: /Download version .* zip/ })
+        .map((link) => link.getAttribute("href")),
     ).toEqual([
       "/api/v1/packages/demo-plugin/download?version=2.0.0",
       "/api/v1/packages/demo-plugin/download?version=2.0.0-beta.1",
     ]);
+    expect(screen.getByRole("link", { name: "Download version 2.0.0 zip" }).textContent).toBe(
+      "Zip",
+    );
+  });
+
+  it("loads and appends the next active release page", async () => {
+    loaderDataMock = {
+      ...loaderDataMock,
+      versions: {
+        items: [
+          {
+            version: "2.0.0",
+            createdAt: 2,
+            changelog: "Current page",
+            distTags: ["latest"],
+          },
+        ],
+        nextCursor: "versions:next",
+      },
+    };
+    vi.mocked(fetchPackageVersions).mockResolvedValueOnce({
+      items: [
+        {
+          version: "1.0.0",
+          createdAt: 1,
+          changelog: "Loaded next page",
+          distTags: [],
+        },
+      ],
+      nextCursor: null,
+    });
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+    fireEvent.click(screen.getByRole("tab", { name: "Versions" }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+    });
+
+    expect(fetchPackageVersions).toHaveBeenCalledWith("demo-plugin", {
+      cursor: "versions:next",
+      limit: 100,
+    });
+    expect(screen.getByText("Current page")).toBeTruthy();
+    expect(screen.getByText("Loaded next page")).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Download version 1.0.0 zip" }).getAttribute("href"),
+    ).toBe("/api/v1/packages/demo-plugin/download?version=1.0.0");
+    expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
+  });
+
+  it("does not hide a remaining release cursor when the current page is empty", async () => {
+    loaderDataMock = {
+      ...loaderDataMock,
+      versions: {
+        items: [],
+        nextCursor: "versions:next",
+      },
+    };
+    vi.mocked(fetchPackageVersions).mockResolvedValueOnce({
+      items: [
+        {
+          version: "1.0.0",
+          createdAt: 1,
+          changelog: "Loaded after empty page",
+          distTags: [],
+        },
+      ],
+      nextCursor: null,
+    });
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+    fireEvent.click(screen.getByRole("tab", { name: "Versions" }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+    });
+
+    expect(screen.getByText("Loaded after empty page")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
+  });
+
+  it("keeps loaded releases and allows retry when loading more fails", async () => {
+    loaderDataMock = {
+      ...loaderDataMock,
+      versions: {
+        items: [
+          {
+            version: "2.0.0",
+            createdAt: 2,
+            changelog: "Current page",
+            distTags: ["latest"],
+          },
+        ],
+        nextCursor: "versions:next",
+      },
+    };
+    vi.mocked(fetchPackageVersions)
+      .mockRejectedValueOnce(new Error("versions unavailable"))
+      .mockResolvedValueOnce({
+        items: [
+          {
+            version: "1.0.0",
+            createdAt: 1,
+            changelog: "Loaded after retry",
+            distTags: [],
+          },
+        ],
+        nextCursor: null,
+      });
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+    fireEvent.click(screen.getByRole("tab", { name: "Versions" }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+    });
+
+    expect(screen.getByText("Current page")).toBeTruthy();
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Could not load more releases. Try again.",
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+    });
+
+    expect(fetchPackageVersions).toHaveBeenLastCalledWith("demo-plugin", {
+      cursor: "versions:next",
+      limit: 100,
+    });
+    expect(screen.getByText("Loaded after retry")).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("ignores a pending release page after navigating to another plugin", async () => {
+    let resolvePendingPage!: (page: Awaited<ReturnType<typeof fetchPackageVersions>>) => void;
+    const pendingPage = new Promise<Awaited<ReturnType<typeof fetchPackageVersions>>>((resolve) => {
+      resolvePendingPage = resolve;
+    });
+    loaderDataMock = {
+      ...loaderDataMock,
+      versions: {
+        items: [
+          {
+            version: "2.0.0",
+            createdAt: 2,
+            changelog: "First plugin release",
+            distTags: ["latest"],
+          },
+        ],
+        nextCursor: "versions:next",
+      },
+    };
+    vi.mocked(fetchPackageVersions).mockReturnValueOnce(pendingPage);
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+    const { rerender } = render(<Component />);
+    fireEvent.click(screen.getByRole("tab", { name: "Versions" }));
+    fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+
+    loaderDataMock = {
+      ...loaderDataMock,
+      detail: {
+        package: {
+          ...loaderDataMock.detail.package!,
+          name: "second-plugin",
+          displayName: "Second Plugin",
+        },
+        owner: null,
+      },
+      versions: {
+        items: [
+          {
+            version: "3.0.0",
+            createdAt: 3,
+            changelog: "Second plugin release",
+            distTags: ["latest"],
+          },
+        ],
+        nextCursor: null,
+      },
+    };
+    rerender(<Component />);
+
+    await act(async () => {
+      resolvePendingPage({
+        items: [
+          {
+            version: "1.0.0",
+            createdAt: 1,
+            changelog: "Stale first plugin release",
+            distTags: [],
+          },
+        ],
+        nextCursor: null,
+      });
+    });
+
+    expect(screen.getByText("Second plugin release")).toBeTruthy();
+    expect(screen.queryByText("Stale first plugin release")).toBeNull();
   });
 
   it("selects the versions tab from the versions hash", async () => {

--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -291,6 +291,91 @@ describe("plugin detail route", () => {
     expect(fetchPackageVersions).toHaveBeenCalledTimes(1);
   });
 
+  it("resets shared detail state when navigating between scoped plugins without a hash", async () => {
+    loaderDataMock = {
+      ...loaderDataMock,
+      detail: {
+        package: {
+          ...loaderDataMock.detail.package!,
+          name: "@scope/plugin-a",
+          displayName: "Plugin A",
+        },
+        owner: null,
+      },
+      readme: "Plugin A README",
+      versions: {
+        items: [
+          {
+            version: "2.0.0",
+            createdAt: 2,
+            changelog: "Plugin A current release",
+            distTags: ["latest"],
+          },
+        ],
+        nextCursor: "versions:next",
+      },
+    };
+    vi.mocked(fetchPackageVersions).mockResolvedValueOnce({
+      items: [
+        {
+          version: "1.0.0",
+          createdAt: 1,
+          changelog: "Plugin A loaded release",
+          distTags: [],
+        },
+      ],
+      nextCursor: null,
+    });
+    const { PluginDetailPage } = await import("../routes/plugins/$name");
+    const { rerender } = render(
+      <PluginDetailPage name="@scope/plugin-a" loaderData={loaderDataMock} />,
+    );
+    fireEvent.click(screen.getByRole("tab", { name: "Versions" }));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+    });
+    expect(screen.getByText("Plugin A loaded release")).toBeTruthy();
+
+    window.history.pushState(null, "", "/plugins/@scope/plugin-b");
+    pathnameMock = "/plugins/@scope/plugin-b";
+    loaderDataMock = {
+      ...loaderDataMock,
+      detail: {
+        package: {
+          ...loaderDataMock.detail.package!,
+          name: "@scope/plugin-b",
+          displayName: "Plugin B",
+        },
+        owner: null,
+      },
+      readme: "Plugin B README",
+      versions: {
+        items: [
+          {
+            version: "3.0.0",
+            createdAt: 3,
+            changelog: "Plugin B release",
+            distTags: ["latest"],
+          },
+        ],
+        nextCursor: null,
+      },
+    };
+    rerender(<PluginDetailPage name="@scope/plugin-b" loaderData={loaderDataMock} />);
+
+    expect(screen.getByRole("tab", { name: "README" }).getAttribute("aria-selected")).toBe("true");
+    expect(screen.getByText("Plugin B README")).toBeTruthy();
+    expect(screen.queryByText("Plugin A loaded release")).toBeNull();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Versions" }));
+
+    expect(screen.getByText("Plugin B release")).toBeTruthy();
+    expect(screen.queryByText("Plugin A loaded release")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
+    expect(fetchPackageVersions).toHaveBeenCalledTimes(1);
+  });
+
   it("does not hide a remaining release cursor when the current page is empty", async () => {
     loaderDataMock = {
       ...loaderDataMock,

--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -228,16 +228,11 @@ describe("plugin detail route", () => {
     expect(screen.getByText("stable")).toBeTruthy();
     expect(screen.getByText("beta")).toBeTruthy();
     expect(
-      screen
-        .getAllByRole("link", { name: /Download version .* zip/ })
-        .map((link) => link.getAttribute("href")),
-    ).toEqual([
-      "/api/v1/packages/demo-plugin/download?version=2.0.0",
-      "/api/v1/packages/demo-plugin/download?version=2.0.0-beta.1",
-    ]);
-    expect(screen.getByRole("link", { name: "Download version 2.0.0 zip" }).textContent).toBe(
-      "Zip",
-    );
+      document.querySelector(
+        'a[href="/api/v1/packages/demo-plugin/download?version=2.0.0-beta.1"]',
+      ),
+    ).toBeNull();
+    expect(screen.queryByText("Zip")).toBeNull();
   });
 
   it("loads and appends the next active release page", async () => {
@@ -283,8 +278,9 @@ describe("plugin detail route", () => {
     expect(screen.getByText("Current page")).toBeTruthy();
     expect(screen.getByText("Loaded next page")).toBeTruthy();
     expect(
-      screen.getByRole("link", { name: "Download version 1.0.0 zip" }).getAttribute("href"),
-    ).toBe("/api/v1/packages/demo-plugin/download?version=1.0.0");
+      document.querySelector('a[href="/api/v1/packages/demo-plugin/download?version=1.0.0"]'),
+    ).toBeNull();
+    expect(screen.queryByText("Zip")).toBeNull();
     expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
   });
 

--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -1,5 +1,6 @@
 /* @vitest-environment jsdom */
 
+import { createRequire } from "node:module";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { getFunctionName } from "convex/server";
 import type { AnchorHTMLAttributes, ComponentType, ReactNode } from "react";
@@ -273,7 +274,7 @@ describe("plugin detail route", () => {
 
     expect(fetchPackageVersions).toHaveBeenCalledWith("demo-plugin", {
       cursor: "versions:next",
-      limit: 100,
+      limit: 20,
     });
     expect(screen.getByText("Current page")).toBeTruthy();
     expect(screen.getByText("Loaded next page")).toBeTruthy();
@@ -366,7 +367,7 @@ describe("plugin detail route", () => {
 
     expect(fetchPackageVersions).toHaveBeenLastCalledWith("demo-plugin", {
       cursor: "versions:next",
-      limit: 100,
+      limit: 20,
     });
     expect(screen.getByText("Loaded after retry")).toBeTruthy();
     expect(screen.queryByRole("alert")).toBeNull();
@@ -460,11 +461,43 @@ describe("plugin detail route", () => {
     const Component = route.__config.component as ComponentType;
 
     render(<Component />);
+    await act(async () => {});
 
     expect(screen.getByRole("tab", { name: "Versions" }).getAttribute("aria-selected")).toBe(
       "true",
     );
     expect(screen.getByText("Initial release")).toBeTruthy();
+  });
+
+  it("keeps the first render on README when the URL hash targets versions", async () => {
+    window.location.hash = "#versions";
+    loaderDataMock = {
+      ...loaderDataMock,
+      versions: {
+        items: [
+          {
+            version: "1.0.0",
+            createdAt: 1,
+            changelog: "Initial release",
+            distTags: ["latest"],
+          },
+        ],
+        nextCursor: null,
+      },
+      readme: "SSR README",
+    };
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+    const { renderToString } = createRequire(`${process.cwd()}/package.json`)(
+      "react-dom/server",
+    ) as {
+      renderToString: (node: ReactNode) => string;
+    };
+
+    const html = renderToString(<Component />);
+
+    expect(html).toContain("SSR README");
+    expect(html).not.toContain("Initial release");
   });
 
   it("keeps the versions tab available for empty active release histories", async () => {
@@ -1229,6 +1262,34 @@ describe("plugin detail route", () => {
     expect(result.rateLimited).toBeNull();
   });
 
+  it("keeps latest version and README when active release history is rate limited", async () => {
+    const route = await loadRoute();
+    const loader = route.__config.loader as ({
+      params,
+    }: {
+      params: { name: string };
+    }) => Promise<PluginDetailLoaderData>;
+    const latestVersion = { package: null, version: null };
+
+    vi.mocked(fetchPackageDetail).mockResolvedValueOnce({
+      package: {
+        ...loaderDataMock.detail.package!,
+        latestVersion: "1.0.0",
+      },
+      owner: null,
+    });
+    vi.mocked(fetchPackageVersion).mockResolvedValueOnce(latestVersion);
+    vi.mocked(fetchPackageReadme).mockResolvedValueOnce("README");
+    vi.mocked(fetchPackageVersions).mockRejectedValueOnce({ status: 429, retryAfterSeconds: 11 });
+
+    const result = await loader({ params: { name: "demo-plugin" } });
+
+    expect(result.version).toBe(latestVersion);
+    expect(result.readme).toBe("README");
+    expect(result.versions).toBeNull();
+    expect(result.rateLimited).toBeNull();
+  });
+
   it("prefers the official scoped package name for short plugin routes", async () => {
     const route = await loadRoute();
     const loader = route.__config.loader as ({
@@ -1267,7 +1328,7 @@ describe("plugin detail route", () => {
     expect(fetchPackageDetailMock).toHaveBeenCalledWith("@openclaw/matrix");
     expect(fetchPackageReadmeMock).toHaveBeenCalledWith("@openclaw/matrix");
     expect(fetchPackageVersionMock).toHaveBeenCalledWith("@openclaw/matrix", "2026.3.22");
-    expect(fetchPackageVersions).toHaveBeenCalledWith("@openclaw/matrix", { limit: 100 });
+    expect(fetchPackageVersions).toHaveBeenCalledWith("@openclaw/matrix", { limit: 20 });
     expect(result.versions).toEqual(emptyVersions);
     expect(result.detail.package?.name).toBe("@openclaw/matrix");
     expect(result.rateLimited).toBeNull();

--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -283,6 +283,12 @@ describe("plugin detail route", () => {
     ).toBeNull();
     expect(screen.queryByText("Zip")).toBeNull();
     expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("tab", { name: "README" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Versions" }));
+
+    expect(screen.getByText("Loaded next page")).toBeTruthy();
+    expect(fetchPackageVersions).toHaveBeenCalledTimes(1);
   });
 
   it("does not hide a remaining release cursor when the current page is empty", async () => {

--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -8,6 +8,7 @@ import {
   fetchPackageDetail,
   fetchPackageReadme,
   fetchPackageVersion,
+  fetchPackageVersions,
   type PackageDetailResponse,
   type PackageVersionDetail,
 } from "../lib/packageApi";
@@ -23,12 +24,15 @@ let pathnameMock = "/plugins/demo-plugin";
 type PluginDetailLoaderData = {
   detail: PackageDetailResponse;
   version: PackageVersionDetail | null;
+  versions: Awaited<ReturnType<typeof fetchPackageVersions>> | null;
   readme: string | null;
   rateLimited: {
     scope: "detail" | "metadata";
     retryAfterSeconds: number | null;
   } | null;
 };
+
+const emptyVersions = { items: [], nextCursor: null };
 
 let paramsMock = { name: "demo-plugin" };
 let loaderDataMock: PluginDetailLoaderData = {
@@ -51,6 +55,7 @@ let loaderDataMock: PluginDetailLoaderData = {
     owner: null,
   },
   version: null,
+  versions: emptyVersions,
   readme: null as string | null,
   rateLimited: null,
 };
@@ -94,6 +99,7 @@ vi.mock("../lib/packageApi", () => ({
   fetchPackageDetail: vi.fn(),
   fetchPackageReadme: vi.fn(),
   fetchPackageVersion: vi.fn(),
+  fetchPackageVersions: vi.fn(),
   isRateLimitedPackageApiError: (error: unknown) => isRateLimitedPackageApiErrorMock(error),
   getPackageArtifactDownloadPath: vi.fn(
     (name: string, version: string) =>
@@ -133,6 +139,8 @@ describe("plugin detail route", () => {
     vi.mocked(fetchPackageDetail).mockReset();
     vi.mocked(fetchPackageReadme).mockReset();
     vi.mocked(fetchPackageVersion).mockReset();
+    vi.mocked(fetchPackageVersions).mockReset();
+    vi.mocked(fetchPackageVersions).mockResolvedValue(emptyVersions);
     loaderDataMock = {
       detail: {
         package: {
@@ -153,6 +161,7 @@ describe("plugin detail route", () => {
         owner: null,
       },
       version: null,
+      versions: emptyVersions,
       readme: null,
       rateLimited: null,
     };
@@ -175,6 +184,107 @@ describe("plugin detail route", () => {
 
     expect(screen.queryByText(/Latest release:/)).toBeNull();
     expect(screen.queryByRole("link", { name: "Download zip" })).toBeNull();
+  });
+
+  it("renders populated active release history on the versions tab", async () => {
+    const publishedAt = new Date("2026-06-01T12:00:00Z").getTime();
+    loaderDataMock = {
+      ...loaderDataMock,
+      detail: {
+        package: {
+          ...loaderDataMock.detail.package!,
+          latestVersion: "2.0.0",
+        },
+        owner: null,
+      },
+      versions: {
+        items: [
+          {
+            version: "2.0.0",
+            createdAt: publishedAt,
+            changelog: "Adds package release history.",
+            distTags: ["latest", "stable"],
+          },
+          {
+            version: "2.0.0-beta.1",
+            createdAt: publishedAt - 86_400_000,
+            changelog: "Previews package release history.",
+            distTags: ["beta"],
+          },
+        ],
+        nextCursor: null,
+      },
+    };
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+    fireEvent.click(screen.getByRole("tab", { name: "Versions" }));
+
+    expect(screen.getByText(`v2.0.0 · ${new Date(publishedAt).toLocaleDateString()}`)).toBeTruthy();
+    expect(screen.getByText("Adds package release history.")).toBeTruthy();
+    expect(screen.getByText("Previews package release history.")).toBeTruthy();
+    expect(screen.getByText("latest")).toBeTruthy();
+    expect(screen.getByText("stable")).toBeTruthy();
+    expect(screen.getByText("beta")).toBeTruthy();
+    expect(
+      screen.getAllByRole("link", { name: "Zip" }).map((link) => link.getAttribute("href")),
+    ).toEqual([
+      "/api/v1/packages/demo-plugin/download?version=2.0.0",
+      "/api/v1/packages/demo-plugin/download?version=2.0.0-beta.1",
+    ]);
+  });
+
+  it("selects the versions tab from the versions hash", async () => {
+    window.location.hash = "#versions";
+    loaderDataMock = {
+      ...loaderDataMock,
+      versions: {
+        items: [
+          {
+            version: "1.0.0",
+            createdAt: 1,
+            changelog: "Initial release",
+            distTags: ["latest"],
+          },
+        ],
+        nextCursor: null,
+      },
+    };
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    expect(screen.getByRole("tab", { name: "Versions" }).getAttribute("aria-selected")).toBe(
+      "true",
+    );
+    expect(screen.getByText("Initial release")).toBeTruthy();
+  });
+
+  it("keeps the versions tab available for empty active release histories", async () => {
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+    fireEvent.click(screen.getByRole("tab", { name: "Versions" }));
+
+    expect(screen.getByText("No active releases are available.")).toBeTruthy();
+  });
+
+  it("distinguishes unavailable release history from an empty history", async () => {
+    loaderDataMock = {
+      ...loaderDataMock,
+      versions: null,
+    };
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+    fireEvent.click(screen.getByRole("tab", { name: "Versions" }));
+
+    expect(screen.getByText("Release history is temporarily unavailable.")).toBeTruthy();
+    expect(screen.queryByText("No active releases are available.")).toBeNull();
   });
 
   it("links plugin breadcrumb owners to canonical publisher profiles", async () => {
@@ -281,6 +391,7 @@ describe("plugin detail route", () => {
           staticScan: null,
         },
       },
+      versions: emptyVersions,
       readme: null,
       rateLimited: null,
     };
@@ -339,6 +450,7 @@ describe("plugin detail route", () => {
         owner: { handle: "demo-owner", displayName: "Demo Owner", image: null },
       },
       version: null,
+      versions: emptyVersions,
       readme: null,
       rateLimited: null,
     };
@@ -394,6 +506,7 @@ describe("plugin detail route", () => {
           },
         },
       },
+      versions: emptyVersions,
       readme: null,
       rateLimited: null,
     };
@@ -460,6 +573,7 @@ describe("plugin detail route", () => {
           staticScan: null,
         },
       },
+      versions: emptyVersions,
       readme: null,
       rateLimited: null,
     };
@@ -523,6 +637,7 @@ describe("plugin detail route", () => {
           staticScan: null,
         },
       },
+      versions: emptyVersions,
       readme: null,
       rateLimited: null,
     };
@@ -581,6 +696,7 @@ describe("plugin detail route", () => {
           staticScan: null,
         },
       },
+      versions: emptyVersions,
       readme: null,
       rateLimited: null,
     };
@@ -645,6 +761,7 @@ describe("plugin detail route", () => {
           staticScan: null,
         },
       },
+      versions: emptyVersions,
       readme: null,
       rateLimited: null,
     };
@@ -751,6 +868,7 @@ describe("plugin detail route", () => {
           staticScan: null,
         },
       },
+      versions: emptyVersions,
       readme: null,
       rateLimited: null,
     };
@@ -819,6 +937,7 @@ describe("plugin detail route", () => {
     loaderDataMock = {
       detail: { package: null, owner: null },
       version: null,
+      versions: emptyVersions,
       readme: null,
       rateLimited: {
         scope: "detail",
@@ -871,10 +990,38 @@ describe("plugin detail route", () => {
     expect(result.detail.package?.name).toBe("demo-plugin");
     expect(result.readme).toBeNull();
     expect(result.version).toBeNull();
+    expect(result.versions).toBeNull();
     expect(result.rateLimited).toEqual({
       scope: "metadata",
       retryAfterSeconds: 11,
     });
+  });
+
+  it("keeps plugin detail available when active release history is unavailable", async () => {
+    const route = await loadRoute();
+    const loader = route.__config.loader as ({
+      params,
+    }: {
+      params: { name: string };
+    }) => Promise<PluginDetailLoaderData>;
+
+    vi.mocked(fetchPackageDetail).mockResolvedValueOnce({
+      package: {
+        ...loaderDataMock.detail.package!,
+        latestVersion: "1.0.0",
+      },
+      owner: null,
+    });
+    vi.mocked(fetchPackageVersion).mockResolvedValueOnce({ package: null, version: null });
+    vi.mocked(fetchPackageReadme).mockResolvedValueOnce("README");
+    vi.mocked(fetchPackageVersions).mockRejectedValueOnce(new Error("versions unavailable"));
+
+    const result = await loader({ params: { name: "demo-plugin" } });
+
+    expect(result.readme).toBe("README");
+    expect(result.version).toEqual({ package: null, version: null });
+    expect(result.versions).toBeNull();
+    expect(result.rateLimited).toBeNull();
   });
 
   it("prefers the official scoped package name for short plugin routes", async () => {
@@ -915,6 +1062,8 @@ describe("plugin detail route", () => {
     expect(fetchPackageDetailMock).toHaveBeenCalledWith("@openclaw/matrix");
     expect(fetchPackageReadmeMock).toHaveBeenCalledWith("@openclaw/matrix");
     expect(fetchPackageVersionMock).toHaveBeenCalledWith("@openclaw/matrix", "2026.3.22");
+    expect(fetchPackageVersions).toHaveBeenCalledWith("@openclaw/matrix", { limit: 100 });
+    expect(result.versions).toEqual(emptyVersions);
     expect(result.detail.package?.name).toBe("@openclaw/matrix");
     expect(result.rateLimited).toBeNull();
   });

--- a/src/components/PluginVersionsPanel.tsx
+++ b/src/components/PluginVersionsPanel.tsx
@@ -1,6 +1,6 @@
 import type { ApiV1PackageVersionListResponse } from "clawhub-schema";
 import { useEffect, useRef, useState } from "react";
-import { fetchPackageVersions, getPackageDownloadPath } from "../lib/packageApi";
+import { fetchPackageVersions } from "../lib/packageApi";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 
@@ -89,15 +89,6 @@ export function PluginVersionsPanel({ packageName, versions }: PluginVersionsPan
                       ))}
                     </div>
                   ) : null}
-                </div>
-                <div className="shrink-0">
-                  <a
-                    href={getPackageDownloadPath(packageName, release.version)}
-                    aria-label={`Download version ${release.version} zip`}
-                    className="inline-flex min-h-[34px] items-center justify-center gap-2 whitespace-nowrap rounded-[var(--radius-pill)] border border-[color:var(--line)] bg-[color:var(--surface)] px-3 py-1.5 text-xs font-semibold text-[color:var(--ink)] no-underline transition-all duration-200"
-                  >
-                    Zip
-                  </a>
                 </div>
               </div>
             ))}

--- a/src/components/PluginVersionsPanel.tsx
+++ b/src/components/PluginVersionsPanel.tsx
@@ -1,15 +1,54 @@
 import type { ApiV1PackageVersionListResponse } from "clawhub-schema";
-import { getPackageDownloadPath } from "../lib/packageApi";
+import { useEffect, useRef, useState } from "react";
+import { fetchPackageVersions, getPackageDownloadPath } from "../lib/packageApi";
 import { Badge } from "./ui/badge";
+import { Button } from "./ui/button";
 
 type PluginVersionsPanelProps = {
   packageName: string;
-  versions: ApiV1PackageVersionListResponse["items"] | null | undefined;
+  versions: ApiV1PackageVersionListResponse | null | undefined;
 };
 
 export function PluginVersionsPanel({ packageName, versions }: PluginVersionsPanelProps) {
   const isUnavailable = versions == null;
-  const releases = versions ?? [];
+  const [releases, setReleases] = useState(versions?.items ?? []);
+  const [nextCursor, setNextCursor] = useState(versions?.nextCursor ?? null);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [loadMoreError, setLoadMoreError] = useState<string | null>(null);
+  const loadMoreInFlightRef = useRef(false);
+  const requestGenerationRef = useRef(0);
+
+  useEffect(() => {
+    requestGenerationRef.current += 1;
+    loadMoreInFlightRef.current = false;
+    setReleases(versions?.items ?? []);
+    setNextCursor(versions?.nextCursor ?? null);
+    setIsLoadingMore(false);
+    setLoadMoreError(null);
+  }, [packageName, versions]);
+
+  const loadMore = async () => {
+    if (!nextCursor || loadMoreInFlightRef.current) return;
+    const cursor = nextCursor;
+    const requestGeneration = requestGenerationRef.current;
+    loadMoreInFlightRef.current = true;
+    setIsLoadingMore(true);
+    setLoadMoreError(null);
+    try {
+      const page = await fetchPackageVersions(packageName, { cursor, limit: 100 });
+      if (requestGeneration !== requestGenerationRef.current) return;
+      setReleases((current) => [...current, ...page.items]);
+      setNextCursor(page.nextCursor);
+    } catch {
+      if (requestGeneration !== requestGenerationRef.current) return;
+      setLoadMoreError("Could not load more releases. Try again.");
+    } finally {
+      if (requestGeneration === requestGenerationRef.current) {
+        setIsLoadingMore(false);
+        loadMoreInFlightRef.current = false;
+      }
+    }
+  };
 
   return (
     <div className="grid max-w-full gap-5 overflow-x-auto">
@@ -26,7 +65,7 @@ export function PluginVersionsPanel({ packageName, versions }: PluginVersionsPan
           <p className="empty-state-title">Release history is temporarily unavailable.</p>
           <p className="empty-state-body">Try again later.</p>
         </div>
-      ) : releases.length > 0 ? (
+      ) : releases.length > 0 || nextCursor ? (
         <div className="max-h-[600px] overflow-y-auto">
           <div className="flex flex-col gap-3">
             {releases.map((release) => (
@@ -54,6 +93,7 @@ export function PluginVersionsPanel({ packageName, versions }: PluginVersionsPan
                 <div className="shrink-0">
                   <a
                     href={getPackageDownloadPath(packageName, release.version)}
+                    aria-label={`Download version ${release.version} zip`}
                     className="inline-flex min-h-[34px] items-center justify-center gap-2 whitespace-nowrap rounded-[var(--radius-pill)] border border-[color:var(--line)] bg-[color:var(--surface)] px-3 py-1.5 text-xs font-semibold text-[color:var(--ink)] no-underline transition-all duration-200"
                   >
                     Zip
@@ -62,6 +102,24 @@ export function PluginVersionsPanel({ packageName, versions }: PluginVersionsPan
               </div>
             ))}
           </div>
+          {loadMoreError ? (
+            <p className="mt-3 text-sm font-medium text-red-600 dark:text-red-400" role="alert">
+              {loadMoreError}
+            </p>
+          ) : null}
+          {nextCursor ? (
+            <div className="mt-3 flex justify-center">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                loading={isLoadingMore}
+                onClick={() => void loadMore()}
+              >
+                Load more
+              </Button>
+            </div>
+          ) : null}
         </div>
       ) : (
         <div className="empty-state px-[var(--space-4)] py-[var(--space-6)]">

--- a/src/components/PluginVersionsPanel.tsx
+++ b/src/components/PluginVersionsPanel.tsx
@@ -1,0 +1,73 @@
+import type { ApiV1PackageVersionListResponse } from "clawhub-schema";
+import { getPackageDownloadPath } from "../lib/packageApi";
+import { Badge } from "./ui/badge";
+
+type PluginVersionsPanelProps = {
+  packageName: string;
+  versions: ApiV1PackageVersionListResponse["items"] | null | undefined;
+};
+
+export function PluginVersionsPanel({ packageName, versions }: PluginVersionsPanelProps) {
+  const isUnavailable = versions == null;
+  const releases = versions ?? [];
+
+  return (
+    <div className="grid max-w-full gap-5 overflow-x-auto">
+      <div>
+        <h2 className="m-0 font-display text-[1.2rem] font-bold text-[color:var(--ink)]">
+          Versions
+        </h2>
+        <p className="m-0 text-sm text-[color:var(--ink-soft)]">
+          Review active release history and changelog.
+        </p>
+      </div>
+      {isUnavailable ? (
+        <div className="empty-state px-[var(--space-4)] py-[var(--space-6)]">
+          <p className="empty-state-title">Release history is temporarily unavailable.</p>
+          <p className="empty-state-body">Try again later.</p>
+        </div>
+      ) : releases.length > 0 ? (
+        <div className="max-h-[600px] overflow-y-auto">
+          <div className="flex flex-col gap-3">
+            {releases.map((release) => (
+              <div
+                key={release.version}
+                className="flex items-start justify-between gap-4 rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)] p-3"
+              >
+                <div className="flex min-w-0 flex-1 flex-col gap-1">
+                  <div>
+                    v{release.version} · {new Date(release.createdAt).toLocaleDateString()}
+                  </div>
+                  <div className="whitespace-pre-wrap break-words text-[color:var(--ink-soft)]">
+                    {release.changelog}
+                  </div>
+                  {release.distTags && release.distTags.length > 0 ? (
+                    <div className="flex flex-wrap items-center gap-2 pt-1">
+                      {release.distTags.map((tag) => (
+                        <Badge key={tag} variant="compact">
+                          {tag}
+                        </Badge>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+                <div className="shrink-0">
+                  <a
+                    href={getPackageDownloadPath(packageName, release.version)}
+                    className="inline-flex min-h-[34px] items-center justify-center gap-2 whitespace-nowrap rounded-[var(--radius-pill)] border border-[color:var(--line)] bg-[color:var(--surface)] px-3 py-1.5 text-xs font-semibold text-[color:var(--ink)] no-underline transition-all duration-200"
+                  >
+                    Zip
+                  </a>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : (
+        <div className="empty-state px-[var(--space-4)] py-[var(--space-6)]">
+          <p className="empty-state-title">No active releases are available.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/PluginVersionsPanel.tsx
+++ b/src/components/PluginVersionsPanel.tsx
@@ -4,6 +4,8 @@ import { fetchPackageVersions } from "../lib/packageApi";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 
+export const PLUGIN_VERSIONS_PAGE_SIZE = 20;
+
 type PluginVersionsPanelProps = {
   packageName: string;
   versions: ApiV1PackageVersionListResponse | null | undefined;
@@ -35,7 +37,10 @@ export function PluginVersionsPanel({ packageName, versions }: PluginVersionsPan
     setIsLoadingMore(true);
     setLoadMoreError(null);
     try {
-      const page = await fetchPackageVersions(packageName, { cursor, limit: 100 });
+      const page = await fetchPackageVersions(packageName, {
+        cursor,
+        limit: PLUGIN_VERSIONS_PAGE_SIZE,
+      });
       if (requestGeneration !== requestGenerationRef.current) return;
       setReleases((current) => [...current, ...page.items]);
       setNextCursor(page.nextCursor);

--- a/src/lib/packageApi.test.ts
+++ b/src/lib/packageApi.test.ts
@@ -12,6 +12,7 @@ import {
   fetchPackageDetail,
   fetchPackageReadme,
   fetchPackageVersion,
+  fetchPackageVersions,
   fetchPluginCatalog,
   fetchPackages,
   getPackageDownloadPath,
@@ -409,6 +410,61 @@ describe("fetchPackages", () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe(
       "https://registry.example/api/v1/packages/demo-plugin/versions/1.2.3%2Bbuild%2Fmeta",
     );
+  });
+
+  it("fetches scoped package version history with pagination", async () => {
+    vi.stubEnv("VITE_CONVEX_URL", "https://registry.example");
+    const response = {
+      items: [
+        {
+          version: "1.2.3",
+          createdAt: 123,
+          changelog: "Added package history",
+          distTags: ["latest"],
+        },
+      ],
+      nextCursor: "versions:next",
+    };
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify(response), { status: 200 }));
+
+    await expect(
+      fetchPackageVersions("@scope/demo-plugin", {
+        cursor: "versions:current",
+        limit: 25,
+      }),
+    ).resolves.toEqual(response);
+
+    const requestUrl = fetchMock.mock.calls[0]?.[0];
+    if (typeof requestUrl !== "string") {
+      throw new Error("Expected fetch to be called with a string URL");
+    }
+    const url = new URL(requestUrl);
+    expect(url.pathname).toBe("/api/v1/packages/%40scope%2Fdemo-plugin/versions");
+    expect(url.searchParams.get("cursor")).toBe("versions:current");
+    expect(url.searchParams.get("limit")).toBe("25");
+  });
+
+  it("omits unprovided package version history params and forwards the signal", async () => {
+    vi.stubEnv("VITE_CONVEX_URL", "https://registry.example");
+    const signal = new AbortController().signal;
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ items: [], nextCursor: null }), { status: 200 }),
+      );
+
+    await fetchPackageVersions("demo-plugin", { signal });
+
+    const requestUrl = fetchMock.mock.calls[0]?.[0];
+    if (typeof requestUrl !== "string") {
+      throw new Error("Expected fetch to be called with a string URL");
+    }
+    const url = new URL(requestUrl);
+    expect(url.searchParams.has("cursor")).toBe(false);
+    expect(url.searchParams.has("limit")).toBe(false);
+    expect(fetchMock.mock.calls[0]?.[1]?.signal).toBe(signal);
   });
 
   it("returns null when no supported README variant exists", async () => {

--- a/src/lib/packageApi.test.ts
+++ b/src/lib/packageApi.test.ts
@@ -467,6 +467,20 @@ describe("fetchPackages", () => {
     expect(fetchMock.mock.calls[0]?.[1]?.signal).toBe(signal);
   });
 
+  it("omits an empty package version history cursor", async () => {
+    vi.stubEnv("VITE_CONVEX_URL", "https://registry.example");
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ items: [], nextCursor: null }), { status: 200 }),
+      );
+
+    await fetchPackageVersions("demo-plugin", { cursor: "" });
+
+    const url = new URL(fetchMock.mock.calls[0]?.[0] as string);
+    expect(url.searchParams.has("cursor")).toBe(false);
+  });
+
   it("returns null when no supported README variant exists", async () => {
     vi.stubEnv("VITE_CONVEX_URL", "https://registry.example");
     const fetchMock = vi

--- a/src/lib/packageApi.ts
+++ b/src/lib/packageApi.ts
@@ -525,7 +525,7 @@ export async function fetchPackageVersions(
   },
 ): Promise<ApiV1PackageVersionListResponse> {
   const url = await packageApiUrl(`${ApiRoutes.packages}/${encodeURIComponent(name)}/versions`);
-  if (options?.cursor !== undefined) url.searchParams.set("cursor", options.cursor);
+  if (options?.cursor) url.searchParams.set("cursor", options.cursor);
   if (typeof options?.limit === "number") url.searchParams.set("limit", String(options.limit));
   return await fetchJson<ApiV1PackageVersionListResponse>(url, options?.signal);
 }

--- a/src/lib/packageApi.ts
+++ b/src/lib/packageApi.ts
@@ -1,5 +1,6 @@
 import type {
   ApiV1PackageResponse,
+  ApiV1PackageVersionListResponse,
   PackageCapabilitySummary,
   PackageCompatibility,
   PackageVerificationSummary,
@@ -513,6 +514,20 @@ export async function fetchPackageDetail(name: string): Promise<PackageDetailRes
   }
   if (!response.ok) throw await createPackageApiError(response);
   return (await response.json()) as PackageDetailResponse;
+}
+
+export async function fetchPackageVersions(
+  name: string,
+  options?: {
+    cursor?: string;
+    limit?: number;
+    signal?: AbortSignal;
+  },
+): Promise<ApiV1PackageVersionListResponse> {
+  const url = await packageApiUrl(`${ApiRoutes.packages}/${encodeURIComponent(name)}/versions`);
+  if (options?.cursor !== undefined) url.searchParams.set("cursor", options.cursor);
+  if (typeof options?.limit === "number") url.searchParams.set("limit", String(options.limit));
+  return await fetchJson<ApiV1PackageVersionListResponse>(url, options?.signal);
 }
 
 export async function fetchPackageVersion(

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -13,6 +13,7 @@ import { InstallCopyButton } from "../../components/InstallCopyButton";
 import { Container } from "../../components/layout/Container";
 import { MarkdownPreview } from "../../components/MarkdownPreview";
 import { OfficialTag } from "../../components/OfficialBadge";
+import { PluginVersionsPanel } from "../../components/PluginVersionsPanel";
 import { SidebarMetadata } from "../../components/SidebarMetadata";
 import { SkillDetailSkeleton } from "../../components/skeletons/SkillDetailSkeleton";
 import { Alert, AlertDescription } from "../../components/ui/alert";
@@ -26,8 +27,9 @@ import { getOpenClawPackageCandidateNames } from "../../lib/openClawExtensionSlu
 import {
   fetchPackageDetail,
   fetchPackageReadme,
-  getPackageArtifactDownloadPath,
   fetchPackageVersion,
+  fetchPackageVersions,
+  getPackageArtifactDownloadPath,
   getPackageDownloadPath,
   isRateLimitedPackageApiError,
   type PackageDetailResponse,
@@ -47,7 +49,7 @@ type PluginDetailRateLimitState = {
   retryAfterSeconds: number | null;
 } | null;
 
-type PluginDetailTab = "readme" | "compatibility" | "validation";
+type PluginDetailTab = "readme" | "versions" | "compatibility" | "validation";
 
 type PluginInspectorFinding = {
   packageName: string;
@@ -79,6 +81,7 @@ type PluginInspectorValidationSummary = {
 export type PluginDetailLoaderData = {
   detail: PackageDetailResponse;
   version: PackageVersionDetail | null;
+  versions: Awaited<ReturnType<typeof fetchPackageVersions>> | null;
   readme: string | null;
   rateLimited: PluginDetailRateLimitState;
 };
@@ -98,6 +101,7 @@ export async function loadPluginDetail(requestedName: string): Promise<PluginDet
         return {
           detail: { package: null, owner: null },
           version: null,
+          versions: null,
           readme: null,
           rateLimited: {
             scope: "detail",
@@ -116,23 +120,28 @@ export async function loadPluginDetail(requestedName: string): Promise<PluginDet
   }
 
   if (!detail.package) {
-    return { detail, version: null, readme: null, rateLimited: null };
+    return { detail, version: null, versions: null, readme: null, rateLimited: null };
   }
 
   try {
-    const [version, readme] = await Promise.all([
+    const [version, versions, readme] = await Promise.all([
       detail.package.latestVersion
         ? fetchPackageVersion(resolvedName, detail.package.latestVersion)
         : Promise.resolve(null),
+      fetchPackageVersions(resolvedName, { limit: 100 }).catch((error: unknown) => {
+        if (isRateLimitedPackageApiError(error)) throw error;
+        return null;
+      }),
       fetchPackageReadme(resolvedName),
     ]);
 
-    return { detail, version, readme, rateLimited: null };
+    return { detail, version, versions, readme, rateLimited: null };
   } catch (error) {
     if (isRateLimitedPackageApiError(error)) {
       return {
         detail,
         version: null,
+        versions: null,
         readme: null,
         rateLimited: {
           scope: "metadata",
@@ -227,13 +236,14 @@ function pluginDetailTabFromHash(hashValue: string): PluginDetailTab {
   const hash = hashValue.replace("#", "");
   if (hash === "warnings") return "validation";
   if (hash === "capabilities" || hash === "verification") return "compatibility";
-  return hash === "compatibility" || hash === "validation" ? hash : "readme";
+  return hash === "versions" || hash === "compatibility" || hash === "validation" ? hash : "readme";
 }
 
 function PluginDetailTabs({
   activeTab,
   setActiveTab,
   readmePanel,
+  versionsPanel,
   compatibilityPanel,
   validationPanel,
   validationCount,
@@ -241,6 +251,7 @@ function PluginDetailTabs({
   activeTab: PluginDetailTab;
   setActiveTab: (tab: PluginDetailTab) => void;
   readmePanel: ReactNode;
+  versionsPanel: ReactNode;
   compatibilityPanel: ReactNode | null;
   validationPanel: ReactNode | null;
   validationCount: number;
@@ -257,17 +268,21 @@ function PluginDetailTabs({
   };
 
   const effectiveActiveTab =
-    activeTab === "compatibility" && compatibilityPanel
-      ? "compatibility"
-      : activeTab === "validation" && validationPanel
-        ? "validation"
-        : "readme";
+    activeTab === "versions"
+      ? "versions"
+      : activeTab === "compatibility" && compatibilityPanel
+        ? "compatibility"
+        : activeTab === "validation" && validationPanel
+          ? "validation"
+          : "readme";
   const activePanel =
-    effectiveActiveTab === "compatibility" && compatibilityPanel
-      ? compatibilityPanel
-      : effectiveActiveTab === "validation" && validationPanel
-        ? validationPanel
-        : readmePanel;
+    effectiveActiveTab === "versions"
+      ? versionsPanel
+      : effectiveActiveTab === "compatibility" && compatibilityPanel
+        ? compatibilityPanel
+        : effectiveActiveTab === "validation" && validationPanel
+          ? validationPanel
+          : readmePanel;
 
   return (
     <div className="tab-card">
@@ -280,6 +295,15 @@ function PluginDetailTabs({
           onClick={() => selectTab("readme")}
         >
           README
+        </button>
+        <button
+          className={`tab-button${effectiveActiveTab === "versions" ? " is-active" : ""}`}
+          type="button"
+          role="tab"
+          aria-selected={effectiveActiveTab === "versions"}
+          onClick={() => selectTab("versions")}
+        >
+          Versions
         </button>
         {compatibilityPanel ? (
           <button
@@ -332,7 +356,7 @@ export function PluginDetailPage({
   name: string;
   loaderData: PluginDetailLoaderData;
 }) {
-  const { detail, version, readme, rateLimited } = loaderData;
+  const { detail, version, versions, readme, rateLimited } = loaderData;
   const pathname = useRouterState({ select: (state) => state.location.pathname });
   const { me } = useAuthStatus();
   const isNestedPluginRoute =
@@ -450,6 +474,7 @@ export function PluginDetailPage({
       <p className="empty-state-body">This plugin doesn't have a README yet.</p>
     </div>
   );
+  const versionsPanel = <PluginVersionsPanel packageName={pkg.name} versions={versions?.items} />;
   const compatibilityPanel =
     compatEntries.length > 0 || artifact ? (
       <div className="plugin-tab-panel">
@@ -775,6 +800,7 @@ export function PluginDetailPage({
             activeTab={activeTab}
             setActiveTab={setActiveTab}
             readmePanel={readmePanel}
+            versionsPanel={versionsPanel}
             compatibilityPanel={compatibilityPanel}
             validationPanel={validationPanel}
             validationCount={validationCount}

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -256,6 +256,7 @@ function PluginDetailTabs({
   validationPanel: ReactNode | null;
   validationCount: number;
 }) {
+  const [hasMountedVersions, setHasMountedVersions] = useState(false);
   const selectTab = (tab: PluginDetailTab) => {
     setActiveTab(tab);
     if (typeof window === "undefined") return;
@@ -275,14 +276,15 @@ function PluginDetailTabs({
         : activeTab === "validation" && validationPanel
           ? "validation"
           : "readme";
+  useEffect(() => {
+    if (effectiveActiveTab === "versions") setHasMountedVersions(true);
+  }, [effectiveActiveTab]);
   const activePanel =
-    effectiveActiveTab === "versions"
-      ? versionsPanel
-      : effectiveActiveTab === "compatibility" && compatibilityPanel
-        ? compatibilityPanel
-        : effectiveActiveTab === "validation" && validationPanel
-          ? validationPanel
-          : readmePanel;
+    effectiveActiveTab === "compatibility" && compatibilityPanel
+      ? compatibilityPanel
+      : effectiveActiveTab === "validation" && validationPanel
+        ? validationPanel
+        : readmePanel;
 
   return (
     <div className="tab-card">
@@ -328,7 +330,12 @@ function PluginDetailTabs({
           </button>
         ) : null}
       </div>
-      <div className="tab-body">{activePanel}</div>
+      <div className="tab-body">
+        {effectiveActiveTab === "versions" ? null : activePanel}
+        {hasMountedVersions || effectiveActiveTab === "versions" ? (
+          <div hidden={effectiveActiveTab !== "versions"}>{versionsPanel}</div>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -13,7 +13,10 @@ import { InstallCopyButton } from "../../components/InstallCopyButton";
 import { Container } from "../../components/layout/Container";
 import { MarkdownPreview } from "../../components/MarkdownPreview";
 import { OfficialTag } from "../../components/OfficialBadge";
-import { PluginVersionsPanel } from "../../components/PluginVersionsPanel";
+import {
+  PLUGIN_VERSIONS_PAGE_SIZE,
+  PluginVersionsPanel,
+} from "../../components/PluginVersionsPanel";
 import { SidebarMetadata } from "../../components/SidebarMetadata";
 import { SkillDetailSkeleton } from "../../components/skeletons/SkillDetailSkeleton";
 import { Alert, AlertDescription } from "../../components/ui/alert";
@@ -128,10 +131,7 @@ export async function loadPluginDetail(requestedName: string): Promise<PluginDet
       detail.package.latestVersion
         ? fetchPackageVersion(resolvedName, detail.package.latestVersion)
         : Promise.resolve(null),
-      fetchPackageVersions(resolvedName, { limit: 100 }).catch((error: unknown) => {
-        if (isRateLimitedPackageApiError(error)) throw error;
-        return null;
-      }),
+      fetchPackageVersions(resolvedName, { limit: PLUGIN_VERSIONS_PAGE_SIZE }).catch(() => null),
       fetchPackageReadme(resolvedName),
     ]);
 
@@ -380,10 +380,7 @@ export function PluginDetailPage({
   const authorInspectorFindings = Array.isArray(inspectorFindings)
     ? inspectorFindings.filter((finding) => finding.authorRemediation?.summary)
     : undefined;
-  const [activeTab, setActiveTab] = useState<PluginDetailTab>(() => {
-    if (typeof window === "undefined") return "readme";
-    return pluginDetailTabFromHash(window.location.hash);
-  });
+  const [activeTab, setActiveTab] = useState<PluginDetailTab>("readme");
   useEffect(() => {
     const syncTabFromHash = () => setActiveTab(pluginDetailTabFromHash(window.location.hash));
     window.addEventListener("hashchange", syncTabFromHash);

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -356,13 +356,16 @@ export function PluginDetailPending() {
   );
 }
 
-export function PluginDetailPage({
-  name,
-  loaderData,
-}: {
+type PluginDetailPageProps = {
   name: string;
   loaderData: PluginDetailLoaderData;
-}) {
+};
+
+export function PluginDetailPage(props: PluginDetailPageProps) {
+  return <PluginDetailPageContent key={props.name} {...props} />;
+}
+
+function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
   const { detail, version, versions, readme, rateLimited } = loaderData;
   const pathname = useRouterState({ select: (state) => state.location.pathname });
   const { me } = useAuthStatus();

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -474,7 +474,7 @@ export function PluginDetailPage({
       <p className="empty-state-body">This plugin doesn't have a README yet.</p>
     </div>
   );
-  const versionsPanel = <PluginVersionsPanel packageName={pkg.name} versions={versions?.items} />;
+  const versionsPanel = <PluginVersionsPanel packageName={pkg.name} versions={versions} />;
   const compatibilityPanel =
     compatEntries.length > 0 || artifact ? (
       <div className="plugin-tab-panel">


### PR DESCRIPTION
## Summary

- add a plugin Versions tab backed by the existing active release-list API
- paginate release history while preserving tab state and isolating history-only failures
- reset tab and pagination state when navigating between plugin identities

## Proof

- [ClawHub UI Proof: desktop and mobile plugin Versions tab](https://github.com/openclaw/clawhub/pull/2646#issuecomment-4704256936)

## Tests

- `bunx vitest run src/lib/packageApi.test.ts src/__tests__/package-detail-route.test.tsx` (59 passed)
- `bunx vitest run convex/packages.public.test.ts -t 'hides soft-deleted releases from public version lists'` (1 passed)
- `bun run ci:static`
- `bun run ci:unit` (3,198 passed, 1 skipped)
- `bun run ci:types-build`
- `autoreview --mode branch --reviewer codex --fallback-reviewer none` (clean)
