### PR TITLE
feat: include creators in global search

### DIFF
--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -60,10 +60,36 @@ const defaultUnifiedSearchResult = {
       },
     },
   ],
+  creatorResults: [
+    {
+      type: "creator",
+      creator: {
+        _id: "publishers:local",
+        _creationTime: 1,
+        kind: "org",
+        handle: "local",
+        displayName: "Local Creator",
+        image: undefined,
+        bio: "Creator weather tools.",
+        linkedUserId: undefined,
+        official: true,
+        stats: {
+          skills: 1,
+          packages: 1,
+          installs: 0,
+          downloads: 3,
+          stars: 0,
+        },
+        publishedItems: [],
+      },
+    },
+  ],
   skillCount: 1,
   pluginCount: 1,
+  creatorCount: 1,
   skillHasMore: false,
   pluginHasMore: false,
+  creatorHasMore: false,
   isSearching: false,
 };
 
@@ -277,7 +303,7 @@ describe("Header", () => {
     expect(screen.queryByText("About")).toBeNull();
     expect(screen.queryByText("Dashboard")).toBeNull();
     expect(screen.queryByText("Manage")).toBeNull();
-    expect(screen.getByPlaceholderText("Search skills and plugins")).toBeTruthy();
+    expect(screen.getByPlaceholderText("Search skills, plugins, and creators")).toBeTruthy();
 
     fireEvent.click(screen.getByRole("button", { name: "Open menu" }));
 
@@ -405,7 +431,7 @@ describe("Header", () => {
 
     render(<Header />);
 
-    const input = screen.getByPlaceholderText("Search skills and plugins");
+    const input = screen.getByPlaceholderText("Search skills, plugins, and creators");
     fireEvent.change(input, { target: { value: "weather" } });
     fireEvent.submit(screen.getByRole("search", { name: "Site search" }));
 
@@ -418,13 +444,13 @@ describe("Header", () => {
   it("opens the empty typeahead state from the global search shortcut", () => {
     render(<Header />);
 
-    const input = screen.getByPlaceholderText("Search skills and plugins");
+    const input = screen.getByPlaceholderText("Search skills, plugins, and creators");
     fireEvent.keyDown(window, { key: "k", metaKey: true });
 
     expect(document.activeElement).toBe(input);
     expect(input.getAttribute("aria-expanded")).toBe("true");
     expect(screen.queryByRole("tablist", { name: "Result type" })).toBeNull();
-    expect(screen.getByText("Start typing to search skills and plugins")).toBeTruthy();
+    expect(screen.getByText("Start typing to search skills, plugins, and creators")).toBeTruthy();
     expect(useUnifiedSearchMock).toHaveBeenLastCalledWith(
       "",
       "all",
@@ -435,7 +461,7 @@ describe("Header", () => {
   it("preserves caret navigation and moves through the unified results with vertical arrows", () => {
     render(<Header />);
 
-    const input = screen.getByPlaceholderText("Search skills and plugins");
+    const input = screen.getByPlaceholderText("Search skills, plugins, and creators");
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: "weather plugin" } });
 
@@ -448,28 +474,34 @@ describe("Header", () => {
     expect(scrollIntoViewMock).toHaveBeenLastCalledWith({ block: "nearest" });
   });
 
-  it("shows skills and plugins together in grouped typeahead sections", () => {
+  it("shows skills, plugins, and creators together in grouped typeahead sections", () => {
     navigateMock.mockReset();
 
     render(<Header />);
 
-    const input = screen.getByPlaceholderText("Search skills and plugins");
+    const input = screen.getByPlaceholderText("Search skills, plugins, and creators");
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: "weather" } });
 
     const typeahead = screen.getByRole("listbox");
     const skillGroup = within(typeahead).getByRole("group", { name: "Skills" });
     const pluginGroup = within(typeahead).getByRole("group", { name: "Plugins" });
+    const creatorGroup = within(typeahead).getByRole("group", { name: "Creators" });
     expect(screen.getByText("Weather Skill")).toBeTruthy();
     expect(screen.getByText("Weather Plugin")).toBeTruthy();
+    expect(screen.getByText("Local Creator")).toBeTruthy();
     expect(
       screen.getByText("Weather Skill").closest(".navbar-search-typeahead-row")?.textContent,
     ).toContain("@local / weather");
     expect(
       screen.getByText("Weather Plugin").closest(".navbar-search-typeahead-row")?.textContent,
     ).toContain("@local / weather-plugin");
+    expect(
+      screen.getByText("Local Creator").closest(".navbar-search-typeahead-row")?.textContent,
+    ).toContain("@local");
     expect(skillGroup.querySelector("svg.lucide-wrench")).not.toBeNull();
     expect(pluginGroup.querySelector("svg.lucide-message-circle")).not.toBeNull();
+    expect(creatorGroup.querySelector("svg.lucide-building-2")).not.toBeNull();
     expect(typeahead.querySelector("svg.lucide-package")).toBeNull();
     expect(screen.queryByRole("tablist", { name: "Result type" })).toBeNull();
     expect(input.getAttribute("role")).toBe("combobox");
@@ -480,6 +512,7 @@ describe("Header", () => {
     expect(document.getElementById(activeDescendant ?? "")).toBeTruthy();
     expect(within(typeahead).queryByText("Publishers")).toBeNull();
     expect(within(typeahead).queryByText('See user results for "weather"')).toBeNull();
+    expect(within(typeahead).getByText('See creator results for "weather"')).toBeTruthy();
 
     fireEvent.keyDown(input, { key: "ArrowDown" });
     fireEvent.keyDown(input, { key: "Enter" });
@@ -487,6 +520,30 @@ describe("Header", () => {
     expect(navigateMock).toHaveBeenCalledWith({
       to: "/search",
       search: { q: "weather", type: "skills" },
+    });
+  });
+
+  it("navigates creator typeahead rows to profiles and creator footers to scoped search", () => {
+    navigateMock.mockReset();
+
+    render(<Header />);
+
+    const input = screen.getByPlaceholderText("Search skills, plugins, and creators");
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "weather" } });
+    fireEvent.click(screen.getByRole("option", { name: /Local Creator/i }));
+
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: "/local",
+    });
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "weather" } });
+    fireEvent.click(screen.getByRole("option", { name: /See creator results/i }));
+
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: "/search",
+      search: { q: "weather", type: "creators" },
     });
   });
 
@@ -508,7 +565,7 @@ describe("Header", () => {
 
     render(<Header />);
 
-    const input = screen.getByPlaceholderText("Search skills and plugins");
+    const input = screen.getByPlaceholderText("Search skills, plugins, and creators");
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: "firecrawl" } });
 
@@ -541,7 +598,7 @@ describe("Header", () => {
 
     render(<Header />);
 
-    const input = screen.getByPlaceholderText("Search skills and plugins");
+    const input = screen.getByPlaceholderText("Search skills, plugins, and creators");
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: "weather" } });
     fireEvent.click(screen.getByRole("option", { name: /Weather Skill/i }));
@@ -562,23 +619,27 @@ describe("Header", () => {
       results: [],
       skillResults: [],
       pluginResults: [],
+      creatorResults: [],
       skillCount: 0,
       pluginCount: 0,
+      creatorCount: 0,
       skillHasMore: false,
       pluginHasMore: false,
+      creatorHasMore: false,
       isSearching: false,
     });
 
     render(<Header />);
 
-    const input = screen.getByPlaceholderText("Search skills and plugins");
+    const input = screen.getByPlaceholderText("Search skills, plugins, and creators");
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: "zzzz" } });
 
