### PR TITLE
ci: chunk security dataset snapshot export

### DIFF
--- a/.github/workflows/security-dataset-snapshot.yml
+++ b/.github/workflows/security-dataset-snapshot.yml
@@ -38,7 +38,7 @@ on:
       shards:
         description: "Created-at shards per source kind"
         required: true
-        default: "24"
+        default: "96"
   schedule:
     - cron: "17 9 * * *"
 
@@ -51,24 +51,141 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  publish-security-dataset:
-    name: Publish sanitized security dataset
+  plan-security-dataset:
+    name: Plan sanitized security dataset shards
     runs-on: ubuntu-24.04
-    timeout-minutes: 360
+    timeout-minutes: 15
     environment: Production
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+      source_snapshot_id: ${{ steps.plan.outputs.source_snapshot_id }}
     env:
       CONVEX_URL: ${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}
       SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}
       HF_DATASET_REPO: OpenClaw/clawhub-security-signals
-      HF_OIDC_RESOURCE: datasets/OpenClaw/clawhub-security-signals
       HF_REVISION: ${{ inputs['hf-revision'] || 'main' }}
       HF_UPLOAD: ${{ github.event_name == 'schedule' || inputs.upload == 'true' }}
       SNAPSHOT_LIMIT: ${{ inputs.limit || '' }}
       SNAPSHOT_PAGE_SIZE: ${{ inputs['page-size'] || '25' }}
       SNAPSHOT_MIN_PAGE_SIZE: ${{ inputs['min-page-size'] || '5' }}
       SNAPSHOT_BATCH_PAGES: ${{ inputs['batch-pages'] || '1' }}
