### PR TITLE
test(skills): cover publisher-scoped slug publish

### DIFF
--- a/convex/skills.ownerMigration.test.ts
+++ b/convex/skills.ownerMigration.test.ts
@@ -804,6 +804,24 @@ describe("skills.insertVersion owner migration", () => {
     });
   });
 
+  it("classifies same-slug publish under another owner as a new scoped skill", async () => {
+    const fixture = createMigrationFixture({
+      skillSource: "other-personal",
+      sourceMemberships: [],
+    });
+
+    const result = await getSkillForPublishPreflightHandler(
+      { db: fixture.db } as never,
+      {
+        userId: "users:caller",
+        slug: "nano",
+        ownerPublisherId: "publishers:org",
+      } as never,
+    );
+
+    expect(result).toBeNull();
+  });
+
   it("rejects an explicit migration when the source owner no longer has the slug", async () => {
     const fixture = createMigrationFixture({
       skillSource: "caller-personal",


### PR DESCRIPTION
## Summary

- Adds regression coverage for publishing a skill slug under a different owner namespace when another publisher already owns the same slug.
- Asserts publish preflight returns `null` for the target owner, so normal publish can create a new scoped skill instead of treating the global slug match as a collision.

## Why

Closes #2363.

## Test plan

- [x] `bunx vitest run convex/skills.ownerMigration.test.ts --reporter=verbose`
