### PR TITLE
fix: parallelize skill artifact backup uploads

### DIFF
--- a/convex/lib/registryArtifactBackup.test.ts
+++ b/convex/lib/registryArtifactBackup.test.ts
@@ -20,6 +20,7 @@ describe("registry artifact backup settings", () => {
     region: process.env.REGISTRY_BACKUP_S3_REGION,
     skillsRoot: process.env.REGISTRY_BACKUP_SKILLS_ROOT,
     packagesRoot: process.env.REGISTRY_BACKUP_PACKAGES_ROOT,
+    skillFileUploadConcurrency: process.env.REGISTRY_BACKUP_SKILL_FILE_UPLOAD_CONCURRENCY,
   };
 
   afterEach(() => {
@@ -31,6 +32,7 @@ describe("registry artifact backup settings", () => {
     setEnv("REGISTRY_BACKUP_S3_REGION", originalEnv.region);
     setEnv("REGISTRY_BACKUP_SKILLS_ROOT", originalEnv.skillsRoot);
     setEnv("REGISTRY_BACKUP_PACKAGES_ROOT", originalEnv.packagesRoot);
+    setEnv("REGISTRY_BACKUP_SKILL_FILE_UPLOAD_CONCURRENCY", originalEnv.skillFileUploadConcurrency);
   });
 
   it("defaults registry artifact backups to skills and packages object roots", () => {
@@ -309,6 +311,66 @@ describe("registry artifact backup settings", () => {
       kind: "skillVersion",
       version: "1.2.3",
       metadata: { files: [{ path: "SKILL.md", sha256: "sha256:skill" }] },
+    });
+  });
+
+  it("uploads skill files with bounded parallelism before writing version metadata", async () => {
+    process.env.REGISTRY_BACKUP_SKILL_FILE_UPLOAD_CONCURRENCY = "3";
+
+    const calls: Array<{ method: string; key: string }> = [];
+    let activeFileUploads = 0;
+    let maxActiveFileUploads = 0;
+    let completedFileUploads = 0;
+    let completedWhenMetaStarted = 0;
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: URL | string, init?: RequestInit) => {
+        const key = objectKey(String(url));
+        calls.push({ method: init?.method ?? "GET", key });
+        if (!key.endsWith("/_meta.json")) {
+          activeFileUploads += 1;
+          maxActiveFileUploads = Math.max(maxActiveFileUploads, activeFileUploads);
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          activeFileUploads -= 1;
+          completedFileUploads += 1;
+        } else {
+          completedWhenMetaStarted = completedFileUploads;
+        }
+        return response(200, "");
+      }),
+    );
+
+    const files = Array.from({ length: 6 }, (_, index) => ({
+      path: `file-${index}.txt`,
+      size: 6,
+      storageId: `storage:file-${index}` as Id<"_storage">,
+      sha256: `sha256:file-${index}`,
+      contentType: "text/plain",
+    }));
+
+    await backupSkillVersionToObjectStorage(
+      makeStorageCtx(
+        Object.fromEntries(files.map((file) => [file.storageId, `body-${file.path}`])),
+      ) as never,
+      {
+        root: "skills",
+        ownerHandle: "OpenClaw Team",
+        versionId: "skillVersions:demo-1" as Id<"skillVersions">,
+        slug: "demo-skill",
+        displayName: "Demo Skill",
+        version: "1.2.3",
+        publishedAt: 1_700_000_000_000,
+        files,
+      },
+      makeContext(),
+    );
+
+    expect(maxActiveFileUploads).toBe(3);
+    expect(completedWhenMetaStarted).toBe(6);
+    expect(calls.at(-1)).toEqual({
+      method: "PUT",
+      key: "skills/openclaw-team/demo-skill/1%2E2%2E3/_meta.json",
     });
   });
 

--- a/convex/lib/registryArtifactBackup.ts
+++ b/convex/lib/registryArtifactBackup.ts
@@ -7,6 +7,8 @@ import { validateFilePath } from "./skillZip";
 
 const DEFAULT_SKILLS_ROOT = "skills";
 const DEFAULT_PACKAGES_ROOT = "packages";
+const DEFAULT_SKILL_FILE_UPLOAD_CONCURRENCY = 16;
+const MAX_SKILL_FILE_UPLOAD_CONCURRENCY = 64;
 const META_FILENAME = "_meta.json";
 
 type BackupFile = {
@@ -114,12 +116,12 @@ export async function backupSkillVersionToObjectStorage(
     ...params,
   });
 
-  for (const file of planned.fileObjects) {
+  await runWithConcurrency(planned.fileObjects, getSkillFileUploadConcurrency(), async (file) => {
     const blob = await readStorageBlob(ctx, file.storageId);
     await putObject(context, file.key, new Uint8Array(await blob.arrayBuffer()), {
       contentType: file.contentType,
     });
-  }
+  });
 
   await putJsonObject(context, planned.metaPath, planned.meta);
 }
@@ -282,7 +284,43 @@ export function buildPackageReleaseBackupManifest(params: PackageBackupParams & 
 
 export const __registryArtifactBackupTestInternals = {
   encodeBackupPathSegment,
+  getSkillFileUploadConcurrency,
 };
+
+async function runWithConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T, index: number) => Promise<void>,
+) {
+  if (items.length === 0) return;
+  let nextIndex = 0;
+  let firstError: unknown;
+  const workerCount = Math.min(concurrency, items.length);
+
+  async function runWorker() {
+    while (firstError === undefined) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= items.length) return;
+      try {
+        await worker(items[index]!, index);
+      } catch (error) {
+        firstError ??= error;
+        return;
+      }
+    }
+  }
+
+  await Promise.allSettled(Array.from({ length: workerCount }, () => runWorker()));
+  if (firstError !== undefined) throw firstError;
+}
+
+function getSkillFileUploadConcurrency() {
+  const raw = process.env.REGISTRY_BACKUP_SKILL_FILE_UPLOAD_CONCURRENCY;
+  const parsed = raw ? Number.parseInt(raw, 10) : DEFAULT_SKILL_FILE_UPLOAD_CONCURRENCY;
+  if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_SKILL_FILE_UPLOAD_CONCURRENCY;
+  return Math.min(parsed, MAX_SKILL_FILE_UPLOAD_CONCURRENCY);
+}
 
 export function normalizeOwner(value: string) {
   const normalized = value


### PR DESCRIPTION
## Summary

- Upload skill backup files with bounded parallelism instead of one-by-one sequential PUTs.
- Add `REGISTRY_BACKUP_SKILL_FILE_UPLOAD_CONCURRENCY` as an optional tuning knob, defaulting to 16 and capped at 64.
- Keep `_meta.json` as the final write after all skill files finish.

## Proof

- `bunx vitest run convex/lib/registryArtifactBackup.test.ts convex/registryArtifactBackups.test.ts` passed: 43 tests.
- `bunx tsc --noEmit --pretty false` passed.
- `bun run ci:static` passed.
- `bun run ci:unit` passed: 267 files, 3293 tests passed, 1 skipped.
- `git diff --check origin/main..HEAD` passed.

## Notes

- This is intended to unblock large skill artifact backups such as `kraken@1.1.0`; production proof requires merging/deploying this backend change, then invoking the prod backup action for that version.
