### PR TITLE
feat: streamline skill and plugin publishing

### DIFF
--- a/convex/skills.publicListCursor.test.ts
+++ b/convex/skills.publicListCursor.test.ts
@@ -1363,6 +1363,43 @@ describe("public skill list deterministic cursors", () => {
     expect(result.items[0]).toMatchObject({ skill: { slug: "demo" } });
   });
 
+  it("warms trending with recent public skills before the first snapshot exists", async () => {
+    const digest = makeSearchDigest({ updatedAt: 12 });
+    const ctx = {
+      db: {
+        query: vi.fn((table: string) => {
+          if (table === "skillLeaderboards") {
+            return {
+              withIndex: () => ({
+                order: () => ({
+                  first: async () => null,
+                }),
+              }),
+            };
+          }
+          if (table === "skillSearchDigest") {
+            return {
+              withIndex: () => ({
+                order: () => ({
+                  take: async () => [digest],
+                }),
+              }),
+            };
+          }
+          throw new Error(`unexpected table ${table}`);
+        }),
+      },
+    };
+
+    const result = await listPublicTrendingPageHandler(ctx as never, {
+      limit: 10,
+      nonSuspiciousOnly: true,
+    });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({ skill: { slug: "demo" } });
+  });
+
   it("keeps verified legacy trending latest versions without owner markers", async () => {
     const legacyDigest = makeSearchDigest({
       latestVersionSkillId: undefined,

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -5884,7 +5884,26 @@ export const listPublicTrendingPage = query({
         .first();
     }
 
-    if (!leaderboard) return { items: [], nextCursor: null };
+    if (!leaderboard) {
+      // The first leaderboard snapshot may not exist yet after deployment.
+      // Use a bounded recent catalog warm-up instead of rendering an empty page.
+      const fallbackDigests = await ctx.db
+        .query("skillSearchDigest")
+        .withIndex("by_active_updated", (q) => q.eq("softDeletedAt", undefined))
+        .order("desc")
+        .take(Math.min(Math.max(limit * 8, limit), 200));
+      const fallbackItems: PublicSkillEntry[] = [];
+      for (const digest of fallbackDigests) {
+        if (args.nonSuspiciousOnly && digest.isSuspicious) continue;
+        if (categorySlug && !resolveStoredSkillCategories(digest).includes(categorySlug)) continue;
+        if (topic && !getCatalogTopicSlugs(digest.topics).includes(topic)) continue;
+        const item = await buildPublicSkillEntryFromDigest(ctx, digest);
+        if (!item) continue;
+        fallbackItems.push(item);
+        if (fallbackItems.length >= limit) break;
+      }
+      return { items: fallbackItems, nextCursor: null };
+    }
 
     const items: PublicSkillEntry[] = [];
     for (const entry of leaderboard.items) {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -11,6 +11,7 @@ import {
   Monitor,
   Moon,
   MoreHorizontal,
+  Plus,
   Search,
   Settings,
   Star,
@@ -434,6 +435,18 @@ export default function Header() {
                         </Link>
                       </SheetClose>
                     ))}
+                    {isAuthenticated && me ? (
+                      <SheetClose asChild>
+                        <Link
+                          to="/add"
+                          search={{ kind: "skill", ownerHandle: undefined }}
+                          className="mobile-nav-link"
+                        >
+                          <Plus size={16} aria-hidden="true" />
+                          Add skill or plugin
+                        </Link>
+                      </SheetClose>
+                    ) : null}
                     {SECONDARY_NAV_ITEMS.map((item) => (
                       <SheetClose key={(item.href ?? item.to ?? "") + item.label} asChild>
                         {item.href ? (
@@ -632,6 +645,16 @@ export default function Header() {
                     <Link to="/dashboard" className="flex items-center gap-2">
                       <LayoutDashboard size={14} aria-hidden="true" />
                       Dashboard
+                    </Link>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem asChild>
+                    <Link
+                      to="/add"
+                      search={{ kind: "skill", ownerHandle: undefined }}
+                      className="flex items-center gap-2"
+                    >
+                      <Plus size={14} aria-hidden="true" />
+                      Add skill or plugin
                     </Link>
                   </DropdownMenuItem>
                   <DropdownMenuItem asChild>

--- a/src/components/PublisherOwnerSelect.tsx
+++ b/src/components/PublisherOwnerSelect.tsx
@@ -7,6 +7,7 @@ export type PublisherOwnerMembership = {
     handle: string;
     displayName: string;
     kind: "user" | "org";
+    official?: boolean;
     image?: string | null;
   };
   role: "owner" | "admin" | "publisher";

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -20,6 +20,7 @@ import { Route as ImportRouteImport } from './routes/import'
 import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as AuditsRouteImport } from './routes/audits'
 import { Route as AdminRouteImport } from './routes/admin'
+import { Route as AddRouteImport } from './routes/add'
 import { Route as AccountBannedRouteImport } from './routes/account-banned'
 import { Route as SlugRouteImport } from './routes/$slug'
 import { Route as IndexRouteImport } from './routes/index'
@@ -113,6 +114,11 @@ const AuditsRoute = AuditsRouteImport.update({
 const AdminRoute = AdminRouteImport.update({
   id: '/admin',
   path: '/admin',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AddRoute = AddRouteImport.update({
+  id: '/add',
+  path: '/add',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AccountBannedRoute = AccountBannedRouteImport.update({
@@ -324,6 +330,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/$slug': typeof SlugRoute
   '/account-banned': typeof AccountBannedRoute
+  '/add': typeof AddRoute
   '/admin': typeof AdminRoute
   '/audits': typeof AuditsRoute
   '/dashboard': typeof DashboardRoute
@@ -376,6 +383,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/$slug': typeof SlugRoute
   '/account-banned': typeof AccountBannedRoute
+  '/add': typeof AddRoute
   '/admin': typeof AdminRoute
   '/audits': typeof AuditsRoute
   '/dashboard': typeof DashboardRoute
@@ -429,6 +437,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/$slug': typeof SlugRoute
   '/account-banned': typeof AccountBannedRoute
+  '/add': typeof AddRoute
   '/admin': typeof AdminRoute
   '/audits': typeof AuditsRoute
   '/dashboard': typeof DashboardRoute
@@ -483,6 +492,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$slug'
     | '/account-banned'
+    | '/add'
     | '/admin'
     | '/audits'
     | '/dashboard'
@@ -535,6 +545,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$slug'
     | '/account-banned'
+    | '/add'
     | '/admin'
     | '/audits'
     | '/dashboard'
@@ -587,6 +598,7 @@ export interface FileRouteTypes {
     | '/'
     | '/$slug'
     | '/account-banned'
+    | '/add'
     | '/admin'
     | '/audits'
     | '/dashboard'
@@ -640,6 +652,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   SlugRoute: typeof SlugRoute
   AccountBannedRoute: typeof AccountBannedRoute
+  AddRoute: typeof AddRoute
   AdminRoute: typeof AdminRoute
   AuditsRoute: typeof AuditsRoute
   DashboardRoute: typeof DashboardRoute
@@ -754,6 +767,13 @@ declare module '@tanstack/react-router' {
       path: '/admin'
       fullPath: '/admin'
       preLoaderRoute: typeof AdminRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/add': {
+      id: '/add'
+      path: '/add'
+      fullPath: '/add'
+      preLoaderRoute: typeof AddRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/account-banned': {
@@ -1108,6 +1128,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   SlugRoute: SlugRoute,
   AccountBannedRoute: AccountBannedRoute,
+  AddRoute: AddRoute,
   AdminRoute: AdminRoute,
   AuditsRoute: AuditsRoute,
   DashboardRoute: DashboardRoute,

--- a/src/routes/add.tsx
+++ b/src/routes/add.tsx
@@ -1,0 +1,222 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useQuery } from "convex/react";
+import { ArrowRight, Download, FolderGit2, Package, Plus, Upload } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { api } from "../../convex/_generated/api";
+import { Container } from "../components/layout/Container";
+import {
+  PublisherOwnerSelect,
+  type PublisherOwnerMembership,
+} from "../components/PublisherOwnerSelect";
+import { SignInPrompt } from "../components/SignInPrompt";
+import { Button } from "../components/ui/button";
+import { Card, CardContent } from "../components/ui/card";
+import { useAuthStatus } from "../lib/useAuthStatus";
+
+type AddKind = "skill" | "plugin";
+
+export const Route = createFileRoute("/add")({
+  validateSearch: (search: Record<string, unknown>) => ({
+    kind: search.kind === "plugin" ? ("plugin" as const) : ("skill" as const),
+    ownerHandle: typeof search.ownerHandle === "string" ? search.ownerHandle : undefined,
+  }),
+  component: AddPage,
+});
+
+const emptyPluginPublishSearch = {
+  ownerHandle: undefined,
+  name: undefined,
+  displayName: undefined,
+  family: undefined,
+  nextVersion: undefined,
+  sourceRepo: undefined,
+} as const;
+
+export function AddPage() {
+  const { isAuthenticated, isLoading, me } = useAuthStatus();
+  const search = Route.useSearch();
+  const memberships = useQuery(api.publishers.listMine, me ? {} : "skip") as
+    | PublisherOwnerMembership[]
+    | undefined;
+  const [kind, setKind] = useState<AddKind>(search.kind);
+  const [ownerHandle, setOwnerHandle] = useState(search.ownerHandle ?? "");
+
+  const selectedMembership = useMemo(
+    () => memberships?.find((entry) => entry.publisher.handle === ownerHandle) ?? null,
+    [memberships, ownerHandle],
+  );
+  const orgMemberships = useMemo(
+    () =>
+      (memberships ?? []).filter(
+        (entry) => entry.publisher.kind === "org" && entry.publisher.official === true,
+      ),
+    [memberships],
+  );
+  const hasGitSyncPublisher = orgMemberships.length > 0;
+
+  useEffect(() => {
+    if (ownerHandle || !memberships?.length) return;
+    const personal = memberships.find((entry) => entry.publisher.kind === "user");
+    setOwnerHandle((personal ?? memberships[0]).publisher.handle);
+  }, [memberships, ownerHandle]);
+
+  useEffect(() => {
+    setKind(search.kind);
+  }, [search.kind]);
+
+  if (isLoading) {
+    return (
+      <main className="py-10">
+        <Container size="narrow">
+          <div className="h-64 animate-pulse rounded-[var(--radius-md)] bg-[color:var(--surface-muted)]" />
+        </Container>
+      </main>
+    );
+  }
+
+  if (!isAuthenticated || !me) {
+    return <SignInPrompt title="Sign in to add a skill or plugin." />;
+  }
+
+  return (
+    <main className="py-10">
+      <Container size="narrow">
+        <header className="mb-8">
+          <p className="mb-2 text-sm font-semibold uppercase tracking-[0.08em] text-[color:var(--accent)]">
+            Publish
+          </p>
+          <h1 className="font-display text-3xl font-black text-[color:var(--ink)]">
+            Add a skill or plugin
+          </h1>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-[color:var(--ink-soft)]">
+            Choose what you are adding, then pick the source that matches how you maintain it.
+          </p>
+        </header>
+
+        <div className="mb-6 flex flex-col gap-3">
+          <label htmlFor="add-owner" className="text-sm font-semibold text-[color:var(--ink)]">
+            Add as
+          </label>
+          <PublisherOwnerSelect
+            id="add-owner"
+            value={ownerHandle}
+            memberships={memberships}
+            onValueChange={setOwnerHandle}
+          />
+          {selectedMembership?.publisher.kind === "org" ? (
+            <p className="text-xs text-[color:var(--ink-soft)]">
+              This will publish into @{selectedMembership.publisher.handle}.
+            </p>
+          ) : null}
+        </div>
+
+        <div className="mb-6 grid grid-cols-2 gap-2 rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface-muted)]/40 p-1">
+          <button
+            type="button"
+            className={`flex min-h-11 items-center justify-center gap-2 rounded-[var(--radius-sm)] px-3 text-sm font-semibold transition-colors ${
+              kind === "skill"
+                ? "bg-[color:var(--surface)] text-[color:var(--ink)] shadow-sm"
+                : "text-[color:var(--ink-soft)] hover:text-[color:var(--ink)]"
+            }`}
+            aria-pressed={kind === "skill"}
+            onClick={() => setKind("skill")}
+          >
+            <Plus size={16} aria-hidden="true" />
+            Skill
+          </button>
+          <button
+            type="button"
+            className={`flex min-h-11 items-center justify-center gap-2 rounded-[var(--radius-sm)] px-3 text-sm font-semibold transition-colors ${
+              kind === "plugin"
+                ? "bg-[color:var(--surface)] text-[color:var(--ink)] shadow-sm"
+                : "text-[color:var(--ink-soft)] hover:text-[color:var(--ink)]"
+            }`}
+            aria-pressed={kind === "plugin"}
+            onClick={() => setKind("plugin")}
+          >
+            <Package size={16} aria-hidden="true" />
+            Plugin
+          </button>
+        </div>
+
+        <div className="grid gap-3">
+          {kind === "skill" && hasGitSyncPublisher ? (
+            <AddMethodCard
+              icon={<FolderGit2 size={20} aria-hidden="true" />}
+              title="Git sync"
+              description="Keep a public GitHub skills repo connected and sync changes automatically."
+              to="/settings"
+              search={{ view: "githubSources" }}
+              action="Configure sync"
+            />
+          ) : null}
+          {kind === "skill" ? (
+            <AddMethodCard
+              icon={<Download size={20} aria-hidden="true" />}
+              title="Import from GitHub"
+              description="Bring one or more skills over from a public repository, then review before publishing."
+              to="/import"
+              action="Import skills"
+            />
+          ) : null}
+          <AddMethodCard
+            icon={<Upload size={20} aria-hidden="true" />}
+            title="Upload files"
+            description={
+              kind === "skill"
+                ? "Upload a skill folder containing SKILL.md and publish it manually."
+                : "Upload a plugin folder, .zip, or .tgz and publish a release."
+            }
+            to={kind === "skill" ? "/skills/publish" : "/plugins/publish"}
+            search={
+              kind === "skill"
+                ? { updateSlug: undefined, ownerHandle: ownerHandle || undefined }
+                : { ...emptyPluginPublishSearch, ownerHandle: ownerHandle || undefined }
+            }
+            action={kind === "skill" ? "Upload skill" : "Upload plugin"}
+          />
+        </div>
+
+        <p className="mt-6 text-center text-xs text-[color:var(--ink-soft)]">
+          You can change the publisher later from the publish form.
+        </p>
+      </Container>
+    </main>
+  );
+}
+
+function AddMethodCard({
+  action,
+  description,
+  icon,
+  search,
+  title,
+  to,
+}: {
+  action: string;
+  description: string;
+  icon: React.ReactNode;
+  search?: Record<string, unknown>;
+  title: string;
+  to: string;
+}) {
+  return (
+    <Card className="transition-colors hover:border-[color:var(--accent)]">
+      <CardContent className="flex items-center gap-4 p-5">
+        <span className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-[var(--radius-sm)] border border-[color:var(--line)] bg-[color:var(--surface-muted)] text-[color:var(--accent)]">
+          {icon}
+        </span>
+        <div className="min-w-0 flex-1">
+          <h2 className="font-display text-lg font-bold text-[color:var(--ink)]">{title}</h2>
+          <p className="mt-1 text-sm leading-5 text-[color:var(--ink-soft)]">{description}</p>
+        </div>
+        <Button asChild size="sm" variant="outline" className="shrink-0">
+          <Link to={to} search={search as never}>
+            {action}
+            <ArrowRight size={15} aria-hidden="true" />
+          </Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/routes/plugins/index.tsx
+++ b/src/routes/plugins/index.tsx
@@ -1,7 +1,7 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute, Link, redirect } from "@tanstack/react-router";
 import { isPluginCategorySlug, normalizeCatalogTopic } from "clawhub-schema";
 import { useQuery } from "convex/react";
-import { BadgeCheck, PackageSearch } from "lucide-react";
+import { BadgeCheck, PackageSearch, Plus } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../../../convex/_generated/api";
 import {
@@ -707,6 +707,12 @@ function PluginsIndex() {
             <div className="empty-state">
               <p className="empty-state-title">No plugins found</p>
               <p className="empty-state-body">Try a different search term or remove filters.</p>
+              <Button asChild size="sm" className="mt-4">
+                <Link to="/add" search={{ kind: "plugin", ownerHandle: undefined }}>
+                  <Plus className="h-4 w-4" aria-hidden="true" />
+                  Add a plugin
+                </Link>
+              </Button>
             </div>
           ) : effectiveView === "grid" ? (
             <div className="grid browse-results-grid">

--- a/src/routes/search.tsx
+++ b/src/routes/search.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { Search, X } from "lucide-react";
+import { Plus, Search, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { PluginListItem } from "../components/PluginListItem";
 import { PublisherListItem } from "../components/PublisherListItem";
@@ -284,6 +284,13 @@ function SearchEmptyState({
         ) : null}
         <a className="search-empty-action" href={browseHref}>
           {browseLabel}
+        </a>
+        <a
+          className="search-empty-action"
+          href={`/add?kind=${activeType === "plugins" ? "plugin" : "skill"}`}
+        >
+          <Plus size={14} aria-hidden="true" />
+          {activeType === "plugins" ? "Add a plugin" : "Add a skill or plugin"}
         </a>
       </div>
     </Card>

--- a/src/routes/skills/-SkillsResults.tsx
+++ b/src/routes/skills/-SkillsResults.tsx
@@ -1,3 +1,5 @@
+import { Link } from "@tanstack/react-router";
+import { Plus } from "lucide-react";
 import type { RefObject } from "react";
 import { BrowseResultsSkeleton } from "../../components/skeletons/BrowseResultsSkeleton";
 import { SkillCard } from "../../components/SkillCard";
@@ -50,6 +52,12 @@ export function SkillsResults({
               ? "Try a different search term or remove filters."
               : "No skills have been published yet."}
           </p>
+          <Button asChild size="sm" className="mt-4">
+            <Link to="/add" search={{ kind: "skill", ownerHandle: undefined }}>
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              Add a skill
+            </Link>
+          </Button>
         </div>
       ) : effectiveView === "grid" ? (
         <div className="grid browse-results-grid">

--- a/src/routes/user/$handle.tsx
+++ b/src/routes/user/$handle.tsx
@@ -15,6 +15,7 @@ import {
   Download,
   Flag,
   MoreHorizontal,
+  Plus,
   Search,
   Star,
   type LucideIcon,
@@ -398,16 +399,26 @@ function PublisherProfile() {
 }
 
 function PublisherProfileChromeActions({
+  addHandle,
   isAuthenticated,
   onReport,
   requireSignIn,
 }: {
+  addHandle?: string;
   isAuthenticated: boolean;
   onReport: () => void;
   requireSignIn: () => void;
 }) {
   return (
     <div className="publisher-profile-chrome-actions">
+      {addHandle ? (
+        <Button asChild size="sm" variant="primary">
+          <Link to="/add" search={{ kind: "skill", ownerHandle: addHandle }}>
+            <Plus size={15} aria-hidden="true" />
+            Add
+          </Link>
+        </Button>
+      ) : null}
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button
@@ -540,6 +551,10 @@ export function PublisherProfilePage({
         (entry.role === "owner" || entry.role === "admin"),
     );
   }, [myPublisherMemberships, handle]);
+  const viewerCanAddToPublisher = useMemo(
+    () => Boolean(myPublisherMemberships?.some((entry) => entry.publisher.handle === handle)),
+    [myPublisherMemberships, handle],
+  );
 
   const {
     results: publishedResults,
@@ -711,6 +726,7 @@ export function PublisherProfilePage({
             <div className="publisher-profile-chrome-top">
               <PublisherProfileChromeIdentity publisher={publisher} />
               <PublisherProfileChromeActions
+                addHandle={viewerCanAddToPublisher ? publisher.handle : undefined}
                 isAuthenticated={isAuthenticated}
                 onReport={openReportDialog}
                 requireSignIn={() => {


### PR DESCRIPTION
## Summary
- add a unified `/add` flow for skills and plugins with publisher selection
- surface add entrypoints from profiles, the sidebar, and empty search/browse states
- preserve the official-publisher gate for Git-backed skill sync

## Verification
- `bunx tsc --noEmit`
- `bun run lint`
- `bunx vitest run src/routes/-dashboard.test.tsx src/routes/-settings.test.tsx`
- `bun run build`