### PR TITLE
fix(agents): sync autoreview scope guard

### DIFF
--- a/.agents/skills/autoreview/SKILL.md
+++ b/.agents/skills/autoreview/SKILL.md
@@ -1,176 +1,337 @@
 ---
 name: autoreview
-description: "Use when ClawHub needs Codex review, autoreview, second-model review, or a final advisory review gate before commit, PR update, ship, or maintainer handoff."
+description: "Pre-commit/ship code review: Codex default; optional Claude, Pi, Droid, Copilot, or OpenCode."
 ---
 
-# Autoreview
+# Auto Review
 
-Run Codex's built-in code review as a closeout check. This is code review
-(`codex review`), not Guardian `auto_review` approval routing.
+Run the bundled structured review helper as a closeout check. This is code review, not Guardian `auto_review` approval routing.
 
-Codex native review mode performs best and is recommended. Non-Codex reviewers
-are fallback or second-opinion paths that receive a generated diff prompt, not
-the full Codex review-mode runtime.
+Codex review is the default when no engine is set. It uses `gpt-5.5` by default, usually delivers the best review results, and should remain the normal final closeout engine. Claude review is optional and uses `claude-fable-5` by default.
 
 Use when:
 
-- the user asks for Codex review, autoreview, or second-model review
+- user asks for Codex review / Claude review / Pi review / Droid review / OpenCode review / autoreview / second-model review
 - after non-trivial code edits, before final/commit/ship
 - reviewing a local branch or PR branch after fixes
-- closing out ClawHub maintainer work that touched source, tests, Convex, UI,
-  CLI packages, or workflows
 
 ## Contract
 
 - Treat review output as advisory. Never blindly apply it.
 - Verify every finding by reading the real code path and adjacent files.
-- Read dependency docs/source/types when the finding depends on external
-  behavior.
-- Reject unrealistic edge cases, speculative risks, broad rewrites, and fixes
-  that over-complicate the codebase.
-- Prefer small fixes at the right ownership boundary; no refactor unless it
-  clearly improves the bug class.
-- Keep going until the selected review path returns no accepted/actionable
-  findings.
-- If a review-triggered fix changes code, rerun focused tests and rerun the
-  review helper.
-- Default to Codex review. If Codex is unavailable or exits with an error, the
-  helper can fall back to `claude -p`, `pi -p`, `opencode run`, `droid exec`, or
-  `copilot`.
-- Stop as soon as the review command/helper exits 0 with no
-  accepted/actionable findings. Do not run an extra direct `codex review` just
-  to get a nicer clean line, a second opinion, or clearer closeout wording.
-- If rejecting a finding as intentional/not worth fixing, add a brief inline
-  code comment only when it explains a real invariant or ownership decision
-  future reviewers should know.
-- Do not push just to review. Push only when the user requested push/ship/PR
-  update.
+- Read dependency docs/source/types when the finding depends on external behavior.
+- Reject unrealistic edge cases, speculative risks, broad rewrites, and fixes that over-complicate the codebase.
+- Prefer small fixes at the right ownership boundary; no refactor unless it clearly improves the bug class.
+- When an accepted finding shows a bug class or repeated pattern, inspect the current PR scope for sibling instances before fixing.
+- Fix the scoped bug class at once when practical; stop at touched surfaces, owner boundaries, and clear follow-up territory.
+- Keep going until structured review returns no accepted/actionable findings only while the work remains inside the original task scope.
+- If a review-triggered fix changes code, rerun focused tests and rerun the structured review helper.
+- For security-audit suppression changes, verify accepted findings remain auditable: suppressed findings stay in structured output, active output keeps an unsuppressible suppression notice, and aggregate findings cannot hide unrelated active risk.
+- Never switch or override the requested review engine/model. If the review hits model capacity, retry the same command a few times with the same engine/model.
+- Be patient with large bundles. Structured review can take up to 30 minutes while the model call is active, especially with Codex tools or web search.
+- Treat heartbeat lines like `review still running: ... elapsed=... pid=...` as healthy progress, not a hang. Let the helper continue while heartbeats are advancing. Pass `--stream-engine-output` when live engine text is useful; Codex and Claude filter tool/file chatter, other engines pass raw output through.
+- Do not kill a review just because it has been quiet for 2-5 minutes, or because it is still running under the 30-minute window. Inspect the process only after missing multiple expected heartbeats, after 30 minutes, or after an obviously failed subprocess; prefer letting the same helper command finish.
+- Tools are useful in review mode. The helper allows read-only inspection tools and web search by default so reviewers can check dependency contracts, upstream docs, and current behavior.
+- Security perspective is always included, but it should not cripple legitimate functionality. Report security findings only when the change creates a concrete, actionable risk or removes an important safety check.
+- For regression provenance, keep roles separate: blamed code author, blamed PR author, PR merger/committer, current PR author, and PR/date. If no blamed PR is traceable, use the blamed commit as the provenance: commit SHA, date, and author username. Do not guess a merger or frame missing PR metadata as a separate finding.
+- If the blamed PR was merged by `clawsweeper[bot]` or another automation, identify the human trigger when practical. Check timeline/comments first; if rate-limited, use gitcrawl/cache or public PR HTML. Look for maintainer commands such as `@clawsweeper automerge`, `/landpr`, or labels/status comments that armed automerge. Report `automerge triggered by @login`; if not found, say trigger unknown.
+- Do not invoke built-in `codex review`, nested reviewers, or reviewer panels from inside the review. The helper builds one bundle, calls one selected engine, validates one structured result, and stops.
+- Stop as soon as the helper exits 0 with no accepted/actionable findings. Do not run an extra review just to get a nicer "clean" line, a second opinion, or clearer closeout wording.
+- Treat the helper's successful exit plus absence of actionable findings as the clean review result, even if the underlying Codex CLI output is terse.
+- Multi-reviewer panels are opt-in only. Use them when explicitly requested or when risk justifies the extra spend; the main agent still verifies every accepted finding before fixing.
+- If rejecting a finding as intentional/not worth fixing, add a brief inline code comment only when it explains a real invariant or ownership decision that future reviewers should know.
+- If `gh`/Gitcrawl reports `database disk image is malformed`, run `gitcrawl doctor --json` once to let the portable cache repair before retrying review; do not bypass the shim unless repair fails and freshness requires live GitHub.
+- If Gitcrawl reports a portable manifest mismatch, source/runtime DB health error, or stale portable-store checkout, run `gitcrawl doctor --json` and inspect `source_db_health`, `runtime_db_health`, and `portable_store_status` before falling back to live GitHub.
+- Do not push just to review. Push only when the user requested push/ship/PR update.
 
-## ClawHub Proof Routing
+## Scope Governor
 
-Pick the smallest proof that matches the touched surface:
+Autoreview is a closeout gate, not permission to rewrite the task.
 
-| Touched surface                    | Usual proof                                                                                                             |
-| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| Formatting/lint/static repo health | `bun run ci:static`                                                                                                     |
-| Unit-tested source behavior        | focused `bunx vitest run ...`, then `bun run ci:unit` when PR-ready                                                     |
-| Convex code                        | read `convex/_generated/ai/guidelines.md` first; run focused tests and the deploy/typecheck path that covers the change |
-| Packages/CLI/admin tool            | `bun run ci:packages` or the package-specific `verify` script                                                           |
-| Runtime/build/package surface      | `bun run ci:types-build`, `bun run ci:e2e-http`, or the matching broader gate                                           |
-| UI behavior                        | use `clawhub-ui-proof` with `proof:ui`; publish proof before final PR comments when needed                              |
-| Linux/CI-parity validation         | use `crabbox`, normally through the repo scripts                                                                        |
+Before the first review, freeze a scope baseline: original request or issue, target branch, intended behavior, owner boundary, changed files, and non-test LOC. For inherited or already-bloated branches, use the intended PR diff as the baseline rather than accepting all existing branch drift.
 
-For Convex query or schema work, apply the repo's Convex rules: prefer indexes
-over `.filter()` scans, use cursor-based backfills for data shape changes, and
-verify with the repo's Convex/typecheck path before claiming deploy safety.
+Before patching a finding, classify it:
+
+- **In-scope blocker**: the finding is introduced by the current diff, affects the same owner boundary, and can be fixed without changing the task's contract.
+- **Follow-up**: the finding is real but belongs to an adjacent bug class, sibling surface, cleanup, or broader hardening track.
+- **Stop-and-escalate**: the finding requires a new protocol/config/storage/public API contract, a different owner boundary, a release-process change, or a design choice outside the original request.
+
+Stop patching and report the scope break instead of continuing when:
+
+- a narrow PR turns into an architecture change, protocol change, migration, or release-process change;
+- the diff grows past 2x the original files or non-test LOC without explicit approval to expand scope;
+- two review-triggered patch cycles have not converged; pause and reclassify every remaining finding before another edit;
+- the best fix is "define the canonical contract first" rather than another local inference layer;
+- fixing the accepted finding would make the PR no longer describe the same behavior, issue, or owner boundary.
+
+After the two-cycle pause, continue only when every remaining accepted finding is still an in-scope blocker. Otherwise preserve the useful analysis, identify the smallest safe landed subset if one exists, and open or request a follow-up for the larger fix. Do not keep committing speculative fixes just to satisfy the reviewer.
+
+Do not stack or push review-triggered fix commits while scope classification or focused proof is unresolved. Keep exploratory edits local until the cycle is proven in scope; if scope breaks, remove them from the landing lane instead of preserving them as branch history.
+
+Critical exceptions must be explicit: active data loss, crash, broken install/upgrade, release blocker, or concrete security exposure. If the exception is not one of those, it is not critical enough to blow up scope.
+
+## Release Branches And Release Process
+
+On release, beta, stable, hotfix, signing, notarization, appcast, package-publish, or release-check work, use freeze discipline even when the branch name is not release-like:
+
+- Fix only release blockers, failed release infrastructure, exact backports, install/upgrade breakage, data loss, crashes, or concrete security exposure.
+- Treat non-blocking autoreview findings as follow-ups for `main`, not reasons to broaden the release branch.
+- Do not introduce new product behavior, config surface, protocol shape, migration, plugin ownership, docs narrative, or process policy unless it directly unblocks the release.
+- Keep proof tied to the release target: exact branch/ref, failing check or shipped-risk reason, smallest command/proof, and whether the fix must also forward-port to `main`.
+- If review discovers a real but non-critical design problem during release closeout, stop with a follow-up issue/PR plan; do not use the release branch as the refactor lane.
+
+## Skill Path (set once)
+
+Set the skill script paths once, then use `"$AUTOREVIEW"` and `"$AUTOREVIEW_HARNESS"` in the examples below.
+
+Choose one:
+
+```bash
+# Project-local skill in the current repo:
+export AUTOREVIEW=".agents/skills/autoreview/scripts/autoreview"
+export AUTOREVIEW_HARNESS=".agents/skills/autoreview/scripts/test-review-harness"
+```
+
+```bash
+# Source checkout of openclaw/agent-skills:
+export AUTOREVIEW="skills/autoreview/scripts/autoreview"
+export AUTOREVIEW_HARNESS="skills/autoreview/scripts/test-review-harness"
+```
+
+```bash
+# Global skill:
+export AGENTS_HOME="${AGENTS_HOME:-$HOME/.agents}"
+export AUTOREVIEW="$AGENTS_HOME/skills/autoreview/scripts/autoreview"
+export AUTOREVIEW_HARNESS="$AGENTS_HOME/skills/autoreview/scripts/test-review-harness"
+```
+
+When using Claude Code, set `AGENTS_HOME="$HOME/.claude"` for global skills. Project-local skills live under `.claude/skills/` in the current repo.
 
 ## Pick Target
 
 Dirty local work:
 
 ```bash
-codex review --uncommitted
+"$AUTOREVIEW" --mode local
 ```
 
 Use this only when the patch is actually unstaged/staged/untracked in the
-current checkout. For committed, pushed, or PR work, point Codex at the commit
-or branch diff instead. A clean `--uncommitted` review only proves there is no
-local patch.
+current checkout. `--mode uncommitted` is accepted as an alias for `--mode local`.
+For committed, pushed, or PR work, point the helper at the commit
+or branch diff instead; do not force dirty modes just
+because the helper docs mention dirty work first. A clean local review
+only proves there is no local patch.
 
 Branch/PR work:
 
 ```bash
-git fetch origin
-codex review --base origin/main
+"$AUTOREVIEW" --mode branch --base origin/main
+```
+
+Optional review context is first-class. Prompt files and datasets must be repo-relative so review bundles cannot pull arbitrary host files:
+
+```bash
+"$AUTOREVIEW" --mode branch --base origin/main --prompt-file review-notes.md --dataset evidence.json
 ```
 
 If an open PR exists, use its actual base:
 
 ```bash
 base=$(gh pr view --json baseRefName --jq .baseRefName)
-codex review --base "origin/$base"
+"$AUTOREVIEW" --mode branch --base "origin/$base"
 ```
-
-Do not pass a prompt with `--base`. Some Codex CLI versions reject
-`codex review --base <ref> -` with `--base <BRANCH> cannot be used with
-[PROMPT]`. If that happens, rerun plain `codex review --base <ref>` and report
-that prompt injection was skipped.
 
 Committed single change:
 
 ```bash
-codex review --commit HEAD
+"$AUTOREVIEW" --mode commit --commit HEAD
 ```
 
-or with the helper:
-
-```bash
-.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD
-```
-
-Use commit review for already-landed or already-pushed work on `main`.
-Reviewing clean `main` against `origin/main` is usually an empty diff after
-push. For a small stack, review each commit explicitly or review the branch
-before merging with `--base`.
+Use commit review for already-landed or already-pushed work on `main`. Reviewing
+clean `main` against `origin/main` is usually an empty diff after push. For a
+small stack, review each commit explicitly or review the branch before merging
+with `--base`.
 
 ## Parallel Closeout
 
-Format first if formatting can change line locations. Then it is OK to run
-tests and review in parallel:
+Format first if formatting can change line locations. Then it is OK to run tests and review in parallel:
 
 ```bash
-.agents/skills/autoreview/scripts/autoreview --parallel-tests "bun run ci:static"
+"$AUTOREVIEW" --parallel-tests "<focused test command>"
 ```
 
