### PR TITLE
fix: prune processed skill stat events

### DIFF
--- a/convex/crons.test.ts
+++ b/convex/crons.test.ts
@@ -7,12 +7,14 @@ const mocks = vi.hoisted(() => {
   const registryArtifactBackupRetryRef = Symbol("registry-artifact-backup-retry");
   const installTelemetryDedupePruneRef = Symbol("install-telemetry-dedupe-prune");
   const rateLimitCountersPruneRef = Symbol("rate-limit-counters-prune");
+  const skillStatEventPruneRef = Symbol("skill-stat-event-prune");
   return {
     interval,
     githubSkillSyncRef,
     registryArtifactBackupRetryRef,
     installTelemetryDedupePruneRef,
     rateLimitCountersPruneRef,
+    skillStatEventPruneRef,
   };
 });
 
@@ -33,7 +35,11 @@ vi.mock("./_generated/api", () => ({
       runSkillStatBackfillInternal: Symbol("skill-stats-backfill"),
       updateGlobalStatsAction: Symbol("global-stats-update"),
     },
-    skillStatEvents: { processSkillStatEventsAction: Symbol("skill-stat-events") },
+    skillStatEvents: {
+      processSkillStatEventsAction: Symbol("skill-stat-events"),
+      processSkillStatEventsInternal: Symbol("skill-doc-stat-sync"),
+      pruneProcessedSkillStatEventsInternal: mocks.skillStatEventPruneRef,
+    },
     packages: {
       processPackageStatEventsInternal: Symbol("package-stat-events"),
       backfillPackageReleaseScansInternal: Symbol("package-scan-backfill"),
@@ -131,6 +137,22 @@ describe("crons", () => {
       { minutes: 15 },
       mocks.rateLimitCountersPruneRef,
       { batchSize: 500 },
+    );
+  });
+
+  it("prunes processed skill stat events daily with a seven-day retention window", async () => {
+    await import("./crons");
+
+    expect(mocks.interval).toHaveBeenCalledWith(
+      "skill-stat-events-prune",
+      { hours: 24 },
+      mocks.skillStatEventPruneRef,
+      {
+        retentionDays: 7,
+        batchSize: 1000,
+        maxBatches: 20,
+        confirmationToken: "PRUNE_PROCESSED_SKILL_STAT_EVENTS",
+      },
     );
   });
 });

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -59,6 +59,18 @@ if (process.env.CLAWHUB_DISABLE_CRONS !== "1") {
   );
 
   crons.interval(
+    "skill-stat-events-prune",
+    { hours: 24 },
+    internal.skillStatEvents.pruneProcessedSkillStatEventsInternal,
+    {
+      retentionDays: 7,
+      batchSize: 1000,
+      maxBatches: 20,
+      confirmationToken: "PRUNE_PROCESSED_SKILL_STAT_EVENTS",
+    },
+  );
+
+  crons.interval(
     "global-stats-update",
     { hours: 24 },
     internal.statsMaintenance.updateGlobalStatsAction,

--- a/convex/skillStatEvents.test.ts
+++ b/convex/skillStatEvents.test.ts
@@ -6,9 +6,12 @@ const apiRefs = vi.hoisted(() => ({
   claimSkillStatDocSyncLeaseInternal: Symbol("claimSkillStatDocSyncLeaseInternal"),
   getStatEventCursor: Symbol("getStatEventCursor"),
   getUnprocessedEventBatch: Symbol("getUnprocessedEventBatch"),
+  kickProcessedSkillStatEventPruneInternal: Symbol("kickProcessedSkillStatEventPruneInternal"),
   processSkillStatEventBatchInternal: Symbol("processSkillStatEventBatchInternal"),
   processSkillStatEventsAction: Symbol("processSkillStatEventsAction"),
   processSkillStatEventsInternal: Symbol("processSkillStatEventsInternal"),
+  pruneProcessedSkillStatEventsInternal: Symbol("pruneProcessedSkillStatEventsInternal"),
+  pruneProcessedSkillStatEventBatchInternal: Symbol("pruneProcessedSkillStatEventBatchInternal"),
   releaseSkillStatDocSyncLeaseInternal: Symbol("releaseSkillStatDocSyncLeaseInternal"),
 }));
 
@@ -25,9 +28,12 @@ vi.mock("./_generated/api", () => ({
       claimSkillStatDocSyncLeaseInternal: apiRefs.claimSkillStatDocSyncLeaseInternal,
       getStatEventCursor: apiRefs.getStatEventCursor,
       getUnprocessedEventBatch: apiRefs.getUnprocessedEventBatch,
+      kickProcessedSkillStatEventPruneInternal: apiRefs.kickProcessedSkillStatEventPruneInternal,
       processSkillStatEventBatchInternal: apiRefs.processSkillStatEventBatchInternal,
       processSkillStatEventsAction: apiRefs.processSkillStatEventsAction,
       processSkillStatEventsInternal: apiRefs.processSkillStatEventsInternal,
+      pruneProcessedSkillStatEventsInternal: apiRefs.pruneProcessedSkillStatEventsInternal,
+      pruneProcessedSkillStatEventBatchInternal: apiRefs.pruneProcessedSkillStatEventBatchInternal,
       releaseSkillStatDocSyncLeaseInternal: apiRefs.releaseSkillStatDocSyncLeaseInternal,
     },
   },
@@ -37,6 +43,9 @@ const {
   processSkillStatEventBatchInternal,
   processSkillStatEventsAction,
   processSkillStatEventsInternal,
+  kickProcessedSkillStatEventPruneInternal,
+  pruneProcessedSkillStatEventBatchInternal,
+  pruneProcessedSkillStatEventsInternal,
 } = await import("./skillStatEvents");
 
 const processSkillStatEventBatchInternalHandler = (
@@ -63,6 +72,56 @@ const processSkillStatEventsInternalHandler = (
       ctx: unknown,
       args: { batchSize?: number; maxBatches?: number },
     ) => Promise<{ processed: number; scheduledContinuation: boolean }>;
+  }
+)._handler;
+
+const pruneProcessedSkillStatEventBatchInternalHandler = (
+  pruneProcessedSkillStatEventBatchInternal as unknown as {
+    _handler: (
+      ctx: unknown,
+      args: {
+        cutoffProcessedAt: number;
+        dryRun: boolean;
+        batchSize?: number;
+        confirmationToken?: string;
+      },
+    ) => Promise<{ matched: number; deleted: number; hasMore: boolean }>;
+  }
+)._handler;
+
+const pruneProcessedSkillStatEventsInternalHandler = (
+  pruneProcessedSkillStatEventsInternal as unknown as {
+    _handler: (
+      ctx: unknown,
+      args: {
+        dryRun?: boolean;
+        retentionDays?: number;
+        batchSize?: number;
+        maxBatches?: number;
+        confirmationToken?: string;
+      },
+    ) => Promise<{ matched: number; deleted: number; scheduledContinuation: boolean }>;
+  }
+)._handler;
+
+const kickProcessedSkillStatEventPruneInternalHandler = (
+  kickProcessedSkillStatEventPruneInternal as unknown as {
+    _handler: (
+      ctx: unknown,
+      args: {
+        dryRun?: boolean;
+        retentionDays?: number;
+        batchSize?: number;
+        maxBatches?: number;
+        confirmationToken?: string;
+      },
+    ) => Promise<{
+      ok: true;
+      dryRun: boolean;
+      retentionDays: number;
+      batchSize: number;
+      maxBatches: number;
+    }>;
   }
 )._handler;
 
@@ -317,5 +376,236 @@ describe("skill stat events", () => {
       "skillStatEvents:install",
       expect.objectContaining({ processedAt: expect.any(Number) }),
     );
+  });
+
+  it("dry-runs processed event pruning through a bounded processedAt range", async () => {
+    const oldProcessedEvent = {
+      _id: "skillStatEvents:old",
+      skillId: "skills:1",
+      kind: "download",
+      occurredAt: 1000,
+      processedAt: 2000,
+    };
+    const deleteDoc = vi.fn();
+    const gt = vi.fn(function (this: unknown) {
+      return this;
+    });
+    const lt = vi.fn(function (this: unknown) {
+      return this;
+    });
+    const take = vi.fn(async () => [oldProcessedEvent]);
+    const ctx = {
+      db: {
+        delete: deleteDoc,
+        query: vi.fn((table: string) => {
+          if (table !== "skillStatEvents") throw new Error(`unexpected table ${table}`);
+          return {
+            withIndex: vi.fn((indexName: string, range: (q: unknown) => unknown) => {
+              expect(indexName).toBe("by_unprocessed");
+              range({ gt, lt });
+              return { take };
+            }),
+          };
+        }),
+      },
+    };
+
+    await expect(
+      pruneProcessedSkillStatEventBatchInternalHandler(ctx, {
+        cutoffProcessedAt: 10_000,
+        dryRun: true,
+        batchSize: 5000,
+      }),
+    ).resolves.toMatchObject({ matched: 1, deleted: 0, hasMore: false });
+
+    expect(gt).toHaveBeenCalledWith("processedAt", 0);
+    expect(lt).toHaveBeenCalledWith("processedAt", 10_000);
+    expect(take).toHaveBeenCalledWith(5000);
+    expect(deleteDoc).not.toHaveBeenCalled();
+  });
+
+  it("requires confirmation before deleting old processed stat events", async () => {
+    const ctx = { db: { delete: vi.fn(), query: vi.fn() } };
+
+    await expect(
+      pruneProcessedSkillStatEventBatchInternalHandler(ctx, {
+        cutoffProcessedAt: 10_000,
+        dryRun: false,
+      }),
+    ).rejects.toThrow("confirmationToken=PRUNE_PROCESSED_SKILL_STAT_EVENTS");
+  });
+
+  it("continues processed event pruning when the manual kick hits its batch cap", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(20 * 24 * 60 * 60 * 1000);
+    const runQuery = vi.fn().mockResolvedValue(15 * 24 * 60 * 60 * 1000);
+    const runMutation = vi
+      .fn()
+      .mockResolvedValueOnce({ matched: 1000, deleted: 1000, hasMore: true })
+      .mockResolvedValueOnce({ matched: 1000, deleted: 1000, hasMore: true });
+    const scheduler = { runAfter: vi.fn() };
+
+    await expect(
+      pruneProcessedSkillStatEventsInternalHandler(
+        { runQuery, runMutation, scheduler },
+        {
+          dryRun: false,
+          retentionDays: 7,
+          batchSize: 1000,
+          maxBatches: 2,
+          confirmationToken: "PRUNE_PROCESSED_SKILL_STAT_EVENTS",
+        },
+      ),
+    ).resolves.toMatchObject({
+      matched: 2000,
+      deleted: 2000,
+      scheduledContinuation: true,
+    });
+
+    expect(runQuery).toHaveBeenCalledWith(apiRefs.getStatEventCursor);
+    expect(runMutation).toHaveBeenCalledTimes(2);
+    expect(runMutation.mock.calls[0]?.[0]).toBe(apiRefs.pruneProcessedSkillStatEventBatchInternal);
+    expect(runMutation.mock.calls[0]?.[1]).toMatchObject({
+      cutoffProcessedAt: 13 * 24 * 60 * 60 * 1000,
+      batchSize: 1000,
+      dryRun: false,
+      confirmationToken: "PRUNE_PROCESSED_SKILL_STAT_EVENTS",
+    });
+    expect(scheduler.runAfter).toHaveBeenCalledWith(
+      0,
+      apiRefs.pruneProcessedSkillStatEventsInternal,
+      expect.objectContaining({
+        dryRun: false,
+        retentionDays: 7,
+        batchSize: 1000,
+        maxBatches: 2,
+        confirmationToken: "PRUNE_PROCESSED_SKILL_STAT_EVENTS",
+      }),
+    );
+  });
+
+  it("caps processed event pruning at the daily stats cursor", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(20 * 24 * 60 * 60 * 1000);
+    const dailyCursor = 11 * 24 * 60 * 60 * 1000;
+    const runQuery = vi.fn().mockResolvedValue(dailyCursor);
+    const runMutation = vi.fn().mockResolvedValue({ matched: 0, deleted: 0, hasMore: false });
+    const scheduler = { runAfter: vi.fn() };
+
+    await expect(
+      pruneProcessedSkillStatEventsInternalHandler(
+        { runQuery, runMutation, scheduler },
+        {
+          dryRun: false,
+          retentionDays: 7,
+          batchSize: 1000,
+          maxBatches: 2,
+          confirmationToken: "PRUNE_PROCESSED_SKILL_STAT_EVENTS",
+        },
+      ),
+    ).resolves.toMatchObject({
+      cutoffProcessedAt: dailyCursor,
+      retentionCutoffProcessedAt: 13 * 24 * 60 * 60 * 1000,
+      dailyStatsCursorCreationTime: dailyCursor,
+      matched: 0,
+      deleted: 0,
+      scheduledContinuation: false,
+    });
+
+    expect(runMutation.mock.calls[0]?.[1]).toMatchObject({
+      cutoffProcessedAt: dailyCursor,
+    });
+  });
+
+  it("does not prune processed events before the daily stats cursor exists", async () => {
+    const runQuery = vi.fn().mockResolvedValue(undefined);
+    const runMutation = vi.fn();
+    const scheduler = { runAfter: vi.fn() };
+
+    await expect(
+      pruneProcessedSkillStatEventsInternalHandler(
+        { runQuery, runMutation, scheduler },
+        {
+          dryRun: false,
+          confirmationToken: "PRUNE_PROCESSED_SKILL_STAT_EVENTS",
+        },
+      ),
+    ).resolves.toMatchObject({
+      batches: 0,
+      matched: 0,
+      deleted: 0,
+      stoppedReason: "cursor_not_ready",
+      scheduledContinuation: false,
+    });
+
+    expect(runMutation).not.toHaveBeenCalled();
+    expect(scheduler.runAfter).not.toHaveBeenCalled();
+  });
+
+  it("samples only one processed event batch during dry-run", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(20 * 24 * 60 * 60 * 1000);
+    const runQuery = vi.fn().mockResolvedValue(15 * 24 * 60 * 60 * 1000);
+    const runMutation = vi.fn().mockResolvedValue({ matched: 1000, deleted: 0, hasMore: true });
+    const scheduler = { runAfter: vi.fn() };
+
+    await expect(
+      pruneProcessedSkillStatEventsInternalHandler(
+        { runQuery, runMutation, scheduler },
+        {
+          dryRun: true,
+          retentionDays: 7,
+          batchSize: 1000,
+          maxBatches: 20,
+        },
+      ),
+    ).resolves.toMatchObject({
+      batches: 1,
+      matched: 1000,
+      deleted: 0,
+      stoppedReason: "max_batches",
+      scheduledContinuation: false,
+    });
+
+    expect(runMutation).toHaveBeenCalledTimes(1);
+    expect(scheduler.runAfter).not.toHaveBeenCalled();
+  });
+
+  it("manual prune kick defaults to dry-run and schedules the bounded prune action", async () => {
+    const scheduler = { runAfter: vi.fn() };
+
+    await expect(
+      kickProcessedSkillStatEventPruneInternalHandler({ scheduler }, {}),
+    ).resolves.toEqual({
+      ok: true,
+      dryRun: true,
+      retentionDays: 7,
+      batchSize: 1000,
+      maxBatches: 20,
+    });
+
+    expect(scheduler.runAfter).toHaveBeenCalledWith(
+      0,
+      apiRefs.pruneProcessedSkillStatEventsInternal,
+      {
+        dryRun: true,
+        retentionDays: 7,
+        batchSize: 1000,
+        maxBatches: 20,
+        confirmationToken: undefined,
+      },
+    );
+  });
+
+  it("manual prune kick requires confirmation before scheduling destructive apply", async () => {
+    const scheduler = { runAfter: vi.fn() };
+
+    await expect(
+      kickProcessedSkillStatEventPruneInternalHandler(
+        { scheduler },
+        {
+          dryRun: false,
+        },
+      ),
+    ).rejects.toThrow("confirmationToken=PRUNE_PROCESSED_SKILL_STAT_EVENTS");
+
+    expect(scheduler.runAfter).not.toHaveBeenCalled();
   });
 });

