### PR TITLE
Fix abuse dashboard pagination

### DIFF
--- a/convex/publisherAbuse.test.ts
+++ b/convex/publisherAbuse.test.ts
@@ -231,6 +231,20 @@ const listDashboardHandler = (
   >
 )._handler;
 
+const listReviewItemsPageHandler = (
+  publisherAbuse.listReviewItemsPage as unknown as Wrapped<
+    {
+      tab: "potential_ban_candidate" | "review" | "all_pending" | "resolved";
+      paginationOpts: { numItems: number; cursor: string | null };
+    },
+    {
+      page: unknown[];
+      isDone: boolean;
+      continueCursor: string;
+    }
+  >
+)._handler;
+
 const getReviewNominationDetailHandler = (
   publisherAbuse.getReviewNominationDetail as unknown as Wrapped<
     { nominationId: string },
@@ -2697,10 +2711,17 @@ describe("publisher abuse dry-run persistence", () => {
             if (indexName === "by_status_and_label_and_last_scored_at") {
               return {
                 order: () => ({
-                  take: async () =>
-                    constraints.label === "review" && constraints.status === "pending"
-                      ? [nomination]
-                      : [],
+                  paginate: async (paginationOpts: { numItems: number; cursor: string | null }) => {
+                    expect(paginationOpts).toEqual({ numItems: 1, cursor: null });
+                    return {
+                      page:
+                        constraints.label === "review" && constraints.status === "pending"
+                          ? [nomination]
+                          : [],
+                      isDone: true,
+                      continueCursor: "",
+                    };
+                  },
                 }),
               };
             }
@@ -2728,9 +2749,14 @@ describe("publisher abuse dry-run persistence", () => {
       },
     };
 
-    await expect(listDashboardHandler(ctx, { limit: 1 })).resolves.toEqual(
+    await expect(
+      listReviewItemsPageHandler(ctx, {
+        tab: "review",
+        paginationOpts: { numItems: 1, cursor: null },
+      }),
+    ).resolves.toEqual(
       expect.objectContaining({
-        pendingReviewItems: [
+        page: [
           expect.objectContaining({
             nomination: expect.objectContaining({
               _id: "publisherAbuseReviewNominations:failed-run",
@@ -2793,10 +2819,16 @@ describe("publisher abuse dry-run persistence", () => {
       label: "potential_ban_candidate",
       status: "pending",
     });
-    const scoresTake = vi.fn(async (limit: number) => {
-      expect(limit).toBe(32);
-      return [staleScore, hiddenScore, visibleScore];
-    });
+    const scoresPaginate = vi.fn(
+      async (paginationOpts: { numItems: number; cursor: string | null }) => {
+        expect(paginationOpts).toEqual({ numItems: 3, cursor: null });
+        return {
+          page: [staleScore, hiddenScore, visibleScore],
+          isDone: true,
+          continueCursor: "",
+        };
+      },
+    );
     const nominationsByOwnerKey = new Map([
       [staleNomination.ownerKey, staleNomination],
       [hiddenNomination.ownerKey, hiddenNomination],
@@ -2878,8 +2910,10 @@ describe("publisher abuse dry-run persistence", () => {
                 expect(constraints.runId).toBe("publisherAbuseScoreRuns:latest");
                 return {
                   order: () => ({
-                    take:
-                      constraints.label === "potential_ban_candidate" ? scoresTake : async () => [],
+                    paginate:
+                      constraints.label === "potential_ban_candidate"
+                        ? scoresPaginate
+                        : async () => ({ page: [], isDone: true, continueCursor: "" }),
                   }),
                 };
               },
@@ -2925,9 +2959,14 @@ describe("publisher abuse dry-run persistence", () => {
       },
     };
 
-    await expect(listDashboardHandler(ctx, { limit: 1 })).resolves.toEqual(
+    await expect(
+      listReviewItemsPageHandler(ctx, {
+        tab: "potential_ban_candidate",
+        paginationOpts: { numItems: 3, cursor: null },
+      }),
+    ).resolves.toEqual(
       expect.objectContaining({
-        pendingPotentialBanCandidateItems: [
+        page: [
           expect.objectContaining({
             nomination: expect.objectContaining({
               _id: "publisherAbuseReviewNominations:visible",
@@ -2938,7 +2977,7 @@ describe("publisher abuse dry-run persistence", () => {
         ],
       }),
     );
-    expect(scoresTake).toHaveBeenCalledWith(32);
+    expect(scoresPaginate).toHaveBeenCalledWith({ numItems: 3, cursor: null });
   });
 
   it("queries recent resolved nominations by review time", async () => {
@@ -3020,7 +3059,7 @@ describe("publisher abuse dry-run persistence", () => {
               return {
                 order: () => ({
                   take: async (limit: number) => {
-                    expect(limit).toBe(90);
+                    expect(limit).toBe(3);
                     if (constraints.status === "banned") return [bannedResolution];
                     if (constraints.status === "reviewed_no_action") {
                       return [rescoredOldResolution, resolvedNomination];
@@ -3157,8 +3196,11 @@ describe("publisher abuse dry-run persistence", () => {
       },
     };
 
-    const result = await listDashboardHandler(ctx, { limit: 2 });
-    expect(result.recentResolvedItems).toEqual([
+    const result = await listReviewItemsPageHandler(ctx, {
+      tab: "resolved",
+      paginationOpts: { numItems: 3, cursor: null },
+    });
+    expect(result.page).toEqual([
       expect.objectContaining({
         nomination: expect.objectContaining({
           _id: "publisherAbuseReviewNominations:banned-resolution",

--- a/convex/publisherAbuse.ts
+++ b/convex/publisherAbuse.ts
@@ -1,3 +1,4 @@
+import { paginationOptsValidator } from "convex/server";
 import { v } from "convex/values";
 import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
@@ -42,10 +43,8 @@ const ACTION_CONTINUATION_DELAY_MS = 60_000;
 const MAX_ACTIVE_SKILL_FALLBACK_SCAN = 500;
 const MAX_ACTIVE_SKILL_FALLBACK_SCANS_PER_PAGE = 20;
 const MAX_OWNER_NOMINATION_VERSION_SCAN = 20;
-const MAX_REVIEW_DASHBOARD_SCAN_MULTIPLIER = 3;
-const MAX_REVIEW_DASHBOARD_LIST_LIMIT = 25;
-const MAX_REVIEW_DASHBOARD_SCORE_SCAN_MULTIPLIER = 32;
-const MAX_REVIEW_DASHBOARD_SCORE_SCAN = 2000;
+const DEFAULT_REVIEW_DASHBOARD_PAGE_SIZE = 25;
+const MAX_REVIEW_DASHBOARD_PAGE_SIZE = 25;
 const MAX_BAN_REASON_LENGTH = 500;
 const DEFAULT_TEMPORAL_BATCH_SIZE = 50;
 const MAX_TEMPORAL_BATCH_SIZE = 100;
@@ -95,6 +94,13 @@ type ScoreRun = Doc<"publisherAbuseScoreRuns">;
 type ScoreDoc = Doc<"publisherAbuseScores">;
 type RunPhase = ScoreRun["phase"];
 type TemporalAbuseMode = "current" | "backfill";
+
+const publisherAbuseReviewTabValidator = v.union(
+  v.literal("potential_ban_candidate"),
+  v.literal("review"),
+  v.literal("all_pending"),
+  v.literal("resolved"),
+);
 
 type RunState = {
   runId: Id<"publisherAbuseScoreRuns">;
@@ -292,50 +298,75 @@ export const listReviewDashboard = query({
   args: {
     limit: v.optional(v.number()),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, _args) => {
     const auth = await requirePublisherAbuseDashboardUser(ctx);
     if (!auth) return emptyPublisherAbuseReviewDashboard();
 
-    const limit = clampInt(
-      args.limit ?? MAX_REVIEW_DASHBOARD_LIST_LIMIT,
-      1,
-      MAX_REVIEW_DASHBOARD_LIST_LIMIT,
-    );
-    const dashboardExclusionBudget = createStaffPublisherManagerExclusionBudget();
     const latestRun = await getLatestPublisherAbuseScoreRun(ctx);
-    const scoreRankRunId = latestRun?.status === "completed" ? latestRun._id : undefined;
-    const pendingPotentialBanCandidateItems = await getPendingPublisherAbuseReviewItemsForLabel(
-      ctx,
-      {
-        status: "pending",
-        label: "potential_ban_candidate",
-        limit,
-        latestCompletedRunId: scoreRankRunId,
-        staffManagerExclusionBudget: dashboardExclusionBudget,
-      },
-    );
-    const pendingReviewItems = await getPendingPublisherAbuseReviewItemsForLabel(ctx, {
-      status: "pending",
-      label: "review",
-      limit,
-      latestCompletedRunId: scoreRankRunId,
-      staffManagerExclusionBudget: dashboardExclusionBudget,
-    });
-    const pendingItems = [...pendingPotentialBanCandidateItems, ...pendingReviewItems]
-      .sort(comparePublisherAbuseReviewItemsByLastScoredAt)
-      .slice(0, limit);
-    const recentResolvedItems = await getRecentResolvedPublisherAbuseReviewItems(
-      ctx,
-      30,
-      dashboardExclusionBudget,
-    );
 
     return {
       latestRun: latestRun ? summarizePublisherAbuseRun(latestRun) : null,
-      pendingItems,
-      pendingPotentialBanCandidateItems,
-      pendingReviewItems,
-      recentResolvedItems,
+      pendingItems: [],
+      pendingPotentialBanCandidateItems: [],
+      pendingReviewItems: [],
+      recentResolvedItems: [],
+    };
+  },
+});
+
+export const listReviewItemsPage = query({
+  args: {
+    tab: publisherAbuseReviewTabValidator,
+    paginationOpts: paginationOptsValidator,
+  },
+  handler: async (ctx, args) => {
+    const auth = await requirePublisherAbuseDashboardUser(ctx);
+    if (!auth) {
+      return {
+        page: [],
+        isDone: true,
+        continueCursor: "",
+      };
+    }
+
+    const paginationOpts = {
+      ...args.paginationOpts,
+      numItems: clampInt(
+        args.paginationOpts.numItems ?? DEFAULT_REVIEW_DASHBOARD_PAGE_SIZE,
+        1,
+        MAX_REVIEW_DASHBOARD_PAGE_SIZE,
+      ),
+    };
+    const dashboardExclusionBudget = createStaffPublisherManagerExclusionBudget();
+    const latestRun = await getLatestPublisherAbuseScoreRun(ctx);
+    const scoreRankRunId = latestRun?.status === "completed" ? latestRun._id : undefined;
+
+    if (args.tab === "potential_ban_candidate" || args.tab === "review") {
+      return await getPendingPublisherAbuseReviewItemsPageForLabel(ctx, {
+        status: "pending",
+        label: args.tab,
+        latestCompletedRunId: scoreRankRunId,
+        paginationOpts,
+        staffManagerExclusionBudget: dashboardExclusionBudget,
+      });
+    }
+
+    if (args.tab === "all_pending") {
+      return await getPublisherAbuseReviewItemsPageFromPendingNominations(ctx, {
+        paginationOpts,
+        staffManagerExclusionBudget: dashboardExclusionBudget,
+      });
+    }
+
+    const recentResolvedItems = await getRecentResolvedPublisherAbuseReviewItems(
+      ctx,
+      paginationOpts.numItems,
+      dashboardExclusionBudget,
+    );
+    return {
+      page: recentResolvedItems,
+      isDone: true,
+      continueCursor: "",
     };
   },
 });
@@ -2963,79 +2994,36 @@ type PublisherAbuseReviewVisibilityOptions = {
   includeScoreDetails?: boolean;
 };
 
-async function getPendingPublisherAbuseReviewItemsForLabel(
+type PublisherAbuseReviewPaginationOpts = {
+  numItems: number;
+  cursor: string | null;
+};
+
+async function getPendingPublisherAbuseReviewItemsPageForLabel(
   ctx: QueryCtx,
   args: {
     status: TriageStatus;
     label: PendingPublisherAbuseReviewLabel;
-    limit: number;
     latestCompletedRunId: Id<"publisherAbuseScoreRuns"> | undefined;
+    paginationOpts: PublisherAbuseReviewPaginationOpts;
     staffManagerExclusionBudget?: StaffPublisherManagerExclusionBudget;
   },
 ) {
   if (!args.latestCompletedRunId) {
-    return await getPendingPublisherAbuseReviewItemsForLabelFromLastScoredAt(ctx, args);
+    return await getPublisherAbuseReviewItemsPageFromPendingNominations(ctx, args);
   }
 
-  const scoreRankItems = await getPendingPublisherAbuseReviewItemsForLabelFromScoreRank(ctx, {
-    latestCompletedRunId: args.latestCompletedRunId,
-    status: args.status,
-    label: args.label,
-    limit: args.limit,
-    staffManagerExclusionBudget: args.staffManagerExclusionBudget,
-  });
-  if (scoreRankItems.length >= args.limit) return scoreRankItems;
-
-  const lastScoredItems = await getPendingPublisherAbuseReviewItemsForLabelFromLastScoredAt(
-    ctx,
-    args,
-  );
-  return mergePublisherAbuseReviewItems(scoreRankItems, lastScoredItems, args.limit);
-}
-
-function mergePublisherAbuseReviewItems(
-  primary: PublisherAbuseReviewItem[],
-  fallback: PublisherAbuseReviewItem[],
-  limit: number,
-) {
-  const items = [...primary];
-  const seen = new Set(primary.map((item) => item.nomination._id));
-  for (const item of fallback) {
-    if (seen.has(item.nomination._id)) continue;
-    items.push(item);
-    seen.add(item.nomination._id);
-    if (items.length >= limit) break;
-  }
-  return items;
-}
-
-function scoreRankScanLimit(limit: number) {
-  return Math.min(
-    limit * MAX_REVIEW_DASHBOARD_SCORE_SCAN_MULTIPLIER,
-    MAX_REVIEW_DASHBOARD_SCORE_SCAN,
-  );
-}
-
-async function getPendingPublisherAbuseReviewItemsForLabelFromScoreRank(
-  ctx: QueryCtx,
-  args: {
-    latestCompletedRunId: Id<"publisherAbuseScoreRuns">;
-    status: TriageStatus;
-    label: PendingPublisherAbuseReviewLabel;
-    limit: number;
-    staffManagerExclusionBudget?: StaffPublisherManagerExclusionBudget;
-  },
-) {
-  const items: PublisherAbuseReviewItem[] = [];
-  const scores = await ctx.db
+  const latestCompletedRunId = args.latestCompletedRunId;
+  const page = await ctx.db
     .query("publisherAbuseScores")
     .withIndex("by_run_and_label_and_rank", (q) =>
-      q.eq("runId", args.latestCompletedRunId).eq("label", args.label),
+      q.eq("runId", latestCompletedRunId).eq("label", args.label),
     )
     .order("asc")
-    .take(scoreRankScanLimit(args.limit));
+    .paginate(args.paginationOpts);
 
-  for (const score of scores) {
+  const items: PublisherAbuseReviewItem[] = [];
+  for (const score of page.page) {
     const nomination = await ctx.db
       .query("publisherAbuseReviewNominations")
       .withIndex("by_owner_key_and_model_version", (q) =>
@@ -3052,49 +3040,56 @@ async function getPendingPublisherAbuseReviewItemsForLabelFromScoreRank(
     }
     const item = await summarizePublisherAbuseReviewNomination(ctx, nomination);
     if (
-      !(await isVisiblePublisherAbuseReviewItem(ctx, item, {
+      await isVisiblePublisherAbuseReviewItem(ctx, item, {
         staffManagerExclusionBudget: args.staffManagerExclusionBudget,
-      }))
+      })
     ) {
-      continue;
+      items.push(item);
     }
-    items.push(item);
-    if (items.length >= args.limit) break;
   }
-  return items;
+
+  return {
+    page: items,
+    isDone: page.isDone,
+    continueCursor: page.continueCursor,
+  };
 }
 
-async function getPendingPublisherAbuseReviewItemsForLabelFromLastScoredAt(
+async function getPublisherAbuseReviewItemsPageFromPendingNominations(
   ctx: QueryCtx,
   args: {
-    status: TriageStatus;
-    label: PendingPublisherAbuseReviewLabel;
-    limit: number;
+    status?: TriageStatus;
+    label?: PendingPublisherAbuseReviewLabel;
+    paginationOpts: PublisherAbuseReviewPaginationOpts;
     staffManagerExclusionBudget?: StaffPublisherManagerExclusionBudget;
   },
 ) {
-  const items: PublisherAbuseReviewItem[] = [];
-  const scanLimit = args.limit * MAX_REVIEW_DASHBOARD_SCAN_MULTIPLIER;
-  const nominations = await ctx.db
-    .query("publisherAbuseReviewNominations")
-    .withIndex("by_status_and_label_and_last_scored_at", (q) =>
-      q.eq("status", args.status).eq("label", args.label),
-    )
-    .order("desc")
-    .take(scanLimit);
-  const pageItems = await summarizePublisherAbuseReviewNominations(ctx, nominations);
-  for (const item of pageItems) {
-    if (
-      !(await isVisiblePublisherAbuseReviewItem(ctx, item, {
-        staffManagerExclusionBudget: args.staffManagerExclusionBudget,
-      }))
-    ) {
-      continue;
-    }
-    items.push(item);
-    if (items.length >= args.limit) break;
-  }
-  return items;
+  const label = args.label;
+  const page =
+    label !== undefined
+      ? await ctx.db
+          .query("publisherAbuseReviewNominations")
+          .withIndex("by_status_and_label_and_last_scored_at", (q) =>
+            q.eq("status", args.status ?? "pending").eq("label", label),
+          )
+          .order("desc")
+          .paginate(args.paginationOpts)
+      : await ctx.db
+          .query("publisherAbuseReviewNominations")
+          .withIndex("by_status_and_last_scored_at", (q) =>
+            q.eq("status", args.status ?? "pending"),
+          )
+          .order("desc")
+          .paginate(args.paginationOpts);
+  const items = await summarizeVisiblePublisherAbuseReviewNominations(ctx, page.page, undefined, {
+    staffManagerExclusionBudget: args.staffManagerExclusionBudget,
+  });
+
+  return {
+    page: items,
+    isDone: page.isDone,
+    continueCursor: page.continueCursor,
+  };
 }
 
 async function getLatestPublisherAbuseScoreRun(ctx: QueryCtx) {
@@ -3137,7 +3132,7 @@ async function getRecentResolvedPublisherAbuseReviewItems(
       .query("publisherAbuseReviewNominations")
       .withIndex("by_status_and_reviewed_at", (q) => q.eq("status", status))
       .order("desc")
-      .take(limit * MAX_REVIEW_DASHBOARD_SCAN_MULTIPLIER);
+      .take(limit);
     nominations.push(...page);
   }
   nominations.sort((left, right) => (right.reviewedAt ?? 0) - (left.reviewedAt ?? 0));
@@ -3145,18 +3140,6 @@ async function getRecentResolvedPublisherAbuseReviewItems(
     staffManagerExclusionBudget,
     includeInactiveTargets: true,
   });
-}
-
-async function summarizePublisherAbuseReviewNominations(
-  ctx: QueryCtx,
-  nominations: Doc<"publisherAbuseReviewNominations">[],
-  options: PublisherAbuseReviewVisibilityOptions = {},
-) {
-  const items = [];
-  for (const nomination of nominations) {
-    items.push(await summarizePublisherAbuseReviewNomination(ctx, nomination, options));
-  }
-  return items;
 }
 
 async function summarizeVisiblePublisherAbuseReviewNominations(
@@ -3217,16 +3200,6 @@ async function isVisiblePublisherAbuseReviewItem(
     (options.includeInactiveTargets || !targetIsInactive) &&
     !(await isPublisherAbuseExcludedReviewItem(ctx, item, options.staffManagerExclusionBudget))
   );
-}
-
-function comparePublisherAbuseReviewItemsByLastScoredAt(
-  left: PublisherAbuseReviewItem,
-  right: PublisherAbuseReviewItem,
-) {
-  if (left.nomination.lastScoredAt !== right.nomination.lastScoredAt) {
-    return right.nomination.lastScoredAt - left.nomination.lastScoredAt;
-  }
-  return right.nomination._id.localeCompare(left.nomination._id);
 }
 
 function summarizePublisherAbuseRun(run: Doc<"publisherAbuseScoreRuns">) {

--- a/src/routes/-management.test.tsx
+++ b/src/routes/-management.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Management } from "./management";
 
 const useQueryMock = vi.fn();
+const usePaginatedQueryMock = vi.fn();
 const useMutationMock = vi.fn();
 const useActionMock = vi.fn();
 const navigateMock = vi.fn();
@@ -145,6 +146,7 @@ function linkHref(to: string, search: unknown) {
 
 vi.mock("convex/react", () => ({
   useAction: (...args: unknown[]) => useActionMock(...args),
+  usePaginatedQuery: (...args: unknown[]) => usePaginatedQueryMock(...args),
   useQuery: (...args: unknown[]) => useQueryMock(...args),
   useMutation: (...args: unknown[]) => useMutationMock(...args),
 }));
@@ -178,6 +180,7 @@ vi.mock("../lib/useAuthStatus", () => ({
 describe("Management", () => {
   beforeEach(() => {
     useQueryMock.mockReset();
+    usePaginatedQueryMock.mockReset();
     useMutationMock.mockReset();
     useActionMock.mockReset();
     navigateMock.mockReset();
@@ -189,6 +192,11 @@ describe("Management", () => {
     };
     useMutationMock.mockReturnValue(vi.fn());
     useActionMock.mockReturnValue(vi.fn());
+    usePaginatedQueryMock.mockReturnValue({
+      results: [],
+      status: "Exhausted",
+      loadMore: vi.fn(),
+    });
     useQueryMock.mockImplementation((query, args) => {
       if (args === "skip") return undefined;
       const name = getFunctionName(query);

--- a/src/routes/-management/AbusePage.tsx
+++ b/src/routes/-management/AbusePage.tsx
@@ -42,6 +42,7 @@ export function AbusePage({
   dashboard,
   detail,
   items,
+  pageStatus,
   notes,
   search,
   selectedItem,
@@ -52,6 +53,7 @@ export function AbusePage({
   onChangeSearch,
   onChangeTab,
   onClose,
+  onLoadMore,
   onRefresh,
   onSelect,
   onToggleAutoban,
@@ -68,6 +70,7 @@ export function AbusePage({
   dashboard: PublisherAbuseReviewDashboard | undefined;
   detail: PublisherAbuseReviewDetail | undefined;
   items: PublisherAbuseReviewItem[];
+  pageStatus: string;
   notes: string;
   search: string;
   selectedItem: PublisherAbuseReviewItem | null;
@@ -78,6 +81,7 @@ export function AbusePage({
   onChangeSearch: (value: string) => void;
   onChangeTab: (value: PublisherAbuseTab) => void;
   onClose: () => void;
+  onLoadMore: () => void;
   onRefresh: () => void;
   onSelect: (value: Id<"publisherAbuseReviewNominations">) => void;
   onToggleAutoban: () => void;
@@ -87,12 +91,18 @@ export function AbusePage({
   const selectedPublisher = selectedItem?.publisher ?? null;
   const canBanSelectedUser = canBanPublisherAbuseOwner(selectedItem, currentUserId);
   const visiblePending = dashboard ? getPublisherAbuseVisiblePendingItems(dashboard) : [];
-  const totalPending = visiblePending.length;
-  const potentialBan = visiblePending.filter(
-    (item) => item.nomination.label === "potential_ban_candidate",
-  ).length;
-  const review = visiblePending.filter((item) => item.nomination.label === "review").length;
-  const resolved = dashboard?.recentResolvedItems.length ?? 0;
+  const potentialBan =
+    dashboard?.latestRun?.potentialBanCandidateCount ??
+    visiblePending.filter((item) => item.nomination.label === "potential_ban_candidate").length;
+  const review =
+    dashboard?.latestRun?.reviewCount ??
+    visiblePending.filter((item) => item.nomination.label === "review").length;
+  const totalPending =
+    dashboard?.latestRun?.potentialBanCandidateCount !== undefined ||
+    dashboard?.latestRun?.reviewCount !== undefined
+      ? potentialBan + review
+      : visiblePending.length;
+  const resolved = tab === "resolved" ? items.length : (dashboard?.recentResolvedItems.length ?? 0);
   const totalForTab =
     tab === "potential_ban_candidate"
       ? potentialBan
@@ -101,7 +111,9 @@ export function AbusePage({
         : tab === "resolved"
           ? resolved
           : totalPending;
-  const loaded = dashboard !== undefined;
+  const loaded = dashboard !== undefined && pageStatus !== "LoadingFirstPage";
+  const canLoadMore = pageStatus === "CanLoadMore";
+  const loadingMore = pageStatus === "LoadingMore";
   const autobanLoaded = autobanSetting !== undefined;
   const autobanEnabled = autobanSetting?.enabled ?? false;
   const autobanStatusLabel = autobanLoaded
@@ -302,9 +314,22 @@ export function AbusePage({
           </table>
         </div>
         <div className="pa-foot">
-          {loaded
-            ? `Showing ${formatWholeNumber(items.length)} of ${formatWholeNumber(totalForTab)} nominations`
-            : "Loading…"}
+          <span>
+            {loaded
+              ? `Showing ${formatWholeNumber(items.length)} of ${formatWholeNumber(totalForTab)} nominations`
+              : "Loading…"}
+          </span>
+          {canLoadMore || loadingMore ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={loadingMore}
+              onClick={onLoadMore}
+            >
+              {loadingMore ? "Loading..." : "Load more"}
+            </Button>
+          ) : null}
         </div>
       </Card>
 
@@ -662,21 +687,30 @@ export function canBanPublisherAbuseOwner(
   return true;
 }
 
-export function getPublisherAbuseVisiblePendingItems(dashboard: PublisherAbuseReviewDashboard) {
-  return [...dashboard.pendingPotentialBanCandidateItems, ...dashboard.pendingReviewItems].filter(
-    isVisiblePublisherAbuseItem,
-  );
+export function getPublisherAbuseVisiblePendingItems(
+  dashboard: PublisherAbuseReviewDashboard,
+): PublisherAbuseReviewItem[] {
+  const potentialBanItems =
+    dashboard.pendingPotentialBanCandidateItems as PublisherAbuseReviewItem[];
+  const reviewItems = dashboard.pendingReviewItems as PublisherAbuseReviewItem[];
+  return [...potentialBanItems, ...reviewItems].filter(isVisiblePublisherAbuseItem);
 }
 
 export function getPublisherAbuseItemsForTab(
   dashboard: PublisherAbuseReviewDashboard,
   tab: PublisherAbuseTab,
-) {
+): PublisherAbuseReviewItem[] {
   if (tab === "potential_ban_candidate") {
-    return dashboard.pendingPotentialBanCandidateItems.filter(isVisiblePublisherAbuseItem);
+    return (dashboard.pendingPotentialBanCandidateItems as PublisherAbuseReviewItem[]).filter(
+      isVisiblePublisherAbuseItem,
+    );
   }
-  if (tab === "review") return dashboard.pendingReviewItems.filter(isVisiblePublisherAbuseItem);
-  if (tab === "resolved") return dashboard.recentResolvedItems;
+  if (tab === "review") {
+    return (dashboard.pendingReviewItems as PublisherAbuseReviewItem[]).filter(
+      isVisiblePublisherAbuseItem,
+    );
+  }
+  if (tab === "resolved") return dashboard.recentResolvedItems as PublisherAbuseReviewItem[];
   return getPublisherAbuseVisiblePendingItems(dashboard);
 }
 

--- a/src/routes/-management/managementShared.ts
+++ b/src/routes/-management/managementShared.ts
@@ -22,7 +22,9 @@ export type PublisherAbuseReviewDashboard = FunctionReturnType<
 export type PublisherAbuseReviewDetail = FunctionReturnType<
   typeof api.publisherAbuse.getReviewNominationDetail
 >;
-export type PublisherAbuseReviewItem = PublisherAbuseReviewDashboard["pendingItems"][number];
+export type PublisherAbuseReviewItem = FunctionReturnType<
+  typeof api.publisherAbuse.listReviewItemsPage
+>["page"][number];
 export type PublisherAbuseReviewScore = NonNullable<PublisherAbuseReviewItem["latestScore"]>;
 export type PublisherAbuseTab = "potential_ban_candidate" | "review" | "all_pending" | "resolved";
 

--- a/src/routes/management.tsx
+++ b/src/routes/management.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { useAction, useMutation, useQuery } from "convex/react";
+import { useAction, useMutation, usePaginatedQuery, useQuery } from "convex/react";
 import {
   AlertTriangle,
   ChevronRight,
@@ -261,6 +261,15 @@ export function Management() {
   const [publisherAbuseNotes, setPublisherAbuseNotes] = useState("");
   const [selectedPublisherAbuseNominationId, setSelectedPublisherAbuseNominationId] =
     useState<Id<"publisherAbuseReviewNominations"> | null>(null);
+  const {
+    results: publisherAbusePageResults,
+    status: publisherAbusePageStatus,
+    loadMore: loadMorePublisherAbuseItems,
+  } = usePaginatedQuery(
+    api.publisherAbuse.listReviewItemsPage,
+    staff && abuseViewActive ? { tab: publisherAbuseTab } : "skip",
+    { initialNumItems: 25 },
+  );
 
   const userQuery = userSearchDebounced.trim();
   const userResult = useStableQuery(
@@ -285,13 +294,18 @@ export function Management() {
 
   const selectedOwnerUserId = selectedSkill?.skill?.ownerUserId ?? null;
   const selectedCanonicalSlug = selectedSkill?.canonical?.skill?.slug ?? "";
-  const publisherAbuseItemsForTab = useMemo(
+  const publisherAbuseDashboardFallbackItems = useMemo(
     () =>
       publisherAbuseDashboard
         ? getPublisherAbuseItemsForTab(publisherAbuseDashboard, publisherAbuseTab)
         : [],
     [publisherAbuseDashboard, publisherAbuseTab],
   );
+  const publisherAbusePageItems = (publisherAbusePageResults ?? []) as PublisherAbuseReviewItem[];
+  const publisherAbuseItemsForTab =
+    publisherAbusePageItems.length > 0 || publisherAbuseDashboardFallbackItems.length === 0
+      ? publisherAbusePageItems
+      : publisherAbuseDashboardFallbackItems;
   const filteredPublisherAbuseItems = useMemo(() => {
     const filtered = filterPublisherAbuseItems(publisherAbuseItemsForTab, publisherAbuseSearch);
     if (publisherAbuseTab === "resolved") return filtered;
@@ -621,6 +635,7 @@ export function Management() {
             dashboard={publisherAbuseDashboard}
             detail={selectedPublisherAbuseDetail}
             items={filteredPublisherAbuseItems}
+            pageStatus={publisherAbusePageStatus}
             notes={publisherAbuseNotes}
             search={publisherAbuseSearch}
             selectedItem={selectedPublisherAbuseItem}
@@ -631,6 +646,7 @@ export function Management() {
             onChangeSearch={setPublisherAbuseSearch}
             onChangeTab={setPublisherAbuseTab}
             onToggleAutoban={requestTogglePublisherAbuseAutoban}
+            onLoadMore={() => loadMorePublisherAbuseItems(25)}
             onRefresh={() => {
               setConfirmRequest({
                 title: "Run a new abuse scan?",


### PR DESCRIPTION
## Summary
- move abuse dashboard rows out of `listReviewDashboard` into `listReviewItemsPage`
- page the active abuse tab with Convex `usePaginatedQuery` and a server-side max of 25 rows
- keep the dashboard query as summary-only so old clients stop requesting the heavy row payload

## Verification
- `bunx convex codegen`
- `bunx vitest run src/routes/-management.test.tsx convex/publisherAbuse.test.ts --testNamePattern "publisher abuse|dashboard|pagination|autoban"`
- `bunx tsc --noEmit --pretty false`
- `git diff --check`