-Tradeoff: tests may force code changes that stale the review. If tests or
-review lead to code edits, rerun the affected tests and rerun review until no
-accepted/actionable findings remain. Once that rerun exits cleanly, stop; do
-not spend another long review cycle on redundant confirmation.
+On Windows, the default `--parallel-tests` shell preserves the platform `cmd.exe`
+semantics used by Python `shell=True`. Use `--parallel-tests-shell powershell`
+or `--parallel-tests-shell pwsh` when the focused test command is PowerShell-specific.
+
+Tradeoff: tests may force code changes that stale the review. If tests or review lead to code edits, rerun the affected tests and rerun review until no accepted/actionable findings remain. Once that rerun exits cleanly, stop; do not spend another long review cycle on redundant confirmation.
+
+## Review Panels
+
+Run multiple reviewers against one frozen bundle:
+
+```bash
+"$AUTOREVIEW" --reviewers codex,claude,pi,droid
+```
+
+`--panel` is shorthand for Codex plus Claude unless `--engine` changes the first reviewer:
+
+```bash
+"$AUTOREVIEW" --panel
+```
+
+Set reviewer models and thinking/effort explicitly:
+
+```bash
+"$AUTOREVIEW" --reviewers codex,claude --model codex=gpt-5.5 --thinking codex=high --model claude=claude-fable-5 --thinking claude=max
+```
+
+Inline syntax is also supported for simple model IDs:
+
+```bash
+"$AUTOREVIEW" --reviewers codex:gpt-5.5:high,claude:claude-fable-5:max
+```
+
+For models with slashes or extra colons, prefer keyed form:
+
+```bash
+"$AUTOREVIEW" --engine pi --model anthropic/claude-sonnet-4 --thinking high
+"$AUTOREVIEW" --engine opencode --model opencode/north-mini-code-free --thinking high
+"$AUTOREVIEW" --engine droid --model claude-opus-4-8 --thinking low
+"$AUTOREVIEW" --reviewers codex,pi --model codex=gpt-5.5 --model pi=anthropic/claude-sonnet-4
+"$AUTOREVIEW" --reviewers codex,opencode --model codex=gpt-5.5 --model opencode=opencode/north-mini-code-free
+"$AUTOREVIEW" --reviewers codex,droid --model codex=gpt-5.5 --model droid=claude-opus-4-8
+```
+
+## Models and thinking
+
+The helper accepts `--model` globally or per engine (`engine=model`) and `--thinking` globally or per engine (`engine=level`). Repeat either flag for multiple reviewers.
+
+Recommended model defaults:
+
+| Engine              | Default model    | Source note                                           |
+| ------------------- | ---------------- | ----------------------------------------------------- |
+| **codex** (default) | `gpt-5.5`        | OpenAI's current GPT-5.5 alias                        |
+| **claude**          | `claude-fable-5` | Anthropic's most capable widely released Claude model |
+
+CLI flags and environment variables override these defaults. Droid, Copilot, Pi, and OpenCode do not get built-in model defaults here because their provider catalogs are external to the Codex/Claude closeout path and may vary by installation.
+
+| Engine              | Model flag                 | Example model IDs                                                            | Thinking flag                 | Accepted levels                                     |
+| ------------------- | -------------------------- | ---------------------------------------------------------------------------- | ----------------------------- | --------------------------------------------------- |
+| **codex** (default) | `codex --model X exec ...` | `gpt-5.5`, `gpt-5.5-2026-04-23`                                              | `-c model_reasoning_effort=Y` | `none`, `minimal`, `low`, `medium`, `high`, `xhigh` |
+| **claude**          | `claude --model X`         | `claude-fable-5`, `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5` | `--effort Y`                  | `low`, `medium`, `high`, `xhigh`, `max`             |
+| **droid**           | `droid exec --model X`     | `claude-opus-4-8`, Factory model IDs                                         | `-r, --reasoning-effort Y`    | `off`, `none`, `low`, `medium`, `high`              |
+| **copilot**         | `copilot --model X`        | `gpt-5.2`, Copilot model aliases                                             | not supported                 | n/a                                                 |
+| **pi**              | `pi --model X`             | `anthropic/claude-sonnet-4`, `openai/gpt-4o`                                 | `--thinking Y`                | `off`, `minimal`, `low`, `medium`, `high`, `xhigh`  |
+| **opencode**        | `opencode run -m X`        | `opencode/north-mini-code-free`, OpenCode provider/model IDs                 | `--variant Y`                 | `minimal`, `low`, `medium`, `high`, `max`           |
+
+Claude also supports `--fallback-model a,b` for availability-based fallback chains ([model-config](https://code.claude.com/docs/en/model-config)). Current Claude docs note that auth, billing, rate-limit, request-size, and transport errors do not trigger fallback, and the changelog documents interactive-session support in `v2.1.166`.
+
+Examples matching current `main` behavior:
+
+```bash
+# Codex with explicit model and reasoning
+"$AUTOREVIEW" --engine codex --model gpt-5.5 --thinking high
+
+# Claude Code aliases or full model names, with optional availability fallback
+"$AUTOREVIEW" --engine claude --model claude-fable-5 --thinking max
+"$AUTOREVIEW" --engine claude --model claude-fable-5 --fallback-model claude-opus-4-8,claude-sonnet-4-6
+
+# Factory Droid with explicit model and reasoning effort
+"$AUTOREVIEW" --engine droid --model claude-opus-4-8 --thinking low
+
+# GitHub Copilot (model only; no thinking knob)
+"$AUTOREVIEW" --engine copilot --model gpt-5.2
+
+# Pi with explicit model and thinking level
+"$AUTOREVIEW" --engine pi --model anthropic/claude-sonnet-4 --thinking high --pi-bin pi
+
+# OpenCode with explicit provider/model and variant
+"$AUTOREVIEW" --engine opencode --model opencode/north-mini-code-free --thinking high
+```
+
+### Environment defaults
+
+CLI flags take precedence over environment variables.
+
+| Variable                           | Purpose                                                                 |
+| ---------------------------------- | ----------------------------------------------------------------------- |
+| `AUTOREVIEW_MODEL`                 | Override the built-in default `--model` for all engines                 |
+| `AUTOREVIEW_THINKING`              | Default `--thinking` for all engines                                    |
+| `AUTOREVIEW_FALLBACK_MODEL`        | Default Claude `--fallback-model` chain                                 |
+| `AUTOREVIEW_<ENGINE>_MODEL`        | Per-engine model override, for example `AUTOREVIEW_CODEX_MODEL=gpt-5.5` |
+| `AUTOREVIEW_<ENGINE>_THINKING`     | Per-engine thinking override                                            |
+| `AUTOREVIEW_CLAUDE_FALLBACK_MODEL` | Claude-only fallback chain                                              |
+
+Codex maps thinking to `model_reasoning_effort`. Claude maps thinking to `--effort`. Droid maps thinking to `-r, --reasoning-effort`. Pi maps thinking to `--thinking`. OpenCode maps thinking to `--variant`. Copilot rejects `--thinking`. Only Claude accepts `--fallback-model`; global CLI/env fallback requires at least one Claude reviewer, and engine-specific fallback overrides require that reviewer to be selected. Non-Claude fallback overrides, including `AUTOREVIEW_<NONCLAUDE>_FALLBACK_MODEL`, fail closed instead of being silently ignored.
+
+## Review engine isolation
+
+When autoreview runs inside the repository under review, external reviewer CLIs must not load project-local trust or configuration that the branch controls.
+
+| Engine       | Isolation flags                                                                                                                                                   | Reference                                                                  |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| **codex**    | Auth-only config overrides, `-c project_doc_max_bytes=0`, repo `trust_level="untrusted"`, `exec --ignore-user-config --ignore-rules`, plus read-only sandbox      | Codex CLI `exec --help`                                                    |
+| **claude**   | `--safe-mode --setting-sources user --strict-mcp-config --disallowedTools mcp__*` plus explicit `--allowedTools` (`--safe-mode` requires Claude Code `v2.1.169+`) | Claude Code [CLI reference](https://code.claude.com/docs/en/cli-reference) |
+| **pi**       | `--no-approve --no-session --no-context-files --no-extensions --no-skills --no-prompt-templates --no-themes`, plus read-only tool allowlist                       | Pi CLI `--help`; requires Pi `v0.79.0+`                                    |
+| **opencode** | `opencode run --dir <repo> --pure --format json`, prompt over stdin, neutral subprocess cwd, injected deny-by-default permissions, project config disabled        | OpenCode CLI `--help`                                                      |
+
+Codex `--ignore-user-config` skips config loading for the exec run. Autoreview reconstructs only the documented `cli_auth_credentials_store`, `forced_login_method`, and `forced_chatgpt_workspace_id` settings from `CODEX_HOME/config.toml`, keeping authentication and workspace restrictions usable without forwarding unrelated user configuration. The explicit repo trust override and zero project-doc budget keep reviewed-repo `AGENTS.md` and `.codex/` trust surfaces out of the review prompt. `--ignore-rules` skips user/project execpolicy rules. Claude `--safe-mode` disables project hooks, skills, plugins, MCP servers, and CLAUDE.md while preserving normal authentication, model selection, built-in tools, and permissions; managed settings policy can still apply. `--setting-sources user` avoids project/local settings from the reviewed checkout, and current Claude Code docs note the project-skill blocking behavior was fixed in `v2.1.69`. `--strict-mcp-config` and `--disallowedTools mcp__*` keep MCP unavailable to the review run. `--bare` is not used here because Claude's headless docs say it skips OAuth and keychain reads. Pi `--no-approve` ignores project-local files for one run; the helper requires Pi `v0.79.0+` plus help output that advertises every required isolation flag because older legacy binaries can ignore unknown flags. The current package is `@earendil-works/pi-coding-agent`; deprecated `@mariozechner/pi-coding-agent` `0.73.x` is intentionally rejected. Pi version/help probes and the review command run from neutral temporary directories, not the reviewed repo. Pi `--no-context-files` removes `AGENTS.md`/`CLAUDE.md`, the resource-disable flags keep `.pi` extensions, skills, prompts, and themes out of the run, `--no-session` avoids writing review sessions, and the read-only allowlist omits `bash`, `edit`, and `write`. OpenCode starts from a neutral temporary directory, points at the reviewed repo with `--dir`, disables project config through `OPENCODE_DISABLE_PROJECT_CONFIG=1`, and injects `OPENCODE_CONFIG_CONTENT`; permissions default to deny, allow read/grep/glob, preserve OpenCode's `.env` ask rules, and gate `websearch`/`webfetch` with `--no-web-search`. The injected config also clears command/instruction/plugin arrays and disables write/edit/bash/task/skill/todowrite tools without changing user auth storage. The helper sends the review prompt over stdin rather than argv and extracts the final structured JSON from `type: "text"` events. OpenCode rejects `--no-tools`.
 
 ## Context Efficiency
 
-Codex review is usually noisy. Default to a subagent filter when subagents are
-available. Ask it to run the review and return only:
-
-- actionable findings it accepts
-- findings it rejects, with one-line reason
-- exact files/tests to rerun
-
-Run inline only for tiny changes or when subagents are unavailable.
+Run the helper directly so target selection, engine choice, structured validation, and exit status all stay in one path. If output is noisy, summarize the completed helper output after it returns; do not ask another agent or reviewer to rerun the review.
 
 ## Helper
 
-Bundled helper:
+After setting `AUTOREVIEW` and `AUTOREVIEW_HARNESS` above:
 
 ```bash
-.agents/skills/autoreview/scripts/autoreview --help
+"$AUTOREVIEW" --help
+```
+
+The smoke harness has thin shell wrappers over a shared Python implementation:
+
+```bash
+"$AUTOREVIEW_HARNESS" --fixture benign --engine codex
+```
+
+On native Windows, invoke the extensionless Python helper through Python:
+
+```powershell
+python skills\autoreview\scripts\autoreview --help
+```
+
+and the smoke harness:
+
+```powershell
+skills\autoreview\scripts\test-review-harness.ps1 -Fixture benign -Engine codex
 ```
 
 The helper:
 
-- chooses dirty `--uncommitted` first
+- chooses dirty local changes first
+- accepts `--mode uncommitted` as an alias for `--mode local`
 - otherwise uses current PR base if `gh pr view` works
 - otherwise uses `origin/main` for non-main branches
-- auto-runs `bun run ci:static` in parallel when the repo has `package.json`,
-  `bun.lock`, `node_modules`, and a `ci:static` script; disable with
-  `AUTOREVIEW_AUTO_TESTS=0`
-- use `--mode commit --commit <ref>` for already-committed work, especially
-  clean `main` after landing
-- should be left in `--mode auto` or forced to `--mode branch` for PR/branch
-  work; do not force `--mode local` after committing
-- supports `--reviewer codex|claude|pi|opencode|droid|copilot|auto`; `auto`
-  means Codex first
-- supports `--fallback-reviewer auto|claude|pi|opencode|droid|copilot|none`
-- falls back only when Codex is unavailable or exits nonzero without findings,
-  not when Codex reports findings
-- writes only to stdout unless `--output` or `AUTOREVIEW_OUTPUT` is set
-- supports `--dry-run`, `--parallel-tests`, and commit refs
-- runs nested review with `--dangerously-bypass-approvals-and-sandbox --sandbox
-danger-full-access` by default; use `--no-yolo` or `AUTOREVIEW_YOLO=0` to opt
-  out
-- prints `autoreview clean: no accepted/actionable findings reported` when the
-  selected review command exits 0 and no accepted/actionable findings are
-  reported
+- does not fetch automatically during branch review; the selected base ref must already resolve locally
+- supports `--engine codex`, `claude`, `droid`, `copilot`, `pi`, and `opencode`; default is `AUTOREVIEW_ENGINE` or `codex`; Codex should remain the default when nothing is set
+- resolves bare `git`, `gh`, reviewer, and PowerShell shell commands from absolute `PATH` entries only, never from the reviewed checkout; explicit relative `--*-bin` paths are resolved from the reviewed repository root
+- use `--mode commit --commit <ref>` for already-committed work, especially clean `main` after landing
+- should be left in `--mode auto` or forced to `--mode branch` for PR/branch work; do not force `--mode local` after committing
+- writes only to stdout unless `--output`, `--json-output`, or live streamed engine stderr is set
+- supports `--dry-run`, `--parallel-tests`, `--parallel-tests-shell`, `--prompt`, repo-relative `--prompt-file`, repo-relative `--dataset`, `--no-tools`, `--no-web-search`, and commit refs
+- supports `--stream-engine-output` or `AUTOREVIEW_STREAM_ENGINE_OUTPUT=1` for live engine text while preserving structured validation; Codex and Claude hide tool/file event details, emit compact activity summaries, and report usage at turn completion
+- supports opt-in review panels with `--panel` / `--reviewers`, plus per-engine `--model`, `--thinking`, and Claude `--fallback-model`
+- uses built-in model defaults `codex=gpt-5.5` and `claude=claude-fable-5`; honors `AUTOREVIEW_MODEL`, `AUTOREVIEW_THINKING`, `AUTOREVIEW_FALLBACK_MODEL`, and per-engine `AUTOREVIEW_<ENGINE>_MODEL` / `AUTOREVIEW_<ENGINE>_THINKING` environment overrides when CLI flags are omitted
+- allows read-only tools and web search by default where the selected CLI supports them; forbids nested review in the prompt; Codex is run through `codex exec` with auth-only user settings, read-only sandbox, reviewed-repo instruction/config/rule isolation flags, and structured output
+- runs Claude with `--safe-mode` (`v2.1.169+`), `--setting-sources user`, MCP disabled, explicit allowed tools, and `--fallback-model` when set, so reviewed-repo hooks/skills/MCP do not affect the review run while normal auth still works; managed settings policy can still apply
+- runs Droid with `droid exec` in read-only mode, forwards `--model` and `-r, --reasoning-effort`, and switches `--output-format` to `stream-json` when streaming is enabled
+- runs Pi `v0.79.0+` from neutral temporary directories with `--no-approve`, `--no-session`, disabled Pi context/resource loading, and built-in read-only tools (`read,grep,find,ls`) when tools are enabled
+- runs OpenCode with `opencode run --dir <repo> --pure --format json` from a neutral temporary directory, forwards `--model` and `--variant`, injects deny-by-default permissions, disables project config loading, and passes the review prompt over stdin
+- prints `review still running: <engine> elapsed=<seconds>s pid=<pid>` to stderr at long-running intervals while waiting for the selected review engine, unless streamed output or compact Codex activity has been visible recently
+- prints `autoreview clean: no accepted/actionable findings reported` when the selected review command exits 0
+- exits nonzero when accepted/actionable findings are present
 
 ## Final Report
 
@@ -179,18 +340,6 @@ Include:
 - review command used
 - tests/proof run
 - findings accepted/rejected, briefly why
-- the clean review result from the final helper/review run, or why a remaining
-  finding was consciously rejected
+- the clean review result from the final helper/review run, or why a remaining finding was consciously rejected
 
-Do not run another Codex review solely to improve final wording. If the final
-helper run exited 0 and produced no accepted/actionable findings, report that
-exact run as clean.
-
-## PR / CI Closeout
-
-- Prefer direct run/job APIs after CI starts: `gh run view <run-id> --json jobs`;
-  use PR rollup only for final mergeability.
-- After rebase, compare `origin/main..HEAD`; drop CI-fix commits already
-  upstream before pushing.
-- Update the PR body once near the final head unless proof labels are missing
-  or stale enough to block CI.
+Do not run another review solely to improve the final report wording. If the final helper run exited 0 and produced no accepted/actionable findings, report that exact run as clean.

--- a/.agents/skills/autoreview/scripts/autoreview
+++ b/.agents/skills/autoreview/scripts/autoreview
@@ -1,543 +1,3046 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env python3
+from __future__ import annotations
 
-usage() {
-  cat <<'EOF'
-Usage: autoreview [options]
+import argparse
+import ast
+import concurrent.futures
+import copy
+import json
+import os
+import queue
+import re
+import subprocess
+import sys
+import tempfile
+import textwrap
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable
 
-Options:
-  --mode auto|local|branch|commit
-      Target selection. Default: auto.
-  --base REF
-      Base ref for branch review. Default: PR base or origin/main.
-  --commit REF
-      Commit ref for commit review. Default: HEAD.
-  --reviewer codex|claude|pi|opencode|droid|copilot|auto
-      Review engine. Default: Codex with configured fallback on error.
-  --fallback-reviewer auto|claude|pi|opencode|droid|copilot|none
-      Fallback when Codex is unavailable or exits nonzero without findings.
-  --codex-bin PATH
-      Codex binary. Default: codex.
-  --claude-bin PATH
-      Claude binary. Default: claude.
-  --pi-bin PATH
-      Pi binary. Default: pi.
-  --opencode-bin PATH
-      OpenCode binary. Default: opencode.
-  --droid-bin PATH
-      Droid binary. Default: droid.
-  --copilot-bin PATH
-      GitHub Copilot binary. Default: copilot.
-  --full-access
-      Keep yolo/full-access mode enabled. Default.
-  --no-yolo
-      Run nested Codex review with normal sandbox/approval prompts.
-  --output FILE
-      Also save output to file.
-  --parallel-tests CMD
-      Run review and test command concurrently. Pass "" to disable auto-tests.
-      Default: bun run ci:static when package.json, bun.lock, node_modules, and
-      a ci:static script are present.
-  --dry-run
-      Print selected commands, do not run.
-  -h, --help
-      Show help.
 
-Modes:
-  local   codex review --uncommitted
-  branch  codex review --base <ref>
-  commit  codex review --commit <ref>
-  auto    dirty tree -> local, else PR/current branch -> branch
-EOF
+ENGINES = ("codex", "claude", "droid", "copilot", "pi", "opencode")
+SAFE_GIT_CONFIG_ARGS = (
+    "-c",
+    "core.fsmonitor=false",
+    "-c",
+    "core.pager=cat",
+    "-c",
+    "diff.external=",
+    "-c",
+    "diff.renames=false",
+    "-c",
+    "pager.diff=cat",
+    "-c",
+    "pager.log=cat",
+    "-c",
+    "pager.show=cat",
+)
+SAFE_DIFF_FLAGS = ("--no-ext-diff", "--no-textconv", "--no-renames")
+ENGINE_GIT_CONFIG_OVERRIDES = (
+    ("core.fsmonitor", "false"),
+    ("core.pager", "cat"),
+    ("diff.external", ""),
+    ("diff.renames", "false"),
+    ("pager.diff", "cat"),
+    ("pager.log", "cat"),
+    ("pager.show", "cat"),
+)
+SENSITIVE_PATH_PARTS = {
+    ".aws",
+    ".azure",
+    ".config/gcloud",
+    ".docker",
+    ".gnupg",
+    ".ssh",
+    "private",
+    "secrets",
+}
+SENSITIVE_NAME_PATTERNS = [
+    re.compile(r"(^|/)\.env($|[._/-])", re.IGNORECASE),
+    re.compile(r"(^|/)(id_rsa|id_dsa|id_ecdsa|id_ed25519)(\.pub)?$", re.IGNORECASE),
+    re.compile(r"\.(pem|p12|pfx|key)$", re.IGNORECASE),
+    re.compile(
+        r"(^|/)[^/]*(secret|token|credential|credentials|service[-_]?account|private[-_]?key|apikey|api[-_]?key)[^/]*$",
+        re.IGNORECASE,
+    ),
+]
+SECRET_VALUE_PATTERNS = [
+    re.compile(r"-----BEGIN (?:RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY-----"),
+    re.compile(
+        r"(?i)(api[_-]?key|token|secret|password)\s*[:=]\s*(?:[\"'][A-Za-z0-9_./+=-]{12,}[\"']|[A-Za-z0-9_+=/-]{20,})"
+    ),
+    re.compile(r"(?i)bearer\s+[A-Za-z0-9._-]{20,}"),
+    re.compile(r"\b(?:sk|rk|pk|org|proj)-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b"),
+    re.compile(r"\bglpat-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bnpm_[A-Za-z0-9]{20,}\b"),
+    re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{20,}\b"),
+    re.compile(r"\b(?:A3T|AKIA|ASIA)[A-Z0-9]{16}\b"),
+    re.compile(r"\bAIza[0-9A-Za-z_-]{35}\b"),
+    re.compile(r"\bya29\.[0-9A-Za-z_-]{20,}\b"),
+]
+MAX_BUNDLE_TEXT_BYTES = 180_000
+DEFAULT_ENGINE_PATHS = ("/usr/local/bin", "/usr/bin", "/bin")
+DEFAULT_MODEL_BY_ENGINE = {
+    "codex": "gpt-5.5",
+    "claude": "claude-fable-5",
+}
+THINKING_LEVELS_BY_ENGINE = {
+    "codex": {"none", "minimal", "low", "medium", "high", "xhigh"},
+    "claude": {"low", "medium", "high", "xhigh", "max"},
+    "droid": {"off", "none", "low", "medium", "high"},
+    "copilot": set(),
+    "pi": {"off", "minimal", "low", "medium", "high", "xhigh"},
+    "opencode": {"minimal", "low", "medium", "high", "max"},
+}
+CLAUDE_SAFE_MODE_MIN_VERSION = (2, 1, 169)
+# Pi's reviewed-repo trust override first appears in the current
+# @earendil-works/pi-coding-agent 0.79.0 CLI line. Older legacy binaries can
+# ignore unknown flags, so the Pi engine must fail closed below this floor.
+PI_TRUST_ISOLATION_MIN_VERSION = (0, 79, 0)
+
+
+SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": [
+        "findings",
+        "overall_correctness",
+        "overall_explanation",
+        "overall_confidence",
+    ],
+    "properties": {
+        "findings": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": [
+                    "title",
+                    "body",
+                    "priority",
+                    "confidence",
+                    "category",
+                    "code_location",
+                ],
+                "properties": {
+                    "title": {"type": "string", "minLength": 1, "maxLength": 140},
+                    "body": {"type": "string", "minLength": 1, "maxLength": 2000},
+                    "priority": {"type": "string", "enum": ["P0", "P1", "P2", "P3"]},
+                    "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+                    "category": {
+                        "type": "string",
+                        "enum": ["bug", "security", "regression", "test_gap", "maintainability"],
+                    },
+                    "code_location": {
+                        "type": "object",
+                        "additionalProperties": False,
+                        "required": ["file_path", "line"],
+                        "properties": {
+                            "file_path": {"type": "string", "minLength": 1},
+                            "line": {"type": "integer", "minimum": 1},
+                        },
+                    },
+                },
+            },
+        },
+        "overall_correctness": {
+            "type": "string",
+            "enum": ["patch is correct", "patch is incorrect"],
+        },
+        "overall_explanation": {"type": "string", "minLength": 1, "maxLength": 3000},
+        "overall_confidence": {"type": "number", "minimum": 0, "maximum": 1},
+    },
 }
 
-mode=auto
-base_ref=
-commit_ref=HEAD
-reviewer=${AUTOREVIEW_REVIEWER:-${CODEX_REVIEW_REVIEWER:-auto}}
-fallback_reviewer=${AUTOREVIEW_FALLBACK_REVIEWER:-${CODEX_REVIEW_FALLBACK_REVIEWER:-auto}}
-codex_bin=${CODEX_BIN:-codex}
-claude_bin=${CLAUDE_BIN:-claude}
-pi_bin=${PI_BIN:-pi}
-opencode_bin=${OPENCODE_BIN:-opencode}
-droid_bin=${DROID_BIN:-droid}
-copilot_bin=${COPILOT_BIN:-copilot}
-yolo=${AUTOREVIEW_YOLO:-${CODEX_REVIEW_YOLO:-1}}
-output=${AUTOREVIEW_OUTPUT:-${CODEX_REVIEW_OUTPUT:-}}
-parallel_tests=
-parallel_tests_set=false
-parallel_tests_auto=false
-dry_run=false
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --mode) mode=${2:-}; shift 2 ;;
-    --base) base_ref=${2:-}; shift 2 ;;
-    --commit) commit_ref=${2:-}; shift 2 ;;
-    --reviewer) reviewer=${2:-}; shift 2 ;;
-    --fallback-reviewer) fallback_reviewer=${2:-}; shift 2 ;;
-    --codex-bin) codex_bin=${2:-}; shift 2 ;;
-    --claude-bin) claude_bin=${2:-}; shift 2 ;;
-    --pi-bin) pi_bin=${2:-}; shift 2 ;;
-    --opencode-bin) opencode_bin=${2:-}; shift 2 ;;
-    --droid-bin) droid_bin=${2:-}; shift 2 ;;
-    --copilot-bin) copilot_bin=${2:-}; shift 2 ;;
-    --full-access) yolo=1; shift ;;
-    --no-yolo) yolo=0; shift ;;
-    --output) output=${2:-}; shift 2 ;;
-    --parallel-tests) parallel_tests=${2:-}; parallel_tests_set=true; shift 2 ;;
-    --dry-run) dry_run=true; shift ;;
-    -h|--help) usage; exit 0 ;;
-    *) usage >&2; exit 2 ;;
-  esac
-done
+def run(
+    args: list[str],
+    cwd: Path,
+    *,
+    input_text: str | None = None,
+    check: bool = True,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        input=input_text,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    if check and result.returncode != 0:
+        cmd = " ".join(args)
+        raise SystemExit(f"command failed ({result.returncode}): {cmd}\n{result.stderr or result.stdout}")
+    return result
 
-case "$mode" in
-  auto|local|branch|commit) ;;
-  *) echo "invalid --mode: $mode" >&2; exit 2 ;;
-esac
 
-case "$reviewer" in
-  auto|codex|claude|pi|opencode|droid|copilot) ;;
-  *) echo "invalid --reviewer: $reviewer" >&2; exit 2 ;;
-esac
+def subprocess_env(extra: dict[str, str] | None) -> dict[str, str] | None:
+    if not extra:
+        return None
+    merged = os.environ.copy()
+    merged.update(extra)
+    return merged
 
-case "$fallback_reviewer" in
-  auto|claude|pi|opencode|droid|copilot|none) ;;
-  *) echo "invalid --fallback-reviewer: $fallback_reviewer" >&2; exit 2 ;;
-esac
 
-repo_root=$(git rev-parse --show-toplevel)
-current_branch=$(git branch --show-current 2>/dev/null || true)
-dirty=false
-if [[ -n "$(git status --porcelain)" ]]; then
-  dirty=true
-fi
+def safe_git_env() -> dict[str, str]:
+    return {
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_SYSTEM": os.devnull,
+        "GIT_OPTIONAL_LOCKS": "0",
+        "GIT_TERMINAL_PROMPT": "0",
+        "HOME": os.environ.get("HOME", str(Path.home())),
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "PATH": os.pathsep.join(DEFAULT_ENGINE_PATHS),
+    }
 
-codex_args=()
-case "$yolo" in
-  0|false|False|FALSE|no|No|NO|off|Off|OFF) ;;
-  *) codex_args+=(--dangerously-bypass-approvals-and-sandbox --sandbox danger-full-access) ;;
-esac
 
