### PR TITLE
Fix abuse dashboard row query runtime

### DIFF
--- a/convex/publisherAbuse.test.ts
+++ b/convex/publisherAbuse.test.ts
@@ -2768,39 +2768,11 @@ describe("publisher abuse dry-run persistence", () => {
     );
   });
 
-  it("uses completed-run score rank while skipping stale and hidden dashboard candidates", async () => {
+  it("pages nomination rows while skipping hidden dashboard candidates", async () => {
     vi.mocked(requireUser).mockResolvedValue({
       userId: "users:moderator",
       user: { _id: "users:moderator", role: "moderator" },
     } as never);
-    const latestRun = makeCompletedPressureScoreRun();
-    const staleScore = makeScore({
-      _id: "publisherAbuseScores:stale",
-      ownerKey: "publisher:publishers:stale",
-      ownerPublisherId: "publishers:stale",
-      rank: 1,
-    });
-    const hiddenScore = makeScore({
-      _id: "publisherAbuseScores:hidden",
-      ownerKey: "publisher:publishers:hidden",
-      ownerPublisherId: "publishers:hidden",
-      rank: 2,
-    });
-    const visibleScore = makeScore({
-      _id: "publisherAbuseScores:visible",
-      ownerKey: "publisher:publishers:visible",
-      ownerPublisherId: "publishers:visible",
-      rank: 3,
-    });
-    const staleNomination = makeNomination({
-      _id: "publisherAbuseReviewNominations:stale",
-      ownerKey: "publisher:publishers:stale",
-      ownerPublisherId: "publishers:stale",
-      ownerUserId: "users:stale",
-      latestScoreId: "publisherAbuseScores:old-stale",
-      label: "potential_ban_candidate",
-      status: "pending",
-    });
     const hiddenNomination = makeNomination({
       _id: "publisherAbuseReviewNominations:hidden",
       ownerKey: "publisher:publishers:hidden",
@@ -2819,27 +2791,19 @@ describe("publisher abuse dry-run persistence", () => {
       label: "potential_ban_candidate",
       status: "pending",
     });
-    const scoresPaginate = vi.fn(
+    const nominationsPaginate = vi.fn(
       async (paginationOpts: { numItems: number; cursor: string | null }) => {
-        expect(paginationOpts).toEqual({ numItems: 3, cursor: null });
+        expect(paginationOpts).toEqual({ numItems: 2, cursor: null });
         return {
-          page: [staleScore, hiddenScore, visibleScore],
+          page: [hiddenNomination, visibleNomination],
           isDone: true,
           continueCursor: "",
         };
       },
     );
-    const nominationsByOwnerKey = new Map([
-      [staleNomination.ownerKey, staleNomination],
-      [hiddenNomination.ownerKey, hiddenNomination],
-      [visibleNomination.ownerKey, visibleNomination],
-    ]);
     const ctx = {
       db: {
         get: vi.fn(async (id: string) => {
-          if (id === "publisherAbuseScoreRuns:latest") return latestRun;
-          if (id === "publisherAbuseScores:hidden") return hiddenScore;
-          if (id === "publisherAbuseScores:visible") return visibleScore;
           if (id === "publishers:hidden") {
             return {
               _id: "publishers:hidden",
@@ -2866,58 +2830,8 @@ describe("publisher abuse dry-run persistence", () => {
           return null;
         }),
         query: vi.fn((table: string) => {
-          if (table === "publisherAbuseScoreRuns") {
-            return {
-              withIndex: (
-                indexName: string,
-                build: (q: { eq: (field: string, value: unknown) => unknown }) => unknown,
-              ) => {
-                expect(indexName).toBe("by_model_version_and_started_at");
-                const constraints: Record<string, unknown> = {};
-                const q = {
-                  eq(field: string, value: unknown) {
-                    constraints[field] = value;
-                    return q;
-                  },
-                };
-                build(q);
-                return {
-                  order: () => ({
-                    first: async () =>
-                      constraints.modelVersion === TEST_MODEL_CONFIG.modelVersion
-                        ? latestRun
-                        : null,
-                  }),
-                };
-              },
-            };
-          }
           if (table === "publisherAbuseScores") {
-            return {
-              withIndex: (
-                indexName: string,
-                build: (q: { eq: (field: string, value: unknown) => unknown }) => unknown,
-              ) => {
-                expect(indexName).toBe("by_run_and_label_and_rank");
-                const constraints: Record<string, unknown> = {};
-                const q = {
-                  eq(field: string, value: unknown) {
-                    constraints[field] = value;
-                    return q;
-                  },
-                };
-                build(q);
-                expect(constraints.runId).toBe("publisherAbuseScoreRuns:latest");
-                return {
-                  order: () => ({
-                    paginate:
-                      constraints.label === "potential_ban_candidate"
-                        ? scoresPaginate
-                        : async () => ({ page: [], isDone: true, continueCursor: "" }),
-                  }),
-                };
-              },
-            };
+            throw new Error("dashboard list pages should not read score documents");
           }
           if (table === "publisherAbuseReviewNominations") {
             return {
@@ -2933,19 +2847,14 @@ describe("publisher abuse dry-run persistence", () => {
                   },
                 };
                 build(q);
-                if (indexName === "by_owner_key_and_model_version") {
-                  return {
-                    first: async () =>
-                      nominationsByOwnerKey.get(String(constraints.ownerKey)) ?? null,
-                  };
-                }
-                if (
-                  indexName === "by_status_and_label_and_last_scored_at" ||
-                  indexName === "by_status_and_reviewed_at"
-                ) {
+                if (indexName === "by_status_and_label_and_last_scored_at") {
+                  expect(constraints).toEqual({
+                    status: "pending",
+                    label: "potential_ban_candidate",
+                  });
                   return {
                     order: () => ({
-                      take: async () => [],
+                      paginate: nominationsPaginate,
                     }),
                   };
                 }
@@ -2962,7 +2871,7 @@ describe("publisher abuse dry-run persistence", () => {
     await expect(
       listReviewItemsPageHandler(ctx, {
         tab: "potential_ban_candidate",
-        paginationOpts: { numItems: 3, cursor: null },
+        paginationOpts: { numItems: 2, cursor: null },
       }),
     ).resolves.toEqual(
       expect.objectContaining({
@@ -2972,12 +2881,13 @@ describe("publisher abuse dry-run persistence", () => {
               _id: "publisherAbuseReviewNominations:visible",
               latestScoreId: "publisherAbuseScores:visible",
             }),
+            latestScore: null,
             publisher: expect.objectContaining({ handle: "visible" }),
           }),
         ],
       }),
     );
-    expect(scoresPaginate).toHaveBeenCalledWith({ numItems: 3, cursor: null });
+    expect(nominationsPaginate).toHaveBeenCalledWith({ numItems: 2, cursor: null });
   });
 
   it("queries recent resolved nominations by review time", async () => {

--- a/convex/publisherAbuse.ts
+++ b/convex/publisherAbuse.ts
@@ -338,14 +338,11 @@ export const listReviewItemsPage = query({
       ),
     };
     const dashboardExclusionBudget = createStaffPublisherManagerExclusionBudget();
-    const latestRun = await getLatestPublisherAbuseScoreRun(ctx);
-    const scoreRankRunId = latestRun?.status === "completed" ? latestRun._id : undefined;
 
     if (args.tab === "potential_ban_candidate" || args.tab === "review") {
-      return await getPendingPublisherAbuseReviewItemsPageForLabel(ctx, {
+      return await getPublisherAbuseReviewItemsPageFromPendingNominations(ctx, {
         status: "pending",
         label: args.tab,
-        latestCompletedRunId: scoreRankRunId,
         paginationOpts,
         staffManagerExclusionBudget: dashboardExclusionBudget,
       });
@@ -2999,62 +2996,6 @@ type PublisherAbuseReviewPaginationOpts = {
   cursor: string | null;
 };
 
-async function getPendingPublisherAbuseReviewItemsPageForLabel(
-  ctx: QueryCtx,
-  args: {
-    status: TriageStatus;
-    label: PendingPublisherAbuseReviewLabel;
-    latestCompletedRunId: Id<"publisherAbuseScoreRuns"> | undefined;
-    paginationOpts: PublisherAbuseReviewPaginationOpts;
-    staffManagerExclusionBudget?: StaffPublisherManagerExclusionBudget;
-  },
-) {
-  if (!args.latestCompletedRunId) {
-    return await getPublisherAbuseReviewItemsPageFromPendingNominations(ctx, args);
-  }
-
-  const latestCompletedRunId = args.latestCompletedRunId;
-  const page = await ctx.db
-    .query("publisherAbuseScores")
-    .withIndex("by_run_and_label_and_rank", (q) =>
-      q.eq("runId", latestCompletedRunId).eq("label", args.label),
-    )
-    .order("asc")
-    .paginate(args.paginationOpts);
-
-  const items: PublisherAbuseReviewItem[] = [];
-  for (const score of page.page) {
-    const nomination = await ctx.db
-      .query("publisherAbuseReviewNominations")
-      .withIndex("by_owner_key_and_model_version", (q) =>
-        q.eq("ownerKey", score.ownerKey).eq("modelVersion", score.modelVersion),
-      )
-      .first();
-    if (
-      !nomination ||
-      nomination.status !== args.status ||
-      nomination.label !== args.label ||
-      nomination.latestScoreId !== score._id
-    ) {
-      continue;
-    }
-    const item = await summarizePublisherAbuseReviewNomination(ctx, nomination);
-    if (
-      await isVisiblePublisherAbuseReviewItem(ctx, item, {
-        staffManagerExclusionBudget: args.staffManagerExclusionBudget,
-      })
-    ) {
-      items.push(item);
-    }
-  }
-
-  return {
-    page: items,
-    isDone: page.isDone,
-    continueCursor: page.continueCursor,
-  };
-}
-
 async function getPublisherAbuseReviewItemsPageFromPendingNominations(
   ctx: QueryCtx,
   args: {
@@ -3081,9 +3022,14 @@ async function getPublisherAbuseReviewItemsPageFromPendingNominations(
           )
           .order("desc")
           .paginate(args.paginationOpts);
-  const items = await summarizeVisiblePublisherAbuseReviewNominations(ctx, page.page, undefined, {
-    staffManagerExclusionBudget: args.staffManagerExclusionBudget,
-  });
+  const items = await summarizeVisiblePublisherAbuseReviewListNominations(
+    ctx,
+    page.page,
+    undefined,
+    {
+      staffManagerExclusionBudget: args.staffManagerExclusionBudget,
+    },
+  );
 
   return {
     page: items,
@@ -3136,13 +3082,13 @@ async function getRecentResolvedPublisherAbuseReviewItems(
     nominations.push(...page);
   }
   nominations.sort((left, right) => (right.reviewedAt ?? 0) - (left.reviewedAt ?? 0));
-  return await summarizeVisiblePublisherAbuseReviewNominations(ctx, nominations, limit, {
+  return await summarizeVisiblePublisherAbuseReviewListNominations(ctx, nominations, limit, {
     staffManagerExclusionBudget,
     includeInactiveTargets: true,
   });
 }
 
-async function summarizeVisiblePublisherAbuseReviewNominations(
+async function summarizeVisiblePublisherAbuseReviewListNominations(
   ctx: QueryCtx,
   nominations: Doc<"publisherAbuseReviewNominations">[],
   limit?: number,
@@ -3150,13 +3096,31 @@ async function summarizeVisiblePublisherAbuseReviewNominations(
 ) {
   const items = [];
   for (const nomination of nominations) {
-    const item = await summarizePublisherAbuseReviewNomination(ctx, nomination, visibilityOptions);
+    const item = await summarizePublisherAbuseReviewNominationListItem(ctx, nomination);
     if (await isVisiblePublisherAbuseReviewItem(ctx, item, visibilityOptions)) {
       items.push(item);
     }
     if (limit && items.length >= limit) break;
   }
   return items;
+}
+
+async function summarizePublisherAbuseReviewNominationListItem(
+  ctx: QueryCtx,
+  nomination: Doc<"publisherAbuseReviewNominations">,
+) {
+  const publisher = nomination.ownerPublisherId
+    ? await ctx.db.get(nomination.ownerPublisherId)
+    : null;
+  const ownerUser = nomination.ownerUserId ? await ctx.db.get(nomination.ownerUserId) : null;
+
+  return {
+    nomination,
+    latestScore: null,
+    publisher: publisher ? summarizePublisherForAbuseReview(publisher) : null,
+    ownerUser: ownerUser ? summarizeUserForAbuseReview(ownerUser) : null,
+    openedByRun: null,
+  };
 }
 
 async function summarizePublisherAbuseReviewNomination(

--- a/src/routes/-management/managementShared.ts
+++ b/src/routes/-management/managementShared.ts
@@ -22,9 +22,7 @@ export type PublisherAbuseReviewDashboard = FunctionReturnType<
 export type PublisherAbuseReviewDetail = FunctionReturnType<
   typeof api.publisherAbuse.getReviewNominationDetail
 >;
-export type PublisherAbuseReviewItem = FunctionReturnType<
-  typeof api.publisherAbuse.listReviewItemsPage
->["page"][number];
+export type PublisherAbuseReviewItem = NonNullable<PublisherAbuseReviewDetail>["item"];
 export type PublisherAbuseReviewScore = NonNullable<PublisherAbuseReviewItem["latestScore"]>;
 export type PublisherAbuseTab = "potential_ban_candidate" | "review" | "all_pending" | "resolved";
 


### PR DESCRIPTION
## Summary
- make `publisherAbuse:listReviewItemsPage` page nomination rows directly
- avoid reading `publisherAbuseScores` in dashboard list rows; detail still loads full score evidence when a row is selected
- update regression coverage so list pages fail if they touch score documents

## Verification
- `bunx convex codegen`
- `bunx vitest run convex/publisherAbuse.test.ts src/routes/-management.test.tsx --testNamePattern "publisher abuse|dashboard|listReviewItemsPage|nomination rows|recent resolved|autoban"`
- `bunx tsc --noEmit --pretty false`
- `git diff --check`
