### PR TITLE
fix: publish security snapshots to live dataset

### DIFF
--- a/.github/workflows/security-dataset-snapshot.yml
+++ b/.github/workflows/security-dataset-snapshot.yml
@@ -71,7 +71,7 @@ jobs:
     env:
       CONVEX_URL: ${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}
       SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}
-      HF_DATASET_REPO: OpenClaw/clawhub-security-signals
+      HF_DATASET_REPO: OpenClaw/clawhub-security-signals-live
       HF_REVISION: ${{ inputs['hf-revision'] || 'main' }}
       HF_UPLOAD: ${{ github.event_name == 'schedule' || inputs.upload == 'true' }}
       SNAPSHOT_LIMIT: ${{ inputs.limit || '' }}
@@ -195,7 +195,7 @@ jobs:
     env:
       CONVEX_URL: ${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}
       SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}
-      HF_DATASET_REPO: OpenClaw/clawhub-security-signals
+      HF_DATASET_REPO: OpenClaw/clawhub-security-signals-live
       HF_REVISION: ${{ inputs['hf-revision'] || 'main' }}
       SNAPSHOT_PAGE_SIZE: ${{ inputs['page-size'] || '25' }}
       SNAPSHOT_MIN_PAGE_SIZE: ${{ inputs['min-page-size'] || '1' }}
@@ -258,8 +258,8 @@ jobs:
       contents: read
       id-token: write
     env:
-      HF_DATASET_REPO: OpenClaw/clawhub-security-signals
-      HF_OIDC_RESOURCE: datasets/OpenClaw/clawhub-security-signals
+      HF_DATASET_REPO: OpenClaw/clawhub-security-signals-live
+      HF_OIDC_RESOURCE: datasets/OpenClaw/clawhub-security-signals-live
       HF_REVISION: ${{ inputs['hf-revision'] || 'main' }}
       HF_UPLOAD: ${{ github.event_name == 'schedule' || inputs.upload == 'true' }}
       SANITIZED_OUT_DIR: /tmp/clawhub-security-dataset/sanitized
@@ -343,8 +343,8 @@ jobs:
       id-token: write
     env:
       GH_TOKEN: ${{ github.token }}
-      HF_DATASET_REPO: OpenClaw/clawhub-security-signals
-      HF_OIDC_RESOURCE: datasets/OpenClaw/clawhub-security-signals
+      HF_DATASET_REPO: OpenClaw/clawhub-security-signals-live
+      HF_OIDC_RESOURCE: datasets/OpenClaw/clawhub-security-signals-live
       HF_REVISION: ${{ inputs['hf-revision'] || 'main' }}
       HF_UPLOAD: ${{ inputs.upload == 'true' }}
       SANITIZED_OUT_DIR: /tmp/clawhub-security-dataset/sanitized

--- a/scripts/security-dataset/export-snapshot.ts
+++ b/scripts/security-dataset/export-snapshot.ts
@@ -18,7 +18,6 @@ import { buildSecurityDatasetManifest } from "./manifest";
 import {
   normalizeArtifactExport,
   type ArtifactExportInput,
-  type DatasetSplit,
   type NormalizedDatasetRows,
   type SourceKind,
 } from "./normalize";
@@ -107,7 +106,7 @@ type SnapshotState = {
     splits: number;
     huggingFaceRows: number;
   };
-  huggingFaceRowCountsBySplit: Record<DatasetSplit, number>;
+  huggingFaceRowCountsBySplit: Record<HuggingFaceLiveSplit, number>;
   scannerVersions: Set<string>;
   modelNames: Set<string>;
 };
@@ -119,7 +118,7 @@ type SnapshotWriters = {
   clawScanFindings: WriteStream;
   labels: WriteStream;
   splits: WriteStream;
-  huggingFaceSplits?: Record<DatasetSplit, WriteStream>;
+  huggingFaceSplits?: Record<HuggingFaceLiveSplit, WriteStream>;
 };
 
 const DEFAULT_PAGE_SIZE = 50;
