### PR TITLE
fix: preserve publisher across add flow

### DIFF
--- a/src/__tests__/import.route.test.tsx
+++ b/src/__tests__/import.route.test.tsx
@@ -7,6 +7,7 @@ vi.mock("@tanstack/react-router", () => ({
   createFileRoute: () => (config: { component: unknown }) => config,
   Link: (props: { children: ReactNode }) => <a href="/">{props.children}</a>,
   useNavigate: () => vi.fn(),
+  useSearch: () => ({ ownerHandle: undefined }),
 }));
 
 const previewCandidate = vi.fn();

--- a/src/components/HomeBringSkillsSection.tsx
+++ b/src/components/HomeBringSkillsSection.tsx
@@ -224,7 +224,7 @@ export function HomeBringSkillsSection() {
         </div>
 
         <div className="home-v2-byos-foot">
-          <Link to="/import" className="home-v2-byos-import">
+          <Link to="/import" search={{ ownerHandle: undefined }} className="home-v2-byos-import">
             <GitHubGlyph />
             or import from your GitHub
             <ArrowRight size={15} aria-hidden="true" />

--- a/src/routes/add.tsx
+++ b/src/routes/add.tsx
@@ -146,7 +146,7 @@ export function AddPage() {
               title="Git sync"
               description="Keep a public GitHub skills repo connected and sync changes automatically."
               to="/settings"
-              search={{ view: "githubSources" }}
+              search={{ view: "githubSources", ownerHandle: ownerHandle || undefined }}
               action="Configure sync"
             />
           ) : null}
