### PR TITLE
Hide scoped plugin prefixes in display labels

### DIFF
--- a/e2e/prod-http-smoke.e2e.test.ts
+++ b/e2e/prod-http-smoke.e2e.test.ts
@@ -91,7 +91,6 @@ async function fetchWithRetry(
       }
       return response;
     } catch (error) {
-      lastError = error;
       if (attempt >= maxAttempts) throw error;
       await new Promise((resolve) => setTimeout(resolve, TRANSIENT_RETRY_DELAY_MS * attempt));
     }

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -487,6 +487,34 @@ describe("Header", () => {
     });
   });
 
+  it("omits scoped package prefixes from plugin typeahead metadata", () => {
+    useUnifiedSearchMock.mockReturnValue({
+      ...defaultUnifiedSearchResult,
+      pluginResults: [
+        {
+          ...defaultUnifiedSearchResult.pluginResults[0],
+          plugin: {
+            ...defaultUnifiedSearchResult.pluginResults[0].plugin,
+            name: "@openclaw/firecrawl-plugin",
+            displayName: "OpenClaw Firecrawl Plugin",
+            ownerHandle: "openclaw",
+          },
+        },
+      ],
+    });
+
+    render(<Header />);
+
+    const input = screen.getByPlaceholderText("Search skills and plugins");
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "firecrawl" } });
+    fireEvent.click(screen.getByRole("tab", { name: "Plugins" }));
+
+    expect(screen.getByText("OpenClaw Firecrawl Plugin")).toBeTruthy();
+    expect(screen.getByText("@openclaw / firecrawl-plugin")).toBeTruthy();
+    expect(screen.queryByText("@openclaw / @openclaw/firecrawl-plugin")).toBeNull();
+  });
+
   it("falls back to typed skill search when a typeahead skill has no owner handle", () => {
     navigateMock.mockReset();
     useUnifiedSearchMock.mockReturnValue({

--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -794,6 +794,29 @@ describe("plugin detail route", () => {
     ).toBeTruthy();
   });
 
+  it("omits scoped package prefixes from plugin breadcrumbs", async () => {
+    loaderDataMock = {
+      ...loaderDataMock,
+      detail: {
+        package: {
+          ...loaderDataMock.detail.package!,
+          name: "@openclaw/firecrawl-plugin",
+          displayName: "OpenClaw Firecrawl Plugin",
+        },
+        owner: { handle: "openclaw", displayName: "OpenClaw", image: null },
+      },
+    };
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    const { container } = render(<Component />);
+
+    const packageCrumb = container.querySelector(
+      'nav[aria-label="Plugin breadcrumbs"] a[href="/plugins/@openclaw/firecrawl-plugin"]',
+    );
+    expect(packageCrumb?.textContent).toBe("firecrawl-plugin");
+  });
+
   it("labels official packages as Official", async () => {
     loaderDataMock = {
       ...loaderDataMock,

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -26,6 +26,7 @@ import {
 } from "../lib/authErrorMessage";
 import { gravatarUrl } from "../lib/gravatar";
 import { PRIMARY_NAV_ITEMS, SECONDARY_NAV_ITEMS } from "../lib/nav-items";
+import { displayPluginPackageName } from "../lib/pluginRoutes";
 import { SITE_NAME } from "../lib/site";
 import { applyTheme, useThemeMode } from "../lib/theme";
 import { clearAuthError, setAuthError } from "../lib/useAuthError";
@@ -995,9 +996,10 @@ function getTypeaheadRowBody(item: TypeaheadItem) {
     };
   }
   if (item.kind === "plugin") {
+    const packageName = displayPluginPackageName(item.result.plugin.name);
     const owner = item.result.plugin.ownerHandle
-      ? `@${item.result.plugin.ownerHandle} / ${item.result.plugin.name}`
-      : item.result.plugin.name;
+      ? `@${item.result.plugin.ownerHandle} / ${packageName}`
+      : packageName;
     return {
       title: item.result.plugin.displayName,
       meta: owner,

--- a/src/lib/pluginRoutes.test.ts
+++ b/src/lib/pluginRoutes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildPluginDetailHref,
   buildPluginSecurityAuditHref,
+  displayPluginPackageName,
   packageNameFromScopedRoute,
   parseScopedPackageName,
 } from "./pluginRoutes";
@@ -25,5 +26,10 @@ describe("plugin routes", () => {
     });
     expect(packageNameFromScopedRoute("@openclaw", "codex")).toBe("@openclaw/codex");
     expect(packageNameFromScopedRoute("openclaw", "codex")).toBeNull();
+  });
+
+  it("formats scoped package names for display without changing unscoped names", () => {
+    expect(displayPluginPackageName("@openclaw/firecrawl-plugin")).toBe("firecrawl-plugin");
+    expect(displayPluginPackageName("web-search-plus-plugin-v2")).toBe("web-search-plus-plugin-v2");
   });
 });

--- a/src/lib/pluginRoutes.ts
+++ b/src/lib/pluginRoutes.ts
@@ -12,6 +12,10 @@ export function parseScopedPackageName(name: string): { scope: string; name: str
   return { scope, name: packageName };
 }
 
+export function displayPluginPackageName(name: string) {
+  return parseScopedPackageName(name)?.name ?? name;
+}
+
 export function buildPluginDetailHref(name: string) {
   const scoped = parseScopedPackageName(name);
   if (!scoped) return `/plugins/${encodeURIComponent(name)}`;

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -62,6 +62,7 @@ import { familyLabel } from "../../lib/packageLabels";
 import {
   buildPluginDetailHref,
   buildPluginSecurityAuditHref,
+  displayPluginPackageName,
   parseScopedPackageName,
 } from "../../lib/pluginRoutes";
 import { buildReadmeAssetBaseUrl } from "../../lib/readmeAssetBaseUrl";
@@ -950,7 +951,7 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
                 <span aria-hidden="true">/</span>
                 <a href="/plugins">plugins</a>
                 <span aria-hidden="true">/</span>
-                <a href={buildPluginDetailHref(pkg.name)}>{pkg.name}</a>
+                <a href={buildPluginDetailHref(pkg.name)}>{displayPluginPackageName(pkg.name)}</a>
               </nav>
               <div className="skill-hero-title-row">
                 <h1 className="skill-page-title">{pkg.displayName}</h1>


### PR DESCRIPTION
## Summary
- Hide scoped package prefixes in plugin search metadata and plugin detail breadcrumbs while preserving canonical scoped routes.
- Add focused regression coverage for scoped and unscoped display names.
- Remove a stale e2e retry-helper assignment that broke the repo type/build gate.

## Proof
- Browser proof: https://github.com/openclaw/clawhub/pull/2782#issuecomment-4772339561

## Tests
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bun run test:e2e:prod-http`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
