### PR TITLE
chore: remove empty legacy cleanup tables

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -927,14 +927,6 @@ const skillVersions = defineTable({
   .index("by_sha256hash", ["sha256hash"])
   .index("by_dep_registry_scan_status_and_created", ["depRegistryScanStatus", "createdAt"]);
 
-const depRegistryCache = defineTable({
-  registry: depRegistryValidator,
-  name: v.string(),
-  exists: v.boolean(),
-  httpStatus: v.number(),
-  checkedAt: v.number(),
-}).index("by_registry_name", ["registry", "name"]);
-
 const skillVersionFingerprints = defineTable({
   skillId: v.id("skills"),
   versionId: v.id("skillVersions"),
@@ -2588,15 +2580,6 @@ const reservedHandles = defineTable({
   .index("by_handle_active_updatedAt", ["handle", "releasedAt", "updatedAt"])
   .index("by_owner", ["rightfulOwnerUserId"]);
 
-// Deprecated GitHub backup state retained so existing production rows keep
-// validating until a separate cleanup migration removes them.
-const githubBackupSyncState = defineTable({
-  key: v.string(),
-  cursor: v.optional(v.string()),
-  pruneCursor: v.optional(v.string()),
-  updatedAt: v.number(),
-}).index("by_key", ["key"]);
-
 const registryArtifactBackupSyncState = defineTable({
   key: v.string(),
   cursor: v.optional(v.string()),
@@ -2689,7 +2672,6 @@ export default defineSchema({
   packageTopicSearchDigest,
   packagePluginCategorySearchDigest,
   skillVersions,
-  depRegistryCache,
   skillVersionFingerprints,
   skillBadges,
   skillEmbeddings,
@@ -2726,7 +2708,6 @@ export default defineSchema({
   installTelemetryDedupes,
   reservedSlugs,
   reservedHandles,
-  githubBackupSyncState,
   registryArtifactBackupSyncState,
   registryArtifactBackupJobs,
   userSkillInstalls,


### PR DESCRIPTION
## Summary

- remove the empty `depRegistryCache` Convex table from the schema
- remove the empty `githubBackupSyncState` Convex table from the schema
- keep active registry artifact backup tables unchanged

## Production cleanup proof

Target deployment: `wry-manatee-359`

- `githubBackupSyncState` had 2 legacy rows before cleanup
- `depRegistryCache` was already empty before cleanup
- replaced both tables with `[]` via `convex import --replace`
- verified both inline reads return `[]`

## Validation

- `bunx convex codegen`
- `bun run format:check -- convex/schema.ts`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `CONVEX_DEPLOYMENT=prod:wry-manatee-359 bunx convex deploy --dry-run --typecheck enable --codegen disable --allow-deleting-large-indexes`
- `bun run ci:static`
- `bun run ci:unit`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Notes

The dry run reported only these table index deletions:

- `depRegistryCache.by_registry_name`
- `githubBackupSyncState.by_key`

Separate Convex dashboard backup confirmation was skipped because Patrick explicitly instructed this worker to clear these two tables with empty arrays and `$yolo` the PR/deploy.
