### PR TITLE
fix: recover staged publishing safely

### DIFF
--- a/convex/migrations.publishAttempts.test.ts
+++ b/convex/migrations.publishAttempts.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import type { Doc, Id } from "./_generated/dataModel";
+import {
+  buildSuspiciousPublishAttemptRecoveryPatch,
+  hasStoredSuspiciousClawscanVerdict,
+} from "./migrations";
+
+function suspiciousAttempt(
+  overrides: Partial<Doc<"publishAttempts">> = {},
+): Doc<"publishAttempts"> {
+  return {
+    _id: "publishAttempts:test" as Id<"publishAttempts">,
+    _creationTime: 1,
+    kind: "skill",
+    status: "blocked",
+    userId: "users:test" as Id<"users">,
+    slug: "demo-skill",
+    displayName: "Demo Skill",
+    version: "1.0.0",
+    idempotencyKey: "skill:test",
+    artifactFingerprint: "fingerprint",
+    files: [],
+    checks: {
+      trufflehog: { status: "clean", checkedAt: 10 },
+      clawscan: {
+        status: "blocked",
+        checkedAt: 11,
+        summary: "Review before installing.",
+        redactedFindings: ["status=completed; verdict=suspicious"],
+      },
+    },
+    skillInsertArgs: { slug: "demo-skill", version: "1.0.0" },
+    createdAt: 1,
+    updatedAt: 11,
+    expiresAt: 100,
+    blockedAt: 11,
+    ...overrides,
+  };
+}
+
+describe("suspicious publish attempt recovery", () => {
+  it("selects only TruffleHog-clean attempts blocked by a stored suspicious verdict", () => {
+    expect(hasStoredSuspiciousClawscanVerdict(suspiciousAttempt())).toBe(true);
+    expect(
+      hasStoredSuspiciousClawscanVerdict(
+        suspiciousAttempt({
+          checks: {
+            trufflehog: { status: "clean" },
+            clawscan: {
+              status: "blocked",
+              redactedFindings: ["status=completed; verdict=malicious"],
+            },
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("requeues replayable attempts with suspicious analysis attached atomically", () => {
+    const patch = buildSuspiciousPublishAttemptRecoveryPatch(
+      suspiciousAttempt(),
+      "replay_missing",
+      20,
+    );
+
+    expect(patch).toMatchObject({
+      status: "ready_to_finalize",
+      checks: {
+        trufflehog: { status: "clean" },
+        clawscan: { status: "clean" },
+      },
+      skillInsertArgs: {
+        slug: "demo-skill",
+        version: "1.0.0",
+        llmAnalysis: {
+          status: "completed",
+          verdict: "suspicious",
+          summary: "Review before installing.",
+          checkedAt: 11,
+        },
+      },
+      blockedAt: undefined,
+      failedAt: undefined,
+      updatedAt: 20,
+    });
+  });
+
+  it("terminates occupied-version conflicts instead of feeding them back to the worker", () => {
+    expect(
+      buildSuspiciousPublishAttemptRecoveryPatch(suspiciousAttempt(), "public_conflict", 20),
+    ).toMatchObject({
+      status: "failed",
+      checkClaimLastError:
+        "Recovery skipped: this version is already occupied by a different public artifact.",
+      blockedAt: undefined,
+      failedAt: 20,
+      updatedAt: 20,
+    });
+  });
+});

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -10,7 +10,7 @@ import type { Doc, Id } from "./_generated/dataModel";
 import type { ActionCtx, MutationCtx, QueryCtx } from "./_generated/server";
 import { internalAction, internalMutation, internalQuery } from "./_generated/server";
 import { syncPackageSearchDigestForPackageId } from "./functions";
-import { derivePluginManifestSummary } from "./lib/packageRegistry";
+import { derivePluginManifestSummary, normalizePackageName } from "./lib/packageRegistry";
 import { adjustPublisherStatsForSkillChange } from "./lib/publisherStats";
 import {
   buildSkillDownloadBackfillPatch,
@@ -35,6 +35,7 @@ const CANONICALIZE_CATALOG_METADATA_CONFIRM = "canonicalize-catalog-metadata";
 const APPLY_SKILL_INSTALL_BACKFILL_CONFIRM = "apply-skill-install-backfill";
 const APPLY_NVIDIA_GITHUB_DOWNLOAD_BACKFILL_CONFIRM = "apply-nvidia-github-download-backfill";
 const BACKFILL_PLUGIN_MANIFEST_SUMMARIES_CONFIRM = "backfill-plugin-manifest-summaries";
+const RECOVER_SUSPICIOUS_PUBLISH_ATTEMPTS_CONFIRM = "recover-suspicious-publish-attempts";
 const SKILL_STAT_EVENTS_CURSOR_KEY = "skill_stat_events";
 const MAX_PENDING_SKILL_STAT_EVENTS_PER_SKILL = 1_000;
 const PLUGIN_PACKAGE_FAMILIES = ["code-plugin", "bundle-plugin"] as const;
@@ -79,6 +80,232 @@ const nvidiaGitHubDownloadBackfillPreviewValidator = v.object({
 export const migrations = new Migrations(components.migrations, {
   schema,
   defaultBatchSize: 25,
+});
+
+type SuspiciousPublishAttemptRecoveryClassification =
+  | "replay_missing"
+  | "replay_identical"
+  | "public_conflict"
+  | "ineligible";
+
+type SuspiciousPublishAttemptRecoveryPreview = {
+  blockedScanned: number;
+  replayMissing: number;
+  replayIdentical: number;
+  publicConflict: number;
+  ineligible: number;
+  samples: Array<{
+    attemptId: Id<"publishAttempts">;
+    kind: "skill" | "package";
+    slug: string;
+    version: string;
+    classification: SuspiciousPublishAttemptRecoveryClassification;
+  }>;
+};
+
+export function hasStoredSuspiciousClawscanVerdict(attempt: Doc<"publishAttempts">) {
+  if (
+    attempt.status !== "blocked" ||
+    attempt.checks.trufflehog.status !== "clean" ||
+    attempt.checks.clawscan.status !== "blocked"
+  ) {
+    return false;
+  }
+  const storedReviewText = [
+    attempt.checks.clawscan.summary,
+    ...(attempt.checks.clawscan.redactedFindings ?? []),
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(" ")
+    .toLowerCase();
+  return storedReviewText.includes("verdict=suspicious") && !storedReviewText.includes("malicious");
+}
+
+async function classifySuspiciousPublishAttemptPublicState(
+  ctx: Pick<QueryCtx, "db"> | Pick<MutationCtx, "db">,
+  attempt: Doc<"publishAttempts">,
+): Promise<SuspiciousPublishAttemptRecoveryClassification> {
+  if (!hasStoredSuspiciousClawscanVerdict(attempt)) return "ineligible";
+
+  if (attempt.kind === "package") {
+    const pkg = await ctx.db
+      .query("packages")
+      .withIndex("by_name", (q) => q.eq("normalizedName", normalizePackageName(attempt.slug)))
+      .unique();
+    if (!pkg) return "replay_missing";
+    const ownerMatches = attempt.ownerPublisherId
+      ? pkg.ownerPublisherId === attempt.ownerPublisherId
+      : pkg.ownerUserId === attempt.ownerUserId;
+    if (!ownerMatches) return "public_conflict";
+    const release = await ctx.db
+      .query("packageReleases")
+      .withIndex("by_package_version", (q) =>
+        q.eq("packageId", pkg._id).eq("version", attempt.version),
+      )
+      .unique();
+    if (!release) return "replay_missing";
+    if (release.softDeletedAt || release.integritySha256 !== attempt.artifactFingerprint) {
+      return "public_conflict";
+    }
+    return "replay_identical";
+  }
+
+  let ownerPublisherId = attempt.ownerPublisherId;
+  if (!ownerPublisherId) {
+    const personalPublishers = await ctx.db
+      .query("publishers")
+      .withIndex("by_linked_user", (q) => q.eq("linkedUserId", attempt.userId))
+      .take(5);
+    ownerPublisherId = personalPublishers.find(
+      (publisher) => publisher.kind === "user" && !publisher.deletedAt && !publisher.deactivatedAt,
+    )?._id;
+  }
+  const skill = ownerPublisherId
+    ? await ctx.db
+        .query("skills")
+        .withIndex("by_owner_publisher_slug", (q) =>
+          q.eq("ownerPublisherId", ownerPublisherId).eq("slug", attempt.slug),
+        )
+        .unique()
+    : await ctx.db
+        .query("skills")
+        .withIndex("by_owner_slug", (q) =>
+          q.eq("ownerUserId", attempt.userId).eq("slug", attempt.slug),
+        )
+        .unique();
+  if (!skill) return "replay_missing";
+  const version = await ctx.db
+    .query("skillVersions")
+    .withIndex("by_skill_version", (q) => q.eq("skillId", skill._id).eq("version", attempt.version))
+    .unique();
+  if (!version) return "replay_missing";
+  if (version.softDeletedAt || version.fingerprint !== attempt.artifactFingerprint) {
+    return "public_conflict";
+  }
+  const embedding = await ctx.db
+    .query("skillEmbeddings")
+    .withIndex("by_version", (q) => q.eq("versionId", version._id))
+    .unique();
+  return embedding ? "replay_identical" : "public_conflict";
+}
+
+function recoveredSuspiciousAnalysis(attempt: Doc<"publishAttempts">) {
+  return {
+    status: "completed",
+    verdict: "suspicious",
+    summary:
+      attempt.checks.clawscan.summary ??
+      "ClawHub security review marked this staged artifact suspicious.",
+    model: "prepublication-recovery",
+    checkedAt: attempt.checks.clawscan.checkedAt ?? Date.now(),
+  };
+}
+
+function withRecoveredSuspiciousAnalysis(insertArgs: unknown, attempt: Doc<"publishAttempts">) {
+  if (!insertArgs || typeof insertArgs !== "object" || Array.isArray(insertArgs)) return insertArgs;
+  return {
+    ...insertArgs,
+    llmAnalysis: recoveredSuspiciousAnalysis(attempt),
+  };
+}
+
+export function buildSuspiciousPublishAttemptRecoveryPatch(
+  attempt: Doc<"publishAttempts">,
+  classification: SuspiciousPublishAttemptRecoveryClassification,
+  now: number,
+): Partial<Doc<"publishAttempts">> | undefined {
+  if (classification === "ineligible") return undefined;
+  if (classification === "public_conflict") {
+    return {
+      status: "failed",
+      checkClaimLastError:
+        "Recovery skipped: this version is already occupied by a different public artifact.",
+      blockedAt: undefined,
+      failedAt: now,
+      updatedAt: now,
+    };
+  }
+  return {
+    status: "ready_to_finalize",
+    checks: {
+      ...attempt.checks,
+      clawscan: {
+        ...attempt.checks.clawscan,
+        status: "clean",
+      },
+    },
+    skillInsertArgs:
+      attempt.kind === "skill"
+        ? withRecoveredSuspiciousAnalysis(attempt.skillInsertArgs, attempt)
+        : attempt.skillInsertArgs,
+    packageInsertArgs:
+      attempt.kind === "package"
+        ? withRecoveredSuspiciousAnalysis(attempt.packageInsertArgs, attempt)
+        : attempt.packageInsertArgs,
+    checkClaimId: undefined,
+    checkClaimedAt: undefined,
+    checkClaimExpiresAt: undefined,
+    checkClaimLastError: undefined,
+    finalizationClaimId: undefined,
+    finalizationClaimedAt: undefined,
+    finalizationClaimExpiresAt: undefined,
+    finalizationLastError: undefined,
+    blockedAt: undefined,
+    failedAt: undefined,
+    updatedAt: now,
+  };
+}
+
+export const recoverSuspiciousBlockedPublishAttempts = migrations.define({
+  table: "publishAttempts",
+  batchSize: 200,
+  customRange: (query) =>
+    query.withIndex("by_status_and_created", (q) => q.eq("status", "blocked")),
+  migrateOne: async (ctx, attempt) => {
+    const classification = await classifySuspiciousPublishAttemptPublicState(ctx, attempt);
+    return buildSuspiciousPublishAttemptRecoveryPatch(attempt, classification, Date.now());
+  },
+});
+
+export const previewSuspiciousPublishAttemptRecoveryInternal = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const attempts = await ctx.db
+      .query("publishAttempts")
+      .withIndex("by_status_and_created", (q) => q.eq("status", "blocked"))
+      .take(1_000);
+    const totals = {
+      blockedScanned: attempts.length,
+      replayMissing: 0,
+      replayIdentical: 0,
+      publicConflict: 0,
+      ineligible: 0,
+    };
+    const samples: Array<{
+      attemptId: Id<"publishAttempts">;
+      kind: "skill" | "package";
+      slug: string;
+      version: string;
+      classification: SuspiciousPublishAttemptRecoveryClassification;
+    }> = [];
+    for (const attempt of attempts) {
+      const classification = await classifySuspiciousPublishAttemptPublicState(ctx, attempt);
+      if (classification === "replay_missing") totals.replayMissing += 1;
+      else if (classification === "replay_identical") totals.replayIdentical += 1;
+      else if (classification === "public_conflict") totals.publicConflict += 1;
+      else totals.ineligible += 1;
+      if (classification !== "ineligible" && samples.length < 20) {
+        samples.push({
+          attemptId: attempt._id,
+          kind: attempt.kind,
+          slug: attempt.slug,
+          version: attempt.version,
+          classification,
+        });
+      }
+    }
+    return { ...totals, samples };
+  },
 });
 
 type CanonicalCatalogMetadataFields = Pick<
@@ -1065,6 +1292,62 @@ export const runPluginManifestSummaryBackfillPage = internalAction({
 });
 
 export const run = migrations.runner();
+
+export const runSuspiciousPublishAttemptRecovery: ReturnType<typeof internalAction> =
+  internalAction({
+    args: {
+      dryRun: v.optional(v.boolean()),
+      confirm: v.optional(v.string()),
+    },
+    handler: async (
+      ctx,
+      args,
+    ): Promise<{
+      ok: true;
+      dryRun: boolean;
+      confirmRequired?: string;
+      before: SuspiciousPublishAttemptRecoveryPreview;
+      after: SuspiciousPublishAttemptRecoveryPreview;
+    }> => {
+      const dryRun = args.dryRun !== false;
+      if (!dryRun && args.confirm !== RECOVER_SUSPICIOUS_PUBLISH_ATTEMPTS_CONFIRM) {
+        throw new ConvexError(
+          `Pass confirm="${RECOVER_SUSPICIOUS_PUBLISH_ATTEMPTS_CONFIRM}" to apply.`,
+        );
+      }
+      const before: SuspiciousPublishAttemptRecoveryPreview = await ctx.runQuery(
+        internal.migrations.previewSuspiciousPublishAttemptRecoveryInternal,
+        {},
+      );
+      if (dryRun) {
+        await ctx.runMutation(internal.migrations.run, {
+          fn: "migrations:recoverSuspiciousBlockedPublishAttempts",
+          dryRun: true,
+          reset: true,
+        });
+      } else {
+        await runToCompletion(
+          ctx,
+          components.migrations,
+          internal.migrations.recoverSuspiciousBlockedPublishAttempts,
+          { cursor: null, batchSize: 200 },
+        );
+      }
+      const after: SuspiciousPublishAttemptRecoveryPreview = dryRun
+        ? before
+        : await ctx.runQuery(
+            internal.migrations.previewSuspiciousPublishAttemptRecoveryInternal,
+            {},
+          );
+      return {
+        ok: true as const,
+        dryRun,
+        confirmRequired: dryRun ? RECOVER_SUSPICIOUS_PUBLISH_ATTEMPTS_CONFIRM : undefined,
+        before,
+        after,
+      };
+    },
+  });
 
 export const runCatalogMetadataCanonicalization = internalAction({
   args: {

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -241,6 +241,7 @@ const insertReleaseInternalHandler = (
       capabilities?: unknown;
       verification?: unknown;
       staticScan?: unknown;
+      llmAnalysis?: unknown;
       artifactKind?: "legacy-zip" | "npm-pack";
       clawpackStorageId?: string;
       clawpackSha256?: string;
@@ -7023,6 +7024,48 @@ describe("packages public queries", () => {
     ]) {
       expect(packagePatch).toHaveProperty(field, undefined);
     }
+  });
+
+  it("publishes suspicious prepublication plugin results with a suspicious scan status", async () => {
+    const ctx = makeInsertReleaseCtx(makePackageDoc());
+    const llmAnalysis = {
+      status: "completed",
+      verdict: "suspicious",
+      summary: "Review before installing.",
+      checkedAt: 123,
+    };
+
+    await insertReleaseInternalHandler(ctx, {
+      actorUserId: "users:owner",
+      ownerUserId: "users:owner",
+      name: "demo-plugin",
+      displayName: "Demo Plugin",
+      family: "code-plugin",
+      version: "1.0.1",
+      changelog: "reviewed release",
+      tags: ["latest"],
+      summary: "demo",
+      verification: { tier: "structural", scanStatus: "pending" },
+      llmAnalysis,
+      files: [],
+      integritySha256: "abc123",
+      sha256hash: "abc123",
+    });
+
+    expect(ctx.insert).toHaveBeenCalledWith(
+      "packageReleases",
+      expect.objectContaining({
+        llmAnalysis,
+        verification: expect.objectContaining({ scanStatus: "suspicious" }),
+      }),
+    );
+    expect(ctx.patch).toHaveBeenCalledWith(
+      "packages:demo",
+      expect.objectContaining({
+        scanStatus: "suspicious",
+        verification: expect.objectContaining({ scanStatus: "suspicious" }),
+      }),
+    );
   });
 
   it("rejects family changes on an existing package name", async () => {

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -86,6 +86,7 @@ import { extractPackageDigestFields, upsertPackageSearchDigest } from "./lib/pac
 import {
   getPackageTrustReasons,
   isPackageBlockedFromPublic,
+  normalizePackageScanStatus,
   resolvePackageReleaseScanStatus,
 } from "./lib/packageSecurity";
 import { toPublicPublisher } from "./lib/public";
@@ -9248,6 +9249,7 @@ export const insertReleaseInternal = internalMutation({
     compatibility: v.optional(v.any()),
     verification: v.optional(v.any()),
     staticScan: v.optional(v.any()),
+    llmAnalysis: v.optional(v.any()),
     allowExistingRelease: v.optional(v.boolean()),
     files: v.array(
       v.object({
@@ -9278,6 +9280,13 @@ export const insertReleaseInternal = internalMutation({
   },
   handler: async (ctx, args) => {
     const now = Date.now();
+    const prePublicationScanStatus = args.llmAnalysis
+      ? normalizePackageScanStatus(args.llmAnalysis.verdict ?? args.llmAnalysis.status)
+      : undefined;
+    const releaseVerification =
+      args.verification && prePublicationScanStatus
+        ? { ...args.verification, scanStatus: prePublicationScanStatus }
+        : args.verification;
     const normalizedName = normalizePackageName(args.name);
     const actor = await ctx.db.get(args.actorUserId);
     if (!actor || actor.deletedAt || actor.deactivatedAt) throw new ConvexError("Unauthorized");
@@ -9408,8 +9417,8 @@ export const insertReleaseInternal = internalMutation({
         topics: args.topics,
         tags: {},
         compatibility: args.compatibility,
-        verification: args.verification,
-        scanStatus: args.verification?.scanStatus,
+        verification: releaseVerification,
+        scanStatus: releaseVerification?.scanStatus,
         stats: { downloads: 0, installs: 0, stars: 0, versions: 0 },
         ...computePackageRecommendationPatch(
           {
@@ -9491,8 +9500,9 @@ export const insertReleaseInternal = internalMutation({
       compatibility: args.compatibility,
       runtimeId: args.runtimeId,
       sourceRepo: args.sourceRepo,
-      verification: args.verification,
+      verification: releaseVerification,
       staticScan: args.staticScan,
+      llmAnalysis: args.llmAnalysis,
       source: args.source,
       createdBy: args.actorUserId,
       publishActor: args.publishActor,
@@ -9547,14 +9557,14 @@ export const insertReleaseInternal = internalMutation({
             changelog: args.changelog,
             icon: args.icon,
             compatibility: args.compatibility,
-            verification: args.verification,
+            verification: releaseVerification,
             artifact: packageArtifactSummary(args),
           }
         : pkg.latestVersionSummary,
       tags: nextTags,
       compatibility: shouldPromoteLatest ? args.compatibility : pkg.compatibility,
-      verification: shouldPromoteLatest ? args.verification : pkg.verification,
-      scanStatus: shouldPromoteLatest ? args.verification?.scanStatus : pkg.scanStatus,
+      verification: shouldPromoteLatest ? releaseVerification : pkg.verification,
+      scanStatus: shouldPromoteLatest ? releaseVerification?.scanStatus : pkg.scanStatus,
       stats: { ...pkg.stats, versions: (pkg.stats?.versions ?? 0) + 1 },
       updatedAt: now,
     });

--- a/convex/publishAttempts.test.ts
+++ b/convex/publishAttempts.test.ts
@@ -231,6 +231,197 @@ describe("publishAttempts", () => {
     expect(ctx.db.patch).not.toHaveBeenCalled();
   });
 
+  it("keeps scanner execution failures fail-closed and retryable", async () => {
+    const now = Date.now();
+    const ctx = {
+      db: {
+        get: vi.fn(async () => ({
+          _id: "publishAttempts:demo",
+          kind: "skill",
+          status: "pending_checks",
+          artifactFingerprint: "fingerprint",
+          checkClaimId: "checks:claim",
+          checkClaimExpiresAt: now + 60_000,
+          checks: {
+            trufflehog: { status: "pending" },
+            clawscan: { status: "pending" },
+          },
+        })),
+        patch: vi.fn(),
+        insert: vi.fn(),
+        replace: vi.fn(),
+        delete: vi.fn(),
+        query: vi.fn(),
+        normalizeId: vi.fn(),
+        system: {},
+      },
+      storage: {
+        delete: vi.fn(),
+      },
+    };
+
+    await expect(
+      completePendingChecksHandler(ctx, {
+        attemptId: "publishAttempts:demo",
+        claimId: "checks:claim",
+        artifactFingerprint: "fingerprint",
+        trufflehog: { status: "failed", summary: "scanner unavailable" },
+        clawscan: { status: "failed", summary: "scanner unavailable" },
+      }),
+    ).resolves.toEqual({
+      attemptId: "publishAttempts:demo",
+      kind: "skill",
+      status: "pending_checks",
+    });
+
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "publishAttempts:demo",
+      expect.objectContaining({
+        status: "pending_checks",
+        checkClaimId: undefined,
+        checkClaimedAt: undefined,
+        checkClaimExpiresAt: expect.any(Number),
+        checkClaimLastError: "scanner unavailable",
+        failedAt: undefined,
+      }),
+    );
+    const patch = ctx.db.patch.mock.calls[0]?.[1] as { checkClaimExpiresAt: number };
+    expect(patch.checkClaimExpiresAt).toBeGreaterThan(now);
+  });
+
+  it("stores suspicious analysis with the staged insert before finalization", async () => {
+    const now = Date.now();
+    const llmAnalysis = {
+      status: "completed",
+      verdict: "suspicious",
+      summary: "Review before installing.",
+      checkedAt: now,
+    };
+    const ctx = {
+      db: {
+        get: vi.fn(async () => ({
+          _id: "publishAttempts:demo",
+          kind: "skill",
+          status: "pending_checks",
+          artifactFingerprint: "fingerprint",
+          checkClaimId: "checks:claim",
+          checkClaimExpiresAt: now + 60_000,
+          skillInsertArgs: {
+            slug: "demo-skill",
+            version: "1.0.0",
+          },
+        })),
+        patch: vi.fn(),
+        insert: vi.fn(),
+        replace: vi.fn(),
+        delete: vi.fn(),
+        query: vi.fn(),
+        normalizeId: vi.fn(),
+        system: {},
+      },
+      storage: {
+        delete: vi.fn(),
+      },
+    };
+
+    await expect(
+      completePendingChecksHandler(ctx, {
+        attemptId: "publishAttempts:demo",
+        claimId: "checks:claim",
+        artifactFingerprint: "fingerprint",
+        trufflehog: { status: "clean" },
+        clawscan: {
+          status: "clean",
+          redactedFindings: ["status=completed; verdict=suspicious"],
+        },
+        clawscanAnalysis: llmAnalysis,
+      }),
+    ).resolves.toEqual({
+      attemptId: "publishAttempts:demo",
+      kind: "skill",
+      status: "ready_to_finalize",
+    });
+
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "publishAttempts:demo",
+      expect.objectContaining({
+        status: "ready_to_finalize",
+        skillInsertArgs: {
+          slug: "demo-skill",
+          version: "1.0.0",
+          llmAnalysis,
+        },
+      }),
+    );
+  });
+
+  it("retains malicious analysis while keeping the staged artifact blocked", async () => {
+    const now = Date.now();
+    const llmAnalysis = {
+      status: "completed",
+      verdict: "malicious",
+      summary: "Credential theft behavior detected.",
+      checkedAt: now,
+    };
+    const ctx = {
+      db: {
+        get: vi.fn(async () => ({
+          _id: "publishAttempts:demo",
+          kind: "package",
+          status: "pending_checks",
+          artifactFingerprint: "fingerprint",
+          checkClaimId: "checks:claim",
+          checkClaimExpiresAt: now + 60_000,
+          packageInsertArgs: {
+            name: "demo-plugin",
+            version: "1.0.0",
+          },
+        })),
+        patch: vi.fn(),
+        insert: vi.fn(),
+        replace: vi.fn(),
+        delete: vi.fn(),
+        query: vi.fn(),
+        normalizeId: vi.fn(),
+        system: {},
+      },
+      storage: {
+        delete: vi.fn(),
+      },
+    };
+
+    await expect(
+      completePendingChecksHandler(ctx, {
+        attemptId: "publishAttempts:demo",
+        claimId: "checks:claim",
+        artifactFingerprint: "fingerprint",
+        trufflehog: { status: "clean" },
+        clawscan: {
+          status: "blocked",
+          redactedFindings: ["status=completed; verdict=malicious"],
+        },
+        clawscanAnalysis: llmAnalysis,
+      }),
+    ).resolves.toEqual({
+      attemptId: "publishAttempts:demo",
+      kind: "package",
+      status: "blocked",
+    });
+
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "publishAttempts:demo",
+      expect.objectContaining({
+        status: "blocked",
+        packageInsertArgs: {
+          name: "demo-plugin",
+          version: "1.0.0",
+          llmAnalysis,
+        },
+      }),
+    );
+    expect(ctx.storage.delete).not.toHaveBeenCalled();
+  });
+
   it("emails the publisher when TruffleHog blocks a staged publish", async () => {
     const ctx = {
       db: {

--- a/convex/publishAttempts.ts
+++ b/convex/publishAttempts.ts
@@ -7,6 +7,7 @@ import { finalizeSkillPublishAttempt } from "./lib/skillPublish";
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 const CHECK_CLAIM_LEASE_MS = 30 * 60 * 1000;
+const CHECK_RETRY_BACKOFF_MS = 5 * 60 * 1000;
 const FINALIZATION_CLAIM_LEASE_MS = 10 * 60 * 1000;
 
 const publishResultValidator = v.object({
@@ -27,6 +28,27 @@ const workerCheckResultValidator = v.object({
   redactedFindings: v.optional(v.array(v.string())),
 });
 
+const workerLlmAnalysisValidator = v.object({
+  status: v.string(),
+  verdict: v.optional(v.string()),
+  confidence: v.optional(v.string()),
+  summary: v.optional(v.string()),
+  dimensions: v.optional(
+    v.array(
+      v.object({
+        name: v.string(),
+        label: v.string(),
+        rating: v.string(),
+        detail: v.string(),
+      }),
+    ),
+  ),
+  guidance: v.optional(v.string()),
+  findings: v.optional(v.string()),
+  model: v.optional(v.string()),
+  checkedAt: v.number(),
+});
+
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -37,6 +59,27 @@ function withoutUndefined<T extends Record<string, unknown>>(value: T) {
   return Object.fromEntries(
     Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
   ) as Partial<T>;
+}
+
+function withClawscanAnalysis(insertArgs: unknown, clawscanAnalysis: unknown) {
+  if (!clawscanAnalysis) return insertArgs;
+  return {
+    ...asRecord(insertArgs),
+    llmAnalysis: clawscanAnalysis,
+  };
+}
+
+function scannerFailureSummary(args: {
+  trufflehog: { status: string; summary?: string };
+  clawscan: { status: string; summary?: string };
+}) {
+  if (args.trufflehog.status === "failed" && args.trufflehog.summary) {
+    return args.trufflehog.summary;
+  }
+  if (args.clawscan.status === "failed" && args.clawscan.summary) {
+    return args.clawscan.summary;
+  }
+  return "Pre-publication scanner failed before returning a verdict.";
 }
 
 export const createSkillPublishAttemptInternal = internalMutation({
@@ -278,6 +321,7 @@ export const completePendingPublishAttemptChecksInternal = internalMutation({
     artifactFingerprint: v.string(),
     trufflehog: workerCheckResultValidator,
     clawscan: workerCheckResultValidator,
+    clawscanAnalysis: v.optional(workerLlmAnalysisValidator),
   },
   handler: async (ctx, args) => {
     const attempt = await ctx.db.get(args.attemptId);
@@ -341,6 +385,14 @@ export const completePendingPublishAttemptChecksInternal = internalMutation({
       await ctx.db.patch(attempt._id, {
         status: "blocked",
         checks,
+        skillInsertArgs:
+          attempt.kind === "skill"
+            ? withClawscanAnalysis(attempt.skillInsertArgs, args.clawscanAnalysis)
+            : attempt.skillInsertArgs,
+        packageInsertArgs:
+          attempt.kind === "package"
+            ? withClawscanAnalysis(attempt.packageInsertArgs, args.clawscanAnalysis)
+            : attempt.packageInsertArgs,
         checkClaimId: undefined,
         checkClaimedAt: undefined,
         checkClaimExpiresAt: undefined,
@@ -353,21 +405,29 @@ export const completePendingPublishAttemptChecksInternal = internalMutation({
 
     if (args.trufflehog.status === "failed" || args.clawscan.status === "failed") {
       await ctx.db.patch(attempt._id, {
-        status: "failed",
+        status: "pending_checks",
         checks,
         checkClaimId: undefined,
         checkClaimedAt: undefined,
-        checkClaimExpiresAt: undefined,
-        checkClaimLastError: undefined,
-        failedAt: now,
+        checkClaimExpiresAt: now + CHECK_RETRY_BACKOFF_MS,
+        checkClaimLastError: scannerFailureSummary(args),
+        failedAt: undefined,
         updatedAt: now,
       });
-      return { attemptId: attempt._id, kind: attempt.kind, status: "failed" as const };
+      return { attemptId: attempt._id, kind: attempt.kind, status: "pending_checks" as const };
     }
 
     await ctx.db.patch(attempt._id, {
       status: "ready_to_finalize",
       checks,
+      skillInsertArgs:
+        attempt.kind === "skill"
+          ? withClawscanAnalysis(attempt.skillInsertArgs, args.clawscanAnalysis)
+          : attempt.skillInsertArgs,
+      packageInsertArgs:
+        attempt.kind === "package"
+          ? withClawscanAnalysis(attempt.packageInsertArgs, args.clawscanAnalysis)
+          : attempt.packageInsertArgs,
       checkClaimId: undefined,
       checkClaimedAt: undefined,
       checkClaimExpiresAt: undefined,
@@ -863,6 +923,7 @@ export const completePrePublicationChecks: ReturnType<typeof action> = action({
     artifactFingerprint: v.string(),
     trufflehog: workerCheckResultValidator,
     clawscan: workerCheckResultValidator,
+    clawscanAnalysis: v.optional(workerLlmAnalysisValidator),
   },
   handler: async (ctx, args): Promise<unknown> => {
     assertWorkerToken(args.token);
@@ -874,11 +935,12 @@ export const completePrePublicationChecks: ReturnType<typeof action> = action({
         artifactFingerprint: args.artifactFingerprint,
         trufflehog: args.trufflehog,
         clawscan: args.clawscan,
+        clawscanAnalysis: args.clawscanAnalysis,
       },
     )) as {
       attemptId: Id<"publishAttempts">;
       kind: "skill" | "package";
-      status: "blocked" | "failed" | "ready_to_finalize";
+      status: "blocked" | "pending_checks" | "ready_to_finalize";
     };
 
     if (completed.status !== "ready_to_finalize") return completed;

--- a/convex/skills.backportLatest.test.ts
+++ b/convex/skills.backportLatest.test.ts
@@ -500,6 +500,32 @@ describe("skills.insertVersion latest-tag protection", () => {
     });
   });
 
+  it("publishes suspicious prepublication results as active and flagged", async () => {
+    const skill = buildExistingSkill();
+    const { ctx, captured } = buildCtx(skill);
+    const llmAnalysis = {
+      status: "completed",
+      verdict: "suspicious",
+      summary: "Review before installing.",
+      checkedAt: 123,
+    };
+
+    await insertVersionHandler(
+      ctx as never,
+      buildPublishArgs({
+        version: "2.1.0",
+        llmAnalysis,
+      }) as never,
+    );
+
+    expect(captured.versionInserted).toMatchObject({ llmAnalysis });
+    expect(captured.skillPatches.at(-1)).toMatchObject({
+      moderationStatus: "active",
+      moderationVerdict: "clean",
+      moderationFlags: ["flagged.review"],
+    });
+  });
+
   it("does not clobber latest when publishing an older (backport) version", async () => {
     const skill = buildExistingSkill({
       inferredCategories: ["automation"],

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -11744,6 +11744,7 @@ export const insertVersion = internalMutation({
       engineVersion: v.string(),
       checkedAt: v.number(),
     }),
+    llmAnalysis: v.optional(v.any()),
     embedding: v.array(v.number()),
   },
   handler: async (ctx, args) => {
@@ -12243,6 +12244,7 @@ export const insertVersion = internalMutation({
       files: args.files,
       parsed: args.parsed,
       staticScan: args.staticScan,
+      llmAnalysis: args.llmAnalysis,
       createdBy: userId,
       createdAt: now,
       softDeletedAt: undefined,
@@ -12306,6 +12308,19 @@ export const insertVersion = internalMutation({
     const nextFlags = Array.from(
       new Set([...(derivedFlags ?? []), ...(moderationSnapshot.legacyFlags ?? [])]),
     );
+    const scannerModerationPatch =
+      args.llmAnalysis && !isQualityQuarantine && !isPublisherUnderModeration
+        ? buildScannerModerationPatchFromVersion({
+            owner: null,
+            version: {
+              _id: versionId,
+              staticScan: args.staticScan,
+              vtAnalysis: undefined,
+              llmAnalysis: args.llmAnalysis,
+            },
+            now,
+          })
+        : {};
     const basePatch: SkillModerationPatch = {
       displayName: nextDisplayName,
       summary: nextSummary ?? undefined,
@@ -12365,6 +12380,7 @@ export const insertVersion = internalMutation({
       unpublishedSlugReleasedAt: undefined,
       unpublishedOriginalSlug: undefined,
       updatedAt: now,
+      ...scannerModerationPatch,
     };
     const patch = applySkillManualOverrideToSkillPatch({
       skill,

--- a/e2e/local-auth/helpers.ts
+++ b/e2e/local-auth/helpers.ts
@@ -124,7 +124,7 @@ export async function completeMockPrePublicationChecks(args: {
   slug: string;
   version: string;
   trufflehog?: "clean" | "blocked";
-  clawscan?: "clean" | "blocked";
+  clawscan?: "clean" | "suspicious" | "malicious" | "failed";
 }) {
   const claim = (await convexClient().action(api.publishAttempts.claimPrePublicationChecks, {
     token: WORKER_TOKEN,
@@ -140,6 +140,20 @@ export async function completeMockPrePublicationChecks(args: {
     throw new Error(`No pending ${args.kind} publish attempt for ${args.slug}@${args.version}`);
   }
 
+  const clawscan = args.clawscan ?? "clean";
+  const clawscanBlocked = clawscan === "malicious";
+  const clawscanFailed = clawscan === "failed";
+  const clawscanAnalysis =
+    clawscan === "suspicious" || clawscan === "malicious"
+      ? {
+          status: "completed",
+          verdict: clawscan,
+          confidence: "high",
+          summary: `Mock ClawScan marked the local e2e fixture ${clawscan}.`,
+          model: "mock-local-e2e",
+          checkedAt: Date.now(),
+        }
+      : undefined;
   return await convexClient().action(api.publishAttempts.completePrePublicationChecks, {
     token: WORKER_TOKEN,
     attemptId: claim.attemptId,
@@ -154,9 +168,14 @@ export async function completeMockPrePublicationChecks(args: {
       redactedFindings: args.trufflehog === "blocked" ? ["redacted-secret"] : undefined,
     },
     clawscan: {
-      status: args.clawscan ?? "clean",
+      status: clawscanBlocked ? "blocked" : clawscanFailed ? "failed" : "clean",
       summary: "Mock ClawScan completed for the local e2e fixture.",
+      redactedFindings:
+        clawscan === "suspicious" || clawscan === "malicious"
+          ? [`status=completed; verdict=${clawscan}`]
+          : undefined,
     },
+    clawscanAnalysis,
   });
 }
 

--- a/e2e/local-auth/plugin-inspector-findings.pw.test.ts
+++ b/e2e/local-auth/plugin-inspector-findings.pw.test.ts
@@ -328,6 +328,47 @@ test("plugin publish stays private until mocked TruffleHog and ClawScan pass", a
   await expectHealthyInspectorPage(page, errors);
 });
 
+test("malicious ClawScan verdict keeps a staged plugin private", async ({
+  page,
+  request,
+}, testInfo) => {
+  const errors = trackRuntimeErrors(page);
+  const suffix = Date.now().toString(36);
+  const name = `pw-malicious-plugin-${suffix}`;
+  const displayName = `Playwright Malicious Plugin ${suffix}`;
+  const version = "1.0.0";
+
+  await signInAsLocalPersona(page, "admin");
+  await page.goto("/plugins/publish", { waitUntil: "domcontentloaded" });
+  await waitForHydration(page);
+  await uploadPluginZip(
+    page,
+    await writePluginZip(testInfo, {
+      name,
+      displayName,
+      kind: "warning",
+    }),
+  );
+  await expect(page.locator("#pluginName")).toHaveValue(name);
+  await page.locator("#pluginSourceCommit").fill("abc123");
+  const publishButton = page.getByRole("button", { name: "Publish plugin" });
+  await expect(publishButton).toBeEnabled({ timeout: 60_000 });
+  await publishButton.click({ timeout: 15_000 });
+  await expect(page.getByText("Running TruffleHog and ClawScan")).toBeVisible({
+    timeout: 60_000,
+  });
+
+  const result = (await completeMockPrePublicationChecks({
+    kind: "package",
+    slug: name,
+    version,
+    clawscan: "malicious",
+  })) as { status?: string };
+  expect(result.status).toBe("blocked");
+  await expect(await publicPackageVersionExists(request, name, version)).toBe(false);
+  await expectHealthyInspectorPage(page, errors);
+});
+
 test("plugin inspector blocks hard publish errors and publishes warning findings", async ({
   page,
 }, testInfo) => {

--- a/e2e/local-auth/publish-skill-lifecycle.pw.test.ts
+++ b/e2e/local-auth/publish-skill-lifecycle.pw.test.ts
@@ -368,6 +368,48 @@ OPENAI_API_KEY=sk-local-e2e-redacted-secret-not-real
   await expectHealthyPublishPage(page, errors);
 });
 
+test("suspicious ClawScan verdict publishes the skill with review metadata", async ({
+  page,
+  request,
+}, testInfo) => {
+  const errors = trackRuntimeErrors(page);
+  const slug = `pw-suspicious-${Date.now().toString(36)}`;
+  const displayName = "Playwright Suspicious Review Skill";
+  const version = "1.0.0";
+  const ownerHandle = await signInAsLocalPublisher(page, "admin");
+
+  await publishSkillVersion(page, testInfo, {
+    ownerHandle,
+    slug,
+    displayName,
+    version,
+    versionLabel: "suspicious review release",
+    changelog: "Suspicious review result should remain public and flagged.",
+    completeChecks: false,
+  });
+
+  const result = (await completeMockPrePublicationChecks({
+    kind: "skill",
+    slug,
+    version,
+    clawscan: "suspicious",
+  })) as { status?: string };
+  expect(result.status).toBe("finalized");
+  await expect
+    .poll(() => publicSkillVersionExists(request, { ownerHandle, slug, version }), {
+      timeout: 60_000,
+      intervals: [500, 1_000, 2_000],
+    })
+    .toBe(true);
+
+  await page.goto(`/${ownerHandle}/${slug}`, { waitUntil: "domcontentloaded" });
+  await waitForHydration(page);
+  await expect(page.locator("h1.skill-page-title", { hasText: displayName })).toBeVisible({
+    timeout: 30_000,
+  });
+  await expectHealthyPublishPage(page, errors);
+});
+
 test("skill publishers can create a skill and publish a new version", async ({
   page,
 }, testInfo) => {

--- a/scripts/security/run-prepublication-worker.test.ts
+++ b/scripts/security/run-prepublication-worker.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Id } from "../../convex/_generated/dataModel";
 import {
   configurePrePublicationCodexHome,
+  processPrePublicationBatch,
   processPrePublicationAttempt,
   resolveTruffleHogImage,
   runNativeTruffleHog,
@@ -106,6 +107,101 @@ describe("pre-publication worker", () => {
       }),
     );
     expect(client.action.mock.calls[0]?.[1].trufflehog).not.toHaveProperty("exitCode");
+  });
+
+  it("publishes suspicious staged artifacts without treating them as malicious", async () => {
+    const client = {
+      action: vi.fn().mockResolvedValue({ status: "finalized" }),
+    };
+
+    await expect(
+      processPrePublicationAttempt(client, "worker-token", attempt, {
+        runClawHubReview: vi.fn().mockResolvedValue({
+          llmAnalysis: {
+            checkedAt: 123,
+            confidence: "high",
+            status: "suspicious",
+            summary: "The artifact needs moderator review.",
+            verdict: "suspicious",
+          },
+        }),
+        runTruffleHog: vi.fn().mockResolvedValue({
+          status: "clean",
+          summary: "TruffleHog found no verified secrets.",
+        }),
+        writeWorkspace: vi.fn().mockResolvedValue(undefined),
+      }),
+    ).resolves.toMatchObject({ completed: true });
+
+    expect(client.action).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        clawscan: {
+          status: "clean",
+          summary: "The artifact needs moderator review.",
+          redactedFindings: ["status=suspicious; verdict=suspicious"],
+        },
+        clawscanAnalysis: expect.objectContaining({
+          status: "suspicious",
+          verdict: "suspicious",
+        }),
+      }),
+    );
+  });
+
+  it("keeps malicious staged artifacts private", async () => {
+    const client = {
+      action: vi.fn().mockResolvedValue({ status: "blocked" }),
+    };
+
+    await expect(
+      processPrePublicationAttempt(client, "worker-token", attempt, {
+        runClawHubReview: vi.fn().mockResolvedValue({
+          llmAnalysis: {
+            checkedAt: 123,
+            confidence: "high",
+            status: "malicious",
+            summary: "The artifact contains intentional credential exfiltration.",
+            verdict: "malicious",
+          },
+        }),
+        runTruffleHog: vi.fn().mockResolvedValue({
+          status: "clean",
+          summary: "TruffleHog found no verified secrets.",
+        }),
+        writeWorkspace: vi.fn().mockResolvedValue(undefined),
+      }),
+    ).resolves.toMatchObject({ completed: true });
+
+    expect(client.action).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        clawscan: expect.objectContaining({
+          status: "blocked",
+          redactedFindings: ["status=malicious; verdict=malicious"],
+        }),
+        clawscanAnalysis: expect.objectContaining({
+          status: "malicious",
+          verdict: "malicious",
+        }),
+      }),
+    );
+  });
+
+  it("continues later attempts when one attempt throws", async () => {
+    const laterAttempt = {
+      ...attempt,
+      attemptId: "publishAttempts:later" as Id<"publishAttempts">,
+    };
+    const processAttempt = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("finalization conflict"))
+      .mockResolvedValueOnce({ completed: true });
+
+    await expect(
+      processPrePublicationBatch([attempt, laterAttempt], processAttempt),
+    ).resolves.toEqual([{ completed: false, result: undefined }, { completed: true }]);
+    expect(processAttempt).toHaveBeenCalledTimes(2);
   });
 
   it("blocks secret-positive attempts without running ClawHub review", async () => {

--- a/scripts/security/run-prepublication-worker.ts
+++ b/scripts/security/run-prepublication-worker.ts
@@ -58,6 +58,11 @@ type WorkerCheckResult = {
   redactedFindings?: string[];
 };
 
+type ProcessAttemptResult = {
+  completed: boolean;
+  result?: unknown;
+};
+
 type PrePublicationWorkerClient = Pick<ConvexHttpClient, "action">;
 
 type TruffleHogResult = WorkerCheckResult & {
@@ -341,16 +346,34 @@ async function runSkillSpectorIfApplicable(job: ClaimedJob, workspace: string) {
 function clawHubReviewCheckResult(llmAnalysis: StoredLlmAnalysis): WorkerCheckResult {
   const status = (llmAnalysis.status || llmAnalysis.verdict || "").trim().toLowerCase();
   const verdict = (llmAnalysis.verdict || "").trim().toLowerCase();
-  const isClean = status === "clean" || verdict === "benign";
+  const normalizedVerdict = verdict || status;
   const summary = publicText(
     llmAnalysis.summary ??
       llmAnalysis.findings ??
       `ClawHub security review returned ${llmAnalysis.status}.`,
   );
-  if (isClean) {
+  if (status === "clean" || normalizedVerdict === "benign") {
     return {
       status: "clean",
       summary: summary || "ClawHub security review passed.",
+    };
+  }
+  if (normalizedVerdict === "suspicious") {
+    return {
+      status: "clean",
+      summary: summary || "ClawHub security review requires user attention.",
+      redactedFindings: [
+        publicText(`status=${llmAnalysis.status}; verdict=${llmAnalysis.verdict}`),
+      ],
+    };
+  }
+  if (normalizedVerdict !== "malicious") {
+    return {
+      status: "failed",
+      summary: summary || "ClawHub security review did not return a final verdict.",
+      redactedFindings: [
+        publicText(`status=${llmAnalysis.status}; verdict=${llmAnalysis.verdict}`),
+      ],
     };
   }
   return {
@@ -376,6 +399,7 @@ async function completeAttempt(
   attempt: ClaimedPrePublicationAttempt,
   trufflehog: WorkerCheckResult,
   clawscan: WorkerCheckResult,
+  clawscanAnalysis?: StoredLlmAnalysis,
 ) {
   return await client.action(api.publishAttempts.completePrePublicationChecks, {
     token,
@@ -384,6 +408,7 @@ async function completeAttempt(
     artifactFingerprint: attempt.artifactFingerprint,
     trufflehog: checkResultForConvex(trufflehog),
     clawscan: checkResultForConvex(clawscan),
+    ...(clawscanAnalysis ? { clawscanAnalysis } : {}),
   });
 }
 
@@ -438,12 +463,14 @@ export async function processPrePublicationAttempt(
   const runTruffleHog = deps.runTruffleHog ?? runNativeTruffleHog;
   const runClawHubReview = deps.runClawHubReview ?? runNormalClawHubReview;
   let truffleHogBlocked = false;
+  let completionStarted = false;
   try {
     const job = buildSyntheticScanJob(attempt);
     await writeWorkspace(job, workspace);
     const trufflehog = await runTruffleHog(workspace);
     if (trufflehog.status === "blocked") {
       truffleHogBlocked = true;
+      completionStarted = true;
       const result = await completeAttempt(client, token, attempt, trufflehog, {
         status: "failed",
         summary: "ClawHub security review skipped because TruffleHog blocked the artifact.",
@@ -461,6 +488,7 @@ export async function processPrePublicationAttempt(
       return { completed: true, result };
     }
     if (trufflehog.status === "failed") {
+      completionStarted = true;
       const result = await completeAttempt(client, token, attempt, trufflehog, {
         status: "failed",
         summary: "ClawHub security review skipped because TruffleHog failed.",
@@ -469,8 +497,10 @@ export async function processPrePublicationAttempt(
     }
 
     let clawscan: WorkerCheckResult;
+    let clawscanAnalysis: StoredLlmAnalysis | undefined;
     try {
       const review = await runClawHubReview(job, workspace);
+      clawscanAnalysis = review.llmAnalysis;
       clawscan = clawHubReviewCheckResult(review.llmAnalysis);
     } catch (error) {
       clawscan = {
@@ -479,7 +509,15 @@ export async function processPrePublicationAttempt(
       };
     }
 
-    const result = await completeAttempt(client, token, attempt, trufflehog, clawscan);
+    completionStarted = true;
+    const result = await completeAttempt(
+      client,
+      token,
+      attempt,
+      trufflehog,
+      clawscan,
+      clawscanAnalysis,
+    );
     logger.info(
       {
         attemptId: attempt.attemptId,
@@ -491,7 +529,8 @@ export async function processPrePublicationAttempt(
       },
       "pre-publication attempt completed",
     );
-    return { completed: trufflehog.status === "clean" && clawscan.status === "clean", result };
+    const status = (result as { status?: string })?.status;
+    return { completed: status === "finalized" || status === "blocked", result };
   } catch (error) {
     if (truffleHogBlocked) {
       logger.error(
@@ -505,11 +544,37 @@ export async function processPrePublicationAttempt(
       );
       return { completed: false, result: undefined };
     }
+    if (completionStarted) {
+      logger.warn(
+        {
+          attemptId: attempt.attemptId,
+          durationMs: Date.now() - startedAt,
+          event: "prepublication_attempt_completion_failed",
+          kind: attempt.kind,
+        },
+        "pre-publication attempt completion failed; leaving attempt retryable",
+      );
+      return { completed: false, result: undefined };
+    }
     const failure = {
       status: "failed" as const,
       summary: publicText(error instanceof Error ? error.message : String(error)),
     };
-    const result = await completeAttempt(client, token, attempt, failure, failure);
+    let result: unknown;
+    try {
+      result = await completeAttempt(client, token, attempt, failure, failure);
+    } catch {
+      logger.warn(
+        {
+          attemptId: attempt.attemptId,
+          durationMs: Date.now() - startedAt,
+          event: "prepublication_attempt_failure_record_failed",
+          kind: attempt.kind,
+        },
+        "pre-publication attempt failure could not be recorded; leaving attempt retryable",
+      );
+      return { completed: false, result: undefined };
+    }
     logger.warn(
       {
         attemptId: attempt.attemptId,
@@ -523,6 +588,29 @@ export async function processPrePublicationAttempt(
   } finally {
     await rm(workspace, { force: true, recursive: true });
   }
+}
+
+export async function processPrePublicationBatch(
+  attempts: ClaimedPrePublicationAttempt[],
+  processAttempt: (attempt: ClaimedPrePublicationAttempt) => Promise<ProcessAttemptResult>,
+) {
+  return await Promise.all(
+    attempts.map(async (attempt) => {
+      try {
+        return await processAttempt(attempt);
+      } catch {
+        logger.warn(
+          {
+            attemptId: attempt.attemptId,
+            event: "prepublication_attempt_unhandled_failure",
+            kind: attempt.kind,
+          },
+          "pre-publication attempt failed unexpectedly; continuing batch",
+        );
+        return { completed: false, result: undefined };
+      }
+    }),
+  );
 }
 
 export async function claimPrePublicationAttempt(
@@ -570,8 +658,8 @@ async function main() {
     ).filter((attempt): attempt is ClaimedPrePublicationAttempt => Boolean(attempt));
     if (attempts.length === 0) break;
     totalClaimed += attempts.length;
-    const results = await Promise.all(
-      attempts.map((attempt) => processPrePublicationAttempt(client, token, attempt)),
+    const results = await processPrePublicationBatch(attempts, (attempt) =>
+      processPrePublicationAttempt(client, token, attempt),
     );
     totalCompleted += results.filter((result) => result.completed).length;
     if (attempts.length < Math.min(batchLimit, remainingJobs)) break;


### PR DESCRIPTION
## Summary

- keep staged publishing disabled while fixing suspicious/malicious/secret status handling
- carry ClawScan analysis into the same publish transaction, keep scanner failures retryable, and isolate per-attempt finalization failures
- add a resumable `@convex-dev/migrations` recovery for the suspicious-blocked production cohort with dry-run and explicit confirmation
- reconcile occupied-version conflicts as terminal failures instead of crashing worker shards

## Production safety

- `CLAWHUB_STAGED_PREPUBLICATION_PUBLISHES` remains `0`
- `.github/workflows/prepublication-publish-checks.yml` remains manually disabled
- migration apply requires `confirm="recover-suspicious-publish-attempts"`
- verified-secret payload deletion remains unchanged; malicious private evidence is retained

## Validation

- `bun run ci:static`
- `bun run ci:unit` (4,439 passed, 1 skipped)
- `bun run ci:types-build`
- `bun run ci:packages`
- `bun run ci:e2e-http`
- local Convex `bunx convex dev --once --typecheck=disable`
- local migration dry run via `migrations:runSuspiciousPublishAttemptRecovery`
- local-auth Playwright publish matrix: 7 passed (clean skill/plugin, suspicious public, malicious private, verified-secret private)
- autoreview clean, no accepted/actionable findings

Linear: CLAW-480
