### PR TITLE
fix: render static audit findings

### DIFF
--- a/src/components/SecurityAuditPage.tsx
+++ b/src/components/SecurityAuditPage.tsx
@@ -27,10 +27,8 @@ import {
 } from "./securityAuditModel";
 import { SidebarMetadata } from "./SidebarMetadata";
 import {
-  ClawScanRiskReview,
   getSkillSpectorOverviewCopy,
   getSkillSpectorIssueCount,
-  hasClawScanRiskReview,
   hasSkillSpectorFindings,
   ScanResultBadge,
   SkillSpectorFindings,
@@ -41,7 +39,6 @@ import {
 } from "./SkillSecurityScanResults";
 import { Button } from "./ui/button";
 import { Skeleton } from "./ui/skeleton";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
 
 type OwnerRef = {
   _id?: string;
@@ -74,8 +71,6 @@ type SecurityAuditPageProps = {
 
 const EMPTY_SKILLSPECTOR_ISSUES: SkillSpectorIssue[] = [];
 const SKILLSPECTOR_VISIBLE_CHECK_LIMIT = 5;
-const RISK_ANALYSIS_SCOPE_COPY =
-  "ClawHub reviews SkillSpector, VirusTotal, and artifact evidence before producing the final verdict.";
 const SKILLSPECTOR_CLEAN_CHECKS = [
   {
     category: "Prompt Injection",
@@ -500,18 +495,76 @@ function SecurityAuditOverview(props: SecurityAuditPageProps) {
   );
 }
 
-function ClawScanSection(props: SecurityAuditPageProps) {
-  const riskAnalysis =
-    props.llmAnalysis && !props.skillSpectorAnalysis && hasClawScanRiskReview(props.llmAnalysis)
-      ? props.llmAnalysis
-      : null;
-  if (!riskAnalysis) return null;
+function hasStaticScanDetails(staticScan?: StaticScan | null): staticScan is StaticScan {
+  return Boolean(staticScan?.summary?.trim() || staticScan?.findings?.length);
+}
 
+function formatStaticScanSeverity(value: string) {
+  return value
+    .trim()
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join(" ");
+}
+
+function StaticScanDetails({ staticScan }: { staticScan: StaticScan }) {
+  const findings = staticScan.findings ?? [];
   return (
     <div className="security-report-panel-body security-report-panel-body-findings">
-      <ClawScanRiskReview analysis={riskAnalysis} showTitle={false} />
+      {staticScan.summary?.trim() ? (
+        <div className="security-report-overview-body">
+          <p>{staticScan.summary}</p>
+        </div>
+      ) : null}
+      {findings.length ? (
+        <div className="static-analysis-findings">
+          {findings.map((finding, index) => (
+            <article
+              key={`${finding.code}-${finding.file}-${finding.line}-${index}`}
+              className="static-analysis-finding"
+            >
+              <div className="static-analysis-finding-header">
+                <h3 className="agentic-risk-finding-title">{finding.message}</h3>
+                <div className="agentic-risk-finding-badges">
+                  <ScanResultBadge
+                    status={finding.severity}
+                    label={formatStaticScanSeverity(finding.severity)}
+                  />
+                </div>
+              </div>
+              <dl className="static-analysis-finding-details">
+                <div>
+                  <dt>Code</dt>
+                  <dd>{finding.code}</dd>
+                </div>
+                <div>
+                  <dt>Location</dt>
+                  <dd>
+                    {finding.file}:{finding.line}
+                  </dd>
+                </div>
+                {finding.evidence?.trim() ? (
+                  <div>
+                    <dt>Evidence</dt>
+                    <dd>
+                      <pre className="agentic-risk-evidence-snippet">{finding.evidence}</pre>
+                    </dd>
+                  </div>
+                ) : null}
+              </dl>
+            </article>
+          ))}
+        </div>
+      ) : null}
     </div>
   );
+}
+
+function StaticScanSection(props: SecurityAuditPageProps) {
+  const staticScan = hasStaticScanDetails(props.staticScan) ? props.staticScan : null;
+  if (!staticScan) return null;
+  return <StaticScanDetails staticScan={staticScan} />;
 }
 
 function VirusTotalSection(props: SecurityAuditPageProps) {
@@ -769,27 +822,6 @@ function useSkillSpectorContentSnippets(entity: EntityRef, issues: SkillSpectorI
   return snippets;
 }
 
-function RiskAnalysisInfoLink() {
-  return (
-    <TooltipProvider delayDuration={400}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            className="security-report-title-info-link"
-            aria-label={RISK_ANALYSIS_SCOPE_COPY}
-          >
-            <Info size={15} aria-hidden="true" />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent side="top" align="start" className="security-report-title-tooltip">
-          {RISK_ANALYSIS_SCOPE_COPY}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-}
-
 function SecurityAuditScannerSection({
   kind,
   props,
@@ -808,11 +840,10 @@ function SecurityAuditScannerSection({
           <h2 id={`${kind}-heading`} className="skill-install-panel-title">
             {label}
           </h2>
-          {kind === "clawscan" ? <RiskAnalysisInfoLink /> : null}
           {kind === "skillspector" ? <SkillSpectorAttribution /> : null}
         </div>
       </div>
-      {kind === "clawscan" ? <ClawScanSection {...props} /> : null}
+      {kind === "static" ? <StaticScanSection {...props} /> : null}
       {kind === "virustotal" ? <VirusTotalSection {...props} /> : null}
       {kind === "skillspector" ? <SkillSpectorSection {...props} /> : null}
     </section>

--- a/src/components/SkillSecurityScanResults.test.tsx
+++ b/src/components/SkillSecurityScanResults.test.tsx
@@ -411,7 +411,7 @@ describe("SecurityScanResults static guidance", () => {
     expect(screen.queryByText("Findings")).toBeNull();
   });
 
-  it("shows ClawScan buckets on the dedicated security audit page", () => {
+  it("uses ClawScan for audit overview without rendering a Risk analysis section", () => {
     const { container } = render(
       <SecurityAuditPage
         entity={{
@@ -437,7 +437,7 @@ describe("SecurityScanResults static guidance", () => {
     );
     expect(screen.queryByText(/Current verdict/i)).toBeNull();
     expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Risk analysis" })).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Risk analysis" })).toBeNull();
     expect(screen.queryByRole("heading", { name: "ClawScan" })).toBeNull();
     expect(screen.getByText(/Collects workspace secrets/i)).toBeTruthy();
     expect(screen.queryByRole("heading", { name: "Findings (2)" })).toBeNull();
@@ -446,20 +446,10 @@ describe("SecurityScanResults static guidance", () => {
     expect(screen.queryByText("Scanner")).toBeNull();
     expect(screen.queryByText("Review scope")).toBeNull();
     expect(screen.queryByText("Permission boundary")).toBeNull();
-    expect(
-      screen.getByText("ASI03: Identity and Privilege Abuse").closest("a")?.getAttribute("href"),
-    ).toBeUndefined();
-    expect(
-      screen
-        .getByRole("button", {
-          name: "ClawHub reviews SkillSpector, VirusTotal, and artifact evidence before producing the final verdict.",
-        })
-        .tagName.toLowerCase(),
-    ).toBe("button");
-    expect(screen.getByText("ASI03: Identity and Privilege Abuse")).toBeTruthy();
+    expect(screen.queryByText("ASI03: Identity and Privilege Abuse")).toBeNull();
     expect(screen.queryByText("metadata")).toBeNull();
-    expect(screen.getAllByText("Skill content").length).toBeGreaterThan(0);
-    expect(screen.getByText("requires.env: TODOIST_API_TOKEN")).toBeTruthy();
+    expect(screen.queryByText("Skill content")).toBeNull();
+    expect(screen.queryByText("requires.env: TODOIST_API_TOKEN")).toBeNull();
     expect(screen.queryByText("Confidence")).toBeNull();
     expect(screen.getByRole("link", { name: "Back to skill" }).getAttribute("href")).toBe(
       "/local/todo-guard",
@@ -474,7 +464,7 @@ describe("SecurityScanResults static guidance", () => {
       Array.from(container.querySelectorAll(".security-report-main > section h2")).map((node) =>
         node.textContent?.trim(),
       ),
-    ).toEqual(["Overview", "VirusTotal", "Risk analysis"]);
+    ).toEqual(["Overview", "SkillSpector", "VirusTotal"]);
   });
 
   it("renders SkillSpector findings as the agentic-risk finding source", () => {
@@ -707,7 +697,7 @@ describe("SecurityScanResults static guidance", () => {
     ).toBeNull();
   });
 
-  it("adds in-page permalinks to dedicated ClawScan findings", () => {
+  it("does not render legacy ClawScan finding permalinks on audit pages", () => {
     render(
       <SecurityAuditPage
         entity={{
@@ -721,16 +711,13 @@ describe("SecurityScanResults static guidance", () => {
       />,
     );
 
-    const permalink = screen.getByRole("link", {
+    const permalink = screen.queryByRole("link", {
       name: "Link to ASI03: Identity and Privilege Abuse",
     });
-    expect(permalink.textContent).toBe("#");
-    expect(permalink.getAttribute("href")).toBe(
-      "#clawscan-finding-asi03-identity-and-privilege-abuse-1",
-    );
+    expect(permalink).toBeNull();
     expect(
       document.getElementById("clawscan-finding-asi03-identity-and-privilege-abuse-1"),
-    ).toBeTruthy();
+    ).toBeNull();
   });
 
   it("does not prompt publishers to add notes on review ClawScan reports", () => {
@@ -1117,8 +1104,8 @@ describe("SecurityScanResults static guidance", () => {
     expect(JSON.parse(decode("virustotal.json")).engineStats.malicious).toBe(1);
   });
 
-  it("shows plugins with legacy ClawScan analysis in the new ClawScan report shell", () => {
-    render(
+  it("shows plugin static findings as their own security audit section", () => {
+    const { container } = render(
       <SecurityAuditPage
         entity={{
           kind: "plugin",
@@ -1128,6 +1115,7 @@ describe("SecurityScanResults static guidance", () => {
           detailPath: "/plugins/plugin-guard",
         }}
         llmAnalysis={legacyClawScanAnalysis}
+        staticScan={staticScan}
       />,
     );
 
@@ -1138,14 +1126,73 @@ describe("SecurityScanResults static guidance", () => {
     expect(screen.getByText("Legacy plugin analysis summary.")).toBeTruthy();
     expect(screen.getByText("Legacy plugin guidance.")).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Risk analysis" })).toBeNull();
+    expect(screen.getByRole("heading", { name: "Static analysis" })).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Security Audit Metadata" })).toBeTruthy();
     expect(screen.queryByText("[legacy.rule] expected: Legacy finding text.")).toBeNull();
     expect(screen.queryByText("Review Dimensions")).toBeNull();
     expect(screen.queryByText("Purpose & Capability")).toBeNull();
+    expect(screen.queryByText("Legacy dimension detail.")).toBeNull();
+    expect(screen.getByText("Static analysis found an external network request.")).toBeTruthy();
+    expect(screen.getByText("static.network_request")).toBeTruthy();
+    expect(screen.getByText("Network request found in skill instructions.")).toBeTruthy();
+    expect(
+      Array.from(container.querySelectorAll(".security-report-main > section h2")).map((node) =>
+        node.textContent?.trim(),
+      ),
+    ).toEqual(["Overview", "VirusTotal", "Static analysis"]);
   });
 
-  it("shows skills with legacy-only ClawScan analysis in the new ClawScan report shell", () => {
+  it("lets static scan risk override a clean legacy ClawScan outcome", () => {
     render(
+      <SecurityAuditPage
+        entity={{
+          kind: "plugin",
+          title: "Static Risk Plugin",
+          name: "static-risk-plugin",
+          version: "2.0.0",
+          detailPath: "/plugins/static-risk-plugin",
+        }}
+        llmAnalysis={{
+          ...legacyClawScanAnalysis,
+          status: "clean",
+          verdict: "benign",
+          summary: "Legacy scan was clean.",
+        }}
+        staticScan={{
+          ...staticScan,
+          status: "malicious",
+          findings: [{ ...staticScan.findings[0], severity: "critical" }],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Malicious")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Static analysis" })).toBeTruthy();
+    expect(screen.getByText("Critical")).toBeTruthy();
+  });
+
+  it("does not let static scan review status downgrade a malicious ClawScan outcome", () => {
+    render(
+      <SecurityAuditPage
+        entity={{
+          kind: "plugin",
+          title: "Mixed Risk Plugin",
+          name: "mixed-risk-plugin",
+          version: "2.0.0",
+          detailPath: "/plugins/mixed-risk-plugin",
+        }}
+        llmAnalysis={{ ...legacyClawScanAnalysis, status: "malicious", verdict: "malicious" }}
+        staticScan={staticScan}
+      />,
+    );
+
+    expect(screen.getByText("Malicious")).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Static analysis" })).toBeTruthy();
+  });
+
+  it("does not render a scanner section for legacy-only ClawScan analysis", () => {
+    const { container } = render(
       <SecurityAuditPage
         entity={{
           kind: "skill",
@@ -1164,9 +1211,17 @@ describe("SecurityScanResults static guidance", () => {
     ).toBeTruthy();
     expect(screen.getByText("Legacy plugin analysis summary.")).toBeTruthy();
     expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Risk analysis" })).toBeNull();
+    expect(screen.queryByRole("heading", { name: "Static analysis" })).toBeNull();
     expect(screen.getByRole("heading", { name: "Security Audit Metadata" })).toBeTruthy();
     expect(screen.queryByText("Review Dimensions")).toBeNull();
     expect(screen.queryByText("Purpose & Capability")).toBeNull();
+    expect(screen.queryByText("[legacy.rule] expected: Legacy finding text.")).toBeNull();
+    expect(
+      Array.from(container.querySelectorAll(".security-report-main > section h2")).map((node) =>
+        node.textContent?.trim(),
+      ),
+    ).toEqual(["Overview", "SkillSpector", "VirusTotal"]);
     expect(screen.getByRole("link", { name: "Back to skill" }).getAttribute("href")).toBe(
       "/local/legacy-skill",
     );
@@ -1191,7 +1246,7 @@ describe("SecurityScanResults static guidance", () => {
       screen.getByText("Security checks across malware telemetry and agentic risk"),
     ).toBeTruthy();
     expect(screen.getAllByText("Pending").length).toBeGreaterThan(0);
-    expect(screen.getByText("No risk analysis has been recorded yet.")).toBeTruthy();
+    expect(screen.getByText("No security analysis has been recorded yet.")).toBeTruthy();
     expect(
       screen.getByText("VirusTotal findings are pending for this skill version."),
     ).toBeTruthy();
@@ -1213,7 +1268,7 @@ describe("SecurityScanResults static guidance", () => {
     expect(screen.getByRole("heading", { name: "Security Audit Metadata" })).toBeTruthy();
   });
 
-  it("shows only legacy Risk analysis when legacy agentic-risk findings exist without SkillSpector", () => {
+  it("does not add a Risk analysis section for legacy agentic-risk findings", () => {
     const { container } = render(
       <SecurityAuditPage
         entity={{
@@ -1227,8 +1282,8 @@ describe("SecurityScanResults static guidance", () => {
       />,
     );
 
-    expect(screen.getByRole("heading", { name: "Risk analysis" })).toBeTruthy();
-    expect(screen.queryByRole("heading", { name: "SkillSpector" })).toBeNull();
+    expect(screen.queryByRole("heading", { name: "Risk analysis" })).toBeNull();
+    expect(screen.getByRole("heading", { name: "SkillSpector" })).toBeTruthy();
     expect(
       screen.queryByText(/Legacy ClawScan findings remain available under Risk analysis/i),
     ).toBeNull();
@@ -1236,7 +1291,7 @@ describe("SecurityScanResults static guidance", () => {
       Array.from(container.querySelectorAll(".security-report-main > section h2")).map((node) =>
         node.textContent?.trim(),
       ),
-    ).toEqual(["Overview", "VirusTotal", "Risk analysis"]);
+    ).toEqual(["Overview", "SkillSpector", "VirusTotal"]);
   });
 
   it("lets skill managers enqueue a security rescan from the audit sidebar", async () => {

--- a/src/components/SkillSecurityScanResults.tsx
+++ b/src/components/SkillSecurityScanResults.tsx
@@ -161,12 +161,28 @@ export function getScanStatusInfo(status: string) {
         className: "scan-status-malicious",
         badgeVariant: "destructive",
       };
+    case "critical":
+    case "high":
+      return {
+        label: status.toLowerCase() === "critical" ? "Critical" : "High",
+        className: "scan-status-malicious",
+        badgeVariant: "destructive",
+      };
     case "review":
     case "suspicious":
       return { label: "Review", className: "scan-status-warn", badgeVariant: "warning" };
+    case "medium":
     case "warn":
     case "warning":
-      return { label: "Warn", className: "scan-status-warn", badgeVariant: "warning" };
+      return {
+        label: status.toLowerCase() === "medium" ? "Medium" : "Warn",
+        className: "scan-status-warn",
+        badgeVariant: "warning",
+      };
+    case "low":
+      return { label: "Low", className: "scan-status-unknown", badgeVariant: "review" };
+    case "info":
+      return { label: "Info", className: "scan-status-unknown", badgeVariant: "compact" };
     case "advisory":
       return { label: "Advisory", className: "scan-status-unknown", badgeVariant: "compact" };
     case "loading":
@@ -295,15 +311,6 @@ function getDimensionIcon(rating: string) {
 
 function getVisibleAgenticRiskFindings(analysis?: LlmAnalysis | null) {
   return (analysis?.agenticRiskFindings ?? []).filter(isVisibleAgenticRiskFinding);
-}
-
-function getVisibleClawScanFindingCount(analysis?: LlmAnalysis | null) {
-  return getVisibleAgenticRiskFindings(analysis).length;
-}
-
-export function hasClawScanRiskReview(analysis?: LlmAnalysis | null) {
-  if (!analysis) return false;
-  return getVisibleClawScanFindingCount(analysis) > 0;
 }
 
 function getFindingSeverityBadgeMeta(severity: string): {
@@ -547,7 +554,7 @@ function AgenticRiskFindingCard({
   );
 }
 
-export function ClawScanRiskReview({
+function ClawScanRiskReview({
   analysis,
   showTitle = true,
   findingsTitle = "Findings",

--- a/src/components/securityAuditModel.ts
+++ b/src/components/securityAuditModel.ts
@@ -1,12 +1,11 @@
 import {
   getClawScanDisplayStatus,
-  hasClawScanRiskReview,
   type LlmAnalysis,
   type SkillSpectorAnalysis,
   type VtAnalysis,
 } from "./SkillSecurityScanResults";
 
-export type AuditScannerKind = "clawscan" | "virustotal" | "skillspector";
+export type AuditScannerKind = "static" | "virustotal" | "skillspector";
 
 export const SECURITY_AUDIT_SUBTEXT = "Security checks across malware telemetry and agentic risk";
 
@@ -14,24 +13,46 @@ type SecurityAuditSignals = {
   vtAnalysis?: VtAnalysis | null;
   llmAnalysis?: LlmAnalysis | null;
   skillSpectorAnalysis?: SkillSpectorAnalysis | null;
+  staticScan?: {
+    status?: string | null;
+    summary?: string | null;
+    findings?: unknown[] | null;
+    checkedAt?: number | null;
+  } | null;
   suppressScanResults?: boolean;
 };
 
 export const AUDIT_SCANNER_LABELS: Record<AuditScannerKind, string> = {
-  clawscan: "Risk analysis",
   skillspector: "SkillSpector",
+  static: "Static analysis",
   virustotal: "VirusTotal",
 };
 
-const DEFAULT_AUDIT_SCANNER_ORDER: AuditScannerKind[] = ["skillspector", "virustotal", "clawscan"];
+const DEFAULT_AUDIT_SCANNER_ORDER: AuditScannerKind[] = ["skillspector", "virustotal", "static"];
 
 const SUPPORTING_AUDIT_SCANNER_ORDER: AuditScannerKind[] = DEFAULT_AUDIT_SCANNER_ORDER.filter(
-  (kind) => kind !== "skillspector" && kind !== "clawscan",
+  (kind) => kind !== "skillspector",
 );
 
 export function aggregateAuditVerdict(signals: SecurityAuditSignals) {
   if (signals.suppressScanResults) return "cleared";
-  return getClawScanDisplayStatus(signals.llmAnalysis);
+  const clawScanStatus = getClawScanDisplayStatus(signals.llmAnalysis);
+  const staticStatus = signals.staticScan?.status?.trim().toLowerCase();
+  if (clawScanStatus === "malicious" || staticStatus === "malicious") return "malicious";
+  if (
+    clawScanStatus === "review" ||
+    clawScanStatus === "suspicious" ||
+    clawScanStatus === "warn" ||
+    clawScanStatus === "warning" ||
+    staticStatus === "suspicious" ||
+    staticStatus === "review" ||
+    staticStatus === "warn" ||
+    staticStatus === "warning"
+  ) {
+    return "review";
+  }
+  if (clawScanStatus !== "pending") return clawScanStatus;
+  return staticStatus || clawScanStatus;
 }
 
 export function getSecurityAuditOverviewCopy({
@@ -45,19 +66,22 @@ export function getSecurityAuditOverviewCopy({
 }) {
   if (suppressScanResults && suppressedMessage?.trim()) return [suppressedMessage.trim()];
   return [
-    llmAnalysis?.summary?.trim() || "No risk analysis has been recorded yet.",
+    llmAnalysis?.summary?.trim() || "No security analysis has been recorded yet.",
     llmAnalysis?.guidance?.trim() || null,
   ].filter((copy): copy is string => Boolean(copy));
 }
 
 export function getAuditScannerOrder(signals?: SecurityAuditSignals): AuditScannerKind[] {
+  const hasStaticScanReview = Boolean(
+    signals?.staticScan?.summary?.trim() || signals?.staticScan?.findings?.length,
+  );
   if (signals?.skillSpectorAnalysis) {
-    return ["skillspector", ...SUPPORTING_AUDIT_SCANNER_ORDER];
+    return hasStaticScanReview
+      ? ["skillspector", ...SUPPORTING_AUDIT_SCANNER_ORDER]
+      : ["skillspector", "virustotal"];
   }
-  if (hasClawScanRiskReview(signals?.llmAnalysis)) {
-    return [...SUPPORTING_AUDIT_SCANNER_ORDER, "clawscan"];
-  }
-  return ["skillspector", ...SUPPORTING_AUDIT_SCANNER_ORDER];
+  if (hasStaticScanReview) return ["virustotal", "static"];
+  return ["skillspector", "virustotal"];
 }
 
 export function getLatestAuditCheckedAt(signals: SecurityAuditSignals) {
@@ -65,6 +89,7 @@ export function getLatestAuditCheckedAt(signals: SecurityAuditSignals) {
     signals.llmAnalysis?.checkedAt,
     signals.skillSpectorAnalysis?.checkedAt,
     signals.vtAnalysis?.checkedAt,
+    signals.staticScan?.checkedAt,
   ].filter((value): value is number => typeof value === "number" && Number.isFinite(value));
   return values.length ? Math.max(...values) : null;
 }


### PR DESCRIPTION
## Summary
- render stored static scan findings as their own `Static analysis` section on security audit pages
- remove the legacy `Risk analysis` audit-page section from scanner ordering
- include static scan timestamps/status in audit metadata, with worse static/ClawScan verdicts winning the sidebar outcome

## Local proof
- URL: `http://127.0.0.1:3011/openclaw/plugins/matrix/security-audit`
- Browser headings: `Overview`, `VirusTotal`, `Static analysis`
- Confirmed no `Risk analysis` text on the page
- Confirmed `suspicious.dangerous_exec` and 18 static finding cards render
- Screenshot: `/tmp/clawhub-matrix-static-analysis-no-risk-section.png`

## Validation
- `bunx vitest run src/components/SkillSecurityScanResults.test.tsx`
- `bun run format:check -- src/components/SecurityAuditPage.tsx src/components/SkillSecurityScanResults.tsx src/components/securityAuditModel.ts src/components/SkillSecurityScanResults.test.tsx`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
