### PR TITLE
ci: validate security dataset guardrails structurally

### DIFF
--- a/.github/workflows/security-dataset-snapshot.yml
+++ b/.github/workflows/security-dataset-snapshot.yml
@@ -226,19 +226,7 @@ jobs:
       - name: Validate sanitized output guardrails
         run: |
           set -euo pipefail
-          test -d "$SNAPSHOT_DIR/hf-dataset/data"
-          test -f "$SNAPSHOT_DIR/manifest.json"
-          for split in train validation test eval_holdout; do
-            test -f "$SNAPSHOT_DIR/hf-dataset/data/$split.jsonl"
-          done
-          if grep -R -E 'storageId|skillVersions:|packageReleases:|_storage/' "$SNAPSHOT_DIR/hf-dataset" "$SNAPSHOT_DIR/manifest.json"; then
-            echo "::error::sanitized output contains raw storage or internal document identifiers"
-            exit 1
-          fi
-          if grep -R -E 'gh[pousr]_[A-Za-z0-9_]{20,}|sk-[A-Za-z0-9_-]{20,}|AKIA[0-9A-Z]{16}|-----BEGIN [A-Z0-9 ]*(PRIVATE KEY|CERTIFICATE)-----' "$SNAPSHOT_DIR/hf-dataset"; then
-            echo "::error::sanitized output contains obvious secret-like values"
-            exit 1
-          fi
+          bun scripts/security-dataset/validate-guardrails.ts --snapshot-dir "$SNAPSHOT_DIR"
 
       - name: Install Hugging Face uploader
         if: ${{ env.HF_UPLOAD == 'true' }}

