### PR TITLE
ci(docs): retry fallback docs dispatch token

### DIFF
--- a/.github/workflows/openclaw-docs-sync-dispatch.yml
+++ b/.github/workflows/openclaw-docs-sync-dispatch.yml
@@ -67,10 +67,11 @@ jobs:
           auth_rejected=false
 
           if [ -n "${OPENCLAW_GH_TOKEN:-}" ]; then
-            if dispatch_with_token "OPENCLAW_GH_TOKEN" "${OPENCLAW_GH_TOKEN}"; then
+            status=0
+            dispatch_with_token "OPENCLAW_GH_TOKEN" "${OPENCLAW_GH_TOKEN}" || status="$?"
+            if [ "${status}" = "0" ]; then
               exit 0
             fi
-            status="$?"
             if [ "${status}" != "2" ]; then
               exit "${status}"
             fi
@@ -78,10 +79,11 @@ jobs:
           fi
 
           if [ -n "${LEGACY_TOKEN:-}" ]; then
-            if dispatch_with_token "OPENCLAW_DOCS_SYNC_TOKEN" "${LEGACY_TOKEN}"; then
+            status=0
+            dispatch_with_token "OPENCLAW_DOCS_SYNC_TOKEN" "${LEGACY_TOKEN}" || status="$?"
+            if [ "${status}" = "0" ]; then
               exit 0
             fi
-            status="$?"
             if [ "${status}" != "2" ]; then
               exit "${status}"
             fi


### PR DESCRIPTION
What Problem This Solves

The docs dispatch workflow now succeeds on rejected credentials, but the retry loop captured the status after the surrounding if statement. That could stop after OPENCLAW_GH_TOKEN instead of trying the legacy fallback.

Why This Change Was Made

Capture the dispatch helper exit code directly with `|| status="$?"`, then branch on that value. This preserves the intended behavior: 204 exits, auth rejection tries the next token, unexpected HTTP/network failures stay red.

User Impact

ClawHub docs dispatch remains non-blocking for stale credentials, but valid fallback credentials can still dispatch OpenClaw docs sync.

Evidence

- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/openclaw-docs-sync-dispatch.yml"); puts "yaml ok"'
- extracted workflow run script piped to bash -n
