### PR TITLE
fix(convex): release skill stat doc sync leases on failure

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2374,6 +2374,9 @@ const skillStatDocSyncLeases = defineTable({
   lastFinishedAt: v.optional(v.number()),
   lastProcessedAt: v.optional(v.number()),
   lastProcessedCount: v.optional(v.number()),
+  lastError: v.optional(v.string()),
+  lastErrorAt: v.optional(v.number()),
+  lastErrorProcessedCount: v.optional(v.number()),
 }).index("by_key", ["key"]);
 
 const skillReports = defineTable({

--- a/convex/skillStatEvents.test.ts
+++ b/convex/skillStatEvents.test.ts
@@ -70,8 +70,13 @@ const processSkillStatEventsInternalHandler = (
   processSkillStatEventsInternal as unknown as {
     _handler: (
       ctx: unknown,
-      args: { batchSize?: number; maxBatches?: number },
-    ) => Promise<{ processed: number; scheduledContinuation: boolean }>;
+      args: { batchSize?: number; maxBatches?: number; retryCount?: number },
+    ) => Promise<{
+      processed: number;
+      scheduledContinuation: boolean;
+      stoppedReason?: "empty" | "max_batches" | "lease_lost" | "error";
+      error?: string;
+    }>;
   }
 )._handler;
 
@@ -255,7 +260,7 @@ describe("skill stat events", () => {
     },
   );
 
-  it("bounds action drain work so stale continuations do not crawl or time out", async () => {
+  it("bounds action drain work and preserves requested small-batch drains", async () => {
     const runMutation = vi.fn(async (_ref: unknown, args: Record<string, unknown>) => {
       if ("leaseMs" in args) {
         return {
@@ -289,11 +294,113 @@ describe("skill stat events", () => {
       return args && typeof args === "object" && "leaseOwner" in args && "batchSize" in args;
     });
     expect(batchCalls).toHaveLength(5);
-    expect(batchCalls[0]?.[1]).toMatchObject({ batchSize: 100 });
+    expect(batchCalls[0]?.[1]).toMatchObject({ batchSize: 10 });
     expect(scheduler.runAfter.mock.calls[0]?.[2]).toMatchObject({
-      batchSize: 100,
+      batchSize: 10,
       maxBatches: 5,
+      retryCount: 0,
     });
+  });
+
+  it("releases the doc-sync lease and schedules a smaller retry when a batch throws", async () => {
+    const runMutation = vi.fn(async (_ref: unknown, args: Record<string, unknown>) => {
+      if ("leaseMs" in args) {
+        return {
+          acquired: true,
+          leaseOwner: "test-lease",
+          leaseExpiresAt: Date.now() + 60_000,
+          now: Date.now(),
+        };
+      }
+      if ("leaseOwner" in args && "batchSize" in args) {
+        throw new Error("transient batch failure");
+      }
+      if ("processed" in args) {
+        return { released: true };
+      }
+      throw new Error(`unexpected mutation args ${JSON.stringify(args)}`);
+    });
+    const scheduler = { runAfter: vi.fn() };
+
+    await expect(
+      processSkillStatEventsInternalHandler(
+        { runMutation, scheduler },
+        { batchSize: 100, maxBatches: 5 },
+      ),
+    ).resolves.toMatchObject({
+      processed: 0,
+      scheduledContinuation: true,
+      stoppedReason: "error",
+      error: "Error: transient batch failure",
+    });
+
+    expect(runMutation).toHaveBeenCalledWith(
+      apiRefs.releaseSkillStatDocSyncLeaseInternal,
+      expect.objectContaining({
+        leaseOwner: "test-lease",
+        processed: 0,
+        error: "Error: transient batch failure",
+      }),
+    );
+    expect(scheduler.runAfter).toHaveBeenCalledWith(
+      30_000,
+      apiRefs.processSkillStatEventsInternal,
+      {
+        batchSize: 50,
+        maxBatches: 1,
+        retryCount: 1,
+      },
+    );
+  });
+
+  it("records release errors on the doc-sync lease", async () => {
+    const now = 1_000;
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now);
+    const patch = vi.fn();
+    const lease = {
+      _id: "skillStatDocSyncLeases:1",
+      key: "skill_doc_stat_sync",
+      leaseOwner: "test-lease",
+      leaseExpiresAt: now + 60_000,
+      updatedAt: now,
+      lastProcessedCount: 50,
+    };
+    const { releaseSkillStatDocSyncLeaseInternal } = await import("./skillStatEvents");
+    const releaseHandler = (
+      releaseSkillStatDocSyncLeaseInternal as unknown as {
+        _handler: (
+          ctx: unknown,
+          args: { leaseOwner: string; processed?: number; error?: string },
+        ) => Promise<{ released: boolean }>;
+      }
+    )._handler;
+
+    await expect(
+      releaseHandler(
+        {
+          db: {
+            patch,
+            query: vi.fn(() => ({
+              withIndex: () => ({
+                unique: async () => lease,
+              }),
+            })),
+          },
+        },
+        { leaseOwner: "test-lease", processed: 12, error: "boom" },
+      ),
+    ).resolves.toEqual({ released: true });
+
+    expect(patch).toHaveBeenCalledWith("skillStatDocSyncLeases:1", {
+      leaseExpiresAt: now,
+      updatedAt: now,
+      lastFinishedAt: now,
+      lastProcessedCount: 12,
+      lastError: "boom",
+      lastErrorAt: now,
+      lastErrorProcessedCount: 12,
+    });
+    nowSpy.mockRestore();
   });
 
   it("applies install deltas to skill ranking fields", async () => {

--- a/convex/skillStatEvents.ts
+++ b/convex/skillStatEvents.ts
@@ -182,6 +182,8 @@ const DEFAULT_DOC_SYNC_BATCH_SIZE = 100;
 const MAX_DOC_SYNC_BATCH_SIZE = 100;
 const DEFAULT_DOC_SYNC_MAX_BATCHES = 5;
 const MAX_DOC_SYNC_MAX_BATCHES = 5;
+const MAX_DOC_SYNC_FAILURE_RETRIES = 3;
+const DOC_SYNC_FAILURE_RETRY_BASE_MS = 30_000;
 export const PROCESSED_SKILL_STAT_EVENT_PRUNE_CONFIRMATION_TOKEN =
   "PRUNE_PROCESSED_SKILL_STAT_EVENTS";
 const DEFAULT_PROCESSED_EVENT_RETENTION_DAYS = 7;
@@ -227,8 +229,9 @@ type SkillStatDocSyncActionResult =
       processed: number;
       skillsUpdated: number;
       batches: number;
-      stoppedReason: "empty" | "max_batches" | "lease_lost";
+      stoppedReason: "empty" | "max_batches" | "lease_lost" | "error";
       scheduledContinuation: boolean;
+      error?: string;
     };
 
 type ProcessedSkillStatEventPruneBatchResult = {
@@ -277,15 +280,28 @@ function normalizeDocSyncBatchSize(batchSize: number | undefined) {
 }
 
 function normalizeDocSyncDrainBatchSize(batchSize: number | undefined) {
-  return clampInt(
-    batchSize ?? DEFAULT_DOC_SYNC_BATCH_SIZE,
-    DEFAULT_DOC_SYNC_BATCH_SIZE,
-    MAX_DOC_SYNC_BATCH_SIZE,
-  );
+  return clampInt(batchSize ?? DEFAULT_DOC_SYNC_BATCH_SIZE, 1, MAX_DOC_SYNC_BATCH_SIZE);
 }
 
 function normalizeDocSyncMaxBatches(maxBatches: number | undefined) {
   return clampInt(maxBatches ?? DEFAULT_DOC_SYNC_MAX_BATCHES, 1, MAX_DOC_SYNC_MAX_BATCHES);
+}
+
+function normalizeDocSyncRetryCount(retryCount: number | undefined) {
+  return clampInt(retryCount ?? 0, 0, MAX_DOC_SYNC_FAILURE_RETRIES);
+}
+
+function nextDocSyncRetryBatchSize(batchSize: number) {
+  return Math.max(1, Math.floor(batchSize / 2));
+}
+
+function docSyncRetryDelayMs(retryCount: number) {
+  return DOC_SYNC_FAILURE_RETRY_BASE_MS * 2 ** retryCount;
+}
+
+function formatDocSyncError(error: unknown) {
+  if (error instanceof Error) return `${error.name}: ${error.message}`;
+  return String(error);
 }
 
 function normalizeProcessedEventRetentionDays(retentionDays: number | undefined) {
@@ -373,6 +389,7 @@ export const releaseSkillStatDocSyncLeaseInternal = internalMutation({
   args: {
     leaseOwner: v.string(),
     processed: v.optional(v.number()),
+    error: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const now = Date.now();
@@ -385,11 +402,15 @@ export const releaseSkillStatDocSyncLeaseInternal = internalMutation({
       return { released: false as const };
     }
 
+    const error = args.error?.slice(0, 2_000);
     await ctx.db.patch(lease._id, {
       leaseExpiresAt: now,
       updatedAt: now,
       lastFinishedAt: now,
       lastProcessedCount: args.processed ?? lease.lastProcessedCount,
+      lastError: error,
+      lastErrorAt: error ? now : undefined,
+      lastErrorProcessedCount: error ? (args.processed ?? 0) : undefined,
     });
 
     return { released: true as const };
@@ -530,12 +551,12 @@ export const processSkillStatEventsInternal: ReturnType<typeof internalAction> =
   args: {
     batchSize: v.optional(v.number()),
     maxBatches: v.optional(v.number()),
+    retryCount: v.optional(v.number()),
   },
   handler: async (ctx, args): Promise<SkillStatDocSyncActionResult> => {
-    // Older scheduled continuations may carry a tiny batch size. Floor action
-    // drains to the production batch size so stale jobs cannot crawl forever.
     const batchSize = normalizeDocSyncDrainBatchSize(args.batchSize);
     const maxBatches = normalizeDocSyncMaxBatches(args.maxBatches);
+    const retryCount = normalizeDocSyncRetryCount(args.retryCount);
     const claim: ClaimSkillStatDocSyncLeaseResult = await ctx.runMutation(
       internal.skillStatEvents.claimSkillStatDocSyncLeaseInternal,
       {
@@ -558,34 +579,67 @@ export const processSkillStatEventsInternal: ReturnType<typeof internalAction> =
     let skillsUpdated = 0;
     let batches = 0;
     let hasMore = false;
-    let stoppedReason: "empty" | "max_batches" | "lease_lost" = "empty";
+    let stoppedReason: "empty" | "max_batches" | "lease_lost" | "error" = "empty";
 
-    for (let index = 0; index < maxBatches; index += 1) {
-      const batch: SkillStatDocSyncBatchResult = await ctx.runMutation(
-        internal.skillStatEvents.processSkillStatEventBatchInternal,
-        {
-          batchSize,
-          leaseOwner: claim.leaseOwner,
-        },
-      );
+    try {
+      for (let index = 0; index < maxBatches; index += 1) {
+        const batch: SkillStatDocSyncBatchResult = await ctx.runMutation(
+          internal.skillStatEvents.processSkillStatEventBatchInternal,
+          {
+            batchSize,
+            leaseOwner: claim.leaseOwner,
+          },
+        );
 
-      if (batch.skipped === "lease_lost") {
-        stoppedReason = "lease_lost";
-        hasMore = false;
-        break;
+        if (batch.skipped === "lease_lost") {
+          stoppedReason = "lease_lost";
+          hasMore = false;
+          break;
+        }
+
+        batches += 1;
+        processed += batch.processed;
+        skillsUpdated += batch.skillsUpdated;
+        hasMore = batch.hasMore;
+
+        if (!batch.hasMore) {
+          stoppedReason = "empty";
+          break;
+        }
+
+        stoppedReason = "max_batches";
+      }
+    } catch (error) {
+      const errorMessage = formatDocSyncError(error);
+      stoppedReason = "error";
+      await ctx.runMutation(internal.skillStatEvents.releaseSkillStatDocSyncLeaseInternal, {
+        leaseOwner: claim.leaseOwner,
+        processed,
+        error: errorMessage,
+      });
+
+      const shouldRetry = retryCount < MAX_DOC_SYNC_FAILURE_RETRIES;
+      if (shouldRetry) {
+        await ctx.scheduler.runAfter(
+          docSyncRetryDelayMs(retryCount),
+          internal.skillStatEvents.processSkillStatEventsInternal,
+          {
+            batchSize: nextDocSyncRetryBatchSize(batchSize),
+            maxBatches: 1,
+            retryCount: retryCount + 1,
+          },
+        );
       }
 
-      batches += 1;
-      processed += batch.processed;
-      skillsUpdated += batch.skillsUpdated;
-      hasMore = batch.hasMore;
-
-      if (!batch.hasMore) {
-        stoppedReason = "empty";
-        break;
-      }
-
-      stoppedReason = "max_batches";
+      return {
+        acquired: true as const,
+        processed,
+        skillsUpdated,
+        batches,
+        stoppedReason,
+        scheduledContinuation: shouldRetry,
+        error: errorMessage,
+      };
     }
 
     await ctx.runMutation(internal.skillStatEvents.releaseSkillStatDocSyncLeaseInternal, {
@@ -597,6 +651,7 @@ export const processSkillStatEventsInternal: ReturnType<typeof internalAction> =
       await ctx.scheduler.runAfter(0, internal.skillStatEvents.processSkillStatEventsInternal, {
         batchSize,
         maxBatches,
+        retryCount: 0,
       });
     }
 
@@ -656,6 +711,9 @@ export const getSkillStatDocSyncStatusInternal = internalQuery({
             lastFinishedAt: lease.lastFinishedAt,
             lastProcessedAt: lease.lastProcessedAt,
             lastProcessedCount: lease.lastProcessedCount,
+            lastError: lease.lastError,
+            lastErrorAt: lease.lastErrorAt,
+            lastErrorProcessedCount: lease.lastErrorProcessedCount,
           }
         : null,
       now,


### PR DESCRIPTION
## Summary
- release the skill-doc stat sync lease when a batch throws instead of leaving the drain stuck behind an expired/stale lease
- record the last doc-sync error on the lease for operator visibility
- schedule bounded smaller retries after batch failures, while keeping successful continuations at the requested drain size

## Validation
- `bun run format:check -- convex/skillStatEvents.ts convex/skillStatEvents.test.ts convex/schema.ts`
- `bun run test convex/skillStatEvents.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `.agents/skills/autoreview/scripts/autoreview --mode local` clean, no accepted/actionable findings

## Prod context
Production currently still has a skill stat doc-sync backlog. This PR is intended to make the drain recover from batch failures and expose any remaining poison row/error instead of silently stopping.
