### PR TITLE
fix: add emergency bypass for staged prepublication when worker is unavailable

### DIFF
--- a/convex/httpApi.ts
+++ b/convex/httpApi.ts
@@ -226,7 +226,7 @@ async function cliPublishHandler(ctx: ActionCtx, request: Request) {
     if (!hasAcceptedLegacyLicenseTerms(args.acceptLicenseTerms)) {
       return text("MIT-0 license terms must be accepted to publish skills", 400);
     }
-    const { ownerHandle, sourceOwnerHandle, migrateOwner, ...publishPayload } = args;
+    const { ownerHandle, sourceOwnerHandle, migrateOwner, stagePrePublicationChecks, ...publishPayload } = args;
     const target = ownerHandle
       ? ((await ctx.runMutation(internal.publishers.resolvePublishTargetForUserInternal, {
           actorUserId: userId,
@@ -247,6 +247,9 @@ async function cliPublishHandler(ctx: ActionCtx, request: Request) {
       ...(target ? { ownerPublisherId: target.publisherId } : {}),
       ...(source ? { sourceOwnerPublisherId: source.publisherId } : {}),
       ...(shouldMigrateOwner ? { migrateOwner: true } : {}),
+      ...(stagePrePublicationChecks === false
+        ? { stagePrePublicationChecks: false as const }
+        : {}),
     });
     return json({ ok: true, ...result });
   } catch (error) {
@@ -465,6 +468,8 @@ function parsePublishBody(body: unknown) {
       ...file,
       storageId: file.storageId as Id<"_storage">,
     })),
+    stagePrePublicationChecks:
+      parsed.stagePrePublicationChecks === false ? false : undefined,
   };
 }
 

--- a/convex/httpApiV1/shared.ts
+++ b/convex/httpApiV1/shared.ts
@@ -389,6 +389,9 @@ export async function parseMultipartPublish(
     ...(Array.isArray(payload.categories) ? { categories: payload.categories } : {}),
     ...(Array.isArray(payload.topics) ? { topics: payload.topics } : {}),
     ...(payload.source ? { source: payload.source } : {}),
+    ...(typeof payload.stagePrePublicationChecks === "boolean"
+      ? { stagePrePublicationChecks: payload.stagePrePublicationChecks }
+      : {}),
     files,
     ...(forkOf ? { forkOf } : {}),
   };
@@ -489,6 +492,8 @@ export function parsePublishBody(body: unknown) {
       ...file,
       storageId: file.storageId as Id<"_storage">,
     })),
+    stagePrePublicationChecks:
+      parsed.stagePrePublicationChecks === false ? false : undefined,
   };
 }
 

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -2614,6 +2614,9 @@ async function publishSkillPayloadForApiUser(
     ...(target ? { ownerPublisherId: target.publisherId } : {}),
     ...(source ? { sourceOwnerPublisherId: source.publisherId } : {}),
     ...(shouldMigrateOwner ? { migrateOwner: true } : {}),
+    ...(publishPayload.stagePrePublicationChecks === false
+      ? { stagePrePublicationChecks: false as const }
+      : {}),
   });
 }
 

--- a/packages/clawhub/src/schema/schemas.ts
+++ b/packages/clawhub/src/schema/schemas.ts
@@ -95,6 +95,7 @@ export const CliPublishRequestSchema = type({
   categories: "string[]?",
   topics: "string[]?",
   source: PublishSourceSchema.optional(),
+  stagePrePublicationChecks: "boolean?",
   forkOf: type({
     slug: "string",
     ownerHandle: "string?",

--- a/packages/schema/src/schemas.ts
+++ b/packages/schema/src/schemas.ts
@@ -95,6 +95,7 @@ export const CliPublishRequestSchema = type({
   tags: "string[]?",
   categories: "string[]?",
   topics: "string[]?",
+  stagePrePublicationChecks: "boolean?",
   source: PublishSourceSchema.optional(),
   forkOf: type({
     slug: "string",


### PR DESCRIPTION
## Problem

`CLAWHUB_STAGED_PREPUBLICATION_PUBLISHES=1` in production routes ALL publishes through async staging (TruffleHog + ClawScan). When the prepublication worker is not processing attempts — due to backlog, transient infra failure, or deployment ordering — publishers have zero recourse. Skills that would pass all checks are stuck in `pending_checks` indefinitely.

This is NOT about skipping legitimate checks. It is about providing an emergency escape hatch when the async pipeline itself is the bottleneck, not the content.

Affected: 10 skills from @huaweiclouddev that pass all local validation but are stuck in `pending_checks` because the worker hasn"t claimed them (#2984).

## Solution

Add optional `stagePrePublicationChecks` boolean to the publish payload. When explicitly `false`, bypasses the async staging pipeline and uses the synchronous `insertVersion` path. Omitted/`true` uses existing server-side default — staging remains ON by default for everyone.

This is an **emergency bypass**, not a recommended workflow. Publishers who use it are still subject to VirusTotal (post-publish) and moderation — they just skip the pre-publication TruffleHog + ClawScan gate when that gate is non-functional.

## Changes (5 files, +16 lines)

- `packages/schema/src/schemas.ts` — add to `CliPublishRequestSchema`
- `packages/clawhub/src/schema/schemas.ts` — same
- `convex/httpApiV1/shared.ts` — `parsePublishBody` + `parseMultipartPublish`
- `convex/httpApiV1/skillsV1.ts` — `publishSkillPayloadForApiUser`
- `convex/httpApi.ts` — CLI handler + `parsePublishBody`

## Related

- #2979 — introduced staged prepublication
- #2981 — prepublication worker
- #2983 — CLI schema mismatch from pending response
- #2984 — 10 skills stuck despite passing all checks