### PR TITLE
fix(web): keep staff skill pages hydrated

### DIFF
--- a/e2e/local-auth/header-profile-link.pw.test.ts
+++ b/e2e/local-auth/header-profile-link.pw.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { buildPublisherProfileHref } from "../../src/lib/ownerRoute";
 import { expectHealthyPage, trackRuntimeErrors, waitForHydration } from "../helpers/runtimeErrors";
 import { signInAsLocalPersona } from "./helpers";
 
@@ -15,15 +16,16 @@ test("signed-in avatar menu links to the active user profile", async ({ page }, 
   await page.locator("header .user-trigger").click();
 
   const profileLink = page.getByRole("menuitem", { name: "Profile" });
+  const profileHref = buildPublisherProfileHref("local");
   await expect(profileLink).toBeVisible();
-  await expect(profileLink).toHaveAttribute("href", "/user/local");
+  await expect(profileLink).toHaveAttribute("href", profileHref);
   await page.screenshot({
     path: testInfo.outputPath("signed-in-avatar-menu.png"),
     fullPage: true,
   });
 
   await profileLink.click();
-  await page.waitForURL("**/user/local");
+  await page.waitForURL(`**${profileHref}`);
   await waitForHydration(page);
   await expect(page.getByRole("heading", { name: "Local Owner" })).toBeVisible();
   await expectHealthyPage(page, errors);

--- a/e2e/local-auth/helpers.ts
+++ b/e2e/local-auth/helpers.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { expect, type Page, type TestInfo } from "@playwright/test";
+import { buildSkillDetailHref } from "../../src/lib/ownerRoute";
 import { waitForHydration } from "../helpers/runtimeErrors";
 
 type DevPersona = "owner" | "user" | "admin" | "abusePublisher";
@@ -59,6 +60,17 @@ function devPersonaHeaderPattern(persona: DevPersona, expectedHandle: string) {
 function devPersonaMenuLabel(persona: DevPersona) {
   if (persona === "abusePublisher") return "abuse publisher";
   return persona;
+}
+
+function parseSkillDetailPath(pathname: string) {
+  const segments = pathname.split("/").filter(Boolean).map(decodeURIComponent);
+  if (segments.length >= 3 && segments[1] === "skills") {
+    return { ownerHandle: segments[0], slug: segments[2] };
+  }
+  if (segments.length >= 2) {
+    return { ownerHandle: segments[0], slug: segments[1] };
+  }
+  throw new Error(`Expected skill detail path, received ${pathname}`);
 }
 
 export function skillMd(args: { slug: string; displayName: string; versionLabel: string }) {
@@ -253,18 +265,19 @@ export async function publishSkillVersion(
   const publishButton = page.getByRole("button", { name: "Publish skill" });
   await expect(publishButton).toBeEnabled();
   await publishButton.click();
-  await expect(page).toHaveURL(new RegExp(`/[^/]+/${escapeRegExp(args.slug)}$`), {
+  await expect(page).toHaveURL(new RegExp(`/${escapeRegExp(args.slug)}$`), {
     timeout: 60_000,
   });
-  const [, actualOwnerHandle, actualSlug] = new URL(page.url()).pathname
-    .split("/")
-    .map(decodeURIComponent);
+  const { ownerHandle: actualOwnerHandle, slug: actualSlug } = parseSkillDetailPath(
+    new URL(page.url()).pathname,
+  );
   expect(actualOwnerHandle).toBeTruthy();
   expect(actualOwnerHandle?.toLowerCase()).toContain(args.ownerHandle.toLowerCase());
   expect(actualSlug).toBe(args.slug);
-  await expect(page.locator(".skill-page-title")).toHaveText(args.displayName);
+  expect(new URL(page.url()).pathname).toBe(buildSkillDetailHref(actualOwnerHandle!, args.slug));
   await expect(page.getByRole("dialog", { name: /it's alive/i })).toBeVisible();
   await page.getByRole("button", { name: "View skill" }).click();
   await expect(page.getByRole("dialog", { name: /it's alive/i })).toBeHidden();
+  await expect(page.locator(".skill-page-title")).toHaveText(args.displayName);
   return actualOwnerHandle!;
 }

--- a/e2e/local-auth/manage-context-proof.pw.test.ts
+++ b/e2e/local-auth/manage-context-proof.pw.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { expect, test, type Page } from "@playwright/test";
+import { buildPluginDetailHref, buildPluginSecurityAuditHref } from "../../src/lib/pluginRoutes";
 import { expectHealthyPage, trackRuntimeErrors, waitForHydration } from "../helpers/runtimeErrors";
 import { signInAsLocalPersona } from "./helpers";
 
@@ -231,7 +232,11 @@ test("plugin manage context query returns only slim catalog metadata", async ({ 
   const errors = trackRuntimeErrors(page);
 
   await signInAsLocalPersona(page, "owner");
-  await page.goto("/plugins/local-scanned-runtime-plugin", { waitUntil: "domcontentloaded" });
+  const packageName = "local-scanned-runtime-plugin";
+  const ownerHandle = "local";
+  await page.goto(buildPluginDetailHref(packageName, { ownerHandle }), {
+    waitUntil: "domcontentloaded",
+  });
   await waitForHydration(page);
 
   await expect(
@@ -241,7 +246,7 @@ test("plugin manage context query returns only slim catalog metadata", async ({ 
 
   await expectSlimManageContextPayload(page);
 
-  await page.goto("/plugins/local-scanned-runtime-plugin/security-audit", {
+  await page.goto(buildPluginSecurityAuditHref(packageName, { ownerHandle }), {
     waitUntil: "domcontentloaded",
   });
   await waitForHydration(page);

--- a/e2e/local-auth/skill-star-sync.pw.test.ts
+++ b/e2e/local-auth/skill-star-sync.pw.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { buildSkillDetailHref } from "../../src/lib/ownerRoute";
 import { expectHealthyPage, trackRuntimeErrors, waitForHydration } from "../helpers/runtimeErrors";
 import {
   expectLocalPersonaActive,
@@ -30,7 +31,7 @@ test("starring a skill survives refresh with the synchronized count", async ({
   });
 
   await signInAsLocalPersona(page, "user");
-  await page.goto(`/${ownerHandle}/${slug}`, { waitUntil: "domcontentloaded" });
+  await page.goto(buildSkillDetailHref(ownerHandle, slug), { waitUntil: "domcontentloaded" });
   await waitForHydration(page);
   await expectLocalPersonaActive(page, "user");
 

--- a/e2e/local-auth/version-delete.pw.test.ts
+++ b/e2e/local-auth/version-delete.pw.test.ts
@@ -1,6 +1,8 @@
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { expect, type Locator, test } from "@playwright/test";
+import { buildSkillDetailHref } from "../../src/lib/ownerRoute";
+import { buildPluginDetailHref } from "../../src/lib/pluginRoutes";
 import {
   expectHealthyPage,
   expectNoFatalErrorUi,
@@ -224,7 +226,7 @@ test("owners can permanently delete individual non-latest skill and plugin versi
   const suffix = uniqueSuffix();
   const skillSlug = `pw-version-delete-skill-${suffix}`;
   const skillDisplayName = `Playwright Version Delete Skill ${suffix}`;
-  const packageName = `@claw333/pw-version-delete-plugin-${suffix}`;
+  const packageName = `@local-user/pw-version-delete-plugin-${suffix}`;
   const packageDisplayName = `Playwright Version Delete Plugin ${suffix}`;
   const fixture = seedVersionDeletionFixture({
     skillSlug,
@@ -285,7 +287,12 @@ test("owners can permanently delete individual non-latest skill and plugin versi
 
   await signInAsLocalPersona(page, "user");
 
-  await page.goto(`/${fixture.handle}/${fixture.skillSlug}`, { waitUntil: "domcontentloaded" });
+  const skillDetailHref = buildSkillDetailHref(fixture.handle, fixture.skillSlug);
+  const pluginDetailHref = buildPluginDetailHref(fixture.packageName, {
+    ownerHandle: fixture.handle,
+  });
+
+  await page.goto(skillDetailHref, { waitUntil: "domcontentloaded" });
   await waitForHydration(page);
   await expect(page.locator(".skill-page-title")).toHaveText(skillDisplayName);
   await page.getByRole("tab", { name: "Versions" }).click();
@@ -311,7 +318,7 @@ test("owners can permanently delete individual non-latest skill and plugin versi
     fullPage: true,
   });
 
-  await page.goto(`/plugins/${encodeURIComponent(fixture.packageName)}`, {
+  await page.goto(pluginDetailHref, {
     waitUntil: "domcontentloaded",
   });
   await waitForHydration(page);
@@ -395,7 +402,7 @@ test("owners can permanently delete individual non-latest skill and plugin versi
   const publicPage = await publicContext.newPage();
   const publicErrors = trackRuntimeErrors(publicPage);
   try {
-    await publicPage.goto(`/${fixture.handle}/${fixture.skillSlug}`, {
+    await publicPage.goto(skillDetailHref, {
       waitUntil: "domcontentloaded",
     });
     await waitForHydration(publicPage);
@@ -403,7 +410,7 @@ test("owners can permanently delete individual non-latest skill and plugin versi
     await publicPage.getByRole("tab", { name: "Versions" }).click();
     await expectPublicVersionsList(publicPage);
 
-    await publicPage.goto(`/plugins/${encodeURIComponent(fixture.packageName)}`, {
+    await publicPage.goto(pluginDetailHref, {
       waitUntil: "domcontentloaded",
     });
     await waitForHydration(publicPage);

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -194,6 +194,86 @@ describe("SkillDetailPage", () => {
     expect(screen.queryByRole("button", { name: "Diff" })).toBeNull();
   });
 
+  it("keeps loader-backed skill content visible while staff live query resolves", async () => {
+    useAuthStatusMock.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      me: { _id: "users:staff", role: "moderator" },
+    });
+    useQueryMock.mockImplementation((_fn: unknown, args: unknown) => {
+      if (args === "skip") return undefined;
+      return undefined;
+    });
+
+    render(
+      <SkillDetailPage
+        slug="github"
+        canonicalOwner="steipete"
+        initialData={{
+          result: {
+            skill: {
+              _id: skillId,
+              _creationTime: 0,
+              slug: "github",
+              displayName: "Github",
+              summary: "Interact with GitHub using the `gh` CLI.",
+              ownerUserId: ownerId,
+              ownerPublisherId,
+              tags: {},
+              badges: {},
+              stats: {
+                stars: 12,
+                downloads: 34,
+                installsCurrent: 5,
+                installsAllTime: 8,
+                versions: 1,
+                comments: 0,
+              },
+              createdAt: 0,
+              updatedAt: 0,
+            },
+            owner: {
+              _id: ownerPublisherId,
+              _creationTime: 0,
+              kind: "user",
+              handle: "steipete",
+              displayName: "Peter",
+              linkedUserId: ownerId,
+            },
+            latestVersion: {
+              _id: versionId,
+              _creationTime: 0,
+              skillId,
+              version: "1.0.0",
+              fingerprint: "abc",
+              changelog: "Initial release",
+              parsed: { license: "MIT-0", frontmatter: {} },
+              files: [
+                {
+                  path: "SKILL.md",
+                  size: 10,
+                  storageId,
+                  sha256: "abc",
+                  contentType: "text/markdown",
+                },
+              ],
+              createdBy: ownerId,
+              createdAt: 0,
+            },
+            forkOf: null,
+            canonical: null,
+          },
+          readme: "# GitHub Skill",
+          readmeError: null,
+        }}
+      />,
+    );
+
+    expect(screen.queryByRole("status", { name: /Loading skill details/i })).toBeNull();
+    expect(screen.getAllByRole("heading", { name: "Github" }).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Interact with GitHub using the `gh` CLI\./i)).toBeTruthy();
+  });
+
   it("loads skill activity graphs through a deferred one-shot query", async () => {
     const activityTrend = {
       installs: {

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -216,7 +216,8 @@ export function SkillDetailPage({
   const publicResult = useQuery(api.skills.getBySlug, !isStaff ? skillLookupArgs : "skip") as
     | SkillBySlugResult
     | undefined;
-  const result = isStaff ? staffResult : publicResult === undefined ? initialResult : publicResult;
+  const liveResult = isStaff ? staffResult : publicResult;
+  const result = liveResult === undefined ? initialResult : liveResult;
 
   const toggleStar = useMutation(api.stars.toggle);
   const reportSkill = useMutation(api.skills.report);
@@ -251,7 +252,7 @@ export function SkillDetailPage({
     delta: number;
   } | null>(null);
 
-  const isLoadingSkill = isStaff ? staffResult === undefined : result === undefined;
+  const isLoadingSkill = result === undefined;
   const skill = result?.skill;
   const owner = result?.owner ?? null;
   const latestVersion = (result?.latestVersion ?? null) as SkillDetailVersion | null;


### PR DESCRIPTION
## Summary
- keep loader-backed skill detail content visible while staff-only live queries are still pending
- add a regression test for staff users loading `/steipete/skills/github`-style skill detail pages without a hydration skeleton flash

## Verification
- `VITE_CONVEX_URL=https://example.invalid bunx vitest run src/__tests__/skill-detail-page.test.tsx --testNamePattern "keeps loader-backed skill content visible while staff live query resolves"` (failed before fix, passed after)
- `VITE_CONVEX_URL=https://example.invalid bunx vitest run src/__tests__/skill-detail-page.test.tsx`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- live browser probe: `https://clawhub.ai/steipete/skills/github` made one document request and rendered `Github` + `openclaw skills install @steipete/github`
