### PR TITLE
security: gate mutable remote assets during publish

### DIFF
--- a/convex/lib/remoteAssetPolicy.test.ts
+++ b/convex/lib/remoteAssetPolicy.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "vitest";
+import { buildRemoteReferenceFindings, extractExternalReferences } from "./remoteAssetPolicy";
+
+describe("remote asset policy", () => {
+  test("extracts external URLs from submitted files", () => {
+    const refs = extractExternalReferences({
+      files: [
+        {
+          path: "SKILL.md",
+          content: "Install from https://raw.githubusercontent.com/acme/tool/main/install.sh",
+        },
+      ],
+    });
+
+    expect(refs).toMatchObject([
+      {
+        url: "https://raw.githubusercontent.com/acme/tool/main/install.sh",
+        file: "SKILL.md",
+        line: 1,
+      },
+    ]);
+  });
+
+  test("blocks raw.githubusercontent.com main branch references", () => {
+    const findings = buildRemoteReferenceFindings({
+      files: [
+        {
+          path: "SKILL.md",
+          content: "Run https://raw.githubusercontent.com/acme/tool/main/install.sh",
+        },
+      ],
+    });
+
+    expect(findings.some((finding) => finding.code === "REMOTE_REFERENCE_UNPINNED_GITHUB")).toBe(
+      true,
+    );
+    expect(findings.some((finding) => finding.code === "REMOTE_REFERENCE_HASH_MISSING")).toBe(true);
+  });
+
+  test("blocks github.com blob main references", () => {
+    const findings = buildRemoteReferenceFindings({
+      files: [
+        {
+          path: "README.md",
+          content: "See https://github.com/acme/tool/blob/main/plugin.js",
+        },
+      ],
+    });
+
+    expect(findings.some((finding) => finding.code === "REMOTE_REFERENCE_UNPINNED_GITHUB")).toBe(
+      true,
+    );
+  });
+
+  test("accepts full commit pinned raw GitHub reference with nearby SHA-256", () => {
+    const findings = buildRemoteReferenceFindings({
+      files: [
+        {
+          path: "SKILL.md",
+          content:
+            "url: https://raw.githubusercontent.com/acme/tool/0123456789abcdef0123456789abcdef01234567/install.sh\nsha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        },
+      ],
+    });
+
+    expect(findings).toEqual([]);
+  });
+
+  test("blocks plaintext HTTP remote references", () => {
+    const findings = buildRemoteReferenceFindings({
+      files: [
+        {
+          path: "SKILL.md",
+          content: "Download http://bad.example.invalid/tool.sh",
+        },
+      ],
+    });
+
+    expect(findings.some((finding) => finding.code === "REMOTE_REFERENCE_INSECURE_HTTP")).toBe(
+      true,
+    );
+  });
+
+  test("ignores example and localhost references", () => {
+    const findings = buildRemoteReferenceFindings({
+      files: [
+        {
+          path: "SKILL.md",
+          content: "Docs: https://example.com/tool and http://localhost:3000/test",
+        },
+      ],
+    });
+
+    expect(findings).toEqual([]);
+  });
+});

--- a/convex/lib/remoteAssetPolicy.ts
+++ b/convex/lib/remoteAssetPolicy.ts
@@ -1,0 +1,288 @@
+import { ConvexError } from "convex/values";
+
+export type RemoteReferenceFindingSeverity = "warn" | "critical";
+
+export type RemoteReferenceFinding = {
+  code:
+    | "REMOTE_REFERENCE_UNPINNED_GITHUB"
+    | "REMOTE_REFERENCE_HASH_MISSING"
+    | "REMOTE_REFERENCE_INSECURE_HTTP"
+    | "REMOTE_REFERENCE_RAW_IP";
+  severity: RemoteReferenceFindingSeverity;
+  file: string;
+  line: number;
+  message: string;
+  evidence: string;
+};
+
+export type RemoteReference = {
+  url: string;
+  file: string;
+  line: number;
+  context: string;
+};
+
+export type RemoteAssetPolicyInput = {
+  files: Array<{ path: string; content: string }>;
+  metadata?: unknown;
+};
+
+export type RemoteAssetPolicyOptions = {
+  blockingCodes?: RemoteReferenceFinding["code"][];
+};
+
+const DEFAULT_BLOCKING_CODES = new Set<RemoteReferenceFinding["code"]>([
+  "REMOTE_REFERENCE_UNPINNED_GITHUB",
+  "REMOTE_REFERENCE_INSECURE_HTTP",
+  "REMOTE_REFERENCE_RAW_IP",
+]);
+
+const URL_PATTERN = /\bhttps?:\/\/[^\s"'`<>)\]}]+/gi;
+const SHA256_PATTERN = /\bsha256[:=]\s*["']?([a-f0-9]{64})["']?/i;
+const RAW_IP_HOST_PATTERN = /^(?:\d{1,3}\.){3}\d{1,3}$/;
+
+const TEXT_CONTENT_TYPES = [
+  "application/json",
+  "application/ld+json",
+  "application/manifest+json",
+  "application/x-yaml",
+  "application/yaml",
+  "text/",
+];
+
+const TEXT_FILE_EXTENSIONS = [
+  ".cjs",
+  ".css",
+  ".js",
+  ".json",
+  ".jsx",
+  ".md",
+  ".mdx",
+  ".mjs",
+  ".toml",
+  ".ts",
+  ".tsx",
+  ".txt",
+  ".yaml",
+  ".yml",
+];
+
+export function isRemoteAssetPolicyTextFile(path: string, contentType?: string) {
+  const lowerPath = path.toLowerCase();
+  const lowerContentType = contentType?.toLowerCase() ?? "";
+
+  if (TEXT_FILE_EXTENSIONS.some((extension) => lowerPath.endsWith(extension))) {
+    return true;
+  }
+
+  return TEXT_CONTENT_TYPES.some((prefix) => lowerContentType.startsWith(prefix));
+}
+
+function trimUrl(url: string) {
+  return url.replace(/[.,;:!?]+$/g, "");
+}
+
+function getLineNumber(content: string, index: number) {
+  return content.slice(0, index).split("\n").length;
+}
+
+function getLineText(content: string, lineNumber: number) {
+  return content.split("\n")[lineNumber - 1]?.trim() ?? "";
+}
+
+function isLocalOrExampleHost(hostname: string) {
+  const host = hostname.toLowerCase();
+  return (
+    host === "localhost" ||
+    host === "127.0.0.1" ||
+    host === "::1" ||
+    host.endsWith(".localhost") ||
+    host === "example.com" ||
+    host.endsWith(".example.com") ||
+    host === "example.org" ||
+    host.endsWith(".example.org") ||
+    host === "example.net" ||
+    host.endsWith(".example.net")
+  );
+}
+
+function isFullGitCommitRef(ref: string) {
+  return /^[a-f0-9]{40}$/i.test(ref);
+}
+
+function githubMutableRefFinding(ref: string) {
+  const normalized = ref.toLowerCase();
+  return (
+    normalized === "main" ||
+    normalized === "master" ||
+    normalized === "develop" ||
+    normalized === "dev" ||
+    normalized.startsWith("release/") ||
+    normalized.startsWith("feature/") ||
+    normalized.startsWith("fix/") ||
+    normalized.startsWith("hotfix/")
+  );
+}
+
+function parseGithubBlobRef(url: URL) {
+  if (url.hostname.toLowerCase() !== "github.com") return null;
+  const parts = url.pathname.split("/").filter(Boolean);
+  const blobIndex = parts.indexOf("blob");
+  if (parts.length < 5 || blobIndex !== 2) return null;
+  return parts[3] ?? null;
+}
+
+function parseRawGithubRef(url: URL) {
+  if (url.hostname.toLowerCase() !== "raw.githubusercontent.com") return null;
+  const parts = url.pathname.split("/").filter(Boolean);
+  if (parts.length < 4) return null;
+  return parts[2] ?? null;
+}
+
+function isGithubReferenceThatMustBePinned(url: URL) {
+  return parseGithubBlobRef(url) ?? parseRawGithubRef(url);
+}
+
+function hasNearbySha256(content: string, index: number) {
+  const start = Math.max(0, index - 500);
+  const end = Math.min(content.length, index + 500);
+  return SHA256_PATTERN.test(content.slice(start, end));
+}
+
+export function extractExternalReferences(input: RemoteAssetPolicyInput): RemoteReference[] {
+  const references: RemoteReference[] = [];
+
+  for (const file of input.files) {
+    URL_PATTERN.lastIndex = 0;
+    for (const match of file.content.matchAll(URL_PATTERN)) {
+      const raw = match[0];
+      const index = match.index ?? 0;
+      const url = trimUrl(raw);
+      const line = getLineNumber(file.content, index);
+      references.push({
+        url,
+        file: file.path,
+        line,
+        context: getLineText(file.content, line),
+      });
+    }
+  }
+
+  const metadataText =
+    input.metadata === undefined
+      ? ""
+      : JSON.stringify(input.metadata, (_key, value) =>
+          typeof value === "bigint" ? String(value) : value,
+        );
+
+  if (metadataText) {
+    URL_PATTERN.lastIndex = 0;
+    for (const match of metadataText.matchAll(URL_PATTERN)) {
+      const url = trimUrl(match[0]);
+      references.push({
+        url,
+        file: "<metadata>",
+        line: 1,
+        context: url,
+      });
+    }
+  }
+
+  return references;
+}
+
+export function buildRemoteReferenceFindings(
+  input: RemoteAssetPolicyInput,
+): RemoteReferenceFinding[] {
+  const findings: RemoteReferenceFinding[] = [];
+
+  for (const file of input.files) {
+    URL_PATTERN.lastIndex = 0;
+    for (const match of file.content.matchAll(URL_PATTERN)) {
+      const raw = match[0];
+      const index = match.index ?? 0;
+      const rawUrl = trimUrl(raw);
+      const line = getLineNumber(file.content, index);
+      const context = getLineText(file.content, line);
+
+      let parsed: URL;
+      try {
+        parsed = new URL(rawUrl);
+      } catch {
+        continue;
+      }
+
+      const hostname = parsed.hostname.toLowerCase();
+      if (isLocalOrExampleHost(hostname)) continue;
+
+      if (parsed.protocol === "http:") {
+        findings.push({
+          code: "REMOTE_REFERENCE_INSECURE_HTTP",
+          severity: "critical",
+          file: file.path,
+          line,
+          message: "Remote asset uses plaintext HTTP.",
+          evidence: context,
+        });
+        continue;
+      }
+
+      if (RAW_IP_HOST_PATTERN.test(hostname)) {
+        findings.push({
+          code: "REMOTE_REFERENCE_RAW_IP",
+          severity: "critical",
+          file: file.path,
+          line,
+          message: "Remote asset uses a raw IP address.",
+          evidence: context,
+        });
+      }
+
+      const gitRef = isGithubReferenceThatMustBePinned(parsed);
+      if (gitRef && (githubMutableRefFinding(gitRef) || !isFullGitCommitRef(gitRef))) {
+        findings.push({
+          code: "REMOTE_REFERENCE_UNPINNED_GITHUB",
+          severity: "critical",
+          file: file.path,
+          line,
+          message: "GitHub remote asset must use a full 40 character commit hash.",
+          evidence: context,
+        });
+      }
+
+      if (
+        parsed.protocol === "https:" &&
+        !hasNearbySha256(file.content, index) &&
+        !isLocalOrExampleHost(hostname)
+      ) {
+        findings.push({
+          code: "REMOTE_REFERENCE_HASH_MISSING",
+          severity: "warn",
+          file: file.path,
+          line,
+          message: "Remote asset should declare a nearby SHA-256 hash.",
+          evidence: context,
+        });
+      }
+    }
+  }
+
+  return findings;
+}
+
+export function assertRemoteAssetPolicy(
+  input: RemoteAssetPolicyInput,
+  options: RemoteAssetPolicyOptions = {},
+) {
+  const findings = buildRemoteReferenceFindings(input);
+  const blockingCodes = new Set(options.blockingCodes ?? DEFAULT_BLOCKING_CODES);
+  const blocking = findings.find(
+    (finding) => finding.severity === "critical" && blockingCodes.has(finding.code),
+  );
+  if (blocking) {
+    throw new ConvexError(
+      `${blocking.code}: ${blocking.message} (${blocking.file}:${blocking.line})`,
+    );
+  }
+  return findings;
+}

--- a/convex/lib/skillPublish.test.ts
+++ b/convex/lib/skillPublish.test.ts
@@ -514,6 +514,66 @@ description: Security scanner smoke fixture.
     ).rejects.toThrow(/exceeds 10MB limit/i);
   });
 
