### PR TITLE
Finish install-based package recommendation behavior

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -8037,6 +8037,66 @@ describe("httpApiV1 handlers", () => {
     );
   });
 
+  it("plugins list defaults filtered browse to updated sort", async () => {
+    const readinessCalls: unknown[] = [];
+    const runQuery = vi.fn((_, args: Record<string, unknown>) => {
+      if (hasPluginRecommendedScoreReadinessArgs(args)) {
+        readinessCalls.push(args);
+        return false;
+      }
+      return { page: [], isDone: true, continueCursor: "" };
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.listPluginsV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/plugins?category=data&limit=7"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(readinessCalls).toEqual([]);
+    for (const [, args] of runQuery.mock.calls) {
+      if (hasPluginRecommendedScoreReadinessArgs(args)) continue;
+      expect(args).toEqual(
+        expect.objectContaining({
+          category: "data",
+          sort: "updated",
+          paginationOpts: { cursor: null, numItems: 7 },
+        }),
+      );
+    }
+  });
+
+  it("plugins list defaults capability-filtered browse to updated sort", async () => {
+    const readinessCalls: unknown[] = [];
+    const runQuery = vi.fn((_, args: Record<string, unknown>) => {
+      if (hasPluginRecommendedScoreReadinessArgs(args)) {
+        readinessCalls.push(args);
+        return false;
+      }
+      return { page: [], isDone: true, continueCursor: "" };
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.listPluginsV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/plugins?capabilityTag=tools&limit=7"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(readinessCalls).toEqual([]);
+    for (const [, args] of runQuery.mock.calls) {
+      if (hasPluginRecommendedScoreReadinessArgs(args)) continue;
+      expect(args).toEqual(
+        expect.objectContaining({
+          capabilityTag: "tools",
+          sort: "updated",
+          paginationOpts: { cursor: null, numItems: 7 },
+        }),
+      );
+    }
+  });
+
   it("plugins list install sort forwards to both plugin families and merges by installs", async () => {
     const codePlugin = makeCatalogItem("code-installed", {
       family: "code-plugin",

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -7774,6 +7774,7 @@ describe("httpApiV1 handlers", () => {
       stats: { downloads: 1, installs: 500, stars: 0, versions: 1 },
     });
     const runQuery = vi.fn((_, args: Record<string, unknown>) => {
+      if (Object.keys(args).length === 0) return false;
       expect(args).toEqual(expect.objectContaining({ sort: "recommended" }));
       if (Object.hasOwn(args, "viewerUserId")) {
         return { page: [pluginPackage], isDone: true, continueCursor: "" };
@@ -7793,7 +7794,43 @@ describe("httpApiV1 handlers", () => {
       "skill-installed",
       "plugin-downloaded",
     ]);
-    expect(runQuery).toHaveBeenCalledTimes(2);
+    expect(runQuery).toHaveBeenCalledTimes(4);
+  });
+
+  it("packages list recommended fallback merges package and skill rows by updated time", async () => {
+    const pluginPackage = makeCatalogItem("plugin-newer-low-score", {
+      family: "code-plugin",
+      updatedAt: 300,
+      stats: { downloads: 1, installs: 0, stars: 0, versions: 1 },
+    });
+    const skillPackage = makeCatalogItem("skill-older-high-score", {
+      family: "skill",
+      updatedAt: 200,
+      stats: { downloads: 100, installs: 100, stars: 10, versions: 1 },
+    });
+    const runQuery = vi.fn((_, args: Record<string, unknown>) => {
+      if (Object.keys(args).length === 0) return true;
+      if (Object.hasOwn(args, "viewerUserId")) {
+        expect(args).toEqual(expect.objectContaining({ sort: "updated" }));
+        return { page: [pluginPackage], isDone: false, continueCursor: "packages-next" };
+      }
+      expect(args).toEqual(expect.objectContaining({ sort: "updated" }));
+      return { page: [skillPackage], isDone: false, continueCursor: "skills-next" };
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.listPackagesV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/packages?limit=1&sort=recommended"),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.items.map((entry: { name: string }) => entry.name)).toEqual([
+      "plugin-newer-low-score",
+    ]);
+    expect(json.nextCursor).toContain('"recommendedFallback":"updated"');
+    expect(runQuery).toHaveBeenCalledTimes(4);
   });
 
   it("plugins list defaults to plugin package families", async () => {

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -7833,6 +7833,51 @@ describe("httpApiV1 handlers", () => {
     expect(runQuery).toHaveBeenCalledTimes(4);
   });
 
+  it("packages list treats stale cursors as fresh for recommended fallback", async () => {
+    const staleSkillCursor = `skillcat:${JSON.stringify({
+      cursor: "skill-cursor",
+      offset: 0,
+      pageSize: 20,
+      done: false,
+    })}`;
+    const pluginPackage = makeCatalogItem("plugin-newer-low-score", {
+      family: "code-plugin",
+      updatedAt: 300,
+      stats: { downloads: 1, installs: 0, stars: 0, versions: 1 },
+    });
+    const skillPackage = makeCatalogItem("skill-older-high-score", {
+      family: "skill",
+      updatedAt: 200,
+      stats: { downloads: 100, installs: 100, stars: 10, versions: 1 },
+    });
+    const runQuery = vi.fn((_, args: Record<string, unknown>) => {
+      if (Object.keys(args).length === 0) return true;
+      expect(args).toEqual(expect.objectContaining({ sort: "updated" }));
+      if (Object.hasOwn(args, "viewerUserId")) {
+        return { page: [pluginPackage], isDone: true, continueCursor: "" };
+      }
+      return { page: [skillPackage], isDone: true, continueCursor: "" };
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.listPackagesV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request(
+        `https://example.com/api/v1/packages?limit=2&sort=recommended&cursor=${encodeURIComponent(
+          staleSkillCursor,
+        )}`,
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.items.map((entry: { name: string }) => entry.name)).toEqual([
+      "plugin-newer-low-score",
+      "skill-older-high-score",
+    ]);
+    expect(runQuery).toHaveBeenCalledTimes(4);
+  });
+
   it("plugins list defaults to plugin package families", async () => {
     const codePlugin = {
       name: "code-plugin",
@@ -8134,6 +8179,52 @@ describe("httpApiV1 handlers", () => {
     const response = await __handlers.listPluginsV1Handler(
       makeCtx({ runQuery, runMutation }),
       new Request("https://example.com/api/v1/plugins?limit=2&sort=recommended"),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.items.map((entry: { name: string }) => entry.name)).toEqual([
+      "bundle-newer-low-score",
+      "code-older-high-score",
+    ]);
+  });
+
+  it("plugins list treats stale cursors as fresh for recommended fallback", async () => {
+    const staleSearchCursor = `pkgpluginsearch:${JSON.stringify({
+      codePlugins: { cursor: "code-search", offset: 0, pageSize: 2, done: false },
+      bundlePlugins: { cursor: null, offset: 0, pageSize: 2, done: true },
+    })}`;
+    const codePlugin = makeCatalogItem("code-older-high-score", {
+      family: "code-plugin",
+      updatedAt: 100,
+      stats: { downloads: 50_000, installs: 500, stars: 10, versions: 1 },
+    });
+    const bundlePlugin = makeCatalogItem("bundle-newer-low-score", {
+      family: "bundle-plugin",
+      updatedAt: 200,
+      stats: { downloads: 1, installs: 0, stars: 0, versions: 1 },
+    });
+    const runQuery = vi.fn((_, args: Record<string, unknown>) => {
+      if (Object.keys(args).length === 0) return 2;
+      if (hasPluginRecommendedScoreReadinessArgs(args)) return true;
+      expect(args).toEqual(expect.objectContaining({ sort: "updated" }));
+      if (args.family === "code-plugin") {
+        return { page: [codePlugin], isDone: true, continueCursor: "" };
+      }
+      if (args.family === "bundle-plugin") {
+        return { page: [bundlePlugin], isDone: true, continueCursor: "" };
+      }
+      throw new Error(`unexpected family ${String(args.family)}`);
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.listPluginsV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request(
+        `https://example.com/api/v1/plugins?limit=2&sort=recommended&cursor=${encodeURIComponent(
+          staleSearchCursor,
+        )}`,
+      ),
     );
 
     expect(response.status).toBe(200);

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -10942,6 +10942,70 @@ describe("httpApiV1 handlers", () => {
     );
   });
 
+  it("npm mirror tarball downloads skip install metrics without a trusted identity", async () => {
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("name" in args && !("paginationOpts" in args)) {
+        return {
+          package: {
+            _id: "packages:demo-plugin",
+            name: "demo-plugin",
+            displayName: "Demo Plugin",
+            family: "code-plugin",
+            tags: { latest: "packageReleases:1" },
+            latestReleaseId: "packageReleases:1",
+            channel: "community",
+            isOfficial: false,
+            summary: "Demo package",
+            createdAt: 1,
+            updatedAt: 1,
+          },
+          latestRelease: null,
+          owner: null,
+        };
+      }
+      if ("paginationOpts" in args) {
+        return {
+          page: [
+            {
+              _id: "packageReleases:1",
+              packageId: "packages:demo-plugin",
+              version: "1.0.0",
+              createdAt: 1,
+              changelog: "Initial release",
+              distTags: ["latest"],
+              files: [],
+              artifactKind: "npm-pack",
+              clawpackStorageId: "storage:clawpack",
+              npmIntegrity: "sha512-demo",
+              npmShasum: "d".repeat(40),
+              npmTarballName: "demo-plugin-1.0.0.tgz",
+            },
+          ],
+          isDone: true,
+          continueCursor: null,
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.npmMirrorGetHandler(
+      makeCtx({
+        runQuery,
+        runMutation,
+        storage: {
+          get: vi.fn(async () => new Blob(["tarball"], { type: "application/octet-stream" })),
+        },
+      }),
+      new Request("https://example.com/api/npm/demo-plugin/-/demo-plugin-1.0.0.tgz"),
+    );
+
+    expect(response.status).toBe(200);
+    const calledMutationRefs = runMutation.mock.calls.map(([mutation]) => mutation);
+    expect(calledMutationRefs).not.toContain(internal.packages.recordPackageInstallInternal);
+    expect(calledMutationRefs).not.toContain(internal.downloadMetrics.recordDownloadMetricInternal);
+  });
+
   it("npm mirror returns not found for invalid package lookup names", async () => {
     const runQuery = vi.fn(async () => {
       throw new Error("unexpected package lookup");

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -7728,6 +7728,40 @@ describe("httpApiV1 handlers", () => {
     );
   });
 
+  it("packages list install sort merges package and skill rows by installs", async () => {
+    const pluginPackage = makeCatalogItem("plugin-installed", {
+      family: "code-plugin",
+      updatedAt: 200,
+      stats: { downloads: 100, installs: 5, stars: 0, versions: 1 },
+    });
+    const skillPackage = makeCatalogItem("skill-installed", {
+      family: "skill",
+      updatedAt: 100,
+      stats: { downloads: 1, installs: 40, stars: 0, versions: 1 },
+    });
+    const runQuery = vi.fn((_, args: Record<string, unknown>) => {
+      expect(args).toEqual(expect.objectContaining({ sort: "installs" }));
+      if (Object.hasOwn(args, "viewerUserId")) {
+        return { page: [pluginPackage], isDone: true, continueCursor: "" };
+      }
+      return { page: [skillPackage], isDone: true, continueCursor: "" };
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.listPackagesV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/packages?limit=2&sort=installs"),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.items.map((entry: { name: string }) => entry.name)).toEqual([
+      "skill-installed",
+      "plugin-installed",
+    ]);
+    expect(runQuery).toHaveBeenCalledTimes(2);
+  });
+
   it("plugins list defaults to plugin package families", async () => {
     const codePlugin = {
       name: "code-plugin",

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -7762,6 +7762,40 @@ describe("httpApiV1 handlers", () => {
     expect(runQuery).toHaveBeenCalledTimes(2);
   });
 
+  it("packages list recommended sort merges package and skill rows by recommendation score", async () => {
+    const pluginPackage = makeCatalogItem("plugin-downloaded", {
+      family: "code-plugin",
+      updatedAt: 200,
+      stats: { downloads: 1_000, installs: 0, stars: 0, versions: 1 },
+    });
+    const skillPackage = makeCatalogItem("skill-installed", {
+      family: "skill",
+      updatedAt: 100,
+      stats: { downloads: 1, installs: 500, stars: 0, versions: 1 },
+    });
+    const runQuery = vi.fn((_, args: Record<string, unknown>) => {
+      expect(args).toEqual(expect.objectContaining({ sort: "recommended" }));
+      if (Object.hasOwn(args, "viewerUserId")) {
+        return { page: [pluginPackage], isDone: true, continueCursor: "" };
+      }
+      return { page: [skillPackage], isDone: true, continueCursor: "" };
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.listPackagesV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/packages?limit=2&sort=recommended"),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.items.map((entry: { name: string }) => entry.name)).toEqual([
+      "skill-installed",
+      "plugin-downloaded",
+    ]);
+    expect(runQuery).toHaveBeenCalledTimes(2);
+  });
+
   it("plugins list defaults to plugin package families", async () => {
     const codePlugin = {
       name: "code-plugin",

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -7785,6 +7785,7 @@ describe("httpApiV1 handlers", () => {
       expect(args).toEqual(
         expect.objectContaining({
           category: undefined,
+          sort: "recommended",
           paginationOpts: { cursor: null, numItems: 7 },
         }),
       );
@@ -7884,6 +7885,44 @@ describe("httpApiV1 handlers", () => {
         paginationOpts: { cursor: "install-cursor", numItems: 25 },
       }),
     );
+  });
+
+  it("plugins list install sort forwards to both plugin families and merges by installs", async () => {
+    const codePlugin = makeCatalogItem("code-installed", {
+      family: "code-plugin",
+      updatedAt: 100,
+      stats: { downloads: 1, installs: 50, stars: 0, versions: 1 },
+    });
+    const bundlePlugin = makeCatalogItem("bundle-installed", {
+      family: "bundle-plugin",
+      updatedAt: 200,
+      stats: { downloads: 100, installs: 5, stars: 0, versions: 1 },
+    });
+    const runQuery = vi.fn((_, args: Record<string, unknown>) => {
+      if (Object.keys(args).length === 0) return 2;
+      if (hasPluginRecommendedScoreReadinessArgs(args)) return false;
+      expect(args).toEqual(expect.objectContaining({ sort: "installs" }));
+      if (args.family === "code-plugin") {
+        return { page: [codePlugin], isDone: true, continueCursor: "" };
+      }
+      if (args.family === "bundle-plugin") {
+        return { page: [bundlePlugin], isDone: true, continueCursor: "" };
+      }
+      throw new Error(`unexpected family ${String(args.family)}`);
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.listPluginsV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/plugins?limit=2&sort=installs"),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.items.map((entry: { name: string }) => entry.name)).toEqual([
+      "code-installed",
+      "bundle-installed",
+    ]);
   });
 
   it("plugins list recommended sort uses weighted scores across plugin families", async () => {

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -8097,6 +8097,36 @@ describe("httpApiV1 handlers", () => {
     }
   });
 
+  it("plugins list defaults featured browse to updated sort", async () => {
+    const readinessCalls: unknown[] = [];
+    const runQuery = vi.fn((_, args: Record<string, unknown>) => {
+      if (hasPluginRecommendedScoreReadinessArgs(args)) {
+        readinessCalls.push(args);
+        return false;
+      }
+      return { page: [], isDone: true, continueCursor: "" };
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.listPluginsV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/plugins?featured=true&limit=7"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(readinessCalls).toEqual([]);
+    for (const [, args] of runQuery.mock.calls) {
+      if (hasPluginRecommendedScoreReadinessArgs(args)) continue;
+      expect(args).toEqual(
+        expect.objectContaining({
+          highlightedOnly: true,
+          sort: "updated",
+          paginationOpts: { cursor: null, numItems: 7 },
+        }),
+      );
+    }
+  });
+
   it("plugins list install sort forwards to both plugin families and merges by installs", async () => {
     const codePlugin = makeCatalogItem("code-installed", {
       family: "code-plugin",

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -849,6 +849,26 @@ function defaultCatalogSourceCursorState(): CatalogSourceCursorState {
   return { cursor: null, offset: 0, pageSize: null, done: false };
 }
 
+function hasCatalogSourceCursorState(state: CatalogSourceCursorState) {
+  return state.cursor !== null || state.offset > 0 || state.pageSize !== null || state.done;
+}
+
+function isUnifiedCatalogFreshStart(state: UnifiedCatalogCursorState) {
+  return (
+    !state.recommendedFallback &&
+    !hasCatalogSourceCursorState(state.packages) &&
+    !hasCatalogSourceCursorState(state.skills)
+  );
+}
+
+function isPluginCatalogFreshStart(state: PluginCatalogCursorState) {
+  return (
+    !state.recommendedFallback &&
+    !hasCatalogSourceCursorState(state.codePlugins) &&
+    !hasCatalogSourceCursorState(state.bundlePlugins)
+  );
+}
+
 function encodeUnifiedCatalogCursor(state: UnifiedCatalogCursorState) {
   return `${UNIFIED_CATALOG_CURSOR_PREFIX}${JSON.stringify(state)}`;
 }
@@ -1498,7 +1518,8 @@ async function listPackages(
 
   if (!effectiveFamily && includeSkills) {
     const decodedCursor = decodeUnifiedCatalogCursor(cursor);
-    const isFreshRecommendedRequest = effectiveSort === "recommended" && !cursor;
+    const isFreshRecommendedRequest =
+      effectiveSort === "recommended" && isUnifiedCatalogFreshStart(decodedCursor);
     const [hasMissingPackageRecommendationScores, hasMissingSkillRecommendationScores] =
       isFreshRecommendedRequest
         ? await Promise.all([
@@ -1620,7 +1641,8 @@ async function listPackages(
     const decodedCursor = decodePluginCatalogCursor(cursor);
     const codePluginSource = initCatalogSource<CatalogListItem>(decodedCursor.codePlugins);
     const bundlePluginSource = initCatalogSource<CatalogListItem>(decodedCursor.bundlePlugins);
-    const isFreshRecommendedRequest = effectiveSort === "recommended" && !cursor;
+    const isFreshRecommendedRequest =
+      effectiveSort === "recommended" && isPluginCatalogFreshStart(decodedCursor);
     const hasMissingRecommendationScores = isFreshRecommendedRequest
       ? await runQueryRef<boolean>(
           ctx,

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -1470,9 +1470,6 @@ async function listPackages(
   const sortParam = parseEnumQueryParam(url.searchParams, "sort", PACKAGE_LIST_SORT_VALUES);
   if (!sortParam.ok) return text(sortParam.message, 400, rate.headers);
   const isLegacyDownloadsSort = sortParam.value === "downloads";
-  const effectiveSort = isLegacyDownloadsSort
-    ? "installs"
-    : (sortParam.value ?? options?.defaultSort);
   const cursor = isLegacyDownloadsSort
     ? rawCursor?.startsWith(LEGACY_DOWNLOADS_INSTALL_CURSOR_PREFIX)
       ? rawCursor.slice(LEGACY_DOWNLOADS_INSTALL_CURSOR_PREFIX.length)
@@ -1487,6 +1484,16 @@ async function listPackages(
   const effectiveFamily = family ?? familyParam.value;
   const includeSkills = options?.includeSkills ?? effectiveFamily === undefined;
   const highlightedOnly = featured.value === true || highlightedOnlyParam.value === true;
+  const filteredPluginDefaultSort =
+    options?.defaultSort === "recommended" &&
+    options.pluginFamilies?.length &&
+    !includeSkills &&
+    (category || capabilityTag)
+      ? "updated"
+      : options?.defaultSort;
+  const effectiveSort = isLegacyDownloadsSort
+    ? "installs"
+    : (sortParam.value ?? filteredPluginDefaultSort);
   if (category && (effectiveFamily === "skill" || (!effectiveFamily && includeSkills))) {
     return text(
       "Plugin category is only supported for plugin package endpoints",

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -716,17 +716,13 @@ async function streamClawPackRelease(
           now,
         })
       : null;
-    if (statKind === "install") {
+    if (statKind === "install" && metricArgs) {
       await runMutationRef(ctx, internalRefs.packages.recordPackageInstallInternal, {
         packageId: pkg._id,
-        ...(metricArgs
-          ? {
-              identityKind: metricArgs.identityKind,
-              identityHash: metricArgs.identityHash,
-              dayStart: metricArgs.dayStart,
-              occurredAt: metricArgs.occurredAt,
-            }
-          : {}),
+        identityKind: metricArgs.identityKind,
+        identityHash: metricArgs.identityHash,
+        dayStart: metricArgs.dayStart,
+        occurredAt: metricArgs.occurredAt,
       });
     }
 

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -148,6 +148,7 @@ const internalRefs = internal as unknown as {
   };
   skills: {
     getSkillBySlugInternal: unknown;
+    hasMissingPackageCatalogRecommendationScoresInternal: unknown;
     searchPackageCatalogForHttpInternal: unknown;
     getVersionByIdInternal: unknown;
     getVersionBySkillAndVersionInternal: unknown;
@@ -808,6 +809,7 @@ type CatalogSourceCursorState = {
 type UnifiedCatalogCursorState = {
   packages: CatalogSourceCursorState;
   skills: CatalogSourceCursorState;
+  recommendedFallback?: "updated";
 };
 
 type PluginCatalogCursorState = {
@@ -880,6 +882,7 @@ function decodeUnifiedCatalogCursor(raw: string | null | undefined): UnifiedCata
     return {
       packages: normalize(parsed.packages),
       skills: normalize(parsed.skills),
+      recommendedFallback: parsed.recommendedFallback === "updated" ? "updated" : undefined,
     };
   } catch {
     return {
@@ -1494,12 +1497,31 @@ async function listPackages(
   }
 
   if (!effectiveFamily && includeSkills) {
-    const packageSource = initCatalogSource<CatalogListItem>(
-      decodeUnifiedCatalogCursor(cursor).packages,
-    );
-    const skillSource = initCatalogSource<CatalogListItem>(
-      decodeUnifiedCatalogCursor(cursor).skills,
-    );
+    const decodedCursor = decodeUnifiedCatalogCursor(cursor);
+    const isFreshRecommendedRequest = effectiveSort === "recommended" && !cursor;
+    const [hasMissingPackageRecommendationScores, hasMissingSkillRecommendationScores] =
+      isFreshRecommendedRequest
+        ? await Promise.all([
+            runQueryRef<boolean>(
+              ctx,
+              internalRefs.packages.hasMissingRecommendationScoresInternal,
+              {},
+            ),
+            runQueryRef<boolean>(
+              ctx,
+              internalRefs.skills.hasMissingPackageCatalogRecommendationScoresInternal,
+              {},
+            ),
+          ])
+        : [false, false];
+    const useUpdatedRecommendationFallback =
+      effectiveSort === "recommended" &&
+      (decodedCursor.recommendedFallback === "updated" ||
+        (isFreshRecommendedRequest &&
+          (hasMissingPackageRecommendationScores || hasMissingSkillRecommendationScores)));
+    const unifiedListSort = useUpdatedRecommendationFallback ? "updated" : effectiveSort;
+    const packageSource = initCatalogSource<CatalogListItem>(decodedCursor.packages);
+    const skillSource = initCatalogSource<CatalogListItem>(decodedCursor.skills);
     const pageSize = limit;
     const items: CatalogListItem[] = [];
 
@@ -1517,7 +1539,7 @@ async function listPackages(
             executesCode: executesCode.value,
             capabilityTag,
             category,
-            sort: effectiveSort,
+            sort: unifiedListSort,
             viewerUserId: viewerUserId ?? undefined,
             paginationOpts: { cursor: pageCursor, numItems },
           });
@@ -1538,7 +1560,7 @@ async function listPackages(
             highlightedOnly: highlightedOnly || undefined,
             executesCode: executesCode.value,
             capabilityTag,
-            sort: effectiveSort,
+            sort: unifiedListSort,
             paginationOpts: { cursor: pageCursor, numItems },
           });
           return {
@@ -1553,7 +1575,7 @@ async function listPackages(
       if (
         !skillCandidate ||
         (packageCandidate &&
-          compareCatalogItemsForSort(packageCandidate, skillCandidate, effectiveSort) <= 0)
+          compareCatalogItemsForSort(packageCandidate, skillCandidate, unifiedListSort) <= 0)
       ) {
         items.push(packageCandidate!);
         packageSource.index += 1;
@@ -1566,6 +1588,7 @@ async function listPackages(
     const nextState = {
       packages: finalizeCatalogSource(packageSource),
       skills: finalizeCatalogSource(skillSource),
+      recommendedFallback: useUpdatedRecommendationFallback ? ("updated" as const) : undefined,
     };
     const isDoneAll =
       nextState.packages.done &&

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -1484,16 +1484,16 @@ async function listPackages(
   const effectiveFamily = family ?? familyParam.value;
   const includeSkills = options?.includeSkills ?? effectiveFamily === undefined;
   const highlightedOnly = featured.value === true || highlightedOnlyParam.value === true;
-  const filteredPluginDefaultSort =
+  const pluginDefaultSort =
     options?.defaultSort === "recommended" &&
     options.pluginFamilies?.length &&
     !includeSkills &&
-    (category || capabilityTag)
+    (highlightedOnly || category || capabilityTag)
       ? "updated"
       : options?.defaultSort;
   const effectiveSort = isLegacyDownloadsSort
     ? "installs"
-    : (sortParam.value ?? filteredPluginDefaultSort);
+    : (sortParam.value ?? pluginDefaultSort);
   if (category && (effectiveFamily === "skill" || (!effectiveFamily && includeSkills))) {
     return text(
       "Plugin category is only supported for plugin package endpoints",

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -1491,9 +1491,7 @@ async function listPackages(
     (highlightedOnly || category || capabilityTag)
       ? "updated"
       : options?.defaultSort;
-  const effectiveSort = isLegacyDownloadsSort
-    ? "installs"
-    : (sortParam.value ?? pluginDefaultSort);
+  const effectiveSort = isLegacyDownloadsSort ? "installs" : (sortParam.value ?? pluginDefaultSort);
   if (category && (effectiveFamily === "skill" || (!effectiveFamily && includeSkills))) {
     return text(
       "Plugin category is only supported for plugin package endpoints",

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -1421,7 +1421,11 @@ async function listPackages(
   ctx: ActionCtx,
   request: Request,
   family?: PackageListQueryArgs["family"],
-  options?: { includeSkills?: boolean; pluginFamilies?: Array<"code-plugin" | "bundle-plugin"> },
+  options?: {
+    defaultSort?: (typeof PACKAGE_LIST_SORT_VALUES)[number];
+    includeSkills?: boolean;
+    pluginFamilies?: Array<"code-plugin" | "bundle-plugin">;
+  },
 ) {
   const rate = await applyRateLimit(ctx, request, "read");
   if (!rate.ok) return rate.response;
@@ -1447,7 +1451,9 @@ async function listPackages(
   const sortParam = parseEnumQueryParam(url.searchParams, "sort", PACKAGE_LIST_SORT_VALUES);
   if (!sortParam.ok) return text(sortParam.message, 400, rate.headers);
   const isLegacyDownloadsSort = sortParam.value === "downloads";
-  const sort = isLegacyDownloadsSort ? "installs" : sortParam.value;
+  const effectiveSort = isLegacyDownloadsSort
+    ? "installs"
+    : (sortParam.value ?? options?.defaultSort);
   const cursor = isLegacyDownloadsSort
     ? rawCursor?.startsWith(LEGACY_DOWNLOADS_INSTALL_CURSOR_PREFIX)
       ? rawCursor.slice(LEGACY_DOWNLOADS_INSTALL_CURSOR_PREFIX.length)
@@ -1481,7 +1487,7 @@ async function listPackages(
       highlightedOnly: highlightedOnly || undefined,
       executesCode: executesCode.value,
       capabilityTag,
-      sort,
+      sort: effectiveSort,
       paginationOpts: { cursor, numItems: limit },
     });
     return json(
@@ -1515,7 +1521,7 @@ async function listPackages(
             executesCode: executesCode.value,
             capabilityTag,
             category,
-            sort,
+            sort: effectiveSort,
             viewerUserId: viewerUserId ?? undefined,
             paginationOpts: { cursor: pageCursor, numItems },
           });
@@ -1536,7 +1542,7 @@ async function listPackages(
             highlightedOnly: highlightedOnly || undefined,
             executesCode: executesCode.value,
             capabilityTag,
-            sort,
+            sort: effectiveSort,
             paginationOpts: { cursor: pageCursor, numItems },
           });
           return {
@@ -1551,7 +1557,7 @@ async function listPackages(
       if (
         !skillCandidate ||
         (packageCandidate &&
-          compareCatalogItemsForSort(packageCandidate, skillCandidate, sort) <= 0)
+          compareCatalogItemsForSort(packageCandidate, skillCandidate, effectiveSort) <= 0)
       ) {
         items.push(packageCandidate!);
         packageSource.index += 1;
@@ -1595,7 +1601,7 @@ async function listPackages(
     const decodedCursor = decodePluginCatalogCursor(cursor);
     const codePluginSource = initCatalogSource<CatalogListItem>(decodedCursor.codePlugins);
     const bundlePluginSource = initCatalogSource<CatalogListItem>(decodedCursor.bundlePlugins);
-    const isFreshRecommendedRequest = sort === "recommended" && !cursor;
+    const isFreshRecommendedRequest = effectiveSort === "recommended" && !cursor;
     const hasMissingRecommendationScores = isFreshRecommendedRequest
       ? await runQueryRef<boolean>(
           ctx,
@@ -1606,10 +1612,10 @@ async function listPackages(
         )
       : false;
     const useUpdatedRecommendationFallback =
-      sort === "recommended" &&
+      effectiveSort === "recommended" &&
       (decodedCursor.recommendedFallback === "updated" ||
         (isFreshRecommendedRequest && hasMissingRecommendationScores));
-    const pluginListSort = useUpdatedRecommendationFallback ? "updated" : sort;
+    const pluginListSort = useUpdatedRecommendationFallback ? "updated" : effectiveSort;
     const pageSize = limit;
     const items: CatalogListItem[] = [];
     const fetchPluginPage = async (
@@ -1702,7 +1708,7 @@ async function listPackages(
     executesCode: executesCode.value,
     capabilityTag,
     category,
-    sort,
+    sort: effectiveSort,
     viewerUserId: viewerUserId ?? undefined,
     paginationOpts: { cursor, numItems: limit },
   } satisfies PackageListQueryArgs);
@@ -2101,6 +2107,7 @@ export async function exportPluginsV1Handler(ctx: ActionCtx, request: Request) {
 
 export async function listPluginsV1Handler(ctx: ActionCtx, request: Request) {
   return await listPackages(ctx, request, undefined, {
+    defaultSort: "recommended",
     includeSkills: false,
     pluginFamilies: ["code-plugin", "bundle-plugin"],
   });

--- a/convex/lib/packageSearchDigest.ts
+++ b/convex/lib/packageSearchDigest.ts
@@ -144,6 +144,34 @@ export async function upsertPackageSearchDigest(
   await adjustGlobalPublicPluginsCount(ctx, getPublicPluginVisibilityDelta(null, fields));
 }
 
+export async function patchPackageSearchDigestStats(
+  ctx: Pick<MutationCtx, "db">,
+  packageId: Id<"packages">,
+  stats: Doc<"packages">["stats"],
+) {
+  const digest = await ctx.db
+    .query("packageSearchDigest")
+    .withIndex("by_package", (q) => q.eq("packageId", packageId))
+    .unique();
+  if (digest) await ctx.db.patch(digest._id, { stats });
+
+  const capabilityDigests = await ctx.db
+    .query("packageCapabilitySearchDigest")
+    .withIndex("by_package", (q) => q.eq("packageId", packageId))
+    .collect();
+  for (const capabilityDigest of capabilityDigests) {
+    await ctx.db.patch(capabilityDigest._id, { stats });
+  }
+
+  const categoryDigests = await ctx.db
+    .query("packagePluginCategorySearchDigest")
+    .withIndex("by_package", (q) => q.eq("packageId", packageId))
+    .collect();
+  for (const categoryDigest of categoryDigests) {
+    await ctx.db.patch(categoryDigest._id, { stats });
+  }
+}
+
 async function syncPackageCapabilitySearchDigests(
   ctx: Pick<MutationCtx, "db">,
   fields: PackageSearchDigestFields,

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -49,6 +49,7 @@ import {
   applyAccountDeletionToOwnedPackagesBatchInternal,
   applyPublisherDeletionToOwnedPackagesBatchInternal,
   applyBanToOwnedPackagesBatchInternal,
+  hardDeletePackageInternal,
   revokePackagePublishTokensForPackageBatchInternal,
   restoreOwnedPackagesForUnbanBatchInternal,
   softDeletePackageInternal,
@@ -773,6 +774,17 @@ const softDeletePackageInternalHandler = (
       releaseCount: number;
       alreadyDeleted: boolean;
     }
+  >
+)._handler;
+const hardDeletePackageInternalHandler = (
+  hardDeletePackageInternal as unknown as WrappedHandler<
+    {
+      packageId: string;
+      actorUserId: string;
+      deletedAt: number;
+      source: "account.delete" | "publisher.delete";
+    },
+    { ok: true; packageId?: string; deleted: boolean; alreadyDeleted?: boolean }
   >
 )._handler;
 const applyBanToOwnedPackagesBatchInternalHandler = (
@@ -11265,6 +11277,7 @@ function makeOwnedPackageBatchCtx(options?: {
   pkg?: Record<string, unknown>;
   owner?: Record<string, unknown> | null;
   packageTokens?: Array<Record<string, unknown>>;
+  packageInstallMetricDedupes?: Array<Record<string, unknown>>;
   releases?: Array<Record<string, unknown>>;
   publisherPackages?: Array<Record<string, unknown>>;
   publishers?: Record<string, Record<string, unknown> | null>;
@@ -11285,11 +11298,13 @@ function makeOwnedPackageBatchCtx(options?: {
   ];
   const patch = vi.fn();
   const insert = vi.fn().mockResolvedValue("auditLogs:1");
+  const deleteDoc = vi.fn();
   const runAfter = vi.fn();
 
   return {
     patch,
     insert,
+    deleteDoc,
     runAfter,
     ctx: {
       scheduler: { runAfter },
@@ -11308,6 +11323,7 @@ function makeOwnedPackageBatchCtx(options?: {
               ? { _id: "users:owner", deletedAt: undefined, deactivatedAt: undefined }
               : options.owner;
           }
+          if (id === pkg._id) return pkg;
           if (options?.publishers && id in options.publishers) {
             return options.publishers[id];
           }
@@ -11376,6 +11392,7 @@ function makeOwnedPackageBatchCtx(options?: {
                   };
                   builder?.(queryBuilder);
                   return {
+                    collect: vi.fn(async () => packageTokens),
                     order: vi.fn(() => ({
                       take: vi.fn(async (limit: number) =>
                         packageTokens
@@ -11396,6 +11413,28 @@ function makeOwnedPackageBatchCtx(options?: {
             return {
               withIndex: vi.fn(() => ({
                 collect: vi.fn().mockResolvedValue(releases),
+              })),
+            };
+          }
+          if (
+            table === "securityScanJobs" ||
+            table === "packageReports" ||
+            table === "packageAppeals" ||
+            table === "packageBadges" ||
+            table === "packageTrustedPublishers" ||
+            table === "packagePublishUploadTickets" ||
+            table === "packageStatEvents"
+          ) {
+            return {
+              withIndex: vi.fn(() => ({
+                collect: vi.fn().mockResolvedValue([]),
+              })),
+            };
+          }
+          if (table === "packageInstallMetricDedupes") {
+            return {
+              withIndex: vi.fn(() => ({
+                collect: vi.fn().mockResolvedValue(options?.packageInstallMetricDedupes ?? []),
               })),
             };
           }
@@ -11427,7 +11466,7 @@ function makeOwnedPackageBatchCtx(options?: {
         insert,
         patch,
         replace: vi.fn(),
-        delete: vi.fn(),
+        delete: deleteDoc,
         normalizeId: vi.fn(),
       },
     },
@@ -12135,6 +12174,27 @@ describe("owned package sanction batches", () => {
       deletedAt: 3_000,
       source: "account.delete",
     });
+  });
+
+  it("deletes package install dedupe rows during package hard delete", async () => {
+    const { ctx, deleteDoc } = makeOwnedPackageBatchCtx({
+      packageInstallMetricDedupes: [
+        { _id: "packageInstallMetricDedupes:one" },
+        { _id: "packageInstallMetricDedupes:two" },
+      ],
+    });
+
+    const result = await hardDeletePackageInternalHandler(ctx as never, {
+      packageId: "packages:demo",
+      actorUserId: "users:owner",
+      deletedAt: 3_000,
+      source: "account.delete",
+    });
+
+    expect(result).toMatchObject({ ok: true, packageId: "packages:demo", deleted: true });
+    expect(deleteDoc).toHaveBeenCalledWith("packageInstallMetricDedupes:one");
+    expect(deleteDoc).toHaveBeenCalledWith("packageInstallMetricDedupes:two");
+    expect(deleteDoc).toHaveBeenCalledWith("packages:demo");
   });
 
   it("schedules hard deletes for account-deleted packages owned through the user's personal publisher", async () => {

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -11300,12 +11300,16 @@ function makeOwnedPackageBatchCtx(options?: {
   const insert = vi.fn().mockResolvedValue("auditLogs:1");
   const deleteDoc = vi.fn();
   const runAfter = vi.fn();
+  const installDedupeTake = vi.fn(async (limit: number) =>
+    (options?.packageInstallMetricDedupes ?? []).slice(0, limit),
+  );
 
   return {
     patch,
     insert,
     deleteDoc,
     runAfter,
+    installDedupeTake,
     ctx: {
       scheduler: { runAfter },
       db: {
@@ -11434,7 +11438,7 @@ function makeOwnedPackageBatchCtx(options?: {
           if (table === "packageInstallMetricDedupes") {
             return {
               withIndex: vi.fn(() => ({
-                collect: vi.fn().mockResolvedValue(options?.packageInstallMetricDedupes ?? []),
+                take: installDedupeTake,
               })),
             };
           }
@@ -12177,7 +12181,7 @@ describe("owned package sanction batches", () => {
   });
 
   it("deletes package install dedupe rows during package hard delete", async () => {
-    const { ctx, deleteDoc } = makeOwnedPackageBatchCtx({
+    const { ctx, deleteDoc, installDedupeTake } = makeOwnedPackageBatchCtx({
       packageInstallMetricDedupes: [
         { _id: "packageInstallMetricDedupes:one" },
         { _id: "packageInstallMetricDedupes:two" },
@@ -12192,8 +12196,32 @@ describe("owned package sanction batches", () => {
     });
 
     expect(result).toMatchObject({ ok: true, packageId: "packages:demo", deleted: true });
+    expect(installDedupeTake).toHaveBeenCalledWith(200);
     expect(deleteDoc).toHaveBeenCalledWith("packageInstallMetricDedupes:one");
     expect(deleteDoc).toHaveBeenCalledWith("packageInstallMetricDedupes:two");
+    expect(deleteDoc).toHaveBeenCalledWith("packages:demo");
+  });
+
+  it("bounds install metric dedupe cleanup during package hard delete", async () => {
+    const packageInstallMetricDedupes = Array.from({ length: 201 }, (_, index) => ({
+      _id: `packageInstallMetricDedupes:${index}`,
+    }));
+    const { ctx, deleteDoc, installDedupeTake } = makeOwnedPackageBatchCtx({
+      packageInstallMetricDedupes,
+    });
+
+    const result = await hardDeletePackageInternalHandler(ctx as never, {
+      packageId: "packages:demo",
+      actorUserId: "users:owner",
+      deletedAt: 3_000,
+      source: "account.delete",
+    });
+
+    expect(result).toMatchObject({ ok: true, packageId: "packages:demo", deleted: true });
+    expect(installDedupeTake).toHaveBeenCalledWith(200);
+    expect(deleteDoc).toHaveBeenCalledWith("packageInstallMetricDedupes:0");
+    expect(deleteDoc).toHaveBeenCalledWith("packageInstallMetricDedupes:199");
+    expect(deleteDoc).not.toHaveBeenCalledWith("packageInstallMetricDedupes:200");
     expect(deleteDoc).toHaveBeenCalledWith("packages:demo");
   });
 

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -12202,11 +12202,11 @@ describe("owned package sanction batches", () => {
     expect(deleteDoc).toHaveBeenCalledWith("packages:demo");
   });
 
-  it("bounds install metric dedupe cleanup during package hard delete", async () => {
+  it("continues install metric dedupe cleanup before package hard delete finalizes", async () => {
     const packageInstallMetricDedupes = Array.from({ length: 201 }, (_, index) => ({
       _id: `packageInstallMetricDedupes:${index}`,
     }));
-    const { ctx, deleteDoc, installDedupeTake } = makeOwnedPackageBatchCtx({
+    const { ctx, deleteDoc, installDedupeTake, runAfter } = makeOwnedPackageBatchCtx({
       packageInstallMetricDedupes,
     });
 
@@ -12217,12 +12217,23 @@ describe("owned package sanction batches", () => {
       source: "account.delete",
     });
 
-    expect(result).toMatchObject({ ok: true, packageId: "packages:demo", deleted: true });
+    expect(result).toMatchObject({
+      ok: true,
+      packageId: "packages:demo",
+      deleted: false,
+      cleanupPending: true,
+    });
     expect(installDedupeTake).toHaveBeenCalledWith(200);
     expect(deleteDoc).toHaveBeenCalledWith("packageInstallMetricDedupes:0");
     expect(deleteDoc).toHaveBeenCalledWith("packageInstallMetricDedupes:199");
     expect(deleteDoc).not.toHaveBeenCalledWith("packageInstallMetricDedupes:200");
-    expect(deleteDoc).toHaveBeenCalledWith("packages:demo");
+    expect(deleteDoc).not.toHaveBeenCalledWith("packages:demo");
+    expect(runAfter).toHaveBeenCalledWith(0, expect.anything(), {
+      packageId: "packages:demo",
+      actorUserId: "users:owner",
+      deletedAt: 3_000,
+      source: "account.delete",
+    });
   });
 
   it("schedules hard deletes for account-deleted packages owned through the user's personal publisher", async () => {

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -12227,6 +12227,8 @@ describe("owned package sanction batches", () => {
     expect(deleteDoc).toHaveBeenCalledWith("packageInstallMetricDedupes:0");
     expect(deleteDoc).toHaveBeenCalledWith("packageInstallMetricDedupes:199");
     expect(deleteDoc).not.toHaveBeenCalledWith("packageInstallMetricDedupes:200");
+    expect(deleteDoc).not.toHaveBeenCalledWith("packagePublishTokens:demo");
+    expect(deleteDoc).not.toHaveBeenCalledWith("packageReleases:demo-1");
     expect(deleteDoc).not.toHaveBeenCalledWith("packages:demo");
     expect(runAfter).toHaveBeenCalledWith(0, expect.anything(), {
       packageId: "packages:demo",

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -3366,6 +3366,36 @@ describe("packages public queries", () => {
     expect(indexNames).toEqual(["by_active_tag_executes_updated"]);
   });
 
+  it("uses capability digests for install-sorted capability listings", async () => {
+    const { ctx, indexNames, tableNames } = makeDigestCtx({
+      capabilityPages: [
+        {
+          page: [
+            makeDigest("tools-demo", {
+              family: "code-plugin",
+              capabilityTag: "tools",
+              capabilityTags: ["tools"],
+              stats: { downloads: 20, installs: 42, stars: 0, versions: 1 },
+            }),
+          ],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+    });
+
+    const result = await listPublicPageHandler(ctx, {
+      family: "code-plugin",
+      capabilityTag: "tools",
+      sort: "installs",
+      paginationOpts: { cursor: null, numItems: 10 },
+    });
+
+    expect(result.page.map((entry) => entry.name)).toEqual(["tools-demo"]);
+    expect(tableNames).toEqual(["packageCapabilitySearchDigest"]);
+    expect(indexNames).toEqual(["by_active_family_tag_installs"]);
+  });
+
   it("uses plugin category digests for category-filtered listings", async () => {
     const { ctx, indexNames, tableNames } = makeDigestCtx({
       categoryPages: [
@@ -3392,6 +3422,36 @@ describe("packages public queries", () => {
     expect(result.page.map((entry) => entry.name)).toEqual(["api-demo"]);
     expect(tableNames).toEqual(["packagePluginCategorySearchDigest"]);
     expect(indexNames).toEqual(["by_active_category_executes_updated"]);
+  });
+
+  it("uses plugin category digests for install-sorted category listings", async () => {
+    const { ctx, indexNames, tableNames } = makeDigestCtx({
+      categoryPages: [
+        {
+          page: [
+            makeDigest("api-demo", {
+              family: "code-plugin",
+              pluginCategory: "data",
+              pluginCategoryTags: ["data"],
+              stats: { downloads: 20, installs: 42, stars: 0, versions: 1 },
+            }),
+          ],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+    });
+
+    const result = await listPublicPageHandler(ctx, {
+      family: "code-plugin",
+      category: "data",
+      sort: "installs",
+      paginationOpts: { cursor: null, numItems: 10 },
+    });
+
+    expect(result.page.map((entry) => entry.name)).toEqual(["api-demo"]);
+    expect(tableNames).toEqual(["packagePluginCategorySearchDigest"]);
+    expect(indexNames).toEqual(["by_active_family_category_installs"]);
   });
 
   it("uses plugin category digests for category-filtered search", async () => {

--- a/convex/packages.stats.test.ts
+++ b/convex/packages.stats.test.ts
@@ -195,19 +195,41 @@ describe("package stat events", () => {
       { _id: "packageStatEvents:3", packageId: "packages:two", kind: "download" },
     ];
     const patch = vi.fn();
+    const insert = vi.fn();
     const ctx = {
       db: {
-        query: vi.fn(() => ({
-          withIndex: vi.fn(() => ({
-            take: vi.fn(async () => events),
-          })),
-        })),
-        get: vi.fn(async (id: string) => ({
-          _id: id,
-          stats: { downloads: 10, installs: 1, stars: 2, versions: 3 },
-        })),
+        query: vi.fn((table: string) => {
+          if (table === "packageStatEvents") {
+            return {
+              withIndex: vi.fn(() => ({
+                take: vi.fn(async () => events),
+              })),
+            };
+          }
+          if (table === "packageSearchDigest") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue(null),
+              })),
+            };
+          }
+          if (
+            table === "packageCapabilitySearchDigest" ||
+            table === "packagePluginCategorySearchDigest"
+          ) {
+            return {
+              withIndex: vi.fn(() => ({
+                collect: vi.fn().mockResolvedValue([]),
+              })),
+            };
+          }
+          throw new Error(`Unexpected table: ${table}`);
+        }),
+        get: vi.fn(async (id: string) =>
+          makeStatsPackageDoc(id, { downloads: 10, installs: 1, stars: 2, versions: 3 }),
+        ),
         normalizeId: vi.fn(),
-        insert: vi.fn(),
+        insert,
         patch,
         replace: vi.fn(),
         delete: vi.fn(),
@@ -253,4 +275,130 @@ describe("package stat events", () => {
       expect.objectContaining({ processedAt: expect.any(Number) }),
     );
   });
+
+  it("syncs package search digest stats after processing install events", async () => {
+    const events = [{ _id: "packageStatEvents:1", packageId: "packages:one", kind: "install" }];
+    const patch = vi.fn();
+    const packageDoc = makeStatsPackageDoc("packages:one", {
+      downloads: 10,
+      installs: 1,
+      stars: 2,
+      versions: 3,
+      capabilityTags: ["tools"],
+    });
+    const ctx = {
+      db: {
+        query: vi.fn((table: string) => {
+          if (table === "packageStatEvents") {
+            return {
+              withIndex: vi.fn(() => ({
+                take: vi.fn(async () => events),
+              })),
+            };
+          }
+          if (table === "packageSearchDigest") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue({
+                  _id: "packageSearchDigest:one",
+                  packageId: "packages:one",
+                  stats: { downloads: 10, installs: 1, stars: 2, versions: 3 },
+                }),
+              })),
+            };
+          }
+          if (table === "packageCapabilitySearchDigest") {
+            return {
+              withIndex: vi.fn(() => ({
+                collect: vi.fn().mockResolvedValue([
+                  {
+                    _id: "packageCapabilitySearchDigest:one-tools",
+                    packageId: "packages:one",
+                    capabilityTag: "tools",
+                    ownerHandle: "owner",
+                    ownerKind: "user",
+                    stats: { downloads: 10, installs: 1, stars: 2, versions: 3 },
+                  },
+                ]),
+              })),
+            };
+          }
+          if (table === "packagePluginCategorySearchDigest") {
+            return {
+              withIndex: vi.fn(() => ({
+                collect: vi.fn().mockResolvedValue([]),
+              })),
+            };
+          }
+          throw new Error(`Unexpected table: ${table}`);
+        }),
+        get: vi.fn(async (id: string) => (id === "packages:one" ? packageDoc : null)),
+        normalizeId: vi.fn(),
+        insert: vi.fn(),
+        patch,
+        replace: vi.fn(),
+        delete: vi.fn(),
+        system: {
+          get: vi.fn(),
+          query: vi.fn(),
+        },
+      },
+      scheduler: {
+        runAfter: vi.fn(),
+      },
+    };
+
+    await processStatsHandler(ctx, { batchSize: 10 });
+
+    expect(patch).toHaveBeenCalledWith(
+      "packageSearchDigest:one",
+      expect.objectContaining({
+        stats: expect.objectContaining({ installs: 2 }),
+      }),
+    );
+    expect(patch).toHaveBeenCalledWith("packageCapabilitySearchDigest:one-tools", {
+      stats: { downloads: 10, installs: 2, stars: 2, versions: 3 },
+    });
+  });
 });
+
+function makeStatsPackageDoc(
+  id: string,
+  overrides: Partial<{
+    downloads: number;
+    installs: number;
+    stars: number;
+    versions: number;
+    capabilityTags: string[];
+  }> = {},
+) {
+  const name = id.replace("packages:", "demo-");
+  return {
+    _id: id,
+    name,
+    normalizedName: name,
+    displayName: name,
+    family: "code-plugin",
+    channel: "community",
+    isOfficial: false,
+    ownerUserId: "users:owner",
+    ownerPublisherId: undefined,
+    tags: {},
+    latestReleaseId: "packageReleases:demo-1",
+    latestVersionSummary: { version: "1.0.0" },
+    compatibility: null,
+    capabilities: null,
+    verification: null,
+    scanStatus: "clean",
+    capabilityTags: overrides.capabilityTags ?? [],
+    stats: {
+      downloads: overrides.downloads ?? 0,
+      installs: overrides.installs ?? 0,
+      stars: overrides.stars ?? 0,
+      versions: overrides.versions ?? 1,
+    },
+    createdAt: 1,
+    updatedAt: 1,
+    softDeletedAt: undefined,
+  };
+}

--- a/convex/packages.stats.test.ts
+++ b/convex/packages.stats.test.ts
@@ -23,10 +23,10 @@ const recordInstallHandler = (
   recordPackageInstallInternal as unknown as WrappedHandler<
     {
       packageId: string;
-      identityKind?: "user" | "ip";
-      identityHash?: string;
-      dayStart?: number;
-      occurredAt?: number;
+      identityKind: "user" | "ip";
+      identityHash: string;
+      dayStart: number;
+      occurredAt: number;
     },
     void
   >
@@ -74,13 +74,21 @@ describe("package stat events", () => {
     );
   });
 
-  it("records installs as append-only events", async () => {
+  it("records identity-backed installs as append-only events", async () => {
     const insert = vi.fn();
+    const unique = vi.fn().mockResolvedValue(null);
+    const queryBuilder = {
+      eq: vi.fn(() => queryBuilder),
+    };
+    const withIndex = vi.fn((_indexName: string, buildQuery: (q: unknown) => unknown) => {
+      buildQuery(queryBuilder);
+      return { unique };
+    });
 
     await recordInstallHandler(
       {
         db: {
-          query: vi.fn(),
+          query: vi.fn(() => ({ withIndex })),
           get: vi.fn(),
           normalizeId: vi.fn(),
           insert,
@@ -95,6 +103,10 @@ describe("package stat events", () => {
       },
       {
         packageId: "packages:one",
+        identityKind: "ip",
+        identityHash: "hash-ip",
+        dayStart: 86_400_000,
+        occurredAt: 86_500_000,
       },
     );
 
@@ -103,6 +115,7 @@ describe("package stat events", () => {
       expect.objectContaining({
         packageId: "packages:one",
         kind: "install",
+        occurredAt: 86_500_000,
         processedAt: undefined,
       }),
     );

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -3609,45 +3609,40 @@ export const recordPackageDownloadInternal = internalMutation({
 export const recordPackageInstallInternal = internalMutation({
   args: {
     packageId: v.id("packages"),
-    identityKind: v.optional(v.union(v.literal("user"), v.literal("ip"))),
-    identityHash: v.optional(v.string()),
-    dayStart: v.optional(v.number()),
-    occurredAt: v.optional(v.number()),
+    identityKind: v.union(v.literal("user"), v.literal("ip")),
+    identityHash: v.string(),
+    dayStart: v.number(),
+    occurredAt: v.number(),
   },
   handler: async (ctx, args) => {
-    const identityKind = args.identityKind;
-    const identityHash = args.identityHash;
-    const dayStart = args.dayStart;
-    if (identityKind && identityHash && typeof dayStart === "number") {
-      const existing = await ctx.db
-        .query("packageInstallMetricDedupes")
-        .withIndex("by_target_metric_identity_day", (q) =>
-          q
-            .eq("targetKind", "package")
-            .eq("targetId", args.packageId)
-            .eq("metricKind", "install")
-            .eq("identityKind", identityKind)
-            .eq("identityHash", identityHash)
-            .eq("dayStart", dayStart),
-        )
-        .unique();
-      if (existing) return;
+    const existing = await ctx.db
+      .query("packageInstallMetricDedupes")
+      .withIndex("by_target_metric_identity_day", (q) =>
+        q
+          .eq("targetKind", "package")
+          .eq("targetId", args.packageId)
+          .eq("metricKind", "install")
+          .eq("identityKind", args.identityKind)
+          .eq("identityHash", args.identityHash)
+          .eq("dayStart", args.dayStart),
+      )
+      .unique();
+    if (existing) return;
 
-      await ctx.db.insert("packageInstallMetricDedupes", {
-        targetKind: "package",
-        targetId: args.packageId,
-        metricKind: "install",
-        identityKind,
-        identityHash,
-        dayStart,
-        createdAt: Date.now(),
-      });
-    }
+    await ctx.db.insert("packageInstallMetricDedupes", {
+      targetKind: "package",
+      targetId: args.packageId,
+      metricKind: "install",
+      identityKind: args.identityKind,
+      identityHash: args.identityHash,
+      dayStart: args.dayStart,
+      createdAt: Date.now(),
+    });
 
     await ctx.db.insert("packageStatEvents", {
       packageId: args.packageId,
       kind: "install",
-      occurredAt: args.occurredAt ?? Date.now(),
+      occurredAt: args.occurredAt,
       processedAt: undefined,
     });
   },
@@ -4026,6 +4021,14 @@ async function hardDeletePackageDoc(
     .withIndex("by_package", (q) => q.eq("packageId", pkg._id))
     .collect();
   for (const statEvent of statEvents) await ctx.db.delete(statEvent._id);
+
+  const installDedupes = await ctx.db
+    .query("packageInstallMetricDedupes")
+    .withIndex("by_target_metric_identity_day", (q) =>
+      q.eq("targetKind", "package").eq("targetId", pkg._id),
+    )
+    .collect();
+  for (const installDedupe of installDedupes) await ctx.db.delete(installDedupe._id);
 
   for (const release of releases) await ctx.db.delete(release._id);
   await ctx.db.delete(pkg._id);

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -4027,7 +4027,7 @@ async function hardDeletePackageDoc(
     .withIndex("by_target_metric_identity_day", (q) =>
       q.eq("targetKind", "package").eq("targetId", pkg._id),
     )
-    .collect();
+    .take(MAX_PUBLIC_LIST_PAGE_SIZE);
   for (const installDedupe of installDedupes) await ctx.db.delete(installDedupe._id);
 
   for (const release of releases) await ctx.db.delete(release._id);

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -3961,6 +3961,27 @@ async function hardDeletePackageDoc(
     source: "account.delete" | "publisher.delete";
   },
 ) {
+  const installDedupes = await ctx.db
+    .query("packageInstallMetricDedupes")
+    .withIndex("by_target_metric_identity_day", (q) =>
+      q.eq("targetKind", "package").eq("targetId", pkg._id),
+    )
+    .take(MAX_PUBLIC_LIST_PAGE_SIZE);
+  for (const installDedupe of installDedupes) await ctx.db.delete(installDedupe._id);
+  if (installDedupes.length === MAX_PUBLIC_LIST_PAGE_SIZE) {
+    await ctx.scheduler.runAfter(0, internal.packages.hardDeletePackageInternal, {
+      packageId: pkg._id,
+      actorUserId: params.actorUserId,
+      deletedAt: params.deletedAt,
+      source: params.source,
+    });
+    return {
+      ok: true as const,
+      packageId: pkg._id,
+      cleanupPending: true as const,
+    };
+  }
+
   const releases = await ctx.db
     .query("packageReleases")
     .withIndex("by_package", (q) => q.eq("packageId", pkg._id))
@@ -4021,27 +4042,6 @@ async function hardDeletePackageDoc(
     .withIndex("by_package", (q) => q.eq("packageId", pkg._id))
     .collect();
   for (const statEvent of statEvents) await ctx.db.delete(statEvent._id);
-
-  const installDedupes = await ctx.db
-    .query("packageInstallMetricDedupes")
-    .withIndex("by_target_metric_identity_day", (q) =>
-      q.eq("targetKind", "package").eq("targetId", pkg._id),
-    )
-    .take(MAX_PUBLIC_LIST_PAGE_SIZE);
-  for (const installDedupe of installDedupes) await ctx.db.delete(installDedupe._id);
-  if (installDedupes.length === MAX_PUBLIC_LIST_PAGE_SIZE) {
-    await ctx.scheduler.runAfter(0, internal.packages.hardDeletePackageInternal, {
-      packageId: pkg._id,
-      actorUserId: params.actorUserId,
-      deletedAt: params.deletedAt,
-      source: params.source,
-    });
-    return {
-      ok: true as const,
-      packageId: pkg._id,
-      cleanupPending: true as const,
-    };
-  }
 
   for (const release of releases) await ctx.db.delete(release._id);
   await ctx.db.delete(pkg._id);

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -3953,7 +3953,7 @@ async function deletePackageModerationEventsForAppeal(
 }
 
 async function hardDeletePackageDoc(
-  ctx: Pick<MutationCtx, "db">,
+  ctx: Pick<MutationCtx, "db" | "scheduler">,
   pkg: Doc<"packages">,
   params: {
     actorUserId: Id<"users">;
@@ -4029,6 +4029,19 @@ async function hardDeletePackageDoc(
     )
     .take(MAX_PUBLIC_LIST_PAGE_SIZE);
   for (const installDedupe of installDedupes) await ctx.db.delete(installDedupe._id);
+  if (installDedupes.length === MAX_PUBLIC_LIST_PAGE_SIZE) {
+    await ctx.scheduler.runAfter(0, internal.packages.hardDeletePackageInternal, {
+      packageId: pkg._id,
+      actorUserId: params.actorUserId,
+      deletedAt: params.deletedAt,
+      source: params.source,
+    });
+    return {
+      ok: true as const,
+      packageId: pkg._id,
+      cleanupPending: true as const,
+    };
+  }
 
   for (const release of releases) await ctx.db.delete(release._id);
   await ctx.db.delete(pkg._id);
@@ -4074,6 +4087,7 @@ export const hardDeletePackageInternal = internalMutation({
       deletedAt: args.deletedAt,
       source: args.source,
     });
+    if ("cleanupPending" in result) return { ...result, deleted: false as const };
     return { ...result, deleted: true as const };
   },
 });

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -64,7 +64,11 @@ import {
   summarizePackageForSearch,
   toConvexSafeJsonValue,
 } from "./lib/packageRegistry";
-import { extractPackageDigestFields, upsertPackageSearchDigest } from "./lib/packageSearchDigest";
+import {
+  extractPackageDigestFields,
+  patchPackageSearchDigestStats,
+  upsertPackageSearchDigest,
+} from "./lib/packageSearchDigest";
 import {
   getPackageTrustReasons,
   isPackageBlockedFromPublic,
@@ -1766,8 +1770,12 @@ function buildPackageCapabilityDigestQuery(
     channel?: PackageChannel;
     isOfficial?: boolean;
     executesCode?: boolean;
+    sort?: "updated" | "installs";
   },
 ) {
+  if (args.sort === "installs") {
+    return buildPackageCapabilityInstallDigestQuery(ctx, args);
+  }
   const family = args.family;
   const channel = args.channel;
   const isOfficial = args.isOfficial;
@@ -1922,6 +1930,170 @@ function buildPackageCapabilityDigestQuery(
     );
 }
 
+function buildPackageCapabilityInstallDigestQuery(
+  ctx: DbReaderCtx,
+  args: {
+    capabilityTag: string;
+    family?: PackageFamily;
+    channel?: PackageChannel;
+    isOfficial?: boolean;
+    executesCode?: boolean;
+  },
+) {
+  const family = args.family;
+  const channel = args.channel;
+  const isOfficial = args.isOfficial;
+  const executesCode = args.executesCode;
+
+  if (family && channel && typeof executesCode === "boolean") {
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_family_channel_tag_executes_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("family", family)
+          .eq("channel", channel)
+          .eq("capabilityTag", args.capabilityTag)
+          .eq("executesCode", executesCode),
+      );
+  }
+  if (family && typeof isOfficial === "boolean" && typeof executesCode === "boolean") {
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_family_official_tag_executes_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("family", family)
+          .eq("isOfficial", isOfficial)
+          .eq("capabilityTag", args.capabilityTag)
+          .eq("executesCode", executesCode),
+      );
+  }
+  if (channel && typeof isOfficial === "boolean" && typeof executesCode === "boolean") {
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_channel_official_tag_executes_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("channel", channel)
+          .eq("isOfficial", isOfficial)
+          .eq("capabilityTag", args.capabilityTag)
+          .eq("executesCode", executesCode),
+      );
+  }
+  if (family && channel) {
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_family_channel_tag_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("family", family)
+          .eq("channel", channel)
+          .eq("capabilityTag", args.capabilityTag),
+      );
+  }
+  if (family && typeof isOfficial === "boolean") {
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_family_official_tag_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("family", family)
+          .eq("isOfficial", isOfficial)
+          .eq("capabilityTag", args.capabilityTag),
+      );
+  }
+  if (channel && typeof isOfficial === "boolean") {
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_channel_official_tag_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("channel", channel)
+          .eq("isOfficial", isOfficial)
+          .eq("capabilityTag", args.capabilityTag),
+      );
+  }
+  if (family && typeof executesCode === "boolean") {
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_family_tag_executes_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("family", family)
+          .eq("capabilityTag", args.capabilityTag)
+          .eq("executesCode", executesCode),
+      );
+  }
+  if (channel && typeof executesCode === "boolean") {
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_channel_tag_executes_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("channel", channel)
+          .eq("capabilityTag", args.capabilityTag)
+          .eq("executesCode", executesCode),
+      );
+  }
+  if (typeof isOfficial === "boolean" && typeof executesCode === "boolean") {
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_official_tag_executes_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("isOfficial", isOfficial)
+          .eq("capabilityTag", args.capabilityTag)
+          .eq("executesCode", executesCode),
+      );
+  }
+  if (family) {
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_family_tag_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("family", family)
+          .eq("capabilityTag", args.capabilityTag),
+      );
+  }
+  if (channel) {
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_channel_tag_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("channel", channel)
+          .eq("capabilityTag", args.capabilityTag),
+      );
+  }
+  if (typeof isOfficial === "boolean") {
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_official_tag_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("isOfficial", isOfficial)
+          .eq("capabilityTag", args.capabilityTag),
+      );
+  }
+  if (typeof executesCode === "boolean") {
+    return ctx.db
+      .query("packageCapabilitySearchDigest")
+      .withIndex("by_active_tag_executes_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("capabilityTag", args.capabilityTag)
+          .eq("executesCode", executesCode),
+      );
+  }
+  return ctx.db
+    .query("packageCapabilitySearchDigest")
+    .withIndex("by_active_tag_installs", (q) =>
+      q.eq("softDeletedAt", undefined).eq("capabilityTag", args.capabilityTag),
+    );
+}
+
 function buildPackagePluginCategoryDigestQuery(
   ctx: DbReaderCtx,
   args: {
@@ -1930,8 +2102,12 @@ function buildPackagePluginCategoryDigestQuery(
     channel?: PackageChannel;
     isOfficial?: boolean;
     executesCode?: boolean;
+    sort?: "updated" | "installs";
   },
 ) {
+  if (args.sort === "installs") {
+    return buildPackagePluginCategoryInstallDigestQuery(ctx, args);
+  }
   const family = args.family;
   const channel = args.channel;
   const isOfficial = args.isOfficial;
@@ -2076,6 +2252,164 @@ function buildPackagePluginCategoryDigestQuery(
   return ctx.db
     .query("packagePluginCategorySearchDigest")
     .withIndex("by_active_category_updated", (q) =>
+      q.eq("softDeletedAt", undefined).eq("pluginCategory", args.category),
+    );
+}
+
+function buildPackagePluginCategoryInstallDigestQuery(
+  ctx: DbReaderCtx,
+  args: {
+    category: PluginCategorySlug;
+    family?: PackageFamily;
+    channel?: PackageChannel;
+    isOfficial?: boolean;
+    executesCode?: boolean;
+  },
+) {
+  const family = args.family;
+  const channel = args.channel;
+  const isOfficial = args.isOfficial;
+  const executesCode = args.executesCode;
+
+  if (family && channel && typeof executesCode === "boolean") {
+    return ctx.db
+      .query("packagePluginCategorySearchDigest")
+      .withIndex("by_active_family_channel_category_executes_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("family", family)
+          .eq("channel", channel)
+          .eq("pluginCategory", args.category)
+          .eq("executesCode", executesCode),
+      );
+  }
+  if (family && typeof isOfficial === "boolean" && typeof executesCode === "boolean") {
+    return ctx.db
+      .query("packagePluginCategorySearchDigest")
+      .withIndex("by_active_family_official_category_executes_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("family", family)
+          .eq("isOfficial", isOfficial)
+          .eq("pluginCategory", args.category)
+          .eq("executesCode", executesCode),
+      );
+  }
+  if (channel && typeof isOfficial === "boolean" && typeof executesCode === "boolean") {
+    return ctx.db
+      .query("packagePluginCategorySearchDigest")
+      .withIndex("by_active_channel_official_category_executes_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("channel", channel)
+          .eq("isOfficial", isOfficial)
+          .eq("pluginCategory", args.category)
+          .eq("executesCode", executesCode),
+      );
+  }
+  if (family && channel) {
+    return ctx.db
+      .query("packagePluginCategorySearchDigest")
+      .withIndex("by_active_family_channel_category_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("family", family)
+          .eq("channel", channel)
+          .eq("pluginCategory", args.category),
+      );
+  }
+  if (family && typeof isOfficial === "boolean") {
+    return ctx.db
+      .query("packagePluginCategorySearchDigest")
+      .withIndex("by_active_family_official_category_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("family", family)
+          .eq("isOfficial", isOfficial)
+          .eq("pluginCategory", args.category),
+      );
+  }
+  if (channel && typeof isOfficial === "boolean") {
+    return ctx.db
+      .query("packagePluginCategorySearchDigest")
+      .withIndex("by_active_channel_official_category_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("channel", channel)
+          .eq("isOfficial", isOfficial)
+          .eq("pluginCategory", args.category),
+      );
+  }
+  if (family && typeof executesCode === "boolean") {
+    return ctx.db
+      .query("packagePluginCategorySearchDigest")
+      .withIndex("by_active_family_category_executes_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("family", family)
+          .eq("pluginCategory", args.category)
+          .eq("executesCode", executesCode),
+      );
+  }
+  if (channel && typeof executesCode === "boolean") {
+    return ctx.db
+      .query("packagePluginCategorySearchDigest")
+      .withIndex("by_active_channel_category_executes_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("channel", channel)
+          .eq("pluginCategory", args.category)
+          .eq("executesCode", executesCode),
+      );
+  }
+  if (typeof isOfficial === "boolean" && typeof executesCode === "boolean") {
+    return ctx.db
+      .query("packagePluginCategorySearchDigest")
+      .withIndex("by_active_official_category_executes_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("isOfficial", isOfficial)
+          .eq("pluginCategory", args.category)
+          .eq("executesCode", executesCode),
+      );
+  }
+  if (family) {
+    return ctx.db
+      .query("packagePluginCategorySearchDigest")
+      .withIndex("by_active_family_category_installs", (q) =>
+        q.eq("softDeletedAt", undefined).eq("family", family).eq("pluginCategory", args.category),
+      );
+  }
+  if (channel) {
+    return ctx.db
+      .query("packagePluginCategorySearchDigest")
+      .withIndex("by_active_channel_category_installs", (q) =>
+        q.eq("softDeletedAt", undefined).eq("channel", channel).eq("pluginCategory", args.category),
+      );
+  }
+  if (typeof isOfficial === "boolean") {
+    return ctx.db
+      .query("packagePluginCategorySearchDigest")
+      .withIndex("by_active_official_category_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("isOfficial", isOfficial)
+          .eq("pluginCategory", args.category),
+      );
+  }
+  if (typeof executesCode === "boolean") {
+    return ctx.db
+      .query("packagePluginCategorySearchDigest")
+      .withIndex("by_active_category_executes_installs", (q) =>
+        q
+          .eq("softDeletedAt", undefined)
+          .eq("pluginCategory", args.category)
+          .eq("executesCode", executesCode),
+      );
+  }
+  return ctx.db
+    .query("packagePluginCategorySearchDigest")
+    .withIndex("by_active_category_installs", (q) =>
       q.eq("softDeletedAt", undefined).eq("pluginCategory", args.category),
     );
 }
@@ -3246,6 +3580,8 @@ async function listPackagePageImpl(
   const channel = args.channel;
   const isOfficial = args.isOfficial;
   const category = isPluginCategorySlug(args.category) ? args.category : undefined;
+  const useFilteredInstallDigest =
+    args.sort === "installs" && (Boolean(category) || Boolean(args.capabilityTag));
   const decodedCursor = decodePublicPageCursor(args.paginationOpts.cursor);
   if (decodedCursor.done && decodedCursor.offset === 0) {
     return { page: collected, isDone: true, continueCursor: "" };
@@ -3273,7 +3609,10 @@ async function listPackagePageImpl(
         : await getPackageRecommendedIndexName(ctx, family)
       : null;
 
-  if (args.sort === "downloads" || args.sort === "installs" || recommendedIndexName) {
+  if (
+    (args.sort === "downloads" || args.sort === "installs" || recommendedIndexName) &&
+    !useFilteredInstallDigest
+  ) {
     let cursor = pageCursor;
     let pageOffset = offset;
     let pageSize: number | null = decodedCursor.pageSize ?? null;
@@ -3364,6 +3703,7 @@ async function listPackagePageImpl(
         channel,
         isOfficial,
         executesCode: args.executesCode,
+        sort: useFilteredInstallDigest ? "installs" : "updated",
       })
     : args.capabilityTag
       ? buildPackageCapabilityDigestQuery(ctx, {
@@ -3372,6 +3712,7 @@ async function listPackagePageImpl(
           channel,
           isOfficial,
           executesCode: args.executesCode,
+          sort: useFilteredInstallDigest ? "installs" : "updated",
         })
       : buildPackageDigestQuery(ctx, {
           family,
@@ -3681,10 +4022,12 @@ export const processPackageStatEventsInternal = internalMutation({
         stars: pkg.stats?.stars ?? 0,
         versions: pkg.stats?.versions ?? 0,
       };
+      const recommendationPatch = computePackageRecommendationPatch(nextStats);
       await ctx.db.patch(pkg._id, {
         stats: nextStats,
-        ...computePackageRecommendationPatch(nextStats),
+        ...recommendationPatch,
       });
+      await patchPackageSearchDigestStats(ctx, pkg._id, nextStats);
       packagesUpdated += 1;
     }
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1620,13 +1620,33 @@ const packageCapabilitySearchDigest = defineTable({
 })
   .index("by_package", ["packageId", "capabilityTag"])
   .index("by_active_tag_updated", ["softDeletedAt", "capabilityTag", "updatedAt"])
+  .index("by_active_tag_installs", [
+    "softDeletedAt",
+    "capabilityTag",
+    "stats.installs",
+    "updatedAt",
+  ])
   .index("by_active_tag_executes_updated", [
     "softDeletedAt",
     "capabilityTag",
     "executesCode",
     "updatedAt",
   ])
+  .index("by_active_tag_executes_installs", [
+    "softDeletedAt",
+    "capabilityTag",
+    "executesCode",
+    "stats.installs",
+    "updatedAt",
+  ])
   .index("by_active_family_tag_updated", ["softDeletedAt", "family", "capabilityTag", "updatedAt"])
+  .index("by_active_family_tag_installs", [
+    "softDeletedAt",
+    "family",
+    "capabilityTag",
+    "stats.installs",
+    "updatedAt",
+  ])
   .index("by_active_family_tag_executes_updated", [
     "softDeletedAt",
     "family",
@@ -1634,10 +1654,25 @@ const packageCapabilitySearchDigest = defineTable({
     "executesCode",
     "updatedAt",
   ])
+  .index("by_active_family_tag_executes_installs", [
+    "softDeletedAt",
+    "family",
+    "capabilityTag",
+    "executesCode",
+    "stats.installs",
+    "updatedAt",
+  ])
   .index("by_active_channel_tag_updated", [
     "softDeletedAt",
     "channel",
     "capabilityTag",
+    "updatedAt",
+  ])
+  .index("by_active_channel_tag_installs", [
+    "softDeletedAt",
+    "channel",
+    "capabilityTag",
+    "stats.installs",
     "updatedAt",
   ])
   .index("by_active_channel_tag_executes_updated", [
@@ -1647,10 +1682,25 @@ const packageCapabilitySearchDigest = defineTable({
     "executesCode",
     "updatedAt",
   ])
+  .index("by_active_channel_tag_executes_installs", [
+    "softDeletedAt",
+    "channel",
+    "capabilityTag",
+    "executesCode",
+    "stats.installs",
+    "updatedAt",
+  ])
   .index("by_active_official_tag_updated", [
     "softDeletedAt",
     "isOfficial",
     "capabilityTag",
+    "updatedAt",
+  ])
+  .index("by_active_official_tag_installs", [
+    "softDeletedAt",
+    "isOfficial",
+    "capabilityTag",
+    "stats.installs",
     "updatedAt",
   ])
   .index("by_active_official_tag_executes_updated", [
@@ -1660,11 +1710,27 @@ const packageCapabilitySearchDigest = defineTable({
     "executesCode",
     "updatedAt",
   ])
+  .index("by_active_official_tag_executes_installs", [
+    "softDeletedAt",
+    "isOfficial",
+    "capabilityTag",
+    "executesCode",
+    "stats.installs",
+    "updatedAt",
+  ])
   .index("by_active_family_channel_tag_updated", [
     "softDeletedAt",
     "family",
     "channel",
     "capabilityTag",
+    "updatedAt",
+  ])
+  .index("by_active_family_channel_tag_installs", [
+    "softDeletedAt",
+    "family",
+    "channel",
+    "capabilityTag",
+    "stats.installs",
     "updatedAt",
   ])
   .index("by_active_family_channel_tag_executes_updated", [
@@ -1675,11 +1741,28 @@ const packageCapabilitySearchDigest = defineTable({
     "executesCode",
     "updatedAt",
   ])
+  .index("by_active_family_channel_tag_executes_installs", [
+    "softDeletedAt",
+    "family",
+    "channel",
+    "capabilityTag",
+    "executesCode",
+    "stats.installs",
+    "updatedAt",
+  ])
   .index("by_active_family_official_tag_updated", [
     "softDeletedAt",
     "family",
     "isOfficial",
     "capabilityTag",
+    "updatedAt",
+  ])
+  .index("by_active_family_official_tag_installs", [
+    "softDeletedAt",
+    "family",
+    "isOfficial",
+    "capabilityTag",
+    "stats.installs",
     "updatedAt",
   ])
   .index("by_active_family_official_tag_executes_updated", [
@@ -1690,11 +1773,28 @@ const packageCapabilitySearchDigest = defineTable({
     "executesCode",
     "updatedAt",
   ])
+  .index("by_active_family_official_tag_executes_installs", [
+    "softDeletedAt",
+    "family",
+    "isOfficial",
+    "capabilityTag",
+    "executesCode",
+    "stats.installs",
+    "updatedAt",
+  ])
   .index("by_active_channel_official_tag_updated", [
     "softDeletedAt",
     "channel",
     "isOfficial",
     "capabilityTag",
+    "updatedAt",
+  ])
+  .index("by_active_channel_official_tag_installs", [
+    "softDeletedAt",
+    "channel",
+    "isOfficial",
+    "capabilityTag",
+    "stats.installs",
     "updatedAt",
   ])
   .index("by_active_channel_official_tag_executes_updated", [
@@ -1703,6 +1803,15 @@ const packageCapabilitySearchDigest = defineTable({
     "isOfficial",
     "capabilityTag",
     "executesCode",
+    "updatedAt",
+  ])
+  .index("by_active_channel_official_tag_executes_installs", [
+    "softDeletedAt",
+    "channel",
+    "isOfficial",
+    "capabilityTag",
+    "executesCode",
+    "stats.installs",
     "updatedAt",
   ]);
 
@@ -1734,16 +1843,36 @@ const packagePluginCategorySearchDigest = defineTable({
 })
   .index("by_package", ["packageId", "pluginCategory"])
   .index("by_active_category_updated", ["softDeletedAt", "pluginCategory", "updatedAt"])
+  .index("by_active_category_installs", [
+    "softDeletedAt",
+    "pluginCategory",
+    "stats.installs",
+    "updatedAt",
+  ])
   .index("by_active_category_executes_updated", [
     "softDeletedAt",
     "pluginCategory",
     "executesCode",
     "updatedAt",
   ])
+  .index("by_active_category_executes_installs", [
+    "softDeletedAt",
+    "pluginCategory",
+    "executesCode",
+    "stats.installs",
+    "updatedAt",
+  ])
   .index("by_active_family_category_updated", [
     "softDeletedAt",
     "family",
     "pluginCategory",
+    "updatedAt",
+  ])
+  .index("by_active_family_category_installs", [
+    "softDeletedAt",
+    "family",
+    "pluginCategory",
+    "stats.installs",
     "updatedAt",
   ])
   .index("by_active_family_category_executes_updated", [
@@ -1753,10 +1882,25 @@ const packagePluginCategorySearchDigest = defineTable({
     "executesCode",
     "updatedAt",
   ])
+  .index("by_active_family_category_executes_installs", [
+    "softDeletedAt",
+    "family",
+    "pluginCategory",
+    "executesCode",
+    "stats.installs",
+    "updatedAt",
+  ])
   .index("by_active_channel_category_updated", [
     "softDeletedAt",
     "channel",
     "pluginCategory",
+    "updatedAt",
+  ])
+  .index("by_active_channel_category_installs", [
+    "softDeletedAt",
+    "channel",
+    "pluginCategory",
+    "stats.installs",
     "updatedAt",
   ])
   .index("by_active_channel_category_executes_updated", [
@@ -1766,10 +1910,25 @@ const packagePluginCategorySearchDigest = defineTable({
     "executesCode",
     "updatedAt",
   ])
+  .index("by_active_channel_category_executes_installs", [
+    "softDeletedAt",
+    "channel",
+    "pluginCategory",
+    "executesCode",
+    "stats.installs",
+    "updatedAt",
+  ])
   .index("by_active_official_category_updated", [
     "softDeletedAt",
     "isOfficial",
     "pluginCategory",
+    "updatedAt",
+  ])
+  .index("by_active_official_category_installs", [
+    "softDeletedAt",
+    "isOfficial",
+    "pluginCategory",
+    "stats.installs",
     "updatedAt",
   ])
   .index("by_active_official_category_executes_updated", [
@@ -1779,11 +1938,27 @@ const packagePluginCategorySearchDigest = defineTable({
     "executesCode",
     "updatedAt",
   ])
+  .index("by_active_official_category_executes_installs", [
+    "softDeletedAt",
+    "isOfficial",
+    "pluginCategory",
+    "executesCode",
+    "stats.installs",
+    "updatedAt",
+  ])
   .index("by_active_family_channel_category_updated", [
     "softDeletedAt",
     "family",
     "channel",
     "pluginCategory",
+    "updatedAt",
+  ])
+  .index("by_active_family_channel_category_installs", [
+    "softDeletedAt",
+    "family",
+    "channel",
+    "pluginCategory",
+    "stats.installs",
     "updatedAt",
   ])
   .index("by_active_family_channel_category_executes_updated", [
@@ -1794,11 +1969,28 @@ const packagePluginCategorySearchDigest = defineTable({
     "executesCode",
     "updatedAt",
   ])
+  .index("by_active_family_channel_category_executes_installs", [
+    "softDeletedAt",
+    "family",
+    "channel",
+    "pluginCategory",
+    "executesCode",
+    "stats.installs",
+    "updatedAt",
+  ])
   .index("by_active_family_official_category_updated", [
     "softDeletedAt",
     "family",
     "isOfficial",
     "pluginCategory",
+    "updatedAt",
+  ])
+  .index("by_active_family_official_category_installs", [
+    "softDeletedAt",
+    "family",
+    "isOfficial",
+    "pluginCategory",
+    "stats.installs",
     "updatedAt",
   ])
   .index("by_active_family_official_category_executes_updated", [
@@ -1809,11 +2001,28 @@ const packagePluginCategorySearchDigest = defineTable({
     "executesCode",
     "updatedAt",
   ])
+  .index("by_active_family_official_category_executes_installs", [
+    "softDeletedAt",
+    "family",
+    "isOfficial",
+    "pluginCategory",
+    "executesCode",
+    "stats.installs",
+    "updatedAt",
+  ])
   .index("by_active_channel_official_category_updated", [
     "softDeletedAt",
     "channel",
     "isOfficial",
     "pluginCategory",
+    "updatedAt",
+  ])
+  .index("by_active_channel_official_category_installs", [
+    "softDeletedAt",
+    "channel",
+    "isOfficial",
+    "pluginCategory",
+    "stats.installs",
     "updatedAt",
   ])
   .index("by_active_channel_official_category_executes_updated", [
@@ -1822,6 +2031,15 @@ const packagePluginCategorySearchDigest = defineTable({
     "isOfficial",
     "pluginCategory",
     "executesCode",
+    "updatedAt",
+  ])
+  .index("by_active_channel_official_category_executes_installs", [
+    "softDeletedAt",
+    "channel",
+    "isOfficial",
+    "pluginCategory",
+    "executesCode",
+    "stats.installs",
     "updatedAt",
   ]);
 

--- a/convex/skills.packageCatalog.test.ts
+++ b/convex/skills.packageCatalog.test.ts
@@ -25,7 +25,7 @@ const listPackageCatalogPageHandler = (
       isOfficial?: boolean;
       executesCode?: boolean;
       capabilityTag?: string;
-      sort?: "updated" | "downloads" | "installs";
+      sort?: "updated" | "downloads" | "installs" | "recommended";
       paginationOpts: { cursor: string | null; numItems: number };
     },
     {
@@ -259,6 +259,54 @@ describe("skills package catalog queries", () => {
       expect.objectContaining({
         name: "installed-skill",
         stats: expect.objectContaining({ installs: 20 }),
+      }),
+    ]);
+  });
+
+  it("accepts recommended sort and uses the recommendation score index for package catalog rows", async () => {
+    const exportArgs = (listPackageCatalogPage as unknown as { exportArgs: () => string })
+      .exportArgs;
+    const exportedArgs = JSON.parse(exportArgs()) as {
+      value: {
+        sort?: {
+          fieldType?: {
+            value?: Array<{ value?: string }>;
+          };
+        };
+      };
+    };
+    expect(exportedArgs.value.sort?.fieldType?.value?.map((entry) => entry.value)).toContain(
+      "recommended",
+    );
+
+    const indexNames: string[] = [];
+    const result = await listPackageCatalogPageHandler(
+      makeCtx(
+        [
+          {
+            page: [
+              makeDigest("recommended-skill", {
+                recommendedScore: 400,
+                recommendedScoreVersion: 3,
+              }),
+            ],
+            isDone: true,
+            continueCursor: "",
+          },
+        ],
+        { indexNames },
+      ),
+      {
+        sort: "recommended",
+        paginationOpts: { cursor: null, numItems: 10 },
+      },
+    );
+
+    expect(indexNames).toEqual(["by_active_recommended_score"]);
+    expect(result.page).toEqual([
+      expect.objectContaining({
+        name: "recommended-skill",
+        family: "skill",
       }),
     ]);
   });

--- a/convex/skills.packageCatalog.test.ts
+++ b/convex/skills.packageCatalog.test.ts
@@ -109,11 +109,13 @@ function makeDigest(
 
 function makeCtx(
   pages: Array<{ page: Array<Record<string, unknown>>; isDone: boolean; continueCursor: string }>,
-  optionsOrIndexNames: { indexNames?: string[] } | string[] = {},
+  optionsOrIndexNames: { firstByIndex?: Record<string, unknown>; indexNames?: string[] } | string[] =
+    {},
 ) {
-  const indexNames = Array.isArray(optionsOrIndexNames)
-    ? optionsOrIndexNames
-    : optionsOrIndexNames.indexNames;
+  const options = Array.isArray(optionsOrIndexNames)
+    ? { indexNames: optionsOrIndexNames }
+    : optionsOrIndexNames;
+  const indexNames = options.indexNames;
   const pageByCursor = new Map<
     string | null,
     { page: Array<Record<string, unknown>>; isDone: boolean; continueCursor: string }
@@ -156,6 +158,7 @@ function makeCtx(
           withIndex: (indexName: string) => {
             indexNames?.push(indexName);
             return {
+              first: async () => options.firstByIndex?.[indexName] ?? null,
               order: () => ({
                 paginate: async ({ cursor: pageCursor }: { cursor: string | null }) =>
                   pageByCursor.get(pageCursor) ?? { page: [], isDone: true, continueCursor: "" },
@@ -302,13 +305,51 @@ describe("skills package catalog queries", () => {
       },
     );
 
-    expect(indexNames).toEqual(["by_active_recommended_score"]);
+    expect(indexNames).toEqual([
+      "by_active_recommended_score",
+      "by_active_recommended_score_version",
+      "by_active_recommended_score_version",
+      "by_active_recommended_score",
+    ]);
     expect(result.page).toEqual([
       expect.objectContaining({
         name: "recommended-skill",
         family: "skill",
       }),
     ]);
+  });
+
+  it("falls back to updated sort for recommended package catalog rows while scores backfill", async () => {
+    const indexNames: string[] = [];
+    const result = await listPackageCatalogPageHandler(
+      makeCtx(
+        [
+          {
+            page: [makeDigest("fallback-skill")],
+            isDone: false,
+            continueCursor: "next-updated-page",
+          },
+        ],
+        {
+          firstByIndex: {
+            by_active_recommended_score_version: { _id: "skillSearchDigest:stale" },
+          },
+          indexNames,
+        },
+      ),
+      {
+        sort: "recommended",
+        paginationOpts: { cursor: null, numItems: 1 },
+      },
+    );
+
+    expect(indexNames).toEqual([
+      "by_active_recommended_score",
+      "by_active_recommended_score_version",
+      "by_active_updated",
+    ]);
+    expect(result.page).toEqual([expect.objectContaining({ name: "fallback-skill" })]);
+    expect(result.continueCursor).toContain('"recommendedFallback":"updated"');
   });
 
   it("searches skills with package-style lexical scoring", async () => {

--- a/convex/skills.packageCatalog.test.ts
+++ b/convex/skills.packageCatalog.test.ts
@@ -352,6 +352,50 @@ describe("skills package catalog queries", () => {
     expect(result.continueCursor).toContain('"recommendedFallback":"updated"');
   });
 
+  it("keeps recommendation sort for non-fallback in-page package catalog cursors", async () => {
+    const indexNames: string[] = [];
+    const cursor = `skillcat:${JSON.stringify({
+      cursor: null,
+      offset: 1,
+      pageSize: 2,
+      done: false,
+    })}`;
+    const result = await listPackageCatalogPageHandler(
+      makeCtx(
+        [
+          {
+            page: [
+              makeDigest("recommended-first", {
+                recommendedScore: 500,
+                recommendedScoreVersion: 3,
+              }),
+              makeDigest("recommended-second", {
+                recommendedScore: 400,
+                recommendedScoreVersion: 3,
+              }),
+            ],
+            isDone: false,
+            continueCursor: "next-recommended-page",
+          },
+        ],
+        {
+          firstByIndex: {
+            by_active_recommended_score_version: { _id: "skillSearchDigest:stale" },
+          },
+          indexNames,
+        },
+      ),
+      {
+        sort: "recommended",
+        paginationOpts: { cursor, numItems: 1 },
+      },
+    );
+
+    expect(indexNames).toEqual(["by_active_recommended_score"]);
+    expect(result.page).toEqual([expect.objectContaining({ name: "recommended-second" })]);
+    expect(result.continueCursor).not.toContain('"recommendedFallback":"updated"');
+  });
+
   it("searches skills with package-style lexical scoring", async () => {
     const result = await searchPackageCatalogPublicHandler(
       makeCtx([

--- a/convex/skills.packageCatalog.test.ts
+++ b/convex/skills.packageCatalog.test.ts
@@ -109,8 +109,9 @@ function makeDigest(
 
 function makeCtx(
   pages: Array<{ page: Array<Record<string, unknown>>; isDone: boolean; continueCursor: string }>,
-  optionsOrIndexNames: { firstByIndex?: Record<string, unknown>; indexNames?: string[] } | string[] =
-    {},
+  optionsOrIndexNames:
+    | { firstByIndex?: Record<string, unknown>; indexNames?: string[] }
+    | string[] = {},
 ) {
   const options = Array.isArray(optionsOrIndexNames)
     ? { indexNames: optionsOrIndexNames }

--- a/convex/skills.packageCatalog.test.ts
+++ b/convex/skills.packageCatalog.test.ts
@@ -109,8 +109,11 @@ function makeDigest(
 
 function makeCtx(
   pages: Array<{ page: Array<Record<string, unknown>>; isDone: boolean; continueCursor: string }>,
-  indexNames: string[] = [],
+  optionsOrIndexNames: { indexNames?: string[] } | string[] = {},
 ) {
+  const indexNames = Array.isArray(optionsOrIndexNames)
+    ? optionsOrIndexNames
+    : optionsOrIndexNames.indexNames;
   const pageByCursor = new Map<
     string | null,
     { page: Array<Record<string, unknown>>; isDone: boolean; continueCursor: string }
@@ -151,7 +154,7 @@ function makeCtx(
 
         return {
           withIndex: (indexName: string) => {
-            indexNames.push(indexName);
+            indexNames?.push(indexName);
             return {
               order: () => ({
                 paginate: async ({ cursor: pageCursor }: { cursor: string | null }) =>
@@ -216,6 +219,46 @@ describe("skills package catalog queries", () => {
         family: "skill",
         channel: "official",
         isOfficial: true,
+      }),
+    ]);
+  });
+
+  it("uses the all-time installs index for install-sorted package catalog rows", async () => {
+    const indexNames: string[] = [];
+    const result = await listPackageCatalogPageHandler(
+      makeCtx(
+        [
+          {
+            page: [
+              makeDigest("installed-skill", {
+                stats: {
+                  downloads: 1,
+                  installsCurrent: 2,
+                  installsAllTime: 20,
+                  stars: 0,
+                  versions: 1,
+                  comments: 0,
+                },
+                statsInstallsAllTime: 20,
+              }),
+            ],
+            isDone: true,
+            continueCursor: "",
+          },
+        ],
+        { indexNames },
+      ),
+      {
+        sort: "installs",
+        paginationOpts: { cursor: null, numItems: 10 },
+      },
+    );
+
+    expect(indexNames).toEqual(["by_active_stats_installs_all_time"]);
+    expect(result.page).toEqual([
+      expect.objectContaining({
+        name: "installed-skill",
+        stats: expect.objectContaining({ installs: 20 }),
       }),
     ]);
   });

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -6164,6 +6164,13 @@ export const searchPackageCatalogPublic = query({
   },
 });
 
+export const hasMissingPackageCatalogRecommendationScoresInternal = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    return await hasMissingRecommendedScores(ctx, false, null);
+  },
+});
+
 export const searchPackageCatalogForHttpInternal = internalQuery({
   args: {
     query: v.string(),

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -5983,10 +5983,16 @@ export const listPackageCatalogPage = query({
     let offset = decodedCursor.offset;
     let pageSize = decodedCursor.pageSize;
     let done = decodedCursor.done;
+    const isFreshRecommendedRequest =
+      args.sort === "recommended" &&
+      !args.paginationOpts.cursor &&
+      !cursor &&
+      offset === 0 &&
+      !done;
     const useUpdatedRecommendationFallback =
       args.sort === "recommended" &&
       (decodedCursor.recommendedFallback === "updated" ||
-        (!cursor && (await hasMissingRecommendedScores(ctx, false, null))));
+        (isFreshRecommendedRequest && (await hasMissingRecommendedScores(ctx, false, null))));
     const effectiveSort = useUpdatedRecommendationFallback ? "updated" : args.sort;
     let loops = 0;
     let remainingScanBudget = MAX_SKILL_CATALOG_SCAN_DOCUMENTS;

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -5771,6 +5771,7 @@ type SkillCatalogCursorState = {
   offset: number;
   pageSize: number | null;
   done: boolean;
+  recommendedFallback?: "updated";
 };
 
 function encodeSkillCatalogCursor(state: SkillCatalogCursorState) {
@@ -5792,6 +5793,7 @@ function decodeSkillCatalogCursor(raw: string | null | undefined): SkillCatalogC
       offset: typeof parsed.offset === "number" && parsed.offset > 0 ? parsed.offset : 0,
       pageSize: typeof parsed.pageSize === "number" && parsed.pageSize > 0 ? parsed.pageSize : null,
       done: parsed.done === true,
+      recommendedFallback: parsed.recommendedFallback === "updated" ? "updated" : undefined,
     };
   } catch {
     return { cursor: null, offset: 0, pageSize: null, done: false };
@@ -5981,6 +5983,11 @@ export const listPackageCatalogPage = query({
     let offset = decodedCursor.offset;
     let pageSize = decodedCursor.pageSize;
     let done = decodedCursor.done;
+    const useUpdatedRecommendationFallback =
+      args.sort === "recommended" &&
+      (decodedCursor.recommendedFallback === "updated" ||
+        (!cursor && (await hasMissingRecommendedScores(ctx, false, null))));
+    const effectiveSort = useUpdatedRecommendationFallback ? "updated" : args.sort;
     let loops = 0;
     let remainingScanBudget = MAX_SKILL_CATALOG_SCAN_DOCUMENTS;
 
@@ -6002,11 +6009,11 @@ export const listPackageCatalogPage = query({
       remainingScanBudget -= effectivePageSize;
       const pageCursor = cursor;
       const indexName =
-        args.sort === "recommended"
+        effectiveSort === "recommended"
           ? "by_active_recommended_score"
-          : args.sort === "downloads"
+          : effectiveSort === "downloads"
             ? "by_active_stats_downloads"
-            : args.sort === "installs"
+            : effectiveSort === "installs"
               ? "by_active_stats_installs_all_time"
               : "by_active_updated";
       const page = await paginator(ctx.db, schema)
@@ -6032,10 +6039,19 @@ export const listPackageCatalogPage = query({
             pageSize = effectivePageSize;
             done = page.isDone;
           }
+          const recommendedFallback = useUpdatedRecommendationFallback
+            ? ("updated" as const)
+            : undefined;
           return {
             page: collected,
             isDone: done && offset === 0,
-            continueCursor: encodeSkillCatalogCursor({ cursor, offset, pageSize, done }),
+            continueCursor: encodeSkillCatalogCursor({
+              cursor,
+              offset,
+              pageSize,
+              done,
+              recommendedFallback,
+            }),
           };
         }
       }
@@ -6046,10 +6062,17 @@ export const listPackageCatalogPage = query({
       pageSize = effectivePageSize;
     }
 
+    const recommendedFallback = useUpdatedRecommendationFallback ? ("updated" as const) : undefined;
     return {
       page: collected,
       isDone: done,
-      continueCursor: encodeSkillCatalogCursor({ cursor, offset, pageSize, done }),
+      continueCursor: encodeSkillCatalogCursor({
+        cursor,
+        offset,
+        pageSize,
+        done,
+        recommendedFallback,
+      }),
     };
   },
 });

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -5956,7 +5956,14 @@ export const listPackageCatalogPage = query({
     highlightedOnly: v.optional(v.boolean()),
     executesCode: v.optional(v.boolean()),
     capabilityTag: v.optional(v.string()),
-    sort: v.optional(v.union(v.literal("updated"), v.literal("downloads"), v.literal("installs"))),
+    sort: v.optional(
+      v.union(
+        v.literal("updated"),
+        v.literal("downloads"),
+        v.literal("installs"),
+        v.literal("recommended"),
+      ),
+    ),
     paginationOpts: paginationOptsValidator,
   },
   handler: async (ctx, args) => {
@@ -5995,11 +6002,13 @@ export const listPackageCatalogPage = query({
       remainingScanBudget -= effectivePageSize;
       const pageCursor = cursor;
       const indexName =
-        args.sort === "downloads"
-          ? "by_active_stats_downloads"
-          : args.sort === "installs"
-            ? "by_active_stats_installs_all_time"
-            : "by_active_updated";
+        args.sort === "recommended"
+          ? "by_active_recommended_score"
+          : args.sort === "downloads"
+            ? "by_active_stats_downloads"
+            : args.sort === "installs"
+              ? "by_active_stats_installs_all_time"
+              : "by_active_updated";
       const page = await paginator(ctx.db, schema)
         .query("skillSearchDigest")
         .withIndex(indexName, (q) => q.eq("softDeletedAt", undefined))

--- a/convex/statsMaintenance.test.ts
+++ b/convex/statsMaintenance.test.ts
@@ -19,6 +19,7 @@ vi.mock("./_generated/api", () => ({
       backfillPackageRecommendationScoresInternal: Symbol(
         "backfillPackageRecommendationScoresInternal",
       ),
+      backfillPackageDigestStatsInternal: Symbol("backfillPackageDigestStatsInternal"),
       getSkillStatBackfillStateInternal: Symbol("getSkillStatBackfillStateInternal"),
       setSkillStatBackfillStateInternal: Symbol("setSkillStatBackfillStateInternal"),
       reconcileSkillStarCounts: Symbol("reconcileSkillStarCounts"),
@@ -32,6 +33,7 @@ vi.mock("./_generated/api", () => ({
 const {
   __test,
   backfillPackageRecommendationScoresInternal,
+  backfillPackageDigestStatsInternal,
   backfillSkillDigestRecommendationScoresInternal,
   countPublicPackageDigestPageInternal,
   reconcileSkillStarCountsHandler,
@@ -70,6 +72,11 @@ const backfillPackageRecommendationScoresHandler = getHandler<
   { cursor?: string; batchSize?: number; dryRun?: boolean },
   { scanned: number; patched: number; cursor: string | null; isDone: boolean; dryRun: boolean }
 >(backfillPackageRecommendationScoresInternal as never);
+
+const backfillPackageDigestStatsHandler = getHandler<
+  { cursor?: string; batchSize?: number; dryRun?: boolean },
+  { scanned: number; patched: number; cursor: string | null; isDone: boolean; dryRun: boolean }
+>(backfillPackageDigestStatsInternal as never);
 
 const runRecommendationScoreBackfillHandler = getHandler<
   {
@@ -470,6 +477,143 @@ describe("recommendation score backfills", () => {
       recommendedScore: computePackageRecommendationScore({ stats } as never),
       recommendedScoreVersion: RECOMMENDATION_SCORE_VERSION,
     });
+  });
+
+  it("patches stale package digest stats in bounded pages", async () => {
+    const packageStats = { downloads: 10, installs: 5, stars: 2, versions: 3 };
+    const patch = vi.fn();
+    const paginate = vi.fn().mockResolvedValue({
+      page: [{ _id: "packages:one", stats: packageStats }],
+      isDone: false,
+      continueCursor: "next",
+    });
+    const ctx = {
+      db: {
+        query: vi.fn((table: string) => {
+          if (table === "packages") {
+            return { order: vi.fn(() => ({ paginate })) };
+          }
+          if (table === "packageSearchDigest") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue({
+                  _id: "packageSearchDigest:one",
+                  stats: { downloads: 10, installs: 1, stars: 2, versions: 3 },
+                }),
+              })),
+            };
+          }
+          if (table === "packageCapabilitySearchDigest") {
+            return {
+              withIndex: vi.fn(() => ({
+                collect: vi.fn().mockResolvedValue([
+                  {
+                    _id: "packageCapabilitySearchDigest:one-tools",
+                    stats: { downloads: 10, installs: 1, stars: 2, versions: 3 },
+                  },
+                ]),
+              })),
+            };
+          }
+          if (table === "packagePluginCategorySearchDigest") {
+            return {
+              withIndex: vi.fn(() => ({
+                collect: vi.fn().mockResolvedValue([
+                  {
+                    _id: "packagePluginCategorySearchDigest:one-data",
+                    stats: { downloads: 10, installs: 1, stars: 2, versions: 3 },
+                  },
+                ]),
+              })),
+            };
+          }
+          throw new Error(`Unexpected table: ${table}`);
+        }),
+        patch,
+      },
+    };
+
+    const result = await backfillPackageDigestStatsHandler(ctx, {
+      cursor: "current",
+      batchSize: 1,
+    });
+
+    expect(result).toMatchObject({
+      scanned: 1,
+      patched: 3,
+      cursor: "next",
+      isDone: false,
+      dryRun: false,
+    });
+    expect(paginate).toHaveBeenCalledWith({ cursor: "current", numItems: 1 });
+    expect(patch).toHaveBeenCalledWith("packageSearchDigest:one", { stats: packageStats });
+    expect(patch).toHaveBeenCalledWith("packageCapabilitySearchDigest:one-tools", {
+      stats: packageStats,
+    });
+    expect(patch).toHaveBeenCalledWith("packagePluginCategorySearchDigest:one-data", {
+      stats: packageStats,
+    });
+  });
+
+  it("dry-runs package digest stat backfills without patching", async () => {
+    const patch = vi.fn();
+    const paginate = vi.fn().mockResolvedValue({
+      page: [
+        {
+          _id: "packages:one",
+          stats: { downloads: 10, installs: 5, stars: 2, versions: 3 },
+        },
+      ],
+      isDone: true,
+      continueCursor: "",
+    });
+    const ctx = {
+      db: {
+        query: vi.fn((table: string) => {
+          if (table === "packages") {
+            return { order: vi.fn(() => ({ paginate })) };
+          }
+          if (table === "packageSearchDigest") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue(null),
+              })),
+            };
+          }
+          if (
+            table === "packageCapabilitySearchDigest" ||
+            table === "packagePluginCategorySearchDigest"
+          ) {
+            return {
+              withIndex: vi.fn(() => ({
+                collect: vi.fn().mockResolvedValue([
+                  {
+                    _id: `${table}:stale`,
+                    stats: { downloads: 10, installs: 1, stars: 2, versions: 3 },
+                  },
+                ]),
+              })),
+            };
+          }
+          throw new Error(`Unexpected table: ${table}`);
+        }),
+        patch,
+      },
+    };
+
+    const result = await backfillPackageDigestStatsHandler(ctx, {
+      batchSize: 5,
+      dryRun: true,
+    });
+
+    expect(result).toMatchObject({
+      scanned: 1,
+      patched: 2,
+      cursor: null,
+      isDone: true,
+      dryRun: true,
+    });
+    expect(patch).not.toHaveBeenCalled();
   });
 
   it("runs skill and package recommendation score backfills with resumable cursors", async () => {

--- a/convex/statsMaintenance.ts
+++ b/convex/statsMaintenance.ts
@@ -270,6 +270,69 @@ export const backfillPackageRecommendationScoresInternal = internalMutation({
   },
 });
 
+export const backfillPackageDigestStatsInternal = internalMutation({
+  args: {
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const batchSize = clampInt(args.batchSize ?? DEFAULT_BATCH_SIZE, 1, MAX_BATCH_SIZE);
+    const dryRun = args.dryRun === true;
+    const { page, isDone, continueCursor } = await ctx.db
+      .query("packages")
+      .order("asc")
+      .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
+
+    let patched = 0;
+    for (const pkg of page) {
+      const packageDigest = await ctx.db
+        .query("packageSearchDigest")
+        .withIndex("by_package", (q) => q.eq("packageId", pkg._id))
+        .unique();
+      if (packageDigest && !packageStatsEqual(packageDigest.stats, pkg.stats)) {
+        patched += 1;
+        if (!dryRun) {
+          await ctx.db.patch(packageDigest._id, { stats: pkg.stats });
+        }
+      }
+
+      const capabilityDigests = await ctx.db
+        .query("packageCapabilitySearchDigest")
+        .withIndex("by_package", (q) => q.eq("packageId", pkg._id))
+        .collect();
+      for (const digest of capabilityDigests) {
+        if (packageStatsEqual(digest.stats, pkg.stats)) continue;
+        patched += 1;
+        if (!dryRun) {
+          await ctx.db.patch(digest._id, { stats: pkg.stats });
+        }
+      }
+
+      const pluginCategoryDigests = await ctx.db
+        .query("packagePluginCategorySearchDigest")
+        .withIndex("by_package", (q) => q.eq("packageId", pkg._id))
+        .collect();
+      for (const digest of pluginCategoryDigests) {
+        if (packageStatsEqual(digest.stats, pkg.stats)) continue;
+        patched += 1;
+        if (!dryRun) {
+          await ctx.db.patch(digest._id, { stats: pkg.stats });
+        }
+      }
+    }
+
+    return {
+      ok: true as const,
+      dryRun,
+      scanned: page.length,
+      patched,
+      cursor: isDone ? null : continueCursor,
+      isDone,
+    };
+  },
+});
+
 type RecommendationScoreBackfillArgs = {
   skillCursor?: string;
   packageCursor?: string;
@@ -421,6 +484,19 @@ function computePackageRecommendationScore(pkg: Doc<"packages">) {
     installs: pkg.stats.installs,
     stars: pkg.stats.stars,
   });
+}
+
+function packageStatsEqual(
+  left: Doc<"packageSearchDigest">["stats"],
+  right: Doc<"packages">["stats"],
+) {
+  if (!left) return false;
+  return (
+    left.downloads === right.downloads &&
+    left.installs === right.installs &&
+    left.stars === right.stars &&
+    left.versions === right.versions
+  );
 }
 
 /**

--- a/docs/api.md
+++ b/docs/api.md
@@ -98,6 +98,8 @@ Public read:
 - `GET /api/v1/skills/{slug}/file?path=&version=&tag=`
 - `GET /api/v1/resolve?slug=&hash=`
 - `GET /api/v1/download?slug=&version=&tag=`
+- `GET /api/v1/packages?limit=&cursor=&sort=`
+  - `sort`: `updated` (default), `recommended`, `installs`, `downloads`
 - `GET /api/v1/plugins?limit=&cursor=&sort=`
   - `sort`: `recommended` (default), `installs`, `updated`
 - `GET /api/v1/plugins/search?q=...`

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -544,6 +544,7 @@ Query params:
 - `channel` (optional): `official`, `community`, or `private`
 - `isOfficial` (optional): `true` or `false`
 - `executesCode` (optional): `true` or `false`
+- `sort` (optional): `updated` (default), `recommended`, `installs`, `downloads`
 - `capabilityTag` (optional): capability filter for plugin packages
 - `category` (optional): plugin category filter. Supported only when the
   request is scoped to plugin packages (`/api/v1/plugins`,

--- a/src/__tests__/packages-route.test.tsx
+++ b/src/__tests__/packages-route.test.tsx
@@ -402,6 +402,23 @@ describe("plugins route", () => {
     );
   });
 
+  it("uses updated sort for unsorted filtered plugin browse", async () => {
+    fetchPluginCatalogMock.mockResolvedValue({ items: [], nextCursor: null });
+    const { loadPluginsPageData } = await import("../routes/plugins/index");
+
+    await loadPluginsPageData({
+      category: "data",
+    });
+
+    expect(fetchPluginCatalogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: "data",
+        sort: "updated",
+        limit: 25,
+      }),
+    );
+  });
+
   it("forwards category through catalog loading without changing the query", async () => {
     fetchPluginCatalogMock.mockResolvedValue({ items: [], nextCursor: null });
     const { loadPluginsPageData } = await import("../routes/plugins/index");
@@ -1055,9 +1072,9 @@ describe("plugins route", () => {
 
     render(<Component />);
 
-    expect(screen.getByRole("radio", { name: "Recommended" }).getAttribute("aria-checked")).toBe(
-      "true",
-    );
+    expect(
+      screen.getByRole("radio", { name: "Recently updated" }).getAttribute("aria-checked"),
+    ).toBe("true");
     expect(screen.getByRole("radio", { name: "Most installed" })).toBeTruthy();
     expect(screen.getByRole("radio", { name: "Recently updated" })).toBeTruthy();
     expect(screen.queryByRole("radio", { name: "Relevance" })).toBeNull();

--- a/src/__tests__/packages-route.test.tsx
+++ b/src/__tests__/packages-route.test.tsx
@@ -804,6 +804,29 @@ describe("plugins route", () => {
     });
   });
 
+  it("keeps recommended explicit when selected from filtered plugin browse", async () => {
+    searchMock = { category: "security" };
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole("radio", { name: "Recommended" }));
+
+    const lastCall = navigateMock.mock.calls.at(-1)?.[0] as {
+      replace?: boolean;
+      search: (prev: Record<string, unknown>) => Record<string, unknown>;
+    };
+    expect(lastCall.replace).toBe(true);
+    expect(lastCall.search({ category: "security", cursor: "cursor:current" })).toEqual({
+      category: "security",
+      cursor: undefined,
+      family: undefined,
+      featured: undefined,
+      sort: "recommended",
+    });
+  });
+
   it("returns a retryable empty state when the catalog is rate limited", async () => {
     fetchPluginCatalogMock.mockRejectedValue({ status: 429, retryAfterSeconds: 22 });
     const { loadPluginsPageData } = await import("../routes/plugins/index");

--- a/src/__tests__/packages-route.test.tsx
+++ b/src/__tests__/packages-route.test.tsx
@@ -389,6 +389,17 @@ describe("plugins route", () => {
         limit: 25,
       }),
     );
+
+    await loadPluginsPageData({
+      sort: "updated",
+    });
+
+    expect(fetchPluginCatalogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sort: "updated",
+        limit: 25,
+      }),
+    );
   });
 
   it("forwards category through catalog loading without changing the query", async () => {
@@ -1112,6 +1123,47 @@ describe("plugins route", () => {
     const zulu = screen.getByText("Zulu Plugin");
     const alpha = screen.getByText("Alpha Plugin");
     expect(zulu.compareDocumentPosition(alpha) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("sorts loaded search results by install count", async () => {
+    searchMock = { q: "security", sort: "installs" };
+    loaderDataMock = {
+      items: [
+        {
+          name: "zulu-plugin",
+          displayName: "Zulu Plugin",
+          family: "code-plugin",
+          channel: "community",
+          isOfficial: false,
+          executesCode: true,
+          createdAt: 2,
+          updatedAt: 20,
+          stats: { downloads: 10, installs: 1, stars: 0, versions: 1 },
+        },
+        {
+          name: "alpha-plugin",
+          displayName: "Alpha Plugin",
+          family: "code-plugin",
+          channel: "community",
+          isOfficial: false,
+          executesCode: true,
+          createdAt: 1,
+          updatedAt: 10,
+          stats: { downloads: 1, installs: 10, stars: 0, versions: 1 },
+        },
+      ],
+      nextCursor: null,
+      rateLimited: false,
+      retryAfterSeconds: null,
+    };
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    const alpha = screen.getByText("Alpha Plugin");
+    const zulu = screen.getByText("Zulu Plugin");
+    expect(alpha.compareDocumentPosition(zulu) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it("keeps search sort visible even if a stale featured flag is present", async () => {

--- a/src/components/SkillHeader.test.tsx
+++ b/src/components/SkillHeader.test.tsx
@@ -182,6 +182,19 @@ describe("SkillHeader", () => {
     expect(screen.queryByText("MIT-0")).toBeNull();
   });
 
+  it("uses top-level migrated install stats when present", () => {
+    const migratedSkill = {
+      ...skill,
+      stats: { ...skill.stats, installsAllTime: undefined },
+      statsInstallsAllTime: 42,
+    };
+
+    renderHeader({ skill: migratedSkill });
+
+    expect(screen.getByText("Installs")).toBeTruthy();
+    expect(screen.getByText("42")).toBeTruthy();
+  });
+
   it("shows the source repository for GitHub-backed skills", () => {
     renderHeader({
       skill: {

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from "react";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
 import { getSkillBadges } from "../lib/badges";
 import { buildSkillCategoryBrowseHref, type SkillCategory } from "../lib/categories";
-import { formatSkillStatsTriplet } from "../lib/numberFormat";
+import { formatSkillStatsTriplet, type SkillStatsTriplet } from "../lib/numberFormat";
 import type { PublicPublisher, PublicSkill } from "../lib/publicUser";
 import { getRuntimeEnv } from "../lib/runtimeEnv";
 import { timeAgo } from "../lib/timeAgo";
@@ -75,6 +75,23 @@ function getGitHubRepositoryLink(skill: Doc<"skills"> | PublicSkill) {
       {repo}
     </a>
   );
+}
+
+function getSkillHeaderStats(skill: Doc<"skills"> | PublicSkill): SkillStatsTriplet {
+  return {
+    downloads:
+      "statsDownloads" in skill && typeof skill.statsDownloads === "number"
+        ? skill.statsDownloads
+        : skill.stats.downloads,
+    stars:
+      "statsStars" in skill && typeof skill.statsStars === "number"
+        ? skill.statsStars
+        : skill.stats.stars,
+    installsAllTime:
+      "statsInstallsAllTime" in skill && typeof skill.statsInstallsAllTime === "number"
+        ? skill.statsInstallsAllTime
+        : skill.stats.installsAllTime,
+  };
 }
 
 type SkillHeaderProps = {
@@ -149,7 +166,7 @@ export function SkillHeader({
   showArchiveMetadata = true,
   children,
 }: SkillHeaderProps) {
-  const formattedStats = formatSkillStatsTriplet(skill.stats);
+  const formattedStats = formatSkillStatsTriplet(getSkillHeaderStats(skill));
   const installOwnerId = owner?._id ?? skill.ownerPublisherId ?? skill.ownerUserId ?? null;
   const convexSiteUrl = getRuntimeEnv("VITE_CONVEX_SITE_URL") ?? "https://clawhub.ai";
   const downloadHref =

--- a/src/routes/plugins/index.tsx
+++ b/src/routes/plugins/index.tsx
@@ -130,6 +130,18 @@ function normalizeActivePluginSort(sort: LegacyPluginSort | undefined): PluginSo
   return sort;
 }
 
+function hasPluginBrowseFilter(
+  args: Pick<PluginsPageDataRequest, "category" | "featured" | "official" | "executesCode">,
+) {
+  return Boolean(args.category || args.featured || args.official || args.executesCode);
+}
+
+function getDefaultPluginBrowseSort(
+  args: Pick<PluginsPageDataRequest, "category" | "featured" | "official" | "executesCode">,
+): VisiblePluginSort {
+  return hasPluginBrowseFilter(args) ? "updated" : "recommended";
+}
+
 function isNavigationAbortError(err: unknown, signal?: AbortSignal) {
   if (signal?.aborted) return true;
   return err instanceof Error && err.name === "AbortError";
@@ -151,7 +163,7 @@ export async function loadPluginsPageData(
         args.sort === "updated" ||
         !args.sort ||
         args.sort === "recommended")
-        ? { sort: args.sort ?? "recommended" }
+        ? { sort: args.sort ?? getDefaultPluginBrowseSort(args) }
         : {}),
       limit: PLUGINS_PAGE_SIZE,
       signal: args.signal,
@@ -388,7 +400,7 @@ function PluginsIndex() {
   const activeSort: PluginSort =
     search.sort === "relevance" || search.sort === "newest" || search.sort === "name"
       ? "recommended"
-      : (search.sort ?? "recommended");
+      : (search.sort ?? (hasQuery ? "recommended" : getDefaultPluginBrowseSort(search)));
   const visibleItems = useMemo(
     () => (hasQuery ? sortPluginSearchItems(items, activeSort) : items),
     [activeSort, hasQuery, items],

--- a/src/routes/plugins/index.tsx
+++ b/src/routes/plugins/index.tsx
@@ -146,7 +146,11 @@ export async function loadPluginsPageData(
       featured: args.featured,
       isOfficial: args.official,
       executesCode: args.executesCode,
-      ...(!args.q && (args.sort === "installs" || !args.sort || args.sort === "recommended")
+      ...(!args.q &&
+      (args.sort === "installs" ||
+        args.sort === "updated" ||
+        !args.sort ||
+        args.sort === "recommended")
         ? { sort: args.sort ?? "recommended" }
         : {}),
       limit: PLUGINS_PAGE_SIZE,

--- a/src/routes/plugins/index.tsx
+++ b/src/routes/plugins/index.tsx
@@ -142,6 +142,12 @@ function getDefaultPluginBrowseSort(
   return hasPluginBrowseFilter(args) ? "updated" : "recommended";
 }
 
+function hasPersistentPluginBrowseFilter(
+  args: Pick<PluginsPageDataRequest, "category" | "official" | "executesCode">,
+) {
+  return Boolean(args.category || args.official || args.executesCode);
+}
+
 function isNavigationAbortError(err: unknown, signal?: AbortSignal) {
   if (signal?.aborted) return true;
   return err instanceof Error && err.name === "AbortError";
@@ -428,22 +434,25 @@ function PluginsIndex() {
 
   const handleSortChange = (value: string) => {
     const nextSort = parsePluginSort(value);
-    const sort =
-      nextSort === "recommended" ||
-      nextSort === "relevance" ||
-      nextSort === "newest" ||
-      nextSort === "name"
-        ? undefined
-        : nextSort;
 
     void navigate({
-      search: (prev: PluginSearchState) => ({
-        ...prev,
-        cursor: undefined,
-        family: undefined,
-        featured: undefined,
-        sort,
-      }),
+      search: (prev: PluginSearchState) => {
+        const isExplicitFilteredRecommendation =
+          nextSort === "recommended" && !prev.q && hasPersistentPluginBrowseFilter(prev);
+        const sort =
+          isExplicitFilteredRecommendation || nextSort === "installs"
+            ? nextSort
+            : nextSort === "updated"
+              ? "updated"
+              : undefined;
+        return {
+          ...prev,
+          cursor: undefined,
+          family: undefined,
+          featured: undefined,
+          sort,
+        };
+      },
       replace: true,
     });
   };


### PR DESCRIPTION
## Summary

Follow-up to #2633. That PR merged the first install-ranking slice; this keeps the remaining branch work that was still local afterward.

- completes install/recommended sort plumbing across plugin, package, and skill catalog endpoints
- keeps recommended pagination stable when score backfills are incomplete or cursors are stale
- defaults filtered plugin browse to updated ordering where recommended scores are not safe to use
- records package install metrics with viewer identity and safer dedupe/cleanup behavior
- updates package stats, search digest, docs, and UI stat displays to use install-based fields consistently

## Verification

- `VITE_CONVEX_URL=https://example.invalid bunx vitest run convex/httpApiV1.handlers.test.ts convex/skills.packageCatalog.test.ts src/__tests__/packages-route.test.tsx convex/packages.public.test.ts convex/packages.stats.test.ts` passed: 5 files, 605 tests
- `bun run ci:unit` passed: 264 files, 3189 tests
- `bunx convex dev --once --typecheck=disable` passed
- `bun run ci:types-build` passed
- `bun run format:check` passed
- `bun run lint` passed
- `bun run deadcode:ci` passed

## Static Gate Note

`bun run ci:static` currently stops in `bun audit` before format/lint/dead-code because `dompurify` advisories are reported through `mermaid` and `monaco-editor`. I ran the remaining static checks directly after that failure.
