### PR TITLE
fix: use app auth for OpenClaw docs dispatch

### DIFF
--- a/.github/workflows/openclaw-docs-sync-dispatch.yml
+++ b/.github/workflows/openclaw-docs-sync-dispatch.yml
@@ -16,21 +16,48 @@ jobs:
   dispatch-openclaw-docs-sync:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        continue-on-error: true
+        with:
+          app-id: "2729701"
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: openclaw
+          repositories: openclaw
+
+      - uses: actions/create-github-app-token@v3
+        id: app-token-fallback
+        continue-on-error: true
+        if: steps.app-token.outcome == 'failure'
+        with:
+          app-id: "2971289"
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          owner: openclaw
+          repositories: openclaw
+
       - name: Dispatch OpenClaw docs sync
         env:
-          OPENCLAW_DOCS_SYNC_TOKEN: ${{ secrets.OPENCLAW_DOCS_SYNC_TOKEN }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          FALLBACK_APP_TOKEN: ${{ steps.app-token-fallback.outputs.token }}
+          LEGACY_TOKEN: ${{ secrets.OPENCLAW_DOCS_SYNC_TOKEN }}
         run: |
           set -euo pipefail
 
+          OPENCLAW_DOCS_SYNC_TOKEN="${APP_TOKEN:-${FALLBACK_APP_TOKEN:-${LEGACY_TOKEN:-}}}"
+
           if [ -z "${OPENCLAW_DOCS_SYNC_TOKEN:-}" ]; then
-            echo "::error::OPENCLAW_DOCS_SYNC_TOKEN is required to dispatch openclaw/openclaw docs sync."
+            echo "::error::GitHub App auth or token is required to dispatch"
+            echo "::error::openclaw/openclaw docs sync."
             exit 1
           fi
+
+          dispatch_url="https://api.github.com/repos/openclaw/openclaw"
+          dispatch_url+="/actions/workflows/docs-sync-publish.yml/dispatches"
 
           curl --fail-with-body --silent --show-error \
             --request POST \
             --header "Authorization: Bearer ${OPENCLAW_DOCS_SYNC_TOKEN}" \
             --header "Accept: application/vnd.github+json" \
             --header "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/openclaw/openclaw/actions/workflows/docs-sync-publish.yml/dispatches \
+            "${dispatch_url}" \
             --data '{"ref":"main"}'


### PR DESCRIPTION
## Summary
- replace the expiring `OPENCLAW_DOCS_SYNC_TOKEN` as the primary auth path with the existing GitHub App credentials
- scope the installation token to `openclaw/openclaw`
- retain the legacy secret as a temporary fallback during rotation

The ClawHub dispatch workflow was failing with `401 Bad credentials` after the fine-grained PAT expired. This removes the monthly secret-rotation dependency while preserving a fallback if App auth is unavailable.

## Validation
- `yamllint .github/workflows/openclaw-docs-sync-dispatch.yml` (warnings only for document start and GitHub's `on` key)
- `bunx prettier --check .github/workflows/openclaw-docs-sync-dispatch.yml`
- `git diff --check`
- autoreview: clean