### PR TITLE
fix: add recovery runner fallback

### DIFF
--- a/.github/workflows/prepublication-publish-checks.yml
+++ b/.github/workflows/prepublication-publish-checks.yml
@@ -15,6 +15,14 @@ on:
         description: "Stop claiming new attempts after this many minutes"
         required: true
         default: "8"
+      runner:
+        description: "Runner label for manual recovery dispatches"
+        required: true
+        default: "blacksmith-8vcpu-ubuntu-2404"
+        type: choice
+        options:
+          - "blacksmith-8vcpu-ubuntu-2404"
+          - "ubuntu-latest"
   schedule:
     - cron: "*/5 * * * *"
 
@@ -28,7 +36,7 @@ concurrency:
 jobs:
   prepublication-publish-checks:
     name: Pre-publication publish checks shard ${{ matrix.shard }}
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ${{ inputs.runner || 'blacksmith-8vcpu-ubuntu-2404' }}
     timeout-minutes: 20
     environment: Production
     strategy:

--- a/scripts/security/prepublication-worker-workflow.test.ts
+++ b/scripts/security/prepublication-worker-workflow.test.ts
@@ -29,19 +29,39 @@ describe("pre-publication publish worker workflow", () => {
           concurrency?: unknown;
           env?: Record<string, unknown>;
           environment?: string;
+          "runs-on"?: string;
           steps: WorkflowStep[];
           strategy?: { matrix?: { shard?: number[] }; "max-parallel"?: number };
           "timeout-minutes"?: number;
         };
       };
-      on?: { schedule?: Array<{ cron?: string }>; workflow_dispatch?: unknown };
+      on?: {
+        schedule?: Array<{ cron?: string }>;
+        workflow_dispatch?: {
+          inputs?: {
+            runner?: {
+              default?: string;
+              options?: string[];
+              type?: string;
+            };
+          };
+        };
+      };
     };
 
     const job = workflow.jobs["prepublication-publish-checks"];
     const steps = job.steps;
     expect(workflow.on?.schedule?.[0]?.cron).toBe("*/5 * * * *");
     expect(workflow.on?.workflow_dispatch).toBeDefined();
+    expect(workflow.on?.workflow_dispatch?.inputs?.runner).toEqual({
+      description: "Runner label for manual recovery dispatches",
+      required: true,
+      default: "blacksmith-8vcpu-ubuntu-2404",
+      type: "choice",
+      options: ["blacksmith-8vcpu-ubuntu-2404", "ubuntu-latest"],
+    });
     expect(job.environment).toBe("Production");
+    expect(job["runs-on"]).toBe("${{ inputs.runner || 'blacksmith-8vcpu-ubuntu-2404' }}");
     expect(job["timeout-minutes"]).toBe(20);
     expect(job.strategy?.matrix?.shard).toEqual([0, 1]);
     expect(job.strategy?.["max-parallel"]).toBe(2);


### PR DESCRIPTION
## Summary

- allow manual prepublication worker dispatches to select `ubuntu-latest`
- preserve Blacksmith as the default for scheduled and normal manual runs
- lock the fallback contract in the workflow test

This is an operational fallback for CLAW-480 while GitHub's runner broker is leaving the Blacksmith recovery canary unassigned. Staged publishing remains disabled.

## Validation

- `actionlint .github/workflows/prepublication-publish-checks.yml`
- `bun test scripts/security/prepublication-worker-workflow.test.ts`
- `bun run format:check -- .github/workflows/prepublication-publish-checks.yml scripts/security/prepublication-worker-workflow.test.ts`
- autoreview: clean
