### PR TITLE
fix(search): keep skills all tab on approved recommended ranking

### DIFF
--- a/convex/lib/publicBrowse.test.ts
+++ b/convex/lib/publicBrowse.test.ts
@@ -4,6 +4,7 @@ import {
   hasPriorApprovedPublicSkillVersion,
   isPubliclyListableSkillVersion,
   isSkillPendingPublicReview,
+  resolvePublicBrowseVersionForSkill,
   shouldExcludeSkillFromPublicBrowse,
 } from "./publicBrowse";
 
@@ -102,5 +103,83 @@ describe("publicBrowse", () => {
         staticScan: undefined,
       }),
     ).toBe(false);
+  });
+
+  it("resolves the last approved version while a newer version is pending review", async () => {
+    const approvedVersion = {
+      _id: "skillVersions:approved",
+      skillId: "skills:1",
+      softDeletedAt: undefined,
+      version: "1.0.0",
+      createdAt: 1,
+      changelog: "approved",
+      changelogSource: "user",
+      parsed: { frontmatter: {}, license: "MIT" },
+      vtAnalysis: { status: "clean", checkedAt: 1 },
+      llmAnalysis: { status: "clean", checkedAt: 1 },
+      staticScan: {
+        status: "clean",
+        reasonCodes: [],
+        findings: [],
+        summary: "",
+        engineVersion: "v1",
+        checkedAt: 1,
+      },
+    };
+    const pendingVersion = {
+      _id: "skillVersions:pending",
+      skillId: "skills:1",
+      softDeletedAt: undefined,
+      version: "2.0.0",
+      createdAt: 2,
+      changelog: "pending",
+      changelogSource: "user",
+      parsed: { frontmatter: {}, license: "MIT" },
+      vtAnalysis: { status: "pending", checkedAt: 2 },
+    };
+
+    const version = await resolvePublicBrowseVersionForSkill(
+      {
+        db: {
+          get: async (id: string) => {
+            if (id === "skills:1") {
+              return {
+                _id: "skills:1",
+                latestVersionId: "skillVersions:pending",
+                moderationSourceVersionId: "skillVersions:pending",
+                moderationStatus: "active",
+                moderationReason: "pending.scan",
+                moderationFlags: undefined,
+                stats: { versions: 2 },
+              };
+            }
+            if (id === "skillVersions:pending") return pendingVersion;
+            return null;
+          },
+          query: () => ({
+            withIndex: () => ({
+              order: () => ({
+                take: async () => [pendingVersion, approvedVersion],
+              }),
+            }),
+          }),
+        },
+      } as never,
+      {
+        _id: "skills:1",
+        latestVersionId: "skillVersions:pending",
+        moderationSourceVersionId: "skillVersions:pending",
+        moderationStatus: "active",
+        moderationReason: "pending.scan",
+        moderationFlags: undefined,
+        stats: { versions: 2 },
+        softDeletedAt: undefined,
+        moderationVerdict: "clean",
+        githubScanStatus: "clean",
+      },
+    );
+
+    expect(version?._id).toBe("skillVersions:approved");
+    expect(version?.version).toBe("1.0.0");
   });
 });

