### PR TITLE
fix: set GitHub scan upload content type

### DIFF
--- a/convex/githubSkillSync.test.ts
+++ b/convex/githubSkillSync.test.ts
@@ -1968,7 +1968,7 @@ describe("verifyGitHubSkillHandler", () => {
 
     const events: string[] = [];
     let storedFile = 0;
-    const store = vi.fn(async () => {
+    const store = vi.fn(async (_blob: Blob) => {
       events.push("store");
       storedFile += 1;
       return `storage:${storedFile}`;
@@ -2043,6 +2043,7 @@ describe("verifyGitHubSkillHandler", () => {
 
     expect(result).toMatchObject({ ok: true, queued: true });
     expect(store).toHaveBeenCalledTimes(2);
+    expect((store.mock.calls[0]?.[0] as Blob | undefined)?.type).toBe("application/octet-stream");
     expect(runMutation).toHaveBeenCalledTimes(3);
     expect(events).toEqual(["prepare", "store", "store", "append", "finalize"]);
     const [prepareMutation, prepareArgs] = runMutation.mock.calls[0] ?? [];

--- a/convex/githubSkillSync.ts
+++ b/convex/githubSkillSync.ts
@@ -1383,7 +1383,9 @@ async function storeGitHubSkillScanFileChunks(
     for (const [path, bytes] of listGitHubSkillFolderEntries(entries, folderPath)) {
       const safeBytes = new Uint8Array(bytes);
       const sha256 = await sha256Hex(safeBytes);
-      const storageId = await ctx.storage.store(new Blob([safeBytes]));
+      const storageId = await ctx.storage.store(
+        new Blob([safeBytes], { type: "application/octet-stream" }),
+      );
       const file = {
         path,
         size: safeBytes.byteLength,


### PR DESCRIPTION
## Summary
- store GitHub scan request files with a valid content type
- assert the verifier uploads scan files as application/octet-stream

## Tests
- bunx vitest run convex/githubSkillSync.test.ts
- bun run ci:static
- bun run ci:types-build

## Context
Production forced NVIDIA GitHub scan recovery reached storage upload but failed with BadHeader for an empty content-type. This patch gives the Blob a valid application/octet-stream type without changing bytes.