### PR TITLE
ci: lower security dataset export min page size

### DIFF
--- a/.github/workflows/security-dataset-snapshot.yml
+++ b/.github/workflows/security-dataset-snapshot.yml
@@ -26,7 +26,7 @@ on:
       min-page-size:
         description: "Smallest page size to retry after Convex timeouts"
         required: true
-        default: "5"
+        default: "1"
       batch-pages:
         description: "Live export pages per Convex request"
         required: true
@@ -67,7 +67,7 @@ jobs:
       HF_UPLOAD: ${{ github.event_name == 'schedule' || inputs.upload == 'true' }}
       SNAPSHOT_LIMIT: ${{ inputs.limit || '' }}
       SNAPSHOT_PAGE_SIZE: ${{ inputs['page-size'] || '25' }}
-      SNAPSHOT_MIN_PAGE_SIZE: ${{ inputs['min-page-size'] || '5' }}
+      SNAPSHOT_MIN_PAGE_SIZE: ${{ inputs['min-page-size'] || '1' }}
       SNAPSHOT_BATCH_PAGES: ${{ inputs['batch-pages'] || '1' }}
       SNAPSHOT_CONCURRENCY: ${{ inputs.concurrency || '1' }}
       SNAPSHOT_SHARDS: ${{ inputs.shards || '128' }}
@@ -127,7 +127,7 @@ jobs:
       HF_DATASET_REPO: OpenClaw/clawhub-security-signals
       HF_REVISION: ${{ inputs['hf-revision'] || 'main' }}
       SNAPSHOT_PAGE_SIZE: ${{ inputs['page-size'] || '25' }}
-      SNAPSHOT_MIN_PAGE_SIZE: ${{ inputs['min-page-size'] || '5' }}
+      SNAPSHOT_MIN_PAGE_SIZE: ${{ inputs['min-page-size'] || '1' }}
       SNAPSHOT_BATCH_PAGES: ${{ inputs['batch-pages'] || '1' }}
       SANITIZED_OUT_DIR: /tmp/clawhub-security-dataset/shard
     steps:

--- a/scripts/security-dataset/export-snapshot.ts
+++ b/scripts/security-dataset/export-snapshot.ts
@@ -851,7 +851,7 @@ function parseArgs(args: string[]): Options {
     mode: "public",
     limit: null,
     pageSize: DEFAULT_PAGE_SIZE,
-    minPageSize: Math.min(10, DEFAULT_PAGE_SIZE),
+    minPageSize: 1,
     batchPages: DEFAULT_BATCH_PAGES,
     concurrency: DEFAULT_CONCURRENCY,
     shards: DEFAULT_SHARDS,


### PR DESCRIPTION
## Summary
- lower the security dataset export minimum page size from 5 to 1 for workflow dispatch, scheduled runs, and CLI defaults
- lets pathological export pages shrink below five artifacts after Convex/socket timeouts

## Test
- `bunx vitest run scripts/security-dataset/exportSnapshotCli.test.ts scripts/security-dataset/validateGuardrails.test.ts scripts/security-dataset/mergeSnapshots.test.ts scripts/security-dataset/huggingFaceExport.test.ts`
- `bun -e 'import { parse } from "yaml"; const text = await Bun.file(".github/workflows/security-dataset-snapshot.yml").text(); parse(text); console.log("yaml ok")' && actionlint .github/workflows/security-dataset-snapshot.yml`
- `bun run format:check -- .github/workflows/security-dataset-snapshot.yml scripts/security-dataset/export-snapshot.ts`
- `bunx tsc --noEmit --pretty false`
- `git diff --check`
