### PR TITLE
fix: bound rate limit counter storage

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -86,6 +86,7 @@ import type * as lib_publisherAbuseScoring from "../lib/publisherAbuseScoring.js
 import type * as lib_publisherCatalogDisplay from "../lib/publisherCatalogDisplay.js";
 import type * as lib_publisherStats from "../lib/publisherStats.js";
 import type * as lib_publishers from "../lib/publishers.js";
+import type * as lib_rateLimitConfig from "../lib/rateLimitConfig.js";
 import type * as lib_recommendationScore from "../lib/recommendationScore.js";
 import type * as lib_registryArtifactBackup from "../lib/registryArtifactBackup.js";
 import type * as lib_reporting from "../lib/reporting.js";
@@ -229,6 +230,7 @@ declare const fullApi: ApiFromModules<{
   "lib/publisherCatalogDisplay": typeof lib_publisherCatalogDisplay;
   "lib/publisherStats": typeof lib_publisherStats;
   "lib/publishers": typeof lib_publishers;
+  "lib/rateLimitConfig": typeof lib_rateLimitConfig;
   "lib/recommendationScore": typeof lib_recommendationScore;
   "lib/registryArtifactBackup": typeof lib_registryArtifactBackup;
   "lib/reporting": typeof lib_reporting;

--- a/convex/crons.test.ts
+++ b/convex/crons.test.ts
@@ -6,11 +6,13 @@ const mocks = vi.hoisted(() => {
   const githubSkillSyncRef = Symbol("github-skill-source-sync");
   const registryArtifactBackupRetryRef = Symbol("registry-artifact-backup-retry");
   const installTelemetryDedupePruneRef = Symbol("install-telemetry-dedupe-prune");
+  const rateLimitCountersPruneRef = Symbol("rate-limit-counters-prune");
   return {
     interval,
     githubSkillSyncRef,
     registryArtifactBackupRetryRef,
     installTelemetryDedupePruneRef,
+    rateLimitCountersPruneRef,
   };
 });
 
@@ -52,6 +54,9 @@ vi.mock("./_generated/api", () => ({
     },
     telemetry: {
       pruneInstallTelemetryDedupesInternal: mocks.installTelemetryDedupePruneRef,
+    },
+    rateLimits: {
+      pruneRateLimitCountersInternal: mocks.rateLimitCountersPruneRef,
     },
   },
 }));
@@ -116,6 +121,17 @@ describe("crons", () => {
       { hours: 24 },
       mocks.installTelemetryDedupePruneRef,
       {},
+    );
+  });
+
+  it("prunes expired rate limit counters frequently", async () => {
+    await import("./crons");
+
+    expect(mocks.interval).toHaveBeenCalledWith(
+      "rate-limit-counters-prune",
+      { minutes: 15 },
+      mocks.rateLimitCountersPruneRef,
+      { batchSize: 500 },
     );
   });
 });

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -128,6 +128,13 @@ if (process.env.CLAWHUB_DISABLE_CRONS !== "1") {
     internal.telemetry.pruneInstallTelemetryDedupesInternal,
     {},
   );
+
+  crons.interval(
+    "rate-limit-counters-prune",
+    { minutes: 15 },
+    internal.rateLimits.pruneRateLimitCountersInternal,
+    { batchSize: 500 },
+  );
 }
 
 export default crons;

