### PR TITLE
ci: shard local-auth Playwright gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,16 @@ jobs:
 
       - uses: ./.github/actions/setup-bun
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+        run: bunx playwright install chromium
 
       - name: Browser e2e
         run: bun run ci:playwright-smoke
@@ -108,26 +116,87 @@ jobs:
           path: playwright-report/
           if-no-files-found: ignore
 
-  playwright-local-auth:
-    name: playwright-local-auth
+  playwright-local-auth-shard:
+    name: playwright-local-auth / ${{ matrix.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: delete-account
+            spec: e2e/local-auth/delete-account-resources.pw.test.ts
+          - name: delete-org
+            spec: e2e/local-auth/delete-org-resources.pw.test.ts
+          - name: header-profile-link
+            spec: e2e/local-auth/header-profile-link.pw.test.ts
+          - name: malicious-skill-ban
+            spec: e2e/local-auth/malicious-skill-ban-flow.pw.test.ts
+          - name: manage-context-proof
+            spec: e2e/local-auth/manage-context-proof.pw.test.ts
+          - name: plugin-inspector-findings
+            spec: e2e/local-auth/plugin-inspector-findings.pw.test.ts
+          - name: publish-generated-card
+            spec: e2e/local-auth/publish-skill-lifecycle.pw.test.ts
+            grep: publishing a skill queues scan
+          - name: publish-new-version
+            spec: e2e/local-auth/publish-skill-lifecycle.pw.test.ts
+            grep: skill publishers can create a skill
+          - name: skill-star-sync
+            spec: e2e/local-auth/skill-star-sync.pw.test.ts
+          - name: version-delete
+            spec: e2e/local-auth/version-delete.pw.test.ts
 
     steps:
       - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-bun
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install Playwright browsers
-        run: bunx playwright install --with-deps chromium
+        run: bunx playwright install chromium
 
       - name: Local-auth browser e2e
-        run: bun run test:pw:local-auth
+        env:
+          PLAYWRIGHT_GREP: ${{ matrix.grep || '' }}
+          PLAYWRIGHT_SPEC: ${{ matrix.spec }}
+        run: |
+          set -euo pipefail
+          args=(--project=chromium "$PLAYWRIGHT_SPEC")
+          if [[ -n "$PLAYWRIGHT_GREP" ]]; then
+            args+=(--grep "$PLAYWRIGHT_GREP")
+          fi
+          bun run test:pw:local-auth -- "${args[@]}"
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-local-auth-report
+          name: playwright-local-auth-report-${{ matrix.name }}
           path: playwright-report/
           if-no-files-found: ignore
+
+  playwright-local-auth:
+    name: playwright-local-auth
+    runs-on: ubuntu-latest
+    needs: playwright-local-auth-shard
+    if: ${{ always() }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Check local-auth shards
+        env:
+          LOCAL_AUTH_RESULT: ${{ needs.playwright-local-auth-shard.result }}
+        run: |
+          if [[ "$LOCAL_AUTH_RESULT" != "success" ]]; then
+            echo "playwright-local-auth shards finished with result: $LOCAL_AUTH_RESULT"
+            exit 1
+          fi
+          echo "playwright-local-auth shards passed."


### PR DESCRIPTION
## Summary

- Split the `playwright-local-auth` gate into one matrix shard per local-auth spec, with the shared publish lifecycle spec split by grep so each shard runs one test path.
- Keep the required `playwright-local-auth` check name as a lightweight aggregate job over the matrix.
- Add a shared Playwright browser cache and avoid reinstalling system deps on every Playwright job.

## RCA / Intent

The last-run pattern points more at slowness than nondeterministic test behavior: the long pole is the monolithic local-auth job doing repeated setup plus all signed-in browser flows serially. Sharding makes the gate parallel and the aggregate job keeps branch protection semantics stable.

## Validation

- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- `bun run format:check -- .github/workflows/ci.yml`
- `bun run ci:static`
- `PLAYWRIGHT_LOCAL_AUTH_CONVEX_URL=http://127.0.0.1:3410 PLAYWRIGHT_LOCAL_AUTH_CONVEX_SITE_URL=http://127.0.0.1:3411 PLAYWRIGHT_PORT=4373 bun run test:pw:local-auth -- --project=chromium e2e/local-auth/header-profile-link.pw.test.ts`
- `PLAYWRIGHT_LOCAL_AUTH_CONVEX_URL=http://127.0.0.1:3420 PLAYWRIGHT_LOCAL_AUTH_CONVEX_SITE_URL=http://127.0.0.1:3421 PLAYWRIGHT_PORT=4383 bun run test:pw:local-auth -- --project=chromium e2e/local-auth/publish-skill-lifecycle.pw.test.ts --grep "publishing a skill queues scan"`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
