### PR TITLE
fix: balance promotion section spacing

### DIFF
--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -290,9 +290,13 @@ describe("restored UI design contract", () => {
   });
 
   it("keeps promotion cards within narrow mobile viewports", () => {
-    expect(cssRule(styles(), ".home-v2-promotions-track")).toContain(
+    const css = styles();
+
+    expect(cssRule(css, ".home-v2-promotions")).toContain("padding: 0 48px 84px");
+    expect(cssRule(css, ".home-v2-promotions-track")).toContain(
       "grid-template-columns: repeat(auto-fit, minmax(min(320px, 100%), 1fr))",
     );
+    expect(css).toContain("padding: 0 20px 72px");
   });
 
   it("keeps typeahead creator avatars round for users and square for orgs", () => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -25507,7 +25507,7 @@ a.search-empty-action {
   width: 100%;
   max-width: 1296px;
   margin: 0 auto;
-  padding: 0 48px 8px;
+  padding: 0 48px 84px;
 }
 
 .home-v2-promotions-track {
@@ -25589,7 +25589,7 @@ a.search-empty-action {
 
 @media (max-width: 720px) {
   .home-v2-promotions {
-    padding: 0 20px 8px;
+    padding: 0 20px 72px;
   }
 }
 


### PR DESCRIPTION
## Summary

- match the promotion section's lower spacing to the hero-side spacing above it
- use `84px` desktop and `72px` mobile spacing so the card is visually centered between the hero and listing
- add a UI contract assertion for both responsive values

## Validation

- `bunx vitest run src/__tests__/ui-design-contract.test.ts src/components/HomePromotionsSection.test.tsx`
- `bun run ci:static`
- `bun run ci:unit`
- `VITE_CONVEX_URL=https://example.invalid bun run build`
- Playwright visual check at `1440x900` and `390x844` against `http://localhost:3101/`

Measured spacing:

- desktop: `84px` above and below the promotion card
- mobile: `72px` above and below the promotion card