--- a/convex/lib/httpRateLimit.test.ts
+++ b/convex/lib/httpRateLimit.test.ts
@@ -214,7 +214,7 @@ describe("applyRateLimit headers", () => {
         .fn()
         .mockRejectedValue(
           new Error(
-            'Document in table "rateLimitShards" changed while this mutation was being run',
+            'Document in table "rateLimitCounters" changed while this mutation was being run',
           ),
         ),
     } as unknown as Parameters<typeof applyRateLimit>[0];
@@ -228,6 +228,29 @@ describe("applyRateLimit headers", () => {
     if (result.ok) return;
     expect(result.response.status).toBe(429);
     expect(result.response.headers.get("Retry-After")).toBe("30");
+  });
+
+  it("selects one of 16 active counter shards", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(2_600_000);
+    vi.spyOn(Math, "random").mockReturnValue(0.999);
+    const ctx = makeRateLimitCtx({
+      ip: {
+        allowed: true,
+        remaining: 19,
+        limit: 20,
+        resetAt: 2_640_000,
+      },
+    });
+    const request = new Request("https://example.com", {
+      headers: { "cf-connecting-ip": "203.0.113.1" },
+    });
+
+    const result = await applyRateLimit(ctx, request, "download");
+
+    expect(result.ok).toBe(true);
+    const runMutation = (ctx as unknown as { runMutation: ReturnType<typeof vi.fn> }).runMutation;
+    const [, args] = runMutation.mock.calls[0] as [unknown, Record<string, unknown>];
+    expect(args.shard).toBe(15);
   });
 
   it("allows authenticated users when user bucket is healthy and shared ip bucket is exhausted", async () => {

--- a/convex/lib/httpRateLimit.ts
+++ b/convex/lib/httpRateLimit.ts
@@ -3,9 +3,8 @@ import type { Doc } from "../_generated/dataModel";
 import type { ActionCtx } from "../_generated/server";
 import { getOptionalApiTokenUser } from "./apiTokenAuth";
 import { corsHeaders, mergeHeaders } from "./httpHeaders";
+import { RATE_LIMIT_COUNTER_SHARDS, RATE_LIMIT_WINDOW_MS } from "./rateLimitConfig";
 
-const RATE_LIMIT_WINDOW_MS = 60_000;
-const RATE_LIMIT_SHARDS = 64;
 export const RATE_LIMITS = {
   read: { ip: 3000, key: 12000, adminKey: 120000 },
   write: { ip: 300, key: 3000, adminKey: 30000 },
@@ -168,7 +167,7 @@ async function checkRateLimit(
       key,
       limit,
       windowMs: RATE_LIMIT_WINDOW_MS,
-      shard: Math.floor(Math.random() * RATE_LIMIT_SHARDS),
+      shard: Math.floor(Math.random() * RATE_LIMIT_COUNTER_SHARDS),
     })) as { allowed: boolean; remaining: number };
   } catch (error) {
     if (isRateLimitWriteConflict(error)) {
@@ -255,7 +254,9 @@ function shouldTrustForwardedIps() {
 function isRateLimitWriteConflict(error: unknown) {
   if (!(error instanceof Error)) return false;
   return (
-    (error.message.includes("rateLimits") || error.message.includes("rateLimitShards")) &&
+    (error.message.includes("rateLimitCounters") ||
+      error.message.includes("rateLimits") ||
+      error.message.includes("rateLimitShards")) &&
     error.message.includes("changed while this mutation was being run")
   );
 }

--- a/convex/lib/rateLimitConfig.ts
+++ b/convex/lib/rateLimitConfig.ts
@@ -1,0 +1,3 @@
+export const RATE_LIMIT_WINDOW_MS = 60_000;
+// Keep enough shards to spread bursty writes while limiting per-window row growth.
+export const RATE_LIMIT_COUNTER_SHARDS = 16;

--- a/convex/maintenance.test.ts
+++ b/convex/maintenance.test.ts
@@ -15,6 +15,10 @@ vi.mock("./_generated/api", () => ({
       getUserOwnedSkillsBackfillPageInternal: Symbol("getUserOwnedSkillsBackfillPageInternal"),
       applyUserStatsBackfillPatchInternal: Symbol("applyUserStatsBackfillPatchInternal"),
       backfillUserStatsInternal: Symbol("backfillUserStatsInternal"),
+      cleanupDeprecatedRateLimitShardsInternal: Symbol("cleanupDeprecatedRateLimitShardsInternal"),
+      deleteDeprecatedRateLimitShardsBatchInternal: Symbol(
+        "deleteDeprecatedRateLimitShardsBatchInternal",
+      ),
       getPublisherStatsBackfillPageInternal: Symbol("getPublisherStatsBackfillPageInternal"),
       recomputePublisherStatsInternal: Symbol("recomputePublisherStatsInternal"),
       backfillPublisherStatsInternal: Symbol("backfillPublisherStatsInternal"),
@@ -54,7 +58,9 @@ const {
   backfillSkillFingerprintsInternalHandler,
   backfillSkillSummariesInternalHandler,
   backfillUserStatsInternalHandler,
+  cleanupDeprecatedRateLimitShardsInternalHandler,
   cleanupEmptySkillsInternalHandler,
+  deleteDeprecatedRateLimitShardsBatchInternalHandler,
   nominateEmptySkillSpammersInternalHandler,
   repairLegacyPublisherOwnershipForUserHandler,
   upsertSkillBadgeRecordInternal,
@@ -1386,6 +1392,179 @@ describe("maintenance empty skill cleanup", () => {
         sampleSlugs: ["spam-a", "spam-b"],
       },
     ]);
+  });
+});
+
+describe("maintenance deprecated rate limit shard cleanup", () => {
+  it("dry-runs one bounded default-order batch without deleting rows", async () => {
+    const rows = [
+      { _id: "rateLimitShards:1", key: "ip:a", windowStart: 100, shard: 0 },
+      { _id: "rateLimitShards:2", key: "ip:b", windowStart: 200, shard: 1 },
+    ];
+    const take = vi.fn(async (limit: number) => rows.slice(0, limit));
+    const order = vi.fn(() => ({ take }));
+    const query = vi.fn(() => ({ order }));
+    const deleteRow = vi.fn();
+
+    const result = await deleteDeprecatedRateLimitShardsBatchInternalHandler(
+      {
+        db: {
+          query,
+          delete: deleteRow,
+        },
+      } as never,
+      {
+        dryRun: true,
+        batchSize: 10,
+      },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      dryRun: true,
+      scanned: 2,
+      deleted: 0,
+      isDone: true,
+      firstWindowStart: 100,
+      lastWindowStart: 200,
+    });
+    expect(query).toHaveBeenCalledWith("rateLimitShards");
+    expect(order).toHaveBeenCalledWith("asc");
+    expect(take).toHaveBeenCalledWith(10);
+    expect(deleteRow).not.toHaveBeenCalled();
+  });
+
+  it("requires explicit table confirmation before deleting old shard rows", async () => {
+    await expect(
+      deleteDeprecatedRateLimitShardsBatchInternalHandler(
+        {
+          db: {
+            query: vi.fn(),
+            delete: vi.fn(),
+          },
+        } as never,
+        {
+          dryRun: false,
+          batchSize: 10,
+        },
+      ),
+    ).rejects.toThrow('confirmTable="rateLimitShards"');
+  });
+
+  it("deletes a confirmed bounded batch from the old shard table", async () => {
+    const rows = [
+      { _id: "rateLimitShards:1", key: "ip:a", windowStart: 100, shard: 0 },
+      { _id: "rateLimitShards:2", key: "ip:b", windowStart: 100, shard: 1 },
+    ];
+    const take = vi.fn(async (limit: number) => rows.slice(0, limit));
+    const order = vi.fn(() => ({ take }));
+    const query = vi.fn(() => ({ order }));
+    const deleteRow = vi.fn();
+
+    const result = await deleteDeprecatedRateLimitShardsBatchInternalHandler(
+      {
+        db: {
+          query,
+          delete: deleteRow,
+        },
+      } as never,
+      {
+        dryRun: false,
+        batchSize: 2,
+        confirmTable: "rateLimitShards",
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      dryRun: false,
+      scanned: 2,
+      deleted: 2,
+      isDone: false,
+      firstWindowStart: 100,
+      lastWindowStart: 100,
+    });
+    expect(deleteRow).toHaveBeenCalledTimes(2);
+    expect(deleteRow).toHaveBeenNthCalledWith(1, "rateLimitShards:1");
+    expect(deleteRow).toHaveBeenNthCalledWith(2, "rateLimitShards:2");
+  });
+
+  it("runs exactly one dry-run batch even when maxBatches is larger", async () => {
+    const runMutation = vi.fn(async () => ({
+      ok: true,
+      dryRun: true,
+      scanned: 1_000,
+      deleted: 0,
+      isDone: false,
+      firstWindowStart: 100,
+      lastWindowStart: 200,
+    }));
+
+    const result = await cleanupDeprecatedRateLimitShardsInternalHandler(
+      { runMutation, scheduler: { runAfter: vi.fn() } } as never,
+      { dryRun: true, batchSize: 1_000, maxBatches: 50 },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      dryRun: true,
+      batchSize: 1_000,
+      maxBatches: 1,
+      batches: 1,
+      scanned: 1_000,
+      deleted: 0,
+      isDone: false,
+      scheduledNext: false,
+    });
+    expect(runMutation).toHaveBeenCalledTimes(1);
+  });
+
+  it("schedules a continuation when requested and old shard cleanup is incomplete", async () => {
+    const runMutation = vi.fn(async () => ({
+      ok: true,
+      dryRun: false,
+      scanned: 500,
+      deleted: 500,
+      isDone: false,
+      firstWindowStart: 100,
+      lastWindowStart: 200,
+    }));
+    const runAfter = vi.fn();
+
+    const result = await cleanupDeprecatedRateLimitShardsInternalHandler(
+      { runMutation, scheduler: { runAfter } } as never,
+      {
+        dryRun: false,
+        batchSize: 500,
+        maxBatches: 2,
+        continueOnIncomplete: true,
+        confirmTable: "rateLimitShards",
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      dryRun: false,
+      batchSize: 500,
+      maxBatches: 2,
+      batches: 2,
+      scanned: 1_000,
+      deleted: 1_000,
+      isDone: false,
+      scheduledNext: true,
+    });
+    expect(runMutation).toHaveBeenCalledTimes(2);
+    expect(runAfter).toHaveBeenCalledWith(
+      0,
+      internal.maintenance.cleanupDeprecatedRateLimitShardsInternal,
+      {
+        dryRun: false,
+        batchSize: 500,
+        maxBatches: 2,
+        continueOnIncomplete: true,
+        confirmTable: "rateLimitShards",
+      },
+    );
   });
 });
 

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -29,6 +29,11 @@ const DEFAULT_BATCH_SIZE = 50;
 const MAX_BATCH_SIZE = 200;
 const DEFAULT_MAX_BATCHES = 20;
 const MAX_MAX_BATCHES = 200;
