### PR TITLE
fix: harden prepublication queue drain

### DIFF
--- a/convex/publishAttempts.test.ts
+++ b/convex/publishAttempts.test.ts
@@ -5,6 +5,8 @@ import {
   claimPrePublicationChecks,
   claimReadyPublishAttemptFinalizationRetryInternal,
   completePendingPublishAttemptChecksInternal,
+  releasePackagePublishAttemptFinalizationClaimInternal,
+  releaseSkillPublishAttemptFinalizationClaimInternal,
 } from "./publishAttempts";
 
 const claimPendingChecksHandler = (
@@ -24,6 +26,16 @@ const claimReadyFinalizationHandler = (
 )._handler;
 const claimPrePublicationChecksHandler = (
   claimPrePublicationChecks as unknown as {
+    _handler: (ctx: unknown, args: unknown) => Promise<unknown>;
+  }
+)._handler;
+const releaseSkillFinalizationHandler = (
+  releaseSkillPublishAttemptFinalizationClaimInternal as unknown as {
+    _handler: (ctx: unknown, args: unknown) => Promise<unknown>;
+  }
+)._handler;
+const releasePackageFinalizationHandler = (
+  releasePackagePublishAttemptFinalizationClaimInternal as unknown as {
     _handler: (ctx: unknown, args: unknown) => Promise<unknown>;
   }
 )._handler;
@@ -291,6 +303,7 @@ describe("publishAttempts", () => {
     const now = Date.now();
     const ctx = {
       db: {
+        delete: vi.fn(),
         get: vi.fn(async () => ({
           _id: "publishAttempts:demo",
           kind: "skill",
@@ -301,7 +314,6 @@ describe("publishAttempts", () => {
         patch: vi.fn(),
         insert: vi.fn(),
         replace: vi.fn(),
-        delete: vi.fn(),
         query: vi.fn(),
         normalizeId: vi.fn(),
         system: {},
@@ -384,6 +396,116 @@ describe("publishAttempts", () => {
     );
     const patch = ctx.db.patch.mock.calls[0]?.[1] as { checkClaimExpiresAt: number };
     expect(patch.checkClaimExpiresAt).toBeGreaterThan(now);
+  });
+
+  it("terminalizes duplicate skill versions instead of retrying finalization", async () => {
+    const ctx = {
+      db: {
+        delete: vi.fn(),
+        get: vi.fn(async () => ({
+          _id: "publishAttempts:demo",
+          kind: "skill",
+          status: "finalizing",
+          skillInsertArgs: { slug: "demo-skill", version: "1.0.0" },
+          followup: {},
+          finalizationClaimId: "finalize:claim",
+        })),
+        insert: vi.fn(),
+        normalizeId: vi.fn(),
+        patch: vi.fn(),
+        query: vi.fn(),
+        replace: vi.fn(),
+        system: {},
+      },
+    };
+    const error =
+      "Uncaught ConvexError: Version 1.0.0 already exists. Increment the version number and try again.";
+
+    await expect(
+      releaseSkillFinalizationHandler(ctx, {
+        attemptId: "publishAttempts:demo",
+        claimId: "finalize:claim",
+        error,
+      }),
+    ).resolves.toEqual({ attemptId: "publishAttempts:demo", status: "failed" });
+
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "publishAttempts:demo",
+      expect.objectContaining({
+        status: "failed",
+        checkClaimId: undefined,
+        finalizationClaimId: undefined,
+        finalizationLastError: error,
+        failedAt: expect.any(Number),
+      }),
+    );
+  });
+
+  it("terminalizes duplicate package versions while preserving transient retries", async () => {
+    const duplicateCtx = {
+      db: {
+        delete: vi.fn(),
+        get: vi.fn(async () => ({
+          _id: "publishAttempts:demo-package",
+          kind: "package",
+          status: "finalizing",
+          packageInsertArgs: { name: "@demo/plugin", version: "1.0.0" },
+          finalizationClaimId: "finalize:claim",
+        })),
+        insert: vi.fn(),
+        normalizeId: vi.fn(),
+        patch: vi.fn(),
+        query: vi.fn(),
+        replace: vi.fn(),
+        system: {},
+      },
+    };
+    const duplicateError =
+      "Version 1.0.0 already exists. Increment the version number and try again.";
+
+    await expect(
+      releasePackageFinalizationHandler(duplicateCtx, {
+        attemptId: "publishAttempts:demo-package",
+        claimId: "finalize:claim",
+        error: duplicateError,
+      }),
+    ).resolves.toEqual({ attemptId: "publishAttempts:demo-package", status: "failed" });
+
+    const transientCtx = {
+      db: {
+        delete: vi.fn(),
+        get: vi.fn(async () => ({
+          _id: "publishAttempts:retry",
+          kind: "skill",
+          status: "finalizing",
+          skillInsertArgs: { slug: "demo-skill", version: "1.0.1" },
+          followup: {},
+          finalizationClaimId: "finalize:retry",
+        })),
+        insert: vi.fn(),
+        normalizeId: vi.fn(),
+        patch: vi.fn(),
+        query: vi.fn(),
+        replace: vi.fn(),
+        system: {},
+      },
+    };
+
+    await expect(
+      releaseSkillFinalizationHandler(transientCtx, {
+        attemptId: "publishAttempts:retry",
+        claimId: "finalize:retry",
+        error: "Rate limit exceeded",
+      }),
+    ).resolves.toEqual({ attemptId: "publishAttempts:retry", status: "ready_to_finalize" });
+    expect(transientCtx.db.patch).toHaveBeenCalledWith(
+      "publishAttempts:retry",
+      expect.objectContaining({
+        status: "ready_to_finalize",
+        finalizationLastError: "Rate limit exceeded",
+      }),
+    );
+    expect(transientCtx.db.patch.mock.calls[0]?.[1]).not.toHaveProperty("failedAt");
   });
 
   it("stores suspicious analysis with the staged insert before finalization", async () => {

--- a/convex/publishAttempts.ts
+++ b/convex/publishAttempts.ts
@@ -82,6 +82,39 @@ function scannerFailureSummary(args: {
   return "Pre-publication scanner failed before returning a verdict.";
 }
 
+function isTerminalVersionConflict(error: string | undefined) {
+  return (
+    typeof error === "string" &&
+    /Version .+ already exists\. Increment the version number and try again\./.test(error)
+  );
+}
+
+function releaseFinalizationClaimPatch(error: string | undefined, now: number) {
+  if (!isTerminalVersionConflict(error)) {
+    return {
+      status: "ready_to_finalize" as const,
+      finalizationClaimId: undefined,
+      finalizationClaimedAt: undefined,
+      finalizationClaimExpiresAt: undefined,
+      finalizationLastError: error,
+      updatedAt: now,
+    };
+  }
+  return {
+    status: "failed" as const,
+    checkClaimId: undefined,
+    checkClaimedAt: undefined,
+    checkClaimExpiresAt: undefined,
+    checkClaimLastError: undefined,
+    finalizationClaimId: undefined,
+    finalizationClaimedAt: undefined,
+    finalizationClaimExpiresAt: undefined,
+    finalizationLastError: error,
+    failedAt: now,
+    updatedAt: now,
+  };
+}
+
 export const createSkillPublishAttemptInternal = internalMutation({
   args: {
     userId: v.id("users"),
@@ -683,15 +716,9 @@ export const releaseSkillPublishAttemptFinalizationClaimInternal = internalMutat
       return { attemptId: attempt._id, status: attempt.status };
     }
 
-    await ctx.db.patch(attempt._id, {
-      status: "ready_to_finalize",
-      finalizationClaimId: undefined,
-      finalizationClaimedAt: undefined,
-      finalizationClaimExpiresAt: undefined,
-      finalizationLastError: args.error,
-      updatedAt: Date.now(),
-    });
-    return { attemptId: attempt._id, status: "ready_to_finalize" as const };
+    const patch = releaseFinalizationClaimPatch(args.error, Date.now());
+    await ctx.db.patch(attempt._id, patch);
+    return { attemptId: attempt._id, status: patch.status };
   },
 });
 
@@ -707,15 +734,9 @@ export const releasePackagePublishAttemptFinalizationClaimInternal = internalMut
       return { attemptId: attempt._id, status: attempt.status };
     }
 
-    await ctx.db.patch(attempt._id, {
-      status: "ready_to_finalize",
-      finalizationClaimId: undefined,
-      finalizationClaimedAt: undefined,
-      finalizationClaimExpiresAt: undefined,
-      finalizationLastError: args.error,
-      updatedAt: Date.now(),
-    });
-    return { attemptId: attempt._id, status: "ready_to_finalize" as const };
+    const patch = releaseFinalizationClaimPatch(args.error, Date.now());
+    await ctx.db.patch(attempt._id, patch);
+    return { attemptId: attempt._id, status: patch.status };
   },
 });
 

--- a/scripts/security/run-prepublication-worker.test.ts
+++ b/scripts/security/run-prepublication-worker.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Id } from "../../convex/_generated/dataModel";
 import {
+  claimPrePublicationBatch,
   configurePrePublicationCodexHome,
   processPrePublicationBatch,
   processPrePublicationAttempt,
@@ -202,6 +203,31 @@ describe("pre-publication worker", () => {
       processPrePublicationBatch([attempt, laterAttempt], processAttempt),
     ).resolves.toEqual([{ completed: false, result: undefined }, { completed: true }]);
     expect(processAttempt).toHaveBeenCalledTimes(2);
+  });
+
+  it("continues with successful claims when a concurrent claim fails", async () => {
+    const client = {
+      action: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("claim conflict"))
+        .mockResolvedValueOnce(attempt),
+    };
+
+    await expect(claimPrePublicationBatch(client, "worker-token", 2)).resolves.toEqual([attempt]);
+    expect(client.action).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails the worker batch when claims fail without claiming work", async () => {
+    const client = {
+      action: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("claim conflict"))
+        .mockResolvedValueOnce(null),
+    };
+
+    await expect(claimPrePublicationBatch(client, "worker-token", 2)).rejects.toThrow(
+      "Pre-publication claims failed without claiming work.",
+    );
   });
 
   it("blocks secret-positive attempts without running ClawHub review", async () => {

--- a/scripts/security/run-prepublication-worker.ts
+++ b/scripts/security/run-prepublication-worker.ts
@@ -622,6 +622,33 @@ export async function claimPrePublicationAttempt(
   })) as ClaimedPrePublicationAttempt | null;
 }
 
+export async function claimPrePublicationBatch(
+  client: PrePublicationWorkerClient,
+  token: string,
+  limit: number,
+) {
+  const claims = await Promise.allSettled(
+    Array.from({ length: limit }, () => claimPrePublicationAttempt(client, token)),
+  );
+  const attempts: ClaimedPrePublicationAttempt[] = [];
+  const failures: unknown[] = [];
+  for (const claim of claims) {
+    if (claim.status === "fulfilled") {
+      if (claim.value) attempts.push(claim.value);
+      continue;
+    }
+    failures.push(claim.reason);
+    logger.warn(
+      { event: "prepublication_claim_failed" },
+      "pre-publication claim failed; continuing with successful claims",
+    );
+  }
+  if (attempts.length === 0 && failures.length > 0) {
+    throw new AggregateError(failures, "Pre-publication claims failed without claiming work.");
+  }
+  return attempts;
+}
+
 async function main() {
   const { batchLimit, maxJobs, maxRuntimeMs } = parseArgs();
   assertCodexWorkerExecutionAllowed(process.env);
@@ -649,13 +676,11 @@ async function main() {
     if (totalClaimed > 0 && claimDeadline - Date.now() < CLAIM_WINDOW_SHUTDOWN_BUFFER_MS) break;
     const remainingJobs = maxJobs === undefined ? batchLimit : Math.max(0, maxJobs - totalClaimed);
     if (remainingJobs === 0) break;
-    const attempts = (
-      await Promise.all(
-        Array.from({ length: Math.min(batchLimit, remainingJobs) }, () =>
-          claimPrePublicationAttempt(client, token),
-        ),
-      )
-    ).filter((attempt): attempt is ClaimedPrePublicationAttempt => Boolean(attempt));
+    const attempts = await claimPrePublicationBatch(
+      client,
+      token,
+      Math.min(batchLimit, remainingJobs),
+    );
     if (attempts.length === 0) break;
     totalClaimed += attempts.length;
     const results = await processPrePublicationBatch(attempts, (attempt) =>


### PR DESCRIPTION
## Summary
- isolate concurrent prepublication claim failures so one OCC conflict does not terminate a shard
- fail visibly when claims fail and no work can be claimed
- terminalize exact duplicate-version finalization conflicts while preserving retries for transient errors

## Production context
CLAW-480 queue recovery found shard crashes during concurrent claims and four confirmed public version conflicts repeatedly returning to `ready_to_finalize`. Staged publishing remains disabled; this change only hardens rollback queue draining.

## Validation
- `bunx vitest run scripts/security/run-prepublication-worker.test.ts convex/publishAttempts.test.ts`
- `bun run ci:static`
- `VITE_CONVEX_URL=https://example.invalid bun run ci:unit` (4,446 passed, 1 skipped)
- `bun run ci:types-build`
- `bunx tsc -p tsconfig.json --noEmit`
- `$autoreview` clean
