### PR TITLE
fix: show temporal abuse signal pressure

### DIFF
--- a/src/routes/-management.test.tsx
+++ b/src/routes/-management.test.tsx
@@ -769,7 +769,8 @@ describe("Management", () => {
       zScore: 2.65,
       scoreOverrides: {
         modelVersion: "publisher-abuse-temporal.v1",
-        pressure: 1,
+        pressure: 1101,
+        temporalMaxPressure: 1,
         reasonCodes: ["temporal_sustained_downloads_flat_installs"],
         temporalBenchmark: {
           sampleSize: 1000,

--- a/src/routes/-management/AbusePage.tsx
+++ b/src/routes/-management/AbusePage.tsx
@@ -857,8 +857,10 @@ function zScoreClass(value: number) {
   return "pa-z-ok";
 }
 
-function formatPressureLabel(score: Pick<PublisherAbuseReviewScore, "pressure">) {
-  const pressure = score.pressure;
+function formatPressureLabel(
+  score: Pick<PublisherAbuseReviewScore, "pressure" | "temporalMaxPressure">,
+) {
+  const pressure = score.temporalMaxPressure ?? score.pressure;
   const formatted = formatRatio(pressure);
   if (pressure >= 100) return `Very High (${formatted})`;
   if (pressure >= 10) return `High (${formatted})`;


### PR DESCRIPTION
## Summary

- Display temporal abuse drawer pressure from `temporalMaxPressure` when present.
- Keep aggregate pressure as the fallback for non-temporal publisher abuse scores.
- Add a regression matching production shape: temporal aggregate pressure around `1101`, actual temporal signal pressure `1`.

## Verification

- `bunx vitest run src/routes/-management.test.tsx`
- `bun run format:check -- src/routes/-management/AbusePage.tsx src/routes/-management.test.tsx`
- `bunx tsc --noEmit`
- `git diff --check`
