### PR TITLE
fix(web): filter New listings, trim CLI steps, and link creator cards

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -8841,6 +8841,35 @@ describe("httpApiV1 handlers", () => {
     ]);
   });
 
+  it("plugins list forwards excluded scan statuses to both plugin families", async () => {
+    const runQuery = vi.fn((_, args: Record<string, unknown>) => {
+      if (Object.keys(args).length === 0) {
+        throw new Error("filtered listings must not query the global count");
+      }
+      return { page: [], isDone: true, continueCursor: "" };
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.listPluginsV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request(
+        "https://example.com/api/v1/plugins?sort=updated&excludeScanStatus=pending,suspicious",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    const familyCalls = runQuery.mock.calls.filter(([, args]) => "family" in args);
+    expect(familyCalls).toHaveLength(2);
+    for (const [, args] of familyCalls) {
+      expect(args).toEqual(
+        expect.objectContaining({
+          excludedScanStatuses: ["pending", "suspicious"],
+          sort: "updated",
+        }),
+      );
+    }
+  });
+
   it("plugins list recommended sort uses weighted scores across plugin families", async () => {
     const codePlugin = makeCatalogItem("code-starred", {
       family: "code-plugin",
@@ -9361,6 +9390,28 @@ describe("httpApiV1 handlers", () => {
           query: "metrics",
           category: "gateway",
           limit: 7,
+        }),
+      );
+    }
+  });
+
+  it("plugins search forwards excluded scan statuses to both plugin families", async () => {
+    const runQuery = vi.fn().mockResolvedValue([]);
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.pluginsGetRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request(
+        "https://example.com/api/v1/plugins/search?q=calendar&excludeScanStatus=pending,suspicious",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runQuery).toHaveBeenCalledTimes(2);
+    for (const [, args] of runQuery.mock.calls) {
+      expect(args).toEqual(
+        expect.objectContaining({
+          excludedScanStatuses: ["pending", "suspicious"],
         }),
       );
     }

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -310,6 +310,13 @@ const PACKAGE_FAMILY_VALUES = ["skill", "code-plugin", "bundle-plugin"] as const
 const PLUGIN_EXPORT_FAMILY_VALUES = ["code-plugin", "bundle-plugin"] as const;
 const PACKAGE_CHANNEL_VALUES = ["official", "community", "private"] as const;
 const PACKAGE_LIST_SORT_VALUES = ["updated", "recommended", "installs"] as const;
+const PACKAGE_SCAN_STATUS_VALUES = [
+  "clean",
+  "suspicious",
+  "malicious",
+  "pending",
+  "not-run",
+] as const;
 const LEGACY_PLUGIN_CATEGORY_FILTER_ALIASES = {
   "mcp-tooling": "tools",
   data: "tools",
@@ -330,6 +337,27 @@ function resolvePluginCategoryFilter(value: string | undefined): PluginCategoryS
   return LEGACY_PLUGIN_CATEGORY_FILTER_ALIASES[
     value as keyof typeof LEGACY_PLUGIN_CATEGORY_FILTER_ALIASES
   ];
+}
+
+function parseExcludedScanStatuses(value: string | null) {
+  if (!value) return { ok: true as const, value: undefined };
+  const statuses = [
+    ...new Set(
+      value
+        .split(",")
+        .map((status) => status.trim())
+        .filter(Boolean),
+    ),
+  ];
+  const invalid = statuses.find(
+    (status) =>
+      !PACKAGE_SCAN_STATUS_VALUES.includes(status as (typeof PACKAGE_SCAN_STATUS_VALUES)[number]),
+  );
+  if (invalid) return { ok: false as const, message: `Invalid excludeScanStatus: ${invalid}` };
+  return {
+    ok: true as const,
+    value: statuses as Array<(typeof PACKAGE_SCAN_STATUS_VALUES)[number]>,
+  };
 }
 
 function invalidQueryParamMessage(name: string) {
@@ -430,6 +458,7 @@ type PackageListQueryArgs = {
   category?: string;
   topic?: string;
   officialFirst?: boolean;
+  excludedScanStatuses?: Array<(typeof PACKAGE_SCAN_STATUS_VALUES)[number]>;
   sort?: (typeof PACKAGE_LIST_SORT_VALUES)[number];
   viewerUserId?: Id<"users">;
   paginationOpts: { cursor: string | null; numItems: number };
@@ -1067,6 +1096,7 @@ async function searchPackageCatalog(
     highlightedOnly?: boolean;
     category?: string;
     topic?: string;
+    excludedScanStatuses?: Array<(typeof PACKAGE_SCAN_STATUS_VALUES)[number]>;
     viewerUserId?: Id<"users">;
   },
 ): Promise<CatalogSearchEntry[]> {
@@ -1082,6 +1112,7 @@ async function searchPackageCatalog(
       highlightedOnly: args.highlightedOnly,
       category: args.category,
       topic: args.topic,
+      excludedScanStatuses: args.excludedScanStatuses,
       viewerUserId: args.viewerUserId,
     },
   );
@@ -1471,6 +1502,10 @@ async function listPackages(
   const topic = url.searchParams.get("topic")?.trim().toLowerCase() || undefined;
   const officialFirst = parseBooleanQueryParam(url.searchParams, "officialFirst");
   if (!officialFirst.ok) return text(officialFirst.message, 400, rate.headers);
+  const excludedScanStatuses = parseExcludedScanStatuses(url.searchParams.get("excludeScanStatus"));
+  if (!excludedScanStatuses.ok) {
+    return text(excludedScanStatuses.message, 400, rate.headers);
+  }
   if (rawCategory && !category) {
     return text("Invalid plugin category", 400, rate.headers);
   }
@@ -1559,6 +1594,7 @@ async function listPackages(
             category,
             topic,
             officialFirst: officialFirst.value,
+            excludedScanStatuses: excludedScanStatuses.value,
             sort: unifiedListSort,
             viewerUserId: viewerUserId ?? undefined,
             paginationOpts: { cursor: pageCursor, numItems },
@@ -1631,7 +1667,8 @@ async function listPackages(
       !topic &&
       !channelParam.value &&
       typeof isOfficial.value !== "boolean" &&
-      !highlightedOnly;
+      !highlightedOnly &&
+      !excludedScanStatuses.value?.length;
     const totalCount = includeTotalCount
       ? await runQueryRef<number | null>(ctx, internalRefs.packages.countPublicPluginsInternal, {})
       : null;
@@ -1675,6 +1712,7 @@ async function listPackages(
         category,
         topic,
         officialFirst: officialFirst.value,
+        excludedScanStatuses: excludedScanStatuses.value,
         sort: pluginListSort,
         viewerUserId: viewerUserId ?? undefined,
         paginationOpts: { cursor: pageCursor, numItems },
@@ -1754,6 +1792,7 @@ async function listPackages(
     category,
     topic,
     officialFirst: officialFirst.value,
+    excludedScanStatuses: excludedScanStatuses.value,
     sort: effectiveSort,
     viewerUserId: viewerUserId ?? undefined,
     paginationOpts: { cursor, numItems: limit },
@@ -3203,6 +3242,10 @@ async function searchPackages(
   const rawCategory = url.searchParams.get("category")?.trim() || undefined;
   const category = resolvePluginCategoryFilter(rawCategory);
   const topic = url.searchParams.get("topic")?.trim().toLowerCase() || undefined;
+  const excludedScanStatuses = parseExcludedScanStatuses(url.searchParams.get("excludeScanStatus"));
+  if (!excludedScanStatuses.ok) {
+    return text(excludedScanStatuses.message, 400, rate.headers);
+  }
   if (rawCategory && !category) {
     return text("Invalid plugin category", 400, rate.headers);
   }
@@ -3243,6 +3286,7 @@ async function searchPackages(
             highlightedOnly: highlightedOnly || undefined,
             category,
             topic,
+            excludedScanStatuses: excludedScanStatuses.value,
             viewerUserId: viewerUserId ?? undefined,
           }),
         ),
@@ -3268,6 +3312,7 @@ async function searchPackages(
         highlightedOnly: highlightedOnly || undefined,
         category,
         topic,
+        excludedScanStatuses: excludedScanStatuses.value,
         viewerUserId: viewerUserId ?? undefined,
       });
     }
@@ -3281,6 +3326,7 @@ async function searchPackages(
         highlightedOnly: highlightedOnly || undefined,
         category,
         topic,
+        excludedScanStatuses: excludedScanStatuses.value,
         viewerUserId: viewerUserId ?? undefined,
       }),
       runQueryRef<CatalogSearchEntry[]>(

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -142,6 +142,7 @@ const listPublicPageHandler = (
       topic?: string;
       officialFirst?: boolean;
       highlightedOnly?: boolean;
+      excludedScanStatuses?: Array<"clean" | "suspicious" | "malicious" | "pending" | "not-run">;
       sort?: "updated" | "downloads" | "recommended" | "installs";
       paginationOpts: { cursor: string | null; numItems: number };
     },
@@ -160,6 +161,7 @@ const listPageForViewerInternalHandler = (
       topic?: string;
       officialFirst?: boolean;
       highlightedOnly?: boolean;
+      excludedScanStatuses?: Array<"clean" | "suspicious" | "malicious" | "pending" | "not-run">;
       sort?: "updated" | "downloads" | "recommended" | "installs";
       viewerUserId?: string;
       paginationOpts: { cursor: string | null; numItems: number };
@@ -284,6 +286,7 @@ const searchPublicHandler = (
       capabilityTag?: string;
       category?: string;
       topic?: string;
+      excludedScanStatuses?: Array<"clean" | "suspicious" | "malicious" | "pending" | "not-run">;
     },
     Array<{ package: { name: string } }>
   >
@@ -300,6 +303,7 @@ const searchForViewerInternalHandler = (
       capabilityTag?: string;
       category?: string;
       topic?: string;
+      excludedScanStatuses?: Array<"clean" | "suspicious" | "malicious" | "pending" | "not-run">;
       viewerUserId?: string;
     },
     Array<{ package: { name: string } }>
@@ -2446,6 +2450,32 @@ describe("packages public queries", () => {
     expect((result.page[0] as { stats?: unknown }).stats).toEqual(stats);
   });
 
+  it("fills filtered pages without pending or suspicious packages", async () => {
+    const { ctx } = makeDigestCtx({
+      pages: [
+        {
+          page: [
+            makeDigest("pending", { scanStatus: "pending", updatedAt: 40 }),
+            makeDigest("suspicious", { scanStatus: "suspicious", updatedAt: 30 }),
+            makeDigest("clean", { scanStatus: "clean", updatedAt: 20 }),
+            makeDigest("not-run", { scanStatus: "not-run", updatedAt: 10 }),
+          ],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+    });
+
+    const result = await listPublicPageHandler(ctx, {
+      sort: "updated",
+      excludedScanStatuses: ["pending", "suspicious"],
+      paginationOpts: { cursor: null, numItems: 2 },
+    });
+
+    expect(result.page.map((entry) => entry.name)).toEqual(["clean", "not-run"]);
+    expect(result.isDone).toBe(true);
+  });
+
   it("uses current package stats when digest stats are stale", async () => {
     const currentStats = { downloads: 99, installs: 7, stars: 2, versions: 3 };
     const { ctx } = makeDigestCtx({
@@ -3565,6 +3595,30 @@ describe("packages public queries", () => {
     });
 
     expect(result.map((entry) => entry.package.name)).toEqual(["tools-demo"]);
+  });
+
+  it("excludes selected scan statuses from package search", async () => {
+    const { ctx } = makeDigestCtx({
+      pages: [
+        {
+          page: [
+            makeDigest("pending-demo", { scanStatus: "pending" }),
+            makeDigest("suspicious-demo", { scanStatus: "suspicious" }),
+            makeDigest("clean-demo", { scanStatus: "clean" }),
+          ],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+    });
+
+    const result = await searchPublicHandler(ctx, {
+      query: "demo",
+      limit: 10,
+      excludedScanStatuses: ["pending", "suspicious"],
+    });
+
+    expect(result.map((entry) => entry.package.name)).toEqual(["clean-demo"]);
   });
 
   it("allows owners to search their private packages", async () => {

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -117,6 +117,14 @@ const MAX_SEARCH_PAGE_SIZE = 200;
 const MAX_DIRECT_PACKAGE_SEARCH_CANDIDATES = 20;
 const MAX_PACKAGE_VERSION_DELETE_LOOKUP_CANDIDATES = 4;
 const MAX_POINTERLESS_RELEASE_SURVIVOR_SCAN = 100;
+const packageListScanStatusValidator = v.union(
+  v.literal("clean"),
+  v.literal("suspicious"),
+  v.literal("malicious"),
+  v.literal("pending"),
+  v.literal("not-run"),
+);
+type PackageListScanStatus = NonNullable<Doc<"packages">["scanStatus"]>;
 const MAX_APPEAL_MESSAGE_LENGTH = 2_000;
 const MAX_OFFICIAL_MIGRATION_BLOCKERS = 20;
 const MAX_OFFICIAL_MIGRATION_FIELD_LENGTH = 300;
@@ -1116,8 +1124,13 @@ function packageArtifactSummary(
 
 function digestMatchesFilters(
   digest: PackageDigestLike,
-  args: { category?: string; topic?: string },
+  args: {
+    category?: string;
+    topic?: string;
+    excludedScanStatuses?: PackageListScanStatus[];
+  },
 ) {
+  if (digest.scanStatus && args.excludedScanStatuses?.includes(digest.scanStatus)) return false;
   if (args.category) {
     if (digest.pluginCategory) {
       if (digest.pluginCategory !== args.category) return false;
@@ -1139,6 +1152,7 @@ function digestMatchesSearchFilters(
     isOfficial?: boolean;
     category?: string;
     topic?: string;
+    excludedScanStatuses?: PackageListScanStatus[];
   },
 ) {
   if (args.family && digest.family !== args.family) return false;
@@ -1157,8 +1171,10 @@ function packageMatchesListFilters(
     isOfficial?: boolean;
     category?: string;
     topic?: string;
+    excludedScanStatuses?: PackageListScanStatus[];
   },
 ) {
+  if (pkg.scanStatus && args.excludedScanStatuses?.includes(pkg.scanStatus)) return false;
   if (args.family && pkg.family !== args.family) return false;
   if (args.channel && pkg.channel !== args.channel) return false;
   if (typeof args.isOfficial === "boolean" && pkg.isOfficial !== args.isOfficial) return false;
@@ -2701,6 +2717,7 @@ export const listPublicPage = query({
     category: v.optional(v.string()),
     topic: v.optional(v.string()),
     officialFirst: v.optional(v.boolean()),
+    excludedScanStatuses: v.optional(v.array(packageListScanStatusValidator)),
     sort: v.optional(
       v.union(
         v.literal("updated"),
@@ -3177,6 +3194,7 @@ export const listPageForViewerInternal = internalQuery({
     category: v.optional(v.string()),
     topic: v.optional(v.string()),
     officialFirst: v.optional(v.boolean()),
+    excludedScanStatuses: v.optional(v.array(packageListScanStatusValidator)),
     sort: v.optional(
       v.union(
         v.literal("updated"),
@@ -3235,6 +3253,7 @@ async function listPackagePageImpl(
     category?: string;
     topic?: string;
     officialFirst?: boolean;
+    excludedScanStatuses?: PackageListScanStatus[];
     sort?: "updated" | "downloads" | "recommended" | "installs";
     viewerUserId?: Id<"users">;
     paginationOpts: { cursor: string | null; numItems: number };
@@ -3436,7 +3455,8 @@ async function listPackagePageImpl(
   let pageOffset = offset;
   let pageSize: number | null = decodedCursor.pageSize ?? null;
   let done = decodedCursor.done;
-  const requiresDigestPostFilterScan = hasCatalogMetadataFilter;
+  const requiresDigestPostFilterScan =
+    hasCatalogMetadataFilter || Boolean(args.excludedScanStatuses?.length);
   let digestScanPages = 0;
   let remainingDigestScanBudget = requiresDigestPostFilterScan
     ? MAX_PUBLIC_LIST_FILTER_SCAN_DOCUMENTS
@@ -3624,6 +3644,7 @@ export const searchPublic = query({
     highlightedOnly: v.optional(v.boolean()),
     category: v.optional(v.string()),
     topic: v.optional(v.string()),
+    excludedScanStatuses: v.optional(v.array(packageListScanStatusValidator)),
   },
   handler: async (ctx, args) => {
     return (await searchPackagesImpl(ctx, args)).map(toPublicPackageSearchEntry);
@@ -3644,6 +3665,7 @@ export const searchForViewerInternal = internalQuery({
     highlightedOnly: v.optional(v.boolean()),
     category: v.optional(v.string()),
     topic: v.optional(v.string()),
+    excludedScanStatuses: v.optional(v.array(packageListScanStatusValidator)),
     viewerUserId: v.optional(v.id("users")),
   },
   handler: async (ctx, args) => {
@@ -3662,6 +3684,7 @@ async function searchPackagesImpl(
     highlightedOnly?: boolean;
     category?: string;
     topic?: string;
+    excludedScanStatuses?: PackageListScanStatus[];
     viewerUserId?: Id<"users">;
   },
 ) {
@@ -3680,6 +3703,9 @@ async function searchPackagesImpl(
   if (args.highlightedOnly) {
     const digests = await fetchHighlightedPackageDigests(ctx, { ...args, category, topic });
     const entries = digests
+      .filter(
+        (digest) => !digest.scanStatus || !args.excludedScanStatuses?.includes(digest.scanStatus),
+      )
       .map((digest) => {
         const match = packageSearchMatch(digest, queryText);
         return match ? { ...match, package: digest } : null;

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -2181,6 +2181,40 @@ describe("search helpers", () => {
     expect(result[0].skill.slug).toBe("the-news");
     expect(result[0].score).toBeGreaterThan(2.8);
   });
+
+  it("filters pending scans before applying the search result limit", async () => {
+    generateEmbeddingMock.mockRejectedValueOnce(new Error("embedding unavailable"));
+    const pending = {
+      skill: makePublicSkill({
+        id: "skills:pending",
+        slug: "search-term-pending",
+        displayName: "Search Term Pending",
+        githubScanStatus: "pending",
+      }),
+      version: null,
+      ownerHandle: "owner",
+      owner: null,
+    };
+    const clean = {
+      skill: makePublicSkill({
+        id: "skills:clean",
+        slug: "search-term-clean",
+        displayName: "Search Term Clean",
+        githubScanStatus: "clean",
+      }),
+      version: null,
+      ownerHandle: "owner",
+      owner: null,
+    };
+    const runQuery = vi.fn().mockResolvedValueOnce([pending, clean]).mockResolvedValueOnce([]);
+
+    const result = await searchSkillsHandler(
+      { vectorSearch: vi.fn(), runQuery },
+      { query: "search term", limit: 1, excludePendingScan: true },
+    );
+
+    expect(result.map((entry) => entry.skill.slug)).toEqual(["search-term-clean"]);
+  });
 });
 
 function makePublicSkill(params: {
@@ -2194,6 +2228,7 @@ function makePublicSkill(params: {
   stars?: number;
   categories?: string[];
   topics?: string[];
+  githubScanStatus?: "pending" | "clean" | "suspicious" | "malicious" | "not-run";
 }) {
   return {
     _id: params.id,
@@ -2209,6 +2244,7 @@ function makePublicSkill(params: {
     tags: {},
     categories: params.categories,
     topics: params.topics,
+    githubScanStatus: params.githubScanStatus,
     badges: {},
     stats: {
       downloads: params.downloads ?? 0,

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -290,6 +290,7 @@ export const searchSkills: ReturnType<typeof action> = action({
     limit: v.optional(v.number()),
     highlightedOnly: v.optional(v.boolean()),
     nonSuspiciousOnly: v.optional(v.boolean()),
+    excludePendingScan: v.optional(v.boolean()),
     categorySlug: v.optional(v.string()),
     topic: v.optional(v.string()),
   },
@@ -316,14 +317,20 @@ export const searchSkills: ReturnType<typeof action> = action({
         : rawExactSlugMatches
           ? [rawExactSlugMatches]
           : []
-    ).filter((entry) => !args.highlightedOnly || isSkillHighlighted(entry.skill));
-    const directPrefixMatches = (await ctx.runQuery(internal.search.directPrefixSkillMatches, {
-      query,
-      highlightedOnly: args.highlightedOnly,
-      nonSuspiciousOnly: args.nonSuspiciousOnly,
-      categorySlug,
-      topic,
-    })) as SkillSearchEntry[];
+    ).filter(
+      (entry) =>
+        (!args.highlightedOnly || isSkillHighlighted(entry.skill)) &&
+        (!args.excludePendingScan || entry.skill.githubScanStatus !== "pending"),
+    );
+    const directPrefixMatches = (
+      (await ctx.runQuery(internal.search.directPrefixSkillMatches, {
+        query,
+        highlightedOnly: args.highlightedOnly,
+        nonSuspiciousOnly: args.nonSuspiciousOnly,
+        categorySlug,
+        topic,
+      })) as SkillSearchEntry[]
+    ).filter((entry) => !args.excludePendingScan || entry.skill.githubScanStatus !== "pending");
     let vector: number[] | null;
     try {
       vector = await generateEmbedding(query);
@@ -385,7 +392,9 @@ export const searchSkills: ReturnType<typeof action> = action({
         // Skills already have badges from their docs (via toPublicSkill).
         // No need for a separate badge table lookup.
         const filtered = hydrated.filter(
-          (entry) => !args.highlightedOnly || isSkillHighlighted(entry.skill),
+          (entry) =>
+            (!args.highlightedOnly || isSkillHighlighted(entry.skill)) &&
+            (!args.excludePendingScan || entry.skill.githubScanStatus !== "pending"),
         );
 
         exactMatches = filtered.filter((entry) =>
@@ -426,12 +435,15 @@ export const searchSkills: ReturnType<typeof action> = action({
             ),
             highlightedOnly: args.highlightedOnly,
             nonSuspiciousOnly: args.nonSuspiciousOnly,
+            excludePendingScan: args.excludePendingScan,
             skipExactSlugLookup: true,
             categorySlug,
             topic,
           })) as SkillSearchEntry[]);
-    const mergedMatches = mergeUniqueBySkillId(primaryMatches, fallbackMatches).filter((entry) =>
-      matchesCatalogFilters(entry.skill, categorySlug, topic),
+    const mergedMatches = mergeUniqueBySkillId(primaryMatches, fallbackMatches).filter(
+      (entry) =>
+        matchesCatalogFilters(entry.skill, categorySlug, topic) &&
+        (!args.excludePendingScan || entry.skill.githubScanStatus !== "pending"),
     );
 
     const rankedMatches = mergedMatches
@@ -882,6 +894,7 @@ export const lexicalFallbackSkills = internalQuery({
     limit: v.optional(v.number()),
     highlightedOnly: v.optional(v.boolean()),
     nonSuspiciousOnly: v.optional(v.boolean()),
+    excludePendingScan: v.optional(v.boolean()),
     skipExactSlugLookup: v.optional(v.boolean()),
     categorySlug: v.optional(v.string()),
     topic: v.optional(v.string()),
@@ -916,6 +929,7 @@ export const lexicalFallbackSkills = internalQuery({
         if (
           !exactSlugSkill.softDeletedAt &&
           (!args.nonSuspiciousOnly || !isSkillSuspicious(exactSlugSkill)) &&
+          (!args.excludePendingScan || exactSlugSkill.githubScanStatus !== "pending") &&
           matchesCatalogFilters(exactSlugSkill, categorySlug, topic)
         ) {
           seenSkillIds.add(exactSlugSkill._id);
@@ -958,6 +972,7 @@ export const lexicalFallbackSkills = internalQuery({
       const skill = digestToHydratableSkill(digest);
       return (
         (!args.highlightedOnly || isSkillHighlighted(skill)) &&
+        (!args.excludePendingScan || skill.githubScanStatus !== "pending") &&
         matchesCatalogFilters(skill, categorySlug, topic) &&
         matchesExactTokens(args.queryTokens, [
           skill.displayName,
@@ -986,6 +1001,7 @@ export const lexicalFallbackSkills = internalQuery({
         if (seenSkillIds.has(digest.skillId)) continue;
         const skill = digestToHydratableSkill(digest);
         if (args.nonSuspiciousOnly && isSkillSuspicious(skill)) continue;
+        if (args.excludePendingScan && skill.githubScanStatus === "pending") continue;
         if (!matchesCatalogFilters(skill, categorySlug, topic)) continue;
         seenSkillIds.add(digest.skillId);
         candidates.push(skill);

--- a/src/__tests__/home-bring-skills-section.test.tsx
+++ b/src/__tests__/home-bring-skills-section.test.tsx
@@ -1,0 +1,21 @@
+/* @vitest-environment jsdom */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+import { HomeBringSkillsSection } from "../components/HomeBringSkillsSection";
+
+describe("HomeBringSkillsSection", () => {
+  it("does not advertise the removed sync command", () => {
+    render(<HomeBringSkillsSection />);
+
+    expect(screen.queryByText("clawhub sync --all")).toBeNull();
+    expect(screen.getByText(/clawhub skill publish/)).toBeTruthy();
+  });
+});

--- a/src/__tests__/home-listing-section.test.tsx
+++ b/src/__tests__/home-listing-section.test.tsx
@@ -304,6 +304,144 @@ describe("HomeListingSection", () => {
     expect(screen.queryByText("999")).toBeNull();
   });
 
+  it("keeps pending and suspicious audits out of skill New", async () => {
+    convexQueryMock.mockResolvedValue({
+      page: [
+        {
+          skill: {
+            _id: "skills:pending",
+            slug: "pending-skill",
+            displayName: "Pending Skill",
+            githubScanStatus: "pending",
+            createdAt: 30,
+            updatedAt: 30,
+            stats: { installsAllTime: 0 },
+          },
+          ownerHandle: "builder",
+        },
+        {
+          skill: {
+            _id: "skills:moderated-suspicious",
+            slug: "moderated-suspicious-skill",
+            displayName: "Moderated Suspicious Skill",
+            isSuspicious: true,
+            createdAt: 25,
+            updatedAt: 25,
+            stats: { installsAllTime: 0 },
+          },
+          ownerHandle: "builder",
+        },
+        {
+          skill: {
+            _id: "skills:suspicious",
+            slug: "suspicious-skill",
+            displayName: "Suspicious Skill",
+            githubScanStatus: "suspicious",
+            createdAt: 20,
+            updatedAt: 20,
+            stats: { installsAllTime: 0 },
+          },
+          ownerHandle: "builder",
+        },
+        {
+          skill: {
+            _id: "skills:clean",
+            slug: "clean-skill",
+            displayName: "Clean Skill",
+            githubScanStatus: "clean",
+            createdAt: 10,
+            updatedAt: 10,
+            stats: { installsAllTime: 0 },
+          },
+          ownerHandle: "builder",
+        },
+      ],
+      hasMore: false,
+      nextCursor: null,
+    });
+
+    render(<HomeListingSection />);
+    fireEvent.click(screen.getByRole("tab", { name: "New" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Clean Skill")).toBeTruthy();
+    });
+    expect(screen.queryByText("Pending Skill")).toBeNull();
+    expect(screen.queryByText("Suspicious Skill")).toBeNull();
+    expect(screen.queryByText("Moderated Suspicious Skill")).toBeNull();
+  });
+
+  it("asks the plugin catalog to exclude pending and suspicious audits from New", async () => {
+    render(<HomeListingSection />);
+    fireEvent.click(screen.getByRole("button", { name: "Plugins" }));
+    fireEvent.click(screen.getByRole("tab", { name: "New" }));
+
+    await waitFor(() => {
+      expect(fetchPluginCatalogMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          excludedScanStatuses: ["pending", "suspicious"],
+          sort: "updated",
+        }),
+      );
+    });
+  });
+
+  it("keeps pending and suspicious audits out of New search", async () => {
+    convexActionMock.mockResolvedValue([
+      {
+        skill: {
+          _id: "skills:pending-search",
+          slug: "pending-search",
+          displayName: "Pending Search Skill",
+          githubScanStatus: "pending",
+          createdAt: 2,
+          updatedAt: 2,
+          stats: { installsAllTime: 0 },
+        },
+        ownerHandle: "builder",
+      },
+      {
+        skill: {
+          _id: "skills:clean-search",
+          slug: "clean-search",
+          displayName: "Clean Search Skill",
+          githubScanStatus: "clean",
+          createdAt: 1,
+          updatedAt: 1,
+          stats: { installsAllTime: 0 },
+        },
+        ownerHandle: "builder",
+      },
+    ]);
+
+    render(<HomeListingSection />);
+    fireEvent.click(screen.getByRole("tab", { name: "New" }));
+    fireEvent.click(screen.getByRole("button", { name: "Search catalog" }));
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: "search" } });
+
+    await waitFor(() => {
+      expect(convexActionMock).toHaveBeenCalledWith("search:searchSkills", {
+        query: "search",
+        limit: 20,
+        nonSuspiciousOnly: true,
+        excludePendingScan: true,
+      });
+      expect(screen.getByText("Clean Search Skill")).toBeTruthy();
+    });
+    expect(screen.queryByText("Pending Search Skill")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Plugins" }));
+    fireEvent.click(screen.getByRole("tab", { name: "New" }));
+    await waitFor(() =>
+      expect(fetchPluginCatalogMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          excludedScanStatuses: ["pending", "suspicious"],
+          q: "search",
+        }),
+      ),
+    );
+  });
+
   it("requests official plugins from the catalog API", async () => {
     fetchPluginCatalogMock.mockResolvedValue({
       items: [

--- a/src/__tests__/home-popular-publishers-section.test.tsx
+++ b/src/__tests__/home-popular-publishers-section.test.tsx
@@ -1,0 +1,72 @@
+/* @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const convexQueryMock = vi.fn();
+
+vi.mock("../convex/client", () => ({
+  convexHttp: { query: (...args: unknown[]) => convexQueryMock(...args) },
+}));
+
+vi.mock("../../convex/_generated/api", () => ({
+  api: { publishers: { getProfileByHandle: "publishers:getProfileByHandle" } },
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    children,
+    className,
+    params,
+    to: _to,
+    ...props
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    params?: { handle?: string };
+    to?: string;
+    [key: string]: unknown;
+  }) => (
+    <a
+      {...props}
+      className={className}
+      href={params?.handle ? `/user/${params.handle}` : "/publishers"}
+    >
+      {children}
+    </a>
+  ),
+}));
+
+import { HomePopularPublishersSection } from "../components/HomePopularPublishersSection";
+
+describe("HomePopularPublishersSection", () => {
+  beforeEach(() => {
+    convexQueryMock.mockReset();
+    convexQueryMock.mockResolvedValue(null);
+  });
+
+  it("keeps creator cards clickable until the pointer actually drags", () => {
+    const setPointerCapture = vi.fn();
+    const hasPointerCapture = vi.fn(() => false);
+    const releasePointerCapture = vi.fn();
+
+    render(<HomePopularPublishersSection />);
+
+    const card = screen.getByRole("link", { name: "OpenClaw, @openclaw" });
+    expect(card.getAttribute("href")).toBe("/user/openclaw");
+    const viewport = document.querySelector(".home-v2-popular-publishers-viewport");
+    expect(viewport).toBeTruthy();
+    Object.assign(viewport!, { setPointerCapture, hasPointerCapture, releasePointerCapture });
+
+    fireEvent.pointerDown(viewport!, {
+      pointerType: "mouse",
+      button: 0,
+      pointerId: 7,
+      clientX: 100,
+    });
+    expect(setPointerCapture).not.toHaveBeenCalled();
+
+    fireEvent.pointerMove(viewport!, { pointerType: "mouse", pointerId: 7, clientX: 90 });
+    expect(setPointerCapture).toHaveBeenCalledWith(7);
+  });
+});

--- a/src/components/HomeBringSkillsSection.tsx
+++ b/src/components/HomeBringSkillsSection.tsx
@@ -78,7 +78,6 @@ const TABS: AudienceTab[] = [
       { text: "clawhub login" },
       { text: "clawhub skill publish ./my-skill --slug my-skill --version 1.0.0" },
       { text: "clawhub package publish your-org/your-plugin" },
-      { text: "clawhub sync --all" },
     ],
   },
 ];

--- a/src/components/HomeListingSection.tsx
+++ b/src/components/HomeListingSection.tsx
@@ -98,6 +98,14 @@ function filterPluginsByTab(items: PackageListItem[], tab: ListingTab) {
   return items;
 }
 
+function isNewSkillEligible(skill: PublicSkill) {
+  return (
+    !skill.isSuspicious &&
+    skill.githubScanStatus !== "pending" &&
+    skill.githubScanStatus !== "suspicious"
+  );
+}
+
 function itemMatchesAnyCategory(
   item: { categories?: readonly string[] | null },
   categorySlugs: readonly string[],
@@ -269,8 +277,10 @@ async function fetchSkillListing(
         });
         if (Array.isArray(result)) break;
 
-        const resultPage = ((result as { page?: SkillPageEntry[] }).page ?? []).filter((entry) =>
-          skillMatchesAnyCategory(entry.skill, categorySlugs),
+        const resultPage = ((result as { page?: SkillPageEntry[] }).page ?? []).filter(
+          (entry) =>
+            skillMatchesAnyCategory(entry.skill, categorySlugs) &&
+            (tab !== "new" || isNewSkillEligible(entry.skill)),
         );
         page.push(...resultPage);
 
@@ -309,6 +319,7 @@ async function fetchPluginListing(
           category: categorySlug ?? undefined,
           cursor: cursor ?? undefined,
           isOfficial: openClawOfficials ? true : undefined,
+          excludedScanStatuses: tab === "new" ? ["pending", "suspicious"] : undefined,
           sort: tab === "new" ? "updated" : "installs",
           limit: Math.min(limit - items.length, PLUGIN_CATALOG_PAGE_LIMIT),
           signal,
@@ -631,6 +642,7 @@ export function HomeListingSection() {
                 convexHttp.action(api.search.searchSkills, {
                   query: trimmedSearch,
                   limit: fetchLimit,
+                  ...(tab === "new" ? { nonSuspiciousOnly: true, excludePendingScan: true } : {}),
                   ...(categorySlug ? { categorySlug } : {}),
                 }),
               ),
@@ -644,7 +656,11 @@ export function HomeListingSection() {
                       ownerHandle: hit.ownerHandle,
                       owner: hit.owner,
                     }))
-                    .filter((entry) => skillMatchesAnyCategory(entry.skill, categorySlugs)),
+                    .filter(
+                      (entry) =>
+                        skillMatchesAnyCategory(entry.skill, categorySlugs) &&
+                        (tab !== "new" || isNewSkillEligible(entry.skill)),
+                    ),
                 ),
               );
               const sortedRows = tab === "new" ? sortSkillEntries(rows, tab) : rows;
@@ -661,6 +677,7 @@ export function HomeListingSection() {
                   q: trimmedSearch,
                   category: categorySlug ?? undefined,
                   isOfficial: tab === "officials" ? true : undefined,
+                  excludedScanStatuses: tab === "new" ? ["pending", "suspicious"] : undefined,
                   sort: tab === "new" ? "updated" : "installs",
                   limit: fetchLimit,
                   signal: controller.signal,

--- a/src/components/HomePopularPublishersSection.tsx
+++ b/src/components/HomePopularPublishersSection.tsx
@@ -44,7 +44,6 @@ function PopularPublisherCard({
       params={{ handle: pinned.handle }}
       className="home-v2-popular-publisher-card"
       aria-label={`${name}, @${pinned.handle}`}
-      role="listitem"
       draggable={false}
     >
       <div className="home-v2-popular-publisher-head">
@@ -115,7 +114,6 @@ export function HomePopularPublishersSection() {
       scrollLeft: viewport.scrollLeft,
       moved: false,
     };
-    viewport.setPointerCapture(event.pointerId);
     setDragging(true);
   };
 
@@ -123,7 +121,12 @@ export function HomePopularPublishersSection() {
     const viewport = viewportRef.current;
     if (!viewport || dragRef.current.pointerId !== event.pointerId) return;
     const distance = event.clientX - dragRef.current.startX;
-    if (Math.abs(distance) > 4) dragRef.current.moved = true;
+    if (Math.abs(distance) > 4) {
+      dragRef.current.moved = true;
+      if (!viewport.hasPointerCapture(event.pointerId)) {
+        viewport.setPointerCapture(event.pointerId);
+      }
+    }
     viewport.scrollLeft = dragRef.current.scrollLeft - distance;
   };
 
@@ -162,7 +165,7 @@ export function HomePopularPublishersSection() {
           dragRef.current.moved = false;
         }}
       >
-        <div className="home-v2-popular-publishers-track" role="list">
+        <div className="home-v2-popular-publishers-track">
           {PINNED_PUBLISHERS.map((publisher) => (
             <PopularPublisherCard
               key={publisher.handle}

--- a/src/lib/packageApi.ts
+++ b/src/lib/packageApi.ts
@@ -369,6 +369,7 @@ export async function fetchPackages(params: {
   category?: string;
   topic?: string;
   officialFirst?: boolean;
+  excludedScanStatuses?: Array<"clean" | "suspicious" | "malicious" | "pending" | "not-run">;
   sort?: PackageCatalogSort;
   limit?: number;
   signal?: AbortSignal;
@@ -410,6 +411,9 @@ export async function fetchPackages(params: {
   if (params.category) url.searchParams.set("category", params.category);
   if (params.topic) url.searchParams.set("topic", params.topic);
   if (params.officialFirst) url.searchParams.set("officialFirst", "true");
+  if (params.excludedScanStatuses?.length) {
+    url.searchParams.set("excludeScanStatus", params.excludedScanStatuses.join(","));
+  }
   if (params.sort) url.searchParams.set("sort", params.sort);
   return await fetchJson<{ items: PackageListItem[]; nextCursor: string | null }>(
     url,
@@ -426,6 +430,7 @@ export async function fetchPluginCatalog(params: {
   category?: string;
   topic?: string;
   officialFirst?: boolean;
+  excludedScanStatuses?: Array<"clean" | "suspicious" | "malicious" | "pending" | "not-run">;
   sort?: PackageCatalogSort;
   limit?: number;
   signal?: AbortSignal;
@@ -440,6 +445,7 @@ export async function fetchPluginCatalog(params: {
       category: params.category,
       topic: params.topic,
       officialFirst: params.officialFirst,
+      excludedScanStatuses: params.excludedScanStatuses,
       sort: params.sort,
       limit: params.limit,
       signal: params.signal,
@@ -469,6 +475,9 @@ export async function fetchPluginCatalog(params: {
     if (params.featured) url.searchParams.set("featured", "true");
     if (params.category) url.searchParams.set("category", params.category);
     if (params.topic) url.searchParams.set("topic", params.topic);
+    if (params.excludedScanStatuses?.length) {
+      url.searchParams.set("excludeScanStatus", params.excludedScanStatuses.join(","));
+    }
     const response = await fetchJson<{
       results?: Array<{
         score: number;
@@ -491,6 +500,9 @@ export async function fetchPluginCatalog(params: {
   if (params.category) url.searchParams.set("category", params.category);
   if (params.topic) url.searchParams.set("topic", params.topic);
   if (params.officialFirst) url.searchParams.set("officialFirst", "true");
+  if (params.excludedScanStatuses?.length) {
+    url.searchParams.set("excludeScanStatus", params.excludedScanStatuses.join(","));
+  }
   if (params.sort) url.searchParams.set("sort", params.sort);
   const result = await fetchJson<PluginCatalogResult>(url, params.signal);
   return {


### PR DESCRIPTION
## Summary

This PR proposes exactly three homepage follow-ups:

1. **Filter the New listings**
   - Hide Skills and Plugins with `pending` or `suspicious` audit states from the **New** tabs.
   - Apply the same rule to catalog searches performed while **New** is active.
   - Apply plugin exclusions before pagination and skill exclusions before the final search result limit, allowing eligible matches to refill the page.

2. **Remove the retired CLI step**
   - Remove `clawhub sync --all` from **Bring your skills to ClawHub**.

3. **Link the Popular creators cards**
   - Make each creator card a normal navigable link.
   - Preserve drag-to-scroll behavior by starting pointer capture only after the pointer crosses the drag threshold.

## Behavioural Proof

- Opened the homepage locally at `/` and verified all three proposed changes in the real app: the Skills/Plugins New tabs, the shortened CLI command list, and clickable creator cards.
- Verified New plugin browse and search requests forward `pending,suspicious` exclusions to both plugin families.
- Verified New skill search requests server-side non-suspicious and non-pending results, with filtering performed before the final result limit.
- Verified `not-run` plugin scans remain eligible; only `pending` and `suspicious` are excluded by this change.

- [x] Behavioural proof included

## Screenshots

The changes reuse the existing homepage layout and styling; no layout or visual redesign is proposed.

- [x] N/A

## Security / Trust Impact

The proposed catalog behavior reduces exposure to items whose audit is still pending or currently suspicious. It does not change moderation verdicts, publishing, installability, or public response schemas.

- [x] Security/trust impact explained

## Data / Deploy Impact

The plugin catalog endpoint gains an optional `excludeScanStatus` query filter, and skill search gains an internal pending-scan exclusion option. No schema change, migration, or backfill is required. The Convex backend must be deployed with the merged revision before the frontend uses the new filters in production.

- [x] Data/deploy impact explained

## Verification

- [x] `bun run ci:static`
- [x] Focused tests:
  - `bun run test -- convex/search.test.ts src/__tests__/home-listing-section.test.tsx src/__tests__/home-bring-skills-section.test.tsx src/__tests__/home-popular-publishers-section.test.tsx convex/packages.public.test.ts convex/httpApiV1.handlers.test.ts`
  - Result: 6 files passed, 695 tests passed.
- [x] `bun run ci:unit`
  - Result: 283 files passed, 1 skipped; 3,605 tests passed, 1 skipped; coverage thresholds passed.
- [x] `bun run ci:types-build`
  - Includes root TypeScript, schema package TypeScript, CLI package TypeScript, admin typecheck, and production build.
- [x] `git diff --check`
- [x] Two direct `codex review` passes. The first found missing suspicious/search handling; the second found post-limit filtering in New skill search. Both findings were fixed and covered by regression tests.
