### PR TITLE
feat: clarify publisher state and discovery labels

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -113,6 +113,7 @@ import type * as lib_publicRouteReservations from "../lib/publicRouteReservation
 import type * as lib_publishLimits from "../lib/publishLimits.js";
 import type * as lib_publisherAbuseScoring from "../lib/publisherAbuseScoring.js";
 import type * as lib_publisherCatalogDisplay from "../lib/publisherCatalogDisplay.js";
+import type * as lib_publisherState from "../lib/publisherState.js";
 import type * as lib_publisherStats from "../lib/publisherStats.js";
 import type * as lib_publishers from "../lib/publishers.js";
 import type * as lib_rankingMetricsImportLock from "../lib/rankingMetricsImportLock.js";
@@ -314,6 +315,7 @@ declare const fullApi: ApiFromModules<{
   "lib/publishLimits": typeof lib_publishLimits;
   "lib/publisherAbuseScoring": typeof lib_publisherAbuseScoring;
   "lib/publisherCatalogDisplay": typeof lib_publisherCatalogDisplay;
+  "lib/publisherState": typeof lib_publisherState;
   "lib/publisherStats": typeof lib_publisherStats;
   "lib/publishers": typeof lib_publishers;
   "lib/rankingMetricsImportLock": typeof lib_rankingMetricsImportLock;

--- a/convex/lib/publisherState.test.ts
+++ b/convex/lib/publisherState.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Doc, Id, TableNames } from "../_generated/dataModel";
+import { getPublisherStateFacts } from "./publisherState";
+
+function testId<TableName extends TableNames>(value: string): Id<TableName> {
+  return value as Id<TableName>;
+}
+
+function makePublisher(overrides: Partial<Doc<"publishers">>): Doc<"publishers"> {
+  return {
+    _id: testId<"publishers">("publishers:publisher"),
+    _creationTime: 1,
+    kind: "org",
+    handle: "publisher",
+    displayName: "Publisher",
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  } as Doc<"publishers">;
+}
+
+function makeCtx(options?: {
+  members?: Array<{ publisherId: string; userId: string; role?: "owner" | "admin" | "publisher" }>;
+  officialPublisherIds?: string[];
+  users?: Record<string, { deletedAt?: number; deactivatedAt?: number } | null>;
+}) {
+  const members = options?.members ?? [];
+  const officialPublisherIds = new Set(options?.officialPublisherIds ?? []);
+  const users = options?.users ?? {};
+
+  return {
+    db: {
+      get: vi.fn(async (id: string) => {
+        const user = users[id] ?? {};
+        return user ? { _id: id, ...user } : null;
+      }),
+      query: vi.fn((table: string) => ({
+        withIndex: vi.fn(
+          (
+            indexName: string,
+            buildQuery: (q: { eq: (field: string, value: string) => unknown }) => unknown,
+          ) => {
+            let publisherId: string | undefined;
+            let role: string | undefined;
+            const queryBuilder = {
+              eq: vi.fn((field: string, value: string) => {
+                if (field === "publisherId") publisherId = value;
+                if (field === "role") role = value;
+                return queryBuilder;
+              }),
+            };
+            buildQuery({
+              eq: queryBuilder.eq,
+            });
+
+            if (table === "publisherMembers" && indexName === "by_publisher_and_role") {
+              return {
+                take: vi.fn(async (limit: number) =>
+                  members
+                    .filter(
+                      (member) =>
+                        member.publisherId === publisherId && (member.role ?? "publisher") === role,
+                    )
+                    .slice(0, limit)
+                    .map((member, index) => ({
+                      _id: `publisherMembers:${index + 1}`,
+                      role: member.role ?? "publisher",
+                      ...member,
+                    })),
+                ),
+              };
+            }
+
+            if (table === "officialPublishers" && indexName === "by_publisher") {
+              return {
+                unique: vi.fn(async () =>
+                  publisherId && officialPublisherIds.has(publisherId)
+                    ? {
+                        _id: testId<"officialPublishers">("officialPublishers:1"),
+                        publisherId: testId<"publishers">(publisherId),
+                      }
+                    : null,
+                ),
+              };
+            }
+
+            throw new Error(`Unexpected query ${table}.${indexName}`);
+          },
+        ),
+      })),
+    },
+  };
+}
+
+describe("getPublisherStateFacts", () => {
+  it("derives claimed official org state from members and official rows", async () => {
+    const ctx = makeCtx({
+      members: [{ publisherId: "publishers:openclaw", userId: "users:owner" }],
+      officialPublisherIds: ["publishers:openclaw"],
+    });
+
+    await expect(
+      getPublisherStateFacts(
+        ctx as never,
+        makePublisher({ _id: testId<"publishers">("publishers:openclaw") }),
+      ),
+    ).resolves.toEqual({
+      claimState: "claimed",
+      officialState: "official",
+      restrictionState: "active",
+    });
+  });
+
+  it("keeps user claims separate from official state", async () => {
+    const ctx = makeCtx();
+
+    await expect(
+      getPublisherStateFacts(
+        ctx as never,
+        makePublisher({
+          _id: testId<"publishers">("publishers:alice"),
+          kind: "user",
+          linkedUserId: testId<"users">("users:alice"),
+        }),
+      ),
+    ).resolves.toEqual({
+      claimState: "claimed",
+      officialState: "notOfficial",
+      restrictionState: "active",
+    });
+  });
+
+  it("preserves legacy personal publisher claims from owner membership", async () => {
+    const ctx = makeCtx({
+      members: [{ publisherId: "publishers:legacy", userId: "users:owner", role: "owner" }],
+    });
+
+    await expect(
+      getPublisherStateFacts(
+        ctx as never,
+        makePublisher({
+          _id: testId<"publishers">("publishers:legacy"),
+          kind: "user",
+          linkedUserId: undefined,
+        }),
+      ),
+    ).resolves.toMatchObject({
+      claimState: "claimed",
+    });
+  });
+
+  it("does not claim personal publishers linked to inactive users", async () => {
+    const ctx = makeCtx({ users: { "users:alice": { deactivatedAt: 10 } } });
+
+    await expect(
+      getPublisherStateFacts(
+        ctx as never,
+        makePublisher({
+          _id: testId<"publishers">("publishers:alice"),
+          kind: "user",
+          linkedUserId: testId<"users">("users:alice"),
+        }),
+      ),
+    ).resolves.toMatchObject({
+      claimState: "unclaimed",
+    });
+  });
+
+  it("only claims publishers with active membership users", async () => {
+    const ctx = makeCtx({
+      members: [
+        { publisherId: "publishers:org", userId: "users:stale" },
+        { publisherId: "publishers:org", userId: "users:active" },
+      ],
+      users: {
+        "users:stale": { deletedAt: 10 },
+        "users:active": {},
+      },
+    });
+
+    await expect(
+      getPublisherStateFacts(
+        ctx as never,
+        makePublisher({ _id: testId<"publishers">("publishers:org") }),
+      ),
+    ).resolves.toMatchObject({
+      claimState: "claimed",
+    });
+  });
+
+  it("keeps large bounded membership buckets claimed without unbounded scans", async () => {
+    const members = Array.from({ length: 20 }, (_value, index) => ({
+      publisherId: "publishers:org",
+      userId: `users:stale${index}`,
+      role: "publisher" as const,
+    }));
+    const ctx = makeCtx({
+      members,
+      users: Object.fromEntries(members.map((member) => [member.userId, { deletedAt: 10 }])),
+    });
+
+    await expect(
+      getPublisherStateFacts(
+        ctx as never,
+        makePublisher({ _id: testId<"publishers">("publishers:org") }),
+      ),
+    ).resolves.toMatchObject({
+      claimState: "claimed",
+    });
+  });
+
+  it("reports missing or deleted publisher restrictions without inventing claims", async () => {
+    const ctx = makeCtx();
+
+    await expect(getPublisherStateFacts(ctx as never, null)).resolves.toEqual({
+      claimState: "unclaimed",
+      officialState: "notOfficial",
+      restrictionState: "missing",
+    });
+    await expect(
+      getPublisherStateFacts(ctx as never, makePublisher({ deletedAt: 10 })),
+    ).resolves.toMatchObject({
+      restrictionState: "deleted",
+    });
+  });
+});