-      SNAPSHOT_CONCURRENCY: ${{ inputs.concurrency || '2' }}
-      SNAPSHOT_SHARDS: ${{ inputs.shards || '24' }}
+      SNAPSHOT_CONCURRENCY: ${{ inputs.concurrency || '1' }}
+      SNAPSHOT_SHARDS: ${{ inputs.shards || '96' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Check configuration
+        run: |
+          set -euo pipefail
+          if [[ -z "$SECURITY_SCAN_WORKER_TOKEN" ]]; then
+            echo "::error::SECURITY_SCAN_WORKER_TOKEN is required"
+            exit 1
+          fi
+          echo "Upload enabled: $HF_UPLOAD"
+          echo "Convex URL: $CONVEX_URL"
+          echo "Hugging Face repo: $HF_DATASET_REPO"
+          echo "Hugging Face revision: $HF_REVISION"
+          echo "Shard count per source kind: $SNAPSHOT_SHARDS"
+
+      - name: Plan live export shards
+        id: plan
+        run: |
+          set -euo pipefail
+          source_snapshot_id="live-convex-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          matrix_path="$RUNNER_TEMP/security-dataset-shards.json"
+          bun scripts/security-dataset/export-snapshot.ts \
+            --convex-url "$CONVEX_URL" \
+            --worker-token "$SECURITY_SCAN_WORKER_TOKEN" \
+            --source-snapshot-id "$source_snapshot_id" \
+            --hf-repo "$HF_DATASET_REPO" \
+            --hf-revision "$HF_REVISION" \
+            --page-size "$SNAPSHOT_PAGE_SIZE" \
+            --min-page-size "$SNAPSHOT_MIN_PAGE_SIZE" \
+            --batch-pages "$SNAPSHOT_BATCH_PAGES" \
+            --concurrency "$SNAPSHOT_CONCURRENCY" \
+            --shards "$SNAPSHOT_SHARDS" \
+            --write-shard-matrix "$matrix_path"
+          echo "source_snapshot_id=$source_snapshot_id" >> "$GITHUB_OUTPUT"
+          echo "matrix=$(jq -c . "$matrix_path")" >> "$GITHUB_OUTPUT"
+          jq '{shard_count: (.include | length), first: .include[0], last: .include[-1]}' "$matrix_path"
+
+  export-security-dataset-shards:
+    name: Export sanitized shard ${{ matrix.index }}
+    needs: plan-security-dataset
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    environment: Production
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix: ${{ fromJson(needs.plan-security-dataset.outputs.matrix) }}
+    env:
+      CONVEX_URL: ${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}
+      SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}
+      HF_DATASET_REPO: OpenClaw/clawhub-security-signals
+      HF_REVISION: ${{ inputs['hf-revision'] || 'main' }}
+      SNAPSHOT_PAGE_SIZE: ${{ inputs['page-size'] || '25' }}
+      SNAPSHOT_MIN_PAGE_SIZE: ${{ inputs['min-page-size'] || '5' }}
+      SNAPSHOT_BATCH_PAGES: ${{ inputs['batch-pages'] || '1' }}
+      SANITIZED_OUT_DIR: /tmp/clawhub-security-dataset/shard
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Export sanitized shard
+        run: |
+          set -euo pipefail
+          mkdir -p "$SANITIZED_OUT_DIR"
+          args=(
+            --convex-url "$CONVEX_URL"
+            --worker-token "$SECURITY_SCAN_WORKER_TOKEN"
+            --source-snapshot-id "${{ needs.plan-security-dataset.outputs.source_snapshot_id }}"
+            --out-dir "$SANITIZED_OUT_DIR"
+            --hf-dataset
+            --hf-repo "$HF_DATASET_REPO"
+            --hf-revision "$HF_REVISION"
+            --source-kind "${{ matrix.sourceKind }}"
+            --created-after "${{ matrix.createdAtGte }}"
+            --created-before "${{ matrix.createdAtLt }}"
+            --page-size "$SNAPSHOT_PAGE_SIZE"
+            --min-page-size "$SNAPSHOT_MIN_PAGE_SIZE"
+            --batch-pages "$SNAPSHOT_BATCH_PAGES"
+            --concurrency 1
+            --shards 1
+          )
+          bun scripts/security-dataset/export-snapshot.ts "${args[@]}" | tee "$SANITIZED_OUT_DIR/summary.json"
+          snapshot_dir="$(jq -r '.snapshotDir' "$SANITIZED_OUT_DIR/summary.json")"
+          if [[ -z "$snapshot_dir" || "$snapshot_dir" == "null" ]]; then
+            echo "::error::export summary did not include snapshotDir"
+            exit 1
+          fi
+          echo "SNAPSHOT_DIR=$snapshot_dir" >> "$GITHUB_ENV"
+          jq '.manifest.row_counts, .manifest.huggingface_dataset' "$SANITIZED_OUT_DIR/summary.json"
+
+      - name: Upload shard artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: security-dataset-shard-${{ matrix.index }}
+          path: ${{ env.SNAPSHOT_DIR }}
+          if-no-files-found: error
+          retention-days: 1
+
+  publish-security-dataset:
+    name: Publish sanitized security dataset
+    needs:
+      - plan-security-dataset
+      - export-security-dataset-shards
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    environment: Production
+    env:
+      HF_DATASET_REPO: OpenClaw/clawhub-security-signals
+      HF_OIDC_RESOURCE: datasets/OpenClaw/clawhub-security-signals
+      HF_REVISION: ${{ inputs['hf-revision'] || 'main' }}
+      HF_UPLOAD: ${{ github.event_name == 'schedule' || inputs.upload == 'true' }}
       SANITIZED_OUT_DIR: /tmp/clawhub-security-dataset/sanitized
       WORK_DIR: /tmp/clawhub-security-dataset
     steps:
@@ -81,45 +198,26 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Check configuration
-        run: |
-          set -euo pipefail
-          if [[ -z "$SECURITY_SCAN_WORKER_TOKEN" ]]; then
-            echo "::error::SECURITY_SCAN_WORKER_TOKEN is required"
-            exit 1
-          fi
-          echo "Upload enabled: $HF_UPLOAD"
-          echo "Convex URL: $CONVEX_URL"
-          echo "Hugging Face repo: $HF_DATASET_REPO"
-          echo "Hugging Face OIDC resource: $HF_OIDC_RESOURCE"
-          echo "Hugging Face revision: $HF_REVISION"
+      - name: Download sanitized shard artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: security-dataset-shard-*
+          path: ${{ env.WORK_DIR }}/shards
 
-      - name: Export sanitized live dataset
+      - name: Merge sanitized shard outputs
         run: |
           set -euo pipefail
           mkdir -p "$SANITIZED_OUT_DIR"
-          source_snapshot_id="live-convex-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          args=(
-            --convex-url "$CONVEX_URL"
-            --worker-token "$SECURITY_SCAN_WORKER_TOKEN"
-            --source-snapshot-id "$source_snapshot_id"
-            --out-dir "$SANITIZED_OUT_DIR"
-            --hf-dataset
-            --hf-repo "$HF_DATASET_REPO"
-            --hf-revision "$HF_REVISION"
-            --page-size "$SNAPSHOT_PAGE_SIZE"
-            --min-page-size "$SNAPSHOT_MIN_PAGE_SIZE"
-            --batch-pages "$SNAPSHOT_BATCH_PAGES"
-            --concurrency "$SNAPSHOT_CONCURRENCY"
-            --shards "$SNAPSHOT_SHARDS"
-          )
-          if [[ -n "$SNAPSHOT_LIMIT" ]]; then
-            args+=(--limit "$SNAPSHOT_LIMIT")
-          fi
-          bun scripts/security-dataset/export-snapshot.ts "${args[@]}" | tee "$SANITIZED_OUT_DIR/summary.json"
+          source_snapshot_id="${{ needs.plan-security-dataset.outputs.source_snapshot_id }}"
+          bun scripts/security-dataset/merge-snapshots.ts \
+            --shards-dir "$WORK_DIR/shards" \
+            --out-dir "$SANITIZED_OUT_DIR" \
+            --source-snapshot-id "$source_snapshot_id" \
+            --hf-repo "$HF_DATASET_REPO" \
+            --hf-revision "$HF_REVISION" | tee "$SANITIZED_OUT_DIR/summary.json"
           snapshot_dir="$(jq -r '.snapshotDir' "$SANITIZED_OUT_DIR/summary.json")"
           if [[ -z "$snapshot_dir" || "$snapshot_dir" == "null" ]]; then
