### PR TITLE
feat: add staged publish prepublication worker

### DIFF
--- a/.github/workflows/prepublication-publish-checks.yml
+++ b/.github/workflows/prepublication-publish-checks.yml
@@ -1,0 +1,88 @@
+name: Pre-publication Publish Checks
+
+on:
+  workflow_dispatch:
+    inputs:
+      batch-limit:
+        description: "Maximum staged publish attempts to check per worker shard"
+        required: true
+        default: "2"
+      max-jobs:
+        description: "Optional total attempts cap per worker shard"
+        required: false
+        default: ""
+      max-runtime-minutes:
+        description: "Stop claiming new attempts after this many minutes"
+        required: true
+        default: "8"
+  schedule:
+    - cron: "*/5 * * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: clawhub-prepublication-publish-checks
+  cancel-in-progress: false
+
+jobs:
+  prepublication-publish-checks:
+    name: Pre-publication publish checks shard ${{ matrix.shard }}
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 20
+    environment: Production
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        shard: [0, 1]
+    env:
+      CONVEX_URL: ${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}
+      PREPUBLICATION_CHECK_LIMIT: ${{ inputs['batch-limit'] || '2' }}
+      PREPUBLICATION_CHECK_MAX_JOBS: ${{ inputs['max-jobs'] || '' }}
+      PREPUBLICATION_CHECK_MAX_RUNTIME_MINUTES: ${{ inputs['max-runtime-minutes'] || '8' }}
+      CODEX_SECURITY_SCAN_TIMEOUT_MS: ${{ vars.CODEX_SECURITY_SCAN_TIMEOUT_MS || '240000' }}
+      PREPUBLICATION_TRUFFLEHOG_IMAGE: ${{ vars.PREPUBLICATION_TRUFFLEHOG_IMAGE || 'ghcr.io/trufflesecurity/trufflehog:3.95.6@sha256:96f8429082cb2d4ae73b1096dcdb2f5aa139881d97042b0c5e5fa226a392e056' }}
+      PREPUBLICATION_WORKER_ID: "github-actions:${{ github.run_id }}:${{ github.run_attempt }}:${{ matrix.shard }}"
+      SKILLSPECTOR_PROVIDER: openai
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-bun
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install Codex CLI
+        run: |
+          set -euo pipefail
+          if ! command -v codex >/dev/null 2>&1; then
+            npm install -g @openai/codex@0.142.3
+          fi
+          codex --version
+
+      - name: Install SkillSpector
+        run: |
+          set -euo pipefail
+          python -m venv "$RUNNER_TEMP/skillspector-venv"
+          source "$RUNNER_TEMP/skillspector-venv/bin/activate"
+          python -m pip install --upgrade pip
+          python -m pip install 'git+https://github.com/NVIDIA/skillspector.git@8f37cfa'
+          echo "$RUNNER_TEMP/skillspector-venv/bin" >> "$GITHUB_PATH"
+          skillspector --help >/dev/null
+
+      - name: Authenticate Codex CLI
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: printf '%s' "$OPENAI_API_KEY" | codex login --with-api-key
+
+      - name: Run pre-publication publish worker
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}
+        run: |
+          bun run publish:prepublication-worker -- \
+            --batch-limit "$PREPUBLICATION_CHECK_LIMIT" \
+            --max-jobs "$PREPUBLICATION_CHECK_MAX_JOBS" \
+            --max-runtime-minutes "$PREPUBLICATION_CHECK_MAX_RUNTIME_MINUTES"

--- a/convex/publishAttempts.test.ts
+++ b/convex/publishAttempts.test.ts
@@ -1,13 +1,195 @@
 import { describe, expect, it, vi } from "vitest";
-import { completePendingPublishAttemptChecksInternal } from "./publishAttempts";
+import {
+  claimPendingPublishAttemptChecksInternal,
+  claimPrePublicationChecks,
+  completePendingPublishAttemptChecksInternal,
+} from "./publishAttempts";
 
+const claimPendingChecksHandler = (
+  claimPendingPublishAttemptChecksInternal as unknown as {
+    _handler: (ctx: unknown, args: unknown) => Promise<unknown>;
+  }
+)._handler;
 const completePendingChecksHandler = (
   completePendingPublishAttemptChecksInternal as unknown as {
     _handler: (ctx: unknown, args: unknown) => Promise<unknown>;
   }
 )._handler;
