### PR TITLE
fix: recall plugin display names in package search

### DIFF
--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -1151,6 +1151,7 @@ function makeDigestCtx(options: {
     indexName: string;
     filters: Array<{ field: string; value: unknown }>;
   }> = [];
+  const searchIndexNames: string[] = [];
   const tableNames: string[] = [];
 
   const setPages = (
@@ -1224,6 +1225,36 @@ function makeDigestCtx(options: {
     takeByTable.set(table, next);
     return next;
   };
+  const searchTake = vi.fn();
+  const stringifySearchValue = (value: unknown) =>
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint"
+      ? String(value)
+      : "";
+  const makeSearchQuery = (table: string, searchField: string, query: string) => ({
+    take: vi.fn(async (limit: number) => {
+      searchTake(limit);
+      const queryTokens: string[] = query.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+      if (queryTokens.length === 0) return [];
+      return [...(options.exactDigests ?? []), ...(rowsByTable.get(table) ?? [])]
+        .filter((row, index, rows) => {
+          const rowId = stringifySearchValue(row._id ?? row.packageId) || String(index);
+          return (
+            rows.findIndex(
+              (candidate) => stringifySearchValue(candidate._id ?? candidate.packageId) === rowId,
+            ) === index
+          );
+        })
+        .filter((row) => {
+          const text = stringifySearchValue(readTestField(row, searchField)).toLowerCase();
+          const textTokens: string[] = text.match(/[a-z0-9]+/g) ?? [];
+          return queryTokens.some((queryToken) => textTokens.includes(queryToken));
+        })
+        .slice(0, limit);
+    }),
+  });
 
   const withIndex = vi.fn((table: string, indexName: string) => {
     indexNames.push(indexName);
@@ -1244,9 +1275,11 @@ function makeDigestCtx(options: {
   return {
     indexNames,
     indexFilters,
+    searchIndexNames,
     tableNames,
     paginate,
     take,
+    searchTake,
     ctx: {
       db: {
         get: vi.fn(async (id: string) => {
@@ -1417,7 +1450,8 @@ function makeDigestCtx(options: {
                 }
                 if (
                   indexName === "by_active_normalized_name" ||
-                  indexName === "by_active_runtime_id"
+                  indexName === "by_active_runtime_id" ||
+                  indexName === "by_active_owner_handle"
                 ) {
                   let lowerBound = "";
                   let upperBound = "";
@@ -1437,14 +1471,43 @@ function makeDigestCtx(options: {
                     indexName === "by_active_normalized_name"
                       ? String(digest.normalizedName) >= lowerBound &&
                         String(digest.normalizedName) < upperBound
-                      : String(digest.runtimeId) >= lowerBound &&
-                        String(digest.runtimeId) < upperBound,
+                      : indexName === "by_active_runtime_id"
+                        ? String(digest.runtimeId) >= lowerBound &&
+                          String(digest.runtimeId) < upperBound
+                        : String(digest.ownerHandle) >= lowerBound &&
+                          String(digest.ownerHandle) < upperBound,
                   );
                   return {
                     take: vi.fn().mockResolvedValue(matches),
                   };
                 }
                 return withIndex(table, indexName);
+              },
+              withSearchIndex: (
+                indexName: string,
+                builder?: (q: {
+                  search: (
+                    field: string,
+                    query: string,
+                  ) => {
+                    eq: (field: string, value: string | undefined) => unknown;
+                  };
+                }) => unknown,
+              ) => {
+                searchIndexNames.push(indexName);
+                let searchField = "";
+                let query = "";
+                const queryBuilder = {
+                  search: (field: string, value: string) => {
+                    searchField = field;
+                    query = value;
+                    return {
+                      eq: () => queryBuilder,
+                    };
+                  },
+                };
+                builder?.(queryBuilder);
+                return makeSearchQuery(table, searchField, query);
               },
             };
           }
@@ -5216,7 +5279,9 @@ describe("packages public queries", () => {
   });
 
   it("bounds fallback search to the first digest take window", async () => {
-    const olderMatch = makeDigest("demo-plugin", {
+    const olderMatch = makeDigest("old-package", {
+      displayName: "Old Package",
+      summary: "legacy helper",
       updatedAt: 10,
     });
     const { ctx, paginate, take } = makeDigestCtx({
@@ -5237,7 +5302,7 @@ describe("packages public queries", () => {
     });
 
     const result = await searchPublicHandler(ctx, {
-      query: "demo-plugin",
+      query: "legacy",
       limit: 10,
     });
 
@@ -5300,6 +5365,45 @@ describe("packages public queries", () => {
     expect(ctx.db.query).toHaveBeenCalledWith("packageSearchDigest");
   });
 
+  it("includes display-name matches before digest scanning", async () => {
+    const displayDigest = makeDigest("vpai-plugin", {
+      packageId: "packages:vpai-plugin",
+      displayName: "Vibe Prospecting",
+      ownerHandle: "vibeprospecting",
+    });
+    const { ctx, searchIndexNames } = makeDigestCtx({
+      pages: [],
+      exactDigests: [displayDigest],
+    });
+
+    const result = await searchPublicHandler(ctx, {
+      query: "vibe prospecting",
+      limit: 10,
+    });
+
+    expect(result.map((entry) => entry.package.name)).toEqual(["vpai-plugin"]);
+    expect(searchIndexNames).toContain("search_by_display_name");
+  });
+
+  it("includes creator handle matches before digest scanning", async () => {
+    const ownerDigest = makeDigest("vpai-plugin", {
+      packageId: "packages:vpai-plugin",
+      displayName: "Vibe Prospecting",
+      ownerHandle: "vibeprospecting",
+    });
+    const { ctx } = makeDigestCtx({
+      pages: [],
+      exactDigests: [ownerDigest],
+    });
+
+    const result = await searchPublicHandler(ctx, {
+      query: "@vibeprospecting",
+      limit: 10,
+    });
+
+    expect(result.map((entry) => entry.package.name)).toEqual(["vpai-plugin"]);
+  });
+
   it("includes prefix package-name matches before digest scanning", async () => {
     const prefixPkg = makePackageDoc({
       _id: "packages:prefix",
@@ -5356,14 +5460,14 @@ describe("packages public queries", () => {
       pages: [
         {
           page: [
-            makeDigest("demo-alpha", { updatedAt: 20 }),
-            makeDigest("demo-beta", { updatedAt: 10 }),
+            makeDigest("alpha", { displayName: "Alpha", summary: "useful demo", updatedAt: 20 }),
+            makeDigest("beta", { displayName: "Beta", summary: "useful demo", updatedAt: 10 }),
           ],
           isDone: false,
           continueCursor: "cursor:1",
         },
         {
-          page: [makeDigest("demo-gamma")],
+          page: [makeDigest("gamma", { displayName: "Gamma", summary: "useful demo" })],
           isDone: true,
           continueCursor: "",
         },
@@ -5371,11 +5475,11 @@ describe("packages public queries", () => {
     });
 
     const result = await searchPublicHandler(ctx, {
-      query: "demo",
+      query: "useful",
       limit: 2,
     });
 
-    expect(result.map((entry) => entry.package.name)).toEqual(["demo-alpha", "demo-beta"]);
+    expect(result.map((entry) => entry.package.name)).toEqual(["alpha", "beta"]);
     expect(take).toHaveBeenCalledTimes(3);
     expect(take).toHaveBeenCalledWith(20);
     expect(take).toHaveBeenCalledWith(50);

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -125,6 +125,7 @@ const MAX_PUBLIC_LIST_FILTER_SCAN_PAGES = 6;
 const MAX_PLUGIN_EXPORT_LIST_LIMIT = 250;
 const MAX_SEARCH_PAGE_SIZE = 200;
 const MAX_DIRECT_PACKAGE_SEARCH_CANDIDATES = 20;
+const MAX_DIRECT_PACKAGE_FULL_TEXT_CANDIDATES = 40;
 const MAX_PACKAGE_VERSION_DELETE_LOOKUP_CANDIDATES = 4;
 const MAX_POINTERLESS_RELEASE_SURVIVOR_SCAN = 100;
 const packageListScanStatusValidator = v.union(
@@ -1603,9 +1604,11 @@ function packageSearchMatch(
   const normalized = digest.normalizedName.toLowerCase();
   const display = digest.displayName.toLowerCase();
   const runtimeId = digest.runtimeId?.toLowerCase() ?? "";
+  const ownerHandle = digest.ownerHandle?.toLowerCase() ?? "";
   const nameTokens = tokenize(normalized);
   const displayTokens = tokenize(display);
   const runtimeTokens = tokenize(runtimeId);
+  const ownerHandleTokens = tokenize(ownerHandle);
   let score = 0;
   let rankTier = Number.POSITIVE_INFINITY;
 
@@ -1626,17 +1629,23 @@ function packageSearchMatch(
   else if (runtimeId.startsWith(needle)) setMatch(1, 90);
   else if (runtimeId.includes(needle)) setMatch(1, 45);
 
+  if (ownerHandle === needle || `@${ownerHandle}` === needle) setMatch(1, 60);
+  else if (ownerHandle.startsWith(needle) || `@${ownerHandle}`.startsWith(needle)) setMatch(1, 35);
+  else if (ownerHandle.includes(needle)) setMatch(1, 20);
+
   if (
     matchesAllTokens(
       queryTokens,
-      [...nameTokens, ...displayTokens, ...runtimeTokens],
+      [...nameTokens, ...displayTokens, ...runtimeTokens, ...ownerHandleTokens],
       (a, b) => a === b,
     )
   ) {
     setMatch(1, 65);
   } else if (
-    matchesAllTokens(queryTokens, [...nameTokens, ...displayTokens, ...runtimeTokens], (a, b) =>
-      a.startsWith(b),
+    matchesAllTokens(
+      queryTokens,
+      [...nameTokens, ...displayTokens, ...runtimeTokens, ...ownerHandleTokens],
+      (a, b) => a.startsWith(b),
     )
   ) {
     setMatch(1, 35);
@@ -1719,7 +1728,15 @@ async function resolveDirectPackageSearchDigests(
       : undefined;
   const queryTokens = tokenize(queryText).filter((token) => token.length > 1);
   const runtimePrefix = queryTokens.length === 1 ? queryTokens[0] : queryText;
-  const [nameDigests, runtimeDigests, exactTopicDigests, categoryDigests] = await Promise.all([
+  const ownerHandlePrefix = queryTokens.length === 1 ? queryTokens[0] : null;
+  const [
+    nameDigests,
+    runtimeDigests,
+    displayNameDigests,
+    ownerHandleDigests,
+    exactTopicDigests,
+    categoryDigests,
+  ] = await Promise.all([
     normalizedQuery
       ? ctx.db
           .query("packageSearchDigest")
@@ -1739,6 +1756,23 @@ async function resolveDirectPackageSearchDigests(
               .eq("softDeletedAt", undefined)
               .gte("runtimeId", runtimePrefix)
               .lt("runtimeId", prefixUpperBound(runtimePrefix)),
+          )
+          .take(MAX_DIRECT_PACKAGE_SEARCH_CANDIDATES)
+      : Promise.resolve([]),
+    ctx.db
+      .query("packageSearchDigest")
+      .withSearchIndex("search_by_display_name", (q) =>
+        q.search("displayName", queryText).eq("softDeletedAt", undefined),
+      )
+      .take(MAX_DIRECT_PACKAGE_FULL_TEXT_CANDIDATES),
+    ownerHandlePrefix
+      ? ctx.db
+          .query("packageSearchDigest")
+          .withIndex("by_active_owner_handle", (q) =>
+            q
+              .eq("softDeletedAt", undefined)
+              .gte("ownerHandle", ownerHandlePrefix)
+              .lt("ownerHandle", prefixUpperBound(ownerHandlePrefix)),
           )
           .take(MAX_DIRECT_PACKAGE_SEARCH_CANDIDATES)
       : Promise.resolve([]),
@@ -1777,6 +1811,8 @@ async function resolveDirectPackageSearchDigests(
   return [
     ...nameDigests,
     ...runtimeDigests,
+    ...displayNameDigests,
+    ...ownerHandleDigests,
     ...exactTopicDigests,
     ...prefixTopicDigests,
     ...categoryDigests,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1901,7 +1901,12 @@ const packageSearchDigest = defineTable({
   ])
   .index("by_active_normalized_name", ["softDeletedAt", "normalizedName", "updatedAt"])
   .index("by_active_runtime_id", ["softDeletedAt", "runtimeId", "updatedAt"])
-  .index("by_active_name", ["softDeletedAt", "displayName"]);
+  .index("by_active_owner_handle", ["softDeletedAt", "ownerHandle", "updatedAt"])
+  .index("by_active_name", ["softDeletedAt", "displayName"])
+  .searchIndex("search_by_display_name", {
+    searchField: "displayName",
+    filterFields: ["softDeletedAt"],
+  });
 
 const packageTopicSearchDigest = defineTable({
   packageId: v.id("packages"),


### PR DESCRIPTION
## Summary

Fixes #2844.

- add indexed direct recall for package/plugin display names via a Convex search index
- add indexed creator-handle recall for package/plugin search using `ownerHandle`
- include owner handles in package search scoring so `@vibeprospecting` can qualify after recall
- add regression coverage for display-name and creator-handle searches that would otherwise miss older digests outside the bounded fallback scan

## Evidence

Production currently reproduces the report:

- `https://clawhub.ai/api/v1/plugins/search?q=vpai-plugin&limit=5` returns `vpai-plugin / Vibe Prospecting / vibeprospecting`
- `https://clawhub.ai/api/v1/plugins/search?q=Vibe%20Prospecting&limit=5` returns no rows
- `https://clawhub.ai/api/v1/plugins/search?q=vibeprospecting&limit=5` returns no rows

Root cause: package search scoring already treated `displayName` as relevant, but direct package recall only queried normalized package name, runtime id, topic, and category digests. Older display-name matches could therefore be missed before scoring because the bounded updated-window fallback never reached them. Creator handle was stored on `packageSearchDigest` but was also not a recall or scoring signal.

Provenance: current direct package recall was introduced around `308056796` (Peter Steinberger, 2026-03-23) and later category/topic recall edits; display-name scoring came through the current package matcher path around `9ab92e584` (Vyctor H. Brzezowski, 2026-05-14). The missing display-name recall is the broken behavior this PR closes.

## Tests

- `VITE_CONVEX_URL=https://example.invalid bunx vitest run convex/packages.public.test.ts convex/lib/packageSearchDigest.test.ts src/lib/packageApi.test.ts`
- `bunx oxfmt --check convex/packages.ts convex/schema.ts convex/packages.public.test.ts`
- `bunx tsc --noEmit`
- `bun run ci:static`
- `bunx convex codegen`

Notes:

- `bun run ci:unit` ran 3861/3862 tests successfully locally, but failed on an unrelated path-encoding issue because this checkout lives under `Documents/New project`: `scripts/skill-cards/run-skill-card-worker.test.ts` tried to open `/Users/mauriceniu/Documents/New%20project/clawhub-issue-2844/scripts/skill-cards/templates/clawhub-skill-card.md.j2`.
- `bunx convex dev --once --typecheck=disable` could not start because a local backend was already running on port 3212.
