### PR TITLE
fix: cap skills feed publication

### DIFF
--- a/convex/catalogFeed.test.ts
+++ b/convex/catalogFeed.test.ts
@@ -1,5 +1,6 @@
+import { CATALOG_FEED_ID, CATALOG_SKILLS_FEED_ID } from "clawhub-schema";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { listOfficialEntries, listOfficialSkillEntries } from "./catalogFeed";
+import { listOfficialEntries, listOfficialSkillEntries, publish } from "./catalogFeed";
 
 vi.mock("./lib/publishers", () => ({
   getOwnerPublisher: vi.fn().mockResolvedValue({ handle: "openclaw" }),
@@ -23,6 +24,9 @@ const listOfficialSkillEntriesHandler = (
     { publisherId: string; cursor: string | null },
     unknown
   >
+)._handler;
+const publishHandler = (
+  publish as unknown as WrappedHandler<{ expiresAt: string }, Array<{ feedId: string }>>
 )._handler;
 
 function makePackage(overrides: Record<string, unknown> = {}) {
@@ -103,6 +107,28 @@ function makeGitHubSource(overrides: Record<string, unknown> = {}) {
     ownerPublisherId: "publishers:1",
     defaultBranch: "main",
     ...overrides,
+  };
+}
+
+function makeFeedSkillEntry(index: number) {
+  const id = `@openclaw/demo-${index.toString().padStart(3, "0")}`;
+  return {
+    type: "skill",
+    id,
+    title: `Demo ${index}`,
+    version: "1.0.0",
+    state: "available",
+    publisher: { id: "openclaw", trust: "official" },
+    install: {
+      candidates: [
+        {
+          sourceRef: "public-clawhub",
+          package: id,
+          version: "1.0.0",
+          integrity: `sha256:skill-${index}`,
+        },
+      ],
+    },
   };
 }
 
@@ -315,6 +341,54 @@ describe("catalog feed projection", () => {
       ],
       isDone: true,
     });
+  });
+
+  it("caps oversized skills feeds instead of blocking plugin publication", async () => {
+    const skillEntries = Array.from({ length: 501 }, (_, index) => makeFeedSkillEntry(index));
+    const runMutation = vi.fn(
+      async (_ref: unknown, args: { feedId: string; entries: unknown[] }) => ({
+        feedId: args.feedId,
+        entryCount: args.entries.length,
+      }),
+    );
+    const runQuery = vi.fn(async (_ref: unknown, args: Record<string, unknown>) => {
+      if ("family" in args) return [];
+      if ("publisherId" in args) {
+        return { entries: skillEntries, isDone: true, continueCursor: "" };
+      }
+      return {
+        publishers: [{ _id: "publishers:1" }],
+        isDone: true,
+        continueCursor: "",
+      };
+    });
+
+    const result = await publishHandler(
+      { runQuery, runMutation },
+      { expiresAt: "2026-06-30T00:00:00.000Z" },
+    );
+
+    expect(runMutation).toHaveBeenCalledTimes(2);
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ feedId: CATALOG_FEED_ID, entries: [] }),
+    );
+    expect(runMutation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        feedId: CATALOG_SKILLS_FEED_ID,
+        entries: expect.arrayContaining([expect.objectContaining({ id: "@openclaw/demo-499" })]),
+      }),
+    );
+    expect(
+      vi
+        .mocked(runMutation)
+        .mock.calls.find(([, args]) => args.feedId === CATALOG_SKILLS_FEED_ID)?.[1].entries,
+    ).toHaveLength(500);
+    expect(result).toEqual([
+      { feedId: CATALOG_FEED_ID, entryCount: 0 },
+      { feedId: CATALOG_SKILLS_FEED_ID, entryCount: 500 },
+    ]);
   });
 
   it("projects suspicious current GitHub-backed skills into public GitHub install candidates", async () => {

--- a/convex/catalogFeed.ts
+++ b/convex/catalogFeed.ts
@@ -42,6 +42,13 @@ type CatalogFeedPublicationResult = {
   entryCount: number;
 };
 
+function appendEntriesWithinFeedLimit<T>(target: T[], entries: T[]) {
+  const remaining = MAX_CATALOG_FEED_ENTRIES - target.length;
+  if (remaining <= 0) return false;
+  target.push(...entries.slice(0, remaining));
+  return entries.length <= remaining;
+}
+
 const catalogFeedEntryFields = {
   id: v.string(),
   title: v.string(),
@@ -420,7 +427,9 @@ export const publish = internalAction({
     const skillEntries: CatalogFeedSkillEntry[] = [];
     const seenPublisherIds = new Set<string>();
     let publisherCursor: string | null = null;
-    while (true) {
+    // The skills feed currently ships as one bounded snapshot. Cap it instead
+    // of blocking the plugin feed refresh until skills pagination/sharding lands.
+    publisherLoop: while (true) {
       const publisherPage: {
         publishers: Doc<"publishers">[];
         isDone: boolean;
@@ -441,10 +450,7 @@ export const publish = internalAction({
             publisherId: publisher._id,
             cursor: skillCursor,
           });
-          skillEntries.push(...skillPage.entries);
-          if (skillEntries.length > MAX_CATALOG_FEED_ENTRIES) {
-            throw new Error(`Catalog skills feed exceeds ${MAX_CATALOG_FEED_ENTRIES} entries`);
-          }
+          if (!appendEntriesWithinFeedLimit(skillEntries, skillPage.entries)) break publisherLoop;
           if (skillPage.isDone) break;
           skillCursor = skillPage.continueCursor;
         }

--- a/specs/hosted-catalog-feed.md
+++ b/specs/hosted-catalog-feed.md
@@ -61,6 +61,9 @@ Suspicious GitHub-backed entries follow the same public feed visibility pattern
 as suspicious hosted packages and skills.
 Pending, failed, malicious, missing, removed, hidden, soft-deleted, or
 incomplete GitHub-backed skills are not emitted.
+Until the skills feed has pagination or sharding, it publishes at most 500
+eligible entries per snapshot so a large skills corpus does not block the plugin
+feed publication path.
 
 ## Publication
 


### PR DESCRIPTION
## Summary
- cap the skills feed at the existing 500-entry single-snapshot limit instead of throwing
- keep plugin feed publication unblocked when the skills corpus exceeds that temporary limit
- document the temporary skills-feed cap until pagination/sharding exists

## Validation
- bunx vitest run convex/catalogFeed.test.ts packages/schema/src/catalogFeed.test.ts convex/httpApiV1.catalogFeed.test.ts
- bunx tsc --noEmit
- bun run ci:static

Context: the production publish workflow was failing with `Catalog skills feed exceeds 500 entries`, which prevented the plugin feed snapshot from refreshing to schema v1.

Follow-up to #2909/#2910 / CLAW-435.