+const claimPrePublicationChecksHandler = (
+  claimPrePublicationChecks as unknown as {
+    _handler: (ctx: unknown, args: unknown) => Promise<unknown>;
+  }
+)._handler;
 
 describe("publishAttempts", () => {
+  it("leases staged publish check claims long enough for scanner timeouts", async () => {
+    const attempt = {
+      _id: "publishAttempts:demo",
+      kind: "skill",
+      status: "pending_checks",
+      userId: "users:publisher",
+      slug: "demo-skill",
+      displayName: "Demo Skill",
+      version: "1.0.0",
+      artifactFingerprint: "fingerprint",
+      files: [{ path: "SKILL.md", storageId: "_storage:skill", size: 10, sha256: "sha" }],
+      skillInsertArgs: {
+        staticScan: { status: "clean" },
+      },
+      createdAt: Date.now(),
+    };
+    const ctx = {
+      db: {
+        delete: vi.fn(),
+        get: vi.fn(),
+        insert: vi.fn(),
+        normalizeId: vi.fn(),
+        patch: vi.fn(),
+        query: vi.fn(() => ({
+          withIndex: vi.fn(() => ({
+            order: vi.fn(() => ({
+              take: vi.fn(async () => [attempt]),
+            })),
+          })),
+        })),
+        replace: vi.fn(),
+        system: {},
+      },
+    };
+
+    await expect(
+      claimPendingChecksHandler(ctx, { claimId: "checks:claim" }),
+    ).resolves.toMatchObject({
+      attemptId: "publishAttempts:demo",
+      claimId: "checks:claim",
+    });
+
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "publishAttempts:demo",
+      expect.objectContaining({
+        checkClaimId: "checks:claim",
+        checkClaimedAt: expect.any(Number),
+        checkClaimExpiresAt: expect.any(Number),
+      }),
+    );
+    const patch = ctx.db.patch.mock.calls[0]?.[1] as {
+      checkClaimedAt: number;
+      checkClaimExpiresAt: number;
+    };
+    expect(patch.checkClaimExpiresAt - patch.checkClaimedAt).toBeGreaterThanOrEqual(30 * 60 * 1000);
+  });
+
+  it("hydrates staged package attempts with ClawPack URL and review context", async () => {
+    const previousToken = process.env.SECURITY_SCAN_WORKER_TOKEN;
+    process.env.SECURITY_SCAN_WORKER_TOKEN = "worker-token";
+    const ctx = {
+      runMutation: vi.fn(async () => ({
+        attemptId: "publishAttempts:demo-package",
+        claimId: "claim-1",
+        kind: "package",
+        userId: "users:publisher",
+        ownerUserId: "users:publisher",
+        slug: "@demo/plugin",
+        displayName: "Demo Plugin",
+        version: "1.0.0",
+        artifactFingerprint: "fingerprint",
+        files: [
+          {
+            path: "package.json",
+            size: 10,
+            storageId: "_storage:manifest",
+            sha256: "manifest-sha",
+          },
+        ],
+        clawpackStorageId: "_storage:clawpack",
+        scanContext: {
+          trustedOpenClawPlugin: true,
+          release: {
+            artifactKind: "npm-pack",
+            pluginManifestSummary: { bundledSkills: [{ rootPath: "skills/demo" }] },
+            staticScan: { status: "clean" },
+          },
+        },
+        checkClaimExpiresAt: Date.now() + 60_000,
+        createdAt: Date.now(),
+      })),
+      storage: {
+        getUrl: vi.fn(async (storageId: string) => `https://signed.example.invalid/${storageId}`),
+      },
+    };
+
+    try {
+      await expect(
+        claimPrePublicationChecksHandler(ctx, { token: "worker-token" }),
+      ).resolves.toMatchObject({
+        attemptId: "publishAttempts:demo-package",
+        files: [
+          expect.objectContaining({
+            path: "package.json",
+            url: "https://signed.example.invalid/_storage:manifest",
+          }),
+        ],
+        clawpackUrl: "https://signed.example.invalid/_storage:clawpack",
+        scanContext: {
+          trustedOpenClawPlugin: true,
+          release: {
+            artifactKind: "npm-pack",
+            pluginManifestSummary: { bundledSkills: [{ rootPath: "skills/demo" }] },
+          },
+        },
+      });
+    } finally {
+      if (previousToken === undefined) delete process.env.SECURITY_SCAN_WORKER_TOKEN;
+      else process.env.SECURITY_SCAN_WORKER_TOKEN = previousToken;
+    }
+
+    expect(ctx.storage.getUrl).toHaveBeenCalledWith("_storage:manifest");
+    expect(ctx.storage.getUrl).toHaveBeenCalledWith("_storage:clawpack");
+  });
+
+  it("claims ready-to-finalize attempts for idempotent finalization retry", async () => {
+    const previousToken = process.env.SECURITY_SCAN_WORKER_TOKEN;
+    process.env.SECURITY_SCAN_WORKER_TOKEN = "worker-token";
+    const ctx = {
+      runMutation: vi
+        .fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          attemptId: "publishAttempts:ready",
+          status: "ready_to_finalize",
+          claimId: "claim-1",
+          kind: "skill",
+          userId: "users:publisher",
+          slug: "demo-skill",
+          displayName: "Demo Skill",
+          version: "1.0.0",
+          artifactFingerprint: "fingerprint",
+          files: [],
+          checkClaimExpiresAt: Date.now() + 60_000,
+          createdAt: Date.now(),
+        }),
+      storage: {
+        getUrl: vi.fn(),
+      },
+    };
+
+    try {
+      await expect(
+        claimPrePublicationChecksHandler(ctx, { token: "worker-token" }),
+      ).resolves.toMatchObject({
+        attemptId: "publishAttempts:ready",
+        status: "ready_to_finalize",
+        files: [],
+      });
+    } finally {
+      if (previousToken === undefined) delete process.env.SECURITY_SCAN_WORKER_TOKEN;
+      else process.env.SECURITY_SCAN_WORKER_TOKEN = previousToken;
+    }
+
+    expect(ctx.runMutation).toHaveBeenCalledTimes(2);
+    expect(ctx.storage.getUrl).not.toHaveBeenCalled();
+  });
+
   it("lets worker completion retries reclaim expired finalization leases", async () => {
     const now = Date.now();
     const ctx = {

--- a/convex/publishAttempts.ts
+++ b/convex/publishAttempts.ts
@@ -6,7 +6,7 @@ import { action, internalAction, internalMutation, internalQuery } from "./funct
 import { finalizeSkillPublishAttempt } from "./lib/skillPublish";
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
-const CHECK_CLAIM_LEASE_MS = 10 * 60 * 1000;
+const CHECK_CLAIM_LEASE_MS = 30 * 60 * 1000;
 const FINALIZATION_CLAIM_LEASE_MS = 10 * 60 * 1000;
 
 const publishResultValidator = v.object({
@@ -26,6 +26,18 @@ const workerCheckResultValidator = v.object({
   summary: v.optional(v.string()),
   redactedFindings: v.optional(v.array(v.string())),
 });
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function withoutUndefined<T extends Record<string, unknown>>(value: T) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
+  ) as Partial<T>;
+}
 
 export const createSkillPublishAttemptInternal = internalMutation({
   args: {
@@ -180,6 +192,46 @@ function getSecretBlockedStorageIds(attempt: {
     }
   }
   return [...storageIds];
+}
+
+function buildSkillAttemptScanContext(attempt: { skillInsertArgs?: unknown }) {
+  const skillInsertArgs = asRecord(attempt.skillInsertArgs);
+  const parsed = asRecord(skillInsertArgs.parsed);
+  return withoutUndefined({
+    version: withoutUndefined({
+      staticScan: skillInsertArgs.staticScan,
+      parsed: withoutUndefined({
+        metadata: parsed.metadata,
+        clawdis: parsed.clawdis,
+        license: parsed.license,
+      }),
+      qualityAssessment: skillInsertArgs.qualityAssessment,
+      sourceProvenance: skillInsertArgs.sourceProvenance,
+    }),
+  });
+}
+
+function buildPackageAttemptScanContext(attempt: { packageInsertArgs?: unknown }) {
+  const packageInsertArgs = asRecord(attempt.packageInsertArgs);
+  const verification = asRecord(packageInsertArgs.verification);
+  return withoutUndefined({
+    trustedOpenClawPlugin: verification.trustedOpenClawPlugin === true ? true : undefined,
+    release: withoutUndefined({
+      staticScan: packageInsertArgs.staticScan,
+      pluginManifestSummary: packageInsertArgs.pluginManifestSummary,
+      verification: packageInsertArgs.verification,
+      artifactKind: packageInsertArgs.artifactKind,
+      npmIntegrity: packageInsertArgs.npmIntegrity,
+      npmShasum: packageInsertArgs.npmShasum,
+      npmTarballName: packageInsertArgs.npmTarballName,
+      source: packageInsertArgs.source,
+    }),
+  });
+}
+
+function publishAttemptClawpackStorageId(attempt: { packageInsertArgs?: unknown }) {
+  const clawpackStorageId = asRecord(attempt.packageInsertArgs).clawpackStorageId;
+  return typeof clawpackStorageId === "string" ? (clawpackStorageId as Id<"_storage">) : undefined;
 }
 
 export const recordSkillPublishAttemptChecksPassedInternal = internalMutation({
@@ -380,6 +432,7 @@ export const claimPendingPublishAttemptChecksInternal = internalMutation({
 
     return {
       attemptId: attempt._id,
+      status: attempt.status,
       claimId: args.claimId,
       kind: attempt.kind,
       userId: attempt.userId,
@@ -391,7 +444,76 @@ export const claimPendingPublishAttemptChecksInternal = internalMutation({
       version: attempt.version,
       artifactFingerprint: attempt.artifactFingerprint,
       files: attempt.files,
+      ...(attempt.kind === "skill"
+        ? {
+            scanContext: buildSkillAttemptScanContext(attempt),
+          }
+        : {
+            clawpackStorageId: publishAttemptClawpackStorageId(attempt),
+            scanContext: buildPackageAttemptScanContext(attempt),
+          }),
       checkClaimExpiresAt,
+      createdAt: attempt.createdAt,
+    };
+  },
+});
+
+export const claimReadyPublishAttemptFinalizationRetryInternal = internalMutation({
+  args: {
+    claimId: v.string(),
+    attemptId: v.optional(v.id("publishAttempts")),
+    kind: v.optional(v.union(v.literal("skill"), v.literal("package"))),
+    slug: v.optional(v.string()),
+    version: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const attempt = args.attemptId
+      ? await ctx.db.get(args.attemptId)
+      : (
+          await ctx.db
+            .query("publishAttempts")
+            .withIndex("by_status_and_created", (q) => q.eq("status", "ready_to_finalize"))
+            .order("asc")
+            .take(25)
+        ).find((candidate) => {
+          if (args.kind && candidate.kind !== args.kind) return false;
+          if (args.slug && candidate.slug !== args.slug) return false;
+          if (args.version && candidate.version !== args.version) return false;
+          return true;
+        });
+
+    if (!attempt) return null;
+    if (attempt.status !== "ready_to_finalize") {
+      if (args.attemptId) {
+        throw new ConvexError(`Publish attempt is ${attempt.status}, not ready to finalize.`);
+      }
+      return null;
+    }
+
+    await ctx.db.patch(attempt._id, {
+      checkClaimId: args.claimId,
+      checkClaimedAt: now,
+      checkClaimExpiresAt: now + CHECK_CLAIM_LEASE_MS,
+      checkClaimLastError: undefined,
+      updatedAt: now,
+    });
+
+    return {
+      attemptId: attempt._id,
+      status: attempt.status,
+      claimId: args.claimId,
+      kind: attempt.kind,
+      userId: attempt.userId,
+      ownerUserId: attempt.ownerUserId,
+      ownerPublisherId: attempt.ownerPublisherId,
+      sourceOwnerPublisherId: attempt.sourceOwnerPublisherId,
+      slug: attempt.slug,
+      displayName: attempt.displayName,
+      version: attempt.version,
+      artifactFingerprint: attempt.artifactFingerprint,
+      files: [],
+      checkClaimExpiresAt: now + CHECK_CLAIM_LEASE_MS,
       createdAt: attempt.createdAt,
     };
   },
@@ -674,17 +796,23 @@ export const claimPrePublicationChecks: ReturnType<typeof action> = action({
   handler: async (ctx, args): Promise<unknown> => {
     assertWorkerToken(args.token);
     const claimId = buildCheckClaimId();
-    const claimed = (await ctx.runMutation(
+    const claimArgs = {
+      claimId,
+      attemptId: args.attemptId,
+      kind: args.kind,
+      slug: args.slug,
+      version: args.version,
+    };
+    const claimed = ((await ctx.runMutation(
       internal.publishAttempts.claimPendingPublishAttemptChecksInternal,
-      {
-        claimId,
-        attemptId: args.attemptId,
-        kind: args.kind,
-        slug: args.slug,
-        version: args.version,
-      },
-    )) as null | {
+      claimArgs,
+    )) ??
+      (await ctx.runMutation(
+        internal.publishAttempts.claimReadyPublishAttemptFinalizationRetryInternal,
+        claimArgs,
+      ))) as null | {
       attemptId: Id<"publishAttempts">;
+      status: "pending_checks" | "ready_to_finalize";
       claimId: string;
       kind: "skill" | "package";
       userId: Id<"users">;
@@ -702,6 +830,8 @@ export const claimPrePublicationChecks: ReturnType<typeof action> = action({
         sha256: string;
         contentType?: string;
       }>;
+      clawpackStorageId?: Id<"_storage">;
+      scanContext?: Record<string, unknown>;
       checkClaimExpiresAt: number;
       createdAt: number;
     };
@@ -713,7 +843,15 @@ export const claimPrePublicationChecks: ReturnType<typeof action> = action({
         url: await ctx.storage.getUrl(file.storageId),
       })),
     );
-    return { ...claimed, files };
+    const clawpackUrl = claimed.clawpackStorageId
+      ? await ctx.storage.getUrl(claimed.clawpackStorageId)
+      : undefined;
+    return withoutUndefined({
+      ...claimed,
+      files,
+      clawpackStorageId: undefined,
+      clawpackUrl,
+    });
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "preview": "bun --bun vite preview",
     "proof:publish": "node scripts/ui-proof-publish.mjs",
     "proof:ui": "node scripts/ui-proof.mjs",
+    "publish:prepublication-worker": "bun scripts/security/run-prepublication-worker.ts",
     "release:clawhub:cli:changelog": "node scripts/extract-changelog-release.mjs",
     "release:clawhub:cli:npm:check": "node scripts/clawhub-cli-npm-release-check.mjs",
     "security:codex-worker": "bun scripts/security/run-codex-scan-worker.ts",

--- a/scripts/security/prepublication-worker-workflow.test.ts
+++ b/scripts/security/prepublication-worker-workflow.test.ts
@@ -1,0 +1,80 @@
+/* @vitest-environment node */
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+
+type WorkflowStep = {
+  env?: Record<string, unknown>;
+  if?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+};
+
+function stepUsesSecret(step: WorkflowStep, secretName: string) {
+  return (
+    Object.hasOwn(step.env ?? {}, secretName) ||
+    JSON.stringify(step).includes(`secrets.${secretName}`)
+  );
+}
+
+describe("pre-publication publish worker workflow", () => {
+  it("runs the missing staged-publish worker on a schedule with scoped secrets", async () => {
+    const workflow = parseYaml(
+      await readFile(".github/workflows/prepublication-publish-checks.yml", "utf8"),
+    ) as {
+      jobs: {
+        "prepublication-publish-checks": {
+          concurrency?: unknown;
+          env?: Record<string, unknown>;
+          environment?: string;
+          steps: WorkflowStep[];
+          strategy?: { matrix?: { shard?: number[] }; "max-parallel"?: number };
+          "timeout-minutes"?: number;
+        };
+      };
+      on?: { schedule?: Array<{ cron?: string }>; workflow_dispatch?: unknown };
+    };
+
+    const job = workflow.jobs["prepublication-publish-checks"];
+    const steps = job.steps;
+    expect(workflow.on?.schedule?.[0]?.cron).toBe("*/5 * * * *");
+    expect(workflow.on?.workflow_dispatch).toBeDefined();
+    expect(job.environment).toBe("Production");
+    expect(job["timeout-minutes"]).toBe(20);
+    expect(job.strategy?.matrix?.shard).toEqual([0, 1]);
+    expect(job.strategy?.["max-parallel"]).toBe(2);
+    expect(job.env).toMatchObject({
+      CODEX_SECURITY_SCAN_TIMEOUT_MS: "${{ vars.CODEX_SECURITY_SCAN_TIMEOUT_MS || '240000' }}",
+      CONVEX_URL:
+        "${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}",
+      PREPUBLICATION_CHECK_LIMIT: "${{ inputs['batch-limit'] || '2' }}",
+      PREPUBLICATION_TRUFFLEHOG_IMAGE:
+        "${{ vars.PREPUBLICATION_TRUFFLEHOG_IMAGE || 'ghcr.io/trufflesecurity/trufflehog:3.95.6@sha256:96f8429082cb2d4ae73b1096dcdb2f5aa139881d97042b0c5e5fa226a392e056' }}",
+    });
+    expect(String(job.env?.PREPUBLICATION_TRUFFLEHOG_IMAGE)).toContain("@sha256:");
+    expect(job.env).not.toHaveProperty("OPENAI_API_KEY");
+    expect(job.env).not.toHaveProperty("SECURITY_SCAN_WORKER_TOKEN");
+
+    const runStep = steps.find((step) => step.name === "Run pre-publication publish worker");
+    expect(runStep?.run).toContain("bun run publish:prepublication-worker");
+    expect(steps.find((step) => step.name === "Install ClawScan CLI")).toBeUndefined();
+    expect(JSON.stringify(job)).not.toContain("CODEX_SECURITY_SCAN_SHADOW_CLAWSCAN");
+    expect(JSON.stringify(job)).not.toContain("clawscan --version");
+    expect(runStep?.env).toEqual({
+      OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}",
+      SECURITY_SCAN_WORKER_TOKEN: "${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}",
+    });
+
+    for (const step of steps) {
+      const stepName = step.name ?? step.uses ?? "<unnamed>";
+      expect(stepUsesSecret(step, "SECURITY_SCAN_WORKER_TOKEN"), stepName).toBe(
+        stepName === "Run pre-publication publish worker",
+      );
+      expect(stepUsesSecret(step, "OPENAI_API_KEY"), stepName).toBe(
+        stepName === "Authenticate Codex CLI" || stepName === "Run pre-publication publish worker",
+      );
+    }
+  });
+});

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -23,7 +23,7 @@ import {
   safeWorkerArtifactPathLabel,
 } from "../lib/workerRedaction";
 
-type ClaimedJob = {
+export type ClaimedJob = {
   job: {
     _id: string;
     leaseToken: string;
@@ -45,7 +45,7 @@ type ClaimedJob = {
   };
 };
 
-type StoredLlmAnalysis = {
+export type StoredLlmAnalysis = {
   status: string;
   verdict?: string;
   confidence?: string;
@@ -72,7 +72,7 @@ type SkillSpectorIssue = {
   codeSnippet?: string;
 };
 
-type SkillSpectorAnalysis = {
+export type SkillSpectorAnalysis = {
   status: string;
   score?: number;
   severity?: string;
@@ -731,7 +731,7 @@ function aggregateSkillSpectorAnalyses(analyses: SkillSpectorAnalysis[]) {
   } satisfies SkillSpectorAnalysis;
 }
 
-async function runSkillSpector(
+export async function runSkillSpector(
   workspace: string,
   scanInputs: string[],
   onDiagnostic: (diagnostic: Partial<CodexCommandDiagnostic>) => void,
@@ -1219,7 +1219,7 @@ export function shouldClaimSecurityScanBatch(
   return totalClaimed === 0 || remainingRuntimeMs >= minClaimWindowMs;
 }
 
-async function runCodex(
+export async function runCodex(
   job: ClaimedJob,
   workspace: string,
   skillSpectorAnalysis: SkillSpectorAnalysis | undefined,

--- a/scripts/security/run-prepublication-worker.test.ts
+++ b/scripts/security/run-prepublication-worker.test.ts
@@ -1,0 +1,332 @@
+/* @vitest-environment node */
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Id } from "../../convex/_generated/dataModel";
+import {
+  configurePrePublicationCodexHome,
+  processPrePublicationAttempt,
+  resolveTruffleHogImage,
+  runNativeTruffleHog,
+} from "./run-prepublication-worker";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })));
+});
+
+async function tempDir() {
+  const dir = await mkdtemp(join(tmpdir(), "clawhub-prepublication-worker-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+const attempt = {
+  attemptId: "publishAttempts:test" as Id<"publishAttempts">,
+  claimId: "claim-test",
+  kind: "skill" as const,
+  slug: "demo-skill",
+  displayName: "Demo Skill",
+  version: "1.2.3",
+  artifactFingerprint: "f".repeat(64),
+  checkClaimExpiresAt: Date.now() + 60_000,
+  createdAt: Date.now(),
+  files: [
+    {
+      path: "SKILL.md",
+      size: 12,
+      sha256: "a".repeat(64),
+      url: "https://signed.example.invalid/skill-md?token=secret",
+      contentType: "text/markdown",
+    },
+  ],
+};
+
+describe("pre-publication worker", () => {
+  it("does not clear the Codex home configured by GitHub Actions login", () => {
+    const env = {
+      CI: "true",
+      GITHUB_ACTIONS: "true",
+      GITHUB_REPOSITORY: "openclaw/clawhub",
+      GITHUB_RUN_ID: "123",
+    } as NodeJS.ProcessEnv;
+
+    expect(configurePrePublicationCodexHome(env)).toBeUndefined();
+    expect(env).not.toHaveProperty("CODEX_HOME");
+  });
+
+  it("requires the TruffleHog image to be pinned by digest", () => {
+    expect(resolveTruffleHogImage()).toContain("@sha256:");
+    expect(() => resolveTruffleHogImage("ghcr.io/trufflesecurity/trufflehog:3.95.6")).toThrow(
+      "must be pinned",
+    );
+  });
+
+  it("completes clean staged publishes after TruffleHog and ClawHub review pass", async () => {
+    const client = {
+      action: vi.fn().mockResolvedValue({ status: "finalized" }),
+    };
+    const runTruffleHog = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      status: "clean",
+      summary: "TruffleHog found no verified secrets.",
+    });
+    const runClawHubReview = vi.fn().mockResolvedValue({
+      llmAnalysis: {
+        checkedAt: 123,
+        confidence: "high",
+        status: "clean",
+        summary: "ClawHub security review passed.",
+        verdict: "benign",
+      },
+    });
+
+    await expect(
+      processPrePublicationAttempt(client, "worker-token", attempt, {
+        runClawHubReview,
+        runTruffleHog,
+        writeWorkspace: vi.fn().mockResolvedValue(undefined),
+      }),
+    ).resolves.toMatchObject({ completed: true });
+
+    expect(runTruffleHog).toHaveBeenCalledTimes(1);
+    expect(runClawHubReview).toHaveBeenCalledTimes(1);
+    expect(client.action).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        artifactFingerprint: attempt.artifactFingerprint,
+        attemptId: attempt.attemptId,
+        claimId: attempt.claimId,
+        token: "worker-token",
+        trufflehog: { status: "clean", summary: "TruffleHog found no verified secrets." },
+        clawscan: expect.objectContaining({ status: "clean" }),
+      }),
+    );
+    expect(client.action.mock.calls[0]?.[1].trufflehog).not.toHaveProperty("exitCode");
+  });
+
+  it("blocks secret-positive attempts without running ClawHub review", async () => {
+    const client = {
+      action: vi.fn().mockResolvedValue({ status: "blocked" }),
+    };
+    const runTruffleHog = vi.fn().mockResolvedValue({
+      status: "blocked",
+      summary: "TruffleHog found verified secret material.",
+      redactedFindings: ["GitHub token in filesystem"],
+    });
+    const runClawHubReview = vi.fn();
+
+    await expect(
+      processPrePublicationAttempt(client, "worker-token", attempt, {
+        runClawHubReview,
+        runTruffleHog,
+        writeWorkspace: vi.fn().mockResolvedValue(undefined),
+      }),
+    ).resolves.toMatchObject({ completed: true });
+
+    expect(runClawHubReview).not.toHaveBeenCalled();
+    expect(client.action).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        trufflehog: expect.objectContaining({
+          redactedFindings: ["GitHub token in filesystem"],
+          status: "blocked",
+        }),
+        clawscan: expect.objectContaining({
+          status: "failed",
+          summary: expect.stringContaining("skipped"),
+        }),
+      }),
+    );
+  });
+
+  it("does not downgrade TruffleHog-positive attempts when blocked cleanup completion fails", async () => {
+    const client = {
+      action: vi.fn().mockRejectedValue(new Error("storage unavailable")),
+    };
+    const runTruffleHog = vi.fn().mockResolvedValue({
+      status: "blocked",
+      summary: "TruffleHog found verified secret material.",
+      redactedFindings: ["GitHub token in filesystem"],
+    });
+
+    await expect(
+      processPrePublicationAttempt(client, "worker-token", attempt, {
+        runClawHubReview: vi.fn(),
+        runTruffleHog,
+        writeWorkspace: vi.fn().mockResolvedValue(undefined),
+      }),
+    ).resolves.toMatchObject({ completed: false, result: undefined });
+
+    expect(client.action).toHaveBeenCalledTimes(1);
+    expect(client.action).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        trufflehog: expect.objectContaining({ status: "blocked" }),
+        clawscan: expect.objectContaining({
+          status: "failed",
+          summary: expect.stringContaining("skipped"),
+        }),
+      }),
+    );
+  });
+
+  it("retries ready-to-finalize attempts without rerunning scanners", async () => {
+    const client = {
+      action: vi.fn().mockResolvedValue({ status: "finalized" }),
+    };
+    const runClawHubReview = vi.fn();
+    const runTruffleHog = vi.fn();
+    const writeWorkspace = vi.fn();
+
+    await expect(
+      processPrePublicationAttempt(
+        client,
+        "worker-token",
+        { ...attempt, status: "ready_to_finalize", files: [] },
+        {
+          runClawHubReview,
+          runTruffleHog,
+          writeWorkspace,
+        },
+      ),
+    ).resolves.toMatchObject({ completed: true });
+
+    expect(writeWorkspace).not.toHaveBeenCalled();
+    expect(runTruffleHog).not.toHaveBeenCalled();
+    expect(runClawHubReview).not.toHaveBeenCalled();
+    expect(client.action).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        attemptId: attempt.attemptId,
+        trufflehog: expect.objectContaining({ status: "clean" }),
+        clawscan: expect.objectContaining({ status: "clean" }),
+      }),
+    );
+  });
+
+  it("passes package ClawPack and manifest context into the ClawHub review job", async () => {
+    const packageAttempt = {
+      ...attempt,
+      kind: "package" as const,
+      slug: "demo-plugin",
+      displayName: "Demo Plugin",
+      artifactFingerprint: "b".repeat(64),
+      clawpackUrl: "https://signed.example.invalid/package.tgz?token=secret",
+      scanContext: {
+        trustedOpenClawPlugin: true,
+        release: {
+          artifactKind: "npm-pack",
+          pluginManifestSummary: {
+            bundledSkills: [{ rootPath: "skills/demo" }],
+          },
+          staticScan: { status: "clean" },
+        },
+      },
+    };
+    const client = {
+      action: vi.fn().mockResolvedValue({ status: "finalized" }),
+    };
+    const writeWorkspace = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      processPrePublicationAttempt(client, "worker-token", packageAttempt, {
+        runClawHubReview: vi.fn().mockResolvedValue({
+          llmAnalysis: {
+            checkedAt: 123,
+            confidence: "high",
+            status: "clean",
+            summary: "ClawHub security review passed.",
+            verdict: "benign",
+          },
+        }),
+        runTruffleHog: vi.fn().mockResolvedValue({
+          status: "clean",
+          summary: "TruffleHog found no verified secrets.",
+        }),
+        writeWorkspace,
+      }),
+    ).resolves.toMatchObject({ completed: true });
+
+    expect(writeWorkspace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        job: expect.objectContaining({ targetKind: "packageRelease" }),
+        target: expect.objectContaining({
+          clawpackUrl: packageAttempt.clawpackUrl,
+          trustedOpenClawPlugin: true,
+          release: expect.objectContaining({
+            artifactKind: "npm-pack",
+            integritySha256: packageAttempt.artifactFingerprint,
+            pluginManifestSummary: packageAttempt.scanContext.release.pluginManifestSummary,
+          }),
+        }),
+      }),
+      expect.any(String),
+    );
+  });
+
+  it("marks attempts failed when staged artifact URLs are unavailable", async () => {
+    const client = {
+      action: vi.fn().mockResolvedValue({ status: "failed" }),
+    };
+
+    await expect(
+      processPrePublicationAttempt(
+        client,
+        "worker-token",
+        {
+          ...attempt,
+          files: [{ ...attempt.files[0], url: null }],
+        },
+        {
+          runClawHubReview: vi.fn(),
+          runTruffleHog: vi.fn(),
+          writeWorkspace: vi.fn().mockResolvedValue(undefined),
+        },
+      ),
+    ).resolves.toMatchObject({ completed: false });
+
+    expect(client.action).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        trufflehog: expect.objectContaining({
+          status: "failed",
+          summary: expect.stringContaining("Artifact file unavailable"),
+        }),
+        clawscan: expect.objectContaining({
+          status: "failed",
+          summary: expect.stringContaining("Artifact file unavailable"),
+        }),
+      }),
+    );
+  });
+
+  it("maps TruffleHog verified-secret exit code to a blocked result", async () => {
+    const workspace = await tempDir();
+    await mkdir(join(workspace, "artifact"), { recursive: true });
+    const fakeTruffleHog = join(workspace, "fake-trufflehog");
+    await writeFile(
+      fakeTruffleHog,
+      `#!/usr/bin/env bash
+cat <<'JSON'
+{"DetectorName":"GitHub","SourceName":"Filesystem"}
+JSON
+exit 183
+`,
+    );
+    await chmod(fakeTruffleHog, 0o755);
+    const previousCommand = process.env.PREPUBLICATION_TRUFFLEHOG_COMMAND;
+    process.env.PREPUBLICATION_TRUFFLEHOG_COMMAND = fakeTruffleHog;
+
+    await expect(runNativeTruffleHog(workspace)).resolves.toMatchObject({
+      redactedFindings: ["GitHub in Filesystem"],
+      status: "blocked",
+    });
+
+    if (previousCommand === undefined) delete process.env.PREPUBLICATION_TRUFFLEHOG_COMMAND;
+    else process.env.PREPUBLICATION_TRUFFLEHOG_COMMAND = previousCommand;
+  });
+});

