### PR TITLE
fix: update codex worker cli pin

### DIFF
--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           set -euo pipefail
           if ! command -v codex >/dev/null 2>&1; then
-            npm install -g @openai/codex@0.115.0
+            npm install -g @openai/codex@0.142.3
           fi
           codex --version
 

--- a/.github/workflows/skill-card-worker.yml
+++ b/.github/workflows/skill-card-worker.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           set -euo pipefail
           if ! command -v codex >/dev/null 2>&1; then
-            npm install -g @openai/codex@0.115.0
+            npm install -g @openai/codex@0.142.3
           fi
           python3 -m pip install --user 'jinja2==3.1.6'
           codex --version

--- a/scripts/security/security-scan-worker-workflow.test.ts
+++ b/scripts/security/security-scan-worker-workflow.test.ts
@@ -81,7 +81,7 @@ describe("security-scan-codex workflow", () => {
     expect(steps.find((step) => step.name === "Check configuration")).toBeUndefined();
     const codexInstall = steps.find((step) => step.name === "Install Codex CLI")?.run;
     const skillspectorInstall = steps.find((step) => step.name === "Install SkillSpector")?.run;
-    expect(codexInstall).toContain("npm install -g @openai/codex@0.115.0");
+    expect(codexInstall).toContain("npm install -g @openai/codex@0.142.3");
     expect(codexInstall).not.toContain("@latest");
     expect(skillspectorInstall).toContain("git+https://github.com/NVIDIA/skillspector.git@8f37cfa");
     expect(skillspectorInstall).not.toContain("git+https://github.com/NVIDIA/skillspector.git'");

--- a/scripts/skill-cards/skill-card-worker-workflow.test.ts
+++ b/scripts/skill-cards/skill-card-worker-workflow.test.ts
@@ -85,7 +85,7 @@ describe("skill-card-worker workflow", () => {
     const dependenciesInstall = job.steps.find(
       (step) => step.name === "Install Codex CLI and renderer dependencies",
     )?.run;
-    expect(dependenciesInstall).toContain("npm install -g @openai/codex@0.115.0");
+    expect(dependenciesInstall).toContain("npm install -g @openai/codex@0.142.3");
     expect(dependenciesInstall).toContain("python3 -m pip install --user 'jinja2==3.1.6'");
     expect(dependenciesInstall).not.toContain("@latest");
     expect(dependenciesInstall).not.toMatch(/pip install --user jinja2(?:\s|$)/);


### PR DESCRIPTION
## What Problem This Solves

Production security scan workers were claiming package rescan jobs but failing every Codex subprocess before analysis. The redacted diagnostics from the failing worker run showed `codex exited 2` because `codex exec` rejected `--ignore-user-config` while the workflow installed an older `@openai/codex@0.115.0`.

## Why This Change Was Made

The worker scripts already pass the current Codex isolation and structured-output flags (`--ignore-user-config`, `--output-schema`, and `--ephemeral`). Updating the pinned CLI version lets the production workers keep those safeguards instead of removing them.

This updates both Codex-backed production workers so the Skill Card worker does not hit the same CLI mismatch.

## User Impact

Queued ClawScan rescans should be able to run again and replace stale stored scan reports. Skill Card generation keeps using a fixed, known Codex CLI version rather than `@latest`.

## Evidence

- Failing production worker run diagnostics: `codex.stderr.redacted.log` reported `error: unexpected argument '--ignore-user-config' found`.
- `npm exec --yes --package=@openai/codex@0.142.3 -- codex exec --help` includes `--ignore-user-config`, `--output-schema`, and `--ephemeral`.
- `bunx vitest run scripts/security/security-scan-worker-workflow.test.ts scripts/skill-cards/skill-card-worker-workflow.test.ts`
- `git diff --check -- .github/workflows/security-scan-codex.yml .github/workflows/skill-card-worker.yml scripts/security/security-scan-worker-workflow.test.ts scripts/skill-cards/skill-card-worker-workflow.test.ts`
- `bun run ci:static`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
