### PR TITLE
chore: remove legacy rate limits schema

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2498,17 +2498,6 @@ const cliDeviceCodes = defineTable({
   .index("by_user_code_hash", ["userCodeHash"])
   .index("by_status_expires", ["status", "expiresAt"]);
 
-const rateLimits = defineTable({
-  key: v.string(),
-  windowStart: v.number(),
-  shard: v.optional(v.number()),
-  count: v.number(),
-  limit: v.number(),
-  updatedAt: v.number(),
-})
-  .index("by_key_window", ["key", "windowStart"])
-  .index("by_key", ["key"]);
-
 const rateLimitCounters = defineTable({
   key: v.string(),
   windowStart: v.number(),
@@ -2731,7 +2720,6 @@ export default defineSchema({
   vtScanLogs,
   apiTokens,
   cliDeviceCodes,
-  rateLimits,
   rateLimitCounters,
   downloadMetricDedupes,
   packageInstallMetricDedupes,


### PR DESCRIPTION
## Summary

- remove the legacy `rateLimits` Convex table from the schema
- keep the active `rateLimitCounters` table and pruning/runtime code unchanged

## Production cleanup proof

- replaced production `rateLimits` with an empty JSON array on `wry-manatee-359`
- verified `await ctx.db.query("rateLimits").take(1)` returns `[]`
- verified `rateLimitCounters` still has fresh active rows

## Validation

- `bunx convex codegen`
- `bunx vitest run convex/rateLimits.test.ts`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bun run format:check -- convex/schema.ts`
- `CONVEX_DEPLOYMENT=prod:wry-manatee-359 bunx convex deploy --dry-run --typecheck enable --codegen disable`

## Skipped

Skipped broader static/unit/type/package/e2e/smoke gates and autoreview per the explicit speed instruction for this cleanup.
