### PR TITLE
fix(web): refresh plugin validation panel

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -103,6 +103,7 @@ import type * as lib_reservedSlugs from "../lib/reservedSlugs.js";
 import type * as lib_retentionPolicy from "../lib/retentionPolicy.js";
 import type * as lib_searchText from "../lib/searchText.js";
 import type * as lib_securityPrompt from "../lib/securityPrompt.js";
+import type * as lib_securityScanPolicy from "../lib/securityScanPolicy.js";
 import type * as lib_skillBackfill from "../lib/skillBackfill.js";
 import type * as lib_skillCards from "../lib/skillCards.js";
 import type * as lib_skillDownloadBackfill from "../lib/skillDownloadBackfill.js";
@@ -255,6 +256,7 @@ declare const fullApi: ApiFromModules<{
   "lib/retentionPolicy": typeof lib_retentionPolicy;
   "lib/searchText": typeof lib_searchText;
   "lib/securityPrompt": typeof lib_securityPrompt;
+  "lib/securityScanPolicy": typeof lib_securityScanPolicy;
   "lib/skillBackfill": typeof lib_skillBackfill;
   "lib/skillCards": typeof lib_skillCards;
   "lib/skillDownloadBackfill": typeof lib_skillDownloadBackfill;

--- a/e2e/local-auth/plugin-inspector-findings.pw.test.ts
+++ b/e2e/local-auth/plugin-inspector-findings.pw.test.ts
@@ -277,7 +277,8 @@ test("plugin inspector blocks hard publish errors and publishes warning findings
       hasText: /^legacy-before-agent-start$/,
     }),
   ).toBeVisible();
-  await expect(page.getByText(/Warning · Deprecated API · P2/)).toBeVisible();
+  await expect(page.getByText(/Deprecated API/)).toBeVisible();
+  await expect(page.getByText(/legacy-before-agent-start/)).toBeVisible();
   await expect(page.getByText(/before_agent_start hook compatibility/i)).toBeVisible();
   await captureProof(page, testInfo, "04-plugin-public-warnings");
 

--- a/e2e/local-auth/plugin-inspector-findings.pw.test.ts
+++ b/e2e/local-auth/plugin-inspector-findings.pw.test.ts
@@ -139,21 +139,21 @@ async function expectDashboardWarningLink(page: Page, warningName: string) {
   return dashboardWarningLink;
 }
 
