### PR TITLE
perf: cache homepage listing tabs

### DIFF
--- a/src/__tests__/home-listing-section.test.tsx
+++ b/src/__tests__/home-listing-section.test.tsx
@@ -100,6 +100,44 @@ describe("HomeListingSection", () => {
     });
   });
 
+  it("renders the initial Skills Top listing without refetching on mount", async () => {
+    render(
+      <HomeListingSection
+        initialListing={{
+          kind: "skills",
+          tab: "popular",
+          categorySlugs: [],
+          fetchLimit: 20,
+          items: [
+            {
+              skill: {
+                _id: "skills:initial" as never,
+                slug: "initial-skill",
+                displayName: "Initial Skill",
+                summary: "Already loaded by the route.",
+                stats: {
+                  comments: 0,
+                  downloads: 0,
+                  installsAllTime: 42,
+                  stars: 0,
+                  versions: 1,
+                },
+              } as never,
+              ownerHandle: "builder",
+            },
+          ],
+          hasMore: true,
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Initial Skill")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Load more" })).toBeTruthy();
+    await waitFor(() => {
+      expect(convexQueryMock).not.toHaveBeenCalled();
+    });
+  });
+
   it("switches to plugins and loads plugin cards", async () => {
     render(<HomeListingSection />);
 
@@ -188,6 +226,42 @@ describe("HomeListingSection", () => {
         categorySlug: "development",
       });
       expect(screen.getByText("Dev Alpha")).toBeTruthy();
+    });
+  });
+
+  it("keeps listing search fetch-on-query instead of serving repeated queries from tab cache", async () => {
+    convexActionMock.mockResolvedValue([
+      {
+        skill: {
+          _id: "skills:alpha",
+          slug: "alpha-skill",
+          displayName: "Alpha Skill",
+          summary: "Alpha",
+          stats: { stars: 1, downloads: 1 },
+        },
+        ownerHandle: "builder",
+      },
+    ]);
+
+    render(<HomeListingSection />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Search catalog" }));
+    const searchInput = await screen.findByRole("searchbox", { name: "Search skills" });
+    fireEvent.change(searchInput, { target: { value: "alpha" } });
+
+    await waitFor(() => {
+      expect(convexActionMock).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.change(searchInput, { target: { value: "" } });
+    await waitFor(() => {
+      expect(screen.queryByText("Alpha Skill")).toBeNull();
+    });
+
+    fireEvent.change(searchInput, { target: { value: "alpha" } });
+
+    await waitFor(() => {
+      expect(convexActionMock).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -302,6 +376,64 @@ describe("HomeListingSection", () => {
     });
     expect(screen.queryByText("Popularity")).toBeNull();
     expect(screen.queryByText("999")).toBeNull();
+  });
+
+  it("reuses cached skill tabs instead of refetching when switching back", async () => {
+    convexQueryMock.mockImplementation((name) => {
+      if (name === "skills:listPublicTrendingPage") {
+        return Promise.resolve({
+          items: [
+            {
+              skill: {
+                _id: "skills:trending",
+                slug: "trending-skill",
+                displayName: "Trending Skill",
+                summary: "Hot this week.",
+                stats: { installsAllTime: 999 },
+              },
+              ownerHandle: "builder",
+            },
+          ],
+        });
+      }
+      return Promise.resolve({
+        page: [
+          {
+            skill: {
+              _id: "skills:top",
+              slug: "top-skill",
+              displayName: "Top Skill",
+              summary: "Popular.",
+              stats: { installsAllTime: 100 },
+            },
+            ownerHandle: "builder",
+          },
+        ],
+        hasMore: false,
+        nextCursor: null,
+      });
+    });
+
+    render(<HomeListingSection />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Top Skill")).toBeTruthy();
+    });
+    expect(convexQueryMock).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Trending" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Trending Skill")).toBeTruthy();
+    });
+    expect(convexQueryMock).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Top" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Top Skill")).toBeTruthy();
+    });
+    expect(convexQueryMock).toHaveBeenCalledTimes(2);
   });
 
   it("keeps pending and suspicious audits out of skill New", async () => {
@@ -479,6 +611,50 @@ describe("HomeListingSection", () => {
     expect(screen.queryByText("Community Plugin")).toBeNull();
     const latestRequest = fetchPluginCatalogMock.mock.calls.at(-1)?.[0] as Record<string, unknown>;
     expect(latestRequest).toEqual(expect.objectContaining({ isOfficial: true, limit: 20 }));
+  });
+
+  it("reuses cached plugin tabs instead of refetching when switching back", async () => {
+    fetchPluginCatalogMock.mockImplementation((args: { isOfficial?: boolean }) =>
+      Promise.resolve({
+        items: [
+          {
+            name: args.isOfficial ? "official-plugin" : "top-plugin",
+            displayName: args.isOfficial ? "Official Plugin" : "Top Plugin",
+            family: "code-plugin",
+            channel: args.isOfficial ? "official" : "community",
+            isOfficial: Boolean(args.isOfficial),
+            summary: "Cached plugin.",
+            createdAt: 1,
+            updatedAt: 2,
+            latestVersion: "1.0.0",
+            stats: { stars: 1, downloads: 2, installs: args.isOfficial ? 50 : 75, versions: 1 },
+          },
+        ],
+        nextCursor: null,
+      }),
+    );
+
+    render(<HomeListingSection />);
+    fireEvent.click(screen.getByRole("button", { name: "Plugins" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Official Plugin")).toBeTruthy();
+    });
+    expect(fetchPluginCatalogMock).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Top" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Top Plugin")).toBeTruthy();
+    });
+    expect(fetchPluginCatalogMock).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Official" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Official Plugin")).toBeTruthy();
+    });
+    expect(fetchPluginCatalogMock).toHaveBeenCalledTimes(2);
   });
 
   it("uses the skills cursor when loading beyond the first page", async () => {

--- a/src/__tests__/home-route.test.tsx
+++ b/src/__tests__/home-route.test.tsx
@@ -4,10 +4,36 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const initialListingFixture = {
+  kind: "skills",
+  tab: "popular",
+  categorySlugs: [],
+  fetchLimit: 20,
+  items: [
+    {
+      skill: {
+        _id: "skills:initial",
+        slug: "initial-skill",
+        displayName: "Initial Skill",
+        stats: { installsAllTime: 10 },
+      },
+      ownerHandle: "builder",
+    },
+  ],
+  hasMore: false,
+};
+
+const homeListingSectionMock = vi.fn();
+const fetchInitialHomeListingMock = vi.fn(() => Promise.resolve(initialListingFixture));
+
 vi.mock("@tanstack/react-router", () => ({
-  createFileRoute: () => (config: { component?: unknown }) => ({
-    __config: config,
-  }),
+  createFileRoute: () => (config: { component?: unknown }) => {
+    const route = {
+      __config: config,
+      useLoaderData: () => initialListingFixture,
+    };
+    return route;
+  },
   Link: ({ children, className, to }: { children: ReactNode; className?: string; to?: string }) => (
     <a className={className} href={to ?? "/"}>
       {children}
@@ -16,7 +42,14 @@ vi.mock("@tanstack/react-router", () => ({
 }));
 
 vi.mock("../components/HomeListingSection", () => ({
-  HomeListingSection: () => <section data-testid="home-listing-stub" />,
+  HomeListingSection: (props: unknown) => {
+    homeListingSectionMock(props);
+    return <section data-testid="home-listing-stub" />;
+  },
+}));
+
+vi.mock("../lib/homeListingData", () => ({
+  fetchInitialHomeListing: () => fetchInitialHomeListingMock(),
 }));
 
 vi.mock("../components/HomePopularPublishersSection", () => ({
@@ -36,6 +69,8 @@ describe("home route", () => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+    homeListingSectionMock.mockClear();
+    fetchInitialHomeListingMock.mockClear();
   });
 
   async function renderHome() {
@@ -44,6 +79,11 @@ describe("home route", () => {
       .__config.component;
 
     render(<Component />);
+  }
+
+  async function getRouteLoader() {
+    const { Route } = await import("../routes/index");
+    return (Route as unknown as { __config: { loader: () => Promise<unknown> } }).__config.loader;
   }
 
   function clickHeroLabelTriple() {
@@ -77,6 +117,33 @@ describe("home route", () => {
     expect(screen.queryByText("Featured skills")).toBeNull();
     expect(screen.queryByText("Trending Now")).toBeNull();
     expect(screen.queryByText(/claw for your claw/i)).toBeNull();
+  });
+
+  it("passes the loader listing into the home listing section", async () => {
+    await renderHome();
+
+    expect(homeListingSectionMock).toHaveBeenCalledWith({
+      initialListing: initialListingFixture,
+    });
+  });
+
+  it("loads the default home listing in the route loader", async () => {
+    const loader = await getRouteLoader();
+
+    await expect(loader()).resolves.toBe(initialListingFixture);
+    expect(fetchInitialHomeListingMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to client loading when the default listing loader fails", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    fetchInitialHomeListingMock.mockRejectedValueOnce(new Error("offline"));
+    const loader = await getRouteLoader();
+
+    await expect(loader()).resolves.toBeNull();
+    expect(errorSpy).toHaveBeenCalledWith(
+      "Failed to load initial home listing:",
+      expect.any(Error),
+    );
   });
 
   it("does not render the homepage social proof stats strip", async () => {

--- a/src/components/HomeListingSection.tsx
+++ b/src/components/HomeListingSection.tsx
@@ -24,13 +24,26 @@ import {
 } from "react";
 import { api } from "../../convex/_generated/api";
 import { convexHttp } from "../convex/client";
-import { isSkillOfficial } from "../lib/badges";
+import { PLUGIN_CATEGORIES, SKILL_CATEGORIES, type BrowseCategory } from "../lib/categories";
 import {
-  getSkillCategoriesForSkill,
-  PLUGIN_CATEGORIES,
-  SKILL_CATEGORIES,
-  type BrowseCategory,
-} from "../lib/categories";
+  filterHomePluginsByTab as filterPluginsByTab,
+  filterHomeSkillsByTab as filterSkillsByTab,
+  fetchHomePluginListing as fetchPluginListing,
+  fetchHomeSkillListing as fetchSkillListing,
+  HOME_LISTING_PAGE_SIZE,
+  homeListingCacheKey as listingCacheKey,
+  isNewHomeSkillEligible as isNewSkillEligible,
+  itemMatchesAnyHomeCategory as itemMatchesAnyCategory,
+  skillMatchesAnyHomeCategory as skillMatchesAnyCategory,
+  sortHomeSkillEntries as sortSkillEntries,
+  uniqueHomePlugins as uniquePlugins,
+  uniqueHomeSkillEntries as uniqueSkillEntries,
+  type HomeListingCacheEntry,
+  type HomeListingInitialData,
+  type HomeListingKind as ListingKind,
+  type HomeListingTab as ListingTab,
+  type HomeSkillListingEntry as SkillPageEntry,
+} from "../lib/homeListingData";
 import { formatCompactStat } from "../lib/numberFormat";
 import { fetchPluginCatalog, type PackageListItem } from "../lib/packageApi";
 import type { PublicSkill, PublicUser } from "../lib/publicUser";
@@ -38,15 +51,7 @@ import { HomeListingCategorySelect } from "./HomeListingCategorySelect";
 import { MarketplaceIcon } from "./MarketplaceIcon";
 import { OfficialBadge } from "./OfficialBadge";
 
-type ListingKind = "skills" | "plugins";
-type ListingTab = "popular" | "trending" | "officials" | "new";
 type ListingView = "list" | "grid";
-
-type SkillPageEntry = {
-  skill: PublicSkill;
-  ownerHandle?: string | null;
-  owner?: PublicUser | null;
-};
 
 const SKILL_LISTING_TABS: Array<{ id: ListingTab; label: string }> = [
   { id: "popular", label: "Top" },
@@ -60,9 +65,8 @@ const PLUGIN_LISTING_TABS: Array<{ id: ListingTab; label: string }> = [
   { id: "new", label: "New" },
 ];
 
-const LISTING_PAGE_SIZE = 20;
+const LISTING_PAGE_SIZE = HOME_LISTING_PAGE_SIZE;
 const LISTING_SEARCH_DEBOUNCE_MS = 220;
-const PLUGIN_CATALOG_PAGE_LIMIT = 100;
 
 const HOME_SKILL_LISTING_CATEGORIES: BrowseCategory[] = SKILL_CATEGORIES.map(
   ({ slug, label, icon }) => ({ slug, label, icon }),
@@ -83,71 +87,6 @@ type SkillSearchHit = {
   ownerHandle?: string | null;
   owner?: PublicUser | null;
 };
-
-function filterSkillsByTab(entries: SkillPageEntry[], tab: ListingTab) {
-  if (tab === "officials") {
-    return entries.filter((entry) => isSkillOfficial(entry.skill));
-  }
-  return entries;
-}
-
-function filterPluginsByTab(items: PackageListItem[], tab: ListingTab) {
-  if (tab === "officials") {
-    return items.filter((item) => item.isOfficial);
-  }
-  return items;
-}
-
-function isNewSkillEligible(skill: PublicSkill) {
-  return (
-    !skill.isSuspicious &&
-    skill.githubScanStatus !== "pending" &&
-    skill.githubScanStatus !== "suspicious"
-  );
-}
-
-function itemMatchesAnyCategory(
-  item: { categories?: readonly string[] | null },
-  categorySlugs: readonly string[],
-) {
-  if (categorySlugs.length === 0) return true;
-  const categories = item.categories ?? [];
-  return categorySlugs.some((slug) => categories.includes(slug));
-}
-
-function skillMatchesAnyCategory(skill: PublicSkill, categorySlugs: readonly string[]) {
-  if (categorySlugs.length === 0) return true;
-  const categories = getSkillCategoriesForSkill(skill);
-  return categorySlugs.some((slug) => categories.some((category) => category.slug === slug));
-}
-
-function uniqueSkillEntries(entries: SkillPageEntry[]) {
-  const byId = new Map<string, SkillPageEntry>();
-  for (const entry of entries) {
-    byId.set(String(entry.skill._id), entry);
-  }
-  return [...byId.values()];
-}
-
-function uniquePlugins(items: PackageListItem[]) {
-  const byName = new Map<string, PackageListItem>();
-  for (const item of items) {
-    byName.set(item.name, item);
-  }
-  return [...byName.values()];
-}
-
-function sortSkillEntries(entries: SkillPageEntry[], tab: ListingTab) {
-  return [...entries].sort((left, right) => {
-    if (tab === "new") {
-      return (
-        (right.skill.updatedAt ?? right.skill.createdAt ?? right.skill._creationTime ?? 0) -
-        (left.skill.updatedAt ?? left.skill.createdAt ?? left.skill._creationTime ?? 0)
-      );
-    }
-    return (right.skill.stats?.downloads ?? 0) - (left.skill.stats?.downloads ?? 0);
-  });
-}
 
 function HomeListingEmptyPanel({
   variant,
@@ -238,114 +177,6 @@ function skillLink(entry: SkillPageEntry) {
     entry.owner?.handle?.trim() ||
     String(entry.skill.ownerPublisherId ?? entry.skill.ownerUserId);
   return `/${encodeURIComponent(owner)}/${encodeURIComponent(entry.skill.slug)}`;
-}
-
-async function fetchSkillListing(
-  tab: ListingTab,
-  categorySlugs: readonly string[],
-  numItems: number,
-) {
-  if (tab === "trending") {
-    const requestLimit = categorySlugs.length > 0 ? 200 : numItems;
-    const result = await convexHttp.query(api.skills.listPublicTrendingPage, {
-      limit: requestLimit,
-    });
-    const items = ((result as { items?: SkillPageEntry[] }).items ?? []).filter((entry) =>
-      skillMatchesAnyCategory(entry.skill, categorySlugs),
-    );
-    return {
-      page: uniqueSkillEntries(items).slice(0, numItems),
-      hasMore: items.length > numItems || (items.length >= numItems && numItems < 200),
-    };
-  }
-
-  const categoriesToFetch = categorySlugs.length > 0 ? categorySlugs : [null];
-  const results = await Promise.all(
-    categoriesToFetch.map(async (categorySlug) => {
-      const page: SkillPageEntry[] = [];
-      let cursor: string | null | undefined;
-      let hasMore = false;
-
-      while (page.length < numItems) {
-        const result = await convexHttp.query(api.skills.listPublicPageV4, {
-          cursor: cursor ?? undefined,
-          numItems: numItems - page.length,
-          sort: tab === "new" ? "newest" : "downloads",
-          dir: "desc",
-          officialFirst: tab === "officials" ? true : undefined,
-          categorySlug: categorySlug ?? undefined,
-        });
-        if (Array.isArray(result)) break;
-
-        const resultPage = ((result as { page?: SkillPageEntry[] }).page ?? []).filter(
-          (entry) =>
-            skillMatchesAnyCategory(entry.skill, categorySlugs) &&
-            (tab !== "new" || isNewSkillEligible(entry.skill)),
-        );
-        page.push(...resultPage);
-
-        const nextCursor = (result as { nextCursor?: string | null }).nextCursor ?? null;
-        hasMore = Boolean((result as { hasMore?: boolean }).hasMore ?? nextCursor);
-        if (!nextCursor || nextCursor === cursor) break;
-        cursor = nextCursor;
-      }
-
-      return { page, hasMore };
-    }),
-  );
-  const pages = results.flatMap((result) => result.page);
-  const sorted = sortSkillEntries(filterSkillsByTab(uniqueSkillEntries(pages), tab), tab);
-  const hasMore = sorted.length > numItems || results.some((result) => result.hasMore);
-  const page = sorted.slice(0, numItems);
-  return { page, hasMore };
-}
-
-async function fetchPluginListing(
-  tab: ListingTab,
-  categorySlugs: readonly string[],
-  limit: number,
-  signal: AbortSignal,
-) {
-  const openClawOfficials = tab === "officials";
-  const categoriesToFetch = categorySlugs.length > 0 ? categorySlugs : [null];
-  const results = await Promise.all(
-    categoriesToFetch.map(async (categorySlug) => {
-      const items: PackageListItem[] = [];
-      let cursor: string | null | undefined;
-      let hasMore = false;
-
-      while (items.length < limit) {
-        const result = await fetchPluginCatalog({
-          category: categorySlug ?? undefined,
-          cursor: cursor ?? undefined,
-          isOfficial: openClawOfficials ? true : undefined,
-          excludedScanStatuses: tab === "new" ? ["pending", "suspicious"] : undefined,
-          sort: tab === "new" ? "updated" : "downloads",
-          limit: Math.min(limit - items.length, PLUGIN_CATALOG_PAGE_LIMIT),
-          signal,
-        });
-        items.push(...result.items.filter((item) => itemMatchesAnyCategory(item, categorySlugs)));
-
-        hasMore = result.nextCursor != null;
-        if (!result.nextCursor || result.nextCursor === cursor) break;
-        cursor = result.nextCursor;
-      }
-
-      return { items, hasMore };
-    }),
-  );
-  let items = uniquePlugins(results.flatMap((result) => result.items));
-  items = filterPluginsByTab(items, tab);
-  if (tab === "new") {
-    items.sort((a, b) => b.updatedAt - a.updatedAt);
-  } else if (tab === "popular" || openClawOfficials) {
-    items.sort((a, b) => (b.stats?.downloads ?? 0) - (a.stats?.downloads ?? 0));
-  }
-  const page = items.slice(0, limit);
-  return {
-    items: page,
-    hasMore: items.length > limit || results.some((result) => result.hasMore),
-  };
 }
 
 function HomeListingSkillRow({ entry, showStats }: { entry: SkillPageEntry; showStats: boolean }) {
@@ -476,25 +307,54 @@ function HomeListingPluginCard({ plugin }: { plugin: PackageListItem }) {
   );
 }
 
-export function HomeListingSection() {
+type HomeListingSectionProps = {
+  initialListing?: HomeListingInitialData | null;
+};
+
+function createInitialListingCache(initialListing: HomeListingInitialData | null) {
+  const cache = new Map<string, HomeListingCacheEntry>();
+  if (!initialListing) return cache;
+  cache.set(
+    listingCacheKey({
+      kind: initialListing.kind,
+      tab: initialListing.tab,
+      categorySlugs: initialListing.categorySlugs,
+      fetchLimit: initialListing.fetchLimit,
+    }),
+    {
+      kind: "skills",
+      items: initialListing.items,
+      hasMore: initialListing.hasMore,
+    },
+  );
+  return cache;
+}
+
+export function HomeListingSection({ initialListing = null }: HomeListingSectionProps = {}) {
   const searchInputRef = useRef<HTMLInputElement>(null);
   const searchRequestRef = useRef(0);
+  const listingCacheRef = useRef<Map<string, HomeListingCacheEntry> | null>(null);
+  listingCacheRef.current ??= createInitialListingCache(initialListing);
+  const listingCache = listingCacheRef.current;
+
   const [kind, setKind] = useState<ListingKind>("skills");
   const [tab, setTab] = useState<ListingTab>("popular");
   const [view, setView] = useState<ListingView>("list");
   const [categorySlugs, setCategorySlugs] = useState<string[]>([]);
   const [visibleCount, setVisibleCount] = useState(LISTING_PAGE_SIZE);
   const [fetchLimit, setFetchLimit] = useState(LISTING_PAGE_SIZE);
-  const [skills, setSkills] = useState<SkillPageEntry[]>([]);
+  const [skills, setSkills] = useState<SkillPageEntry[]>(initialListing?.items ?? []);
   const [plugins, setPlugins] = useState<PackageListItem[]>([]);
-  const [status, setStatus] = useState<"loading" | "idle" | "error">("loading");
+  const [status, setStatus] = useState<"loading" | "idle" | "error">(
+    initialListing ? "idle" : "loading",
+  );
   const [loadingMore, setLoadingMore] = useState(false);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [searchSkills, setSearchSkills] = useState<SkillPageEntry[]>([]);
   const [searchPlugins, setSearchPlugins] = useState<PackageListItem[]>([]);
   const [searchStatus, setSearchStatus] = useState<"idle" | "loading" | "error">("idle");
-  const [listingHasMore, setListingHasMore] = useState(false);
+  const [listingHasMore, setListingHasMore] = useState(initialListing?.hasMore ?? false);
 
   const trimmedSearch = searchQuery.trim();
   const isSearchMode = trimmedSearch.length > 0;
@@ -566,6 +426,17 @@ export function HomeListingSection() {
 
   useEffect(() => {
     if (isSearchMode) return undefined;
+    const cacheKey = listingCacheKey({ kind, tab, categorySlugs, fetchLimit });
+    const cached = listingCache.get(cacheKey);
+    if (cached) {
+      if (cached.kind === "skills") setSkills(cached.items);
+      else setPlugins(cached.items);
+      setListingHasMore(cached.hasMore);
+      setStatus("idle");
+      setLoadingMore(false);
+      return undefined;
+    }
+
     const controller = new AbortController();
     // "Load more" only grows fetchLimit: keep the existing rows mounted and
     // append, instead of swapping in the skeleton (which collapses height and
@@ -582,12 +453,22 @@ export function HomeListingSection() {
       kind === "skills"
         ? fetchSkillListing(tab, categorySlugs, fetchLimit).then((result) => {
             if (controller.signal.aborted) return;
+            listingCache.set(cacheKey, {
+              kind: "skills",
+              items: result.page,
+              hasMore: result.hasMore,
+            });
             setSkills(result.page);
             setListingHasMore(result.hasMore);
             setStatus("idle");
           })
         : fetchPluginListing(tab, categorySlugs, fetchLimit, controller.signal).then((result) => {
             if (controller.signal.aborted) return;
+            listingCache.set(cacheKey, {
+              kind: "plugins",
+              items: result.items,
+              hasMore: result.hasMore,
+            });
             setPlugins(result.items);
             setListingHasMore(result.hasMore);
             setStatus("idle");
@@ -612,14 +493,13 @@ export function HomeListingSection() {
       });
 
     return () => controller.abort();
-  }, [categorySlugs, fetchLimit, isSearchMode, kind, tab]);
+  }, [categorySlugs, fetchLimit, isSearchMode, kind, listingCache, tab]);
 
   useEffect(() => {
     if (!isSearchMode) {
       setSearchSkills([]);
       setSearchPlugins([]);
       setSearchStatus("idle");
-      setListingHasMore(false);
       return undefined;
     }
 
@@ -664,11 +544,12 @@ export function HomeListingSection() {
                 ),
               );
               const sortedRows = tab === "new" ? sortSkillEntries(rows, tab) : rows;
-              setSearchSkills(sortedRows.slice(0, fetchLimit));
-              setListingHasMore(
+              const items = sortedRows.slice(0, fetchLimit);
+              const hasMore =
                 sortedRows.length > fetchLimit ||
-                  results.some((hits) => (hits as SkillSearchHit[]).length >= fetchLimit),
-              );
+                results.some((hits) => (hits as SkillSearchHit[]).length >= fetchLimit);
+              setSearchSkills(items);
+              setListingHasMore(hasMore);
               setSearchStatus("idle");
             })
           : Promise.all(
@@ -690,14 +571,13 @@ export function HomeListingSection() {
                   result.items.filter((item) => itemMatchesAnyCategory(item, categorySlugs)),
                 ),
               );
-              setSearchPlugins(
-                tab === "new" ? [...items].sort((a, b) => b.updatedAt - a.updatedAt) : items,
+              const sortedItems =
+                tab === "new" ? [...items].sort((a, b) => b.updatedAt - a.updatedAt) : items;
+              const hasMore = results.some(
+                (result) => result.nextCursor != null || result.items.length >= fetchLimit,
               );
-              setListingHasMore(
-                results.some(
-                  (result) => result.nextCursor != null || result.items.length >= fetchLimit,
-                ),
-              );
+              setSearchPlugins(sortedItems);
+              setListingHasMore(hasMore);
               setSearchStatus("idle");
             });
 

--- a/src/lib/homeListingData.ts
+++ b/src/lib/homeListingData.ts
@@ -1,0 +1,241 @@
+import { api } from "../../convex/_generated/api";
+import { convexHttp } from "../convex/client";
+import { isSkillOfficial } from "./badges";
+import { getSkillCategoriesForSkill } from "./categories";
+import { fetchPluginCatalog, type PackageListItem } from "./packageApi";
+import type { PublicSkill, PublicUser } from "./publicUser";
+
+export type HomeListingKind = "skills" | "plugins";
+export type HomeListingTab = "popular" | "trending" | "officials" | "new";
+
+export type HomeSkillListingEntry = {
+  skill: PublicSkill;
+  ownerHandle?: string | null;
+  owner?: PublicUser | null;
+};
+
+export type HomeListingCacheEntry =
+  | { kind: "skills"; items: HomeSkillListingEntry[]; hasMore: boolean }
+  | { kind: "plugins"; items: PackageListItem[]; hasMore: boolean };
+
+export type HomeListingInitialData = {
+  kind: "skills";
+  tab: "popular";
+  categorySlugs: [];
+  fetchLimit: typeof HOME_LISTING_PAGE_SIZE;
+  items: HomeSkillListingEntry[];
+  hasMore: boolean;
+};
+
+export const HOME_LISTING_PAGE_SIZE = 20;
+
+const PLUGIN_CATALOG_PAGE_LIMIT = 100;
+
+export function homeListingCacheKey({
+  kind,
+  tab,
+  categorySlugs,
+  fetchLimit,
+}: {
+  kind: HomeListingKind;
+  tab: HomeListingTab;
+  categorySlugs: readonly string[];
+  fetchLimit: number;
+}) {
+  return ["listing", kind, tab, categoryCacheKey(categorySlugs), fetchLimit].join(":");
+}
+
+export function filterHomeSkillsByTab(entries: HomeSkillListingEntry[], tab: HomeListingTab) {
+  if (tab === "officials") {
+    return entries.filter((entry) => isSkillOfficial(entry.skill));
+  }
+  return entries;
+}
+
+export function filterHomePluginsByTab(items: PackageListItem[], tab: HomeListingTab) {
+  if (tab === "officials") {
+    return items.filter((item) => item.isOfficial);
+  }
+  return items;
+}
+
+export function isNewHomeSkillEligible(skill: PublicSkill) {
+  return (
+    !skill.isSuspicious &&
+    skill.githubScanStatus !== "pending" &&
+    skill.githubScanStatus !== "suspicious"
+  );
+}
+
+export function itemMatchesAnyHomeCategory(
+  item: { categories?: readonly string[] | null },
+  categorySlugs: readonly string[],
+) {
+  if (categorySlugs.length === 0) return true;
+  const categories = item.categories ?? [];
+  return categorySlugs.some((slug) => categories.includes(slug));
+}
+
+export function skillMatchesAnyHomeCategory(skill: PublicSkill, categorySlugs: readonly string[]) {
+  if (categorySlugs.length === 0) return true;
+  const categories = getSkillCategoriesForSkill(skill);
+  return categorySlugs.some((slug) => categories.some((category) => category.slug === slug));
+}
+
+export function uniqueHomeSkillEntries(entries: HomeSkillListingEntry[]) {
+  const byId = new Map<string, HomeSkillListingEntry>();
+  for (const entry of entries) {
+    byId.set(String(entry.skill._id), entry);
+  }
+  return [...byId.values()];
+}
+
+export function uniqueHomePlugins(items: PackageListItem[]) {
+  const byName = new Map<string, PackageListItem>();
+  for (const item of items) {
+    byName.set(item.name, item);
+  }
+  return [...byName.values()];
+}
+
+export function sortHomeSkillEntries(entries: HomeSkillListingEntry[], tab: HomeListingTab) {
+  return [...entries].sort((left, right) => {
+    if (tab === "new") {
+      return (
+        (right.skill.updatedAt ?? right.skill.createdAt ?? right.skill._creationTime ?? 0) -
+        (left.skill.updatedAt ?? left.skill.createdAt ?? left.skill._creationTime ?? 0)
+      );
+    }
+    return (right.skill.stats?.downloads ?? 0) - (left.skill.stats?.downloads ?? 0);
+  });
+}
+
+export async function fetchHomeSkillListing(
+  tab: HomeListingTab,
+  categorySlugs: readonly string[],
+  numItems: number,
+) {
+  if (tab === "trending") {
+    const requestLimit = categorySlugs.length > 0 ? 200 : numItems;
+    const result = await convexHttp.query(api.skills.listPublicTrendingPage, {
+      limit: requestLimit,
+    });
+    const items = ((result as { items?: HomeSkillListingEntry[] }).items ?? []).filter((entry) =>
+      skillMatchesAnyHomeCategory(entry.skill, categorySlugs),
+    );
+    return {
+      page: uniqueHomeSkillEntries(items).slice(0, numItems),
+      hasMore: items.length > numItems || (items.length >= numItems && numItems < 200),
+    };
+  }
+
+  const categoriesToFetch = categorySlugs.length > 0 ? categorySlugs : [null];
+  const results = await Promise.all(
+    categoriesToFetch.map(async (categorySlug) => {
+      const page: HomeSkillListingEntry[] = [];
+      let cursor: string | null | undefined;
+      let hasMore = false;
+
+      while (page.length < numItems) {
+        const result = await convexHttp.query(api.skills.listPublicPageV4, {
+          cursor: cursor ?? undefined,
+          numItems: numItems - page.length,
+          sort: tab === "new" ? "newest" : "downloads",
+          dir: "desc",
+          officialFirst: tab === "officials" ? true : undefined,
+          categorySlug: categorySlug ?? undefined,
+        });
+        if (Array.isArray(result)) break;
+
+        const resultPage = ((result as { page?: HomeSkillListingEntry[] }).page ?? []).filter(
+          (entry) =>
+            skillMatchesAnyHomeCategory(entry.skill, categorySlugs) &&
+            (tab !== "new" || isNewHomeSkillEligible(entry.skill)),
+        );
+        page.push(...resultPage);
+
+        const nextCursor = (result as { nextCursor?: string | null }).nextCursor ?? null;
+        hasMore = Boolean((result as { hasMore?: boolean }).hasMore ?? nextCursor);
+        if (!nextCursor || nextCursor === cursor) break;
+        cursor = nextCursor;
+      }
+
+      return { page, hasMore };
+    }),
+  );
+  const pages = results.flatMap((result) => result.page);
+  const sorted = sortHomeSkillEntries(
+    filterHomeSkillsByTab(uniqueHomeSkillEntries(pages), tab),
+    tab,
+  );
+  const hasMore = sorted.length > numItems || results.some((result) => result.hasMore);
+  const page = sorted.slice(0, numItems);
+  return { page, hasMore };
+}
+
+export async function fetchHomePluginListing(
+  tab: HomeListingTab,
+  categorySlugs: readonly string[],
+  limit: number,
+  signal?: AbortSignal,
+) {
+  const openClawOfficials = tab === "officials";
+  const categoriesToFetch = categorySlugs.length > 0 ? categorySlugs : [null];
+  const results = await Promise.all(
+    categoriesToFetch.map(async (categorySlug) => {
+      const items: PackageListItem[] = [];
+      let cursor: string | null | undefined;
+      let hasMore = false;
+
+      while (items.length < limit) {
+        const result = await fetchPluginCatalog({
+          category: categorySlug ?? undefined,
+          cursor: cursor ?? undefined,
+          isOfficial: openClawOfficials ? true : undefined,
+          excludedScanStatuses: tab === "new" ? ["pending", "suspicious"] : undefined,
+          sort: tab === "new" ? "updated" : "downloads",
+          limit: Math.min(limit - items.length, PLUGIN_CATALOG_PAGE_LIMIT),
+          signal,
+        });
+        items.push(
+          ...result.items.filter((item) => itemMatchesAnyHomeCategory(item, categorySlugs)),
+        );
+
+        hasMore = result.nextCursor != null;
+        if (!result.nextCursor || result.nextCursor === cursor) break;
+        cursor = result.nextCursor;
+      }
+
+      return { items, hasMore };
+    }),
+  );
+  let items = uniqueHomePlugins(results.flatMap((result) => result.items));
+  items = filterHomePluginsByTab(items, tab);
+  if (tab === "new") {
+    items.sort((a, b) => b.updatedAt - a.updatedAt);
+  } else if (tab === "popular" || openClawOfficials) {
+    items.sort((a, b) => (b.stats?.downloads ?? 0) - (a.stats?.downloads ?? 0));
+  }
+  const page = items.slice(0, limit);
+  return {
+    items: page,
+    hasMore: items.length > limit || results.some((result) => result.hasMore),
+  };
+}
+
+export async function fetchInitialHomeListing(): Promise<HomeListingInitialData> {
+  const result = await fetchHomeSkillListing("popular", [], HOME_LISTING_PAGE_SIZE);
+  return {
+    kind: "skills",
+    tab: "popular",
+    categorySlugs: [],
+    fetchLimit: HOME_LISTING_PAGE_SIZE,
+    items: result.page,
+    hasMore: result.hasMore,
+  };
+}
+
+function categoryCacheKey(categorySlugs: readonly string[]) {
+  if (categorySlugs.length === 0) return "all";
+  return [...categorySlugs].sort().join(",");
+}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -5,10 +5,21 @@ import { HomeBringSkillsSection } from "../components/HomeBringSkillsSection";
 import { HomeListingSection } from "../components/HomeListingSection";
 import { HomePopularPublishersSection } from "../components/HomePopularPublishersSection";
 import { HomeV2FoldBottomFade } from "../components/HomeV2FoldBottomFade";
+import { fetchInitialHomeListing, type HomeListingInitialData } from "../lib/homeListingData";
 
 export const Route = createFileRoute("/")({
+  loader: loadInitialHomeListing,
   component: SkillsHome,
 });
+
+async function loadInitialHomeListing(): Promise<HomeListingInitialData | null> {
+  try {
+    return await fetchInitialHomeListing();
+  } catch (error) {
+    console.error("Failed to load initial home listing:", error);
+    return null;
+  }
+}
 
 const SLOT_WORDS = [
   "Equip",
@@ -28,6 +39,7 @@ const SLOT_WORDS = [
 const HACK_INDEX = SLOT_WORDS.indexOf("Hack");
 
 function SkillsHome() {
+  const initialListing = Route.useLoaderData();
   const clickTimesRef = useRef<number[]>([]);
   const [slotState, setSlotState] = useState<
     | null
@@ -364,7 +376,7 @@ function SkillsHome() {
         <p className="home-v2-sub">Discover skills and plugins from top creators</p>
       </section>
 
-      <HomeListingSection />
+      <HomeListingSection initialListing={initialListing} />
       <HomePopularPublishersSection />
       <HomeAppsSection />
       <HomeBringSkillsSection />


### PR DESCRIPTION
Visual proof: [homepage listing cache walkthrough](https://tawny-nectar-xbms.here.now/droppie-2026-06-20T18-19-53Z.mp4)

## Summary
- Adds a home route loader for the default Skills / Top listing and passes that payload into the homepage listing section.
- Seeds the client-side listing cache from that initial payload, so the first visible tab does not fetch again after hydration.
- Keeps other browse tabs lazy-loaded and cached by kind, tab, categories, and limit after first visit.
- Leaves search fetch-on-query and does not add prefetching or load all tabs upfront.
- Falls back to normal client loading if the initial listing loader fails, so a catalog hiccup does not take down the full homepage.

## Tests
- `bun run test -- src/__tests__/home-listing-section.test.tsx src/__tests__/home-route.test.tsx`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `git diff --check upstream/main`

## Browser proof
- Local homepage checked at `http://127.0.0.1:13438/` using production Convex env.
- Verified Skills / Top arrives from initial data with no browser `skills:listPublicPageV4` refetch.
- Verified Top → Trending → Top reuses cached Top data.
- Verified Plugins Official → Top → Official reuses cached Official plugin data after first load.
