### PR TITLE
fix: improve publisher abuse scan resilience

### DIFF
--- a/convex/crons.test.ts
+++ b/convex/crons.test.ts
@@ -148,7 +148,7 @@ describe("crons", () => {
       mocks.publisherAbuseScoreRefreshRef,
       {
         batchSize: 250,
-        maxPages: 5,
+        maxPages: 20,
         trigger: "cron",
       },
     );

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -101,7 +101,7 @@ if (process.env.CLAWHUB_DISABLE_CRONS !== "1") {
     "publisher-abuse-score-refresh",
     { hours: 24 },
     internal.publisherAbuse.runPublisherAbuseScoreRunInternal,
-    { batchSize: 250, maxPages: 5, trigger: "cron" },
+    { batchSize: 250, maxPages: 20, trigger: "cron" },
   );
 
   crons.interval(

--- a/convex/publisherAbuse.test.ts
+++ b/convex/publisherAbuse.test.ts
@@ -7932,6 +7932,50 @@ describe("publisher abuse dry-run persistence", () => {
     });
   });
 
+  it("does not retry transient score run failures when telemetry finds an inactive run", async () => {
+    const transientError = new Error("Your request couldn't be completed. Try again later.");
+    const scheduler = { runAfter: vi.fn(async () => null) };
+    const runMutation = vi.fn(async (target: symbol, _args?: unknown) => {
+      const targetName = String(target);
+      if (targetName.includes("collectPublisherAbuseScoresPageInternal")) {
+        throw transientError;
+      }
+      if (targetName.includes("recordPublisherAbuseScoreRunTransientErrorInternal")) {
+        return { ok: true, recorded: false };
+      }
+      if (targetName.includes("markPublisherAbuseScoreRunFailedInternal")) {
+        throw new Error("inactive transient retry should not mark the run failed");
+      }
+      throw new Error(`unexpected mutation ${targetName}`);
+    });
+    const ctx = {
+      scheduler,
+      runQuery: vi.fn(async () => ({
+        runId: "publisherAbuseScoreRuns:run",
+        phase: "collecting",
+        status: "running",
+      })),
+      runMutation,
+    };
+
+    await expect(
+      runHandler(ctx, { runId: "publisherAbuseScoreRuns:run", batchSize: 100, maxPages: 1 }),
+    ).resolves.toEqual({
+      ok: true,
+      runId: "publisherAbuseScoreRuns:run",
+      pages: 0,
+      isDone: true,
+    });
+
+    expect(String(runMutation.mock.calls[0]?.[0])).toContain(
+      "collectPublisherAbuseScoresPageInternal",
+    );
+    expect(String(runMutation.mock.calls[1]?.[0])).toContain(
+      "recordPublisherAbuseScoreRunTransientErrorInternal",
+    );
+    expect(scheduler.runAfter).not.toHaveBeenCalled();
+  });
+
   it("marks transient score run failures failed after the retry budget is exhausted", async () => {
     const transientError = new Error("changed while this mutation was being run");
     const scheduler = { runAfter: vi.fn(async () => null) };

--- a/convex/publisherAbuse.test.ts
+++ b/convex/publisherAbuse.test.ts
@@ -61,6 +61,9 @@ vi.mock("./_generated/api", () => ({
       ),
       getPublisherAbuseAutobanEnabledInternal: Symbol("getPublisherAbuseAutobanEnabledInternal"),
       processPublisherAbuseAutobansInternal: Symbol("processPublisherAbuseAutobansInternal"),
+      recordPublisherAbuseScoreRunTransientErrorInternal: Symbol(
+        "recordPublisherAbuseScoreRunTransientErrorInternal",
+      ),
       recordPublisherAbuseWarningSentInternal: Symbol("recordPublisherAbuseWarningSentInternal"),
       runPublisherAbuseScoreRunInternal: Symbol("runPublisherAbuseScoreRunInternal"),
       runTemporalPublisherAbuseScanInternal: Symbol("runTemporalPublisherAbuseScanInternal"),
@@ -123,6 +126,7 @@ const runHandler = (
       maxPages?: number;
       trigger?: "cron" | "manual";
       actorUserId?: string;
+      retryAttempt?: number;
     },
     { ok: true; runId: string; pages: number; isDone: boolean }
   >
@@ -7618,7 +7622,7 @@ describe("publisher abuse dry-run persistence", () => {
     });
 
     expect(scheduler.runAfter).toHaveBeenCalledWith(
-      60_000,
+      5_000,
       expect.anything(),
       expect.objectContaining({ runId: "publisherAbuseScoreRuns:run" }),
     );
@@ -7745,7 +7749,7 @@ describe("publisher abuse dry-run persistence", () => {
 
   it("resumes a finalizing run without restarting collection", async () => {
     const scheduler = { runAfter: vi.fn(async () => null) };
-    const runMutation = vi.fn(async (target: symbol) => {
+    const runMutation = vi.fn(async (target: symbol, _args?: unknown) => {
       if (String(target).includes("finalizePublisherAbuseScoresPageInternal")) {
         return {
           runId: "publisherAbuseScoreRuns:run",
@@ -7800,7 +7804,7 @@ describe("publisher abuse dry-run persistence", () => {
 
   it("does not mark a completed score run failed when the autoban sweep fails", async () => {
     const autobanError = new Error("autoban failed");
-    const runMutation = vi.fn(async (target: symbol) => {
+    const runMutation = vi.fn(async (target: symbol, _args?: unknown) => {
       if (String(target).includes("finalizePublisherAbuseScoresPageInternal")) {
         return {
           runId: "publisherAbuseScoreRuns:run",
@@ -7871,6 +7875,110 @@ describe("publisher abuse dry-run persistence", () => {
       runId: "publisherAbuseScoreRuns:run",
       errorMessage: "page failed",
     });
+  });
+
+  it("records and retries transient score run page failures without failing the run", async () => {
+    const transientError = new Error("Your request couldn't be completed. Try again later.");
+    const scheduler = { runAfter: vi.fn(async () => null) };
+    const runMutation = vi.fn(async (target: symbol, _args?: unknown) => {
+      const targetName = String(target);
+      if (targetName.includes("collectPublisherAbuseScoresPageInternal")) {
+        throw transientError;
+      }
+      if (targetName.includes("recordPublisherAbuseScoreRunTransientErrorInternal")) {
+        return { ok: true, recorded: true };
+      }
+      if (targetName.includes("markPublisherAbuseScoreRunFailedInternal")) {
+        throw new Error("transient failure should not mark the run failed");
+      }
+      throw new Error(`unexpected mutation ${targetName}`);
+    });
+    const ctx = {
+      scheduler,
+      runQuery: vi.fn(async () => ({
+        runId: "publisherAbuseScoreRuns:run",
+        phase: "collecting",
+        status: "running",
+      })),
+      runMutation,
+    };
+
+    await expect(
+      runHandler(ctx, { runId: "publisherAbuseScoreRuns:run", batchSize: 100, maxPages: 1 }),
+    ).resolves.toEqual({
+      ok: true,
+      runId: "publisherAbuseScoreRuns:run",
+      pages: 0,
+      isDone: false,
+    });
+
+    const runMutationCalls = runMutation.mock.calls as unknown[][];
+    expect(String(runMutationCalls[0]?.[0])).toContain("collectPublisherAbuseScoresPageInternal");
+    expect(String(runMutationCalls[1]?.[0])).toContain(
+      "recordPublisherAbuseScoreRunTransientErrorInternal",
+    );
+    expect(runMutationCalls[1]?.[1]).toEqual({
+      runId: "publisherAbuseScoreRuns:run",
+      errorMessage: "Your request couldn't be completed. Try again later.",
+      retryAttempt: 1,
+      retryDelayMs: 30_000,
+    });
+    expect(scheduler.runAfter).toHaveBeenCalledWith(30_000, expect.any(Symbol), {
+      runId: "publisherAbuseScoreRuns:run",
+      batchSize: 100,
+      maxPages: 1,
+      trigger: "cron",
+      retryAttempt: 1,
+    });
+  });
+
+  it("marks transient score run failures failed after the retry budget is exhausted", async () => {
+    const transientError = new Error("changed while this mutation was being run");
+    const scheduler = { runAfter: vi.fn(async () => null) };
+    const runMutation = vi.fn(async (target: symbol, _args?: unknown) => {
+      const targetName = String(target);
+      if (targetName.includes("collectPublisherAbuseScoresPageInternal")) {
+        throw transientError;
+      }
+      if (targetName.includes("markPublisherAbuseScoreRunFailedInternal")) {
+        return {
+          runId: "publisherAbuseScoreRuns:run",
+          phase: "collecting",
+          status: "failed",
+        };
+      }
+      if (targetName.includes("recordPublisherAbuseScoreRunTransientErrorInternal")) {
+        throw new Error("exhausted transient retry should not be recorded for retry");
+      }
+      throw new Error(`unexpected mutation ${targetName}`);
+    });
+    const ctx = {
+      scheduler,
+      runQuery: vi.fn(async () => ({
+        runId: "publisherAbuseScoreRuns:run",
+        phase: "collecting",
+        status: "running",
+      })),
+      runMutation,
+    };
+
+    await expect(
+      runHandler(ctx, {
+        runId: "publisherAbuseScoreRuns:run",
+        batchSize: 100,
+        maxPages: 1,
+        retryAttempt: 5,
+      }),
+    ).rejects.toThrow("changed while this mutation was being run");
+
+    const runMutationCalls = runMutation.mock.calls as unknown[][];
+    expect(String(runMutationCalls[0]?.[0])).toContain("collectPublisherAbuseScoresPageInternal");
+    expect(String(runMutationCalls[1]?.[0])).toContain("markPublisherAbuseScoreRunFailedInternal");
+    expect(runMutationCalls[1]?.[1]).toEqual({
+      runId: "publisherAbuseScoreRuns:run",
+      errorMessage: "changed while this mutation was being run",
+    });
+    expect(scheduler.runAfter).not.toHaveBeenCalled();
   });
 
   it("does not continue page processing for a failed score run", async () => {

--- a/convex/publisherAbuse.test.ts
+++ b/convex/publisherAbuse.test.ts
@@ -7932,6 +7932,56 @@ describe("publisher abuse dry-run persistence", () => {
     });
   });
 
+  it("records and retries transient score run state-load failures", async () => {
+    const transientError = new Error("Your request couldn't be completed. Try again later.");
+    const scheduler = { runAfter: vi.fn(async () => null) };
+    const runMutation = vi.fn(async (target: symbol, _args?: unknown) => {
+      const targetName = String(target);
+      if (targetName.includes("recordPublisherAbuseScoreRunTransientErrorInternal")) {
+        return { ok: true, recorded: true };
+      }
+      if (targetName.includes("markPublisherAbuseScoreRunFailedInternal")) {
+        throw new Error("transient state-load failure should not mark the run failed");
+      }
+      throw new Error(`unexpected mutation ${targetName}`);
+    });
+    const ctx = {
+      scheduler,
+      runQuery: vi.fn(async () => {
+        throw transientError;
+      }),
+      runMutation,
+    };
+
+    await expect(
+      runHandler(ctx, { runId: "publisherAbuseScoreRuns:run", batchSize: 100, maxPages: 1 }),
+    ).resolves.toEqual({
+      ok: true,
+      runId: "publisherAbuseScoreRuns:run",
+      pages: 0,
+      isDone: false,
+    });
+
+    const runQueryCalls = ctx.runQuery.mock.calls as unknown[][];
+    expect(String(runQueryCalls[0]?.[0])).toContain("getPublisherAbuseScoreRunStateInternal");
+    expect(String(runMutation.mock.calls[0]?.[0])).toContain(
+      "recordPublisherAbuseScoreRunTransientErrorInternal",
+    );
+    expect(runMutation.mock.calls[0]?.[1]).toEqual({
+      runId: "publisherAbuseScoreRuns:run",
+      errorMessage: "Your request couldn't be completed. Try again later.",
+      retryAttempt: 1,
+      retryDelayMs: 30_000,
+    });
+    expect(scheduler.runAfter).toHaveBeenCalledWith(30_000, expect.any(Symbol), {
+      runId: "publisherAbuseScoreRuns:run",
+      batchSize: 100,
+      maxPages: 1,
+      trigger: "cron",
+      retryAttempt: 1,
+    });
+  });
+
   it("does not retry transient score run failures when telemetry finds an inactive run", async () => {
     const transientError = new Error("Your request couldn't be completed. Try again later.");
     const scheduler = { runAfter: vi.fn(async () => null) };

--- a/convex/publisherAbuse.ts
+++ b/convex/publisherAbuse.ts
@@ -1437,7 +1437,7 @@ export const recordPublisherAbuseScoreRunTransientErrorInternal = internalMutati
       transientErrorCount: (run.transientErrorCount ?? 0) + 1,
       lastTransientError: args.errorMessage,
       lastTransientErrorAt: now,
-      lastTransientRetryAt: now + args.retryDelayMs,
+      nextTransientRetryAt: now + args.retryDelayMs,
       updatedAt: now,
     });
     console.warn("[publisher-abuse] transient score run failure; retrying", {
@@ -2021,8 +2021,9 @@ export async function runPublisherAbuseScoreRunInternalHandler(
     if (isRetryablePublisherAbuseScoreRunError(errorMessage)) {
       if (retryAttempt < MAX_PUBLISHER_ABUSE_SCORE_RUN_TRANSIENT_RETRIES) {
         const retryDelayMs = publisherAbuseScoreRunRetryDelayMs(retryAttempt);
+        let shouldScheduleRetry = true;
         try {
-          await ctx.runMutation(
+          const retryRecord: { ok: true; recorded: boolean } = await ctx.runMutation(
             internal.publisherAbuse.recordPublisherAbuseScoreRunTransientErrorInternal,
             {
               runId: state.runId,
@@ -2031,12 +2032,21 @@ export async function runPublisherAbuseScoreRunInternalHandler(
               retryDelayMs,
             },
           );
+          shouldScheduleRetry = retryRecord.recorded;
         } catch (recordError) {
           console.warn("[publisher-abuse] failed to record transient retry telemetry", {
             runId: state.runId,
             retryAttempt: retryAttempt + 1,
             errorMessage: errorMessageFromUnknown(recordError),
           });
+        }
+        if (!shouldScheduleRetry) {
+          console.warn("[publisher-abuse] skipped transient retry for inactive score run", {
+            runId: state.runId,
+            retryAttempt: retryAttempt + 1,
+            errorMessage,
+          });
+          return { ok: true, runId: state.runId, pages, isDone: true };
         }
         await ctx.scheduler.runAfter(
           retryDelayMs,

--- a/convex/publisherAbuse.ts
+++ b/convex/publisherAbuse.ts
@@ -1957,16 +1957,42 @@ export async function runPublisherAbuseScoreRunInternalHandler(
     0,
     MAX_PUBLISHER_ABUSE_SCORE_RUN_TRANSIENT_RETRIES,
   );
-  let state: RunState = args.runId
-    ? await ctx.runQuery(internal.publisherAbuse.getPublisherAbuseScoreRunStateInternal, {
-        runId: args.runId,
-      })
-    : await ctx.runMutation(internal.publisherAbuse.getOrStartPublisherAbuseScoreRunInternal, {
-        trigger: args.trigger ?? "cron",
-        actorUserId: args.actorUserId,
-        forceNew: args.forceNew,
-      });
   let pages = 0;
+  let state: RunState;
+  try {
+    state = args.runId
+      ? await ctx.runQuery(internal.publisherAbuse.getPublisherAbuseScoreRunStateInternal, {
+          runId: args.runId,
+        })
+      : await ctx.runMutation(internal.publisherAbuse.getOrStartPublisherAbuseScoreRunInternal, {
+          trigger: args.trigger ?? "cron",
+          actorUserId: args.actorUserId,
+          forceNew: args.forceNew,
+        });
+  } catch (error) {
+    const errorMessage = errorMessageFromUnknown(error);
+    if (args.runId && isRetryablePublisherAbuseScoreRunError(errorMessage)) {
+      const retryResult = await schedulePublisherAbuseScoreRunTransientRetry(ctx, {
+        runId: args.runId,
+        batchSize,
+        maxPages,
+        trigger: args.trigger ?? "cron",
+        retryAttempt,
+        errorMessage,
+      });
+      if (retryResult === "scheduled") {
+        return { ok: true, runId: args.runId, pages, isDone: false };
+      }
+      if (retryResult === "inactive") {
+        return { ok: true, runId: args.runId, pages, isDone: true };
+      }
+      await ctx.runMutation(internal.publisherAbuse.markPublisherAbuseScoreRunFailedInternal, {
+        runId: args.runId,
+        errorMessage,
+      });
+    }
+    throw error;
+  }
 
   if (state.status !== "running") {
     if (state.status === "completed") {
@@ -2019,53 +2045,20 @@ export async function runPublisherAbuseScoreRunInternalHandler(
   } catch (error) {
     const errorMessage = errorMessageFromUnknown(error);
     if (isRetryablePublisherAbuseScoreRunError(errorMessage)) {
-      if (retryAttempt < MAX_PUBLISHER_ABUSE_SCORE_RUN_TRANSIENT_RETRIES) {
-        const retryDelayMs = publisherAbuseScoreRunRetryDelayMs(retryAttempt);
-        let shouldScheduleRetry = true;
-        try {
-          const retryRecord: { ok: true; recorded: boolean } = await ctx.runMutation(
-            internal.publisherAbuse.recordPublisherAbuseScoreRunTransientErrorInternal,
-            {
-              runId: state.runId,
-              errorMessage,
-              retryAttempt: retryAttempt + 1,
-              retryDelayMs,
-            },
-          );
-          shouldScheduleRetry = retryRecord.recorded;
-        } catch (recordError) {
-          console.warn("[publisher-abuse] failed to record transient retry telemetry", {
-            runId: state.runId,
-            retryAttempt: retryAttempt + 1,
-            errorMessage: errorMessageFromUnknown(recordError),
-          });
-        }
-        if (!shouldScheduleRetry) {
-          console.warn("[publisher-abuse] skipped transient retry for inactive score run", {
-            runId: state.runId,
-            retryAttempt: retryAttempt + 1,
-            errorMessage,
-          });
-          return { ok: true, runId: state.runId, pages, isDone: true };
-        }
-        await ctx.scheduler.runAfter(
-          retryDelayMs,
-          internal.publisherAbuse.runPublisherAbuseScoreRunInternal,
-          {
-            runId: state.runId,
-            batchSize,
-            maxPages,
-            trigger: args.trigger ?? "cron",
-            retryAttempt: retryAttempt + 1,
-          },
-        );
-        return { ok: true, runId: state.runId, pages, isDone: false };
-      }
-      console.error("[publisher-abuse] score run exceeded transient retry budget", {
+      const retryResult = await schedulePublisherAbuseScoreRunTransientRetry(ctx, {
         runId: state.runId,
+        batchSize,
+        maxPages,
+        trigger: args.trigger ?? "cron",
         retryAttempt,
         errorMessage,
       });
+      if (retryResult === "scheduled") {
+        return { ok: true, runId: state.runId, pages, isDone: false };
+      }
+      if (retryResult === "inactive") {
+        return { ok: true, runId: state.runId, pages, isDone: true };
+      }
     }
     await ctx.runMutation(internal.publisherAbuse.markPublisherAbuseScoreRunFailedInternal, {
       runId: state.runId,
@@ -2093,6 +2086,71 @@ export async function runPublisherAbuseScoreRunInternalHandler(
     await processPublisherAbuseAutobanPages(ctx, {});
   }
   return { ok: true, runId: state.runId, pages, isDone: false };
+}
+
+async function schedulePublisherAbuseScoreRunTransientRetry(
+  ctx: Pick<ActionCtx, "runMutation" | "scheduler">,
+  args: {
+    runId: Id<"publisherAbuseScoreRuns">;
+    batchSize: number;
+    maxPages: number;
+    trigger: "cron" | "manual";
+    retryAttempt: number;
+    errorMessage: string;
+  },
+): Promise<"scheduled" | "inactive" | "exhausted"> {
+  if (args.retryAttempt >= MAX_PUBLISHER_ABUSE_SCORE_RUN_TRANSIENT_RETRIES) {
+    console.error("[publisher-abuse] score run exceeded transient retry budget", {
+      runId: args.runId,
+      retryAttempt: args.retryAttempt,
+      errorMessage: args.errorMessage,
+    });
+    return "exhausted";
+  }
+
+  const nextRetryAttempt = args.retryAttempt + 1;
+  const retryDelayMs = publisherAbuseScoreRunRetryDelayMs(args.retryAttempt);
+  let shouldScheduleRetry = true;
+  try {
+    const retryRecord: { ok: true; recorded: boolean } = await ctx.runMutation(
+      internal.publisherAbuse.recordPublisherAbuseScoreRunTransientErrorInternal,
+      {
+        runId: args.runId,
+        errorMessage: args.errorMessage,
+        retryAttempt: nextRetryAttempt,
+        retryDelayMs,
+      },
+    );
+    shouldScheduleRetry = retryRecord.recorded;
+  } catch (recordError) {
+    console.warn("[publisher-abuse] failed to record transient retry telemetry", {
+      runId: args.runId,
+      retryAttempt: nextRetryAttempt,
+      errorMessage: errorMessageFromUnknown(recordError),
+    });
+  }
+
+  if (!shouldScheduleRetry) {
+    console.warn("[publisher-abuse] skipped transient retry for inactive score run", {
+      runId: args.runId,
+      retryAttempt: nextRetryAttempt,
+      errorMessage: args.errorMessage,
+    });
+    return "inactive";
+  }
+
+  await ctx.scheduler.runAfter(
+    retryDelayMs,
+    internal.publisherAbuse.runPublisherAbuseScoreRunInternal,
+    {
+      runId: args.runId,
+      batchSize: args.batchSize,
+      maxPages: args.maxPages,
+      trigger: args.trigger,
+      retryAttempt: nextRetryAttempt,
+    },
+  );
+  return "scheduled";
 }
 
 function isRetryablePublisherAbuseScoreRunError(errorMessage: string) {

--- a/convex/publisherAbuse.ts
+++ b/convex/publisherAbuse.ts
@@ -37,9 +37,13 @@ import { readCanonicalStat } from "./lib/skillStats";
 
 const DEFAULT_BATCH_SIZE = 250;
 const MAX_BATCH_SIZE = 1000;
-const DEFAULT_MAX_PAGES = 5;
+const DEFAULT_MAX_PAGES = 20;
 const MAX_MAX_PAGES = 50;
 const ACTION_CONTINUATION_DELAY_MS = 60_000;
+const PUBLISHER_ABUSE_SCORE_RUN_CONTINUATION_DELAY_MS = 5_000;
+const PUBLISHER_ABUSE_SCORE_RUN_TRANSIENT_RETRY_BASE_DELAY_MS = 30_000;
+const PUBLISHER_ABUSE_SCORE_RUN_TRANSIENT_RETRY_MAX_DELAY_MS = 5 * 60_000;
+const MAX_PUBLISHER_ABUSE_SCORE_RUN_TRANSIENT_RETRIES = 5;
 const MAX_ACTIVE_SKILL_FALLBACK_SCAN = 500;
 const MAX_ACTIVE_SKILL_FALLBACK_SCANS_PER_PAGE = 20;
 const MAX_OWNER_NOMINATION_VERSION_SCAN = 20;
@@ -1416,6 +1420,37 @@ export const markPublisherAbuseScoreRunFailedInternal = internalMutation({
   handler: markPublisherAbuseScoreRunFailedInternalHandler,
 });
 
+export const recordPublisherAbuseScoreRunTransientErrorInternal = internalMutation({
+  args: {
+    runId: v.id("publisherAbuseScoreRuns"),
+    errorMessage: v.string(),
+    retryAttempt: v.number(),
+    retryDelayMs: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const run = await ctx.db.get(args.runId);
+    if (!run || run.status !== "running") {
+      return { ok: true as const, recorded: false as const };
+    }
+    const now = Date.now();
+    await ctx.db.patch(run._id, {
+      transientErrorCount: (run.transientErrorCount ?? 0) + 1,
+      lastTransientError: args.errorMessage,
+      lastTransientErrorAt: now,
+      lastTransientRetryAt: now + args.retryDelayMs,
+      updatedAt: now,
+    });
+    console.warn("[publisher-abuse] transient score run failure; retrying", {
+      runId: args.runId,
+      phase: run.phase,
+      retryAttempt: args.retryAttempt,
+      retryDelayMs: args.retryDelayMs,
+      errorMessage: args.errorMessage,
+    });
+    return { ok: true as const, recorded: true as const };
+  },
+});
+
 export const runPublisherAbuseScoreRunInternal = internalAction({
   args: {
     runId: v.optional(v.id("publisherAbuseScoreRuns")),
@@ -1424,6 +1459,7 @@ export const runPublisherAbuseScoreRunInternal = internalAction({
     forceNew: v.optional(v.boolean()),
     trigger: v.optional(v.union(v.literal("cron"), v.literal("manual"))),
     actorUserId: v.optional(v.id("users")),
+    retryAttempt: v.optional(v.number()),
   },
   handler: runPublisherAbuseScoreRunInternalHandler,
 });
@@ -1911,10 +1947,16 @@ export async function runPublisherAbuseScoreRunInternalHandler(
     forceNew?: boolean;
     trigger?: "cron" | "manual";
     actorUserId?: Id<"users">;
+    retryAttempt?: number;
   },
 ): Promise<{ ok: true; runId: Id<"publisherAbuseScoreRuns">; pages: number; isDone: boolean }> {
   const batchSize = clampInt(args.batchSize ?? DEFAULT_BATCH_SIZE, 1, MAX_BATCH_SIZE);
   const maxPages = clampInt(args.maxPages ?? DEFAULT_MAX_PAGES, 1, MAX_MAX_PAGES);
+  const retryAttempt = clampInt(
+    args.retryAttempt ?? 0,
+    0,
+    MAX_PUBLISHER_ABUSE_SCORE_RUN_TRANSIENT_RETRIES,
+  );
   let state: RunState = args.runId
     ? await ctx.runQuery(internal.publisherAbuse.getPublisherAbuseScoreRunStateInternal, {
         runId: args.runId,
@@ -1975,9 +2017,49 @@ export async function runPublisherAbuseScoreRunInternalHandler(
       }
     }
   } catch (error) {
+    const errorMessage = errorMessageFromUnknown(error);
+    if (isRetryablePublisherAbuseScoreRunError(errorMessage)) {
+      if (retryAttempt < MAX_PUBLISHER_ABUSE_SCORE_RUN_TRANSIENT_RETRIES) {
+        const retryDelayMs = publisherAbuseScoreRunRetryDelayMs(retryAttempt);
+        try {
+          await ctx.runMutation(
+            internal.publisherAbuse.recordPublisherAbuseScoreRunTransientErrorInternal,
+            {
+              runId: state.runId,
+              errorMessage,
+              retryAttempt: retryAttempt + 1,
+              retryDelayMs,
+            },
+          );
+        } catch (recordError) {
+          console.warn("[publisher-abuse] failed to record transient retry telemetry", {
+            runId: state.runId,
+            retryAttempt: retryAttempt + 1,
+            errorMessage: errorMessageFromUnknown(recordError),
+          });
+        }
+        await ctx.scheduler.runAfter(
+          retryDelayMs,
+          internal.publisherAbuse.runPublisherAbuseScoreRunInternal,
+          {
+            runId: state.runId,
+            batchSize,
+            maxPages,
+            trigger: args.trigger ?? "cron",
+            retryAttempt: retryAttempt + 1,
+          },
+        );
+        return { ok: true, runId: state.runId, pages, isDone: false };
+      }
+      console.error("[publisher-abuse] score run exceeded transient retry budget", {
+        runId: state.runId,
+        retryAttempt,
+        errorMessage,
+      });
+    }
     await ctx.runMutation(internal.publisherAbuse.markPublisherAbuseScoreRunFailedInternal, {
       runId: state.runId,
-      errorMessage: errorMessageFromUnknown(error),
+      errorMessage,
     });
     throw error;
   }
@@ -1988,7 +2070,7 @@ export async function runPublisherAbuseScoreRunInternalHandler(
   }
 
   await ctx.scheduler.runAfter(
-    ACTION_CONTINUATION_DELAY_MS,
+    PUBLISHER_ABUSE_SCORE_RUN_CONTINUATION_DELAY_MS,
     internal.publisherAbuse.runPublisherAbuseScoreRunInternal,
     {
       runId: state.runId,
@@ -2001,6 +2083,20 @@ export async function runPublisherAbuseScoreRunInternalHandler(
     await processPublisherAbuseAutobanPages(ctx, {});
   }
   return { ok: true, runId: state.runId, pages, isDone: false };
+}
+
+function isRetryablePublisherAbuseScoreRunError(errorMessage: string) {
+  return (
+    errorMessage.includes("Your request couldn't be completed. Try again later.") ||
+    errorMessage.includes("changed while this mutation was being run")
+  );
+}
+
+function publisherAbuseScoreRunRetryDelayMs(retryAttempt: number) {
+  return Math.min(
+    PUBLISHER_ABUSE_SCORE_RUN_TRANSIENT_RETRY_BASE_DELAY_MS * 2 ** retryAttempt,
+    PUBLISHER_ABUSE_SCORE_RUN_TRANSIENT_RETRY_MAX_DELAY_MS,
+  );
 }
 
 async function processPublisherAbuseAutobanPages(

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2606,7 +2606,7 @@ const publisherAbuseScoreRuns = defineTable({
   transientErrorCount: v.optional(v.number()),
   lastTransientError: v.optional(v.string()),
   lastTransientErrorAt: v.optional(v.number()),
-  lastTransientRetryAt: v.optional(v.number()),
+  nextTransientRetryAt: v.optional(v.number()),
 })
   .index("by_status_and_updated_at", ["status", "updatedAt"])
   .index("by_model_version_and_started_at", ["modelVersion", "startedAt"])

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2603,6 +2603,10 @@ const publisherAbuseScoreRuns = defineTable({
     }),
   ),
   errorMessage: v.optional(v.string()),
+  transientErrorCount: v.optional(v.number()),
+  lastTransientError: v.optional(v.string()),
+  lastTransientErrorAt: v.optional(v.number()),
+  lastTransientRetryAt: v.optional(v.number()),
 })
   .index("by_status_and_updated_at", ["status", "updatedAt"])
   .index("by_model_version_and_started_at", ["modelVersion", "startedAt"])


### PR DESCRIPTION
## Summary

Publisher-abuse pressure scoring was spending most of its runtime asleep between continuation actions. The old cron processed 5 pages of 250 publishers, then waited 60 seconds before the next continuation, which adds roughly 6 hours of scheduler idle time for a ~475k-publisher run before counting the actual scoring work.

This keeps the existing serial cursor-based scan design, but makes the continuation cadence match the work: 20 pages per action, the same 250-publisher mutation page size, and a 5-second delay between score-run continuations. It also adds bounded retry/resume for transient Convex failures so a long run does not fail permanently on a single generic platform retry error, run-doc OCC failure, or retryable state-load failure.

## What Changed

- Pressure score cron throughput: runs `maxPages: 20` instead of `5`, so each action can process up to 5,000 publishers while each mutation still only handles 250 publishers.
- Pressure score continuation delay: score-run continuations now wait 5 seconds instead of sharing the generic 60-second action delay used by other workflows.
- Bounded transient retries: generic Convex transient errors and `changed while this mutation was being run` now record telemetry and reschedule the same run with exponential backoff from 30 seconds to 5 minutes, capped at 5 retry attempts.
- State-load resilience: scheduled continuations now use the same retry path when loading run state fails with a retryable transient.
- Observability: score-run docs now record transient error count, last transient error, last transient error time, and next retry time; the action also logs retry and exhausted-budget events.
- Failure semantics: deterministic failures still mark the score run failed, and exhausted transient retries also fail the run instead of looping forever.

## Convex Capacity Check

Read-only production investigation found the bottleneck and the current resource shape:

- Current batching was 1,250 publishers per action followed by 60 seconds of idle delay. At ~475,000 publishers, that creates about 380 continuations and about 6.3 hours of scheduler delay alone.
- Keeping the 250-publisher mutation page avoids increasing individual transaction read/write pressure. The same corpus still uses roughly the same number of 250-publisher page mutations; this PR reduces action continuations to about 95 and scheduled idle time to under 8 minutes.
- Production Convex insights over the last 72 hours show read/byte-limit and OCC noise in other surfaces, especially search, package release/version reads, rate limits, security scan claiming, and auth/user writes.
- The publisher-abuse score path appears only in OCC retry warnings: `collectPublisherAbuseScoresPageInternal` had 3 retry warnings on `users` and 51 retry warnings on `publishers`. It did not appear in production read-limit, byte-limit, or permanent OCC failure buckets.
- The increased cadence is still serial. It does not shard, parallelize, or increase the per-mutation publisher page size.
- Parallel sharding is intentionally not part of this PR because the current pressure model accumulates `sumLogPressure` and `sumSquaredLogPressure` during collection, then finalizes scores by ordered cursor/rank. Sharding that safely would require a separate aggregation/ranking design.

This should be within the existing deployment quota shape because the transaction size stays bounded and only scheduler idle time is compressed. The first production run should still be watched in Convex logs/insights because it will concentrate the existing scan work into a shorter wall-clock window.

No screenshot is included because this is backend-only cron/action/schema behavior; the management UI surface is unchanged.

## Verification

Reviewer-checkable behavior:

- The cron now schedules pressure scoring with `batchSize: 250`, `maxPages: 20`, `trigger: "cron"`.
- A retryable collection failure records transient telemetry and schedules the same run after 30 seconds without marking it failed.
- A retryable state-load failure for a scheduled continuation records transient telemetry and schedules the same run after 30 seconds without marking it failed.
- A retryable collection failure at `retryAttempt: 5` marks the run failed and does not schedule another retry.
- A normal incomplete score-run action schedules its continuation after 5 seconds.

Checks run:

- `bunx vitest run convex/publisherAbuse.test.ts convex/crons.test.ts --testNamePattern 'publisher abuse|score run|cron jobs|transient|continuation'` passed, 121 passed / 8 skipped.
- `bunx vitest run convex/publisherAbuse.test.ts convex/crons.test.ts` passed, 126 passed.
- `bunx tsc --noEmit --pretty false` passed.
- `git diff --check` passed.
- `bunx convex dev --once --typecheck=disable` passed against development deployment `dev:admired-dodo-615`; Convex functions/schema ready in 8.82s on the latest run.
- `bunx convex insights --prod --details` passed/read-only; publisher-abuse appeared only in OCC retry warnings and not read-limit, byte-limit, or permanent OCC failure buckets.
- `$code-review` completed: native review clean, cold-review found one retryability gap, the gap was fixed, and both follow-up native and cold-review passes were clean.
- GitHub CI on head `3e61d5efcaf2fba8d2dc96bd52ad6530cf5cef96` passed (`pr-gates`, static, unit, packages, types-build, e2e-http, Playwright shards, CodeQL, Vercel).

## Operational Rollout

- Merge does not deploy production by itself.
- Deploy backend when ready, then watch the first production publisher-abuse score refresh in Convex logs/insights.
- Expected runtime shape: same total number of 250-publisher page mutations, fewer action continuations, and materially less scheduler idle time.
- Rollback lever: revert this PR or deploy the previous backend if the first production scan shows unexpected Convex resource pressure.
