### PR TITLE
ci(docs): soften ClawHub docs dispatch auth failures

### DIFF
--- a/.github/workflows/openclaw-docs-sync-dispatch.yml
+++ b/.github/workflows/openclaw-docs-sync-dispatch.yml
@@ -24,34 +24,74 @@ jobs:
           set -euo pipefail
 
           if [ -z "${LEGACY_TOKEN:-}" ] && [ -z "${OPENCLAW_GH_TOKEN:-}" ]; then
-            echo "::error::OPENCLAW_DOCS_SYNC_TOKEN or OPENCLAW_GH_TOKEN"
-            echo "::error::is required to dispatch docs sync."
-            echo "::error::to dispatch openclaw/openclaw docs sync."
-            exit 1
+            echo "::warning::Skipping OpenClaw docs sync dispatch because no cross-repo token is configured."
+            exit 0
           fi
 
           dispatch_url="https://api.github.com/repos/openclaw/openclaw"
           dispatch_url+="/actions/workflows/docs-sync-publish.yml/dispatches"
 
           dispatch_with_token() {
-            local token="$1"
-            curl --fail-with-body --silent --show-error \
+            local label="$1"
+            local token="$2"
+            local response_body
+            local http_status
+
+            response_body="$(mktemp)"
+            http_status="$(curl --silent --show-error \
+              --output "${response_body}" \
+              --write-out "%{http_code}" \
               --request POST \
               --header "Authorization: Bearer ${token}" \
               --header "Accept: application/vnd.github+json" \
               --header "X-GitHub-Api-Version: 2022-11-28" \
               "${dispatch_url}" \
-              --data '{"ref":"main"}'
+              --data '{"ref":"main"}' || printf '000')"
+
+            if [ "${http_status}" = "204" ]; then
+              echo "OpenClaw docs sync dispatch accepted with ${label}."
+              return 0
+            fi
+
+            if [ "${http_status}" = "401" ] || [ "${http_status}" = "403" ]; then
+              echo "::warning::OpenClaw docs sync dispatch ${label} credential was rejected with HTTP ${http_status}."
+              cat "${response_body}"
+              return 2
+            fi
+
+            cat "${response_body}"
+            echo "::error::OpenClaw docs sync dispatch failed with ${label} credential, HTTP ${http_status}."
+            return 1
           }
 
-          if dispatch_with_token "${OPENCLAW_GH_TOKEN:-}"; then
+          auth_rejected=false
+
+          if [ -n "${OPENCLAW_GH_TOKEN:-}" ]; then
+            if dispatch_with_token "OPENCLAW_GH_TOKEN" "${OPENCLAW_GH_TOKEN}"; then
+              exit 0
+            fi
+            status="$?"
+            if [ "${status}" != "2" ]; then
+              exit "${status}"
+            fi
+            auth_rejected=true
+          fi
+
+          if [ -n "${LEGACY_TOKEN:-}" ]; then
+            if dispatch_with_token "OPENCLAW_DOCS_SYNC_TOKEN" "${LEGACY_TOKEN}"; then
+              exit 0
+            fi
+            status="$?"
+            if [ "${status}" != "2" ]; then
+              exit "${status}"
+            fi
+            auth_rejected=true
+          fi
+
+          if [ "${auth_rejected}" = "true" ]; then
+            echo "::warning::All configured OpenClaw docs sync credentials were rejected."
+            echo "::warning::Refresh OPENCLAW_GH_TOKEN or OPENCLAW_DOCS_SYNC_TOKEN to restore automatic docs sync."
             exit 0
           fi
 
-          if dispatch_with_token "${LEGACY_TOKEN:-}"; then
-            exit 0
-          fi
-
-          echo "::error::Both docs-sync credentials were rejected."
-          echo "::error::Rotate one of the repository secrets."
-          exit 1
+          echo "::warning::Skipping OpenClaw docs sync dispatch because no non-empty credential was available."


### PR DESCRIPTION
What Problem This Solves

ClawHub main is red because OpenClaw Docs Sync Dispatch receives HTTP 401 from both configured cross-repo dispatch tokens. The latest token-order fix proved the secrets are present, but stale or invalid.

Why This Change Was Made

The docs sync ping is operational follow-up, not ClawHub build correctness. Missing or rejected dispatch credentials should warn and keep the workflow green, while unexpected dispatch failures still fail.

User Impact

ClawHub CI stops going red on stale docs-dispatch credentials. Automatic OpenClaw docs sync still works when a valid token is configured, and logs now say exactly which secret family needs rotation when GitHub rejects it.

Evidence

- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/openclaw-docs-sync-dispatch.yml"); puts "yaml ok"'
- Live failing run: https://github.com/openclaw/clawhub/actions/runs/28153482760 returned HTTP 401 even with OPENCLAW_GH_TOKEN and legacy token present.
