### PR TITLE
fix(ui): harden skill and plugin detail polish

### DIFF
--- a/src/__tests__/packages-route.test.tsx
+++ b/src/__tests__/packages-route.test.tsx
@@ -54,6 +54,8 @@ vi.mock("@tanstack/react-router", () => ({
       useSearch: () => searchMock,
       useLoaderData: () => loaderDataMock,
     }),
+  useRouterState: (options: { select: (state: unknown) => unknown }) =>
+    options.select({ location: { searchStr: "" } }),
   Link: (props: { children: ReactNode }) => <a href="/">{props.children}</a>,
   redirect: (args: unknown) => redirectMock(args),
 }));

--- a/src/__tests__/skill-detail-page.test.tsx
+++ b/src/__tests__/skill-detail-page.test.tsx
@@ -271,7 +271,9 @@ describe("SkillDetailPage", () => {
 
     expect(screen.queryByRole("status", { name: /Loading skill details/i })).toBeNull();
     expect(screen.getAllByRole("heading", { name: "Github" }).length).toBeGreaterThan(0);
-    expect(screen.getByText(/Interact with GitHub using the `gh` CLI\./i)).toBeTruthy();
+    const summary = document.querySelector(".skill-summary-line");
+    expect(summary?.textContent).toBe("Interact with GitHub using the gh CLI.");
+    expect(summary?.querySelector("code.skill-summary-inline-code")?.textContent).toBe("gh");
   });
 
   it("loads skill activity graphs through a deferred one-shot query", async () => {

--- a/src/__tests__/skills-index-load-more.test.tsx
+++ b/src/__tests__/skills-index-load-more.test.tsx
@@ -18,6 +18,8 @@ vi.mock("@tanstack/react-router", () => ({
     useNavigate: () => navigateMock,
     useSearch: () => searchMock,
   }),
+  useRouterState: (options: { select: (state: unknown) => unknown }) =>
+    options.select({ location: { searchStr: "" } }),
   redirect: (options: unknown) => ({ redirect: options }),
   Link: (props: { children: ReactNode }) => <a href="/">{props.children}</a>,
 }));

--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -19,6 +19,8 @@ vi.mock("@tanstack/react-router", () => ({
     useNavigate: () => navigateMock,
     useSearch: () => searchMock,
   }),
+  useRouterState: (options: { select: (state: unknown) => unknown }) =>
+    options.select({ location: { searchStr: "" } }),
   redirect: (options: unknown) => ({ redirect: options }),
   Link: (props: { children: ReactNode }) => <a href="/">{props.children}</a>,
 }));
