### PR TITLE
fix: show taxonomy on plugin cards

### DIFF
--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -2558,6 +2558,66 @@ describe("packages public queries", () => {
     expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 50 });
   });
 
+  it("includes current inferred taxonomy on install-sorted package pages", async () => {
+    const { ctx } = makeDigestCtx({
+      packagePages: [
+        {
+          page: [
+            makePackageDoc({
+              categories: undefined,
+              topics: undefined,
+              inferredCategories: ["memory", "tools"],
+              inferredTopics: ["Agent Memory", "Retrieval"],
+              inferredFromReleaseId: "packageReleases:demo-1",
+            }),
+          ],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+    });
+
+    const result = await listPublicPageHandler(ctx, {
+      family: "code-plugin",
+      sort: "installs",
+      paginationOpts: { cursor: null, numItems: 1 },
+    });
+
+    expect(result.page[0]).toMatchObject({
+      categories: ["memory", "tools"],
+      topics: ["Agent Memory", "Retrieval"],
+    });
+  });
+
+  it("preserves stored skill taxonomy on install-sorted package pages", async () => {
+    const { ctx } = makeDigestCtx({
+      packagePages: [
+        {
+          page: [
+            makePackageDoc({
+              family: "skill",
+              categories: ["developer-tools"],
+              topics: ["Automation"],
+            }),
+          ],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+    });
+
+    const result = await listPublicPageHandler(ctx, {
+      family: "skill",
+      sort: "installs",
+      paginationOpts: { cursor: null, numItems: 1 },
+    });
+
+    expect(result.page[0]).toMatchObject({
+      categories: ["developer-tools"],
+      topics: ["Automation"],
+    });
+  });
+
   it("uses a family-scoped weighted recommended score index after backfill", async () => {
     const { ctx, indexFilters, indexNames, paginate } = makeDigestCtx({
       packagePages: [

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -1248,6 +1248,10 @@ async function toPublicPackageListItemFromPackage(
   ctx: DbReaderCtx,
   pkg: Doc<"packages">,
 ): Promise<PublicPackageListItem> {
+  const catalogMetadata =
+    pkg.family === "code-plugin" || pkg.family === "bundle-plugin"
+      ? extractPackageDigestFields(pkg)
+      : pkg;
   const owner = toPublicPublisher(
     await getOwnerPublisher(ctx, {
       ownerPublisherId: pkg.ownerPublisherId,
@@ -1267,8 +1271,8 @@ async function toPublicPackageListItemFromPackage(
     createdAt: pkg.createdAt,
     updatedAt: pkg.updatedAt,
     latestVersion: pkg.latestVersionSummary?.version ?? null,
-    categories: pkg.categories,
-    topics: pkg.topics,
+    categories: catalogMetadata.categories,
+    topics: catalogMetadata.topics,
     verificationTier: pkg.verification?.tier ?? null,
     stats: pkg.stats,
   };

--- a/src/components/CatalogTopicList.tsx
+++ b/src/components/CatalogTopicList.tsx
@@ -1,14 +1,19 @@
 type CatalogTopicListProps = {
   topics?: string[] | null;
   limit?: number;
+  ariaLabel?: string;
 };
 
-export function CatalogTopicList({ topics, limit = 4 }: CatalogTopicListProps) {
+export function CatalogTopicList({
+  topics,
+  limit = 4,
+  ariaLabel = "Topics",
+}: CatalogTopicListProps) {
   const visibleTopics = (topics ?? []).slice(0, limit);
   if (visibleTopics.length === 0) return null;
 
   return (
-    <div className="catalog-topics" aria-label="Topics">
+    <div className="catalog-topics" aria-label={ariaLabel}>
       {visibleTopics.map((topic) => (
         <span key={topic} className="catalog-topic">
           {topic}

--- a/src/components/PluginListItem.test.tsx
+++ b/src/components/PluginListItem.test.tsx
@@ -28,10 +28,27 @@ describe("PluginListItem", () => {
   });
 
   it("renders author topics", () => {
-    render(<PluginListItem item={makePlugin({ topics: ["local-models", "inference"] })} />);
+    render(
+      <PluginListItem
+        item={makePlugin({
+          categories: ["models"],
+          topics: ["local-models", "inference"],
+        })}
+      />,
+    );
 
     expect(screen.getByText("local-models")).toBeTruthy();
     expect(screen.getByText("inference")).toBeTruthy();
+    expect(screen.queryByText("Models")).toBeNull();
+    expect(screen.getByLabelText("Topics")).toBeTruthy();
+  });
+
+  it("renders category labels when topics are unavailable", () => {
+    render(<PluginListItem item={makePlugin({ categories: ["memory", "tools"] })} />);
+
+    expect(screen.getByText("Memory")).toBeTruthy();
+    expect(screen.getByText("Tools")).toBeTruthy();
+    expect(screen.getByLabelText("Categories")).toBeTruthy();
   });
 
   it("renders a plugin manifest icon URL with safe image attributes", () => {

--- a/src/components/PluginListItem.tsx
+++ b/src/components/PluginListItem.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@tanstack/react-router";
+import { PLUGIN_CATEGORY_DEFINITIONS } from "clawhub-schema";
 import { PackageCheck } from "lucide-react";
 import { formatCompactStat } from "../lib/numberFormat";
 import type { PackageListItem } from "../lib/packageApi";
@@ -11,8 +12,24 @@ type PluginListItemProps = {
   variant?: "list" | "card";
 };
 
+const PLUGIN_CATEGORY_LABELS = new Map<string, string>(
+  PLUGIN_CATEGORY_DEFINITIONS.map(({ slug, label }) => [slug, label]),
+);
+
+function getPluginTaxonomyDisplay(item: PackageListItem) {
+  const topics = (item.topics ?? []).filter((topic) => topic.trim());
+  if (topics.length > 0) return { labels: topics, ariaLabel: "Topics" };
+
+  const categories = (item.categories ?? []).flatMap((category) => {
+    const label = PLUGIN_CATEGORY_LABELS.get(category);
+    return label ? [label] : [];
+  });
+  return { labels: categories, ariaLabel: "Categories" };
+}
+
 export function PluginListItem({ item, variant = "list" }: PluginListItemProps) {
   const installs = formatCompactStat(item.stats?.installs ?? 0);
+  const taxonomy = getPluginTaxonomyDisplay(item);
 
   if (variant === "card") {
     return (
@@ -34,7 +51,7 @@ export function PluginListItem({ item, variant = "list" }: PluginListItemProps) 
         <p className="skill-card-summary">
           {item.summary ?? "Plugin package for agent workflows."}
         </p>
-        <CatalogTopicList topics={item.topics} limit={3} />
+        <CatalogTopicList topics={taxonomy.labels} limit={3} ariaLabel={taxonomy.ariaLabel} />
         <div className="skill-card-footer">
           <div className="skill-list-item-meta plugin-card-meta">
             <span className="skill-list-item-meta-item">Plugin</span>
@@ -75,7 +92,7 @@ export function PluginListItem({ item, variant = "list" }: PluginListItemProps) 
         <p className="skill-list-item-summary">
           {item.summary ?? "Plugin package for agent workflows."}
         </p>
-        <CatalogTopicList topics={item.topics} />
+        <CatalogTopicList topics={taxonomy.labels} ariaLabel={taxonomy.ariaLabel} />
         <div className="skill-list-item-meta">
           <span className="skill-list-item-meta-item">Plugin</span>
           {item.latestVersion ? (


### PR DESCRIPTION
## Summary

- return resolved plugin categories and topics from the package-table fast paths used by Recommended and Most installed sorting
- render plugin topics on list and grid cards, falling back to human-readable category labels when topics are unavailable
- preserve stored skill taxonomy when the shared package converter serves skill-family rows

## Root cause

The sorted package-table path projected raw `packages.categories` and `packages.topics`, so plugins that relied on current inferred taxonomy reached the UI without metadata. Plugin cards also rendered topics only, leaving topicless categorized plugins without a taxonomy chip.

## Verification

- `bunx vitest run src/__tests__/packages-route.test.tsx src/components/PluginListItem.test.tsx convex/packages.public.test.ts` (321 passed)
- `bun run ci:unit` (3,633 passed, 1 skipped)
- `bun run ci:static`
- `bun run ci:types-build`
- structured autoreview: clean, no actionable findings
- real local Convex/API checks confirmed Recommended and Most installed plugin rows return taxonomy
- real browser checks confirmed taxonomy chips render in list, grid, and mobile layouts
