### PR TITLE
fix: pass Codex API key to ClawScan shadow

### DIFF
--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -95,6 +95,7 @@ jobs:
 
       - name: Run Codex security worker
         env:
+          CODEX_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}
         run: |

--- a/scripts/lib/workerRedaction.ts
+++ b/scripts/lib/workerRedaction.ts
@@ -48,6 +48,7 @@ export function maskKnownWorkerSecrets(
 ) {
   const secretKeys = [
     "SECURITY_SCAN_WORKER_TOKEN",
+    "CODEX_API_KEY",
     "OPENAI_API_KEY",
     "GH_TOKEN",
     "GITHUB_TOKEN",

--- a/scripts/security/security-scan-worker-workflow.test.ts
+++ b/scripts/security/security-scan-worker-workflow.test.ts
@@ -70,12 +70,15 @@ describe("security-scan-codex workflow", () => {
       "${{ vars.CODEX_SECURITY_SCAN_TIMEOUT_MS || '240000' }}",
     );
     expect(jobEnv).not.toHaveProperty("OPENAI_API_KEY");
+    expect(jobEnv).not.toHaveProperty("CODEX_API_KEY");
     expect(jobEnv).not.toHaveProperty("SECURITY_SCAN_WORKER_TOKEN");
+    expectSecretStepAllowlist(steps, "CODEX_API_KEY", ["Run Codex security worker"]);
     expectSecretStepAllowlist(steps, "OPENAI_API_KEY", [
       "Authenticate Codex CLI",
       "Run Codex security worker",
     ]);
     expectSecretStepAllowlist(steps, "SECURITY_SCAN_WORKER_TOKEN", ["Run Codex security worker"]);
+    expect(scanStep?.env ?? {}).not.toHaveProperty("CODEX_API_KEY");
     expect(scanStep?.env ?? {}).not.toHaveProperty("OPENAI_API_KEY");
     expect(scanStep?.env ?? {}).not.toHaveProperty("SECURITY_SCAN_WORKER_TOKEN");
     expect(steps.find((step) => step.name === "Check configuration")).toBeUndefined();
@@ -86,6 +89,7 @@ describe("security-scan-codex workflow", () => {
     expect(skillspectorInstall).toContain("git+https://github.com/NVIDIA/skillspector.git@8f37cfa");
     expect(skillspectorInstall).not.toContain("git+https://github.com/NVIDIA/skillspector.git'");
     expect(steps.find((step) => step.name === "Run Codex security worker")?.env).toEqual({
+      CODEX_API_KEY: "${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}",
       OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}",
       SECURITY_SCAN_WORKER_TOKEN: "${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}",
     });


### PR DESCRIPTION
## Summary
- pass `CODEX_API_KEY` into the security scan worker, falling back to `OPENAI_API_KEY`
- mask `CODEX_API_KEY` at worker log boundaries
- update workflow assertions so the key remains scoped to the worker step

## Why
The ClawScan `clawhub` profile runs its judge inside the ClawScan Docker runtime with `codex exec --ignore-user-config`. That nested Codex process cannot see the host `codex login` state and does not authenticate from `OPENAI_API_KEY`; it needs `CODEX_API_KEY` in the container env.

## Validation
- `bunx vitest run scripts/security/security-scan-worker-workflow.test.ts scripts/lib/workerRedaction.test.ts`
- `bunx vitest run scripts/security/run-codex-scan-worker.test.ts`
- `bun run format:check -- .github/workflows/security-scan-codex.yml scripts/security/security-scan-worker-workflow.test.ts scripts/lib/workerRedaction.ts`
- `bun run lint -- .github/workflows/security-scan-codex.yml scripts/security/security-scan-worker-workflow.test.ts scripts/lib/workerRedaction.ts`
- local ClawScan smoke with `CODEX_API_KEY=$OPENAI_API_KEY`, `--profile clawhub`, and Docker sandbox completed judge successfully