+  it("rejects mutable GitHub remote references during skill publish", async () => {
+    const storedFiles = new Map([
+      [
+        "_storage:skill",
+        `---
+description: Blocks mutable remote install references.
+---
+# Mutable Remote Skill
+
+Install from https://raw.githubusercontent.com/acme/tool/main/install.sh
+`,
+      ],
+    ]);
+    const runMutation = vi.fn(async () => null);
+    const ctx = {
+      runQuery: vi
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ _id: "users:1", handle: "demo", createdAt: 1 }),
+      runMutation,
+      scheduler: { runAfter: vi.fn() },
+      storage: {
+        get: vi.fn(async (storageId: string) => {
+          const content = storedFiles.get(storageId);
+          return content === undefined ? null : new Blob([content]);
+        }),
+      },
+    };
+
+    await expect(
+      publishVersionForUser(
+        ctx as never,
+        "users:1" as never,
+        {
+          slug: "mutable-remote-skill",
+          displayName: "Mutable Remote Skill",
+          version: "1.0.0",
+          changelog: "Initial release",
+          files: [
+            {
+              path: "SKILL.md",
+              size: 180,
+              storageId: "_storage:skill" as never,
+              sha256: "a".repeat(64),
+              contentType: "text/markdown",
+            },
+          ],
+        },
+        {
+          bypassGitHubAccountAge: true,
+          bypassQualityGate: true,
+          skipWebhook: true,
+        },
+      ),
+    ).rejects.toThrow("REMOTE_REFERENCE_UNPINNED_GITHUB");
+
+    expect(runMutation).not.toHaveBeenCalled();
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
+  });
+
   it("rejects publisher-authored skill-card.md files", async () => {
     const ctx = {
       runQuery: vi.fn(async () => null),

--- a/convex/lib/skillPublish.ts
+++ b/convex/lib/skillPublish.ts
@@ -20,6 +20,7 @@ import {
   getPublishTotalSizeError,
   MAX_PUBLISH_TOTAL_BYTES,
 } from "./publishLimits";
+import { assertRemoteAssetPolicy } from "./remoteAssetPolicy";
 import { isSkillCardPath } from "./skillCards";
 import {
   computeQualitySignals,
@@ -282,6 +283,11 @@ export async function publishVersionForUser(
   } catch (error) {
     throw new ConvexError(error instanceof Error ? error.message : "Invalid catalog metadata");
   }
+
+  assertRemoteAssetPolicy({
+    metadata,
+    files: fileContents,
+  });
 
   const staticScan = await runStaticPublishScan(ctx, {
     slug,

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -112,6 +112,7 @@ import {
   computeRecommendationScore,
   RECOMMENDATION_SCORE_VERSION,
 } from "./lib/recommendationScore";
+import { assertRemoteAssetPolicy, isRemoteAssetPolicyTextFile } from "./lib/remoteAssetPolicy";
 import { MAX_ACTIVE_REPORTS_PER_USER, MAX_REPORT_REASON_LENGTH } from "./lib/reporting";
 import { matchesAllTokens, matchesExploratoryTokenPrefixes, tokenize } from "./lib/searchText";
 import { hashSkillFiles } from "./lib/skills";
@@ -7451,6 +7452,30 @@ async function publishPackageImpl(
     throw new ConvexError(error instanceof Error ? error.message : "Invalid catalog metadata");
   }
   const topics = normalizedTopics.length ? normalizedTopics : undefined;
+  const remotePolicyFiles: Array<{ path: string; content: string }> = [];
+  for (const file of files) {
+    if (!isRemoteAssetPolicyTextFile(file.path, file.contentType ?? undefined)) continue;
+    remotePolicyFiles.push({
+      path: file.path,
+      content: await readStorageText(ctx, file.storageId),
+    });
+  }
+
+  assertRemoteAssetPolicy(
+    {
+      metadata: {
+        packageJson,
+        pluginManifest,
+        bundleManifest,
+        source: effectiveSource,
+      },
+      files: remotePolicyFiles,
+    },
+    {
+      blockingCodes: ["REMOTE_REFERENCE_UNPINNED_GITHUB", "REMOTE_REFERENCE_RAW_IP"],
+    },
+  );
+
   const staticScan = await runStaticPublishScan(ctx, {
     slug: name,
     displayName,


### PR DESCRIPTION
## Summary

Adds a first-pass remote asset policy gate to ClawHub publish paths.

For skill publishes, the new gate blocks:

- mutable GitHub remote file references, such as `raw.githubusercontent.com/.../main/...`
- GitHub remote file references that are not pinned to a full 40-character commit
- plaintext `http://` remote references
- raw IP remote references

For package publishes, the first PR blocks mutable GitHub references and raw IP remote references while preserving the existing static scan and Plugin Inspector paths for other suspicious references. Plaintext HTTP and missing SHA-256 declarations are surfaced as policy findings, but are not hard-blocking for package publishes yet. This avoids bypassing existing manifest normalization and scan-status forwarding behavior.

## Why

Skills and plugins can reference remote assets in `SKILL.md`, README files, package metadata, and plugin manifests. Without a publish-time remote asset gate, a reviewed artifact can later be affected by remote content changes or branch bait-and-switch behavior.

This PR intentionally keeps the scope narrow. It adds the blocking policy layer first. Follow-up work can add asset proxying, manifest signing, sandbox network interception, and scheduled post-submission diff audits.

## Implementation

- Adds `convex/lib/remoteAssetPolicy.ts`.
- Extracts external references from submitted text files and package metadata.
- Flags unsafe or mutable remote references.
- Calls the policy from skill publish before static scan and version insertion.
- Calls the policy from package publish before static scan and release insertion.
- Keeps package publish compatibility with existing manifest icon normalization and Plugin Inspector scan forwarding behavior.
- Adds focused regression coverage for the policy logic.

## Proof

### Policy helper proof

```bash
bun run test -- convex/lib/remoteAssetPolicy.test.ts
```

Covers:

- URL extraction from submitted files
- mutable `raw.githubusercontent.com/.../main/...` detection
- mutable `github.com/.../blob/main/...` detection
- pinned full-commit raw GitHub reference with nearby SHA-256 accepted
- plaintext HTTP detection
- localhost/example references ignored

### Package publish compatibility proof

```bash
bunx vitest run convex/packages.public.test.ts --testNamePattern "forwards only valid HTTPS plugin manifest icons to release insertion|scans plugin publishes and forwards scan status to insertReleaseInternal"
```

Covers:

- valid HTTPS plugin manifest icons still reach release insertion
- invalid plugin manifest icons are still normalized away
- package static scan still forwards suspicious scan status to release insertion
- package HTTP findings do not bypass existing static scan and Plugin Inspector behavior

### Repo-level proof

```bash
bun run lint
bunx tsc --noEmit
bun run ci:static
bun run ci:unit
bun run ci:types-build
```

Covers:

- formatting
- type-aware lint
- TypeScript typecheck
- unit coverage
- production build/type CI paths

## Follow-up PRs

- Persist remote asset policy findings for audit and review.
- Store `remoteAssetAudits` rows for approved references.
- Download, verify, and proxy remote assets through immutable ClawHub storage/CDN.
- Sign canonical release manifests after inspection.
- Add sandbox dynamic analysis with outbound network interception.
- Add scheduled post-submission URL diff scans.