### PR TITLE
Update creator social image design

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -53,6 +53,7 @@
         "remark-gfm": "4.0.1",
         "resend": "6.14.0",
         "semver": "7.8.5",
+        "sharp": "0.34.5",
         "shiki": "4.2.0",
         "sonner": "2.0.7",
         "tailwind-merge": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "remark-gfm": "4.0.1",
     "resend": "6.14.0",
     "semver": "7.8.5",
+    "sharp": "0.34.5",
     "shiki": "4.2.0",
     "sonner": "2.0.7",
     "tailwind-merge": "3.6.0",

--- a/server/og/fetchPublisherOgMeta.test.ts
+++ b/server/og/fetchPublisherOgMeta.test.ts
@@ -36,6 +36,16 @@ describe("fetchPublisherOgMeta", () => {
       displayName: "OpenClaw",
       bio: "Build with claws.",
       image: null,
+      official: true,
+      affiliations: [
+        {
+          publisher: {
+            handle: "github",
+            displayName: "GitHub",
+            image: "https://example.com/github.png",
+          },
+        },
+      ],
       stats: { downloads: 99, installs: 1200 },
     });
 
@@ -47,5 +57,9 @@ describe("fetchPublisherOgMeta", () => {
       handle: "openclaw",
     });
     expect(meta?.stats.downloads).toBe(99);
+    expect(meta?.official).toBe(true);
+    expect(meta?.affiliations).toEqual([
+      { handle: "github", displayName: "GitHub", image: "https://example.com/github.png" },
+    ]);
   });
 });

