### PR TITLE
Allow official personal publishers

### DIFF
--- a/convex/githubSkillSources.test.ts
+++ b/convex/githubSkillSources.test.ts
@@ -15,11 +15,24 @@ vi.mock("./lib/publishers", async () => {
 
 const { requireUser } = await import("./lib/access");
 const { requirePublisherRole } = await import("./lib/publishers");
-const { cleanupDeletedSourceScansHandler, deleteForPublisherHandler } =
-  await import("./githubSkillSources");
+const {
+  cleanupDeletedSourceScansHandler,
+  deleteForPublisherHandler,
+  listForManageableOfficialPublishers,
+} = await import("./githubSkillSources");
 const { buildSkillInstallResolution } = await import("./lib/installResolver");
 
 type Row = Record<string, unknown> & { _id: string };
+type WrappedHandler<TArgs, TResult = unknown> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
+};
+
+const listForManageableOfficialPublishersHandler = (
+  listForManageableOfficialPublishers as unknown as WrappedHandler<
+    Record<string, never>,
+    Array<{ _id: string; repo: string; ownerPublisher: { handle: string } | null }>
+  >
+)._handler;
 
 function chainEq(constraints: Record<string, unknown>) {
   return {
@@ -313,5 +326,128 @@ describe("githubSkillSources.deleteForPublisherHandler", () => {
         now: 123,
       }),
     ).rejects.toBeInstanceOf(ConvexError);
+  });
+});
+
+describe("githubSkillSources.listForManageableOfficialPublishers", () => {
+  beforeEach(() => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:steipete",
+      user: {
+        _id: "users:steipete",
+        handle: "steipete",
+        displayName: "Peter Steinberger",
+        personalPublisherId: "publishers:steipete",
+        createdAt: 1,
+        updatedAt: 2,
+      },
+    } as never);
+  });
+
+  it("includes official personal publishers the user can administer", async () => {
+    const { db } = createDb({
+      publisherMembers: [
+        {
+          _id: "publisherMembers:steipete-owner",
+          publisherId: "publishers:steipete",
+          userId: "users:steipete",
+          role: "owner",
+        },
+      ],
+      publishers: [
+        {
+          _id: "publishers:steipete",
+          kind: "user",
+          handle: "steipete",
+          displayName: "Peter Steinberger",
+          linkedUserId: "users:steipete",
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ],
+      officialPublishers: [
+        {
+          _id: "officialPublishers:steipete",
+          publisherId: "publishers:steipete",
+          reason: "Verified individual publisher",
+          createdAt: 3,
+          updatedAt: 3,
+        },
+      ],
+      githubSkillSources: [
+        {
+          _id: "githubSkillSources:steipete",
+          ownerPublisherId: "publishers:steipete",
+          repo: "steipete/agent-rules",
+          defaultBranch: "main",
+          lastSyncStatus: "ok",
+          createdAt: 4,
+          updatedAt: 5,
+        },
+      ],
+      skills: [],
+    });
+
+    await expect(
+      listForManageableOfficialPublishersHandler({ db } as never, {}),
+    ).resolves.toMatchObject([
+      {
+        _id: "githubSkillSources:steipete",
+        repo: "steipete/agent-rules",
+        ownerPublisher: {
+          handle: "steipete",
+        },
+      },
+    ]);
+  });
+
+  it("includes linked official personal publishers without a membership row", async () => {
+    const { db } = createDb({
+      publisherMembers: [],
+      publishers: [
+        {
+          _id: "publishers:steipete",
+          kind: "user",
+          handle: "steipete",
+          displayName: "Peter Steinberger",
+          linkedUserId: "users:steipete",
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ],
+      officialPublishers: [
+        {
+          _id: "officialPublishers:steipete",
+          publisherId: "publishers:steipete",
+          reason: "Verified individual publisher",
+          createdAt: 3,
+          updatedAt: 3,
+        },
+      ],
+      githubSkillSources: [
+        {
+          _id: "githubSkillSources:steipete",
+          ownerPublisherId: "publishers:steipete",
+          repo: "steipete/agent-rules",
+          defaultBranch: "main",
+          lastSyncStatus: "ok",
+          createdAt: 4,
+          updatedAt: 5,
+        },
+      ],
+      skills: [],
+    });
+
+    await expect(
+      listForManageableOfficialPublishersHandler({ db } as never, {}),
+    ).resolves.toMatchObject([
+      {
+        _id: "githubSkillSources:steipete",
+        repo: "steipete/agent-rules",
+        ownerPublisher: {
+          handle: "steipete",
+        },
+      },
+    ]);
   });
 });