+const DEPRECATED_RATE_LIMIT_SHARD_CLEANUP_CONFIRM_TABLE = "rateLimitShards";
+const DEFAULT_DEPRECATED_RATE_LIMIT_SHARD_CLEANUP_BATCH_SIZE = 500;
+const MAX_DEPRECATED_RATE_LIMIT_SHARD_CLEANUP_BATCH_SIZE = 1_000;
+const DEFAULT_DEPRECATED_RATE_LIMIT_SHARD_CLEANUP_MAX_BATCHES = 1;
+const MAX_DEPRECATED_RATE_LIMIT_SHARD_CLEANUP_MAX_BATCHES = 100;
 const DEFAULT_EMPTY_SKILL_MAX_README_BYTES = 8000;
 const DEFAULT_EMPTY_SKILL_NOMINATION_THRESHOLD = 3;
 const PLATFORM_SKILL_LICENSE = "MIT-0" as const;
@@ -90,6 +95,43 @@ type UserOwnedSkillsBackfillPageResult = {
   items: Array<Pick<Doc<"skills">, "stats" | "softDeletedAt">>;
   cursor: string | null;
   isDone: boolean;
+};
+
+type DeprecatedRateLimitShardCleanupBatchResult = {
+  ok: true;
+  dryRun: boolean;
+  scanned: number;
+  deleted: number;
+  isDone: boolean;
+  firstWindowStart: number | null;
+  lastWindowStart: number | null;
+};
+
+type DeprecatedRateLimitShardCleanupBatchTiming = DeprecatedRateLimitShardCleanupBatchResult & {
+  batch: number;
+  elapsedMs: number;
+};
+
+type DeprecatedRateLimitShardCleanupActionArgs = {
+  dryRun?: boolean;
+  batchSize?: number;
+  maxBatches?: number;
+  continueOnIncomplete?: boolean;
+  confirmTable?: string;
+};
+
+type DeprecatedRateLimitShardCleanupResult = {
+  ok: true;
+  dryRun: boolean;
+  batchSize: number;
+  maxBatches: number;
+  batches: number;
+  scanned: number;
+  deleted: number;
+  isDone: boolean;
+  scheduledNext: boolean;
+  elapsedMs: number;
+  batchTimings: DeprecatedRateLimitShardCleanupBatchTiming[];
 };
 
 type LegacyPublisherOwnershipTargetPhase = "skills" | "packages";