--- a/convex/lib/publisherState.ts
+++ b/convex/lib/publisherState.ts
@@ -1,0 +1,96 @@
+import type { Doc } from "../_generated/dataModel";
+import type { MutationCtx, QueryCtx } from "../_generated/server";
+import { hasOfficialPublisherRow } from "./officialPublishers";
+
+type DbCtx = Pick<QueryCtx | MutationCtx, "db">;
+
+type PublisherStateCandidate =
+  | Pick<Doc<"publishers">, "_id" | "kind" | "linkedUserId" | "deletedAt" | "deactivatedAt">
+  | null
+  | undefined;
+
+export type PublisherClaimState = "unclaimed" | "claimed";
+export type PublisherOfficialState = "notOfficial" | "official";
+export type PublisherRestrictionState = "active" | "deactivated" | "deleted" | "missing";
+
+type PublisherMemberRole = Doc<"publisherMembers">["role"];
+
+const CLAIM_MEMBER_ROLE_SCAN_LIMIT = 20;
+const ORG_CLAIM_ROLES: PublisherMemberRole[] = ["owner", "admin", "publisher"];
+
+export type PublisherStateFacts = {
+  claimState: PublisherClaimState;
+  officialState: PublisherOfficialState;
+  restrictionState: PublisherRestrictionState;
+};
+
+function publisherRestrictionState(publisher: PublisherStateCandidate): PublisherRestrictionState {
+  if (!publisher) return "missing";
+  if (publisher.deletedAt) return "deleted";
+  if (publisher.deactivatedAt) return "deactivated";
+  return "active";
+}
+
+async function hasActiveUser(ctx: DbCtx, userId: Doc<"users">["_id"]): Promise<boolean> {
+  const user = await ctx.db.get(userId);
+  return Boolean(user && !user.deletedAt && !user.deactivatedAt);
+}
+
+async function hasActiveMemberForRole(
+  ctx: DbCtx,
+  publisherId: Doc<"publishers">["_id"],
+  role: PublisherMemberRole,
+): Promise<boolean> {
+  const members = await ctx.db
+    .query("publisherMembers")
+    .withIndex("by_publisher_and_role", (q) => q.eq("publisherId", publisherId).eq("role", role))
+    .take(CLAIM_MEMBER_ROLE_SCAN_LIMIT);
+
+  for (const member of members) {
+    if (await hasActiveUser(ctx, member.userId)) return true;
+  }
+
+  if (members.length >= CLAIM_MEMBER_ROLE_SCAN_LIMIT) return true;
+  return false;
+}
+
+async function hasActiveMemberForAnyRole(
+  ctx: DbCtx,
+  publisherId: Doc<"publishers">["_id"],
+  roles: PublisherMemberRole[],
+): Promise<boolean> {
+  for (const role of roles) {
+    if (await hasActiveMemberForRole(ctx, publisherId, role)) return true;
+  }
+  return false;
+}
+
+async function publisherClaimState(
+  ctx: DbCtx,
+  publisher: PublisherStateCandidate,
+): Promise<PublisherClaimState> {
+  if (!publisher) return "unclaimed";
+  if (publisher.kind === "user" && publisher.linkedUserId) {
+    return (await hasActiveUser(ctx, publisher.linkedUserId)) ? "claimed" : "unclaimed";
+  }
+
+  const claimed =
+    publisher.kind === "user"
+      ? await hasActiveMemberForRole(ctx, publisher._id, "owner")
+      : await hasActiveMemberForAnyRole(ctx, publisher._id, ORG_CLAIM_ROLES);
+  return claimed ? "claimed" : "unclaimed";
+}
+
+export async function getPublisherStateFacts(
+  ctx: DbCtx,
+  publisher: PublisherStateCandidate,
+  options?: { official?: boolean },
+): Promise<PublisherStateFacts> {
+  const official =
+    options?.official ?? (publisher ? await hasOfficialPublisherRow(ctx, publisher._id) : false);
+  return {
+    claimState: await publisherClaimState(ctx, publisher),
+    officialState: official ? "official" : "notOfficial",
+    restrictionState: publisherRestrictionState(publisher),
+  };
+}

