### PR TITLE
fix: show downloads on skill detail stats

### DIFF
--- a/docs/clawhub.md
+++ b/docs/clawhub.md
@@ -56,7 +56,8 @@ pnpm add -g clawhub
 ClawHub tracks semver versions, tags such as `latest`, changelogs, files,
 downloads, installs, stars, and security scan summaries. Public pages show
 current registry state so users can inspect a skill or plugin before installing
-it.
+it. Downloads include archive fetches and may include automated traffic, while
+installs are the primary adoption signal.
 
 ## Native OpenClaw flows
 

--- a/docs/clawhub.md
+++ b/docs/clawhub.md
@@ -54,8 +54,9 @@ pnpm add -g clawhub
 | Bundle plugins | Packaged plugin bundles for OpenClaw distribution            | `clawhub package publish <source>`           |
 
 ClawHub tracks semver versions, tags such as `latest`, changelogs, files,
-installs, stars, and security scan summaries. Public pages show current registry
-state so users can inspect a skill or plugin before installing it.
+downloads, installs, stars, and security scan summaries. Public pages show
+current registry state so users can inspect a skill or plugin before installing
+it.
 
 ## Native OpenClaw flows
 

--- a/src/components/SkillHeader.test.tsx
+++ b/src/components/SkillHeader.test.tsx
@@ -154,6 +154,11 @@ describe("SkillHeader", () => {
 
     expect(labels.slice(0, 2)).toEqual(["Installs", "Downloads"]);
     expect(values.slice(0, 2)).toEqual(["1", "803"]);
+    expect(
+      screen.getByRole("button", {
+        name: "Downloads include archive fetches and may include automated traffic.",
+      }),
+    ).toBeTruthy();
   });
 
   it("shows the Official tag in the title for official owner skills", () => {

--- a/src/components/SkillHeader.test.tsx
+++ b/src/components/SkillHeader.test.tsx
@@ -121,11 +121,39 @@ describe("SkillHeader", () => {
     expect(onOpenReport).not.toHaveBeenCalled();
     expect(screen.getByText("Owner")).toBeTruthy();
     expect(screen.getByText("Installs")).toBeTruthy();
+    expect(screen.getByText("Downloads")).toBeTruthy();
     expect(screen.getByText("3")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
     expect(container.querySelector('a[href="/user/local"]')).toBeTruthy();
     expect(
       container.querySelector('nav[aria-label="Skill breadcrumbs"] a[href="/user/local"]'),
     ).toBeTruthy();
+  });
+
+  it("shows downloads alongside install counts in skill metadata", () => {
+    const { container } = renderHeader({
+      skill: {
+        ...skill,
+        stats: {
+          ...skill.stats,
+          downloads: 803,
+          installsAllTime: 1,
+        },
+      },
+    });
+
+    const metadata = container.querySelector('dl[aria-label="Skill metadata"]');
+    const labels = Array.from(
+      metadata?.querySelectorAll(".sidebar-metadata-label") ?? [],
+      (label) => label.textContent?.trim(),
+    );
+    const values = Array.from(
+      metadata?.querySelectorAll(".sidebar-metadata-value") ?? [],
+      (value) => value.textContent?.trim(),
+    );
+
+    expect(labels.slice(0, 2)).toEqual(["Installs", "Downloads"]);
+    expect(values.slice(0, 2)).toEqual(["1", "803"]);
   });
 
   it("shows the Official tag in the title for official owner skills", () => {
@@ -174,6 +202,7 @@ describe("SkillHeader", () => {
     renderHeader({ showArchiveMetadata: false });
 
     expect(screen.getByText("Installs")).toBeTruthy();
+    expect(screen.getByText("Downloads")).toBeTruthy();
     expect(screen.getByText("Owner")).toBeTruthy();
     expect(screen.getByText("Last updated")).toBeTruthy();
     expect(screen.queryByText("Current version")).toBeNull();

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -483,7 +483,12 @@ function SkillSidebarStats({
       ariaLabel="Skill metadata"
       density="compact"
       blocks={[
-        { label: "Installs", value: formattedStats.installsAllTime, large: true },
+        {
+          grid: [
+            { label: "Installs", value: formattedStats.installsAllTime, large: true },
+            { label: "Downloads", value: formattedStats.downloads, large: true },
+          ],
+        },
         { label: "Repository", value: githubRepositoryLink },
         {
           label: "Owner",

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import type { ClawdisSkillMetadata } from "clawhub-schema";
 import { PLATFORM_SKILL_LICENSE } from "clawhub-schema/licenseConstants";
-import { Download, Flag, Settings, ShieldCheck, Star, Upload } from "lucide-react";
+import { Download, Flag, Info, Settings, ShieldCheck, Star, Upload } from "lucide-react";
 import type { ReactNode } from "react";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
 import { getSkillBadges } from "../lib/badges";
@@ -486,7 +486,12 @@ function SkillSidebarStats({
         {
           grid: [
             { label: "Installs", value: formattedStats.installsAllTime, large: true },
-            { label: "Downloads", value: formattedStats.downloads, large: true },
+            {
+              key: "Downloads",
+              label: <DownloadsMetadataLabel />,
+              value: formattedStats.downloads,
+              large: true,
+            },
           ],
         },
         { label: "Repository", value: githubRepositoryLink },
@@ -527,5 +532,25 @@ function SkillSidebarStats({
           : []),
       ]}
     />
+  );
+}
+
+function DownloadsMetadataLabel() {
+  const description = "Downloads include archive fetches and may include automated traffic.";
+
+  return (
+    <span className="security-audit-sidebar-label">
+      <span>Downloads</span>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button type="button" className="security-audit-sidebar-info" aria-label={description}>
+            <Info size={13} aria-hidden="true" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" align="start" className="security-report-title-tooltip">
+          {description}
+        </TooltipContent>
+      </Tooltip>
+    </span>
   );
 }

--- a/src/components/skeletons/SkillDetailSkeleton.tsx
+++ b/src/components/skeletons/SkillDetailSkeleton.tsx
@@ -95,9 +95,15 @@ export function SkillDetailSkeleton({ kind = "skill" }: SkillDetailSkeletonProps
                 <aside className="skill-hero-sidebar">
                   <div className="skill-hero-sidebar-stack">
                     <div className="sidebar-metadata sidebar-metadata-compact">
-                      <div className="sidebar-metadata-row sidebar-metadata-row-large">
-                        <Skeleton className="h-3 w-16" />
-                        <Skeleton className="h-8 w-24" />
+                      <div className="sidebar-metadata-grid">
+                        <div className="sidebar-metadata-row sidebar-metadata-row-large">
+                          <Skeleton className="h-3 w-16" />
+                          <Skeleton className="h-8 w-24" />
+                        </div>
+                        <div className="sidebar-metadata-row sidebar-metadata-row-large">
+                          <Skeleton className="h-3 w-20" />
+                          <Skeleton className="h-8 w-24" />
+                        </div>
                       </div>
                       <div className="sidebar-metadata-row">
                         <Skeleton className="h-3 w-14" />


### PR DESCRIPTION
Closes #2691

## Summary
- Show `Downloads` next to `Installs` in the skill detail metadata sidebar so publishers can see both archive fetches and telemetry-confirmed installs.
- Keep installs as the primary adoption signal by leaving public cards, profile cards, and browse/search ranking surfaces unchanged.
- Add a Downloads info tooltip explaining that downloads include archive fetches and may include automated traffic.
- Keep the skill detail skeleton aligned with the two-stat layout and update docs/tests for the new presentation.

## Behavior proof
- Ran the local app against the public read backend:
  `VITE_CONVEX_URL=https://wry-manatee-359.convex.cloud VITE_CONVEX_SITE_URL=https://wry-manatee-359.convex.site bun run dev -- --host 127.0.0.1`
- Opened `http://127.0.0.1:3000/kittitys/local-knowledge-retrieval` with Playwright CLI.
- The real page snapshot showed skill metadata with `Installs` = `1`, `Downloads` = `818`, and a Downloads explanation button labelled `Downloads include archive fetches and may include automated traffic.`
- Copied Playwright snapshot output is also posted in https://github.com/openclaw/clawhub/pull/2728#issuecomment-4739635714.

## Tests
- `VITE_CONVEX_URL=https://example.invalid bunx vitest run src/components/SkillHeader.test.tsx src/__tests__/skill-detail-page.test.tsx`
- `bun run format:check -- docs/clawhub.md src/components/SkillHeader.tsx src/components/SkillHeader.test.tsx`
- `bun run ci:static`

## CI note
- GitHub CI is green on this branch, including `static`, `unit`, `types-build`, `packages`, `e2e-http`, `playwright-smoke`, and `playwright-local-auth`.
- The Vercel preview status is failing because Vercel requires a member of the Amantus Machina team to authorize the deployment; this is unrelated to the code diff.

## Local coverage note
- `VITE_CONVEX_URL=https://example.invalid bun run coverage` still has one unrelated existing local failure in `scripts/skill-cards/run-skill-card-worker.test.ts`: it looks for `/Users/mauriceniu/Documents/New%20project/clawhub-issue-2691/scripts/skill-cards/templates/clawhub-skill-card.md.j2`, which fails because the workspace path contains a space encoded as `%20`. All other coverage tests reported as passed before that failure (`3592 passed`, `1 failed`, `1 skipped`).
