### PR TITLE
Remove retired comment schema

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1947,44 +1947,6 @@ const skillStatDocSyncLeases = defineTable({
   lastProcessedCount: v.optional(v.number()),
 }).index("by_key", ["key"]);
 
-// Legacy skill comment storage is retained only so old production rows keep
-// validating and hard-delete/ban cleanup can purge them safely.
-const comments = defineTable({
-  skillId: v.id("skills"),
-  userId: v.id("users"),
-  body: v.string(),
-  reportCount: v.optional(v.number()),
-  lastReportedAt: v.optional(v.number()),
-  scamScanVerdict: v.optional(
-    v.union(v.literal("not_scam"), v.literal("likely_scam"), v.literal("certain_scam")),
-  ),
-  scamScanConfidence: v.optional(v.union(v.literal("low"), v.literal("medium"), v.literal("high"))),
-  scamScanExplanation: v.optional(v.string()),
-  scamScanEvidence: v.optional(v.array(v.string())),
-  scamScanModel: v.optional(v.string()),
-  scamScanCheckedAt: v.optional(v.number()),
-  scamBanTriggeredAt: v.optional(v.number()),
-  createdAt: v.number(),
-  softDeletedAt: v.optional(v.number()),
-  deletedBy: v.optional(v.id("users")),
-})
-  .index("by_skill", ["skillId"])
-  .index("by_user", ["userId"])
-  .index("by_scam_scan_checked", ["scamScanCheckedAt"]);
-
-const commentReports = defineTable({
-  commentId: v.id("comments"),
-  skillId: v.id("skills"),
-  userId: v.id("users"),
-  reason: v.optional(v.string()),
-  createdAt: v.number(),
-})
-  .index("by_comment", ["commentId"])
-  .index("by_comment_createdAt", ["commentId", "createdAt"])
-  .index("by_skill", ["skillId"])
-  .index("by_user", ["userId"])
-  .index("by_comment_user", ["commentId", "userId"]);
-
 const skillReports = defineTable({
   skillId: v.id("skills"),
   skillVersionId: v.optional(v.id("skillVersions")),
@@ -2602,8 +2564,6 @@ export default defineSchema({
   skillStatEvents,
   skillStatUpdateCursors,
   skillStatDocSyncLeases,
-  comments,
-  commentReports,
   skillReports,
   skillAppeals,
   skillModerationEventLogs,

--- a/convex/skills.banBatches.test.ts
+++ b/convex/skills.banBatches.test.ts
@@ -74,6 +74,14 @@ function makeCtx({
       return {
         withIndex: () => ({
           collect: async () => [],
+          take: async () => [],
+        }),
+      };
+    }
+    if (table === "skillReports") {
+      return {
+        withIndex: () => ({
+          take: async () => [],
         }),
       };
     }
@@ -93,6 +101,8 @@ function makeCtx({
         get: vi.fn(async (id: string) => {
           if (id === "users:owner") return user;
           if (id === "publishers:org") return { _id: id, kind: "org", deletedAt: 3_000 };
+          const skill = skills.find((row) => row._id === id);
+          if (skill) return skill;
           return null;
         }),
         insert: vi.fn(),
@@ -105,71 +115,6 @@ function makeCtx({
       scheduler,
     } as never,
     patch,
-    query,
-    scheduler,
-  };
-}
-
-function makeLegacyCommentHardDeleteCtx({
-  comments = [],
-  commentReports = [],
-}: {
-  comments?: Array<Record<string, unknown>>;
-  commentReports?: Array<Record<string, unknown>>;
-}) {
-  const deleteDoc = vi.fn();
-  const scheduler = { runAfter: vi.fn() };
-  const skill = {
-    _id: "skills:legacy",
-    slug: "legacy",
-    ownerUserId: "users:owner",
-    softDeletedAt: 1_000,
-    moderationStatus: "removed",
-    hiddenAt: 1_000,
-    hiddenBy: "users:admin",
-    stats: {
-      downloads: 0,
-      stars: 0,
-      comments: 0,
-      versions: 1,
-      installsCurrent: 0,
-      installsAllTime: 0,
-    },
-  };
-  const query = vi.fn((table: string) => {
-    if (table === "comments") {
-      return {
-        withIndex: () => ({
-          take: async () => comments,
-        }),
-      };
-    }
-    if (table === "commentReports") {
-      return {
-        withIndex: () => ({
-          take: async () => commentReports,
-        }),
-      };
-    }
-    throw new Error(`Unexpected table ${table}`);
-  });
-
-  return {
-    ctx: {
-      db: {
-        get: vi.fn(async (id: string) => {
-          if (id === "users:admin") return { _id: id, role: "admin" };
-          if (id === "skills:legacy") return skill;
-          return null;
-        }),
-        normalizeId: vi.fn(),
-        patch: vi.fn(),
-        delete: deleteDoc,
-        query,
-      },
-      scheduler,
-    } as never,
-    deleteDoc,
     query,
     scheduler,
   };
@@ -785,52 +730,46 @@ describe("skills ban/unban batches", () => {
     expect(patch).not.toHaveBeenCalledWith("skills:removed", expect.anything());
   });
 
-  it("deletes legacy skill comments during hard-delete cleanup", async () => {
-    const { ctx, deleteDoc, query, scheduler } = makeLegacyCommentHardDeleteCtx({
-      comments: [{ _id: "comments:1" }, { _id: "comments:2" }],
+  it("continues stale retired comment cleanup phases at skill reports", async () => {
+    const { ctx, query, scheduler } = makeCtx({
+      user: { _id: "users:owner", role: "admin" },
+      skills: [
+        {
+          _id: "skills:legacy",
+          slug: "legacy",
+          ownerUserId: "users:owner",
+          softDeletedAt: 1_000,
+          moderationStatus: "removed",
+          hiddenAt: 1_000,
+          hiddenBy: "users:owner",
+          stats: {
+            downloads: 0,
+            stars: 0,
+            comments: 0,
+            versions: 1,
+            installsCurrent: 0,
+            installsAllTime: 0,
+          },
+        },
+      ],
     });
 
     await hardDeleteHandler(ctx, {
       skillId: "skills:legacy",
-      actorUserId: "users:admin",
+      actorUserId: "users:owner",
       phase: "comments",
     });
 
-    expect(query).toHaveBeenCalledWith("comments");
-    expect(deleteDoc).toHaveBeenCalledWith("comments:1");
-    expect(deleteDoc).toHaveBeenCalledWith("comments:2");
+    expect(query).not.toHaveBeenCalledWith("comments");
+    expect(query).not.toHaveBeenCalledWith("commentReports");
+    expect(query).toHaveBeenCalledWith("skillReports");
     expect(scheduler.runAfter).toHaveBeenCalledWith(
       0,
       expect.anything(),
       expect.objectContaining({
         skillId: "skills:legacy",
-        actorUserId: "users:admin",
-        phase: "commentReports",
-        source: "admin",
-      }),
-    );
-  });
-
-  it("deletes legacy comment reports during hard-delete cleanup", async () => {
-    const { ctx, deleteDoc, query, scheduler } = makeLegacyCommentHardDeleteCtx({
-      commentReports: [{ _id: "commentReports:1" }],
-    });
-
-    await hardDeleteHandler(ctx, {
-      skillId: "skills:legacy",
-      actorUserId: "users:admin",
-      phase: "commentReports",
-    });
-
-    expect(query).toHaveBeenCalledWith("commentReports");
-    expect(deleteDoc).toHaveBeenCalledWith("commentReports:1");
-    expect(scheduler.runAfter).toHaveBeenCalledWith(
-      0,
-      expect.anything(),
-      expect.objectContaining({
-        skillId: "skills:legacy",
-        actorUserId: "users:admin",
-        phase: "reports",
+        actorUserId: "users:owner",
+        phase: "stars",
         source: "admin",
       }),
     );

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -1597,8 +1597,6 @@ const HARD_DELETE_PHASES = [
   "githubScans",
   "skillCardJobs",
   "embeddings",
-  "comments",
-  "commentReports",
   "reports",
   "stars",
   "badges",
@@ -1740,36 +1738,6 @@ async function hardDeleteSkillStep(
       }
       if (embeddings.length === HARD_DELETE_BATCH_SIZE) {
         await scheduleHardDelete(ctx, skill._id, actorUserId, "embeddings", scope);
-        return;
-      }
-      await scheduleHardDelete(ctx, skill._id, actorUserId, "comments", scope);
-      return;
-    }
-    case "comments": {
-      const comments = await ctx.db
-        .query("comments")
-        .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
-        .take(HARD_DELETE_BATCH_SIZE);
-      for (const comment of comments) {
-        await ctx.db.delete(comment._id);
-      }
-      if (comments.length === HARD_DELETE_BATCH_SIZE) {
-        await scheduleHardDelete(ctx, skill._id, actorUserId, "comments", scope);
-        return;
-      }
-      await scheduleHardDelete(ctx, skill._id, actorUserId, "commentReports", scope);
-      return;
-    }
-    case "commentReports": {
-      const commentReports = await ctx.db
-        .query("commentReports")
-        .withIndex("by_skill", (q) => q.eq("skillId", skill._id))
-        .take(HARD_DELETE_BATCH_SIZE);
-      for (const report of commentReports) {
-        await ctx.db.delete(report._id);
-      }
-      if (commentReports.length === HARD_DELETE_BATCH_SIZE) {
-        await scheduleHardDelete(ctx, skill._id, actorUserId, "commentReports", scope);
         return;
       }
       await scheduleHardDelete(ctx, skill._id, actorUserId, "reports", scope);
@@ -10705,13 +10673,16 @@ export const hardDeleteInternal = internalMutation({
         throw new Error("Skill is outside publisher deletion scope");
       }
     }
-    // Jobs scheduled before root telemetry removal should continue at the next durable phase.
+    // Jobs scheduled before earlier cleanup phases were removed should continue
+    // at the next durable phase instead of restarting from the beginning.
     const phase =
       args.phase === "rootInstalls"
         ? "installTelemetryDedupes"
-        : isHardDeletePhase(args.phase)
-          ? args.phase
-          : "versions";
+        : args.phase === "comments" || args.phase === "commentReports"
+          ? "reports"
+          : isHardDeletePhase(args.phase)
+            ? args.phase
+            : "versions";
     await hardDeleteSkillStep(ctx, skill, args.actorUserId, phase, {
       source,
       ownerPublisherId: args.ownerPublisherId,

--- a/convex/users.test.ts
+++ b/convex/users.test.ts
@@ -9,13 +9,8 @@ vi.mock("./lib/access", async () => {
   return { ...actual, requireUser: vi.fn() };
 });
 
-vi.mock("./skillStatEvents", () => ({
-  insertStatEvent: vi.fn(),
-}));
-
 const { requireUser } = await import("./lib/access");
 const { getAuthUserId } = await import("@convex-dev/auth/server");
-const { insertStatEvent } = await import("./skillStatEvents");
 const {
   ensureHandler,
   getByHandle,
@@ -427,27 +422,12 @@ function makeBanCtx(options: { auditLogs?: Array<Record<string, unknown>> } = {}
   const runMutation = vi.fn();
   const runAfter = vi.fn();
   const apiTokens = [{ _id: "apiTokens:1", revokedAt: undefined }];
-  const userComments = [
-    {
-      _id: "comments:active",
-      userId: "users:target",
-      skillId: "skills:1",
-      softDeletedAt: undefined,
-    },
-    {
-      _id: "comments:already-deleted",
-      userId: "users:target",
-      skillId: "skills:1",
-      softDeletedAt: 123,
-    },
-  ];
   const query = vi.fn((table: string) => ({
     withIndex: (_index: string, _cb: unknown) => {
       if (table === "auditLogs") {
         return { order: vi.fn(() => ({ take: vi.fn().mockResolvedValue(auditLogs) })) };
       }
       if (table === "apiTokens") return { collect: vi.fn().mockResolvedValue(apiTokens) };
-      if (table === "comments") return { collect: vi.fn().mockResolvedValue(userComments) };
       throw new Error(`Unexpected table ${table}`);
     },
   }));
@@ -457,7 +437,7 @@ function makeBanCtx(options: { auditLogs?: Array<Record<string, unknown>> } = {}
     runMutation,
     scheduler: { runAfter },
   } as never;
-  return { ctx, patch, insert, get, runMutation, runAfter };
+  return { ctx, patch, insert, get, query, runMutation, runAfter };
 }
 
 function makeBanAppealContextCtx(options: {
@@ -3004,13 +2984,12 @@ describe("users.searchInternal", () => {
 
 describe("users.banUserInternal", () => {
   afterEach(() => {
-    vi.mocked(insertStatEvent).mockReset();
     vi.restoreAllMocks();
   });
 
-  it("soft-deletes legacy skill comments during ban", async () => {
+  it("does not query retired skill comments during ban", async () => {
     vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
-    const { ctx, get, patch, insert, runMutation } = makeBanCtx();
+    const { ctx, get, insert, runMutation } = makeBanCtx();
 
     get.mockImplementation(async (id: string) => {
       if (id === "users:actor") return { _id: "users:actor", role: "moderator" };
@@ -3045,22 +3024,14 @@ describe("users.banUserInternal", () => {
     expect(result).toMatchObject({
       ok: true,
       alreadyBanned: false,
-      deletedSkillComments: 1,
-    });
-    expect(patch).toHaveBeenCalledWith("comments:active", {
-      softDeletedAt: 1_700_000_000_000,
-      deletedBy: "users:actor",
-    });
-    expect(insertStatEvent).toHaveBeenCalledWith(expect.anything(), {
-      skillId: "skills:1",
-      kind: "uncomment",
+      deletedSkillComments: 0,
     });
     expect(insert).toHaveBeenCalledWith(
       "auditLogs",
       expect.objectContaining({
         action: "user.ban",
         metadata: expect.objectContaining({
-          deletedSkillComments: 1,
+          deletedSkillComments: 0,
         }),
       }),
     );
@@ -3114,9 +3085,9 @@ describe("users.banUserInternal", () => {
     });
   });
 
-  it("cleans lingering legacy skill comments when re-banning a deleted user", async () => {
+  it("does not query retired skill comments when re-banning a deleted user", async () => {
     vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
-    const { ctx, get, patch, runMutation } = makeBanCtx();
+    const { ctx, get, query, runMutation } = makeBanCtx();
 
     get.mockImplementation(async (id: string) => {
       if (id === "users:actor") return { _id: "users:actor", role: "moderator" };
@@ -3149,7 +3120,7 @@ describe("users.banUserInternal", () => {
       ok: true,
       alreadyBanned: true,
       deletedSkills: 0,
-      deletedSkillComments: 1,
+      deletedSkillComments: 0,
     });
     expect(runMutation).toHaveBeenCalledWith(
       expect.anything(),
@@ -3160,10 +3131,7 @@ describe("users.banUserInternal", () => {
         deletedByRole: "moderator",
       }),
     );
-    expect(patch).toHaveBeenCalledWith("comments:active", {
-      softDeletedAt: 1_600_000_000_000,
-      deletedBy: "users:actor",
-    });
+    expect(query).not.toHaveBeenCalledWith("comments");
   });
 });
 

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -36,7 +36,6 @@ import {
   upsertReservedHandleForRightfulOwner,
 } from "./lib/reservedHandles";
 import { buildUserSearchResults } from "./lib/userSearch";
-import { insertStatEvent } from "./skillStatEvents";
 
 const DEFAULT_ROLE = "user";
 const ADMIN_HANDLE = "steipete";
@@ -1596,16 +1595,11 @@ async function banUserWithActor(
       deletedByRole: actor.role === "admin" ? "admin" : "moderator",
       cursor: undefined,
     });
-    const deletedSkillComments = await softDeleteUserCommentsForBan(ctx, {
-      userId: targetUserId,
-      deletedBy: actor._id,
-      deletedAt: target.deletedAt,
-    });
     return {
       ok: true as const,
       alreadyBanned: true,
       deletedSkills: 0,
-      deletedSkillComments,
+      deletedSkillComments: 0,
     };
   }
 
@@ -1630,12 +1624,6 @@ async function banUserWithActor(
       await ctx.db.patch(token._id, { revokedAt: now });
     }
   }
-
-  const deletedSkillComments = await softDeleteUserCommentsForBan(ctx, {
-    userId: targetUserId,
-    deletedBy: actor._id,
-    deletedAt: now,
-  });
 
   await ctx.db.patch(targetUserId, {
     deletedAt: now,
@@ -1670,7 +1658,7 @@ async function banUserWithActor(
       deletedPackages: deletedPackageCount,
       revokedPackagePublishTokens,
       scheduledPackages,
-      deletedSkillComments,
+      deletedSkillComments: 0,
       reason: reason || undefined,
     },
     createdAt: now,
@@ -1689,7 +1677,7 @@ async function banUserWithActor(
     ok: true as const,
     alreadyBanned: false,
     deletedSkills: hiddenCount,
-    deletedSkillComments,
+    deletedSkillComments: 0,
     scheduledSkills,
   };
 }
@@ -2329,12 +2317,6 @@ export const autobanMalwareAuthorInternal = internalMutation({
       }
     }
 
-    const deletedSkillComments = await softDeleteUserCommentsForBan(ctx, {
-      userId: args.ownerUserId,
-      deletedBy: args.ownerUserId,
-      deletedAt: now,
-    });
-
     // Ban the user
     await ctx.db.patch(args.ownerUserId, {
       deletedAt: now,
@@ -2368,7 +2350,7 @@ export const autobanMalwareAuthorInternal = internalMutation({
       deletedPackages: deletedPackageCount,
       revokedPackagePublishTokens,
       scheduledPackages,
-      deletedSkillComments,
+      deletedSkillComments: 0,
     };
     if (args.sha256hash?.trim()) {
       metadata.sha256hash = args.sha256hash.trim();
@@ -2406,7 +2388,7 @@ export const autobanMalwareAuthorInternal = internalMutation({
       ok: true,
       alreadyBanned: false,
       deletedSkills: hiddenCount,
-      deletedSkillComments,
+      deletedSkillComments: 0,
       scheduledSkills,
     };
   },
@@ -2542,26 +2524,3 @@ export const recordStaffEmailSentAuditInternal = internalMutation({
     return { ok: true as const };
   },
 });
-
-async function softDeleteUserCommentsForBan(
-  ctx: MutationCtx,
-  args: { userId: Id<"users">; deletedBy: Id<"users">; deletedAt: number },
-): Promise<number> {
-  let skillComments = 0;
-
-  const comments = await ctx.db
-    .query("comments")
-    .withIndex("by_user", (q) => q.eq("userId", args.userId))
-    .collect();
-  for (const comment of comments) {
-    if (comment.softDeletedAt) continue;
-    await ctx.db.patch(comment._id, {
-      softDeletedAt: args.deletedAt,
-      deletedBy: args.deletedBy,
-    });
-    await insertStatEvent(ctx, { skillId: comment.skillId, kind: "uncomment" });
-    skillComments += 1;
-  }
-
-  return skillComments;
-}

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -289,8 +289,6 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
       current ban so the next matching unban can restore them
   - retimestamps already ban-hidden owned skills to the current ban marker so
     a later matching unban can restore them
-  - soft-deletes any authored legacy skill-comment rows until the retired
-    comments table is purged by a cleanup migration
   - revokes API tokens
   - sets `deletedAt` on the user
 - Admins can manually unban (`deletedAt` + `banReason` cleared); revoked API tokens
@@ -325,22 +323,6 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
 - Moderators cannot ban admins; nobody can ban themselves.
 - Report counters effectively reset because deleted/banned skills are no longer
   considered active in the per-user report cap.
-
-### Retired skill-comment data purge
-
-Before running the schema cleanup migration that removes the legacy `comments`
-and `commentReports` tables, purge their production rows with a single-table
-Convex import that replaces each table with an empty JSON array:
-
-```sh
-printf '[]\n' > /tmp/clawhub-empty-table.json
-bunx convex import --deployment wry-manatee-359 --table commentReports --replace --yes /tmp/clawhub-empty-table.json
-bunx convex import --deployment wry-manatee-359 --table comments --replace --yes /tmp/clawhub-empty-table.json
-```
-
-Run `commentReports` first so report rows are removed before their legacy
-comment targets. After the import, verify both tables are empty before deploying
-the schema cleanup that deletes the tables.
 
 ## User account deletion
 


### PR DESCRIPTION
## Summary
- Remove the retired `comments` and `commentReports` Convex schema tables after the production purge completed.
- Drop ban/hard-delete cleanup branches that queried those tables, while mapping stale scheduled hard-delete phases to the next durable `reports` phase.
- Update moderation spec/test coverage to reflect the post-purge schema cleanup state.

## Production data precondition
The production data purge already completed on `wry-manatee-359` after a manual Convex dashboard backup:

```text
commentReports: deleted 111 of 111, imported 0 documents
comments: deleted 2,375 of 2,375, imported 0 documents
verification: both tables returned no documents via `convex data`; inline read-only query returned no sample ids
```

## Verification
```text
bun run test convex/skills.banBatches.test.ts convex/users.test.ts
PASS: 2 files, 83 tests

bunx convex codegen
PASS

bunx tsc -p packages/schema/tsconfig.json --noEmit
PASS

bunx tsc -p packages/clawhub/tsconfig.json --noEmit
PASS

bun run ci:static
PASS

bun run ci:unit
PASS: 266 files passed, 1 skipped; 3283 tests passed, 1 skipped; coverage 86.59% statements / 75.74% branches / 87.02% functions / 90.07% lines

bun run ci:types-build
PASS

bunx convex dev --once --typecheck=disable
PASS: local Convex reported deleted indexes for comments/commentReports and functions ready

.agents/skills/autoreview/scripts/autoreview --mode local
PASS: autoreview clean, no accepted/actionable findings
```

## Notes
- `bunx convex deploy --dry-run --typecheck=disable` was attempted but blocked by this worktree's linked anonymous local Convex config; the real production deploy workflow is the cloud validation path after merge.
