### PR TITLE
fix(search): keep review-only skills discoverable

### DIFF
--- a/convex/lib/publicBrowse.test.ts
+++ b/convex/lib/publicBrowse.test.ts
@@ -30,14 +30,21 @@ const browseFields = {
 };
 
 describe("publicBrowse", () => {
-  it("treats scanner review flags as pending public review", () => {
+  it("keeps review-only guidance publicly browsable", () => {
     expect(
       isSkillPendingPublicReview({
         moderationStatus: "active",
         moderationReason: "scanner.llm.review",
         moderationFlags: ["flagged.review"],
       }),
-    ).toBe(true);
+    ).toBe(false);
+    expect(
+      shouldExcludeSkillFromPublicBrowse({
+        ...browseFields,
+        moderationReason: "scanner.llm.review",
+        moderationFlags: ["flagged.review"],
+      }),
+    ).toBe(false);
   });
 
   it("treats active pending.scan skills as pending public review", () => {

--- a/convex/lib/publicBrowse.ts
+++ b/convex/lib/publicBrowse.ts
@@ -5,7 +5,7 @@ import {
   isSecurityScanStatusBlockedFromPublic,
   normalizeSecurityScanStatus,
 } from "./securityScanPolicy";
-import { isSkillReviewFlagged, isSkillSuspicious } from "./skillSafety";
+import { isSkillSuspicious } from "./skillSafety";
 
 type SkillPublicBrowseFields = Pick<
   Doc<"skills">,
@@ -49,7 +49,6 @@ function isPendingSkillModerationReason(reason: string | null | undefined) {
 export function isSkillPendingPublicReview(
   skill: Pick<Doc<"skills">, "moderationStatus" | "moderationReason" | "moderationFlags">,
 ) {
-  if (isSkillReviewFlagged(skill)) return true;
   return isPendingSkillModerationReason(skill.moderationReason);
 }
 

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -773,6 +773,45 @@ describe("search helpers", () => {
     expect(ctx.db.query).toHaveBeenCalledWith("skillSearchDigest");
   });
 
+  it("includes review-only first-publish skills in exact slug search", async () => {
+    const exactSlugSkill = makeSkillDoc({
+      id: "skills:wechatpay",
+      slug: "wechatpay-payment-integration",
+      displayName: "WeChat Pay Integration",
+      moderationFlags: ["flagged.review"],
+      moderationReason: "scanner.llm.review",
+    });
+    const ctx = makeLexicalCtx({
+      exactSlugSkill,
+      recentSkills: [],
+    });
+
+    const result = await getExactSkillSlugMatchHandler(ctx, {
+      slug: "wechatpay-payment-integration",
+    });
+
+    expect(result.map((entry) => entry.skill.slug)).toEqual(["wechatpay-payment-integration"]);
+  });
+
+  it("still excludes first-publish pending scan skills from exact slug search", async () => {
+    const exactSlugSkill = makeSkillDoc({
+      id: "skills:pending",
+      slug: "pending-payment-integration",
+      displayName: "Pending Payment Integration",
+      moderationReason: "pending.scan",
+    });
+    const ctx = makeLexicalCtx({
+      exactSlugSkill,
+      recentSkills: [],
+    });
+
+    const result = await getExactSkillSlugMatchHandler(ctx, {
+      slug: "pending-payment-integration",
+    });
+
+    expect(result).toEqual([]);
+  });
+
   it("returns duplicate exact slug matches without requiring global slug uniqueness", async () => {
     const ctx = makeLexicalCtx({
       exactSlugSkills: [


### PR DESCRIPTION
Closes #2938.

## Summary

- Stops treating `flagged.review` / `scanner.llm.review` as pending public-review state for public browse/search eligibility.
- Keeps the existing gates for true scanner-pending first publishes (`pending.scan`, `pending.scan.stale`, `scanner.*.pending`) and suspicious/malicious skills.
- Adds exact-slug search regressions for the reported review-only first-publish shape and for the pending-scan counterexample.

## Root cause

The reported skill is publicly reachable through the owner-qualified detail API, and the live API returns a clean moderation verdict with review-only guidance (`review.llm_review`). Current search/browse filtering routes `flagged.review` through `isSkillPendingPublicReview`, so a hosted first-publish skill with only review guidance is excluded from search even though the public detail path exposes it.

This change aligns the search/browse gate with `specs/security-moderation.md`: `flagged.review` is visible guidance and must not be hidden by default, while `flagged.suspicious` and pending scanner reasons remain blocked from public search/listing.

## Recent related PRs checked

- #2941 is search-digest stats sync for #2939; it does not address review-only discoverability.
- #2881 introduced the current pending public browse/search gate and approved-version handling; this PR preserves its true pending-scan safety boundary while correcting review-only guidance.
- #242 previously tried exposing pending-scan skills and was closed for security concerns; this PR does not expose pending-scan first publishes.

## Live proof before fix

- `GET https://clawhub.ai/api/v1/skills/wechatpay-payment-integration` returned HTTP 200 for owner `tencent-adm`, version `1.0.1`, verdict `clean`, reasonCodes `review.llm_review`.
- `GET https://clawhub.ai/api/v1/search?q=wechatpay-payment-integration&limit=10` returned HTTP 200 with `results: []`.

## Tests

- [x] `bun run test -- convex/lib/publicBrowse.test.ts convex/search.test.ts` (77 passed)
- [x] `bun run format:check -- convex/lib/publicBrowse.ts convex/lib/publicBrowse.test.ts convex/search.test.ts`
- [x] `git diff --check`
- [x] `bun run ci:static`
- [x] GitHub CI: `static`, `unit`, `packages`, `types-build`, `e2e-http`, `playwright-smoke`, and local-auth shards passed on PR #2942
- [ ] Local `bun run ci:unit` was attempted twice, but this checkout path contains a space (`New project`) and exposes an unrelated existing path-encoding issue in `scripts/skill-cards/run-skill-card-worker.ts`: it tries to read `/Users/mauriceniu/Documents/New%20project/.../scripts/skill-cards/templates/clawhub-skill-card.md.j2`. GitHub CI `unit` passed in a normal runner path.