-async function expectValidationTabSelected(page: Page, warningName: string) {
+async function expectValidationSectionVisible(page: Page, warningName: string) {
   const detailHref = buildPluginValidationHref(warningName);
-  const validationTab = page.getByRole("tab", { name: /Validation \(\d+\)/ });
+  const validationSection = page.locator("#validation");
 
   for (let attempt = 1; attempt <= 6; attempt += 1) {
     await waitForHydration(page).catch(() => {});
-    if ((await validationTab.count()) > 0) {
-      await expect(validationTab).toHaveAttribute("aria-selected", "true", { timeout: 10_000 });
+    if ((await validationSection.count()) > 0) {
+      await expect(validationSection).toBeVisible({ timeout: 10_000 });
       return;
     }
     await page.goto(detailHref, { waitUntil: "domcontentloaded" });
     await page.waitForTimeout(500 * attempt);
   }
 
-  await expect(validationTab).toHaveAttribute("aria-selected", "true", { timeout: 10_000 });
+  await expect(validationSection).toBeVisible({ timeout: 10_000 });
 }
 
 async function publishWarningPluginWithRetry(args: {
@@ -271,13 +271,13 @@ test("plugin inspector blocks hard publish errors and publishes warning findings
   await expect(page).toHaveURL(
     new RegExp(`${escapeRegExp(buildPluginValidationHref(warningName))}$`),
   );
-  await expectValidationTabSelected(page, warningName);
+  await expectValidationSectionVisible(page, warningName);
   await expect(
-    page.locator(".plugin-warning-item-header code").filter({
+    page.locator(".plugin-warning-item-code").filter({
       hasText: /^legacy-before-agent-start$/,
     }),
   ).toBeVisible();
-  await expect(page.getByText("deprecation-warning")).toBeVisible();
+  await expect(page.getByText(/Warning · Deprecated API · P2/)).toBeVisible();
   await expect(page.getByText(/before_agent_start hook compatibility/i)).toBeVisible();
   await captureProof(page, testInfo, "04-plugin-public-warnings");
 

--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { createRequire } from "node:module";
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { getFunctionName } from "convex/server";
 import type { AnchorHTMLAttributes, ComponentType, ReactNode } from "react";
 import { toast } from "sonner";
@@ -140,13 +140,6 @@ vi.mock("../components/MarkdownPreview", () => ({
     className?: string;
     highlight?: boolean;
   }) => <div>{children}</div>,
-}));
-
-vi.mock("../components/ui/tooltip", () => ({
-  Tooltip: ({ children }: { children: ReactNode }) => children,
-  TooltipContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  TooltipProvider: ({ children }: { children: ReactNode }) => children,
-  TooltipTrigger: ({ children }: { children: ReactNode }) => children,
 }));
 
 async function loadRoute() {
@@ -1550,7 +1543,8 @@ describe("plugin detail route", () => {
     expect(screen.getByText("ClawPack")).toBeTruthy();
     expect(screen.getByText("demo-plugin-1.0.0.tgz")).toBeTruthy();
     expect(screen.getByText("sha512-demo")).toBeTruthy();
-    expect(screen.getByText("openclaw plugins install clawhub:demo-plugin")).toBeTruthy();
+    expect(screen.getByText("openclaw plugins install")).toBeTruthy();
+    expect(screen.getByText("clawhub:demo-plugin")).toBeTruthy();
     expect(screen.getByRole("link", { name: /Download/i }).getAttribute("href")).toBe(
       "/api/v1/packages/demo-plugin/versions/1.0.0/artifact/download",
     );
@@ -1775,16 +1769,38 @@ describe("plugin detail route", () => {
 
     render(<Component />);
 
-    expect(screen.getByRole("region", { name: "Validation findings" })).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Validation findings", level: 2 })).toBeTruthy();
+    expect(screen.getByRole("region", { name: "Validation" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Validation", level: 2 })).toBeTruthy();
     expect(screen.queryByRole("tab", { name: /Validation/ })).toBeNull();
     expect(screen.queryByRole("link", { name: "2 warnings" })).toBeNull();
+    expect(screen.getByText("Validate locally before publishing")).toBeTruthy();
     expect(screen.getByText("clawhub package validate <path-to-plugin>")).toBeTruthy();
-    expect(screen.getByText(/Run locally/)).toBeTruthy();
+    expect(screen.getByRole("toolbar", { name: "Validation actions" })).toBeTruthy();
+    expect(document.getElementById("validation-toolbar-cli")?.getAttribute("aria-labelledby")).toBe(
+      "validation-toolbar-label",
+    );
+    const titleActions = document.querySelector(".plugin-validation-panel-title-actions");
+    expect(titleActions?.querySelector(".plugin-validation-panel-stats")).toBeTruthy();
+    expect(titleActions?.textContent).toMatch(/0 errors/);
+    expect(titleActions?.textContent).toMatch(/1 warning/);
+    expect(titleActions?.querySelector(".plugin-validation-panel-agent")).toBeNull();
+    const validationToolbar = screen.getByRole("toolbar", { name: "Validation actions" });
+    const commandBlock = validationToolbar.querySelector(".plugin-validation-command-block");
+    expect(commandBlock?.querySelector(".plugin-validation-toolbar-label")).toBeTruthy();
+    expect(validationToolbar.querySelector(":scope > .plugin-validation-toolbar-label")).toBeNull();
+    expect(validationToolbar.querySelector(".plugin-validation-toolbar-agent")).toBeTruthy();
+    expect(
+      within(validationToolbar as HTMLElement).getByRole("button", {
+        name: "Copy fix instructions",
+      }),
+    ).toBeTruthy();
     expect(screen.getByRole("button", { name: "Copy validate command" })).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Copy agent fix prompt" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Copy fix instructions" })).toBeTruthy();
+    expect(screen.getByText("Copy instructions")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Agent" })).toBeNull();
     expect(screen.getByText("legacy-before-agent-start")).toBeTruthy();
-    expect(screen.getByText(/Warning · Deprecated API · P2/)).toBeTruthy();
+    expect(screen.getByText(/Deprecated API/)).toBeTruthy();
+    expect(screen.queryByText(/Warning · Deprecated API · P2/)).toBeNull();
     expect(screen.queryByText("deprecation-warning")).toBeNull();
     expect(screen.queryByText("missing-expected-seam")).toBeNull();
     expect(screen.queryByText("registerTool is no longer available")).toBeNull();
@@ -1793,9 +1809,21 @@ describe("plugin detail route", () => {
     expect(screen.getByRole("link", { name: "View fix guide ↗" }).getAttribute("href")).toBe(
       "https://docs.openclaw.ai/clawhub/plugin-validation-fixes#legacy-before-agent-start",
     );
-    expect(screen.getByText(/Release v1\.0\.0 · Target OpenClaw 0\.9\.0/)).toBeTruthy();
+    const validationRegion = screen.getByRole("region", { name: "Validation" });
+    expect(within(validationRegion).getByText("Release")).toBeTruthy();
+    expect(within(validationRegion).getByText("v1.0.0")).toBeTruthy();
+    expect(within(validationRegion).getByText("Target")).toBeTruthy();
+    expect(within(validationRegion).getByText("OpenClaw 0.9.0")).toBeTruthy();
     expect(screen.getByText(/Legacy before_agent_start hook is deprecated\./)).toBeTruthy();
-    expect(screen.getByText(/No blocking errors\. 1 warning should be reviewed\./)).toBeTruthy();
+    expect(screen.getByText(/Hey, we found/)).toBeTruthy();
+    expect(screen.getByText("1 issue")).toBeTruthy();
+    expect(
+      within(screen.getByRole("region", { name: "Validation" })).getByText("demo-plugin"),
+    ).toBeTruthy();
+    expect(screen.getByText(/version 1\.0\.0/)).toBeTruthy();
+    expect(
+      screen.getByText(/Review the findings below, apply the fix, and upload a new version\./),
+    ).toBeTruthy();
   });
 
   it("does not show validation outputs to signed-out viewers when the hash changes", async () => {

--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -1675,7 +1675,7 @@ describe("plugin detail route", () => {
     expect(screen.queryByText("missing-expected-seam")).toBeNull();
   });
 
-  it("shows validation outputs to plugin managers on the validation tab", async () => {
+  it("shows validation outputs to plugin managers above the detail tabs", async () => {
     useAuthStatusMock.mockReturnValue({
       isAuthenticated: true,
       isLoading: false,
@@ -1775,32 +1775,27 @@ describe("plugin detail route", () => {
 
     render(<Component />);
 
-    expect(screen.getByRole("tab", { name: "Validation (1)" })).toBeTruthy();
+    expect(screen.getByRole("region", { name: "Validation findings" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Validation findings", level: 2 })).toBeTruthy();
+    expect(screen.queryByRole("tab", { name: /Validation/ })).toBeNull();
     expect(screen.queryByRole("link", { name: "2 warnings" })).toBeNull();
-    expect(
-      screen.getByText(
-        /Validation outputs are only visible to plugin owners and admins. Run locally using the CLI:/,
-      ),
-    ).toBeTruthy();
     expect(screen.getByText("clawhub package validate <path-to-plugin>")).toBeTruthy();
+    expect(screen.getByText(/Run locally/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Copy validate command" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Copy agent fix prompt" })).toBeTruthy();
     expect(screen.getByText("legacy-before-agent-start")).toBeTruthy();
+    expect(screen.getByText(/Warning · Deprecated API · P2/)).toBeTruthy();
+    expect(screen.queryByText("deprecation-warning")).toBeNull();
     expect(screen.queryByText("missing-expected-seam")).toBeNull();
     expect(screen.queryByText("registerTool is no longer available")).toBeNull();
     expect(screen.queryByText("Inspector")).toBeNull();
     expect(screen.queryByText("Scan")).toBeNull();
-    expect(screen.getByText("Fix")).toBeTruthy();
-    expect(
-      screen.getByText("Replace the legacy before_agent_start hook with current prompt hooks."),
-    ).toBeTruthy();
-    expect(
-      screen
-        .getByRole("link", {
-          name: "https://docs.openclaw.ai/clawhub/plugin-validation-fixes#legacy-before-agent-start",
-        })
-        .getAttribute("href"),
-    ).toBe("https://docs.openclaw.ai/clawhub/plugin-validation-fixes#legacy-before-agent-start");
-    expect(screen.getByText("Docs")).toBeTruthy();
-    expect(screen.getAllByText("OpenClaw 0.9.0").length).toBeGreaterThan(0);
+    expect(screen.getByRole("link", { name: "View fix guide ↗" }).getAttribute("href")).toBe(
+      "https://docs.openclaw.ai/clawhub/plugin-validation-fixes#legacy-before-agent-start",
+    );
+    expect(screen.getByText(/Release v1\.0\.0 · Target OpenClaw 0\.9\.0/)).toBeTruthy();
+    expect(screen.getByText(/Legacy before_agent_start hook is deprecated\./)).toBeTruthy();
+    expect(screen.getByText(/No blocking errors\. 1 warning should be reviewed\./)).toBeTruthy();
   });
 
   it("does not show validation outputs to signed-out viewers when the hash changes", async () => {

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -1110,9 +1110,8 @@ describe("SkillDetailPage", () => {
     expect(sidebarMetadata).toBeTruthy();
 
     expect(screen.getAllByRole("heading", { name: "Install" }).length).toBeGreaterThan(0);
-    expect(screen.getAllByText("openclaw skills install @steipete/weather").length).toBeGreaterThan(
-      0,
-    );
+    expect(screen.getAllByText("openclaw skills install").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("@steipete/weather").length).toBeGreaterThan(0);
     expect(screen.queryByText("npx clawhub@latest install @steipete/weather")).toBeNull();
     expect(screen.queryByRole("tab", { name: "ClawHub" })).toBeNull();
     expect(screen.getByRole("tab", { name: "CLI" }).getAttribute("aria-selected")).toBe("true");

--- a/src/components/InstallCopyButton.tsx
+++ b/src/components/InstallCopyButton.tsx
@@ -2,6 +2,7 @@ import { Check, Copy } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { cn } from "../lib/utils";
 import { Button } from "./ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
 
 type CopyState = "idle" | "copied" | "failed";
 
@@ -36,12 +37,16 @@ export function InstallCopyButton({
   text,
   label = "Copy",
   ariaLabel,
+  title,
+  tooltip,
   className,
   showLabel = true,
 }: {
   text: string;
   label?: string;
   ariaLabel?: string;
+  title?: string;
+  tooltip?: string;
   className?: string;
   showLabel?: boolean;
 }) {
@@ -71,13 +76,14 @@ export function InstallCopyButton({
   const buttonLabel =
     copyState === "copied" ? "Copied" : copyState === "failed" ? "Copy Failed" : label;
 
-  return (
+  const button = (
     <Button
       type="button"
       size="sm"
       variant="outline"
       className={cn("skill-install-copy-button", className)}
       aria-label={ariaLabel ?? label}
+      title={tooltip ? undefined : title}
       data-copy-state={copyState}
       onClick={() => {
         void copyText(text)
@@ -98,5 +104,20 @@ export function InstallCopyButton({
       )}
       {showLabel ? <span aria-live="polite">{buttonLabel}</span> : null}
     </Button>
+  );
+
+  if (!tooltip) {
+    return button;
+  }
+
+  return (
+    <TooltipProvider delayDuration={120}>
+      <Tooltip>
+        <TooltipTrigger asChild>{button}</TooltipTrigger>
+        <TooltipContent side="top" align="end">
+          {tooltip}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/src/components/SkillDetailPage.tsx
+++ b/src/components/SkillDetailPage.tsx
@@ -45,7 +45,6 @@ import { SkillOwnershipPanel } from "./SkillOwnershipPanel";
 import { SkillPublishSuccessDialog } from "./SkillPublishSuccessDialog";
 import { SkillRelatedSection, type RelatedSkillEntry } from "./SkillRelatedSection";
 import { SkillReportDialog } from "./SkillReportDialog";
-import { Alert, AlertDescription } from "./ui/alert";
 import { Button } from "./ui/button";
 import { Card } from "./ui/card";
 
@@ -813,10 +812,10 @@ export function SkillDetailPage({
       />
     ) : null;
   const staffVisibilityAlert = staffModerationNote ? (
-    <Alert variant="warn" className="skill-visibility-alert" role="status">
-      <TriangleAlert size={18} aria-hidden="true" />
-      <AlertDescription>{staffModerationNote}</AlertDescription>
-    </Alert>
+    <p className="skill-visibility-alert" role="status">
+      <TriangleAlert size={14} aria-hidden="true" />
+      <span>{staffModerationNote}</span>
+    </p>
   ) : null;
   const settingsPanel =
     canAccessSettings && skill ? (
@@ -914,7 +913,7 @@ export function SkillDetailPage({
           clawdis={clawdis}
           category={relatedCategory}
           categories={relatedCategories}
-          priorityContent={staffVisibilityAlert}
+          staffVisibilityAlert={staffVisibilityAlert}
           securityAuditSummary={securitySummary}
           activityTrend={activityTrend}
           activityTrendLoading={activityTrendLoading}

--- a/src/components/SkillHeader.test.tsx
+++ b/src/components/SkillHeader.test.tsx
@@ -131,7 +131,7 @@ describe("SkillHeader", () => {
       configRequirements: undefined,
       cliHelp: undefined,
       clawdis: undefined,
-      priorityContent: null,
+      staffVisibilityAlert: null,
       settingsHref: null,
       ...overrides,
     };

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -120,7 +120,7 @@ type SkillHeaderProps = {
   clawdis: ClawdisSkillMetadata | undefined;
   category?: SkillCategory | null;
   categories?: SkillCategory[] | null;
-  priorityContent?: ReactNode;
+  staffVisibilityAlert?: ReactNode;
   postInstallContent?: ReactNode;
   securityAuditSummary?: ReactNode;
   activityTrend?: ActivityTrend | null;
@@ -158,7 +158,7 @@ export function SkillHeader({
   clawdis,
   category,
   categories,
-  priorityContent,
+  staffVisibilityAlert,
   postInstallContent,
   securityAuditSummary,
   activityTrend,
@@ -233,9 +233,13 @@ export function SkillHeader({
   };
 
   const managementToolbar =
-    hasOwnerActions || isStaff ? (
+    hasOwnerActions || isStaff || staffVisibilityAlert ? (
       <div className="skill-management-toolbar">
-        <div className="skill-management-toolbar-inner">
+        {staffVisibilityAlert ? (
+          <div className="skill-management-toolbar-alert">{staffVisibilityAlert}</div>
+        ) : null}
+        {hasOwnerActions || isStaff ? (
+          <div className="skill-management-toolbar-inner">
           {newVersionHref ? (
             <Button asChild variant="ghost" size="xs" className="skill-management-toolbar-action">
               <a href={newVersionHref} aria-label="New version">
@@ -260,7 +264,8 @@ export function SkillHeader({
               </Link>
             </Button>
           ) : null}
-        </div>
+          </div>
+        ) : null}
       </div>
     ) : null;
 
@@ -484,8 +489,6 @@ export function SkillHeader({
           </>
         }
       >
-        {priorityContent}
-
         <div className="detail-mobile-install">
           <SkillCommandLineCard
             slug={skill.slug}

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -240,30 +240,30 @@ export function SkillHeader({
         ) : null}
         {hasOwnerActions || isStaff ? (
           <div className="skill-management-toolbar-inner">
-          {newVersionHref ? (
-            <Button asChild variant="ghost" size="xs" className="skill-management-toolbar-action">
-              <a href={newVersionHref} aria-label="New version">
-                <Upload size={13} aria-hidden="true" />
-                New version
-              </a>
-            </Button>
-          ) : null}
-          {settingsHref ? (
-            <Button asChild variant="ghost" size="xs" className="skill-management-toolbar-action">
-              <a href={settingsHref} aria-label="Settings">
-                <Settings size={13} aria-hidden="true" />
-                Settings
-              </a>
-            </Button>
-          ) : null}
-          {isStaff ? (
-            <Button asChild variant="ghost" size="xs" className="skill-management-toolbar-action">
-              <Link to="/management" search={{ skill: skill.slug, plugin: undefined }}>
-                <ShieldCheck size={13} aria-hidden="true" />
-                Manage
-              </Link>
-            </Button>
-          ) : null}
+            {newVersionHref ? (
+              <Button asChild variant="ghost" size="xs" className="skill-management-toolbar-action">
+                <a href={newVersionHref} aria-label="New version">
+                  <Upload size={13} aria-hidden="true" />
+                  New version
+                </a>
+              </Button>
+            ) : null}
+            {settingsHref ? (
+              <Button asChild variant="ghost" size="xs" className="skill-management-toolbar-action">
+                <a href={settingsHref} aria-label="Settings">
+                  <Settings size={13} aria-hidden="true" />
+                  Settings
+                </a>
+              </Button>
+            ) : null}
+            {isStaff ? (
+              <Button asChild variant="ghost" size="xs" className="skill-management-toolbar-action">
+                <Link to="/management" search={{ skill: skill.slug, plugin: undefined }}>
+                  <ShieldCheck size={13} aria-hidden="true" />
+                  Manage
+                </Link>
+              </Button>
+            ) : null}
           </div>
         ) : null}
       </div>

--- a/src/components/SkillInstallSurface.test.tsx
+++ b/src/components/SkillInstallSurface.test.tsx
@@ -3,7 +3,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { SkillCommandLineCard, SkillInstallSurface } from "./SkillInstallSurface";
+import { SkillCommandLineCard, OpenClawCliInstallCommand, SkillInstallSurface } from "./SkillInstallSurface";
 import { TooltipProvider } from "./ui/tooltip";
 
 const writeTextMock = vi.fn();
@@ -79,7 +79,14 @@ describe("SkillInstallSurface", () => {
       </TooltipProvider>,
     );
 
-    expect(screen.getByText("openclaw skills install @steipete/weather")).toBeTruthy();
+    expect(screen.getByText("openclaw skills install")).toBeTruthy();
+    expect(screen.getByText("@steipete/weather")).toBeTruthy();
+    expect(document.querySelector(".skill-install-command-verb")?.textContent).toBe(
+      "openclaw skills install",
+    );
+    expect(document.querySelector(".skill-install-command-target")?.textContent).toBe(
+      " @steipete/weather",
+    );
     expect(screen.queryByText("npx clawhub@latest install @steipete/weather")).toBeNull();
     expect(screen.getByRole("tab", { name: "CLI" }).getAttribute("aria-selected")).toBe("true");
     expect(screen.getByRole("tab", { name: "Prompt" }).getAttribute("aria-selected")).toBe("false");
@@ -102,5 +109,14 @@ describe("SkillInstallSurface", () => {
         expect.stringContaining("Before installing anything"),
       );
     });
+  });
+
+  it("splits plugin install commands into muted verb and highlighted target", () => {
+    render(
+      <OpenClawCliInstallCommand command="openclaw plugins install clawhub:demo-plugin" />,
+    );
+
+    expect(screen.getByText("openclaw plugins install")).toBeTruthy();
+    expect(screen.getByText("clawhub:demo-plugin")).toBeTruthy();
   });
 });

--- a/src/components/SkillInstallSurface.test.tsx
+++ b/src/components/SkillInstallSurface.test.tsx
@@ -3,7 +3,11 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { SkillCommandLineCard, OpenClawCliInstallCommand, SkillInstallSurface } from "./SkillInstallSurface";
+import {
+  SkillCommandLineCard,
+  OpenClawCliInstallCommand,
+  SkillInstallSurface,
+} from "./SkillInstallSurface";
 import { TooltipProvider } from "./ui/tooltip";
 
 const writeTextMock = vi.fn();
@@ -112,9 +116,7 @@ describe("SkillInstallSurface", () => {
   });
 
   it("splits plugin install commands into muted verb and highlighted target", () => {
-    render(
-      <OpenClawCliInstallCommand command="openclaw plugins install clawhub:demo-plugin" />,
-    );
+    render(<OpenClawCliInstallCommand command="openclaw plugins install clawhub:demo-plugin" />);
 
     expect(screen.getByText("openclaw plugins install")).toBeTruthy();
     expect(screen.getByText("clawhub:demo-plugin")).toBeTruthy();

--- a/src/components/SkillInstallSurface.tsx
+++ b/src/components/SkillInstallSurface.tsx
@@ -171,6 +171,20 @@ export function SkillInstallSurface({
   );
 }
 
+export function OpenClawCliInstallCommand({ command }: { command: string }) {
+  const match = command.match(/^(openclaw (?:skills|plugins) install)( .+)$/);
+  if (!match) {
+    return <code translate="no">{command}</code>;
+  }
+
+  return (
+    <code translate="no">
+      <span className="skill-install-command-verb">{match[1]}</span>
+      <span className="skill-install-command-target">{match[2]}</span>
+    </code>
+  );
+}
+
 export function SkillCommandLineCard({
   slug,
   displayName,
@@ -250,7 +264,11 @@ export function SkillCommandLineCard({
             } skill-install-command-reveal`}
             tabIndex={0}
           >
-            <code translate="no">{activeInstallText}</code>
+            {activeInstallTab === "cli" ? (
+              <OpenClawCliInstallCommand command={activeInstallText} />
+            ) : (
+              <code translate="no">{activeInstallText}</code>
+            )}
           </pre>
           <InstallCopyButton
             text={activeInstallText}

--- a/src/routes/-dashboard.test.tsx
+++ b/src/routes/-dashboard.test.tsx
@@ -313,7 +313,7 @@ describe("Dashboard rows", () => {
     ).toBeNull();
   });
 
-  it("links public plugin finding counts to the plugin validation tab", () => {
+  it("links public plugin finding counts to the plugin validation section", () => {
     arrangeDashboard({
       packages: [
         createPackage({

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -9,6 +9,7 @@ import { useMutation, useQuery } from "convex/react";
 import {
   AlertTriangle,
   Braces,
+  ChevronRight,
   Download,
   FileArchive,
   Files,
@@ -16,6 +17,7 @@ import {
   HardDrive,
   Info,
   Package,
+  Plus,
   Server,
   Sparkles,
   Tag,
@@ -34,7 +36,6 @@ import {
 import { useDownloadsSidebarMetricBlock } from "../../components/DownloadsMetricCard";
 import { EmptyState } from "../../components/EmptyState";
 import { InstallCopyButton } from "../../components/InstallCopyButton";
-import { OpenClawCliInstallCommand } from "../../components/SkillInstallSurface";
 import { Container } from "../../components/layout/Container";
 import { MarkdownPreview } from "../../components/MarkdownPreview";
 import { OfficialTag } from "../../components/OfficialBadge";
@@ -44,6 +45,7 @@ import {
 } from "../../components/PluginVersionsPanel";
 import { SidebarMetadata } from "../../components/SidebarMetadata";
 import { SkillDetailSkeleton } from "../../components/skeletons/SkillDetailSkeleton";
+import { OpenClawCliInstallCommand } from "../../components/SkillInstallSurface";
 import { Alert, AlertDescription } from "../../components/ui/alert";
 import { Badge } from "../../components/ui/badge";
 import { Button } from "../../components/ui/button";
@@ -104,8 +106,7 @@ type PluginDetailTab =
   | "compatibility"
   | "configuration"
   | "mcpServers"
-  | "skills"
-  | "validation";
+  | "skills";
 
 type PluginInspectorFinding = {
   packageName: string;
@@ -299,14 +300,13 @@ function formatArtifactSize(value: number | null | undefined): string | null {
 
 function pluginDetailTabFromHash(hashValue: string): PluginDetailTab {
   const hash = hashValue.replace("#", "");
-  if (hash === "warnings") return "validation";
+  if (hash === "warnings" || hash === "validation") return "readme";
   if (hash === "verification") return "compatibility";
   if (hash === "mcp-servers" || hash === "mcpServers") return "mcpServers";
   return hash === "versions" ||
     hash === "compatibility" ||
     hash === "configuration" ||
-    hash === "skills" ||
-    hash === "validation"
+    hash === "skills"
     ? hash
     : "readme";
 }
@@ -323,8 +323,6 @@ function PluginDetailTabs({
   configurationPanel,
   mcpServersPanel,
   skillsPanel,
-  validationPanel,
-  validationCount,
 }: {
   activeTab: PluginDetailTab;
   setActiveTab: (tab: PluginDetailTab) => void;
@@ -335,8 +333,6 @@ function PluginDetailTabs({
   configurationPanel: ReactNode | null;
   mcpServersPanel: ReactNode | null;
   skillsPanel: ReactNode | null;
-  validationPanel: ReactNode | null;
-  validationCount: number;
 }) {
   const [hasMountedVersions, setHasMountedVersions] = useState(activeTab === "versions");
   const [isReadmeExpanded, setIsReadmeExpanded] = useState(false);
@@ -374,9 +370,7 @@ function PluginDetailTabs({
             ? "mcpServers"
             : activeTab === "skills" && skillsPanel
               ? "skills"
-              : activeTab === "validation" && validationPanel
-                ? "validation"
-                : "readme";
+              : "readme";
   useEffect(() => {
     if (effectiveActiveTab === "versions") setHasMountedVersions(true);
   }, [effectiveActiveTab]);
@@ -415,9 +409,7 @@ function PluginDetailTabs({
           ? mcpServersPanel
           : effectiveActiveTab === "skills" && skillsPanel
             ? skillsPanel
-            : effectiveActiveTab === "validation" && validationPanel
-              ? validationPanel
-              : readmePanel;
+            : readmePanel;
 
   return (
     <div className="tab-card detail-mobile-tabs">
@@ -496,19 +488,6 @@ function PluginDetailTabs({
         >
           Versions
         </button>
-        {validationPanel ? (
-          <button
-            id="plugin-tab-validation"
-            className={`tab-button${effectiveActiveTab === "validation" ? " is-active" : ""}`}
-            type="button"
-            role="tab"
-            aria-selected={effectiveActiveTab === "validation"}
-            aria-controls="plugin-tabpanel-validation"
-            onClick={() => selectTab("validation")}
-          >
-            Validation ({validationCount})
-          </button>
-        ) : null}
       </div>
       {effectiveActiveTab !== "versions" ? (
         <div
@@ -700,6 +679,297 @@ function PluginManifestSkillsPanel({
   );
 }
 
+const PLUGIN_VALIDATE_CLI = "clawhub package validate <path-to-plugin>";
+
+const INSPECTOR_ISSUE_CLASS_LABELS: Record<string, string> = {
+  "upstream-metadata": "Metadata",
+  "deprecation-warning": "Deprecated API",
+  "compatibility-error": "Compatibility",
+  "compatibility-warning": "Compatibility",
+};
+
+function formatInspectorIssueClassLabel(issueClass?: string) {
+  if (!issueClass || issueClass === "inspector-gap") return null;
+  if (INSPECTOR_ISSUE_CLASS_LABELS[issueClass]) {
+    return INSPECTOR_ISSUE_CLASS_LABELS[issueClass];
+  }
+  return issueClass
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function parseInspectorPriority(severity?: string) {
+  const match = severity?.match(/^P(\d+)$/i);
+  return match ? Number.parseInt(match[1] ?? "99", 10) : 99;
+}
+
+function compareInspectorFindings(a: PluginInspectorFinding, b: PluginInspectorFinding) {
+  const priorityDiff = parseInspectorPriority(a.severity) - parseInspectorPriority(b.severity);
+  if (priorityDiff !== 0) return priorityDiff;
+  const categoryA = formatInspectorIssueClassLabel(a.issueClass) ?? "";
+  const categoryB = formatInspectorIssueClassLabel(b.issueClass) ?? "";
+  return categoryA.localeCompare(categoryB);
+}
+
+function formatValidationSummaryHint(errorCount: number, warningCount: number) {
+  if (errorCount > 0 && warningCount > 0) {
+    return "Fix errors first to avoid publishing or compatibility issues.";
+  }
+  if (errorCount > 0) {
+    return errorCount === 1 ? "1 error needs attention." : `${errorCount} errors need attention.`;
+  }
+  if (warningCount > 0) {
+    return warningCount === 1
+      ? "No blocking errors. 1 warning should be reviewed."
+      : `No blocking errors. ${warningCount} warnings should be reviewed.`;
+  }
+  return null;
+}
+
+function formatValidationFindingMessage(message: string) {
+  const trimmed = message.trim();
+  if (!trimmed) return trimmed;
+  const normalized = trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
+  return normalized.endsWith(".") ? normalized : `${normalized}.`;
+}
+
+function buildValidationAgentFixPrompt(args: {
+  packageName: string;
+  releaseVersion?: string | null;
+  findings: PluginInspectorFinding[];
+}) {
+  const sortedFindings = [...args.findings].sort(compareInspectorFindings);
+  const errors = sortedFindings.filter((finding) => finding.findingKind === "error");
+  const warnings = sortedFindings.filter((finding) => finding.findingKind !== "error");
+
+  const lines = [
+    `Fix the following OpenClaw plugin validation findings for package "${args.packageName}".`,
+  ];
+  if (args.releaseVersion) {
+    lines.push(`Validated release: v${args.releaseVersion}.`);
+  }
+  lines.push(
+    "",
+    "Make the minimum code and manifest changes needed to resolve every issue below.",
+    "After editing, run locally:",
+    PLUGIN_VALIDATE_CLI,
+    "",
+  );
+
+  const appendFindings = (title: string, findings: PluginInspectorFinding[]) => {
+    if (findings.length === 0) return;
+    lines.push(`## ${title}`, "");
+    for (const finding of findings) {
+      const kind = finding.findingKind === "error" ? "Error" : "Warning";
+      const categoryLabel = formatInspectorIssueClassLabel(finding.issueClass);
+      const heading = [finding.code, categoryLabel, finding.severity].filter(Boolean).join(" · ");
+      lines.push(`### ${heading}`);
+      lines.push(`**${kind}:** ${formatValidationFindingMessage(finding.message)}`);
+      if (finding.authorRemediation?.summary) {
+        lines.push(`**How to fix:** ${finding.authorRemediation.summary}`);
+      }
+      if (finding.authorRemediation?.docsUrl) {
+        lines.push(`**Docs:** ${finding.authorRemediation.docsUrl}`);
+      }
+      const metadataLine = [
+        finding.version ? `Release v${finding.version}` : null,
+        finding.targetOpenClawVersion ? `Target OpenClaw ${finding.targetOpenClawVersion}` : null,
+      ]
+        .filter(Boolean)
+        .join(" · ");
+      if (metadataLine) {
+        lines.push(`**Context:** ${metadataLine}`);
+      }
+      if (finding.evidence && finding.evidence.length > 0) {
+        lines.push("**Evidence:**");
+        for (const entry of finding.evidence) {
+          lines.push(`- ${entry}`);
+        }
+      }
+      lines.push("");
+    }
+  };
+
+  if (errors.length > 0) {
+    appendFindings(`Errors (${errors.length}) — fix first`, errors);
+  }
+  if (warnings.length > 0) {
+    appendFindings(`Warnings (${warnings.length})`, warnings);
+  }
+
+  lines.push("Confirm all findings are resolved before publishing a new release.");
+  return lines.join("\n").trim();
+}
+
+function buildDevValidationFindingMocks(
+  template: PluginInspectorFinding,
+): PluginInspectorFinding[] {
+  return [
+    {
+      ...template,
+      code: "package-min-host-version-drift",
+      findingKind: "warning",
+      issueClass: "upstream-metadata",
+      severity: "P2",
+      message: "OpenClaw package minimum host version drifts from build target.",
+      authorRemediation: {
+        summary:
+          "Set the package minimum host version to the OpenClaw version range the plugin was built and tested against.",
+        docsUrl:
+          "https://docs.openclaw.ai/clawhub/plugin-validation-fixes#package-min-host-version-drift",
+      },
+      evidence: ["minHostVersion: >=2026.4.25", "buildOpenClawVersion: 2026.6.9"],
+    },
+    {
+      ...template,
+      code: "missing-expected-seam",
+      findingKind: "warning",
+      issueClass: "compatibility-warning",
+      severity: "P3",
+      message: "Plugin manifest does not declare the expected registration seam.",
+      authorRemediation: {
+        summary: "Export activate() and register capabilities through the current plugin API.",
+        docsUrl:
+          "https://docs.openclaw.ai/clawhub/plugin-validation-fixes#missing-expected-seam",
+      },
+      evidence: ["manifest.extensions missing ./dist/index.js reference"],
+    },
+    {
+      ...template,
+      code: "package-plugin-api-compat-missing",
+      findingKind: "error",
+      issueClass: "compatibility-error",
+      severity: "P0",
+      message: "openclaw.compat.pluginApi is missing from package.json.",
+      authorRemediation: {
+        summary:
+          "Add openclaw.compat.pluginApi with the minimum API version your plugin supports.",
+        docsUrl:
+          "https://docs.openclaw.ai/clawhub/plugin-validation-fixes#package-plugin-api-compat-missing",
+      },
+      evidence: ['package.json has no "openclaw.compat.pluginApi" field'],
+    },
+  ];
+}
+
+function shouldShowDevValidationFindingMocks() {
+  // Visual iteration only — remove before PR. Skips Vitest (`MODE === "test"`).
+  return import.meta.env.DEV && import.meta.env.MODE === "development";
+}
+
+function PluginValidationFindingCard({
+  finding,
+  compact = false,
+}: {
+  finding: PluginInspectorFinding;
+  compact?: boolean;
+}) {
+  const kind = finding.findingKind ?? "warning";
+  const categoryLabel = formatInspectorIssueClassLabel(finding.issueClass);
+  const evidence = finding.evidence ?? [];
+  const visibleEvidence = evidence.slice(0, 4);
+  const hiddenEvidenceCount = Math.max(evidence.length - visibleEvidence.length, 0);
+  const metadataLine = [
+    finding.version ? `Release v${finding.version}` : null,
+    finding.targetOpenClawVersion ? `Target OpenClaw ${finding.targetOpenClawVersion}` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+  const kicker = [kind === "error" ? "Error" : "Warning", categoryLabel, finding.severity]
+    .filter(Boolean)
+    .join(" · ");
+
+  const summaryCopy = (
+    <div className="plugin-warning-item-copy">
+      <p className="plugin-warning-item-message">
+        {formatValidationFindingMessage(finding.message)}
+      </p>
+      <p className={`plugin-warning-item-tags is-${kind}`}>{kicker}</p>
+    </div>
+  );
+
+  const fixGuide = finding.authorRemediation?.summary ? (
+    <div className="plugin-warning-fix-guide">
+      <p className="plugin-warning-fix-copy">
+        <span className="plugin-warning-fix-guide-label">How to fix</span>{" "}
+        {finding.authorRemediation.summary}
+        {finding.authorRemediation.docsUrl ? (
+          <>
+            {" "}
+            <a
+              className="plugin-warning-fix-link"
+              href={finding.authorRemediation.docsUrl}
+              target="_blank"
+              rel="noreferrer"
+            >
+              View fix guide ↗
+            </a>
+          </>
+        ) : null}
+      </p>
+    </div>
+  ) : null;
+
+  const metadata = metadataLine ? (
+    <p className="plugin-warning-meta-line">{metadataLine}</p>
+  ) : null;
+
+  const evidenceDetails =
+    visibleEvidence.length > 0 ? (
+      <details className="plugin-warning-evidence-details">
+        <summary className="plugin-warning-evidence-summary">
+          <span className="plugin-warning-evidence-summary-label">Technical evidence</span>
+          <ChevronRight className="plugin-warning-evidence-chevron" size={14} aria-hidden="true" />
+        </summary>
+        <div className="plugin-warning-evidence-block">
+          {visibleEvidence.map((entry) => (
+            <div className="plugin-warning-evidence-line" key={entry}>
+              {entry}
+            </div>
+          ))}
+          {hiddenEvidenceCount > 0 ? (
+            <p className="plugin-warning-evidence-more">+{hiddenEvidenceCount} more</p>
+          ) : null}
+        </div>
+      </details>
+    ) : null;
+
+  const body = (
+    <div className="plugin-warning-item-body">
+      {fixGuide}
+      {metadata}
+      {evidenceDetails}
+    </div>
+  );
+
+  if (compact) {
+    return (
+      <details
+        className={`plugin-warning-item plugin-warning-item-details is-${kind}`}
+        open={kind === "error"}
+      >
+        <summary className="plugin-warning-item-summary">
+          {summaryCopy}
+          <code className="plugin-warning-item-code">{finding.code}</code>
+          <ChevronRight className="plugin-warning-item-chevron" size={14} aria-hidden="true" />
+        </summary>
+        {body}
+      </details>
+    );
+  }
+
+  return (
+    <article className={`plugin-warning-item is-${kind}`}>
+      <div className="plugin-warning-item-main">
+        {summaryCopy}
+        <code className="plugin-warning-item-code">{finding.code}</code>
+      </div>
+      {body}
+    </article>
+  );
+}
+
 function PluginDetailRoute() {
   const { name } = Route.useParams();
   const loaderData = Route.useLoaderData() as PluginDetailLoaderData;
@@ -766,6 +1036,13 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
   const authorInspectorFindings = Array.isArray(inspectorFindings)
     ? inspectorFindings.filter((finding) => finding.authorRemediation?.summary)
     : undefined;
+  const displayInspectorFindings =
+    authorInspectorFindings && shouldShowDevValidationFindingMocks()
+      ? [
+          ...authorInspectorFindings,
+          ...buildDevValidationFindingMocks(authorInspectorFindings[0]),
+        ]
+      : authorInspectorFindings;
   const [activeTab, setActiveTab] = useState<PluginDetailTab>("readme");
   const [mobileDetailPanel, setMobileDetailPanel] = useState<"content" | "stats">("content");
   const isMobileDetailLayout = useMediaQuery("(max-width: 900px)");
@@ -951,7 +1228,6 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
         skills={pluginManifestSummary.bundledSkills}
       />
     ) : null;
-  const validationCount = authorInspectorFindings?.length ?? validationSummary?.findingCount ?? 0;
   const incompatibilityAlert =
     validationSummary &&
     validationSummary.errorCount > 0 &&
@@ -964,73 +1240,144 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
         </AlertDescription>
       </Alert>
     ) : null;
-  const validationPanel =
-    authorInspectorFindings && authorInspectorFindings.length > 0 ? (
-      <div className="plugin-tab-panel plugin-warnings-panel">
-        <Alert variant="info" role="status">
-          <Info size={16} aria-hidden="true" />
-          <AlertDescription>
-            <span>
-              Validation outputs are only visible to plugin owners and admins. Run locally using the
-              CLI:
-            </span>
-            <code className="plugin-validation-command">
-              clawhub package validate &lt;path-to-plugin&gt;
-            </code>
-          </AlertDescription>
-        </Alert>
-        <div className="plugin-warning-list">
-          {authorInspectorFindings.map((finding) => (
-            <article
-              key={`${finding.version}:${finding.code}:${finding.message}`}
-              className={`plugin-warning-item is-${finding.findingKind ?? "warning"}`}
-            >
-              <div className="plugin-warning-item-header">
-                <Badge variant={finding.findingKind === "error" ? "destructive" : "warning"}>
-                  {finding.findingKind === "error" ? "Error" : "Warning"}
-                </Badge>
-                <code>{finding.code}</code>
-                {finding.issueClass ? <span>{finding.issueClass}</span> : null}
-                {finding.severity ? <span>{finding.severity}</span> : null}
-              </div>
-              <p>{finding.message}</p>
-              <dl className="plugin-warning-meta">
-                <div>
-                  <dt>Plugin version</dt>
-                  <dd>v{finding.version}</dd>
-                </div>
-                {finding.targetOpenClawVersion ? (
-                  <div>
-                    <dt>Target</dt>
-                    <dd>OpenClaw {finding.targetOpenClawVersion}</dd>
-                  </div>
-                ) : null}
-              </dl>
-              {finding.evidence && finding.evidence.length > 0 ? (
-                <ul className="plugin-warning-evidence">
-                  {finding.evidence.slice(0, 4).map((entry) => (
-                    <li key={entry}>{entry}</li>
-                  ))}
-                </ul>
-              ) : null}
-              {finding.authorRemediation?.summary ? (
-                <div className="plugin-warning-remediation">
-                  <h4>Fix</h4>
-                  <p>{finding.authorRemediation.summary}</p>
-                  {finding.authorRemediation.docsUrl ? (
-                    <>
-                      <h4>Docs</h4>
-                      <a href={finding.authorRemediation.docsUrl} target="_blank" rel="noreferrer">
-                        {finding.authorRemediation.docsUrl}
-                      </a>
-                    </>
-                  ) : null}
-                </div>
-              ) : null}
-            </article>
-          ))}
-        </div>
+  const validationErrors = (
+    displayInspectorFindings?.filter((finding) => finding.findingKind === "error") ?? []
+  ).sort(compareInspectorFindings);
+  const validationWarnings = (
+    displayInspectorFindings?.filter((finding) => finding.findingKind !== "error") ?? []
+  ).sort(compareInspectorFindings);
+  const showValidationGroups = validationErrors.length > 0 && validationWarnings.length > 0;
+  const validationSummaryHint = formatValidationSummaryHint(
+    validationErrors.length,
+    validationWarnings.length,
+  );
+  const validationAgentFixPrompt =
+    authorInspectorFindings && authorInspectorFindings.length > 0
+      ? buildValidationAgentFixPrompt({
+          packageName: pkg.name,
+          releaseVersion: latestRelease?.version ?? pkg.latestVersion ?? null,
+          findings: authorInspectorFindings,
+        })
+      : null;
+  const compactFindingCards = (displayInspectorFindings?.length ?? 0) > 1;
+  const validationAgentPromptCard = validationAgentFixPrompt ? (
+    <div
+      className="plugin-validation-agent-prompt-card"
+      aria-labelledby="validation-agent-prompt-label"
+    >
+      <div className="plugin-validation-agent-prompt-copy">
+        <span id="validation-agent-prompt-label" className="plugin-validation-agent-prompt-label">
+          Fix with your agent
+        </span>
+        <p className="plugin-validation-agent-prompt-hint">
+          Paste into your coding agent to fix this check.
+        </p>
       </div>
+      <InstallCopyButton
+        text={validationAgentFixPrompt}
+        label="Copy prompt"
+        ariaLabel="Copy agent fix prompt"
+        className="plugin-validation-agent-prompt-button"
+      />
+    </div>
+  ) : null;
+  const validationPanel =
+    displayInspectorFindings && displayInspectorFindings.length > 0 ? (
+      <section
+        id="validation"
+        className="plugin-validation-panel"
+        aria-labelledby="validation-heading"
+      >
+        <header className="plugin-validation-overview">
+          <div className="plugin-validation-panel-title-row">
+            <h2 id="validation-heading" className="plugin-validation-panel-title">
+              Validation findings
+            </h2>
+            <span className="plugin-validation-panel-stats" aria-label="Validation summary">
+              <span
+                className={
+                  validationErrors.length > 0
+                    ? "plugin-validation-panel-stat is-error"
+                    : "plugin-validation-panel-stat is-muted"
+                }
+              >
+                {validationErrors.length}{" "}
+                {validationErrors.length === 1 ? "error" : "errors"}
+              </span>
+              <span className="plugin-validation-panel-stats-sep" aria-hidden="true">
+                ·
+              </span>
+              <span
+                className={
+                  validationWarnings.length > 0
+                    ? "plugin-validation-panel-stat is-warning"
+                    : "plugin-validation-panel-stat is-muted"
+                }
+              >
+                {validationWarnings.length}{" "}
+                {validationWarnings.length === 1 ? "warning" : "warnings"}
+              </span>
+            </span>
+          </div>
+          {validationSummaryHint ? (
+            <p className="plugin-validation-summary-hint">{validationSummaryHint}</p>
+          ) : null}
+          <div className="plugin-validation-cli-card" aria-labelledby="validation-cli-label">
+            <span id="validation-cli-label" className="plugin-validation-cli-label">
+              Run locally
+            </span>
+            <code className="plugin-validation-command">{PLUGIN_VALIDATE_CLI}</code>
+            <InstallCopyButton
+              text={PLUGIN_VALIDATE_CLI}
+              ariaLabel="Copy validate command"
+              showLabel={false}
+              className="plugin-validation-cli-copy"
+            />
+          </div>
+          {validationAgentPromptCard}
+        </header>
+        <section
+          className="plugin-validation-panel-findings"
+          aria-label="Issues to review"
+        >
+          {validationErrors.length > 0 ? (
+            <>
+              {showValidationGroups ? (
+                <h4 className="plugin-validation-group-label is-error">
+                  Errors ({validationErrors.length})
+                </h4>
+              ) : null}
+              <div className="plugin-warning-list">
+                {validationErrors.map((finding) => (
+                  <PluginValidationFindingCard
+                    key={`${finding.version}:${finding.code}:${finding.message}`}
+                    finding={finding}
+                    compact={compactFindingCards}
+                  />
+                ))}
+              </div>
+            </>
+          ) : null}
+          {validationWarnings.length > 0 ? (
+            <>
+              {showValidationGroups ? (
+                <h4 className="plugin-validation-group-label is-warning">
+                  Warnings ({validationWarnings.length})
+                </h4>
+              ) : null}
+              <div className="plugin-warning-list">
+                {validationWarnings.map((finding) => (
+                  <PluginValidationFindingCard
+                    key={`${finding.version}:${finding.code}:${finding.message}`}
+                    finding={finding}
+                    compact={compactFindingCards}
+                  />
+                ))}
+              </div>
+            </>
+          ) : null}
+        </section>
+      </section>
     ) : null;
   const sourceRepoLink = verification?.sourceRepo
     ? (() => {
@@ -1184,7 +1531,36 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
                 </a>
               </nav>
               <div className="skill-hero-heading-stack">
-                {headerCategories.length > 0 || headerTopics.length > 0 ? (
+                {showCatalogMetadataEmptyState ? (
+                  <div
+                    className="plugin-catalog-empty-alert plugin-catalog-empty-alert--hero"
+                    role="status"
+                  >
+                    <span className="plugin-catalog-empty-alert-visibility">
+                      Visible only to you
+                    </span>
+                    <div className="plugin-catalog-empty-alert-row">
+                      <div className="plugin-catalog-empty-alert-icon" aria-hidden="true">
+                        <Sparkles size={14} />
+                      </div>
+                      <span className="plugin-catalog-empty-alert-title">
+                        Categorize your plugin
+                      </span>
+                      <span className="skill-hero-taxonomy-separator" aria-hidden="true" />
+                      <Button
+                        type="button"
+                        variant="link"
+                        size="xs"
+                        className="plugin-catalog-empty-alert-cta"
+                        aria-label="Add categories and topics"
+                        onClick={() => setIsCatalogMetadataDialogOpen(true)}
+                      >
+                        <Plus size={13} aria-hidden="true" />
+                        Add categories & topics
+                      </Button>
+                    </div>
+                  </div>
+                ) : headerCategories.length > 0 || headerTopics.length > 0 ? (
                   <div className="skill-hero-taxonomy-row" aria-label="Plugin metadata">
                     {headerCategories.length > 0 ? (
                       <div className="skill-category-meta-list" aria-label="Categories">
@@ -1272,57 +1648,6 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
             </div>
           }
         >
-          <div className="plugin-install-stack detail-mobile-install">
-            {incompatibilityAlert}
-            <Card className="skill-install-command-card">
-              <CardHeader className="detail-hero-summary-row plugin-install-card-header">
-                <CardTitle className="skill-install-panel-title">Install</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="skill-install-command-wrap">
-                  <div className="skill-install-command-shell skill-install-command-shell-cli">
-                    <span className="skill-install-command-prompt" aria-hidden="true">
-                      $
-                    </span>
-                    <pre className="skill-install-command">
-                      <OpenClawCliInstallCommand command={installSnippet} />
-                    </pre>
-                    <InstallCopyButton
-                      text={installSnippet}
-                      ariaLabel="Copy plugin install command"
-                      showLabel={false}
-                      className="skill-install-command-inline-button"
-                    />
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-            {showCatalogMetadataEmptyState ? (
-              <div className="plugin-catalog-empty-alert" role="status">
-                <div className="plugin-catalog-empty-alert-icon" aria-hidden="true">
-                  <Sparkles size={15} />
-                </div>
-                <div className="plugin-catalog-empty-alert-copy">
-                  <div className="plugin-catalog-empty-alert-heading">
-                    <span>Categorize this plugin</span>
-                    <span className="plugin-catalog-empty-alert-visibility">
-                      Visible only to you
-                    </span>
-                  </div>
-                  <p>Add categories and topics.</p>
-                </div>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="plugin-catalog-empty-alert-cta"
-                  onClick={() => setIsCatalogMetadataDialogOpen(true)}
-                >
-                  Categorize
-                </Button>
-              </div>
-            ) : null}
-          </div>
           <div className="detail-mobile-master-tabs" data-active={mobileDetailPanel}>
             <div
               className="detail-mobile-master-tab-list"
@@ -1365,6 +1690,33 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
               aria-labelledby="plugin-mobile-master-tab-content"
               hidden={mobileDetailPanel !== "content"}
             >
+              {validationPanel}
+              <div className="plugin-install-stack detail-mobile-install">
+                {incompatibilityAlert}
+                <Card className="skill-install-command-card">
+                  <CardHeader className="detail-hero-summary-row plugin-install-card-header">
+                    <CardTitle className="skill-install-panel-title">Install</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="skill-install-command-wrap">
+                      <div className="skill-install-command-shell skill-install-command-shell-cli">
+                        <span className="skill-install-command-prompt" aria-hidden="true">
+                          $
+                        </span>
+                        <pre className="skill-install-command">
+                          <OpenClawCliInstallCommand command={installSnippet} />
+                        </pre>
+                        <InstallCopyButton
+                          text={installSnippet}
+                          ariaLabel="Copy plugin install command"
+                          showLabel={false}
+                          className="skill-install-command-inline-button"
+                        />
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
               <PluginDetailTabs
                 activeTab={activeTab}
                 setActiveTab={setActiveTab}
@@ -1375,8 +1727,6 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
                 configurationPanel={configurationPanel}
                 mcpServersPanel={mcpServersPanel}
                 skillsPanel={skillsPanel}
-                validationPanel={validationPanel}
-                validationCount={validationCount}
               />
             </div>
             {pluginSidebarStatsContent && isMobileDetailLayout ? (
@@ -1397,8 +1747,10 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
         <Dialog open={isCatalogMetadataDialogOpen} onOpenChange={setIsCatalogMetadataDialogOpen}>
           <DialogContent className="plugin-catalog-metadata-dialog">
             <DialogHeader>
-              <DialogTitle>Catalog metadata</DialogTitle>
-              <DialogDescription>Choose categories and topics for this plugin.</DialogDescription>
+              <DialogTitle>Categorize this plugin</DialogTitle>
+              <DialogDescription>
+                Select up to 3 categories and add topics to organize this plugin.
+              </DialogDescription>
             </DialogHeader>
             <CatalogMetadataEditor
               kind="plugin"

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -34,6 +34,7 @@ import {
 import { useDownloadsSidebarMetricBlock } from "../../components/DownloadsMetricCard";
 import { EmptyState } from "../../components/EmptyState";
 import { InstallCopyButton } from "../../components/InstallCopyButton";
+import { OpenClawCliInstallCommand } from "../../components/SkillInstallSurface";
 import { Container } from "../../components/layout/Container";
 import { MarkdownPreview } from "../../components/MarkdownPreview";
 import { OfficialTag } from "../../components/OfficialBadge";
@@ -1284,7 +1285,7 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
                       $
                     </span>
                     <pre className="skill-install-command">
-                      <code>{installSnippet}</code>
+                      <OpenClawCliInstallCommand command={installSnippet} />
                     </pre>
                     <InstallCopyButton
                       text={installSnippet}

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -891,23 +891,20 @@ function PluginValidationFindingCard({
 
   const fixGuide = finding.authorRemediation?.summary ? (
     <div className="plugin-warning-fix-guide">
-      <p className="plugin-warning-fix-copy">
-        <span className="plugin-warning-fix-guide-label">How to fix</span>{" "}
-        {finding.authorRemediation.summary}
+      <div className="plugin-warning-fix-guide-header">
+        <p className="plugin-warning-fix-guide-label">How to fix</p>
         {finding.authorRemediation.docsUrl ? (
-          <>
-            {" "}
-            <a
-              className="plugin-warning-fix-link"
-              href={finding.authorRemediation.docsUrl}
-              target="_blank"
-              rel="noreferrer"
-            >
-              View fix guide ↗
-            </a>
-          </>
+          <a
+            className="plugin-warning-fix-link"
+            href={finding.authorRemediation.docsUrl}
+            target="_blank"
+            rel="noreferrer"
+          >
+            View fix guide ↗
+          </a>
         ) : null}
-      </p>
+      </div>
+      <p className="plugin-warning-fix-copy">{finding.authorRemediation.summary}</p>
     </div>
   ) : null;
 

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -891,20 +891,20 @@ function PluginValidationFindingCard({
 
   const fixGuide = finding.authorRemediation?.summary ? (
     <div className="plugin-warning-fix-guide">
-      <div className="plugin-warning-fix-guide-header">
+      <div className="plugin-warning-fix-guide-copy">
         <p className="plugin-warning-fix-guide-label">How to fix</p>
-        {finding.authorRemediation.docsUrl ? (
-          <a
-            className="plugin-warning-fix-link"
-            href={finding.authorRemediation.docsUrl}
-            target="_blank"
-            rel="noreferrer"
-          >
-            View fix guide ↗
-          </a>
-        ) : null}
+        <p className="plugin-warning-fix-copy">{finding.authorRemediation.summary}</p>
       </div>
-      <p className="plugin-warning-fix-copy">{finding.authorRemediation.summary}</p>
+      {finding.authorRemediation.docsUrl ? (
+        <a
+          className="plugin-warning-fix-link"
+          href={finding.authorRemediation.docsUrl}
+          target="_blank"
+          rel="noreferrer"
+        >
+          View fix guide ↗
+        </a>
+      ) : null}
     </div>
   ) : null;
 

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -14,6 +14,7 @@ import {
   FileArchive,
   Files,
   Fingerprint,
+  Hammer,
   HardDrive,
   Info,
   Package,
@@ -680,6 +681,7 @@ function PluginManifestSkillsPanel({
 }
 
 const PLUGIN_VALIDATE_CLI = "clawhub package validate <path-to-plugin>";
+const PLUGIN_VALIDATE_TOOLBAR_LABEL = "Validate locally before publishing";
 
 const INSPECTOR_ISSUE_CLASS_LABELS: Record<string, string> = {
   "upstream-metadata": "Metadata",
@@ -712,19 +714,25 @@ function compareInspectorFindings(a: PluginInspectorFinding, b: PluginInspectorF
   return categoryA.localeCompare(categoryB);
 }
 
-function formatValidationSummaryHint(errorCount: number, warningCount: number) {
-  if (errorCount > 0 && warningCount > 0) {
-    return "Fix errors first to avoid publishing or compatibility issues.";
-  }
-  if (errorCount > 0) {
-    return errorCount === 1 ? "1 error needs attention." : `${errorCount} errors need attention.`;
-  }
-  if (warningCount > 0) {
-    return warningCount === 1
-      ? "No blocking errors. 1 warning should be reviewed."
-      : `No blocking errors. ${warningCount} warnings should be reviewed.`;
-  }
-  return null;
+function ValidationSummaryHint({
+  issueCount,
+  packageName,
+  version,
+}: {
+  issueCount: number;
+  packageName: string;
+  version: string | null;
+}) {
+  const issueLabel = issueCount === 1 ? "1 issue" : `${issueCount} issues`;
+  const versionLabel = version ? `version ${version}` : "this release";
+
+  return (
+    <>
+      Hey, we found <strong>{issueLabel}</strong> with {versionLabel} of{" "}
+      <strong>{packageName}</strong>. Review the findings below, apply the fix, and upload a new
+      version.
+    </>
+  );
 }
 
 function formatValidationFindingMessage(message: string) {
@@ -830,8 +838,7 @@ function buildDevValidationFindingMocks(
       message: "Plugin manifest does not declare the expected registration seam.",
       authorRemediation: {
         summary: "Export activate() and register capabilities through the current plugin API.",
-        docsUrl:
-          "https://docs.openclaw.ai/clawhub/plugin-validation-fixes#missing-expected-seam",
+        docsUrl: "https://docs.openclaw.ai/clawhub/plugin-validation-fixes#missing-expected-seam",
       },
       evidence: ["manifest.extensions missing ./dist/index.js reference"],
     },
@@ -843,8 +850,7 @@ function buildDevValidationFindingMocks(
       severity: "P0",
       message: "openclaw.compat.pluginApi is missing from package.json.",
       authorRemediation: {
-        summary:
-          "Add openclaw.compat.pluginApi with the minimum API version your plugin supports.",
+        summary: "Add openclaw.compat.pluginApi with the minimum API version your plugin supports.",
         docsUrl:
           "https://docs.openclaw.ai/clawhub/plugin-validation-fixes#package-plugin-api-compat-missing",
       },
@@ -856,6 +862,11 @@ function buildDevValidationFindingMocks(
 function shouldShowDevValidationFindingMocks() {
   // Visual iteration only — remove before PR. Skips Vitest (`MODE === "test"`).
   return import.meta.env.DEV && import.meta.env.MODE === "development";
+}
+
+function shouldShowValidationPriorityBadge(severity?: string) {
+  const priority = parseInspectorPriority(severity);
+  return Boolean(severity) && priority <= 1;
 }
 
 function PluginValidationFindingCard({
@@ -870,29 +881,54 @@ function PluginValidationFindingCard({
   const evidence = finding.evidence ?? [];
   const visibleEvidence = evidence.slice(0, 4);
   const hiddenEvidenceCount = Math.max(evidence.length - visibleEvidence.length, 0);
-  const metadataLine = [
-    finding.version ? `Release v${finding.version}` : null,
-    finding.targetOpenClawVersion ? `Target OpenClaw ${finding.targetOpenClawVersion}` : null,
-  ]
-    .filter(Boolean)
-    .join(" · ");
-  const kicker = [kind === "error" ? "Error" : "Warning", categoryLabel, finding.severity]
-    .filter(Boolean)
-    .join(" · ");
+  const showPriorityBadge = shouldShowValidationPriorityBadge(finding.severity);
+  const hasMetadata = Boolean(finding.version || finding.targetOpenClawVersion);
 
   const summaryCopy = (
-    <div className="plugin-warning-item-copy">
-      <p className="plugin-warning-item-message">
-        {formatValidationFindingMessage(finding.message)}
-      </p>
-      <p className={`plugin-warning-item-tags is-${kind}`}>{kicker}</p>
+    <div className="plugin-warning-item-lead">
+      <span className={`plugin-warning-severity-dot is-${kind}`} aria-hidden="true" />
+      <div className="plugin-warning-item-copy">
+        <div className="plugin-warning-item-title-row">
+          <p className="plugin-warning-item-message">
+            {formatValidationFindingMessage(finding.message)}
+          </p>
+          {showPriorityBadge ? (
+            <span className={`plugin-warning-priority-badge is-${kind}`}>{finding.severity}</span>
+          ) : null}
+          {compact ? (
+            <ChevronRight
+              className="plugin-warning-item-expand-chevron"
+              size={14}
+              aria-hidden="true"
+            />
+          ) : null}
+        </div>
+        <p className="plugin-warning-item-meta">
+          <span className="plugin-warning-item-meta-text">
+            {categoryLabel ? <span>{categoryLabel}</span> : null}
+            {categoryLabel && finding.code ? (
+              <span className="plugin-warning-item-meta-sep" aria-hidden="true">
+                {" · "}
+              </span>
+            ) : null}
+            {finding.code ? (
+              <code className="plugin-warning-item-code" title={finding.code}>
+                {finding.code}
+              </code>
+            ) : null}
+          </span>
+        </p>
+      </div>
     </div>
   );
 
   const fixGuide = finding.authorRemediation?.summary ? (
     <div className="plugin-warning-fix-guide">
       <div className="plugin-warning-fix-guide-copy">
-        <p className="plugin-warning-fix-guide-label">How to fix</p>
+        <p className="plugin-warning-fix-guide-label">
+          <Hammer size={14} aria-hidden="true" />
+          How to fix
+        </p>
         <p className="plugin-warning-fix-copy">{finding.authorRemediation.summary}</p>
       </div>
       {finding.authorRemediation.docsUrl ? (
@@ -908,60 +944,63 @@ function PluginValidationFindingCard({
     </div>
   ) : null;
 
-  const metadata = metadataLine ? (
-    <p className="plugin-warning-meta-line">{metadataLine}</p>
+  const metadata = hasMetadata ? (
+    <dl className="plugin-warning-meta-group">
+      {finding.version ? (
+        <div className="plugin-warning-meta-field">
+          <dt className="plugin-warning-meta-key">Release</dt>
+          <dd className="plugin-warning-meta-value">v{finding.version}</dd>
+        </div>
+      ) : null}
+      {finding.targetOpenClawVersion ? (
+        <div className="plugin-warning-meta-field">
+          <dt className="plugin-warning-meta-key">Target</dt>
+          <dd className="plugin-warning-meta-value">OpenClaw {finding.targetOpenClawVersion}</dd>
+        </div>
+      ) : null}
+    </dl>
   ) : null;
 
-  const evidenceDetails =
+  const evidenceBlock =
     visibleEvidence.length > 0 ? (
-      <details className="plugin-warning-evidence-details">
-        <summary className="plugin-warning-evidence-summary">
-          <span className="plugin-warning-evidence-summary-label">Technical evidence</span>
-          <ChevronRight className="plugin-warning-evidence-chevron" size={14} aria-hidden="true" />
-        </summary>
-        <div className="plugin-warning-evidence-block">
-          {visibleEvidence.map((entry) => (
-            <div className="plugin-warning-evidence-line" key={entry}>
-              {entry}
-            </div>
-          ))}
-          {hiddenEvidenceCount > 0 ? (
-            <p className="plugin-warning-evidence-more">+{hiddenEvidenceCount} more</p>
-          ) : null}
-        </div>
-      </details>
+      <div className="plugin-warning-evidence-block">
+        <p className="plugin-warning-evidence-label">Technical evidence</p>
+        {visibleEvidence.map((entry) => (
+          <div className="plugin-warning-evidence-line" key={entry}>
+            {entry}
+          </div>
+        ))}
+        {hiddenEvidenceCount > 0 ? (
+          <p className="plugin-warning-evidence-more">+{hiddenEvidenceCount} more</p>
+        ) : null}
+      </div>
     ) : null;
 
   const body = (
     <div className="plugin-warning-item-body">
       {fixGuide}
+      {evidenceBlock}
       {metadata}
-      {evidenceDetails}
     </div>
   );
+
+  const findingLabel = `${kind === "error" ? "Error" : "Warning"}: ${formatValidationFindingMessage(finding.message)}`;
 
   if (compact) {
     return (
       <details
         className={`plugin-warning-item plugin-warning-item-details is-${kind}`}
-        open={kind === "error"}
+        aria-label={findingLabel}
       >
-        <summary className="plugin-warning-item-summary">
-          {summaryCopy}
-          <code className="plugin-warning-item-code">{finding.code}</code>
-          <ChevronRight className="plugin-warning-item-chevron" size={14} aria-hidden="true" />
-        </summary>
+        <summary className="plugin-warning-item-summary">{summaryCopy}</summary>
         {body}
       </details>
     );
   }
 
   return (
-    <article className={`plugin-warning-item is-${kind}`}>
-      <div className="plugin-warning-item-main">
-        {summaryCopy}
-        <code className="plugin-warning-item-code">{finding.code}</code>
-      </div>
+    <article className={`plugin-warning-item is-${kind}`} aria-label={findingLabel}>
+      <div className="plugin-warning-item-main">{summaryCopy}</div>
       {body}
     </article>
   );
@@ -1035,10 +1074,7 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
     : undefined;
   const displayInspectorFindings =
     authorInspectorFindings && shouldShowDevValidationFindingMocks()
-      ? [
-          ...authorInspectorFindings,
-          ...buildDevValidationFindingMocks(authorInspectorFindings[0]),
-        ]
+      ? [...authorInspectorFindings, ...buildDevValidationFindingMocks(authorInspectorFindings[0])]
       : authorInspectorFindings;
   const [activeTab, setActiveTab] = useState<PluginDetailTab>("readme");
   const [mobileDetailPanel, setMobileDetailPanel] = useState<"content" | "stats">("content");
@@ -1243,11 +1279,9 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
   const validationWarnings = (
     displayInspectorFindings?.filter((finding) => finding.findingKind !== "error") ?? []
   ).sort(compareInspectorFindings);
+  const validationIssueCount = validationErrors.length + validationWarnings.length;
+  const validationReleaseVersion = latestRelease?.version ?? pkg.latestVersion ?? null;
   const showValidationGroups = validationErrors.length > 0 && validationWarnings.length > 0;
-  const validationSummaryHint = formatValidationSummaryHint(
-    validationErrors.length,
-    validationWarnings.length,
-  );
   const validationAgentFixPrompt =
     authorInspectorFindings && authorInspectorFindings.length > 0
       ? buildValidationAgentFixPrompt({
@@ -1257,27 +1291,6 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
         })
       : null;
   const compactFindingCards = (displayInspectorFindings?.length ?? 0) > 1;
-  const validationAgentPromptCard = validationAgentFixPrompt ? (
-    <div
-      className="plugin-validation-agent-prompt-card"
-      aria-labelledby="validation-agent-prompt-label"
-    >
-      <div className="plugin-validation-agent-prompt-copy">
-        <span id="validation-agent-prompt-label" className="plugin-validation-agent-prompt-label">
-          Fix with your agent
-        </span>
-        <p className="plugin-validation-agent-prompt-hint">
-          Paste into your coding agent to fix this check.
-        </p>
-      </div>
-      <InstallCopyButton
-        text={validationAgentFixPrompt}
-        label="Copy prompt"
-        ariaLabel="Copy agent fix prompt"
-        className="plugin-validation-agent-prompt-button"
-      />
-    </div>
-  ) : null;
   const validationPanel =
     displayInspectorFindings && displayInspectorFindings.length > 0 ? (
       <section
@@ -1288,57 +1301,83 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
         <header className="plugin-validation-overview">
           <div className="plugin-validation-panel-title-row">
             <h2 id="validation-heading" className="plugin-validation-panel-title">
-              Validation findings
+              Validation
             </h2>
-            <span className="plugin-validation-panel-stats" aria-label="Validation summary">
-              <span
-                className={
-                  validationErrors.length > 0
-                    ? "plugin-validation-panel-stat is-error"
-                    : "plugin-validation-panel-stat is-muted"
-                }
-              >
-                {validationErrors.length}{" "}
-                {validationErrors.length === 1 ? "error" : "errors"}
+            <div className="plugin-validation-panel-title-actions">
+              <span className="plugin-validation-panel-stats" aria-label="Validation summary">
+                <span
+                  className={
+                    validationErrors.length > 0
+                      ? "plugin-validation-panel-stat"
+                      : "plugin-validation-panel-stat is-muted"
+                  }
+                >
+                  {validationErrors.length} {validationErrors.length === 1 ? "error" : "errors"}
+                </span>
+                <span className="plugin-validation-panel-stats-sep" aria-hidden="true">
+                  ·
+                </span>
+                <span
+                  className={
+                    validationWarnings.length > 0
+                      ? "plugin-validation-panel-stat"
+                      : "plugin-validation-panel-stat is-muted"
+                  }
+                >
+                  {validationWarnings.length}{" "}
+                  {validationWarnings.length === 1 ? "warning" : "warnings"}
+                </span>
               </span>
-              <span className="plugin-validation-panel-stats-sep" aria-hidden="true">
-                ·
-              </span>
-              <span
-                className={
-                  validationWarnings.length > 0
-                    ? "plugin-validation-panel-stat is-warning"
-                    : "plugin-validation-panel-stat is-muted"
-                }
-              >
-                {validationWarnings.length}{" "}
-                {validationWarnings.length === 1 ? "warning" : "warnings"}
-              </span>
-            </span>
+            </div>
           </div>
-          {validationSummaryHint ? (
-            <p className="plugin-validation-summary-hint">{validationSummaryHint}</p>
+          {validationIssueCount > 0 ? (
+            <p className="plugin-validation-summary-hint">
+              <ValidationSummaryHint
+                issueCount={validationIssueCount}
+                packageName={pkg.name}
+                version={validationReleaseVersion}
+              />
+            </p>
           ) : null}
-          <div className="plugin-validation-cli-card" aria-labelledby="validation-cli-label">
-            <span id="validation-cli-label" className="plugin-validation-cli-label">
-              Run locally
-            </span>
-            <code className="plugin-validation-command">{PLUGIN_VALIDATE_CLI}</code>
-            <InstallCopyButton
-              text={PLUGIN_VALIDATE_CLI}
-              ariaLabel="Copy validate command"
-              showLabel={false}
-              className="plugin-validation-cli-copy"
-            />
+          <div className="plugin-validation-actions" role="toolbar" aria-label="Validation actions">
+            <div className="plugin-validation-actions-row">
+              <div className="plugin-validation-command-block">
+                <span id="validation-toolbar-label" className="plugin-validation-toolbar-label">
+                  {PLUGIN_VALIDATE_TOOLBAR_LABEL}
+                </span>
+                <div className="plugin-validation-toolbar">
+                  <div
+                    id="validation-toolbar-cli"
+                    className="plugin-validation-toolbar-cli"
+                    aria-labelledby="validation-toolbar-label"
+                  >
+                    <code className="plugin-validation-command">{PLUGIN_VALIDATE_CLI}</code>
+                    <InstallCopyButton
+                      text={PLUGIN_VALIDATE_CLI}
+                      ariaLabel="Copy validate command"
+                      showLabel={false}
+                      className="plugin-validation-toolbar-copy"
+                    />
+                  </div>
+                </div>
+              </div>
+              {validationAgentFixPrompt ? (
+                <div className="plugin-validation-toolbar-agent">
+                  <InstallCopyButton
+                    text={validationAgentFixPrompt}
+                    label="Copy instructions"
+                    tooltip="Paste into your coding agent to fix these findings."
+                    ariaLabel="Copy fix instructions"
+                    className="plugin-validation-panel-agent"
+                  />
+                </div>
+              ) : null}
+            </div>
           </div>
-          {validationAgentPromptCard}
         </header>
-        <section
-          className="plugin-validation-panel-findings"
-          aria-label="Issues to review"
-        >
+        <section className="plugin-validation-panel-findings" aria-label="Issues to review">
           {validationErrors.length > 0 ? (
-            <>
+            <div className="plugin-validation-findings-group is-error">
               {showValidationGroups ? (
                 <h4 className="plugin-validation-group-label is-error">
                   Errors ({validationErrors.length})
@@ -1353,10 +1392,10 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
                   />
                 ))}
               </div>
-            </>
+            </div>
           ) : null}
           {validationWarnings.length > 0 ? (
-            <>
+            <div className="plugin-validation-findings-group is-warning">
               {showValidationGroups ? (
                 <h4 className="plugin-validation-group-label is-warning">
                   Warnings ({validationWarnings.length})
@@ -1371,7 +1410,7 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
                   />
                 ))}
               </div>
-            </>
+            </div>
           ) : null}
         </section>
       </section>

--- a/src/styles.css
+++ b/src/styles.css
@@ -4884,12 +4884,21 @@ code {
 }
 
 .plugin-validation-panel .plugin-warning-fix-guide {
+  display: grid;
+  gap: 4px;
   width: 100%;
   padding: 8px 10px;
   border: 0;
   border-left: 2px solid color-mix(in srgb, var(--status-success-fg) 42%, var(--line));
   border-radius: 0;
   background: color-mix(in srgb, var(--status-success-fg) 5%, transparent);
+}
+
+.plugin-validation-panel .plugin-warning-fix-guide-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
 }
 
 .plugin-validation-panel .plugin-warning-fix-guide-label {
@@ -4909,9 +4918,11 @@ code {
 }
 
 .plugin-validation-panel .plugin-warning-fix-link {
+  flex-shrink: 0;
   color: color-mix(in srgb, #7ab7ff 88%, white);
   font-weight: 500;
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .plugin-validation-panel .plugin-warning-fix-link:hover,
@@ -5110,12 +5121,21 @@ code {
 }
 
 .plugin-warning-fix-guide {
+  display: grid;
+  gap: 4px;
   width: 100%;
   padding: 8px 10px;
   border: 0;
   border-left: 2px solid color-mix(in srgb, var(--status-success-fg) 42%, var(--line));
   border-radius: 0;
   background: color-mix(in srgb, var(--status-success-fg) 5%, transparent);
+}
+
+.plugin-warning-fix-guide-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
 }
 
 .plugin-warning-fix-guide-label {
@@ -5251,11 +5271,12 @@ code {
 }
 
 .plugin-warning-fix-link {
-  justify-self: start;
+  flex-shrink: 0;
   color: color-mix(in srgb, #7ab7ff 88%, white);
   font-size: 0.84rem;
   font-weight: 650;
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .plugin-warning-fix-link:hover,

--- a/src/styles.css
+++ b/src/styles.css
@@ -5448,10 +5448,19 @@ code {
 .skill-management-toolbar {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 12px;
   width: 100%;
-  min-height: 0;
+  min-height: 32px;
   padding: 0 2px 8px;
   border-bottom: 1px solid color-mix(in srgb, var(--line) 60%, transparent);
+}
+
+.skill-management-toolbar-alert {
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .skill-management-toolbar-inner {
@@ -5459,7 +5468,8 @@ code {
   align-items: center;
   justify-content: flex-end;
   gap: 4px;
-  width: 100%;
+  flex: 0 0 auto;
+  margin-left: auto;
 }
 
 .skill-management-toolbar-action {
@@ -5617,12 +5627,24 @@ code {
 }
 
 .skill-visibility-alert {
-  max-width: 760px;
-  color: #f5c84b;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin: 0;
+  min-width: 0;
+  color: var(--status-error-fg);
+  font-size: 0.8125rem;
+  font-weight: 550;
+  line-height: 1.3;
 }
 
 .skill-visibility-alert > svg {
-  color: #f5c84b;
+  flex: 0 0 auto;
+  color: var(--status-error-fg);
+}
+
+.skill-visibility-alert > span {
+  min-width: 0;
 }
 
 .tag-accent {
@@ -6759,6 +6781,14 @@ code {
   color: color-mix(in srgb, var(--ink-soft) 70%, transparent);
   user-select: none;
   pointer-events: none;
+}
+
+.skill-install-command-wrap .skill-install-command-verb {
+  color: color-mix(in srgb, var(--ink-soft) 70%, transparent);
+}
+
+.skill-install-command-wrap .skill-install-command-target {
+  color: var(--ink);
 }
 
 [data-theme-resolved="light"] .skill-install-command-shell {

--- a/src/styles.css
+++ b/src/styles.css
@@ -4549,7 +4549,7 @@ code {
 
 .plugin-validation-panel {
   display: grid;
-  gap: var(--space-5);
+  gap: var(--space-6);
   margin-bottom: var(--space-4);
   border: 1px solid color-mix(in srgb, var(--line) 92%, transparent);
   border-radius: var(--radius-md);
@@ -4560,19 +4560,29 @@ code {
 
 .plugin-validation-overview {
   display: grid;
-  gap: var(--space-4);
+  gap: var(--space-3);
 }
 
 .plugin-validation-panel-title-row {
   display: flex;
   flex-wrap: wrap;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
   gap: var(--space-2) var(--space-3);
 }
 
+.plugin-validation-panel-title-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2) var(--space-3);
+  margin-left: auto;
+}
+
 .plugin-validation-panel-title {
   margin: 0;
+  min-width: 0;
   color: var(--ink);
   font-size: 1.02rem;
   font-weight: 750;
@@ -4584,30 +4594,31 @@ code {
   display: inline-flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
   white-space: nowrap;
+  padding: 2px 10px;
+  border: 1px solid color-mix(in srgb, var(--line) 82%, transparent);
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--surface-muted) 42%, transparent);
+  color: var(--ink-soft);
 }
 
 .plugin-validation-panel-stat {
-  font-size: 0.8rem;
+  font-size: 0.74rem;
   font-weight: 600;
-  line-height: 1.3;
-}
-
-.plugin-validation-panel-stat.is-error,
-.plugin-validation-panel-stat.is-warning {
-  color: var(--ink);
+  line-height: 1.35;
+  color: var(--ink-soft);
 }
 
 .plugin-validation-panel-stat.is-muted {
-  color: var(--ink-soft);
   font-weight: 500;
+  opacity: 0.72;
 }
 
 .plugin-validation-panel-stats-sep {
   color: var(--ink-soft);
-  opacity: 0.42;
-  font-size: 0.8rem;
+  opacity: 0.38;
+  font-size: 0.74rem;
   line-height: 1;
   user-select: none;
 }
@@ -4620,99 +4631,170 @@ code {
   line-height: 1.5;
 }
 
-.plugin-validation-cli-card {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  align-items: center;
-  gap: var(--space-3);
-  border: 1px solid color-mix(in srgb, var(--line) 92%, transparent);
-  border-radius: var(--radius-md);
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--surface-muted) 34%, var(--surface)) 0%,
-    color-mix(in srgb, var(--surface-muted) 10%, var(--surface)) 100%
-  );
-  box-shadow: inset 0 1px 0 color-mix(in srgb, white 4%, transparent);
-  padding: var(--space-3) var(--space-4);
+.plugin-validation-summary-hint strong {
+  color: var(--ink);
+  font-weight: 650;
 }
 
-.plugin-validation-agent-prompt-card {
+.plugin-validation-actions {
+  min-width: 0;
+}
+
+.plugin-validation-summary-hint + .plugin-validation-actions {
+  margin-top: var(--space-3);
+}
+
+.plugin-validation-actions-row {
+  --plugin-validation-toolbar-height: 2.5rem;
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
+  align-items: flex-end;
   gap: var(--space-3);
-  border: 1px solid color-mix(in srgb, var(--line) 92%, transparent);
-  border-radius: var(--radius-md);
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--surface-muted) 28%, var(--surface)) 0%,
-    color-mix(in srgb, var(--surface-muted) 8%, var(--surface)) 100%
-  );
-  box-shadow: inset 0 1px 0 color-mix(in srgb, white 4%, transparent);
-  padding: var(--space-3) var(--space-4);
 }
 
-.plugin-validation-agent-prompt-copy {
-  display: grid;
-  gap: 2px;
+.plugin-validation-command-block {
+  display: flex;
+  flex: 1 1 16rem;
+  flex-direction: column;
+  gap: var(--space-2);
   min-width: 0;
-  flex: 1 1 14rem;
 }
 
-.plugin-validation-agent-prompt-label {
-  color: var(--ink);
-  font-size: 0.8rem;
-  font-weight: 650;
-  line-height: 1.3;
+.plugin-validation-toolbar {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: center;
+  min-width: 0;
+  height: var(--plugin-validation-toolbar-height);
+  min-height: var(--plugin-validation-toolbar-height);
+  border: 1px solid color-mix(in srgb, var(--line) 52%, transparent);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--surface-muted) 14%, transparent);
+  padding: var(--space-2) var(--space-3);
 }
 
-.plugin-validation-agent-prompt-hint {
+[data-theme-resolved="light"] .plugin-validation-toolbar {
+  border-color: color-mix(in srgb, var(--line) 44%, transparent);
+  background: color-mix(in srgb, var(--surface-muted) 10%, var(--bg) 90%);
+}
+
+.plugin-validation-toolbar-label {
   margin: 0;
   color: var(--ink-soft);
-  font-size: 0.78rem;
-  line-height: 1.45;
-}
-
-.plugin-validation-agent-prompt-button {
-  flex: 0 0 auto;
-}
-
-.plugin-validation-cli-label {
-  color: var(--ink-soft);
-  font-size: 0.8rem;
+  font-size: 0.74rem;
   font-weight: 500;
+  line-height: 1.3;
+  opacity: 0.82;
+}
+
+.plugin-validation-toolbar-cli {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  width: 100%;
+}
+
+.plugin-validation-toolbar-copy.skill-install-copy-button {
+  flex: 0 0 auto;
+  width: 2rem;
+  min-width: 2rem;
+  height: 2rem;
+  min-height: 2rem;
+  padding: 0;
+  justify-content: center;
+  border-color: transparent;
+  background: transparent;
+  color: color-mix(in srgb, var(--ink-soft) 88%, transparent);
+  box-shadow: none;
+}
+
+.plugin-validation-toolbar-copy.skill-install-copy-button:hover:not(:disabled),
+.plugin-validation-toolbar-copy.skill-install-copy-button:focus-visible {
+  border-color: color-mix(in srgb, var(--line) 58%, transparent);
+  background: color-mix(in srgb, var(--surface-muted) 28%, transparent);
+  color: var(--ink);
+}
+
+[data-theme-resolved="light"]
+  .plugin-validation-toolbar-copy.skill-install-copy-button:hover:not(:disabled),
+[data-theme-resolved="light"]
+  .plugin-validation-toolbar-copy.skill-install-copy-button:focus-visible {
+  border-color: color-mix(in srgb, var(--line) 50%, transparent);
+  background: color-mix(in srgb, var(--surface-muted) 22%, var(--bg) 78%);
+}
+
+.plugin-validation-toolbar-agent {
+  display: flex;
+  flex: 0 0 auto;
+  align-self: flex-end;
+  align-items: center;
+  height: var(--plugin-validation-toolbar-height);
+}
+
+.plugin-validation-panel-agent.skill-install-copy-button {
+  flex: 0 0 auto;
+  height: var(--plugin-validation-toolbar-height);
+  min-height: var(--plugin-validation-toolbar-height);
+  max-height: var(--plugin-validation-toolbar-height);
+  padding-top: 0;
+  padding-bottom: 0;
   white-space: nowrap;
+  border-color: color-mix(in srgb, var(--line) 78%, transparent);
+  background: color-mix(in srgb, var(--surface-muted) 34%, transparent);
+  color: var(--ink);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 5%, transparent);
+}
+
+[data-theme-resolved="light"] .plugin-validation-panel-agent.skill-install-copy-button {
+  border-color: color-mix(in srgb, var(--line) 70%, transparent);
+  background: color-mix(in srgb, var(--surface-muted) 18%, var(--bg) 82%);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 72%, transparent);
+}
+
+.plugin-validation-panel-agent.skill-install-copy-button:hover:not(:disabled),
+.plugin-validation-panel-agent.skill-install-copy-button:focus-visible {
+  border-color: color-mix(in srgb, var(--line) 92%, var(--accent) 8%);
+  background: color-mix(in srgb, var(--surface-muted) 48%, transparent);
 }
 
 .plugin-validation-command {
+  flex: 1;
   min-width: 0;
   border: 0;
   border-radius: 0;
   background: transparent;
   padding: 0;
-  color: var(--ink);
+  color: var(--ink-soft);
   font-family: var(--font-mono);
-  font-size: 0.76rem;
+  font-size: 0.74rem;
   line-height: 1.45;
-  overflow-wrap: anywhere;
-  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .plugin-validation-panel-findings {
   display: grid;
-  gap: var(--space-4);
+  gap: var(--space-6);
   padding-top: var(--space-5);
   border-top: 1px solid color-mix(in srgb, var(--line) 90%, transparent);
 }
 
+.plugin-validation-findings-group {
+  display: grid;
+  gap: var(--space-2);
+}
+
 .plugin-validation-group-label {
   margin: 0;
-  padding-top: var(--space-1);
-  color: var(--ink);
-  font-size: 0.78rem;
-  font-weight: 650;
+  padding: 0;
+  color: var(--ink-soft);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.07em;
   line-height: 1.3;
+  text-transform: uppercase;
 }
 
 .plugin-validation-group-label.is-error {
@@ -4724,73 +4806,68 @@ code {
 }
 
 @media (max-width: 640px) {
-  .plugin-validation-cli-card {
-    grid-template-columns: 1fr auto;
-    grid-template-rows: auto auto;
+  .plugin-validation-panel-title-row {
+    flex-direction: column;
+    align-items: flex-start;
   }
 
-  .plugin-validation-cli-label {
-    grid-column: 1 / -1;
+  .plugin-validation-panel-title-actions {
+    margin-left: 0;
+  }
+
+  .plugin-validation-actions-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .plugin-validation-command-block {
+    flex: 1 1 100%;
+  }
+
+  .plugin-validation-toolbar-agent {
+    flex: 0 0 auto;
+    justify-content: flex-start;
+  }
+
+  .plugin-validation-panel-agent.skill-install-copy-button {
+    align-self: stretch;
+    width: 100%;
+    height: auto;
+    min-height: var(--plugin-validation-toolbar-height);
+    max-height: none;
+    padding-top: 0.375rem;
+    padding-bottom: 0.375rem;
+    justify-content: center;
   }
 
   .plugin-validation-command {
-    grid-column: 1;
-    text-align: left;
-  }
-
-  .plugin-validation-cli-copy {
-    grid-column: 2;
-    grid-row: 2;
-  }
-
-  .plugin-validation-panel .plugin-warning-item-summary,
-  .plugin-warning-item-summary {
-    grid-template-columns: 1fr auto;
-    grid-template-rows: auto auto;
-  }
-
-  .plugin-validation-panel .plugin-warning-item-code,
-  .plugin-warning-item-code {
-    grid-column: 1;
-    max-width: none;
-    text-align: left;
-  }
-
-  .plugin-warning-item-chevron {
-    grid-column: 2;
-    grid-row: 1 / span 2;
-    align-self: center;
-  }
-
-  .plugin-validation-panel .plugin-warning-item-main,
-  .plugin-warning-item-main {
-    grid-template-columns: 1fr;
-    gap: var(--space-2);
-  }
-
-  .plugin-validation-panel .plugin-warning-item-code,
-  .plugin-warning-item-code {
-    max-width: none;
-    text-align: left;
+    white-space: normal;
+    overflow-wrap: anywhere;
   }
 }
 
 .plugin-validation-panel .plugin-warning-list {
-  gap: var(--space-3);
+  gap: 0;
   padding: 0;
+  overflow: hidden;
+  border-radius: var(--radius-sm);
 }
 
 .plugin-validation-panel-findings:has(.plugin-warning-item-details) .plugin-warning-list {
-  gap: var(--space-2);
+  gap: 0;
 }
 
 .plugin-validation-panel .plugin-warning-item {
-  border: 1px solid color-mix(in srgb, var(--line) 92%, transparent);
-  border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--surface-muted) 18%, transparent);
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   box-shadow: none;
-  padding: var(--space-3);
-  gap: var(--space-2);
+  padding: 0;
+  gap: 0;
+}
+
+.plugin-validation-panel .plugin-warning-list > :not(:first-child) {
+  border-top: 1px solid var(--line);
 }
 
 .plugin-validation-panel .plugin-warning-item.plugin-warning-item-details {
@@ -4798,16 +4875,22 @@ code {
   gap: 0;
 }
 
+.plugin-validation-panel .plugin-warning-item.plugin-warning-item-details[open] {
+  background: color-mix(in srgb, var(--surface-muted) 42%, var(--bg-soft));
+}
+
+.plugin-validation-panel .plugin-warning-list > .plugin-warning-item-details[open],
+.plugin-validation-panel .plugin-warning-list > .plugin-warning-item-details[open] + * {
+  border-top-color: transparent;
+}
+
 .plugin-warning-item-summary {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
-  align-items: start;
-  gap: var(--space-2) var(--space-3);
   width: 100%;
   padding: var(--space-3);
   cursor: pointer;
   list-style: none;
   user-select: none;
+  background: transparent;
   transition: background-color 120ms ease;
 }
 
@@ -4821,15 +4904,37 @@ code {
 
 .plugin-warning-item-summary:hover,
 .plugin-warning-item-summary:focus-visible {
-  background: color-mix(in srgb, var(--surface-muted) 42%, transparent);
+  background: color-mix(in srgb, var(--surface-muted) 60%, transparent);
   outline: none;
 }
 
-.plugin-warning-item-details[open] > .plugin-warning-item-summary {
-  border-bottom: 1px solid color-mix(in srgb, var(--line) 90%, transparent);
+.plugin-validation-panel .plugin-warning-item-summary:hover,
+.plugin-validation-panel .plugin-warning-item-summary:focus-visible {
+  background: color-mix(in srgb, var(--surface-muted) 34%, transparent);
 }
 
-.plugin-warning-item-chevron {
+.plugin-warning-item-details[open] > .plugin-warning-item-summary {
+  background: color-mix(in srgb, var(--surface-muted) 65%, transparent);
+  border-bottom: 1px solid var(--line);
+}
+
+.plugin-validation-panel .plugin-warning-item-details[open] > .plugin-warning-item-summary {
+  background: color-mix(in srgb, var(--surface-muted) 72%, var(--bg-soft));
+  border-bottom: none;
+}
+
+.plugin-validation-panel .plugin-warning-item-details[open] > .plugin-warning-item-summary:hover,
+.plugin-validation-panel
+  .plugin-warning-item-details[open]
+  > .plugin-warning-item-summary:focus-visible {
+  background: color-mix(in srgb, var(--surface-muted) 78%, var(--bg-soft));
+}
+
+.plugin-validation-panel .plugin-warning-item-details[open] > .plugin-warning-item-body {
+  background: transparent;
+}
+
+.plugin-warning-item-expand-chevron {
   flex-shrink: 0;
   align-self: center;
   color: var(--ink-soft);
@@ -4838,49 +4943,141 @@ code {
     color 120ms ease;
 }
 
-.plugin-warning-item-summary:hover .plugin-warning-item-chevron,
-.plugin-warning-item-summary:focus-visible .plugin-warning-item-chevron {
-  color: var(--ink);
+.plugin-warning-item-summary:hover .plugin-warning-item-expand-chevron,
+.plugin-warning-item-summary:focus-visible .plugin-warning-item-expand-chevron {
+  color: color-mix(in srgb, var(--ink) 78%, var(--ink-soft));
 }
 
-.plugin-warning-item-details[open] .plugin-warning-item-chevron {
+.plugin-warning-item-details[open] .plugin-warning-item-expand-chevron {
   transform: rotate(90deg);
 }
 
 .plugin-warning-item-body {
   display: grid;
   gap: var(--space-2);
-  padding: var(--space-2) var(--space-3) var(--space-3);
+  padding: 0 var(--space-3) var(--space-3) calc(var(--space-3) + 18px);
+}
+
+.plugin-validation-panel .plugin-warning-item-body {
+  padding-top: var(--space-3);
 }
 
 .plugin-validation-panel .plugin-warning-item-main {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: start;
-  gap: var(--space-4);
+  padding: var(--space-3);
 }
 
-.plugin-validation-panel .plugin-warning-item-copy {
+.plugin-warning-item-lead {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  min-width: 0;
+}
+
+.plugin-warning-severity-dot {
+  flex-shrink: 0;
+  align-self: flex-start;
+  width: 8px;
+  height: 8px;
+  margin-top: 0.38em;
+  border-radius: 50%;
+}
+
+.plugin-warning-severity-dot.is-error {
+  background: var(--status-error-fg);
+}
+
+.plugin-warning-severity-dot.is-warning {
+  background: var(--status-warning-fg);
+}
+
+.plugin-warning-item-copy {
   display: grid;
+  flex: 1;
   gap: 4px;
   min-width: 0;
 }
 
-.plugin-validation-panel .plugin-warning-item-message {
-  margin: 0;
-  max-width: none;
-  color: var(--ink);
-  font-size: 0.86rem;
-  font-weight: 600;
-  line-height: 1.4;
+.plugin-warning-item-title-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  width: 100%;
 }
 
-.plugin-validation-panel .plugin-warning-item-tags {
+.plugin-warning-item-title-row > .plugin-warning-item-expand-chevron {
+  flex-shrink: 0;
+  align-self: center;
+  margin-inline-start: auto;
+}
+
+.plugin-validation-panel .plugin-warning-item-message {
   margin: 0;
-  color: var(--ink-soft);
-  font-size: 0.78rem;
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: none;
+  color: var(--ink);
+  font-size: 0.84rem;
   font-weight: 500;
+  line-height: 1.45;
+}
+
+.plugin-warning-priority-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  align-self: center;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  line-height: 1;
+}
+
+.plugin-warning-priority-badge.is-error {
+  color: var(--status-error-fg);
+  background: color-mix(in srgb, var(--status-error-bg) 80%, transparent);
+}
+
+.plugin-warning-priority-badge.is-warning {
+  color: var(--status-warning-fg);
+  background: color-mix(in srgb, var(--status-warning-bg) 80%, transparent);
+}
+
+.plugin-validation-panel .plugin-warning-item-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0;
+  min-width: 0;
+  color: var(--ink-soft);
+  font-size: 0.76rem;
+  font-weight: 400;
   line-height: 1.35;
+}
+
+.plugin-warning-item-meta-text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.plugin-validation-panel .plugin-warning-item-code {
+  display: inline;
+  padding: 0;
+  overflow: hidden;
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  font-weight: 400;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  vertical-align: baseline;
+  white-space: nowrap;
 }
 
 .plugin-validation-panel .plugin-warning-fix-guide {
@@ -4889,9 +5086,8 @@ code {
   gap: var(--space-3);
   width: 100%;
   padding: 8px 10px;
-  border: 0;
-  border-left: 2px solid color-mix(in srgb, var(--status-success-fg) 42%, var(--line));
-  border-radius: 0;
+  border: 1px solid color-mix(in srgb, var(--status-success-fg) 30%, var(--line));
+  border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--status-success-fg) 5%, transparent);
 }
 
@@ -4903,6 +5099,9 @@ code {
 }
 
 .plugin-validation-panel .plugin-warning-fix-guide-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   margin: 0;
   color: color-mix(in srgb, var(--status-success-fg) 74%, var(--ink));
   font-size: 0.78rem;
@@ -4920,53 +5119,80 @@ code {
 
 .plugin-validation-panel .plugin-warning-fix-link {
   flex-shrink: 0;
-  color: #0099ff;
+  color: var(--official-fg);
   font-weight: 500;
   text-decoration: none;
   white-space: nowrap;
+  transition: color 120ms ease;
 }
 
 .plugin-validation-panel .plugin-warning-fix-link:hover,
 .plugin-validation-panel .plugin-warning-fix-link:focus-visible {
+  color: color-mix(in srgb, var(--official-fg) 72%, var(--ink));
   text-decoration: underline;
 }
 
-.plugin-validation-panel .plugin-warning-meta-line {
+.plugin-validation-panel .plugin-warning-meta-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2) var(--space-3);
+  margin: var(--space-2) 0 0;
+  padding: 0;
+}
+
+.plugin-validation-panel .plugin-warning-meta-field {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
   margin: 0;
-  color: color-mix(in srgb, var(--ink-soft) 88%, transparent);
+}
+
+.plugin-validation-panel .plugin-warning-meta-key {
+  margin: 0;
+  color: var(--ink-soft);
   font-size: 0.76rem;
+  font-weight: 500;
   line-height: 1.4;
 }
 
-.plugin-validation-panel .plugin-warning-item-code {
-  flex: 0 0 auto;
-  max-width: 9rem;
-  padding: 2px 0;
-  color: var(--ink-soft);
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
+.plugin-validation-panel .plugin-warning-meta-value {
+  margin: 0;
+  color: color-mix(in srgb, var(--ink-soft) 92%, var(--ink));
+  font-size: 0.76rem;
   font-weight: 500;
-  line-height: 1.35;
-  text-align: right;
-  overflow-wrap: anywhere;
+  line-height: 1.4;
 }
 
-.plugin-validation-panel .plugin-warning-evidence-details {
-  margin-top: 0;
+.plugin-validation-panel .plugin-warning-evidence-block {
+  display: grid;
+  gap: 2px;
+  margin-top: var(--space-3);
   padding-top: var(--space-2);
   border-top: 1px solid color-mix(in srgb, var(--line) 90%, transparent);
-}
-
-.plugin-validation-panel .plugin-warning-evidence-chevron {
-  flex-shrink: 0;
   color: var(--ink-soft);
-  transition:
-    transform 120ms ease,
-    color 120ms ease;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  line-height: 1.35;
 }
 
-.plugin-validation-panel .plugin-warning-evidence-details[open] .plugin-warning-evidence-chevron {
-  transform: rotate(90deg);
+.plugin-validation-panel .plugin-warning-evidence-label {
+  margin: 0 0 2px;
+  color: var(--ink-soft);
+  font-family: var(--font-sans);
+  font-size: 0.76rem;
+  line-height: 1.25;
+}
+
+.plugin-validation-panel .plugin-warning-evidence-line + .plugin-warning-evidence-line {
+  margin-top: 0;
+}
+
+.plugin-validation-panel .plugin-warning-evidence-more {
+  margin: 2px 0 0;
+  color: var(--ink-soft);
+  font-family: var(--font-sans);
+  font-size: 0.7rem;
 }
 
 .plugin-manifest-section {
@@ -5060,6 +5286,12 @@ code {
   background: color-mix(in srgb, var(--surface-muted) 18%, transparent);
 }
 
+.plugin-validation-panel .plugin-warning-item,
+.plugin-validation-panel .plugin-warning-item.is-error,
+.plugin-validation-panel .plugin-warning-item.is-warning {
+  background: transparent;
+}
+
 .plugin-warning-item-main {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -5127,9 +5359,8 @@ code {
   gap: var(--space-3);
   width: 100%;
   padding: 8px 10px;
-  border: 0;
-  border-left: 2px solid color-mix(in srgb, var(--status-success-fg) 42%, var(--line));
-  border-radius: 0;
+  border: 1px solid color-mix(in srgb, var(--status-success-fg) 30%, var(--line));
+  border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--status-success-fg) 5%, transparent);
 }
 
@@ -5141,6 +5372,9 @@ code {
 }
 
 .plugin-warning-fix-guide-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   margin: 0;
   color: color-mix(in srgb, var(--status-success-fg) 74%, var(--ink));
   font-size: 0.78rem;
@@ -5160,83 +5394,57 @@ code {
   font-weight: 650;
 }
 
-.plugin-warning-meta-line {
+.plugin-warning-meta-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2) var(--space-3);
+  margin: var(--space-2) 0 0;
+  padding: 0;
+}
+
+.plugin-warning-meta-field {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
   margin: 0;
-  color: color-mix(in srgb, var(--ink-soft) 88%, transparent);
+}
+
+.plugin-warning-meta-key {
+  margin: 0;
+  color: var(--ink-soft);
   font-size: 0.76rem;
+  font-weight: 500;
   line-height: 1.4;
 }
 
-.plugin-warning-evidence-details {
-  display: grid;
-  gap: var(--space-2);
-  margin-top: var(--space-3);
-  padding-top: var(--space-3);
-  border-top: 1px solid color-mix(in srgb, var(--line) 90%, transparent);
-}
-
-.plugin-warning-evidence-summary {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
-  width: calc(100% + (var(--space-4) * 2));
-  min-height: 2.25rem;
-  margin-inline: calc(var(--space-4) * -1);
-  padding: var(--space-2) var(--space-4);
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  color: var(--ink-soft);
-  font-size: 0.78rem;
+.plugin-warning-meta-value {
+  margin: 0;
+  color: color-mix(in srgb, var(--ink-soft) 92%, var(--ink));
+  font-size: 0.76rem;
   font-weight: 500;
-  line-height: 1.3;
-  list-style: none;
-  user-select: none;
-  transition:
-    background-color 120ms ease,
-    color 120ms ease;
-}
-
-.plugin-warning-evidence-summary:hover,
-.plugin-warning-evidence-summary:focus-visible {
-  background: color-mix(in srgb, var(--surface-muted) 42%, transparent);
-  color: var(--ink);
-  outline: none;
-}
-
-.plugin-warning-evidence-summary:hover .plugin-warning-evidence-chevron,
-.plugin-warning-evidence-summary:focus-visible .plugin-warning-evidence-chevron {
-  color: var(--ink);
-}
-
-.plugin-warning-evidence-summary::-webkit-details-marker {
-  display: none;
-}
-
-.plugin-warning-evidence-summary::marker {
-  content: "";
-}
-
-.plugin-warning-evidence-chevron {
-  flex-shrink: 0;
-  color: var(--ink-soft);
-  transition:
-    transform 120ms ease,
-    color 120ms ease;
-}
-
-.plugin-warning-evidence-details[open] .plugin-warning-evidence-chevron {
-  transform: rotate(90deg);
+  line-height: 1.4;
 }
 
 .plugin-warning-evidence-block {
   display: grid;
   gap: 4px;
-  padding-top: 6px;
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid color-mix(in srgb, var(--line) 90%, transparent);
   color: var(--ink-soft);
   font-family: var(--font-mono);
   font-size: 0.74rem;
   line-height: 1.45;
+}
+
+.plugin-warning-evidence-label {
+  margin: 0 0 2px;
+  color: var(--ink-soft);
+  font-family: var(--font-sans);
+  font-size: 0.76rem;
+  font-weight: 500;
+  line-height: 1.4;
 }
 
 .plugin-warning-evidence-line + .plugin-warning-evidence-line {
@@ -5274,16 +5482,17 @@ code {
 
 .plugin-warning-fix-link {
   flex-shrink: 0;
-  color: #0099ff;
+  color: var(--official-fg);
   font-size: 0.84rem;
   font-weight: 650;
   text-decoration: none;
   white-space: nowrap;
+  transition: color 120ms ease;
 }
 
 .plugin-warning-fix-link:hover,
 .plugin-warning-fix-link:focus-visible {
-  color: #33adff;
+  color: color-mix(in srgb, var(--official-fg) 72%, var(--ink));
   text-decoration: underline;
 }
 
@@ -5963,7 +6172,7 @@ code {
   width: 18px;
   height: 18px;
   background: transparent;
-  color: var(--accent);
+  color: color-mix(in srgb, var(--ink-soft) 76%, var(--bg));
 }
 
 .plugin-catalog-empty-alert--hero .plugin-catalog-empty-alert-icon svg {
@@ -5987,17 +6196,18 @@ code {
   gap: 4px;
   border: none !important;
   background: transparent !important;
-  color: var(--accent) !important;
+  color: color-mix(in srgb, var(--ink-soft) 76%, var(--bg)) !important;
   font-size: 0.75rem;
-  font-weight: 650;
+  font-weight: 600;
   text-decoration: none;
+  text-underline-offset: 3px;
 }
 
 .plugin-catalog-empty-alert--hero .plugin-catalog-empty-alert-cta:hover,
 .plugin-catalog-empty-alert--hero .plugin-catalog-empty-alert-cta:focus-visible {
   border: none !important;
   background: transparent !important;
-  color: var(--accent-deep) !important;
+  color: var(--ink) !important;
   text-decoration: underline;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -4547,13 +4547,414 @@ code {
   min-width: 0;
 }
 
-.plugin-warnings-panel {
+.plugin-validation-panel {
+  display: grid;
+  gap: var(--space-5);
+  margin-bottom: var(--space-4);
+  border: 1px solid color-mix(in srgb, var(--line) 92%, transparent);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  padding: var(--space-5);
+  scroll-margin-top: var(--space-6);
+}
+
+.plugin-validation-overview {
+  display: grid;
   gap: var(--space-4);
 }
 
-.plugin-manifest-capabilities {
+.plugin-validation-panel-title-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2) var(--space-3);
+}
+
+.plugin-validation-panel-title {
+  margin: 0;
+  color: var(--ink);
+  font-size: 1.02rem;
+  font-weight: 750;
+  line-height: 1.3;
+  letter-spacing: -0.01em;
+}
+
+.plugin-validation-panel-stats {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.plugin-validation-panel-stat {
+  font-size: 0.8rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.plugin-validation-panel-stat.is-error,
+.plugin-validation-panel-stat.is-warning {
+  color: var(--ink);
+}
+
+.plugin-validation-panel-stat.is-muted {
+  color: var(--ink-soft);
+  font-weight: 500;
+}
+
+.plugin-validation-panel-stats-sep {
+  color: var(--ink-soft);
+  opacity: 0.42;
+  font-size: 0.8rem;
+  line-height: 1;
+  user-select: none;
+}
+
+.plugin-validation-summary-hint {
+  margin: 0;
+  max-width: 62ch;
+  color: var(--ink-soft);
+  font-size: 0.84rem;
+  line-height: 1.5;
+}
+
+.plugin-validation-cli-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-3);
+  border: 1px solid color-mix(in srgb, var(--line) 92%, transparent);
+  border-radius: var(--radius-md);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--surface-muted) 34%, var(--surface)) 0%,
+    color-mix(in srgb, var(--surface-muted) 10%, var(--surface)) 100%
+  );
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 4%, transparent);
+  padding: var(--space-3) var(--space-4);
+}
+
+.plugin-validation-agent-prompt-card {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  border: 1px solid color-mix(in srgb, var(--line) 92%, transparent);
+  border-radius: var(--radius-md);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--surface-muted) 28%, var(--surface)) 0%,
+    color-mix(in srgb, var(--surface-muted) 8%, var(--surface)) 100%
+  );
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 4%, transparent);
+  padding: var(--space-3) var(--space-4);
+}
+
+.plugin-validation-agent-prompt-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  flex: 1 1 14rem;
+}
+
+.plugin-validation-agent-prompt-label {
+  color: var(--ink);
+  font-size: 0.8rem;
+  font-weight: 650;
+  line-height: 1.3;
+}
+
+.plugin-validation-agent-prompt-hint {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.plugin-validation-agent-prompt-button {
+  flex: 0 0 auto;
+}
+
+.plugin-validation-cli-label {
+  color: var(--ink-soft);
+  font-size: 0.8rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.plugin-validation-command {
+  min-width: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  text-align: right;
+}
+
+.plugin-validation-panel-findings {
   display: grid;
   gap: var(--space-4);
+  padding-top: var(--space-5);
+  border-top: 1px solid color-mix(in srgb, var(--line) 90%, transparent);
+}
+
+.plugin-validation-group-label {
+  margin: 0;
+  padding-top: var(--space-1);
+  color: var(--ink);
+  font-size: 0.78rem;
+  font-weight: 650;
+  line-height: 1.3;
+}
+
+.plugin-validation-group-label.is-error {
+  color: color-mix(in srgb, var(--status-error-fg) 68%, var(--ink-soft));
+}
+
+.plugin-validation-group-label.is-warning {
+  color: color-mix(in srgb, var(--status-warning-fg) 68%, var(--ink-soft));
+}
+
+@media (max-width: 640px) {
+  .plugin-validation-cli-card {
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto auto;
+  }
+
+  .plugin-validation-cli-label {
+    grid-column: 1 / -1;
+  }
+
+  .plugin-validation-command {
+    grid-column: 1;
+    text-align: left;
+  }
+
+  .plugin-validation-cli-copy {
+    grid-column: 2;
+    grid-row: 2;
+  }
+
+  .plugin-validation-panel .plugin-warning-item-summary,
+  .plugin-warning-item-summary {
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto auto;
+  }
+
+  .plugin-validation-panel .plugin-warning-item-code,
+  .plugin-warning-item-code {
+    grid-column: 1;
+    max-width: none;
+    text-align: left;
+  }
+
+  .plugin-warning-item-chevron {
+    grid-column: 2;
+    grid-row: 1 / span 2;
+    align-self: center;
+  }
+
+  .plugin-validation-panel .plugin-warning-item-main,
+  .plugin-warning-item-main {
+    grid-template-columns: 1fr;
+    gap: var(--space-2);
+  }
+
+  .plugin-validation-panel .plugin-warning-item-code,
+  .plugin-warning-item-code {
+    max-width: none;
+    text-align: left;
+  }
+}
+
+.plugin-validation-panel .plugin-warning-list {
+  gap: var(--space-3);
+  padding: 0;
+}
+
+.plugin-validation-panel-findings:has(.plugin-warning-item-details) .plugin-warning-list {
+  gap: var(--space-2);
+}
+
+.plugin-validation-panel .plugin-warning-item {
+  border: 1px solid color-mix(in srgb, var(--line) 92%, transparent);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--surface-muted) 18%, transparent);
+  box-shadow: none;
+  padding: var(--space-3);
+  gap: var(--space-2);
+}
+
+.plugin-validation-panel .plugin-warning-item.plugin-warning-item-details {
+  padding: 0;
+  gap: 0;
+}
+
+.plugin-warning-item-summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: start;
+  gap: var(--space-2) var(--space-3);
+  width: 100%;
+  padding: var(--space-3);
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  transition: background-color 120ms ease;
+}
+
+.plugin-warning-item-summary::-webkit-details-marker {
+  display: none;
+}
+
+.plugin-warning-item-summary::marker {
+  content: "";
+}
+
+.plugin-warning-item-summary:hover,
+.plugin-warning-item-summary:focus-visible {
+  background: color-mix(in srgb, var(--surface-muted) 42%, transparent);
+  outline: none;
+}
+
+.plugin-warning-item-details[open] > .plugin-warning-item-summary {
+  border-bottom: 1px solid color-mix(in srgb, var(--line) 90%, transparent);
+}
+
+.plugin-warning-item-chevron {
+  flex-shrink: 0;
+  align-self: center;
+  color: var(--ink-soft);
+  transition:
+    transform 120ms ease,
+    color 120ms ease;
+}
+
+.plugin-warning-item-summary:hover .plugin-warning-item-chevron,
+.plugin-warning-item-summary:focus-visible .plugin-warning-item-chevron {
+  color: var(--ink);
+}
+
+.plugin-warning-item-details[open] .plugin-warning-item-chevron {
+  transform: rotate(90deg);
+}
+
+.plugin-warning-item-body {
+  display: grid;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3) var(--space-3);
+}
+
+.plugin-validation-panel .plugin-warning-item-main {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: var(--space-4);
+}
+
+.plugin-validation-panel .plugin-warning-item-copy {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.plugin-validation-panel .plugin-warning-item-message {
+  margin: 0;
+  max-width: none;
+  color: var(--ink);
+  font-size: 0.86rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.plugin-validation-panel .plugin-warning-item-tags {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 0.78rem;
+  font-weight: 500;
+  line-height: 1.35;
+}
+
+.plugin-validation-panel .plugin-warning-fix-guide {
+  width: 100%;
+  padding: 8px 10px;
+  border: 0;
+  border-left: 2px solid color-mix(in srgb, var(--status-success-fg) 42%, var(--line));
+  border-radius: 0;
+  background: color-mix(in srgb, var(--status-success-fg) 5%, transparent);
+}
+
+.plugin-validation-panel .plugin-warning-fix-guide-label {
+  margin: 0;
+  color: color-mix(in srgb, var(--status-success-fg) 74%, var(--ink));
+  font-size: 0.78rem;
+  font-weight: 650;
+  line-height: 1.35;
+}
+
+.plugin-validation-panel .plugin-warning-fix-copy {
+  margin: 0;
+  max-width: none;
+  color: var(--ink-soft);
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.plugin-validation-panel .plugin-warning-fix-link {
+  color: color-mix(in srgb, #7ab7ff 88%, white);
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.plugin-validation-panel .plugin-warning-fix-link:hover,
+.plugin-validation-panel .plugin-warning-fix-link:focus-visible {
+  text-decoration: underline;
+}
+
+.plugin-validation-panel .plugin-warning-meta-line {
+  margin: 0;
+  color: color-mix(in srgb, var(--ink-soft) 88%, transparent);
+  font-size: 0.76rem;
+  line-height: 1.4;
+}
+
+.plugin-validation-panel .plugin-warning-item-code {
+  flex: 0 0 auto;
+  max-width: 9rem;
+  padding: 2px 0;
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  font-weight: 500;
+  line-height: 1.35;
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.plugin-validation-panel .plugin-warning-evidence-details {
+  margin-top: 0;
+  padding-top: var(--space-2);
+  border-top: 1px solid color-mix(in srgb, var(--line) 90%, transparent);
+}
+
+.plugin-validation-panel .plugin-warning-evidence-chevron {
+  flex-shrink: 0;
+  color: var(--ink-soft);
+  transition:
+    transform 120ms ease,
+    color 120ms ease;
+}
+
+.plugin-validation-panel .plugin-warning-evidence-details[open] .plugin-warning-evidence-chevron {
+  transform: rotate(90deg);
 }
 
 .plugin-manifest-section {
@@ -4630,98 +5031,248 @@ code {
 
 .plugin-warning-item {
   display: grid;
-  gap: var(--space-3);
-  border: 1px solid var(--line);
-  border-radius: var(--radius-md);
-  background: var(--surface);
-  padding: var(--space-4);
-}
-
-.plugin-warning-item.is-error {
-  border-color: color-mix(in srgb, var(--status-error-fg) 32%, var(--line));
-}
-
-.plugin-warning-item-header {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
   gap: var(--space-2);
+  border: 1px solid color-mix(in srgb, var(--line) 92%, transparent);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--surface-muted) 18%, transparent);
+  padding: var(--space-3);
 }
 
-.plugin-warning-item-header code {
-  border-radius: 4px;
-  background: var(--surface-muted);
-  padding: 0.125rem 0.35rem;
-  font-size: 0.82rem;
+.plugin-warning-item.plugin-warning-item-details {
+  padding: 0;
+  gap: 0;
 }
 
-.plugin-warning-item p {
-  margin: 0;
-  color: var(--ink);
+.plugin-warning-item.is-error,
+.plugin-warning-item.is-warning {
+  background: color-mix(in srgb, var(--surface-muted) 18%, transparent);
 }
 
-.plugin-validation-command {
-  display: block;
-  margin-top: var(--space-1);
-  overflow-wrap: anywhere;
-}
-
-.plugin-warning-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-3);
-  margin: 0;
-}
-
-.plugin-warning-meta div {
+.plugin-warning-item-main {
   display: grid;
-  gap: 0.1rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: var(--space-4);
 }
 
-.plugin-warning-meta dt {
-  color: color-mix(in srgb, var(--ink-soft) 76%, var(--bg));
-  font-size: 0.72rem;
-  font-weight: 700;
-  text-transform: uppercase;
+.plugin-warning-item-copy {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
 }
 
-.plugin-warning-meta dd {
+.plugin-warning-item-tags {
   margin: 0;
   color: var(--ink-soft);
-  font-size: 0.86rem;
+  font-size: 0.78rem;
+  font-weight: 500;
+  line-height: 1.35;
 }
 
-.plugin-warning-evidence {
+.plugin-warning-item-kicker {
   margin: 0;
-  padding-left: var(--space-4);
+  flex: 1 1 auto;
+  min-width: 0;
+  color: var(--ink-soft);
+  font-size: 0.76rem;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.plugin-warning-item-kicker.is-error {
+  color: color-mix(in srgb, var(--status-error-fg) 72%, var(--ink-soft));
+}
+
+.plugin-warning-item-kicker.is-warning {
+  color: color-mix(in srgb, var(--status-warning-fg) 72%, var(--ink-soft));
+}
+
+.plugin-warning-item-code {
+  display: block;
+  flex: 0 0 auto;
+  max-width: 11rem;
+  overflow-wrap: anywhere;
   color: var(--ink-soft);
   font-family: var(--font-mono);
-  font-size: 0.78rem;
+  font-size: 0.72rem;
+  font-weight: 500;
+  line-height: 1.35;
+  text-align: right;
 }
 
-.plugin-warning-remediation {
-  display: grid;
-  gap: var(--space-2);
-  border-top: 1px solid var(--line);
-  padding-top: var(--space-3);
-}
-
-.plugin-warning-remediation h4 {
+.plugin-warning-item-message {
   margin: 0;
+  max-width: none;
   color: var(--ink);
   font-size: 0.9rem;
-  font-weight: 750;
+  font-weight: 600;
+  line-height: 1.45;
 }
 
-.plugin-warning-remediation a {
+.plugin-warning-fix-guide {
+  width: 100%;
+  padding: 8px 10px;
+  border: 0;
+  border-left: 2px solid color-mix(in srgb, var(--status-success-fg) 42%, var(--line));
+  border-radius: 0;
+  background: color-mix(in srgb, var(--status-success-fg) 5%, transparent);
+}
+
+.plugin-warning-fix-guide-label {
+  margin: 0;
+  color: color-mix(in srgb, var(--status-success-fg) 74%, var(--ink));
+  font-size: 0.78rem;
+  font-weight: 650;
+  line-height: 1.35;
+}
+
+.plugin-warning-fix-copy {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.plugin-warning-fix-lead {
+  color: var(--ink);
+  font-weight: 650;
+}
+
+.plugin-warning-meta-line {
+  margin: 0;
+  color: color-mix(in srgb, var(--ink-soft) 88%, transparent);
+  font-size: 0.76rem;
+  line-height: 1.4;
+}
+
+.plugin-warning-evidence-details {
+  display: grid;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid color-mix(in srgb, var(--line) 90%, transparent);
+}
+
+.plugin-warning-evidence-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  width: calc(100% + (var(--space-4) * 2));
+  min-height: 2.25rem;
+  margin-inline: calc(var(--space-4) * -1);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  color: var(--ink-soft);
+  font-size: 0.78rem;
+  font-weight: 500;
+  line-height: 1.3;
+  list-style: none;
+  user-select: none;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.plugin-warning-evidence-summary:hover,
+.plugin-warning-evidence-summary:focus-visible {
+  background: color-mix(in srgb, var(--surface-muted) 42%, transparent);
+  color: var(--ink);
+  outline: none;
+}
+
+.plugin-warning-evidence-summary:hover .plugin-warning-evidence-chevron,
+.plugin-warning-evidence-summary:focus-visible .plugin-warning-evidence-chevron {
+  color: var(--ink);
+}
+
+.plugin-warning-evidence-summary::-webkit-details-marker {
+  display: none;
+}
+
+.plugin-warning-evidence-summary::marker {
+  content: "";
+}
+
+.plugin-warning-evidence-chevron {
+  flex-shrink: 0;
+  color: var(--ink-soft);
+  transition:
+    transform 120ms ease,
+    color 120ms ease;
+}
+
+.plugin-warning-evidence-details[open] .plugin-warning-evidence-chevron {
+  transform: rotate(90deg);
+}
+
+.plugin-warning-evidence-block {
+  display: grid;
+  gap: 4px;
+  padding-top: 6px;
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  line-height: 1.45;
+}
+
+.plugin-warning-evidence-line + .plugin-warning-evidence-line {
+  margin-top: 2px;
+}
+
+.plugin-warning-evidence-more {
+  margin: 4px 0 0;
+  color: var(--ink-soft);
+  font-family: var(--font-sans);
+  font-size: 0.72rem;
+}
+
+.plugin-warning-fix {
+  display: grid;
+  gap: var(--space-2);
+  border-radius: var(--radius-sm);
+  padding: var(--space-3);
+}
+
+.plugin-warning-fix-heading {
+  margin: 0;
+  color: var(--ink);
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.plugin-warning-fix p {
+  margin: 0;
+  max-width: 68ch;
+  color: var(--ink);
+  font-size: 0.88rem;
+  line-height: 1.5;
+}
+
+.plugin-warning-fix-link {
+  justify-self: start;
+  color: color-mix(in srgb, #7ab7ff 88%, white);
+  font-size: 0.84rem;
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.plugin-warning-fix-link:hover,
+.plugin-warning-fix-link:focus-visible {
+  color: color-mix(in srgb, var(--official-fg) 82%, white);
+  text-decoration: underline;
+}
+
+.plugin-warning-fix a:not(.plugin-warning-fix-link) {
+  justify-self: start;
   color: var(--accent);
-  font-size: 0.9rem;
+  font-size: 0.88rem;
   font-weight: 700;
   text-decoration: none;
-  overflow-wrap: anywhere;
 }
 
-.plugin-warning-remediation a:hover {
+.plugin-warning-fix a:not(.plugin-warning-fix-link):hover {
   text-decoration: underline;
 }
 
@@ -5346,6 +5897,96 @@ code {
   border-radius: var(--r-sm);
   background: color-mix(in srgb, #f6c76a 8%, var(--surface));
   color: var(--ink);
+}
+
+.plugin-catalog-empty-alert--hero {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+  max-width: 100%;
+  padding: 2px 0 0;
+  border: none;
+  background: transparent;
+  gap: 10px;
+}
+
+.plugin-detail-page .skill-hero-heading-stack:has(.plugin-catalog-empty-alert--hero) {
+  gap: 12px;
+}
+
+.plugin-catalog-empty-alert--hero .plugin-catalog-empty-alert-visibility {
+  width: fit-content;
+  padding: 0;
+  border: none;
+  color: var(--ink-soft);
+  font-size: 0.68rem;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.plugin-catalog-empty-alert-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.plugin-catalog-empty-alert--hero .plugin-catalog-empty-alert-row {
+  margin-top: 2px;
+}
+
+.plugin-catalog-empty-alert--hero .plugin-catalog-empty-alert-icon {
+  width: 18px;
+  height: 18px;
+  background: transparent;
+  color: var(--accent);
+}
+
+.plugin-catalog-empty-alert--hero .plugin-catalog-empty-alert-icon svg {
+  width: 14px;
+  height: 14px;
+}
+
+.plugin-catalog-empty-alert-title {
+  min-width: 0;
+  color: var(--ink);
+  font-size: 0.8rem;
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+.plugin-catalog-empty-alert--hero .plugin-catalog-empty-alert-cta {
+  height: auto;
+  min-height: 0;
+  margin-left: 0;
+  padding: 0;
+  gap: 4px;
+  border: none !important;
+  background: transparent !important;
+  color: var(--accent) !important;
+  font-size: 0.75rem;
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.plugin-catalog-empty-alert--hero .plugin-catalog-empty-alert-cta:hover,
+.plugin-catalog-empty-alert--hero .plugin-catalog-empty-alert-cta:focus-visible {
+  border: none !important;
+  background: transparent !important;
+  color: var(--accent-deep) !important;
+  text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+  .plugin-catalog-empty-alert-row {
+    flex-wrap: wrap;
+    row-gap: 6px;
+  }
+
+  .plugin-catalog-empty-alert--hero .plugin-catalog-empty-alert-cta {
+    margin-left: 24px;
+  }
 }
 
 .plugin-catalog-empty-alert-icon {

--- a/src/styles.css
+++ b/src/styles.css
@@ -4884,8 +4884,9 @@ code {
 }
 
 .plugin-validation-panel .plugin-warning-fix-guide {
-  display: grid;
-  gap: 4px;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
   width: 100%;
   padding: 8px 10px;
   border: 0;
@@ -4894,11 +4895,11 @@ code {
   background: color-mix(in srgb, var(--status-success-fg) 5%, transparent);
 }
 
-.plugin-validation-panel .plugin-warning-fix-guide-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
+.plugin-validation-panel .plugin-warning-fix-guide-copy {
+  display: grid;
+  flex: 1;
+  gap: 4px;
+  min-width: 0;
 }
 
 .plugin-validation-panel .plugin-warning-fix-guide-label {
@@ -4919,7 +4920,7 @@ code {
 
 .plugin-validation-panel .plugin-warning-fix-link {
   flex-shrink: 0;
-  color: color-mix(in srgb, #7ab7ff 88%, white);
+  color: #0099ff;
   font-weight: 500;
   text-decoration: none;
   white-space: nowrap;
@@ -5121,8 +5122,9 @@ code {
 }
 
 .plugin-warning-fix-guide {
-  display: grid;
-  gap: 4px;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
   width: 100%;
   padding: 8px 10px;
   border: 0;
@@ -5131,11 +5133,11 @@ code {
   background: color-mix(in srgb, var(--status-success-fg) 5%, transparent);
 }
 
-.plugin-warning-fix-guide-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-3);
+.plugin-warning-fix-guide-copy {
+  display: grid;
+  flex: 1;
+  gap: 4px;
+  min-width: 0;
 }
 
 .plugin-warning-fix-guide-label {
@@ -5272,7 +5274,7 @@ code {
 
 .plugin-warning-fix-link {
   flex-shrink: 0;
-  color: color-mix(in srgb, #7ab7ff 88%, white);
+  color: #0099ff;
   font-size: 0.84rem;
   font-weight: 650;
   text-decoration: none;
@@ -5281,7 +5283,7 @@ code {
 
 .plugin-warning-fix-link:hover,
 .plugin-warning-fix-link:focus-visible {
-  color: color-mix(in srgb, var(--official-fg) 82%, white);
+  color: #33adff;
   text-decoration: underline;
 }
 


### PR DESCRIPTION
<!-- clawhub-ui-proof -->

**Validation panel — collapsed findings**

<img src="https://raw.githubusercontent.com/vyctorbrzezowski/clawhub/qa-artifacts/clawhub-ui-proof/pr-2835/pr-2835-validation/candidate/validation-collapsed.png" width="720" alt="Validation panel — collapsed findings">

**Validation panel — expanded error with fix guide**

<img src="https://raw.githubusercontent.com/vyctorbrzezowski/clawhub/qa-artifacts/clawhub-ui-proof/pr-2835/pr-2835-validation/candidate/validation-expanded.png" width="720" alt="Validation panel — expanded error with fix guide">

Local browser proof (`local-scanned-runtime-plugin` @ localhost:3000). [Raw proof files](https://github.com/vyctorbrzezowski/clawhub/tree/qa-artifacts/clawhub-ui-proof/pr-2835/pr-2835-validation).

## Summary
- Move plugin validation findings into a hero section above detail tabs with clearer hierarchy: neutral stats pill, summary hint, collapsed findings list, severity dots, and refined fix-guide/evidence layout.
- Restructure validation actions into a CLI validate block plus a separate **Copy instructions** button (Radix tooltip) aligned to the command row height.
- Polish skill/plugin install surfaces by splitting OpenClaw CLI commands into verb/target spans for readability and updating related unit/e2e assertions.

## Test plan
- [x] `bun run ci:static`
- [x] `VITE_CONVEX_URL=https://example.invalid bun run vitest run src/__tests__/package-detail-route.test.tsx`
- [x] `VITE_CONVEX_URL=https://example.invalid bun run vitest run src/__tests__/skill-detail-page.test.tsx -t "renders the install surface"`
- [x] Autoreview (local): no actionable findings
- [ ] `bun run test:pw:local-auth` (plugin inspector findings flow) — recommended before merge