### PR TITLE
fix: align official plugin browse with official publishers

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -8799,7 +8799,7 @@ describe("httpApiV1 handlers", () => {
     }
   });
 
-  it("plugins list install sort forwards to both plugin families and merges by installs", async () => {
+  it("official plugins install sort forwards the filter to both families and merges by installs", async () => {
     const codePlugin = makeCatalogItem("code-installed", {
       family: "code-plugin",
       updatedAt: 100,
@@ -8813,7 +8813,7 @@ describe("httpApiV1 handlers", () => {
     const runQuery = vi.fn((_, args: Record<string, unknown>) => {
       if (Object.keys(args).length === 0) return 2;
       if (hasPluginRecommendedScoreReadinessArgs(args)) return false;
-      expect(args).toEqual(expect.objectContaining({ sort: "installs" }));
+      expect(args).toEqual(expect.objectContaining({ isOfficial: true, sort: "installs" }));
       if (args.family === "code-plugin") {
         return { page: [codePlugin], isDone: true, continueCursor: "" };
       }
@@ -8826,7 +8826,7 @@ describe("httpApiV1 handlers", () => {
 
     const response = await __handlers.listPluginsV1Handler(
       makeCtx({ runQuery, runMutation }),
-      new Request("https://example.com/api/v1/plugins?limit=2&sort=installs"),
+      new Request("https://example.com/api/v1/plugins?isOfficial=true&limit=2&sort=installs"),
     );
 
     expect(response.status).toBe(200);

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -1277,6 +1277,7 @@ function makeDigestCtx(options: {
                     indexName === "by_active_family_downloads" ||
                     indexName === "by_active_installs" ||
                     indexName === "by_active_family_installs" ||
+                    indexName === "by_active_family_official_installs" ||
                     indexName === "by_active_recommended_rank" ||
                     indexName === "by_active_family_recommended_rank" ||
                     indexName === "by_active_recommended_score" ||
@@ -2556,6 +2557,52 @@ describe("packages public queries", () => {
     ]);
     expect(paginate).toHaveBeenCalledTimes(1);
     expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 50 });
+  });
+
+  it("uses a family-and-official installs index for official plugin pages", async () => {
+    const { ctx, indexFilters, indexNames, paginate } = makeDigestCtx({
+      packagePages: [
+        {
+          page: [
+            makePackageDoc({
+              _id: "packages:official-code-plugin",
+              name: "official-code-plugin",
+              normalizedName: "official-code-plugin",
+              displayName: "Official Code Plugin",
+              family: "code-plugin",
+              isOfficial: true,
+              channel: "official",
+              stats: { downloads: 100, installs: 200, stars: 0, versions: 1 },
+            }),
+          ],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+    });
+
+    const result = await listPageForViewerInternalHandler(ctx, {
+      family: "code-plugin",
+      isOfficial: true,
+      sort: "installs",
+      paginationOpts: { cursor: null, numItems: 24 },
+    });
+
+    expect(result.page.map((entry) => entry.name)).toEqual(["official-code-plugin"]);
+    expect(result.isDone).toBe(true);
+    expect(indexNames).toEqual(["by_active_family_official_installs"]);
+    expect(indexFilters).toEqual([
+      {
+        indexName: "by_active_family_official_installs",
+        filters: [
+          { field: "softDeletedAt", value: undefined },
+          { field: "family", value: "code-plugin" },
+          { field: "isOfficial", value: true },
+        ],
+      },
+    ]);
+    expect(paginate).toHaveBeenCalledTimes(1);
+    expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 120 });
   });
 
   it("includes current inferred taxonomy on install-sorted package pages", async () => {

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -12,6 +12,7 @@ import { buildDeterministicPackageZip } from "./lib/skillZip";
 import {
   backfillLatestPackageScanStatusInternal,
   backfillPackageReleaseScansInternal,
+  normalizeOfficialPublisherPackagesInternal,
   getPackageReleaseScanBackfillBatchInternal,
   getByName,
   list,
@@ -678,6 +679,26 @@ const backfillPackageReleaseScansInternalHandler = (
       scheduled?: number;
     },
     { scheduled: number; nextCursor: number; done: boolean }
+  >
+)._handler;
+const normalizeOfficialPublisherPackagesInternalHandler = (
+  normalizeOfficialPublisherPackagesInternal as unknown as WrappedHandler<
+    {
+      family?: "code-plugin" | "bundle-plugin";
+      cursor?: string | null;
+      batchSize?: number;
+      dryRun?: boolean;
+    },
+    {
+      family: "code-plugin" | "bundle-plugin";
+      cursor: string;
+      isDone: boolean;
+      scanned: number;
+      matched: number;
+      patched: number;
+      skippedPrivate: number;
+      dryRun: boolean;
+    }
   >
 )._handler;
 const listOfficialPluginMigrationsInternalHandler = (
@@ -2603,6 +2624,165 @@ describe("packages public queries", () => {
     ]);
     expect(paginate).toHaveBeenCalledTimes(1);
     expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 120 });
+  });
+
+  it("normalizes public plugins from official publishers for official browse", async () => {
+    const officialPublisher = {
+      _id: "publishers:openclaw",
+      handle: "openclaw",
+      kind: "org",
+      deletedAt: undefined,
+      deactivatedAt: undefined,
+    };
+    const staleOfficialPlugin = makePackageDoc({
+      _id: "packages:memory",
+      name: "@openclaw/memory-lancedb",
+      normalizedName: "@openclaw/memory-lancedb",
+      displayName: "Memory LanceDB",
+      ownerPublisherId: officialPublisher._id,
+      channel: "community",
+      isOfficial: false,
+      capabilityTags: ["memory"],
+    });
+    const privateOfficialPlugin = makePackageDoc({
+      _id: "packages:private",
+      name: "@openclaw/private-plugin",
+      normalizedName: "@openclaw/private-plugin",
+      displayName: "Private Plugin",
+      ownerPublisherId: officialPublisher._id,
+      channel: "private",
+      isOfficial: false,
+    });
+    const communityPlugin = makePackageDoc({
+      _id: "packages:community",
+      name: "community-plugin",
+      normalizedName: "community-plugin",
+      displayName: "Community Plugin",
+      ownerPublisherId: "publishers:community",
+      channel: "community",
+      isOfficial: false,
+    });
+    const patch = vi.fn();
+    const insert = vi.fn();
+    const packageIndex = vi.fn();
+    const paginatePackages = vi.fn().mockResolvedValue({
+      page: [staleOfficialPlugin, privateOfficialPlugin, communityPlugin],
+      continueCursor: "",
+      isDone: true,
+    });
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === officialPublisher._id) return officialPublisher;
+          if (id === "publishers:community") {
+            return {
+              _id: id,
+              handle: "community",
+              kind: "org",
+              deletedAt: undefined,
+              deactivatedAt: undefined,
+            };
+          }
+          return null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table === "packages") {
+            return {
+              withIndex: packageIndex.mockImplementation((_indexName, builder) => {
+                builder?.({
+                  eq: (_field: string, _value: string) => ({}),
+                });
+                return { paginate: paginatePackages };
+              }),
+            };
+          }
+          if (table === "officialPublishers") {
+            return {
+              withIndex: vi.fn((_indexName, builder) => {
+                let publisherId: string | undefined;
+                builder?.({
+                  eq: (_field: string, value: string) => {
+                    publisherId = value;
+                    return {};
+                  },
+                });
+                return {
+                  unique: vi
+                    .fn()
+                    .mockResolvedValue(
+                      publisherId === officialPublisher._id
+                        ? { _id: "officialPublishers:openclaw", publisherId }
+                        : null,
+                    ),
+                };
+              }),
+            };
+          }
+          if (table === "packageSearchDigest") {
+            return {
+              withIndex: vi.fn(() => ({
+                unique: vi.fn().mockResolvedValue({
+                  _id: "packageSearchDigest:memory",
+                  packageId: staleOfficialPlugin._id,
+                  channel: "community",
+                  isOfficial: false,
+                }),
+              })),
+            };
+          }
+          if (
+            table === "packageCapabilitySearchDigest" ||
+            table === "packagePluginCategorySearchDigest" ||
+            table === "packageTopicSearchDigest"
+          ) {
+            return {
+              withIndex: vi.fn(() => ({
+                collect: vi.fn().mockResolvedValue([]),
+              })),
+            };
+          }
+          throw new Error(`Unexpected table ${table}`);
+        }),
+        patch,
+        insert,
+        delete: vi.fn(),
+        normalizeId: vi.fn(),
+      },
+    };
+
+    const result = await normalizeOfficialPublisherPackagesInternalHandler(ctx as never, {
+      family: "code-plugin",
+      dryRun: false,
+      batchSize: 10,
+    });
+
+    expect(result).toMatchObject({
+      family: "code-plugin",
+      scanned: 3,
+      matched: 1,
+      patched: 1,
+      skippedPrivate: 1,
+      dryRun: false,
+    });
+    expect(packageIndex).toHaveBeenCalledWith("by_family_updated", expect.any(Function));
+    expect(paginatePackages).toHaveBeenCalledWith({ cursor: null, numItems: 10 });
+    expect(patch).toHaveBeenCalledWith("packages:memory", {
+      channel: "official",
+      isOfficial: true,
+    });
+    expect(patch).not.toHaveBeenCalledWith(
+      "packages:private",
+      expect.objectContaining({ channel: "official" }),
+    );
+    expect(patch).toHaveBeenCalledWith(
+      "packageSearchDigest:memory",
+      expect.objectContaining({
+        channel: "official",
+        isOfficial: true,
+        ownerHandle: "openclaw",
+        ownerKind: "org",
+      }),
+    );
   });
 
   it("includes current inferred taxonomy on install-sorted package pages", async () => {

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -39,6 +39,7 @@ import {
 import {
   assertAdmin,
   assertModerator,
+  assertRole,
   getOptionalActiveAuthUserId,
   requireUserFromAction,
   requireUser,
@@ -381,6 +382,7 @@ const internalRefs = internal as unknown as {
     insertAuditLogInternal: unknown;
     updateReleaseStaticScanInternal: unknown;
     backfillLatestPackageScanStatusInternal: unknown;
+    normalizeOfficialPublisherPackagesInternal: unknown;
     insertPackageInspectorWarningsInternal: unknown;
     sendPackageInspectorFindingsEmailInternal: unknown;
     getPackageInspectorEmailContextInternal: unknown;
@@ -8726,6 +8728,95 @@ export const backfillLatestPackageScanStatus = action({
       internalRefs.packages.backfillLatestPackageScanStatusInternal,
       {
         batchSize: args.batchSize,
+      },
+    );
+  },
+});
+
+export const normalizeOfficialPublisherPackagesInternal = internalMutation({
+  args: {
+    family: v.optional(v.union(v.literal("code-plugin"), v.literal("bundle-plugin"))),
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const batchSize = Math.max(10, Math.min(args.batchSize ?? 100, 200));
+    const dryRun = args.dryRun !== false;
+    const family = args.family ?? "code-plugin";
+    const { page, continueCursor, isDone } = await ctx.db
+      .query("packages")
+      .withIndex("by_family_updated", (q) => q.eq("family", family))
+      .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
+
+    let matched = 0;
+    let patched = 0;
+    let skippedPrivate = 0;
+    for (const pkg of page) {
+      if (!pkg.ownerPublisherId || pkg.softDeletedAt) continue;
+      const ownerPublisher = await ctx.db.get(pkg.ownerPublisherId);
+      if (!(await isOfficialPublisher(ctx, ownerPublisher))) continue;
+      if (pkg.channel === "private") {
+        skippedPrivate++;
+        continue;
+      }
+      if (pkg.channel === "official" && pkg.isOfficial === true) continue;
+
+      matched++;
+      if (dryRun) continue;
+
+      const nextPackage = {
+        ...pkg,
+        channel: "official" as const,
+        isOfficial: true,
+      };
+      await ctx.db.patch(pkg._id, {
+        channel: nextPackage.channel,
+        isOfficial: nextPackage.isOfficial,
+      });
+      const owner = await getOwnerPublisher(ctx, {
+        ownerPublisherId: nextPackage.ownerPublisherId,
+        ownerUserId: nextPackage.ownerUserId,
+      });
+      await upsertPackageSearchDigest(ctx, {
+        ...extractPackageDigestFields(nextPackage),
+        ownerHandle: owner?.handle ?? "",
+        ownerKind: owner?.kind,
+      });
+      patched++;
+    }
+
+    return {
+      family,
+      cursor: continueCursor,
+      isDone,
+      scanned: page.length,
+      matched,
+      patched,
+      skippedPrivate,
+      dryRun,
+    };
+  },
+});
+
+export const normalizeOfficialPublisherPackages = action({
+  args: {
+    family: v.optional(v.union(v.literal("code-plugin"), v.literal("bundle-plugin"))),
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+    dryRun: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const { user } = await requireUserFromAction(ctx);
+    assertRole(user, ["admin"]);
+    return await runMutationRef(
+      ctx,
+      internalRefs.packages.normalizeOfficialPublisherPackagesInternal,
+      {
+        family: args.family,
+        cursor: args.cursor,
+        batchSize: args.batchSize,
+        dryRun: args.dryRun,
       },
     );
   },

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -3324,6 +3324,13 @@ async function listPackagePageImpl(
     let done = decodedCursor.done;
     const buildSortedQuery = () => {
       if (family) {
+        if (args.sort === "installs" && typeof isOfficial === "boolean") {
+          return ctx.db
+            .query("packages")
+            .withIndex("by_active_family_official_installs", (q) =>
+              q.eq("softDeletedAt", undefined).eq("family", family).eq("isOfficial", isOfficial),
+            );
+        }
         const indexName =
           args.sort === "installs"
             ? "by_active_family_installs"

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1385,6 +1385,13 @@ const packages = defineTable({
   .index("by_active_family_downloads", ["softDeletedAt", "family", "stats.downloads", "updatedAt"])
   .index("by_active_installs", ["softDeletedAt", "stats.installs", "updatedAt"])
   .index("by_active_family_installs", ["softDeletedAt", "family", "stats.installs", "updatedAt"])
+  .index("by_active_family_official_installs", [
+    "softDeletedAt",
+    "family",
+    "isOfficial",
+    "stats.installs",
+    "updatedAt",
+  ])
   .index("by_active_recommended_rank", [
     "softDeletedAt",
     "stats.stars",


### PR DESCRIPTION
## Summary

- add a family-and-official installs index for package listings
- use that index for official plugin pages sorted by installs
- add an admin repair path to normalize public plugins from official publishers to `channel: "official"` / `isOfficial: true`
- keep private plugins private and out of official browse

## Root cause

`/api/v1/plugins?isOfficial=true&sort=installs` queried code and bundle plugin families separately. Each family used the broad family installs index and filtered `isOfficial` afterward, so asking for more official items than one family currently had could scan community rows until Convex hit the read limit and returned HTTP 500.

There was also a data-contract mismatch for legacy official publisher packages: publisher profiles treat items from an Official publisher as official, but public plugin browse relies on denormalized package/digest fields. This PR keeps browse fast and index-backed by repairing public `code-plugin` and `bundle-plugin` packages owned by official publishers so their package and digest fields match the product rule.

## Product rule

Any public plugin owned by an Official publisher is Official. Private plugins stay private.

## Operational note

After deploy, run `packages:normalizeOfficialPublisherPackages` for both plugin families to repair existing production rows:

```text
family=code-plugin, dryRun=true
family=code-plugin, dryRun=false
family=bundle-plugin, dryRun=true
family=bundle-plugin, dryRun=false
```

Use the returned cursor to continue if a family needs multiple batches.

## Reproduction before this PR

```text
/api/v1/plugins?isOfficial=true&sort=installs&limit=4 -> HTTP 200
/api/v1/plugins?isOfficial=true&sort=installs&limit=5 -> HTTP 500
```

## Validation

- `bun run test -- convex/packages.public.test.ts convex/httpApiV1.handlers.test.ts` (608 passed)
- `bun run ci:unit` (3,576 passed, 1 skipped)
- `bun run ci:types-build`
- `bun run ci:static`
- `git diff --check`