--- a/server/og/fetchPublisherOgMeta.ts
+++ b/server/og/fetchPublisherOgMeta.ts
@@ -4,9 +4,15 @@ import { api } from "../../convex/_generated/api";
 export type PublisherOgMeta = {
   handle: string | null;
   kind: "user" | "org";
+  official: boolean;
   displayName: string | null;
   bio: string | null;
   image: string | null;
+  affiliations: Array<{
+    handle: string;
+    displayName: string;
+    image: string | null;
+  }>;
   stats: {
     downloads: number;
   };
@@ -15,14 +21,24 @@ export type PublisherOgMeta = {
 type PublisherProfileResult = {
   handle?: string | null;
   kind?: "user" | "org";
+  official?: boolean;
   displayName?: string | null;
   bio?: string | null;
   image?: string | null;
+  affiliations?: Array<{
+    publisher?: {
+      handle?: string | null;
+      displayName?: string | null;
+      image?: string | null;
+    } | null;
+  }>;
   stats?: {
     downloads?: number;
     installs?: number;
   };
 } | null;
+
+type PublisherProfileAffiliations = NonNullable<PublisherProfileResult>["affiliations"];
 
 export async function fetchPublisherOgMeta(
   handle: string,
@@ -37,9 +53,11 @@ export async function fetchPublisherOgMeta(
     return {
       handle: profile.handle ?? null,
       kind: profile.kind === "org" ? "org" : "user",
+      official: profile.official === true,
       displayName: profile.displayName ?? null,
       bio: profile.bio ?? null,
       image: profile.image ?? null,
+      affiliations: readAffiliations(profile.affiliations),
       stats: {
         downloads: readNumber(profile.stats?.downloads),
       },
@@ -51,4 +69,18 @@ export async function fetchPublisherOgMeta(
 
 function readNumber(value: unknown) {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function readAffiliations(value: PublisherProfileAffiliations) {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => {
+      const handle = item?.publisher?.handle?.trim();
+      const displayName = item?.publisher?.displayName?.trim();
+      if (!handle || !displayName) return null;
+      return { handle, displayName, image: item.publisher?.image ?? null };
+    })
+    .filter((item): item is { handle: string; displayName: string; image: string | null } =>
+      Boolean(item),
+    );
 }

--- a/server/og/normalizeLogoDataUrl.test.ts
+++ b/server/og/normalizeLogoDataUrl.test.ts
@@ -1,0 +1,62 @@
+import sharp from "sharp";
+import { describe, expect, it } from "vitest";
+import { normalizeOgLogoDataUrl } from "./normalizeLogoDataUrl";
+
+async function makeLogoDataUrl(padding: number) {
+  const size = 96;
+  const markSize = size - padding * 2;
+  const buffer = await sharp({
+    create: {
+      width: size,
+      height: size,
+      channels: 4,
+      background: { r: 0, g: 0, b: 0, alpha: 0 },
+    },
+  })
+    .composite([
+      {
+        input: Buffer.from(
+          `<svg width="${markSize}" height="${markSize}" viewBox="0 0 ${markSize} ${markSize}" xmlns="http://www.w3.org/2000/svg"><circle cx="${markSize / 2}" cy="${markSize / 2}" r="${markSize / 2}" fill="#D4453A"/></svg>`,
+        ),
+        left: padding,
+        top: padding,
+      },
+    ])
+    .png()
+    .toBuffer();
+  return `data:image/png;base64,${buffer.toString("base64")}`;
+}
+
+async function visibleAlphaBounds(dataUrl: string) {
+  const buffer = Buffer.from(dataUrl.split(",")[1] ?? "", "base64");
+  const image = sharp(buffer).ensureAlpha();
+  const metadata = await image.metadata();
+  const raw = await image.raw().toBuffer();
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxX = 0;
+  let maxY = 0;
+  for (let y = 0; y < (metadata.height ?? 0); y += 1) {
+    for (let x = 0; x < (metadata.width ?? 0); x += 1) {
+      const alpha = raw[(y * (metadata.width ?? 0) + x) * 4 + 3] ?? 0;
+      if (alpha === 0) continue;
+      minX = Math.min(minX, x);
+      minY = Math.min(minY, y);
+      maxX = Math.max(maxX, x);
+      maxY = Math.max(maxY, y);
+    }
+  }
+  return { width: maxX - minX + 1, height: maxY - minY + 1 };
+}
+
+describe("normalizeOgLogoDataUrl", () => {
+  it("normalizes logos with different transparent padding to the same visible size", async () => {
+    const paddedLogo = await normalizeOgLogoDataUrl(await makeLogoDataUrl(24));
+    const tightLogo = await normalizeOgLogoDataUrl(await makeLogoDataUrl(4));
+    expect(paddedLogo).toMatch(/^data:image\/png;base64,/);
+    expect(tightLogo).toMatch(/^data:image\/png;base64,/);
+
+    await expect(visibleAlphaBounds(paddedLogo ?? "")).resolves.toEqual({ width: 48, height: 48 });
+    await expect(visibleAlphaBounds(tightLogo ?? "")).resolves.toEqual({ width: 48, height: 48 });
+  });
+});

--- a/server/og/normalizeLogoDataUrl.ts
+++ b/server/og/normalizeLogoDataUrl.ts
@@ -1,0 +1,34 @@
+import sharp from "sharp";
+
+const NORMALIZED_LOGO_SIZE = 48;
+
+function readDataUrl(dataUrl: string) {
+  const match = /^data:([^;,]+);base64,(.+)$/s.exec(dataUrl);
+  if (!match) return null;
+  return {
+    mimeType: match[1],
+    buffer: Buffer.from(match[2], "base64"),
+  };
+}
+
+export async function normalizeOgLogoDataUrl(dataUrl: string | null | undefined) {
+  if (!dataUrl) return null;
+  const parsed = readDataUrl(dataUrl);
+  if (!parsed || !parsed.mimeType.startsWith("image/")) return dataUrl;
+
+  try {
+    const normalized = await sharp(parsed.buffer)
+      .ensureAlpha()
+      .trim({ threshold: 8 })
+      .resize(NORMALIZED_LOGO_SIZE, NORMALIZED_LOGO_SIZE, {
+        fit: "contain",
+        background: { r: 0, g: 0, b: 0, alpha: 0 },
+        withoutEnlargement: false,
+      })
+      .png()
+      .toBuffer();
+    return `data:image/png;base64,${normalized.toString("base64")}`;
+  } catch {
+    return dataUrl;
+  }
+}

--- a/server/og/ogAssets.test.ts
+++ b/server/og/ogAssets.test.ts
@@ -61,6 +61,26 @@ describe("ogAssets", () => {
     expect(String(readFileMock.mock.calls[1]?.[0])).toContain("public/clawd-logo.png");
   });
 
+  it("loads the fixed ClawHub logo from clawd-logo.png", async () => {
+    readFileMock.mockImplementation(async (input: unknown) => {
+      const path = String(input);
+      if (path.includes("public/clawd-logo.png")) {
+        return Buffer.from("clawhub-logo");
+      }
+      if (path.endsWith("clawd-logo.png")) {
+        throw new Error("missing root logo");
+      }
+      throw new Error(`unexpected read: ${path}`);
+    });
+
+    const { getClawHubLogoDataUrl } = await import("./ogAssets");
+
+    await expect(getClawHubLogoDataUrl()).resolves.toBe("data:image/png;base64,Y2xhd2h1Yi1sb2dv");
+    expect(readFileMock).toHaveBeenCalledTimes(2);
+    expect(String(readFileMock.mock.calls[0]?.[0])).toContain("clawd-logo.png");
+    expect(String(readFileMock.mock.calls[1]?.[0])).toContain("public/clawd-logo.png");
+  });
+
   it("initializes resvg wasm only once per process", async () => {
     readFileMock.mockImplementation(async (input: unknown) => {
       const path = String(input);
@@ -90,13 +110,14 @@ describe("ogAssets", () => {
     const first = await getFontBuffers();
     const second = await getFontBuffers();
 
-    expect(first).toHaveLength(5);
+    expect(first).toHaveLength(6);
     expect(first[0]).toBeInstanceOf(Uint8Array);
     expect(second).toEqual(first);
-    expect(readFileMock).toHaveBeenCalledTimes(5);
+    expect(readFileMock).toHaveBeenCalledTimes(6);
     expect(readFileMock.mock.calls.map((call) => String(call[0]))).toEqual(
       expect.arrayContaining([
         expect.stringContaining("bricolage-grotesque-latin-800-normal.woff2"),
+        expect.stringContaining("bricolage-grotesque-latin-700-normal.woff2"),
         expect.stringContaining("bricolage-grotesque-latin-500-normal.woff2"),
         expect.stringContaining("ibm-plex-mono-latin-500-normal.woff2"),
         expect.stringContaining("noto-sans-sc-chinese-simplified-800-normal.woff2"),

--- a/server/og/ogAssets.test.ts
+++ b/server/og/ogAssets.test.ts
@@ -125,4 +125,23 @@ describe("ogAssets", () => {
       ]),
     );
   });
+
+  it("loads publisher fonts with Bricolage 700 first", async () => {
+    readFileMock.mockResolvedValue(Buffer.from([9, 8, 7]));
+
+    const { getPublisherFontBuffers } = await import("./ogAssets");
+
+    const first = await getPublisherFontBuffers();
+    const second = await getPublisherFontBuffers();
+
+    expect(first).toHaveLength(6);
+    expect(second).toEqual(first);
+    expect(readFileMock).toHaveBeenCalledTimes(6);
+    expect(String(readFileMock.mock.calls[0]?.[0])).toContain(
+      "bricolage-grotesque-latin-700-normal.woff2",
+    );
+    expect(String(readFileMock.mock.calls[1]?.[0])).toContain(
+      "bricolage-grotesque-latin-800-normal.woff2",
+    );
+  });
 });

--- a/server/og/ogAssets.ts
+++ b/server/og/ogAssets.ts
@@ -10,6 +10,7 @@ type GlobalNitroMain = {
 };
 
 let markDataUrlPromise: Promise<string> | null = null;
+let clawHubLogoDataUrlPromise: Promise<string> | null = null;
 let watermarkDataUrlPromise: Promise<string> | null = null;
 let resvgWasmPromise: Promise<Uint8Array> | null = null;
 let fontBuffersPromise: Promise<Uint8Array[]> | null = null;
@@ -31,48 +32,47 @@ function getServerUrl(pathname: string) {
   return new URL(pathname.replace(/^\//, ""), getServerRootUrl());
 }
 
+async function readFirstDataUrl(candidates: URL[]) {
+  let lastError: unknown = null;
+  for (const url of candidates) {
+    try {
+      const buffer = await readFile(url);
+      return `data:image/png;base64,${buffer.toString("base64")}`;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
+export async function getClawHubLogoDataUrl() {
+  if (!clawHubLogoDataUrlPromise) {
+    clawHubLogoDataUrlPromise = readFirstDataUrl([
+      getServerUrl("clawd-logo.png"),
+      getServerUrl("public/clawd-logo.png"),
+    ]);
+  }
+  return clawHubLogoDataUrlPromise;
+}
+
 export async function getMarkDataUrl() {
   if (!markDataUrlPromise) {
-    markDataUrlPromise = (async () => {
-      const candidates = [
-        getServerUrl("clawd-logo.png"),
-        getServerUrl("public/clawd-logo.png"),
-        getServerUrl("clawd-mark.png"),
-        getServerUrl("public/clawd-mark.png"),
-      ];
-      let lastError: unknown = null;
-      for (const url of candidates) {
-        try {
-          const buffer = await readFile(url);
-          return `data:image/png;base64,${buffer.toString("base64")}`;
-        } catch (error) {
-          lastError = error;
-        }
-      }
-      throw lastError;
-    })();
+    markDataUrlPromise = readFirstDataUrl([
+      getServerUrl("clawd-logo.png"),
+      getServerUrl("public/clawd-logo.png"),
+      getServerUrl("clawd-mark.png"),
+      getServerUrl("public/clawd-mark.png"),
+    ]);
   }
   return markDataUrlPromise;
 }
 
 export async function getWatermarkDataUrl() {
   if (!watermarkDataUrlPromise) {
-    watermarkDataUrlPromise = (async () => {
-      const candidates = [
-        getServerUrl("og-clawhub-watermark.png"),
-        getServerUrl("public/og-clawhub-watermark.png"),
-      ];
-      let lastError: unknown = null;
-      for (const url of candidates) {
-        try {
-          const buffer = await readFile(url);
-          return `data:image/png;base64,${buffer.toString("base64")}`;
-        } catch (error) {
-          lastError = error;
-        }
-      }
-      throw lastError;
-    })();
+    watermarkDataUrlPromise = readFirstDataUrl([
+      getServerUrl("og-clawhub-watermark.png"),
+      getServerUrl("public/og-clawhub-watermark.png"),
+    ]);
   }
   return watermarkDataUrlPromise;
 }
@@ -99,6 +99,11 @@ export async function getFontBuffers() {
       readFile(
         getServerUrl(
           "node_modules/@fontsource/bricolage-grotesque/files/bricolage-grotesque-latin-800-normal.woff2",
+        ),
+      ),
+      readFile(
+        getServerUrl(
+          "node_modules/@fontsource/bricolage-grotesque/files/bricolage-grotesque-latin-700-normal.woff2",
         ),
       ),
       readFile(

--- a/server/og/ogAssets.ts
+++ b/server/og/ogAssets.ts
@@ -17,6 +17,23 @@ let fontBuffersPromise: Promise<Uint8Array[]> | null = null;
 let publisherFontBuffersPromise: Promise<Uint8Array[]> | null = null;
 let resvgInitPromise: Promise<void> | null = null;
 
+const SHARED_FONT_PATHS = [
+  "node_modules/@fontsource/bricolage-grotesque/files/bricolage-grotesque-latin-500-normal.woff2",
+  "node_modules/@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-500-normal.woff2",
+  "node_modules/@fontsource/noto-sans-sc/files/noto-sans-sc-chinese-simplified-800-normal.woff2",
+  "node_modules/@fontsource/noto-sans-sc/files/noto-sans-sc-chinese-simplified-500-normal.woff2",
+];
+const DEFAULT_FONT_PATHS = [
+  "node_modules/@fontsource/bricolage-grotesque/files/bricolage-grotesque-latin-800-normal.woff2",
+  "node_modules/@fontsource/bricolage-grotesque/files/bricolage-grotesque-latin-700-normal.woff2",
+  ...SHARED_FONT_PATHS,
+];
+const PUBLISHER_FONT_PATHS = [
+  "node_modules/@fontsource/bricolage-grotesque/files/bricolage-grotesque-latin-700-normal.woff2",
+  "node_modules/@fontsource/bricolage-grotesque/files/bricolage-grotesque-latin-800-normal.woff2",
+  ...SHARED_FONT_PATHS,
+];
+
 function getServerRootUrl() {
   const nitroMain = (globalThis as unknown as GlobalNitroMain).__nitro_main__;
   if (typeof nitroMain === "string") {
@@ -94,78 +111,22 @@ export async function ensureResvgWasm() {
   await resvgInitPromise;
 }
 
+function readFontBuffers(paths: string[]) {
+  return Promise.all(paths.map((pathname) => readFile(getServerUrl(pathname)))).then((buffers) =>
+    buffers.map((buffer) => new Uint8Array(buffer)),
+  );
+}
+
 export async function getFontBuffers() {
   if (!fontBuffersPromise) {
-    fontBuffersPromise = Promise.all([
-      readFile(
-        getServerUrl(
-          "node_modules/@fontsource/bricolage-grotesque/files/bricolage-grotesque-latin-800-normal.woff2",
-        ),
-      ),
-      readFile(
-        getServerUrl(
-          "node_modules/@fontsource/bricolage-grotesque/files/bricolage-grotesque-latin-700-normal.woff2",
-        ),
-      ),
-      readFile(
-        getServerUrl(
-          "node_modules/@fontsource/bricolage-grotesque/files/bricolage-grotesque-latin-500-normal.woff2",
-        ),
-      ),
-      readFile(
-        getServerUrl(
-          "node_modules/@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-500-normal.woff2",
-        ),
-      ),
-      readFile(
-        getServerUrl(
-          "node_modules/@fontsource/noto-sans-sc/files/noto-sans-sc-chinese-simplified-800-normal.woff2",
-        ),
-      ),
-      readFile(
-        getServerUrl(
-          "node_modules/@fontsource/noto-sans-sc/files/noto-sans-sc-chinese-simplified-500-normal.woff2",
-        ),
-      ),
-    ]).then((buffers) => buffers.map((buffer) => new Uint8Array(buffer)));
+    fontBuffersPromise = readFontBuffers(DEFAULT_FONT_PATHS);
   }
   return fontBuffersPromise;
 }
 
 export async function getPublisherFontBuffers() {
   if (!publisherFontBuffersPromise) {
-    publisherFontBuffersPromise = Promise.all([
-      readFile(
-        getServerUrl(
-          "node_modules/@fontsource/bricolage-grotesque/files/bricolage-grotesque-latin-700-normal.woff2",
-        ),
-      ),
-      readFile(
-        getServerUrl(
-          "node_modules/@fontsource/bricolage-grotesque/files/bricolage-grotesque-latin-800-normal.woff2",
-        ),
-      ),
-      readFile(
-        getServerUrl(
-          "node_modules/@fontsource/bricolage-grotesque/files/bricolage-grotesque-latin-500-normal.woff2",
-        ),
-      ),
-      readFile(
-        getServerUrl(
-          "node_modules/@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-500-normal.woff2",
-        ),
-      ),
-      readFile(
-        getServerUrl(
-          "node_modules/@fontsource/noto-sans-sc/files/noto-sans-sc-chinese-simplified-800-normal.woff2",
-        ),
-      ),
-      readFile(
-        getServerUrl(
-          "node_modules/@fontsource/noto-sans-sc/files/noto-sans-sc-chinese-simplified-500-normal.woff2",
-        ),
-      ),
-    ]).then((buffers) => buffers.map((buffer) => new Uint8Array(buffer)));
+    publisherFontBuffersPromise = readFontBuffers(PUBLISHER_FONT_PATHS);
   }
   return publisherFontBuffersPromise;
 }

--- a/server/og/ogAssets.ts
+++ b/server/og/ogAssets.ts
@@ -14,6 +14,7 @@ let clawHubLogoDataUrlPromise: Promise<string> | null = null;
 let watermarkDataUrlPromise: Promise<string> | null = null;
 let resvgWasmPromise: Promise<Uint8Array> | null = null;
 let fontBuffersPromise: Promise<Uint8Array[]> | null = null;
+let publisherFontBuffersPromise: Promise<Uint8Array[]> | null = null;
 let resvgInitPromise: Promise<void> | null = null;
 
 function getServerRootUrl() {
@@ -129,4 +130,42 @@ export async function getFontBuffers() {
     ]).then((buffers) => buffers.map((buffer) => new Uint8Array(buffer)));
   }
   return fontBuffersPromise;
+}
+
+export async function getPublisherFontBuffers() {
+  if (!publisherFontBuffersPromise) {
+    publisherFontBuffersPromise = Promise.all([
+      readFile(
+        getServerUrl(
+          "node_modules/@fontsource/bricolage-grotesque/files/bricolage-grotesque-latin-700-normal.woff2",
+        ),
+      ),
+      readFile(
+        getServerUrl(
+          "node_modules/@fontsource/bricolage-grotesque/files/bricolage-grotesque-latin-800-normal.woff2",
+        ),
+      ),
+      readFile(
+        getServerUrl(
+          "node_modules/@fontsource/bricolage-grotesque/files/bricolage-grotesque-latin-500-normal.woff2",
+        ),
+      ),
+      readFile(
+        getServerUrl(
+          "node_modules/@fontsource/ibm-plex-mono/files/ibm-plex-mono-latin-500-normal.woff2",
+        ),
+      ),
+      readFile(
+        getServerUrl(
+          "node_modules/@fontsource/noto-sans-sc/files/noto-sans-sc-chinese-simplified-800-normal.woff2",
+        ),
+      ),
+      readFile(
+        getServerUrl(
+          "node_modules/@fontsource/noto-sans-sc/files/noto-sans-sc-chinese-simplified-500-normal.woff2",
+        ),
+      ),
+    ]).then((buffers) => buffers.map((buffer) => new Uint8Array(buffer)));
+  }
+  return publisherFontBuffersPromise;
 }

--- a/server/og/publisherOgSvg.test.ts
+++ b/server/og/publisherOgSvg.test.ts
@@ -3,14 +3,23 @@ import { buildPublisherOgSvg } from "./publisherOgSvg";
 
 const transparentPixel =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+const clawHubLogoDataUrl = "data:image/png;base64,Y2xhd2h1Yi1sb2dv";
+
+function readOfficialBadgeX(svg: string) {
+  const match = /<svg x="([^"]+)" y="[^"]+" width="42" height="42"/.exec(svg);
+  return match ? Number.parseFloat(match[1]) : null;
+}
+
+function readTitleLastLine(svg: string) {
+  const matches = [...svg.matchAll(/<tspan x="[^"]+" dy="[^"]+">([^<]+)<\/tspan>/g)];
+  return matches.at(-1)?.[1] ?? "";
+}
 
 function buildSvg(overrides: Partial<Parameters<typeof buildPublisherOgSvg>[0]> = {}) {
   return buildPublisherOgSvg({
-    markDataUrl: transparentPixel,
-    watermarkDataUrl: transparentPixel,
+    clawHubLogoDataUrl,
     avatarDataUrl: transparentPixel,
     title: "Matt Van Horn",
-    description: "Publisher @mvanhorn on ClawHub.",
     handleLabel: "@mvanhorn",
     ...overrides,
   });
@@ -28,6 +37,20 @@ describe("buildPublisherOgSvg", () => {
     expect(svg).not.toContain("Organization");
   });
 
+  it("always renders the fixed ClawHub logo next to the ClawHub header text", () => {
+    const svg = buildSvg({
+      avatarDataUrl: "data:image/png;base64,YXZhdGFy",
+      organizationLogos: ["data:image/png;base64,b3Jn"],
+    });
+
+    expect(svg).toContain(
+      `<image href="${clawHubLogoDataUrl}" x="958" y="34" width="44" height="44"`,
+    );
+    expect(svg).toContain(">ClawHub</text>");
+    expect(svg).not.toContain('<image href="data:image/png;base64,YXZhdGFy" x="958" y="34"');
+    expect(svg).not.toContain('<image href="data:image/png;base64,b3Jn" x="958" y="34"');
+  });
+
   it("renders the verified badge when official", () => {
     const svg = buildSvg({ official: true });
     expect(svg).toContain("#60A5FA");
@@ -39,15 +62,73 @@ describe("buildPublisherOgSvg", () => {
   it("keeps the no-organization verified badge on the guide title line without shrinking text", () => {
     const svg = buildSvg({ official: true });
     expect(svg).toContain('font-size="72"');
+    expect(svg).toContain('font-family="Bricolage Grotesque, sans-serif"');
+    expect(svg).toContain('font-weight="700"');
+    expect(svg).toContain('fill="#BB3D34"');
+    expect(svg).toContain('gradientTransform="translate(96 84) rotate(24) scale(440 240)"');
+    expect(svg).toContain('stop-color="#7F1D2D" stop-opacity="0.2"');
+    expect(svg).toContain('stop-color="#6C1B2B" stop-opacity="0"');
+    expect(svg).not.toContain("#D4453A");
     expect(svg).toContain('<tspan x="542" dy="0">Matt Van Horn</tspan>');
-    expect(svg).toContain('<svg x="1040" y="198" width="42" height="42"');
+    expect(svg).toContain('<svg x="1061.33" y="198.24" width="42" height="42"');
   });
 
   it("keeps the organization verified badge on the guide title line", () => {
     const svg = buildSvg({ official: true, organizationLogos: [transparentPixel] });
     expect(svg).toContain('font-size="72"');
     expect(svg).toContain('<tspan x="509" dy="0">Matt Van Horn</tspan>');
-    expect(svg).toContain('<svg x="1007" y="145" width="42" height="42"');
+    expect(svg).toContain('<svg x="1028.33" y="145.24" width="42" height="42"');
+  });
+
+  it("positions the official badge from the current one-line title length", () => {
+    const shortTitleBadgeX = readOfficialBadgeX(buildSvg({ official: true, title: "Matt" }));
+    const normalTitleBadgeX = readOfficialBadgeX(
+      buildSvg({ official: true, organizationLogos: [transparentPixel] }),
+    );
+    const longerTitleBadgeX = readOfficialBadgeX(
+      buildSvg({
+        official: true,
+        title: "Matt Van Horn!",
+        organizationLogos: [transparentPixel],
+      }),
+    );
+
+    expect(shortTitleBadgeX).toBeLessThan(normalTitleBadgeX ?? 0);
+    expect(longerTitleBadgeX).toBeGreaterThan(normalTitleBadgeX ?? 0);
+  });
+
+  it("adds extra badge spacing after truncated title dots", () => {
+    const svg = buildSvg({
+      official: true,
+      title: "Matt Van Horn lalalallalalalalalallallalalalalalalalala",
+      handleLabel: "@mvanhornfgfgfgfgfggfgfgfgfgfgsd",
+      organizationLogos: [transparentPixel],
+    });
+
+    expect(readTitleLastLine(svg)).toMatch(/\.\.\.$/);
+    expect(readOfficialBadgeX(svg)).toBe(1056.18);
+  });
+
+  it("keeps fixed labels anchored when variable publisher text changes", () => {
+    const normalSvg = buildSvg({ official: true });
+    const variableSvg = buildSvg({
+      official: true,
+      title: "Ana",
+      handleLabel: "@ana-tools",
+      stats: [{ label: "Downloads", value: "9.8m" }],
+    });
+
+    for (const stableMarkup of [
+      '<text x="542" y="303"',
+      ">on ClawHub</text>",
+      '<text x="542" y="380"',
+      ">Creator</text>",
+      '<text x="913" y="380"',
+      ">Downloads</text>",
+    ]) {
+      expect(normalSvg).toContain(stableMarkup);
+      expect(variableSvg).toContain(stableMarkup);
+    }
   });
 
   it("renders organization state when affiliations exist", () => {
@@ -97,7 +178,8 @@ describe("buildPublisherOgSvg", () => {
     expect(svg).toContain("Matt Van Horn");
     expect(svg).not.toContain("lalalallalalalalalallallalalalalalalalala</tspan>");
     expect(svg).toContain("#60A5FA");
-    expect(svg).toContain('font-size="46"');
+    expect(svg).toContain('font-size="44"');
+    expect(svg).toContain('font-size="24"');
     expect(svg).toMatch(/@mvanhornfgfgfgfgfgg.*\.\.\./);
     expect(svg).toContain("...");
     expect(svg).not.toContain("…");

--- a/server/og/publisherOgSvg.test.ts
+++ b/server/og/publisherOgSvg.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { buildPublisherOgSvg } from "./publisherOgSvg";
+
+const transparentPixel =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+function buildSvg(overrides: Partial<Parameters<typeof buildPublisherOgSvg>[0]> = {}) {
+  return buildPublisherOgSvg({
+    markDataUrl: transparentPixel,
+    watermarkDataUrl: transparentPixel,
+    avatarDataUrl: transparentPixel,
+    title: "Matt Van Horn",
+    description: "Publisher @mvanhorn on ClawHub.",
+    handleLabel: "@mvanhorn",
+    ...overrides,
+  });
+}
+
+describe("buildPublisherOgSvg", () => {
+  it("renders the no-badge no-organization creator layout", () => {
+    const svg = buildSvg();
+    expect(svg).toContain("Matt Van Horn");
+    expect(svg).toContain("on ClawHub");
+    expect(svg).toContain("Creator");
+    expect(svg).toContain("@mvanhorn");
+    expect(svg).toContain("Downloads");
+    expect(svg).not.toContain("Publisher</text>");
+    expect(svg).not.toContain("Organization");
+  });
+
+  it("renders the verified badge when official", () => {
+    const svg = buildSvg({ official: true });
+    expect(svg).toContain("#60A5FA");
+    expect(svg).toContain('width="42" height="42"');
+    expect(svg).toContain('stroke-width="1.71"');
+    expect(svg).toContain("M3.85 8.62");
+  });
+
+  it("keeps the no-organization verified badge on the guide title line without shrinking text", () => {
+    const svg = buildSvg({ official: true });
+    expect(svg).toContain('font-size="72"');
+    expect(svg).toContain('<tspan x="542" dy="0">Matt Van Horn</tspan>');
+    expect(svg).toContain('<svg x="1040" y="198" width="42" height="42"');
+  });
+
+  it("keeps the organization verified badge on the guide title line", () => {
+    const svg = buildSvg({ official: true, organizationLogos: [transparentPixel] });
+    expect(svg).toContain('font-size="72"');
+    expect(svg).toContain('<tspan x="509" dy="0">Matt Van Horn</tspan>');
+    expect(svg).toContain('<svg x="1007" y="145" width="42" height="42"');
+  });
+
+  it("renders organization state when affiliations exist", () => {
+    const svg = buildSvg({
+      organizationLogos: [transparentPixel, transparentPixel, transparentPixel],
+    });
+    expect(svg).toContain("Organizations");
+    expect(svg).not.toContain("OpenClaw");
+    expect(svg).toContain("orgLogoClip0");
+    expect(svg).toContain("orgLogoClip2");
+    expect(svg).toContain('width="48" height="48" clip-path="url(#orgLogoClip0)"');
+    expect(svg).toContain('width="48" height="48" clip-path="url(#orgLogoClip2)"');
+    expect(svg).not.toContain('rx="8" fill="#F7F1EA"');
+  });
+
+  it("caps rendered organization logos at five", () => {
+    const svg = buildSvg({
+      organizationLogos: [
+        transparentPixel,
+        transparentPixel,
+        transparentPixel,
+        transparentPixel,
+        transparentPixel,
+        transparentPixel,
+      ],
+    });
+    expect(svg).toContain("orgLogoClip4");
+    expect(svg).not.toContain("orgLogoClip5");
+  });
+
+  it("keeps long publisher names left aligned and within the content column", () => {
+    const svg = buildSvg({
+      official: true,
+      title: "Matt Van Horn lalalallalalalalalallallalalalalalalalala",
+      handleLabel: "@mvanhornfgfgfgfgfggfgfgfgfgfgsd",
+      organizationLogos: [
+        transparentPixel,
+        transparentPixel,
+        transparentPixel,
+        transparentPixel,
+        transparentPixel,
+      ],
+      stats: [{ label: "Downloads", value: "41.9k" }],
+    });
+    expect(svg).not.toContain('text-anchor="middle"');
+    expect(svg).toContain('<tspan x="447" dy="0">');
+    expect(svg).toContain("Matt Van Horn");
+    expect(svg).not.toContain("lalalallalalalalalallallalalalalalalalala</tspan>");
+    expect(svg).toContain("#60A5FA");
+    expect(svg).toContain('font-size="46"');
+    expect(svg).toMatch(/@mvanhornfgfgfgfgfgg.*\.\.\./);
+    expect(svg).toContain("...");
+    expect(svg).not.toContain("…");
+    expect(svg).toContain('x="110" y="500" width="48" height="48"');
+    expect(svg).toContain('x="447" y="547"');
+    expect(svg).toContain(">41.9k</text>");
+  });
+});

--- a/server/og/publisherOgSvg.ts
+++ b/server/og/publisherOgSvg.ts
@@ -1,14 +1,12 @@
 import { FONT_SANS } from "./ogAssets";
-import { escapeXml, OPENCLAW_RED, type RegistryOgStat } from "./registryOgSvg";
+import { escapeXml, type RegistryOgStat } from "./registryOgSvg";
 
 export type PublisherOgSvgParams = {
-  markDataUrl: string;
-  watermarkDataUrl?: string | null;
+  clawHubLogoDataUrl: string;
   avatarDataUrl?: string | null;
   avatarShape?: "circle" | "rounded";
   official?: boolean;
   title: string;
-  description: string;
   handleLabel: string;
   organizationLogos?: string[];
   stats?: RegistryOgStat[];
@@ -17,6 +15,19 @@ export type PublisherOgSvgParams = {
 const OFFICIAL_BLUE = "#60A5FA";
 const OFFICIAL_BADGE_SIZE = 42;
 const OFFICIAL_BADGE_STROKE = 1.71;
+const OFFICIAL_BADGE_VISIBLE_LEFT_INSET = (3.85 / 24) * OFFICIAL_BADGE_SIZE;
+const OFFICIAL_BADGE_VISIBLE_CENTER_INSET = (12 / 24) * OFFICIAL_BADGE_SIZE;
+const OFFICIAL_BADGE_VISIBLE_GAP = 32;
+const OFFICIAL_BADGE_TRUNCATED_VISIBLE_GAP = 80;
+const LONG_LAYOUT_BADGE_MAX_X = 1084;
+const NORMAL_TITLE_WIDTH_SCALE = 0.94;
+const TITLE_VISUAL_CENTER_FROM_BASELINE = 0.33;
+const PUBLISHER_RED = "#BB3D34";
+const PUBLISHER_GRADIENT_RED = "#7F1D2D";
+const PUBLISHER_GRADIENT_FADE = "#6C1B2B";
+const PUBLISHER_TEXT_WEIGHT = 700;
+const PUBLISHER_LABEL_SIZE = 24;
+const PUBLISHER_VALUE_SIZE = 44;
 
 function estimateTextWidth(value: string, fontSize: number) {
   return [...value].reduce((width, char) => {
@@ -36,8 +47,38 @@ function estimateBadgeX(
   maxX: number,
   estimateScale: number,
 ) {
-  const estimatedWidth = estimateTextWidth(value, fontSize) * estimateScale;
-  return Math.min(maxX, Math.round(x + estimatedWidth + 19));
+  const estimatedTextEnd = x + estimateTextWidth(value, fontSize) * estimateScale;
+  const visibleGap = value.endsWith("...")
+    ? OFFICIAL_BADGE_TRUNCATED_VISIBLE_GAP
+    : OFFICIAL_BADGE_VISIBLE_GAP;
+  const badgeX = estimatedTextEnd + visibleGap - OFFICIAL_BADGE_VISIBLE_LEFT_INSET;
+  return Math.min(maxX, Math.round(badgeX * 100) / 100);
+}
+
+function normalOfficialTitleMaxWidth(contentWidth: number) {
+  return Math.min(
+    contentWidth,
+    (contentWidth -
+      OFFICIAL_BADGE_SIZE -
+      OFFICIAL_BADGE_VISIBLE_GAP +
+      OFFICIAL_BADGE_VISIBLE_LEFT_INSET) /
+      NORMAL_TITLE_WIDTH_SCALE,
+  );
+}
+
+function longOfficialTitleMaxWidth(titleX: number, contentWidth: number) {
+  return Math.min(
+    contentWidth,
+    LONG_LAYOUT_BADGE_MAX_X +
+      OFFICIAL_BADGE_VISIBLE_LEFT_INSET -
+      OFFICIAL_BADGE_TRUNCATED_VISIBLE_GAP -
+      titleX,
+  );
+}
+
+function estimateBadgeY(titleBaselineY: number, fontSize: number) {
+  const titleVisualCenterY = titleBaselineY - fontSize * TITLE_VISUAL_CENTER_FROM_BASELINE;
+  return Math.round((titleVisualCenterY - OFFICIAL_BADGE_VISIBLE_CENTER_INSET) * 100) / 100;
 }
 
 function officialBadge(x: number, y: number) {
@@ -156,8 +197,8 @@ function statColumn(
   options?: { truncateWithDots?: boolean },
 ) {
   const valueFontSize = options?.truncateWithDots
-    ? 46
-    : fitSingleLineText(value, valueMaxWidth, 46, 18);
+    ? PUBLISHER_VALUE_SIZE
+    : fitSingleLineText(value, valueMaxWidth, PUBLISHER_VALUE_SIZE, 18);
   const displayValue =
     options?.truncateWithDots && estimateTextWidth(value, valueFontSize) > valueMaxWidth
       ? truncateWithDots(value, valueMaxWidth, valueFontSize)
@@ -165,18 +206,18 @@ function statColumn(
   return `<g>
     <text x="${x}" y="${y}"
       fill="#9D9692"
-      font-size="32"
-      font-weight="700"
+      font-size="${PUBLISHER_LABEL_SIZE}"
+      font-weight="${PUBLISHER_TEXT_WEIGHT}"
       font-family="${FONT_SANS}, sans-serif">${escapeXml(label)}</text>
     <text x="${x}" y="${y + 63}"
       fill="#F7F1EA"
       font-size="${valueFontSize}"
-      font-weight="800"
+      font-weight="${PUBLISHER_TEXT_WEIGHT}"
       font-family="${FONT_SANS}, sans-serif">${escapeXml(displayValue)}</text>
   </g>`;
 }
 
-function orgLogoTiles(logos: string[], markDataUrl: string, x: number, yOffset: number) {
+function orgLogoTiles(logos: string[], fallbackLogoDataUrl: string, x: number, yOffset: number) {
   const visibleLogos = logos.slice(0, 5);
   if (visibleLogos.length === 0) return "";
   const y = 459 + yOffset;
@@ -190,15 +231,15 @@ function orgLogoTiles(logos: string[], markDataUrl: string, x: number, yOffset: 
         <clipPath id="${clipId}">
           <rect x="${tileX}" y="${y}" width="${size}" height="${size}" rx="8"/>
         </clipPath>
-        <image href="${logo || markDataUrl}" x="${tileX}" y="${y}" width="${size}" height="${size}" clip-path="url(#${clipId})" preserveAspectRatio="xMidYMid slice"/>
+        <image href="${logo || fallbackLogoDataUrl}" x="${tileX}" y="${y}" width="${size}" height="${size}" clip-path="url(#${clipId})" preserveAspectRatio="xMidYMid slice"/>
       </g>`;
     })
     .join("");
   return `<g>
     <text x="${x}" y="${438 + yOffset}"
-      fill="${OPENCLAW_RED}"
-      font-size="32"
-      font-weight="800"
+      fill="${PUBLISHER_RED}"
+      font-size="${PUBLISHER_LABEL_SIZE}"
+      font-weight="${PUBLISHER_TEXT_WEIGHT}"
       font-family="${FONT_SANS}, sans-serif">Organizations</text>
     ${tiles}
   </g>`;
@@ -206,7 +247,7 @@ function orgLogoTiles(logos: string[], markDataUrl: string, x: number, yOffset: 
 
 export function buildPublisherOgSvg(params: PublisherOgSvgParams) {
   const rawTitle = params.title.trim() || params.handleLabel;
-  const avatar = params.avatarDataUrl || params.markDataUrl;
+  const avatar = params.avatarDataUrl || params.clawHubLogoDataUrl;
   const avatarShape = params.avatarShape ?? "circle";
   const organizationLogos = params.organizationLogos?.filter(Boolean) ?? [];
   const hasOrganizations = organizationLogos.length > 0;
@@ -230,15 +271,12 @@ export function buildPublisherOgSvg(params: PublisherOgSvgParams) {
         downloadsWidth: 190,
       };
   const normalTitleMaxWidth = params.official
-    ? hasOrganizations
-      ? normalLayout.contentWidth - 78
-      : normalLayout.contentWidth
+    ? normalOfficialTitleMaxWidth(normalLayout.contentWidth)
     : normalLayout.contentWidth;
   const titleNeedsOverflow = wrapTextWithoutEllipsis(rawTitle, normalTitleMaxWidth, 72).length > 1;
   const creatorNeedsOverflow =
     estimateTextWidth(params.handleLabel, 46) > normalLayout.creatorWidth;
   const usesLongLayout = titleNeedsOverflow || creatorNeedsOverflow;
-  const contentYOffset = 0;
   const organizationExtraGap = usesLongLayout ? 41 : 0;
   const layout = usesLongLayout
     ? {
@@ -253,10 +291,8 @@ export function buildPublisherOgSvg(params: PublisherOgSvgParams) {
     : normalLayout;
   const titleMaxWidth = params.official
     ? usesLongLayout
-      ? layout.contentWidth
-      : hasOrganizations
-        ? layout.contentWidth - 78
-        : layout.contentWidth
+      ? longOfficialTitleMaxWidth(layout.titleX, layout.contentWidth)
+      : normalOfficialTitleMaxWidth(layout.contentWidth)
     : layout.contentWidth;
   const title = usesLongLayout
     ? fitMultilineTextWithDots(rawTitle, titleMaxWidth, 2, 66)
@@ -274,43 +310,33 @@ export function buildPublisherOgSvg(params: PublisherOgSvgParams) {
     ? 151
     : hasOrganizations
       ? titleLines.length > 1
-        ? 138 + contentYOffset
-        : 190 + contentYOffset
+        ? 138
+        : 190
       : titleLines.length > 1
-        ? 195 + contentYOffset
-        : 243 + contentYOffset;
+        ? 195
+        : 243;
   const lastTitleLine = titleLines.at(-1) ?? rawTitle;
-  const badgeX =
-    params.official && !hasOrganizations && !usesLongLayout && titleLines.length === 1
-      ? 1040
-      : params.official && hasOrganizations && !usesLongLayout && titleLines.length === 1
-        ? 1007
-        : estimateBadgeX(
-            lastTitleLine,
-            layout.titleX,
-            titleFontSize,
-            usesLongLayout ? 1084 : layout.titleX + layout.contentWidth - OFFICIAL_BADGE_SIZE,
-            titleLines.length > 1 ? 1 : 0.875,
-          );
-  const badgeY =
-    params.official && !hasOrganizations && !usesLongLayout && titleLines.length === 1
-      ? 198
-      : params.official && hasOrganizations && !usesLongLayout && titleLines.length === 1
-        ? 145
-        : usesLongLayout
-          ? 143
-          : titleY + (titleLines.length - 1) * titleLineHeight - 45;
+  const badgeX = estimateBadgeX(
+    lastTitleLine,
+    layout.titleX,
+    titleFontSize,
+    usesLongLayout
+      ? LONG_LAYOUT_BADGE_MAX_X
+      : layout.titleX + layout.contentWidth - OFFICIAL_BADGE_SIZE,
+    titleLines.length > 1 ? 1 : NORMAL_TITLE_WIDTH_SCALE,
+  );
   const titleLastBaselineY = titleY + (titleLines.length - 1) * titleLineHeight;
+  const badgeY = estimateBadgeY(titleLastBaselineY, titleFontSize);
   const taglineY = titleLastBaselineY + 60;
   const detailY = taglineY + 77;
   const downloadsStat = params.stats?.[0] ?? { label: "Downloads", value: "0" };
   const avatarCircle = hasOrganizations
     ? usesLongLayout
       ? { cx: 249, cy: 222, imageX: 87, imageY: 60 }
-      : { cx: 308, cy: 262 + contentYOffset, imageX: 146, imageY: 100 + contentYOffset }
+      : { cx: 308, cy: 262, imageX: 146, imageY: 100 }
     : usesLongLayout
       ? { cx: 249, cy: 222, imageX: 87, imageY: 60 }
-      : { cx: 276, cy: 315 + contentYOffset, imageX: 114, imageY: 153 + contentYOffset };
+      : { cx: 276, cy: 315, imageX: 114, imageY: 153 };
   const statsMarkup = usesLongLayout
     ? `${statColumn("Creator", params.handleLabel, layout.detailX, detailY, layout.creatorWidth, { truncateWithDots: true })}
     ${statColumn(downloadsStat.label, downloadsStat.value, layout.downloadsX, detailY + 112, layout.downloadsWidth)}`
@@ -335,16 +361,16 @@ export function buildPublisherOgSvg(params: PublisherOgSvgParams) {
       <stop offset="1" stop-color="#050505"/>
     </linearGradient>
     <radialGradient id="bgAccent" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1064 78) rotate(152) scale(520 260)">
-      <stop stop-color="${OPENCLAW_RED}" stop-opacity="0.17"/>
-      <stop offset="1" stop-color="${OPENCLAW_RED}" stop-opacity="0"/>
+      <stop stop-color="${PUBLISHER_GRADIENT_RED}" stop-opacity="0.17"/>
+      <stop offset="1" stop-color="${PUBLISHER_GRADIENT_FADE}" stop-opacity="0"/>
     </radialGradient>
     <radialGradient id="bgDepth" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(178 590) rotate(-18) scale(600 250)">
       <stop stop-color="#12090A" stop-opacity="0.08"/>
       <stop offset="1" stop-color="#12090A" stop-opacity="0"/>
     </radialGradient>
     <radialGradient id="bgCorner" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(96 84) rotate(24) scale(440 240)">
-      <stop stop-color="#7F1D2D" stop-opacity="0.2"/>
-      <stop offset="1" stop-color="#6C1B2B" stop-opacity="0"/>
+      <stop stop-color="${PUBLISHER_GRADIENT_RED}" stop-opacity="0.2"/>
+      <stop offset="1" stop-color="${PUBLISHER_GRADIENT_FADE}" stop-opacity="0"/>
     </radialGradient>
     <clipPath id="publisherAvatarCircleClip">
       <circle cx="${avatarCircle.cx}" cy="${avatarCircle.cy}" r="139"/>
@@ -362,29 +388,29 @@ export function buildPublisherOgSvg(params: PublisherOgSvgParams) {
     <g>${avatarFrame}</g>
 
     <g>
-      <image href="${params.markDataUrl}" x="958" y="34" width="44" height="44" opacity="0.92" preserveAspectRatio="xMidYMid meet"/>
+      <image href="${params.clawHubLogoDataUrl}" x="958" y="34" width="44" height="44" opacity="0.92" preserveAspectRatio="xMidYMid meet"/>
       <text x="1016" y="66"
         fill="#F7F1EA"
         font-size="28"
-        font-weight="800"
+        font-weight="${PUBLISHER_TEXT_WEIGHT}"
         font-family="${FONT_SANS}, sans-serif">ClawHub</text>
     </g>
 
     <text x="${layout.titleX}" y="${titleY}"
       fill="#F7F1EA"
       font-size="${titleFontSize}"
-      font-weight="800"
+      font-weight="${PUBLISHER_TEXT_WEIGHT}"
       font-family="${FONT_SANS}, sans-serif">${titleTspans}</text>
     ${params.official ? officialBadge(badgeX, badgeY) : ""}
 
     <text x="${layout.subtitleX}" y="${taglineY}"
-      fill="${OPENCLAW_RED}"
+      fill="${PUBLISHER_RED}"
       font-size="44"
-      font-weight="800"
+      font-weight="${PUBLISHER_TEXT_WEIGHT}"
       font-family="${FONT_SANS}, sans-serif">on ClawHub</text>
 
     ${statsMarkup}
-    ${orgLogoTiles(organizationLogos, params.markDataUrl, orgLogosX, contentYOffset + organizationExtraGap)}
+    ${orgLogoTiles(organizationLogos, params.clawHubLogoDataUrl, orgLogosX, organizationExtraGap)}
   </g>
 </svg>`;
 }

--- a/server/og/publisherOgSvg.ts
+++ b/server/og/publisherOgSvg.ts
@@ -1,69 +1,330 @@
 import { FONT_SANS } from "./ogAssets";
-import {
-  escapeXml,
-  OPENCLAW_RED,
-  type RegistryOgStat,
-  statLabelMarkup,
-  wrapText,
-} from "./registryOgSvg";
+import { escapeXml, OPENCLAW_RED, type RegistryOgStat } from "./registryOgSvg";
 
 export type PublisherOgSvgParams = {
   markDataUrl: string;
   watermarkDataUrl?: string | null;
   avatarDataUrl?: string | null;
   avatarShape?: "circle" | "rounded";
+  official?: boolean;
   title: string;
   description: string;
   handleLabel: string;
+  organizationLogos?: string[];
   stats?: RegistryOgStat[];
 };
 
-function statBlock(stats: RegistryOgStat[] | undefined, x: number, y: number) {
-  const stat = stats?.[0] ?? { value: "ClawHub", label: "Publisher" };
+const OFFICIAL_BLUE = "#60A5FA";
+const OFFICIAL_BADGE_SIZE = 42;
+const OFFICIAL_BADGE_STROKE = 1.71;
+
+function estimateTextWidth(value: string, fontSize: number) {
+  return [...value].reduce((width, char) => {
+    if (char === " ") return width + fontSize * 0.28;
+    if (/[ilI.,:;|!'"`]/.test(char)) return width + fontSize * 0.28;
+    if (/[mwMW@%&]/.test(char)) return width + fontSize * 0.9;
+    if (/[A-Z]/.test(char)) return width + fontSize * 0.68;
+    if (/[0-9]/.test(char)) return width + fontSize * 0.6;
+    return width + fontSize * 0.56;
+  }, 0);
+}
+
+function estimateBadgeX(
+  value: string,
+  x: number,
+  fontSize: number,
+  maxX: number,
+  estimateScale: number,
+) {
+  const estimatedWidth = estimateTextWidth(value, fontSize) * estimateScale;
+  return Math.min(maxX, Math.round(x + estimatedWidth + 19));
+}
+
+function officialBadge(x: number, y: number) {
+  return `<svg x="${x}" y="${y}" width="${OFFICIAL_BADGE_SIZE}" height="${OFFICIAL_BADGE_SIZE}" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path d="M3.85 8.62a4 4 0 0 1 4.78-4.77 4 4 0 0 1 6.74 0 4 4 0 0 1 4.78 4.78 4 4 0 0 1 0 6.74 4 4 0 0 1-4.77 4.78 4 4 0 0 1-6.75 0 4 4 0 0 1-4.78-4.77 4 4 0 0 1 0-6.76Z" stroke="${OFFICIAL_BLUE}" stroke-width="${OFFICIAL_BADGE_STROKE}" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="m9 12 2 2 4-4" stroke="${OFFICIAL_BLUE}" stroke-width="${OFFICIAL_BADGE_STROKE}" stroke-linecap="round" stroke-linejoin="round"/>
+  </svg>`;
+}
+
+function wrapTextWithoutEllipsis(value: string, maxWidth: number, fontSize: number) {
+  const words = value.trim().split(/\s+/).filter(Boolean);
+  const lines: string[] = [];
+  let current = "";
+
+  function splitLongWord(word: string) {
+    if (estimateTextWidth(word, fontSize) <= maxWidth) return [word];
+    const parts: string[] = [];
+    let chunk = "";
+    for (const char of word) {
+      const next = chunk + char;
+      if (chunk && estimateTextWidth(next, fontSize) > maxWidth) {
+        parts.push(chunk);
+        chunk = char;
+        continue;
+      }
+      chunk = next;
+    }
+    if (chunk) parts.push(chunk);
+    return parts;
+  }
+
+  const tokens = words.flatMap((word, wordIndex) =>
+    splitLongWord(word).map((part, partIndex) => ({
+      text: part,
+      needsLeadingSpace: wordIndex > 0 && partIndex === 0,
+    })),
+  );
+
+  for (const token of tokens) {
+    const separator = current && token.needsLeadingSpace ? " " : "";
+    const next = current ? `${current}${separator}${token.text}` : token.text;
+    if (estimateTextWidth(next, fontSize) <= maxWidth) {
+      current = next;
+      continue;
+    }
+    if (current) lines.push(current);
+    current = token.text;
+  }
+  if (current) lines.push(current);
+  return lines.length > 0 ? lines : [value.trim()];
+}
+
+function fitMultilineText(
+  value: string,
+  maxWidth: number,
+  maxLines: number,
+  options: { maxFontSize: number; minFontSize: number },
+) {
+  for (let fontSize = options.maxFontSize; fontSize >= options.minFontSize; fontSize -= 2) {
+    const lines = wrapTextWithoutEllipsis(value, maxWidth, fontSize);
+    if (lines.length <= maxLines) {
+      return { fontSize, lines };
+    }
+  }
+  const fontSize = options.minFontSize;
+  return { fontSize, lines: wrapTextWithoutEllipsis(value, maxWidth, fontSize) };
+}
+
+function fitMultilineTextWithDots(
+  value: string,
+  maxWidth: number,
+  maxLines: number,
+  fontSize: number,
+) {
+  const wrappedLines = wrapTextWithoutEllipsis(value, maxWidth, fontSize);
+  if (wrappedLines.length <= maxLines) return { fontSize, lines: wrappedLines };
+  const visibleLines = wrappedLines.slice(0, maxLines - 1);
+  const hiddenText = wrappedLines.slice(maxLines - 1).join(" ");
+  return {
+    fontSize,
+    lines: [...visibleLines, truncateWithDots(hiddenText, maxWidth, fontSize)],
+  };
+}
+
+function fitSingleLineText(
+  value: string,
+  maxWidth: number,
+  maxFontSize: number,
+  minFontSize: number,
+) {
+  for (let fontSize = maxFontSize; fontSize >= minFontSize; fontSize -= 1) {
+    if (estimateTextWidth(value, fontSize) <= maxWidth) return fontSize;
+  }
+  const estimatedAtMin = estimateTextWidth(value, minFontSize);
+  if (estimatedAtMin <= maxWidth) return minFontSize;
+  return Math.max(10, Math.floor((minFontSize * maxWidth) / Math.max(estimatedAtMin, 1)));
+}
+
+function truncateWithDots(value: string, maxWidth: number, fontSize: number) {
+  if (estimateTextWidth(value, fontSize) <= maxWidth) return value;
+  const dots = "...";
+  const dotsWidth = estimateTextWidth(dots, fontSize);
+  const chars = [...value];
+  while (chars.length > 0 && estimateTextWidth(chars.join(""), fontSize) + dotsWidth > maxWidth) {
+    chars.pop();
+  }
+  return `${chars.join("").trimEnd()}${dots}`;
+}
+
+function statColumn(
+  label: string,
+  value: string,
+  x: number,
+  y: number,
+  valueMaxWidth: number,
+  options?: { truncateWithDots?: boolean },
+) {
+  const valueFontSize = options?.truncateWithDots
+    ? 46
+    : fitSingleLineText(value, valueMaxWidth, 46, 18);
+  const displayValue =
+    options?.truncateWithDots && estimateTextWidth(value, valueFontSize) > valueMaxWidth
+      ? truncateWithDots(value, valueMaxWidth, valueFontSize)
+      : value;
   return `<g>
-    ${statLabelMarkup(x, y, stat.label, { fontSize: 22 })}
-    <text x="${x}" y="${y + 44}"
+    <text x="${x}" y="${y}"
+      fill="#9D9692"
+      font-size="32"
+      font-weight="700"
+      font-family="${FONT_SANS}, sans-serif">${escapeXml(label)}</text>
+    <text x="${x}" y="${y + 63}"
       fill="#F7F1EA"
-      font-size="44"
+      font-size="${valueFontSize}"
       font-weight="800"
-      font-family="${FONT_SANS}, sans-serif">${escapeXml(stat.value)}</text>
+      font-family="${FONT_SANS}, sans-serif">${escapeXml(displayValue)}</text>
+  </g>`;
+}
+
+function orgLogoTiles(logos: string[], markDataUrl: string, x: number, yOffset: number) {
+  const visibleLogos = logos.slice(0, 5);
+  if (visibleLogos.length === 0) return "";
+  const y = 459 + yOffset;
+  const size = 48;
+  const gap = 10;
+  const tiles = visibleLogos
+    .map((logo, index) => {
+      const tileX = x + index * (size + gap);
+      const clipId = `orgLogoClip${index}`;
+      return `<g>
+        <clipPath id="${clipId}">
+          <rect x="${tileX}" y="${y}" width="${size}" height="${size}" rx="8"/>
+        </clipPath>
+        <image href="${logo || markDataUrl}" x="${tileX}" y="${y}" width="${size}" height="${size}" clip-path="url(#${clipId})" preserveAspectRatio="xMidYMid slice"/>
+      </g>`;
+    })
+    .join("");
+  return `<g>
+    <text x="${x}" y="${438 + yOffset}"
+      fill="${OPENCLAW_RED}"
+      font-size="32"
+      font-weight="800"
+      font-family="${FONT_SANS}, sans-serif">Organizations</text>
+    ${tiles}
   </g>`;
 }
 
 export function buildPublisherOgSvg(params: PublisherOgSvgParams) {
   const rawTitle = params.title.trim() || params.handleLabel;
-  const rawDescription = params.description.trim() || "Publisher on ClawHub.";
   const avatar = params.avatarDataUrl || params.markDataUrl;
-  const watermark = params.watermarkDataUrl || params.markDataUrl;
   const avatarShape = params.avatarShape ?? "circle";
-  const contentX = 430;
-  const contentWidth = 650;
-  const titleLines = wrapText(rawTitle, contentWidth, 72, 2);
-  const titleFontSize = titleLines.length > 1 ? 62 : 72;
-  const normalizedTitleLines = wrapText(rawTitle, contentWidth, titleFontSize, 2);
-  const descriptionLines = wrapText(rawDescription, contentWidth, 30, 2);
-  const titleTspans = normalizedTitleLines
+  const organizationLogos = params.organizationLogos?.filter(Boolean) ?? [];
+  const hasOrganizations = organizationLogos.length > 0;
+  const normalLayout = hasOrganizations
+    ? {
+        titleX: 509,
+        subtitleX: 509,
+        detailX: 509,
+        downloadsX: 861,
+        contentWidth: 610,
+        creatorWidth: 320,
+        downloadsWidth: 210,
+      }
+    : {
+        titleX: 542,
+        subtitleX: 542,
+        detailX: 542,
+        downloadsX: 913,
+        contentWidth: 565,
+        creatorWidth: 300,
+        downloadsWidth: 190,
+      };
+  const normalTitleMaxWidth = params.official
+    ? hasOrganizations
+      ? normalLayout.contentWidth - 78
+      : normalLayout.contentWidth
+    : normalLayout.contentWidth;
+  const titleNeedsOverflow = wrapTextWithoutEllipsis(rawTitle, normalTitleMaxWidth, 72).length > 1;
+  const creatorNeedsOverflow =
+    estimateTextWidth(params.handleLabel, 46) > normalLayout.creatorWidth;
+  const usesLongLayout = titleNeedsOverflow || creatorNeedsOverflow;
+  const contentYOffset = 0;
+  const organizationExtraGap = usesLongLayout ? 41 : 0;
+  const layout = usesLongLayout
+    ? {
+        titleX: 447,
+        subtitleX: 447,
+        detailX: 447,
+        downloadsX: 447,
+        contentWidth: 650,
+        creatorWidth: 680,
+        downloadsWidth: 210,
+      }
+    : normalLayout;
+  const titleMaxWidth = params.official
+    ? usesLongLayout
+      ? layout.contentWidth
+      : hasOrganizations
+        ? layout.contentWidth - 78
+        : layout.contentWidth
+    : layout.contentWidth;
+  const title = usesLongLayout
+    ? fitMultilineTextWithDots(rawTitle, titleMaxWidth, 2, 66)
+    : fitMultilineText(rawTitle, titleMaxWidth, 2, { maxFontSize: 72, minFontSize: 30 });
+  const titleFontSize = title.fontSize;
+  const titleLines = title.lines;
+  const titleLineHeight = usesLongLayout ? 84 : Math.max(50, Math.round(titleFontSize * 0.98));
+  const titleTspans = titleLines
     .map(
       (line, index) =>
-        `<tspan x="${contentX}" dy="${index === 0 ? 0 : 70}">${escapeXml(line)}</tspan>`,
+        `<tspan x="${layout.titleX}" dy="${index === 0 ? 0 : titleLineHeight}">${escapeXml(line)}</tspan>`,
     )
     .join("");
-  const descriptionTspans = descriptionLines
-    .map(
-      (line, index) =>
-        `<tspan x="${contentX}" dy="${index === 0 ? 0 : 40}">${escapeXml(line)}</tspan>`,
-    )
-    .join("");
-  const descriptionY = normalizedTitleLines.length > 1 ? 354 : 340;
-  const statsY = descriptionY + descriptionLines.length * 40 + 34;
+  const titleY = usesLongLayout
+    ? 151
+    : hasOrganizations
+      ? titleLines.length > 1
+        ? 138 + contentYOffset
+        : 190 + contentYOffset
+      : titleLines.length > 1
+        ? 195 + contentYOffset
+        : 243 + contentYOffset;
+  const lastTitleLine = titleLines.at(-1) ?? rawTitle;
+  const badgeX =
+    params.official && !hasOrganizations && !usesLongLayout && titleLines.length === 1
+      ? 1040
+      : params.official && hasOrganizations && !usesLongLayout && titleLines.length === 1
+        ? 1007
+        : estimateBadgeX(
+            lastTitleLine,
+            layout.titleX,
+            titleFontSize,
+            usesLongLayout ? 1084 : layout.titleX + layout.contentWidth - OFFICIAL_BADGE_SIZE,
+            titleLines.length > 1 ? 1 : 0.875,
+          );
+  const badgeY =
+    params.official && !hasOrganizations && !usesLongLayout && titleLines.length === 1
+      ? 198
+      : params.official && hasOrganizations && !usesLongLayout && titleLines.length === 1
+        ? 145
+        : usesLongLayout
+          ? 143
+          : titleY + (titleLines.length - 1) * titleLineHeight - 45;
+  const titleLastBaselineY = titleY + (titleLines.length - 1) * titleLineHeight;
+  const taglineY = titleLastBaselineY + 60;
+  const detailY = taglineY + 77;
+  const downloadsStat = params.stats?.[0] ?? { label: "Downloads", value: "0" };
+  const avatarCircle = hasOrganizations
+    ? usesLongLayout
+      ? { cx: 249, cy: 222, imageX: 87, imageY: 60 }
+      : { cx: 308, cy: 262 + contentYOffset, imageX: 146, imageY: 100 + contentYOffset }
+    : usesLongLayout
+      ? { cx: 249, cy: 222, imageX: 87, imageY: 60 }
+      : { cx: 276, cy: 315 + contentYOffset, imageX: 114, imageY: 153 + contentYOffset };
+  const statsMarkup = usesLongLayout
+    ? `${statColumn("Creator", params.handleLabel, layout.detailX, detailY, layout.creatorWidth, { truncateWithDots: true })}
+    ${statColumn(downloadsStat.label, downloadsStat.value, layout.downloadsX, detailY + 112, layout.downloadsWidth)}`
+    : `${statColumn("Creator", params.handleLabel, layout.detailX, detailY, layout.creatorWidth, { truncateWithDots: true })}
+    ${statColumn(downloadsStat.label, downloadsStat.value, layout.downloadsX, detailY, layout.downloadsWidth)}`;
+  const orgLogosX = usesLongLayout ? 110 : 169;
   const avatarFrame =
     avatarShape === "circle"
-      ? `<circle cx="211" cy="305" r="139" fill="#FFFFFF" fill-opacity="0.055" stroke="#FFFFFF" stroke-opacity="0.16"/>
-      <image href="${avatar}" x="49" y="143" width="324" height="324" clip-path="url(#publisherAvatarCircleClip)" preserveAspectRatio="xMidYMid slice"/>
-      <circle cx="211" cy="305" r="139" stroke="#FFFFFF" stroke-opacity="0.18" stroke-width="1.5"/>`
-      : `<rect x="71" y="165" width="280" height="280" rx="58" fill="#FFFFFF" fill-opacity="0.055" stroke="#FFFFFF" stroke-opacity="0.16"/>
-      <image href="${avatar}" x="49" y="143" width="324" height="324" clip-path="url(#publisherAvatarRoundedClip)" preserveAspectRatio="xMidYMid slice"/>
-      <rect x="71.75" y="165.75" width="278.5" height="278.5" rx="57.25" stroke="#FFFFFF" stroke-opacity="0.18" stroke-width="1.5"/>`;
+      ? `<circle cx="${avatarCircle.cx}" cy="${avatarCircle.cy}" r="139" fill="#FFFFFF" fill-opacity="0.055" stroke="#FFFFFF" stroke-opacity="0.16"/>
+      <image href="${avatar}" x="${avatarCircle.imageX}" y="${avatarCircle.imageY}" width="324" height="324" clip-path="url(#publisherAvatarCircleClip)" preserveAspectRatio="xMidYMid slice"/>
+      <circle cx="${avatarCircle.cx}" cy="${avatarCircle.cy}" r="139" stroke="#FFFFFF" stroke-opacity="0.18" stroke-width="1.5"/>`
+      : `<rect x="${avatarCircle.cx - 139}" y="${avatarCircle.cy - 139}" width="278" height="278" rx="58" fill="#FFFFFF" fill-opacity="0.055" stroke="#FFFFFF" stroke-opacity="0.16"/>
+      <image href="${avatar}" x="${avatarCircle.imageX}" y="${avatarCircle.imageY}" width="324" height="324" clip-path="url(#publisherAvatarRoundedClip)" preserveAspectRatio="xMidYMid slice"/>
+      <rect x="${avatarCircle.cx - 138.25}" y="${avatarCircle.cy - 138.25}" width="276.5" height="276.5" rx="57.25" stroke="#FFFFFF" stroke-opacity="0.18" stroke-width="1.5"/>`;
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -71,25 +332,25 @@ export function buildPublisherOgSvg(params: PublisherOgSvgParams) {
     <linearGradient id="bgBase" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
       <stop stop-color="#12090A"/>
       <stop offset="0.46" stop-color="#08090A"/>
-      <stop offset="1" stop-color="#07100E"/>
+      <stop offset="1" stop-color="#050505"/>
     </linearGradient>
     <radialGradient id="bgAccent" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1064 78) rotate(152) scale(520 260)">
       <stop stop-color="${OPENCLAW_RED}" stop-opacity="0.17"/>
       <stop offset="1" stop-color="${OPENCLAW_RED}" stop-opacity="0"/>
     </radialGradient>
     <radialGradient id="bgDepth" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(178 590) rotate(-18) scale(600 250)">
-      <stop stop-color="#0D7A67" stop-opacity="0.13"/>
-      <stop offset="1" stop-color="#0D7A67" stop-opacity="0"/>
+      <stop stop-color="#12090A" stop-opacity="0.08"/>
+      <stop offset="1" stop-color="#12090A" stop-opacity="0"/>
     </radialGradient>
     <radialGradient id="bgCorner" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(96 84) rotate(24) scale(440 240)">
       <stop stop-color="#7F1D2D" stop-opacity="0.2"/>
       <stop offset="1" stop-color="#6C1B2B" stop-opacity="0"/>
     </radialGradient>
     <clipPath id="publisherAvatarCircleClip">
-      <circle cx="211" cy="305" r="139"/>
+      <circle cx="${avatarCircle.cx}" cy="${avatarCircle.cy}" r="139"/>
     </clipPath>
     <clipPath id="publisherAvatarRoundedClip">
-      <rect x="71" y="165" width="280" height="280" rx="58"/>
+      <rect x="${avatarCircle.cx - 139}" y="${avatarCircle.cy - 139}" width="278" height="278" rx="58"/>
     </clipPath>
   </defs>
 
@@ -98,7 +359,6 @@ export function buildPublisherOgSvg(params: PublisherOgSvgParams) {
   <rect width="1200" height="630" fill="url(#bgDepth)"/>
   <rect width="1200" height="630" fill="url(#bgCorner)"/>
   <g>
-    <image href="${watermark}" x="905" y="365" width="430" height="430" opacity="0.035" preserveAspectRatio="xMidYMid meet"/>
     <g>${avatarFrame}</g>
 
     <g>
@@ -110,25 +370,21 @@ export function buildPublisherOgSvg(params: PublisherOgSvgParams) {
         font-family="${FONT_SANS}, sans-serif">ClawHub</text>
     </g>
 
-    <text x="${contentX}" y="132"
-      fill="${OPENCLAW_RED}"
-      font-size="25"
-      font-weight="800"
-      font-family="${FONT_SANS}, sans-serif">${escapeXml(params.handleLabel)} / Publisher</text>
-
-    <text x="${contentX}" y="${normalizedTitleLines.length > 1 ? 216 : 248}"
+    <text x="${layout.titleX}" y="${titleY}"
       fill="#F7F1EA"
       font-size="${titleFontSize}"
       font-weight="800"
       font-family="${FONT_SANS}, sans-serif">${titleTspans}</text>
+    ${params.official ? officialBadge(badgeX, badgeY) : ""}
 
-    <text x="${contentX}" y="${descriptionY}"
-      fill="#B9B0AA"
-      font-size="30"
-      font-weight="500"
-      font-family="${FONT_SANS}, sans-serif">${descriptionTspans}</text>
+    <text x="${layout.subtitleX}" y="${taglineY}"
+      fill="${OPENCLAW_RED}"
+      font-size="44"
+      font-weight="800"
+      font-family="${FONT_SANS}, sans-serif">on ClawHub</text>
 
-    ${statBlock(params.stats, contentX, statsY)}
+    ${statsMarkup}
+    ${orgLogoTiles(organizationLogos, params.markDataUrl, orgLogosX, contentYOffset + organizationExtraGap)}
   </g>
 </svg>`;
 }

--- a/server/routes/og/profile.png.ts
+++ b/server/routes/og/profile.png.ts
@@ -8,9 +8,8 @@ import {
   ensureResvgWasm,
   FONT_MONO,
   FONT_SANS,
+  getClawHubLogoDataUrl,
   getFontBuffers,
-  getMarkDataUrl,
-  getWatermarkDataUrl,
 } from "../../og/ogAssets";
 import { pngResponse } from "../../og/pngResponse";
 import { buildPublisherOgSvg } from "../../og/publisherOgSvg";
@@ -19,7 +18,6 @@ import { buildOgDownloadsStat } from "../../og/registryOgSvg";
 type OgQuery = {
   handle?: string;
   title?: string;
-  description?: string;
   downloads?: string;
   installs?: string;
   kind?: string;
@@ -63,14 +61,12 @@ export default defineEventHandler(async (event) => {
   }
 
   const titleFromQuery = cleanString(query.title);
-  const descriptionFromQuery = cleanString(query.description);
   const kindFromQuery = cleanString(query.kind);
   const avatarFromQuery = cleanString(query.avatar);
   const organizationImagesFromQuery = readOrganizationImagesQuery(query.orgImages);
   const convexUrl = getConvexUrl();
   const needFetch =
     !titleFromQuery ||
-    !descriptionFromQuery ||
     !readOgDownloadsQuery(query) ||
     !avatarFromQuery ||
     !cleanString(query.official) ||
@@ -79,11 +75,9 @@ export default defineEventHandler(async (event) => {
   const meta = needFetch && convexUrl ? await fetchPublisherOgMeta(handle, convexUrl) : null;
   const handleLabel = `@${meta?.handle || handle}`;
   const title = titleFromQuery || meta?.displayName || handleLabel;
-  const description = descriptionFromQuery || meta?.bio || "Publisher on ClawHub.";
 
-  const [markDataUrl, watermarkDataUrl, fontBuffers] = await Promise.all([
-    getMarkDataUrl(),
-    getWatermarkDataUrl(),
+  const [clawHubLogoDataUrl, fontBuffers] = await Promise.all([
+    getClawHubLogoDataUrl(),
     ensureResvgWasm().then(() => getFontBuffers()),
   ]);
   const avatarDataUrl = await fetchPublisherProfileImageDataUrl(avatarFromQuery || meta?.image);
@@ -104,13 +98,11 @@ export default defineEventHandler(async (event) => {
   ).filter((imageUrl): imageUrl is string => Boolean(imageUrl));
 
   const svg = buildPublisherOgSvg({
-    markDataUrl,
-    watermarkDataUrl,
+    clawHubLogoDataUrl,
     avatarDataUrl,
     avatarShape: kindFromQuery === "org" || meta?.kind === "org" ? "rounded" : "circle",
     official: cleanString(query.official) ? readBooleanQuery(query.official) : meta?.official,
     title,
-    description,
     handleLabel,
     organizationLogos: organizationLogoDataUrls,
     stats: [buildOgDownloadsStat(resolveOgDownloadsDisplay(query, meta?.stats.downloads))],

--- a/server/routes/og/profile.png.ts
+++ b/server/routes/og/profile.png.ts
@@ -9,7 +9,7 @@ import {
   FONT_MONO,
   FONT_SANS,
   getClawHubLogoDataUrl,
-  getFontBuffers,
+  getPublisherFontBuffers,
 } from "../../og/ogAssets";
 import { pngResponse } from "../../og/pngResponse";
 import { buildPublisherOgSvg } from "../../og/publisherOgSvg";
@@ -78,7 +78,7 @@ export default defineEventHandler(async (event) => {
 
   const [clawHubLogoDataUrl, fontBuffers] = await Promise.all([
     getClawHubLogoDataUrl(),
-    ensureResvgWasm().then(() => getFontBuffers()),
+    ensureResvgWasm().then(() => getPublisherFontBuffers()),
   ]);
   const avatarDataUrl = await fetchPublisherProfileImageDataUrl(avatarFromQuery || meta?.image);
   const organizationImageUrls =

--- a/server/routes/og/profile.png.ts
+++ b/server/routes/og/profile.png.ts
@@ -1,8 +1,9 @@
 import { Resvg } from "@resvg/resvg-wasm";
 import { defineEventHandler, getQuery, setHeader } from "h3";
-import { fetchPublisherProfileImageDataUrl } from "../../og/fetchImageDataUrl";
+import { fetchImageDataUrl, fetchPublisherProfileImageDataUrl } from "../../og/fetchImageDataUrl";
 import { fetchPublisherOgMeta } from "../../og/fetchPublisherOgMeta";
 import { readOgDownloadsQuery, resolveOgDownloadsDisplay } from "../../og/formatOgStats";
+import { normalizeOgLogoDataUrl } from "../../og/normalizeLogoDataUrl";
 import {
   ensureResvgWasm,
   FONT_MONO,
@@ -22,6 +23,9 @@ type OgQuery = {
   downloads?: string;
   installs?: string;
   kind?: string;
+  official?: string;
+  orgState?: string;
+  orgImages?: string;
   avatar?: string;
   v?: string;
 };
@@ -33,6 +37,21 @@ function cleanString(value: unknown) {
 
 function getConvexUrl() {
   return process.env.VITE_CONVEX_URL?.trim() || process.env.CONVEX_URL?.trim() || null;
+}
+
+function readBooleanQuery(value: unknown) {
+  const raw = cleanString(value).toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes";
+}
+
+function readOrganizationImagesQuery(value: unknown) {
+  const raw = cleanString(value);
+  if (raw === "0") return [];
+  return raw
+    .split("|")
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .slice(0, 5);
 }
 
 export default defineEventHandler(async (event) => {
@@ -47,9 +66,16 @@ export default defineEventHandler(async (event) => {
   const descriptionFromQuery = cleanString(query.description);
   const kindFromQuery = cleanString(query.kind);
   const avatarFromQuery = cleanString(query.avatar);
+  const organizationImagesFromQuery = readOrganizationImagesQuery(query.orgImages);
   const convexUrl = getConvexUrl();
   const needFetch =
-    !titleFromQuery || !descriptionFromQuery || !readOgDownloadsQuery(query) || !avatarFromQuery;
+    !titleFromQuery ||
+    !descriptionFromQuery ||
+    !readOgDownloadsQuery(query) ||
+    !avatarFromQuery ||
+    !cleanString(query.official) ||
+    !cleanString(query.orgState) ||
+    !cleanString(query.orgImages);
   const meta = needFetch && convexUrl ? await fetchPublisherOgMeta(handle, convexUrl) : null;
   const handleLabel = `@${meta?.handle || handle}`;
   const title = titleFromQuery || meta?.displayName || handleLabel;
@@ -61,15 +87,32 @@ export default defineEventHandler(async (event) => {
     ensureResvgWasm().then(() => getFontBuffers()),
   ]);
   const avatarDataUrl = await fetchPublisherProfileImageDataUrl(avatarFromQuery || meta?.image);
+  const organizationImageUrls =
+    organizationImagesFromQuery.length > 0
+      ? organizationImagesFromQuery
+      : (meta?.affiliations.map((affiliation) => affiliation.image).filter(Boolean) ?? []);
+  const organizationLogoDataUrls = (
+    await Promise.all(
+      organizationImageUrls.map(async (imageUrl) => {
+        const dataUrl = await fetchImageDataUrl(imageUrl, {
+          allowPublicHttps: true,
+          followRedirects: true,
+        });
+        return normalizeOgLogoDataUrl(dataUrl);
+      }),
+    )
+  ).filter((imageUrl): imageUrl is string => Boolean(imageUrl));
 
   const svg = buildPublisherOgSvg({
     markDataUrl,
     watermarkDataUrl,
     avatarDataUrl,
     avatarShape: kindFromQuery === "org" || meta?.kind === "org" ? "rounded" : "circle",
+    official: cleanString(query.official) ? readBooleanQuery(query.official) : meta?.official,
     title,
     description,
     handleLabel,
+    organizationLogos: organizationLogoDataUrls,
     stats: [buildOgDownloadsStat(resolveOgDownloadsDisplay(query, meta?.stats.downloads))],
   });
 

--- a/src/lib/og.test.ts
+++ b/src/lib/og.test.ts
@@ -51,19 +51,41 @@ describe("og helpers", () => {
       bio: "maton.ai",
       image: "https://example.com/logo.png",
       kind: "org",
+      official: true,
+      affiliations: [
+        { publisher: { displayName: "OpenClaw", image: "https://example.com/openclaw.png" } },
+      ],
       downloads: 1200,
     });
     expect(meta.title).toBe("byungkyu — ClawHub");
     expect(meta.description).toBe("maton.ai");
     expect(meta.url).toBe("https://clawhub.ai/byungkyu");
     expect(meta.image).toContain("/og/profile?");
-    expect(meta.image).toContain("v=7");
+    expect(meta.image).toContain("v=8");
     expect(meta.image).toContain("handle=byungkyu");
     expect(meta.image).toContain("title=byungkyu");
     expect(meta.image).toContain("description=maton.ai");
     expect(meta.image).toContain("kind=org");
+    expect(meta.image).toContain("official=1");
+    expect(meta.image).toContain("orgState=1");
+    expect(meta.image).not.toContain("OpenClaw");
+    expect(meta.image).toContain("orgImages=https%3A%2F%2Fexample.com%2Fopenclaw.png");
     expect(meta.image).toContain("avatar=https%3A%2F%2Fexample.com%2Flogo.png");
     expect(meta.image).toContain("downloads=1200");
+  });
+
+  it("builds no-badge no-organization publisher metadata explicitly", () => {
+    const meta = buildPublisherMeta({
+      handle: "mvanhorn",
+      displayName: "Matt Van Horn",
+      bio: "Publisher @mvanhorn on ClawHub.",
+      kind: "user",
+      official: false,
+      affiliations: [],
+    });
+    expect(meta.image).toContain("official=0");
+    expect(meta.image).toContain("orgState=0");
+    expect(meta.image).not.toContain("kind=org");
   });
 
   it("uses defaults when owner and summary are missing", () => {

--- a/src/lib/og.ts
+++ b/src/lib/og.ts
@@ -34,6 +34,13 @@ type PublisherMetaSource = {
   bio?: string | null;
   image?: string | null;
   kind?: "user" | "org";
+  official?: boolean | null;
+  affiliations?: Array<{
+    publisher?: {
+      displayName?: string | null;
+      image?: string | null;
+    } | null;
+  }> | null;
   downloads?: number | null;
 };
 
@@ -46,7 +53,7 @@ type BasicMeta = {
 
 const OG_SKILL_IMAGE_LAYOUT_VERSION = "10";
 const OG_PLUGIN_IMAGE_LAYOUT_VERSION = "5";
-const OG_PUBLISHER_IMAGE_LAYOUT_VERSION = "7";
+const OG_PUBLISHER_IMAGE_LAYOUT_VERSION = "8";
 
 function getSiteUrl() {
   return getClawHubSiteUrl();
@@ -141,6 +148,18 @@ export function buildPublisherMeta(source: PublisherMetaSource): BasicMeta {
   imageParams.set("title", displayName);
   imageParams.set("description", truncate(description, 200));
   if (source.kind === "org") imageParams.set("kind", "org");
+  imageParams.set("official", source.official ? "1" : "0");
+  const organizationCount = source.affiliations?.length ?? 0;
+  imageParams.set("orgState", organizationCount > 1 ? "many" : String(organizationCount));
+  const organizationImages =
+    source.affiliations
+      ?.map((affiliation) => clean(affiliation.publisher?.image))
+      .map((imageUrl) => imageUrl.replace(/\|/g, ""))
+      .filter(Boolean) ?? [];
+  imageParams.set(
+    "orgImages",
+    organizationImages.length > 0 ? organizationImages.slice(0, 5).join("|") : "0",
+  );
   if (image) imageParams.set("avatar", image);
   if (typeof source.downloads === "number" && Number.isFinite(source.downloads)) {
     imageParams.set("downloads", String(Math.max(0, Math.trunc(source.downloads))));

--- a/src/routes/user/$handle.tsx
+++ b/src/routes/user/$handle.tsx
@@ -102,6 +102,8 @@ export const Route = createFileRoute("/user/$handle")({
       bio: publisher?.bio,
       image: publisher?.image,
       kind: publisher?.kind,
+      official: publisher?.official,
+      affiliations: publisher?.affiliations,
       downloads: publisher?.stats.downloads,
     });
     return {


### PR DESCRIPTION
## Summary
- Redesign creator OG/social images for official badge, organization, no-organization, and long-text states.
- Official creator badge and organization logo metadata into the profile OG route.
- Normalize organization logos to consistent 48x48 rendering and cap visible organization logos at five.

### **Updates**

**Current social image**
<img width="2400" height="1260" alt="image" src="https://github.com/user-attachments/assets/056dfa1e-2543-482d-9fdc-6bfe70a5b375" />

**New redesign variants**
<img width="1200" height="1440" alt="image" src="https://github.com/user-attachments/assets/aeb97012-fb84-41b7-9c84-a31b0c3dfa2a" />

