### PR TITLE
Fix Official plugin download listing

### DIFF
--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -1300,6 +1300,7 @@ function makeDigestCtx(options: {
                   if (
                     indexName === "by_active_downloads" ||
                     indexName === "by_active_family_downloads" ||
+                    indexName === "by_active_family_official_downloads" ||
                     indexName === "by_active_installs" ||
                     indexName === "by_active_family_installs" ||
                     indexName === "by_active_family_official_installs" ||
@@ -2654,6 +2655,153 @@ describe("packages public queries", () => {
     ]);
     expect(paginate).toHaveBeenCalledTimes(1);
     expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 120 });
+  });
+
+  it("uses a family-and-official downloads index for official plugin pages", async () => {
+    const { ctx, indexFilters, indexNames, paginate } = makeDigestCtx({
+      packagePages: [
+        {
+          page: [
+            makePackageDoc({
+              _id: "packages:official-code-plugin",
+              name: "official-code-plugin",
+              normalizedName: "official-code-plugin",
+              displayName: "Official Code Plugin",
+              family: "code-plugin",
+              isOfficial: true,
+              channel: "official",
+              stats: { downloads: 200, installs: 100, stars: 0, versions: 1 },
+            }),
+          ],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+    });
+
+    const result = await listPageForViewerInternalHandler(ctx, {
+      family: "code-plugin",
+      isOfficial: true,
+      sort: "downloads",
+      paginationOpts: { cursor: null, numItems: 24 },
+    });
+
+    expect(result.page.map((entry) => entry.name)).toEqual(["official-code-plugin"]);
+    expect(result.isDone).toBe(true);
+    expect(indexNames).toEqual(["by_active_family_official_downloads"]);
+    expect(indexFilters).toEqual([
+      {
+        indexName: "by_active_family_official_downloads",
+        filters: [
+          { field: "softDeletedAt", value: undefined },
+          { field: "family", value: "code-plugin" },
+          { field: "isOfficial", value: true },
+        ],
+      },
+    ]);
+    expect(paginate).toHaveBeenCalledTimes(1);
+    expect(paginate).toHaveBeenCalledWith({ cursor: null, numItems: 120 });
+  });
+
+  it("keeps new official downloads cursors on the family-and-official index", async () => {
+    const { ctx, indexNames } = makeDigestCtx({
+      packagePages: [
+        {
+          page: [
+            makePackageDoc({
+              _id: "packages:official-code-plugin-1",
+              name: "official-code-plugin-1",
+              normalizedName: "official-code-plugin-1",
+              displayName: "Official Code Plugin 1",
+              family: "code-plugin",
+              isOfficial: true,
+              channel: "official",
+            }),
+          ],
+          isDone: false,
+          continueCursor: "official-downloads-next",
+        },
+        {
+          page: [
+            makePackageDoc({
+              _id: "packages:official-code-plugin-2",
+              name: "official-code-plugin-2",
+              normalizedName: "official-code-plugin-2",
+              displayName: "Official Code Plugin 2",
+              family: "code-plugin",
+              isOfficial: true,
+              channel: "official",
+            }),
+          ],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+    });
+
+    const first = await listPageForViewerInternalHandler(ctx, {
+      family: "code-plugin",
+      isOfficial: true,
+      sort: "downloads",
+      paginationOpts: { cursor: null, numItems: 1 },
+    });
+    const second = await listPageForViewerInternalHandler(ctx, {
+      family: "code-plugin",
+      isOfficial: true,
+      sort: "downloads",
+      paginationOpts: { cursor: first.continueCursor, numItems: 1 },
+    });
+
+    expect(first.page.map((entry) => entry.name)).toEqual(["official-code-plugin-1"]);
+    expect(second.page.map((entry) => entry.name)).toEqual(["official-code-plugin-2"]);
+    expect(indexNames).toEqual([
+      "by_active_family_official_downloads",
+      "by_active_family_official_downloads",
+    ]);
+  });
+
+  it("keeps legacy official downloads cursors on the family downloads index", async () => {
+    const legacyCursor = `pkgpage:${JSON.stringify({
+      cursor: "legacy-official-downloads-next",
+      offset: 0,
+      pageSize: 50,
+      done: false,
+      mode: "packages",
+    })}`;
+    const { ctx, indexNames } = makeDigestCtx({
+      packagePages: [
+        {
+          page: [],
+          isDone: false,
+          continueCursor: "legacy-official-downloads-next",
+        },
+        {
+          page: [
+            makePackageDoc({
+              _id: "packages:official-code-plugin",
+              name: "official-code-plugin",
+              normalizedName: "official-code-plugin",
+              displayName: "Official Code Plugin",
+              family: "code-plugin",
+              isOfficial: true,
+              channel: "official",
+            }),
+          ],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+    });
+
+    const result = await listPageForViewerInternalHandler(ctx, {
+      family: "code-plugin",
+      isOfficial: true,
+      sort: "downloads",
+      paginationOpts: { cursor: legacyCursor, numItems: 1 },
+    });
+
+    expect(result.page.map((entry) => entry.name)).toEqual(["official-code-plugin"]);
+    expect(indexNames).toEqual(["by_active_family_downloads"]);
   });
 
   it("normalizes public plugins from official publishers for official browse", async () => {

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -901,6 +901,7 @@ type PublicPageCursorState = {
   done: boolean;
   mode?: "packages" | "digest";
   sort?: "updated" | "downloads" | "recommended" | "installs";
+  packageIndex?: "family-official-downloads";
 };
 const PUBLIC_PAGE_CURSOR_PREFIX = "pkgpage:";
 type OfficialFirstPackageCategoryCursorState = {
@@ -1549,6 +1550,8 @@ function decodePublicPageCursor(raw: string | null | undefined): PublicPageCurso
         parsed.sort === "installs"
           ? parsed.sort
           : undefined,
+      packageIndex:
+        parsed.packageIndex === "family-official-downloads" ? parsed.packageIndex : undefined,
     };
   } catch {
     return { cursor: null, offset: 0, pageSize: null, done: false };
@@ -3487,6 +3490,13 @@ async function listPackagePageImpl(
   }
   const pageCursor = decodedCursor.cursor;
   const offset = decodedCursor.offset;
+  const sortedPackageIndex =
+    family &&
+    args.sort === "downloads" &&
+    typeof isOfficial === "boolean" &&
+    (!args.paginationOpts.cursor || decodedCursor.packageIndex === "family-official-downloads")
+      ? ("family-official-downloads" as const)
+      : undefined;
   const effectivePageSize = Math.min(
     MAX_PUBLIC_LIST_PAGE_SIZE,
     Math.max(
@@ -3527,6 +3537,13 @@ async function listPackagePageImpl(
     let done = decodedCursor.done;
     const buildSortedQuery = () => {
       if (family) {
+        if (sortedPackageIndex === "family-official-downloads" && typeof isOfficial === "boolean") {
+          return ctx.db
+            .query("packages")
+            .withIndex("by_active_family_official_downloads", (q) =>
+              q.eq("softDeletedAt", undefined).eq("family", family).eq("isOfficial", isOfficial),
+            );
+        }
         if (args.sort === "installs" && typeof isOfficial === "boolean") {
           return ctx.db
             .query("packages")
@@ -3576,6 +3593,7 @@ async function listPackagePageImpl(
                   pageSize: scanPageSize,
                   done: page.isDone,
                   mode: "packages" as const,
+                  packageIndex: sortedPackageIndex,
                 }
               : {
                   cursor: page.continueCursor,
@@ -3583,6 +3601,7 @@ async function listPackagePageImpl(
                   pageSize: scanPageSize,
                   done: page.isDone,
                   mode: "packages" as const,
+                  packageIndex: sortedPackageIndex,
                 };
           return {
             page: collected,
@@ -3607,6 +3626,7 @@ async function listPackagePageImpl(
         pageSize,
         done,
         mode: "packages",
+        packageIndex: sortedPackageIndex,
       }),
     };
   }

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1428,6 +1428,13 @@ const packages = defineTable({
   .index("by_active_updated", ["softDeletedAt", "updatedAt"])
   .index("by_active_downloads", ["softDeletedAt", "stats.downloads", "updatedAt"])
   .index("by_active_family_downloads", ["softDeletedAt", "family", "stats.downloads", "updatedAt"])
+  .index("by_active_family_official_downloads", [
+    "softDeletedAt",
+    "family",
+    "isOfficial",
+    "stats.downloads",
+    "updatedAt",
+  ])
   .index("by_active_installs", ["softDeletedAt", "stats.installs", "updatedAt"])
   .index("by_active_family_installs", ["softDeletedAt", "family", "stats.installs", "updatedAt"])
   .index("by_active_family_official_installs", [


### PR DESCRIPTION
## Summary

- add a selective `family + isOfficial + downloads` package index for Official plugin listings
- route fresh Official plugin download pages through the selective index
- preserve compatibility with pre-deploy pagination cursors by continuing legacy cursors on the previous index

The production Official Plugins view was returning HTTP 500 because the downloads-sorted query scanned the broad active-family index and post-filtered sparse Official results, eventually crossing Convex transaction/pagination limits.

This complements #2771, which addresses the broader multi-`paginate()` behavior. This PR independently fixes the affected Official downloads view while following the repository's indexed-query rules.

## Verification

- `bun run test convex/packages.public.test.ts`
- clean isolated local Convex deploy: `bunx convex dev --once --typecheck disable`
- clean isolated local query: `bunx convex run packages:listPageForViewerInternal '{"family":"code-plugin","isOfficial":true,"sort":"downloads","paginationOpts":{"cursor":null,"numItems":20}}'`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bun run ci:packages`
- real local browser proof at `http://127.0.0.1:3001/` using the committed public corpus: the Official Plugins request returned HTTP 200 and rendered `@openclaw/googlechat` instead of the error state
- `bunx convex insights --prod --details` reported no deployment health issues

`bunx convex dev --once` against the shared cloud dev deployment remains blocked by unrelated pre-existing data/schema drift: a `packagePluginCategorySearchDigest` document contains an extra `capabilityTags` field. The same Convex deployment and query validation passed against a clean isolated local deployment.

Autoreview identified the cursor compatibility risk; the fix and regression coverage were added, and the final autoreview completed with no actionable findings.
