### PR TITLE
Fix abuse dashboard read auth fallback

### DIFF
--- a/convex/publisherAbuse.test.ts
+++ b/convex/publisherAbuse.test.ts
@@ -529,7 +529,7 @@ function makePublisherAbuseAutobanSettingQuery(setting: unknown) {
 }
 
 describe("publisher abuse dry-run persistence", () => {
-  it("guards staff-only review entrypoints with moderator access", async () => {
+  it("keeps read-only dashboard entrypoints empty for non-staff while guarding writes", async () => {
     const user = { _id: "users:viewer", role: "user" };
     vi.mocked(assertModerator).mockImplementation(() => {
       throw new Error("Forbidden");
@@ -545,13 +545,28 @@ describe("publisher abuse dry-run persistence", () => {
       const dbQuery = vi.fn();
       const runMutation = vi.fn();
 
-      await expect(listDashboardHandler({ db: {} }, {})).rejects.toThrow("Forbidden");
+      await expect(
+        listDashboardHandler({ db: { get: dbGet, query: dbQuery } }, {}),
+      ).resolves.toEqual({
+        latestRun: null,
+        pendingItems: [],
+        pendingPotentialBanCandidateItems: [],
+        pendingReviewItems: [],
+        recentResolvedItems: [],
+      });
+      await expect(
+        getPublisherAbuseAutobanSettingHandler({ db: { query: dbQuery } }, {}),
+      ).resolves.toEqual({
+        enabled: false,
+        updatedAt: null,
+        updatedByUserId: null,
+      });
       await expect(
         getReviewNominationDetailHandler(
           { db: { get: dbGet, query: dbQuery } },
           { nominationId: "publisherAbuseReviewNominations:nomination" },
         ),
-      ).rejects.toThrow("Forbidden");
+      ).resolves.toBeNull();
       await expect(
         banPublisherAbuseOwnerHandler(
           { db: { get: dbGet }, runMutation },
@@ -632,7 +647,7 @@ describe("publisher abuse dry-run persistence", () => {
       updatedByUserId: null,
     });
 
-    expect(assertModerator).toHaveBeenCalledWith(user);
+    expect(ctx.db.query).toHaveBeenCalledWith("systemSettings");
   });
 
   it("lets admins enable publisher abuse autobans with an audit log", async () => {

--- a/convex/publisherAbuse.ts
+++ b/convex/publisherAbuse.ts
@@ -294,8 +294,6 @@ export const listReviewDashboard = query({
   handler: async (ctx, args) => {
     const auth = await requirePublisherAbuseDashboardUser(ctx);
     if (!auth) return emptyPublisherAbuseReviewDashboard();
-    const { user } = auth;
-    assertModerator(user);
 
     const limit = clampInt(args.limit ?? 150, 1, 250);
     const dashboardExclusionBudget = createStaffPublisherManagerExclusionBudget();
@@ -344,8 +342,6 @@ export const getReviewNominationDetail = query({
   handler: async (ctx, args) => {
     const auth = await requirePublisherAbuseDashboardUser(ctx);
     if (!auth) return null;
-    const { user } = auth;
-    assertModerator(user);
 
     const nomination = await ctx.db.get(args.nominationId);
     if (!nomination) return null;
@@ -378,8 +374,6 @@ export const getPublisherAbuseAutobanSetting = query({
   handler: async (ctx) => {
     const auth = await requirePublisherAbuseDashboardUser(ctx);
     if (!auth) return summarizePublisherAbuseAutobanSetting(null);
-    const { user } = auth;
-    assertModerator(user);
 
     const setting = await getPublisherAbuseAutobanSettingDoc(ctx);
     return summarizePublisherAbuseAutobanSetting(setting);
@@ -388,7 +382,8 @@ export const getPublisherAbuseAutobanSetting = query({
 
 async function requirePublisherAbuseDashboardUser(ctx: QueryCtx) {
   try {
-    return await requireUser(ctx);
+    const auth = await requireUser(ctx);
+    return auth.user.role === "admin" || auth.user.role === "moderator" ? auth : null;
   } catch (error) {
     if (error instanceof Error && error.message === "Unauthorized") return null;
     throw error;


### PR DESCRIPTION
## Summary
- Make read-only publisher abuse dashboard queries fail closed for non-staff callers as well as missing auth.
- Keep write paths strict: manual bans, scan starts, and kill-switch mutations still require moderator/admin access.
- Update the focused regression test to cover non-staff read fallback plus guarded writes.

## Reproduction
Before this patch, the dev backend used by `127.0.0.1:3030` resolved unauthenticated/dev CLI calls to `@local` with role `user`, then `publisherAbuse:listReviewDashboard` threw `Forbidden` from `assertModerator`.

## Verification
- `bunx vitest run convex/publisherAbuse.test.ts --testNamePattern "non-staff|auth is missing|defaults publisher abuse autobans|guards staff-only"`
- `bunx tsc --noEmit --pretty false`
- `git diff --check`
- `bunx convex dev --once --typecheck=disable` against `admired-dodo-615`
- Direct dev query now returns success/empty for `publisherAbuse:listReviewDashboard`
- Direct dev query now returns success/default-disabled for `publisherAbuse:getPublisherAbuseAutobanSetting`
- Headless local page check for `http://127.0.0.1:3030/management?view=abuse` records no publisher-abuse Convex errors
