### PR TITLE
fix(ci): cap security dataset snapshot fanout

### DIFF
--- a/.github/workflows/security-dataset-snapshot.yml
+++ b/.github/workflows/security-dataset-snapshot.yml
@@ -38,7 +38,7 @@ on:
       shards:
         description: "Created-at shards per source kind"
         required: true
-        default: "128"
+        default: "12"
   schedule:
     - cron: "17 9 * * *"
 
@@ -70,7 +70,9 @@ jobs:
       SNAPSHOT_MIN_PAGE_SIZE: ${{ inputs['min-page-size'] || '1' }}
       SNAPSHOT_BATCH_PAGES: ${{ inputs['batch-pages'] || '1' }}
       SNAPSHOT_CONCURRENCY: ${{ inputs.concurrency || '1' }}
-      SNAPSHOT_SHARDS: ${{ inputs.shards || '128' }}
+      SNAPSHOT_SHARDS: ${{ inputs.shards || '12' }}
+      SNAPSHOT_MAX_SHARDS_PER_SOURCE: ${{ vars.SECURITY_DATASET_MAX_SHARDS_PER_SOURCE || '16' }}
+      SNAPSHOT_MAX_MATRIX_JOBS: ${{ vars.SECURITY_DATASET_MAX_MATRIX_JOBS || '32' }}
     steps:
       - uses: actions/checkout@v7
 
@@ -88,6 +90,27 @@ jobs:
           echo "Hugging Face repo: $HF_DATASET_REPO"
           echo "Hugging Face revision: $HF_REVISION"
           echo "Shard count per source kind: $SNAPSHOT_SHARDS"
