### PR TITLE
fix: allow guarded transfer of deleted skills

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -6763,6 +6763,118 @@ describe("httpApiV1 handlers", () => {
     );
   });
 
+  it("allows platform admins to transfer soft-deleted skills", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:admin",
+      user: { _id: "users:admin", handle: "admin", role: "admin" },
+    } as never);
+
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ _id: "skills:deleted", slug: "deleted-demo", softDeletedAt: 123 })
+      .mockResolvedValueOnce({ _id: "publishers:team", kind: "org", handle: "team" });
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if ("key" in args) return okRate();
+      return {
+        ok: true,
+        transferred: true,
+        skillSlug: "deleted-demo",
+        toPublisherHandle: "team",
+      };
+    });
+
+    const response = await __handlers.skillsPostRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/deleted-demo/transfer", {
+        method: "POST",
+        headers: { Authorization: "Bearer clh_test", "content-type": "application/json" },
+        body: JSON.stringify({ toUserHandle: "@team", message: "Publisher recovery" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        actorUserId: "users:admin",
+        slug: "deleted-demo",
+        toOwner: "@team",
+        reason: "Publisher recovery",
+      }),
+    );
+  });
+
+  it("prefers a live merged-alias target before admin soft-delete recovery lookup", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:admin",
+      user: { _id: "users:admin", handle: "admin", role: "admin" },
+    } as never);
+
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce({ _id: "skills:canonical", slug: "canonical-demo" })
+      .mockResolvedValueOnce({ _id: "publishers:team", kind: "org", handle: "team" });
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if ("key" in args) return okRate();
+      return {
+        ok: true,
+        transferred: true,
+        skillSlug: "canonical-demo",
+        toPublisherHandle: "team",
+      };
+    });
+
+    const response = await __handlers.skillsPostRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/merged-demo/transfer", {
+        method: "POST",
+        headers: { Authorization: "Bearer clh_test", "content-type": "application/json" },
+        body: JSON.stringify({ toOwner: "@team" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        actorUserId: "users:admin",
+        slug: "canonical-demo",
+        toOwner: "@team",
+      }),
+    );
+    expect(runQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it("requires an audit reason for soft-deleted skill transfers", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:admin",
+      user: { _id: "users:admin", handle: "admin", role: "admin" },
+    } as never);
+
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ _id: "skills:deleted", slug: "deleted-demo", softDeletedAt: 123 });
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if ("key" in args) return okRate();
+      throw new Error(`unexpected mutation ${JSON.stringify(args)}`);
+    });
+    const ctx = makeCtx({ runQuery, runMutation });
+
+    const missingReason = await __handlers.skillsPostRouterV1Handler(
+      ctx,
+      new Request("https://example.com/api/v1/skills/deleted-demo/transfer", {
+        method: "POST",
+        headers: { Authorization: "Bearer clh_test", "content-type": "application/json" },
+        body: JSON.stringify({ toOwner: "@team" }),
+      }),
+    );
+
+    expect(missingReason.status).toBe(400);
+    expect(await missingReason.text()).toBe("message required for soft-deleted skill transfer");
+  });
+
   it("skill transfer maps ownership denials to 403", async () => {
     vi.mocked(requireApiTokenUser).mockResolvedValue({
       userId: "users:stranger",

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -2456,8 +2456,13 @@ async function resolveTransferContext(
   const auth = await requireApiTokenUserOrResponse(ctx, request, headers);
   if (!auth.ok) return auth;
 
-  const skill = await ctx.runQuery(internal.skills.getSkillBySlugInternal, { slug });
-  if (!skill || skill.softDeletedAt)
+  const liveSkill = await ctx.runQuery(internal.skills.getSkillBySlugInternal, { slug });
+  const skill =
+    liveSkill ??
+    (auth.user.role === "admin"
+      ? await ctx.runQuery(internal.skills.getSkillBySlugIncludingSoftDeletedInternal, { slug })
+      : null);
+  if (!skill || (skill.softDeletedAt && auth.user.role !== "admin"))
     return { ok: false, response: text("Skill not found", 404, headers) };
 
   return { ok: true, userId: auth.userId, skill };
@@ -2486,6 +2491,9 @@ async function handleTransferRequest(
   const toHandleRaw = toOwnerRaw || toUserHandleRaw;
   if (!toHandleRaw) return text("toUserHandle required", 400, headers);
   const message = typeof parsed.payload.message === "string" ? parsed.payload.message : undefined;
+  if (transferContext.skill.softDeletedAt && !message?.trim()) {
+    return text("message required for soft-deleted skill transfer", 400, headers);
+  }
 
   try {
     const publisher = (await ctx.runQuery(internal.publishers.getByHandleInternal, {
@@ -2493,7 +2501,12 @@ async function handleTransferRequest(
     })) as { kind?: "user" | "org"; handle?: string; linkedUserId?: Id<"users"> } | null;
     const isActorPersonalPublisher =
       publisher?.kind === "user" && publisher.linkedUserId === transferContext.userId;
-    if (toOwnerRaw || publisher?.kind === "org" || isActorPersonalPublisher) {
+    if (
+      transferContext.skill.softDeletedAt ||
+      toOwnerRaw ||
+      publisher?.kind === "org" ||
+      isActorPersonalPublisher
+    ) {
       const result = await ctx.runMutation(internal.skills.transferSkillOwnerForUserInternal, {
         actorUserId: transferContext.userId,
         slug: transferContext.skill.slug,

--- a/convex/lib/skillSafety.test.ts
+++ b/convex/lib/skillSafety.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  isSoftDeletedSkillEligibleForAdminTransfer,
   isSkillReviewFlagged,
   isSkillSuspicious,
   isSkillTransferBlockedByModeration,
@@ -69,6 +70,66 @@ describe("isSkillTransferBlockedByModeration", () => {
         moderationReason: undefined,
         moderationReasonCodes: undefined,
         softDeletedAt: 123,
+      }),
+    ).toBe(true);
+  });
+
+  it("allows admins to relocate clean soft-deleted skills without allowing unsafe moderation", () => {
+    expect(
+      isSoftDeletedSkillEligibleForAdminTransfer({
+        moderationStatus: "hidden",
+        moderationVerdict: "clean",
+        isSuspicious: false,
+        moderationFlags: undefined,
+        moderationReason: undefined,
+        moderationReasonCodes: undefined,
+        softDeletedAt: 123,
+      }),
+    ).toBe(true);
+    expect(
+      isSoftDeletedSkillEligibleForAdminTransfer({
+        moderationStatus: "hidden",
+        moderationVerdict: "malicious",
+        isSuspicious: false,
+        moderationFlags: undefined,
+        moderationReason: undefined,
+        moderationReasonCodes: undefined,
+        softDeletedAt: 123,
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks known administrative delete reasons even when the owner performed the action", () => {
+    for (const moderationReason of ["owner.merged", "user.banned", "security.redaction"]) {
+      expect(
+        isSoftDeletedSkillEligibleForAdminTransfer({
+          moderationStatus: "hidden",
+          moderationVerdict: "clean",
+          isSuspicious: false,
+          moderationFlags: undefined,
+          moderationReason,
+          moderationReasonCodes: undefined,
+          softDeletedAt: 123,
+        }),
+      ).toBe(false);
+    }
+  });
+
+  it("does not treat an ordinary duplicate relationship as merge provenance", () => {
+    expect(
+      isSoftDeletedSkillEligibleForAdminTransfer({
+        moderationStatus: "hidden",
+        moderationVerdict: "clean",
+        isSuspicious: false,
+        moderationFlags: undefined,
+        moderationReason: undefined,
+        moderationReasonCodes: undefined,
+        softDeletedAt: 123,
+        forkOf: {
+          skillId: "skills:canonical" as never,
+          kind: "duplicate",
+          at: 100,
+        },
       }),
     ).toBe(true);
   });

--- a/convex/lib/skillSafety.ts
+++ b/convex/lib/skillSafety.ts
@@ -1,6 +1,24 @@
 import type { Doc } from "../_generated/dataModel";
 import { verdictFromCodes } from "./moderationReasonCodes";
 
+type SkillTransferSafetyFields = Pick<
+  Doc<"skills">,
+  | "moderationStatus"
+  | "moderationVerdict"
+  | "isSuspicious"
+  | "moderationFlags"
+  | "moderationReason"
+  | "moderationReasonCodes"
+  | "softDeletedAt"
+  | "forkOf"
+>;
+
+const ADMIN_TRANSFER_DENIED_REASONS = new Set([
+  "owner.merged",
+  "user.banned",
+  "security.redaction",
+]);
+
 function isScannerSuspiciousReason(reason: string | undefined) {
   if (!reason) return false;
   return reason.startsWith("scanner.") && reason.endsWith(".suspicious");
@@ -22,24 +40,10 @@ export function isSkillBlockedByMalware(skill: Pick<Doc<"skills">, "moderationFl
   return skill.moderationFlags?.includes("blocked.malware") ?? false;
 }
 
-export function isSkillTransferBlockedByModeration(
-  skill: Pick<
-    Doc<"skills">,
-    | "moderationStatus"
-    | "moderationVerdict"
-    | "isSuspicious"
-    | "moderationFlags"
-    | "moderationReason"
-    | "moderationReasonCodes"
-    | "softDeletedAt"
-  >,
-) {
-  const moderationStatus = skill.moderationStatus ?? "active";
+function hasUnsafeSkillTransferModeration(skill: SkillTransferSafetyFields) {
   const moderationVerdict =
     skill.moderationVerdict ?? verdictFromCodes(skill.moderationReasonCodes ?? []);
   return (
-    skill.softDeletedAt !== undefined ||
-    moderationStatus !== "active" ||
     moderationVerdict === "suspicious" ||
     moderationVerdict === "malicious" ||
     skill.isSuspicious ||
@@ -47,6 +51,25 @@ export function isSkillTransferBlockedByModeration(
     isSkillBlockedByMalware(skill) ||
     isSkillSuspicious(skill) ||
     isScannerMaliciousReason(skill.moderationReason)
+  );
+}
+
+export function isSoftDeletedSkillEligibleForAdminTransfer(skill: SkillTransferSafetyFields) {
+  // Hide actor provenance requires DB-backed publisher authorization and is checked transactionally.
+  return (
+    skill.softDeletedAt !== undefined &&
+    (skill.moderationStatus === undefined || skill.moderationStatus === "hidden") &&
+    !ADMIN_TRANSFER_DENIED_REASONS.has(skill.moderationReason ?? "") &&
+    !hasUnsafeSkillTransferModeration(skill)
+  );
+}
+
+export function isSkillTransferBlockedByModeration(skill: SkillTransferSafetyFields) {
+  const moderationStatus = skill.moderationStatus ?? "active";
+  return (
+    skill.softDeletedAt !== undefined ||
+    moderationStatus !== "active" ||
+    hasUnsafeSkillTransferModeration(skill)
   );
 }
 

--- a/convex/skills.ownership.test.ts
+++ b/convex/skills.ownership.test.ts
@@ -610,6 +610,245 @@ describe("skills ownership", () => {
     );
   });
 
+  it("allows platform admins to transfer a soft-deleted skill without restoring it", async () => {
+    const patch = vi.fn(async () => {});
+    const insert = vi.fn(async () => "auditLogs:1");
+    const softDeletedAt = 123;
+    const skill = {
+      _id: "skills:deleted",
+      slug: "deleted-demo",
+      displayName: "Deleted Demo",
+      ownerUserId: "users:owner",
+      ownerPublisherId: "publishers:previous",
+      softDeletedAt,
+      hiddenBy: "users:admin",
+      moderationStatus: "hidden",
+      moderationVerdict: "clean",
+      forkOf: undefined as
+        | {
+            skillId: string;
+            kind: "duplicate";
+            at: number;
+          }
+        | undefined,
+      stats: defaultSkillStats,
+    };
+    let hideAuditActorRole: "admin" | "moderator" | "user" = "user";
+    let ownerCurrentRole: "admin" | "moderator" | "user" = "user";
+    let hasMergeAudit = false;
+
+    const ctx = {
+      db: {
+        normalizeId: vi.fn(() => null),
+        get: vi.fn(async (id: string) => {
+          if (id === "users:admin") return { _id: "users:admin", role: "admin" };
+          if (id === "users:owner") return { _id: "users:owner", role: ownerCurrentRole };
+          if (id === "publishers:previous") {
+            return {
+              _id: "publishers:previous",
+              kind: "user",
+              handle: "owner",
+              linkedUserId: "users:owner",
+            };
+          }
+          if (id === "publishers:team") {
+            return {
+              _id: "publishers:team",
+              kind: "org",
+              handle: "team",
+              displayName: "Team",
+            };
+          }
+          return null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table === "skills") {
+            return {
+              withIndex: (name: string, build: (q: ReturnType<typeof chainEq>) => unknown) => {
+                const constraints: Record<string, unknown> = {};
+                build(chainEq(constraints));
+                if (name !== "by_slug") throw new Error(`unexpected skills index ${name}`);
+                return {
+                  unique: async () => (constraints.slug === "deleted-demo" ? skill : null),
+                };
+              },
+            };
+          }
+          if (table === "publishers") {
+            return {
+              withIndex: (name: string) => {
+                if (name !== "by_handle") throw new Error(`unexpected publishers index ${name}`);
+                return {
+                  unique: async () => ({
+                    _id: "publishers:team",
+                    kind: "org",
+                    handle: "team",
+                    displayName: "Team",
+                    deletedAt: undefined,
+                    deactivatedAt: undefined,
+                  }),
+                };
+              },
+            };
+          }
+          if (table === "auditLogs") {
+            return {
+              withIndex: (name: string, build: (q: ReturnType<typeof chainEq>) => unknown) => {
+                const constraints: Record<string, unknown> = {};
+                build(chainEq(constraints));
+                if (name !== "by_target_createdAt") {
+                  throw new Error(`unexpected auditLogs index ${name}`);
+                }
+                return {
+                  take: async () => {
+                    if (constraints.createdAt === softDeletedAt) {
+                      return [
+                        {
+                          _id: "auditLogs:delete",
+                          action: "skill.delete",
+                          actorUserId: skill.hiddenBy,
+                          targetType: "skill",
+                          targetId: skill._id,
+                          createdAt: softDeletedAt,
+                          metadata: {
+                            actorRole: hideAuditActorRole,
+                            softDeletedAt,
+                          },
+                        },
+                      ];
+                    }
+                    const duplicate = skill.forkOf;
+                    if (hasMergeAudit && duplicate && constraints.createdAt === duplicate.at) {
+                      return [
+                        {
+                          _id: "auditLogs:merge",
+                          action: "skill.merge",
+                          actorUserId: skill.hiddenBy,
+                          targetType: "skill",
+                          targetId: skill._id,
+                          createdAt: duplicate.at,
+                          metadata: {
+                            targetSkillId: duplicate.skillId,
+                          },
+                        },
+                      ];
+                    }
+                    return [];
+                  },
+                };
+              },
+            };
+          }
+          if (table === "skillSlugAliases") {
+            return {
+              withIndex: (name: string) => {
+                if (name !== "by_skill") {
+                  throw new Error(`unexpected skillSlugAliases index ${name}`);
+                }
+                return { collect: async () => [] };
+              },
+            };
+          }
+          if (table === "skillEmbeddings") {
+            return {
+              withIndex: (name: string) => {
+                if (name !== "by_skill")
+                  throw new Error(`unexpected skillEmbeddings index ${name}`);
+                return { collect: async () => [] };
+              },
+            };
+          }
+          if (table === "skillSearchDigest") {
+            return {
+              withIndex: (name: string) => {
+                if (name !== "by_skill") {
+                  throw new Error(`unexpected skillSearchDigest index ${name}`);
+                }
+                return { unique: async () => ({ _id: "skillSearchDigest:deleted" }) };
+              },
+            };
+          }
+          throw new Error(`unexpected table ${table}`);
+        }),
+        patch,
+        insert,
+      },
+    } as never;
+
+    await expect(
+      transferSkillOwnerForUserInternalHandler(ctx, {
+        actorUserId: "users:admin",
+        slug: "deleted-demo",
+        toOwner: "team",
+        reason: "Publisher recovery",
+      }),
+    ).rejects.toThrow("Skill is not eligible for ownership transfer while under moderation");
+
+    skill.hiddenBy = "users:owner";
+
+    hideAuditActorRole = "moderator";
+    await expect(
+      transferSkillOwnerForUserInternalHandler(ctx, {
+        actorUserId: "users:admin",
+        slug: "deleted-demo",
+        toOwner: "team",
+        reason: "Publisher recovery",
+      }),
+    ).rejects.toThrow("Skill is not eligible for ownership transfer while under moderation");
+
+    hideAuditActorRole = "user";
+    skill.forkOf = {
+      skillId: "skills:canonical",
+      kind: "duplicate",
+      at: 100,
+    };
+    hasMergeAudit = true;
+    await expect(
+      transferSkillOwnerForUserInternalHandler(ctx, {
+        actorUserId: "users:admin",
+        slug: "deleted-demo",
+        toOwner: "team",
+        reason: "Publisher recovery",
+      }),
+    ).rejects.toThrow("Skill is not eligible for ownership transfer while under moderation");
+    hasMergeAudit = false;
+
+    // Deletion-time audit provenance remains authoritative after a later staff promotion.
+    ownerCurrentRole = "admin";
+    await expect(
+      transferSkillOwnerForUserInternalHandler(ctx, {
+        actorUserId: "users:admin",
+        slug: "deleted-demo",
+        toOwner: "team",
+      }),
+    ).rejects.toThrow("Reason required for soft-deleted skill ownership transfer");
+
+    const result = await transferSkillOwnerForUserInternalHandler(ctx, {
+      actorUserId: "users:admin",
+      slug: "deleted-demo",
+      toOwner: "team",
+      reason: "Publisher recovery",
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      transferred: true,
+      skillSlug: "deleted-demo",
+      toPublisherHandle: "team",
+    });
+    expect(patch).toHaveBeenCalledWith(
+      "skills:deleted",
+      expect.objectContaining({
+        ownerUserId: "users:admin",
+        ownerPublisherId: "publishers:team",
+      }),
+    );
+    expect(patch).not.toHaveBeenCalledWith(
+      "skills:deleted",
+      expect.objectContaining({ softDeletedAt: undefined }),
+    );
+  });
+
   it("rejects stale personal publisher memberships as skill transfer destinations", async () => {
     const patch = vi.fn(async () => {});
     const skill = {

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -118,6 +118,7 @@ import {
 import { getFrontmatterValue, hashSkillFiles } from "./lib/skills";
 import {
   computeIsSuspicious,
+  isSoftDeletedSkillEligibleForAdminTransfer,
   isSkillReviewFlagged,
   isSkillSuspicious,
   isSkillTransferBlockedByModeration,
@@ -9872,6 +9873,7 @@ async function transferSkillOwnershipAndEmbeddings(
     ownerUserId: Id<"users">;
     ownerPublisherId?: Id<"publishers"> | null;
     now: number;
+    allowSoftDeleted?: boolean;
   },
 ) {
   const patch: Partial<Doc<"skills">> = {
@@ -9887,7 +9889,10 @@ async function transferSkillOwnershipAndEmbeddings(
   const publisherChanged =
     "ownerPublisherId" in params && params.skill.ownerPublisherId !== params.ownerPublisherId;
   if (!ownerChanged && !publisherChanged) return;
-  if (isSkillTransferBlockedByModeration(params.skill)) {
+  if (
+    isSkillTransferBlockedByModeration(params.skill) &&
+    !(params.allowSoftDeleted && isSoftDeletedSkillEligibleForAdminTransfer(params.skill))
+  ) {
     throw new ConvexError("Skill is not eligible for ownership transfer while under moderation");
   }
 
@@ -9939,6 +9944,8 @@ async function canManagePublisherDestination(
   actor: Doc<"users">,
   publisher: Doc<"publishers">,
 ) {
+  // Platform-admin transfers are audited staff recovery/moderation operations,
+  // so they may select any verified active destination without publisher membership.
   if (actor.role === "admin") return true;
   if (publisher.kind === "user") {
     return publisher.linkedUserId
@@ -9966,7 +9973,9 @@ export const transferSkillOwnerForUserInternal = internalMutation({
       .query("skills")
       .withIndex("by_slug", (q) => q.eq("slug", slug))
       .unique();
-    if (!skill || skill.softDeletedAt) throw new ConvexError("Skill not found");
+    if (!skill || (skill.softDeletedAt && actor.role !== "admin")) {
+      throw new ConvexError("Skill not found");
+    }
 
     await assertCanManageOwnedResource(ctx, {
       actor,
@@ -9975,8 +9984,15 @@ export const transferSkillOwnerForUserInternal = internalMutation({
       allowedPublisherRoles: ["admin"],
       allowPlatformAdmin: true,
     });
-    if (isSkillTransferBlockedByModeration(skill)) {
+    const allowSoftDeletedTransfer =
+      actor.role === "admin" &&
+      isSoftDeletedSkillEligibleForAdminTransfer(skill) &&
+      (await isOwnerInitiatedSkillHideForAdminTransfer(ctx, skill));
+    if (isSkillTransferBlockedByModeration(skill) && !allowSoftDeletedTransfer) {
       throw new ConvexError("Skill is not eligible for ownership transfer while under moderation");
+    }
+    if (allowSoftDeletedTransfer && !args.reason?.trim()) {
+      throw new ConvexError("Reason required for soft-deleted skill ownership transfer");
     }
 
     const destinationHandle = normalizePublisherHandle(args.toOwner);
@@ -10005,6 +10021,7 @@ export const transferSkillOwnerForUserInternal = internalMutation({
       ownerUserId: nextOwner._id,
       ownerPublisherId: destinationPublisher._id,
       now,
+      allowSoftDeleted: allowSoftDeletedTransfer,
     });
     await syncSkillSearchDigestForSkillDoc(ctx, {
       ...skill,
@@ -11295,6 +11312,70 @@ async function isOwnerInitiatedSkillHideForActor(
   const hiddenBy = await ctx.db.get(skill.hiddenBy);
   if (!hiddenBy || hiddenBy.deletedAt || hiddenBy.deactivatedAt) return false;
   if (hiddenBy.role === "admin" || hiddenBy.role === "moderator") return false;
+
+  try {
+    await assertCanManageOwnedResource(ctx, {
+      actor: hiddenBy,
+      ownerUserId: skill.ownerUserId,
+      ownerPublisherId: skill.ownerPublisherId,
+      allowedPublisherRoles: ["admin"],
+    });
+    return true;
+  } catch (error) {
+    if (error instanceof ConvexError || error instanceof Error) return false;
+    throw error;
+  }
+}
+
+async function isOwnerInitiatedSkillHideForAdminTransfer(
+  ctx: MutationCtx,
+  skill: Pick<
+    Doc<"skills">,
+    "_id" | "ownerUserId" | "ownerPublisherId" | "hiddenBy" | "softDeletedAt" | "forkOf"
+  >,
+) {
+  if (!skill.hiddenBy || skill.softDeletedAt === undefined) return false;
+  const softDeletedAt = skill.softDeletedAt;
+  const hiddenBy = await ctx.db.get(skill.hiddenBy);
+  if (!hiddenBy || hiddenBy.deletedAt || hiddenBy.deactivatedAt) return false;
+
+  const hideAuditLogs = await ctx.db
+    .query("auditLogs")
+    .withIndex("by_target_createdAt", (q) =>
+      q.eq("targetType", "skill").eq("targetId", skill._id).eq("createdAt", softDeletedAt),
+    )
+    .take(10);
+  const hasOrdinaryOwnerDeleteAudit = hideAuditLogs.some((log) => {
+    const metadata =
+      typeof log.metadata === "object" && log.metadata !== null
+        ? (log.metadata as Record<string, unknown>)
+        : null;
+    return (
+      log.action === "skill.delete" &&
+      log.actorUserId === skill.hiddenBy &&
+      metadata?.actorRole === "user" &&
+      metadata.softDeletedAt === softDeletedAt
+    );
+  });
+  if (!hasOrdinaryOwnerDeleteAudit) return false;
+
+  const duplicate = skill.forkOf?.kind === "duplicate" ? skill.forkOf : null;
+  if (duplicate) {
+    const relationshipAuditLogs = await ctx.db
+      .query("auditLogs")
+      .withIndex("by_target_createdAt", (q) =>
+        q.eq("targetType", "skill").eq("targetId", skill._id).eq("createdAt", duplicate.at),
+      )
+      .take(10);
+    const hasMergeProvenance = relationshipAuditLogs.some((log) => {
+      const metadata =
+        typeof log.metadata === "object" && log.metadata !== null
+          ? (log.metadata as Record<string, unknown>)
+          : null;
+      return log.action === "skill.merge" && metadata?.targetSkillId === duplicate.skillId;
+    });
+    if (hasMergeProvenance) return false;
+  }
 
   try {
     await assertCanManageOwnedResource(ctx, {

--- a/specs/orgs.md
+++ b/specs/orgs.md
@@ -173,8 +173,14 @@ Use dual fields during rollout:
   administer both the current owner and destination publisher. User-to-user skill
   transfers remain recipient-accepted unless the actor controls the destination
   publisher.
-- No ownership transfer path should move a skill while it is hidden, removed,
-  suspicious, or malicious; the artifact must be cleared by moderation first.
+- Ownership transfer paths must not move hidden, removed, suspicious, or
+  malicious skills. The narrow exception is a platform-admin publisher recovery
+  that directly relocates a clean, owner-deleted skill without restoring it. The
+  current hide must have been written by a non-staff owner or publisher admin,
+  proven by the matching `skill.delete` audit event at the current deletion
+  timestamp; the platform admin must explicitly select an active destination,
+  and the audited transfer must include a reason. Moderator, scanner, ban,
+  security, merge, and unknown-provenance hides remain blocked.
 
 ## Naming Rules
 


### PR DESCRIPTION
## Summary
- allow platform admins to transfer clean owner-deleted skills without restoring them
- require exact deletion audit proof, block merge/moderation/system hides, and require a recovery reason
- preserve live merged-alias resolution before the soft-deleted recovery lookup

## Validation
- `bunx vitest run convex/httpApiV1.handlers.test.ts convex/skills.ownership.test.ts convex/lib/skillSafety.test.ts` (326 passed)
- `bun run ci:static`
- `bun run ci:unit` (3190 passed, 1 skipped)
- `bun run ci:types-build`
- final diff review: no accepted/actionable findings

## Review Notes
- Local real-Convex validation remains blocked by pre-existing fixture/schema drift on `packageReleases.clawScanNote`; the production backend deploy and guarded API transfer will provide runtime proof.
