### PR TITLE
Fix security dataset export timeouts

### DIFF
--- a/.github/workflows/security-dataset-snapshot.yml
+++ b/.github/workflows/security-dataset-snapshot.yml
@@ -82,6 +82,9 @@ jobs:
             --hf-dataset
             --hf-repo "$HF_DATASET_REPO"
             --hf-revision "$HF_REVISION"
+            --page-size 25
+            --batch-pages 2
+            --concurrency 3
           )
           if [[ -n "$SNAPSHOT_LIMIT" ]]; then
             args+=(--limit "$SNAPSHOT_LIMIT")

--- a/scripts/security-dataset/export-snapshot.ts
+++ b/scripts/security-dataset/export-snapshot.ts
@@ -296,7 +296,7 @@ async function runConvexPage(
         return { page: decodeCompressedConvexPage(compressed), batchPages: pageCount };
       } catch (error) {
         lastError = error;
-        if (isLikelyTruncatedConvexOutput(error) && pageCount > 1) break;
+        if (isLikelyOversizedConvexBatch(error) && pageCount > 1) break;
         if (attempt === DEFAULT_MAX_CONVEX_ATTEMPTS) break;
         console.error(
           `[snapshot] retrying ${functionName} batch-pages=${pageCount} after attempt ${attempt}: ${errorMessage(error)}`,
@@ -305,7 +305,7 @@ async function runConvexPage(
       }
     }
 
-    if (isLikelyTruncatedConvexOutput(lastError) && pageCount > 1) {
+    if (isLikelyOversizedConvexBatch(lastError) && pageCount > 1) {
       const nextPageCount = Math.max(1, Math.floor(pageCount / 2));
       console.error(
         `[snapshot] ${shard.label} reducing batch-pages ${pageCount}->${nextPageCount}: ${errorMessage(lastError)}`,
@@ -756,6 +756,16 @@ function errorMessage(error: unknown) {
 
 function isLikelyTruncatedConvexOutput(error: unknown) {
   return /Convex JSON output \(524288 bytes\)/.test(errorMessage(error));
+}
+
+function isLikelyConvexOperationTimeout(error: unknown) {
+  return /(?:The operation timed out|operation timeout|deadline exceeded)/i.test(
+    errorMessage(error),
+  );
+}
+
+function isLikelyOversizedConvexBatch(error: unknown) {
+  return isLikelyTruncatedConvexOutput(error) || isLikelyConvexOperationTimeout(error);
 }
 
 function writeCommandErrorOutput(error: unknown) {


### PR DESCRIPTION
## Summary
- reduce nightly live export pressure to `--page-size 25 --batch-pages 2 --concurrency 3`
- treat Convex operation timeouts like oversized export batches so the exporter halves `batch-pages` and retries smaller instead of retrying the same failing batch

## Failure Evidence
Manual full upload run [28049753000](https://github.com/openclaw/clawhub/actions/runs/28049753000) reached the real export step and failed after ~33 minutes:

```text
[snapshot] skill:4/12 +230 artifacts (10224 total)
The operation timed out.
```

The logs showed repeated retries for `securityDatasetNode:listArtifactExportBatchCompressedInternal batch-pages=5`; the retry loop only reduced batch size for truncated Convex output, not operation timeouts.

## Proof
```bash
bunx vitest run scripts/security-dataset/exportSnapshotCli.test.ts scripts/security-dataset/huggingFaceExport.test.ts scripts/security-dataset/manifest.test.ts convex/securityDatasetNode.test.ts
bunx tsc --noEmit --pretty false
node -e "const fs=require('fs'); const YAML=require('yaml'); YAML.parse(fs.readFileSync('.github/workflows/security-dataset-snapshot.yml','utf8')); console.log('yaml ok')"
actionlint .github/workflows/security-dataset-snapshot.yml
git diff --check
bun run format:check -- .github/workflows/security-dataset-snapshot.yml scripts/security-dataset/export-snapshot.ts
```

Result: all passed locally.
