### PR TITLE
Show official badges in search typeahead

### DIFF
--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -42,7 +42,13 @@ const getExactSkillSlugMatchHandler = (
     _handler: (
       ctx: unknown,
       args: unknown,
-    ) => Promise<Array<{ skill: { slug: string; _id: string }; ownerHandle: string | null }>>;
+    ) => Promise<
+      Array<{
+        skill: { slug: string; _id: string };
+        ownerHandle: string | null;
+        owner: { official?: boolean } | null;
+      }>
+    >;
   }
 )._handler;
 const hydrateResultsHandler = (
@@ -793,6 +799,26 @@ describe("search helpers", () => {
       "skills:org-demo",
     ]);
     expect(result.map((entry) => entry.ownerHandle)).toEqual(["alice", "org"]);
+  });
+
+  it("includes official publisher status on skill search owners", async () => {
+    const ctx = makeLexicalCtx({
+      exactSlugSkills: [
+        makeSkillDoc({
+          id: "skills:org-demo",
+          slug: "demo",
+          displayName: "Org Demo",
+          ownerPublisherId: "publishers:org",
+        }),
+      ],
+      officialPublisherIds: ["publishers:org"],
+      recentSkills: [],
+    });
+
+    const result = await getExactSkillSlugMatchHandler(ctx, { slug: "demo" });
+
+    expect(result[0]?.ownerHandle).toBe("org");
+    expect(result[0]?.owner?.official).toBe(true);
   });
 
   it("filters duplicate exact slug matches by topic", async () => {
@@ -2302,11 +2328,13 @@ function makePaginatedRows<T>(rows: T[], onPaginate?: () => void) {
 function makeLexicalCtx(params: {
   exactSlugSkill?: ReturnType<typeof makeSkillDoc> | null;
   exactSlugSkills?: Array<ReturnType<typeof makeSkillDoc>>;
+  officialPublisherIds?: string[];
   recentSkills: Array<ReturnType<typeof makeSkillDoc>>;
   recentByCreated?: Array<ReturnType<typeof makeSkillDoc>>;
 }) {
   const exactSlugSkills =
     params.exactSlugSkills ?? (params.exactSlugSkill ? [params.exactSlugSkill] : []);
+  const officialPublisherIds = new Set(params.officialPublisherIds ?? []);
   // Convert skill docs to digest-shaped rows (add skillId + owner fields).
   const toDigestRows = (skills: Array<ReturnType<typeof makeSkillDoc>>) =>
     skills.map((skill) => ({
@@ -2330,6 +2358,29 @@ function makeLexicalCtx(params: {
     },
     db: {
       query: vi.fn((table: string) => {
+        if (table === "officialPublishers") {
+          return {
+            withIndex: (
+              index: string,
+              builder: (q: { eq: (field: string, value: unknown) => unknown }) => unknown,
+            ) => {
+              usedIndexes.push(index);
+              let publisherId = "";
+              const q = {
+                eq: (field: string, value: unknown) => {
+                  if (field === "publisherId") publisherId = String(value);
+                  return q;
+                },
+              };
+              builder(q);
+              return {
+                unique: vi.fn(async () =>
+                  officialPublisherIds.has(publisherId) ? { publisherId } : null,
+                ),
+              };
+            },
+          };
+        }
         if (table === "skills") {
           return {
             withIndex: (index: string) => {
@@ -2489,6 +2540,13 @@ function makeDirectPrefixCtx(skills: Array<ReturnType<typeof makeSkillDoc>>) {
                 }),
               };
             },
+          };
+        }
+        if (table === "officialPublishers") {
+          return {
+            withIndex: () => ({
+              unique: vi.fn(async () => null),
+            }),
           };
         }
         if (table !== "skillSearchDigest") throw new Error(`Unexpected table ${table}`);

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -13,8 +13,9 @@ import type { QueryCtx } from "./_generated/server";
 import { action, internalQuery } from "./functions";
 import { isSkillHighlighted } from "./lib/badges";
 import { generateEmbedding } from "./lib/embeddings";
+import { hasOfficialPublisherRow, toPublicPublisherWithOfficial } from "./lib/officialPublishers";
 import type { HydratableSkill, PublicPublisher } from "./lib/public";
-import { toPublicPublisher, toPublicSkill } from "./lib/public";
+import { toPublicSkill } from "./lib/public";
 import { getOwnerPublisher } from "./lib/publishers";
 import {
   matchesAllTokens,
@@ -42,8 +43,8 @@ function makeOwnerInfoGetter(ctx: Pick<QueryCtx, "db">) {
     const ownerPromise = getOwnerPublisher(ctx, {
       ownerPublisherId,
       ownerUserId,
-    }).then((ownerDoc) => {
-      const owner = toPublicPublisher(ownerDoc);
+    }).then(async (ownerDoc) => {
+      const owner = await toPublicPublisherWithOfficial(ctx, ownerDoc);
       return {
         ownerHandle: owner?.handle ?? null,
         owner,
@@ -51,6 +52,20 @@ function makeOwnerInfoGetter(ctx: Pick<QueryCtx, "db">) {
     });
     ownerCache.set(cacheKey, ownerPromise);
     return ownerPromise;
+  };
+}
+
+async function withOfficialOwnerInfo(ctx: Pick<QueryCtx, "db">, ownerInfo: OwnerInfo) {
+  if (!ownerInfo.owner) return ownerInfo;
+  if (ownerInfo.owner.official) return ownerInfo;
+  const official = await hasOfficialPublisherRow(ctx, ownerInfo.owner._id);
+  if (!official) return ownerInfo;
+  return {
+    ...ownerInfo,
+    owner: {
+      ...ownerInfo.owner,
+      official: true,
+    },
   };
 }
 
@@ -810,7 +825,7 @@ export const directPrefixSkillMatches = internalQuery({
         if (!matchesCatalogFilters(skill, categorySlug, topic)) return null;
         const preResolved = digestToOwnerInfo(digest);
         const resolved = preResolved?.owner
-          ? preResolved
+          ? await withOfficialOwnerInfo(ctx, preResolved)
           : await getOwnerInfo(skill.ownerUserId, skill.ownerPublisherId);
         const publicSkill = toPublicSearchSkill(skill);
         if (!publicSkill || !resolved.owner) return null;
@@ -869,7 +884,7 @@ export const hydrateResults = internalQuery({
         // Fall back to live lookup when digest owner is null (deactivated/deleted user).
         const preResolved = digest ? digestToOwnerInfo(digest) : null;
         const resolved = preResolved?.owner
-          ? preResolved
+          ? await withOfficialOwnerInfo(ctx, preResolved)
           : await getOwnerInfo(skill.ownerUserId, skill.ownerPublisherId);
         const publicSkill = toPublicSearchSkill(skill);
         if (!publicSkill || !resolved.owner) return null;
@@ -1031,7 +1046,7 @@ export const lexicalFallbackSkills = internalQuery({
       matched.map(async (skill) => {
         const preResolved = preResolvedOwners.get(skill._id);
         const resolved = preResolved?.owner
-          ? preResolved
+          ? await withOfficialOwnerInfo(ctx, preResolved)
           : await getOwnerInfo(skill.ownerUserId, skill.ownerPublisherId);
         const publicSkill = toPublicSearchSkill(skill);
         if (!publicSkill || !resolved.owner) return null;

--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -36,6 +36,7 @@ const defaultUnifiedSearchResult = {
         createdAt: 1,
         updatedAt: 2,
       },
+      owner: null,
     },
   ],
   pluginResults: [
@@ -460,9 +461,13 @@ describe("Header", () => {
     const skillGroup = within(typeahead).getByRole("group", { name: "Skills" });
     const pluginGroup = within(typeahead).getByRole("group", { name: "Plugins" });
     expect(screen.getByText("Weather Skill")).toBeTruthy();
-    expect(screen.getByText("@local / weather")).toBeTruthy();
     expect(screen.getByText("Weather Plugin")).toBeTruthy();
-    expect(screen.getByText("@local / weather-plugin")).toBeTruthy();
+    expect(
+      screen.getByText("Weather Skill").closest(".navbar-search-typeahead-row")?.textContent,
+    ).toContain("@local / weather");
+    expect(
+      screen.getByText("Weather Plugin").closest(".navbar-search-typeahead-row")?.textContent,
+    ).toContain("@local / weather-plugin");
     expect(skillGroup.querySelector("svg.lucide-wrench")).not.toBeNull();
     expect(pluginGroup.querySelector("svg.lucide-message-circle")).not.toBeNull();
     expect(typeahead.querySelector("svg.lucide-package")).toBeNull();
@@ -508,8 +513,11 @@ describe("Header", () => {
     fireEvent.change(input, { target: { value: "firecrawl" } });
 
     expect(screen.getByText("OpenClaw Firecrawl Plugin")).toBeTruthy();
-    expect(screen.getByText("@openclaw / firecrawl-plugin")).toBeTruthy();
-    expect(screen.queryByText("@openclaw / @openclaw/firecrawl-plugin")).toBeNull();
+    const pluginRow = screen
+      .getByText("OpenClaw Firecrawl Plugin")
+      .closest(".navbar-search-typeahead-row");
+    expect(pluginRow?.textContent).toContain("@openclaw / firecrawl-plugin");
+    expect(pluginRow?.textContent).not.toContain("@openclaw / @openclaw/firecrawl-plugin");
   });
 
   it("falls back to typed skill search when a typeahead skill has no owner handle", () => {
@@ -618,5 +626,54 @@ describe("Header", () => {
     expect(screen.getByText("Stars").closest("a")?.getAttribute("href")).toBe("/stars");
     expect(screen.getAllByText("Dashboard").length).toBeGreaterThan(0);
     expect(screen.getByText("Settings")).toBeTruthy();
+  });
+
+  it("shows compact official badges beside official typeahead publishers", () => {
+    useUnifiedSearchMock.mockReturnValue({
+      ...defaultUnifiedSearchResult,
+      skillResults: [
+        {
+          ...defaultUnifiedSearchResult.skillResults[0],
+          owner: {
+            _id: "publishers:local",
+            _creationTime: 1,
+            kind: "org",
+            handle: "local",
+            displayName: "Local",
+            image: undefined,
+            bio: undefined,
+            linkedUserId: undefined,
+            official: true,
+          },
+        },
+      ],
+      pluginResults: [
+        {
+          ...defaultUnifiedSearchResult.pluginResults[0],
+          plugin: {
+            ...defaultUnifiedSearchResult.pluginResults[0].plugin,
+            isOfficial: true,
+          },
+        },
+      ],
+    });
+
+    render(<Header />);
+
+    const input = screen.getByPlaceholderText("Search skills and plugins");
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "weather" } });
+
+    const skillRow = screen.getByText("Weather Skill").closest(".navbar-search-typeahead-row");
+    const pluginRow = screen.getByText("Weather Plugin").closest(".navbar-search-typeahead-row");
+
+    expect(skillRow?.querySelector(".navbar-search-typeahead-meta")?.textContent).toContain(
+      "@local / weather",
+    );
+    expect(pluginRow?.querySelector(".navbar-search-typeahead-meta")?.textContent).toContain(
+      "@local / weather-plugin",
+    );
+    expect(skillRow?.querySelector(".official-badge")).toBeTruthy();
+    expect(pluginRow?.querySelector(".official-badge")).toBeTruthy();
   });
 });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -39,6 +39,7 @@ import {
   type UnifiedSkillResult,
 } from "../lib/useUnifiedSearch";
 import { MarketplaceIcon } from "./MarketplaceIcon";
+import { OfficialBadge } from "./OfficialBadge";
 import { Button } from "./ui/button";
 import {
   DropdownMenu,
@@ -962,23 +963,54 @@ function getTypeaheadRowBody(item: TypeaheadItem) {
     const owner = item.result.ownerHandle ? `@${item.result.ownerHandle}` : "Skill";
     return {
       title: item.result.skill.displayName,
-      meta: `${owner} / ${item.result.skill.slug}`,
+      meta: (
+        <TypeaheadPublisherMeta
+          owner={owner}
+          official={item.result.owner?.official === true}
+          packageName={item.result.skill.slug}
+        />
+      ),
     };
   }
   if (item.kind === "plugin") {
     const packageName = displayPluginPackageName(item.result.plugin.name);
-    const owner = item.result.plugin.ownerHandle
-      ? `@${item.result.plugin.ownerHandle} / ${packageName}`
-      : packageName;
+    const owner = item.result.plugin.ownerHandle ? `@${item.result.plugin.ownerHandle}` : null;
     return {
       title: item.result.plugin.displayName,
-      meta: owner,
+      meta: owner ? (
+        <TypeaheadPublisherMeta
+          owner={owner}
+          official={item.result.plugin.isOfficial}
+          packageName={packageName}
+        />
+      ) : (
+        packageName
+      ),
     };
   }
   return {
     title: item.label,
     meta: null,
   };
+}
+
+function TypeaheadPublisherMeta({
+  owner,
+  official,
+  packageName,
+}: {
+  owner: string;
+  official: boolean;
+  packageName: string;
+}) {
+  return (
+    <>
+      <span className="navbar-search-typeahead-publisher">{owner}</span>
+      {official ? <OfficialBadge /> : null}
+      <span className="navbar-search-typeahead-separator"> / </span>
+      <span className="navbar-search-typeahead-package">{packageName}</span>
+    </>
+  );
 }
 function NavbarThemeSwitcher({
   mode,

--- a/src/lib/useUnifiedSearch.ts
+++ b/src/lib/useUnifiedSearch.ts
@@ -2,6 +2,7 @@ import { useAction } from "convex/react";
 import { useEffect, useRef, useState } from "react";
 import { api } from "../../convex/_generated/api";
 import { fetchPluginCatalog, type PackageListItem } from "./packageApi";
+import type { PublicPublisher } from "./publicUser";
 
 export type UnifiedSearchType = "all" | "skills" | "plugins";
 const MAX_UNIFIED_SEARCH_LIMIT = 100;
@@ -24,6 +25,7 @@ export type UnifiedSkillResult = {
     createdAt: number;
   };
   ownerHandle: string | null;
+  owner?: PublicPublisher | null;
   score: number;
 };
 
@@ -118,12 +120,14 @@ export function useUnifiedSearch(
             (skillsRaw as Array<{
               skill: UnifiedSkillResult["skill"];
               ownerHandle: string | null;
+              owner?: PublicPublisher | null;
               score: number;
             }>) ?? []
           ).map((entry) => ({
             type: "skill" as const,
             skill: entry.skill,
             ownerHandle: entry.ownerHandle,
+            owner: entry.owner ?? null,
             score: entry.score,
           }));
           const nextSkillResults = skillMatches.slice(0, skillLimit);

--- a/src/styles.css
+++ b/src/styles.css
@@ -655,6 +655,37 @@ code {
   font-size: var(--fs-xs);
 }
 
+.navbar-search-typeahead-meta:has(.navbar-search-typeahead-publisher) {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+}
+
+.navbar-search-typeahead-publisher,
+.navbar-search-typeahead-package {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.navbar-search-typeahead-separator {
+  flex: 0 0 auto;
+}
+
+.navbar-search-typeahead-meta .official-badge {
+  width: 15px;
+  height: 15px;
+  border: 0;
+  background: transparent;
+}
+
+.navbar-search-typeahead-meta .official-badge svg {
+  width: 13px;
+  height: 13px;
+}
+
 .navbar-search-typeahead-status {
   padding: 12px;
   color: var(--ink-soft);


### PR DESCRIPTION
## Summary
- Show the compact official badge beside official skill publishers in global search typeahead results.
- Preserve search owner data through `useUnifiedSearch`, including publisher-scoped official status for user and org publishers.
- Reuse the existing plugin official-badge placement so publisher metadata stays `@owner [badge] / package`.

## Behavioural Proof
- Local browser proof captured on `http://localhost:3001` with query `brave`; the live typeahead row for `@openclaw/brave-plugin` shows the official badge next to `@local-corpus-stephanie-blanda` before `/ brave-plugin`.
- Published proof comment: https://github.com/openclaw/clawhub/pull/2824#issuecomment-4784620947

## Tests
- `bunx vitest run src/__tests__/header.test.tsx src/lib/useUnifiedSearch.test.tsx`
- `bunx vitest run convex/search.test.ts`
- `bun run ci:static`
- `VITE_CONVEX_URL=https://example.invalid bun run coverage`
- `bun run ci:types-build`
- `bunx convex dev --once --typecheck=disable`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
