### PR TITLE
fix: resanitize security dataset splits before publish

### DIFF
--- a/scripts/security-dataset/merge-snapshots.ts
+++ b/scripts/security-dataset/merge-snapshots.ts
@@ -4,6 +4,7 @@ import { createReadStream, createWriteStream, type WriteStream } from "node:fs";
 import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { buildSecurityDatasetManifest } from "./manifest";
+import { redactBundleContent, redactSkillContent, redactText } from "./normalize";
 
 type DatasetSplit = "train" | "validation" | "test" | "eval_holdout";
 
@@ -102,7 +103,7 @@ async function concatenateSnapshotFiles(
     const writer = createWriteStream(join(snapshotDir, "hf-dataset", "data", `${split}.jsonl`), {
       encoding: "utf8",
     });
-    await concatenateFiles(
+    await concatenateRedactedHuggingFaceRows(
       writer,
       manifests.map(({ dir }) => join(dir, "hf-dataset", "data", `${split}.jsonl`)),
     );
@@ -122,6 +123,59 @@ async function concatenateFiles(writer: WriteStream, paths: string[]) {
     writer.end();
     await once(writer, "finish");
   }
+}
+
+async function concatenateRedactedHuggingFaceRows(writer: WriteStream, paths: string[]) {
+  try {
+    for (const path of paths) {
+      if (!(await isFile(path))) continue;
+      const reader = createReadStream(path, { encoding: "utf8" });
+      let carry = "";
+      for await (const chunk of reader) {
+        carry += chunk;
+        const lines = carry.split("\n");
+        carry = lines.pop() ?? "";
+        for (const line of lines) {
+          await writeRedactedHuggingFaceRow(writer, line);
+        }
+      }
+      if (carry.length > 0) await writeRedactedHuggingFaceRow(writer, carry);
+    }
+  } finally {
+    writer.end();
+    await once(writer, "finish");
+  }
+}
+
+async function writeRedactedHuggingFaceRow(writer: WriteStream, line: string) {
+  if (line.trim() === "") return;
+  const row = redactHuggingFaceRow(JSON.parse(line) as Record<string, unknown>);
+  if (!writer.write(`${JSON.stringify(row)}\n`)) await once(writer, "drain");
+}
+
+function redactHuggingFaceRow(row: Record<string, unknown>) {
+  return {
+    ...row,
+    skill_slug:
+      typeof row.skill_slug === "string" ? redactText(row.skill_slug, 2048) : row.skill_slug,
+    skill_md_content:
+      typeof row.skill_md_content === "string"
+        ? redactSkillContent(row.skill_md_content)
+        : row.skill_md_content,
+    skill_bundle_content: Array.isArray(row.skill_bundle_content)
+      ? row.skill_bundle_content.map(redactHuggingFaceBundleFile)
+      : row.skill_bundle_content,
+  };
+}
+
+function redactHuggingFaceBundleFile(file: unknown) {
+  if (!file || typeof file !== "object" || Array.isArray(file)) return file;
+  const row = file as Record<string, unknown>;
+  return {
+    ...row,
+    path: typeof row.path === "string" ? redactText(row.path, 2048) : row.path,
+    content: typeof row.content === "string" ? redactBundleContent(row.content) : row.content,
+  };
 }
 
 function buildMergedManifest(input: {

--- a/scripts/security-dataset/mergeSnapshots.test.ts
+++ b/scripts/security-dataset/mergeSnapshots.test.ts
@@ -78,6 +78,12 @@ describe("security dataset snapshot merge CLI", () => {
         readFile(join(summary.snapshotDir, "hf-dataset", "data", "train.jsonl"), "utf8"),
       ).resolves.toContain('"id":"row-a"');
       await expect(
+        readFile(join(summary.snapshotDir, "hf-dataset", "data", "train.jsonl"), "utf8"),
+      ).resolves.toContain("[REDACTED_SECRET]");
+      await expect(
+        readFile(join(summary.snapshotDir, "hf-dataset", "data", "train.jsonl"), "utf8"),
+      ).resolves.not.toContain("supersecretvalue123");
+      await expect(
         readFile(join(summary.snapshotDir, "hf-dataset", "data", "test.jsonl"), "utf8"),
       ).resolves.toContain('"id":"row-b"');
     } finally {
@@ -112,7 +118,17 @@ async function writeShardSnapshot(
   for (const split of ["train", "validation", "test", "eval_holdout"]) {
     const rowCount = split === input.split ? input.sourceArtifacts : 0;
     const rows = Array.from({ length: rowCount }, (_, index) =>
-      JSON.stringify({ id: index === 0 ? input.rowId : `${input.rowId}-${index}` }),
+      JSON.stringify({
+        id: index === 0 ? input.rowId : `${input.rowId}-${index}`,
+        skill_slug: "owner/sk-abcdefghijklmnopqrstuvwxyz",
+        skill_md_content: "Use this skill. skill secret: supersecretvalue123",
+        skill_bundle_content: [
+          {
+            path: "config/sk-abcdefghijklmnopqrstuvwxyz/settings.json",
+            content: "password=supersecretvalue123\n",
+          },
+        ],
+      }),
     );
     await writeFile(join(dir, "hf-dataset", "data", `${split}.jsonl`), rows.join("\n"));
   }


### PR DESCRIPTION
## Summary
- re-run the sanitizer over Hugging Face split rows at the merge/publish boundary
- cover skill content, bundle paths/content, and public skill slugs before guardrails/upload
- add a regression test that proves merge redacts secret-like shard rows instead of passing them through

## Tests
- `bun run format:check -- scripts/security-dataset/merge-snapshots.ts scripts/security-dataset/mergeSnapshots.test.ts`
- `bun test scripts/security-dataset/mergeSnapshots.test.ts scripts/security-dataset/validateGuardrails.test.ts scripts/security-dataset/normalize.test.ts`
