### PR TITLE
Fix account deletion auth cleanup

### DIFF
--- a/src/routes/-settings.test.tsx
+++ b/src/routes/-settings.test.tsx
@@ -191,6 +191,7 @@ describe("Settings", () => {
     vi.mocked(toast.success).mockReset();
     useAuthActionsMock.mockReturnValue({
       signIn: vi.fn(),
+      signOut: vi.fn().mockResolvedValue(undefined),
     });
     useAuthStatusMock.mockReturnValue({
       isAuthenticated: true,
@@ -308,6 +309,28 @@ describe("Settings", () => {
       expect(getLastQueryArgs("tokens:listMine")).toBe("skip");
       expect(getLastQueryArgs("publishers:listMine")).toBe("skip");
     });
+  });
+
+  it("clears auth state and leaves settings after account deletion succeeds", async () => {
+    const deleteAccount = vi.fn().mockResolvedValue(undefined);
+    const signOut = vi.fn().mockResolvedValue(undefined);
+    useAuthActionsMock.mockReturnValue({ signIn: vi.fn(), signOut });
+    useMutationMock.mockImplementation((mutation) =>
+      getFunctionName(mutation) === "users:deleteAccount" ? deleteAccount : vi.fn(),
+    );
+    mockSignedInSettings({
+      search: { view: "danger" },
+      memberships: [personalMembership],
+    });
+
+    render(<Settings />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete account" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Permanently delete account" }));
+
+    await waitFor(() => expect(deleteAccount).toHaveBeenCalled());
+    await waitFor(() => expect(signOut).toHaveBeenCalled());
+    expect(navigateMock).toHaveBeenCalledWith({ to: "/", replace: true });
   });
 
   it("lets official publisher owners configure a public GitHub sync source", async () => {

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -1,3 +1,4 @@
+import { useAuthActions } from "@convex-dev/auth/react";
 import { Link, createFileRoute, useNavigate, useSearch } from "@tanstack/react-router";
 import { useAction, useMutation, useQuery } from "convex/react";
 import {
@@ -220,6 +221,8 @@ const themeToggleItemClass =
   "!h-20 min-w-0 flex-1 flex-col gap-2 !rounded-[var(--r-btn)] border border-[color:var(--line)] bg-[color:var(--surface)] px-3 text-sm font-semibold text-[color:var(--ink-soft)] opacity-70 hover:border-[color:var(--border-ui-hover)] hover:bg-[color:var(--surface-muted)] hover:text-[color:var(--ink)] hover:opacity-100 data-[state=on]:border-[color:var(--accent)] data-[state=on]:!bg-[color:var(--surface-muted)] data-[state=on]:text-[color:var(--ink)] data-[state=on]:opacity-100 sm:!w-28 sm:flex-none";
 
 export function Settings() {
+  const navigate = useNavigate();
+  const { signOut } = useAuthActions();
   const { isAuthenticated, isLoading: isAuthLoading, me } = useAuthStatus();
   const updateProfile = useMutation(api.users.updateProfile);
   const deleteAccount = useMutation(api.users.deleteAccount);
@@ -403,6 +406,10 @@ export function Settings() {
     setIsDeletingAccount(true);
     try {
       await deleteAccount();
+      // The account deletion mutation purges auth rows server-side; sign-out is best-effort
+      // client cleanup before leaving the authenticated settings route.
+      await signOut().catch(() => undefined);
+      await navigate({ to: "/", replace: true });
     } catch (error) {
       setIsDeletingAccount(false);
       toast.error(getUserFacingConvexError(error, "Account could not be deleted."));


### PR DESCRIPTION
## Summary

- Clear Convex Auth client state after successful account deletion.
- Replace-navigate away from Settings so stale authenticated subscriptions do not keep the deleted account route alive.
- Add a regression test for sign-out and navigation after account deletion succeeds.

## Proof

- Scenario: local-auth browser account deletion flow in Chromium.
- Command:
  ```bash
  PLAYWRIGHT_LOCAL_AUTH_CONVEX_URL=http://127.0.0.1:3310 PLAYWRIGHT_LOCAL_AUTH_CONVEX_SITE_URL=http://127.0.0.1:3311 PLAYWRIGHT_PORT=4273 bun run test:pw:local-auth -- --project=chromium e2e/local-auth/delete-account-resources.pw.test.ts
  ```
- Result: passed, 1/1 Playwright test.
- Relevant output:
  ```text
  ✓ 1 [chromium] › e2e/local-auth/delete-account-resources.pw.test.ts › users can permanently delete their account and personal publisher resources
  1 passed
  ```

## Tests

```bash
bun run test -- src/routes/-settings.test.tsx
bun run ci:static
bun run ci:unit
bun run ci:types-build
bunx tsc -p packages/schema/tsconfig.json --noEmit
bunx tsc -p packages/clawhub/tsconfig.json --noEmit
.agents/skills/autoreview/scripts/autoreview --mode local
```

All commands above passed. Autoreview reported no accepted/actionable findings.

## Notes

- The local Playwright run required refreshing generated local dependencies with a frozen isolated Bun install and installing the matching Chromium browser binary before rerunning the test.