--- a/scripts/security/run-prepublication-worker.ts
+++ b/scripts/security/run-prepublication-worker.ts
@@ -1,0 +1,602 @@
+import { spawn } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { ConvexHttpClient } from "convex/browser";
+import { api } from "../../convex/_generated/api";
+import type { Id } from "../../convex/_generated/dataModel";
+import { assertCodexWorkerExecutionAllowed, resolveCodexWorkerHome } from "../codex-worker-guard";
+import { createWorkerLogger } from "../lib/workerLogger";
+import {
+  maskKnownWorkerSecrets,
+  redactWorkerPublicErrorMessage,
+  redactWorkerPublicText,
+} from "../lib/workerRedaction";
+import {
+  runCodex,
+  runSkillSpector,
+  resolveSkillSpectorScanInputs,
+  type ClaimedJob,
+  type SkillSpectorAnalysis,
+  type StoredLlmAnalysis,
+  writeArtifactWorkspace,
+} from "./run-codex-scan-worker";
+
+type ClaimedPrePublicationAttempt = {
+  attemptId: Id<"publishAttempts">;
+  status?: "pending_checks" | "ready_to_finalize";
+  claimId: string;
+  kind: "skill" | "package";
+  slug: string;
+  displayName: string;
+  version: string;
+  artifactFingerprint: string;
+  files: Array<{
+    path: string;
+    size: number;
+    sha256: string;
+    url: string | null;
+    contentType?: string;
+  }>;
+  clawpackUrl?: string | null;
+  scanContext?: {
+    trustedOpenClawPlugin?: boolean;
+    skill?: Record<string, unknown>;
+    version?: Record<string, unknown>;
+    package?: Record<string, unknown>;
+    release?: Record<string, unknown>;
+  };
+  checkClaimExpiresAt: number;
+  createdAt: number;
+};
+
+type WorkerCheckResult = {
+  status: "clean" | "blocked" | "failed";
+  summary?: string;
+  redactedFindings?: string[];
+};
+
+type PrePublicationWorkerClient = Pick<ConvexHttpClient, "action">;
+
+type TruffleHogResult = WorkerCheckResult & {
+  exitCode?: number | null;
+};
+
+type ProcessAttemptDeps = {
+  runClawHubReview?: (
+    job: ClaimedJob,
+    workspace: string,
+  ) => Promise<{ llmAnalysis: StoredLlmAnalysis; skillSpectorAnalysis?: SkillSpectorAnalysis }>;
+  runTruffleHog?: (workspace: string) => Promise<TruffleHogResult>;
+  writeWorkspace?: (job: ClaimedJob, workspace: string) => Promise<void>;
+};
+
+const DEFAULT_BATCH_LIMIT = 2;
+const DEFAULT_MAX_RUNTIME_MS = 8 * 60 * 1000;
+const CLAIM_WINDOW_SHUTDOWN_BUFFER_MS = 90_000;
+const DEFAULT_TRUFFLEHOG_IMAGE =
+  "ghcr.io/trufflesecurity/trufflehog:3.95.6@sha256:96f8429082cb2d4ae73b1096dcdb2f5aa139881d97042b0c5e5fa226a392e056";
+const TRUFFLEHOG_SECRET_EXIT_CODE = 183;
+const MAX_TRUFFLEHOG_FINDINGS = 10;
+const MAX_PUBLIC_SUMMARY_CHARS = 600;
+const LOCAL_CODEX_HOME = join(rootDir(), ".codex/runtime/codex-workers/prepublication");
+const logger = createWorkerLogger({ name: "prepublication-worker" });
+
+function rootDir() {
+  return resolve(new URL("../..", import.meta.url).pathname);
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const get = (name: string) => {
+    const index = args.indexOf(name);
+    return index === -1 ? undefined : args[index + 1];
+  };
+  const numberFrom = (value: string | undefined, fallback: number) => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  };
+  const optionalNumberFrom = (value: string | undefined) => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+  };
+  return {
+    batchLimit: numberFrom(
+      get("--batch-limit") ?? process.env.PREPUBLICATION_CHECK_LIMIT,
+      DEFAULT_BATCH_LIMIT,
+    ),
+    maxJobs: optionalNumberFrom(get("--max-jobs") ?? process.env.PREPUBLICATION_CHECK_MAX_JOBS),
+    maxRuntimeMs:
+      numberFrom(
+        get("--max-runtime-minutes") ?? process.env.PREPUBLICATION_CHECK_MAX_RUNTIME_MINUTES,
+        DEFAULT_MAX_RUNTIME_MS / 60_000,
+      ) * 60_000,
+  };
+}
+
+function requireEnv(name: string) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function publicText(value: string, maxChars = MAX_PUBLIC_SUMMARY_CHARS) {
+  return redactWorkerPublicErrorMessage(redactWorkerPublicText(value, maxChars));
+}
+
+function buildSyntheticScanJob(attempt: ClaimedPrePublicationAttempt): ClaimedJob {
+  const targetKind = attempt.kind === "skill" ? "skillVersion" : "packageRelease";
+  if (attempt.kind === "package" && attempt.clawpackUrl === null) {
+    throw new Error("ClawPack artifact unavailable");
+  }
+  return {
+    job: {
+      _id: String(attempt.attemptId),
+      leaseToken: attempt.claimId,
+      targetKind,
+      source: "pre-publication",
+      hasMaliciousSignal: false,
+      waitForVtUntil: 0,
+      attempts: 1,
+    },
+    target: {
+      ...(attempt.scanContext?.trustedOpenClawPlugin
+        ? { trustedOpenClawPlugin: attempt.scanContext.trustedOpenClawPlugin }
+        : {}),
+      files: attempt.files.map((file) => {
+        if (!file.url) throw new Error(`Artifact file unavailable: ${file.path}`);
+        return {
+          path: file.path,
+          size: file.size,
+          sha256: file.sha256,
+          contentType: file.contentType,
+          url: file.url,
+        };
+      }),
+      ...(attempt.kind === "skill"
+        ? {
+            skill: {
+              ...attempt.scanContext?.skill,
+              slug: attempt.slug,
+              displayName: attempt.displayName,
+            },
+            version: {
+              ...attempt.scanContext?.version,
+              version: attempt.version,
+              sha256hash: attempt.artifactFingerprint,
+            },
+          }
+        : {
+            package: {
+              ...attempt.scanContext?.package,
+              name: attempt.slug,
+              displayName: attempt.displayName,
+            },
+            release: {
+              ...attempt.scanContext?.release,
+              version: attempt.version,
+              integritySha256: attempt.artifactFingerprint,
+            },
+            clawpackUrl: attempt.clawpackUrl,
+          }),
+    },
+  };
+}
+
+function truffleHogTimeoutMs() {
+  const parsed = Number(process.env.PREPUBLICATION_TRUFFLEHOG_TIMEOUT_MS);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 180_000;
+}
+
+function truffleHogCommand() {
+  return process.env.PREPUBLICATION_TRUFFLEHOG_COMMAND?.trim() || "";
+}
+
+export function resolveTruffleHogImage(image = process.env.PREPUBLICATION_TRUFFLEHOG_IMAGE) {
+  const resolved = image?.trim() || DEFAULT_TRUFFLEHOG_IMAGE;
+  if (!resolved.includes("@sha256:")) {
+    throw new Error("PREPUBLICATION_TRUFFLEHOG_IMAGE must be pinned by sha256 digest");
+  }
+  return resolved;
+}
+
+function parseTruffleHogFindings(stdout: string) {
+  const findings: string[] = [];
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+      const detector =
+        typeof parsed.DetectorName === "string"
+          ? parsed.DetectorName
+          : typeof parsed.detectorName === "string"
+            ? parsed.detectorName
+            : "verified secret";
+      const source =
+        typeof parsed.SourceName === "string"
+          ? parsed.SourceName
+          : typeof parsed.sourceName === "string"
+            ? parsed.sourceName
+            : "artifact";
+      findings.push(publicText(`${detector} in ${source}`, 160));
+    } catch {
+      // TruffleHog can write human text on some paths. Keep only a redacted, bounded summary.
+      findings.push(publicText(trimmed, 160));
+    }
+    if (findings.length >= MAX_TRUFFLEHOG_FINDINGS) break;
+  }
+  return findings;
+}
+
+async function runCommand(
+  command: string,
+  args: string[],
+  options: { cwd: string; timeoutMs: number },
+) {
+  return await new Promise<{ code: number | null; stdout: string; stderr: string }>(
+    (resolvePromise, reject) => {
+      const child = spawn(command, args, {
+        cwd: options.cwd,
+        env: {
+          ...process.env,
+          NO_COLOR: "1",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let stdout = "";
+      let stderr = "";
+      let timedOut = false;
+      const timeout = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGTERM");
+        setTimeout(() => child.kill("SIGKILL"), 10_000).unref();
+      }, options.timeoutMs);
+      child.stdout.on("data", (chunk) => {
+        stdout += String(chunk);
+      });
+      child.stderr.on("data", (chunk) => {
+        stderr += String(chunk);
+      });
+      child.on("error", (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      });
+      child.on("close", (code) => {
+        clearTimeout(timeout);
+        if (timedOut) {
+          reject(new Error(`${command} timed out`));
+          return;
+        }
+        resolvePromise({ code, stdout, stderr });
+      });
+    },
+  );
+}
+
+export async function runNativeTruffleHog(workspace: string): Promise<TruffleHogResult> {
+  const artifactDir = join(workspace, "artifact");
+  const explicitCommand = truffleHogCommand();
+  const command = explicitCommand || "docker";
+  const args = explicitCommand
+    ? ["filesystem", artifactDir, "--only-verified", "--fail", "--json", "--no-update"]
+    : [
+        "run",
+        "--rm",
+        "-v",
+        `${artifactDir}:/scan:ro`,
+        resolveTruffleHogImage(),
+        "filesystem",
+        "/scan",
+        "--only-verified",
+        "--fail",
+        "--json",
+        "--no-update",
+      ];
+
+  const output = await runCommand(command, args, {
+    cwd: workspace,
+    timeoutMs: truffleHogTimeoutMs(),
+  });
+  if (output.code === 0) {
+    return {
+      status: "clean",
+      summary: "TruffleHog found no verified secrets in the staged publish artifact.",
+      exitCode: output.code,
+    };
+  }
+  if (output.code === TRUFFLEHOG_SECRET_EXIT_CODE) {
+    const findings = parseTruffleHogFindings(output.stdout);
+    return {
+      status: "blocked",
+      summary:
+        findings.length > 0
+          ? `TruffleHog found verified secret material: ${findings.join("; ")}.`
+          : "TruffleHog found verified secret material in the staged publish artifact.",
+      redactedFindings: findings.length > 0 ? findings : undefined,
+      exitCode: output.code,
+    };
+  }
+  return {
+    status: "failed",
+    summary: publicText(`TruffleHog failed before returning a verdict: ${output.stderr}`),
+    exitCode: output.code,
+  };
+}
+
+export async function runNormalClawHubReview(job: ClaimedJob, workspace: string) {
+  const skillSpectorAnalysis = await runSkillSpectorIfApplicable(job, workspace);
+  const llmAnalysis = await runCodex(job, workspace, skillSpectorAnalysis, () => {});
+  return { llmAnalysis, skillSpectorAnalysis };
+}
+
+async function runSkillSpectorIfApplicable(job: ClaimedJob, workspace: string) {
+  const inputs = await resolveSkillSpectorScanInputs(workspace, job);
+  if (inputs.length === 0) return undefined;
+  return await runSkillSpector(workspace, inputs, () => {});
+}
+
+function clawHubReviewCheckResult(llmAnalysis: StoredLlmAnalysis): WorkerCheckResult {
+  const status = (llmAnalysis.status || llmAnalysis.verdict || "").trim().toLowerCase();
+  const verdict = (llmAnalysis.verdict || "").trim().toLowerCase();
+  const isClean = status === "clean" || verdict === "benign";
+  const summary = publicText(
+    llmAnalysis.summary ??
+      llmAnalysis.findings ??
+      `ClawHub security review returned ${llmAnalysis.status}.`,
+  );
+  if (isClean) {
+    return {
+      status: "clean",
+      summary: summary || "ClawHub security review passed.",
+    };
+  }
+  return {
+    status: "blocked",
+    summary:
+      summary ||
+      `ClawHub security review blocked the staged publish with status ${llmAnalysis.status}.`,
+    redactedFindings: [publicText(`status=${llmAnalysis.status}; verdict=${llmAnalysis.verdict}`)],
+  };
+}
+
+function checkResultForConvex(result: WorkerCheckResult): WorkerCheckResult {
+  return {
+    status: result.status,
+    ...(result.summary ? { summary: result.summary } : {}),
+    ...(result.redactedFindings ? { redactedFindings: result.redactedFindings } : {}),
+  };
+}
+
+async function completeAttempt(
+  client: PrePublicationWorkerClient,
+  token: string,
+  attempt: ClaimedPrePublicationAttempt,
+  trufflehog: WorkerCheckResult,
+  clawscan: WorkerCheckResult,
+) {
+  return await client.action(api.publishAttempts.completePrePublicationChecks, {
+    token,
+    attemptId: attempt.attemptId,
+    claimId: attempt.claimId,
+    artifactFingerprint: attempt.artifactFingerprint,
+    trufflehog: checkResultForConvex(trufflehog),
+    clawscan: checkResultForConvex(clawscan),
+  });
+}
+
+export async function processPrePublicationAttempt(
+  client: PrePublicationWorkerClient,
+  token: string,
+  attempt: ClaimedPrePublicationAttempt,
+  deps: ProcessAttemptDeps = {},
+) {
+  if (attempt.status === "ready_to_finalize") {
+    try {
+      const result = await completeAttempt(
+        client,
+        token,
+        attempt,
+        {
+          status: "clean",
+          summary: "Pre-publication TruffleHog check already passed.",
+        },
+        {
+          status: "clean",
+          summary: "Pre-publication ClawHub security review already passed.",
+        },
+      );
+      logger.info(
+        {
+          attemptId: attempt.attemptId,
+          event: "prepublication_attempt_finalization_retried",
+          kind: attempt.kind,
+        },
+        "pre-publication attempt finalization retried",
+      );
+      return { completed: (result as { status?: string })?.status === "finalized", result };
+    } catch {
+      logger.warn(
+        {
+          attemptId: attempt.attemptId,
+          event: "prepublication_attempt_finalization_retry_failed",
+          kind: attempt.kind,
+        },
+        "pre-publication attempt finalization retry failed",
+      );
+      return { completed: false, result: undefined };
+    }
+  }
+
+  const workspace = await mkdtemp(
+    join(tmpdir(), `clawhub-prepublication-${basename(String(attempt.attemptId))}-`),
+  );
+  const startedAt = Date.now();
+  const writeWorkspace = deps.writeWorkspace ?? writeArtifactWorkspace;
+  const runTruffleHog = deps.runTruffleHog ?? runNativeTruffleHog;
+  const runClawHubReview = deps.runClawHubReview ?? runNormalClawHubReview;
+  let truffleHogBlocked = false;
+  try {
+    const job = buildSyntheticScanJob(attempt);
+    await writeWorkspace(job, workspace);
+    const trufflehog = await runTruffleHog(workspace);
+    if (trufflehog.status === "blocked") {
+      truffleHogBlocked = true;
+      const result = await completeAttempt(client, token, attempt, trufflehog, {
+        status: "failed",
+        summary: "ClawHub security review skipped because TruffleHog blocked the artifact.",
+      });
+      logger.info(
+        {
+          attemptId: attempt.attemptId,
+          durationMs: Date.now() - startedAt,
+          event: "prepublication_attempt_blocked",
+          kind: attempt.kind,
+          scanner: "trufflehog",
+        },
+        "pre-publication attempt blocked by TruffleHog",
+      );
+      return { completed: true, result };
+    }
+    if (trufflehog.status === "failed") {
+      const result = await completeAttempt(client, token, attempt, trufflehog, {
+        status: "failed",
+        summary: "ClawHub security review skipped because TruffleHog failed.",
+      });
+      return { completed: false, result };
+    }
+
+    let clawscan: WorkerCheckResult;
+    try {
+      const review = await runClawHubReview(job, workspace);
+      clawscan = clawHubReviewCheckResult(review.llmAnalysis);
+    } catch (error) {
+      clawscan = {
+        status: "failed",
+        summary: publicText(error instanceof Error ? error.message : String(error)),
+      };
+    }
+
+    const result = await completeAttempt(client, token, attempt, trufflehog, clawscan);
+    logger.info(
+      {
+        attemptId: attempt.attemptId,
+        clawscanStatus: clawscan.status,
+        durationMs: Date.now() - startedAt,
+        event: "prepublication_attempt_completed",
+        kind: attempt.kind,
+        trufflehogStatus: trufflehog.status,
+      },
+      "pre-publication attempt completed",
+    );
+    return { completed: trufflehog.status === "clean" && clawscan.status === "clean", result };
+  } catch (error) {
+    if (truffleHogBlocked) {
+      logger.error(
+        {
+          attemptId: attempt.attemptId,
+          durationMs: Date.now() - startedAt,
+          event: "prepublication_attempt_secret_block_completion_failed",
+          kind: attempt.kind,
+        },
+        "pre-publication TruffleHog block completion failed; leaving attempt retryable",
+      );
+      return { completed: false, result: undefined };
+    }
+    const failure = {
+      status: "failed" as const,
+      summary: publicText(error instanceof Error ? error.message : String(error)),
+    };
+    const result = await completeAttempt(client, token, attempt, failure, failure);
+    logger.warn(
+      {
+        attemptId: attempt.attemptId,
+        durationMs: Date.now() - startedAt,
+        event: "prepublication_attempt_failed",
+        kind: attempt.kind,
+      },
+      "pre-publication attempt failed before checks completed",
+    );
+    return { completed: false, result };
+  } finally {
+    await rm(workspace, { force: true, recursive: true });
+  }
+}
+
+export async function claimPrePublicationAttempt(
+  client: PrePublicationWorkerClient,
+  token: string,
+) {
+  return (await client.action(api.publishAttempts.claimPrePublicationChecks, {
+    token,
+  })) as ClaimedPrePublicationAttempt | null;
+}
+
+async function main() {
+  const { batchLimit, maxJobs, maxRuntimeMs } = parseArgs();
+  assertCodexWorkerExecutionAllowed(process.env);
+  maskKnownWorkerSecrets();
+  const convexUrl = process.env.CONVEX_URL ?? process.env.VITE_CONVEX_URL;
+  if (!convexUrl) throw new Error("CONVEX_URL or VITE_CONVEX_URL is required");
+  const token = requireEnv("SECURITY_SCAN_WORKER_TOKEN");
+  const client = new ConvexHttpClient(convexUrl);
+  const startedAt = Date.now();
+  const claimDeadline = startedAt + maxRuntimeMs;
+  let totalClaimed = 0;
+  let totalCompleted = 0;
+
+  logger.info(
+    {
+      event: "prepublication_worker_started",
+      workerId:
+        process.env.PREPUBLICATION_WORKER_ID ??
+        `github-actions:${process.env.GITHUB_RUN_ID ?? process.pid}`,
+    },
+    "pre-publication worker started",
+  );
+
+  while (Date.now() < claimDeadline) {
+    if (totalClaimed > 0 && claimDeadline - Date.now() < CLAIM_WINDOW_SHUTDOWN_BUFFER_MS) break;
+    const remainingJobs = maxJobs === undefined ? batchLimit : Math.max(0, maxJobs - totalClaimed);
+    if (remainingJobs === 0) break;
+    const attempts = (
+      await Promise.all(
+        Array.from({ length: Math.min(batchLimit, remainingJobs) }, () =>
+          claimPrePublicationAttempt(client, token),
+        ),
+      )
+    ).filter((attempt): attempt is ClaimedPrePublicationAttempt => Boolean(attempt));
+    if (attempts.length === 0) break;
+    totalClaimed += attempts.length;
+    const results = await Promise.all(
+      attempts.map((attempt) => processPrePublicationAttempt(client, token, attempt)),
+    );
+    totalCompleted += results.filter((result) => result.completed).length;
+    if (attempts.length < Math.min(batchLimit, remainingJobs)) break;
+  }
+
+  logger.info(
+    {
+      elapsedMs: Date.now() - startedAt,
+      event: "prepublication_worker_summary",
+      totalClaimed,
+      totalCompleted,
+    },
+    "pre-publication worker summary",
+  );
+}
+
+export function configurePrePublicationCodexHome(env: NodeJS.ProcessEnv = process.env) {
+  const codexHome = resolveCodexWorkerHome(env, LOCAL_CODEX_HOME);
+  if (!codexHome) return undefined;
+  env.CODEX_HOME = codexHome;
+  mkdirSync(codexHome, { recursive: true });
+  return codexHome;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  configurePrePublicationCodexHome();
+  await main();
+}


### PR DESCRIPTION
## Summary
- add the scheduled pre-publication publish worker that claims staged skill/plugin publish attempts, runs native TruffleHog, then runs the normal ClawHub SkillSpector/Codex review before finalizing
- hydrate staged package attempts with ClawPack and review context, and add retry handling for already-checked `ready_to_finalize` attempts
- pin the production TruffleHog image by digest and cover clean, blocked, failure, package, auth-home, and retry paths in tests

## Tests
- `bunx vitest run scripts/security/run-prepublication-worker.test.ts scripts/security/prepublication-worker-workflow.test.ts convex/publishAttempts.test.ts`
- `bunx tsc --noEmit --pretty false`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
