### PR TITLE
fix: encode R2 backup object keys for SigV4

### DIFF
--- a/convex/lib/registryArtifactBackup.test.ts
+++ b/convex/lib/registryArtifactBackup.test.ts
@@ -206,6 +206,16 @@ describe("registry artifact backup settings", () => {
     );
   });
 
+  it("uses strict AWS URI encoding for object keys before signing R2 requests", () => {
+    expect(
+      __registryArtifactBackupTestInternals.encodeObjectKey(
+        "skills/smartpeopleconnected/token-optimizer/1%2E0%2E0/infomaterial/4_github_publish_Alles ist fertig!.txt",
+      ),
+    ).toBe(
+      "skills/smartpeopleconnected/token-optimizer/1%252E0%252E0/infomaterial/4_github_publish_Alles%20ist%20fertig%21.txt",
+    );
+  });
+
   it("preserves valid owner handle punctuation in backup paths", () => {
     const dotted = buildSkillVersionBackupManifest({
       root: "skills",

--- a/convex/lib/registryArtifactBackup.ts
+++ b/convex/lib/registryArtifactBackup.ts
@@ -284,6 +284,7 @@ export function buildPackageReleaseBackupManifest(params: PackageBackupParams & 
 
 export const __registryArtifactBackupTestInternals = {
   encodeBackupPathSegment,
+  encodeObjectKey,
   getSkillFileUploadConcurrency,
 };
 
@@ -483,7 +484,10 @@ function encodeObjectKey(key: string) {
 }
 
 function encodePathSegment(value: string) {
-  return encodeURIComponent(value);
+  return encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
 }
 
 function amzDate(date: Date) {


### PR DESCRIPTION
## Summary

- Encode `! ' ( ) *` in R2 object key path segments before SigV4 signing.
- Add a regression test for the production failing key shape from the registry backup backfill.

## Context

During the historical R2 backfill, R2 rejected this object key with `SignatureDoesNotMatch`:

`skills/smartpeopleconnected/token-optimizer/1%2E0%2E0/infomaterial/4_github_publish_Alles ist fertig!.txt`

AWS SigV4 canonical URI encoding requires `!` to be percent-encoded as `%21`; `encodeURIComponent` leaves it raw.

## Proof

- `bunx vitest run convex/lib/registryArtifactBackup.test.ts convex/registryArtifactBackups.test.ts` passed: 44 tests.
- `bunx tsc --noEmit --pretty false` passed.
- `bun run ci:static` passed.
- `bun run ci:unit` passed: 280 files, 3579 tests passed, 1 skipped.
- `git diff --check` passed.
