### PR TITLE
fix(ci): report testbox hydration failures

### DIFF
--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -74,7 +74,7 @@ jobs:
           sudo ln -sf "$node_bin/npx" /usr/local/bin/npx
 
       - name: Run Testbox
-        uses: useblacksmith/run-testbox@5ca05834db1d3813554d1dd109e5f2087a8d7cbc
+        uses: useblacksmith/run-testbox@3f60ff9ceb2c10c3feefa87dc0c6490cffae059d
         if: always()
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"


### PR DESCRIPTION
## Summary

- What changed: upgrade `run-testbox` to the lifecycle-aware action revision.
- Why: ClawHub's Testbox backend currently strands runs after `Prepare Testbox shell` fails.

## Behavioural Proof

Live main runs reproduced the sequence: `Prepare Testbox shell` failed, `Run Testbox` was cancelled or lingered, and `Complete runner` remained pending. The newer action reports hydration failure and completion instead of leaving the backend session unowned.

## Verification

- `git diff --check`
- Existing workflow already invokes the finalizer with `always()`.
- Live Blacksmith inventory observed ready boxes draining after the idle window.

## Security / Trust Impact

- [x] No security/trust impact

## Data / Deploy Impact

- [x] No data/deploy impact

AI-assisted: yes.
