### PR TITLE
fix: restore catalog feed schema v1

### DIFF
--- a/packages/schema/dist/catalogFeed.d.ts
+++ b/packages/schema/dist/catalogFeed.d.ts
@@ -183,7 +183,7 @@ export declare const CatalogFeedSchema: import("arktype/internal/variants/object
     description?: string | undefined;
 }, {}>;
 export type CatalogFeed = (typeof CatalogFeedSchema)[inferred];
-export declare const CATALOG_FEED_SCHEMA_VERSION = 2;
+export declare const CATALOG_FEED_SCHEMA_VERSION = 1;
 export declare const CATALOG_FEED_ID = "clawhub-official";
 export declare const CATALOG_FEED_SOURCE_REF = "public-clawhub";
 export declare const CATALOG_FEED_GITHUB_SOURCE_REF = "public-github";

--- a/packages/schema/dist/catalogFeed.js
+++ b/packages/schema/dist/catalogFeed.js
@@ -51,7 +51,7 @@ export const CatalogFeedSchema = type({
     description: "string?",
     entries: CatalogFeedEntrySchema.array(),
 });
-export const CATALOG_FEED_SCHEMA_VERSION = 2;
+export const CATALOG_FEED_SCHEMA_VERSION = 1;
 export const CATALOG_FEED_ID = "clawhub-official";
 export const CATALOG_FEED_SOURCE_REF = "public-clawhub";
 export const CATALOG_FEED_GITHUB_SOURCE_REF = "public-github";

--- a/packages/schema/src/catalogFeed.test.ts
+++ b/packages/schema/src/catalogFeed.test.ts
@@ -95,7 +95,7 @@ describe("catalog feed schema", () => {
   });
 
   it("rejects unsupported versions and expired feeds", () => {
-    expect(() => parseCatalogFeed(makeFeed({ schemaVersion: 1 } as never))).toThrow(
+    expect(() => parseCatalogFeed(makeFeed({ schemaVersion: 2 } as never))).toThrow(
       "Unsupported catalog feed schema version",
     );
     expect(() => parseCatalogFeed(makeFeed({ expiresAt: "2026-06-22T00:00:00.000Z" }))).toThrow(

--- a/packages/schema/src/catalogFeed.ts
+++ b/packages/schema/src/catalogFeed.ts
@@ -73,7 +73,7 @@ export const CatalogFeedSchema = type({
 });
 export type CatalogFeed = (typeof CatalogFeedSchema)[inferred];
 
-export const CATALOG_FEED_SCHEMA_VERSION = 2;
+export const CATALOG_FEED_SCHEMA_VERSION = 1;
 export const CATALOG_FEED_ID = "clawhub-official";
 export const CATALOG_FEED_SOURCE_REF = "public-clawhub";
 export const CATALOG_FEED_GITHUB_SOURCE_REF = "public-github";

--- a/specs/hosted-catalog-feed.md
+++ b/specs/hosted-catalog-feed.md
@@ -15,7 +15,7 @@ skill records; they are not second catalogs.
 ## Contract
 
 - Feed id: `clawhub-official`
-- Schema version: `2`
+- Schema version: `1`
 - Initial scope: `code-plugin` and `bundle-plugin` packages plus official skills
 - Source profiles: `public-clawhub` for ClawHub-hosted artifacts and
   `public-github` for source-backed skills available through the public feed


### PR DESCRIPTION
## Summary
- restore the shared catalog feed schema version constant to v1
- update the schema-version rejection test to reject v2 again
- align the hosted feed spec with the v1 producer contract

## Validation
- bunx vitest run packages/schema/src/catalogFeed.test.ts convex/catalogFeed.test.ts convex/httpApiV1.catalogFeed.test.ts
- bunx tsc -p packages/schema/tsconfig.json --noEmit
- bunx tsc -p packages/clawhub/tsconfig.json --noEmit
- bun run --cwd packages/clawhub-admin test:artifact
- bunx vitest run -c vitest.config.ts src/cli.version-delete.test.ts (from packages/clawhub)
- bun run ci:static
- bunx tsc --noEmit

Note: an initial `bun run ci:packages` run failed because this checkout had stale `node_modules`; after `bun install --frozen-lockfile`, the admin artifact test passed directly. A later full `ci:packages` rerun timed out once in `src/cli.version-delete.test.ts`, and that exact test passed when rerun directly.

Linear: CLAW-435