### PR TITLE
fix(search): warm trending before leaderboard snapshot

### DIFF
--- a/convex/skills.publicListCursor.test.ts
+++ b/convex/skills.publicListCursor.test.ts
@@ -1363,6 +1363,43 @@ describe("public skill list deterministic cursors", () => {
     expect(result.items[0]).toMatchObject({ skill: { slug: "demo" } });
   });
 
+  it("warms trending with recent public skills before the first snapshot exists", async () => {
+    const digest = makeSearchDigest({ updatedAt: 12 });
+    const ctx = {
+      db: {
+        query: vi.fn((table: string) => {
+          if (table === "skillLeaderboards") {
+            return {
+              withIndex: () => ({
+                order: () => ({
+                  first: async () => null,
+                }),
+              }),
+            };
+          }
+          if (table === "skillSearchDigest") {
+            return {
+              withIndex: () => ({
+                order: () => ({
+                  take: async () => [digest],
+                }),
+              }),
+            };
+          }
+          throw new Error(`unexpected table ${table}`);
+        }),
+      },
+    };
+
+    const result = await listPublicTrendingPageHandler(ctx as never, {
+      limit: 10,
+      nonSuspiciousOnly: true,
+    });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({ skill: { slug: "demo" } });
+  });
+
   it("keeps verified legacy trending latest versions without owner markers", async () => {
     const legacyDigest = makeSearchDigest({
       latestVersionSkillId: undefined,

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -5884,7 +5884,26 @@ export const listPublicTrendingPage = query({
         .first();
     }
 
-    if (!leaderboard) return { items: [], nextCursor: null };
+    if (!leaderboard) {
+      // The first leaderboard snapshot may not exist yet after deployment.
+      // Use a bounded recent catalog warm-up instead of rendering an empty page.
+      const fallbackDigests = await ctx.db
+        .query("skillSearchDigest")
+        .withIndex("by_active_updated", (q) => q.eq("softDeletedAt", undefined))
+        .order("desc")
+        .take(Math.min(Math.max(limit * 8, limit), 200));
+      const fallbackItems: PublicSkillEntry[] = [];
+      for (const digest of fallbackDigests) {
+        if (args.nonSuspiciousOnly && digest.isSuspicious) continue;
+        if (categorySlug && !resolveStoredSkillCategories(digest).includes(categorySlug)) continue;
+        if (topic && !getCatalogTopicSlugs(digest.topics).includes(topic)) continue;
+        const item = await buildPublicSkillEntryFromDigest(ctx, digest);
+        if (!item) continue;
+        fallbackItems.push(item);
+        if (fallbackItems.length >= limit) break;
+      }
+      return { items: fallbackItems, nextCursor: null };
+    }
 
     const items: PublicSkillEntry[] = [];
     for (const entry of leaderboard.items) {


### PR DESCRIPTION
## Summary

- fall back to a bounded indexed recent-skills catalog when no trending leaderboard snapshot exists yet
- preserve category, topic, and suspicious-item filtering in the warm-up path
- add regression coverage for a fresh production deployment before the first cron snapshot

## Why

The production Convex deployment had no `skillLeaderboards` snapshot yet. The trending page treated that as an empty catalog, so it rendered `No skills found` even though skills were published. The warm-up keeps the page useful until the hourly leaderboard rebuild has data.

## Validation

- `bunx vitest run convex/skills.publicListCursor.test.ts` (36 passing)
- targeted format and oxlint passed