### PR TITLE
fix(search): keep trending populated during rollout

### DIFF
--- a/convex/skills.publicListCursor.test.ts
+++ b/convex/skills.publicListCursor.test.ts
@@ -1309,6 +1309,60 @@ describe("public skill list deterministic cursors", () => {
     expect(result.items[0]).toMatchObject({ latestVersion: null });
   });
 
+  it("falls back to the general trending snapshot during non-suspicious rollout", async () => {
+    const digest = makeSearchDigest();
+    const requestedKinds: string[] = [];
+    const ctx = {
+      db: {
+        query: vi.fn((table: string) => {
+          if (table === "skillLeaderboards") {
+            return {
+              withIndex: vi.fn(
+                (
+                  _indexName: string,
+                  builder: (q: { eq: (field: string, value: string) => unknown }) => unknown,
+                ) => {
+                  const queryBuilder = {
+                    eq: (_field: string, value: string) => {
+                      requestedKinds.push(value);
+                      return queryBuilder;
+                    },
+                  };
+                  builder(queryBuilder);
+                  return {
+                    order: () => ({
+                      first: async () =>
+                        requestedKinds.at(-1) === "trending_non_suspicious"
+                          ? null
+                          : { items: [{ skillId: "skills:demo" }] },
+                    }),
+                  };
+                },
+              ),
+            };
+          }
+          if (table === "skillSearchDigest") {
+            return {
+              withIndex: () => ({
+                unique: async () => digest,
+              }),
+            };
+          }
+          throw new Error(`unexpected table ${table}`);
+        }),
+      },
+    };
+
+    const result = await listPublicTrendingPageHandler(ctx as never, {
+      limit: 10,
+      nonSuspiciousOnly: true,
+    });
+
+    expect(requestedKinds).toEqual(["trending_non_suspicious", "trending"]);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({ skill: { slug: "demo" } });
+  });
+
   it("keeps verified legacy trending latest versions without owner markers", async () => {
     const legacyDigest = makeSearchDigest({
       latestVersionSkillId: undefined,

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -5868,11 +5868,21 @@ export const listPublicTrendingPage = query({
     const kind = args.nonSuspiciousOnly
       ? TRENDING_NON_SUSPICIOUS_LEADERBOARD_KIND
       : TRENDING_LEADERBOARD_KIND;
-    const leaderboard = await ctx.db
+    let leaderboard = await ctx.db
       .query("skillLeaderboards")
       .withIndex("by_kind", (q) => q.eq("kind", kind))
       .order("desc")
       .first();
+
+    // Older deployments may have the general snapshot but not the
+    // non-suspicious snapshot yet. Keep trending populated during rollout.
+    if (!leaderboard && args.nonSuspiciousOnly) {
+      leaderboard = await ctx.db
+        .query("skillLeaderboards")
+        .withIndex("by_kind", (q) => q.eq("kind", TRENDING_LEADERBOARD_KIND))
+        .order("desc")
+        .first();
+    }
 
     if (!leaderboard) return { items: [], nextCursor: null };
 


### PR DESCRIPTION
## Summary

- fall back from a missing `trending_non_suspicious` snapshot to the existing general trending snapshot
- keep the existing suspicious-item filter in place during that fallback
- add a regression test for the rollout state that caused `/skills?sort=trending` to render an empty catalog

## Validation

- `bunx vitest run convex/skills.publicListCursor.test.ts` (35 passing)
- `bun run format:check -- convex/skills.ts convex/skills.publicListCursor.test.ts`
- targeted oxlint passed

## Root cause

The UI requested the newly split non-suspicious leaderboard kind unconditionally. Older/partially deployed environments can have the general trending snapshot but not the derived non-suspicious snapshot yet, which made the page report no published skills.