### PR TITLE
fix: prioritize publish finalization retries

### DIFF
--- a/convex/publishAttempts.test.ts
+++ b/convex/publishAttempts.test.ts
@@ -1,7 +1,9 @@
+import { getFunctionName } from "convex/server";
 import { describe, expect, it, vi } from "vitest";
 import {
   claimPendingPublishAttemptChecksInternal,
   claimPrePublicationChecks,
+  claimReadyPublishAttemptFinalizationRetryInternal,
   completePendingPublishAttemptChecksInternal,
 } from "./publishAttempts";
 
@@ -12,6 +14,11 @@ const claimPendingChecksHandler = (
 )._handler;
 const completePendingChecksHandler = (
   completePendingPublishAttemptChecksInternal as unknown as {
+    _handler: (ctx: unknown, args: unknown) => Promise<unknown>;
+  }
+)._handler;
+const claimReadyFinalizationHandler = (
+  claimReadyPublishAttemptFinalizationRetryInternal as unknown as {
     _handler: (ctx: unknown, args: unknown) => Promise<unknown>;
   }
 )._handler;
@@ -147,27 +154,24 @@ describe("publishAttempts", () => {
     expect(ctx.storage.getUrl).toHaveBeenCalledWith("_storage:clawpack");
   });
 
-  it("claims ready-to-finalize attempts for idempotent finalization retry", async () => {
+  it("prioritizes ready-to-finalize attempts over pending scanner work", async () => {
     const previousToken = process.env.SECURITY_SCAN_WORKER_TOKEN;
     process.env.SECURITY_SCAN_WORKER_TOKEN = "worker-token";
     const ctx = {
-      runMutation: vi
-        .fn()
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce({
-          attemptId: "publishAttempts:ready",
-          status: "ready_to_finalize",
-          claimId: "claim-1",
-          kind: "skill",
-          userId: "users:publisher",
-          slug: "demo-skill",
-          displayName: "Demo Skill",
-          version: "1.0.0",
-          artifactFingerprint: "fingerprint",
-          files: [],
-          checkClaimExpiresAt: Date.now() + 60_000,
-          createdAt: Date.now(),
-        }),
+      runMutation: vi.fn().mockResolvedValueOnce({
+        attemptId: "publishAttempts:ready",
+        status: "ready_to_finalize",
+        claimId: "claim-1",
+        kind: "skill",
+        userId: "users:publisher",
+        slug: "demo-skill",
+        displayName: "Demo Skill",
+        version: "1.0.0",
+        artifactFingerprint: "fingerprint",
+        files: [],
+        checkClaimExpiresAt: Date.now() + 60_000,
+        createdAt: Date.now(),
+      }),
       storage: {
         getUrl: vi.fn(),
       },
@@ -186,8 +190,101 @@ describe("publishAttempts", () => {
       else process.env.SECURITY_SCAN_WORKER_TOKEN = previousToken;
     }
 
-    expect(ctx.runMutation).toHaveBeenCalledTimes(2);
+    expect(ctx.runMutation).toHaveBeenCalledTimes(1);
+    expect(
+      getFunctionName(ctx.runMutation.mock.calls[0]?.[0] as Parameters<typeof getFunctionName>[0]),
+    ).toBe("publishAttempts:claimReadyPublishAttemptFinalizationRetryInternal");
     expect(ctx.storage.getUrl).not.toHaveBeenCalled();
+  });
+
+  it("lets targeted pending attempts fall through the ready-finalization lookup", async () => {
+    const ctx = {
+      db: {
+        delete: vi.fn(),
+        get: vi.fn(async () => ({
+          _id: "publishAttempts:pending",
+          status: "pending_checks",
+        })),
+        insert: vi.fn(),
+        normalizeId: vi.fn(),
+        patch: vi.fn(),
+        query: vi.fn(),
+        replace: vi.fn(),
+        system: {},
+      },
+    };
+
+    await expect(
+      claimReadyFinalizationHandler(ctx, {
+        attemptId: "publishAttempts:pending",
+        claimId: "claim-1",
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("skips ready-to-finalize attempts with an active retry lease", async () => {
+    const ctx = {
+      db: {
+        delete: vi.fn(),
+        get: vi.fn(),
+        insert: vi.fn(),
+        normalizeId: vi.fn(),
+        patch: vi.fn(),
+        query: vi.fn(() => ({
+          withIndex: vi.fn(() => ({
+            order: vi.fn(() => ({
+              take: vi.fn(async () => [
+                {
+                  _id: "publishAttempts:ready",
+                  status: "ready_to_finalize",
+                  checkClaimId: "existing-claim",
+                  checkClaimExpiresAt: Date.now() + 60_000,
+                },
+              ]),
+            })),
+          })),
+        })),
+        replace: vi.fn(),
+        system: {},
+      },
+    };
+
+    await expect(
+      claimReadyFinalizationHandler(ctx, {
+        claimId: "new-claim",
+      }),
+    ).resolves.toBeNull();
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+  });
+
+  it("rejects targeted ready-finalization claims with mismatched filters", async () => {
+    const ctx = {
+      db: {
+        delete: vi.fn(),
+        get: vi.fn(async () => ({
+          _id: "publishAttempts:ready",
+          status: "ready_to_finalize",
+          kind: "skill",
+          slug: "expected-skill",
+          version: "1.0.0",
+        })),
+        insert: vi.fn(),
+        normalizeId: vi.fn(),
+        patch: vi.fn(),
+        query: vi.fn(),
+        replace: vi.fn(),
+        system: {},
+      },
+    };
+
+    await expect(
+      claimReadyFinalizationHandler(ctx, {
+        attemptId: "publishAttempts:ready",
+        claimId: "claim-1",
+        slug: "different-skill",
+      }),
+    ).rejects.toThrow("Publish attempt slug does not match worker claim.");
+    expect(ctx.db.patch).not.toHaveBeenCalled();
   });
 
   it("lets worker completion retries reclaim expired finalization leases", async () => {

--- a/convex/publishAttempts.ts
+++ b/convex/publishAttempts.ts
@@ -537,6 +537,7 @@ export const claimReadyPublishAttemptFinalizationRetryInternal = internalMutatio
             .order("asc")
             .take(25)
         ).find((candidate) => {
+          if ((candidate.checkClaimExpiresAt ?? 0) > now) return false;
           if (args.kind && candidate.kind !== args.kind) return false;
           if (args.slug && candidate.slug !== args.slug) return false;
           if (args.version && candidate.version !== args.version) return false;
@@ -545,10 +546,19 @@ export const claimReadyPublishAttemptFinalizationRetryInternal = internalMutatio
 
     if (!attempt) return null;
     if (attempt.status !== "ready_to_finalize") {
-      if (args.attemptId) {
-        throw new ConvexError(`Publish attempt is ${attempt.status}, not ready to finalize.`);
-      }
       return null;
+    }
+    if (args.kind && attempt.kind !== args.kind) {
+      throw new ConvexError("Publish attempt kind does not match worker claim.");
+    }
+    if (args.slug && attempt.slug !== args.slug) {
+      throw new ConvexError("Publish attempt slug does not match worker claim.");
+    }
+    if (args.version && attempt.version !== args.version) {
+      throw new ConvexError("Publish attempt version does not match worker claim.");
+    }
+    if ((attempt.checkClaimExpiresAt ?? 0) > now && attempt.checkClaimId !== args.claimId) {
+      throw new ConvexError("Publish attempt finalization retry is already claimed.");
     }
 
     await ctx.db.patch(attempt._id, {
@@ -864,11 +874,11 @@ export const claimPrePublicationChecks: ReturnType<typeof action> = action({
       version: args.version,
     };
     const claimed = ((await ctx.runMutation(
-      internal.publishAttempts.claimPendingPublishAttemptChecksInternal,
+      internal.publishAttempts.claimReadyPublishAttemptFinalizationRetryInternal,
       claimArgs,
     )) ??
       (await ctx.runMutation(
-        internal.publishAttempts.claimReadyPublishAttemptFinalizationRetryInternal,
+        internal.publishAttempts.claimPendingPublishAttemptChecksInternal,
         claimArgs,
       ))) as null | {
       attemptId: Id<"publishAttempts">;


### PR DESCRIPTION
## Summary

- prioritize already-scanned `ready_to_finalize` publish attempts before new scanner work
- make finalization retry claims lease-aware so a failing attempt cannot monopolize workers
- preserve targeted pending-attempt fallback and enforce kind/slug/version filters

This lets the CLAW-480 repaired queue finalize promptly without starving pending scans or rerunning scanners.

## Validation

- `bun test convex/publishAttempts.test.ts scripts/security/run-prepublication-worker.test.ts` (25 passed)
- `bun run ci:static`
- `VITE_CONVEX_URL=https://example.invalid bun run coverage` (4,442 passed, 1 skipped)
- `bun run ci:types-build`
- autoreview: clean after resolving all accepted findings

The checkout's anonymous local Convex deployment is no longer linked, so the real Convex runtime proof will be the bounded production worker canary immediately after backend deployment.
