### PR TITLE
feat: unify header search results

### DIFF
--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -30,6 +30,7 @@ const defaultUnifiedSearchResult = {
         _id: "skills:weather",
         slug: "weather",
         displayName: "Weather Skill",
+        categories: ["development"],
         ownerUserId: "users:local",
         stats: { downloads: 1, stars: 2 },
         createdAt: 1,
@@ -47,6 +48,7 @@ const defaultUnifiedSearchResult = {
         channel: "community",
         isOfficial: false,
         summary: "Plugin weather tools.",
+        categories: ["channels"],
         ownerHandle: "local",
         createdAt: 1,
         updatedAt: 2,
@@ -225,9 +227,12 @@ function compactHeaderCss() {
   throw new Error("Missing compact header media query");
 }
 
+const scrollIntoViewMock = vi.fn();
+
 describe("Header", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
     authStatusMock.mockReturnValue({
       isAuthenticated: false,
       isLoading: false,
@@ -414,9 +419,7 @@ describe("Header", () => {
 
     expect(document.activeElement).toBe(input);
     expect(input.getAttribute("aria-expanded")).toBe("true");
-    expect(screen.getByRole("tablist", { name: "Result type" })).toBeTruthy();
-    expect(screen.getByText("tabs")).toBeTruthy();
-    expect(screen.getByText("results")).toBeTruthy();
+    expect(screen.queryByRole("tablist", { name: "Result type" })).toBeNull();
     expect(screen.getByText("Start typing to search skills and plugins")).toBeTruthy();
     expect(useUnifiedSearchMock).toHaveBeenLastCalledWith(
       "",
@@ -425,27 +428,23 @@ describe("Header", () => {
     );
   });
 
-  it("preserves caret navigation in the search input and switches focused tabs with arrows", () => {
+  it("preserves caret navigation and moves through the unified results with vertical arrows", () => {
     render(<Header />);
 
     const input = screen.getByPlaceholderText("Search skills and plugins");
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: "weather plugin" } });
 
-    const skillsTab = screen.getByRole("tab", { name: "Skills" });
-    const pluginsTab = screen.getByRole("tab", { name: "Plugins" });
-
     expect(fireEvent.keyDown(input, { key: "ArrowLeft" })).toBe(true);
-    expect(skillsTab.getAttribute("aria-selected")).toBe("true");
-
-    skillsTab.focus();
-    fireEvent.keyDown(skillsTab, { key: "ArrowRight" });
-
-    expect(pluginsTab.getAttribute("aria-selected")).toBe("true");
-    expect(document.activeElement).toBe(pluginsTab);
+    const firstActiveId = input.getAttribute("aria-activedescendant");
+    const initialScrollCount = scrollIntoViewMock.mock.calls.length;
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    expect(input.getAttribute("aria-activedescendant")).not.toBe(firstActiveId);
+    expect(scrollIntoViewMock.mock.calls.length).toBeGreaterThan(initialScrollCount);
+    expect(scrollIntoViewMock).toHaveBeenLastCalledWith({ block: "nearest" });
   });
 
-  it("shows tabbed skills and plugins typeahead without users", () => {
+  it("shows skills and plugins together in grouped typeahead sections", () => {
     navigateMock.mockReset();
 
     render(<Header />);
@@ -454,16 +453,17 @@ describe("Header", () => {
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: "weather" } });
 
-    const tablist = screen.getByRole("tablist", { name: "Result type" });
-    expect(within(tablist).getByRole("tab", { name: "Skills" })).toBeTruthy();
-    expect(within(tablist).getByRole("tab", { name: "Plugins" })).toBeTruthy();
-    expect(screen.getByText("tabs")).toBeTruthy();
-    expect(screen.getByText("results")).toBeTruthy();
-
     const typeahead = screen.getByRole("listbox");
+    const skillGroup = within(typeahead).getByRole("group", { name: "Skills" });
+    const pluginGroup = within(typeahead).getByRole("group", { name: "Plugins" });
     expect(screen.getByText("Weather Skill")).toBeTruthy();
     expect(screen.getByText("@local / weather")).toBeTruthy();
-    expect(screen.queryByText("Weather Plugin")).toBeNull();
+    expect(screen.getByText("Weather Plugin")).toBeTruthy();
+    expect(screen.getByText("@local / weather-plugin")).toBeTruthy();
+    expect(skillGroup.querySelector("svg.lucide-wrench")).not.toBeNull();
+    expect(pluginGroup.querySelector("svg.lucide-message-circle")).not.toBeNull();
+    expect(typeahead.querySelector("svg.lucide-package")).toBeNull();
+    expect(screen.queryByRole("tablist", { name: "Result type" })).toBeNull();
     expect(input.getAttribute("role")).toBe("combobox");
     expect(input.getAttribute("aria-autocomplete")).toBe("list");
     expect(input.getAttribute("aria-expanded")).toBe("true");
@@ -473,11 +473,6 @@ describe("Header", () => {
     expect(within(typeahead).queryByText("Publishers")).toBeNull();
     expect(within(typeahead).queryByText('See user results for "weather"')).toBeNull();
 
-    fireEvent.click(within(tablist).getByRole("tab", { name: "Plugins" }));
-    expect(screen.getByText("Weather Plugin")).toBeTruthy();
-    expect(screen.queryByText("Weather Skill")).toBeNull();
-
-    fireEvent.click(within(tablist).getByRole("tab", { name: "Skills" }));
     fireEvent.keyDown(input, { key: "ArrowDown" });
     fireEvent.keyDown(input, { key: "Enter" });
 
@@ -543,9 +538,7 @@ describe("Header", () => {
     fireEvent.change(input, { target: { value: "zzzz" } });
 
     expect(screen.getByText('No skills or plugins found for "zzzz"')).toBeTruthy();
-    expect(screen.getByRole("tablist", { name: "Result type" })).toBeTruthy();
-    expect(screen.getByText("tabs")).toBeTruthy();
-    expect(screen.getByText("results")).toBeTruthy();
+    expect(screen.queryByRole("tablist", { name: "Result type" })).toBeNull();
     expect(screen.queryByText('See skill results for "zzzz"')).toBeNull();
     expect(screen.queryByText('See plugin results for "zzzz"')).toBeNull();
   });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -97,7 +97,7 @@ function GitHubLogo({ className }: { className?: string }) {
   );
 }
 
-type TypeaheadTab = "skills" | "plugins";
+type TypeaheadSection = "skills" | "plugins";
 
 type TypeaheadItem =
   | {
@@ -113,7 +113,7 @@ type TypeaheadItem =
   | {
       kind: "footer";
       key: string;
-      section: TypeaheadTab;
+      section: TypeaheadSection;
       label: string;
     };
 
@@ -135,7 +135,6 @@ export default function Header() {
   );
   const [navSearchQuery, setNavSearchQuery] = useState("");
   const [typeaheadOpen, setTypeaheadOpen] = useState(false);
-  const [typeaheadTab, setTypeaheadTab] = useState<TypeaheadTab>("skills");
   const [typeaheadActiveIndex, setTypeaheadActiveIndex] = useState(0);
   const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -193,7 +192,10 @@ export default function Header() {
     return items;
   }, [hasNavSearchQuery, pluginResults, trimmedNavSearchQuery]);
 
-  const typeaheadItems = typeaheadTab === "skills" ? typeaheadSkillItems : typeaheadPluginItems;
+  const typeaheadItems = useMemo(
+    () => [...typeaheadSkillItems, ...typeaheadPluginItems],
+    [typeaheadPluginItems, typeaheadSkillItems],
+  );
   const activeTypeaheadItem = showTypeahead ? typeaheadItems[typeaheadActiveIndex] : undefined;
   const activeTypeaheadId = activeTypeaheadItem
     ? getTypeaheadOptionId(activeTypeaheadItem)
@@ -201,16 +203,11 @@ export default function Header() {
 
   useEffect(() => {
     setTypeaheadActiveIndex(0);
-    setTypeaheadTab("skills");
   }, [trimmedNavSearchQuery]);
 
   useEffect(() => {
     setTypeaheadActiveIndex((index) => Math.min(index, Math.max(typeaheadItems.length - 1, 0)));
   }, [typeaheadItems.length]);
-
-  useEffect(() => {
-    setTypeaheadActiveIndex(0);
-  }, [typeaheadTab]);
 
   useEffect(() => {
     if (!typeaheadOpen && !mobileSearchOpen) return () => {};
@@ -525,12 +522,9 @@ export default function Header() {
               {showTypeahead && !mobileSearchOpen ? (
                 <SearchTypeahead
                   activeIndex={typeaheadActiveIndex}
-                  activeTab={typeaheadTab}
-                  items={typeaheadItems}
                   loading={typeaheadSearching}
                   onHoverItem={setTypeaheadActiveIndex}
                   onSelectItem={navigateToTypeaheadItem}
-                  onTabChange={setTypeaheadTab}
                   pluginItems={typeaheadPluginItems}
                   query={trimmedNavSearchQuery}
                   skillItems={typeaheadSkillItems}
@@ -730,12 +724,9 @@ export default function Header() {
             {showMobileTypeahead ? (
               <SearchTypeahead
                 activeIndex={typeaheadActiveIndex}
-                activeTab={typeaheadTab}
-                items={typeaheadItems}
                 loading={typeaheadSearching}
                 onHoverItem={setTypeaheadActiveIndex}
                 onSelectItem={navigateToTypeaheadItem}
-                onTabChange={setTypeaheadTab}
                 pluginItems={typeaheadPluginItems}
                 query={trimmedNavSearchQuery}
                 skillItems={typeaheadSkillItems}
@@ -787,23 +778,17 @@ function HeaderNavTab({
 
 function SearchTypeahead({
   activeIndex,
-  activeTab,
-  items,
   loading,
   onHoverItem,
   onSelectItem,
-  onTabChange,
   pluginItems,
   query,
   skillItems,
 }: {
   activeIndex: number;
-  activeTab: TypeaheadTab;
-  items: TypeaheadItem[];
   loading: boolean;
   onHoverItem: (index: number) => void;
   onSelectItem: (item: TypeaheadItem) => void;
-  onTabChange: (tab: TypeaheadTab) => void;
   pluginItems: TypeaheadItem[];
   query: string;
   skillItems: TypeaheadItem[];
@@ -812,80 +797,17 @@ function SearchTypeahead({
   const hasSkillMatches = skillItems.some((item) => item.kind === "skill");
   const hasPluginMatches = pluginItems.some((item) => item.kind === "plugin");
   const hasMatches = hasSkillMatches || hasPluginMatches;
-  const activeTabHasItems = items.length > 0;
-  const emptyTabLabel = activeTab === "skills" ? "skills" : "plugins";
-  const skillsTabRef = useRef<HTMLButtonElement | null>(null);
-  const pluginsTabRef = useRef<HTMLButtonElement | null>(null);
-
-  const handleTabKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
-    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
-    event.preventDefault();
-    const nextTab = activeTab === "skills" ? "plugins" : "skills";
-    onTabChange(nextTab);
-    (nextTab === "skills" ? skillsTabRef : pluginsTabRef).current?.focus();
-  };
+  const pluginStartIndex = skillItems.length;
 
   return (
     <div className="navbar-search-typeahead" id="navbar-search-typeahead">
-      <div className="navbar-search-typeahead-top">
-        <div
-          className="navbar-search-typeahead-tabs clawhub-segmented"
-          role="tablist"
-          aria-label="Result type"
-        >
-          <button
-            ref={skillsTabRef}
-            type="button"
-            role="tab"
-            id="navbar-search-typeahead-tab-skills"
-            aria-selected={activeTab === "skills"}
-            aria-controls="navbar-search-typeahead-panel"
-            tabIndex={activeTab === "skills" ? 0 : -1}
-            className={`navbar-search-typeahead-tab clawhub-segmented-btn${activeTab === "skills" ? " is-active" : ""}`}
-            onMouseDown={(event) => event.preventDefault()}
-            onClick={() => onTabChange("skills")}
-            onKeyDown={handleTabKeyDown}
-          >
-            Skills
-          </button>
-          <button
-            ref={pluginsTabRef}
-            type="button"
-            role="tab"
-            id="navbar-search-typeahead-tab-plugins"
-            aria-selected={activeTab === "plugins"}
-            aria-controls="navbar-search-typeahead-panel"
-            tabIndex={activeTab === "plugins" ? 0 : -1}
-            className={`navbar-search-typeahead-tab clawhub-segmented-btn${activeTab === "plugins" ? " is-active" : ""}`}
-            onMouseDown={(event) => event.preventDefault()}
-            onClick={() => onTabChange("plugins")}
-            onKeyDown={handleTabKeyDown}
-          >
-            Plugins
-          </button>
-        </div>
-        <div className="navbar-search-typeahead-hint" aria-hidden="true">
-          <kbd>←</kbd>
-          <kbd>→</kbd>
-          <span>tabs</span>
-          <kbd>↑</kbd>
-          <kbd>↓</kbd>
-          <span>results</span>
-        </div>
-      </div>
-      <div
-        id="navbar-search-typeahead-panel"
-        className="navbar-search-typeahead-panel"
-        role="tabpanel"
-        aria-labelledby={
-          activeTab === "skills"
-            ? "navbar-search-typeahead-tab-skills"
-            : "navbar-search-typeahead-tab-plugins"
-        }
-      >
+      <div className="navbar-search-typeahead-panel">
         {!hasQuery ? (
-          <div className="navbar-search-typeahead-status">
-            Start typing to search skills and plugins
+          <div className="navbar-search-typeahead-status is-empty">
+            <span className="navbar-search-typeahead-status-icon" aria-hidden="true">
+              <Search size={17} />
+            </span>
+            <span>Start typing to search skills and plugins</span>
           </div>
         ) : null}
         {hasQuery && loading && !hasMatches ? (
@@ -902,22 +824,54 @@ function SearchTypeahead({
             role="listbox"
             aria-label="Search suggestions"
           >
-            {activeTabHasItems ? (
-              items.map((item, index) => (
-                <TypeaheadRow
-                  key={item.key}
-                  active={activeIndex === index}
-                  item={item}
-                  index={index}
-                  onHoverItem={onHoverItem}
-                  onSelectItem={onSelectItem}
-                />
-              ))
-            ) : (
-              <div className="navbar-search-typeahead-status">
-                No {emptyTabLabel} found for "{query}"
+            {hasSkillMatches ? (
+              <div
+                className="navbar-search-typeahead-section"
+                role="group"
+                aria-labelledby="navbar-search-typeahead-skills-heading"
+              >
+                <div
+                  id="navbar-search-typeahead-skills-heading"
+                  className="navbar-search-typeahead-heading"
+                >
+                  Skills
+                </div>
+                {skillItems.map((item, index) => (
+                  <TypeaheadRow
+                    key={item.key}
+                    active={activeIndex === index}
+                    item={item}
+                    index={index}
+                    onHoverItem={onHoverItem}
+                    onSelectItem={onSelectItem}
+                  />
+                ))}
               </div>
-            )}
+            ) : null}
+            {hasPluginMatches ? (
+              <div
+                className="navbar-search-typeahead-section"
+                role="group"
+                aria-labelledby="navbar-search-typeahead-plugins-heading"
+              >
+                <div
+                  id="navbar-search-typeahead-plugins-heading"
+                  className="navbar-search-typeahead-heading"
+                >
+                  Plugins
+                </div>
+                {pluginItems.map((item, index) => (
+                  <TypeaheadRow
+                    key={item.key}
+                    active={activeIndex === pluginStartIndex + index}
+                    item={item}
+                    index={pluginStartIndex + index}
+                    onHoverItem={onHoverItem}
+                    onSelectItem={onSelectItem}
+                  />
+                ))}
+              </div>
+            ) : null}
           </div>
         ) : null}
       </div>
@@ -938,9 +892,17 @@ function TypeaheadRow({
   onHoverItem: (index: number) => void;
   onSelectItem: (item: TypeaheadItem) => void;
 }) {
+  const rowRef = useRef<HTMLButtonElement | null>(null);
   const body = getTypeaheadRowBody(item);
+
+  useEffect(() => {
+    if (!active) return;
+    rowRef.current?.scrollIntoView({ block: "nearest" });
+  }, [active]);
+
   return (
     <button
+      ref={rowRef}
       id={getTypeaheadOptionId(item)}
       className={`navbar-search-typeahead-row${active ? " is-active" : ""}${item.kind === "footer" ? " is-footer" : ""}`}
       type="button"
@@ -969,7 +931,7 @@ function TypeaheadRowIcon({ item }: { item: TypeaheadItem }) {
     const label = item.result.skill.displayName || item.result.skill.slug;
     return (
       <span className="navbar-search-typeahead-icon" aria-hidden="true">
-        <MarketplaceIcon kind="skill" label={label} size="xs" />
+        <MarketplaceIcon kind="skill" label={label} skill={item.result.skill} size="xs" />
       </span>
     );
   }
@@ -978,7 +940,12 @@ function TypeaheadRowIcon({ item }: { item: TypeaheadItem }) {
     const label = item.result.plugin.displayName || item.result.plugin.name;
     return (
       <span className="navbar-search-typeahead-icon" aria-hidden="true">
-        <MarketplaceIcon kind="plugin" label={label} size="xs" />
+        <MarketplaceIcon
+          kind="plugin"
+          label={label}
+          categorySlug={item.result.plugin.categories?.[0]}
+          size="xs"
+        />
       </span>
     );
   }

--- a/src/components/MarketplaceIcon.tsx
+++ b/src/components/MarketplaceIcon.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type CSSProperties } from "react";
-import { getSkillIconCategoryForSkill } from "../lib/categories";
+import { getPluginCategoryBySlug, getSkillIconCategoryForSkill } from "../lib/categories";
 import { getCategoryIconComponent, UNRESOLVED_SKILL_CATEGORY_ICON } from "../lib/categoryIcons";
 import { MARKETPLACE_KIND_ICONS, type MarketplaceIconKind } from "../lib/marketplaceIcons";
 
@@ -7,6 +7,7 @@ type MarketplaceIconProps = {
   kind: MarketplaceIconKind;
   label: string;
   imageUrl?: string | null;
+  categorySlug?: string | null;
   /** Legacy skill custom-icon value. Ignored for rendering. */
   icon?: string | null;
   skill?: {
@@ -38,6 +39,7 @@ export function MarketplaceIcon({
   kind,
   label,
   imageUrl,
+  categorySlug,
   skill,
   size = "sm",
 }: MarketplaceIconProps) {
@@ -46,11 +48,14 @@ export function MarketplaceIcon({
     setFailedImageUrl(null);
   }, [imageUrl]);
 
-  const category = kind === "skill" && skill ? getSkillIconCategoryForSkill(skill) : null;
+  const skillCategory = kind === "skill" && skill ? getSkillIconCategoryForSkill(skill) : null;
+  const pluginCategory = kind === "plugin" ? getPluginCategoryBySlug(categorySlug) : null;
   const Icon =
     kind === "skill" && skill
-      ? (getCategoryIconComponent(category?.icon) ?? UNRESOLVED_SKILL_CATEGORY_ICON)
-      : MARKETPLACE_KIND_ICONS[kind];
+      ? (getCategoryIconComponent(skillCategory?.icon) ?? UNRESOLVED_SKILL_CATEGORY_ICON)
+      : kind === "plugin" && pluginCategory
+        ? (getCategoryIconComponent(pluginCategory.icon) ?? MARKETPLACE_KIND_ICONS.plugin)
+        : MARKETPLACE_KIND_ICONS[kind];
   const tone = hashTone(label);
   const visibleImageUrl = imageUrl && failedImageUrl !== imageUrl ? imageUrl : null;
 

--- a/src/lib/categories.ts
+++ b/src/lib/categories.ts
@@ -60,6 +60,9 @@ const LEGACY_SKILL_BROWSE_CATEGORY_ALIASES = {
 const SKILL_CATEGORIES_BY_SLUG = new Map(
   SKILL_CATEGORIES.map((category) => [category.slug, category]),
 );
+const PLUGIN_CATEGORIES_BY_SLUG = new Map(
+  PLUGIN_CATEGORIES.map((category) => [category.slug, category]),
+);
 
 export function resolvePluginBrowseCategorySlug(
   value: string | null | undefined,
@@ -126,6 +129,11 @@ export function getSkillIconCategoryForSkill(
 export function getSkillCategoryBySlug(slug: string | null | undefined) {
   if (!slug) return null;
   return SKILL_CATEGORIES.find((category) => category.slug === slug) ?? null;
+}
+
+export function getPluginCategoryBySlug(slug: string | null | undefined) {
+  const resolvedSlug = resolvePluginBrowseCategorySlug(slug);
+  return resolvedSlug ? (PLUGIN_CATEGORIES_BY_SLUG.get(resolvedSlug) ?? null) : null;
 }
 
 export function buildSkillCategoryBrowseHref(category: SkillCategory) {

--- a/src/lib/useUnifiedSearch.ts
+++ b/src/lib/useUnifiedSearch.ts
@@ -13,6 +13,10 @@ export type UnifiedSkillResult = {
     slug: string;
     displayName: string;
     summary?: string | null;
+    categories?: string[] | null;
+    inferredCategories?: string[] | null;
+    latestVersionId?: string | null;
+    inferredFromVersionId?: string | null;
     ownerUserId: string;
     ownerPublisherId?: string | null;
     stats: { downloads: number; stars: number; versions?: number };

--- a/src/styles.css
+++ b/src/styles.css
@@ -21696,6 +21696,7 @@ a.home-v2-apps-see-all:focus-visible svg {
   position: absolute;
   top: 8px;
   right: 8px;
+  width: auto;
 }
 
 .home-v2-byos-prompt-spark {
@@ -22463,6 +22464,35 @@ a[class*="rounded-full"] {
   background: color-mix(in srgb, var(--nav-bg) 78%, transparent);
 }
 
+.navbar.navbar-calm.navbar-calm-scrolled:has(.navbar-search-typeahead) {
+  background: color-mix(in srgb, var(--nav-bg) 94%, transparent);
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+}
+
+.app-shell:has(.navbar-search-typeahead)::after {
+  content: "";
+  position: fixed;
+  z-index: 9;
+  inset: 0;
+  pointer-events: none;
+  background: rgb(0 0 0 / 0.1);
+  animation: navbar-search-scrim-in 120ms ease-out both;
+}
+
+[data-theme-resolved="light"] .app-shell:has(.navbar-search-typeahead)::after {
+  background: rgb(10 10 10 / 0.06);
+}
+
+@keyframes navbar-search-scrim-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 .navbar-calm .navbar-top {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(240px, 360px) minmax(0, 1fr);
@@ -22750,66 +22780,47 @@ a[class*="rounded-full"] {
   right: auto;
   left: 50%;
   width: min(520px, calc(100vw - 32px));
+  max-height: min(680px, calc(100vh - 112px));
   transform: translateX(-50%);
   border-radius: 12px;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
   box-shadow: var(--shadow-dialog);
-}
-
-.navbar-search-typeahead-top {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 14px;
-  margin: 10px 10px 0;
-}
-
-.navbar-search-typeahead-tabs.clawhub-segmented {
-  width: fit-content;
-}
-
-.navbar-search-typeahead-hint {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding-right: 4px;
-  color: var(--ink-soft);
-  font-size: 11px;
-  opacity: 0.48;
-  white-space: nowrap;
-}
-
-.navbar-search-typeahead-hint kbd {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 18px;
-  height: 18px;
-  padding: 0 5px;
-  border: 1px solid color-mix(in srgb, var(--line) 82%, transparent);
-  border-radius: 5px;
-  background: color-mix(in srgb, var(--ink) 4%, transparent);
-  color: color-mix(in srgb, var(--ink-soft) 86%, var(--ink));
-  font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 650;
-  line-height: 1;
+  -webkit-backdrop-filter: blur(18px) saturate(1.08);
+  backdrop-filter: blur(18px) saturate(1.08);
 }
 
 .navbar-search-typeahead-panel {
-  padding: 8px 0 0;
-}
-
-.navbar-search-typeahead-tab {
-  all: unset;
-  box-sizing: border-box;
-  cursor: pointer;
+  min-height: 0;
 }
 
 .navbar-search-typeahead-results {
   display: flex;
   flex-direction: column;
+  overflow-y: auto;
+  max-height: min(680px, calc(100vh - 112px));
+  scrollbar-width: thin;
+}
+
+.navbar-search-typeahead-section {
+  display: flex;
+  flex-direction: column;
   gap: 2px;
-  padding: 0 6px;
+  padding: 6px;
+}
+
+.navbar-search-typeahead-section + .navbar-search-typeahead-section {
+  border-top: 1px solid var(--line);
+}
+
+.navbar-search-typeahead-heading {
+  margin: -6px -6px 4px;
+  padding: 9px 12px;
+  border-bottom: 1px solid color-mix(in srgb, var(--line) 78%, transparent);
+  background: color-mix(in srgb, var(--ink) 5%, transparent);
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
 }
 
 .navbar-search-typeahead-row {
@@ -22822,16 +22833,16 @@ a[class*="rounded-full"] {
 
 .navbar-search-typeahead-row:hover,
 .navbar-search-typeahead-row.is-active {
-  background: color-mix(in srgb, var(--ink) 6%, var(--surface-muted));
+  background: color-mix(in srgb, var(--ink) 8%, transparent);
 }
 
 .navbar-search-typeahead-row.is-footer {
   width: calc(100% + 12px);
-  min-height: 48px;
-  margin: 4px -6px 0;
-  padding: 12px 16px;
+  min-height: 44px;
+  margin: 4px -6px -6px;
+  padding: 10px 12px;
   border-top: 1px solid var(--line);
-  border-radius: 0 0 10px 10px;
+  border-radius: 0;
   font-size: var(--fs-sm);
   font-weight: 500;
 }
@@ -22852,15 +22863,22 @@ a[class*="rounded-full"] {
 .navbar-search-typeahead-icon .marketplace-icon {
   width: 28px;
   height: 28px;
-  border: 1px solid color-mix(in srgb, var(--marketplace-icon-accent) 18%, transparent) !important;
+  border: 1px solid color-mix(in srgb, var(--ink) 9%, transparent) !important;
   border-radius: 8px;
-  background: color-mix(in srgb, var(--marketplace-icon-accent) 10%, transparent) !important;
-  color: var(--marketplace-icon-accent);
+  background: color-mix(in srgb, var(--ink) 5%, transparent) !important;
+  color: var(--ink-soft);
   box-shadow: none;
   pointer-events: none;
   transform: none;
   transition: none;
   --marketplace-icon-wash: transparent;
+  --marketplace-icon-accent: var(--ink-soft);
+}
+
+.navbar-search-typeahead-icon .marketplace-icon-glyph,
+.navbar-search-typeahead-icon .marketplace-icon-image {
+  filter: grayscale(1);
+  opacity: 0.82;
 }
 
 .navbar-search-typeahead-icon .marketplace-icon-glyph {
@@ -22888,6 +22906,26 @@ a[class*="rounded-full"] {
 .navbar-search-typeahead-status {
   padding: 12px 14px 14px;
   line-height: 1.45;
+}
+
+.navbar-search-typeahead-status.is-empty {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px;
+}
+
+.navbar-search-typeahead-status-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 32px;
+  height: 32px;
+  border: 1px solid color-mix(in srgb, var(--ink) 9%, transparent);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--ink) 5%, transparent);
+  color: var(--ink-soft);
 }
 
 .clawhub-segmented {
@@ -22949,24 +22987,6 @@ a[class*="rounded-full"] {
   --clawhub-segmented-active-bg: color-mix(in srgb, var(--hv2-text) 10%, transparent);
 }
 
-.navbar-search-typeahead-tabs.clawhub-segmented,
-.app-shell:has(.home-v2-main) .navbar-search-typeahead-tabs.clawhub-segmented {
-  --navbar-search-typeahead-tabs-radius: var(--r-btn);
-  --navbar-search-typeahead-tabs-inset: 3px;
-  --clawhub-segmented-border: #3a3a3f;
-  --clawhub-segmented-bg: #101011;
-  --clawhub-segmented-fg: #8f8f98;
-  --clawhub-segmented-fg-hover: #d6d6da;
-  --clawhub-segmented-fg-active: #f7f7f8;
-  --clawhub-segmented-active-bg: #303033;
-  padding: var(--navbar-search-typeahead-tabs-inset);
-  border-radius: var(--navbar-search-typeahead-tabs-radius);
-}
-
-.navbar-search-typeahead-tab.clawhub-segmented-btn {
-  border-radius: calc(var(--navbar-search-typeahead-tabs-radius) - 2px);
-}
-
 .app-shell:has(.home-v2-main) main.home-v2-main {
   margin-top: -64px;
   padding-bottom: 0;
@@ -23015,10 +23035,6 @@ a[class*="rounded-full"] {
     transform: none;
   }
 
-  .navbar-search-typeahead-hint {
-    display: none;
-  }
-
   .navbar-calm .navbar-top {
     grid-template-columns: auto minmax(180px, 360px) auto;
   }
@@ -23040,6 +23056,10 @@ a[class*="rounded-full"] {
 }
 
 @media (max-width: 760px) {
+  .navbar-calm .navbar-inner {
+    padding: 0;
+  }
+
   .navbar-calm .navbar-top {
     grid-template-columns: minmax(0, 1fr) auto;
     gap: 8px;


### PR DESCRIPTION
<img src="https://ember-beacon-z5y8.here.now/droppie-2026-06-20T16-55-07Z.png" alt="Unified ClawHub header search showing grouped skill and plugin results" width="1310">

## Summary

- Show skills and plugins together in the header search dialog, grouped in one keyboard-navigable result list without tabs.
- Keep the existing search input unchanged while adding production-backed plugin results, category icons, clear empty/loading states, and a restrained glass surface.
- Keep the active keyboard option visible when the combined result list scrolls.
- Fix the mobile homepage header offset and keep the CLI copy control content-sized on small screens.

## Tests

- `bun run test -- src/__tests__/header.test.tsx src/components/MarketplaceIcon.test.tsx src/lib/categories.test.ts src/__tests__/home-bring-skills-section.test.tsx`
- `bun run ci:static`
- `bun run ci:unit` — 3,618 passed, 1 skipped
- `bun run ci:types-build`
- `git diff --check upstream/main`

## Visual proof

The screenshot above shows the unified search dialog with real skill and plugin results, grouped sections, category icons, hover state, and the final surface treatment.
