### PR TITLE
chore: bump plugin inspector session sdk checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - Web: organization publishers can upload durable PNG, JPEG, or WebP logos from settings instead of relying on hotlinked image URLs.
 - Web/API: make default skill and plugin discovery freshness-aware, add seven-day trending views for both catalogs, and use verified status plus usage as search tie-breakers within direct matches.
 
+## 0.23.1 - 2026-06-29
+
+### Changes
+
+- CLI: update Plugin Inspector to `0.3.17` so `clawhub package validate` reports deprecated session SDK reads, writes, file helpers, and transcript helpers with remediation links.
+
 ## 0.23.0 - 2026-06-23
 
 ### Changes

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "@fontsource/manrope": "5.2.8",
         "@fontsource/noto-sans-sc": "5.2.9",
         "@monaco-editor/react": "4.7.0",
-        "@openclaw/plugin-inspector": "0.3.15",
+        "@openclaw/plugin-inspector": "0.3.17",
         "@radix-ui/react-avatar": "1.2.0",
         "@radix-ui/react-dialog": "1.1.17",
         "@radix-ui/react-dropdown-menu": "2.1.18",
@@ -100,7 +100,7 @@
       },
       "dependencies": {
         "@clack/prompts": "1.6.0",
-        "@openclaw/plugin-inspector": "0.3.15",
+        "@openclaw/plugin-inspector": "0.3.17",
         "arktype": "2.2.1",
         "commander": "15.0.0",
         "fflate": "0.8.3",
@@ -420,7 +420,7 @@
 
     "@openclaw/clawhub-admin": ["@openclaw/clawhub-admin@workspace:packages/clawhub-admin"],
 
-    "@openclaw/plugin-inspector": ["@openclaw/plugin-inspector@0.3.15", "", { "bin": { "plugin-inspector": "src/cli.js" } }, "sha512-zg7hBRHE3BTcRcaD3B5RK9y2Tme2u6aLK5qpDZXx8eJ91y7yXOYEH48gqZl5qZytQJ3SN3bxGyjr9f0iRPqqTg=="],
+    "@openclaw/plugin-inspector": ["@openclaw/plugin-inspector@0.3.17", "", { "bin": { "plugin-inspector": "src/cli.js" } }, "sha512-JPPHPhiXMsIvrV8UR8RQjhflMjRZX/uIhy9meE81dup7MMSnRJcsTGOXYACohv6e4z2P95z2QuE7nZkWT6Ysuw=="],
 
     "@oslojs/asn1": ["@oslojs/asn1@1.0.0", "", { "dependencies": { "@oslojs/binary": "1.0.0" } }, "sha512-zw/wn0sj0j0QKbIXfIlnEcTviaCzYOY3V5rAyjR6YtOByFtJiT574+8p9Wlach0lZH9fddD4yb9laEAIl4vXQA=="],
 

--- a/convex/packageInspectorNode.test.ts
+++ b/convex/packageInspectorNode.test.ts
@@ -47,7 +47,7 @@ describe("package inspector publish normalization", () => {
   it("keeps legacy author-facing warnings and drops internal coverage findings", () => {
     const result = normalizeInspectorReportForPublish({
       status: "pass",
-      summary: { breakageCount: 0, warningCount: 2, issueCount: 2 },
+      summary: { breakageCount: 0, warningCount: 3, issueCount: 3 },
       warnings: [
         {
           code: "package-plugin-api-compat-missing",
@@ -60,6 +60,12 @@ describe("package inspector publish normalization", () => {
           level: "warning",
           message: "runtime tools need capture before contract judgment",
         },
+        {
+          code: "sdk-session-file-helper",
+          level: "warning",
+          issueClass: "deprecation-warning",
+          message: "deprecated session file-path helper is still used",
+        },
       ],
     });
 
@@ -67,8 +73,8 @@ describe("package inspector publish normalization", () => {
       status: "pass",
       summary: {
         breakageCount: 0,
-        warningCount: 1,
-        issueCount: 1,
+        warningCount: 2,
+        issueCount: 2,
       },
       warnings: [
         {
@@ -77,6 +83,15 @@ describe("package inspector publish normalization", () => {
             summary: "Declare the OpenClaw plugin API range this package supports.",
             docsUrl:
               "https://docs.openclaw.ai/clawhub/plugin-validation-fixes#package-plugin-api-compat-missing",
+          },
+        },
+        {
+          code: "sdk-session-file-helper",
+          authorRemediation: {
+            summary:
+              "Replace deprecated session file-path helpers with session entry and transcript identity APIs.",
+            docsUrl:
+              "https://docs.openclaw.ai/clawhub/plugin-validation-fixes#sdk-session-file-helper",
           },
         },
       ],

--- a/convex/packageInspectorNode.ts
+++ b/convex/packageInspectorNode.ts
@@ -80,6 +80,16 @@ const LEGACY_AUTHOR_REMEDIATION_SUMMARIES = {
   "reserved-sdk-import": "Stop importing reserved bundled-plugin SDK compatibility paths.",
   "security-manifest-schema-unavailable":
     "Remove or update the unsupported security manifest schema reference.",
+  "sdk-load-session-store":
+    "Replace deprecated loadSessionStore whole-store access with row-scoped session helpers.",
+  "sdk-session-file-helper":
+    "Replace deprecated session file-path helpers with session entry and transcript identity APIs.",
+  "sdk-session-store-write":
+    "Replace deprecated whole-store session writes with row-scoped session helpers.",
+  "sdk-session-transcript-file-target":
+    "Replace legacy transcript file targets with public transcript identity or target helpers.",
+  "sdk-session-transcript-low-level":
+    "Replace low-level transcript writes with the structured transcript runtime helpers.",
   "unrecognized-security-manifest":
     "Remove unsupported security manifest files until OpenClaw documents a versioned security manifest schema.",
 } satisfies Record<string, string>;

--- a/docs/plugin-validation-fixes.md
+++ b/docs/plugin-validation-fixes.md
@@ -46,6 +46,10 @@ clawhub package validate <path-to-plugin>
 | `legacy-root-sdk-import`                | [Replace root SDK imports](./plugin-validation-fixes.md#legacy-root-sdk-import)                                             |
 | `reserved-sdk-import`                   | [Remove reserved SDK imports](./plugin-validation-fixes.md#reserved-sdk-import)                                             |
 | `sdk-load-session-store`                | [Replace whole-session-store access](./plugin-validation-fixes.md#sdk-load-session-store)                                   |
+| `sdk-session-store-write`               | [Replace whole-session-store writes](./plugin-validation-fixes.md#sdk-session-store-write)                                  |
+| `sdk-session-file-helper`               | [Replace session file-path helpers](./plugin-validation-fixes.md#sdk-session-file-helper)                                   |
+| `sdk-session-transcript-file-target`    | [Replace legacy transcript file targets](./plugin-validation-fixes.md#sdk-session-transcript-file-target)                   |
+| `sdk-session-transcript-low-level`      | [Replace low-level transcript helpers](./plugin-validation-fixes.md#sdk-session-transcript-low-level)                       |
 | `legacy-before-agent-start`             | [Replace before_agent_start](./plugin-validation-fixes.md#legacy-before-agent-start)                                        |
 | `provider-auth-env-vars`                | [Move provider env vars to setup metadata](./plugin-validation-fixes.md#provider-auth-env-vars)                             |
 | `channel-env-vars`                      | [Mirror channel env vars in current metadata](./plugin-validation-fixes.md#channel-env-vars)                                |
@@ -274,6 +278,69 @@ The plugin still uses the deprecated whole-session-store helper
 - Avoid loading, mutating, and saving the whole session store object.
 - Keep `loadSessionStore(...)` only while your declared compatibility range
   still supports older OpenClaw versions that require it.
+- See [Runtime API](/plugins/sdk-runtime#agent-session-state) and
+  [Plugin SDK subpaths](/plugins/sdk-subpaths).
+- Rerun `clawhub package validate <path-to-plugin>`.
+
+### sdk-session-store-write
+
+The plugin still uses a deprecated whole-session-store write helper such as
+`saveSessionStore` or `updateSessionStore`.
+
+- Use `patchSessionEntry(...)` when updating fields on an existing session
+  entry.
+- Use `upsertSessionEntry(...)` when replacing or creating a session entry.
+- Avoid loading, mutating, and saving the whole session store object.
+- Keep whole-store write helpers only while your declared compatibility range
+  still supports older OpenClaw versions that require them.
+- See [Runtime API](/plugins/sdk-runtime#agent-session-state) and
+  [Plugin SDK subpaths](/plugins/sdk-subpaths).
+- Rerun `clawhub package validate <path-to-plugin>`.
+
+### sdk-session-file-helper
+
+The plugin still uses deprecated session file-path helpers such as
+`resolveSessionFilePath` or `resolveAndPersistSessionFile`.
+
+- Use `getSessionEntry(...)` to read session metadata by agent and session
+  identity.
+- Use `patchSessionEntry(...)` or `upsertSessionEntry(...)` to persist session
+  metadata.
+- Use transcript identity or target helpers when the code is preparing a
+  transcript operation.
+- Do not persist or depend on legacy transcript file paths.
+- See [Runtime API](/plugins/sdk-runtime#agent-session-state) and
+  [Plugin SDK subpaths](/plugins/sdk-subpaths).
+- Rerun `clawhub package validate <path-to-plugin>`.
+
+### sdk-session-transcript-file-target
+
+The plugin still uses the deprecated transcript file target helper
+`resolveSessionTranscriptLegacyFileTarget`.
+
+- Use `resolveSessionTranscriptIdentity(...)` when the code only needs public
+  session identity.
+- Use `resolveSessionTranscriptTarget(...)` when the code needs a structured
+  transcript operation target.
+- Avoid reading or constructing legacy transcript file targets directly.
+- Keep the legacy helper only while your declared compatibility range still
+  supports older OpenClaw versions that require it.
+- See [Runtime API](/plugins/sdk-runtime#agent-session-state) and
+  [Plugin SDK subpaths](/plugins/sdk-subpaths).
+- Rerun `clawhub package validate <path-to-plugin>`.
+
+### sdk-session-transcript-low-level
+
+The plugin still uses deprecated low-level transcript helpers such as
+`appendSessionTranscriptMessage` or `emitSessionTranscriptUpdate`.
+
+- Use `appendSessionTranscriptMessageByIdentity(...)` for transcript appends.
+- Use `publishSessionTranscriptUpdateByIdentity(...)` for transcript update
+  notifications.
+- Prefer the structured transcript runtime surface so OpenClaw can apply the
+  correct transaction boundaries and identity handling.
+- Keep low-level transcript helpers only while your declared compatibility range
+  still supports older OpenClaw versions that require them.
 - See [Runtime API](/plugins/sdk-runtime#agent-session-state) and
   [Plugin SDK subpaths](/plugins/sdk-subpaths).
 - Rerun `clawhub package validate <path-to-plugin>`.

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@fontsource/manrope": "5.2.8",
     "@fontsource/noto-sans-sc": "5.2.9",
     "@monaco-editor/react": "4.7.0",
-    "@openclaw/plugin-inspector": "0.3.15",
+    "@openclaw/plugin-inspector": "0.3.17",
     "@radix-ui/react-avatar": "1.2.0",
     "@radix-ui/react-dialog": "1.1.17",
     "@radix-ui/react-dropdown-menu": "2.1.18",

--- a/packages/clawhub/package.json
+++ b/packages/clawhub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawhub",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "ClawHub CLI \\u2014 install, update, search, and publish skills plus OpenClaw packages.",
   "homepage": "https://clawhub.ai",
   "bugs": {

--- a/packages/clawhub/package.json
+++ b/packages/clawhub/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@clack/prompts": "1.6.0",
-    "@openclaw/plugin-inspector": "0.3.15",
+    "@openclaw/plugin-inspector": "0.3.17",
     "arktype": "2.2.1",
     "commander": "15.0.0",
     "fflate": "0.8.3",

--- a/packages/clawhub/src/cli/commands/packages.test.ts
+++ b/packages/clawhub/src/cli/commands/packages.test.ts
@@ -413,8 +413,8 @@ describe("package commands", () => {
         status: "pass",
         summary: {
           breakageCount: 0,
-          warningCount: 3,
-          issueCount: 3,
+          warningCount: 4,
+          issueCount: 4,
           inspectorGapCount: 1,
         },
         issues: [
@@ -437,6 +437,12 @@ describe("package commands", () => {
             level: "warning",
             message: "package.json is missing openclaw.compat.pluginApi",
           },
+          {
+            code: "sdk-session-store-write",
+            level: "warning",
+            issueClass: "deprecation-warning",
+            message: "deprecated whole-store session write helper is still used",
+          },
         ],
       };
       inspectorMocks.pluginRoot.runCheck.mockResolvedValueOnce({
@@ -451,9 +457,9 @@ describe("package commands", () => {
         status: "pass",
         summary: {
           breakageCount: 0,
-          warningCount: 2,
-          deprecationWarningCount: 0,
-          issueCount: 2,
+          warningCount: 3,
+          deprecationWarningCount: 1,
+          issueCount: 3,
         },
         issues: [
           {
@@ -475,6 +481,18 @@ describe("package commands", () => {
                 "https://docs.openclaw.ai/clawhub/plugin-validation-fixes#package-plugin-api-compat-missing",
             },
           },
+          {
+            code: "sdk-session-store-write",
+            level: "warning",
+            issueClass: "deprecation-warning",
+            message: "deprecated whole-store session write helper is still used",
+            authorRemediation: {
+              summary:
+                "Replace deprecated whole-store session writes with row-scoped session helpers.",
+              docsUrl:
+                "https://docs.openclaw.ai/clawhub/plugin-validation-fixes#sdk-session-store-write",
+            },
+          },
         ],
       });
       expect(mockWrite.mock.calls.join("\n")).not.toContain("runtime-tool-capture");
@@ -484,6 +502,7 @@ describe("package commands", () => {
         "utf8",
       );
       expect(artifactReport).toContain("package-plugin-api-compat-missing");
+      expect(artifactReport).toContain("sdk-session-store-write");
       expect(artifactReport).not.toContain("runtime-tool-capture");
       expect(artifactReport).not.toContain("inspectorGapCount");
       expect(mockLog).not.toHaveBeenCalled();

--- a/packages/clawhub/src/cli/commands/packages.ts
+++ b/packages/clawhub/src/cli/commands/packages.ts
@@ -111,6 +111,16 @@ const LEGACY_AUTHOR_REMEDIATION_SUMMARIES = {
   "reserved-sdk-import": "Stop importing reserved bundled-plugin SDK compatibility paths.",
   "security-manifest-schema-unavailable":
     "Remove or update the unsupported security manifest schema reference.",
+  "sdk-load-session-store":
+    "Replace deprecated loadSessionStore whole-store access with row-scoped session helpers.",
+  "sdk-session-file-helper":
+    "Replace deprecated session file-path helpers with session entry and transcript identity APIs.",
+  "sdk-session-store-write":
+    "Replace deprecated whole-store session writes with row-scoped session helpers.",
+  "sdk-session-transcript-file-target":
+    "Replace legacy transcript file targets with public transcript identity or target helpers.",
+  "sdk-session-transcript-low-level":
+    "Replace low-level transcript writes with the structured transcript runtime helpers.",
   "unrecognized-security-manifest":
     "Remove unsupported security manifest files until OpenClaw documents a versioned security manifest schema.",
 } as const;

--- a/scripts/clawhub-cli-npm-release-check.test.mjs
+++ b/scripts/clawhub-cli-npm-release-check.test.mjs
@@ -4,7 +4,7 @@ import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 
 describe("clawhub CLI npm release metadata check", () => {
-  const releaseTag = "v0.23.0";
+  const releaseTag = "v0.23.1";
 
   function runCheck(args) {
     const env = { ...process.env };


### PR DESCRIPTION
## Summary
- Bump `@openclaw/plugin-inspector` from `0.3.15` to published `0.3.17` in the app and CLI package.
- Add ClawHub remediation docs for the new deprecated session SDK warning codes.
- Add CLI and Convex fallback remediation mappings/tests for the session SDK codes, including sparse legacy reports.

## Proof
- `npm view @openclaw/plugin-inspector@0.3.17 version dist.integrity --json`
- `bun install --frozen-lockfile`
- `bun run format:check -- docs/plugin-validation-fixes.md package.json packages/clawhub/package.json packages/clawhub/src/cli/commands/packages.ts packages/clawhub/src/cli/commands/packages.test.ts convex/packageInspectorNode.ts convex/packageInspectorNode.test.ts`
- `bunx vitest run convex/packageInspectorNode.test.ts`
- `cd packages/clawhub && bunx vitest run -c vitest.config.ts src/cli/commands/packages.test.ts`
- `bun run ci:static`
- `bun run ci:packages`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bunx convex codegen` against local `anonymous:anonymous-clawhub`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean

## Affected package sweep
Validated all 23 exact package versions from the session SDK impact set using this branch's ClawHub CLI and the published inspector. Results: 23 validations completed, 0 failures, 21 packages emitted session SDK warnings. The two raw-match outliers remained clean: `@contexory/openclaw-plugin@0.3.1` and `@xmoxmo/bncr@0.4.6`.

Artifacts:
- `/Users/patrickerichsen/Git/openclaw/clawhub/.artifacts/session-sdk-impact-2026-06-29T17-23-22-708Z/clawhub-cli-0.3.17-proof/summary.json`
- `/Users/patrickerichsen/Git/openclaw/clawhub/.artifacts/session-sdk-impact-2026-06-29T17-23-22-708Z/clawhub-cli-0.3.17-proof/summary.csv`
