### PR TITLE
fix: harden script CSP

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -48,7 +48,6 @@ const config = {
               "src/__tests__/**/*.{ts,tsx}!",
               "convex/**/*.test.{ts,tsx}!",
               "emails/**/*.test.{ts,tsx}!",
-              "scripts/**/*.test.{ts,mjs,js}!",
               "server/**/*.test.{ts,tsx}!",
             ]
           : []),

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -34,6 +34,7 @@ const config = {
     ".": {
       entry: [
         "src/router.tsx!",
+        "src/server.ts!",
         "src/routes/**/*.{ts,tsx}!",
         "src/styles.css!",
         "server/**/*.{ts,tsx}!",

--- a/scripts/vercel-security-headers.test.mjs
+++ b/scripts/vercel-security-headers.test.mjs
@@ -1,0 +1,125 @@
+/* @vitest-environment node */
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  createContentSecurityPolicy,
+  isLocalDevelopmentRequestUrl,
+} from "../src/lib/securityHeaders";
+import {
+  createThemeModeCookie,
+  getThemeModeFromCookieHeader,
+  THEME_MODE_COOKIE,
+} from "../src/lib/themeCookie";
+
+const repoRoot = resolve(import.meta.dirname, "..");
+const bootstrapPath = resolve(repoRoot, "public/theme-bootstrap.js");
+
+function getGlobalVercelHeaders() {
+  const vercelConfig = JSON.parse(readFileSync(resolve(repoRoot, "vercel.json"), "utf8"));
+  return vercelConfig.headers.find((entry) => entry.source === "/(.*)")?.headers ?? [];
+}
+
+function getCspHeader() {
+  return createContentSecurityPolicy("test-nonce");
+}
+
+function getLocalDevelopmentCspHeader() {
+  return createContentSecurityPolicy("test-nonce", { allowLocalDevelopment: true });
+}
+
+function getDirective(csp, name) {
+  return (
+    csp
+      .split(";")
+      .map((directive) => directive.trim())
+      .find((directive) => directive.startsWith(`${name} `)) ?? ""
+  );
+}
+
+function getDirectiveTokens(csp, name) {
+  return getDirective(csp, name).split(/\s+/u);
+}
+
+describe("Vercel security headers", () => {
+  it("does not allow all inline scripts in the global CSP", () => {
+    expect(getDirectiveTokens(getCspHeader(), "script-src")).not.toContain("'unsafe-inline'");
+  });
+
+  it("allows nonce-tagged framework scripts", () => {
+    expect(getDirectiveTokens(getCspHeader(), "script-src")).toEqual([
+      "script-src",
+      "'self'",
+      "'nonce-test-nonce'",
+      "'unsafe-eval'",
+    ]);
+  });
+
+  it("documents the current eval allowance without reopening inline script execution", () => {
+    const scriptTokens = getDirectiveTokens(getCspHeader(), "script-src");
+
+    expect(scriptTokens).toContain("'unsafe-eval'");
+    expect(scriptTokens).not.toContain("'unsafe-inline'");
+  });
+
+  it("does not emit a second static Vercel CSP that would block dynamic nonces", () => {
+    expect(
+      getGlobalVercelHeaders().some((header) => header.key === "Content-Security-Policy"),
+    ).toBe(false);
+  });
+
+  it("keeps local Convex HTTP and WebSocket connections usable in local development", () => {
+    const csp = getLocalDevelopmentCspHeader();
+    const connectTokens = getDirectiveTokens(csp, "connect-src");
+
+    expect(connectTokens).toEqual(["connect-src", "'self'", "https:", "wss:", "http:", "ws:"]);
+    expect(csp).not.toContain("[::1]");
+    expect(csp).not.toContain("upgrade-insecure-requests");
+  });
+
+  it("keeps local docs auth form posts usable only in local development", () => {
+    expect(getDirectiveTokens(getCspHeader(), "form-action")).toEqual([
+      "form-action",
+      "'self'",
+      "https://clawhub.ai",
+      "https://documentation.openclaw.ai",
+      "https://docs.openclaw.ai",
+    ]);
+
+    expect(getDirectiveTokens(getLocalDevelopmentCspHeader(), "form-action")).toEqual([
+      "form-action",
+      "'self'",
+      "https://clawhub.ai",
+      "https://documentation.openclaw.ai",
+      "https://docs.openclaw.ai",
+      "http://localhost:*",
+      "http://127.0.0.1:*",
+    ]);
+  });
+
+  it("detects IPv4, IPv6, and localhost app origins as local development", () => {
+    expect(isLocalDevelopmentRequestUrl("http://localhost:3000/")).toBe(true);
+    expect(isLocalDevelopmentRequestUrl("http://127.0.0.1:3000/")).toBe(true);
+    expect(isLocalDevelopmentRequestUrl("http://[::1]:3000/")).toBe(true);
+    expect(isLocalDevelopmentRequestUrl("https://clawhub.ai/")).toBe(false);
+  });
+
+  it("does not load a theme bootstrap script", () => {
+    const rootRoute = readFileSync(resolve(repoRoot, "src/routes/__root.tsx"), "utf8");
+
+    expect(rootRoute).not.toContain("ScriptOnce");
+    expect(rootRoute).not.toContain("themeBootstrapScript");
+    expect(rootRoute).not.toContain('src="/theme-bootstrap.js');
+    expect(rootRoute).not.toContain("dangerouslySetInnerHTML");
+    expect(existsSync(bootstrapPath)).toBe(false);
+  });
+
+  it("normalizes the SSR theme cookie to supported modes", () => {
+    expect(getThemeModeFromCookieHeader(`${THEME_MODE_COOKIE}=dark`)).toBe("dark");
+    expect(getThemeModeFromCookieHeader(`${THEME_MODE_COOKIE}=light`)).toBe("light");
+    expect(getThemeModeFromCookieHeader(`${THEME_MODE_COOKIE}=system`)).toBe("system");
+    expect(getThemeModeFromCookieHeader(`${THEME_MODE_COOKIE}=custom`)).toBe("system");
+    expect(createThemeModeCookie("dark")).toContain(`${THEME_MODE_COOKIE}=dark`);
+  });
+});

--- a/specs/auth-identity.md
+++ b/specs/auth-identity.md
@@ -66,7 +66,15 @@ Permitted destinations (`src/lib/docsAuth.ts`):
   current app origin, not to a runtime env flag, so a public staging, preview,
   or misconfigured deployment can never POST the token to a localhost listener.
 
-The deployed Content-Security-Policy `form-action` (`vercel.json`) must stay
-aligned with this allowlist: it lists `'self'` plus the cross-origin docs hosts
-and must not include loopback origins in production. The CSP is the browser-side
-backstop if the application allowlist ever regresses.
+The deployed Content-Security-Policy `form-action`
+(`src/lib/securityHeaders.ts`) must stay aligned with this allowlist: it lists
+`'self'` plus the cross-origin docs hosts and must not include loopback origins
+in production. The CSP is the browser-side backstop if the application allowlist
+ever regresses.
+
+The production script CSP is emitted per request by the TanStack Start server
+entry so framework/runtime inline scripts can be nonce-tagged without reopening
+global inline execution. Do not reintroduce a static global Vercel CSP with
+script `'unsafe-inline'`. First-paint theme state is represented with a
+server-readable preference cookie plus CSS media queries, not a pre-hydration
+theme bootstrap script.

--- a/src/lib/openClawExtensionSlugs.ts
+++ b/src/lib/openClawExtensionSlugs.ts
@@ -1,5 +1,1 @@
-export {
-  getOpenClawExtensionPackageName,
-  getOpenClawPackageCandidateNames,
-  OPENCLAW_EXTENSION_SLUG_TO_PACKAGE,
-} from "clawhub-schema";
+export { getOpenClawExtensionPackageName, getOpenClawPackageCandidateNames } from "clawhub-schema";

--- a/src/lib/securityHeaders.test.ts
+++ b/src/lib/securityHeaders.test.ts
@@ -1,24 +1,26 @@
 /* @vitest-environment node */
 
 import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import {
-  createContentSecurityPolicy,
-  isLocalDevelopmentRequestUrl,
-} from "../src/lib/securityHeaders";
+import { createContentSecurityPolicy, isLocalDevelopmentRequestUrl } from "./securityHeaders";
 import {
   createThemeModeCookie,
   getThemeModeFromCookieHeader,
   THEME_MODE_COOKIE,
-} from "../src/lib/themeCookie";
+} from "./themeCookie";
 
-const repoRoot = resolve(import.meta.dirname, "..");
+const libDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(libDir, "../..");
 const bootstrapPath = resolve(repoRoot, "public/theme-bootstrap.js");
 
 function getGlobalVercelHeaders() {
   const vercelConfig = JSON.parse(readFileSync(resolve(repoRoot, "vercel.json"), "utf8"));
-  return vercelConfig.headers.find((entry) => entry.source === "/(.*)")?.headers ?? [];
+  return (
+    vercelConfig.headers.find((entry: { source?: string }) => entry.source === "/(.*)")?.headers ??
+    []
+  );
 }
 
 function getCspHeader() {
@@ -29,7 +31,7 @@ function getLocalDevelopmentCspHeader() {
   return createContentSecurityPolicy("test-nonce", { allowLocalDevelopment: true });
 }
 
-function getDirective(csp, name) {
+function getDirective(csp: string, name: string) {
   return (
     csp
       .split(";")
@@ -38,16 +40,12 @@ function getDirective(csp, name) {
   );
 }
 
-function getDirectiveTokens(csp, name) {
+function getDirectiveTokens(csp: string, name: string) {
   return getDirective(csp, name).split(/\s+/u);
 }
 
-describe("Vercel security headers", () => {
-  it("does not allow all inline scripts in the global CSP", () => {
-    expect(getDirectiveTokens(getCspHeader(), "script-src")).not.toContain("'unsafe-inline'");
-  });
-
-  it("allows nonce-tagged framework scripts", () => {
+describe("security headers", () => {
+  it("blocks arbitrary inline scripts while allowing nonce-tagged framework scripts", () => {
     expect(getDirectiveTokens(getCspHeader(), "script-src")).toEqual([
       "script-src",
       "'self'",
@@ -65,7 +63,9 @@ describe("Vercel security headers", () => {
 
   it("does not emit a second static Vercel CSP that would block dynamic nonces", () => {
     expect(
-      getGlobalVercelHeaders().some((header) => header.key === "Content-Security-Policy"),
+      getGlobalVercelHeaders().some(
+        (header: { key?: string }) => header.key === "Content-Security-Policy",
+      ),
     ).toBe(false);
   });
 
@@ -105,11 +105,9 @@ describe("Vercel security headers", () => {
     expect(isLocalDevelopmentRequestUrl("https://clawhub.ai/")).toBe(false);
   });
 
-  it("does not load a theme bootstrap script", () => {
+  it("does not bypass nonce CSP with a root-level theme bootstrap", () => {
     const rootRoute = readFileSync(resolve(repoRoot, "src/routes/__root.tsx"), "utf8");
 
-    expect(rootRoute).not.toContain("ScriptOnce");
-    expect(rootRoute).not.toContain("themeBootstrapScript");
     expect(rootRoute).not.toContain('src="/theme-bootstrap.js');
     expect(rootRoute).not.toContain("dangerouslySetInnerHTML");
     expect(existsSync(bootstrapPath)).toBe(false);

--- a/src/lib/securityHeaders.ts
+++ b/src/lib/securityHeaders.ts
@@ -1,0 +1,57 @@
+const CSP_FORM_ACTION_ORIGINS = [
+  "'self'",
+  "https://clawhub.ai",
+  "https://documentation.openclaw.ai",
+  "https://docs.openclaw.ai",
+];
+
+const LOCAL_DEVELOPMENT_CONNECT_SOURCES = [
+  // Browser CSP parsers reject bracketed IPv6 host sources like http://[::1]:*.
+  "http:",
+  "ws:",
+];
+
+const LOCAL_DEVELOPMENT_FORM_ACTION_ORIGINS = ["http://localhost:*", "http://127.0.0.1:*"];
+
+type ContentSecurityPolicyOptions = {
+  allowLocalDevelopment?: boolean;
+};
+
+export function isLocalDevelopmentRequestUrl(requestUrl: string) {
+  const { hostname } = new URL(requestUrl);
+  return (
+    hostname === "localhost" ||
+    hostname === "127.0.0.1" ||
+    hostname === "[::1]" ||
+    hostname === "::1"
+  );
+}
+
+export function createContentSecurityPolicy(
+  scriptNonce: string,
+  options: ContentSecurityPolicyOptions = {},
+) {
+  const connectSources = ["'self'", "https:", "wss:"];
+  const formActionOrigins = [...CSP_FORM_ACTION_ORIGINS];
+  if (options.allowLocalDevelopment) {
+    connectSources.push(...LOCAL_DEVELOPMENT_CONNECT_SOURCES);
+    formActionOrigins.push(...LOCAL_DEVELOPMENT_FORM_ACTION_ORIGINS);
+  }
+
+  return [
+    "default-src 'self'",
+    // Arktype currently ships in public route bundles through shared schema helpers and probes
+    // eval support with Function(). Keep inline scripts nonce-gated, but allow eval until those
+    // helpers are split out of the browser bundle.
+    `script-src 'self' 'nonce-${scriptNonce}' 'unsafe-eval'`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: blob: https:",
+    "font-src 'self' data:",
+    `connect-src ${connectSources.join(" ")}`,
+    "object-src 'none'",
+    "base-uri 'self'",
+    "frame-ancestors 'none'",
+    `form-action ${formActionOrigins.join(" ")}`,
+    ...(options.allowLocalDevelopment ? [] : ["upgrade-insecure-requests"]),
+  ].join("; ");
+}

--- a/src/lib/theme.test.tsx
+++ b/src/lib/theme.test.tsx
@@ -7,6 +7,7 @@ import {
   getStoredThemeSelection,
   useThemeMode,
 } from "./theme";
+import { THEME_MODE_COOKIE } from "./themeCookie";
 
 describe("theme", () => {
   let store: Record<string, string>;
@@ -50,6 +51,7 @@ describe("theme", () => {
     delete document.documentElement.dataset.themeFamily;
     delete document.documentElement.dataset.themeMode;
     window.localStorage.clear();
+    document.cookie = `${THEME_MODE_COOKIE}=; Max-Age=0; path=/`;
     vi.unstubAllGlobals();
   });
 
@@ -74,6 +76,11 @@ describe("theme", () => {
     window.localStorage.clear();
     window.localStorage.setItem("clawdhub-theme", "openknot");
     expect(getStoredThemeSelection()).toEqual({ theme: "claw", mode: "system" });
+  });
+
+  it("falls back to the server-readable theme cookie when local storage has no preference", () => {
+    document.cookie = `${THEME_MODE_COOKIE}=dark; path=/`;
+    expect(getStoredThemeSelection()).toEqual({ theme: "claw", mode: "dark" });
   });
 
   it("clears custom overlay state and resets stale visual settings to system defaults", () => {
@@ -166,5 +173,6 @@ describe("theme", () => {
 
     expect(window.localStorage.getItem("clawhub-theme")).toBe("dark");
     expect(window.localStorage.getItem("clawhub-theme-name")).toBe("claw");
+    expect(document.cookie).toContain(`${THEME_MODE_COOKIE}=dark`);
   });
 });

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,7 +1,13 @@
 import { useEffect, useState } from "react";
+import {
+  createThemeModeCookie,
+  getThemeModeFromCookieHeader,
+  normalizeThemeMode,
+  VALID_THEME_MODES,
+  type ThemeMode,
+} from "./themeCookie";
 
 type ThemeName = "claw";
-type ThemeMode = "system" | "light" | "dark";
 type ResolvedTheme = "light" | "dark";
 
 type ThemeSelection = {
@@ -20,7 +26,6 @@ const LEGACY_CUSTOM_THEME_STYLE_ID = "clawhub-custom-theme-style";
 const LEGACY_CUSTOM_THEME_FONT_LINK_ID = "clawhub-custom-theme-fonts";
 
 const VALID_THEME_NAMES = new Set<ThemeName>(["claw"]);
-const VALID_THEME_MODES = new Set<ThemeMode>(["system", "light", "dark"]);
 const DEFAULT_THEME_SELECTION: ThemeSelection = { theme: "claw", mode: "system" };
 const LEGACY_VISUAL_STORAGE_KEYS = [LEGACY_CUSTOM_THEME_KEY, LEGACY_PREFERENCES_KEY] as const;
 const LEGACY_VISUAL_COOKIE_KEYS = [
@@ -57,6 +62,7 @@ function persistThemeSelection(selection: ThemeSelection) {
   window.localStorage.setItem(THEME_SELECTION_KEY, JSON.stringify(selection));
   window.localStorage.setItem(THEME_KEY, selection.mode);
   window.localStorage.setItem(THEME_NAME_KEY, selection.theme);
+  document.cookie = createThemeModeCookie(selection.mode);
 }
 
 function safeGetLocalStorageItem(key: string): string | null {
@@ -189,7 +195,13 @@ export function getStoredThemeSelection(): ThemeSelection {
     return parseThemeSelection(legacy, undefined);
   }
 
-  return DEFAULT_THEME_SELECTION;
+  return {
+    theme: "claw",
+    mode:
+      typeof document === "undefined"
+        ? DEFAULT_THEME_SELECTION.mode
+        : getThemeModeFromCookieHeader(document.cookie),
+  };
 }
 
 export function getStoredTheme(): ThemeMode {
@@ -201,6 +213,7 @@ export function getStoredThemeName(): ThemeName {
 }
 
 function resolveMode(mode: ThemeMode): ResolvedTheme {
+  mode = normalizeThemeMode(mode);
   if (mode !== "system") return mode;
   if (typeof window === "undefined" || typeof window.matchMedia !== "function") return "light";
   return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";

--- a/src/lib/themeCookie.ts
+++ b/src/lib/themeCookie.ts
@@ -3,7 +3,8 @@ export type ThemeMode = "system" | "light" | "dark";
 export const THEME_MODE_COOKIE = "clawhub-theme-mode";
 export const VALID_THEME_MODES = new Set<ThemeMode>(["system", "light", "dark"]);
 
-const THEME_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+// Browsers cap long-lived client-set cookies, so use the practical maximum.
+const THEME_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 400;
 
 export function normalizeThemeMode(value: unknown): ThemeMode {
   return typeof value === "string" && VALID_THEME_MODES.has(value as ThemeMode)

--- a/src/lib/themeCookie.ts
+++ b/src/lib/themeCookie.ts
@@ -1,0 +1,33 @@
+export type ThemeMode = "system" | "light" | "dark";
+
+export const THEME_MODE_COOKIE = "clawhub-theme-mode";
+export const VALID_THEME_MODES = new Set<ThemeMode>(["system", "light", "dark"]);
+
+const THEME_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+export function normalizeThemeMode(value: unknown): ThemeMode {
+  return typeof value === "string" && VALID_THEME_MODES.has(value as ThemeMode)
+    ? (value as ThemeMode)
+    : "system";
+}
+
+export function getThemeModeFromCookieHeader(cookieHeader: string | null | undefined): ThemeMode {
+  if (!cookieHeader) return "system";
+
+  for (const part of cookieHeader.split(";")) {
+    const [rawName, ...rawValueParts] = part.trim().split("=");
+    if (rawName !== THEME_MODE_COOKIE) continue;
+
+    try {
+      return normalizeThemeMode(decodeURIComponent(rawValueParts.join("=")));
+    } catch {
+      return "system";
+    }
+  }
+
+  return "system";
+}
+
+export function createThemeModeCookie(mode: ThemeMode): string {
+  return `${THEME_MODE_COOKIE}=${encodeURIComponent(mode)}; Max-Age=${THEME_COOKIE_MAX_AGE_SECONDS}; Path=/; SameSite=Lax`;
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import {
   redirect,
   Scripts,
   useLocation,
+  useRouter,
 } from "@tanstack/react-router";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/react";
@@ -22,6 +23,7 @@ import {
   normalizeAuthErrorMessage,
 } from "../lib/authErrorMessage";
 import { getClawHubSiteUrl, SITE_DESCRIPTION, SITE_NAME } from "../lib/site";
+import { getThemeModeFromCookieHeader, normalizeThemeMode } from "../lib/themeCookie";
 import appCss from "../styles.css?url";
 
 const OG_IMAGE_VERSION = "20260420-12";
@@ -157,6 +159,13 @@ function getSearchStringValue(search: unknown, key: string) {
 }
 
 function RootDocument({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const initialThemeMode = normalizeThemeMode(
+    (router.options.context as { initialThemeMode?: unknown } | undefined)?.initialThemeMode ??
+      (typeof document === "undefined" ? undefined : getThemeModeFromCookieHeader(document.cookie)),
+  );
+  const initialResolvedTheme = initialThemeMode === "system" ? undefined : initialThemeMode;
+
   useEffect(() => {
     document.documentElement.dataset.clawhubHydrated = "true";
   }, []);
@@ -166,14 +175,17 @@ function RootDocument({ children }: { children: React.ReactNode }) {
     !["localhost", "127.0.0.1", "::1"].includes(window.location.hostname);
 
   return (
-    <html lang="en">
+    <html
+      className={initialThemeMode === "dark" ? "dark" : undefined}
+      data-theme={initialResolvedTheme}
+      data-theme-family="claw"
+      data-theme-mode={initialThemeMode}
+      data-theme-resolved={initialResolvedTheme}
+      lang="en"
+      suppressHydrationWarning
+    >
       <head>
         <HeadContent />
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `(function(){try{var d=document.documentElement,s='clawhub-theme-selection',k='clawhub-theme',n='clawhub-theme-name',l='clawdhub-theme',c='clawhub-custom-theme',p='clawhub-preferences';var defaults={theme:'claw',mode:'system'};var storageKeys=[c,p,s,k,n,l];var cookieKeys=[c,p,s,k,n,l];function hasCookie(name){if(!document.cookie)return false;return document.cookie.split(';').some(function(part){return part.trim().indexOf(name+'=')===0})}function clearCookie(name){document.cookie=name+'=; Max-Age=0; path=/';document.cookie=name+'=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/'}function cleanupDom(){var style=document.getElementById('clawhub-custom-theme-style');if(style)style.remove();var fonts=document.getElementById('clawhub-custom-theme-fonts');if(fonts)fonts.remove();d.classList.remove('theme-custom','high-contrast','reduce-motion');delete d.dataset.density;delete d.dataset.animation;d.style.removeProperty('--code-font-size')}var reset=false;try{if(localStorage.getItem(c)||localStorage.getItem(p))reset=true;var raw=localStorage.getItem(s);if(raw){try{var parsed=JSON.parse(raw);if(parsed&&parsed.theme&&parsed.theme!=='claw')reset=true}catch(e){reset=true}}var storedName=localStorage.getItem(n);if(storedName&&storedName!=='claw')reset=true;var storedMode=localStorage.getItem(k);if(storedMode&&['system','light','dark'].indexOf(storedMode)<0)reset=true;var legacy=localStorage.getItem(l);if(legacy&&['system','light','dark'].indexOf(legacy)<0)reset=true}catch(e){}if(cookieKeys.some(hasCookie))reset=true;if(reset){try{storageKeys.forEach(function(key){localStorage.removeItem(key)});localStorage.setItem(s,JSON.stringify(defaults));localStorage.setItem(k,defaults.mode);localStorage.setItem(n,defaults.theme)}catch(e){}cookieKeys.forEach(clearCookie);cleanupDom()}var sel;try{var stored=localStorage.getItem(s);if(stored){sel=JSON.parse(stored)}}catch(e){}if(!sel){var m=localStorage.getItem(k),t=localStorage.getItem(n);if(m||t){sel={theme:t||'claw',mode:m||'system'}}else{var lg=localStorage.getItem(l);if(lg){var map={dark:'dark',light:'light',system:'system'};sel={theme:'claw',mode:map[lg]||'system'}}}}if(!sel)sel=defaults;var themes=['claw'],modes=['system','light','dark'];if(themes.indexOf(sel.theme)<0)sel.theme='claw';if(modes.indexOf(sel.mode)<0)sel.mode='system';var resolved=sel.mode==='system'?(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):sel.mode;d.dataset.theme=resolved;d.dataset.themeResolved=resolved;d.dataset.themeMode=sel.mode;d.dataset.themeFamily=sel.theme;if(resolved==='dark')d.classList.add('dark');else d.classList.remove('dark')}catch(e){}})()`,
-          }}
-        />
       </head>
       <body>
         <AppProviders>

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,44 @@
+import type { Register } from "@tanstack/react-router";
+import {
+  createStartHandler,
+  defaultStreamHandler,
+  type RequestHandler,
+} from "@tanstack/react-start/server";
+import { createContentSecurityPolicy, isLocalDevelopmentRequestUrl } from "./lib/securityHeaders";
+import { getThemeModeFromCookieHeader } from "./lib/themeCookie";
+
+function createNonce() {
+  const bytes = new Uint8Array(18);
+  crypto.getRandomValues(bytes);
+  return Buffer.from(bytes).toString("base64");
+}
+
+const fetch = createStartHandler(async (ctx) => {
+  const nonce = createNonce();
+  ctx.router.update({
+    context: {
+      ...ctx.router.options.context,
+      initialThemeMode: getThemeModeFromCookieHeader(ctx.request.headers.get("cookie")),
+    },
+    ssr: { nonce },
+  });
+  ctx.responseHeaders.set(
+    "Content-Security-Policy",
+    createContentSecurityPolicy(nonce, {
+      allowLocalDevelopment: isLocalDevelopmentRequestUrl(ctx.request.url),
+    }),
+  );
+  return defaultStreamHandler(ctx);
+});
+
+type ServerEntry = { fetch: RequestHandler<Register> };
+
+function createServerEntry(entry: ServerEntry): ServerEntry {
+  return {
+    async fetch(...args) {
+      return await entry.fetch(...args);
+    },
+  };
+}
+
+export default createServerEntry({ fetch });

--- a/src/styles.css
+++ b/src/styles.css
@@ -267,6 +267,74 @@
   --diff-scrollbar-rgb: 115, 115, 115;
 }
 
+@media (prefers-color-scheme: light) {
+  [data-theme-family="claw"][data-theme-mode="system"] {
+    color-scheme: light;
+    --bg: #f9f9f9;
+    --bg-soft: #f9f9f9;
+    --surface: #ffffff;
+    --surface-muted: #ffffff;
+    --nav-bg: #f9f9f9;
+    --ink: #0a0a0a;
+    --ink-soft: #525252;
+    --accent: #dc2626;
+    --accent-fg: #ffffff;
+    --accent-deep: #b91c1c;
+    --accent-subtle: rgba(220, 38, 38, 0.08);
+    --line: rgba(0, 0, 0, 0.08);
+    --border-ui: rgba(0, 0, 0, 0.12);
+    --border-ui-hover: rgba(0, 0, 0, 0.18);
+    --border-ui-active: rgba(220, 38, 38, 0.6);
+
+    /* Status colors — light */
+    --status-success-bg: rgba(34, 197, 94, 0.1);
+    --status-success-fg: #16a34a;
+    --status-warning-bg: rgba(245, 158, 11, 0.1);
+    --status-warning-fg: #d97706;
+    --status-error-bg: rgba(239, 68, 68, 0.1);
+    --status-error-fg: #dc2626;
+    --official-bg: rgba(37, 99, 235, 0.1);
+    --official-fg: #2563eb;
+    --official-border: rgba(37, 99, 235, 0.26);
+
+    /* Form controls — light */
+    --input-border: rgba(0, 0, 0, 0.12);
+    --input-bg: #ffffff;
+    --input-placeholder: rgba(82, 82, 82, 0.6);
+    --input-focus-border: rgba(220, 38, 38, 0.5);
+    --input-focus-ring: rgba(220, 38, 38, 0.15);
+    --label-fg: rgba(10, 10, 10, 0.8);
+
+    /* Interactive states — light */
+    --hover-bg: rgba(0, 0, 0, 0.03);
+    --active-bg: rgba(220, 38, 38, 0.08);
+
+    /* Overlay — light */
+    --overlay-bg: rgba(250, 246, 241, 0.75);
+
+    /* Shadows — light */
+    --shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04);
+    --shadow-dialog: 0 24px 48px -12px rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(0, 0, 0, 0.05);
+    --shadow-hover: 0 8px 24px -4px rgba(0, 0, 0, 0.1);
+    --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.04);
+
+    /* Metric trend sparklines */
+    --metric-trend-line: color-mix(in srgb, #4a7fd0 84%, var(--ink));
+    --metric-trend-area: color-mix(in srgb, #4a7fd0 14%, transparent);
+    --metric-trend-marker: color-mix(in srgb, #4a7fd0 30%, transparent);
+
+    /* Diff viewer — muted, readable in light mode */
+    --diff-added: #16a34a;
+    --diff-added-strong: #15803d;
+    --diff-removed: #e57373;
+    --diff-removed-strong: #dc2626;
+    --diff-diagonal: #5252520a;
+    --diff-border: rgba(0, 0, 0, 0.08);
+    --diff-line-number: #9ca3af;
+    --diff-scrollbar-rgb: 115, 115, 115;
+  }
+}
+
 pre,
 code,
 .code-block {

--- a/vercel.json
+++ b/vercel.json
@@ -3,10 +3,6 @@
     {
       "source": "/(.*)",
       "headers": [
-        {
-          "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self' https://clawhub.ai https://documentation.openclaw.ai https://docs.openclaw.ai; upgrade-insecure-requests"
-        },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },


### PR DESCRIPTION
## Summary

This splits the CSP hardening from GHSA-p2qm-w5vv-54j3 into its own PR. ClawHub now emits a per-request script nonce from the TanStack Start server entry and removes global script `'unsafe-inline'` from production CSP.

## What Changed

- Added `src/server.ts` to generate a fresh nonce per request, pass it into SSR, and set a matching `Content-Security-Policy` response header.
- Removed the root inline `dangerouslySetInnerHTML` theme bootstrap and removed the follow-up `themeBootstrapScript`/`ScriptOnce` version as well.
- Replaced pre-hydration theme script execution with normal primitives: explicit theme mode is mirrored into a server-readable `clawhub-theme-mode` preference cookie, SSR stamps the initial `<html>` theme attributes from that cookie, and CSS handles `system` mode via `prefers-color-scheme`.
- Removed the static Vercel CSP header so it does not conflict with dynamic nonces; the other static security headers remain.
- Added CSP/helper coverage for production and local-development directives, no-bootstrap behavior, SSR theme cookie normalization, and the no-`unsafe-inline` invariant.
- Updated `specs/auth-identity.md` so docs-auth `form-action`, dynamic CSP, and first-paint theme invariants point at the current implementation.
- Kept script `'unsafe-eval'` for now because the current browser bundle includes arktype through shared schema helpers and arktype probes eval support with `Function()`. This PR still nonce-gates inline scripts and removes global inline execution.
- Removed now-unused frontend-only exports that caused `deadcode:exports` to fail in the rebased PR merge tree.

## Proof

Behavioral proof from built preview on `http://127.0.0.1:4179/`:

```text
default:      status 200, nonce true, unsafe-inline false, /theme-bootstrap.js requests 0, CSP violations 0, page errors 0, themeMode system, bg #f9f9f9
dark-cookie:  status 200, nonce true, unsafe-inline false, /theme-bootstrap.js requests 0, CSP violations 0, page errors 0, themeMode dark,   bg #060608
light-cookie: status 200, nonce true, unsafe-inline false, /theme-bootstrap.js requests 0, CSP violations 0, page errors 0, themeMode light,  bg #f9f9f9
un-nonced inline scripts: 0 in all three scenarios
```

Screenshots: omitted because this PR intentionally preserves visible UI state. Header/script execution and CSP behavior are better proven by the response headers, DOM script audit, and browser CSP violation listener than by an unchanged page screenshot.

## Verification

Passed locally after rebasing onto current `main`:

- `bun run test -- scripts/vercel-security-headers.test.mjs`
- `bun run format:check -- src/lib/theme.ts src/lib/openClawExtensionSlugs.ts knip.config.ts scripts/vercel-security-headers.test.mjs specs/auth-identity.md src/lib/securityHeaders.ts src/lib/theme.test.tsx src/lib/themeCookie.ts src/routes/__root.tsx src/server.ts src/styles.css vercel.json`
- `git diff --check`
- `bun run lint -- src/lib/theme.ts src/lib/openClawExtensionSlugs.ts src/lib/securityHeaders.ts src/lib/theme.test.tsx src/lib/themeCookie.ts src/routes/__root.tsx src/server.ts scripts/vercel-security-headers.test.mjs`
- `bunx tsc --noEmit`
- `bun run ci:types-build`

Earlier browser proof on the no-bootstrap implementation:

- `VITE_CONVEX_URL=https://wry-manatee-359.convex.cloud VITE_CONVEX_SITE_URL=https://wry-manatee-359.convex.site bun run build`
- Built preview on `http://127.0.0.1:4179/` with Playwright CSP/theme-cookie probe for default, dark-cookie, and light-cookie scenarios.

Local environment note:

- `bun run test -- src/lib/theme.test.tsx` is blocked locally before test execution by this shell's Node 20.16/jsdom dependency ESM loader issue (`html-encoding-sniffer` requiring `@exodus/bytes/encoding-lite.js`). The focused node-environment CSP test passes; CI should run the jsdom test on its normal toolchain.
- `KNIP_INCLUDE_TESTS=1 bunx knip@6.8.0 --config knip.config.ts --no-progress --reporter compact --exports --no-config-hints` is blocked locally by this shell's Node 20.16/`oxc-parser` ESM loader issue before reporting exports. The remote `static` job uses the CI runner toolchain.
- Build commands print Vite's Node version warning because this shell is on Node 20.16.0 and Vite wants 20.19+ or 22.12+. The commands still exited successfully.

## Follow-Up

Future hardening can remove script `'unsafe-eval'` by splitting browser-safe catalog/schema helpers away from arktype-backed runtime validators.
