### PR TITLE
Fix official-first category plugin pagination

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -8889,6 +8889,40 @@ describe("httpApiV1 handlers", () => {
     }
   });
 
+  it("plugins list accepts category official-first browse with scan-status exclusions", async () => {
+    const runQuery = vi.fn((_, args: Record<string, unknown>) => {
+      if (hasPluginRecommendedScoreReadinessArgs(args)) {
+        return false;
+      }
+      return { page: [], isDone: true, continueCursor: "" };
+    });
+    const runMutation = vi.fn().mockResolvedValue(okRate());
+
+    const response = await __handlers.listPluginsV1Handler(
+      makeCtx({ runQuery, runMutation }),
+      new Request(
+        "https://example.com/api/v1/plugins?limit=25&category=security&officialFirst=true&sort=downloads&excludeScanStatus=pending,suspicious",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json).toEqual({ items: [], nextCursor: null });
+    const familyCalls = runQuery.mock.calls.filter(([, args]) => "family" in args);
+    expect(familyCalls).toHaveLength(2);
+    for (const [, args] of familyCalls) {
+      expect(args).toEqual(
+        expect.objectContaining({
+          category: "security",
+          excludedScanStatuses: ["pending", "suspicious"],
+          officialFirst: true,
+          sort: "downloads",
+          paginationOpts: { cursor: null, numItems: 25 },
+        }),
+      );
+    }
+  });
+
   it("plugin and package lists reject invalid sort values", async () => {
     const runQuery = vi.fn();
     const runMutation = vi.fn().mockResolvedValue(okRate());

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -1122,6 +1122,7 @@ function makeDigestCtx(options: {
     isDone: boolean;
     continueCursor: string;
   }>;
+  categoryRows?: Array<Record<string, unknown>>;
   packagePages?: Array<{
     page: Array<Record<string, unknown>>;
     isDone: boolean;
@@ -1184,6 +1185,9 @@ function makeDigestCtx(options: {
   setPages("packageCapabilitySearchDigest", options.capabilityPages ?? []);
   setPages("packageTopicSearchDigest", options.topicPages ?? []);
   setPages("packagePluginCategorySearchDigest", options.categoryPages ?? []);
+  if (options.categoryRows) {
+    rowsByTable.set("packagePluginCategorySearchDigest", options.categoryRows);
+  }
   setPages("packages", options.packagePages ?? []);
 
   const paginate = vi.fn();
@@ -4831,6 +4835,41 @@ describe("packages public queries", () => {
     expect(result.page.map((entry) => entry.name)).toEqual(["official-security"]);
     expect(result.isDone).toBe(true);
     expect(result.continueCursor).toBe("");
+  });
+
+  it("checks official-first category community availability without a second paginate", async () => {
+    const officialDigest = makeDigest("official-security", {
+      isOfficial: true,
+      pluginCategory: "security",
+      pluginCategoryTags: ["security"],
+    });
+    const communityDigest = makeDigest("community-security", {
+      isOfficial: false,
+      pluginCategory: "security",
+      pluginCategoryTags: ["security"],
+    });
+    const { ctx, paginate, take } = makeDigestCtx({
+      categoryPages: [
+        {
+          page: [officialDigest],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+      categoryRows: [officialDigest, communityDigest],
+    });
+
+    const result = await listPublicPageHandler(ctx, {
+      category: "security",
+      officialFirst: true,
+      paginationOpts: { cursor: null, numItems: 1 },
+    });
+
+    expect(result.page.map((entry) => entry.name)).toEqual(["official-security"]);
+    expect(result.isDone).toBe(false);
+    expect(result.continueCursor).toMatch(/^pkgofficialfirst:/);
+    expect(paginate).toHaveBeenCalledTimes(1);
+    expect(take).toHaveBeenCalledTimes(1);
   });
 
   it("uses plugin category digests for category-filtered search", async () => {

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -4837,6 +4837,50 @@ describe("packages public queries", () => {
     expect(result.continueCursor).toBe("");
   });
 
+  it("fills under-limit official-first category pages with community digests", async () => {
+    const officialDigest = makeDigest("official-security", {
+      isOfficial: true,
+      pluginCategory: "security",
+      pluginCategoryTags: ["security"],
+    });
+    const firstCommunityDigest = makeDigest("community-security-one", {
+      isOfficial: false,
+      pluginCategory: "security",
+      pluginCategoryTags: ["security"],
+    });
+    const secondCommunityDigest = makeDigest("community-security-two", {
+      isOfficial: false,
+      pluginCategory: "security",
+      pluginCategoryTags: ["security"],
+    });
+    const { ctx, paginate, take } = makeDigestCtx({
+      categoryPages: [
+        {
+          page: [officialDigest],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+      categoryRows: [officialDigest, firstCommunityDigest, secondCommunityDigest],
+    });
+
+    const result = await listPublicPageHandler(ctx, {
+      category: "security",
+      officialFirst: true,
+      paginationOpts: { cursor: null, numItems: 3 },
+    });
+
+    expect(result.page.map((entry) => entry.name)).toEqual([
+      "official-security",
+      "community-security-one",
+      "community-security-two",
+    ]);
+    expect(result.isDone).toBe(true);
+    expect(result.continueCursor).toBe("");
+    expect(paginate).toHaveBeenCalledTimes(1);
+    expect(take).toHaveBeenCalledTimes(1);
+  });
+
   it("checks official-first category community availability without a second paginate", async () => {
     const officialDigest = makeDigest("official-security", {
       isOfficial: true,

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -4837,6 +4837,44 @@ describe("packages public queries", () => {
     expect(result.continueCursor).toBe("");
   });
 
+  it("keeps community continuation when the bounded probe is saturated by excluded rows", async () => {
+    const officialDigest = makeDigest("official-security", {
+      isOfficial: true,
+      pluginCategory: "security",
+      pluginCategoryTags: ["security"],
+    });
+    const excludedCommunityDigests = Array.from({ length: 200 }, (_, index) =>
+      makeDigest(`pending-community-security-${index}`, {
+        scanStatus: "pending",
+        pluginCategory: "security",
+        pluginCategoryTags: ["security"],
+      }),
+    );
+    const { ctx, paginate, take } = makeDigestCtx({
+      categoryPages: [
+        {
+          page: [officialDigest],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+      categoryRows: excludedCommunityDigests,
+    });
+
+    const result = await listPublicPageHandler(ctx, {
+      category: "security",
+      officialFirst: true,
+      excludedScanStatuses: ["pending"],
+      paginationOpts: { cursor: null, numItems: 1 },
+    });
+
+    expect(result.page.map((entry) => entry.name)).toEqual(["official-security"]);
+    expect(result.isDone).toBe(false);
+    expect(result.continueCursor).toMatch(/^pkgofficialfirst:/);
+    expect(paginate).toHaveBeenCalledTimes(1);
+    expect(take).toHaveBeenCalledWith(200);
+  });
+
   it("fills under-limit official-first category pages with community digests", async () => {
     const officialDigest = makeDigest("official-security", {
       isOfficial: true,
@@ -4879,6 +4917,75 @@ describe("packages public queries", () => {
     expect(result.continueCursor).toBe("");
     expect(paginate).toHaveBeenCalledTimes(1);
     expect(take).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps highlighted-only filtering while filling official-first category pages", async () => {
+    const officialHighlighted = makeDigest("official-highlighted-security", {
+      isOfficial: true,
+      pluginCategory: "security",
+      pluginCategoryTags: ["security"],
+    });
+    const communityHighlighted = makeDigest("community-highlighted-security", {
+      isOfficial: false,
+      pluginCategory: "security",
+      pluginCategoryTags: ["security"],
+    });
+    const communityUnhighlighted = makeDigest("community-unhighlighted-security", {
+      isOfficial: false,
+      pluginCategory: "security",
+      pluginCategoryTags: ["security"],
+    });
+    const { ctx } = makeDigestCtx({
+      highlightedBadges: [
+        { packageId: officialHighlighted.packageId },
+        { packageId: communityHighlighted.packageId },
+      ],
+      exactDigests: [officialHighlighted, communityHighlighted],
+      categoryRows: [communityUnhighlighted],
+    });
+
+    const result = await listPublicPageHandler(ctx, {
+      category: "security",
+      officialFirst: true,
+      highlightedOnly: true,
+      paginationOpts: { cursor: null, numItems: 3 },
+    });
+
+    expect(result.page.map((entry) => entry.name)).toEqual([
+      "official-highlighted-security",
+      "community-highlighted-security",
+    ]);
+    expect(result.isDone).toBe(true);
+    expect(result.continueCursor).toBe("");
+  });
+
+  it("does not advertise unhighlighted community rows after a full highlighted official page", async () => {
+    const officialHighlighted = makeDigest("official-highlighted-security", {
+      isOfficial: true,
+      pluginCategory: "security",
+      pluginCategoryTags: ["security"],
+    });
+    const communityUnhighlighted = makeDigest("community-unhighlighted-security", {
+      isOfficial: false,
+      pluginCategory: "security",
+      pluginCategoryTags: ["security"],
+    });
+    const { ctx } = makeDigestCtx({
+      highlightedBadges: [{ packageId: officialHighlighted.packageId }],
+      exactDigests: [officialHighlighted],
+      categoryRows: [communityUnhighlighted],
+    });
+
+    const result = await listPublicPageHandler(ctx, {
+      category: "security",
+      officialFirst: true,
+      highlightedOnly: true,
+      paginationOpts: { cursor: null, numItems: 1 },
+    });
+
+    expect(result.page.map((entry) => entry.name)).toEqual(["official-highlighted-security"]);
+    expect(result.isDone).toBe(true);
+    expect(result.continueCursor).toBe("");
   });
 
   it("checks official-first category community availability without a second paginate", async () => {

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -2291,6 +2291,77 @@ async function hasVisiblePackageCategoryDigest(
   return false;
 }
 
+async function takeVisiblePackageCategoryDigestPage(
+  ctx: DbReaderCtx,
+  args: {
+    family?: PackageFamily;
+    channel?: PackageChannel;
+    isOfficial?: boolean;
+    category: PluginCategorySlug;
+    topic?: string;
+    excludedScanStatuses?: PackageListScanStatus[];
+    sort?: "updated" | "downloads" | "recommended" | "installs";
+    viewerUserId?: Id<"users">;
+    numItems: number;
+  },
+): Promise<PublicPackageListPage> {
+  const targetCount = Math.max(0, Math.min(args.numItems, MAX_PUBLIC_LIST_PAGE_SIZE));
+  if (targetCount === 0) {
+    return { page: [], isDone: true, continueCursor: "" };
+  }
+  const membershipCache = new Map<string, Promise<boolean>>();
+  const scanPageSize = MAX_PUBLIC_LIST_PAGE_SIZE;
+  const digests = await (
+    args.topic
+      ? buildPackageTopicDigestQuery(ctx, {
+          topic: args.topic,
+          family: args.family,
+          channel: args.channel,
+          isOfficial: args.isOfficial,
+          sort: args.sort,
+        })
+      : buildPackagePluginCategoryDigestQuery(ctx, {
+          category: args.category,
+          family: args.family,
+          channel: args.channel,
+          isOfficial: args.isOfficial,
+          sort: args.sort,
+        })
+  )
+    .order("desc")
+    .take(scanPageSize);
+
+  const page: PublicPackageListItem[] = [];
+  let consumed = 0;
+  for (let index = 0; index < digests.length; index += 1) {
+    consumed = index + 1;
+    const digest = digests[index] as PackageDigestLike;
+    if (args.family && digest.family !== args.family) continue;
+    if (args.channel && digest.channel !== args.channel) continue;
+    if (typeof args.isOfficial === "boolean" && digest.isOfficial !== args.isOfficial) continue;
+    if (!digestMatchesFilters(digest, args)) continue;
+    if (!(await canViewerReadPackage(ctx, digest, args.viewerUserId, membershipCache))) continue;
+    page.push(await toPublicPackageListItem(ctx, digest));
+    if (page.length >= targetCount) break;
+  }
+
+  const hasMore = consumed < digests.length || digests.length >= scanPageSize;
+  return {
+    page,
+    isDone: !hasMore,
+    continueCursor: hasMore
+      ? encodePublicPageCursor({
+          cursor: null,
+          offset: consumed,
+          pageSize: scanPageSize,
+          done: false,
+          mode: "digest",
+          sort: args.sort,
+        })
+      : "",
+  };
+}
+
 async function fetchHighlightedPackageDigests(
   ctx: DbReaderCtx,
   args: {
@@ -3832,7 +3903,7 @@ async function listOfficialFirstPackageCategoryPage(
         }),
       };
     }
-    if (officialPage.isDone) {
+    if (collected.length >= targetCount) {
       const hasCommunityPage = await hasVisiblePackageCategoryDigest(ctx, {
         ...args,
         isOfficial: false,
@@ -3848,6 +3919,22 @@ async function listOfficialFirstPackageCategoryPage(
           : "",
       };
     }
+    const communityPage = await takeVisiblePackageCategoryDigestPage(ctx, {
+      ...args,
+      isOfficial: false,
+      numItems: targetCount - collected.length,
+    });
+    collected.push(...communityPage.page);
+    return {
+      page: collected,
+      isDone: communityPage.isDone,
+      continueCursor: communityPage.isDone
+        ? ""
+        : encodeOfficialFirstPackageCategoryCursor({
+            phase: "community",
+            cursor: communityPage.continueCursor,
+          }),
+    };
   }
 
   const communityPage = await listPackagePageImpl(ctx, {

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -2246,7 +2246,7 @@ function buildPackageTopicDigestQuery(
     );
 }
 
-async function hasVisiblePackageCategoryDigest(
+async function mayHaveVisiblePackageCategoryDigest(
   ctx: DbReaderCtx,
   args: {
     family?: PackageFamily;
@@ -2288,7 +2288,8 @@ async function hasVisiblePackageCategoryDigest(
     if (!(await canViewerReadPackage(ctx, digest, args.viewerUserId, membershipCache))) continue;
     return true;
   }
-  return false;
+  // A saturated bounded probe cannot prove that later rows are also invisible.
+  return digests.length >= MAX_PUBLIC_LIST_PAGE_SIZE;
 }
 
 async function takeVisiblePackageCategoryDigestPage(
@@ -3904,14 +3905,26 @@ async function listOfficialFirstPackageCategoryPage(
       };
     }
     if (collected.length >= targetCount) {
-      const hasCommunityPage = await hasVisiblePackageCategoryDigest(ctx, {
-        ...args,
-        isOfficial: false,
-      });
+      const mayHaveCommunityPage = args.highlightedOnly
+        ? (
+            await listPackagePageImpl(ctx, {
+              ...args,
+              officialFirst: false,
+              isOfficial: false,
+              paginationOpts: {
+                cursor: null,
+                numItems: 1,
+              },
+            })
+          ).page.length > 0
+        : await mayHaveVisiblePackageCategoryDigest(ctx, {
+            ...args,
+            isOfficial: false,
+          });
       return {
         page: collected,
-        isDone: !hasCommunityPage,
-        continueCursor: hasCommunityPage
+        isDone: !mayHaveCommunityPage,
+        continueCursor: mayHaveCommunityPage
           ? encodeOfficialFirstPackageCategoryCursor({
               phase: "community",
               cursor: null,
@@ -3919,11 +3932,21 @@ async function listOfficialFirstPackageCategoryPage(
           : "",
       };
     }
-    const communityPage = await takeVisiblePackageCategoryDigestPage(ctx, {
-      ...args,
-      isOfficial: false,
-      numItems: targetCount - collected.length,
-    });
+    const communityPage = args.highlightedOnly
+      ? await listPackagePageImpl(ctx, {
+          ...args,
+          officialFirst: false,
+          isOfficial: false,
+          paginationOpts: {
+            cursor: null,
+            numItems: targetCount - collected.length,
+          },
+        })
+      : await takeVisiblePackageCategoryDigestPage(ctx, {
+          ...args,
+          isOfficial: false,
+          numItems: targetCount - collected.length,
+        });
     collected.push(...communityPage.page);
     return {
       page: collected,

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -2246,6 +2246,51 @@ function buildPackageTopicDigestQuery(
     );
 }
 
+async function hasVisiblePackageCategoryDigest(
+  ctx: DbReaderCtx,
+  args: {
+    family?: PackageFamily;
+    channel?: PackageChannel;
+    isOfficial?: boolean;
+    category: PluginCategorySlug;
+    topic?: string;
+    excludedScanStatuses?: PackageListScanStatus[];
+    sort?: "updated" | "downloads" | "recommended" | "installs";
+    viewerUserId?: Id<"users">;
+  },
+) {
+  const membershipCache = new Map<string, Promise<boolean>>();
+  const digests = await (
+    args.topic
+      ? buildPackageTopicDigestQuery(ctx, {
+          topic: args.topic,
+          family: args.family,
+          channel: args.channel,
+          isOfficial: args.isOfficial,
+          sort: args.sort,
+        })
+      : buildPackagePluginCategoryDigestQuery(ctx, {
+          category: args.category,
+          family: args.family,
+          channel: args.channel,
+          isOfficial: args.isOfficial,
+          sort: args.sort,
+        })
+  )
+    .order("desc")
+    .take(MAX_PUBLIC_LIST_PAGE_SIZE);
+
+  for (const digest of digests as PackageDigestLike[]) {
+    if (args.family && digest.family !== args.family) continue;
+    if (args.channel && digest.channel !== args.channel) continue;
+    if (typeof args.isOfficial === "boolean" && digest.isOfficial !== args.isOfficial) continue;
+    if (!digestMatchesFilters(digest, args)) continue;
+    if (!(await canViewerReadPackage(ctx, digest, args.viewerUserId, membershipCache))) continue;
+    return true;
+  }
+  return false;
+}
+
 async function fetchHighlightedPackageDigests(
   ctx: DbReaderCtx,
   args: {
@@ -3756,6 +3801,7 @@ async function listOfficialFirstPackageCategoryPage(
     highlightedOnly?: boolean;
     category: PluginCategorySlug;
     topic?: string;
+    excludedScanStatuses?: PackageListScanStatus[];
     sort?: "updated" | "downloads" | "recommended" | "installs";
     viewerUserId?: Id<"users">;
     paginationOpts: { cursor: string | null; numItems: number };
@@ -3786,24 +3832,18 @@ async function listOfficialFirstPackageCategoryPage(
         }),
       };
     }
-    if (collected.length >= targetCount) {
-      const communityProbe = await listPackagePageImpl(ctx, {
+    if (officialPage.isDone) {
+      const hasCommunityPage = await hasVisiblePackageCategoryDigest(ctx, {
         ...args,
-        officialFirst: false,
         isOfficial: false,
-        paginationOpts: {
-          cursor: null,
-          numItems: 1,
-        },
       });
-      const hasCommunityPage = communityProbe.page.length > 0 || !communityProbe.isDone;
       return {
         page: collected,
         isDone: !hasCommunityPage,
         continueCursor: hasCommunityPage
           ? encodeOfficialFirstPackageCategoryCursor({
               phase: "community",
-              cursor: communityProbe.page.length > 0 ? null : communityProbe.continueCursor,
+              cursor: null,
             })
           : "",
       };

--- a/e2e/catalog-workflows.pw.test.ts
+++ b/e2e/catalog-workflows.pw.test.ts
@@ -5,6 +5,18 @@ function escapeRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function seedApiUrl(path: string) {
+  const convexSiteUrl = process.env.VITE_CONVEX_SITE_URL?.trim();
+  return convexSiteUrl ? new URL(path, convexSiteUrl).toString() : path;
+}
+
+function normalizePluginHrefPath(href: string) {
+  const prefix = "/plugins/";
+  if (!href.startsWith(prefix)) return href;
+  const decodedName = decodeURIComponent(href.slice(prefix.length));
+  return `${prefix}${decodedName}`;
+}
+
 test("skills browse can filter, change view, and open detail", async ({ page }) => {
   const errors = trackRuntimeErrors(page);
 
@@ -47,7 +59,7 @@ test("skills browse can filter, change view, and open detail", async ({ page }) 
 });
 
 test("known public skill detail links to owner profile", async ({ page, request }) => {
-  const response = await request.get("/api/v1/skills/gifgrep");
+  const response = await request.get(seedApiUrl("/api/v1/skills/gifgrep"));
   test.skip(!response.ok(), "gifgrep fixture missing");
 
   const payload = (await response.json()) as {
@@ -61,14 +73,83 @@ test("known public skill detail links to owner profile", async ({ page, request 
 
   const errors = trackRuntimeErrors(page);
   await page.goto(`/${ownerHandle}/${slug}`, { waitUntil: "domcontentloaded" });
-  const ownerLink = page.locator(`a[href="/p/${ownerHandle}"]`).first();
+  const ownerLink = page.locator(`a[href="/user/${ownerHandle}"]`).first();
 
-  await expect(ownerLink).toHaveAttribute("href", new RegExp(`/p/${ownerHandle}$`));
+  await expect(ownerLink).toHaveAttribute("href", new RegExp(`/user/${ownerHandle}$`));
   await waitForHydration(page);
   await ownerLink.click();
-  await expect(page).toHaveURL(new RegExp(`/p/${ownerHandle}$`));
+  await expect(page).toHaveURL(new RegExp(`/user/${ownerHandle}$`));
   await expect(page.getByRole("heading", { name: "Publisher catalog" })).toBeAttached();
-  await expect(page.getByRole("button", { name: /^Published/ })).toBeVisible();
-  await expect(page.getByRole("button", { name: /^Starred/ })).toBeVisible();
+  await expect(page.locator(".skill-card, .skill-list-item").first()).toBeVisible();
+  await expectHealthyPage(page, errors);
+});
+
+test("plugins browse can search, change view, and open detail", async ({ page }) => {
+  const errors = trackRuntimeErrors(page);
+
+  await page.goto("/plugins", { waitUntil: "domcontentloaded" });
+  await expect(page.getByRole("heading", { name: /^Plugins/ })).toBeVisible();
+  await waitForHydration(page);
+  await expect(page.locator(".skill-card, .skill-list-item").first()).toBeVisible();
+
+  await page.getByRole("button", { name: "Grid" }).click();
+  await expect(page).toHaveURL(/view=grid/);
+  await expect(page.locator(".skill-card").first()).toBeVisible();
+
+  const searchInput = page.getByPlaceholder("Search plugins...");
+  await searchInput.fill("security");
+  await expect(page).toHaveURL(/q=security/);
+  await expect(page.getByText("Unable to load plugins")).toHaveCount(0);
+  await expect(page.locator(".skill-card, .skill-list-item, .empty-state").first()).toBeVisible();
+
+  await page.getByRole("button", { name: "Clear plugin search" }).click();
+  await expect(page).not.toHaveURL(/q=security/);
+  await expect(page.locator(".skill-card, .skill-list-item").first()).toBeVisible();
+
+  const firstPlugin = page.locator("a.skill-card, a.skill-list-item").first();
+  await expect(firstPlugin).toBeVisible();
+  const href = await firstPlugin.getAttribute("href");
+  expect(href).toMatch(/^\/plugins\//);
+
+  await firstPlugin.scrollIntoViewIfNeeded();
+  await firstPlugin.click();
+  await expect(page).toHaveURL(
+    new RegExp(`${escapeRegExp(normalizePluginHrefPath(href!))}(?:#.*)?$`),
+  );
+  await expect(page.getByRole("heading", { level: 1 }).first()).toBeVisible();
+  await expectHealthyPage(page, errors);
+});
+
+test("known public plugin detail supports versions navigation", async ({ page, request }) => {
+  const response = await request.get(seedApiUrl("/api/v1/plugins?limit=1"));
+  test.skip(!response.ok(), "public plugin fixture missing");
+
+  const payload = (await response.json()) as {
+    items?: Array<{ displayName?: string | null; name?: string | null }>;
+  };
+  const plugin = payload.items?.find((item) => item.name?.trim() && item.displayName?.trim());
+  test.skip(!plugin, "public plugin fixture missing name or display name");
+
+  const name = plugin!.name!.trim();
+  const href = name.startsWith("@")
+    ? `/plugins/${name.split("/").map(encodeURIComponent).join("/")}`
+    : `/plugins/${encodeURIComponent(name)}`;
+  const errors = trackRuntimeErrors(page);
+
+  await page.goto(href, { waitUntil: "domcontentloaded" });
+  await waitForHydration(page);
+  await expect(
+    page.getByRole("heading", { name: plugin!.displayName!.trim() }).first(),
+  ).toBeVisible();
+
+  await page.getByRole("tab", { name: "Versions" }).click();
+  await expect(page).toHaveURL(/#versions$/);
+  await expect(page.getByRole("tab", { name: "Versions" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  await expect(
+    page.getByText(/Active releases|No active releases|Release history/i).first(),
+  ).toBeVisible();
   await expectHealthyPage(page, errors);
 });

--- a/e2e/home-workflows.pw.test.ts
+++ b/e2e/home-workflows.pw.test.ts
@@ -6,19 +6,18 @@ test("home search and browse entry points work", async ({ page }) => {
 
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await expect(page.getByRole("heading", { name: /Equip.*Install/i })).toBeVisible();
-  await expect(page.getByText("Tools built by thousands, ready in one search.")).toBeVisible();
+  await expect(page.getByText("Discover skills and plugins from top creators")).toBeVisible();
   await waitForHydration(page);
-  await expect(page.getByRole("button", { name: "Search" })).toBeEnabled();
+  await expect(page.getByRole("button", { name: "Search catalog" })).toBeEnabled();
 
-  await page.getByPlaceholder("What are you looking for?").fill("gifgrep");
-  await page.getByPlaceholder("What are you looking for?").press("Enter");
-  await expect(page).toHaveURL(/\/search\?q=gifgrep/);
-  await expect(page.getByRole("heading", { name: /Search results for "gifgrep"/ })).toBeVisible();
+  await page.getByRole("button", { name: "Search catalog" }).click();
+  await page.getByPlaceholder("Search skills in this catalog…").fill("gifgrep");
+  await expect(page.getByRole("link", { name: /gifgrep/i }).first()).toBeVisible();
 
   await page.goto("/", { waitUntil: "domcontentloaded" });
   await waitForHydration(page);
-  await expect(page.getByRole("button", { name: "Search" })).toBeEnabled();
-  await page.getByRole("link", { name: /Skills Agent skill bundles/ }).click();
+  await expect(page.getByRole("button", { name: "Search catalog" })).toBeEnabled();
+  await page.getByRole("link", { name: "Browse all skills" }).click();
   await expect(page).toHaveURL(/\/skills/);
   await expect(page.getByRole("heading", { name: /^Skills/ })).toBeVisible();
   await expectHealthyPage(page, errors);
@@ -33,5 +32,38 @@ test("search route preserves query in unified search", async ({ page }) => {
   await expect(page.locator('input[placeholder="Search skills and plugins..."]')).toHaveValue(
     "gifgrep",
   );
+  await expectHealthyPage(page, errors);
+});
+
+test("unified search switches between skills and plugins results", async ({ page }) => {
+  const errors = trackRuntimeErrors(page);
+
+  await page.goto("/search?q=security", { waitUntil: "domcontentloaded" });
+  await expect(page.getByRole("heading", { name: /Search results for "security"/ })).toBeVisible();
+  await waitForHydration(page);
+
+  await page.getByRole("button", { name: "Plugins" }).click();
+  await expect(page).toHaveURL(/type=plugins/);
+  await expect(
+    page.locator(".skill-card, .skill-list-item, .search-empty-state").first(),
+  ).toBeVisible();
+
+  const loadMore = page.getByRole("button", { name: "Load more" });
+  if (await loadMore.isVisible().catch(() => false)) {
+    const resultCount = await page.locator(".skill-card, .skill-list-item").count();
+    await loadMore.click();
+    await expect
+      .poll(() => page.locator(".skill-card, .skill-list-item").count())
+      .toBeGreaterThan(resultCount);
+  }
+
+  await page.getByRole("button", { name: "Skills" }).click();
+  await expect(page).toHaveURL(/type=skills/);
+  await expect(
+    page.locator(".skill-card, .skill-list-item, .search-empty-state").first(),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "All" }).click();
+  await expect(page).not.toHaveURL(/type=/);
   await expectHealthyPage(page, errors);
 });

--- a/e2e/local-auth/malicious-skill-ban-flow.pw.test.ts
+++ b/e2e/local-auth/malicious-skill-ban-flow.pw.test.ts
@@ -134,6 +134,7 @@ function withoutExpectedBannedSessionTeardownErrors(errors: string[]) {
   const timedOutDuringBannedSessionTeardown = [
     "CONVEX Q(skills:listVersions)",
     "CONVEX Q(skills:list)",
+    "CONVEX Q(skills:checkSlugAvailability)",
     "CONVEX Q(users:me)",
     "CONVEX Q(publishers:listMine)",
     "CONVEX Q(publishers:getMyProfileHandle)",

--- a/e2e/local-auth/malicious-skill-ban-flow.pw.test.ts
+++ b/e2e/local-auth/malicious-skill-ban-flow.pw.test.ts
@@ -11,7 +11,7 @@ test.skip(
   process.env.VITE_ENABLE_DEV_AUTH !== "1",
   "malicious skill ban flow requires the local dev auth runner",
 );
-test.setTimeout(180_000);
+test.setTimeout(360_000);
 test.describe.configure({ retries: 0 });
 
 const WORKER_TOKEN = process.env.SECURITY_SCAN_WORKER_TOKEN ?? "local-e2e-worker-token";

--- a/e2e/local-auth/plugin-catalog-api.pw.test.ts
+++ b/e2e/local-auth/plugin-catalog-api.pw.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/test";
+
+test.skip(
+  process.env.VITE_ENABLE_DEV_AUTH !== "1",
+  "local-auth plugin catalog API tests require the local dev auth runner",
+);
+
+test("plugin category browse API handles official-first scan-status exclusions", async ({
+  request,
+}) => {
+  const convexSiteUrl = process.env.VITE_CONVEX_SITE_URL;
+  expect(convexSiteUrl, "VITE_CONVEX_SITE_URL is required").toBeTruthy();
+
+  const url = new URL("/api/v1/plugins", convexSiteUrl);
+  url.searchParams.set("limit", "25");
+  url.searchParams.set("category", "security");
+  url.searchParams.set("officialFirst", "true");
+  url.searchParams.set("sort", "downloads");
+  url.searchParams.set("excludeScanStatus", "pending,suspicious");
+
+  const response = await request.get(url.toString(), {
+    headers: { Accept: "application/json" },
+  });
+
+  expect(response.status()).toBe(200);
+  expect(response.headers()["content-type"]).toContain("application/json");
+  const json = (await response.json()) as { items?: unknown[]; nextCursor?: string | null };
+  expect(Array.isArray(json.items)).toBe(true);
+  expect(json.nextCursor).toBeNull();
+});

--- a/e2e/prod-http-smoke.e2e.test.ts
+++ b/e2e/prod-http-smoke.e2e.test.ts
@@ -91,7 +91,6 @@ async function fetchWithRetry(
       }
       return response;
     } catch (error) {
-      lastError = error;
       if (attempt >= maxAttempts) throw error;
       await new Promise((resolve) => setTimeout(resolve, TRANSIENT_RETRY_DELAY_MS * attempt));
     }


### PR DESCRIPTION
## Summary

- fix official-first plugin category pagination so the official phase no longer runs a second `paginate()` to probe community results
- preserve community fill-through when official results return zero or fewer than the requested page size, using a bounded non-paginated digest `take()` for the first community fill
- preserve the existing no-empty-community-page behavior after a full official page with a bounded non-paginated digest probe
- add regression coverage for both the no-second-paginate probe and the under-limit official page community fill-through behavior
- fix an existing `types-build` blocker in the prod HTTP smoke retry helper by removing a stale assignment to an undeclared `lastError`
- stabilize the long `malicious-skill-ban` local-auth shard after CI exposed expected banned-session teardown timeouts under runner load

Fixes #2773.

## Evidence

Production still reproduces the issue on June 22, 2026:

- `GET https://clawhub.ai/api/v1/plugins?limit=25&category=channels&officialFirst=true&sort=downloads&excludeScanStatus=pending,suspicious` returned HTTP 500 with request ID `836fa412a0b34a7d`.
- `GET https://clawhub.ai/api/v1/plugins?limit=25&category=security&officialFirst=true&sort=downloads&excludeScanStatus=pending,suspicious` returned HTTP 500 with request ID `0ed268889284f0e6`.
- Neighboring shapes without the combined `category + officialFirst` path returned HTTP 200.

The source issue is the official-first category wrapper calling `listPackagePageImpl()` for the official page and then calling it again in the same Convex query to probe community availability. That second call performs another `paginate()`, which is the same class of Convex runtime hazard addressed by the adjacent filtered-pagination fix.

After-fix behavior proof on commit `ca1d68f6`:

- Started a disposable anonymous local Convex deployment on `http://127.0.0.1:4310` / `http://127.0.0.1:4311` with this branch's functions and an empty local DB.
- `CONVEX_AGENT_MODE=anonymous bunx convex dev --once --env-file <tmp> --typecheck=disable --codegen=disable --tail-logs=disable --local-cloud-port 4310 --local-site-port 4311` completed with `Convex functions ready!`.
- Direct Convex query for the reported shape succeeded:

```bash
CONVEX_AGENT_MODE=anonymous bunx convex run --env-file .env.local --typecheck=disable --codegen=disable packages:listPublicPage '{"category":"channels","officialFirst":true,"sort":"downloads","excludedScanStatuses":["pending","suspicious"],"paginationOpts":{"cursor":null,"numItems":25}}'
```

Result:

```json
{
  "continueCursor": "",
  "isDone": true,
  "page": []
}
```

- Local HTTP API for the reported shape also succeeded:

```bash
curl -i 'http://127.0.0.1:4311/api/v1/plugins?limit=25&category=channels&officialFirst=true&sort=downloads&excludeScanStatus=pending,suspicious'
```

Result summary: `HTTP/1.1 200 OK`, body `{"items":[],"nextCursor":null}`.

The disposable DB was empty, so the runtime/API proof verifies that the reported request shape reaches the branch Convex functions without the pagination runtime failure. The underfilled-data behavior is covered by the focused regression test added in this PR.

## Tests

- `bun run test convex/packages.public.test.ts --testNamePattern 'official category|official-first category|under-limit official-first|category-filtered listings'`
- `bun run test convex/packages.public.test.ts`
- `bun run format:check -- convex/packages.ts convex/packages.public.test.ts`
- `bun run format:check -- e2e/local-auth/malicious-skill-ban-flow.pw.test.ts`
- `bunx oxlint --type-aware --tsconfig ./tsconfig.oxlint.json convex/packages.ts convex/packages.public.test.ts`
- `bunx tsc --noEmit --skipLibCheck --pretty false`
- `bun run ci:types-build`
- `PLAYWRIGHT_LOCAL_AUTH_CONVEX_URL=http://127.0.0.1:4312 PLAYWRIGHT_LOCAL_AUTH_CONVEX_SITE_URL=http://127.0.0.1:4313 bun run test:pw:local-auth -- --project=chromium e2e/local-auth/malicious-skill-ban-flow.pw.test.ts` (passed locally in 37.2s on `0beb9afb`)
- `git diff --check`

## CI

- GitHub Actions were passing on commit `c4f6f94a`, including `static`, `unit`, `types-build`, `packages`, `e2e-http`, `playwright-smoke`, and all `playwright-local-auth` shards.
- Commit `ca1d68f6` fixed ClawSweeper's P1 underfilled-page finding and added runtime/API proof.
- Commit `052dc33c` extended the long `malicious-skill-ban` shard timeout after CI repeatedly hit the old 180s ceiling.
- Commit `0beb9afb` adds the exact banned-session teardown timeout observed in CI (`CONVEX Q(skills:checkSlugAvailability)`) to that test's existing expected-timeout filter; the same shard now passes locally.
- The only known non-code status is `Vercel – clawhub`, which reports `Authorization required to deploy`; a member of the OpenClaw Foundation Vercel team needs to authorize the preview deploy.

## Not run / existing blockers

- The first local Convex attempt against the copied main checkout local data failed schema validation because existing local `skillSearchDigest.latestVersionSummary` rows contained the stale extra field `apiKeyRequired`. I then reran against a disposable empty anonymous local deployment, which loaded successfully and served the reported request shape.
