### PR TITLE
Fix social cards to show installs instead of downloads

### DIFF
--- a/server/og/fetchPluginOgMeta.test.ts
+++ b/server/og/fetchPluginOgMeta.test.ts
@@ -1,0 +1,36 @@
+/* @vitest-environment node */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchPluginOgMeta } from "./fetchPluginOgMeta";
+
+describe("fetchPluginOgMeta", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reads installs from package API stats", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        package: {
+          name: "@openclaw/codex",
+          displayName: "Codex",
+          summary: "OpenClaw Codex harness.",
+          latestVersion: "1.0.0",
+          stats: { downloads: 99, installs: 1200 },
+          verification: { scanStatus: "clean" },
+        },
+        owner: { handle: "openclaw", image: null },
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const meta = await fetchPluginOgMeta("@openclaw/codex", "https://clawhub.ai");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://clawhub.ai/api/v1/packages/%40openclaw%2Fcodex",
+      { headers: { Accept: "application/json" } },
+    );
+    expect(meta?.stats.installs).toBe(1200);
+  });
+});

--- a/server/og/fetchPluginOgMeta.ts
+++ b/server/og/fetchPluginOgMeta.ts
@@ -6,7 +6,7 @@ export type PluginOgMeta = {
   ownerImage: string | null;
   latestVersion: string | null;
   stats: {
-    downloads: number;
+    installs: number;
   };
   verification: {
     scanStatus: string | null;
@@ -41,7 +41,7 @@ export async function fetchPluginOgMeta(
       ownerImage: payload.owner?.image ?? null,
       latestVersion: payload.package?.latestVersion ?? null,
       stats: {
-        downloads: readNumber(stats.downloads),
+        installs: readNumber(stats.installs),
       },
       verification: payload.package?.verification
         ? { scanStatus: payload.package.verification.scanStatus ?? null }

--- a/server/og/fetchPublisherOgMeta.test.ts
+++ b/server/og/fetchPublisherOgMeta.test.ts
@@ -1,0 +1,51 @@
+/* @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const queryMock = vi.fn();
+const clientCtorMock = vi.fn();
+
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: class ConvexHttpClientMock {
+    constructor(url: string) {
+      clientCtorMock(url);
+    }
+
+    query = queryMock;
+  },
+}));
+
+vi.mock("../../convex/_generated/api", () => ({
+  api: { publishers: { getProfileByHandle: "publishers.getProfileByHandle" } },
+}));
+
+describe("fetchPublisherOgMeta", () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+    clientCtorMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("reads installs from publisher profile stats", async () => {
+    queryMock.mockResolvedValue({
+      handle: "openclaw",
+      kind: "org",
+      displayName: "OpenClaw",
+      bio: "Build with claws.",
+      image: null,
+      stats: { downloads: 99, installs: 1200 },
+    });
+
+    const { fetchPublisherOgMeta } = await import("./fetchPublisherOgMeta");
+    const meta = await fetchPublisherOgMeta("openclaw", "https://example.convex.cloud");
+
+    expect(clientCtorMock).toHaveBeenCalledWith("https://example.convex.cloud");
+    expect(queryMock).toHaveBeenCalledWith("publishers.getProfileByHandle", {
+      handle: "openclaw",
+    });
+    expect(meta?.stats.installs).toBe(1200);
+  });
+});

--- a/server/og/fetchPublisherOgMeta.ts
+++ b/server/og/fetchPublisherOgMeta.ts
@@ -8,7 +8,7 @@ export type PublisherOgMeta = {
   bio: string | null;
   image: string | null;
   stats: {
-    downloads: number;
+    installs: number;
   };
 };
 
@@ -19,7 +19,7 @@ type PublisherProfileResult = {
   bio?: string | null;
   image?: string | null;
   stats?: {
-    downloads?: number;
+    installs?: number;
   };
 } | null;
 
@@ -40,7 +40,7 @@ export async function fetchPublisherOgMeta(
       bio: profile.bio ?? null,
       image: profile.image ?? null,
       stats: {
-        downloads: readNumber(profile.stats?.downloads),
+        installs: readNumber(profile.stats?.installs),
       },
     };
   } catch {

--- a/server/og/fetchSkillOgMeta.test.ts
+++ b/server/og/fetchSkillOgMeta.test.ts
@@ -1,0 +1,37 @@
+/* @vitest-environment node */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchSkillOgMeta } from "./fetchSkillOgMeta";
+
+describe("fetchSkillOgMeta", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reads all-time installs from the public skill API stats", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        skill: {
+          displayName: "Gifgrep",
+          summary: "Search GIFs fast",
+          stats: { downloads: 99, installsAllTime: 1200 },
+        },
+        owner: { handle: "steipete", image: "https://avatars.githubusercontent.com/u/1?v=4" },
+        latestVersion: { version: "1.0.1" },
+        moderation: { verdict: "clean", isSuspicious: false, isMalwareBlocked: false },
+      }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const meta = await fetchSkillOgMeta("gifgrep", "https://clawhub.ai", "@steipete");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://clawhub.ai/api/v1/skills/gifgrep?ownerHandle=steipete",
+      {
+        headers: { Accept: "application/json" },
+      },
+    );
+    expect(meta?.stats.installsAllTime).toBe(1200);
+  });
+});

