### PR TITLE
fix(ui): mark plugin SkillSpector as not applicable

### DIFF
--- a/src/components/SecurityAuditPage.tsx
+++ b/src/components/SecurityAuditPage.tsx
@@ -65,6 +65,7 @@ type SecurityAuditPageProps = {
   vtAnalysis?: VtAnalysis | null;
   llmAnalysis?: LlmAnalysis | null;
   skillSpectorAnalysis?: SkillSpectorAnalysis | null;
+  skillSpectorApplicable?: boolean;
   staticScan?: StaticScan | null;
   source?: Record<string, unknown> | null;
   canManageArtifact?: boolean;
@@ -536,6 +537,16 @@ function VirusTotalSection(props: SecurityAuditPageProps) {
 }
 
 function SkillSpectorSection(props: SecurityAuditPageProps) {
+  if (props.skillSpectorApplicable === false) {
+    return (
+      <div className="security-report-panel-body security-report-panel-body-findings">
+        <div className="security-report-overview-body">
+          <p>SkillSpector was not run because this plugin release contains no bundled skills.</p>
+        </div>
+      </div>
+    );
+  }
+
   const analysis = props.skillSpectorAnalysis ?? null;
   const overviewCopy = getSkillSpectorOverviewCopy(analysis);
   const contentSnippets = useSkillSpectorContentSnippets(

--- a/src/components/SkillSecurityScanResults.test.tsx
+++ b/src/components/SkillSecurityScanResults.test.tsx
@@ -780,6 +780,28 @@ describe("SecurityScanResults static guidance", () => {
     );
   });
 
+  it("does not show SkillSpector as pending for plugins without bundled skills", () => {
+    render(
+      <SecurityAuditPage
+        entity={{
+          kind: "plugin",
+          title: "Matrix",
+          name: "@openclaw/matrix",
+          version: "2026.6.10",
+          detailPath: "/plugins/@openclaw/matrix",
+        }}
+        skillSpectorApplicable={false}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "SkillSpector was not run because this plugin release contains no bundled skills.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText("SkillSpector findings are pending for this release.")).toBeNull();
+  });
+
   it("renders latest audit timestamps deterministically for hydration", () => {
     render(
       <SecurityAuditPage

--- a/src/routes/plugins/$name/security-audit.tsx
+++ b/src/routes/plugins/$name/security-audit.tsx
@@ -162,6 +162,11 @@ export function PluginSecurityAuditPage({
       vtAnalysis={release.vtAnalysis ?? null}
       llmAnalysis={release.llmAnalysis ?? null}
       skillSpectorAnalysis={release.skillSpectorAnalysis ?? null}
+      skillSpectorApplicable={
+        release.pluginManifestSummary
+          ? release.pluginManifestSummary.bundledSkills.length > 0
+          : true
+      }
       staticScan={release.staticScan ?? null}
       canManageArtifact={Boolean(manageContext)}
       onRequestRescan={


### PR DESCRIPTION
## Summary

- pass plugin manifest bundled-skill scope into the security audit page
- show an explicit not-applicable message when a plugin release has no bundled skills
- keep pending behavior for skills, bundled-skill plugins, and legacy releases without manifest scope

This fixes Matrix and similar plugin audit pages showing SkillSpector as pending after the legacy plugin-level result was correctly cleared.

## Validation

- `bunx vitest run src/components/SkillSecurityScanResults.test.tsx`
- `bun run ci:static`
- `bun run ci:unit`
- `bunx tsc --noEmit --pretty false`
- autoreview clean