--- a/convex/skillStatEvents.ts
+++ b/convex/skillStatEvents.ts
@@ -182,6 +182,15 @@ const DEFAULT_DOC_SYNC_BATCH_SIZE = 100;
 const MAX_DOC_SYNC_BATCH_SIZE = 100;
 const DEFAULT_DOC_SYNC_MAX_BATCHES = 5;
 const MAX_DOC_SYNC_MAX_BATCHES = 5;
+export const PROCESSED_SKILL_STAT_EVENT_PRUNE_CONFIRMATION_TOKEN =
+  "PRUNE_PROCESSED_SKILL_STAT_EVENTS";
+const DEFAULT_PROCESSED_EVENT_RETENTION_DAYS = 7;
+const MIN_PROCESSED_EVENT_RETENTION_DAYS = 1;
+const MAX_PROCESSED_EVENT_RETENTION_DAYS = 90;
+const DEFAULT_PROCESSED_EVENT_PRUNE_BATCH_SIZE = 1_000;
+const MAX_PROCESSED_EVENT_PRUNE_BATCH_SIZE = 5_000;
+const DEFAULT_PROCESSED_EVENT_PRUNE_MAX_BATCHES = 20;
+const MAX_PROCESSED_EVENT_PRUNE_MAX_BATCHES = 100;
 
 type ClaimSkillStatDocSyncLeaseResult =
   | {
@@ -222,6 +231,27 @@ type SkillStatDocSyncActionResult =
       scheduledContinuation: boolean;
     };
 
