### PR TITLE
fix(cli): prefer plugin manifests for code plugin detection

### DIFF
--- a/packages/clawhub/src/cli/commands/packages.test.ts
+++ b/packages/clawhub/src/cli/commands/packages.test.ts
@@ -2164,6 +2164,52 @@ describe("package commands", () => {
     }
   });
 
+  it("prefers openclaw.plugin.json over skills markers when detecting package family", async () => {
+    const workdir = await makeTmpWorkdir();
+    try {
+      const folder = join(workdir, "demo-plugin");
+      await mkdir(join(folder, "dist"), { recursive: true });
+      await mkdir(join(folder, "skills", "demo"), { recursive: true });
+      await writeFile(
+        join(folder, "package.json"),
+        makeCodePluginPackageJson({
+          name: "demo-plugin",
+          displayName: "Demo Plugin",
+          version: "1.0.0",
+        }),
+        "utf8",
+      );
+      await writeFile(
+        join(folder, "openclaw.plugin.json"),
+        JSON.stringify({ id: "demo.plugin" }),
+        "utf8",
+      );
+      await writeFile(join(folder, "skills", "demo", "SKILL.md"), "---\nname: demo\n---\n", "utf8");
+      await writeFile(join(folder, "dist", "index.js"), "export default {};\n", "utf8");
+
+      httpMocks.apiRequestForm.mockResolvedValueOnce({
+        ok: true,
+        packageId: "pkg_code",
+        releaseId: "rel_code",
+      });
+
+      await cmdPublishPackage(makeOpts(workdir), "demo-plugin", {
+        sourceRepo: "openclaw/demo-plugin",
+        sourceCommit: "abc123",
+      });
+
+      expect(getPublishPayload()).toMatchObject({
+        name: "demo-plugin",
+        displayName: "Demo Plugin",
+        family: "code-plugin",
+        version: "1.0.0",
+      });
+      expect(getUploadedClawPackNames()).toEqual(["demo-plugin-1.0.0.tgz"]);
+    } finally {
+      await rm(workdir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects code-plugin publish without source metadata", async () => {
     const workdir = await makeTmpWorkdir();
     try {

--- a/packages/clawhub/src/cli/commands/packages.ts
+++ b/packages/clawhub/src/cli/commands/packages.ts
@@ -2117,19 +2117,20 @@ const REAL_BUNDLE_MANIFESTS = [
   { path: ".cursor-plugin/plugin.json", format: "cursor" },
 ] as const;
 
-function hasRealBundleMarker(fileSet: Set<string>) {
-  return (
-    REAL_BUNDLE_MANIFESTS.some((marker) => fileSet.has(marker.path)) ||
-    Array.from(fileSet).some(
-      (path) =>
-        path.startsWith("skills/") ||
-        path.startsWith("commands/") ||
-        path.startsWith("agents/") ||
-        path === "hooks/hooks.json" ||
-        path === ".mcp.json" ||
-        path === ".lsp.json" ||
-        path === "settings.json",
-    )
+function hasRealBundleManifest(fileSet: Set<string>) {
+  return REAL_BUNDLE_MANIFESTS.some((marker) => fileSet.has(marker.path));
+}
+
+function hasLooseBundleMarker(fileSet: Set<string>) {
+  return Array.from(fileSet).some(
+    (path) =>
+      path.startsWith("skills/") ||
+      path.startsWith("commands/") ||
+      path.startsWith("agents/") ||
+      path === "hooks/hooks.json" ||
+      path === ".mcp.json" ||
+      path === ".lsp.json" ||
+      path === "settings.json",
   );
 }
 
@@ -2138,8 +2139,9 @@ function detectPackageFamily(
   explicit?: "code-plugin" | "bundle-plugin",
 ): "code-plugin" | "bundle-plugin" {
   if (explicit) return explicit;
-  if (hasRealBundleMarker(fileSet)) return "bundle-plugin";
+  if (hasRealBundleManifest(fileSet)) return "bundle-plugin";
   if (fileSet.has("openclaw.plugin.json")) return "code-plugin";
+  if (hasLooseBundleMarker(fileSet)) return "bundle-plugin";
   return fail("Could not detect package family. Use --family.");
 }
 


### PR DESCRIPTION
## Summary
- Prefer real bundle manifests over plugin manifests, but let `openclaw.plugin.json` win over loose bundle markers like `skills/`
- Add a regression test for OpenClaw code-plugin packages that bundle `skills/<id>/SKILL.md`

## Validation
- `bun run format:check -- packages/clawhub/src/cli/commands/packages.ts packages/clawhub/src/cli/commands/packages.test.ts`
- `git diff --check`
- `bun run --cwd packages/clawhub test:src -- src/cli/commands/packages.test.ts`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bun run --cwd packages/clawhub verify`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `bun run ci:static`
- `bun run ci:unit`