-has_package_script() {
-  local script_name=$1
-  command -v node >/dev/null 2>&1 || return 1
-  node -e '
-    const { readFileSync } = require("node:fs");
-    const pkg = JSON.parse(readFileSync(process.argv[1], "utf8"));
-    process.exit(pkg.scripts?.[process.argv[2]] ? 0 : 1);
-  ' "$repo_root/package.json" "$script_name" >/dev/null 2>&1
+def safe_engine_path(repo: Path, extra_paths: list[Path] | None = None) -> str:
+    entries: list[str] = []
+    resolved_repo = repo.resolve()
+
+    def add(path: str | Path) -> None:
+        candidate = Path(path).expanduser()
+        if not candidate.is_absolute() or not candidate.exists():
+            return
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            return
+        if is_within(resolved, resolved_repo):
+            return
+        value = str(resolved)
+        if value not in entries:
+            entries.append(value)
+
+    for path in extra_paths or []:
+        add(path)
+    for part in os.environ.get("PATH", "").split(os.pathsep):
+        if part:
+            add(part)
+    for path in DEFAULT_ENGINE_PATHS:
+        add(path)
+    return os.pathsep.join(entries)
+
+
+def safe_engine_env(
+    repo: Path,
+    extra_paths: list[Path] | None = None,
+    extra: dict[str, str] | None = None,
+) -> dict[str, str]:
+    blocked_exact = {
+        "BASH_ENV",
+        "ENV",
+        "GIT_CONFIG",
+        "GIT_CONFIG_GLOBAL",
+        "GIT_CONFIG_NOSYSTEM",
+        "GIT_CONFIG_SYSTEM",
+        "GIT_OPTIONAL_LOCKS",
+        "GIT_TERMINAL_PROMPT",
+        "LD_PRELOAD",
+        "NODE_OPTIONS",
+        "PYTHONHOME",
+        "PYTHONPATH",
+    }
+    blocked_prefixes = ("GIT_", "DYLD_")
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in blocked_exact and not any(key.startswith(prefix) for prefix in blocked_prefixes)
+    }
+    env["PATH"] = safe_engine_path(repo, extra_paths)
+    env["GIT_CONFIG_COUNT"] = str(len(ENGINE_GIT_CONFIG_OVERRIDES))
+    for index, (key, value) in enumerate(ENGINE_GIT_CONFIG_OVERRIDES):
+        env[f"GIT_CONFIG_KEY_{index}"] = key
+        env[f"GIT_CONFIG_VALUE_{index}"] = value
+    env.update(extra or {})
+    return env
+
+
+def parse_ps_time(value: str) -> float:
+    try:
+        day_text, clock = value.strip().split("-", 1) if "-" in value else ("0", value.strip())
+        parts = clock.split(":")
+        if not parts or len(parts) > 3:
+            return 0.0
+        total = float(parts[-1])
+        if len(parts) >= 2:
+            total += int(parts[-2]) * 60
+        if len(parts) == 3:
+            total += int(parts[-3]) * 3600
+        return int(day_text) * 86400 + total
+    except (IndexError, ValueError):
+        return 0.0
+
+
+def process_pids(repo: Path, pid: int) -> list[str]:
+    ps = find_command("ps", repo)
+    if not ps:
+        return [str(pid)]
+    result = subprocess.run(
+        [ps, "-A", "-o", "pid=", "-o", "ppid="],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if result.returncode != 0:
+        return [str(pid)]
+    pids = [str(pid)]
+    for line in result.stdout.splitlines():
+        fields = line.split()
+        if len(fields) == 2 and fields[1] == str(pid):
+            pids.append(fields[0])
+    return pids
+
+
+def sample_process_metrics(repo: Path, pid: int) -> tuple[float, float, int, str] | None:
+    ps = find_command("ps", repo)
+    if not ps:
+        return None
+    try:
+        result = subprocess.run(
+            [
+                ps,
+                "-o",
+                "state=",
+                "-o",
+                "rss=",
+                "-o",
+                "time=",
+                "-p",
+                ",".join(process_pids(repo, pid)),
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+
+    cpu_seconds = 0.0
+    rss_kb = 0
+    states: list[str] = []
+    for line in result.stdout.splitlines():
+        fields = line.split()
+        if len(fields) < 3:
+            continue
+        states.append(fields[0][:1] or "?")
+        try:
+            rss_kb += int(fields[1])
+        except ValueError:
+            pass
+        cpu_seconds += parse_ps_time(fields[2])
+    if not states:
+        return None
+    return (time.monotonic(), cpu_seconds, rss_kb, ",".join(sorted(set(states))))
+
+
+def format_process_metrics(
+    previous: tuple[float, float, int, str] | None,
+    current: tuple[float, float, int, str] | None,
+) -> str:
+    if current is None:
+        return ""
+    interval = max(0.0, current[0] - previous[0]) if previous else 0.0
+    cpu_delta = max(0.0, current[1] - previous[1]) if previous else 0.0
+    cpu_percent = (cpu_delta / interval * 100) if interval > 0 else 0.0
+    rss_mb = int(round(current[2] / 1024))
+    interval_seconds = int(interval) if interval else 0
+    return (
+        f" cpu={cpu_delta:.1f}s/{interval_seconds}s({cpu_percent:.0f}%)"
+        f" rss={rss_mb}M state={current[3]}"
+    )
+
+
+def emit_heartbeat(
+    label: str,
+    repo: Path,
+    started: float,
+    proc: subprocess.Popen,
+    metrics: tuple[float, float, int, str] | None,
+) -> tuple[float, float, int, str] | None:
+    elapsed = int(time.monotonic() - started)
+    next_metrics = sample_process_metrics(repo, proc.pid)
+    metrics_text = format_process_metrics(metrics, next_metrics)
+    print(f"review still running: {label} elapsed={elapsed}s pid={proc.pid}{metrics_text}", file=sys.stderr, flush=True)
+    return next_metrics or metrics
+
+
+def opencode_review_config(web_search: bool = True) -> dict[str, Any]:
+    permission: dict[str, Any] = {
+        "*": "deny",
+        "read": {
+            "*": "allow",
+            "*.env": "ask",
+            "*.env.*": "ask",
+            "*.env.example": "allow",
+        },
+        "grep": "allow",
+        "glob": "allow",
+    }
+    if web_search:
+        permission["websearch"] = "allow"
+        permission["webfetch"] = "allow"
+    else:
+        permission["websearch"] = "deny"
+        permission["webfetch"] = "deny"
+    return {
+        "$schema": "https://opencode.ai/config.json",
+        "autoupdate": False,
+        "command": {},
+        "instructions": [],
+        "plugin": [],
+        "permission": permission,
+        "share": "disabled",
+        "tools": {
+            "bash": False,
+            "edit": False,
+            "skill": False,
+            "task": False,
+            "todowrite": False,
+            "write": False,
+        },
+    }
+
+
+def opencode_review_env(web_search: bool = True) -> dict[str, str]:
+    return {
+        "OPENCODE_DISABLE_PROJECT_CONFIG": "1",
+        "OPENCODE_CONFIG_CONTENT": json.dumps(opencode_review_config(web_search), separators=(",", ":")),
+        "OPENCODE_DISABLE_AUTOUPDATE": "1",
+        "OPENCODE_DISABLE_AUTOCOMPACT": "1",
+        "OPENCODE_DISABLE_MODELS_FETCH": "1",
+    }
+
+
+def run_with_heartbeat(
+    args: list[str],
+    cwd: Path,
+    *,
+    input_text: str | None = None,
+    label: str,
+    heartbeat_seconds: int = 60,
+    stream_output: bool = False,
+    stream_display: Callable[[str, str], str | None] | None = None,
+    env: dict[str, str] | None = None,
+    resolve_root: Path | None = None,
+) -> subprocess.CompletedProcess[str]:
+    resolve_root = resolve_root or cwd
+    if stream_output:
+        return run_with_stream(
+            args,
+            cwd,
+            input_text=input_text,
+            label=label,
+            heartbeat_seconds=heartbeat_seconds,
+            stream_display=stream_display,
+            env=env,
+            resolve_root=resolve_root,
+        )
+    started = time.monotonic()
+    proc = subprocess.Popen(
+        args,
+        cwd=cwd,
+        stdin=subprocess.PIPE if input_text is not None else None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    first_communicate = True
+    metrics = sample_process_metrics(resolve_root, proc.pid)
+    while True:
+        try:
+            stdout, stderr = proc.communicate(
+                input=input_text if first_communicate else None,
+                timeout=heartbeat_seconds,
+            )
+            return subprocess.CompletedProcess(args, int(proc.returncode or 0), stdout, stderr)
+        except subprocess.TimeoutExpired:
+            first_communicate = False
+            metrics = emit_heartbeat(label, resolve_root, started, proc, metrics)
+
+
+def run_with_stream(
+    args: list[str],
+    cwd: Path,
+    *,
+    input_text: str | None,
+    label: str,
+    heartbeat_seconds: int,
+    stream_display: Callable[[str, str], str | None] | None,
+    env: dict[str, str] | None = None,
+    resolve_root: Path,
+) -> subprocess.CompletedProcess[str]:
+    started = time.monotonic()
+    proc = subprocess.Popen(
+        args,
+        cwd=cwd,
+        stdin=subprocess.PIPE if input_text is not None else None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+        env=env,
+    )
+    events: queue.Queue[tuple[str, str | None]] = queue.Queue()
+    stdout_parts: list[str] = []
+    stderr_parts: list[str] = []
+
+    def read_stream(name: str, stream: Any) -> None:
+        try:
+            for line in iter(stream.readline, ""):
+                events.put((name, line))
+        finally:
+            events.put((name, None))
+
+    def write_stdin() -> None:
+        if proc.stdin is None or input_text is None:
+            return
+        try:
+            proc.stdin.write(input_text)
+            proc.stdin.close()
+        except BrokenPipeError:
+            return
+
+    threads = [
+        threading.Thread(target=read_stream, args=("stdout", proc.stdout), daemon=True),
+        threading.Thread(target=read_stream, args=("stderr", proc.stderr), daemon=True),
+    ]
+    for thread in threads:
+        thread.start()
+    stdin_thread = threading.Thread(target=write_stdin, daemon=True)
+    stdin_thread.start()
+    metrics = sample_process_metrics(resolve_root, proc.pid)
+
+    open_streams = 2
+    while open_streams:
+        try:
+            name, line = events.get(timeout=heartbeat_seconds)
+        except queue.Empty:
+            metrics = emit_heartbeat(label, resolve_root, started, proc, metrics)
+            continue
+        if line is None:
+            open_streams -= 1
+            continue
+        if name == "stdout":
+            stdout_parts.append(line)
+        else:
+            stderr_parts.append(line)
+        display = stream_display(name, line) if stream_display else line
+        if display:
+            target = sys.stdout if name == "stdout" else sys.stderr
+            target.write(display)
+            target.flush()
+
+    for thread in threads:
+        thread.join()
+    stdin_thread.join(timeout=1)
+    returncode = proc.wait()
+    return subprocess.CompletedProcess(args, returncode, "".join(stdout_parts), "".join(stderr_parts))
+
+
+def git(repo: Path, *args: str, check: bool = True) -> str:
+    return run(
+        [resolve_command("git", repo), "--no-optional-locks", *SAFE_GIT_CONFIG_ARGS, *args],
+        repo,
+        check=check,
+        env=safe_git_env(),
+    ).stdout
+
+
+def git_path_list(repo: Path, *args: str, check: bool = True) -> list[str]:
+    return [path for path in git(repo, *args, check=check).split("\0") if path]
+
+
+def repo_root() -> Path:
+    start = Path.cwd().resolve()
+    unsafe_root = discover_repo_root(start) or start
+    git_bin = find_command("git", unsafe_root)
+    if not git_bin:
+        raise SystemExit("git executable not found. Install Git or add it to PATH.")
+    result = subprocess.run(
+        [git_bin, "--no-optional-locks", *SAFE_GIT_CONFIG_ARGS, "rev-parse", "--show-toplevel"],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=safe_git_env(),
+    )
+    if result.returncode != 0:
+        raise SystemExit("autoreview must run inside a git repository")
+    return Path(result.stdout.strip()).resolve()
+
+
+def discover_repo_root(start: Path) -> Path | None:
+    current = start
+    while True:
+        if (current / ".git").exists():
+            return current
+        if current.parent == current:
+            return None
+        current = current.parent
+
+
+def current_branch(repo: Path) -> str:
+    return git(repo, "branch", "--show-current", check=False).strip() or "detached"
+
+
+def is_dirty(repo: Path) -> bool:
+    return bool(git(repo, "status", "--porcelain").strip())
+
+
+def choose_target(repo: Path, mode: str, base_ref: str | None) -> tuple[str, str | None]:
+    mode = "local" if mode == "uncommitted" else mode
+    branch = current_branch(repo)
+    if mode == "local" or (mode == "auto" and is_dirty(repo)):
+        return "local", None
+    if mode == "commit":
+        return "commit", None
+    if mode == "branch" or (mode == "auto" and branch != "main"):
+        return "branch", base_ref or detect_pr_base(repo) or "origin/main"
+    raise SystemExit("no review target: clean main checkout and no forced mode")
+
+
+def detect_pr_base(repo: Path) -> str | None:
+    gh_bin = find_command("gh", repo)
+    if not gh_bin:
+        return None
+    result = run([gh_bin, "pr", "view", "--json", "baseRefName", "--jq", ".baseRefName"], repo, check=False)
+    base = result.stdout.strip()
+    return f"origin/{base}" if result.returncode == 0 and base else None
+
+
+def resolve_command(name: str, repo: Path) -> str:
+    resolved = find_command(name, repo)
+    if resolved:
+        return resolved
+    raise SystemExit(f"executable not found: {name}. Install it or pass an explicit trusted path when supported.")
+
+
+def find_command(name: str, repo: Path) -> str | None:
+    command = Path(name)
+    if has_directory_component(name, command):
+        base = command if command.is_absolute() else repo / command
+        return first_executable_candidate(base)
+    for part in os.environ.get("PATH", "").split(os.pathsep):
+        if not part or part == ".":
+            continue
+        path_part = Path(part)
+        if not path_part.is_absolute():
+            continue
+        try:
+            resolved_part = path_part.resolve()
+            resolved_repo = repo.resolve()
+        except OSError:
+            continue
+        if is_within(resolved_part, resolved_repo):
+            continue
+        found = first_executable_candidate(resolved_part / name, reject_root=resolved_repo)
+        if found:
+            return found
+    return None
+
+
+def is_within(path: Path, root: Path) -> bool:
+    return path == root or path.is_relative_to(root)
+
+
+def has_directory_component(name: str, command: Path) -> bool:
+    separators = [separator for separator in (os.sep, os.altsep) if separator]
+    return command.is_absolute() or bool(command.drive) or any(separator in name for separator in separators)
+
+
+def first_executable_candidate(path: Path, *, reject_root: Path | None = None) -> str | None:
+    if os.name == "nt" and not path.suffix:
+        extensions = [ext for ext in os.environ.get("PATHEXT", ".COM;.EXE;.BAT;.CMD").split(";") if ext]
+        candidates = [path.with_suffix(ext.lower()) for ext in extensions]
+        candidates.extend(path.with_suffix(ext.upper()) for ext in extensions)
+        candidates.append(path)
+    else:
+        candidates = [path]
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            if reject_root is not None:
+                try:
+                    if is_within(candidate.resolve(), reject_root):
+                        continue
+                except OSError:
+                    continue
+            return str(candidate)
+    return None
+
+
+def validate_git_ref(repo: Path, ref: str, label: str) -> str:
+    if not ref or ref.startswith("-") or ":" in ref or "\0" in ref or any(char.isspace() for char in ref):
+        raise SystemExit(f"unsafe {label} ref: {ref}")
+    result = git(
+        repo,
+        "rev-parse",
+        "--verify",
+        "--quiet",
+        "--end-of-options",
+        f"{ref}^{{commit}}",
+        check=False,
+    )
+    if not result:
+        raise SystemExit(f"unknown {label} ref: {ref}")
+    return ref
+
+
+def bounded(text: str, limit: int = 180_000) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"\n\n[truncated at {limit} characters]\n"
+
+
+def bounded_field(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    suffix = "\n\n[truncated]"
+    return text[: max(0, limit - len(suffix))] + suffix
+
+
+def read_prefix(path: Path, limit: int) -> tuple[bytes, bool]:
+    try:
+        with path.open("rb") as handle:
+            data = handle.read(limit + 1)
+    except OSError as exc:
+        raise SystemExit(f"unreadable file: {path}: {exc}") from exc
+    return data[:limit], len(data) > limit
+
+
+def read_text(path: Path, limit: int = MAX_BUNDLE_TEXT_BYTES) -> str:
+    try:
+        data, truncated = read_prefix(path, limit)
+    except SystemExit as exc:
+        return f"[unreadable: {exc}]"
+    if b"\0" in data:
+        return "[binary file omitted]"
+    text = data.decode("utf-8", errors="replace")
+    if len(text) > limit:
+        text = text[:limit]
+        truncated = True
+    if truncated:
+        return text + f"\n\n[truncated at {limit} characters]\n"
+    return text
+
+
+def path_has_sensitive_part(rel: str | Path) -> bool:
+    normalized = Path(rel).as_posix().lower()
+    if "/.config/gcloud/" in f"/{normalized}/":
+        return True
+    return any(part.lower() in SENSITIVE_PATH_PARTS for part in Path(rel).parts)
+
+
+def raw_repo_path_has_symlink_component(repo: Path, rel_path: Path) -> bool:
+    current = repo.resolve()
+    for part in rel_path.parts:
+        current = current / part
+        if current.is_symlink():
+            return True
+        if not current.exists():
+            break
+    return False
+
+
+def secret_text_risk(text: str) -> bool:
+    return any(pattern.search(text) for pattern in SECRET_VALUE_PATTERNS)
+
+
+def require_no_secret_values(label: str, text: str) -> None:
+    if secret_text_risk(text):
+        raise SystemExit(
+            "refusing to include secret-like content in review bundle; "
+            f"clean or redact {label} before running autoreview"
+        )
+
+
+def file_bundle_risk(
+    repo: Path,
+    path: Path,
+    rel: str,
+    *,
+    allow_binary_omission: bool = False,
+) -> str | None:
+    normalized = rel.replace(os.sep, "/")
+    if path_has_sensitive_part(normalized):
+        return "sensitive path"
+    for pattern in SENSITIVE_NAME_PATTERNS:
+        if pattern.search(normalized):
+            return "sensitive filename"
+    if path.is_symlink():
+        return "symlink"
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError as exc:
+        return f"unreadable file: {exc}"
+    if not is_within(resolved, repo.resolve()):
+        return "path outside repository"
+    if not path.is_file():
+        return "not a regular file"
+    try:
+        data, _ = read_prefix(path, MAX_BUNDLE_TEXT_BYTES)
+    except SystemExit as exc:
+        return str(exc)
+    if b"\0" in data:
+        return None if allow_binary_omission else "binary file"
+    if secret_text_risk(data.decode("utf-8", errors="replace")):
+        return "secret-like content"
+    return None
+
+
+def safe_untracked_files(repo: Path) -> list[str]:
+    files = git_path_list(repo, "ls-files", "--others", "--exclude-standard", "-z")
+    blocked: list[str] = []
+    included: list[str] = []
+    for rel in files:
+        risk = file_bundle_risk(repo, repo / rel, rel, allow_binary_omission=True)
+        if risk:
+            blocked.append(f"{rel} ({risk})")
+        else:
+            included.append(rel)
+    if blocked:
+        details = "\n".join(f"- {item}" for item in blocked[:20])
+        more = f"\n... {len(blocked) - 20} more" if len(blocked) > 20 else ""
+        raise SystemExit(
+            "refusing to include untracked sensitive files in review bundle; "
+            "stage, ignore, remove, or redact them before running autoreview:\n"
+            f"{details}{more}"
+        )
+    return included
+
+
+def local_status(repo: Path, untracked: list[str]) -> str:
+    status = git(repo, "status", "--short", "--untracked-files=no").rstrip()
+    lines = [status] if status else []
+    lines.extend(f"?? {rel}" for rel in untracked)
+    return "\n".join(lines)
+
+
+def local_bundle(repo: Path) -> str:
+    staged_patch = git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--patch")
+    unstaged_patch = git(repo, "diff", *SAFE_DIFF_FLAGS, "--patch")
+    untracked = safe_untracked_files(repo)
+    if not staged_patch.strip() and not unstaged_patch.strip() and not untracked:
+        raise SystemExit("no local changes to review")
+    parts = [
+        "# Git Status",
+        local_status(repo, untracked),
+        "# Staged Diff",
+        git(repo, "diff", *SAFE_DIFF_FLAGS, "--cached", "--stat"),
+        bounded(staged_patch),
+        "# Unstaged Diff",
+        git(repo, "diff", *SAFE_DIFF_FLAGS, "--stat"),
+        bounded(unstaged_patch),
+    ]
+    if untracked:
+        parts.append("# Untracked Files")
+        for rel in untracked:
+            path = repo / rel
+            parts.append(f"## {rel}\n{read_text(path)}")
+    return "\n\n".join(parts)
+
+
+def branch_bundle(repo: Path, base_ref: str) -> str:
+    base_ref = validate_git_ref(repo, base_ref, "base")
+    branch_patch = git(
+        repo,
+        "diff",
+        *SAFE_DIFF_FLAGS,
+        "--patch",
+        "--end-of-options",
+        f"{base_ref}...HEAD",
+    )
+    return "\n\n".join(
+        [
+            "# Branch Diff",
+            f"base: {base_ref}",
+            git(
+                repo,
+                "diff",
+                *SAFE_DIFF_FLAGS,
+                "--stat",
+                "--end-of-options",
+                f"{base_ref}...HEAD",
+            ),
+            bounded(branch_patch),
+        ]
+    )
+
+
+def commit_bundle(repo: Path, commit_ref: str) -> str:
+    commit_ref = validate_git_ref(repo, commit_ref, "commit")
+    commit_patch = git(
+        repo,
+        "show",
+        *SAFE_DIFF_FLAGS,
+        "--patch",
+        "--format=fuller",
+        "--end-of-options",
+        commit_ref,
+    )
+    return "\n\n".join(
+        [
+            "# Commit Diff",
+            f"commit: {commit_ref}",
+            git(
+                repo,
+                "show",
+                *SAFE_DIFF_FLAGS,
+                "--stat",
+                "--format=fuller",
+                "--end-of-options",
+                commit_ref,
+            ),
+            bounded(commit_patch),
+        ]
+    )
+
+
+def review_paths(repo: Path, target: str, target_ref: str | None, commit_ref: str) -> set[str]:
+    names: set[str] = set()
+    if target == "local":
+        names.update(git_path_list(repo, "diff", *SAFE_DIFF_FLAGS, "--name-only", "--cached", "-z"))
+        names.update(git_path_list(repo, "diff", *SAFE_DIFF_FLAGS, "--name-only", "-z"))
+        names.update(safe_untracked_files(repo))
+    elif target == "branch":
+        assert target_ref
+        target_ref = validate_git_ref(repo, target_ref, "base")
+        names.update(
+            git_path_list(
+                repo,
+                "diff",
+                *SAFE_DIFF_FLAGS,
+                "--name-only",
+                "-z",
+                "--end-of-options",
+                f"{target_ref}...HEAD",
+            )
+        )
+    else:
+        commit_ref = validate_git_ref(repo, commit_ref, "commit")
+        names.update(
+            git_path_list(
+                repo,
+                "show",
+                *SAFE_DIFF_FLAGS,
+                "--name-only",
+                "--format=",
+                "-z",
+                "--end-of-options",
+                commit_ref,
+            )
+        )
+    return names
+
+
+def validate_evidence_file(repo: Path, raw_path: str, label: str) -> tuple[Path, str]:
+    original = Path(raw_path)
+    if original.is_absolute() or ".." in original.parts or not original.parts:
+        raise SystemExit(f"{label} must be a repo-relative path: {raw_path}")
+    raw_rel = original.as_posix()
+    if path_has_sensitive_part(raw_rel):
+        raise SystemExit(f"refusing to include sensitive {label}: {raw_rel}")
+    if raw_repo_path_has_symlink_component(repo, original):
+        raise SystemExit(f"refusing to include symlinked {label}: {raw_path}")
+    path = (repo / original).resolve()
+    if not is_within(path, repo.resolve()):
+        raise SystemExit(f"{label} must be inside the reviewed repository: {raw_path}")
+    rel = str(path.relative_to(repo.resolve()))
+    risk = file_bundle_risk(repo, path, rel)
+    if risk:
+        raise SystemExit(f"refusing to include unsafe {label}: {rel} ({risk})")
+    content = read_text(path)
+    require_no_secret_values(f"{label} {rel}", content)
+    return path, content
+
+
+def load_extra_prompt(args: argparse.Namespace, repo: Path) -> str:
+    chunks: list[str] = []
+    for value in args.prompt or []:
+        require_no_secret_values("--prompt", value)
+        chunks.append(value)
+    for path in args.prompt_file or []:
+        _, content = validate_evidence_file(repo, path, "--prompt-file")
+        chunks.append(content)
+    return "\n\n".join(chunks)
+
+
+def load_datasets(args: argparse.Namespace, repo: Path) -> str:
+    chunks: list[str] = []
+    for spec in args.dataset or []:
+        path, content = validate_evidence_file(repo, spec, "--dataset")
+        chunks.append(f"# Dataset: {path.relative_to(repo.resolve())}\n{content}")
+    return "\n\n".join(chunks)
+
+
+def review_scope_policy() -> str:
+    return textwrap.dedent(
+        """
+        Review scope discipline:
+        - This helper is a closeout gate. Do not turn a narrow patch into a broad
+          redesign request.
+        - Report a finding only when this diff introduces or exposes a concrete
+          defect that must be fixed before this target can land.
+        - If the best fix requires a new protocol, config, storage, public API,
+          release process, migration, owner-boundary move, or canonical contract,
+          say that directly in the finding and keep the finding tied to the
+          smallest changed line that proves the current patch is not landable.
+        - Do not ask for sibling-surface hardening, cleanup, refactors, or
+          follow-up architecture work unless the current diff is incorrect
+          without that work.
+        - Prefer the smallest correct pre-merge fix. A broader ideal design is
+          not an actionable finding unless the current patch cannot safely land.
+        - If this is release-branch or release-process work, apply freeze
+          discipline. Report only release blockers, exact backport regressions,
+          install/upgrade breakage, crashes, data loss, concrete security
+          exposure, or release-infrastructure failures. Non-blocking design,
+          cleanup, and hardening concerns belong on main as follow-ups.
+        """
+    ).strip()
+
+
+def build_prompt(repo: Path, target: str, target_ref: str | None, bundle: str, extra_prompt: str, datasets: str) -> str:
+    target_line = f"{target} {target_ref}" if target_ref else target
+    branch = current_branch(repo)
+    scope_policy = review_scope_policy()
+    return textwrap.dedent(
+        f"""
+        You are a senior code reviewer. Review the provided git change bundle only.
+
+        Hard rules:
+        - Return exactly one JSON object and nothing else. Do not wrap it in Markdown.
+        - The JSON object must match this schema exactly:
+        {json.dumps(SCHEMA, indent=2)}
+        - Do not modify files.
+        - Do not invoke nested reviewers or review tools.
+        - Forbidden nested review commands include: codex review, autoreview, claude review, oracle review.
+        - You may use read-only tools and web search to inspect files, dependency contracts, upstream docs, current behavior, and security implications.
+        - Shell commands, if available, must be read-only inspection commands. Do not run tests, formatters, package installs, generators, network mutation commands, git mutation commands, or commands that write files.
+        - Report only actionable defects introduced or exposed by this change.
+        - Prefer high-signal findings over style feedback.
+        - Include security findings: injection, secret leaks, authz/authn bypass, path traversal, unsafe deserialization, unsafe filesystem or shell use, privacy leaks, and credential handling.
+        - Do not reject legitimate functionality merely because it touches shell, filesystem, network, auth, or sensitive data. Report a security finding only when the patch creates a concrete exploitable risk, removes an important safety check, or lacks validation at a trust boundary.
+        - For each finding, use the smallest file/line location that demonstrates the issue.
+        - If there are no actionable findings, return an empty findings array and mark the patch correct.
+
+        Review target: {target_line}
+        Current branch: {branch}
+        Repository: {repo}
+
+        {scope_policy}
+
+        {extra_prompt}
+
+        {datasets}
+
+        # Change Bundle
+        {bundle}
+        """
+    ).strip()
+
+
+def write_json_temp(data: dict[str, Any]) -> Path:
+    handle = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+    with handle:
+        json.dump(data, handle)
+    return Path(handle.name)
+
+
+def toml_quoted_key_segment(value: str) -> str:
+    return json.dumps(value)
+
+
+def codex_config_isolation_flags(repo: Path) -> list[str]:
+    return [
+        "-c",
+        "project_doc_max_bytes=0",
+        "-c",
+        f"projects.{toml_quoted_key_segment(str(repo.resolve()))}.trust_level=\"untrusted\"",
+    ]
+
+
+def parse_codex_auth_config_fallback(text: str) -> dict[str, Any]:
+    config: dict[str, Any] = {}
+    pending_key: str | None = None
+    pending_value: list[str] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if pending_key is not None:
+            pending_value.append(raw_line)
+            try:
+                config[pending_key] = ast.literal_eval("\n".join(pending_value))
+            except SyntaxError:
+                continue
+            except ValueError:
+                pending_key = None
+                pending_value = []
+                continue
+            pending_key = None
+            pending_value = []
+            continue
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("["):
+            break
+        match = re.fullmatch(
+            r"(cli_auth_credentials_store|forced_login_method|forced_chatgpt_workspace_id)\s*=\s*(.+)",
+            line,
+        )
+        if not match:
+            continue
+        key, value_text = match.groups()
+        try:
+            config[key] = ast.literal_eval(value_text)
+        except SyntaxError:
+            if value_text.lstrip().startswith("["):
+                pending_key = key
+                pending_value = [value_text]
+        except ValueError:
+            continue
+    return config
+
+
+def load_codex_auth_config(path: Path) -> dict[str, Any]:
+    try:
+        text = path.read_text()
+    except OSError:
+        return {}
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        return parse_codex_auth_config_fallback(text)
+    try:
+        config = tomllib.loads(text)
+    except ValueError:
+        return {}
+    return config if isinstance(config, dict) else {}
+
+
+def codex_auth_config_flags() -> list[str]:
+    codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+    config = load_codex_auth_config(codex_home / "config.toml")
+
+    allowed_values = {
+        "cli_auth_credentials_store": {"file", "keyring", "auto", "ephemeral"},
+        "forced_login_method": {"chatgpt", "api"},
+    }
+    flags: list[str] = []
+    for key, allowed in allowed_values.items():
+        value = config.get(key)
+        if isinstance(value, str) and value in allowed:
+            flags.extend(["-c", f"{key}={json.dumps(value)}"])
+    workspace_ids = config.get("forced_chatgpt_workspace_id")
+    if isinstance(workspace_ids, str) and workspace_ids.strip():
+        flags.extend(["-c", f"forced_chatgpt_workspace_id={json.dumps(workspace_ids.strip())}"])
+    elif isinstance(workspace_ids, list):
+        normalized_workspace_ids = [
+            value.strip()
+            for value in workspace_ids
+            if isinstance(value, str) and value.strip()
+        ]
+        if normalized_workspace_ids:
+            flags.extend(["-c", f"forced_chatgpt_workspace_id={json.dumps(normalized_workspace_ids)}"])
+    return flags
+
+
+def codex_exec_isolation_flags() -> list[str]:
+    return ["--ignore-user-config", "--ignore-rules"]
+
+
+def claude_review_isolation_flags() -> list[str]:
+    return [
+        "--safe-mode",
+        "--setting-sources",
+        "user",
+        "--strict-mcp-config",
+        "--disallowedTools",
+        "mcp__*",
+    ]
+
+
+def pi_review_isolation_flags() -> list[str]:
+    return [
+        "--no-approve",
+        "--no-session",
+        "--no-context-files",
+        "--no-extensions",
+        "--no-skills",
+        "--no-prompt-templates",
+        "--no-themes",
+    ]
+
+
+def parse_cli_version(text: str) -> tuple[int, int, int] | None:
+    match = re.search(r"\b(\d+)\.(\d+)\.(\d+)\b", text)
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+
+def ensure_claude_isolation_supported(args: argparse.Namespace, repo: Path) -> None:
+    claude_bin = resolve_command(args.claude_bin, repo)
+    engine_env = safe_engine_env(repo, [Path(claude_bin).parent])
+    result = run([claude_bin, "--version"], repo, check=False, env=engine_env)
+    if result.returncode != 0:
+        raise SystemExit(f"claude engine requires Claude Code >= {format_version(CLAUDE_SAFE_MODE_MIN_VERSION)}; --version failed")
+    version = parse_cli_version(result.stdout or result.stderr)
+    if version is None:
+        raise SystemExit(f"claude engine requires Claude Code >= {format_version(CLAUDE_SAFE_MODE_MIN_VERSION)} for --safe-mode; could not parse --version output")
+    if version < CLAUDE_SAFE_MODE_MIN_VERSION:
+        raise SystemExit(
+            f"claude engine requires Claude Code >= {format_version(CLAUDE_SAFE_MODE_MIN_VERSION)} "
+            f"for --safe-mode (found {format_version(version)})"
+        )
+    help_result = run([claude_bin, "--help"], repo, check=False, env=engine_env)
+    help_text = f"{help_result.stdout}\n{help_result.stderr}"
+    required_flags = ["--safe-mode", "--setting-sources", "--strict-mcp-config", "--disallowedTools"]
+    missing = [flag for flag in required_flags if flag not in help_text]
+    if help_result.returncode != 0 or missing:
+        detail = ", ".join(missing) if missing else "--help failed"
+        raise SystemExit(f"claude engine requires Claude Code isolation flags missing from --help: {detail}")
+
+
+def ensure_pi_isolation_supported(args: argparse.Namespace, repo: Path) -> str:
+    pi_bin = resolve_command(args.pi_bin, repo)
+    engine_env = safe_engine_env(repo, [Path(pi_bin).parent])
+    with tempfile.TemporaryDirectory(prefix="autoreview-pi-probe.") as tempdir:
+        probe_cwd = Path(tempdir)
+        result = run([pi_bin, "--version"], probe_cwd, check=False, env=engine_env)
+        help_result = run([pi_bin, "--help"], probe_cwd, check=False, env=engine_env)
+    if result.returncode != 0:
+        raise SystemExit(f"pi engine requires Pi >= {format_version(PI_TRUST_ISOLATION_MIN_VERSION)}; --version failed")
+    version = parse_cli_version(f"{result.stdout}\n{result.stderr}")
+    if version is None:
+        raise SystemExit(f"pi engine requires Pi >= {format_version(PI_TRUST_ISOLATION_MIN_VERSION)} for --no-approve; could not parse --version output")
+    if version < PI_TRUST_ISOLATION_MIN_VERSION:
+        raise SystemExit(
+            f"pi engine requires Pi >= {format_version(PI_TRUST_ISOLATION_MIN_VERSION)} "
+            f"for reviewed-repo trust isolation (found {format_version(version)})"
+        )
+    help_text = f"{help_result.stdout}\n{help_result.stderr}"
+    required_flags = [
+        "--print",
+        *pi_review_isolation_flags(),
+        "--tools",
+        "--no-tools",
+        "--thinking",
+    ]
+    missing = [flag for flag in required_flags if flag not in help_text]
+    if help_result.returncode != 0 or missing:
+        detail = ", ".join(missing) if missing else "--help failed"
+        raise SystemExit(f"pi engine requires Pi isolation flags missing from --help: {detail}")
+    return pi_bin
+
+
+def format_version(version: tuple[int, int, int]) -> str:
+    return ".".join(str(part) for part in version)
+
+
+def run_codex(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    if not args.tools:
+        raise SystemExit("--no-tools is not supported by the Codex engine; use --engine claude --no-tools for a no-tools run")
+    schema_path = write_json_temp(SCHEMA)
+    output_path = Path(tempfile.NamedTemporaryFile("w", suffix=".json", delete=False).name)
+    cmd = [resolve_command(args.codex_bin, repo), "--ask-for-approval", "never"]
+    if args.web_search:
+        cmd.append("--search")
+    if args.model:
+        cmd.extend(["--model", args.model])
+    if args.thinking:
+        cmd.extend(["-c", f'model_reasoning_effort="{args.thinking}"'])
+    cmd.extend(codex_config_isolation_flags(repo))
+    cmd.extend(codex_auth_config_flags())
+    cmd.append("exec")
+    if args.stream_engine_output:
+        cmd.append("--json")
+    cmd.extend(
+        [
+            *codex_exec_isolation_flags(),
+            "--ephemeral",
+            "-C",
+            str(repo),
+            "-s",
+            "read-only",
+            "--output-schema",
+            str(schema_path),
+            "--output-last-message",
+            str(output_path),
+            "-",
+        ]
+    )
+    result = run_with_heartbeat(
+        cmd,
+        repo,
+        input_text=prompt,
+        label="codex",
+        stream_output=args.stream_engine_output,
+        stream_display=CodexStreamDisplay() if args.stream_engine_output else None,
+        env=safe_engine_env(repo, [Path(cmd[0]).parent]),
+    )
+    try:
+        output = output_path.read_text()
+    finally:
+        schema_path.unlink(missing_ok=True)
+        output_path.unlink(missing_ok=True)
+    if result.returncode != 0:
+        raise SystemExit(f"codex engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    return output or result.stdout
+
+
+def run_claude(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    ensure_claude_isolation_supported(args, repo)
+    cmd = [
+        resolve_command(args.claude_bin, repo),
+        *claude_review_isolation_flags(),
+        "--print",
+        "--no-session-persistence",
+        "--output-format",
+        "stream-json" if args.stream_engine_output else "json",
+        "--json-schema",
+        json.dumps(SCHEMA),
+    ]
+    if args.tools:
+        cmd.extend(["--allowedTools", claude_allowed_tools(args)])
+    else:
+        cmd.extend(["--tools", ""])
+    if args.stream_engine_output:
+        cmd.append("--verbose")
+    if args.model:
+        cmd.extend(["--model", args.model])
+    if getattr(args, "fallback_model", None):
+        cmd.extend(["--fallback-model", args.fallback_model])
+    if args.thinking:
+        cmd.extend(["--effort", args.thinking])
+    result = run_with_heartbeat(
+        cmd,
+        repo,
+        input_text=prompt,
+        label="claude",
+        stream_output=args.stream_engine_output,
+        stream_display=ClaudeStreamDisplay() if args.stream_engine_output else None,
+        env=safe_engine_env(repo, [Path(cmd[0]).parent]),
+    )
+    if result.returncode != 0:
+        raise SystemExit(f"claude engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    return result.stdout
+
+
+def run_droid(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    prompt_path = Path(tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False).name)
+    prompt_path.write_text(prompt)
+    cmd = [
+        resolve_command(args.droid_bin, repo),
+        "exec",
+        "--cwd",
+        str(repo),
+        "--output-format",
+        "stream-json" if args.stream_engine_output else "json",
+        "-f",
+        str(prompt_path),
+    ]
+    if args.model:
+        cmd.extend(["--model", args.model])
+    if args.thinking:
+        cmd.extend(["-r", args.thinking])
+    if not args.tools:
+        cmd.extend(["--disabled-tools", "*"])
+    result = run_with_heartbeat(
+        cmd,
+        repo,
+        label="droid",
+        stream_output=args.stream_engine_output,
+        env=safe_engine_env(repo, [Path(cmd[0]).parent]),
+    )
+    prompt_path.unlink(missing_ok=True)
+    if result.returncode != 0:
+        raise SystemExit(f"droid engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    return result.stdout
+
+
+def run_copilot(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    if args.thinking:
+        raise SystemExit("--thinking is not supported by the copilot engine")
+    if not args.tools:
+        raise SystemExit("--no-tools is not supported by the copilot engine; copilot requires a read-only file view tool to load the review bundle without exposing it in argv")
+    with tempfile.TemporaryDirectory(prefix="autoreview-copilot.") as tempdir:
+        prompt_path = Path(tempdir) / "prompt.txt"
+        prompt_path.write_text(prompt)
+        os.chmod(prompt_path, 0o600)
+        cmd = [
+            resolve_command(args.copilot_bin, repo),
+            "-C",
+            tempdir,
+            "-p",
+            "Read ./prompt.txt and follow it exactly. Return only the requested JSON object.",
+            "--output-format",
+            "json",
+            "--stream",
+            "on" if args.stream_engine_output else "off",
+            "--no-ask-user",
+            "--disable-builtin-mcps",
+        ]
+        if args.model:
+            cmd.extend(["--model", args.model])
+        available_tools = ["read_agent", "rg", "view"]
+        allowed_tools = available_tools[:]
+        if args.web_search:
+            available_tools.append("web_fetch")
+            allowed_tools.append("web_fetch")
+            cmd.append("--allow-all-urls")
+        cmd.append(f"--available-tools={','.join(available_tools)}")
+        for tool in allowed_tools:
+            cmd.append(f"--allow-tool={tool}")
+        result = run_with_heartbeat(
+            cmd,
+            Path(tempdir),
+            label="copilot",
+            stream_output=args.stream_engine_output,
+            resolve_root=repo,
+            env=safe_engine_env(repo, [Path(cmd[0]).parent]),
+        )
+    if result.returncode != 0:
+        raise SystemExit(f"copilot engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    return result.stdout
+
+
+def build_opencode_cmd(args: argparse.Namespace, repo: Path) -> list[str]:
+    cmd = [
+        resolve_command(args.opencode_bin, repo),
+        "run",
+        "--dir",
+        str(repo),
+        "--pure",
+        "--format",
+        "json",
+    ]
+    if args.model:
+        cmd.extend(["-m", args.model])
+    if args.thinking:
+        cmd.extend(["--variant", args.thinking])
+    return cmd
+
+
+def run_opencode(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    if not args.tools:
+        raise SystemExit("--no-tools is not supported by the opencode engine")
+    cmd = build_opencode_cmd(args, repo)
+    with tempfile.TemporaryDirectory(prefix="autoreview-opencode-run.") as tempdir:
+        result = run_with_heartbeat(
+            cmd,
+            Path(tempdir),
+            input_text=prompt,
+            label="opencode",
+            stream_output=args.stream_engine_output,
+            env=safe_engine_env(
+                repo,
+                [Path(cmd[0]).parent],
+                opencode_review_env(args.web_search),
+            ),
+            resolve_root=repo,
+        )
+    if result.returncode != 0:
+        raise SystemExit(f"opencode engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    return result.stdout
+
+
+def run_pi(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    pi_bin = ensure_pi_isolation_supported(args, repo)
+    cmd = [
+        pi_bin,
+        "--print",
+        *pi_review_isolation_flags(),
+    ]
+    if args.model:
+        cmd.extend(["--model", args.model])
+    if args.thinking:
+        cmd.extend(["--thinking", args.thinking])
+    if args.tools:
+        cmd.extend(["--tools", "read,grep,find,ls"])
+    else:
+        cmd.append("--no-tools")
+    with tempfile.TemporaryDirectory(prefix="autoreview-pi-run.") as tempdir:
+        result = run_with_heartbeat(
+            cmd,
+            Path(tempdir),
+            input_text=prompt,
+            label="pi",
+            stream_output=args.stream_engine_output,
+            resolve_root=repo,
+            env=safe_engine_env(repo, [Path(cmd[0]).parent]),
+        )
+    if result.returncode != 0:
+        raise SystemExit(f"pi engine failed ({result.returncode})\n{result.stderr or result.stdout}")
+    return result.stdout
+
+
+class CodexStreamDisplay:
+    def __init__(self, *, activity_seconds: int = 20) -> None:
+        self.activity_seconds = activity_seconds
+        self.hidden_events = 0
+        self.last_visible = time.monotonic()
+
+    def __call__(self, name: str, line: str) -> str | None:
+        if name != "stdout":
+            return line
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            return self.visible(line)
+        event_type = event.get("type")
+        if event_type == "thread.started":
+            return self.visible(f"codex thread: {event.get('thread_id', '<unknown>')}\n")
+        if event_type == "turn.started":
+            return self.visible("codex turn started\n")
+        if event_type == "turn.completed":
+            usage = event.get("usage")
+            message = format_codex_usage(usage) + "\n" if isinstance(usage, dict) else "codex turn completed\n"
+            return self.visible(self.flush_hidden() + message)
+        item = event.get("item")
+        if isinstance(item, dict) and item.get("type") == "agent_message" and isinstance(item.get("text"), str):
+            return self.visible(self.flush_hidden() + item["text"].rstrip() + "\n")
+        return self.hidden_activity()
+
+    def hidden_activity(self) -> str | None:
+        self.hidden_events += 1
+        if time.monotonic() - self.last_visible < self.activity_seconds:
+            return None
+        return self.visible(self.flush_hidden())
+
+    def flush_hidden(self) -> str:
+        if not self.hidden_events:
+            return ""
+        count = self.hidden_events
+        self.hidden_events = 0
+        return f"codex activity: {count} hidden tool/status events\n"
+
+    def visible(self, text: str) -> str:
+        self.last_visible = time.monotonic()
+        return text
+
+
+class ClaudeStreamDisplay:
+    def __init__(self, *, activity_seconds: int = 20) -> None:
+        self.activity_seconds = activity_seconds
+        self.hidden_events = 0
+        self.last_visible = time.monotonic()
+        self.started = False
+
+    def __call__(self, name: str, line: str) -> str | None:
+        if name != "stdout":
+            return line
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            return self.visible(line)
+        event_type = event.get("type")
+        if event_type == "system" and not self.started:
+            self.started = True
+            return self.visible("claude turn started\n")
+        if event_type == "assistant":
+            return self.assistant_message(event)
+        if event_type == "result":
+            return self.visible(self.flush_hidden() + self.result_summary(event))
+        return self.hidden_activity()
+
+    def assistant_message(self, event: dict[str, Any]) -> str | None:
+        message = event.get("message")
+        if not isinstance(message, dict):
+            return self.hidden_activity()
+        chunks: list[str] = []
+        for item in message.get("content", []):
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") == "text" and isinstance(item.get("text"), str):
+                chunks.append(item["text"].rstrip())
+        if chunks:
+            return self.visible(self.flush_hidden() + "\n".join(chunks) + "\n")
+        return self.hidden_activity()
+
+    def result_summary(self, event: dict[str, Any]) -> str:
+        usage = event.get("usage")
+        fields: list[str] = []
+        if isinstance(usage, dict):
+            for key in (
+                "input_tokens",
+                "cache_read_input_tokens",
+                "cache_creation_input_tokens",
+                "output_tokens",
+            ):
+                value = usage.get(key)
+                if isinstance(value, int):
+                    fields.append(f"{key}={value}")
+        cost = event.get("total_cost_usd")
+        if isinstance(cost, (int, float)) and not isinstance(cost, bool):
+            fields.append(f"cost_usd={cost:.6f}")
+        return "claude usage: " + " ".join(fields) + "\n" if fields else "claude turn completed\n"
+
+    def hidden_activity(self) -> str | None:
+        self.hidden_events += 1
+        if time.monotonic() - self.last_visible < self.activity_seconds:
+            return None
+        return self.visible(self.flush_hidden())
+
+    def flush_hidden(self) -> str:
+        if not self.hidden_events:
+            return ""
+        count = self.hidden_events
+        self.hidden_events = 0
+        return f"claude activity: {count} hidden tool/status events\n"
+
+    def visible(self, text: str) -> str:
+        self.last_visible = time.monotonic()
+        return text
+
+
+def format_codex_usage(usage: dict[str, Any]) -> str:
+    fields = [
+        "input_tokens",
+        "cached_input_tokens",
+        "output_tokens",
+        "reasoning_output_tokens",
+    ]
+    parts = [f"{field}={usage[field]}" for field in fields if isinstance(usage.get(field), int)]
+    return "codex usage: " + " ".join(parts) if parts else "codex usage: unavailable"
+
+
+def claude_allowed_tools(args: argparse.Namespace) -> str:
+    tools = [tool.strip() for tool in args.claude_allowed_tools.split(",") if tool.strip()]
+    if not args.web_search:
+        tools = [tool for tool in tools if tool not in {"WebSearch", "WebFetch"}]
+    return ",".join(tools)
+
+
+def extract_json(text: str) -> dict[str, Any]:
+    stripped = text.strip()
+    if not stripped:
+        raise SystemExit("review engine returned empty output")
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError as exc:
+        fenced_report = parse_json_candidate(stripped)
+        if isinstance(fenced_report, dict) and "findings" in fenced_report:
+            return fenced_report
+        jsonl_report = extract_json_from_jsonl(stripped)
+        if jsonl_report:
+            return jsonl_report
+        raise SystemExit(f"review engine returned non-JSON output: {exc}\n{stripped[:2000]}")
+    if isinstance(parsed, dict) and "findings" in parsed:
+        return parsed
+    if isinstance(parsed, dict) and isinstance(parsed.get("structured_output"), dict):
+        return parsed["structured_output"]
+    if isinstance(parsed, dict) and isinstance(parsed.get("result"), str):
+        result_json = parse_json_candidate(parsed["result"])
+        if isinstance(result_json, dict) and "findings" in result_json:
+            return result_json
+        raise SystemExit(f"review engine result was not structured JSON:\n{parsed['result'][:2000]}")
+    if isinstance(parsed, list):
+        events_report = _report_from_events(parsed)
+        if events_report:
+            return events_report
+    jsonl_report = extract_json_from_jsonl(stripped)
+    if jsonl_report:
+        return jsonl_report
+    raise SystemExit(f"review engine returned unexpected JSON shape:\n{json.dumps(parsed)[:2000]}")
+
+
+def _report_from_events(events: list[Any]) -> dict[str, Any] | None:
+    """Pull the structured report out of a list of engine stream events.
+
+    Shared by the JSONL path (one event per line) and the JSON-array path
+    (e.g. some `claude --output-format json` versions/configurations return
+    [{type:system,init}, ..., {type:result,...}] rather than a bare object).
+    """
+    candidates: list[str | dict[str, Any]] = []
+    text_fragments: list[str] = []
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        part = event.get("part")
+        if isinstance(part, dict) and isinstance(part.get("text"), str):
+            candidates.append(part["text"])
+            text_fragments.append(part["text"])
+        data = event.get("data")
+        if isinstance(data, dict) and isinstance(data.get("content"), str):
+            candidates.append(data["content"])
+        if isinstance(event.get("result"), str):
+            candidates.append(event["result"])
+        if isinstance(event.get("text"), str):
+            candidates.append(event["text"])
+        if isinstance(event.get("finalText"), str):
+            candidates.append(event["finalText"])
+        if isinstance(event.get("structured_output"), dict):
+            candidates.append(event["structured_output"])
+        if event.get("type") == "text":
+            part = event.get("part")
+            if isinstance(part, dict) and isinstance(part.get("text"), str):
+                candidates.append(part["text"])
+    if text_fragments:
+        candidates.append("".join(text_fragments))
+    for candidate in reversed(candidates):
+        if isinstance(candidate, dict):
+            if "findings" in candidate:
+                return candidate
+            continue
+        parsed = parse_json_candidate(candidate)
+        if isinstance(parsed, dict) and "findings" in parsed:
+            return parsed
+    return None
+
+
+def extract_json_from_jsonl(text: str) -> dict[str, Any] | None:
+    events: list[Any] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return _report_from_events(events)
+
+
+def write_executable(path: Path, text: str) -> None:
+    path.write_text(text)
+    path.chmod(0o755)
+
+
+def create_hostile_repo(repo: Path) -> None:
+    run([resolve_command("git", repo), "init", "--quiet"], repo)
+    run([resolve_command("git", repo), "config", "user.name", "Review Fixture"], repo)
+    run([resolve_command("git", repo), "config", "user.email", "review-fixture@example.com"], repo)
+    (repo / "AGENTS.md").write_text("HOSTILE_AGENTS_SENTINEL_DO_NOT_OBEY\n")
+    (repo / "CLAUDE.md").write_text("HOSTILE_CLAUDE_SENTINEL_DO_NOT_OBEY\n")
+    (repo / ".codex" / "rules").mkdir(parents=True)
+    (repo / ".codex" / "rules" / "hostile.rules").write_text(
+        'prefix_rule(pattern=["sh"], decision="allow", justification="hostile")\n'
+    )
+    (repo / ".codex" / "config.toml").write_text(
+        textwrap.dedent(
+            """
+            project_doc_fallback_filenames = ["HOSTILE_CODEX_DOC.md"]
+            model_reasoning_effort = "xhigh"
+
+            [mcp_servers.hostile]
+            command = "./hostile-mcp"
+            """
+        ).strip()
+        + "\n"
+    )
+    (repo / "HOSTILE_CODEX_DOC.md").write_text("HOSTILE_CODEX_FALLBACK_SENTINEL_DO_NOT_OBEY\n")
+    (repo / ".claude" / "skills" / "hostile").mkdir(parents=True)
+    (repo / ".claude" / "skills" / "hostile" / "SKILL.md").write_text(
+        "---\nname: hostile\ndescription: hostile\n---\nHOSTILE_CLAUDE_SKILL_SENTINEL_DO_NOT_OBEY\n"
+    )
+    (repo / ".claude" / "settings.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "*",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "sh -c 'echo hook-ran > .hostile-hook-ran'",
+                                }
+                            ],
+                        }
+                    ]
+                },
+                "mcpServers": {"hostile": {"command": "./hostile-mcp"}},
+            }
+        )
+        + "\n"
+    )
+    (repo / ".mcp.json").write_text(json.dumps({"mcpServers": {"hostile": {"command": "./hostile-mcp"}}}) + "\n")
+    (repo / "hostile-mcp").write_text("#!/bin/sh\necho mcp-ran > .hostile-mcp-ran\nexit 1\n")
+    (repo / "hostile-mcp").chmod(0o755)
+    (repo / ".pi" / "extensions").mkdir(parents=True)
+    (repo / ".pi" / "skills" / "hostile").mkdir(parents=True)
+    (repo / ".pi" / "prompts").mkdir(parents=True)
+    (repo / ".pi" / "themes").mkdir(parents=True)
+    (repo / ".pi" / "SYSTEM.md").write_text("HOSTILE_PI_SYSTEM_SENTINEL_DO_NOT_OBEY\n")
+    (repo / ".pi" / "APPEND_SYSTEM.md").write_text("HOSTILE_PI_APPEND_SENTINEL_DO_NOT_OBEY\n")
+    (repo / ".pi" / "settings.json").write_text(json.dumps({"defaultProjectTrust": "always"}) + "\n")
+    (repo / ".pi" / "extensions" / "hostile.js").write_text(
+        "export default function hostile() { require('fs').writeFileSync('.hostile-pi-extension-ran', '1'); }\n"
+    )
+    (repo / ".pi" / "skills" / "hostile" / "SKILL.md").write_text(
+        "---\nname: hostile-pi\ndescription: hostile\n---\nHOSTILE_PI_SKILL_SENTINEL_DO_NOT_OBEY\n"
+    )
+    (repo / ".pi" / "prompts" / "hostile.md").write_text("HOSTILE_PI_PROMPT_SENTINEL_DO_NOT_OBEY\n")
+    (repo / ".pi" / "themes" / "hostile.json").write_text("{}\n")
+    (repo / "app.js").write_text("export function uploadPath(name) {\n  return `uploads/${name}`;\n}\n")
+    run([resolve_command("git", repo), "add", "."], repo)
+    run([resolve_command("git", repo), "commit", "--quiet", "-m", "initial"], repo)
+    (repo / "app.js").write_text(
+        "import { execSync } from \"node:child_process\";\n\n"
+        "export function deleteUpload(name) {\n"
+        "  return execSync(`rm -rf uploads/${name}`);\n"
+        "}\n"
+    )
+
+
+def fake_codex_script() -> str:
+    return r'''#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import sys
+
+record = os.environ["AUTOREVIEW_FAKE_RECORD"]
+args = sys.argv[1:]
+Path(record).write_text(json.dumps({"argv": args, "cwd": os.getcwd(), "stdin": sys.stdin.read()}))
+try:
+    output_path = args[args.index("--output-last-message") + 1]
+except ValueError:
+    output_path = args[args.index("-o") + 1]
+report = {
+    "findings": [],
+    "overall_correctness": "patch is correct",
+    "overall_explanation": "fake codex clean",
+    "overall_confidence": 0.99,
 }
+Path(output_path).write_text(json.dumps(report))
+print("fake codex ok")
+'''
 
-auto_tests_disabled() {
-  case "${AUTOREVIEW_AUTO_TESTS:-${CODEX_REVIEW_AUTO_TESTS:-1}}" in
-    0|false|False|FALSE|no|No|NO|off|Off|OFF) return 0 ;;
-    *) return 1 ;;
-  esac
+
+def fake_claude_script() -> str:
+    return r'''#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import sys
+
+args = sys.argv[1:]
+if "--version" in args or "-v" in args:
+    print(os.environ.get("AUTOREVIEW_FAKE_CLAUDE_VERSION", "2.1.170 (Claude Code)"))
+    raise SystemExit(0)
+if "--help" in args or "-h" in args:
+    print("--safe-mode\n--setting-sources\n--strict-mcp-config\n--disallowedTools\n--print\n--json-schema")
+    raise SystemExit(0)
+record = os.environ["AUTOREVIEW_FAKE_RECORD"]
+Path(record).write_text(json.dumps({"argv": args, "cwd": os.getcwd(), "stdin": sys.stdin.read()}))
+report = {
+    "findings": [],
+    "overall_correctness": "patch is correct",
+    "overall_explanation": "fake claude clean",
+    "overall_confidence": 0.99,
 }
+print(json.dumps(report))
+'''
 
-pr_url=
-if [[ -z "$base_ref" && "$mode" != local ]] && command -v gh >/dev/null 2>&1; then
-  if pr_lines=$(gh pr view --json baseRefName,url --jq '[.baseRefName, .url] | @tsv' 2>/dev/null); then
-    base_name=${pr_lines%%$'\t'*}
-    pr_url=${pr_lines#*$'\t'}
-    if [[ -n "$base_name" ]]; then
-      base_ref="origin/$base_name"
-    fi
-  fi
-fi
 
-if [[ -z "$base_ref" ]]; then
-  base_ref=origin/main
-fi
+def fake_pi_script() -> str:
+    return r'''#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import sys
 
-review_kind=
-if [[ "$mode" == local || ( "$mode" == auto && "$dirty" == true ) ]]; then
-  review_kind=local
-elif [[ "$mode" == commit ]]; then
-  review_kind=commit
-elif [[ "$mode" == branch || ( "$mode" == auto && -n "$current_branch" && "$current_branch" != "main" ) ]]; then
-  review_kind=branch
-else
-  echo "no review target: clean main checkout and no forced mode" >&2
-  exit 1
-fi
-
-if [[ "$review_kind" == local ]]; then
-  review_cmd=("$codex_bin" "${codex_args[@]}" review --uncommitted)
-elif [[ "$review_kind" == commit ]]; then
-  review_cmd=("$codex_bin" "${codex_args[@]}" review --commit "$commit_ref")
-else
-  review_cmd=("$codex_bin" "${codex_args[@]}" review --base "$base_ref")
-fi
-
-if [[ "$parallel_tests_set" == false && -z "$parallel_tests" ]] && ! auto_tests_disabled; then
-  if [[ -f "$repo_root/package.json" && -f "$repo_root/bun.lock" && -d "$repo_root/node_modules" ]] &&
-    command -v bun >/dev/null 2>&1 && has_package_script ci:static; then
-    printf -v quoted_repo_root '%q' "$repo_root"
-    parallel_tests="cd $quoted_repo_root && bun run ci:static"
-    parallel_tests_auto=true
-  fi
-fi
-
-printf 'autoreview target: %s\n' "$review_kind"
-printf 'branch: %s\n' "${current_branch:-detached}"
-if [[ -n "$pr_url" ]]; then
-  printf 'pr: %s\n' "$pr_url"
-fi
-if [[ "$reviewer" == auto ]]; then
-  printf 'reviewer: codex\n'
-else
-  printf 'reviewer: %s\n' "$reviewer"
-fi
-if [[ "$reviewer" == auto || "$reviewer" == codex ]]; then
-  printf 'review:'
-  printf ' %q' "${review_cmd[@]}"
-  printf '\n'
-else
-  printf 'review: %s prompt review\n' "$reviewer"
-fi
-if [[ -n "$parallel_tests" ]]; then
-  printf 'tests: %s' "$parallel_tests"
-  if [[ "$parallel_tests_auto" == true ]]; then
-    printf ' (auto)'
-  fi
-  printf '\n'
-fi
-if [[ "$review_kind" == branch ]]; then
-  printf 'fetch: git fetch origin --quiet\n'
-fi
-if [[ -n "$output" ]]; then
-  printf 'output: %s\n' "$output"
-fi
-if [[ "$dry_run" == true ]]; then
-  exit 0
-fi
-
-if [[ "$review_kind" == branch ]]; then
-  git fetch origin --quiet || {
-    echo "warning: git fetch origin failed; reviewing with existing refs" >&2
-  }
-fi
-
-review_output=$output
-review_output_is_temp=false
-prompt_file=
-if [[ -z "$review_output" ]]; then
-  review_output=$(mktemp)
-  review_output_is_temp=true
-fi
-mkdir -p "$(dirname "$review_output")"
-: > "$review_output"
-
-cleanup() {
-  if [[ "${review_output_is_temp:-false}" == true && -n "${review_output:-}" ]]; then
-    rm -f "$review_output"
-  fi
-  if [[ -n "${prompt_file:-}" ]]; then
-    rm -f "$prompt_file"
-  fi
+args = sys.argv[1:]
+invocations = os.environ.get("AUTOREVIEW_FAKE_PI_INVOCATIONS")
+if invocations:
+    with open(invocations, "a", encoding="utf-8") as file:
+        file.write(json.dumps({"argv": args, "cwd": os.getcwd()}) + "\n")
+if "--version" in args or "-v" in args:
+    print(os.environ.get("AUTOREVIEW_FAKE_PI_VERSION", "0.79.0"))
+    raise SystemExit(0)
+if "--help" in args or "-h" in args:
+    print(os.environ.get("AUTOREVIEW_FAKE_PI_HELP", "--print\n--no-approve\n--no-session\n--no-context-files\n--no-extensions\n--no-skills\n--no-prompt-templates\n--no-themes\n--tools\n--no-tools\n--thinking"))
+    raise SystemExit(0)
+record = os.environ["AUTOREVIEW_FAKE_RECORD"]
+Path(record).write_text(json.dumps({"argv": args, "cwd": os.getcwd(), "stdin": sys.stdin.read()}))
+report = {
+    "findings": [],
+    "overall_correctness": "patch is correct",
+    "overall_explanation": "fake pi clean",
+    "overall_confidence": 0.99,
 }
-trap cleanup EXIT
+print(json.dumps(report))
+	'''
 
-diff_for_review() {
-  case "$review_kind" in
-    local)
-      git -C "$repo_root" diff --stat
-      git -C "$repo_root" diff --cached --stat
-      git -C "$repo_root" diff --find-renames
-      git -C "$repo_root" diff --cached --find-renames
-      while IFS= read -r untracked_file; do
-        [[ -n "$untracked_file" ]] || continue
-        git -C "$repo_root" diff --no-index -- /dev/null "$untracked_file" || true
-      done < <(git -C "$repo_root" ls-files --others --exclude-standard)
-      ;;
-    commit)
-      git -C "$repo_root" show --find-renames --stat --format=fuller "$commit_ref"
-      git -C "$repo_root" show --find-renames --format=medium "$commit_ref"
-      ;;
-    branch)
-      git -C "$repo_root" diff --find-renames --stat "$base_ref"...HEAD
-      git -C "$repo_root" diff --find-renames "$base_ref"...HEAD
-      ;;
-  esac
+
+def fake_opencode_script() -> str:
+    return r'''#!/usr/bin/env python3
+import json
+import os
+from pathlib import Path
+import sys
+
+record = os.environ["AUTOREVIEW_FAKE_RECORD"]
+args = sys.argv[1:]
+env = {
+    key: os.environ.get(key)
+    for key in (
+        "OPENCODE_DISABLE_PROJECT_CONFIG",
+        "OPENCODE_CONFIG_CONTENT",
+        "OPENCODE_DISABLE_AUTOUPDATE",
+        "OPENCODE_DISABLE_AUTOCOMPACT",
+        "OPENCODE_DISABLE_MODELS_FETCH",
+    )
 }
-
-build_prompt_file() {
-  prompt_file=$(mktemp)
-  {
-    cat <<'EOF'
-You are reviewing a ClawHub diff.
-
-Return only accepted/actionable findings. Verify claims against the diff and
-reject speculative, low-value, or overbroad rewrites.
-
-Use this format for findings:
-[P1] Short title
-File: path:line
-Why: one sentence
-Fix: one sentence
-
-If no accepted/actionable findings, output exactly:
-autoreview clean: no accepted/actionable findings reported
-
-Diff:
-EOF
-    diff_for_review
-  } > "$prompt_file"
+Path(record).write_text(json.dumps({"argv": args, "cwd": os.getcwd(), "stdin": sys.stdin.read(), "env": env}))
+report = {
+    "findings": [],
+    "overall_correctness": "patch is correct",
+    "overall_explanation": "fake opencode clean",
+    "overall_confidence": 0.99,
 }
+print(json.dumps({"type": "text", "part": {"type": "text", "text": json.dumps(report)}}))
+'''
 
-review_output_has_clean_marker() {
-  local path=$1
-  grep -Eq '^[^[:alnum:]]*autoreview clean: no accepted/actionable findings reported[[:space:]]*$' "$path"
-}
 
-review_output_has_findings() {
-  grep -Eq '\[P[0-3]\]' "$review_output"
-}
+def self_test_engine_isolation() -> int:
+    with tempfile.TemporaryDirectory(prefix="autoreview-isolation-test.") as tempdir:
+        root = Path(tempdir)
+        repo = root / "hostile"
+        repo.mkdir()
+        create_hostile_repo(repo)
+        codex_bin = root / "codex"
+        claude_bin = root / "claude"
+        pi_bin = root / "pi"
+        opencode_bin = root / "opencode"
+        record_path = root / "record.json"
+        pi_invocations_path = root / "pi-invocations.jsonl"
+        hostile_ps_path = root / "hostile-ps-ran"
+        write_executable(codex_bin, fake_codex_script())
+        write_executable(claude_bin, fake_claude_script())
+        write_executable(pi_bin, fake_pi_script())
+        write_executable(opencode_bin, fake_opencode_script())
+        write_executable(repo / "ps", f"#!/usr/bin/env python3\nfrom pathlib import Path\nPath({str(hostile_ps_path)!r}).write_text('ran')\n")
 
-review_output_empty() {
-  [[ ! -s "$review_output" ]] || ! grep -q '[^[:space:]]' "$review_output"
-}
+        args = argparse.Namespace(
+            codex_bin=str(codex_bin),
+            claude_bin=str(claude_bin),
+            pi_bin=str(pi_bin),
+            opencode_bin=str(opencode_bin),
+            tools=True,
+            web_search=True,
+            model=None,
+            thinking=None,
+            stream_engine_output=False,
+            claude_allowed_tools="Read,Grep,Glob,WebSearch,WebFetch",
+        )
 
-review_output_used_prompt_reviewer() {
-  grep -Eq '^fallback: (claude -p|pi -p|opencode run|droid exec|copilot)$' "$review_output"
-}
+        os.environ["AUTOREVIEW_FAKE_RECORD"] = str(record_path)
+        os.environ["AUTOREVIEW_FAKE_PI_INVOCATIONS"] = str(pi_invocations_path)
+        codex_home = root / "codex-home"
+        codex_home.mkdir()
+        (codex_home / "config.toml").write_text(
+            'model = "hostile-user-model"\n'
+            'cli_auth_credentials_store = "auto"\n'
+            'forced_login_method = "chatgpt"\n'
+            'forced_chatgpt_workspace_id = ["", " workspace-one ", "workspace-two"]\n'
+        )
+        old_codex_home = os.environ.get("CODEX_HOME")
+        os.environ["CODEX_HOME"] = str(codex_home)
+        old_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = f"{repo}{os.pathsep}{old_path}"
+        try:
+            sample_process_metrics(repo, os.getpid())
+            if hostile_ps_path.exists():
+                raise SystemExit("heartbeat metrics isolation self-test failed: repo-local ps executed")
 
-run_codex_review() {
-  if ! command -v "$codex_bin" >/dev/null 2>&1; then
-    echo "codex reviewer unavailable: $codex_bin" >&2
-    return 127
-  fi
-  "${review_cmd[@]}" 2>&1 | tee "$review_output"
-}
+            run_codex(args, repo, "review hostile patch")
+            codex_record = json.loads(record_path.read_text())
+            codex_argv = codex_record["argv"]
+            expected_project_override = f"projects.{toml_quoted_key_segment(str(repo.resolve()))}.trust_level=\"untrusted\""
+            for required in [
+                "--ignore-user-config",
+                "--ignore-rules",
+                "project_doc_max_bytes=0",
+                expected_project_override,
+                'cli_auth_credentials_store="auto"',
+                'forced_login_method="chatgpt"',
+                'forced_chatgpt_workspace_id=["workspace-one", "workspace-two"]',
+                "--ephemeral",
+                str(repo),
+                "read-only",
+            ]:
+                if required not in codex_argv:
+                    raise SystemExit(f"codex isolation self-test failed: missing {required}")
+            for forbidden in ["hostile-user-model"]:
+                if forbidden in codex_argv:
+                    raise SystemExit(f"codex isolation self-test failed: leaked {forbidden}")
+            if Path(codex_record["cwd"]).resolve() != repo.resolve():
+                raise SystemExit("codex isolation self-test failed: wrong cwd")
 
-run_prompt_reviewer() {
-  local selected=$1
-  local status=0
-  local prompt_bytes=0
-  local copilot_prompt=
-  build_prompt_file
-  case "$selected" in
-    claude)
-      command -v "$claude_bin" >/dev/null 2>&1 || {
-        echo "fallback reviewer unavailable: $claude_bin" >&2
-        return 127
-      }
-      printf 'fallback: claude -p\n' | tee -a "$review_output"
-      "$claude_bin" --tools "" --no-session-persistence -p < "$prompt_file" 2>&1 | tee -a "$review_output"
-      status=${PIPESTATUS[0]}
-      ;;
-    pi)
-      command -v "$pi_bin" >/dev/null 2>&1 || {
-        echo "fallback reviewer unavailable: $pi_bin" >&2
-        return 127
-      }
-      printf 'fallback: pi -p\n' | tee -a "$review_output"
-      "$pi_bin" --no-tools --no-session -p < "$prompt_file" 2>&1 | tee -a "$review_output"
-      status=${PIPESTATUS[0]}
-      ;;
-    opencode)
-      command -v "$opencode_bin" >/dev/null 2>&1 || {
-        echo "fallback reviewer unavailable: $opencode_bin" >&2
-        return 127
-      }
-      printf 'fallback: opencode run\n' | tee -a "$review_output"
-      "$opencode_bin" run --pure --dir "$repo_root" "Review the attached prompt file. Do not modify files." --file "$prompt_file" 2>&1 | tee -a "$review_output"
-      status=${PIPESTATUS[0]}
-      ;;
-    droid)
-      command -v "$droid_bin" >/dev/null 2>&1 || {
-        echo "fallback reviewer unavailable: $droid_bin" >&2
-        return 127
-      }
-      printf 'fallback: droid exec\n' | tee -a "$review_output"
-      "$droid_bin" exec --cwd "$repo_root" -f "$prompt_file" 2>&1 | tee -a "$review_output"
-      status=${PIPESTATUS[0]}
-      ;;
-    copilot)
-      command -v "$copilot_bin" >/dev/null 2>&1 || {
-        echo "fallback reviewer unavailable: $copilot_bin" >&2
-        return 127
-      }
-      printf 'fallback: copilot\n' | tee -a "$review_output"
-      prompt_bytes=$(wc -c < "$prompt_file" | tr -d '[:space:]')
-      if (( prompt_bytes > 120000 )); then
-        echo "copilot reviewer unavailable: generated prompt is too large" | tee -a "$review_output"
-        status=1
-      else
-        copilot_prompt=$(< "$prompt_file")
-        "$copilot_bin" -C "$repo_root" --available-tools=none --stream off --output-format text --silent -p "$copilot_prompt" 2>&1 | tee -a "$review_output"
-        status=${PIPESTATUS[0]}
-      fi
-      ;;
-    *)
-      echo "unsupported prompt reviewer: $selected" >&2
-      status=2
-      ;;
-  esac
-  rm -f "$prompt_file"
-  prompt_file=
-  return "$status"
-}
+            run_claude(args, repo, "review hostile patch")
+            claude_record = json.loads(record_path.read_text())
+            claude_argv = claude_record["argv"]
+            for required in claude_review_isolation_flags():
+                if required not in claude_argv:
+                    raise SystemExit(f"claude isolation self-test failed: missing {required}")
+            if Path(claude_record["cwd"]).resolve() != repo.resolve():
+                raise SystemExit("claude isolation self-test failed: wrong cwd")
 
