### PR TITLE
Fix abuse review row serialization

### DIFF
--- a/convex/publisherAbuse.test.ts
+++ b/convex/publisherAbuse.test.ts
@@ -468,6 +468,13 @@ function makeEmptyPublisherMembersQuery() {
   };
 }
 
+function hasNoUndefinedValues(value: unknown): boolean {
+  if (value === undefined) return false;
+  if (value === null || typeof value !== "object") return true;
+  if (Array.isArray(value)) return value.every(hasNoUndefinedValues);
+  return Object.values(value).every(hasNoUndefinedValues);
+}
+
 function makeAutoBanNominationQuery(
   nominations: unknown[],
   options: { isDone?: boolean; continueCursor?: string; expectedCursor?: string | null } = {},
@@ -2888,6 +2895,98 @@ describe("publisher abuse dry-run persistence", () => {
       }),
     );
     expect(nominationsPaginate).toHaveBeenCalledWith({ numItems: 2, cursor: null });
+  });
+
+  it("normalizes absent optional publisher and user fields in nomination rows", async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:moderator",
+      user: { _id: "users:moderator", role: "moderator" },
+    } as never);
+    const nomination = makeNomination({
+      _id: "publisherAbuseReviewNominations:legacy",
+      ownerKey: "publisher:publishers:legacy",
+      ownerPublisherId: "publishers:legacy",
+      ownerUserId: "users:legacy",
+      latestScoreId: "publisherAbuseScores:legacy",
+      label: "potential_ban_candidate",
+      status: "pending",
+    });
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "publishers:legacy") {
+            return {
+              _id: "publishers:legacy",
+              kind: "user",
+              handle: "legacy",
+              displayName: "Legacy Publisher",
+              createdAt: 1,
+              updatedAt: 1,
+            };
+          }
+          if (id === "users:legacy") {
+            return { _id: "users:legacy" };
+          }
+          return null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table === "publisherAbuseReviewNominations") {
+            return {
+              withIndex: () => ({
+                order: () => ({
+                  paginate: async () => ({
+                    page: [nomination],
+                    isDone: true,
+                    continueCursor: "",
+                  }),
+                }),
+              }),
+            };
+          }
+          if (table === "officialPublishers") return makeEmptyOfficialPublishersQuery();
+          throw new Error(`unexpected table ${table}`);
+        }),
+      },
+    };
+
+    const result = await listReviewItemsPageHandler(ctx, {
+      tab: "potential_ban_candidate",
+      paginationOpts: { numItems: 1, cursor: null },
+    });
+
+    const [item] = result.page as Array<{
+      publisher: unknown;
+      ownerUser: unknown;
+    }>;
+    expect(result.page).toEqual([
+      expect.objectContaining({
+        publisher: expect.objectContaining({
+          linkedUserId: null,
+          publishedSkills: 0,
+          publishedPackages: 0,
+          totalInstalls: 0,
+          totalStars: 0,
+          totalDownloads: 0,
+          skillTotalInstalls: 0,
+          skillTotalStars: 0,
+          skillTotalDownloads: 0,
+          deletedAt: null,
+          deactivatedAt: null,
+        }),
+        ownerUser: expect.objectContaining({
+          handle: null,
+          name: null,
+          displayName: null,
+          role: "user",
+          image: null,
+          deletedAt: null,
+          deactivatedAt: null,
+          banReason: null,
+        }),
+      }),
+    ]);
+    expect(hasNoUndefinedValues(item.publisher)).toBe(true);
+    expect(hasNoUndefinedValues(item.ownerUser)).toBe(true);
   });
 
   it("queries recent resolved nominations by review time", async () => {

--- a/convex/publisherAbuse.ts
+++ b/convex/publisherAbuse.ts
@@ -137,10 +137,11 @@ type PublisherMetricsDoc = Pick<
   | "skillTotalDownloads"
 >;
 
-type PublisherAbuseExclusionPublisher = Pick<
-  Doc<"publishers">,
-  "_id" | "kind" | "linkedUserId" | "deletedAt" | "deactivatedAt"
->;
+type PublisherAbuseExclusionPublisher = Pick<Doc<"publishers">, "_id" | "kind"> & {
+  linkedUserId?: Id<"users"> | null;
+  deletedAt?: number | null;
+  deactivatedAt?: number | null;
+};
 
 type TemporalSkillCandidate = {
   ownerKey: string;
@@ -3224,31 +3225,31 @@ function summarizePublisherForAbuseReview(publisher: Doc<"publishers">) {
     handle: publisher.handle,
     displayName: publisher.displayName,
     kind: publisher.kind,
-    linkedUserId: publisher.linkedUserId,
-    publishedSkills: publisher.publishedSkills,
-    publishedPackages: publisher.publishedPackages,
-    totalInstalls: publisher.totalInstalls,
-    totalStars: publisher.totalStars,
-    totalDownloads: publisher.totalDownloads,
-    skillTotalInstalls: publisher.skillTotalInstalls,
-    skillTotalStars: publisher.skillTotalStars,
-    skillTotalDownloads: publisher.skillTotalDownloads,
-    deletedAt: publisher.deletedAt,
-    deactivatedAt: publisher.deactivatedAt,
+    linkedUserId: publisher.linkedUserId ?? null,
+    publishedSkills: publisher.publishedSkills ?? 0,
+    publishedPackages: publisher.publishedPackages ?? 0,
+    totalInstalls: publisher.totalInstalls ?? 0,
+    totalStars: publisher.totalStars ?? 0,
+    totalDownloads: publisher.totalDownloads ?? 0,
+    skillTotalInstalls: publisher.skillTotalInstalls ?? 0,
+    skillTotalStars: publisher.skillTotalStars ?? 0,
+    skillTotalDownloads: publisher.skillTotalDownloads ?? 0,
+    deletedAt: publisher.deletedAt ?? null,
+    deactivatedAt: publisher.deactivatedAt ?? null,
   };
 }
 
 function summarizeUserForAbuseReview(user: Doc<"users">) {
   return {
     _id: user._id,
-    handle: user.handle,
-    name: user.name,
-    displayName: user.displayName,
-    role: user.role,
-    image: user.image,
-    deletedAt: user.deletedAt,
-    deactivatedAt: user.deactivatedAt,
-    banReason: user.banReason,
+    handle: user.handle ?? null,
+    name: user.name ?? null,
+    displayName: user.displayName ?? null,
+    role: user.role ?? "user",
+    image: user.image ?? null,
+    deletedAt: user.deletedAt ?? null,
+    deactivatedAt: user.deactivatedAt ?? null,
+    banReason: user.banReason ?? null,
   };
 }
 


### PR DESCRIPTION
## Summary
- Normalize optional publisher/user fields in publisher-abuse review row summaries so Convex never serializes `undefined` to the client.
- Keep exclusion checks compatible with the normalized `null` values.
- Add a regression test for legacy-shaped publisher/user docs with absent optional fields.

## Local proof
- Local ClawHub: `http://127.0.0.1:3031/management?view=abuse`
- Dev Convex target: `admired-dodo-615`
- Signed in as `@local-admin`, loaded seeded abuse review rows, clicked a row to load details.
- Dev Convex logs showed successful `publisherAbuse:listReviewItemsPage` and `publisherAbuse:getReviewNominationDetail` calls with `error: null`.

## Verification
- `bunx vitest run convex/publisherAbuse.test.ts --testNamePattern "normalizes absent optional publisher and user fields|pages nomination rows"`
- `bunx vitest run convex/publisherAbuse.test.ts`
- `bunx tsc --noEmit --pretty false`
- `git diff --check`
