### PR TITLE
chore: record inspector upload results

### DIFF
--- a/scripts/package-inspector-nightly-scan.ts
+++ b/scripts/package-inspector-nightly-scan.ts
@@ -54,6 +54,12 @@ type ImpactEntry = {
   findings: NormalizedFinding[];
 };
 
+type UploadResult = {
+  ok: true;
+  inserted: number;
+  shouldEmailOwner: boolean;
+};
+
 const siteUrl = (process.env.CLAWHUB_SITE_URL ?? "https://clawhub.ai").replace(/\/+$/, "");
 const token = process.env.CLAWHUB_PLUGIN_INSPECTOR_WORKER_TOKEN;
 const batchSize = process.env.PLUGIN_INSPECTOR_BATCH_SIZE ?? "25";
@@ -194,13 +200,23 @@ async function inspectPackageItem(item: ClaimItem, inspectorVersion: string) {
     const findings = normalizeFindings(report);
     const targetOpenClawVersion = extractTargetOpenClawVersion(report.targetOpenClaw);
     if (!dryRun) {
-      await postJson(`${siteUrl}/api/v1/package-inspector/results`, {
-        packageId: item.packageId,
-        releaseId: item.releaseId,
-        inspectorVersion,
-        targetOpenClawVersion,
-        findings,
-      });
+      const uploadResult = await postJson<UploadResult>(
+        `${siteUrl}/api/v1/package-inspector/results`,
+        {
+          packageId: item.packageId,
+          releaseId: item.releaseId,
+          inspectorVersion,
+          targetOpenClawVersion,
+          findings,
+        },
+      );
+      await writeFile(
+        path.join(reportDir, "upload-result.json"),
+        `${JSON.stringify({ findingCount: findings.length, ...uploadResult }, null, 2)}\n`,
+      );
+      console.log(
+        `Uploaded ${item.packageName}@${item.version}: findings=${findings.length}, inserted=${uploadResult.inserted}, shouldEmailOwner=${uploadResult.shouldEmailOwner}`,
+      );
     }
     return {
       failed: false,


### PR DESCRIPTION
## Summary
- Record each Plugin Inspector bulk scan upload response as `upload-result.json` beside the package report.
- Log finding count, inserted count, and owner-email flag for each uploaded package.

## Why
The targeted session SDK scan produced correct report findings, but owner-visible summaries still reported zero. This makes the production ingest response auditable from workflow artifacts instead of silently succeeding with ambiguous persistence.

## Tests
- `bunx vitest run scripts/package-inspector-nightly-scan.test.ts`
- `bun run ci:static`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