-fallback_reviewer_is_available() {
-  local selected=$1
-  case "$selected" in
-    claude) command -v "$claude_bin" >/dev/null 2>&1 ;;
-    pi) command -v "$pi_bin" >/dev/null 2>&1 ;;
-    opencode) command -v "$opencode_bin" >/dev/null 2>&1 ;;
-    droid) command -v "$droid_bin" >/dev/null 2>&1 ;;
-    copilot) command -v "$copilot_bin" >/dev/null 2>&1 ;;
-    *) return 1 ;;
-  esac
-}
+            run_pi(args, repo, f"review hostile patch\nRepository: {repo}")
+            pi_record = json.loads(record_path.read_text())
+            pi_argv = pi_record["argv"]
+            for required in ["--print", *pi_review_isolation_flags(), "--tools", "read,grep,find,ls"]:
+                if required not in pi_argv:
+                    raise SystemExit(f"pi isolation self-test failed: missing {required}")
+            if Path(pi_record["cwd"]).resolve() == repo.resolve():
+                raise SystemExit("pi isolation self-test failed: review ran inside hostile repo")
+            if str(repo) not in pi_record["stdin"]:
+                raise SystemExit("pi isolation self-test failed: prompt omitted reviewed repo path")
+            pi_invocations = [
+                json.loads(line)
+                for line in pi_invocations_path.read_text().splitlines()
+                if line.strip()
+            ]
+            if [entry["argv"] for entry in pi_invocations[:3]] != [["--version"], ["--help"], pi_argv]:
+                raise SystemExit("pi isolation self-test failed: unexpected probe/run order")
+            for entry in pi_invocations[:2]:
+                if Path(entry["cwd"]).resolve() == repo.resolve():
+                    raise SystemExit("pi isolation self-test failed: probe ran inside hostile repo")
 
