### PR TITLE
Floor skill stat drain batch size

### DIFF
--- a/convex/skillStatEvents.test.ts
+++ b/convex/skillStatEvents.test.ts
@@ -19,7 +19,8 @@ vi.mock("./_generated/api", () => ({
   },
 }));
 
-const { processSkillStatEventBatchInternal } = await import("./skillStatEvents");
+const { processSkillStatEventBatchInternal, processSkillStatEventsInternal } =
+  await import("./skillStatEvents");
 
 const processSkillStatEventBatchInternalHandler = (
   processSkillStatEventBatchInternal as unknown as {
@@ -27,6 +28,15 @@ const processSkillStatEventBatchInternalHandler = (
       ctx: unknown,
       args: { batchSize?: number; leaseOwner: string },
     ) => Promise<{ processed: number }>;
+  }
+)._handler;
+
+const processSkillStatEventsInternalHandler = (
+  processSkillStatEventsInternal as unknown as {
+    _handler: (
+      ctx: unknown,
+      args: { batchSize?: number; maxBatches?: number },
+    ) => Promise<{ processed: number; scheduledContinuation: boolean }>;
   }
 )._handler;
 
@@ -110,6 +120,40 @@ describe("skill stat events - comment delta handling", () => {
       "skillStatDocSyncLeases:1",
       expect.objectContaining({ lastProcessedCount: 1 }),
     );
+  });
+
+  it("floors action drain batch size so stale small continuations do not crawl", async () => {
+    const runMutation = vi.fn(async (_ref: unknown, args: Record<string, unknown>) => {
+      if ("leaseMs" in args) {
+        return {
+          acquired: true,
+          leaseOwner: "test-lease",
+          leaseExpiresAt: Date.now() + 60_000,
+          now: Date.now(),
+        };
+      }
+      if ("leaseOwner" in args && "batchSize" in args) {
+        return { processed: 100, skillsUpdated: 1, hasMore: true };
+      }
+      if ("processed" in args) {
+        return { released: true };
+      }
+      throw new Error(`unexpected mutation args ${JSON.stringify(args)}`);
+    });
+    const scheduler = { runAfter: vi.fn() };
+
+    await expect(
+      processSkillStatEventsInternalHandler(
+        { runMutation, scheduler },
+        { batchSize: 10, maxBatches: 1 },
+      ),
+    ).resolves.toMatchObject({
+      processed: 100,
+      scheduledContinuation: true,
+    });
+
+    expect(runMutation.mock.calls[1]?.[1]).toMatchObject({ batchSize: 100 });
+    expect(scheduler.runAfter.mock.calls[0]?.[2]).toMatchObject({ batchSize: 100 });
   });
 
   it("aggregates comment and uncomment events into net deltas", () => {

--- a/convex/skillStatEvents.ts
+++ b/convex/skillStatEvents.ts
@@ -233,6 +233,14 @@ function normalizeDocSyncBatchSize(batchSize: number | undefined) {
   return clampInt(batchSize ?? DEFAULT_DOC_SYNC_BATCH_SIZE, 1, MAX_DOC_SYNC_BATCH_SIZE);
 }
 
+function normalizeDocSyncDrainBatchSize(batchSize: number | undefined) {
+  return clampInt(
+    batchSize ?? DEFAULT_DOC_SYNC_BATCH_SIZE,
+    DEFAULT_DOC_SYNC_BATCH_SIZE,
+    MAX_DOC_SYNC_BATCH_SIZE,
+  );
+}
+
 function normalizeDocSyncMaxBatches(maxBatches: number | undefined) {
   return clampInt(maxBatches ?? DEFAULT_DOC_SYNC_MAX_BATCHES, 1, MAX_DOC_SYNC_MAX_BATCHES);
 }
@@ -447,7 +455,9 @@ export const processSkillStatEventsInternal: ReturnType<typeof internalAction> =
     maxBatches: v.optional(v.number()),
   },
   handler: async (ctx, args): Promise<SkillStatDocSyncActionResult> => {
-    const batchSize = normalizeDocSyncBatchSize(args.batchSize);
+    // Older scheduled continuations may carry a tiny batch size. Floor action
+    // drains to the production batch size so stale jobs cannot crawl forever.
+    const batchSize = normalizeDocSyncDrainBatchSize(args.batchSize);
     const maxBatches = normalizeDocSyncMaxBatches(args.maxBatches);
     const claim: ClaimSkillStatDocSyncLeaseResult = await ctx.runMutation(
       internal.skillStatEvents.claimSkillStatDocSyncLeaseInternal,
@@ -530,7 +540,7 @@ export const kickSkillStatDocSyncInternal = internalMutation({
     maxBatches: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const batchSize = normalizeDocSyncBatchSize(args.batchSize);
+    const batchSize = normalizeDocSyncDrainBatchSize(args.batchSize);
     const maxBatches = normalizeDocSyncMaxBatches(args.maxBatches);
     await ctx.scheduler.runAfter(0, internal.skillStatEvents.processSkillStatEventsInternal, {
       batchSize,


### PR DESCRIPTION
## Summary

- Floor skill document stat drain action/kick batch sizes to the production batch size.
- Prevent legacy queued continuations carrying tiny `batchSize` values from self-scheduling slow drains forever.
- Add a regression test for `batchSize: 10` being normalized to `100` at the action boundary.

## Validation

- `bun test convex/skillStatEvents.test.ts`
- `bun run format:check -- convex/skillStatEvents.ts convex/skillStatEvents.test.ts`
- `bunx tsc --noEmit --pretty false`
- `bun run ci:static`
- `bun run ci:unit`
- `bunx convex dev --once --typecheck=disable`
- `codex review --uncommitted`
