### PR TITLE
Harden package install metrics cleanup

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -11455,6 +11455,70 @@ describe("httpApiV1 handlers", () => {
     );
   });
 
+  it("npm mirror tarball downloads skip install metrics without a trusted identity", async () => {
+    const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
+      if ("name" in args && !("paginationOpts" in args)) {
+        return {
+          package: {
+            _id: "packages:demo-plugin",
+            name: "demo-plugin",
+            displayName: "Demo Plugin",
+            family: "code-plugin",
+            tags: { latest: "packageReleases:1" },
+            latestReleaseId: "packageReleases:1",
+            channel: "community",
+            isOfficial: false,
+            summary: "Demo package",
+            createdAt: 1,
+            updatedAt: 1,
+          },
+          latestRelease: null,
+          owner: null,
+        };
+      }
+      if ("paginationOpts" in args) {
+        return {
+          page: [
+            {
+              _id: "packageReleases:1",
+              packageId: "packages:demo-plugin",
+              version: "1.0.0",
+              createdAt: 1,
+              changelog: "Initial release",
+              distTags: ["latest"],
+              files: [],
+              artifactKind: "npm-pack",
+              clawpackStorageId: "storage:clawpack",
+              npmIntegrity: "sha512-demo",
+              npmShasum: "d".repeat(40),
+              npmTarballName: "demo-plugin-1.0.0.tgz",
+            },
+          ],
+          isDone: true,
+          continueCursor: null,
+        };
+      }
+      return null;
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.npmMirrorGetHandler(
+      makeCtx({
+        runQuery,
+        runMutation,
+        storage: {
+          get: vi.fn(async () => new Blob(["tarball"], { type: "application/octet-stream" })),
+        },
+      }),
+      new Request("https://example.com/api/npm/demo-plugin/-/demo-plugin-1.0.0.tgz"),
+    );
+
+    expect(response.status).toBe(200);
+    const calledMutationRefs = runMutation.mock.calls.map(([mutation]) => mutation);
+    expect(calledMutationRefs).not.toContain(internal.packages.recordPackageInstallInternal);
+    expect(calledMutationRefs).not.toContain(internal.downloadMetrics.recordDownloadMetricInternal);
+  });
+
   it("npm mirror returns not found for invalid package lookup names", async () => {
     const runQuery = vi.fn(async () => {
       throw new Error("unexpected package lookup");

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -770,17 +770,13 @@ async function streamClawPackRelease(
           now,
         })
       : null;
-    if (statKind === "install") {
+    if (statKind === "install" && metricArgs) {
       await runMutationRef(ctx, internalRefs.packages.recordPackageInstallInternal, {
         packageId: pkg._id,
-        ...(metricArgs
-          ? {
-              identityKind: metricArgs.identityKind,
-              identityHash: metricArgs.identityHash,
-              dayStart: metricArgs.dayStart,
-              occurredAt: metricArgs.occurredAt,
-            }
-          : {}),
+        identityKind: metricArgs.identityKind,
+        identityHash: metricArgs.identityHash,
+        dayStart: metricArgs.dayStart,
+        occurredAt: metricArgs.occurredAt,
       });
     }
 

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -12495,11 +12495,11 @@ describe("owned package sanction batches", () => {
     expect(deleteDoc).toHaveBeenCalledWith("packages:demo");
   });
 
-  it("bounds install metric dedupe cleanup during package hard delete", async () => {
+  it("continues install metric dedupe cleanup before package hard delete finalizes", async () => {
     const packageInstallMetricDedupes = Array.from({ length: 201 }, (_, index) => ({
       _id: `packageInstallMetricDedupes:${index}`,
     }));
-    const { ctx, deleteDoc, installDedupeTake } = makeOwnedPackageBatchCtx({
+    const { ctx, deleteDoc, installDedupeTake, runAfter } = makeOwnedPackageBatchCtx({
       packageInstallMetricDedupes,
     });
 
@@ -12510,12 +12510,23 @@ describe("owned package sanction batches", () => {
       source: "account.delete",
     });
 
-    expect(result).toMatchObject({ ok: true, packageId: "packages:demo", deleted: true });
+    expect(result).toMatchObject({
+      ok: true,
+      packageId: "packages:demo",
+      deleted: false,
+      cleanupPending: true,
+    });
     expect(installDedupeTake).toHaveBeenCalledWith(200);
     expect(deleteDoc).toHaveBeenCalledWith("packageInstallMetricDedupes:0");
     expect(deleteDoc).toHaveBeenCalledWith("packageInstallMetricDedupes:199");
     expect(deleteDoc).not.toHaveBeenCalledWith("packageInstallMetricDedupes:200");
-    expect(deleteDoc).toHaveBeenCalledWith("packages:demo");
+    expect(deleteDoc).not.toHaveBeenCalledWith("packages:demo");
+    expect(runAfter).toHaveBeenCalledWith(0, expect.anything(), {
+      packageId: "packages:demo",
+      actorUserId: "users:owner",
+      deletedAt: 3_000,
+      source: "account.delete",
+    });
   });
 
   it("schedules hard deletes for account-deleted packages owned through the user's personal publisher", async () => {

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -50,6 +50,7 @@ import {
   applyAccountDeletionToOwnedPackagesBatchInternal,
   applyPublisherDeletionToOwnedPackagesBatchInternal,
   applyBanToOwnedPackagesBatchInternal,
+  hardDeletePackageInternal,
   revokePackagePublishTokensForPackageBatchInternal,
   restoreOwnedPackagesForUnbanBatchInternal,
   softDeletePackageInternal,
@@ -780,6 +781,17 @@ const softDeletePackageInternalHandler = (
       releaseCount: number;
       alreadyDeleted: boolean;
     }
+  >
+)._handler;
+const hardDeletePackageInternalHandler = (
+  hardDeletePackageInternal as unknown as WrappedHandler<
+    {
+      packageId: string;
+      actorUserId: string;
+      deletedAt: number;
+      source: "account.delete" | "publisher.delete";
+    },
+    { ok: true; packageId?: string; deleted: boolean; alreadyDeleted?: boolean }
   >
 )._handler;
 const applyBanToOwnedPackagesBatchInternalHandler = (
@@ -11558,6 +11570,7 @@ function makeOwnedPackageBatchCtx(options?: {
   pkg?: Record<string, unknown>;
   owner?: Record<string, unknown> | null;
   packageTokens?: Array<Record<string, unknown>>;
+  packageInstallMetricDedupes?: Array<Record<string, unknown>>;
   releases?: Array<Record<string, unknown>>;
   publisherPackages?: Array<Record<string, unknown>>;
   publishers?: Record<string, Record<string, unknown> | null>;
@@ -11578,11 +11591,13 @@ function makeOwnedPackageBatchCtx(options?: {
   ];
   const patch = vi.fn();
   const insert = vi.fn().mockResolvedValue("auditLogs:1");
+  const deleteDoc = vi.fn();
   const runAfter = vi.fn();
 
   return {
     patch,
     insert,
+    deleteDoc,
     runAfter,
     ctx: {
       scheduler: { runAfter },
@@ -11601,6 +11616,7 @@ function makeOwnedPackageBatchCtx(options?: {
               ? { _id: "users:owner", deletedAt: undefined, deactivatedAt: undefined }
               : options.owner;
           }
+          if (id === pkg._id) return pkg;
           if (options?.publishers && id in options.publishers) {
             return options.publishers[id];
           }
@@ -11669,6 +11685,7 @@ function makeOwnedPackageBatchCtx(options?: {
                   };
                   builder?.(queryBuilder);
                   return {
+                    collect: vi.fn(async () => packageTokens),
                     order: vi.fn(() => ({
                       take: vi.fn(async (limit: number) =>
                         packageTokens
@@ -11689,6 +11706,28 @@ function makeOwnedPackageBatchCtx(options?: {
             return {
               withIndex: vi.fn(() => ({
                 collect: vi.fn().mockResolvedValue(releases),
+              })),
+            };
+          }
+          if (
+            table === "securityScanJobs" ||
+            table === "packageReports" ||
+            table === "packageAppeals" ||
+            table === "packageBadges" ||
+            table === "packageTrustedPublishers" ||
+            table === "packagePublishUploadTickets" ||
+            table === "packageStatEvents"
+          ) {
+            return {
+              withIndex: vi.fn(() => ({
+                collect: vi.fn().mockResolvedValue([]),
+              })),
+            };
+          }
+          if (table === "packageInstallMetricDedupes") {
+            return {
+              withIndex: vi.fn(() => ({
+                collect: vi.fn().mockResolvedValue(options?.packageInstallMetricDedupes ?? []),
               })),
             };
           }
@@ -11720,7 +11759,7 @@ function makeOwnedPackageBatchCtx(options?: {
         insert,
         patch,
         replace: vi.fn(),
-        delete: vi.fn(),
+        delete: deleteDoc,
         normalizeId: vi.fn(),
       },
     },
@@ -12428,6 +12467,27 @@ describe("owned package sanction batches", () => {
       deletedAt: 3_000,
       source: "account.delete",
     });
+  });
+
+  it("deletes package install dedupe rows during package hard delete", async () => {
+    const { ctx, deleteDoc } = makeOwnedPackageBatchCtx({
+      packageInstallMetricDedupes: [
+        { _id: "packageInstallMetricDedupes:one" },
+        { _id: "packageInstallMetricDedupes:two" },
+      ],
+    });
+
+    const result = await hardDeletePackageInternalHandler(ctx as never, {
+      packageId: "packages:demo",
+      actorUserId: "users:owner",
+      deletedAt: 3_000,
+      source: "account.delete",
+    });
+
+    expect(result).toMatchObject({ ok: true, packageId: "packages:demo", deleted: true });
+    expect(deleteDoc).toHaveBeenCalledWith("packageInstallMetricDedupes:one");
+    expect(deleteDoc).toHaveBeenCalledWith("packageInstallMetricDedupes:two");
+    expect(deleteDoc).toHaveBeenCalledWith("packages:demo");
   });
 
   it("schedules hard deletes for account-deleted packages owned through the user's personal publisher", async () => {

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -12520,6 +12520,8 @@ describe("owned package sanction batches", () => {
     expect(deleteDoc).toHaveBeenCalledWith("packageInstallMetricDedupes:0");
     expect(deleteDoc).toHaveBeenCalledWith("packageInstallMetricDedupes:199");
     expect(deleteDoc).not.toHaveBeenCalledWith("packageInstallMetricDedupes:200");
+    expect(deleteDoc).not.toHaveBeenCalledWith("packagePublishTokens:demo");
+    expect(deleteDoc).not.toHaveBeenCalledWith("packageReleases:demo-1");
     expect(deleteDoc).not.toHaveBeenCalledWith("packages:demo");
     expect(runAfter).toHaveBeenCalledWith(0, expect.anything(), {
       packageId: "packages:demo",

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -11593,12 +11593,16 @@ function makeOwnedPackageBatchCtx(options?: {
   const insert = vi.fn().mockResolvedValue("auditLogs:1");
   const deleteDoc = vi.fn();
   const runAfter = vi.fn();
+  const installDedupeTake = vi.fn(async (limit: number) =>
+    (options?.packageInstallMetricDedupes ?? []).slice(0, limit),
+  );
 
   return {
     patch,
     insert,
     deleteDoc,
     runAfter,
+    installDedupeTake,
     ctx: {
       scheduler: { runAfter },
       db: {
@@ -11727,7 +11731,7 @@ function makeOwnedPackageBatchCtx(options?: {
           if (table === "packageInstallMetricDedupes") {
             return {
               withIndex: vi.fn(() => ({
-                collect: vi.fn().mockResolvedValue(options?.packageInstallMetricDedupes ?? []),
+                take: installDedupeTake,
               })),
             };
           }
@@ -12470,7 +12474,7 @@ describe("owned package sanction batches", () => {
   });
 
   it("deletes package install dedupe rows during package hard delete", async () => {
-    const { ctx, deleteDoc } = makeOwnedPackageBatchCtx({
+    const { ctx, deleteDoc, installDedupeTake } = makeOwnedPackageBatchCtx({
       packageInstallMetricDedupes: [
         { _id: "packageInstallMetricDedupes:one" },
         { _id: "packageInstallMetricDedupes:two" },
@@ -12485,8 +12489,32 @@ describe("owned package sanction batches", () => {
     });
 
     expect(result).toMatchObject({ ok: true, packageId: "packages:demo", deleted: true });
+    expect(installDedupeTake).toHaveBeenCalledWith(200);
     expect(deleteDoc).toHaveBeenCalledWith("packageInstallMetricDedupes:one");
     expect(deleteDoc).toHaveBeenCalledWith("packageInstallMetricDedupes:two");
+    expect(deleteDoc).toHaveBeenCalledWith("packages:demo");
+  });
+
+  it("bounds install metric dedupe cleanup during package hard delete", async () => {
+    const packageInstallMetricDedupes = Array.from({ length: 201 }, (_, index) => ({
+      _id: `packageInstallMetricDedupes:${index}`,
+    }));
+    const { ctx, deleteDoc, installDedupeTake } = makeOwnedPackageBatchCtx({
+      packageInstallMetricDedupes,
+    });
+
+    const result = await hardDeletePackageInternalHandler(ctx as never, {
+      packageId: "packages:demo",
+      actorUserId: "users:owner",
+      deletedAt: 3_000,
+      source: "account.delete",
+    });
+
+    expect(result).toMatchObject({ ok: true, packageId: "packages:demo", deleted: true });
+    expect(installDedupeTake).toHaveBeenCalledWith(200);
+    expect(deleteDoc).toHaveBeenCalledWith("packageInstallMetricDedupes:0");
+    expect(deleteDoc).toHaveBeenCalledWith("packageInstallMetricDedupes:199");
+    expect(deleteDoc).not.toHaveBeenCalledWith("packageInstallMetricDedupes:200");
     expect(deleteDoc).toHaveBeenCalledWith("packages:demo");
   });
 

--- a/convex/packages.stats.test.ts
+++ b/convex/packages.stats.test.ts
@@ -23,10 +23,10 @@ const recordInstallHandler = (
   recordPackageInstallInternal as unknown as WrappedHandler<
     {
       packageId: string;
-      identityKind?: "user" | "ip";
-      identityHash?: string;
-      dayStart?: number;
-      occurredAt?: number;
+      identityKind: "user" | "ip";
+      identityHash: string;
+      dayStart: number;
+      occurredAt: number;
     },
     void
   >
@@ -74,13 +74,21 @@ describe("package stat events", () => {
     );
   });
 
-  it("records installs as append-only events", async () => {
+  it("records identity-backed installs as append-only events", async () => {
     const insert = vi.fn();
+    const unique = vi.fn().mockResolvedValue(null);
+    const queryBuilder = {
+      eq: vi.fn(() => queryBuilder),
+    };
+    const withIndex = vi.fn((_indexName: string, buildQuery: (q: unknown) => unknown) => {
+      buildQuery(queryBuilder);
+      return { unique };
+    });
 
     await recordInstallHandler(
       {
         db: {
-          query: vi.fn(),
+          query: vi.fn(() => ({ withIndex })),
           get: vi.fn(),
           normalizeId: vi.fn(),
           insert,
@@ -95,6 +103,10 @@ describe("package stat events", () => {
       },
       {
         packageId: "packages:one",
+        identityKind: "ip",
+        identityHash: "hash-ip",
+        dayStart: 86_400_000,
+        occurredAt: 86_500_000,
       },
     );
 
@@ -103,6 +115,7 @@ describe("package stat events", () => {
       expect.objectContaining({
         packageId: "packages:one",
         kind: "install",
+        occurredAt: 86_500_000,
         processedAt: undefined,
       }),
     );

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -3987,7 +3987,7 @@ async function deletePackageModerationEventsForAppeal(
 }
 
 async function hardDeletePackageDoc(
-  ctx: Pick<MutationCtx, "db">,
+  ctx: Pick<MutationCtx, "db" | "scheduler">,
   pkg: Doc<"packages">,
   params: {
     actorUserId: Id<"users">;
@@ -4063,6 +4063,19 @@ async function hardDeletePackageDoc(
     )
     .take(MAX_PUBLIC_LIST_PAGE_SIZE);
   for (const installDedupe of installDedupes) await ctx.db.delete(installDedupe._id);
+  if (installDedupes.length === MAX_PUBLIC_LIST_PAGE_SIZE) {
+    await ctx.scheduler.runAfter(0, internal.packages.hardDeletePackageInternal, {
+      packageId: pkg._id,
+      actorUserId: params.actorUserId,
+      deletedAt: params.deletedAt,
+      source: params.source,
+    });
+    return {
+      ok: true as const,
+      packageId: pkg._id,
+      cleanupPending: true as const,
+    };
+  }
 
   for (const release of releases) await ctx.db.delete(release._id);
   await ctx.db.delete(pkg._id);
@@ -4108,6 +4121,7 @@ export const hardDeletePackageInternal = internalMutation({
       deletedAt: args.deletedAt,
       source: args.source,
     });
+    if ("cleanupPending" in result) return { ...result, deleted: false as const };
     return { ...result, deleted: true as const };
   },
 });

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -4061,7 +4061,7 @@ async function hardDeletePackageDoc(
     .withIndex("by_target_metric_identity_day", (q) =>
       q.eq("targetKind", "package").eq("targetId", pkg._id),
     )
-    .collect();
+    .take(MAX_PUBLIC_LIST_PAGE_SIZE);
   for (const installDedupe of installDedupes) await ctx.db.delete(installDedupe._id);
 
   for (const release of releases) await ctx.db.delete(release._id);

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -3643,45 +3643,40 @@ export const recordPackageDownloadInternal = internalMutation({
 export const recordPackageInstallInternal = internalMutation({
   args: {
     packageId: v.id("packages"),
-    identityKind: v.optional(v.union(v.literal("user"), v.literal("ip"))),
-    identityHash: v.optional(v.string()),
-    dayStart: v.optional(v.number()),
-    occurredAt: v.optional(v.number()),
+    identityKind: v.union(v.literal("user"), v.literal("ip")),
+    identityHash: v.string(),
+    dayStart: v.number(),
+    occurredAt: v.number(),
   },
   handler: async (ctx, args) => {
-    const identityKind = args.identityKind;
-    const identityHash = args.identityHash;
-    const dayStart = args.dayStart;
-    if (identityKind && identityHash && typeof dayStart === "number") {
-      const existing = await ctx.db
-        .query("packageInstallMetricDedupes")
-        .withIndex("by_target_metric_identity_day", (q) =>
-          q
-            .eq("targetKind", "package")
-            .eq("targetId", args.packageId)
-            .eq("metricKind", "install")
-            .eq("identityKind", identityKind)
-            .eq("identityHash", identityHash)
-            .eq("dayStart", dayStart),
-        )
-        .unique();
-      if (existing) return;
+    const existing = await ctx.db
+      .query("packageInstallMetricDedupes")
+      .withIndex("by_target_metric_identity_day", (q) =>
+        q
+          .eq("targetKind", "package")
+          .eq("targetId", args.packageId)
+          .eq("metricKind", "install")
+          .eq("identityKind", args.identityKind)
+          .eq("identityHash", args.identityHash)
+          .eq("dayStart", args.dayStart),
+      )
+      .unique();
+    if (existing) return;
 
-      await ctx.db.insert("packageInstallMetricDedupes", {
-        targetKind: "package",
-        targetId: args.packageId,
-        metricKind: "install",
-        identityKind,
-        identityHash,
-        dayStart,
-        createdAt: Date.now(),
-      });
-    }
+    await ctx.db.insert("packageInstallMetricDedupes", {
+      targetKind: "package",
+      targetId: args.packageId,
+      metricKind: "install",
+      identityKind: args.identityKind,
+      identityHash: args.identityHash,
+      dayStart: args.dayStart,
+      createdAt: Date.now(),
+    });
 
     await ctx.db.insert("packageStatEvents", {
       packageId: args.packageId,
       kind: "install",
-      occurredAt: args.occurredAt ?? Date.now(),
+      occurredAt: args.occurredAt,
       processedAt: undefined,
     });
   },
@@ -4060,6 +4055,14 @@ async function hardDeletePackageDoc(
     .withIndex("by_package", (q) => q.eq("packageId", pkg._id))
     .collect();
   for (const statEvent of statEvents) await ctx.db.delete(statEvent._id);
+
+  const installDedupes = await ctx.db
+    .query("packageInstallMetricDedupes")
+    .withIndex("by_target_metric_identity_day", (q) =>
+      q.eq("targetKind", "package").eq("targetId", pkg._id),
+    )
+    .collect();
+  for (const installDedupe of installDedupes) await ctx.db.delete(installDedupe._id);
 
   for (const release of releases) await ctx.db.delete(release._id);
   await ctx.db.delete(pkg._id);

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -3995,6 +3995,27 @@ async function hardDeletePackageDoc(
     source: "account.delete" | "publisher.delete";
   },
 ) {
+  const installDedupes = await ctx.db
+    .query("packageInstallMetricDedupes")
+    .withIndex("by_target_metric_identity_day", (q) =>
+      q.eq("targetKind", "package").eq("targetId", pkg._id),
+    )
+    .take(MAX_PUBLIC_LIST_PAGE_SIZE);
+  for (const installDedupe of installDedupes) await ctx.db.delete(installDedupe._id);
+  if (installDedupes.length === MAX_PUBLIC_LIST_PAGE_SIZE) {
+    await ctx.scheduler.runAfter(0, internal.packages.hardDeletePackageInternal, {
+      packageId: pkg._id,
+      actorUserId: params.actorUserId,
+      deletedAt: params.deletedAt,
+      source: params.source,
+    });
+    return {
+      ok: true as const,
+      packageId: pkg._id,
+      cleanupPending: true as const,
+    };
+  }
+
   const releases = await ctx.db
     .query("packageReleases")
     .withIndex("by_package", (q) => q.eq("packageId", pkg._id))
@@ -4055,27 +4076,6 @@ async function hardDeletePackageDoc(
     .withIndex("by_package", (q) => q.eq("packageId", pkg._id))
     .collect();
   for (const statEvent of statEvents) await ctx.db.delete(statEvent._id);
-
-  const installDedupes = await ctx.db
-    .query("packageInstallMetricDedupes")
-    .withIndex("by_target_metric_identity_day", (q) =>
-      q.eq("targetKind", "package").eq("targetId", pkg._id),
-    )
-    .take(MAX_PUBLIC_LIST_PAGE_SIZE);
-  for (const installDedupe of installDedupes) await ctx.db.delete(installDedupe._id);
-  if (installDedupes.length === MAX_PUBLIC_LIST_PAGE_SIZE) {
-    await ctx.scheduler.runAfter(0, internal.packages.hardDeletePackageInternal, {
-      packageId: pkg._id,
-      actorUserId: params.actorUserId,
-      deletedAt: params.deletedAt,
-      source: params.source,
-    });
-    return {
-      ok: true as const,
-      packageId: pkg._id,
-      cleanupPending: true as const,
-    };
-  }
 
   for (const release of releases) await ctx.db.delete(release._id);
   await ctx.db.delete(pkg._id);

--- a/convex/skills.packageCatalog.test.ts
+++ b/convex/skills.packageCatalog.test.ts
@@ -353,6 +353,50 @@ describe("skills package catalog queries", () => {
     expect(result.continueCursor).toContain('"recommendedFallback":"updated"');
   });
 
+  it("keeps recommendation sort for non-fallback in-page package catalog cursors", async () => {
+    const indexNames: string[] = [];
+    const cursor = `skillcat:${JSON.stringify({
+      cursor: null,
+      offset: 1,
+      pageSize: 2,
+      done: false,
+    })}`;
+    const result = await listPackageCatalogPageHandler(
+      makeCtx(
+        [
+          {
+            page: [
+              makeDigest("recommended-first", {
+                recommendedScore: 500,
+                recommendedScoreVersion: 3,
+              }),
+              makeDigest("recommended-second", {
+                recommendedScore: 400,
+                recommendedScoreVersion: 3,
+              }),
+            ],
+            isDone: false,
+            continueCursor: "next-recommended-page",
+          },
+        ],
+        {
+          firstByIndex: {
+            by_active_recommended_score_version: { _id: "skillSearchDigest:stale" },
+          },
+          indexNames,
+        },
+      ),
+      {
+        sort: "recommended",
+        paginationOpts: { cursor, numItems: 1 },
+      },
+    );
+
+    expect(indexNames).toEqual(["by_active_recommended_score"]);
+    expect(result.page).toEqual([expect.objectContaining({ name: "recommended-second" })]);
+    expect(result.continueCursor).not.toContain('"recommendedFallback":"updated"');
+  });
+
   it("searches skills with package-style lexical scoring", async () => {
     const result = await searchPackageCatalogPublicHandler(
       makeCtx([

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -6116,10 +6116,16 @@ export const listPackageCatalogPage = query({
     let offset = decodedCursor.offset;
     let pageSize = decodedCursor.pageSize;
     let done = decodedCursor.done;
+    const isFreshRecommendedRequest =
+      args.sort === "recommended" &&
+      !args.paginationOpts.cursor &&
+      !cursor &&
+      offset === 0 &&
+      !done;
     const useUpdatedRecommendationFallback =
       args.sort === "recommended" &&
       (decodedCursor.recommendedFallback === "updated" ||
-        (!cursor && (await hasMissingRecommendedScores(ctx, false, null))));
+        (isFreshRecommendedRequest && (await hasMissingRecommendedScores(ctx, false, null))));
     const effectiveSort = useUpdatedRecommendationFallback ? "updated" : args.sort;
     let loops = 0;
     let remainingScanBudget = MAX_SKILL_CATALOG_SCAN_DOCUMENTS;

--- a/src/components/SkillHeader.test.tsx
+++ b/src/components/SkillHeader.test.tsx
@@ -182,6 +182,19 @@ describe("SkillHeader", () => {
     expect(screen.queryByText("MIT-0")).toBeNull();
   });
 
+  it("uses top-level migrated install stats when present", () => {
+    const migratedSkill = {
+      ...skill,
+      stats: { ...skill.stats, installsAllTime: undefined },
+      statsInstallsAllTime: 42,
+    };
+
+    renderHeader({ skill: migratedSkill });
+
+    expect(screen.getByText("Installs")).toBeTruthy();
+    expect(screen.getByText("42")).toBeTruthy();
+  });
+
   it("shows the source repository for GitHub-backed skills", () => {
     renderHeader({
       skill: {

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from "react";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
 import { getSkillBadges } from "../lib/badges";
 import { buildSkillCategoryBrowseHref, type SkillCategory } from "../lib/categories";
-import { formatSkillStatsTriplet } from "../lib/numberFormat";
+import { formatSkillStatsTriplet, type SkillStatsTriplet } from "../lib/numberFormat";
 import type { PublicPublisher, PublicSkill } from "../lib/publicUser";
 import { getRuntimeEnv } from "../lib/runtimeEnv";
 import { timeAgo } from "../lib/timeAgo";
@@ -75,6 +75,23 @@ function getGitHubRepositoryLink(skill: Doc<"skills"> | PublicSkill) {
       {repo}
     </a>
   );
+}
+
+function getSkillHeaderStats(skill: Doc<"skills"> | PublicSkill): SkillStatsTriplet {
+  return {
+    downloads:
+      "statsDownloads" in skill && typeof skill.statsDownloads === "number"
+        ? skill.statsDownloads
+        : skill.stats.downloads,
+    stars:
+      "statsStars" in skill && typeof skill.statsStars === "number"
+        ? skill.statsStars
+        : skill.stats.stars,
+    installsAllTime:
+      "statsInstallsAllTime" in skill && typeof skill.statsInstallsAllTime === "number"
+        ? skill.statsInstallsAllTime
+        : skill.stats.installsAllTime,
+  };
 }
 
 type SkillHeaderProps = {
@@ -149,7 +166,7 @@ export function SkillHeader({
   showArchiveMetadata = true,
   children,
 }: SkillHeaderProps) {
-  const formattedStats = formatSkillStatsTriplet(skill.stats);
+  const formattedStats = formatSkillStatsTriplet(getSkillHeaderStats(skill));
   const installOwnerId = owner?._id ?? skill.ownerPublisherId ?? skill.ownerUserId ?? null;
   const convexSiteUrl = getRuntimeEnv("VITE_CONVEX_SITE_URL") ?? "https://clawhub.ai";
   const downloadHref =


### PR DESCRIPTION
## Summary

- Requires a viewer identity before recording package install metrics.
- Bounds package install dedupe cleanup so it does not scan unbounded stale rows in one mutation.
- Cleans package install telemetry and catalog references before hard delete.
- Preserves hard-delete audit counts after cleanup.
- Reads skill header install stats from the canonical top-level stat fields when present.

## What Changed

Net diff from `jesse/package-recommendation-fallbacks` to this PR:

```text
9 files changed, 324 insertions, 53 deletions
```

Main files:

- `convex/packages.ts`
- `convex/httpApiV1/packagesV1.ts`
- `convex/skills.ts`
- `src/components/SkillHeader.tsx`

## Flow

```mermaid
flowchart TD
  A[Package install request] --> B{Viewer identity available?}
  B -- no --> C[Do not record install metric]
  B -- yes --> D[Record install metric]
  D --> E[Apply bounded dedupe cleanup]

  F[Hard-delete package] --> G[Clean package telemetry/catalog references]
  G --> H[Delete package]
  H --> I[Keep audit count snapshot]
```

## Proof

| Evidence | Claim Proved | How To Check |
| --- | --- | --- |
| `convex/httpApiV1.handlers.test.ts` | Anonymous package install requests cannot write install metrics. | Run the focused Vitest command below. |
| `convex/packages.public.test.ts` | Package hard delete removes package telemetry/catalog references and keeps audit counts stable. | Run the focused Vitest command below. |
| `convex/packages.stats.test.ts` | Install stat changes still update package stats correctly. | Run the focused Vitest command below. |
| `src/components/SkillHeader.test.tsx` | Skill header displays top-level install stats when available. | Run the focused Vitest command below. |

No screenshots are included. The only UI change is the numeric source for an existing header stat; the unit test proves the rendered count from the data shape.

## How To Test

```text
1. Try an unauthenticated package install telemetry request and confirm no install metric is recorded.
2. Hard-delete a package fixture and confirm related package install/search records are cleaned while audit counts remain available.
3. Open a skill detail page and confirm install count matches canonical stat data.
```

## Verification

```text
bun run format:check
VITE_CONVEX_URL=https://example.invalid bunx vitest run convex/httpApiV1.handlers.test.ts convex/packages.public.test.ts convex/packages.stats.test.ts convex/skills.packageCatalog.test.ts src/components/SkillHeader.test.tsx
```

Result:

```text
format: passed
5 test files passed, 591 tests passed
```
