### PR TITLE
feat: backfill plugin manifest summaries

### DIFF
--- a/convex/lib/packageRegistry.test.ts
+++ b/convex/lib/packageRegistry.test.ts
@@ -241,6 +241,95 @@ describe("packageRegistry", () => {
     ]);
   });
 
+  it("derives bundled skills from directory-style skill manifest roots", () => {
+    const summary = derivePluginManifestSummary({
+      pluginManifest: {
+        name: "example-ai-plugin",
+        openclaw: { compat: { pluginApi: "^2.0.0" } },
+        configSchema: {
+          type: "object",
+          required: ["EXAMPLE_PLUGIN_API_KEY"],
+          properties: {
+            EXAMPLE_PLUGIN_API_KEY: {
+              type: "string",
+              description: "API key used to connect to the example service.",
+              sensitive: true,
+            },
+          },
+        },
+        mcpServers: {
+          exampleMcp: {
+            command: "node",
+            args: ["dist/mcp.js"],
+          },
+        },
+        customMetadata: {
+          ignored: true,
+        },
+      },
+      skillManifest: {
+        skills: ["./skills/"],
+      },
+      files: [
+        {
+          path: "skills/research/SKILL.md",
+          size: 128,
+          sha256: "a".repeat(64),
+          text: "---\nname: research\ndescription: Deep research assistant.\n---\n# Research",
+        },
+        {
+          path: "skills/write-report/SKILL.md",
+          size: 256,
+          sha256: "b".repeat(64),
+          text: "---\nname: write-report\ndescription: Drafts a concise report.\n---\n# Write Report",
+        },
+        {
+          path: "skills/code-audit/SKILL.md",
+          size: 384,
+          sha256: "c".repeat(64),
+          text: "---\nname: code-audit\ndescription: Reviews code changes.\n---\n# Code Audit",
+        },
+        {
+          path: "skills/not-a-skill/README.md",
+          size: 12,
+          sha256: "d".repeat(64),
+          text: "ignored",
+        },
+      ],
+    });
+
+    expect(summary.bundledSkills).toEqual([
+      {
+        name: "research",
+        description: "Deep research assistant.",
+        rootPath: "skills/research",
+        skillMdPath: "skills/research/SKILL.md",
+        sha256: "a".repeat(64),
+        size: 128,
+      },
+      {
+        name: "write-report",
+        description: "Drafts a concise report.",
+        rootPath: "skills/write-report",
+        skillMdPath: "skills/write-report/SKILL.md",
+        sha256: "b".repeat(64),
+        size: 256,
+      },
+      {
+        name: "code-audit",
+        description: "Reviews code changes.",
+        rootPath: "skills/code-audit",
+        skillMdPath: "skills/code-audit/SKILL.md",
+        sha256: "c".repeat(64),
+        size: 384,
+      },
+    ]);
+    expect(summary.configFields).toHaveLength(1);
+    expect(summary.mcpServers).toEqual([{ name: "exampleMcp" }]);
+    expect(JSON.stringify(summary)).not.toContain("command");
+    expect(JSON.stringify(summary)).not.toContain("customMetadata");
+  });
+
   it("allows missing host and environment metadata for code plugins", () => {
     const result = extractCodePluginArtifacts({
       packageName: "demo-plugin",

--- a/convex/lib/packageRegistry.ts
+++ b/convex/lib/packageRegistry.ts
@@ -98,7 +98,7 @@ function normalizeSkillRootPath(value: unknown) {
           optionalString(value.rootPath))
         : undefined;
   if (!raw) return null;
-  return sanitizePath(raw.replace(/\/+$/, ""));
+  return sanitizePath(raw)?.replace(/^\.\//, "").replace(/\/+$/, "") ?? null;
 }
 
 function normalizeSkillRootPaths(input: unknown) {
@@ -114,6 +114,33 @@ function findSkillMarkdownFile(files: PluginManifestSummaryFile[], rootPath: str
     files.find((file) => file.path.toLowerCase() === expectedLower) ??
     null
   );
+}
+
+function skillRootPathFromMarkdownFile(filePath: string) {
+  return filePath.split("/").slice(0, -1).join("/");
+}
+
+function findSkillMarkdownFiles(files: PluginManifestSummaryFile[], rootPath: string) {
+  const exact = findSkillMarkdownFile(files, rootPath);
+  if (exact) return [{ rootPath, file: exact }];
+
+  const directoryPrefix = `${rootPath.toLowerCase()}/`;
+  const seen = new Set<string>();
+  return files
+    .filter((file) => {
+      const lowerPath = file.path.toLowerCase();
+      return lowerPath.startsWith(directoryPrefix) && lowerPath.endsWith("/skill.md");
+    })
+    .map((file) => ({
+      rootPath: skillRootPathFromMarkdownFile(file.path),
+      file,
+    }))
+    .filter((entry) => {
+      const key = entry.file.path.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
 }
 
 function extractCompatibilityFromManifest(
@@ -217,9 +244,8 @@ export function derivePluginManifestSummary(params: {
     ...normalizeSkillRootPaths(skillManifest.bundledSkills),
   ]);
   const bundledSkills = skillRoots
-    .map((rootPath) => {
-      const file = findSkillMarkdownFile(params.files, rootPath);
-      if (!file) return null;
+    .flatMap((rootPath) => findSkillMarkdownFiles(params.files, rootPath))
+    .map(({ rootPath, file }) => {
       const metadata = parseSkillMarkdownMetadata(file.text);
       return {
         name: metadata.name ?? pathDerivedName(rootPath),
@@ -230,7 +256,12 @@ export function derivePluginManifestSummary(params: {
         size: file.size,
       };
     })
-    .filter((entry): entry is NonNullable<typeof entry> => Boolean(entry));
+    .filter((entry, index, entries) => {
+      const firstIndex = entries.findIndex(
+        (candidate) => candidate.skillMdPath.toLowerCase() === entry.skillMdPath.toLowerCase(),
+      );
+      return firstIndex === index;
+    });
 
   return {
     schemaVersion: 1 as const,

--- a/convex/migrations.test.ts
+++ b/convex/migrations.test.ts
@@ -10,11 +10,19 @@ import {
   backfillOneSkillInstallEstimate,
   buildCanonicalCatalogMetadataPatch,
   runCatalogMetadataCanonicalization,
+  runPluginManifestSummaryBackfill,
   runSkillInstallBackfill,
 } from "./migrations";
 
 type InstallBackfillWrappedHandler = {
   _handler: (ctx: unknown, args: { dryRun?: boolean; confirm?: string }) => Promise<unknown>;
+};
+
+type PluginManifestSummaryBackfillWrappedHandler = {
+  _handler: (
+    ctx: unknown,
+    args: { dryRun?: boolean; confirm?: string; maxPackages?: number },
+  ) => Promise<unknown>;
 };
 
 type CatalogMetadataCanonicalizationWrappedHandler = {
@@ -35,6 +43,7 @@ const skillId = testId("skills", "skills:demo");
 const ownerUserId = testId("users", "users:owner");
 const publisherId = testId("publishers", "publishers:owner");
 const digestId = testId("skillSearchDigest", "skillSearchDigest:demo");
+const packageReleaseId = testId("packageReleases", "packageReleases:demo");
 
 function makeSkillDoc(): Doc<"skills"> {
   return {
@@ -693,5 +702,109 @@ describe("skill install backfill migration", () => {
         }),
       }),
     );
+  });
+});
+
+describe("plugin manifest summary backfill migration", () => {
+  it("dry-runs latest active plugin release summary backfill by default", async () => {
+    const runQuery = vi.fn().mockResolvedValue({
+      page: [],
+      isDone: true,
+      continueCursor: "",
+    });
+    const handler = (
+      runPluginManifestSummaryBackfill as unknown as PluginManifestSummaryBackfillWrappedHandler
+    )._handler;
+
+    const result = await handler({ runQuery, runMutation: vi.fn(), storage: {} }, {});
+
+    expect(runQuery).toHaveBeenCalledWith(expect.anything(), {
+      family: "code-plugin",
+      cursor: null,
+      limit: 50,
+    });
+    expect(runQuery).toHaveBeenCalledWith(expect.anything(), {
+      family: "bundle-plugin",
+      cursor: null,
+      limit: 50,
+    });
+    expect(result).toMatchObject({
+      ok: true,
+      dryRun: true,
+      confirmRequired: "backfill-plugin-manifest-summaries",
+      scannedPackages: 0,
+      eligibleReleases: 0,
+      changedReleases: 0,
+      patchedReleases: 0,
+    });
+  });
+
+  it("requires explicit confirmation before applying plugin manifest summary backfill", async () => {
+    const handler = (
+      runPluginManifestSummaryBackfill as unknown as PluginManifestSummaryBackfillWrappedHandler
+    )._handler;
+
+    await expect(
+      handler({ runQuery: vi.fn(), runMutation: vi.fn(), storage: {} }, { dryRun: false }),
+    ).rejects.toThrow('Pass confirm="backfill-plugin-manifest-summaries" to apply.');
+  });
+
+  it("skips applying a degraded summary when skill markdown cannot be read", async () => {
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce({
+        page: [
+          {
+            packageName: "example-ai-plugin",
+            displayName: "Example AI Plugin",
+            release: {
+              _id: packageReleaseId,
+              version: "1.0.0",
+              files: [
+                {
+                  path: "skills/research/SKILL.md",
+                  storageId: "storage:missing",
+                  size: 128,
+                  sha256: "a".repeat(64),
+                },
+              ],
+              extractedPluginManifest: {
+                skills: ["skills/research"],
+              },
+            },
+          },
+        ],
+        isDone: true,
+        continueCursor: "",
+      })
+      .mockResolvedValue({
+        page: [],
+        isDone: true,
+        continueCursor: "",
+      });
+    const runMutation = vi.fn();
+    const handler = (
+      runPluginManifestSummaryBackfill as unknown as PluginManifestSummaryBackfillWrappedHandler
+    )._handler;
+
+    const result = await handler(
+      {
+        runQuery,
+        runMutation,
+        storage: { get: vi.fn(async () => null) },
+      },
+      { dryRun: false, confirm: "backfill-plugin-manifest-summaries" },
+    );
+
+    expect(runMutation).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      ok: true,
+      dryRun: false,
+      eligibleReleases: 1,
+      changedReleases: 0,
+      patchedReleases: 0,
+      skippedSkillMarkdownReadErrorReleases: 1,
+      skillMarkdownReadErrors: 1,
+    });
   });
 });

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -7,9 +7,10 @@ import {
 import { ConvexError, v } from "convex/values";
 import { components, internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
-import type { MutationCtx } from "./_generated/server";
-import { internalAction } from "./_generated/server";
+import type { ActionCtx, MutationCtx } from "./_generated/server";
+import { internalAction, internalMutation, internalQuery } from "./_generated/server";
 import { syncPackageSearchDigestForPackageId } from "./functions";
+import { derivePluginManifestSummary } from "./lib/packageRegistry";
 import { adjustPublisherStatsForSkillChange } from "./lib/publisherStats";
 import {
   buildSkillInstallBackfillPatch,
@@ -22,8 +23,12 @@ import schema from "./schema";
 
 const CANONICALIZE_CATALOG_METADATA_CONFIRM = "canonicalize-catalog-metadata";
 const APPLY_SKILL_INSTALL_BACKFILL_CONFIRM = "apply-skill-install-backfill";
+const BACKFILL_PLUGIN_MANIFEST_SUMMARIES_CONFIRM = "backfill-plugin-manifest-summaries";
 const SKILL_STAT_EVENTS_CURSOR_KEY = "skill_stat_events";
 const MAX_PENDING_SKILL_STAT_EVENTS_PER_SKILL = 1_000;
+const PLUGIN_PACKAGE_FAMILIES = ["code-plugin", "bundle-plugin"] as const;
+const PLUGIN_MANIFEST_SUMMARY_BACKFILL_PAGE_SIZE = 50;
+const PLUGIN_MANIFEST_SUMMARY_BACKFILL_MAX_PACKAGES = 5_000;
 
 export const migrations = new Migrations(components.migrations, {
   schema,
@@ -314,6 +319,340 @@ export const backfillSkillInstallEstimates = migrations.define({
   batchSize: 10,
   migrateOne: async (ctx, skill) => {
     await backfillOneSkillInstallEstimate(ctx, skill);
+  },
+});
+
+type PluginPackageFamily = (typeof PLUGIN_PACKAGE_FAMILIES)[number];
+
+type LatestPluginManifestSummaryCandidate = {
+  packageName: string;
+  displayName: string;
+  release: Doc<"packageReleases"> | null;
+};
+
+type LatestPluginManifestSummaryCandidatePage = {
+  page: LatestPluginManifestSummaryCandidate[];
+  isDone: boolean;
+  continueCursor: string;
+};
+
+type PluginManifestSummaryBackfillSample = {
+  packageName: string;
+  displayName: string;
+  version: string;
+  releaseId: Id<"packageReleases">;
+  configFieldCount: number;
+  mcpServerCount: number;
+  bundledSkillCount: number;
+};
+
+type PluginManifestSummaryBackfillResult = {
+  ok: true;
+  dryRun: boolean;
+  confirmRequired?: string;
+  scannedPackages: number;
+  eligibleReleases: number;
+  changedReleases: number;
+  patchedReleases: number;
+  unchangedReleases: number;
+  skippedMissingRelease: number;
+  skippedMissingManifest: number;
+  skippedSkillMarkdownReadErrorReleases: number;
+  skillMarkdownReadErrors: number;
+  samples: PluginManifestSummaryBackfillSample[];
+};
+
+function isJsonRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isSkillMarkdownPath(path: string) {
+  const lowerPath = path.toLowerCase();
+  return lowerPath === "skill.md" || lowerPath.endsWith("/skill.md");
+}
+
+async function readStorageText(ctx: Pick<ActionCtx, "storage">, storageId: string) {
+  const blob = await ctx.storage.get(storageId as never);
+  if (!blob) throw new ConvexError("Uploaded file no longer exists");
+  return await blob.text();
+}
+
+async function withSkillMarkdownTextsForPluginManifestSummaryBackfill(
+  ctx: Pick<ActionCtx, "storage">,
+  files: Doc<"packageReleases">["files"],
+) {
+  let readErrors = 0;
+  const nextFiles = await Promise.all(
+    files.map(async (file) => {
+      if (!isSkillMarkdownPath(file.path)) return file;
+      try {
+        return {
+          ...file,
+          text: await readStorageText(ctx, file.storageId),
+        };
+      } catch {
+        readErrors += 1;
+        return file;
+      }
+    }),
+  );
+  return { files: nextFiles, readErrors };
+}
+
+function hasSamePluginManifestSummary(
+  release: Doc<"packageReleases">,
+  pluginManifestSummary: unknown,
+) {
+  return (
+    JSON.stringify(release.pluginManifestSummary ?? null) === JSON.stringify(pluginManifestSummary)
+  );
+}
+
+export const listLatestPluginManifestSummaryBackfillCandidates = internalQuery({
+  args: {
+    family: v.union(v.literal("code-plugin"), v.literal("bundle-plugin")),
+    cursor: v.union(v.string(), v.null()),
+    limit: v.number(),
+  },
+  returns: v.object({
+    page: v.array(
+      v.object({
+        packageName: v.string(),
+        displayName: v.string(),
+        release: v.union(v.any(), v.null()),
+      }),
+    ),
+    isDone: v.boolean(),
+    continueCursor: v.string(),
+  }),
+  handler: async (ctx, args) => {
+    const numItems = Math.max(1, Math.min(100, Math.floor(args.limit)));
+    const page = await ctx.db
+      .query("packages")
+      .withIndex("by_active_family_recommended_score", (q) =>
+        q.eq("softDeletedAt", undefined).eq("family", args.family),
+      )
+      .paginate({ cursor: args.cursor, numItems });
+    const candidates = await Promise.all(
+      page.page.map(async (pkg) => ({
+        packageName: pkg.normalizedName,
+        displayName: pkg.displayName,
+        release: pkg.latestReleaseId ? await ctx.db.get(pkg.latestReleaseId) : null,
+      })),
+    );
+    return {
+      page: candidates,
+      isDone: page.isDone,
+      continueCursor: page.continueCursor,
+    };
+  },
+});
+
+export const applyPluginManifestSummaryBackfillPatch = internalMutation({
+  args: {
+    releaseId: v.id("packageReleases"),
+    pluginManifestSummary: v.any(),
+  },
+  returns: v.boolean(),
+  handler: async (ctx, args) => {
+    const release = await ctx.db.get(args.releaseId);
+    if (!release || release.softDeletedAt !== undefined) return false;
+    await ctx.db.patch(args.releaseId, {
+      pluginManifestSummary: args.pluginManifestSummary,
+    });
+    return true;
+  },
+});
+
+async function backfillLatestPluginManifestSummariesForFamily(
+  ctx: Pick<ActionCtx, "runMutation" | "runQuery" | "storage">,
+  family: PluginPackageFamily,
+  dryRun: boolean,
+  maxPackages: number,
+) {
+  let cursor: string | null = null;
+  let scannedPackages = 0;
+  let eligibleReleases = 0;
+  let changedReleases = 0;
+  let patchedReleases = 0;
+  let unchangedReleases = 0;
+  let skippedMissingRelease = 0;
+  let skippedMissingManifest = 0;
+  let skippedSkillMarkdownReadErrorReleases = 0;
+  let skillMarkdownReadErrors = 0;
+  const samples: PluginManifestSummaryBackfillSample[] = [];
+
+  while (scannedPackages < maxPackages) {
+    const page: LatestPluginManifestSummaryCandidatePage = await ctx.runQuery(
+      internal.migrations.listLatestPluginManifestSummaryBackfillCandidates,
+      {
+        family,
+        cursor,
+        limit: Math.min(PLUGIN_MANIFEST_SUMMARY_BACKFILL_PAGE_SIZE, maxPackages - scannedPackages),
+      },
+    );
+
+    for (const candidate of page.page) {
+      scannedPackages += 1;
+      if (!candidate.release || candidate.release.softDeletedAt !== undefined) {
+        skippedMissingRelease += 1;
+        continue;
+      }
+
+      const pluginManifest = candidate.release.extractedPluginManifest;
+      if (!isJsonRecord(pluginManifest)) {
+        skippedMissingManifest += 1;
+        continue;
+      }
+
+      eligibleReleases += 1;
+      const filesResult = await withSkillMarkdownTextsForPluginManifestSummaryBackfill(
+        ctx,
+        candidate.release.files,
+      );
+      skillMarkdownReadErrors += filesResult.readErrors;
+      if (filesResult.readErrors > 0) {
+        skippedSkillMarkdownReadErrorReleases += 1;
+        continue;
+      }
+      const summary = derivePluginManifestSummary({
+        pluginManifest,
+        ...(isJsonRecord(candidate.release.normalizedBundleManifest)
+          ? { skillManifest: candidate.release.normalizedBundleManifest }
+          : {}),
+        compatibility: candidate.release.compatibility,
+        files: filesResult.files,
+      });
+      if (hasSamePluginManifestSummary(candidate.release, summary)) {
+        unchangedReleases += 1;
+        continue;
+      }
+
+      changedReleases += 1;
+      if (!dryRun) {
+        const patched: boolean = await ctx.runMutation(
+          internal.migrations.applyPluginManifestSummaryBackfillPatch,
+          {
+            releaseId: candidate.release._id,
+            pluginManifestSummary: summary,
+          },
+        );
+        if (patched) patchedReleases += 1;
+      }
+      if (samples.length < 10) {
+        samples.push({
+          packageName: candidate.packageName,
+          displayName: candidate.displayName,
+          version: candidate.release.version,
+          releaseId: candidate.release._id,
+          configFieldCount: summary.configFields.length,
+          mcpServerCount: summary.mcpServers.length,
+          bundledSkillCount: summary.bundledSkills.length,
+        });
+      }
+    }
+
+    if (page.isDone || scannedPackages >= maxPackages) break;
+    cursor = page.continueCursor;
+  }
+
+  return {
+    scannedPackages,
+    eligibleReleases,
+    changedReleases,
+    patchedReleases,
+    unchangedReleases,
+    skippedMissingRelease,
+    skippedMissingManifest,
+    skippedSkillMarkdownReadErrorReleases,
+    skillMarkdownReadErrors,
+    samples,
+  };
+}
+
+export const runPluginManifestSummaryBackfill = internalAction({
+  args: {
+    dryRun: v.optional(v.boolean()),
+    confirm: v.optional(v.string()),
+    maxPackages: v.optional(v.number()),
+  },
+  returns: v.object({
+    ok: v.literal(true),
+    dryRun: v.boolean(),
+    confirmRequired: v.optional(v.string()),
+    scannedPackages: v.number(),
+    eligibleReleases: v.number(),
+    changedReleases: v.number(),
+    patchedReleases: v.number(),
+    unchangedReleases: v.number(),
+    skippedMissingRelease: v.number(),
+    skippedMissingManifest: v.number(),
+    skippedSkillMarkdownReadErrorReleases: v.number(),
+    skillMarkdownReadErrors: v.number(),
+    samples: v.array(
+      v.object({
+        packageName: v.string(),
+        displayName: v.string(),
+        version: v.string(),
+        releaseId: v.id("packageReleases"),
+        configFieldCount: v.number(),
+        mcpServerCount: v.number(),
+        bundledSkillCount: v.number(),
+      }),
+    ),
+  }),
+  handler: async (ctx, args): Promise<PluginManifestSummaryBackfillResult> => {
+    const dryRun = args.dryRun !== false;
+    if (!dryRun && args.confirm !== BACKFILL_PLUGIN_MANIFEST_SUMMARIES_CONFIRM) {
+      throw new ConvexError(
+        `Pass confirm="${BACKFILL_PLUGIN_MANIFEST_SUMMARIES_CONFIRM}" to apply.`,
+      );
+    }
+
+    const maxPackages = Math.max(
+      1,
+      Math.min(
+        PLUGIN_MANIFEST_SUMMARY_BACKFILL_MAX_PACKAGES,
+        Math.floor(args.maxPackages ?? PLUGIN_MANIFEST_SUMMARY_BACKFILL_MAX_PACKAGES),
+      ),
+    );
+    const totals: PluginManifestSummaryBackfillResult = {
+      ok: true,
+      dryRun,
+      confirmRequired: dryRun ? BACKFILL_PLUGIN_MANIFEST_SUMMARIES_CONFIRM : undefined,
+      scannedPackages: 0,
+      eligibleReleases: 0,
+      changedReleases: 0,
+      patchedReleases: 0,
+      unchangedReleases: 0,
+      skippedMissingRelease: 0,
+      skippedMissingManifest: 0,
+      skippedSkillMarkdownReadErrorReleases: 0,
+      skillMarkdownReadErrors: 0,
+      samples: [],
+    };
+
+    for (const family of PLUGIN_PACKAGE_FAMILIES) {
+      const result = await backfillLatestPluginManifestSummariesForFamily(
+        ctx,
+        family,
+        dryRun,
+        maxPackages - totals.scannedPackages,
+      );
+      totals.scannedPackages += result.scannedPackages;
+      totals.eligibleReleases += result.eligibleReleases;
+      totals.changedReleases += result.changedReleases;
+      totals.patchedReleases += result.patchedReleases;
+      totals.unchangedReleases += result.unchangedReleases;
+      totals.skippedMissingRelease += result.skippedMissingRelease;
+      totals.skippedMissingManifest += result.skippedMissingManifest;
+      totals.skippedSkillMarkdownReadErrorReleases += result.skippedSkillMarkdownReadErrorReleases;
+      totals.skillMarkdownReadErrors += result.skillMarkdownReadErrors;
+      totals.samples.push(...result.samples.slice(0, 10 - totals.samples.length));
+      if (totals.scannedPackages >= maxPackages) break;
+    }
+
+    return totals;
   },
 });
 


### PR DESCRIPTION
## Summary
- Derive bundled skills from directory-style manifest roots such as `./skills/` by scanning nested `SKILL.md` files.
- Add a dry-run-first Convex backfill for plugin package latest active releases only.
- Skip releases with unreadable `SKILL.md` blobs so the backfill cannot overwrite richer existing summaries with degraded metadata.

## Proof
- `bunx vitest run convex/lib/packageRegistry.test.ts convex/migrations.test.ts src/lib/packageApi.test.ts src/__tests__/package-detail-route.test.tsx` — passed, 96 tests.
- `bun run ci:static` — passed.
- `bun run ci:unit` — passed, 280 files, 3597 tests.
- `bun run ci:types-build` — passed.
- `bun run ci:packages` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean after fixes.

## Notes
- Production apply requires `confirm="backfill-plugin-manifest-summaries"`.
- Backfill scope is active plugin packages' latest active release only.
