### PR TITLE
Update create organization dialog copy

### DIFF
--- a/src/routes/-settings.test.tsx
+++ b/src/routes/-settings.test.tsx
@@ -551,11 +551,14 @@ describe("Settings", () => {
     render(<Settings />);
 
     fireEvent.click(screen.getByRole("button", { name: "Create org" }));
+    expect(screen.getAllByText("Create an organization for your team").length).toBeGreaterThan(0);
+    expect(screen.getByPlaceholderText("@openclaw")).toBeTruthy();
     fireEvent.change(screen.getByLabelText("Handle"), { target: { value: "romneyda" } });
     fireEvent.change(screen.getByLabelText("Display name"), {
       target: { value: "Dallin Romney @ OpenClaw" },
     });
-    const createOrgButtons = screen.getAllByRole("button", { name: "Create org" });
+    const createOrgButtons = screen.getAllByRole("button", { name: "Create" });
+    expect(createOrgButtons[createOrgButtons.length - 1]?.querySelector("svg")).toBeNull();
     fireEvent.click(createOrgButtons[createOrgButtons.length - 1]);
 
     await waitFor(() => {

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -975,7 +975,7 @@ export function Settings() {
                           <DialogHeader>
                             <DialogTitle>Create organization</DialogTitle>
                             <DialogDescription>
-                              Create a publisher profile for a team or project.
+                              Create an organization for your team
                             </DialogDescription>
                           </DialogHeader>
                           <div className="grid gap-4">
@@ -987,7 +987,7 @@ export function Settings() {
                                   setOrgHandle(event.target.value);
                                   setCreateOrgError(null);
                                 }}
-                                placeholder="example.tools"
+                                placeholder="@openclaw"
                               />
                             </Field>
                             <Field label="Display name" htmlFor="settings-org-display-name">
@@ -1020,8 +1020,7 @@ export function Settings() {
                               disabled={!orgHandle.trim() || isCreatingOrg}
                               onClick={() => void onCreateOrg()}
                             >
-                              <Building2 size={16} />
-                              {isCreatingOrg ? "Creating..." : "Create org"}
+                              {isCreatingOrg ? "Creating..." : "Create"}
                             </Button>
                           </DialogFooter>
                         </DialogContent>
@@ -1387,7 +1386,7 @@ export function Settings() {
                             Create organization
                           </h3>
                           <p className="text-sm text-[color:var(--ink-soft)]">
-                            Add a publisher profile for a team or project.
+                            Create an organization for your team
                           </p>
                         </div>
                       </div>
@@ -1408,7 +1407,7 @@ export function Settings() {
                           <DialogHeader>
                             <DialogTitle>Create organization</DialogTitle>
                             <DialogDescription>
-                              Create a publisher profile for a team or project.
+                              Create an organization for your team
                             </DialogDescription>
                           </DialogHeader>
                           <div className="grid gap-4">
@@ -1420,7 +1419,7 @@ export function Settings() {
                                   setOrgHandle(event.target.value);
                                   setCreateOrgError(null);
                                 }}
-                                placeholder="example.tools"
+                                placeholder="@openclaw"
                               />
                             </Field>
                             <Field label="Display name" htmlFor="settings-org-display-name-empty">
@@ -1453,8 +1452,7 @@ export function Settings() {
                               disabled={!orgHandle.trim() || isCreatingOrg}
                               onClick={() => void onCreateOrg()}
                             >
-                              <Building2 size={16} />
-                              {isCreatingOrg ? "Creating..." : "Create org"}
+                              {isCreatingOrg ? "Creating..." : "Create"}
                             </Button>
                           </DialogFooter>
                         </DialogContent>


### PR DESCRIPTION
## Summary
- updates the create organization modal helper copy and handle placeholder
- changes the modal submit button to text-only `Create`
- adds a regression assertion for the new copy, placeholder, and icon-free submit button

## Validation
- `bunx vitest run src/routes/-settings.test.tsx`
- `bun run format:check -- src/routes/settings.tsx src/routes/-settings.test.tsx e2e/local-auth/org-create-copy-proof.tmp.pw.test.ts`
- `PLAYWRIGHT_LOCAL_AUTH_CONVEX_URL=http://127.0.0.1:3310 PLAYWRIGHT_LOCAL_AUTH_CONVEX_SITE_URL=http://127.0.0.1:3311 PLAYWRIGHT_PORT=4173 bun run test:pw:local-auth -- --project=chromium e2e/local-auth/org-create-copy-proof.tmp.pw.test.ts --retries=0`
- `bun run ci:static`
- `bun run ci:unit`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt-file .proof/autoreview-context.md`

## UI Proof
- Local-auth screenshot: `/Users/patrickerichsen/.codex/worktrees/settings-org-create-copy/clawhub/.proof/org-create-copy-local-auth.png`
- Preview server left running at `http://127.0.0.1:3010/`
