### PR TITLE
fix: keep categorize dialog usable and taxonomy editable by owners

### DIFF
--- a/src/components/CatalogMetadataFields.tsx
+++ b/src/components/CatalogMetadataFields.tsx
@@ -103,7 +103,12 @@ export function CatalogMetadataFields({
           <Label htmlFor={`${fieldIdPrefix}Categories`}>Categories</Label>
           {categoryToolbar}
         </div>
-        <DropdownMenu>
+        {/* modal={false}: a modal dropdown disables pointer events on the rest
+            of the page, so the click that dismisses it targets <body> — which a
+            parent Dialog counts as an outside interaction and closes too,
+            losing unsaved selections. Non-modal keeps the dialog interactive so
+            only the dropdown dismisses. */}
+        <DropdownMenu modal={false}>
           <DropdownMenuTrigger asChild>
             <button
               id={`${fieldIdPrefix}Categories`}

--- a/src/routes/plugins/$name.tsx
+++ b/src/routes/plugins/$name.tsx
@@ -18,6 +18,7 @@ import {
   HardDrive,
   Info,
   Package,
+  Pencil,
   Plus,
   Server,
   Sparkles,
@@ -1634,6 +1635,22 @@ function PluginDetailPageContent({ name, loaderData }: PluginDetailPageProps) {
                           </a>
                         ))}
                       </div>
+                    ) : null}
+                    {manageContext ? (
+                      <>
+                        <span className="skill-hero-taxonomy-separator" aria-hidden="true" />
+                        <Button
+                          type="button"
+                          variant="link"
+                          size="xs"
+                          className="plugin-catalog-empty-alert-cta"
+                          aria-label="Edit categories and topics"
+                          onClick={() => setIsCatalogMetadataDialogOpen(true)}
+                        >
+                          <Pencil size={13} aria-hidden="true" />
+                          Edit
+                        </Button>
+                      </>
                     ) : null}
                   </div>
                 ) : null}


### PR DESCRIPTION
## Summary

Two fixes for plugin taxonomy management on the plugin detail page:

- **Categorize dialog no longer closes (and loses selections) mid-edit.** The category dropdown inside the dialog was a modal Radix `DropdownMenu`: while open it disables pointer events on the rest of the page, so the click that dismisses it targets `<body>` — which the parent `Dialog` counts as an outside interaction and closes too, discarding unsaved category selections before the user can hit Save. Rendering the dropdown with `modal={false}` keeps the dialog interactive so only the dropdown dismisses.
- **Owners can edit categories/topics after they're set.** The categorize CTA only rendered while a plugin had no taxonomy, so once categories/topics were saved there was no way back into the dialog. The taxonomy chip row now shows an owner-only **Edit** affordance that reopens the same categorize dialog.

## Verification

- `bun run ci:static`
- `bun run ci:unit` (4,321 passed | 1 skipped, coverage above thresholds)
- structured autoreview: clean, no actionable findings
- Real-browser proof against a local ClawHub instance (local anonymous Convex + seeded fixtures, dev-auth as the plugin owner `@local`, `http://localhost:3101/plugins/local-flagged-runtime-plugin`): Edit affordance renders in the taxonomy chip row; selecting a category and clicking the dialog body leaves the dialog open (previously closed it); Save persists and the new category chip renders.

### Screenshots (local instance, plugin owner)

Owner-only Edit affordance next to existing taxonomy chips:

![Edit affordance in taxonomy chip row](https://raw.githubusercontent.com/fuller-stack-dev/clawhub/57695ef90e0abd1c5f761036e0356083eefa508c/pr-taxonomy-edit-button.png)

Dialog still open after selecting a category and clicking the dialog body (the interaction that previously dismissed everything):

![Dialog stays open](https://raw.githubusercontent.com/fuller-stack-dev/clawhub/57695ef90e0abd1c5f761036e0356083eefa508c/pr-taxonomy-dialog-stays-open.png)

Save persists the change:

![Save toast](https://raw.githubusercontent.com/fuller-stack-dev/clawhub/57695ef90e0abd1c5f761036e0356083eefa508c/pr-taxonomy-saved.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
