### PR TITLE
fix: raise catalog skills feed cap

### DIFF
--- a/convex/catalogFeed.test.ts
+++ b/convex/catalogFeed.test.ts
@@ -344,7 +344,7 @@ describe("catalog feed projection", () => {
   });
 
   it("caps oversized skills feeds instead of blocking plugin publication", async () => {
-    const skillEntries = Array.from({ length: 501 }, (_, index) => makeFeedSkillEntry(index));
+    const skillEntries = Array.from({ length: 1001 }, (_, index) => makeFeedSkillEntry(index));
     const runMutation = vi.fn(
       async (_ref: unknown, args: { feedId: string; entries: unknown[] }) => ({
         feedId: args.feedId,
@@ -377,17 +377,17 @@ describe("catalog feed projection", () => {
       expect.anything(),
       expect.objectContaining({
         feedId: CATALOG_SKILLS_FEED_ID,
-        entries: expect.arrayContaining([expect.objectContaining({ id: "@openclaw/demo-499" })]),
+        entries: expect.arrayContaining([expect.objectContaining({ id: "@openclaw/demo-999" })]),
       }),
     );
     expect(
       vi
         .mocked(runMutation)
         .mock.calls.find(([, args]) => args.feedId === CATALOG_SKILLS_FEED_ID)?.[1].entries,
-    ).toHaveLength(500);
+    ).toHaveLength(1000);
     expect(result).toEqual([
       { feedId: CATALOG_FEED_ID, entryCount: 0 },
-      { feedId: CATALOG_SKILLS_FEED_ID, entryCount: 500 },
+      { feedId: CATALOG_SKILLS_FEED_ID, entryCount: 1000 },
     ]);
   });
 
@@ -482,6 +482,26 @@ describe("catalog feed projection", () => {
         "githubSkillSources:1": makeGitHubSource(),
       }),
       { publisherId: "publishers:1", cursor: null },
+    )) as { entries: unknown[] };
+
+    expect(result.entries).toEqual([]);
+  });
+
+  it("excludes GitHub-backed skills from non-official publishers", async () => {
+    vi.mocked((await import("./lib/officialPublishers")).isOfficialPublisher).mockResolvedValue(
+      false,
+    );
+
+    const result = (await listOfficialSkillEntriesHandler(
+      makeCtx([makeGitHubSkill({ slug: "community-source" })], {
+        "publishers:community": {
+          _id: "publishers:community",
+          kind: "org",
+          handle: "community",
+        },
+        "githubSkillSources:1": makeGitHubSource({ ownerPublisherId: "publishers:community" }),
+      }),
+      { publisherId: "publishers:community", cursor: null },
     )) as { entries: unknown[] };
 
     expect(result.entries).toEqual([]);

--- a/convex/catalogFeed.ts
+++ b/convex/catalogFeed.ts
@@ -29,7 +29,7 @@ import {
 
 const CATALOG_FEED_DESCRIPTION = "Official OpenClaw plugins published on ClawHub.";
 const CATALOG_FEED_PAGE_SIZE = 100;
-const MAX_CATALOG_FEED_ENTRIES = 500;
+const MAX_CATALOG_FEED_ENTRIES = 1000;
 const CATALOG_FEED_FAMILIES = ["code-plugin", "bundle-plugin"] as const;
 
 type CatalogQueryCtx = Pick<QueryCtx, "db">;

--- a/specs/hosted-catalog-feed.md
+++ b/specs/hosted-catalog-feed.md
@@ -61,7 +61,7 @@ Suspicious GitHub-backed entries follow the same public feed visibility pattern
 as suspicious hosted packages and skills.
 Pending, failed, malicious, missing, removed, hidden, soft-deleted, or
 incomplete GitHub-backed skills are not emitted.
-Until the skills feed has pagination or sharding, it publishes at most 500
+Until the skills feed has pagination or sharding, it publishes at most 1000
 eligible entries per snapshot so a large skills corpus does not block the plugin
 feed publication path.
 


### PR DESCRIPTION
## Summary

- raises the temporary hosted skills feed snapshot cap from 500 to 1000 entries
- keeps the oversized skills feed behavior bounded so plugin feed publication is not blocked
- adds an explicit regression that GitHub-backed `public-github` skill entries are excluded for non-official publishers
- updates the hosted catalog feed spec note to match the 1000-entry cap

## Validation

- `bunx vitest run convex/catalogFeed.test.ts packages/schema/src/catalogFeed.test.ts convex/httpApiV1.catalogFeed.test.ts`
- `bunx tsc --noEmit`
- `bun run ci:static`