@@ -185,6 +227,159 @@ export const applySkillBackfillPatchInternal = internalMutation({
       await ctx.db.patch(args.versionId, { parsed: args.parsed });
     }
     return { ok: true as const };
+  },
+});
+
+export async function deleteDeprecatedRateLimitShardsBatchInternalHandler(
+  ctx: Pick<MutationCtx, "db">,
+  args: {
+    dryRun?: boolean;
+    batchSize?: number;
+    confirmTable?: string;
+  },
+): Promise<DeprecatedRateLimitShardCleanupBatchResult> {
+  const dryRun = Boolean(args.dryRun);
+  if (!dryRun && args.confirmTable !== DEPRECATED_RATE_LIMIT_SHARD_CLEANUP_CONFIRM_TABLE) {
+    throw new ConvexError(
+      `Refusing to delete deprecated rate limit shard rows without confirmTable="${DEPRECATED_RATE_LIMIT_SHARD_CLEANUP_CONFIRM_TABLE}"`,
+    );
+  }
+
+  const batchSize = clampInt(
+    args.batchSize ?? DEFAULT_DEPRECATED_RATE_LIMIT_SHARD_CLEANUP_BATCH_SIZE,
+    1,
+    MAX_DEPRECATED_RATE_LIMIT_SHARD_CLEANUP_BATCH_SIZE,
+  );
+  const rows = await ctx.db.query("rateLimitShards").order("asc").take(batchSize);
+
+  if (!dryRun) {
+    for (const row of rows) {
+      await ctx.db.delete(row._id);
+    }
+  }
+
+  return {
+    ok: true as const,
+    dryRun,
+    scanned: rows.length,
+    deleted: dryRun ? 0 : rows.length,
+    isDone: rows.length < batchSize,
+    firstWindowStart: rows[0]?.windowStart ?? null,
+    lastWindowStart: rows.at(-1)?.windowStart ?? null,
+  };
+}
+
+export const deleteDeprecatedRateLimitShardsBatchInternal = internalMutation({
+  args: {
+    dryRun: v.optional(v.boolean()),
+    batchSize: v.optional(v.number()),
+    confirmTable: v.optional(v.string()),
+  },
+  handler: deleteDeprecatedRateLimitShardsBatchInternalHandler,
+});
+
+export async function cleanupDeprecatedRateLimitShardsInternalHandler(
+  ctx: Pick<ActionCtx, "runMutation" | "scheduler">,
+  args: DeprecatedRateLimitShardCleanupActionArgs,
+): Promise<DeprecatedRateLimitShardCleanupResult> {
+  const dryRun = Boolean(args.dryRun);
+  if (!dryRun && args.confirmTable !== DEPRECATED_RATE_LIMIT_SHARD_CLEANUP_CONFIRM_TABLE) {
+    throw new ConvexError(
+      `Refusing to delete deprecated rate limit shard rows without confirmTable="${DEPRECATED_RATE_LIMIT_SHARD_CLEANUP_CONFIRM_TABLE}"`,
+    );
+  }
+
+  const batchSize = clampInt(
+    args.batchSize ?? DEFAULT_DEPRECATED_RATE_LIMIT_SHARD_CLEANUP_BATCH_SIZE,
+    1,
+    MAX_DEPRECATED_RATE_LIMIT_SHARD_CLEANUP_BATCH_SIZE,
+  );
+  const maxBatches = dryRun
+    ? 1
+    : clampInt(
+        args.maxBatches ?? DEFAULT_DEPRECATED_RATE_LIMIT_SHARD_CLEANUP_MAX_BATCHES,
+        1,
+        MAX_DEPRECATED_RATE_LIMIT_SHARD_CLEANUP_MAX_BATCHES,
+      );
+  const startedAt = Date.now();
+  const batchTimings: DeprecatedRateLimitShardCleanupBatchTiming[] = [];
+  let scanned = 0;
+  let deleted = 0;
+  let isDone = false;
+
+  for (let batch = 1; batch <= maxBatches; batch += 1) {
+    const batchStartedAt = Date.now();
+    const result = (await ctx.runMutation(
+      internal.maintenance.deleteDeprecatedRateLimitShardsBatchInternal,
+      {
+        dryRun,
+        batchSize,
+        confirmTable: args.confirmTable,
+      },
+    )) as DeprecatedRateLimitShardCleanupBatchResult;
+    batchTimings.push({
+      ...result,
+      batch,
+      elapsedMs: Date.now() - batchStartedAt,
+    });
+    scanned += result.scanned;
+    deleted += result.deleted;
+    isDone = result.isDone;
+    if (result.isDone || result.scanned === 0) break;
+  }
+
+  const scheduledNext = !dryRun && !isDone && Boolean(args.continueOnIncomplete);
+  if (scheduledNext) {
+    await ctx.scheduler.runAfter(0, internal.maintenance.cleanupDeprecatedRateLimitShardsInternal, {
+      dryRun: false,
+      batchSize,
+      maxBatches,
+      continueOnIncomplete: true,
+      confirmTable: DEPRECATED_RATE_LIMIT_SHARD_CLEANUP_CONFIRM_TABLE,
+    });
+  }
+
+  return {
+    ok: true as const,
+    dryRun,
+    batchSize,
+    maxBatches,
+    batches: batchTimings.length,
+    scanned,
+    deleted,
+    isDone,
+    scheduledNext,
+    elapsedMs: Date.now() - startedAt,
+    batchTimings,
+  };
+}
+
+export const cleanupDeprecatedRateLimitShardsInternal = internalAction({
+  args: {
+    dryRun: v.optional(v.boolean()),
+    batchSize: v.optional(v.number()),
+    maxBatches: v.optional(v.number()),
+    continueOnIncomplete: v.optional(v.boolean()),
+    confirmTable: v.optional(v.string()),
+  },
+  handler: cleanupDeprecatedRateLimitShardsInternalHandler,
+});
+
+export const cleanupDeprecatedRateLimitShards: ReturnType<typeof action> = action({
+  args: {
+    dryRun: v.optional(v.boolean()),
+    batchSize: v.optional(v.number()),
+    maxBatches: v.optional(v.number()),
+    continueOnIncomplete: v.optional(v.boolean()),
+    confirmTable: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<DeprecatedRateLimitShardCleanupResult> => {
+    const { user } = await requireUserFromAction(ctx);
+    assertRole(user, ["admin"]);
+    return ctx.runAction(
+      internal.maintenance.cleanupDeprecatedRateLimitShardsInternal,
+      args,
+    ) as Promise<DeprecatedRateLimitShardCleanupResult>;
   },
 });
 

--- a/convex/rateLimits.test.ts
+++ b/convex/rateLimits.test.ts
@@ -1,7 +1,11 @@
 /* @vitest-environment node */
 
 import { describe, expect, it, vi } from "vitest";
-import { consumeRateLimitInternal, getRateLimitStatusInternal } from "./rateLimits";
+import {
+  consumeRateLimitInternal,
+  getRateLimitStatusInternal,
+  pruneRateLimitCountersInternal,
+} from "./rateLimits";
 
 type WrappedHandler<TArgs, TResult> = {
   _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
@@ -21,8 +25,15 @@ const consumeHandler = (
   >
 )._handler;
 
+const pruneHandler = (
+  pruneRateLimitCountersInternal as unknown as WrappedHandler<
+    { batchSize?: number },
+    { deleted: number; hasMore: boolean }
+  >
+)._handler;
+
 describe("rate limit sharding", () => {
-  it("sums shard rows without reading the legacy rateLimits table", async () => {
+  it("sums active counter rows without reading legacy rate limit tables", async () => {
     const ctx = {
       db: {
         query: vi.fn(() => ({
@@ -42,10 +53,12 @@ describe("rate limit sharding", () => {
     expect(result.allowed).toBe(true);
     expect(result.remaining).toBe(11);
     expect(ctx.db.query).toHaveBeenCalledTimes(1);
-    expect(ctx.db.query).toHaveBeenCalledWith("rateLimitShards");
+    expect(ctx.db.query).toHaveBeenCalledWith("rateLimitCounters");
+    expect(ctx.db.query).not.toHaveBeenCalledWith("rateLimitShards");
+    expect(ctx.db.query).not.toHaveBeenCalledWith("rateLimits");
   });
 
-  it("writes only the selected shard when consuming", async () => {
+  it("writes only the selected active counter shard when consuming", async () => {
     const insert = vi.fn();
     const withIndex = vi.fn((_index, builder) => {
       builder({
@@ -82,12 +95,100 @@ describe("rate limit sharding", () => {
 
     expect(withIndex).toHaveBeenCalledWith("by_key_window_shard", expect.any(Function));
     expect(insert).toHaveBeenCalledWith(
-      "rateLimitShards",
+      "rateLimitCounters",
       expect.objectContaining({
         key: "ip:test",
         shard: 7,
         count: 1,
+        expiresAt: expect.any(Number),
       }),
     );
+    expect(insert).not.toHaveBeenCalledWith("rateLimitShards", expect.anything());
+  });
+
+  it("clamps out-of-range shard inputs to the active counter shard range", async () => {
+    const insert = vi.fn();
+    const withIndex = vi.fn((_index, builder) => {
+      builder({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(),
+          })),
+        })),
+      });
+      return { first: vi.fn(async () => null) };
+    });
+    const ctx = {
+      db: {
+        query: vi.fn(() => ({ withIndex })),
+        get: vi.fn(),
+        normalizeId: vi.fn(),
+        insert,
+        patch: vi.fn(),
+        replace: vi.fn(),
+        delete: vi.fn(),
+        system: {
+          get: vi.fn(),
+          query: vi.fn(),
+        },
+      },
+    };
+
+    await consumeHandler(ctx, {
+      key: "ip:test",
+      limit: 20,
+      windowMs: 60_000,
+      shard: 999,
+    });
+
+    expect(insert).toHaveBeenCalledWith(
+      "rateLimitCounters",
+      expect.objectContaining({
+        shard: 15,
+      }),
+    );
+  });
+
+  it("prunes only expired active counter rows in bounded batches", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+    const stale = [
+      { _id: "rateLimitCounters:a", expiresAt: 930_000 },
+      { _id: "rateLimitCounters:b", expiresAt: 940_000 },
+    ];
+    const take = vi.fn(async () => stale);
+    const withIndex = vi.fn((_index, builder) => {
+      builder({ lt: vi.fn() });
+      return { take };
+    });
+    const deleteRow = vi.fn();
+    const ctx = {
+      db: {
+        query: vi.fn(() => ({ withIndex })),
+        get: vi.fn(),
+        normalizeId: vi.fn(),
+        insert: vi.fn(),
+        patch: vi.fn(),
+        replace: vi.fn(),
+        delete: deleteRow,
+        system: {
+          get: vi.fn(),
+          query: vi.fn(),
+        },
+      },
+      scheduler: {
+        runAfter: vi.fn(),
+      },
+    };
+
+    const result = await pruneHandler(ctx, { batchSize: 10 });
+
+    expect(ctx.db.query).toHaveBeenCalledWith("rateLimitCounters");
+    expect(withIndex).toHaveBeenCalledWith("by_expires_at", expect.any(Function));
+    expect(take).toHaveBeenCalledWith(10);
+    expect(deleteRow).toHaveBeenCalledTimes(2);
+    expect(deleteRow).toHaveBeenCalledWith("rateLimitCounters:a");
+    expect(deleteRow).toHaveBeenCalledWith("rateLimitCounters:b");
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
+    expect(result).toEqual({ deleted: 2, hasMore: false });
   });
 });

--- a/convex/rateLimits.ts
+++ b/convex/rateLimits.ts
@@ -1,5 +1,11 @@
 import { v } from "convex/values";
+import { internal } from "./_generated/api";
 import { internalMutation, internalQuery } from "./functions";
+import { RATE_LIMIT_COUNTER_SHARDS } from "./lib/rateLimitConfig";
+
+const RATE_LIMIT_COUNTER_RETENTION_BUFFER_MS = 5 * 60_000;
+const DEFAULT_PRUNE_RATE_LIMIT_COUNTERS_BATCH_SIZE = 200;
+const MAX_PRUNE_RATE_LIMIT_COUNTERS_BATCH_SIZE = 1_000;
 
 /**
  * Read-only rate limit check. Returns current status without writing anything.
@@ -20,7 +26,7 @@ export const getRateLimitStatusInternal = internalQuery({
     }
 
     const shardRows = await ctx.db
-      .query("rateLimitShards")
+      .query("rateLimitCounters")
       .withIndex("by_key_window", (q) => q.eq("key", args.key).eq("windowStart", windowStart))
       .collect();
 
@@ -50,23 +56,26 @@ export const consumeRateLimitInternal = internalMutation({
   handler: async (ctx, args) => {
     const now = Date.now();
     const windowStart = Math.floor(now / args.windowMs) * args.windowMs;
-    const shard = Math.max(0, Math.floor(args.shard ?? 0));
+    const resetAt = windowStart + args.windowMs;
+    const requestedShard = Number.isFinite(args.shard) ? Math.floor(args.shard ?? 0) : 0;
+    const shard = Math.max(0, Math.min(RATE_LIMIT_COUNTER_SHARDS - 1, requestedShard));
 
     const existing = await ctx.db
-      .query("rateLimitShards")
+      .query("rateLimitCounters")
       .withIndex("by_key_window_shard", (q) =>
         q.eq("key", args.key).eq("windowStart", windowStart).eq("shard", shard),
       )
       .first();
 
     if (!existing) {
-      await ctx.db.insert("rateLimitShards", {
+      await ctx.db.insert("rateLimitCounters", {
         key: args.key,
         windowStart,
         shard,
         count: 1,
         limit: args.limit,
         updatedAt: now,
+        expiresAt: resetAt + RATE_LIMIT_COUNTER_RETENTION_BUFFER_MS,
       });
       return { allowed: true, remaining: Math.max(0, args.limit - 1) };
     }
@@ -75,10 +84,43 @@ export const consumeRateLimitInternal = internalMutation({
       count: existing.count + 1,
       limit: args.limit,
       updatedAt: now,
+      expiresAt: resetAt + RATE_LIMIT_COUNTER_RETENTION_BUFFER_MS,
     });
     return {
       allowed: true,
       remaining: Math.max(0, args.limit - 1),
     };
+  },
+});
+
+export const pruneRateLimitCountersInternal = internalMutation({
+  args: {
+    batchSize: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const requestedBatchSize = Number.isFinite(args.batchSize)
+      ? Math.floor(args.batchSize ?? DEFAULT_PRUNE_RATE_LIMIT_COUNTERS_BATCH_SIZE)
+      : DEFAULT_PRUNE_RATE_LIMIT_COUNTERS_BATCH_SIZE;
+    const batchSize = Math.max(
+      1,
+      Math.min(requestedBatchSize, MAX_PRUNE_RATE_LIMIT_COUNTERS_BATCH_SIZE),
+    );
+    const stale = await ctx.db
+      .query("rateLimitCounters")
+      .withIndex("by_expires_at", (q) => q.lt("expiresAt", Date.now()))
+      .take(batchSize);
+
+    for (const row of stale) {
+      await ctx.db.delete(row._id);
+    }
+
+    const hasMore = stale.length === batchSize;
+    if (hasMore) {
+      await ctx.scheduler.runAfter(0, internal.rateLimits.pruneRateLimitCountersInternal, {
+        batchSize,
+      });
+    }
+
+    return { deleted: stale.length, hasMore };
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2126,6 +2126,19 @@ const rateLimitShards = defineTable({
   .index("by_key_window", ["key", "windowStart"])
   .index("by_key_window_shard", ["key", "windowStart", "shard"]);
 
+const rateLimitCounters = defineTable({
+  key: v.string(),
+  windowStart: v.number(),
+  shard: v.number(),
+  count: v.number(),
+  limit: v.number(),
+  updatedAt: v.number(),
+  expiresAt: v.number(),
+})
+  .index("by_key_window", ["key", "windowStart"])
+  .index("by_key_window_shard", ["key", "windowStart", "shard"])
+  .index("by_expires_at", ["expiresAt"]);
+
 const downloadDedupes = defineTable({
   skillId: v.id("skills"),
   identityHash: v.string(),
@@ -2342,6 +2355,7 @@ export default defineSchema({
   cliDeviceCodes,
   rateLimits,
   rateLimitShards,
+  rateLimitCounters,
   downloadDedupes,
   downloadMetricDedupes,
   packageInstallMetricDedupes,


### PR DESCRIPTION
## Summary

- move active API rate-limit reads/writes from `rateLimitShards` to a new bounded `rateLimitCounters` table
- reduce active counter shards from 64 to 16 and clamp shard inputs at the Convex mutation boundary
- add bounded pruning for new counter rows and a guarded maintenance dry-run/delete path for deprecated `rateLimitShards`

## Safety notes

- legacy `rateLimitShards` remains in schema but is no longer used by active rate-limit code
- no production cleanup is run by this PR
- deprecated shard cleanup is admin-gated, dry-run capable, bounded by batch/max-batch limits, and requires `confirmTable: "rateLimitShards"` for real deletes
- no new index is added to `rateLimitShards`, avoiding a huge legacy-table backfill

## Proof

```bash
bunx vitest run convex/rateLimits.test.ts convex/lib/httpRateLimit.test.ts convex/crons.test.ts convex/maintenance.test.ts
# Test Files  4 passed (4)
# Tests  59 passed (59)

bunx convex dev --once --typecheck=disable
# Convex functions ready

bun run ci:unit
# Test Files  269 passed | 1 skipped (270)
# Tests  3369 passed | 1 skipped (3370)

bun run ci:static
# passed

bun run ci:types-build
# passed

.agents/skills/autoreview/scripts/autoreview --mode local
# autoreview clean: no accepted/actionable findings reported
```
