### PR TITLE
fix: grant app token workflow dispatch access

### DIFF
--- a/.github/workflows/openclaw-docs-sync-dispatch.yml
+++ b/.github/workflows/openclaw-docs-sync-dispatch.yml
@@ -24,6 +24,7 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: openclaw
           repositories: openclaw
+          permission-actions: write
 
       - uses: actions/create-github-app-token@v3
         id: app-token-fallback
@@ -34,6 +35,7 @@ jobs:
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
           owner: openclaw
           repositories: openclaw
+          permission-actions: write
 
       - name: Dispatch OpenClaw docs sync
         env:


### PR DESCRIPTION
## Summary
- request `actions: write` when minting the GitHub App installation token

The first fix proved App auth was available, but the token lacked the permission required by the workflow-dispatch API and the merged workflow returned `403 Resource not accessible by integration`. This grants the exact permission needed for dispatching `openclaw/openclaw`'s docs workflow.

## Validation
- `yamllint .github/workflows/openclaw-docs-sync-dispatch.yml` (warnings only for document start and GitHub's `on` key)
- `bunx prettier --check .github/workflows/openclaw-docs-sync-dispatch.yml`
- `git diff --check`
- autoreview: clean