### PR TITLE
fix(ci): bundle ClawHub PR gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ env:
   VITE_CONVEX_URL: https://example.invalid
 
 jobs:
-  static:
-    name: static
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 15
+  pr-gates:
+    name: pr-gates
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@v6
@@ -32,57 +32,87 @@ jobs:
       - name: Static checks
         run: bun run ci:static
 
-  unit:
-    name: unit
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 15
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: ./.github/actions/setup-bun
-
-      - name: Coverage
+      - name: Unit coverage
         run: bun run ci:unit
-
-  packages:
-    name: packages
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 15
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: ./.github/actions/setup-bun
 
       - name: Package checks
         run: bun run ci:packages
 
-  types-build:
-    name: types-build
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 15
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: ./.github/actions/setup-bun
-
       - name: Typecheck and build
         run: bun run ci:types-build
 
-  e2e-http:
-    name: e2e-http
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 20
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: ./.github/actions/setup-bun
-
       - name: HTTP e2e
         run: bun run ci:e2e-http
+
+  static:
+    name: static
+    runs-on: ubuntu-latest
+    needs: pr-gates
+    if: ${{ always() }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Mirror pr-gates result
+        env:
+          PR_GATES_RESULT: ${{ needs.pr-gates.result }}
+        run: |
+          test "$PR_GATES_RESULT" = "success"
+
+  unit:
+    name: unit
+    runs-on: ubuntu-latest
+    needs: pr-gates
+    if: ${{ always() }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Mirror pr-gates result
+        env:
+          PR_GATES_RESULT: ${{ needs.pr-gates.result }}
+        run: |
+          test "$PR_GATES_RESULT" = "success"
+
+  packages:
+    name: packages
+    runs-on: ubuntu-latest
+    needs: pr-gates
+    if: ${{ always() }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Mirror pr-gates result
+        env:
+          PR_GATES_RESULT: ${{ needs.pr-gates.result }}
+        run: |
+          test "$PR_GATES_RESULT" = "success"
+
+  types-build:
+    name: types-build
+    runs-on: ubuntu-latest
+    needs: pr-gates
+    if: ${{ always() }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Mirror pr-gates result
+        env:
+          PR_GATES_RESULT: ${{ needs.pr-gates.result }}
+        run: |
+          test "$PR_GATES_RESULT" = "success"
+
+  e2e-http:
+    name: e2e-http
+    runs-on: ubuntu-latest
+    needs: pr-gates
+    if: ${{ always() }}
+    timeout-minutes: 5
+
+    steps:
+      - name: Mirror pr-gates result
+        env:
+          PR_GATES_RESULT: ${{ needs.pr-gates.result }}
+        run: |
+          test "$PR_GATES_RESULT" = "success"
 
   playwright-smoke:
     name: playwright-smoke
@@ -125,28 +155,28 @@ jobs:
       max-parallel: 3
       matrix:
         include:
-          - name: delete-account
-            spec: e2e/local-auth/delete-account-resources.pw.test.ts
-          - name: delete-org
-            spec: e2e/local-auth/delete-org-resources.pw.test.ts
-          - name: header-profile-link
-            spec: e2e/local-auth/header-profile-link.pw.test.ts
-          - name: malicious-skill-ban
-            spec: e2e/local-auth/malicious-skill-ban-flow.pw.test.ts
-          - name: manage-context-proof
-            spec: e2e/local-auth/manage-context-proof.pw.test.ts
-          - name: plugin-inspector-findings
-            spec: e2e/local-auth/plugin-inspector-findings.pw.test.ts
+          - name: account-cleanup
+            specs: |
+              e2e/local-auth/delete-account-resources.pw.test.ts
+              e2e/local-auth/delete-org-resources.pw.test.ts
+          - name: profile-context
+            specs: |
+              e2e/local-auth/header-profile-link.pw.test.ts
+              e2e/local-auth/manage-context-proof.pw.test.ts
+          - name: moderation-star
+            specs: |
+              e2e/local-auth/malicious-skill-ban-flow.pw.test.ts
+              e2e/local-auth/skill-star-sync.pw.test.ts
+          - name: inspector-version
+            specs: |
+              e2e/local-auth/plugin-inspector-findings.pw.test.ts
+              e2e/local-auth/version-delete.pw.test.ts
           - name: publish-generated-card
-            spec: e2e/local-auth/publish-skill-lifecycle.pw.test.ts
+            specs: e2e/local-auth/publish-skill-lifecycle.pw.test.ts
             grep: publishing a skill queues scan
           - name: publish-new-version
-            spec: e2e/local-auth/publish-skill-lifecycle.pw.test.ts
+            specs: e2e/local-auth/publish-skill-lifecycle.pw.test.ts
             grep: skill publishers can create a skill
-          - name: skill-star-sync
-            spec: e2e/local-auth/skill-star-sync.pw.test.ts
-          - name: version-delete
-            spec: e2e/local-auth/version-delete.pw.test.ts
 
     steps:
       - uses: actions/checkout@v6
@@ -167,10 +197,11 @@ jobs:
       - name: Local-auth browser e2e
         env:
           PLAYWRIGHT_GREP: ${{ matrix.grep || '' }}
-          PLAYWRIGHT_SPEC: ${{ matrix.spec }}
+          PLAYWRIGHT_SPECS: ${{ matrix.specs }}
         run: |
           set -euo pipefail
-          args=(--project=chromium "$PLAYWRIGHT_SPEC")
+          mapfile -t specs < <(printf '%s\n' "$PLAYWRIGHT_SPECS" | sed '/^[[:space:]]*$/d')
+          args=(--project=chromium "${specs[@]}")
           if [[ -n "$PLAYWRIGHT_GREP" ]]; then
             args+=(--grep "$PLAYWRIGHT_GREP")
           fi

--- a/specs/ci.md
+++ b/specs/ci.md
@@ -4,8 +4,9 @@ Pull requests are validated by `.github/workflows/ci.yml`.
 
 ## PR Checks
 
-The `CI` workflow is intentionally split into named jobs so failures and required
-status checks are precise:
+The `CI` workflow keeps the public required status checks stable while bundling
+the short non-browser gates into one Blacksmith runner registration. The
+`pr-gates` job runs the actual command steps for:
 
 - `static` runs peer dependency validation, dependency audit, formatting, lint,
   and dead-code checks.
@@ -15,11 +16,19 @@ status checks are precise:
 - `types-build` typechecks the app, schema package, and CLI package, then builds
   the app.
 - `e2e-http` runs the secretless HTTP and CLI end-to-end subset.
+
+The `static`, `unit`, `packages`, `types-build`, and `e2e-http` jobs are
+hosted-runner compatibility mirrors of `pr-gates` so existing branch protection
+rules do not need to change. Inspect the `pr-gates` step logs for the exact
+failing command.
+
 - `playwright-smoke` builds the app and runs a chromium browser smoke against the
   public read backend.
 - `playwright-local-auth` uses `test:pw:local-auth` to start a local anonymous
   Convex backend with dev auth, then runs the chromium specs under
-  `e2e/local-auth/`.
+  `e2e/local-auth/`. Related low-risk specs are grouped so the matrix spends
+  fewer Blacksmith runner registrations while keeping publish lifecycle checks
+  isolated for easier failure triage.
 
 For local reproduction, run the matching `ci:*` package scripts. `bun run ci:pr`
 matches the non-browser PR gates. `bun run ci:playwright-smoke` assumes the


### PR DESCRIPTION
## Summary

- What changed: bundle the short non-browser PR gates into one `pr-gates` Blacksmith job, keep the existing required check names as hosted mirror jobs, and group local-auth Playwright specs from 10 shards to 6.
- Why: reduce Blacksmith runner registrations per PR while preserving branch-protection status names and coverage.

## Linked Issue

- Related: openclaw/openclaw CI runner-registration incident

## Screenshots

- [x] Screenshots/recordings attached, or `N/A`

## Behavioural Proof

Workflow/config-only change. Verified the workflow YAML parses and the touched files are formatted.

- [x] Behavioural proof included, or `N/A`

## Security / Trust Impact

- [x] No security/trust impact
- [ ] Security/trust impact explained

## Data / Deploy Impact

- [x] No data/deploy impact
- [ ] Data/deploy impact explained

## Verification

- [ ] `bun run ci:static`
- [ ] Focused tests for touched behavior:
- [ ] `bun run ci:unit` or `N/A` for docs/config-only: `N/A`
- [ ] Broader gate when required (`ci:types-build`, `ci:packages`, `ci:e2e-http`, `ci:playwright-smoke`, `test:pw:local-auth`, `proof:ui`): `N/A`
- [x] Other: `git diff --check`; `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'`; `bunx --bun oxfmt --check .github/workflows/ci.yml specs/ci.md`
