### PR TITLE
ci: smooth blacksmith worker bursts

### DIFF
--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: clawhub-testbox-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   BUN_VERSION: "1.3.10"
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -37,6 +37,7 @@ jobs:
     environment: Production
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         shard: [0, 1, 2, 3]
     env:

--- a/.github/workflows/skill-card-worker.yml
+++ b/.github/workflows/skill-card-worker.yml
@@ -34,6 +34,7 @@ jobs:
     environment: Production
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         shard: [0, 1, 2, 3]
     env:


### PR DESCRIPTION
## What changed
- add workflow-level cancellation for superseded Blacksmith Testbox runs on the same ref
- cap Security Scan Codex and Skill Card worker shard fanout at 2 concurrent Blacksmith runners per run

## Why
The org shares GitHub's runner-registration budget, so long-tail repo bursts should use the same smoothing pattern as OpenClaw's main CI. The scheduled worker workflows keep `cancel-in-progress: false` intentionally so active lease workers are not killed mid-claim; this PR limits per-run fanout instead.

## Evidence
- org workflow scan found ClawHub Blacksmith workflows missing Testbox concurrency and worker `max-parallel`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/workflows/ci-check-testbox.yml .github/workflows/security-scan-codex.yml .github/workflows/skill-card-worker.yml`
- `git diff --check`
