### PR TITLE
Improve homepage app icon loading

### DIFF
--- a/src/lib/homeApps.ts
+++ b/src/lib/homeApps.ts
@@ -528,6 +528,26 @@ export function simpleIconUrl(slug: string) {
   return `${SIMPLE_ICON_BASE_URL}/${slug}.svg`;
 }
 
+const HOME_APP_POPULAR_SIMPLE_ICON_IDS = [
+  "github",
+  "vscode",
+  "notion",
+  "slack",
+  "gmail",
+  "google-drive",
+  "google-sheets",
+  "google-calendar",
+  "linear",
+  "figma",
+  "trello",
+  "whatsapp",
+] as const satisfies readonly (keyof typeof HOME_APP_SIMPLE_ICONS)[];
+
+export const HOME_APP_ICON_PRELOAD_HREFS = [
+  ...HOME_APP_POPULAR_SIMPLE_ICON_IDS.map((id) => simpleIconUrl(HOME_APP_SIMPLE_ICONS[id])),
+  ...Object.values(HOME_APP_IMAGE_ICONS),
+];
+
 function homeAppIcon({ id, iconDomain }: { id: string; iconDomain?: string }): HomeAppIcon {
   if (id in HOME_APP_IMAGE_ICONS) {
     return {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -27,7 +27,6 @@ import { getThemeModeFromCookieHeader, normalizeThemeMode } from "../lib/themeCo
 import appCss from "../styles.css?url";
 
 const OG_IMAGE_VERSION = "20260624-1";
-
 export const Route = createRootRoute({
   beforeLoad: ({ location }) => {
     if (location.pathname === BANNED_ACCOUNT_PATH) return;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -5,49 +5,39 @@ import { HomeBringSkillsSection } from "../components/HomeBringSkillsSection";
 import { HomeListingSection } from "../components/HomeListingSection";
 import { HomePopularPublishersSection } from "../components/HomePopularPublishersSection";
 import { HomeV2FoldBottomFade } from "../components/HomeV2FoldBottomFade";
+import { HOME_APP_ICON_PRELOAD_HREFS } from "../lib/homeApps";
 import { fetchInitialHomeListing, type HomeListingInitialData } from "../lib/homeListingData";
 
-const HOME_APP_ICON_PRELOADS = [
-  ...[
-    "github",
-    "visualstudiocode",
-    "notion",
-    "slack",
-    "gmail",
-    "googledrive",
-    "googlesheets",
-    "googlecalendar",
-    "linear",
-    "figma",
-    "trello",
-    "whatsapp",
-  ].map((slug) => `https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/${slug}.svg`),
-  ...[
-    "cerebras",
-    "deepinfra",
-    "exa",
-    "feishu",
-    "firecrawl",
-    "groq",
-    "llama-cpp",
-    "parallel",
-    "scraperapi",
-  ].map((slug) => `/app-icons/${slug}.svg`),
-];
+type HomeRouteHeadLink =
+  | {
+      rel: "preconnect";
+      href: string;
+    }
+  | {
+      rel: "preload";
+      as: "image";
+      href: string;
+    };
+
+function imagePreloadLink(href: string): HomeRouteHeadLink {
+  return {
+    rel: "preload",
+    as: "image",
+    href,
+  };
+}
+
+const HOME_ROUTE_HEAD_LINKS = [
+  {
+    rel: "preconnect",
+    href: "https://cdn.jsdelivr.net",
+  },
+  ...HOME_APP_ICON_PRELOAD_HREFS.map(imagePreloadLink),
+] satisfies HomeRouteHeadLink[];
 
 export const Route = createFileRoute("/")({
   head: () => ({
-    links: [
-      {
-        rel: "preconnect",
-        href: "https://cdn.jsdelivr.net",
-      },
-      ...HOME_APP_ICON_PRELOADS.map((href) => ({
-        rel: "preload",
-        as: "image",
-        href,
-      })),
-    ],
+    links: HOME_ROUTE_HEAD_LINKS,
   }),
   loader: loadInitialHomeListing,
   component: SkillsHome,

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,7 +7,48 @@ import { HomePopularPublishersSection } from "../components/HomePopularPublisher
 import { HomeV2FoldBottomFade } from "../components/HomeV2FoldBottomFade";
 import { fetchInitialHomeListing, type HomeListingInitialData } from "../lib/homeListingData";
 
+const HOME_APP_ICON_PRELOADS = [
+  ...[
+    "github",
+    "visualstudiocode",
+    "notion",
+    "slack",
+    "gmail",
+    "googledrive",
+    "googlesheets",
+    "googlecalendar",
+    "linear",
+    "figma",
+    "trello",
+    "whatsapp",
+  ].map((slug) => `https://cdn.jsdelivr.net/npm/simple-icons@latest/icons/${slug}.svg`),
+  ...[
+    "cerebras",
+    "deepinfra",
+    "exa",
+    "feishu",
+    "firecrawl",
+    "groq",
+    "llama-cpp",
+    "parallel",
+    "scraperapi",
+  ].map((slug) => `/app-icons/${slug}.svg`),
+];
+
 export const Route = createFileRoute("/")({
+  head: () => ({
+    links: [
+      {
+        rel: "preconnect",
+        href: "https://cdn.jsdelivr.net",
+      },
+      ...HOME_APP_ICON_PRELOADS.map((href) => ({
+        rel: "preload",
+        as: "image",
+        href,
+      })),
+    ],
+  }),
   loader: loadInitialHomeListing,
   component: SkillsHome,
 });


### PR DESCRIPTION
## Why this change

The homepage app-grid icons can briefly flash in after the surrounding UI has already rendered. This keeps the existing icon sources and visual treatment, but asks the browser to start fetching the app-grid icons earlier.

## What changed

- Added a preconnect hint for the Simple Icons CDN.
- Added preload hints for the 12 Simple Icons shown in the initial Popular app grid.
- Added preload hints for the 9 local fallback SVGs in `/app-icons` used by non-Simple-Icons app-grid icons.
- Centralized the homepage preload hrefs in `homeApps.ts` so the route head metadata derives from the same icon registry used by the UI.
- Added a typed route-head link boundary for the homepage resource hints.

## Scope and non-goals

In scope:

- Reduce first-load icon flashing for homepage app-grid icons.
- Keep the existing Simple Icons CDN source.
- Keep the existing local `/app-icons` fallback SVG source.
- Keep the existing CSS mask/image rendering and light/dark behavior.

Not in scope:

- No icon artwork changes.
- No card/hero artwork changes.
- No SVG inlining.
- No moving Simple Icons into local files.
- No loading-state redesign.

## How to review

1. Open the homepage.
2. Hard refresh the page.
3. Check the Popular app-grid icons.
4. Switch through the other app-grid tabs that include local fallback icons.
5. Confirm the icons look visually unchanged and appear earlier with less flashing.
6. Confirm the hero/cards above the grid are unchanged.

## Screenshots or recording

Recommended: a short before/after screen recording from the same viewport, because this is a loading-timing change rather than a static visual change.

Reviewer focus: the icon artwork should look identical; only the loading flash should be reduced.

## Validation

Maintainer validation on head `120530900d400d40d8875338cfe4fff8a1e8bb9e`:

- `bunx tsc --noEmit --pretty false` passed.
- `bun run format:check -- src/routes/index.tsx src/lib/homeApps.ts src/routes/__root.tsx` passed.
- `bun run lint -- src/routes/index.tsx src/lib/homeApps.ts src/routes/__root.tsx` passed.
- `bun run test -- src/__tests__/home-route.test.tsx` passed.
- `bun run ci:static` passed.
- `bun run ci:unit` passed.
- `bun run ci:types-build` passed.
- `bunx tsc -p packages/schema/tsconfig.json --noEmit` passed.
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit` passed.

Original author validation:

- Local homepage HTML confirmed:
  - 1 `preconnect` link for `https://cdn.jsdelivr.net`
  - 12 Simple Icons `preload` links
  - 9 local `/app-icons` SVG `preload` links
- Manually reviewed locally at `http://127.0.0.1:3101/`.

## Risks, edge cases, and open questions

- This reduces the flash but may not fully eliminate it on very slow networks because the Simple Icons SVGs still come from the external CDN.
- Preloading more assets increases early page requests, but the added local SVGs are small and already used by the homepage app grid.
