### PR TITLE
Publish security dataset from live Convex export

### DIFF
--- a/.github/workflows/security-dataset-snapshot.yml
+++ b/.github/workflows/security-dataset-snapshot.yml
@@ -1,0 +1,220 @@
+name: Security Dataset Snapshot
+
+on:
+  workflow_dispatch:
+    inputs:
+      upload:
+        description: "Upload sanitized dataset files to Hugging Face"
+        required: true
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+      limit:
+        description: "Optional source artifact cap for validation runs"
+        required: false
+        default: ""
+      hf-revision:
+        description: "Hugging Face branch/revision to upload to"
+        required: true
+        default: "main"
+  schedule:
+    - cron: "17 9 * * *"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: clawhub-security-dataset-snapshot
+  cancel-in-progress: false
+
+jobs:
+  publish-security-dataset:
+    name: Publish sanitized security dataset
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 360
+    environment: Production
+    env:
+      CONVEX_URL: ${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}
+      SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}
+      HF_DATASET_REPO: OpenClaw/clawhub-security-signals
+      HF_OIDC_RESOURCE: datasets/OpenClaw/clawhub-security-signals
+      HF_REVISION: ${{ inputs.hf-revision || 'main' }}
+      HF_UPLOAD: ${{ github.event_name == 'schedule' || inputs.upload == 'true' }}
+      SNAPSHOT_LIMIT: ${{ inputs.limit || '' }}
+      SANITIZED_OUT_DIR: ${{ runner.temp }}/clawhub-security-dataset/sanitized
+      WORK_DIR: ${{ runner.temp }}/clawhub-security-dataset
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-bun
+
+      - uses: actions/setup-python@v6
+        if: ${{ env.HF_UPLOAD == 'true' }}
+        with:
+          python-version: "3.12"
+
+      - name: Check configuration
+        run: |
+          set -euo pipefail
+          if [[ -z "$SECURITY_SCAN_WORKER_TOKEN" ]]; then
+            echo "::error::SECURITY_SCAN_WORKER_TOKEN is required"
+            exit 1
+          fi
+          echo "Upload enabled: $HF_UPLOAD"
+          echo "Convex URL: $CONVEX_URL"
+          echo "Hugging Face repo: $HF_DATASET_REPO"
+          echo "Hugging Face OIDC resource: $HF_OIDC_RESOURCE"
+          echo "Hugging Face revision: $HF_REVISION"
+
+      - name: Export sanitized live dataset
+        run: |
+          set -euo pipefail
+          mkdir -p "$SANITIZED_OUT_DIR"
+          source_snapshot_id="live-convex-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          args=(
+            --convex-url "$CONVEX_URL"
+            --worker-token "$SECURITY_SCAN_WORKER_TOKEN"
+            --source-snapshot-id "$source_snapshot_id"
+            --out-dir "$SANITIZED_OUT_DIR"
+            --hf-dataset
+            --hf-repo "$HF_DATASET_REPO"
+            --hf-revision "$HF_REVISION"
+          )
+          if [[ -n "$SNAPSHOT_LIMIT" ]]; then
+            args+=(--limit "$SNAPSHOT_LIMIT")
+          fi
+          bun scripts/security-dataset/export-snapshot.ts "${args[@]}" | tee "$SANITIZED_OUT_DIR/summary.json"
+          snapshot_dir="$(jq -r '.snapshotDir' "$SANITIZED_OUT_DIR/summary.json")"
+          if [[ -z "$snapshot_dir" || "$snapshot_dir" == "null" ]]; then
+            echo "::error::export summary did not include snapshotDir"
+            exit 1
+          fi
+          echo "SNAPSHOT_DIR=$snapshot_dir" >> "$GITHUB_ENV"
+          jq '.manifest.row_counts, .manifest.huggingface_dataset' "$SANITIZED_OUT_DIR/summary.json"
+
+      - name: Validate sanitized output guardrails
+        run: |
+          set -euo pipefail
+          test -d "$SNAPSHOT_DIR/hf-dataset/data"
+          test -f "$SNAPSHOT_DIR/manifest.json"
+          for split in train validation test eval_holdout; do
+            test -f "$SNAPSHOT_DIR/hf-dataset/data/$split.jsonl"
+          done
+          if grep -R -E 'storageId|skillVersions:|packageReleases:|_storage/' "$SNAPSHOT_DIR/hf-dataset" "$SNAPSHOT_DIR/manifest.json"; then
+            echo "::error::sanitized output contains raw storage or internal document identifiers"
+            exit 1
+          fi
+          if grep -R -E 'gh[pousr]_[A-Za-z0-9_]{20,}|sk-[A-Za-z0-9_-]{20,}|AKIA[0-9A-Z]{16}|-----BEGIN [A-Z0-9 ]*(PRIVATE KEY|CERTIFICATE)-----' "$SNAPSHOT_DIR/hf-dataset"; then
+            echo "::error::sanitized output contains obvious secret-like values"
+            exit 1
+          fi
+
+      - name: Install Hugging Face uploader
+        if: ${{ env.HF_UPLOAD == 'true' }}
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install 'huggingface_hub[hf_xet]'
+
+      - name: Upload sanitized dataset to Hugging Face
+        if: ${{ env.HF_UPLOAD == 'true' }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+          from pathlib import Path
+          from huggingface_hub import HfApi
+
+          def get_github_oidc_token() -> str:
+              request_url = os.environ["ACTIONS_ID_TOKEN_REQUEST_URL"]
+              separator = "&" if "?" in request_url else "?"
+              request = urllib.request.Request(
+                  f"{request_url}{separator}audience=https://huggingface.co",
+                  headers={
+                      "Authorization": f"bearer {os.environ['ACTIONS_ID_TOKEN_REQUEST_TOKEN']}",
+                      "Accept": "application/json",
+                  },
+              )
+              with urllib.request.urlopen(request) as response:
+                  payload = json.loads(response.read().decode("utf-8"))
+              return payload["value"]
+
+          def exchange_hugging_face_token(oidc_token: str, resource: str) -> str:
+              body = json.dumps({
+                  "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+                  "subject_token_type": "urn:ietf:params:oauth:token-type:id_token",
+                  "subject_token": oidc_token,
+                  "resource": resource,
+              }).encode("utf-8")
+              request = urllib.request.Request(
+                  "https://huggingface.co/oauth/token",
+                  data=body,
+                  headers={
+                      "Content-Type": "application/json",
+                      "Accept": "application/json",
+                  },
+                  method="POST",
+              )
+              with urllib.request.urlopen(request) as response:
+                  payload = json.loads(response.read().decode("utf-8"))
+              return payload["access_token"]
+
+          snapshot_dir = Path(os.environ["SNAPSHOT_DIR"])
+          repo_id = os.environ["HF_DATASET_REPO"]
+          revision = os.environ["HF_REVISION"]
+          token = exchange_hugging_face_token(
+              get_github_oidc_token(),
+              os.environ["HF_OIDC_RESOURCE"],
+          )
+          api = HfApi(token=token)
+
+          data_commit = api.upload_folder(
+              folder_path=str(snapshot_dir / "hf-dataset" / "data"),
+              path_in_repo="data",
+              repo_id=repo_id,
+              repo_type="dataset",
+              revision=revision,
+              delete_patterns="data/*.jsonl",
+              commit_message="Update nightly ClawHub security dataset splits",
+          )
+
+          manifest_path = snapshot_dir / "manifest.json"
+          manifest = json.loads(manifest_path.read_text())
+          manifest["huggingface_dataset"]["commit"] = data_commit.oid
+          manifest["huggingface_dataset"]["revision"] = revision
+          manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+
+          manifest_commit = api.upload_file(
+              path_or_fileobj=str(manifest_path),
+              path_in_repo="metadata/latest-manifest.json",
+              repo_id=repo_id,
+              repo_type="dataset",
+              revision=revision,
+              commit_message="Update nightly ClawHub security dataset manifest",
+          )
+          print(json.dumps({
+              "data_commit": data_commit.oid,
+              "manifest_commit": manifest_commit.oid,
+              "repo": repo_id,
+              "revision": revision,
+          }, indent=2))
+          PY
+
+      - name: Upload sanitized summary artifact
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: security-dataset-summary-${{ github.run_id }}
+          path: |
+            ${{ env.SANITIZED_OUT_DIR }}/summary.json
+            ${{ env.SNAPSHOT_DIR }}/manifest.json
+          if-no-files-found: ignore
+
+      - name: Cleanup transient dataset files
+        if: ${{ always() }}
+        run: rm -rf "$WORK_DIR"

--- a/convex/securityDatasetNode.test.ts
+++ b/convex/securityDatasetNode.test.ts
@@ -1,0 +1,130 @@
+/* @vitest-environment node */
+import { gunzipSync } from "node:zlib";
+import { describe, expect, it, vi } from "vitest";
+import { listArtifactExportBatchCompressed } from "./securityDatasetNode";
+
+type WrappedHandler<TArgs, TResult = unknown> = {
+  _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;
+};
+
+const listArtifactExportBatchCompressedHandler = (
+  listArtifactExportBatchCompressed as unknown as WrappedHandler<
+    {
+      token: string;
+      sourceKind: "skill";
+      paginationOpts: { cursor: string | null; numItems: number };
+      pageCount: number;
+    },
+    { encoding: "gzip-base64-json"; payload: string }
+  >
+)._handler;
+
+describe("security dataset worker export", () => {
+  it("requires the shared worker token", async () => {
+    vi.stubEnv("SECURITY_SCAN_WORKER_TOKEN", "worker-secret");
+
+    await expect(
+      listArtifactExportBatchCompressedHandler(makeCtx(), {
+        token: "wrong",
+        sourceKind: "skill",
+        paginationOpts: { cursor: null, numItems: 1 },
+        pageCount: 1,
+      }),
+    ).rejects.toThrow("Unauthorized");
+  });
+
+  it("returns redacted storage-backed content without storage ids", async () => {
+    vi.stubEnv("SECURITY_SCAN_WORKER_TOKEN", "worker-secret");
+    const result = await listArtifactExportBatchCompressedHandler(makeCtx(), {
+      token: "worker-secret",
+      sourceKind: "skill",
+      paginationOpts: { cursor: null, numItems: 1 },
+      pageCount: 1,
+    });
+
+    const decoded = JSON.parse(
+      gunzipSync(Buffer.from(result.payload, "base64")).toString("utf8"),
+    ) as {
+      page: Array<{
+        skillMdContentRedacted: string;
+        bundleFilesRedacted: Array<{ path: string; content: string }>;
+        files: Array<Record<string, unknown>>;
+      }>;
+    };
+
+    expect(decoded.page).toEqual([
+      expect.objectContaining({
+        skillMdContentRedacted: "Use this skill. [REDACTED_SECRET]",
+        bundleFilesRedacted: [
+          {
+            path: "scripts/run.sh",
+            content: "echo [REDACTED_SECRET]\n",
+          },
+        ],
+        files: [
+          expect.not.objectContaining({ storageId: expect.anything() }),
+          expect.not.objectContaining({ storageId: expect.anything() }),
+        ],
+      }),
+    ]);
+  });
+});
+
+function makeCtx() {
+  return {
+    runQuery: vi.fn(async () => ({
+      page: [
+        {
+          sourceKind: "skill",
+          sourceDocId: "skillVersions:1",
+          parentDocId: "skills:1",
+          publicName: "Demo",
+          publicOwnerHandle: "owner",
+          publicSlug: "demo",
+          version: "1.0.0",
+          artifactSha256: "a".repeat(64),
+          createdAt: 1,
+          softDeletedAt: null,
+          files: [
+            {
+              path: "SKILL.md",
+              size: 42,
+              sha256: "skill-sha",
+              storageId: "storage:skill",
+              contentType: "text/markdown",
+            },
+            {
+              path: "scripts/run.sh",
+              size: 32,
+              sha256: "script-sha",
+              storageId: "storage:script",
+              contentType: "text/x-shellscript",
+            },
+          ],
+          packageFamily: null,
+          packageChannel: null,
+          sourceRepoHost: null,
+          vtAnalysis: null,
+          skillSpectorAnalysis: null,
+          staticScan: null,
+          llmAnalysis: null,
+          moderationConsensus: null,
+        },
+      ],
+      isDone: true,
+      continueCursor: "",
+      exportMode: "public",
+    })),
+    storage: {
+      get: vi.fn(async (id: string) => {
+        if (id === "storage:skill") {
+          return new Blob(["Use this skill. token=supersecret123"]);
+        }
+        if (id === "storage:script") {
+          return new Blob(["echo password=scriptsecret123\n"]);
+        }
+        return null;
+      }),
+    },
+  };
+}

--- a/convex/securityDatasetNode.ts
+++ b/convex/securityDatasetNode.ts
@@ -2,10 +2,10 @@
 
 import { gzipSync } from "node:zlib";
 import { paginationOptsValidator } from "convex/server";
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 import { internal } from "./_generated/api";
 import type { ActionCtx } from "./_generated/server";
-import { internalAction } from "./functions";
+import { action, internalAction } from "./functions";
 
 const MAX_EXPORT_BATCH_PAGES = 20;
 const MAX_REDACTED_BUNDLE_FILE_BYTES = 192 * 1024;
@@ -17,6 +17,21 @@ type ArtifactExportPage = {
   isDone: boolean;
   continueCursor: string;
   exportMode: "public";
+};
+
+type DatasetLineage = {
+  exportMode: "public";
+  generatedAt: number;
+  maxExportPageSize: number;
+  maxExportBatchPages: number;
+  redactionPolicyVersion: string;
+  sourceTables: readonly string[];
+  scannerSources: readonly string[];
+  sourceBounds: Array<{
+    sourceKind: "skill" | "package";
+    minCreatedAt: number | null;
+    maxCreatedAt: number | null;
+  }>;
 };
 
 const SECRET_PATTERNS: RegExp[] = [
@@ -31,6 +46,24 @@ const SECRET_PATTERNS: RegExp[] = [
   /(["'`])(?=[A-Za-z0-9+/=_-]{32,}\1)(?=.*[A-Z])(?=.*[a-z])(?=.*\d)[A-Za-z0-9+/=_-]+\1/g,
 ];
 
+type ArtifactExportBatchArgs = {
+  sourceKind: "skill" | "package";
+  mode?: "public";
+  createdAtGte?: number;
+  createdAtLt?: number;
+  paginationOpts: {
+    cursor: string | null;
+    numItems: number;
+  };
+  pageCount: number;
+};
+
+function assertDatasetExportWorkerToken(token: string) {
+  // Shared worker credential already used by the security and Skill Card GitHub workers.
+  const expected = process.env.SECURITY_SCAN_WORKER_TOKEN;
+  if (!expected || token !== expected) throw new ConvexError("Unauthorized");
+}
+
 export const listArtifactExportBatchCompressedInternal = internalAction({
   args: {
     sourceKind: v.union(v.literal("skill"), v.literal("package")),
@@ -40,42 +73,76 @@ export const listArtifactExportBatchCompressedInternal = internalAction({
     paginationOpts: paginationOptsValidator,
     pageCount: v.number(),
   },
+  handler: async (ctx, args) => listArtifactExportBatchCompressedForWorker(ctx, args),
+});
+
+export const listArtifactExportBatchCompressed = action({
+  args: {
+    token: v.string(),
+    sourceKind: v.union(v.literal("skill"), v.literal("package")),
+    mode: v.optional(v.literal("public")),
+    createdAtGte: v.optional(v.number()),
+    createdAtLt: v.optional(v.number()),
+    paginationOpts: paginationOptsValidator,
+    pageCount: v.number(),
+  },
   handler: async (ctx, args) => {
-    const pageCount = Math.min(Math.max(1, Math.floor(args.pageCount)), MAX_EXPORT_BATCH_PAGES);
-    let cursor = args.paginationOpts.cursor;
-    const page: ArtifactExportPage["page"] = [];
-    let isDone = false;
-    for (let pageIndex = 0; pageIndex < pageCount; pageIndex += 1) {
-      const result: ArtifactExportPage = await ctx.runQuery(
-        internal.securityDataset.listArtifactExportPageInternal,
-        {
-          sourceKind: args.sourceKind,
-          mode: args.mode,
-          createdAtGte: args.createdAtGte,
-          createdAtLt: args.createdAtLt,
-          paginationOpts: {
-            cursor,
-            numItems: args.paginationOpts.numItems,
-          },
-        },
-      );
-      page.push(...result.page);
-      cursor = result.continueCursor;
-      isDone = result.isDone;
-      if (isDone) break;
-    }
-    const json = JSON.stringify({
-      page: await enrichAndSanitizeArtifactRows(ctx, page),
-      isDone,
-      continueCursor: cursor,
-      exportMode: args.mode ?? "public",
-    });
-    return {
-      encoding: "gzip-base64-json" as const,
-      payload: gzipSync(json).toString("base64"),
-    };
+    assertDatasetExportWorkerToken(args.token);
+    return await listArtifactExportBatchCompressedForWorker(ctx, args);
   },
 });
+
+export const getDatasetLineage = action({
+  args: {
+    token: v.string(),
+    mode: v.optional(v.literal("public")),
+  },
+  handler: async (ctx, args): Promise<DatasetLineage> => {
+    assertDatasetExportWorkerToken(args.token);
+    return await ctx.runQuery(internal.securityDataset.getDatasetLineageInternal, {
+      mode: args.mode,
+    });
+  },
+});
+
+async function listArtifactExportBatchCompressedForWorker(
+  ctx: ActionCtx,
+  args: ArtifactExportBatchArgs,
+) {
+  const pageCount = Math.min(Math.max(1, Math.floor(args.pageCount)), MAX_EXPORT_BATCH_PAGES);
+  let cursor = args.paginationOpts.cursor;
+  const page: ArtifactExportPage["page"] = [];
+  let isDone = false;
+  for (let pageIndex = 0; pageIndex < pageCount; pageIndex += 1) {
+    const result: ArtifactExportPage = await ctx.runQuery(
+      internal.securityDataset.listArtifactExportPageInternal,
+      {
+        sourceKind: args.sourceKind,
+        mode: args.mode,
+        createdAtGte: args.createdAtGte,
+        createdAtLt: args.createdAtLt,
+        paginationOpts: {
+          cursor,
+          numItems: args.paginationOpts.numItems,
+        },
+      },
+    );
+    page.push(...result.page);
+    cursor = result.continueCursor;
+    isDone = result.isDone;
+    if (isDone) break;
+  }
+  const json = JSON.stringify({
+    page: await enrichAndSanitizeArtifactRows(ctx, page),
+    isDone,
+    continueCursor: cursor,
+    exportMode: args.mode ?? "public",
+  });
+  return {
+    encoding: "gzip-base64-json" as const,
+    payload: gzipSync(json).toString("base64"),
+  };
+}
 
 async function enrichAndSanitizeArtifactRows(ctx: ActionCtx, rows: unknown[]) {
   const enrichedRows = [];

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -210,6 +210,31 @@ same automatic patch-version behavior.
 Set `dry_run: true` to preview without a token. Real publishes require the
 `clawhub_token` secret.
 
+### `sync`
+
+- Scans the current workdir, the configured skills directory, and any
+  `--root <dir>` folders for local skill folders containing `SKILL.md` or
+  `skill.md`.
+- Compares each local skill fingerprint with ClawHub and publishes only new or
+  changed skills.
+- New skills publish as `1.0.0`; changed skills publish the next patch version
+  by default. Use `--bump minor|major` for update batches that should move by a
+  larger semver step.
+- `--dry-run` shows the publish plan without uploading; `--json` prints a
+  machine-readable plan.
+- `--all` publishes every new or changed skill without prompting. Without
+  `--all`, interactive terminals let you select the skills to publish.
+- `--owner <handle>` publishes under an org/user publisher handle when the
+  actor has publisher access.
+- `sync` is one-way publish only. It does not install, update, download, or
+  report install/download telemetry.
+
+```bash
+clawhub sync --all --dry-run
+clawhub sync --all
+clawhub sync --root ./skills --owner openclaw --bump minor
+```
+
 ### `scan --slug <slug>`
 
 - Requires `clawhub login`.

--- a/packages/clawhub/README.md
+++ b/packages/clawhub/README.md
@@ -51,6 +51,8 @@ clawhub update --all --no-input --force
 clawhub unpin bear-notes
 clawhub skill publish ./my-skill-pack --slug my-skill-pack --name "My Skill Pack" --changelog "Fixes + docs"
 clawhub skill publish ./org-skill --owner openclaw --changelog "Org publish"
+clawhub sync --all --dry-run
+clawhub sync --all
 clawhub package explore --family skill
 clawhub package explore --family code-plugin
 clawhub package inspect @openclaw/example-plugin

--- a/packages/clawhub/src/cli.ts
+++ b/packages/clawhub/src/cli.ts
@@ -46,6 +46,7 @@ import {
   cmdUpdate,
 } from "./cli/commands/skills.js";
 import { cmdStarSkill } from "./cli/commands/star.js";
+import { cmdSync } from "./cli/commands/sync.js";
 import {
   cmdTransferAccept,
   cmdTransferCancel,
@@ -861,6 +862,50 @@ registerCommand(program, ["unstar"])
     await cmdUnstarSkill(opts, slug, options, isInputAllowed());
   });
 
+registerCommand(program, ["sync"])
+  .description("Scan local skills and publish new or changed ones")
+  .option("--root <dir...>", "Extra scan roots (one or more)")
+  .option("--all", "Publish all new or changed skills without prompting")
+  .option("--dry-run", "Show what would be published")
+  .option("--json", "Output JSON")
+  .option("--owner <handle>", "Publish under an org/user publisher handle")
+  .option("--bump <type>", "Version bump for updates (patch|minor|major)", "patch")
+  .option("--changelog <text>", "Changelog to use for updates")
+  .option("--tags <tags>", "Comma-separated tags", "latest")
+  .option("--concurrency <n>", "Concurrent registry/file checks", (value) =>
+    Number.parseInt(value, 10),
+  )
+  .option("--source-repo <repo>", "GitHub repo URL or owner/name for source provenance")
+  .option("--source-commit <sha>", "Git commit SHA for source provenance")
+  .option("--source-ref <ref>", "Git ref for source provenance")
+  .action(async (options) => {
+    const opts = await resolveGlobalOpts();
+    const bump =
+      options.bump === "patch" || options.bump === "minor" || options.bump === "major"
+        ? options.bump
+        : fail("--bump must be patch, minor, or major");
+    const concurrency = options.concurrency ?? 6;
+    if (concurrency < 1 || concurrency > 32) fail("--concurrency must be between 1 and 32");
+    await cmdSync(
+      opts,
+      {
+        root: options.root,
+        all: options.all,
+        dryRun: options.dryRun,
+        json: options.json,
+        owner: options.owner,
+        bump,
+        changelog: options.changelog,
+        tags: options.tags,
+        concurrency,
+        sourceRepo: options.sourceRepo,
+        sourceCommit: options.sourceCommit,
+        sourceRef: options.sourceRef,
+      },
+      isInputAllowed(),
+    );
+  });
+
 applyCommandHelpGroups(program, {
   login: "Auth:",
   logout: "Auth:",
@@ -878,6 +923,7 @@ applyCommandHelpGroups(program, {
   star: "Skills:",
   unstar: "Skills:",
   publish: "Publishing:",
+  sync: "Publishing:",
   skill: "Publishing:",
   publisher: "Publishing:",
   package: "Packages:",

--- a/packages/clawhub/src/cli/commands/publish.ts
+++ b/packages/clawhub/src/cli/commands/publish.ts
@@ -50,6 +50,7 @@ export async function cmdPublish(
     sourcePath?: string;
     dryRun?: boolean;
     json?: boolean;
+    quiet?: boolean;
   },
 ): Promise<SkillPublishResult> {
   const folder = folderArg ? resolve(opts.workdir, folderArg) : null;
@@ -86,11 +87,9 @@ export async function cmdPublish(
   if (!displayName) fail("--name required");
   if (explicitVersion && !semver.valid(explicitVersion)) fail("--version must be valid semver");
 
-  const spinner = options.json ? null : createCrabLoader(`Preparing ${slug}`);
+  const spinner = options.json || options.quiet ? null : createCrabLoader(`Preparing ${slug}`);
   try {
-    const filesOnDisk = stripGeneratedSkillCards(
-      await ensureRootManifestFile(folder, await listTextFiles(folder)),
-    );
+    const filesOnDisk = await prepareSkillFilesForPublish(folder);
     if (filesOnDisk.length === 0) fail("No files found");
     if (
       !filesOnDisk.some((file) => {
@@ -226,7 +225,7 @@ function parseCsv(value: string | undefined) {
     .filter(Boolean);
 }
 
-async function resolveDefaultOwnerHandle(registry: string, token: string) {
+export async function resolveDefaultOwnerHandle(registry: string, token: string) {
   const whoami = await apiRequest(
     registry,
     { method: "GET", path: ApiRoutes.whoami, token },
@@ -275,6 +274,12 @@ function buildPublishResult(result: Omit<SkillPublishResult, "ok">): SkillPublis
 
 function writePublishJsonIfRequested(json: boolean | undefined, result: SkillPublishResult) {
   if (json) process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+export async function prepareSkillFilesForPublish(folder: string) {
+  return stripGeneratedSkillCards(
+    await ensureRootManifestFile(folder, await listTextFiles(folder)),
+  );
 }
 
 function stripGeneratedSkillCards(files: Awaited<ReturnType<typeof listTextFiles>>) {

--- a/packages/clawhub/src/cli/commands/sync.test.ts
+++ b/packages/clawhub/src/cli/commands/sync.test.ts
@@ -1,0 +1,423 @@
+/* @vitest-environment node */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createAuthTokenModuleMocks,
+  createHttpModuleMocks,
+  createRegistryModuleMocks,
+  createUiModuleMocks,
+  makeGlobalOpts,
+} from "../../../test/cliCommandTestKit.js";
+import type { SkillOrigin } from "../../skills.js";
+
+const mockIntro = vi.fn();
+const mockOutro = vi.fn();
+const mockLog = vi.fn();
+const mockMultiselect = vi.fn(async (_args?: unknown) => [] as string[]);
+let interactive = false;
+const mocked = <T>(value: T) =>
+  value as T & { mockImplementation: (...args: unknown[]) => unknown };
+
+const defaultFindSkillFolders = async (root: string) => {
+  if (!root.endsWith("/scan")) return [];
+  return [
+    { folder: `${root}/new-skill`, slug: "new-skill", displayName: "New Skill" },
+    { folder: `${root}/synced-skill`, slug: "synced-skill", displayName: "Synced Skill" },
+    { folder: `${root}/update-skill`, slug: "update-skill", displayName: "Update Skill" },
+  ];
+};
+
+vi.mock("@clack/prompts", () => ({
+  intro: (value: string) => mockIntro(value),
+  outro: (value: string) => mockOutro(value),
+  multiselect: (args: unknown) => mockMultiselect(args),
+  isCancel: () => false,
+}));
+
+const authTokenMocks = createAuthTokenModuleMocks();
+const registryMocks = createRegistryModuleMocks();
+const httpMocks = createHttpModuleMocks();
+const uiMocks = createUiModuleMocks();
+const mockApiRequest = httpMocks.apiRequest;
+const mockFail = uiMocks.fail;
+const mockSpinner = uiMocks.spinner;
+vi.mock("../authToken.js", () => authTokenMocks.moduleFactory());
+vi.mock("../registry.js", () => registryMocks.moduleFactory());
+vi.mock("../../http.js", () => httpMocks.moduleFactory());
+vi.mock("../ui.js", () => ({
+  createCrabLoader: vi.fn(() => mockSpinner),
+  fail: (message: string) => mockFail(message),
+  formatError: (error: unknown) => (error instanceof Error ? error.message : String(error)),
+  isInteractive: () => interactive,
+}));
+
+vi.mock("../scanSkills.js", () => ({
+  findSkillFolders: vi.fn(defaultFindSkillFolders),
+  getFallbackSkillRoots: vi.fn(() => []),
+}));
+
+const mockListTextFiles = vi.fn(async (folder: string) => [
+  { relPath: "SKILL.md", bytes: new TextEncoder().encode(folder) },
+]);
+const mockHashSkillFiles = vi.fn((files: Array<{ relPath: string; bytes: Uint8Array }>) => ({
+  fingerprint: files
+    .map((file) => `${file.relPath}:${Buffer.from(file.bytes).toString("hex")}`)
+    .join("|"),
+  files: [],
+}));
+const mockReadSkillOrigin = vi.fn(async (_folder?: string): Promise<SkillOrigin | null> => null);
+vi.mock("../../skills.js", () => ({
+  listTextFiles: (folder: string) => mockListTextFiles(folder),
+  hashSkillFiles: (files: Array<{ relPath: string; bytes: Uint8Array }>) =>
+    mockHashSkillFiles(files),
+  readSkillOrigin: (folder: string) => mockReadSkillOrigin(folder),
+}));
+
+const mockCmdPublish = vi.fn();
+const mockPrepareSkillFilesForPublish = vi.fn(async (folder: string) => mockListTextFiles(folder));
+vi.mock("./publish.js", () => ({
+  cmdPublish: (opts: unknown, folder: unknown, options?: unknown) =>
+    mockCmdPublish(opts, folder, options),
+  prepareSkillFilesForPublish: (folder: string) => mockPrepareSkillFilesForPublish(folder),
+  resolveDefaultOwnerHandle: async (_registry: string, _token: string) => "steipete",
+}));
+
+const { cmdSync } = await import("./sync");
+
+function makeOpts() {
+  return makeGlobalOpts();
+}
+
+afterEach(async () => {
+  vi.clearAllMocks();
+  mockCmdPublish.mockReset();
+  mockPrepareSkillFilesForPublish.mockImplementation(async (folder: string) =>
+    mockListTextFiles(folder),
+  );
+  mockReadSkillOrigin.mockImplementation(async (_folder?: string) => null);
+  process.exitCode = undefined;
+  const { findSkillFolders, getFallbackSkillRoots } = await import("../scanSkills.js");
+  mocked(findSkillFolders).mockImplementation(defaultFindSkillFolders);
+  mocked(getFallbackSkillRoots).mockImplementation(() => []);
+});
+
+vi.spyOn(console, "log").mockImplementation((...args) => {
+  mockLog(args.map(String).join(" "));
+});
+
+describe("cmdSync", () => {
+  it("emits CI JSON dry-run without requiring auth", async () => {
+    interactive = false;
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    mockApiRequest.mockImplementation(async (_registry: string, args: { path?: string }) => {
+      if (args.path?.startsWith("/api/v1/resolve?")) {
+        const u = new URL(`https://x.test${args.path}`);
+        const slug = u.searchParams.get("slug");
+        if (slug === "new-skill") throw new Error("Skill not found");
+        if (slug === "synced-skill") {
+          return { match: { version: "1.2.3" }, latestVersion: { version: "1.2.3" } };
+        }
+        if (slug === "update-skill") {
+          return { match: null, latestVersion: { version: "1.0.0" } };
+        }
+      }
+      throw new Error(`Unexpected apiRequest: ${String(args.path)}`);
+    });
+
+    let output = "";
+    try {
+      await cmdSync(
+        makeOpts(),
+        {
+          root: ["/scan"],
+          all: true,
+          dryRun: true,
+          json: true,
+          owner: "nvidia",
+        },
+        false,
+      );
+      output = String(stdoutWrite.mock.calls.at(-1)?.[0] ?? "").trim();
+    } finally {
+      stdoutWrite.mockRestore();
+    }
+
+    expect(authTokenMocks.requireAuthToken).not.toHaveBeenCalled();
+    expect(mockCmdPublish).not.toHaveBeenCalled();
+    expect(mockPrepareSkillFilesForPublish).toHaveBeenCalledTimes(3);
+    for (const call of mockApiRequest.mock.calls) {
+      const path = String(call[1]?.path ?? "");
+      if (path.startsWith("/api/v1/resolve?")) {
+        expect(new URL(`https://x.test${path}`).searchParams.get("ownerHandle")).toBe("nvidia");
+      }
+    }
+    expect(mockLog).not.toHaveBeenCalled();
+    expect(mockIntro).not.toHaveBeenCalled();
+    expect(mockOutro).not.toHaveBeenCalled();
+
+    const parsed = JSON.parse(output) as {
+      ok: boolean;
+      dryRun: boolean;
+      owner?: string;
+      summary: { wouldPublish: number; alreadySynced: number; failed: number };
+      wouldPublish: Array<{ slug: string; version: string; status: string }>;
+      alreadySynced: Array<{ slug: string; version: string }>;
+      published: unknown[];
+      failed: unknown[];
+    };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.dryRun).toBe(true);
+    expect(parsed.owner).toBe("nvidia");
+    expect(parsed.summary).toMatchObject({ wouldPublish: 2, alreadySynced: 1, failed: 0 });
+    expect(parsed.wouldPublish.map((entry) => [entry.slug, entry.version, entry.status])).toEqual([
+      ["new-skill", "1.0.0", "new"],
+      ["update-skill", "1.0.1", "update"],
+    ]);
+    expect(parsed.alreadySynced).toEqual([
+      expect.objectContaining({ slug: "synced-skill", version: "1.2.3" }),
+    ]);
+    expect(parsed.published).toEqual([]);
+    expect(parsed.failed).toEqual([]);
+  });
+
+  it("publishes selected skills without reporting install telemetry", async () => {
+    interactive = false;
+    mockApiRequest.mockImplementation(async (_registry: string, args: { path?: string }) => {
+      if (args.path === "/api/v1/whoami") return { user: { handle: "steipete" } };
+      if (args.path?.startsWith("/api/v1/resolve?")) {
+        const u = new URL(`https://x.test${args.path}`);
+        const slug = u.searchParams.get("slug");
+        if (slug === "new-skill") throw new Error("Skill not found");
+        if (slug === "synced-skill") {
+          return { match: { version: "1.2.3" }, latestVersion: { version: "1.2.3" } };
+        }
+        if (slug === "update-skill") {
+          return { match: null, latestVersion: { version: "1.0.0" } };
+        }
+      }
+      throw new Error(`Unexpected apiRequest: ${String(args.path)}`);
+    });
+
+    await cmdSync(makeOpts(), { root: ["/scan"], all: true, dryRun: false }, true);
+
+    expect(mockCmdPublish).toHaveBeenCalledTimes(2);
+    expect(mockCmdPublish.mock.calls.map((call) => (call[2] as { slug: string }).slug)).toEqual([
+      "new-skill",
+      "update-skill",
+    ]);
+    for (const call of mockApiRequest.mock.calls) {
+      const path = String(call[1]?.path ?? "");
+      if (path.startsWith("/api/v1/resolve?")) {
+        expect(new URL(`https://x.test${path}`).searchParams.get("ownerHandle")).toBe("steipete");
+      }
+    }
+    expect(mockCmdPublish.mock.calls.map((call) => (call[2] as { owner: string }).owner)).toEqual([
+      "steipete",
+      "steipete",
+    ]);
+    expect(
+      mockApiRequest.mock.calls.some((call) => call[1]?.path === "/api/cli/telemetry/install"),
+    ).toBe(false);
+  });
+
+  it("owner-qualifies fork provenance from installed origins", async () => {
+    interactive = false;
+    mockReadSkillOrigin.mockImplementation(async (folder?: string) =>
+      folder?.endsWith("/new-skill")
+        ? {
+            version: 1,
+            registry: "https://clawhub.ai",
+            slug: "new-skill",
+            ownerHandle: "openclaw",
+            installedVersion: "1.2.3",
+            installedAt: 1,
+          }
+        : null,
+    );
+    mockApiRequest.mockImplementation(async (_registry: string, args: { path?: string }) => {
+      if (args.path === "/api/v1/whoami") return { user: { handle: "steipete" } };
+      if (args.path?.startsWith("/api/v1/resolve?")) {
+        const u = new URL(`https://x.test${args.path}`);
+        const slug = u.searchParams.get("slug");
+        if (slug === "new-skill") throw new Error("Skill not found");
+        return { match: { version: "1.2.3" }, latestVersion: { version: "1.2.3" } };
+      }
+      throw new Error(`Unexpected apiRequest: ${String(args.path)}`);
+    });
+
+    await cmdSync(makeOpts(), { root: ["/scan"], all: true, dryRun: false }, false);
+
+    expect(mockCmdPublish).toHaveBeenCalledTimes(1);
+    expect(mockCmdPublish.mock.calls[0]?.[2]).toMatchObject({
+      slug: "new-skill",
+      forkOf: "@openclaw/new-skill@1.2.3",
+    });
+  });
+
+  it("resolves relative roots against --workdir and keeps source paths relative", async () => {
+    interactive = false;
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue("/workspace/scan");
+    const { findSkillFolders } = await import("../scanSkills.js");
+    mockApiRequest.mockImplementation(async (_registry: string, args: { path?: string }) => {
+      if (args.path?.startsWith("/api/v1/resolve?")) {
+        const u = new URL(`https://x.test${args.path}`);
+        const slug = u.searchParams.get("slug");
+        if (slug === "synced-skill") {
+          return { match: { version: "1.2.3" }, latestVersion: { version: "1.2.3" } };
+        }
+        throw new Error("Skill not found");
+      }
+      throw new Error(`Unexpected apiRequest: ${String(args.path)}`);
+    });
+
+    try {
+      await cmdSync(
+        makeGlobalOpts("/workspace"),
+        {
+          root: ["scan"],
+          all: true,
+          dryRun: false,
+          sourceRepo: "example/tools",
+          sourceCommit: "1234567890abcdef",
+        },
+        false,
+      );
+    } finally {
+      cwdSpy.mockRestore();
+    }
+
+    expect(findSkillFolders).toHaveBeenCalledWith("/workspace/scan");
+    expect(
+      mockCmdPublish.mock.calls.map((call) => (call[2] as { sourcePath?: string }).sourcePath),
+    ).toEqual(["scan/new-skill", "scan/update-skill"]);
+  });
+
+  it("uses scan-root-relative source paths for skills outside --workdir", async () => {
+    interactive = false;
+    mockApiRequest.mockImplementation(async (_registry: string, args: { path?: string }) => {
+      if (args.path?.startsWith("/api/v1/resolve?")) {
+        const u = new URL(`https://x.test${args.path}`);
+        const slug = u.searchParams.get("slug");
+        if (slug === "synced-skill") {
+          return { match: { version: "1.2.3" }, latestVersion: { version: "1.2.3" } };
+        }
+        throw new Error("Skill not found");
+      }
+      throw new Error(`Unexpected apiRequest: ${String(args.path)}`);
+    });
+
+    await cmdSync(
+      makeGlobalOpts("/workspace"),
+      {
+        root: ["/external/scan"],
+        all: true,
+        dryRun: false,
+        sourceRepo: "example/tools",
+        sourceCommit: "1234567890abcdef",
+      },
+      false,
+    );
+
+    expect(
+      mockCmdPublish.mock.calls.map((call) => (call[2] as { sourcePath?: string }).sourcePath),
+    ).toEqual(["new-skill", "update-skill"]);
+  });
+
+  it("keeps real sync JSON output owned by sync", async () => {
+    interactive = false;
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    mockApiRequest.mockImplementation(async (_registry: string, args: { path?: string }) => {
+      if (args.path?.startsWith("/api/v1/resolve?")) {
+        const u = new URL(`https://x.test${args.path}`);
+        const slug = u.searchParams.get("slug");
+        if (slug === "new-skill") throw new Error("Skill not found");
+        if (slug === "synced-skill") {
+          return { match: { version: "1.2.3" }, latestVersion: { version: "1.2.3" } };
+        }
+        if (slug === "update-skill") {
+          return { match: null, latestVersion: { version: "1.0.0" } };
+        }
+      }
+      throw new Error(`Unexpected apiRequest: ${String(args.path)}`);
+    });
+    mockCmdPublish.mockImplementation((_opts: unknown, _folder: unknown, options?: unknown) => {
+      if (!(options as { quiet?: boolean } | undefined)?.quiet) {
+        process.stdout.write("child publish output\n");
+      }
+      return {
+        version: (options as { version?: string } | undefined)?.version ?? "1.0.0",
+      };
+    });
+
+    let output = "";
+    try {
+      await cmdSync(makeOpts(), { root: ["/scan"], all: true, dryRun: false, json: true }, false);
+      expect(stdoutWrite).toHaveBeenCalledTimes(1);
+      output = String(stdoutWrite.mock.calls[0]?.[0] ?? "");
+    } finally {
+      stdoutWrite.mockRestore();
+    }
+
+    const parsed = JSON.parse(output);
+    expect(parsed).toMatchObject({
+      ok: true,
+      summary: { published: 2, failed: 0 },
+    });
+    expect(mockCmdPublish.mock.calls.map((call) => (call[2] as { quiet?: boolean }).quiet)).toEqual(
+      [true, true],
+    );
+  });
+
+  it("requires --all for non-interactive publish mode", async () => {
+    interactive = false;
+    mockApiRequest.mockImplementation(async (_registry: string, args: { path?: string }) => {
+      if (args.path?.startsWith("/api/v1/resolve?")) {
+        const u = new URL(`https://x.test${args.path}`);
+        const slug = u.searchParams.get("slug");
+        if (slug === "synced-skill") {
+          return { match: { version: "1.2.3" }, latestVersion: { version: "1.2.3" } };
+        }
+        throw new Error("Skill not found");
+      }
+      throw new Error(`Unexpected apiRequest: ${String(args.path)}`);
+    });
+
+    await expect(cmdSync(makeOpts(), { root: ["/scan"], dryRun: false }, false)).rejects.toThrow(
+      "Pass --all",
+    );
+
+    expect(mockMultiselect).not.toHaveBeenCalled();
+    expect(mockCmdPublish).not.toHaveBeenCalled();
+  });
+
+  it("refuses real --all publishes from fallback roots", async () => {
+    interactive = false;
+    const { findSkillFolders, getFallbackSkillRoots } = await import("../scanSkills.js");
+    mocked(findSkillFolders).mockImplementation(async (root: string) => {
+      if (root === "/work" || root === "/work/skills") return [];
+      if (root === "/fallback/skills") {
+        return [
+          {
+            folder: "/fallback/skills/private-skill",
+            slug: "private-skill",
+            displayName: "Private Skill",
+          },
+        ];
+      }
+      return [];
+    });
+    mocked(getFallbackSkillRoots).mockImplementation(() => ["/fallback/skills"]);
+    mockApiRequest.mockImplementation(async (_registry: string, args: { path?: string }) => {
+      if (args.path?.startsWith("/api/v1/resolve?")) throw new Error("Skill not found");
+      throw new Error(`Unexpected apiRequest: ${String(args.path)}`);
+    });
+
+    await expect(cmdSync(makeOpts(), { all: true, dryRun: false }, false)).rejects.toThrow(
+      "Refusing to publish fallback skill roots with --all",
+    );
+
+    expect(mockCmdPublish).not.toHaveBeenCalled();
+    expect(mockPrepareSkillFilesForPublish).not.toHaveBeenCalled();
+    expect(mockApiRequest).not.toHaveBeenCalled();
+  });
+});

--- a/packages/clawhub/src/cli/commands/sync.ts
+++ b/packages/clawhub/src/cli/commands/sync.ts
@@ -1,0 +1,497 @@
+import { isAbsolute, relative } from "node:path";
+import { intro, outro } from "@clack/prompts";
+import { hashSkillFiles, readSkillOrigin } from "../../skills.js";
+import { getOptionalAuthToken, requireAuthToken } from "../authToken.js";
+import { getRegistry } from "../registry.js";
+import { getFallbackSkillRoots } from "../scanSkills.js";
+import type { GlobalOpts } from "../types.js";
+import { createCrabLoader, fail, formatError, isInteractive } from "../ui.js";
+import { normalizeGitHubRepo } from "./github.js";
+import { cmdPublish, prepareSkillFilesForPublish, resolveDefaultOwnerHandle } from "./publish.js";
+import {
+  buildScanRoots,
+  checkRegistrySyncState,
+  dedupeSkillsBySlug,
+  formatActionableLine,
+  formatBulletList,
+  formatCommaList,
+  formatList,
+  formatSyncedDisplay,
+  formatSyncedSummary,
+  mapWithConcurrency,
+  normalizeConcurrency,
+  printSection,
+  resolvePublishMeta,
+  scanRootsWithLabels,
+  selectToUpload,
+} from "./syncHelpers.js";
+import type { Candidate, LocalSkill, SyncOptions } from "./syncTypes.js";
+
+export async function cmdSync(opts: GlobalOpts, options: SyncOptions, inputAllowed: boolean) {
+  const jsonMode = options.json === true;
+  const allowPrompt = !jsonMode && isInteractive() && inputAllowed !== false;
+  if (!jsonMode) intro("ClawHub sync");
+
+  const token = options.dryRun ? await getOptionalAuthToken() : await requireAuthToken();
+  const registry = await getRegistry(opts, { cache: true });
+  const ownerHandle = await resolveSyncOwnerHandle(registry, token, options.owner);
+  const selectedRoots = buildScanRoots(opts, options.root);
+  const concurrency = normalizeConcurrency(options.concurrency);
+
+  const spinner = jsonMode ? null : createCrabLoader("Scanning for local skills");
+  const primaryScan = await scanRootsWithLabels(selectedRoots);
+  let scan = primaryScan;
+  let outputRoots = primaryScan.roots;
+  if (primaryScan.skills.length === 0) {
+    const fallbackScan = await scanRootsWithLabels(getFallbackSkillRoots(opts.workdir));
+    spinner?.stop();
+    scan = fallbackScan;
+    outputRoots = fallbackScan.roots;
+    if (fallbackScan.skills.length === 0) fail("No skills found (checked configured roots)");
+    if (!options.dryRun && options.all) {
+      fail(
+        "Refusing to publish fallback skill roots with --all. Pass --root for the skills to sync.",
+      );
+    }
+    if (!jsonMode) {
+      printSection(
+        `No skills in workdir. Found ${fallbackScan.skills.length} in fallback locations.`,
+        formatList(fallbackScan.rootsWithSkills, 10),
+      );
+    }
+  } else {
+    spinner?.stop();
+    if (!jsonMode && primaryScan.rootsWithSkills.length > 0) {
+      printSection("Roots with skills", formatList(primaryScan.rootsWithSkills, 10));
+    }
+  }
+
+  const deduped = dedupeSkillsBySlug(scan.skills);
+  const skills = deduped.skills;
+  if (!jsonMode && deduped.duplicates.length > 0) {
+    printSection("Skipped duplicate slugs", formatCommaList(deduped.duplicates, 16));
+  }
+
+  const parsingLoader = jsonMode ? null : createCrabLoader("Parsing local skills");
+  const locals: LocalSkill[] = [];
+  try {
+    let done = 0;
+    const parsed = await mapWithConcurrency(skills, Math.min(concurrency, 12), async (skill) => {
+      const filesOnDisk = await prepareSkillFilesForPublish(skill.folder);
+      const hashed = hashSkillFiles(filesOnDisk);
+      const origin = await readSkillOrigin(skill.folder);
+      done += 1;
+      if (parsingLoader) parsingLoader.text = `Parsing local skills ${done}/${skills.length}`;
+      return {
+        ...skill,
+        fingerprint: hashed.fingerprint,
+        fileCount: filesOnDisk.length,
+        origin,
+      };
+    });
+    locals.push(...parsed);
+  } catch (error) {
+    parsingLoader?.fail(formatError(error));
+    throw error;
+  } finally {
+    parsingLoader?.stop();
+  }
+
+  const candidatesLoader = jsonMode ? null : createCrabLoader("Checking registry sync state");
+  const candidates: Candidate[] = [];
+  try {
+    let done = 0;
+    const resolved = await mapWithConcurrency(locals, Math.min(concurrency, 16), async (skill) => {
+      try {
+        return await checkRegistrySyncState(registry, skill, ownerHandle, token);
+      } finally {
+        done += 1;
+        if (candidatesLoader) {
+          candidatesLoader.text = `Checking registry sync state ${done}/${locals.length}`;
+        }
+      }
+    });
+    candidates.push(...resolved);
+  } catch (error) {
+    candidatesLoader?.fail(formatError(error));
+    throw error;
+  } finally {
+    candidatesLoader?.stop();
+  }
+
+  const synced = candidates.filter((candidate) => candidate.status === "synced");
+  const actionable = candidates.filter((candidate) => candidate.status !== "synced");
+  const bump = options.bump ?? "patch";
+
+  if (actionable.length === 0) {
+    writeNoActionOutput({
+      jsonMode,
+      dryRun: Boolean(options.dryRun),
+      registry,
+      roots: outputRoots,
+      owner: ownerHandle,
+      duplicates: deduped.duplicates,
+      synced,
+    });
+    return;
+  }
+
+  if (!jsonMode) {
+    printSection(
+      "To sync",
+      formatBulletList(
+        actionable.map((candidate) => formatActionableLine(candidate, bump)),
+        20,
+      ),
+    );
+  }
+  if (!jsonMode && synced.length > 0) {
+    printSection("Already synced", formatSyncedDisplay(synced));
+  }
+
+  if (!options.dryRun && !options.all && !allowPrompt) {
+    fail("Pass --all to publish every detected local skill without prompting.");
+  }
+
+  const selected = await selectToUpload(actionable, {
+    allowPrompt,
+    all: Boolean(options.all),
+    bump,
+  });
+  if (selected.length === 0) {
+    writeNoActionOutput({
+      jsonMode,
+      dryRun: Boolean(options.dryRun),
+      registry,
+      roots: outputRoots,
+      owner: ownerHandle,
+      duplicates: deduped.duplicates,
+      synced,
+      outroText: "Nothing selected.",
+    });
+    return;
+  }
+
+  const plannedPublishes = selected.map((skill) => {
+    const source = buildSourceProvenance(opts, skill, options, outputRoots);
+    return { skill, source };
+  });
+
+  if (options.dryRun) {
+    const wouldPublish = plannedPublishes.map(({ skill, source }) => {
+      const { publishVersion } = resolvePublishMeta(skill, {
+        bump,
+        changelogFlag: options.changelog,
+      });
+      return formatPublishJson(skill, publishVersion, source);
+    });
+    if (jsonMode) {
+      writeSyncJson(
+        buildSyncJsonOutput({
+          ok: true,
+          dryRun: true,
+          registry,
+          roots: outputRoots,
+          owner: ownerHandle,
+          duplicates: deduped.duplicates,
+          alreadySynced: synced.map(formatSyncedJson),
+          wouldPublish,
+          published: [],
+          failed: [],
+        }),
+      );
+      return;
+    }
+    outro(`Dry run: would publish ${selected.length} skill(s).`);
+    return;
+  }
+
+  const tags = options.tags ?? "latest";
+  const failedUploads: Array<{ slug: string; message: string }> = [];
+  const published: Array<{ slug: string; folder: string; version: string }> = [];
+
+  for (const { skill, source } of plannedPublishes) {
+    const { publishVersion, changelog } = resolvePublishMeta(skill, {
+      bump,
+      changelogFlag: options.changelog,
+    });
+    const forkOf = buildForkOf(skill, registry, ownerHandle);
+    try {
+      const previousExitCode = process.exitCode;
+      const result = await cmdPublish(opts, skill.folder, {
+        slug: skill.slug,
+        name: skill.displayName,
+        owner: ownerHandle,
+        version: publishVersion,
+        changelog,
+        tags,
+        forkOf,
+        quiet: jsonMode,
+        ...(source
+          ? {
+              sourceRepo: options.sourceRepo,
+              sourceCommit: options.sourceCommit,
+              sourceRef: options.sourceRef,
+              sourcePath: source.path,
+            }
+          : {}),
+      });
+      const publishExitCode = process.exitCode;
+      if (isNonZeroExitCode(publishExitCode) && publishExitCode !== previousExitCode) {
+        process.exitCode = previousExitCode;
+        failedUploads.push({
+          slug: skill.slug,
+          message: `Publish command exited with code ${String(publishExitCode)}`,
+        });
+        continue;
+      }
+      published.push({
+        slug: skill.slug,
+        folder: skill.folder,
+        version: result?.version ?? publishVersion,
+      });
+    } catch (error) {
+      failedUploads.push({ slug: skill.slug, message: formatError(error) });
+    }
+  }
+
+  if (failedUploads.length > 0) {
+    if (jsonMode) {
+      writeSyncJson(
+        buildSyncJsonOutput({
+          ok: false,
+          dryRun: false,
+          registry,
+          roots: outputRoots,
+          owner: ownerHandle,
+          duplicates: deduped.duplicates,
+          alreadySynced: synced.map(formatSyncedJson),
+          wouldPublish: [],
+          published,
+          failed: failedUploads,
+        }),
+      );
+      process.exitCode = 1;
+      return;
+    }
+    printSection(
+      "Failed to publish",
+      formatBulletList(
+        failedUploads.map((failure) => `${failure.slug}: ${failure.message}`),
+        20,
+      ),
+    );
+    outro(
+      `Published ${published.length} of ${selected.length} skill(s). ${failedUploads.length} failed.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (jsonMode) {
+    writeSyncJson(
+      buildSyncJsonOutput({
+        ok: true,
+        dryRun: false,
+        registry,
+        roots: outputRoots,
+        owner: ownerHandle,
+        duplicates: deduped.duplicates,
+        alreadySynced: synced.map(formatSyncedJson),
+        wouldPublish: [],
+        published,
+        failed: [],
+      }),
+    );
+    return;
+  }
+
+  outro(`Published ${selected.length} skill(s).`);
+}
+
+function writeNoActionOutput(params: {
+  jsonMode: boolean;
+  dryRun: boolean;
+  registry: string;
+  roots: string[];
+  owner?: string;
+  duplicates: string[];
+  synced: Candidate[];
+  outroText?: string;
+}) {
+  if (params.jsonMode) {
+    writeSyncJson(
+      buildSyncJsonOutput({
+        ok: true,
+        dryRun: params.dryRun,
+        registry: params.registry,
+        roots: params.roots,
+        owner: params.owner,
+        duplicates: params.duplicates,
+        alreadySynced: params.synced.map(formatSyncedJson),
+        wouldPublish: [],
+        published: [],
+        failed: [],
+      }),
+    );
+    return;
+  }
+  if (params.synced.length > 0) {
+    printSection("Already synced", formatCommaList(params.synced.map(formatSyncedSummary), 16));
+  }
+  outro(params.outroText ?? "Nothing to sync.");
+}
+
+function normalizeRegistry(value: string) {
+  return value.trim().replace(/\/+$/, "").toLowerCase();
+}
+
+function buildForkOf(skill: Candidate, registry: string, ownerHandle: string | undefined) {
+  const origin = skill.origin;
+  if (!origin || normalizeRegistry(origin.registry) !== normalizeRegistry(registry))
+    return undefined;
+  const originOwner = normalizeOwner(origin.ownerHandle);
+  const publishOwner = normalizeOwner(ownerHandle);
+  if (origin.slug === skill.slug && originOwner === publishOwner) return undefined;
+  const ref = `${origin.slug}@${origin.installedVersion}`;
+  return originOwner ? `@${originOwner}/${ref}` : ref;
+}
+
+function isNonZeroExitCode(value: string | number | null | undefined) {
+  if (typeof value === "number") return value !== 0;
+  if (typeof value === "string") return value.trim() !== "" && value.trim() !== "0";
+  return false;
+}
+
+function normalizeOwner(value: string | undefined) {
+  return value?.trim().replace(/^@+/, "") || undefined;
+}
+
+async function resolveSyncOwnerHandle(registry: string, token: string | undefined, owner?: string) {
+  const explicitOwner = normalizeOwner(owner);
+  if (explicitOwner || !token) return explicitOwner;
+  return await resolveDefaultOwnerHandle(registry, token);
+}
+
+function formatSyncedJson(candidate: Candidate) {
+  return {
+    slug: candidate.slug,
+    folder: candidate.folder,
+    version: candidate.matchVersion ?? candidate.latestVersion ?? "unknown",
+  };
+}
+
+function formatPublishJson(
+  candidate: Candidate,
+  version: string,
+  source: ReturnType<typeof buildSourceProvenance>,
+) {
+  return {
+    slug: candidate.slug,
+    displayName: candidate.displayName,
+    folder: candidate.folder,
+    status: candidate.status,
+    version,
+    latestVersion: candidate.latestVersion,
+    fileCount: candidate.fileCount,
+    fingerprint: candidate.fingerprint,
+    ...(source ? { source } : {}),
+  };
+}
+
+function buildSourceProvenance(
+  opts: GlobalOpts,
+  skill: Candidate,
+  options: SyncOptions,
+  scanRoots: string[],
+) {
+  const rawRepo = options.sourceRepo?.trim();
+  const commit = options.sourceCommit?.trim();
+  if (!rawRepo && !commit && !options.sourceRef?.trim()) return undefined;
+  if (!rawRepo || !commit) fail("--source-repo and --source-commit must be provided together");
+  const repo = normalizeGitHubRepo(rawRepo);
+  if (!repo) fail("--source-repo must be a GitHub repo or URL");
+  return {
+    kind: "github" as const,
+    url: `https://github.com/${repo}`,
+    repo,
+    ref: options.sourceRef?.trim() || commit,
+    commit,
+    path: sourcePathForSkill(opts, skill.folder, scanRoots),
+  };
+}
+
+function sourcePathForSkill(opts: GlobalOpts, folder: string, scanRoots: string[]) {
+  const bases = Array.from(
+    new Set([opts.workdir, opts.dir, ...scanRoots, process.cwd()].map(normalizeSourcePathBase)),
+  );
+  for (const base of bases) {
+    const rel = relativeInside(base, folder);
+    if (rel) return rel;
+  }
+  fail(
+    "Source provenance requires each skill folder to be inside the current directory, --workdir, configured skills directory, or a --root directory.",
+  );
+  throw new Error("unreachable");
+}
+
+function normalizeSourcePathBase(value: string) {
+  return value.replace(/\/+$/, "") || "/";
+}
+
+function relativeInside(base: string, target: string) {
+  const rel = relative(base, target);
+  if (!rel) return ".";
+  if (rel.startsWith("..") || isAbsolute(rel)) return null;
+  return normalizeSourcePath(rel);
+}
+
+function normalizeSourcePath(value: string) {
+  const normalized = value
+    .replaceAll("\\", "/")
+    .replace(/^\.\/+/, "")
+    .replace(/\/+$/, "");
+  return normalized || ".";
+}
+
+function buildSyncJsonOutput(params: {
+  ok: boolean;
+  dryRun: boolean;
+  registry: string;
+  roots: string[];
+  owner?: string;
+  duplicates: string[];
+  alreadySynced: Array<{ slug: string; folder: string; version: string }>;
+  wouldPublish: Array<ReturnType<typeof formatPublishJson>>;
+  published: Array<{ slug: string; folder: string; version: string }>;
+  failed: Array<{ slug: string; message: string }>;
+}) {
+  const skipped = params.duplicates.map((duplicate) => ({
+    slug: duplicate.replace(/\s+\(\d+\)$/, ""),
+    reason: "duplicate-slug",
+    detail: duplicate,
+  }));
+  return {
+    ok: params.ok,
+    dryRun: params.dryRun,
+    registry: params.registry,
+    roots: params.roots,
+    ...(params.owner ? { owner: params.owner } : {}),
+    summary: {
+      wouldPublish: params.wouldPublish.length,
+      published: params.published.length,
+      alreadySynced: params.alreadySynced.length,
+      skipped: skipped.length,
+      failed: params.failed.length,
+    },
+    wouldPublish: params.wouldPublish,
+    published: params.published,
+    alreadySynced: params.alreadySynced,
+    skipped,
+    failed: params.failed,
+  };
+}
+
+function writeSyncJson(value: unknown) {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}

--- a/packages/clawhub/src/cli/commands/syncHelpers.ts
+++ b/packages/clawhub/src/cli/commands/syncHelpers.ts
@@ -1,0 +1,260 @@
+import { realpath } from "node:fs/promises";
+import { isAbsolute, resolve } from "node:path";
+import { isCancel, multiselect } from "@clack/prompts";
+import semver from "semver";
+import { resolveHome } from "../../homedir.js";
+import { apiRequest } from "../../http.js";
+import { ApiRoutes, ApiV1SkillResolveResponseSchema } from "../../schema/index.js";
+import { findSkillFolders, type SkillFolder } from "../scanSkills.js";
+import type { GlobalOpts } from "../types.js";
+import { fail, formatError } from "../ui.js";
+import type { Candidate, LocalSkill } from "./syncTypes.js";
+
+export function buildScanRoots(opts: GlobalOpts, extraRoots: string[] | undefined) {
+  const roots = [opts.workdir, opts.dir, ...(extraRoots ?? [])];
+  return Array.from(new Set(roots.map((root) => resolveScanRoot(opts, root))));
+}
+
+function resolveScanRoot(opts: GlobalOpts, root: string) {
+  return isAbsolute(root) ? resolve(root) : resolve(opts.workdir, root);
+}
+
+export function normalizeConcurrency(value: number | undefined) {
+  const raw = typeof value === "number" ? value : 4;
+  const rounded = Number.isFinite(raw) ? Math.round(raw) : 4;
+  return Math.min(32, Math.max(1, rounded));
+}
+
+export async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+) {
+  const results = Array.from({ length: items.length }) as R[];
+  let nextIndex = 0;
+  const workerCount = Math.min(Math.max(1, limit), items.length || 1);
+
+  async function worker() {
+    while (true) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= items.length) return;
+      results[index] = await fn(items[index] as T);
+    }
+  }
+
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}
+
+export async function checkRegistrySyncState(
+  registry: string,
+  skill: LocalSkill,
+  ownerHandle?: string,
+  token?: string,
+): Promise<Candidate> {
+  try {
+    const params = new URLSearchParams({
+      slug: skill.slug,
+      hash: skill.fingerprint,
+    });
+    if (ownerHandle) params.set("ownerHandle", ownerHandle);
+    const resolved = await apiRequest(
+      registry,
+      {
+        method: "GET",
+        path: `${ApiRoutes.resolve}?${params.toString()}`,
+        token,
+      },
+      ApiV1SkillResolveResponseSchema,
+    );
+    const latestVersion = resolved.latestVersion?.version ?? null;
+    const matchVersion = resolved.match?.version ?? null;
+    if (!latestVersion) {
+      return { ...skill, status: "new", matchVersion: null, latestVersion: null };
+    }
+    return {
+      ...skill,
+      status: matchVersion ? "synced" : "update",
+      matchVersion,
+      latestVersion,
+    };
+  } catch (error) {
+    const message = formatError(error);
+    if (/skill not found/i.test(message) || /HTTP 404/i.test(message)) {
+      return { ...skill, status: "new", matchVersion: null, latestVersion: null };
+    }
+    throw error;
+  }
+}
+
+export async function scanRootsWithLabels(roots: string[]) {
+  const all: SkillFolder[] = [];
+  const rootsWithSkills: string[] = [];
+  const uniqueRoots = await dedupeRoots(roots);
+  const skillsByRoot: Record<string, SkillFolder[]> = {};
+  for (const root of uniqueRoots) {
+    const found = await findSkillFolders(root);
+    skillsByRoot[root] = found;
+    if (found.length > 0) rootsWithSkills.push(root);
+    all.push(...found);
+  }
+  const byFolder = new Map<string, SkillFolder>();
+  for (const folder of all) {
+    byFolder.set(folder.folder, folder);
+  }
+  return {
+    roots: uniqueRoots,
+    skillsByRoot,
+    skills: Array.from(byFolder.values()),
+    rootsWithSkills,
+  };
+}
+
+async function dedupeRoots(roots: string[]) {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const root of roots) {
+    const resolved = resolve(root);
+    const canonical = await realpath(resolved).catch(() => null);
+    const key = canonical ?? resolved;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(key);
+  }
+  return unique;
+}
+
+export async function selectToUpload(
+  candidates: Candidate[],
+  params: { allowPrompt: boolean; all: boolean; bump: "patch" | "minor" | "major" },
+): Promise<Candidate[]> {
+  if (params.all || !params.allowPrompt) return candidates;
+
+  const valueByKey = new Map<string, Candidate>();
+  const choices = candidates.map((candidate) => {
+    const key = candidate.folder;
+    valueByKey.set(key, candidate);
+    return {
+      value: key,
+      label: `${candidate.slug}  ${formatActionableStatus(candidate, params.bump)}`,
+      hint: `${abbreviatePath(candidate.folder)} | ${candidate.fileCount} files`,
+    };
+  });
+
+  const picked = await multiselect({
+    message: "Select skills to publish",
+    options: choices,
+    initialValues: choices.map((choice) => choice.value),
+    required: false,
+  });
+  if (isCancel(picked)) fail("Canceled");
+  return picked.map((key) => valueByKey.get(key)).filter(Boolean) as Candidate[];
+}
+
+export function resolvePublishMeta(
+  skill: Candidate,
+  params: { bump: "patch" | "minor" | "major"; changelogFlag?: string },
+) {
+  if (skill.status === "new") {
+    return { publishVersion: "1.0.0", changelog: "" };
+  }
+
+  const latest = skill.latestVersion;
+  if (!latest) fail(`Could not resolve latest version for ${skill.slug}`);
+  const publishVersion = semver.inc(latest, params.bump);
+  if (!publishVersion) fail(`Could not bump version for ${skill.slug}`);
+
+  const fromFlag = params.changelogFlag?.trim();
+  return { publishVersion, changelog: fromFlag ?? "" };
+}
+
+export function formatList(values: string[], max: number) {
+  if (values.length === 0) return "";
+  const shown = values.map(abbreviatePath);
+  if (shown.length <= max) return shown.join("\n");
+  const head = shown.slice(0, Math.max(1, max - 1));
+  const rest = values.length - head.length;
+  return [...head, `... +${rest} more`].join("\n");
+}
+
+export function printSection(title: string, body?: string) {
+  const trimmed = body?.trim();
+  if (!trimmed) {
+    console.log(title);
+    return;
+  }
+  if (trimmed.includes("\n")) {
+    console.log(`\n${title}\n${trimmed}`);
+    return;
+  }
+  console.log(`${title}: ${trimmed}`);
+}
+
+function abbreviatePath(value: string) {
+  const home = resolveHome();
+  if (value.startsWith(home)) return `~${value.slice(home.length)}`;
+  return value;
+}
+
+export function dedupeSkillsBySlug(skills: SkillFolder[]) {
+  const bySlug = new Map<string, SkillFolder[]>();
+  for (const skill of skills) {
+    const existing = bySlug.get(skill.slug);
+    if (existing) existing.push(skill);
+    else bySlug.set(skill.slug, [skill]);
+  }
+  const unique: SkillFolder[] = [];
+  const duplicates: string[] = [];
+  for (const [slug, entries] of bySlug.entries()) {
+    unique.push(entries[0] as SkillFolder);
+    if (entries.length > 1) duplicates.push(`${slug} (${entries.length})`);
+  }
+  return { skills: unique, duplicates };
+}
+
+function formatActionableStatus(candidate: Candidate, bump: "patch" | "minor" | "major"): string {
+  if (candidate.status === "new") return "NEW (publish 1.0.0)";
+  const latest = candidate.latestVersion;
+  const next = latest ? semver.inc(latest, bump) : null;
+  if (latest && next) return `LOCAL CHANGES latest ${latest}; publish ${next}`;
+  return "LOCAL CHANGES";
+}
+
+export function formatActionableLine(
+  candidate: Candidate,
+  bump: "patch" | "minor" | "major",
+): string {
+  return `${candidate.slug}  ${formatActionableStatus(candidate, bump)}  (${candidate.fileCount} files)`;
+}
+
+function formatSyncedLine(candidate: Candidate): string {
+  const version = candidate.matchVersion ?? candidate.latestVersion ?? "unknown";
+  return `${candidate.slug}  synced (${version})`;
+}
+
+export function formatSyncedSummary(candidate: Candidate): string {
+  const version = candidate.matchVersion ?? candidate.latestVersion;
+  return version ? `${candidate.slug}@${version}` : candidate.slug;
+}
+
+export function formatBulletList(lines: string[], max: number): string {
+  if (lines.length <= max) return lines.map((line) => `- ${line}`).join("\n");
+  const head = lines.slice(0, max);
+  const rest = lines.length - head.length;
+  return [...head, `... +${rest} more`].map((line) => `- ${line}`).join("\n");
+}
+
+export function formatSyncedDisplay(synced: Candidate[]) {
+  const lines = synced.map(formatSyncedLine);
+  if (lines.length <= 12) return formatBulletList(lines, 12);
+  return formatCommaList(synced.map(formatSyncedSummary), 24);
+}
+
+export function formatCommaList(values: string[], max: number) {
+  if (values.length === 0) return "";
+  if (values.length <= max) return values.join(", ");
+  const head = values.slice(0, Math.max(1, max - 1));
+  const rest = values.length - head.length;
+  return `${head.join(", ")}, ... +${rest} more`;
+}

--- a/packages/clawhub/src/cli/commands/syncTypes.ts
+++ b/packages/clawhub/src/cli/commands/syncTypes.ts
@@ -1,0 +1,29 @@
+import type { SkillOrigin } from "../../skills.js";
+import type { SkillFolder } from "../scanSkills.js";
+
+export type SyncOptions = {
+  root?: string[];
+  all?: boolean;
+  dryRun?: boolean;
+  json?: boolean;
+  owner?: string;
+  bump?: "patch" | "minor" | "major";
+  changelog?: string;
+  tags?: string;
+  concurrency?: number;
+  sourceRepo?: string;
+  sourceCommit?: string;
+  sourceRef?: string;
+};
+
+export type LocalSkill = SkillFolder & {
+  fingerprint: string;
+  fileCount: number;
+  origin: SkillOrigin | null;
+};
+
+export type Candidate = LocalSkill & {
+  status: "synced" | "new" | "update";
+  matchVersion: string | null;
+  latestVersion: string | null;
+};

--- a/packages/clawhub/src/cli/scanSkills.ts
+++ b/packages/clawhub/src/cli/scanSkills.ts
@@ -1,0 +1,65 @@
+import { readdir, stat } from "node:fs/promises";
+import { basename, join, resolve } from "node:path";
+import { resolveHome } from "../homedir.js";
+import { sanitizeSlug, titleCase } from "./slug.js";
+
+export type SkillFolder = {
+  folder: string;
+  slug: string;
+  displayName: string;
+};
+
+export async function findSkillFolders(root: string): Promise<SkillFolder[]> {
+  const absRoot = resolve(root);
+  const rootStat = await stat(absRoot).catch(() => null);
+  if (!rootStat || !rootStat.isDirectory()) return [];
+
+  const direct = await isSkillFolder(absRoot);
+  if (direct) return [direct];
+
+  const entries = await readdir(absRoot, { withFileTypes: true }).catch(() => []);
+  const folders = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(absRoot, entry.name));
+  const results: SkillFolder[] = [];
+  for (const folder of folders) {
+    const found = await isSkillFolder(folder);
+    if (found) results.push(found);
+  }
+  return results.sort((a, b) => a.slug.localeCompare(b.slug));
+}
+
+export function getFallbackSkillRoots(workdir: string) {
+  const home = resolveHome();
+  const roots = [
+    resolve(workdir, "..", "openclaw", "skills"),
+    resolve(workdir, "..", "openclaw", "Skills"),
+    resolve(home, ".openclaw", "skills"),
+    resolve(home, ".openclaw", "Skills"),
+    resolve(home, "openclaw", "skills"),
+    resolve(home, "openclaw", "Skills"),
+    resolve(home, "Library", "Application Support", "openclaw", "skills"),
+    resolve(home, "Library", "Application Support", "openclaw", "Skills"),
+  ];
+  return Array.from(new Set(roots));
+}
+
+async function isSkillFolder(folder: string): Promise<SkillFolder | null> {
+  const marker = await findSkillMarker(folder);
+  if (!marker) return null;
+  const base = basename(folder);
+  const slug = sanitizeSlug(base);
+  if (!slug) return null;
+  const displayName = titleCase(base);
+  return { folder, slug, displayName };
+}
+
+async function findSkillMarker(folder: string) {
+  const candidates = ["SKILL.md", "skill.md"];
+  for (const name of candidates) {
+    const path = join(folder, name);
+    const st = await stat(path).catch(() => null);
+    if (st?.isFile()) return path;
+  }
+  return null;
+}

--- a/packages/clawhub/test-artifact/cli.artifact.test.ts
+++ b/packages/clawhub/test-artifact/cli.artifact.test.ts
@@ -330,7 +330,7 @@ describe("built CLI artifact", () => {
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toContain("Usage: clawhub");
-    expect(result.stdout).not.toContain("sync");
+    expect(result.stdout).toContain("sync");
   });
 
   it("prints help for bare logged-in invocations", async () => {
@@ -349,11 +349,56 @@ describe("built CLI artifact", () => {
     expect(requests).toHaveLength(0);
   });
 
-  it("does not expose the removed sync command", async () => {
-    const result = runNode([binPath, "sync"]);
+  it("exposes the restored sync command", async () => {
+    const result = runNode([binPath, "sync", "--help"]);
 
-    expect(result.status).toBe(1);
-    expect(result.stderr).toContain("error: unknown command 'sync'");
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("Scan local skills and publish new or changed ones");
+    expect(result.stdout).toContain("--dry-run");
+    expect(result.stdout).toContain("--json");
+  });
+
+  it("plans sync publishes without install telemetry", async () => {
+    const { registry, requests } = await startLocalRegistry();
+    const workdir = await makeTmpDir("clawhub-artifact-sync-");
+    const root = join(workdir, "skills");
+    await mkdir(join(root, "new-skill"), { recursive: true });
+    await mkdir(join(root, "changed-skill"), { recursive: true });
+    await mkdir(join(root, "synced-skill"), { recursive: true });
+    await writeFile(join(root, "new-skill", "SKILL.md"), "# New\n", "utf8");
+    await writeFile(join(root, "changed-skill", "SKILL.md"), "# Changed\n", "utf8");
+    await writeFile(join(root, "synced-skill", "SKILL.md"), "# Synced\n", "utf8");
+
+    const result = await runNodeAsync([
+      binPath,
+      "--workdir",
+      workdir,
+      "--registry",
+      registry,
+      "--no-input",
+      "sync",
+      "--root",
+      root,
+      "--all",
+      "--dry-run",
+      "--json",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    const parsed = JSON.parse(result.stdout) as {
+      ok: boolean;
+      summary: { wouldPublish: number; alreadySynced: number };
+      wouldPublish: Array<{ slug: string; version: string; status: string }>;
+    };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.summary).toMatchObject({ wouldPublish: 2, alreadySynced: 1 });
+    expect(parsed.wouldPublish.map((entry) => [entry.slug, entry.version, entry.status])).toEqual([
+      ["changed-skill", "1.2.4", "update"],
+      ["new-skill", "1.0.0", "new"],
+    ]);
+    expect(requests.map((request) => request.path)).not.toContain("/api/cli/telemetry/install");
   });
 
   it("reports unknown top-level commands clearly", async () => {

--- a/scripts/security-dataset/export-snapshot.ts
+++ b/scripts/security-dataset/export-snapshot.ts
@@ -1,17 +1,24 @@
 import { execFile, spawnSync } from "node:child_process";
 import { once } from "node:events";
 import { createWriteStream, type WriteStream } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readdir, stat, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { gunzipSync } from "node:zlib";
+import { ConvexHttpClient } from "convex/browser";
+import { api } from "../../convex/_generated/api";
 import { artifactInputsFromConvexExportZip } from "./convexExport";
 import { parseConvexJsonMatching } from "./convexOutput";
 import { reserveExportInputs } from "./exportLimit";
+import {
+  buildHuggingFaceSecuritySignalRows,
+  type HuggingFaceSecuritySignalRow,
+} from "./huggingFaceExport";
 import { buildSecurityDatasetManifest } from "./manifest";
 import {
   normalizeArtifactExport,
   type ArtifactExportInput,
+  type DatasetSplit,
   type NormalizedDatasetRows,
   type SourceKind,
 } from "./normalize";
@@ -38,6 +45,14 @@ type ConvexBounds = {
   maxCreatedAt: number | null;
 };
 
+type DatasetLineage = {
+  exportMode: "public";
+  generatedAt: number;
+  redactionPolicyVersion: string;
+  sourceTables: string[];
+  sourceBounds: ConvexBounds[];
+};
+
 type CompressedConvexPage = {
   encoding: "gzip-base64-json";
   payload: string;
@@ -45,6 +60,8 @@ type CompressedConvexPage = {
 
 type Options = {
   deployment: string | null;
+  convexUrl: string | null;
+  workerToken: string | null;
   prod: boolean;
   push: boolean;
   dryRun: boolean;
@@ -58,6 +75,10 @@ type Options = {
   sourceKind: SourceKind | "all";
   timeWindow: CreatedTimeWindow;
   convexExportZip: string | null;
+  sourceSnapshotId: string | null;
+  huggingFaceDataset: boolean;
+  huggingFaceRepo: string;
+  huggingFaceRevision: string;
 };
 
 type ExportShard = {
@@ -76,7 +97,9 @@ type SnapshotState = {
     clawScanFindings: number;
     labels: number;
     splits: number;
+    huggingFaceRows: number;
   };
+  huggingFaceRowCountsBySplit: Record<DatasetSplit, number>;
   scannerVersions: Set<string>;
   modelNames: Set<string>;
 };
@@ -88,6 +111,7 @@ type SnapshotWriters = {
   clawScanFindings: WriteStream;
   labels: WriteStream;
   splits: WriteStream;
+  huggingFaceSplits?: Record<DatasetSplit, WriteStream>;
 };
 
 const DEFAULT_PAGE_SIZE = 50;
@@ -98,12 +122,13 @@ const DEFAULT_MAX_CONVEX_ATTEMPTS = 6;
 const DEFAULT_OUT_DIR = ".data/security-dataset/snapshots";
 const CONVEX_RUN_MAX_BUFFER_BYTES = 128 * 1024 * 1024;
 const SOURCE_KINDS: SourceKind[] = ["skill", "package"];
+const HF_SPLITS: DatasetSplit[] = ["train", "validation", "test", "eval_holdout"];
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const snapshotId = buildSnapshotId(options);
   const snapshotDir = resolve(options.outDir, snapshotId);
-  const writers = options.dryRun ? null : await openSnapshotWriters(snapshotDir);
+  const writers = options.dryRun ? null : await openSnapshotWriters(snapshotDir, options);
   let writersClosed = false;
   const state = createSnapshotState();
 
@@ -111,9 +136,15 @@ async function main() {
     const shardCount = options.convexExportZip
       ? await exportConvexExportZip({ options, state, writers })
       : await exportRemoteShards({ options, state, writers });
-    const manifest = buildManifest({ options, snapshotId, state, shardCount });
 
     if (options.dryRun) {
+      const manifest = buildManifest({
+        options,
+        snapshotId,
+        state,
+        shardCount,
+        outputSizes: {},
+      });
       console.log(JSON.stringify({ snapshotId, dryRun: true, manifest }, null, 2));
       return;
     }
@@ -121,6 +152,8 @@ async function main() {
     if (!writers) throw new Error("Snapshot writers were not opened.");
     await closeSnapshotWriters(writers);
     writersClosed = true;
+    const outputSizes = await collectOutputSizes(snapshotDir);
+    const manifest = buildManifest({ options, snapshotId, state, shardCount, outputSizes });
     await writeFile(join(snapshotDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
 
     console.log(JSON.stringify({ snapshotId, snapshotDir, manifest }, null, 2));
@@ -231,6 +264,7 @@ async function runConvexPage(
   batchPages: number,
 ): Promise<{ page: ConvexPage; batchPages: number }> {
   const functionName = "securityDatasetNode:listArtifactExportBatchCompressedInternal";
+  const workerFunctionName = "securityDatasetNode:listArtifactExportBatchCompressed";
   let pageCount = batchPages;
 
   while (true) {
@@ -246,12 +280,19 @@ async function runConvexPage(
     let lastError: unknown = null;
     for (let attempt = 1; attempt <= DEFAULT_MAX_CONVEX_ATTEMPTS; attempt += 1) {
       try {
-        const compressed = await runConvexJsonOnce<CompressedConvexPage>(
-          options,
-          functionName,
-          args,
-          isCompressedConvexPage,
-        );
+        const compressed = options.workerToken
+          ? await runWorkerAction<CompressedConvexPage>(
+              options,
+              workerFunctionName,
+              { ...args, token: options.workerToken },
+              isCompressedConvexPage,
+            )
+          : await runConvexJsonOnce<CompressedConvexPage>(
+              options,
+              functionName,
+              args,
+              isCompressedConvexPage,
+            );
         return { page: decodeCompressedConvexPage(compressed), batchPages: pageCount };
       } catch (error) {
         lastError = error;
@@ -279,12 +320,50 @@ async function runConvexPage(
 }
 
 async function runConvexBounds(options: Options, sourceKind: SourceKind): Promise<ConvexBounds> {
+  if (options.workerToken) {
+    const lineage = await runWorkerAction<DatasetLineage>(
+      options,
+      "securityDatasetNode:getDatasetLineage",
+      { token: options.workerToken, mode: options.mode },
+      isDatasetLineage,
+    );
+    const bounds = lineage.sourceBounds.find((candidate) => candidate.sourceKind === sourceKind);
+    if (!bounds) {
+      return { sourceKind, minCreatedAt: null, maxCreatedAt: null };
+    }
+    return bounds;
+  }
   return runConvexJson<ConvexBounds>(
     options,
     "securityDataset:getArtifactExportBoundsInternal",
     { sourceKind },
     isConvexBounds,
   );
+}
+
+async function runWorkerAction<T>(
+  options: Options,
+  functionName: string,
+  args: unknown,
+  validate: (value: unknown) => value is T,
+): Promise<T> {
+  if (!options.convexUrl) {
+    throw new Error("--convex-url or CONVEX_URL is required when using --worker-token.");
+  }
+  const client = new ConvexHttpClient(options.convexUrl);
+  const result = await client.action(resolveWorkerAction(functionName), args as never);
+  if (validate(result)) return result;
+  throw new Error(`Invalid ${functionName} response.`);
+}
+
+function resolveWorkerAction(functionName: string) {
+  if (functionName === "securityDatasetNode:listArtifactExportBatchCompressed") {
+    return api.securityDatasetNode.listArtifactExportBatchCompressed;
+  }
+  if (functionName === "securityDatasetNode:getDatasetLineage") {
+    return api.securityDatasetNode.getDatasetLineage;
+  }
+  throw new Error(`Unsupported worker action: ${functionName}`);
 }
 
 async function runConvexJson<T>(
@@ -352,14 +431,19 @@ function buildManifest(input: {
   snapshotId: string;
   state: SnapshotState;
   shardCount: number;
+  outputSizes: Record<string, number>;
 }) {
-  const { options, snapshotId, state, shardCount } = input;
+  const { options, snapshotId, state, shardCount, outputSizes } = input;
   const repoGitSha = gitSha();
   return buildSecurityDatasetManifest({
     snapshotId,
+    sourceSnapshotId: options.sourceSnapshotId ?? snapshotId,
     createdAt: new Date().toISOString(),
     repoGitSha,
-    convexDeployment: options.deployment ?? (options.prod ? "prod" : "configured-dev"),
+    convexDeployment:
+      options.deployment ??
+      inferDeploymentFromConvexUrl(options.convexUrl) ??
+      (options.prod ? "prod" : "configured-dev"),
     exportMode: options.mode,
     pageSize: options.pageSize,
     concurrency: options.concurrency,
@@ -373,13 +457,34 @@ function buildManifest(input: {
       clawScanFindings: state.rowCounts.clawScanFindings,
       labels: state.rowCounts.labels,
       splits: state.rowCounts.splits,
+      huggingFaceRows: state.rowCounts.huggingFaceRows,
     },
+    outputSizes,
     scannerVersions: Array.from(state.scannerVersions).sort(),
     modelNames: Array.from(state.modelNames).sort(),
     redactionPolicyVersion: "public-signals-v2-bundle-files",
     sourceTables: ["skillVersions", "packageReleases"],
     timeWindow: options.timeWindow,
+    huggingFaceDataset: options.huggingFaceDataset
+      ? {
+          repo: options.huggingFaceRepo,
+          revision: options.huggingFaceRevision,
+          commit: null,
+          configNames: ["default"],
+          splitNames: HF_SPLITS,
+          rowCountsBySplit: state.huggingFaceRowCountsBySplit,
+        }
+      : undefined,
   });
+}
+
+function inferDeploymentFromConvexUrl(convexUrl: string | null) {
+  if (!convexUrl) return null;
+  try {
+    return new URL(convexUrl).hostname.split(".")[0] || null;
+  } catch {
+    return null;
+  }
 }
 
 function buildSnapshotId(options: Options) {
@@ -388,7 +493,9 @@ function buildSnapshotId(options: Options) {
     .replace(/[-:]/g, "")
     .replace(/\.\d{3}Z$/, "Z");
   const deployment =
-    options.deployment?.replace(/[^a-zA-Z0-9]+/g, "-") ?? (options.prod ? "prod" : "dev");
+    options.deployment?.replace(/[^a-zA-Z0-9]+/g, "-") ??
+    inferDeploymentFromConvexUrl(options.convexUrl)?.replace(/[^a-zA-Z0-9]+/g, "-") ??
+    (options.prod ? "prod" : "dev");
   return `clawhub-${deployment}-${timestamp}-${gitSha().slice(0, 8)}`;
 }
 
@@ -402,6 +509,13 @@ function createSnapshotState(): SnapshotState {
       clawScanFindings: 0,
       labels: 0,
       splits: 0,
+      huggingFaceRows: 0,
+    },
+    huggingFaceRowCountsBySplit: {
+      train: 0,
+      validation: 0,
+      test: 0,
+      eval_holdout: 0,
     },
     scannerVersions: new Set(),
     modelNames: new Set(),
@@ -415,12 +529,17 @@ async function processArtifactInputs(input: {
 }) {
   const { inputs, state, writers } = input;
   const rows = normalizeArtifactExport(inputs);
+  const hfRows = buildHuggingFaceSecuritySignalRows(rows);
   state.rowCounts.artifacts += rows.artifacts.length;
   state.rowCounts.scanResults += rows.scanResults.length;
   state.rowCounts.staticFindings += rows.staticFindings.length;
   state.rowCounts.clawScanFindings += rows.clawScanFindings.length;
   state.rowCounts.labels += rows.labels.length;
   state.rowCounts.splits += rows.splits.length;
+  state.rowCounts.huggingFaceRows += hfRows.length;
+  for (const row of hfRows) {
+    state.huggingFaceRowCountsBySplit[row.split] += 1;
+  }
   for (const row of rows.scanResults) {
     if (row.scanner_version) state.scannerVersions.add(row.scanner_version);
     if (row.model) state.modelNames.add(row.model);
@@ -428,11 +547,17 @@ async function processArtifactInputs(input: {
 
   if (!writers) return;
   await writeNormalizedRows(writers, rows);
+  if (writers.huggingFaceSplits) {
+    await writeHuggingFaceRows(writers.huggingFaceSplits, hfRows);
+  }
 }
 
-async function openSnapshotWriters(snapshotDir: string): Promise<SnapshotWriters> {
+async function openSnapshotWriters(
+  snapshotDir: string,
+  options: Options,
+): Promise<SnapshotWriters> {
   await mkdir(snapshotDir, { recursive: true });
-  return {
+  const writers: SnapshotWriters = {
     artifacts: createWriteStream(join(snapshotDir, "artifacts.jsonl"), { encoding: "utf8" }),
     scanResults: createWriteStream(join(snapshotDir, "scan_results.jsonl"), { encoding: "utf8" }),
     staticFindings: createWriteStream(join(snapshotDir, "static_findings.jsonl"), {
@@ -444,10 +569,30 @@ async function openSnapshotWriters(snapshotDir: string): Promise<SnapshotWriters
     labels: createWriteStream(join(snapshotDir, "labels.jsonl"), { encoding: "utf8" }),
     splits: createWriteStream(join(snapshotDir, "splits.jsonl"), { encoding: "utf8" }),
   };
+  if (options.huggingFaceDataset) {
+    const dataDir = join(snapshotDir, "hf-dataset", "data");
+    await mkdir(dataDir, { recursive: true });
+    writers.huggingFaceSplits = {
+      train: createWriteStream(join(dataDir, "train.jsonl"), { encoding: "utf8" }),
+      validation: createWriteStream(join(dataDir, "validation.jsonl"), { encoding: "utf8" }),
+      test: createWriteStream(join(dataDir, "test.jsonl"), { encoding: "utf8" }),
+      eval_holdout: createWriteStream(join(dataDir, "eval_holdout.jsonl"), { encoding: "utf8" }),
+    };
+  }
+  return writers;
 }
 
 async function closeSnapshotWriters(writers: SnapshotWriters) {
-  await Promise.all(Object.values(writers).map((stream) => endStream(stream)));
+  const streams = [
+    writers.artifacts,
+    writers.scanResults,
+    writers.staticFindings,
+    writers.clawScanFindings,
+    writers.labels,
+    writers.splits,
+    ...Object.values(writers.huggingFaceSplits ?? {}),
+  ];
+  await Promise.all(streams.map((stream) => endStream(stream)));
 }
 
 async function endStream(stream: WriteStream) {
@@ -468,6 +613,37 @@ async function writeJsonlRows(stream: WriteStream, rows: unknown[]) {
   if (rows.length === 0) return;
   const chunk = `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`;
   if (!stream.write(chunk)) await once(stream, "drain");
+}
+
+async function writeHuggingFaceRows(
+  streams: Record<DatasetSplit, WriteStream>,
+  rows: HuggingFaceSecuritySignalRow[],
+) {
+  for (const split of HF_SPLITS) {
+    await writeJsonlRows(
+      streams[split],
+      rows.filter((row) => row.split === split),
+    );
+  }
+}
+
+async function collectOutputSizes(root: string) {
+  const sizes: Record<string, number> = {};
+  await collectOutputSizesInto(root, root, sizes);
+  return sizes;
+}
+
+async function collectOutputSizesInto(root: string, dir: string, sizes: Record<string, number>) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await collectOutputSizesInto(root, path, sizes);
+    } else if (entry.isFile()) {
+      const relativePath = path.slice(root.length + 1);
+      sizes[relativePath] = (await stat(path)).size;
+    }
+  }
 }
 
 function boundsToShards(bounds: ConvexBounds, shardCount: number): ExportShard[] {
@@ -547,6 +723,18 @@ function isCompressedConvexPage(value: unknown): value is CompressedConvexPage {
   );
 }
 
+function isDatasetLineage(value: unknown): value is DatasetLineage {
+  return (
+    isRecord(value) &&
+    value.exportMode === "public" &&
+    typeof value.generatedAt === "number" &&
+    typeof value.redactionPolicyVersion === "string" &&
+    Array.isArray(value.sourceTables) &&
+    Array.isArray(value.sourceBounds) &&
+    value.sourceBounds.every(isConvexBounds)
+  );
+}
+
 function decodeCompressedConvexPage(value: CompressedConvexPage) {
   const json = gunzipSync(Buffer.from(value.payload, "base64")).toString("utf8");
   const parsed: unknown = JSON.parse(json);
@@ -588,6 +776,8 @@ function gitSha() {
 function parseArgs(args: string[]): Options {
   const options: Options = {
     deployment: null,
+    convexUrl: null,
+    workerToken: null,
     prod: false,
     push: false,
     dryRun: false,
@@ -601,6 +791,10 @@ function parseArgs(args: string[]): Options {
     sourceKind: "all",
     timeWindow: emptyCreatedTimeWindow(),
     convexExportZip: null,
+    sourceSnapshotId: null,
+    huggingFaceDataset: false,
+    huggingFaceRepo: process.env.HF_DATASET_REPO ?? "OpenClaw/clawhub-security-signals",
+    huggingFaceRevision: process.env.HF_REVISION ?? "main",
   };
 
   for (let index = 0; index < args.length; index += 1) {
@@ -613,6 +807,10 @@ function parseArgs(args: string[]): Options {
       options.dryRun = true;
     } else if (arg === "--deployment") {
       options.deployment = readValue(args, ++index, arg);
+    } else if (arg === "--convex-url") {
+      options.convexUrl = readValue(args, ++index, arg);
+    } else if (arg === "--worker-token") {
+      options.workerToken = readValue(args, ++index, arg);
     } else if (arg === "--limit") {
       options.limit = readPositiveInt(readValue(args, ++index, arg), arg);
     } else if (arg === "--page-size") {
@@ -633,6 +831,14 @@ function parseArgs(args: string[]): Options {
       options.timeWindow.createdAtLt = parseCreatedTimestamp(readValue(args, ++index, arg), arg);
     } else if (arg === "--convex-export-zip" || arg === "--from-convex-export") {
       options.convexExportZip = readValue(args, ++index, arg);
+    } else if (arg === "--source-snapshot-id") {
+      options.sourceSnapshotId = readValue(args, ++index, arg);
+    } else if (arg === "--hf-dataset") {
+      options.huggingFaceDataset = true;
+    } else if (arg === "--hf-repo") {
+      options.huggingFaceRepo = readValue(args, ++index, arg);
+    } else if (arg === "--hf-revision") {
+      options.huggingFaceRevision = readValue(args, ++index, arg);
     } else if (arg === "--mode") {
       const mode = readValue(args, ++index, arg);
       if (mode !== "public") throw new Error(`Unsupported mode: ${mode}`);
@@ -644,6 +850,9 @@ function parseArgs(args: string[]): Options {
 
   if (options.prod && options.deployment) {
     throw new Error("Use either --prod or --deployment, not both.");
+  }
+  if (options.workerToken && (options.prod || options.deployment || options.push)) {
+    throw new Error("Use --worker-token with --convex-url instead of --prod/--deployment/--push.");
   }
   assertCreatedTimeWindow(options.timeWindow);
   return options;

--- a/scripts/security-dataset/exportSnapshotCli.test.ts
+++ b/scripts/security-dataset/exportSnapshotCli.test.ts
@@ -1,0 +1,151 @@
+/* @vitest-environment node */
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { strToU8, zipSync } from "fflate";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+describe("security dataset snapshot CLI", () => {
+  it("writes flat Hugging Face split files from a tiny sanitized Convex export", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "clawhub-security-dataset-cli-"));
+    try {
+      const snapshotZip = join(directory, "snapshot.zip");
+      const outDir = join(directory, "out");
+      await writeFile(snapshotZip, Buffer.from(buildTinyConvexSnapshotZip()));
+
+      const result = await execFileAsync(
+        "bun",
+        [
+          "scripts/security-dataset/export-snapshot.ts",
+          "--convex-export-zip",
+          snapshotZip,
+          "--source-snapshot-id",
+          "live-export-prod-123-1",
+          "--out-dir",
+          outDir,
+          "--hf-dataset",
+        ],
+        {
+          cwd: process.cwd(),
+          encoding: "utf8",
+          maxBuffer: 16 * 1024 * 1024,
+        },
+      );
+      const summary: {
+        snapshotDir: string;
+        manifest: {
+          source_snapshot_id: string;
+          row_counts: { huggingface_rows: number };
+          huggingface_dataset: { repo: string; rowCountsBySplit: Record<string, number> };
+        };
+      } = JSON.parse(result.stdout);
+
+      expect(summary.manifest.source_snapshot_id).toBe("live-export-prod-123-1");
+      expect(summary.manifest.row_counts.huggingface_rows).toBe(1);
+      expect(summary.manifest.huggingface_dataset.repo).toBe("OpenClaw/clawhub-security-signals");
+      const dataDir = join(summary.snapshotDir, "hf-dataset", "data");
+      const files = await readdir(dataDir);
+      expect(files.sort()).toEqual([
+        "eval_holdout.jsonl",
+        "test.jsonl",
+        "train.jsonl",
+        "validation.jsonl",
+      ]);
+
+      const splitContents = await Promise.all(
+        files.map(async (file) => readFile(join(dataDir, file), "utf8")),
+      );
+      const flatRows = splitContents
+        .join("")
+        .split(/\r?\n/)
+        .filter((line) => line.length > 0)
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+      expect(flatRows).toEqual([
+        expect.objectContaining({
+          id: "a".repeat(64),
+          skill_slug: "owner/stored-skill",
+          skill_version: "1.0.0",
+          skill_md_content: "Stored SKILL.md [REDACTED_SECRET]",
+          skill_bundle_content: [
+            expect.objectContaining({
+              path: "scripts/run.sh",
+              content: "echo [REDACTED_SECRET]\n",
+            }),
+          ],
+        }),
+      ]);
+      const serializedRows = JSON.stringify(flatRows);
+      expect(serializedRows).not.toContain("storageId");
+      expect(serializedRows).not.toContain("skillVersions:1");
+      expect(serializedRows).not.toContain("supersecret123");
+      expect(serializedRows).not.toContain("scriptsecret123");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});
+
+function buildTinyConvexSnapshotZip() {
+  return zipSync({
+    "skills/documents.jsonl": strToU8(
+      `${JSON.stringify({
+        _id: "skills:1",
+        displayName: "Stored Skill",
+        slug: "stored-skill",
+        ownerUserId: "users:owner",
+      })}\n`,
+    ),
+    "skillVersions/documents.jsonl": strToU8(
+      `${JSON.stringify({
+        _id: "skillVersions:1",
+        skillId: "skills:1",
+        version: "1.0.0",
+        createdAt: Date.UTC(2026, 5, 23),
+        sha256hash: "a".repeat(64),
+        files: [
+          {
+            path: "SKILL.md",
+            size: 31,
+            sha256: "skill-md-sha",
+            content: "Stored SKILL.md token=supersecret123",
+            contentType: "text/markdown",
+          },
+          {
+            path: "scripts/run.sh",
+            size: 35,
+            sha256: "script-sha",
+            content: "echo password=scriptsecret123\n",
+            contentType: "text/x-shellscript",
+          },
+        ],
+        staticScan: {
+          status: "clean",
+          reasonCodes: [],
+          findings: [],
+          summary: "No suspicious patterns detected.",
+          engineVersion: "static-v1",
+          checkedAt: Date.UTC(2026, 5, 23),
+        },
+        llmAnalysis: {
+          status: "completed",
+          verdict: "suspicious",
+          confidence: "medium",
+          summary: "Review before trusting.",
+          agenticRiskFindings: [],
+          model: "gpt-test",
+          checkedAt: Date.UTC(2026, 5, 23),
+        },
+      })}\n`,
+    ),
+    "packages/documents.jsonl": strToU8(""),
+    "packageReleases/documents.jsonl": strToU8(""),
+    "users/documents.jsonl": strToU8(
+      `${JSON.stringify({ _id: "users:owner", handle: "owner" })}\n`,
+    ),
+  });
+}

--- a/scripts/security-dataset/huggingFaceExport.test.ts
+++ b/scripts/security-dataset/huggingFaceExport.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import { buildHuggingFaceSecuritySignalRows } from "./huggingFaceExport";
+import { hashString, type NormalizedDatasetRows } from "./normalize";
+
+describe("Hugging Face security dataset export", () => {
+  it("builds flat researcher rows from normalized security dataset sidecars", () => {
+    const artifactId = `skill:${"a".repeat(64)}`;
+    const normalized: NormalizedDatasetRows = {
+      artifacts: [
+        {
+          artifact_id: artifactId,
+          source_kind: "skill",
+          source_table: "skillVersions",
+          source_doc_id_hash: hashString("skillVersions:1"),
+          parent_doc_id_hash: hashString("skills:1"),
+          public_name: "Demo Skill",
+          public_owner_handle: "openclaw",
+          public_slug: "demo-skill",
+          public_qualified_slug: "openclaw/demo-skill",
+          version: "1.0.0",
+          artifact_sha256: "a".repeat(64),
+          skill_md_content_redacted: "Use this skill with [REDACTED_SECRET]",
+          bundle_files_redacted: [
+            {
+              path: "scripts/run.sh",
+              content: "echo [REDACTED_SECRET]\n",
+              sha256: "bundle-content-sha",
+              size_bytes: 23,
+            },
+          ],
+          created_at: Date.UTC(2026, 5, 23),
+          created_month: "2026-06",
+          soft_deleted: false,
+          is_public: true,
+          file_count: 2,
+          total_bytes: 42,
+          file_ext_counts: { ".md": 1, ".sh": 1 },
+          package_family: null,
+          package_channel: null,
+          source_repo_host: null,
+          has_vt_scan: true,
+          has_skillspector_scan: true,
+          has_static_scan: true,
+          has_llm_scan: true,
+        },
+      ],
+      scanResults: [
+        {
+          artifact_id: artifactId,
+          scanner: "static",
+          scanner_version: "static-v1",
+          model: null,
+          status: "clean",
+          verdict: "clean",
+          confidence: null,
+          checked_at: Date.UTC(2026, 5, 23),
+          reason_codes: [],
+          engine_stats: null,
+          summary_redacted: "No suspicious patterns detected.",
+          raw_status_family: "clean",
+        },
+        {
+          artifact_id: artifactId,
+          scanner: "virustotal",
+          scanner_version: "vt-v3",
+          model: null,
+          status: "clean",
+          verdict: "clean",
+          confidence: null,
+          checked_at: Date.UTC(2026, 5, 23),
+          reason_codes: [],
+          engine_stats: { malicious: 0, suspicious: 0, harmless: 1, undetected: 65 },
+          summary_redacted: null,
+          raw_status_family: "clean",
+        },
+        {
+          artifact_id: artifactId,
+          scanner: "skillspector",
+          scanner_version: "2.0.0",
+          model: null,
+          status: "suspicious",
+          verdict: "CAUTION",
+          confidence: null,
+          checked_at: Date.UTC(2026, 5, 23),
+          score: 35,
+          severity: "MEDIUM",
+          reason_codes: ["SQP-1"],
+          issues: [
+            {
+              code: "SQP-1",
+              category: "Skill Quality",
+              severity: "MEDIUM",
+              confidence: 0.9,
+              explanation_redacted: "Broad trigger scope.",
+            },
+          ],
+          engine_stats: null,
+          summary_redacted: "Found broad trigger scope.",
+          raw_status_family: "suspicious",
+        },
+        {
+          artifact_id: artifactId,
+          scanner: "llm",
+          scanner_version: null,
+          model: "gpt-test",
+          status: "completed",
+          verdict: "suspicious",
+          confidence: "medium",
+          checked_at: Date.UTC(2026, 5, 23),
+          reason_codes: [],
+          engine_stats: null,
+          summary_redacted: "Review before trusting.",
+          raw_status_family: "suspicious",
+        },
+      ],
+      staticFindings: [
+        {
+          artifact_id: artifactId,
+          finding_id: "finding-1",
+          code: "suspicious.env_credential_access",
+          severity: "warn",
+          file_path_hash: hashString("scripts/run.sh"),
+          file_ext: ".sh",
+          line_bucket: "1-20",
+          message: "Reads credentials",
+          evidence_redacted: "[REDACTED_SECRET]",
+        },
+      ],
+      clawScanFindings: [],
+      labels: [
+        {
+          artifact_id: artifactId,
+          label: "suspicious",
+          label_source: "moderation_consensus",
+          label_confidence: "derived_consensus",
+          reason_codes: ["suspicious.env_credential_access"],
+          scanner_agreement: 1,
+          notes_redacted: null,
+        },
+      ],
+      splits: [
+        {
+          artifact_id: artifactId,
+          split: "train",
+          split_version: "sha256-v1",
+          split_key: hashString("a".repeat(64)),
+        },
+      ],
+    };
+
+    expect(buildHuggingFaceSecuritySignalRows(normalized)).toEqual([
+      expect.objectContaining({
+        id: "a".repeat(64),
+        skill_slug: "openclaw/demo-skill",
+        skill_version: "1.0.0",
+        skill_md_content: "Use this skill with [REDACTED_SECRET]",
+        skill_bundle_content: [
+          {
+            path: "scripts/run.sh",
+            content: "echo [REDACTED_SECRET]\n",
+            sha256: "bundle-content-sha",
+            sizeBytes: 23,
+          },
+        ],
+        clawscan_verdict: "suspicious",
+        clawscan_confidence: "medium",
+        clawscan_model: "gpt-test",
+        static_status: "clean",
+        static_finding_count: 1,
+        virustotal_malicious_count: 0,
+        skillspector_issue_categories: ["Skill Quality"],
+        split: "train",
+      }),
+    ]);
+  });
+});

--- a/scripts/security-dataset/huggingFaceExport.ts
+++ b/scripts/security-dataset/huggingFaceExport.ts
@@ -1,0 +1,197 @@
+import {
+  hashString,
+  type ArtifactRow,
+  type DatasetSplit,
+  type LabelRow,
+  type NormalizedDatasetRows,
+  type ScanResultRow,
+  type StaticFindingRow,
+} from "./normalize";
+
+export type HuggingFaceSecuritySignalRow = {
+  id: string;
+  skill_slug: string | null;
+  skill_version: string;
+  skill_md_content: string | null;
+  skill_bundle_content: Array<{
+    path: string;
+    content: string;
+    sha256: string;
+    sizeBytes: number;
+  }>;
+  clawscan_verdict: string;
+  clawscan_confidence: string | null;
+  clawscan_model: string | null;
+  clawscan_summary: string | null;
+  static_status: string | null;
+  static_finding_count: number;
+  static_reason_codes: string[];
+  virustotal_status: string | null;
+  virustotal_malicious_count: number | null;
+  virustotal_suspicious_count: number | null;
+  virustotal_harmless_count: number | null;
+  virustotal_undetected_count: number | null;
+  skillspector_status: string | null;
+  skillspector_score: number | null;
+  skillspector_severity: string | null;
+  skillspector_issue_count: number;
+  skillspector_issue_codes: string[];
+  skillspector_issue_categories: string[];
+  clawscan_context: Record<string, unknown>;
+  split: DatasetSplit;
+};
+
+export function buildHuggingFaceSecuritySignalRows(
+  rows: NormalizedDatasetRows,
+): HuggingFaceSecuritySignalRow[] {
+  const scansByArtifact = groupBy(rows.scanResults, (row) => row.artifact_id);
+  const labelsByArtifact = groupBy(rows.labels, (row) => row.artifact_id);
+  const staticFindingsByArtifact = groupBy(rows.staticFindings, (row) => row.artifact_id);
+  const splitByArtifact = new Map(rows.splits.map((row) => [row.artifact_id, row.split]));
+
+  return rows.artifacts.flatMap((artifact) => {
+    if (artifact.source_kind !== "skill" || !artifact.is_public || artifact.soft_deleted) {
+      return [];
+    }
+    const scans = scansByArtifact.get(artifact.artifact_id) ?? [];
+    const labels = labelsByArtifact.get(artifact.artifact_id) ?? [];
+    const staticFindings = staticFindingsByArtifact.get(artifact.artifact_id) ?? [];
+    const split = splitByArtifact.get(artifact.artifact_id);
+    if (!split) return [];
+
+    const staticScan = scanByName(scans, "static");
+    const vtScan = scanByName(scans, "virustotal");
+    const skillSpectorScan = scanByName(scans, "skillspector");
+    const llmScan = scanByName(scans, "llm");
+    const verdict = labelBySource(labels, "moderation_consensus")?.label ?? "unknown";
+
+    return [
+      {
+        id: flatArtifactId(artifact),
+        skill_slug: artifact.public_qualified_slug ?? artifact.public_slug,
+        skill_version: artifact.version,
+        skill_md_content: artifact.skill_md_content_redacted ?? null,
+        skill_bundle_content: (artifact.bundle_files_redacted ?? []).map((file) => ({
+          path: file.path,
+          content: file.content,
+          sha256: file.sha256,
+          sizeBytes: file.size_bytes,
+        })),
+        clawscan_verdict: verdict,
+        clawscan_confidence: llmScan?.confidence ?? null,
+        clawscan_model: llmScan?.model ?? null,
+        clawscan_summary: llmScan?.summary_redacted ?? null,
+        static_status: staticScan?.status ?? null,
+        static_finding_count: staticFindings.length,
+        static_reason_codes: staticScan?.reason_codes ?? [],
+        virustotal_status: vtScan?.status ?? null,
+        virustotal_malicious_count: vtScan?.engine_stats?.malicious ?? null,
+        virustotal_suspicious_count: vtScan?.engine_stats?.suspicious ?? null,
+        virustotal_harmless_count: vtScan?.engine_stats?.harmless ?? null,
+        virustotal_undetected_count: vtScan?.engine_stats?.undetected ?? null,
+        skillspector_status: skillSpectorScan?.status ?? null,
+        skillspector_score: skillSpectorScan?.score ?? null,
+        skillspector_severity: skillSpectorScan?.severity ?? null,
+        skillspector_issue_count: skillSpectorScan?.issues?.length ?? 0,
+        skillspector_issue_codes: skillSpectorScan?.reason_codes ?? [],
+        skillspector_issue_categories: uniqueSorted(
+          (skillSpectorScan?.issues ?? []).flatMap((issue) =>
+            issue.category ? [issue.category] : [],
+          ),
+        ),
+        clawscan_context: buildClawScanContext({
+          staticScan,
+          vtScan,
+          skillSpectorScan,
+          staticFindings,
+        }),
+        split,
+      },
+    ];
+  });
+}
+
+function buildClawScanContext(input: {
+  staticScan: ScanResultRow | undefined;
+  vtScan: ScanResultRow | undefined;
+  skillSpectorScan: ScanResultRow | undefined;
+  staticFindings: StaticFindingRow[];
+}) {
+  const context: Record<string, unknown> = {};
+  const { staticScan, vtScan, skillSpectorScan, staticFindings } = input;
+  if (staticScan) {
+    context.static = {
+      status: staticScan.status,
+      verdict: staticScan.verdict,
+      reason_codes: staticScan.reason_codes,
+      summary: staticScan.summary_redacted,
+      checked_at: isoTime(staticScan.checked_at),
+      scanner_version: staticScan.scanner_version,
+      finding_count: staticFindings.length,
+    };
+  }
+  if (vtScan) {
+    context.virustotal = {
+      status: vtScan.status,
+      verdict: vtScan.verdict,
+      checked_at: isoTime(vtScan.checked_at),
+      scanner_version: vtScan.scanner_version,
+      engine_stats: vtScan.engine_stats,
+    };
+  }
+  if (skillSpectorScan) {
+    context.skillspector = {
+      status: skillSpectorScan.status,
+      verdict: skillSpectorScan.verdict,
+      checked_at: isoTime(skillSpectorScan.checked_at),
+      scanner_version: skillSpectorScan.scanner_version,
+      issue_codes: skillSpectorScan.reason_codes,
+      score: skillSpectorScan.score ?? null,
+      severity: skillSpectorScan.severity ?? null,
+      issue_count: skillSpectorScan.issues?.length ?? 0,
+      issues: (skillSpectorScan.issues ?? []).map((issue) => ({
+        code: issue.code,
+        category: issue.category,
+        severity: issue.severity,
+        confidence: issue.confidence,
+        explanation: issue.explanation_redacted,
+      })),
+    };
+  }
+  return context;
+}
+
+function flatArtifactId(artifact: ArtifactRow) {
+  if (artifact.artifact_sha256) return artifact.artifact_sha256;
+  return hashString(artifact.artifact_id);
+}
+
+function scanByName(scans: ScanResultRow[], scanner: ScanResultRow["scanner"]) {
+  return scans.find((row) => row.scanner === scanner);
+}
+
+function labelBySource(labels: LabelRow[], source: LabelRow["label_source"]) {
+  return labels.find((row) => row.label_source === source);
+}
+
+function groupBy<T>(items: T[], getKey: (item: T) => string) {
+  const map = new Map<string, T[]>();
+  for (const item of items) {
+    const key = getKey(item);
+    const group = map.get(key);
+    if (group) {
+      group.push(item);
+    } else {
+      map.set(key, [item]);
+    }
+  }
+  return map;
+}
+
+function uniqueSorted(values: string[]) {
+  return Array.from(new Set(values)).sort((left, right) => left.localeCompare(right));
+}
+
+function isoTime(value: number | null) {
+  return value === null ? null : new Date(value).toISOString();
+}

--- a/scripts/security-dataset/manifest.ts
+++ b/scripts/security-dataset/manifest.ts
@@ -1,5 +1,6 @@
 export type SnapshotManifestInput = {
   snapshotId: string;
+  sourceSnapshotId?: string | null;
   createdAt: string;
   repoGitSha: string;
   convexDeployment: string;
@@ -16,7 +17,9 @@ export type SnapshotManifestInput = {
     clawScanFindings: number;
     labels: number;
     splits: number;
+    huggingFaceRows?: number;
   };
+  outputSizes?: Record<string, number>;
   scannerVersions: string[];
   modelNames: string[];
   redactionPolicyVersion: string;
@@ -25,11 +28,20 @@ export type SnapshotManifestInput = {
     createdAtGte: number | null;
     createdAtLt: number | null;
   };
+  huggingFaceDataset?: {
+    repo: string;
+    revision: string;
+    commit: string | null;
+    configNames: string[];
+    splitNames: string[];
+    rowCountsBySplit: Record<string, number>;
+  };
 };
 
 export function buildSecurityDatasetManifest(input: SnapshotManifestInput) {
   return {
     snapshot_id: input.snapshotId,
+    source_snapshot_id: input.sourceSnapshotId ?? input.snapshotId,
     created_at: input.createdAt,
     repo_git_sha: input.repoGitSha,
     convex_deployment: input.convexDeployment,
@@ -47,7 +59,9 @@ export function buildSecurityDatasetManifest(input: SnapshotManifestInput) {
       clawscan_findings: input.rowCounts.clawScanFindings,
       labels: input.rowCounts.labels,
       splits: input.rowCounts.splits,
+      huggingface_rows: input.rowCounts.huggingFaceRows ?? 0,
     },
+    output_sizes: input.outputSizes ?? {},
     scanner_versions: input.scannerVersions,
     model_names: input.modelNames,
     redaction_policy_version: input.redactionPolicyVersion,
@@ -57,6 +71,7 @@ export function buildSecurityDatasetManifest(input: SnapshotManifestInput) {
       created_at_gte: input.timeWindow?.createdAtGte ?? null,
       created_at_lt: input.timeWindow?.createdAtLt ?? null,
     },
+    huggingface_dataset: input.huggingFaceDataset ?? null,
   };
 }
 


### PR DESCRIPTION
## Summary
- add token-gated live Convex security dataset export actions for sanitized pages and lineage
- extend the snapshot CLI to write normalized sidecars plus flat Hugging Face split JSONL and manifest metadata
- add a nightly/manual Blacksmith workflow that exports via the worker token and uploads to Hugging Face with OIDC

## Validation
- bunx vitest run convex/securityDatasetNode.test.ts scripts/security-dataset/huggingFaceExport.test.ts scripts/security-dataset/exportSnapshotCli.test.ts scripts/security-dataset/manifest.test.ts
- bunx tsc --noEmit --pretty false
- node -e "const fs=require('fs'); const YAML=require('yaml'); YAML.parse(fs.readFileSync('.github/workflows/security-dataset-snapshot.yml','utf8')); console.log('yaml ok')"
- manual tiny Convex export fixture: 1 source artifact, 1 HF row, all four split files, guardrail=true for no raw storage ids/internal ids/fixture secrets
- bun run ci:static
- bun run ci:unit
- .agents/skills/autoreview/scripts/autoreview --mode local
