### PR TITLE
feat(web): add active publisher context

### DIFF
--- a/convex/publishers.ts
+++ b/convex/publishers.ts
@@ -108,6 +108,14 @@ type PublisherListItem = NonNullable<ReturnType<typeof toPublicPublisher>> & {
   }>;
 };
 
+type PublisherMembershipListItem = {
+  publisher: Pick<
+    Doc<"publishers">,
+    "_id" | "handle" | "displayName" | "kind" | "image" | "linkedUserId"
+  >;
+  role: Doc<"publisherMembers">["role"];
+};
+
 type PublisherListSummary = {
   publisher: Doc<"publishers">;
   item: PublisherListItem;
@@ -1833,6 +1841,64 @@ export const listMine = query({
     ) {
       visiblePublishers.unshift({
         publisher: personalPublisher,
+        role: "owner",
+      });
+    }
+    return visiblePublishers;
+  },
+});
+
+export const listMineMemberships = query({
+  args: {},
+  handler: async (ctx): Promise<PublisherMembershipListItem[]> => {
+    const userId = await getOptionalActiveAuthUserId(ctx);
+    if (!userId) return [];
+    const user = await ctx.db.get(userId);
+    if (!user || user.deletedAt || user.deactivatedAt) return [];
+    const memberships = await ctx.db
+      .query("publisherMembers")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .collect();
+    const publishers = await Promise.all(
+      memberships.map(async (membership) => {
+        const publisher = await ctx.db.get(membership.publisherId);
+        if (!publisher || !isPublisherActive(publisher)) return null;
+        if (publisher.kind === "user") {
+          const isLinkedPersonal = publisher.linkedUserId === userId;
+          const isLegacyPersonal =
+            !publisher.linkedUserId && user.personalPublisherId === publisher._id;
+          if (!isLinkedPersonal && !isLegacyPersonal) return null;
+        }
+        return {
+          publisher: {
+            _id: publisher._id,
+            handle: publisher.handle,
+            displayName: publisher.displayName,
+            kind: publisher.kind,
+            image: publisher.image,
+            linkedUserId: publisher.linkedUserId,
+          },
+          role: publisher.kind === "user" ? "owner" : membership.role,
+        };
+      }),
+    );
+    const visiblePublishers = publishers.filter(
+      (item): item is NonNullable<(typeof publishers)[number]> => Boolean(item),
+    );
+    const personalPublisher = await getPersonalPublisherForUserOrFallback(ctx, user);
+    if (
+      personalPublisher &&
+      !visiblePublishers.some((entry) => entry.publisher._id === personalPublisher._id)
+    ) {
+      visiblePublishers.unshift({
+        publisher: {
+          _id: personalPublisher._id,
+          handle: personalPublisher.handle,
+          displayName: personalPublisher.displayName,
+          kind: personalPublisher.kind,
+          image: personalPublisher.image,
+          linkedUserId: personalPublisher.linkedUserId,
+        },
         role: "owner",
       });
     }

--- a/specs/orgs.md
+++ b/specs/orgs.md
@@ -486,6 +486,38 @@ Compatibility should have clear limits:
 - return canonical scoped locator in responses
 - do not allow old format to remain canonical in docs or new UI
 
+## Active Publisher UI Context
+
+Signed-in users can select one active publisher globally in the app shell.
+
+This active publisher is a convenience default for owned surfaces, not an auth
+boundary and not a marketplace filter.
+
+Rules:
+
+- The active publisher represents "who I am publishing or managing as" for UI
+  defaults.
+- Backend mutations and queries remain the authority for membership, role, and
+  ownership checks.
+- Public browse, search, home, detail, install, and star flows stay global or
+  personal; they must not silently scope themselves to the active publisher.
+- Personal actions such as stars, API tokens, account profile, sign out, and
+  account deletion stay tied to the signed-in user.
+- Dashboard and new publish flows may default to the active publisher.
+- A URL-level `ownerHandle` is an explicit page override. It may prefill the
+  current screen, but it must not persist a new global active publisher unless
+  the user changes the global selector directly.
+- Existing resources keep their current owner as the default for updates and new
+  versions. Active publisher selection must not trigger owner migration.
+- Owner migration remains an explicit confirmed flow that sends
+  `migrateOwner: true`; normal active-publisher defaults must not set it.
+- Role handling must distinguish publish access from management access. A
+  `publisher` member can publish for that publisher but must not see org member
+  management, destructive publisher actions, or other admin-only controls.
+- If a persisted active publisher is no longer available in `publishers.listMine`,
+  the UI must fall back to the personal publisher when possible, then the first
+  available publisher.
+
 ## UI Surfaces
 
 Need updates in:

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -442,11 +442,13 @@ describe("Header", () => {
     expect(screen.getByText("Personal")).toBeTruthy();
     expect(screen.queryByText("Personal · owner")).toBeNull();
     expect(within(activePublisher).getByText("OpenClaw")).toBeTruthy();
-    expect(within(activePublisher).getByText("connected as")).toBeTruthy();
-    expect(within(activePublisher).getByText("@patrick")).toBeTruthy();
-    expect(within(activePublisher).queryByText("Org · Admin")).toBeNull();
+    expect(within(activePublisher).getByText("Org · Admin")).toBeTruthy();
+    const managingRow = document.querySelector(".user-dropdown-managing-row");
+    expect(managingRow).toBeTruthy();
+    expect(within(managingRow as HTMLElement).getByText("Managing as")).toBeTruthy();
+    expect(within(managingRow as HTMLElement).getByText("@patrick")).toBeTruthy();
     expect(
-      activePublisher.querySelector(".user-dropdown-via-avatar-fallback .lucide-user-round"),
+      managingRow?.querySelector(".user-dropdown-managing-avatar-fallback .lucide-user-round"),
     ).toBeTruthy();
     expect(screen.getByLabelText("Publisher actions for @openclaw")).toBeTruthy();
     expect(within(publisherActions).queryByText("Stars")).toBeNull();

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -13,11 +13,52 @@ type HeaderAuthStatus = {
 };
 
 const navigateMock = vi.fn();
-const { profileHandleMock, signInMock, useUnifiedSearchMock } = vi.hoisted(() => ({
-  profileHandleMock: vi.fn(),
-  signInMock: vi.fn(),
-  useUnifiedSearchMock: vi.fn(),
-}));
+const { activePublisherMock, profileHandleMock, signInMock, useUnifiedSearchMock } = vi.hoisted(
+  () => ({
+    activePublisherMock: vi.fn(),
+    profileHandleMock: vi.fn(),
+    signInMock: vi.fn(),
+    useUnifiedSearchMock: vi.fn(),
+  }),
+);
+
+const personalPublisher = {
+  publisher: {
+    _id: "publishers:patrick",
+    handle: "patrick",
+    displayName: "Patrick",
+    kind: "user",
+    image: null,
+  },
+  role: "owner",
+} as const;
+
+const orgPublisher = {
+  publisher: {
+    _id: "publishers:openclaw",
+    handle: "openclaw",
+    displayName: "OpenClaw",
+    kind: "org",
+    image: null,
+  },
+  role: "admin",
+} as const;
+
+const setActivePublisherIdMock = vi.fn();
+
+const defaultActivePublisherState = {
+  activePublisher: personalPublisher,
+  activePublisherId: personalPublisher.publisher._id,
+  activeOwnerHandle: personalPublisher.publisher.handle,
+  canManageActivePublisher: true,
+  canPublishAsActivePublisher: true,
+  canViewActivePublisherScope: true,
+  hasMultiplePublishers: false,
+  isLoading: false,
+  memberships: [personalPublisher],
+  personalPublisher,
+  setActivePublisherId: setActivePublisherIdMock,
+};
 
 const defaultUnifiedSearchResult = {
   results: [],
@@ -102,6 +143,10 @@ const authStatusMock = vi.fn<() => HeaderAuthStatus>(() => ({
 
 vi.mock("../lib/useAuthStatus", () => ({
   useAuthStatus: () => authStatusMock(),
+}));
+
+vi.mock("../lib/activePublisher", () => ({
+  useActivePublisher: () => activePublisherMock(),
 }));
 
 const setModeMock = vi.fn();
@@ -234,6 +279,8 @@ describe("Header", () => {
       me: null,
     });
     profileHandleMock.mockReturnValue(null);
+    setActivePublisherIdMock.mockReset();
+    activePublisherMock.mockReturnValue(defaultActivePublisherState);
     useUnifiedSearchMock.mockReturnValue(defaultUnifiedSearchResult);
     signInMock.mockReset();
     signInMock.mockResolvedValue({ signingIn: true });
@@ -320,6 +367,43 @@ describe("Header", () => {
     expect(setModeMock).toHaveBeenCalledWith("light");
     fireEvent.click(screen.getByLabelText("Dark theme"));
     expect(setModeMock).toHaveBeenCalledWith("dark");
+  });
+
+  it("renders a global publisher switcher in the account menu", () => {
+    authStatusMock.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      me: {
+        displayName: "Patrick",
+        email: "patrick@example.com",
+        handle: "patrick",
+        image: null,
+        name: "Patrick",
+      },
+    });
+    activePublisherMock.mockReturnValue({
+      ...defaultActivePublisherState,
+      activePublisher: orgPublisher,
+      activePublisherId: orgPublisher.publisher._id,
+      activeOwnerHandle: orgPublisher.publisher.handle,
+      hasMultiplePublishers: true,
+      memberships: [personalPublisher, orgPublisher],
+    });
+
+    render(<Header />);
+
+    expect(screen.getByRole("button", { name: "Open account menu for @openclaw" })).toBeTruthy();
+    expect(screen.getByText("@patrick")).toBeTruthy();
+    expect(screen.getByText("Personal · owner")).toBeTruthy();
+    expect(screen.getAllByText("@openclaw").length).toBeGreaterThan(1);
+    expect(screen.getByText("Org · admin")).toBeTruthy();
+    expect(screen.getByText("Signed in as @patrick")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("@patrick"));
+
+    expect(setActivePublisherIdMock).toHaveBeenCalledWith("publishers:patrick");
+    expect(screen.getByText("Stars")).toBeTruthy();
+    expect(screen.getByText("Settings")).toBeTruthy();
   });
 
   it("renders the GitHub sign-in button with desktop and compact labels", () => {

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -327,7 +327,7 @@ describe("Header", () => {
     expect(screen.queryByText("About")).toBeNull();
   });
 
-  it("separates active publisher actions from personal account controls", () => {
+  it("separates the publisher switcher from personal account controls", () => {
     authStatusMock.mockReturnValue({
       isAuthenticated: true,
       isLoading: false,
@@ -345,20 +345,26 @@ describe("Header", () => {
     expect(document.querySelector(".theme-mode-toggle")).toBeNull();
     expect(screen.queryByText("Theme")).toBeNull();
 
+    expect(screen.getByRole("button", { name: "Open publisher switcher for @patrick" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open account menu for @patrick" })).toBeTruthy();
+
     const activePublisher = screen.getByLabelText("Current publisher @patrick");
     const account = screen.getByLabelText("Account @patrick");
+    const appActions = screen.getByLabelText("App actions");
     const themeRow = document.querySelector(".user-dropdown-theme-row");
-    const settings = within(activePublisher).getByText("Settings");
-    const stars = within(account).getByText("Stars");
-    const appearance = within(account).getByText("Appearance");
-    const signOut = within(account).getByText("Sign out");
+    const managePublisher = within(activePublisher).getByText("Manage publisher…");
+    const stars = within(appActions).getByText("Stars");
+    const appearance = within(appActions).getByText("Appearance");
+    const signOut = screen.getByText("Sign out");
 
     expect(within(activePublisher).queryByText("Stars")).toBeNull();
-    expect(within(account).queryByText("Settings")).toBeNull();
+    expect(within(activePublisher).queryByText("Appearance")).toBeNull();
+    expect(within(account).queryByText("Stars")).toBeNull();
+    expect(within(account).queryByText("Manage publisher…")).toBeNull();
     expect(screen.queryByText("Switch publisher")).toBeNull();
     expect(themeRow).toBeTruthy();
     expect(themeRow?.children).toHaveLength(3);
-    expect(settings.compareDocumentPosition(stars) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+    expect(managePublisher.compareDocumentPosition(stars) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
     expect(stars.compareDocumentPosition(appearance) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
@@ -377,7 +383,7 @@ describe("Header", () => {
     expect(setModeMock).toHaveBeenCalledWith("dark");
   });
 
-  it("renders a global publisher switcher in the account menu", () => {
+  it("renders a compact publisher switcher separate from the account menu", () => {
     authStatusMock.mockReturnValue({
       isAuthenticated: true,
       isLoading: false,
@@ -400,21 +406,24 @@ describe("Header", () => {
 
     render(<Header />);
 
-    expect(screen.getByRole("button", { name: "Open account menu for @openclaw" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open publisher switcher for @openclaw" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open account menu for @patrick" })).toBeTruthy();
     const activePublisher = screen.getByLabelText("Current publisher @openclaw");
     const account = screen.getByLabelText("Account @patrick");
-    const profile = within(activePublisher).getByText("Profile");
+    const managePublisher = within(activePublisher).getByText("Manage publisher…");
 
     expect(within(account).getByText("@patrick")).toBeTruthy();
+    expect(within(account).getByText("Account settings")).toBeTruthy();
+    expect(within(account).queryByText("Switch publisher")).toBeNull();
     expect(screen.getByText("Switch publisher")).toBeTruthy();
     expect(screen.getByLabelText("Switch to @patrick")).toBeTruthy();
-    expect(screen.getByText("Personal")).toBeTruthy();
+    expect(screen.getByText("Personal publisher")).toBeTruthy();
     expect(screen.queryByText("Personal · owner")).toBeNull();
     expect(within(activePublisher).getByText("@openclaw")).toBeTruthy();
-    expect(within(activePublisher).getByText("Org · admin")).toBeTruthy();
-    expect(screen.getByLabelText("Publisher actions for @openclaw")).toBeTruthy();
-    expect(profile.closest("a")?.getAttribute("href")).toBe("/user/openclaw");
-    expect(profile.closest("a")?.querySelector(".lucide-building-2")).toBeTruthy();
+    expect(within(activePublisher).getByText("Organization · Admin")).toBeTruthy();
+    expect(managePublisher.closest("a")?.getAttribute("href")).toBe("/settings");
+    expect(screen.queryByText("Profile")).toBeNull();
+    expect(screen.queryByText("Dashboard")).toBeNull();
     expect(screen.queryByText("Signed in as @patrick")).toBeNull();
     expect(screen.queryByText(/For @openclaw/)).toBeNull();
 
@@ -422,7 +431,7 @@ describe("Header", () => {
 
     expect(setActivePublisherIdMock).toHaveBeenCalledWith("publishers:patrick");
     expect(screen.getByText("Stars")).toBeTruthy();
-    expect(screen.getByText("Settings")).toBeTruthy();
+    expect(screen.getByText("Account settings")).toBeTruthy();
   });
 
   it("renders the GitHub sign-in button with desktop and compact labels", () => {
@@ -672,8 +681,7 @@ describe("Header", () => {
     ).toBeTruthy();
   });
 
-  it("links profile and starred skills from the signed-in avatar menu", () => {
-    profileHandleMock.mockReturnValue("patrick-profile");
+  it("links publisher management and account actions from separate menus", () => {
     authStatusMock.mockReturnValue({
       isAuthenticated: true,
       isLoading: false,
@@ -688,15 +696,17 @@ describe("Header", () => {
 
     render(<Header />);
 
-    const profile = screen.getByText("Profile");
-    const dashboard = screen.getAllByText("Dashboard").at(-1)!;
-
-    expect(profile.closest("a")?.getAttribute("href")).toBe("/user/patrick-profile");
-    expect(profile.compareDocumentPosition(dashboard) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING,
+    expect(screen.getByText("Manage publisher…").closest("a")?.getAttribute("href")).toBe(
+      "/settings",
     );
     expect(screen.getByText("Stars").closest("a")?.getAttribute("href")).toBe("/stars");
-    expect(screen.getAllByText("Dashboard").length).toBeGreaterThan(0);
-    expect(screen.getByText("Settings")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("Account settings"));
+
+    expect(setActivePublisherIdMock).toHaveBeenCalledWith("publishers:patrick");
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: "/settings",
+      search: { view: "profile" },
+    });
   });
 });

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -424,7 +424,7 @@ describe("Header", () => {
     expect(screen.getByRole("button", { name: "Open account menu for @openclaw" })).toBeTruthy();
     const activePublisher = screen.getByLabelText("Current publisher @openclaw");
     const publisherActions = screen.getByLabelText("Publisher actions for @openclaw");
-    const profile = within(publisherActions).getByText("Profile");
+    const profile = within(publisherActions).getByText("Org profile");
 
     expect(screen.queryByLabelText("Account @patrick")).toBeNull();
     expect(screen.getByText("Switch publisher")).toBeTruthy();

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -430,7 +430,7 @@ describe("Header", () => {
 
     render(<Header />);
 
-    expect(screen.getByRole("button", { name: "Open account menu for @openclaw" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open account menu for OpenClaw" })).toBeTruthy();
     const activePublisher = screen.getByLabelText("Current publisher @openclaw");
     const publisherActions = screen.getByLabelText("Publisher actions for @openclaw");
     const profile = within(publisherActions).getByText("Org profile");
@@ -441,8 +441,13 @@ describe("Header", () => {
     expect(screen.getByText("Create organization")).toBeTruthy();
     expect(screen.getByText("Personal")).toBeTruthy();
     expect(screen.queryByText("Personal · owner")).toBeNull();
-    expect(within(activePublisher).getByText("@openclaw")).toBeTruthy();
-    expect(within(activePublisher).getByText("Org · Admin")).toBeTruthy();
+    expect(within(activePublisher).getByText("OpenClaw")).toBeTruthy();
+    expect(within(activePublisher).getByText("via")).toBeTruthy();
+    expect(within(activePublisher).getByText("@patrick")).toBeTruthy();
+    expect(within(activePublisher).queryByText("Org · Admin")).toBeNull();
+    expect(
+      activePublisher.querySelector(".user-dropdown-via-avatar-fallback .lucide-user-round"),
+    ).toBeTruthy();
     expect(screen.getByLabelText("Publisher actions for @openclaw")).toBeTruthy();
     expect(within(publisherActions).queryByText("Stars")).toBeNull();
     expect(profile.closest("a")?.getAttribute("href")).toBe("/user/openclaw");

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -442,7 +442,7 @@ describe("Header", () => {
     expect(screen.getByText("Personal")).toBeTruthy();
     expect(screen.queryByText("Personal · owner")).toBeNull();
     expect(within(activePublisher).getByText("OpenClaw")).toBeTruthy();
-    expect(within(activePublisher).getByText("via")).toBeTruthy();
+    expect(within(activePublisher).getByText("connected as")).toBeTruthy();
     expect(within(activePublisher).getByText("@patrick")).toBeTruthy();
     expect(within(activePublisher).queryByText("Org · Admin")).toBeNull();
     expect(

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -327,7 +327,7 @@ describe("Header", () => {
     expect(screen.queryByText("About")).toBeNull();
   });
 
-  it("renders theme mode controls as a compact row between Settings and Sign out", () => {
+  it("separates active publisher actions from personal account controls", () => {
     authStatusMock.mockReturnValue({
       isAuthenticated: true,
       isLoading: false,
@@ -347,17 +347,20 @@ describe("Header", () => {
 
     const themeRow = document.querySelector(".user-dropdown-theme-row");
     const settings = screen.getByText("Settings");
+    const stars = screen.getByText("Stars");
     const signOut = screen.getByText("Sign out");
 
     expect(themeRow).toBeTruthy();
     expect(themeRow?.children).toHaveLength(3);
-    expect(settings.compareDocumentPosition(themeRow!) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+    expect(settings.compareDocumentPosition(stars) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(stars.compareDocumentPosition(themeRow!) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
     expect(themeRow!.compareDocumentPosition(signOut) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
-    expect(themeRow?.previousElementSibling?.tagName).toBe("HR");
     expect(signOut.previousElementSibling?.tagName).toBe("HR");
 
     expect(screen.getByLabelText("System theme").getAttribute("aria-current")).toBe("true");
@@ -394,9 +397,12 @@ describe("Header", () => {
 
     expect(screen.getByRole("button", { name: "Open account menu for @openclaw" })).toBeTruthy();
     expect(screen.getByText("@patrick")).toBeTruthy();
-    expect(screen.getByText("Personal · owner")).toBeTruthy();
+    expect(screen.getByText("Personal")).toBeTruthy();
+    expect(screen.queryByText("Personal · owner")).toBeNull();
     expect(screen.getAllByText("@openclaw").length).toBeGreaterThan(1);
     expect(screen.getByText("Org · admin")).toBeTruthy();
+    expect(screen.getByLabelText("Actions for @openclaw")).toBeTruthy();
+    expect(screen.getByText("Profile").closest("a")?.getAttribute("href")).toBe("/user/openclaw");
     expect(screen.queryByText("Signed in as @patrick")).toBeNull();
 
     fireEvent.click(screen.getByText("@patrick"));

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -371,12 +371,13 @@ describe("Header", () => {
     const publisherActions = screen.getByLabelText("Publisher actions for @patrick");
     const themeRow = document.querySelector(".user-dropdown-theme-row");
     const settings = within(publisherActions).getByText("Settings");
-    const stars = screen.getByText("Stars");
+    const stars = within(publisherActions).getByText("Stars");
     const appearance = screen.getByText("Appearance");
     const signOut = screen.getByText("Sign out");
 
     expect(within(activePublisher).queryByText("Stars")).toBeNull();
     expect(within(account).queryByText("Stars")).toBeNull();
+    expect(within(account).queryByText("Sign out")).toBeNull();
     expect(within(account).queryByText("Settings")).toBeNull();
     expect(within(account).getByText("Account")).toBeTruthy();
     expect(screen.queryByText("Switch publisher")).toBeNull();
@@ -433,21 +434,33 @@ describe("Header", () => {
     expect(within(account).getByText("@patrick")).toBeTruthy();
     expect(screen.getByText("Switch publisher")).toBeTruthy();
     expect(screen.getByLabelText("Switch to @patrick")).toBeTruthy();
+    expect(screen.getByText("Create organization")).toBeTruthy();
     expect(screen.getByText("Personal")).toBeTruthy();
     expect(screen.queryByText("Personal · owner")).toBeNull();
     expect(within(activePublisher).getByText("@openclaw")).toBeTruthy();
     expect(within(activePublisher).getByText("Org · Admin")).toBeTruthy();
     expect(screen.getByLabelText("Publisher actions for @openclaw")).toBeTruthy();
+    expect(within(publisherActions).queryByText("Stars")).toBeNull();
     expect(profile.closest("a")?.getAttribute("href")).toBe("/user/openclaw");
     expect(profile.closest("a")?.querySelector(".lucide-building-2")).toBeTruthy();
     expect(screen.getByLabelText("Selected publisher @openclaw")).toBeTruthy();
     expect(screen.queryByText("Signed in as @patrick")).toBeNull();
     expect(screen.queryByText(/For @openclaw/)).toBeNull();
 
+    fireEvent.click(screen.getByText("Create organization"));
+
+    expect(setActivePublisherIdMock).toHaveBeenCalledWith("publishers:patrick");
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: "/settings",
+      search: { view: "organizations" },
+    });
+
+    setActivePublisherIdMock.mockClear();
     fireEvent.click(screen.getByLabelText("Switch to @patrick"));
 
     expect(setActivePublisherIdMock).toHaveBeenCalledWith("publishers:patrick");
     expect(screen.getByText("Stars")).toBeTruthy();
+    expect(screen.getByText("Sign out")).toBeTruthy();
     expect(screen.getByText("Settings")).toBeTruthy();
   });
 

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -442,7 +442,8 @@ describe("Header", () => {
     expect(screen.getByText("Personal")).toBeTruthy();
     expect(screen.queryByText("Personal · owner")).toBeNull();
     expect(within(activePublisher).getByText("OpenClaw")).toBeTruthy();
-    expect(within(activePublisher).getByText("Org · Admin")).toBeTruthy();
+    expect(within(activePublisher).getByText("Organization")).toBeTruthy();
+    expect(screen.queryByText("Org · Admin")).toBeNull();
     const managingRow = document.querySelector(".user-dropdown-managing-row");
     expect(managingRow).toBeTruthy();
     expect(within(managingRow as HTMLElement).getByText("Managing as")).toBeTruthy();

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -444,13 +444,7 @@ describe("Header", () => {
     expect(within(activePublisher).getByText("OpenClaw")).toBeTruthy();
     expect(within(activePublisher).getByText("Organization")).toBeTruthy();
     expect(screen.queryByText("Org · Admin")).toBeNull();
-    const managingRow = document.querySelector(".user-dropdown-managing-row");
-    expect(managingRow).toBeTruthy();
-    expect(within(managingRow as HTMLElement).getByText("Managing as")).toBeTruthy();
-    expect(within(managingRow as HTMLElement).getByText("@patrick")).toBeTruthy();
-    expect(
-      managingRow?.querySelector(".user-dropdown-managing-avatar-fallback .lucide-user-round"),
-    ).toBeTruthy();
+    expect(screen.queryByText("Managing as")).toBeNull();
     expect(screen.getByLabelText("Publisher actions for @openclaw")).toBeTruthy();
     expect(within(publisherActions).queryByText("Stars")).toBeNull();
     expect(profile.closest("a")?.getAttribute("href")).toBe("/user/openclaw");

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -192,27 +192,6 @@ vi.mock("../components/ui/dropdown-menu", () => ({
   DropdownMenuContent: ({ children, className }: { children: ReactNode; className?: string }) => (
     <div className={className}>{children}</div>
   ),
-  DropdownMenuSub: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  DropdownMenuSubContent: ({
-    children,
-    className,
-  }: {
-    children: ReactNode;
-    className?: string;
-  }) => <div className={className}>{children}</div>,
-  DropdownMenuSubTrigger: ({
-    children,
-    className,
-    ...props
-  }: {
-    children: ReactNode;
-    className?: string;
-    "aria-label"?: string;
-  }) => (
-    <div aria-label={props["aria-label"]} className={className}>
-      {children}
-    </div>
-  ),
   DropdownMenuItem: ({
     children,
     className,
@@ -294,6 +273,16 @@ function compactHeaderCss() {
 describe("Header", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    });
     authStatusMock.mockReturnValue({
       isAuthenticated: false,
       isLoading: false,
@@ -436,10 +425,6 @@ describe("Header", () => {
     const profile = within(publisherActions).getByText("Org profile");
 
     expect(screen.queryByLabelText("Account @patrick")).toBeNull();
-    expect(screen.getByText("Switch publisher")).toBeTruthy();
-    expect(screen.getByLabelText("Switch to @patrick")).toBeTruthy();
-    expect(screen.getByText("Create organization")).toBeTruthy();
-    expect(screen.getByText("Personal")).toBeTruthy();
     expect(screen.queryByText("Personal · owner")).toBeNull();
     expect(within(activePublisher).getByText("OpenClaw")).toBeTruthy();
     expect(within(activePublisher).getByText("Organization")).toBeTruthy();
@@ -449,9 +434,16 @@ describe("Header", () => {
     expect(within(publisherActions).queryByText("Stars")).toBeNull();
     expect(profile.closest("a")?.getAttribute("href")).toBe("/user/openclaw");
     expect(profile.closest("a")?.querySelector(".lucide-building-2")).toBeTruthy();
-    expect(screen.getByLabelText("Selected publisher @openclaw")).toBeTruthy();
     expect(screen.queryByText("Signed in as @patrick")).toBeNull();
     expect(screen.queryByText(/For @openclaw/)).toBeNull();
+
+    fireEvent.click(activePublisher);
+
+    expect(screen.getByLabelText("Selected publisher @openclaw")).toBeTruthy();
+    expect(screen.getByLabelText("Switch to @patrick")).toBeTruthy();
+    expect(screen.getByText("Create organization")).toBeTruthy();
+    expect(screen.getByText("Personal")).toBeTruthy();
+    expect(document.querySelector('[data-slot="dropdown-menu-sub-content"]')).toBeNull();
 
     fireEvent.click(screen.getByText("Create organization"));
 
@@ -465,10 +457,53 @@ describe("Header", () => {
     fireEvent.click(screen.getByLabelText("Switch to @patrick"));
 
     expect(setActivePublisherIdMock).toHaveBeenCalledWith("publishers:patrick");
+    fireEvent.click(screen.getByText("Back"));
     expect(screen.queryByText("Stars")).toBeNull();
     expect(screen.getByText("Appearance")).toBeTruthy();
     expect(screen.getByText("Sign out")).toBeTruthy();
     expect(screen.getByText("Settings")).toBeTruthy();
+  });
+
+  it("opens the publisher switcher inside the account menu on mobile", async () => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === "(max-width: 639px)",
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      })),
+    });
+    authStatusMock.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      me: {
+        displayName: "Patrick",
+        email: "patrick@example.com",
+        handle: "patrick",
+        image: null,
+        name: "Patrick",
+      },
+    });
+    activePublisherMock.mockReturnValue({
+      ...defaultActivePublisherState,
+      activePublisher: orgPublisher,
+      activePublisherId: orgPublisher.publisher._id,
+      activeOwnerHandle: orgPublisher.publisher.handle,
+      hasMultiplePublishers: true,
+      memberships: [personalPublisher, orgPublisher],
+    });
+
+    render(<Header />);
+
+    const currentPublisher = await screen.findByLabelText("Current publisher @openclaw");
+    fireEvent.click(currentPublisher);
+
+    expect(await screen.findByLabelText("Switch publisher")).toBeTruthy();
+    expect(screen.getByText("Back")).toBeTruthy();
+    expect(document.querySelector('[data-slot="dropdown-menu-sub-content"]')).toBeNull();
+    expect(screen.queryByLabelText("Publisher actions for @openclaw")).toBeNull();
   });
 
   it("renders the GitHub sign-in button with desktop and compact labels", () => {

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -454,7 +454,7 @@ describe("Header", () => {
     fireEvent.click(screen.getByLabelText("Switch to @patrick"));
 
     expect(setActivePublisherIdMock).toHaveBeenCalledWith("publishers:patrick");
-    expect(screen.getByText("Stars")).toBeTruthy();
+    expect(screen.queryByText("Stars")).toBeNull();
     expect(screen.getByText("Appearance")).toBeTruthy();
     expect(screen.getByText("Sign out")).toBeTruthy();
     expect(screen.getByText("Settings")).toBeTruthy();

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -349,6 +349,7 @@ describe("Header", () => {
   });
 
   it("separates active publisher actions from personal account controls", () => {
+    profileHandleMock.mockReturnValue("patrick-profile");
     authStatusMock.mockReturnValue({
       isAuthenticated: true,
       isLoading: false,
@@ -369,6 +370,8 @@ describe("Header", () => {
     const activePublisher = screen.getByLabelText("Current publisher @patrick");
     const publisherActions = screen.getByLabelText("Publisher actions for @patrick");
     const themeRow = document.querySelector(".user-dropdown-theme-row");
+    const dashboard = within(publisherActions).getByText("Dashboard");
+    const profile = within(publisherActions).getByText("Profile");
     const settings = within(publisherActions).getByText("Settings");
     const stars = within(publisherActions).getByText("Stars");
     const appearance = screen.getByText("Appearance");
@@ -379,10 +382,16 @@ describe("Header", () => {
     expect(screen.queryByText("Switch publisher")).toBeNull();
     expect(themeRow).toBeTruthy();
     expect(themeRow?.children).toHaveLength(3);
-    expect(settings.compareDocumentPosition(stars) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+    expect(dashboard.compareDocumentPosition(profile) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
-    expect(stars.compareDocumentPosition(appearance) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+    expect(profile.compareDocumentPosition(stars) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(stars.compareDocumentPosition(settings) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(settings.compareDocumentPosition(appearance) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
     expect(themeRow!.compareDocumentPosition(signOut) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
@@ -727,7 +736,7 @@ describe("Header", () => {
     const dashboard = screen.getAllByText("Dashboard").at(-1)!;
 
     expect(profile.closest("a")?.getAttribute("href")).toBe("/user/patrick-profile");
-    expect(profile.compareDocumentPosition(dashboard) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+    expect(dashboard.compareDocumentPosition(profile) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
     expect(screen.getByText("Stars").closest("a")?.getAttribute("href")).toBe("/stars");

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -367,7 +367,6 @@ describe("Header", () => {
     expect(screen.queryByText("Theme")).toBeNull();
 
     const activePublisher = screen.getByLabelText("Current publisher @patrick");
-    const account = screen.getByLabelText("Account @patrick");
     const publisherActions = screen.getByLabelText("Publisher actions for @patrick");
     const themeRow = document.querySelector(".user-dropdown-theme-row");
     const settings = within(publisherActions).getByText("Settings");
@@ -376,10 +375,7 @@ describe("Header", () => {
     const signOut = screen.getByText("Sign out");
 
     expect(within(activePublisher).queryByText("Stars")).toBeNull();
-    expect(within(account).queryByText("Stars")).toBeNull();
-    expect(within(account).queryByText("Sign out")).toBeNull();
-    expect(within(account).queryByText("Settings")).toBeNull();
-    expect(within(account).getByText("Account")).toBeTruthy();
+    expect(screen.queryByLabelText("Account @patrick")).toBeNull();
     expect(screen.queryByText("Switch publisher")).toBeNull();
     expect(themeRow).toBeTruthy();
     expect(themeRow?.children).toHaveLength(3);
@@ -427,11 +423,10 @@ describe("Header", () => {
 
     expect(screen.getByRole("button", { name: "Open account menu for @openclaw" })).toBeTruthy();
     const activePublisher = screen.getByLabelText("Current publisher @openclaw");
-    const account = screen.getByLabelText("Account @patrick");
     const publisherActions = screen.getByLabelText("Publisher actions for @openclaw");
     const profile = within(publisherActions).getByText("Profile");
 
-    expect(within(account).getByText("@patrick")).toBeTruthy();
+    expect(screen.queryByLabelText("Account @patrick")).toBeNull();
     expect(screen.getByText("Switch publisher")).toBeTruthy();
     expect(screen.getByLabelText("Switch to @patrick")).toBeTruthy();
     expect(screen.getByText("Create organization")).toBeTruthy();
@@ -460,6 +455,7 @@ describe("Header", () => {
 
     expect(setActivePublisherIdMock).toHaveBeenCalledWith("publishers:patrick");
     expect(screen.getByText("Stars")).toBeTruthy();
+    expect(screen.getByText("Appearance")).toBeTruthy();
     expect(screen.getByText("Sign out")).toBeTruthy();
     expect(screen.getByText("Settings")).toBeTruthy();
   });

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -345,23 +345,28 @@ describe("Header", () => {
     expect(document.querySelector(".theme-mode-toggle")).toBeNull();
     expect(screen.queryByText("Theme")).toBeNull();
 
+    const activePublisher = screen.getByLabelText("Current publisher @patrick");
+    const account = screen.getByLabelText("Account @patrick");
     const themeRow = document.querySelector(".user-dropdown-theme-row");
-    const settings = screen.getByText("Settings");
-    const stars = screen.getByText("Stars");
-    const signOut = screen.getByText("Sign out");
+    const settings = within(activePublisher).getByText("Settings");
+    const stars = within(account).getByText("Stars");
+    const appearance = within(account).getByText("Appearance");
+    const signOut = within(account).getByText("Sign out");
 
+    expect(within(activePublisher).queryByText("Stars")).toBeNull();
+    expect(within(account).queryByText("Settings")).toBeNull();
+    expect(screen.queryByText("Switch publisher")).toBeNull();
     expect(themeRow).toBeTruthy();
     expect(themeRow?.children).toHaveLength(3);
     expect(settings.compareDocumentPosition(stars) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
-    expect(stars.compareDocumentPosition(themeRow!) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+    expect(stars.compareDocumentPosition(appearance) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
     expect(themeRow!.compareDocumentPosition(signOut) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
-    expect(signOut.previousElementSibling?.tagName).toBe("HR");
 
     expect(screen.getByLabelText("System theme").getAttribute("aria-current")).toBe("true");
     expect(screen.getByLabelText("System theme").getAttribute("data-status")).toBe("active");
@@ -396,16 +401,24 @@ describe("Header", () => {
     render(<Header />);
 
     expect(screen.getByRole("button", { name: "Open account menu for @openclaw" })).toBeTruthy();
-    expect(screen.getByText("@patrick")).toBeTruthy();
+    const activePublisher = screen.getByLabelText("Current publisher @openclaw");
+    const account = screen.getByLabelText("Account @patrick");
+    const profile = within(activePublisher).getByText("Profile");
+
+    expect(within(account).getByText("@patrick")).toBeTruthy();
+    expect(screen.getByText("Switch publisher")).toBeTruthy();
+    expect(screen.getByLabelText("Switch to @patrick")).toBeTruthy();
     expect(screen.getByText("Personal")).toBeTruthy();
     expect(screen.queryByText("Personal · owner")).toBeNull();
-    expect(screen.getAllByText("@openclaw").length).toBeGreaterThan(1);
-    expect(screen.getByText("Org · admin")).toBeTruthy();
-    expect(screen.getByLabelText("Actions for @openclaw")).toBeTruthy();
-    expect(screen.getByText("Profile").closest("a")?.getAttribute("href")).toBe("/user/openclaw");
+    expect(within(activePublisher).getByText("@openclaw")).toBeTruthy();
+    expect(within(activePublisher).getByText("Org · admin")).toBeTruthy();
+    expect(screen.getByLabelText("Publisher actions for @openclaw")).toBeTruthy();
+    expect(profile.closest("a")?.getAttribute("href")).toBe("/user/openclaw");
+    expect(profile.closest("a")?.querySelector(".lucide-building-2")).toBeTruthy();
     expect(screen.queryByText("Signed in as @patrick")).toBeNull();
+    expect(screen.queryByText(/For @openclaw/)).toBeNull();
 
-    fireEvent.click(screen.getByText("@patrick"));
+    fireEvent.click(screen.getByLabelText("Switch to @patrick"));
 
     expect(setActivePublisherIdMock).toHaveBeenCalledWith("publishers:patrick");
     expect(screen.getByText("Stars")).toBeTruthy();

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -363,6 +363,7 @@ describe("Header", () => {
     const profile = within(publisherActions).getByText("Profile");
     const settings = within(publisherActions).getByText("Settings");
     const stars = within(publisherActions).getByText("Stars");
+    const createOrganization = screen.getByText("Create organization");
     const appearance = screen.getByText("Appearance");
     const signOut = screen.getByText("Sign out");
 
@@ -380,6 +381,13 @@ describe("Header", () => {
     expect(stars.compareDocumentPosition(settings) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
+    expect(
+      activePublisher.compareDocumentPosition(createOrganization) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(
+      createOrganization.compareDocumentPosition(dashboard) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(settings.compareDocumentPosition(appearance) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
@@ -427,7 +435,8 @@ describe("Header", () => {
     expect(screen.queryByLabelText("Account @patrick")).toBeNull();
     expect(screen.queryByText("Personal · owner")).toBeNull();
     expect(within(activePublisher).getByText("OpenClaw")).toBeTruthy();
-    expect(within(activePublisher).getByText("Organization")).toBeTruthy();
+    expect(within(activePublisher).getByText("@openclaw")).toBeTruthy();
+    expect(within(activePublisher).queryByText("Organization")).toBeNull();
     expect(screen.queryByText("Org · Admin")).toBeNull();
     expect(screen.queryByText("Managing as")).toBeNull();
     expect(screen.getByLabelText("Publisher actions for @openclaw")).toBeTruthy();
@@ -439,10 +448,14 @@ describe("Header", () => {
 
     fireEvent.click(activePublisher);
 
-    expect(screen.getByLabelText("Selected publisher @openclaw")).toBeTruthy();
-    expect(screen.getByLabelText("Switch to @patrick")).toBeTruthy();
+    const selectedPublisher = screen.getByLabelText("Selected publisher @openclaw");
+    const personalPublisherOption = screen.getByLabelText("Switch to @patrick");
+    expect(within(selectedPublisher).getByText("OpenClaw")).toBeTruthy();
+    expect(within(selectedPublisher).getByText("@openclaw")).toBeTruthy();
+    expect(within(personalPublisherOption).getByText("Patrick")).toBeTruthy();
+    expect(within(personalPublisherOption).getByText("@patrick")).toBeTruthy();
     expect(screen.getByText("Create organization")).toBeTruthy();
-    expect(screen.getByText("Personal")).toBeTruthy();
+    expect(screen.queryByText("Personal")).toBeNull();
     expect(document.querySelector('[data-slot="dropdown-menu-sub-content"]')).toBeNull();
 
     fireEvent.click(screen.getByText("Create organization"));

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -327,7 +327,7 @@ describe("Header", () => {
     expect(screen.queryByText("About")).toBeNull();
   });
 
-  it("separates the publisher switcher from personal account controls", () => {
+  it("separates active publisher actions from personal account controls", () => {
     authStatusMock.mockReturnValue({
       isAuthenticated: true,
       isLoading: false,
@@ -345,26 +345,20 @@ describe("Header", () => {
     expect(document.querySelector(".theme-mode-toggle")).toBeNull();
     expect(screen.queryByText("Theme")).toBeNull();
 
-    expect(screen.getByRole("button", { name: "Open publisher switcher for @patrick" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Open account menu for @patrick" })).toBeTruthy();
-
     const activePublisher = screen.getByLabelText("Current publisher @patrick");
     const account = screen.getByLabelText("Account @patrick");
-    const appActions = screen.getByLabelText("App actions");
     const themeRow = document.querySelector(".user-dropdown-theme-row");
-    const managePublisher = within(activePublisher).getByText("Manage publisher…");
-    const stars = within(appActions).getByText("Stars");
-    const appearance = within(appActions).getByText("Appearance");
-    const signOut = screen.getByText("Sign out");
+    const settings = within(activePublisher).getByText("Settings");
+    const stars = within(account).getByText("Stars");
+    const appearance = within(account).getByText("Appearance");
+    const signOut = within(account).getByText("Sign out");
 
     expect(within(activePublisher).queryByText("Stars")).toBeNull();
-    expect(within(activePublisher).queryByText("Appearance")).toBeNull();
-    expect(within(account).queryByText("Stars")).toBeNull();
-    expect(within(account).queryByText("Manage publisher…")).toBeNull();
+    expect(within(account).queryByText("Settings")).toBeNull();
     expect(screen.queryByText("Switch publisher")).toBeNull();
     expect(themeRow).toBeTruthy();
     expect(themeRow?.children).toHaveLength(3);
-    expect(managePublisher.compareDocumentPosition(stars) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+    expect(settings.compareDocumentPosition(stars) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
     expect(stars.compareDocumentPosition(appearance) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
@@ -383,7 +377,7 @@ describe("Header", () => {
     expect(setModeMock).toHaveBeenCalledWith("dark");
   });
 
-  it("renders a compact publisher switcher separate from the account menu", () => {
+  it("renders a global publisher switcher in the account menu", () => {
     authStatusMock.mockReturnValue({
       isAuthenticated: true,
       isLoading: false,
@@ -406,24 +400,21 @@ describe("Header", () => {
 
     render(<Header />);
 
-    expect(screen.getByRole("button", { name: "Open publisher switcher for @openclaw" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Open account menu for @patrick" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Open account menu for @openclaw" })).toBeTruthy();
     const activePublisher = screen.getByLabelText("Current publisher @openclaw");
     const account = screen.getByLabelText("Account @patrick");
-    const managePublisher = within(activePublisher).getByText("Manage publisher…");
+    const profile = within(activePublisher).getByText("Profile");
 
     expect(within(account).getByText("@patrick")).toBeTruthy();
-    expect(within(account).getByText("Account settings")).toBeTruthy();
-    expect(within(account).queryByText("Switch publisher")).toBeNull();
     expect(screen.getByText("Switch publisher")).toBeTruthy();
     expect(screen.getByLabelText("Switch to @patrick")).toBeTruthy();
-    expect(screen.getByText("Personal publisher")).toBeTruthy();
+    expect(screen.getByText("Personal")).toBeTruthy();
     expect(screen.queryByText("Personal · owner")).toBeNull();
     expect(within(activePublisher).getByText("@openclaw")).toBeTruthy();
-    expect(within(activePublisher).getByText("Organization · Admin")).toBeTruthy();
-    expect(managePublisher.closest("a")?.getAttribute("href")).toBe("/settings");
-    expect(screen.queryByText("Profile")).toBeNull();
-    expect(screen.queryByText("Dashboard")).toBeNull();
+    expect(within(activePublisher).getByText("Org · admin")).toBeTruthy();
+    expect(screen.getByLabelText("Publisher actions for @openclaw")).toBeTruthy();
+    expect(profile.closest("a")?.getAttribute("href")).toBe("/user/openclaw");
+    expect(profile.closest("a")?.querySelector(".lucide-building-2")).toBeTruthy();
     expect(screen.queryByText("Signed in as @patrick")).toBeNull();
     expect(screen.queryByText(/For @openclaw/)).toBeNull();
 
@@ -431,7 +422,7 @@ describe("Header", () => {
 
     expect(setActivePublisherIdMock).toHaveBeenCalledWith("publishers:patrick");
     expect(screen.getByText("Stars")).toBeTruthy();
-    expect(screen.getByText("Account settings")).toBeTruthy();
+    expect(screen.getByText("Settings")).toBeTruthy();
   });
 
   it("renders the GitHub sign-in button with desktop and compact labels", () => {
@@ -681,7 +672,8 @@ describe("Header", () => {
     ).toBeTruthy();
   });
 
-  it("links publisher management and account actions from separate menus", () => {
+  it("links profile and starred skills from the signed-in avatar menu", () => {
+    profileHandleMock.mockReturnValue("patrick-profile");
     authStatusMock.mockReturnValue({
       isAuthenticated: true,
       isLoading: false,
@@ -696,17 +688,15 @@ describe("Header", () => {
 
     render(<Header />);
 
-    expect(screen.getByText("Manage publisher…").closest("a")?.getAttribute("href")).toBe(
-      "/settings",
+    const profile = screen.getByText("Profile");
+    const dashboard = screen.getAllByText("Dashboard").at(-1)!;
+
+    expect(profile.closest("a")?.getAttribute("href")).toBe("/user/patrick-profile");
+    expect(profile.compareDocumentPosition(dashboard) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
     );
     expect(screen.getByText("Stars").closest("a")?.getAttribute("href")).toBe("/stars");
-
-    fireEvent.click(screen.getByText("Account settings"));
-
-    expect(setActivePublisherIdMock).toHaveBeenCalledWith("publishers:patrick");
-    expect(navigateMock).toHaveBeenCalledWith({
-      to: "/settings",
-      search: { view: "profile" },
-    });
+    expect(screen.getAllByText("Dashboard").length).toBeGreaterThan(0);
+    expect(screen.getByText("Settings")).toBeTruthy();
   });
 });

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -192,6 +192,27 @@ vi.mock("../components/ui/dropdown-menu", () => ({
   DropdownMenuContent: ({ children, className }: { children: ReactNode; className?: string }) => (
     <div className={className}>{children}</div>
   ),
+  DropdownMenuSub: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuSubContent: ({
+    children,
+    className,
+  }: {
+    children: ReactNode;
+    className?: string;
+  }) => <div className={className}>{children}</div>,
+  DropdownMenuSubTrigger: ({
+    children,
+    className,
+    ...props
+  }: {
+    children: ReactNode;
+    className?: string;
+    "aria-label"?: string;
+  }) => (
+    <div aria-label={props["aria-label"]} className={className}>
+      {children}
+    </div>
+  ),
   DropdownMenuItem: ({
     children,
     className,
@@ -347,14 +368,17 @@ describe("Header", () => {
 
     const activePublisher = screen.getByLabelText("Current publisher @patrick");
     const account = screen.getByLabelText("Account @patrick");
+    const publisherActions = screen.getByLabelText("Publisher actions for @patrick");
     const themeRow = document.querySelector(".user-dropdown-theme-row");
-    const settings = within(activePublisher).getByText("Settings");
-    const stars = within(account).getByText("Stars");
-    const appearance = within(account).getByText("Appearance");
-    const signOut = within(account).getByText("Sign out");
+    const settings = within(publisherActions).getByText("Settings");
+    const stars = screen.getByText("Stars");
+    const appearance = screen.getByText("Appearance");
+    const signOut = screen.getByText("Sign out");
 
     expect(within(activePublisher).queryByText("Stars")).toBeNull();
+    expect(within(account).queryByText("Stars")).toBeNull();
     expect(within(account).queryByText("Settings")).toBeNull();
+    expect(within(account).getByText("Account")).toBeTruthy();
     expect(screen.queryByText("Switch publisher")).toBeNull();
     expect(themeRow).toBeTruthy();
     expect(themeRow?.children).toHaveLength(3);
@@ -403,7 +427,8 @@ describe("Header", () => {
     expect(screen.getByRole("button", { name: "Open account menu for @openclaw" })).toBeTruthy();
     const activePublisher = screen.getByLabelText("Current publisher @openclaw");
     const account = screen.getByLabelText("Account @patrick");
-    const profile = within(activePublisher).getByText("Profile");
+    const publisherActions = screen.getByLabelText("Publisher actions for @openclaw");
+    const profile = within(publisherActions).getByText("Profile");
 
     expect(within(account).getByText("@patrick")).toBeTruthy();
     expect(screen.getByText("Switch publisher")).toBeTruthy();
@@ -411,10 +436,11 @@ describe("Header", () => {
     expect(screen.getByText("Personal")).toBeTruthy();
     expect(screen.queryByText("Personal · owner")).toBeNull();
     expect(within(activePublisher).getByText("@openclaw")).toBeTruthy();
-    expect(within(activePublisher).getByText("Org · admin")).toBeTruthy();
+    expect(within(activePublisher).getByText("Org · Admin")).toBeTruthy();
     expect(screen.getByLabelText("Publisher actions for @openclaw")).toBeTruthy();
     expect(profile.closest("a")?.getAttribute("href")).toBe("/user/openclaw");
     expect(profile.closest("a")?.querySelector(".lucide-building-2")).toBeTruthy();
+    expect(screen.getByLabelText("Selected publisher @openclaw")).toBeTruthy();
     expect(screen.queryByText("Signed in as @patrick")).toBeNull();
     expect(screen.queryByText(/For @openclaw/)).toBeNull();
 

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -397,7 +397,7 @@ describe("Header", () => {
     expect(screen.getByText("Personal · owner")).toBeTruthy();
     expect(screen.getAllByText("@openclaw").length).toBeGreaterThan(1);
     expect(screen.getByText("Org · admin")).toBeTruthy();
-    expect(screen.getByText("Signed in as @patrick")).toBeTruthy();
+    expect(screen.queryByText("Signed in as @patrick")).toBeNull();
 
     fireEvent.click(screen.getByText("@patrick"));
 

--- a/src/__tests__/plugins-publish-route.test.tsx
+++ b/src/__tests__/plugins-publish-route.test.tsx
@@ -34,6 +34,7 @@ const fetchMock = vi.fn();
 const useAuthStatusMock = vi.fn();
 const useQueryMock = vi.fn();
 const useSearchMock = vi.fn();
+const useActivePublisherMock = vi.fn();
 const originalFetch = globalThis.fetch;
 
 vi.mock("convex/react", () => ({
@@ -47,7 +48,61 @@ vi.mock("../lib/useAuthStatus", () => ({
   useAuthStatus: () => useAuthStatusMock(),
 }));
 
+vi.mock("../lib/activePublisher", () => ({
+  useActivePublisher: () => useActivePublisherMock(),
+}));
+
 import { PublishPluginRoute, Route } from "../routes/plugins/publish";
+
+const vintageAyuMembership = {
+  publisher: {
+    _id: "publishers:vintageayu",
+    handle: "vintageayu",
+    displayName: "VintageAyu",
+    kind: "user",
+    image: "/clawd-logo.png",
+  },
+  role: "owner",
+} as const;
+
+const openClawMembership = {
+  publisher: {
+    _id: "publishers:openclaw",
+    handle: "openclaw",
+    displayName: "OpenClaw",
+    kind: "org",
+    image: null,
+  },
+  role: "admin",
+} as const;
+
+type PublisherMembership = typeof vintageAyuMembership | typeof openClawMembership;
+
+function mockActivePublisher({
+  memberships = [vintageAyuMembership],
+  activeOwnerHandle = memberships[0]?.publisher.handle ?? null,
+}: {
+  memberships?: PublisherMembership[];
+  activeOwnerHandle?: string | null;
+} = {}) {
+  const activePublisher =
+    memberships.find((membership) => membership.publisher.handle === activeOwnerHandle) ??
+    memberships[0] ??
+    null;
+  useActivePublisherMock.mockReturnValue({
+    activePublisher,
+    activePublisherId: activePublisher?.publisher._id ?? null,
+    activeOwnerHandle: activePublisher?.publisher.handle ?? null,
+    canManageActivePublisher: true,
+    canPublishAsActivePublisher: true,
+    canViewActivePublisherScope: true,
+    hasMultiplePublishers: memberships.length > 1,
+    isLoading: false,
+    memberships,
+    personalPublisher: memberships.find((entry) => entry.publisher.kind === "user") ?? null,
+    setActivePublisherId: vi.fn(),
+  });
+}
 
 function renderPublishRoute() {
   render(createElement(PublishPluginRoute as never));
@@ -103,6 +158,7 @@ describe("plugins publish route", () => {
     useAuthStatusMock.mockReset();
     useQueryMock.mockReset();
     useSearchMock.mockReset();
+    useActivePublisherMock.mockReset();
     toastErrorMock.mockReset();
 
     useSearchMock.mockReturnValue({
@@ -118,23 +174,11 @@ describe("plugins publish route", () => {
       isLoading: false,
       me: { _id: "users:1" },
     });
-    useQueryMock.mockImplementation((fn: unknown, args: unknown) => {
+    useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
       if (args === "skip") return undefined;
-      const name = fn ? getFunctionName(fn as Parameters<typeof getFunctionName>[0]) : "";
-      if (name !== "publishers:listMine") return null;
-      return [
-        {
-          publisher: {
-            _id: "publishers:vintageayu",
-            handle: "vintageayu",
-            displayName: "VintageAyu",
-            kind: "user",
-            image: "/clawd-logo.png",
-          },
-          role: "owner",
-        },
-      ];
+      return null;
     });
+    mockActivePublisher();
     generateUploadUrl.mockResolvedValue("https://upload.local");
     publishRelease.mockResolvedValue({ ok: true, packageId: "pkg:1", releaseId: "rel:1" });
     fetchMock.mockImplementation(async (_url: string, init?: RequestInit) => ({
@@ -197,7 +241,9 @@ describe("plugins publish route", () => {
     expect(screen.getByPlaceholderText("Display name").getAttribute("disabled")).not.toBeNull();
     expect(screen.getByPlaceholderText("Version").getAttribute("disabled")).not.toBeNull();
     expect(screen.queryByPlaceholderText("Describe what changed in this release...")).toBeNull();
-    expect(screen.getByLabelText("Owner").textContent).toContain("@vintageayu · VintageAyu");
+    expect(screen.getByRole("group", { name: "Publishing as" }).textContent).toContain(
+      "@vintageayu · VintageAyu",
+    );
     expect(document.querySelector('img[src="/clawd-logo.png"]')).toBeTruthy();
     expect(
       screen.getByRole("button", { name: "Publish plugin" }).getAttribute("disabled"),
@@ -603,6 +649,63 @@ describe("plugins publish route", () => {
       screen.getByRole("button", { name: "Publish plugin" }).getAttribute("disabled"),
     ).not.toBeNull();
     expect(publishRelease).not.toHaveBeenCalled();
+  });
+
+  it("publishes scoped plugin packages under the active org publisher", async () => {
+    mockActivePublisher({
+      memberships: [vintageAyuMembership, openClawMembership],
+      activeOwnerHandle: "openclaw",
+    });
+    renderPublishRoute();
+
+    const packageJson = withRelativePath(
+      new File(
+        [
+          makeCodePluginPackageJson({
+            name: "@openclaw/dronzer",
+            displayName: "Dronzer Controller",
+            version: "1.0.0",
+            repository: "https://github.com/openclaw/dronzer.git",
+          }),
+        ],
+        "package.json",
+        { type: "application/json" },
+      ),
+      "dronzer/package.json",
+    );
+    const manifest = withRelativePath(
+      new File(['{"id":"dronzer"}'], "openclaw.plugin.json", { type: "application/json" }),
+      "dronzer/openclaw.plugin.json",
+    );
+    const dist = withRelativePath(
+      new File(["export const demo = true;\n"], "index.js", { type: "text/javascript" }),
+      "dronzer/dist/index.js",
+    );
+
+    fireEvent.change(getFileInput(), { target: { files: [packageJson, manifest, dist] } });
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("@openclaw/dronzer")).toBeTruthy();
+      expect(screen.getByRole("group", { name: "Publishing as" }).textContent).toContain(
+        "@openclaw · OpenClaw",
+      );
+    });
+    expect(screen.queryByText(/Package scope "@openclaw" must match selected owner/i)).toBeNull();
+
+    fireEvent.change(screen.getByPlaceholderText("Full commit SHA"), {
+      target: { value: "abc123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Publish plugin" }));
+
+    await waitFor(() => {
+      expect(publishRelease).toHaveBeenCalledTimes(1);
+    });
+    expect(publishRelease).toHaveBeenCalledWith({
+      payload: expect.objectContaining({
+        name: "@openclaw/dronzer",
+        ownerHandle: "openclaw",
+      }),
+    });
   });
 
   it("does not mark the upload summary ready while validation errors are present", async () => {

--- a/src/__tests__/plugins-publish-route.test.tsx
+++ b/src/__tests__/plugins-publish-route.test.tsx
@@ -109,7 +109,7 @@ function mockActivePublisher({
 }
 
 function renderPublishRoute() {
-  render(createElement(PublishPluginRoute as never));
+  return render(createElement(PublishPluginRoute as never));
 }
 
 function withRelativePath(file: File, path: string) {
@@ -279,7 +279,7 @@ describe("plugins publish route", () => {
     expect(setActivePublisherId).toHaveBeenCalledWith("publishers:openclaw");
   });
 
-  it("replaces a stale ownerHandle in the new plugin publish URL", async () => {
+  it("preserves an explicit ownerHandle in the new plugin publish URL", async () => {
     useSearchMock.mockReturnValue({
       ownerHandle: "vintageayu",
       name: undefined,
@@ -295,20 +295,38 @@ describe("plugins publish route", () => {
 
     renderPublishRoute();
 
-    await waitFor(() => {
-      expect(navigateMock).toHaveBeenCalledWith({
-        to: "/plugins/publish",
-        search: {
-          ownerHandle: "openclaw",
-          name: undefined,
-          displayName: undefined,
-          family: undefined,
-          nextVersion: undefined,
-          sourceRepo: undefined,
-        },
-        replace: true,
-      });
+    await screen.findByText(/VintageAyu/);
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves an explicit ownerHandle change while the plugin route stays mounted", async () => {
+    let search = {
+      ownerHandle: "vintageayu",
+      name: undefined,
+      displayName: undefined,
+      family: undefined,
+      nextVersion: undefined,
+      sourceRepo: undefined,
+    };
+    useSearchMock.mockImplementation(() => search);
+    mockActivePublisher({
+      memberships: [vintageAyuMembership, openClawMembership],
+      activeOwnerHandle: "vintageayu",
     });
+
+    const { rerender } = renderPublishRoute();
+    await screen.findByText(/VintageAyu/);
+    navigateMock.mockClear();
+
+    search = { ...search, ownerHandle: "openclaw" };
+    rerender(createElement(PublishPluginRoute as never));
+
+    await waitFor(() => {
+      expect(screen.getByRole("group", { name: "Publishing as" }).textContent).toContain(
+        "OpenClaw / @openclaw",
+      );
+    });
+    expect(navigateMock).not.toHaveBeenCalled();
   });
 
   it("opens only the directory picker when clicking Choose folder", () => {

--- a/src/__tests__/plugins-publish-route.test.tsx
+++ b/src/__tests__/plugins-publish-route.test.tsx
@@ -15,6 +15,7 @@ vi.mock("@tanstack/react-router", () => ({
     __config: config,
     __path: path,
   }),
+  useNavigate: () => navigateMock,
   useSearch: () => useSearchMock(),
 }));
 
@@ -35,6 +36,7 @@ const useAuthStatusMock = vi.fn();
 const useQueryMock = vi.fn();
 const useSearchMock = vi.fn();
 const useActivePublisherMock = vi.fn();
+const navigateMock = vi.fn();
 const originalFetch = globalThis.fetch;
 
 vi.mock("convex/react", () => ({
@@ -81,9 +83,11 @@ type PublisherMembership = typeof vintageAyuMembership | typeof openClawMembersh
 function mockActivePublisher({
   memberships = [vintageAyuMembership],
   activeOwnerHandle = memberships[0]?.publisher.handle ?? null,
+  setActivePublisherId = vi.fn(),
 }: {
   memberships?: PublisherMembership[];
   activeOwnerHandle?: string | null;
+  setActivePublisherId?: ReturnType<typeof vi.fn>;
 } = {}) {
   const activePublisher =
     memberships.find((membership) => membership.publisher.handle === activeOwnerHandle) ??
@@ -100,7 +104,7 @@ function mockActivePublisher({
     isLoading: false,
     memberships,
     personalPublisher: memberships.find((entry) => entry.publisher.kind === "user") ?? null,
-    setActivePublisherId: vi.fn(),
+    setActivePublisherId,
   });
 }
 
@@ -159,6 +163,7 @@ describe("plugins publish route", () => {
     useQueryMock.mockReset();
     useSearchMock.mockReset();
     useActivePublisherMock.mockReset();
+    navigateMock.mockReset();
     toastErrorMock.mockReset();
 
     useSearchMock.mockReturnValue({
@@ -236,18 +241,74 @@ describe("plugins publish route", () => {
   it("keeps metadata inputs locked until plugin code is uploaded", () => {
     renderPublishRoute();
 
+    const publishingAs = screen.getByRole("group", { name: "Publishing as" });
+    const uploadPrompt = screen.getByText("Upload plugin code first");
+
+    expect(publishingAs.parentElement?.contains(uploadPrompt)).toBe(true);
+    expect(
+      publishingAs.compareDocumentPosition(uploadPrompt) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
     expect(screen.getByText(/Upload plugin code first/i)).toBeTruthy();
     expect(screen.getByPlaceholderText("Plugin name").getAttribute("disabled")).not.toBeNull();
     expect(screen.getByPlaceholderText("Display name").getAttribute("disabled")).not.toBeNull();
     expect(screen.getByPlaceholderText("Version").getAttribute("disabled")).not.toBeNull();
     expect(screen.queryByPlaceholderText("Describe what changed in this release...")).toBeNull();
     expect(screen.getByRole("group", { name: "Publishing as" }).textContent).toContain(
-      "@vintageayu · VintageAyu",
+      "VintageAyu / @vintageayu",
     );
     expect(document.querySelector('img[src="/clawd-logo.png"]')).toBeTruthy();
     expect(
       screen.getByRole("button", { name: "Publish plugin" }).getAttribute("disabled"),
     ).not.toBeNull();
+  });
+
+  it("switches publisher from the plugin upload card", async () => {
+    const setActivePublisherId = vi.fn();
+    mockActivePublisher({
+      memberships: [vintageAyuMembership, openClawMembership],
+      setActivePublisherId,
+    });
+
+    renderPublishRoute();
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Switch publisher" }), {
+      button: 0,
+    });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Switch to @openclaw" }));
+
+    expect(setActivePublisherId).toHaveBeenCalledWith("publishers:openclaw");
+  });
+
+  it("replaces a stale ownerHandle in the new plugin publish URL", async () => {
+    useSearchMock.mockReturnValue({
+      ownerHandle: "vintageayu",
+      name: undefined,
+      displayName: undefined,
+      family: undefined,
+      nextVersion: undefined,
+      sourceRepo: undefined,
+    });
+    mockActivePublisher({
+      memberships: [vintageAyuMembership, openClawMembership],
+      activeOwnerHandle: "openclaw",
+    });
+
+    renderPublishRoute();
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith({
+        to: "/plugins/publish",
+        search: {
+          ownerHandle: "openclaw",
+          name: undefined,
+          displayName: undefined,
+          family: undefined,
+          nextVersion: undefined,
+          sourceRepo: undefined,
+        },
+        replace: true,
+      });
+    });
   });
 
   it("opens only the directory picker when clicking Choose folder", () => {
@@ -687,7 +748,7 @@ describe("plugins publish route", () => {
     await waitFor(() => {
       expect(screen.getByDisplayValue("@openclaw/dronzer")).toBeTruthy();
       expect(screen.getByRole("group", { name: "Publishing as" }).textContent).toContain(
-        "@openclaw · OpenClaw",
+        "OpenClaw / @openclaw",
       );
     });
     expect(screen.queryByText(/Package scope "@openclaw" must match selected owner/i)).toBeNull();

--- a/src/__tests__/skills-publish-route.test.tsx
+++ b/src/__tests__/skills-publish-route.test.tsx
@@ -23,6 +23,7 @@ const generateChangelogPreview = vi.fn();
 const fetchMock = vi.fn();
 const useQueryMock = vi.fn();
 const useAuthStatusMock = vi.fn();
+const useActivePublisherMock = vi.fn();
 // Allows individual test cases to drive the value `useSearch` returns.
 // The `updateSlug` search param triggers the form's "update existing"
 // branch and is required by the F1 regression cases below.
@@ -52,6 +53,76 @@ vi.mock("../lib/useAuthStatus", () => ({
   useAuthStatus: () => useAuthStatusMock(),
 }));
 
+vi.mock("../lib/activePublisher", () => ({
+  useActivePublisher: () => useActivePublisherMock(),
+}));
+
+const personalMembership = {
+  publisher: {
+    _id: "publishers:local",
+    handle: "local",
+    displayName: "Local",
+    kind: "user",
+    image: null,
+  },
+  role: "owner",
+} as const;
+
+const orgMembership = {
+  publisher: {
+    _id: "publishers:clawkit",
+    handle: "clawkit",
+    displayName: "ClawKit",
+    kind: "org",
+    image: "https://example.com/clawkit.png",
+  },
+  role: "admin",
+} as const;
+
+const aliceMembership = {
+  publisher: {
+    _id: "publishers:alice",
+    handle: "alice",
+    displayName: "Alice",
+    kind: "user",
+    image: null,
+  },
+  role: "owner",
+} as const;
+
+type TestPublisherMembership = {
+  publisher: {
+    _id: string;
+    handle: string;
+    displayName: string;
+    kind: "user" | "org";
+    image: string | null;
+  };
+  role: "owner" | "admin" | "publisher";
+};
+
+function mockActivePublisher(
+  overrides: Partial<{
+    activeOwnerHandle: string | null;
+    memberships: TestPublisherMembership[];
+  }> = {},
+) {
+  const memberships = overrides.memberships ?? [personalMembership];
+  useActivePublisherMock.mockReturnValue({
+    activePublisher: memberships[0] ?? null,
+    activePublisherId: memberships[0]?.publisher._id ?? null,
+    activeOwnerHandle: overrides.activeOwnerHandle ?? memberships[0]?.publisher.handle ?? null,
+    canManageActivePublisher: true,
+    canPublishAsActivePublisher: true,
+    canViewActivePublisherScope: true,
+    hasMultiplePublishers: memberships.length > 1,
+    isLoading: false,
+    memberships,
+    personalPublisher: memberships.find((entry) => entry.publisher.kind === "user") ?? null,
+    setActivePublisherId: vi.fn(),
+  });
+}
+
 describe("Upload route", () => {
   beforeEach(() => {
     generateUploadUrl.mockReset();
@@ -63,27 +134,14 @@ describe("Upload route", () => {
     useSearchMock.mockReset();
     useSearchMock.mockReturnValue({ updateSlug: undefined, ownerHandle: undefined });
     useActionCallCount = 0;
+    mockActivePublisher();
     useAuthStatusMock.mockReturnValue({
       isAuthenticated: true,
       isLoading: false,
       me: { _id: "users:1" },
     });
-    useQueryMock.mockImplementation((fn: unknown, args: unknown) => {
+    useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
       if (args === "skip") return undefined;
-      const name = fn ? getFunctionName(fn as Parameters<typeof getFunctionName>[0]) : "";
-      if (name === "publishers:listMine") {
-        return [
-          {
-            publisher: {
-              _id: "publishers:local",
-              handle: "local",
-              displayName: "Local",
-              kind: "user",
-            },
-            role: "owner",
-          },
-        ];
-      }
       return null;
     });
     fetchMock.mockResolvedValue({
@@ -571,22 +629,8 @@ describe("Upload route", () => {
   });
 
   it("blocks publish in preflight when slug availability reports a collision", async () => {
-    useQueryMock.mockImplementation((fn: unknown, args: unknown) => {
+    useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
       if (args === "skip") return undefined;
-      const name = fn ? getFunctionName(fn as Parameters<typeof getFunctionName>[0]) : "";
-      if (name === "publishers:listMine") {
-        return [
-          {
-            publisher: {
-              _id: "publishers:local",
-              handle: "local",
-              displayName: "Local",
-              kind: "user",
-            },
-            role: "owner",
-          },
-        ];
-      }
       if (
         args &&
         typeof args === "object" &&
@@ -635,8 +679,12 @@ describe("Upload route", () => {
     ).not.toBeNull();
   });
 
-  it("uses the ownerHandle search param for the owner selector and slug availability", async () => {
+  it("uses the ownerHandle search param as a local publishing override", async () => {
     useSearchMock.mockReturnValue({ updateSlug: undefined, ownerHandle: "clawkit" });
+    mockActivePublisher({
+      activeOwnerHandle: "local",
+      memberships: [personalMembership, orgMembership],
+    });
     useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
       if (args === "skip") return undefined;
       if (
@@ -652,18 +700,7 @@ describe("Upload route", () => {
           url: null,
         };
       }
-      return [
-        {
-          publisher: {
-            _id: "publishers:clawkit",
-            handle: "clawkit",
-            displayName: "ClawKit",
-            kind: "org",
-            image: "https://example.com/clawkit.png",
-          },
-          role: "admin",
-        },
-      ];
+      return null;
     });
 
     render(<Upload />);
@@ -671,7 +708,9 @@ describe("Upload route", () => {
       target: { value: "org-skill" },
     });
 
-    expect(screen.getByLabelText("Owner").textContent).toContain("@clawkit · ClawKit · admin");
+    expect(screen.getByRole("group", { name: "Publishing as" }).textContent).toContain(
+      "@clawkit · ClawKit · admin",
+    );
     expect(document.querySelector('img[src="https://example.com/clawkit.png"]')).toBeTruthy();
     expect(screen.queryByText("Available")).toBeNull();
     expect(await screen.findByLabelText("Slug available")).toBeTruthy();
@@ -728,21 +767,23 @@ describe("Upload route", () => {
   });
 
   it("reconciles the selected owner when publisher memberships change", async () => {
-    let memberships = [
-      {
-        publisher: {
-          _id: "publishers:local",
-          handle: "local",
-          displayName: "Local Owner",
-          kind: "user",
-        },
-        role: "owner",
-      },
-    ];
+    let memberships: TestPublisherMembership[] = [personalMembership];
+    useActivePublisherMock.mockImplementation(() => ({
+      activePublisher: memberships[0] ?? null,
+      activePublisherId: memberships[0]?.publisher._id ?? null,
+      activeOwnerHandle: null,
+      canManageActivePublisher: true,
+      canPublishAsActivePublisher: true,
+      canViewActivePublisherScope: true,
+      hasMultiplePublishers: memberships.length > 1,
+      isLoading: false,
+      memberships,
+      personalPublisher: memberships.find((entry) => entry.publisher.kind === "user") ?? null,
+      setActivePublisherId: vi.fn(),
+    }));
     useQueryMock.mockImplementation((fn: unknown, args: unknown) => {
       if (args === "skip") return undefined;
       const name = fn ? getFunctionName(fn as Parameters<typeof getFunctionName>[0]) : "";
-      if (name === "publishers:listMine") return memberships;
       if (name === "skills:checkSlugAvailability") {
         return {
           available: true,
@@ -757,7 +798,7 @@ describe("Upload route", () => {
     const { rerender } = render(<Upload />);
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Owner").textContent).toContain("@local");
+      expect(screen.getByRole("group", { name: "Publishing as" }).textContent).toContain("@local");
     });
 
     memberships = [
@@ -767,14 +808,18 @@ describe("Upload route", () => {
           handle: "local-owner",
           displayName: "Local Owner",
           kind: "user",
+          image: null,
         },
         role: "owner",
       },
     ];
+
     rerender(<Upload />);
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Owner").textContent).toContain("@local-owner");
+      expect(screen.getByRole("group", { name: "Publishing as" }).textContent).toContain(
+        "@local-owner",
+      );
     });
 
     fireEvent.change(screen.getByPlaceholderText("skill-name"), {
@@ -786,6 +831,37 @@ describe("Upload route", () => {
         ownerHandle: "local-owner",
       });
     });
+  });
+
+  it("preserves the existing owner on update even when another publisher is active", async () => {
+    useSearchMock.mockReturnValue({ updateSlug: "owned-skill", ownerHandle: undefined });
+    mockActivePublisher({
+      activeOwnerHandle: "clawkit",
+      memberships: [personalMembership, orgMembership, aliceMembership],
+    });
+    useQueryMock.mockImplementation((fn: unknown, args: unknown) => {
+      if (args === "skip") return undefined;
+      const name = fn ? getFunctionName(fn as Parameters<typeof getFunctionName>[0]) : "";
+      if (name === "skills:getBySlug") {
+        return {
+          skill: {
+            slug: "owned-skill",
+            displayName: "Owned Skill",
+            icon: null,
+          },
+          latestVersion: { version: "1.0.0" },
+          owner: { handle: "alice", displayName: "Alice" },
+        };
+      }
+      return null;
+    });
+
+    render(<Upload />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Owner").textContent).toContain("@alice · Alice · owner");
+    });
+    expect(screen.getByLabelText("Owner").textContent).not.toContain("@clawkit");
   });
 
   it("renders the icon picker and forwards the selected lucide icon to publishVersion", async () => {
@@ -898,6 +974,10 @@ describe("Upload route", () => {
     // Simulate a `New Version` flow: `?updateSlug=with-icon` is in the URL
     // and the existing skill row carries `icon: \"lucide:Plug\"`.
     useSearchMock.mockReturnValue({ updateSlug: "with-icon" });
+    mockActivePublisher({
+      activeOwnerHandle: "local",
+      memberships: [personalMembership, aliceMembership],
+    });
     useQueryMock.mockImplementation((fn: unknown, args: unknown) => {
       if (args === "skip") return undefined;
       // The convex `anyApi` proxy returns a fresh proxy on every property
@@ -979,6 +1059,10 @@ describe("Upload route", () => {
     // to \"No icon\", and pre-population leaves `iconName === null` without
     // any user interaction.
     useSearchMock.mockReturnValue({ updateSlug: "stale-icon" });
+    mockActivePublisher({
+      activeOwnerHandle: "local",
+      memberships: [personalMembership, aliceMembership],
+    });
     useQueryMock.mockImplementation((fn: unknown, args: unknown) => {
       if (args === "skip") return undefined;
       const name = fn ? getFunctionName(fn as Parameters<typeof getFunctionName>[0]) : "";

--- a/src/__tests__/skills-publish-route.test.tsx
+++ b/src/__tests__/skills-publish-route.test.tsx
@@ -105,6 +105,7 @@ function mockActivePublisher(
   overrides: Partial<{
     activeOwnerHandle: string | null;
     memberships: TestPublisherMembership[];
+    setActivePublisherId: ReturnType<typeof vi.fn>;
   }> = {},
 ) {
   const memberships = overrides.memberships ?? [personalMembership];
@@ -122,7 +123,7 @@ function mockActivePublisher(
     isLoading: false,
     memberships,
     personalPublisher: memberships.find((entry) => entry.publisher.kind === "user") ?? null,
-    setActivePublisherId: vi.fn(),
+    setActivePublisherId: overrides.setActivePublisherId ?? vi.fn(),
   });
 }
 
@@ -176,6 +177,24 @@ describe("Upload route", () => {
     expect(
       publishingAs.compareDocumentPosition(uploadPrompt) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).not.toBe(0);
+    expect(screen.queryByRole("button", { name: "Change publisher" })).toBeNull();
+  });
+
+  it("changes the active publisher from the upload card", async () => {
+    const setActivePublisherId = vi.fn();
+    mockActivePublisher({
+      memberships: [personalMembership, orgMembership],
+      setActivePublisherId,
+    });
+
+    render(<Upload />);
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Change publisher" }), {
+      button: 0,
+    });
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Switch to @clawkit" }));
+
+    expect(setActivePublisherId).toHaveBeenCalledWith("publishers:clawkit");
   });
 
   it("drops invalid legacy category metadata and offers explicit generation on republish", async () => {

--- a/src/__tests__/skills-publish-route.test.tsx
+++ b/src/__tests__/skills-publish-route.test.tsx
@@ -108,10 +108,13 @@ function mockActivePublisher(
   }> = {},
 ) {
   const memberships = overrides.memberships ?? [personalMembership];
+  const activeOwnerHandle = Object.hasOwn(overrides, "activeOwnerHandle")
+    ? (overrides.activeOwnerHandle ?? null)
+    : (memberships[0]?.publisher.handle ?? null);
   useActivePublisherMock.mockReturnValue({
     activePublisher: memberships[0] ?? null,
     activePublisherId: memberships[0]?.publisher._id ?? null,
-    activeOwnerHandle: overrides.activeOwnerHandle ?? memberships[0]?.publisher.handle ?? null,
+    activeOwnerHandle,
     canManageActivePublisher: true,
     canPublishAsActivePublisher: true,
     canViewActivePublisherScope: true,
@@ -683,10 +686,10 @@ describe("Upload route", () => {
     ).not.toBeNull();
   });
 
-  it("uses the ownerHandle search param as a local publishing override", async () => {
+  it("uses the ownerHandle search param when no active publisher is selected", async () => {
     useSearchMock.mockReturnValue({ updateSlug: undefined, ownerHandle: "clawkit" });
     mockActivePublisher({
-      activeOwnerHandle: "local",
+      activeOwnerHandle: null,
       memberships: [personalMembership, orgMembership],
     });
     useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
@@ -721,6 +724,35 @@ describe("Upload route", () => {
     await waitFor(() => {
       expect(useQueryMock).toHaveBeenCalledWith(expect.anything(), {
         slug: "org-skill",
+        ownerHandle: "clawkit",
+      });
+    });
+  });
+
+  it("keeps new publishing synced with the active publisher", async () => {
+    useSearchMock.mockReturnValue({ updateSlug: undefined, ownerHandle: "local" });
+    const memberships = [personalMembership, orgMembership];
+    mockActivePublisher({ activeOwnerHandle: "local", memberships });
+
+    const { rerender } = render(<Upload />);
+
+    expect(screen.getByRole("group", { name: "Publishing as" }).textContent).toContain("@local");
+
+    mockActivePublisher({ activeOwnerHandle: "clawkit", memberships });
+    rerender(<Upload />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("group", { name: "Publishing as" }).textContent).toContain(
+        "@clawkit · ClawKit · admin",
+      );
+    });
+
+    fireEvent.change(screen.getByPlaceholderText("skill-name"), {
+      target: { value: "context-skill" },
+    });
+    await waitFor(() => {
+      expect(useQueryMock).toHaveBeenCalledWith(expect.anything(), {
+        slug: "context-skill",
         ownerHandle: "clawkit",
       });
     });

--- a/src/__tests__/skills-publish-route.test.tsx
+++ b/src/__tests__/skills-publish-route.test.tsx
@@ -166,6 +166,17 @@ describe("Upload route", () => {
     expect(guideLink.getAttribute("target")).toBe("_blank");
   });
 
+  it("shows the publishing context before file selection", () => {
+    render(<Upload />);
+
+    const publishingAs = screen.getByRole("group", { name: "Publishing as" });
+    const uploadPrompt = screen.getByText("Drop a skill folder");
+
+    expect(
+      publishingAs.compareDocumentPosition(uploadPrompt) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
+  });
+
   it("drops invalid legacy category metadata and offers explicit generation on republish", async () => {
     useSearchMock.mockReturnValue({ updateSlug: "uncategorized-skill" });
     useQueryMock.mockImplementation((fn: unknown, args: unknown) => {

--- a/src/__tests__/skills-publish-route.test.tsx
+++ b/src/__tests__/skills-publish-route.test.tsx
@@ -172,6 +172,7 @@ describe("Upload route", () => {
     const publishingAs = screen.getByRole("group", { name: "Publishing as" });
     const uploadPrompt = screen.getByText("Drop a skill folder");
 
+    expect(publishingAs.parentElement?.contains(uploadPrompt)).toBe(true);
     expect(
       publishingAs.compareDocumentPosition(uploadPrompt) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).not.toBe(0);

--- a/src/__tests__/skills-publish-route.test.tsx
+++ b/src/__tests__/skills-publish-route.test.tsx
@@ -199,7 +199,7 @@ describe("Upload route", () => {
     expect(setActivePublisherId).toHaveBeenCalledWith("publishers:clawkit");
   });
 
-  it("replaces a stale ownerHandle in the new publish URL", async () => {
+  it("preserves an explicit ownerHandle in the new publish URL", async () => {
     useSearchMock.mockReturnValue({ updateSlug: undefined, ownerHandle: "local" });
     mockActivePublisher({
       activeOwnerHandle: "clawkit",
@@ -209,12 +209,34 @@ describe("Upload route", () => {
     render(<Upload />);
 
     await waitFor(() => {
-      expect(navigateMock).toHaveBeenCalledWith({
-        to: "/skills/publish",
-        search: { ownerHandle: "clawkit" },
-        replace: true,
-      });
+      expect(screen.getByRole("group", { name: "Publishing as" }).textContent).toContain(
+        "Local / @local",
+      );
     });
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves an explicit ownerHandle change while the publish route stays mounted", async () => {
+    let search = { updateSlug: undefined, ownerHandle: "local" as string | undefined };
+    useSearchMock.mockImplementation(() => search);
+    mockActivePublisher({
+      activeOwnerHandle: "local",
+      memberships: [personalMembership, orgMembership],
+    });
+
+    const { rerender } = render(<Upload />);
+    await screen.findByText(/Local/);
+    navigateMock.mockClear();
+
+    search = { updateSlug: undefined, ownerHandle: "clawkit" };
+    rerender(<Upload />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("group", { name: "Publishing as" }).textContent).toContain(
+        "ClawKit / @clawkit",
+      );
+    });
+    expect(navigateMock).not.toHaveBeenCalled();
   });
 
   it("drops invalid legacy category metadata and offers explicit generation on republish", async () => {
@@ -781,7 +803,7 @@ describe("Upload route", () => {
   });
 
   it("keeps new publishing synced with the active publisher", async () => {
-    useSearchMock.mockReturnValue({ updateSlug: undefined, ownerHandle: "local" });
+    useSearchMock.mockReturnValue({ updateSlug: undefined, ownerHandle: undefined });
     const memberships = [personalMembership, orgMembership];
     mockActivePublisher({ activeOwnerHandle: "local", memberships });
 

--- a/src/__tests__/skills-publish-route.test.tsx
+++ b/src/__tests__/skills-publish-route.test.tsx
@@ -242,6 +242,10 @@ describe("Upload route", () => {
 
   it("sends explicit empty metadata arrays when categories and topics are cleared on republish", async () => {
     useSearchMock.mockReturnValue({ updateSlug: "categorized-skill" });
+    mockActivePublisher({
+      activeOwnerHandle: "local",
+      memberships: [personalMembership, aliceMembership],
+    });
     useQueryMock.mockImplementation((fn: unknown, args: unknown) => {
       if (args === "skip") return undefined;
       const name = fn ? getFunctionName(fn as Parameters<typeof getFunctionName>[0]) : "";

--- a/src/__tests__/skills-publish-route.test.tsx
+++ b/src/__tests__/skills-publish-route.test.tsx
@@ -177,7 +177,7 @@ describe("Upload route", () => {
     expect(
       publishingAs.compareDocumentPosition(uploadPrompt) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).not.toBe(0);
-    expect(screen.queryByRole("button", { name: "Change publisher" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Switch publisher" })).toBeNull();
   });
 
   it("changes the active publisher from the upload card", async () => {
@@ -189,7 +189,7 @@ describe("Upload route", () => {
 
     render(<Upload />);
 
-    fireEvent.pointerDown(screen.getByRole("button", { name: "Change publisher" }), {
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Switch publisher" }), {
       button: 0,
     });
     fireEvent.click(await screen.findByRole("menuitem", { name: "Switch to @clawkit" }));

--- a/src/__tests__/skills-publish-route.test.tsx
+++ b/src/__tests__/skills-publish-route.test.tsx
@@ -9,7 +9,7 @@ import { Upload } from "../routes/skills/publish";
 vi.mock("@tanstack/react-router", () => ({
   Link: ({ children, to }: { children: ReactNode; to: string }) => <a href={to}>{children}</a>,
   createFileRoute: () => (config: { component: unknown }) => config,
-  useNavigate: () => vi.fn(),
+  useNavigate: () => navigateMock,
   useSearch: () => useSearchMock(),
 }));
 
@@ -24,6 +24,7 @@ const fetchMock = vi.fn();
 const useQueryMock = vi.fn();
 const useAuthStatusMock = vi.fn();
 const useActivePublisherMock = vi.fn();
+const navigateMock = vi.fn();
 // Allows individual test cases to drive the value `useSearch` returns.
 // The `updateSlug` search param triggers the form's "update existing"
 // branch and is required by the F1 regression cases below.
@@ -135,6 +136,7 @@ describe("Upload route", () => {
     fetchMock.mockReset();
     useQueryMock.mockReset();
     useAuthStatusMock.mockReset();
+    navigateMock.mockReset();
     useSearchMock.mockReset();
     useSearchMock.mockReturnValue({ updateSlug: undefined, ownerHandle: undefined });
     useActionCallCount = 0;
@@ -195,6 +197,24 @@ describe("Upload route", () => {
     fireEvent.click(await screen.findByRole("menuitem", { name: "Switch to @clawkit" }));
 
     expect(setActivePublisherId).toHaveBeenCalledWith("publishers:clawkit");
+  });
+
+  it("replaces a stale ownerHandle in the new publish URL", async () => {
+    useSearchMock.mockReturnValue({ updateSlug: undefined, ownerHandle: "local" });
+    mockActivePublisher({
+      activeOwnerHandle: "clawkit",
+      memberships: [personalMembership, orgMembership],
+    });
+
+    render(<Upload />);
+
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith({
+        to: "/skills/publish",
+        search: { ownerHandle: "clawkit" },
+        replace: true,
+      });
+    });
   });
 
   it("drops invalid legacy category metadata and offers explicit generation on republish", async () => {

--- a/src/__tests__/skills-publish-route.test.tsx
+++ b/src/__tests__/skills-publish-route.test.tsx
@@ -767,7 +767,7 @@ describe("Upload route", () => {
     });
 
     expect(screen.getByRole("group", { name: "Publishing as" }).textContent).toContain(
-      "@clawkit · ClawKit · admin",
+      "ClawKit / @clawkit",
     );
     expect(document.querySelector('img[src="https://example.com/clawkit.png"]')).toBeTruthy();
     expect(screen.queryByText("Available")).toBeNull();
@@ -794,7 +794,7 @@ describe("Upload route", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("group", { name: "Publishing as" }).textContent).toContain(
-        "@clawkit · ClawKit · admin",
+        "ClawKit / @clawkit",
       );
     });
 

--- a/src/components/AppProviders.tsx
+++ b/src/components/AppProviders.tsx
@@ -2,6 +2,7 @@ import { ConvexAuthProvider, useAuthActions } from "@convex-dev/auth/react";
 import { useEffect, useRef } from "react";
 import { toast } from "sonner";
 import { convex } from "../convex/client";
+import { ActivePublisherProvider } from "../lib/activePublisher";
 import {
   AUTH_CODE_NO_SESSION_MESSAGE,
   getUserFacingAuthError,
@@ -185,7 +186,7 @@ export function AppProviders({ children }: { children: React.ReactNode }) {
         <AuthErrorHandler />
         <AuthErrorToast />
         <UserBootstrap />
-        {children}
+        <ActivePublisherProvider>{children}</ActivePublisherProvider>
         <ClientOnly>
           <DevPersonaFab />
         </ClientOnly>

--- a/src/components/CatalogMetadataFields.tsx
+++ b/src/components/CatalogMetadataFields.tsx
@@ -73,7 +73,7 @@ export function CatalogMetadataFields({
   return (
     <>
       <div className="flex min-w-0 flex-col gap-2">
-        <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex min-h-[30px] flex-wrap items-center justify-between gap-2">
           <Label htmlFor={`${fieldIdPrefix}Categories`}>Categories</Label>
           <div className="flex items-center gap-2">
             {generatedCategories ? (
@@ -145,7 +145,9 @@ export function CatalogMetadataFields({
         </DropdownMenu>
       </div>
       <div className="flex flex-col gap-2">
-        <Label htmlFor={`${fieldIdPrefix}Topics`}>Topics</Label>
+        <div className="flex min-h-[30px] items-center">
+          <Label htmlFor={`${fieldIdPrefix}Topics`}>Topics</Label>
+        </div>
         <CatalogTopicInput
           id={`${fieldIdPrefix}Topics`}
           value={topics}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,6 +6,7 @@ import {
   Building2,
   Check,
   ChevronDown,
+  ChevronRight,
   Command,
   LayoutDashboard,
   LogOut,
@@ -47,6 +48,9 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
 import {
@@ -150,10 +154,15 @@ export default function Header() {
   const activeOrgProfileHandle =
     triggerPublisher?.kind === "org" ? triggerPublisher.handle : null;
   const menuProfileHandle = activeOrgProfileHandle ?? profileHandle;
+  const formatPublisherRole = (role: string | undefined) =>
+    role ? `${role.charAt(0).toUpperCase()}${role.slice(1)}` : "";
+  const formatPublisherMeta = (entry: typeof activePublisher) => {
+    if (!entry || entry.publisher.kind !== "org") return "Personal";
+    const role = formatPublisherRole(entry.role);
+    return role ? `Org · ${role}` : "Org";
+  };
   const activePublisherMeta =
-    triggerPublisher?.kind === "org"
-      ? `Org${activePublisher?.role ? ` · ${activePublisher.role}` : ""}`
-      : "Personal";
+    triggerPublisher?.kind === "org" ? formatPublisherMeta(activePublisher) : "Personal";
   const otherPublisherMemberships =
     publisherMemberships?.filter((entry) => entry.publisher._id !== activePublisherId) ?? [];
   const [navSearchQuery, setNavSearchQuery] = useState("");
@@ -613,13 +622,108 @@ export default function Header() {
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="user-dropdown-content">
-                  <div className="user-dropdown-section-label">Publisher</div>
-                  <section
-                    aria-label={`Current publisher @${triggerHandle}`}
-                    className="user-dropdown-active-card"
-                  >
-                    <div className="user-dropdown-active-header">
-                      <span className="user-dropdown-active-icon" aria-hidden="true">
+                  {hasMultiplePublishers && otherPublisherMemberships.length > 0 ? (
+                    <DropdownMenuSub>
+                      <DropdownMenuSubTrigger
+                        aria-label={`Current publisher @${triggerHandle}`}
+                        className="user-dropdown-current-trigger"
+                      >
+                        <span className="user-dropdown-publisher-icon" aria-hidden="true">
+                          {triggerPublisher ? (
+                            <MarketplaceIcon
+                              kind={triggerPublisher.kind}
+                              label={triggerPublisher.displayName || triggerPublisher.handle}
+                              imageUrl={triggerPublisher.image}
+                              size="xs"
+                            />
+                          ) : avatar ? (
+                            <img
+                              className="user-dropdown-account-avatar"
+                              src={avatar}
+                              alt=""
+                            />
+                          ) : (
+                            <span className="user-dropdown-account-avatar user-dropdown-account-fallback">
+                              {initial}
+                            </span>
+                          )}
+                        </span>
+                        <span className="user-dropdown-publisher-copy">
+                          <span className="user-dropdown-publisher-title">@{triggerHandle}</span>
+                          <span className="user-dropdown-publisher-meta">
+                            {activePublisherMeta}
+                          </span>
+                        </span>
+                        <ChevronRight className="user-dropdown-submenu-chevron" size={16} />
+                      </DropdownMenuSubTrigger>
+                      <DropdownMenuSubContent className="user-dropdown-subcontent user-dropdown-switcher-subcontent">
+                        <div className="user-dropdown-section-label">Switch publisher</div>
+                        <div className="user-dropdown-publisher-list" aria-label="Switch publisher">
+                          {activePublisher ? (
+                            <div
+                              aria-label={`Selected publisher @${activePublisher.publisher.handle}`}
+                              className="user-dropdown-publisher-item user-dropdown-publisher-item-current"
+                            >
+                              <span className="user-dropdown-publisher-icon" aria-hidden="true">
+                                <MarketplaceIcon
+                                  kind={activePublisher.publisher.kind}
+                                  label={
+                                    activePublisher.publisher.displayName ||
+                                    activePublisher.publisher.handle
+                                  }
+                                  imageUrl={activePublisher.publisher.image}
+                                  size="xs"
+                                />
+                              </span>
+                              <span className="user-dropdown-publisher-copy">
+                                <span className="user-dropdown-publisher-title">
+                                  @{activePublisher.publisher.handle}
+                                </span>
+                                <span className="user-dropdown-publisher-meta">
+                                  {formatPublisherMeta(activePublisher)}
+                                </span>
+                              </span>
+                              <Check
+                                className="user-dropdown-publisher-check"
+                                size={16}
+                                aria-label="Selected publisher"
+                              />
+                            </div>
+                          ) : null}
+                          {otherPublisherMemberships.map((entry) => (
+                            <DropdownMenuItem
+                              key={entry.publisher._id}
+                              aria-label={`Switch to @${entry.publisher.handle}`}
+                              className="user-dropdown-publisher-item"
+                              onClick={() => setActivePublisherId(entry.publisher._id)}
+                            >
+                              <span className="user-dropdown-publisher-icon" aria-hidden="true">
+                                <MarketplaceIcon
+                                  kind={entry.publisher.kind}
+                                  label={entry.publisher.displayName || entry.publisher.handle}
+                                  imageUrl={entry.publisher.image}
+                                  size="xs"
+                                />
+                              </span>
+                              <span className="user-dropdown-publisher-copy">
+                                <span className="user-dropdown-publisher-title">
+                                  @{entry.publisher.handle}
+                                </span>
+                                <span className="user-dropdown-publisher-meta">
+                                  {formatPublisherMeta(entry)}
+                                </span>
+                              </span>
+                            </DropdownMenuItem>
+                          ))}
+                        </div>
+                      </DropdownMenuSubContent>
+                    </DropdownMenuSub>
+                  ) : (
+                    <div
+                      aria-label={`Current publisher @${triggerHandle}`}
+                      className="user-dropdown-current-trigger user-dropdown-current-static"
+                    >
+                      <span className="user-dropdown-publisher-icon" aria-hidden="true">
                         {triggerPublisher ? (
                           <MarketplaceIcon
                             kind={triggerPublisher.kind}
@@ -628,147 +732,123 @@ export default function Header() {
                             size="xs"
                           />
                         ) : avatar ? (
-                          <img src={avatar} alt="" />
+                          <img
+                            className="user-dropdown-account-avatar"
+                            src={avatar}
+                            alt=""
+                          />
                         ) : (
-                          <span className="user-menu-fallback">{initial}</span>
+                          <span className="user-dropdown-account-avatar user-dropdown-account-fallback">
+                            {initial}
+                          </span>
                         )}
                       </span>
                       <span className="user-dropdown-publisher-copy">
                         <span className="user-dropdown-publisher-title">@{triggerHandle}</span>
                         <span className="user-dropdown-publisher-meta">{activePublisherMeta}</span>
                       </span>
-                      <Check
-                        className="user-dropdown-publisher-check"
-                        size={16}
-                        aria-label="Selected publisher"
-                      />
                     </div>
-                    <div
-                      aria-label={`Publisher actions for @${triggerHandle}`}
-                      className="user-dropdown-active-actions"
-                    >
-                      {menuProfileHandle ? (
-                        <DropdownMenuItem asChild className="user-dropdown-scoped-action">
-                          <Link
-                            to="/user/$handle"
-                            params={{ handle: menuProfileHandle }}
-                            className="flex items-center gap-2"
-                          >
-                            {triggerPublisher?.kind === "org" ? (
-                              <Building2 size={14} aria-hidden="true" />
-                            ) : (
-                              <UserRound size={14} aria-hidden="true" />
-                            )}
-                            Profile
-                          </Link>
-                        </DropdownMenuItem>
-                      ) : null}
-                      <DropdownMenuItem asChild className="user-dropdown-scoped-action">
-                        <Link to="/dashboard" className="flex items-center gap-2">
-                          <LayoutDashboard size={14} aria-hidden="true" />
-                          Dashboard
-                        </Link>
-                      </DropdownMenuItem>
-                      <DropdownMenuItem asChild className="user-dropdown-scoped-action">
-                        <Link to="/settings" className="flex items-center gap-2">
-                          <Settings size={14} aria-hidden="true" />
-                          Settings
-                        </Link>
-                      </DropdownMenuItem>
-                    </div>
-                  </section>
-                  {hasMultiplePublishers && otherPublisherMemberships.length > 0 ? (
-                    <>
-                      <DropdownMenuSeparator />
-                      <div className="user-dropdown-section-label">Switch publisher</div>
-                      <div className="user-dropdown-publisher-list" aria-label="Switch publisher">
-                        {otherPublisherMemberships.map((entry) => (
-                          <DropdownMenuItem
-                            key={entry.publisher._id}
-                            aria-label={`Switch to @${entry.publisher.handle}`}
-                            className="user-dropdown-publisher-item"
-                            onClick={() => setActivePublisherId(entry.publisher._id)}
-                          >
-                            <span className="user-dropdown-publisher-icon" aria-hidden="true">
-                              <MarketplaceIcon
-                                kind={entry.publisher.kind}
-                                label={entry.publisher.displayName || entry.publisher.handle}
-                                imageUrl={entry.publisher.image}
-                                size="xs"
-                              />
-                            </span>
-                            <span className="user-dropdown-publisher-copy">
-                              <span className="user-dropdown-publisher-title">
-                                @{entry.publisher.handle}
-                              </span>
-                              <span className="user-dropdown-publisher-meta">
-                                {entry.publisher.kind === "org" ? `Org · ${entry.role}` : "Personal"}
-                              </span>
-                            </span>
-                          </DropdownMenuItem>
-                        ))}
-                      </div>
-                    </>
-                  ) : null}
+                  )}
                   <DropdownMenuSeparator />
-                  <div className="user-dropdown-section-label">Account</div>
-                  <section
-                    aria-label={`Account @${rawHandle}`}
-                    className="user-dropdown-account-section"
+                  <div
+                    aria-label={`Publisher actions for @${triggerHandle}`}
+                    className="user-dropdown-active-actions"
                   >
-                    <div
-                      aria-label={`Signed-in account @${rawHandle}`}
-                      className="user-dropdown-account-identity"
-                    >
-                      {avatar ? (
-                        <img
-                          className="user-dropdown-account-avatar"
-                          src={avatar}
-                          alt={me.displayName ?? me.name ?? "User avatar"}
-                        />
-                      ) : (
-                        <span className="user-dropdown-account-avatar user-dropdown-account-fallback">
-                          {initial}
-                        </span>
-                      )}
-                      <span className="user-dropdown-account-handle">@{rawHandle}</span>
-                    </div>
-                    <DropdownMenuItem asChild className="user-dropdown-account-action">
-                      <Link to="/stars" className="flex items-center gap-2">
-                        <Star size={14} aria-hidden="true" />
-                        Stars
+                    {menuProfileHandle ? (
+                      <DropdownMenuItem asChild className="user-dropdown-scoped-action">
+                        <Link
+                          to="/user/$handle"
+                          params={{ handle: menuProfileHandle }}
+                          className="flex items-center gap-2"
+                        >
+                          {triggerPublisher?.kind === "org" ? (
+                            <Building2 size={14} aria-hidden="true" />
+                          ) : (
+                            <UserRound size={14} aria-hidden="true" />
+                          )}
+                          Profile
+                        </Link>
+                      </DropdownMenuItem>
+                    ) : null}
+                    <DropdownMenuItem asChild className="user-dropdown-scoped-action">
+                      <Link to="/dashboard" className="flex items-center gap-2">
+                        <LayoutDashboard size={14} aria-hidden="true" />
+                        Dashboard
                       </Link>
                     </DropdownMenuItem>
-                    <div className="user-dropdown-appearance-row">
-                      <span className="user-dropdown-appearance-label">
-                        <Palette size={14} aria-hidden="true" />
-                        Appearance
-                      </span>
-                      <div className="user-dropdown-theme-row" role="group" aria-label="Theme">
-                        {THEME_MODE_ITEMS.map(({ mode: themeMode, label, Icon }) => (
-                          <DropdownMenuItem
-                            key={themeMode}
-                            aria-label={label}
-                            aria-current={mode === themeMode ? "true" : undefined}
-                            className="user-dropdown-theme-button"
-                            data-status={mode === themeMode ? "active" : undefined}
-                            title={label}
-                            onClick={() => setThemeMode(themeMode)}
-                          >
-                            <Icon size={15} aria-hidden="true" />
-                            <span className="sr-only">{label}</span>
-                          </DropdownMenuItem>
-                        ))}
-                      </div>
-                    </div>
-                    <DropdownMenuItem
-                      className="user-dropdown-account-action"
-                      onClick={() => void signOut()}
-                    >
-                      <LogOut size={14} aria-hidden="true" />
-                      Sign out
+                    <DropdownMenuItem asChild className="user-dropdown-scoped-action">
+                      <Link to="/settings" className="flex items-center gap-2">
+                        <Settings size={14} aria-hidden="true" />
+                        Settings
+                      </Link>
                     </DropdownMenuItem>
-                  </section>
+                  </div>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuSub>
+                    <DropdownMenuSubTrigger
+                      aria-label={`Account @${rawHandle}`}
+                      className="user-dropdown-account-trigger"
+                    >
+                      <span className="user-dropdown-account-label">Account</span>
+                      <span className="user-dropdown-account-handle">@{rawHandle}</span>
+                      <ChevronRight className="user-dropdown-submenu-chevron" size={16} />
+                    </DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent className="user-dropdown-subcontent user-dropdown-account-subcontent">
+                      <div
+                        aria-label={`Signed-in account @${rawHandle}`}
+                        className="user-dropdown-account-identity"
+                      >
+                        {avatar ? (
+                          <img
+                            className="user-dropdown-account-avatar"
+                            src={avatar}
+                            alt={me.displayName ?? me.name ?? "User avatar"}
+                          />
+                        ) : (
+                          <span className="user-dropdown-account-avatar user-dropdown-account-fallback">
+                            {initial}
+                          </span>
+                        )}
+                        <span className="user-dropdown-account-handle">@{rawHandle}</span>
+                      </div>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem asChild className="user-dropdown-account-action">
+                        <Link to="/stars" className="flex items-center gap-2">
+                          <Star size={14} aria-hidden="true" />
+                          Stars
+                        </Link>
+                      </DropdownMenuItem>
+                      <div className="user-dropdown-appearance-row">
+                        <span className="user-dropdown-appearance-label">
+                          <Palette size={14} aria-hidden="true" />
+                          Appearance
+                        </span>
+                        <div className="user-dropdown-theme-row" role="group" aria-label="Theme">
+                          {THEME_MODE_ITEMS.map(({ mode: themeMode, label, Icon }) => (
+                            <DropdownMenuItem
+                              key={themeMode}
+                              aria-label={label}
+                              aria-current={mode === themeMode ? "true" : undefined}
+                              className="user-dropdown-theme-button"
+                              data-status={mode === themeMode ? "active" : undefined}
+                              title={label}
+                              onClick={() => setThemeMode(themeMode)}
+                            >
+                              <Icon size={15} aria-hidden="true" />
+                              <span className="sr-only">{label}</span>
+                            </DropdownMenuItem>
+                          ))}
+                        </div>
+                      </div>
+                      <DropdownMenuItem
+                        className="user-dropdown-account-action"
+                        onClick={() => void signOut()}
+                      >
+                        <LogOut size={14} aria-hidden="true" />
+                        Sign out
+                      </DropdownMenuItem>
+                    </DropdownMenuSubContent>
+                  </DropdownMenuSub>
                 </DropdownMenuContent>
               </DropdownMenu>
             ) : isAuthResolving ? (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -145,10 +145,15 @@ export default function Header() {
   const initial = (me?.displayName ?? me?.name ?? rawHandle).charAt(0).toUpperCase();
   const triggerPublisher = activePublisher?.publisher;
   const triggerHandle = triggerPublisher?.handle ?? rawHandle;
-  const triggerTitle =
-    triggerPublisher?.kind === "org" && triggerPublisher.displayName
-      ? triggerPublisher.displayName
-      : `@${triggerHandle}`;
+  const formatPublisherTitle = (entry: typeof activePublisher) => {
+    if (!entry) return me?.displayName?.trim() || me?.name?.trim() || rawHandle;
+    return (
+      entry.publisher.displayName?.trim() ||
+      (entry.publisher.kind === "user" ? me?.displayName?.trim() || me?.name?.trim() : undefined) ||
+      entry.publisher.handle
+    );
+  };
+  const triggerTitle = formatPublisherTitle(activePublisher);
   const triggerLabel = triggerTitle.length > 25 ? `${triggerTitle.slice(0, 25)}…` : triggerTitle;
   const isAuthResolving = isLoading || (isAuthenticated && me === undefined);
   const profileHandle = useQuery(
@@ -159,12 +164,8 @@ export default function Header() {
   const menuProfileHandle = activeOrgProfileHandle ?? profileHandle;
   const isPersonalPublisher = triggerPublisher?.kind !== "org";
   const profileMenuLabel = isPersonalPublisher ? "Profile" : "Org profile";
-  const formatPublisherMeta = (entry: typeof activePublisher) => {
-    if (!entry || entry.publisher.kind !== "org") return "Personal";
-    return "Organization";
-  };
-  const activePublisherMeta =
-    triggerPublisher?.kind === "org" ? formatPublisherMeta(activePublisher) : "Personal";
+  const hasOrganizationPublisher =
+    publisherMemberships?.some((entry) => entry.publisher.kind === "org") ?? false;
   const otherPublisherMemberships =
     publisherMemberships?.filter((entry) => entry.publisher._id !== activePublisherId) ?? [];
   const goToOrganizationCreation = () => {
@@ -431,7 +432,7 @@ export default function Header() {
           </span>
           <span className="user-dropdown-publisher-copy">
             <span className="user-dropdown-publisher-title">{triggerTitle}</span>
-            <span className="user-dropdown-publisher-meta">{activePublisherMeta}</span>
+            <span className="user-dropdown-publisher-meta">@{triggerHandle}</span>
           </span>
           <ChevronRight className="user-dropdown-submenu-chevron" size={16} />
         </button>
@@ -458,10 +459,19 @@ export default function Header() {
           </span>
           <span className="user-dropdown-publisher-copy">
             <span className="user-dropdown-publisher-title">{triggerTitle}</span>
-            <span className="user-dropdown-publisher-meta">{activePublisherMeta}</span>
+            <span className="user-dropdown-publisher-meta">@{triggerHandle}</span>
           </span>
         </div>
       )}
+      {!hasOrganizationPublisher ? (
+        <DropdownMenuItem
+          className="user-dropdown-create-org-action"
+          onClick={goToOrganizationCreation}
+        >
+          <Plus size={15} aria-hidden="true" />
+          Create organization
+        </DropdownMenuItem>
+      ) : null}
       <DropdownMenuSeparator />
       <div
         aria-label={`Publisher actions for @${triggerHandle}`}
@@ -564,10 +574,10 @@ export default function Header() {
             </span>
             <span className="user-dropdown-publisher-copy">
               <span className="user-dropdown-publisher-title">
-                @{activePublisher.publisher.handle}
+                {formatPublisherTitle(activePublisher)}
               </span>
               <span className="user-dropdown-publisher-meta">
-                {formatPublisherMeta(activePublisher)}
+                @{activePublisher.publisher.handle}
               </span>
             </span>
             <Check
@@ -593,8 +603,8 @@ export default function Header() {
               />
             </span>
             <span className="user-dropdown-publisher-copy">
-              <span className="user-dropdown-publisher-title">@{entry.publisher.handle}</span>
-              <span className="user-dropdown-publisher-meta">{formatPublisherMeta(entry)}</span>
+              <span className="user-dropdown-publisher-title">{formatPublisherTitle(entry)}</span>
+              <span className="user-dropdown-publisher-meta">@{entry.publisher.handle}</span>
             </span>
           </DropdownMenuItem>
         ))}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -836,7 +836,7 @@ export default function Header() {
                       </Link>
                     </DropdownMenuItem>
                   </div>
-                  <DropdownMenuSeparator />
+                  <DropdownMenuSeparator className="user-dropdown-full-bleed-separator" />
                   <div className="user-dropdown-appearance-row">
                     <span className="user-dropdown-appearance-label">
                       <Palette size={14} aria-hidden="true" />
@@ -859,7 +859,7 @@ export default function Header() {
                       ))}
                     </div>
                   </div>
-                  <DropdownMenuSeparator />
+                  <DropdownMenuSeparator className="user-dropdown-full-bleed-separator" />
                   <DropdownMenuItem
                     className="user-dropdown-account-action"
                     onClick={() => void signOut()}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -184,6 +184,9 @@ export default function Header() {
   const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [publisherSwitcherOpen, setPublisherSwitcherOpen] = useState(false);
+  const [publisherMenuMotion, setPublisherMenuMotion] = useState<"idle" | "forward" | "back">(
+    "idle",
+  );
   const [headerScrolled, setHeaderScrolled] = useState(false);
   const searchWrapRef = useRef<HTMLDivElement | null>(null);
   const mobileSearchWrapRef = useRef<HTMLDivElement | null>(null);
@@ -399,12 +402,149 @@ export default function Header() {
     }
   };
 
+  const publisherActionsContent = (
+    <>
+      {hasMultiplePublishers && otherPublisherMemberships.length > 0 ? (
+        <button
+          type="button"
+          aria-label={`Current publisher @${triggerHandle}`}
+          className="user-dropdown-current-trigger"
+          onClick={() => {
+            setPublisherMenuMotion("forward");
+            setPublisherSwitcherOpen(true);
+          }}
+        >
+          <span className="user-dropdown-publisher-icon" aria-hidden="true">
+            {triggerPublisher ? (
+              <MarketplaceIcon
+                kind={triggerPublisher.kind}
+                label={triggerPublisher.displayName || triggerPublisher.handle}
+                imageUrl={triggerPublisher.image}
+                size="xs"
+              />
+            ) : avatar ? (
+              <img className="user-dropdown-account-avatar" src={avatar} alt="" />
+            ) : (
+              <span className="user-dropdown-account-avatar user-dropdown-account-fallback">
+                {initial}
+              </span>
+            )}
+          </span>
+          <span className="user-dropdown-publisher-copy">
+            <span className="user-dropdown-publisher-title">{triggerTitle}</span>
+            <span className="user-dropdown-publisher-meta">{activePublisherMeta}</span>
+          </span>
+          <ChevronRight className="user-dropdown-submenu-chevron" size={16} />
+        </button>
+      ) : (
+        <div
+          aria-label={`Current publisher @${triggerHandle}`}
+          className="user-dropdown-current-trigger user-dropdown-current-static"
+        >
+          <span className="user-dropdown-publisher-icon" aria-hidden="true">
+            {triggerPublisher ? (
+              <MarketplaceIcon
+                kind={triggerPublisher.kind}
+                label={triggerPublisher.displayName || triggerPublisher.handle}
+                imageUrl={triggerPublisher.image}
+                size="xs"
+              />
+            ) : avatar ? (
+              <img className="user-dropdown-account-avatar" src={avatar} alt="" />
+            ) : (
+              <span className="user-dropdown-account-avatar user-dropdown-account-fallback">
+                {initial}
+              </span>
+            )}
+          </span>
+          <span className="user-dropdown-publisher-copy">
+            <span className="user-dropdown-publisher-title">{triggerTitle}</span>
+            <span className="user-dropdown-publisher-meta">{activePublisherMeta}</span>
+          </span>
+        </div>
+      )}
+      <DropdownMenuSeparator />
+      <div
+        aria-label={`Publisher actions for @${triggerHandle}`}
+        className="user-dropdown-active-actions"
+      >
+        <DropdownMenuItem asChild className="user-dropdown-scoped-action">
+          <Link to="/dashboard" className="flex items-center gap-2">
+            <LayoutDashboard size={14} aria-hidden="true" />
+            Dashboard
+          </Link>
+        </DropdownMenuItem>
+        {menuProfileHandle ? (
+          <DropdownMenuItem asChild className="user-dropdown-scoped-action">
+            <Link
+              to="/user/$handle"
+              params={{ handle: menuProfileHandle }}
+              className="flex items-center gap-2"
+            >
+              {triggerPublisher?.kind === "org" ? (
+                <Building2 size={14} aria-hidden="true" />
+              ) : (
+                <UserRound size={14} aria-hidden="true" />
+              )}
+              {profileMenuLabel}
+            </Link>
+          </DropdownMenuItem>
+        ) : null}
+        {isPersonalPublisher ? (
+          <DropdownMenuItem asChild className="user-dropdown-scoped-action">
+            <Link to="/stars" className="flex items-center gap-2">
+              <Star size={14} aria-hidden="true" />
+              Stars
+            </Link>
+          </DropdownMenuItem>
+        ) : null}
+        <DropdownMenuItem asChild className="user-dropdown-scoped-action">
+          <Link to="/settings" className="flex items-center gap-2">
+            <Settings size={14} aria-hidden="true" />
+            Settings
+          </Link>
+        </DropdownMenuItem>
+      </div>
+      <DropdownMenuSeparator />
+      <div className="user-dropdown-appearance-row">
+        <span className="user-dropdown-appearance-label">
+          <Palette size={14} aria-hidden="true" />
+          Appearance
+        </span>
+        <div className="user-dropdown-theme-row" role="group" aria-label="Theme">
+          {THEME_MODE_ITEMS.map(({ mode: themeMode, label, Icon }) => (
+            <DropdownMenuItem
+              key={themeMode}
+              aria-label={label}
+              aria-current={mode === themeMode ? "true" : undefined}
+              className="user-dropdown-theme-button"
+              data-status={mode === themeMode ? "active" : undefined}
+              title={label}
+              onClick={() => setThemeMode(themeMode)}
+            >
+              <Icon size={15} aria-hidden="true" />
+              <span className="sr-only">{label}</span>
+            </DropdownMenuItem>
+          ))}
+        </div>
+      </div>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem className="user-dropdown-account-action" onClick={() => void signOut()}>
+        <LogOut size={14} aria-hidden="true" />
+        Sign out
+      </DropdownMenuItem>
+    </>
+  );
+
   const publisherSwitcherContent = (
     <>
       <button
         type="button"
         className="user-dropdown-switcher-back"
-        onClick={() => setPublisherSwitcherOpen(false)}
+        onClick={() => {
+          setPublisherMenuMotion("back");
+          setPublisherSwitcherOpen(false);
+        }}
       >
         <ChevronLeft size={14} aria-hidden="true" />
         Back
@@ -710,148 +850,20 @@ export default function Header() {
                     <ChevronDown className="user-menu-chevron" size={16} />
                   </button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="user-dropdown-content">
-                  {publisherSwitcherOpen ? (
-                    publisherSwitcherContent
-                  ) : (
-                    <>
-                      {hasMultiplePublishers && otherPublisherMemberships.length > 0 ? (
-                      <button
-                        type="button"
-                        aria-label={`Current publisher @${triggerHandle}`}
-                        className="user-dropdown-current-trigger"
-                        onClick={() => setPublisherSwitcherOpen(true)}
-                      >
-                        <span className="user-dropdown-publisher-icon" aria-hidden="true">
-                          {triggerPublisher ? (
-                            <MarketplaceIcon
-                              kind={triggerPublisher.kind}
-                              label={triggerPublisher.displayName || triggerPublisher.handle}
-                              imageUrl={triggerPublisher.image}
-                              size="xs"
-                            />
-                          ) : avatar ? (
-                            <img className="user-dropdown-account-avatar" src={avatar} alt="" />
-                          ) : (
-                            <span className="user-dropdown-account-avatar user-dropdown-account-fallback">
-                              {initial}
-                            </span>
-                          )}
-                        </span>
-                        <span className="user-dropdown-publisher-copy">
-                          <span className="user-dropdown-publisher-title">{triggerTitle}</span>
-                          <span className="user-dropdown-publisher-meta">
-                            {activePublisherMeta}
-                          </span>
-                        </span>
-                        <ChevronRight className="user-dropdown-submenu-chevron" size={16} />
-                      </button>
-                      ) : (
-                        <div
-                      aria-label={`Current publisher @${triggerHandle}`}
-                      className="user-dropdown-current-trigger user-dropdown-current-static"
-                    >
-                      <span className="user-dropdown-publisher-icon" aria-hidden="true">
-                        {triggerPublisher ? (
-                          <MarketplaceIcon
-                            kind={triggerPublisher.kind}
-                            label={triggerPublisher.displayName || triggerPublisher.handle}
-                            imageUrl={triggerPublisher.image}
-                            size="xs"
-                          />
-                        ) : avatar ? (
-                          <img
-                            className="user-dropdown-account-avatar"
-                            src={avatar}
-                            alt=""
-                          />
-                        ) : (
-                          <span className="user-dropdown-account-avatar user-dropdown-account-fallback">
-                            {initial}
-                          </span>
-                        )}
-                      </span>
-                      <span className="user-dropdown-publisher-copy">
-                        <span className="user-dropdown-publisher-title">{triggerTitle}</span>
-                        <span className="user-dropdown-publisher-meta">{activePublisherMeta}</span>
-                      </span>
-                    </div>
-                      )}
-                  <DropdownMenuSeparator />
+                <DropdownMenuContent
+                  align="end"
+                  className="user-dropdown-content"
+                  onCloseAutoFocus={() => {
+                    setPublisherMenuMotion("idle");
+                  }}
+                >
                   <div
-                    aria-label={`Publisher actions for @${triggerHandle}`}
-                    className="user-dropdown-active-actions"
+                    className="user-dropdown-panel"
+                    data-motion={publisherMenuMotion}
+                    key={publisherSwitcherOpen ? "publisher-switcher" : "publisher-actions"}
                   >
-                    <DropdownMenuItem asChild className="user-dropdown-scoped-action">
-                      <Link to="/dashboard" className="flex items-center gap-2">
-                        <LayoutDashboard size={14} aria-hidden="true" />
-                        Dashboard
-                      </Link>
-                    </DropdownMenuItem>
-                    {menuProfileHandle ? (
-                      <DropdownMenuItem asChild className="user-dropdown-scoped-action">
-                        <Link
-                          to="/user/$handle"
-                          params={{ handle: menuProfileHandle }}
-                          className="flex items-center gap-2"
-                        >
-                          {triggerPublisher?.kind === "org" ? (
-                            <Building2 size={14} aria-hidden="true" />
-                          ) : (
-                            <UserRound size={14} aria-hidden="true" />
-                          )}
-                          {profileMenuLabel}
-                        </Link>
-                      </DropdownMenuItem>
-                    ) : null}
-                    {isPersonalPublisher ? (
-                      <DropdownMenuItem asChild className="user-dropdown-scoped-action">
-                        <Link to="/stars" className="flex items-center gap-2">
-                          <Star size={14} aria-hidden="true" />
-                          Stars
-                        </Link>
-                      </DropdownMenuItem>
-                    ) : null}
-                    <DropdownMenuItem asChild className="user-dropdown-scoped-action">
-                      <Link to="/settings" className="flex items-center gap-2">
-                        <Settings size={14} aria-hidden="true" />
-                        Settings
-                      </Link>
-                    </DropdownMenuItem>
+                    {publisherSwitcherOpen ? publisherSwitcherContent : publisherActionsContent}
                   </div>
-                  <DropdownMenuSeparator />
-                  <div className="user-dropdown-appearance-row">
-                    <span className="user-dropdown-appearance-label">
-                      <Palette size={14} aria-hidden="true" />
-                      Appearance
-                    </span>
-                    <div className="user-dropdown-theme-row" role="group" aria-label="Theme">
-                      {THEME_MODE_ITEMS.map(({ mode: themeMode, label, Icon }) => (
-                        <DropdownMenuItem
-                          key={themeMode}
-                          aria-label={label}
-                          aria-current={mode === themeMode ? "true" : undefined}
-                          className="user-dropdown-theme-button"
-                          data-status={mode === themeMode ? "active" : undefined}
-                          title={label}
-                          onClick={() => setThemeMode(themeMode)}
-                        >
-                          <Icon size={15} aria-hidden="true" />
-                          <span className="sr-only">{label}</span>
-                        </DropdownMenuItem>
-                      ))}
-                    </div>
-                  </div>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    className="user-dropdown-account-action"
-                    onClick={() => void signOut()}
-                  >
-                    <LogOut size={14} aria-hidden="true" />
-                    Sign out
-                  </DropdownMenuItem>
-                    </>
-                  )}
                 </DropdownMenuContent>
               </DropdownMenu>
             ) : isAuthResolving ? (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -147,7 +147,12 @@ export default function Header() {
   const initial = (me?.displayName ?? me?.name ?? rawHandle).charAt(0).toUpperCase();
   const triggerPublisher = activePublisher?.publisher;
   const triggerHandle = triggerPublisher?.handle ?? rawHandle;
-  const triggerLabel = triggerHandle.length > 25 ? `${triggerHandle.slice(0, 25)}…` : triggerHandle;
+  const triggerTitle =
+    triggerPublisher?.kind === "org" && triggerPublisher.displayName
+      ? triggerPublisher.displayName
+      : `@${triggerHandle}`;
+  const triggerLabel = triggerTitle.length > 25 ? `${triggerTitle.slice(0, 25)}…` : triggerTitle;
+  const accountHandle = me?.handle ?? rawHandle;
   const isAuthResolving = isLoading || (isAuthenticated && me === undefined);
   const profileHandle = useQuery(
     api.publishers.getMyProfileHandle,
@@ -166,7 +171,21 @@ export default function Header() {
     return role ? `Org · ${role}` : "Org";
   };
   const activePublisherMeta =
-    triggerPublisher?.kind === "org" ? formatPublisherMeta(activePublisher) : "Personal";
+    triggerPublisher?.kind === "org" ? (
+      <span className="user-dropdown-publisher-via">
+        <span>via</span>
+        {avatar ? (
+          <img className="user-dropdown-via-avatar" src={avatar} alt="" />
+        ) : (
+          <span className="user-dropdown-via-avatar user-dropdown-via-avatar-fallback">
+            <UserRound size={9} aria-hidden="true" />
+          </span>
+        )}
+        <span className="user-dropdown-via-handle">@{accountHandle}</span>
+      </span>
+    ) : (
+      "Personal"
+    );
   const otherPublisherMemberships =
     publisherMemberships?.filter((entry) => entry.publisher._id !== activePublisherId) ?? [];
   const goToOrganizationCreation = () => {
@@ -614,7 +633,7 @@ export default function Header() {
                   <button
                     className="user-trigger"
                     type="button"
-                    aria-label={`Open account menu for @${triggerHandle}`}
+                    aria-label={`Open account menu for ${triggerTitle}`}
                   >
                     {triggerPublisher ? (
                       <span className="user-menu-publisher-icon" aria-hidden="true">
@@ -630,7 +649,7 @@ export default function Header() {
                     ) : (
                       <span className="user-menu-fallback">{initial}</span>
                     )}
-                    <span className="user-trigger-handle truncate">@{triggerLabel}</span>
+                    <span className="user-trigger-handle truncate">{triggerLabel}</span>
                     <ChevronDown className="user-menu-chevron" size={16} />
                   </button>
                 </DropdownMenuTrigger>
@@ -662,7 +681,7 @@ export default function Header() {
                           )}
                         </span>
                         <span className="user-dropdown-publisher-copy">
-                          <span className="user-dropdown-publisher-title">@{triggerHandle}</span>
+                          <span className="user-dropdown-publisher-title">{triggerTitle}</span>
                           <span className="user-dropdown-publisher-meta">
                             {activePublisherMeta}
                           </span>
@@ -765,7 +784,7 @@ export default function Header() {
                         )}
                       </span>
                       <span className="user-dropdown-publisher-copy">
-                        <span className="user-dropdown-publisher-title">@{triggerHandle}</span>
+                        <span className="user-dropdown-publisher-title">{triggerTitle}</span>
                         <span className="user-dropdown-publisher-meta">{activePublisherMeta}</span>
                       </span>
                     </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -155,8 +155,7 @@ export default function Header() {
     api.publishers.getMyProfileHandle,
     isAuthenticated && me ? {} : "skip",
   );
-  const activeOrgProfileHandle =
-    triggerPublisher?.kind === "org" ? triggerPublisher.handle : null;
+  const activeOrgProfileHandle = triggerPublisher?.kind === "org" ? triggerPublisher.handle : null;
   const menuProfileHandle = activeOrgProfileHandle ?? profileHandle;
   const isPersonalPublisher = triggerPublisher?.kind !== "org";
   const profileMenuLabel = isPersonalPublisher ? "Profile" : "Org profile";

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,14 +3,17 @@ import { Link, useLocation, useNavigate } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
 import {
   ArrowRight,
+  Building2,
   Check,
   ChevronDown,
   Command,
   LayoutDashboard,
+  LogOut,
   Menu,
   Monitor,
   Moon,
   MoreHorizontal,
+  Palette,
   Search,
   Settings,
   Star,
@@ -147,6 +150,12 @@ export default function Header() {
   const activeOrgProfileHandle =
     triggerPublisher?.kind === "org" ? triggerPublisher.handle : null;
   const menuProfileHandle = activeOrgProfileHandle ?? profileHandle;
+  const activePublisherMeta =
+    triggerPublisher?.kind === "org"
+      ? `Org${activePublisher?.role ? ` · ${activePublisher.role}` : ""}`
+      : "Personal";
+  const otherPublisherMemberships =
+    publisherMemberships?.filter((entry) => entry.publisher._id !== activePublisherId) ?? [];
   const [navSearchQuery, setNavSearchQuery] = useState("");
   const [typeaheadOpen, setTypeaheadOpen] = useState(false);
   const [typeaheadTab, setTypeaheadTab] = useState<TypeaheadTab>("skills");
@@ -604,104 +613,162 @@ export default function Header() {
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="user-dropdown-content">
-                  {hasMultiplePublishers && publisherMemberships ? (
+                  <div className="user-dropdown-section-label">Publisher</div>
+                  <section
+                    aria-label={`Current publisher @${triggerHandle}`}
+                    className="user-dropdown-active-card"
+                  >
+                    <div className="user-dropdown-active-header">
+                      <span className="user-dropdown-active-icon" aria-hidden="true">
+                        {triggerPublisher ? (
+                          <MarketplaceIcon
+                            kind={triggerPublisher.kind}
+                            label={triggerPublisher.displayName || triggerPublisher.handle}
+                            imageUrl={triggerPublisher.image}
+                            size="xs"
+                          />
+                        ) : avatar ? (
+                          <img src={avatar} alt="" />
+                        ) : (
+                          <span className="user-menu-fallback">{initial}</span>
+                        )}
+                      </span>
+                      <span className="user-dropdown-publisher-copy">
+                        <span className="user-dropdown-publisher-title">@{triggerHandle}</span>
+                        <span className="user-dropdown-publisher-meta">{activePublisherMeta}</span>
+                      </span>
+                      <Check
+                        className="user-dropdown-publisher-check"
+                        size={16}
+                        aria-label="Selected publisher"
+                      />
+                    </div>
+                    <div
+                      aria-label={`Publisher actions for @${triggerHandle}`}
+                      className="user-dropdown-active-actions"
+                    >
+                      {menuProfileHandle ? (
+                        <DropdownMenuItem asChild className="user-dropdown-scoped-action">
+                          <Link
+                            to="/user/$handle"
+                            params={{ handle: menuProfileHandle }}
+                            className="flex items-center gap-2"
+                          >
+                            {triggerPublisher?.kind === "org" ? (
+                              <Building2 size={14} aria-hidden="true" />
+                            ) : (
+                              <UserRound size={14} aria-hidden="true" />
+                            )}
+                            Profile
+                          </Link>
+                        </DropdownMenuItem>
+                      ) : null}
+                      <DropdownMenuItem asChild className="user-dropdown-scoped-action">
+                        <Link to="/dashboard" className="flex items-center gap-2">
+                          <LayoutDashboard size={14} aria-hidden="true" />
+                          Dashboard
+                        </Link>
+                      </DropdownMenuItem>
+                      <DropdownMenuItem asChild className="user-dropdown-scoped-action">
+                        <Link to="/settings" className="flex items-center gap-2">
+                          <Settings size={14} aria-hidden="true" />
+                          Settings
+                        </Link>
+                      </DropdownMenuItem>
+                    </div>
+                  </section>
+                  {hasMultiplePublishers && otherPublisherMemberships.length > 0 ? (
                     <>
-                      <div className="user-dropdown-publisher-list" aria-label="Active publisher">
-                        {publisherMemberships.map((entry) => {
-                          const active = entry.publisher._id === activePublisherId;
-                          return (
-                            <DropdownMenuItem
-                              key={entry.publisher._id}
-                              aria-current={active ? "true" : undefined}
-                              className="user-dropdown-publisher-item"
-                              data-status={active ? "active" : undefined}
-                              onClick={() => setActivePublisherId(entry.publisher._id)}
-                            >
-                              <span className="user-dropdown-publisher-icon" aria-hidden="true">
-                                <MarketplaceIcon
-                                  kind={entry.publisher.kind}
-                                  label={entry.publisher.displayName || entry.publisher.handle}
-                                  imageUrl={entry.publisher.image}
-                                  size="xs"
-                                />
-                              </span>
-                              <span className="user-dropdown-publisher-copy">
-                                <span className="user-dropdown-publisher-title">
-                                  @{entry.publisher.handle}
-                                </span>
-                                <span className="user-dropdown-publisher-meta">
-                                  {entry.publisher.kind === "org" ? `Org · ${entry.role}` : "Personal"}
-                                </span>
-                              </span>
-                              {active ? (
-                                <Check
-                                  className="user-dropdown-publisher-check"
-                                  size={15}
-                                  aria-hidden="true"
-                                />
-                              ) : null}
-                            </DropdownMenuItem>
-                          );
-                        })}
-                      </div>
                       <DropdownMenuSeparator />
+                      <div className="user-dropdown-section-label">Switch publisher</div>
+                      <div className="user-dropdown-publisher-list" aria-label="Switch publisher">
+                        {otherPublisherMemberships.map((entry) => (
+                          <DropdownMenuItem
+                            key={entry.publisher._id}
+                            aria-label={`Switch to @${entry.publisher.handle}`}
+                            className="user-dropdown-publisher-item"
+                            onClick={() => setActivePublisherId(entry.publisher._id)}
+                          >
+                            <span className="user-dropdown-publisher-icon" aria-hidden="true">
+                              <MarketplaceIcon
+                                kind={entry.publisher.kind}
+                                label={entry.publisher.displayName || entry.publisher.handle}
+                                imageUrl={entry.publisher.image}
+                                size="xs"
+                              />
+                            </span>
+                            <span className="user-dropdown-publisher-copy">
+                              <span className="user-dropdown-publisher-title">
+                                @{entry.publisher.handle}
+                              </span>
+                              <span className="user-dropdown-publisher-meta">
+                                {entry.publisher.kind === "org" ? `Org · ${entry.role}` : "Personal"}
+                              </span>
+                            </span>
+                          </DropdownMenuItem>
+                        ))}
+                      </div>
                     </>
                   ) : null}
-                  <div
-                    aria-label={`Actions for @${triggerHandle}`}
-                    className="user-dropdown-context-label"
+                  <DropdownMenuSeparator />
+                  <div className="user-dropdown-section-label">Account</div>
+                  <section
+                    aria-label={`Account @${rawHandle}`}
+                    className="user-dropdown-account-section"
                   >
-                    For <span className="mono">@{triggerHandle}</span>
-                  </div>
-                  {menuProfileHandle ? (
-                    <DropdownMenuItem asChild>
-                      <Link
-                        to="/user/$handle"
-                        params={{ handle: menuProfileHandle }}
-                        className="flex items-center gap-2"
-                      >
-                        <UserRound size={14} aria-hidden="true" />
-                        Profile
+                    <div
+                      aria-label={`Signed-in account @${rawHandle}`}
+                      className="user-dropdown-account-identity"
+                    >
+                      {avatar ? (
+                        <img
+                          className="user-dropdown-account-avatar"
+                          src={avatar}
+                          alt={me.displayName ?? me.name ?? "User avatar"}
+                        />
+                      ) : (
+                        <span className="user-dropdown-account-avatar user-dropdown-account-fallback">
+                          {initial}
+                        </span>
+                      )}
+                      <span className="user-dropdown-account-handle">@{rawHandle}</span>
+                    </div>
+                    <DropdownMenuItem asChild className="user-dropdown-account-action">
+                      <Link to="/stars" className="flex items-center gap-2">
+                        <Star size={14} aria-hidden="true" />
+                        Stars
                       </Link>
                     </DropdownMenuItem>
-                  ) : null}
-                  <DropdownMenuItem asChild>
-                    <Link to="/dashboard" className="flex items-center gap-2">
-                      <LayoutDashboard size={14} aria-hidden="true" />
-                      Dashboard
-                    </Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem asChild>
-                    <Link to="/settings" className="flex items-center gap-2">
-                      <Settings size={14} aria-hidden="true" />
-                      Settings
-                    </Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem asChild>
-                    <Link to="/stars" className="flex items-center gap-2">
-                      <Star size={14} aria-hidden="true" />
-                      Stars
-                    </Link>
-                  </DropdownMenuItem>
-                  <div className="user-dropdown-theme-row" role="group" aria-label="Theme">
-                    {THEME_MODE_ITEMS.map(({ mode: themeMode, label, Icon }) => (
-                      <DropdownMenuItem
-                        key={themeMode}
-                        aria-label={label}
-                        aria-current={mode === themeMode ? "true" : undefined}
-                        className="user-dropdown-theme-button"
-                        data-status={mode === themeMode ? "active" : undefined}
-                        title={label}
-                        onClick={() => setThemeMode(themeMode)}
-                      >
-                        <Icon size={15} aria-hidden="true" />
-                        <span className="sr-only">{label}</span>
-                      </DropdownMenuItem>
-                    ))}
-                  </div>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem onClick={() => void signOut()}>Sign out</DropdownMenuItem>
+                    <div className="user-dropdown-appearance-row">
+                      <span className="user-dropdown-appearance-label">
+                        <Palette size={14} aria-hidden="true" />
+                        Appearance
+                      </span>
+                      <div className="user-dropdown-theme-row" role="group" aria-label="Theme">
+                        {THEME_MODE_ITEMS.map(({ mode: themeMode, label, Icon }) => (
+                          <DropdownMenuItem
+                            key={themeMode}
+                            aria-label={label}
+                            aria-current={mode === themeMode ? "true" : undefined}
+                            className="user-dropdown-theme-button"
+                            data-status={mode === themeMode ? "active" : undefined}
+                            title={label}
+                            onClick={() => setThemeMode(themeMode)}
+                          >
+                            <Icon size={15} aria-hidden="true" />
+                            <span className="sr-only">{label}</span>
+                          </DropdownMenuItem>
+                        ))}
+                      </div>
+                    </div>
+                    <DropdownMenuItem
+                      className="user-dropdown-account-action"
+                      onClick={() => void signOut()}
+                    >
+                      <LogOut size={14} aria-hidden="true" />
+                      Sign out
+                    </DropdownMenuItem>
+                  </section>
                 </DropdownMenuContent>
               </DropdownMenu>
             ) : isAuthResolving ? (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -813,14 +813,6 @@ export default function Header() {
                     ) : null}
                   </div>
                   <DropdownMenuSeparator />
-                  {!isPersonalPublisher ? (
-                    <DropdownMenuItem asChild className="user-dropdown-account-action">
-                      <Link to="/stars" className="flex items-center gap-2">
-                        <Star size={14} aria-hidden="true" />
-                        Stars
-                      </Link>
-                    </DropdownMenuItem>
-                  ) : null}
                   <div className="user-dropdown-appearance-row">
                     <span className="user-dropdown-appearance-label">
                       <Palette size={14} aria-hidden="true" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,28 +1,24 @@
 import { useAuthActions } from "@convex-dev/auth/react";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
-import { useQuery } from "convex/react";
 import {
   ArrowRight,
-  Building2,
   Check,
   ChevronDown,
   Command,
-  LayoutDashboard,
   LogOut,
   Menu,
   Monitor,
   Moon,
   MoreHorizontal,
   Palette,
+  Plus,
   Search,
   Settings,
   Star,
   Sun,
-  UserRound,
   X,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { api } from "../../convex/_generated/api";
 import { useActivePublisher } from "../lib/activePublisher";
 import {
   getUserFacingAuthError,
@@ -127,8 +123,10 @@ export default function Header() {
   const {
     activePublisher,
     activePublisherId,
+    canManageActivePublisher,
     hasMultiplePublishers,
     memberships: publisherMemberships,
+    personalPublisher,
     setActivePublisherId,
   } = useActivePublisher();
   const { signIn, signOut } = useAuthActions();
@@ -141,21 +139,48 @@ export default function Header() {
   const initial = (me?.displayName ?? me?.name ?? rawHandle).charAt(0).toUpperCase();
   const triggerPublisher = activePublisher?.publisher;
   const triggerHandle = triggerPublisher?.handle ?? rawHandle;
-  const triggerLabel = triggerHandle.length > 25 ? `${triggerHandle.slice(0, 25)}…` : triggerHandle;
+  const triggerLabel =
+    triggerHandle.length > 26
+      ? `${triggerHandle.slice(0, 14)}…${triggerHandle.slice(-7)}`
+      : triggerHandle;
   const isAuthResolving = isLoading || (isAuthenticated && me === undefined);
-  const profileHandle = useQuery(
-    api.publishers.getMyProfileHandle,
-    isAuthenticated && me ? {} : "skip",
-  );
-  const activeOrgProfileHandle =
-    triggerPublisher?.kind === "org" ? triggerPublisher.handle : null;
-  const menuProfileHandle = activeOrgProfileHandle ?? profileHandle;
-  const activePublisherMeta =
-    triggerPublisher?.kind === "org"
-      ? `Org${activePublisher?.role ? ` · ${activePublisher.role}` : ""}`
-      : "Personal";
-  const otherPublisherMemberships =
-    publisherMemberships?.filter((entry) => entry.publisher._id !== activePublisherId) ?? [];
+  const roleLabel = (role: string | undefined) =>
+    role ? `${role.charAt(0).toUpperCase()}${role.slice(1)}` : "";
+  const membershipMeta = (entry: typeof activePublisher) => {
+    if (!entry) return "Personal publisher";
+    return entry.publisher.kind === "org"
+      ? `Organization · ${roleLabel(entry.role)}`
+      : "Personal publisher";
+  };
+  const activePublisherMeta = membershipMeta(activePublisher);
+  const otherPublisherMemberships = useMemo(() => {
+    return (publisherMemberships ?? [])
+      .filter((entry) => entry.publisher._id !== activePublisherId)
+      .sort((left, right) => {
+        if (left.publisher.kind !== right.publisher.kind) {
+          return left.publisher.kind === "user" ? -1 : 1;
+        }
+        return left.publisher.handle.localeCompare(right.publisher.handle);
+      });
+  }, [activePublisherId, publisherMemberships]);
+  const goToOrganizationCreation = () => {
+    if (personalPublisher) {
+      setActivePublisherId(personalPublisher.publisher._id);
+    }
+    void navigate({
+      to: "/settings",
+      search: { view: "organizations" },
+    });
+  };
+  const goToAccountSettings = () => {
+    if (personalPublisher) {
+      setActivePublisherId(personalPublisher.publisher._id);
+    }
+    void navigate({
+      to: "/settings",
+      search: { view: "profile" },
+    });
+  };
   const [navSearchQuery, setNavSearchQuery] = useState("");
   const [typeaheadOpen, setTypeaheadOpen] = useState(false);
   const [typeaheadTab, setTypeaheadTab] = useState<TypeaheadTab>("skills");
@@ -587,180 +612,209 @@ export default function Header() {
               <NavbarThemeSwitcher mode={mode} onSetMode={setThemeMode} />
             ) : null}
             {isAuthenticated && me ? (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <button
-                    className="user-trigger"
-                    type="button"
-                    aria-label={`Open account menu for @${triggerHandle}`}
-                  >
-                    {triggerPublisher ? (
-                      <span className="user-menu-publisher-icon" aria-hidden="true">
-                        <MarketplaceIcon
-                          kind={triggerPublisher.kind}
-                          label={triggerPublisher.displayName || triggerPublisher.handle}
-                          imageUrl={triggerPublisher.image}
-                          size="xs"
-                        />
-                      </span>
-                    ) : avatar ? (
-                      <img src={avatar} alt={me.displayName ?? me.name ?? "User avatar"} />
-                    ) : (
-                      <span className="user-menu-fallback">{initial}</span>
-                    )}
-                    <span className="user-trigger-handle truncate">@{triggerLabel}</span>
-                    <ChevronDown className="user-menu-chevron" size={16} />
-                  </button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="user-dropdown-content">
-                  <div className="user-dropdown-section-label">Publisher</div>
-                  <section
-                    aria-label={`Current publisher @${triggerHandle}`}
-                    className="user-dropdown-active-card"
-                  >
-                    <div className="user-dropdown-active-header">
-                      <span className="user-dropdown-active-icon" aria-hidden="true">
-                        {triggerPublisher ? (
+              <>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      className="user-trigger publisher-trigger"
+                      type="button"
+                      aria-label={`Open publisher switcher for @${triggerHandle}`}
+                      title={`Acting as @${triggerHandle}`}
+                    >
+                      {triggerPublisher ? (
+                        <span className="user-menu-publisher-icon" aria-hidden="true">
                           <MarketplaceIcon
                             kind={triggerPublisher.kind}
                             label={triggerPublisher.displayName || triggerPublisher.handle}
                             imageUrl={triggerPublisher.image}
                             size="xs"
                           />
-                        ) : avatar ? (
-                          <img src={avatar} alt="" />
-                        ) : (
-                          <span className="user-menu-fallback">{initial}</span>
-                        )}
-                      </span>
-                      <span className="user-dropdown-publisher-copy">
-                        <span className="user-dropdown-publisher-title">@{triggerHandle}</span>
-                        <span className="user-dropdown-publisher-meta">{activePublisherMeta}</span>
-                      </span>
-                      <Check
-                        className="user-dropdown-publisher-check"
-                        size={16}
-                        aria-label="Selected publisher"
-                      />
-                    </div>
-                    <div
-                      aria-label={`Publisher actions for @${triggerHandle}`}
-                      className="user-dropdown-active-actions"
+                        </span>
+                      ) : avatar ? (
+                        <img src={avatar} alt={me.displayName ?? me.name ?? "User avatar"} />
+                      ) : (
+                        <span className="user-menu-fallback">{initial}</span>
+                      )}
+                      <span className="user-trigger-handle truncate">@{triggerLabel}</span>
+                      <ChevronDown className="user-menu-chevron" size={16} />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="user-dropdown-content publisher-dropdown-content">
+                    <div className="user-dropdown-section-label">Current publisher</div>
+                    <section
+                      aria-label={`Current publisher @${triggerHandle}`}
+                      className="publisher-current-section"
                     >
-                      {menuProfileHandle ? (
-                        <DropdownMenuItem asChild className="user-dropdown-scoped-action">
-                          <Link
-                            to="/user/$handle"
-                            params={{ handle: menuProfileHandle }}
-                            className="flex items-center gap-2"
-                          >
-                            {triggerPublisher?.kind === "org" ? (
-                              <Building2 size={14} aria-hidden="true" />
-                            ) : (
-                              <UserRound size={14} aria-hidden="true" />
-                            )}
-                            Profile
+                      <div className="publisher-current-row">
+                        <span className="user-dropdown-publisher-icon" aria-hidden="true">
+                          {triggerPublisher ? (
+                            <MarketplaceIcon
+                              kind={triggerPublisher.kind}
+                              label={triggerPublisher.displayName || triggerPublisher.handle}
+                              imageUrl={triggerPublisher.image}
+                              size="xs"
+                            />
+                          ) : avatar ? (
+                            <img
+                              className="user-dropdown-account-avatar"
+                              src={avatar}
+                              alt=""
+                            />
+                          ) : (
+                            <span className="user-dropdown-account-avatar user-dropdown-account-fallback">
+                              {initial}
+                            </span>
+                          )}
+                        </span>
+                        <span className="user-dropdown-publisher-copy">
+                          <span className="user-dropdown-publisher-title">@{triggerHandle}</span>
+                          <span className="user-dropdown-publisher-meta">
+                            {activePublisherMeta}
+                          </span>
+                        </span>
+                        <Check
+                          className="user-dropdown-publisher-check"
+                          size={16}
+                          aria-label="Selected publisher"
+                        />
+                      </div>
+                      {canManageActivePublisher ? (
+                        <DropdownMenuItem asChild className="publisher-manage-action">
+                          <Link to="/settings" className="flex items-center gap-2">
+                            <Settings size={14} aria-hidden="true" />
+                            Manage publisher…
                           </Link>
                         </DropdownMenuItem>
                       ) : null}
-                      <DropdownMenuItem asChild className="user-dropdown-scoped-action">
-                        <Link to="/dashboard" className="flex items-center gap-2">
-                          <LayoutDashboard size={14} aria-hidden="true" />
-                          Dashboard
-                        </Link>
-                      </DropdownMenuItem>
-                      <DropdownMenuItem asChild className="user-dropdown-scoped-action">
-                        <Link to="/settings" className="flex items-center gap-2">
-                          <Settings size={14} aria-hidden="true" />
-                          Settings
-                        </Link>
-                      </DropdownMenuItem>
-                    </div>
-                  </section>
-                  {hasMultiplePublishers && otherPublisherMemberships.length > 0 ? (
-                    <>
-                      <DropdownMenuSeparator />
-                      <div className="user-dropdown-section-label">Switch publisher</div>
-                      <div className="user-dropdown-publisher-list" aria-label="Switch publisher">
-                        {otherPublisherMemberships.map((entry) => (
-                          <DropdownMenuItem
-                            key={entry.publisher._id}
-                            aria-label={`Switch to @${entry.publisher.handle}`}
-                            className="user-dropdown-publisher-item"
-                            onClick={() => setActivePublisherId(entry.publisher._id)}
-                          >
-                            <span className="user-dropdown-publisher-icon" aria-hidden="true">
-                              <MarketplaceIcon
-                                kind={entry.publisher.kind}
-                                label={entry.publisher.displayName || entry.publisher.handle}
-                                imageUrl={entry.publisher.image}
-                                size="xs"
-                              />
-                            </span>
-                            <span className="user-dropdown-publisher-copy">
-                              <span className="user-dropdown-publisher-title">
-                                @{entry.publisher.handle}
+                    </section>
+                    {hasMultiplePublishers && otherPublisherMemberships.length > 0 ? (
+                      <>
+                        <DropdownMenuSeparator />
+                        <div className="user-dropdown-section-label">Switch publisher</div>
+                        <div className="user-dropdown-publisher-list" aria-label="Switch publisher">
+                          {otherPublisherMemberships.map((entry) => (
+                            <DropdownMenuItem
+                              key={entry.publisher._id}
+                              aria-label={`Switch to @${entry.publisher.handle}`}
+                              className="user-dropdown-publisher-item"
+                              onClick={() => setActivePublisherId(entry.publisher._id)}
+                            >
+                              <span className="user-dropdown-publisher-icon" aria-hidden="true">
+                                <MarketplaceIcon
+                                  kind={entry.publisher.kind}
+                                  label={entry.publisher.displayName || entry.publisher.handle}
+                                  imageUrl={entry.publisher.image}
+                                  size="xs"
+                                />
                               </span>
-                              <span className="user-dropdown-publisher-meta">
-                                {entry.publisher.kind === "org" ? `Org · ${entry.role}` : "Personal"}
+                              <span className="user-dropdown-publisher-copy">
+                                <span className="user-dropdown-publisher-title">
+                                  @{entry.publisher.handle}
+                                </span>
+                                <span className="user-dropdown-publisher-meta">
+                                  {membershipMeta(entry)}
+                                </span>
                               </span>
-                            </span>
-                          </DropdownMenuItem>
-                        ))}
-                      </div>
-                    </>
-                  ) : null}
-                  <DropdownMenuSeparator />
-                  <div className="user-dropdown-section-label">Account</div>
-                  <section
-                    aria-label={`Account @${rawHandle}`}
-                    className="user-dropdown-account-section"
-                  >
-                    <div
-                      aria-label={`Signed-in account @${rawHandle}`}
-                      className="user-dropdown-account-identity"
+                            </DropdownMenuItem>
+                          ))}
+                        </div>
+                      </>
+                    ) : null}
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      className="publisher-create-action"
+                      onClick={goToOrganizationCreation}
+                    >
+                      <Plus size={14} aria-hidden="true" />
+                      Create organization…
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      className="account-trigger"
+                      type="button"
+                      aria-label={`Open account menu for @${rawHandle}`}
+                      title={`Account @${rawHandle}`}
                     >
                       {avatar ? (
-                        <img
-                          className="user-dropdown-account-avatar"
-                          src={avatar}
-                          alt={me.displayName ?? me.name ?? "User avatar"}
-                        />
+                        <img src={avatar} alt={me.displayName ?? me.name ?? "User avatar"} />
                       ) : (
-                        <span className="user-dropdown-account-avatar user-dropdown-account-fallback">
-                          {initial}
-                        </span>
+                        <span className="user-menu-fallback">{initial}</span>
                       )}
-                      <span className="user-dropdown-account-handle">@{rawHandle}</span>
-                    </div>
-                    <DropdownMenuItem asChild className="user-dropdown-account-action">
-                      <Link to="/stars" className="flex items-center gap-2">
-                        <Star size={14} aria-hidden="true" />
-                        Stars
-                      </Link>
-                    </DropdownMenuItem>
-                    <div className="user-dropdown-appearance-row">
-                      <span className="user-dropdown-appearance-label">
-                        <Palette size={14} aria-hidden="true" />
-                        Appearance
-                      </span>
-                      <div className="user-dropdown-theme-row" role="group" aria-label="Theme">
-                        {THEME_MODE_ITEMS.map(({ mode: themeMode, label, Icon }) => (
-                          <DropdownMenuItem
-                            key={themeMode}
-                            aria-label={label}
-                            aria-current={mode === themeMode ? "true" : undefined}
-                            className="user-dropdown-theme-button"
-                            data-status={mode === themeMode ? "active" : undefined}
-                            title={label}
-                            onClick={() => setThemeMode(themeMode)}
-                          >
-                            <Icon size={15} aria-hidden="true" />
-                            <span className="sr-only">{label}</span>
-                          </DropdownMenuItem>
-                        ))}
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="user-dropdown-content account-dropdown-content">
+                    <div className="user-dropdown-section-label">Signed in as</div>
+                    <section
+                      aria-label={`Account @${rawHandle}`}
+                      className="user-dropdown-account-section"
+                    >
+                      <div
+                        aria-label={`Signed-in account @${rawHandle}`}
+                        className="user-dropdown-account-identity"
+                      >
+                        {avatar ? (
+                          <img
+                            className="user-dropdown-account-avatar"
+                            src={avatar}
+                            alt={me.displayName ?? me.name ?? "User avatar"}
+                          />
+                        ) : (
+                          <span className="user-dropdown-account-avatar user-dropdown-account-fallback">
+                            {initial}
+                          </span>
+                        )}
+                        <span className="user-dropdown-account-copy">
+                          <span className="user-dropdown-account-name">
+                            {me.displayName ?? me.name ?? rawHandle}
+                          </span>
+                          <span className="user-dropdown-account-handle">@{rawHandle}</span>
+                        </span>
                       </div>
-                    </div>
+                      <DropdownMenuItem
+                        className="user-dropdown-account-action"
+                        onClick={goToAccountSettings}
+                      >
+                        <Settings size={14} aria-hidden="true" />
+                        Account settings
+                      </DropdownMenuItem>
+                    </section>
+                    <DropdownMenuSeparator />
+                    <div className="user-dropdown-section-label">App</div>
+                    <section className="user-dropdown-account-section" aria-label="App actions">
+                      <DropdownMenuItem asChild className="user-dropdown-account-action">
+                        <Link to="/stars" className="flex items-center gap-2">
+                          <Star size={14} aria-hidden="true" />
+                          Stars
+                        </Link>
+                      </DropdownMenuItem>
+                      <div className="user-dropdown-appearance-row">
+                        <span className="user-dropdown-appearance-label">
+                          <Palette size={14} aria-hidden="true" />
+                          Appearance
+                        </span>
+                        <div className="user-dropdown-theme-row" role="group" aria-label="Theme">
+                          {THEME_MODE_ITEMS.map(({ mode: themeMode, label, Icon }) => (
+                            <DropdownMenuItem
+                              key={themeMode}
+                              aria-label={label}
+                              aria-current={mode === themeMode ? "true" : undefined}
+                              className="user-dropdown-theme-button"
+                              data-status={mode === themeMode ? "active" : undefined}
+                              title={label}
+                              onClick={() => setThemeMode(themeMode)}
+                            >
+                              <Icon size={15} aria-hidden="true" />
+                              <span className="sr-only">{label}</span>
+                            </DropdownMenuItem>
+                          ))}
+                        </div>
+                      </div>
+                    </section>
+                    <DropdownMenuSeparator />
+                    <div className="user-dropdown-section-label">Session</div>
                     <DropdownMenuItem
                       className="user-dropdown-account-action"
                       onClick={() => void signOut()}
@@ -768,9 +822,9 @@ export default function Header() {
                       <LogOut size={14} aria-hidden="true" />
                       Sign out
                     </DropdownMenuItem>
-                  </section>
-                </DropdownMenuContent>
-              </DropdownMenu>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </>
             ) : isAuthResolving ? (
               <div className="github-sign-in-button auth-loading-placeholder" aria-hidden="true" />
             ) : (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,6 +15,7 @@ import {
   Moon,
   MoreHorizontal,
   Palette,
+  Plus,
   Search,
   Settings,
   Star,
@@ -133,6 +134,7 @@ export default function Header() {
     activePublisherId,
     hasMultiplePublishers,
     memberships: publisherMemberships,
+    personalPublisher,
     setActivePublisherId,
   } = useActivePublisher();
   const { signIn, signOut } = useAuthActions();
@@ -154,6 +156,7 @@ export default function Header() {
   const activeOrgProfileHandle =
     triggerPublisher?.kind === "org" ? triggerPublisher.handle : null;
   const menuProfileHandle = activeOrgProfileHandle ?? profileHandle;
+  const isPersonalPublisher = triggerPublisher?.kind !== "org";
   const formatPublisherRole = (role: string | undefined) =>
     role ? `${role.charAt(0).toUpperCase()}${role.slice(1)}` : "";
   const formatPublisherMeta = (entry: typeof activePublisher) => {
@@ -165,6 +168,15 @@ export default function Header() {
     triggerPublisher?.kind === "org" ? formatPublisherMeta(activePublisher) : "Personal";
   const otherPublisherMemberships =
     publisherMemberships?.filter((entry) => entry.publisher._id !== activePublisherId) ?? [];
+  const goToOrganizationCreation = () => {
+    if (personalPublisher) {
+      setActivePublisherId(personalPublisher.publisher._id);
+    }
+    void navigate({
+      to: "/settings",
+      search: { view: "organizations" },
+    });
+  };
   const [navSearchQuery, setNavSearchQuery] = useState("");
   const [typeaheadOpen, setTypeaheadOpen] = useState(false);
   const [typeaheadTab, setTypeaheadTab] = useState<TypeaheadTab>("skills");
@@ -716,6 +728,14 @@ export default function Header() {
                             </DropdownMenuItem>
                           ))}
                         </div>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          className="user-dropdown-create-org-action"
+                          onClick={goToOrganizationCreation}
+                        >
+                          <Plus size={14} aria-hidden="true" />
+                          Create organization
+                        </DropdownMenuItem>
                       </DropdownMenuSubContent>
                     </DropdownMenuSub>
                   ) : (
@@ -782,6 +802,14 @@ export default function Header() {
                         Settings
                       </Link>
                     </DropdownMenuItem>
+                    {isPersonalPublisher ? (
+                      <DropdownMenuItem asChild className="user-dropdown-scoped-action">
+                        <Link to="/stars" className="flex items-center gap-2">
+                          <Star size={14} aria-hidden="true" />
+                          Stars
+                        </Link>
+                      </DropdownMenuItem>
+                    ) : null}
                   </div>
                   <DropdownMenuSeparator />
                   <DropdownMenuSub>
@@ -812,12 +840,14 @@ export default function Header() {
                         <span className="user-dropdown-account-handle">@{rawHandle}</span>
                       </div>
                       <DropdownMenuSeparator />
-                      <DropdownMenuItem asChild className="user-dropdown-account-action">
-                        <Link to="/stars" className="flex items-center gap-2">
-                          <Star size={14} aria-hidden="true" />
-                          Stars
-                        </Link>
-                      </DropdownMenuItem>
+                      {!isPersonalPublisher ? (
+                        <DropdownMenuItem asChild className="user-dropdown-account-action">
+                          <Link to="/stars" className="flex items-center gap-2">
+                            <Star size={14} aria-hidden="true" />
+                            Stars
+                          </Link>
+                        </DropdownMenuItem>
+                      ) : null}
                       <div className="user-dropdown-appearance-row">
                         <span className="user-dropdown-appearance-label">
                           <Palette size={14} aria-hidden="true" />
@@ -840,15 +870,16 @@ export default function Header() {
                           ))}
                         </div>
                       </div>
-                      <DropdownMenuItem
-                        className="user-dropdown-account-action"
-                        onClick={() => void signOut()}
-                      >
-                        <LogOut size={14} aria-hidden="true" />
-                        Sign out
-                      </DropdownMenuItem>
                     </DropdownMenuSubContent>
                   </DropdownMenuSub>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    className="user-dropdown-account-action"
+                    onClick={() => void signOut()}
+                  >
+                    <LogOut size={14} aria-hidden="true" />
+                    Sign out
+                  </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
             ) : isAuthResolving ? (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useNavigate } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
 import {
   ArrowRight,
+  Check,
   ChevronDown,
   Command,
   LayoutDashboard,
@@ -19,6 +20,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../../convex/_generated/api";
+import { useActivePublisher } from "../lib/activePublisher";
 import {
   getUserFacingAuthError,
   isBannedAccountAuthError,
@@ -119,6 +121,13 @@ type TypeaheadItem =
 
 export default function Header() {
   const { isAuthenticated, isLoading, me } = useAuthStatus();
+  const {
+    activePublisher,
+    activePublisherId,
+    hasMultiplePublishers,
+    memberships: publisherMemberships,
+    setActivePublisherId,
+  } = useActivePublisher();
   const { signIn, signOut } = useAuthActions();
   const { theme, mode, setMode } = useThemeMode();
   const navigate = useNavigate();
@@ -128,6 +137,9 @@ export default function Header() {
   const rawHandle = me?.handle ?? me?.displayName ?? "user";
   const handle = rawHandle.length > 25 ? `${rawHandle.slice(0, 25)}…` : rawHandle;
   const initial = (me?.displayName ?? me?.name ?? rawHandle).charAt(0).toUpperCase();
+  const triggerPublisher = activePublisher?.publisher;
+  const triggerHandle = triggerPublisher?.handle ?? rawHandle;
+  const triggerLabel = triggerHandle.length > 25 ? `${triggerHandle.slice(0, 25)}…` : triggerHandle;
   const isAuthResolving = isLoading || (isAuthenticated && me === undefined);
   const profileHandle = useQuery(
     api.publishers.getMyProfileHandle,
@@ -566,17 +578,77 @@ export default function Header() {
             {isAuthenticated && me ? (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <button className="user-trigger" type="button">
-                    {avatar ? (
+                  <button
+                    className="user-trigger"
+                    type="button"
+                    aria-label={`Open account menu for @${triggerHandle}`}
+                  >
+                    {triggerPublisher ? (
+                      <span className="user-menu-publisher-icon" aria-hidden="true">
+                        <MarketplaceIcon
+                          kind={triggerPublisher.kind}
+                          label={triggerPublisher.displayName || triggerPublisher.handle}
+                          imageUrl={triggerPublisher.image}
+                          size="xs"
+                        />
+                      </span>
+                    ) : avatar ? (
                       <img src={avatar} alt={me.displayName ?? me.name ?? "User avatar"} />
                     ) : (
                       <span className="user-menu-fallback">{initial}</span>
                     )}
-                    <span className="user-trigger-handle truncate">@{handle}</span>
+                    <span className="user-trigger-handle truncate">@{triggerLabel}</span>
                     <ChevronDown className="user-menu-chevron" size={16} />
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="user-dropdown-content">
+                  {hasMultiplePublishers && publisherMemberships ? (
+                    <>
+                      <div className="user-dropdown-publisher-list" aria-label="Active publisher">
+                        {publisherMemberships.map((entry) => {
+                          const active = entry.publisher._id === activePublisherId;
+                          return (
+                            <DropdownMenuItem
+                              key={entry.publisher._id}
+                              aria-current={active ? "true" : undefined}
+                              className="user-dropdown-publisher-item"
+                              data-status={active ? "active" : undefined}
+                              onClick={() => setActivePublisherId(entry.publisher._id)}
+                            >
+                              <span className="user-dropdown-publisher-icon" aria-hidden="true">
+                                <MarketplaceIcon
+                                  kind={entry.publisher.kind}
+                                  label={entry.publisher.displayName || entry.publisher.handle}
+                                  imageUrl={entry.publisher.image}
+                                  size="xs"
+                                />
+                              </span>
+                              <span className="user-dropdown-publisher-copy">
+                                <span className="user-dropdown-publisher-title">
+                                  @{entry.publisher.handle}
+                                </span>
+                                <span className="user-dropdown-publisher-meta">
+                                  {entry.publisher.kind === "org" ? "Org" : "Personal"} ·{" "}
+                                  {entry.role}
+                                </span>
+                              </span>
+                              {active ? (
+                                <Check
+                                  className="user-dropdown-publisher-check"
+                                  size={15}
+                                  aria-hidden="true"
+                                />
+                              ) : null}
+                            </DropdownMenuItem>
+                          );
+                        })}
+                      </div>
+                      {activePublisher?.publisher.kind === "org" ? (
+                        <div className="user-dropdown-signed-in">Signed in as @{handle}</div>
+                      ) : null}
+                      <DropdownMenuSeparator />
+                    </>
+                  ) : null}
                   {profileHandle ? (
                     <DropdownMenuItem asChild>
                       <Link

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -135,7 +135,6 @@ export default function Header() {
 
   const avatar = me?.image ?? (me?.email ? gravatarUrl(me.email) : undefined);
   const rawHandle = me?.handle ?? me?.displayName ?? "user";
-  const handle = rawHandle.length > 25 ? `${rawHandle.slice(0, 25)}…` : rawHandle;
   const initial = (me?.displayName ?? me?.name ?? rawHandle).charAt(0).toUpperCase();
   const triggerPublisher = activePublisher?.publisher;
   const triggerHandle = triggerPublisher?.handle ?? rawHandle;
@@ -643,9 +642,6 @@ export default function Header() {
                           );
                         })}
                       </div>
-                      {activePublisher?.publisher.kind === "org" ? (
-                        <div className="user-dropdown-signed-in">Signed in as @{handle}</div>
-                      ) : null}
                       <DropdownMenuSeparator />
                     </>
                   ) : null}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,6 +6,7 @@ import {
   Building2,
   Check,
   ChevronDown,
+  ChevronLeft,
   ChevronRight,
   Command,
   LayoutDashboard,
@@ -49,9 +50,6 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
 import {
@@ -185,6 +183,7 @@ export default function Header() {
   const [typeaheadActiveIndex, setTypeaheadActiveIndex] = useState(0);
   const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [publisherSwitcherOpen, setPublisherSwitcherOpen] = useState(false);
   const [headerScrolled, setHeaderScrolled] = useState(false);
   const searchWrapRef = useRef<HTMLDivElement | null>(null);
   const mobileSearchWrapRef = useRef<HTMLDivElement | null>(null);
@@ -400,6 +399,78 @@ export default function Header() {
     }
   };
 
+  const publisherSwitcherContent = (
+    <>
+      <button
+        type="button"
+        className="user-dropdown-switcher-back"
+        onClick={() => setPublisherSwitcherOpen(false)}
+      >
+        <ChevronLeft size={14} aria-hidden="true" />
+        Back
+      </button>
+      <div className="user-dropdown-publisher-list" aria-label="Switch publisher">
+        {activePublisher ? (
+          <div
+            aria-label={`Selected publisher @${activePublisher.publisher.handle}`}
+            className="user-dropdown-publisher-item user-dropdown-publisher-item-current"
+          >
+            <span className="user-dropdown-publisher-icon" aria-hidden="true">
+              <MarketplaceIcon
+                kind={activePublisher.publisher.kind}
+                label={activePublisher.publisher.displayName || activePublisher.publisher.handle}
+                imageUrl={activePublisher.publisher.image}
+                size="xs"
+              />
+            </span>
+            <span className="user-dropdown-publisher-copy">
+              <span className="user-dropdown-publisher-title">
+                @{activePublisher.publisher.handle}
+              </span>
+              <span className="user-dropdown-publisher-meta">
+                {formatPublisherMeta(activePublisher)}
+              </span>
+            </span>
+            <Check
+              className="user-dropdown-publisher-check"
+              size={16}
+              aria-label="Selected publisher"
+            />
+          </div>
+        ) : null}
+        {otherPublisherMemberships.map((entry) => (
+          <DropdownMenuItem
+            key={entry.publisher._id}
+            aria-label={`Switch to @${entry.publisher.handle}`}
+            className="user-dropdown-publisher-item"
+            onClick={() => setActivePublisherId(entry.publisher._id)}
+          >
+            <span className="user-dropdown-publisher-icon" aria-hidden="true">
+              <MarketplaceIcon
+                kind={entry.publisher.kind}
+                label={entry.publisher.displayName || entry.publisher.handle}
+                imageUrl={entry.publisher.image}
+                size="xs"
+              />
+            </span>
+            <span className="user-dropdown-publisher-copy">
+              <span className="user-dropdown-publisher-title">@{entry.publisher.handle}</span>
+              <span className="user-dropdown-publisher-meta">{formatPublisherMeta(entry)}</span>
+            </span>
+          </DropdownMenuItem>
+        ))}
+      </div>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem
+        className="user-dropdown-create-org-action"
+        onClick={goToOrganizationCreation}
+      >
+        <Plus size={14} aria-hidden="true" />
+        Create organization
+      </DropdownMenuItem>
+    </>
+  );
+
   return (
     <header className={`navbar navbar-calm${headerScrolled ? " navbar-calm-scrolled" : ""}`}>
       <div className="navbar-inner">
@@ -610,7 +681,11 @@ export default function Header() {
               <NavbarThemeSwitcher mode={mode} onSetMode={setThemeMode} />
             ) : null}
             {isAuthenticated && me ? (
-              <DropdownMenu>
+              <DropdownMenu
+                onOpenChange={(open) => {
+                  if (!open) setPublisherSwitcherOpen(false);
+                }}
+              >
                 <DropdownMenuTrigger asChild>
                   <button
                     className="user-trigger"
@@ -636,11 +711,16 @@ export default function Header() {
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="user-dropdown-content">
-                  {hasMultiplePublishers && otherPublisherMemberships.length > 0 ? (
-                    <DropdownMenuSub>
-                      <DropdownMenuSubTrigger
+                  {publisherSwitcherOpen ? (
+                    publisherSwitcherContent
+                  ) : (
+                    <>
+                      {hasMultiplePublishers && otherPublisherMemberships.length > 0 ? (
+                      <button
+                        type="button"
                         aria-label={`Current publisher @${triggerHandle}`}
                         className="user-dropdown-current-trigger"
+                        onClick={() => setPublisherSwitcherOpen(true)}
                       >
                         <span className="user-dropdown-publisher-icon" aria-hidden="true">
                           {triggerPublisher ? (
@@ -651,11 +731,7 @@ export default function Header() {
                               size="xs"
                             />
                           ) : avatar ? (
-                            <img
-                              className="user-dropdown-account-avatar"
-                              src={avatar}
-                              alt=""
-                            />
+                            <img className="user-dropdown-account-avatar" src={avatar} alt="" />
                           ) : (
                             <span className="user-dropdown-account-avatar user-dropdown-account-fallback">
                               {initial}
@@ -669,79 +745,9 @@ export default function Header() {
                           </span>
                         </span>
                         <ChevronRight className="user-dropdown-submenu-chevron" size={16} />
-                      </DropdownMenuSubTrigger>
-                      <DropdownMenuSubContent className="user-dropdown-subcontent user-dropdown-switcher-subcontent">
-                        <div className="user-dropdown-section-label">Switch publisher</div>
-                        <div className="user-dropdown-publisher-list" aria-label="Switch publisher">
-                          {activePublisher ? (
-                            <div
-                              aria-label={`Selected publisher @${activePublisher.publisher.handle}`}
-                              className="user-dropdown-publisher-item user-dropdown-publisher-item-current"
-                            >
-                              <span className="user-dropdown-publisher-icon" aria-hidden="true">
-                                <MarketplaceIcon
-                                  kind={activePublisher.publisher.kind}
-                                  label={
-                                    activePublisher.publisher.displayName ||
-                                    activePublisher.publisher.handle
-                                  }
-                                  imageUrl={activePublisher.publisher.image}
-                                  size="xs"
-                                />
-                              </span>
-                              <span className="user-dropdown-publisher-copy">
-                                <span className="user-dropdown-publisher-title">
-                                  @{activePublisher.publisher.handle}
-                                </span>
-                                <span className="user-dropdown-publisher-meta">
-                                  {formatPublisherMeta(activePublisher)}
-                                </span>
-                              </span>
-                              <Check
-                                className="user-dropdown-publisher-check"
-                                size={16}
-                                aria-label="Selected publisher"
-                              />
-                            </div>
-                          ) : null}
-                          {otherPublisherMemberships.map((entry) => (
-                            <DropdownMenuItem
-                              key={entry.publisher._id}
-                              aria-label={`Switch to @${entry.publisher.handle}`}
-                              className="user-dropdown-publisher-item"
-                              onClick={() => setActivePublisherId(entry.publisher._id)}
-                            >
-                              <span className="user-dropdown-publisher-icon" aria-hidden="true">
-                                <MarketplaceIcon
-                                  kind={entry.publisher.kind}
-                                  label={entry.publisher.displayName || entry.publisher.handle}
-                                  imageUrl={entry.publisher.image}
-                                  size="xs"
-                                />
-                              </span>
-                              <span className="user-dropdown-publisher-copy">
-                                <span className="user-dropdown-publisher-title">
-                                  @{entry.publisher.handle}
-                                </span>
-                                <span className="user-dropdown-publisher-meta">
-                                  {formatPublisherMeta(entry)}
-                                </span>
-                              </span>
-                            </DropdownMenuItem>
-                          ))}
-                        </div>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem
-                          className="user-dropdown-create-org-action"
-                          onClick={goToOrganizationCreation}
-                        >
-                          <Plus size={14} aria-hidden="true" />
-                          Create organization
-                        </DropdownMenuItem>
-                      </DropdownMenuSubContent>
-                    </DropdownMenuSub>
-                  ) : (
-                    <div
+                      </button>
+                      ) : (
+                        <div
                       aria-label={`Current publisher @${triggerHandle}`}
                       className="user-dropdown-current-trigger user-dropdown-current-static"
                     >
@@ -770,7 +776,7 @@ export default function Header() {
                         <span className="user-dropdown-publisher-meta">{activePublisherMeta}</span>
                       </span>
                     </div>
-                  )}
+                      )}
                   <DropdownMenuSeparator />
                   <div
                     aria-label={`Publisher actions for @${triggerHandle}`}
@@ -844,6 +850,8 @@ export default function Header() {
                     <LogOut size={14} aria-hidden="true" />
                     Sign out
                   </DropdownMenuItem>
+                    </>
+                  )}
                 </DropdownMenuContent>
               </DropdownMenu>
             ) : isAuthResolving ? (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -152,7 +152,6 @@ export default function Header() {
       ? triggerPublisher.displayName
       : `@${triggerHandle}`;
   const triggerLabel = triggerTitle.length > 25 ? `${triggerTitle.slice(0, 25)}…` : triggerTitle;
-  const accountHandle = me?.handle ?? rawHandle;
   const isAuthResolving = isLoading || (isAuthenticated && me === undefined);
   const profileHandle = useQuery(
     api.publishers.getMyProfileHandle,
@@ -169,22 +168,6 @@ export default function Header() {
   };
   const activePublisherMeta =
     triggerPublisher?.kind === "org" ? formatPublisherMeta(activePublisher) : "Personal";
-  const activePublisherManagingRow =
-    triggerPublisher?.kind === "org" ? (
-      <div className="user-dropdown-managing-row">
-        <span className="user-dropdown-managing-label">Managing as</span>
-        <span className="user-dropdown-managing-account">
-          {avatar ? (
-            <img className="user-dropdown-managing-avatar" src={avatar} alt="" />
-          ) : (
-            <span className="user-dropdown-managing-avatar user-dropdown-managing-avatar-fallback">
-              <UserRound size={9} aria-hidden="true" />
-            </span>
-          )}
-          <span className="user-dropdown-managing-handle">@{accountHandle}</span>
-        </span>
-      </div>
-    ) : null;
   const otherPublisherMemberships =
     publisherMemberships?.filter((entry) => entry.publisher._id !== activePublisherId) ?? [];
   const goToOrganizationCreation = () => {
@@ -788,13 +771,7 @@ export default function Header() {
                       </span>
                     </div>
                   )}
-                  {activePublisherManagingRow ? (
-                    <>
-                      <DropdownMenuSeparator className="user-dropdown-managing-separator" />
-                      {activePublisherManagingRow}
-                    </>
-                  ) : null}
-                  <DropdownMenuSeparator className="user-dropdown-managing-separator" />
+                  <DropdownMenuSeparator />
                   <div
                     aria-label={`Publisher actions for @${triggerHandle}`}
                     className="user-dropdown-active-actions"
@@ -836,7 +813,7 @@ export default function Header() {
                       </Link>
                     </DropdownMenuItem>
                   </div>
-                  <DropdownMenuSeparator className="user-dropdown-full-bleed-separator" />
+                  <DropdownMenuSeparator />
                   <div className="user-dropdown-appearance-row">
                     <span className="user-dropdown-appearance-label">
                       <Palette size={14} aria-hidden="true" />
@@ -859,7 +836,7 @@ export default function Header() {
                       ))}
                     </div>
                   </div>
-                  <DropdownMenuSeparator className="user-dropdown-full-bleed-separator" />
+                  <DropdownMenuSeparator />
                   <DropdownMenuItem
                     className="user-dropdown-account-action"
                     onClick={() => void signOut()}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -144,6 +144,9 @@ export default function Header() {
     api.publishers.getMyProfileHandle,
     isAuthenticated && me ? {} : "skip",
   );
+  const activeOrgProfileHandle =
+    triggerPublisher?.kind === "org" ? triggerPublisher.handle : null;
+  const menuProfileHandle = activeOrgProfileHandle ?? profileHandle;
   const [navSearchQuery, setNavSearchQuery] = useState("");
   const [typeaheadOpen, setTypeaheadOpen] = useState(false);
   const [typeaheadTab, setTypeaheadTab] = useState<TypeaheadTab>("skills");
@@ -627,8 +630,7 @@ export default function Header() {
                                   @{entry.publisher.handle}
                                 </span>
                                 <span className="user-dropdown-publisher-meta">
-                                  {entry.publisher.kind === "org" ? "Org" : "Personal"} ·{" "}
-                                  {entry.role}
+                                  {entry.publisher.kind === "org" ? `Org · ${entry.role}` : "Personal"}
                                 </span>
                               </span>
                               {active ? (
@@ -645,11 +647,17 @@ export default function Header() {
                       <DropdownMenuSeparator />
                     </>
                   ) : null}
-                  {profileHandle ? (
+                  <div
+                    aria-label={`Actions for @${triggerHandle}`}
+                    className="user-dropdown-context-label"
+                  >
+                    For <span className="mono">@{triggerHandle}</span>
+                  </div>
+                  {menuProfileHandle ? (
                     <DropdownMenuItem asChild>
                       <Link
                         to="/user/$handle"
-                        params={{ handle: profileHandle }}
+                        params={{ handle: menuProfileHandle }}
                         className="flex items-center gap-2"
                       >
                         <UserRound size={14} aria-hidden="true" />
@@ -664,18 +672,18 @@ export default function Header() {
                     </Link>
                   </DropdownMenuItem>
                   <DropdownMenuItem asChild>
-                    <Link to="/stars" className="flex items-center gap-2">
-                      <Star size={14} aria-hidden="true" />
-                      Stars
-                    </Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem asChild>
                     <Link to="/settings" className="flex items-center gap-2">
                       <Settings size={14} aria-hidden="true" />
                       Settings
                     </Link>
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
+                  <DropdownMenuItem asChild>
+                    <Link to="/stars" className="flex items-center gap-2">
+                      <Star size={14} aria-hidden="true" />
+                      Stars
+                    </Link>
+                  </DropdownMenuItem>
                   <div className="user-dropdown-theme-row" role="group" aria-label="Theme">
                     {THEME_MODE_ITEMS.map(({ mode: themeMode, label, Icon }) => (
                       <DropdownMenuItem

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,24 +1,28 @@
 import { useAuthActions } from "@convex-dev/auth/react";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
+import { useQuery } from "convex/react";
 import {
   ArrowRight,
+  Building2,
   Check,
   ChevronDown,
   Command,
+  LayoutDashboard,
   LogOut,
   Menu,
   Monitor,
   Moon,
   MoreHorizontal,
   Palette,
-  Plus,
   Search,
   Settings,
   Star,
   Sun,
+  UserRound,
   X,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { api } from "../../convex/_generated/api";
 import { useActivePublisher } from "../lib/activePublisher";
 import {
   getUserFacingAuthError,
@@ -123,10 +127,8 @@ export default function Header() {
   const {
     activePublisher,
     activePublisherId,
-    canManageActivePublisher,
     hasMultiplePublishers,
     memberships: publisherMemberships,
-    personalPublisher,
     setActivePublisherId,
   } = useActivePublisher();
   const { signIn, signOut } = useAuthActions();
@@ -139,48 +141,21 @@ export default function Header() {
   const initial = (me?.displayName ?? me?.name ?? rawHandle).charAt(0).toUpperCase();
   const triggerPublisher = activePublisher?.publisher;
   const triggerHandle = triggerPublisher?.handle ?? rawHandle;
-  const triggerLabel =
-    triggerHandle.length > 26
-      ? `${triggerHandle.slice(0, 14)}…${triggerHandle.slice(-7)}`
-      : triggerHandle;
+  const triggerLabel = triggerHandle.length > 25 ? `${triggerHandle.slice(0, 25)}…` : triggerHandle;
   const isAuthResolving = isLoading || (isAuthenticated && me === undefined);
-  const roleLabel = (role: string | undefined) =>
-    role ? `${role.charAt(0).toUpperCase()}${role.slice(1)}` : "";
-  const membershipMeta = (entry: typeof activePublisher) => {
-    if (!entry) return "Personal publisher";
-    return entry.publisher.kind === "org"
-      ? `Organization · ${roleLabel(entry.role)}`
-      : "Personal publisher";
-  };
-  const activePublisherMeta = membershipMeta(activePublisher);
-  const otherPublisherMemberships = useMemo(() => {
-    return (publisherMemberships ?? [])
-      .filter((entry) => entry.publisher._id !== activePublisherId)
-      .sort((left, right) => {
-        if (left.publisher.kind !== right.publisher.kind) {
-          return left.publisher.kind === "user" ? -1 : 1;
-        }
-        return left.publisher.handle.localeCompare(right.publisher.handle);
-      });
-  }, [activePublisherId, publisherMemberships]);
-  const goToOrganizationCreation = () => {
-    if (personalPublisher) {
-      setActivePublisherId(personalPublisher.publisher._id);
-    }
-    void navigate({
-      to: "/settings",
-      search: { view: "organizations" },
-    });
-  };
-  const goToAccountSettings = () => {
-    if (personalPublisher) {
-      setActivePublisherId(personalPublisher.publisher._id);
-    }
-    void navigate({
-      to: "/settings",
-      search: { view: "profile" },
-    });
-  };
+  const profileHandle = useQuery(
+    api.publishers.getMyProfileHandle,
+    isAuthenticated && me ? {} : "skip",
+  );
+  const activeOrgProfileHandle =
+    triggerPublisher?.kind === "org" ? triggerPublisher.handle : null;
+  const menuProfileHandle = activeOrgProfileHandle ?? profileHandle;
+  const activePublisherMeta =
+    triggerPublisher?.kind === "org"
+      ? `Org${activePublisher?.role ? ` · ${activePublisher.role}` : ""}`
+      : "Personal";
+  const otherPublisherMemberships =
+    publisherMemberships?.filter((entry) => entry.publisher._id !== activePublisherId) ?? [];
   const [navSearchQuery, setNavSearchQuery] = useState("");
   const [typeaheadOpen, setTypeaheadOpen] = useState(false);
   const [typeaheadTab, setTypeaheadTab] = useState<TypeaheadTab>("skills");
@@ -612,209 +587,180 @@ export default function Header() {
               <NavbarThemeSwitcher mode={mode} onSetMode={setThemeMode} />
             ) : null}
             {isAuthenticated && me ? (
-              <>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <button
-                      className="user-trigger publisher-trigger"
-                      type="button"
-                      aria-label={`Open publisher switcher for @${triggerHandle}`}
-                      title={`Acting as @${triggerHandle}`}
-                    >
-                      {triggerPublisher ? (
-                        <span className="user-menu-publisher-icon" aria-hidden="true">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    className="user-trigger"
+                    type="button"
+                    aria-label={`Open account menu for @${triggerHandle}`}
+                  >
+                    {triggerPublisher ? (
+                      <span className="user-menu-publisher-icon" aria-hidden="true">
+                        <MarketplaceIcon
+                          kind={triggerPublisher.kind}
+                          label={triggerPublisher.displayName || triggerPublisher.handle}
+                          imageUrl={triggerPublisher.image}
+                          size="xs"
+                        />
+                      </span>
+                    ) : avatar ? (
+                      <img src={avatar} alt={me.displayName ?? me.name ?? "User avatar"} />
+                    ) : (
+                      <span className="user-menu-fallback">{initial}</span>
+                    )}
+                    <span className="user-trigger-handle truncate">@{triggerLabel}</span>
+                    <ChevronDown className="user-menu-chevron" size={16} />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="user-dropdown-content">
+                  <div className="user-dropdown-section-label">Publisher</div>
+                  <section
+                    aria-label={`Current publisher @${triggerHandle}`}
+                    className="user-dropdown-active-card"
+                  >
+                    <div className="user-dropdown-active-header">
+                      <span className="user-dropdown-active-icon" aria-hidden="true">
+                        {triggerPublisher ? (
                           <MarketplaceIcon
                             kind={triggerPublisher.kind}
                             label={triggerPublisher.displayName || triggerPublisher.handle}
                             imageUrl={triggerPublisher.image}
                             size="xs"
                           />
-                        </span>
-                      ) : avatar ? (
-                        <img src={avatar} alt={me.displayName ?? me.name ?? "User avatar"} />
-                      ) : (
-                        <span className="user-menu-fallback">{initial}</span>
-                      )}
-                      <span className="user-trigger-handle truncate">@{triggerLabel}</span>
-                      <ChevronDown className="user-menu-chevron" size={16} />
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="user-dropdown-content publisher-dropdown-content">
-                    <div className="user-dropdown-section-label">Current publisher</div>
-                    <section
-                      aria-label={`Current publisher @${triggerHandle}`}
-                      className="publisher-current-section"
+                        ) : avatar ? (
+                          <img src={avatar} alt="" />
+                        ) : (
+                          <span className="user-menu-fallback">{initial}</span>
+                        )}
+                      </span>
+                      <span className="user-dropdown-publisher-copy">
+                        <span className="user-dropdown-publisher-title">@{triggerHandle}</span>
+                        <span className="user-dropdown-publisher-meta">{activePublisherMeta}</span>
+                      </span>
+                      <Check
+                        className="user-dropdown-publisher-check"
+                        size={16}
+                        aria-label="Selected publisher"
+                      />
+                    </div>
+                    <div
+                      aria-label={`Publisher actions for @${triggerHandle}`}
+                      className="user-dropdown-active-actions"
                     >
-                      <div className="publisher-current-row">
-                        <span className="user-dropdown-publisher-icon" aria-hidden="true">
-                          {triggerPublisher ? (
-                            <MarketplaceIcon
-                              kind={triggerPublisher.kind}
-                              label={triggerPublisher.displayName || triggerPublisher.handle}
-                              imageUrl={triggerPublisher.image}
-                              size="xs"
-                            />
-                          ) : avatar ? (
-                            <img
-                              className="user-dropdown-account-avatar"
-                              src={avatar}
-                              alt=""
-                            />
-                          ) : (
-                            <span className="user-dropdown-account-avatar user-dropdown-account-fallback">
-                              {initial}
-                            </span>
-                          )}
-                        </span>
-                        <span className="user-dropdown-publisher-copy">
-                          <span className="user-dropdown-publisher-title">@{triggerHandle}</span>
-                          <span className="user-dropdown-publisher-meta">
-                            {activePublisherMeta}
-                          </span>
-                        </span>
-                        <Check
-                          className="user-dropdown-publisher-check"
-                          size={16}
-                          aria-label="Selected publisher"
-                        />
-                      </div>
-                      {canManageActivePublisher ? (
-                        <DropdownMenuItem asChild className="publisher-manage-action">
-                          <Link to="/settings" className="flex items-center gap-2">
-                            <Settings size={14} aria-hidden="true" />
-                            Manage publisher…
+                      {menuProfileHandle ? (
+                        <DropdownMenuItem asChild className="user-dropdown-scoped-action">
+                          <Link
+                            to="/user/$handle"
+                            params={{ handle: menuProfileHandle }}
+                            className="flex items-center gap-2"
+                          >
+                            {triggerPublisher?.kind === "org" ? (
+                              <Building2 size={14} aria-hidden="true" />
+                            ) : (
+                              <UserRound size={14} aria-hidden="true" />
+                            )}
+                            Profile
                           </Link>
                         </DropdownMenuItem>
                       ) : null}
-                    </section>
-                    {hasMultiplePublishers && otherPublisherMemberships.length > 0 ? (
-                      <>
-                        <DropdownMenuSeparator />
-                        <div className="user-dropdown-section-label">Switch publisher</div>
-                        <div className="user-dropdown-publisher-list" aria-label="Switch publisher">
-                          {otherPublisherMemberships.map((entry) => (
-                            <DropdownMenuItem
-                              key={entry.publisher._id}
-                              aria-label={`Switch to @${entry.publisher.handle}`}
-                              className="user-dropdown-publisher-item"
-                              onClick={() => setActivePublisherId(entry.publisher._id)}
-                            >
-                              <span className="user-dropdown-publisher-icon" aria-hidden="true">
-                                <MarketplaceIcon
-                                  kind={entry.publisher.kind}
-                                  label={entry.publisher.displayName || entry.publisher.handle}
-                                  imageUrl={entry.publisher.image}
-                                  size="xs"
-                                />
-                              </span>
-                              <span className="user-dropdown-publisher-copy">
-                                <span className="user-dropdown-publisher-title">
-                                  @{entry.publisher.handle}
-                                </span>
-                                <span className="user-dropdown-publisher-meta">
-                                  {membershipMeta(entry)}
-                                </span>
-                              </span>
-                            </DropdownMenuItem>
-                          ))}
-                        </div>
-                      </>
-                    ) : null}
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      className="publisher-create-action"
-                      onClick={goToOrganizationCreation}
-                    >
-                      <Plus size={14} aria-hidden="true" />
-                      Create organization…
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <button
-                      className="account-trigger"
-                      type="button"
-                      aria-label={`Open account menu for @${rawHandle}`}
-                      title={`Account @${rawHandle}`}
-                    >
-                      {avatar ? (
-                        <img src={avatar} alt={me.displayName ?? me.name ?? "User avatar"} />
-                      ) : (
-                        <span className="user-menu-fallback">{initial}</span>
-                      )}
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="user-dropdown-content account-dropdown-content">
-                    <div className="user-dropdown-section-label">Signed in as</div>
-                    <section
-                      aria-label={`Account @${rawHandle}`}
-                      className="user-dropdown-account-section"
-                    >
-                      <div
-                        aria-label={`Signed-in account @${rawHandle}`}
-                        className="user-dropdown-account-identity"
-                      >
-                        {avatar ? (
-                          <img
-                            className="user-dropdown-account-avatar"
-                            src={avatar}
-                            alt={me.displayName ?? me.name ?? "User avatar"}
-                          />
-                        ) : (
-                          <span className="user-dropdown-account-avatar user-dropdown-account-fallback">
-                            {initial}
-                          </span>
-                        )}
-                        <span className="user-dropdown-account-copy">
-                          <span className="user-dropdown-account-name">
-                            {me.displayName ?? me.name ?? rawHandle}
-                          </span>
-                          <span className="user-dropdown-account-handle">@{rawHandle}</span>
-                        </span>
-                      </div>
-                      <DropdownMenuItem
-                        className="user-dropdown-account-action"
-                        onClick={goToAccountSettings}
-                      >
-                        <Settings size={14} aria-hidden="true" />
-                        Account settings
-                      </DropdownMenuItem>
-                    </section>
-                    <DropdownMenuSeparator />
-                    <div className="user-dropdown-section-label">App</div>
-                    <section className="user-dropdown-account-section" aria-label="App actions">
-                      <DropdownMenuItem asChild className="user-dropdown-account-action">
-                        <Link to="/stars" className="flex items-center gap-2">
-                          <Star size={14} aria-hidden="true" />
-                          Stars
+                      <DropdownMenuItem asChild className="user-dropdown-scoped-action">
+                        <Link to="/dashboard" className="flex items-center gap-2">
+                          <LayoutDashboard size={14} aria-hidden="true" />
+                          Dashboard
                         </Link>
                       </DropdownMenuItem>
-                      <div className="user-dropdown-appearance-row">
-                        <span className="user-dropdown-appearance-label">
-                          <Palette size={14} aria-hidden="true" />
-                          Appearance
-                        </span>
-                        <div className="user-dropdown-theme-row" role="group" aria-label="Theme">
-                          {THEME_MODE_ITEMS.map(({ mode: themeMode, label, Icon }) => (
-                            <DropdownMenuItem
-                              key={themeMode}
-                              aria-label={label}
-                              aria-current={mode === themeMode ? "true" : undefined}
-                              className="user-dropdown-theme-button"
-                              data-status={mode === themeMode ? "active" : undefined}
-                              title={label}
-                              onClick={() => setThemeMode(themeMode)}
-                            >
-                              <Icon size={15} aria-hidden="true" />
-                              <span className="sr-only">{label}</span>
-                            </DropdownMenuItem>
-                          ))}
-                        </div>
+                      <DropdownMenuItem asChild className="user-dropdown-scoped-action">
+                        <Link to="/settings" className="flex items-center gap-2">
+                          <Settings size={14} aria-hidden="true" />
+                          Settings
+                        </Link>
+                      </DropdownMenuItem>
+                    </div>
+                  </section>
+                  {hasMultiplePublishers && otherPublisherMemberships.length > 0 ? (
+                    <>
+                      <DropdownMenuSeparator />
+                      <div className="user-dropdown-section-label">Switch publisher</div>
+                      <div className="user-dropdown-publisher-list" aria-label="Switch publisher">
+                        {otherPublisherMemberships.map((entry) => (
+                          <DropdownMenuItem
+                            key={entry.publisher._id}
+                            aria-label={`Switch to @${entry.publisher.handle}`}
+                            className="user-dropdown-publisher-item"
+                            onClick={() => setActivePublisherId(entry.publisher._id)}
+                          >
+                            <span className="user-dropdown-publisher-icon" aria-hidden="true">
+                              <MarketplaceIcon
+                                kind={entry.publisher.kind}
+                                label={entry.publisher.displayName || entry.publisher.handle}
+                                imageUrl={entry.publisher.image}
+                                size="xs"
+                              />
+                            </span>
+                            <span className="user-dropdown-publisher-copy">
+                              <span className="user-dropdown-publisher-title">
+                                @{entry.publisher.handle}
+                              </span>
+                              <span className="user-dropdown-publisher-meta">
+                                {entry.publisher.kind === "org" ? `Org · ${entry.role}` : "Personal"}
+                              </span>
+                            </span>
+                          </DropdownMenuItem>
+                        ))}
                       </div>
-                    </section>
-                    <DropdownMenuSeparator />
-                    <div className="user-dropdown-section-label">Session</div>
+                    </>
+                  ) : null}
+                  <DropdownMenuSeparator />
+                  <div className="user-dropdown-section-label">Account</div>
+                  <section
+                    aria-label={`Account @${rawHandle}`}
+                    className="user-dropdown-account-section"
+                  >
+                    <div
+                      aria-label={`Signed-in account @${rawHandle}`}
+                      className="user-dropdown-account-identity"
+                    >
+                      {avatar ? (
+                        <img
+                          className="user-dropdown-account-avatar"
+                          src={avatar}
+                          alt={me.displayName ?? me.name ?? "User avatar"}
+                        />
+                      ) : (
+                        <span className="user-dropdown-account-avatar user-dropdown-account-fallback">
+                          {initial}
+                        </span>
+                      )}
+                      <span className="user-dropdown-account-handle">@{rawHandle}</span>
+                    </div>
+                    <DropdownMenuItem asChild className="user-dropdown-account-action">
+                      <Link to="/stars" className="flex items-center gap-2">
+                        <Star size={14} aria-hidden="true" />
+                        Stars
+                      </Link>
+                    </DropdownMenuItem>
+                    <div className="user-dropdown-appearance-row">
+                      <span className="user-dropdown-appearance-label">
+                        <Palette size={14} aria-hidden="true" />
+                        Appearance
+                      </span>
+                      <div className="user-dropdown-theme-row" role="group" aria-label="Theme">
+                        {THEME_MODE_ITEMS.map(({ mode: themeMode, label, Icon }) => (
+                          <DropdownMenuItem
+                            key={themeMode}
+                            aria-label={label}
+                            aria-current={mode === themeMode ? "true" : undefined}
+                            className="user-dropdown-theme-button"
+                            data-status={mode === themeMode ? "active" : undefined}
+                            title={label}
+                            onClick={() => setThemeMode(themeMode)}
+                          >
+                            <Icon size={15} aria-hidden="true" />
+                            <span className="sr-only">{label}</span>
+                          </DropdownMenuItem>
+                        ))}
+                      </div>
+                    </div>
                     <DropdownMenuItem
                       className="user-dropdown-account-action"
                       onClick={() => void signOut()}
@@ -822,9 +768,9 @@ export default function Header() {
                       <LogOut size={14} aria-hidden="true" />
                       Sign out
                     </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </>
+                  </section>
+                </DropdownMenuContent>
+              </DropdownMenu>
             ) : isAuthResolving ? (
               <div className="github-sign-in-button auth-loading-placeholder" aria-hidden="true" />
             ) : (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -163,12 +163,9 @@ export default function Header() {
   const menuProfileHandle = activeOrgProfileHandle ?? profileHandle;
   const isPersonalPublisher = triggerPublisher?.kind !== "org";
   const profileMenuLabel = isPersonalPublisher ? "Profile" : "Org profile";
-  const formatPublisherRole = (role: string | undefined) =>
-    role ? `${role.charAt(0).toUpperCase()}${role.slice(1)}` : "";
   const formatPublisherMeta = (entry: typeof activePublisher) => {
     if (!entry || entry.publisher.kind !== "org") return "Personal";
-    const role = formatPublisherRole(entry.role);
-    return role ? `Org · ${role}` : "Org";
+    return "Organization";
   };
   const activePublisherMeta =
     triggerPublisher?.kind === "org" ? formatPublisherMeta(activePublisher) : "Personal";
@@ -793,11 +790,11 @@ export default function Header() {
                   )}
                   {activePublisherManagingRow ? (
                     <>
-                      <DropdownMenuSeparator />
+                      <DropdownMenuSeparator className="user-dropdown-managing-separator" />
                       {activePublisherManagingRow}
                     </>
                   ) : null}
-                  <DropdownMenuSeparator />
+                  <DropdownMenuSeparator className="user-dropdown-managing-separator" />
                   <div
                     aria-label={`Publisher actions for @${triggerHandle}`}
                     className="user-dropdown-active-actions"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -812,66 +812,36 @@ export default function Header() {
                     ) : null}
                   </div>
                   <DropdownMenuSeparator />
-                  <DropdownMenuSub>
-                    <DropdownMenuSubTrigger
-                      aria-label={`Account @${rawHandle}`}
-                      className="user-dropdown-account-trigger"
-                    >
-                      <span className="user-dropdown-account-label">Account</span>
-                      <span className="user-dropdown-account-handle">@{rawHandle}</span>
-                      <ChevronRight className="user-dropdown-submenu-chevron" size={16} />
-                    </DropdownMenuSubTrigger>
-                    <DropdownMenuSubContent className="user-dropdown-subcontent user-dropdown-account-subcontent">
-                      <div
-                        aria-label={`Signed-in account @${rawHandle}`}
-                        className="user-dropdown-account-identity"
-                      >
-                        {avatar ? (
-                          <img
-                            className="user-dropdown-account-avatar"
-                            src={avatar}
-                            alt={me.displayName ?? me.name ?? "User avatar"}
-                          />
-                        ) : (
-                          <span className="user-dropdown-account-avatar user-dropdown-account-fallback">
-                            {initial}
-                          </span>
-                        )}
-                        <span className="user-dropdown-account-handle">@{rawHandle}</span>
-                      </div>
-                      <DropdownMenuSeparator />
-                      {!isPersonalPublisher ? (
-                        <DropdownMenuItem asChild className="user-dropdown-account-action">
-                          <Link to="/stars" className="flex items-center gap-2">
-                            <Star size={14} aria-hidden="true" />
-                            Stars
-                          </Link>
+                  {!isPersonalPublisher ? (
+                    <DropdownMenuItem asChild className="user-dropdown-account-action">
+                      <Link to="/stars" className="flex items-center gap-2">
+                        <Star size={14} aria-hidden="true" />
+                        Stars
+                      </Link>
+                    </DropdownMenuItem>
+                  ) : null}
+                  <div className="user-dropdown-appearance-row">
+                    <span className="user-dropdown-appearance-label">
+                      <Palette size={14} aria-hidden="true" />
+                      Appearance
+                    </span>
+                    <div className="user-dropdown-theme-row" role="group" aria-label="Theme">
+                      {THEME_MODE_ITEMS.map(({ mode: themeMode, label, Icon }) => (
+                        <DropdownMenuItem
+                          key={themeMode}
+                          aria-label={label}
+                          aria-current={mode === themeMode ? "true" : undefined}
+                          className="user-dropdown-theme-button"
+                          data-status={mode === themeMode ? "active" : undefined}
+                          title={label}
+                          onClick={() => setThemeMode(themeMode)}
+                        >
+                          <Icon size={15} aria-hidden="true" />
+                          <span className="sr-only">{label}</span>
                         </DropdownMenuItem>
-                      ) : null}
-                      <div className="user-dropdown-appearance-row">
-                        <span className="user-dropdown-appearance-label">
-                          <Palette size={14} aria-hidden="true" />
-                          Appearance
-                        </span>
-                        <div className="user-dropdown-theme-row" role="group" aria-label="Theme">
-                          {THEME_MODE_ITEMS.map(({ mode: themeMode, label, Icon }) => (
-                            <DropdownMenuItem
-                              key={themeMode}
-                              aria-label={label}
-                              aria-current={mode === themeMode ? "true" : undefined}
-                              className="user-dropdown-theme-button"
-                              data-status={mode === themeMode ? "active" : undefined}
-                              title={label}
-                              onClick={() => setThemeMode(themeMode)}
-                            >
-                              <Icon size={15} aria-hidden="true" />
-                              <span className="sr-only">{label}</span>
-                            </DropdownMenuItem>
-                          ))}
-                        </div>
-                      </div>
-                    </DropdownMenuSubContent>
-                  </DropdownMenuSub>
+                      ))}
+                    </div>
+                  </div>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
                     className="user-dropdown-account-action"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -173,7 +173,7 @@ export default function Header() {
   const activePublisherMeta =
     triggerPublisher?.kind === "org" ? (
       <span className="user-dropdown-publisher-via">
-        <span>via</span>
+        <span>connected as</span>
         {avatar ? (
           <img className="user-dropdown-via-avatar" src={avatar} alt="" />
         ) : (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -171,21 +171,21 @@ export default function Header() {
     return role ? `Org · ${role}` : "Org";
   };
   const activePublisherMeta =
+    triggerPublisher?.kind === "org" ? formatPublisherMeta(activePublisher) : "Personal";
+  const activePublisherManagingRow =
     triggerPublisher?.kind === "org" ? (
-      <span className="user-dropdown-publisher-via">
-        <span>connected as</span>
+      <div className="user-dropdown-managing-row">
+        <span className="user-dropdown-managing-label">Managing as</span>
         {avatar ? (
-          <img className="user-dropdown-via-avatar" src={avatar} alt="" />
+          <img className="user-dropdown-managing-avatar" src={avatar} alt="" />
         ) : (
-          <span className="user-dropdown-via-avatar user-dropdown-via-avatar-fallback">
+          <span className="user-dropdown-managing-avatar user-dropdown-managing-avatar-fallback">
             <UserRound size={9} aria-hidden="true" />
           </span>
         )}
-        <span className="user-dropdown-via-handle">@{accountHandle}</span>
-      </span>
-    ) : (
-      "Personal"
-    );
+        <span className="user-dropdown-managing-handle">@{accountHandle}</span>
+      </div>
+    ) : null;
   const otherPublisherMemberships =
     publisherMemberships?.filter((entry) => entry.publisher._id !== activePublisherId) ?? [];
   const goToOrganizationCreation = () => {
@@ -789,6 +789,12 @@ export default function Header() {
                       </span>
                     </div>
                   )}
+                  {activePublisherManagingRow ? (
+                    <>
+                      <DropdownMenuSeparator />
+                      {activePublisherManagingRow}
+                    </>
+                  ) : null}
                   <DropdownMenuSeparator />
                   <div
                     aria-label={`Publisher actions for @${triggerHandle}`}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -157,6 +157,7 @@ export default function Header() {
     triggerPublisher?.kind === "org" ? triggerPublisher.handle : null;
   const menuProfileHandle = activeOrgProfileHandle ?? profileHandle;
   const isPersonalPublisher = triggerPublisher?.kind !== "org";
+  const profileMenuLabel = isPersonalPublisher ? "Profile" : "Org profile";
   const formatPublisherRole = (role: string | undefined) =>
     role ? `${role.charAt(0).toUpperCase()}${role.slice(1)}` : "";
   const formatPublisherMeta = (entry: typeof activePublisher) => {
@@ -786,7 +787,7 @@ export default function Header() {
                           ) : (
                             <UserRound size={14} aria-hidden="true" />
                           )}
-                          Profile
+                          {profileMenuLabel}
                         </Link>
                       </DropdownMenuItem>
                     ) : null}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -176,14 +176,16 @@ export default function Header() {
     triggerPublisher?.kind === "org" ? (
       <div className="user-dropdown-managing-row">
         <span className="user-dropdown-managing-label">Managing as</span>
-        {avatar ? (
-          <img className="user-dropdown-managing-avatar" src={avatar} alt="" />
-        ) : (
-          <span className="user-dropdown-managing-avatar user-dropdown-managing-avatar-fallback">
-            <UserRound size={9} aria-hidden="true" />
-          </span>
-        )}
-        <span className="user-dropdown-managing-handle">@{accountHandle}</span>
+        <span className="user-dropdown-managing-account">
+          {avatar ? (
+            <img className="user-dropdown-managing-avatar" src={avatar} alt="" />
+          ) : (
+            <span className="user-dropdown-managing-avatar user-dropdown-managing-avatar-fallback">
+              <UserRound size={9} aria-hidden="true" />
+            </span>
+          )}
+          <span className="user-dropdown-managing-handle">@{accountHandle}</span>
+        </span>
       </div>
     ) : null;
   const otherPublisherMemberships =

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -775,6 +775,12 @@ export default function Header() {
                     aria-label={`Publisher actions for @${triggerHandle}`}
                     className="user-dropdown-active-actions"
                   >
+                    <DropdownMenuItem asChild className="user-dropdown-scoped-action">
+                      <Link to="/dashboard" className="flex items-center gap-2">
+                        <LayoutDashboard size={14} aria-hidden="true" />
+                        Dashboard
+                      </Link>
+                    </DropdownMenuItem>
                     {menuProfileHandle ? (
                       <DropdownMenuItem asChild className="user-dropdown-scoped-action">
                         <Link
@@ -791,18 +797,6 @@ export default function Header() {
                         </Link>
                       </DropdownMenuItem>
                     ) : null}
-                    <DropdownMenuItem asChild className="user-dropdown-scoped-action">
-                      <Link to="/dashboard" className="flex items-center gap-2">
-                        <LayoutDashboard size={14} aria-hidden="true" />
-                        Dashboard
-                      </Link>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem asChild className="user-dropdown-scoped-action">
-                      <Link to="/settings" className="flex items-center gap-2">
-                        <Settings size={14} aria-hidden="true" />
-                        Settings
-                      </Link>
-                    </DropdownMenuItem>
                     {isPersonalPublisher ? (
                       <DropdownMenuItem asChild className="user-dropdown-scoped-action">
                         <Link to="/stars" className="flex items-center gap-2">
@@ -811,6 +805,12 @@ export default function Header() {
                         </Link>
                       </DropdownMenuItem>
                     ) : null}
+                    <DropdownMenuItem asChild className="user-dropdown-scoped-action">
+                      <Link to="/settings" className="flex items-center gap-2">
+                        <Settings size={14} aria-hidden="true" />
+                        Settings
+                      </Link>
+                    </DropdownMenuItem>
                   </div>
                   <DropdownMenuSeparator />
                   <div className="user-dropdown-appearance-row">

--- a/src/components/PackageSourceChooser.tsx
+++ b/src/components/PackageSourceChooser.tsx
@@ -119,6 +119,7 @@ export function PackageSourceChooser(props: {
   codePluginFieldIssues: string[];
   onPickFiles: (selected: File[], sourceKind: PackagePickSource) => Promise<void>;
   onClearFiles: () => void;
+  embedded?: boolean;
 }) {
   const [isDragging, setIsDragging] = useState(false);
   const archiveInputRef = useRef<HTMLInputElement | null>(null);
@@ -193,7 +194,7 @@ export function PackageSourceChooser(props: {
       />
       {hasSelectedPackage ? (
         <div
-          className={`mb-5 overflow-hidden rounded-[var(--radius-md)] border transition-colors ${selectedPackagePanelToneClass}`}
+          className={`${props.embedded ? "" : "mb-5"} overflow-hidden rounded-[var(--radius-md)] border transition-colors ${selectedPackagePanelToneClass}`}
           onDragOver={(event) => {
             event.preventDefault();
             setIsDragging(true);
@@ -290,7 +291,7 @@ export function PackageSourceChooser(props: {
           </div>
         </div>
       ) : (
-        <Card className="mb-5">
+        <Card className={props.embedded ? "gap-0 border-0 bg-transparent !p-0" : "mb-5"}>
           <div
             className={`relative flex flex-col items-center gap-4 overflow-hidden rounded-[var(--radius-md)] border-2 border-dashed p-8 text-center transition-colors ${
               isDragging

--- a/src/components/PublisherOwnerSelect.tsx
+++ b/src/components/PublisherOwnerSelect.tsx
@@ -1,5 +1,6 @@
 import { Check } from "lucide-react";
 import type { ReactNode } from "react";
+import type { Id } from "../../convex/_generated/dataModel";
 import { MarketplaceIcon } from "./MarketplaceIcon";
 import { Button } from "./ui/button";
 import {
@@ -12,7 +13,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from ".
 
 type PublisherOwnerMembership = {
   publisher: {
-    _id: string;
+    _id: Id<"publishers">;
     handle: string;
     displayName: string;
     kind: "user" | "org";
@@ -29,7 +30,7 @@ export function PublisherContextStrip({
 }: {
   ownerHandle: string;
   memberships: PublisherOwnerMembership[] | undefined;
-  onSwitchPublisher: (publisherId: string) => void;
+  onSwitchPublisher: (publisherId: Id<"publishers">) => void;
   validation?: ReactNode;
 }) {
   return (

--- a/src/components/PublisherOwnerSelect.tsx
+++ b/src/components/PublisherOwnerSelect.tsx
@@ -216,9 +216,9 @@ export function PublisherOwnerDisplay({
             size="xs"
           />
         </span>
-        <span className="min-w-0 truncate text-sm font-medium text-[color:var(--ink)]">
+        <span className="min-w-0 truncate text-xs font-normal text-[color:var(--ink)]">
           {publisher.displayName || publisher.handle}
-          <span className="hidden text-[13px] font-normal text-[color:var(--ink-soft)] sm:inline">
+          <span className="hidden font-normal text-[color:var(--ink-soft)] sm:inline">
             {" "}
             / @{publisher.handle}
           </span>

--- a/src/components/PublisherOwnerSelect.tsx
+++ b/src/components/PublisherOwnerSelect.tsx
@@ -30,7 +30,7 @@ export function PublisherContextStrip({
 }: {
   ownerHandle: string;
   memberships: PublisherOwnerMembership[] | undefined;
-  onSwitchPublisher: (publisherId: Id<"publishers">) => void;
+  onSwitchPublisher: (publisher: PublisherOwnerMembership["publisher"]) => void;
   validation?: ReactNode;
 }) {
   return (
@@ -76,10 +76,10 @@ export function PublisherContextStrip({
                       </span>
                       <span className="user-dropdown-publisher-copy">
                         <span className="user-dropdown-publisher-title">
-                          @{entry.publisher.handle}
+                          {entry.publisher.displayName?.trim() || entry.publisher.handle}
                         </span>
                         <span className="user-dropdown-publisher-meta">
-                          {entry.publisher.kind === "org" ? "Organization" : "Personal"}
+                          @{entry.publisher.handle}
                         </span>
                       </span>
                     </>
@@ -103,7 +103,7 @@ export function PublisherContextStrip({
                       key={entry.publisher._id}
                       aria-label={`Switch to @${entry.publisher.handle}`}
                       className="user-dropdown-publisher-item"
-                      onSelect={() => onSwitchPublisher(entry.publisher._id)}
+                      onSelect={() => onSwitchPublisher(entry.publisher)}
                     >
                       {publisherIdentity}
                     </DropdownMenuItem>

--- a/src/components/PublisherOwnerSelect.tsx
+++ b/src/components/PublisherOwnerSelect.tsx
@@ -216,7 +216,7 @@ export function PublisherOwnerDisplay({
             size="xs"
           />
         </span>
-        <span className="min-w-0 truncate text-xs font-normal text-[color:var(--ink)]">
+        <span className="min-w-0 truncate text-xs font-semibold text-[color:var(--ink)]">
           {publisher.displayName || publisher.handle}
           <span className="hidden font-normal text-[color:var(--ink-soft)] sm:inline">
             {" "}

--- a/src/components/PublisherOwnerSelect.tsx
+++ b/src/components/PublisherOwnerSelect.tsx
@@ -107,9 +107,12 @@ export function PublisherOwnerDisplay({
             size="xs"
           />
         </span>
-        <span className="min-w-0 truncate font-medium text-[color:var(--ink)]">
+        <span className="min-w-0 truncate text-sm font-medium text-[color:var(--ink)]">
           {publisher.displayName || publisher.handle}
-          <span className="font-normal text-[color:var(--ink-soft)]"> / @{publisher.handle}</span>
+          <span className="text-[13px] font-normal text-[color:var(--ink-soft)]">
+            {" "}
+            / @{publisher.handle}
+          </span>
         </span>
       </span>
     );

--- a/src/components/PublisherOwnerSelect.tsx
+++ b/src/components/PublisherOwnerSelect.tsx
@@ -1,7 +1,16 @@
+import { Check } from "lucide-react";
+import type { ReactNode } from "react";
 import { MarketplaceIcon } from "./MarketplaceIcon";
+import { Button } from "./ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
 
-type PublisherOwnerMembership = {
+export type PublisherOwnerMembership = {
   publisher: {
     _id: string;
     handle: string;
@@ -11,6 +20,104 @@ type PublisherOwnerMembership = {
   };
   role: "owner" | "admin" | "publisher";
 };
+
+export function PublisherContextStrip({
+  ownerHandle,
+  memberships,
+  onSwitchPublisher,
+  validation,
+}: {
+  ownerHandle: string;
+  memberships: PublisherOwnerMembership[] | undefined;
+  onSwitchPublisher: (publisherId: string) => void;
+  validation?: ReactNode;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label="Publishing as"
+      className="grid min-h-[52px] grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 bg-[color:var(--surface-muted)] px-space-5 py-space-3 text-sm text-[color:var(--ink)]"
+    >
+      <div className="flex min-w-0 flex-col gap-1 lg:flex-row lg:items-center lg:gap-2">
+        <span className="text-xs font-medium text-[color:var(--ink-soft)]">Publishing as</span>
+        <span className="publishing-context-owner min-w-0">
+          <PublisherOwnerDisplay value={ownerHandle} memberships={memberships} compact />
+        </span>
+      </div>
+      {(memberships?.length ?? 0) > 1 ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              className="ml-auto focus-visible:ring-0 focus-visible:ring-offset-0"
+              aria-label="Switch publisher"
+            >
+              <span className="lg:hidden">Switch</span>
+              <span className="hidden lg:inline">Switch publisher</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="end"
+            className="publishing-context-switcher user-dropdown-subcontent user-dropdown-switcher-subcontent"
+          >
+            <div className="user-dropdown-section-label">Switch publisher</div>
+            <div className="user-dropdown-publisher-list" aria-label="Switch publisher">
+              {memberships?.map((entry) => {
+                const publisherIdentity = (
+                  <>
+                    <span className="user-dropdown-publisher-icon" aria-hidden="true">
+                      <MarketplaceIcon
+                        kind={entry.publisher.kind}
+                        label={entry.publisher.displayName || entry.publisher.handle}
+                        imageUrl={entry.publisher.image}
+                        size="xs"
+                      />
+                    </span>
+                    <span className="user-dropdown-publisher-copy">
+                      <span className="user-dropdown-publisher-title">
+                        @{entry.publisher.handle}
+                      </span>
+                      <span className="user-dropdown-publisher-meta">
+                        {entry.publisher.kind === "org" ? "Organization" : "Personal"}
+                      </span>
+                    </span>
+                  </>
+                );
+
+                return entry.publisher.handle === ownerHandle ? (
+                  <div
+                    key={entry.publisher._id}
+                    aria-label={`Selected publisher @${entry.publisher.handle}`}
+                    className="user-dropdown-publisher-item user-dropdown-publisher-item-current"
+                  >
+                    {publisherIdentity}
+                    <Check
+                      className="user-dropdown-publisher-check"
+                      size={16}
+                      aria-label="Selected publisher"
+                    />
+                  </div>
+                ) : (
+                  <DropdownMenuItem
+                    key={entry.publisher._id}
+                    aria-label={`Switch to @${entry.publisher.handle}`}
+                    className="user-dropdown-publisher-item"
+                    onSelect={() => onSwitchPublisher(entry.publisher._id)}
+                  >
+                    {publisherIdentity}
+                  </DropdownMenuItem>
+                );
+              })}
+            </div>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : null}
+      {validation ? <div className="col-span-full">{validation}</div> : null}
+    </div>
+  );
+}
 
 type PublisherOwnerSelectProps = {
   id: string;

--- a/src/components/PublisherOwnerSelect.tsx
+++ b/src/components/PublisherOwnerSelect.tsx
@@ -98,7 +98,7 @@ export function PublisherOwnerDisplay({
   if (selected && compact) {
     const { publisher } = selected;
     return (
-      <span className="flex min-w-0 items-center gap-2 leading-none">
+      <span className="flex min-w-0 items-center gap-2 leading-snug">
         <span className="inline-flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-full">
           <MarketplaceIcon
             kind={publisher.kind}

--- a/src/components/PublisherOwnerSelect.tsx
+++ b/src/components/PublisherOwnerSelect.tsx
@@ -10,7 +10,7 @@ import {
 } from "./ui/dropdown-menu";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
 
-export type PublisherOwnerMembership = {
+type PublisherOwnerMembership = {
   publisher: {
     _id: string;
     handle: string;
@@ -191,7 +191,7 @@ function PublisherOwnerOption({ membership }: { membership: PublisherOwnerMember
   );
 }
 
-export function PublisherOwnerDisplay({
+function PublisherOwnerDisplay({
   value,
   memberships,
   compact = false,

--- a/src/components/PublisherOwnerSelect.tsx
+++ b/src/components/PublisherOwnerSelect.tsx
@@ -84,3 +84,18 @@ function PublisherOwnerOption({ membership }: { membership: PublisherOwnerMember
     </span>
   );
 }
+
+export function PublisherOwnerDisplay({
+  value,
+  memberships,
+}: {
+  value: string;
+  memberships: PublisherOwnerMembership[] | undefined;
+}) {
+  const selected = (memberships ?? []).find((entry) => entry.publisher.handle === value) ?? null;
+  return selected ? (
+    <PublisherOwnerOption membership={selected} />
+  ) : (
+    <span className="truncate">{value ? `@${value}` : "No publisher selected"}</span>
+  );
+}

--- a/src/components/PublisherOwnerSelect.tsx
+++ b/src/components/PublisherOwnerSelect.tsx
@@ -1,7 +1,7 @@
 import { MarketplaceIcon } from "./MarketplaceIcon";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
 
-export type PublisherOwnerMembership = {
+type PublisherOwnerMembership = {
   publisher: {
     _id: string;
     handle: string;

--- a/src/components/PublisherOwnerSelect.tsx
+++ b/src/components/PublisherOwnerSelect.tsx
@@ -39,9 +39,6 @@ export function PublisherContextStrip({
       className="flex min-h-[42px] flex-wrap items-center bg-[color:var(--surface-muted)] px-4 py-2 text-sm text-[color:var(--ink)] sm:px-space-5"
     >
       <div className="flex w-full min-w-0 items-center gap-2">
-        <span className="hidden shrink-0 text-xs font-medium text-[color:var(--ink-soft)] sm:inline">
-          Publishing as
-        </span>
         <span className="publishing-context-owner min-w-0 flex-1">
           <PublisherOwnerDisplay value={ownerHandle} memberships={memberships} compact />
         </span>

--- a/src/components/PublisherOwnerSelect.tsx
+++ b/src/components/PublisherOwnerSelect.tsx
@@ -88,11 +88,33 @@ function PublisherOwnerOption({ membership }: { membership: PublisherOwnerMember
 export function PublisherOwnerDisplay({
   value,
   memberships,
+  compact = false,
 }: {
   value: string;
   memberships: PublisherOwnerMembership[] | undefined;
+  compact?: boolean;
 }) {
   const selected = (memberships ?? []).find((entry) => entry.publisher.handle === value) ?? null;
+  if (selected && compact) {
+    const { publisher } = selected;
+    return (
+      <span className="flex min-w-0 items-center gap-2 leading-none">
+        <span className="inline-flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-full">
+          <MarketplaceIcon
+            kind={publisher.kind}
+            label={publisher.displayName || publisher.handle}
+            imageUrl={publisher.image}
+            size="xs"
+          />
+        </span>
+        <span className="min-w-0 truncate font-medium text-[color:var(--ink)]">
+          {publisher.displayName || publisher.handle}
+          <span className="font-normal text-[color:var(--ink-soft)]"> / @{publisher.handle}</span>
+        </span>
+      </span>
+    );
+  }
+
   return selected ? (
     <PublisherOwnerOption membership={selected} />
   ) : (

--- a/src/components/PublisherOwnerSelect.tsx
+++ b/src/components/PublisherOwnerSelect.tsx
@@ -36,85 +36,87 @@ export function PublisherContextStrip({
     <div
       role="group"
       aria-label="Publishing as"
-      className="grid min-h-[52px] grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 bg-[color:var(--surface-muted)] px-space-5 py-space-3 text-sm text-[color:var(--ink)]"
+      className="flex min-h-[52px] flex-wrap items-center bg-[color:var(--surface-muted)] px-4 py-space-3 text-sm text-[color:var(--ink)] sm:px-space-5"
     >
-      <div className="flex min-w-0 flex-col gap-1 lg:flex-row lg:items-center lg:gap-2">
-        <span className="text-xs font-medium text-[color:var(--ink-soft)]">Publishing as</span>
-        <span className="publishing-context-owner min-w-0">
+      <div className="flex w-full min-w-0 items-center gap-2">
+        <span className="hidden shrink-0 text-xs font-medium text-[color:var(--ink-soft)] sm:inline">
+          Publishing as
+        </span>
+        <span className="publishing-context-owner min-w-0 flex-1">
           <PublisherOwnerDisplay value={ownerHandle} memberships={memberships} compact />
         </span>
-      </div>
-      {(memberships?.length ?? 0) > 1 ? (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              type="button"
-              variant="ghost"
-              size="xs"
-              className="ml-auto focus-visible:ring-0 focus-visible:ring-offset-0"
-              aria-label="Switch publisher"
+        {(memberships?.length ?? 0) > 1 ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                className="ml-auto focus-visible:ring-0 focus-visible:ring-offset-0"
+                aria-label="Switch publisher"
+              >
+                <span className="sm:hidden">Switch</span>
+                <span className="hidden sm:inline">Switch publisher</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              className="publishing-context-switcher user-dropdown-subcontent user-dropdown-switcher-subcontent"
             >
-              <span className="lg:hidden">Switch</span>
-              <span className="hidden lg:inline">Switch publisher</span>
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            align="end"
-            className="publishing-context-switcher user-dropdown-subcontent user-dropdown-switcher-subcontent"
-          >
-            <div className="user-dropdown-section-label">Switch publisher</div>
-            <div className="user-dropdown-publisher-list" aria-label="Switch publisher">
-              {memberships?.map((entry) => {
-                const publisherIdentity = (
-                  <>
-                    <span className="user-dropdown-publisher-icon" aria-hidden="true">
-                      <MarketplaceIcon
-                        kind={entry.publisher.kind}
-                        label={entry.publisher.displayName || entry.publisher.handle}
-                        imageUrl={entry.publisher.image}
-                        size="xs"
-                      />
-                    </span>
-                    <span className="user-dropdown-publisher-copy">
-                      <span className="user-dropdown-publisher-title">
-                        @{entry.publisher.handle}
+              <div className="user-dropdown-section-label">Switch publisher</div>
+              <div className="user-dropdown-publisher-list" aria-label="Switch publisher">
+                {memberships?.map((entry) => {
+                  const publisherIdentity = (
+                    <>
+                      <span className="user-dropdown-publisher-icon" aria-hidden="true">
+                        <MarketplaceIcon
+                          kind={entry.publisher.kind}
+                          label={entry.publisher.displayName || entry.publisher.handle}
+                          imageUrl={entry.publisher.image}
+                          size="xs"
+                        />
                       </span>
-                      <span className="user-dropdown-publisher-meta">
-                        {entry.publisher.kind === "org" ? "Organization" : "Personal"}
+                      <span className="user-dropdown-publisher-copy">
+                        <span className="user-dropdown-publisher-title">
+                          @{entry.publisher.handle}
+                        </span>
+                        <span className="user-dropdown-publisher-meta">
+                          {entry.publisher.kind === "org" ? "Organization" : "Personal"}
+                        </span>
                       </span>
-                    </span>
-                  </>
-                );
+                    </>
+                  );
 
-                return entry.publisher.handle === ownerHandle ? (
-                  <div
-                    key={entry.publisher._id}
-                    aria-label={`Selected publisher @${entry.publisher.handle}`}
-                    className="user-dropdown-publisher-item user-dropdown-publisher-item-current"
-                  >
-                    {publisherIdentity}
-                    <Check
-                      className="user-dropdown-publisher-check"
-                      size={16}
-                      aria-label="Selected publisher"
-                    />
-                  </div>
-                ) : (
-                  <DropdownMenuItem
-                    key={entry.publisher._id}
-                    aria-label={`Switch to @${entry.publisher.handle}`}
-                    className="user-dropdown-publisher-item"
-                    onSelect={() => onSwitchPublisher(entry.publisher._id)}
-                  >
-                    {publisherIdentity}
-                  </DropdownMenuItem>
-                );
-              })}
-            </div>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      ) : null}
-      {validation ? <div className="col-span-full">{validation}</div> : null}
+                  return entry.publisher.handle === ownerHandle ? (
+                    <div
+                      key={entry.publisher._id}
+                      aria-label={`Selected publisher @${entry.publisher.handle}`}
+                      className="user-dropdown-publisher-item user-dropdown-publisher-item-current"
+                    >
+                      {publisherIdentity}
+                      <Check
+                        className="user-dropdown-publisher-check"
+                        size={16}
+                        aria-label="Selected publisher"
+                      />
+                    </div>
+                  ) : (
+                    <DropdownMenuItem
+                      key={entry.publisher._id}
+                      aria-label={`Switch to @${entry.publisher.handle}`}
+                      className="user-dropdown-publisher-item"
+                      onSelect={() => onSwitchPublisher(entry.publisher._id)}
+                    >
+                      {publisherIdentity}
+                    </DropdownMenuItem>
+                  );
+                })}
+              </div>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : null}
+      </div>
+      {validation ? <div className="mt-1 w-full">{validation}</div> : null}
     </div>
   );
 }
@@ -206,7 +208,7 @@ export function PublisherOwnerDisplay({
     const { publisher } = selected;
     return (
       <span className="flex min-w-0 items-center gap-2 leading-snug">
-        <span className="inline-flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-full">
+        <span className="inline-flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full sm:h-[26px] sm:w-[26px]">
           <MarketplaceIcon
             kind={publisher.kind}
             label={publisher.displayName || publisher.handle}
@@ -216,7 +218,7 @@ export function PublisherOwnerDisplay({
         </span>
         <span className="min-w-0 truncate text-sm font-medium text-[color:var(--ink)]">
           {publisher.displayName || publisher.handle}
-          <span className="text-[13px] font-normal text-[color:var(--ink-soft)]">
+          <span className="hidden text-[13px] font-normal text-[color:var(--ink-soft)] sm:inline">
             {" "}
             / @{publisher.handle}
           </span>

--- a/src/components/PublisherOwnerSelect.tsx
+++ b/src/components/PublisherOwnerSelect.tsx
@@ -36,7 +36,7 @@ export function PublisherContextStrip({
     <div
       role="group"
       aria-label="Publishing as"
-      className="flex min-h-[52px] flex-wrap items-center bg-[color:var(--surface-muted)] px-4 py-space-3 text-sm text-[color:var(--ink)] sm:px-space-5"
+      className="flex min-h-[42px] flex-wrap items-center bg-[color:var(--surface-muted)] px-4 py-2 text-sm text-[color:var(--ink)] sm:px-space-5"
     >
       <div className="flex w-full min-w-0 items-center gap-2">
         <span className="hidden shrink-0 text-xs font-medium text-[color:var(--ink-soft)] sm:inline">

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -5,8 +5,6 @@ import { cn } from "../../lib/utils";
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
-const DropdownMenuSub = DropdownMenuPrimitive.Sub;
-const DropdownMenuSubTrigger = DropdownMenuPrimitive.SubTrigger;
 
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
@@ -30,25 +28,6 @@ const DropdownMenuContent = React.forwardRef<
   </DropdownMenuPrimitive.Portal>
 ));
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
-
-const DropdownMenuSubContent = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubContent
-    ref={ref}
-    data-slot="dropdown-menu-sub-content"
-    className={cn(
-      "z-50 min-w-[180px] origin-[var(--radix-dropdown-menu-content-transform-origin)] overflow-hidden rounded-[var(--radius-md)] border border-[color:var(--line)] bg-[color:var(--surface)] p-2 text-[color:var(--ink)] shadow-[var(--shadow)]",
-      "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
-      "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
-      "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className,
-    )}
-    {...props}
-  />
-));
-DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
 
 const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,
@@ -109,11 +88,8 @@ DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
 
 export {
   DropdownMenu,
-  DropdownMenuSub,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   DropdownMenuContent,
-  DropdownMenuSubContent,
   DropdownMenuCheckboxItem,
   DropdownMenuItem,
   DropdownMenuSeparator,

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -5,6 +5,8 @@ import { cn } from "../../lib/utils";
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+const DropdownMenuSubTrigger = DropdownMenuPrimitive.SubTrigger;
 
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
@@ -28,6 +30,25 @@ const DropdownMenuContent = React.forwardRef<
   </DropdownMenuPrimitive.Portal>
 ));
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    data-slot="dropdown-menu-sub-content"
+    className={cn(
+      "z-50 min-w-[180px] origin-[var(--radix-dropdown-menu-content-transform-origin)] overflow-hidden rounded-[var(--radius-md)] border border-[color:var(--line)] bg-[color:var(--surface)] p-2 text-[color:var(--ink)] shadow-[var(--shadow)]",
+      "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+      "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+      "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
 
 const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,
@@ -88,8 +109,11 @@ DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
 
 export {
   DropdownMenu,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   DropdownMenuContent,
+  DropdownMenuSubContent,
   DropdownMenuCheckboxItem,
   DropdownMenuItem,
   DropdownMenuSeparator,

--- a/src/lib/activePublisher.test.tsx
+++ b/src/lib/activePublisher.test.tsx
@@ -79,7 +79,7 @@ describe("ActivePublisherProvider", () => {
       me,
     });
     useQueryMock.mockImplementation((query, args) => {
-      expect(getFunctionName(query)).toBe(getFunctionName(api.publishers.listMine));
+      expect(getFunctionName(query)).toBe(getFunctionName(api.publishers.listMineMemberships));
       if (args === "skip") return undefined;
       return memberships;
     });
@@ -97,7 +97,7 @@ describe("ActivePublisherProvider", () => {
       </ProviderHarness>,
     );
 
-    expect(useQueryMock).toHaveBeenCalledWith(api.publishers.listMine, "skip");
+    expect(useQueryMock).toHaveBeenCalledWith(api.publishers.listMineMemberships, "skip");
     expect(screen.getByTestId("active-handle").textContent).toBe("none");
   });
 

--- a/src/lib/activePublisher.test.tsx
+++ b/src/lib/activePublisher.test.tsx
@@ -1,0 +1,154 @@
+/* @vitest-environment jsdom */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { getFunctionName } from "convex/server";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api } from "../../convex/_generated/api";
+import { ActivePublisherProvider, useActivePublisher } from "./activePublisher";
+
+const useQueryMock = vi.fn();
+const useAuthStatusMock = vi.fn();
+
+vi.mock("convex/react", () => ({
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
+}));
+
+vi.mock("./useAuthStatus", () => ({
+  useAuthStatus: () => useAuthStatusMock(),
+}));
+
+const me = {
+  _id: "users:local",
+  handle: "local",
+};
+
+const personalPublisher = {
+  publisher: {
+    _id: "publishers:local",
+    handle: "local",
+    displayName: "Local",
+    kind: "user",
+    image: null,
+  },
+  role: "owner",
+};
+
+const orgPublisher = {
+  publisher: {
+    _id: "publishers:openclaw",
+    handle: "openclaw",
+    displayName: "OpenClaw",
+    kind: "org",
+    image: null,
+  },
+  role: "admin",
+};
+
+const publisherStorageKey = "clawhub-active-publisher:users:local";
+
+function ProviderHarness({ children }: { children: ReactNode }) {
+  return <ActivePublisherProvider>{children}</ActivePublisherProvider>;
+}
+
+function Probe() {
+  const activePublisher = useActivePublisher();
+  return (
+    <div>
+      <div data-testid="active-handle">{activePublisher.activeOwnerHandle ?? "none"}</div>
+      <div data-testid="can-manage">{activePublisher.canManageActivePublisher ? "yes" : "no"}</div>
+      <button
+        type="button"
+        onClick={() => activePublisher.setActivePublisherId("publishers:openclaw" as never)}
+      >
+        Switch org
+      </button>
+    </div>
+  );
+}
+
+describe("ActivePublisherProvider", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    useQueryMock.mockReset();
+    useAuthStatusMock.mockReset();
+    useAuthStatusMock.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      me,
+    });
+    useQueryMock.mockImplementation((query, args) => {
+      expect(getFunctionName(query)).toBe(getFunctionName(api.publishers.listMine));
+      if (args === "skip") return undefined;
+      return [personalPublisher, orgPublisher];
+    });
+  });
+
+  it("loads memberships only after the signed-in user row exists", () => {
+    useAuthStatusMock.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: true,
+      me: undefined,
+    });
+    render(
+      <ProviderHarness>
+        <Probe />
+      </ProviderHarness>,
+    );
+
+    expect(useQueryMock).toHaveBeenCalledWith(api.publishers.listMine, "skip");
+    expect(screen.getByTestId("active-handle").textContent).toBe("none");
+  });
+
+  it("falls back to the personal publisher and persists direct switches", async () => {
+    render(
+      <ProviderHarness>
+        <Probe />
+      </ProviderHarness>,
+    );
+
+    expect(screen.getByTestId("active-handle").textContent).toBe("local");
+
+    screen.getByRole("button", { name: "Switch org" }).click();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("active-handle").textContent).toBe("openclaw");
+    });
+    expect(screen.getByTestId("can-manage").textContent).toBe("yes");
+    expect(window.localStorage.getItem(publisherStorageKey)).toBe("publishers:openclaw");
+  });
+
+  it("clears stale persisted publishers and returns to the personal publisher", async () => {
+    window.localStorage.setItem(publisherStorageKey, "publishers:stale");
+
+    render(
+      <ProviderHarness>
+        <Probe />
+      </ProviderHarness>,
+    );
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(publisherStorageKey)).toBeNull();
+    });
+    expect(screen.getByTestId("active-handle").textContent).toBe("local");
+  });
+
+  it("syncs active publisher changes from another tab", async () => {
+    render(
+      <ProviderHarness>
+        <Probe />
+      </ProviderHarness>,
+    );
+
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: publisherStorageKey,
+        newValue: "publishers:openclaw",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("active-handle").textContent).toBe("openclaw");
+    });
+  });
+});

--- a/src/lib/activePublisher.test.tsx
+++ b/src/lib/activePublisher.test.tsx
@@ -46,6 +46,7 @@ const orgPublisher = {
 };
 
 const publisherStorageKey = "clawhub-active-publisher:users:local";
+let memberships = [personalPublisher, orgPublisher];
 
 function ProviderHarness({ children }: { children: ReactNode }) {
   return <ActivePublisherProvider>{children}</ActivePublisherProvider>;
@@ -80,7 +81,7 @@ describe("ActivePublisherProvider", () => {
     useQueryMock.mockImplementation((query, args) => {
       expect(getFunctionName(query)).toBe(getFunctionName(api.publishers.listMine));
       if (args === "skip") return undefined;
-      return [personalPublisher, orgPublisher];
+      return memberships;
     });
   });
 
@@ -131,6 +132,34 @@ describe("ActivePublisherProvider", () => {
       expect(window.localStorage.getItem(publisherStorageKey)).toBeNull();
     });
     expect(screen.getByTestId("active-handle").textContent).toBe("local");
+  });
+
+  it("keeps a pending publisher selected until memberships include it", async () => {
+    memberships = [personalPublisher];
+
+    const { rerender } = render(
+      <ProviderHarness>
+        <Probe />
+      </ProviderHarness>,
+    );
+
+    expect(screen.getByTestId("active-handle").textContent).toBe("local");
+
+    screen.getByRole("button", { name: "Switch org" }).click();
+
+    expect(window.localStorage.getItem(publisherStorageKey)).toBe("publishers:openclaw");
+    expect(screen.getByTestId("active-handle").textContent).toBe("local");
+
+    memberships = [personalPublisher, orgPublisher];
+    rerender(
+      <ProviderHarness>
+        <Probe />
+      </ProviderHarness>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("active-handle").textContent).toBe("openclaw");
+    });
   });
 
   it("syncs active publisher changes from another tab", async () => {

--- a/src/lib/activePublisher.tsx
+++ b/src/lib/activePublisher.tsx
@@ -16,7 +16,7 @@ const ACTIVE_PUBLISHER_STORAGE_PREFIX = "clawhub-active-publisher";
 
 type PublisherRole = "owner" | "admin" | "publisher";
 
-export type ActivePublisherMembership = {
+type ActivePublisherMembership = {
   publisher: Pick<
     Doc<"publishers">,
     "_id" | "handle" | "displayName" | "kind" | "image" | "linkedUserId"

--- a/src/lib/activePublisher.tsx
+++ b/src/lib/activePublisher.tsx
@@ -116,7 +116,7 @@ export function ActivePublisherProvider({ children }: { children: ReactNode }) {
   }, [memberships, selectedPublisherId, userId]);
 
   useEffect(() => {
-    if (!userId || typeof window === "undefined") return;
+    if (!userId || typeof window === "undefined") return undefined;
     const key = storageKeyForUser(userId);
     const onStorage = (event: StorageEvent) => {
       if (event.key !== key) return;

--- a/src/lib/activePublisher.tsx
+++ b/src/lib/activePublisher.tsx
@@ -99,10 +99,12 @@ export function ActivePublisherProvider({ children }: { children: ReactNode }) {
     | ActivePublisherMembership[]
     | undefined;
   const [selectedPublisherId, setSelectedPublisherIdState] = useState<string | null>(null);
+  const [pendingPublisherId, setPendingPublisherId] = useState<string | null>(null);
   const userId = me?._id ? String(me._id) : null;
 
   useEffect(() => {
     setSelectedPublisherIdState(userId ? readStoredPublisherId(userId) : null);
+    setPendingPublisherId(null);
   }, [userId]);
 
   useEffect(() => {
@@ -110,10 +112,14 @@ export function ActivePublisherProvider({ children }: { children: ReactNode }) {
     const selectedStillExists = memberships.some(
       (entry) => entry.publisher._id === selectedPublisherId,
     );
-    if (selectedStillExists) return;
+    if (selectedStillExists) {
+      if (pendingPublisherId === selectedPublisherId) setPendingPublisherId(null);
+      return;
+    }
+    if (pendingPublisherId === selectedPublisherId) return;
     clearStoredPublisherId(userId);
     setSelectedPublisherIdState(null);
-  }, [memberships, selectedPublisherId, userId]);
+  }, [memberships, pendingPublisherId, selectedPublisherId, userId]);
 
   useEffect(() => {
     if (!userId || typeof window === "undefined") return undefined;
@@ -130,7 +136,7 @@ export function ActivePublisherProvider({ children }: { children: ReactNode }) {
     (publisherId: Id<"publishers">) => {
       if (!userId) return;
       const hasPublisher = memberships?.some((entry) => entry.publisher._id === publisherId);
-      if (!hasPublisher) return;
+      setPendingPublisherId(hasPublisher ? null : publisherId);
       setSelectedPublisherIdState(publisherId);
       writeStoredPublisherId(userId, publisherId);
     },

--- a/src/lib/activePublisher.tsx
+++ b/src/lib/activePublisher.tsx
@@ -1,0 +1,188 @@
+import { useQuery } from "convex/react";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { api } from "../../convex/_generated/api";
+import type { Doc, Id } from "../../convex/_generated/dataModel";
+import { useAuthStatus } from "./useAuthStatus";
+
+const ACTIVE_PUBLISHER_STORAGE_PREFIX = "clawhub-active-publisher";
+
+type PublisherRole = "owner" | "admin" | "publisher";
+
+export type ActivePublisherMembership = {
+  publisher: Pick<
+    Doc<"publishers">,
+    "_id" | "handle" | "displayName" | "kind" | "image" | "linkedUserId"
+  > & {
+    image?: string | null;
+  };
+  role: PublisherRole;
+};
+
+type ActivePublisherContextValue = {
+  activePublisher: ActivePublisherMembership | null;
+  activePublisherId: Id<"publishers"> | null;
+  activeOwnerHandle: string | null;
+  canManageActivePublisher: boolean;
+  canPublishAsActivePublisher: boolean;
+  canViewActivePublisherScope: boolean;
+  hasMultiplePublishers: boolean;
+  isLoading: boolean;
+  memberships: ActivePublisherMembership[] | undefined;
+  personalPublisher: ActivePublisherMembership | null;
+  setActivePublisherId: (publisherId: Id<"publishers">) => void;
+};
+
+const ActivePublisherContext = createContext<ActivePublisherContextValue | null>(null);
+
+function storageKeyForUser(userId: string) {
+  return `${ACTIVE_PUBLISHER_STORAGE_PREFIX}:${userId}`;
+}
+
+function isManageRole(role: PublisherRole | undefined) {
+  return role === "owner" || role === "admin";
+}
+
+function resolveFallbackPublisher(memberships: ActivePublisherMembership[] | undefined) {
+  return memberships?.find((entry) => entry.publisher.kind === "user") ?? memberships?.[0] ?? null;
+}
+
+function resolveActivePublisher(
+  memberships: ActivePublisherMembership[] | undefined,
+  selectedPublisherId: string | null,
+) {
+  if (!memberships?.length) return null;
+  if (selectedPublisherId) {
+    const selected = memberships.find((entry) => entry.publisher._id === selectedPublisherId);
+    if (selected) return selected;
+  }
+  return resolveFallbackPublisher(memberships);
+}
+
+function readStoredPublisherId(userId: string) {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(storageKeyForUser(userId));
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredPublisherId(userId: string, publisherId: string) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(storageKeyForUser(userId), publisherId);
+  } catch {
+    // Local persistence is best-effort; the in-memory active publisher still updates.
+  }
+}
+
+function clearStoredPublisherId(userId: string) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(storageKeyForUser(userId));
+  } catch {
+    // Ignore storage failures; fallback selection still keeps the UI usable.
+  }
+}
+
+export function ActivePublisherProvider({ children }: { children: ReactNode }) {
+  const { isLoading: isAuthLoading, me } = useAuthStatus();
+  const memberships = useQuery(api.publishers.listMine, me ? {} : "skip") as
+    | ActivePublisherMembership[]
+    | undefined;
+  const [selectedPublisherId, setSelectedPublisherIdState] = useState<string | null>(null);
+  const userId = me?._id ? String(me._id) : null;
+
+  useEffect(() => {
+    setSelectedPublisherIdState(userId ? readStoredPublisherId(userId) : null);
+  }, [userId]);
+
+  useEffect(() => {
+    if (!userId || !memberships || !selectedPublisherId) return;
+    const selectedStillExists = memberships.some(
+      (entry) => entry.publisher._id === selectedPublisherId,
+    );
+    if (selectedStillExists) return;
+    clearStoredPublisherId(userId);
+    setSelectedPublisherIdState(null);
+  }, [memberships, selectedPublisherId, userId]);
+
+  useEffect(() => {
+    if (!userId || typeof window === "undefined") return;
+    const key = storageKeyForUser(userId);
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== key) return;
+      setSelectedPublisherIdState(event.newValue);
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, [userId]);
+
+  const setActivePublisherId = useCallback(
+    (publisherId: Id<"publishers">) => {
+      if (!userId) return;
+      const hasPublisher = memberships?.some((entry) => entry.publisher._id === publisherId);
+      if (!hasPublisher) return;
+      setSelectedPublisherIdState(publisherId);
+      writeStoredPublisherId(userId, publisherId);
+    },
+    [memberships, userId],
+  );
+
+  const activePublisher = resolveActivePublisher(memberships, selectedPublisherId);
+  const personalPublisher = resolveFallbackPublisher(memberships);
+  const activePublisherId = activePublisher?.publisher._id ?? null;
+  const activeOwnerHandle = activePublisher?.publisher.handle ?? null;
+  const canPublishAsActivePublisher = Boolean(activePublisher);
+  const canManageActivePublisher = isManageRole(activePublisher?.role);
+  const canViewActivePublisherScope = Boolean(activePublisher);
+  const isLoading = Boolean(me) && (isAuthLoading || memberships === undefined);
+
+  const value = useMemo<ActivePublisherContextValue>(
+    () => ({
+      activePublisher,
+      activePublisherId,
+      activeOwnerHandle,
+      canManageActivePublisher,
+      canPublishAsActivePublisher,
+      canViewActivePublisherScope,
+      hasMultiplePublishers: (memberships?.length ?? 0) > 1,
+      isLoading,
+      memberships,
+      personalPublisher,
+      setActivePublisherId,
+    }),
+    [
+      activeOwnerHandle,
+      activePublisher,
+      activePublisherId,
+      canManageActivePublisher,
+      canPublishAsActivePublisher,
+      canViewActivePublisherScope,
+      isLoading,
+      memberships,
+      personalPublisher,
+      setActivePublisherId,
+    ],
+  );
+
+  return (
+    <ActivePublisherContext.Provider value={value}>{children}</ActivePublisherContext.Provider>
+  );
+}
+
+export function useActivePublisher() {
+  const value = useContext(ActivePublisherContext);
+  if (!value) {
+    throw new Error("useActivePublisher must be used inside ActivePublisherProvider");
+  }
+  return value;
+}

--- a/src/lib/activePublisher.tsx
+++ b/src/lib/activePublisher.tsx
@@ -95,7 +95,7 @@ function clearStoredPublisherId(userId: string) {
 
 export function ActivePublisherProvider({ children }: { children: ReactNode }) {
   const { isLoading: isAuthLoading, me } = useAuthStatus();
-  const memberships = useQuery(api.publishers.listMine, me ? {} : "skip") as
+  const memberships = useQuery(api.publishers.listMineMemberships, me ? {} : "skip") as
     | ActivePublisherMembership[]
     | undefined;
   const [selectedPublisherId, setSelectedPublisherIdState] = useState<string | null>(null);

--- a/src/routes/-dashboard.test.tsx
+++ b/src/routes/-dashboard.test.tsx
@@ -1,5 +1,5 @@
 /* @vitest-environment jsdom */
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { getFunctionName } from "convex/server";
 import type React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -8,6 +8,7 @@ import { TooltipProvider } from "../components/ui/tooltip";
 import { Dashboard } from "./dashboard";
 
 const mocks = vi.hoisted(() => ({
+  useActivePublisher: vi.fn(),
   useQuery: vi.fn(),
   usePaginatedQuery: vi.fn(),
   useAuthStatus: vi.fn(),
@@ -20,6 +21,10 @@ vi.mock("convex/react", () => ({
 
 vi.mock("../lib/useAuthStatus", () => ({
   useAuthStatus: () => mocks.useAuthStatus(),
+}));
+
+vi.mock("../lib/activePublisher", () => ({
+  useActivePublisher: () => mocks.useActivePublisher(),
 }));
 
 vi.mock("@tanstack/react-router", () => ({
@@ -158,7 +163,17 @@ const me = {
   displayName: "Local Dev",
 };
 
-const publishers = [
+type TestPublisherMembership = {
+  publisher: {
+    _id: Id<"publishers">;
+    handle: string;
+    displayName: string;
+    kind: "user" | "org";
+  };
+  role: "owner" | "admin" | "publisher";
+};
+
+const publishers: TestPublisherMembership[] = [
   {
     publisher: {
       _id: "publishers:local" as Id<"publishers">,
@@ -250,6 +265,47 @@ function arrangeDashboard({
   });
 }
 
+function mockActivePublisher(
+  publisher: TestPublisherMembership = publishers[0]!,
+  overrides?: Partial<ActivePublisherState>,
+) {
+  mocks.useActivePublisher.mockReturnValue(createActivePublisherState(publisher, overrides));
+}
+
+type ActivePublisherState = {
+  activePublisher: TestPublisherMembership;
+  activePublisherId: Id<"publishers">;
+  activeOwnerHandle: string;
+  canManageActivePublisher: boolean;
+  canPublishAsActivePublisher: boolean;
+  canViewActivePublisherScope: boolean;
+  hasMultiplePublishers: boolean;
+  isLoading: boolean;
+  memberships: TestPublisherMembership[];
+  personalPublisher: TestPublisherMembership | null;
+  setActivePublisherId: () => void;
+};
+
+function createActivePublisherState(
+  publisher: TestPublisherMembership = publishers[0]!,
+  overrides?: Partial<ActivePublisherState>,
+): ActivePublisherState {
+  return {
+    activePublisher: publisher,
+    activePublisherId: publisher.publisher._id,
+    activeOwnerHandle: publisher.publisher.handle,
+    canManageActivePublisher: publisher.role !== "publisher",
+    canPublishAsActivePublisher: true,
+    canViewActivePublisherScope: true,
+    hasMultiplePublishers: false,
+    isLoading: false,
+    memberships: [publisher],
+    personalPublisher: publishers.find((entry) => entry.publisher.kind === "user") ?? null,
+    setActivePublisherId: vi.fn(),
+    ...overrides,
+  };
+}
+
 function renderDashboard() {
   return render(
     <TooltipProvider>
@@ -273,6 +329,7 @@ describe("Dashboard rows", () => {
       isLoading: false,
       me,
     });
+    mockActivePublisher();
   });
 
   it("renders compact clickable artifact cards with status and inventory context", () => {
@@ -340,19 +397,20 @@ describe("Dashboard rows", () => {
     );
   });
 
-  it("shows a publisher selector and loads org packages when switching publishers", async () => {
-    const orgPublishers = [
-      publishers[0],
-      {
-        publisher: {
-          _id: "publishers:clawkit" as Id<"publishers">,
-          handle: "clawkit",
-          displayName: "ClawKit",
-          kind: "org" as const,
-        },
-        role: "admin" as const,
+  it("loads packages for the active publisher from the app shell", async () => {
+    const orgPublisher = {
+      publisher: {
+        _id: "publishers:clawkit" as Id<"publishers">,
+        handle: "clawkit",
+        displayName: "ClawKit",
+        kind: "org" as const,
       },
-    ];
+      role: "admin" as const,
+    };
+    mockActivePublisher(orgPublisher, {
+      hasMultiplePublishers: true,
+      memberships: [publishers[0], orgPublisher],
+    });
     const orgPackage = createPackage({
       _id: "packages:clawkit" as Id<"packages">,
       name: "@clawkit/clawkit-for-lovable",
@@ -365,10 +423,8 @@ describe("Dashboard rows", () => {
       status: "Exhausted",
       loadMore: vi.fn(),
     });
-    mocks.useQuery.mockImplementation((query: unknown, args: unknown) => {
+    mocks.useQuery.mockImplementation((_query: unknown, args: unknown) => {
       if (args === "skip") return undefined;
-      const name = getFunctionName(query as never);
-      if (name === "publishers:listMine") return orgPublishers;
       if (
         typeof args === "object" &&
         args !== null &&
@@ -382,17 +438,6 @@ describe("Dashboard rows", () => {
 
     renderDashboard();
 
-    const selector = await screen.findByLabelText("Dashboard publisher");
-    await waitFor(() =>
-      expect(mocks.useQuery).toHaveBeenCalledWith(expect.anything(), {
-        ownerPublisherId: "publishers:local",
-        limit: 100,
-      }),
-    );
-    expect(screen.getByText("@clawkit · Org")).toBeTruthy();
-
-    fireEvent.change(selector, { target: { value: "publishers:clawkit" } });
-
     await waitFor(() =>
       expect(mocks.useQuery).toHaveBeenCalledWith(expect.anything(), {
         ownerPublisherId: "publishers:clawkit",
@@ -402,40 +447,70 @@ describe("Dashboard rows", () => {
     expect(screen.getByText("ClawKit for Lovable")).toBeTruthy();
   });
 
-  it("passes the selected publisher into skill publishing links", async () => {
-    const orgPublishers = [
-      publishers[0],
-      {
-        publisher: {
-          _id: "publishers:clawkit" as Id<"publishers">,
-          handle: "clawkit",
-          displayName: "ClawKit",
-          kind: "org" as const,
-        },
-        role: "admin" as const,
+  it("passes the active publisher into skill publishing links", async () => {
+    const orgPublisher = {
+      publisher: {
+        _id: "publishers:clawkit" as Id<"publishers">,
+        handle: "clawkit",
+        displayName: "ClawKit",
+        kind: "org" as const,
       },
-    ];
+      role: "admin" as const,
+    };
+    mockActivePublisher(orgPublisher, {
+      hasMultiplePublishers: true,
+      memberships: [publishers[0], orgPublisher],
+    });
     mocks.usePaginatedQuery.mockReturnValue({
       results: [],
       status: "Exhausted",
       loadMore: vi.fn(),
     });
-    mocks.useQuery.mockImplementation((query: unknown, args: unknown) => {
+    mocks.useQuery.mockImplementation((_query: unknown, args: unknown) => {
       if (args === "skip") return undefined;
-      const name = getFunctionName(query as never);
-      if (name === "publishers:listMine") return orgPublishers;
       return [];
     });
 
     renderDashboard();
 
-    fireEvent.change(await screen.findByLabelText("Dashboard publisher"), {
-      target: { value: "publishers:clawkit" },
-    });
-
     expect(
       (await screen.findByRole("link", { name: "Publish manually" })).getAttribute("href"),
     ).toBe("/skills/publish?ownerHandle=clawkit");
+  });
+
+  it("hides skill management actions for publisher-only org roles", () => {
+    const publisherOnlyOrg = {
+      publisher: {
+        _id: "publishers:clawkit" as Id<"publishers">,
+        handle: "clawkit",
+        displayName: "ClawKit",
+        kind: "org" as const,
+      },
+      role: "publisher" as const,
+    };
+    mockActivePublisher(publisherOnlyOrg, {
+      memberships: [publishers[0], publisherOnlyOrg],
+      hasMultiplePublishers: true,
+      canManageActivePublisher: false,
+    });
+    arrangeDashboard({
+      skills: [
+        createSkill({
+          ownerPublisherId: "publishers:clawkit" as Id<"publishers">,
+          detailHref: "/clawkit/local-flagged-skill",
+          settingsHref: "/clawkit/local-flagged-skill/settings",
+        }),
+      ],
+    });
+
+    renderDashboard();
+
+    expect(
+      screen.queryByRole("link", { name: "Open settings for Local Flagged Skill" }),
+    ).toBeNull();
+    expect(screen.getByRole("link", { name: "New Skill" }).getAttribute("href")).toBe(
+      "/skills/publish?ownerHandle=clawkit",
+    );
   });
 
   it("renders a skeleton while auth state is loading", () => {

--- a/src/routes/-dashboard.test.tsx
+++ b/src/routes/-dashboard.test.tsx
@@ -447,6 +447,42 @@ describe("Dashboard rows", () => {
     expect(screen.getByText("ClawKit for Lovable")).toBeTruthy();
   });
 
+  it("loads personal dashboards through the user owner even with a publisher context", async () => {
+    const syntheticPersonalPublisher = {
+      publisher: {
+        _id: "publishers:synthetic-local" as Id<"publishers">,
+        handle: "local",
+        displayName: "Local",
+        kind: "user" as const,
+      },
+      role: "owner" as const,
+    };
+    mockActivePublisher(syntheticPersonalPublisher, {
+      memberships: [syntheticPersonalPublisher],
+      personalPublisher: syntheticPersonalPublisher,
+    });
+    arrangeDashboard({ skills: [createSkill()], packages: [createPackage()] });
+
+    renderDashboard();
+
+    await waitFor(() =>
+      expect(mocks.usePaginatedQuery).toHaveBeenCalledWith(
+        expect.anything(),
+        { ownerUserId: me._id },
+        { initialNumItems: 50 },
+      ),
+    );
+    expect(mocks.useQuery).toHaveBeenCalledWith(expect.anything(), {
+      ownerUserId: me._id,
+      limit: 100,
+    });
+    expect(mocks.usePaginatedQuery).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ ownerPublisherId: "publishers:synthetic-local" }),
+      expect.anything(),
+    );
+  });
+
   it("passes the active publisher into skill publishing links", async () => {
     const orgPublisher = {
       publisher: {

--- a/src/routes/-settings.test.tsx
+++ b/src/routes/-settings.test.tsx
@@ -69,6 +69,13 @@ const orgMembership = {
     image: null,
     bio: "OpenClaw publisher",
     official: true,
+    stats: {
+      skills: 4,
+      packages: 2,
+      installs: 120,
+      downloads: 500,
+      stars: 24,
+    },
   },
   role: "owner",
 };
@@ -364,7 +371,11 @@ describe("Settings", () => {
       "true",
     );
     expect(await screen.findByText("OpenClaw Team")).toBeTruthy();
-    expect(screen.getByText("@openclaw · owner")).toBeTruthy();
+    expect(screen.getByText("@openclaw")).toBeTruthy();
+    expect(screen.getByText("Owner")).toBeTruthy();
+    expect(screen.getByText("Official")).toBeTruthy();
+    expect(screen.getByText("4 skills")).toBeTruthy();
+    expect(screen.getByText("2 packages")).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "Members" })).toBeNull();
     expect(useQueryMock).toHaveBeenCalledWith(api.publishers.listMembers, "skip");
     fireEvent.click(screen.getByRole("button", { name: "Manage" }));

--- a/src/routes/-settings.test.tsx
+++ b/src/routes/-settings.test.tsx
@@ -409,11 +409,9 @@ describe("Settings", () => {
     expect(screen.queryByRole("button", { name: "Delete organization" })).toBeNull();
     expect(screen.queryByRole("button", { name: "GitHub Skill Sync" })).toBeNull();
     expect((screen.getByLabelText("Display name") as HTMLInputElement).disabled).toBe(true);
-    expect((screen.getByLabelText("Avatar URL") as HTMLInputElement).disabled).toBe(true);
+    expect(screen.queryByLabelText("Avatar URL")).toBeNull();
     expect((screen.getByLabelText("Bio") as HTMLTextAreaElement).disabled).toBe(true);
-    expect(screen.getByRole("button", { name: "Save profile" }).hasAttribute("disabled")).toBe(
-      true,
-    );
+    expect(screen.queryByRole("button", { name: "Save profile" })).toBeNull();
     expect(screen.getByText(/You can publish under this org/i)).toBeTruthy();
     expect(useQueryMock).toHaveBeenCalledWith(api.publishers.listMembers, "skip");
     expect(useQueryMock).toHaveBeenCalledWith(api.githubSkillSources.listForPublisher, "skip");

--- a/src/routes/-settings.test.tsx
+++ b/src/routes/-settings.test.tsx
@@ -324,6 +324,26 @@ describe("Settings", () => {
     expect(useQueryMock.mock.calls.some(([, args]) => args === "skip")).toBe(true);
   });
 
+  it("preserves org settings deep links while memberships load", () => {
+    mockSignedInSettings({
+      search: { view: "members" },
+      memberships: [personalMembership, orgMembership],
+      activePublisher: orgMembership,
+    });
+    useQueryMock.mockImplementation((query, args) => {
+      const queryName = query ? getFunctionName(query) : "";
+      if (args === "skip") return undefined;
+      if (queryName === "tokens:listMine") return [];
+      if (queryName === "publishers:listMine") return undefined;
+      return [];
+    });
+
+    render(<Settings />);
+
+    expect(screen.getByLabelText(/loading settings/i)).toBeTruthy();
+    expect(navigateMock).not.toHaveBeenCalledWith({ search: { view: "profile" }, replace: true });
+  });
+
   it("renders the personal profile as the default settings view", () => {
     mockSignedInSettings();
 

--- a/src/routes/-settings.test.tsx
+++ b/src/routes/-settings.test.tsx
@@ -375,7 +375,7 @@ describe("Settings", () => {
     expect(screen.getByText("Owner")).toBeTruthy();
     expect(screen.getByText("Official")).toBeTruthy();
     expect(screen.getByText("4 skills")).toBeTruthy();
-    expect(screen.getByText("2 packages")).toBeTruthy();
+    expect(screen.getByText("2 plugins")).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "Members" })).toBeNull();
     expect(useQueryMock).toHaveBeenCalledWith(api.publishers.listMembers, "skip");
     fireEvent.click(screen.getByRole("button", { name: "Manage" }));

--- a/src/routes/-settings.test.tsx
+++ b/src/routes/-settings.test.tsx
@@ -456,7 +456,7 @@ describe("Settings", () => {
       "true",
     );
     expect(screen.queryByRole("button", { name: "Members" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Delete organization" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Danger zone" })).toBeNull();
     expect(screen.queryByRole("button", { name: "GitHub Skill Sync" })).toBeNull();
     expect((screen.getByLabelText("Display name") as HTMLInputElement).disabled).toBe(true);
     expect(screen.queryByLabelText("Avatar URL")).toBeNull();

--- a/src/routes/-settings.test.tsx
+++ b/src/routes/-settings.test.tsx
@@ -86,6 +86,19 @@ const clawkitMembership = {
   role: "admin",
 };
 
+const publisherOnlyOrgMembership = {
+  publisher: {
+    _id: "publisher_readonly",
+    handle: "readonly-org",
+    displayName: "Readonly Org",
+    kind: "org",
+    image: null,
+    bio: "Publish-only org",
+    official: true,
+  },
+  role: "publisher",
+};
+
 const personalMembership = {
   publisher: {
     _id: "publisher_patrick",
@@ -138,12 +151,18 @@ function mockSignedInSettings({
   setActivePublisherId = vi.fn(),
 }: {
   search?: Record<string, unknown>;
-  memberships?: Array<typeof orgMembership | typeof personalMembership | typeof clawkitMembership>;
+  memberships?: Array<
+    | typeof orgMembership
+    | typeof personalMembership
+    | typeof clawkitMembership
+    | typeof publisherOnlyOrgMembership
+  >;
   members?: typeof orgMembers | typeof clawkitMembers;
   activePublisher?:
     | typeof orgMembership
     | typeof personalMembership
     | typeof clawkitMembership
+    | typeof publisherOnlyOrgMembership
     | null;
   setActivePublisherId?: ReturnType<typeof vi.fn>;
   githubSources?: Array<{
@@ -372,6 +391,32 @@ describe("Settings", () => {
     expect(useQueryMock).toHaveBeenCalledWith(api.publishers.listMembers, {
       publisherHandle: "clawkit",
     });
+  });
+
+  it("shows publish-only org settings as read-only", () => {
+    mockSignedInSettings({
+      memberships: [personalMembership, publisherOnlyOrgMembership],
+      activePublisher: publisherOnlyOrgMembership,
+    });
+
+    render(<Settings />);
+
+    expect(screen.getByText("Manage @readonly-org's publisher profile and access.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Profile" }).getAttribute("aria-current")).toBe(
+      "true",
+    );
+    expect(screen.queryByRole("button", { name: "Members" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Delete organization" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "GitHub Skill Sync" })).toBeNull();
+    expect((screen.getByLabelText("Display name") as HTMLInputElement).disabled).toBe(true);
+    expect((screen.getByLabelText("Avatar URL") as HTMLInputElement).disabled).toBe(true);
+    expect((screen.getByLabelText("Bio") as HTMLTextAreaElement).disabled).toBe(true);
+    expect(screen.getByRole("button", { name: "Save profile" }).hasAttribute("disabled")).toBe(
+      true,
+    );
+    expect(screen.getByText(/You can publish under this org/i)).toBeTruthy();
+    expect(useQueryMock).toHaveBeenCalledWith(api.publishers.listMembers, "skip");
+    expect(useQueryMock).toHaveBeenCalledWith(api.githubSkillSources.listForPublisher, "skip");
   });
 
   it("aliases legacy organization settings URLs to the active org profile", () => {

--- a/src/routes/-settings.test.tsx
+++ b/src/routes/-settings.test.tsx
@@ -131,10 +131,11 @@ const clawkitMembers = {
 
 function mockSignedInSettings({
   search = {},
-  memberships = [orgMembership],
+  memberships = [personalMembership, orgMembership],
   members = orgMembers,
   githubSources = [],
   activePublisher = null,
+  setActivePublisherId = vi.fn(),
 }: {
   search?: Record<string, unknown>;
   memberships?: Array<typeof orgMembership | typeof personalMembership | typeof clawkitMembership>;
@@ -144,6 +145,7 @@ function mockSignedInSettings({
     | typeof personalMembership
     | typeof clawkitMembership
     | null;
+  setActivePublisherId?: ReturnType<typeof vi.fn>;
   githubSources?: Array<{
     _id: string;
     repo: string;
@@ -201,7 +203,7 @@ function mockSignedInSettings({
     isLoading: false,
     memberships,
     personalPublisher: memberships.find((entry) => entry.publisher.kind === "user") ?? null,
-    setActivePublisherId: vi.fn(),
+    setActivePublisherId,
   });
   useQueryMock.mockImplementation((query, args) => {
     const queryName = query ? getFunctionName(query) : "";
@@ -210,6 +212,7 @@ function mockSignedInSettings({
     if (queryName === "tokens:listMine") return [];
     if (queryName === "publishers:listMine") return memberships;
     if (queryName === "publishers:listMembers") return members;
+    if (queryName === "githubSkillSources:listForPublisher") return githubSources;
     if (queryName === "githubSkillSources:listForManageableOfficialPublishers")
       return githubSources;
     if (args && typeof args === "object" && "publisherHandle" in args) return members;
@@ -281,15 +284,29 @@ describe("Settings", () => {
     expect(useQueryMock.mock.calls.some(([, args]) => args === "skip")).toBe(true);
   });
 
-  it("renders account and appearance inside signed-in account preferences", () => {
+  it("renders the personal profile as the default settings view", () => {
     mockSignedInSettings();
 
     render(<Settings />);
 
-    expect(screen.getByRole("button", { name: "Account & Preferences" })).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Account" })).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Appearance" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Profile" }).getAttribute("aria-current")).toBe(
+      "true",
+    );
+    expect(screen.getByRole("heading", { name: "Patrick" })).toBeTruthy();
+    expect((screen.getByLabelText("Display name") as HTMLInputElement).value).toBe("Patrick");
     expect(screen.queryByRole("heading", { name: "Stars" })).toBeNull();
+    expect(screen.queryByRole("radio", { name: /system/i })).toBeNull();
+  });
+
+  it("keeps appearance as a separate personal settings view", () => {
+    mockSignedInSettings({ search: { view: "appearance" } });
+
+    render(<Settings />);
+
+    expect(screen.getByRole("button", { name: "Appearance" }).getAttribute("aria-current")).toBe(
+      "true",
+    );
+    expect(screen.getByRole("heading", { name: "Appearance" })).toBeTruthy();
     expect(screen.getByRole("radio", { name: /system/i })).toBeTruthy();
     expect(screen.queryByText(/tweakcn overlay/i)).toBeNull();
     expect(screen.queryByText(/density/i)).toBeNull();
@@ -299,7 +316,7 @@ describe("Settings", () => {
     expect(screen.queryByText(/experimental features/i)).toBeNull();
   });
 
-  it("does not load organization members on the default account view", () => {
+  it("does not load organization members on the default profile view", () => {
     mockSignedInSettings();
 
     render(<Settings />);
@@ -318,8 +335,9 @@ describe("Settings", () => {
     expect(navigateMock).toHaveBeenCalledWith({ search: { view: "organizations" } });
   });
 
-  it("renders organization management and loads members only on the organizations view", async () => {
-    mockSignedInSettings({ search: { view: "organizations" } });
+  it("renders personal organization switching without loading members", async () => {
+    const setActivePublisherId = vi.fn();
+    mockSignedInSettings({ search: { view: "organizations" }, setActivePublisherId });
 
     render(<Settings />);
 
@@ -328,38 +346,67 @@ describe("Settings", () => {
     );
     expect(await screen.findByText("OpenClaw Team")).toBeTruthy();
     expect(screen.getByText("@openclaw · owner")).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Members" })).toBeTruthy();
-    expect(screen.getByText("Patrick")).toBeTruthy();
-    expect(useQueryMock).toHaveBeenCalledWith(api.publishers.listMembers, {
-      publisherHandle: "openclaw",
-    });
+    expect(screen.queryByRole("heading", { name: "Members" })).toBeNull();
+    expect(useQueryMock).toHaveBeenCalledWith(api.publishers.listMembers, "skip");
+    fireEvent.click(screen.getByRole("button", { name: "Manage" }));
+
+    expect(setActivePublisherId).toHaveBeenCalledWith("publisher_openclaw");
+    expect(navigateMock).toHaveBeenCalledWith({ search: { view: "profile" } });
   });
 
-  it("preselects the active org when opening organization settings", async () => {
+  it("uses the active org as the members settings scope", async () => {
     mockSignedInSettings({
-      search: { view: "organizations" },
-      memberships: [orgMembership, clawkitMembership],
+      search: { view: "members" },
+      memberships: [personalMembership, orgMembership, clawkitMembership],
       members: clawkitMembers,
       activePublisher: clawkitMembership,
     });
 
     render(<Settings />);
 
-    expect(await screen.findByText("@clawkit · admin")).toBeTruthy();
-    expect(await screen.findByText("ClawKit")).toBeTruthy();
+    expect(screen.getByText("Manage @clawkit's publisher profile and access.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Members" }).getAttribute("aria-current")).toBe(
+      "true",
+    );
+    expect(await screen.findByText("Patrick")).toBeTruthy();
     expect(useQueryMock).toHaveBeenCalledWith(api.publishers.listMembers, {
       publisherHandle: "clawkit",
     });
   });
 
-  it("lets organization owners confirm org deletion", async () => {
-    const deleteOrg = vi.fn().mockResolvedValue({ deleted: true });
-    useMutationMock.mockReturnValue(deleteOrg);
-    mockSignedInSettings({ search: { view: "organizations" } });
+  it("aliases legacy organization settings URLs to the active org profile", () => {
+    mockSignedInSettings({
+      search: { view: "organizations" },
+      memberships: [personalMembership, orgMembership],
+      activePublisher: orgMembership,
+    });
 
     render(<Settings />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Delete organization" }));
+    expect(screen.getByRole("button", { name: "Profile" }).getAttribute("aria-current")).toBe(
+      "true",
+    );
+    expect(screen.queryByRole("button", { name: "Organizations" })).toBeNull();
+    expect(navigateMock).toHaveBeenCalledWith({ search: { view: "profile" }, replace: true });
+  });
+
+  it("lets organization owners confirm org deletion", async () => {
+    const deleteOrg = vi.fn().mockResolvedValue({ deleted: true });
+    useMutationMock.mockImplementation((mutation) =>
+      getFunctionName(mutation) === "publishers:deleteOrg" ? deleteOrg : vi.fn(),
+    );
+    mockSignedInSettings({
+      search: { view: "danger" },
+      memberships: [personalMembership, orgMembership],
+      activePublisher: orgMembership,
+    });
+
+    render(<Settings />);
+
+    const deleteOrganizationButtons = screen.getAllByRole("button", {
+      name: "Delete organization",
+    });
+    fireEvent.click(deleteOrganizationButtons[deleteOrganizationButtons.length - 1]);
 
     expect(await screen.findByText(/Permanently delete @openclaw/)).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Permanently delete organization" }));
@@ -422,6 +469,7 @@ describe("Settings", () => {
     mockSignedInSettings({
       search: { view: "githubSources" },
       memberships: [personalMembership, orgMembership],
+      activePublisher: orgMembership,
     });
 
     render(<Settings />);
@@ -432,10 +480,13 @@ describe("Settings", () => {
     expect(screen.getByRole("heading", { name: "Sync GitHub skills repo" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Synced repositories" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "No synced repositories" })).toBeTruthy();
-    expect(screen.getByLabelText("Publisher")).toBeTruthy();
+    expect(screen.queryByLabelText("Publisher")).toBeNull();
     expect(screen.getByPlaceholderText("https://github.com/owner/repo")).toBeTruthy();
     expect(screen.queryByText(/Publishing as/i)).toBeNull();
     expect(screen.queryByText(/skills\.sh\.json/i)).toBeNull();
+    expect(useQueryMock).toHaveBeenCalledWith(api.githubSkillSources.listForPublisher, {
+      ownerPublisherId: "publisher_openclaw",
+    });
 
     fireEvent.change(screen.getByLabelText("GitHub repo URL"), {
       target: { value: "https://github.com/NVIDIA/skills" },
@@ -460,7 +511,8 @@ describe("Settings", () => {
     );
     mockSignedInSettings({
       search: { view: "githubSources" },
-      memberships: [orgMembership],
+      memberships: [personalMembership, orgMembership],
+      activePublisher: orgMembership,
       githubSources: [
         {
           _id: "githubSkillSources:matt",
@@ -571,11 +623,11 @@ describe("Settings", () => {
     render(<Settings />);
 
     expect(screen.queryByRole("button", { name: "GitHub Skill Sync" })).toBeNull();
-    expect(
-      screen.getByRole("button", { name: "Account & Preferences" }).getAttribute("aria-current"),
-    ).toBe("true");
+    expect(screen.getByRole("button", { name: "Profile" }).getAttribute("aria-current")).toBe(
+      "true",
+    );
     expect(screen.queryByRole("heading", { name: "GitHub Skill Sync" })).toBeNull();
-    expect(screen.queryByPlaceholderText("Enter a public repo")).toBeNull();
+    expect(screen.queryByPlaceholderText("https://github.com/owner/repo")).toBeNull();
   });
 
   it("shows create organization mutation errors to the user", async () => {

--- a/src/routes/-settings.test.tsx
+++ b/src/routes/-settings.test.tsx
@@ -38,7 +38,21 @@ vi.mock("../lib/activePublisher", () => ({
 
 vi.mock("@tanstack/react-router", () => ({
   createFileRoute: () => (config: unknown) => config,
-  Link: ({ children, to }: { children: ReactNode; to: string }) => <a href={to}>{children}</a>,
+  Link: ({
+    children,
+    params,
+    to,
+  }: {
+    children: ReactNode;
+    params?: Record<string, string>;
+    to: string;
+  }) => {
+    const href = Object.entries(params ?? {}).reduce(
+      (path, [key, value]) => path.replace(`$${key}`, value),
+      to,
+    );
+    return <a href={href}>{children}</a>;
+  },
   useNavigate: () => navigateMock,
   useSearch: () => searchMock(),
 }));
@@ -376,12 +390,37 @@ describe("Settings", () => {
     expect(screen.getByText("Official")).toBeTruthy();
     expect(screen.getByText("4 skills")).toBeTruthy();
     expect(screen.getByText("2 plugins")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "View profile" }).getAttribute("href")).toBe(
+      "/user/openclaw",
+    );
     expect(screen.queryByRole("heading", { name: "Members" })).toBeNull();
     expect(useQueryMock).toHaveBeenCalledWith(api.publishers.listMembers, "skip");
     fireEvent.click(screen.getByRole("button", { name: "Manage" }));
 
     expect(setActivePublisherId).toHaveBeenCalledWith("publisher_openclaw");
     expect(navigateMock).toHaveBeenCalledWith({ search: { view: "profile" } });
+  });
+
+  it("lets publisher-only members view or switch to an organization", async () => {
+    const setActivePublisherId = vi.fn();
+    mockSignedInSettings({
+      search: { view: "organizations" },
+      memberships: [personalMembership, publisherOnlyOrgMembership],
+      setActivePublisherId,
+    });
+
+    render(<Settings />);
+
+    expect(await screen.findByText("Readonly Org")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "View profile" }).getAttribute("href")).toBe(
+      "/user/readonly-org",
+    );
+    expect(screen.queryByRole("button", { name: "Manage" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch" }));
+
+    expect(setActivePublisherId).toHaveBeenCalledWith("publisher_readonly");
+    expect(navigateMock).toHaveBeenCalledWith({ to: "/dashboard" });
   });
 
   it("uses the active org as the members settings scope", async () => {

--- a/src/routes/-settings.test.tsx
+++ b/src/routes/-settings.test.tsx
@@ -12,6 +12,7 @@ const useMutationMock = vi.fn();
 const useActionMock = vi.fn();
 const useAuthActionsMock = vi.fn();
 const useAuthStatusMock = vi.fn();
+const useActivePublisherMock = vi.fn();
 const { navigateMock, searchMock } = vi.hoisted(() => ({
   navigateMock: vi.fn(),
   searchMock: vi.fn(() => ({})),
@@ -29,6 +30,10 @@ vi.mock("@convex-dev/auth/react", () => ({
 
 vi.mock("../lib/useAuthStatus", () => ({
   useAuthStatus: () => useAuthStatusMock(),
+}));
+
+vi.mock("../lib/activePublisher", () => ({
+  useActivePublisher: () => useActivePublisherMock(),
 }));
 
 vi.mock("@tanstack/react-router", () => ({
@@ -68,6 +73,19 @@ const orgMembership = {
   role: "owner",
 };
 
+const clawkitMembership = {
+  publisher: {
+    _id: "publisher_clawkit",
+    handle: "clawkit",
+    displayName: "ClawKit",
+    kind: "org",
+    image: null,
+    bio: "ClawKit publisher",
+    official: false,
+  },
+  role: "admin",
+};
+
 const personalMembership = {
   publisher: {
     _id: "publisher_patrick",
@@ -96,15 +114,36 @@ const orgMembers = {
   ],
 };
 
+const clawkitMembers = {
+  publisher: { _id: "publisher_clawkit", handle: "clawkit" },
+  members: [
+    {
+      role: "admin",
+      user: {
+        _id: "user_123",
+        handle: "patrick",
+        displayName: "Patrick",
+        image: null,
+      },
+    },
+  ],
+};
+
 function mockSignedInSettings({
   search = {},
   memberships = [orgMembership],
   members = orgMembers,
   githubSources = [],
+  activePublisher = null,
 }: {
   search?: Record<string, unknown>;
-  memberships?: Array<typeof orgMembership | typeof personalMembership>;
-  members?: typeof orgMembers;
+  memberships?: Array<typeof orgMembership | typeof personalMembership | typeof clawkitMembership>;
+  members?: typeof orgMembers | typeof clawkitMembers;
+  activePublisher?:
+    | typeof orgMembership
+    | typeof personalMembership
+    | typeof clawkitMembership
+    | null;
   githubSources?: Array<{
     _id: string;
     repo: string;
@@ -151,6 +190,19 @@ function mockSignedInSettings({
     me: signedInUser,
   });
   searchMock.mockReturnValue(search);
+  useActivePublisherMock.mockReturnValue({
+    activePublisher,
+    activePublisherId: activePublisher?.publisher._id ?? null,
+    activeOwnerHandle: activePublisher?.publisher.handle ?? null,
+    canManageActivePublisher: true,
+    canPublishAsActivePublisher: true,
+    canViewActivePublisherScope: true,
+    hasMultiplePublishers: memberships.length > 1,
+    isLoading: false,
+    memberships,
+    personalPublisher: memberships.find((entry) => entry.publisher.kind === "user") ?? null,
+    setActivePublisherId: vi.fn(),
+  });
   useQueryMock.mockImplementation((query, args) => {
     const queryName = query ? getFunctionName(query) : "";
     if (queryName === "users:me") return signedInUser;
@@ -182,6 +234,7 @@ describe("Settings", () => {
     useActionMock.mockReset();
     useAuthActionsMock.mockReset();
     useAuthStatusMock.mockReset();
+    useActivePublisherMock.mockReset();
     navigateMock.mockReset();
     searchMock.mockReset();
     searchMock.mockReturnValue({});
@@ -197,6 +250,19 @@ describe("Settings", () => {
       isAuthenticated: true,
       isLoading: false,
       me: signedInUser,
+    });
+    useActivePublisherMock.mockReturnValue({
+      activePublisher: null,
+      activePublisherId: null,
+      activeOwnerHandle: null,
+      canManageActivePublisher: false,
+      canPublishAsActivePublisher: false,
+      canViewActivePublisherScope: false,
+      hasMultiplePublishers: false,
+      isLoading: false,
+      memberships: [],
+      personalPublisher: null,
+      setActivePublisherId: vi.fn(),
     });
   });
 
@@ -266,6 +332,23 @@ describe("Settings", () => {
     expect(screen.getByText("Patrick")).toBeTruthy();
     expect(useQueryMock).toHaveBeenCalledWith(api.publishers.listMembers, {
       publisherHandle: "openclaw",
+    });
+  });
+
+  it("preselects the active org when opening organization settings", async () => {
+    mockSignedInSettings({
+      search: { view: "organizations" },
+      memberships: [orgMembership, clawkitMembership],
+      members: clawkitMembers,
+      activePublisher: clawkitMembership,
+    });
+
+    render(<Settings />);
+
+    expect(await screen.findByText("@clawkit · admin")).toBeTruthy();
+    expect(await screen.findByText("ClawKit")).toBeTruthy();
+    expect(useQueryMock).toHaveBeenCalledWith(api.publishers.listMembers, {
+      publisherHandle: "clawkit",
     });
   });
 

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { usePaginatedQuery, useQuery } from "convex/react";
 import { AlertTriangle, Box, Download, Loader2, Package, Plus, Settings } from "lucide-react";
-import { useState } from "react";
 import { api } from "../../convex/_generated/api";
 import type { Doc } from "../../convex/_generated/dataModel";
 import { ArtifactCard } from "../components/artifacts/ArtifactCard";
@@ -10,13 +9,7 @@ import { SignInPrompt } from "../components/SignInPrompt";
 import { DashboardSkeleton } from "../components/skeletons/DashboardSkeleton";
 import { buildSkillHref } from "../components/skillDetailUtils";
 import { Button } from "../components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "../components/ui/select";
+import { useActivePublisher } from "../lib/activePublisher";
 import { buildPluginDetailHref, buildPluginValidationHref } from "../lib/pluginRoutes";
 import { useAuthStatus } from "../lib/useAuthStatus";
 
@@ -105,34 +98,18 @@ export const Route = createFileRoute("/dashboard")({
 
 export function Dashboard() {
   const { isAuthenticated, isLoading: isAuthLoading, me } = useAuthStatus();
-  const publishers = useQuery(api.publishers.listMine, me ? {} : "skip") as
-    | Array<{
-        publisher: {
-          _id: string;
-          handle: string;
-          displayName: string;
-          kind: "user" | "org";
-        };
-        role: "owner" | "admin" | "publisher";
-      }>
-    | undefined;
-  const [selectedPublisherId, setSelectedPublisherId] = useState<string>("");
-  const defaultPublisher =
-    publishers?.find((entry) => entry.publisher.kind === "user") ?? publishers?.[0] ?? null;
-  const selectedPublisherFromState = selectedPublisherId
-    ? (publishers?.find((entry) => entry.publisher._id === selectedPublisherId) ?? null)
-    : null;
-  const selectedPublisher = selectedPublisherFromState ?? defaultPublisher ?? null;
-  const activePublisherId = selectedPublisher?.publisher._id ?? "";
+  const {
+    activePublisherId,
+    activeOwnerHandle,
+    canManageActivePublisher,
+    isLoading: isPublisherLoading,
+  } = useActivePublisher();
 
-  const skillsQueryArgs =
-    selectedPublisher?.publisher.kind === "user" && me?._id
+  const skillsQueryArgs = activePublisherId
+    ? { ownerPublisherId: activePublisherId }
+    : me?._id
       ? { ownerUserId: me._id }
-      : activePublisherId
-        ? { ownerPublisherId: activePublisherId as Doc<"publishers">["_id"] }
-        : me?._id
-          ? { ownerUserId: me._id }
-          : "skip";
+      : "skip";
   const {
     results: paginatedSkills,
     status: skillsStatus,
@@ -144,7 +121,7 @@ export function Dashboard() {
   const myPackages = useQuery(
     api.packages.list,
     activePublisherId
-      ? { ownerPublisherId: activePublisherId as Doc<"publishers">["_id"], limit: 100 }
+      ? { ownerPublisherId: activePublisherId, limit: 100 }
       : me?._id
         ? { ownerUserId: me._id, limit: 100 }
         : "skip",
@@ -161,36 +138,13 @@ export function Dashboard() {
   const skills = mySkills ?? [];
   const packages = myPackages ?? [];
   const isLoading =
-    publishers === undefined || skillsStatus === "LoadingFirstPage" || myPackages === undefined;
-  const ownerHandle =
-    selectedPublisher?.publisher.handle ?? me.handle ?? me.name ?? me.displayName ?? me._id;
+    isPublisherLoading || skillsStatus === "LoadingFirstPage" || myPackages === undefined;
+  const ownerHandle = activeOwnerHandle ?? me.handle ?? me.name ?? me.displayName ?? me._id;
   const isDashboardEmpty = !isLoading && skills.length === 0 && packages.length === 0;
 
   if (isLoading) {
     return <DashboardSkeleton />;
   }
-
-  const publisherSelector =
-    publishers && publishers.length > 1 ? (
-      <div className="dashboard-publisher-select">
-        <span className="text-sm font-medium text-muted-foreground">Viewing as</span>
-        <Select value={activePublisherId} onValueChange={setSelectedPublisherId}>
-          <SelectTrigger
-            aria-label="Dashboard publisher"
-            className="min-w-[220px] rounded-[var(--radius-sm)]"
-          >
-            <SelectValue placeholder="Select publisher" />
-          </SelectTrigger>
-          <SelectContent>
-            {publishers.map((entry) => (
-              <SelectItem key={entry.publisher._id} value={entry.publisher._id}>
-                @{entry.publisher.handle} · {entry.publisher.kind === "org" ? "Org" : "Personal"}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-    ) : null;
 
   // Welcome state for new users with no content
   if (isDashboardEmpty) {
@@ -203,7 +157,6 @@ export function Dashboard() {
           <p className="empty-state-body">
             You're signed in as @{ownerHandle}. Import a public GitHub repo or publish manually.
           </p>
-          {publisherSelector}
           <div className="flex flex-wrap gap-3 justify-center">
             <Button asChild variant="primary">
               <Link to="/import">
@@ -242,9 +195,10 @@ export function Dashboard() {
       <div className="dashboard-header">
         <div>
           <h1 className="section-title m-0">Dashboard</h1>
-          <p className="section-subtitle m-0">View your published skills and plugins.</p>
+          <p className="section-subtitle m-0">
+            View published skills and plugins for @{ownerHandle}.
+          </p>
         </div>
-        {publisherSelector}
       </div>
 
       <div className="dashboard-owner-grid">
@@ -276,7 +230,12 @@ export function Dashboard() {
           ) : (
             <div className="dashboard-list">
               {skills.map((skill) => (
-                <SkillRow key={skill._id} skill={skill} ownerHandle={ownerHandle} />
+                <SkillRow
+                  key={skill._id}
+                  skill={skill}
+                  ownerHandle={ownerHandle}
+                  showManageActions={canManageActivePublisher}
+                />
               ))}
             </div>
           )}
@@ -323,7 +282,15 @@ export function Dashboard() {
   );
 }
 
-function SkillRow({ skill, ownerHandle }: { skill: DashboardSkill; ownerHandle: string }) {
+function SkillRow({
+  skill,
+  ownerHandle,
+  showManageActions,
+}: {
+  skill: DashboardSkill;
+  ownerHandle: string;
+  showManageActions: boolean;
+}) {
   const status = skillArtifactStatus(skill);
   const titleId = `dashboard-skill-title-${skill._id}`;
   const detailHref =
@@ -345,7 +312,9 @@ function SkillRow({ skill, ownerHandle }: { skill: DashboardSkill; ownerHandle: 
       status={status}
       stats={stats}
       actions={
-        <SettingsLink href={settingsHref} label={`Open settings for ${skill.displayName}`} />
+        showManageActions ? (
+          <SettingsLink href={settingsHref} label={`Open settings for ${skill.displayName}`} />
+        ) : null
       }
     />
   );

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -99,17 +99,20 @@ export const Route = createFileRoute("/dashboard")({
 export function Dashboard() {
   const { isAuthenticated, isLoading: isAuthLoading, me } = useAuthStatus();
   const {
+    activePublisher,
     activePublisherId,
     activeOwnerHandle,
     canManageActivePublisher,
     isLoading: isPublisherLoading,
   } = useActivePublisher();
 
-  const skillsQueryArgs = activePublisherId
-    ? { ownerPublisherId: activePublisherId }
-    : me?._id
-      ? { ownerUserId: me._id }
-      : "skip";
+  const activePublisherKind = activePublisher?.publisher.kind;
+  const skillsQueryArgs =
+    activePublisherKind === "org" && activePublisherId
+      ? { ownerPublisherId: activePublisherId }
+      : me?._id
+        ? { ownerUserId: me._id }
+        : "skip";
   const {
     results: paginatedSkills,
     status: skillsStatus,
@@ -120,7 +123,7 @@ export function Dashboard() {
   const mySkills = paginatedSkills as DashboardSkill[] | undefined;
   const myPackages = useQuery(
     api.packages.list,
-    activePublisherId
+    activePublisherKind === "org" && activePublisherId
       ? { ownerPublisherId: activePublisherId, limit: 100 }
       : me?._id
         ? { ownerUserId: me._id, limit: 100 }

--- a/src/routes/plugins/publish.tsx
+++ b/src/routes/plugins/publish.tsx
@@ -546,7 +546,11 @@ export function PublishPluginRoute() {
                 </div>
                 <div className="flex flex-col gap-2">
                   <Label>Publishing as</Label>
-                  <div className="flex min-h-[44px] w-full items-center rounded-[var(--radius-sm)] border border-input-border bg-input-bg px-3.5 py-space-3 text-sm text-[color:var(--ink)]">
+                  <div
+                    role="group"
+                    aria-label="Publishing as"
+                    className="flex min-h-[44px] w-full items-center rounded-[var(--radius-sm)] border border-input-border bg-input-bg px-3.5 py-space-3 text-sm text-[color:var(--ink)]"
+                  >
                     <PublisherOwnerDisplay value={ownerHandle} memberships={publisherMemberships} />
                   </div>
                 </div>

--- a/src/routes/plugins/publish.tsx
+++ b/src/routes/plugins/publish.tsx
@@ -397,13 +397,7 @@ export function PublishPluginRoute() {
     if (personal?.publisher.handle) {
       setOwnerHandle(personal.publisher.handle);
     }
-  }, [
-    activeOwnerHandle,
-    ownerHandle,
-    publisherMemberships,
-    search.name,
-    search.ownerHandle,
-  ]);
+  }, [activeOwnerHandle, ownerHandle, publisherMemberships, search.name, search.ownerHandle]);
 
   useEffect(() => {
     if (search.name || !ownerHandle || search.ownerHandle === ownerHandle) return;

--- a/src/routes/plugins/publish.tsx
+++ b/src/routes/plugins/publish.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, useSearch } from "@tanstack/react-router";
+import { createFileRoute, useNavigate, useSearch } from "@tanstack/react-router";
 import { DocsLinks, getPackageScopeOwnerMismatch, isPluginCategorySlug } from "clawhub-schema";
 import { useAction, useMutation, useQuery } from "convex/react";
 import { ExternalLink, Info, Lock } from "lucide-react";
@@ -18,7 +18,7 @@ import {
   PackageSourceChooser,
   type PackagePickSource,
 } from "../../components/PackageSourceChooser";
-import { PublisherOwnerDisplay } from "../../components/PublisherOwnerSelect";
+import { PublisherContextStrip } from "../../components/PublisherOwnerSelect";
 import { PublishFormSkeleton } from "../../components/PublishFormSkeleton";
 import { SignInButton } from "../../components/SignInButton";
 import { Badge } from "../../components/ui/badge";
@@ -189,7 +189,9 @@ export function PublishPluginRoute() {
     activeOwnerHandle,
     memberships: publisherMemberships,
     isLoading: isActivePublisherLoading,
+    setActivePublisherId,
   } = useActivePublisher();
+  const navigate = useNavigate();
   const existing = useQuery(
     api.packages.getManageContext,
     me && search.name ? { name: search.name } : "skip",
@@ -384,8 +386,7 @@ export function PublishPluginRoute() {
   };
 
   useEffect(() => {
-    if (search.ownerHandle) return;
-    if (activeOwnerHandle) {
+    if (!search.name && activeOwnerHandle) {
       if (ownerHandle !== activeOwnerHandle) setOwnerHandle(activeOwnerHandle);
       return;
     }
@@ -396,7 +397,23 @@ export function PublishPluginRoute() {
     if (personal?.publisher.handle) {
       setOwnerHandle(personal.publisher.handle);
     }
-  }, [activeOwnerHandle, ownerHandle, publisherMemberships, search.ownerHandle]);
+  }, [
+    activeOwnerHandle,
+    ownerHandle,
+    publisherMemberships,
+    search.name,
+    search.ownerHandle,
+  ]);
+
+  useEffect(() => {
+    if (search.name || !ownerHandle || search.ownerHandle === ownerHandle) return;
+
+    void navigate({
+      to: "/plugins/publish",
+      search: { ...search, ownerHandle },
+      replace: true,
+    });
+  }, [navigate, ownerHandle, search]);
 
   useEffect(() => {
     if (!existing?.package) return;
@@ -474,20 +491,30 @@ export function PublishPluginRoute() {
           </Card>
         ) : null}
 
-        <PackageSourceChooser
-          files={files}
-          totalBytes={totalBytes}
-          normalizedPaths={normalizedPaths}
-          normalizedPathSet={normalizedPathSet}
-          selectedSourceKind={packageSourceKind}
-          ignoredPaths={ignoredPaths}
-          detectedPrefillFields={detectedPrefillFields}
-          family={family}
-          validationError={validationError}
-          codePluginFieldIssues={codePluginFieldIssues}
-          onPickFiles={onPickFiles}
-          onClearFiles={clearSelectedFiles}
-        />
+        <Card className="mb-5 gap-0 overflow-hidden !p-0">
+          <PublisherContextStrip
+            ownerHandle={ownerHandle}
+            memberships={publisherMemberships}
+            onSwitchPublisher={setActivePublisherId}
+          />
+          <div className="border-t border-[color:var(--line)] p-space-5">
+            <PackageSourceChooser
+              files={files}
+              totalBytes={totalBytes}
+              normalizedPaths={normalizedPaths}
+              normalizedPathSet={normalizedPathSet}
+              selectedSourceKind={packageSourceKind}
+              ignoredPaths={ignoredPaths}
+              detectedPrefillFields={detectedPrefillFields}
+              family={family}
+              validationError={validationError}
+              codePluginFieldIssues={codePluginFieldIssues}
+              onPickFiles={onPickFiles}
+              onClearFiles={clearSelectedFiles}
+              embedded
+            />
+          </div>
+        </Card>
 
         <div
           className={
@@ -542,16 +569,6 @@ export function PublishPluginRoute() {
                     className="min-h-[44px] w-full rounded-[var(--radius-sm)] border border-[rgba(29,59,78,0.22)] bg-[rgba(255,255,255,0.94)] px-3.5 py-[13px] text-sm text-[color:var(--ink)] dark:border-[rgba(255,255,255,0.12)] dark:bg-[rgba(14,28,37,0.84)]"
                   >
                     {family === "code-plugin" ? "Code plugin" : "Bundle plugin"}
-                  </div>
-                </div>
-                <div className="flex flex-col gap-2">
-                  <Label>Publishing as</Label>
-                  <div
-                    role="group"
-                    aria-label="Publishing as"
-                    className="flex min-h-[44px] w-full items-center rounded-[var(--radius-sm)] border border-input-border bg-input-bg px-3.5 py-space-3 text-sm text-[color:var(--ink)]"
-                  >
-                    <PublisherOwnerDisplay value={ownerHandle} memberships={publisherMemberships} />
                   </div>
                 </div>
                 <div className="flex flex-col gap-2">

--- a/src/routes/plugins/publish.tsx
+++ b/src/routes/plugins/publish.tsx
@@ -18,10 +18,7 @@ import {
   PackageSourceChooser,
   type PackagePickSource,
 } from "../../components/PackageSourceChooser";
-import {
-  PublisherOwnerSelect,
-  type PublisherOwnerMembership,
-} from "../../components/PublisherOwnerSelect";
+import { PublisherOwnerDisplay } from "../../components/PublisherOwnerSelect";
 import { PublishFormSkeleton } from "../../components/PublishFormSkeleton";
 import { SignInButton } from "../../components/SignInButton";
 import { Badge } from "../../components/ui/badge";
@@ -31,6 +28,7 @@ import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
 import { Textarea } from "../../components/ui/textarea";
 import { VersionInput } from "../../components/VersionInput";
+import { useActivePublisher } from "../../lib/activePublisher";
 import {
   detectRelativeReadmeAssets,
   type RelativeReadmeAssetReport,
@@ -187,9 +185,11 @@ function PluginPublishError({ message }: { message: string }) {
 export function PublishPluginRoute() {
   const search = useSearch({ from: "/plugins/publish" });
   const { isAuthenticated, isLoading: isAuthLoading, me } = useAuthStatus();
-  const publishers = useQuery(api.publishers.listMine, me ? {} : "skip") as
-    | Array<PublisherOwnerMembership>
-    | undefined;
+  const {
+    activeOwnerHandle,
+    memberships: publisherMemberships,
+    isLoading: isActivePublisherLoading,
+  } = useActivePublisher();
   const existing = useQuery(
     api.packages.getManageContext,
     me && search.name ? { name: search.name } : "skip",
@@ -384,13 +384,19 @@ export function PublishPluginRoute() {
   };
 
   useEffect(() => {
+    if (search.ownerHandle) return;
+    if (activeOwnerHandle) {
+      if (ownerHandle !== activeOwnerHandle) setOwnerHandle(activeOwnerHandle);
+      return;
+    }
     if (ownerHandle) return;
     const personal =
-      publishers?.find((entry) => entry.publisher.kind === "user") ?? publishers?.[0];
+      publisherMemberships?.find((entry) => entry.publisher.kind === "user") ??
+      publisherMemberships?.[0];
     if (personal?.publisher.handle) {
       setOwnerHandle(personal.publisher.handle);
     }
-  }, [ownerHandle, publishers]);
+  }, [activeOwnerHandle, ownerHandle, publisherMemberships, search.ownerHandle]);
 
   useEffect(() => {
     if (!existing?.package) return;
@@ -409,7 +415,7 @@ export function PublishPluginRoute() {
     }
   }, [existing]);
 
-  if (isAuthLoading) {
+  if (isAuthLoading || isActivePublisherLoading) {
     return <PublishFormSkeleton />;
   }
 
@@ -508,7 +514,7 @@ export function PublishPluginRoute() {
                 </div>
                 {ownerScopeError ? (
                   <Badge variant="warning" className="md:col-span-2">
-                    <span>{ownerScopeError}</span>
+                    <span>{ownerScopeError} Switch active publisher in the account menu.</span>
                     <a
                       href={DocsLinks.clawhub.packageScopeFaq}
                       target="_blank"
@@ -539,14 +545,10 @@ export function PublishPluginRoute() {
                   </div>
                 </div>
                 <div className="flex flex-col gap-2">
-                  <Label htmlFor="pluginOwner">Owner</Label>
-                  <PublisherOwnerSelect
-                    id="pluginOwner"
-                    value={ownerHandle}
-                    memberships={publishers}
-                    disabled={metadataDisabled}
-                    onValueChange={setOwnerHandle}
-                  />
+                  <Label>Publishing as</Label>
+                  <div className="flex min-h-[44px] w-full items-center rounded-[var(--radius-sm)] border border-input-border bg-input-bg px-3.5 py-space-3 text-sm text-[color:var(--ink)]">
+                    <PublisherOwnerDisplay value={ownerHandle} memberships={publisherMemberships} />
+                  </div>
                 </div>
                 <div className="flex flex-col gap-2">
                   <Label htmlFor="pluginVersion">Version</Label>

--- a/src/routes/plugins/publish.tsx
+++ b/src/routes/plugins/publish.tsx
@@ -204,6 +204,8 @@ export function PublishPluginRoute() {
   const [name, setName] = useState(search.name ?? "");
   const [displayName, setDisplayName] = useState(search.displayName ?? "");
   const [ownerHandle, setOwnerHandle] = useState(search.ownerHandle ?? "");
+  const observedActiveOwnerHandleRef = useRef<string | undefined>(undefined);
+  const autoSelectedOwnerHandleRef = useRef<string | undefined>(undefined);
   const [version, setVersion] = useState(search.nextVersion ?? "0.1.0");
   const [changelog, setChangelog] = useState("");
   const [categories, setCategories] = useState<string[]>([]);
@@ -386,7 +388,35 @@ export function PublishPluginRoute() {
   };
 
   useEffect(() => {
-    if (!search.name && activeOwnerHandle) {
+    if (search.name || !search.ownerHandle || search.ownerHandle === ownerHandle) return;
+
+    autoSelectedOwnerHandleRef.current = undefined;
+    setOwnerHandle(search.ownerHandle);
+  }, [ownerHandle, search.name, search.ownerHandle]);
+
+  useEffect(() => {
+    const searchOwnerWasAutoSelected =
+      search.ownerHandle && search.ownerHandle === autoSelectedOwnerHandleRef.current;
+    if (search.name || (search.ownerHandle && !searchOwnerWasAutoSelected) || !activeOwnerHandle)
+      return;
+    if (observedActiveOwnerHandleRef.current === undefined) {
+      observedActiveOwnerHandleRef.current = activeOwnerHandle;
+      return;
+    }
+    if (observedActiveOwnerHandleRef.current === activeOwnerHandle) return;
+
+    observedActiveOwnerHandleRef.current = activeOwnerHandle;
+    autoSelectedOwnerHandleRef.current = activeOwnerHandle;
+    setOwnerHandle(activeOwnerHandle);
+    void navigate({
+      to: "/plugins/publish",
+      search: { ...search, ownerHandle: activeOwnerHandle },
+      replace: true,
+    });
+  }, [activeOwnerHandle, navigate, search]);
+
+  useEffect(() => {
+    if (!search.name && activeOwnerHandle && !search.ownerHandle && !ownerHandle) {
       if (ownerHandle !== activeOwnerHandle) setOwnerHandle(activeOwnerHandle);
       return;
     }
@@ -401,7 +431,9 @@ export function PublishPluginRoute() {
 
   useEffect(() => {
     if (search.name || !ownerHandle || search.ownerHandle === ownerHandle) return;
+    if (search.ownerHandle && search.ownerHandle !== autoSelectedOwnerHandleRef.current) return;
 
+    autoSelectedOwnerHandleRef.current = ownerHandle;
     void navigate({
       to: "/plugins/publish",
       search: { ...search, ownerHandle },
@@ -489,7 +521,17 @@ export function PublishPluginRoute() {
           <PublisherContextStrip
             ownerHandle={ownerHandle}
             memberships={publisherMemberships}
-            onSwitchPublisher={setActivePublisherId}
+            onSwitchPublisher={(publisher) => {
+              observedActiveOwnerHandleRef.current = publisher.handle;
+              autoSelectedOwnerHandleRef.current = publisher.handle;
+              setOwnerHandle(publisher.handle);
+              setActivePublisherId(publisher._id);
+              void navigate({
+                to: "/plugins/publish",
+                search: { ...search, ownerHandle: publisher.handle },
+                replace: true,
+              });
+            }}
           />
           <div className="border-t border-[color:var(--line)] p-space-5">
             <PackageSourceChooser

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -11,7 +11,6 @@ import {
   KeyRound,
   Monitor,
   Moon,
-  Package,
   Palette,
   Plus,
   Save,
@@ -65,6 +64,7 @@ import { Textarea } from "../components/ui/textarea";
 import { ToggleGroup, ToggleGroupItem } from "../components/ui/toggle-group";
 import { useActivePublisher } from "../lib/activePublisher";
 import { getUserFacingConvexError } from "../lib/convexError";
+import { PLUGIN_NAV_ICON, SKILL_NAV_ICON } from "../lib/marketplaceIcons";
 import { useThemeMode } from "../lib/theme";
 import { timeAgo } from "../lib/timeAgo";
 import { useAuthStatus } from "../lib/useAuthStatus";
@@ -930,13 +930,13 @@ export function Settings() {
                           <div className="flex flex-col gap-4 border-t border-[color:var(--line)] pt-4 sm:flex-row sm:items-center sm:justify-between">
                             <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-[color:var(--ink-soft)]">
                               <span className="inline-flex items-center gap-1.5">
-                                <Code size={14} aria-hidden="true" />
+                                <SKILL_NAV_ICON size={14} aria-hidden="true" />
                                 <span>
                                   {skillCount} {skillCount === 1 ? "skill" : "skills"}
                                 </span>
                               </span>
                               <span className="inline-flex items-center gap-1.5">
-                                <Package size={14} aria-hidden="true" />
+                                <PLUGIN_NAV_ICON size={14} aria-hidden="true" />
                                 <span>
                                   {pluginCount} {pluginCount === 1 ? "plugin" : "plugins"}
                                 </span>

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -926,7 +926,7 @@ export function Settings() {
                             </div>
                           </div>
 
-                          <div className="flex flex-col gap-4 border-t border-[color:var(--line)] pt-4 sm:flex-row sm:items-center sm:justify-between">
+                          <div className="flex flex-col gap-4 border-t border-[color:var(--line)] pt-4 min-[480px]:flex-row min-[480px]:items-center min-[480px]:justify-between">
                             <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-[color:var(--ink-soft)]">
                               <span className="inline-flex items-center gap-1.5">
                                 <SKILL_NAV_ICON size={14} aria-hidden="true" />

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -62,6 +62,7 @@ import {
 import { Separator } from "../components/ui/separator";
 import { Textarea } from "../components/ui/textarea";
 import { ToggleGroup, ToggleGroupItem } from "../components/ui/toggle-group";
+import { useActivePublisher } from "../lib/activePublisher";
 import { getUserFacingConvexError } from "../lib/convexError";
 import { useThemeMode } from "../lib/theme";
 import { timeAgo } from "../lib/timeAgo";
@@ -224,6 +225,7 @@ export function Settings() {
   const navigate = useNavigate();
   const { signOut } = useAuthActions();
   const { isAuthenticated, isLoading: isAuthLoading, me } = useAuthStatus();
+  const { activePublisher } = useActivePublisher();
   const updateProfile = useMutation(api.users.updateProfile);
   const deleteAccount = useMutation(api.users.deleteAccount);
   const { mode: themeMode, setMode: setThemeMode } = useThemeMode();
@@ -330,10 +332,17 @@ export function Settings() {
 
   useEffect(() => {
     if (selectedOrgHandle) return;
+    if (activePublisher?.publisher.kind === "org") {
+      const activeOrg = orgs.find((entry) => entry.publisher._id === activePublisher.publisher._id);
+      if (activeOrg?.publisher.handle) {
+        setSelectedOrgHandle(activeOrg.publisher.handle);
+        return;
+      }
+    }
     if (orgs[0]?.publisher.handle) {
       setSelectedOrgHandle(orgs[0].publisher.handle);
     }
-  }, [orgs, selectedOrgHandle]);
+  }, [activePublisher, orgs, selectedOrgHandle]);
 
   useEffect(() => {
     if (!officialGitHubSourcePublishers.length) {

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -911,16 +911,17 @@ export function Settings() {
                                     Official
                                   </Badge>
                                 ) : null}
+                                <Badge
+                                  variant="compact"
+                                  size="sm"
+                                  aria-label={`Your role: ${roleLabel}`}
+                                >
+                                  {roleLabel}
+                                </Badge>
                               </div>
                               <p className="mt-1 truncate text-sm text-[color:var(--ink-soft)]">
                                 @{entry.publisher.handle}
                               </p>
-                              <dl className="mt-2 flex items-center gap-2 text-xs">
-                                <dt className="text-[color:var(--ink-soft)]">Role</dt>
-                                <dd className="font-semibold text-[color:var(--ink)]">
-                                  {roleLabel}
-                                </dd>
-                              </dl>
                             </div>
                           </div>
 

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -941,8 +941,8 @@ export function Settings() {
                                 </span>
                               </span>
                             </div>
-                            <div className="flex shrink-0 flex-wrap items-center gap-2">
-                              <Button asChild variant="ghost" className="sm:w-auto">
+                            <div className="settings-organization-actions">
+                              <Button asChild variant="ghost">
                                 <Link
                                   to="/user/$handle"
                                   params={{ handle: entry.publisher.handle }}
@@ -953,7 +953,6 @@ export function Settings() {
                               <Button
                                 type="button"
                                 variant="outline"
-                                className="sm:w-auto"
                                 onClick={() => {
                                   setActivePublisherId(entry.publisher._id);
                                   if (canManageOrg) {

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -11,6 +11,7 @@ import {
   KeyRound,
   Monitor,
   Moon,
+  Package,
   Palette,
   Plus,
   Save,

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -68,16 +68,26 @@ import { useThemeMode } from "../lib/theme";
 import { timeAgo } from "../lib/timeAgo";
 import { useAuthStatus } from "../lib/useAuthStatus";
 
-const settingsViews = ["account", "organizations", "githubSources", "tokens", "danger"] as const;
-type SettingsView = (typeof settingsViews)[number];
+const settingsSearchViews = [
+  "profile",
+  "account",
+  "appearance",
+  "organizations",
+  "members",
+  "githubSources",
+  "tokens",
+  "danger",
+] as const;
+type SettingsSearchView = (typeof settingsSearchViews)[number];
+type SettingsView = Exclude<SettingsSearchView, "account">;
 
-function isSettingsView(value: unknown): value is SettingsView {
-  return typeof value === "string" && settingsViews.includes(value as SettingsView);
+function isSettingsSearchView(value: unknown): value is SettingsSearchView {
+  return typeof value === "string" && settingsSearchViews.includes(value as SettingsSearchView);
 }
 
 export const Route = createFileRoute("/settings")({
-  validateSearch: (search: Record<string, unknown>): { view?: SettingsView } => ({
-    view: isSettingsView(search.view) ? search.view : undefined,
+  validateSearch: (search: Record<string, unknown>): { view?: SettingsSearchView } => ({
+    view: isSettingsSearchView(search.view) ? search.view : undefined,
   }),
   component: Settings,
 });
@@ -170,48 +180,12 @@ type GitHubSkillSource = {
   updatedAt: number;
 };
 
-const navigationGroups: Array<{
-  items: Array<{
-    view: SettingsView;
-    label: string;
-    mobileLabel: string;
-    icon: LucideIcon;
-  }>;
-}> = [
-  {
-    items: [
-      {
-        view: "account",
-        label: "Account & Preferences",
-        mobileLabel: "Account",
-        icon: UserRound,
-      },
-    ],
-  },
-  {
-    items: [
-      {
-        view: "organizations",
-        label: "Organizations",
-        mobileLabel: "Orgs",
-        icon: Building2,
-      },
-      {
-        view: "githubSources",
-        label: "GitHub Skill Sync",
-        mobileLabel: "Skill Sync",
-        icon: GitBranch,
-      },
-      { view: "tokens", label: "API tokens", mobileLabel: "Tokens", icon: KeyRound },
-      {
-        view: "danger",
-        label: "Account deletion",
-        mobileLabel: "Deletion",
-        icon: ShieldAlert,
-      },
-    ],
-  },
-];
+type SettingsNavigationItem = {
+  view: SettingsView;
+  label: string;
+  mobileLabel: string;
+  icon: LucideIcon;
+};
 
 const settingsStickyTop = "calc(128px + var(--space-4))";
 const settingsScrollMargin = "calc(128px + var(--space-5))";
@@ -225,7 +199,11 @@ export function Settings() {
   const navigate = useNavigate();
   const { signOut } = useAuthActions();
   const { isAuthenticated, isLoading: isAuthLoading, me } = useAuthStatus();
-  const { activePublisher } = useActivePublisher();
+  const {
+    activePublisher,
+    isLoading: isActivePublisherLoading,
+    setActivePublisherId,
+  } = useActivePublisher();
   const updateProfile = useMutation(api.users.updateProfile);
   const deleteAccount = useMutation(api.users.deleteAccount);
   const { mode: themeMode, setMode: setThemeMode } = useThemeMode();
@@ -255,13 +233,9 @@ export function Settings() {
   const [orgDisplayName, setOrgDisplayName] = useState("");
   const [createOrgError, setCreateOrgError] = useState<string | null>(null);
   const [isCreatingOrg, setIsCreatingOrg] = useState(false);
-  const [selectedOrgHandle, setSelectedOrgHandle] = useState("");
-  const [selectedOrgDisplayName, setSelectedOrgDisplayName] = useState("");
-  const [selectedOrgBio, setSelectedOrgBio] = useState("");
-  const [selectedOrgImage, setSelectedOrgImage] = useState("");
+  const [publisherImage, setPublisherImage] = useState("");
   const [memberHandle, setMemberHandle] = useState("");
   const [memberRole, setMemberRole] = useState<"owner" | "admin" | "publisher">("publisher");
-  const [selectedSourcePublisherId, setSelectedSourcePublisherId] = useState("");
   const [githubRepo, setGithubRepo] = useState("");
   const [isSyncingSource, setIsSyncingSource] = useState(false);
   const [deletingSourceId, setDeletingSourceId] = useState<Id<"githubSkillSources"> | null>(null);
@@ -271,106 +245,157 @@ export function Settings() {
   const [createOrgDialogOpen, setCreateOrgDialogOpen] = useState(false);
   const [addMemberDialogOpen, setAddMemberDialogOpen] = useState(false);
   const [revokeTokenId, setRevokeTokenId] = useState<Id<"apiTokens"> | null>(null);
-  const { activeView, navigateToView } = useActiveSettingsView();
-  const orgs = (publisherMemberships ?? []).filter((entry) => entry.publisher.kind === "org");
-  const manageablePublishers = (publisherMemberships ?? []).filter(
-    (entry) => entry.role !== "publisher",
+  const memberships = publisherMemberships ?? [];
+  const orgs = memberships.filter((entry) => entry.publisher.kind === "org");
+  const personalPublisher = memberships.find((entry) => entry.publisher.kind === "user") ?? null;
+  const activePublisherId = activePublisher?.publisher._id ?? null;
+  const activePublisherMembership = activePublisherId
+    ? memberships.find((entry) => entry.publisher._id === activePublisherId)
+    : null;
+  const settingsPublisher =
+    activePublisherMembership ?? personalPublisher ?? memberships[0] ?? null;
+  const isOrgSettings = settingsPublisher?.publisher.kind === "org";
+  const settingsPublisherRole = settingsPublisher?.role ?? "owner";
+  const canManageSettingsPublisher = Boolean(
+    settingsPublisher &&
+    (!isOrgSettings || settingsPublisherRole === "owner" || settingsPublisherRole === "admin"),
   );
-  const officialGitHubSourcePublishers = manageablePublishers.filter(
-    (entry) => entry.publisher.official === true,
+  const canDeleteSettingsPublisher = Boolean(isOrgSettings && settingsPublisherRole === "owner");
+  const canConfigureActiveGitHubSources = Boolean(
+    settingsPublisher?.publisher.official === true && canManageSettingsPublisher,
+  );
+  const settingsNavigationItems: SettingsNavigationItem[] = isOrgSettings
+    ? [
+        {
+          view: "profile",
+          label: "Profile",
+          mobileLabel: "Profile",
+          icon: Building2,
+        },
+        ...(canManageSettingsPublisher
+          ? [
+              {
+                view: "members" as const,
+                label: "Members",
+                mobileLabel: "Members",
+                icon: Users,
+              },
+            ]
+          : []),
+        ...(canConfigureActiveGitHubSources
+          ? [
+              {
+                view: "githubSources" as const,
+                label: "GitHub Skill Sync",
+                mobileLabel: "Skill Sync",
+                icon: GitBranch,
+              },
+            ]
+          : []),
+        ...(canDeleteSettingsPublisher
+          ? [
+              {
+                view: "danger" as const,
+                label: "Delete organization",
+                mobileLabel: "Delete",
+                icon: ShieldAlert,
+              },
+            ]
+          : []),
+      ]
+    : [
+        { view: "profile", label: "Profile", mobileLabel: "Profile", icon: UserRound },
+        { view: "appearance", label: "Appearance", mobileLabel: "Theme", icon: Palette },
+        {
+          view: "organizations",
+          label: "Organizations",
+          mobileLabel: "Orgs",
+          icon: Building2,
+        },
+        ...(canConfigureActiveGitHubSources
+          ? [
+              {
+                view: "githubSources" as const,
+                label: "GitHub Skill Sync",
+                mobileLabel: "Skill Sync",
+                icon: GitBranch,
+              },
+            ]
+          : []),
+        { view: "tokens", label: "API tokens", mobileLabel: "Tokens", icon: KeyRound },
+        {
+          view: "danger",
+          label: "Account deletion",
+          mobileLabel: "Deletion",
+          icon: ShieldAlert,
+        },
+      ];
+  const availableSettingsViews = settingsNavigationItems.map((item) => item.view);
+  const { activeView, navigateToView } = useActiveSettingsView(
+    availableSettingsViews,
+    Boolean(isOrgSettings),
   );
   const publisherMembershipsLoaded = publisherMemberships !== undefined;
-  const canConfigureGitHubSources = officialGitHubSourcePublishers.length > 0;
-  const effectiveActiveView =
-    activeView === "githubSources" && publisherMembershipsLoaded && !canConfigureGitHubSources
-      ? "account"
-      : activeView;
-  const selectedSourcePublisher =
-    officialGitHubSourcePublishers.find(
-      (entry) => entry.publisher._id === selectedSourcePublisherId,
-    ) ??
-    officialGitHubSourcePublishers[0] ??
-    null;
-  const selectedOrg =
-    orgs.find((entry) => entry.publisher.handle === selectedOrgHandle) ?? orgs[0] ?? null;
-  const hasOrgProfileChanges = selectedOrg
-    ? selectedOrgDisplayName !== (selectedOrg.publisher.displayName ?? "") ||
-      selectedOrgBio !== (selectedOrg.publisher.bio ?? "") ||
-      selectedOrgImage !== (selectedOrg.publisher.image ?? "")
-    : false;
-  const hasProfileChanges = me
-    ? displayName !== (me.displayName ?? "") || bio !== (me.bio ?? "")
-    : false;
+  const effectiveActiveView = activeView;
+  const hasProfileChanges =
+    isOrgSettings && settingsPublisher
+      ? displayName !== (settingsPublisher.publisher.displayName ?? "") ||
+        bio !== (settingsPublisher.publisher.bio ?? "") ||
+        publisherImage !== (settingsPublisher.publisher.image ?? "")
+      : me
+        ? displayName !== (me.displayName ?? "") || bio !== (me.bio ?? "")
+        : false;
   const activeTokens = (tokens ?? []).filter((token) => !token.revokedAt);
   const revokedTokens = (tokens ?? []).filter((token) => token.revokedAt);
   const orgMembers = useQuery(
     api.publishers.listMembers,
     shouldLoadAccountScopedQueries &&
-      activeView === "organizations" &&
-      selectedOrg &&
-      selectedOrg.role !== "publisher"
-      ? { publisherHandle: selectedOrg.publisher.handle }
+      effectiveActiveView === "members" &&
+      isOrgSettings &&
+      canManageSettingsPublisher &&
+      settingsPublisher
+      ? { publisherHandle: settingsPublisher.publisher.handle }
       : "skip",
   ) as OrgMembersResult | null | undefined;
   const githubSources = useQuery(
-    api.githubSkillSources.listForManageableOfficialPublishers,
+    api.githubSkillSources.listForPublisher,
     shouldLoadAccountScopedQueries &&
       effectiveActiveView === "githubSources" &&
-      canConfigureGitHubSources
-      ? {}
+      canConfigureActiveGitHubSources &&
+      settingsPublisher
+      ? { ownerPublisherId: settingsPublisher.publisher._id }
       : "skip",
   ) as GitHubSkillSource[] | undefined;
-  const deletionPublishers = (publisherMemberships ?? []).filter(
+  const deletionPublishers = memberships.filter(
     (entry) => entry.publisher.kind === "user" || entry.role === "owner",
   );
 
   useEffect(() => {
-    if (!me) return;
-    setDisplayName(me.displayName ?? "");
-    setBio(me.bio ?? "");
-  }, [me]);
-
-  useEffect(() => {
-    if (selectedOrgHandle) return;
-    if (activePublisher?.publisher.kind === "org") {
-      const activeOrg = orgs.find((entry) => entry.publisher._id === activePublisher.publisher._id);
-      if (activeOrg?.publisher.handle) {
-        setSelectedOrgHandle(activeOrg.publisher.handle);
-        return;
-      }
-    }
-    if (orgs[0]?.publisher.handle) {
-      setSelectedOrgHandle(orgs[0].publisher.handle);
-    }
-  }, [activePublisher, orgs, selectedOrgHandle]);
-
-  useEffect(() => {
-    if (!officialGitHubSourcePublishers.length) {
-      setSelectedSourcePublisherId("");
+    if (isOrgSettings && settingsPublisher) {
+      setDisplayName(settingsPublisher.publisher.displayName ?? "");
+      setBio(settingsPublisher.publisher.bio ?? "");
+      setPublisherImage(settingsPublisher.publisher.image ?? "");
       return;
     }
-    if (
-      selectedSourcePublisherId &&
-      officialGitHubSourcePublishers.some(
-        (entry) => entry.publisher._id === selectedSourcePublisherId,
-      )
-    ) {
-      return;
+    if (me) {
+      setDisplayName(me.displayName ?? "");
+      setBio(me.bio ?? "");
+      setPublisherImage("");
     }
-    setSelectedSourcePublisherId(officialGitHubSourcePublishers[0]?.publisher._id ?? "");
-  }, [officialGitHubSourcePublishers, selectedSourcePublisherId]);
+  }, [
+    isOrgSettings,
+    me,
+    settingsPublisher?.publisher.bio,
+    settingsPublisher?.publisher.displayName,
+    settingsPublisher?.publisher.image,
+    settingsPublisher?.publisher._id,
+  ]);
 
   useEffect(() => {
-    if (!selectedOrg) {
-      setSelectedOrgDisplayName("");
-      setSelectedOrgBio("");
-      setSelectedOrgImage("");
-      return;
+    if (settingsPublisherRole !== "owner" && memberRole === "owner") {
+      setMemberRole("publisher");
     }
-    setSelectedOrgDisplayName(selectedOrg.publisher.displayName ?? "");
-    setSelectedOrgBio(selectedOrg.publisher.bio ?? "");
-    setSelectedOrgImage(selectedOrg.publisher.image ?? "");
-  }, [selectedOrg]);
+  }, [memberRole, settingsPublisherRole]);
 
   if (isAuthLoading) {
     return <SettingsSkeleton />;
@@ -390,22 +415,56 @@ export function Settings() {
   }
 
   const activeSectionLoading =
-    (activeView === "organizations" &&
-      (publisherMemberships === undefined ||
-        (selectedOrg && selectedOrg.role !== "publisher" && orgMembers === undefined))) ||
-    (activeView === "tokens" && tokens === undefined);
+    !publisherMembershipsLoaded ||
+    isActivePublisherLoading ||
+    (effectiveActiveView === "members" &&
+      isOrgSettings &&
+      canManageSettingsPublisher &&
+      orgMembers === undefined) ||
+    (effectiveActiveView === "githubSources" &&
+      canConfigureActiveGitHubSources &&
+      githubSources === undefined) ||
+    (effectiveActiveView === "tokens" && tokens === undefined);
 
   if (activeSectionLoading) {
     return <SettingsSkeleton />;
   }
 
-  const accountAvatar = me.image ?? undefined;
-  const accountInitial = (displayName || me.displayName || me.name || me.handle || "U")
-    .charAt(0)
-    .toUpperCase();
+  const profileImage = isOrgSettings
+    ? publisherImage.trim() || undefined
+    : (settingsPublisher?.publisher.image ?? me.image ?? undefined);
+  const profileHandle = isOrgSettings
+    ? settingsPublisher?.publisher.handle
+    : (settingsPublisher?.publisher.handle ?? me.handle);
+  const profileKind = isOrgSettings ? "org" : "user";
+  const profileTitle = isOrgSettings ? "Organization profile" : "Profile";
+  const profileDescription = isOrgSettings
+    ? "Public publisher details for this organization."
+    : "Public profile details used across skills, plugins, and publisher pages.";
+  const settingsSubtitle = isOrgSettings
+    ? `Manage @${settingsPublisher?.publisher.handle ?? "this org"}'s publisher profile and access.`
+    : "Manage your personal publisher, organizations, and account access.";
 
-  async function onSave(event: FormEvent) {
+  async function onSaveProfile(event: FormEvent) {
     event.preventDefault();
+    if (isOrgSettings) {
+      if (!settingsPublisher || !canManageSettingsPublisher) {
+        toast.error("Only org owners and admins can update this profile.");
+        return;
+      }
+      try {
+        await updateOrgProfile({
+          publisherId: settingsPublisher.publisher._id,
+          displayName,
+          bio: bio || undefined,
+          image: publisherImage || undefined,
+        });
+        toast.success("Organization updated");
+      } catch (error) {
+        toast.error(getUserFacingConvexError(error, "Organization could not be updated."));
+      }
+      return;
+    }
     await updateProfile({ displayName, bio });
     toast.success("Saved");
   }
@@ -442,10 +501,13 @@ export function Settings() {
         bio: undefined,
       });
       if (result?.publisher?.handle) {
-        setSelectedOrgHandle(result.publisher.handle);
+        if (result.publisher._id) {
+          setActivePublisherId(result.publisher._id);
+        }
         setOrgHandle("");
         setOrgDisplayName("");
         setCreateOrgDialogOpen(false);
+        navigateToView("profile");
         toast.success("Organization created");
       }
     } catch (error) {
@@ -457,36 +519,27 @@ export function Settings() {
     }
   }
 
-  async function onSaveOrgProfile() {
-    if (!selectedOrg) return;
-    await updateOrgProfile({
-      publisherId: selectedOrg.publisher._id,
-      displayName: selectedOrgDisplayName,
-      bio: selectedOrgBio || undefined,
-      image: selectedOrgImage || undefined,
-    });
-    toast.success("Organization updated");
-  }
-
   async function onDeleteOrg() {
-    if (!selectedOrg) return;
-    const deletingHandle = selectedOrg.publisher.handle;
-    await deleteOrg({ publisherId: selectedOrg.publisher._id });
+    if (!settingsPublisher || !isOrgSettings) return;
+    const deletingHandle = settingsPublisher.publisher.handle;
+    await deleteOrg({ publisherId: settingsPublisher.publisher._id });
     setDeleteOrgDialogOpen(false);
-    const nextOrg = orgs.find((entry) => entry.publisher.handle !== deletingHandle);
-    setSelectedOrgHandle(nextOrg?.publisher.handle ?? "");
+    if (personalPublisher) {
+      setActivePublisherId(personalPublisher.publisher._id);
+    }
+    navigateToView("profile");
     toast.success(`Deleted @${deletingHandle}`);
   }
 
   async function onConfigureGitHubSource(event: FormEvent) {
     event.preventDefault();
-    if (!selectedSourcePublisher) return;
+    if (!settingsPublisher || !canConfigureActiveGitHubSources) return;
     const repo = parseGitHubRepoInput(githubRepo);
     if (!repo) return;
     setIsSyncingSource(true);
     try {
       const result = await configureGitHubSource({
-        ownerPublisherId: selectedSourcePublisher.publisher._id,
+        ownerPublisherId: settingsPublisher.publisher._id,
         repo,
       });
       setGithubRepo("");
@@ -499,7 +552,7 @@ export function Settings() {
   }
 
   async function onDeleteGitHubSource(source: GitHubSkillSource) {
-    const ownerPublisherId = source.ownerPublisher?._id ?? selectedSourcePublisher?.publisher._id;
+    const ownerPublisherId = source.ownerPublisher?._id ?? settingsPublisher?.publisher._id;
     if (!ownerPublisherId) return;
     setDeletingSourceId(source._id);
     try {
@@ -537,7 +590,7 @@ export function Settings() {
             Settings
           </h1>
           <p className="mt-2 max-w-2xl text-sm leading-6 text-[color:var(--ink-soft)]">
-            Account identity, publishing organizations, and API access for ClawHub.
+            {settingsSubtitle}
           </p>
         </header>
         <Separator />
@@ -549,113 +602,149 @@ export function Settings() {
                 className="flex gap-2 overflow-x-auto pb-1 lg:flex-col lg:gap-1 lg:overflow-visible lg:pb-0"
                 aria-label="Settings sections"
               >
-                {navigationGroups.map((group, groupIndex) => (
-                  <div
-                    key={`settings-nav-group-${groupIndex}`}
-                    className="contents lg:flex lg:shrink lg:flex-col lg:gap-1"
-                  >
-                    {group.items.map((item) => {
-                      if (
-                        item.view === "githubSources" &&
-                        publisherMembershipsLoaded &&
-                        !canConfigureGitHubSources
-                      ) {
-                        return null;
-                      }
-                      const active = effectiveActiveView === item.view;
-                      return (
-                        <button
-                          key={item.view}
-                          type="button"
-                          onClick={() => navigateToView(item.view)}
-                          aria-current={active ? "true" : undefined}
-                          aria-label={item.label}
-                          className={`settings-sidebar-link inline-flex min-h-11 shrink-0 items-center gap-2 whitespace-nowrap rounded-[var(--radius-sm)] px-3 py-2 text-left text-sm font-semibold no-underline transition-colors hover:no-underline lg:min-h-10 lg:px-2 ${
-                            active
-                              ? "bg-[color-mix(in_srgb,var(--accent)_12%,transparent)] text-[color:var(--ink)]"
-                              : "text-[color:var(--ink-soft)] hover:bg-[color-mix(in_srgb,var(--accent)_8%,transparent)] hover:text-[color:var(--ink)]"
-                          }`}
-                        >
-                          <item.icon
-                            size={16}
-                            className={
-                              active
-                                ? "text-[color:var(--ink)] opacity-75"
-                                : "text-[color:var(--ink-soft)] opacity-60"
-                            }
-                          />
-                          <span className="lg:hidden">{item.mobileLabel}</span>
-                          <span className="hidden lg:inline">{item.label}</span>
-                        </button>
-                      );
-                    })}
-                  </div>
-                ))}
+                {settingsNavigationItems.map((item) => {
+                  const active = effectiveActiveView === item.view;
+                  return (
+                    <button
+                      key={item.view}
+                      type="button"
+                      onClick={() => navigateToView(item.view)}
+                      aria-current={active ? "true" : undefined}
+                      aria-label={item.label}
+                      className={`settings-sidebar-link inline-flex min-h-11 shrink-0 items-center gap-2 whitespace-nowrap rounded-[var(--radius-sm)] px-3 py-2 text-left text-sm font-semibold no-underline transition-colors hover:no-underline lg:min-h-10 lg:px-2 ${
+                        active
+                          ? "bg-[color-mix(in_srgb,var(--accent)_12%,transparent)] text-[color:var(--ink)]"
+                          : "text-[color:var(--ink-soft)] hover:bg-[color-mix(in_srgb,var(--accent)_8%,transparent)] hover:text-[color:var(--ink)]"
+                      }`}
+                    >
+                      <item.icon
+                        size={16}
+                        className={
+                          active
+                            ? "text-[color:var(--ink)] opacity-75"
+                            : "text-[color:var(--ink-soft)] opacity-60"
+                        }
+                      />
+                      <span className="lg:hidden">{item.mobileLabel}</span>
+                      <span className="hidden lg:inline">{item.label}</span>
+                    </button>
+                  );
+                })}
               </nav>
             </div>
           </aside>
 
           <div className="flex min-w-0 flex-col lg:flex-1">
             <SettingsSection
-              id="account"
-              visible={effectiveActiveView === "account"}
-              icon={<UserRound size={18} />}
-              title="Account & Preferences"
-              description="Profile details and interface preferences."
+              id="profile"
+              visible={effectiveActiveView === "profile"}
+              icon={isOrgSettings ? <Building2 size={18} /> : <UserRound size={18} />}
+              title={profileTitle}
+              description={profileDescription}
             >
               <div className="flex flex-col gap-5">
                 <SettingsBlock>
                   <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
                     <div className="flex min-w-0 items-center gap-3">
-                      <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)] text-[color:var(--ink)]">
-                        <UserRound size={17} />
+                      <span className="inline-flex h-10 w-10 shrink-0 overflow-hidden rounded-[var(--radius-sm)]">
+                        <MarketplaceIcon
+                          kind={profileKind}
+                          label={displayName || profileHandle || "Profile"}
+                          imageUrl={profileImage}
+                          size="xs"
+                        />
                       </span>
                       <div className="min-w-0">
-                        <h3 className="text-sm font-bold text-[color:var(--ink)]">Account</h3>
+                        <h3 className="text-sm font-bold text-[color:var(--ink)]">
+                          {displayName || profileHandle || "Profile"}
+                        </h3>
                         <p className="text-sm text-[color:var(--ink-soft)]">
-                          Public profile details used across skills, plugins, and publisher pages.
+                          @{profileHandle ?? me.handle}
                         </p>
                       </div>
                     </div>
-                    <Avatar className="hidden h-14 w-14 rounded-full sm:flex" title="github avatar">
-                      {accountAvatar ? (
-                        <AvatarImage src={accountAvatar} alt="GitHub avatar" />
-                      ) : null}
-                      <AvatarFallback>{accountInitial}</AvatarFallback>
-                    </Avatar>
                   </div>
 
-                  <form className="flex min-w-0 flex-col gap-4" onSubmit={onSave}>
+                  <form className="flex min-w-0 flex-col gap-4" onSubmit={onSaveProfile}>
                     <Field label="Display name" htmlFor="settings-display-name">
                       <Input
                         id="settings-display-name"
                         value={displayName}
                         onChange={(event) => setDisplayName(event.target.value)}
+                        disabled={isOrgSettings && !canManageSettingsPublisher}
                       />
                     </Field>
+                    {isOrgSettings ? (
+                      <div className="flex min-w-0 items-center gap-2">
+                        <div className="min-w-0 flex-1">
+                          <Field label="Avatar URL" htmlFor="settings-publisher-image">
+                            <Input
+                              id="settings-publisher-image"
+                              value={publisherImage}
+                              onChange={(event) => setPublisherImage(event.target.value)}
+                              disabled={!canManageSettingsPublisher}
+                              placeholder="https://example.com/logo.png"
+                            />
+                          </Field>
+                        </div>
+                        {publisherImage && canManageSettingsPublisher ? (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon-sm"
+                            aria-label="Clear avatar URL"
+                            className="mt-6 shrink-0"
+                            onClick={() => setPublisherImage("")}
+                          >
+                            <X size={15} />
+                          </Button>
+                        ) : null}
+                      </div>
+                    ) : null}
                     <Field label="Bio" htmlFor="settings-bio">
                       <Textarea
                         id="settings-bio"
                         rows={5}
                         value={bio}
                         onChange={(event) => setBio(event.target.value)}
+                        disabled={isOrgSettings && !canManageSettingsPublisher}
                         placeholder="Tell people what you're building."
                       />
                     </Field>
+                    {isOrgSettings && !canManageSettingsPublisher ? (
+                      <div className="rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface-muted)]/30 p-3 text-sm text-[color:var(--ink-soft)]">
+                        You can publish under this org. Owners and admins manage profile and
+                        members.
+                      </div>
+                    ) : null}
                     <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
                       {hasProfileChanges ? (
                         <span className="text-sm font-semibold text-red-700 dark:text-red-300">
                           You have unsaved changes.
                         </span>
                       ) : null}
-                      <Button variant="primary" type="submit">
+                      <Button
+                        variant="primary"
+                        type="submit"
+                        disabled={isOrgSettings && !canManageSettingsPublisher}
+                      >
                         <Save size={16} />
                         Save profile
                       </Button>
                     </div>
                   </form>
                 </SettingsBlock>
+              </div>
+            </SettingsSection>
 
+            <SettingsSection
+              id="appearance"
+              visible={effectiveActiveView === "appearance"}
+              icon={<Palette size={18} />}
+              title="Appearance"
+              description="Interface theme preference."
+            >
+              <div className="flex flex-col gap-5">
                 <SettingsBlock>
                   <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
                     <div className="flex items-center gap-3">
@@ -715,523 +804,292 @@ export function Settings() {
               visible={effectiveActiveView === "organizations"}
               icon={<Building2 size={18} />}
               title="Organizations"
-              description="Publisher profiles and access."
+              description="Switch into an organization to manage its profile and access."
             >
               <div className="flex flex-col gap-5">
-                {orgs.length > 0 ? (
-                  <>
-                    <div className="flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
-                      <Select
-                        value={selectedOrg?.publisher.handle ?? ""}
-                        onValueChange={setSelectedOrgHandle}
+                <div className="flex justify-end">
+                  <Dialog
+                    open={createOrgDialogOpen}
+                    onOpenChange={(open) => {
+                      setCreateOrgDialogOpen(open);
+                      if (open) setCreateOrgError(null);
+                    }}
+                  >
+                    <DialogTrigger asChild>
+                      <Button
+                        variant={orgs.length ? "outline" : "primary"}
+                        type="button"
+                        className="sm:w-auto"
                       >
-                        <SelectTrigger
-                          id="settings-manage-org"
-                          aria-label="Manage organization"
-                          className="h-12 sm:min-w-[280px]"
+                        <Plus size={16} />
+                        {orgs.length ? "Add new org" : "Create org"}
+                      </Button>
+                    </DialogTrigger>
+                    <DialogContent>
+                      <DialogHeader>
+                        <DialogTitle>Create organization</DialogTitle>
+                        <DialogDescription>
+                          Create a publisher profile for a team or project.
+                        </DialogDescription>
+                      </DialogHeader>
+                      <div className="grid gap-4">
+                        <Field label="Handle" htmlFor="settings-org-handle">
+                          <Input
+                            id="settings-org-handle"
+                            value={orgHandle}
+                            onChange={(event) => {
+                              setOrgHandle(event.target.value);
+                              setCreateOrgError(null);
+                            }}
+                            placeholder="example.tools"
+                          />
+                        </Field>
+                        <Field label="Display name" htmlFor="settings-org-display-name">
+                          <Input
+                            id="settings-org-display-name"
+                            value={orgDisplayName}
+                            onChange={(event) => {
+                              setOrgDisplayName(event.target.value);
+                              setCreateOrgError(null);
+                            }}
+                            placeholder="OpenClaw"
+                          />
+                        </Field>
+                      </div>
+                      {createOrgError ? (
+                        <p
+                          className="text-sm font-medium text-red-600 dark:text-red-400"
+                          role="alert"
                         >
-                          {selectedOrg ? (
-                            <span className="flex min-w-0 items-center gap-2">
-                              <OrgLogoSmall
-                                image={selectedOrg.publisher.image}
-                                name={selectedOrg.publisher.displayName}
-                                handle={selectedOrg.publisher.handle}
-                                className="h-6 w-6"
-                              />
-                              <span className="truncate">
-                                @{selectedOrg.publisher.handle} · {selectedOrg.role}
-                              </span>
-                            </span>
-                          ) : (
-                            <SelectValue placeholder="Select an org" />
-                          )}
-                        </SelectTrigger>
-                        <SelectContent>
-                          {orgs.map((entry) => (
-                            <SelectItem key={entry.publisher._id} value={entry.publisher.handle}>
-                              <span className="flex min-w-0 items-center gap-2">
-                                <OrgLogoSmall
-                                  image={entry.publisher.image}
-                                  name={entry.publisher.displayName}
-                                  handle={entry.publisher.handle}
-                                  className="h-6 w-6"
-                                />
-                                <span className="truncate">
-                                  @{entry.publisher.handle} · {entry.role}
-                                </span>
-                              </span>
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <Dialog
-                        open={createOrgDialogOpen}
-                        onOpenChange={(open) => {
-                          setCreateOrgDialogOpen(open);
-                          if (open) setCreateOrgError(null);
-                        }}
-                      >
-                        <DialogTrigger asChild>
-                          <Button variant="outline" type="button" className="h-12 sm:w-auto">
-                            <Plus size={16} />
-                            Add new org
+                          {createOrgError}
+                        </p>
+                      ) : null}
+                      <DialogFooter>
+                        <Button variant="ghost" onClick={() => setCreateOrgDialogOpen(false)}>
+                          Cancel
+                        </Button>
+                        <Button
+                          variant="primary"
+                          type="button"
+                          disabled={!orgHandle.trim() || isCreatingOrg}
+                          onClick={() => void onCreateOrg()}
+                        >
+                          <Building2 size={16} />
+                          {isCreatingOrg ? "Creating..." : "Create org"}
+                        </Button>
+                      </DialogFooter>
+                    </DialogContent>
+                  </Dialog>
+                </div>
+
+                {orgs.length ? (
+                  <div className="grid gap-3">
+                    {orgs.map((entry) => (
+                      <SettingsBlock key={entry.publisher._id} className="gap-3">
+                        <div className="flex min-w-0 flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                          <div className="flex min-w-0 items-center gap-3">
+                            <OrgLogoSmall
+                              image={entry.publisher.image}
+                              name={entry.publisher.displayName}
+                              handle={entry.publisher.handle}
+                              className="h-10 w-10"
+                            />
+                            <div className="min-w-0">
+                              <h3 className="truncate text-sm font-bold text-[color:var(--ink)]">
+                                {entry.publisher.displayName || entry.publisher.handle}
+                              </h3>
+                              <p className="truncate text-sm text-[color:var(--ink-soft)]">
+                                @{entry.publisher.handle} · {entry.role}
+                              </p>
+                            </div>
+                          </div>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            className="sm:w-auto"
+                            onClick={() => {
+                              setActivePublisherId(entry.publisher._id);
+                              navigateToView("profile");
+                            }}
+                          >
+                            Manage
                           </Button>
-                        </DialogTrigger>
-                        <DialogContent>
-                          <DialogHeader>
-                            <DialogTitle>Create organization</DialogTitle>
-                            <DialogDescription>
-                              Create a publisher profile for a team or project.
-                            </DialogDescription>
-                          </DialogHeader>
-                          <div className="grid gap-4">
-                            <Field label="Handle" htmlFor="settings-org-handle">
-                              <Input
-                                id="settings-org-handle"
-                                value={orgHandle}
-                                onChange={(event) => {
-                                  setOrgHandle(event.target.value);
-                                  setCreateOrgError(null);
-                                }}
-                                placeholder="example.tools"
-                              />
-                            </Field>
-                            <Field label="Display name" htmlFor="settings-org-display-name">
-                              <Input
-                                id="settings-org-display-name"
-                                value={orgDisplayName}
-                                onChange={(event) => {
-                                  setOrgDisplayName(event.target.value);
-                                  setCreateOrgError(null);
-                                }}
-                                placeholder="OpenClaw"
-                              />
-                            </Field>
-                          </div>
-                          {createOrgError ? (
-                            <p
-                              className="text-sm font-medium text-red-600 dark:text-red-400"
-                              role="alert"
-                            >
-                              {createOrgError}
-                            </p>
-                          ) : null}
-                          <DialogFooter>
-                            <Button variant="ghost" onClick={() => setCreateOrgDialogOpen(false)}>
-                              Cancel
-                            </Button>
-                            <Button
-                              variant="primary"
-                              type="button"
-                              disabled={!orgHandle.trim() || isCreatingOrg}
-                              onClick={() => void onCreateOrg()}
-                            >
-                              <Building2 size={16} />
-                              {isCreatingOrg ? "Creating..." : "Create org"}
-                            </Button>
-                          </DialogFooter>
-                        </DialogContent>
-                      </Dialog>
-                    </div>
-
-                    {selectedOrg && selectedOrg.role !== "publisher" ? (
-                      <>
-                        <SettingsBlock>
-                          <div className="flex min-w-0 w-full flex-col gap-5">
-                            <div className="flex min-w-0 items-center gap-4">
-                              <OrgLogo
-                                image={selectedOrgImage.trim() || undefined}
-                                name={selectedOrgDisplayName}
-                                handle={selectedOrg.publisher.handle}
-                                className="h-16 w-16"
-                              />
-                              <div className="min-w-0">
-                                <h3 className="truncate text-base font-bold text-[color:var(--ink)]">
-                                  {selectedOrgDisplayName || selectedOrg.publisher.handle}
-                                </h3>
-                                <p className="truncate text-sm text-[color:var(--ink-soft)]">
-                                  @{selectedOrg.publisher.handle}
-                                </p>
-                              </div>
-                            </div>
-
-                            <div className="grid w-full grid-cols-1 gap-4 lg:grid-cols-2">
-                              <Field
-                                label="Display name"
-                                htmlFor="settings-selected-org-display-name"
-                              >
-                                <Input
-                                  id="settings-selected-org-display-name"
-                                  value={selectedOrgDisplayName}
-                                  onChange={(event) =>
-                                    setSelectedOrgDisplayName(event.target.value)
-                                  }
-                                  placeholder="OpenClaw"
-                                />
-                              </Field>
-                              <div className="flex min-w-0 items-center gap-2">
-                                <div className="min-w-0 flex-1">
-                                  <Field label="Avatar URL" htmlFor="settings-selected-org-image">
-                                    <Input
-                                      id="settings-selected-org-image"
-                                      value={selectedOrgImage}
-                                      onChange={(event) => setSelectedOrgImage(event.target.value)}
-                                      placeholder="https://example.com/logo.png"
-                                    />
-                                  </Field>
-                                </div>
-                                {selectedOrgImage ? (
-                                  <Button
-                                    type="button"
-                                    variant="ghost"
-                                    size="icon-sm"
-                                    aria-label="Clear avatar URL"
-                                    className="mt-6 shrink-0"
-                                    onClick={() => setSelectedOrgImage("")}
-                                  >
-                                    <X size={15} />
-                                  </Button>
-                                ) : null}
-                              </div>
-                              <div className="lg:col-span-2">
-                                <Field label="Bio" htmlFor="settings-selected-org-bio">
-                                  <Textarea
-                                    id="settings-selected-org-bio"
-                                    rows={4}
-                                    value={selectedOrgBio}
-                                    onChange={(event) => setSelectedOrgBio(event.target.value)}
-                                    placeholder="Tell people what this organization publishes."
-                                  />
-                                </Field>
-                              </div>
-                              <div className="flex flex-col gap-3 lg:col-span-2 lg:flex-row lg:items-center lg:justify-end">
-                                {hasOrgProfileChanges ? (
-                                  <span className="text-sm font-semibold text-red-700 dark:text-red-300">
-                                    You have unsaved changes.
-                                  </span>
-                                ) : null}
-                                <Button type="button" onClick={() => void onSaveOrgProfile()}>
-                                  <Save size={16} />
-                                  Save changes
-                                </Button>
-                              </div>
-                            </div>
-                          </div>
-                        </SettingsBlock>
-
-                        <SettingsBlock>
-                          <div className="flex items-center justify-between gap-3">
-                            <div className="flex min-w-0 items-center gap-3">
-                              <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)] text-[color:var(--ink)]">
-                                <Users size={16} />
-                              </span>
-                              <div className="min-w-0">
-                                <div className="flex items-center gap-2">
-                                  <h3 className="text-sm font-bold text-[color:var(--ink)]">
-                                    Members
-                                  </h3>
-                                  <span className="inline-flex h-5 items-center rounded-full border border-[color:var(--line)] bg-[color:var(--surface-muted)] px-2 text-[11px] font-semibold text-[color:var(--ink-soft)]">
-                                    {(orgMembers?.members ?? []).length}
-                                  </span>
-                                </div>
-                              </div>
-                            </div>
-                            <Dialog
-                              open={addMemberDialogOpen}
-                              onOpenChange={setAddMemberDialogOpen}
-                            >
-                              <DialogTrigger asChild>
-                                <Button
-                                  type="button"
-                                  className="h-10 w-auto shrink-0 px-3 text-sm sm:h-11 sm:px-4"
-                                >
-                                  <Users size={16} />
-                                  Add member
-                                </Button>
-                              </DialogTrigger>
-                              <DialogContent>
-                                <DialogHeader>
-                                  <DialogTitle>Add member</DialogTitle>
-                                  <DialogDescription>
-                                    Give a user access to @{selectedOrg.publisher.handle}.
-                                  </DialogDescription>
-                                </DialogHeader>
-                                <div className="grid gap-4">
-                                  <Field label="User handle" htmlFor="settings-add-member">
-                                    <Input
-                                      id="settings-add-member"
-                                      value={memberHandle}
-                                      onChange={(event) => setMemberHandle(event.target.value)}
-                                      placeholder="@username"
-                                    />
-                                  </Field>
-                                  <Field label="Role" htmlFor="settings-member-role">
-                                    <Select
-                                      value={memberRole}
-                                      onValueChange={(value) =>
-                                        setMemberRole(value as "owner" | "admin" | "publisher")
-                                      }
-                                    >
-                                      <SelectTrigger id="settings-member-role">
-                                        <SelectValue />
-                                      </SelectTrigger>
-                                      <SelectContent>
-                                        <SelectItem value="publisher">Publisher</SelectItem>
-                                        <SelectItem value="admin">Admin</SelectItem>
-                                        <SelectItem value="owner">Owner</SelectItem>
-                                      </SelectContent>
-                                    </Select>
-                                  </Field>
-                                </div>
-                                <DialogFooter>
-                                  <Button
-                                    variant="ghost"
-                                    onClick={() => setAddMemberDialogOpen(false)}
-                                  >
-                                    Cancel
-                                  </Button>
-                                  <Button
-                                    type="button"
-                                    disabled={!memberHandle.trim()}
-                                    onClick={() =>
-                                      void addOrgMember({
-                                        publisherId: selectedOrg.publisher._id,
-                                        userHandle: memberHandle,
-                                        role: memberRole,
-                                      }).then(() => {
-                                        setMemberHandle("");
-                                        setAddMemberDialogOpen(false);
-                                      })
-                                    }
-                                  >
-                                    <Users size={16} />
-                                    Add member
-                                  </Button>
-                                </DialogFooter>
-                              </DialogContent>
-                            </Dialog>
-                          </div>
-
-                          <div className="flex min-w-0 flex-col gap-4">
-                            {(orgMembers?.members ?? []).length ? (
-                              <div className="divide-y divide-[color:var(--line)] overflow-hidden">
-                                {orgMembers?.members.map((entry) => (
-                                  <div
-                                    key={`${entry.user._id}:${entry.role}`}
-                                    className="flex items-center justify-between gap-3 py-3"
-                                  >
-                                    <div className="flex min-w-0 items-center gap-3">
-                                      <Avatar className="h-9 w-9 rounded-full">
-                                        {entry.user.image ? (
-                                          <AvatarImage
-                                            src={entry.user.image}
-                                            alt={
-                                              entry.user.displayName ?? entry.user.handle ?? "User"
-                                            }
-                                          />
-                                        ) : null}
-                                        <AvatarFallback>
-                                          {(entry.user.displayName ?? entry.user.handle ?? "U")
-                                            .charAt(0)
-                                            .toUpperCase()}
-                                        </AvatarFallback>
-                                      </Avatar>
-                                      <div className="flex min-w-0 flex-col gap-1">
-                                        <div className="flex min-w-0 items-center gap-2">
-                                          <span className="truncate pr-1 text-sm font-semibold text-[color:var(--ink)]">
-                                            {entry.user.displayName ??
-                                              entry.user.handle ??
-                                              entry.user._id}
-                                          </span>
-                                          <Badge className="shrink-0 self-center px-2.5 py-0.5 text-fs-xs">
-                                            {entry.role}
-                                          </Badge>
-                                        </div>
-                                        <div className="truncate text-xs text-[color:var(--ink-soft)]">
-                                          @{entry.user.handle ?? "user"}
-                                        </div>
-                                      </div>
-                                    </div>
-                                    <div className="flex shrink-0 items-center">
-                                      {entry.role !== "owner" ? (
-                                        <Button
-                                          variant="ghost"
-                                          size="sm"
-                                          type="button"
-                                          onClick={() =>
-                                            void removeOrgMember({
-                                              publisherId: selectedOrg.publisher._id,
-                                              userId: entry.user._id,
-                                            })
-                                          }
-                                        >
-                                          Remove
-                                        </Button>
-                                      ) : null}
-                                    </div>
-                                  </div>
-                                ))}
-                              </div>
-                            ) : null}
-                          </div>
-                        </SettingsBlock>
-
-                        {selectedOrg.role === "owner" ? (
-                          <SettingsBlock tone="danger">
-                            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                              <div className="flex min-w-0 items-center gap-3">
-                                <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-red-300/40 bg-red-500/10 text-red-700 dark:border-red-500/30 dark:text-red-300">
-                                  <ShieldAlert size={17} />
-                                </span>
-                                <div className="min-w-0">
-                                  <h3 className="text-sm font-bold text-red-700 dark:text-red-300">
-                                    Delete organization
-                                  </h3>
-                                  <p className="text-sm text-[color:var(--ink-soft)]">
-                                    Permanently remove this org and its published skills and
-                                    plugins.
-                                  </p>
-                                </div>
-                              </div>
-                              <Dialog
-                                open={deleteOrgDialogOpen}
-                                onOpenChange={setDeleteOrgDialogOpen}
-                              >
-                                <DialogTrigger asChild>
-                                  <Button variant="destructive" type="button" className="sm:w-auto">
-                                    <Trash2 size={16} />
-                                    Delete organization
-                                  </Button>
-                                </DialogTrigger>
-                                <DialogContent>
-                                  <DialogHeader>
-                                    <DialogTitle>Delete organization</DialogTitle>
-                                    <DialogDescription>
-                                      Permanently delete @{selectedOrg.publisher.handle} and its
-                                      published resources. This action cannot be undone.
-                                    </DialogDescription>
-                                  </DialogHeader>
-                                  <DeletionResourceSummary
-                                    publishers={[selectedOrg]}
-                                    emptyLabel="This organization has no published skills or plugins."
-                                  />
-                                  <DialogFooter>
-                                    <Button
-                                      variant="ghost"
-                                      onClick={() => setDeleteOrgDialogOpen(false)}
-                                    >
-                                      Cancel
-                                    </Button>
-                                    <Button
-                                      variant="destructive"
-                                      onClick={() => void onDeleteOrg()}
-                                    >
-                                      Permanently delete organization
-                                    </Button>
-                                  </DialogFooter>
-                                </DialogContent>
-                              </Dialog>
-                            </div>
-                          </SettingsBlock>
-                        ) : null}
-                      </>
-                    ) : selectedOrg ? (
-                      <div className="rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface-muted)]/30 p-4 text-sm text-[color:var(--ink-soft)]">
-                        You can publish under this org. Owners and admins manage profile and
-                        members.
-                      </div>
-                    ) : null}
-                  </>
-                ) : null}
-
-                {!orgs.length ? (
-                  <SettingsBlock>
-                    <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-                      <div className="flex min-w-0 items-center gap-3">
-                        <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)] text-[color:var(--ink)]">
-                          <Building2 size={17} />
-                        </span>
-                        <div className="min-w-0">
-                          <h3 className="text-sm font-bold text-[color:var(--ink)]">
-                            Create organization
-                          </h3>
-                          <p className="text-sm text-[color:var(--ink-soft)]">
-                            Add a publisher profile for a team or project.
-                          </p>
                         </div>
+                      </SettingsBlock>
+                    ))}
+                  </div>
+                ) : (
+                  <SettingsBlock>
+                    <div className="flex min-w-0 items-center gap-3">
+                      <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)] text-[color:var(--ink)]">
+                        <Building2 size={17} />
+                      </span>
+                      <div className="min-w-0">
+                        <h3 className="text-sm font-bold text-[color:var(--ink)]">
+                          No organizations yet
+                        </h3>
                       </div>
-                      <Dialog
-                        open={createOrgDialogOpen}
-                        onOpenChange={(open) => {
-                          setCreateOrgDialogOpen(open);
-                          if (open) setCreateOrgError(null);
-                        }}
-                      >
-                        <DialogTrigger asChild>
-                          <Button variant="primary" type="button" className="lg:w-auto">
-                            <Building2 size={16} />
-                            Create org
-                          </Button>
-                        </DialogTrigger>
-                        <DialogContent>
-                          <DialogHeader>
-                            <DialogTitle>Create organization</DialogTitle>
-                            <DialogDescription>
-                              Create a publisher profile for a team or project.
-                            </DialogDescription>
-                          </DialogHeader>
-                          <div className="grid gap-4">
-                            <Field label="Handle" htmlFor="settings-org-handle-empty">
-                              <Input
-                                id="settings-org-handle-empty"
-                                value={orgHandle}
-                                onChange={(event) => {
-                                  setOrgHandle(event.target.value);
-                                  setCreateOrgError(null);
-                                }}
-                                placeholder="example.tools"
-                              />
-                            </Field>
-                            <Field label="Display name" htmlFor="settings-org-display-name-empty">
-                              <Input
-                                id="settings-org-display-name-empty"
-                                value={orgDisplayName}
-                                onChange={(event) => {
-                                  setOrgDisplayName(event.target.value);
-                                  setCreateOrgError(null);
-                                }}
-                                placeholder="OpenClaw"
-                              />
-                            </Field>
-                          </div>
-                          {createOrgError ? (
-                            <p
-                              className="text-sm font-medium text-red-600 dark:text-red-400"
-                              role="alert"
-                            >
-                              {createOrgError}
-                            </p>
-                          ) : null}
-                          <DialogFooter>
-                            <Button variant="ghost" onClick={() => setCreateOrgDialogOpen(false)}>
-                              Cancel
-                            </Button>
-                            <Button
-                              variant="primary"
-                              type="button"
-                              disabled={!orgHandle.trim() || isCreatingOrg}
-                              onClick={() => void onCreateOrg()}
-                            >
-                              <Building2 size={16} />
-                              {isCreatingOrg ? "Creating..." : "Create org"}
-                            </Button>
-                          </DialogFooter>
-                        </DialogContent>
-                      </Dialog>
                     </div>
                   </SettingsBlock>
-                ) : null}
+                )}
               </div>
+            </SettingsSection>
+
+            <SettingsSection
+              id="members"
+              visible={effectiveActiveView === "members"}
+              icon={<Users size={18} />}
+              title="Members"
+              description="Organization access for the active publisher."
+            >
+              {settingsPublisher && isOrgSettings ? (
+                <SettingsBlock>
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="flex min-w-0 items-center gap-3">
+                      <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)] text-[color:var(--ink)]">
+                        <Users size={16} />
+                      </span>
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <h3 className="text-sm font-bold text-[color:var(--ink)]">Members</h3>
+                          <span className="inline-flex h-5 items-center rounded-full border border-[color:var(--line)] bg-[color:var(--surface-muted)] px-2 text-[11px] font-semibold text-[color:var(--ink-soft)]">
+                            {(orgMembers?.members ?? []).length}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <Dialog open={addMemberDialogOpen} onOpenChange={setAddMemberDialogOpen}>
+                      <DialogTrigger asChild>
+                        <Button
+                          type="button"
+                          className="h-10 w-auto shrink-0 px-3 text-sm sm:h-11 sm:px-4"
+                        >
+                          <Users size={16} />
+                          Add member
+                        </Button>
+                      </DialogTrigger>
+                      <DialogContent>
+                        <DialogHeader>
+                          <DialogTitle>Add member</DialogTitle>
+                          <DialogDescription>
+                            Give a user access to @{settingsPublisher.publisher.handle}.
+                          </DialogDescription>
+                        </DialogHeader>
+                        <div className="grid gap-4">
+                          <Field label="User handle" htmlFor="settings-add-member">
+                            <Input
+                              id="settings-add-member"
+                              value={memberHandle}
+                              onChange={(event) => setMemberHandle(event.target.value)}
+                              placeholder="@username"
+                            />
+                          </Field>
+                          <Field label="Role" htmlFor="settings-member-role">
+                            <Select
+                              value={memberRole}
+                              onValueChange={(value) =>
+                                setMemberRole(value as "owner" | "admin" | "publisher")
+                              }
+                            >
+                              <SelectTrigger id="settings-member-role">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectItem value="publisher">Publisher</SelectItem>
+                                <SelectItem value="admin">Admin</SelectItem>
+                                {settingsPublisherRole === "owner" ? (
+                                  <SelectItem value="owner">Owner</SelectItem>
+                                ) : null}
+                              </SelectContent>
+                            </Select>
+                          </Field>
+                        </div>
+                        <DialogFooter>
+                          <Button variant="ghost" onClick={() => setAddMemberDialogOpen(false)}>
+                            Cancel
+                          </Button>
+                          <Button
+                            type="button"
+                            disabled={!memberHandle.trim()}
+                            onClick={() =>
+                              void addOrgMember({
+                                publisherId: settingsPublisher.publisher._id,
+                                userHandle: memberHandle,
+                                role: memberRole,
+                              }).then(() => {
+                                setMemberHandle("");
+                                setAddMemberDialogOpen(false);
+                              })
+                            }
+                          >
+                            <Users size={16} />
+                            Add member
+                          </Button>
+                        </DialogFooter>
+                      </DialogContent>
+                    </Dialog>
+                  </div>
+
+                  <div className="flex min-w-0 flex-col gap-4">
+                    {(orgMembers?.members ?? []).length ? (
+                      <div className="divide-y divide-[color:var(--line)] overflow-hidden">
+                        {orgMembers?.members.map((entry) => (
+                          <div
+                            key={entry.user._id + ":" + entry.role}
+                            className="flex items-center justify-between gap-3 py-3"
+                          >
+                            <div className="flex min-w-0 items-center gap-3">
+                              <Avatar className="h-9 w-9 rounded-full">
+                                {entry.user.image ? (
+                                  <AvatarImage
+                                    src={entry.user.image}
+                                    alt={entry.user.displayName ?? entry.user.handle ?? "User"}
+                                  />
+                                ) : null}
+                                <AvatarFallback>
+                                  {(entry.user.displayName ?? entry.user.handle ?? "U")
+                                    .charAt(0)
+                                    .toUpperCase()}
+                                </AvatarFallback>
+                              </Avatar>
+                              <div className="flex min-w-0 flex-col gap-1">
+                                <div className="flex min-w-0 items-center gap-2">
+                                  <span className="truncate pr-1 text-sm font-semibold text-[color:var(--ink)]">
+                                    {entry.user.displayName ?? entry.user.handle ?? entry.user._id}
+                                  </span>
+                                  <Badge className="shrink-0 self-center px-2.5 py-0.5 text-fs-xs">
+                                    {entry.role}
+                                  </Badge>
+                                </div>
+                                <div className="truncate text-xs text-[color:var(--ink-soft)]">
+                                  @{entry.user.handle ?? "user"}
+                                </div>
+                              </div>
+                            </div>
+                            <div className="flex shrink-0 items-center">
+                              {entry.role !== "owner" ? (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  type="button"
+                                  onClick={() =>
+                                    void removeOrgMember({
+                                      publisherId: settingsPublisher.publisher._id,
+                                      userId: entry.user._id,
+                                    })
+                                  }
+                                >
+                                  Remove
+                                </Button>
+                              ) : null}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                </SettingsBlock>
+              ) : null}
             </SettingsSection>
 
             <SettingsSection
@@ -1259,11 +1117,8 @@ export function Settings() {
                       </div>
                     </div>
 
-                    {selectedSourcePublisher ? (
+                    {settingsPublisher && canConfigureActiveGitHubSources ? (
                       <GitHubSourceForm
-                        publisherOptions={officialGitHubSourcePublishers}
-                        selectedPublisherId={selectedSourcePublisher.publisher._id}
-                        onPublisherChange={setSelectedSourcePublisherId}
                         githubRepo={githubRepo}
                         onGithubRepoChange={setGithubRepo}
                         onConfigure={onConfigureGitHubSource}
@@ -1436,71 +1291,125 @@ export function Settings() {
               id="danger"
               visible={effectiveActiveView === "danger"}
               icon={<ShieldAlert size={18} />}
-              title="Account deletion"
-              description="Delete your account permanently and hide personal published resources."
+              title={isOrgSettings ? "Delete organization" : "Account deletion"}
+              description={
+                isOrgSettings
+                  ? "Delete the active organization permanently."
+                  : "Delete your account permanently and hide personal published resources."
+              }
               tone="danger"
               hideHeader
             >
               <SettingsBlock>
-                <div className="flex flex-col gap-4">
-                  <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                    <div className="flex min-w-0 items-center gap-3">
-                      <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)] text-[color:var(--ink)]">
-                        <ShieldAlert size={18} />
-                      </span>
-                      <div className="min-w-0">
-                        <h3 className="text-sm font-bold text-[color:var(--ink)]">
-                          Account deletion
-                        </h3>
+                {isOrgSettings && settingsPublisher ? (
+                  <div className="flex flex-col gap-4">
+                    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                      <div className="flex min-w-0 items-center gap-3">
+                        <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-red-300/40 bg-red-500/10 text-red-700 dark:border-red-500/30 dark:text-red-300">
+                          <ShieldAlert size={18} />
+                        </span>
+                        <div className="min-w-0">
+                          <h3 className="text-sm font-bold text-red-700 dark:text-red-300">
+                            Delete organization
+                          </h3>
+                          <p className="text-sm text-[color:var(--ink-soft)]">
+                            Permanently remove @{settingsPublisher.publisher.handle} and its
+                            published skills and plugins.
+                          </p>
+                        </div>
+                      </div>
+                      <Dialog open={deleteOrgDialogOpen} onOpenChange={setDeleteOrgDialogOpen}>
+                        <DialogTrigger asChild>
+                          <Button variant="destructive" type="button" className="sm:w-auto">
+                            <Trash2 size={16} />
+                            Delete organization
+                          </Button>
+                        </DialogTrigger>
+                        <DialogContent>
+                          <DialogHeader>
+                            <DialogTitle>Delete organization</DialogTitle>
+                            <DialogDescription>
+                              Permanently delete @{settingsPublisher.publisher.handle}. This action
+                              cannot be undone.
+                            </DialogDescription>
+                          </DialogHeader>
+                          <DeletionResourceSummary
+                            publishers={[settingsPublisher]}
+                            emptyLabel="This organization has no published skills or plugins."
+                          />
+                          <DialogFooter>
+                            <Button variant="ghost" onClick={() => setDeleteOrgDialogOpen(false)}>
+                              Cancel
+                            </Button>
+                            <Button variant="destructive" onClick={() => void onDeleteOrg()}>
+                              Permanently delete organization
+                            </Button>
+                          </DialogFooter>
+                        </DialogContent>
+                      </Dialog>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex flex-col gap-4">
+                    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                      <div className="flex min-w-0 items-center gap-3">
+                        <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)] text-[color:var(--ink)]">
+                          <ShieldAlert size={18} />
+                        </span>
+                        <div className="min-w-0">
+                          <h3 className="text-sm font-bold text-[color:var(--ink)]">
+                            Account deletion
+                          </h3>
+                        </div>
+                      </div>
+                      <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+                        <DialogTrigger asChild>
+                          <Button variant="destructive" type="button" className="sm:w-auto">
+                            <Trash2 size={16} />
+                            Delete account
+                          </Button>
+                        </DialogTrigger>
+                        <DialogContent>
+                          <DialogHeader>
+                            <DialogTitle>Delete account</DialogTitle>
+                            <DialogDescription>
+                              This permanently deletes your account and eligible owned resources.
+                              This action cannot be undone.
+                            </DialogDescription>
+                          </DialogHeader>
+                          <DeletionResourceSummary
+                            publishers={deletionPublishers}
+                            emptyLabel="No published skills or plugins are attached to your account."
+                          />
+                          <DialogFooter>
+                            <Button variant="ghost" onClick={() => setDeleteDialogOpen(false)}>
+                              Cancel
+                            </Button>
+                            <Button variant="destructive" onClick={() => void onDelete()}>
+                              Permanently delete account
+                            </Button>
+                          </DialogFooter>
+                        </DialogContent>
+                      </Dialog>
+                    </div>
+
+                    <div className="flex items-start gap-3 rounded-[var(--radius-sm)] border border-red-300/20 bg-red-500/[0.04] p-4 dark:border-red-500/20 dark:bg-red-500/[0.06]">
+                      <ShieldAlert
+                        size={18}
+                        className="mt-0.5 shrink-0 text-red-600 dark:text-red-400"
+                      />
+                      <div className="flex flex-col gap-1">
+                        <p className="text-sm font-semibold text-red-700 dark:text-red-300">
+                          This will permanently delete your account
+                        </p>
+                        <p className="text-sm text-[color:var(--ink-soft)]">
+                          Your profile, API tokens, personal publisher resources, and sole-owner org
+                          resources will be permanently removed.
+                        </p>
                       </div>
                     </div>
-                    <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-                      <DialogTrigger asChild>
-                        <Button variant="destructive" type="button" className="sm:w-auto">
-                          <Trash2 size={16} />
-                          Delete account
-                        </Button>
-                      </DialogTrigger>
-                      <DialogContent>
-                        <DialogHeader>
-                          <DialogTitle>Delete account</DialogTitle>
-                          <DialogDescription>
-                            This permanently deletes your account and eligible owned resources. This
-                            action cannot be undone.
-                          </DialogDescription>
-                        </DialogHeader>
-                        <DeletionResourceSummary
-                          publishers={deletionPublishers}
-                          emptyLabel="No published skills or plugins are attached to your account."
-                        />
-                        <DialogFooter>
-                          <Button variant="ghost" onClick={() => setDeleteDialogOpen(false)}>
-                            Cancel
-                          </Button>
-                          <Button variant="destructive" onClick={() => void onDelete()}>
-                            Permanently delete account
-                          </Button>
-                        </DialogFooter>
-                      </DialogContent>
-                    </Dialog>
                   </div>
-
-                  <div className="flex items-start gap-3 rounded-[var(--radius-sm)] border border-red-300/20 bg-red-500/[0.04] p-4 dark:border-red-500/20 dark:bg-red-500/[0.06]">
-                    <ShieldAlert
-                      size={18}
-                      className="mt-0.5 shrink-0 text-red-600 dark:text-red-400"
-                    />
-                    <div className="flex flex-col gap-1">
-                      <p className="text-sm font-semibold text-red-700 dark:text-red-300">
-                        This will permanently delete your account
-                      </p>
-                      <p className="text-sm text-[color:var(--ink-soft)]">
-                        Your profile, API tokens, personal publisher resources, and sole-owner org
-                        resources will be permanently removed.
-                      </p>
-                    </div>
-                  </div>
-                </div>
+                )}
               </SettingsBlock>
             </SettingsSection>
           </div>
@@ -1694,26 +1603,6 @@ function SettingsBlock({
     >
       {children}
     </div>
-  );
-}
-
-function OrgLogo({
-  image,
-  name,
-  handle,
-  className,
-}: {
-  image?: string | null;
-  name: string;
-  handle: string;
-  className?: string;
-}) {
-  return (
-    <span
-      className={`settings-org-logo inline-flex overflow-hidden rounded-[var(--radius-sm)] ${className ?? ""}`}
-    >
-      <MarketplaceIcon kind="org" label={name || handle} imageUrl={image} size="md" />
-    </span>
   );
 }
 
@@ -2096,17 +1985,11 @@ function GitHubSourceStatusPill({ needsAttention }: { needsAttention: boolean })
 }
 
 function GitHubSourceForm({
-  publisherOptions,
-  selectedPublisherId,
-  onPublisherChange,
   githubRepo,
   onGithubRepoChange,
   onConfigure,
   isSyncing,
 }: {
-  publisherOptions: PublisherMembership[];
-  selectedPublisherId: string;
-  onPublisherChange: (publisherId: string) => void;
   githubRepo: string;
   onGithubRepoChange: (repo: string) => void;
   onConfigure: (event: FormEvent) => void;
@@ -2114,22 +1997,6 @@ function GitHubSourceForm({
 }) {
   return (
     <form className="flex flex-col gap-3 sm:flex-row sm:items-end" onSubmit={onConfigure}>
-      <div className="min-w-0 sm:w-64 sm:shrink-0">
-        <Field label="Publisher" htmlFor="settings-github-source-publisher">
-          <Select value={selectedPublisherId} onValueChange={onPublisherChange}>
-            <SelectTrigger id="settings-github-source-publisher">
-              <SelectValue placeholder="Select org" />
-            </SelectTrigger>
-            <SelectContent>
-              {publisherOptions.map((entry) => (
-                <SelectItem key={entry.publisher._id} value={entry.publisher._id}>
-                  @{entry.publisher.handle}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </Field>
-      </div>
       <div className="flex min-w-0 flex-1 flex-col gap-3 sm:flex-row sm:items-end">
         <div className="min-w-0 flex-1">
           <Field label="GitHub repo URL" htmlFor="settings-github-repo">
@@ -2377,22 +2244,45 @@ function Field({
   );
 }
 
-function useActiveSettingsView() {
+function normalizeSettingsView(
+  view: SettingsSearchView | null | undefined,
+  availableViews: SettingsView[],
+  isOrgContext: boolean,
+): SettingsView {
+  const fallback = availableViews[0] ?? "profile";
+  if (!view) return fallback;
+  if (view === "account") return availableViews.includes("profile") ? "profile" : fallback;
+  if (view === "organizations" && isOrgContext) {
+    return availableViews.includes("profile") ? "profile" : fallback;
+  }
+  return availableViews.includes(view) ? view : fallback;
+}
+
+function useActiveSettingsView(availableViews: SettingsView[], isOrgContext: boolean) {
   const navigate = useNavigate({ from: "/settings" });
   const search = useSearch({ from: "/settings" });
-  const [migratedHashView, setMigratedHashView] = useState<SettingsView | null>(null);
+  const [migratedHashView, setMigratedHashView] = useState<SettingsSearchView | null>(null);
   const [hasCheckedHash, setHasCheckedHash] = useState(false);
-  const activeView = isSettingsView(search.view) ? search.view : (migratedHashView ?? "account");
+  const requestedView = isSettingsSearchView(search.view) ? search.view : migratedHashView;
+  const activeView = normalizeSettingsView(requestedView, availableViews, isOrgContext);
 
   useEffect(() => {
     if (hasCheckedHash) return;
     setHasCheckedHash(true);
     const hash = window.location.hash.replace("#", "");
-    if (isSettingsView(hash)) {
+    if (isSettingsSearchView(hash)) {
       setMigratedHashView(hash);
-      void navigate({ search: { view: hash }, replace: true });
+      void navigate({
+        search: { view: normalizeSettingsView(hash, availableViews, isOrgContext) },
+        replace: true,
+      });
     }
-  }, [hasCheckedHash, navigate]);
+  }, [availableViews, hasCheckedHash, isOrgContext, navigate]);
+
+  useEffect(() => {
+    if (!search.view || search.view === activeView) return;
+    void navigate({ search: { view: activeView }, replace: true });
+  }, [activeView, navigate, search.view]);
 
   const navigateToView = (view: SettingsView) => {
     void navigate({ search: { view } });

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -331,11 +331,12 @@ export function Settings() {
         },
       ];
   const availableSettingsViews = settingsNavigationItems.map((item) => item.view);
+  const publisherMembershipsLoaded = publisherMemberships !== undefined;
   const { activeView, navigateToView } = useActiveSettingsView(
     availableSettingsViews,
     isOrgSettings,
+    publisherMembershipsLoaded && !isActivePublisherLoading,
   );
-  const publisherMembershipsLoaded = publisherMemberships !== undefined;
   const effectiveActiveView = activeView;
   const hasProfileChanges =
     isOrgSettings && settingsPublisher
@@ -2309,13 +2310,20 @@ function normalizeSettingsView(
   return availableViews.includes(view) ? view : fallback;
 }
 
-function useActiveSettingsView(availableViews: SettingsView[], isOrgContext: boolean) {
+function useActiveSettingsView(
+  availableViews: SettingsView[],
+  isOrgContext: boolean,
+  canNormalizeView: boolean,
+) {
   const navigate = useNavigate({ from: "/settings" });
   const search = useSearch({ from: "/settings" });
   const [migratedHashView, setMigratedHashView] = useState<SettingsSearchView | null>(null);
   const [hasCheckedHash, setHasCheckedHash] = useState(false);
   const requestedView = isSettingsSearchView(search.view) ? search.view : migratedHashView;
-  const activeView = normalizeSettingsView(requestedView, availableViews, isOrgContext);
+  const activeView =
+    canNormalizeView || requestedView === "account" || !isSettingsSearchView(requestedView)
+      ? normalizeSettingsView(requestedView, availableViews, isOrgContext)
+      : requestedView;
 
   useEffect(() => {
     if (hasCheckedHash) return;
@@ -2323,17 +2331,19 @@ function useActiveSettingsView(availableViews: SettingsView[], isOrgContext: boo
     const hash = window.location.hash.replace("#", "");
     if (isSettingsSearchView(hash)) {
       setMigratedHashView(hash);
+      if (!canNormalizeView) return;
       void navigate({
         search: { view: normalizeSettingsView(hash, availableViews, isOrgContext) },
         replace: true,
       });
     }
-  }, [availableViews, hasCheckedHash, isOrgContext, navigate]);
+  }, [availableViews, canNormalizeView, hasCheckedHash, isOrgContext, navigate]);
 
   useEffect(() => {
+    if (!canNormalizeView) return;
     if (!search.view || search.view === activeView) return;
     void navigate({ search: { view: activeView }, replace: true });
-  }, [activeView, navigate, search.view]);
+  }, [activeView, canNormalizeView, navigate, search.view]);
 
   const navigateToView = (view: SettingsView) => {
     void navigate({ search: { view } });

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -885,7 +885,7 @@ export function Settings() {
                   <div className="grid gap-3 md:grid-cols-2">
                     {orgs.map((entry) => {
                       const skillCount = entry.publisher.stats?.skills ?? 0;
-                      const packageCount = entry.publisher.stats?.packages ?? 0;
+                      const pluginCount = entry.publisher.stats?.packages ?? 0;
                       const roleLabel =
                         entry.role.charAt(0).toUpperCase() + entry.role.slice(1);
 
@@ -938,7 +938,7 @@ export function Settings() {
                               <span className="inline-flex items-center gap-1.5">
                                 <Package size={14} aria-hidden="true" />
                                 <span>
-                                  {packageCount} {packageCount === 1 ? "package" : "packages"}
+                                  {pluginCount} {pluginCount === 1 ? "plugin" : "plugins"}
                                 </span>
                               </span>
                             </div>

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -881,7 +881,7 @@ export function Settings() {
                 </div>
 
                 {orgs.length ? (
-                  <div className="grid gap-3">
+                  <div className="grid gap-3 md:grid-cols-2">
                     {orgs.map((entry) => (
                       <SettingsBlock key={entry.publisher._id} className="gap-3">
                         <div className="flex min-w-0 flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -888,6 +888,7 @@ export function Settings() {
                       const pluginCount = entry.publisher.stats?.packages ?? 0;
                       const roleLabel =
                         entry.role.charAt(0).toUpperCase() + entry.role.slice(1);
+                      const canManageOrg = entry.role === "owner" || entry.role === "admin";
 
                       return (
                         <SettingsBlock
@@ -940,18 +941,32 @@ export function Settings() {
                                 </span>
                               </span>
                             </div>
-                            <Button
-                              type="button"
-                              variant="outline"
-                              className="shrink-0 sm:w-auto"
-                              onClick={() => {
-                                setActivePublisherId(entry.publisher._id);
-                                navigateToView("profile");
-                              }}
-                            >
-                              Manage
-                              <ArrowRight size={14} aria-hidden="true" />
-                            </Button>
+                            <div className="flex shrink-0 flex-wrap items-center gap-2">
+                              <Button asChild variant="ghost" className="sm:w-auto">
+                                <Link
+                                  to="/user/$handle"
+                                  params={{ handle: entry.publisher.handle }}
+                                >
+                                  View profile
+                                </Link>
+                              </Button>
+                              <Button
+                                type="button"
+                                variant="outline"
+                                className="sm:w-auto"
+                                onClick={() => {
+                                  setActivePublisherId(entry.publisher._id);
+                                  if (canManageOrg) {
+                                    navigateToView("profile");
+                                    return;
+                                  }
+                                  void navigate({ to: "/dashboard" });
+                                }}
+                              >
+                                {canManageOrg ? "Manage" : "Switch"}
+                                <ArrowRight size={14} aria-hidden="true" />
+                              </Button>
+                            </div>
                           </div>
                         </SettingsBlock>
                       );

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -882,7 +882,7 @@ export function Settings() {
                 </div>
 
                 {orgs.length ? (
-                  <div className="grid gap-3 md:grid-cols-2">
+                  <div className="settings-organizations-grid">
                     {orgs.map((entry) => {
                       const skillCount = entry.publisher.stats?.skills ?? 0;
                       const pluginCount = entry.publisher.stats?.packages ?? 0;

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -297,8 +297,8 @@ export function Settings() {
           ? [
               {
                 view: "danger" as const,
-                label: "Delete organization",
-                mobileLabel: "Delete",
+                label: "Danger zone",
+                mobileLabel: "Danger zone",
                 icon: ShieldAlert,
               },
             ]
@@ -326,8 +326,8 @@ export function Settings() {
         { view: "tokens", label: "API tokens", mobileLabel: "Tokens", icon: KeyRound },
         {
           view: "danger",
-          label: "Account deletion",
-          mobileLabel: "Deletion",
+          label: "Danger zone",
+          mobileLabel: "Danger zone",
           icon: ShieldAlert,
         },
       ];

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -674,7 +674,7 @@ export function Settings() {
                         disabled={isOrgSettings && !canManageSettingsPublisher}
                       />
                     </Field>
-                    {isOrgSettings ? (
+                    {isOrgSettings && canManageSettingsPublisher ? (
                       <div className="flex min-w-0 items-center gap-2">
                         <div className="min-w-0 flex-1">
                           <Field label="Avatar URL" htmlFor="settings-publisher-image">
@@ -687,7 +687,7 @@ export function Settings() {
                             />
                           </Field>
                         </div>
-                        {publisherImage && canManageSettingsPublisher ? (
+                        {publisherImage ? (
                           <Button
                             type="button"
                             variant="ghost"
@@ -717,21 +717,19 @@ export function Settings() {
                         members.
                       </div>
                     ) : null}
-                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
-                      {hasProfileChanges ? (
-                        <span className="text-sm font-semibold text-red-700 dark:text-red-300">
-                          You have unsaved changes.
-                        </span>
-                      ) : null}
-                      <Button
-                        variant="primary"
-                        type="submit"
-                        disabled={isOrgSettings && !canManageSettingsPublisher}
-                      >
-                        <Save size={16} />
-                        Save profile
-                      </Button>
-                    </div>
+                    {!isOrgSettings || canManageSettingsPublisher ? (
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
+                        {hasProfileChanges ? (
+                          <span className="text-sm font-semibold text-red-700 dark:text-red-300">
+                            You have unsaved changes.
+                          </span>
+                        ) : null}
+                        <Button variant="primary" type="submit">
+                          <Save size={16} />
+                          Save profile
+                        </Button>
+                      </div>
+                    ) : null}
                   </form>
                 </SettingsBlock>
               </div>

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -2,6 +2,7 @@ import { useAuthActions } from "@convex-dev/auth/react";
 import { Link, createFileRoute, useNavigate, useSearch } from "@tanstack/react-router";
 import { useAction, useMutation, useQuery } from "convex/react";
 import {
+  ArrowRight,
   Building2,
   CircleX,
   Code,
@@ -891,7 +892,7 @@ export function Settings() {
                       return (
                         <SettingsBlock
                           key={entry.publisher._id}
-                          className="min-h-[220px] justify-between gap-6 md:only:col-span-full"
+                          className="gap-5 md:only:col-span-full"
                         >
                           <div className="flex min-w-0 items-start justify-between gap-5">
                             <div className="flex min-w-0 items-start gap-4">
@@ -917,6 +918,30 @@ export function Settings() {
                                 </p>
                               </div>
                             </div>
+                            <Badge
+                              variant="compact"
+                              aria-label={`Your role: ${roleLabel}`}
+                              className="shrink-0"
+                            >
+                              {roleLabel}
+                            </Badge>
+                          </div>
+
+                          <div className="flex flex-col gap-4 border-t border-[color:var(--line)] pt-4 sm:flex-row sm:items-center sm:justify-between">
+                            <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-[color:var(--ink-soft)]">
+                              <span className="inline-flex items-center gap-1.5">
+                                <Code size={14} aria-hidden="true" />
+                                <span>
+                                  {skillCount} {skillCount === 1 ? "skill" : "skills"}
+                                </span>
+                              </span>
+                              <span className="inline-flex items-center gap-1.5">
+                                <Package size={14} aria-hidden="true" />
+                                <span>
+                                  {packageCount} {packageCount === 1 ? "package" : "packages"}
+                                </span>
+                              </span>
+                            </div>
                             <Button
                               type="button"
                               variant="outline"
@@ -927,37 +952,8 @@ export function Settings() {
                               }}
                             >
                               Manage
+                              <ArrowRight size={14} aria-hidden="true" />
                             </Button>
-                          </div>
-
-                          <div className="grid gap-5 border-t border-[color:var(--line)] pt-4 sm:grid-cols-[minmax(120px,0.35fr)_1fr]">
-                            <div className="min-w-0">
-                              <p className="text-[11px] font-semibold uppercase tracking-wide text-[color:var(--ink-soft)]">
-                                Your role
-                              </p>
-                              <p className="mt-1 text-sm font-semibold text-[color:var(--ink)]">
-                                {roleLabel}
-                              </p>
-                            </div>
-                            <div className="min-w-0">
-                              <p className="text-[11px] font-semibold uppercase tracking-wide text-[color:var(--ink-soft)]">
-                                Published
-                              </p>
-                              <div className="mt-1 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-[color:var(--ink-soft)]">
-                                <span className="inline-flex items-center gap-1.5">
-                                  <Code size={14} aria-hidden="true" />
-                                  <span>
-                                    {skillCount} {skillCount === 1 ? "skill" : "skills"}
-                                  </span>
-                                </span>
-                                <span className="inline-flex items-center gap-1.5">
-                                  <Package size={14} aria-hidden="true" />
-                                  <span>
-                                    {packageCount} {packageCount === 1 ? "package" : "packages"}
-                                  </span>
-                                </span>
-                              </div>
-                            </div>
                           </div>
                         </SettingsBlock>
                       );

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -257,14 +257,12 @@ export function Settings() {
     activePublisherMembership ?? personalPublisher ?? memberships[0] ?? null;
   const isOrgSettings = settingsPublisher?.publisher.kind === "org";
   const settingsPublisherRole = settingsPublisher?.role ?? "owner";
-  const canManageSettingsPublisher = Boolean(
-    settingsPublisher &&
-    (!isOrgSettings || settingsPublisherRole === "owner" || settingsPublisherRole === "admin"),
-  );
-  const canDeleteSettingsPublisher = Boolean(isOrgSettings && settingsPublisherRole === "owner");
-  const canConfigureActiveGitHubSources = Boolean(
-    settingsPublisher?.publisher.official === true && canManageSettingsPublisher,
-  );
+  const canManageSettingsPublisher =
+    settingsPublisher != null &&
+    (!isOrgSettings || settingsPublisherRole === "owner" || settingsPublisherRole === "admin");
+  const canDeleteSettingsPublisher = isOrgSettings && settingsPublisherRole === "owner";
+  const canConfigureActiveGitHubSources =
+    settingsPublisher?.publisher.official === true && canManageSettingsPublisher;
   const settingsNavigationItems: SettingsNavigationItem[] = isOrgSettings
     ? [
         {
@@ -334,7 +332,7 @@ export function Settings() {
   const availableSettingsViews = settingsNavigationItems.map((item) => item.view);
   const { activeView, navigateToView } = useActiveSettingsView(
     availableSettingsViews,
-    Boolean(isOrgSettings),
+    isOrgSettings,
   );
   const publisherMembershipsLoaded = publisherMemberships !== undefined;
   const effectiveActiveView = activeView;
@@ -886,8 +884,7 @@ export function Settings() {
                     {orgs.map((entry) => {
                       const skillCount = entry.publisher.stats?.skills ?? 0;
                       const pluginCount = entry.publisher.stats?.packages ?? 0;
-                      const roleLabel =
-                        entry.role.charAt(0).toUpperCase() + entry.role.slice(1);
+                      const roleLabel = entry.role.charAt(0).toUpperCase() + entry.role.slice(1);
                       const canManageOrg = entry.role === "owner" || entry.role === "admin";
 
                       return (

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -882,39 +882,86 @@ export function Settings() {
 
                 {orgs.length ? (
                   <div className="grid gap-3 md:grid-cols-2">
-                    {orgs.map((entry) => (
-                      <SettingsBlock key={entry.publisher._id} className="gap-3">
-                        <div className="flex min-w-0 flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-                          <div className="flex min-w-0 items-center gap-3">
-                            <OrgLogoSmall
-                              image={entry.publisher.image}
-                              name={entry.publisher.displayName}
-                              handle={entry.publisher.handle}
-                              className="h-10 w-10"
-                            />
+                    {orgs.map((entry) => {
+                      const skillCount = entry.publisher.stats?.skills ?? 0;
+                      const packageCount = entry.publisher.stats?.packages ?? 0;
+                      const roleLabel =
+                        entry.role.charAt(0).toUpperCase() + entry.role.slice(1);
+
+                      return (
+                        <SettingsBlock
+                          key={entry.publisher._id}
+                          className="min-h-[220px] justify-between gap-6 md:only:col-span-full"
+                        >
+                          <div className="flex min-w-0 items-start justify-between gap-5">
+                            <div className="flex min-w-0 items-start gap-4">
+                              <OrgLogoSmall
+                                image={entry.publisher.image}
+                                name={entry.publisher.displayName}
+                                handle={entry.publisher.handle}
+                                className="h-12 w-12"
+                              />
+                              <div className="min-w-0">
+                                <div className="flex min-w-0 flex-wrap items-center gap-2">
+                                  <h3 className="truncate text-base font-bold text-[color:var(--ink)]">
+                                    {entry.publisher.displayName || entry.publisher.handle}
+                                  </h3>
+                                  {entry.publisher.official ? (
+                                    <Badge variant="official" size="sm">
+                                      Official
+                                    </Badge>
+                                  ) : null}
+                                </div>
+                                <p className="mt-1 truncate text-sm text-[color:var(--ink-soft)]">
+                                  @{entry.publisher.handle}
+                                </p>
+                              </div>
+                            </div>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              className="shrink-0 sm:w-auto"
+                              onClick={() => {
+                                setActivePublisherId(entry.publisher._id);
+                                navigateToView("profile");
+                              }}
+                            >
+                              Manage
+                            </Button>
+                          </div>
+
+                          <div className="grid gap-5 border-t border-[color:var(--line)] pt-4 sm:grid-cols-[minmax(120px,0.35fr)_1fr]">
                             <div className="min-w-0">
-                              <h3 className="truncate text-sm font-bold text-[color:var(--ink)]">
-                                {entry.publisher.displayName || entry.publisher.handle}
-                              </h3>
-                              <p className="truncate text-sm text-[color:var(--ink-soft)]">
-                                @{entry.publisher.handle} · {entry.role}
+                              <p className="text-[11px] font-semibold uppercase tracking-wide text-[color:var(--ink-soft)]">
+                                Your role
+                              </p>
+                              <p className="mt-1 text-sm font-semibold text-[color:var(--ink)]">
+                                {roleLabel}
                               </p>
                             </div>
+                            <div className="min-w-0">
+                              <p className="text-[11px] font-semibold uppercase tracking-wide text-[color:var(--ink-soft)]">
+                                Published
+                              </p>
+                              <div className="mt-1 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-[color:var(--ink-soft)]">
+                                <span className="inline-flex items-center gap-1.5">
+                                  <Code size={14} aria-hidden="true" />
+                                  <span>
+                                    {skillCount} {skillCount === 1 ? "skill" : "skills"}
+                                  </span>
+                                </span>
+                                <span className="inline-flex items-center gap-1.5">
+                                  <Package size={14} aria-hidden="true" />
+                                  <span>
+                                    {packageCount} {packageCount === 1 ? "package" : "packages"}
+                                  </span>
+                                </span>
+                              </div>
+                            </div>
                           </div>
-                          <Button
-                            type="button"
-                            variant="outline"
-                            className="sm:w-auto"
-                            onClick={() => {
-                              setActivePublisherId(entry.publisher._id);
-                              navigateToView("profile");
-                            }}
-                          >
-                            Manage
-                          </Button>
-                        </div>
-                      </SettingsBlock>
-                    ))}
+                        </SettingsBlock>
+                      );
+                    })}
                   </div>
                 ) : (
                   <SettingsBlock>

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -894,37 +894,34 @@ export function Settings() {
                           key={entry.publisher._id}
                           className="gap-5 md:only:col-span-full"
                         >
-                          <div className="flex min-w-0 items-start justify-between gap-5">
-                            <div className="flex min-w-0 items-start gap-4">
-                              <OrgLogoSmall
-                                image={entry.publisher.image}
-                                name={entry.publisher.displayName}
-                                handle={entry.publisher.handle}
-                                className="h-12 w-12"
-                              />
-                              <div className="min-w-0">
-                                <div className="flex min-w-0 flex-wrap items-center gap-2">
-                                  <h3 className="truncate text-base font-bold text-[color:var(--ink)]">
-                                    {entry.publisher.displayName || entry.publisher.handle}
-                                  </h3>
-                                  {entry.publisher.official ? (
-                                    <Badge variant="official" size="sm">
-                                      Official
-                                    </Badge>
-                                  ) : null}
-                                </div>
-                                <p className="mt-1 truncate text-sm text-[color:var(--ink-soft)]">
-                                  @{entry.publisher.handle}
-                                </p>
+                          <div className="flex min-w-0 items-start gap-4">
+                            <OrgLogoSmall
+                              image={entry.publisher.image}
+                              name={entry.publisher.displayName}
+                              handle={entry.publisher.handle}
+                              className="h-12 w-12"
+                            />
+                            <div className="min-w-0">
+                              <div className="flex min-w-0 flex-wrap items-center gap-2">
+                                <h3 className="truncate text-base font-bold text-[color:var(--ink)]">
+                                  {entry.publisher.displayName || entry.publisher.handle}
+                                </h3>
+                                {entry.publisher.official ? (
+                                  <Badge variant="official" size="sm">
+                                    Official
+                                  </Badge>
+                                ) : null}
                               </div>
+                              <p className="mt-1 truncate text-sm text-[color:var(--ink-soft)]">
+                                @{entry.publisher.handle}
+                              </p>
+                              <dl className="mt-2 flex items-center gap-2 text-xs">
+                                <dt className="text-[color:var(--ink-soft)]">Role</dt>
+                                <dd className="font-semibold text-[color:var(--ink)]">
+                                  {roleLabel}
+                                </dd>
+                              </dl>
                             </div>
-                            <Badge
-                              variant="compact"
-                              aria-label={`Your role: ${roleLabel}`}
-                              className="shrink-0"
-                            >
-                              {roleLabel}
-                            </Badge>
                           </div>
 
                           <div className="flex flex-col gap-4 border-t border-[color:var(--line)] pt-4 sm:flex-row sm:items-center sm:justify-between">

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -29,6 +29,7 @@ import {
 } from "../../components/CatalogMetadataFields";
 import { EmptyState } from "../../components/EmptyState";
 import { Container } from "../../components/layout/Container";
+import { MarketplaceIcon } from "../../components/MarketplaceIcon";
 import { PublisherOwnerDisplay, PublisherOwnerSelect } from "../../components/PublisherOwnerSelect";
 import { PublishFormSkeleton } from "../../components/PublishFormSkeleton";
 import { SignInButton } from "../../components/SignInButton";
@@ -36,6 +37,12 @@ import { SkillIconPicker } from "../../components/SkillIconPicker";
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
 import { Card, CardContent, CardTitle } from "../../components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "../../components/ui/dropdown-menu";
 import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
 import { Textarea } from "../../components/ui/textarea";
@@ -93,6 +100,7 @@ export function Upload() {
     activeOwnerHandle,
     memberships: publisherMemberships,
     isLoading: isActivePublisherLoading,
+    setActivePublisherId,
   } = useActivePublisher();
   const showChangelogField = Boolean(updateSlug);
 
@@ -877,6 +885,75 @@ export function Upload() {
                 </span>
                 <PublisherOwnerDisplay value={ownerHandle} memberships={publisherMemberships} />
                 <InlineValidationMessage id="owner-validation-error" message={ownerIssue} />
+                {(publisherMemberships?.length ?? 0) > 1 ? (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="xs"
+                        className="ml-auto"
+                        aria-label="Change publisher"
+                      >
+                        Change
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent
+                      align="end"
+                      className="user-dropdown-subcontent user-dropdown-switcher-subcontent"
+                    >
+                      <div className="user-dropdown-section-label">Switch publisher</div>
+                      <div className="user-dropdown-publisher-list" aria-label="Switch publisher">
+                        {publisherMemberships?.map((entry) => {
+                          const publisherIdentity = (
+                            <>
+                              <span className="user-dropdown-publisher-icon" aria-hidden="true">
+                                <MarketplaceIcon
+                                  kind={entry.publisher.kind}
+                                  label={entry.publisher.displayName || entry.publisher.handle}
+                                  imageUrl={entry.publisher.image}
+                                  size="xs"
+                                />
+                              </span>
+                              <span className="user-dropdown-publisher-copy">
+                                <span className="user-dropdown-publisher-title">
+                                  @{entry.publisher.handle}
+                                </span>
+                                <span className="user-dropdown-publisher-meta">
+                                  {entry.publisher.kind === "org" ? "Organization" : "Personal"}
+                                </span>
+                              </span>
+                            </>
+                          );
+
+                          return entry.publisher.handle === ownerHandle ? (
+                            <div
+                              key={entry.publisher._id}
+                              aria-label={`Selected publisher @${entry.publisher.handle}`}
+                              className="user-dropdown-publisher-item user-dropdown-publisher-item-current"
+                            >
+                              {publisherIdentity}
+                              <Check
+                                className="user-dropdown-publisher-check"
+                                size={16}
+                                aria-label="Selected publisher"
+                              />
+                            </div>
+                          ) : (
+                            <DropdownMenuItem
+                              key={entry.publisher._id}
+                              aria-label={`Switch to @${entry.publisher.handle}`}
+                              className="user-dropdown-publisher-item"
+                              onSelect={() => setActivePublisherId(entry.publisher._id)}
+                            >
+                              {publisherIdentity}
+                            </DropdownMenuItem>
+                          );
+                        })}
+                      </div>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                ) : null}
               </div>
             ) : null}
 

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -886,7 +886,9 @@ export function Upload() {
                 memberships={publisherMemberships}
                 onSwitchPublisher={setActivePublisherId}
                 validation={
-                  <InlineValidationMessage id="owner-validation-error" message={ownerIssue} />
+                  ownerIssue ? (
+                    <InlineValidationMessage id="owner-validation-error" message={ownerIssue} />
+                  ) : undefined
                 }
               />
             ) : null}

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -422,6 +422,16 @@ export function Upload() {
   ]);
 
   useEffect(() => {
+    if (updateSlug || !ownerHandle || searchOwnerHandle === ownerHandle) return;
+
+    void navigate({
+      to: "/skills/publish",
+      search: { ownerHandle },
+      replace: true,
+    });
+  }, [navigate, ownerHandle, searchOwnerHandle, updateSlug]);
+
+  useEffect(() => {
     if (!showChangelogField) return;
     if (changelogTouchedRef.current) return;
     if (trimmedChangelog) return;

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -29,10 +29,7 @@ import {
 } from "../../components/CatalogMetadataFields";
 import { EmptyState } from "../../components/EmptyState";
 import { Container } from "../../components/layout/Container";
-import {
-  PublisherOwnerSelect,
-  type PublisherOwnerMembership,
-} from "../../components/PublisherOwnerSelect";
+import { PublisherOwnerDisplay, PublisherOwnerSelect } from "../../components/PublisherOwnerSelect";
 import { PublishFormSkeleton } from "../../components/PublishFormSkeleton";
 import { SignInButton } from "../../components/SignInButton";
 import { SkillIconPicker } from "../../components/SkillIconPicker";
@@ -44,6 +41,7 @@ import { Label } from "../../components/ui/label";
 import { Textarea } from "../../components/ui/textarea";
 import { UploadDropzoneDecor } from "../../components/UploadDropzoneDecor";
 import { VersionInput } from "../../components/VersionInput";
+import { useActivePublisher } from "../../lib/activePublisher";
 import { setPostPublishFlash } from "../../lib/postPublishFlash";
 import { extractSkillFrontmatterDescription } from "../../lib/skillFrontmatter";
 import { ALLOWED_LUCIDE_ICONS, makeLucideIconValue, parseSkillIcon } from "../../lib/skillIcon";
@@ -91,6 +89,11 @@ export const Route = createFileRoute("/skills/publish")({
 export function Upload() {
   const { isAuthenticated, isLoading: isAuthLoading, me } = useAuthStatus();
   const { updateSlug, ownerHandle: searchOwnerHandle } = useSearch({ from: "/skills/publish" });
+  const {
+    activeOwnerHandle,
+    memberships: publisherMemberships,
+    isLoading: isActivePublisherLoading,
+  } = useActivePublisher();
   const showChangelogField = Boolean(updateSlug);
 
   const generateUploadUrl = useMutation(api.uploads.generateUploadUrl);
@@ -163,9 +166,6 @@ export function Upload() {
   const [status, setStatus] = useState<string | null>(null);
   const isSubmitting = status !== null;
   const [error, setError] = useState<string | null>(null);
-  const publisherMemberships = useQuery(api.publishers.listMine, me ? {} : "skip") as
-    | PublisherOwnerMembership[]
-    | undefined;
   const [ownerHandle, setOwnerHandle] = useState(searchOwnerHandle ?? "");
   const ownerTouchedRef = useRef(false);
   // Owner migration opt-in: when updating an existing skill under a different
@@ -362,6 +362,8 @@ export function Upload() {
     if (memberships.length === 0) {
       if (!ownerHandle && existingOwnerHandle) {
         setOwnerHandle(existingOwnerHandle);
+      } else if (!ownerHandle && !updateSlug && !searchOwnerHandle && activeOwnerHandle) {
+        setOwnerHandle(activeOwnerHandle);
       }
       return;
     }
@@ -372,17 +374,28 @@ export function Upload() {
     const existingOwner = existingOwnerHandle
       ? memberships.find((entry) => entry.publisher.handle === existingOwnerHandle)
       : undefined;
+    const activeOwner = activeOwnerHandle
+      ? memberships.find((entry) => entry.publisher.handle === activeOwnerHandle)
+      : undefined;
     const shouldPreferExistingOwner = Boolean(
       !ownerTouchedRef.current &&
       updateSlug &&
       existingOwner &&
       ownerHandle !== existingOwner.publisher.handle,
     );
-    if (currentOwnerExists && !shouldPreferExistingOwner) return;
+    const shouldPreferActiveOwner = Boolean(
+      !ownerTouchedRef.current &&
+      !updateSlug &&
+      !searchOwnerHandle &&
+      activeOwner &&
+      ownerHandle !== activeOwner.publisher.handle,
+    );
+    if (currentOwnerExists && !shouldPreferExistingOwner && !shouldPreferActiveOwner) return;
 
     const personalPublisher = memberships.find((entry) => entry.publisher.kind === "user");
     const nextOwnerHandle =
       existingOwner?.publisher.handle ??
+      activeOwner?.publisher.handle ??
       personalPublisher?.publisher.handle ??
       memberships[0]?.publisher.handle;
     if (!nextOwnerHandle || nextOwnerHandle === ownerHandle) return;
@@ -392,7 +405,14 @@ export function Upload() {
     // a stale handle while the DOM displays the replacement option.
     setOwnerHandle(nextOwnerHandle);
     setConfirmMigrateOwner(false);
-  }, [ownerHandle, publisherMemberships, existing?.owner?.handle, updateSlug]);
+  }, [
+    activeOwnerHandle,
+    ownerHandle,
+    publisherMemberships,
+    existing?.owner?.handle,
+    searchOwnerHandle,
+    updateSlug,
+  ]);
 
   useEffect(() => {
     if (!showChangelogField) return;
@@ -590,7 +610,7 @@ export function Upload() {
   // webkitdirectory/directory attributes are set via the ref callback (setFileInputRef)
   // to ensure they persist across hydration and re-renders (#58)
 
-  if (isAuthLoading) {
+  if (isAuthLoading || isActivePublisherLoading) {
     return <PublishFormSkeleton />;
   }
 
@@ -1163,21 +1183,35 @@ export function Upload() {
               </div>
 
               <div className="flex flex-col gap-2">
-                <Label htmlFor="ownerHandle">Owner</Label>
-                <PublisherOwnerSelect
-                  id="ownerHandle"
-                  value={ownerHandle}
-                  memberships={publisherMemberships}
-                  onValueChange={(nextOwnerHandle) => {
-                    ownerTouchedRef.current = true;
-                    setOwnerHandle(nextOwnerHandle);
-                    // Reset the migration confirmation any time the Owner
-                    // selector changes; the user must re-acknowledge the move
-                    // after picking a different target to avoid a stale tick
-                    // turning into a silent transfer.
-                    setConfirmMigrateOwner(false);
-                  }}
-                />
+                {updateSlug ? (
+                  <>
+                    <Label htmlFor="ownerHandle">Owner</Label>
+                    <PublisherOwnerSelect
+                      id="ownerHandle"
+                      value={ownerHandle}
+                      memberships={publisherMemberships}
+                      onValueChange={(nextOwnerHandle) => {
+                        ownerTouchedRef.current = true;
+                        setOwnerHandle(nextOwnerHandle);
+                        // Reset the migration confirmation any time the Owner
+                        // selector changes; the user must re-acknowledge the move
+                        // after picking a different target to avoid a stale tick
+                        // turning into a silent transfer.
+                        setConfirmMigrateOwner(false);
+                      }}
+                    />
+                  </>
+                ) : (
+                  <>
+                    <Label>Publishing as</Label>
+                    <div className="flex min-h-[44px] w-full items-center rounded-[var(--radius-sm)] border border-input-border bg-input-bg px-3.5 py-space-3 text-sm text-[color:var(--ink)]">
+                      <PublisherOwnerDisplay
+                        value={ownerHandle}
+                        memberships={publisherMemberships}
+                      />
+                    </div>
+                  </>
+                )}
                 {isOwnerMigration ? (
                   <label className="flex items-start gap-2 text-sm cursor-pointer mt-2">
                     <input

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -865,7 +865,7 @@ export function Upload() {
             }}
           />
 
-          <Card className="gap-0 overflow-hidden p-0">
+          <Card className="gap-0 overflow-hidden !p-0">
             {!updateSlug ? (
               <div
                 role="group"

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -973,7 +973,7 @@ export function Upload() {
               </div>
             ) : null}
 
-            <CardContent className="relative z-[1] -mt-1 rounded-t-[var(--radius-md)] border-t border-[color:var(--line)] bg-[color:var(--surface)] p-space-5">
+            <CardContent className="border-t border-[color:var(--line)] p-space-5">
               {files.length > 0 ? (
                 <div
               className={`overflow-hidden rounded-[var(--radius-md)] border transition-colors ${

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -878,12 +878,14 @@ export function Upload() {
               <div
                 role="group"
                 aria-label="Publishing as"
-                className="flex min-h-[52px] flex-wrap items-center gap-x-4 gap-y-2 bg-[color:var(--surface-muted)] px-space-5 py-space-3 text-sm text-[color:var(--ink)]"
+                className="flex min-h-[52px] flex-wrap items-center gap-x-2 gap-y-2 bg-[color:var(--surface-muted)] px-space-5 py-space-3 text-sm text-[color:var(--ink)]"
               >
                 <span className="text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--ink-soft)]">
                   Publishing as
                 </span>
-                <PublisherOwnerDisplay value={ownerHandle} memberships={publisherMemberships} />
+                <span className="publishing-context-owner">
+                  <PublisherOwnerDisplay value={ownerHandle} memberships={publisherMemberships} />
+                </span>
                 <InlineValidationMessage id="owner-validation-error" message={ownerIssue} />
                 {(publisherMemberships?.length ?? 0) > 1 ? (
                   <DropdownMenu>

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -890,7 +890,7 @@ export function Upload() {
                 aria-label="Publishing as"
                 className="flex min-h-[52px] flex-wrap items-center gap-x-2 gap-y-2 bg-[color:var(--surface-muted)] px-space-5 py-space-3 text-sm text-[color:var(--ink)]"
               >
-                <span className="text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--ink-soft)]">
+                <span className="text-xs font-medium text-[color:var(--ink-soft)]">
                   Publishing as
                 </span>
                 <span className="publishing-context-owner">

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -894,7 +894,11 @@ export function Upload() {
                   Publishing as
                 </span>
                 <span className="publishing-context-owner">
-                  <PublisherOwnerDisplay value={ownerHandle} memberships={publisherMemberships} />
+                  <PublisherOwnerDisplay
+                    value={ownerHandle}
+                    memberships={publisherMemberships}
+                    compact
+                  />
                 </span>
                 <InlineValidationMessage id="owner-validation-error" message={ownerIssue} />
                 {(publisherMemberships?.length ?? 0) > 1 ? (

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -851,20 +851,6 @@ export function Upload() {
         </header>
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          {!updateSlug ? (
-            <div className="flex flex-col gap-2">
-              <Label>Publishing as</Label>
-              <div
-                role="group"
-                aria-label="Publishing as"
-                className="flex min-h-[44px] w-full items-center rounded-[var(--radius-sm)] border border-input-border bg-input-bg px-3.5 py-space-3 text-sm text-[color:var(--ink)]"
-              >
-                <PublisherOwnerDisplay value={ownerHandle} memberships={publisherMemberships} />
-              </div>
-              <InlineValidationMessage id="owner-validation-error" message={ownerIssue} />
-            </div>
-          ) : null}
-
           {/* File upload panel */}
           <input
             ref={setFileInputRef}
@@ -879,8 +865,24 @@ export function Upload() {
             }}
           />
 
-          {files.length > 0 ? (
-            <div
+          <Card className="gap-0 overflow-hidden p-0">
+            {!updateSlug ? (
+              <div
+                role="group"
+                aria-label="Publishing as"
+                className="flex min-h-[52px] flex-wrap items-center gap-x-4 gap-y-2 bg-[color:var(--surface-muted)] px-space-5 py-space-3 text-sm text-[color:var(--ink)]"
+              >
+                <span className="text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--ink-soft)]">
+                  Publishing as
+                </span>
+                <PublisherOwnerDisplay value={ownerHandle} memberships={publisherMemberships} />
+                <InlineValidationMessage id="owner-validation-error" message={ownerIssue} />
+              </div>
+            ) : null}
+
+            <CardContent className="border-t border-[color:var(--line)] p-space-5">
+              {files.length > 0 ? (
+                <div
               className={`overflow-hidden rounded-[var(--radius-md)] border transition-colors ${
                 isDragging
                   ? "border-[color:var(--accent)] bg-[color:var(--accent)]/5"
@@ -1042,10 +1044,8 @@ export function Upload() {
                   </div>
                 ) : null}
               </div>
-            </div>
-          ) : (
-            <Card>
-              <CardContent>
+                </div>
+              ) : (
                 <div
                   className={`relative flex flex-col items-center gap-3 overflow-hidden rounded-[var(--radius-md)] border-2 border-dashed p-8 transition-colors ${
                     isDragging
@@ -1078,9 +1078,9 @@ export function Upload() {
                     </Button>
                   </div>
                 </div>
-              </CardContent>
-            </Card>
-          )}
+              )}
+            </CardContent>
+          </Card>
 
           {/* Metadata panel */}
           <Card>

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -386,7 +386,6 @@ export function Upload() {
     const shouldPreferActiveOwner = Boolean(
       !ownerTouchedRef.current &&
       !updateSlug &&
-      !searchOwnerHandle &&
       activeOwner &&
       ownerHandle !== activeOwner.publisher.handle,
     );

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -169,6 +169,8 @@ export function Upload() {
   const [error, setError] = useState<string | null>(null);
   const [ownerHandle, setOwnerHandle] = useState(searchOwnerHandle ?? "");
   const ownerTouchedRef = useRef(false);
+  const observedActiveOwnerHandleRef = useRef<string | undefined>(undefined);
+  const autoSelectedOwnerHandleRef = useRef<string | undefined>(undefined);
   // Owner migration opt-in: when updating an existing skill under a different
   // publisher than its current owner, the backend requires an explicit
   // `migrateOwner: true` signal. We only send it when the user ticks this box,
@@ -301,6 +303,36 @@ export function Upload() {
   );
 
   useEffect(() => {
+    if (updateSlug || !searchOwnerHandle || searchOwnerHandle === ownerHandle) return;
+
+    autoSelectedOwnerHandleRef.current = undefined;
+    setOwnerHandle(searchOwnerHandle);
+    setConfirmMigrateOwner(false);
+  }, [ownerHandle, searchOwnerHandle, updateSlug]);
+
+  useEffect(() => {
+    const searchOwnerWasAutoSelected =
+      searchOwnerHandle && searchOwnerHandle === autoSelectedOwnerHandleRef.current;
+    if (updateSlug || (searchOwnerHandle && !searchOwnerWasAutoSelected) || !activeOwnerHandle)
+      return;
+    if (observedActiveOwnerHandleRef.current === undefined) {
+      observedActiveOwnerHandleRef.current = activeOwnerHandle;
+      return;
+    }
+    if (observedActiveOwnerHandleRef.current === activeOwnerHandle) return;
+
+    observedActiveOwnerHandleRef.current = activeOwnerHandle;
+    autoSelectedOwnerHandleRef.current = activeOwnerHandle;
+    setOwnerHandle(activeOwnerHandle);
+    setConfirmMigrateOwner(false);
+    void navigate({
+      to: "/skills/publish",
+      search: { ownerHandle: activeOwnerHandle, updateSlug: undefined },
+      replace: true,
+    });
+  }, [activeOwnerHandle, navigate, searchOwnerHandle, updateSlug]);
+
+  useEffect(() => {
     let cancelled = false;
     const requiredIndex = normalizedPaths.findIndex((path) => isRequiredSkillFile(path));
     const requiredFile = requiredIndex >= 0 ? files[requiredIndex] : undefined;
@@ -388,6 +420,7 @@ export function Upload() {
       !ownerTouchedRef.current &&
       !updateSlug &&
       activeOwner &&
+      !searchOwnerHandle &&
       ownerHandle !== activeOwner.publisher.handle,
     );
     if (currentOwnerExists && !shouldPreferExistingOwner && !shouldPreferActiveOwner) return;
@@ -416,7 +449,9 @@ export function Upload() {
 
   useEffect(() => {
     if (updateSlug || !ownerHandle || searchOwnerHandle === ownerHandle) return;
+    if (searchOwnerHandle && searchOwnerHandle !== autoSelectedOwnerHandleRef.current) return;
 
+    autoSelectedOwnerHandleRef.current = ownerHandle;
     void navigate({
       to: "/skills/publish",
       search: { ownerHandle, updateSlug: undefined },
@@ -881,7 +916,19 @@ export function Upload() {
               <PublisherContextStrip
                 ownerHandle={ownerHandle}
                 memberships={publisherMemberships}
-                onSwitchPublisher={setActivePublisherId}
+                onSwitchPublisher={(publisher) => {
+                  ownerTouchedRef.current = true;
+                  observedActiveOwnerHandleRef.current = publisher.handle;
+                  autoSelectedOwnerHandleRef.current = publisher.handle;
+                  setOwnerHandle(publisher.handle);
+                  setConfirmMigrateOwner(false);
+                  setActivePublisherId(publisher._id);
+                  void navigate({
+                    to: "/skills/publish",
+                    search: { ownerHandle: publisher.handle, updateSlug: undefined },
+                    replace: true,
+                  });
+                }}
                 validation={
                   ownerIssue ? (
                     <InlineValidationMessage id="owner-validation-error" message={ownerIssue} />

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -419,7 +419,7 @@ export function Upload() {
 
     void navigate({
       to: "/skills/publish",
-      search: { ownerHandle },
+      search: { ownerHandle, updateSlug: undefined },
       replace: true,
     });
   }, [navigate, ownerHandle, searchOwnerHandle, updateSlug]);

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -1204,7 +1204,11 @@ export function Upload() {
                 ) : (
                   <>
                     <Label>Publishing as</Label>
-                    <div className="flex min-h-[44px] w-full items-center rounded-[var(--radius-sm)] border border-input-border bg-input-bg px-3.5 py-space-3 text-sm text-[color:var(--ink)]">
+                    <div
+                      role="group"
+                      aria-label="Publishing as"
+                      className="flex min-h-[44px] w-full items-center rounded-[var(--radius-sm)] border border-input-border bg-input-bg px-3.5 py-space-3 text-sm text-[color:var(--ink)]"
+                    >
                       <PublisherOwnerDisplay
                         value={ownerHandle}
                         memberships={publisherMemberships}

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -29,20 +29,16 @@ import {
 } from "../../components/CatalogMetadataFields";
 import { EmptyState } from "../../components/EmptyState";
 import { Container } from "../../components/layout/Container";
-import { MarketplaceIcon } from "../../components/MarketplaceIcon";
-import { PublisherOwnerDisplay, PublisherOwnerSelect } from "../../components/PublisherOwnerSelect";
+import {
+  PublisherContextStrip,
+  PublisherOwnerSelect,
+} from "../../components/PublisherOwnerSelect";
 import { PublishFormSkeleton } from "../../components/PublishFormSkeleton";
 import { SignInButton } from "../../components/SignInButton";
 import { SkillIconPicker } from "../../components/SkillIconPicker";
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
 import { Card, CardContent, CardTitle } from "../../components/ui/card";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "../../components/ui/dropdown-menu";
 import { Input } from "../../components/ui/input";
 import { Label } from "../../components/ui/label";
 import { Textarea } from "../../components/ui/textarea";
@@ -885,92 +881,14 @@ export function Upload() {
 
           <Card className="gap-0 overflow-hidden !p-0">
             {!updateSlug ? (
-              <div
-                role="group"
-                aria-label="Publishing as"
-                className="flex min-h-[52px] flex-wrap items-center gap-x-2 gap-y-2 bg-[color:var(--surface-muted)] px-space-5 py-space-3 text-sm text-[color:var(--ink)]"
-              >
-                <span className="text-xs font-medium text-[color:var(--ink-soft)]">
-                  Publishing as
-                </span>
-                <span className="publishing-context-owner">
-                  <PublisherOwnerDisplay
-                    value={ownerHandle}
-                    memberships={publisherMemberships}
-                    compact
-                  />
-                </span>
-                <InlineValidationMessage id="owner-validation-error" message={ownerIssue} />
-                {(publisherMemberships?.length ?? 0) > 1 ? (
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="xs"
-                        className="ml-auto focus-visible:ring-0 focus-visible:ring-offset-0"
-                        aria-label="Switch publisher"
-                      >
-                        Switch publisher
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent
-                      align="end"
-                      className="publishing-context-switcher user-dropdown-subcontent user-dropdown-switcher-subcontent"
-                    >
-                      <div className="user-dropdown-section-label">Switch publisher</div>
-                      <div className="user-dropdown-publisher-list" aria-label="Switch publisher">
-                        {publisherMemberships?.map((entry) => {
-                          const publisherIdentity = (
-                            <>
-                              <span className="user-dropdown-publisher-icon" aria-hidden="true">
-                                <MarketplaceIcon
-                                  kind={entry.publisher.kind}
-                                  label={entry.publisher.displayName || entry.publisher.handle}
-                                  imageUrl={entry.publisher.image}
-                                  size="xs"
-                                />
-                              </span>
-                              <span className="user-dropdown-publisher-copy">
-                                <span className="user-dropdown-publisher-title">
-                                  @{entry.publisher.handle}
-                                </span>
-                                <span className="user-dropdown-publisher-meta">
-                                  {entry.publisher.kind === "org" ? "Organization" : "Personal"}
-                                </span>
-                              </span>
-                            </>
-                          );
-
-                          return entry.publisher.handle === ownerHandle ? (
-                            <div
-                              key={entry.publisher._id}
-                              aria-label={`Selected publisher @${entry.publisher.handle}`}
-                              className="user-dropdown-publisher-item user-dropdown-publisher-item-current"
-                            >
-                              {publisherIdentity}
-                              <Check
-                                className="user-dropdown-publisher-check"
-                                size={16}
-                                aria-label="Selected publisher"
-                              />
-                            </div>
-                          ) : (
-                            <DropdownMenuItem
-                              key={entry.publisher._id}
-                              aria-label={`Switch to @${entry.publisher.handle}`}
-                              className="user-dropdown-publisher-item"
-                              onSelect={() => setActivePublisherId(entry.publisher._id)}
-                            >
-                              {publisherIdentity}
-                            </DropdownMenuItem>
-                          );
-                        })}
-                      </div>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                ) : null}
-              </div>
+              <PublisherContextStrip
+                ownerHandle={ownerHandle}
+                memberships={publisherMemberships}
+                onSwitchPublisher={setActivePublisherId}
+                validation={
+                  <InlineValidationMessage id="owner-validation-error" message={ownerIssue} />
+                }
+              />
             ) : null}
 
             <CardContent className="border-t border-[color:var(--line)] p-space-5">

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -29,10 +29,7 @@ import {
 } from "../../components/CatalogMetadataFields";
 import { EmptyState } from "../../components/EmptyState";
 import { Container } from "../../components/layout/Container";
-import {
-  PublisherContextStrip,
-  PublisherOwnerSelect,
-} from "../../components/PublisherOwnerSelect";
+import { PublisherContextStrip, PublisherOwnerSelect } from "../../components/PublisherOwnerSelect";
 import { PublishFormSkeleton } from "../../components/PublishFormSkeleton";
 import { SignInButton } from "../../components/SignInButton";
 import { SkillIconPicker } from "../../components/SkillIconPicker";
@@ -896,167 +893,169 @@ export function Upload() {
             <CardContent className="border-t border-[color:var(--line)] p-space-5">
               {files.length > 0 ? (
                 <div
-              className={`overflow-hidden rounded-[var(--radius-md)] border transition-colors ${
-                isDragging
-                  ? "border-[color:var(--accent)] bg-[color:var(--accent)]/5"
-                  : "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
-              }`}
-              onDragOver={(event) => {
-                event.preventDefault();
-                setIsDragging(true);
-              }}
-              onDragLeave={() => setIsDragging(false)}
-              onDrop={handleFilesDrop}
-            >
-              <div className="flex flex-col gap-4 px-4 pt-4 pb-2 md:flex-row md:items-center md:justify-between">
-                <div className="flex min-w-0 items-center gap-3">
-                  <div
-                    className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)]"
-                    aria-hidden="true"
-                  >
-                    <FolderOpen className="h-4 w-4 text-[color:var(--ink-soft)]" />
-                  </div>
-                  <div className="min-w-0">
-                    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                      <strong className="text-sm text-[color:var(--ink)]">
-                        Skill folder selected
-                      </strong>
-                      <span className="text-xs text-[color:var(--ink-soft)]">
-                        {files.length} files · {sizeLabel}
-                      </span>
+                  className={`overflow-hidden rounded-[var(--radius-md)] border transition-colors ${
+                    isDragging
+                      ? "border-[color:var(--accent)] bg-[color:var(--accent)]/5"
+                      : "border-[color:var(--line)] bg-[color:var(--surface-muted)]"
+                  }`}
+                  onDragOver={(event) => {
+                    event.preventDefault();
+                    setIsDragging(true);
+                  }}
+                  onDragLeave={() => setIsDragging(false)}
+                  onDrop={handleFilesDrop}
+                >
+                  <div className="flex flex-col gap-4 px-4 pt-4 pb-2 md:flex-row md:items-center md:justify-between">
+                    <div className="flex min-w-0 items-center gap-3">
+                      <div
+                        className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface)]"
+                        aria-hidden="true"
+                      >
+                        <FolderOpen className="h-4 w-4 text-[color:var(--ink-soft)]" />
+                      </div>
+                      <div className="min-w-0">
+                        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                          <strong className="text-sm text-[color:var(--ink)]">
+                            Skill folder selected
+                          </strong>
+                          <span className="text-xs text-[color:var(--ink-soft)]">
+                            {files.length} files · {sizeLabel}
+                          </span>
+                        </div>
+                        {unsupportedFileEntries.length > 0 ? (
+                          <div className="mt-3 flex flex-wrap gap-1.5">
+                            <Badge variant="warning" size="sm">
+                              {unsupportedFileEntries.length} unsupported
+                            </Badge>
+                          </div>
+                        ) : null}
+                      </div>
                     </div>
-                    {unsupportedFileEntries.length > 0 ? (
-                      <div className="mt-3 flex flex-wrap gap-1.5">
-                        <Badge variant="warning" size="sm">
-                          {unsupportedFileEntries.length} unsupported
-                        </Badge>
+                    <div className="flex shrink-0 flex-wrap items-center gap-4 md:justify-end">
+                      {unsupportedFileEntries.length > 0 ? (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          type="button"
+                          onClick={removeUnsupportedFiles}
+                        >
+                          Remove unsupported
+                        </Button>
+                      ) : null}
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        type="button"
+                        onClick={() => fileInputRef.current?.click()}
+                      >
+                        Replace folder
+                      </Button>
+                      <button
+                        type="button"
+                        className="cursor-pointer text-xs font-medium text-[color:var(--ink-soft)] transition-colors hover:text-[color:var(--ink)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)]/35 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--bg)]"
+                        onClick={clearSelectedFiles}
+                      >
+                        Clear files
+                      </button>
+                    </div>
+                  </div>
+                  <div className="mt-2 overflow-hidden rounded-t-[calc(var(--radius-md)+8px)] border-t border-[color:var(--line)] bg-[color:var(--surface)]">
+                    <div className="flex max-h-[300px] flex-col gap-1 overflow-y-auto p-3">
+                      {!hasRequiredFile ? (
+                        <div className="flex items-center gap-2 rounded-[var(--radius-sm)] border border-status-error-fg/35 bg-status-error-bg px-3 py-1.5 text-sm text-status-error-fg">
+                          <span className="min-w-0 flex-1 truncate font-mono">
+                            {REQUIRED_FILE_LABEL}
+                          </span>
+                          <Badge variant="destructive" size="sm">
+                            Missing
+                          </Badge>
+                        </div>
+                      ) : null}
+                      {visibleFileEntries.map(({ file, index, path }) => {
+                        const isUnsupported = !isTextFile(file);
+                        const isConfirmingRemoval = pendingFileRemovalIndex === index;
+                        return (
+                          <div
+                            key={`${index}:${path}`}
+                            className={[
+                              "flex items-center gap-2 rounded-[var(--radius-sm)] px-3 py-1.5 text-sm bg-[color:var(--surface-muted)]",
+                              isUnsupported
+                                ? "text-status-error-fg"
+                                : "text-[color:var(--ink-soft)]",
+                            ].join(" ")}
+                          >
+                            <span className="min-w-0 flex-1 truncate font-mono" title={path}>
+                              {path}
+                            </span>
+                            {isUnsupported ? (
+                              <Badge variant="warning" size="sm">
+                                Unsupported
+                              </Badge>
+                            ) : null}
+                            {isConfirmingRemoval ? (
+                              <div className="flex shrink-0 items-center gap-1">
+                                <span className="text-xs font-medium text-status-error-fg">
+                                  Remove?
+                                </span>
+                                <Button
+                                  aria-label={`Cancel removing ${path}`}
+                                  title={`Cancel removing ${path}`}
+                                  variant="ghost"
+                                  size="icon-xs"
+                                  type="button"
+                                  className="hover:not-disabled:bg-[color:var(--surface)]"
+                                  onClick={() => setPendingFileRemovalIndex(null)}
+                                >
+                                  <X className="h-3.5 w-3.5" aria-hidden="true" />
+                                </Button>
+                                <Button
+                                  aria-label={`Confirm removing ${path}`}
+                                  title={`Confirm removing ${path}`}
+                                  variant="ghost"
+                                  size="icon-xs"
+                                  type="button"
+                                  className="text-status-error-fg hover:not-disabled:bg-status-error-bg hover:not-disabled:text-status-error-fg"
+                                  onClick={() => removeFileAtIndex(index)}
+                                >
+                                  <Check className="h-3.5 w-3.5" aria-hidden="true" />
+                                </Button>
+                              </div>
+                            ) : (
+                              <Button
+                                aria-label={`Remove ${path}`}
+                                title={`Remove ${path}`}
+                                variant="ghost"
+                                size="icon-xs"
+                                type="button"
+                                onClick={() => setPendingFileRemovalIndex(index)}
+                              >
+                                <X className="h-3.5 w-3.5" aria-hidden="true" />
+                              </Button>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                    {hasFilePanelFooter ? (
+                      <div className="border-t border-[color:var(--line)] bg-[color:var(--surface-muted)] px-3 py-2 text-xs text-[color:var(--ink-soft)]">
+                        <div className="flex flex-col gap-1">
+                          {ignoredLocalMetadataNote ? <p>{ignoredLocalMetadataNote}</p> : null}
+                          {visibleFileIssues.map((issue) => (
+                            <p
+                              key={issue}
+                              className={
+                                issue.startsWith("Remove unsupported files")
+                                  ? "text-status-error-fg"
+                                  : undefined
+                              }
+                            >
+                              {issue}
+                            </p>
+                          ))}
+                        </div>
                       </div>
                     ) : null}
                   </div>
-                </div>
-                <div className="flex shrink-0 flex-wrap items-center gap-4 md:justify-end">
-                  {unsupportedFileEntries.length > 0 ? (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      type="button"
-                      onClick={removeUnsupportedFiles}
-                    >
-                      Remove unsupported
-                    </Button>
-                  ) : null}
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    type="button"
-                    onClick={() => fileInputRef.current?.click()}
-                  >
-                    Replace folder
-                  </Button>
-                  <button
-                    type="button"
-                    className="cursor-pointer text-xs font-medium text-[color:var(--ink-soft)] transition-colors hover:text-[color:var(--ink)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent)]/35 focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--bg)]"
-                    onClick={clearSelectedFiles}
-                  >
-                    Clear files
-                  </button>
-                </div>
-              </div>
-              <div className="mt-2 overflow-hidden rounded-t-[calc(var(--radius-md)+8px)] border-t border-[color:var(--line)] bg-[color:var(--surface)]">
-                <div className="flex max-h-[300px] flex-col gap-1 overflow-y-auto p-3">
-                  {!hasRequiredFile ? (
-                    <div className="flex items-center gap-2 rounded-[var(--radius-sm)] border border-status-error-fg/35 bg-status-error-bg px-3 py-1.5 text-sm text-status-error-fg">
-                      <span className="min-w-0 flex-1 truncate font-mono">
-                        {REQUIRED_FILE_LABEL}
-                      </span>
-                      <Badge variant="destructive" size="sm">
-                        Missing
-                      </Badge>
-                    </div>
-                  ) : null}
-                  {visibleFileEntries.map(({ file, index, path }) => {
-                    const isUnsupported = !isTextFile(file);
-                    const isConfirmingRemoval = pendingFileRemovalIndex === index;
-                    return (
-                      <div
-                        key={`${index}:${path}`}
-                        className={[
-                          "flex items-center gap-2 rounded-[var(--radius-sm)] px-3 py-1.5 text-sm bg-[color:var(--surface-muted)]",
-                          isUnsupported ? "text-status-error-fg" : "text-[color:var(--ink-soft)]",
-                        ].join(" ")}
-                      >
-                        <span className="min-w-0 flex-1 truncate font-mono" title={path}>
-                          {path}
-                        </span>
-                        {isUnsupported ? (
-                          <Badge variant="warning" size="sm">
-                            Unsupported
-                          </Badge>
-                        ) : null}
-                        {isConfirmingRemoval ? (
-                          <div className="flex shrink-0 items-center gap-1">
-                            <span className="text-xs font-medium text-status-error-fg">
-                              Remove?
-                            </span>
-                            <Button
-                              aria-label={`Cancel removing ${path}`}
-                              title={`Cancel removing ${path}`}
-                              variant="ghost"
-                              size="icon-xs"
-                              type="button"
-                              className="hover:not-disabled:bg-[color:var(--surface)]"
-                              onClick={() => setPendingFileRemovalIndex(null)}
-                            >
-                              <X className="h-3.5 w-3.5" aria-hidden="true" />
-                            </Button>
-                            <Button
-                              aria-label={`Confirm removing ${path}`}
-                              title={`Confirm removing ${path}`}
-                              variant="ghost"
-                              size="icon-xs"
-                              type="button"
-                              className="text-status-error-fg hover:not-disabled:bg-status-error-bg hover:not-disabled:text-status-error-fg"
-                              onClick={() => removeFileAtIndex(index)}
-                            >
-                              <Check className="h-3.5 w-3.5" aria-hidden="true" />
-                            </Button>
-                          </div>
-                        ) : (
-                          <Button
-                            aria-label={`Remove ${path}`}
-                            title={`Remove ${path}`}
-                            variant="ghost"
-                            size="icon-xs"
-                            type="button"
-                            onClick={() => setPendingFileRemovalIndex(index)}
-                          >
-                            <X className="h-3.5 w-3.5" aria-hidden="true" />
-                          </Button>
-                        )}
-                      </div>
-                    );
-                  })}
-                </div>
-                {hasFilePanelFooter ? (
-                  <div className="border-t border-[color:var(--line)] bg-[color:var(--surface-muted)] px-3 py-2 text-xs text-[color:var(--ink-soft)]">
-                    <div className="flex flex-col gap-1">
-                      {ignoredLocalMetadataNote ? <p>{ignoredLocalMetadataNote}</p> : null}
-                      {visibleFileIssues.map((issue) => (
-                        <p
-                          key={issue}
-                          className={
-                            issue.startsWith("Remove unsupported files")
-                              ? "text-status-error-fg"
-                              : undefined
-                          }
-                        >
-                          {issue}
-                        </p>
-                      ))}
-                    </div>
-                  </div>
-                ) : null}
-              </div>
                 </div>
               ) : (
                 <div

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -895,14 +895,14 @@ export function Upload() {
                         variant="ghost"
                         size="xs"
                         className="ml-auto"
-                        aria-label="Change publisher"
+                        aria-label="Switch publisher"
                       >
-                        Change
+                        Switch
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent
                       align="end"
-                      className="user-dropdown-subcontent user-dropdown-switcher-subcontent"
+                      className="publishing-context-switcher user-dropdown-subcontent user-dropdown-switcher-subcontent"
                     >
                       <div className="user-dropdown-section-label">Switch publisher</div>
                       <div className="user-dropdown-publisher-list" aria-label="Switch publisher">

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -907,7 +907,7 @@ export function Upload() {
                         className="ml-auto"
                         aria-label="Switch publisher"
                       >
-                        Switch
+                        Switch publisher
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -908,7 +908,7 @@ export function Upload() {
                         type="button"
                         variant="ghost"
                         size="xs"
-                        className="ml-auto"
+                        className="ml-auto focus-visible:ring-0 focus-visible:ring-offset-0"
                         aria-label="Switch publisher"
                       >
                         Switch publisher

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -851,6 +851,20 @@ export function Upload() {
         </header>
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-6">
+          {!updateSlug ? (
+            <div className="flex flex-col gap-2">
+              <Label>Publishing as</Label>
+              <div
+                role="group"
+                aria-label="Publishing as"
+                className="flex min-h-[44px] w-full items-center rounded-[var(--radius-sm)] border border-input-border bg-input-bg px-3.5 py-space-3 text-sm text-[color:var(--ink)]"
+              >
+                <PublisherOwnerDisplay value={ownerHandle} memberships={publisherMemberships} />
+              </div>
+              <InlineValidationMessage id="owner-validation-error" message={ownerIssue} />
+            </div>
+          ) : null}
+
           {/* File upload panel */}
           <input
             ref={setFileInputRef}
@@ -1181,58 +1195,42 @@ export function Upload() {
                 />
               </div>
 
-              <div className="flex flex-col gap-2">
-                {updateSlug ? (
-                  <>
-                    <Label htmlFor="ownerHandle">Owner</Label>
-                    <PublisherOwnerSelect
-                      id="ownerHandle"
-                      value={ownerHandle}
-                      memberships={publisherMemberships}
-                      onValueChange={(nextOwnerHandle) => {
-                        ownerTouchedRef.current = true;
-                        setOwnerHandle(nextOwnerHandle);
-                        // Reset the migration confirmation any time the Owner
-                        // selector changes; the user must re-acknowledge the move
-                        // after picking a different target to avoid a stale tick
-                        // turning into a silent transfer.
-                        setConfirmMigrateOwner(false);
-                      }}
-                    />
-                  </>
-                ) : (
-                  <>
-                    <Label>Publishing as</Label>
-                    <div
-                      role="group"
-                      aria-label="Publishing as"
-                      className="flex min-h-[44px] w-full items-center rounded-[var(--radius-sm)] border border-input-border bg-input-bg px-3.5 py-space-3 text-sm text-[color:var(--ink)]"
-                    >
-                      <PublisherOwnerDisplay
-                        value={ownerHandle}
-                        memberships={publisherMemberships}
+              {updateSlug ? (
+                <div className="flex flex-col gap-2">
+                  <Label htmlFor="ownerHandle">Owner</Label>
+                  <PublisherOwnerSelect
+                    id="ownerHandle"
+                    value={ownerHandle}
+                    memberships={publisherMemberships}
+                    onValueChange={(nextOwnerHandle) => {
+                      ownerTouchedRef.current = true;
+                      setOwnerHandle(nextOwnerHandle);
+                      // Reset the migration confirmation any time the Owner
+                      // selector changes; the user must re-acknowledge the move
+                      // after picking a different target to avoid a stale tick
+                      // turning into a silent transfer.
+                      setConfirmMigrateOwner(false);
+                    }}
+                  />
+                  {isOwnerMigration ? (
+                    <label className="flex items-start gap-2 text-sm cursor-pointer mt-2">
+                      <input
+                        type="checkbox"
+                        className="mt-0.5"
+                        checked={confirmMigrateOwner}
+                        onChange={(event) => setConfirmMigrateOwner(event.target.checked)}
                       />
-                    </div>
-                  </>
-                )}
-                {isOwnerMigration ? (
-                  <label className="flex items-start gap-2 text-sm cursor-pointer mt-2">
-                    <input
-                      type="checkbox"
-                      className="mt-0.5"
-                      checked={confirmMigrateOwner}
-                      onChange={(event) => setConfirmMigrateOwner(event.target.checked)}
-                    />
-                    <span>
-                      Move ownership of <strong>{trimmedSlug || "this skill"}</strong> from{" "}
-                      <strong>@{existingOwnerHandle}</strong> to <strong>@{ownerHandle}</strong>.
-                      Versions, tags, stats and stars are preserved; the old URL redirects to the
-                      new one.
-                    </span>
-                  </label>
-                ) : null}
-                <InlineValidationMessage id="owner-validation-error" message={ownerIssue} />
-              </div>
+                      <span>
+                        Move ownership of <strong>{trimmedSlug || "this skill"}</strong> from{" "}
+                        <strong>@{existingOwnerHandle}</strong> to <strong>@{ownerHandle}</strong>.
+                        Versions, tags, stats and stars are preserved; the old URL redirects to the
+                        new one.
+                      </span>
+                    </label>
+                  ) : null}
+                  <InlineValidationMessage id="owner-validation-error" message={ownerIssue} />
+                </div>
+              ) : null}
 
               <div className="flex flex-col gap-2">
                 <Label htmlFor="version">Version</Label>

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -959,7 +959,7 @@ export function Upload() {
               </div>
             ) : null}
 
-            <CardContent className="border-t border-[color:var(--line)] p-space-5">
+            <CardContent className="relative z-[1] -mt-1 rounded-t-[var(--radius-md)] border-t border-[color:var(--line)] bg-[color:var(--surface)] p-space-5">
               {files.length > 0 ? (
                 <div
               className={`overflow-hidden rounded-[var(--radius-md)] border transition-colors ${

--- a/src/styles.css
+++ b/src/styles.css
@@ -1224,11 +1224,15 @@ code {
   justify-content: space-between;
   gap: 14px;
   margin: 0;
-  padding: 8px 10px;
-  border-radius: 6px;
+  padding: 9px 10px;
+  border-radius: 0;
   background: color-mix(in srgb, var(--surface-muted) 44%, transparent);
   color: var(--ink-soft);
   font-size: 0.76rem;
+}
+
+.user-dropdown-content .user-dropdown-managing-separator {
+  margin-block: 0;
 }
 
 .user-dropdown-managing-label {
@@ -1244,8 +1248,8 @@ code {
 }
 
 .user-dropdown-managing-avatar {
-  width: 15px;
-  height: 15px;
+  width: 20px;
+  height: 20px;
   flex-shrink: 0;
   border-radius: 50%;
   object-fit: cover;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1054,6 +1054,7 @@ code {
 }
 
 .user-trigger img,
+.user-menu-publisher-icon,
 .user-menu-fallback {
   width: 24px;
   height: 24px;
@@ -1071,6 +1072,13 @@ code {
   font-size: var(--fs-sm);
   font-weight: 600;
   letter-spacing: 0;
+}
+
+.user-menu-publisher-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
 }
 
 .user-menu-chevron {
@@ -1094,6 +1102,65 @@ code {
 
 .user-dropdown-content [data-slot="dropdown-menu-item"]:focus-visible {
   outline: none;
+}
+
+.user-dropdown-publisher-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 240px;
+}
+
+.user-dropdown-publisher-item {
+  gap: 9px;
+}
+
+.user-dropdown-publisher-item[data-status="active"] {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  color: var(--ink);
+}
+
+.user-dropdown-publisher-icon {
+  display: inline-flex;
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+}
+
+.user-dropdown-publisher-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.user-dropdown-publisher-title,
+.user-dropdown-publisher-meta {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.user-dropdown-publisher-title {
+  font-weight: 700;
+}
+
+.user-dropdown-publisher-meta,
+.user-dropdown-signed-in {
+  color: var(--ink-soft);
+  font-size: 0.76rem;
+}
+
+.user-dropdown-publisher-check {
+  flex-shrink: 0;
+  color: var(--accent);
+}
+
+.user-dropdown-signed-in {
+  padding: 6px 8px 2px;
 }
 
 .user-dropdown-theme-row {
@@ -6738,6 +6805,7 @@ code {
   }
 
   .user-trigger img,
+  .user-menu-publisher-icon,
   .user-menu-fallback {
     width: 18px;
     height: 18px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -327,6 +327,30 @@ a.home-v2-trend-card:hover {
   gap: 12px;
 }
 
+.settings-organization-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  width: 100%;
+}
+
+.settings-organization-actions > * {
+  width: 100%;
+}
+
+@media (min-width: 480px) {
+  .settings-organization-actions {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    width: auto;
+  }
+
+  .settings-organization-actions > * {
+    width: auto;
+  }
+}
+
 @media (min-width: 768px) {
   .settings-organizations-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/src/styles.css
+++ b/src/styles.css
@@ -321,6 +321,18 @@ a.home-v2-trend-card:hover {
   border-radius: inherit;
 }
 
+.settings-organizations-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 12px;
+}
+
+@media (min-width: 768px) {
+  .settings-organizations-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 /* Global focus indicator for keyboard navigation */
 :focus-visible {
   outline: 2px solid var(--accent);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1053,33 +1053,6 @@ code {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
 }
 
-.account-trigger {
-  display: inline-grid;
-  width: 32px;
-  height: 32px;
-  flex-shrink: 0;
-  place-items: center;
-  border: 1px solid var(--line);
-  border-radius: var(--r-btn);
-  background: var(--surface);
-  cursor: pointer;
-  transition:
-    border-color 0.15s ease,
-    box-shadow 0.15s ease;
-}
-
-.account-trigger:hover {
-  border-color: color-mix(in srgb, var(--ink) 20%, var(--line));
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
-}
-
-.account-trigger img,
-.account-trigger .user-menu-fallback {
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-}
-
 .user-trigger img,
 .user-menu-publisher-icon,
 .user-menu-fallback {
@@ -1122,14 +1095,6 @@ code {
   background-clip: padding-box;
 }
 
-.publisher-dropdown-content {
-  width: min(292px, calc(100vw - 24px));
-}
-
-.account-dropdown-content {
-  width: min(284px, calc(100vw - 24px));
-}
-
 /* Remove global link underline and focus outline from user dropdown items */
 .user-dropdown-content a,
 .user-dropdown-content a:hover {
@@ -1147,28 +1112,67 @@ code {
   font-weight: 650;
 }
 
-.publisher-current-section {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+.user-dropdown-active-card {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--accent) 12%, var(--line));
+  border-radius: var(--r-md);
+  background: color-mix(in srgb, var(--accent) 3%, var(--surface));
+  padding: 5px;
 }
 
-.publisher-current-row {
+.user-dropdown-active-card::before {
+  position: absolute;
+  top: 10px;
+  bottom: 10px;
+  left: 0;
+  width: 2px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 52%, transparent);
+  content: "";
+  pointer-events: none;
+}
+
+.user-dropdown-active-header {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 6px 8px 7px;
+  padding: 8px 8px 7px;
 }
 
-.publisher-manage-action,
-.publisher-create-action {
+.user-dropdown-active-icon {
+  display: inline-flex;
+  width: 30px;
+  height: 30px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+}
+
+.user-dropdown-active-icon > img {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.user-dropdown-active-icon .user-menu-fallback {
+  width: 30px;
+  height: 30px;
+}
+
+.user-dropdown-active-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.user-dropdown-scoped-action {
   padding-inline: 10px;
 }
 
-.publisher-manage-action:focus,
-.publisher-manage-action[data-highlighted],
-.publisher-create-action:focus,
-.publisher-create-action[data-highlighted] {
+.user-dropdown-scoped-action:focus,
+.user-dropdown-scoped-action[data-highlighted] {
   background: color-mix(in srgb, var(--accent) 7%, var(--surface-muted));
 }
 
@@ -1235,14 +1239,6 @@ code {
   gap: 1px;
 }
 
-.user-dropdown-account-copy {
-  display: flex;
-  min-width: 0;
-  flex: 1;
-  flex-direction: column;
-  gap: 1px;
-}
-
 .user-dropdown-account-avatar {
   width: 26px;
   height: 26px;
@@ -1260,22 +1256,12 @@ code {
   font-weight: 700;
 }
 
-.user-dropdown-account-name,
 .user-dropdown-account-handle {
   overflow: hidden;
+  font-size: var(--fs-sm);
+  font-weight: 650;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.user-dropdown-account-name {
-  font-size: var(--fs-sm);
-  font-weight: 700;
-}
-
-.user-dropdown-account-handle {
-  color: var(--ink-soft);
-  font-size: 0.76rem;
-  font-weight: 600;
 }
 
 .user-dropdown-account-action {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1212,39 +1212,50 @@ code {
   font-size: 0.76rem;
 }
 
-.user-dropdown-publisher-via {
-  display: inline-flex;
-  min-width: 0;
-  align-items: center;
-  gap: 5px;
+.user-dropdown-publisher-check {
+  flex-shrink: 0;
+  color: var(--accent);
 }
 
-.user-dropdown-via-avatar {
-  width: 14px;
-  height: 14px;
+.user-dropdown-managing-row {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 7px;
+  margin: 2px 0;
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--surface-muted) 76%, var(--surface));
+  color: var(--ink-soft);
+  font-size: 0.76rem;
+}
+
+.user-dropdown-managing-label {
+  flex-shrink: 0;
+}
+
+.user-dropdown-managing-avatar {
+  width: 15px;
+  height: 15px;
   flex-shrink: 0;
   border-radius: 50%;
   object-fit: cover;
 }
 
-.user-dropdown-via-avatar-fallback {
+.user-dropdown-managing-avatar-fallback {
   display: inline-grid;
   place-items: center;
-  background: var(--surface-muted);
+  background: var(--surface);
   color: var(--ink-soft);
-  font-size: 0.58rem;
-  font-weight: 700;
 }
 
-.user-dropdown-via-handle {
+.user-dropdown-managing-handle {
   min-width: 0;
   overflow: hidden;
+  color: var(--ink);
+  font-weight: 600;
   text-overflow: ellipsis;
-}
-
-.user-dropdown-publisher-check {
-  flex-shrink: 0;
-  color: var(--accent);
+  white-space: nowrap;
 }
 
 .user-dropdown-create-org-action {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1218,6 +1218,7 @@ code {
 }
 
 .user-dropdown-create-org-action {
+  border-radius: var(--r-sm);
   padding-inline: 10px;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1137,6 +1137,9 @@ code {
 
 .user-dropdown-subcontent {
   width: min(300px, calc(100vw - 24px));
+  overflow: hidden;
+  border-radius: calc(var(--r-md) + 4px) !important;
+  background-clip: padding-box;
 }
 
 /* Remove global link underline and focus outline from user dropdown items */
@@ -1216,7 +1219,18 @@ code {
   display: flex;
   align-items: center;
   padding: 8px 10px;
-  background: color-mix(in srgb, var(--accent) 7%, transparent);
+  background: var(--surface-muted);
+}
+
+.user-dropdown-switcher-subcontent
+  [data-slot="dropdown-menu-item"].user-dropdown-publisher-item:focus,
+.user-dropdown-switcher-subcontent
+  [data-slot="dropdown-menu-item"].user-dropdown-publisher-item:focus-visible,
+.user-dropdown-switcher-subcontent
+  [data-slot="dropdown-menu-item"].user-dropdown-publisher-item[data-highlighted] {
+  background: var(--surface-muted);
+  outline: none;
+  box-shadow: none;
 }
 
 .user-dropdown-publisher-icon {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1154,8 +1154,7 @@ code {
   font-weight: 700;
 }
 
-.user-dropdown-publisher-meta,
-.user-dropdown-signed-in {
+.user-dropdown-publisher-meta {
   color: var(--ink-soft);
   font-size: 0.76rem;
 }
@@ -1163,10 +1162,6 @@ code {
 .user-dropdown-publisher-check {
   flex-shrink: 0;
   color: var(--accent);
-}
-
-.user-dropdown-signed-in {
-  padding: 6px 8px 2px;
 }
 
 .user-dropdown-theme-row {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1159,6 +1159,16 @@ code {
   font-size: 0.76rem;
 }
 
+.user-dropdown-context-label {
+  overflow: hidden;
+  padding: 4px 8px 6px;
+  color: var(--ink-soft);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .user-dropdown-publisher-check {
   flex-shrink: 0;
   color: var(--accent);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1152,6 +1152,41 @@ code {
   outline: none;
 }
 
+.user-dropdown-panel {
+  animation: user-dropdown-panel-enter 160ms cubic-bezier(0.23, 1, 0.32, 1);
+  will-change: opacity, transform;
+}
+
+.user-dropdown-panel[data-motion="idle"] {
+  animation: none;
+}
+
+.user-dropdown-panel[data-motion="forward"] {
+  --user-dropdown-panel-x: 8px;
+}
+
+.user-dropdown-panel[data-motion="back"] {
+  --user-dropdown-panel-x: -8px;
+}
+
+@keyframes user-dropdown-panel-enter {
+  from {
+    opacity: 0;
+    transform: translate3d(var(--user-dropdown-panel-x, 0), 0, 0);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .user-dropdown-panel {
+    animation: none;
+  }
+}
+
 .user-dropdown-section-label {
   padding: 4px 8px 6px;
   color: var(--ink-soft);
@@ -1217,6 +1252,7 @@ code {
 }
 
 .user-dropdown-current-trigger:focus,
+.user-dropdown-current-trigger:hover,
 .user-dropdown-current-trigger[data-highlighted] {
   background: var(--surface-muted);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1089,9 +1089,16 @@ code {
 }
 
 .user-dropdown-content {
+  --user-dropdown-gutter: 8px;
+  --user-dropdown-identity-surface: color-mix(
+    in srgb,
+    var(--surface-muted) 68%,
+    var(--surface)
+  );
   width: min(300px, calc(100vw - 24px));
   overflow: hidden;
   border-radius: var(--r-md) !important;
+  background: var(--surface);
   background-clip: padding-box;
 }
 
@@ -1118,11 +1125,13 @@ code {
 
 .user-dropdown-current-trigger {
   display: flex;
-  width: 100%;
+  width: calc(100% + var(--user-dropdown-gutter) * 2);
   align-items: center;
   gap: 9px;
-  border-radius: var(--r-sm);
-  padding: 8px 10px;
+  margin-inline: calc(var(--user-dropdown-gutter) * -1);
+  border-radius: 0;
+  background: var(--user-dropdown-identity-surface);
+  padding: 8px calc(10px + var(--user-dropdown-gutter));
   outline: none;
   cursor: pointer;
 }
@@ -1148,7 +1157,7 @@ code {
 
 .user-dropdown-current-trigger:focus,
 .user-dropdown-current-trigger[data-highlighted] {
-  background: color-mix(in srgb, var(--accent) 7%, var(--surface-muted));
+  background: color-mix(in srgb, var(--accent) 7%, var(--user-dropdown-identity-surface));
 }
 
 .user-dropdown-submenu-chevron {
@@ -1223,16 +1232,21 @@ code {
   align-items: center;
   justify-content: space-between;
   gap: 14px;
-  margin: 0;
-  padding: 9px 10px;
+  margin: 0 calc(var(--user-dropdown-gutter) * -1);
+  padding: 9px calc(10px + var(--user-dropdown-gutter));
   border-radius: 0;
-  background: color-mix(in srgb, var(--surface-muted) 44%, transparent);
+  background: var(--user-dropdown-identity-surface);
   color: var(--ink-soft);
   font-size: 0.76rem;
 }
 
 .user-dropdown-content .user-dropdown-managing-separator {
+  margin-inline: calc(var(--user-dropdown-gutter) * -1);
   margin-block: 0;
+}
+
+.user-dropdown-content .user-dropdown-full-bleed-separator {
+  margin-inline: calc(var(--user-dropdown-gutter) * -1);
 }
 
 .user-dropdown-managing-label {
@@ -1314,7 +1328,9 @@ code {
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 8px;
-  padding: 2px 4px 2px 10px;
+  margin-inline: calc(var(--user-dropdown-gutter) * -1);
+  padding: 2px calc(4px + var(--user-dropdown-gutter)) 2px
+    calc(10px + var(--user-dropdown-gutter));
 }
 
 .user-dropdown-appearance-label {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1248,7 +1248,14 @@ code {
 
 .user-dropdown-scoped-action:focus,
 .user-dropdown-scoped-action[data-highlighted] {
-  background: color-mix(in srgb, var(--accent) 7%, var(--surface-muted));
+  background: var(--surface-muted);
+}
+
+.user-dropdown-current-trigger > .user-dropdown-publisher-icon,
+.user-dropdown-current-trigger > .user-dropdown-publisher-icon .marketplace-icon-xs,
+.user-dropdown-current-trigger > .user-dropdown-publisher-icon .user-dropdown-account-avatar {
+  width: 30px;
+  height: 30px;
 }
 
 .user-dropdown-current-trigger:focus,
@@ -1341,12 +1348,13 @@ code {
 
 .user-dropdown-create-org-action {
   border-radius: var(--r-sm);
+  color: var(--ink-soft);
   padding-inline: 10px;
 }
 
 .user-dropdown-create-org-action:focus,
 .user-dropdown-create-org-action[data-highlighted] {
-  background: color-mix(in srgb, var(--accent) 7%, var(--surface-muted));
+  background: var(--surface-muted);
 }
 
 .user-dropdown-account-avatar {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1191,7 +1191,7 @@ code {
 
 .user-dropdown-current-trigger:focus,
 .user-dropdown-current-trigger[data-highlighted] {
-  background: color-mix(in srgb, var(--accent) 7%, var(--surface-muted));
+  background: var(--surface-muted);
 }
 
 .user-dropdown-submenu-chevron {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1100,6 +1100,11 @@ code {
   text-decoration: none;
 }
 
+.user-dropdown-content {
+  border-radius: var(--r-md);
+  overflow: hidden;
+}
+
 .user-dropdown-content [data-slot="dropdown-menu-item"]:focus-visible {
   outline: none;
 }
@@ -1113,6 +1118,7 @@ code {
 
 .user-dropdown-publisher-item {
   gap: 9px;
+  border-radius: var(--r-sm);
 }
 
 .user-dropdown-publisher-item[data-status="active"] {
@@ -1173,6 +1179,7 @@ code {
   min-width: 0;
   justify-content: center;
   padding-inline: 0;
+  border-radius: var(--r-sm);
 }
 
 .user-dropdown-theme-button[data-status="active"] {

--- a/src/styles.css
+++ b/src/styles.css
@@ -3547,6 +3547,18 @@ code {
   box-shadow: none;
 }
 
+.publishing-context-owner .marketplace-icon-xs {
+  width: 22px;
+  height: 22px;
+}
+
+@media (min-width: 640px) {
+  .publishing-context-owner .marketplace-icon-xs {
+    width: 26px;
+    height: 26px;
+  }
+}
+
 .publishing-context-switcher {
   overflow: hidden;
   border-radius: var(--radius-md) !important;

--- a/src/styles.css
+++ b/src/styles.css
@@ -331,6 +331,8 @@ a.home-v2-trend-card:hover {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 8px;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
   width: 100%;
 }
 
@@ -343,6 +345,8 @@ a.home-v2-trend-card:hover {
     display: flex;
     align-items: center;
     flex-shrink: 0;
+    padding-top: 0;
+    border-top: 0;
     width: auto;
   }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1089,10 +1089,14 @@ code {
 }
 
 .user-dropdown-content {
-  width: min(320px, calc(100vw - 24px));
+  width: min(300px, calc(100vw - 24px));
   overflow: hidden;
   border-radius: var(--r-md) !important;
   background-clip: padding-box;
+}
+
+.user-dropdown-subcontent {
+  width: min(300px, calc(100vw - 24px));
 }
 
 /* Remove global link underline and focus outline from user dropdown items */
@@ -1112,53 +1116,19 @@ code {
   font-weight: 650;
 }
 
-.user-dropdown-active-card {
-  position: relative;
-  overflow: hidden;
-  border: 1px solid color-mix(in srgb, var(--accent) 12%, var(--line));
-  border-radius: var(--r-md);
-  background: color-mix(in srgb, var(--accent) 3%, var(--surface));
-  padding: 5px;
-}
-
-.user-dropdown-active-card::before {
-  position: absolute;
-  top: 10px;
-  bottom: 10px;
-  left: 0;
-  width: 2px;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--accent) 52%, transparent);
-  content: "";
-  pointer-events: none;
-}
-
-.user-dropdown-active-header {
+.user-dropdown-current-trigger {
   display: flex;
+  width: 100%;
   align-items: center;
-  gap: 10px;
-  padding: 8px 8px 7px;
+  gap: 9px;
+  border-radius: var(--r-sm);
+  padding: 8px 10px;
+  outline: none;
+  cursor: pointer;
 }
 
-.user-dropdown-active-icon {
-  display: inline-flex;
-  width: 30px;
-  height: 30px;
-  flex-shrink: 0;
-  align-items: center;
-  justify-content: center;
-}
-
-.user-dropdown-active-icon > img {
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  object-fit: cover;
-}
-
-.user-dropdown-active-icon .user-menu-fallback {
-  width: 30px;
-  height: 30px;
+.user-dropdown-current-static {
+  cursor: default;
 }
 
 .user-dropdown-active-actions {
@@ -1176,15 +1146,39 @@ code {
   background: color-mix(in srgb, var(--accent) 7%, var(--surface-muted));
 }
 
+.user-dropdown-current-trigger:focus,
+.user-dropdown-current-trigger[data-highlighted],
+.user-dropdown-account-trigger:focus,
+.user-dropdown-account-trigger[data-highlighted] {
+  background: color-mix(in srgb, var(--accent) 7%, var(--surface-muted));
+}
+
+.user-dropdown-submenu-chevron {
+  flex-shrink: 0;
+  color: var(--ink-soft);
+}
+
 .user-dropdown-publisher-list {
   display: flex;
   flex-direction: column;
   gap: 2px;
 }
 
+.user-dropdown-switcher-subcontent .user-dropdown-publisher-list {
+  max-height: min(320px, calc(100vh - 160px));
+  overflow-y: auto;
+}
+
 .user-dropdown-publisher-item {
   gap: 9px;
   border-radius: var(--r-sm);
+}
+
+.user-dropdown-publisher-item-current {
+  display: flex;
+  align-items: center;
+  padding: 8px 10px;
+  background: color-mix(in srgb, var(--accent) 7%, transparent);
 }
 
 .user-dropdown-publisher-icon {
@@ -1233,10 +1227,29 @@ code {
   padding: 5px 10px 7px;
 }
 
-.user-dropdown-account-section {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
+.user-dropdown-account-trigger {
+  display: grid;
+  width: 100%;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1px 8px;
+  align-items: center;
+  border-radius: var(--r-sm);
+  padding: 8px 10px;
+  outline: none;
+  cursor: pointer;
+}
+
+.user-dropdown-account-trigger .user-dropdown-submenu-chevron {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+}
+
+.user-dropdown-account-label {
+  overflow: hidden;
+  font-size: var(--fs-sm);
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .user-dropdown-account-avatar {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1221,17 +1221,26 @@ code {
   display: flex;
   min-width: 0;
   align-items: center;
-  gap: 7px;
-  margin: 2px 0;
+  justify-content: space-between;
+  gap: 14px;
+  margin: 0;
   padding: 8px 10px;
-  border-radius: 12px;
-  background: color-mix(in srgb, var(--surface-muted) 76%, var(--surface));
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--surface-muted) 44%, transparent);
   color: var(--ink-soft);
   font-size: 0.76rem;
 }
 
 .user-dropdown-managing-label {
   flex-shrink: 0;
+}
+
+.user-dropdown-managing-account {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 7px;
 }
 
 .user-dropdown-managing-avatar {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1159,12 +1159,39 @@ code {
   font-weight: 650;
 }
 
+.user-dropdown-switcher-back {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+  border: 0;
+  border-radius: var(--r-sm);
+  background: transparent;
+  color: var(--ink-soft);
+  font: inherit;
+  text-align: left;
+  padding: 8px 10px;
+  cursor: pointer;
+}
+
+.user-dropdown-switcher-back:focus,
+.user-dropdown-switcher-back:hover {
+  background: var(--surface-muted);
+  outline: none;
+}
+
 .user-dropdown-current-trigger {
   display: flex;
   width: 100%;
   align-items: center;
   gap: 9px;
+  border: 0;
   border-radius: var(--r-sm);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
   padding: 8px 10px;
   outline: none;
   cursor: pointer;
@@ -1240,6 +1267,11 @@ code {
   flex-shrink: 0;
   align-items: center;
   justify-content: center;
+}
+
+.user-dropdown-publisher-icon .marketplace-icon-xs {
+  width: 26px;
+  height: 26px;
 }
 
 .user-dropdown-publisher-copy {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1147,9 +1147,7 @@ code {
 }
 
 .user-dropdown-current-trigger:focus,
-.user-dropdown-current-trigger[data-highlighted],
-.user-dropdown-account-trigger:focus,
-.user-dropdown-account-trigger[data-highlighted] {
+.user-dropdown-current-trigger[data-highlighted] {
   background: color-mix(in srgb, var(--accent) 7%, var(--surface-muted));
 }
 
@@ -1226,39 +1224,6 @@ code {
 .user-dropdown-create-org-action:focus,
 .user-dropdown-create-org-action[data-highlighted] {
   background: color-mix(in srgb, var(--accent) 7%, var(--surface-muted));
-}
-
-.user-dropdown-account-identity {
-  display: flex;
-  min-width: 0;
-  align-items: center;
-  gap: 9px;
-  padding: 5px 10px 7px;
-}
-
-.user-dropdown-account-trigger {
-  display: grid;
-  width: 100%;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 1px 8px;
-  align-items: center;
-  border-radius: var(--r-sm);
-  padding: 8px 10px;
-  outline: none;
-  cursor: pointer;
-}
-
-.user-dropdown-account-trigger .user-dropdown-submenu-chevron {
-  grid-column: 2;
-  grid-row: 1 / span 2;
-}
-
-.user-dropdown-account-label {
-  overflow: hidden;
-  font-size: var(--fs-sm);
-  font-weight: 700;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .user-dropdown-account-avatar {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1268,8 +1268,9 @@ code {
   min-width: 0;
   align-items: center;
   gap: 8px;
-  font-size: var(--fs-sm);
-  font-weight: 650;
+  color: var(--ink-soft);
+  font-size: 0.78rem;
+  font-weight: 600;
 }
 
 .user-dropdown-theme-row {

--- a/src/styles.css
+++ b/src/styles.css
@@ -3550,8 +3550,12 @@ code {
 .publishing-context-switcher
   [data-slot="dropdown-menu-item"].user-dropdown-publisher-item:focus,
 .publishing-context-switcher
+  [data-slot="dropdown-menu-item"].user-dropdown-publisher-item:focus-visible,
+.publishing-context-switcher
   [data-slot="dropdown-menu-item"].user-dropdown-publisher-item[data-highlighted] {
   background: var(--surface-muted);
+  outline: none;
+  box-shadow: none;
 }
 
 .marketplace-icon-xs {

--- a/src/styles.css
+++ b/src/styles.css
@@ -3641,8 +3641,7 @@ code {
   background: var(--surface-muted);
 }
 
-.publishing-context-switcher
-  [data-slot="dropdown-menu-item"].user-dropdown-publisher-item:focus,
+.publishing-context-switcher [data-slot="dropdown-menu-item"].user-dropdown-publisher-item:focus,
 .publishing-context-switcher
   [data-slot="dropdown-menu-item"].user-dropdown-publisher-item:focus-visible,
 .publishing-context-switcher

--- a/src/styles.css
+++ b/src/styles.css
@@ -1089,6 +1089,7 @@ code {
 }
 
 .user-dropdown-content {
+  width: min(320px, calc(100vw - 24px));
   overflow: hidden;
   border-radius: var(--r-md) !important;
   background-clip: padding-box;
@@ -1100,30 +1101,73 @@ code {
   text-decoration: none;
 }
 
-.user-dropdown-content {
-  border-radius: var(--r-md);
-  overflow: hidden;
-}
-
 .user-dropdown-content [data-slot="dropdown-menu-item"]:focus-visible {
   outline: none;
+}
+
+.user-dropdown-section-label {
+  padding: 4px 8px 6px;
+  color: var(--ink-soft);
+  font-size: 0.72rem;
+  font-weight: 650;
+}
+
+.user-dropdown-active-card {
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--line));
+  border-left: 2px solid var(--accent);
+  border-radius: var(--r-md);
+  background: color-mix(in srgb, var(--accent) 5%, var(--surface));
+  padding: 4px;
+}
+
+.user-dropdown-active-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 8px 7px;
+}
+
+.user-dropdown-active-icon {
+  display: inline-flex;
+  width: 30px;
+  height: 30px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+}
+
+.user-dropdown-active-icon > img {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.user-dropdown-active-icon .user-menu-fallback {
+  width: 30px;
+  height: 30px;
+}
+
+.user-dropdown-active-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.user-dropdown-scoped-action {
+  padding-inline: 10px;
 }
 
 .user-dropdown-publisher-list {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  min-width: 240px;
 }
 
 .user-dropdown-publisher-item {
   gap: 9px;
   border-radius: var(--r-sm);
-}
-
-.user-dropdown-publisher-item[data-status="active"] {
-  background: color-mix(in srgb, var(--accent) 10%, transparent);
-  color: var(--ink);
 }
 
 .user-dropdown-publisher-icon {
@@ -1159,31 +1203,82 @@ code {
   font-size: 0.76rem;
 }
 
-.user-dropdown-context-label {
-  overflow: hidden;
-  padding: 4px 8px 6px;
-  color: var(--ink-soft);
-  font-size: 0.72rem;
-  font-weight: 600;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .user-dropdown-publisher-check {
   flex-shrink: 0;
   color: var(--accent);
 }
 
+.user-dropdown-account-identity {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 9px;
+  padding: 5px 10px 7px;
+}
+
+.user-dropdown-account-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.user-dropdown-account-avatar {
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.user-dropdown-account-fallback {
+  display: grid;
+  place-items: center;
+  background: var(--surface-muted);
+  color: var(--accent-deep);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.user-dropdown-account-handle {
+  overflow: hidden;
+  font-size: var(--fs-sm);
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.user-dropdown-account-action {
+  padding-inline: 10px;
+}
+
+.user-dropdown-appearance-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 4px 2px 10px;
+}
+
+.user-dropdown-appearance-label {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--fs-sm);
+  font-weight: 650;
+}
+
 .user-dropdown-theme-row {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 4px;
+  width: 116px;
+  gap: 2px;
 }
 
 .user-dropdown-theme-button {
   min-width: 0;
   justify-content: center;
-  padding-inline: 0;
+  padding: 8px 0;
   border-radius: var(--r-sm);
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1113,12 +1113,24 @@ code {
 }
 
 .user-dropdown-active-card {
+  position: relative;
   overflow: hidden;
-  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--line));
-  border-left: 2px solid var(--accent);
+  border: 1px solid color-mix(in srgb, var(--accent) 12%, var(--line));
   border-radius: var(--r-md);
-  background: color-mix(in srgb, var(--accent) 5%, var(--surface));
-  padding: 4px;
+  background: color-mix(in srgb, var(--accent) 3%, var(--surface));
+  padding: 5px;
+}
+
+.user-dropdown-active-card::before {
+  position: absolute;
+  top: 10px;
+  bottom: 10px;
+  left: 0;
+  width: 2px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 52%, transparent);
+  content: "";
+  pointer-events: none;
 }
 
 .user-dropdown-active-header {
@@ -1157,6 +1169,11 @@ code {
 
 .user-dropdown-scoped-action {
   padding-inline: 10px;
+}
+
+.user-dropdown-scoped-action:focus,
+.user-dropdown-scoped-action[data-highlighted] {
+  background: color-mix(in srgb, var(--accent) 7%, var(--surface-muted));
 }
 
 .user-dropdown-publisher-list {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1212,6 +1212,36 @@ code {
   font-size: 0.76rem;
 }
 
+.user-dropdown-publisher-via {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 5px;
+}
+
+.user-dropdown-via-avatar {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.user-dropdown-via-avatar-fallback {
+  display: inline-grid;
+  place-items: center;
+  background: var(--surface-muted);
+  color: var(--ink-soft);
+  font-size: 0.58rem;
+  font-weight: 700;
+}
+
+.user-dropdown-via-handle {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .user-dropdown-publisher-check {
   flex-shrink: 0;
   color: var(--accent);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1089,16 +1089,9 @@ code {
 }
 
 .user-dropdown-content {
-  --user-dropdown-gutter: 8px;
-  --user-dropdown-identity-surface: color-mix(
-    in srgb,
-    var(--surface-muted) 68%,
-    var(--surface)
-  );
   width: min(300px, calc(100vw - 24px));
   overflow: hidden;
   border-radius: var(--r-md) !important;
-  background: var(--surface);
   background-clip: padding-box;
 }
 
@@ -1125,13 +1118,11 @@ code {
 
 .user-dropdown-current-trigger {
   display: flex;
-  width: calc(100% + var(--user-dropdown-gutter) * 2);
+  width: 100%;
   align-items: center;
   gap: 9px;
-  margin-inline: calc(var(--user-dropdown-gutter) * -1);
-  border-radius: 0;
-  background: var(--user-dropdown-identity-surface);
-  padding: 8px calc(10px + var(--user-dropdown-gutter));
+  border-radius: var(--r-sm);
+  padding: 8px 10px;
   outline: none;
   cursor: pointer;
 }
@@ -1157,7 +1148,7 @@ code {
 
 .user-dropdown-current-trigger:focus,
 .user-dropdown-current-trigger[data-highlighted] {
-  background: color-mix(in srgb, var(--accent) 7%, var(--user-dropdown-identity-surface));
+  background: color-mix(in srgb, var(--accent) 7%, var(--surface-muted));
 }
 
 .user-dropdown-submenu-chevron {
@@ -1226,65 +1217,6 @@ code {
   color: var(--accent);
 }
 
-.user-dropdown-managing-row {
-  display: flex;
-  min-width: 0;
-  align-items: center;
-  justify-content: space-between;
-  gap: 14px;
-  margin: 0 calc(var(--user-dropdown-gutter) * -1);
-  padding: 9px calc(10px + var(--user-dropdown-gutter));
-  border-radius: 0;
-  background: var(--user-dropdown-identity-surface);
-  color: var(--ink-soft);
-  font-size: 0.76rem;
-}
-
-.user-dropdown-content .user-dropdown-managing-separator {
-  margin-inline: calc(var(--user-dropdown-gutter) * -1);
-  margin-block: 0;
-}
-
-.user-dropdown-content .user-dropdown-full-bleed-separator {
-  margin-inline: calc(var(--user-dropdown-gutter) * -1);
-}
-
-.user-dropdown-managing-label {
-  flex-shrink: 0;
-}
-
-.user-dropdown-managing-account {
-  display: inline-flex;
-  min-width: 0;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 7px;
-}
-
-.user-dropdown-managing-avatar {
-  width: 20px;
-  height: 20px;
-  flex-shrink: 0;
-  border-radius: 50%;
-  object-fit: cover;
-}
-
-.user-dropdown-managing-avatar-fallback {
-  display: inline-grid;
-  place-items: center;
-  background: var(--surface);
-  color: var(--ink-soft);
-}
-
-.user-dropdown-managing-handle {
-  min-width: 0;
-  overflow: hidden;
-  color: var(--ink);
-  font-weight: 600;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .user-dropdown-create-org-action {
   padding-inline: 10px;
 }
@@ -1328,9 +1260,7 @@ code {
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 8px;
-  margin-inline: calc(var(--user-dropdown-gutter) * -1);
-  padding: 2px calc(4px + var(--user-dropdown-gutter)) 2px
-    calc(10px + var(--user-dropdown-gutter));
+  padding: 2px 4px 2px 10px;
 }
 
 .user-dropdown-appearance-label {

--- a/src/styles.css
+++ b/src/styles.css
@@ -3528,6 +3528,11 @@ code {
   box-shadow: 0 4px 12px color-mix(in srgb, var(--marketplace-icon-accent) 20%, transparent);
 }
 
+.publishing-context-owner .marketplace-icon:hover {
+  transform: none;
+  box-shadow: none;
+}
+
 .marketplace-icon-xs {
   width: 26px;
   height: 26px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1053,6 +1053,33 @@ code {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
 }
 
+.account-trigger {
+  display: inline-grid;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  place-items: center;
+  border: 1px solid var(--line);
+  border-radius: var(--r-btn);
+  background: var(--surface);
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.account-trigger:hover {
+  border-color: color-mix(in srgb, var(--ink) 20%, var(--line));
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.account-trigger img,
+.account-trigger .user-menu-fallback {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+}
+
 .user-trigger img,
 .user-menu-publisher-icon,
 .user-menu-fallback {
@@ -1095,6 +1122,14 @@ code {
   background-clip: padding-box;
 }
 
+.publisher-dropdown-content {
+  width: min(292px, calc(100vw - 24px));
+}
+
+.account-dropdown-content {
+  width: min(284px, calc(100vw - 24px));
+}
+
 /* Remove global link underline and focus outline from user dropdown items */
 .user-dropdown-content a,
 .user-dropdown-content a:hover {
@@ -1112,67 +1147,28 @@ code {
   font-weight: 650;
 }
 
-.user-dropdown-active-card {
-  position: relative;
-  overflow: hidden;
-  border: 1px solid color-mix(in srgb, var(--accent) 12%, var(--line));
-  border-radius: var(--r-md);
-  background: color-mix(in srgb, var(--accent) 3%, var(--surface));
-  padding: 5px;
+.publisher-current-section {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
-.user-dropdown-active-card::before {
-  position: absolute;
-  top: 10px;
-  bottom: 10px;
-  left: 0;
-  width: 2px;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--accent) 52%, transparent);
-  content: "";
-  pointer-events: none;
-}
-
-.user-dropdown-active-header {
+.publisher-current-row {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 8px 8px 7px;
+  padding: 6px 8px 7px;
 }
 
-.user-dropdown-active-icon {
-  display: inline-flex;
-  width: 30px;
-  height: 30px;
-  flex-shrink: 0;
-  align-items: center;
-  justify-content: center;
-}
-
-.user-dropdown-active-icon > img {
-  width: 30px;
-  height: 30px;
-  border-radius: 50%;
-  object-fit: cover;
-}
-
-.user-dropdown-active-icon .user-menu-fallback {
-  width: 30px;
-  height: 30px;
-}
-
-.user-dropdown-active-actions {
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-}
-
-.user-dropdown-scoped-action {
+.publisher-manage-action,
+.publisher-create-action {
   padding-inline: 10px;
 }
 
-.user-dropdown-scoped-action:focus,
-.user-dropdown-scoped-action[data-highlighted] {
+.publisher-manage-action:focus,
+.publisher-manage-action[data-highlighted],
+.publisher-create-action:focus,
+.publisher-create-action[data-highlighted] {
   background: color-mix(in srgb, var(--accent) 7%, var(--surface-muted));
 }
 
@@ -1239,6 +1235,14 @@ code {
   gap: 1px;
 }
 
+.user-dropdown-account-copy {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 1px;
+}
+
 .user-dropdown-account-avatar {
   width: 26px;
   height: 26px;
@@ -1256,12 +1260,22 @@ code {
   font-weight: 700;
 }
 
+.user-dropdown-account-name,
 .user-dropdown-account-handle {
   overflow: hidden;
-  font-size: var(--fs-sm);
-  font-weight: 650;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.user-dropdown-account-name {
+  font-size: var(--fs-sm);
+  font-weight: 700;
+}
+
+.user-dropdown-account-handle {
+  color: var(--ink-soft);
+  font-size: 0.76rem;
+  font-weight: 600;
 }
 
 .user-dropdown-account-action {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1219,6 +1219,15 @@ code {
   color: var(--accent);
 }
 
+.user-dropdown-create-org-action {
+  padding-inline: 10px;
+}
+
+.user-dropdown-create-org-action:focus,
+.user-dropdown-create-org-action[data-highlighted] {
+  background: color-mix(in srgb, var(--accent) 7%, var(--surface-muted));
+}
+
 .user-dropdown-account-identity {
   display: flex;
   min-width: 0;

--- a/src/styles.css
+++ b/src/styles.css
@@ -3533,6 +3533,27 @@ code {
   box-shadow: none;
 }
 
+.publishing-context-switcher {
+  overflow: hidden;
+  border-radius: var(--radius-md) !important;
+}
+
+.publishing-context-switcher .user-dropdown-publisher-item {
+  margin-inline: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.publishing-context-switcher .user-dropdown-publisher-item-current {
+  background: var(--surface-muted);
+}
+
+.publishing-context-switcher
+  [data-slot="dropdown-menu-item"].user-dropdown-publisher-item:focus,
+.publishing-context-switcher
+  [data-slot="dropdown-menu-item"].user-dropdown-publisher-item[data-highlighted] {
+  background: var(--surface-muted);
+}
+
 .marketplace-icon-xs {
   width: 26px;
   height: 26px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -1288,20 +1288,30 @@ code {
 .user-dropdown-theme-row {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  width: 116px;
-  gap: 2px;
+  width: 118px;
+  gap: 1px;
+  border: 1px solid color-mix(in srgb, var(--line) 82%, transparent);
+  border-radius: var(--r-sm);
+  background: color-mix(in srgb, var(--surface-muted) 70%, transparent);
+  padding: 2px;
 }
 
 .user-dropdown-theme-button {
   min-width: 0;
   justify-content: center;
-  padding: 8px 0;
-  border-radius: var(--r-sm);
+  padding: 6px 0;
+  border-radius: calc(var(--r-sm) - 2px);
+}
+
+.user-dropdown-theme-button:focus,
+.user-dropdown-theme-button[data-highlighted] {
+  background: color-mix(in srgb, var(--accent) 6%, var(--surface));
 }
 
 .user-dropdown-theme-button[data-status="active"] {
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  background: var(--surface);
   color: var(--ink);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.16);
 }
 
 .navbar-theme-switcher {


### PR DESCRIPTION
## Proposal

This PR adds a global **active publisher context** to ClawHub.

Until this change, ClawHub had enough publisher/org primitives in the data model, but the product UI still treated many signed-in actions as if they were implicitly personal. That made organization work feel patched on: users could belong to orgs, but the header, dashboard, settings, and publishing surfaces did not all share one obvious answer to “who am I acting as right now?”

This PR makes that answer explicit and consistent:

- A signed-in user has one active publisher context at a time.
- The active publisher can be their personal publisher or an organization they belong to.
- Publisher-scoped actions inherit that active context.
- Account/app actions remain tied to the signed-in user.

The goal is not to turn ClawHub into a workspace app with a heavy org switcher everywhere. The goal is a small, durable context model that lets users publish and manage work as either themselves or an organization without mixing account identity, publisher identity, and app-level controls.

## Product model

The PR separates three concepts that were previously easy to blur:

| Concept | Meaning | Examples |
| --- | --- | --- |
| Signed-in account | The authenticated user session | sign out, appearance, stars |
| Active publisher | The current publishing/profile context | personal publisher, organization publisher |
| Publisher-scoped actions | Actions that should apply to the active publisher | dashboard, profile, settings, publish skill/plugin |

In practice:

- **Dashboard** follows the active publisher.
- **Profile / Org profile** follows the active publisher.
- **Settings** follows the active publisher.
- **Skill and plugin publishing** follows the active publisher unless an explicit `ownerHandle` URL says otherwise.
- **Stars** stays personal/account-scoped.
- **Appearance** stays app-scoped.
- **Sign out** stays account-scoped.

## Header and global menu

The header now exposes the current publisher as the primary signed-in control.

For a personal publisher, the menu shows the personal publisher identity and the personal actions:

- Dashboard
- Profile
- Stars
- Settings
- Appearance
- Sign out

If the user has no organization yet, `Create organization` appears directly under their identity so the next step is discoverable without taking over the menu.

For an organization publisher, the menu changes the publisher-scoped actions to organization language:

- Dashboard
- Org profile
- Settings

Account/app actions stay separated below the scoped actions. `Stars` is intentionally not shown in the organization context because stars belong to the signed-in account, not to the active org.

The switcher is nested inside the current publisher row instead of being a second competing dropdown. Selecting the publisher row opens a context switch panel with personal/org options and `Create organization`. This keeps the main menu compact while still making the active context clear.

## Settings behavior

Settings are now context-aware.

When the active context is personal, `/settings` edits the signed-in user/personal publisher surface:

- Profile
- Appearance
- Organizations
- API tokens
- Danger zone

When the active context is an organization, `/settings` edits that organization:

- Profile
- Members, when the user can manage the org
- GitHub Skill Sync, when the active org is eligible/configurable
- Danger zone, when the user is allowed to delete the org

This avoids mixing user profile editing and org profile editing in the same visual state. The page title/subtitle and sidebar reflect the active settings scope.

Role gating is preserved:

- Owners/admins can manage organization settings and members.
- Publisher-only members can switch into an org context but do not get management actions.
- Org deletion remains owner-only.
- GitHub source management remains limited to eligible manageable official publishers.

## Organizations settings page

The personal settings area includes an Organizations view that lists the orgs available to the account.

Each org card shows:

- organization avatar/icon
- display name
- handle
- user role badge
- skill count
- plugin count
- View profile
- Manage or Switch, depending on permissions

The layout is intentionally card-based and supports two orgs per row on wide screens while staying compact enough for the common case where a user has one org.

## Publish skill/plugin flows

The skill and plugin publish pages now show the current publishing owner at the top of the upload card.

The strip is intentionally lightweight:

- avatar/icon
- publisher display name
- muted handle on larger screens
- Switch publisher action when another context is available

The selector updates the `ownerHandle` URL when switching context, so publishing state is shareable, reload-safe, and not only stored in client memory.

Important behavior preserved:

- An explicit `ownerHandle` in the URL wins when opening the page.
- Existing skill update flows keep the existing owner by default.
- Owner migration stays opt-in instead of happening accidentally during an update.
- Switching publisher on the publish page updates both the visible “publishing as” context and the URL.

## Dashboard behavior

Dashboard queries now follow active publisher scope without breaking legacy personal ownership.

For org publishers, the dashboard queries by `ownerPublisherId`.

For personal publishers, the dashboard continues querying by `ownerUserId`. This matters because local/legacy personal publishers can be synthesized or compatibility-backed; treating those as real publisher document IDs can hide existing personal content. This PR keeps personal dashboards on the user-owner path while allowing org dashboards to use publisher ownership.

## Backend/data changes

This PR adds a lightweight publisher membership query for the global context provider.

The existing richer `publishers.listMine` query is still useful for settings pages that need profile/status/count data. The app-level context provider does not need that full payload, so it now uses a narrower query that returns only publisher identity and role data.

That avoids putting a heavy “all published items” subscription around the entire app shell.

The lightweight membership query still handles:

- signed-in user filtering
- deleted/deactivated user guards
- active publisher filtering
- user-kind publisher ownership checks
- legacy personal publisher fallback through `personalPublisherId`

## Loading and deep-link behavior

The settings page now avoids normalizing org-only deep links before publisher memberships finish loading.

For example, `/settings?view=members` should not be immediately rewritten to `/settings?view=profile` just because memberships have not arrived yet. The page can show a skeleton while loading, but it should preserve the requested view until it knows whether the active publisher is an org and whether the requested view is valid.

This PR adds that loading guard and regression coverage.

## What intentionally does not change

This PR does not change the underlying authorization rules for publishing or org management.

It also does not make stars organization-scoped. Stars remain personal/account-level.

It does not make appearance publisher-scoped. Appearance remains an app/user preference.

It does not make update publishing migrate owners automatically. Migration must remain explicit.

It does not remove direct URL ownership. `ownerHandle` remains the shareable way to open publish flows in a specific owner context.

## Evidence

### Personal account menu

The personal menu keeps account/app actions separate from publisher-scoped actions. `Create organization` is promoted only when there is no org yet, and Stars appears only in the personal context.

![Personal account menu with Create organization, Dashboard, Profile, Stars, Settings, Appearance, and Sign out](https://quaint-shrine-7vj6.here.now/droppie-2026-06-18T23-05-58Z.png)

### Header context switch flow

This video shows the header interaction model: open the current publisher menu, use the nested publisher switcher, switch between personal/org contexts, and return to scoped actions for the selected publisher.

<video src="https://inner-knoll-gnge.here.now/droppie-2026-06-18T22-17-50Z.mov" controls></video>

[Open video directly](https://inner-knoll-gnge.here.now/droppie-2026-06-18T22-17-50Z.mov)

### Organizations management in personal settings

The Organizations view lists available orgs from the signed-in account, with profile access, management access, role indication, and lightweight skill/plugin metadata.

![Organizations settings view with two organization cards, role badges, counts, View profile, and Manage actions](https://spruce-laurel-ay2z.here.now/droppie-2026-06-18T21-54-04Z.png)

### Personal settings profile

When the active context is personal, Settings edits the user/personal profile rather than an organization.

![Personal settings profile view for Local Owner](https://hollow-marsh-25df.here.now/droppie-2026-06-18T21-53-58Z.png)

### Organization settings profile

When an org is active, Settings switches to the organization profile and exposes org-specific navigation such as Members and Danger zone.

![Organization settings profile view for Openclaw with Members and Danger zone navigation](https://jolly-vision-a84n.here.now/droppie-2026-06-18T21-53-44Z.png)

### Publish page context switcher

The skill publish page shows the current publishing owner and allows switching publisher from the publishing surface itself. The menu uses neutral selection styling with a checkmark and keeps personal/org options distinct.

![Publish skill page with Switch publisher dropdown showing personal and organization publishers](https://starry-slate-h8hq.here.now/droppie-2026-06-18T21-52-48Z.png)

### Publish page owner strip

The publish owner strip is attached to the upload card and shows the active publishing owner without extra explanatory copy. It keeps the page focused on the upload task while making the publishing target visible before the user drops a folder.

![Publish skill page showing compact owner strip above the dropzone](https://grassy-prism-r8ks.here.now/droppie-2026-06-18T21-52-38Z.png)

## Testing

- `bunx vitest run src/routes/-settings.test.tsx src/lib/activePublisher.test.tsx src/routes/-dashboard.test.tsx src/__tests__/header.test.tsx src/__tests__/skills-publish-route.test.tsx src/__tests__/plugins-publish-route.test.tsx`
- `bun run ci:static`
- `bunx tsc --noEmit`
- `bun run ci:types-build`
- `bun run ci:unit`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main --engine opencode --model opencode-go/kimi-k2.7-code --thinking medium --no-web-search`

## Review notes

A second-model review with Kimi K2.7 Code via Opencode found no accepted/actionable findings after the final rebase.

The review specifically checked the product goal and the highest-risk paths:

- role-gated org settings
- publish owner URL synchronization
- explicit `ownerHandle` preservation
- loading/deep-link behavior
- legacy/synthetic personal publisher fallback
- global context query cost
- personal vs organization dashboard ownership
- account-scoped vs publisher-scoped menu actions