--- a/server/og/fetchSkillOgMeta.ts
+++ b/server/og/fetchSkillOgMeta.ts
@@ -5,7 +5,7 @@ export type SkillOgMeta = {
   ownerImage: string | null;
   version: string | null;
   stats: {
-    downloads: number;
+    installsAllTime: number;
   };
   moderation: {
     verdict: "clean" | "suspicious" | "malicious" | null;
@@ -14,9 +14,15 @@ export type SkillOgMeta = {
   } | null;
 };
 
-export async function fetchSkillOgMeta(slug: string, apiBase: string): Promise<SkillOgMeta | null> {
+export async function fetchSkillOgMeta(
+  slug: string,
+  apiBase: string,
+  ownerHandle?: string | null,
+): Promise<SkillOgMeta | null> {
   try {
     const url = new URL(`/api/v1/skills/${encodeURIComponent(slug)}`, apiBase);
+    const owner = ownerHandle?.trim().replace(/^@+/, "");
+    if (owner) url.searchParams.set("ownerHandle", owner);
     const response = await fetch(url.toString(), { headers: { Accept: "application/json" } });
     if (!response.ok) return null;
     const payload = (await response.json()) as {
@@ -37,7 +43,7 @@ export async function fetchSkillOgMeta(slug: string, apiBase: string): Promise<S
       ownerImage: payload.owner?.image ?? null,
       version: payload.latestVersion?.version ?? null,
       stats: {
-        downloads: readNumber(stats.downloads),
+        installsAllTime: readNumber(stats.installsAllTime),
       },
       moderation: payload.moderation
         ? {

--- a/server/og/skillOgSvg.test.ts
+++ b/server/og/skillOgSvg.test.ts
@@ -16,7 +16,7 @@ describe("skill OG SVG", () => {
         target: "discord-doctor",
       },
       stats: [
-        { value: "1.2k", label: "Downloads" },
+        { value: "1.2k", label: "Installs" },
         { value: "PASS", label: "Audit" },
       ],
     });

--- a/server/routes/og/plugin.png.test.ts
+++ b/server/routes/og/plugin.png.test.ts
@@ -111,7 +111,7 @@ describe("plugin og route", () => {
       latestVersion: null,
       displayName: "Codex",
       summary: "OpenClaw Codex harness.",
-      stats: { downloads: 1200 },
+      stats: { installs: 1200 },
       verification: { scanStatus: "pending" },
     });
 
@@ -126,7 +126,7 @@ describe("plugin og route", () => {
     expect(buildPluginOgSvgMock).toHaveBeenCalledWith(
       expect.objectContaining({
         stats: [
-          { value: "1.2k", label: "Downloads" },
+          { value: "1.2k", label: "Installs" },
           { value: "PENDING", label: "Audit" },
         ],
       }),
@@ -142,7 +142,7 @@ describe("plugin og route", () => {
       latestVersion: "1.0.0",
       displayName: "Codex",
       summary: "OpenClaw Codex harness.",
-      stats: { downloads: 1200 },
+      stats: { installs: 1200 },
       verification: { scanStatus: "clean" },
     });
 
@@ -153,7 +153,7 @@ describe("plugin og route", () => {
     expect(buildPluginOgSvgMock).toHaveBeenCalledWith(
       expect.objectContaining({
         stats: [
-          { value: "1.2k", label: "Downloads" },
+          { value: "1.2k", label: "Installs" },
           { value: "PASS", label: "Audit" },
         ],
       }),
@@ -166,6 +166,7 @@ describe("plugin og route", () => {
       owner: "openclaw",
       title: "Codex",
       description: "OpenClaw Codex harness.",
+      installs: "0",
     });
 
     const handler = (await import("./plugin.png")).default;
@@ -175,7 +176,31 @@ describe("plugin og route", () => {
     expect(buildPluginOgSvgMock).toHaveBeenCalledWith(
       expect.objectContaining({
         stats: [
-          { value: "0", label: "Downloads" },
+          { value: "0", label: "Installs" },
+          { value: "UNKNOWN", label: "Audit" },
+        ],
+      }),
+    );
+  });
+
+  it("uses explicit installs over legacy downloads query params", async () => {
+    getQueryMock.mockReturnValue({
+      name: "@openclaw/codex",
+      owner: "openclaw",
+      title: "Codex",
+      description: "OpenClaw Codex harness.",
+      installs: "0",
+      downloads: "9.9k",
+    });
+
+    const handler = (await import("./plugin.png")).default;
+    await handler({} as never);
+
+    expect(fetchPluginOgMetaMock).not.toHaveBeenCalled();
+    expect(buildPluginOgSvgMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stats: [
+          { value: "0", label: "Installs" },
           { value: "UNKNOWN", label: "Audit" },
         ],
       }),

--- a/server/routes/og/plugin.png.ts
+++ b/server/routes/og/plugin.png.ts
@@ -19,7 +19,7 @@ type OgQuery = {
   owner?: string;
   title?: string;
   description?: string;
-  downloads?: string;
+  installs?: string;
   audit?: string;
   avatar?: string;
   v?: string;
@@ -63,7 +63,7 @@ export default defineEventHandler(async (event) => {
   const ownerFromQuery = cleanString(query.owner);
   const titleFromQuery = cleanString(query.title);
   const descriptionFromQuery = cleanString(query.description);
-  const downloadsFromQuery = cleanString(query.downloads);
+  const installsFromQuery = cleanString(query.installs);
   const auditFromQuery = cleanString(query.audit);
   const avatarFromQuery = cleanString(query.avatar);
   const needFetch = !ownerFromQuery || !titleFromQuery || !descriptionFromQuery;
@@ -100,8 +100,8 @@ export default defineEventHandler(async (event) => {
     },
     stats: [
       {
-        value: downloadsFromQuery || formatOgStat(meta?.stats.downloads),
-        label: "Downloads",
+        value: installsFromQuery || formatOgStat(meta?.stats.installs),
+        label: "Installs",
       },
       {
         value: (auditFromQuery || getAuditLabel(meta?.verification?.scanStatus)).replace(

--- a/server/routes/og/profile.png.ts
+++ b/server/routes/og/profile.png.ts
@@ -18,7 +18,7 @@ type OgQuery = {
   handle?: string;
   title?: string;
   description?: string;
-  downloads?: string;
+  installs?: string;
   kind?: string;
   avatar?: string;
   v?: string;
@@ -43,11 +43,11 @@ export default defineEventHandler(async (event) => {
 
   const titleFromQuery = cleanString(query.title);
   const descriptionFromQuery = cleanString(query.description);
-  const downloadsFromQuery = cleanString(query.downloads);
+  const installsFromQuery = cleanString(query.installs);
   const kindFromQuery = cleanString(query.kind);
   const avatarFromQuery = cleanString(query.avatar);
   const convexUrl = getConvexUrl();
-  const needFetch = !titleFromQuery || !descriptionFromQuery || !downloadsFromQuery;
+  const needFetch = !titleFromQuery || !descriptionFromQuery || !installsFromQuery;
   const meta = needFetch && convexUrl ? await fetchPublisherOgMeta(handle, convexUrl) : null;
   const handleLabel = `@${meta?.handle || handle}`;
   const title = titleFromQuery || meta?.displayName || handleLabel;
@@ -70,8 +70,8 @@ export default defineEventHandler(async (event) => {
     handleLabel,
     stats: [
       {
-        value: downloadsFromQuery || formatOgStat(meta?.stats.downloads),
-        label: "Downloads",
+        value: installsFromQuery || formatOgStat(meta?.stats.installs),
+        label: "Installs",
       },
     ],
   });

--- a/server/routes/og/skill.png.test.ts
+++ b/server/routes/og/skill.png.test.ts
@@ -108,6 +108,7 @@ describe("skill og route", () => {
       version: "1.0.1",
       title: "Gifgrep",
       description: "Search GIFs fast",
+      installs: "0",
     });
 
     const handler = (await import("./skill.png")).default;
@@ -131,7 +132,7 @@ describe("skill og route", () => {
         target: "gifgrep",
       },
       stats: [
-        { value: "0", label: "Downloads" },
+        { value: "0", label: "Installs" },
         { value: "PASS", label: "Audit" },
       ],
     });
@@ -156,14 +157,18 @@ describe("skill og route", () => {
       displayName: "Gifgrep",
       summary: "Search GIFs fast",
       ownerImage: null,
-      stats: { downloads: 1200 },
+      stats: { installsAllTime: 1200 },
       moderation: { verdict: "clean", isSuspicious: false, isMalwareBlocked: false },
     });
 
     const handler = (await import("./skill.png")).default;
     const response = (await handler({} as never)) as Response;
 
-    expect(fetchSkillOgMetaMock).toHaveBeenCalledWith("gifgrep", "https://preview.clawhub.ai");
+    expect(fetchSkillOgMetaMock).toHaveBeenCalledWith(
+      "gifgrep",
+      "https://preview.clawhub.ai",
+      undefined,
+    );
     expect(response.headers.get("Cache-Control")).toBe("public, max-age=3600");
     expect(buildSkillOgSvgMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -172,7 +177,32 @@ describe("skill og route", () => {
         ownerLabel: "@steipete",
         versionLabel: "latest",
         stats: [
-          { value: "1.2k", label: "Downloads" },
+          { value: "1.2k", label: "Installs" },
+          { value: "PASS", label: "Audit" },
+        ],
+      }),
+    );
+  });
+
+  it("uses explicit installs over legacy downloads query params", async () => {
+    getQueryMock.mockReturnValue({
+      slug: "gifgrep",
+      owner: "steipete",
+      version: "1.0.1",
+      title: "Gifgrep",
+      description: "Search GIFs fast",
+      installs: "0",
+      downloads: "9.9k",
+    });
+
+    const handler = (await import("./skill.png")).default;
+    await handler({} as never);
+
+    expect(fetchSkillOgMetaMock).not.toHaveBeenCalled();
+    expect(buildSkillOgSvgMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stats: [
+          { value: "0", label: "Installs" },
           { value: "PASS", label: "Audit" },
         ],
       }),

--- a/server/routes/og/skill.png.ts
+++ b/server/routes/og/skill.png.ts
@@ -20,7 +20,7 @@ type OgQuery = {
   version?: string;
   title?: string;
   description?: string;
-  downloads?: string;
+  installs?: string;
   audit?: string;
   avatar?: string;
   v?: string;
@@ -54,13 +54,15 @@ export default defineEventHandler(async (event) => {
   const versionFromQuery = cleanString(query.version);
   const titleFromQuery = cleanString(query.title);
   const descriptionFromQuery = cleanString(query.description);
-  const downloadsFromQuery = cleanString(query.downloads);
+  const installsFromQuery = cleanString(query.installs);
   const auditFromQuery = cleanString(query.audit);
   const avatarFromQuery = cleanString(query.avatar);
 
   const needFetch =
     !titleFromQuery || !descriptionFromQuery || !ownerFromQuery || !versionFromQuery;
-  const meta = needFetch ? await fetchSkillOgMeta(slug, getApiBase(getRequestHost(event))) : null;
+  const meta = needFetch
+    ? await fetchSkillOgMeta(slug, getApiBase(getRequestHost(event)), ownerFromQuery || undefined)
+    : null;
 
   const owner = ownerFromQuery || meta?.owner || "";
   const version = versionFromQuery || meta?.version || "";
@@ -100,8 +102,8 @@ export default defineEventHandler(async (event) => {
     },
     stats: [
       {
-        value: downloadsFromQuery || formatOgStat(meta?.stats.downloads),
-        label: "Downloads",
+        value: installsFromQuery || formatOgStat(meta?.stats.installsAllTime),
+        label: "Installs",
       },
       { value: auditLabel.replace(/^Audit\s+/i, ""), label: "Audit" },
     ],

--- a/src/__tests__/skill-route-loader.test.ts
+++ b/src/__tests__/skill-route-loader.test.ts
@@ -344,11 +344,11 @@ describe("skill route loader", () => {
         { property: "og:url", content: "https://clawhub.ai/steipete/weather" },
         {
           property: "og:image",
-          content: "https://clawhub.ai/og/skill?v=7&slug=weather&owner=steipete&version=1.0.0",
+          content: "https://clawhub.ai/og/skill?v=8&slug=weather&owner=steipete&version=1.0.0",
         },
         {
           name: "twitter:image",
-          content: "https://clawhub.ai/og/skill?v=7&slug=weather&owner=steipete&version=1.0.0",
+          content: "https://clawhub.ai/og/skill?v=8&slug=weather&owner=steipete&version=1.0.0",
         },
       ]),
     );

--- a/src/lib/og.test.ts
+++ b/src/lib/og.test.ts
@@ -19,7 +19,7 @@ describe("og helpers", () => {
     expect(meta.url).toContain("/steipete/weather");
     expect(meta.owner).toBe("steipete");
     expect(meta.image).toContain("/og/skill?");
-    expect(meta.image).toContain("v=7");
+    expect(meta.image).toContain("v=8");
     expect(meta.image).toContain("slug=weather");
     expect(meta.image).toContain("owner=steipete");
     expect(meta.image).toContain("version=1.2.3");
@@ -39,7 +39,7 @@ describe("og helpers", () => {
     expect(meta.description).toBe("OpenClaw Codex harness.");
     expect(meta.url).toBe("https://clawhub.ai/plugins/@openclaw/codex");
     expect(meta.image).toContain("/og/plugin?");
-    expect(meta.image).toContain("v=2");
+    expect(meta.image).toContain("v=3");
     expect(meta.image).toContain("name=%40openclaw%2Fcodex");
     expect(meta.image).toContain("version=1.0.0");
   });
@@ -54,7 +54,7 @@ describe("og helpers", () => {
     expect(meta.description).toBe("maton.ai");
     expect(meta.url).toBe("https://clawhub.ai/user/byungkyu");
     expect(meta.image).toContain("/og/profile?");
-    expect(meta.image).toContain("v=2");
+    expect(meta.image).toContain("v=3");
     expect(meta.image).toContain("handle=byungkyu");
   });
 

--- a/src/lib/og.ts
+++ b/src/lib/og.ts
@@ -39,9 +39,9 @@ type BasicMeta = {
   url: string;
 };
 
-const OG_SKILL_IMAGE_LAYOUT_VERSION = "7";
-const OG_PLUGIN_IMAGE_LAYOUT_VERSION = "2";
-const OG_PUBLISHER_IMAGE_LAYOUT_VERSION = "2";
+const OG_SKILL_IMAGE_LAYOUT_VERSION = "8";
+const OG_PLUGIN_IMAGE_LAYOUT_VERSION = "3";
+const OG_PUBLISHER_IMAGE_LAYOUT_VERSION = "3";
 
 function getSiteUrl() {
   return getClawHubSiteUrl();


### PR DESCRIPTION
## Summary

This PR changes the OG/social-card stats from downloads to installs for skill, plugin, org, and publisher cards.

The implementation keeps the existing OG rendering path and only changes the stat source plus label:

- Skill cards read `stats.installsAllTime` from the public skill API.
- Plugin cards read package `stats.installs`.
- Publisher/org cards read profile `stats.installs`.
- `downloads=` is no longer accepted as the stat query param for these OG routes; explicit zero values should use `installs=0`.
- Skill OG metadata fetches include `ownerHandle` when the route has an owner, matching the owner-scoped slug lookup added on `main`.

## Production source check

Captured against the candidate route with production Convex configured, without passing stat numbers in the OG URL.

- Skill `pskoett/self-improving-agent`: production API returned `downloads: 462162`, `installsAllTime: 6923`; OG shows `Installs 6.9k`.
- Plugin `zerogpu-router`: production API returned `downloads: 393`, `installs: 74`; OG shows `Installs 74`.
- Org `openclaw`: production profile returned `installs: 32`; OG shows `Installs 32`.
- Publisher `pskoett`: production profile returned `installs: 6934`; OG shows `Installs 6.9k`.

## Screenshots

| Skill | Plugin |
| --- | --- |
| <img src="https://raw.githubusercontent.com/vyctorbrzezowski/clawhub/ed82fcbb/clawhub-ui-proof/pr-2713/2026-06-17T-production-social-card-installs/candidate/skill-og-production.png" width="420" alt="Skill OG card showing Installs 6.9k"> | <img src="https://raw.githubusercontent.com/vyctorbrzezowski/clawhub/ed82fcbb/clawhub-ui-proof/pr-2713/2026-06-17T-production-social-card-installs/candidate/plugin-og-production.png" width="420" alt="Plugin OG card showing Installs 74"> |

| Org | Publisher |
| --- | --- |
| <img src="https://raw.githubusercontent.com/vyctorbrzezowski/clawhub/ed82fcbb/clawhub-ui-proof/pr-2713/2026-06-17T-production-social-card-installs/candidate/org-og-production.png" width="420" alt="Org OG card showing Installs 32"> | <img src="https://raw.githubusercontent.com/vyctorbrzezowski/clawhub/ed82fcbb/clawhub-ui-proof/pr-2713/2026-06-17T-production-social-card-installs/candidate/publisher-og-production.png" width="420" alt="Publisher OG card showing Installs 6.9k"> |

## Validation

- `bun run test -- server/og/fetchSkillOgMeta.test.ts server/og/fetchPluginOgMeta.test.ts server/og/fetchPublisherOgMeta.test.ts server/routes/og/skill.png.test.ts server/routes/og/plugin.png.test.ts server/og/skillOgSvg.test.ts src/lib/og.test.ts src/__tests__/skill-route-loader.test.ts`
- `git diff --check`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bun run ci:e2e-http`

## CI Notes

- GitHub `e2e-http` is red on this run because `e2e/permissions.e2e.test.ts` timed out at 60s on the runner. The same `bun run ci:e2e-http` command passed locally after the push.
- I attempted `gh run rerun 27725259333 --failed`, but GitHub rejected it with `Must have admin rights to Repository`.
- Vercel is red because deploy authorization is required for this fork PR.
- `bun run proof:ui` could not publish through the repo helper because the local `crabbox` command is unavailable here, so the screenshots above were captured manually from the local candidate route using production Convex.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main` could not complete because the external Codex reviewer hit the account usage limit; `--engine claude` is unavailable on this machine.