-            echo "::error::export summary did not include snapshotDir"
+            echo "::error::merge summary did not include snapshotDir"
             exit 1
           fi
           echo "SNAPSHOT_DIR=$snapshot_dir" >> "$GITHUB_ENV"

--- a/scripts/security-dataset/export-snapshot.ts
+++ b/scripts/security-dataset/export-snapshot.ts
@@ -80,6 +80,7 @@ type Options = {
   huggingFaceDataset: boolean;
   huggingFaceRepo: string;
   huggingFaceRevision: string;
+  writeShardMatrix: string | null;
 };
 
 type ExportShard = {
@@ -127,6 +128,11 @@ const HF_SPLITS: DatasetSplit[] = ["train", "validation", "test", "eval_holdout"
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
+  if (options.writeShardMatrix) {
+    await writeShardMatrix(options);
+    return;
+  }
+
   const snapshotId = buildSnapshotId(options);
   const snapshotDir = resolve(options.outDir, snapshotId);
   const writers = options.dryRun ? null : await openSnapshotWriters(snapshotDir, options);
@@ -162,6 +168,31 @@ async function main() {
     if (writers && !writersClosed) await closeSnapshotWriters(writers).catch(() => {});
     throw error;
   }
+}
+
+async function writeShardMatrix(options: Options) {
+  const shards = await buildExportShards(options);
+  const matrix = {
+    include: shards.map((shard, index) => ({
+      index,
+      sourceKind: shard.sourceKind,
+      createdAtGte: shard.createdAtGte,
+      createdAtLt: shard.createdAtLt,
+      label: shard.label,
+    })),
+  };
+  await writeFile(options.writeShardMatrix!, `${JSON.stringify(matrix, null, 2)}\n`);
+  console.log(
+    JSON.stringify(
+      {
+        shardCount: shards.length,
+        matrixPath: options.writeShardMatrix,
+        sourceKinds: Array.from(new Set(shards.map((shard) => shard.sourceKind))).sort(),
+      },
+      null,
+      2,
+    ),
+  );
 }
 
 async function exportRemoteShards(input: {
@@ -832,6 +863,7 @@ function parseArgs(args: string[]): Options {
     huggingFaceDataset: false,
     huggingFaceRepo: process.env.HF_DATASET_REPO ?? "OpenClaw/clawhub-security-signals",
     huggingFaceRevision: process.env.HF_REVISION ?? "main",
+    writeShardMatrix: null,
   };
 
   for (let index = 0; index < args.length; index += 1) {
@@ -878,6 +910,8 @@ function parseArgs(args: string[]): Options {
       options.huggingFaceRepo = readValue(args, ++index, arg);
     } else if (arg === "--hf-revision") {
       options.huggingFaceRevision = readValue(args, ++index, arg);
+    } else if (arg === "--write-shard-matrix") {
+      options.writeShardMatrix = readValue(args, ++index, arg);
     } else if (arg === "--mode") {
       const mode = readValue(args, ++index, arg);
       if (mode !== "public") throw new Error(`Unsupported mode: ${mode}`);

--- a/scripts/security-dataset/merge-snapshots.ts
+++ b/scripts/security-dataset/merge-snapshots.ts
@@ -1,0 +1,327 @@
+import { spawnSync } from "node:child_process";
+import { once } from "node:events";
+import { createReadStream, createWriteStream, type WriteStream } from "node:fs";
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { buildSecurityDatasetManifest } from "./manifest";
+
+type DatasetSplit = "train" | "validation" | "test" | "eval_holdout";
+
+type Options = {
+  shardsDir: string;
+  outDir: string;
+  snapshotId: string | null;
+  sourceSnapshotId: string | null;
+  huggingFaceRepo: string;
+  huggingFaceRevision: string;
+};
+
+type ShardManifest = {
+  snapshot_id: string;
+  source_snapshot_id: string;
+  created_at: string;
+  repo_git_sha: string;
+  convex_deployment: string;
+  export_mode: "public";
+  page_size: number;
+  concurrency: number;
+  shards: number;
+  shard_count: number;
+  row_counts: {
+    source_artifacts: number;
+    artifacts: number;
+    scan_results: number;
+    static_findings: number;
+    clawscan_findings: number;
+    labels: number;
+    splits: number;
+    huggingface_rows: number;
+  };
+  scanner_versions: string[];
+  model_names: string[];
+  redaction_policy_version: string;
+  source_tables: string[];
+  created_time_window: {
+    created_at_gte: number | null;
+    created_at_lt: number | null;
+  };
+  huggingface_dataset: {
+    rowCountsBySplit?: Record<DatasetSplit, number>;
+    row_counts_by_split?: Record<DatasetSplit, number>;
+  } | null;
+};
+
+const JSONL_FILES = [
+  "artifacts.jsonl",
+  "scan_results.jsonl",
+  "static_findings.jsonl",
+  "clawscan_findings.jsonl",
+  "labels.jsonl",
+  "splits.jsonl",
+] as const;
+const HF_SPLITS: DatasetSplit[] = ["train", "validation", "test", "eval_holdout"];
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const shardManifests = await findShardManifests(resolve(options.shardsDir));
+  if (shardManifests.length === 0) {
+    throw new Error(`No shard manifests found under ${options.shardsDir}`);
+  }
+
+  const snapshotId = options.snapshotId ?? buildSnapshotId();
+  const snapshotDir = resolve(options.outDir, snapshotId);
+  await mkdir(join(snapshotDir, "hf-dataset", "data"), { recursive: true });
+
+  const manifests: Array<{ path: string; dir: string; manifest: ShardManifest }> = [];
+  for (const manifestPath of shardManifests.sort()) {
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as ShardManifest;
+    manifests.push({ path: manifestPath, dir: dirname(manifestPath), manifest });
+  }
+
+  await concatenateSnapshotFiles(manifests, snapshotDir);
+  const outputSizes = await collectOutputSizes(snapshotDir);
+  const manifest = buildMergedManifest({ options, manifests, snapshotId, outputSizes });
+  await writeFile(join(snapshotDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+
+  console.log(JSON.stringify({ snapshotId, snapshotDir, manifest }, null, 2));
+}
+
+async function concatenateSnapshotFiles(
+  manifests: Array<{ dir: string; manifest: ShardManifest }>,
+  snapshotDir: string,
+) {
+  for (const file of JSONL_FILES) {
+    const writer = createWriteStream(join(snapshotDir, file), { encoding: "utf8" });
+    await concatenateFiles(
+      writer,
+      manifests.map(({ dir }) => join(dir, file)),
+    );
+  }
+
+  for (const split of HF_SPLITS) {
+    const writer = createWriteStream(join(snapshotDir, "hf-dataset", "data", `${split}.jsonl`), {
+      encoding: "utf8",
+    });
+    await concatenateFiles(
+      writer,
+      manifests.map(({ dir }) => join(dir, "hf-dataset", "data", `${split}.jsonl`)),
+    );
+  }
+}
+
+async function concatenateFiles(writer: WriteStream, paths: string[]) {
+  try {
+    for (const path of paths) {
+      if (!(await isFile(path))) continue;
+      const reader = createReadStream(path, { encoding: "utf8" });
+      for await (const chunk of reader) {
+        if (!writer.write(chunk)) await once(writer, "drain");
+      }
+    }
+  } finally {
+    writer.end();
+    await once(writer, "finish");
+  }
+}
+
+function buildMergedManifest(input: {
+  options: Options;
+  manifests: Array<{ manifest: ShardManifest }>;
+  snapshotId: string;
+  outputSizes: Record<string, number>;
+}) {
+  const { options, manifests, snapshotId, outputSizes } = input;
+  const first = manifests[0]!.manifest;
+  const rowCounts = sumRowCounts(manifests.map(({ manifest }) => manifest));
+  const rowCountsBySplit = sumHuggingFaceSplitCounts(manifests.map(({ manifest }) => manifest));
+  return buildSecurityDatasetManifest({
+    snapshotId,
+    sourceSnapshotId: options.sourceSnapshotId ?? snapshotId,
+    createdAt: new Date().toISOString(),
+    repoGitSha: gitSha(),
+    convexDeployment: first.convex_deployment,
+    exportMode: "public",
+    pageSize: first.page_size,
+    concurrency: 1,
+    shards: manifests.length,
+    shardCount: manifests.reduce((sum, { manifest }) => sum + manifest.shard_count, 0),
+    rowCounts: {
+      sourceArtifacts: rowCounts.source_artifacts,
+      artifacts: rowCounts.artifacts,
+      scanResults: rowCounts.scan_results,
+      staticFindings: rowCounts.static_findings,
+      clawScanFindings: rowCounts.clawscan_findings,
+      labels: rowCounts.labels,
+      splits: rowCounts.splits,
+      huggingFaceRows: rowCounts.huggingface_rows,
+    },
+    outputSizes,
+    scannerVersions: uniqueSorted(manifests.flatMap(({ manifest }) => manifest.scanner_versions)),
+    modelNames: uniqueSorted(manifests.flatMap(({ manifest }) => manifest.model_names)),
+    redactionPolicyVersion: first.redaction_policy_version,
+    sourceTables: first.source_tables,
+    timeWindow: mergeTimeWindows(manifests.map(({ manifest }) => manifest)),
+    huggingFaceDataset: {
+      repo: options.huggingFaceRepo,
+      revision: options.huggingFaceRevision,
+      commit: null,
+      configNames: ["default"],
+      splitNames: HF_SPLITS,
+      rowCountsBySplit,
+    },
+  });
+}
+
+function sumRowCounts(manifests: ShardManifest[]) {
+  return manifests.reduce(
+    (sum, manifest) => ({
+      source_artifacts: sum.source_artifacts + manifest.row_counts.source_artifacts,
+      artifacts: sum.artifacts + manifest.row_counts.artifacts,
+      scan_results: sum.scan_results + manifest.row_counts.scan_results,
+      static_findings: sum.static_findings + manifest.row_counts.static_findings,
+      clawscan_findings: sum.clawscan_findings + manifest.row_counts.clawscan_findings,
+      labels: sum.labels + manifest.row_counts.labels,
+      splits: sum.splits + manifest.row_counts.splits,
+      huggingface_rows: sum.huggingface_rows + manifest.row_counts.huggingface_rows,
+    }),
+    {
+      source_artifacts: 0,
+      artifacts: 0,
+      scan_results: 0,
+      static_findings: 0,
+      clawscan_findings: 0,
+      labels: 0,
+      splits: 0,
+      huggingface_rows: 0,
+    },
+  );
+}
+
+function sumHuggingFaceSplitCounts(manifests: ShardManifest[]): Record<DatasetSplit, number> {
+  const counts = { train: 0, validation: 0, test: 0, eval_holdout: 0 };
+  for (const manifest of manifests) {
+    const shardCounts =
+      manifest.huggingface_dataset?.rowCountsBySplit ??
+      manifest.huggingface_dataset?.row_counts_by_split ??
+      counts;
+    for (const split of HF_SPLITS) {
+      counts[split] += shardCounts[split] ?? 0;
+    }
+  }
+  return counts;
+}
+
+function mergeTimeWindows(manifests: ShardManifest[]) {
+  const starts = manifests
+    .map((manifest) => manifest.created_time_window.created_at_gte)
+    .filter((value): value is number => typeof value === "number");
+  const ends = manifests
+    .map((manifest) => manifest.created_time_window.created_at_lt)
+    .filter((value): value is number => typeof value === "number");
+  return {
+    createdAtGte: starts.length === 0 ? null : Math.min(...starts),
+    createdAtLt: ends.length === 0 ? null : Math.max(...ends),
+  };
+}
+
+async function findShardManifests(root: string): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true });
+  const manifests: string[] = [];
+  for (const entry of entries) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) {
+      manifests.push(...(await findShardManifests(path)));
+    } else if (entry.isFile() && entry.name === "manifest.json") {
+      manifests.push(path);
+    }
+  }
+  return manifests;
+}
+
+async function collectOutputSizes(root: string) {
+  const sizes: Record<string, number> = {};
+  await collectOutputSizesInto(root, root, sizes);
+  return sizes;
+}
+
+async function collectOutputSizesInto(root: string, dir: string, sizes: Record<string, number>) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await collectOutputSizesInto(root, path, sizes);
+    } else if (entry.isFile()) {
+      sizes[path.slice(root.length + 1)] = (await stat(path)).size;
+    }
+  }
+}
+
+async function isFile(path: string) {
+  try {
+    return (await stat(path)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function uniqueSorted(values: string[]) {
+  return Array.from(new Set(values)).sort();
+}
+
+function buildSnapshotId() {
+  const timestamp = new Date()
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d{3}Z$/, "Z");
+  return `clawhub-merged-${timestamp}-${gitSha().slice(0, 8)}`;
+}
+
+function gitSha() {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" });
+  if (result.status !== 0) return "unknown";
+  return result.stdout.trim();
+}
+
+function parseArgs(args: string[]): Options {
+  const options: Options = {
+    shardsDir: "",
+    outDir: ".data/security-dataset/merged",
+    snapshotId: null,
+    sourceSnapshotId: null,
+    huggingFaceRepo: process.env.HF_DATASET_REPO ?? "OpenClaw/clawhub-security-signals",
+    huggingFaceRevision: process.env.HF_REVISION ?? "main",
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--shards-dir") {
+      options.shardsDir = readValue(args, ++index, arg);
+    } else if (arg === "--out-dir") {
+      options.outDir = readValue(args, ++index, arg);
+    } else if (arg === "--snapshot-id") {
+      options.snapshotId = readValue(args, ++index, arg);
+    } else if (arg === "--source-snapshot-id") {
+      options.sourceSnapshotId = readValue(args, ++index, arg);
+    } else if (arg === "--hf-repo") {
+      options.huggingFaceRepo = readValue(args, ++index, arg);
+    } else if (arg === "--hf-revision") {
+      options.huggingFaceRevision = readValue(args, ++index, arg);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!options.shardsDir) throw new Error("--shards-dir is required.");
+  return options;
+}
+
+function readValue(args: string[], index: number, flag: string) {
+  const value = args[index];
+  if (!value) throw new Error(`Missing value for ${flag}`);
+  return value;
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/security-dataset/mergeSnapshots.test.ts
+++ b/scripts/security-dataset/mergeSnapshots.test.ts
@@ -1,0 +1,163 @@
+/* @vitest-environment node */
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { buildSecurityDatasetManifest } from "./manifest";
+
+const execFileAsync = promisify(execFile);
+
+describe("security dataset snapshot merge CLI", () => {
+  it("merges shard manifests and Hugging Face split files", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "clawhub-security-dataset-merge-"));
+    try {
+      const shardsDir = join(directory, "shards");
+      const outDir = join(directory, "out");
+      await writeShardSnapshot(shardsDir, "shard-a", {
+        sourceArtifacts: 1,
+        split: "train",
+        rowId: "row-a",
+        createdAtGte: 100,
+        createdAtLt: 200,
+      });
+      await writeShardSnapshot(shardsDir, "shard-b", {
+        sourceArtifacts: 2,
+        split: "test",
+        rowId: "row-b",
+        createdAtGte: 200,
+        createdAtLt: 300,
+      });
+
+      const result = await execFileAsync(
+        "bun",
+        [
+          "scripts/security-dataset/merge-snapshots.ts",
+          "--shards-dir",
+          shardsDir,
+          "--out-dir",
+          outDir,
+          "--source-snapshot-id",
+          "live-convex-test-1",
+          "--hf-repo",
+          "OpenClaw/clawhub-security-signals",
+          "--hf-revision",
+          "main",
+        ],
+        {
+          cwd: process.cwd(),
+          encoding: "utf8",
+          maxBuffer: 16 * 1024 * 1024,
+        },
+      );
+
+      const summary: {
+        snapshotDir: string;
+        manifest: {
+          source_snapshot_id: string;
+          row_counts: { source_artifacts: number; huggingface_rows: number };
+          created_time_window: { created_at_gte: number; created_at_lt: number };
+          huggingface_dataset: { rowCountsBySplit: Record<string, number> };
+        };
+      } = JSON.parse(result.stdout);
+
+      expect(summary.manifest.source_snapshot_id).toBe("live-convex-test-1");
+      expect(summary.manifest.row_counts.source_artifacts).toBe(3);
+      expect(summary.manifest.row_counts.huggingface_rows).toBe(3);
+      expect(summary.manifest.created_time_window).toEqual({
+        created_at_gte: 100,
+        created_at_lt: 300,
+      });
+      expect(summary.manifest.huggingface_dataset.rowCountsBySplit).toMatchObject({
+        train: 1,
+        test: 2,
+      });
+
+      await expect(
+        readFile(join(summary.snapshotDir, "hf-dataset", "data", "train.jsonl"), "utf8"),
+      ).resolves.toContain('"id":"row-a"');
+      await expect(
+        readFile(join(summary.snapshotDir, "hf-dataset", "data", "test.jsonl"), "utf8"),
+      ).resolves.toContain('"id":"row-b"');
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});
+
+async function writeShardSnapshot(
+  root: string,
+  name: string,
+  input: {
+    sourceArtifacts: number;
+    split: "train" | "test";
+    rowId: string;
+    createdAtGte: number;
+    createdAtLt: number;
+  },
+) {
+  const dir = join(root, name);
+  await mkdir(join(dir, "hf-dataset", "data"), { recursive: true });
+  for (const file of [
+    "artifacts.jsonl",
+    "scan_results.jsonl",
+    "static_findings.jsonl",
+    "clawscan_findings.jsonl",
+    "labels.jsonl",
+    "splits.jsonl",
+  ]) {
+    await writeFile(join(dir, file), "");
+  }
+  for (const split of ["train", "validation", "test", "eval_holdout"]) {
+    const rowCount = split === input.split ? input.sourceArtifacts : 0;
+    const rows = Array.from({ length: rowCount }, (_, index) =>
+      JSON.stringify({ id: index === 0 ? input.rowId : `${input.rowId}-${index}` }),
+    );
+    await writeFile(join(dir, "hf-dataset", "data", `${split}.jsonl`), rows.join("\n"));
+  }
+  const manifest = buildSecurityDatasetManifest({
+    snapshotId: name,
+    sourceSnapshotId: name,
+    createdAt: new Date(0).toISOString(),
+    repoGitSha: "abc123",
+    convexDeployment: "wry-manatee-359",
+    exportMode: "public",
+    pageSize: 25,
+    concurrency: 1,
+    shards: 1,
+    shardCount: 1,
+    rowCounts: {
+      sourceArtifacts: input.sourceArtifacts,
+      artifacts: input.sourceArtifacts,
+      scanResults: 0,
+      staticFindings: 0,
+      clawScanFindings: 0,
+      labels: 0,
+      splits: input.sourceArtifacts,
+      huggingFaceRows: input.sourceArtifacts,
+    },
+    scannerVersions: [],
+    modelNames: [],
+    redactionPolicyVersion: "public-signals-v2-bundle-files",
+    sourceTables: ["skillVersions"],
+    timeWindow: {
+      createdAtGte: input.createdAtGte,
+      createdAtLt: input.createdAtLt,
+    },
+    huggingFaceDataset: {
+      repo: "OpenClaw/clawhub-security-signals",
+      revision: "main",
+      commit: null,
+      configNames: ["default"],
+      splitNames: ["train", "validation", "test", "eval_holdout"],
+      rowCountsBySplit: {
+        train: input.split === "train" ? input.sourceArtifacts : 0,
+        validation: 0,
+        test: input.split === "test" ? input.sourceArtifacts : 0,
+        eval_holdout: 0,
+      },
+    },
+  });
+  await writeFile(join(dir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+}


### PR DESCRIPTION
## Summary
- split the security dataset snapshot workflow into plan -> shard export matrix -> merge/guardrail/upload
- add `--write-shard-matrix` to the live exporter so the workflow can create deterministic source/time shard jobs from production bounds
- add `merge-snapshots.ts` to assemble shard artifacts back into the existing normalized + HF dataset shape and manifest

## Context
Both single-runner publish attempts failed before HF upload:
- Blacksmith run died during export after ~2h08: https://github.com/openclaw/clawhub/actions/runs/28060972658
- GitHub-hosted retry was cancelled during export after ~94m: https://github.com/openclaw/clawhub/actions/runs/28075073709

The GitHub-hosted logs showed steady progress to 17,210 artifacts, then `##[error]The operation was canceled.` No Convex timeout or script stack trace was captured. This patch makes each export unit bounded and uploads shard artifacts before the final assemble/upload job.

## Proof
- `bunx vitest run scripts/security-dataset/exportSnapshotCli.test.ts scripts/security-dataset/mergeSnapshots.test.ts scripts/security-dataset/huggingFaceExport.test.ts scripts/security-dataset/manifest.test.ts convex/securityDatasetNode.test.ts`
- `bun -e 'import { parse } from "yaml"; const text = await Bun.file(".github/workflows/security-dataset-snapshot.yml").text(); parse(text); console.log("yaml ok")' && actionlint .github/workflows/security-dataset-snapshot.yml`
- `bun run format:check -- .github/workflows/security-dataset-snapshot.yml scripts/security-dataset/export-snapshot.ts scripts/security-dataset/merge-snapshots.ts scripts/security-dataset/mergeSnapshots.test.ts`
- `git diff --check && bunx tsc --noEmit --pretty false`
