### PR TITLE
fix: drain publisher abuse signal notifications

### DIFF
--- a/convex/crons.test.ts
+++ b/convex/crons.test.ts
@@ -180,7 +180,7 @@ describe("crons", () => {
     );
     expect(mocks.interval).toHaveBeenCalledWith(
       "publisher-abuse-signal-notifications",
-      { minutes: 15 },
+      { hours: 1 },
       mocks.publisherAbuseSignalNotificationsRef,
       {},
     );

--- a/convex/crons.test.ts
+++ b/convex/crons.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => {
   const githubSkillSyncRef = Symbol("github-skill-source-sync");
   const installTelemetryDedupePruneRef = Symbol("install-telemetry-dedupe-prune");
   const publisherAbuseAutobanRef = Symbol("publisher-abuse-autobans");
+  const publisherAbuseSignalNotificationsRef = Symbol("publisher-abuse-signal-notifications");
   const publisherAbuseScoreRefreshRef = Symbol("publisher-abuse-score-refresh");
   const publisherTemporalAbuseScanRef = Symbol("publisher-temporal-abuse-scan");
   const httpRateLimitKeysPruneRef = Symbol("http-rate-limit-keys-prune");
@@ -19,6 +20,7 @@ const mocks = vi.hoisted(() => {
     githubSkillSyncRef,
     installTelemetryDedupePruneRef,
     publisherAbuseAutobanRef,
+    publisherAbuseSignalNotificationsRef,
     publisherAbuseScoreRefreshRef,
     publisherTemporalAbuseScanRef,
     httpRateLimitKeysPruneRef,
@@ -61,6 +63,7 @@ vi.mock("./_generated/api", () => ({
     publisherAbuse: {
       runPublisherAbuseScoreRunInternal: mocks.publisherAbuseScoreRefreshRef,
       runTemporalPublisherAbuseScanInternal: mocks.publisherTemporalAbuseScanRef,
+      notifyPublisherAbuseSignalChangesInternal: mocks.publisherAbuseSignalNotificationsRef,
       processPublisherAbuseAutobansInternal: mocks.publisherAbuseAutobanRef,
     },
     vt: {
@@ -174,6 +177,12 @@ describe("crons", () => {
         batchSize: 1,
         maxPages: 50,
       },
+    );
+    expect(mocks.interval).toHaveBeenCalledWith(
+      "publisher-abuse-signal-notifications",
+      { minutes: 15 },
+      mocks.publisherAbuseSignalNotificationsRef,
+      {},
     );
   });
 

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -121,7 +121,7 @@ if (process.env.CLAWHUB_DISABLE_CRONS !== "1") {
 
   crons.interval(
     "publisher-abuse-signal-notifications",
-    { minutes: 15 },
+    { hours: 1 },
     internal.publisherAbuse.notifyPublisherAbuseSignalChangesInternal,
     {},
   );

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -120,6 +120,13 @@ if (process.env.CLAWHUB_DISABLE_CRONS !== "1") {
   );
 
   crons.interval(
+    "publisher-abuse-signal-notifications",
+    { minutes: 15 },
+    internal.publisherAbuse.notifyPublisherAbuseSignalChangesInternal,
+    {},
+  );
+
+  crons.interval(
     "publisher-abuse-autobans",
     { hours: 24 },
     internal.publisherAbuse.processPublisherAbuseAutobansInternal,

--- a/convex/publisherAbuse.test.ts
+++ b/convex/publisherAbuse.test.ts
@@ -411,6 +411,18 @@ const banPublisherAbuseOwnerHandler = (
   >
 )._handler;
 
+const markPublisherAbuseNominationReviewedHandler = (
+  publisherAbuse.markPublisherAbuseNominationReviewed as unknown as Wrapped<
+    {
+      nominationId: string;
+      expectedLatestScoreId: string;
+      expectedUpdatedAt: number;
+      note?: string;
+    },
+    { ok: true; status: "reviewed_no_action" }
+  >
+)._handler;
+
 const autoBanPublisherAbuseCandidatesPageHandler = (
   publisherAbuse.autoBanPublisherAbuseCandidatesPageInternal as unknown as Wrapped<
     { batchSize?: number; cursor?: string },
@@ -626,6 +638,45 @@ function makePublisherAbuseSignalCountQuery(signals: unknown[]) {
   };
 }
 
+function makePublisherAbuseNominationCountQuery(nominations: unknown[] = []) {
+  return {
+    withIndex: (
+      indexName: string,
+      build: (q: { eq: (field: string, value: unknown) => unknown }) => unknown,
+    ) => {
+      expect(["by_status_and_label_and_last_scored_at", "by_status_and_reviewed_at"]).toContain(
+        indexName,
+      );
+      const constraints: Record<string, unknown> = {};
+      const q = {
+        eq(field: string, value: unknown) {
+          constraints[field] = value;
+          return q;
+        },
+      };
+      build(q);
+      expect(constraints.status).toBeDefined();
+      return {
+        order: (direction: "asc" | "desc") => {
+          expect(direction).toBe("desc");
+          return {
+            take: async (limit: number) =>
+              nominations
+                .filter((nomination) => {
+                  if (!nomination || typeof nomination !== "object") return false;
+                  const fields = nomination as Record<string, unknown>;
+                  return Object.entries(constraints).every(
+                    ([field, value]) => fields[field] === value,
+                  );
+                })
+                .slice(0, limit),
+          };
+        },
+      };
+    },
+  };
+}
+
 function makeEmptyPublisherAbuseScoreRunsQuery() {
   return {
     withIndex: (
@@ -760,6 +811,14 @@ describe("publisher abuse dry-run persistence", () => {
         pendingPotentialBanCandidateItems: [],
         pendingReviewItems: [],
         recentResolvedItems: [],
+        pendingPotentialBanCandidateCount: 0,
+        pendingReviewCount: 0,
+        pendingCount: 0,
+        recentResolvedCount: 0,
+        pendingPotentialBanCandidateCountHasMore: false,
+        pendingReviewCountHasMore: false,
+        pendingCountHasMore: false,
+        recentResolvedCountHasMore: false,
         signalCount: 0,
         signalCountHasMore: false,
       });
@@ -817,6 +876,14 @@ describe("publisher abuse dry-run persistence", () => {
       pendingPotentialBanCandidateItems: [],
       pendingReviewItems: [],
       recentResolvedItems: [],
+      pendingPotentialBanCandidateCount: 0,
+      pendingReviewCount: 0,
+      pendingCount: 0,
+      recentResolvedCount: 0,
+      pendingPotentialBanCandidateCountHasMore: false,
+      pendingReviewCountHasMore: false,
+      pendingCountHasMore: false,
+      recentResolvedCountHasMore: false,
       signalCount: 0,
       signalCountHasMore: false,
     });
@@ -1544,6 +1611,9 @@ describe("publisher abuse dry-run persistence", () => {
       get: vi.fn(async () => null),
       query: vi.fn((table: string) => {
         if (table === "publisherAbuseScoreRuns") return makeEmptyPublisherAbuseScoreRunsQuery();
+        if (table === "publisherAbuseReviewNominations") {
+          return makePublisherAbuseNominationCountQuery();
+        }
         if (table === "publisherAbuseSignals") return makePublisherAbuseSignalCountQuery(signals);
         if (table === "officialPublishers") return makeEmptyOfficialPublishersQuery();
         throw new Error(`unexpected table ${table}`);
@@ -1556,11 +1626,172 @@ describe("publisher abuse dry-run persistence", () => {
       pendingPotentialBanCandidateItems: [],
       pendingReviewItems: [],
       recentResolvedItems: [],
+      pendingPotentialBanCandidateCount: 0,
+      pendingReviewCount: 0,
+      pendingCount: 0,
+      recentResolvedCount: 0,
+      pendingPotentialBanCandidateCountHasMore: false,
+      pendingReviewCountHasMore: false,
+      pendingCountHasMore: false,
+      recentResolvedCountHasMore: false,
       signalCount: 25,
       signalCountHasMore: true,
     });
 
     expect(db.query).toHaveBeenCalledWith("publisherAbuseSignals");
+  });
+
+  it("returns pending publisher abuse nomination counts on the dashboard", async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:moderator",
+      user: { _id: "users:moderator", role: "moderator" },
+    } as never);
+    const nominations = [
+      makeNomination({
+        _id: "publisherAbuseReviewNominations:ban",
+        latestScoreId: "publisherAbuseScores:ban",
+        label: "potential_ban_candidate",
+        status: "pending",
+      }),
+      makeNomination({
+        _id: "publisherAbuseReviewNominations:review",
+        latestScoreId: "publisherAbuseScores:review",
+        label: "review",
+        status: "pending",
+      }),
+    ];
+    const db = {
+      get: vi.fn(async (id: string) => {
+        if (id.startsWith("publisherAbuseScores:")) {
+          throw new Error("dashboard count should not hydrate score rows");
+        }
+        return null;
+      }),
+      query: vi.fn((table: string) => {
+        if (table === "publisherAbuseScoreRuns") return makeEmptyPublisherAbuseScoreRunsQuery();
+        if (table === "publisherAbuseReviewNominations") {
+          return makePublisherAbuseNominationCountQuery(nominations);
+        }
+        if (table === "publisherAbuseSignals") return makePublisherAbuseSignalCountQuery([]);
+        if (table === "officialPublishers") return makeEmptyOfficialPublishersQuery();
+        throw new Error(`unexpected table ${table}`);
+      }),
+    };
+
+    await expect(listDashboardHandler({ db }, {})).resolves.toEqual(
+      expect.objectContaining({
+        pendingPotentialBanCandidateCount: 1,
+        pendingReviewCount: 1,
+        pendingCount: 2,
+        recentResolvedCount: 0,
+      }),
+    );
+    expect(db.get).not.toHaveBeenCalled();
+  });
+
+  it("counts only visible publisher abuse nominations on the dashboard", async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:moderator",
+      user: { _id: "users:moderator", role: "moderator" },
+    } as never);
+    const visiblePotentialBans = Array.from({ length: 26 }, (_, index) =>
+      makeNomination({
+        _id: `publisherAbuseReviewNominations:visible-ban-${index}`,
+        latestScoreId: `publisherAbuseScores:visible-ban-${index}`,
+        label: "potential_ban_candidate",
+        status: "pending",
+      }),
+    );
+    const nominations = [
+      ...visiblePotentialBans,
+      makeNomination({
+        _id: "publisherAbuseReviewNominations:inactive-pending",
+        latestScoreId: "publisherAbuseScores:inactive-pending",
+        ownerUserId: "users:inactive",
+        label: "potential_ban_candidate",
+        status: "pending",
+      }),
+      makeNomination({
+        _id: "publisherAbuseReviewNominations:official-pending",
+        latestScoreId: "publisherAbuseScores:official-pending",
+        ownerPublisherId: "publishers:official",
+        label: "review",
+        status: "pending",
+      }),
+      makeNomination({
+        _id: "publisherAbuseReviewNominations:visible-review",
+        latestScoreId: "publisherAbuseScores:visible-review",
+        label: "review",
+        status: "pending",
+      }),
+      makeNomination({
+        _id: "publisherAbuseReviewNominations:inactive-resolved",
+        latestScoreId: "publisherAbuseScores:inactive-resolved",
+        ownerUserId: "users:inactive",
+        label: "potential_ban_candidate",
+        status: "reviewed_no_action",
+      }),
+      makeNomination({
+        _id: "publisherAbuseReviewNominations:official-resolved",
+        latestScoreId: "publisherAbuseScores:official-resolved",
+        ownerPublisherId: "publishers:official",
+        label: "potential_ban_candidate",
+        status: "reviewed_no_action",
+      }),
+    ];
+    const db = {
+      get: vi.fn(async (id: string) => {
+        if (id.startsWith("publisherAbuseScores:")) {
+          throw new Error("dashboard count should not hydrate score rows");
+        }
+        if (id === "users:inactive") {
+          return { _id: "users:inactive", role: "user", deactivatedAt: 100 };
+        }
+        if (id === "publishers:official") {
+          return {
+            _id: "publishers:official",
+            kind: "user",
+            handle: "official",
+            linkedUserId: "users:official-owner",
+          };
+        }
+        if (id === "users:official-owner") {
+          return { _id: "users:official-owner", role: "user" };
+        }
+        return null;
+      }),
+      query: vi.fn((table: string) => {
+        if (table === "publisherAbuseScoreRuns") return makeEmptyPublisherAbuseScoreRunsQuery();
+        if (table === "publisherAbuseReviewNominations") {
+          return makePublisherAbuseNominationCountQuery(nominations);
+        }
+        if (table === "publisherAbuseSignals") return makePublisherAbuseSignalCountQuery([]);
+        if (table === "officialPublishers") {
+          return {
+            withIndex: (indexName: string) => {
+              expect(indexName).toBe("by_publisher");
+              return {
+                unique: async () => ({ publisherId: "publishers:official" }),
+              };
+            },
+          };
+        }
+        throw new Error(`unexpected table ${table}`);
+      }),
+    };
+
+    await expect(listDashboardHandler({ db }, {})).resolves.toEqual(
+      expect.objectContaining({
+        pendingPotentialBanCandidateCount: 25,
+        pendingReviewCount: 1,
+        pendingCount: 26,
+        recentResolvedCount: 1,
+        pendingPotentialBanCandidateCountHasMore: true,
+        pendingReviewCountHasMore: false,
+        pendingCountHasMore: true,
+        recentResolvedCountHasMore: false,
+      }),
+    );
   });
 
   it("does not mark the signal count as approximate at the exact scan limit", async () => {
@@ -1588,6 +1819,9 @@ describe("publisher abuse dry-run persistence", () => {
       }),
       query: vi.fn((table: string) => {
         if (table === "publisherAbuseScoreRuns") return makeEmptyPublisherAbuseScoreRunsQuery();
+        if (table === "publisherAbuseReviewNominations") {
+          return makePublisherAbuseNominationCountQuery();
+        }
         if (table === "publisherAbuseSignals") return makePublisherAbuseSignalCountQuery(signals);
         if (table === "officialPublishers") return makeEmptyOfficialPublishersQuery();
         throw new Error(`unexpected table ${table}`);
@@ -1600,6 +1834,14 @@ describe("publisher abuse dry-run persistence", () => {
       pendingPotentialBanCandidateItems: [],
       pendingReviewItems: [],
       recentResolvedItems: [],
+      pendingPotentialBanCandidateCount: 0,
+      pendingReviewCount: 0,
+      pendingCount: 0,
+      recentResolvedCount: 0,
+      pendingPotentialBanCandidateCountHasMore: false,
+      pendingReviewCountHasMore: false,
+      pendingCountHasMore: false,
+      recentResolvedCountHasMore: false,
       signalCount: 1,
       signalCountHasMore: false,
     });
@@ -1645,6 +1887,9 @@ describe("publisher abuse dry-run persistence", () => {
       }),
       query: vi.fn((table: string) => {
         if (table === "publisherAbuseScoreRuns") return makeEmptyPublisherAbuseScoreRunsQuery();
+        if (table === "publisherAbuseReviewNominations") {
+          return makePublisherAbuseNominationCountQuery();
+        }
         if (table === "publisherAbuseSignals") return makePublisherAbuseSignalCountQuery(signals);
         if (table === "officialPublishers") {
           return {
@@ -1680,6 +1925,14 @@ describe("publisher abuse dry-run persistence", () => {
       pendingPotentialBanCandidateItems: [],
       pendingReviewItems: [],
       recentResolvedItems: [],
+      pendingPotentialBanCandidateCount: 0,
+      pendingReviewCount: 0,
+      pendingCount: 0,
+      recentResolvedCount: 0,
+      pendingPotentialBanCandidateCountHasMore: false,
+      pendingReviewCountHasMore: false,
+      pendingCountHasMore: false,
+      recentResolvedCountHasMore: false,
       signalCount: 1,
       signalCountHasMore: false,
     });
@@ -2334,6 +2587,220 @@ describe("publisher abuse dry-run persistence", () => {
     );
   });
 
+  it("marks a pending publisher abuse nomination reviewed without banning", async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:moderator",
+      user: { _id: "users:moderator", role: "moderator" },
+    } as never);
+    const nomination = makeNomination({
+      _id: "publisherAbuseReviewNominations:review",
+      ownerKey: "publisher:owner",
+      latestScoreId: "publisherAbuseScores:latest",
+      updatedAt: 123,
+    });
+    const patch = vi.fn(async () => null);
+    const insert = vi.fn(async (table: string) => `${table}:new`);
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => (id === nomination._id ? nomination : null)),
+        insert,
+        patch,
+      },
+    };
+
+    await expect(
+      markPublisherAbuseNominationReviewedHandler(ctx, {
+        nominationId: nomination._id,
+        expectedLatestScoreId: nomination.latestScoreId,
+        expectedUpdatedAt: nomination.updatedAt,
+        note: " moved to signals ",
+      }),
+    ).resolves.toEqual({ ok: true, status: "reviewed_no_action" });
+
+    expect(assertModerator).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: "users:moderator" }),
+    );
+    expect(patch).toHaveBeenCalledWith(
+      nomination._id,
+      expect.objectContaining({
+        status: "reviewed_no_action",
+        reviewedByUserId: "users:moderator",
+        reviewedAt: expect.any(Number),
+        notes: "moved to signals",
+        warningSentAt: undefined,
+        warningPendingAt: undefined,
+        updatedAt: expect.any(Number),
+      }),
+    );
+    expect(insert).toHaveBeenCalledWith(
+      "publisherAbuseReviewEvents",
+      expect.objectContaining({
+        nominationId: nomination._id,
+        ownerKey: nomination.ownerKey,
+        actorUserId: "users:moderator",
+        scoreId: nomination.latestScoreId,
+        eventType: "triage_status_changed",
+        previousStatus: "pending",
+        nextStatus: "reviewed_no_action",
+        notes: "moved to signals",
+      }),
+    );
+  });
+
+  it("rejects stale publisher abuse nomination review actions", async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:moderator",
+      user: { _id: "users:moderator", role: "moderator" },
+    } as never);
+    const nomination = makeNomination({
+      _id: "publisherAbuseReviewNominations:stale",
+      latestScoreId: "publisherAbuseScores:newer",
+      updatedAt: 456,
+    });
+    const ctx = {
+      db: {
+        get: vi.fn(async () => nomination),
+        insert: vi.fn(),
+        patch: vi.fn(),
+      },
+    };
+
+    await expect(
+      markPublisherAbuseNominationReviewedHandler(ctx, {
+        nominationId: nomination._id,
+        expectedLatestScoreId: "publisherAbuseScores:older",
+        expectedUpdatedAt: nomination.updatedAt,
+      }),
+    ).rejects.toThrow("Publisher abuse nomination changed; refresh and try again");
+
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+    expect(ctx.db.insert).not.toHaveBeenCalled();
+  });
+
+  it("rejects marking review-only calibration nominations reviewed", async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:moderator",
+      user: { _id: "users:moderator", role: "moderator" },
+    } as never);
+    const nomination = makeNomination({
+      _id: "publisherAbuseReviewNominations:calibration",
+      latestScoreId: "publisherAbuseScores:latest",
+      label: "review",
+      status: "pending",
+      updatedAt: 123,
+    });
+    const ctx = {
+      db: {
+        get: vi.fn(async () => nomination),
+        insert: vi.fn(),
+        patch: vi.fn(),
+      },
+    };
+
+    await expect(
+      markPublisherAbuseNominationReviewedHandler(ctx, {
+        nominationId: nomination._id,
+        expectedLatestScoreId: nomination.latestScoreId,
+        expectedUpdatedAt: nomination.updatedAt,
+      }),
+    ).rejects.toThrow(/calibration/i);
+
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+    expect(ctx.db.insert).not.toHaveBeenCalled();
+  });
+
+  it("rejects marking non-pending potential-ban nominations reviewed", async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:moderator",
+      user: { _id: "users:moderator", role: "moderator" },
+    } as never);
+    const nomination = makeNomination({
+      _id: "publisherAbuseReviewNominations:already-reviewed",
+      latestScoreId: "publisherAbuseScores:latest",
+      label: "potential_ban_candidate",
+      status: "reviewed_no_action",
+      updatedAt: 123,
+    });
+    const ctx = {
+      db: {
+        get: vi.fn(async () => nomination),
+        insert: vi.fn(),
+        patch: vi.fn(),
+      },
+    };
+
+    await expect(
+      markPublisherAbuseNominationReviewedHandler(ctx, {
+        nominationId: nomination._id,
+        expectedLatestScoreId: nomination.latestScoreId,
+        expectedUpdatedAt: nomination.updatedAt,
+      }),
+    ).rejects.toThrow("Only pending publisher abuse nominations can be marked reviewed");
+
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+    expect(ctx.db.insert).not.toHaveBeenCalled();
+  });
+
+  it("rejects marking excluded publisher abuse nominations reviewed", async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:moderator",
+      user: { _id: "users:moderator", role: "moderator" },
+    } as never);
+    const nomination = makeNomination({
+      _id: "publisherAbuseReviewNominations:official",
+      ownerKey: "publisher:publishers:official",
+      ownerPublisherId: "publishers:official",
+      ownerUserId: "users:owner",
+      latestScoreId: "publisherAbuseScores:latest",
+      label: "potential_ban_candidate",
+      status: "pending",
+      updatedAt: 123,
+    });
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === nomination._id) return nomination;
+          if (id === "publishers:official") {
+            return {
+              _id: "publishers:official",
+              kind: "user",
+              handle: "official",
+              linkedUserId: "users:owner",
+            };
+          }
+          if (id === "users:owner") return { _id: "users:owner", role: "user" };
+          return null;
+        }),
+        insert: vi.fn(),
+        patch: vi.fn(),
+        query: vi.fn((table: string) => {
+          if (table === "officialPublishers") {
+            return {
+              withIndex: () => ({
+                unique: async () => ({
+                  _id: "officialPublishers:official",
+                  publisherId: "publishers:official",
+                }),
+              }),
+            };
+          }
+          throw new Error(`unexpected table ${table}`);
+        }),
+      },
+    };
+
+    await expect(
+      markPublisherAbuseNominationReviewedHandler(ctx, {
+        nominationId: nomination._id,
+        expectedLatestScoreId: nomination.latestScoreId,
+        expectedUpdatedAt: nomination.updatedAt,
+      }),
+    ).rejects.toThrow("Excluded publisher abuse nominations cannot be acted on");
+
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+    expect(ctx.db.insert).not.toHaveBeenCalled();
+  });
+
   it.each(["admin", "moderator"] as const)(
     "rejects direct ban actions for %s owners without a publisher row",
     async (role) => {
@@ -2865,6 +3332,87 @@ describe("publisher abuse dry-run persistence", () => {
         warningPendingRunId: undefined,
       }),
     );
+  });
+
+  it("preserves sent warning state when deferring candidates from failed score runs", async () => {
+    const nomination = {
+      ...makeNomination({
+        _id: "publisherAbuseReviewNominations:candidate",
+        ownerKey: "publisher:publishers:candidate",
+        ownerPublisherId: "publishers:candidate",
+        ownerUserId: "users:candidate",
+        latestScoreId: "publisherAbuseScores:candidate",
+        label: "potential_ban_candidate",
+        status: "pending",
+      }),
+      warningSentAt: 10,
+      warningExpiresAt: 20,
+      warningScoreId: "publisherAbuseScores:warned",
+      warningRunId: "publisherAbuseScoreRuns:warned",
+    };
+    const score = makeScore({
+      _id: "publisherAbuseScores:candidate",
+      ownerKey: nomination.ownerKey,
+      ownerPublisherId: "publishers:candidate",
+    });
+    const patch = vi.fn(async () => null);
+    const insert = vi.fn(async (table: string) => `${table}:new`);
+    const ctx = {
+      scheduler: { runAfter: vi.fn(async () => null) },
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "publisherAbuseScores:candidate") return score;
+          if (id === score.runId) return { ...makeCompletedPressureScoreRun(), status: "failed" };
+          return null;
+        }),
+        patch,
+        insert,
+        query: vi.fn((table: string) => {
+          if (table === "publisherAbuseReviewNominations") {
+            return makeAutoBanNominationQuery([nomination]);
+          }
+          if (table === "systemSettings") {
+            return makePublisherAbuseAutobanSettingQuery({
+              key: "publisherAbuseAutobanEnabled",
+              enabled: true,
+              updatedAt: 1,
+              updatedByUserId: "users:admin",
+            });
+          }
+          throw new Error(`unexpected table ${table}`);
+        }),
+      },
+    };
+
+    await expect(autoBanPublisherAbuseCandidatesPageHandler(ctx, {})).resolves.toEqual({
+      ok: true,
+      processed: 1,
+      warned: 0,
+      banned: 0,
+      alreadyBanned: 0,
+      skipped: 1,
+      isDone: true,
+    });
+
+    expect(patch).toHaveBeenCalledWith(
+      nomination._id,
+      expect.objectContaining({
+        status: "candidate_for_future_action",
+        notes: "Autoban skipped: score run failed before completion; manual review required.",
+        warningSentAt: 10,
+        warningExpiresAt: 20,
+        warningScoreId: "publisherAbuseScores:warned",
+        warningRunId: "publisherAbuseScoreRuns:warned",
+      }),
+    );
+    expect(insert).toHaveBeenCalledWith(
+      "publisherAbuseReviewEvents",
+      expect.objectContaining({
+        nominationId: nomination._id,
+        nextStatus: "candidate_for_future_action",
+      }),
+    );
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/convex/publisherAbuse.test.ts
+++ b/convex/publisherAbuse.test.ts
@@ -8422,7 +8422,7 @@ describe("publisher abuse dry-run persistence", () => {
         candidates: [expect.objectContaining({ skillId: "skills:bounded-ratio" })],
       }),
     );