+type ProcessedSkillStatEventPruneBatchResult = {
+  cutoffProcessedAt: number;
+  dryRun: boolean;
+  matched: number;
+  deleted: number;
+  hasMore: boolean;
+};
+
+type ProcessedSkillStatEventPruneResult = {
+  cutoffProcessedAt: number;
+  retentionCutoffProcessedAt: number;
+  dailyStatsCursorCreationTime: number | null;
+  retentionDays: number;
+  dryRun: boolean;
+  batches: number;
+  matched: number;
+  deleted: number;
+  stoppedReason: "empty" | "max_batches" | "cursor_not_ready";
+  scheduledContinuation: boolean;
+};
+
 function clampInt(value: number, min: number, max: number) {
   if (!Number.isFinite(value)) return min;
   return Math.max(min, Math.min(Math.floor(value), max));
@@ -241,6 +271,30 @@ function normalizeDocSyncDrainBatchSize(batchSize: number | undefined) {
 
 function normalizeDocSyncMaxBatches(maxBatches: number | undefined) {
   return clampInt(maxBatches ?? DEFAULT_DOC_SYNC_MAX_BATCHES, 1, MAX_DOC_SYNC_MAX_BATCHES);
+}
+
+function normalizeProcessedEventRetentionDays(retentionDays: number | undefined) {
+  return clampInt(
+    retentionDays ?? DEFAULT_PROCESSED_EVENT_RETENTION_DAYS,
+    MIN_PROCESSED_EVENT_RETENTION_DAYS,
+    MAX_PROCESSED_EVENT_RETENTION_DAYS,
+  );
+}
+
+function normalizeProcessedEventPruneBatchSize(batchSize: number | undefined) {
+  return clampInt(
+    batchSize ?? DEFAULT_PROCESSED_EVENT_PRUNE_BATCH_SIZE,
+    1,
+    MAX_PROCESSED_EVENT_PRUNE_BATCH_SIZE,
+  );
+}
+
+function normalizeProcessedEventPruneMaxBatches(maxBatches: number | undefined) {
+  return clampInt(
+    maxBatches ?? DEFAULT_PROCESSED_EVENT_PRUNE_MAX_BATCHES,
+    1,
+    MAX_PROCESSED_EVENT_PRUNE_MAX_BATCHES,
+  );
 }
 
 export const claimSkillStatDocSyncLeaseInternal = internalMutation({
@@ -579,6 +633,179 @@ export const getSkillStatDocSyncStatusInternal = internalQuery({
         : null,
       now,
     };
+  },
+});
+
+export const pruneProcessedSkillStatEventBatchInternal = internalMutation({
+  args: {
+    cutoffProcessedAt: v.number(),
+    dryRun: v.boolean(),
+    batchSize: v.optional(v.number()),
+    confirmationToken: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<ProcessedSkillStatEventPruneBatchResult> => {
+    if (
+      !args.dryRun &&
+      args.confirmationToken !== PROCESSED_SKILL_STAT_EVENT_PRUNE_CONFIRMATION_TOKEN
+    ) {
+      throw new Error(
+        `Apply requires confirmationToken=${PROCESSED_SKILL_STAT_EVENT_PRUNE_CONFIRMATION_TOKEN}`,
+      );
+    }
+
+    const batchSize = normalizeProcessedEventPruneBatchSize(args.batchSize);
+    const events = await ctx.db
+      .query("skillStatEvents")
+      .withIndex("by_unprocessed", (q) =>
+        q.gt("processedAt", 0).lt("processedAt", args.cutoffProcessedAt),
+      )
+      .take(batchSize);
+
+    if (!args.dryRun) {
+      for (const event of events) {
+        await ctx.db.delete(event._id);
+      }
+    }
+
+    return {
+      cutoffProcessedAt: args.cutoffProcessedAt,
+      dryRun: args.dryRun,
+      matched: events.length,
+      deleted: args.dryRun ? 0 : events.length,
+      hasMore: events.length === batchSize,
+    };
+  },
+});
+
+export const pruneProcessedSkillStatEventsInternal: ReturnType<typeof internalAction> =
+  internalAction({
+    args: {
+      dryRun: v.optional(v.boolean()),
+      retentionDays: v.optional(v.number()),
+      batchSize: v.optional(v.number()),
+      maxBatches: v.optional(v.number()),
+      confirmationToken: v.optional(v.string()),
+    },
+    handler: async (ctx, args): Promise<ProcessedSkillStatEventPruneResult> => {
+      const dryRun = args.dryRun ?? false;
+      const retentionDays = normalizeProcessedEventRetentionDays(args.retentionDays);
+      const batchSize = normalizeProcessedEventPruneBatchSize(args.batchSize);
+      const maxBatches = normalizeProcessedEventPruneMaxBatches(args.maxBatches);
+      const retentionCutoffProcessedAt = Date.now() - retentionDays * 24 * 60 * 60 * 1_000;
+      const dailyStatsCursorCreationTime = (await ctx.runQuery(
+        internal.skillStatEvents.getStatEventCursor,
+      )) as number | undefined;
+      const cutoffProcessedAt = Math.min(
+        retentionCutoffProcessedAt,
+        dailyStatsCursorCreationTime ?? 0,
+      );
+
+      if (cutoffProcessedAt <= 0) {
+        return {
+          cutoffProcessedAt,
+          retentionCutoffProcessedAt,
+          dailyStatsCursorCreationTime: dailyStatsCursorCreationTime ?? null,
+          retentionDays,
+          dryRun,
+          batches: 0,
+          matched: 0,
+          deleted: 0,
+          stoppedReason: "cursor_not_ready",
+          scheduledContinuation: false,
+        };
+      }
+
+      let batches = 0;
+      let matched = 0;
+      let deleted = 0;
+      let hasMore = false;
+      let stoppedReason: "empty" | "max_batches" | "cursor_not_ready" = "empty";
+      const batchLimit = dryRun ? 1 : maxBatches;
+
+      for (let index = 0; index < batchLimit; index += 1) {
+        const batch = (await ctx.runMutation(
+          internal.skillStatEvents.pruneProcessedSkillStatEventBatchInternal,
+          {
+            cutoffProcessedAt,
+            dryRun,
+            batchSize,
+            confirmationToken: args.confirmationToken,
+          },
+        )) as ProcessedSkillStatEventPruneBatchResult;
+
+        batches += 1;
+        matched += batch.matched;
+        deleted += batch.deleted;
+        hasMore = batch.hasMore;
+
+        if (!batch.hasMore) {
+          stoppedReason = "empty";
+          break;
+        }
+
+        stoppedReason = "max_batches";
+      }
+
+      if (!dryRun && hasMore && stoppedReason === "max_batches") {
+        await ctx.scheduler.runAfter(
+          0,
+          internal.skillStatEvents.pruneProcessedSkillStatEventsInternal,
+          {
+            dryRun,
+            retentionDays,
+            batchSize,
+            maxBatches,
+            confirmationToken: args.confirmationToken,
+          },
+        );
+      }
+
+      return {
+        cutoffProcessedAt,
+        retentionCutoffProcessedAt,
+        dailyStatsCursorCreationTime: dailyStatsCursorCreationTime ?? null,
+        retentionDays,
+        dryRun,
+        batches,
+        matched,
+        deleted,
+        stoppedReason,
+        scheduledContinuation: !dryRun && hasMore && stoppedReason === "max_batches",
+      };
+    },
+  });
+
+export const kickProcessedSkillStatEventPruneInternal = internalMutation({
+  args: {
+    dryRun: v.optional(v.boolean()),
+    retentionDays: v.optional(v.number()),
+    batchSize: v.optional(v.number()),
+    maxBatches: v.optional(v.number()),
+    confirmationToken: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const dryRun = args.dryRun ?? true;
+    if (!dryRun && args.confirmationToken !== PROCESSED_SKILL_STAT_EVENT_PRUNE_CONFIRMATION_TOKEN) {
+      throw new Error(
+        `Apply requires confirmationToken=${PROCESSED_SKILL_STAT_EVENT_PRUNE_CONFIRMATION_TOKEN}`,
+      );
+    }
+
+    const retentionDays = normalizeProcessedEventRetentionDays(args.retentionDays);
+    const batchSize = normalizeProcessedEventPruneBatchSize(args.batchSize);
+    const maxBatches = normalizeProcessedEventPruneMaxBatches(args.maxBatches);
+    await ctx.scheduler.runAfter(
+      0,
+      internal.skillStatEvents.pruneProcessedSkillStatEventsInternal,
+      {
+        dryRun,
+        retentionDays,
+        batchSize,
+        maxBatches,
+        confirmationToken: args.confirmationToken,
+      },
+    );
+    return { ok: true as const, dryRun, retentionDays, batchSize, maxBatches };
   },
 });
 


### PR DESCRIPTION
## Summary

- add a bounded processed `skillStatEvents` retention action and manual internal kick
- schedule daily pruning with 7-day retention, 1k batches, and continuation scheduling
- guard destructive applies with `PRUNE_PROCESSED_SKILL_STAT_EVENTS`
- cap pruning at the daily-stats cursor so rows are only deleted after both stat consumers have moved past them

## Safety

- no new Convex index; pruning uses the existing `by_unprocessed` processedAt index
- dry-run deletes nothing and samples one batch so it does not over-count the same page
- apply requires the confirmation token
- production manual apply should still be preceded by a Convex dashboard backup and a production dry-run

## Validation

- `bun run test convex/skillStatEvents.test.ts convex/crons.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bunx convex dev --once --typecheck=disable --tail-logs disable`
- `bunx convex run skillStatEvents:pruneProcessedSkillStatEventsInternal '{"dryRun":true,"retentionDays":7,"batchSize":1000,"maxBatches":20}' --typecheck=disable --codegen=disable`
- `.agents/skills/autoreview/scripts/autoreview --mode local --engine codex`