@@ -132,7 +131,8 @@ const MAX_TIMER_TIMEOUT_MS = 2_147_483_647;
 const DEFAULT_OUT_DIR = ".data/security-dataset/snapshots";
 const CONVEX_RUN_MAX_BUFFER_BYTES = 128 * 1024 * 1024;
 const SOURCE_KINDS: SourceKind[] = ["skill", "package"];
-const HF_SPLITS: DatasetSplit[] = ["train", "validation", "test", "eval_holdout"];
+const HF_LIVE_SPLIT = "latest";
+type HuggingFaceLiveSplit = typeof HF_LIVE_SPLIT;
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
@@ -566,7 +566,7 @@ function buildManifest(input: {
           revision: options.huggingFaceRevision,
           commit: null,
           configNames: ["default"],
-          splitNames: HF_SPLITS,
+          splitNames: [HF_LIVE_SPLIT],
           rowCountsBySplit: state.huggingFaceRowCountsBySplit,
         }
       : undefined,
@@ -607,10 +607,7 @@ function createSnapshotState(): SnapshotState {
       huggingFaceRows: 0,
     },
     huggingFaceRowCountsBySplit: {
-      train: 0,
-      validation: 0,
-      test: 0,
-      eval_holdout: 0,
+      latest: 0,
     },
     scannerVersions: new Set(),
     modelNames: new Set(),
@@ -632,9 +629,7 @@ async function processArtifactInputs(input: {
   state.rowCounts.labels += rows.labels.length;
   state.rowCounts.splits += rows.splits.length;
   state.rowCounts.huggingFaceRows += hfRows.length;
-  for (const row of hfRows) {
-    state.huggingFaceRowCountsBySplit[row.split] += 1;
-  }
+  state.huggingFaceRowCountsBySplit.latest += hfRows.length;
   for (const row of rows.scanResults) {
     if (row.scanner_version) state.scannerVersions.add(row.scanner_version);
     if (row.model) state.modelNames.add(row.model);
@@ -668,10 +663,7 @@ async function openSnapshotWriters(
     const dataDir = join(snapshotDir, "hf-dataset", "data");
     await mkdir(dataDir, { recursive: true });
     writers.huggingFaceSplits = {
-      train: createWriteStream(join(dataDir, "train.jsonl"), { encoding: "utf8" }),
-      validation: createWriteStream(join(dataDir, "validation.jsonl"), { encoding: "utf8" }),
-      test: createWriteStream(join(dataDir, "test.jsonl"), { encoding: "utf8" }),
-      eval_holdout: createWriteStream(join(dataDir, "eval_holdout.jsonl"), { encoding: "utf8" }),
+      latest: createWriteStream(join(dataDir, "latest.jsonl"), { encoding: "utf8" }),
     };
   }
   return writers;
@@ -711,15 +703,13 @@ async function writeJsonlRows(stream: WriteStream, rows: unknown[]) {
 }
 
 async function writeHuggingFaceRows(
-  streams: Record<DatasetSplit, WriteStream>,
+  streams: Record<HuggingFaceLiveSplit, WriteStream>,
   rows: HuggingFaceSecuritySignalRow[],
 ) {
-  for (const split of HF_SPLITS) {
-    await writeJsonlRows(
-      streams[split],
-      rows.filter((row) => row.split === split),
-    );
-  }
+  await writeJsonlRows(
+    streams.latest,
+    rows.map((row) => ({ ...row, split: HF_LIVE_SPLIT })),
+  );
 }
 
 async function collectOutputSizes(root: string) {
@@ -940,7 +930,7 @@ function parseArgs(args: string[]): Options {
     convexExportZip: null,
     sourceSnapshotId: null,
     huggingFaceDataset: false,
-    huggingFaceRepo: process.env.HF_DATASET_REPO ?? "OpenClaw/clawhub-security-signals",
+    huggingFaceRepo: process.env.HF_DATASET_REPO ?? "OpenClaw/clawhub-security-signals-live",
     huggingFaceRevision: process.env.HF_REVISION ?? "main",
     writeShardMatrix: null,
   };

--- a/scripts/security-dataset/exportSnapshotCli.test.ts
+++ b/scripts/security-dataset/exportSnapshotCli.test.ts
@@ -40,21 +40,24 @@ describe("security dataset snapshot CLI", () => {
         manifest: {
           source_snapshot_id: string;
           row_counts: { huggingface_rows: number };
-          huggingface_dataset: { repo: string; rowCountsBySplit: Record<string, number> };
+          huggingface_dataset: {
+            repo: string;
+            splitNames: string[];
+            rowCountsBySplit: Record<string, number>;
+          };
         };
       } = JSON.parse(result.stdout);
 
       expect(summary.manifest.source_snapshot_id).toBe("live-export-prod-123-1");
       expect(summary.manifest.row_counts.huggingface_rows).toBe(1);
-      expect(summary.manifest.huggingface_dataset.repo).toBe("OpenClaw/clawhub-security-signals");
+      expect(summary.manifest.huggingface_dataset.repo).toBe(
+        "OpenClaw/clawhub-security-signals-live",
+      );
+      expect(summary.manifest.huggingface_dataset.splitNames).toEqual(["latest"]);
+      expect(summary.manifest.huggingface_dataset.rowCountsBySplit).toEqual({ latest: 1 });
       const dataDir = join(summary.snapshotDir, "hf-dataset", "data");
       const files = await readdir(dataDir);
-      expect(files.sort()).toEqual([
-        "eval_holdout.jsonl",
-        "test.jsonl",
-        "train.jsonl",
-        "validation.jsonl",
-      ]);
+      expect(files.sort()).toEqual(["latest.jsonl"]);
 
       const splitContents = await Promise.all(
         files.map(async (file) => readFile(join(dataDir, file), "utf8")),

--- a/scripts/security-dataset/huggingface-live/README.md
+++ b/scripts/security-dataset/huggingface-live/README.md
@@ -1,0 +1,83 @@
+---
+language:
+  - en
+license: mit
+size_categories:
+  - 10K<n<100K
+task_categories:
+  - text-classification
+task_ids:
+  - multi-class-classification
+pretty_name: ClawHub Security Signals Live
+tags:
+  - security
+  - llm-security
+  - agentic-ai
+  - agent-skills
+  - openclaw
+  - clawhub
+  - malware-detection
+  - static-analysis
+  - software-supply-chain
+  - live-dataset
+  - weekly
+configs:
+  - config_name: default
+    data_files:
+      - split: latest
+        path: data/latest.jsonl
+---
+
+# ClawHub Security Signals Live
+
+This dataset is the refreshed ClawHub security-signals corpus for scanner testing, prompt regression checks, and operational research against recent public ClawHub skills.
+
+It is a moving dataset, not the fixed paper benchmark. `main` is expected to change when the ClawHub security dataset snapshot workflow publishes a new sanitized export. Pin a Hugging Face revision or commit when you need reproducibility.
+
+For the frozen research-paper snapshot, use [`OpenClaw/clawhub-security-signals`](https://huggingface.co/datasets/OpenClaw/clawhub-security-signals).
+
+## Data Shape
+
+The live dataset exposes one public split:
+
+| Split    | Meaning                                                                                      |
+| -------- | -------------------------------------------------------------------------------------------- |
+| `latest` | Latest sanitized public ClawHub security-signal rows from the most recent successful export. |
+
+The live split deliberately avoids `train`, `validation`, `test`, and `eval_holdout` names because this corpus is refreshed over time and should not be treated as a stable benchmark unless you pin a specific revision.
+
+## Reproducibility
+
+Each publish writes [`metadata/latest-manifest.json`](metadata/latest-manifest.json) with:
+
+- source snapshot id
+- exporter git SHA
+- Convex deployment
+- redaction policy version
+- Hugging Face data commit
+- row counts
+- split/config names
+- output sizes
+
+For stable comparisons, record both the Hugging Face repository commit and the manifest's `huggingface_dataset.commit`.
+
+## Safety
+
+The export path publishes sanitized public data only. It excludes private/deleted artifacts, raw Convex storage identifiers, raw internal document ids, obvious secret-like values, and unsanitized package contents. The workflow validates sanitized output guardrails before upload.
+
+Scanner labels are evidence signals, not human-adjudicated ground truth. A suspicious verdict means review before trusting; it does not by itself prove malicious intent.
+
+## Intended Uses
+
+- testing ClawScan and other agent-skill security scanners against current public registry data
+- monitoring scanner drift over time
+- building reproducible scanner regression suites by pinning specific dataset revisions
+- studying recent public ClawHub security-signal distributions
+
+## Out Of Scope
+
+This live dataset is not intended to replace the frozen paper snapshot, and `main` should not be used as a stable leaderboard target without pinning a commit.
+
+## License
+
+This dataset is released under the MIT license.

--- a/scripts/security-dataset/merge-snapshots.ts
+++ b/scripts/security-dataset/merge-snapshots.ts
@@ -6,7 +6,8 @@ import { dirname, join, resolve } from "node:path";
 import { buildSecurityDatasetManifest } from "./manifest";
 import { redactBundleContent, redactSkillContent, redactText } from "./normalize";
 
-type DatasetSplit = "train" | "validation" | "test" | "eval_holdout";
+type PaperDatasetSplit = "train" | "validation" | "test" | "eval_holdout";
+type LiveDatasetSplit = "latest";
 
 type Options = {
   shardsDir: string;
@@ -47,8 +48,8 @@ type ShardManifest = {
     created_at_lt: number | null;
   };
   huggingface_dataset: {
-    rowCountsBySplit?: Record<DatasetSplit, number>;
-    row_counts_by_split?: Record<DatasetSplit, number>;
+    rowCountsBySplit?: Record<string, number>;
+    row_counts_by_split?: Record<string, number>;
   } | null;
 };
 
@@ -60,7 +61,8 @@ const JSONL_FILES = [
   "labels.jsonl",
   "splits.jsonl",
 ] as const;
-const HF_SPLITS: DatasetSplit[] = ["train", "validation", "test", "eval_holdout"];
+const HF_LIVE_SPLIT: LiveDatasetSplit = "latest";
+const PAPER_HF_SPLITS: PaperDatasetSplit[] = ["train", "validation", "test", "eval_holdout"];
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
@@ -99,15 +101,22 @@ async function concatenateSnapshotFiles(
     );
   }
 
-  for (const split of HF_SPLITS) {
-    const writer = createWriteStream(join(snapshotDir, "hf-dataset", "data", `${split}.jsonl`), {
+  {
+    const writer = createWriteStream(join(snapshotDir, "hf-dataset", "data", "latest.jsonl"), {
       encoding: "utf8",
     });
     await concatenateRedactedHuggingFaceRows(
       writer,
-      manifests.map(({ dir }) => join(dir, "hf-dataset", "data", `${split}.jsonl`)),
+      manifests.flatMap(({ dir }) => huggingFaceShardRowPaths(dir)),
     );
   }
+}
+
+function huggingFaceShardRowPaths(dir: string) {
+  return [
+    join(dir, "hf-dataset", "data", "latest.jsonl"),
+    ...PAPER_HF_SPLITS.map((split) => join(dir, "hf-dataset", "data", `${split}.jsonl`)),
+  ];
 }
 
 async function concatenateFiles(writer: WriteStream, paths: string[]) {
@@ -156,6 +165,7 @@ async function writeRedactedHuggingFaceRow(writer: WriteStream, line: string) {
 function redactHuggingFaceRow(row: Record<string, unknown>) {
   return {
     ...row,
+    split: HF_LIVE_SPLIT,
     skill_slug:
       typeof row.skill_slug === "string" ? redactText(row.skill_slug, 2048) : row.skill_slug,
     skill_md_content:
@@ -220,7 +230,7 @@ function buildMergedManifest(input: {
       revision: options.huggingFaceRevision,
       commit: null,
       configNames: ["default"],
-      splitNames: HF_SPLITS,
+      splitNames: [HF_LIVE_SPLIT],
       rowCountsBySplit,
     },
   });
@@ -251,16 +261,15 @@ function sumRowCounts(manifests: ShardManifest[]) {
   );
 }
 
-function sumHuggingFaceSplitCounts(manifests: ShardManifest[]): Record<DatasetSplit, number> {
-  const counts = { train: 0, validation: 0, test: 0, eval_holdout: 0 };
+function sumHuggingFaceSplitCounts(manifests: ShardManifest[]): Record<LiveDatasetSplit, number> {
+  const counts = { latest: 0 };
   for (const manifest of manifests) {
     const shardCounts =
       manifest.huggingface_dataset?.rowCountsBySplit ??
-      manifest.huggingface_dataset?.row_counts_by_split ??
-      counts;
-    for (const split of HF_SPLITS) {
-      counts[split] += shardCounts[split] ?? 0;
-    }
+      manifest.huggingface_dataset?.row_counts_by_split;
+    counts.latest +=
+      shardCounts?.latest ??
+      PAPER_HF_SPLITS.reduce((sum, split) => sum + (shardCounts?.[split] ?? 0), 0);
   }
   return counts;
 }
@@ -342,7 +351,7 @@ function parseArgs(args: string[]): Options {
     outDir: ".data/security-dataset/merged",
     snapshotId: null,
     sourceSnapshotId: null,
-    huggingFaceRepo: process.env.HF_DATASET_REPO ?? "OpenClaw/clawhub-security-signals",
+    huggingFaceRepo: process.env.HF_DATASET_REPO ?? "OpenClaw/clawhub-security-signals-live",
     huggingFaceRevision: process.env.HF_REVISION ?? "main",
   };
 

--- a/scripts/security-dataset/mergeSnapshots.test.ts
+++ b/scripts/security-dataset/mergeSnapshots.test.ts
@@ -41,7 +41,7 @@ describe("security dataset snapshot merge CLI", () => {
           "--source-snapshot-id",
           "live-convex-test-1",
           "--hf-repo",
-          "OpenClaw/clawhub-security-signals",
+          "OpenClaw/clawhub-security-signals-live",
           "--hf-revision",
           "main",
         ],
@@ -58,7 +58,7 @@ describe("security dataset snapshot merge CLI", () => {
           source_snapshot_id: string;
           row_counts: { source_artifacts: number; huggingface_rows: number };
           created_time_window: { created_at_gte: number; created_at_lt: number };
-          huggingface_dataset: { rowCountsBySplit: Record<string, number> };
+          huggingface_dataset: { splitNames: string[]; rowCountsBySplit: Record<string, number> };
         };
       } = JSON.parse(result.stdout);
 
@@ -69,23 +69,27 @@ describe("security dataset snapshot merge CLI", () => {
         created_at_gte: 100,
         created_at_lt: 300,
       });
-      expect(summary.manifest.huggingface_dataset.rowCountsBySplit).toMatchObject({
-        train: 1,
-        test: 2,
-      });
+      expect(summary.manifest.huggingface_dataset.splitNames).toEqual(["latest"]);
+      expect(summary.manifest.huggingface_dataset.rowCountsBySplit).toEqual({ latest: 3 });
 
       await expect(
-        readFile(join(summary.snapshotDir, "hf-dataset", "data", "train.jsonl"), "utf8"),
+        readFile(join(summary.snapshotDir, "hf-dataset", "data", "latest.jsonl"), "utf8"),
       ).resolves.toContain('"id":"row-a"');
       await expect(
-        readFile(join(summary.snapshotDir, "hf-dataset", "data", "train.jsonl"), "utf8"),
+        readFile(join(summary.snapshotDir, "hf-dataset", "data", "latest.jsonl"), "utf8"),
       ).resolves.toContain("[REDACTED_SECRET]");
       await expect(
-        readFile(join(summary.snapshotDir, "hf-dataset", "data", "train.jsonl"), "utf8"),
+        readFile(join(summary.snapshotDir, "hf-dataset", "data", "latest.jsonl"), "utf8"),
       ).resolves.not.toContain("supersecretvalue123");
       await expect(
-        readFile(join(summary.snapshotDir, "hf-dataset", "data", "test.jsonl"), "utf8"),
+        readFile(join(summary.snapshotDir, "hf-dataset", "data", "latest.jsonl"), "utf8"),
       ).resolves.toContain('"id":"row-b"');
+      await expect(
+        readFile(join(summary.snapshotDir, "hf-dataset", "data", "latest.jsonl"), "utf8"),
+      ).resolves.toContain('"split":"latest"');
+      await expect(
+        readFile(join(summary.snapshotDir, "hf-dataset", "data", "latest.jsonl"), "utf8"),
+      ).resolves.not.toContain('"split":"train"');
     } finally {
       await rm(directory, { recursive: true, force: true });
     }
@@ -120,6 +124,7 @@ async function writeShardSnapshot(
     const rows = Array.from({ length: rowCount }, (_, index) =>
       JSON.stringify({
         id: index === 0 ? input.rowId : `${input.rowId}-${index}`,
+        split,
         skill_slug: "owner/sk-abcdefghijklmnopqrstuvwxyz",
         skill_md_content: "Use this skill. skill secret: supersecretvalue123",
         skill_bundle_content: [
@@ -162,16 +167,13 @@ async function writeShardSnapshot(
       createdAtLt: input.createdAtLt,
     },
     huggingFaceDataset: {
-      repo: "OpenClaw/clawhub-security-signals",
+      repo: "OpenClaw/clawhub-security-signals-live",
       revision: "main",
       commit: null,
       configNames: ["default"],
-      splitNames: ["train", "validation", "test", "eval_holdout"],
+      splitNames: ["latest"],
       rowCountsBySplit: {
-        train: input.split === "train" ? input.sourceArtifacts : 0,
-        validation: 0,
-        test: input.split === "test" ? input.sourceArtifacts : 0,
-        eval_holdout: 0,
+        latest: input.sourceArtifacts,
       },
     },
   });

--- a/scripts/security-dataset/security-dataset-snapshot-workflow.test.ts
+++ b/scripts/security-dataset/security-dataset-snapshot-workflow.test.ts
@@ -40,6 +40,7 @@ describe("security-dataset-snapshot workflow", () => {
     expect(workflow.on?.workflow_dispatch?.inputs?.["reuse-shards-run-id"]?.default).toBe("");
     expect(planJob.if).toContain("reuse-shards-run-id");
     expect(planJob.env?.SNAPSHOT_SHARDS).toBe("${{ inputs.shards || '12' }}");
+    expect(planJob.env?.HF_DATASET_REPO).toBe("OpenClaw/clawhub-security-signals-live");
     expect(planJob.env?.SNAPSHOT_MAX_SHARDS_PER_SOURCE).toBe(
       "${{ vars.SECURITY_DATASET_MAX_SHARDS_PER_SOURCE || '128' }}",
     );

--- a/scripts/security-dataset/upload-huggingface.py
+++ b/scripts/security-dataset/upload-huggingface.py
@@ -72,6 +72,14 @@ with tempfile.TemporaryDirectory(prefix="clawhub-hf-upload-") as staging_root:
         manifest_path,
         staging_dir / "metadata" / "latest-manifest.json",
     )
+    readme_path = Path(
+        os.environ.get(
+            "HF_DATASET_README",
+            "scripts/security-dataset/huggingface-live/README.md",
+        )
+    )
+    if readme_path.exists():
+        shutil.copy2(readme_path, staging_dir / "README.md")
     dataset_commit = api.upload_folder(
         folder_path=str(staging_dir),
         path_in_repo="",

--- a/scripts/security-dataset/validate-guardrails.ts
+++ b/scripts/security-dataset/validate-guardrails.ts
@@ -1,5 +1,5 @@
 import { createReadStream } from "node:fs";
-import { readFile, stat } from "node:fs/promises";
+import { readFile, readdir, stat } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { hasSecretLikeValue } from "./normalize";
@@ -15,7 +15,6 @@ type Finding = {
   reason: string;
 };
 
-const HF_SPLITS = ["train", "validation", "test", "eval_holdout"] as const;
 const RAW_CONVEX_REF_PATTERN = /\b(?:skillVersions|packageReleases):[a-z0-9]{6,}\b/i;
 const RAW_STORAGE_PATH_PATTERN = /(^|\/)_storage\//;
 
@@ -23,14 +22,15 @@ async function main() {
   const options = parseArgs(process.argv.slice(2));
   const snapshotDir = resolve(options.snapshotDir);
   const findings: Finding[] = [];
+  const dataDir = join(snapshotDir, "hf-dataset", "data");
 
   await assertFile(join(snapshotDir, "manifest.json"));
-  await assertDirectory(join(snapshotDir, "hf-dataset", "data"));
+  await assertDirectory(dataDir);
   await inspectJsonFile(join(snapshotDir, "manifest.json"), snapshotDir, findings);
 
-  for (const split of HF_SPLITS) {
-    const file = join(snapshotDir, "hf-dataset", "data", `${split}.jsonl`);
-    await assertFile(file);
+  const dataFiles = await listDataFiles(dataDir);
+  if (dataFiles.length === 0) throw new Error(`Expected at least one JSONL data file: ${dataDir}`);
+  for (const file of dataFiles) {
     await inspectJsonlFile(file, snapshotDir, findings);
   }
 
@@ -56,6 +56,14 @@ async function assertDirectory(path: string) {
 async function assertFile(path: string) {
   const entry = await stat(path);
   if (!entry.isFile()) throw new Error(`Expected file: ${path}`);
+}
+
+async function listDataFiles(dataDir: string) {
+  const entries = await readdir(dataDir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+    .map((entry) => join(dataDir, entry.name))
+    .sort();
 }
 
 async function inspectJsonFile(path: string, root: string, findings: Finding[]) {

--- a/scripts/security-dataset/validateGuardrails.test.ts
+++ b/scripts/security-dataset/validateGuardrails.test.ts
@@ -67,12 +67,10 @@ async function createSnapshot(rows: unknown[]) {
   const snapshotDir = await mkdtemp(join(tmpdir(), "clawhub-security-guardrails-"));
   await mkdir(join(snapshotDir, "hf-dataset", "data"), { recursive: true });
   await writeFile(join(snapshotDir, "manifest.json"), JSON.stringify({ ok: true }));
-  for (const split of ["train", "validation", "test", "eval_holdout"]) {
-    await writeFile(
-      join(snapshotDir, "hf-dataset", "data", `${split}.jsonl`),
-      split === "train" ? rows.map((row) => JSON.stringify(row)).join("\n") : "",
-    );
-  }
+  await writeFile(
+    join(snapshotDir, "hf-dataset", "data", "latest.jsonl"),
+    rows.map((row) => JSON.stringify(row)).join("\n"),
+  );
   return snapshotDir;
 }
 


### PR DESCRIPTION
## Summary

- point the security dataset snapshot workflow at `OpenClaw/clawhub-security-signals-live`
- publish Hugging Face live data as a single `latest` split instead of benchmark-style train/validation/test/eval_holdout files
- keep merge compatibility for older shard artifacts while rewriting row-level `split` values to `latest`
- make guardrail validation inspect present JSONL data files so it works for both paper and live shapes
- add the maintained live Hugging Face dataset card and include it in uploader staging when present

## Tests

- `bun test scripts/security-dataset/*.test.ts`
- `python3 -m py_compile scripts/security-dataset/upload-huggingface.py`
- `bun run ci:static`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Notes

The frozen paper dataset has already been restored on Hugging Face to the paper snapshot plus a small card pointer to the live dataset. Raw HF files now total 67,453 rows again; the Hugging Face dataset-viewer derived size endpoint is still showing the previous cached 66,192-row latest-only parquet view.

Creating `OpenClaw/clawhub-security-signals-live` is blocked by the currently available Hugging Face token/account: it can update the existing dataset but receives `403 Forbidden` when creating a new dataset under `OpenClaw` via both API and browser UI. Do not merge/run this workflow until an OpenClaw HF admin creates the live dataset repo and configures the Trusted Publisher resource `datasets/OpenClaw/clawhub-security-signals-live`.
