### PR TITLE
fix: simplify creator typeahead metadata

### DIFF
--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -496,9 +496,11 @@ describe("Header", () => {
     expect(
       screen.getByText("Weather Plugin").closest(".navbar-search-typeahead-row")?.textContent,
     ).toContain("@local / weather-plugin");
-    expect(
-      screen.getByText("Local Creator").closest(".navbar-search-typeahead-row")?.textContent,
-    ).toContain("@local");
+    const creatorRowText = screen
+      .getByText("Local Creator")
+      .closest(".navbar-search-typeahead-row")?.textContent;
+    expect(creatorRowText).toContain("@local");
+    expect(creatorRowText).not.toContain("/ Org");
     expect(skillGroup.querySelector("svg.lucide-wrench")).not.toBeNull();
     expect(pluginGroup.querySelector("svg.lucide-message-circle")).not.toBeNull();
     expect(creatorGroup.querySelector("svg.lucide-building-2")).not.toBeNull();
@@ -737,6 +739,9 @@ describe("Header", () => {
     );
     expect(creatorRow?.querySelector(".navbar-search-typeahead-meta")?.textContent).toContain(
       "@local",
+    );
+    expect(creatorRow?.querySelector(".navbar-search-typeahead-meta")?.textContent).not.toContain(
+      "/ Org",
     );
     expect(skillRow?.querySelector(".official-badge")).toBeTruthy();
     expect(pluginRow?.querySelector(".official-badge")).toBeTruthy();

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1079,7 +1079,6 @@ function getTypeaheadRowBody(item: TypeaheadItem) {
         <TypeaheadCreatorMeta
           handle={`@${publisher.handle}`}
           official={publisher.official === true}
-          kind={publisher.kind}
         />
       ),
     };
@@ -1109,25 +1108,11 @@ function TypeaheadPublisherMeta({
   );
 }
 
-function TypeaheadCreatorMeta({
-  handle,
-  kind,
-  official,
-}: {
-  handle: string;
-  kind: "user" | "org";
-  official: boolean;
-}) {
+function TypeaheadCreatorMeta({ handle, official }: { handle: string; official: boolean }) {
   return (
     <>
       <span className="navbar-search-typeahead-publisher">{handle}</span>
       {official ? <OfficialBadge /> : null}
-      {kind === "org" ? (
-        <>
-          <span className="navbar-search-typeahead-separator"> / </span>
-          <span className="navbar-search-typeahead-package">Org</span>
-        </>
-      ) : null}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- remove the `/ Org` kind suffix from creator rows in the header global-search typeahead
- keep creator handles and official badges visible beside creator names
- add regression coverage so creator typeahead metadata does not reintroduce `/ Org`

## Proof
- `bunx vitest run src/__tests__/header.test.tsx` failed before the component change with `Local Creator@local / Org`
- `bunx vitest run src/__tests__/header.test.tsx src/__tests__/ui-design-contract.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- Playwright against `http://localhost:3003/` with query `expedia`: creator row rendered as `Expedia Group@expediagroup`, official badge count `1`, `/ Org` absent

Screenshot: `/tmp/clawhub-typeahead-expedia-no-org.png`
