### PR TITLE
fix: shard skill stat event pruning

### DIFF
--- a/convex/skillStatEvents.test.ts
+++ b/convex/skillStatEvents.test.ts
@@ -83,6 +83,8 @@ const pruneProcessedSkillStatEventBatchInternalHandler = (
         cutoffProcessedAt: number;
         dryRun: boolean;
         batchSize?: number;
+        minProcessedAt?: number;
+        maxProcessedAt?: number;
         confirmationToken?: string;
       },
     ) => Promise<{ matched: number; deleted: number; hasMore: boolean }>;
@@ -98,6 +100,8 @@ const pruneProcessedSkillStatEventsInternalHandler = (
         retentionDays?: number;
         batchSize?: number;
         maxBatches?: number;
+        minProcessedAt?: number;
+        maxProcessedAt?: number;
         confirmationToken?: string;
       },
     ) => Promise<{ matched: number; deleted: number; scheduledContinuation: boolean }>;
@@ -113,6 +117,8 @@ const kickProcessedSkillStatEventPruneInternalHandler = (
         retentionDays?: number;
         batchSize?: number;
         maxBatches?: number;
+        minProcessedAt?: number;
+        maxProcessedAt?: number;
         confirmationToken?: string;
       },
     ) => Promise<{
@@ -420,8 +426,54 @@ describe("skill stat events", () => {
 
     expect(gt).toHaveBeenCalledWith("processedAt", 0);
     expect(lt).toHaveBeenCalledWith("processedAt", 10_000);
-    expect(take).toHaveBeenCalledWith(5000);
+    expect(take).toHaveBeenCalledWith(3000);
     expect(deleteDoc).not.toHaveBeenCalled();
+  });
+
+  it("dry-runs processed event pruning within a lane-specific processedAt range", async () => {
+    const laneEvent = {
+      _id: "skillStatEvents:lane",
+      skillId: "skills:1",
+      kind: "download",
+      occurredAt: 1000,
+      processedAt: 7000,
+    };
+    const gte = vi.fn(function (this: unknown) {
+      return this;
+    });
+    const lt = vi.fn(function (this: unknown) {
+      return this;
+    });
+    const take = vi.fn(async () => [laneEvent]);
+    const ctx = {
+      db: {
+        delete: vi.fn(),
+        query: vi.fn((table: string) => {
+          if (table !== "skillStatEvents") throw new Error(`unexpected table ${table}`);
+          return {
+            withIndex: vi.fn((indexName: string, range: (q: unknown) => unknown) => {
+              expect(indexName).toBe("by_unprocessed");
+              range({ gte, lt });
+              return { take };
+            }),
+          };
+        }),
+      },
+    };
+
+    await expect(
+      pruneProcessedSkillStatEventBatchInternalHandler(ctx, {
+        cutoffProcessedAt: 10_000,
+        dryRun: true,
+        batchSize: 1000,
+        minProcessedAt: 5_000,
+        maxProcessedAt: 8_000,
+      }),
+    ).resolves.toMatchObject({ matched: 1, deleted: 0, hasMore: false });
+
+    expect(gte).toHaveBeenCalledWith("processedAt", 5_000);
+    expect(lt).toHaveBeenCalledWith("processedAt", 8_000);
+    expect(take).toHaveBeenCalledWith(1000);
   });
 
   it("requires confirmation before deleting old processed stat events", async () => {
@@ -479,6 +531,49 @@ describe("skill stat events", () => {
         batchSize: 1000,
         maxBatches: 2,
         confirmationToken: "PRUNE_PROCESSED_SKILL_STAT_EVENTS",
+      }),
+    );
+  });
+
+  it("preserves lane bounds when processed event pruning schedules continuation", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(20 * 24 * 60 * 60 * 1000);
+    const runQuery = vi.fn().mockResolvedValue(15 * 24 * 60 * 60 * 1000);
+    const runMutation = vi.fn().mockResolvedValue({ matched: 1000, deleted: 1000, hasMore: true });
+    const scheduler = { runAfter: vi.fn() };
+
+    await expect(
+      pruneProcessedSkillStatEventsInternalHandler(
+        { runQuery, runMutation, scheduler },
+        {
+          dryRun: false,
+          retentionDays: 7,
+          batchSize: 1000,
+          maxBatches: 1,
+          minProcessedAt: 5 * 24 * 60 * 60 * 1000,
+          maxProcessedAt: 9 * 24 * 60 * 60 * 1000,
+          confirmationToken: "PRUNE_PROCESSED_SKILL_STAT_EVENTS",
+        },
+      ),
+    ).resolves.toMatchObject({
+      matched: 1000,
+      deleted: 1000,
+      scheduledContinuation: true,
+    });
+
+    expect(runMutation).toHaveBeenCalledWith(
+      apiRefs.pruneProcessedSkillStatEventBatchInternal,
+      expect.objectContaining({
+        cutoffProcessedAt: 9 * 24 * 60 * 60 * 1000,
+        minProcessedAt: 5 * 24 * 60 * 60 * 1000,
+        maxProcessedAt: 9 * 24 * 60 * 60 * 1000,
+      }),
+    );
+    expect(scheduler.runAfter).toHaveBeenCalledWith(
+      0,
+      apiRefs.pruneProcessedSkillStatEventsInternal,
+      expect.objectContaining({
+        minProcessedAt: 5 * 24 * 60 * 60 * 1000,
+        maxProcessedAt: 9 * 24 * 60 * 60 * 1000,
       }),
     );
   });
