### PR TITLE
fix: sanitize ClawPack repair metadata

### DIFF
--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -11497,6 +11497,87 @@ describe("package scan backfill", () => {
     );
   });
 
+  it("sanitizes historical ClawPack metadata before storing repaired release rows", async () => {
+    const pack = npmPackFixture({
+      "package/package.json": JSON.stringify({
+        $schema: "https://json.schemastore.org/package",
+        name: "@scope/demo",
+        version: "1.0.0",
+      }),
+      "package/openclaw.plugin.json": JSON.stringify({
+        $schema: "https://example.com/openclaw-plugin.schema.json",
+        id: "scope.demo",
+        configSchema: {
+          $defs: {
+            token: { type: "string" },
+          },
+        },
+      }),
+      "package/README.md": "# Demo\n",
+    });
+    const storageGet = vi.fn(async (storageId: string) =>
+      storageId === "storage:clawpack"
+        ? new Blob([bytesToArrayBuffer(pack)], { type: "application/octet-stream" })
+        : null,
+    );
+    const storageStore = vi.fn(async () => `storage:repaired-${storageStore.mock.calls.length}`);
+    const runMutation = vi.fn(async (_ref: unknown, args: Record<string, unknown>) => {
+      if (Array.isArray(args.files)) return { repaired: true };
+      return { jobId: "securityScanJobs:1" };
+    });
+    const runAfter = vi.fn().mockResolvedValue(undefined);
+
+    await repairClawPackReleaseFilesInternalHandler(
+      {
+        runQuery: vi.fn(async (_ref: unknown, args: { packageId?: string; releaseId?: string }) => {
+          if (args.releaseId) {
+            return makeReleaseDoc({
+              _id: args.releaseId,
+              packageId: "packages:demo",
+              version: "1.0.0",
+              artifactKind: "npm-pack",
+              clawpackStorageId: "storage:clawpack",
+              npmFileCount: 3,
+              files: [
+                { path: "package.json", size: 10, storageId: "storage:package" },
+                {
+                  path: "openclaw.plugin.json",
+                  size: 10,
+                  storageId: "storage:plugin",
+                },
+              ],
+            });
+          }
+          if (args.packageId === "packages:demo") {
+            return makePackageDoc({ _id: "packages:demo", name: "@scope/demo" });
+          }
+          return null;
+        }),
+        runMutation,
+        scheduler: { runAfter },
+        storage: { get: storageGet, store: storageStore },
+      } as never,
+      { releaseId: "packageReleases:truncated-clawpack" },
+    );
+
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        extractedPackageJson: expect.objectContaining({
+          dollar_schema: "https://json.schemastore.org/package",
+        }),
+        extractedPluginManifest: expect.objectContaining({
+          dollar_schema: "https://example.com/openclaw-plugin.schema.json",
+          configSchema: {
+            dollar_defs: {
+              token: { type: "string" },
+            },
+          },
+        }),
+      }),
+    );
+  });
+
   it("backfills legacy static-only package scan status into the package search digest", async () => {
     const verification = {
       tier: "source-linked",

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -8534,8 +8534,12 @@ async function repairClawPackReleaseFiles(
       npmUnpackedSize: parsed.unpackedSize,
       npmFileCount: parsed.fileCount,
       integritySha256,
-      extractedPackageJson: parsed.packageJson,
-      extractedPluginManifest: parsed.pluginManifest,
+      extractedPackageJson: toConvexSafeJsonValue(parsed.packageJson, {
+        maxDepth: MAX_STORED_PACKAGE_METADATA_DEPTH,
+      }),
+      extractedPluginManifest: toConvexSafeJsonValue(parsed.pluginManifest, {
+        maxDepth: MAX_STORED_PACKAGE_METADATA_DEPTH,
+      }),
       checkedAt: Date.now(),
     },
   );


### PR DESCRIPTION
## Summary
- Sanitize parsed ClawPack `package.json` and `openclaw.plugin.json` metadata before the historical repair mutation stores it.
- Add a regression test for `$schema` / `$defs` metadata that Convex rejects when stored raw.

## Production context
The live repair partially applied 44 of 79 historical ClawPack releases, then stopped on `@openclaw/line@2026.5.3-beta.2` because `openclaw.plugin.json` contains `$schema`. This hotfix reuses the same Convex-safe metadata conversion already used by normal package publishing.

## Proof
- `bunx vitest run convex/packages.public.test.ts -t "sanitizes historical ClawPack metadata"` passed.
- `bunx vitest run convex/packages.public.test.ts -t "historical ClawPack|ClawPack repair"` passed.
- `bun run format:check -- convex/packages.ts convex/packages.public.test.ts` passed.
- `bun run ci:static` passed.
- `bun run ci:types-build` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` passed with no accepted/actionable findings.

## Local note
- `bun run ci:unit` was attempted locally and failed in unrelated email-rendering tests because the local Bun install resolved `htmlparser2` against an incompatible `entities` package export. The targeted repair tests above cover this change; GitHub CI should be treated as authoritative for the full unit suite.
