### PR TITLE
feat: clarify publisher discovery state labels

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -19,6 +19,7 @@ into `docs/` and leave only the design record here.
 
 - `spec.md`: product + implementation spec for the original registry model.
 - `orgs.md`: org, publisher membership, and scoped identity plan.
+- `profile-discovery-surfaces.md`: profile, feed, search, and discovery surfaces for ClawHub account and publisher feeds.
 - `github-import.md`: GitHub import feature spec.
 - `github-backed-skills.md`: source-backed GitHub skills catalog and install invariants.
 - `diffing.md`: skill version diffing UI/API design.

--- a/specs/profile-discovery-surfaces.md
+++ b/specs/profile-discovery-surfaces.md
@@ -1,0 +1,162 @@
+---
+summary: "Profile, feed, search, and discovery surfaces for ClawHub account and publisher feeds."
+read_when:
+  - Adding account or publisher profile feed surfaces
+  - Changing ClawHub search, browse, or discovery filters
+  - Displaying claim, verified, official, review, scan, follow, or local approval labels
+---
+
+# Profile And Discovery Surfaces
+
+Account and publisher feeds need human-readable ClawHub surfaces as much as
+machine-readable feed routes. Users should be able to inspect who published an
+entry, what state ClawHub actually knows, and which filters shaped the current
+view without confusing identity, review, approval, and install safety.
+
+This spec defines the profile and discovery surface expectations for future
+account and publisher feeds.
+
+## Surfaces
+
+ClawHub should provide or extend these surfaces:
+
+- account profile page
+- publisher profile page
+- account feed page
+- publisher feed page
+- search filter for followed publishers
+- search filter for official publishers
+- search filter or facet for reviewed entries when OpenClaw review state exists
+- search filter or facet for scan state when ClawHub has scan state
+
+Profile pages are the human-readable inspection surfaces. Feed pages expose the
+machine-readable feed and should link back to the corresponding profile page.
+
+The first shipped version should prioritize publisher profile and publisher feed
+surfaces because packages, skills, official state, and publishing authority are
+already publisher-scoped.
+
+## Profile Content
+
+Publisher profile pages should show:
+
+- stable publisher identity
+- display name, handle, avatar, and profile copy
+- claim, verified, and official state when available
+- follow control and current follow state
+- public packages and skills owned by the publisher
+- feed URL when the feed is public
+- source, package digest, scan, and review state only when ClawHub has real data
+  for those fields
+
+Account profile pages may aggregate one or more publishers owned by or linked to
+the account, but they should not imply that account-level identity automatically
+grants official state to every publisher the account can manage.
+
+Suspended or revoked publishers should remain resolvable for history and audit
+continuity, but their pages should clearly show restricted status and should not
+look active, endorsed, or safe to install from.
+
+## Display Rules
+
+Use separate labels for:
+
+- claimed
+- verified
+- official
+- OpenClaw reviewed
+- OpenClaw scanned
+- followed
+- locally approved
+
+Do not collapse these labels into one trust badge. A user should not have to
+guess whether "trusted" means identity, official publisher status, scan result,
+review result, local approval, or install eligibility.
+
+Display labels only when ClawHub has the backing state. Do not infer review or
+scan status from official state, follow state, package popularity, publisher
+name, profile copy, or feed presence.
+
+Package/source provenance should be shown separately from publisher identity.
+For example, a publisher can be official while a specific package still needs
+artifact integrity checks, scan results, OpenClaw review, or local approval
+before install.
+
+## Search And Discovery
+
+Search and browse surfaces may add filters such as:
+
+- people I follow
+- publishers I follow
+- official publishers
+- reviewed entries
+- scanned entries
+- public account feeds
+- public publisher feeds
+
+These filters should narrow or rank already eligible results. They must not
+override moderation, safety, visibility, deletion, scan, review, package
+integrity, or local approval gates.
+
+Unofficial and community results should remain discoverable unless the user
+explicitly applies a stricter filter.
+
+Official-publisher filters should mean exactly "publisher has ClawHub official
+publisher state." They should not imply OpenClaw reviewed, scanned, locally
+approved, or safe to install.
+
+## Empty And Restricted States
+
+Empty and filtered views should use plain user-facing explanations:
+
+- followed-publisher filter with no follows
+- followed-publisher filter with no matching results
+- official-publisher filter with no matching results
+- profile with no public feed entries
+- profile restricted because the publisher is suspended or revoked
+- feed unavailable because the profile is private or not public yet
+
+Empty states should provide the next useful action, such as clearing a filter,
+following publishers, viewing all results, or returning to the profile. They
+should not expose private moderation or review evidence.
+
+## Feed Page Behavior
+
+Human-readable feed pages should:
+
+- identify the account or publisher that owns the feed
+- link to the raw machine-readable feed
+- show the latest generated time and sequence when available
+- show whether the feed is public, restricted, suspended, or revoked
+- show entries with the same identity and trust labels used elsewhere
+
+Machine-readable feed responses should stay focused on the feed contract. Rich
+human explanation belongs on the profile/feed page, not inside every feed entry.
+
+## Accessibility And Copy
+
+Trust and state labels should have accessible names that describe the actual
+state, not only icons or colors. Copy should be short and literal:
+
+- "Official publisher"
+- "Verified identity"
+- "OpenClaw reviewed"
+- "Scan available"
+- "Following"
+- "Locally approved"
+- "Suspended publisher"
+- "Revoked publisher"
+
+Avoid labels such as "trusted" unless the exact trust source is shown nearby.
+
+## Open Questions
+
+- Does ClawHub need separate account profile URLs, or should publisher profiles
+  remain the primary public surface?
+- Should account feeds appear in global search by default?
+- What is the first user-facing noun: account feed, publisher feed, creator
+  feed, or profile feed?
+- Which existing labels and icons should be reused for official, scan, and
+  review state?
+- Should public follower counts appear on profile pages, or should follows stay
+  private initially?