@@ -46,6 +48,20 @@ describe("SkillsIndex", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
+  });
+
+  it("maps topic search params", () => {
+    const validateSearch = (
+      SkillsRoute as unknown as {
+        __config: {
+          validateSearch: (search: Record<string, unknown>) => Record<string, unknown>;
+        };
+      }
+    ).__config.validateSearch;
+
+    expect(validateSearch({ topic: "github" })).toEqual(
+      expect.objectContaining({ topic: "github" }),
+    );
   });
 
   it("maps legacy category URLs before browsing", () => {
@@ -678,7 +694,7 @@ describe("SkillsIndex", () => {
     expect(screen.queryByText(/\d+ loaded/)).toBeNull();
   });
 
-  it("passes author topics to browse filtering without rendering topic navigation", async () => {
+  it("passes author topics to browse filtering and shows the active topic chip", async () => {
     searchMock = { topic: "google-calendar" };
     convexHttpMock.query.mockResolvedValue({
       page: [
@@ -698,7 +714,8 @@ describe("SkillsIndex", () => {
         topic: "google-calendar",
       }),
     );
-    expect(screen.queryByRole("radio", { name: "google-calendar" })).toBeNull();
+    const topicChip = screen.getByRole("button", { name: "Clear topic google-calendar" });
+    expect(topicChip).toBeTruthy();
     expect(screen.queryByRole("radio", { name: "All topics" })).toBeNull();
   });
 
@@ -741,7 +758,7 @@ describe("SkillsIndex", () => {
     expect(lastCall.replace).toBe(true);
   });
 
-  it("clears the active category topic when its chip is selected again", async () => {
+  it("clears the active category topic when its clear button is pressed", async () => {
     searchMock = { category: "development", topic: "docker" };
     convexReactMocks.useQuery.mockImplementation((_reference, args) => {
       if (
@@ -758,22 +775,19 @@ describe("SkillsIndex", () => {
     render(<SkillsIndex />);
     await act(async () => {});
 
-    const topic = screen.getByRole("button", { name: "#docker" });
-    expect(topic.getAttribute("aria-pressed")).toBe("true");
-    fireEvent.click(topic);
+    fireEvent.click(screen.getByRole("button", { name: "Clear topic docker" }));
 
     const lastCall = navigateMock.mock.calls.at(-1)?.[0] as {
       search: (prev: Record<string, unknown>) => Record<string, unknown>;
     };
     expect(lastCall.search({ category: "development", topic: "docker" })).toEqual({
       category: "development",
-      topic: undefined,
       featured: undefined,
       highlighted: undefined,
     });
   });
 
-  it("does not render an active topic in the sidebar when it has no results", async () => {
+  it("shows the active topic chip when topic filtering returns no results", async () => {
     searchMock = { topic: "google-calendar" };
     convexHttpMock.query.mockResolvedValue({
       page: [],
@@ -784,7 +798,7 @@ describe("SkillsIndex", () => {
     render(<SkillsIndex />);
     await act(async () => {});
 
-    expect(screen.queryByRole("radio", { name: "google-calendar" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Clear topic google-calendar" })).toBeTruthy();
     expect(screen.queryByRole("radio", { name: "All topics" })).toBeNull();
   });
 

--- a/src/components/BrowseControls.tsx
+++ b/src/components/BrowseControls.tsx
@@ -570,19 +570,49 @@ type BrowseTopicChipsProps = {
 };
 
 export function BrowseTopicChips({ topics, activeTopic, onChange }: BrowseTopicChipsProps) {
-  const safeTopics = Array.isArray(topics) ? topics : [];
-  if (safeTopics.length === 0) return null;
+  const displayTopics = useMemo(() => {
+    const safeTopics = Array.isArray(topics) ? topics.filter(Boolean) : [];
+    if (!activeTopic || safeTopics.includes(activeTopic)) return safeTopics;
+    return [activeTopic, ...safeTopics];
+  }, [activeTopic, topics]);
+
+  if (displayTopics.length === 0) return null;
+
+  const ariaLabel =
+    displayTopics.length === 1 && activeTopic ? "Active topic filter" : "Top topics";
+
   return (
-    <div className="browse-topic-chips" aria-label="Top topics">
-      {safeTopics.slice(0, 8).map((topic) => {
+    <div className="browse-topic-chips" aria-label={ariaLabel}>
+      {displayTopics.slice(0, 8).map((topic) => {
         const active = activeTopic === topic;
+        if (active) {
+          return (
+            <span
+              key={topic}
+              className="browse-topic-chip is-active"
+              role="group"
+              aria-label={`Topic filter ${topic}`}
+            >
+              <span className="browse-topic-chip-label">#{topic}</span>
+              <button
+                type="button"
+                className="browse-topic-chip-clear"
+                aria-label={`Clear topic ${topic}`}
+                onClick={() => onChange(undefined)}
+              >
+                <X size={12} strokeWidth={2.25} aria-hidden="true" />
+              </button>
+            </span>
+          );
+        }
+
         return (
           <button
             key={topic}
             type="button"
-            className={`browse-topic-chip${active ? " is-active" : ""}`}
-            aria-pressed={active}
-            onClick={() => onChange(active ? undefined : topic)}
+            className="browse-topic-chip"
+            aria-pressed={false}
+            onClick={() => onChange(topic)}
           >
             #{topic}
           </button>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,6 +7,7 @@ import {
   ChevronDown,
   Command,
   LayoutDashboard,
+  Loader2,
   Menu,
   Monitor,
   Moon,
@@ -884,7 +885,12 @@ function SearchTypeahead({
           </div>
         ) : null}
         {hasQuery && loading && !hasMatches ? (
-          <div className="navbar-search-typeahead-status">Searching...</div>
+          <div className="navbar-search-typeahead-status is-loading">
+            <span className="navbar-search-typeahead-status-icon" aria-hidden="true">
+              <Loader2 className="navbar-search-typeahead-status-spinner" size={17} />
+            </span>
+            <span>Searching…</span>
+          </div>
         ) : null}
         {hasQuery && !loading && !hasMatches ? (
           <div className="navbar-search-typeahead-status">

--- a/src/components/InlineCodeSummary.tsx
+++ b/src/components/InlineCodeSummary.tsx
@@ -1,0 +1,24 @@
+import { Fragment } from "react";
+import { parseInlineCodeSummary } from "../lib/formatInlineCodeSummary";
+
+type InlineCodeSummaryProps = {
+  children: string;
+};
+
+export function InlineCodeSummary({ children }: InlineCodeSummaryProps) {
+  const segments = parseInlineCodeSummary(children);
+
+  return (
+    <>
+      {segments.map((segment, index) =>
+        segment.type === "code" ? (
+          <code key={index} className="skill-summary-inline-code">
+            {segment.value}
+          </code>
+        ) : (
+          <Fragment key={index}>{segment.value}</Fragment>
+        ),
+      )}
+    </>
+  );
+}

--- a/src/components/InstallCopyButton.tsx
+++ b/src/components/InstallCopyButton.tsx
@@ -41,6 +41,8 @@ export function InstallCopyButton({
   tooltip,
   className,
   showLabel = true,
+  variant = "outline",
+  size = "sm",
 }: {
   text: string;
   label?: string;
@@ -49,6 +51,8 @@ export function InstallCopyButton({
   tooltip?: string;
   className?: string;
   showLabel?: boolean;
+  variant?: "default" | "primary" | "secondary" | "destructive" | "ghost" | "outline" | "link";
+  size?: "default" | "xs" | "sm" | "lg" | "icon" | "icon-xs" | "icon-sm" | "icon-lg";
 }) {
   const [copyState, setCopyState] = useState<CopyState>("idle");
   const resetTimeoutRef = useRef<number | null>(null);
@@ -79,8 +83,8 @@ export function InstallCopyButton({
   const button = (
     <Button
       type="button"
-      size="sm"
-      variant="outline"
+      size={size}
+      variant={variant}
       className={cn("skill-install-copy-button", className)}
       aria-label={ariaLabel ?? label}
       title={tooltip ? undefined : title}

--- a/src/components/PluginVersionsPanel.tsx
+++ b/src/components/PluginVersionsPanel.tsx
@@ -150,16 +150,19 @@ export function PluginVersionsPanel({
           </div>
         ) : releases.length > 0 || nextCursor ? (
           <div className="skill-versions-scroll">
-            <div className="skill-versions-list">
-              <div className="skill-versions-column-header" aria-hidden="true">
-                <span>Version</span>
-                <span>Tags</span>
-                <span>Release</span>
-                <span className="skill-versions-column-header-download">
+            <div className="skill-versions-list skill-versions-list-plugins">
+              <div
+                className="skill-versions-column-header skill-versions-column-header-plugins"
+                aria-hidden="true"
+              >
+                <span className="skill-versions-col-version">Version</span>
+                <span className="skill-versions-col-tags">Tags</span>
+                <span className="skill-versions-col-release">Release</span>
+                <span className="skill-versions-col-download">
                   <Download size={13} aria-hidden="true" />
                   <span className="sr-only">Download</span>
                 </span>
-                <span />
+                <span className="skill-versions-col-expand" />
               </div>
               {releases.map((release) => {
                 const hasLatestTag = release.distTags?.includes("latest");

--- a/src/components/SkillDiffCard.test.tsx
+++ b/src/components/SkillDiffCard.test.tsx
@@ -13,6 +13,10 @@ vi.mock("convex/react", () => ({
   useAction: () => getFileTextMock,
 }));
 
+vi.mock("../lib/monacoLoader", () => ({
+  ensureMonacoLoader: () => Promise.resolve(),
+}));
+
 vi.mock("@monaco-editor/react", () => ({
   DiffEditor: ({
     className,

--- a/src/components/SkillDiffCard.tsx
+++ b/src/components/SkillDiffCard.tsx
@@ -23,9 +23,11 @@ import {
   selectDefaultFilePath,
   sortVersionsBySemver,
 } from "../lib/diffing";
+import { ensureMonacoLoader } from "../lib/monacoLoader";
 import { isDarkThemeResolved, onThemeChange } from "../lib/theme";
 import { ClientOnly } from "./ClientOnly";
 import { Button } from "./ui/button";
+import { Skeleton } from "./ui/skeleton";
 
 type SkillDiffCardProps = {
   skill: Doc<"skills">;
@@ -109,6 +111,34 @@ function useCompactDiffLayout(threshold = COMPACT_DIFF_THRESHOLD) {
   return { ref, isCompact };
 }
 
+function DiffViewerLoading() {
+  return (
+    <div
+      className="diff-skeleton-editor diff-skeleton-editor-embedded"
+      role="status"
+      aria-label="Loading diff"
+    >
+      <div className="diff-skeleton-gutter" aria-hidden="true">
+        <Skeleton />
+        <Skeleton />
+        <Skeleton />
+        <Skeleton />
+        <Skeleton />
+        <Skeleton />
+      </div>
+      <div className="diff-skeleton-code" aria-hidden="true">
+        <Skeleton className="w-[18%]" />
+        <Skeleton className="w-[58%]" />
+        <Skeleton className="w-[82%]" />
+        <Skeleton className="w-[72%]" />
+        <Skeleton className="mt-4 w-[34%]" />
+        <Skeleton className="w-[66%]" />
+        <Skeleton className="w-[48%]" />
+      </div>
+    </div>
+  );
+}
+
 export function SkillDiffCard({ skill, versions, variant = "card" }: SkillDiffCardProps) {
   const getFileText = useAction(api.skills.getFileText);
   const monaco = useMonaco();
@@ -121,6 +151,8 @@ export function SkillDiffCard({ skill, versions, variant = "card" }: SkillDiffCa
   const [rightText, setRightText] = useState(EMPTY_DIFF_TEXT);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [monacoReady, setMonacoReady] = useState(false);
+  const [monacoError, setMonacoError] = useState<string | null>(null);
   const [sizeWarning, setSizeWarning] = useState<SizeWarning | null>(null);
   const cacheRef = useRef(new Map<string, string>());
   const userSelectedViewModeRef = useRef(false);
@@ -350,6 +382,24 @@ export function SkillDiffCard({ skill, versions, variant = "card" }: SkillDiffCa
       cancelled = true;
     };
   }, [getFileText, leftVersionId, rightVersionId, selectedItem]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void ensureMonacoLoader()
+      .then(() => {
+        if (!cancelled) setMonacoReady(true);
+      })
+      .catch((loadError) => {
+        if (!cancelled) {
+          setMonacoError(
+            loadError instanceof Error ? loadError.message : "Failed to load diff viewer",
+          );
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (!monaco || typeof document === "undefined") return () => {};
@@ -593,18 +643,20 @@ export function SkillDiffCard({ skill, versions, variant = "card" }: SkillDiffCa
             <div className="diff-empty">Select two versions.</div>
           ) : !fileSelected ? (
             <div className="diff-empty">Select a file.</div>
+          ) : monacoError ? (
+            <div className="diff-empty">{monacoError}</div>
+          ) : !monacoReady || isLoading ? (
+            <DiffViewerLoading />
           ) : (
-            <ClientOnly fallback={<div className="diff-empty">Preparing diff…</div>}>
+            <ClientOnly fallback={<DiffViewerLoading />}>
               <DiffEditor
                 className={`diff-monaco diff-monaco-${viewMode}`}
                 original={leftText}
                 modified={rightText}
                 theme={getMonacoThemeName()}
-                loading={<div className="diff-empty">Loading diff…</div>}
                 options={diffOptions}
                 onMount={handleDiffMount}
               />
-              {isLoading ? <div className="diff-loading">Loading…</div> : null}
             </ClientOnly>
           )}
         </div>

--- a/src/components/SkillFilesPanel.test.tsx
+++ b/src/components/SkillFilesPanel.test.tsx
@@ -55,6 +55,49 @@ describe("SkillFilesPanel", () => {
     });
   });
 
+  it("shows a loading skeleton while fetching uncached file content", () => {
+    getFileTextMock.mockImplementation(
+      () =>
+        new Promise<{ text: string; size: number; sha256: string }>(() => {
+          /* never resolves */
+        }),
+    );
+
+    const { container } = render(
+      <SkillFilesPanel
+        versionId={"skillVersions:1" as Id<"skillVersions">}
+        latestFiles={[makeFile("scripts/run.sh", 10)]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /scripts\/run\.sh/i }));
+
+    expect(container.querySelector(".file-viewer.is-loading")).not.toBeNull();
+    expect(container.querySelector(".file-viewer-skeleton")).not.toBeNull();
+    expect(screen.getByRole("status", { name: "Loading file" })).toBeTruthy();
+  });
+
+  it("clears the loading min-height after file content resolves", async () => {
+    getFileTextMock.mockResolvedValue({
+      text: "echo hello",
+      size: 10,
+      sha256: "a".repeat(64),
+    });
+
+    const { container } = render(
+      <SkillFilesPanel
+        versionId={"skillVersions:1" as Id<"skillVersions">}
+        latestFiles={[makeFile("scripts/run.sh", 10)]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /scripts\/run\.sh/i }));
+    await screen.findByText("echo hello");
+
+    expect(container.querySelector(".file-viewer.is-loading")).toBeNull();
+    expect(container.querySelector(".file-viewer")?.getAttribute("style")).toBeNull();
+  });
+
   it("renders an empty file after it loads", async () => {
     const { container } = render(
       <SkillFilesPanel

--- a/src/components/SkillFilesPanel.tsx
+++ b/src/components/SkillFilesPanel.tsx
@@ -280,7 +280,9 @@ export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps
                 ) : null}
               </div>
             </div>
-            <div className={`file-viewer-body${isViewerLoading ? " file-viewer-body-loading" : ""}`}>
+            <div
+              className={`file-viewer-body${isViewerLoading ? " file-viewer-body-loading" : ""}`}
+            >
               {isViewerLoading ? (
                 <FileViewerSkeleton />
               ) : fileError ? (

--- a/src/components/SkillFilesPanel.tsx
+++ b/src/components/SkillFilesPanel.tsx
@@ -97,6 +97,19 @@ function getFileTreeLevelStyle(level: number) {
   return { "--file-tree-level": level } as CSSProperties;
 }
 
+const FILE_VIEWER_SKELETON_LINES = 10;
+
+function FileViewerSkeleton() {
+  return (
+    <div className="file-viewer-skeleton" role="status" aria-label="Loading file">
+      {Array.from({ length: FILE_VIEWER_SKELETON_LINES }, (_, index) => (
+        <span key={index} className="file-viewer-skeleton-line" />
+      ))}
+      <span className="file-viewer-skeleton-fill" aria-hidden="true" />
+    </div>
+  );
+}
+
 export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps) {
   const getFileText = useAction(api.skills.getFileText);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
@@ -144,18 +157,19 @@ export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps
 
       requestId.current += 1;
       const current = requestId.current;
-      if (fileListRef.current) {
-        setViewerMinHeight(fileListRef.current.offsetHeight);
-      }
       setSelectedPath(path);
       setFileError(null);
       if (cached) {
+        setViewerMinHeight(undefined);
         setFileContent(cached.text);
         setFileMeta({ size: cached.size, sha256: cached.sha256 });
         setIsLoading(false);
         return;
       }
 
+      if (fileListRef.current) {
+        setViewerMinHeight(fileListRef.current.offsetHeight);
+      }
       setFileContent(null);
       setFileMeta(null);
       setIsLoading(true);
@@ -167,12 +181,14 @@ export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps
           setFileContent(data.text);
           setFileMeta({ size: data.size, sha256: data.sha256 });
           setIsLoading(false);
+          setViewerMinHeight(undefined);
         })
         .catch((error) => {
           if (!isMounted.current) return;
           if (requestId.current !== current) return;
           setFileError(error instanceof Error ? error.message : "Failed to load file");
           setIsLoading(false);
+          setViewerMinHeight(undefined);
         });
     },
     [fileContent, getFileText, isLoading, selectedPath, versionId],
@@ -187,6 +203,8 @@ export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps
     setIsLoading(false);
     setViewerMinHeight(undefined);
   };
+
+  const isViewerLoading = isLoading && fileContent === null && fileError === null;
 
   const selectedFileSize =
     fileMeta?.size ?? latestFiles.find((file) => file.path === selectedPath)?.size;
@@ -230,8 +248,8 @@ export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps
       <div className={`file-browser${selectedPath ? " is-viewing-file" : ""}`}>
         {selectedPath ? (
           <div
-            className="file-viewer"
-            style={viewerMinHeight ? { minHeight: viewerMinHeight } : undefined}
+            className={`file-viewer${isViewerLoading ? " is-loading" : ""}`}
+            style={isViewerLoading && viewerMinHeight ? { minHeight: viewerMinHeight } : undefined}
           >
             <div className="file-viewer-header">
               <button
@@ -262,9 +280,9 @@ export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps
                 ) : null}
               </div>
             </div>
-            <div className="file-viewer-body">
-              {isLoading ? (
-                <div className="stat">Loading…</div>
+            <div className={`file-viewer-body${isViewerLoading ? " file-viewer-body-loading" : ""}`}>
+              {isViewerLoading ? (
+                <FileViewerSkeleton />
               ) : fileError ? (
                 <div className="stat">Failed to load file: {fileError}</div>
               ) : fileContent !== null ? (
@@ -273,7 +291,11 @@ export function SkillFilesPanel({ versionId, latestFiles }: SkillFilesPanelProps
                 </pre>
               ) : null}
             </div>
-            {fileMeta ? (
+            {isViewerLoading ? (
+              <div className="file-viewer-meta file-viewer-meta-skeleton" aria-hidden="true">
+                <span className="file-viewer-skeleton-hash" />
+              </div>
+            ) : fileMeta ? (
               <div className="file-viewer-meta">
                 <Fingerprint size={14} className="file-viewer-hash-icon" aria-hidden="true" />
                 <span className="file-viewer-hash">{fileMeta.sha256}</span>

--- a/src/components/SkillHeader.test.tsx
+++ b/src/components/SkillHeader.test.tsx
@@ -501,6 +501,20 @@ describe("SkillHeader", () => {
     expect(container.querySelector(".skill-hero-title-row .skill-title-actions")).toBeNull();
   });
 
+  it("places Star on the creator row on mobile detail layout", () => {
+    setViewportWidth(390);
+    const { container } = renderHeader();
+
+    expect(container.querySelector(".skill-sidebar-star-band")).toBeNull();
+    const creator = container.querySelector(".skill-hero-creator");
+    expect(creator).toBeTruthy();
+    const starButton = within(creator as HTMLElement).getByRole("button", {
+      name: "Star skill",
+    });
+    expect(starButton.className).toContain("skill-sidebar-star-action");
+    expect(starButton.closest(".skill-hero-creator-star")).toBeTruthy();
+  });
+
   it("does not render a separate warning banner for scanner warnings", () => {
     renderHeader({
       modInfo: {

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -7,13 +7,15 @@ import type { Doc, Id } from "../../convex/_generated/dataModel";
 import type { ActivityTrend } from "../lib/activityTrend";
 import { getSkillBadges, isSkillOfficial } from "../lib/badges";
 import { BrowseCategoryIcon } from "../lib/browseCategoryIcons";
-import { buildSkillCategoryBrowseHref, type SkillCategory } from "../lib/categories";
+import { buildSkillCategoryBrowseHref, buildSkillTopicBrowseHref, formatCatalogTopicLabel, type SkillCategory } from "../lib/categories";
 import { formatSkillStatsTriplet } from "../lib/numberFormat";
 import { buildPublisherProfileHref } from "../lib/ownerRoute";
 import type { PublicPublisher, PublicSkill } from "../lib/publicUser";
 import { timeAgo } from "../lib/timeAgo";
 import { useHeroCreatorPublisher } from "../lib/useHeroCreatorPublisher";
+import { useMediaQuery } from "../lib/useMediaQuery";
 import { ActivityMetricLabel } from "./ActivityMetricLabel";
+import { InlineCodeSummary } from "./InlineCodeSummary";
 import { DetailHero, DETAIL_HERO_TOPIC_LIMIT } from "./DetailPageShell";
 import { DetailSecuritySummaryLabel } from "./DetailSecuritySummary";
 import { useDownloadsSidebarMetricBlock } from "./DownloadsMetricCard";
@@ -53,7 +55,7 @@ const SUMMARY_COLLAPSE_THRESHOLD = 220;
 type MobileDetailPanel = "content" | "stats";
 
 function formatHeaderTopic(topic: string) {
-  return `#${topic.trim().toLowerCase().replace(/\s+/g, "-")}`;
+  return formatCatalogTopicLabel(topic);
 }
 
 type SkillHeaderLatestVersion =
@@ -189,6 +191,7 @@ export function SkillHeader({
   const hasSummaryToggle = headerDescription.length > SUMMARY_COLLAPSE_THRESHOLD;
   const [isSummaryExpanded, setIsSummaryExpanded] = useState(false);
   const [mobileDetailPanel, setMobileDetailPanel] = useState<MobileDetailPanel>("content");
+  const isMobileDetailLayout = useMediaQuery("(max-width: 900px)");
 
   const renderStarAction = () => (
     <SignedInActionTooltip
@@ -342,9 +345,11 @@ export function SkillHeader({
         topClassName={hasPluginBundle ? "has-plugin" : undefined}
         sidebar={
           <div className="skill-hero-sidebar-stack">
-            <div className="skill-sidebar-star-band detail-hero-summary-row">
-              {renderStarAction()}
-            </div>
+            {!isMobileDetailLayout ? (
+              <div className="skill-sidebar-star-band detail-hero-summary-row">
+                {renderStarAction()}
+              </div>
+            ) : null}
             <div className="detail-sidebar-stats">{desktopStatsContent}</div>
           </div>
         }
@@ -394,9 +399,14 @@ export function SkillHeader({
                     {headerTopics.length > 0 ? (
                       <div className="skill-hero-topic-list" aria-label="Topics">
                         {headerTopics.map((topic) => (
-                          <span className="skill-hero-topic" key={topic}>
+                          <a
+                            key={topic}
+                            className="skill-hero-topic"
+                            href={buildSkillTopicBrowseHref(topic)}
+                            aria-label={`View skills tagged ${formatHeaderTopic(topic)}`}
+                          >
                             {formatHeaderTopic(topic)}
-                          </span>
+                          </a>
                         ))}
                       </div>
                     ) : null}
@@ -447,7 +457,7 @@ export function SkillHeader({
                     hasSummaryToggle && !isSummaryExpanded ? " line-clamp-2" : ""
                   }`}
                 >
-                  {headerDescription}
+                  <InlineCodeSummary>{headerDescription}</InlineCodeSummary>
                 </p>
                 {hasSummaryToggle ? (
                   <button
@@ -473,6 +483,9 @@ export function SkillHeader({
                     stackMutedHandleBelowName
                     disableTooltip
                   />
+                  {isMobileDetailLayout ? (
+                    <div className="skill-hero-creator-star">{renderStarAction()}</div>
+                  ) : null}
                 </div>
               ) : null}
 

--- a/src/components/SkillHeader.tsx
+++ b/src/components/SkillHeader.tsx
@@ -7,7 +7,12 @@ import type { Doc, Id } from "../../convex/_generated/dataModel";
 import type { ActivityTrend } from "../lib/activityTrend";
 import { getSkillBadges, isSkillOfficial } from "../lib/badges";
 import { BrowseCategoryIcon } from "../lib/browseCategoryIcons";
-import { buildSkillCategoryBrowseHref, buildSkillTopicBrowseHref, formatCatalogTopicLabel, type SkillCategory } from "../lib/categories";
+import {
+  buildSkillCategoryBrowseHref,
+  buildSkillTopicBrowseHref,
+  formatCatalogTopicLabel,
+  type SkillCategory,
+} from "../lib/categories";
 import { formatSkillStatsTriplet } from "../lib/numberFormat";
 import { buildPublisherProfileHref } from "../lib/ownerRoute";
 import type { PublicPublisher, PublicSkill } from "../lib/publicUser";
@@ -15,10 +20,10 @@ import { timeAgo } from "../lib/timeAgo";
 import { useHeroCreatorPublisher } from "../lib/useHeroCreatorPublisher";
 import { useMediaQuery } from "../lib/useMediaQuery";
 import { ActivityMetricLabel } from "./ActivityMetricLabel";
-import { InlineCodeSummary } from "./InlineCodeSummary";
 import { DetailHero, DETAIL_HERO_TOPIC_LIMIT } from "./DetailPageShell";
 import { DetailSecuritySummaryLabel } from "./DetailSecuritySummary";
 import { useDownloadsSidebarMetricBlock } from "./DownloadsMetricCard";
+import { InlineCodeSummary } from "./InlineCodeSummary";
 import { SidebarMetadata } from "./SidebarMetadata";
 import { buildSkillHref } from "./skillDetailUtils";
 import { SkillCommandLineCard } from "./SkillInstallSurface";

--- a/src/components/SkillInstallSurface.tsx
+++ b/src/components/SkillInstallSurface.tsx
@@ -273,6 +273,8 @@ export function SkillCommandLineCard({
             }
             className="skill-install-command-inline-button"
             showLabel={false}
+            variant="ghost"
+            size="icon-sm"
           />
         </div>
       </div>

--- a/src/components/SkillVersionsPanel.tsx
+++ b/src/components/SkillVersionsPanel.tsx
@@ -108,12 +108,15 @@ export function SkillVersionsPanel({
           ) : null}
         </div>
         <div className="skill-versions-scroll">
-          <div className="skill-versions-list skill-versions-list-without-checks">
-            <div className="skill-versions-column-header" aria-hidden="true">
-              <span>Version</span>
-              <span>Release</span>
-              <span className="skill-versions-column-header-download">Download</span>
-              <span />
+          <div className="skill-versions-list skill-versions-list-skills">
+            <div
+              className="skill-versions-column-header skill-versions-column-header-skills"
+              aria-hidden="true"
+            >
+              <span className="skill-versions-col-version">Version</span>
+              <span className="skill-versions-col-release">Release</span>
+              <span className="skill-versions-col-download">Download</span>
+              <span className="skill-versions-col-expand" />
             </div>
             {visibleVersions.map((version) => {
               const isLatest =

--- a/src/lib/browseTopicSearch.test.ts
+++ b/src/lib/browseTopicSearch.test.ts
@@ -21,7 +21,9 @@ describe("browseTopicSearch", () => {
   });
 
   it("removes malformed topic keys when sanitizing search state", () => {
-    expect(sanitizeBrowseTopicSearch({ "topic=github": "", category: "development" }, "github")).toEqual({
+    expect(
+      sanitizeBrowseTopicSearch({ "topic=github": "", category: "development" }, "github"),
+    ).toEqual({
       category: "development",
       topic: "github",
     });

--- a/src/lib/browseTopicSearch.test.ts
+++ b/src/lib/browseTopicSearch.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseBrowseTopicFromSearchInput,
+  parseBrowseTopicFromSearchString,
+  sanitizeBrowseTopicSearch,
+} from "./browseTopicSearch";
+
+describe("browseTopicSearch", () => {
+  it("parses a normal topic query param", () => {
+    expect(parseBrowseTopicFromSearchString("?topic=github")).toBe("github");
+    expect(parseBrowseTopicFromSearchInput({ topic: "github" })).toBe("github");
+  });
+
+  it("parses malformed topic%3Dgithub query strings", () => {
+    expect(parseBrowseTopicFromSearchString("?topic%3Dgithub")).toBe("github");
+    expect(parseBrowseTopicFromSearchInput({ "topic=github": "" })).toBe("github");
+  });
+
+  it("normalizes topic labels", () => {
+    expect(parseBrowseTopicFromSearchString("?topic=GitHub")).toBe("github");
+  });
+
+  it("removes malformed topic keys when sanitizing search state", () => {
+    expect(sanitizeBrowseTopicSearch({ "topic=github": "", category: "development" }, "github")).toEqual({
+      category: "development",
+      topic: "github",
+    });
+    expect(sanitizeBrowseTopicSearch({ "topic=github": "", topic: "github" }, null)).toEqual({});
+  });
+});

--- a/src/lib/browseTopicSearch.ts
+++ b/src/lib/browseTopicSearch.ts
@@ -55,10 +55,7 @@ export function parseBrowseTopicFromSearchString(searchStr: string | undefined) 
   return parseTopicFromSearchParams(new URLSearchParams(normalized));
 }
 
-export function hasMalformedBrowseTopicSearch(
-  search: Record<string, unknown>,
-  searchStr?: string,
-) {
+export function hasMalformedBrowseTopicSearch(search: Record<string, unknown>, searchStr?: string) {
   if (Object.keys(search).some((key) => key.startsWith("topic="))) {
     return true;
   }

--- a/src/lib/browseTopicSearch.ts
+++ b/src/lib/browseTopicSearch.ts
@@ -1,0 +1,95 @@
+import { normalizeCatalogTopic } from "clawhub-schema";
+
+function parseTopicSlug(value: string | undefined) {
+  if (!value) return undefined;
+  return normalizeCatalogTopic(value) ?? undefined;
+}
+
+function parseTopicFromSearchParams(params: URLSearchParams) {
+  const direct = parseTopicSlug(params.get("topic") ?? undefined);
+  if (direct) return direct;
+
+  for (const [key, value] of params.entries()) {
+    if (key.startsWith("topic=")) {
+      const embedded = parseTopicSlug(key.slice("topic=".length) || value);
+      if (embedded) return embedded;
+    }
+  }
+
+  return undefined;
+}
+
+export function parseBrowseTopicFromSearchInput(
+  search: Record<string, unknown> | string | undefined,
+) {
+  if (search == null) return undefined;
+
+  if (typeof search === "string") {
+    const normalized = search.startsWith("?") ? search.slice(1) : search;
+    return parseTopicFromSearchParams(new URLSearchParams(normalized));
+  }
+
+  const direct = parseTopicSlug(typeof search.topic === "string" ? search.topic : undefined);
+  if (direct) return direct;
+
+  for (const [key, value] of Object.entries(search)) {
+    if (key === "topic" && typeof value === "string") {
+      const topic = parseTopicSlug(value);
+      if (topic) return topic;
+    }
+    if (key.startsWith("topic=")) {
+      const embedded = parseTopicSlug(
+        key.slice("topic=".length) || (typeof value === "string" ? value : undefined),
+      );
+      if (embedded) return embedded;
+    }
+  }
+
+  return undefined;
+}
+
+export function parseBrowseTopicFromSearchString(searchStr: string | undefined) {
+  if (!searchStr) return undefined;
+  const normalized = searchStr.startsWith("?") ? searchStr.slice(1) : searchStr;
+  if (!normalized) return undefined;
+  return parseTopicFromSearchParams(new URLSearchParams(normalized));
+}
+
+export function hasMalformedBrowseTopicSearch(
+  search: Record<string, unknown>,
+  searchStr?: string,
+) {
+  if (Object.keys(search).some((key) => key.startsWith("topic="))) {
+    return true;
+  }
+  if (!searchStr) return false;
+  const normalized = searchStr.startsWith("?") ? searchStr.slice(1) : searchStr;
+  if (!normalized) return false;
+  for (const key of new URLSearchParams(normalized).keys()) {
+    if (key.startsWith("topic=")) return true;
+  }
+  return false;
+}
+
+export function sanitizeBrowseTopicSearch<T extends Record<string, unknown>>(
+  search: T,
+  topic?: string | null,
+): T {
+  const next = { ...search } as Record<string, unknown>;
+  for (const key of Object.keys(next)) {
+    if (key === "topic" || key.startsWith("topic=")) {
+      delete next[key];
+    }
+  }
+
+  if (topic === null) {
+    return next as T;
+  }
+
+  const resolvedTopic = topic ?? parseBrowseTopicFromSearchInput(search);
+  if (resolvedTopic) {
+    next.topic = resolvedTopic;
+  }
+
+  return next as T;
+}

--- a/src/lib/categories.test.ts
+++ b/src/lib/categories.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildPluginTopicBrowseHref,
   buildSkillCategoryBrowseHref,
+  buildSkillTopicBrowseHref,
+  formatCatalogTopicLabel,
   getSkillCategoryForSkill,
   resolvePluginBrowseCategorySlug,
   resolveSkillBrowseCategorySlug,
@@ -47,5 +50,16 @@ describe("skill category helpers", () => {
     });
 
     expect(category?.slug).toBe("operations");
+  });
+});
+
+describe("catalog topic browse helpers", () => {
+  it("formats topic labels with a hash prefix", () => {
+    expect(formatCatalogTopicLabel("Agent Security")).toBe("#agent-security");
+  });
+
+  it("builds skill and plugin browse links from topic slugs", () => {
+    expect(buildSkillTopicBrowseHref("security-audit")).toBe("/skills?topic=security-audit");
+    expect(buildPluginTopicBrowseHref("security-audit")).toBe("/plugins?topic=security-audit");
   });
 });

--- a/src/lib/categories.ts
+++ b/src/lib/categories.ts
@@ -1,6 +1,7 @@
 import {
   isPluginCategorySlug,
   isSkillCategorySlug,
+  normalizeCatalogTopic,
   PLUGIN_CATEGORY_DEFINITIONS,
   resolveStoredSkillCategories,
   SKILL_CATEGORY_DEFINITIONS,
@@ -143,5 +144,24 @@ export function buildSkillCategoryBrowseHref(category: SkillCategory) {
 
 export function buildPluginCategoryBrowseHref(category: BrowseCategory) {
   const params = new URLSearchParams({ category: category.slug });
+  return `/plugins?${params.toString()}`;
+}
+
+export function formatCatalogTopicLabel(topic: string) {
+  const normalized = normalizeCatalogTopic(topic);
+  return `#${normalized ?? topic.trim().normalize("NFKC").toLocaleLowerCase("en-US")}`;
+}
+
+export function buildSkillTopicBrowseHref(topic: string) {
+  const normalized = normalizeCatalogTopic(topic);
+  if (!normalized) return "/skills";
+  const params = new URLSearchParams({ topic: normalized });
+  return `/skills?${params.toString()}`;
+}
+
+export function buildPluginTopicBrowseHref(topic: string) {
+  const normalized = normalizeCatalogTopic(topic);
+  if (!normalized) return "/plugins";
+  const params = new URLSearchParams({ topic: normalized });
   return `/plugins?${params.toString()}`;
 }

--- a/src/lib/formatInlineCodeSummary.test.ts
+++ b/src/lib/formatInlineCodeSummary.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { parseInlineCodeSummary } from "./formatInlineCodeSummary";
+
+describe("parseInlineCodeSummary", () => {
+  it("returns plain text when there are no backticks", () => {
+    expect(parseInlineCodeSummary("Get current weather.")).toEqual([
+      { type: "text", value: "Get current weather." },
+    ]);
+  });
+
+  it("parses a single inline code span", () => {
+    expect(parseInlineCodeSummary("Use the `gh` CLI.")).toEqual([
+      { type: "text", value: "Use the " },
+      { type: "code", value: "gh" },
+      { type: "text", value: " CLI." },
+    ]);
+  });
+
+  it("parses multiple inline code spans", () => {
+    expect(parseInlineCodeSummary("Use `gh issue`, `gh pr`, and `gh run`.")).toEqual([
+      { type: "text", value: "Use " },
+      { type: "code", value: "gh issue" },
+      { type: "text", value: ", " },
+      { type: "code", value: "gh pr" },
+      { type: "text", value: ", and " },
+      { type: "code", value: "gh run" },
+      { type: "text", value: "." },
+    ]);
+  });
+
+  it("leaves unmatched backticks as plain text", () => {
+    expect(parseInlineCodeSummary("Broken `quote")).toEqual([
+      { type: "text", value: "Broken `quote" },
+    ]);
+  });
+});

--- a/src/lib/formatInlineCodeSummary.ts
+++ b/src/lib/formatInlineCodeSummary.ts
@@ -1,0 +1,25 @@
+export type InlineCodeSummarySegment =
+  | { type: "text"; value: string }
+  | { type: "code"; value: string };
+
+const INLINE_CODE_PATTERN = /`([^`\n]+)`/g;
+
+export function parseInlineCodeSummary(text: string): InlineCodeSummarySegment[] {
+  const segments: InlineCodeSummarySegment[] = [];
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(INLINE_CODE_PATTERN)) {
+    const matchIndex = match.index ?? 0;
+    if (matchIndex > lastIndex) {
+      segments.push({ type: "text", value: text.slice(lastIndex, matchIndex) });
+    }
+    segments.push({ type: "code", value: match[1] });
+    lastIndex = matchIndex + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ type: "text", value: text.slice(lastIndex) });
+  }
+
+  return segments.length > 0 ? segments : [{ type: "text", value: text }];
+}

--- a/src/lib/formatInlineCodeSummary.ts
+++ b/src/lib/formatInlineCodeSummary.ts
@@ -1,6 +1,4 @@
-export type InlineCodeSummarySegment =
-  | { type: "text"; value: string }
-  | { type: "code"; value: string };
+type InlineCodeSummarySegment = { type: "text"; value: string } | { type: "code"; value: string };
 
 const INLINE_CODE_PATTERN = /`([^`\n]+)`/g;
 

--- a/src/lib/monacoLoader.ts
+++ b/src/lib/monacoLoader.ts
@@ -2,11 +2,12 @@ import { loader } from "@monaco-editor/react";
 import * as monaco from "monaco-editor";
 import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
 
-type MonacoWindow = Window & typeof globalThis & {
-  MonacoEnvironment?: {
-    getWorker: () => Worker;
+type MonacoWindow = Window &
+  typeof globalThis & {
+    MonacoEnvironment?: {
+      getWorker: () => Worker;
+    };
   };
-};
 
 const browserWindow = typeof window !== "undefined" ? (window as MonacoWindow) : undefined;
 

--- a/src/lib/monacoLoader.ts
+++ b/src/lib/monacoLoader.ts
@@ -1,0 +1,33 @@
+import { loader } from "@monaco-editor/react";
+import * as monaco from "monaco-editor";
+import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+
+type MonacoWindow = Window & typeof globalThis & {
+  MonacoEnvironment?: {
+    getWorker: () => Worker;
+  };
+};
+
+const browserWindow = typeof window !== "undefined" ? (window as MonacoWindow) : undefined;
+
+if (browserWindow && !browserWindow.MonacoEnvironment) {
+  browserWindow.MonacoEnvironment = {
+    getWorker() {
+      return new editorWorker();
+    },
+  };
+}
+
+loader.config({ monaco });
+
+let initPromise: Promise<void> | null = null;
+
+export function ensureMonacoLoader() {
+  if (typeof window === "undefined") {
+    return Promise.reject(new Error("Monaco loader is only available in the browser"));
+  }
+  if (!initPromise) {
+    initPromise = loader.init().then(() => undefined);
+  }
+  return initPromise;
+}

--- a/src/lib/useBrowseTopicSearch.test.ts
+++ b/src/lib/useBrowseTopicSearch.test.ts
@@ -1,0 +1,30 @@
+/* @vitest-environment jsdom */
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useBrowseTopicSearch } from "./useBrowseTopicSearch";
+
+const useRouterStateMock = vi.fn();
+const navigateMock = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  useRouterState: (options: { select: (state: unknown) => unknown }) =>
+    options.select({
+      location: { searchStr: useRouterStateMock() },
+    }),
+}));
+
+describe("useBrowseTopicSearch", () => {
+  it("uses the validated route topic when present", () => {
+    useRouterStateMock.mockReturnValue("");
+    const { result } = renderHook(() => useBrowseTopicSearch({ topic: "github" }));
+    expect(result.current.activeTopic).toBe("github");
+    expect(result.current.search.topic).toBe("github");
+  });
+
+  it("falls back to malformed topic%3Dgithub query strings", () => {
+    useRouterStateMock.mockReturnValue("?topic%3Dgithub");
+    const { result } = renderHook(() => useBrowseTopicSearch({ "topic=github": "" }));
+    expect(result.current.activeTopic).toBe("github");
+    expect(result.current.search.topic).toBe("github");
+  });
+});

--- a/src/lib/useBrowseTopicSearch.test.ts
+++ b/src/lib/useBrowseTopicSearch.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, it, vi } from "vitest";
 import { useBrowseTopicSearch } from "./useBrowseTopicSearch";
 
 const useRouterStateMock = vi.fn();
-const navigateMock = vi.fn();
 
 vi.mock("@tanstack/react-router", () => ({
   useRouterState: (options: { select: (state: unknown) => unknown }) =>
@@ -23,7 +22,9 @@ describe("useBrowseTopicSearch", () => {
 
   it("falls back to malformed topic%3Dgithub query strings", () => {
     useRouterStateMock.mockReturnValue("?topic%3Dgithub");
-    const { result } = renderHook(() => useBrowseTopicSearch({ "topic=github": "" }));
+    const { result } = renderHook(() =>
+      useBrowseTopicSearch<{ topic?: string; "topic=github"?: string }>({ "topic=github": "" }),
+    );
     expect(result.current.activeTopic).toBe("github");
     expect(result.current.search.topic).toBe("github");
   });

--- a/src/lib/useBrowseTopicSearch.ts
+++ b/src/lib/useBrowseTopicSearch.ts
@@ -1,0 +1,66 @@
+import { useRouterState } from "@tanstack/react-router";
+import { useEffect, useMemo } from "react";
+import {
+  hasMalformedBrowseTopicSearch,
+  parseBrowseTopicFromSearchInput,
+  parseBrowseTopicFromSearchString,
+  sanitizeBrowseTopicSearch,
+} from "./browseTopicSearch";
+
+type BrowseTopicSearch = {
+  topic?: string;
+};
+
+type BrowseTopicNavigate<T extends BrowseTopicSearch> = (options: {
+  search: (prev: T) => T;
+  replace?: boolean;
+}) => void | Promise<void>;
+
+export function useBrowseTopicSearch<T extends BrowseTopicSearch>(
+  search: T,
+  navigate?: BrowseTopicNavigate<T>,
+) {
+  const searchStr = useRouterState({
+    select: (state) => state.location.searchStr ?? "",
+  });
+
+  const resolved = useMemo(() => {
+    const routeTopic = parseBrowseTopicFromSearchInput(search);
+    const urlTopic = parseBrowseTopicFromSearchString(searchStr);
+    const activeTopic = routeTopic ?? urlTopic;
+
+    if (!activeTopic) {
+      return { search, activeTopic: undefined as string | undefined };
+    }
+
+    return {
+      search: sanitizeBrowseTopicSearch(search, activeTopic),
+      activeTopic,
+    };
+  }, [search, searchStr]);
+
+  useEffect(() => {
+    if (!navigate) return;
+
+    if (!resolved.activeTopic) {
+      if (hasMalformedBrowseTopicSearch(search, searchStr)) {
+        void navigate({
+          search: (prev) => sanitizeBrowseTopicSearch(prev),
+          replace: true,
+        });
+      }
+      return;
+    }
+
+    const needsCanonical =
+      hasMalformedBrowseTopicSearch(search, searchStr) || search.topic !== resolved.activeTopic;
+    if (!needsCanonical) return;
+
+    void navigate({
+      search: (prev) => sanitizeBrowseTopicSearch(prev, resolved.activeTopic),
+      replace: true,
+    });
+  }, [navigate, resolved.activeTopic, search, searchStr]);
+
+  return resolved;
+}

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -40,6 +40,7 @@ import {
 } from "../../components/DetailSecuritySummary";
 import { useDownloadsSidebarMetricBlock } from "../../components/DownloadsMetricCard";
 import { EmptyState } from "../../components/EmptyState";
+import { InlineCodeSummary } from "../../components/InlineCodeSummary";
 import { InstallCopyButton } from "../../components/InstallCopyButton";
 import { Container } from "../../components/layout/Container";
 import { MarkdownPreview } from "../../components/MarkdownPreview";
@@ -66,6 +67,8 @@ import { getActivityTrendEndDay } from "../../lib/activityTrend";
 import { BrowseCategoryIcon } from "../../lib/browseCategoryIcons";
 import {
   buildPluginCategoryBrowseHref,
+  buildPluginTopicBrowseHref,
+  formatCatalogTopicLabel,
   PLUGIN_CATEGORIES,
   resolvePluginBrowseCategorySlug,
 } from "../../lib/categories";
@@ -1627,9 +1630,14 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
                     {headerTopics.length > 0 ? (
                       <div className="skill-hero-topic-list" aria-label="Topics">
                         {headerTopics.map((topic) => (
-                          <span className="skill-hero-topic" key={topic}>
-                            #{topic.toLowerCase().replace(/\s+/g, "-")}
-                          </span>
+                          <a
+                            key={topic}
+                            className="skill-hero-topic"
+                            href={buildPluginTopicBrowseHref(topic)}
+                            aria-label={`View plugins tagged ${formatCatalogTopicLabel(topic)}`}
+                          >
+                            {formatCatalogTopicLabel(topic)}
+                          </a>
                         ))}
                       </div>
                     ) : null}
@@ -1650,7 +1658,7 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
                     hasSummaryToggle && !isSummaryExpanded ? " line-clamp-2" : ""
                   }`}
                 >
-                  {headerSummary}
+                  <InlineCodeSummary>{headerSummary}</InlineCodeSummary>
                 </p>
                 {hasSummaryToggle ? (
                   <button
@@ -1744,6 +1752,8 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
                           text={installSnippet}
                           ariaLabel="Copy plugin install command"
                           showLabel={false}
+                          variant="ghost"
+                          size="icon-sm"
                           className="skill-install-command-inline-button"
                         />
                       </div>

--- a/src/routes/plugins/index.tsx
+++ b/src/routes/plugins/index.tsx
@@ -22,6 +22,8 @@ import { BrowseResultsSkeleton } from "../../components/skeletons/BrowseResultsS
 import { Button } from "../../components/ui/button";
 import { formatBrowseCount } from "../../lib/browseCount";
 import { PLUGIN_CATEGORIES, resolvePluginBrowseCategorySlug } from "../../lib/categories";
+import { parseBrowseTopicFromSearchInput, sanitizeBrowseTopicSearch } from "../../lib/browseTopicSearch";
+import { useBrowseTopicSearch } from "../../lib/useBrowseTopicSearch";
 import {
   fetchPluginCatalog,
   isRateLimitedPackageApiError,
@@ -253,7 +255,7 @@ export const Route = createFileRoute("/plugins/")({
     return {
       q,
       category,
-      topic: typeof search.topic === "string" ? normalizeCatalogTopic(search.topic) : undefined,
+      topic: parseBrowseTopicFromSearchInput(search as Record<string, unknown>),
       cursor:
         !legacyInstallSort &&
         !staleImplicitFilteredCursor &&
@@ -331,8 +333,9 @@ function PluginsIndexPending() {
 }
 
 function PluginsIndex() {
-  const search = Route.useSearch();
+  const routeSearch = Route.useSearch();
   const navigate = Route.useNavigate();
+  const { search, activeTopic } = useBrowseTopicSearch(routeSearch, navigate);
   const initialLoaderData = Route.useLoaderData() as PluginsLoaderData | undefined;
   const [catalogData, setCatalogData] = useState<PluginsLoaderData>(
     () => initialLoaderData ?? createPluginsLoadingData(),
@@ -369,7 +372,7 @@ function PluginsIndex() {
   const hasActiveFilters =
     hasQuery ||
     Boolean(search.category) ||
-    Boolean(search.topic) ||
+    Boolean(activeTopic) ||
     Boolean(search.official) ||
     Boolean(search.featured);
   const formattedCount = !hasActiveFilters ? formatBrowseCount(totalCount) : null;
@@ -501,12 +504,15 @@ function PluginsIndex() {
 
   const handleTopicChange = (topic: string | undefined) => {
     void navigate({
-      search: (prev: PluginSearchState) => ({
-        ...prev,
-        cursor: undefined,
-        family: undefined,
-        topic,
-      }),
+      search: (prev: PluginSearchState) =>
+        sanitizeBrowseTopicSearch(
+          {
+            ...prev,
+            cursor: undefined,
+            family: undefined,
+          },
+          topic ?? null,
+        ),
       replace: true,
     });
   };
@@ -635,15 +641,17 @@ function PluginsIndex() {
   return (
     <main className="browse-page browse-page-borderless-header">
       <div className="browse-page-header">
-        <h1 className="browse-title">
-          Plugins
-          {formattedCount ? (
-            <>
-              {" "}
-              <span className="browse-count">{formattedCount}</span>
-            </>
-          ) : null}
-        </h1>
+        <div className="browse-page-header-main">
+          <h1 className="browse-title">
+            Plugins
+            {formattedCount ? (
+              <>
+                {" "}
+                <span className="browse-count">{formattedCount}</span>
+              </>
+            ) : null}
+          </h1>
+        </div>
       </div>
       <BrowseControls>
         <BrowseControlsRow>
@@ -681,7 +689,7 @@ function PluginsIndex() {
         </BrowseControlsRow>
         <BrowseTopicChips
           topics={categoryTopics ?? []}
-          activeTopic={search.topic}
+          activeTopic={activeTopic}
           onChange={handleTopicChange}
         />
       </BrowseControls>

--- a/src/routes/plugins/index.tsx
+++ b/src/routes/plugins/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, redirect } from "@tanstack/react-router";
-import { isPluginCategorySlug, normalizeCatalogTopic } from "clawhub-schema";
+import { isPluginCategorySlug } from "clawhub-schema";
 import { useQuery } from "convex/react";
 import { BadgeCheck, PackageSearch, Plus } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -21,14 +21,17 @@ import { PluginListItem } from "../../components/PluginListItem";
 import { BrowseResultsSkeleton } from "../../components/skeletons/BrowseResultsSkeleton";
 import { Button } from "../../components/ui/button";
 import { formatBrowseCount } from "../../lib/browseCount";
+import {
+  parseBrowseTopicFromSearchInput,
+  sanitizeBrowseTopicSearch,
+} from "../../lib/browseTopicSearch";
 import { PLUGIN_CATEGORIES, resolvePluginBrowseCategorySlug } from "../../lib/categories";
-import { parseBrowseTopicFromSearchInput, sanitizeBrowseTopicSearch } from "../../lib/browseTopicSearch";
-import { useBrowseTopicSearch } from "../../lib/useBrowseTopicSearch";
 import {
   fetchPluginCatalog,
   isRateLimitedPackageApiError,
   type PackageListItem,
 } from "../../lib/packageApi";
+import { useBrowseTopicSearch } from "../../lib/useBrowseTopicSearch";
 import { useMediaQuery } from "../../lib/useMediaQuery";
 
 type VisiblePluginSort = "recommended" | "updated" | "downloads" | "trending";

--- a/src/routes/search.tsx
+++ b/src/routes/search.tsx
@@ -228,9 +228,9 @@ function UnifiedSearchPage() {
               {results.map((item) =>
                 item.type === "skill" ? (
                   <SkillResultRow key={`skill-${item.skill._id}`} result={item} />
-                ) : (
+                ) : item.type === "plugin" ? (
                   <PluginResultRow key={`plugin-${item.plugin.name}`} result={item} />
-                ),
+                ) : null,
               )}
             </div>
           )}
@@ -340,4 +340,3 @@ function SkillResultRow({ result }: { result: UnifiedSkillResult }) {
 function PluginResultRow({ result }: { result: UnifiedPluginResult }) {
   return <PluginListItem item={result.plugin} />;
 }
-

--- a/src/routes/search.tsx
+++ b/src/routes/search.tsx
@@ -216,22 +216,20 @@ function UnifiedSearchPage() {
                 </SearchResultSection>
               ) : null}
               {creatorResults.length > 0 ? (
-                <SearchResultSection title="Creators">
-                  {creatorResults.map((item) => (
-                    <CreatorResultRow key={`creator-${item.creator._id}`} result={item} />
-                  ))}
+                <SearchResultSection title="Creators" bare>
+                  <CreatorResultsList results={creatorResults} />
                 </SearchResultSection>
               ) : null}
             </div>
+          ) : activeType === "creators" ? (
+            <CreatorResultsList results={creatorResults} />
           ) : (
             <div className="results-list">
               {results.map((item) =>
                 item.type === "skill" ? (
                   <SkillResultRow key={`skill-${item.skill._id}`} result={item} />
-                ) : item.type === "plugin" ? (
-                  <PluginResultRow key={`plugin-${item.plugin.name}`} result={item} />
                 ) : (
-                  <CreatorResultRow key={`creator-${item.creator._id}`} result={item} />
+                  <PluginResultRow key={`plugin-${item.plugin.name}`} result={item} />
                 ),
               )}
             </div>
@@ -297,14 +295,40 @@ function SearchEmptyState({
   );
 }
 
-function SearchResultSection({ children, title }: { children: React.ReactNode; title: string }) {
+function SearchResultSection({
+  bare = false,
+  children,
+  title,
+}: {
+  bare?: boolean;
+  children: React.ReactNode;
+  title: string;
+}) {
   return (
     <section className="search-results-section" aria-label={title}>
       <div className="search-results-section-header">
         <h2 className="search-results-section-title">{title}</h2>
       </div>
-      <div className="results-list">{children}</div>
+      {bare ? children : <div className="results-list">{children}</div>}
     </section>
+  );
+}
+
+function CreatorResultsList({ results }: { results: UnifiedCreatorResult[] }) {
+  if (results.length === 0) return null;
+
+  return (
+    <div className="browse-list-stack">
+      <div className="publisher-directory-list">
+        {results.map((item) => (
+          <PublisherListItem
+            key={`creator-${item.creator._id}`}
+            publisher={item.creator}
+            variant="list"
+          />
+        ))}
+      </div>
+    </div>
   );
 }
 
@@ -317,6 +341,3 @@ function PluginResultRow({ result }: { result: UnifiedPluginResult }) {
   return <PluginListItem item={result.plugin} />;
 }
 
-function CreatorResultRow({ result }: { result: UnifiedCreatorResult }) {
-  return <PublisherListItem publisher={result.creator} />;
-}

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -18,11 +18,11 @@ import {
   useBrowseSearchDisclosure,
 } from "../../components/BrowseControls";
 import { formatBrowseCount } from "../../lib/browseCount";
-import { parseBrowseTopicFromSearchInput, sanitizeBrowseTopicSearch } from "../../lib/browseTopicSearch";
 import {
-  resolveSkillBrowseCategorySlug,
-  SKILL_CATEGORIES,
-} from "../../lib/categories";
+  parseBrowseTopicFromSearchInput,
+  sanitizeBrowseTopicSearch,
+} from "../../lib/browseTopicSearch";
+import { resolveSkillBrowseCategorySlug, SKILL_CATEGORIES } from "../../lib/categories";
 import { useBrowseTopicSearch } from "../../lib/useBrowseTopicSearch";
 import { parseDir, parseSort } from "./-params";
 import { SkillsResults } from "./-SkillsResults";
@@ -101,10 +101,7 @@ export function SkillsIndex() {
           : "all";
   const activeSort = ["updated", "newest", "name"].includes(model.sort) ? model.sort : undefined;
   const hasActiveFilters =
-    model.hasQuery ||
-    Boolean(model.activeCategory) ||
-    Boolean(activeTopic) ||
-    model.featuredOnly;
+    model.hasQuery || Boolean(model.activeCategory) || Boolean(activeTopic) || model.featuredOnly;
   const totalSkillsCount = useQuery(api.skills.countPublicSkills, {});
   const categoryTopics = useQuery(
     api.catalogTopics.listTopByCategory,

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -1,5 +1,4 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { normalizeCatalogTopic } from "clawhub-schema";
 import { useQuery } from "convex/react";
 import { useCallback, useRef } from "react";
 import { api } from "../../../convex/_generated/api";
@@ -19,7 +18,12 @@ import {
   useBrowseSearchDisclosure,
 } from "../../components/BrowseControls";
 import { formatBrowseCount } from "../../lib/browseCount";
-import { resolveSkillBrowseCategorySlug, SKILL_CATEGORIES } from "../../lib/categories";
+import { parseBrowseTopicFromSearchInput, sanitizeBrowseTopicSearch } from "../../lib/browseTopicSearch";
+import {
+  resolveSkillBrowseCategorySlug,
+  SKILL_CATEGORIES,
+} from "../../lib/categories";
+import { useBrowseTopicSearch } from "../../lib/useBrowseTopicSearch";
 import { parseDir, parseSort } from "./-params";
 import { SkillsResults } from "./-SkillsResults";
 import {
@@ -61,7 +65,7 @@ export const Route = createFileRoute("/skills/")({
           ? true
           : undefined,
       category: parseSkillCategorySlug(search.category),
-      topic: typeof search.topic === "string" ? normalizeCatalogTopic(search.topic) : undefined,
+      topic: parseBrowseTopicFromSearchInput(search as Record<string, unknown>),
       view: normalizeSkillsView(search.view),
       focus: search.focus === "search" ? "search" : undefined,
     };
@@ -71,7 +75,8 @@ export const Route = createFileRoute("/skills/")({
 
 export function SkillsIndex() {
   const navigate = Route.useNavigate();
-  const search = Route.useSearch();
+  const routeSearch = Route.useSearch();
+  const { search, activeTopic } = useBrowseTopicSearch(routeSearch, navigate);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   const model = useSkillsBrowseModel({
@@ -95,7 +100,11 @@ export function SkillsIndex() {
           ? "stars"
           : "all";
   const activeSort = ["updated", "newest", "name"].includes(model.sort) ? model.sort : undefined;
-  const hasActiveFilters = model.hasQuery || Boolean(model.activeCategory) || model.featuredOnly;
+  const hasActiveFilters =
+    model.hasQuery ||
+    Boolean(model.activeCategory) ||
+    Boolean(activeTopic) ||
+    model.featuredOnly;
   const totalSkillsCount = useQuery(api.skills.countPublicSkills, {});
   const categoryTopics = useQuery(
     api.catalogTopics.listTopByCategory,
@@ -198,12 +207,15 @@ export function SkillsIndex() {
   const handleTopicChange = useCallback(
     (topic: string | undefined) => {
       void navigate({
-        search: (prev: SkillsSearchState) => ({
-          ...prev,
-          topic,
-          featured: undefined,
-          highlighted: undefined,
-        }),
+        search: (prev: SkillsSearchState) =>
+          sanitizeBrowseTopicSearch(
+            {
+              ...prev,
+              featured: undefined,
+              highlighted: undefined,
+            },
+            topic ?? null,
+          ),
         replace: true,
       });
     },
@@ -213,15 +225,17 @@ export function SkillsIndex() {
   return (
     <main className="browse-page browse-page-borderless-header">
       <div className="browse-page-header">
-        <h1 className="browse-title">
-          Skills
-          {formattedCount ? (
-            <>
-              {" "}
-              <span className="browse-count">{formattedCount}</span>
-            </>
-          ) : null}
-        </h1>
+        <div className="browse-page-header-main">
+          <h1 className="browse-title">
+            Skills
+            {formattedCount ? (
+              <>
+                {" "}
+                <span className="browse-count">{formattedCount}</span>
+              </>
+            ) : null}
+          </h1>
+        </div>
       </div>
       <BrowseControls>
         <BrowseControlsRow>
@@ -266,7 +280,7 @@ export function SkillsIndex() {
         </BrowseControlsRow>
         <BrowseTopicChips
           topics={categoryTopics ?? []}
-          activeTopic={model.activeTopic}
+          activeTopic={activeTopic}
           onChange={handleTopicChange}
         />
       </BrowseControls>

--- a/src/routes/user/$handle.tsx
+++ b/src/routes/user/$handle.tsx
@@ -556,8 +556,7 @@ export function PublisherProfilePage({
     () => Boolean(myPublisherMemberships?.some((entry) => entry.publisher.handle === handle)),
     [myPublisherMemberships, handle],
   );
-  const viewerCanSeeOrgRoles =
-    isAdmin(me) || (me?.handle != null && me.handle === publisher.handle);
+  const viewerCanSeeOrgRoles = isAdmin(me) || (me?.handle != null && me.handle === handle);
 
   const {
     results: publishedResults,

--- a/src/routes/user/$handle.tsx
+++ b/src/routes/user/$handle.tsx
@@ -76,6 +76,7 @@ import type {
   PublicSkill,
 } from "../../lib/publicUser";
 import { readPublicDownloadCount } from "../../lib/publicUser";
+import { isAdmin } from "../../lib/roles";
 import { useAuthStatus } from "../../lib/useAuthStatus";
 
 export const Route = createFileRoute("/user/$handle")({
@@ -488,7 +489,7 @@ export function PublisherProfilePage({
   handle: string;
   loaderPublisher: PublicPublisherListItem;
 }) {
-  const { isAuthenticated } = useAuthStatus();
+  const { isAuthenticated, me } = useAuthStatus();
   const { signIn } = useAuthActions();
   const [catalogTab, setCatalogTab] = useState<ProfileCatalogTab>(() =>
     resolveDefaultCatalogTab(loaderPublisher),
@@ -555,6 +556,8 @@ export function PublisherProfilePage({
     () => Boolean(myPublisherMemberships?.some((entry) => entry.publisher.handle === handle)),
     [myPublisherMemberships, handle],
   );
+  const viewerCanSeeOrgRoles =
+    isAdmin(me) || (me?.handle != null && me.handle === publisher.handle);
 
   const {
     results: publishedResults,
@@ -784,7 +787,7 @@ export function PublisherProfilePage({
                             />
                             <span className="publisher-profile-meta-chip-copy">
                               <strong>{entry.publisher.displayName}</strong>
-                              <small>{entry.role}</small>
+                              {viewerCanSeeOrgRoles ? <small>{entry.role}</small> : null}
                             </span>
                           </Link>
                         ))}

--- a/src/styles.css
+++ b/src/styles.css
@@ -2982,6 +2982,18 @@ code {
   margin-bottom: 0;
 }
 
+.skill-summary-line .skill-summary-inline-code {
+  padding: 0.12em 0.35em;
+  border-radius: var(--r-xs);
+  background: color-mix(in srgb, var(--surface-muted) 74%, var(--ink) 6%);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--line) 56%, transparent);
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+  font-size: 0.88em;
+  font-family: var(--font-mono);
+  overflow-wrap: anywhere;
+}
+
 .skill-summary-line.line-clamp-2 {
   display: -webkit-box;
   overflow: hidden;
@@ -6245,6 +6257,26 @@ code {
   text-decoration: none;
 }
 
+.skill-hero-creator .user-badge-link {
+  border-radius: var(--r-pill);
+  padding: 4px 10px 4px 4px;
+  margin-left: -4px;
+  transition:
+    background-color 0.18s ease,
+    color 0.18s ease;
+}
+
+.skill-hero-creator .user-badge-link .user-avatar {
+  transition:
+    border-color 0.18s ease,
+    box-shadow 0.18s ease;
+}
+
+.skill-hero-creator .user-badge-link .user-name,
+.skill-hero-creator .user-badge-link .user-handle {
+  transition: color 0.18s ease;
+}
+
 .skill-hero-creator .user-avatar {
   grid-column: 1;
   grid-row: 1 / span 2;
@@ -6288,13 +6320,30 @@ code {
 
 .skill-hero-creator .user-badge-link:hover,
 .skill-hero-creator .user-badge-link:focus-visible {
+  background: var(--hover-bg);
   text-decoration: none;
+  outline: none;
+}
+
+.skill-hero-creator .user-badge-link:focus-visible {
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ink) 14%, transparent);
+}
+
+.skill-hero-creator .user-badge-link:hover .user-avatar,
+.skill-hero-creator .user-badge-link:focus-visible .user-avatar {
+  border-color: color-mix(in srgb, var(--ink-soft) 42%, var(--line));
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--ink) 6%, transparent);
 }
 
 .skill-hero-creator .user-badge-link:hover .user-name,
-.skill-hero-creator .user-badge-link:focus-visible .user-name,
+.skill-hero-creator .user-badge-link:focus-visible .user-name {
+  color: var(--ink);
+  text-decoration: none;
+}
+
 .skill-hero-creator .user-badge-link:hover .user-handle,
 .skill-hero-creator .user-badge-link:focus-visible .user-handle {
+  color: color-mix(in srgb, var(--ink) 68%, var(--ink-soft));
   text-decoration: none;
 }
 
@@ -6489,6 +6538,7 @@ code {
   line-height: 1.05;
   font-weight: 700;
   color: var(--ink);
+  text-wrap: balance;
 }
 
 .skill-title-actions {
@@ -6615,9 +6665,10 @@ code {
 }
 
 .skill-category-meta-list {
+  --skill-category-meta-gap: 6px;
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: var(--skill-category-meta-gap);
   min-width: 0;
   color: color-mix(in srgb, var(--ink-soft) 76%, var(--bg));
 }
@@ -6625,7 +6676,7 @@ code {
 .skill-category-meta-link {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--skill-category-meta-gap);
   min-width: 0;
   color: color-mix(in srgb, var(--ink-soft) 76%, var(--bg));
   font-size: 12px;
@@ -6666,6 +6717,13 @@ code {
   font-weight: 520;
   line-height: 1;
   white-space: nowrap;
+  text-decoration: none;
+}
+
+.skill-hero-topic:hover,
+.skill-hero-topic:focus-visible {
+  color: var(--ink);
+  text-decoration: none;
 }
 
 .skill-settings-link {
@@ -7674,7 +7732,7 @@ code {
   background: #161619;
 }
 
-.skill-install-copy-button {
+.skill-install-copy-button:not(.skill-install-command-inline-button) {
   border-color: rgba(255, 255, 255, 0.12);
   background: rgba(255, 255, 255, 0.02);
   color: var(--ink);
@@ -7686,17 +7744,17 @@ code {
   touch-action: manipulation;
 }
 
-[data-theme-resolved="light"] .skill-install-copy-button {
+[data-theme-resolved="light"] .skill-install-copy-button:not(.skill-install-command-inline-button) {
   border-color: rgba(15, 12, 10, 0.12);
   background: rgba(255, 255, 255, 0.62);
 }
 
-.skill-install-copy-button[data-copy-state="copied"] {
+.skill-install-copy-button:not(.skill-install-command-inline-button)[data-copy-state="copied"] {
   border-color: rgba(34, 197, 94, 0.36);
   color: var(--status-success-fg);
 }
 
-.skill-install-copy-button[data-copy-state="failed"] {
+.skill-install-copy-button:not(.skill-install-command-inline-button)[data-copy-state="failed"] {
   border-color: rgba(239, 68, 68, 0.32);
   color: var(--status-error-fg);
 }
@@ -7949,45 +8007,71 @@ code {
   overflow: visible;
   text-overflow: clip;
   white-space: pre-wrap;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
+  word-break: normal;
 }
 
 .skill-install-command-wrap .skill-install-prompt-compact code {
   overflow: visible;
   text-overflow: clip;
   white-space: pre-wrap;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
+  word-break: normal;
 }
 
-.skill-install-command-inline-button {
+.skill-install-command-inline-button.skill-install-copy-button {
   position: absolute;
+  right: 10px;
+  border: 0 !important;
+  background: transparent !important;
+  color: color-mix(in srgb, var(--ink-soft) 88%, transparent);
+  box-shadow: none;
+  transition: color 0.18s ease !important;
+}
+
+.skill-install-command-shell-cli .skill-install-command-inline-button.skill-install-copy-button {
   top: 50%;
-  right: 12px;
-  width: 34px;
-  min-width: 34px;
-  max-width: 34px;
-  height: 34px;
-  min-height: 34px;
-  padding-inline: 0;
-  padding-block: 0;
   transform: translateY(-50%);
 }
 
 .skill-install-command-shell:not(.skill-install-command-shell-cli)
-  .skill-install-command-inline-button {
+  .skill-install-command-inline-button.skill-install-copy-button {
   top: 12px;
   transform: none;
 }
 
-[data-theme-resolved="dark"] .skill-install-command-inline-button {
-  border-color: color-mix(in srgb, var(--line) 68%, transparent);
-  background: color-mix(in srgb, var(--surface-muted) 44%, var(--bg) 56%);
-  color: color-mix(in srgb, var(--ink) 82%, var(--ink-soft) 18%);
+.skill-install-command-inline-button.skill-install-copy-button:hover:not(:disabled),
+.skill-install-command-inline-button.skill-install-copy-button:focus-visible {
+  border: 0 !important;
+  background: transparent !important;
+  color: var(--ink);
+  box-shadow: none;
 }
 
-[data-theme-resolved="dark"] .skill-install-command-inline-button:hover {
-  border-color: color-mix(in srgb, var(--line) 90%, var(--accent) 10%);
-  background: color-mix(in srgb, var(--surface-muted) 58%, var(--bg) 42%);
+.skill-install-command-shell-cli
+  .skill-install-command-inline-button.skill-install-copy-button:hover:not(:disabled),
+.skill-install-command-shell-cli
+  .skill-install-command-inline-button.skill-install-copy-button:focus-visible {
+  transform: translateY(-50%);
+}
+
+.skill-install-command-shell-cli
+  .skill-install-command-inline-button.skill-install-copy-button[data-copy-state="copied"],
+.skill-install-command-shell-cli
+  .skill-install-command-inline-button.skill-install-copy-button[data-copy-state="failed"] {
+  transform: translateY(-50%);
+}
+
+.skill-install-command-inline-button.skill-install-copy-button[data-copy-state="copied"] {
+  border: 0 !important;
+  background: transparent !important;
+  color: var(--status-success-fg);
+}
+
+.skill-install-command-inline-button.skill-install-copy-button[data-copy-state="failed"] {
+  border: 0 !important;
+  background: transparent !important;
+  color: var(--status-error-fg);
 }
 
 .skill-install-command-caption {
@@ -8229,6 +8313,10 @@ code {
     min-width: 0;
   }
 
+  .skill-detail-page .detail-mobile-install {
+    margin-top: 14px;
+  }
+
   .detail-mobile-install .skill-install-command-card {
     --detail-mobile-install-border: color-mix(in srgb, var(--ink-soft) 30%, transparent);
     position: relative;
@@ -8299,18 +8387,56 @@ code {
   }
 
   .detail-mobile-install .skill-install-command-shell-cli .skill-install-command-inline-button {
-    position: absolute;
     top: 50%;
-    right: 12px;
-    width: 34px;
-    height: 34px;
-    min-height: 34px !important;
-    max-width: 34px;
+    right: 10px;
     margin-top: 0;
-    padding: 0 !important;
     transform: translateY(-50%);
     flex: none;
     justify-content: center;
+  }
+
+  .detail-mobile-install .skill-install-command-shell:not(.skill-install-command-shell-cli) {
+    flex-direction: column;
+    align-items: stretch;
+    padding: 12px 48px 12px 14px;
+  }
+
+  .detail-mobile-install
+    .skill-install-command-shell:not(.skill-install-command-shell-cli)
+    .skill-install-command {
+    display: block;
+    flex: none;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    word-break: normal;
+    overflow-x: hidden;
+  }
+
+  .detail-mobile-install
+    .skill-install-command-shell:not(.skill-install-command-shell-cli)
+    .skill-install-command
+    code {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    word-break: normal;
+  }
+
+  .detail-mobile-install
+    .skill-install-command-shell:not(.skill-install-command-shell-cli)
+    .skill-install-command-inline-button {
+    position: absolute;
+    top: 12px;
+    right: 10px;
+    align-self: auto;
+    width: auto;
+    margin-top: 0;
+    transform: none;
   }
 
   .skill-hero-main-extra
@@ -8358,6 +8484,37 @@ code {
 
   :is(.skill-detail-page, .plugin-detail-page) .skill-hero-creator {
     margin-top: 18px;
+  }
+
+  .skill-detail-page .skill-hero-creator {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    gap: 12px;
+  }
+
+  .skill-detail-page .skill-hero-creator .user-badge,
+  .skill-detail-page .skill-hero-creator .user-badge-link {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .skill-detail-page .skill-hero-creator-star {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    margin-left: auto;
+  }
+
+  .skill-detail-page .skill-hero-creator-star .skill-sidebar-star-action {
+    min-height: 0;
+    justify-content: flex-end;
+  }
+
+  .skill-detail-page .skill-hero-creator-star .skill-sidebar-star-action:hover,
+  .skill-detail-page .skill-hero-creator-star .skill-sidebar-star-action:focus-visible {
+    text-decoration: none;
   }
 
   .skill-detail-page .skill-hero-lower.has-sidebar {
@@ -8737,7 +8894,7 @@ code {
 }
 
 .detail-skeleton .skill-install-command-inline-button {
-  width: 34px;
+  width: auto;
 }
 
 .detail-skeleton-deferred-summary {
@@ -10754,8 +10911,74 @@ code {
   border: 1px solid var(--line);
   background: var(--surface);
   display: grid;
-  grid-template-rows: auto 1fr auto;
+  grid-template-rows: auto auto auto;
   overflow: hidden;
+}
+
+.file-viewer.is-loading {
+  grid-template-rows: auto 1fr auto;
+}
+
+.file-viewer.is-loading .file-viewer-body-loading {
+  display: flex;
+  flex-direction: column;
+  max-height: none;
+  min-height: 0;
+}
+
+.file-viewer-skeleton {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 100%;
+}
+
+.file-viewer-skeleton-line,
+.file-viewer-skeleton-fill,
+.file-viewer-skeleton-hash {
+  border-radius: var(--r-xs);
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--ink) 7%, transparent),
+    color-mix(in srgb, var(--ink) 14%, transparent),
+    color-mix(in srgb, var(--ink) 7%, transparent)
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.15s ease-in-out infinite;
+}
+
+.file-viewer-skeleton-line {
+  display: block;
+  height: 11px;
+}
+
+.file-viewer-skeleton-line:nth-child(3n + 1) {
+  width: 96%;
+}
+
+.file-viewer-skeleton-line:nth-child(3n + 2) {
+  width: 88%;
+}
+
+.file-viewer-skeleton-line:nth-child(3n) {
+  width: 72%;
+}
+
+.file-viewer-skeleton-fill {
+  flex: 1;
+  min-height: 12px;
+  width: 100%;
+}
+
+.file-viewer-meta-skeleton {
+  min-height: 42px;
+}
+
+.file-viewer-skeleton-hash {
+  display: block;
+  width: min(100%, 420px);
+  height: 12px;
 }
 
 .file-viewer-header {
@@ -11069,10 +11292,7 @@ code {
 }
 
 .skill-versions-list {
-  --skill-versions-grid-columns: minmax(150px, 176px) minmax(180px, 220px) fit-content(168px)
-    minmax(0, 1fr) minmax(44px, max-content) 36px;
   display: grid;
-  grid-template-columns: var(--skill-versions-grid-columns);
   gap: 0;
   border: 1px solid color-mix(in srgb, var(--line) 92%, transparent);
   border-radius: var(--r-md);
@@ -11080,16 +11300,22 @@ code {
   background: color-mix(in srgb, var(--surface) 28%, transparent);
 }
 
-.skill-versions-list-without-checks {
-  --skill-versions-grid-columns: minmax(150px, 176px) fit-content(168px) minmax(0, 1fr)
-    minmax(154px, max-content) 36px;
+.skill-versions-list-skills {
+  --skill-versions-grid-columns: minmax(0, 1fr) max-content max-content 36px;
+  grid-template-columns: var(--skill-versions-grid-columns);
+}
+
+.skill-versions-list-plugins {
+  --skill-versions-grid-columns: minmax(0, 1fr) minmax(88px, max-content) max-content max-content
+    36px;
+  grid-template-columns: var(--skill-versions-grid-columns);
 }
 
 .skill-versions-column-header {
   grid-column: 1 / -1;
   display: grid;
   grid-template-columns: subgrid;
-  gap: 10px;
+  column-gap: 16px;
   align-items: center;
   padding: 10px 16px;
   border-bottom: 1px solid color-mix(in srgb, var(--line) 66%, transparent);
@@ -11101,56 +11327,56 @@ code {
   text-transform: uppercase;
 }
 
-.skill-versions-column-header > span:nth-child(1) {
+.skill-versions-col-version {
   grid-column: 1;
   justify-self: start;
 }
 
-.skill-versions-column-header > span:nth-child(2) {
+.skill-versions-col-tags {
   grid-column: 2;
   justify-self: start;
 }
 
-.skill-versions-column-header > span:nth-child(3) {
-  grid-column: 3;
+.skill-versions-col-release {
   justify-self: start;
 }
 
-.skill-versions-column-header > span:nth-child(4) {
-  grid-column: 5;
-  justify-self: center;
+.skill-versions-column-header-skills .skill-versions-col-release {
+  grid-column: 2;
 }
 
-.skill-versions-column-header-download {
+.skill-versions-column-header-plugins .skill-versions-col-release {
+  grid-column: 3;
+}
+
+.skill-versions-col-download {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 28px;
+  justify-content: flex-end;
+  justify-self: end;
   min-height: 22px;
   color: color-mix(in srgb, var(--ink-soft) 72%, transparent);
 }
 
-.skill-versions-list-without-checks .skill-versions-column-header > span:nth-child(2) {
-  grid-column: 2;
+.skill-versions-column-header-skills .skill-versions-col-download {
+  grid-column: 3;
 }
 
-.skill-versions-list-without-checks .skill-versions-column-header > span:nth-child(3) {
+.skill-versions-column-header-plugins .skill-versions-col-download {
   grid-column: 4;
-  justify-self: center;
+  width: 28px;
 }
 
-.skill-versions-list-without-checks .skill-versions-column-header > span:nth-child(4) {
+.skill-versions-col-expand {
+  justify-self: end;
+}
+
+.skill-versions-column-header-skills .skill-versions-col-expand {
+  grid-column: 4;
+}
+
+.skill-versions-column-header-plugins .skill-versions-col-expand {
   grid-column: 5;
-  justify-self: end;
-}
-
-.skill-versions-list-without-checks .skill-versions-column-header-download {
-  width: auto;
-}
-
-.skill-versions-column-header > span:nth-child(5) {
-  grid-column: 6;
-  justify-self: end;
 }
 
 .skill-version-release {
@@ -11177,11 +11403,11 @@ code {
   grid-column: 1 / -1;
   display: grid;
   grid-template-columns: subgrid;
-  gap: 10px;
+  column-gap: 16px;
   align-items: center;
   min-width: 0;
-  min-height: 72px;
-  padding: 14px 16px;
+  min-height: 64px;
+  padding: 12px 16px;
   transition: background-color 160ms ease;
 }
 
@@ -11248,7 +11474,6 @@ code {
 }
 
 .skill-version-release-chevron-button {
-  grid-column: 6;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -11340,20 +11565,22 @@ code {
 }
 
 .skill-version-release-scan {
-  grid-column: 2;
   display: flex;
   flex-direction: row;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: flex-start;
-  gap: 8px;
+  gap: 6px;
   width: 100%;
   min-width: 0;
   min-height: 22px;
 }
 
+.skill-versions-list-plugins .skill-version-release-scan {
+  grid-column: 2;
+}
+
 .skill-version-release-tags {
-  grid-column: 3;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -11364,15 +11591,31 @@ code {
   min-height: 22px;
 }
 
+.skill-versions-list-skills .skill-version-release-tags {
+  grid-column: 2;
+}
+
+.skill-versions-list-plugins .skill-version-release-tags {
+  grid-column: 3;
+}
+
 .skill-version-release-actions {
-  grid-column: 5;
   display: flex;
   flex-wrap: nowrap;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-end;
   gap: 8px;
   width: 100%;
   min-width: 0;
+  justify-self: end;
+}
+
+.skill-versions-list-skills .skill-version-release-actions {
+  grid-column: 3;
+}
+
+.skill-versions-list-plugins .skill-version-release-actions {
+  grid-column: 4;
 }
 
 .skill-version-release-download {
@@ -11410,15 +11653,11 @@ code {
   white-space: nowrap;
 }
 
-.skill-versions-list-without-checks .skill-version-release-tags {
-  grid-column: 2;
-}
-
-.skill-versions-list-without-checks .skill-version-release-actions {
+.skill-versions-list-skills .skill-version-release-chevron-button {
   grid-column: 4;
 }
 
-.skill-versions-list-without-checks .skill-version-release-chevron-button {
+.skill-versions-list-plugins .skill-version-release-chevron-button {
   grid-column: 5;
 }
 
@@ -15555,15 +15794,9 @@ a.agentic-risk-finding-title:focus-visible {
   }
 
   .skill-install-command-shell-cli .skill-install-command-inline-button {
-    position: absolute;
     top: 50%;
     right: 10px;
-    width: 34px;
-    height: 34px;
-    min-height: 34px !important;
-    max-width: 34px;
     margin-top: 0;
-    padding: 0 !important;
     transform: translateY(-50%);
     flex: none;
     justify-content: center;
@@ -15574,24 +15807,33 @@ a.agentic-risk-finding-title:focus-visible {
     overflow: visible;
     text-overflow: clip;
     white-space: pre-wrap;
+    overflow-wrap: break-word;
+    word-break: normal;
   }
 
   .skill-install-command-shell:not(.skill-install-command-shell-cli) .skill-install-command code {
     overflow: visible;
     text-overflow: clip;
     white-space: pre-wrap;
-    overflow-wrap: anywhere;
+    overflow-wrap: break-word;
+    word-break: normal;
   }
 
   .skill-install-command-shell:not(.skill-install-command-shell-cli) {
-    padding-right: 18px;
+    flex-direction: column;
+    align-items: stretch;
+    padding-right: 48px;
   }
 
   .skill-install-command-shell:not(.skill-install-command-shell-cli)
     .skill-install-command-inline-button {
-    position: static;
-    width: 100%;
-    margin-top: 8px;
+    position: absolute;
+    top: 12px;
+    right: 10px;
+    width: auto;
+    align-self: auto;
+    margin-top: 0;
+    transform: none;
     justify-content: center;
   }
 
@@ -17299,6 +17541,13 @@ body:has(.browse-page-borderless-header) .navbar {
   margin-bottom: 18px;
 }
 
+.browse-page-header-main {
+  display: grid;
+  gap: 12px;
+  width: 100%;
+  min-width: 0;
+}
+
 .browse-page-search {
   display: flex;
   align-items: center;
@@ -17926,6 +18175,7 @@ body:has(.browse-page-borderless-header) .navbar {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 4px;
   min-height: 30px;
   padding: 0 10px;
   border: 1px solid var(--line);
@@ -17937,6 +18187,39 @@ body:has(.browse-page-borderless-header) .navbar {
   font-size: 12px;
   font-weight: 600;
   white-space: nowrap;
+}
+
+.browse-topic-chip-label {
+  line-height: 1;
+}
+
+.browse-topic-chip-clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-pill);
+  background: transparent;
+  color: color-mix(in srgb, var(--ink-soft) 82%, transparent);
+  cursor: pointer;
+  transition:
+    background-color 0.14s ease,
+    color 0.14s ease;
+}
+
+.browse-topic-chip-clear:hover,
+.browse-topic-chip-clear:focus-visible {
+  background: color-mix(in srgb, var(--ink) 8%, transparent);
+  color: var(--ink);
+  outline: none;
+}
+
+.browse-topic-chip.is-active {
+  padding-right: 6px;
+  cursor: default;
 }
 
 .browse-topic-chip:hover,
@@ -28202,11 +28485,22 @@ a[class*="rounded-full"] {
   line-height: 1.45;
 }
 
-.navbar-search-typeahead-status.is-empty {
+.navbar-search-typeahead-status.is-empty,
+.navbar-search-typeahead-status.is-loading {
   display: flex;
   align-items: center;
   gap: 10px;
   padding: 14px;
+}
+
+.navbar-search-typeahead-status-spinner {
+  animation: navbar-search-typeahead-spin 0.75s linear infinite;
+}
+
+@keyframes navbar-search-typeahead-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .navbar-search-typeahead-status-icon {


### PR DESCRIPTION
## Summary

UI polish for **skill/plugin detail**, **creator search results**, and a small **publisher profile** privacy tweak.

### Skill & plugin detail
- **Diff tab:** bundled Monaco + loading skeleton (no stuck "Loading diff…")
- **Versions table:** separate grids for skills vs plugins
- **Inline code hero:** improved light-mode contrast
- **Topic browse:** removable chip, malformed URL fix (`?topic%3Dgithub`)
- **Install copy:** ghost icon-only button; centered CLI, top-right Prompt; mobile `break-word` layout
- **Mobile hero:** Star on creator row; spacing above install card
- **Files panel:** loading skeleton
- **Header search:** `Loader2` spinner while loading
- **Creator hover:** subtle badge hover state
- **Tests:** topic browse helpers, router mocks, etc.

### Search & profile
- **Creator search results:** match `/creators` list row styling (`PublisherListItem` list variant)
- **Publisher profile:** hide organization membership roles from the public; visible only to the profile owner or site admins

## Test plan

- [ ] Skill/plugin detail on desktop and mobile — hero, install copy, diff, files, versions
- [ ] Browse skills/plugins with topic filter — chip, clear filter, correct URL
- [ ] Header search — loading spinner during query
- [ ] Search creators tab — list rows match `/creators`
- [ ] Publisher profile org chips — role hidden when logged out; visible for owner/admin
- [ ] CI `pr-gates` green