### PR TITLE
fix: honor owner scope in skill install resolver

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -2237,6 +2237,30 @@ describe("httpApiV1 handlers", () => {
     });
   });
 
+  it("uses the public site origin for production ambiguous skill choices", async () => {
+    vi.stubEnv("CONVEX_DEPLOYMENT", "prod:wry-manatee-359");
+    const runQuery = vi.fn().mockResolvedValue({
+      skill: null,
+      ambiguous: true,
+      ambiguousMatches: [
+        { slug: "demo", ownerHandle: "openclaw" },
+        { slug: "demo", ownerHandle: "patrick" },
+      ],
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+    const response = await __handlers.skillsGetRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://wry-manatee-359.convex.site/api/v1/skills/demo"),
+    );
+
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.matches).toEqual([
+      expect.objectContaining({ url: "https://clawhub.ai/openclaw/demo" }),
+      expect.objectContaining({ url: "https://clawhub.ai/patrick/demo" }),
+    ]);
+  });
+
   it("get skill returns pending-scan message for owner api token", async () => {
     vi.mocked(getOptionalApiTokenUserId).mockResolvedValue("users:1" as never);
     const runQuery = vi.fn(async (_query: unknown, args: Record<string, unknown>) => {
@@ -2557,6 +2581,42 @@ describe("httpApiV1 handlers", () => {
       archive: {
         version: "1.0.0",
         downloadUrl: "https://example.com/api/v1/download?slug=demo&version=1.0.0",
+      },
+    });
+  });
+
+  it("skill install resolver threads ownerHandle through scoped archive installs", async () => {
+    const runQuery = makeInstallResolverRunQuery({
+      skill: {
+        _id: "skills:demo",
+        slug: "demo",
+        displayName: "Demo Skill",
+        latestVersionSummary: { version: "1.0.0" },
+      },
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.skillsGetRouterV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request("https://example.com/api/v1/skills/demo/install?ownerHandle=acme"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runQuery).toHaveBeenCalledWith(
+      internal.skills.getSkillBySlugInternal,
+      expect.objectContaining({ slug: "demo", ownerHandle: "acme" }),
+    );
+    expect(runQuery).toHaveBeenCalledWith(
+      api.skills.getBySlug,
+      expect.objectContaining({ slug: "demo", ownerHandle: "acme" }),
+    );
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      slug: "demo",
+      installKind: "archive",
+      archive: {
+        version: "1.0.0",
+        downloadUrl: "https://example.com/api/v1/download?slug=demo&ownerHandle=acme&version=1.0.0",
       },
     });
   });

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -1620,6 +1620,7 @@ function ambiguousSkillChoicesForRequest(
   request: Request,
   matches: Array<{ slug: string; ownerHandle?: string | null }> | undefined,
 ): AmbiguousSkillSlugChoice[] {
+  const origin = publicApiOrigin(request);
   return (matches ?? []).flatMap((match) => {
     const ownerHandle = match.ownerHandle?.trim().replace(/^@+/, "");
     if (!ownerHandle) return [];
@@ -1632,7 +1633,7 @@ function ambiguousSkillChoicesForRequest(
         ref: `@${ownerHandle}/${slug}`,
         url: new URL(
           `/${encodeURIComponent(ownerHandle)}/${encodeURIComponent(slug)}`,
-          request.url,
+          origin,
         ).toString(),
       },
     ];
@@ -1823,7 +1824,7 @@ export async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request)
           moderationFlags?: string[];
         })
       | null
-    >(ctx, internalRefs.skills.getSkillBySlugInternal, { slug })) as
+    >(ctx, internalRefs.skills.getSkillBySlugInternal, skillLookupArgs)) as
       | (InstallResolverSkill & {
           _id: Id<"skills">;
           githubSourceId?: Id<"githubSkillSources">;
@@ -1847,12 +1848,14 @@ export async function skillsGetRouterV1Handler(ctx: ActionCtx, request: Request)
       origin: publicApiOrigin(request),
       skill,
       source,
+      ownerHandle,
       forceInstall,
     });
 
-    const publicSkillResult = (await ctx.runQuery(api.skills.getBySlug, {
-      slug,
-    })) as GetBySlugResult;
+    const publicSkillResult = (await ctx.runQuery(
+      api.skills.getBySlug,
+      skillLookupArgs,
+    )) as GetBySlugResult;
     const publiclyVisible = publicSkillResult?.skill?._id === skill._id;
     if (!publiclyVisible) {
       if (!resolution.ok && shouldExposeHiddenGitHubInstallBlock(skill, resolution)) {

--- a/convex/lib/installResolver.test.ts
+++ b/convex/lib/installResolver.test.ts
@@ -42,6 +42,30 @@ describe("buildSkillInstallResolution", () => {
     });
   });
 
