### PR TITLE
Remove homepage proof stats strip

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -148,7 +148,7 @@
     },
   },
   "overrides": {
-    "dompurify": "3.4.1",
+    "dompurify": "3.4.10",
     "next": "16.2.6",
     "postcss": "8.5.12",
     "ws": "8.21.0",
@@ -1152,7 +1152,7 @@
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
-    "dompurify": ["dompurify@3.4.1", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw=="],
+    "dompurify": ["dompurify@3.4.10", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "vitest": "4.1.8"
   },
   "overrides": {
-    "dompurify": "3.4.1",
+    "dompurify": "3.4.10",
     "next": "16.2.6",
     "postcss": "8.5.12",
     "ws": "8.21.0"

--- a/src/__tests__/home-route.test.tsx
+++ b/src/__tests__/home-route.test.tsx
@@ -92,6 +92,16 @@ describe("home route", () => {
     expect(screen.getByText("Publishers")).toBeTruthy();
   });
 
+  it("does not render the homepage social proof stats strip", async () => {
+    await renderHome();
+
+    expect(document.querySelector(".home-v2-proof-bar")).toBeNull();
+    expect(screen.queryByText("52.7k")).toBeNull();
+    expect(screen.queryByText("180k")).toBeNull();
+    expect(screen.queryByText("12M")).toBeNull();
+    expect(screen.queryByText("avg rating")).toBeNull();
+  });
+
   it("keeps the featured skill carousel as a duplicated scrolling track", async () => {
     convexQueryMock.mockResolvedValue([
       {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -663,29 +663,6 @@ function SkillsHome() {
         </div>
       </section>
 
-      {/* ═══ PROOF BAR ═══ */}
-      <div className="home-v2-proof-bar">
-        <div className="home-v2-proof-item">
-          <span className="home-v2-proof-num">52.7k</span>
-          <span className="home-v2-proof-label">tools</span>
-        </div>
-        <span className="home-v2-proof-sep" />
-        <div className="home-v2-proof-item">
-          <span className="home-v2-proof-num">180k</span>
-          <span className="home-v2-proof-label">users</span>
-        </div>
-        <span className="home-v2-proof-sep" />
-        <div className="home-v2-proof-item">
-          <span className="home-v2-proof-num">12M</span>
-          <span className="home-v2-proof-label">installs</span>
-        </div>
-        <span className="home-v2-proof-sep" />
-        <div className="home-v2-proof-item">
-          <span className="home-v2-proof-num">4.8</span>
-          <span className="home-v2-proof-label">avg rating</span>
-        </div>
-      </div>
-
       {/* ═══ TRENDING ═══ */}
       {trendingCards.length > 0 && (
         <section className="home-v2-trending-section">

--- a/src/styles.css
+++ b/src/styles.css
@@ -14276,37 +14276,6 @@ a.publisher-profile-detail:hover {
   transform: translateX(3px);
 }
 
-/* ═══ PROOF BAR ═══ */
-.home-v2-proof-bar {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 48px;
-  padding: 28px 48px;
-  border-top: 1px solid var(--hv2-border);
-  border-bottom: 1px solid var(--hv2-border);
-}
-.home-v2-proof-item {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-}
-.home-v2-proof-num {
-  font-family: "JetBrains Mono", monospace;
-  font-weight: 700;
-  font-size: 20px;
-  color: var(--hv2-text);
-}
-.home-v2-proof-label {
-  font-size: 13px;
-  color: var(--hv2-text-secondary);
-}
-.home-v2-proof-sep {
-  width: 1px;
-  height: 16px;
-  background: var(--hv2-border);
-}
-
 /* ═══ TRENDING ═══ */
 .home-v2-trending-section {
   padding: 48px 48px 80px;
@@ -14469,10 +14438,6 @@ a.publisher-profile-detail:hover {
   .home-v2-trending-grid {
     grid-template-columns: repeat(2, 1fr);
   }
-  .home-v2-proof-bar {
-    gap: 24px;
-    flex-wrap: wrap;
-  }
 }
 @media (max-width: 768px) {
   .home-v2-hero {
@@ -14538,10 +14503,6 @@ a.publisher-profile-detail:hover {
   }
   .home-v2-trending-section {
     padding: 36px 20px 60px;
-  }
-  .home-v2-proof-bar {
-    padding: 20px;
-    gap: 16px;
   }
   .home-v2-search-go-label {
     display: none;
@@ -14762,15 +14723,6 @@ a.publisher-profile-detail:hover {
 }
 [data-theme-resolved="light"] .home-v2-cat-item:hover {
   background: rgba(210, 170, 130, 0.06);
-}
-
-/* Light — proof bar */
-[data-theme-resolved="light"] .home-v2-proof-bar {
-  border-top-color: rgba(170, 125, 80, 0.15);
-  border-bottom-color: rgba(170, 125, 80, 0.15);
-}
-[data-theme-resolved="light"] .home-v2-proof-num {
-  color: #1a1410;
 }
 
 /* Light — install buttons (green) */


### PR DESCRIPTION
## Summary
- Remove the hard-coded homepage social proof stats strip from the ClawHub landing UI.
- Remove the now-unused proof strip CSS, including responsive and light-theme overrides.
- Update the DOMPurify override from 3.4.1 to 3.4.10 so the repo static audit gate stays green.

## Proof
- Local browser proof on the real ClawHub dev app: homepage rendered at the branch head with `.home-v2-proof-bar` count `0` and no `52.7k`, `180k`, `12M`, or `avg rating` text present.
- Responsive browser checks at 390x844, 768x1024, and 1366x768 showed no horizontal overflow and no proof strip.

## Tests
- `bunx vitest run src/__tests__/home-route.test.tsx`
- `bunx vitest run src/__tests__/ui-design-contract.test.ts src/__tests__/home-route.test.tsx`
- `bun run format:check -- src/routes/index.tsx src/styles.css src/__tests__/home-route.test.tsx`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local`