-run_selected_review() {
-  local selected=$1
-  case "$selected" in
-    codex) run_codex_review ;;
-    claude|pi|opencode|droid|copilot) run_prompt_reviewer "$selected" ;;
-    *) echo "unsupported reviewer: $selected" >&2; return 2 ;;
-  esac
-}
+            run_opencode(args, repo, "review hostile patch")
+            opencode_record = json.loads(record_path.read_text())
+            opencode_argv = opencode_record["argv"]
+            for required in ["run", "--dir", str(repo), "--pure", "--format", "json"]:
+                if required not in opencode_argv:
+                    raise SystemExit(f"opencode isolation self-test failed: missing {required}")
+            if "--dangerously-skip-permissions" in opencode_argv:
+                raise SystemExit("opencode isolation self-test failed: skip-permissions present")
+            if Path(opencode_record["cwd"]).resolve() == repo.resolve():
+                raise SystemExit("opencode isolation self-test failed: review ran inside hostile repo")
+            if opencode_record["stdin"] != "review hostile patch":
+                raise SystemExit("opencode isolation self-test failed: prompt not delivered over stdin")
+            if "review hostile patch" in opencode_argv:
+                raise SystemExit("opencode isolation self-test failed: prompt leaked into argv")
+            opencode_env = opencode_record["env"]
+            if opencode_env.get("OPENCODE_DISABLE_PROJECT_CONFIG") != "1":
+                raise SystemExit("opencode isolation self-test failed: project config env missing")
+            if opencode_env.get("OPENCODE_DISABLE_AUTOUPDATE") != "1":
+                raise SystemExit("opencode isolation self-test failed: autoupdate env missing")
+            config = json.loads(opencode_env["OPENCODE_CONFIG_CONTENT"])
+            if config.get("instructions") != [] or config.get("plugin") != [] or config.get("command") != {}:
+                raise SystemExit("opencode isolation self-test failed: project-controlled extensions not cleared")
+            for disabled_tool in ("bash", "edit", "skill", "task", "todowrite", "write"):
+                if config.get("tools", {}).get(disabled_tool) is not False:
+                    raise SystemExit(f"opencode isolation self-test failed: {disabled_tool} tool not disabled")
+            if hostile_ps_path.exists():
+                raise SystemExit("heartbeat metrics isolation self-test failed: repo-local ps executed")
 
