### PR TITLE
fix: redirect sign-in to dashboard

### DIFF
--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -342,7 +342,7 @@ describe("Header", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Sign in with GitHub" }));
 
-    expect(signInMock).toHaveBeenCalledWith("github", { redirectTo: "/" });
+    expect(signInMock).toHaveBeenCalledWith("github", { redirectTo: "/dashboard" });
     await waitFor(() => {
       expect(setAuthError).toHaveBeenCalledWith("Sign in failed. Please try again.");
     });
@@ -359,7 +359,7 @@ describe("Header", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Sign in with GitHub" }));
 
-    expect(signInMock).toHaveBeenCalledWith("github", { redirectTo: "/" });
+    expect(signInMock).toHaveBeenCalledWith("github", { redirectTo: "/dashboard" });
     await Promise.resolve();
     expect(setAuthError).not.toHaveBeenCalled();
   });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -133,8 +133,6 @@ export default function Header() {
     api.publishers.getMyProfileHandle,
     isAuthenticated && me ? {} : "skip",
   );
-  const signInRedirectTo = getCurrentRelativeUrl();
-
   const [navSearchQuery, setNavSearchQuery] = useState("");
   const [typeaheadOpen, setTypeaheadOpen] = useState(false);
   const [typeaheadTab, setTypeaheadTab] = useState<TypeaheadTab>("skills");
@@ -643,10 +641,7 @@ export default function Header() {
                   disabled={isLoading}
                   onClick={() => {
                     clearAuthError();
-                    void signIn(
-                      "github",
-                      signInRedirectTo ? { redirectTo: signInRedirectTo } : undefined,
-                    )
+                    void signIn("github", { redirectTo: "/dashboard" })
                       .then((result) => {
                         if (result?.signingIn === false && !result.redirect) {
                           setAuthError("Sign in failed. Please try again.");
@@ -1013,12 +1008,6 @@ function getTypeaheadRowBody(item: TypeaheadItem) {
     meta: null,
   };
 }
-
-function getCurrentRelativeUrl() {
-  if (typeof window === "undefined") return "/";
-  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
-}
-
 function NavbarThemeSwitcher({
   mode,
   onSetMode,


### PR DESCRIPTION
## Summary

- route the global GitHub sign-in flow to `/dashboard`
- keep contextual sign-in flows unchanged
- update header authentication tests for the proposed destination

## Why

After authentication, the primary header sign-in should open the user's dashboard instead of returning to the home page.

## Validation

- `bunx vitest run src/__tests__/header.test.tsx`
- `bun run ci:static`
- `VITE_CONVEX_URL=https://example.invalid bun run ci:unit`
- `git diff --check`

No screenshot is included because this changes post-authentication navigation without changing the rendered UI.
