### PR TITLE
fix: harden CSP and staged secret output

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -34,6 +34,7 @@ const config = {
     ".": {
       entry: [
         "src/router.tsx!",
+        "src/server.ts!",
         "src/routes/**/*.{ts,tsx}!",
         "src/styles.css!",
         "server/**/*.{ts,tsx}!",

--- a/public/theme-bootstrap.js
+++ b/public/theme-bootstrap.js
@@ -1,0 +1,117 @@
+(function () {
+  try {
+    var d = document.documentElement;
+    var selectionKey = "clawhub-theme-selection";
+    var modeKey = "clawhub-theme";
+    var nameKey = "clawhub-theme-name";
+    var legacyModeKey = "clawdhub-theme";
+    var customThemeKey = "clawhub-custom-theme";
+    var preferencesKey = "clawhub-preferences";
+    var defaults = { theme: "claw", mode: "system" };
+    var storageKeys = [
+      customThemeKey,
+      preferencesKey,
+      selectionKey,
+      modeKey,
+      nameKey,
+      legacyModeKey,
+    ];
+    var cookieKeys = storageKeys;
+
+    function hasCookie(name) {
+      if (!document.cookie) return false;
+      return document.cookie.split(";").some(function (part) {
+        return part.trim().indexOf(name + "=") === 0;
+      });
+    }
+
+    function clearCookie(name) {
+      document.cookie = name + "=; Max-Age=0; path=/";
+      document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/";
+    }
+
+    function cleanupDom() {
+      var style = document.getElementById("clawhub-custom-theme-style");
+      if (style) style.remove();
+      var fonts = document.getElementById("clawhub-custom-theme-fonts");
+      if (fonts) fonts.remove();
+      d.classList.remove("theme-custom", "high-contrast", "reduce-motion");
+      delete d.dataset.density;
+      delete d.dataset.animation;
+      d.style.removeProperty("--code-font-size");
+    }
+
+    var reset = false;
+    try {
+      if (localStorage.getItem(customThemeKey) || localStorage.getItem(preferencesKey)) {
+        reset = true;
+      }
+      var raw = localStorage.getItem(selectionKey);
+      if (raw) {
+        try {
+          var parsed = JSON.parse(raw);
+          if (parsed && parsed.theme && parsed.theme !== "claw") reset = true;
+        } catch (_error) {
+          reset = true;
+        }
+      }
+      var storedName = localStorage.getItem(nameKey);
+      if (storedName && storedName !== "claw") reset = true;
+      var storedMode = localStorage.getItem(modeKey);
+      if (storedMode && ["system", "light", "dark"].indexOf(storedMode) < 0) reset = true;
+      var legacyMode = localStorage.getItem(legacyModeKey);
+      if (legacyMode && ["system", "light", "dark"].indexOf(legacyMode) < 0) reset = true;
+    } catch (_error) {}
+
+    if (cookieKeys.some(hasCookie)) reset = true;
+    if (reset) {
+      try {
+        storageKeys.forEach(function (key) {
+          localStorage.removeItem(key);
+        });
+        localStorage.setItem(selectionKey, JSON.stringify(defaults));
+        localStorage.setItem(modeKey, defaults.mode);
+        localStorage.setItem(nameKey, defaults.theme);
+      } catch (_error) {}
+      cookieKeys.forEach(clearCookie);
+      cleanupDom();
+    }
+
+    var selection;
+    try {
+      var storedSelection = localStorage.getItem(selectionKey);
+      if (storedSelection) selection = JSON.parse(storedSelection);
+    } catch (_error) {}
+
+    if (!selection) {
+      var mode = localStorage.getItem(modeKey);
+      var theme = localStorage.getItem(nameKey);
+      if (mode || theme) {
+        selection = { theme: theme || "claw", mode: mode || "system" };
+      } else {
+        var legacy = localStorage.getItem(legacyModeKey);
+        if (legacy) {
+          var legacyModeMap = { dark: "dark", light: "light", system: "system" };
+          selection = { theme: "claw", mode: legacyModeMap[legacy] || "system" };
+        }
+      }
+    }
+
+    if (!selection) selection = defaults;
+    if (["claw"].indexOf(selection.theme) < 0) selection.theme = "claw";
+    if (["system", "light", "dark"].indexOf(selection.mode) < 0) selection.mode = "system";
+
+    var resolved =
+      selection.mode === "system"
+        ? window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
+          ? "dark"
+          : "light"
+        : selection.mode;
+    d.dataset.theme = resolved;
+    d.dataset.themeResolved = resolved;
+    d.dataset.themeMode = selection.mode;
+    d.dataset.themeFamily = selection.theme;
+    if (resolved === "dark") d.classList.add("dark");
+    else d.classList.remove("dark");
+  } catch (_error) {}
+})();

--- a/scripts/check-staged-secrets.mjs
+++ b/scripts/check-staged-secrets.mjs
@@ -78,6 +78,15 @@ function scanContent(path, content) {
   return findings;
 }
 
+function redactSecrets(value) {
+  let redacted = value;
+  for (const { pattern } of SECRET_PATTERNS) {
+    const flags = pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`;
+    redacted = redacted.replace(new RegExp(pattern.source, flags), "[REDACTED]");
+  }
+  return redacted;
+}
+
 const stagedPaths = getStagedPaths();
 const findings = [];
 
@@ -106,7 +115,7 @@ console.error(
 );
 console.error("");
 for (const finding of findings) {
-  console.error(`- ${finding.path}: ${finding.reason}`);
+  console.error(`- ${redactSecrets(finding.path)}: ${finding.reason}`);
   console.error("  [REDACTED]");
 }
 console.error("");

--- a/scripts/check-staged-secrets.mjs
+++ b/scripts/check-staged-secrets.mjs
@@ -73,7 +73,6 @@ function scanContent(path, content) {
     findings.push({
       path,
       reason: `matched ${name}`,
-      snippet: match[0].slice(0, 80),
     });
   }
   return findings;
@@ -87,7 +86,6 @@ for (const path of stagedPaths) {
     findings.push({
       path,
       reason: "sensitive file type should not be committed",
-      snippet: path,
     });
     continue;
   }
@@ -109,7 +107,7 @@ console.error(
 console.error("");
 for (const finding of findings) {
   console.error(`- ${finding.path}: ${finding.reason}`);
-  console.error(`  ${finding.snippet}`);
+  console.error("  [REDACTED]");
 }
 console.error("");
 console.error("If a real secret was staged, rotate it before trying again.");

--- a/scripts/check-staged-secrets.test.mjs
+++ b/scripts/check-staged-secrets.test.mjs
@@ -1,7 +1,7 @@
 /* @vitest-environment node */
 
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -31,7 +31,7 @@ function createTempGitRepo() {
 describe("check-staged-secrets", () => {
   it("blocks staged secrets without printing reconstructable secret material", () => {
     const cwd = createTempGitRepo();
-    const token = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    const token = ["gh", "p_", "A".repeat(30)].join("");
     writeFileSync(join(cwd, "leak.txt"), `token=${token}\n`, "utf8");
     runGit(cwd, ["add", "leak.txt"]);
 
@@ -41,6 +41,23 @@ describe("check-staged-secrets", () => {
     expect(result.stderr).toContain("Secret scan blocked this commit.");
     expect(result.stderr).toContain("- leak.txt: matched GitHub token");
     expect(result.stderr).toContain("[REDACTED]");
+    expect(result.stderr).not.toContain(token);
+    expect(result.stderr).not.toContain("ghp_");
+  });
+
+  it("redacts secret material from blocked staged paths", () => {
+    const cwd = createTempGitRepo();
+    const token = ["gh", "p_", "B".repeat(30)].join("");
+    const secretDir = `leaks-${token}`;
+    mkdirSync(join(cwd, secretDir));
+    writeFileSync(join(cwd, secretDir, ".env.local"), "SAFE=value\n", "utf8");
+    runGit(cwd, ["add", join(secretDir, ".env.local")]);
+
+    const result = spawnSync("node", [scannerPath], { cwd, encoding: "utf8" });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(`- leaks-[REDACTED]/.env.local`);
+    expect(result.stderr).toContain("sensitive file type should not be committed");
     expect(result.stderr).not.toContain(token);
     expect(result.stderr).not.toContain("ghp_");
   });

--- a/scripts/check-staged-secrets.test.mjs
+++ b/scripts/check-staged-secrets.test.mjs
@@ -1,0 +1,47 @@
+/* @vitest-environment node */
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "..");
+const scannerPath = join(repoRoot, "scripts/check-staged-secrets.mjs");
+const tempRepos = [];
+
+afterEach(() => {
+  for (const path of tempRepos.splice(0)) {
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+function runGit(cwd, args) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  expect(result.status, `${args.join(" ")}\n${result.stderr}`).toBe(0);
+}
+
+function createTempGitRepo() {
+  const cwd = mkdtempSync(join(tmpdir(), "clawhub-secret-scan-"));
+  tempRepos.push(cwd);
+  runGit(cwd, ["init"]);
+  return cwd;
+}
+
+describe("check-staged-secrets", () => {
+  it("blocks staged secrets without printing reconstructable secret material", () => {
+    const cwd = createTempGitRepo();
+    const token = "ghp_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    writeFileSync(join(cwd, "leak.txt"), `token=${token}\n`, "utf8");
+    runGit(cwd, ["add", "leak.txt"]);
+
+    const result = spawnSync("node", [scannerPath], { cwd, encoding: "utf8" });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Secret scan blocked this commit.");
+    expect(result.stderr).toContain("- leak.txt: matched GitHub token");
+    expect(result.stderr).toContain("[REDACTED]");
+    expect(result.stderr).not.toContain(token);
+    expect(result.stderr).not.toContain("ghp_");
+  });
+});

--- a/scripts/vercel-security-headers.test.mjs
+++ b/scripts/vercel-security-headers.test.mjs
@@ -3,15 +3,25 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import {
+  createContentSecurityPolicy,
+  isLocalDevelopmentRequestUrl,
+} from "../src/lib/securityHeaders";
 
 const repoRoot = resolve(import.meta.dirname, "..");
+const bootstrapPath = resolve(repoRoot, "public/theme-bootstrap.js");
+
+function getGlobalVercelHeaders() {
+  const vercelConfig = JSON.parse(readFileSync(resolve(repoRoot, "vercel.json"), "utf8"));
+  return vercelConfig.headers.find((entry) => entry.source === "/(.*)")?.headers ?? [];
+}
 
 function getCspHeader() {
-  const vercelConfig = JSON.parse(readFileSync(resolve(repoRoot, "vercel.json"), "utf8"));
-  const globalHeaders = vercelConfig.headers.find((entry) => entry.source === "/(.*)")?.headers;
-  const csp = globalHeaders?.find((header) => header.key === "Content-Security-Policy")?.value;
-  expect(csp).toEqual(expect.any(String));
-  return csp;
+  return createContentSecurityPolicy("test-nonce");
+}
+
+function getLocalDevelopmentCspHeader() {
+  return createContentSecurityPolicy("test-nonce", { allowLocalDevelopment: true });
 }
 
 function getDirective(csp, name) {
@@ -23,9 +33,23 @@ function getDirective(csp, name) {
   );
 }
 
+function getDirectiveTokens(csp, name) {
+  return getDirective(csp, name).split(/\s+/u);
+}
+
+function runBootstrap() {
+  window.eval(readFileSync(bootstrapPath, "utf8"));
+}
+
 describe("Vercel security headers", () => {
   afterEach(() => {
     window.localStorage.clear();
+    for (const cookie of document.cookie.split(";")) {
+      const name = cookie.split("=")[0]?.trim();
+      if (name) document.cookie = `${name}=; Max-Age=0; path=/`;
+    }
+    document.getElementById("clawhub-custom-theme-style")?.remove();
+    document.getElementById("clawhub-custom-theme-fonts")?.remove();
     document.documentElement.className = "";
     delete document.documentElement.dataset.theme;
     delete document.documentElement.dataset.themeResolved;
@@ -34,9 +58,65 @@ describe("Vercel security headers", () => {
   });
 
   it("does not allow all inline scripts in the global CSP", () => {
-    expect(getDirective(getCspHeader(), "script-src").split(/\s+/u)).not.toContain(
-      "'unsafe-inline'",
-    );
+    expect(getDirectiveTokens(getCspHeader(), "script-src")).not.toContain("'unsafe-inline'");
+  });
+
+  it("allows the self-hosted theme bootstrap and nonce-tagged framework scripts", () => {
+    expect(getDirectiveTokens(getCspHeader(), "script-src")).toEqual([
+      "script-src",
+      "'self'",
+      "'nonce-test-nonce'",
+      "'unsafe-eval'",
+    ]);
+  });
+
+  it("documents the current eval allowance without reopening inline script execution", () => {
+    const scriptTokens = getDirectiveTokens(getCspHeader(), "script-src");
+
+    expect(scriptTokens).toContain("'unsafe-eval'");
+    expect(scriptTokens).not.toContain("'unsafe-inline'");
+  });
+
+  it("does not emit a second static Vercel CSP that would block dynamic nonces", () => {
+    expect(
+      getGlobalVercelHeaders().some((header) => header.key === "Content-Security-Policy"),
+    ).toBe(false);
+  });
+
+  it("keeps local Convex HTTP and WebSocket connections usable in local development", () => {
+    const csp = getLocalDevelopmentCspHeader();
+    const connectTokens = getDirectiveTokens(csp, "connect-src");
+
+    expect(connectTokens).toEqual(["connect-src", "'self'", "https:", "wss:", "http:", "ws:"]);
+    expect(csp).not.toContain("[::1]");
+    expect(csp).not.toContain("upgrade-insecure-requests");
+  });
+
+  it("keeps local docs auth form posts usable only in local development", () => {
+    expect(getDirectiveTokens(getCspHeader(), "form-action")).toEqual([
+      "form-action",
+      "'self'",
+      "https://clawhub.ai",
+      "https://documentation.openclaw.ai",
+      "https://docs.openclaw.ai",
+    ]);
+
+    expect(getDirectiveTokens(getLocalDevelopmentCspHeader(), "form-action")).toEqual([
+      "form-action",
+      "'self'",
+      "https://clawhub.ai",
+      "https://documentation.openclaw.ai",
+      "https://docs.openclaw.ai",
+      "http://localhost:*",
+      "http://127.0.0.1:*",
+    ]);
+  });
+
+  it("detects IPv4, IPv6, and localhost app origins as local development", () => {
+    expect(isLocalDevelopmentRequestUrl("http://localhost:3000/")).toBe(true);
+    expect(isLocalDevelopmentRequestUrl("http://127.0.0.1:3000/")).toBe(true);
+    expect(isLocalDevelopmentRequestUrl("http://[::1]:3000/")).toBe(true);
+    expect(isLocalDevelopmentRequestUrl("https://clawhub.ai/")).toBe(false);
   });
 
   it("loads the theme bootstrap as an external self-hosted script", () => {
@@ -52,12 +132,64 @@ describe("Vercel security headers", () => {
       JSON.stringify({ theme: "claw", mode: "dark" }),
     );
 
-    window.eval(readFileSync(resolve(repoRoot, "public/theme-bootstrap.js"), "utf8"));
+    runBootstrap();
 
     expect(document.documentElement.dataset.theme).toBe("dark");
     expect(document.documentElement.dataset.themeResolved).toBe("dark");
     expect(document.documentElement.dataset.themeMode).toBe("dark");
     expect(document.documentElement.dataset.themeFamily).toBe("claw");
     expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("cleans stale custom theme state from the external bootstrap", () => {
+    window.localStorage.setItem(
+      "clawhub-custom-theme",
+      JSON.stringify({ light: { background: "red" }, dark: { background: "black" } }),
+    );
+    window.localStorage.setItem(
+      "clawhub-theme-selection",
+      JSON.stringify({ theme: "hub", mode: "dark" }),
+    );
+    window.localStorage.setItem("clawhub-theme", "dark");
+    window.localStorage.setItem("clawhub-theme-name", "hub");
+    window.localStorage.setItem(
+      "clawhub-preferences",
+      JSON.stringify({ layoutDensity: "compact" }),
+    );
+    document.cookie = "clawhub-custom-theme=1; path=/";
+    document.cookie = "clawhub-preferences=1; path=/";
+
+    const style = document.createElement("style");
+    style.id = "clawhub-custom-theme-style";
+    document.head.appendChild(style);
+    const fonts = document.createElement("link");
+    fonts.id = "clawhub-custom-theme-fonts";
+    document.head.appendChild(fonts);
+    document.documentElement.classList.add("theme-custom", "high-contrast", "reduce-motion");
+    document.documentElement.dataset.density = "compact";
+    document.documentElement.dataset.animation = "none";
+    document.documentElement.style.setProperty("--code-font-size", "16px");
+
+    runBootstrap();
+
+    expect(window.localStorage.getItem("clawhub-custom-theme")).toBeNull();
+    expect(window.localStorage.getItem("clawhub-preferences")).toBeNull();
+    expect(window.localStorage.getItem("clawhub-theme")).toBe("system");
+    expect(window.localStorage.getItem("clawhub-theme-name")).toBe("claw");
+    expect(window.localStorage.getItem("clawhub-theme-selection")).toBe(
+      JSON.stringify({ theme: "claw", mode: "system" }),
+    );
+    expect(document.cookie).not.toContain("clawhub-custom-theme");
+    expect(document.cookie).not.toContain("clawhub-preferences");
+    expect(document.getElementById("clawhub-custom-theme-style")).toBeNull();
+    expect(document.getElementById("clawhub-custom-theme-fonts")).toBeNull();
+    expect(document.documentElement.classList.contains("theme-custom")).toBe(false);
+    expect(document.documentElement.classList.contains("high-contrast")).toBe(false);
+    expect(document.documentElement.classList.contains("reduce-motion")).toBe(false);
+    expect(document.documentElement.dataset.density).toBeUndefined();
+    expect(document.documentElement.dataset.animation).toBeUndefined();
+    expect(document.documentElement.style.getPropertyValue("--code-font-size")).toBe("");
+    expect(document.documentElement.dataset.themeFamily).toBe("claw");
+    expect(document.documentElement.dataset.themeMode).toBe("system");
   });
 });

--- a/scripts/vercel-security-headers.test.mjs
+++ b/scripts/vercel-security-headers.test.mjs
@@ -1,0 +1,63 @@
+/* @vitest-environment jsdom */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const repoRoot = resolve(import.meta.dirname, "..");
+
+function getCspHeader() {
+  const vercelConfig = JSON.parse(readFileSync(resolve(repoRoot, "vercel.json"), "utf8"));
+  const globalHeaders = vercelConfig.headers.find((entry) => entry.source === "/(.*)")?.headers;
+  const csp = globalHeaders?.find((header) => header.key === "Content-Security-Policy")?.value;
+  expect(csp).toEqual(expect.any(String));
+  return csp;
+}
+
+function getDirective(csp, name) {
+  return (
+    csp
+      .split(";")
+      .map((directive) => directive.trim())
+      .find((directive) => directive.startsWith(`${name} `)) ?? ""
+  );
+}
+
+describe("Vercel security headers", () => {
+  afterEach(() => {
+    window.localStorage.clear();
+    document.documentElement.className = "";
+    delete document.documentElement.dataset.theme;
+    delete document.documentElement.dataset.themeResolved;
+    delete document.documentElement.dataset.themeMode;
+    delete document.documentElement.dataset.themeFamily;
+  });
+
+  it("does not allow all inline scripts in the global CSP", () => {
+    expect(getDirective(getCspHeader(), "script-src").split(/\s+/u)).not.toContain(
+      "'unsafe-inline'",
+    );
+  });
+
+  it("loads the theme bootstrap as an external self-hosted script", () => {
+    const rootRoute = readFileSync(resolve(repoRoot, "src/routes/__root.tsx"), "utf8");
+
+    expect(rootRoute).toContain('src="/theme-bootstrap.js');
+    expect(rootRoute).not.toContain("dangerouslySetInnerHTML");
+  });
+
+  it("applies the stored theme selection from the external bootstrap", () => {
+    window.localStorage.setItem(
+      "clawhub-theme-selection",
+      JSON.stringify({ theme: "claw", mode: "dark" }),
+    );
+
+    window.eval(readFileSync(resolve(repoRoot, "public/theme-bootstrap.js"), "utf8"));
+
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(document.documentElement.dataset.themeResolved).toBe("dark");
+    expect(document.documentElement.dataset.themeMode).toBe("dark");
+    expect(document.documentElement.dataset.themeFamily).toBe("claw");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+});

--- a/src/lib/securityHeaders.ts
+++ b/src/lib/securityHeaders.ts
@@ -1,0 +1,57 @@
+const CSP_FORM_ACTION_ORIGINS = [
+  "'self'",
+  "https://clawhub.ai",
+  "https://documentation.openclaw.ai",
+  "https://docs.openclaw.ai",
+];
+
+const LOCAL_DEVELOPMENT_CONNECT_SOURCES = [
+  // Browser CSP parsers reject bracketed IPv6 host sources like http://[::1]:*.
+  "http:",
+  "ws:",
+];
+
+const LOCAL_DEVELOPMENT_FORM_ACTION_ORIGINS = ["http://localhost:*", "http://127.0.0.1:*"];
+
+type ContentSecurityPolicyOptions = {
+  allowLocalDevelopment?: boolean;
+};
+
+export function isLocalDevelopmentRequestUrl(requestUrl: string) {
+  const { hostname } = new URL(requestUrl);
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "[::1]" ||
+    hostname === "::1"
+  );
+}
+
+export function createContentSecurityPolicy(
+  scriptNonce: string,
+  options: ContentSecurityPolicyOptions = {},
+) {
+  const connectSources = ["'self'", "https:", "wss:"];
+  const formActionOrigins = [...CSP_FORM_ACTION_ORIGINS];
+  if (options.allowLocalDevelopment) {
+    connectSources.push(...LOCAL_DEVELOPMENT_CONNECT_SOURCES);
+    formActionOrigins.push(...LOCAL_DEVELOPMENT_FORM_ACTION_ORIGINS);
+  }
+
+  return [
+    "default-src 'self'",
+    // Arktype currently ships in public route bundles through shared schema helpers and probes
+    // eval support with Function(). Keep inline scripts nonce-gated, but allow eval until those
+    // helpers are split out of the browser bundle.
+    `script-src 'self' 'nonce-${scriptNonce}' 'unsafe-eval'`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob: https:",
+    "font-src 'self' data:",
+    `connect-src ${connectSources.join(" ")}`,
+    "object-src 'none'",
+    "base-uri 'self'",
+    "frame-ancestors 'none'",
+    `form-action ${formActionOrigins.join(" ")}`,
+    ...(options.allowLocalDevelopment ? [] : ["upgrade-insecure-requests"]),
+  ].join("; ");
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -166,14 +166,10 @@ function RootDocument({ children }: { children: React.ReactNode }) {
     !["localhost", "127.0.0.1", "::1"].includes(window.location.hostname);
 
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <HeadContent />
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `(function(){try{var d=document.documentElement,s='clawhub-theme-selection',k='clawhub-theme',n='clawhub-theme-name',l='clawdhub-theme',c='clawhub-custom-theme',p='clawhub-preferences';var defaults={theme:'claw',mode:'system'};var storageKeys=[c,p,s,k,n,l];var cookieKeys=[c,p,s,k,n,l];function hasCookie(name){if(!document.cookie)return false;return document.cookie.split(';').some(function(part){return part.trim().indexOf(name+'=')===0})}function clearCookie(name){document.cookie=name+'=; Max-Age=0; path=/';document.cookie=name+'=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/'}function cleanupDom(){var style=document.getElementById('clawhub-custom-theme-style');if(style)style.remove();var fonts=document.getElementById('clawhub-custom-theme-fonts');if(fonts)fonts.remove();d.classList.remove('theme-custom','high-contrast','reduce-motion');delete d.dataset.density;delete d.dataset.animation;d.style.removeProperty('--code-font-size')}var reset=false;try{if(localStorage.getItem(c)||localStorage.getItem(p))reset=true;var raw=localStorage.getItem(s);if(raw){try{var parsed=JSON.parse(raw);if(parsed&&parsed.theme&&parsed.theme!=='claw')reset=true}catch(e){reset=true}}var storedName=localStorage.getItem(n);if(storedName&&storedName!=='claw')reset=true;var storedMode=localStorage.getItem(k);if(storedMode&&['system','light','dark'].indexOf(storedMode)<0)reset=true;var legacy=localStorage.getItem(l);if(legacy&&['system','light','dark'].indexOf(legacy)<0)reset=true}catch(e){}if(cookieKeys.some(hasCookie))reset=true;if(reset){try{storageKeys.forEach(function(key){localStorage.removeItem(key)});localStorage.setItem(s,JSON.stringify(defaults));localStorage.setItem(k,defaults.mode);localStorage.setItem(n,defaults.theme)}catch(e){}cookieKeys.forEach(clearCookie);cleanupDom()}var sel;try{var stored=localStorage.getItem(s);if(stored){sel=JSON.parse(stored)}}catch(e){}if(!sel){var m=localStorage.getItem(k),t=localStorage.getItem(n);if(m||t){sel={theme:t||'claw',mode:m||'system'}}else{var lg=localStorage.getItem(l);if(lg){var map={dark:'dark',light:'light',system:'system'};sel={theme:'claw',mode:map[lg]||'system'}}}}if(!sel)sel=defaults;var themes=['claw'],modes=['system','light','dark'];if(themes.indexOf(sel.theme)<0)sel.theme='claw';if(modes.indexOf(sel.mode)<0)sel.mode='system';var resolved=sel.mode==='system'?(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):sel.mode;d.dataset.theme=resolved;d.dataset.themeResolved=resolved;d.dataset.themeMode=sel.mode;d.dataset.themeFamily=sel.theme;if(resolved==='dark')d.classList.add('dark');else d.classList.remove('dark')}catch(e){}})()`,
-          }}
-        />
+        <script src="/theme-bootstrap.js" />
       </head>
       <body>
         <AppProviders>

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,37 @@
+import type { Register } from "@tanstack/react-router";
+import {
+  createStartHandler,
+  defaultStreamHandler,
+  type RequestHandler,
+} from "@tanstack/react-start/server";
+import { createContentSecurityPolicy, isLocalDevelopmentRequestUrl } from "./lib/securityHeaders";
+
+function createNonce() {
+  const bytes = new Uint8Array(18);
+  crypto.getRandomValues(bytes);
+  return Buffer.from(bytes).toString("base64");
+}
+
+const fetch = createStartHandler(async (ctx) => {
+  const nonce = createNonce();
+  ctx.router.update({ ssr: { nonce } });
+  ctx.responseHeaders.set(
+    "Content-Security-Policy",
+    createContentSecurityPolicy(nonce, {
+      allowLocalDevelopment: isLocalDevelopmentRequestUrl(ctx.request.url),
+    }),
+  );
+  return defaultStreamHandler(ctx);
+});
+
+type ServerEntry = { fetch: RequestHandler<Register> };
+
+function createServerEntry(entry: ServerEntry): ServerEntry {
+  return {
+    async fetch(...args) {
+      return await entry.fetch(...args);
+    },
+  };
+}
+
+export default createServerEntry({ fetch });

--- a/vercel.json
+++ b/vercel.json
@@ -3,10 +3,6 @@
     {
       "source": "/(.*)",
       "headers": [
-        {
-          "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self' https://clawhub.ai https://documentation.openclaw.ai https://docs.openclaw.ai; upgrade-insecure-requests"
-        },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },

--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self' https://clawhub.ai https://documentation.openclaw.ai https://docs.openclaw.ai; upgrade-insecure-requests"
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self' https://clawhub.ai https://documentation.openclaw.ai https://docs.openclaw.ai; upgrade-insecure-requests"
         },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },


### PR DESCRIPTION
## Summary

This hardens two defense-in-depth surfaces from `GHSA-p2qm-w5vv-54j3`. The staged-secret scanner still blocks commits when it finds likely secrets, but it no longer stores or prints matched token text. The app now serves a dynamic CSP with per-request script nonces, so ClawHub can remove global script `'unsafe-inline'` while keeping TanStack Start SSR scripts and the self-hosted theme bootstrap working.

## What Changed

- Staged-secret scanner output: findings now print path, reason, and `[REDACTED]`; token-shaped material is also redacted from blocked staged paths.
- Theme bootstrap: the existing pre-hydration theme/reset logic moved from an inline script in `src/routes/__root.tsx` to `public/theme-bootstrap.js`, loaded as `/theme-bootstrap.js`.
- CSP runtime: `src/server.ts` generates a per-request nonce, passes it into TanStack SSR, and sets a matching `Content-Security-Policy` header.
- CSP policy: production script CSP removes global `'unsafe-inline'` and uses `'self' 'nonce-...' 'unsafe-eval'`. The eval allowance is intentional for the current client bundle because shared `clawhub-schema` helpers pull in arktype, which probes eval support with `Function()`; inline scripts remain nonce-gated.
- Local development CSP: loopback responses keep HTTP/WebSocket and docs-auth form-post allowances needed for development.
- Vercel headers: the static global CSP was removed from `vercel.json` so it does not conflict with dynamic nonces; other security headers remain.
- Regression coverage: added scanner redaction tests, CSP helper tests, local-development CSP tests, external-bootstrap behavior tests, and an explicit test documenting that `unsafe-eval` must not reopen `'unsafe-inline'`.

## Proof

Behavioral proof:

- A staged fake GitHub token is blocked, and stderr contains `[REDACTED]` without the token prefix or token value.
- A token-shaped staged path such as `leaks-<token>/.env.local` is blocked and printed as `leaks-[REDACTED]/.env.local`.
- Built SSR responses include a fresh nonce in `script-src`; `/theme-bootstrap.js` is loaded as a same-origin external script, and all inline TanStack/runtime scripts carry the matching nonce.
- Browser CSP probe against a built local preview loaded `/`, `/skills`, and `/plugins` with no `securitypolicyviolation` events, no CSP console errors, and no page errors.

Reviewer-checkable CSP sample from the rebuilt local preview:

```text
status 200
script-src 'self' 'nonce-MMoWNwba1xT0oXHKu43OKvOY' 'unsafe-eval'
nonceLength 24
hasUnsafeInlineScript false
hasUnsafeEval true
scriptTags 4
noncedScriptCount 3
externalTheme true
unnoncedInlineScripts 0
browserCspViolations []
```

Screenshots: omitted because the PR intentionally preserves visible UI state. The changed behavior is header/script execution and scanner stderr output, which the commands and CSP sample prove more directly than an unchanged page screenshot.

## Verification

Automated checks passed locally:

- `bun run check:secrets`
- `bun run test -- scripts/check-staged-secrets.test.mjs scripts/vercel-security-headers.test.mjs`
- `bun run format:check -- knip.config.ts public/theme-bootstrap.js scripts/check-staged-secrets.mjs scripts/check-staged-secrets.test.mjs scripts/vercel-security-headers.test.mjs src/lib/securityHeaders.ts src/routes/__root.tsx src/server.ts vercel.json`
- `bun run lint:oxlint`
- `bun run deadcode:files`
- `VITE_CONVEX_URL=https://example.invalid bun run build`
- `bun run ci:static`
- `bun run ci:unit`

Additional CSP breakage check after the eval finding:

- `bun run test -- scripts/vercel-security-headers.test.mjs scripts/check-staged-secrets.test.mjs`
- `bun run format:check -- src/lib/securityHeaders.ts scripts/vercel-security-headers.test.mjs`
- `VITE_CONVEX_URL=https://wry-manatee-359.convex.cloud VITE_CONVEX_SITE_URL=https://wry-manatee-359.convex.site bun run build`
- Built preview on `http://127.0.0.1:4177/` plus Playwright CSP probe for `/`, `/skills`, and `/plugins`: zero CSP violations.
- `bun run ci:static`

Known residual:

- `bunx tsc --noEmit --pretty false` fails in this stale local checkout at `e2e/prod-http-smoke.e2e.test.ts:94` with `Cannot find name 'lastError'`. That file is outside this PR's net diff; remote `types-build` passed before the latest amended push, and the scoped CSP/scanner checks above pass.
- Future hardening can remove `'unsafe-eval'` by splitting browser-safe catalog/schema helpers away from arktype-backed runtime validators.
