### PR TITLE
test(packages): cover npm-compatible publisher scopes

### DIFF
--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -1,6 +1,10 @@
 import { getAuthUserId } from "@convex-dev/auth/server";
 import { describe, expect, it, vi } from "vitest";
-import { assertCanManageOwnedResource, requirePublisherRole } from "./lib/publishers";
+import {
+  assertCanManageOwnedResource,
+  PUBLISHER_HANDLE_PATTERN,
+  requirePublisherRole,
+} from "./lib/publishers";
 import {
   addMember,
   listPublicPage,
@@ -32,6 +36,15 @@ vi.mock("@convex-dev/auth/server", () => ({
   getAuthUserId: vi.fn(),
   authTables: {},
 }));
+
+describe("publisher handle validation", () => {
+  it("accepts npm-compatible dot and underscore org handles", () => {
+    expect(PUBLISHER_HANDLE_PATTERN.test("bitrouter.ai")).toBe(true);
+    expect(PUBLISHER_HANDLE_PATTERN.test("glin_1")).toBe(true);
+    expect(PUBLISHER_HANDLE_PATTERN.test("pluglab_thinkly")).toBe(true);
+    expect(PUBLISHER_HANDLE_PATTERN.test("souls_market")).toBe(true);
+  });
+});
 
 type WrappedHandler<TArgs, TResult = unknown> = {
   _handler: (ctx: unknown, args: TArgs) => Promise<TResult>;

--- a/packages/schema/src/schemas.test.ts
+++ b/packages/schema/src/schemas.test.ts
@@ -237,6 +237,21 @@ describe("clawhub-schema", () => {
       suggestedName: "@vintageayu/dronzer",
       message: `Package scope "@openclaw" must match selected owner "@vintageayu". Publish as "@openclaw" or rename this package to "@vintageayu/dronzer". More info: ${DocsLinks.clawhub.packageScopeFaq}`,
     });
+
+    expect(inferPackageNameScope("@bitrouter.ai/openclaw-plugin")).toBe("bitrouter.ai");
+    expect(getPackageScopeOwnerMismatch("@bitrouter.ai/openclaw-plugin", "bitrouter.ai")).toBeNull();
+
+    expect(inferPackageNameScope("@glin_1/miniabc")).toBe("glin_1");
+    expect(getPackageScopeOwnerMismatch("@glin_1/miniabc", "@glin_1")).toBeNull();
+
+    expect(
+      getPackageScopeOwnerMismatch(
+        "@pluglab_thinkly/thinkly-openclaw-plugin",
+        "pluglab_thinkly",
+      ),
+    ).toBeNull();
+
+    expect(getPackageScopeOwnerMismatch("@souls_market/openclaw-plugin", "souls_market")).toBeNull();
   });
 
   it("builds OpenClaw docs URLs from normalized paths", () => {


### PR DESCRIPTION
## Summary

- Adds regression coverage for npm-compatible package scopes that contain dots or underscores.
- Asserts ClawHub publisher-handle validation accepts the same dot and underscore handles needed by affected npm scopes.
- Asserts package scope and selected owner matching works for `@bitrouter.ai`, `@glin_1`, `@pluglab_thinkly`, and `@souls_market`.

## Why

Closes #2367.

## Test plan

- [x] `bunx vitest run packages/schema/src/schemas.test.ts convex/publishers.test.ts --reporter=verbose`