@@ -591,6 +686,68 @@ describe("skill stat events", () => {
         maxBatches: 20,
         confirmationToken: undefined,
       },
+    );
+  });
+
+  it("manual prune kick forwards lane bounds to the bounded prune action", async () => {
+    const scheduler = { runAfter: vi.fn() };
+
+    await expect(
+      kickProcessedSkillStatEventPruneInternalHandler(
+        { scheduler },
+        {
+          dryRun: false,
+          retentionDays: 7,
+          batchSize: 3000,
+          maxBatches: 20,
+          minProcessedAt: 5_000,
+          maxProcessedAt: 10_000,
+          confirmationToken: "PRUNE_PROCESSED_SKILL_STAT_EVENTS",
+        },
+      ),
+    ).resolves.toMatchObject({
+      ok: true,
+      dryRun: false,
+      retentionDays: 7,
+      batchSize: 3000,
+      maxBatches: 20,
+    });
+
+    expect(scheduler.runAfter).toHaveBeenCalledWith(
+      0,
+      apiRefs.pruneProcessedSkillStatEventsInternal,
+      expect.objectContaining({
+        minProcessedAt: 5_000,
+        maxProcessedAt: 10_000,
+      }),
+    );
+  });
+
+  it("manual prune kick clamps oversized lane batches to the production-safe batch size", async () => {
+    const scheduler = { runAfter: vi.fn() };
+
+    await expect(
+      kickProcessedSkillStatEventPruneInternalHandler(
+        { scheduler },
+        {
+          dryRun: false,
+          batchSize: 5000,
+          maxBatches: 20,
+          minProcessedAt: 5_000,
+          maxProcessedAt: 10_000,
+          confirmationToken: "PRUNE_PROCESSED_SKILL_STAT_EVENTS",
+        },
+      ),
+    ).resolves.toMatchObject({
+      batchSize: 3000,
+    });
+
+    expect(scheduler.runAfter).toHaveBeenCalledWith(
+      0,
+      apiRefs.pruneProcessedSkillStatEventsInternal,
+      expect.objectContaining({
+        batchSize: 3000,
+      }),
     );
   });
 

--- a/convex/skillStatEvents.ts
+++ b/convex/skillStatEvents.ts
@@ -188,7 +188,7 @@ const DEFAULT_PROCESSED_EVENT_RETENTION_DAYS = 7;
 const MIN_PROCESSED_EVENT_RETENTION_DAYS = 1;
 const MAX_PROCESSED_EVENT_RETENTION_DAYS = 90;
 const DEFAULT_PROCESSED_EVENT_PRUNE_BATCH_SIZE = 1_000;
-const MAX_PROCESSED_EVENT_PRUNE_BATCH_SIZE = 5_000;
+const MAX_PROCESSED_EVENT_PRUNE_BATCH_SIZE = 3_000;
 const DEFAULT_PROCESSED_EVENT_PRUNE_MAX_BATCHES = 20;
 const MAX_PROCESSED_EVENT_PRUNE_MAX_BATCHES = 100;
 
