### PR TITLE
Parallelize registry artifact backup backfill

### DIFF
--- a/convex/registryArtifactBackups.test.ts
+++ b/convex/registryArtifactBackups.test.ts
@@ -1,17 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Id } from "./_generated/dataModel";
 import {
+  claimRegistryArtifactBackupJobsHandler,
   enqueueRegistryArtifactBackupJobHandler,
   getDueRegistryArtifactBackupJobsInternal,
   getRegistryArtifactBackupHealthHandler,
   getRegistryArtifactBackupPageInternal,
   getPackageRegistryArtifactBackupPageInternal,
+  markRegistryArtifactBackupJobSucceededHandler,
   releaseRegistryArtifactBackupRetryLeaseHandler,
   tryAcquireRegistryArtifactBackupRetryLeaseHandler,
 } from "./registryArtifactBackups";
 import {
   backupPackageForPublishInternal,
   backupSkillForPublishInternal,
+  processRegistryArtifactBackupQueueInternalHandler,
   processRegistryArtifactBackupRetriesInternalHandler,
   seedRegistryArtifactBackupsInternalHandler,
 } from "./registryArtifactBackupsNode";
@@ -61,10 +64,16 @@ beforeEach(() => {
   registryBackupMocks.backupPackageReleaseToObjectStorage.mockResolvedValue(undefined);
 });
 
-function retryLeaseRunMutation() {
+function retryLeaseRunMutation(claimedJobs: Array<unknown> = []) {
   return vi.fn(async (_ref, args) => {
     if (args && typeof args === "object" && "token" in args) {
       return { acquired: true, released: true };
+    }
+    if (args && typeof args === "object" && "leaseToken" in args && "limit" in args) {
+      return claimedJobs;
+    }
+    if (args && typeof args === "object" && "jobId" in args) {
+      return { missing: false, stale: false, exhausted: false, attempts: 1 };
     }
     return undefined;
   });
@@ -547,6 +556,88 @@ describe("package registry artifact backup page filtering", () => {
 });
 
 describe("seedRegistryArtifactBackupsInternalHandler", () => {
+  it("can seed the backup ledger without uploading artifacts inline", async () => {
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce({ cursor: null })
+      .mockResolvedValueOnce({
+        items: [
+          {
+            kind: "ok",
+            skillId: "skills:demo",
+            versionId: "skillVersions:demo-1",
+            slug: "demo-skill",
+            displayName: "Demo Skill",
+            version: "1.0.0",
+            isLatest: true,
+            ownerHandle: "alice",
+            publishedAt: 1,
+          },
+        ],
+        cursor: null,
+        isDone: true,
+      })
+      .mockResolvedValueOnce({ cursor: null })
+      .mockResolvedValueOnce({
+        items: [
+          {
+            kind: "ok",
+            packageId: "packages:demo",
+            releaseId: "packageReleases:demo-1",
+            ownerHandle: "alice",
+            packageName: "@openclaw/demo",
+            normalizedName: "@openclaw/demo",
+            displayName: "Demo",
+            family: "code-plugin",
+            version: "1.0.0",
+            isLatest: true,
+            publishedAt: 1,
+            artifactStorageId: "storage:artifact",
+            files: [],
+          },
+          {
+            kind: "missingArtifact",
+            releaseId: "packageReleases:missing",
+            packageId: "packages:missing",
+          },
+        ],
+        cursor: null,
+        isDone: true,
+      })
+      .mockResolvedValueOnce({ stale: 0, exhausted: 0 });
+    const runMutation = retryLeaseRunMutation();
+
+    const result = await seedRegistryArtifactBackupsInternalHandler(
+      { runQuery, runMutation } as never,
+      { queueOnly: true, batchSize: 2, maxBatches: 1 },
+    );
+
+    expect(result.stats.skillsEnqueued).toBe(1);
+    expect(result.stats.packagesEnqueued).toBe(1);
+    expect(result.stats.packagesMissingArtifact).toBe(1);
+    expect(registryBackupMocks.fetchSkillVersionBackupMeta).not.toHaveBeenCalled();
+    expect(registryBackupMocks.backupSkillVersionToObjectStorage).not.toHaveBeenCalled();
+    expect(registryBackupMocks.backupPackageReleaseToObjectStorage).not.toHaveBeenCalled();
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        targetKind: "skillVersion",
+        skillVersionId: "skillVersions:demo-1",
+        reason: "seed",
+        preserveTerminal: true,
+      }),
+    );
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        targetKind: "packageRelease",
+        packageReleaseId: "packageReleases:demo-1",
+        reason: "seed",
+        preserveTerminal: true,
+      }),
+    );
+  });
+
   it("reports package cursor progress when skills are done but package releases remain", async () => {
     const runQuery = vi
       .fn()
@@ -575,7 +666,6 @@ describe("seedRegistryArtifactBackupsInternalHandler", () => {
     registryBackupMocks.fetchSkillVersionBackupMeta.mockRejectedValueOnce(new Error("R2 500"));
     const runQuery = vi
       .fn()
-      .mockResolvedValueOnce([])
       .mockResolvedValueOnce({ cursor: null })
       .mockResolvedValueOnce({
         items: [
@@ -596,7 +686,7 @@ describe("seedRegistryArtifactBackupsInternalHandler", () => {
       .mockResolvedValueOnce({ cursor: null })
       .mockResolvedValueOnce({ items: [], cursor: null, isDone: true })
       .mockResolvedValueOnce({ stale: 0, exhausted: 0 });
-    const runMutation = vi.fn();
+    const runMutation = retryLeaseRunMutation();
 
     const result = await seedRegistryArtifactBackupsInternalHandler(
       { runQuery, runMutation } as never,
@@ -659,7 +749,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
       forceDue: true,
     });
 
-    expect(runQuery.mock.calls[0]?.[1]).toMatchObject({ ignoreNextRunAt: true });
+    expect(runMutation.mock.calls[1]?.[1]).toMatchObject({ forceDue: true });
   });
 
   it("backs up retry artifacts without acquiring per-index leases", async () => {
@@ -682,7 +772,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
       if ("staleAfterMs" in args) return { stale: 0, exhausted: 0 };
       throw new Error(`unexpected query ${JSON.stringify(args)}`);
     });
-    const runMutation = retryLeaseRunMutation();
+    const runMutation = retryLeaseRunMutation(jobs);
     registryBackupMocks.fetchSkillVersionBackupMeta.mockResolvedValue(null);
 
     const result = await processRegistryArtifactBackupRetriesInternalHandler(
@@ -708,7 +798,6 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
     };
     const runQuery = vi
       .fn()
-      .mockResolvedValueOnce([dueJob])
       .mockResolvedValueOnce({
         _id: "packageReleases:demo",
         packageId: "packages:demo",
@@ -735,7 +824,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
         deactivatedAt: undefined,
       })
       .mockResolvedValueOnce({ stale: 0, exhausted: 0 });
-    const runMutation = retryLeaseRunMutation();
+    const runMutation = retryLeaseRunMutation([dueJob]);
 
     const result = await processRegistryArtifactBackupRetriesInternalHandler(
       { runQuery, runMutation } as never,
@@ -770,11 +859,25 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
       {},
     );
 
-    expect(runQuery.mock.calls[0]?.[1]).toMatchObject({
+    expect(runMutation.mock.calls[1]?.[1]).toMatchObject({
       includeExhaustedRepair: true,
       limit: 500,
       maxRepairAttempts: 16,
     });
+  });
+
+  it("uses a unique queue lease token even with a stable worker id", async () => {
+    const runMutation = vi.fn().mockResolvedValueOnce([]);
+    const runQuery = vi.fn().mockResolvedValueOnce({ stale: 0, exhausted: 0 });
+
+    await processRegistryArtifactBackupQueueInternalHandler({ runQuery, runMutation } as never, {
+      workerId: "worker-a",
+      limit: 1,
+    });
+
+    const leaseToken = runMutation.mock.calls[0]?.[1]?.leaseToken;
+    expect(leaseToken).not.toBe("worker-a");
+    expect(leaseToken).toEqual(expect.stringMatching(/^worker-a-\d+-[a-z0-9]+$/));
   });
 
   it("gives repaired exhausted jobs a finite second retry budget", async () => {
@@ -820,11 +923,11 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
       if ("staleAfterMs" in args) return { stale: 0, exhausted: 0 };
       throw new Error(`unexpected query ${JSON.stringify(args)}`);
     });
-    const runMutation = retryLeaseRunMutation();
     registryBackupMocks.fetchSkillVersionBackupMeta.mockResolvedValue(null);
     registryBackupMocks.backupSkillVersionToObjectStorage.mockRejectedValueOnce(
       new Error("R2 still down"),
     );
+    const runMutation = retryLeaseRunMutation([dueJob]);
 
     const result = await processRegistryArtifactBackupRetriesInternalHandler(
       { runQuery, runMutation } as never,
@@ -887,11 +990,11 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
       if ("staleAfterMs" in args) return { stale: 0, exhausted: 0 };
       throw new Error(`unexpected query ${JSON.stringify(args)}`);
     });
-    const runMutation = retryLeaseRunMutation();
     registryBackupMocks.fetchSkillVersionBackupMeta.mockResolvedValueOnce({
       version: "1.0.0",
       restore: { versionId: "skillVersions:demo" },
     });
+    const runMutation = retryLeaseRunMutation([dueJob]);
 
     const result = await processRegistryArtifactBackupRetriesInternalHandler(
       { runQuery, runMutation } as never,
@@ -945,7 +1048,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
     );
 
     const result = await processRegistryArtifactBackupRetriesInternalHandler(
-      { runQuery, runMutation: retryLeaseRunMutation() } as never,
+      { runQuery, runMutation: retryLeaseRunMutation(jobs) } as never,
       {},
     );
 
@@ -1001,7 +1104,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
     );
 
     const result = await processRegistryArtifactBackupRetriesInternalHandler(
-      { runQuery, runMutation: retryLeaseRunMutation() } as never,
+      { runQuery, runMutation: retryLeaseRunMutation(jobs) } as never,
       {},
     );
 
@@ -1060,7 +1163,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
     });
 
     const result = await processRegistryArtifactBackupRetriesInternalHandler(
-      { runQuery, runMutation: retryLeaseRunMutation() } as never,
+      { runQuery, runMutation: retryLeaseRunMutation(jobs) } as never,
       {},
     );
 
@@ -1111,7 +1214,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
     });
 
     const result = await processRegistryArtifactBackupRetriesInternalHandler(
-      { runQuery, runMutation: retryLeaseRunMutation() } as never,
+      { runQuery, runMutation: retryLeaseRunMutation(jobs) } as never,
       {},
     );
 