--- a/convex/lib/publicBrowse.test.ts
+++ b/convex/lib/publicBrowse.test.ts
@@ -1,0 +1,106 @@
+/* @vitest-environment node */
+import { describe, expect, it } from "vitest";
+import {
+  hasPriorApprovedPublicSkillVersion,
+  isPubliclyListableSkillVersion,
+  isSkillPendingPublicReview,
+  shouldExcludeSkillFromPublicBrowse,
+} from "./publicBrowse";
+
+describe("publicBrowse", () => {
+  it("treats scanner review flags as pending public review", () => {
+    expect(
+      isSkillPendingPublicReview({
+        moderationStatus: "active",
+        moderationReason: "scanner.llm.review",
+        moderationFlags: ["flagged.review"],
+      }),
+    ).toBe(true);
+  });
+
+  it("treats active pending.scan skills as pending public review", () => {
+    expect(
+      isSkillPendingPublicReview({
+        moderationStatus: "active",
+        moderationReason: "pending.scan",
+        moderationFlags: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it("excludes first-publish pending review skills from public browse", () => {
+    expect(
+      shouldExcludeSkillFromPublicBrowse({
+        softDeletedAt: undefined,
+        moderationStatus: "active",
+        moderationReason: "pending.scan",
+        moderationFlags: undefined,
+        moderationVerdict: "clean",
+        moderationSourceVersionId: undefined,
+        latestVersionId: "skillVersions:1",
+        githubScanStatus: "clean",
+        stats: {
+          versions: 1,
+          downloads: 0,
+          stars: 0,
+          installsCurrent: 0,
+          installsAllTime: 0,
+          comments: 0,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps previously approved skills visible while a newer version is pending review", () => {
+    expect(
+      hasPriorApprovedPublicSkillVersion({
+        stats: {
+          versions: 2,
+          downloads: 0,
+          stars: 0,
+          installsCurrent: 0,
+          installsAllTime: 0,
+          comments: 0,
+        },
+      }),
+    ).toBe(true);
+    expect(
+      shouldExcludeSkillFromPublicBrowse({
+        softDeletedAt: undefined,
+        moderationStatus: "active",
+        moderationReason: "pending.scan",
+        moderationFlags: undefined,
+        moderationVerdict: "clean",
+        moderationSourceVersionId: "skillVersions:2",
+        latestVersionId: "skillVersions:2",
+        githubScanStatus: "clean",
+        stats: {
+          versions: 2,
+          downloads: 0,
+          stars: 0,
+          installsCurrent: 0,
+          installsAllTime: 0,
+          comments: 0,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects pending-review skill versions from public listing", () => {
+    expect(
+      isPubliclyListableSkillVersion({
+        _id: "skillVersions:pending",
+        skillId: "skills:1",
+        softDeletedAt: undefined,
+        version: "2.0.0",
+        createdAt: 1,
+        changelog: "c",
+        changelogSource: "user",
+        parsed: { frontmatter: {}, license: "MIT" },
+        vtAnalysis: { status: "pending", checkedAt: 1 },
+        llmAnalysis: undefined,
+        staticScan: undefined,
+      }),
+    ).toBe(false);
+  });
+});

--- a/convex/lib/publicBrowse.test.ts
+++ b/convex/lib/publicBrowse.test.ts
@@ -8,6 +8,15 @@ import {
   shouldExcludeSkillFromPublicBrowse,
 } from "./publicBrowse";
 
+const emptyStats = {
+  versions: 1,
+  downloads: 0,
+  stars: 0,
+  installsCurrent: 0,
+  installsAllTime: 0,
+  comments: 0,
+};
+
 describe("publicBrowse", () => {
   it("treats scanner review flags as pending public review", () => {
     expect(
@@ -38,16 +47,9 @@ describe("publicBrowse", () => {
         moderationFlags: undefined,
         moderationVerdict: "clean",
         moderationSourceVersionId: undefined,
-        latestVersionId: "skillVersions:1",
+        latestVersionId: "skillVersions:1" as never,
         githubScanStatus: "clean",
-        stats: {
-          versions: 1,
-          downloads: 0,
-          stars: 0,
-          installsCurrent: 0,
-          installsAllTime: 0,
-          comments: 0,
-        },
+        stats: emptyStats,
       }),
     ).toBe(true);
   });
@@ -55,14 +57,7 @@ describe("publicBrowse", () => {
   it("keeps previously approved skills visible while a newer version is pending review", () => {
     expect(
       hasPriorApprovedPublicSkillVersion({
-        stats: {
-          versions: 2,
-          downloads: 0,
-          stars: 0,
-          installsCurrent: 0,
-          installsAllTime: 0,
-          comments: 0,
-        },
+        stats: { ...emptyStats, versions: 2 },
       }),
     ).toBe(true);
     expect(
@@ -72,17 +67,10 @@ describe("publicBrowse", () => {
         moderationReason: "pending.scan",
         moderationFlags: undefined,
         moderationVerdict: "clean",
-        moderationSourceVersionId: "skillVersions:2",
-        latestVersionId: "skillVersions:2",
+        moderationSourceVersionId: "skillVersions:2" as never,
+        latestVersionId: "skillVersions:2" as never,
         githubScanStatus: "clean",
-        stats: {
-          versions: 2,
-          downloads: 0,
-          stars: 0,
-          installsCurrent: 0,
-          installsAllTime: 0,
-          comments: 0,
-        },
+        stats: { ...emptyStats, versions: 2 },
       }),
     ).toBe(false);
   });
@@ -90,14 +78,14 @@ describe("publicBrowse", () => {
   it("rejects pending-review skill versions from public listing", () => {
     expect(
       isPubliclyListableSkillVersion({
-        _id: "skillVersions:pending",
-        skillId: "skills:1",
+        _id: "skillVersions:pending" as never,
+        skillId: "skills:1" as never,
         softDeletedAt: undefined,
         version: "2.0.0",
         createdAt: 1,
         changelog: "c",
         changelogSource: "user",
-        parsed: { frontmatter: {}, license: "MIT" },
+        parsed: { frontmatter: {}, license: "MIT-0" },
         vtAnalysis: { status: "pending", checkedAt: 1 },
         llmAnalysis: undefined,
         staticScan: undefined,
@@ -107,18 +95,18 @@ describe("publicBrowse", () => {
 
   it("resolves the last approved version while a newer version is pending review", async () => {
     const approvedVersion = {
-      _id: "skillVersions:approved",
-      skillId: "skills:1",
+      _id: "skillVersions:approved" as never,
+      skillId: "skills:1" as never,
       softDeletedAt: undefined,
       version: "1.0.0",
       createdAt: 1,
       changelog: "approved",
-      changelogSource: "user",
-      parsed: { frontmatter: {}, license: "MIT" },
-      vtAnalysis: { status: "clean", checkedAt: 1 },
-      llmAnalysis: { status: "clean", checkedAt: 1 },
+      changelogSource: "user" as const,
+      parsed: { frontmatter: {}, license: "MIT-0" as const },
+      vtAnalysis: { status: "clean" as const, checkedAt: 1 },
+      llmAnalysis: { status: "clean" as const, checkedAt: 1 },
       staticScan: {
-        status: "clean",
+        status: "clean" as const,
         reasonCodes: [],
         findings: [],
         summary: "",
@@ -127,15 +115,15 @@ describe("publicBrowse", () => {
       },
     };
     const pendingVersion = {
-      _id: "skillVersions:pending",
-      skillId: "skills:1",
+      _id: "skillVersions:pending" as never,
+      skillId: "skills:1" as never,
       softDeletedAt: undefined,
       version: "2.0.0",
       createdAt: 2,
       changelog: "pending",
-      changelogSource: "user",
-      parsed: { frontmatter: {}, license: "MIT" },
-      vtAnalysis: { status: "pending", checkedAt: 2 },
+      changelogSource: "user" as const,
+      parsed: { frontmatter: {}, license: "MIT-0" as const },
+      vtAnalysis: { status: "pending" as const, checkedAt: 2 },
     };
 
     const version = await resolvePublicBrowseVersionForSkill(
@@ -144,13 +132,13 @@ describe("publicBrowse", () => {
           get: async (id: string) => {
             if (id === "skills:1") {
               return {
-                _id: "skills:1",
-                latestVersionId: "skillVersions:pending",
-                moderationSourceVersionId: "skillVersions:pending",
+                _id: "skills:1" as never,
+                latestVersionId: "skillVersions:pending" as never,
+                moderationSourceVersionId: "skillVersions:pending" as never,
                 moderationStatus: "active",
                 moderationReason: "pending.scan",
                 moderationFlags: undefined,
-                stats: { versions: 2 },
+                stats: { ...emptyStats, versions: 2 },
               };
             }
             if (id === "skillVersions:pending") return pendingVersion;
@@ -166,13 +154,13 @@ describe("publicBrowse", () => {
         },
       } as never,
       {
-        _id: "skills:1",
-        latestVersionId: "skillVersions:pending",
-        moderationSourceVersionId: "skillVersions:pending",
+        _id: "skills:1" as never,
+        latestVersionId: "skillVersions:pending" as never,
+        moderationSourceVersionId: "skillVersions:pending" as never,
         moderationStatus: "active",
         moderationReason: "pending.scan",
         moderationFlags: undefined,
-        stats: { versions: 2 },
+        stats: { ...emptyStats, versions: 2 },
         softDeletedAt: undefined,
         moderationVerdict: "clean",
         githubScanStatus: "clean",

--- a/convex/lib/publicBrowse.test.ts
+++ b/convex/lib/publicBrowse.test.ts
@@ -1,7 +1,8 @@
 /* @vitest-environment node */
 import { describe, expect, it } from "vitest";
 import {
-  hasPriorApprovedPublicSkillVersion,
+  hostedSkillMayHavePriorApprovedVersion,
+  isHostedSkillPendingFirstPublicRelease,
   isPubliclyListableSkillVersion,
   isSkillPendingPublicReview,
   resolvePublicBrowseVersionForSkill,
@@ -15,6 +16,17 @@ const emptyStats = {
   installsCurrent: 0,
   installsAllTime: 0,
   comments: 0,
+};
+
+const browseFields = {
+  softDeletedAt: undefined,
+  moderationStatus: "active" as const,
+  moderationFlags: undefined,
+  moderationVerdict: "clean" as const,
+  moderationSourceVersionId: undefined,
+  latestVersionId: "skillVersions:1" as never,
+  githubScanStatus: "clean" as const,
+  stats: emptyStats,
 };
 
 describe("publicBrowse", () => {
@@ -41,35 +53,45 @@ describe("publicBrowse", () => {
   it("excludes first-publish pending review skills from public browse", () => {
     expect(
       shouldExcludeSkillFromPublicBrowse({
-        softDeletedAt: undefined,
+        ...browseFields,
+        moderationReason: "pending.scan",
+      }),
+    ).toBe(true);
+    expect(
+      isHostedSkillPendingFirstPublicRelease({
+        installKind: undefined,
         moderationStatus: "active",
         moderationReason: "pending.scan",
         moderationFlags: undefined,
-        moderationVerdict: "clean",
-        moderationSourceVersionId: undefined,
-        latestVersionId: "skillVersions:1" as never,
-        githubScanStatus: "clean",
         stats: emptyStats,
       }),
     ).toBe(true);
   });
 
-  it("keeps previously approved skills visible while a newer version is pending review", () => {
+  it("keeps GitHub-backed pending verification visible in public browse", () => {
     expect(
-      hasPriorApprovedPublicSkillVersion({
+      shouldExcludeSkillFromPublicBrowse({
+        ...browseFields,
+        installKind: "github",
+        moderationReason: "pending.scan",
+        githubScanStatus: "pending",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps previously approved hosted skills visible while a newer version is pending review", () => {
+    expect(
+      hostedSkillMayHavePriorApprovedVersion({
+        installKind: undefined,
         stats: { ...emptyStats, versions: 2 },
       }),
     ).toBe(true);
     expect(
       shouldExcludeSkillFromPublicBrowse({
-        softDeletedAt: undefined,
-        moderationStatus: "active",
+        ...browseFields,
         moderationReason: "pending.scan",
-        moderationFlags: undefined,
-        moderationVerdict: "clean",
         moderationSourceVersionId: "skillVersions:2" as never,
         latestVersionId: "skillVersions:2" as never,
-        githubScanStatus: "clean",
         stats: { ...emptyStats, versions: 2 },
       }),
     ).toBe(false);
@@ -169,5 +191,54 @@ describe("publicBrowse", () => {
 
     expect(version?._id).toBe("skillVersions:approved");
     expect(version?.version).toBe("1.0.0");
+  });
+
+  it("returns null when every hosted version is still pending review", async () => {
+    const pendingV2 = {
+      _id: "skillVersions:pending-2" as never,
+      skillId: "skills:1" as never,
+      softDeletedAt: undefined,
+      version: "2.0.0",
+      createdAt: 2,
+      changelog: "pending",
+      changelogSource: "user" as const,
+      parsed: { frontmatter: {}, license: "MIT-0" as const },
+      vtAnalysis: { status: "pending" as const, checkedAt: 2 },
+    };
+    const pendingV1 = {
+      ...pendingV2,
+      _id: "skillVersions:pending-1" as never,
+      version: "1.0.0",
+      createdAt: 1,
+    };
+
+    const version = await resolvePublicBrowseVersionForSkill(
+      {
+        db: {
+          get: async () => null,
+          query: () => ({
+            withIndex: () => ({
+              order: () => ({
+                take: async () => [pendingV2, pendingV1],
+              }),
+            }),
+          }),
+        },
+      } as never,
+      {
+        _id: "skills:1" as never,
+        latestVersionId: "skillVersions:pending-2" as never,
+        moderationSourceVersionId: "skillVersions:pending-2" as never,
+        moderationStatus: "active",
+        moderationReason: "pending.scan",
+        moderationFlags: undefined,
+        stats: { ...emptyStats, versions: 2 },
+        softDeletedAt: undefined,
+        moderationVerdict: "clean",
+        githubScanStatus: "clean",
+      },
+    );
+
+    expect(version).toBeNull();
   });
 });

--- a/convex/lib/publicBrowse.ts
+++ b/convex/lib/publicBrowse.ts
@@ -16,6 +16,7 @@ type SkillPublicBrowseFields = Pick<
   | "moderationVerdict"
   | "moderationSourceVersionId"
   | "latestVersionId"
+  | "installKind"
   | "githubScanStatus"
   | "stats"
 >;
@@ -52,16 +53,35 @@ export function isSkillPendingPublicReview(
   return isPendingSkillModerationReason(skill.moderationReason);
 }
 
-export function hasPriorApprovedPublicSkillVersion(skill: Pick<Doc<"skills">, "stats">) {
-  return (skill.stats?.versions ?? 0) > 1;
+export function isHostedSkillPendingPublicReview(
+  skill: Pick<
+    Doc<"skills">,
+    "installKind" | "moderationStatus" | "moderationReason" | "moderationFlags"
+  >,
+) {
+  return skill.installKind !== "github" && isSkillPendingPublicReview(skill);
+}
+
+export function isHostedSkillPendingFirstPublicRelease(
+  skill: Pick<
+    Doc<"skills">,
+    "installKind" | "stats" | "moderationStatus" | "moderationReason" | "moderationFlags"
+  >,
+) {
+  return isHostedSkillPendingPublicReview(skill) && (skill.stats?.versions ?? 0) <= 1;
+}
+
+/** Cheap hint that a hosted skill may have an older public version to resolve. */
+export function hostedSkillMayHavePriorApprovedVersion(
+  skill: Pick<Doc<"skills">, "installKind" | "stats">,
+) {
+  return skill.installKind !== "github" && (skill.stats?.versions ?? 0) > 1;
 }
 
 export function shouldExcludeSkillFromPublicBrowse(skill: SkillPublicBrowseFields) {
   if (!isPublicSkillDoc(skill)) return true;
   if (isSkillSuspicious(skill)) return true;
-  if (normalizeSecurityScanStatus(skill.githubScanStatus) === "pending") return true;
-  if (!isSkillPendingPublicReview(skill)) return false;
-  return !hasPriorApprovedPublicSkillVersion(skill);
+  return isHostedSkillPendingFirstPublicRelease(skill);
 }
 
 export function isPubliclyListableSkillVersion(
@@ -75,6 +95,15 @@ export function isPubliclyListableSkillVersion(
   ];
   if (statuses.some((status) => status === "pending" || status === "not-run")) return false;
   return !statuses.some((status) => isSecurityScanStatusBlockedFromPublic(status));
+}
+
+export async function hasResolvablePublicBrowseVersion(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  skill: SkillPublicBrowseFields & { _id: Id<"skills"> },
+) {
+  if (shouldExcludeSkillFromPublicBrowse(skill)) return false;
+  if (!isHostedSkillPendingPublicReview(skill)) return true;
+  return (await resolvePublicBrowseVersionForSkill(ctx, skill)) !== null;
 }
 
 export async function resolvePublicBrowseVersionForSkill(
@@ -93,7 +122,7 @@ export async function resolvePublicBrowseVersionForSkill(
       : null;
   }
 
-  if (!hasPriorApprovedPublicSkillVersion(skill)) return null;
+  if (!hostedSkillMayHavePriorApprovedVersion(skill)) return null;
 
   const versions = await ctx.db
     .query("skillVersions")

--- a/convex/lib/publicBrowse.ts
+++ b/convex/lib/publicBrowse.ts
@@ -1,0 +1,111 @@
+import type { Doc, Id } from "../_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "../_generated/server";
+import { isPublicSkillDoc } from "./globalStats";
+import {
+  isSecurityScanStatusBlockedFromPublic,
+  normalizeSecurityScanStatus,
+} from "./securityScanPolicy";
+import { isSkillReviewFlagged, isSkillSuspicious } from "./skillSafety";
+
+type SkillPublicBrowseFields = Pick<
+  Doc<"skills">,
+  | "softDeletedAt"
+  | "moderationStatus"
+  | "moderationReason"
+  | "moderationFlags"
+  | "moderationVerdict"
+  | "moderationSourceVersionId"
+  | "latestVersionId"
+  | "githubScanStatus"
+  | "stats"
+>;
+
+type SkillVersionPublicBrowseFields = Pick<
+  Doc<"skillVersions">,
+  | "_id"
+  | "skillId"
+  | "softDeletedAt"
+  | "version"
+  | "createdAt"
+  | "changelog"
+  | "changelogSource"
+  | "parsed"
+  | "vtAnalysis"
+  | "llmAnalysis"
+  | "staticScan"
+>;
+
+function isPendingSkillModerationReason(reason: string | null | undefined) {
+  const normalized = reason?.trim().toLowerCase();
+  return (
+    normalized === "pending.scan" ||
+    normalized === "pending.scan.stale" ||
+    normalized === "scanner.vt.pending" ||
+    normalized === "scanner.llm.pending"
+  );
+}
+
+export function isSkillPendingPublicReview(
+  skill: Pick<Doc<"skills">, "moderationStatus" | "moderationReason" | "moderationFlags">,
+) {
+  if (isSkillReviewFlagged(skill)) return true;
+  return isPendingSkillModerationReason(skill.moderationReason);
+}
+
+export function hasPriorApprovedPublicSkillVersion(skill: Pick<Doc<"skills">, "stats">) {
+  return (skill.stats?.versions ?? 0) > 1;
+}
+
+export function shouldExcludeSkillFromPublicBrowse(skill: SkillPublicBrowseFields) {
+  if (!isPublicSkillDoc(skill)) return true;
+  if (isSkillSuspicious(skill)) return true;
+  if (normalizeSecurityScanStatus(skill.githubScanStatus) === "pending") return true;
+  if (!isSkillPendingPublicReview(skill)) return false;
+  return !hasPriorApprovedPublicSkillVersion(skill);
+}
+
+export function isPubliclyListableSkillVersion(
+  version: SkillVersionPublicBrowseFields | null | undefined,
+) {
+  if (!version || version.softDeletedAt) return false;
+  const statuses = [
+    normalizeSecurityScanStatus(version.vtAnalysis?.status),
+    normalizeSecurityScanStatus(version.llmAnalysis?.verdict ?? version.llmAnalysis?.status),
+    normalizeSecurityScanStatus(version.staticScan?.status),
+  ];
+  if (statuses.some((status) => status === "pending" || status === "not-run")) return false;
+  return !statuses.some((status) => isSecurityScanStatusBlockedFromPublic(status));
+}
+
+export async function resolvePublicBrowseVersionForSkill(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  skill: SkillPublicBrowseFields & { _id: Id<"skills"> },
+): Promise<Doc<"skillVersions"> | null> {
+  const latestVersionId = skill.latestVersionId;
+  if (!latestVersionId) return null;
+
+  if (!isSkillPendingPublicReview(skill)) {
+    const latestVersion = await ctx.db.get(latestVersionId);
+    return latestVersion &&
+      latestVersion.skillId === skill._id &&
+      isPubliclyListableSkillVersion(latestVersion)
+      ? latestVersion
+      : null;
+  }
+
+  if (!hasPriorApprovedPublicSkillVersion(skill)) return null;
+
+  const versions = await ctx.db
+    .query("skillVersions")
+    .withIndex("by_skill_active_created", (q) =>
+      q.eq("skillId", skill._id).eq("softDeletedAt", undefined),
+    )
+    .order("desc")
+    .take(24);
+
+  for (const version of versions) {
+    if (version._id === skill.moderationSourceVersionId) continue;
+    if (isPubliclyListableSkillVersion(version)) return version;
+  }
+  return null;
+}

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -708,7 +708,7 @@ describe("search helpers", () => {
     );
   });
 
-  it("preserves suspicious lexical fallback results when nonSuspiciousOnly is unset", async () => {
+  it("excludes suspicious lexical fallback results from public search", async () => {
     const clean = makeSkillDoc({ id: "skills:clean", slug: "orf-clean", displayName: "ORF Clean" });
     const suspicious = makeSkillDoc({
       id: "skills:suspicious",
@@ -727,7 +727,7 @@ describe("search helpers", () => {
       limit: 10,
     });
 
-    expect(result.map((entry) => entry.skill.slug)).toEqual(["orf-clean", "orf-suspicious"]);
+    expect(result.map((entry) => entry.skill.slug)).toEqual(["orf-clean"]);
     expect(ctx.usedIndexes).toEqual(
       expect.arrayContaining(["by_active_updated", "by_active_created"]),
     );

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -16,7 +16,10 @@ import { generateEmbedding } from "./lib/embeddings";
 import { hasOfficialPublisherRow, toPublicPublisherWithOfficial } from "./lib/officialPublishers";
 import type { HydratableSkill, PublicPublisher } from "./lib/public";
 import { toPublicSkill } from "./lib/public";
-import { shouldExcludeSkillFromPublicBrowse } from "./lib/publicBrowse";
+import {
+  hasResolvablePublicBrowseVersion,
+  shouldExcludeSkillFromPublicBrowse,
+} from "./lib/publicBrowse";
 import { getOwnerPublisher } from "./lib/publishers";
 import {
   matchesAllTokens,
@@ -901,8 +904,10 @@ export const hydrateResults = internalQuery({
         const resolved = preResolved?.owner
           ? await withOfficialOwnerInfo(ctx, preResolved)
           : await getOwnerInfo(skill.ownerUserId, skill.ownerPublisherId);
+        if (!resolved.owner) return null;
+        if (!(await hasResolvablePublicBrowseVersion(ctx, { ...skill, _id: skillId }))) return null;
         const publicSkill = toPublicSearchSkill(skill);
-        if (!publicSkill || !resolved.owner) return null;
+        if (!publicSkill) return null;
         return {
           embeddingId,
           skill: publicSkill,
@@ -1064,8 +1069,11 @@ export const lexicalFallbackSkills = internalQuery({
         const resolved = preResolved?.owner
           ? await withOfficialOwnerInfo(ctx, preResolved)
           : await getOwnerInfo(skill.ownerUserId, skill.ownerPublisherId);
+        if (!resolved.owner) return null;
+        if (!(await hasResolvablePublicBrowseVersion(ctx, { ...skill, _id: skill._id })))
+          return null;
         const publicSkill = toPublicSearchSkill(skill);
-        if (!publicSkill || !resolved.owner) return null;
+        if (!publicSkill) return null;
         return {
           skill: publicSkill,
           version: null as Doc<"skillVersions"> | null,

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -16,6 +16,7 @@ import { generateEmbedding } from "./lib/embeddings";
 import { hasOfficialPublisherRow, toPublicPublisherWithOfficial } from "./lib/officialPublishers";
 import type { HydratableSkill, PublicPublisher } from "./lib/public";
 import { toPublicSkill } from "./lib/public";
+import { shouldExcludeSkillFromPublicBrowse } from "./lib/publicBrowse";
 import { getOwnerPublisher } from "./lib/publishers";
 import {
   matchesAllTokens,
@@ -270,6 +271,7 @@ function matchesCatalogFilters(
 }
 
 function toPublicSearchSkill(skill: HydratableSkill) {
+  if (shouldExcludeSkillFromPublicBrowse(skill)) return null;
   return toPublicSkill({
     ...skill,
     categories: resolveStoredSkillCategories(skill),
@@ -576,10 +578,15 @@ export const directPrefixSkillMatches = internalQuery({
         ...(digest.categories ?? []),
         ...(digest.topics ?? []),
       ]);
-    const matchesDirectRecallFilters = (digest: Doc<"skillSearchDigest">) =>
-      (!args.highlightedOnly || isSkillHighlighted(digestToHydratableSkill(digest))) &&
-      passesAllQueryTokens(digest) &&
-      matchesCatalogFilters(digest, categorySlug, topic);
+    const matchesDirectRecallFilters = (digest: Doc<"skillSearchDigest">) => {
+      const skill = digestToHydratableSkill(digest);
+      return (
+        !shouldExcludeSkillFromPublicBrowse(skill) &&
+        (!args.highlightedOnly || isSkillHighlighted(skill)) &&
+        passesAllQueryTokens(digest) &&
+        matchesCatalogFilters(skill, categorySlug, topic)
+      );
+    };
     const needsExpandedRecall = Boolean(
       categorySlug || topic || args.highlightedOnly || queryTokens.length > 1,
     );
@@ -950,7 +957,7 @@ export const lexicalFallbackSkills = internalQuery({
         .take(MAX_EXACT_SLUG_MATCHES);
       for (const exactSlugSkill of exactSlugSkills) {
         if (
-          !exactSlugSkill.softDeletedAt &&
+          !shouldExcludeSkillFromPublicBrowse(exactSlugSkill) &&
           (!args.nonSuspiciousOnly || !isSkillSuspicious(exactSlugSkill)) &&
           (!args.excludePendingScan || exactSlugSkill.githubScanStatus !== "pending") &&
           matchesCatalogFilters(exactSlugSkill, categorySlug, topic)
@@ -994,6 +1001,7 @@ export const lexicalFallbackSkills = internalQuery({
     const matchesFallbackRecallFilters = (digest: Doc<"skillSearchDigest">) => {
       const skill = digestToHydratableSkill(digest);
       return (
+        !shouldExcludeSkillFromPublicBrowse(skill) &&
         (!args.highlightedOnly || isSkillHighlighted(skill)) &&
         (!args.excludePendingScan || skill.githubScanStatus !== "pending") &&
         matchesCatalogFilters(skill, categorySlug, topic) &&

--- a/convex/skills.listPublicPageV4.test.ts
+++ b/convex/skills.listPublicPageV4.test.ts
@@ -87,7 +87,7 @@ describe("skills.listPublicPageV4", () => {
     });
   });
 
-  it("falls back to updated results while recommendation scores are missing", () => {
+  it("falls back to the recommended rank index while recommendation scores are missing", () => {
     expect(
       __test.resolveRecommendedPublicListQuery({
         scoreIndexName: "by_active_recommended_score",
@@ -99,8 +99,8 @@ describe("skills.listPublicPageV4", () => {
         hasMissingScores: true,
       }),
     ).toEqual({
-      sort: "updated",
-      indexName: "by_active_updated",
+      sort: "recommended",
+      indexName: "by_active_recommended_rank",
       decodedCursor: null,
     });
   });

--- a/convex/skills.packageCatalog.test.ts
+++ b/convex/skills.packageCatalog.test.ts
@@ -428,7 +428,7 @@ describe("skills package catalog queries", () => {
     expect(indexNames).not.toContain("by_active_topic_updated");
   });
 
-  it("falls topic recommendation sorting back to downloads while scores are missing", async () => {
+  it("keeps topic recommended sorting on the recommendation score index while scores are missing", async () => {
     const indexNames: string[] = [];
     const calendarSkill = makeDigest("calendar-skill", { topics: ["calendar"] });
 
@@ -444,7 +444,7 @@ describe("skills package catalog queries", () => {
               },
             ],
             isDone: false,
-            continueCursor: "downloads-next",
+            continueCursor: "recommended-next",
           },
         ],
         [calendarSkill],
@@ -459,9 +459,9 @@ describe("skills package catalog queries", () => {
     );
 
     expect(result.page.map((entry) => entry.name)).toEqual(["calendar-skill"]);
-    expect(indexNames).toContain("by_active_topic_downloads");
-    expect(indexNames).not.toContain("by_active_topic_recommended_score");
-    expect(result.continueCursor).toContain('"recommendedFallback":"downloads"');
+    expect(indexNames).toContain("by_active_topic_recommended_score");
+    expect(indexNames).not.toContain("by_active_topic_downloads");
+    expect(result.continueCursor).not.toContain('"recommendedFallback":"downloads"');
   });
 
   it("keeps legacy topic recommendation fallback cursors on the updated index", async () => {
@@ -606,12 +606,7 @@ describe("skills package catalog queries", () => {
       },
     );
 
-    expect(indexNames).toEqual([
-      "by_active_recommended_score",
-      "by_active_recommended_score_version",
-      "by_active_recommended_score_version",
-      "by_active_recommended_score",
-    ]);
+    expect(indexNames).toEqual(["by_active_recommended_score"]);
     expect(result.page).toEqual([
       expect.objectContaining({
         name: "recommended-skill",
@@ -620,7 +615,7 @@ describe("skills package catalog queries", () => {
     ]);
   });
 
-  it("falls back to downloads sort for recommended package catalog rows while scores backfill", async () => {
+  it("keeps recommended package catalog rows on the recommendation score index while scores backfill", async () => {
     const indexNames: string[] = [];
     const result = await listPackageCatalogPageHandler(
       makeCtx(
@@ -628,7 +623,7 @@ describe("skills package catalog queries", () => {
           {
             page: [makeDigest("fallback-skill")],
             isDone: false,
-            continueCursor: "next-updated-page",
+            continueCursor: "next-recommended-page",
           },
         ],
         {
@@ -644,13 +639,9 @@ describe("skills package catalog queries", () => {
       },
     );
 
-    expect(indexNames).toEqual([
-      "by_active_recommended_score",
-      "by_active_recommended_score_version",
-      "by_active_stats_downloads",
-    ]);
+    expect(indexNames).toEqual(["by_active_recommended_score"]);
     expect(result.page).toEqual([expect.objectContaining({ name: "fallback-skill" })]);
-    expect(result.continueCursor).toContain('"recommendedFallback":"downloads"');
+    expect(result.continueCursor).not.toContain('"recommendedFallback":"downloads"');
   });
 
   it("uses the recommended score index for recommended package catalog rows", async () => {
@@ -681,7 +672,7 @@ describe("skills package catalog queries", () => {
     expect(result.page).toEqual([expect.objectContaining({ name: "recommended-skill" })]);
   });
 
-  it("falls recommended package catalog rows back to downloads when scores are missing", async () => {
+  it("keeps recommended package catalog rows on the recommendation score index when scores are missing", async () => {
     const indexNames: string[] = [];
     const result = await listPackageCatalogPageHandler(
       makeCtx(
@@ -689,7 +680,7 @@ describe("skills package catalog queries", () => {
           {
             page: [makeDigest("download-fallback-skill")],
             isDone: false,
-            continueCursor: "updated-next",
+            continueCursor: "recommended-next",
           },
         ],
         { indexNames, missingRecommendedScores: true },
@@ -700,9 +691,9 @@ describe("skills package catalog queries", () => {
       },
     );
 
-    expect(indexNames).toEqual(["by_active_recommended_score", "by_active_stats_downloads"]);
+    expect(indexNames).toEqual(["by_active_recommended_score"]);
     expect(result.page).toEqual([expect.objectContaining({ name: "download-fallback-skill" })]);
-    expect(result.continueCursor).toContain('"recommendedFallback":"downloads"');
+    expect(result.continueCursor).not.toContain('"recommendedFallback":"downloads"');
   });
 
   it("keeps recommended package catalog cursors on their original index", async () => {

--- a/convex/skills.publicListCursor.test.ts
+++ b/convex/skills.publicListCursor.test.ts
@@ -382,7 +382,7 @@ describe("public skill list deterministic cursors", () => {
     });
   });
 
-  it("keeps topic recommendation fallback cursors on the updated index", async () => {
+  it("keeps topic recommended browse on the recommended score index when scores are missing", async () => {
     const firstDigest = makeSearchDigest({
       skillId: "skills:calendar-one",
       slug: "calendar-one",
@@ -452,12 +452,12 @@ describe("public skill list deterministic cursors", () => {
     expect(first.nextCursor).not.toBeNull();
     expect(second.nextCursor).toBeNull();
     expect(getPageMock.mock.calls[0]?.[1]).toMatchObject({
-      index: "by_active_topic_updated",
+      index: "by_active_topic_recommended_score",
       startIndexKey: [undefined, "calendar"],
       startInclusive: true,
     });
     expect(getPageMock.mock.calls[1]?.[1]).toMatchObject({
-      index: "by_active_topic_updated",
+      index: "by_active_topic_recommended_score",
       startIndexKey: firstIndexKey,
       startInclusive: false,
     });
@@ -543,7 +543,7 @@ describe("public skill list deterministic cursors", () => {
     });
   });
 
-  it("falls back to the updated index while recommendation scores are missing", async () => {
+  it("falls back to the recommended rank index while recommendation scores are missing", async () => {
     const { ctx, withIndex } = makeMissingRecommendedScoresCtx();
 
     await listPublicPageV4Handler(ctx, {
@@ -555,14 +555,14 @@ describe("public skill list deterministic cursors", () => {
     ]);
     expect(getPageMock).toHaveBeenCalledTimes(1);
     expect(getPageMock.mock.calls[0]?.[1]).toMatchObject({
-      index: "by_active_updated",
+      index: "by_active_recommended_rank",
       startIndexKey: [undefined],
       endIndexKey: [undefined],
       startInclusive: true,
     });
   });
 
-  it("falls back to the non-suspicious updated index while recommendation scores are missing", async () => {
+  it("falls back to the non-suspicious recommended rank index while recommendation scores are missing", async () => {
     const { ctx, withIndex } = makeMissingRecommendedScoresCtx();
 
     await listPublicApiPageV1Handler(ctx, {
@@ -576,7 +576,7 @@ describe("public skill list deterministic cursors", () => {
     ]);
     expect(getPageMock).toHaveBeenCalledTimes(1);
     expect(getPageMock.mock.calls[0]?.[1]).toMatchObject({
-      index: "by_nonsuspicious_updated",
+      index: "by_nonsuspicious_recommended_rank",
       startIndexKey: [undefined, false],
       endIndexKey: [undefined, false],
       startInclusive: true,

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -6005,55 +6005,72 @@ async function addOfficialStatusToOwnerInfo(
 
 async function loadPublicLatestVersionForDigest(
   ctx: Pick<QueryCtx, "db">,
-  digest: Pick<Doc<"skillSearchDigest">, "skillId" | "latestVersionId" | "latestVersionSkillId">,
+  digest: Pick<
+    Doc<"skillSearchDigest">,
+    | "skillId"
+    | "latestVersionId"
+    | "latestVersionSkillId"
+    | "moderationReason"
+    | "moderationFlags"
+    | "stats"
+    | "moderationSourceVersionId"
+  >,
 ) {
   if (!digest.latestVersionId) return null;
   if (digest.latestVersionSkillId !== undefined && digest.latestVersionSkillId !== digest.skillId) {
     return null;
   }
-  const skill = await ctx.db.get(digest.skillId);
-  if (skill && isSkillPendingPublicReview(skill) && hasPriorApprovedPublicSkillVersion(skill)) {
-    const version = await resolvePublicBrowseVersionForSkill(ctx, skill);
-    return version && isPublicSkillVersionAvailableForSkill(version, digest.skillId)
-      ? version
-      : null;
-  }
-  const version = await ctx.db.get(digest.latestVersionId);
-  return isPublicSkillVersionAvailableForSkill(version, digest.skillId) ? version : null;
-}
 
-function toDigestLatestVersionForSkill(digest: Doc<"skillSearchDigest">) {
-  if (!digest.latestVersionSummary || !digest.latestVersionId) {
-    return null;
+  const needsApprovedSnapshot =
+    isSkillPendingPublicReview(digest) && hasPriorApprovedPublicSkillVersion(digest);
+
+  if (!needsApprovedSnapshot) {
+    const version = await ctx.db.get(digest.latestVersionId);
+    return isPublicSkillVersionAvailableForSkill(version, digest.skillId) ? version : null;
   }
-  if (digest.latestVersionSkillId !== digest.skillId) {
-    return null;
-  }
-  return toPublicSkillListVersionFromSummary(
-    digest.latestVersionSummary,
-    digest.latestVersionId,
-    digest.skillId,
-  );
+
+  const skill = await ctx.db.get(digest.skillId);
+  if (!skill) return null;
+  const version = await resolvePublicBrowseVersionForSkill(ctx, skill);
+  return version && isPublicSkillVersionAvailableForSkill(version, digest.skillId) ? version : null;
 }
 
 async function resolveDigestLatestVersionForSkill(
   ctx: Pick<QueryCtx, "db">,
   digest: Doc<"skillSearchDigest">,
 ) {
-  if (!digest.latestVersionSummary || !digest.latestVersionId) {
-    return null;
+  const needsApprovedSnapshot =
+    isSkillPendingPublicReview(digest) && hasPriorApprovedPublicSkillVersion(digest);
+
+  if (
+    !needsApprovedSnapshot &&
+    digest.latestVersionSummary &&
+    digest.latestVersionId &&
+    (digest.latestVersionSkillId === undefined || digest.latestVersionSkillId === digest.skillId)
+  ) {
+    return toPublicSkillListVersionFromSummary(
+      digest.latestVersionSummary,
+      digest.latestVersionId,
+      digest.skillId,
+    );
   }
-  if (digest.latestVersionSkillId === undefined) {
-    const latestVersion = await loadPublicLatestVersionForDigest(ctx, digest);
-    return latestVersion
-      ? toPublicSkillListVersionFromSummary(
-          digest.latestVersionSummary,
-          digest.latestVersionId,
-          digest.skillId,
-        )
-      : null;
+
+  const version = await loadPublicLatestVersionForDigest(ctx, digest);
+  if (!version) return null;
+
+  if (
+    digest.latestVersionSummary &&
+    digest.latestVersionId === version._id &&
+    (digest.latestVersionSkillId === undefined || digest.latestVersionSkillId === digest.skillId)
+  ) {
+    return toPublicSkillListVersionFromSummary(
+      digest.latestVersionSummary,
+      version._id,
+      digest.skillId,
+    );
   }
-  return toDigestLatestVersionForSkill(digest);
+
+  return toPublicSkillListVersion(version);
 }
 
 async function buildPublicSkillApiListEntryFromDigest(

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -88,6 +88,12 @@ import {
   toPublicUser,
 } from "./lib/public";
 import {
+  hasPriorApprovedPublicSkillVersion,
+  isSkillPendingPublicReview,
+  resolvePublicBrowseVersionForSkill,
+  shouldExcludeSkillFromPublicBrowse,
+} from "./lib/publicBrowse";
+import {
   assertCanManageOwnedResource,
   canAccessPublisherOwnerScope,
   ensurePersonalPublisherForUser,
@@ -5423,16 +5429,10 @@ export const listPublicPageV4 = query({
     }
 
     if (officialFirstCursor && categorySlug) {
-      const sort =
-        officialFirstCursor.sort ??
-        (requestedSort === "recommended" &&
-        (await hasMissingRecommendedScores(ctx, args.nonSuspiciousOnly ?? false, null))
-          ? "updated"
-          : requestedSort);
       return await listOfficialFirstSkillCategoryPage(ctx, {
-        state: { ...officialFirstCursor, sort },
-        sort,
-        dir: resolvePublicListDir(sort, args.dir),
+        state: { ...officialFirstCursor, sort: officialFirstCursor.sort ?? requestedSort },
+        sort: officialFirstCursor.sort ?? requestedSort,
+        dir: resolvePublicListDir(officialFirstCursor.sort ?? requestedSort, args.dir),
         numItems,
         topic,
         categorySlug,
@@ -5713,20 +5713,9 @@ async function listSkillTopicFilteredPage(
       allowLegacyArray: false,
     });
   const recommendedCursor = opts.sort === "recommended" ? decodeTopicCursor("recommended") : null;
-  const updatedCursor = opts.sort === "recommended" ? decodeTopicCursor("updated") : null;
-  const useUpdatedRecommendationFallback =
-    opts.sort === "recommended" &&
-    (Boolean(updatedCursor) ||
-      (!recommendedCursor &&
-        (await hasMissingRecommendedScores(ctx, opts.nonSuspiciousOnly, null))));
-  const sort = useUpdatedRecommendationFallback ? "updated" : opts.sort;
+  const sort = opts.sort;
   const indexName = getTopicIndexName(sort);
-  const decodedCursor =
-    opts.sort === "recommended"
-      ? sort === "updated"
-        ? updatedCursor
-        : recommendedCursor
-      : decodeTopicCursor(sort);
+  const decodedCursor = opts.sort === "recommended" ? recommendedCursor : decodeTopicCursor(sort);
   const items: PublicSkillEntry[] = [];
   let scanCursor = decodedCursor ?? eqPrefix;
   let scanInclusive = !decodedCursor;
@@ -5986,6 +5975,7 @@ async function buildPublicSkillEntryFromDigest(
   digest: Doc<"skillSearchDigest">,
 ): Promise<PublicSkillEntry | null> {
   const hydratable = digestToHydratableSkill(digest);
+  if (shouldExcludeSkillFromPublicBrowse(hydratable)) return null;
   const publicSkill = toPublicSkill(hydratable);
   if (!publicSkill) return null;
   const ownerInfo = await addOfficialStatusToOwnerInfo(
@@ -6020,6 +6010,13 @@ async function loadPublicLatestVersionForDigest(
   if (!digest.latestVersionId) return null;
   if (digest.latestVersionSkillId !== undefined && digest.latestVersionSkillId !== digest.skillId) {
     return null;
+  }
+  const skill = await ctx.db.get(digest.skillId);
+  if (skill && isSkillPendingPublicReview(skill) && hasPriorApprovedPublicSkillVersion(skill)) {
+    const version = await resolvePublicBrowseVersionForSkill(ctx, skill);
+    return version && isPublicSkillVersionAvailableForSkill(version, digest.skillId)
+      ? version
+      : null;
   }
   const version = await ctx.db.get(digest.latestVersionId);
   return isPublicSkillVersionAvailableForSkill(version, digest.skillId) ? version : null;
@@ -6306,6 +6303,7 @@ function skillCatalogMatchesFilters(
   },
 ) {
   if (!isVisibleSkillCatalogDigest(digest)) return false;
+  if (shouldExcludeSkillFromPublicBrowse(digestToHydratableSkill(digest))) return false;
   if (args.channel === "private") return false;
   const isOfficial = isSkillCatalogOfficial(digest);
   const channel = getSkillCatalogChannel(digest);
@@ -6366,15 +6364,7 @@ async function listSkillPackageCatalogTopicPage(
   let done = decodedCursor.done;
   let loops = 0;
   let remainingScanBudget = MAX_SKILL_CATALOG_SCAN_DOCUMENTS;
-  const isFreshRecommendedRequest =
-    args.sort === "recommended" && args.paginationOpts.cursor === null;
-  const recommendedFallback =
-    args.sort === "recommended"
-      ? (decodedCursor.recommendedFallback ??
-        (isFreshRecommendedRequest && (await hasMissingRecommendedScores(ctx, false, null))
-          ? SKILL_CATALOG_RECOMMENDED_FALLBACK_SORT
-          : undefined))
-      : undefined;
+  const recommendedFallback = decodedCursor.recommendedFallback;
   const catalogSort = recommendedFallback ?? args.sort;
 
   while (
@@ -6588,15 +6578,7 @@ export const listPackageCatalogPage = query({
     let done = decodedCursor.done;
     let loops = 0;
     let remainingScanBudget = MAX_SKILL_CATALOG_SCAN_DOCUMENTS;
-    const isFreshRecommendedRequest =
-      args.sort === "recommended" && args.paginationOpts.cursor === null;
-    const recommendedFallback =
-      args.sort === "recommended"
-        ? (decodedCursor.recommendedFallback ??
-          (isFreshRecommendedRequest && (await hasMissingRecommendedScores(ctx, false, null))
-            ? SKILL_CATALOG_RECOMMENDED_FALLBACK_SORT
-            : undefined))
-        : undefined;
+    const recommendedFallback = decodedCursor.recommendedFallback;
     const catalogSort = recommendedFallback ?? args.sort;
 
     while (
@@ -6925,7 +6907,7 @@ function resolveRecommendedPublicListQuery({
     return { sort: "updated", indexName: updatedIndexName, decodedCursor: updatedCursor };
   }
   if (hasMissingScores) {
-    return { sort: "updated", indexName: updatedIndexName, decodedCursor: null };
+    return { sort: "recommended", indexName: rankIndexName, decodedCursor: null };
   }
   return { sort: "recommended", indexName: scoreIndexName, decodedCursor: null };
 }

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -6013,7 +6013,6 @@ async function loadPublicLatestVersionForDigest(
     | "moderationReason"
     | "moderationFlags"
     | "stats"
-    | "moderationSourceVersionId"
   >,
 ) {
   if (!digest.latestVersionId) return null;
@@ -6077,7 +6076,9 @@ async function buildPublicSkillApiListEntryFromDigest(
   ctx: Pick<QueryCtx, "db">,
   digest: Doc<"skillSearchDigest">,
 ) {
-  const publicSkill = toPublicSkill(digestToHydratableSkill(digest));
+  const hydratable = digestToHydratableSkill(digest);
+  if (shouldExcludeSkillFromPublicBrowse(hydratable)) return null;
+  const publicSkill = toPublicSkill(hydratable);
   if (!publicSkill) return null;
   const ownerInfo = digestToOwnerInfo(digest);
   if (!ownerInfo?.owner) return null;

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -88,8 +88,8 @@ import {
   toPublicUser,
 } from "./lib/public";
 import {
-  hasPriorApprovedPublicSkillVersion,
-  isSkillPendingPublicReview,
+  hostedSkillMayHavePriorApprovedVersion,
+  isHostedSkillPendingPublicReview,
   resolvePublicBrowseVersionForSkill,
   shouldExcludeSkillFromPublicBrowse,
 } from "./lib/publicBrowse";
@@ -5121,6 +5121,7 @@ export const listPublicPageV3 = query({
       );
       if (!ownerInfo?.owner) continue;
       const latestVersion = await resolveDigestLatestVersionForSkill(ctx, digest);
+      if (isHostedSkillPendingPublicReview(hydratable) && !latestVersion) continue;
       items.push({
         skill: publicSkill,
         latestVersion,
@@ -5985,6 +5986,7 @@ async function buildPublicSkillEntryFromDigest(
   );
   if (!ownerInfo?.owner) return null;
   const latestVersion = await resolveDigestLatestVersionForSkill(ctx, digest);
+  if (isHostedSkillPendingPublicReview(hydratable) && !latestVersion) return null;
   return {
     skill: publicSkill,
     latestVersion,
@@ -6013,6 +6015,7 @@ async function loadPublicLatestVersionForDigest(
     | "moderationReason"
     | "moderationFlags"
     | "stats"
+    | "installKind"
   >,
 ) {
   if (!digest.latestVersionId) return null;
@@ -6021,7 +6024,7 @@ async function loadPublicLatestVersionForDigest(
   }
 
   const needsApprovedSnapshot =
-    isSkillPendingPublicReview(digest) && hasPriorApprovedPublicSkillVersion(digest);
+    isHostedSkillPendingPublicReview(digest) && hostedSkillMayHavePriorApprovedVersion(digest);
 
   if (!needsApprovedSnapshot) {
     const version = await ctx.db.get(digest.latestVersionId);
@@ -6039,7 +6042,7 @@ async function resolveDigestLatestVersionForSkill(
   digest: Doc<"skillSearchDigest">,
 ) {
   const needsApprovedSnapshot =
-    isSkillPendingPublicReview(digest) && hasPriorApprovedPublicSkillVersion(digest);
+    isHostedSkillPendingPublicReview(digest) && hostedSkillMayHavePriorApprovedVersion(digest);
 
   if (
     !needsApprovedSnapshot &&
@@ -6083,6 +6086,7 @@ async function buildPublicSkillApiListEntryFromDigest(
   const ownerInfo = digestToOwnerInfo(digest);
   if (!ownerInfo?.owner) return null;
   const latestVersion = await resolveDigestLatestVersionForSkill(ctx, digest);
+  if (isHostedSkillPendingPublicReview(hydratable) && !latestVersion) return null;
 
   return {
     skill: {
@@ -6335,9 +6339,11 @@ function skillCatalogMatchesFilters(
 async function toPublicSkillCatalogItem(
   ctx: Pick<QueryCtx, "db">,
   digest: Doc<"skillSearchDigest">,
-): Promise<PublicSkillCatalogItem> {
+): Promise<PublicSkillCatalogItem | null> {
+  const hydratable = digestToHydratableSkill(digest);
   const ownerInfo = digestToOwnerInfo(digest);
   const latestVersion = await resolveDigestLatestVersionForSkill(ctx, digest);
+  if (isHostedSkillPendingPublicReview(hydratable) && !latestVersion) return null;
   return {
     name: digest.slug,
     displayName: digest.displayName,
@@ -6423,7 +6429,9 @@ async function listSkillPackageCatalogTopicPage(
         .withIndex("by_skill", (q) => q.eq("skillId", topicDigest.skillId))
         .unique();
       if (!digest || !skillCatalogMatchesFilters(digest, args)) continue;
-      collected.push(await toPublicSkillCatalogItem(ctx, digest));
+      const item = await toPublicSkillCatalogItem(ctx, digest);
+      if (!item) continue;
+      collected.push(item);
       if (collected.length >= targetCount) {
         const nextOffset = index + 1;
         if (nextOffset < page.page.length) {
@@ -6633,7 +6641,9 @@ export const listPackageCatalogPage = query({
       for (let index = offset; index < page.page.length; index += 1) {
         const digest = page.page[index];
         if (!skillCatalogMatchesFilters(digest, args)) continue;
-        collected.push(await toPublicSkillCatalogItem(ctx, digest));
+        const item = await toPublicSkillCatalogItem(ctx, digest);
+        if (!item) continue;
+        collected.push(item);
         if (collected.length >= targetCount) {
           const nextOffset = index + 1;
           if (nextOffset < page.page.length) {
@@ -6725,10 +6735,13 @@ async function searchPackageCatalogImpl(ctx: QueryCtx, args: SkillPackageCatalog
       const match = skillCatalogSearchMatch(exactDigest, queryText);
       if (match) {
         seen.add(exactDigest.skillId);
-        matches.push({
-          ...match,
-          package: await toPublicSkillCatalogItem(ctx, exactDigest),
-        });
+        const catalogItem = await toPublicSkillCatalogItem(ctx, exactDigest);
+        if (catalogItem) {
+          matches.push({
+            ...match,
+            package: catalogItem,
+          });
+        }
       }
     }
   }
@@ -6769,9 +6782,11 @@ async function searchPackageCatalogImpl(ctx: QueryCtx, args: SkillPackageCatalog
         const match = skillCatalogSearchMatch(digest, queryText);
         if (!match || seen.has(digest.skillId)) continue;
         seen.add(digest.skillId);
+        const catalogItem = await toPublicSkillCatalogItem(ctx, digest);
+        if (!catalogItem) continue;
         matches.push({
           ...match,
-          package: await toPublicSkillCatalogItem(ctx, digest),
+          package: catalogItem,
         });
         if (matches.length >= targetCount) break;
       }
@@ -6810,9 +6825,11 @@ async function searchPackageCatalogImpl(ctx: QueryCtx, args: SkillPackageCatalog
       const match = skillCatalogSearchMatch(digest, queryText);
       if (!match || seen.has(digest.skillId)) continue;
       seen.add(digest.skillId);
+      const catalogItem = await toPublicSkillCatalogItem(ctx, digest);
+      if (!catalogItem) continue;
       matches.push({
         ...match,
-        package: await toPublicSkillCatalogItem(ctx, digest),
+        package: catalogItem,
       });
     }
   }


### PR DESCRIPTION
## Summary

- Keeps the `/skills` **All** tab on recommended discovery ranking instead of silently falling back to `updatedAt` ordering when recommendation scores are missing or stale (uses the recommended rank index as a score-based proxy).
- Leaves **Recently updated** as the explicit `updatedAt desc` sort only.
- Excludes pending-review, suspicious, hidden, and other non-public items from public browse/search.
- When a skill already has an approved public release and a newer version is pending review, browse/search keeps showing the approved public state (not the pending version).

## Test plan

- [x] `bunx vitest run` on touched Convex tests (`publicBrowse`, `listPublicPageV4`, `publicListCursor`, `packageCatalog`, `search`, `backportLatest`)
- [x] `git diff --check`
- [x] `bun run ci:static`
- [x] `bun run ci:unit`