### PR TITLE
fix: redact security dataset public metadata

### DIFF
--- a/scripts/security-dataset/normalize.test.ts
+++ b/scripts/security-dataset/normalize.test.ts
@@ -269,6 +269,32 @@ describe("security dataset normalizer", () => {
     ]);
   });
 
+  it("redacts secret-like public metadata and bundle paths", () => {
+    const rows = normalizeArtifactExport([
+      {
+        ...baseArtifact,
+        publicName: "Demo token=supersecretvalue123",
+        publicOwnerHandle: "ghp_abcdefghijklmnopqrstuvwxyz1234567890",
+        publicSlug: "sk-abcdefghijklmnopqrstuvwxyz",
+        bundleFilesRedacted: [
+          {
+            path: "config/sk-abcdefghijklmnopqrstuvwxyz/settings.json",
+            content: "echo safe\n",
+          },
+        ],
+      },
+    ]);
+
+    const artifact = rows.artifacts[0];
+    expect(artifact?.public_name).toBe("Demo [REDACTED_SECRET]");
+    expect(artifact?.public_owner_handle).toBe("[REDACTED_SECRET]");
+    expect(artifact?.public_slug).toBe("[REDACTED_SECRET]");
+    expect(artifact?.public_qualified_slug).toBe("[REDACTED_SECRET]/[REDACTED_SECRET]");
+    expect(artifact?.bundle_files_redacted?.[0]?.path).toBe(
+      "config/[REDACTED_SECRET]/settings.json",
+    );
+  });
+
   it("omits oversized redacted bundle files", () => {
     const rows = normalizeArtifactExport([
       {

--- a/scripts/security-dataset/normalize.ts
+++ b/scripts/security-dataset/normalize.ts
@@ -299,6 +299,13 @@ export function redactText(value: string | null | undefined, maxLength = MAX_RED
   return `${redacted.slice(0, maxLength - 1)}...`;
 }
 
+export function hasSecretLikeValue(value: string) {
+  return SECRET_PATTERNS.some((pattern) => {
+    pattern.lastIndex = 0;
+    return pattern.test(value);
+  });
+}
+
 export function redactSkillContent(value: string | null | undefined) {
   return redactText(value, MAX_REDACTED_SKILL_CONTENT_LENGTH);
 }
@@ -342,16 +349,18 @@ export function assignSplit(splitKey: string): DatasetSplit {
 
 function buildArtifactRow(input: ArtifactExportInput, artifactId: string): ArtifactRow {
   const bundleFiles = buildBundleFileRows(input);
+  const publicOwnerHandle = redactMetadata(input.publicOwnerHandle);
+  const publicSlug = redactMetadata(input.publicSlug);
   return {
     artifact_id: artifactId,
     source_kind: input.sourceKind,
     source_table: input.sourceKind === "skill" ? "skillVersions" : "packageReleases",
     source_doc_id_hash: hashString(input.sourceDocId),
     parent_doc_id_hash: hashString(input.parentDocId),
-    public_name: input.publicName,
-    public_owner_handle: input.publicOwnerHandle,
-    public_slug: input.publicSlug,
-    public_qualified_slug: qualifiedPublicSlug(input),
+    public_name: redactMetadata(input.publicName) ?? "",
+    public_owner_handle: publicOwnerHandle,
+    public_slug: publicSlug,
+    public_qualified_slug: qualifiedPublicSlug(input.sourceKind, publicOwnerHandle, publicSlug),
     version: input.version,
     artifact_sha256: input.artifactSha256,
     ...(input.sourceKind === "skill" && input.skillMdContentRedacted
@@ -380,7 +389,7 @@ function buildBundleFileRows(
 ): NonNullable<ArtifactRow["bundle_files_redacted"]> {
   if (input.sourceKind !== "skill" || !Array.isArray(input.bundleFilesRedacted)) return [];
   return input.bundleFilesRedacted.flatMap((file) => {
-    const path = file.path.trim();
+    const path = redactBundlePath(file.path);
     if (!path || !file.content) return [];
     const content = redactBundleContent(file.content);
     if (Buffer.byteLength(content, "utf8") > MAX_REDACTED_BUNDLE_FILE_BYTES) return [];
@@ -395,6 +404,14 @@ function buildBundleFileRows(
   });
 }
 
+function redactMetadata(value: string | null | undefined) {
+  return redactText(value);
+}
+
+function redactBundlePath(value: string) {
+  return redactText(value.trim(), 2048) ?? "";
+}
+
 export function redactBundleContent(value: string) {
   let redacted = "";
   for (let index = 0; index < value.length; index += 1) {
@@ -407,10 +424,14 @@ export function redactBundleContent(value: string) {
   return redacted;
 }
 
-function qualifiedPublicSlug(input: ArtifactExportInput) {
-  if (input.sourceKind !== "skill") return null;
-  if (!input.publicOwnerHandle || !input.publicSlug) return null;
-  return `${input.publicOwnerHandle}/${input.publicSlug}`;
+function qualifiedPublicSlug(
+  sourceKind: SourceKind,
+  publicOwnerHandle: string | null,
+  publicSlug: string | null,
+) {
+  if (sourceKind !== "skill") return null;
+  if (!publicOwnerHandle || !publicSlug) return null;
+  return `${publicOwnerHandle}/${publicSlug}`;
 }
 
 function buildScanResultRows(input: ArtifactExportInput, artifactId: string): ScanResultRow[] {

--- a/scripts/security-dataset/validate-guardrails.ts
+++ b/scripts/security-dataset/validate-guardrails.ts
@@ -2,6 +2,7 @@ import { createReadStream } from "node:fs";
 import { readFile, stat } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 import { createInterface } from "node:readline";
+import { hasSecretLikeValue } from "./normalize";
 
 type Options = {
   snapshotDir: string;
@@ -15,8 +16,6 @@ type Finding = {
 };
 
 const HF_SPLITS = ["train", "validation", "test", "eval_holdout"] as const;
-const SECRET_PATTERN =
-  /gh[pousr]_[A-Za-z0-9_]{20,}|sk-[A-Za-z0-9_-]{20,}|AKIA[0-9A-Z]{16}|-----BEGIN [A-Z0-9 ]*(PRIVATE KEY|CERTIFICATE)-----/;
 const RAW_CONVEX_REF_PATTERN = /\b(?:skillVersions|packageReleases):[a-z0-9]{6,}\b/i;
 const RAW_STORAGE_PATH_PATTERN = /(^|\/)_storage\//;
 
@@ -130,7 +129,7 @@ function inspectValue(
       reason: "raw Convex document id reference is not allowed",
     });
   }
-  if (SECRET_PATTERN.test(value)) {
+  if (hasSecretLikeValue(value)) {
     findings.push({
       file,
       line,

--- a/scripts/security-dataset/validateGuardrails.test.ts
+++ b/scripts/security-dataset/validateGuardrails.test.ts
@@ -16,7 +16,8 @@ describe("security dataset guardrail validator", () => {
         skill_bundle_content: [
           {
             path: "references/components/data_collection_&_storage.md",
-            content: "A user file may mention storageId as code text without leaking a raw field.",
+            content:
+              "A user file may mention storageId as code text or ask-abcdefghijklmnopqrstuvwxyz without leaking a raw field.",
           },
         ],
       },


### PR DESCRIPTION
## Summary
- redact secret-like public metadata and bundle file paths in security dataset normalization
- make the guardrail validator reuse the sanitizer's secret detector so policy and validation stay aligned
- add regression coverage for metadata/path redaction and non-token substring false positives

## Test
- `bunx vitest run scripts/security-dataset/normalize.test.ts scripts/security-dataset/validateGuardrails.test.ts scripts/security-dataset/huggingFaceExport.test.ts scripts/security-dataset/exportSnapshotCli.test.ts`
- `bunx vitest run scripts/security-dataset/mergeSnapshots.test.ts scripts/security-dataset/validateGuardrails.test.ts scripts/security-dataset/normalize.test.ts scripts/security-dataset/huggingFaceExport.test.ts scripts/security-dataset/exportSnapshotCli.test.ts`
- `bun run format:check -- scripts/security-dataset/normalize.ts scripts/security-dataset/normalize.test.ts scripts/security-dataset/validate-guardrails.ts scripts/security-dataset/validateGuardrails.test.ts`
- `bunx tsc --noEmit --pretty false`
- `git diff --check`
