### PR TITLE
fix: harden plugin manifest backfill

### DIFF
--- a/convex/lib/packageRegistry.test.ts
+++ b/convex/lib/packageRegistry.test.ts
@@ -241,6 +241,66 @@ describe("packageRegistry", () => {
     ]);
   });
 
+  it("derives config fields from direct plugin config maps", () => {
+    const summary = derivePluginManifestSummary({
+      pluginManifest: {
+        name: "example-ai-plugin",
+        configSchema: {
+          EXAMPLE_DATABASE_URL: {
+            type: "string",
+            required: true,
+            description: "Database connection URL.",
+            uiHints: { sensitive: true },
+          },
+          EXAMPLE_MODEL: {
+            type: "string",
+            required: false,
+            description: "Optional model override.",
+          },
+        },
+      },
+      files: [],
+    });
+
+    expect(summary.configFields).toEqual([
+      {
+        name: "EXAMPLE_DATABASE_URL",
+        description: "Database connection URL.",
+        required: true,
+        sensitive: true,
+      },
+      {
+        name: "EXAMPLE_MODEL",
+        description: "Optional model override.",
+        required: false,
+        sensitive: false,
+      },
+    ]);
+  });
+
+  it("does not treat JSON Schema metadata as direct config fields", () => {
+    const summary = derivePluginManifestSummary({
+      pluginManifest: {
+        name: "example-ai-plugin",
+        configSchema: {
+          type: "object",
+          $defs: {
+            sharedSecret: {
+              type: "string",
+              description: "Reusable schema, not a top-level config field.",
+            },
+          },
+          patternProperties: {
+            "^EXAMPLE_": { type: "string" },
+          },
+        },
+      },
+      files: [],
+    });
+
+    expect(summary.configFields).toEqual([]);
+  });
+
   it("derives bundled skills from directory-style skill manifest roots", () => {
     const summary = derivePluginManifestSummary({
       pluginManifest: {

--- a/convex/lib/packageRegistry.ts
+++ b/convex/lib/packageRegistry.ts
@@ -179,10 +179,42 @@ function isSensitiveConfigProperty(name: string, property: JsonRecord) {
   if (property.sensitive === true || property.secret === true || property["x-sensitive"] === true) {
     return true;
   }
+  if (isRecord(property.uiHints) && property.uiHints.sensitive === true) {
+    return true;
+  }
   const loweredName = name.toLowerCase();
   if (/(secret|token|api[_-]?key|password|credential)/.test(loweredName)) return true;
   const format = optionalString(property.format)?.toLowerCase();
   return format === "password" || format === "secret";
+}
+
+const CONFIG_SCHEMA_META_KEYS = new Set([
+  "$schema",
+  "$defs",
+  "additionalProperties",
+  "definitions",
+  "description",
+  "dependentSchemas",
+  "patternProperties",
+  "properties",
+  "required",
+  "title",
+  "type",
+  "uiHints",
+]);
+
+function isLikelyDirectConfigFieldProperty(value: JsonRecord) {
+  return (
+    optionalString(value.type) !== undefined ||
+    optionalString(value.description) !== undefined ||
+    optionalString(value.format) !== undefined ||
+    value.required === true ||
+    value.required === false ||
+    value.sensitive === true ||
+    value.secret === true ||
+    value["x-sensitive"] === true ||
+    isRecord(value.uiHints)
+  );
 }
 
 function extractConfigFields(manifest: JsonRecord) {
@@ -194,7 +226,22 @@ function extractConfigFields(manifest: JsonRecord) {
       : undefined;
   if (!schema) return [];
   const required = new Set(normalizeStringList(schema.required));
-  const properties = isRecord(schema.properties) ? schema.properties : {};
+  const shouldReadDirectMap =
+    !isRecord(schema.properties) &&
+    optionalString(schema.type) === undefined &&
+    optionalString(schema["$schema"]) === undefined;
+  const properties = isRecord(schema.properties)
+    ? schema.properties
+    : shouldReadDirectMap
+      ? Object.fromEntries(
+          Object.entries(schema).filter(
+            ([name, value]) =>
+              !CONFIG_SCHEMA_META_KEYS.has(name) &&
+              isRecord(value) &&
+              isLikelyDirectConfigFieldProperty(value),
+          ),
+        )
+      : {};
   return Object.entries(properties)
     .filter((entry): entry is [string, JsonRecord] => isRecord(entry[1]))
     .map(([name, property]) => ({
@@ -202,7 +249,7 @@ function extractConfigFields(manifest: JsonRecord) {
       ...(optionalString(property.description)
         ? { description: optionalString(property.description) }
         : {}),
-      required: required.has(name),
+      required: required.has(name) || property.required === true,
       sensitive: isSensitiveConfigProperty(name, property),
     }));
 }

--- a/convex/migrations.test.ts
+++ b/convex/migrations.test.ts
@@ -11,6 +11,7 @@ import {
   buildCanonicalCatalogMetadataPatch,
   runCatalogMetadataCanonicalization,
   runPluginManifestSummaryBackfill,
+  runPluginManifestSummaryBackfillPage,
   runSkillInstallBackfill,
 } from "./migrations";
 
@@ -22,6 +23,19 @@ type PluginManifestSummaryBackfillWrappedHandler = {
   _handler: (
     ctx: unknown,
     args: { dryRun?: boolean; confirm?: string; maxPackages?: number },
+  ) => Promise<unknown>;
+};
+
+type PluginManifestSummaryBackfillPageWrappedHandler = {
+  _handler: (
+    ctx: unknown,
+    args: {
+      family: "code-plugin" | "bundle-plugin";
+      cursor?: string | null;
+      limit?: number;
+      dryRun?: boolean;
+      confirm?: string;
+    },
   ) => Promise<unknown>;
 };
 
@@ -747,6 +761,89 @@ describe("plugin manifest summary backfill migration", () => {
     await expect(
       handler({ runQuery: vi.fn(), runMutation: vi.fn(), storage: {} }, { dryRun: false }),
     ).rejects.toThrow('Pass confirm="backfill-plugin-manifest-summaries" to apply.');
+  });
+
+  it("applies one cursor page for a single plugin family", async () => {
+    const runQuery = vi.fn().mockResolvedValueOnce({
+      page: [
+        {
+          packageName: "example-ai-plugin",
+          displayName: "Example AI Plugin",
+          release: {
+            _id: packageReleaseId,
+            version: "1.0.0",
+            files: [],
+            compatibility: { builtWithOpenClawVersion: "1.0.0" },
+            extractedPluginManifest: {
+              configSchema: {
+                EXAMPLE_DATABASE_URL: {
+                  type: "string",
+                  required: true,
+                  uiHints: { sensitive: true },
+                },
+              },
+              mcpServers: {
+                exampleMcp: {
+                  command: "node",
+                  args: ["server.js"],
+                },
+              },
+            },
+          },
+        },
+      ],
+      isDone: false,
+      continueCursor: "next-page",
+    });
+    const runMutation = vi.fn().mockResolvedValue(true);
+    const handler = (
+      runPluginManifestSummaryBackfillPage as unknown as PluginManifestSummaryBackfillPageWrappedHandler
+    )._handler;
+
+    const result = await handler(
+      { runQuery, runMutation, storage: {} },
+      {
+        family: "bundle-plugin",
+        cursor: "current-page",
+        limit: 25,
+        dryRun: false,
+        confirm: "backfill-plugin-manifest-summaries",
+      },
+    );
+
+    expect(runQuery).toHaveBeenCalledWith(expect.anything(), {
+      family: "bundle-plugin",
+      cursor: "current-page",
+      limit: 25,
+    });
+    expect(runMutation).toHaveBeenCalledWith(expect.anything(), {
+      releaseId: packageReleaseId,
+      pluginManifestSummary: expect.objectContaining({
+        configFields: [
+          {
+            name: "EXAMPLE_DATABASE_URL",
+            required: true,
+            sensitive: true,
+          },
+        ],
+        mcpServers: [{ name: "exampleMcp" }],
+      }),
+    });
+    expect(JSON.stringify(runMutation.mock.calls[0]?.[1]?.pluginManifestSummary)).not.toContain(
+      "server.js",
+    );
+    expect(result).toMatchObject({
+      ok: true,
+      dryRun: false,
+      family: "bundle-plugin",
+      continueCursor: "next-page",
+      isDone: false,
+      scannedPackages: 1,
+      eligibleReleases: 1,
+      changedReleases: 1,
+      patchedReleases: 1,
+      skillMarkdownReadErrors: 0,
+    });
   });
 
   it("skips applying a degraded summary when skill markdown cannot be read", async () => {

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -29,6 +29,7 @@ const MAX_PENDING_SKILL_STAT_EVENTS_PER_SKILL = 1_000;
 const PLUGIN_PACKAGE_FAMILIES = ["code-plugin", "bundle-plugin"] as const;
 const PLUGIN_MANIFEST_SUMMARY_BACKFILL_PAGE_SIZE = 50;
 const PLUGIN_MANIFEST_SUMMARY_BACKFILL_MAX_PACKAGES = 5_000;
+const pluginPackageFamilyValidator = v.union(v.literal("code-plugin"), v.literal("bundle-plugin"));
 
 export const migrations = new Migrations(components.migrations, {
   schema,
@@ -653,6 +654,157 @@ export const runPluginManifestSummaryBackfill = internalAction({
     }
 
     return totals;
+  },
+});
+
+export const runPluginManifestSummaryBackfillPage = internalAction({
+  args: {
+    family: pluginPackageFamilyValidator,
+    cursor: v.optional(v.union(v.string(), v.null())),
+    limit: v.optional(v.number()),
+    dryRun: v.optional(v.boolean()),
+    confirm: v.optional(v.string()),
+  },
+  returns: v.object({
+    ok: v.literal(true),
+    dryRun: v.boolean(),
+    confirmRequired: v.optional(v.string()),
+    family: pluginPackageFamilyValidator,
+    continueCursor: v.string(),
+    isDone: v.boolean(),
+    scannedPackages: v.number(),
+    eligibleReleases: v.number(),
+    changedReleases: v.number(),
+    patchedReleases: v.number(),
+    unchangedReleases: v.number(),
+    skippedMissingRelease: v.number(),
+    skippedMissingManifest: v.number(),
+    skippedSkillMarkdownReadErrorReleases: v.number(),
+    skillMarkdownReadErrors: v.number(),
+    samples: v.array(
+      v.object({
+        packageName: v.string(),
+        displayName: v.string(),
+        version: v.string(),
+        releaseId: v.id("packageReleases"),
+        configFieldCount: v.number(),
+        mcpServerCount: v.number(),
+        bundledSkillCount: v.number(),
+      }),
+    ),
+  }),
+  handler: async (ctx, args) => {
+    const dryRun = args.dryRun !== false;
+    if (!dryRun && args.confirm !== BACKFILL_PLUGIN_MANIFEST_SUMMARIES_CONFIRM) {
+      throw new ConvexError(
+        `Pass confirm="${BACKFILL_PLUGIN_MANIFEST_SUMMARIES_CONFIRM}" to apply.`,
+      );
+    }
+
+    const limit = Math.max(
+      1,
+      Math.min(
+        PLUGIN_MANIFEST_SUMMARY_BACKFILL_PAGE_SIZE,
+        Math.floor(args.limit ?? PLUGIN_MANIFEST_SUMMARY_BACKFILL_PAGE_SIZE),
+      ),
+    );
+    const page: LatestPluginManifestSummaryCandidatePage = await ctx.runQuery(
+      internal.migrations.listLatestPluginManifestSummaryBackfillCandidates,
+      {
+        family: args.family,
+        cursor: args.cursor ?? null,
+        limit,
+      },
+    );
+
+    let eligibleReleases = 0;
+    let changedReleases = 0;
+    let patchedReleases = 0;
+    let unchangedReleases = 0;
+    let skippedMissingRelease = 0;
+    let skippedMissingManifest = 0;
+    let skippedSkillMarkdownReadErrorReleases = 0;
+    let skillMarkdownReadErrors = 0;
+    const samples: PluginManifestSummaryBackfillSample[] = [];
+
+    for (const candidate of page.page) {
+      if (!candidate.release || candidate.release.softDeletedAt !== undefined) {
+        skippedMissingRelease += 1;
+        continue;
+      }
+
+      const pluginManifest = candidate.release.extractedPluginManifest;
+      if (!isJsonRecord(pluginManifest)) {
+        skippedMissingManifest += 1;
+        continue;
+      }
+
+      eligibleReleases += 1;
+      const filesResult = await withSkillMarkdownTextsForPluginManifestSummaryBackfill(
+        ctx,
+        candidate.release.files,
+      );
+      skillMarkdownReadErrors += filesResult.readErrors;
+      if (filesResult.readErrors > 0) {
+        skippedSkillMarkdownReadErrorReleases += 1;
+        continue;
+      }
+
+      const summary = derivePluginManifestSummary({
+        pluginManifest,
+        ...(isJsonRecord(candidate.release.normalizedBundleManifest)
+          ? { skillManifest: candidate.release.normalizedBundleManifest }
+          : {}),
+        compatibility: candidate.release.compatibility,
+        files: filesResult.files,
+      });
+      if (hasSamePluginManifestSummary(candidate.release, summary)) {
+        unchangedReleases += 1;
+        continue;
+      }
+
+      changedReleases += 1;
+      if (!dryRun) {
+        const patched: boolean = await ctx.runMutation(
+          internal.migrations.applyPluginManifestSummaryBackfillPatch,
+          {
+            releaseId: candidate.release._id,
+            pluginManifestSummary: summary,
+          },
+        );
+        if (patched) patchedReleases += 1;
+      }
+      if (samples.length < 10) {
+        samples.push({
+          packageName: candidate.packageName,
+          displayName: candidate.displayName,
+          version: candidate.release.version,
+          releaseId: candidate.release._id,
+          configFieldCount: summary.configFields.length,
+          mcpServerCount: summary.mcpServers.length,
+          bundledSkillCount: summary.bundledSkills.length,
+        });
+      }
+    }
+
+    return {
+      ok: true as const,
+      dryRun,
+      confirmRequired: dryRun ? BACKFILL_PLUGIN_MANIFEST_SUMMARIES_CONFIRM : undefined,
+      family: args.family,
+      continueCursor: page.continueCursor,
+      isDone: page.isDone,
+      scannedPackages: page.page.length,
+      eligibleReleases,
+      changedReleases,
+      patchedReleases,
+      unchangedReleases,
+      skippedMissingRelease,
+      skippedMissingManifest,
+      skippedSkillMarkdownReadErrorReleases,
+      skillMarkdownReadErrors,
+      samples,
+    };
   },
 });
 


### PR DESCRIPTION
## Summary
- support direct plugin config-map manifests when deriving `pluginManifestSummary.configFields`
- preserve `uiHints.sensitive` while continuing to omit MCP launch details
- add a cursor-based `runPluginManifestSummaryBackfillPage` action for production-safe batched backfills

## Proof
- `bunx vitest run convex/lib/packageRegistry.test.ts convex/migrations.test.ts` passed
- `bunx convex codegen` passed
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean
- `bun run ci:static` passed
- `bun run ci:types-build` passed
- Live fixture derivation for a plugin with direct config-map fields returned `configFieldCount: 2`, `mcpServerCount: 1`, `bundledSkillCount: 7`

## Notes
- This is a follow-up hardening patch for the latest-active-release manifest-summary backfill.
- Production frontend deployment for the previous merge is currently blocked by a stale/pending Vercel commit status, so user-visible production page proof is not included here.
