### PR TITLE
fix: allow github sync owner-scoped skill slugs

### DIFF
--- a/convex/githubSkillSync.test.ts
+++ b/convex/githubSkillSync.test.ts
@@ -1133,7 +1133,7 @@ describe("applyGitHubSkillSourceSyncHandler", () => {
     });
   });
 
-  it("applies a trusted fetched snapshot without overwriting unrelated slug owners", async () => {
+  it("applies a trusted fetched snapshot without blocking unrelated slug owners", async () => {
     const snapshot = await buildGitHubSkillSourceSnapshot({
       repo: "NVIDIA/skills",
       defaultBranch: "main",
@@ -1218,55 +1218,71 @@ describe("applyGitHubSkillSourceSyncHandler", () => {
     expect(result.stats).toMatchObject({
       discovered: 2,
       changed: 1,
-      inserted: 0,
-      conflicts: 1,
+      inserted: 1,
+      conflicts: 0,
     });
     expect(tables.githubSkillSources[0]).toMatchObject({
       ownerPublisherId: "publishers:nvidia",
       displayManifestStatus: "ok",
       displayManifestCommit: "2".repeat(40),
-      lastSyncIssues: [
-        {
-          slug: "vision-helper",
-          path: "skills/vision-helper",
-          displayName: "Vision Helper",
-          kind: "slug_conflict",
-          severity: "error",
-          message: "Slug already exists on ClawHub under @jonathanjing.",
-          existingOwnerHandle: "jonathanjing",
-        },
-      ],
+      lastSyncIssues: [],
     });
     expect(tables.skills.find((skill) => skill._id === "skills:aiq-deploy")).toMatchObject({
       githubCurrentCommit: "2".repeat(40),
       githubScanStatus: "pending",
       moderationStatus: "active",
     });
-    expect(tables.githubSkillContents).toEqual([
-      expect.objectContaining({
-        skillId: "skills:aiq-deploy",
-        githubSourceId: "githubSkillSources:nvidia",
-        githubPath: "skills/aiq-deploy",
-        skillMarkdownPath: "skills/aiq-deploy/SKILL.md",
-        skillMarkdown: "# AIQ Deploy v2\n",
-        skillCardMarkdownPath: "skills/aiq-deploy/skill-card.md",
-        skillCardMarkdown: "# AIQ Card v2\n",
-        githubCommit: "2".repeat(40),
-        githubContentHash: snapshot.skills.find((skill) => skill.slug === "aiq-deploy")
-          ?.contentHash,
-        fetchedAt: 123,
-      }),
-    ]);
+    expect(tables.githubSkillContents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          skillId: "skills:aiq-deploy",
+          githubSourceId: "githubSkillSources:nvidia",
+          githubPath: "skills/aiq-deploy",
+          skillMarkdownPath: "skills/aiq-deploy/SKILL.md",
+          skillMarkdown: "# AIQ Deploy v2\n",
+          skillCardMarkdownPath: "skills/aiq-deploy/skill-card.md",
+          skillCardMarkdown: "# AIQ Card v2\n",
+          githubCommit: "2".repeat(40),
+          githubContentHash: snapshot.skills.find((skill) => skill.slug === "aiq-deploy")
+            ?.contentHash,
+          fetchedAt: 123,
+        }),
+        expect.objectContaining({
+          skillId: "skills:new-1",
+          githubSourceId: "githubSkillSources:nvidia",
+          githubPath: "skills/vision-helper",
+          skillMarkdownPath: "skills/vision-helper/SKILL.md",
+          skillMarkdown: "# Vision Helper\n",
+          githubCommit: "2".repeat(40),
+          githubContentHash: snapshot.skills.find((skill) => skill.slug === "vision-helper")
+            ?.contentHash,
+          fetchedAt: 123,
+        }),
+      ]),
+    );
     expect(tables.globalStats[0]).toMatchObject({
-      activeSkillsCount: 10,
-      updatedAt: 1,
+      activeSkillsCount: 11,
+      updatedAt: 123,
     });
     const conflict = tables.skills.find((skill) => skill._id === "skills:vision-helper-conflict");
     expect(conflict).toMatchObject({
       displayName: "Existing Direct Skill",
     });
     expect(conflict).not.toHaveProperty("installKind");
-    expect(tables.skills).toHaveLength(2);
+    expect(tables.skills).toHaveLength(3);
+    expect(tables.skills.find((skill) => skill._id === "skills:new-1")).toMatchObject({
+      slug: "vision-helper",
+      displayName: "Vision Helper",
+      ownerUserId: "users:nvidia",
+      ownerPublisherId: "publishers:nvidia",
+      installKind: "github",
+      githubSourceId: "githubSkillSources:nvidia",
+      githubPath: "skills/vision-helper",
+      githubCurrentCommit: "2".repeat(40),
+      githubCurrentStatus: "present",
+      githubScanStatus: "pending",
+      moderationStatus: "active",
+    });
   });
 
   it("preserves an existing soft delete timestamp when upstream remains missing", async () => {

--- a/convex/githubSkillSync.ts
+++ b/convex/githubSkillSync.ts
@@ -545,67 +545,57 @@ export async function applyGitHubSkillSourceSyncHandler(
       continue;
     }
 
-    const existingBySlug = await ctx.db
-      .query("skills")
-      .withIndex("by_slug", (q) => q.eq("slug", skillInsert.slug))
-      .unique();
-    if (existingBySlug) {
-      if (canReviveGitHubSkillSlugConflict(existingBySlug, sourceOwnerPublisherId)) {
-        const previousSkillSnapshot = { ...existingBySlug } as Doc<"skills">;
-        const doc = stripUndefined(skillInsert.doc) as Partial<Doc<"skills">>;
-        const patch = {
-          ...doc,
-          createdAt: existingBySlug.createdAt,
-          tags: existingBySlug.tags ?? {},
-          statsDownloads: existingBySlug.statsDownloads ?? doc.statsDownloads,
-          statsStars: existingBySlug.statsStars ?? doc.statsStars,
-          statsInstallsCurrent: existingBySlug.statsInstallsCurrent ?? doc.statsInstallsCurrent,
-          statsInstallsAllTime: existingBySlug.statsInstallsAllTime ?? doc.statsInstallsAllTime,
-          stats: existingBySlug.stats ?? doc.stats,
-          badges: existingBySlug.badges,
-          latestVersionId: undefined,
-          githubRemovedAt: undefined,
-          softDeletedAt: undefined,
-          updatedAt: now,
-        };
-        await ctx.db.patch(existingBySlug._id, patch);
-        const nextSkillSnapshot = { ...previousSkillSnapshot, ...patch } as Doc<"skills">;
-        const discovered = discoveredBySlug.get(skillInsert.slug);
-        if (discovered) {
-          if (hasGitHubSkillContent(discovered)) {
-            await upsertGitHubSkillContent(ctx, {
-              skillId: existingBySlug._id,
-              sourceId,
-              discovered,
-              commit: args.snapshot.commit,
-              now,
-            });
-          }
-          await scheduleGitHubSkillVerification(ctx, {
-            skillId: existingBySlug._id,
-            contentHash: discovered.contentHash,
-            scanStatus: doc.githubScanStatus,
+    const reviveCandidate = await findGitHubSkillRevivalCandidate(ctx, {
+      ownerUserId: args.ownerUserId,
+      ownerPublisherId: sourceOwnerPublisherId,
+      slug: skillInsert.slug,
+    });
+    if (reviveCandidate && canReviveGitHubSkillForSource(reviveCandidate)) {
+      const previousSkillSnapshot = { ...reviveCandidate } as Doc<"skills">;
+      const doc = stripUndefined(skillInsert.doc) as Partial<Doc<"skills">>;
+      const patch = {
+        ...doc,
+        createdAt: reviveCandidate.createdAt,
+        tags: reviveCandidate.tags ?? {},
+        statsDownloads: reviveCandidate.statsDownloads ?? doc.statsDownloads,
+        statsStars: reviveCandidate.statsStars ?? doc.statsStars,
+        statsInstallsCurrent: reviveCandidate.statsInstallsCurrent ?? doc.statsInstallsCurrent,
+        statsInstallsAllTime: reviveCandidate.statsInstallsAllTime ?? doc.statsInstallsAllTime,
+        stats: reviveCandidate.stats ?? doc.stats,
+        badges: reviveCandidate.badges,
+        latestVersionId: undefined,
+        githubRemovedAt: undefined,
+        softDeletedAt: undefined,
+        updatedAt: now,
+      };
+      await ctx.db.patch(reviveCandidate._id, patch);
+      const nextSkillSnapshot = { ...previousSkillSnapshot, ...patch } as Doc<"skills">;
+      const discovered = discoveredBySlug.get(skillInsert.slug);
+      if (discovered) {
+        if (hasGitHubSkillContent(discovered)) {
+          await upsertGitHubSkillContent(ctx, {
+            skillId: reviveCandidate._id,
+            sourceId,
+            discovered,
+            commit: args.snapshot.commit,
             now,
           });
         }
-        await adjustGlobalPublicCountForSkillChange(
-          ctx,
-          previousSkillSnapshot,
-          nextSkillSnapshot,
+        await scheduleGitHubSkillVerification(ctx, {
+          skillId: reviveCandidate._id,
+          contentHash: discovered.contentHash,
+          scanStatus: doc.githubScanStatus,
           now,
-        );
-        await syncSkillSearchDigestForSkill(ctx, nextSkillSnapshot);
-        revived += 1;
-        continue;
+        });
       }
-      conflicts += 1;
-      issues.push(
-        await buildSlugConflictIssue(ctx, {
-          skillInsert,
-          existingSkill: existingBySlug,
-          discovered: discoveredBySlug.get(skillInsert.slug),
-        }),
+      await adjustGlobalPublicCountForSkillChange(
+        ctx,
+        previousSkillSnapshot,
+        nextSkillSnapshot,
+        now,
       );
+      await syncSkillSearchDigestForSkill(ctx, nextSkillSnapshot);
+      revived += 1;
       continue;
     }
 
@@ -658,58 +648,30 @@ export async function applyGitHubSkillSourceSyncHandler(
   };
 }
 
-async function buildSlugConflictIssue(
+async function findGitHubSkillRevivalCandidate(
   ctx: MutationCtx,
   args: {
-    skillInsert: ReturnType<typeof buildGitHubSkillSyncPlan>["skillInserts"][number];
-    existingSkill: Doc<"skills">;
-    discovered: GitHubSkillSourceMetadataSnapshot["skills"][number] | undefined;
+    ownerUserId: Id<"users">;
+    ownerPublisherId: Id<"publishers"> | undefined;
+    slug: string;
   },
-): Promise<GitHubSkillSourceSyncIssue> {
-  const displayName =
-    typeof args.skillInsert.doc.displayName === "string"
-      ? args.skillInsert.doc.displayName
-      : args.skillInsert.slug;
-  const path =
-    args.discovered?.path ??
-    (typeof args.skillInsert.doc.githubPath === "string"
-      ? args.skillInsert.doc.githubPath
-      : args.skillInsert.slug);
-  const existingOwnerHandle = await getSkillOwnerHandle(ctx, args.existingSkill);
-  const ownerPhrase = existingOwnerHandle ? ` under @${existingOwnerHandle}` : "";
-  return {
-    slug: args.skillInsert.slug,
-    path,
-    displayName,
-    kind: "slug_conflict",
-    severity: "error",
-    message: `Slug already exists on ClawHub${ownerPhrase}.`,
-    ...(existingOwnerHandle ? { existingOwnerHandle } : {}),
-  };
-}
-
-async function getSkillOwnerHandle(ctx: MutationCtx, skill: Doc<"skills">) {
-  if (skill.ownerPublisherId) {
-    const publisher = await ctx.db.get(skill.ownerPublisherId);
-    if (publisher?.handle) return publisher.handle;
-  }
-  if (skill.ownerUserId) {
-    const user = await ctx.db.get(skill.ownerUserId);
-    if (user?.handle) return user.handle;
-  }
-  return null;
-}
-
-function canReviveGitHubSkillSlugConflict(
-  skill: Doc<"skills">,
-  ownerPublisherId: Id<"publishers"> | undefined,
 ) {
-  return (
-    skill.installKind === "github" &&
-    typeof skill.softDeletedAt === "number" &&
-    Boolean(ownerPublisherId) &&
-    skill.ownerPublisherId === ownerPublisherId
-  );
+  if (args.ownerPublisherId) {
+    return await ctx.db
+      .query("skills")
+      .withIndex("by_owner_publisher_slug", (q) =>
+        q.eq("ownerPublisherId", args.ownerPublisherId).eq("slug", args.slug),
+      )
+      .unique();
+  }
+  return await ctx.db
+    .query("skills")
+    .withIndex("by_owner_slug", (q) => q.eq("ownerUserId", args.ownerUserId).eq("slug", args.slug))
+    .unique();
+}
+
+function canReviveGitHubSkillForSource(skill: Doc<"skills">) {
+  return skill.installKind === "github" && typeof skill.softDeletedAt === "number";
 }
 
 function hasGitHubSkillContent(


### PR DESCRIPTION
## Summary

- remove the global slug-conflict gate from GitHub-backed source sync inserts
- keep owner-scoped soft-delete revival for re-added GitHub skills
- update regression coverage so unrelated owners no longer block a source-backed skill with the same slug

## Validation

- `bunx vitest run convex/githubSkillSync.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bunx convex codegen --typecheck enable`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
