### PR TITLE
fix: show publisher installs on profiles

### DIFF
--- a/src/__tests__/user-profile-route.test.tsx
+++ b/src/__tests__/user-profile-route.test.tsx
@@ -1,0 +1,87 @@
+/* @vitest-environment jsdom */
+
+import { render, screen, within } from "@testing-library/react";
+import type { ComponentType, ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { loaderDataMock, paginatedQueryMock, queryMock } = vi.hoisted(() => ({
+  loaderDataMock: vi.fn(),
+  paginatedQueryMock: vi.fn(),
+  queryMock: vi.fn(),
+}));
+
+vi.mock("convex/react", () => ({
+  usePaginatedQuery: (...args: unknown[]) => paginatedQueryMock(...args),
+  useQuery: (...args: unknown[]) => queryMock(...args),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (config: { component?: unknown; head?: unknown; loader?: unknown }) => ({
+    __config: config,
+    useLoaderData: () => loaderDataMock(),
+    useParams: () => ({ handle: "nvidia" }),
+  }),
+  Link: ({ children, to }: { children: ReactNode; to?: string }) => (
+    <a href={to ?? "/test"}>{children}</a>
+  ),
+  notFound: () => ({ notFound: true }),
+}));
+
+async function loadRoute() {
+  return (await import("../routes/user/$handle")).Route as unknown as {
+    __config: {
+      component?: ComponentType;
+    };
+  };
+}
+
+const publisher = {
+  _id: "publishers:nvidia",
+  _creationTime: 1,
+  bio: "Official NVIDIA publisher.",
+  displayName: "NVIDIA",
+  handle: "nvidia",
+  image: null,
+  kind: "org" as const,
+  official: true,
+  publishedItems: [],
+  stats: {
+    downloads: 0,
+    installs: 27,
+    packages: 0,
+    skills: 136,
+    stars: 0,
+  },
+};
+
+describe("user profile route", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    loaderDataMock.mockReset();
+    loaderDataMock.mockReturnValue({ publisher });
+    paginatedQueryMock.mockReset();
+    paginatedQueryMock.mockReturnValue({
+      loadMore: vi.fn(),
+      results: [],
+      status: "Exhausted",
+    });
+    queryMock.mockReset();
+    queryMock.mockImplementation((_query, args: Record<string, unknown>) => {
+      if ("publisherHandle" in args) return { publisher, members: [] };
+      if ("kind" in args) return null;
+      return publisher;
+    });
+  });
+
+  it("shows total installs instead of downloads in the publisher header", async () => {
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    const stats = screen.getByLabelText("Publisher stats");
+    expect(within(stats).getByText("27")).toBeTruthy();
+    expect(within(stats).getByText("installs")).toBeTruthy();
+    expect(within(stats).queryByText("downloads")).toBeNull();
+  });
+});

--- a/src/routes/user/$handle.tsx
+++ b/src/routes/user/$handle.tsx
@@ -235,8 +235,8 @@ function PublisherProfile() {
             <div className="publisher-profile-hero-stats" aria-label="Publisher stats">
               <PublisherStat
                 icon={ArrowDownToLine}
-                value={formatCompactStat(publisher.stats.downloads)}
-                label="downloads"
+                value={formatCompactStat(publisher.stats.installs)}
+                label="installs"
               />
               <PublisherStat
                 icon={Star}


### PR DESCRIPTION
## Summary
- show aggregate installs instead of downloads in publisher profile headers
- add a regression test that distinguishes installs from downloads

## Tests
- `bun run test src/__tests__/user-profile-route.test.tsx` (pass)
- `bunx tsc --noEmit` (pass)
- `bun run ci:static` (exit 0; Knip logged local `h3-v2` resolution warnings)
- `bun run ci:unit` (blocked locally by coverage/dependency-tree errors after the suite ran)
- `bun run ci:types-build` (blocked locally: missing `h3-v2` from the installed dependency tree)

## Review Notes
- Autoreview skipped at requester direction.
- Local browser proof was blocked by the same missing `h3-v2` dependency resolution error; CI should validate from a clean install.
