### PR TITLE
fix: show official badge on skills

### DIFF
--- a/src/__tests__/search-route.test.tsx
+++ b/src/__tests__/search-route.test.tsx
@@ -36,7 +36,18 @@ vi.mock("../components/PublisherListItem", () => ({
 }));
 
 vi.mock("../components/SkillListItem", () => ({
-  SkillListItem: ({ skill }: { skill: { slug: string } }) => <div>{skill.slug}</div>,
+  SkillListItem: ({
+    skill,
+    owner,
+  }: {
+    skill: { slug: string };
+    owner?: { official?: boolean } | null;
+  }) => (
+    <div>
+      {skill.slug}
+      {owner?.official ? <span data-testid="skill-official-badge" /> : null}
+    </div>
+  ),
 }));
 
 vi.mock("../components/ui/card", () => ({
@@ -285,6 +296,44 @@ describe("search route", () => {
     expect(screen.getByText("weather")).toBeTruthy();
     expect(screen.queryByText("weather-plugin")).toBeNull();
     expect(screen.queryByText("Weather Creator @weather")).toBeNull();
+  });
+
+  it("passes official owner metadata to skill search rows", async () => {
+    searchMock = { q: "weather", type: "skills" };
+    const skill = {
+      type: "skill",
+      skill: {
+        _id: "skill-weather",
+        slug: "weather",
+        displayName: "Weather",
+        ownerUserId: "users:1",
+        stats: { downloads: 0, stars: 0 },
+        updatedAt: 1,
+        createdAt: 1,
+      },
+      ownerHandle: "openclaw",
+      owner: { official: true },
+      score: 1,
+    };
+    useUnifiedSearchMock.mockReturnValue({
+      results: [skill],
+      skillResults: [skill],
+      pluginResults: [],
+      creatorResults: [],
+      skillCount: 1,
+      pluginCount: 0,
+      creatorCount: 0,
+      skillHasMore: false,
+      pluginHasMore: false,
+      creatorHasMore: false,
+      isSearching: false,
+    });
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    expect(screen.getByTestId("skill-official-badge")).toBeTruthy();
   });
 
   it("does not render partial count labels when more results are available", async () => {

--- a/src/components/SkillCard.test.tsx
+++ b/src/components/SkillCard.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import type { Id } from "../../convex/_generated/dataModel";
-import type { PublicSkill } from "../lib/publicUser";
+import type { PublicPublisher, PublicSkill } from "../lib/publicUser";
 import { SkillCard } from "./SkillCard";
 
 vi.mock("@tanstack/react-router", () => ({
@@ -24,6 +24,20 @@ describe("SkillCard", () => {
 
     expect(screen.getByLabelText("Verified")).toBeTruthy();
     expect(screen.queryByText("Verified")).toBeNull();
+    expect(container.querySelector(".official-badge")).toBeTruthy();
+  });
+
+  it("renders the compact official mark for skills owned by official publishers", () => {
+    const { container } = render(
+      <SkillCard
+        skill={makeSkill()}
+        owner={makePublisher({ official: true })}
+        summaryFallback="Fallback summary"
+        meta={<span>meta</span>}
+      />,
+    );
+
+    expect(screen.getByLabelText("Verified")).toBeTruthy();
     expect(container.querySelector(".official-badge")).toBeTruthy();
   });
 
@@ -67,6 +81,20 @@ function makeSkill(overrides: Partial<PublicSkill> = {}): PublicSkill {
     isSuspicious: false,
     createdAt: 1,
     updatedAt: 1,
+    ...overrides,
+  };
+}
+
+function makePublisher(overrides: Partial<PublicPublisher> = {}): PublicPublisher {
+  return {
+    _id: "publishers:owner" as Id<"publishers">,
+    _creationTime: 1,
+    kind: "org",
+    handle: "owner",
+    displayName: "Owner",
+    image: undefined,
+    bio: undefined,
+    linkedUserId: undefined,
     ...overrides,
   };
 }

--- a/src/components/SkillCard.tsx
+++ b/src/components/SkillCard.tsx
@@ -2,7 +2,7 @@ import { Link } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { BrowseCategoryIcon } from "../lib/browseCategoryIcons";
 import { getSkillCategoryForSkill } from "../lib/categories";
-import type { PublicSkill } from "../lib/publicUser";
+import type { PublicPublisher, PublicSkill } from "../lib/publicUser";
 import { truncateText } from "../lib/truncateText";
 import { CatalogTopicList } from "./CatalogTopicList";
 import { MarketplaceIcon } from "./MarketplaceIcon";
@@ -19,6 +19,7 @@ type SkillCardProps = {
   href?: string;
   className?: string;
   ownerHandle?: string | null;
+  owner?: PublicPublisher | null;
 };
 
 export function SkillCard({
@@ -31,12 +32,18 @@ export function SkillCard({
   href,
   className,
   ownerHandle,
+  owner,
 }: SkillCardProps) {
-  const owner = encodeURIComponent(String(skill.ownerUserId));
-  const link = href ?? `/${owner}/${skill.slug}`;
+  const ownerSegment = encodeURIComponent(String(skill.ownerUserId));
+  const link = href ?? `/${ownerSegment}/${skill.slug}`;
   const badges = Array.isArray(badge) ? badge : badge ? [badge] : [];
-  const isOfficial = badges.includes("Verified");
-  const visibleBadges = ownerHandle ? badges.filter((label) => label !== "Verified") : badges;
+  const isOfficial = badges.includes("Verified") || owner?.official === true;
+  const nonOfficialBadges = badges.filter((label) => label !== "Verified");
+  const visibleBadges = ownerHandle
+    ? nonOfficialBadges
+    : isOfficial
+      ? ["Verified", ...nonOfficialBadges]
+      : badges;
   const primaryCategory = getSkillCategoryForSkill(skill);
   const hasSecondaryTags =
     visibleBadges.length || chip || platformLabels?.length || skill.topics?.length;

--- a/src/components/SkillListItem.test.tsx
+++ b/src/components/SkillListItem.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import type { Id } from "../../convex/_generated/dataModel";
-import type { PublicSkill } from "../lib/publicUser";
+import type { PublicPublisher, PublicSkill } from "../lib/publicUser";
 import { SkillListItem } from "./SkillListItem";
 
 vi.mock("@tanstack/react-router", () => ({
@@ -29,6 +29,15 @@ describe("SkillListItem", () => {
 
     expect(screen.getByLabelText("Verified")).toBeTruthy();
     expect(screen.queryByText("Verified")).toBeNull();
+    expect(container.querySelector(".official-badge")).toBeTruthy();
+  });
+
+  it("renders the compact official mark for skills owned by official publishers", () => {
+    const { container } = render(
+      <SkillListItem skill={makeSkill()} owner={makePublisher({ official: true })} />,
+    );
+
+    expect(screen.getByLabelText("Verified")).toBeTruthy();
     expect(container.querySelector(".official-badge")).toBeTruthy();
   });
 
@@ -74,6 +83,20 @@ function makeSkill(overrides: Partial<PublicSkill> = {}): PublicSkill {
     isSuspicious: false,
     createdAt: 1,
     updatedAt: 1,
+    ...overrides,
+  };
+}
+
+function makePublisher(overrides: Partial<PublicPublisher> = {}): PublicPublisher {
+  return {
+    _id: "publishers:owner" as Id<"publishers">,
+    _creationTime: 1,
+    kind: "org",
+    handle: "owner",
+    displayName: "Owner",
+    image: undefined,
+    bio: undefined,
+    linkedUserId: undefined,
     ...overrides,
   };
 }

--- a/src/components/SkillListItem.tsx
+++ b/src/components/SkillListItem.tsx
@@ -29,6 +29,7 @@ export function SkillListItem({
   const href =
     hrefOverride ?? `/${encodeURIComponent(ownerSegment)}/${encodeURIComponent(skill.slug)}`;
   const badges = getSkillBadges(skill);
+  const isOfficial = badges.includes("Verified") || owner?.official === true;
   const categories = getSkillCategoriesForSkill(skill);
   const categoryLabel = categories
     .slice(0, 3)
@@ -42,15 +43,14 @@ export function SkillListItem({
         <div className="skill-list-item-main">
           <span className="skill-list-item-name">{truncateText(skill.displayName, 40)}</span>
           {handle ? <span className="skill-list-item-owner">@{handle}</span> : null}
-          {badges.map((b) =>
-            b === "Verified" ? (
-              <OfficialBadge key={b} />
-            ) : (
-              <Badge key={b} variant="compact">
-                {b}
+          {isOfficial ? <OfficialBadge /> : null}
+          {badges
+            .filter((badge) => badge !== "Verified")
+            .map((badge) => (
+              <Badge key={badge} variant="compact">
+                {badge}
               </Badge>
-            ),
-          )}
+            ))}
           <CatalogTopicList topics={skill.topics} limit={2} />
         </div>
         {skill.summary ? (

--- a/src/routes/search.tsx
+++ b/src/routes/search.tsx
@@ -303,7 +303,7 @@ function SearchResultSection({ children, title }: { children: React.ReactNode; t
 
 function SkillResultRow({ result }: { result: UnifiedSkillResult }) {
   const skill = result.skill as unknown as PublicSkill;
-  return <SkillListItem skill={skill} ownerHandle={result.ownerHandle} />;
+  return <SkillListItem skill={skill} ownerHandle={result.ownerHandle} owner={result.owner} />;
 }
 
 function PluginResultRow({ result }: { result: UnifiedPluginResult }) {

--- a/src/routes/skills/-SkillsResults.tsx
+++ b/src/routes/skills/-SkillsResults.tsx
@@ -75,6 +75,7 @@ export function SkillsResults({
                     <span className="skill-card-updated">Updated {timeAgo(skill.updatedAt)}</span>
                   </div>
                 }
+                owner={entry.owner}
               />
             );
           })}


### PR DESCRIPTION
## Summary
- show the compact official tick on skill list rows when the skill or its owner publisher is official
- pass official owner metadata through global search and skill browse cards
- add route and component coverage for official publisher-owned skills

## Root cause
Plugin listings expose a combined `isOfficial` flag, but skill rows only rendered the skill-level badge and the global search row discarded the resolved owner metadata.

## Checks
- `bunx vitest run src/components/SkillListItem.test.tsx src/components/SkillCard.test.tsx src/__tests__/search-route.test.tsx`
- `bunx tsc --noEmit --pretty false`
- `bunx oxlint --type-aware --tsconfig ./tsconfig.oxlint.json src/components/SkillListItem.tsx src/components/SkillListItem.test.tsx src/components/SkillCard.tsx src/components/SkillCard.test.tsx src/routes/search.tsx src/routes/skills/-SkillsResults.tsx src/__tests__/search-route.test.tsx`
- `bun run format:check -- src/components/SkillListItem.tsx src/components/SkillListItem.test.tsx src/components/SkillCard.tsx src/components/SkillCard.test.tsx src/routes/search.tsx src/routes/skills/-SkillsResults.tsx src/__tests__/search-route.test.tsx`