+  it("keeps ownerHandle in archive download URLs for scoped installs", () => {
+    const resolution = buildSkillInstallResolution({
+      origin: "https://clawhub.ai",
+      skill: {
+        slug: "direct-skill",
+        displayName: "Direct Skill",
+        latestVersionSummary: { version: "1.2.3" },
+      },
+      source: null,
+      ownerHandle: "acme",
+    });
+
+    expect(resolution).toEqual({
+      ok: true,
+      slug: "direct-skill",
+      installKind: "archive",
+      archive: {
+        version: "1.2.3",
+        downloadUrl:
+          "https://clawhub.ai/api/v1/download?slug=direct-skill&ownerHandle=acme&version=1.2.3",
+      },
+    });
+  });
+
   it("returns a pinned GitHub descriptor when current upstream state is scan-clean", () => {
     const resolution = buildSkillInstallResolution({
       origin: "https://clawhub.ai",

--- a/convex/lib/installResolver.ts
+++ b/convex/lib/installResolver.ts
@@ -60,11 +60,13 @@ export function buildSkillInstallResolution({
   origin,
   skill,
   source,
+  ownerHandle,
   forceInstall = false,
 }: {
   origin: string;
   skill: InstallResolverSkill;
   source: InstallResolverSource | null;
+  ownerHandle?: string | null;
   forceInstall?: boolean;
 }): SkillInstallResolution {
   if (skill.installKind !== "github") {
@@ -75,6 +77,7 @@ export function buildSkillInstallResolution({
 
     const url = new URL("/api/v1/download", origin);
     url.searchParams.set("slug", skill.slug);
+    if (ownerHandle) url.searchParams.set("ownerHandle", ownerHandle);
     url.searchParams.set("version", version);
     return {
       ok: true,


### PR DESCRIPTION
## Summary

- Thread `ownerHandle` through the skill install resolver's internal and public visibility lookups so `@owner/slug` installs can resolve when an unscoped slug is ambiguous.
- Preserve `ownerHandle` in archive install descriptor download URLs.
- Use the public ClawHub origin for ambiguous skill choice URLs so Convex HTTP requests do not point users at non-frontend `*.convex.site` pages.

Fixes #2766.

## Tests

- `bunx vitest run convex/lib/installResolver.test.ts convex/httpApiV1.handlers.test.ts`
- `bun run format:check -- convex/httpApiV1/skillsV1.ts convex/httpApiV1.handlers.test.ts convex/lib/installResolver.ts convex/lib/installResolver.test.ts`
- `bun run ci:static`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit && bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bun run ci:types-build`

## Real behavior proof

Local Convex proof against this branch at `36ca3813` with an isolated local fixture containing `maximeprades/auto-updater@1.0.0` and `dreamboat2000/auto-updater@1.0.1`. No auth tokens or production data were used.

```console
$ curl -sS -i 'http://127.0.0.1:3213/api/v1/skills/auto-updater'
HTTP/1.1 409 Conflict

{"code":"AMBIGUOUS_SKILL_SLUG","message":"Found multiple skills with the slug \"auto-updater\"; specify which one you want to install:","slug":"auto-updater","matches":[{"ownerHandle":"maximeprades","slug":"auto-updater","ref":"@maximeprades/auto-updater","url":"http://127.0.0.1:3213/maximeprades/auto-updater"},{"ownerHandle":"dreamboat2000","slug":"auto-updater","ref":"@dreamboat2000/auto-updater","url":"http://127.0.0.1:3213/dreamboat2000/auto-updater"}]}

$ curl -sS -i 'http://127.0.0.1:3213/api/v1/skills/auto-updater/install?ownerHandle=maximeprades'
HTTP/1.1 200 OK

{"ok":true,"slug":"auto-updater","installKind":"archive","archive":{"version":"1.0.0","downloadUrl":"http://127.0.0.1:3213/api/v1/download?slug=auto-updater&ownerHandle=maximeprades&version=1.0.0"}}

$ curl -sS -i 'http://127.0.0.1:3213/api/v1/skills/auto-updater/install?ownerHandle=dreamboat2000'
HTTP/1.1 200 OK

{"ok":true,"slug":"auto-updater","installKind":"archive","archive":{"version":"1.0.1","downloadUrl":"http://127.0.0.1:3213/api/v1/download?slug=auto-updater&ownerHandle=dreamboat2000&version=1.0.1"}}
```

## Notes

- `bun run ci:unit` was attempted twice and reached 3675 passing tests, but fails locally in `scripts/skill-cards/run-skill-card-worker.test.ts` because this worktree path contains a space (`New project`) and that script builds a filesystem path from `import.meta.url.pathname`, leaving `New%20project` encoded. This appears unrelated to the install resolver change.