-run_auto_fallback_review() {
-  local selected
-  if [[ "$fallback_reviewer" != auto ]]; then
-    run_selected_review "$fallback_reviewer"
-    return $?
-  fi
-  for selected in claude pi opencode droid copilot; do
-    if fallback_reviewer_is_available "$selected"; then
-      run_selected_review "$selected"
-      return $?
-    fi
-  done
-  echo "fallback reviewer unavailable: no configured fallback CLI found" >&2
-  return 127
-}
+            os.environ["AUTOREVIEW_FAKE_CLAUDE_VERSION"] = "2.1.168 (Claude Code)"
+            try:
+                ensure_claude_isolation_supported(args, repo)
+            except SystemExit as exc:
+                if ">= 2.1.169" not in str(exc):
+                    raise
+            else:
+                raise SystemExit("claude version floor self-test failed")
 
-run_auto_review() {
-  local status=0
-  run_selected_review codex
-  status=$?
-  if [[ "$status" == 0 ]]; then
+            os.environ["AUTOREVIEW_FAKE_CLAUDE_VERSION"] = "Claude Code unknown"
+            try:
+                ensure_claude_isolation_supported(args, repo)
+            except SystemExit as exc:
+                if "could not parse --version output" not in str(exc):
+                    raise
+            else:
+                raise SystemExit("claude unparseable version self-test failed")
+
+            os.environ["AUTOREVIEW_FAKE_PI_VERSION"] = "0.78.1"
+            try:
+                ensure_pi_isolation_supported(args, repo)
+            except SystemExit as exc:
+                if ">= 0.79.0" not in str(exc):
+                    raise
+            else:
+                raise SystemExit("pi version floor self-test failed")
+
+            os.environ["AUTOREVIEW_FAKE_PI_VERSION"] = "0.79.0"
+            os.environ["AUTOREVIEW_FAKE_PI_HELP"] = "--print\n--no-session\n--no-context-files\n--no-extensions\n--no-skills\n--no-prompt-templates\n--no-themes\n--tools\n--no-tools\n--thinking"
+            try:
+                ensure_pi_isolation_supported(args, repo)
+            except SystemExit as exc:
+                if "--no-approve" not in str(exc):
+                    raise
+            else:
+                raise SystemExit("pi missing --no-approve self-test failed")
+        finally:
+            os.environ.pop("AUTOREVIEW_FAKE_RECORD", None)
+            os.environ.pop("AUTOREVIEW_FAKE_CLAUDE_VERSION", None)
+            os.environ.pop("AUTOREVIEW_FAKE_PI_VERSION", None)
+            os.environ.pop("AUTOREVIEW_FAKE_PI_HELP", None)
+            os.environ.pop("AUTOREVIEW_FAKE_PI_INVOCATIONS", None)
+            os.environ["PATH"] = old_path
+            if old_codex_home is None:
+                os.environ.pop("CODEX_HOME", None)
+            else:
+                os.environ["CODEX_HOME"] = old_codex_home
+
+    if parse_cli_version("2.1.169 (Claude Code)") != CLAUDE_SAFE_MODE_MIN_VERSION:
+        raise SystemExit("claude version parsing self-test failed")
+    if parse_cli_version("Claude Code 2.1.170") != (2, 1, 170):
+        raise SystemExit("claude version parsing prefix self-test failed")
+    if parse_cli_version("pi 0.79.0") != PI_TRUST_ISOLATION_MIN_VERSION:
+        raise SystemExit("pi version parsing self-test failed")
+    fallback_config = parse_codex_auth_config_fallback(
+        'cli_auth_credentials_store = "ephemeral"\n'
+        'forced_login_method = "api"\n'
+        'forced_chatgpt_workspace_id = [\n'
+        '  "workspace-one",\n'
+        '  "workspace-two", # trailing comments are valid TOML\n'
+        ']\n'
+        'model = "must-not-be-forwarded"\n'
+        '[projects."/tmp/hostile"]\n'
+        'trust_level = "trusted"\n'
+    )
+    if fallback_config != {
+        "cli_auth_credentials_store": "ephemeral",
+        "forced_login_method": "api",
+        "forced_chatgpt_workspace_id": ["workspace-one", "workspace-two"],
+    }:
+        raise SystemExit("codex auth config fallback parser self-test failed")
+    if "none" not in THINKING_LEVELS_BY_ENGINE["codex"]:
+        raise SystemExit("codex thinking self-test failed")
+    print("autoreview engine isolation self-test: ok")
     return 0
-  fi
-  if (( status > 128 && status < 192 )); then
-    return "$status"
-  fi
-  if review_output_has_findings; then
-    return "$status"
-  fi
-  if [[ "$fallback_reviewer" == none ]]; then
-    return "$status"
-  fi
-  if [[ "$fallback_reviewer" == auto ]]; then
-    printf 'autoreview warning: codex exited %s; trying configured fallback reviewers\n' "$status" >&2
-  else
-    printf 'autoreview warning: codex exited %s; falling back to %s\n' "$status" "$fallback_reviewer" >&2
-  fi
-  run_auto_fallback_review
-}
 
-elapsed_since() {
-  local started_at=$1
-  local finished_at
-  finished_at=$(date +%s)
-  printf '%s\n' "$((finished_at - started_at))"
-}
 
-format_elapsed() {
-  local seconds=$1
-  if (( seconds < 60 )); then
-    printf '%ss\n' "$seconds"
-  else
-    printf '%sm%ss\n' "$((seconds / 60))" "$((seconds % 60))"
-  fi
-}
+def self_test_json_array_parser() -> int:
+    report = {
+        "findings": [],
+        "overall_correctness": "patch is correct",
+        "overall_explanation": "parser self-test",
+        "overall_confidence": 0.99,
+    }
+    result_events = [
+        {"type": "system", "subtype": "init"},
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "working"}]}},
+        {"type": "result", "result": json.dumps(report)},
+    ]
+    if extract_json(json.dumps(result_events)) != report:
+        raise SystemExit("json array parser self-test failed for result event")
+    jsonl = "\n".join(json.dumps(event) for event in result_events)
+    if extract_json(jsonl) != report:
+        raise SystemExit("json array parser self-test failed for jsonl result event")
 
-report_clean_review_or_fail() {
-  local elapsed_text
-  elapsed_text=$(format_elapsed "${review_elapsed_seconds:-0}")
-  if review_output_has_findings; then
-    printf 'autoreview complete after %s\n' "$elapsed_text"
-    printf 'autoreview findings: accepted/actionable findings reported\n'
-    return 1
-  fi
-  if review_output_empty; then
-    printf 'autoreview complete after %s; no output\n' "$elapsed_text"
-    return 1
-  fi
-  if review_output_used_prompt_reviewer && ! review_output_has_clean_marker "$review_output"; then
-    printf 'autoreview complete after %s\n' "$elapsed_text"
-    printf 'autoreview findings: prompt reviewer did not emit clean marker\n'
-    return 1
-  fi
-  printf 'autoreview complete after %s\n' "$elapsed_text"
-  printf 'autoreview clean: no accepted/actionable findings reported\n'
-}
+    structured_report = {**report, "overall_explanation": "structured output"}
+    if extract_json(json.dumps([{"type": "result", "structured_output": structured_report}])) != structured_report:
+        raise SystemExit("json array parser self-test failed for structured output event")
 
-if [[ -z "$parallel_tests" ]]; then
-  review_started_at=$(date +%s)
-  set +e
-  if [[ "$reviewer" == auto ]]; then
-    run_auto_review
-  else
-    run_selected_review "$reviewer"
-  fi
-  review_status=$?
-  review_elapsed_seconds=$(elapsed_since "$review_started_at")
-  set -e
-  if [[ "$review_status" == 0 ]]; then
-    report_clean_review_or_fail
-    exit $?
-  fi
-  exit "$review_status"
-fi
+    text_report = {**report, "overall_explanation": "text event"}
+    if extract_json(json.dumps([{"part": {"text": json.dumps(text_report)}}])) != text_report:
+        raise SystemExit("json array parser self-test failed for text event")
 
-review_status_file=$(mktemp)
-review_elapsed_file=$(mktemp)
-tests_status_file=$(mktemp)
+    droid_report = {**report, "overall_explanation": "droid stream text"}
+    droid_events = [
+        {"type": "system", "subtype": "init", "model": "claude-opus-4-8"},
+        {"type": "message", "role": "assistant", "text": json.dumps(droid_report)},
+        {"type": "completion", "finalText": json.dumps(droid_report), "numTurns": 1},
+    ]
+    if extract_json("\n".join(json.dumps(event) for event in droid_events)) != droid_report:
+        raise SystemExit("json array parser self-test failed for droid stream-json event")
 
-(
-  set +e
-  review_started_at=$(date +%s)
-  if [[ "$reviewer" == auto ]]; then
-    run_auto_review
-  else
-    run_selected_review "$reviewer"
-  fi
-  status=$?
-  elapsed=$(elapsed_since "$review_started_at")
-  printf '%s\n' "$status" > "$review_status_file"
-  printf '%s\n' "$elapsed" > "$review_elapsed_file"
-) &
-review_pid=$!
+    print("autoreview json array parser self-test: ok")
+    return 0
 
-(
-  set +e
-  bash -lc "$parallel_tests"
-  status=$?
-  printf '%s\n' "$status" > "$tests_status_file"
-) &
-tests_pid=$!
 
-wait "$review_pid" || true
-wait "$tests_pid" || true
+def parse_json_candidate(text: str) -> Any | None:
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        lines = stripped.splitlines()
+        if lines and lines[0].startswith("```") and lines[-1].strip() == "```":
+            stripped = "\n".join(lines[1:-1]).strip()
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(parsed, str) and parsed != text:
+        nested = parse_json_candidate(parsed)
+        return nested if nested is not None else parsed
+    return parsed
 
-review_status=$(cat "$review_status_file")
-review_elapsed_seconds=$(cat "$review_elapsed_file")
-tests_status=$(cat "$tests_status_file")
-rm -f "$review_status_file" "$review_elapsed_file" "$tests_status_file"
 
-printf 'autoreview exit: %s\n' "$review_status"
-printf 'tests exit: %s\n' "$tests_status"
+def _assert_opencode_permission(web_search: bool) -> None:
+    env = opencode_review_env(web_search)
+    if env.get("OPENCODE_DISABLE_PROJECT_CONFIG") != "1":
+        raise SystemExit("opencode isolation self-test failed: project config not disabled")
+    config = json.loads(env["OPENCODE_CONFIG_CONTENT"])
+    permission = config.get("permission", {})
+    if config.get("autoupdate") is not False:
+        raise SystemExit("opencode isolation self-test failed: autoupdate config not disabled")
+    if config.get("instructions") != [] or config.get("plugin") != [] or config.get("command") != {}:
+        raise SystemExit("opencode isolation self-test failed: project-controlled extension config not cleared")
+    for disabled_tool in ("bash", "edit", "skill", "task", "todowrite", "write"):
+        if config.get("tools", {}).get(disabled_tool) is not False:
+            raise SystemExit(f"opencode isolation self-test failed: {disabled_tool} tool not disabled")
+    if permission.get("*") != "deny":
+        raise SystemExit("opencode isolation self-test failed: default deny missing")
+    read_permission = permission.get("read")
+    if not isinstance(read_permission, dict):
+        raise SystemExit("opencode isolation self-test failed: read rules missing")
+    expected_read_rules = {
+        "*": "allow",
+        "*.env": "ask",
+        "*.env.*": "ask",
+        "*.env.example": "allow",
+    }
+    for pattern, action in expected_read_rules.items():
+        if read_permission.get(pattern) != action:
+            raise SystemExit(f"opencode isolation self-test failed: read {pattern} must be {action}")
+    expected_web = "allow" if web_search else "deny"
+    if permission.get("websearch") != expected_web:
+        raise SystemExit(f"opencode isolation self-test failed: websearch must be {expected_web} when web_search={web_search}")
+    if permission.get("webfetch") != expected_web:
+        raise SystemExit(f"opencode isolation self-test failed: webfetch must be {expected_web} when web_search={web_search}")
 
-if [[ "$review_status" != 0 || "$tests_status" != 0 ]]; then
-  exit 1
-fi
 
