### PR TITLE
fix: remove hero category comma separators

### DIFF
--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -317,6 +317,31 @@ describe("plugin detail route", () => {
     expect(screen.getByLabelText("Topics").textContent).toContain("#research");
   });
 
+  it("renders hero category labels without comma separators", async () => {
+    loaderDataMock = {
+      ...loaderDataMock,
+      detail: {
+        ...loaderDataMock.detail,
+        package: {
+          ...loaderDataMock.detail.package!,
+          categories: ["tools", "web", "channels"],
+          topics: ["Workflow"],
+        },
+      },
+    };
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    const taxonomy = document.querySelector(".skill-category-meta-list");
+    expect(taxonomy).toBeTruthy();
+    expect(taxonomy?.textContent).toContain("Tools");
+    expect(taxonomy?.textContent).toContain("Web");
+    expect(taxonomy?.textContent).toContain("Channels");
+    expect(taxonomy?.textContent).not.toContain(",");
+  });
+
   it("renders populated active release history on the versions tab", async () => {
     const publishedAt = new Date("2026-06-01T12:00:00Z").getTime();
     loaderDataMock = {

--- a/src/components/SkillHeader.test.tsx
+++ b/src/components/SkillHeader.test.tsx
@@ -165,6 +165,22 @@ describe("SkillHeader", () => {
     ).toBeTruthy();
   });
 
+  it("renders hero category labels without comma separators", () => {
+    const { container } = renderHeader({
+      skill: { ...skill, topics: ["workflow"] },
+      categories: [
+        { slug: "automation", label: "Automation", icon: "zap", keywords: [] },
+        { slug: "development", label: "Development", icon: "wrench", keywords: [] },
+      ],
+    });
+
+    const taxonomy = container.querySelector(".skill-category-meta-list");
+    expect(taxonomy).toBeTruthy();
+    expect(taxonomy?.textContent).toContain("Automation");
+    expect(taxonomy?.textContent).toContain("Development");
+    expect(taxonomy?.textContent).not.toContain(",");
+  });
+
   it("keeps desktop-width sidebar details expanded at 1071px", () => {
     const { container } = renderHeader();
 

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -367,7 +367,7 @@ export function SkillHeader({
                   <div className="skill-hero-taxonomy-row" aria-label="Skill metadata">
                     {headerCategories.length > 0 ? (
                       <div className="skill-category-meta-list" aria-label="Categories">
-                        {headerCategories.map((categoryItem, index) => (
+                        {headerCategories.map((categoryItem) => (
                           <a
                             key={categoryItem.slug}
                             className="skill-category-meta-link"
@@ -380,10 +380,7 @@ export function SkillHeader({
                               size={14}
                               className="skill-category-icon"
                             />
-                            <span>
-                              {categoryItem.label}
-                              {index < headerCategories.length - 1 ? "," : ""}
-                            </span>
+                            <span>{categoryItem.label}</span>
                           </a>
                         ))}
                       </div>

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -1600,7 +1600,7 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
                   <div className="skill-hero-taxonomy-row" aria-label="Plugin metadata">
                     {headerCategories.length > 0 ? (
                       <div className="skill-category-meta-list" aria-label="Categories">
-                        {headerCategories.map((category, index) => (
+                        {headerCategories.map((category) => (
                           <a
                             key={category.slug}
                             className="skill-category-meta-link"
@@ -1613,10 +1613,7 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
                               size={14}
                               className="skill-category-icon"
                             />
-                            <span>
-                              {category.label}
-                              {index < headerCategories.length - 1 ? "," : ""}
-                            </span>
+                            <span>{category.label}</span>
                           </a>
                         ))}
                       </div>


### PR DESCRIPTION
## Summary
- remove literal comma characters from skill and plugin hero category metadata links
- add regression coverage for multi-category skill and plugin hero rows

## Proof
- Local browser proof published in https://github.com/openclaw/clawhub/pull/2849#issuecomment-4791421126

## Tests
- `bun run test src/components/SkillHeader.test.tsx src/__tests__/package-detail-route.test.tsx`
- `bun run format:check -- src/components/SkillHeader.tsx src/components/SkillHeader.test.tsx src/__tests__/package-detail-route.test.tsx src/routes/plugins/\$name.tsx`
- `bun run ci:static`
- `bun run ci:unit`
- `./.agents/skills/autoreview/scripts/autoreview --mode local`
