### PR TITLE
fix(deps): resolve static audit advisories

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -149,10 +149,11 @@
   },
   "overrides": {
     "ast-v8-to-istanbul": "1.0.4",
-    "dompurify": "3.4.10",
+    "dompurify": "3.4.11",
     "esbuild": "0.28.1",
     "next": "16.2.6",
     "postcss": "8.5.12",
+    "undici": "7.28.0",
     "ws": "8.21.0",
   },
   "packages": {
@@ -1156,7 +1157,7 @@
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
 
-    "dompurify": ["dompurify@3.4.10", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w=="],
+    "dompurify": ["dompurify@3.4.11", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
@@ -1929,8 +1930,6 @@
     "hast-util-raw/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "htmlparser2/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
-
-    "jsdom/undici": ["undici@7.27.1", "", {}, "sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg=="],
 
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 

--- a/package.json
+++ b/package.json
@@ -154,10 +154,11 @@
   },
   "overrides": {
     "ast-v8-to-istanbul": "1.0.4",
-    "dompurify": "3.4.10",
+    "dompurify": "3.4.11",
     "esbuild": "0.28.1",
     "next": "16.2.6",
     "postcss": "8.5.12",
+    "undici": "7.28.0",
     "ws": "8.21.0"
   }
 }


### PR DESCRIPTION
## Summary
- bump the DOMPurify override to the patched `3.4.11` release
- force transitive undici consumers, including jsdom, onto patched `7.28.0`
- remove the stale nested undici `7.27.1` lockfile resolution without adding audit ignores

This resolves one high-severity and two moderate dependency advisories that caused the repository-wide static gate to fail.

## Verification
- `bun audit`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:packages`
- `bun run ci:types-build`
- `bun run ci:e2e-http`
- `git diff --check`
- `$autoreview` (clean, no actionable findings)
