### PR TITLE
fix: use authenticated GitHub API for imports

### DIFF
--- a/convex/githubImport.test.ts
+++ b/convex/githubImport.test.ts
@@ -1,4 +1,5 @@
 /* @vitest-environment node */
+import { generateKeyPairSync } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { internal } from "./_generated/api";
 import { __test } from "./githubImport";
@@ -16,10 +17,18 @@ vi.mock("./_generated/api", () => ({
 }));
 
 const originalGitHubToken = process.env.GITHUB_TOKEN;
+const originalGitHubAppEnv = {
+  appId: process.env.GITHUB_APP_ID,
+  installationId: process.env.GITHUB_APP_INSTALLATION_ID,
+  privateKey: process.env.GITHUB_APP_PRIVATE_KEY,
+};
 
 describe("githubImport", () => {
   beforeEach(() => {
     delete process.env.GITHUB_TOKEN;
+    delete process.env.GITHUB_APP_ID;
+    delete process.env.GITHUB_APP_INSTALLATION_ID;
+    delete process.env.GITHUB_APP_PRIVATE_KEY;
   });
 
   afterEach(() => {
@@ -27,6 +36,14 @@ describe("githubImport", () => {
       process.env.GITHUB_TOKEN = originalGitHubToken;
     } else {
       delete process.env.GITHUB_TOKEN;
+    }
+    for (const [key, value] of [
+      ["GITHUB_APP_ID", originalGitHubAppEnv.appId],
+      ["GITHUB_APP_INSTALLATION_ID", originalGitHubAppEnv.installationId],
+      ["GITHUB_APP_PRIVATE_KEY", originalGitHubAppEnv.privateKey],
+    ] as const) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
     }
   });
 
@@ -518,6 +535,68 @@ describe("githubImport", () => {
         headers: expect.objectContaining({ Authorization: "Bearer github-token" }),
       }),
     );
+  });
+
+  it("falls back from an out-of-scope GitHub App token for public repo lookup", async () => {
+    const { privateKey } = generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      privateKeyEncoding: { type: "pkcs1", format: "pem" },
+      publicKeyEncoding: { type: "spki", format: "pem" },
+    });
+    process.env.GITHUB_APP_ID = "3536245";
+    process.env.GITHUB_APP_INSTALLATION_ID = "987654";
+    process.env.GITHUB_APP_PRIVATE_KEY = privateKey;
+
+    const ctx = {
+      runQuery: vi.fn().mockResolvedValue("123"),
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({
+          token: "ghs_app_token",
+          expires_at: "2027-02-02T13:00:00Z",
+        }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          id: 123,
+          login: "vyctorbrzezowski",
+          avatar_url: "https://avatars.githubusercontent.com/u/123?v=4",
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(
+        Response.json({
+          name: "public-skill",
+          full_name: "vyctorbrzezowski/public-skill",
+          private: false,
+          visibility: "public",
+          owner: { id: 123, login: "vyctorbrzezowski" },
+        }),
+      );
+
+    await expect(
+      __test.requireOwnedPublicGitHubRepoForImport(
+        ctx as never,
+        "users:1" as never,
+        "vyctorbrzezowski",
+        "public-skill",
+        fetchMock as never,
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        full_name: "vyctorbrzezowski/public-skill",
+      }),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock.mock.calls[2]?.[1]).toEqual(
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer ghs_app_token" }),
+      }),
+    );
+    expect(fetchMock.mock.calls[3]?.[1]?.headers).not.toHaveProperty("Authorization");
   });
 
   it("falls back to the repo archive when GitHub truncates the discovery tree", async () => {

--- a/convex/githubImport.ts
+++ b/convex/githubImport.ts
@@ -6,6 +6,7 @@ import type { Id } from "./_generated/dataModel";
 import type { ActionCtx } from "./_generated/server";
 import { action } from "./functions";
 import { requireUserFromAction } from "./lib/access";
+import { buildGitHubApiHeaders, isGitHubAppConfigured } from "./lib/githubAuth";
 import {
   buildGitHubImportFileList,
   computeDefaultSelectedPaths,
@@ -431,7 +432,7 @@ async function listOwnedPublicGitHubReposForUser(
   url.searchParams.set("per_page", String(fallbackPerPage));
   url.searchParams.set("page", String(page));
 
-  const response = await fetcher(url.toString(), { headers: buildGitHubHeaders() });
+  const response = await fetchGitHubApi(url.toString(), fetcher, undefined, false);
   if (!response.ok) throwGitHubApiError(response.status);
 
   const payload = (await response.json()) as unknown;
@@ -505,9 +506,7 @@ async function requireCurrentGitHubIdentity(
   if (!providerAccountId) throw new ConvexError("GitHub account required");
   assertGitHubNumericId(providerAccountId);
 
-  const response = await fetcher(`${GITHUB_API}/user/${providerAccountId}`, {
-    headers: buildGitHubHeaders(),
-  });
+  const response = await fetchGitHubApi(`${GITHUB_API}/user/${providerAccountId}`, fetcher);
   if (!response.ok) throwGitHubApiError(response.status);
 
   const payload = (await response.json()) as GitHubUserPayload;
@@ -523,7 +522,7 @@ async function requireCurrentGitHubIdentity(
 
 async function fetchGitHubRepoMetadata(owner: string, repo: string, fetcher: typeof fetch) {
   const url = `${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
-  const response = await fetcher(url, { headers: buildGitHubHeaders() });
+  const response = await fetchGitHubApi(url, fetcher);
   if (!response.ok) {
     if (response.status === 404) throw new ConvexError(OWNED_PUBLIC_REPO_ONLY_ERROR);
     throwGitHubApiError(response.status);
@@ -631,7 +630,7 @@ async function listOwnedPublicSkillCandidatesWithCodeSearch(
       url.searchParams.set("per_page", String(args.perPage));
       url.searchParams.set("page", String(args.page));
 
-      const response = await fetcher(url.toString(), { headers: buildGitHubHeaders() });
+      const response = await fetchGitHubApi(url.toString(), fetcher, undefined, false);
       if (!response.ok) throwGitHubApiError(response.status);
 
       const payload = (await response.json()) as GitHubCodeSearchPayload;
@@ -747,7 +746,7 @@ async function fetchGitHubBlobBytes(
   fetcher: typeof fetch,
 ) {
   const url = `${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/git/blobs/${encodeURIComponent(sha)}`;
-  const response = await fetcher(url, { headers: buildGitHubRawHeaders() });
+  const response = await fetchGitHubApi(url, fetcher, "application/vnd.github.raw");
   if (!response.ok) throwGitHubApiError(response.status);
   return new Uint8Array(await response.arrayBuffer());
 }
@@ -778,7 +777,7 @@ async function fetchGitHubRepoTreeResult(
   );
   url.searchParams.set("recursive", "1");
 
-  const response = await fetcher(url.toString(), { headers: buildGitHubHeaders() });
+  const response = await fetchGitHubApi(url.toString(), fetcher);
   if (response.status === 404 || response.status === 409) return null;
   if (!response.ok) throwGitHubApiError(response.status);
 
@@ -833,24 +832,41 @@ function toOwnedPublicSkillCandidate(repo: OwnedPublicRepoListItem, skillPath: s
   };
 }
 
-function buildGitHubHeaders() {
-  const headers: Record<string, string> = {
-    Accept: "application/vnd.github+json",
-    "User-Agent": "clawhub/github-import",
-  };
-  const token = process.env.GITHUB_TOKEN;
-  if (token) headers.Authorization = `Bearer ${token}`;
-  return headers;
+async function fetchGitHubApi(
+  url: string,
+  fetcher: typeof fetch,
+  accept = "application/vnd.github+json",
+  useGitHubApp = true,
+) {
+  const headers = await buildGitHubApiHeaders({
+    userAgent: "clawhub/github-import",
+    accept,
+    fetchImpl: fetcher,
+    useGitHubApp,
+  });
+  const response = await fetcher(url, { headers });
+  if (
+    useGitHubApp &&
+    !response.ok &&
+    isGitHubAppConfigured() &&
+    headers.Authorization &&
+    (response.status === 401 || response.status === 403 || response.status === 404)
+  ) {
+    const fallbackHeaders = await buildGitHubApiHeaders({
+      userAgent: "clawhub/github-import",
+      accept,
+      fetchImpl: fetcher,
+      useGitHubApp: false,
+    });
+    if (fallbackHeaders.Authorization !== headers.Authorization) {
+      return await fetcher(url, { headers: fallbackHeaders });
+    }
+  }
+  return response;
 }
 
 function hasGitHubApiToken() {
   return Boolean(process.env.GITHUB_TOKEN?.trim());
-}
-
-function buildGitHubRawHeaders() {
-  const headers = buildGitHubHeaders();
-  headers.Accept = "application/vnd.github.raw";
-  return headers;
 }
 
 function assertGitHubNumericId(providerAccountId: string) {


### PR DESCRIPTION
## Summary
- use the shared cached GitHub App installation auth for selected-repo import reads
- fall back to PAT/anonymous auth when App-scoped public lookups are rejected
- keep public repo listing and code search on their existing PAT/anonymous semantics
- add regression coverage for an out-of-scope App token

## Root cause
The GitHub import path used an anonymous API client even though ClawHub already had shared GitHub App auth for sync. Production exhausted GitHub's anonymous quota during publish, surfacing `GitHub API rate limit exceeded`.

## Validation
- `bun run ci:static`
- `bunx vitest run convex/githubImport.test.ts convex/lib/githubAuth.test.ts src/__tests__/import.route.test.tsx convex/githubSkillSync.test.ts`
- autoreview clean