### PR TITLE
ci: increase security dataset shard parallelism

### DIFF
--- a/.github/workflows/security-dataset-snapshot.yml
+++ b/.github/workflows/security-dataset-snapshot.yml
@@ -38,7 +38,7 @@ on:
       shards:
         description: "Created-at shards per source kind"
         required: true
-        default: "96"
+        default: "128"
   schedule:
     - cron: "17 9 * * *"
 
@@ -70,7 +70,7 @@ jobs:
       SNAPSHOT_MIN_PAGE_SIZE: ${{ inputs['min-page-size'] || '5' }}
       SNAPSHOT_BATCH_PAGES: ${{ inputs['batch-pages'] || '1' }}
       SNAPSHOT_CONCURRENCY: ${{ inputs.concurrency || '1' }}
-      SNAPSHOT_SHARDS: ${{ inputs.shards || '96' }}
+      SNAPSHOT_SHARDS: ${{ inputs.shards || '128' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -119,7 +119,7 @@ jobs:
     environment: Production
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 12
       matrix: ${{ fromJson(needs.plan-security-dataset.outputs.matrix) }}
     env:
       CONVEX_URL: ${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}


### PR DESCRIPTION
## Summary
- increase the default live export shard count from 96 to 128 per source kind
- raise the shard matrix parallelism from 4 to 12 bounded GitHub-hosted jobs

## Context
The first chunked production publish run on `main` was working with 0 failures, but after nearly two hours it had only completed 30 of 193 jobs because dense time shards were holding the four available lanes. This keeps the same sanitizer/export/publish flow and just reduces wall time and per-shard density.

## Validation
- `bun -e 'import { parse } from "yaml"; const text = await Bun.file(".github/workflows/security-dataset-snapshot.yml").text(); parse(text); console.log("yaml ok")' && actionlint .github/workflows/security-dataset-snapshot.yml`
- `bun run format:check -- .github/workflows/security-dataset-snapshot.yml`
