### PR TITLE
Reserve OpenClaw publisher handles

### DIFF
--- a/convex/lib/publishers.ts
+++ b/convex/lib/publishers.ts
@@ -48,8 +48,11 @@ export function derivePersonalPublisherHandle(user: Doc<"users">) {
   );
 }
 
-function synthesizePersonalPublisher(user: Doc<"users">): Doc<"publishers"> {
-  const handle = derivePersonalPublisherHandle(user);
+function synthesizePersonalPublisher(
+  user: Doc<"users">,
+  handleOverride?: string,
+): Doc<"publishers"> {
+  const handle = handleOverride ?? derivePersonalPublisherHandle(user);
   const now = user.updatedAt ?? user.createdAt ?? user._creationTime;
   const displayName = user.displayName?.trim() || user.name?.trim() || handle;
   const bio = user.bio?.trim() || undefined;
@@ -88,6 +91,20 @@ export async function getPersonalPublisherForUserOrFallback(ctx: DbCtx, user: Do
 export function normalizePublisherHandle(handle: string | undefined | null) {
   const normalized = handle?.trim().replace(/^@+/, "").toLowerCase();
   return normalized ? normalized : undefined;
+}
+
+export function isReservedOpenClawPublisherHandle(handle: string | undefined | null) {
+  return Boolean(normalizePublisherHandle(handle)?.includes("openclaw"));
+}
+
+export function assertPublisherHandleAllowed(handle: string) {
+  if (isReservedOpenClawPublisherHandle(handle)) {
+    throw new ConvexError(formatReservedOpenClawPublisherHandleMessage(handle));
+  }
+}
+
+export function formatReservedOpenClawPublisherHandleMessage(handle: string) {
+  return `Handle "@${handle}" is reserved for OpenClaw publishers`;
 }
 
 export function isPublisherActive(
@@ -230,6 +247,14 @@ export async function ensurePersonalPublisherForUser(
   } catch (error) {
     if (!isMissingPublisherTableError(error)) throw error;
     return synthesizePersonalPublisher(user);
+  }
+  if (isReservedOpenClawPublisherHandle(handle)) {
+    if (options?.handleConflict === "skip") {
+      return existing && isPublisherActive(existing)
+        ? existing
+        : synthesizePersonalPublisher(user, "user");
+    }
+    throw new ConvexError(formatReservedOpenClawPublisherHandleMessage(handle));
   }
   if (existing && isPublisherActive(existing)) {
     const existingPublisher = existing;

--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -1,6 +1,10 @@
 import { getAuthUserId } from "@convex-dev/auth/server";
 import { describe, expect, it, vi } from "vitest";
-import { assertCanManageOwnedResource, requirePublisherRole } from "./lib/publishers";
+import {
+  assertCanManageOwnedResource,
+  ensurePersonalPublisherForUser,
+  requirePublisherRole,
+} from "./lib/publishers";
 import {
   addMember,
   listPublicPage,
@@ -4875,6 +4879,65 @@ describe("publisher bootstrap", () => {
     ]);
   });
 
+  it("rejects personal publisher handles containing openclaw", async () => {
+    const inserts: Array<{ table: string; value: Record<string, unknown> }> = [];
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "users:openclaw-china") {
+            return {
+              _id: id,
+              _creationTime: 1,
+              handle: "openclaw-china",
+              displayName: "Openclaw China",
+              trustedPublisher: false,
+              createdAt: 1,
+              updatedAt: 1,
+            };
+          }
+          return null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table === "publishers") {
+            return {
+              withIndex: vi.fn((indexName: string) => {
+                if (indexName === "by_linked_user") {
+                  return { unique: vi.fn().mockResolvedValue(null) };
+                }
+                if (indexName === "by_handle") {
+                  return { unique: vi.fn().mockResolvedValue(null) };
+                }
+                throw new Error(`unexpected index ${indexName}`);
+              }),
+            };
+          }
+          throw new Error(`unexpected table ${table}`);
+        }),
+        insert: vi.fn(async (table: string, value: Record<string, unknown>) => {
+          inserts.push({ table, value });
+          return `${table}:${inserts.length}`;
+        }),
+        patch: vi.fn(),
+      },
+    };
+
+    await expect(
+      ensurePersonalPublisherForUser(
+        ctx as never,
+        {
+          _id: "users:openclaw-china",
+          _creationTime: 1,
+          handle: "openclaw-china",
+          displayName: "Openclaw China",
+          trustedPublisher: false,
+          createdAt: 1,
+          updatedAt: 1,
+        } as never,
+      ),
+    ).rejects.toThrow('Handle "@openclaw-china" is reserved for OpenClaw publishers');
+    expect(inserts).toHaveLength(0);
+  });
+
   it("filters stale personal memberships from mine listings", async () => {
     vi.mocked(getAuthUserId).mockResolvedValue("users:friend" as never);
     const memberships = [
@@ -5278,6 +5341,19 @@ describe("self-serve org publisher creation", () => {
         handle: "opik",
       }),
     ).rejects.toThrow('Publisher "@opik" already exists');
+  });
+
+  it("rejects self-serve org handles containing openclaw", async () => {
+    const { ctx, inserts } = makeCreateOrgPublisherCtx({});
+
+    await expect(
+      createOrgPublisherForUserInternalHandler(ctx as never, {
+        actorUserId: "users:vincent",
+        handle: "openclaw-china",
+        displayName: "Openclaw China",
+      }),
+    ).rejects.toThrow('Handle "@openclaw-china" is reserved for OpenClaw publishers');
+    expect(inserts).toHaveLength(0);
   });
 
   it("rejects creation when the handle belongs to a user or personal publisher", async () => {
@@ -6267,7 +6343,7 @@ describe("legacy publisher migration", () => {
     expect(inserts).toHaveLength(0);
   });
 
-  it("lets admins create a missing org publisher with only the legacy package owner as owner", async () => {
+  it("lets admins create a missing reserved OpenClaw org publisher with only the legacy package owner as owner", async () => {
     vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
 
     const users = new Map<string, Record<string, unknown>>([
@@ -6397,8 +6473,8 @@ describe("legacy publisher migration", () => {
       } as never,
       {
         actorUserId: "users:admin",
-        handle: "opik",
-        displayName: "Opik",
+        handle: "openclaw",
+        displayName: "OpenClaw",
         memberHandle: "vincentkoc",
         memberRole: "owner",
       },
@@ -6406,7 +6482,7 @@ describe("legacy publisher migration", () => {
 
     expect(result).toMatchObject({
       ok: true,
-      handle: "opik",
+      handle: "openclaw",
       created: true,
       member: {
         userId: "users:vincent",
@@ -6417,7 +6493,11 @@ describe("legacy publisher migration", () => {
     expect(inserts).toContainEqual(
       expect.objectContaining({
         table: "publishers",
-        value: expect.objectContaining({ kind: "org", handle: "opik", displayName: "Opik" }),
+        value: expect.objectContaining({
+          kind: "org",
+          handle: "openclaw",
+          displayName: "OpenClaw",
+        }),
       }),
     );
     const memberInserts = inserts.filter(
@@ -6644,7 +6724,7 @@ describe("legacy publisher migration", () => {
     ).rejects.toThrow("Publisher must have at least one owner");
   });
 
-  it("converts a legacy personal publisher into an org and rehomes package ownership", async () => {
+  it("converts a reserved OpenClaw legacy personal publisher into an org with a safe default fallback", async () => {
     vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
 
     const users = new Map<string, Record<string, unknown>>([
@@ -6672,20 +6752,6 @@ describe("legacy publisher migration", () => {
           kind: "user",
           handle: "openclaw",
           displayName: "OpenClaw",
-          linkedUserId: "users:openclaw",
-          trustedPublisher: true,
-          createdAt: 1,
-          updatedAt: 1,
-        },
-      ],
-      [
-        "publishers:openclaw-user",
-        {
-          _id: "publishers:openclaw-user",
-          _creationTime: 1,
-          kind: "user",
-          handle: "openclaw-user",
-          displayName: "OpenClaw User",
           linkedUserId: "users:openclaw",
           trustedPublisher: true,
           createdAt: 1,
@@ -6736,7 +6802,7 @@ describe("legacy publisher migration", () => {
 
     const insert = vi.fn(async (table: string, value: Record<string, unknown>) => {
       if (table === "publishers") {
-        const id = "publishers:openclaw-user";
+        const id = "publishers:user";
         publishers.set(id, { _id: id, _creationTime: 1, ...value });
         return id;
       }
@@ -6894,7 +6960,10 @@ describe("legacy publisher migration", () => {
     const result = await migrateLegacyPublisherHandleToOrgInternalHandler(
       {
         db: {
-          get: vi.fn(async (id: string) => users.get(id) ?? publishers.get(id) ?? null),
+          get: vi.fn(async (...args: string[]) => {
+            const id = args.length === 2 ? args[1] : args[0];
+            return users.get(id) ?? publishers.get(id) ?? null;
+          }),
           query,
           patch,
           insert,
@@ -6906,7 +6975,6 @@ describe("legacy publisher migration", () => {
       {
         actorUserId: "users:admin",
         handle: "openclaw",
-        fallbackUserHandle: "openclaw-user",
         displayName: "OpenClaw",
       } as never,
     );
@@ -6916,15 +6984,15 @@ describe("legacy publisher migration", () => {
       handle: "openclaw",
       orgPublisherId: "publishers:openclaw",
       legacyUserId: "users:openclaw",
-      fallbackUserHandle: "openclaw-user",
-      personalPublisherId: "publishers:openclaw-user",
+      fallbackUserHandle: "user",
+      personalPublisherId: "publishers:user",
       convertedExistingPublisher: true,
       packagesMigrated: 1,
     });
     expect(users.get("users:openclaw")).toEqual(
       expect.objectContaining({
-        handle: "openclaw-user",
-        personalPublisherId: "publishers:openclaw-user",
+        handle: "user",
+        personalPublisherId: "publishers:user",
       }),
     );
     expect(publishers.get("publishers:openclaw")).toEqual(
@@ -6934,10 +7002,10 @@ describe("legacy publisher migration", () => {
         linkedUserId: undefined,
       }),
     );
-    expect(publishers.get("publishers:openclaw-user")).toEqual(
+    expect(publishers.get("publishers:user")).toEqual(
       expect.objectContaining({
         kind: "user",
-        handle: "openclaw-user",
+        handle: "user",
         linkedUserId: "users:openclaw",
       }),
     );

--- a/convex/publishers.ts
+++ b/convex/publishers.ts
@@ -23,6 +23,7 @@ import {
 } from "./lib/publisherCatalogDisplay";
 import {
   canAccessPublisherOwnerScope,
+  assertPublisherHandleAllowed,
   ensurePersonalPublisherForUser,
   getActiveUserByHandleOrPersonalPublisher,
   getOwnerPublisher,
@@ -32,6 +33,7 @@ import {
   getPersonalPublisherForUser,
   isPublisherActive,
   isPublisherRoleAllowed,
+  isReservedOpenClawPublisherHandle,
   PUBLISHER_HANDLE_PATTERN,
   PUBLISHER_HANDLE_REQUIREMENTS_MESSAGE,
   normalizePublisherHandle,
@@ -142,11 +144,17 @@ type PublisherListCounts = {
   organizations: number;
 };
 
-function validateHandle(rawHandle: string) {
+function validateHandle(
+  rawHandle: string,
+  options?: { allowReservedOpenClawPublisherHandle?: boolean },
+) {
   const handle = normalizePublisherHandle(rawHandle);
   if (!handle) throw new ConvexError("Handle is required");
   if (!PUBLISHER_HANDLE_PATTERN.test(handle)) {
     throw new ConvexError(PUBLISHER_HANDLE_REQUIREMENTS_MESSAGE);
+  }
+  if (!options?.allowReservedOpenClawPublisherHandle) {
+    assertPublisherHandleAllowed(handle);
   }
   if (isReservedPublicOwnerHandle(handle)) {
     throw new ConvexError(formatReservedPublicOwnerHandleMessage(handle));
@@ -848,6 +856,13 @@ async function resolveAvailableUserHandle(
   throw new ConvexError(`Unable to find an available fallback handle for "@${baseHandle}"`);
 }
 
+function deriveLegacyOrgFallbackHandle(orgHandle: string, explicitFallbackHandle?: string) {
+  return (
+    explicitFallbackHandle ??
+    (isReservedOpenClawPublisherHandle(orgHandle) ? "user" : `${orgHandle}-user`)
+  );
+}
+
 async function migrateLegacyPublisherHandleToOrgWithActor(
   ctx: Pick<MutationCtx, "db">,
   args: {
@@ -861,8 +876,10 @@ async function migrateLegacyPublisherHandleToOrgWithActor(
   if (!actor || actor.deletedAt || actor.deactivatedAt) throw new ConvexError("Unauthorized");
   assertAdmin(actor);
 
-  const orgHandle = validateHandle(args.handle);
-  const fallbackBase = validateHandle(args.fallbackUserHandle ?? `${orgHandle}-user`);
+  const orgHandle = validateHandle(args.handle, { allowReservedOpenClawPublisherHandle: true });
+  const fallbackBase = validateHandle(
+    deriveLegacyOrgFallbackHandle(orgHandle, args.fallbackUserHandle),
+  );
   const now = Date.now();
 
   const handlePublisher = await getPublisherByHandle(ctx, orgHandle);
@@ -1020,7 +1037,7 @@ async function ensureOrgPublisherHandleWithActor(
   if (!actor || actor.deletedAt || actor.deactivatedAt) throw new ConvexError("Unauthorized");
   assertAdmin(actor);
 
-  const handle = validateHandle(args.handle);
+  const handle = validateHandle(args.handle, { allowReservedOpenClawPublisherHandle: true });
   const now = Date.now();
   const existingPublisher = await getPublisherByHandle(ctx, handle);
   const existingUser = await getUserByHandle(ctx, handle);

--- a/convex/users.test.ts
+++ b/convex/users.test.ts
@@ -711,6 +711,39 @@ describe("ensureHandler", () => {
     },
   );
 
+  it("falls back when a derived handle and email local part contain openclaw", async () => {
+    const { ctx, insert, patch } = makeCtx();
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:openclaw-china",
+      user: {
+        _id: "users:openclaw-china",
+        _creationTime: 1,
+        handle: undefined,
+        displayName: undefined,
+        name: "openclaw-china",
+        email: "openclaw-china@example.com",
+        role: "user",
+        createdAt: 1,
+      },
+    } as never);
+
+    await ensureHandler(ctx);
+
+    expect(patch).toHaveBeenCalledWith("users:openclaw-china", {
+      handle: "user",
+      displayName: "user",
+      updatedAt: expect.any(Number),
+    });
+    expect(insert).toHaveBeenCalledWith(
+      "publishers",
+      expect.objectContaining({
+        kind: "user",
+        handle: "user",
+        linkedUserId: "users:openclaw-china",
+      }),
+    );
+  });
+
   it("repairs an existing handle that is no longer claimable", async () => {
     const { ctx, patch, query } = makeCtx();
     query.mockImplementation(((table: string) => {
@@ -743,12 +776,12 @@ describe("ensureHandler", () => {
             if (name === "by_handle") {
               return {
                 unique: vi.fn(async () => {
-                  if (handle === "openclaw") {
+                  if (handle === "acme-tools") {
                     return {
-                      _id: "publishers:openclaw",
+                      _id: "publishers:acme-tools",
                       kind: "org",
-                      handle: "openclaw",
-                      displayName: "OpenClaw",
+                      handle: "acme-tools",
+                      displayName: "Acme Tools",
                     };
                   }
                   return null;
@@ -760,11 +793,11 @@ describe("ensureHandler", () => {
                 unique: vi.fn(async () =>
                   linkedUserId === "users:owner"
                     ? {
-                        _id: "publishers:openclaw-user",
+                        _id: "publishers:acme-tools-user",
                         kind: "user",
-                        handle: "openclaw-user",
+                        handle: "acme-tools-user",
                         linkedUserId: "users:owner",
-                        displayName: "OpenClaw User",
+                        displayName: "Acme Tools User",
                       }
                     : null,
                 ),
@@ -801,21 +834,21 @@ describe("ensureHandler", () => {
       user: {
         _id: "users:owner",
         _creationTime: 1,
-        handle: "openclaw",
-        displayName: "openclaw",
-        name: "openclaw",
+        handle: "acme-tools",
+        displayName: "acme-tools",
+        name: "acme-tools",
         email: "owner@example.com",
         role: "user",
         createdAt: 1,
-        personalPublisherId: "publishers:openclaw-user",
+        personalPublisherId: "publishers:acme-tools-user",
       },
     } as never);
 
     await ensureHandler(ctx);
 
     expect(patch).toHaveBeenCalledWith("users:owner", {
-      handle: "openclaw-2",
-      displayName: "openclaw-2",
+      handle: "acme-tools-2",
+      displayName: "acme-tools-2",
       updatedAt: expect.any(Number),
     });
   });
@@ -834,7 +867,7 @@ describe("ensureHandler", () => {
               take: async () => [
                 {
                   _id: "reservedHandles:1",
-                  handle: "openclaw",
+                  handle: "acme-tools",
                   rightfulOwnerUserId: "users:owner",
                   releasedAt: undefined,
                   createdAt: 1,
@@ -853,7 +886,7 @@ describe("ensureHandler", () => {
         _creationTime: 1,
         handle: undefined,
         displayName: undefined,
-        name: "openclaw",
+        name: "acme-tools",
         email: undefined,
         role: "user",
         createdAt: 1,
@@ -897,12 +930,12 @@ describe("ensureHandler", () => {
             if (name === "by_handle") {
               return {
                 unique: vi.fn(async () =>
-                  handle === "openclaw"
+                  handle === "acme-tools"
                     ? {
-                        _id: "publishers:openclaw",
+                        _id: "publishers:acme-tools",
                         kind: "org",
-                        handle: "openclaw",
-                        displayName: "OpenClaw",
+                        handle: "acme-tools",
+                        displayName: "Acme Tools",
                       }
                     : null,
                 ),
@@ -913,11 +946,11 @@ describe("ensureHandler", () => {
                 unique: vi.fn(async () =>
                   linkedUserId === "users:other"
                     ? {
-                        _id: "publishers:openclaw-user",
+                        _id: "publishers:acme-tools-user",
                         kind: "user",
-                        handle: "openclaw-user",
+                        handle: "acme-tools-user",
                         linkedUserId: "users:other",
-                        displayName: "OpenClaw User",
+                        displayName: "Acme Tools User",
                       }
                     : null,
                 ),
@@ -956,7 +989,7 @@ describe("ensureHandler", () => {
         _creationTime: 1,
         handle: undefined,
         displayName: undefined,
-        name: "openclaw",
+        name: "acme-tools",
         email: undefined,
         role: "user",
         createdAt: 1,
@@ -967,7 +1000,7 @@ describe("ensureHandler", () => {
 
     expect(patch).not.toHaveBeenCalledWith(
       "users:other",
-      expect.objectContaining({ handle: "openclaw" }),
+      expect.objectContaining({ handle: "acme-tools" }),
     );
   });
 

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -25,6 +25,7 @@ import {
   getPersonalPublisherForUser,
   getPersonalPublisherForUserOrFallback,
   getUserByHandleOrPersonalPublisher,
+  isReservedOpenClawPublisherHandle,
 } from "./lib/publishers";
 import {
   getPackagePublisherContribution,
@@ -736,6 +737,10 @@ function appendHandleSuffix(base: string, suffix: number) {
   return `${base.slice(0, maxBaseLength)}${suffixText}`;
 }
 
+function getSafePersonalHandleFallbackBase(handle: string | undefined) {
+  return isReservedOpenClawPublisherHandle(handle) ? "user" : handle;
+}
+
 async function resolveAvailableHandle(
   ctx: MutationCtx,
   preferredHandle: string | undefined,
@@ -758,6 +763,7 @@ async function canUserClaimHandle(
   const normalizedHandle = normalizeReservedHandle(handle);
   if (!normalizedHandle) return false;
   if (isReservedPublicOwnerHandle(normalizedHandle)) return false;
+  if (isReservedOpenClawPublisherHandle(normalizedHandle)) return false;
   if (await isHandleReservedForAnotherUser(ctx, normalizedHandle, userId)) return false;
 
   const publisher = await getPublisherByHandle(ctx, normalizedHandle);
@@ -788,16 +794,17 @@ async function computeEnsureUpdates(ctx: MutationCtx, user: Doc<"users">) {
       : undefined;
   if (!derivedHandle && (!existingHandle || !existingHandleClaimable)) {
     const emailFallback = normalizeHandle(user.email?.split("@")[0]);
+    const safeEmailFallback = getSafePersonalHandleFallbackBase(emailFallback);
     const emailFallbackHandle =
       emailFallback && emailFallback !== requestedHandle
-        ? await resolveAvailableHandle(ctx, emailFallback, user._id)
+        ? await resolveAvailableHandle(ctx, safeEmailFallback, user._id)
         : undefined;
+    const preferredFallbackBase = requestedHandle ?? existingHandle ?? githubLogin ?? emailFallback;
+    const fallbackBase = isReservedOpenClawPublisherHandle(preferredFallbackBase)
+      ? (safeEmailFallback ?? "user")
+      : preferredFallbackBase;
     derivedHandle =
-      (await resolveAvailableHandle(
-        ctx,
-        requestedHandle ?? existingHandle ?? githubLogin ?? emailFallback,
-        user._id,
-      )) ?? emailFallbackHandle;
+      (await resolveAvailableHandle(ctx, fallbackBase, user._id)) ?? emailFallbackHandle;
   }
   const baseHandle = derivedHandle ?? (existingHandleClaimable ? existingHandle : undefined);
 


### PR DESCRIPTION
## Summary
- Block self-serve org and personal publisher handles containing `openclaw`
- Keep admin-owned OpenClaw org ensure/migration paths working for platform publishers
- Use safe non-reserved fallback personal handles during user ensure and legacy publisher migration

## Validation
- `bunx vitest run convex/publishers.test.ts convex/users.test.ts --testNamePattern "openclaw|OpenClaw|derived handle contains openclaw|derived handle and email local part contain openclaw|repairs an existing handle|reserved handle for another user|already owned by an org publisher|legacy personal publisher"`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`

## Notes
- `bunx convex dev --once --typecheck=disable` is blocked in this worktree by missing Convex local deployment config: `Failed to load deployment config - try running npx convex dev --configure`.
