### PR TITLE
Fix filtered plugin catalog pagination

### DIFF
--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -2656,6 +2656,113 @@ describe("packages public queries", () => {
     expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 120 });
   });
 
+  it("returns a cursor instead of paginating twice when sorted package filters skip rows", async () => {
+    const firstOfficial = makePackageDoc({
+      _id: "packages:official-1",
+      name: "official-1",
+      normalizedName: "official-1",
+      displayName: "Official 1",
+      family: "bundle-plugin",
+      isOfficial: true,
+      stats: { downloads: 100, installs: 0, stars: 0, versions: 1 },
+    });
+    const community = makePackageDoc({
+      _id: "packages:community",
+      name: "community",
+      normalizedName: "community",
+      displayName: "Community",
+      family: "bundle-plugin",
+      isOfficial: false,
+      stats: { downloads: 90, installs: 0, stars: 0, versions: 1 },
+    });
+    const secondOfficial = makePackageDoc({
+      _id: "packages:official-2",
+      name: "official-2",
+      normalizedName: "official-2",
+      displayName: "Official 2",
+      family: "bundle-plugin",
+      isOfficial: true,
+      stats: { downloads: 80, installs: 0, stars: 0, versions: 1 },
+    });
+    const { ctx, paginate } = makeDigestCtx({
+      packagePages: [
+        { page: [firstOfficial, community], isDone: false, continueCursor: "next-page" },
+        { page: [secondOfficial], isDone: true, continueCursor: "" },
+      ],
+    });
+
+    const first = await listPageForViewerInternalHandler(ctx, {
+      family: "bundle-plugin",
+      isOfficial: true,
+      sort: "downloads",
+      paginationOpts: { cursor: null, numItems: 2 },
+    });
+
+    expect(first.page.map((entry) => entry.name)).toEqual(["official-1"]);
+    expect(first.isDone).toBe(false);
+    expect(first.continueCursor).toMatch(/^pkgpage:/);
+    expect(paginate).toHaveBeenCalledTimes(1);
+
+    const second = await listPageForViewerInternalHandler(ctx, {
+      family: "bundle-plugin",
+      isOfficial: true,
+      sort: "downloads",
+      paginationOpts: { cursor: first.continueCursor, numItems: 2 },
+    });
+
+    expect(second.page.map((entry) => entry.name)).toEqual(["official-2"]);
+    expect(second.isDone).toBe(true);
+    expect(paginate).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns a cursor instead of paginating twice when digest scan filters skip rows", async () => {
+    const firstClean = makeDigest("clean-1", {
+      scanStatus: "clean",
+      updatedAt: 100,
+    });
+    const suspicious = makeDigest("suspicious", {
+      scanStatus: "suspicious",
+      updatedAt: 90,
+    });
+    const secondClean = makeDigest("clean-2", {
+      scanStatus: "clean",
+      updatedAt: 80,
+    });
+    const thirdClean = makeDigest("clean-3", {
+      scanStatus: "clean",
+      updatedAt: 70,
+    });
+    const { ctx, paginate } = makeDigestCtx({
+      pages: [
+        { page: [firstClean, suspicious, secondClean], isDone: false, continueCursor: "next-page" },
+        { page: [thirdClean], isDone: true, continueCursor: "" },
+      ],
+    });
+
+    const first = await listPageForViewerInternalHandler(ctx, {
+      family: "code-plugin",
+      sort: "updated",
+      excludedScanStatuses: ["suspicious"],
+      paginationOpts: { cursor: null, numItems: 3 },
+    });
+
+    expect(first.page.map((entry) => entry.name)).toEqual(["clean-1", "clean-2"]);
+    expect(first.isDone).toBe(false);
+    expect(first.continueCursor).toMatch(/^pkgpage:/);
+    expect(paginate).toHaveBeenCalledTimes(1);
+
+    const second = await listPageForViewerInternalHandler(ctx, {
+      family: "code-plugin",
+      sort: "updated",
+      excludedScanStatuses: ["suspicious"],
+      paginationOpts: { cursor: first.continueCursor, numItems: 3 },
+    });
+
+    expect(second.page.map((entry) => entry.name)).toEqual(["clean-3"]);
+    expect(second.isDone).toBe(true);
+    expect(paginate).toHaveBeenCalledTimes(2);
+  });
+
   it("normalizes public plugins from official publishers for official browse", async () => {
     const officialPublisher = {
       _id: "publishers:openclaw",
@@ -4372,13 +4479,23 @@ describe("packages public queries", () => {
       ],
     });
 
-    const result = await listPublicPageHandler(ctx, {
+    const first = await listPublicPageHandler(ctx, {
       topic: "calendar",
       paginationOpts: { cursor: null, numItems: 1 },
     });
 
-    expect(result.page.map((entry) => entry.name)).toEqual(["calendar-public"]);
-    expect(result.isDone).toBe(true);
+    expect(first.page).toEqual([]);
+    expect(first.isDone).toBe(false);
+    expect(first.continueCursor).toMatch(/^pkgpage:/);
+    expect(paginate).toHaveBeenCalledTimes(1);
+
+    const second = await listPublicPageHandler(ctx, {
+      topic: "calendar",
+      paginationOpts: { cursor: first.continueCursor, numItems: 1 },
+    });
+
+    expect(second.page.map((entry) => entry.name)).toEqual(["calendar-public"]);
+    expect(second.isDone).toBe(true);
     expect(paginate).toHaveBeenCalledTimes(2);
   });
 
@@ -4430,13 +4547,26 @@ describe("packages public queries", () => {
       ],
     });
 
-    const result = await listPublicPageHandler(ctx, {
+    const first = await listPublicPageHandler(ctx, {
       topic: "calendar",
       category: "tools",
       paginationOpts: { cursor: null, numItems: 1 },
     });
 
-    expect(result.page.map((entry) => entry.name)).toEqual(["calendar-api"]);
+    expect(first.page).toEqual([]);
+    expect(first.isDone).toBe(false);
+    expect(first.continueCursor).toMatch(/^pkgpage:/);
+    expect(tableNames).toEqual(["packageTopicSearchDigest"]);
+    expect(indexNames).toEqual(["by_active_topic_updated"]);
+    expect(paginate).toHaveBeenCalledTimes(1);
+
+    const second = await listPublicPageHandler(ctx, {
+      topic: "calendar",
+      category: "tools",
+      paginationOpts: { cursor: first.continueCursor, numItems: 1 },
+    });
+
+    expect(second.page.map((entry) => entry.name)).toEqual(["calendar-api"]);
     expect(tableNames).toEqual(["packageTopicSearchDigest", "packageTopicSearchDigest"]);
     expect(indexNames).toEqual(["by_active_topic_updated", "by_active_topic_updated"]);
     expect(paginate).toHaveBeenCalledTimes(2);
@@ -4456,25 +4586,27 @@ describe("packages public queries", () => {
     }));
     const { ctx, paginate } = makeDigestCtx({ topicPages });
 
-    const first = await listPublicPageHandler(ctx, {
+    let cursor: string | null = null;
+    for (let index = 0; index < 6; index += 1) {
+      const result = await listPublicPageHandler(ctx, {
+        topic: "calendar",
+        category: "tools",
+        paginationOpts: { cursor, numItems: 1 },
+      });
+      expect(result.page).toEqual([]);
+      expect(result.isDone).toBe(false);
+      expect(result.continueCursor.startsWith("pkgpage:")).toBe(true);
+      cursor = result.continueCursor;
+    }
+
+    const final = await listPublicPageHandler(ctx, {
       topic: "calendar",
       category: "tools",
-      paginationOpts: { cursor: null, numItems: 1 },
+      paginationOpts: { cursor, numItems: 1 },
     });
 
-    expect(first.page).toEqual([]);
-    expect(first.isDone).toBe(false);
-    expect(first.continueCursor.startsWith("pkgpage:")).toBe(true);
-    expect(paginate).toHaveBeenCalledTimes(6);
-
-    const second = await listPublicPageHandler(ctx, {
-      topic: "calendar",
-      category: "tools",
-      paginationOpts: { cursor: first.continueCursor, numItems: 1 },
-    });
-
-    expect(second.page.map((entry) => entry.name)).toEqual(["calendar-api"]);
-    expect(second.isDone).toBe(true);
+    expect(final.page.map((entry) => entry.name)).toEqual(["calendar-api"]);
+    expect(final.isDone).toBe(true);
     expect(paginate).toHaveBeenCalledTimes(7);
   });
 

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -3549,7 +3549,7 @@ async function listPackagePageImpl(
       return ctx.db.query("packages").withIndex(indexName, (q) => q.eq("softDeletedAt", undefined));
     };
 
-    while ((pageOffset > 0 || !done) && collected.length < targetCount) {
+    if (pageOffset > 0 || !done) {
       const scanPageSize = Math.min(
         MAX_PUBLIC_LIST_PAGE_SIZE,
         pageOffset > 0 && pageSize
@@ -3644,7 +3644,7 @@ async function listPackagePageImpl(
     ? MAX_PUBLIC_LIST_FILTER_SCAN_DOCUMENTS
     : MAX_PUBLIC_LIST_PAGE_SIZE;
 
-  while (
+  if (
     (pageOffset > 0 || !done) &&
     collected.length < targetCount &&
     digestScanPages < MAX_PUBLIC_LIST_FILTER_SCAN_PAGES &&
@@ -3657,61 +3657,61 @@ async function listPackagePageImpl(
         ? Math.max(pageSize, pageOffset + targetCount)
         : Math.max(effectivePageSize, targetCount),
     );
-    if (scanPageSize <= 0) break;
-    digestScanPages += 1;
-    remainingDigestScanBudget -= scanPageSize;
-    const currentCursor = cursor;
-    const page: {
-      page: PackageDigestLike[];
-      isDone: boolean;
-      continueCursor: string;
-    } = await buildDigestQuery()
-      .order("desc")
-      .paginate({ cursor: currentCursor, numItems: scanPageSize });
+    if (scanPageSize > 0) {
+      digestScanPages += 1;
+      remainingDigestScanBudget -= scanPageSize;
+      const currentCursor = cursor;
+      const page: {
+        page: PackageDigestLike[];
+        isDone: boolean;
+        continueCursor: string;
+      } = await buildDigestQuery()
+        .order("desc")
+        .paginate({ cursor: currentCursor, numItems: scanPageSize });
 
-    for (let index = pageOffset; index < page.page.length; index += 1) {
-      const digest = page.page[index] as PackageDigestLike;
-      if (!(await canViewPackage(digest))) continue;
-      if (family && digest.family !== family) continue;
-      if (channel && digest.channel !== channel) continue;
-      if (typeof isOfficial === "boolean" && digest.isOfficial !== isOfficial) {
-        continue;
+      for (let index = pageOffset; index < page.page.length; index += 1) {
+        const digest = page.page[index] as PackageDigestLike;
+        if (!(await canViewPackage(digest))) continue;
+        if (family && digest.family !== family) continue;
+        if (channel && digest.channel !== channel) continue;
+        if (typeof isOfficial === "boolean" && digest.isOfficial !== isOfficial) {
+          continue;
+        }
+        if (!digestMatchesFilters(digest, { ...args, category, topic })) continue;
+        collected.push(await toPublicPackageListItem(ctx, digest));
+        if (collected.length >= targetCount) {
+          const nextOffset = index + 1;
+          const nextState =
+            nextOffset < page.page.length
+              ? {
+                  cursor: currentCursor,
+                  offset: nextOffset,
+                  pageSize: scanPageSize,
+                  done: page.isDone,
+                  mode: "digest" as const,
+                  sort: effectiveDigestSort,
+                }
+              : {
+                  cursor: page.continueCursor,
+                  offset: 0,
+                  pageSize: scanPageSize,
+                  done: page.isDone,
+                  mode: "digest" as const,
+                  sort: effectiveDigestSort,
+                };
+          return {
+            page: collected,
+            isDone: nextState.done && nextState.offset === 0,
+            continueCursor: encodePublicPageCursor(nextState),
+          };
+        }
       }
-      if (!digestMatchesFilters(digest, { ...args, category, topic })) continue;
-      collected.push(await toPublicPackageListItem(ctx, digest));
-      if (collected.length >= targetCount) {
-        const nextOffset = index + 1;
-        const nextState =
-          nextOffset < page.page.length
-            ? {
-                cursor: currentCursor,
-                offset: nextOffset,
-                pageSize: scanPageSize,
-                done: page.isDone,
-                mode: "digest" as const,
-                sort: effectiveDigestSort,
-              }
-            : {
-                cursor: page.continueCursor,
-                offset: 0,
-                pageSize: scanPageSize,
-                done: page.isDone,
-                mode: "digest" as const,
-                sort: effectiveDigestSort,
-              };
-        return {
-          page: collected,
-          isDone: nextState.done && nextState.offset === 0,
-          continueCursor: encodePublicPageCursor(nextState),
-        };
-      }
+
+      done = page.isDone;
+      cursor = page.continueCursor;
+      pageOffset = 0;
+      pageSize = scanPageSize;
     }
-
-    done = page.isDone;
-    cursor = page.continueCursor;
-    pageOffset = 0;
-    pageSize = scanPageSize;
-    if (!requiresDigestPostFilterScan) break;
   }
 
   return {

--- a/e2e/local-auth/malicious-skill-ban-flow.pw.test.ts
+++ b/e2e/local-auth/malicious-skill-ban-flow.pw.test.ts
@@ -12,6 +12,7 @@ test.skip(
   "malicious skill ban flow requires the local dev auth runner",
 );
 test.setTimeout(180_000);
+test.describe.configure({ retries: 0 });
 
 const WORKER_TOKEN = process.env.SECURITY_SCAN_WORKER_TOKEN ?? "local-e2e-worker-token";
 const { ConvexHttpClient } = convexBrowser;
@@ -130,14 +131,28 @@ async function expectCurrentVersion(page: import("@playwright/test").Page, versi
 }
 
 function withoutExpectedBannedSessionTeardownErrors(errors: string[]) {
+  const timedOutDuringBannedSessionTeardown = [
+    "CONVEX Q(skills:listVersions)",
+    "CONVEX Q(skills:list)",
+    "CONVEX Q(users:me)",
+    "CONVEX Q(publishers:listMine)",
+    "CONVEX Q(publishers:getMyProfileHandle)",
+    "CONVEX M(packages:applyBanToOwnedPackagesBatchInternal)",
+  ];
   return errors.filter(
-    (error) => !(error.includes("CONVEX M(users:ensure)") && error.includes("User not found")),
+    (error) =>
+      !(error.includes("CONVEX M(users:ensure)") && error.includes("User not found")) &&
+      !(
+        error.includes("Function execution timed out (maximum duration: 1s)") &&
+        timedOutDuringBannedSessionTeardown.some((functionName) => error.includes(functionName))
+      ),
   );
 }
 
 test("malicious skill retries keep the clean latest visible, email the publisher, and ban on third rejection", async ({
   page,
 }, testInfo) => {
+  await page.route("https://openclaw.ai/**", (route) => route.fulfill({ status: 204 }));
   const errors = trackRuntimeErrors(page);
   const client = convexClient();
   const slug = `pw-malware-${Date.now().toString(36)}`;

--- a/scripts/run-playwright-local-auth.ts
+++ b/scripts/run-playwright-local-auth.ts
@@ -244,9 +244,18 @@ function isFunctionUnavailableOutput(output: string) {
   );
 }
 
+function isLocalConvexModuleStillPreparingOutput(output: string) {
+  return (
+    output.includes("InvalidModules") &&
+    output.includes("ENOENT: no such file or directory") &&
+    output.includes("/modules/")
+  );
+}
+
 function isFunctionReadinessRetryableOutput(output: string) {
   return (
     isFunctionUnavailableOutput(output) ||
+    isLocalConvexModuleStillPreparingOutput(output) ||
     output.includes("Function execution timed out (maximum duration: 1s)")
   );
 }

--- a/src/components/SkillPublishSuccessDialog.test.tsx
+++ b/src/components/SkillPublishSuccessDialog.test.tsx
@@ -102,7 +102,7 @@ describe("SkillPublishSuccessDialog", () => {
     await waitFor(() => {
       expect(writeTextMock).toHaveBeenCalledWith(expect.stringContaining("/vyctor/agent-helper"));
     });
-    expect(screen.getByText("Copied")).toBeTruthy();
+    expect(await screen.findByText("Copied")).toBeTruthy();
   });
 
   it("copies a ready Discord message before opening the Discord channel", async () => {


### PR DESCRIPTION
## Summary

Plugin catalog tabs that filter sparse package lists can fail with a Convex runtime error instead of returning the next matching packages. PR #2772 fixed the Official/downloads index case, but it does not cover filtered pagination paths such as the homepage Plugins -> New request:

```text
GET /api/v1/plugins?limit=20&excludeScanStatus=pending,suspicious&sort=updated
```

This PR changes package listing so each Convex query invocation performs one `.paginate()` call, then returns a resumable `pkgpage:` cursor when more filtered rows may exist. The existing HTTP catalog merge loop follows those cursors until it fills the requested page or reaches the end.

## What Changed

- Filtered package listing now scans one page per Convex query call and returns a cursor for the caller to resume.
- Sorted package scans and digest scans preserve cursor state after skipped rows.
- Topic/category digest pagination tests now expect one page per query call, then resume through the returned cursor.
- Regression tests cover skipped rows across sorted package scans, digest scans, official downloads pages, and topic/category pagination.
- The publish-success dialog test now waits for the async copied state before asserting it.
- The local-auth Playwright runner retries only transient Convex module-prep/readiness failures seen while functions are still preparing.
- The malicious-skill ban local-auth test now stubs external OpenClaw footer assets, allows the expected banned-session teardown timeouts, and disables retry because the test intentionally bans the only publisher persona it uses.

## Proof

Affected API shapes:

```text
GET /api/v1/plugins?limit=5&sort=updated&excludeScanStatus=pending,suspicious
GET /api/v1/bundle-plugins?limit=5&isOfficial=true&sort=downloads
```

Before this change, the underlying Convex package list query could call `.paginate()` more than once while trying to skip filtered-out rows, which Convex rejects. After this change, each invocation returns either matching rows or a `pkgpage:` cursor for the next invocation.

Screenshots are omitted because this PR does not change UI rendering. The visible effect is that existing homepage/plugin tabs receive API data instead of an API 500 after this backend change is deployed. The other UI-adjacent hunks are test-only.

## Verification

Net diff checked against current `main`:

```text
convex/packages.public.test.ts                     | 170 ++++++++++++++++++---
convex/packages.ts                                 | 110 ++++++-------
e2e/local-auth/malicious-skill-ban-flow.pw.test.ts |  17 ++-
scripts/run-playwright-local-auth.ts               |   9 ++
src/components/SkillPublishSuccessDialog.test.tsx  |   2 +-
5 files changed, 232 insertions(+), 76 deletions(-)
```

After the latest e2e-only commit, these checks passed locally:

```sh
bun run test:pw:local-auth -- --project=chromium e2e/local-auth/malicious-skill-ban-flow.pw.test.ts
bunx tsc --noEmit
bun run ci:static
```

Earlier on the same merged branch, before the final e2e-only stability commit, these broader checks passed locally:

```sh
bun run test convex/packages.public.test.ts --testNamePattern 'paginating twice|family-and-official downloads|legacy official downloads|official plugin pages'
bun run test convex/packages.public.test.ts
bun run test src/components/SkillPublishSuccessDialog.test.tsx
bunx tsc -p packages/schema/tsconfig.json --noEmit
bunx tsc -p packages/clawhub/tsconfig.json --noEmit
bun run ci:unit
bun run ci:types-build
```