-    expect(screen.getByText('No skills or plugins found for "zzzz"')).toBeTruthy();
+    expect(screen.getByText('No skills, plugins, or creators found for "zzzz"')).toBeTruthy();
     expect(screen.queryByRole("tablist", { name: "Result type" })).toBeNull();
     expect(screen.queryByText('See skill results for "zzzz"')).toBeNull();
     expect(screen.queryByText('See plugin results for "zzzz"')).toBeNull();
+    expect(screen.queryByText('See creator results for "zzzz"')).toBeNull();
   });
 
   it("shows Home above Skills in the mobile menu", () => {
@@ -660,12 +721,13 @@ describe("Header", () => {
 
     render(<Header />);
 
-    const input = screen.getByPlaceholderText("Search skills and plugins");
+    const input = screen.getByPlaceholderText("Search skills, plugins, and creators");
     fireEvent.focus(input);
     fireEvent.change(input, { target: { value: "weather" } });
 
     const skillRow = screen.getByText("Weather Skill").closest(".navbar-search-typeahead-row");
     const pluginRow = screen.getByText("Weather Plugin").closest(".navbar-search-typeahead-row");
+    const creatorRow = screen.getByText("Local Creator").closest(".navbar-search-typeahead-row");
 
     expect(skillRow?.querySelector(".navbar-search-typeahead-meta")?.textContent).toContain(
       "@local / weather",
@@ -673,7 +735,11 @@ describe("Header", () => {
     expect(pluginRow?.querySelector(".navbar-search-typeahead-meta")?.textContent).toContain(
       "@local / weather-plugin",
     );
+    expect(creatorRow?.querySelector(".navbar-search-typeahead-meta")?.textContent).toContain(
+      "@local",
+    );
     expect(skillRow?.querySelector(".official-badge")).toBeTruthy();
     expect(pluginRow?.querySelector(".official-badge")).toBeTruthy();
+    expect(creatorRow?.querySelector(".official-badge")).toBeTruthy();
   });
 });

--- a/src/__tests__/search-route.test.tsx
+++ b/src/__tests__/search-route.test.tsx
@@ -7,7 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const navigateMock = vi.fn();
 let searchMock: {
   q?: string;
-  type?: "all" | "skills" | "plugins";
+  type?: "all" | "skills" | "plugins" | "creators";
 } = {};
 const useUnifiedSearchMock = vi.fn();
 
@@ -25,6 +25,14 @@ vi.mock("../lib/useUnifiedSearch", () => ({
 
 vi.mock("../components/PluginListItem", () => ({
   PluginListItem: ({ item }: { item: { name: string } }) => <div>{item.name}</div>,
+}));
+
+vi.mock("../components/PublisherListItem", () => ({
+  PublisherListItem: ({ publisher }: { publisher: { handle: string; displayName: string } }) => (
+    <div>
+      {publisher.displayName} @{publisher.handle}
+    </div>
+  ),
 }));
 
 vi.mock("../components/SkillListItem", () => ({
@@ -54,10 +62,13 @@ describe("search route", () => {
       results: [],
       skillResults: [],
       pluginResults: [],
+      creatorResults: [],
       skillCount: 0,
       pluginCount: 0,
+      creatorCount: 0,
       skillHasMore: false,
       pluginHasMore: false,
+      creatorHasMore: false,
       isSearching: false,
     });
   });
@@ -67,7 +78,9 @@ describe("search route", () => {
     const Component = route.__config.component as ComponentType;
     const rendered = render(<Component />);
 
-    const input = screen.getByPlaceholderText("Search skills and plugins...") as HTMLInputElement;
+    const input = screen.getByPlaceholderText(
+      "Search skills, plugins, and creators...",
+    ) as HTMLInputElement;
     expect(input.value).toBe("first");
 
     fireEvent.change(input, { target: { value: "draft" } });
@@ -77,7 +90,8 @@ describe("search route", () => {
     rendered.rerender(<Component />);
 
     expect(
-      (screen.getByPlaceholderText("Search skills and plugins...") as HTMLInputElement).value,
+      (screen.getByPlaceholderText("Search skills, plugins, and creators...") as HTMLInputElement)
+        .value,
     ).toBe("second");
   });
 
@@ -95,8 +109,10 @@ describe("search route", () => {
       results: [],
       skillResults: [],
       pluginResults: [],
+      creatorResults: [],
       skillCount: 0,
       pluginCount: 0,
+      creatorCount: 0,
       isSearching: true,
     });
     const route = await loadRoute();
@@ -113,10 +129,13 @@ describe("search route", () => {
       results: [],
       skillResults: [],
       pluginResults: [{ type: "plugin", plugin: { name: "github-plugin" } }],
+      creatorResults: [],
       skillCount: 0,
       pluginCount: 3,
+      creatorCount: 0,
       skillHasMore: false,
       pluginHasMore: false,
+      creatorHasMore: false,
       isSearching: false,
     });
     const route = await loadRoute();
@@ -127,6 +146,7 @@ describe("search route", () => {
     expect(screen.getByRole("button", { name: "All" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Skills" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Plugins" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Creators" })).toBeTruthy();
     expect(screen.queryByText("0")).toBeNull();
     expect(screen.queryByText("3")).toBeNull();
   });
@@ -166,10 +186,13 @@ describe("search route", () => {
       results: skills,
       skillResults: skills,
       pluginResults: [],
+      creatorResults: [],
       skillCount: 25,
       pluginCount: 0,
+      creatorCount: 0,
       skillHasMore: true,
       pluginHasMore: false,
+      creatorHasMore: false,
       isSearching: false,
     });
     const route = await loadRoute();
@@ -178,13 +201,13 @@ describe("search route", () => {
     render(<Component />);
 
     expect(useUnifiedSearchMock).toHaveBeenCalledWith("weather", "all", {
-      limits: { skills: 25, plugins: 25 },
+      limits: { skills: 25, plugins: 25, creators: 25 },
     });
 
     fireEvent.click(screen.getByRole("button", { name: "Load more" }));
 
     expect(useUnifiedSearchMock).toHaveBeenCalledWith("weather", "all", {
-      limits: { skills: 50, plugins: 50 },
+      limits: { skills: 50, plugins: 50, creators: 50 },
     });
   });
 
@@ -225,10 +248,30 @@ describe("search route", () => {
         },
       ],
       pluginResults: [{ type: "plugin", plugin: { name: "weather-plugin" } }],
+      creatorResults: [
+        {
+          type: "creator",
+          creator: {
+            _id: "publishers:weather",
+            _creationTime: 1,
+            kind: "org",
+            handle: "weather",
+            displayName: "Weather Creator",
+            image: undefined,
+            bio: "Weather creator",
+            linkedUserId: undefined,
+            official: true,
+            stats: { skills: 0, packages: 0, installs: 0, downloads: 0, stars: 0 },
+            publishedItems: [],
+          },
+        },
+      ],
       skillCount: 1,
       pluginCount: 1,
+      creatorCount: 1,
       skillHasMore: false,
       pluginHasMore: false,
+      creatorHasMore: false,
       isSearching: false,
     });
     const route = await loadRoute();
@@ -238,8 +281,10 @@ describe("search route", () => {
 
     expect(screen.getByRole("button", { name: "All" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Plugins" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Creators" })).toBeTruthy();
     expect(screen.getByText("weather")).toBeTruthy();
     expect(screen.queryByText("weather-plugin")).toBeNull();
+    expect(screen.queryByText("Weather Creator @weather")).toBeNull();
   });
 
   it("does not render partial count labels when more results are available", async () => {
@@ -247,10 +292,13 @@ describe("search route", () => {
       results: [],
       skillResults: [],
       pluginResults: [{ type: "plugin", plugin: { name: "github-plugin" } }],
+      creatorResults: [],
       skillCount: 0,
       pluginCount: 25,
+      creatorCount: 0,
       skillHasMore: false,
       pluginHasMore: true,
+      creatorHasMore: false,
       isSearching: false,
     });
     const route = await loadRoute();
@@ -282,10 +330,13 @@ describe("search route", () => {
       })),
       skillResults: [],
       pluginResults: [],
+      creatorResults: [],
       skillCount: 25,
       pluginCount: 0,
+      creatorCount: 0,
       skillHasMore: false,
       pluginHasMore: false,
+      creatorHasMore: false,
       isSearching: false,
     });
     const route = await loadRoute();
@@ -308,7 +359,23 @@ describe("search route", () => {
       "/skills",
     );
     expect(screen.queryByRole("link", { name: "Show all plugins" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Show all creators" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Search all types" })).toBeNull();
+  });
+
+  it("links to creators browse when creator search has no matches", async () => {
+    searchMock = { q: "zzzz", type: "creators" };
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    expect(screen.getByText('No matches for "zzzz"')).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Show all creators" }).getAttribute("href")).toBe(
+      "/creators",
+    );
+    expect(screen.queryByRole("link", { name: "Show all skills" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Show all plugins" })).toBeNull();
   });
 
   it("offers all-types recovery when the active type is empty but another type matched", async () => {
@@ -317,10 +384,13 @@ describe("search route", () => {
       results: [{ type: "plugin", plugin: { name: "weather-plugin" } }],
       skillResults: [],
       pluginResults: [{ type: "plugin", plugin: { name: "weather-plugin" } }],
+      creatorResults: [],
       skillCount: 0,
       pluginCount: 1,
+      creatorCount: 0,
       skillHasMore: false,
       pluginHasMore: false,
+      creatorHasMore: false,
       isSearching: false,
     });
     const route = await loadRoute();
@@ -346,8 +416,79 @@ describe("search route", () => {
     render(<Component />);
 
     expect(useUnifiedSearchMock).toHaveBeenLastCalledWith("hello", "all", {
-      limits: { skills: 25, plugins: 25 },
+      limits: { skills: 25, plugins: 25, creators: 25 },
     });
+  });
+
+  it("renders creators as their own all-results section and active tab", async () => {
+    searchMock = { q: "weather" };
+    useUnifiedSearchMock.mockReturnValue({
+      results: [
+        {
+          type: "creator",
+          creator: {
+            _id: "publishers:weather",
+            _creationTime: 1,
+            kind: "org",
+            handle: "weather",
+            displayName: "Weather Creator",
+            image: undefined,
+            bio: "Weather creator",
+            linkedUserId: undefined,
+            official: true,
+            stats: { skills: 0, packages: 0, installs: 0, downloads: 0, stars: 0 },
+            publishedItems: [],
+          },
+        },
+      ],
+      skillResults: [],
+      pluginResults: [],
+      creatorResults: [
+        {
+          type: "creator",
+          creator: {
+            _id: "publishers:weather",
+            _creationTime: 1,
+            kind: "org",
+            handle: "weather",
+            displayName: "Weather Creator",
+            image: undefined,
+            bio: "Weather creator",
+            linkedUserId: undefined,
+            official: true,
+            stats: { skills: 0, packages: 0, installs: 0, downloads: 0, stars: 0 },
+            publishedItems: [],
+          },
+        },
+      ],
+      skillCount: 0,
+      pluginCount: 0,
+      creatorCount: 1,
+      skillHasMore: false,
+      pluginHasMore: false,
+      creatorHasMore: false,
+      isSearching: false,
+    });
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    const rendered = render(<Component />);
+
+    expect(screen.getByRole("button", { name: "Creators" })).toBeTruthy();
+    expect(screen.getByRole("region", { name: "Creators" })).toBeTruthy();
+    expect(screen.getByText("Weather Creator @weather")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Creators" }));
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: "/search",
+      search: { q: "weather", type: "creators" },
+      replace: true,
+    });
+
+    searchMock = { q: "weather", type: "creators" };
+    rendered.rerender(<Component />);
+
+    expect(screen.getByText("Weather Creator @weather")).toBeTruthy();
   });
 
   it("does not render a warning-filter chip on the plugins tab", async () => {

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -107,7 +107,7 @@ describe("restored UI design contract", () => {
     expect(headerSource).toContain('className="github-sign-in-button"');
     expect(headerSource).toContain('className="sign-in-full-copy"');
     expect(headerSource).toContain('className="sign-in-compact-copy"');
-    expect(headerSource).toContain("Search skills and plugins");
+    expect(headerSource).toContain("Search skills, plugins, and creators");
     expect(headerSource).not.toContain('className="navbar-tabs-primary"');
     expect(headerSource).not.toContain('className="navbar-tabs-secondary"');
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -27,7 +27,7 @@ import {
 } from "../lib/authErrorMessage";
 import { gravatarUrl } from "../lib/gravatar";
 import { PRIMARY_NAV_ITEMS, SECONDARY_NAV_ITEMS } from "../lib/nav-items";
-import { buildSkillDetailHref } from "../lib/ownerRoute";
+import { buildPublisherProfileHref, buildSkillDetailHref } from "../lib/ownerRoute";
 import { buildPluginDetailHref, displayPluginPackageName } from "../lib/pluginRoutes";
 import { SITE_NAME } from "../lib/site";
 import { applyTheme, useThemeMode } from "../lib/theme";
@@ -35,6 +35,7 @@ import { clearAuthError, setAuthError } from "../lib/useAuthError";
 import { useAuthStatus } from "../lib/useAuthStatus";
 import {
   useUnifiedSearch,
+  type UnifiedCreatorResult,
   type UnifiedPluginResult,
   type UnifiedSkillResult,
 } from "../lib/useUnifiedSearch";
@@ -94,7 +95,7 @@ function GitHubLogo({ className }: { className?: string }) {
   );
 }
 
-type TypeaheadSection = "skills" | "plugins";
+type TypeaheadSection = "skills" | "plugins" | "creators";
 
 type TypeaheadItem =
   | {
@@ -106,6 +107,11 @@ type TypeaheadItem =
       kind: "plugin";
       key: string;
       result: UnifiedPluginResult;
+    }
+  | {
+      kind: "creator";
+      key: string;
+      result: UnifiedCreatorResult;
     }
   | {
       kind: "footer";
@@ -149,11 +155,12 @@ export default function Header() {
   const {
     skillResults,
     pluginResults,
+    creatorResults,
     isSearching: typeaheadSearching,
   } = useUnifiedSearch(navSearchQuery, "all", {
     debounceMs: 180,
     enabled: typeaheadOpen && hasNavSearchQuery,
-    limits: { skills: 4, plugins: 4 },
+    limits: { skills: 4, plugins: 4, creators: 4 },
   });
   const typeaheadSkillItems = useMemo<TypeaheadItem[]>(() => {
     if (!hasNavSearchQuery) return [];
@@ -189,9 +196,26 @@ export default function Header() {
     return items;
   }, [hasNavSearchQuery, pluginResults, trimmedNavSearchQuery]);
 
+  const typeaheadCreatorItems = useMemo<TypeaheadItem[]>(() => {
+    if (!hasNavSearchQuery) return [];
+    const items: TypeaheadItem[] = [];
+    for (const result of creatorResults) {
+      items.push({ kind: "creator", key: `creator-${result.creator._id}`, result });
+    }
+    if (creatorResults.length > 0) {
+      items.push({
+        kind: "footer",
+        key: "footer-creators",
+        section: "creators",
+        label: `See creator results for "${trimmedNavSearchQuery}"`,
+      });
+    }
+    return items;
+  }, [creatorResults, hasNavSearchQuery, trimmedNavSearchQuery]);
+
   const typeaheadItems = useMemo(
-    () => [...typeaheadSkillItems, ...typeaheadPluginItems],
-    [typeaheadPluginItems, typeaheadSkillItems],
+    () => [...typeaheadSkillItems, ...typeaheadPluginItems, ...typeaheadCreatorItems],
+    [typeaheadCreatorItems, typeaheadPluginItems, typeaheadSkillItems],
   );
   const activeTypeaheadItem = showTypeahead ? typeaheadItems[typeaheadActiveIndex] : undefined;
   const activeTypeaheadId = activeTypeaheadItem
@@ -304,6 +328,21 @@ export default function Header() {
         to: buildPluginDetailHref(item.result.plugin.name, {
           ownerHandle: item.result.plugin.ownerHandle,
         }),
+      });
+    } else if (item.kind === "creator") {
+      const publisherHandle = item.result.creator.handle.trim();
+      if (!publisherHandle) {
+        void navigate({
+          to: "/search",
+          search: { q: trimmedNavSearchQuery, type: "creators" },
+        });
+        setNavSearchQuery("");
+        setTypeaheadOpen(false);
+        setMobileSearchOpen(false);
+        return;
+      }
+      void navigate({
+        to: buildPublisherProfileHref(publisherHandle),
       });
     } else {
       void navigate({
@@ -507,7 +546,7 @@ export default function Header() {
                   className="navbar-search-input"
                   type="search"
                   role="combobox"
-                  placeholder="Search skills and plugins"
+                  placeholder="Search skills, plugins, and creators"
                   value={navSearchQuery}
                   onChange={(e) => {
                     setNavSearchQuery(e.target.value);
@@ -530,6 +569,7 @@ export default function Header() {
                   loading={typeaheadSearching}
                   onHoverItem={setTypeaheadActiveIndex}
                   onSelectItem={navigateToTypeaheadItem}
+                  creatorItems={typeaheadCreatorItems}
                   pluginItems={typeaheadPluginItems}
                   query={trimmedNavSearchQuery}
                   skillItems={typeaheadSkillItems}
@@ -695,7 +735,7 @@ export default function Header() {
                 className="navbar-search-input"
                 type="search"
                 role="combobox"
-                placeholder="Search skills and plugins"
+                placeholder="Search skills, plugins, and creators"
                 value={navSearchQuery}
                 onChange={(e) => {
                   setNavSearchQuery(e.target.value);
@@ -732,6 +772,7 @@ export default function Header() {
                 loading={typeaheadSearching}
                 onHoverItem={setTypeaheadActiveIndex}
                 onSelectItem={navigateToTypeaheadItem}
+                creatorItems={typeaheadCreatorItems}
                 pluginItems={typeaheadPluginItems}
                 query={trimmedNavSearchQuery}
                 skillItems={typeaheadSkillItems}
@@ -783,6 +824,7 @@ function HeaderNavTab({
 
 function SearchTypeahead({
   activeIndex,
+  creatorItems,
   loading,
   onHoverItem,
   onSelectItem,
@@ -791,6 +833,7 @@ function SearchTypeahead({
   skillItems,
 }: {
   activeIndex: number;
+  creatorItems: TypeaheadItem[];
   loading: boolean;
   onHoverItem: (index: number) => void;
   onSelectItem: (item: TypeaheadItem) => void;
@@ -801,8 +844,10 @@ function SearchTypeahead({
   const hasQuery = query.length > 0;
   const hasSkillMatches = skillItems.some((item) => item.kind === "skill");
   const hasPluginMatches = pluginItems.some((item) => item.kind === "plugin");
-  const hasMatches = hasSkillMatches || hasPluginMatches;
+  const hasCreatorMatches = creatorItems.some((item) => item.kind === "creator");
+  const hasMatches = hasSkillMatches || hasPluginMatches || hasCreatorMatches;
   const pluginStartIndex = skillItems.length;
+  const creatorStartIndex = skillItems.length + pluginItems.length;
 
   return (
     <div className="navbar-search-typeahead" id="navbar-search-typeahead">
@@ -812,7 +857,7 @@ function SearchTypeahead({
             <span className="navbar-search-typeahead-status-icon" aria-hidden="true">
               <Search size={17} />
             </span>
-            <span>Start typing to search skills and plugins</span>
+            <span>Start typing to search skills, plugins, and creators</span>
           </div>
         ) : null}
         {hasQuery && loading && !hasMatches ? (
@@ -820,7 +865,7 @@ function SearchTypeahead({
         ) : null}
         {hasQuery && !loading && !hasMatches ? (
           <div className="navbar-search-typeahead-status">
-            No skills or plugins found for "{query}"
+            No skills, plugins, or creators found for "{query}"
           </div>
         ) : null}
         {hasMatches ? (
@@ -871,6 +916,30 @@ function SearchTypeahead({
                     active={activeIndex === pluginStartIndex + index}
                     item={item}
                     index={pluginStartIndex + index}
+                    onHoverItem={onHoverItem}
+                    onSelectItem={onSelectItem}
+                  />
+                ))}
+              </div>
+            ) : null}
+            {hasCreatorMatches ? (
+              <div
+                className="navbar-search-typeahead-section"
+                role="group"
+                aria-labelledby="navbar-search-typeahead-creators-heading"
+              >
+                <div
+                  id="navbar-search-typeahead-creators-heading"
+                  className="navbar-search-typeahead-heading"
+                >
+                  Creators
+                </div>
+                {creatorItems.map((item, index) => (
+                  <TypeaheadRow
+                    key={item.key}
+                    active={activeIndex === creatorStartIndex + index}
+                    item={item}
+                    index={creatorStartIndex + index}
                     onHoverItem={onHoverItem}
                     onSelectItem={onSelectItem}
                   />
@@ -955,6 +1024,20 @@ function TypeaheadRowIcon({ item }: { item: TypeaheadItem }) {
     );
   }
 
+  if (item.kind === "creator") {
+    const publisher = item.result.creator;
+    return (
+      <span className="navbar-search-typeahead-icon" aria-hidden="true">
+        <MarketplaceIcon
+          kind={publisher.kind === "org" ? "org" : "user"}
+          label={publisher.displayName}
+          imageUrl={publisher.image}
+          size="xs"
+        />
+      </span>
+    );
+  }
+
   return null;
 }
 
@@ -988,6 +1071,19 @@ function getTypeaheadRowBody(item: TypeaheadItem) {
       ),
     };
   }
+  if (item.kind === "creator") {
+    const publisher = item.result.creator;
+    return {
+      title: publisher.displayName,
+      meta: (
+        <TypeaheadCreatorMeta
+          handle={`@${publisher.handle}`}
+          official={publisher.official === true}
+          kind={publisher.kind}
+        />
+      ),
+    };
+  }
   return {
     title: item.label,
     meta: null,
@@ -1009,6 +1105,29 @@ function TypeaheadPublisherMeta({
       {official ? <OfficialBadge /> : null}
       <span className="navbar-search-typeahead-separator"> / </span>
       <span className="navbar-search-typeahead-package">{packageName}</span>
+    </>
+  );
+}
+
+function TypeaheadCreatorMeta({
+  handle,
+  kind,
+  official,
+}: {
+  handle: string;
+  kind: "user" | "org";
+  official: boolean;
+}) {
+  return (
+    <>
+      <span className="navbar-search-typeahead-publisher">{handle}</span>
+      {official ? <OfficialBadge /> : null}
+      {kind === "org" ? (
+        <>
+          <span className="navbar-search-typeahead-separator"> / </span>
+          <span className="navbar-search-typeahead-package">Org</span>
+        </>
+      ) : null}
     </>
   );
 }

--- a/src/lib/useUnifiedSearch.test.tsx
+++ b/src/lib/useUnifiedSearch.test.tsx
@@ -4,9 +4,10 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useUnifiedSearch } from "./useUnifiedSearch";
 
-const { searchSkillsMock, fetchPluginCatalogMock } = vi.hoisted(() => ({
+const { searchSkillsMock, fetchPluginCatalogMock, convexQueryMock } = vi.hoisted(() => ({
   searchSkillsMock: vi.fn(),
   fetchPluginCatalogMock: vi.fn(),
+  convexQueryMock: vi.fn(),
 }));
 
 vi.mock("convex/react", () => ({
@@ -15,6 +16,12 @@ vi.mock("convex/react", () => ({
 
 vi.mock("./packageApi", () => ({
   fetchPluginCatalog: (...args: unknown[]) => fetchPluginCatalogMock(...args),
+}));
+
+vi.mock("../convex/client", () => ({
+  convexHttp: {
+    query: (...args: unknown[]) => convexQueryMock(...args),
+  },
 }));
 
 function makeSkill(slug: string) {
@@ -45,10 +52,33 @@ function makePlugin(name: string) {
   };
 }
 
+function makeCreator(handle: string) {
+  return {
+    _id: `publishers:${handle}`,
+    _creationTime: 1,
+    kind: "org",
+    handle,
+    displayName: handle,
+    image: undefined,
+    bio: "Creator profile",
+    linkedUserId: undefined,
+    official: true,
+    stats: {
+      skills: 0,
+      packages: 0,
+      installs: 0,
+      downloads: 0,
+      stars: 0,
+    },
+    publishedItems: [],
+  };
+}
+
 describe("useUnifiedSearch", () => {
   beforeEach(() => {
     searchSkillsMock.mockReset();
     fetchPluginCatalogMock.mockReset();
+    convexQueryMock.mockReset();
   });
 
   it("requests one extra result and exposes hasMore without inflating counts", async () => {
@@ -57,17 +87,23 @@ describe("useUnifiedSearch", () => {
       items: [makePlugin("one-plugin"), makePlugin("two-plugin"), makePlugin("three-plugin")],
       nextCursor: null,
     });
+    convexQueryMock.mockResolvedValue({
+      page: [makeCreator("one-creator"), makeCreator("two-creator"), makeCreator("three-creator")],
+      continueCursor: null,
+      isDone: false,
+    });
 
     const { result } = renderHook(() =>
       useUnifiedSearch("ghost", "all", {
         debounceMs: 0,
-        limits: { skills: 2, plugins: 2 },
+        limits: { skills: 2, plugins: 2, creators: 2 },
       }),
     );
 
     await waitFor(() => {
       expect(result.current.skillCount).toBe(2);
       expect(result.current.pluginCount).toBe(2);
+      expect(result.current.creatorCount).toBe(2);
     });
 
     expect(searchSkillsMock).toHaveBeenCalledWith({
@@ -77,29 +113,48 @@ describe("useUnifiedSearch", () => {
     expect(fetchPluginCatalogMock).toHaveBeenCalledWith(
       expect.objectContaining({ q: "ghost", limit: 3 }),
     );
+    expect(convexQueryMock.mock.calls.at(-1)?.[1]).toEqual({
+      query: "ghost",
+      paginationOpts: { cursor: null, numItems: 3 },
+    });
     expect(result.current.skillResults.map((entry) => entry.skill.slug)).toEqual(["one", "two"]);
     expect(result.current.pluginResults.map((entry) => entry.plugin.name)).toEqual([
       "one-plugin",
       "two-plugin",
     ]);
+    expect(result.current.creatorResults.map((entry) => entry.creator.handle)).toEqual([
+      "one-creator",
+      "two-creator",
+    ]);
+    expect(result.current.results.map((entry) => entry.type)).toEqual([
+      "skill",
+      "skill",
+      "plugin",
+      "plugin",
+      "creator",
+      "creator",
+    ]);
     expect(result.current.skillHasMore).toBe(true);
     expect(result.current.pluginHasMore).toBe(true);
+    expect(result.current.creatorHasMore).toBe(true);
   });
 
-  it("caps requested limits at the backend search maximum", async () => {
+  it("caps requested skill and plugin limits at the backend search maximum", async () => {
     searchSkillsMock.mockResolvedValue([]);
     fetchPluginCatalogMock.mockResolvedValue({ items: [], nextCursor: null });
+    convexQueryMock.mockResolvedValue({ page: [], continueCursor: null, isDone: true });
 
     renderHook(() =>
       useUnifiedSearch("ghost", "all", {
         debounceMs: 0,
-        limits: { skills: 150, plugins: 150 },
+        limits: { skills: 150, plugins: 150, creators: 150 },
       }),
     );
 
     await waitFor(() => {
       expect(searchSkillsMock).toHaveBeenCalled();
       expect(fetchPluginCatalogMock).toHaveBeenCalled();
+      expect(convexQueryMock).toHaveBeenCalled();
     });
 
     expect(searchSkillsMock).toHaveBeenCalledWith({
@@ -109,5 +164,36 @@ describe("useUnifiedSearch", () => {
     expect(fetchPluginCatalogMock).toHaveBeenCalledWith(
       expect.objectContaining({ q: "ghost", limit: 101 }),
     );
+    expect(convexQueryMock.mock.calls.at(-1)?.[1]).toEqual({
+      query: "ghost",
+      paginationOpts: { cursor: null, numItems: 50 },
+    });
+  });
+
+  it("does not leave creator load more stuck after the publisher page cap", async () => {
+    searchSkillsMock.mockResolvedValue([]);
+    fetchPluginCatalogMock.mockResolvedValue({ items: [], nextCursor: null });
+    convexQueryMock.mockResolvedValue({
+      page: Array.from({ length: 50 }, (_, index) => makeCreator(`creator-${index}`)),
+      continueCursor: "next-page",
+      isDone: false,
+    });
+
+    const { result } = renderHook(() =>
+      useUnifiedSearch("ghost", "creators", {
+        debounceMs: 0,
+        limits: { creators: 150 },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.creatorCount).toBe(50);
+    });
+
+    expect(convexQueryMock.mock.calls.at(-1)?.[1]).toEqual({
+      query: "ghost",
+      paginationOpts: { cursor: null, numItems: 50 },
+    });
+    expect(result.current.creatorHasMore).toBe(false);
   });
 });

--- a/src/lib/useUnifiedSearch.ts
+++ b/src/lib/useUnifiedSearch.ts
@@ -1,11 +1,13 @@
 import { useAction } from "convex/react";
 import { useEffect, useRef, useState } from "react";
 import { api } from "../../convex/_generated/api";
+import { convexHttp } from "../convex/client";
 import { fetchPluginCatalog, type PackageListItem } from "./packageApi";
-import type { PublicPublisher } from "./publicUser";
+import type { PublicPublisher, PublicPublisherListItem } from "./publicUser";
 
-export type UnifiedSearchType = "all" | "skills" | "plugins";
+export type UnifiedSearchType = "all" | "skills" | "plugins" | "creators";
 const MAX_UNIFIED_SEARCH_LIMIT = 100;
+const MAX_CREATOR_SEARCH_LIMIT = 50;
 
 export type UnifiedSkillResult = {
   type: "skill";
@@ -34,7 +36,12 @@ export type UnifiedPluginResult = {
   plugin: PackageListItem;
 };
 
-type UnifiedResult = UnifiedSkillResult | UnifiedPluginResult;
+export type UnifiedCreatorResult = {
+  type: "creator";
+  creator: PublicPublisherListItem;
+};
+
+type UnifiedResult = UnifiedSkillResult | UnifiedPluginResult | UnifiedCreatorResult;
 
 type UnifiedSearchOptions = {
   debounceMs?: number;
@@ -42,6 +49,7 @@ type UnifiedSearchOptions = {
   limits?: {
     skills?: number;
     plugins?: number;
+    creators?: number;
   };
 };
 
@@ -54,10 +62,13 @@ export function useUnifiedSearch(
   const [results, setResults] = useState<UnifiedResult[]>([]);
   const [skillResults, setSkillResults] = useState<UnifiedSkillResult[]>([]);
   const [pluginResults, setPluginResults] = useState<UnifiedPluginResult[]>([]);
+  const [creatorResults, setCreatorResults] = useState<UnifiedCreatorResult[]>([]);
   const [skillCount, setSkillCount] = useState(0);
   const [pluginCount, setPluginCount] = useState(0);
+  const [creatorCount, setCreatorCount] = useState(0);
   const [skillHasMore, setSkillHasMore] = useState(false);
   const [pluginHasMore, setPluginHasMore] = useState(false);
+  const [creatorHasMore, setCreatorHasMore] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
   const requestRef = useRef(0);
   const debounceMs = options.debounceMs ?? 300;
@@ -67,6 +78,11 @@ export function useUnifiedSearch(
     0,
     Math.min(options.limits?.plugins ?? 25, MAX_UNIFIED_SEARCH_LIMIT),
   );
+  const creatorLimit = Math.max(
+    0,
+    Math.min(options.limits?.creators ?? 25, MAX_CREATOR_SEARCH_LIMIT),
+  );
+  const creatorRequestLimit = Math.min(creatorLimit + 1, MAX_CREATOR_SEARCH_LIMIT);
 
   useEffect(() => {
     const trimmed = query.trim();
@@ -75,10 +91,13 @@ export function useUnifiedSearch(
       setResults([]);
       setSkillResults([]);
       setPluginResults([]);
+      setCreatorResults([]);
       setSkillCount(0);
       setPluginCount(0);
+      setCreatorCount(0);
       setSkillHasMore(false);
       setPluginHasMore(false);
+      setCreatorHasMore(false);
       setIsSearching(false);
       return () => {};
     }
@@ -91,8 +110,11 @@ export function useUnifiedSearch(
     const handle = window.setTimeout(() => {
       void (async () => {
         try {
-          const promises: [Promise<unknown> | null, Promise<{ items: PackageListItem[] }> | null] =
-            [null, null];
+          const promises: [
+            Promise<unknown> | null,
+            Promise<{ items: PackageListItem[] }> | null,
+            Promise<{ page: PublicPublisherListItem[]; isDone?: boolean }> | null,
+          ] = [null, null, null];
 
           if (activeType === "all" || activeType === "skills") {
             promises[0] = searchSkills({
@@ -109,12 +131,20 @@ export function useUnifiedSearch(
             });
           }
 
+          if (activeType === "all" || activeType === "creators") {
+            promises[2] = convexHttp.query(api.publishers.listPublicPage, {
+              query: trimmed,
+              paginationOpts: { cursor: null, numItems: creatorRequestLimit },
+            });
+          }
+
           const settled = await Promise.allSettled(promises.map((p) => p ?? Promise.resolve(null)));
 
           if (requestId !== requestRef.current) return;
 
           const skillsRaw = settled[0].status === "fulfilled" ? settled[0].value : null;
           const pluginsRaw = settled[1].status === "fulfilled" ? settled[1].value : null;
+          const creatorsRaw = settled[2].status === "fulfilled" ? settled[2].value : null;
 
           const skillMatches: UnifiedSkillResult[] = (
             (skillsRaw as Array<{
@@ -140,20 +170,37 @@ export function useUnifiedSearch(
           }));
           const nextPluginResults = pluginMatches.slice(0, pluginLimit);
 
+          const creatorMatches: UnifiedCreatorResult[] = (
+            (creatorsRaw as { page: PublicPublisherListItem[] } | null)?.page ?? []
+          ).map((item) => ({
+            type: "creator" as const,
+            creator: item,
+          }));
+          const nextCreatorResults = creatorMatches.slice(0, creatorLimit);
+
           setSkillCount(nextSkillResults.length);
           setPluginCount(nextPluginResults.length);
+          setCreatorCount(nextCreatorResults.length);
           setSkillHasMore(skillMatches.length > skillLimit);
           setPluginHasMore(pluginMatches.length > pluginLimit);
+          setCreatorHasMore(
+            creatorLimit < MAX_CREATOR_SEARCH_LIMIT &&
+              (creatorMatches.length > creatorLimit ||
+                (creatorsRaw as { isDone?: boolean } | null)?.isDone === false),
+          );
           setSkillResults(nextSkillResults);
           setPluginResults(nextPluginResults);
+          setCreatorResults(nextCreatorResults);
 
           const merged: UnifiedResult[] = [];
           if (activeType === "all") {
-            merged.push(...nextSkillResults, ...nextPluginResults);
+            merged.push(...nextSkillResults, ...nextPluginResults, ...nextCreatorResults);
           } else if (activeType === "skills") {
             merged.push(...nextSkillResults);
-          } else {
+          } else if (activeType === "plugins") {
             merged.push(...nextPluginResults);
+          } else {
+            merged.push(...nextCreatorResults);
           }
 
           setResults(merged);
@@ -163,10 +210,13 @@ export function useUnifiedSearch(
             setResults([]);
             setSkillResults([]);
             setPluginResults([]);
+            setCreatorResults([]);
             setSkillCount(0);
             setPluginCount(0);
+            setCreatorCount(0);
             setSkillHasMore(false);
             setPluginHasMore(false);
+            setCreatorHasMore(false);
           }
         } finally {
           if (requestId === requestRef.current) {
@@ -181,16 +231,29 @@ export function useUnifiedSearch(
       controller.abort();
       window.clearTimeout(handle);
     };
-  }, [query, activeType, searchSkills, debounceMs, enabled, skillLimit, pluginLimit]);
+  }, [
+    query,
+    activeType,
+    searchSkills,
+    debounceMs,
+    enabled,
+    skillLimit,
+    pluginLimit,
+    creatorLimit,
+    creatorRequestLimit,
+  ]);
 
   return {
     results,
     skillResults,
     pluginResults,
+    creatorResults,
     skillCount,
     pluginCount,
+    creatorCount,
     skillHasMore,
     pluginHasMore,
+    creatorHasMore,
     isSearching,
   };
 }

--- a/src/routes/search.tsx
+++ b/src/routes/search.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Search, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { PluginListItem } from "../components/PluginListItem";
+import { PublisherListItem } from "../components/PublisherListItem";
 import { BrowseResultsSkeleton } from "../components/skeletons/BrowseResultsSkeleton";
 import { SkillListItem } from "../components/SkillListItem";
 import { Card } from "../components/ui/card";
@@ -9,6 +10,7 @@ import type { PublicSkill } from "../lib/publicUser";
 import {
   useUnifiedSearch,
   type UnifiedSearchType,
+  type UnifiedCreatorResult,
   type UnifiedPluginResult,
   type UnifiedSkillResult,
 } from "../lib/useUnifiedSearch";
@@ -23,7 +25,10 @@ type SearchState = {
 export const Route = createFileRoute("/search")({
   validateSearch: (search: Record<string, unknown>): SearchState => ({
     q: typeof search.q === "string" && search.q.trim() ? search.q : undefined,
-    type: search.type === "skills" || search.type === "plugins" ? search.type : undefined,
+    type:
+      search.type === "skills" || search.type === "plugins" || search.type === "creators"
+        ? search.type
+        : undefined,
   }),
   component: UnifiedSearchPage,
 });
@@ -47,27 +52,38 @@ function UnifiedSearchPage() {
     results: allResults,
     skillResults,
     pluginResults,
+    creatorResults,
     skillCount,
     pluginCount,
+    creatorCount,
     skillHasMore,
     pluginHasMore,
+    creatorHasMore,
     isSearching,
   } = useUnifiedSearch(search.q ?? "", "all", {
     limits: {
       skills: resultLimit,
       plugins: resultLimit,
+      creators: resultLimit,
     },
   });
-  const results: Array<UnifiedSkillResult | UnifiedPluginResult> =
-    activeType === "all" ? allResults : activeType === "skills" ? skillResults : pluginResults;
-  const allCount = skillCount + pluginCount;
-  const allHasMore = skillHasMore || pluginHasMore;
+  const results: Array<UnifiedSkillResult | UnifiedPluginResult | UnifiedCreatorResult> =
+    activeType === "all"
+      ? allResults
+      : activeType === "skills"
+        ? skillResults
+        : activeType === "plugins"
+          ? pluginResults
+          : creatorResults;
+  const allCount = skillCount + pluginCount + creatorCount;
+  const allHasMore = skillHasMore || pluginHasMore || creatorHasMore;
   const canLoadMore =
     search.q &&
     !isSearching &&
     ((activeType === "all" && allHasMore) ||
       (activeType === "skills" && skillHasMore) ||
-      (activeType === "plugins" && pluginHasMore));
+      (activeType === "plugins" && pluginHasMore) ||
+      (activeType === "creators" && creatorHasMore));
   const hasOtherTypeMatches = activeType !== "all" && allCount > 0;
 
   const handleSearch = (e: React.FormEvent) => {
@@ -119,7 +135,7 @@ function UnifiedSearchPage() {
           <input
             className="browse-search-input"
             type="text"
-            placeholder="Search skills and plugins..."
+            placeholder="Search skills, plugins, and creators..."
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             autoFocus
@@ -159,13 +175,20 @@ function UnifiedSearchPage() {
         >
           Plugins
         </button>
+        <button
+          className={`search-tab${activeType === "creators" ? " is-active" : ""}`}
+          type="button"
+          onClick={() => setType("creators")}
+        >
+          Creators
+        </button>
       </div>
 
       {isSearching ? (
         <BrowseResultsSkeleton count={activeType === "all" ? 8 : 6} />
       ) : !search.q ? (
         <Card className="text-center p-10">
-          <p className="text-ink-soft">Enter a search term to find skills and plugins</p>
+          <p className="text-ink-soft">Enter a search term to find skills, plugins, and creators</p>
         </Card>
       ) : results.length === 0 ? (
         <SearchEmptyState
@@ -192,14 +215,23 @@ function UnifiedSearchPage() {
                   ))}
                 </SearchResultSection>
               ) : null}
+              {creatorResults.length > 0 ? (
+                <SearchResultSection title="Creators">
+                  {creatorResults.map((item) => (
+                    <CreatorResultRow key={`creator-${item.creator._id}`} result={item} />
+                  ))}
+                </SearchResultSection>
+              ) : null}
             </div>
           ) : (
             <div className="results-list">
               {results.map((item) =>
                 item.type === "skill" ? (
                   <SkillResultRow key={`skill-${item.skill._id}`} result={item} />
-                ) : (
+                ) : item.type === "plugin" ? (
                   <PluginResultRow key={`plugin-${item.plugin.name}`} result={item} />
+                ) : (
+                  <CreatorResultRow key={`creator-${item.creator._id}`} result={item} />
                 ),
               )}
             </div>
@@ -232,8 +264,14 @@ function SearchEmptyState({
   onSearchAllTypes: () => void;
   query: string;
 }) {
-  const browseHref = activeType === "plugins" ? "/plugins" : "/skills";
-  const browseLabel = activeType === "plugins" ? "Show all plugins" : "Show all skills";
+  const browseHref =
+    activeType === "plugins" ? "/plugins" : activeType === "creators" ? "/creators" : "/skills";
+  const browseLabel =
+    activeType === "plugins"
+      ? "Show all plugins"
+      : activeType === "creators"
+        ? "Show all creators"
+        : "Show all skills";
 
   return (
     <Card className="search-empty-state">
@@ -270,4 +308,8 @@ function SkillResultRow({ result }: { result: UnifiedSkillResult }) {
 
 function PluginResultRow({ result }: { result: UnifiedPluginResult }) {
   return <PluginListItem item={result.plugin} />;
+}
+
+function CreatorResultRow({ result }: { result: UnifiedCreatorResult }) {
+  return <PublisherListItem publisher={result.creator} />;
 }


### PR DESCRIPTION
## Summary
- add creators as a first-class global search result type in the shared search hook
- show creator groups, rows, and scoped footer navigation in the header typeahead
- add a Creators tab and grouped Creators section on `/search`
- cap creator search load-more behavior at the publisher query page ceiling to avoid a stuck loader

## Proof
- Browser proof captured against the local app with the public read backend; screenshots will be published in a PR comment.

## Tests
- `bunx vitest run src/lib/useUnifiedSearch.test.tsx src/__tests__/header.test.tsx src/__tests__/search-route.test.tsx src/__tests__/ui-design-contract.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