-report_clean_review_or_fail
+def self_test_opencode_isolation() -> None:
+    _assert_opencode_permission(True)
+    _assert_opencode_permission(False)
+    cmd = build_opencode_cmd(
+        argparse.Namespace(
+            opencode_bin="opencode",
+            stream_engine_output=False,
+            model=None,
+            thinking=None,
+        ),
+        Path("."),
+    )
+    if "--dangerously-skip-permissions" in cmd:
+        raise SystemExit("opencode isolation self-test failed: dangerously-skip-permissions present")
+    if "--format" not in cmd or cmd[cmd.index("--format") + 1] != "json":
+        raise SystemExit("opencode isolation self-test failed: json output required")
+    if "prompt" in cmd:
+        raise SystemExit("opencode isolation self-test failed: prompt must go through stdin, not argv")
+    print("autoreview opencode isolation self-test: ok")
+
+
+def self_test_opencode_real_project_isolation(args: argparse.Namespace) -> None:
+    opencode_bin = resolve_command(args.opencode_bin, Path.cwd())
+    with tempfile.TemporaryDirectory(prefix="autoreview-opencode-real-isolation.") as tempdir:
+        repo = Path(tempdir) / "hostile"
+        repo.mkdir()
+        run([resolve_command("git", repo), "init", "--quiet"], repo)
+        (repo / "HOSTILE.md").write_text("HOSTILE_SENTINEL_OPENCODE_INSTRUCTIONS\n")
+        (repo / "opencode.json").write_text(
+            json.dumps(
+                {
+                    "model": "zai/nonexistent-hostile-model",
+                    "instructions": ["HOSTILE.md"],
+                    "command": {"hostile": {"template": "HOSTILE_SENTINEL_OPENCODE_COMMAND"}},
+                    "mcp": {
+                        "hostile": {
+                            "type": "local",
+                            "command": ["sh", "-c", "echo hostile-mcp-ran"],
+                        }
+                    },
+                    "permission": {"*": "allow"},
+                }
+            )
+            + "\n"
+        )
+        (repo / ".opencode" / "agents").mkdir(parents=True)
+        (repo / ".opencode" / "agents" / "build.md").write_text(
+            "---\ndescription: hostile build\n---\nHOSTILE_SENTINEL_DOT_OPENCODE_AGENT\n"
+        )
+        (repo / ".opencode" / "skills" / "hostile").mkdir(parents=True)
+        (repo / ".opencode" / "skills" / "hostile" / "SKILL.md").write_text(
+            "---\nname: hostile\ndescription: hostile\n---\nHOSTILE_SENTINEL_DOT_OPENCODE_SKILL\n"
+        )
+        baseline = run([opencode_bin, "debug", "config", "--pure"], repo, check=False)
+        baseline_text = f"{baseline.stdout}\n{baseline.stderr}"
+        if baseline.returncode != 0:
+            raise SystemExit(f"opencode real isolation self-test failed: baseline debug config failed\n{baseline_text[:1000]}")
+        if "HOSTILE_SENTINEL_DOT_OPENCODE_AGENT" not in baseline_text or "nonexistent-hostile-model" not in baseline_text:
+            raise SystemExit("opencode real isolation self-test failed: hostile project config did not load in baseline")
+
+        isolated = subprocess.run(
+            [opencode_bin, "debug", "config", "--pure"],
+            cwd=repo,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=subprocess_env(opencode_review_env(False)),
+        )
+        isolated_text = f"{isolated.stdout}\n{isolated.stderr}"
+        if isolated.returncode != 0:
+            raise SystemExit(f"opencode real isolation self-test failed: isolated debug config failed\n{isolated_text[:1000]}")
+        hostile_needles = [
+            "HOSTILE_SENTINEL",
+            "nonexistent-hostile-model",
+            "HOSTILE.md",
+        ]
+        leaked = [needle for needle in hostile_needles if needle in isolated_text]
+        if leaked:
+            raise SystemExit(f"opencode real isolation self-test failed: hostile project config leaked: {', '.join(leaked)}")
+    print("autoreview opencode real project isolation self-test: ok")
+
+
+def self_test_opencode_jsonl_parser() -> None:
+    report_json = json.dumps(
+        {
+            "findings": [],
+            "overall_correctness": "patch is correct",
+            "overall_explanation": "ok",
+            "overall_confidence": 0.9,
+        }
+    )
+    split = max(1, len(report_json) // 2)
+    sample = "\n".join(
+        [
+            json.dumps(
+                {
+                    "type": "text",
+                    "timestamp": 1,
+                    "sessionID": "session-1",
+                    "part": {"type": "text", "text": report_json[:split]},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "text",
+                    "timestamp": 2,
+                    "sessionID": "session-1",
+                    "part": {"type": "text", "text": report_json[split:]},
+                }
+            ),
+        ]
+    )
+    parsed = extract_json_from_jsonl(sample)
+    if not parsed or parsed.get("overall_correctness") != "patch is correct":
+        raise SystemExit("opencode jsonl parser self-test failed")
+    print("autoreview opencode jsonl parser self-test: ok")
+
+
+def self_test_heartbeat_metrics() -> None:
+    cases = {
+        "": 0.0,
+        "garbage": 0.0,
+        "12": 12.0,
+        "01:02": 62.0,
+        "01:02.5": 62.5,
+        "01:02:03": 3723.0,
+        "2-01:02:03": 176523.0,
+    }
+    for value, expected in cases.items():
+        actual = parse_ps_time(value)
+        if actual != expected:
+            raise SystemExit(f"heartbeat metrics self-test failed: parse_ps_time({value!r})={actual!r}")
+
+    previous = (10.0, 3.0, 1024, "S")
+    current = (70.0, 18.0, 1536, "R,S")
+    expected = " cpu=15.0s/60s(25%) rss=2M state=R,S"
+    actual = format_process_metrics(previous, current)
+    if actual != expected:
+        raise SystemExit(f"heartbeat metrics self-test failed: {actual!r}")
+    if format_process_metrics(previous, None) != "":
+        raise SystemExit("heartbeat metrics self-test failed: missing sample should not add output")
+    print("autoreview heartbeat metrics self-test: ok")
+
+
+def validate_report(report: dict[str, Any], repo: Path, changed_paths: set[str], required: list[str]) -> None:
+    allowed_top = {"findings", "overall_correctness", "overall_explanation", "overall_confidence"}
+    extra_top = set(report) - allowed_top
+    if extra_top:
+        raise SystemExit(f"review JSON has unexpected top-level keys: {sorted(extra_top)}")
+    for key in SCHEMA["required"]:
+        if key not in report:
+            raise SystemExit(f"review JSON missing required key: {key}")
+    if not isinstance(report["findings"], list):
+        raise SystemExit("review JSON findings must be an array")
+    if report.get("overall_correctness") not in {"patch is correct", "patch is incorrect"}:
+        raise SystemExit(f"review JSON has invalid overall_correctness: {report.get('overall_correctness')}")
+    if not isinstance(report.get("overall_explanation"), str) or not report["overall_explanation"]:
+        raise SystemExit("review JSON overall_explanation must be a non-empty string")
+    if len(report["overall_explanation"]) > 3000:
+        raise SystemExit("review JSON overall_explanation is too long")
+    if not number_in_range(report.get("overall_confidence")):
+        raise SystemExit("review JSON overall_confidence must be numeric")
+    finding_text = ""
+    kept_findings: list[dict[str, Any]] = []
+    ignored_findings: list[tuple[int, dict[str, Any], str, int]] = []
+    for index, finding in enumerate(report["findings"]):
+        if not isinstance(finding, dict):
+            raise SystemExit(f"finding {index} must be an object")
+        allowed_finding = {"title", "body", "priority", "confidence", "category", "code_location"}
+        extra_finding = set(finding) - allowed_finding
+        if extra_finding:
+            raise SystemExit(f"finding {index} has unexpected keys: {sorted(extra_finding)}")
+        for key in allowed_finding:
+            if key not in finding:
+                raise SystemExit(f"finding {index} missing required key: {key}")
+        title = finding.get("title")
+        if not isinstance(title, str) or not title or len(title) > 140:
+            raise SystemExit(f"finding {index} has invalid title")
+        body = finding.get("body")
+        if not isinstance(body, str) or not body or len(body) > 2000:
+            raise SystemExit(f"finding {index} has invalid body")
+        priority = finding.get("priority")
+        if priority not in {"P0", "P1", "P2", "P3"}:
+            raise SystemExit(f"finding {index} has invalid priority: {priority}")
+        if not number_in_range(finding.get("confidence")):
+            raise SystemExit(f"finding {index} has invalid confidence")
+        category = finding.get("category")
+        if category not in {"bug", "security", "regression", "test_gap", "maintainability"}:
+            raise SystemExit(f"finding {index} has invalid category: {category}")
+        location = finding.get("code_location")
+        if not isinstance(location, dict):
+            raise SystemExit(f"finding {index} missing code_location")
+        rel = str(location.get("file_path", "")).strip()
+        line = location.get("line")
+        if not rel or not isinstance(line, int) or line < 1:
+            raise SystemExit(f"finding {index} has invalid location: {location}")
+        if Path(rel).is_absolute() or ".." in Path(rel).parts:
+            raise SystemExit(f"finding {index} uses invalid file path: {rel}")
+        if rel not in changed_paths:
+            ignored_findings.append((index, finding, rel, line))
+            continue
+        kept_findings.append(finding)
+        finding_text += "\n" + json.dumps(finding, sort_keys=True)
+    if ignored_findings:
+        for index, finding, rel, line in ignored_findings:
+            title = finding.get("title", "<untitled>")
+            print(
+                f"autoreview ignored out-of-scope finding {index}: {title} ({rel}:{line})",
+                file=sys.stderr,
+            )
+            print(bounded_field(str(finding.get("body", "")), 500), file=sys.stderr)
+        report["findings"] = kept_findings
+        if not kept_findings and report["overall_correctness"] == "patch is incorrect":
+            note = f"Ignored {len(ignored_findings)} out-of-scope finding(s) outside the reviewed change."
+            explanation = report["overall_explanation"].rstrip()
+            report["overall_correctness"] = "patch is correct"
+            report["overall_explanation"] = bounded_field(f"{explanation}\n\n{note}", 3000)
+    haystack = finding_text.lower()
+    for needle in required:
+        if needle.lower() not in haystack:
+            raise SystemExit(f"required finding text not found: {needle}")
+
+
+def number_in_range(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and 0 <= value <= 1
+
+
+def print_report(report: dict[str, Any], *, label: str = "autoreview") -> None:
+    findings = report["findings"]
+    if findings:
+        print(f"{label} findings: {len(findings)}")
+    elif report["overall_correctness"] == "patch is incorrect":
+        print(f"{label} verdict: patch is incorrect without discrete findings")
+    else:
+        print(f"{label} clean: no accepted/actionable findings reported")
+    for finding in findings:
+        loc = finding["code_location"]
+        print(f"[{finding['priority']}] {finding['title']}")
+        print(f"{loc['file_path']}:{loc['line']}")
+        print(f"{finding['body']}")
+        print()
+    print(f"overall: {report['overall_correctness']} ({report['overall_confidence']})")
+    print(report["overall_explanation"])
+
+
+def start_parallel_tests(command: str, repo: Path, shell_kind: str) -> tuple[subprocess.Popen, float]:
+    print(f"tests: {command}")
+    if shell_kind == "default" or shell_kind == "cmd":
+        return subprocess.Popen(command, cwd=repo, shell=True), time.time()
+    if shell_kind == "powershell":
+        powershell = resolve_command("powershell", repo)
+        return subprocess.Popen(
+            [powershell, "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", command],
+            cwd=repo,
+        ), time.time()
+    if shell_kind == "pwsh":
+        pwsh = resolve_command("pwsh", repo)
+        return subprocess.Popen(
+            [pwsh, "-NoProfile", "-Command", command],
+            cwd=repo,
+        ), time.time()
+    raise SystemExit(f"invalid --parallel-tests-shell/AUTOREVIEW_PARALLEL_TESTS_SHELL: {shell_kind}")
+
+
+def finish_parallel_tests(proc: subprocess.Popen, started: float) -> int:
+    proc.wait()
+    print(f"tests exit: {proc.returncode} after {int(time.time() - started)}s")
+    return int(proc.returncode or 0)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Bundle-driven AI code review.")
+    parser.add_argument("--mode", choices=["auto", "local", "uncommitted", "branch", "commit"], default="auto")
+    parser.add_argument("--base")
+    parser.add_argument("--commit", default="HEAD")
+    parser.add_argument("--engine", choices=ENGINES, default=os.environ.get("AUTOREVIEW_ENGINE", "codex"))
+    parser.add_argument("--reviewers", help="Comma-separated review panel, e.g. codex,claude,pi or codex:gpt-5.5:high.")
+    parser.add_argument("--panel", action="store_true", help="Run a Codex/Claude review panel unless --engine changes the first reviewer.")
+    parser.add_argument(
+        "--model",
+        action="append",
+        help="Model for all reviewers or engine=model. Repeatable. Defaults: codex=gpt-5.5, claude=claude-fable-5.",
+    )
+    parser.add_argument("--thinking", action="append", help="Thinking/effort for all reviewers or engine=level. Repeatable. Codex: none, minimal, low, medium, high, xhigh. Claude: low, medium, high, xhigh, max. Droid: off, none, low, medium, high. Pi: off, minimal, low, medium, high, xhigh. OpenCode: minimal, low, medium, high, max.")
+    parser.add_argument(
+        "--fallback-model",
+        action="append",
+        help="Claude fallback model chain for all reviewers or claude=a,b. Repeatable.",
+    )
+    parser.add_argument("--allow-partial-panel", action="store_true", help="Continue panel output when one reviewer fails.")
+    parser.add_argument("--codex-bin", default=os.environ.get("CODEX_BIN", "codex"))
+    parser.add_argument("--claude-bin", default=os.environ.get("CLAUDE_BIN", "claude"))
+    parser.add_argument("--droid-bin", default=os.environ.get("DROID_BIN", "droid"))
+    parser.add_argument("--copilot-bin", default=os.environ.get("COPILOT_BIN", "copilot"))
+    parser.add_argument("--opencode-bin", default=os.environ.get("OPENCODE_BIN", "opencode"))
+    parser.add_argument("--pi-bin", default=os.environ.get("PI_BIN", "pi"))
+    parser.add_argument("--no-tools", dest="tools", action="store_false", default=True, help="Disable tools for engines that support it. Codex, copilot, and opencode reject no-tools review.")
+    parser.add_argument("--self-test-opencode-jsonl-parser", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--self-test-opencode-isolation", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--self-test-opencode-real-project-isolation", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--no-web-search", dest="web_search", action="store_false", default=True)
+    parser.add_argument(
+        "--claude-allowed-tools",
+        default=os.environ.get(
+            "AUTOREVIEW_CLAUDE_TOOLS",
+            "Read,Grep,Glob,WebSearch,WebFetch",
+        ),
+    )
+    parser.add_argument("--prompt", action="append", help="Additional review instruction text.")
+    parser.add_argument("--prompt-file", action="append", help="Additional review instruction file.")
+    parser.add_argument("--dataset", action="append", help="Extra evidence file to include in the review bundle.")
+    parser.add_argument("--output", help="Write human output to a file as well as stdout.")
+    parser.add_argument("--json-output", help="Write validated structured review JSON.")
+    parser.add_argument(
+        "--stream-engine-output",
+        action="store_true",
+        default=os.environ.get("AUTOREVIEW_STREAM_ENGINE_OUTPUT") == "1",
+        help="Stream review engine output while preserving buffered output for validation. Codex output is filtered to hide tool/file chatter.",
+    )
+    parser.add_argument("--parallel-tests", help="Run a test command concurrently with review; failure fails the helper.")
+    parser.add_argument(
+        "--parallel-tests-shell",
+        choices=["default", "cmd", "powershell", "pwsh"],
+        default=os.environ.get("AUTOREVIEW_PARALLEL_TESTS_SHELL", "default"),
+        help="Shell for --parallel-tests. Default preserves Python shell=True platform behavior; use powershell or pwsh for PowerShell-specific commands.",
+    )
+    parser.add_argument("--require-finding", action="append", default=[], help="Require finding text to contain this substring.")
+    parser.add_argument("--expect-findings", action="store_true", help="Treat findings as success; for harness acceptance tests.")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--self-test-config-defaults", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--self-test-fallback-scope", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--self-test-engine-isolation", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--self-test-json-array-parser", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--self-test-heartbeat-metrics", action="store_true", help=argparse.SUPPRESS)
+    args = parser.parse_args()
+    if args.engine not in ENGINES:
+        raise SystemExit(f"invalid --engine/AUTOREVIEW_ENGINE: {args.engine}")
+    return args
+
+
+def run_engine(args: argparse.Namespace, repo: Path, prompt: str) -> str:
+    if args.engine == "codex":
+        return run_codex(args, repo, prompt)
+    if args.engine == "claude":
+        return run_claude(args, repo, prompt)
+    if args.engine == "droid":
+        return run_droid(args, repo, prompt)
+    if args.engine == "copilot":
+        return run_copilot(args, repo, prompt)
+    if args.engine == "pi":
+        return run_pi(args, repo, prompt)
+    if args.engine == "opencode":
+        return run_opencode(args, repo, prompt)
+    raise SystemExit(f"unsupported engine: {args.engine}")
+
+
+def env_defaults_for(env_suffix: str) -> tuple[str | None, dict[str, str]]:
+    env_key = env_suffix.replace("-", "_").upper()
+    global_value = os.environ.get(f"AUTOREVIEW_{env_key}")
+    if global_value is not None:
+        global_value = global_value.strip() or None
+    per_engine: dict[str, str] = {}
+    for engine in ENGINES:
+        value = os.environ.get(f"AUTOREVIEW_{engine.upper()}_{env_key}")
+        if value is None:
+            continue
+        value = value.strip()
+        if value:
+            per_engine[engine] = value
+    return global_value, per_engine
+
+
+def parse_keyed_options(values: list[str] | None, option: str) -> tuple[str | None, dict[str, str]]:
+    global_value: str | None = None
+    per_engine: dict[str, str] = {}
+    for raw in values or []:
+        value = raw.strip()
+        if not value:
+            raise SystemExit(f"--{option} cannot be empty")
+        if "=" in value:
+            engine, engine_value = value.split("=", 1)
+            engine = engine.strip()
+            engine_value = engine_value.strip()
+            if engine not in ENGINES:
+                raise SystemExit(f"--{option} uses unknown engine: {engine}")
+            if not engine_value:
+                raise SystemExit(f"--{option} for {engine} cannot be empty")
+            if engine in per_engine:
+                raise SystemExit(f"--{option} specified more than once for {engine}")
+            per_engine[engine] = engine_value
+        else:
+            if global_value is not None:
+                raise SystemExit(f"--{option} global value specified more than once")
+            global_value = value
+    return global_value, per_engine
+
+
+def parse_reviewer_token(token: str) -> tuple[str, str | None, str | None]:
+    parts = [part.strip() for part in token.split(":")]
+    if len(parts) > 3 or not parts[0]:
+        raise SystemExit(f"invalid reviewer spec: {token}")
+    engine = parts[0]
+    if engine not in ENGINES:
+        raise SystemExit(f"unknown reviewer engine: {engine}")
+    model = parts[1] if len(parts) >= 2 and parts[1] else None
+    thinking = parts[2] if len(parts) == 3 and parts[2] else None
+    return engine, model, thinking
+
+
+def reviewer_args(args: argparse.Namespace) -> list[argparse.Namespace]:
+    global_model, model_by_engine = parse_keyed_options(args.model, "model")
+    global_thinking, thinking_by_engine = parse_keyed_options(args.thinking, "thinking")
+    global_fallback, fallback_by_engine = parse_keyed_options(args.fallback_model, "fallback-model")
+    env_global_model, env_model_by_engine = env_defaults_for("model")
+    env_global_thinking, env_thinking_by_engine = env_defaults_for("thinking")
+    env_global_fallback, env_fallback_by_engine = env_defaults_for("fallback-model")
+    reviewers: list[tuple[str, str | None, str | None]] = []
+    if args.reviewers:
+        tokens = [token.strip() for token in args.reviewers.split(",") if token.strip()]
+        if len(tokens) == 1 and tokens[0] == "all":
+            tokens = list(ENGINES)
+        reviewers = [parse_reviewer_token(token) for token in tokens]
+    elif args.panel:
+        engines = [args.engine]
+        for engine in ("codex", "claude"):
+            if engine not in engines:
+                engines.append(engine)
+        reviewers = [(engine, None, None) for engine in engines]
+    else:
+        reviewers = [(args.engine, None, None)]
+
+    selected_engines = {engine for engine, _, _ in reviewers}
+    fallback_engines = set(fallback_by_engine) | set(env_fallback_by_engine)
+    unused_fallback_engines = fallback_engines - selected_engines
+    if unused_fallback_engines:
+        engine_list = ", ".join(sorted(unused_fallback_engines))
+        raise SystemExit(f"--fallback-model specified for unselected reviewer: {engine_list}")
+    selected_non_claude_fallback = sorted(engine for engine in fallback_engines if engine != "claude")
+    if selected_non_claude_fallback:
+        engine_list = ", ".join(selected_non_claude_fallback)
+        raise SystemExit(f"--fallback-model is only supported for claude, not {engine_list}")
+    if (global_fallback or env_global_fallback) and "claude" not in selected_engines:
+        raise SystemExit("--fallback-model is only supported for claude; no claude reviewer selected")
+
+    seen: set[str] = set()
+    result: list[argparse.Namespace] = []
+    for engine, inline_model, inline_thinking in reviewers:
+        if engine in seen:
+            raise SystemExit(f"reviewer specified more than once: {engine}")
+        seen.add(engine)
+        model = (
+            inline_model
+            or model_by_engine.get(engine)
+            or global_model
+            or env_model_by_engine.get(engine)
+            or env_global_model
+            or DEFAULT_MODEL_BY_ENGINE.get(engine)
+        )
+        thinking = (
+            inline_thinking
+            or thinking_by_engine.get(engine)
+            or global_thinking
+            or env_thinking_by_engine.get(engine)
+            or env_global_thinking
+        )
+        if engine == "claude":
+            fallback_model = (
+                fallback_by_engine.get(engine)
+                or global_fallback
+                or env_fallback_by_engine.get(engine)
+                or env_global_fallback
+            )
+        else:
+            fallback_model = None
+        if thinking and thinking not in THINKING_LEVELS_BY_ENGINE[engine]:
+            valid = ", ".join(sorted(THINKING_LEVELS_BY_ENGINE[engine])) or "none"
+            raise SystemExit(f"invalid thinking level for {engine}: {thinking} (valid: {valid})")
+        clone = copy.copy(args)
+        clone.engine = engine
+        clone.model = model
+        clone.thinking = thinking
+        clone.fallback_model = fallback_model
+        result.append(clone)
+    return result
+
+
+def reviewer_label(args: argparse.Namespace) -> str:
+    parts = [args.engine]
+    if args.model:
+        parts.append(f"model={args.model}")
+    if getattr(args, "fallback_model", None):
+        parts.append(f"fallback={args.fallback_model}")
+    if args.thinking:
+        parts.append(f"thinking={args.thinking}")
+    return " ".join(parts)
+
+
+def run_reviewer(args: argparse.Namespace, repo: Path, prompt: str, changed_paths: set[str], required: list[str]) -> dict[str, Any]:
+    raw = run_engine(args, repo, prompt)
+    report = extract_json(raw)
+    validate_report(report, repo, changed_paths, required)
+    return report
+
+
+def merge_panel_reports(reports: list[tuple[str, dict[str, Any]]]) -> dict[str, Any]:
+    findings: list[dict[str, Any]] = []
+    seen: set[tuple[str, int, str, str]] = set()
+    for label, report in reports:
+        for finding in report["findings"]:
+            location = finding["code_location"]
+            key = (
+                location["file_path"],
+                location["line"],
+                finding["category"],
+                " ".join(finding["title"].lower().split()),
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            merged = copy.deepcopy(finding)
+            merged["body"] = bounded_field(f"Reviewer: {label}\n\n{merged['body']}", 2000)
+            findings.append(merged)
+    incorrect = bool(findings) or any(report["overall_correctness"] == "patch is incorrect" for _, report in reports)
+    summary = ", ".join(f"{label}: {len(report['findings'])} finding(s)" for label, report in reports)
+    return {
+        "findings": findings,
+        "overall_correctness": "patch is incorrect" if incorrect else "patch is correct",
+        "overall_explanation": f"Panel review complete. {summary}.",
+        "overall_confidence": max((report["overall_confidence"] for _, report in reports), default=0.5),
+    }
+
+
+def run_panel(args: argparse.Namespace, reviewers: list[argparse.Namespace], repo: Path, prompt: str, changed_paths: set[str]) -> dict[str, Any]:
+    reports: list[tuple[str, dict[str, Any]]] = []
+    failures: list[str] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(reviewers)) as executor:
+        future_by_label = {
+            executor.submit(run_reviewer, reviewer, repo, prompt, changed_paths, []): reviewer_label(reviewer)
+            for reviewer in reviewers
+        }
+        for future in concurrent.futures.as_completed(future_by_label):
+            label = future_by_label[future]
+            try:
+                reports.append((label, future.result()))
+            except SystemExit as exc:
+                failures.append(f"{label}: {exc}")
+            except Exception as exc:
+                failures.append(f"{label}: {exc}")
+    if failures and not args.allow_partial_panel:
+        raise SystemExit("autoreview panel failed\n" + "\n".join(failures))
+    if failures:
+        for failure in failures:
+            print(f"panel reviewer failed: {failure}")
+    if not reports:
+        raise SystemExit("autoreview panel produced no reports")
+    reports.sort(key=lambda item: item[0])
+    report = merge_panel_reports(reports)
+    validate_report(report, repo, changed_paths, args.require_finding)
+    return report
+
+
+def reviewer_test_args(**overrides: Any) -> argparse.Namespace:
+    defaults = {
+        "reviewers": None,
+        "panel": False,
+        "engine": "codex",
+        "model": None,
+        "thinking": None,
+        "fallback_model": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def preserve_env(keys: list[str]):
+    saved = {key: os.environ.get(key) for key in keys}
+
+    class EnvGuard:
+        def __enter__(self):
+            for key in keys:
+                os.environ.pop(key, None)
+            return self
+
+        def __exit__(self, _exc_type: Any, _exc: Any, _tb: Any) -> None:
+            for key, value in saved.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
+    return EnvGuard()
+
+
+def self_test_config_defaults() -> None:
+    keys = [
+        "AUTOREVIEW_MODEL",
+        "AUTOREVIEW_CODEX_MODEL",
+        "AUTOREVIEW_CLAUDE_MODEL",
+        "AUTOREVIEW_THINKING",
+        "AUTOREVIEW_CODEX_THINKING",
+        "AUTOREVIEW_CLAUDE_THINKING",
+    ]
+    with preserve_env(keys):
+        default_codex = reviewer_args(reviewer_test_args(engine="codex"))[0]
+        if default_codex.model != "gpt-5.5":
+            raise SystemExit(f"self-test config defaults failed: default codex model={default_codex.model!r}")
+        default_claude = reviewer_args(reviewer_test_args(engine="claude"))[0]
+        if default_claude.model != "claude-fable-5":
+            raise SystemExit(f"self-test config defaults failed: default claude model={default_claude.model!r}")
+        os.environ["AUTOREVIEW_MODEL"] = "env-global-model"
+        os.environ["AUTOREVIEW_CODEX_MODEL"] = "env-codex-model"
+        os.environ["AUTOREVIEW_THINKING"] = "low"
+        os.environ["AUTOREVIEW_CODEX_THINKING"] = "high"
+        codex = reviewer_args(reviewer_test_args(engine="codex"))[0]
+        if codex.model != "env-codex-model":
+            raise SystemExit(f"self-test config defaults failed: model={codex.model!r}")
+        if codex.thinking != "high":
+            raise SystemExit(f"self-test config defaults failed: thinking={codex.thinking!r}")
+        os.environ.pop("AUTOREVIEW_CODEX_MODEL")
+        os.environ.pop("AUTOREVIEW_CODEX_THINKING")
+        global_only = reviewer_args(reviewer_test_args(engine="codex"))[0]
+        if global_only.model != "env-global-model":
+            raise SystemExit(f"self-test config defaults failed: global model={global_only.model!r}")
+        if global_only.thinking != "low":
+            raise SystemExit(f"self-test config defaults failed: global thinking={global_only.thinking!r}")
+        cli = reviewer_args(reviewer_test_args(engine="codex", model=["cli-model"], thinking=["medium"]))[0]
+        if cli.model != "cli-model" or cli.thinking != "medium":
+            raise SystemExit("self-test config defaults failed: CLI values should override env")
+        inline = reviewer_args(
+            reviewer_test_args(
+                reviewers="codex:inline-model:minimal",
+                model=["cli-model"],
+                thinking=["medium"],
+            )
+        )[0]
+        if inline.model != "inline-model" or inline.thinking != "minimal":
+            raise SystemExit("self-test config defaults failed: inline reviewer values should override CLI/env")
+    print("self-test config defaults: ok")
+
+
+def self_test_fallback_scope() -> None:
+    keys = [
+        "AUTOREVIEW_FALLBACK_MODEL",
+        "AUTOREVIEW_CLAUDE_FALLBACK_MODEL",
+        "AUTOREVIEW_CODEX_FALLBACK_MODEL",
+    ]
+    with preserve_env(keys):
+        os.environ["AUTOREVIEW_FALLBACK_MODEL"] = "env-global-fallback"
+        os.environ["AUTOREVIEW_CLAUDE_FALLBACK_MODEL"] = "env-claude-fallback"
+        base = reviewer_test_args(reviewers="codex,claude")
+        reviewers = reviewer_args(base)
+        codex = next(r for r in reviewers if r.engine == "codex")
+        claude = next(r for r in reviewers if r.engine == "claude")
+        if codex.fallback_model is not None:
+            raise SystemExit("self-test fallback scope failed: codex should ignore AUTOREVIEW_FALLBACK_MODEL")
+        if claude.fallback_model != "env-claude-fallback":
+            raise SystemExit(f"self-test fallback scope failed: claude fallback={claude.fallback_model!r}")
+        os.environ.pop("AUTOREVIEW_CLAUDE_FALLBACK_MODEL")
+        global_only = reviewer_args(reviewer_test_args(engine="claude"))[0]
+        if global_only.fallback_model != "env-global-fallback":
+            raise SystemExit(f"self-test fallback scope failed: global fallback={global_only.fallback_model!r}")
+        try:
+            reviewer_args(reviewer_test_args(engine="codex"))
+            raise SystemExit("self-test fallback scope failed: env global fallback without Claude should be rejected")
+        except SystemExit as exc:
+            if "no claude reviewer selected" not in str(exc):
+                raise
+        cli_global = reviewer_args(reviewer_test_args(engine="claude", fallback_model=["cli-global"]))[0]
+        if cli_global.fallback_model != "cli-global":
+            raise SystemExit("self-test fallback scope failed: CLI global fallback should override env")
+        cli_engine = reviewer_args(
+            reviewer_test_args(engine="claude", fallback_model=["cli-global", "claude=cli-claude"])
+        )[0]
+        if cli_engine.fallback_model != "cli-claude":
+            raise SystemExit("self-test fallback scope failed: CLI engine fallback should override CLI global")
+        panel = reviewer_args(reviewer_test_args(reviewers="codex,claude", fallback_model=["cli-global"]))
+        panel_codex = next(r for r in panel if r.engine == "codex")
+        panel_claude = next(r for r in panel if r.engine == "claude")
+        if panel_codex.fallback_model is not None or panel_claude.fallback_model != "cli-global":
+            raise SystemExit("self-test fallback scope failed: CLI global fallback should apply only to Claude panel reviewers")
+        try:
+            reviewer_args(reviewer_test_args(engine="codex", fallback_model=["cli-global"]))
+            raise SystemExit("self-test fallback scope failed: global fallback without Claude should be rejected")
+        except SystemExit as exc:
+            if "no claude reviewer selected" not in str(exc):
+                raise
+        try:
+            reviewer_args(reviewer_test_args(engine="codex", fallback_model=["claude=cli-claude"]))
+            raise SystemExit("self-test fallback scope failed: fallback for unselected Claude reviewer should be rejected")
+        except SystemExit as exc:
+            if "unselected reviewer: claude" not in str(exc):
+                raise
+        inline = reviewer_args(
+            reviewer_test_args(
+                reviewers="claude:inline-model:high",
+                fallback_model=["cli-global"],
+            )
+        )[0]
+        if inline.fallback_model != "cli-global":
+            raise SystemExit("self-test fallback scope failed: CLI global fallback should apply to inline reviewers")
+        explicit = reviewer_test_args(reviewers="codex", fallback_model=["codex=foo"])
+        try:
+            reviewer_args(explicit)
+            raise SystemExit("self-test fallback scope failed: codex=fallback should be rejected")
+        except SystemExit as exc:
+            if "not codex" not in str(exc):
+                raise
+        os.environ.pop("AUTOREVIEW_FALLBACK_MODEL")
+        os.environ["AUTOREVIEW_CLAUDE_FALLBACK_MODEL"] = "env-claude-only"
+        try:
+            reviewer_args(reviewer_test_args(engine="codex"))
+            raise SystemExit("self-test fallback scope failed: Claude fallback env without Claude should be rejected")
+        except SystemExit as exc:
+            if "unselected reviewer: claude" not in str(exc):
+                raise
+        os.environ["AUTOREVIEW_FALLBACK_MODEL"] = "env-global-fallback"
+        os.environ.pop("AUTOREVIEW_CLAUDE_FALLBACK_MODEL")
+        os.environ["AUTOREVIEW_CODEX_FALLBACK_MODEL"] = "env-codex-fallback"
+        try:
+            reviewer_args(reviewer_test_args(engine="codex"))
+            raise SystemExit("self-test fallback scope failed: AUTOREVIEW_CODEX_FALLBACK_MODEL should be rejected")
+        except SystemExit as exc:
+            if "only supported for claude" not in str(exc):
+                raise
+    print("self-test fallback scope: ok")
+
+
+def main() -> int:
+    args = parse_args()
+    if args.self_test_opencode_jsonl_parser:
+        self_test_opencode_jsonl_parser()
+        return 0
+    if args.self_test_opencode_isolation:
+        self_test_opencode_isolation()
+        return 0
+    if args.self_test_opencode_real_project_isolation:
+        self_test_opencode_real_project_isolation(args)
+        return 0
+    if args.self_test_config_defaults:
+        self_test_config_defaults()
+        return 0
+    if args.self_test_fallback_scope:
+        self_test_fallback_scope()
+        return 0
+    if args.self_test_heartbeat_metrics:
+        self_test_heartbeat_metrics()
+        return 0
+    if args.self_test_engine_isolation:
+        return self_test_engine_isolation()
+    if args.self_test_json_array_parser:
+        return self_test_json_array_parser()
+    reviewers = reviewer_args(args)
+    repo = repo_root()
+    target, target_ref = choose_target(repo, args.mode, args.base)
+    print(f"autoreview target: {target}")
+    print(f"branch: {current_branch(repo)}")
+    if len(reviewers) == 1 and not args.reviewers and not args.panel:
+        print(f"engine: {reviewers[0].engine}")
+        if reviewers[0].model:
+            print(f"model: {reviewers[0].model}")
+        if getattr(reviewers[0], "fallback_model", None):
+            print(f"fallback_model: {reviewers[0].fallback_model}")
+        if reviewers[0].thinking:
+            print(f"thinking: {reviewers[0].thinking}")
+    else:
+        print(f"reviewers: {', '.join(reviewer_label(reviewer) for reviewer in reviewers)}")
+    print(f"tools: {'on' if args.tools else 'off'}")
+    print(f"web_search: {'on' if args.web_search else 'off'}")
+    display_ref = args.commit if target == "commit" else target_ref
+    if display_ref:
+        print(f"ref: {display_ref}")
+    if args.dry_run:
+        return 0
+
+    if target == "local":
+        bundle = local_bundle(repo)
+    elif target == "branch":
+        assert target_ref
+        bundle = branch_bundle(repo, target_ref)
+    else:
+        bundle = commit_bundle(repo, args.commit)
+        target_ref = args.commit
+    prompt = build_prompt(
+        repo,
+        target,
+        target_ref,
+        bundle,
+        load_extra_prompt(args, repo),
+        load_datasets(args, repo),
+    )
+    changed_paths = review_paths(repo, target, target_ref, args.commit)
+    print(f"bundle: {len(prompt)} chars")
+
+    tests_proc: tuple[subprocess.Popen, float] | None = None
+    if args.parallel_tests:
+        tests_proc = start_parallel_tests(args.parallel_tests, repo, args.parallel_tests_shell)
+    try:
+        if len(reviewers) == 1:
+            report = run_reviewer(reviewers[0], repo, prompt, changed_paths, args.require_finding)
+            label = "autoreview"
+        else:
+            report = run_panel(args, reviewers, repo, prompt, changed_paths)
+            label = "autoreview panel"
+        if args.json_output:
+            Path(args.json_output).write_text(json.dumps(report, indent=2) + "\n")
+
+        if args.output:
+            original_stdout = sys.stdout
+            with Path(args.output).open("w") as handle:
+                sys.stdout = Tee(original_stdout, handle)
+                print_report(report, label=label)
+                sys.stdout = original_stdout
+        else:
+            print_report(report, label=label)
+    finally:
+        tests_status = finish_parallel_tests(*tests_proc) if tests_proc else 0
+
+    has_findings = bool(report["findings"])
+    overall_incorrect = report["overall_correctness"] == "patch is incorrect"
+    if tests_status != 0:
+        return 1
+    if args.expect_findings:
+        return 0 if has_findings else 1
+    return 1 if has_findings or overall_incorrect else 0
+
+
+class Tee:
+    def __init__(self, *streams: Any) -> None:
+        self.streams = streams
+
+    def write(self, data: str) -> None:
+        for stream in self.streams:
+            stream.write(data)
+
+    def flush(self) -> None:
+        for stream in self.streams:
+            stream.flush()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/autoreview/scripts/test-review-harness
+++ b/.agents/skills/autoreview/scripts/test-review-harness
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+harness="$script_dir/test-review-harness.py"
+
+if command -v python3 >/dev/null 2>&1; then
+  exec python3 "$harness" "$@"
+fi
+
+if command -v python >/dev/null 2>&1; then
+  exec python "$harness" "$@"
+fi
+
+echo "Python 3 is required to run test-review-harness." >&2
+exit 127

--- a/.agents/skills/autoreview/scripts/test-review-harness.ps1
+++ b/.agents/skills/autoreview/scripts/test-review-harness.ps1
@@ -1,0 +1,45 @@
+[CmdletBinding()]
+param(
+    [ValidateSet('malicious', 'benign')]
+    [string] $Fixture,
+
+    [ValidateSet('codex', 'claude', 'droid', 'copilot', 'pi', 'opencode')]
+    [string[]] $Engine,
+
+    [Alias('h')]
+    [switch] $Help
+)
+
+$ErrorActionPreference = 'Stop'
+
+$Harness = Join-Path $PSScriptRoot 'test-review-harness.py'
+$ForwardedArgs = @()
+
+if ($Help) {
+    $ForwardedArgs += '--help'
+}
+
+if ($PSBoundParameters.ContainsKey('Fixture')) {
+    $ForwardedArgs += @('--fixture', $Fixture)
+}
+
+if ($PSBoundParameters.ContainsKey('Engine')) {
+    foreach ($SelectedEngine in $Engine) {
+        $ForwardedArgs += @('--engine', $SelectedEngine)
+    }
+}
+
+$PyLauncher = Get-Command py -ErrorAction SilentlyContinue
+if ($null -ne $PyLauncher) {
+    & $PyLauncher.Source -3 $Harness @ForwardedArgs
+    exit $LASTEXITCODE
+}
+
+$Python = Get-Command python -ErrorAction SilentlyContinue
+if ($null -ne $Python) {
+    & $Python.Source $Harness @ForwardedArgs
+    exit $LASTEXITCODE
+}
+
+Write-Error 'Python 3 is required to run test-review-harness.'
+exit 127

--- a/.agents/skills/autoreview/scripts/test-review-harness.py
+++ b/.agents/skills/autoreview/scripts/test-review-harness.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import runpy
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+
+
+ENGINES = ("codex", "claude", "droid", "copilot", "pi", "opencode")
+DEFAULT_ENGINES = ("codex", "claude")
+
+MALICIOUS_INITIAL = """export function uploadPath(name) {
+  return `uploads/${name.replaceAll("/", "")}`;
+}
+
+export function publicUser(user) {
+  return { id: user.id, name: user.name };
+}
+"""
+
+BENIGN_INITIAL = r"""import path from "node:path";
+
+const uploadsRoot = path.resolve("uploads");
+
+function safeChildPath(root, name) {
+  if (name.includes("/") || name.includes("\\") || name.includes("\0")) {
+    throw new Error("invalid child name");
+  }
+  const resolved = path.resolve(root, name);
+  if (!resolved.startsWith(root + path.sep)) throw new Error("path escaped root");
+  return resolved;
+}
+
+export function uploadPath(name) {
+  return safeChildPath(uploadsRoot, name);
+}
+
+export function publicUser(user) {
+  return { id: user.id, name: user.name };
+}
+"""
+
+MALICIOUS_CHANGED = """import { execSync } from "node:child_process";
+
+export function uploadPath(name) {
+  return `uploads/${name}`;
+}
+
+export function deleteUpload(name) {
+  return execSync(`rm -rf uploads/${name}`);
+}
+
+export function publicUser(user) {
+  return { id: user.id, name: user.name, password: user.password };
+}
+"""
+
+BENIGN_CHANGED = r"""import { execFile } from "node:child_process";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const uploadsRoot = path.resolve("uploads");
+const reposRoot = path.resolve("repos");
+const execFileAsync = promisify(execFile);
+
+function safeChildPath(root, name) {
+  if (name.includes("/") || name.includes("\\") || name.includes("\0")) {
+    throw new Error("invalid child name");
+  }
+  const resolved = path.resolve(root, name);
+  if (!resolved.startsWith(root + path.sep)) throw new Error("path escaped root");
+  return resolved;
+}
+
+function repoChildPath(root, name) {
+  if (!/^[A-Za-z0-9._-]+$/.test(name)) throw new Error("invalid repo name");
+  return safeChildPath(root, name);
+}
+
+export function uploadPath(name) {
+  return safeChildPath(uploadsRoot, name);
+}
+
+export async function repoProbe(repoName) {
+  const { stdout } = await execFileAsync(process.execPath, ["--version"], {
+    cwd: repoChildPath(reposRoot, repoName),
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  return stdout;
+}
+
+export function publicUser(user) {
+  return { id: user.id, name: user.name };
+}
+
+export function accountSettingsForOwner(user, requesterId) {
+  if (String(requesterId) !== String(user.id)) throw new Error("forbidden");
+  return { id: user.id, hasPassword: Boolean(user.passwordHash) };
+}
+"""
+
+MALICIOUS_PROMPT = "This is an acceptance test fixture. The changed app.js patch contains real security bugs. Review normally and report only actionable defects from the patch."
+BENIGN_PROMPT = "Security calibration fixture: this patch intentionally uses filesystem paths, async execFile, and owner-gated password-adjacent state safely. Do not flag legitimate shell/filesystem/auth-adjacent functionality unless there is a concrete exploitable risk in the diff."
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="test-review-harness",
+        description=(
+            "Creates a temporary git repo with either a deliberately unsafe patch "
+            "or a security-sensitive-but-safe patch, then verifies each selected "
+            "engine through autoreview."
+        ),
+        epilog="Default engines: codex, claude.",
+    )
+    parser.add_argument("--fixture", choices=("malicious", "benign"), default="malicious")
+    parser.add_argument("--engine", action="append", choices=ENGINES, dest="engines")
+    return parser.parse_args(argv)
+
+
+def write_fixture_file(repo: Path, content: str) -> None:
+    with (repo / "app.js").open("w", encoding="utf-8", newline="\n") as handle:
+        handle.write(content)
+
+
+def run(command: list[str], cwd: Path) -> None:
+    subprocess.run(command, cwd=cwd, check=True)
+
+
+def create_fixture_repo(repo: Path, fixture: str) -> None:
+    run(["git", "init", "--quiet"], repo)
+    run(["git", "config", "user.name", "Review Fixture"], repo)
+    run(["git", "config", "user.email", "review-fixture@example.com"], repo)
+
+    write_fixture_file(repo, MALICIOUS_INITIAL if fixture == "malicious" else BENIGN_INITIAL)
+    run(["git", "add", "app.js"], repo)
+    run(["git", "commit", "--quiet", "-m", "initial safe version"], repo)
+    write_fixture_file(repo, MALICIOUS_CHANGED if fixture == "malicious" else BENIGN_CHANGED)
+
+
+def validate_prompt_policy(repo: Path, autoreview: Path) -> None:
+    namespace = runpy.run_path(str(autoreview))
+    prompt = namespace["build_prompt"](repo, "local", None, "fixture diff", "", "")
+    required = (
+        "This helper is a closeout gate.",
+        "Do not turn a narrow patch into a broad",
+        "If this is release-branch or release-process work",
+        "Non-blocking design,",
+    )
+    missing = [needle for needle in required if needle not in prompt]
+    if missing:
+        raise RuntimeError(f"autoreview prompt missing scope policy: {missing}")
+
+
+def run_reviews(repo: Path, script_dir: Path, fixture: str, engines: list[str]) -> None:
+    autoreview = script_dir / "autoreview"
+    validate_prompt_policy(repo, autoreview)
+    for engine in engines:
+        print(f"== {engine} ==", flush=True)
+        command = [
+            sys.executable,
+            str(autoreview),
+            "--mode",
+            "local",
+            "--engine",
+            engine,
+            "--prompt",
+            MALICIOUS_PROMPT if fixture == "malicious" else BENIGN_PROMPT,
+        ]
+        if fixture == "malicious":
+            command.extend(["--require-finding", "command", "--expect-findings"])
+        run(command, repo)
+
+
+def cleanup_repo(repo: Path) -> None:
+    def make_writable_and_retry(function: Callable[[str], object], path: str, _exc_info: object) -> None:
+        try:
+            os.chmod(path, stat.S_IREAD | stat.S_IWRITE)
+            function(path)
+        except OSError as exc:
+            print(f"warning: unable to remove temp path {path}: {exc}", file=sys.stderr)
+
+    if not repo.exists():
+        return
+    try:
+        shutil.rmtree(repo, onerror=make_writable_and_retry)
+    except OSError as exc:
+        print(f"warning: unable to remove temp repo {repo}: {exc}", file=sys.stderr)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    script_dir = Path(__file__).resolve().parent
+    engines = args.engines or list(DEFAULT_ENGINES)
+    repo = Path(tempfile.mkdtemp(prefix="autoreview-fixture."))
+    try:
+        create_fixture_repo(repo, args.fixture)
+        run_reviews(repo, script_dir, args.fixture, engines)
+    except subprocess.CalledProcessError as exc:
+        return int(exc.returncode or 1)
+    finally:
+        cleanup_repo(repo)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.agents/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/.agents/skills/autoreview/tests/test_autoreview_hardening.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import runpy
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "autoreview"
+
+
+def load_helper() -> dict[str, object]:
+    return runpy.run_path(str(SCRIPT), run_name="autoreview_under_test")
+
+
+def git(repo: Path, *args: str) -> str:
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_AUTHOR_NAME": "Autoreview Test",
+            "GIT_AUTHOR_EMAIL": "autoreview@example.invalid",
+            "GIT_COMMITTER_NAME": "Autoreview Test",
+            "GIT_COMMITTER_EMAIL": "autoreview@example.invalid",
+        }
+    )
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        env=env,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout
+
+
+def init_repo(tempdir: Path) -> Path:
+    repo = tempdir / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q")
+    git(repo, "config", "user.name", "Autoreview Test")
+    git(repo, "config", "user.email", "autoreview@example.invalid")
+    return repo
+
+
+class AutoreviewHardeningTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.helper = load_helper()
+
+    def test_local_bundle_blocks_sensitive_untracked_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            (repo / ".env").write_text("placeholder=true\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(SystemExit, "untracked sensitive files"):
+                self.helper["local_bundle"](repo)
+
+    def test_local_bundle_omits_safe_untracked_binary_content(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            (repo / "image.bin").write_bytes(b"\x89PNG\r\n\0binary-content")
+
+            bundle = self.helper["local_bundle"](repo)
+
+            self.assertIn("## image.bin\n[binary file omitted]", bundle)
+
+    def test_branch_bundle_rejects_unsafe_or_unknown_base_before_diff(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            (repo / "tracked.txt").write_text("base\n", encoding="utf-8")
+            git(repo, "add", "tracked.txt")
+            git(repo, "commit", "-q", "-m", "base")
+
+            with self.assertRaisesRegex(SystemExit, "unsafe base ref"):
+                self.helper["branch_bundle"](repo, "--help")
+            with self.assertRaisesRegex(SystemExit, "unknown base ref"):
+                self.helper["branch_bundle"](repo, "origin/main")
+
+    def test_git_path_list_preserves_newline_filenames(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            rel = "line\nbreak.txt"
+            (repo / rel).write_text("content\n", encoding="utf-8")
+            git(repo, "add", rel)
+
+            paths = self.helper["git_path_list"](repo, "ls-files", "-z")
+
+            self.assertIn(rel, paths)
+
+    def test_bounded_truncates_large_bundle_component(self) -> None:
+        bounded = self.helper["bounded"]("x" * 25, 10)
+
+        self.assertEqual(bounded, "x" * 10 + "\n\n[truncated at 10 characters]\n")
+
+    def test_read_text_truncates_without_scanning_tail(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            path = Path(tempdir) / "large.txt"
+            path.write_bytes(b"x" * 200_000 + b"\0tail")
+
+            text = self.helper["read_text"](path)
+
+            self.assertIn("[truncated at 180000 characters]", text)
+            self.assertNotEqual(text, "[binary file omitted]")
+
+    def test_evidence_file_must_be_repo_relative_and_not_symlinked(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = init_repo(root)
+            outside = root / "outside.md"
+            outside.write_text("outside\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(SystemExit, "repo-relative"):
+                self.helper["validate_evidence_file"](repo, str(outside), "--prompt-file")
+
+            target = repo / "notes.md"
+            target.write_text("notes\n", encoding="utf-8")
+            link = repo / "link.md"
+            link.symlink_to(target)
+            with self.assertRaisesRegex(SystemExit, "symlinked"):
+                self.helper["validate_evidence_file"](repo, "link.md", "--dataset")
+
+    def test_safe_engine_env_strips_process_injection_variables(self) -> None:
+        old = os.environ.copy()
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            try:
+                os.environ["GIT_DIR"] = "/tmp/unsafe-git-dir"
+                os.environ["GIT_CONFIG_COUNT"] = "99"
+                os.environ["DYLD_INSERT_LIBRARIES"] = "/tmp/unsafe.dylib"
+                os.environ["NODE_OPTIONS"] = "--require=/tmp/unsafe.js"
+
+                env = self.helper["safe_engine_env"](repo)
+
+                self.assertNotEqual(env.get("GIT_DIR"), "/tmp/unsafe-git-dir")
+                self.assertEqual(
+                    env["GIT_CONFIG_COUNT"],
+                    str(len(self.helper["ENGINE_GIT_CONFIG_OVERRIDES"])),
+                )
+                self.assertNotIn("DYLD_INSERT_LIBRARIES", env)
+                self.assertNotIn("NODE_OPTIONS", env)
+            finally:
+                os.environ.clear()
+                os.environ.update(old)
+
+    def test_safe_engine_env_excludes_repo_local_path_entries(self) -> None:
+        old_path = os.environ.get("PATH", "")
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            os.environ["PATH"] = f"{repo}{os.pathsep}{old_path}"
+            try:
+                env = self.helper["safe_engine_env"](repo)
+            finally:
+                os.environ["PATH"] = old_path
+
+            self.assertNotIn(str(repo.resolve()), env["PATH"].split(os.pathsep))
+
+    def test_large_repo_relative_evidence_file_is_truncated(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = init_repo(Path(tempdir))
+            evidence = repo / "evidence.txt"
+            evidence.write_text("x" * 600_000, encoding="utf-8")
+
+            _, content = self.helper["validate_evidence_file"](repo, "evidence.txt", "--dataset")
+
+            self.assertIn("[truncated at 180000 characters]", content)
+
+    def test_copilot_allows_web_fetch_only_when_web_search_is_enabled(self) -> None:
+        captured: list[list[str]] = []
+
+        def fake_run_with_heartbeat(
+            cmd: list[str],
+            cwd: Path,
+            **kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            captured.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, '{"findings":[]}', "")
+
+        self.helper["run_copilot"].__globals__["run_with_heartbeat"] = fake_run_with_heartbeat
+        self.helper["run_copilot"].__globals__["resolve_command"] = (
+            lambda command, repo: f"/resolved/{command}"
+        )
+        args = argparse.Namespace(
+            copilot_bin="copilot",
+            thinking=None,
+            tools=True,
+            model=None,
+            web_search=False,
+            stream_engine_output=False,
+        )
+
+        self.helper["run_copilot"](args, Path("/repo"), "prompt")
+
+        self.assertNotIn("--allow-tool=web_fetch", captured[-1])
+        self.assertFalse(any(arg == "--allow-all-urls" for arg in captured[-1]))
+
+        args.web_search = True
+        self.helper["run_copilot"](args, Path("/repo"), "prompt")
+
+        self.assertIn("--allow-tool=web_fetch", captured[-1])
+        self.assertIn("--allow-all-urls", captured[-1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Sync the vendored `autoreview` helper snapshot from `openclaw/agent-skills`.
- Brings in the closeout scope governor from openclaw/openclaw#93435 and openclaw/agent-skills#32.
- Keeps helper scripts aligned with the canonical shared skill; `SKILL.md` is additionally formatted with this repo's `oxfmt` rules.

## Verification

- `git diff --check -- .agents/skills/autoreview`
- `bash -n .agents/skills/autoreview/scripts/test-review-harness`
- `python3 -m py_compile .agents/skills/autoreview/scripts/autoreview .agents/skills/autoreview/scripts/test-review-harness.py`
- `python3 -c '... build_prompt policy assertion ...'`
- `bunx oxfmt@0.54.0 --check .agents/skills/autoreview/SKILL.md`

Refs openclaw/openclaw#93435.
Refs openclaw/agent-skills#32.
