### PR TITLE
fix: remove activity metric tooltip

### DIFF
--- a/e2e/prod-http-smoke.e2e.test.ts
+++ b/e2e/prod-http-smoke.e2e.test.ts
@@ -91,7 +91,6 @@ async function fetchWithRetry(
       }
       return response;
     } catch (error) {
-      lastError = error;
       if (attempt >= maxAttempts) throw error;
       await new Promise((resolve) => setTimeout(resolve, TRANSIENT_RETRY_DELAY_MS * attempt));
     }

--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -907,7 +907,7 @@ describe("plugin detail route", () => {
     expect(screen.queryByText("30-day Installs")).toBeNull();
     expect(screen.queryByRole("img", { name: "Daily installs over the last 30 days" })).toBeNull();
     expect(screen.getByRole("img", { name: "Daily downloads over the last 30 days" })).toBeTruthy();
-    expect(screen.getAllByRole("button", { name: "About activity counts" })).toHaveLength(1);
+    expect(screen.queryByRole("button", { name: "About activity counts" })).toBeNull();
     expect(
       convexQueryMock.mock.calls.some(([query, args]) => {
         return (

--- a/src/components/ActivityMetricLabel.test.tsx
+++ b/src/components/ActivityMetricLabel.test.tsx
@@ -1,0 +1,15 @@
+/* @vitest-environment jsdom */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ActivityMetricLabel } from "./ActivityMetricLabel";
+
+describe("ActivityMetricLabel", () => {
+  it("renders activity labels without the downloads warning tooltip", () => {
+    render(<ActivityMetricLabel label="Downloads" />);
+
+    expect(screen.getByText("Downloads")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "About activity counts" })).toBeNull();
+    expect(screen.queryByText(/Download counts can be inflated/i)).toBeNull();
+  });
+});

--- a/src/components/ActivityMetricLabel.tsx
+++ b/src/components/ActivityMetricLabel.tsx
@@ -1,29 +1,7 @@
-import { Info } from "lucide-react";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
-
-const DOWNLOAD_COUNT_HELP =
-  "Download counts can be inflated by bots or spam. Use them as context only, not as a quality or trust signal.";
-
 export function ActivityMetricLabel({ label }: { label: string }) {
   return (
     <span className="activity-metric-label">
       <span>{label}</span>
-      <TooltipProvider delayDuration={400}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <button
-              type="button"
-              className="activity-metric-info"
-              aria-label="About activity counts"
-            >
-              <Info size={13} aria-hidden="true" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="top" align="start" className="activity-metric-tooltip">
-            {DOWNLOAD_COUNT_HELP}
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
     </span>
   );
 }

--- a/src/components/SkillHeader.test.tsx
+++ b/src/components/SkillHeader.test.tsx
@@ -154,7 +154,7 @@ describe("SkillHeader", () => {
     expect(screen.queryByText("5")).toBeNull();
     expect(screen.queryByRole("img", { name: "Daily installs over the last 30 days" })).toBeNull();
     expect(screen.getByRole("img", { name: "Daily downloads over the last 30 days" })).toBeTruthy();
-    expect(screen.getAllByRole("button", { name: "About activity counts" })).toHaveLength(1);
+    expect(screen.queryByRole("button", { name: "About activity counts" })).toBeNull();
   });
 
   it("reserves graph space while activity metrics are loading", () => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -5085,57 +5085,6 @@ code {
   display: inline-flex;
   min-width: 0;
   align-items: center;
-  gap: 6px;
-}
-
-.activity-metric-info {
-  display: inline-flex;
-  position: relative;
-  width: 44px;
-  height: 44px;
-  align-items: center;
-  justify-content: center;
-  margin: -12px;
-  padding: 0;
-  border: 0;
-  border-radius: 999px;
-  background: transparent;
-  color: var(--ink-soft);
-  cursor: help;
-}
-
-.activity-metric-info::before {
-  position: absolute;
-  inset: 12px;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  background: var(--surface);
-  content: "";
-}
-
-.activity-metric-info svg {
-  position: relative;
-  z-index: 1;
-}
-
-.activity-metric-info:hover,
-.activity-metric-info:focus-visible {
-  color: var(--accent);
-}
-
-.activity-metric-info:hover::before,
-.activity-metric-info:focus-visible::before {
-  border-color: var(--accent);
-}
-
-.activity-metric-info:focus-visible {
-  outline: 2px solid var(--input-focus-border);
-  outline-offset: 2px;
-}
-
-.activity-metric-tooltip {
-  max-width: 260px;
-  line-height: 1.4;
 }
 
 .metric-trend-card {


### PR DESCRIPTION
## Summary
- Remove the downloads activity info tooltip from metric labels.
- Add a regression test that the Downloads label renders without the activity warning affordance.
- Drop a stale retry assignment that blocked the repo type/build gate.

## Tests
- `VITE_CONVEX_URL=https://example.invalid bunx vitest run src/components/ActivityMetricLabel.test.tsx src/components/SkillHeader.test.tsx src/__tests__/package-detail-route.test.tsx`
- `bun run ci:static`
- `VITE_CONVEX_URL=https://example.invalid bun run ci:unit`
- `bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Screenshots
- Real local ClawHub proof captured and will be published in the PR comments with `bun run proof:publish`.
