### PR TITLE
fix(ci): reduce ClawHub worker fanout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   static:
     name: static
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
 
     steps:
@@ -34,7 +34,7 @@ jobs:
 
   unit:
     name: unit
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
 
     steps:
@@ -47,7 +47,7 @@ jobs:
 
   packages:
     name: packages
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
 
     steps:
@@ -60,7 +60,7 @@ jobs:
 
   types-build:
     name: types-build
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
 
     steps:
@@ -73,7 +73,7 @@ jobs:
 
   e2e-http:
     name: e2e-http
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
 
     steps:
@@ -86,7 +86,7 @@ jobs:
 
   playwright-smoke:
     name: playwright-smoke
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 25
 
     steps:
@@ -118,10 +118,11 @@ jobs:
 
   playwright-local-auth-shard:
     name: playwright-local-auth / ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         include:
           - name: delete-account

--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -10,7 +10,7 @@ on:
       batch-limit:
         description: "Maximum Codex scans to run in parallel per worker shard"
         required: true
-        default: "6"
+        default: "4"
       max-jobs:
         description: "Optional total jobs cap per worker shard"
         required: false
@@ -25,6 +25,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: clawhub-security-scan
+  cancel-in-progress: false
+
 jobs:
   codex-security-scan:
     name: Codex security scan shard ${{ matrix.shard }}
@@ -34,12 +38,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3, 4, 5, 6, 7]
+        shard: [0, 1, 2, 3]
     env:
       CONVEX_URL: ${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}
       SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-      CODEX_SECURITY_SCAN_LIMIT: ${{ inputs.limit || inputs['batch-limit'] || '6' }}
+      CODEX_SECURITY_SCAN_LIMIT: ${{ inputs.limit || inputs['batch-limit'] || '4' }}
       CODEX_SECURITY_SCAN_MAX_JOBS: ${{ inputs['max-jobs'] || '' }}
       CODEX_SECURITY_SCAN_MAX_RUNTIME_MINUTES: ${{ inputs['max-runtime-minutes'] || '40' }}
       CODEX_SECURITY_SCAN_LEASE_MINUTES: "60"

--- a/.github/workflows/skill-card-worker.yml
+++ b/.github/workflows/skill-card-worker.yml
@@ -9,7 +9,7 @@ on:
       batch-limit:
         description: "Maximum Skill Card jobs to run in parallel per worker shard"
         required: true
-        default: "6"
+        default: "4"
       max-jobs:
         description: "Optional total jobs cap per worker shard"
         required: false
@@ -22,6 +22,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: clawhub-skill-card-worker
+  cancel-in-progress: false
+
 jobs:
   skill-card-worker:
     name: Skill Card worker shard ${{ matrix.shard }}
@@ -31,12 +35,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3, 4, 5, 6, 7]
+        shard: [0, 1, 2, 3]
     env:
       CONVEX_URL: ${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}
       # Shared Convex worker credential used by security and Skill Card workers.
       SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}
-      SKILL_CARD_WORKER_LIMIT: ${{ github.event.inputs['batch-limit'] || '6' }}
+      SKILL_CARD_WORKER_LIMIT: ${{ github.event.inputs['batch-limit'] || '4' }}
       SKILL_CARD_WORKER_MAX_JOBS: ${{ github.event.inputs['max-jobs'] || '' }}
       SKILL_CARD_WORKER_MAX_RUNTIME_MINUTES: ${{ github.event.inputs['max-runtime-minutes'] || '40' }}
       SKILL_CARD_WORKER_LEASE_MINUTES: "60"

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -99,7 +99,7 @@ type JobDiagnosticInput = {
   status: "completed" | "failed";
 };
 
-const DEFAULT_BATCH_LIMIT = 6;
+const DEFAULT_BATCH_LIMIT = 4;
 const DEFAULT_MAX_RUNTIME_MS = 40 * 60 * 1000;
 const DEFAULT_CODEX_SCAN_TIMEOUT_MS = 20 * 60 * 1000;
 const MAX_DIAGNOSTIC_TEXT_CHARS = 20_000;

--- a/scripts/skill-cards/run-skill-card-worker.test.ts
+++ b/scripts/skill-cards/run-skill-card-worker.test.ts
@@ -42,7 +42,7 @@ describe("run-skill-card-worker Codex skill setup", () => {
   });
 
   it("uses the same batch, runtime, and lease defaults as the security worker", () => {
-    expect(DEFAULT_BATCH_LIMIT).toBe(6);
+    expect(DEFAULT_BATCH_LIMIT).toBe(4);
     expect(DEFAULT_MAX_RUNTIME_MS).toBe(40 * 60 * 1000);
     expect(DEFAULT_LEASE_MS).toBe(60 * 60 * 1000);
   });

--- a/scripts/skill-cards/run-skill-card-worker.ts
+++ b/scripts/skill-cards/run-skill-card-worker.ts
@@ -37,7 +37,7 @@ type CommandResult = {
 
 type JsonRecord = Record<string, unknown>;
 
-export const DEFAULT_BATCH_LIMIT = 6;
+export const DEFAULT_BATCH_LIMIT = 4;
 export const DEFAULT_MAX_RUNTIME_MS = 40 * 60 * 1000;
 export const DEFAULT_LEASE_MS = 60 * 60 * 1000;
 const DEFAULT_CODEX_TIMEOUT_MS = 15 * 60 * 1000;

--- a/scripts/skill-cards/skill-card-worker-workflow.test.ts
+++ b/scripts/skill-cards/skill-card-worker-workflow.test.ts
@@ -25,13 +25,16 @@ describe("skill-card-worker workflow", () => {
     };
     const job = workflow.jobs["skill-card-worker"];
 
-    expect(workflow.on?.workflow_dispatch?.inputs?.["batch-limit"]?.default).toBe("6");
+    expect(workflow.on?.workflow_dispatch?.inputs?.["batch-limit"]?.default).toBe("4");
     expect(workflow.on?.workflow_dispatch?.inputs?.["max-runtime-minutes"]?.default).toBe("40");
-    expect(workflow.concurrency).toBeUndefined();
+    expect(workflow.concurrency).toEqual({
+      group: "clawhub-skill-card-worker",
+      "cancel-in-progress": false,
+    });
     expect(job["timeout-minutes"]).toBe(60);
-    expect(job.strategy?.matrix?.shard).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+    expect(job.strategy?.matrix?.shard).toEqual([0, 1, 2, 3]);
     expect(job.env?.SKILL_CARD_WORKER_LIMIT).toBe(
-      "${{ github.event.inputs['batch-limit'] || '6' }}",
+      "${{ github.event.inputs['batch-limit'] || '4' }}",
     );
     expect(job.env?.SKILL_CARD_WORKER_MAX_RUNTIME_MINUTES).toBe(
       "${{ github.event.inputs['max-runtime-minutes'] || '40' }}",


### PR DESCRIPTION
## Summary
- right-size the standard CI jobs to Blacksmith 4-vCPU runners, keeping Playwright smoke at 8-vCPU
- cap local-auth matrix parallelism at 3
- halve security-scan and Skill Card worker shards and per-shard batch defaults, with non-canceling workflow concurrency guards

## Verification
- targeted Bun tests: 26 passed
- `bun run ci:static`
- Ruby YAML parse for changed workflows
- `git diff --check`
- branch autoreview clean

The goal is to smooth runner-registration bursts without cancelling an active worker wave.