### PR TITLE
fix: stabilize CI smoke and local-auth gates

### DIFF
--- a/e2e/ci-smoke.pw.test.ts
+++ b/e2e/ci-smoke.pw.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { stubExternalMediaInVitePreview } from "./helpers/externalMedia";
 import { expectHealthyPage, trackRuntimeErrors } from "./helpers/runtimeErrors";
 
 test("public navigation routes render without runtime errors", async ({ browser }) => {
@@ -9,6 +10,7 @@ test("public navigation routes render without runtime errors", async ({ browser 
 
   for (const route of routes) {
     const page = await browser.newPage();
+    await stubExternalMediaInVitePreview(page);
     const errors = trackRuntimeErrors(page);
 
     await page.goto(route.path, { waitUntil: "domcontentloaded" });
@@ -19,6 +21,7 @@ test("public navigation routes render without runtime errors", async ({ browser 
 });
 
 test("signed-out publish entry renders", async ({ page }) => {
+  await stubExternalMediaInVitePreview(page);
   const errors = trackRuntimeErrors(page);
 
   await page.goto("/upload", { waitUntil: "domcontentloaded" });

--- a/e2e/helpers/externalMedia.ts
+++ b/e2e/helpers/externalMedia.ts
@@ -1,0 +1,41 @@
+import type { Page } from "@playwright/test";
+
+const OPENCLAW_MEDIA_EXTENSIONS = new Set([
+  ".avif",
+  ".gif",
+  ".ico",
+  ".jpeg",
+  ".jpg",
+  ".png",
+  ".svg",
+  ".webp",
+]);
+
+export function isKnownOpenClawMediaUrl(url: string) {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    return false;
+  }
+
+  if (parsedUrl.origin !== "https://openclaw.ai") return false;
+  if (parsedUrl.pathname === "/favicon.svg") return true;
+  if (!parsedUrl.pathname.startsWith("/ecosystem/")) return false;
+
+  const extension = parsedUrl.pathname.match(/\.[^./]+$/)?.[0]?.toLowerCase();
+  return extension !== undefined && OPENCLAW_MEDIA_EXTENSIONS.has(extension);
+}
+
+export async function stubExternalMediaInVitePreview(page: Page) {
+  if (process.env.PLAYWRIGHT_BASE_URL) return;
+
+  await page.route("**/_vercel/image?**", (route) => route.fulfill({ status: 204 }));
+
+  await page.route("https://openclaw.ai/**", (route) => {
+    if (isKnownOpenClawMediaUrl(route.request().url())) {
+      return route.fulfill({ status: 204 });
+    }
+    return route.continue();
+  });
+}

--- a/e2e/helpers/runtimeErrors.ts
+++ b/e2e/helpers/runtimeErrors.ts
@@ -1,4 +1,12 @@
-import { expect, type Page } from "@playwright/test";
+import { expect, type ConsoleMessage, type Page } from "@playwright/test";
+import { isKnownOpenClawMediaUrl } from "./externalMedia";
+
+const EXTERNAL_RESOURCE_DNS_ERROR = "Failed to load resource: net::ERR_NAME_NOT_RESOLVED";
+
+function isIgnoredExternalResourceDnsError(message: ConsoleMessage) {
+  if (message.text() !== EXTERNAL_RESOURCE_DNS_ERROR) return false;
+  return isKnownOpenClawMediaUrl(message.location().url);
+}
 
 export function trackRuntimeErrors(page: Page) {
   const errors: string[] = [];
@@ -9,6 +17,7 @@ export function trackRuntimeErrors(page: Page) {
 
   page.on("console", (message) => {
     if (message.type() !== "error") return;
+    if (isIgnoredExternalResourceDnsError(message)) return;
     errors.push(`console:${message.text()}`);
   });
 

--- a/e2e/public-routes-smoke.pw.test.ts
+++ b/e2e/public-routes-smoke.pw.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+import { stubExternalMediaInVitePreview } from "./helpers/externalMedia";
 import { expectHealthyPage, trackRuntimeErrors, waitForHydration } from "./helpers/runtimeErrors";
 
 type SeedFixtures = {
@@ -30,12 +31,6 @@ function pluginDetailPath(name: string) {
 function seedApiUrl(path: string) {
   const convexSiteUrl = process.env.VITE_CONVEX_SITE_URL?.trim();
   return convexSiteUrl ? new URL(path, convexSiteUrl).toString() : path;
-}
-
-async function stubVercelImageOptimizerInVitePreview(page: Page) {
-  if (process.env.PLAYWRIGHT_BASE_URL) return;
-  // Vite preview does not serve Vercel's production-only image optimizer.
-  await page.route("**/_vercel/image?**", (route) => route.fulfill({ status: 204 }));
 }
 
 async function getSeedFixture(request: APIRequestContext, path: string) {
@@ -212,7 +207,7 @@ async function expectPublicRouteHealthy(
   route: PublicRouteCase,
   fixtures: SeedFixtures,
 ) {
-  await stubVercelImageOptimizerInVitePreview(page);
+  await stubExternalMediaInVitePreview(page);
   const errors = trackRuntimeErrors(page);
   const path = route.path(fixtures);
   const response = await page.goto(path, { waitUntil: "domcontentloaded" });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ci:pr": "bun run ci:static && bun run ci:unit && bun run ci:packages && bun run ci:types-build && bun run ci:e2e-http",
     "ci:static": "bun run check:peers && bun audit --ignore GHSA-rmmr-r34h-pfm5 --ignore GHSA-gv7w-rqvm-qjhr --ignore GHSA-g7r4-m6w7-qqqr --ignore GHSA-x4vx-rjvf-j5p4 --ignore GHSA-76mc-f452-cxcm --ignore GHSA-hpcv-96wg-7vj8 --ignore GHSA-r47g-fvhr-h676 --ignore GHSA-vxr8-fq34-vvx9 --ignore GHSA-gvmj-g25r-r7wr --ignore GHSA-rp9w-3fw7-7cwq --ignore GHSA-cmwh-pvxp-8882 --ignore GHSA-vmh5-mc38-953g --ignore GHSA-pr7r-676h-xcf6 && bun run llms:check && bun run format:check && bun run lint && bun run deadcode:ci",
     "ci:types-build": "bunx tsc --noEmit && bunx tsc -p packages/schema/tsconfig.json --noEmit && bunx tsc -p packages/clawhub/tsconfig.json --noEmit && bun run --cwd packages/clawhub-admin typecheck && VITE_CONVEX_URL=https://example.invalid bun run build",
-    "ci:unit": "VITE_CONVEX_URL=https://example.invalid bun run coverage",
+    "ci:unit": "SITE_URL= VITE_SITE_URL= VITE_CONVEX_URL=https://example.invalid bun run coverage",
     "clawscan:local": "bun scripts/local-clawscan-dry-run.ts",
     "convex:deploy": "bunx convex deploy --typecheck=disable --yes",
     "coverage": "vitest run --coverage",

--- a/scripts/playwright-local-auth-config.test.ts
+++ b/scripts/playwright-local-auth-config.test.ts
@@ -1,7 +1,24 @@
 import { describe, expect, it } from "vitest";
-import { resolveLocalAuthRunnerConfig } from "./playwright-local-auth-config";
+import {
+  resolveLocalAuthDeployment,
+  resolveLocalAuthRunnerConfig,
+} from "./playwright-local-auth-config";
 
 describe("playwright local-auth runner config", () => {
+  it("defaults local-auth Convex to the anonymous deployment marker", () => {
+    expect(resolveLocalAuthDeployment(undefined, null)).toBe("anonymous:anonymous-agent");
+    expect(resolveLocalAuthDeployment(undefined, undefined)).toBe("anonymous:anonymous-agent");
+  });
+
+  it("prefers explicit and discovered local-auth deployments before the default", () => {
+    expect(resolveLocalAuthDeployment("anonymous:explicit-agent", "anonymous:local-agent")).toBe(
+      "anonymous:explicit-agent",
+    );
+    expect(resolveLocalAuthDeployment(undefined, "anonymous:local-agent")).toBe(
+      "anonymous:local-agent",
+    );
+  });
+
   it("does not inherit the generic CI Convex URL", () => {
     expect(
       resolveLocalAuthRunnerConfig({

--- a/scripts/playwright-local-auth-config.ts
+++ b/scripts/playwright-local-auth-config.ts
@@ -1,5 +1,6 @@
 const DEFAULT_CONVEX_URL = "http://127.0.0.1:3210";
 const DEFAULT_CONVEX_SITE_URL = "http://127.0.0.1:3211";
+export const DEFAULT_LOCAL_AUTH_CONVEX_DEPLOYMENT = "anonymous:anonymous-agent";
 const DEFAULT_PLAYWRIGHT_ARGS = ["--project=chromium", "e2e/local-auth"];
 const DEFAULT_PLAYWRIGHT_RETRIES = "1";
 
@@ -21,6 +22,13 @@ function withDefaultRetries(args: string[]) {
     return args;
   }
   return [`--retries=${DEFAULT_PLAYWRIGHT_RETRIES}`, ...args];
+}
+
+export function resolveLocalAuthDeployment(
+  configuredDeployment: string | undefined,
+  fallbackDeployment: string | null | undefined,
+) {
+  return configuredDeployment ?? fallbackDeployment ?? DEFAULT_LOCAL_AUTH_CONVEX_DEPLOYMENT;
 }
 
 export function resolveLocalAuthRunnerConfig(

--- a/scripts/run-playwright-local-auth.ts
+++ b/scripts/run-playwright-local-auth.ts
@@ -13,9 +13,11 @@ import {
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { resolveLocalAuthRunnerConfig } from "./playwright-local-auth-config";
+import {
+  resolveLocalAuthDeployment,
+  resolveLocalAuthRunnerConfig,
+} from "./playwright-local-auth-config";
 
-const DEFAULT_CONVEX_DEPLOYMENT = "anonymous-agent";
 const DEFAULT_DEV_AUTH_CONVEX_DEPLOYMENT = "anonymous:anonymous-agent";
 const DEFAULT_PLAYWRIGHT_PORT = 4173;
 const DEFAULT_E2E_WORKER_TOKEN = "local-e2e-worker-token";
@@ -468,8 +470,10 @@ async function main() {
   isolateLocalState();
 
   const authKeys = buildAuthKeys();
-  const deployment =
-    runnerConfig.convexDeployment ?? readLocalDeployment() ?? DEFAULT_CONVEX_DEPLOYMENT;
+  const deployment = resolveLocalAuthDeployment(
+    runnerConfig.convexDeployment,
+    readLocalDeployment(),
+  );
   const e2eEnv: NodeJS.ProcessEnv = {
     ...process.env,
     AUTH_GITHUB_ID: process.env.AUTH_GITHUB_ID ?? "local-dev",


### PR DESCRIPTION
## Summary

This stabilizes the local CI gates that were failing in prepared worktrees. Public Playwright smoke tests now stub only local-preview external media that is outside the app runtime contract, local-auth Playwright uses the correct anonymous Convex deployment marker fallback, and unit CI no longer inherits local site URL overrides from `.env.local`.

## What Changed

- Public browser smoke: added a shared Vite-preview media stub for the Vercel image optimizer and known OpenClaw media assets, and reused it across the public smoke specs.
- Runtime error tracking: narrowed DNS-error suppression to exact known OpenClaw media URLs so unrelated script, style, data, page, or console errors still fail the smoke gate.
- Local-auth runner: extracted deployment resolution and defaulted isolated local Convex runs to `anonymous:anonymous-agent`, with unit coverage for explicit, discovered, and default precedence.
- Unit CI: clears `SITE_URL` and `VITE_SITE_URL` before coverage so local worktree URLs do not change public-origin assertions.

## Proof

- The smoke helper only runs when `PLAYWRIGHT_BASE_URL` is unset, so external target runs keep real network behavior.
- OpenClaw media matching is constrained to `https://openclaw.ai/favicon.svg` and `/ecosystem/*` files with media extensions.
- Local-auth deployment resolution is covered by focused config tests and the full local-auth browser gate.
- Screenshots: none included; this PR changes CI/test infrastructure and does not change reviewer-visible UI.

## Verification

Automated checks run locally:

- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bun run ci:packages`
- `bun run ci:e2e-http`
- `bun run ci:playwright-smoke`
- `bun run test:pw:local-auth`
- `bun test scripts/playwright-local-auth-config.test.ts`
- `git diff --check && git diff --cached --check`

Review:

- `$code-review` completed with no remaining actionable findings after the tracked-helper and media-allowlist fixes.