--- a/src/__tests__/creators-route.test.tsx
+++ b/src/__tests__/creators-route.test.tsx
@@ -192,7 +192,7 @@ describe("creators route", () => {
     expect(screen.getByRole("heading", { name: "Creators" })).toBeTruthy();
     expect(screen.queryByText("17")).toBeNull();
     expect(screen.getByRole("radio", { name: "All" })).toBeTruthy();
-    expect(screen.getByRole("radio", { name: "Verified" })).toBeTruthy();
+    expect(screen.getByRole("radio", { name: "Official" })).toBeTruthy();
     expect(screen.getByRole("radio", { name: "Organizations" })).toBeTruthy();
     expect(screen.getByRole("radio", { name: "Users" })).toBeTruthy();
     expect(screen.queryByText("Builders")).toBeNull();

--- a/src/__tests__/user-profile-route.test.tsx
+++ b/src/__tests__/user-profile-route.test.tsx
@@ -3,9 +3,12 @@
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import type { ComponentType, ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Id } from "../../convex/_generated/dataModel";
+import type { PublicPublisherListItem } from "../lib/publicUser";
 import {
   buildPublisherCatalogCategoryOptions,
   buildPublisherGroupTabOptions,
+  buildPublisherProfileStateLabels,
   formatRelativeUpdatedAt,
   getCatalogItemShortTypeLabel,
   groupPublisherCatalogItemsByTopic,
@@ -61,13 +64,13 @@ async function loadRoute() {
   };
 }
 
-const publisher = {
-  _id: "publishers:nvidia",
+const publisher: PublicPublisherListItem = {
+  _id: "publishers:nvidia" as Id<"publishers">,
   _creationTime: 1,
   bio: "Official NVIDIA publisher.",
   displayName: "NVIDIA",
   handle: "nvidia",
-  image: null,
+  image: undefined,
   kind: "org" as const,
   official: true,
   publishedItems: [],
@@ -140,6 +143,22 @@ describe("user profile route", () => {
     ).toBeTruthy();
     expect(screen.getByRole("combobox", { name: "Sort" })).toBeTruthy();
     expect(screen.getByRole("combobox", { name: "Sort" }).textContent).toMatch(/^Sort$/i);
+  });
+
+  it("renders literal profile state labels without implying missing review states", async () => {
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    const profileState = screen.getByLabelText("Profile state");
+    expect(within(profileState).getByText("Official publisher")).toBeTruthy();
+    expect(within(profileState).getByText("Public profile")).toBeTruthy();
+    expect(within(profileState).getByText("Public catalog")).toBeTruthy();
+    expect(within(profileState).queryByText(/reviewed/i)).toBeNull();
+    expect(within(profileState).queryByText(/scanned/i)).toBeNull();
+    expect(within(profileState).queryByText(/following/i)).toBeNull();
+    expect(within(profileState).queryByText(/locally approved/i)).toBeNull();
   });
 
   it("opens plugins tab when publisher has plugins but no skills", async () => {
@@ -527,6 +546,21 @@ describe("publisher profile helpers", () => {
 
     const now = Date.UTC(2026, 5, 23, 12, 0, 0);
     expect(formatRelativeUpdatedAt(now - 3 * 24 * 60 * 60 * 1000, now)).toBe("3d ago");
+  });
+
+  it("builds profile state labels only from profile facts present on the publisher", () => {
+    expect(buildPublisherProfileStateLabels(publisher).map((label) => label.label)).toEqual([
+      "Official publisher",
+      "Public profile",
+      "Public catalog",
+    ]);
+    expect(
+      buildPublisherProfileStateLabels({
+        ...publisher,
+        official: false,
+        stats: { ...publisher.stats, skills: 0, packages: 0 },
+      }).map((label) => label.label),
+    ).toEqual(["Public profile"]);
   });
 
   it("builds category options from catalog items and matches category slugs", () => {

--- a/src/components/OfficialBadge.tsx
+++ b/src/components/OfficialBadge.tsx
@@ -6,10 +6,10 @@ export function OfficialTag({ className }: { className?: string }) {
     <Badge
       variant="official"
       className={className ? `official-tag rounded-full ${className}` : "official-tag rounded-full"}
-      aria-label="Verified"
+      aria-label="Official publisher"
     >
       <BadgeCheck size={15} aria-hidden="true" className="official-badge-icon" />
-      Verified
+      Official
     </Badge>
   );
 }

--- a/src/publisher-profile.css
+++ b/src/publisher-profile.css
@@ -451,6 +451,36 @@
   cursor: pointer;
 }
 
+.publisher-profile-state-labels {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.publisher-profile-state-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  height: 30px;
+  padding: 0 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--r-pill);
+  background: color-mix(in srgb, var(--bg) 72%, transparent);
+  color: var(--ink-soft);
+  font-size: var(--fs-xs);
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.publisher-profile-state-label.is-official {
+  border-color: color-mix(in srgb, var(--official-fg) 42%, var(--line));
+  background: color-mix(in srgb, var(--official-bg) 72%, transparent);
+  color: var(--official-fg);
+}
+
 .publisher-profile-members-trigger {
   display: inline-flex;
   width: fit-content;

--- a/src/routes/creators/index.tsx
+++ b/src/routes/creators/index.tsx
@@ -50,7 +50,7 @@ const PUBLISHER_KIND_OPTIONS = [
   { value: undefined, label: "All" },
   {
     value: "official",
-    label: "Verified",
+    label: "Official",
     icon: <BadgeCheck size={14} strokeWidth={2.25} aria-hidden="true" />,
   },
   { value: "orgs", label: "Organizations", mobileLabel: "Orgs" },

--- a/src/routes/user/$handle.tsx
+++ b/src/routes/user/$handle.tsx
@@ -11,9 +11,12 @@ import { usePaginatedQuery, useQuery } from "convex/react";
 import {
   ArrowRight,
   ArrowUpRight,
+  BadgeCheck,
   Building2,
   Download,
   Flag,
+  Globe2,
+  Library,
   MoreHorizontal,
   Plus,
   Search,
@@ -265,6 +268,13 @@ type PublisherStatCard = {
   icon: LucideIcon;
 };
 
+type PublisherProfileStateLabel = {
+  key: string;
+  label: string;
+  icon: LucideIcon;
+  tone?: "official";
+};
+
 export function buildPublisherStatCards(publisher: PublicPublisherListItem): PublisherStatCard[] {
   return [
     {
@@ -282,6 +292,34 @@ export function buildPublisherStatCards(publisher: PublicPublisherListItem): Pub
   ];
 }
 
+export function buildPublisherProfileStateLabels(
+  publisher: PublicPublisherListItem,
+): PublisherProfileStateLabel[] {
+  const labels: PublisherProfileStateLabel[] = [
+    {
+      key: "public-profile",
+      label: "Public profile",
+      icon: Globe2,
+    },
+  ];
+  if (publisher.official) {
+    labels.unshift({
+      key: "official",
+      label: "Official publisher",
+      icon: BadgeCheck,
+      tone: "official",
+    });
+  }
+  if (publisher.stats.skills + publisher.stats.packages > 0) {
+    labels.push({
+      key: "public-catalog",
+      label: "Public catalog",
+      icon: Library,
+    });
+  }
+  return labels;
+}
+
 function PublisherProfileStatCards({ cards }: { cards: PublisherStatCard[] }) {
   return (
     <dl className="publisher-profile-stat-cards" aria-label="Publisher stats">
@@ -296,6 +334,26 @@ function PublisherProfileStatCards({ cards }: { cards: PublisherStatCard[] }) {
         );
       })}
     </dl>
+  );
+}
+
+function PublisherProfileStateLabels({ publisher }: { publisher: PublicPublisherListItem }) {
+  const labels = buildPublisherProfileStateLabels(publisher);
+  return (
+    <div className="publisher-profile-state-labels">
+      {labels.map((label) => {
+        const Icon = label.icon;
+        return (
+          <span
+            key={label.key}
+            className={`publisher-profile-state-label${label.tone ? ` is-${label.tone}` : ""}`}
+          >
+            <Icon size={14} aria-hidden="true" />
+            {label.label}
+          </span>
+        );
+      })}
+    </div>
   );
 }
 
@@ -752,6 +810,14 @@ export function PublisherProfilePage({
                 </div>
 
                 <div className="publisher-profile-details-inline">
+                  <section
+                    className="publisher-profile-detail-block publisher-profile-detail-block-fit publisher-profile-details-state"
+                    aria-label="Profile state"
+                  >
+                    <h2 className="publisher-profile-detail-label">Status</h2>
+                    <PublisherProfileStateLabels publisher={publisher} />
+                  </section>
+
                   {showMembers ? (
                     <section
                       className="publisher-profile-detail-block publisher-profile-detail-block-fit publisher-profile-details-members"


### PR DESCRIPTION
## Summary
- Keep the profile/discovery surfaces spec and make this PR code-backed.
- Rename the creators official filter and publisher title tag from generic `Verified` wording to `Official` where the backing fact is ClawHub official publisher state.
- Add explicit publisher profile status labels for facts present on the existing profile payload: `Official publisher`, `Public profile`, and `Public catalog`.
- Add route/helper coverage proving profile labels do not imply missing OpenClaw review, scan, follow, or local approval state.

## Scope notes
- This slice only clarifies current profile/discovery presentation using data available on this branch.
- It does not add follow controls, feed pages, OpenClaw registry review state, scan state, local approval state, install eligibility, or signed feed trust. Those remain later stack slices after the backing data exists.
- Compact package/plugin badges still use existing `Verified` wording outside this publisher-profile surface to avoid broad unrelated UI churn.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `npx --yes oxfmt --check src/routes/creators/index.tsx 'src/routes/user/$handle.tsx' src/publisher-profile.css src/components/OfficialBadge.tsx src/__tests__/creators-route.test.tsx src/__tests__/user-profile-route.test.tsx`
- `codex review --uncommitted` - no actionable findings in staged implementation before amend

## Not run locally
- `npx vitest run src/__tests__/creators-route.test.tsx src/__tests__/user-profile-route.test.tsx` could not start in this Windows checkout because `vitest.config.ts` imports `vitest/config` and local dependencies are not installed (`Cannot find package 'vitest'`). CI should cover the focused tests after push.