### PR TITLE
chore: release clawhub cli 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.23.0 - 2026-06-23
+
+### Changes
+
+- CLI: restore `clawhub sync` for scanning local skill folders and publishing new or changed skills in batches, including dry-run, JSON, owner, version-bump, provenance, and non-interactive `--all` options.
+
 ## 0.22.0 - 2026-06-15
 
 ### Changes

--- a/bun.lock
+++ b/bun.lock
@@ -90,7 +90,7 @@
     },
     "packages/clawhub": {
       "name": "clawhub",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "bin": {
         "clawdhub": "bin/clawdhub.js",
         "clawhub": "bin/clawdhub.js",

--- a/packages/clawhub/package.json
+++ b/packages/clawhub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawhub",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "ClawHub CLI \\u2014 install, update, search, and publish skills plus OpenClaw packages.",
   "homepage": "https://clawhub.ai",
   "bugs": {


### PR DESCRIPTION
## What Problem This Solves

The restored `clawhub sync` implementation is on `main`, but the published `clawhub@0.22.0` npm package does not include the sync command. Users still cannot run `clawhub sync` from the latest npm release.

## Why This Change Was Made

- Bumps `packages/clawhub` from `0.22.0` to `0.23.0`.
- Adds the matching changelog section for the release workflow.
- Updates the Bun lock metadata for the package version.

## User Impact

After the npm release workflow publishes `0.23.0`, `npx clawhub@latest sync --help` will expose the restored batch skill publish command.

## Evidence

- `bun run --cwd packages/clawhub verify`
- `node scripts/extract-changelog-release.mjs --tag v0.23.0`
- `node scripts/clawhub-cli-npm-release-check.mjs --tag v0.23.0 --release-sha $(git rev-parse HEAD) --release-main-ref origin/main`
- `git diff --check`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- Local packed-tarball smoke: `clawhub --cli-version` printed `0.23.0`, and `clawhub sync --help` showed the restored `sync` command options.