@@ -233,6 +233,8 @@ type SkillStatDocSyncActionResult =
 
 type ProcessedSkillStatEventPruneBatchResult = {
   cutoffProcessedAt: number;
+  minProcessedAt: number | null;
+  maxProcessedAt: number | null;
   dryRun: boolean;
   matched: number;
   deleted: number;
@@ -241,6 +243,8 @@ type ProcessedSkillStatEventPruneBatchResult = {
 
 type ProcessedSkillStatEventPruneResult = {
   cutoffProcessedAt: number;
+  minProcessedAt: number | null;
+  maxProcessedAt: number | null;
   retentionCutoffProcessedAt: number;
   dailyStatsCursorCreationTime: number | null;
   retentionDays: number;
@@ -641,6 +645,8 @@ export const pruneProcessedSkillStatEventBatchInternal = internalMutation({
     cutoffProcessedAt: v.number(),
     dryRun: v.boolean(),
     batchSize: v.optional(v.number()),
+    minProcessedAt: v.optional(v.number()),
+    maxProcessedAt: v.optional(v.number()),
     confirmationToken: v.optional(v.string()),
   },
   handler: async (ctx, args): Promise<ProcessedSkillStatEventPruneBatchResult> => {
@@ -654,11 +660,33 @@ export const pruneProcessedSkillStatEventBatchInternal = internalMutation({
     }
 
     const batchSize = normalizeProcessedEventPruneBatchSize(args.batchSize);
+    const minProcessedAt = args.minProcessedAt;
+    const cutoffProcessedAt = Math.min(args.cutoffProcessedAt, args.maxProcessedAt ?? Infinity);
+
+    if (
+      cutoffProcessedAt <= 0 ||
+      (minProcessedAt !== undefined && cutoffProcessedAt <= minProcessedAt)
+    ) {
+      return {
+        cutoffProcessedAt,
+        minProcessedAt: minProcessedAt ?? null,
+        maxProcessedAt: args.maxProcessedAt ?? null,
+        dryRun: args.dryRun,
+        matched: 0,
+        deleted: 0,
+        hasMore: false,
+      };
+    }
+
     const events = await ctx.db
       .query("skillStatEvents")
-      .withIndex("by_unprocessed", (q) =>
-        q.gt("processedAt", 0).lt("processedAt", args.cutoffProcessedAt),
-      )
+      .withIndex("by_unprocessed", (q) => {
+        const lowerBound =
+          minProcessedAt === undefined
+            ? q.gt("processedAt", 0)
+            : q.gte("processedAt", minProcessedAt);
+        return lowerBound.lt("processedAt", cutoffProcessedAt);
+      })
       .take(batchSize);
 
     if (!args.dryRun) {
@@ -668,7 +696,9 @@ export const pruneProcessedSkillStatEventBatchInternal = internalMutation({
     }
 
     return {
-      cutoffProcessedAt: args.cutoffProcessedAt,
+      cutoffProcessedAt,
+      minProcessedAt: minProcessedAt ?? null,
+      maxProcessedAt: args.maxProcessedAt ?? null,
       dryRun: args.dryRun,
       matched: events.length,
       deleted: args.dryRun ? 0 : events.length,
@@ -684,6 +714,8 @@ export const pruneProcessedSkillStatEventsInternal: ReturnType<typeof internalAc
       retentionDays: v.optional(v.number()),
       batchSize: v.optional(v.number()),
       maxBatches: v.optional(v.number()),
+      minProcessedAt: v.optional(v.number()),
+      maxProcessedAt: v.optional(v.number()),
       confirmationToken: v.optional(v.string()),
     },
     handler: async (ctx, args): Promise<ProcessedSkillStatEventPruneResult> => {
@@ -698,11 +730,14 @@ export const pruneProcessedSkillStatEventsInternal: ReturnType<typeof internalAc
       const cutoffProcessedAt = Math.min(
         retentionCutoffProcessedAt,
         dailyStatsCursorCreationTime ?? 0,
+        args.maxProcessedAt ?? Infinity,
       );
 
       if (cutoffProcessedAt <= 0) {
         return {
           cutoffProcessedAt,
+          minProcessedAt: args.minProcessedAt ?? null,
+          maxProcessedAt: args.maxProcessedAt ?? null,
           retentionCutoffProcessedAt,
           dailyStatsCursorCreationTime: dailyStatsCursorCreationTime ?? null,
           retentionDays,
@@ -711,6 +746,23 @@ export const pruneProcessedSkillStatEventsInternal: ReturnType<typeof internalAc
           matched: 0,
           deleted: 0,
           stoppedReason: "cursor_not_ready",
+          scheduledContinuation: false,
+        };
+      }
+
+      if (args.minProcessedAt !== undefined && cutoffProcessedAt <= args.minProcessedAt) {
+        return {
+          cutoffProcessedAt,
+          minProcessedAt: args.minProcessedAt,
+          maxProcessedAt: args.maxProcessedAt ?? null,
+          retentionCutoffProcessedAt,
+          dailyStatsCursorCreationTime: dailyStatsCursorCreationTime ?? null,
+          retentionDays,
+          dryRun,
+          batches: 0,
+          matched: 0,
+          deleted: 0,
+          stoppedReason: "empty",
           scheduledContinuation: false,
         };
       }
@@ -729,6 +781,8 @@ export const pruneProcessedSkillStatEventsInternal: ReturnType<typeof internalAc
             cutoffProcessedAt,
             dryRun,
             batchSize,
+            minProcessedAt: args.minProcessedAt,
+            maxProcessedAt: args.maxProcessedAt,
             confirmationToken: args.confirmationToken,
           },
         )) as ProcessedSkillStatEventPruneBatchResult;
@@ -755,6 +809,8 @@ export const pruneProcessedSkillStatEventsInternal: ReturnType<typeof internalAc
             retentionDays,
             batchSize,
             maxBatches,
+            minProcessedAt: args.minProcessedAt,
+            maxProcessedAt: args.maxProcessedAt,
             confirmationToken: args.confirmationToken,
           },
         );
@@ -762,6 +818,8 @@ export const pruneProcessedSkillStatEventsInternal: ReturnType<typeof internalAc
 
       return {
         cutoffProcessedAt,
+        minProcessedAt: args.minProcessedAt ?? null,
+        maxProcessedAt: args.maxProcessedAt ?? null,
         retentionCutoffProcessedAt,
         dailyStatsCursorCreationTime: dailyStatsCursorCreationTime ?? null,
         retentionDays,
@@ -781,6 +839,8 @@ export const kickProcessedSkillStatEventPruneInternal = internalMutation({
     retentionDays: v.optional(v.number()),
     batchSize: v.optional(v.number()),
     maxBatches: v.optional(v.number()),
+    minProcessedAt: v.optional(v.number()),
+    maxProcessedAt: v.optional(v.number()),
     confirmationToken: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
@@ -802,6 +862,8 @@ export const kickProcessedSkillStatEventPruneInternal = internalMutation({
         retentionDays,
         batchSize,
         maxBatches,
+        minProcessedAt: args.minProcessedAt,
+        maxProcessedAt: args.maxProcessedAt,
         confirmationToken: args.confirmationToken,
       },
     );


### PR DESCRIPTION
## Summary

- add optional `minProcessedAt` / `maxProcessedAt` lane bounds to processed `skillStatEvents` pruning
- preserve lane bounds through manual kicks and scheduled continuations
- clamp prune batch size to the observed production-safe max of 3000 after `5000` hit Convex's read limit

## Safety

- lanes are half-open ranges: `processedAt >= minProcessedAt && processedAt < maxProcessedAt`
- existing retention and daily-stats cursor cutoffs still cap every lane
- destructive apply still requires `PRUNE_PROCESSED_SKILL_STAT_EVENTS`
- no new index; lanes use the existing `by_unprocessed` / `processedAt` index

## Validation

- `bun run test convex/skillStatEvents.test.ts convex/crons.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bunx convex dev --once --typecheck=disable --tail-logs disable`
- `bunx convex run skillStatEvents:pruneProcessedSkillStatEventsInternal '{"dryRun":true,"retentionDays":7,"batchSize":5000,"maxBatches":20,"minProcessedAt":1000,"maxProcessedAt":2000}' --typecheck=disable --codegen=disable`
- `.agents/skills/autoreview/scripts/autoreview --mode local --engine codex`

## Production plan after deploy

Run several non-overlapping processedAt windows in parallel, each at `batchSize=3000`, `maxBatches=20`, with the existing destructive confirmation token.
