### PR TITLE
chore: run security dataset snapshot weekly

### DIFF
--- a/.github/workflows/security-dataset-snapshot.yml
+++ b/.github/workflows/security-dataset-snapshot.yml
@@ -48,7 +48,8 @@ on:
         required: false
         default: ""
   schedule:
-    - cron: "17 9 * * *"
+    # Sunday night Pacific time: 10:17 PM PDT / 9:17 PM PST.
+    - cron: "17 5 * * 1"
 
 permissions:
   actions: read


### PR DESCRIPTION
## Summary
- Change the Security Dataset Snapshot schedule from nightly to weekly.
- Run on Sunday night Pacific time via `17 5 * * 1` UTC, which lands at 10:17 PM PDT / 9:17 PM PST.

## Validation
- Not run, per explicit request to not wait for tests for this workflow-only schedule change.