@@ -156,6 +156,7 @@ export function AddPage() {
               title="Import from GitHub"
               description="Bring one or more skills over from a public repository, then review before publishing."
               to="/import"
+              search={{ ownerHandle: ownerHandle || undefined }}
               action="Import skills"
             />
           ) : null}

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -206,7 +206,7 @@ export function Dashboard() {
           {publisherSelector}
           <div className="flex flex-wrap gap-3 justify-center">
             <Button asChild variant="primary">
-              <Link to="/import">
+              <Link to="/import" search={{ ownerHandle: undefined }}>
                 <Download className="h-4 w-4" aria-hidden="true" />
                 Import from GitHub
               </Link>
@@ -253,7 +253,7 @@ export function Dashboard() {
             <h2 className="dashboard-collection-title">Skills</h2>
             <div className="flex flex-wrap gap-2">
               <Button asChild size="sm" variant="outline" className="dashboard-section-action">
-                <Link to="/import">
+                <Link to="/import" search={{ ownerHandle: undefined }}>
                   <Download className="h-4 w-4" aria-hidden="true" />
                   Import from GitHub
                 </Link>

--- a/src/routes/import.tsx
+++ b/src/routes/import.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useSearch } from "@tanstack/react-router";
 import { inferSkillCategories, resolveSkillCategories } from "clawhub-schema";
 import {
   PLATFORM_SKILL_LICENSE,
@@ -50,6 +50,9 @@ import { formatBytes } from "../lib/uploadUtils";
 import { useAuthStatus } from "../lib/useAuthStatus";
 
 export const Route = createFileRoute("/import")({
+  validateSearch: (search: Record<string, unknown>) => ({
+    ownerHandle: typeof search.ownerHandle === "string" ? search.ownerHandle : undefined,
+  }),
   head: () => {
     const siteUrl = getClawHubSiteUrl();
     const title = `Import from GitHub | ${SITE_NAME}`;
@@ -182,6 +185,7 @@ const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 export function ImportGitHub() {
   const { isAuthenticated, isLoading, me } = useAuthStatus();
+  const { ownerHandle: requestedOwnerHandle } = useSearch({ from: "/import" });
   const listOwnedRepos = useAction(api.githubImport.listOwnedPublicGitHubRepos);
   const previewCandidate = useAction(api.githubImport.previewGitHubImportCandidate);
   const importSkill = useAction(api.githubImport.importGitHubSkill);
@@ -206,7 +210,7 @@ export function ImportGitHub() {
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isBusy, setIsBusy] = useState(false);
-  const ownerHandle = me?.handle?.trim() || "";
+  const ownerHandle = requestedOwnerHandle?.trim() || me?.handle?.trim() || "";
   const repoLoadSeq = useRef(0);
   const reposRef = useRef<OwnedGitHubRepo[]>([]);
 

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -78,8 +78,14 @@ function isSettingsView(value: unknown): value is SettingsView {
 }
 
 export const Route = createFileRoute("/settings")({
-  validateSearch: (search: Record<string, unknown>): { view?: SettingsView } => ({
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): {
+    view?: SettingsView;
+    ownerHandle?: string;
+  } => ({
     view: isSettingsView(search.view) ? search.view : undefined,
+    ownerHandle: typeof search.ownerHandle === "string" ? search.ownerHandle : undefined,
   }),
   component: Settings,
 });
@@ -277,7 +283,7 @@ export function Settings() {
   const [createOrgDialogOpen, setCreateOrgDialogOpen] = useState(false);
   const [addMemberDialogOpen, setAddMemberDialogOpen] = useState(false);
   const [revokeTokenId, setRevokeTokenId] = useState<Id<"apiTokens"> | null>(null);
-  const { activeView, navigateToView } = useActiveSettingsView();
+  const { activeView, navigateToView, ownerHandle: requestedOwnerHandle } = useActiveSettingsView();
   const orgs = (publisherMemberships ?? []).filter((entry) => entry.publisher.kind === "org");
   const manageablePublishers = (publisherMemberships ?? []).filter(
     (entry) => entry.role !== "publisher",
@@ -349,6 +355,15 @@ export function Settings() {
       setSelectedSourcePublisherId("");
       return;
     }
+    const requestedPublisher = requestedOwnerHandle
+      ? officialGitHubSourcePublishers.find(
+          (entry) => entry.publisher.handle === requestedOwnerHandle,
+        )
+      : null;
+    if (requestedPublisher) {
+      setSelectedSourcePublisherId(requestedPublisher.publisher._id);
+      return;
+    }
     if (
       selectedSourcePublisherId &&
       officialGitHubSourcePublishers.some(
@@ -358,7 +373,7 @@ export function Settings() {
       return;
     }
     setSelectedSourcePublisherId(officialGitHubSourcePublishers[0]?.publisher._id ?? "");
-  }, [officialGitHubSourcePublishers, selectedSourcePublisherId]);
+  }, [officialGitHubSourcePublishers, requestedOwnerHandle, selectedSourcePublisherId]);
 
   useEffect(() => {
     if (!selectedOrg) {
@@ -2463,7 +2478,11 @@ function useActiveSettingsView() {
     void navigate({ search: { view } });
   };
 
-  return { activeView, navigateToView };
+  return {
+    activeView,
+    navigateToView,
+    ownerHandle: typeof search.ownerHandle === "string" ? search.ownerHandle : undefined,
+  };
 }
 
 function formatShortDate(value: number) {

--- a/src/routes/skills/publish.tsx
+++ b/src/routes/skills/publish.tsx
@@ -798,7 +798,7 @@ export function Upload() {
           </div>
           <div className="flex flex-wrap items-center gap-2">
             <Button asChild variant="outline" size="sm" className="w-fit">
-              <Link to="/import">
+              <Link to="/import" search={{ ownerHandle: undefined }}>
                 <GitHubLogo className="h-3.5 w-3.5" />
                 Import from GitHub
               </Link>


### PR DESCRIPTION
## Summary
- carry the selected publisher into GitHub sync and GitHub import
- make settings select the requested official publisher on arrival
- keep existing import links type-safe with the new search parameter

## Verification
- `bunx tsc --noEmit`
- `bun run lint`
- `bun run format:check -- src/routes/add.tsx src/routes/settings.tsx src/routes/import.tsx src/routes/dashboard.tsx src/routes/skills/publish.tsx src/components/HomeBringSkillsSection.tsx src/__tests__/import.route.test.tsx`
- `bunx vitest run src/__tests__/import.route.test.tsx src/routes/-settings.test.tsx src/__tests__/skills-publish-route.test.tsx`
- `bun run build`