### PR TITLE
fix: backfill stored plugin manifests

### DIFF
--- a/convex/migrations.test.ts
+++ b/convex/migrations.test.ts
@@ -846,6 +846,107 @@ describe("plugin manifest summary backfill migration", () => {
     });
   });
 
+  it("derives a summary from stored openclaw.plugin.json when the extracted manifest is missing", async () => {
+    const storageGet = vi.fn(async () => {
+      return new Blob([
+        JSON.stringify({
+          configSchema: {
+            EXAMPLE_PLUGIN_API_KEY: {
+              type: "string",
+              description: "API key used to connect to the example service.",
+              required: true,
+              uiHints: { sensitive: true },
+            },
+          },
+          mcpServers: {
+            exampleMcp: {
+              command: "node",
+              args: ["server.js"],
+            },
+          },
+          skills: ["skills/research"],
+          compat: {
+            pluginApi: "^2.0.0",
+          },
+        }),
+      ]);
+    });
+    const runQuery = vi.fn().mockResolvedValueOnce({
+      page: [
+        {
+          packageName: "example-ai-plugin",
+          displayName: "Example AI Plugin",
+          release: {
+            _id: packageReleaseId,
+            version: "1.0.0",
+            files: [
+              {
+                path: "openclaw.plugin.json",
+                storageId: "storage:manifest",
+                size: 512,
+                sha256: "a".repeat(64),
+              },
+              {
+                path: "skills/research/SKILL.md",
+                storageId: "storage:skill",
+                size: 128,
+                sha256: "b".repeat(64),
+              },
+            ],
+            compatibility: { builtWithOpenClawVersion: "1.0.0" },
+            extractedPluginManifest: null,
+          },
+        },
+      ],
+      isDone: true,
+      continueCursor: "",
+    });
+    const runMutation = vi.fn().mockResolvedValue(true);
+    const handler = (
+      runPluginManifestSummaryBackfillPage as unknown as PluginManifestSummaryBackfillPageWrappedHandler
+    )._handler;
+
+    const result = await handler(
+      {
+        runQuery,
+        runMutation,
+        storage: { get: storageGet },
+      },
+      {
+        family: "bundle-plugin",
+        dryRun: false,
+        confirm: "backfill-plugin-manifest-summaries",
+      },
+    );
+
+    expect(storageGet).toHaveBeenCalledWith("storage:manifest");
+    const mutationArgs = runMutation.mock.calls[0]?.[1];
+    expect(mutationArgs?.releaseId).toBe(packageReleaseId);
+    expect(mutationArgs?.pluginManifestSummary).toMatchObject({
+      configFields: [
+        {
+          name: "EXAMPLE_PLUGIN_API_KEY",
+          description: "API key used to connect to the example service.",
+          required: true,
+          sensitive: true,
+        },
+      ],
+      mcpServers: [{ name: "exampleMcp" }],
+      bundledSkills: [expect.objectContaining({ rootPath: "skills/research" })],
+      compatibility: expect.objectContaining({ builtWithOpenClawVersion: "1.0.0" }),
+    });
+    expect(JSON.stringify(mutationArgs?.pluginManifestSummary)).not.toContain("server.js");
+    expect(result).toMatchObject({
+      ok: true,
+      dryRun: false,
+      eligibleReleases: 1,
+      changedReleases: 1,
+      patchedReleases: 1,
+      skippedMissingManifest: 0,
+      skillMarkdownReadErrors: 0,
+    });
+  });
+
   it("skips applying a degraded summary when skill markdown cannot be read", async () => {
     const runQuery = vi
       .fn()

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -372,10 +372,37 @@ function isSkillMarkdownPath(path: string) {
   return lowerPath === "skill.md" || lowerPath.endsWith("/skill.md");
 }
 
+function isPluginManifestPath(path: string) {
+  return path.toLowerCase() === "openclaw.plugin.json";
+}
+
 async function readStorageText(ctx: Pick<ActionCtx, "storage">, storageId: string) {
   const blob = await ctx.storage.get(storageId as never);
   if (!blob) throw new ConvexError("Uploaded file no longer exists");
   return await blob.text();
+}
+
+async function readStoredPluginManifestForBackfill(
+  ctx: Pick<ActionCtx, "storage">,
+  files: Doc<"packageReleases">["files"],
+) {
+  const manifestFile = files.find((file) => isPluginManifestPath(file.path));
+  if (!manifestFile) return null;
+  try {
+    const text = await readStorageText(ctx, manifestFile.storageId);
+    const parsed: unknown = JSON.parse(text);
+    return isJsonRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolvePluginManifestForSummaryBackfill(
+  ctx: Pick<ActionCtx, "storage">,
+  release: Doc<"packageReleases">,
+) {
+  if (isJsonRecord(release.extractedPluginManifest)) return release.extractedPluginManifest;
+  return await readStoredPluginManifestForBackfill(ctx, release.files);
 }
 
 async function withSkillMarkdownTextsForPluginManifestSummaryBackfill(
@@ -500,7 +527,7 @@ async function backfillLatestPluginManifestSummariesForFamily(
         continue;
       }
 
-      const pluginManifest = candidate.release.extractedPluginManifest;
+      const pluginManifest = await resolvePluginManifestForSummaryBackfill(ctx, candidate.release);
       if (!isJsonRecord(pluginManifest)) {
         skippedMissingManifest += 1;
         continue;
@@ -733,7 +760,7 @@ export const runPluginManifestSummaryBackfillPage = internalAction({
         continue;
       }
 
-      const pluginManifest = candidate.release.extractedPluginManifest;
+      const pluginManifest = await resolvePluginManifestForSummaryBackfill(ctx, candidate.release);
       if (!isJsonRecord(pluginManifest)) {
         skippedMissingManifest += 1;
         continue;

--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -551,11 +551,13 @@ describe("plugin detail route", () => {
         "1.2.3",
       );
     });
-    expect(
-      screen.getAllByText((_content, element) =>
-        Boolean(element?.textContent?.includes("# Research")),
-      ).length,
-    ).toBeGreaterThan(0);
+    await waitFor(() => {
+      expect(
+        screen.getAllByText((_content, element) =>
+          Boolean(element?.textContent?.includes("# Research")),
+        ).length,
+      ).toBeGreaterThan(0);
+    });
   });
 
   it("keeps loaded releases and allows retry when loading more fails", async () => {


### PR DESCRIPTION
## Summary
- fall back to stored `openclaw.plugin.json` when latest active plugin releases are missing `extractedPluginManifest`
- keep MCP summary derivation name-only and preserve release compatibility as authoritative
- add a regression test for a stored manifest + bundled skill file backfill path

## Validation
- `bunx vitest run convex/migrations.test.ts convex/lib/packageRegistry.test.ts` - passed
- `bunx convex codegen` - passed
- `.agents/skills/autoreview/scripts/autoreview --mode local` - clean
- `bun run ci:static` - passed after formatting
- `bun run ci:types-build` - passed

## Production note
The first production backfill skipped the live gbrain release because its latest release has `openclaw.plugin.json` in file storage but no `extractedPluginManifest` field. This patch lets the backfill recover that summary from package file storage.
