### PR TITLE
Fix security dataset workflow dispatch

### DIFF
--- a/.github/workflows/security-dataset-snapshot.yml
+++ b/.github/workflows/security-dataset-snapshot.yml
@@ -41,11 +41,11 @@ jobs:
       SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}
       HF_DATASET_REPO: OpenClaw/clawhub-security-signals
       HF_OIDC_RESOURCE: datasets/OpenClaw/clawhub-security-signals
-      HF_REVISION: ${{ inputs.hf-revision || 'main' }}
+      HF_REVISION: ${{ inputs['hf-revision'] || 'main' }}
       HF_UPLOAD: ${{ github.event_name == 'schedule' || inputs.upload == 'true' }}
       SNAPSHOT_LIMIT: ${{ inputs.limit || '' }}
-      SANITIZED_OUT_DIR: ${{ runner.temp }}/clawhub-security-dataset/sanitized
-      WORK_DIR: ${{ runner.temp }}/clawhub-security-dataset
+      SANITIZED_OUT_DIR: /tmp/clawhub-security-dataset/sanitized
+      WORK_DIR: /tmp/clawhub-security-dataset
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- replace invalid job-level `${{ runner.temp }}` expressions in the security dataset workflow with stable temp paths
- use bracket notation for the hyphenated `hf-revision` input

## Proof
- Live dispatch failure before fix: GitHub rejected `security-dataset-snapshot.yml` with `Unrecognized named-value: 'runner'` at the job-level env lines.
- Local validation after fix:
  ```bash
  node -e "const fs=require('fs'); const YAML=require('yaml'); YAML.parse(fs.readFileSync('.github/workflows/security-dataset-snapshot.yml','utf8')); console.log('yaml ok')"
  actionlint .github/workflows/security-dataset-snapshot.yml
  git diff --check
  bun run format:check -- .github/workflows/security-dataset-snapshot.yml
  ```
  Result: all passed (`yaml ok`; actionlint/diff check exited 0; format check reported all matched files use correct format).
