### PR TITLE
Rename Official UI labels to Verified

### DIFF
--- a/src/__tests__/creators-route.test.tsx
+++ b/src/__tests__/creators-route.test.tsx
@@ -192,7 +192,7 @@ describe("creators route", () => {
     expect(screen.getByRole("heading", { name: "Creators" })).toBeTruthy();
     expect(screen.queryByText("17")).toBeNull();
     expect(screen.getByRole("radio", { name: "All" })).toBeTruthy();
-    expect(screen.getByRole("radio", { name: "Official" })).toBeTruthy();
+    expect(screen.getByRole("radio", { name: "Verified" })).toBeTruthy();
     expect(screen.getByRole("radio", { name: "Organizations" })).toBeTruthy();
     expect(screen.getByRole("radio", { name: "Users" })).toBeTruthy();
     expect(screen.queryByText("Builders")).toBeNull();

--- a/src/__tests__/home-listing-section.test.tsx
+++ b/src/__tests__/home-listing-section.test.tsx
@@ -603,7 +603,7 @@ describe("HomeListingSection", () => {
 
     render(<HomeListingSection />);
     fireEvent.click(screen.getByRole("button", { name: "Plugins" }));
-    fireEvent.click(screen.getByRole("tab", { name: "Official" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Verified" }));
 
     await waitFor(() => {
       expect(screen.getByText("Official Plugin").textContent).toBe("Official Plugin");
@@ -649,7 +649,7 @@ describe("HomeListingSection", () => {
     });
     expect(fetchPluginCatalogMock).toHaveBeenCalledTimes(2);
 
-    fireEvent.click(screen.getByRole("tab", { name: "Official" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Verified" }));
 
     await waitFor(() => {
       expect(screen.getByText("Official Plugin")).toBeTruthy();

--- a/src/__tests__/package-detail-route.test.tsx
+++ b/src/__tests__/package-detail-route.test.tsx
@@ -955,7 +955,7 @@ describe("plugin detail route", () => {
     expect(packageCrumb?.textContent).toBe("firecrawl-plugin");
   });
 
-  it("labels official packages as Official", async () => {
+  it("labels official packages as Verified", async () => {
     loaderDataMock = {
       ...loaderDataMock,
       detail: {
@@ -972,7 +972,7 @@ describe("plugin detail route", () => {
 
     const { container } = render(<Component />);
 
-    expect(screen.getAllByLabelText("Official").length).toBeGreaterThan(0);
+    expect(screen.getAllByLabelText("Verified").length).toBeGreaterThan(0);
     expect(container.querySelector(".skill-hero-creator .official-badge-icon-only")).toBeTruthy();
     expect(container.querySelector(".skill-hero-title-row .official-tag")).toBeNull();
     expect(screen.queryByText("Verified")).toBeNull();

--- a/src/__tests__/packages-route.test.tsx
+++ b/src/__tests__/packages-route.test.tsx
@@ -1297,7 +1297,7 @@ describe("plugins route", () => {
     render(<Component />);
 
     expect(screen.getByRole("radio", { name: "All" }).getAttribute("aria-checked")).toBe("true");
-    expect(screen.getByRole("radio", { name: "Official" })).toBeTruthy();
+    expect(screen.getByRole("radio", { name: "Verified" })).toBeTruthy();
     expect(screen.getByRole("radio", { name: "Updated" })).toBeTruthy();
     expect(screen.queryByRole("radio", { name: "Relevance" })).toBeNull();
   });
@@ -1443,7 +1443,7 @@ describe("plugins route", () => {
     const sortOptions = Array.from(
       screen.getByRole("radiogroup", { name: "Sort order" }).querySelectorAll('[role="radio"]'),
     ).map((option) => option.textContent);
-    expect(sortOptions).toEqual(["All", "Official", "Updated"]);
+    expect(sortOptions).toEqual(["All", "Verified", "Updated"]);
     expect(screen.queryByRole("radio", { name: "Most downloaded" })).toBeNull();
     expect(screen.queryByRole("radio", { name: "Newest" })).toBeNull();
     expect(screen.queryByRole("radio", { name: "Name" })).toBeNull();

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -22,7 +22,7 @@ const FOOTER_EASTER_ASCII = [
   "  hooks runners slash-commands skill.md templates scanners review-bots",
   "openclaw ecosystem    crabbox clickclack crawler packs gateway plugins",
   "---- downloads installs stars lineage ownership docs package integrity",
-  "  safe browse paths   official gateways   publisher handles   org trust",
+  "  safe browse paths   verified gateways   publisher handles   org trust",
 ];
 const FOOTER_EASTER_ASCII_FIELD = Array.from({ length: 44 }, (_, row) => {
   const a = FOOTER_EASTER_ASCII[row % FOOTER_EASTER_ASCII.length];

--- a/src/components/HomeBringSkillsSection.tsx
+++ b/src/components/HomeBringSkillsSection.tsx
@@ -12,7 +12,7 @@ const BYOS_ASCII = [
   "  hooks runners slash-commands skill.md templates scanners review-bots",
   "openclaw ecosystem    crabbox clickclack crawler packs gateway plugins",
   "---- downloads installs stars lineage ownership docs package integrity",
-  "  safe browse paths   official gateways   publisher handles   org trust",
+  "  safe browse paths   verified gateways   publisher handles   org trust",
 ];
 const BYOS_ASCII_FIELD = Array.from({ length: 56 }, (_, row) => {
   const a = BYOS_ASCII[row % BYOS_ASCII.length];

--- a/src/components/HomeListingSection.tsx
+++ b/src/components/HomeListingSection.tsx
@@ -64,7 +64,7 @@ const SKILL_LISTING_TABS: Array<{ id: ListingTab; label: string }> = [
 ];
 
 const PLUGIN_LISTING_TABS: Array<{ id: ListingTab; label: string }> = [
-  { id: "officials", label: "Official" },
+  { id: "officials", label: "Verified" },
   { id: "popular", label: "Top" },
   { id: "new", label: "New" },
 ];

--- a/src/components/OfficialBadge.tsx
+++ b/src/components/OfficialBadge.tsx
@@ -6,10 +6,10 @@ export function OfficialTag({ className }: { className?: string }) {
     <Badge
       variant="official"
       className={className ? `official-tag rounded-full ${className}` : "official-tag rounded-full"}
-      aria-label="Official"
+      aria-label="Verified"
     >
       <BadgeCheck size={15} aria-hidden="true" className="official-badge-icon" />
-      Official
+      Verified
     </Badge>
   );
 }
@@ -25,14 +25,14 @@ export function OfficialBadge({ className, iconOnly = false, size = 12 }: Offici
     const iconClassName = className
       ? `official-badge-icon-only ${className}`
       : "official-badge-icon-only";
-    return <BadgeCheck size={size} className={iconClassName} aria-label="Official" />;
+    return <BadgeCheck size={size} className={iconClassName} aria-label="Verified" />;
   }
 
   return (
     <span
       className={className ? `official-badge ${className}` : "official-badge"}
-      aria-label="Official"
-      title="Official"
+      aria-label="Verified"
+      title="Verified"
     >
       <BadgeCheck size={size} aria-hidden="true" />
     </span>

--- a/src/components/PluginListItem.test.tsx
+++ b/src/components/PluginListItem.test.tsx
@@ -14,16 +14,16 @@ describe("PluginListItem", () => {
   it("renders official list plugins with the compact official mark", () => {
     render(<PluginListItem item={makePlugin()} />);
 
-    expect(screen.getByLabelText("Official")).toBeTruthy();
-    expect(screen.queryByText("Official")).toBeNull();
+    expect(screen.getByLabelText("Verified")).toBeTruthy();
+    expect(screen.queryByText("Verified")).toBeNull();
     expect(screen.queryByText("Verified")).toBeNull();
   });
 
   it("renders official plugin cards with the compact official mark", () => {
     render(<PluginListItem item={makePlugin()} variant="card" />);
 
-    expect(screen.getByLabelText("Official")).toBeTruthy();
-    expect(screen.queryByText("Official")).toBeNull();
+    expect(screen.getByLabelText("Verified")).toBeTruthy();
+    expect(screen.queryByText("Verified")).toBeNull();
     expect(screen.queryByText("Verified")).toBeNull();
   });
 

--- a/src/components/PublishedItemCard.test.tsx
+++ b/src/components/PublishedItemCard.test.tsx
@@ -98,8 +98,8 @@ describe("PublishedItemCard", () => {
 
   it("renders the compact official mark for official published rows", () => {
     render(<PublishedItemCard item={{ ...baseSkill, icon: null, isOfficial: true }} />);
-    expect(screen.getByLabelText("Official")).toBeTruthy();
-    expect(screen.queryByText("Official")).toBeNull();
+    expect(screen.getByLabelText("Verified")).toBeTruthy();
+    expect(screen.queryByText("Verified")).toBeNull();
   });
 
   it("does not add source-backed chrome to GitHub-backed skill rows", () => {

--- a/src/components/PublisherListItem.test.tsx
+++ b/src/components/PublisherListItem.test.tsx
@@ -15,8 +15,8 @@ describe("PublisherListItem", () => {
   it("renders official publishers with the compact official mark", () => {
     const { container } = render(<PublisherListItem publisher={makePublisher()} />);
 
-    expect(screen.getByLabelText("Official")).toBeTruthy();
-    expect(screen.queryByText("Official")).toBeNull();
+    expect(screen.getByLabelText("Verified")).toBeTruthy();
+    expect(screen.queryByText("Verified")).toBeNull();
     expect(container.querySelector(".official-badge")).toBeTruthy();
   });
 

--- a/src/components/SkillCard.test.tsx
+++ b/src/components/SkillCard.test.tsx
@@ -16,14 +16,14 @@ describe("SkillCard", () => {
     const { container } = render(
       <SkillCard
         skill={makeSkill()}
-        badge="Official"
+        badge="Verified"
         summaryFallback="Fallback summary"
         meta={<span>meta</span>}
       />,
     );
 
-    expect(screen.getByLabelText("Official")).toBeTruthy();
-    expect(screen.queryByText("Official")).toBeNull();
+    expect(screen.getByLabelText("Verified")).toBeTruthy();
+    expect(screen.queryByText("Verified")).toBeNull();
     expect(container.querySelector(".official-badge")).toBeTruthy();
   });
 

--- a/src/components/SkillCard.tsx
+++ b/src/components/SkillCard.tsx
@@ -35,8 +35,8 @@ export function SkillCard({
   const owner = encodeURIComponent(String(skill.ownerUserId));
   const link = href ?? `/${owner}/${skill.slug}`;
   const badges = Array.isArray(badge) ? badge : badge ? [badge] : [];
-  const isOfficial = badges.includes("Official");
-  const visibleBadges = ownerHandle ? badges.filter((label) => label !== "Official") : badges;
+  const isOfficial = badges.includes("Verified");
+  const visibleBadges = ownerHandle ? badges.filter((label) => label !== "Verified") : badges;
   const primaryCategory = getSkillCategoryForSkill(skill);
   const hasSecondaryTags =
     visibleBadges.length || chip || platformLabels?.length || skill.topics?.length;
@@ -79,7 +79,7 @@ export function SkillCard({
             <span className="skill-card-tag-separator" aria-hidden="true" />
           ) : null}
           {visibleBadges.map((label) =>
-            label === "Official" ? (
+            label === "Verified" ? (
               <OfficialBadge key={label} />
             ) : (
               <Badge key={label}>{label}</Badge>

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -172,7 +172,7 @@ export function SkillHeader({
   const hasOwnerActions = Boolean(newVersionHref) || Boolean(settingsHref);
   const showReportAction = !canManage || isStaff;
   const badges = getSkillBadges(skill);
-  const titleBadges = badges.filter((badge) => badge !== "Official");
+  const titleBadges = badges.filter((badge) => badge !== "Verified");
   const heroCreatorPublisher = useHeroCreatorPublisher({
     owner,
     skillOfficial: isSkillOfficial(skill),

--- a/src/components/SkillListItem.test.tsx
+++ b/src/components/SkillListItem.test.tsx
@@ -27,8 +27,8 @@ describe("SkillListItem", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Official")).toBeTruthy();
-    expect(screen.queryByText("Official")).toBeNull();
+    expect(screen.getByLabelText("Verified")).toBeTruthy();
+    expect(screen.queryByText("Verified")).toBeNull();
     expect(container.querySelector(".official-badge")).toBeTruthy();
   });
 

--- a/src/components/SkillListItem.tsx
+++ b/src/components/SkillListItem.tsx
@@ -43,7 +43,7 @@ export function SkillListItem({
           <span className="skill-list-item-name">{truncateText(skill.displayName, 40)}</span>
           {handle ? <span className="skill-list-item-owner">@{handle}</span> : null}
           {badges.map((b) =>
-            b === "Official" ? (
+            b === "Verified" ? (
               <OfficialBadge key={b} />
             ) : (
               <Badge key={b} variant="compact">

--- a/src/components/UserBadge.test.tsx
+++ b/src/components/UserBadge.test.tsx
@@ -134,10 +134,10 @@ describe("UserBadge", () => {
     );
   });
 
-  it("shows a compact Official badge for official publishers", () => {
+  it("shows a compact Verified badge for official publishers", () => {
     const { container } = renderBadge(orgPublisher);
 
-    expect(screen.getByLabelText("Official")).toBeTruthy();
+    expect(screen.getByLabelText("Verified")).toBeTruthy();
     expect(container.querySelector(".official-badge")).toBeTruthy();
     expect(container.querySelector(".official-tag")).toBeFalsy();
   });

--- a/src/lib/badges.test.ts
+++ b/src/lib/badges.test.ts
@@ -67,12 +67,12 @@ describe("badges", () => {
       ).toEqual(["Deprecated"]);
     });
 
-    it("returns Official when official is set", () => {
+    it("returns Verified when official is set", () => {
       expect(
         getSkillBadges({
           badges: { official: { byUserId: "user1" as never, at: 123 } },
         }),
-      ).toEqual(["Official"]);
+      ).toEqual(["Verified"]);
     });
 
     it("does not surface Highlighted as a trust badge", () => {
@@ -92,7 +92,7 @@ describe("badges", () => {
             highlighted: { byUserId: "user1" as never, at: 123 },
           },
         }),
-      ).toEqual(["Deprecated", "Official"]);
+      ).toEqual(["Deprecated", "Verified"]);
     });
   });
 });

--- a/src/lib/badges.ts
+++ b/src/lib/badges.ts
@@ -6,7 +6,7 @@ type SkillBadgeMap = Partial<Record<BadgeKind, { byUserId: Id<"users">; at: numb
 
 type SkillLike = { badges?: SkillBadgeMap | null };
 
-type BadgeLabel = "Deprecated" | "Official";
+type BadgeLabel = "Deprecated" | "Verified";
 
 export function isSkillHighlighted(skill: SkillLike) {
   return Boolean(skill.badges?.highlighted);
@@ -23,6 +23,6 @@ export function isSkillDeprecated(skill: SkillLike) {
 export function getSkillBadges(skill: SkillLike): BadgeLabel[] {
   const badges: BadgeLabel[] = [];
   if (isSkillDeprecated(skill)) badges.push("Deprecated");
-  if (isSkillOfficial(skill)) badges.push("Official");
+  if (isSkillOfficial(skill)) badges.push("Verified");
   return badges;
 }

--- a/src/routes/-management/PluginsPage.tsx
+++ b/src/routes/-management/PluginsPage.tsx
@@ -91,7 +91,7 @@ export function PluginsPage({
                   </div>
                   <div className="management-tags">
                     <Badge>{plugin.channel}</Badge>
-                    {plugin.isOfficial ? <Badge variant="official">Official</Badge> : null}
+                    {plugin.isOfficial ? <Badge variant="official">Verified</Badge> : null}
                     {plugin.runtimeId ? <Badge>{plugin.runtimeId}</Badge> : null}
                   </div>
                   <div className="management-sublist">

--- a/src/routes/-management/SkillsPage.tsx
+++ b/src/routes/-management/SkillsPage.tsx
@@ -407,7 +407,7 @@ export function SkillsPage({
                         type="button"
                         onClick={() => onSetOfficialBadge(skill._id, !isOfficial)}
                       >
-                        {isOfficial ? "Remove official" : "Mark official"}
+                        {isOfficial ? "Remove verified" : "Mark verified"}
                       </Button>
                       <Button
                         className="management-action-btn"

--- a/src/routes/creators/index.tsx
+++ b/src/routes/creators/index.tsx
@@ -50,7 +50,7 @@ const PUBLISHER_KIND_OPTIONS = [
   { value: undefined, label: "All" },
   {
     value: "official",
-    label: "Official",
+    label: "Verified",
     icon: <BadgeCheck size={14} strokeWidth={2.25} aria-hidden="true" />,
   },
   { value: "orgs", label: "Organizations", mobileLabel: "Orgs" },

--- a/src/routes/plugins/index.tsx
+++ b/src/routes/plugins/index.tsx
@@ -55,7 +55,7 @@ const PLUGIN_BROWSE_TABS = [
   { value: "downloads", label: "All" },
   {
     value: "official",
-    label: "Official",
+    label: "Verified",
     icon: <BadgeCheck size={14} strokeWidth={2.25} aria-hidden="true" />,
   },
   { value: "updated", label: "Updated" },

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -1262,7 +1262,7 @@ export function Settings() {
                       />
                     ) : (
                       <p className="rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface-muted)]/25 p-3 text-sm text-[color:var(--ink-soft)]">
-                        You need an official publisher profile before adding GitHub skill sync.
+                        You need a verified publisher profile before adding GitHub skill sync.
                       </p>
                     )}
                   </div>


### PR DESCRIPTION
## Summary
- Rename user-facing Official labels/badges/filters to Verified across the ClawHub UI.
- Preserve the existing internal `official` data model, routes, query params, CSS variants, and API contracts.
- Update UI assertions for the new visible label.

## Proof
- Local browser: `http://127.0.0.1:3001/plugins` rendered one `Verified` radio and zero `Official` radios in the browse filter.
- Screenshot: `/tmp/clawhub-verified-ui-proof/candidate/verified-plugin-filter.png`

## Validation
- `bun install --frozen-lockfile`
- `bun run format:check -- <changed files>`
- `SITE_URL= VITE_SITE_URL= VITE_CONVEX_URL=https://example.invalid bunx vitest run src/lib/badges.test.ts src/components/SkillCard.test.tsx src/components/SkillListItem.test.tsx src/components/PluginListItem.test.tsx src/components/PublisherListItem.test.tsx src/components/UserBadge.test.tsx src/components/PublishedItemCard.test.tsx src/__tests__/creators-route.test.tsx src/__tests__/packages-route.test.tsx src/__tests__/home-listing-section.test.tsx src/__tests__/package-detail-route.test.tsx`
- `bun run ci:static`
- `SITE_URL= VITE_SITE_URL= VITE_CONVEX_URL=https://example.invalid bun run coverage`
- `VITE_CONVEX_URL=https://example.invalid bun run build`
- `VITE_CONVEX_URL=https://example.invalid bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
