### PR TITLE
fix(security): tolerate transient scan claim failures

### DIFF
--- a/scripts/security/run-codex-scan-worker.test.ts
+++ b/scripts/security/run-codex-scan-worker.test.ts
@@ -12,6 +12,8 @@ import {
 import * as codexScanWorker from "./run-codex-scan-worker";
 import {
   buildPrompt,
+  claimBatchDrainedQueue,
+  claimFailuresAreFatal,
   normalizeSkillSpectorAnalysis,
   processJob,
   resolveSkillSpectorScanInput,
@@ -59,6 +61,19 @@ function unsafeFixtureLabels() {
 }
 
 describe("run-codex-scan-worker diagnostics", () => {
+  it("treats transient claim failures as fatal only when no jobs were claimed", () => {
+    expect(claimFailuresAreFatal(0, 0)).toBe(false);
+    expect(claimFailuresAreFatal(1, 0)).toBe(true);
+    expect(claimFailuresAreFatal(1, 3)).toBe(false);
+  });
+
+  it("keeps claiming after partial transient claim failures", () => {
+    expect(claimBatchDrainedQueue(0, 0, 4)).toBe(true);
+    expect(claimBatchDrainedQueue(0, 3, 4)).toBe(true);
+    expect(claimBatchDrainedQueue(1, 3, 4)).toBe(false);
+    expect(claimBatchDrainedQueue(0, 4, 4)).toBe(false);
+  });
+
   it("keeps successful claims when a parallel claim request fails", async () => {
     const claimCodexScanJobBatch = (
       codexScanWorker as typeof codexScanWorker & {

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -1323,6 +1323,18 @@ export async function claimCodexScanJobBatch(
   return { claimFailures, jobs };
 }
 
+export function claimFailuresAreFatal(claimFailures: number, claimedJobs: number) {
+  return claimFailures > 0 && claimedJobs === 0;
+}
+
+export function claimBatchDrainedQueue(
+  claimFailures: number,
+  claimedJobs: number,
+  claimLimit: number,
+) {
+  return claimFailures === 0 && claimedJobs < claimLimit;
+}
+
 async function main() {
   const { batchLimit, maxJobs, maxRuntimeMs, leaseMs, diagnosticsRoot } = parseArgs();
   assertCodexWorkerExecutionAllowed(process.env);
@@ -1342,6 +1354,7 @@ async function main() {
   let totalClaimed = 0;
   let totalCompleted = 0;
   let totalFailed = 0;
+  let totalClaimFailures = 0;
 
   logger.info(
     { diagnosticsRoot, event: "security_scan_diagnostics_directory", workerId },
@@ -1376,7 +1389,10 @@ async function main() {
         })) as ClaimedJob[],
     );
     const { claimFailures, jobs } = claimBatch;
-    totalFailed += claimFailures;
+    totalClaimFailures += claimFailures;
+    if (claimFailuresAreFatal(claimFailures, jobs.length)) {
+      totalFailed += claimFailures;
+    }
     logger.info(
       {
         claimed: jobs.length,
@@ -1397,7 +1413,7 @@ async function main() {
     totalCompleted += results.filter(Boolean).length;
     totalFailed += results.filter((ok) => !ok).length;
 
-    if (jobs.length < claimLimit) break;
+    if (claimBatchDrainedQueue(claimFailures, jobs.length, claimLimit)) break;
   }
 
   logger.info(
@@ -1405,6 +1421,7 @@ async function main() {
       elapsedMs: Date.now() - startedAt,
       event: "security_scan_worker_summary",
       totalClaimed,
+      totalClaimFailures,
       totalCompleted,
       totalFailed,
       workerId,


### PR DESCRIPTION
## Summary

- Keep Codex security scan claim RPC failures visible as `totalClaimFailures`.
- Treat claim failures as fatal only when the worker claimed no jobs at all.
- Continue claiming after partial transient claim failures instead of exiting early.

## Validation

- `bun test scripts/security/run-codex-scan-worker.test.ts`
- `bun run format:check -- scripts/security/run-codex-scan-worker.ts scripts/security/run-codex-scan-worker.test.ts`
- `git diff --check`
- `bun run ci:static`
- autoreview clean

## Impact

Fixes scheduled `Security Scan Codex Worker` runs failing after completing claimed work when one parallel claim request returns a transient Convex server error.