--- a/convex/githubSkillSources.ts
+++ b/convex/githubSkillSources.ts
@@ -7,7 +7,12 @@ import { requireUser } from "./lib/access";
 import { deleteGitHubSkillScansForSource } from "./lib/githubSkillScans";
 import { adjustGlobalPublicSkillsCount, getPublicSkillVisibilityDelta } from "./lib/globalStats";
 import { isOfficialPublisher } from "./lib/officialPublishers";
-import { isPublisherActive, isPublisherRoleAllowed, requirePublisherRole } from "./lib/publishers";
+import {
+  getPersonalPublisherForUserOrFallback,
+  isPublisherActive,
+  isPublisherRoleAllowed,
+  requirePublisherRole,
+} from "./lib/publishers";
 import { syncSkillSearchDigestForSkill } from "./lib/skillSearchDigest";
 
 const GITHUB_SKILL_SCAN_CLEANUP_BATCH_SIZE = 25;
@@ -105,27 +110,34 @@ export const listForPublisher = query({
 export const listForManageableOfficialPublishers = query({
   args: {},
   handler: async (ctx): Promise<PublicGitHubSkillSource[]> => {
-    const { userId } = await requireUser(ctx);
+    const { userId, user } = await requireUser(ctx);
     const memberships = await ctx.db
       .query("publisherMembers")
       .withIndex("by_user", (q) => q.eq("userId", userId))
       .collect();
-    const ownerPublisherIds: Id<"publishers">[] = [];
+    const ownerPublisherIds = new Set<Id<"publishers">>();
     for (const membership of memberships) {
       if (!isPublisherRoleAllowed(membership.role, ["admin"])) continue;
       const publisher = await ctx.db.get(membership.publisherId);
       if (
         !publisher ||
-        publisher.kind !== "org" ||
         !isPublisherActive(publisher) ||
         !(await isOfficialPublisher(ctx, publisher))
       ) {
         continue;
       }
-      ownerPublisherIds.push(publisher._id);
+      ownerPublisherIds.add(publisher._id);
+    }
+    const personalPublisher = await getPersonalPublisherForUserOrFallback(ctx, user);
+    if (
+      personalPublisher &&
+      isPublisherActive(personalPublisher) &&
+      (await isOfficialPublisher(ctx, personalPublisher))
+    ) {
+      ownerPublisherIds.add(personalPublisher._id);
     }
     const sourceGroups = await Promise.all(
-      ownerPublisherIds.map((ownerPublisherId) =>
+      [...ownerPublisherIds].map((ownerPublisherId) =>
         ctx.db
           .query("githubSkillSources")
           .withIndex("by_owner_publisher", (q) => q.eq("ownerPublisherId", ownerPublisherId))

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -1530,7 +1530,7 @@ describe("httpApiV1 handlers", () => {
     });
   });
 
-  it("users/publisher-official adds official org publishers for admin", async () => {
+  it("users/publisher-official adds official publishers for admin", async () => {
     vi.mocked(requireApiTokenUser).mockResolvedValue({
       userId: "users:admin",
       user: { _id: "users:admin", role: "admin" },
@@ -1568,7 +1568,7 @@ describe("httpApiV1 handlers", () => {
     });
   });
 
-  it("users/publisher-official removes official org publishers for admin", async () => {
+  it("users/publisher-official removes official publishers for admin", async () => {
     vi.mocked(requireApiTokenUser).mockResolvedValue({
       userId: "users:admin",
       user: { _id: "users:admin", role: "admin" },

--- a/convex/publisherAbuse.test.ts
+++ b/convex/publisherAbuse.test.ts
@@ -599,7 +599,7 @@ describe("publisher abuse dry-run persistence", () => {
     expect(insert).not.toHaveBeenCalled();
   });
 
-  it("rejects direct ban actions for official org publisher nominations", async () => {
+  it("rejects direct ban actions for official publisher nominations", async () => {
     vi.mocked(requireUser).mockResolvedValue({
       userId: "users:moderator",
       user: { _id: "users:moderator", role: "moderator" },
@@ -659,7 +659,7 @@ describe("publisher abuse dry-run persistence", () => {
         expectedUpdatedAt: 1,
         reason: "confirmed spam",
       }),
-    ).rejects.toThrow(/official org/i);
+    ).rejects.toThrow(/official publisher/i);
 
     expect(runMutation).not.toHaveBeenCalled();
     expect(patch).not.toHaveBeenCalled();
@@ -992,7 +992,7 @@ describe("publisher abuse dry-run persistence", () => {
     expect(scoreTakeLimit).toBe(32);
   });
 
-  it("hides stale official org nominations from dashboard lists and nomination detail", async () => {
+  it("hides stale official publisher nominations from dashboard lists and nomination detail", async () => {
     vi.mocked(requireUser).mockResolvedValue({
       userId: "users:moderator",
       user: { _id: "users:moderator", role: "moderator" },
@@ -1747,7 +1747,7 @@ describe("publisher abuse dry-run persistence", () => {
     );
   });
 
-  it("excludes official org publishers from abuse scoring even when they match abuse-pressure criteria", async () => {
+  it("excludes official publishers from abuse scoring even when they match abuse-pressure criteria", async () => {
     const insert = vi.fn(async (table: string) => `${table}:new`);
     const patch = vi.fn(async () => null);
     const officialOrgPublisher = {
@@ -2968,7 +2968,7 @@ describe("publisher abuse dry-run persistence", () => {
     );
   });
 
-  it("does not create nominations for official org score rows left by an older run", async () => {
+  it("does not create nominations for official publisher score rows left by an older run", async () => {
     const insert = vi.fn(async (table: string) => `${table}:new`);
     const patch = vi.fn(async () => null);
     const officialPublisher = {
@@ -3928,6 +3928,7 @@ describe("publisher abuse dry-run persistence", () => {
               },
             };
           }
+          if (table === "officialPublishers") return makeEmptyOfficialPublishersQuery();
           throw new Error(`unexpected table ${table}`);
         }),
       },
@@ -4022,6 +4023,7 @@ describe("publisher abuse dry-run persistence", () => {
               },
             };
           }
+          if (table === "officialPublishers") return makeEmptyOfficialPublishersQuery();
           throw new Error(`unexpected table ${table}`);
         }),
       },
@@ -4051,17 +4053,17 @@ describe("publisher abuse dry-run persistence", () => {
     });
   });
 
-  it("skips official org publishers during temporal candidate collection", async () => {
+  it("skips official personal publishers during temporal candidate collection", async () => {
     const indexBuilder = {
       eq: vi.fn(() => indexBuilder),
       gte: vi.fn(() => indexBuilder),
       lte: vi.fn(() => indexBuilder),
     };
     const officialPublisher = {
-      _id: "publishers:openclaw",
-      kind: "org",
-      handle: "openclaw",
-      linkedUserId: "users:openclaw",
+      _id: "publishers:steipete",
+      kind: "user",
+      handle: "steipete",
+      linkedUserId: "users:steipete",
     };
     const ctx = {
       db: {
@@ -4128,7 +4130,7 @@ describe("publisher abuse dry-run persistence", () => {
                 callback(indexBuilder);
                 return {
                   unique: async () => ({
-                    _id: "officialPublishers:openclaw",
+                    _id: "officialPublishers:steipete",
                     publisherId: officialPublisher._id,
                   }),
                 };

--- a/convex/publisherAbuse.ts
+++ b/convex/publisherAbuse.ts
@@ -1363,7 +1363,8 @@ async function isPublisherExcludedFromPublisherAbuse(
   ctx: Pick<QueryCtx | MutationCtx, "db">,
   publisher: PublisherAbuseExclusionPublisher | null | undefined,
 ) {
-  if (!publisher || publisher.kind !== "org") return false;
+  if (!publisher) return false;
+  if (publisher.kind !== "user" && publisher.kind !== "org") return false;
   return await hasOfficialPublisherRow(ctx, publisher._id);
 }
 
@@ -1390,7 +1391,7 @@ async function requirePublisherAbuseNominationNotExcluded(
   if (!nomination.ownerPublisherId) return;
   const publisher = await ctx.db.get(nomination.ownerPublisherId);
   if (!(await isPublisherExcludedFromPublisherAbuse(ctx, publisher))) return;
-  throw new Error("Official org publisher abuse nominations cannot be acted on.");
+  throw new Error("Official publisher abuse nominations cannot be acted on.");
 }
 
 function summarizePublisherAbuseFinalizationCohort(run: ScoreRun) {

--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -19,6 +19,7 @@ import {
   createOrg,
   deleteOrg,
   removeMember,
+  addOfficialPublisherInternal,
   createOrgPublisherForUserInternal,
   deleteSoleOwnerOrgsForAccountDeletionInternal,
   resolvePublishTargetForUserInternal,
@@ -99,6 +100,23 @@ const removeOrgPublisherMemberInternalHandler = (
       handle: string;
       removed: boolean;
       member: { userId: string; handle: string; role: "owner" | "admin" | "publisher" };
+    }
+  >
+)._handler;
+
+const addOfficialPublisherInternalHandler = (
+  addOfficialPublisherInternal as unknown as WrappedHandler<
+    {
+      actorUserId: string;
+      handle: string;
+      reason: string;
+    },
+    {
+      ok: true;
+      added: boolean;
+      publisherId: string;
+      handle: string;
+      officialPublisherId: string;
     }
   >
 )._handler;
@@ -3169,6 +3187,92 @@ describe("publisher audit logs", () => {
           previousTrustedPublisher: false,
           trustedPublisher: true,
         },
+      }),
+    );
+  });
+});
+
+describe("official publisher administration", () => {
+  it("marks personal publishers official", async () => {
+    const actor = { _id: "users:admin", role: "admin" };
+    const publisher = {
+      _id: "publishers:steipete",
+      kind: "user",
+      handle: "steipete",
+      displayName: "Peter Steinberger",
+      linkedUserId: "users:steipete",
+    };
+    const inserted: Array<{ table: string; doc: Record<string, unknown> }> = [];
+    const query = vi.fn((table: string) => ({
+      withIndex: vi.fn(
+        (
+          indexName: string,
+          builder: (q: { eq: (field: string, value: string) => unknown }) => unknown,
+        ) => {
+          const fields: Record<string, string> = {};
+          const q = {
+            eq: (field: string, value: string) => {
+              fields[field] = value;
+              return q;
+            },
+          };
+          builder(q);
+          if (table === "publishers" && indexName === "by_handle") {
+            return {
+              unique: vi.fn(async () => (fields.handle === "steipete" ? publisher : null)),
+            };
+          }
+          if (table === "officialPublishers" && indexName === "by_publisher") {
+            return { unique: vi.fn(async () => null) };
+          }
+          throw new Error(`unexpected ${table} index ${indexName}`);
+        },
+      ),
+    }));
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => (id === "users:admin" ? actor : null)),
+        query,
+        patch: vi.fn(),
+        delete: vi.fn(),
+        insert: vi.fn(async (table: string, doc: Record<string, unknown>) => {
+          inserted.push({ table, doc });
+          return table === "officialPublishers"
+            ? "officialPublishers:steipete"
+            : `auditLogs:${inserted.length}`;
+        }),
+        replace: vi.fn(),
+        normalizeId: vi.fn(),
+      },
+    };
+
+    await expect(
+      addOfficialPublisherInternalHandler(ctx as never, {
+        actorUserId: "users:admin",
+        handle: "@steipete",
+        reason: "Verified individual publisher",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      added: true,
+      publisherId: "publishers:steipete",
+      handle: "steipete",
+      officialPublisherId: "officialPublishers:steipete",
+    });
+    expect(ctx.db.insert).toHaveBeenCalledWith(
+      "officialPublishers",
+      expect.objectContaining({
+        publisherId: "publishers:steipete",
+        reason: "Verified individual publisher",
+        createdByUserId: "users:admin",
+      }),
+    );
+    expect(ctx.db.insert).toHaveBeenCalledWith(
+      "auditLogs",
+      expect.objectContaining({
+        action: "publisher.official.add",
+        targetId: "publishers:steipete",
+        metadata: { handle: "steipete", reason: "Verified individual publisher" },
       }),
     );
   });

--- a/convex/publishers.ts
+++ b/convex/publishers.ts
@@ -2551,9 +2551,6 @@ export const addOfficialPublisherInternal = internalMutation({
     if (!publisher || publisher.deletedAt || publisher.deactivatedAt) {
       throw new ConvexError(`Publisher "@${handle}" not found`);
     }
-    if (publisher.kind !== "org") {
-      throw new ConvexError("Only org publishers can be marked official");
-    }
 
     const existing = await ctx.db
       .query("officialPublishers")

--- a/packages/clawhub-admin/README.md
+++ b/packages/clawhub-admin/README.md
@@ -93,13 +93,21 @@ Org publisher administration:
 
 ```bash
 bun run admin -- org create <handle> --member <handle> [--display-name <name>] [--role owner|admin|publisher] [--trusted] [--json]
-bun run admin -- org official list [--json]
-bun run admin -- org official add <handle> --reason <text> [--yes] [--json]
-bun run admin -- org official remove <handle> --reason <text> [--yes] [--json]
 ```
 
 `org create` requires `--member` and defaults that member to `owner`; it does
 not add the admin running the command as an org member.
+
+Publisher administration:
+
+```bash
+bun run admin -- publisher official list [--json]
+bun run admin -- publisher official add <handle> --reason <text> [--yes] [--json]
+bun run admin -- publisher official remove <handle> --reason <text> [--yes] [--json]
+```
+
+`org official ...` is retained as a compatibility alias for existing operator
+scripts.
 
 Package moderation and operations:
 

--- a/packages/clawhub-admin/src/cli.ts
+++ b/packages/clawhub-admin/src/cli.ts
@@ -303,6 +303,13 @@ const org = program
   .showHelpAfterError()
   .showSuggestionAfterError();
 
+const publisher = program
+  .command("publisher")
+  .alias("publishers")
+  .description("Publisher administration")
+  .showHelpAfterError()
+  .showSuggestionAfterError();
+
 const email = program
   .command("email")
   .description("Guarded staff email operations")
@@ -328,6 +335,7 @@ registerPluginGovernanceCommands(plugins);
 registerPluginOperations(packages);
 registerPluginModerationCommands(packages);
 registerPluginGovernanceCommands(packages);
+registerOfficialPublisherCommands(publisher);
 registerOrgCommands(org);
 registerEmailCommands(email);
 registerContentRightsCommands(contentRights);
@@ -395,16 +403,16 @@ function registerEmailCommands(command: Command) {
     });
 }
 
-function registerOrgCommands(command: Command) {
+function registerOfficialPublisherCommands(command: Command) {
   const official = command
     .command("official")
-    .description("Manage official org publishers")
+    .description("Manage official publishers")
     .showHelpAfterError()
     .showSuggestionAfterError();
 
   official
     .command("list")
-    .description("List official org publishers")
+    .description("List official publishers")
     .option("--json", "Output JSON")
     .action(async (options) => {
       const opts = await resolveGlobalOpts();
@@ -413,8 +421,8 @@ function registerOrgCommands(command: Command) {
 
   official
     .command("add")
-    .description("Mark an org publisher as official")
-    .argument("<handle>", "Org publisher handle")
+    .description("Mark a publisher as official")
+    .argument("<handle>", "Publisher handle")
     .requiredOption("--reason <reason>", "Audit reason")
     .option("--yes", "Skip confirmation")
     .option("--json", "Output JSON")
@@ -425,8 +433,8 @@ function registerOrgCommands(command: Command) {
 
   official
     .command("remove")
-    .description("Remove an org publisher from the official list")
-    .argument("<handle>", "Org publisher handle")
+    .description("Remove a publisher from the official list")
+    .argument("<handle>", "Publisher handle")
     .requiredOption("--reason <reason>", "Audit reason")
     .option("--yes", "Skip confirmation")
     .option("--json", "Output JSON")
@@ -434,6 +442,10 @@ function registerOrgCommands(command: Command) {
       const opts = await resolveGlobalOpts();
       await cmdRemoveOfficialOrg(opts, handle, options, isInputAllowed());
     });
+}
+
+function registerOrgCommands(command: Command) {
+  registerOfficialPublisherCommands(command);
 
   command
     .command("create")

--- a/packages/clawhub-admin/src/commands/orgs.test.ts
+++ b/packages/clawhub-admin/src/commands/orgs.test.ts
@@ -285,8 +285,8 @@ describe("cmdDeleteOrg", () => {
   });
 });
 
-describe("official org commands", () => {
-  it("lists official org publishers", async () => {
+describe("official publisher commands", () => {
+  it("lists official publishers", async () => {
     httpMocks.apiRequest.mockResolvedValueOnce({
       ok: true,
       items: [
@@ -321,7 +321,36 @@ describe("official org commands", () => {
     );
   });
 
-  it("requires --yes to add an official org when input is disabled", async () => {
+  it("prints official personal publishers", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      ok: true,
+      items: [
+        {
+          officialPublisherId: "officialPublishers:steipete",
+          publisherId: "publishers:steipete",
+          handle: "steipete",
+          displayName: "Peter Steinberger",
+          kind: "user",
+          active: true,
+          reason: "Verified individual publisher",
+          createdByUserId: "users:admin",
+          createdByHandle: "patrick-erichsen-2",
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+    });
+
+    await cmdListOfficialOrgs(makeGlobalOpts());
+
+    expect(log).toHaveBeenCalledWith(
+      "@steipete  Peter Steinberger - Verified individual publisher",
+    );
+    log.mockRestore();
+  });
+
+  it("requires --yes to add an official publisher when input is disabled", async () => {
     await expect(
       cmdAddOfficialOrg(
         makeGlobalOpts(),
@@ -333,7 +362,7 @@ describe("official org commands", () => {
     expect(httpMocks.apiRequest).not.toHaveBeenCalled();
   });
 
-  it("marks an org publisher official", async () => {
+  it("marks a publisher official", async () => {
     httpMocks.apiRequest.mockResolvedValueOnce({
       ok: true,
       publisherId: "publishers:nvidia",

--- a/packages/clawhub-admin/src/commands/orgs.ts
+++ b/packages/clawhub-admin/src/commands/orgs.ts
@@ -237,7 +237,7 @@ export async function cmdDeleteOrg(
 export async function cmdListOfficialOrgs(opts: GlobalOpts, options: OrgOfficialListOptions = {}) {
   const token = await requireAuthToken();
   const registry = await getRegistry(opts, { cache: true });
-  const spinner = options.json ? null : createSpinner("Listing official org publishers");
+  const spinner = options.json ? null : createSpinner("Listing official publishers");
   try {
     const result = await apiRequest(
       registry,
@@ -255,9 +255,9 @@ export async function cmdListOfficialOrgs(opts: GlobalOpts, options: OrgOfficial
       return result;
     }
 
-    const items = result.items.filter((item) => item.kind === "org" && item.active);
+    const items = result.items.filter((item) => item.active);
     if (items.length === 0) {
-      console.log("No official org publishers.");
+      console.log("No official publishers.");
       return result;
     }
 
@@ -281,7 +281,7 @@ export async function cmdAddOfficialOrg(
   options: OrgOfficialWriteOptions = {},
   inputAllowed: boolean,
 ) {
-  const orgHandle = normalizeHandleOrFail(handle, "Org handle");
+  const orgHandle = normalizeHandleOrFail(handle, "Publisher handle");
   const reason = normalizeReasonOrFail(options.reason);
   await confirmOfficialOrgUpdate(
     `Mark @${orgHandle} official? (admin only; affects official badge and GitHub sync eligibility)`,
@@ -327,10 +327,10 @@ export async function cmdRemoveOfficialOrg(
   options: OrgOfficialWriteOptions = {},
   inputAllowed: boolean,
 ) {
-  const orgHandle = normalizeHandleOrFail(handle, "Org handle");
+  const orgHandle = normalizeHandleOrFail(handle, "Publisher handle");
   const reason = normalizeReasonOrFail(options.reason);
   await confirmOfficialOrgUpdate(
-    `Remove @${orgHandle} from official org publishers? (admin only)`,
+    `Remove @${orgHandle} from official publishers? (admin only)`,
     options,
     inputAllowed,
   );
@@ -339,7 +339,7 @@ export async function cmdRemoveOfficialOrg(
   const registry = await getRegistry(opts, { cache: true });
   const spinner = options.json
     ? null
-    : createSpinner(`Removing @${orgHandle} from official org publishers`);
+    : createSpinner(`Removing @${orgHandle} from official publishers`);
   try {
     const result = await apiRequest(
       registry,
@@ -358,7 +358,7 @@ export async function cmdRemoveOfficialOrg(
 
     spinner?.succeed(
       result.removed
-        ? `Removed @${result.handle} from official org publishers`
+        ? `Removed @${result.handle} from official publishers`
         : `@${result.handle} was not official`,
     );
     if (options.json) {

--- a/specs/github-backed-skills.md
+++ b/specs/github-backed-skills.md
@@ -72,8 +72,8 @@ It is not inherited from org membership, GitHub identity, OIDC, or
 `trustedPublisher`.
 
 Default official publishers are not seeded from deploy. Maintainers should mark
-`openclaw` and `nvidia` official explicitly using the moderation/admin CLI
-before enabling their source sync.
+official publishers explicitly using the moderation/admin CLI before enabling
+their source sync.
 
 ## Sync
 

--- a/specs/official-publishers.md
+++ b/specs/official-publishers.md
@@ -9,6 +9,8 @@ For now, Official means:
   `officialPublishers` row
 - official status is publisher-scoped; it is not inherited by users, personal
   publishers, org members, GitHub identities, OIDC trust, or `trustedPublisher`
+- personal and org publishers can both be marked Official when ClawHub staff
+  verify that publisher identity
 
 Official must not be accepted from uploaded skill or package metadata.
 Membership in an official org does not make a member's personal publisher
@@ -22,7 +24,7 @@ The same policy signal appears in several places:
   `official` channel; private packages stay private.
 - GitHub Skill Sync UI/backend: only manageable Official publishers can
   configure source-backed GitHub skill sync.
-- Publisher abuse scoring: Official org publishers are excluded from bulk
+- Publisher abuse scoring: Official publishers are excluded from bulk
   publisher-abuse scoring, nomination queues, and stale nomination actions.
 
 `trustedPublisher` is an internal automated-publish permission. It does not make

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -45,7 +45,7 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
 - Publisher abuse scoring is a staff review signal for bulk-publishing abuse.
   It must not directly ban users; staff action goes through the publisher abuse
   nomination review path.
-- Official org publishers are excluded from publisher abuse scoring and
+- Official publishers are excluded from publisher abuse scoring and
   enforcement. An excluded publisher must not contribute to score-run cohort
   statistics, receive a score label/rank, open or update a nomination, appear in
   the dashboard/detail state, or be actionable through a stale nomination id.


### PR DESCRIPTION
## Summary
- allow personal/user publishers to receive the ClawHub-managed Official publisher flag
- extend official-publisher powers to personal publishers: GitHub Skill Sync visibility, official package eligibility, and publisher-abuse exemption
- add `publisher official ...` admin CLI entrypoint while keeping `org official ...` as a compatibility path
- update official-publisher specs/admin docs and tests

## Validation
- `bun run test convex/publishers.test.ts convex/githubSkillSources.test.ts convex/publisherAbuse.test.ts packages/clawhub-admin/src/commands/orgs.test.ts`
- `bun packages/clawhub-admin/src/cli.ts publisher official --help`
- `bun packages/clawhub-admin/src/cli.ts org official --help`
- `bunx convex dev --once --typecheck=disable`
- `bun run ci:static`
- `bun run ci:packages`
- `VITE_CONVEX_URL=https://example.invalid bun run coverage`
- `bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean after one accepted finding was fixed)