@@ -1141,7 +1244,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
       if ("staleAfterMs" in args) return { stale: 0, exhausted: 0 };
       throw new Error(`unexpected query ${JSON.stringify(args)}`);
     });
-    const runMutation = retryLeaseRunMutation();
+    const runMutation = retryLeaseRunMutation(jobs);
     registryBackupMocks.fetchSkillVersionBackupMeta.mockResolvedValue(null);
 
     const result = await processRegistryArtifactBackupRetriesInternalHandler(
@@ -1175,7 +1278,6 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
     };
     const runQuery = vi
       .fn()
-      .mockResolvedValueOnce([dueJob])
       .mockResolvedValueOnce({
         _id: "skillVersions:hidden",
         skillId: "skills:hidden",
@@ -1195,7 +1297,7 @@ describe("processRegistryArtifactBackupRetriesInternalHandler", () => {
         moderationStatus: "hidden",
       })
       .mockResolvedValueOnce({ stale: 0, exhausted: 0 });
-    const runMutation = retryLeaseRunMutation();
+    const runMutation = retryLeaseRunMutation([dueJob]);
 
     const result = await processRegistryArtifactBackupRetriesInternalHandler(
       { runQuery, runMutation } as never,
@@ -1292,6 +1394,108 @@ function makePackage(id: string, name: string) {
 }
 
 describe("registry artifact backup jobs", () => {
+  it("ignores stale worker completion after a job lease is reclaimed", async () => {
+    const now = 1_700_000_000_000;
+    const job = {
+      _id: "registryArtifactBackupJobs:demo",
+      status: "running",
+      leaseToken: "worker-b",
+    };
+    const ctx = {
+      db: {
+        get: vi.fn().mockResolvedValue(job),
+        patch: vi.fn(),
+      },
+    };
+
+    const result = await markRegistryArtifactBackupJobSucceededHandler(ctx as never, {
+      jobId: "registryArtifactBackupJobs:demo" as Id<"registryArtifactBackupJobs">,
+      leaseToken: "worker-a",
+      now,
+    });
+
+    expect(result).toEqual({ missing: false, stale: true });
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+
+  it("ignores worker completion after a leased job is requeued", async () => {
+    const now = 1_700_000_000_000;
+    const job = {
+      _id: "registryArtifactBackupJobs:demo",
+      status: "pending",
+      leaseToken: "worker-a",
+    };
+    const ctx = {
+      db: {
+        get: vi.fn().mockResolvedValue(job),
+        patch: vi.fn(),
+      },
+    };
+
+    const result = await markRegistryArtifactBackupJobSucceededHandler(ctx as never, {
+      jobId: "registryArtifactBackupJobs:demo" as Id<"registryArtifactBackupJobs">,
+      leaseToken: "worker-a",
+      now,
+    });
+
+    expect(result).toEqual({ missing: false, stale: true });
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+
+  it("claims pending and expired running jobs with a lease for parallel workers", async () => {
+    const now = 1_700_000_000_000;
+    const pendingJob = {
+      _id: "registryArtifactBackupJobs:pending",
+      status: "pending",
+      nextRunAt: now - 1,
+    };
+    const expiredRunningJob = {
+      _id: "registryArtifactBackupJobs:expired",
+      status: "running",
+      leaseExpiresAt: now - 1,
+    };
+    const pendingTake = vi.fn().mockResolvedValue([pendingJob]);
+    const runningTake = vi.fn().mockResolvedValue([expiredRunningJob]);
+    const patch = vi.fn();
+    const withIndex = vi.fn((indexName: string) => ({
+      take: indexName === "by_status_leaseExpiresAt" ? runningTake : pendingTake,
+    }));
+    const ctx = {
+      db: {
+        query: vi.fn(() => ({ withIndex })),
+        patch,
+      },
+    };
+
+    const result = await claimRegistryArtifactBackupJobsHandler(ctx as never, {
+      now,
+      limit: 2,
+      leaseToken: "worker-1",
+      leaseTtlMs: 60_000,
+    });
+
+    expect(result.map((job: { _id: string }) => job._id)).toEqual([
+      "registryArtifactBackupJobs:pending",
+      "registryArtifactBackupJobs:expired",
+    ]);
+    expect(patch).toHaveBeenCalledWith(
+      "registryArtifactBackupJobs:pending",
+      expect.objectContaining({
+        status: "running",
+        leaseToken: "worker-1",
+        leaseExpiresAt: now + 60_000,
+      }),
+    );
+    expect(patch).toHaveBeenCalledWith(
+      "registryArtifactBackupJobs:expired",
+      expect.objectContaining({
+        status: "running",
+        leaseToken: "worker-1",
+        leaseExpiresAt: now + 60_000,
+      }),
+    );
+  });
+
   it("can force pending jobs without waiting for nextRunAt", async () => {
     const now = 1_700_000_000_000;
     const pendingJobs = [
@@ -1599,20 +1803,26 @@ describe("registry artifact backup jobs", () => {
     });
 
     expect(ctx.db.insert).not.toHaveBeenCalled();
-    expect(patch).toHaveBeenCalledWith("registryArtifactBackupJobs:existing", {
-      status: "pending",
-      reason: "publish",
-      attempts: 0,
-      lastError: "R2 500",
-      nextRunAt: now,
-      createdAt: now,
-      updatedAt: now,
-      exhaustedAt: undefined,
-      completedAt: undefined,
-    });
+    expect(patch).toHaveBeenCalledWith(
+      "registryArtifactBackupJobs:existing",
+      expect.objectContaining({
+        status: "pending",
+        reason: "publish",
+        attempts: 0,
+        lastError: "R2 500",
+        nextRunAt: now,
+        createdAt: now,
+        updatedAt: now,
+        exhaustedAt: undefined,
+        completedAt: undefined,
+        leaseToken: undefined,
+        leaseExpiresAt: undefined,
+        claimedAt: undefined,
+      }),
+    );
   });
 
-  it("reports stale and exhausted backup jobs for alerting", async () => {
+  it("reports stale, expired running, and exhausted backup jobs for alerting", async () => {
     const now = 1_700_000_000_000;
     const pendingJobs = [
       {
@@ -1648,16 +1858,55 @@ describe("registry artifact backup jobs", () => {
         nextRunAt: now - 1000,
       },
     ];
-    const take = vi.fn((limit: number) => {
-      if (take.mock.calls.length === 1) return Promise.resolve(pendingJobs.slice(0, limit));
-      return Promise.resolve(exhaustedJobs.slice(0, limit));
-    });
+    const runningJobs = [
+      {
+        _id: "registryArtifactBackupJobs:running",
+        targetKind: "skillVersion",
+        skillVersionId: "skillVersions:running",
+        status: "running",
+        attempts: 1,
+        createdAt: now - 60 * 60 * 1000,
+        updatedAt: now - 1000,
+        nextRunAt: now - 1000,
+        leaseExpiresAt: now + 60 * 1000,
+      },
+      {
+        _id: "registryArtifactBackupJobs:running-extra",
+        targetKind: "skillVersion",
+        skillVersionId: "skillVersions:running-extra",
+        status: "running",
+        attempts: 1,
+        createdAt: now - 60 * 60 * 1000,
+        updatedAt: now - 1000,
+        nextRunAt: now - 1000,
+        leaseExpiresAt: now + 60 * 1000,
+      },
+    ];
+    const expiredRunningJobs = [
+      {
+        _id: "registryArtifactBackupJobs:expired-running",
+        targetKind: "skillVersion",
+        skillVersionId: "skillVersions:expired-running",
+        status: "running",
+        attempts: 1,
+        createdAt: now - 60 * 60 * 1000,
+        updatedAt: now - 1000,
+        nextRunAt: now - 1000,
+        leaseExpiresAt: now - 1000,
+      },
+    ];
+    const pendingTake = vi.fn((limit: number) => Promise.resolve(pendingJobs.slice(0, limit)));
+    const exhaustedTake = vi.fn((limit: number) => Promise.resolve(exhaustedJobs.slice(0, limit)));
+    const runningTake = vi.fn((limit: number) => Promise.resolve(runningJobs.slice(0, limit)));
+    const expiredRunningTake = vi.fn((limit: number) =>
+      Promise.resolve(expiredRunningJobs.slice(0, limit)),
+    );
+    const takeByCall = [pendingTake, exhaustedTake, runningTake, expiredRunningTake];
+    const withIndex = vi.fn(() => ({ take: takeByCall[withIndex.mock.calls.length - 1] }));
     const ctx = {
       db: {
         query: vi.fn(() => ({
-          withIndex: vi.fn(() => ({
-            take,
-          })),
+          withIndex,
         })),
       },
     };
@@ -1668,14 +1917,20 @@ describe("registry artifact backup jobs", () => {
       sampleLimit: 1,
     });
 
-    expect(take).toHaveBeenNthCalledWith(1, 2);
-    expect(take).toHaveBeenNthCalledWith(2, 2);
+    expect(pendingTake).toHaveBeenCalledWith(2);
+    expect(exhaustedTake).toHaveBeenCalledWith(2);
+    expect(runningTake).toHaveBeenCalledWith(2);
+    expect(expiredRunningTake).toHaveBeenCalledWith(2);
     expect(result).toMatchObject({
       pending: 1,
-      stale: 1,
+      running: 1,
+      expiredRunning: 1,
+      stale: 2,
       exhausted: 1,
       oldestPendingAgeMs: 49 * 60 * 60 * 1000,
       pendingCapped: true,
+      runningCapped: true,
+      expiredRunningCapped: false,
       exhaustedCapped: false,
     });
   });

--- a/convex/registryArtifactBackups.ts
+++ b/convex/registryArtifactBackups.ts
@@ -20,6 +20,8 @@ const MAX_BACKUP_JOB_LIMIT = 500;
 const DEFAULT_BACKUP_JOB_REPAIR_ATTEMPTS = 16;
 const DEFAULT_RETRY_LEASE_TTL_MS = 20 * 60 * 1000;
 const MAX_RETRY_LEASE_TTL_MS = 60 * 60 * 1000;
+const DEFAULT_BACKUP_JOB_LEASE_TTL_MS = 20 * 60 * 1000;
+const MAX_BACKUP_JOB_LEASE_TTL_MS = 60 * 60 * 1000;
 
 type BackupPageItem =
   | {
@@ -99,6 +101,8 @@ export type SeedRegistryArtifactBackupsResult = {
     packagesMissingArtifact: number;
     packagesMissingPackage: number;
     packagesMissingOwner: number;
+    skillsEnqueued: number;
+    packagesEnqueued: number;
     retryJobsProcessed: number;
     retryJobsSucceeded: number;
     retryJobsFailed: number;
@@ -418,6 +422,13 @@ const registryArtifactBackupReasonValidator = v.union(
   v.literal("retry"),
   v.literal("sync"),
 );
+const registryArtifactBackupStatusValidator = v.union(
+  v.literal("pending"),
+  v.literal("running"),
+  v.literal("succeeded"),
+  v.literal("exhausted"),
+  v.literal("missingArtifact"),
+);
 
 export const enqueueRegistryArtifactBackupJobInternal = internalMutation({
   args: {
@@ -425,32 +436,128 @@ export const enqueueRegistryArtifactBackupJobInternal = internalMutation({
     skillVersionId: v.optional(v.id("skillVersions")),
     packageReleaseId: v.optional(v.id("packageReleases")),
     reason: registryArtifactBackupReasonValidator,
+    status: v.optional(registryArtifactBackupStatusValidator),
+    preserveTerminal: v.optional(v.boolean()),
     error: v.optional(v.string()),
     now: v.optional(v.number()),
   },
   handler: enqueueRegistryArtifactBackupJobHandler,
 });
 
+export async function claimRegistryArtifactBackupJobsHandler(
+  ctx: Pick<MutationCtx, "db">,
+  args: {
+    now?: number;
+    limit?: number;
+    leaseToken: string;
+    leaseTtlMs?: number;
+    forceDue?: boolean;
+    includeExhaustedRepair?: boolean;
+    maxRepairAttempts?: number;
+  },
+) {
+  const now = args.now ?? Date.now();
+  const limit = clampInt(args.limit ?? DEFAULT_BACKUP_JOB_LIMIT, 1, MAX_BACKUP_JOB_LIMIT);
+  const leaseTtlMs = clampInt(
+    args.leaseTtlMs ?? DEFAULT_BACKUP_JOB_LEASE_TTL_MS,
+    1_000,
+    MAX_BACKUP_JOB_LEASE_TTL_MS,
+  );
+  const pending = await ctx.db
+    .query("registryArtifactBackupJobs")
+    .withIndex("by_status_nextRunAt", (q) => {
+      const byStatus = q.eq("status", "pending");
+      return args.forceDue ? byStatus : byStatus.lte("nextRunAt", now);
+    })
+    .take(limit);
+
+  let claimed = pending;
+  if (claimed.length < limit) {
+    const expiredRunning = await ctx.db
+      .query("registryArtifactBackupJobs")
+      .withIndex("by_status_leaseExpiresAt", (q) =>
+        q.eq("status", "running").lte("leaseExpiresAt", now),
+      )
+      .take(limit - claimed.length);
+    claimed = [...claimed, ...expiredRunning];
+  }
+  if (args.includeExhaustedRepair && claimed.length < limit) {
+    const maxRepairAttempts = Math.max(
+      1,
+      Math.floor(args.maxRepairAttempts ?? DEFAULT_BACKUP_JOB_REPAIR_ATTEMPTS),
+    );
+    const exhausted = await ctx.db
+      .query("registryArtifactBackupJobs")
+      .withIndex("by_status_attempts", (q) =>
+        q.eq("status", "exhausted").lt("attempts", maxRepairAttempts),
+      )
+      .take(limit - claimed.length);
+    claimed = [...claimed, ...exhausted];
+  }
+
+  const leaseExpiresAt = now + leaseTtlMs;
+  for (const job of claimed) {
+    await ctx.db.patch(job._id, {
+      status: "running",
+      leaseToken: args.leaseToken,
+      leaseExpiresAt,
+      claimedAt: now,
+      lastAttemptAt: now,
+      updatedAt: now,
+    });
+  }
+  return claimed;
+}
+
+export const claimRegistryArtifactBackupJobsInternal = internalMutation({
+  args: {
+    now: v.optional(v.number()),
+    limit: v.optional(v.number()),
+    leaseToken: v.string(),
+    leaseTtlMs: v.optional(v.number()),
+    forceDue: v.optional(v.boolean()),
+    includeExhaustedRepair: v.optional(v.boolean()),
+    maxRepairAttempts: v.optional(v.number()),
+  },
+  handler: claimRegistryArtifactBackupJobsHandler,
+});
+
+export async function markRegistryArtifactBackupJobSucceededHandler(
+  ctx: Pick<MutationCtx, "db">,
+  args: { jobId: Id<"registryArtifactBackupJobs">; leaseToken?: string; now?: number },
+) {
+  const now = args.now ?? Date.now();
+  const job = await ctx.db.get(args.jobId);
+  if (!job) return { missing: true as const, stale: false as const };
+  if (args.leaseToken && (job.status !== "running" || job.leaseToken !== args.leaseToken)) {
+    return { missing: false as const, stale: true as const };
+  }
+  await ctx.db.patch(args.jobId, {
+    status: "succeeded",
+    completedAt: now,
+    lastError: undefined,
+    leaseToken: undefined,
+    leaseExpiresAt: undefined,
+    claimedAt: undefined,
+    updatedAt: now,
+  });
+  return { missing: false as const, stale: false as const };
+}
+
 export const markRegistryArtifactBackupJobSucceededInternal = internalMutation({
   args: {
     jobId: v.id("registryArtifactBackupJobs"),
+    leaseToken: v.optional(v.string()),
     now: v.optional(v.number()),
   },
-  handler: async (ctx, args) => {
-    const now = args.now ?? Date.now();
-    await ctx.db.patch(args.jobId, {
-      status: "succeeded",
-      completedAt: now,
-      lastError: undefined,
-      updatedAt: now,
-    });
-  },
+  handler: markRegistryArtifactBackupJobSucceededHandler,
 });
 
 export const markRegistryArtifactBackupJobFailedInternal = internalMutation({
   args: {
     jobId: v.id("registryArtifactBackupJobs"),
     error: v.string(),
+    leaseToken: v.optional(v.string()),
     now: v.optional(v.number()),
     maxAttempts: v.optional(v.number()),
   },
@@ -459,6 +566,9 @@ export const markRegistryArtifactBackupJobFailedInternal = internalMutation({
     const maxAttempts = Math.max(1, Math.floor(args.maxAttempts ?? 8));
     const job = await ctx.db.get(args.jobId);
     if (!job) return { missing: true as const };
+    if (args.leaseToken && (job.status !== "running" || job.leaseToken !== args.leaseToken)) {
+      return { missing: false as const, stale: true as const };
+    }
     const attempts = job.attempts + 1;
     const exhausted = attempts >= maxAttempts;
     await ctx.db.patch(args.jobId, {
@@ -468,9 +578,12 @@ export const markRegistryArtifactBackupJobFailedInternal = internalMutation({
       lastError: truncateBackupJobError(args.error),
       nextRunAt: exhausted ? now : now + retryDelayMs(attempts),
       exhaustedAt: exhausted ? now : undefined,
+      leaseToken: undefined,
+      leaseExpiresAt: undefined,
+      claimedAt: undefined,
       updatedAt: now,
     });
-    return { missing: false as const, exhausted, attempts };
+    return { missing: false as const, stale: false as const, exhausted, attempts };
   },
 });
 
@@ -524,6 +637,7 @@ export const seedRegistryArtifactBackups: ReturnType<typeof action> = action({
     dryRun: v.optional(v.boolean()),
     batchSize: v.optional(v.number()),
     maxBatches: v.optional(v.number()),
+    queueOnly: v.optional(v.boolean()),
     resetCursor: v.optional(v.boolean()),
   },
   handler: async (ctx, args): Promise<SeedRegistryArtifactBackupsResult> => {
@@ -549,6 +663,7 @@ export const seedRegistryArtifactBackups: ReturnType<typeof action> = action({
       dryRun: args.dryRun,
       batchSize: args.batchSize,
       maxBatches: args.maxBatches,
+      queueOnly: args.queueOnly,
     }) as Promise<SeedRegistryArtifactBackupsResult>;
   },
 });
@@ -564,11 +679,14 @@ export async function enqueueRegistryArtifactBackupJobHandler(
     skillVersionId?: Id<"skillVersions">;
     packageReleaseId?: Id<"packageReleases">;
     reason: "publish" | "seed" | "retry" | "sync";
+    status?: "pending" | "running" | "succeeded" | "exhausted" | "missingArtifact";
+    preserveTerminal?: boolean;
     error?: string;
     now?: number;
   },
 ) {
   const now = args.now ?? Date.now();
+  const status = args.status ?? "pending";
   const existing =
     args.targetKind === "skillVersion" && args.skillVersionId
       ? await ctx.db
@@ -584,16 +702,25 @@ export async function enqueueRegistryArtifactBackupJobHandler(
 
   const lastError = truncateBackupJobError(args.error);
   if (existing) {
+    if (
+      args.preserveTerminal &&
+      (existing.status === "succeeded" || existing.status === "missingArtifact")
+    ) {
+      return { jobId: existing._id, created: false as const, preserved: true as const };
+    }
     await ctx.db.patch(existing._id, {
-      status: "pending",
+      status,
       reason: args.reason,
       attempts: 0,
       lastError,
       nextRunAt: now,
+      leaseToken: undefined,
+      leaseExpiresAt: undefined,
+      claimedAt: undefined,
       createdAt: now,
       updatedAt: now,
       exhaustedAt: undefined,
-      completedAt: undefined,
+      completedAt: status === "missingArtifact" || status === "succeeded" ? now : undefined,
     });
     return { jobId: existing._id, created: false as const };
   }
@@ -602,11 +729,12 @@ export async function enqueueRegistryArtifactBackupJobHandler(
     targetKind: args.targetKind,
     skillVersionId: args.skillVersionId,
     packageReleaseId: args.packageReleaseId,
-    status: "pending",
+    status,
     reason: args.reason,
     attempts: 0,
     nextRunAt: now,
     lastError,
+    completedAt: status === "missingArtifact" || status === "succeeded" ? now : undefined,
     createdAt: now,
     updatedAt: now,
   });
@@ -632,21 +760,38 @@ export async function getRegistryArtifactBackupHealthHandler(
     .query("registryArtifactBackupJobs")
     .withIndex("by_status_nextRunAt", (q) => q.eq("status", "exhausted"))
     .take(sampleLimit + 1);
+  const running = await ctx.db
+    .query("registryArtifactBackupJobs")
+    .withIndex("by_status_leaseExpiresAt", (q) => q.eq("status", "running"))
+    .take(sampleLimit + 1);
+  const expiredRunning = await ctx.db
+    .query("registryArtifactBackupJobs")
+    .withIndex("by_status_leaseExpiresAt", (q) =>
+      q.eq("status", "running").lte("leaseExpiresAt", now),
+    )
+    .take(sampleLimit + 1);
   const pendingSample = pending.slice(0, sampleLimit);
   const exhaustedSample = exhausted.slice(0, sampleLimit);
+  const runningSample = running.slice(0, sampleLimit);
+  const expiredRunningSample = expiredRunning.slice(0, sampleLimit);
   const oldestPendingAgeMs = pendingSample.reduce(
     (max: number, job: { createdAt: number }) => Math.max(max, now - job.createdAt),
     0,
   );
-  const stale = pendingSample.filter(
+  const stalePending = pendingSample.filter(
     (job: { createdAt: number }) => now - job.createdAt >= staleAfterMs,
   ).length;
+  const stale = stalePending + expiredRunningSample.length;
   return {
     pending: pendingSample.length,
+    running: runningSample.length,
+    expiredRunning: expiredRunningSample.length,
     stale,
     exhausted: exhaustedSample.length,
     oldestPendingAgeMs,
     pendingCapped: pending.length > sampleLimit,
+    runningCapped: running.length > sampleLimit,
+    expiredRunningCapped: expiredRunning.length > sampleLimit,
     exhaustedCapped: exhausted.length > sampleLimit,
   };
 }

--- a/convex/registryArtifactBackupsNode.ts
+++ b/convex/registryArtifactBackupsNode.ts
@@ -76,7 +76,7 @@ type PackageBackupPageItem =
     }
   | { kind: "missingPackage" }
   | { kind: "missingOwner" }
-  | { kind: "missingArtifact" };
+  | { kind: "missingArtifact"; releaseId: Id<"packageReleases"> };
 
 export type RegistryArtifactBackupSyncStats = {
   skillsScanned: number;
@@ -90,6 +90,8 @@ export type RegistryArtifactBackupSyncStats = {
   packagesMissingArtifact: number;
   packagesMissingPackage: number;
   packagesMissingOwner: number;
+  skillsEnqueued: number;
+  packagesEnqueued: number;
   retryJobsProcessed: number;
   retryJobsSucceeded: number;
   retryJobsFailed: number;
@@ -102,6 +104,7 @@ export type SeedRegistryArtifactBackupsInternalArgs = {
   dryRun?: boolean;
   batchSize?: number;
   maxBatches?: number;
+  queueOnly?: boolean;
 };
 
 export type SeedRegistryArtifactBackupsInternalResult = {
@@ -120,6 +123,14 @@ export type ProcessRegistryArtifactBackupRetriesInternalResult = {
 export type ProcessRegistryArtifactBackupRetriesInternalArgs = {
   dryRun?: boolean;
   forceDue?: boolean;
+};
+
+export type ProcessRegistryArtifactBackupQueueInternalArgs = {
+  dryRun?: boolean;
+  forceDue?: boolean;
+  limit?: number;
+  leaseTtlMs?: number;
+  workerId?: string;
 };
 
 export const backupSkillForPublishInternal = internalAction({
@@ -233,6 +244,7 @@ export async function seedRegistryArtifactBackupsInternalHandler(
   args: SeedRegistryArtifactBackupsInternalArgs,
 ): Promise<SeedRegistryArtifactBackupsInternalResult> {
   const dryRun = Boolean(args.dryRun);
+  const queueOnly = Boolean(args.queueOnly);
   const stats = initialRegistryArtifactBackupSyncStats();
 
   if (!isRegistryArtifactBackupConfigured()) {
@@ -249,7 +261,9 @@ export async function seedRegistryArtifactBackupsInternalHandler(
   const batchSize = clampInt(args.batchSize ?? DEFAULT_BATCH_SIZE, 1, MAX_BATCH_SIZE);
   const maxBatches = clampInt(args.maxBatches ?? DEFAULT_MAX_BATCHES, 1, MAX_MAX_BATCHES);
   const context = getRegistryArtifactBackupContext();
-  await processDueRegistryArtifactBackupJobs(ctx, context, dryRun, stats);
+  if (!queueOnly) {
+    await processDueRegistryArtifactBackupJobs(ctx, context, dryRun, stats);
+  }
 
   const state = dryRun
     ? { cursor: null as string | null }
@@ -284,6 +298,21 @@ export async function seedRegistryArtifactBackupsInternalHandler(
       }
 
       stats.skillsScanned += 1;
+      if (queueOnly) {
+        if (!dryRun) {
+          await ctx.runMutation(
+            internal.registryArtifactBackups.enqueueRegistryArtifactBackupJobInternal,
+            {
+              targetKind: "skillVersion",
+              skillVersionId: item.versionId,
+              reason: "seed",
+              preserveTerminal: true,
+            },
+          );
+        }
+        stats.skillsEnqueued += 1;
+        continue;
+      }
       try {
         const meta = await fetchSkillVersionBackupMeta(
           context,
@@ -351,7 +380,7 @@ export async function seedRegistryArtifactBackupsInternalHandler(
     if (isDone) break;
   }
 
-  const packageSync = await syncPackageReleaseBackups(ctx, context, args, dryRun, stats);
+  const packageSync = await syncPackageReleaseBackups(ctx, context, args, dryRun, queueOnly, stats);
   await alertOnUnhealthyBackupBacklog(ctx, stats);
 
   if (!dryRun) {
@@ -378,6 +407,7 @@ async function syncPackageReleaseBackups(
   context: RegistryArtifactBackupContext,
   args: SeedRegistryArtifactBackupsInternalArgs,
   dryRun: boolean,
+  queueOnly: boolean,
   stats: RegistryArtifactBackupSyncStats,
 ): Promise<{ cursor: string | null; isDone: boolean }> {
   const batchSize = clampInt(args.batchSize ?? DEFAULT_BATCH_SIZE, 1, MAX_BATCH_SIZE);
@@ -407,12 +437,41 @@ async function syncPackageReleaseBackups(
 
     for (const item of page.items) {
       if (item.kind !== "ok") {
-        if (item.kind === "missingArtifact") stats.packagesMissingArtifact += 1;
+        if (item.kind === "missingArtifact") {
+          stats.packagesMissingArtifact += 1;
+          if (queueOnly && !dryRun) {
+            await ctx.runMutation(
+              internal.registryArtifactBackups.enqueueRegistryArtifactBackupJobInternal,
+              {
+                targetKind: "packageRelease",
+                packageReleaseId: item.releaseId,
+                reason: "seed",
+                status: "missingArtifact",
+                preserveTerminal: true,
+              },
+            );
+          }
+        }
         if (item.kind === "missingPackage") stats.packagesMissingPackage += 1;
         if (item.kind === "missingOwner") stats.packagesMissingOwner += 1;
         continue;
       }
       stats.packagesScanned += 1;
+      if (queueOnly) {
+        if (!dryRun) {
+          await ctx.runMutation(
+            internal.registryArtifactBackups.enqueueRegistryArtifactBackupJobInternal,
+            {
+              targetKind: "packageRelease",
+              packageReleaseId: item.releaseId,
+              reason: "seed",
+              preserveTerminal: true,
+            },
+          );
+        }
+        stats.packagesEnqueued += 1;
+        continue;
+      }
       try {
         const meta = await fetchPackageReleaseBackupMeta(
           context,
@@ -466,15 +525,20 @@ async function processDueRegistryArtifactBackupJobs(
   context: RegistryArtifactBackupContext,
   dryRun: boolean,
   stats: RegistryArtifactBackupSyncStats,
-  options: { forceDue?: boolean } = {},
+  options: { forceDue?: boolean; leaseToken?: string } = {},
 ) {
   if (dryRun) return;
-  const jobs = (await ctx.runQuery(
-    internal.registryArtifactBackups.getDueRegistryArtifactBackupJobsInternal,
+  const leaseToken =
+    options.leaseToken ??
+    `registry-backup-serial-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const jobs = (await ctx.runMutation(
+    internal.registryArtifactBackups.claimRegistryArtifactBackupJobsInternal,
     {
-      includeExhaustedRepair: true,
-      ignoreNextRunAt: options.forceDue,
+      forceDue: options.forceDue,
       limit: DEFAULT_JOB_BATCH_SIZE,
+      leaseToken,
+      leaseTtlMs: RETRY_LEASE_TTL_MS,
+      includeExhaustedRepair: true,
       maxRepairAttempts: MAX_RETRY_REPAIR_ATTEMPTS,
     },
   )) as Array<Doc<"registryArtifactBackupJobs">>;
@@ -483,7 +547,7 @@ async function processDueRegistryArtifactBackupJobs(
   const chunks = chunkRetryJobGroups(groups);
   for (const chunk of chunks) {
     const results = await Promise.all(
-      chunk.map((group) => processRetryJobGroup(ctx, context, group)),
+      chunk.map((group) => processRetryJobGroup(ctx, context, group, leaseToken)),
     );
     for (const result of results) {
       stats.retryJobsProcessed += result.processed;
@@ -583,6 +647,7 @@ async function processRetryJobGroup(
   ctx: ActionCtx,
   context: RegistryArtifactBackupContext,
   group: RetryJobGroup,
+  leaseToken?: string,
 ) {
   const result = { processed: 0, succeeded: 0, failed: 0 };
   for (const workItem of group.items) {
@@ -591,49 +656,55 @@ async function processRetryJobGroup(
       if (workItem.kind === "lookupFailed") {
         throw workItem.error;
       } else if (workItem.kind === "missing") {
-        await markRetryJobSucceeded(ctx, workItem.job);
-        result.succeeded += 1;
+        const mark = await markRetryJobSucceeded(ctx, workItem.job, leaseToken);
+        if (!mark?.stale) result.succeeded += 1;
       } else if (workItem.kind === "packageRelease") {
         if (await hasMatchingPackageReleaseMeta(context, workItem.item)) {
-          await markRetryJobSucceeded(ctx, workItem.job);
-          result.succeeded += 1;
+          const mark = await markRetryJobSucceeded(ctx, workItem.job, leaseToken);
+          if (!mark?.stale) result.succeeded += 1;
         } else {
           await backupPackageReleaseToObjectStorage(ctx, workItem.item, context);
-          await markRetryJobSucceeded(ctx, workItem.job);
-          result.succeeded += 1;
+          const mark = await markRetryJobSucceeded(ctx, workItem.job, leaseToken);
+          if (!mark?.stale) result.succeeded += 1;
         }
       } else {
         if (await hasMatchingSkillVersionMeta(context, workItem.item)) {
-          await markRetryJobSucceeded(ctx, workItem.job);
-          result.succeeded += 1;
+          const mark = await markRetryJobSucceeded(ctx, workItem.job, leaseToken);
+          if (!mark?.stale) result.succeeded += 1;
         } else {
           await backupSkillVersionToObjectStorage(ctx, workItem.item, context);
-          await markRetryJobSucceeded(ctx, workItem.job);
-          result.succeeded += 1;
+          const mark = await markRetryJobSucceeded(ctx, workItem.job, leaseToken);
+          if (!mark?.stale) result.succeeded += 1;
         }
       }
     } catch (error) {
-      result.failed += 1;
-      await ctx.runMutation(
+      const mark = (await ctx.runMutation(
         internal.registryArtifactBackups.markRegistryArtifactBackupJobFailedInternal,
         {
           jobId: workItem.job._id,
           error: errorMessage(error),
+          leaseToken,
           maxAttempts: MAX_RETRY_REPAIR_ATTEMPTS,
         },
-      );
+      )) as { stale?: boolean };
+      if (!mark?.stale) result.failed += 1;
     }
   }
   return result;
 }
 
-async function markRetryJobSucceeded(ctx: ActionCtx, job: Doc<"registryArtifactBackupJobs">) {
-  await ctx.runMutation(
+async function markRetryJobSucceeded(
+  ctx: ActionCtx,
+  job: Doc<"registryArtifactBackupJobs">,
+  leaseToken?: string,
+) {
+  return (await ctx.runMutation(
     internal.registryArtifactBackups.markRegistryArtifactBackupJobSucceededInternal,
     {
       jobId: job._id,
+      leaseToken,
     },
-  );
+  )) as { stale?: boolean };
 }
 
 async function hasMatchingSkillVersionMeta(
@@ -834,6 +905,7 @@ export async function processRegistryArtifactBackupRetriesInternalHandler(
   try {
     await processDueRegistryArtifactBackupJobs(ctx, context, false, stats, {
       forceDue: args.forceDue,
+      leaseToken: token,
     });
     await alertOnUnhealthyBackupBacklog(ctx, stats);
   } finally {
@@ -847,11 +919,59 @@ export async function processRegistryArtifactBackupRetriesInternalHandler(
   return { stats };
 }
 
+export async function processRegistryArtifactBackupQueueInternalHandler(
+  ctx: ActionCtx,
+  args: ProcessRegistryArtifactBackupQueueInternalArgs,
+): Promise<ProcessRegistryArtifactBackupRetriesInternalResult> {
+  const stats = initialRegistryArtifactBackupSyncStats();
+
+  if (!isRegistryArtifactBackupConfigured()) {
+    return { stats };
+  }
+
+  const context = getRegistryArtifactBackupContext();
+  if (args.dryRun) {
+    await processDueRegistryArtifactBackupJobs(ctx, context, true, stats);
+    await alertOnUnhealthyBackupBacklog(ctx, stats);
+    return { stats };
+  }
+
+  const workerLabel = args.workerId ?? "registry-backup-worker";
+  const leaseToken = `${workerLabel}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const jobs = (await ctx.runMutation(
+    internal.registryArtifactBackups.claimRegistryArtifactBackupJobsInternal,
+    {
+      forceDue: args.forceDue,
+      leaseToken,
+      leaseTtlMs: args.leaseTtlMs,
+      limit: args.limit,
+      includeExhaustedRepair: true,
+      maxRepairAttempts: MAX_RETRY_REPAIR_ATTEMPTS,
+    },
+  )) as Array<Doc<"registryArtifactBackupJobs">>;
+
+  const groups = await groupRetryJobsByRoot(ctx, jobs);
+  const chunks = chunkRetryJobGroups(groups);
+  for (const chunk of chunks) {
+    const results = await Promise.all(
+      chunk.map((group) => processRetryJobGroup(ctx, context, group, leaseToken)),
+    );
+    for (const result of results) {
+      stats.retryJobsProcessed += result.processed;
+      stats.retryJobsSucceeded += result.succeeded;
+      stats.retryJobsFailed += result.failed;
+    }
+  }
+  await alertOnUnhealthyBackupBacklog(ctx, stats);
+  return { stats };
+}
+
 export const seedRegistryArtifactBackupsInternal = internalAction({
   args: {
     dryRun: v.optional(v.boolean()),
     batchSize: v.optional(v.number()),
     maxBatches: v.optional(v.number()),
+    queueOnly: v.optional(v.boolean()),
   },
   handler: seedRegistryArtifactBackupsInternalHandler,
 });
@@ -862,6 +982,17 @@ export const processRegistryArtifactBackupRetriesInternal = internalAction({
     forceDue: v.optional(v.boolean()),
   },
   handler: processRegistryArtifactBackupRetriesInternalHandler,
+});
+
+export const processRegistryArtifactBackupQueueInternal = internalAction({
+  args: {
+    dryRun: v.optional(v.boolean()),
+    forceDue: v.optional(v.boolean()),
+    limit: v.optional(v.number()),
+    leaseTtlMs: v.optional(v.number()),
+    workerId: v.optional(v.string()),
+  },
+  handler: processRegistryArtifactBackupQueueInternalHandler,
 });
 
 function clampInt(value: number, min: number, max: number) {
@@ -885,6 +1016,8 @@ function initialRegistryArtifactBackupSyncStats(): RegistryArtifactBackupSyncSta
     packagesMissingArtifact: 0,
     packagesMissingPackage: 0,
     packagesMissingOwner: 0,
+    skillsEnqueued: 0,
+    packagesEnqueued: 0,
     retryJobsProcessed: 0,
     retryJobsSucceeded: 0,
     retryJobsFailed: 0,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2607,10 +2607,19 @@ const registryArtifactBackupJobs = defineTable({
   targetKind: v.union(v.literal("skillVersion"), v.literal("packageRelease")),
   skillVersionId: v.optional(v.id("skillVersions")),
   packageReleaseId: v.optional(v.id("packageReleases")),
-  status: v.union(v.literal("pending"), v.literal("succeeded"), v.literal("exhausted")),
+  status: v.union(
+    v.literal("pending"),
+    v.literal("running"),
+    v.literal("succeeded"),
+    v.literal("exhausted"),
+    v.literal("missingArtifact"),
+  ),
   reason: v.union(v.literal("publish"), v.literal("seed"), v.literal("retry"), v.literal("sync")),
   attempts: v.number(),
   nextRunAt: v.number(),
+  leaseToken: v.optional(v.string()),
+  leaseExpiresAt: v.optional(v.number()),
+  claimedAt: v.optional(v.number()),
   lastAttemptAt: v.optional(v.number()),
   lastError: v.optional(v.string()),
   completedAt: v.optional(v.number()),
@@ -2619,6 +2628,7 @@ const registryArtifactBackupJobs = defineTable({
   updatedAt: v.number(),
 })
   .index("by_status_nextRunAt", ["status", "nextRunAt"])
+  .index("by_status_leaseExpiresAt", ["status", "leaseExpiresAt"])
   .index("by_status_attempts", ["status", "attempts"])
   .index("by_skill_version", ["skillVersionId"])
   .index("by_package_release", ["packageReleaseId"])


### PR DESCRIPTION
## Summary

- add leased `running` backup jobs so many registry artifact backup workers can claim queue work in parallel
- add queue-only seed mode so the historical scan creates durable ledger jobs without uploading inline
- preserve terminal backup ledger states, fence stale worker completions, reclaim expired running jobs, and count expired leases as stale health
- keep retry/repair behavior for pending, expired running, and repairable exhausted jobs

## Proof

- `bunx convex codegen --typecheck disable`
- `bunx vitest run convex/registryArtifactBackups.test.ts`
- `bunx tsc --noEmit --pretty false`
- `git diff --check`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode local` -> clean after accepted fixes

Refs CLAW-289.
