### PR TITLE
fix: match exact recovery verdict markers

### DIFF
--- a/convex/migrations.publishAttempts.test.ts
+++ b/convex/migrations.publishAttempts.test.ts
@@ -48,6 +48,20 @@ describe("suspicious publish attempt recovery", () => {
             trufflehog: { status: "clean" },
             clawscan: {
               status: "blocked",
+              summary: "No malicious behavior was confirmed, but review is required.",
+              redactedFindings: ["status=completed; verdict=suspicious"],
+            },
+          },
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      hasStoredSuspiciousClawscanVerdict(
+        suspiciousAttempt({
+          checks: {
+            trufflehog: { status: "clean" },
+            clawscan: {
+              status: "blocked",
               redactedFindings: ["status=completed; verdict=malicious"],
             },
           },

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -118,7 +118,10 @@ export function hasStoredSuspiciousClawscanVerdict(attempt: Doc<"publishAttempts
     .filter((value): value is string => Boolean(value))
     .join(" ")
     .toLowerCase();
-  return storedReviewText.includes("verdict=suspicious") && !storedReviewText.includes("malicious");
+  return (
+    storedReviewText.includes("verdict=suspicious") &&
+    !storedReviewText.includes("verdict=malicious")
+  );
 }
 
 async function classifySuspiciousPublishAttemptPublicState(


### PR DESCRIPTION
## Summary

- match exact `verdict=malicious` recovery markers instead of excluding any suspicious summary containing the word malicious
- cover suspicious summaries such as "no malicious behavior"

## Validation

- `bunx vitest run convex/migrations.publishAttempts.test.ts`
- `bunx tsc --noEmit -p tsconfig.json --pretty false`
- `bun run ci:static`
- autoreview clean

Follow-up to #2994 for CLAW-480 production dry-run reconciliation.
