### PR TITLE
fix: persist registry backup seed completion state

### DIFF
--- a/convex/registryArtifactBackups.test.ts
+++ b/convex/registryArtifactBackups.test.ts
@@ -556,6 +556,32 @@ describe("package registry artifact backup page filtering", () => {
 });
 
 describe("seedRegistryArtifactBackupsInternalHandler", () => {
+  it("does not rescan backup dimensions whose sync state is already complete", async () => {
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce({ cursor: null, isDone: true })
+      .mockResolvedValueOnce({ cursor: null, isDone: true })
+      .mockResolvedValueOnce({ stale: 0, exhausted: 0 });
+    const runMutation = vi.fn();
+
+    const result = await seedRegistryArtifactBackupsInternalHandler(
+      { runQuery, runMutation } as never,
+      { queueOnly: true, batchSize: 2, maxBatches: 1 },
+    );
+
+    expect(result).toMatchObject({
+      cursor: null,
+      packageCursor: null,
+      skillsIsDone: true,
+      packageIsDone: true,
+      isDone: true,
+    });
+    expect(result.stats.skillsEnqueued).toBe(0);
+    expect(result.stats.packagesEnqueued).toBe(0);
+    expect(runQuery).toHaveBeenCalledTimes(3);
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
   it("can seed the backup ledger without uploading artifacts inline", async () => {
     const runQuery = vi
       .fn()

--- a/convex/registryArtifactBackups.ts
+++ b/convex/registryArtifactBackups.ts
@@ -86,6 +86,7 @@ type PackageBackupPageResult = {
 
 type BackupSyncState = {
   cursor: string | null;
+  isDone: boolean;
 };
 
 export type SeedRegistryArtifactBackupsResult = {
@@ -274,13 +275,14 @@ export const getRegistryArtifactBackupSyncStateInternal = internalQuery({
       .query("registryArtifactBackupSyncState")
       .withIndex("by_key", (q) => q.eq("key", SYNC_STATE_KEY))
       .unique();
-    return { cursor: state?.cursor ?? null };
+    return { cursor: state?.cursor ?? null, isDone: state?.isDone === true };
   },
 });
 
 export const setRegistryArtifactBackupSyncStateInternal = internalMutation({
   args: {
     cursor: v.optional(v.string()),
+    isDone: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const now = Date.now();
@@ -293,6 +295,7 @@ export const setRegistryArtifactBackupSyncStateInternal = internalMutation({
       await ctx.db.insert("registryArtifactBackupSyncState", {
         key: SYNC_STATE_KEY,
         cursor: args.cursor,
+        isDone: args.isDone ?? false,
         updatedAt: now,
       });
       return { ok: true as const };
@@ -300,6 +303,7 @@ export const setRegistryArtifactBackupSyncStateInternal = internalMutation({
 
     await ctx.db.patch(state._id, {
       cursor: args.cursor,
+      isDone: args.isDone ?? false,
       updatedAt: now,
     });
 
@@ -314,13 +318,14 @@ export const getPackageRegistryArtifactBackupSyncStateInternal = internalQuery({
       .query("registryArtifactBackupSyncState")
       .withIndex("by_key", (q) => q.eq("key", PACKAGE_SYNC_STATE_KEY))
       .unique();
-    return { cursor: state?.cursor ?? null };
+    return { cursor: state?.cursor ?? null, isDone: state?.isDone === true };
   },
 });
 
 export const setPackageRegistryArtifactBackupSyncStateInternal = internalMutation({
   args: {
     cursor: v.optional(v.string()),
+    isDone: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const now = Date.now();
@@ -333,6 +338,7 @@ export const setPackageRegistryArtifactBackupSyncStateInternal = internalMutatio
       await ctx.db.insert("registryArtifactBackupSyncState", {
         key: PACKAGE_SYNC_STATE_KEY,
         cursor: args.cursor,
+        isDone: args.isDone ?? false,
         updatedAt: now,
       });
       return { ok: true as const };
@@ -340,6 +346,7 @@ export const setPackageRegistryArtifactBackupSyncStateInternal = internalMutatio
 
     await ctx.db.patch(state._id, {
       cursor: args.cursor,
+      isDone: args.isDone ?? false,
       updatedAt: now,
     });
 
@@ -649,12 +656,14 @@ export const seedRegistryArtifactBackups: ReturnType<typeof action> = action({
         internal.registryArtifactBackups.setRegistryArtifactBackupSyncStateInternal,
         {
           cursor: undefined,
+          isDone: false,
         },
       );
       await ctx.runMutation(
         internal.registryArtifactBackups.setPackageRegistryArtifactBackupSyncStateInternal,
         {
           cursor: undefined,
+          isDone: false,
         },
       );
     }

--- a/convex/registryArtifactBackupsNode.ts
+++ b/convex/registryArtifactBackupsNode.ts
@@ -266,18 +266,19 @@ export async function seedRegistryArtifactBackupsInternalHandler(
   }
 
   const state = dryRun
-    ? { cursor: null as string | null }
+    ? { cursor: null as string | null, isDone: false }
     : ((await ctx.runQuery(
         internal.registryArtifactBackups.getRegistryArtifactBackupSyncStateInternal,
         {},
       )) as {
         cursor: string | null;
+        isDone: boolean;
       });
 
   let cursor: string | null = state.cursor;
-  let isDone = false;
+  let isDone = state.isDone;
 
-  for (let batch = 0; batch < maxBatches; batch++) {
+  for (let batch = 0; !isDone && batch < maxBatches; batch++) {
     const page = (await ctx.runQuery(
       internal.registryArtifactBackups.getRegistryArtifactBackupPageInternal,
       {
@@ -373,6 +374,7 @@ export async function seedRegistryArtifactBackupsInternalHandler(
         internal.registryArtifactBackups.setRegistryArtifactBackupSyncStateInternal,
         {
           cursor: isDone ? undefined : (cursor ?? undefined),
+          isDone,
         },
       );
     }
@@ -383,11 +385,12 @@ export async function seedRegistryArtifactBackupsInternalHandler(
   const packageSync = await syncPackageReleaseBackups(ctx, context, args, dryRun, queueOnly, stats);
   await alertOnUnhealthyBackupBacklog(ctx, stats);
 
-  if (!dryRun) {
+  if (!dryRun && !state.isDone) {
     await ctx.runMutation(
       internal.registryArtifactBackups.setRegistryArtifactBackupSyncStateInternal,
       {
         cursor: isDone ? undefined : (cursor ?? undefined),
+        isDone,
       },
     );
   }
@@ -414,17 +417,18 @@ async function syncPackageReleaseBackups(
   const maxBatches = clampInt(args.maxBatches ?? DEFAULT_MAX_BATCHES, 1, MAX_MAX_BATCHES);
 
   const state = dryRun
-    ? { cursor: null as string | null }
+    ? { cursor: null as string | null, isDone: false }
     : ((await ctx.runQuery(
         internal.registryArtifactBackups.getPackageRegistryArtifactBackupSyncStateInternal,
         {},
       )) as {
         cursor: string | null;
+        isDone: boolean;
       });
   let cursor: string | null = state.cursor;
-  let isDone = false;
+  let isDone = state.isDone;
 
-  for (let batch = 0; batch < maxBatches; batch++) {
+  for (let batch = 0; !isDone && batch < maxBatches; batch++) {
     const page = (await ctx.runQuery(
       internal.registryArtifactBackups.getPackageRegistryArtifactBackupPageInternal,
       {
@@ -512,6 +516,7 @@ async function syncPackageReleaseBackups(
         internal.registryArtifactBackups.setPackageRegistryArtifactBackupSyncStateInternal,
         {
           cursor: isDone ? undefined : (cursor ?? undefined),
+          isDone,
         },
       );
     }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2600,6 +2600,7 @@ const reservedHandles = defineTable({
 const registryArtifactBackupSyncState = defineTable({
   key: v.string(),
   cursor: v.optional(v.string()),
+  isDone: v.optional(v.boolean()),
   updatedAt: v.number(),
 }).index("by_key", ["key"]);
 


### PR DESCRIPTION
## Summary
- Persist `isDone` on registry artifact backup sync-state rows so completed seed dimensions do not restart on later operator runs.
- Skip skill/package seed pagination when the stored sync state is already complete.
- Add a regression test for completed sync-state no-op behavior.

## Production context
While continuing the R2 backfill after PR #2741 deployed, package seeding reported `packageIsDone: true`, then a later seed run restarted package pagination because completion was represented as `cursor: undefined`, which was indistinguishable from an unstarted scan. This patch keeps the completion bit explicit.

## Validation
- `bunx vitest run convex/registryArtifactBackups.test.ts`
- `bunx convex codegen --typecheck disable`
- `bunx tsc --noEmit --pretty false`
- `git diff --check`
- `bun run ci:static`
- `bun run ci:unit`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
