### PR TITLE
fix: reduce static scanner false positives

### DIFF
--- a/convex/lib/moderationEngine.test.ts
+++ b/convex/lib/moderationEngine.test.ts
@@ -96,6 +96,81 @@ describe("moderationEngine", () => {
     );
   });
 
+  it("flags unquoted alphanumeric hardcoded secrets", () => {
+    const alphanumericKey = "AbCdEfGhIjKl1234567890";
+    const result = runStaticModerationScan({
+      slug: "plain-token",
+      displayName: "Plain Token",
+      summary: "Uses a provider API",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: ".env.example", size: 128 }],
+      fileContents: [
+        {
+          path: ".env.example",
+          content: `PROVIDER_API_KEY=${alphanumericKey}`,
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.exposed_secret_literal");
+    expect(result.status).toBe("suspicious");
+    expect(result.findings[0]?.evidence).not.toContain(alphanumericKey);
+  });
+
+  it("flags long numeric hardcoded credentials", () => {
+    const numericKey = "1234567890123456";
+    const result = runStaticModerationScan({
+      slug: "numeric-token",
+      displayName: "Numeric Token",
+      summary: "Uses a numeric provider key",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: ".env.example", size: 128 }],
+      fileContents: [
+        {
+          path: ".env.example",
+          content: `PROVIDER_API_KEY=${numericKey}`,
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.exposed_secret_literal");
+    expect(result.status).toBe("suspicious");
+    expect(result.findings[0]?.evidence).not.toContain(numericKey);
+  });
+
+  it("flags all-letter hardcoded secrets in env and quoted code values", () => {
+    const envKey = "abcdefghijklmnopqrstuvwxyz";
+    const passphrase = "CorrectHorseBatteryStaple";
+    const result = runStaticModerationScan({
+      slug: "letter-secret",
+      displayName: "Letter Secret",
+      summary: "Uses provider credentials",
+      frontmatter: {},
+      metadata: {},
+      files: [
+        { path: ".env.example", size: 128 },
+        { path: "src/config.ts", size: 128 },
+      ],
+      fileContents: [
+        {
+          path: ".env.example",
+          content: `API_KEY=${envKey}`,
+        },
+        {
+          path: "src/config.ts",
+          content: `password: "${passphrase}",`,
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.exposed_secret_literal");
+    expect(result.status).toBe("suspicious");
+    expect(result.findings.map((finding) => finding.evidence).join("\n")).not.toContain(envKey);
+    expect(result.findings.map((finding) => finding.evidence).join("\n")).not.toContain(passphrase);
+  });
+
   it("flags code that disables HTTPS certificate verification", () => {
     const result = runStaticModerationScan({
       slug: "cms-config-myclaw",
@@ -175,6 +250,97 @@ describe("moderationEngine", () => {
     expect(result.findings.map((finding) => finding.evidence).join("\n")).toContain("[REDACTED]");
   });
 
+  it("flags known-prefix test-mode provider keys", () => {
+    const stripeTestKey = "sk_test_1234567890abcdefSECRET";
+    const result = runStaticModerationScan({
+      slug: "stripe-demo",
+      displayName: "Stripe Demo",
+      summary: "Uses Stripe",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: ".env.example", size: 128 }],
+      fileContents: [
+        {
+          path: ".env.example",
+          content: `STRIPE_API_KEY=${stripeTestKey}`,
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.exposed_secret_literal");
+    expect(result.status).toBe("suspicious");
+    expect(result.findings[0]?.evidence).not.toContain(stripeTestKey);
+  });
+
+  it("flags generic secrets that contain a test segment", () => {
+    const key = "prod-test-AbCdEfGhIjKl1234567890";
+    const result = runStaticModerationScan({
+      slug: "provider-demo",
+      displayName: "Provider Demo",
+      summary: "Uses provider credentials",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: ".env.example", size: 128 }],
+      fileContents: [
+        {
+          path: ".env.example",
+          content: `PROVIDER_API_KEY=${key}`,
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.exposed_secret_literal");
+    expect(result.status).toBe("suspicious");
+    expect(result.findings[0]?.evidence).not.toContain(key);
+  });
+
+  it("flags lowercase credential-shaped literals instead of treating them as placeholders", () => {
+    const key = "api-token-a1b2c3d4e5f6g7h8";
+    const result = runStaticModerationScan({
+      slug: "provider-demo",
+      displayName: "Provider Demo",
+      summary: "Uses provider credentials",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: ".env.example", size: 128 }],
+      fileContents: [
+        {
+          path: ".env.example",
+          content: `PROVIDER_API_KEY=${key}`,
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.exposed_secret_literal");
+    expect(result.status).toBe("suspicious");
+    expect(result.findings[0]?.evidence).not.toContain(key);
+  });
+
+  it("does not flag low-entropy named secret fixtures in test files", () => {
+    const result = runStaticModerationScan({
+      slug: "fixture-secret",
+      displayName: "Fixture Secret",
+      summary: "Uses test credentials",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/config.test.ts", size: 256 }],
+      fileContents: [
+        {
+          path: "src/config.test.ts",
+          content: [
+            'const cfg = { accessToken: "recreated-stale-legacy-token" };',
+            'const old = { accessToken: "secret-token-old" };',
+            'const log = "GET /api/v1/attachment?password=secret&guid=socket-secret&token=api-token";',
+            'expect(resolveSecret()).toBe("resolved-top-level-secret");',
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).not.toContain("suspicious.exposed_secret_literal");
+    expect(result.status).toBe("clean");
+  });
+
   it("does not flag placeholder or env-var secret examples", () => {
     const result = runStaticModerationScan({
       slug: "demo",
@@ -197,6 +363,130 @@ describe("moderationEngine", () => {
 
     expect(result.reasonCodes).not.toContain("suspicious.exposed_secret_literal");
     expect(result.status).toBe("clean");
+  });
+
+  it("does not flag credential field plumbing as hardcoded secrets", () => {
+    const result = runStaticModerationScan({
+      slug: "matrix",
+      displayName: "Matrix",
+      summary: "Matrix channel integration",
+      frontmatter: {},
+      metadata: {},
+      files: [
+        { path: "src/matrix/sdk/http-client.ts", size: 256 },
+        { path: "src/config-schema.ts", size: 256 },
+        { path: "src/engine/config/setup-logic.ts", size: 256 },
+      ],
+      fileContents: [
+        {
+          path: "src/matrix/sdk/http-client.ts",
+          content: [
+            "constructor(params: MatrixAuthedHttpClientParams) {",
+            "  this.homeserver = params.homeserver;",
+            "  this.accessToken = params.accessToken;",
+            "}",
+          ].join("\n"),
+        },
+        {
+          path: "src/config-schema.ts",
+          content: [
+            "export const configSchema = z.object({",
+            "  accessToken: buildSecretInputSchema().optional(),",
+            "  clientSecret: buildSecretInputSchema().optional(),",
+            "});",
+          ].join("\n"),
+        },
+        {
+          path: "src/engine/config/setup-logic.ts",
+          content: [
+            "const clientSecret = params.input.clientSecret?.trim();",
+            "return clientSecret ? { clientSecret, clientSecretFile: undefined } : undefined;",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).not.toContain("suspicious.exposed_secret_literal");
+    expect(result.status).toBe("clean");
+  });
+
+  it("does not flag hardcoded-looking credential fixtures in tests", () => {
+    const result = runStaticModerationScan({
+      slug: "qqbot",
+      displayName: "QQ Bot",
+      summary: "QQ Bot channel integration",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/config.test.ts", size: 256 }],
+      fileContents: [
+        {
+          path: "src/config.test.ts",
+          content: [
+            "const next = setup.applyAccountConfig?.({",
+            "  input: {",
+            '    token: "102905186:Oi2Mg1Mh2Ni3:Pl7TpBXuHe1OmAYwKi7W",',
+            "  },",
+            "});",
+            "const accountConfig = readAccountConfig(next);",
+            "expect(accountConfig).toStrictEqual({",
+            '  appId: "102905186",',
+            '  clientSecret: "Oi2Mg1Mh2Ni3:Pl7TpBXuHe1OmAYwKi7W",',
+            "});",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).not.toContain("suspicious.exposed_secret_literal");
+    expect(result.status).toBe("clean");
+  });
+
+  it("still flags known-prefix secrets in test files", () => {
+    const result = runStaticModerationScan({
+      slug: "test-secret",
+      displayName: "Test Secret",
+      summary: "Test fixture with a real key",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/config.test.ts", size: 256 }],
+      fileContents: [
+        {
+          path: "src/config.test.ts",
+          content: [
+            "expect(accountConfig).toStrictEqual({",
+            '  apiKey: "sk_live_1234567890abcdefSECRET",',
+            "});",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.exposed_secret_literal");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags generic hardcoded secrets in test expectations", () => {
+    const result = runStaticModerationScan({
+      slug: "test-secret",
+      displayName: "Test Secret",
+      summary: "Test fixture with a real key",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/config.test.ts", size: 256 }],
+      fileContents: [
+        {
+          path: "src/config.test.ts",
+          content: [
+            "expect(accountConfig).toStrictEqual({",
+            '  clientSecret: "AbCdEfGhIjKl1234567890",',
+            "});",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.exposed_secret_literal");
+    expect(result.status).toBe("suspicious");
   });
 
   it("flags instructions that persist credential variables into git remotes or memory", () => {
@@ -424,6 +714,142 @@ describe("moderationEngine", () => {
     expect(result.status).toBe("suspicious");
   });
 
+  it("does not treat RegExp exec as child process execution", () => {
+    const result = runStaticModerationScan({
+      slug: "bluebubbles",
+      displayName: "BlueBubbles",
+      summary: "BlueBubbles channel integration",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/monitor-reply-fetch.ts", size: 256 }],
+      fileContents: [
+        {
+          path: "src/monitor-reply-fetch.ts",
+          content: [
+            'import { execFile } from "node:child_process";',
+            "const execFileAsync = promisify(execFile);",
+            "const match = PART_INDEX_REPLY_TO_ID_PATTERN.exec(trimmed);",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).not.toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("clean");
+  });
+
+  it("still flags child_process namespace exec calls", () => {
+    const result = runStaticModerationScan({
+      slug: "namespace-exec",
+      displayName: "Namespace Exec",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "scripts/run.js", size: 256 }],
+      fileContents: [
+        {
+          path: "scripts/run.js",
+          content: [
+            'const childProcess = require("node:child_process");',
+            "childProcess.exec(userCommand);",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags child_process aliases loaded through module name variables", () => {
+    const result = runStaticModerationScan({
+      slug: "dynamic-namespace-exec",
+      displayName: "Dynamic Namespace Exec",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "scripts/run.js", size: 256 }],
+      fileContents: [
+        {
+          path: "scripts/run.js",
+          content: [
+            'const moduleName = "node:child_process";',
+            "const childProcess = require(moduleName);",
+            "childProcess.exec(userCommand);",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags optional-chained child_process namespace exec calls", () => {
+    const result = runStaticModerationScan({
+      slug: "optional-namespace-exec",
+      displayName: "Optional Namespace Exec",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "scripts/run.js", size: 256 }],
+      fileContents: [
+        {
+          path: "scripts/run.js",
+          content: [
+            'const childProcess = require("node:child_process");',
+            "childProcess?.exec(userCommand);",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags optional-chained direct child_process require exec calls", () => {
+    const result = runStaticModerationScan({
+      slug: "optional-direct-require-exec",
+      displayName: "Optional Direct Require Exec",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "scripts/run.js", size: 256 }],
+      fileContents: [
+        {
+          path: "scripts/run.js",
+          content: 'require("node:child_process")?.exec(userCommand);',
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags TypeScript import-equals child_process namespace exec calls", () => {
+    const result = runStaticModerationScan({
+      slug: "import-equals-namespace-exec",
+      displayName: "Import Equals Namespace Exec",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "scripts/run.ts", size: 256 }],
+      fileContents: [
+        {
+          path: "scripts/run.ts",
+          content: ['import cp = require("node:child_process");', "cp.exec(userCommand);"].join(
+            "\n",
+          ),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
   it("flags install scripts that patch host platform source and rebuild it", () => {
     const result = runStaticModerationScan({
       slug: "shell-security-ultimate",
@@ -474,6 +900,1249 @@ describe("moderationEngine", () => {
 
     expect(result.reasonCodes).not.toContain("suspicious.dangerous_exec");
     expect(result.status).toBe("clean");
+  });
+
+  it("does not flag bounded fixed-argv spawn helpers as dangerous exec", () => {
+    const result = runStaticModerationScan({
+      slug: "matrix",
+      displayName: "Matrix",
+      summary: "Matrix channel integration",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/matrix/deps.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/matrix/deps.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const [command, ...args] = params.argv;",
+            "  const proc = spawn(command, args, {",
+            "    cwd: params.cwd,",
+            "    stdio: ['ignore', 'pipe', 'pipe'],",
+            "  });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime(params: {",
+            "  runCommand?: typeof runFixedCommandWithTimeout;",
+            "}) {",
+            "  const nodeExecutable = process.execPath;",
+            '  const scriptPath = resolveFn("@matrix-org/matrix-sdk-crypto-nodejs/download-lib.js");',
+            "  const runCommand = params.runCommand ?? runFixedCommandWithTimeout;",
+            "  await runCommand({",
+            "    argv: [nodeExecutable, scriptPath],",
+            "    cwd: path.dirname(scriptPath),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).not.toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("clean");
+  });
+
+  it("does not flag fixed-argv helpers that update unrelated arrays before spawning", () => {
+    const result = runStaticModerationScan({
+      slug: "fixed-wrapper-logs",
+      displayName: "Fixed Wrapper Logs",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/run.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const logs: string[] = [];",
+            "  const [command, ...args] = params.argv;",
+            '  logs.push("starting");',
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer, logs);",
+            "}",
+            "async function ensureRuntime() {",
+            "  await runFixedCommandWithTimeout({",
+            '    argv: [process.execPath, "./download-lib.js"],',
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).not.toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("clean");
+  });
+
+  it("does not flag fixed-argv helpers that read args before spawning", () => {
+    const result = runStaticModerationScan({
+      slug: "fixed-wrapper-args-read",
+      displayName: "Fixed Wrapper Args Read",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/run.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const [command, ...args] = params.argv;",
+            "  if (args.length === 0) {",
+            "    throw new Error('command args are required');",
+            "  }",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  await runFixedCommandWithTimeout({",
+            '    argv: [process.execPath, "./download-lib.js"],',
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).not.toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("clean");
+  });
+
+  it("does not flag fixed-argv helpers that alias params.argv before spawning", () => {
+    const result = runStaticModerationScan({
+      slug: "fixed-wrapper-argv-alias",
+      displayName: "Fixed Wrapper Argv Alias",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/run.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const argv = params.argv;",
+            "  const [command, ...args] = argv;",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  await runFixedCommandWithTimeout({",
+            '    argv: [process.execPath, "./download-lib.js"],',
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).not.toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("clean");
+  });
+
+  it("does not flag fixed-argv helpers that destructure params.argv before spawning", () => {
+    const result = runStaticModerationScan({
+      slug: "fixed-wrapper-argv-destructuring",
+      displayName: "Fixed Wrapper Argv Destructuring",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/run.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const { argv } = params;",
+            "  const [command, ...args] = argv;",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  await runFixedCommandWithTimeout({",
+            '    argv: [process.execPath, "./download-lib.js"],',
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).not.toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("clean");
+  });
+
+  it("still flags fixed-argv helpers that execute shells", () => {
+    const result = runStaticModerationScan({
+      slug: "shell-wrapper",
+      displayName: "Shell Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/run.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const [command, ...args] = params.argv;",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function runShell() {",
+            "  await runFixedCommandWithTimeout({",
+            '    argv: ["bash", "-c", "echo unsafe"],',
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("flags fixed-argv helpers when the matching spawn call follows an args mutation", () => {
+    const result = runStaticModerationScan({
+      slug: "duplicate-spawn-wrapper",
+      displayName: "Duplicate Spawn Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/run.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const [command, ...args] = params.argv;",
+            "  const first = spawn(command, args, { cwd: params.cwd });",
+            "  args.push(params.cwd);",
+            "  const second = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => second.kill('SIGTERM'), params.timeoutMs);",
+            "  first.kill('SIGTERM');",
+            "  return await waitForExit(second, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  await runFixedCommandWithTimeout({",
+            '    argv: [process.execPath, "./download-lib.js"],',
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags fixed-argv helpers that use mutable argv destructuring", () => {
+    const result = runStaticModerationScan({
+      slug: "mutable-wrapper",
+      displayName: "Mutable Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/run.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  let [command, ...args] = params.argv;",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  await runFixedCommandWithTimeout({",
+            '    argv: [process.execPath, "./download-lib.js"],',
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags fixed-argv helpers that mutate args before spawning", () => {
+    const result = runStaticModerationScan({
+      slug: "mutating-wrapper",
+      displayName: "Mutating Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/run.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const [command, ...args] = params.argv;",
+            "  args.push(params.cwd);",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  await runFixedCommandWithTimeout({",
+            '    argv: [process.execPath, "./download-lib.js"],',
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags fixed-argv helpers that call bracketed args mutators before spawning", () => {
+    const result = runStaticModerationScan({
+      slug: "bracket-mutating-wrapper",
+      displayName: "Bracket Mutating Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/run.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const [command, ...args] = params.argv;",
+            "  args['push']?.(params.cwd);",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  await runFixedCommandWithTimeout({",
+            '    argv: [process.execPath, "./download-lib.js"],',
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags fixed-argv helpers that use compound args assignment before spawning", () => {
+    const result = runStaticModerationScan({
+      slug: "compound-mutating-wrapper",
+      displayName: "Compound Mutating Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/run.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const [command, ...args] = params.argv;",
+            "  args[0] ||= params.cwd;",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  await runFixedCommandWithTimeout({",
+            '    argv: [process.execPath, "./download-lib.js"],',
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags fixed-argv helpers that mutate args through indirect array APIs", () => {
+    const result = runStaticModerationScan({
+      slug: "indirect-mutating-wrapper",
+      displayName: "Indirect Mutating Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/run.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const [command, ...args] = params.argv;",
+            '  Object.assign(args, ["-e", params.cwd]);',
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  await runFixedCommandWithTimeout({",
+            '    argv: [process.execPath, "./download-lib.js"],',
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags fixed-argv helpers that mutate params.argv before spawning", () => {
+    const result = runStaticModerationScan({
+      slug: "mutating-params-wrapper",
+      displayName: "Mutating Params Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/run.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  params.argv.push(params.cwd);",
+            "  const [command, ...args] = params.argv;",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  await runFixedCommandWithTimeout({",
+            '    argv: [process.execPath, "./download-lib.js"],',
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags fixed-argv helpers that mutate bare argv before spawning", () => {
+    const result = runStaticModerationScan({
+      slug: "mutating-bare-argv-wrapper",
+      displayName: "Mutating Bare Argv Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/run.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const { argv } = params;",
+            "  argv.push(params.cwd);",
+            "  const [command, ...args] = argv;",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  await runFixedCommandWithTimeout({",
+            '    argv: [process.execPath, "./download-lib.js"],',
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags fixed-argv helpers that mutate destructured argv before spawning", () => {
+    const result = runStaticModerationScan({
+      slug: "mutating-destructured-argv-wrapper",
+      displayName: "Mutating Destructured Argv Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/run.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const { argv } = params;",
+            "  argv.push(params.cwd);",
+            "  const [command, ...args] = params.argv;",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  await runFixedCommandWithTimeout({",
+            '    argv: [process.execPath, "./download-lib.js"],',
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags nested dynamic child process calls inside fixed-argv helpers", () => {
+    const result = runStaticModerationScan({
+      slug: "nested-dynamic-wrapper",
+      displayName: "Nested Dynamic Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/run.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const [command, ...args] = params.argv;",
+            "  function runUserCommand(command: string, args: string[]) {",
+            "    return spawn(command, args, { cwd: params.cwd });",
+            "  }",
+            "  return runUserCommand(command, args);",
+            "}",
+            "async function ensureRuntime() {",
+            "  await runFixedCommandWithTimeout({",
+            '    argv: [process.execPath, "./download-lib.js"],',
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags fixed-argv helpers that mutate args through an alias", () => {
+    const result = runStaticModerationScan({
+      slug: "mutating-alias-wrapper",
+      displayName: "Mutating Alias Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/run.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const [command, ...args] = params.argv;",
+            "  const mutableArgs = args;",
+            "  mutableArgs.push(params.cwd);",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  await runFixedCommandWithTimeout({",
+            '    argv: [process.execPath, "./download-lib.js"],',
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags fixed-argv helpers that mutate args through a typed alias", () => {
+    const result = runStaticModerationScan({
+      slug: "mutating-typed-alias-wrapper",
+      displayName: "Mutating Typed Alias Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/run.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const [command, ...args] = params.argv;",
+            "  const mutableArgs: string[] = args;",
+            "  mutableArgs.push(params.cwd);",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  await runFixedCommandWithTimeout({",
+            '    argv: [process.execPath, "./download-lib.js"],',
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags dynamic argv wrappers as dangerous exec", () => {
+    const result = runStaticModerationScan({
+      slug: "dynamic-wrapper",
+      displayName: "Dynamic Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/run.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const [command, ...args] = params.argv;",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "export async function runUserCommand(params: { argv: string[] }) {",
+            "  return await runFixedCommandWithTimeout({",
+            "    argv: params.argv,",
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags renamed dynamic argv items as dangerous exec", () => {
+    const result = runStaticModerationScan({
+      slug: "renamed-dynamic-wrapper",
+      displayName: "Renamed Dynamic Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/run.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const [command, ...args] = params.argv;",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "export async function runUserCommand(request: { binary: string; flags: string }) {",
+            "  const bin = request.binary;",
+            "  const flags = request.flags;",
+            "  return await runFixedCommandWithTimeout({",
+            "    argv: [bin, flags],",
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags cross-file dynamic argv callers for exported helpers", () => {
+    const result = runStaticModerationScan({
+      slug: "cross-file-wrapper",
+      displayName: "Cross File Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [
+        { path: "src/run.ts", size: 1024 },
+        { path: "src/caller.ts", size: 512 },
+      ],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const [command, ...args] = params.argv;",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  const nodeExecutable = process.execPath;",
+            '  const scriptPath = resolveFn("@matrix-org/matrix-sdk-crypto-nodejs/download-lib.js");',
+            "  await runFixedCommandWithTimeout({",
+            "    argv: [nodeExecutable, scriptPath],",
+            "    cwd: path.dirname(scriptPath),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+        {
+          path: "src/caller.ts",
+          content: [
+            'import { runFixedCommandWithTimeout } from "./run";',
+            "export async function runUserCommand(request: { binary: string; flags: string }) {",
+            "  const bin = request.binary;",
+            "  const flags = request.flags;",
+            "  return await runFixedCommandWithTimeout({",
+            "    argv: [bin, flags],",
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags namespace dynamic argv callers for exported helpers", () => {
+    const result = runStaticModerationScan({
+      slug: "namespace-wrapper",
+      displayName: "Namespace Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [
+        { path: "src/run.ts", size: 1024 },
+        { path: "src/caller.ts", size: 512 },
+      ],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const [command, ...args] = params.argv;",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  const nodeExecutable = process.execPath;",
+            '  const scriptPath = resolveFn("@matrix-org/matrix-sdk-crypto-nodejs/download-lib.js");',
+            "  await runFixedCommandWithTimeout({",
+            "    argv: [nodeExecutable, scriptPath],",
+            "    cwd: path.dirname(scriptPath),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+        {
+          path: "src/caller.ts",
+          content: [
+            'import * as run from "./run";',
+            "export async function runUserCommand(request: { argv: string[] }) {",
+            "  return await run.runFixedCommandWithTimeout({",
+            "    argv: request.argv,",
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("does not reuse fixed argv assignments from other files", () => {
+    const result = runStaticModerationScan({
+      slug: "cross-file-shadowed-wrapper",
+      displayName: "Cross File Shadowed Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [
+        { path: "src/run.ts", size: 1024 },
+        { path: "src/caller.ts", size: 512 },
+      ],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const [command, ...args] = params.argv;",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  const nodeExecutable = process.execPath;",
+            '  const scriptPath = resolveFn("@matrix-org/matrix-sdk-crypto-nodejs/download-lib.js");',
+            "  await runFixedCommandWithTimeout({",
+            "    argv: [nodeExecutable, scriptPath],",
+            "    cwd: path.dirname(scriptPath),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+        {
+          path: "src/caller.ts",
+          content: [
+            'import { runFixedCommandWithTimeout } from "./run";',
+            "export async function runUserCommand(request: { scriptPath: string }) {",
+            "  const nodeExecutable = process.execPath;",
+            "  const scriptPath = request.scriptPath;",
+            "  return await runFixedCommandWithTimeout({",
+            "    argv: [nodeExecutable, scriptPath],",
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("does not reuse fixed argv assignments from another function in the same file", () => {
+    const result = runStaticModerationScan({
+      slug: "same-file-shadowed-wrapper",
+      displayName: "Same File Shadowed Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/run.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const [command, ...args] = params.argv;",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  const nodeExecutable = process.execPath;",
+            '  const scriptPath = resolveFn("@matrix-org/matrix-sdk-crypto-nodejs/download-lib.js");',
+            "  await runFixedCommandWithTimeout({",
+            "    argv: [nodeExecutable, scriptPath],",
+            "    cwd: path.dirname(scriptPath),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+            "export async function runUserCommand(request: { scriptPath: string }) {",
+            "  const nodeExecutable = process.execPath;",
+            "  const scriptPath = request.scriptPath;",
+            "  return await runFixedCommandWithTimeout({",
+            "    argv: [nodeExecutable, scriptPath],",
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags imported alias dynamic argv callers", () => {
+    const result = runStaticModerationScan({
+      slug: "import-alias-wrapper",
+      displayName: "Import Alias Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [
+        { path: "src/run.ts", size: 1024 },
+        { path: "src/caller.ts", size: 512 },
+      ],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const [command, ...args] = params.argv;",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  const nodeExecutable = process.execPath;",
+            '  const scriptPath = resolveFn("@matrix-org/matrix-sdk-crypto-nodejs/download-lib.js");',
+            "  await runFixedCommandWithTimeout({",
+            "    argv: [nodeExecutable, scriptPath],",
+            "    cwd: path.dirname(scriptPath),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+        {
+          path: "src/caller.ts",
+          content: [
+            'import { runFixedCommandWithTimeout as runCommand } from "./run";',
+            "export async function runUserCommand(params: { argv: string[] }) {",
+            "  return await runCommand({",
+            "    argv: params.argv,",
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags CommonJS alias dynamic argv callers", () => {
+    const result = runStaticModerationScan({
+      slug: "cjs-alias-wrapper",
+      displayName: "CJS Alias Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [
+        { path: "src/run.ts", size: 1024 },
+        { path: "src/caller.ts", size: 512 },
+      ],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const [command, ...args] = params.argv;",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  const nodeExecutable = process.execPath;",
+            '  const scriptPath = resolveFn("@matrix-org/matrix-sdk-crypto-nodejs/download-lib.js");',
+            "  await runFixedCommandWithTimeout({",
+            "    argv: [nodeExecutable, scriptPath],",
+            "    cwd: path.dirname(scriptPath),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+        {
+          path: "src/caller.ts",
+          content: [
+            'const { runFixedCommandWithTimeout: runCommand } = require("./run");',
+            "export async function runUserCommand(params: { argv: string[] }) {",
+            "  return await runCommand({",
+            "    argv: params.argv,",
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags exported fixed-argv helpers that are re-exported from runtime files", () => {
+    const result = runStaticModerationScan({
+      slug: "reexported-wrapper",
+      displayName: "Re-exported Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [
+        { path: "src/run.ts", size: 1024 },
+        { path: "src/index.ts", size: 128 },
+      ],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const [command, ...args] = params.argv;",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  await runFixedCommandWithTimeout({",
+            '    argv: [process.execPath, "./download-lib.js"],',
+            "    cwd: process.cwd(),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+          ].join("\n"),
+        },
+        {
+          path: "src/index.ts",
+          content: 'export { runFixedCommandWithTimeout } from "./run.js";',
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
+  });
+
+  it("still flags unrelated dynamic child process calls beside a safe fixed-argv helper", () => {
+    const result = runStaticModerationScan({
+      slug: "mixed-wrapper",
+      displayName: "Mixed Wrapper",
+      summary: "Runs helper commands",
+      frontmatter: {},
+      metadata: {},
+      files: [{ path: "src/run.ts", size: 1024 }],
+      fileContents: [
+        {
+          path: "src/run.ts",
+          content: [
+            'import { spawn } from "node:child_process";',
+            "export async function runFixedCommandWithTimeout(params: {",
+            "  argv: string[];",
+            "  cwd: string;",
+            "  timeoutMs: number;",
+            "}) {",
+            "  const [command, ...args] = params.argv;",
+            "  const proc = spawn(command, args, { cwd: params.cwd });",
+            "  const timer = setTimeout(() => proc.kill('SIGTERM'), params.timeoutMs);",
+            "  return await waitForExit(proc, timer);",
+            "}",
+            "async function ensureRuntime() {",
+            "  const nodeExecutable = process.execPath;",
+            "  const scriptPath = resolveDownloadScript();",
+            "  await runFixedCommandWithTimeout({",
+            "    argv: [nodeExecutable, scriptPath],",
+            "    cwd: path.dirname(scriptPath),",
+            "    timeoutMs: 300_000,",
+            "  });",
+            "}",
+            "export function runUserCommand(command: string, args: string[]) {",
+            "  return spawn(command, args);",
+            "}",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    expect(result.reasonCodes).toContain("suspicious.dangerous_exec");
+    expect(result.status).toBe("suspicious");
   });
 
   it("still flags execFileSync when shell mode is enabled", () => {

--- a/convex/lib/moderationEngine.ts
+++ b/convex/lib/moderationEngine.ts
@@ -94,10 +94,14 @@ const GOOGLE_SHEETS_SPREADSHEET_URL_PATTERN =
   /https?:\/\/[^\s"'`]*\/spreadsheets\/([A-Za-z0-9_-]{20,})\/[^\s"'`]*/i;
 const DESTRUCTIVE_DELETE_PATTERN =
   /\brm\s+-[A-Za-z]*r[A-Za-z]*f[A-Za-z]*\s+(["']?)(\/root\/\.openclaw\/|\/home\/[^/\s"'`]+\/\.openclaw\/|\/Users\/[^/\s"'`]+\/\.openclaw\/|~\/\.openclaw\/|\$HOME\/\.openclaw\/|\$\{HOME\}\/\.openclaw\/|\/etc\/|\/usr\/|\/opt\/|\/Library\/|\/Applications\/)[^\s"'`;|&)]*\1/i;
-const SECRET_ASSIGNMENT_PATTERN =
-  /\b(?:[A-Za-z0-9]+[_\s-]+)*(?:(?:api|client|consumer)[_\s-]?(?:secret|key|token)|secret[_\s-]?key|access[_\s-]?(?:token|key|secret|grant)|auth[_\s-]?token|bearer(?:[_\s-]?token)?|private[_\s-]?key|service[_\s-]?role[_\s-]?key|github[_\s-]?(?:pat|token)|(?:openrouter|supabase|storj)[_\s-]?(?:key|token|secret|access[_\s-]?grant)|password)\b\s*[:=]\s*["'`]?([A-Za-z0-9][A-Za-z0-9._~+/=-]{15,})["'`]?/i;
+const SECRET_FIELD_PATTERN_SOURCE = String.raw`(?:[A-Za-z0-9]+[_\s-]+)*(?:(?:api|client|consumer)[_\s-]?(?:secret|key|token)|secret[_\s-]?key|access[_\s-]?(?:token|key|secret|grant)|auth[_\s-]?token|bearer(?:[_\s-]?token)?|private[_\s-]?key|service[_\s-]?role[_\s-]?key|github[_\s-]?(?:pat|token)|(?:openrouter|supabase|storj)[_\s-]?(?:key|token|secret|access[_\s-]?grant)|password)`;
+const SECRET_ASSIGNMENT_PATTERN = new RegExp(
+  String.raw`\b${SECRET_FIELD_PATTERN_SOURCE}\b\s*[:=]\s*(.+)$`,
+  "i",
+);
 const AUTH_HEADER_SECRET_PATTERN =
-  /\b(?:authorization|x-api-key|x-api-secret)\b\s*[:=]\s*(?:Bearer\s+)?["'`]?([A-Za-z0-9][A-Za-z0-9._~+/=-]{15,})["'`]?/i;
+  /\b(?:authorization|x-api-key|x-api-secret)\b\s*[:=]\s*(?:Bearer\s+)?(?:(["'`])([^"'`]{15,})\1|([A-Za-z0-9][A-Za-z0-9._~+/=-]{15,}))/i;
+const KNOWN_SECRET_PREFIX_PATTERN = /^(?:sk[-_]|ak[-_]|pk[-_]|gh[opsu]_|xox[baprs]-|ya29\.|eyJ)/;
 const SHELL_CREDENTIAL_VARIABLE_PATTERN =
   /\$(?:\{)?[A-Z_][A-Z0-9_]*(?:TOKEN|PAT|SECRET|KEY)[A-Z0-9_]*(?:\})?/;
 const GIT_REMOTE_CREDENTIAL_URL_PATTERN =
@@ -214,18 +218,141 @@ function looksLikePlaceholderSecret(secret: string) {
   if (!normalized) return true;
   if (/^(?:x+|_+|-+|\*+|\.{3})$/.test(normalized)) return true;
   if (/process\.env\.|os\.environ[.[]|getenv\s*\(/.test(normalized)) return true;
+  if (normalized.startsWith("secretref:")) return true;
   return /(your|example|placeholder|change-?me|replace|redacted|dummy|sample|test-token|token-here|secret-here|api-key-here)/i.test(
     normalized,
   );
 }
 
-function findHardcodedSecret(content: string) {
+function readSecretCandidate(value: string): { secret: string; quoted: boolean } | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const quote = trimmed[0];
+  if (quote === '"' || quote === "'" || quote === "`") {
+    let escaped = false;
+    for (let i = 1; i < trimmed.length; i += 1) {
+      const char = trimmed[i];
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (char === quote) return { secret: trimmed.slice(1, i), quoted: true };
+    }
+    return null;
+  }
+
+  const token = trimmed.match(/^[^\s,;#)"'`]+/)?.[0];
+  return token ? { secret: token, quoted: false } : null;
+}
+
+function looksLikeCodeSecretReference(path: string, secret: string, quoted: boolean) {
+  if (/[$}{]/.test(secret)) return true;
+  if (quoted) return false;
+  if (/^(?:process\.env|os\.environ|os\.getenv|getenv)\b/.test(secret)) return true;
+  if (CODE_EXTENSION.test(path)) {
+    if (/^[A-Za-z_$][\w$]*\??\./.test(secret)) return true;
+    if (/^[A-Za-z_$][\w$]*\s*\(/.test(secret)) return true;
+    if (/^[A-Za-z_$][\w$]*$/.test(secret)) return true;
+  }
+  return false;
+}
+
+function looksLikeHardcodedSecret(path: string, secret: string, quoted: boolean) {
+  if (secret.length < 16) return false;
+  const hasKnownSecretPrefix = KNOWN_SECRET_PREFIX_PATTERN.test(secret);
+  if (hasKnownSecretPrefix) return true;
+  if (looksLikePlaceholderSecret(secret)) return false;
+  if (looksLikeCodeSecretReference(path, secret, quoted)) return false;
+
+  const hasLetter = /[A-Za-z]/.test(secret);
+  const hasLongNumericCredential = /\d{16,}/.test(secret);
+  return hasKnownSecretPrefix || hasLetter || hasLongNumericCredential;
+}
+
+function findSecretAssignmentMatch(path: string, line: string) {
+  const authMatch = line.match(AUTH_HEADER_SECRET_PATTERN);
+  const authSecret = authMatch?.[2] ?? authMatch?.[3];
+  if (authSecret && looksLikeHardcodedSecret(path, authSecret, Boolean(authMatch?.[2]))) {
+    return authSecret;
+  }
+
+  const assignmentMatch = line.match(SECRET_ASSIGNMENT_PATTERN);
+  const candidate = assignmentMatch?.[1] ? readSecretCandidate(assignmentMatch[1]) : null;
+  if (!candidate) return null;
+  return looksLikeHardcodedSecret(path, candidate.secret, candidate.quoted)
+    ? candidate.secret
+    : null;
+}
+
+function isTestFixtureFile(path: string) {
+  return /(?:^|\/)(?:__tests__|fixtures?)\/|(?:\.test|\.spec)\.[^/]+$/i.test(path);
+}
+
+function isAllowedTestFixtureSecret(
+  path: string,
+  lines: string[],
+  lineIndex: number,
+  secret: string,
+) {
+  if (!isTestFixtureFile(path)) return false;
+  if (KNOWN_SECRET_PREFIX_PATTERN.test(secret)) return false;
+  if (looksLikeNamedTestFixtureSecret(secret)) return true;
+  const context = lines.slice(Math.max(0, lineIndex - 20), lineIndex + 3).join("\n");
+  const escapedSecret = secret.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const parsedFromColonDelimitedToken = new RegExp(
+    String.raw`\btoken\s*:\s*(["'])[^"'\n:]{1,80}:${escapedSecret}\1`,
+  ).test(context);
+  return (
+    parsedFromColonDelimitedToken && /\bexpect\b[\s\S]{0,500}\btoStrictEqual\s*\(/.test(context)
+  );
+}
+
+function looksLikeNamedTestFixtureSecret(secret: string) {
+  const normalized = secret.trim().toLowerCase();
+  if (normalized !== secret.trim()) return false;
+  if (/\d/.test(normalized)) return false;
+  const parts = normalized.split(/[-_:/&=]+/).filter(Boolean);
+  if (parts.length < 2) return false;
+  const fixtureWords = new Set([
+    "api",
+    "guid",
+    "inline",
+    "legacy",
+    "level",
+    "my",
+    "new",
+    "old",
+    "ops",
+    "password",
+    "react",
+    "recreated",
+    "regression",
+    "resolved",
+    "secret",
+    "socket",
+    "stale",
+    "super",
+    "token",
+    "top",
+  ]);
+  const credentialWords = new Set(["api", "password", "secret", "token"]);
+  return (
+    parts.every((part) => fixtureWords.has(part)) && parts.some((part) => credentialWords.has(part))
+  );
+}
+
+function findHardcodedSecret(path: string, content: string) {
   const lines = content.split("\n");
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i];
-    const match = line.match(SECRET_ASSIGNMENT_PATTERN) ?? line.match(AUTH_HEADER_SECRET_PATTERN);
-    const secret = match?.[1];
-    if (!secret || looksLikePlaceholderSecret(secret)) continue;
+    const secret = findSecretAssignmentMatch(path, line);
+    if (!secret) continue;
+    if (isAllowedTestFixtureSecret(path, lines, i, secret)) continue;
     return {
       line: i + 1,
       text: line.replaceAll(secret, "[REDACTED]"),
@@ -280,7 +407,7 @@ function findHostPlatformSourcePatch(content: string) {
 }
 
 function scanSecretLiteralFile(path: string, content: string, findings: ModerationFinding[]) {
-  const secretMatch = findHardcodedSecret(content);
+  const secretMatch = findHardcodedSecret(path, content);
   if (!secretMatch) return;
 
   addFinding(findings, {
@@ -430,14 +557,428 @@ function isSafeLiteralChildProcessCall(callName: string, callText: string) {
   return !/^(?:sh|bash|zsh|fish|cmd|powershell|pwsh)$/.test(basename);
 }
 
-function findDangerousChildProcessCall(content: string) {
+function isSafeFixedArgvChildProcessCall(
+  callName: string,
+  callText: string,
+  helperContext: string,
+  helperCallIndex: number,
+  runtimeFiles: TextFile[],
+  helperFilePath: string,
+) {
+  if (!["execFile", "execFileSync", "spawn", "spawnSync"].includes(callName)) return false;
+  if (/\bshell\s*:\s*true\b/.test(callText)) return false;
+  if (!new RegExp(String.raw`\b${callName}\s*\(\s*command\s*,\s*args\s*,`).test(callText)) {
+    return false;
+  }
+
+  const fixedArgvDestructuring = findFixedArgvDestructuring(helperContext);
+  return (
+    /\brunFixedCommandWithTimeout\b/.test(helperContext) &&
+    fixedArgvDestructuring !== null &&
+    !mutatesFixedArgvBeforeChildProcessCall(
+      helperContext,
+      helperCallIndex,
+      fixedArgvDestructuring,
+    ) &&
+    /\b(?:timeoutMs|setTimeout)\b/.test(helperContext) &&
+    !hasRuntimeReExportOfRunFixedCommandHelper(runtimeFiles, helperFilePath) &&
+    hasOnlyFixedRunCommandArgvCallSites(runtimeFiles)
+  );
+}
+
+function findFixedArgvDestructuring(helperContext: string) {
+  const match = /\bconst\s+\[\s*command\s*,\s*\.\.\.\s*args\s*\]\s*=\s*(params\.argv|argv)/.exec(
+    helperContext,
+  );
+  if (match?.index === undefined) return null;
+  return {
+    source: match[1] ?? "params.argv",
+    start: match.index,
+    end: match.index + match[0].length,
+  };
+}
+
+function mutatesFixedArgvBeforeChildProcessCall(
+  helperContext: string,
+  helperCallIndex: number,
+  fixedArgvDestructuring: { source: string; start: number; end: number },
+) {
+  if (
+    helperCallIndex < 0 ||
+    helperCallIndex > helperContext.length ||
+    fixedArgvDestructuring.end > helperCallIndex ||
+    fixedArgvDestructuring.start < findInnermostBlockStart(helperContext, helperCallIndex)
+  ) {
+    return true;
+  }
+
+  const beforeDestructuring = helperContext.slice(0, fixedArgvDestructuring.start);
+  const betweenDestructuringAndCall = helperContext.slice(
+    fixedArgvDestructuring.end,
+    helperCallIndex,
+  );
+  const beforeArgvRefs = findFixedArgvMutableReferences(
+    beforeDestructuring,
+    new Set(["params.argv"]),
+  );
+  if (!beforeArgvRefs.has(fixedArgvDestructuring.source)) return true;
+
+  return (
+    hasStandaloneAssignment(betweenDestructuringAndCall, "command") ||
+    hasFixedArgvMutationInRefs(beforeDestructuring, beforeArgvRefs) ||
+    hasFixedArgvMutations(betweenDestructuringAndCall, new Set(["args"]))
+  );
+}
+
+function hasFixedArgvMutations(prefix: string, initialRefs: Set<string>) {
+  const argvRefs = findFixedArgvMutableReferences(prefix, initialRefs);
+  return hasFixedArgvMutationInRefs(prefix, argvRefs);
+}
+
+function hasFixedArgvMutationInRefs(prefix: string, argvRefs: Set<string>) {
+  return [...argvRefs].some((ref) => hasFixedArgvMutation(prefix, ref));
+}
+
+function findFixedArgvMutableReferences(prefix: string, initialRefs: Set<string>) {
+  const refs = new Set(initialRefs);
+  if (refs.has("params.argv")) {
+    for (const match of prefix.matchAll(
+      /\b(?:const|let|var)\s*\{([^}]+)\}\s*=\s*params\s*(?:[;\n]|$)/g,
+    )) {
+      for (const property of (match[1] ?? "").split(",")) {
+        const aliasMatch = property.match(/^\s*argv\s*(?::\s*([A-Za-z_$][\w$]*))?(?:\s*=.+)?\s*$/);
+        if (!aliasMatch) continue;
+        refs.add(aliasMatch[1] ?? "argv");
+      }
+    }
+  }
+  const aliasPattern =
+    /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)(?:\s*:\s*[^=;\n]+)?\s*=\s*([A-Za-z_$][\w$]*|params\.argv)\s*(?:[;\n]|$)/g;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const match of prefix.matchAll(aliasPattern)) {
+      const [, alias, source] = match;
+      if (!alias || !source || refs.has(alias) || !refs.has(source)) continue;
+      refs.add(alias);
+      changed = true;
+    }
+  }
+  return refs;
+}
+
+function hasFixedArgvMutation(prefix: string, ref: string) {
+  const refPattern = buildFixedArgvReferencePattern(ref);
+  return (
+    hasStandaloneAssignment(prefix, ref) ||
+    new RegExp(String.raw`\bdelete\s+${refPattern}\s*(?:\.|\[)`).test(prefix) ||
+    new RegExp(
+      String.raw`${refPattern}\s*(?:\[[^\]]+\]|\.\s*[A-Za-z_$][\w$]*)\s*${ASSIGNMENT_OPERATOR_PATTERN}`,
+    ).test(prefix) ||
+    new RegExp(
+      String.raw`${refPattern}\s*(?:\?\.\s*|\.\s*)${MUTATING_ARRAY_METHOD_PATTERN}\s*(?:\?\.)?\s*\(`,
+    ).test(prefix) ||
+    new RegExp(
+      String.raw`${refPattern}\s*(?:\?\.\s*)?\[\s*["']${MUTATING_ARRAY_METHOD_PATTERN}["']\s*\]\s*(?:\?\.)?\s*\(`,
+    ).test(prefix) ||
+    new RegExp(
+      String.raw`\bObject\.(?:assign|defineProperties|defineProperty|setPrototypeOf)\s*\(\s*${refPattern}\s*,`,
+    ).test(prefix) ||
+    new RegExp(
+      String.raw`\bReflect\.(?:deleteProperty|set|setPrototypeOf)\s*\(\s*${refPattern}\s*,`,
+    ).test(prefix) ||
+    new RegExp(
+      String.raw`\bArray\.prototype\.(?:copyWithin|fill|pop|push|reverse|shift|sort|splice|unshift)\s*\.\s*(?:call|apply)\s*\(\s*${refPattern}\s*,`,
+    ).test(prefix)
+  );
+}
+
+function hasStandaloneAssignment(prefix: string, ref: string) {
+  const assignmentPattern = new RegExp(
+    String.raw`${buildFixedArgvReferencePattern(ref)}\s*${ASSIGNMENT_OPERATOR_PATTERN}`,
+    "g",
+  );
+  for (const match of prefix.matchAll(assignmentPattern)) {
+    const index = match.index ?? 0;
+    if (isDeclarationInitializer(prefix, index)) continue;
+    return true;
+  }
+  return false;
+}
+
+const ASSIGNMENT_OPERATOR_PATTERN = String.raw`(?:(?:\|\||&&|\?\?|<<|>>>|>>|\*\*)|[-+*/%&|^])?=(?!=|>)`;
+const MUTATING_ARRAY_METHOD_PATTERN = String.raw`(?:copyWithin|fill|pop|push|reverse|shift|sort|splice|unshift)`;
+
+function isDeclarationInitializer(prefix: string, refIndex: number) {
+  const before = prefix.slice(Math.max(0, refIndex - 120), refIndex);
+  return /\b(?:const|let|var)\s*$/.test(before);
+}
+
+function buildFixedArgvReferencePattern(ref: string) {
+  return ref === "params.argv"
+    ? String.raw`(?<![\w$.])params\.argv(?![\w$])`
+    : String.raw`(?<![\w$.])${escapeRegExp(ref)}(?![\w$])`;
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function hasRuntimeReExportOfRunFixedCommandHelper(files: TextFile[], helperFilePath: string) {
+  for (const file of files) {
+    if (file.path === helperFilePath) continue;
+    if (/\bexport\s*\{[^}]*\brunFixedCommandWithTimeout\b[^}]*\}/.test(file.content)) {
+      return true;
+    }
+    if (/\bexport\s+\*\s+from\s+["'][^"']*(?:deps|run)\.js["']/.test(file.content)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function findBlockEnd(content: string, openBraceIndex: number) {
+  let depth = 0;
+  let quote: '"' | "'" | "`" | undefined;
+  let escaped = false;
+
+  for (let i = openBraceIndex; i < content.length; i += 1) {
+    const char = content[i];
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (char === quote) quote = undefined;
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return i + 1;
+    }
+  }
+
+  return content.length;
+}
+
+function findInnermostBlockStart(content: string, targetIndex: number) {
+  const stack: number[] = [];
+  let quote: '"' | "'" | "`" | undefined;
+  let escaped = false;
+
+  for (let i = 0; i < targetIndex; i += 1) {
+    const char = content[i];
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (char === quote) quote = undefined;
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "{") stack.push(i);
+    if (char === "}") stack.pop();
+  }
+
+  return (stack.at(-1) ?? -1) + 1;
+}
+
+function findNamedFunctionContextAtIndex(content: string, callIndex: number, functionName: string) {
+  const pattern = new RegExp(String.raw`\bfunction\s+${functionName}\s*\(`, "g");
+  for (const match of content.matchAll(pattern)) {
+    const start = match.index;
+    if (start === undefined) continue;
+    const openParenIndex = content.indexOf("(", start);
+    if (openParenIndex === -1) continue;
+    const closeParenIndex = findCallEnd(content, openParenIndex);
+    const openBraceIndex = content.indexOf("{", closeParenIndex);
+    if (openBraceIndex === -1) continue;
+    const end = findBlockEnd(content, openBraceIndex);
+    if (callIndex >= openBraceIndex && callIndex < end) {
+      return { start, text: content.slice(start, end) };
+    }
+  }
+  return null;
+}
+
+function hasOnlyFixedRunCommandArgvCallSites(files: TextFile[]) {
+  let fixedCallSites = 0;
+  for (const file of files) {
+    const fileFixedCallSites = countFixedRunCommandArgvCallSites(file.content);
+    if (fileFixedCallSites === null) return false;
+    fixedCallSites += fileFixedCallSites;
+  }
+  return fixedCallSites > 0;
+}
+
+function countFixedRunCommandArgvCallSites(context: string) {
+  const runnerNames = new Set(["runFixedCommandWithTimeout"]);
+  for (const match of context.matchAll(
+    /\bconst\s+([A-Za-z_$][\w$]*)\s*=\s*[^\n;]*\brunFixedCommandWithTimeout\b/g,
+  )) {
+    if (match[1]) runnerNames.add(match[1]);
+  }
+  for (const match of context.matchAll(
+    /\bimport\s*\{[^}]*\brunFixedCommandWithTimeout\s+as\s+([A-Za-z_$][\w$]*)[^}]*\}/g,
+  )) {
+    if (match[1]) runnerNames.add(match[1]);
+  }
+  for (const match of context.matchAll(
+    /\b(?:const|let|var)\s*\{[^}]*\brunFixedCommandWithTimeout\s*:\s*([A-Za-z_$][\w$]*)[^}]*\}\s*=\s*require\(/g,
+  )) {
+    if (match[1]) runnerNames.add(match[1]);
+  }
+
+  let fixedCallSites = 0;
+  const runnerPattern = new RegExp(String.raw`\b(${Array.from(runnerNames).join("|")})\s*\(`, "g");
+  for (const match of context.matchAll(runnerPattern)) {
+    const callIndex = match.index;
+    if (callIndex === undefined) continue;
+    const before = context.slice(Math.max(0, callIndex - 32), callIndex);
+    if (/\bfunction\s+$/.test(before)) continue;
+
+    const openParenIndex = context.indexOf("(", callIndex);
+    const callEnd = findCallEnd(context, openParenIndex);
+    const callText = context.slice(callIndex, callEnd);
+    const callScope = context.slice(findInnermostBlockStart(context, callIndex), callIndex);
+    if (!hasFixedArgvArrayProperty(callText, callScope)) return null;
+    fixedCallSites += 1;
+  }
+  return fixedCallSites;
+}
+
+function findConstAssignment(content: string, identifier: string) {
+  const escapedIdentifier = identifier.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return content.match(new RegExp(String.raw`\bconst\s+${escapedIdentifier}\s*=\s*([^\n;]+)`))?.[1];
+}
+
+function isKnownFixedArgvIdentifier(identifier: string, content: string) {
+  const assignment = findConstAssignment(content, identifier)?.trim();
+  if (!assignment) return false;
+  if (identifier === "nodeExecutable") {
+    return /^(?:params\.nodeExecutable\s*\?\?\s*)?process\.execPath$/.test(assignment);
+  }
+  if (identifier === "scriptPath") {
+    return /^resolveFn\(\s*["']@matrix-org\/matrix-sdk-crypto-nodejs\/download-lib\.js["']\s*\)$/.test(
+      assignment,
+    );
+  }
+  return false;
+}
+
+function isFixedArgvItem(item: string, content: string) {
+  if (/^(["']).*\1$/.test(item)) return true;
+  if (item === "process.execPath") return true;
+  if (/^[A-Za-z_$][\w$]*$/.test(item)) return isKnownFixedArgvIdentifier(item, content);
+  return false;
+}
+
+function readQuotedArgvItem(item: string) {
+  const match = item.match(/^(["'])(.*)\1$/);
+  return match?.[2];
+}
+
+function hasFixedArgvArrayProperty(callText: string, content: string) {
+  const argvMatch = callText.match(/\bargv\s*:\s*\[([\s\S]*?)\]/);
+  const argvItems = argvMatch?.[1];
+  if (!argvItems) return false;
+  const items = argvItems
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  const executable = readQuotedArgvItem(items[0] ?? "")
+    ?.split(/[\\/]/)
+    .at(-1)
+    ?.toLowerCase();
+  if (executable && /^(?:sh|bash|zsh|fish|cmd|powershell|pwsh)$/.test(executable)) {
+    return false;
+  }
+  return items.every((item) => isFixedArgvItem(item, content));
+}
+
+function findChildProcessNamespaceAliases(content: string) {
+  const aliases = new Set<string>();
+  const moduleNameIdentifiers = new Set<string>();
+  for (const match of content.matchAll(
+    /\bconst\s+([A-Za-z_$][\w$]*)\s*=\s*["'](?:node:)?child_process["']/g,
+  )) {
+    if (match[1]) moduleNameIdentifiers.add(match[1]);
+  }
+  const patterns = [
+    /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*require\(\s*["'](?:node:)?child_process["']\s*\)/g,
+    /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*await\s+import\(\s*["'](?:node:)?child_process["']\s*\)/g,
+    /\bimport\s+\*\s+as\s+([A-Za-z_$][\w$]*)\s+from\s+["'](?:node:)?child_process["']/g,
+    /\bimport\s+([A-Za-z_$][\w$]*)\s+from\s+["'](?:node:)?child_process["']/g,
+    /\bimport\s+([A-Za-z_$][\w$]*)\s*=\s*require\(\s*["'](?:node:)?child_process["']\s*\)/g,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of content.matchAll(pattern)) {
+      if (match[1]) aliases.add(match[1]);
+    }
+  }
+  for (const moduleName of moduleNameIdentifiers) {
+    const escapedModuleName = escapeRegExp(moduleName);
+    for (const match of content.matchAll(
+      new RegExp(
+        String.raw`\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:await\s+import|require)\(\s*${escapedModuleName}\s*\)`,
+        "g",
+      ),
+    )) {
+      if (match[1]) aliases.add(match[1]);
+    }
+  }
+
+  return aliases;
+}
+
+function isChildProcessCallMatch(
+  content: string,
+  callIndex: number,
+  namespaceAliases: Set<string>,
+) {
+  const previous = content[callIndex - 1];
+  if (!previous || !/[\w$.]/.test(previous)) return true;
+  if (previous !== ".") return false;
+
+  const prefix = content.slice(Math.max(0, callIndex - 200), callIndex);
+  const namespace = prefix.match(/([A-Za-z_$][\w$]*)\??\.$/)?.[1];
+  if (namespace && namespaceAliases.has(namespace)) return true;
+  return (
+    /require\(\s*["'](?:node:)?child_process["']\s*\)\s*\??\.$/.test(prefix) ||
+    /import\(\s*["'](?:node:)?child_process["']\s*\)\s*\)?\s*\??\.$/.test(prefix)
+  );
+}
+
+function findDangerousChildProcessCall(path: string, content: string, runtimeFiles: TextFile[]) {
   if (!/child_process/.test(content)) return null;
 
+  const namespaceAliases = findChildProcessNamespaceAliases(content);
   const execPattern = /\b(exec|execSync|spawn|spawnSync|execFile|execFileSync)\s*\(/g;
   for (const match of content.matchAll(execPattern)) {
     const callName = match[1];
     const callIndex = match.index;
     if (callIndex === undefined || !callName) continue;
+    if (!isChildProcessCallMatch(content, callIndex, namespaceAliases)) continue;
 
     if (
       callName === "execFile" ||
@@ -449,6 +990,24 @@ function findDangerousChildProcessCall(content: string) {
       const callEnd = findCallEnd(content, openParenIndex);
       const callText = content.slice(callIndex, callEnd);
       if (isSafeLiteralChildProcessCall(callName, callText)) continue;
+      const helperContext = findNamedFunctionContextAtIndex(
+        content,
+        callIndex,
+        "runFixedCommandWithTimeout",
+      );
+      if (
+        helperContext &&
+        isSafeFixedArgvChildProcessCall(
+          callName,
+          callText,
+          helperContext.text,
+          callIndex - helperContext.start,
+          runtimeFiles,
+          path,
+        )
+      ) {
+        continue;
+      }
     }
 
     return findLineAtIndex(content, callIndex);
@@ -707,10 +1266,11 @@ function scanCodeFile(
   content: string,
   findings: ModerationFinding[],
   declaredEnvNames: Set<string>,
+  runtimeFiles: TextFile[],
 ) {
   if (!CODE_EXTENSION.test(path)) return;
 
-  const dangerousChildProcessCall = findDangerousChildProcessCall(content);
+  const dangerousChildProcessCall = findDangerousChildProcessCall(path, content, runtimeFiles);
   if (dangerousChildProcessCall) {
     addFinding(findings, {
       code: REASON_CODES.DANGEROUS_EXEC,
@@ -1147,12 +1707,13 @@ function completedCodexStatus(status?: string, analysis?: LlmAnalysis) {
 export function runStaticModerationScan(input: StaticScanInput): StaticScanResult {
   const findings: ModerationFinding[] = [];
   const files = [...input.fileContents].sort((a, b) => a.path.localeCompare(b.path));
+  const runtimeFiles = files.filter((file) => !isTestFixtureFile(file.path));
   const declaredEnvNames = collectDeclaredEnvNames(input);
 
   for (const file of files) {
     scanSecretLiteralFile(file.path, file.content, findings);
     scanPlaintextCgnatEndpointFile(file.path, file.content, findings);
-    scanCodeFile(file.path, file.content, findings, declaredEnvNames);
+    scanCodeFile(file.path, file.content, findings, declaredEnvNames, runtimeFiles);
     scanMarkdownFile(file.path, file.content, findings, input.slug);
     scanManifestFile(file.path, file.content, findings);
   }

--- a/convex/lib/moderationReasonCodes.ts
+++ b/convex/lib/moderationReasonCodes.ts
@@ -12,7 +12,7 @@ export type ModerationFinding = {
   evidence: string;
 };
 
-export const MODERATION_ENGINE_VERSION = "v2.4.25";
+export const MODERATION_ENGINE_VERSION = "v2.4.26";
 
 export const REASON_CODES = {
   LLM_REVIEW: "review.llm_review",


### PR DESCRIPTION
## What Problem This Solves

Official plugin packages can be marked suspicious by static scanner patterns that confuse normal secret plumbing, regex usage, and bounded fixed-argv child process helpers with risky behavior.

## Why This Change Was Made

This updates the moderation scanner to classify source-level evidence more precisely:

- Only literal secret-like values are reported as exposed secret literals; parameter forwarding and environment references are not.
- Child process detection ignores ordinary regex `.exec(...)` calls while still flagging real `child_process` calls, namespace aliases, dynamic aliases, optional chains, shell execution, dynamic argv wrappers, and mutated fixed-argv helpers.
- Matrix-style fixed command helpers are exempted only when every call site supplies a proven fixed argv array and the helper does not mutate argv before spawning.

## User Impact

Legitimate official packages should no longer surface static `dangerous_exec` or `exposed_secret_literal` warnings for expected implementation patterns, while unsafe child-process patterns remain suspicious.

## Evidence

- `bunx vitest run convex/lib/moderationEngine.test.ts` — 130 tests passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean.
- `bun run ci:static` — passed.
- `bun run ci:unit` — 325 test files passed, 4202 tests passed, 1 skipped.
- `bun run ci:types-build` — passed.
- `bun run ci:packages` — passed.
- Local package scan static results from this branch:
  - `@openclaw/bluebubbles@2026.5.7`: static clean, 0 findings.
  - `@openclaw/matrix@2026.6.10`: static clean, 0 findings.
  - `@openclaw/lobster@2026.6.10`: static clean, 0 findings.
  - `@openclaw/qqbot@2026.6.10`: static clean, 0 findings.
