### PR TITLE
fix: preserve selected GitHub skills across resync

### DIFF
--- a/convex/githubSkillSync.test.ts
+++ b/convex/githubSkillSync.test.ts
@@ -380,6 +380,111 @@ describe("configurePublicGitHubSkillSourceHandler", () => {
     );
   });
 
+  it("requires an explicit selection when a new repo contains multiple skills", async () => {
+    const zip = zipSync({
+      "skills-main/skills/bundled/SKILL.md": new TextEncoder().encode("# Bundled\n"),
+      "skills-main/skills/vibethon/SKILL.md": new TextEncoder().encode("# Vibethon\n"),
+    });
+    const runQuery = vi.fn(async () => ({
+      ownerUserId: "users:publisher-owner",
+      existingSource: null,
+      official: true,
+    }));
+    const runMutation = vi.fn();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          full_name: "Vibethon/skills",
+          private: false,
+          visibility: "public",
+          default_branch: "main",
+          disabled: false,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ sha: "2".repeat(40) }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-length": String(zip.byteLength) }),
+        body: null,
+        arrayBuffer: async () => zip.buffer.slice(zip.byteOffset, zip.byteOffset + zip.byteLength),
+      });
+
+    await expect(
+      configurePublicGitHubSkillSourceHandler(
+        { runQuery, runMutation, auth: { getUserIdentity: vi.fn() } } as never,
+        {
+          ownerPublisherId: "publishers:vibethon" as never,
+          repo: "Vibethon/skills",
+        },
+        fetchMock as never,
+        { userId: "users:actor" as never },
+      ),
+    ).rejects.toThrow(/select at least one skill/i);
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("preserves all-skill behavior for legacy sources without a saved selection", async () => {
+    const zip = zipSync({
+      "skills-main/skills/bundled/SKILL.md": new TextEncoder().encode("# Bundled\n"),
+      "skills-main/skills/vibethon/SKILL.md": new TextEncoder().encode("# Vibethon\n"),
+    });
+    const runQuery = vi.fn(async () => ({
+      ownerUserId: "users:publisher-owner",
+      existingSource: {
+        _id: "githubSkillSources:legacy",
+        repo: "Vibethon/skills",
+        ownerPublisherId: "publishers:vibethon",
+        defaultBranch: "main",
+      },
+      official: true,
+    }));
+    const runMutation = vi.fn(async () => ({ ok: true, stats: { discovered: 2 } }));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          full_name: "Vibethon/skills",
+          private: false,
+          visibility: "public",
+          default_branch: "main",
+          disabled: false,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ sha: "3".repeat(40) }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: new Headers({ "content-length": String(zip.byteLength) }),
+        body: null,
+        arrayBuffer: async () => zip.buffer.slice(zip.byteOffset, zip.byteOffset + zip.byteLength),
+      });
+
+    await configurePublicGitHubSkillSourceHandler(
+      { runQuery, runMutation, auth: { getUserIdentity: vi.fn() } } as never,
+      {
+        ownerPublisherId: "publishers:vibethon" as never,
+        repo: "Vibethon/skills",
+      },
+      fetchMock as never,
+      { userId: "users:actor" as never },
+    );
+
+    const syncArgs = (runMutation.mock.calls[0] as unknown[] | undefined)?.[1] as Record<
+      string,
+      unknown
+    >;
+    expect(syncArgs).not.toHaveProperty("selectedSkillPaths");
+    expect((syncArgs.snapshot as { skills: unknown[] }).skills).toHaveLength(2);
+  });
+
   it("rejects non-official publishers before fetching skill contents", async () => {
     const runQuery = vi.fn(async () => ({
       ownerUserId: "users:publisher-owner",

--- a/convex/githubSkillSync.ts
+++ b/convex/githubSkillSync.ts
@@ -18,6 +18,7 @@ import {
   type DiscoveredGitHubSkill,
   type DisplayManifestStatus,
   githubBackedSkillModeration,
+  normalizeSelectedSkillPaths,
   type GitHubSkillScanStatus,
   type GitHubSkillSourceMetadataSnapshot,
   type GitHubSkillSourceSnapshot,
@@ -45,7 +46,7 @@ const MAX_SOURCE_SYNC_BATCH_SIZE = 50;
 
 type SourceForSync = Pick<
   Doc<"githubSkillSources">,
-  "_id" | "repo" | "ownerPublisherId" | "defaultBranch"
+  "_id" | "repo" | "ownerPublisherId" | "defaultBranch" | "selectedSkillPaths"
 >;
 
 type SourceForSyncPage = {
@@ -119,6 +120,24 @@ type GitHubSkillSourceSetupContext = {
   ownerUserId: Id<"users">;
   existingSource: SourceForSync | null;
   official: boolean;
+};
+
+type GitHubSkillSourcePreview = {
+  ok: true;
+  repo: string;
+  defaultBranch: string;
+  commit: string;
+  manifestStatus: DisplayManifestStatus;
+  existingSourceId?: Id<"githubSkillSources">;
+  selectedSkillPaths?: string[];
+  skills: Array<{
+    slug: string;
+    displayName: string;
+    summary?: string;
+    path: string;
+    skillCardMarkdownPath?: string;
+    contentHash: string;
+  }>;
 };
 
 type GitHubSkillVerificationTarget = {
@@ -395,6 +414,7 @@ export type ApplyGitHubSkillSourceSyncArgs = {
   repo: string;
   ownerUserId: Id<"users">;
   ownerPublisherId?: Id<"publishers">;
+  selectedSkillPaths?: string[];
   snapshot: GitHubSkillSourceMetadataSnapshot;
   now?: number;
 };
@@ -423,6 +443,9 @@ export async function applyGitHubSkillSourceSyncHandler(
   }
 
   const sourceOwnerPublisherId = args.ownerPublisherId ?? existingSource?.ownerPublisherId;
+  const selectedSkillPaths =
+    normalizeSelectedSkillPaths(args.selectedSkillPaths) ??
+    normalizeSelectedSkillPaths(existingSource?.selectedSkillPaths);
   const sourceId =
     existingSource?._id ??
     (await ctx.db.insert(
@@ -430,6 +453,7 @@ export async function applyGitHubSkillSourceSyncHandler(
       stripUndefined({
         repo,
         ownerPublisherId: sourceOwnerPublisherId,
+        selectedSkillPaths,
         createdAt: now,
         updatedAt: now,
       }) as Omit<Doc<"githubSkillSources">, "_id" | "_creationTime">,
@@ -443,6 +467,7 @@ export async function applyGitHubSkillSourceSyncHandler(
     sourceId,
     ownerUserId: args.ownerUserId,
     ...(sourceOwnerPublisherId ? { ownerPublisherId: sourceOwnerPublisherId } : {}),
+    selectedSkillPaths,
     existingSkills: existingSkills.map((skill) => ({
       _id: skill._id,
       slug: skill.slug,
@@ -840,6 +865,7 @@ export const applyGitHubSkillSourceSyncInternal = internalMutation({
     repo: v.string(),
     ownerUserId: v.id("users"),
     ownerPublisherId: v.optional(v.id("publishers")),
+    selectedSkillPaths: v.optional(v.array(v.string())),
     snapshot: sourceSnapshotValidator,
     now: v.optional(v.number()),
   },
@@ -977,7 +1003,11 @@ export async function verifyGitHubSkillHandler(
 
 export async function configurePublicGitHubSkillSourceHandler(
   ctx: ActionCtx,
-  args: { ownerPublisherId: Id<"publishers">; repo: string },
+  args: {
+    ownerPublisherId: Id<"publishers">;
+    repo: string;
+    selectedSkillPaths?: string[];
+  },
   fetcher: typeof fetch = fetch,
   authOverride?: { userId: Id<"users"> },
 ): Promise<SyncOneResult> {
@@ -1004,22 +1034,94 @@ export async function configurePublicGitHubSkillSourceHandler(
   if (snapshot.skills.length === 0) {
     throw new ConvexError("No skills were found in that public GitHub repo.");
   }
+  const hasExplicitSelection = args.selectedSkillPaths !== undefined;
+  const selectedSkillPaths = hasExplicitSelection
+    ? normalizeSelectedSkillPaths(args.selectedSkillPaths)
+    : normalizeSelectedSkillPaths(setup.existingSource?.selectedSkillPaths);
+  if (hasExplicitSelection && !selectedSkillPaths) {
+    throw new ConvexError("Select at least one skill before adding this repo.");
+  }
+  if (!setup.existingSource && !selectedSkillPaths && snapshot.skills.length > 1) {
+    throw new ConvexError("Select at least one skill before adding this repo.");
+  }
+  if (selectedSkillPaths) {
+    const discoveredPaths = new Set(snapshot.skills.map((skill) => skill.path));
+    const missingPath = selectedSkillPaths.find((path) => !discoveredPaths.has(path));
+    if (missingPath) {
+      throw new ConvexError(`Selected GitHub skill is not present in the repo: ${missingPath}`);
+    }
+  }
+  const effectiveSelectedSkillPaths =
+    !setup.existingSource && !selectedSkillPaths
+      ? [snapshot.skills[0]?.path as string]
+      : selectedSkillPaths;
   return await applyFetchedGitHubSkillSourceSnapshot(ctx, {
     sourceId: setup.existingSource?._id,
     repo: metadata.repo,
     ownerUserId: setup.ownerUserId,
     ownerPublisherId: args.ownerPublisherId,
+    selectedSkillPaths: effectiveSelectedSkillPaths,
     snapshot,
   });
+}
+
+export async function previewPublicGitHubSkillSourceHandler(
+  ctx: ActionCtx,
+  args: { ownerPublisherId: Id<"publishers">; repo: string },
+  fetcher: typeof fetch = fetch,
+  authOverride?: { userId: Id<"users"> },
+): Promise<GitHubSkillSourcePreview> {
+  const actor = authOverride ?? (await requireUserFromAction(ctx));
+  const metadata = await fetchPublicGitHubRepoMetadata(args.repo, fetcher);
+  const setup = (await ctx.runQuery(
+    internal.githubSkillSync.getPublicGitHubSkillSourceSetupContextInternal,
+    {
+      ownerPublisherId: args.ownerPublisherId,
+      actorUserId: actor.userId,
+      repo: metadata.repo,
+    },
+  )) as GitHubSkillSourceSetupContext;
+  if (!setup.official) {
+    throw new ConvexError("GitHub source sync is only available for official publishers.");
+  }
+  const snapshot = await fetchGitHubSkillSourceSnapshot(
+    { repo: metadata.repo, defaultBranch: metadata.defaultBranch },
+    fetcher,
+  );
+  if (snapshot.skills.length === 0) {
+    throw new ConvexError("No skills were found in that public GitHub repo.");
+  }
+  return {
+    ok: true,
+    repo: metadata.repo,
+    defaultBranch: metadata.defaultBranch,
+    commit: snapshot.commit,
+    manifestStatus: snapshot.manifestStatus,
+    existingSourceId: setup.existingSource?._id,
+    selectedSkillPaths: normalizeSelectedSkillPaths(setup.existingSource?.selectedSkillPaths),
+    skills: snapshot.skills.map(
+      ({ skillMarkdown: _skillMarkdown, skillCardMarkdown: _skillCardMarkdown, ...skill }) => skill,
+    ),
+  };
 }
 
 export const configurePublicGitHubSkillSource: ReturnType<typeof action> = action({
   args: {
     ownerPublisherId: v.id("publishers"),
     repo: v.string(),
+    selectedSkillPaths: v.optional(v.array(v.string())),
   },
   handler: async (ctx, args): Promise<SyncOneResult> =>
     configurePublicGitHubSkillSourceHandler(ctx, args),
+});
+
+export const previewPublicGitHubSkillSource: ReturnType<typeof action> = action({
+  args: {
+    ownerPublisherId: v.id("publishers"),
+    repo: v.string(),
+  },
+  handler: async (ctx, args): Promise<GitHubSkillSourcePreview> =>
+    previewPublicGitHubSkillSourceHandler(ctx, args),
 });
 
 async function applyFetchedGitHubSkillSourceSnapshot(
@@ -1029,6 +1131,7 @@ async function applyFetchedGitHubSkillSourceSnapshot(
     repo: string;
     ownerUserId: Id<"users">;
     ownerPublisherId?: Id<"publishers">;
+    selectedSkillPaths?: string[];
     snapshot: GitHubSkillSourceSnapshot;
   },
 ) {
@@ -1039,6 +1142,7 @@ async function applyFetchedGitHubSkillSourceSnapshot(
       repo: args.repo,
       ownerUserId: args.ownerUserId,
       ownerPublisherId: args.ownerPublisherId,
+      ...(args.selectedSkillPaths ? { selectedSkillPaths: args.selectedSkillPaths } : {}),
       snapshot: toGitHubSkillSourceMetadataSnapshot(args.snapshot),
     },
   )) as SyncOneResult;

--- a/convex/lib/githubSkillSync.test.ts
+++ b/convex/lib/githubSkillSync.test.ts
@@ -197,6 +197,38 @@ describe("buildGitHubSkillSourceSnapshot", () => {
 });
 
 describe("buildGitHubSkillSyncPlan", () => {
+  it("limits a source to its explicit selected skill paths", async () => {
+    const snapshot = await buildGitHubSkillSourceSnapshot({
+      repo: "vibethon/skills",
+      defaultBranch: "main",
+      commit: "a".repeat(40),
+      entries: repoEntries({
+        "SKILL.md": "# Bundled project skill\n",
+        "skills/vibethon/SKILL.md": "# Vibethon\n",
+      }),
+    });
+
+    const plan = buildGitHubSkillSyncPlan({
+      sourceId: "githubSkillSources:vibethon",
+      ownerUserId: "users:vibethon",
+      ownerPublisherId: "publishers:vibethon",
+      selectedSkillPaths: ["skills/vibethon"],
+      existingSkills: [],
+      snapshot,
+      now: 123,
+    });
+
+    expect(plan.stats.discovered).toBe(1);
+    expect(plan.skillInserts).toHaveLength(1);
+    expect(plan.skillInserts[0]?.doc).toMatchObject({
+      slug: "vibethon",
+      githubPath: "skills/vibethon",
+    });
+    expect(plan.sourcePatch).toMatchObject({
+      selectedSkillPaths: ["skills/vibethon"],
+    });
+  });
+
   it("marks changed upstream content pending", async () => {
     const snapshot = await buildGitHubSkillSourceSnapshot({
       repo: "NVIDIA/skills",

--- a/convex/lib/githubSkillSync.ts
+++ b/convex/lib/githubSkillSync.ts
@@ -99,6 +99,14 @@ export type GitHubSkillSyncPlan = {
   };
 };
 
+export function normalizeSelectedSkillPaths(paths: readonly string[] | undefined) {
+  if (!paths) return undefined;
+  const normalized = [...new Set(paths.map((path) => path.trim()).filter(Boolean))].sort((a, b) =>
+    a.localeCompare(b),
+  );
+  return normalized.length > 0 ? normalized : undefined;
+}
+
 const SKILL_MARKDOWN_BASENAME = "skill.md";
 const SKILL_CARD_MARKDOWN_BASENAME = "skill-card.md";
 const MAX_STORED_MARKDOWN_BYTES = 512 * 1024;
@@ -260,6 +268,7 @@ export function buildGitHubSkillSyncPlan({
   sourceId,
   ownerUserId,
   ownerPublisherId,
+  selectedSkillPaths,
   existingSkills,
   snapshot,
   now,
@@ -267,10 +276,15 @@ export function buildGitHubSkillSyncPlan({
   sourceId: string;
   ownerUserId: string;
   ownerPublisherId?: string;
+  selectedSkillPaths?: readonly string[];
   existingSkills: ExistingGitHubSkillForSync[];
   snapshot: GitHubSkillSourceSnapshot | GitHubSkillSourceMetadataSnapshot;
   now: number;
 }): GitHubSkillSyncPlan {
+  const selectedPaths = selectedSkillPaths ? new Set(selectedSkillPaths) : null;
+  const discoveredSkills = selectedPaths
+    ? snapshot.skills.filter((skill) => selectedPaths.has(skill.path))
+    : snapshot.skills;
   const sourcePatch = {
     repo: snapshot.repo,
     defaultBranch: snapshot.defaultBranch,
@@ -283,6 +297,7 @@ export function buildGitHubSkillSyncPlan({
     displayManifestFetchedAt: now,
     displayManifestStatus: snapshot.manifestStatus,
     displayManifest: snapshot.manifest,
+    ...(selectedSkillPaths ? { selectedSkillPaths: [...selectedSkillPaths] } : {}),
     ...(ownerPublisherId ? { ownerPublisherId } : {}),
     updatedAt: now,
   };
@@ -296,14 +311,14 @@ export function buildGitHubSkillSyncPlan({
   const skillPatches: GitHubSkillPatchForSync[] = [];
   const skillInserts: GitHubSkillInsertForSync[] = [];
   const stats = {
-    discovered: snapshot.skills.length,
+    discovered: discoveredSkills.length,
     inserted: 0,
     changed: 0,
     unchanged: 0,
     removed: 0,
   };
 
-  for (const discovered of snapshot.skills) {
+  for (const discovered of discoveredSkills) {
     const existing = existingByPath.get(discovered.path) ?? existingBySlug.get(discovered.slug);
     if (!existing) {
       const scanStatus: GitHubSkillScanStatus = "pending";

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -322,6 +322,7 @@ const githubSkillSourceIssueValidator = v.object({
 const githubSkillSources = defineTable({
   repo: v.string(),
   ownerPublisherId: v.optional(v.id("publishers")),
+  selectedSkillPaths: v.optional(v.array(v.string())),
   defaultBranch: v.optional(v.string()),
   lastSyncStatus: v.optional(v.union(v.literal("ok"), v.literal("failed"), v.literal("skipped"))),
   lastSyncError: v.optional(v.string()),

--- a/convex/skills.publicListCursor.test.ts
+++ b/convex/skills.publicListCursor.test.ts
@@ -1363,6 +1363,43 @@ describe("public skill list deterministic cursors", () => {
     expect(result.items[0]).toMatchObject({ skill: { slug: "demo" } });
   });
 
+  it("warms trending with recent public skills before the first snapshot exists", async () => {
+    const digest = makeSearchDigest({ updatedAt: 12 });
+    const ctx = {
+      db: {
+        query: vi.fn((table: string) => {
+          if (table === "skillLeaderboards") {
+            return {
+              withIndex: () => ({
+                order: () => ({
+                  first: async () => null,
+                }),
+              }),
+            };
+          }
+          if (table === "skillSearchDigest") {
+            return {
+              withIndex: () => ({
+                order: () => ({
+                  take: async () => [digest],
+                }),
+              }),
+            };
+          }
+          throw new Error(`unexpected table ${table}`);
+        }),
+      },
+    };
+
+    const result = await listPublicTrendingPageHandler(ctx as never, {
+      limit: 10,
+      nonSuspiciousOnly: true,
+    });
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]).toMatchObject({ skill: { slug: "demo" } });
+  });
+
   it("keeps verified legacy trending latest versions without owner markers", async () => {
     const legacyDigest = makeSearchDigest({
       latestVersionSkillId: undefined,

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -5884,7 +5884,26 @@ export const listPublicTrendingPage = query({
         .first();
     }
 
-    if (!leaderboard) return { items: [], nextCursor: null };
+    if (!leaderboard) {
+      // The first leaderboard snapshot may not exist yet after deployment.
+      // Use a bounded recent catalog warm-up instead of rendering an empty page.
+      const fallbackDigests = await ctx.db
+        .query("skillSearchDigest")
+        .withIndex("by_active_updated", (q) => q.eq("softDeletedAt", undefined))
+        .order("desc")
+        .take(Math.min(Math.max(limit * 8, limit), 200));
+      const fallbackItems: PublicSkillEntry[] = [];
+      for (const digest of fallbackDigests) {
+        if (args.nonSuspiciousOnly && digest.isSuspicious) continue;
+        if (categorySlug && !resolveStoredSkillCategories(digest).includes(categorySlug)) continue;
+        if (topic && !getCatalogTopicSlugs(digest.topics).includes(topic)) continue;
+        const item = await buildPublicSkillEntryFromDigest(ctx, digest);
+        if (!item) continue;
+        fallbackItems.push(item);
+        if (fallbackItems.length >= limit) break;
+      }
+      return { items: fallbackItems, nextCursor: null };
+    }
 
     const items: PublicSkillEntry[] = [];
     for (const entry of leaderboard.items) {

--- a/specs/github-backed-skills.md
+++ b/specs/github-backed-skills.md
@@ -34,6 +34,9 @@ version.
 
 - `repo`: GitHub `owner/repo`, for example `NVIDIA/skills`
 - `ownerPublisherId`: ClawHub publisher that owns the synced catalog
+- `selectedSkillPaths`: optional explicit skill-folder paths selected for this
+  source. Legacy sources without this field retain the historical all-detected
+  skills behavior.
 - `defaultBranch`: optional branch value discovered from GitHub
 - `displayManifestKind`: currently only `skills.sh`
 - `displayManifestCommit`, `displayManifestHash`, `displayManifestFetchedAt`
@@ -94,6 +97,12 @@ applies it to ClawHub. Pagination must use a stable source cursor, not
 remain on the Node runtime action. Per-skill verification also fetches and
 expands the source archive, so verification actions must run in the Node runtime
 as well.
+
+When a new repository contains multiple detected skills, the settings flow
+previews the candidates and requires the publisher to choose one or more skill
+paths before creating the source. That selection is persisted on the source and
+applied on every scheduled sync, so unrelated root or bundled `SKILL.md` files
+cannot be silently revived after a source is deleted and added again.
 
 Sync must not pass the full repo Markdown payload through one large Convex
 mutation. The intended split is:

--- a/src/__tests__/search-route.test.tsx
+++ b/src/__tests__/search-route.test.tsx
@@ -16,6 +16,11 @@ vi.mock("@tanstack/react-router", () => ({
     __config: config,
     useSearch: () => searchMock,
   }),
+  Link: ({ children, className, to }: { children: ReactNode; className?: string; to?: string }) => (
+    <a className={className} href={to}>
+      {children}
+    </a>
+  ),
   useNavigate: () => navigateMock,
 }));
 

--- a/src/routes/-settings.test.tsx
+++ b/src/routes/-settings.test.tsx
@@ -335,7 +335,26 @@ describe("Settings", () => {
 
   it("lets official publisher owners configure a public GitHub sync source", async () => {
     const configureSource = vi.fn().mockResolvedValue({ ok: true, stats: { discovered: 1 } });
-    useActionMock.mockReturnValue(configureSource);
+    const previewSource = vi.fn().mockResolvedValue({
+      ok: true,
+      repo: "NVIDIA/skills",
+      defaultBranch: "main",
+      commit: "a".repeat(40),
+      manifestStatus: "ok",
+      skills: [
+        {
+          slug: "aiq-deploy",
+          displayName: "AIQ Deploy",
+          path: "skills/aiq-deploy",
+          contentHash: "hash-aiq-deploy",
+        },
+      ],
+    });
+    useActionMock.mockImplementation((action) =>
+      getFunctionName(action) === "githubSkillSync:previewPublicGitHubSkillSource"
+        ? previewSource
+        : configureSource,
+    );
     mockSignedInSettings({
       search: { view: "githubSources" },
       memberships: [personalMembership, orgMembership],
@@ -363,9 +382,200 @@ describe("Settings", () => {
       expect(configureSource).toHaveBeenCalledWith({
         ownerPublisherId: "publisher_openclaw",
         repo: "NVIDIA/skills",
+        selectedSkillPaths: ["skills/aiq-deploy"],
       });
     });
     expect(toast.success).toHaveBeenCalledWith(expect.stringMatching(/GitHub source synced/i));
+  });
+
+  it("keeps a legacy single-skill source in all-skills mode on resync", async () => {
+    const configureSource = vi.fn().mockResolvedValue({ ok: true, stats: { discovered: 1 } });
+    const previewSource = vi.fn().mockResolvedValue({
+      ok: true,
+      repo: "vibethon/skills",
+      defaultBranch: "main",
+      commit: "a".repeat(40),
+      manifestStatus: "ok",
+      existingSourceId: "githubSkillSources:vibethon",
+      skills: [
+        {
+          slug: "vibethon",
+          displayName: "Vibethon",
+          path: "skills/vibethon",
+          contentHash: "hash-vibethon",
+        },
+      ],
+    });
+    useActionMock.mockImplementation((action) =>
+      getFunctionName(action) === "githubSkillSync:previewPublicGitHubSkillSource"
+        ? previewSource
+        : configureSource,
+    );
+    mockSignedInSettings({
+      search: { view: "githubSources" },
+      memberships: [personalMembership, orgMembership],
+    });
+
+    render(<Settings />);
+    fireEvent.change(screen.getByLabelText("GitHub repo URL"), {
+      target: { value: "https://github.com/vibethon/skills" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Add repo/i }));
+
+    await waitFor(() => {
+      expect(configureSource).toHaveBeenCalledWith({
+        ownerPublisherId: "publisher_openclaw",
+        repo: "vibethon/skills",
+      });
+    });
+  });
+
+  it("does not replace a missing saved selection with an unrelated skill", async () => {
+    const configureSource = vi.fn().mockResolvedValue({ ok: true, stats: { discovered: 1 } });
+    const previewSource = vi.fn().mockResolvedValue({
+      ok: true,
+      repo: "vibethon/skills",
+      defaultBranch: "main",
+      commit: "a".repeat(40),
+      manifestStatus: "ok",
+      existingSourceId: "githubSkillSources:vibethon",
+      selectedSkillPaths: ["skills/vibethon"],
+      skills: [
+        {
+          slug: "bundled",
+          displayName: "Bundled",
+          path: "SKILL.md",
+          contentHash: "hash-bundled",
+        },
+      ],
+    });
+    useActionMock.mockImplementation((action) =>
+      getFunctionName(action) === "githubSkillSync:previewPublicGitHubSkillSource"
+        ? previewSource
+        : configureSource,
+    );
+    mockSignedInSettings({
+      search: { view: "githubSources" },
+      memberships: [personalMembership, orgMembership],
+    });
+
+    render(<Settings />);
+    fireEvent.change(screen.getByLabelText("GitHub repo URL"), {
+      target: { value: "https://github.com/vibethon/skills" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Add repo/i }));
+
+    expect(await screen.findByRole("heading", { name: "Select skills to sync" })).toBeTruthy();
+    expect(configureSource).not.toHaveBeenCalled();
+  });
+
+  it("asks which skills to sync when a repo contains multiple candidates", async () => {
+    const configureSource = vi.fn().mockResolvedValue({ ok: true, stats: { discovered: 1 } });
+    const previewSource = vi.fn().mockResolvedValue({
+      ok: true,
+      repo: "vibethon/skills",
+      defaultBranch: "main",
+      commit: "a".repeat(40),
+      manifestStatus: "missing",
+      skills: [
+        {
+          slug: "bundled",
+          displayName: "Bundled",
+          path: "SKILL.md",
+          contentHash: "hash-bundled",
+        },
+        {
+          slug: "vibethon",
+          displayName: "Vibethon",
+          path: "skills/vibethon",
+          contentHash: "hash-vibethon",
+        },
+      ],
+    });
+    useActionMock.mockImplementation((action) =>
+      getFunctionName(action) === "githubSkillSync:previewPublicGitHubSkillSource"
+        ? previewSource
+        : configureSource,
+    );
+    mockSignedInSettings({
+      search: { view: "githubSources" },
+      memberships: [personalMembership, orgMembership],
+    });
+
+    render(<Settings />);
+    fireEvent.change(screen.getByLabelText("GitHub repo URL"), {
+      target: { value: "https://github.com/vibethon/skills" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Add repo/i }));
+
+    expect(await screen.findByRole("heading", { name: "Select skills to sync" })).toBeTruthy();
+    expect(configureSource).not.toHaveBeenCalled();
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    fireEvent.click(checkboxes[1] as HTMLElement);
+    fireEvent.click(screen.getByRole("button", { name: "Sync selected skills" }));
+
+    await waitFor(() => {
+      expect(configureSource).toHaveBeenCalledWith({
+        ownerPublisherId: "publisher_openclaw",
+        repo: "vibethon/skills",
+        selectedSkillPaths: ["skills/vibethon"],
+      });
+    });
+  });
+
+  it("preserves legacy all-skill selection when resyncing an existing source", async () => {
+    const configureSource = vi.fn().mockResolvedValue({ ok: true, stats: { discovered: 2 } });
+    const previewSource = vi.fn().mockResolvedValue({
+      ok: true,
+      repo: "vibethon/skills",
+      defaultBranch: "main",
+      commit: "a".repeat(40),
+      manifestStatus: "missing",
+      existingSourceId: "githubSkillSources:vibethon",
+      skills: [
+        {
+          slug: "bundled",
+          displayName: "Bundled",
+          path: "SKILL.md",
+          contentHash: "hash-bundled",
+        },
+        {
+          slug: "vibethon",
+          displayName: "Vibethon",
+          path: "skills/vibethon",
+          contentHash: "hash-vibethon",
+        },
+      ],
+    });
+    useActionMock.mockImplementation((action) =>
+      getFunctionName(action) === "githubSkillSync:previewPublicGitHubSkillSource"
+        ? previewSource
+        : configureSource,
+    );
+    mockSignedInSettings({
+      search: { view: "githubSources" },
+      memberships: [personalMembership, orgMembership],
+    });
+
+    render(<Settings />);
+    fireEvent.change(screen.getByLabelText("GitHub repo URL"), {
+      target: { value: "https://github.com/vibethon/skills" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Add repo/i }));
+
+    expect(await screen.findByRole("heading", { name: "Select skills to sync" })).toBeTruthy();
+    expect(
+      screen.getAllByRole("checkbox").every((checkbox) => (checkbox as HTMLInputElement).checked),
+    ).toBe(true);
+    fireEvent.click(screen.getByRole("button", { name: "Sync selected skills" }));
+
+    await waitFor(() => {
+      expect(configureSource).toHaveBeenCalledWith({
+        ownerPublisherId: "publisher_openclaw",
+        repo: "vibethon/skills",
+      });
+    });
   });
 
   it("shows synced repos as separate cards and lets owners delete a source", async () => {

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -173,6 +173,25 @@ type GitHubSkillSource = {
   updatedAt: number;
 };
 
+type GitHubSkillSourcePreview = {
+  ok: true;
+  ownerPublisherId: Id<"publishers">;
+  repo: string;
+  defaultBranch: string;
+  commit: string;
+  manifestStatus: "ok" | "missing" | "invalid" | "failed";
+  existingSourceId?: Id<"githubSkillSources">;
+  selectedSkillPaths?: string[];
+  skills: Array<{
+    slug: string;
+    displayName: string;
+    summary?: string;
+    path: string;
+    skillCardMarkdownPath?: string;
+    contentHash: string;
+  }>;
+};
+
 const navigationGroups: Array<{
   items: Array<{
     view: SettingsView;
@@ -248,6 +267,7 @@ export function Settings() {
   const updateOrgProfile = useMutation(api.publishers.updateProfile);
   const addOrgMember = useMutation(api.publishers.addMember);
   const removeOrgMember = useMutation(api.publishers.removeMember);
+  const previewGitHubSource = useAction(api.githubSkillSync.previewPublicGitHubSkillSource);
   const configureGitHubSource = useAction(api.githubSkillSync.configurePublicGitHubSkillSource);
   const deleteGitHubSource = useMutation(api.githubSkillSources.deleteForPublisher);
   const [displayName, setDisplayName] = useState("");
@@ -270,6 +290,9 @@ export function Settings() {
   const [selectedSourcePublisherId, setSelectedSourcePublisherId] = useState("");
   const [githubRepo, setGithubRepo] = useState("");
   const [isSyncingSource, setIsSyncingSource] = useState(false);
+  const [sourcePreview, setSourcePreview] = useState<GitHubSkillSourcePreview | null>(null);
+  const [selectedSkillPaths, setSelectedSkillPaths] = useState<string[]>([]);
+  const [isSelectingSourceSkills, setIsSelectingSourceSkills] = useState(false);
   const [deletingSourceId, setDeletingSourceId] = useState<Id<"githubSkillSources"> | null>(null);
   const [sourceToDelete, setSourceToDelete] = useState<GitHubSkillSource | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -537,11 +560,65 @@ export function Settings() {
     if (!repo) return;
     setIsSyncingSource(true);
     try {
-      const result = await configureGitHubSource({
+      const previewResult = (await previewGitHubSource({
         ownerPublisherId: selectedSourcePublisher.publisher._id,
         repo,
+      })) as Omit<GitHubSkillSourcePreview, "ownerPublisherId">;
+      const preview: GitHubSkillSourcePreview = {
+        ...previewResult,
+        ownerPublisherId: selectedSourcePublisher.publisher._id,
+      };
+      const existingSelection = new Set(preview.selectedSkillPaths ?? []);
+      const currentSkillPaths = new Set(preview.skills.map((skill) => skill.path));
+      const hasMissingExistingSelection =
+        preview.selectedSkillPaths?.some((path) => !currentSkillPaths.has(path)) ?? false;
+      const preserveLegacyAllSkills =
+        preview.existingSourceId !== undefined && preview.selectedSkillPaths === undefined;
+      const initialSelection = preview.skills
+        .filter((skill) => preserveLegacyAllSkills || existingSelection.has(skill.path))
+        .map((skill) => skill.path);
+      if (preview.skills.length > 1 || hasMissingExistingSelection) {
+        setSourcePreview(preview);
+        setSelectedSkillPaths(initialSelection);
+        setIsSelectingSourceSkills(true);
+      } else {
+        const omitSelectedSkillPaths =
+          preview.existingSourceId !== undefined && preview.selectedSkillPaths === undefined;
+        const result = await configureGitHubSource({
+          ownerPublisherId: selectedSourcePublisher.publisher._id,
+          repo: preview.repo,
+          ...(omitSelectedSkillPaths
+            ? {}
+            : { selectedSkillPaths: [preview.skills[0]?.path as string] }),
+        });
+        setGithubRepo("");
+        toast.success(formatGitHubSourceSyncToast(result?.stats));
+      }
+    } catch (error) {
+      toast.error(getUserFacingConvexError(error, "GitHub source could not be synced."));
+    } finally {
+      setIsSyncingSource(false);
+    }
+  }
+
+  async function onConfirmGitHubSourceSkills() {
+    if (!sourcePreview || selectedSkillPaths.length === 0) return;
+    setIsSyncingSource(true);
+    try {
+      const preserveLegacyAllSkills =
+        sourcePreview.existingSourceId !== undefined &&
+        sourcePreview.selectedSkillPaths === undefined &&
+        selectedSkillPaths.length === sourcePreview.skills.length &&
+        sourcePreview.skills.every((skill) => selectedSkillPaths.includes(skill.path));
+      const result = await configureGitHubSource({
+        ownerPublisherId: sourcePreview.ownerPublisherId,
+        repo: sourcePreview.repo,
+        ...(preserveLegacyAllSkills ? {} : { selectedSkillPaths }),
       });
       setGithubRepo("");
+      setSourcePreview(null);
+      setSelectedSkillPaths([]);
+      setIsSelectingSourceSkills(false);
       toast.success(formatGitHubSourceSyncToast(result?.stats));
     } catch (error) {
       toast.error(getUserFacingConvexError(error, "GitHub source could not be synced."));
@@ -1342,6 +1419,22 @@ export function Settings() {
                   </div>
                 </SettingsBlock>
 
+                <GitHubSourceSkillSelectionDialog
+                  preview={sourcePreview}
+                  selectedPaths={selectedSkillPaths}
+                  isOpen={isSelectingSourceSkills}
+                  isSyncing={isSyncingSource}
+                  onOpenChange={(open) => {
+                    setIsSelectingSourceSkills(open);
+                    if (!open) {
+                      setSourcePreview(null);
+                      setSelectedSkillPaths([]);
+                    }
+                  }}
+                  onSelectedPathsChange={setSelectedSkillPaths}
+                  onConfirm={() => void onConfirmGitHubSourceSkills()}
+                />
+
                 <GitHubSourceList
                   sources={githubSources}
                   deletingSourceId={deletingSourceId}
@@ -2008,6 +2101,94 @@ function GitHubSourceDeleteDialog({
           >
             <Trash2 size={16} />
             Delete synced repo &amp; skills
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function GitHubSourceSkillSelectionDialog({
+  preview,
+  selectedPaths,
+  isOpen,
+  isSyncing,
+  onOpenChange,
+  onSelectedPathsChange,
+  onConfirm,
+}: {
+  preview: GitHubSkillSourcePreview | null;
+  selectedPaths: string[];
+  isOpen: boolean;
+  isSyncing: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelectedPathsChange: (paths: string[]) => void;
+  onConfirm: () => void;
+}) {
+  const selected = new Set(selectedPaths);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="flex w-[min(100%,640px)] flex-col gap-4">
+        <DialogHeader>
+          <DialogTitle>Select skills to sync</DialogTitle>
+          <DialogDescription>
+            {preview?.repo
+              ? `Choose which skills from ${preview.repo} should be published for this source.`
+              : "Choose which skills should be published for this source."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-80 overflow-auto rounded-[var(--radius-sm)] border border-[color:var(--line)]">
+          {preview?.skills.map((skill) => {
+            const checked = selected.has(skill.path);
+            return (
+              <label
+                key={skill.path}
+                className="flex cursor-pointer items-start gap-3 border-b border-[color:var(--line)] px-3 py-3 last:border-b-0 hover:bg-[color:var(--surface-muted)]"
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() => {
+                    const next = new Set(selected);
+                    if (checked) next.delete(skill.path);
+                    else next.add(skill.path);
+                    onSelectedPathsChange([...next].sort((a, b) => a.localeCompare(b)));
+                  }}
+                  className="mt-1 h-4 w-4 accent-[var(--accent)]"
+                />
+                <span className="min-w-0">
+                  <span className="block text-sm font-semibold text-[color:var(--ink)]">
+                    {skill.displayName}
+                  </span>
+                  <span className="block truncate text-xs text-[color:var(--ink-soft)]">
+                    {skill.path}
+                  </span>
+                  {skill.summary ? (
+                    <span className="mt-1 block text-xs leading-5 text-[color:var(--ink-soft)]">
+                      {skill.summary}
+                    </span>
+                  ) : null}
+                </span>
+              </label>
+            );
+          })}
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" type="button" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            type="button"
+            disabled={selectedPaths.length === 0 || isSyncing}
+            loading={isSyncing}
+            onClick={onConfirm}
+          >
+            <Plus size={16} />
+            Sync selected skills
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## Summary
- persist explicit GitHub skill selections on each source
- preview multi-skill repos and require an explicit selection before syncing
- preserve legacy all-skills sources and prevent stale selections from being replaced by unrelated skills
- fix the search route test router mock after adding the `Link` action

## Root cause
GitHub source setup previously synced every detected skill in a repository and stored no selection state. After deletion and re-add, discovery revived every candidate, including bundled skills, without asking the owner which skill to keep.

## Validation
- `bun run ci:unit`
- `bun run ci:static`
- `bunx tsc --noEmit --incremental false --pretty false`
- focused GitHub sync/settings tests
- autoreview clean