### PR TITLE
Fix missing light-mode publisher profile tab selected state

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -18566,6 +18566,10 @@ a.publisher-profile-detail:hover {
   color: var(--ink);
 }
 
+[data-theme-resolved="light"] .publisher-profile-catalog-tabs button.is-active {
+  background: var(--hover-bg);
+}
+
 .publisher-profile-load-more {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
Still work in progress don't merge 


## Why this change

<!-- Add the problem, who it affects, and why it matters. -->

[Fill this in]

## What changed

<!-- Describe the visible result. -->

- [Fill this in]

## Scope and non-goals

In scope:

- [Fill this in]

Not in scope:

- [Fill this in]

## How to review

1. [Fill this in]
2. [Fill this in]
3. [Fill this in]

## Screenshots

### Before

<!-- Add a light-mode screenshot using the same page, state, viewport, and crop as the after image. -->

[Add screenshot]

### After

<!-- Add the matching after screenshot. -->

[Add screenshot]

### Dark mode reference

<!-- Add a dark-mode screenshot if it helps reviewers compare the selected state. -->

[Add screenshot]

## Validation

<!-- Check only items you actually verified. -->

- [ ] [Add manual check]
- [ ] [Add automated check or mark as needing confirmation]

## Risks and open questions

- [Fill this in]

## Related links

- Design: [Add link if available]
- Ticket or discussion: [Add link if available]
