### PR TITLE
fix: move GitHub source sync to Node runtime

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -26,6 +26,7 @@ import type * as githubIdentity from "../githubIdentity.js";
 import type * as githubImport from "../githubImport.js";
 import type * as githubSkillSources from "../githubSkillSources.js";
 import type * as githubSkillSync from "../githubSkillSync.js";
+import type * as githubSkillSyncNode from "../githubSkillSyncNode.js";
 import type * as http from "../http.js";
 import type * as httpApi from "../httpApi.js";
 import type * as httpApiV1 from "../httpApiV1.js";
@@ -170,6 +171,7 @@ declare const fullApi: ApiFromModules<{
   githubImport: typeof githubImport;
   githubSkillSources: typeof githubSkillSources;
   githubSkillSync: typeof githubSkillSync;
+  githubSkillSyncNode: typeof githubSkillSyncNode;
   http: typeof http;
   httpApi: typeof httpApi;
   httpApiV1: typeof httpApiV1;

--- a/convex/crons.test.ts
+++ b/convex/crons.test.ts
@@ -19,7 +19,7 @@ vi.mock("./_generated/api", () => ({
     registryArtifactBackupsNode: {
       processRegistryArtifactBackupRetriesInternal: mocks.registryArtifactBackupRetryRef,
     },
-    githubSkillSync: { syncGitHubSkillSourcesInternal: mocks.githubSkillSyncRef },
+    githubSkillSyncNode: { syncGitHubSkillSourcesInternal: mocks.githubSkillSyncRef },
     leaderboards: { rebuildTrendingLeaderboardAction: Symbol("trending-leaderboard") },
     statsMaintenance: {
       runSkillStatBackfillInternal: Symbol("skill-stats-backfill"),

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -13,7 +13,7 @@ crons.interval(
 crons.interval(
   "github-skill-source-sync",
   { minutes: 15 },
-  internal.githubSkillSync.syncGitHubSkillSourcesInternal,
+  internal.githubSkillSyncNode.syncGitHubSkillSourcesInternal,
   {},
 );
 

--- a/convex/githubSkillSync.test.ts
+++ b/convex/githubSkillSync.test.ts
@@ -1,3 +1,4 @@
+import { getFunctionName } from "convex/server";
 import { zipSync } from "fflate";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -505,6 +506,30 @@ describe("syncGitHubSkillSourcesHandler", () => {
     } finally {
       consoleLog.mockRestore();
     }
+  });
+
+  it("continues paginated scheduled syncs in the Node runtime", async () => {
+    const scheduler = {
+      runAfter: vi.fn(
+        async (_delayMs: number, _functionRef: unknown, _args: Record<string, unknown>) =>
+          undefined,
+      ),
+    };
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce({ sources: [], continueCursor: "next-page", isDone: false });
+
+    const result = await syncGitHubSkillSourcesHandler(
+      { runQuery, runMutation: vi.fn(), scheduler } as never,
+      {},
+      vi.fn() as never,
+    );
+
+    expect(result).toMatchObject({ scheduledNext: true, cursor: "next-page", isDone: false });
+    const scheduledFunction = scheduler.runAfter.mock.calls[0]?.[1];
+    expect(getFunctionName(scheduledFunction as Parameters<typeof getFunctionName>[0])).toBe(
+      "githubSkillSyncNode:syncGitHubSkillSourcesInternal",
+    );
   });
 
   it("rechecks repo visibility before scheduled syncs", async () => {
@@ -1396,7 +1421,12 @@ describe("applyGitHubSkillSourceSyncHandler", () => {
         },
       ],
     });
-    const scheduler = { runAfter: vi.fn(async () => undefined) };
+    const scheduler = {
+      runAfter: vi.fn(
+        async (_delayMs: number, _functionRef: unknown, _args: Record<string, unknown>) =>
+          undefined,
+      ),
+    };
 
     await applyGitHubSkillSourceSyncHandler({ db, scheduler } as never, {
       sourceId: "githubSkillSources:nvidia" as never,
@@ -1411,6 +1441,10 @@ describe("applyGitHubSkillSourceSyncHandler", () => {
       skillId: "skills:new-1",
       contentHash: snapshot.skills[0]?.contentHash,
     });
+    const scheduledFunction = scheduler.runAfter.mock.calls[0]?.[1];
+    expect(getFunctionName(scheduledFunction as Parameters<typeof getFunctionName>[0])).toBe(
+      "githubSkillSyncNode:verifyGitHubSkillInternal",
+    );
   });
 
   it("refreshes cached GitHub content metadata when bytes are unchanged at a new commit", async () => {

--- a/convex/githubSkillSync.ts
+++ b/convex/githubSkillSync.ts
@@ -3,7 +3,7 @@ import { unzipSync, type UnzipFileInfo } from "fflate";
 import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import type { ActionCtx, MutationCtx, QueryCtx } from "./_generated/server";
-import { action, internalAction, internalMutation, internalQuery } from "./functions";
+import { action, internalMutation, internalQuery } from "./functions";
 import { assertAdmin, requireUserFromAction } from "./lib/access";
 import { buildGitHubApiHeaders } from "./lib/githubAuth";
 import {
@@ -786,7 +786,7 @@ async function scheduleGitHubSkillVerification(
   },
 ) {
   if (args.scanStatus !== "pending") return;
-  await ctx.scheduler?.runAfter(0, internal.githubSkillSync.verifyGitHubSkillInternal, {
+  await ctx.scheduler?.runAfter(0, internal.githubSkillSyncNode.verifyGitHubSkillInternal, {
     skillId: args.skillId,
     contentHash: args.contentHash,
   });
@@ -906,14 +906,6 @@ export async function verifyGitHubSkillHandler(
     scanStatus: staticScan.status,
   };
 }
-
-export const verifyGitHubSkillInternal = internalAction({
-  args: {
-    skillId: v.id("skills"),
-    contentHash: v.string(),
-  },
-  handler: verifyGitHubSkillHandler,
-});
 
 export async function configurePublicGitHubSkillSourceHandler(
   ctx: ActionCtx,
@@ -1160,7 +1152,7 @@ export async function syncGitHubSkillSourcesHandler(
 
   let scheduledNext = false;
   if (!page.isDone && page.continueCursor && ctx.scheduler) {
-    await ctx.scheduler.runAfter(0, internal.githubSkillSync.syncGitHubSkillSourcesInternal, {
+    await ctx.scheduler.runAfter(0, internal.githubSkillSyncNode.syncGitHubSkillSourcesInternal, {
       cursor: page.continueCursor,
       batchSize,
     });
@@ -1178,21 +1170,6 @@ export async function syncGitHubSkillSourcesHandler(
     results,
   };
 }
-
-export const syncGitHubSkillSourcesInternal = internalAction({
-  args: {
-    cursor: v.optional(v.union(v.string(), v.null())),
-    batchSize: v.optional(v.number()),
-  },
-  handler: async (ctx, args) => {
-    try {
-      return await syncGitHubSkillSourcesHandler(ctx, args);
-    } catch (error) {
-      logErrorEvent(Events.GitHubSkillSourceSyncFailed, { error: getErrorMessage(error) });
-      throw error;
-    }
-  },
-});
 
 async function fetchGitHubSkillSourceSnapshot(
   {

--- a/convex/githubSkillSyncNode.ts
+++ b/convex/githubSkillSyncNode.ts
@@ -1,0 +1,39 @@
+"use node";
+
+import { v } from "convex/values";
+import { internalAction } from "./functions";
+import { syncGitHubSkillSourcesHandler, verifyGitHubSkillHandler } from "./githubSkillSync";
+import { Events, logErrorEvent } from "./lib/observabilityEvents";
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return String(error);
+}
+
+export const syncGitHubSkillSourcesInternal = internalAction({
+  args: {
+    cursor: v.optional(v.union(v.string(), v.null())),
+    batchSize: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    try {
+      return await syncGitHubSkillSourcesHandler(ctx, args);
+    } catch (error) {
+      logErrorEvent(Events.GitHubSkillSourceSyncFailed, { error: getErrorMessage(error) });
+      throw error;
+    }
+  },
+});
+
+export const verifyGitHubSkillInternal = internalAction({
+  args: {
+    skillId: v.id("skills"),
+    contentHash: v.string(),
+  },
+  handler: verifyGitHubSkillHandler,
+});

--- a/specs/github-backed-skills.md
+++ b/specs/github-backed-skills.md
@@ -83,12 +83,17 @@ ClawHub.
 The production cron runs every 15 minutes:
 
 ```text
-github-skill-source-sync -> githubSkillSync.syncGitHubSkillSourcesInternal
+github-skill-source-sync -> githubSkillSyncNode.syncGitHubSkillSourcesInternal
 ```
 
-That cron fetches the current public GitHub repo, reads `skills.sh.json`, builds
-a source snapshot, and applies it to ClawHub. Pagination must use a stable source
-cursor, not `updatedAt`, because syncing a row updates the row.
+That cron runs in Convex's Node runtime because fetching and expanding a source
+archive can exceed the default action runtime's memory limit. It fetches the
+current public GitHub repo, reads `skills.sh.json`, builds a source snapshot, and
+applies it to ClawHub. Pagination must use a stable source cursor, not
+`updatedAt`, because syncing a row updates the row. Cursor continuations must
+remain on the Node runtime action. Per-skill verification also fetches and
+expands the source archive, so verification actions must run in the Node runtime
+as well.
 
 Sync must not pass the full repo Markdown payload through one large Convex
 mutation. The intended split is:


### PR DESCRIPTION
## Summary
- run scheduled GitHub-backed source syncs and cursor continuations in Convex's Node runtime
- run source-backed skill verification in the Node runtime to avoid the same archive-expansion OOM
- document and regression-test the Node runtime boundary

## Tests
- `bunx vitest run convex/crons.test.ts convex/githubSkillSync.test.ts`
- `bunx vitest run`
- `bun run ci:types-build`
- `bunx tsc --noEmit`
- `bunx convex dev --once --typecheck=disable`
- `bunx convex run githubSkillSyncNode:syncGitHubSkillSourcesInternal '{"batchSize":1}'`
- `CLAWHUB_LIVE_GITHUB_CANARY=1 CLAWHUB_LIVE_GITHUB_REPO=NVIDIA/skills CLAWHUB_LIVE_GITHUB_SKILL=aiq-deploy bunx vitest run convex/githubSkillSync.live.test.ts`
- autoreview: clean, no accepted/actionable findings
- CI passing: unit, packages, types-build, e2e-http, CodeQL, secret scanning

## Unrelated CI failures
- `static` stops at `bun audit` on the newly surfaced transitive `ws <8.21.0` advisory `GHSA-96hv-2xvq-fx4p`; `main` has the same lockfile/audit command and a local rerun reproduces it independently of this patch.
- `playwright-smoke` reaches the production-data-backed `/plugins/gc-provider` page, then its local preview `_vercel/image` request for an external README image returns 404. The trace confirms the page itself rendered successfully; this patch does not touch UI, plugin routes, or image handling.
