### PR TITLE
Fix abuse dashboard list size cap

### DIFF
--- a/convex/publisherAbuse.ts
+++ b/convex/publisherAbuse.ts
@@ -43,6 +43,7 @@ const MAX_ACTIVE_SKILL_FALLBACK_SCAN = 500;
 const MAX_ACTIVE_SKILL_FALLBACK_SCANS_PER_PAGE = 20;
 const MAX_OWNER_NOMINATION_VERSION_SCAN = 20;
 const MAX_REVIEW_DASHBOARD_SCAN_MULTIPLIER = 3;
+const MAX_REVIEW_DASHBOARD_LIST_LIMIT = 25;
 const MAX_REVIEW_DASHBOARD_SCORE_SCAN_MULTIPLIER = 32;
 const MAX_REVIEW_DASHBOARD_SCORE_SCAN = 2000;
 const MAX_BAN_REASON_LENGTH = 500;
@@ -295,7 +296,11 @@ export const listReviewDashboard = query({
     const auth = await requirePublisherAbuseDashboardUser(ctx);
     if (!auth) return emptyPublisherAbuseReviewDashboard();
 
-    const limit = clampInt(args.limit ?? 150, 1, 250);
+    const limit = clampInt(
+      args.limit ?? MAX_REVIEW_DASHBOARD_LIST_LIMIT,
+      1,
+      MAX_REVIEW_DASHBOARD_LIST_LIMIT,
+    );
     const dashboardExclusionBudget = createStaffPublisherManagerExclusionBudget();
     const latestRun = await getLatestPublisherAbuseScoreRun(ctx);
     const scoreRankRunId = latestRun?.status === "completed" ? latestRun._id : undefined;

--- a/src/routes/management.tsx
+++ b/src/routes/management.tsx
@@ -217,7 +217,7 @@ export function Management() {
   ) as DuplicateCandidateEntry[] | undefined;
   const publisherAbuseDashboard = useQuery(
     api.publisherAbuse.listReviewDashboard,
-    staff && abuseViewActive ? { limit: 150 } : "skip",
+    staff && abuseViewActive ? { limit: 25 } : "skip",
   );
   const publisherAbuseAutobanSetting = useQuery(
     api.publisherAbuse.getPublisherAbuseAutobanSetting,


### PR DESCRIPTION
## Summary
- Cap the publisher abuse dashboard list query to 25 items per status while the dashboard is still non-paginated.
- Lower the management page request to the same cap.

## Why
The existing frontend still calls `publisherAbuse:listReviewDashboard` with `limit: 150`. Even after compacting score rows, production staff dashboard payloads were still too large. This backend cap protects production until the abuse queue is moved to a cursor-paginated list query.

## Verification
- `bunx vitest run convex/publisherAbuse.test.ts --testNamePattern "dashboard|non-staff|auth is missing|defaults publisher abuse autobans"`
- `bunx tsc --noEmit --pretty false`
- Production data payload estimate with cap: ~166 KB for current prod rows.
