### PR TITLE
fix: prefer publisher handles over plugin aliases

### DIFF
--- a/specs/slug-routing.md
+++ b/specs/slug-routing.md
@@ -49,8 +49,9 @@ Plugins:
 - Encoded security compatibility page: `/plugins/%40scope%2Fname/security-audit`
 - Legacy scanner pages redirect to the corresponding plugin security audit page.
 
-Bare `/<handle>` routes are profile routes after static routes and official
-OpenClaw plugin aliases have won precedence.
+Bare `/<handle>` routes are profile routes after static routes and existing
+publisher handles have won precedence. Official OpenClaw plugin aliases remain
+available at the root only when no active publisher owns that handle.
 
 Encoded compatibility routes are npm-style package-name routes. They redirect
 with `308` to the readable scoped route so the address bar shows
@@ -91,9 +92,10 @@ The effective precedence is:
 
 1. Static app routes win first, such as `/search`, `/settings`, `/plugins`, and
    `/api/...`.
-2. A top-level path matching an official OpenClaw extension alias redirects to
-   that plugin package.
-3. Any other top-level path may resolve as a publisher profile.
+2. A top-level path matching an active publisher handle resolves as that
+   publisher profile.
+3. Any other top-level path matching an official OpenClaw extension alias
+   redirects to that plugin package.
 4. Unknown top-level paths may still resolve through the historical skill slug
    fallback and redirect to `/<owner>/skills/<slug>`.
 5. `/openclaw/<alias>` and `/@openclaw/<alias>` only resolve official OpenClaw
@@ -107,9 +109,12 @@ The effective precedence is:
    `/plugins/<name>` probes package candidates in this order: official OpenClaw
    alias package, `@openclaw/<name>`, then the unscoped package name.
 
-This means official OpenClaw aliases are reserved before skills at the root.
-That is intentional: `https://clawhub.ai/codex` must show the official OpenClaw
-Codex plugin even if a skill named `codex` exists.
+This means official OpenClaw aliases are reserved before skills at the root, but
+not before existing publisher handles. That is intentional:
+`https://clawhub.ai/codex` should show the official OpenClaw Codex plugin when
+no `codex` publisher exists, while `https://clawhub.ai/tencent` must show a
+`tencent` publisher profile if that publisher exists instead of shadowing it
+with the `tencent` plugin alias.
 
 ## Collision policy
 

--- a/src/lib/slugRoute.test.ts
+++ b/src/lib/slugRoute.test.ts
@@ -92,4 +92,26 @@ describe("slug route resolution", () => {
     });
     expect(fetchSkillPageDataMock).not.toHaveBeenCalled();
   });
+
+  it("resolves publisher handles before OpenClaw plugin aliases", async () => {
+    queryMock.mockResolvedValue({ _id: "publishers:tencent", handle: "tencent", kind: "org" });
+
+    await expect(resolveTopLevelSlugRoute("tencent")).resolves.toEqual({
+      kind: "publisher",
+      handle: "tencent",
+      publisher: { _id: "publishers:tencent", handle: "tencent", kind: "org" },
+    });
+    expect(fetchSkillPageDataMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps OpenClaw plugin aliases available when no publisher handle exists", async () => {
+    queryMock.mockResolvedValue(null);
+
+    await expect(resolveTopLevelSlugRoute("tencent")).resolves.toEqual({
+      kind: "plugin",
+      name: "@openclaw/tencent-provider",
+      href: "/openclaw/plugins/tencent-provider",
+    });
+    expect(fetchSkillPageDataMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/slugRoute.ts
+++ b/src/lib/slugRoute.ts
@@ -50,9 +50,6 @@ export async function resolveOpenClawPluginSlug(
 }
 
 export async function resolveTopLevelSlugRoute(slug: string): Promise<SlugRouteTarget | null> {
-  const plugin = await resolveOpenClawPluginSlug(slug);
-  if (plugin) return plugin;
-
   const publisher = await resolvePublisherHandle(slug);
   if (publisher) {
     return {
@@ -61,6 +58,9 @@ export async function resolveTopLevelSlugRoute(slug: string): Promise<SlugRouteT
       publisher,
     };
   }
+
+  const plugin = await resolveOpenClawPluginSlug(slug);
+  if (plugin) return plugin;
 
   const data = await fetchSkillPageData(slug);
   const owner = data.initialData?.result?.owner?.handle ?? data.owner;


### PR DESCRIPTION
## Summary

- Resolve top-level publisher handles before OpenClaw plugin aliases so an org like `tencent` opens its publisher profile instead of `/openclaw/plugins/tencent-provider`.
- Keep official OpenClaw plugin aliases available when no publisher owns the handle.
- Update the slug-routing spec to document the publisher-first precedence.

Closes #2807.

## Root Cause

`resolveTopLevelSlugRoute()` checked OpenClaw official plugin aliases before checking publisher handles. After #2793 made `/<handle>` a publisher profile route, handles such as `tencent` could be shadowed by entries in `OPENCLAW_EXTENSION_SLUG_TO_PACKAGE`.

Provenance: made visible by #2793 (`55fe4a856333b9941120528507b56351e4aeca4c`, 2026-06-23), which added owner-qualified catalog routes and placed publisher handle resolution behind existing plugin alias resolution.

## Tests

- `bunx vitest run src/lib/slugRoute.test.ts src/__tests__/slug-route-loader.test.ts src/__tests__/skill-route-loader.test.ts`
- `bun run format:check -- src/lib/slugRoute.ts src/lib/slugRoute.test.ts specs/slug-routing.md`
- `bun run ci:static`
- `VITE_CONVEX_URL=https://example.invalid bun run coverage` from `/private/tmp/clawhub-issue-2807-test`: 294 passed, 1 skipped; 3766 tests passed, 1 skipped

Note: the first full coverage attempt from `/Users/mauriceniu/Documents/New project/clawhub-issue-2807` hit an existing path-space issue in `scripts/skill-cards/run-skill-card-worker.test.ts` (`New%20project` in a template path). The same diff passed from a no-space temp worktree.
