### PR TITLE
fix: repair publisher abuse dashboard display

### DIFF
--- a/convex/publisherAbuse.test.ts
+++ b/convex/publisherAbuse.test.ts
@@ -2791,6 +2791,14 @@ describe("publisher abuse dry-run persistence", () => {
       label: "potential_ban_candidate",
       status: "pending",
     });
+    const hiddenScore = makeScore({
+      _id: "publisherAbuseScores:hidden",
+      ownerKey: hiddenNomination.ownerKey,
+    });
+    const visibleScore = makeScore({
+      _id: "publisherAbuseScores:visible",
+      ownerKey: visibleNomination.ownerKey,
+    });
     const nominationsPaginate = vi.fn(
       async (paginationOpts: { numItems: number; cursor: string | null }) => {
         expect(paginationOpts).toEqual({ numItems: 2, cursor: null });
@@ -2821,6 +2829,8 @@ describe("publisher abuse dry-run persistence", () => {
               linkedUserId: "users:visible",
             };
           }
+          if (id === "publisherAbuseScores:hidden") return hiddenScore;
+          if (id === "publisherAbuseScores:visible") return visibleScore;
           if (id === "users:hidden") {
             return { _id: "users:hidden", handle: "hidden", role: "user" };
           }
@@ -2830,9 +2840,6 @@ describe("publisher abuse dry-run persistence", () => {
           return null;
         }),
         query: vi.fn((table: string) => {
-          if (table === "publisherAbuseScores") {
-            throw new Error("dashboard list pages should not read score documents");
-          }
           if (table === "publisherAbuseReviewNominations") {
             return {
               withIndex: (
@@ -2881,7 +2888,11 @@ describe("publisher abuse dry-run persistence", () => {
               _id: "publisherAbuseReviewNominations:visible",
               latestScoreId: "publisherAbuseScores:visible",
             }),
-            latestScore: null,
+            latestScore: expect.objectContaining({
+              _id: "publisherAbuseScores:visible",
+              zScore: visibleScore.zScore,
+              reasonCodes: visibleScore.reasonCodes,
+            }),
             publisher: expect.objectContaining({
               displayName: null,
               handle: "visible",

--- a/convex/publisherAbuse.ts
+++ b/convex/publisherAbuse.ts
@@ -3109,10 +3109,13 @@ async function summarizePublisherAbuseReviewNominationListItem(
     ? await ctx.db.get(nomination.ownerPublisherId)
     : null;
   const ownerUser = nomination.ownerUserId ? await ctx.db.get(nomination.ownerUserId) : null;
+  const latestScore = await ctx.db.get(nomination.latestScoreId);
 
   return {
     nomination,
-    latestScore: null,
+    latestScore: latestScore
+      ? summarizePublisherAbuseScoreForReview(latestScore, { includeTemporalDetails: false })
+      : null,
     publisher: publisher ? summarizePublisherForAbuseReview(publisher) : null,
     ownerUser: ownerUser ? summarizeUserForAbuseReview(ownerUser) : null,
     openedByRun: null,

--- a/src/routes/-management.test.tsx
+++ b/src/routes/-management.test.tsx
@@ -644,6 +644,9 @@ describe("Management", () => {
     expect(screen.getByRole("columnheader", { name: "Reasons" })).toBeTruthy();
     // Empty-state copy must not show when there are rows.
     expect(screen.queryByText("Queue clear")).toBeNull();
+    // Latest-run candidate counts are not the same as the open queue size.
+    expect(screen.getByRole("tab", { name: /Potential ban 2/ })).toBeTruthy();
+    expect(screen.getByText("Showing 2 of 2 nominations")).toBeTruthy();
 
     // The handle shows in the queue row; the detail drawer is closed until a
     // row is activated, so detail-only content is not on screen yet.
@@ -656,6 +659,7 @@ describe("Management", () => {
     });
     expect(screen.getByText("Published skills")).toBeTruthy();
     expect(screen.getByText("of 42 scored")).toBeTruthy();
+    expect(screen.getByText("Elevated (9)")).toBeTruthy();
     expect(screen.getAllByText("spammy-pub").length).toBeGreaterThanOrEqual(2);
 
     expect(screen.getByText("Triage note")).toBeTruthy();
@@ -762,8 +766,10 @@ describe("Management", () => {
   it("shows temporal download/install evidence in the abuse drawer", () => {
     const item = makePublisherAbuseItem({
       handle: "temporal-pub",
+      zScore: 2.65,
       scoreOverrides: {
         modelVersion: "publisher-abuse-temporal.v1",
+        pressure: 1,
         reasonCodes: ["temporal_sustained_downloads_flat_installs"],
         temporalBenchmark: {
           sampleSize: 1000,
@@ -825,6 +831,8 @@ describe("Management", () => {
     fireEvent.click(screen.getByText("temporal-pub"));
 
     expect(screen.getByText("Temporal signal")).toBeTruthy();
+    expect(screen.getByText("Low (1)")).toBeTruthy();
+    expect(screen.queryByText("Very High")).toBeNull();
     expect(screen.getByText(/Compared with 1,000 scanned skills/)).toBeTruthy();
     expect(screen.getByText("Download Burst")).toBeTruthy();
     expect(screen.getByText("16,200")).toBeTruthy();

--- a/src/routes/-management/AbusePage.tsx
+++ b/src/routes/-management/AbusePage.tsx
@@ -103,7 +103,8 @@ export function AbusePage({
       ? potentialBan + review
       : visiblePending.length;
   const resolved = tab === "resolved" ? items.length : (dashboard?.recentResolvedItems.length ?? 0);
-  const totalForTab =
+  const loaded = dashboard !== undefined && pageStatus !== "LoadingFirstPage";
+  const latestRunTotalForTab =
     tab === "potential_ban_candidate"
       ? potentialBan
       : tab === "review"
@@ -111,9 +112,22 @@ export function AbusePage({
         : tab === "resolved"
           ? resolved
           : totalPending;
-  const loaded = dashboard !== undefined && pageStatus !== "LoadingFirstPage";
+  const totalForTab = loaded ? Math.max(latestRunTotalForTab, items.length) : latestRunTotalForTab;
+  const potentialBanTabCount =
+    tab === "potential_ban_candidate" && loaded
+      ? Math.max(potentialBan, items.length)
+      : potentialBan;
+  const reviewTabCount = tab === "review" && loaded ? Math.max(review, items.length) : review;
+  const allPendingTabCount =
+    tab === "all_pending" && loaded ? Math.max(totalPending, items.length) : totalPending;
   const canLoadMore = pageStatus === "CanLoadMore";
   const loadingMore = pageStatus === "LoadingMore";
+  const nominationCountLabel =
+    loaded && (canLoadMore || loadingMore)
+      ? `Showing ${formatWholeNumber(items.length)}+ nominations`
+      : loaded
+        ? `Showing ${formatWholeNumber(items.length)} of ${formatWholeNumber(totalForTab)} nominations`
+        : "Loading…";
   const autobanLoaded = autobanSetting !== undefined;
   const autobanEnabled = autobanSetting?.enabled ?? false;
   const autobanStatusLabel = autobanLoaded
@@ -193,19 +207,19 @@ export function AbusePage({
       <div className="pa-tabs" role="tablist" aria-label="Publisher abuse queue">
         <PublisherAbuseTabButton
           active={tab === "potential_ban_candidate"}
-          count={loaded ? potentialBan : undefined}
+          count={loaded ? potentialBanTabCount : undefined}
           label="Potential ban"
           onClick={() => onChangeTab("potential_ban_candidate")}
         />
         <PublisherAbuseTabButton
           active={tab === "review"}
-          count={loaded ? review : undefined}
+          count={loaded ? reviewTabCount : undefined}
           label="On the brink"
           onClick={() => onChangeTab("review")}
         />
         <PublisherAbuseTabButton
           active={tab === "all_pending"}
-          count={loaded ? totalPending : undefined}
+          count={loaded ? allPendingTabCount : undefined}
           label="All flagged"
           onClick={() => onChangeTab("all_pending")}
         />
@@ -314,11 +328,7 @@ export function AbusePage({
           </table>
         </div>
         <div className="pa-foot">
-          <span>
-            {loaded
-              ? `Showing ${formatWholeNumber(items.length)} of ${formatWholeNumber(totalForTab)} nominations`
-              : "Loading…"}
-          </span>
+          <span>{nominationCountLabel}</span>
           {canLoadMore || loadingMore ? (
             <Button
               type="button"
@@ -847,9 +857,11 @@ function zScoreClass(value: number) {
   return "pa-z-ok";
 }
 
-function formatPressureLabel(score: Pick<PublisherAbuseReviewScore, "zScore">) {
-  if (score.zScore >= 2.5) return "Very High";
-  if (score.zScore >= 1.5) return "High";
-  if (score.zScore >= 0.5) return "Elevated";
-  return "Low";
+function formatPressureLabel(score: Pick<PublisherAbuseReviewScore, "pressure">) {
+  const pressure = score.pressure;
+  const formatted = formatRatio(pressure);
+  if (pressure >= 100) return `Very High (${formatted})`;
+  if (pressure >= 10) return `High (${formatted})`;
+  if (pressure >= 2) return `Elevated (${formatted})`;
+  return `Low (${formatted})`;
 }


### PR DESCRIPTION
## Summary

- Populate z-score and reason-code columns for paginated publisher abuse review rows.
- Prevent latest-run counts from making the active queue show impossible totals like `Showing 13 of 2 nominations`.
- Base the drawer pressure label on raw pressure and show the numeric value instead of deriving pressure from z-score.

## Verification

- `bunx vitest run convex/publisherAbuse.test.ts src/routes/-management.test.tsx`
- `bun run format:check -- src/routes/-management/AbusePage.tsx src/routes/-management.test.tsx convex/publisherAbuse.ts convex/publisherAbuse.test.ts`
- `bunx tsc --noEmit`
- `bunx convex dev --once --typecheck=disable`
- `bun run ci:static`
- `bun run ci:unit`

## Notes

Autoreview was attempted with `.agents/skills/autoreview/scripts/autoreview --mode local`, but the local Codex review engine failed with a `401 Unauthorized` auth error before returning findings.
