### PR TITLE
Fix abuse dashboard auth churn

### DIFF
--- a/convex/publisherAbuse.test.ts
+++ b/convex/publisherAbuse.test.ts
@@ -580,6 +580,37 @@ describe("publisher abuse dry-run persistence", () => {
     }
   });
 
+  it("does not crash read-only publisher abuse dashboard queries while auth is missing", async () => {
+    vi.mocked(requireUser).mockRejectedValue(new Error("Unauthorized"));
+    const db = {
+      get: vi.fn(),
+      query: vi.fn(),
+    };
+
+    await expect(listDashboardHandler({ db }, {})).resolves.toEqual({
+      latestRun: null,
+      pendingItems: [],
+      pendingPotentialBanCandidateItems: [],
+      pendingReviewItems: [],
+      recentResolvedItems: [],
+    });
+    await expect(getPublisherAbuseAutobanSettingHandler({ db }, {})).resolves.toEqual({
+      enabled: false,
+      updatedAt: null,
+      updatedByUserId: null,
+    });
+    await expect(
+      getReviewNominationDetailHandler(
+        { db },
+        { nominationId: "publisherAbuseReviewNominations:nomination" },
+      ),
+    ).resolves.toBeNull();
+
+    expect(assertModerator).not.toHaveBeenCalled();
+    expect(db.get).not.toHaveBeenCalled();
+    expect(db.query).not.toHaveBeenCalled();
+  });
+
   it("defaults publisher abuse autobans to disabled when no setting exists", async () => {
     const user = { _id: "users:moderator", role: "moderator" };
     vi.mocked(requireUser).mockResolvedValue({

--- a/convex/publisherAbuse.ts
+++ b/convex/publisherAbuse.ts
@@ -292,7 +292,9 @@ export const listReviewDashboard = query({
     limit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const { user } = await requireUser(ctx);
+    const auth = await requirePublisherAbuseDashboardUser(ctx);
+    if (!auth) return emptyPublisherAbuseReviewDashboard();
+    const { user } = auth;
     assertModerator(user);
 
     const limit = clampInt(args.limit ?? 150, 1, 250);
@@ -340,7 +342,9 @@ export const getReviewNominationDetail = query({
     nominationId: v.id("publisherAbuseReviewNominations"),
   },
   handler: async (ctx, args) => {
-    const { user } = await requireUser(ctx);
+    const auth = await requirePublisherAbuseDashboardUser(ctx);
+    if (!auth) return null;
+    const { user } = auth;
     assertModerator(user);
 
     const nomination = await ctx.db.get(args.nominationId);
@@ -372,13 +376,34 @@ export const getReviewNominationDetail = query({
 export const getPublisherAbuseAutobanSetting = query({
   args: {},
   handler: async (ctx) => {
-    const { user } = await requireUser(ctx);
+    const auth = await requirePublisherAbuseDashboardUser(ctx);
+    if (!auth) return summarizePublisherAbuseAutobanSetting(null);
+    const { user } = auth;
     assertModerator(user);
 
     const setting = await getPublisherAbuseAutobanSettingDoc(ctx);
     return summarizePublisherAbuseAutobanSetting(setting);
   },
 });
+
+async function requirePublisherAbuseDashboardUser(ctx: QueryCtx) {
+  try {
+    return await requireUser(ctx);
+  } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") return null;
+    throw error;
+  }
+}
+
+function emptyPublisherAbuseReviewDashboard() {
+  return {
+    latestRun: null,
+    pendingItems: [],
+    pendingPotentialBanCandidateItems: [],
+    pendingReviewItems: [],
+    recentResolvedItems: [],
+  };
+}
 
 export const setPublisherAbuseAutobanEnabled = mutation({
   args: {


### PR DESCRIPTION
## Summary

The abuse management dashboard read queries now tolerate missing auth during client token churn by returning safe empty/default values instead of throwing a raw Convex server error. Moderator authorization is still enforced when a user is present, and all write/enforcement paths continue to require auth.

## Verification

```text
bunx vitest run convex/publisherAbuse.test.ts --testNamePattern "auth is missing|guards staff-only|defaults publisher abuse autobans"
bunx tsc --noEmit --pretty false
git diff --check
```
