### PR TITLE
ci: default plugin inspector scans to dry run

### DIFF
--- a/.github/workflows/plugin-inspector-bulk-scan.yml
+++ b/.github/workflows/plugin-inspector-bulk-scan.yml
@@ -10,7 +10,7 @@ on:
       dry_run:
         description: "Preview impact without persisting findings or sending emails"
         required: false
-        default: "false"
+        default: "true"
         type: boolean
       dry_run_max_batches:
         description: "Maximum preview batches to scan when dry_run is enabled"

--- a/.github/workflows/plugin-inspector-pin-bump-dispatch.yml
+++ b/.github/workflows/plugin-inspector-pin-bump-dispatch.yml
@@ -49,7 +49,7 @@ jobs:
           gh workflow run plugin-inspector-bulk-scan.yml \
             --ref main \
             -f batch_size=25 \
-            -f dry_run=false \
+            -f dry_run=true \
             -f dry_run_max_batches=20 \
             -f source_sha=${{ github.sha }}
 

--- a/src/__tests__/package-publish-workflow.test.ts
+++ b/src/__tests__/package-publish-workflow.test.ts
@@ -42,6 +42,15 @@ describe("package publish workflow", () => {
       resolve(".github/workflows/plugin-inspector-bulk-scan.yml"),
       "utf8",
     );
+    const parsedWorkflow = parseYaml(workflow) as {
+      on?: {
+        workflow_dispatch?: {
+          inputs?: {
+            dry_run?: { default?: string };
+          };
+        };
+      };
+    };
     const script = readFileSync(resolve("scripts/package-inspector-nightly-scan.ts"), "utf8");
     const http = readFileSync(resolve("convex/packageInspectorHttp.ts"), "utf8");
 
@@ -70,6 +79,7 @@ describe("package publish workflow", () => {
     expect(script).not.toContain("plugin-inspector-bulk-scan-error");
     expect(script).toContain("pluginInspector");
     expect(workflow).toContain("dry_run:");
+    expect(parsedWorkflow.on?.workflow_dispatch?.inputs?.dry_run?.default).toBe("true");
     expect(workflow).toContain("PLUGIN_INSPECTOR_DRY_RUN");
     expect(workflow).toContain("PLUGIN_INSPECTOR_DRY_RUN_MAX_BATCHES");
     expect(script).toContain("const dryRun =");
@@ -80,7 +90,7 @@ describe("package publish workflow", () => {
     expect(workflow).toContain("actions/upload-artifact");
   });
 
-  it("dispatches plugin inspector bulk scans after main inspector pin bumps", () => {
+  it("dispatches dry-run plugin inspector bulk scans after main inspector pin bumps", () => {
     const workflowText = readFileSync(
       resolve(".github/workflows/plugin-inspector-pin-bump-dispatch.yml"),
       "utf8",
@@ -114,7 +124,7 @@ describe("package publish workflow", () => {
     expect(workflowText).toContain("gh workflow run plugin-inspector-bulk-scan.yml");
     expect(workflowText).toContain("--ref main");
     expect(workflowText).toContain("batch_size=25");
-    expect(workflowText).toContain("dry_run=false");
+    expect(workflowText).toContain("dry_run=true");
     expect(workflowText).toContain("BASE_SHA: ${{ github.event.before }}");
     expect(workflowText).toContain("HEAD_SHA: ${{ github.sha }}");
     expect(workflowText).toContain(


### PR DESCRIPTION
## Summary
- Default manual Plugin Inspector bulk scans to dry-run mode.
- Make automatic pin-bump dispatches pass `dry_run=true` so dependency bumps still produce artifacts without persisting findings or sending owner emails.
- Update the workflow regression test to assert both dry-run defaults.

## Verification
- `bunx vitest run src/__tests__/package-publish-workflow.test.ts`
- `bun run format:check -- .github/workflows/plugin-inspector-bulk-scan.yml .github/workflows/plugin-inspector-pin-bump-dispatch.yml src/__tests__/package-publish-workflow.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Notes
- `bun run ci:static` currently stops in `check:peers` before reaching this workflow change: `@auth/core` is declared as `0.41.2`, but `@convex-dev/auth` requires `^0.37.0`.
