### PR TITLE
ci: run security dataset snapshot on github runner

### DIFF
--- a/.github/workflows/security-dataset-snapshot.yml
+++ b/.github/workflows/security-dataset-snapshot.yml
@@ -53,7 +53,7 @@ concurrency:
 jobs:
   publish-security-dataset:
     name: Publish sanitized security dataset
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 360
     environment: Production
     env:


### PR DESCRIPTION
## Summary
- move `security-dataset-snapshot.yml` from Blacksmith to GitHub-hosted `ubuntu-24.04`

## Context
The last two full publish attempts died during the long `Export sanitized live dataset` step around ~2h, with the step still recorded as in-progress and no script-level error captured. Since this job only needs HTTPS access to production Convex plus HF OIDC upload, it does not need the Blacksmith runner label.

Failed Blacksmith run: https://github.com/openclaw/clawhub/actions/runs/28060972658

## Proof
- `bun -e 'import { parse } from "yaml"; const text = await Bun.file(".github/workflows/security-dataset-snapshot.yml").text(); parse(text); console.log("yaml ok")' && actionlint .github/workflows/security-dataset-snapshot.yml`
- `bun run format:check -- .github/workflows/security-dataset-snapshot.yml`
- `git diff --check`