--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -6908,7 +6908,12 @@ describe("official publisher administration", () => {
       expect.objectContaining({
         action: "publisher.official.add",
         targetId: "publishers:steipete",
-        metadata: { handle: "steipete", reason: "Verified individual publisher" },
+        metadata: {
+          handle: "steipete",
+          reason: "Verified individual publisher",
+          priorOfficialState: "notOfficial",
+          officialState: "official",
+        },
       }),
     );
   });

--- a/convex/publishers.ts
+++ b/convex/publishers.ts
@@ -39,6 +39,7 @@ import {
   PUBLISHER_HANDLE_REQUIREMENTS_MESSAGE,
   normalizePublisherHandle,
 } from "./lib/publishers";
+import { getPublisherStateFacts } from "./lib/publisherState";
 import {
   getLatestActiveReservedHandle,
   isHandleReservedForAnotherUser,
@@ -3608,6 +3609,7 @@ export const listOfficialPublishersInternal = internalQuery({
           displayName: publisher?.displayName ?? null,
           kind: publisher?.kind ?? null,
           active: Boolean(publisher && !publisher.deletedAt && !publisher.deactivatedAt),
+          state: await getPublisherStateFacts(ctx, publisher, { official: true }),
           reason: row.reason ?? null,
           createdByUserId: row.createdByUserId ?? null,
           createdByHandle: createdBy?.handle ?? null,
@@ -3680,6 +3682,8 @@ export const addOfficialPublisherInternal = internalMutation({
       metadata: {
         handle: publisher.handle,
         reason,
+        priorOfficialState: "notOfficial",
+        officialState: "official",
       },
       createdAt: now,
     });
@@ -3740,6 +3744,8 @@ export const removeOfficialPublisherInternal = internalMutation({
         handle: publisher.handle,
         reason,
         officialPublisherId: existing._id,
+        priorOfficialState: "official",
+        officialState: "notOfficial",
       },
       createdAt: now,
     });

--- a/packages/clawhub/src/schema/schemas.test.ts
+++ b/packages/clawhub/src/schema/schemas.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { parseArk } from "./ark";
 import { ApiV1PackagePublishResponseSchema } from "./packages";
 import {
+  ApiV1OfficialPublisherListResponseSchema,
   ApiV1SearchResponseSchema,
   ApiV1SkillRescanResponseSchema,
   ApiV1SkillVerifyResponseSchema,
@@ -189,5 +190,51 @@ describe("packages/clawhub skill metadata schema", () => {
 
     if (!("githubContentHash" in parsed)) throw new Error("expected GitHub rescan response");
     expect(parsed.githubContentHash).toBe("content-hash");
+  });
+
+  it("parses optional official publisher state facts", () => {
+    const parsed = parseArk(
+      ApiV1OfficialPublisherListResponseSchema,
+      {
+        ok: true,
+        items: [
+          {
+            officialPublisherId: "officialPublishers:openclaw",
+            publisherId: "publishers:openclaw",
+            handle: "openclaw",
+            displayName: "OpenClaw",
+            kind: "org",
+            active: true,
+            state: {
+              claimState: "claimed",
+              officialState: "official",
+              restrictionState: "active",
+            },
+            reason: "platform-owned publisher",
+            createdByUserId: "users:admin",
+            createdByHandle: "patrick-erichsen-2",
+            createdAt: 1,
+            updatedAt: 1,
+          },
+          {
+            officialPublisherId: "officialPublishers:legacy",
+            publisherId: "publishers:legacy",
+            handle: null,
+            displayName: null,
+            kind: null,
+            active: false,
+            reason: null,
+            createdByUserId: null,
+            createdByHandle: null,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ],
+      },
+      "Official publishers",
+    );
+
+    expect(parsed.items[0]?.state?.officialState).toBe("official");
+    expect(parsed.items[1]?.state).toBeUndefined();
   });
 });

--- a/packages/clawhub/src/schema/schemas.ts
+++ b/packages/clawhub/src/schema/schemas.ts
@@ -383,6 +383,11 @@ export const ApiV1OfficialPublisherListResponseSchema = type({
     displayName: "string|null",
     kind: '"user"|"org"|null',
     active: "boolean",
+    "state?": {
+      claimState: '"unclaimed"|"claimed"',
+      officialState: '"notOfficial"|"official"',
+      restrictionState: '"active"|"deactivated"|"deleted"|"missing"',
+    },
     reason: "string|null",
     createdByUserId: "string|null",
     createdByHandle: "string|null",

--- a/specs/README.md
+++ b/specs/README.md
@@ -20,6 +20,7 @@ into `docs/` and leave only the design record here.
 - `spec.md`: product + implementation spec for the original registry model.
 - `orgs.md`: org, publisher membership, and scoped identity plan.
 - `claim-official-state.md`: claim, verification, official, suspension, and revocation state for ClawHub publishers.
+- `profile-discovery-surfaces.md`: profile, feed, search, and discovery surfaces for ClawHub account and publisher feeds.
 - `github-import.md`: GitHub import feature spec.
 - `github-backed-skills.md`: source-backed GitHub skills catalog and install invariants.
 - `diffing.md`: skill version diffing UI/API design.

--- a/specs/README.md
+++ b/specs/README.md
@@ -19,6 +19,7 @@ into `docs/` and leave only the design record here.
 
 - `spec.md`: product + implementation spec for the original registry model.
 - `orgs.md`: org, publisher membership, and scoped identity plan.
+- `claim-official-state.md`: claim, verification, official, suspension, and revocation state for ClawHub publishers.
 - `github-import.md`: GitHub import feature spec.
 - `github-backed-skills.md`: source-backed GitHub skills catalog and install invariants.
 - `diffing.md`: skill version diffing UI/API design.

--- a/specs/claim-official-state.md
+++ b/specs/claim-official-state.md
@@ -1,0 +1,173 @@
+---
+summary: "Claim, verification, official, suspension, and revocation state for ClawHub publishers."
+read_when:
+  - Changing publisher claim, verification, official, suspension, or revocation behavior
+  - Adding account feed or publisher feed status fields
+  - Reviewing trust labels shown on ClawHub profiles, feeds, search, or OpenClaw exports
+---
+
+# Claim And Official State
+
+ClawHub publisher state must separate identity, policy, and safety signals.
+Users should be able to understand whether a publisher is claimed, verified,
+official, suspended, revoked, reviewed, scanned, or locally approved without
+those labels collapsing into a single trust badge.
+
+This spec defines the product-state boundaries for account and publisher feeds.
+It does not change the existing official publisher policy in
+`specs/official-publishers.md`; it records how claim, verification, official,
+suspension, and revocation states should relate as ClawHub grows account-backed
+feeds and follow surfaces.
+
+## State Definitions
+
+ClawHub should keep these states distinct:
+
+- `unclaimed`: no current ClawHub account has established ownership or
+  representation of the account or publisher identity.
+- `claimPending`: a claim request exists, but staff or automated verification
+  has not accepted it.
+- `claimed`: ClawHub has linked the publisher or namespace to a ClawHub account
+  or organization, but has not granted a stronger verification signal.
+- `verified`: ClawHub has accepted evidence that the account or publisher
+  represents the claimed identity.
+- `official`: ClawHub staff have granted official publisher status under the
+  policy in `specs/official-publishers.md`.
+- `suspended`: ClawHub has temporarily restricted the publisher or related
+  feed/profile surfaces because of policy, security, abuse, or account-risk
+  concerns.
+- `revoked`: ClawHub has removed a previous claim, verification, official
+  status, or feed eligibility decision.
+
+These names are product-state labels, not necessarily one stored enum. Existing
+tables may keep separate rows or fields for claims, publisher membership,
+official publisher rows, moderation holds, deleted/deactivated state, and audit
+history.
+
+## Boundaries
+
+`official` means official in ClawHub only. It does not mean:
+
+- OpenClaw reviewed
+- OpenClaw scanned
+- locally approved
+- safe to install
+- exempt from package artifact integrity checks
+- exempt from moderation or security review
+
+Ordinary community publishing must not require official status. Official status
+is a stronger signal for selected publishers, not the baseline path for account
+feeds, publisher profiles, search visibility, or package publication.
+
+Uploaded skill, package, feed, or profile metadata must not be able to mark a
+publisher as claimed, verified, official, suspended, or revoked. Those states
+must come from ClawHub-controlled account, staff, policy, moderation, or audit
+paths.
+
+## Transition Rules
+
+Self-service paths may create or update:
+
+- claim requests
+- account profile metadata
+- publisher profile metadata
+- ordinary public package or skill publication
+- follow state
+
+Self-service paths must not directly grant:
+
+- verified state
+- official state
+- suspension
+- revocation
+- reinstatement after suspension or revocation
+
+Staff or system-controlled paths should define the actor, proof type, reason,
+and affected identity for each transition before implementation.
+
+Revoked or suspended publishers should remain resolvable for audit history.
+Their public profile or feed may show a restricted state, but URLs should not be
+reused in a way that makes old feed entries or audit records point at an
+unrelated identity.
+
+## Display Rules
+
+ClawHub UI and feed fields should use separate labels for:
+
+- claimed
+- verified
+- official
+- OpenClaw reviewed
+- OpenClaw scanned
+- locally approved
+
+Do not collapse them into one trust badge. A user who sees `official` should not
+read it as `OpenClaw scanned`, `reviewed`, `locally approved`, or `safe to
+install`.
+
+Profile, feed, and search surfaces should:
+
+- show claim and official status separately
+- show scan or review state only when ClawHub has that state
+- show local approval only when the current context actually has that approval
+- preserve historical provenance when a state changes
+- keep suspended or revoked publishers visibly restricted instead of active or
+  endorsed
+
+## Feed Behavior
+
+Future account and publisher feeds should include only ClawHub-authored state
+facts. Feed consumers should treat those facts as inputs to their own trust
+model, not as install authority.
+
+When state changes:
+
+- official grants and removals should affect future feed snapshots
+- suspensions and revocations should affect future feed snapshots
+- historical feed revisions should remain auditable
+- followers may be notified about material restriction changes, but the
+  notification must not imply install safety
+
+If a publisher is suspended or revoked, feed endpoints should return a
+well-defined restricted state or error response without exposing private review
+evidence.
+
+## Audit Requirements
+
+Record audit events for:
+
+- claim request created
+- claim accepted
+- claim rejected
+- verification granted
+- verification removed
+- official status granted
+- official status removed
+- publisher suspended
+- publisher reinstated
+- publisher revoked
+- feed eligibility restricted or restored because of claim, official, security,
+  or moderation state
+
+Each audit event should include:
+
+- actor
+- timestamp
+- affected account id or publisher id
+- prior state
+- new state
+- reason
+- proof type when applicable
+- related feed revision when applicable
+
+Private proof material should not be copied into public feeds, profile payloads,
+or user-facing audit summaries.
+
+## Open Questions
+
+- What proof types should be accepted for account or publisher claims?
+- Which claim decisions are staff-only, and which can be automated?
+- Does verified state apply to accounts, publishers, namespaces, or all three?
+- Should official state remain publisher-only, matching the current
+  `officialPublishers` contract?
+- What correction or appeal path exists after suspension or revocation?

--- a/specs/profile-discovery-surfaces.md
+++ b/specs/profile-discovery-surfaces.md
@@ -1,0 +1,162 @@
+---
+summary: "Profile, feed, search, and discovery surfaces for ClawHub account and publisher feeds."
+read_when:
+  - Adding account or publisher profile feed surfaces
+  - Changing ClawHub search, browse, or discovery filters
+  - Displaying claim, verified, official, review, scan, follow, or local approval labels
+---
+
+# Profile And Discovery Surfaces
+
+Account and publisher feeds need human-readable ClawHub surfaces as much as
+machine-readable feed routes. Users should be able to inspect who published an
+entry, what state ClawHub actually knows, and which filters shaped the current
+view without confusing identity, review, approval, and install safety.
+
+This spec defines the profile and discovery surface expectations for future
+account and publisher feeds.
+
+## Surfaces
+
+ClawHub should provide or extend these surfaces:
+
+- account profile page
+- publisher profile page
+- account feed page
+- publisher feed page
+- search filter for followed publishers
+- search filter for official publishers
+- search filter or facet for reviewed entries when OpenClaw review state exists
+- search filter or facet for scan state when ClawHub has scan state
+
+Profile pages are the human-readable inspection surfaces. Feed pages expose the
+machine-readable feed and should link back to the corresponding profile page.
+
+The first shipped version should prioritize publisher profile and publisher feed
+surfaces because packages, skills, official state, and publishing authority are
+already publisher-scoped.
+
+## Profile Content
+
+Publisher profile pages should show:
+
+- stable publisher identity
+- display name, handle, avatar, and profile copy
+- claim, verified, and official state when available
+- follow control and current follow state
+- public packages and skills owned by the publisher
+- feed URL when the feed is public
+- source, package digest, scan, and review state only when ClawHub has real data
+  for those fields
+
+Account profile pages may aggregate one or more publishers owned by or linked to
+the account, but they should not imply that account-level identity automatically
+grants official state to every publisher the account can manage.
+
+Suspended or revoked publishers should remain resolvable for history and audit
+continuity, but their pages should clearly show restricted status and should not
+look active, endorsed, or safe to install from.
+
+## Display Rules
+
+Use separate labels for:
+
+- claimed
+- verified
+- official
+- OpenClaw reviewed
+- OpenClaw scanned
+- followed
+- locally approved
+
+Do not collapse these labels into one trust badge. A user should not have to
+guess whether "trusted" means identity, official publisher status, scan result,
+review result, local approval, or install eligibility.
+
+Display labels only when ClawHub has the backing state. Do not infer review or
+scan status from official state, follow state, package popularity, publisher
+name, profile copy, or feed presence.
+
+Package/source provenance should be shown separately from publisher identity.
+For example, a publisher can be official while a specific package still needs
+artifact integrity checks, scan results, OpenClaw review, or local approval
+before install.
+
+## Search And Discovery
+
+Search and browse surfaces may add filters such as:
+
+- people I follow
+- publishers I follow
+- official publishers
+- reviewed entries
+- scanned entries
+- public account feeds
+- public publisher feeds
+
+These filters should narrow or rank already eligible results. They must not
+override moderation, safety, visibility, deletion, scan, review, package
+integrity, or local approval gates.
+
+Unofficial and community results should remain discoverable unless the user
+explicitly applies a stricter filter.
+
+Official-publisher filters should mean exactly "publisher has ClawHub official
+publisher state." They should not imply OpenClaw reviewed, scanned, locally
+approved, or safe to install.
+
+## Empty And Restricted States
+
+Empty and filtered views should use plain user-facing explanations:
+
+- followed-publisher filter with no follows
+- followed-publisher filter with no matching results
+- official-publisher filter with no matching results
+- profile with no public feed entries
+- profile restricted because the publisher is suspended or revoked
+- feed unavailable because the profile is private or not public yet
+
+Empty states should provide the next useful action, such as clearing a filter,
+following publishers, viewing all results, or returning to the profile. They
+should not expose private moderation or review evidence.
+
+## Feed Page Behavior
+
+Human-readable feed pages should:
+
+- identify the account or publisher that owns the feed
+- link to the raw machine-readable feed
+- show the latest generated time and sequence when available
+- show whether the feed is public, restricted, suspended, or revoked
+- show entries with the same identity and trust labels used elsewhere
+
+Machine-readable feed responses should stay focused on the feed contract. Rich
+human explanation belongs on the profile/feed page, not inside every feed entry.
+
+## Accessibility And Copy
+
+Trust and state labels should have accessible names that describe the actual
+state, not only icons or colors. Copy should be short and literal:
+
+- "Official publisher"
+- "Verified identity"
+- "OpenClaw reviewed"
+- "Scan available"
+- "Following"
+- "Locally approved"
+- "Suspended publisher"
+- "Revoked publisher"
+
+Avoid labels such as "trusted" unless the exact trust source is shown nearby.
+
+## Open Questions
+
+- Does ClawHub need separate account profile URLs, or should publisher profiles
+  remain the primary public surface?
+- Should account feeds appear in global search by default?
+- What is the first user-facing noun: account feed, publisher feed, creator
+  feed, or profile feed?
+- Which existing labels and icons should be reused for official, scan, and
+  review state?
+- Should public follower counts appear on profile pages, or should follows stay
+  private initially?

--- a/src/__tests__/user-profile-route.test.tsx
+++ b/src/__tests__/user-profile-route.test.tsx
@@ -3,9 +3,12 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import type { ComponentType, ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Id } from "../../convex/_generated/dataModel";
+import type { PublicPublisherListItem } from "../lib/publicUser";
 import {
   buildPublisherCatalogCategoryOptions,
   buildPublisherGroupTabOptions,
+  buildPublisherProfileStateLabels,
   formatRelativeUpdatedAt,
   getCatalogItemShortTypeLabel,
   groupPublisherCatalogItemsByTopic,
@@ -62,13 +65,13 @@ async function loadRoute() {
   };
 }
 
-const publisher = {
-  _id: "publishers:nvidia",
+const publisher: PublicPublisherListItem = {
+  _id: "publishers:nvidia" as Id<"publishers">,
   _creationTime: 1,
   bio: "Official NVIDIA publisher.",
   displayName: "NVIDIA",
   handle: "nvidia",
-  image: null,
+  image: undefined,
   kind: "org" as const,
   githubHandle: "nvidia",
   official: true,
@@ -200,6 +203,22 @@ describe("user profile route", () => {
     ).toBeTruthy();
     expect(screen.getByRole("combobox", { name: "Sort" })).toBeTruthy();
     expect(screen.getByRole("combobox", { name: "Sort" }).textContent).toMatch(/^Sort$/i);
+  });
+
+  it("renders literal profile state labels without implying missing review states", async () => {
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    const profileState = screen.getByLabelText("Profile state");
+    expect(within(profileState).getByText("Official publisher")).toBeTruthy();
+    expect(within(profileState).getByText("Public profile")).toBeTruthy();
+    expect(within(profileState).getByText("Public catalog")).toBeTruthy();
+    expect(within(profileState).queryByText(/reviewed/i)).toBeNull();
+    expect(within(profileState).queryByText(/scanned/i)).toBeNull();
+    expect(within(profileState).queryByText(/following/i)).toBeNull();
+    expect(within(profileState).queryByText(/locally approved/i)).toBeNull();
   });
 
   it("opens plugins tab when publisher has plugins but no skills", async () => {
@@ -599,6 +618,21 @@ describe("publisher profile helpers", () => {
 
     const now = Date.UTC(2026, 5, 23, 12, 0, 0);
     expect(formatRelativeUpdatedAt(now - 3 * 24 * 60 * 60 * 1000, now)).toBe("3d ago");
+  });
+
+  it("builds profile state labels only from profile facts present on the publisher", () => {
+    expect(buildPublisherProfileStateLabels(publisher).map((label) => label.label)).toEqual([
+      "Official publisher",
+      "Public profile",
+      "Public catalog",
+    ]);
+    expect(
+      buildPublisherProfileStateLabels({
+        ...publisher,
+        official: false,
+        stats: { ...publisher.stats, skills: 0, packages: 0 },
+      }).map((label) => label.label),
+    ).toEqual(["Public profile"]);
   });
 
   it("builds category options from catalog items and matches category slugs", () => {

--- a/src/components/OfficialBadge.tsx
+++ b/src/components/OfficialBadge.tsx
@@ -10,7 +10,7 @@ export function OfficialTag({ className }: { className?: string }) {
           ? `official-tag rounded-[var(--oc-radius-control)] ${className}`
           : "official-tag rounded-[var(--oc-radius-control)]"
       }
-      aria-label="Official"
+      aria-label="Official publisher"
     >
       <BadgeCheck size={15} aria-hidden="true" className="official-badge-icon" />
       Official

--- a/src/publisher-profile.css
+++ b/src/publisher-profile.css
@@ -451,6 +451,36 @@
   cursor: pointer;
 }
 
+.publisher-profile-state-labels {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.publisher-profile-state-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  height: 30px;
+  padding: 0 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-pill);
+  background: color-mix(in srgb, var(--bg) 72%, transparent);
+  color: var(--ink-soft);
+  font-size: var(--fs-xs);
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.publisher-profile-state-label.is-official {
+  border-color: color-mix(in srgb, var(--official-fg) 42%, var(--line));
+  background: color-mix(in srgb, var(--official-bg) 72%, transparent);
+  color: var(--official-fg);
+}
+
 .publisher-profile-members-trigger {
   display: inline-flex;
   width: fit-content;

--- a/src/routes/user/$handle.tsx
+++ b/src/routes/user/$handle.tsx
@@ -11,9 +11,12 @@ import { usePaginatedQuery, useQuery } from "convex/react";
 import {
   ArrowRight,
   ArrowUpRight,
+  BadgeCheck,
   Building2,
   Download,
   Flag,
+  Globe2,
+  Library,
   MoreHorizontal,
   Plus,
   Search,
@@ -272,6 +275,13 @@ type PublisherStatCard = {
   icon: LucideIcon;
 };
 
+type PublisherProfileStateLabel = {
+  key: string;
+  label: string;
+  icon: LucideIcon;
+  tone?: "official";
+};
+
 export function buildPublisherStatCards(
   publisher: PublicPublisherProfileItem,
 ): PublisherStatCard[] {
@@ -291,6 +301,34 @@ export function buildPublisherStatCards(
   ];
 }
 
+export function buildPublisherProfileStateLabels(
+  publisher: PublicPublisherProfileItem,
+): PublisherProfileStateLabel[] {
+  const labels: PublisherProfileStateLabel[] = [
+    {
+      key: "public-profile",
+      label: "Public profile",
+      icon: Globe2,
+    },
+  ];
+  if (publisher.official) {
+    labels.unshift({
+      key: "official",
+      label: "Official publisher",
+      icon: BadgeCheck,
+      tone: "official",
+    });
+  }
+  if (publisher.stats.skills + publisher.stats.packages > 0) {
+    labels.push({
+      key: "public-catalog",
+      label: "Public catalog",
+      icon: Library,
+    });
+  }
+  return labels;
+}
+
 function PublisherProfileStatCards({ cards }: { cards: PublisherStatCard[] }) {
   return (
     <dl className="publisher-profile-stat-cards" aria-label="Publisher stats">
@@ -305,6 +343,26 @@ function PublisherProfileStatCards({ cards }: { cards: PublisherStatCard[] }) {
         );
       })}
     </dl>
+  );
+}
+
+function PublisherProfileStateLabels({ publisher }: { publisher: PublicPublisherProfileItem }) {
+  const labels = buildPublisherProfileStateLabels(publisher);
+  return (
+    <div className="publisher-profile-state-labels">
+      {labels.map((label) => {
+        const Icon = label.icon;
+        return (
+          <span
+            key={label.key}
+            className={`publisher-profile-state-label${label.tone ? ` is-${label.tone}` : ""}`}
+          >
+            <Icon size={14} aria-hidden="true" />
+            {label.label}
+          </span>
+        );
+      })}
+    </div>
   );
 }
 
@@ -775,6 +833,14 @@ export function PublisherProfilePage({
                 </div>
 
                 <div className="publisher-profile-details-inline">
+                  <section
+                    className="publisher-profile-detail-block publisher-profile-detail-block-fit publisher-profile-details-state"
+                    aria-label="Profile state"
+                  >
+                    <h2 className="publisher-profile-detail-label">Status</h2>
+                    <PublisherProfileStateLabels publisher={publisher} />
+                  </section>
+
                   {showMembers ? (
                     <section
                       className="publisher-profile-detail-block publisher-profile-detail-block-fit publisher-profile-details-members"


### PR DESCRIPTION
## Summary

- define separate claim, official, and restriction facts for ClawHub publishers
- derive official state only from ClawHub-managed official-publisher records
- keep claim, verification, suspension, and revocation concepts separate from feed trust
- rename publisher discovery surfaces from generic `Verified` wording to `Official`
- show explicit `Official publisher`, `Public profile`, and `Public catalog` labels where supported by existing facts
- preserve compatibility with legacy publisher ownership and older admin responses

## Review unit

This PR combines publisher-state facts with the profile/discovery labels that consume existing publisher facts. It does not add following, feed transport, scan authority, install eligibility, or OpenClaw registry decisions.

## Trust boundary

Publisher official state is a ClawHub identity fact. It does not imply that a feed is signed, an artifact is reviewed or scanned, or an install is locally approved.

## Validation

- targeted publisher state, publisher route, schema, creators-route, and profile-route coverage from the two original slices
- targeted oxfmt over the combined diff
- `git diff --check`
- combined branch resolved only the specs index and retains both source specifications
- focused tests were not rerun in the consolidation worktree because dependencies are not installed; the original slices carried their own focused proof