+          echo "Maximum shards per source kind: $SNAPSHOT_MAX_SHARDS_PER_SOURCE"
+          echo "Maximum matrix jobs: $SNAPSHOT_MAX_MATRIX_JOBS"
+          if [[ ! "$SNAPSHOT_SHARDS" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::shards must be a positive integer"
+            exit 1
+          fi
+          if [[ ! "$SNAPSHOT_MAX_SHARDS_PER_SOURCE" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::SECURITY_DATASET_MAX_SHARDS_PER_SOURCE must be a positive integer"
+            exit 1
+          fi
+          if [[ ! "$SNAPSHOT_MAX_MATRIX_JOBS" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::SECURITY_DATASET_MAX_MATRIX_JOBS must be a positive integer"
+            exit 1
+          fi
+          bun -e '
+          const [shards, maxShards] = process.argv.slice(1);
+          if (BigInt(shards) > BigInt(maxShards)) {
+            console.error(`::error::requested ${shards} shards per source kind, above SECURITY_DATASET_MAX_SHARDS_PER_SOURCE=${maxShards}`);
+            process.exit(1);
+          }
+          ' "$SNAPSHOT_SHARDS" "$SNAPSHOT_MAX_SHARDS_PER_SOURCE"
 
       - name: Plan live export shards
         id: plan
@@ -107,6 +130,14 @@ jobs:
             --concurrency "$SNAPSHOT_CONCURRENCY" \
             --shards "$SNAPSHOT_SHARDS" \
             --write-shard-matrix "$matrix_path"
+          shard_count="$(jq '.include | length' "$matrix_path")"
+          bun -e '
+          const [shardCount, maxJobs] = process.argv.slice(1);
+          if (BigInt(shardCount) > BigInt(maxJobs)) {
+            console.error(`::error::planned ${shardCount} dataset shard jobs, above SECURITY_DATASET_MAX_MATRIX_JOBS=${maxJobs}`);
+            process.exit(1);
+          }
+          ' "$shard_count" "$SNAPSHOT_MAX_MATRIX_JOBS"
           echo "source_snapshot_id=$source_snapshot_id" >> "$GITHUB_OUTPUT"
           echo "matrix=$(jq -c . "$matrix_path")" >> "$GITHUB_OUTPUT"
           jq '{shard_count: (.include | length), first: .include[0], last: .include[-1]}' "$matrix_path"

--- a/scripts/security-dataset/security-dataset-snapshot-workflow.test.ts
+++ b/scripts/security-dataset/security-dataset-snapshot-workflow.test.ts
@@ -1,0 +1,52 @@
+/* @vitest-environment node */
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+
+describe("security-dataset-snapshot workflow", () => {
+  it("keeps the scheduled dataset snapshot below the runner registration budget", async () => {
+    const workflow = parseYaml(
+      await readFile(".github/workflows/security-dataset-snapshot.yml", "utf8"),
+    ) as {
+      jobs: {
+        "export-security-dataset-shards": {
+          strategy?: { "max-parallel"?: number };
+        };
+        "plan-security-dataset": {
+          env?: Record<string, unknown>;
+          steps: Array<{ id?: string; run?: string }>;
+        };
+      };
+      on?: {
+        workflow_dispatch?: {
+          inputs?: Record<string, { default?: string }>;
+        };
+      };
+    };
+
+    const planJob = workflow.jobs["plan-security-dataset"];
+    const exportJob = workflow.jobs["export-security-dataset-shards"];
+    const planStep = planJob.steps.find((step) => step.id === "plan");
+
+    expect(workflow.on?.workflow_dispatch?.inputs?.shards?.default).toBe("12");
+    expect(planJob.env?.SNAPSHOT_SHARDS).toBe("${{ inputs.shards || '12' }}");
+    expect(planJob.env?.SNAPSHOT_MAX_SHARDS_PER_SOURCE).toBe(
+      "${{ vars.SECURITY_DATASET_MAX_SHARDS_PER_SOURCE || '16' }}",
+    );
+    expect(planJob.env?.SNAPSHOT_MAX_MATRIX_JOBS).toBe(
+      "${{ vars.SECURITY_DATASET_MAX_MATRIX_JOBS || '32' }}",
+    );
+    expect(planJob.steps.find((step) => step.run?.includes("Maximum matrix jobs"))?.run).toContain(
+      "requested ${shards} shards per source kind",
+    );
+    expect(planJob.steps.find((step) => step.run?.includes("Maximum matrix jobs"))?.run).toContain(
+      "BigInt(shards) > BigInt(maxShards)",
+    );
+    expect(planJob.steps.find((step) => step.run?.includes("Maximum matrix jobs"))?.run).toContain(
+      "SECURITY_DATASET_MAX_MATRIX_JOBS must be a positive integer",
+    );
+    expect(planStep?.run).toContain("planned ${shardCount} dataset shard jobs");
+    expect(planStep?.run).toContain("BigInt(shardCount) > BigInt(maxJobs)");
+    expect(exportJob.strategy?.["max-parallel"]).toBe(12);
+  });
+});

--- a/specs/ci.md
+++ b/specs/ci.md
@@ -58,6 +58,18 @@ The full `bun run test:e2e` suite includes token-backed CLI flows. Keep that for
 local or secret-backed validation; PR CI should not require a developer auth
 token or a local global ClawHub config.
 
+## Maintenance Jobs
+
+`Security Dataset Snapshot` exports live production security-review data for the
+sanitized Hugging Face dataset. Keep its default fanout small enough that a
+nightly run cannot dominate the org-level GitHub runner-registration bucket:
+12 created-at shards per source kind, at most 32 planned matrix jobs, and
+`max-parallel: 12`. Manual dispatches are also capped before shard planning, so a
+large input cannot allocate a huge matrix before the guard runs. This workflow
+publishes a complete replacement snapshot, so do not run overlapping dispatches
+as a backfill strategy; make any higher-fanout backfill a deliberate temporary
+workflow change with its own capacity plan.
+
 ## Required Checks
 
 GitHub rulesets should require these status checks on `main`:


### PR DESCRIPTION
## Summary
- reduce the scheduled Security Dataset Snapshot default from 128 to 12 shards per source kind
- cap manual dispatch inputs before shard planning and cap planned matrix jobs before matrix consumption
- document the dataset snapshot runner-registration budget and add a workflow guard test

## Tests
- `bun test scripts/security-dataset/security-dataset-snapshot-workflow.test.ts`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/security-dataset-snapshot.yml"); puts "yaml ok"'`
- `git diff --check`
- `bun run ci:static`
- `/Users/vincentkoc/GIT/_Perso/openclaw/.agents/skills/autoreview/scripts/autoreview --mode local`