-    expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
+    expect(ctx.scheduler.runAfter).toHaveBeenCalledWith(0, expect.any(Symbol), {});
   });
 
   it("caps temporal scan candidate limits below Convex array limits", async () => {

--- a/convex/publisherAbuse.ts
+++ b/convex/publisherAbuse.ts
@@ -249,7 +249,7 @@ type PublisherAbuseAutobanRunResult = PublisherAbuseAutobanPageResult & {
 type PublisherAbuseAutobanEligibility =
   | { kind: "ready" }
   | { kind: "pending_run" }
-  | { kind: "defer"; status: TriageStatus; notes: string };
+  | { kind: "defer"; status: TriageStatus; notes: string; preserveWarningState?: boolean };
 
 type PublisherAbuseAutobanSettingDoc = Doc<"systemSettings">;
 
@@ -332,8 +332,9 @@ export const listReviewDashboard = query({
     const auth = await requirePublisherAbuseDashboardUser(ctx);
     if (!auth) return emptyPublisherAbuseReviewDashboard();
 
-    const [latestRun, signalCountSummary] = await Promise.all([
+    const [latestRun, nominationCountSummary, signalCountSummary] = await Promise.all([
       getLatestPublisherAbuseScoreRun(ctx),
+      getPublisherAbuseReviewNominationCountSummary(ctx),
       getPublisherAbuseSignalCountSummary(ctx),
     ]);
 
@@ -343,6 +344,7 @@ export const listReviewDashboard = query({
       pendingPotentialBanCandidateItems: [],
       pendingReviewItems: [],
       recentResolvedItems: [],
+      ...nominationCountSummary,
       ...signalCountSummary,
     };
   },
@@ -528,6 +530,14 @@ function emptyPublisherAbuseReviewDashboard() {
     pendingPotentialBanCandidateItems: [],
     pendingReviewItems: [],
     recentResolvedItems: [],
+    pendingPotentialBanCandidateCount: 0,
+    pendingReviewCount: 0,
+    pendingCount: 0,
+    recentResolvedCount: 0,
+    pendingPotentialBanCandidateCountHasMore: false,
+    pendingReviewCountHasMore: false,
+    pendingCountHasMore: false,
+    recentResolvedCountHasMore: false,
     signalCount: 0,
     signalCountHasMore: false,
   };
@@ -706,6 +716,44 @@ export const banPublisherAbuseOwner = mutation({
   },
 });
 
+export const markPublisherAbuseNominationReviewed = mutation({
+  args: {
+    nominationId: v.id("publisherAbuseReviewNominations"),
+    expectedLatestScoreId: v.id("publisherAbuseScores"),
+    expectedUpdatedAt: v.number(),
+    note: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const { user } = await requireUser(ctx);
+    assertModerator(user);
+
+    const nomination = await ctx.db.get(args.nominationId);
+    if (!nomination) throw new Error("Publisher abuse nomination not found");
+    requireFreshPublisherAbuseReviewNomination(nomination, args);
+    if (nomination.label !== "potential_ban_candidate") {
+      throw new Error(
+        "Only potential ban publisher abuse nominations can be marked reviewed; review nominations are calibration signals.",
+      );
+    }
+    if (nomination.status !== "pending") {
+      throw new Error("Only pending publisher abuse nominations can be marked reviewed.");
+    }
+    await requirePublisherAbuseNominationNotExcluded(ctx, nomination);
+
+    const now = Date.now();
+    const notes = normalizePublisherAbuseReviewNote(args.note);
+    await setPublisherAbuseReviewStatusWithActor(ctx, {
+      nomination,
+      status: "reviewed_no_action",
+      notes,
+      actorUserId: user._id,
+      now,
+    });
+
+    return { ok: true, status: "reviewed_no_action" as const };
+  },
+});
+
 export const autoBanPublisherAbuseCandidatesPageInternal = internalMutation({
   args: {
     batchSize: v.optional(v.number()),
@@ -722,13 +770,22 @@ async function setPublisherAbuseReviewStatusWithActor(
     notes: string | undefined;
     actorUserId?: Id<"users">;
     now: number;
+    preserveWarningState?: boolean;
   },
 ) {
+  const keepWarningState = args.status === "pending" || args.preserveWarningState === true;
   await ctx.db.patch(args.nomination._id, {
     status: args.status,
     reviewedByUserId: args.status === "pending" ? undefined : args.actorUserId,
     reviewedAt: args.status === "pending" ? undefined : args.now,
     notes: args.notes,
+    warningSentAt: keepWarningState ? args.nomination.warningSentAt : undefined,
+    warningExpiresAt: keepWarningState ? args.nomination.warningExpiresAt : undefined,
+    warningScoreId: keepWarningState ? args.nomination.warningScoreId : undefined,
+    warningRunId: keepWarningState ? args.nomination.warningRunId : undefined,
+    warningPendingAt: keepWarningState ? args.nomination.warningPendingAt : undefined,
+    warningPendingScoreId: keepWarningState ? args.nomination.warningPendingScoreId : undefined,
+    warningPendingRunId: keepWarningState ? args.nomination.warningPendingRunId : undefined,
     updatedAt: args.now,
   });
   await ctx.db.insert("publisherAbuseReviewEvents", {
@@ -797,6 +854,17 @@ function normalizePublisherAbuseSignalReviewNote(note: string | undefined) {
   return trimmed;
 }
 
+function normalizePublisherAbuseReviewNote(note: string | undefined) {
+  const trimmed = note?.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.length > MAX_BAN_REASON_LENGTH) {
+    throw new Error(
+      `Publisher abuse review note must be ${MAX_BAN_REASON_LENGTH} characters or fewer.`,
+    );
+  }
+  return trimmed;
+}
+
 async function getPublisherAbuseAutobanEligibility(
   ctx: Pick<MutationCtx, "db">,
   nomination: Doc<"publisherAbuseReviewNominations">,
@@ -815,6 +883,7 @@ async function getPublisherAbuseAutobanEligibility(
       kind: "defer",
       status: "candidate_for_future_action",
       notes: FAILED_SCORE_RUN_AUTOBAN_SKIP_NOTE,
+      preserveWarningState: true,
     };
   }
   if (scoredByRun.modelVersion !== PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION) {
@@ -1099,6 +1168,7 @@ export async function autoBanPublisherAbuseCandidatesPageInternalHandler(
         nomination,
         status: eligibility.status,
         notes: eligibility.notes,
+        preserveWarningState: eligibility.preserveWarningState,
         now,
       });
       skipped += 1;
@@ -4099,6 +4169,132 @@ async function summarizeVisiblePublisherAbuseSignals(
     });
   }
   return items;
+}
+
+async function getPublisherAbuseReviewNominationCountSummary(ctx: QueryCtx) {
+  const [potentialBanSummary, reviewSummary, resolvedSummary] = await Promise.all([
+    getVisiblePublisherAbuseNominationCount(ctx, {
+      status: "pending",
+      label: "potential_ban_candidate",
+      staffManagerExclusionBudget: createStaffPublisherManagerExclusionBudget(),
+    }),
+    getVisiblePublisherAbuseNominationCount(ctx, {
+      status: "pending",
+      label: "review",
+      staffManagerExclusionBudget: createStaffPublisherManagerExclusionBudget(),
+    }),
+    getResolvedPublisherAbuseNominationCount(ctx, {
+      staffManagerExclusionBudget: createStaffPublisherManagerExclusionBudget(),
+    }),
+  ]);
+  return {
+    pendingPotentialBanCandidateCount: potentialBanSummary.count,
+    pendingReviewCount: reviewSummary.count,
+    pendingCount: potentialBanSummary.count + reviewSummary.count,
+    recentResolvedCount: resolvedSummary.count,
+    pendingPotentialBanCandidateCountHasMore: potentialBanSummary.hasMore,
+    pendingReviewCountHasMore: reviewSummary.hasMore,
+    pendingCountHasMore: potentialBanSummary.hasMore || reviewSummary.hasMore,
+    recentResolvedCountHasMore: resolvedSummary.hasMore,
+  };
+}
+
+async function getVisiblePublisherAbuseNominationCount(
+  ctx: QueryCtx,
+  args: {
+    status: TriageStatus;
+    label: PendingPublisherAbuseReviewLabel;
+    staffManagerExclusionBudget?: StaffPublisherManagerExclusionBudget;
+  },
+) {
+  const nominations = await ctx.db
+    .query("publisherAbuseReviewNominations")
+    .withIndex("by_status_and_label_and_last_scored_at", (q) =>
+      q.eq("status", args.status).eq("label", args.label),
+    )
+    .order("desc")
+    .take(DASHBOARD_SIGNAL_COUNT_SCAN_LIMIT + 1);
+  return await countVisiblePublisherAbuseNominations(ctx, nominations, {
+    staffManagerExclusionBudget: args.staffManagerExclusionBudget,
+  });
+}
+
+async function getResolvedPublisherAbuseNominationCount(
+  ctx: QueryCtx,
+  args: { staffManagerExclusionBudget?: StaffPublisherManagerExclusionBudget },
+) {
+  const resolvedStatuses: TriageStatus[] = [
+    "banned",
+    "reviewed_no_action",
+    "false_positive",
+    "needs_policy_discussion",
+    "candidate_for_future_action",
+  ];
+  let count = 0;
+  let hasMore = false;
+  for (const status of resolvedStatuses) {
+    const nominations = await ctx.db
+      .query("publisherAbuseReviewNominations")
+      .withIndex("by_status_and_reviewed_at", (q) => q.eq("status", status))
+      .order("desc")
+      .take(DASHBOARD_SIGNAL_COUNT_SCAN_LIMIT + 1);
+    const summary = await countVisiblePublisherAbuseNominations(ctx, nominations, {
+      staffManagerExclusionBudget: args.staffManagerExclusionBudget,
+      includeInactiveTargets: true,
+    });
+    count += summary.count;
+    hasMore = hasMore || summary.hasMore;
+    if (count > DASHBOARD_SIGNAL_COUNT_LIMIT) {
+      hasMore = true;
+      count = DASHBOARD_SIGNAL_COUNT_LIMIT;
+      break;
+    }
+  }
+  return { count, hasMore };
+}
+
+async function countVisiblePublisherAbuseNominations(
+  ctx: QueryCtx,
+  nominations: Doc<"publisherAbuseReviewNominations">[],
+  visibilityOptions: PublisherAbuseReviewVisibilityOptions,
+) {
+  const scannedNominations = nominations.slice(0, DASHBOARD_SIGNAL_COUNT_SCAN_LIMIT);
+  let visibleCount = 0;
+  for (const nomination of scannedNominations) {
+    if (await isVisiblePublisherAbuseNominationCountTarget(ctx, nomination, visibilityOptions)) {
+      visibleCount += 1;
+      if (visibleCount > DASHBOARD_SIGNAL_COUNT_LIMIT) break;
+    }
+  }
+  return {
+    count: Math.min(visibleCount, DASHBOARD_SIGNAL_COUNT_LIMIT),
+    hasMore:
+      visibleCount > DASHBOARD_SIGNAL_COUNT_LIMIT ||
+      nominations.length > DASHBOARD_SIGNAL_COUNT_SCAN_LIMIT,
+  };
+}
+
+async function isVisiblePublisherAbuseNominationCountTarget(
+  ctx: QueryCtx,
+  nomination: Doc<"publisherAbuseReviewNominations">,
+  options: PublisherAbuseReviewVisibilityOptions,
+) {
+  if (nomination.label === "pass") return false;
+  const [publisher, ownerUser] = await Promise.all([
+    nomination.ownerPublisherId ? ctx.db.get(nomination.ownerPublisherId) : null,
+    nomination.ownerUserId ? ctx.db.get(nomination.ownerUserId) : null,
+  ]);
+  const targetIsInactive =
+    ownerUser?.deletedAt ||
+    ownerUser?.deactivatedAt ||
+    publisher?.deletedAt ||
+    publisher?.deactivatedAt;
+  if (!options.includeInactiveTargets && targetIsInactive) return false;
+  return !(await isPublisherExcludedFromPublisherAbuse(
+    ctx,
+    publisher,
+    options.staffManagerExclusionBudget,
+  ));
 }
 
 async function getPublisherAbuseSignalCountSummary(ctx: QueryCtx) {

--- a/convex/publisherAbuse.ts
+++ b/convex/publisherAbuse.ts
@@ -2897,7 +2897,7 @@ export async function runTemporalPublisherAbuseScanInternalHandler(
       await archiveTemporalPublisherAbuseSignalPages(ctx, {
         candidates: highTemporalCandidates,
         now: Date.now(),
-        notifyHermit: (args.trigger ?? "cron") === "cron" && scanComplete,
+        notifyHermit: (args.trigger ?? "cron") === "cron",
       });
     }
     return {

--- a/src/routes/-management.test.tsx
+++ b/src/routes/-management.test.tsx
@@ -320,6 +320,48 @@ describe("Management", () => {
     expect(screen.queryByRole("button", { name: "Mark reviewed" })).toBeNull();
   });
 
+  it("does not mark unresolved resolved-tab rows as reachable", () => {
+    const resolvedItem = makePublisherAbuseItem({
+      handle: "recently-cleared",
+      id: "11",
+      label: "review",
+      ownerKey: "user:recently-cleared",
+      ownerUserId: "users:recently-cleared",
+      status: "reviewed_no_action",
+      zScore: 1.2,
+    });
+    useQueryMock.mockImplementation((query, args) => {
+      if (args === "skip") return undefined;
+      const name = getFunctionName(query);
+      if (name === "skills:listRecentVersions") return [];
+      if (name === "skills:listReportedSkills") return [];
+      if (name === "skills:listDuplicateCandidates") return [];
+      if (name === "publisherAbuse:listReviewDashboard") {
+        return {
+          latestRun: null,
+          pendingItems: [],
+          pendingPotentialBanCandidateItems: [],
+          pendingReviewItems: [],
+          recentResolvedItems: [resolvedItem],
+          recentResolvedCount: 25,
+          recentResolvedCountHasMore: true,
+        };
+      }
+      if (name === "users:list") return { items: [], total: 0 };
+      return undefined;
+    });
+
+    render(<Management />);
+
+    expect(screen.getByRole("tab", { name: /Resolved 1$/ })).toBeTruthy();
+    expect(screen.queryByRole("tab", { name: /Resolved 25\+/ })).toBeNull();
+
+    fireEvent.click(screen.getByRole("tab", { name: /Resolved/ }));
+
+    expect(screen.getByText("Showing 1 of 1 nominations")).toBeTruthy();
+    expect(screen.queryByText("Showing 1 of 25+ nominations")).toBeNull();
+  });
+
   it("shows only the active publisher abuse tab rows", () => {
     const potentialBanItem = makePublisherAbuseItem();
     const reviewItem = makePublisherAbuseItem({
@@ -776,6 +818,126 @@ describe("Management", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Load more" }));
     expect(loadMoreSignals).toHaveBeenCalledWith(25);
+  });
+
+  it("keeps nomination tab badges accurate while the signals tab is active", () => {
+    searchState = { view: "abuse", tab: "signals" };
+    const signal = makePublisherAbuseSignal();
+    useQueryMock.mockImplementation((query, args) => {
+      if (args === "skip") return undefined;
+      const name = getFunctionName(query);
+      if (name === "skills:listRecentVersions") return [];
+      if (name === "skills:listReportedSkills") return [];
+      if (name === "skills:listDuplicateCandidates") return [];
+      if (name === "publisherAbuse:listReviewDashboard") {
+        return {
+          latestRun: {
+            status: "completed",
+            scannedPublishers: 10,
+            scoredPublishers: 10,
+            potentialBanCandidateCount: 99,
+            reviewCount: 12,
+          },
+          pendingItems: [],
+          pendingPotentialBanCandidateItems: [],
+          pendingReviewItems: [],
+          recentResolvedItems: [],
+          pendingPotentialBanCandidateCount: 13,
+          pendingReviewCount: 0,
+          pendingCount: 13,
+          recentResolvedCount: 0,
+          signalCount: 8,
+          signalCountHasMore: false,
+        };
+      }
+      if (name === "users:list") return { items: [], total: 0 };
+      return undefined;
+    });
+    usePaginatedQueryMock.mockImplementation((query, args) => {
+      const name = getFunctionName(query);
+      if (name === "publisherAbuse:listSignalsPage") {
+        return {
+          results: args === "skip" ? [] : [signal],
+          status: args === "skip" ? "LoadingFirstPage" : "Exhausted",
+          loadMore: vi.fn(),
+        };
+      }
+      return {
+        results: [],
+        status: args === "skip" ? "LoadingFirstPage" : "Exhausted",
+        loadMore: vi.fn(),
+      };
+    });
+
+    render(<Management />);
+
+    expect(screen.getByRole("tab", { name: /Potential ban 13/ })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: /All flagged 13/ })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: /Signals 8/ })).toBeTruthy();
+  });
+
+  it("marks bounded nomination badge counts as approximate", () => {
+    searchState = { view: "abuse", tab: "potential_ban_candidate" };
+    const item = makePublisherAbuseItem({
+      ownerKey: "user:bounded",
+      handle: "bounded",
+      zScore: 3.8,
+    });
+    useQueryMock.mockImplementation((query, args) => {
+      if (args === "skip") return undefined;
+      const name = getFunctionName(query);
+      if (name === "skills:listRecentVersions") return [];
+      if (name === "skills:listReportedSkills") return [];
+      if (name === "skills:listDuplicateCandidates") return [];
+      if (name === "publisherAbuse:listReviewDashboard") {
+        return {
+          latestRun: {
+            status: "completed",
+            scannedPublishers: 30,
+            scoredPublishers: 30,
+            potentialBanCandidateCount: 30,
+            reviewCount: 0,
+          },
+          pendingItems: [],
+          pendingPotentialBanCandidateItems: [],
+          pendingReviewItems: [],
+          recentResolvedItems: [],
+          pendingPotentialBanCandidateCount: 25,
+          pendingReviewCount: 0,
+          pendingCount: 25,
+          recentResolvedCount: 0,
+          pendingPotentialBanCandidateCountHasMore: true,
+          pendingReviewCountHasMore: false,
+          pendingCountHasMore: true,
+          recentResolvedCountHasMore: false,
+          signalCount: 0,
+          signalCountHasMore: false,
+        };
+      }
+      if (name === "users:list") return { items: [], total: 0 };
+      return undefined;
+    });
+    usePaginatedQueryMock.mockImplementation((query, args) => {
+      const name = getFunctionName(query);
+      if (name === "publisherAbuse:listReviewItemsPage") {
+        return {
+          results: args === "skip" ? [] : [item],
+          status: args === "skip" ? "LoadingFirstPage" : "Exhausted",
+          loadMore: vi.fn(),
+        };
+      }
+      return {
+        results: [],
+        status: args === "skip" ? "LoadingFirstPage" : "Exhausted",
+        loadMore: vi.fn(),
+      };
+    });
+
+    render(<Management />);
+
+    expect(screen.getByRole("tab", { name: /Potential ban 25\+/ })).toBeTruthy();
+    expect(screen.getByRole("tab", { name: /All flagged 25\+/ })).toBeTruthy();
+    expect(screen.getByText("Showing 1 of 25+ nominations")).toBeTruthy();
   });
 
   it("shows table skeleton rows while the active publisher abuse page is loading", () => {
@@ -1346,7 +1508,7 @@ describe("Management", () => {
     fireEvent.click(screen.getByText("spammy-pub"));
 
     expect(screen.getByRole("button", { name: "Ban user" })).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "Mark reviewed" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Mark reviewed" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "False positive" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Needs discussion" })).toBeNull();
     expect(screen.queryByText(/Non-ban decisions remove/i)).toBeNull();
@@ -1367,6 +1529,54 @@ describe("Management", () => {
       });
     });
     expect(banUser).not.toHaveBeenCalled();
+  });
+
+  it("marks potential-ban nominations reviewed from the publisher abuse drawer", async () => {
+    const markReviewed = vi.fn(async () => ({ ok: true, status: "reviewed_no_action" }));
+    const item = makePublisherAbuseItem();
+    useMutationMock.mockImplementation((mutation) => {
+      const name = getFunctionName(mutation);
+      if (name === "publisherAbuse:markPublisherAbuseNominationReviewed") return markReviewed;
+      return vi.fn(async () => ({ ok: true }));
+    });
+    useQueryMock.mockImplementation((query, args) => {
+      if (args === "skip") return undefined;
+      const name = getFunctionName(query);
+      if (name === "skills:listRecentVersions") return [];
+      if (name === "skills:listReportedSkills") return [];
+      if (name === "skills:listDuplicateCandidates") return [];
+      if (name === "publisherAbuse:listReviewDashboard") {
+        return {
+          latestRun: null,
+          pendingItems: [],
+          pendingPotentialBanCandidateItems: [item],
+          pendingReviewItems: [],
+          recentResolvedItems: [],
+        };
+      }
+      if (name === "users:list") return { items: [], total: 0 };
+      return undefined;
+    });
+
+    render(<Management />);
+
+    fireEvent.click(screen.getByText("spammy-pub"));
+    fireEvent.change(screen.getByPlaceholderText("Why are you taking this action? (optional)"), {
+      target: { value: "tracked as signal now" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Mark reviewed" }));
+    expect(screen.getByRole("heading", { name: "Mark spammy-pub reviewed?" })).toBeTruthy();
+    const reviewButtons = screen.getAllByRole("button", { name: "Mark reviewed" });
+    fireEvent.click(reviewButtons[reviewButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(markReviewed).toHaveBeenCalledWith({
+        nominationId: item.nomination._id,
+        expectedLatestScoreId: item.nomination.latestScoreId,
+        expectedUpdatedAt: item.nomination.updatedAt,
+        note: "tracked as signal now",
+      });
+    });
   });
 
   it("does not offer publisher abuse bans for staff owners", () => {

--- a/src/routes/-management/AbusePage.tsx
+++ b/src/routes/-management/AbusePage.tsx
@@ -66,6 +66,7 @@ export function AbusePage({
   onChangeTab,
   onClose,
   onDismissSignal,
+  onMarkReviewed,
   onLoadMore,
   onRefresh,
   onReopenSignal,
@@ -102,6 +103,7 @@ export function AbusePage({
   onChangeTab: (value: PublisherAbuseTab) => void;
   onClose: () => void;
   onDismissSignal: (item: PublisherAbuseSignalEntry) => void;
+  onMarkReviewed: (item: PublisherAbuseReviewItem) => void;
   onLoadMore: () => void;
   onRefresh: () => void;
   onReopenSignal: (item: PublisherAbuseSignalEntry) => void;
@@ -133,16 +135,21 @@ export function AbusePage({
   const selectedPublisher = selectedItem?.publisher ?? null;
   const canBanSelectedUser = canBanPublisherAbuseOwner(selectedItem, currentUserId);
   const visiblePending = dashboard ? getPublisherAbuseVisiblePendingItems(dashboard) : [];
-  const potentialBan = Math.max(
-    dashboard?.latestRun?.potentialBanCandidateCount ?? 0,
-    visiblePending.filter((item) => item.nomination.label === "potential_ban_candidate").length,
-  );
-  const review = Math.max(
-    dashboard?.latestRun?.reviewCount ?? 0,
-    visiblePending.filter((item) => item.nomination.label === "review").length,
-  );
-  const totalPending = Math.max(potentialBan + review, visiblePending.length);
-  const resolved = tab === "resolved" ? items.length : (dashboard?.recentResolvedItems.length ?? 0);
+  const visiblePotentialBan = visiblePending.filter(
+    (item) => item.nomination.label === "potential_ban_candidate",
+  ).length;
+  const visibleReview = visiblePending.filter((item) => item.nomination.label === "review").length;
+  const potentialBan =
+    dashboard?.pendingPotentialBanCandidateCount ??
+    Math.max(dashboard?.latestRun?.potentialBanCandidateCount ?? 0, visiblePotentialBan);
+  const review =
+    dashboard?.pendingReviewCount ??
+    Math.max(dashboard?.latestRun?.reviewCount ?? 0, visibleReview);
+  const totalPending =
+    dashboard?.pendingCount ?? Math.max(potentialBan + review, visiblePending.length);
+  const resolvedVisibleCount = dashboard?.recentResolvedItems.length ?? 0;
+  const resolved =
+    tab === "resolved" ? Math.max(items.length, resolvedVisibleCount) : resolvedVisibleCount;
   const dashboardLoaded = dashboard !== undefined;
   const nominationPageLoaded = pageStatus !== "LoadingFirstPage";
   const loaded = dashboardLoaded && nominationPageLoaded;
@@ -160,16 +167,30 @@ export function AbusePage({
             : totalPending;
   const totalForTab = loaded ? Math.max(latestRunTotalForTab, items.length) : latestRunTotalForTab;
   const currentPageTotalForTab = loaded ? totalForTab : 0;
+  const canLoadMore = pageStatus === "CanLoadMore";
+  const loadingMore = pageStatus === "LoadingMore";
+  const nominationPageHasMore = canLoadMore || loadingMore;
   const potentialBanTabCount = Math.max(
     potentialBan,
     tab === "potential_ban_candidate" ? currentPageTotalForTab : 0,
   );
+  const potentialBanTabHasMore =
+    dashboard?.pendingPotentialBanCandidateCountHasMore ||
+    (tab === "potential_ban_candidate" && nominationPageHasMore);
   const reviewTabCount = Math.max(review, tab === "review" ? currentPageTotalForTab : 0);
+  const reviewTabHasMore =
+    dashboard?.pendingReviewCountHasMore || (tab === "review" && nominationPageHasMore);
   const allPendingTabCount = Math.max(
     totalPending,
     tab === "all_pending" ? currentPageTotalForTab : 0,
     potentialBanTabCount + reviewTabCount,
   );
+  const allPendingTabHasMore =
+    dashboard?.pendingCountHasMore ||
+    potentialBanTabHasMore ||
+    reviewTabHasMore ||
+    (tab === "all_pending" && nominationPageHasMore);
+  const resolvedTabHasMore = tab === "resolved" && nominationPageHasMore;
   const signalTabCount = Math.max(
     signalDashboardCount,
     tab === "signals" && signalsLoaded ? signalLoadedCount : 0,
@@ -182,13 +203,29 @@ export function AbusePage({
     signalTabHasMore && signalTabCount > 0
       ? `${formatWholeNumber(signalTabCount)}+`
       : formatWholeNumber(signalTabCount);
-  const canLoadMore = pageStatus === "CanLoadMore";
-  const loadingMore = pageStatus === "LoadingMore";
+  const potentialBanTabCountLabel = formatAbuseTabCountLabel(
+    potentialBanTabCount,
+    potentialBanTabHasMore,
+  );
+  const reviewTabCountLabel = formatAbuseTabCountLabel(reviewTabCount, reviewTabHasMore);
+  const allPendingTabCountLabel = formatAbuseTabCountLabel(
+    allPendingTabCount,
+    allPendingTabHasMore,
+  );
+  const resolvedTabCountLabel = formatAbuseTabCountLabel(resolved, resolvedTabHasMore);
   const signalsCanLoadMore = signalPageStatus === "CanLoadMore";
   const signalsLoadingMore = signalPageStatus === "LoadingMore";
+  const activeNominationHasMore =
+    tab === "potential_ban_candidate"
+      ? potentialBanTabHasMore
+      : tab === "review"
+        ? reviewTabHasMore
+        : tab === "resolved"
+          ? resolvedTabHasMore
+          : allPendingTabHasMore;
   const nominationCountLabel =
-    loaded && (canLoadMore || loadingMore)
-      ? `Showing ${formatWholeNumber(items.length)}+ nominations`
+    loaded && (nominationPageHasMore || activeNominationHasMore)
+      ? `Showing ${formatWholeNumber(items.length)} of ${formatWholeNumber(totalForTab)}+ nominations`
       : loaded
         ? `Showing ${formatWholeNumber(items.length)} of ${formatWholeNumber(totalForTab)} nominations`
         : "Loading…";
@@ -283,6 +320,7 @@ export function AbusePage({
         <PublisherAbuseTabButton
           active={tab === "potential_ban_candidate"}
           count={dashboardLoaded ? potentialBanTabCount : undefined}
+          countLabel={dashboardLoaded ? potentialBanTabCountLabel : undefined}
           label="Potential ban"
           loading={!dashboardLoaded}
           onClick={() => onChangeTab("potential_ban_candidate")}
@@ -290,6 +328,7 @@ export function AbusePage({
         <PublisherAbuseTabButton
           active={tab === "review"}
           count={dashboardLoaded ? reviewTabCount : undefined}
+          countLabel={dashboardLoaded ? reviewTabCountLabel : undefined}
           label="On the brink"
           loading={!dashboardLoaded}
           onClick={() => onChangeTab("review")}
@@ -297,6 +336,7 @@ export function AbusePage({
         <PublisherAbuseTabButton
           active={tab === "all_pending"}
           count={dashboardLoaded ? allPendingTabCount : undefined}
+          countLabel={dashboardLoaded ? allPendingTabCountLabel : undefined}
           label="All flagged"
           loading={!dashboardLoaded}
           onClick={() => onChangeTab("all_pending")}
@@ -304,6 +344,7 @@ export function AbusePage({
         <PublisherAbuseTabButton
           active={tab === "resolved"}
           count={dashboardLoaded ? resolved : undefined}
+          countLabel={dashboardLoaded ? resolvedTabCountLabel : undefined}
           label="Resolved"
           loading={!dashboardLoaded}
           onClick={() => onChangeTab("resolved")}
@@ -637,6 +678,15 @@ export function AbusePage({
                     <div className="pa-actions">
                       <Button
                         type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => onMarkReviewed(selectedItem)}
+                      >
+                        <XCircle size={14} />
+                        Mark reviewed
+                      </Button>
+                      <Button
+                        type="button"
                         variant="destructive"
                         size="sm"
                         className="pa-ban"
@@ -715,6 +765,10 @@ function PublisherAbuseTabButton({
       )}
     </button>
   );
+}
+
+function formatAbuseTabCountLabel(count: number, hasMore: boolean | undefined) {
+  return hasMore && count > 0 ? `${formatWholeNumber(count)}+` : formatWholeNumber(count);
 }
 
 function PublisherAbuseTableSkeletonRows({

--- a/src/routes/management.tsx
+++ b/src/routes/management.tsx
@@ -257,6 +257,9 @@ export function Management() {
   const setSkillManualOverride = useMutation(api.skills.setSkillManualOverride);
   const clearSkillManualOverride = useMutation(api.skills.clearSkillManualOverride);
   const banPublisherAbuseOwnerMutation = useMutation(api.publisherAbuse.banPublisherAbuseOwner);
+  const markPublisherAbuseNominationReviewed = useMutation(
+    api.publisherAbuse.markPublisherAbuseNominationReviewed,
+  );
   const setPublisherAbuseAutobanEnabled = useMutation(
     api.publisherAbuse.setPublisherAbuseAutobanEnabled,
   );
@@ -656,6 +659,30 @@ export function Management() {
     });
   };
 
+  const requestMarkPublisherAbuseNominationReviewed = (item: PublisherAbuseReviewItem) => {
+    const label = item.nomination.handleSnapshot;
+    const note = publisherAbuseNotes.trim() || undefined;
+    setConfirmRequest({
+      title: `Mark ${label} reviewed?`,
+      body: "Removes this nomination from the active abuse queue without banning the user. The score and review note stay in the resolved history.",
+      confirmLabel: "Mark reviewed",
+      onConfirm: () => {
+        void markPublisherAbuseNominationReviewed({
+          nominationId: item.nomination._id,
+          expectedLatestScoreId: item.nomination.latestScoreId,
+          expectedUpdatedAt: item.nomination.updatedAt,
+          note,
+        })
+          .then(() => {
+            toast.success("Nomination marked reviewed.");
+            setPublisherAbuseNotes("");
+            setSelectedPublisherAbuseNominationId(null);
+          })
+          .catch((error) => toast.error(formatMutationError(error)));
+      },
+    });
+  };
+
   const requestDismissPublisherAbuseSignal = (item: PublisherAbuseSignalEntry) => {
     setConfirmRequest({
       title: `Dismiss ${item.signal.skillDisplayName}?`,
@@ -773,6 +800,7 @@ export function Management() {
             }}
             onToggleAutoban={requestTogglePublisherAbuseAutoban}
             onDismissSignal={requestDismissPublisherAbuseSignal}
+            onMarkReviewed={requestMarkPublisherAbuseNominationReviewed}
             onLoadMore={() => {
               if (publisherAbuseTab === "signals") {
                 loadMorePublisherAbuseSignals(25);


### PR DESCRIPTION
## Summary

Publisher abuse signals could appear in the management dashboard without sending the Hermit Discord digest. The dry-run temporal scan archives dashboard signals even when it stops at the configured candidate limit, but the Hermit scheduler was gated on full scan completion, so partial dry-run scans left `needsNotification=true` rows stranded.

This hotfix schedules the existing Hermit digest worker whenever a cron dry-run archive changes signals, even if the candidate scan is partial. It also adds a small periodic drain for pending publisher-abuse signal notifications so missed one-shot schedules do not leave rows stuck indefinitely.

## What Changed

- Partial temporal dry-run archives: changed signals now schedule `notifyPublisherAbuseSignalChangesInternal` for cron runs without requiring `scanComplete`.
- Pending signal recovery: a 15-minute `publisher-abuse-signal-notifications` cron invokes the existing claim/send/mark-success flow for rows with `needsNotification=true`.
- Regression coverage: the partial dry-run archive test now asserts Hermit scheduling, and cron registration tests cover the new drain.

## Proof

Behavioral proof:

- Prod data showed 7 real `publisherAbuseSignals` rows with `needsNotification=true`, no `notificationClaimedAt`, no `lastNotifiedAt`, and no `lastNotificationError`; that state means ClawHub never started the Hermit notification action for those rows.
- The current cron is `dryRun: true`, `archiveDryRunSignals: true`, `candidateLimit: 1_000`, `maxPages: 20`. In that path, signal rows are archived before the function returns, but notification was previously gated by `scanComplete`.
- The existing Hermit digest action already handles claiming, POST failure requeue, success marking, pagination, and stale claim recovery. This PR only makes sure it is invoked for partial archives and periodically drains pending rows.

## Verification

Reviewer-checkable behavior:

- `convex/publisherAbuse.test.ts` now proves a bounded current temporal dry-run that archives changed signals before scan completion schedules `notifyPublisherAbuseSignalChangesInternal`.
- `convex/crons.test.ts` now proves the pending notification drain cron is registered every 15 minutes.

Automated checks run locally:

- `bun run format convex/publisherAbuse.ts convex/publisherAbuse.test.ts convex/crons.ts convex/crons.test.ts`
- `bunx vitest run convex/publisherAbuse.test.ts convex/crons.test.ts --reporter verbose` - 129 passed
- `bunx tsc --noEmit --pretty false`
- `bunx convex dev --once --typecheck=disable` against dev deployment `admired-dodo-615`

No screenshots: backend-only scheduling fix; the management UI surface is unchanged.