--- a/e2e/prod-http-smoke.e2e.test.ts
+++ b/e2e/prod-http-smoke.e2e.test.ts
@@ -106,6 +106,22 @@ async function fetchHtml(pathname: string) {
   return response.text();
 }
 
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function expectLinkWithRelAndHref(html: string, rel: string, href: string) {
+  const relPattern = new RegExp(`\\brel=["']${escapeRegExp(rel)}["']`, "i");
+  const hrefPattern = new RegExp(`\\bhref=["']${escapeRegExp(href)}["']`, "i");
+  const hasLink = [...html.matchAll(/<link\b[^>]*>/gi)].some(
+    ([tag]) => relPattern.test(tag) && hrefPattern.test(tag),
+  );
+
+  expect(hasLink, `expected HTML to contain <link> with rel="${rel}" and href="${href}"`).toBe(
+    true,
+  );
+}
+
 type SkillDetailResponse = {
   skill: { slug: string; displayName: string; summary: string | null };
   latestVersion: { version: string | null } | null;
@@ -147,8 +163,10 @@ describe("prod http smoke", () => {
     const html = await fetchHtml(`/${owner}/${detail.skill.slug}`);
 
     expect(html).toContain(`<title>${detail.skill.displayName} — ClawHub</title>`);
-    expect(html).toContain(
-      `<link rel="canonical" href="${getSiteBase()}/${owner}/skills/${detail.skill.slug}"/>`,
+    expectLinkWithRelAndHref(
+      html,
+      "canonical",
+      `${getSiteBase()}/${owner}/skills/${detail.skill.slug}`,
     );
     if (detail.skill.summary) {
       expect(html).toContain(detail.skill.summary);

--- a/scripts/security-dataset/validate-guardrails.ts
+++ b/scripts/security-dataset/validate-guardrails.ts
@@ -1,0 +1,162 @@
+import { createReadStream } from "node:fs";
+import { readFile, stat } from "node:fs/promises";
+import { join, relative, resolve } from "node:path";
+import { createInterface } from "node:readline";
+
+type Options = {
+  snapshotDir: string;
+};
+
+type Finding = {
+  file: string;
+  line?: number;
+  path: string;
+  reason: string;
+};
+
+const HF_SPLITS = ["train", "validation", "test", "eval_holdout"] as const;
+const SECRET_PATTERN =
+  /gh[pousr]_[A-Za-z0-9_]{20,}|sk-[A-Za-z0-9_-]{20,}|AKIA[0-9A-Z]{16}|-----BEGIN [A-Z0-9 ]*(PRIVATE KEY|CERTIFICATE)-----/;
+const RAW_CONVEX_REF_PATTERN = /\b(?:skillVersions|packageReleases):[a-z0-9]{6,}\b/i;
+const RAW_STORAGE_PATH_PATTERN = /(^|\/)_storage\//;
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const snapshotDir = resolve(options.snapshotDir);
+  const findings: Finding[] = [];
+
+  await assertFile(join(snapshotDir, "manifest.json"));
+  await assertDirectory(join(snapshotDir, "hf-dataset", "data"));
+  await inspectJsonFile(join(snapshotDir, "manifest.json"), snapshotDir, findings);
+
+  for (const split of HF_SPLITS) {
+    const file = join(snapshotDir, "hf-dataset", "data", `${split}.jsonl`);
+    await assertFile(file);
+    await inspectJsonlFile(file, snapshotDir, findings);
+  }
+
+  if (findings.length > 0) {
+    for (const finding of findings.slice(0, 50)) {
+      const location = finding.line ? `${finding.file}:${finding.line}` : finding.file;
+      console.error(`${location} ${finding.path}: ${finding.reason}`);
+    }
+    if (findings.length > 50) {
+      console.error(`... ${findings.length - 50} additional guardrail findings omitted`);
+    }
+    throw new Error(`sanitized output guardrail check failed with ${findings.length} finding(s)`);
+  }
+
+  console.log("sanitized output guardrails passed");
+}
+
+async function assertDirectory(path: string) {
+  const entry = await stat(path);
+  if (!entry.isDirectory()) throw new Error(`Expected directory: ${path}`);
+}
+
+async function assertFile(path: string) {
+  const entry = await stat(path);
+  if (!entry.isFile()) throw new Error(`Expected file: ${path}`);
+}
+
+async function inspectJsonFile(path: string, root: string, findings: Finding[]) {
+  const json = JSON.parse(await readFile(path, "utf8"));
+  inspectValue(json, relative(root, path), "$", findings);
+}
+
+async function inspectJsonlFile(path: string, root: string, findings: Finding[]) {
+  const file = relative(root, path);
+  const input = createReadStream(path, { encoding: "utf8" });
+  const lines = createInterface({ input, crlfDelay: Number.POSITIVE_INFINITY });
+  let lineNumber = 0;
+  for await (const line of lines) {
+    lineNumber += 1;
+    if (line.trim() === "") continue;
+    try {
+      inspectValue(JSON.parse(line), file, "$", findings, lineNumber);
+    } catch (error) {
+      findings.push({
+        file,
+        line: lineNumber,
+        path: "$",
+        reason: `invalid JSONL row: ${error instanceof Error ? error.message : String(error)}`,
+      });
+    }
+  }
+}
+
+function inspectValue(
+  value: unknown,
+  file: string,
+  path: string,
+  findings: Finding[],
+  line?: number,
+) {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => inspectValue(item, file, `${path}[${index}]`, findings, line));
+    return;
+  }
+
+  if (value && typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      const childPath = `${path}.${key}`;
+      if (key === "storageId") {
+        findings.push({
+          file,
+          line,
+          path: childPath,
+          reason: "raw storageId field is not allowed",
+        });
+      }
+      if (key === "path" && typeof child === "string" && RAW_STORAGE_PATH_PATTERN.test(child)) {
+        findings.push({
+          file,
+          line,
+          path: childPath,
+          reason: "raw _storage/ bundle path is not allowed",
+        });
+      }
+      inspectValue(child, file, childPath, findings, line);
+    }
+    return;
+  }
+
+  if (typeof value !== "string") return;
+  if (RAW_CONVEX_REF_PATTERN.test(value)) {
+    findings.push({
+      file,
+      line,
+      path,
+      reason: "raw Convex document id reference is not allowed",
+    });
+  }
+  if (SECRET_PATTERN.test(value)) {
+    findings.push({
+      file,
+      line,
+      path,
+      reason: "obvious secret-like value is not allowed",
+    });
+  }
+}
+
+function parseArgs(args: string[]): Options {
+  let snapshotDir: string | null = null;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--snapshot-dir") {
+      snapshotDir = args[++index] ?? null;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!snapshotDir) throw new Error("--snapshot-dir is required");
+  return { snapshotDir };
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/security-dataset/validateGuardrails.test.ts
+++ b/scripts/security-dataset/validateGuardrails.test.ts
@@ -1,0 +1,88 @@
+/* @vitest-environment node */
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+describe("security dataset guardrail validator", () => {
+  it("allows ordinary skill content that mentions storage concepts", async () => {
+    const snapshotDir = await createSnapshot([
+      {
+        id: "row-ok",
+        skill_bundle_content: [
+          {
+            path: "references/components/data_collection_&_storage.md",
+            content: "A user file may mention storageId as code text without leaking a raw field.",
+          },
+        ],
+      },
+    ]);
+    try {
+      await expect(runValidator(snapshotDir)).resolves.toMatchObject({
+        stdout: expect.stringContaining("sanitized output guardrails passed"),
+      });
+    } finally {
+      await rm(snapshotDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects raw storage fields, raw storage paths, raw Convex ids, and obvious secrets", async () => {
+    const snapshotDir = await createSnapshot([
+      {
+        id: "row-bad",
+        storageId: "abc123",
+        skill_bundle_content: [
+          {
+            path: "_storage/raw-blob",
+            content: "raw ref skillVersions:abc123def456 and token sk-abcdefghijklmnopqrstuvwxyz",
+          },
+        ],
+      },
+    ]);
+    try {
+      await expect(runValidator(snapshotDir)).rejects.toMatchObject({
+        stderr: expect.stringContaining("raw storageId field is not allowed"),
+      });
+      await expect(runValidator(snapshotDir)).rejects.toMatchObject({
+        stderr: expect.stringContaining("raw _storage/ bundle path is not allowed"),
+      });
+      await expect(runValidator(snapshotDir)).rejects.toMatchObject({
+        stderr: expect.stringContaining("raw Convex document id reference is not allowed"),
+      });
+      await expect(runValidator(snapshotDir)).rejects.toMatchObject({
+        stderr: expect.stringContaining("obvious secret-like value is not allowed"),
+      });
+    } finally {
+      await rm(snapshotDir, { recursive: true, force: true });
+    }
+  });
+});
+
+async function createSnapshot(rows: unknown[]) {
+  const snapshotDir = await mkdtemp(join(tmpdir(), "clawhub-security-guardrails-"));
+  await mkdir(join(snapshotDir, "hf-dataset", "data"), { recursive: true });
+  await writeFile(join(snapshotDir, "manifest.json"), JSON.stringify({ ok: true }));
+  for (const split of ["train", "validation", "test", "eval_holdout"]) {
+    await writeFile(
+      join(snapshotDir, "hf-dataset", "data", `${split}.jsonl`),
+      split === "train" ? rows.map((row) => JSON.stringify(row)).join("\n") : "",
+    );
+  }
+  return snapshotDir;
+}
+
+async function runValidator(snapshotDir: string) {
+  return await execFileAsync(
+    "bun",
+    ["scripts/security-dataset/validate-guardrails.ts", "--snapshot-dir", snapshotDir],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- replace the security dataset publish job's broad grep guardrail with a structured JSON/JSONL validator
- keep blocking actual raw `storageId` fields, raw `_storage/` bundle paths, raw Convex document id references, and obvious secret-like values
- allow ordinary skill content and file paths that mention storage concepts, e.g. `data_collection_&_storage/...` or text that discusses `storageId`

## Why
The tuned production publish run exported and merged all 256 shards successfully, then failed before upload because the broad grep matched valid skill content in HF rows. The failing run was https://github.com/openclaw/clawhub/actions/runs/28084680994; upload was correctly skipped.

## Validation
- `bun -e 'import { parse } from "yaml"; const text = await Bun.file(".github/workflows/security-dataset-snapshot.yml").text(); parse(text); console.log("yaml ok")' && actionlint .github/workflows/security-dataset-snapshot.yml`
- `bun run format:check -- .github/workflows/security-dataset-snapshot.yml scripts/security-dataset/validate-guardrails.ts scripts/security-dataset/validateGuardrails.test.ts`
- `bunx vitest run scripts/security-dataset/validateGuardrails.test.ts scripts/security-dataset/mergeSnapshots.test.ts scripts/security-dataset/exportSnapshotCli.test.ts scripts/security-dataset/huggingFaceExport.test.ts`
- `bunx tsc --noEmit --pretty false`
- `git diff --check`
