### PR TITLE
fix: bypass replay rate limits for incident cohort

### DIFF
--- a/convex/lib/skillPublish.test.ts
+++ b/convex/lib/skillPublish.test.ts
@@ -511,6 +511,7 @@ description: Security scanner smoke fixture.
         return {
           status: "claimed",
           attemptId: "publishAttempts:security-scanner-smoke",
+          createdAt: Date.parse("2026-07-07T15:00:00Z"),
           skillInsertArgs: insertArgs,
           followup: {
             skipWebhook: true,
@@ -555,7 +556,10 @@ description: Security scanner smoke fixture.
       versionId: "skillVersions:demo",
       embeddingId: "skillEmbeddings:demo",
     });
-    expect(runMutation).toHaveBeenCalledWith(expect.anything(), insertArgs);
+    expect(runMutation).toHaveBeenCalledWith(expect.anything(), {
+      ...insertArgs,
+      bypassNewSkillRateLimit: true,
+    });
     expect(scheduler.runAfter).toHaveBeenCalledWith(0, expect.anything(), {
       versionId: "skillVersions:demo",
     });
@@ -569,6 +573,24 @@ description: Security scanner smoke fixture.
       preserveActiveJob: true,
       preserveExistingJob: true,
     });
+  });
+
+  it("does not bypass new-skill limits for attempts created after the recovery cutoff", () => {
+    const insertArgs = {
+      userId: "users:1",
+      slug: "future-staged-skill",
+      version: "1.0.0",
+    };
+
+    expect(
+      __test.withStagedFinalizationRateLimitBypass(insertArgs, Date.parse("2026-07-07T15:27:10Z")),
+    ).toBe(insertArgs);
+    expect(
+      __test.withStagedFinalizationRateLimitBypass(
+        { ...insertArgs, bypassNewSkillRateLimit: true },
+        Date.parse("2026-07-07T15:27:10Z"),
+      ),
+    ).toEqual({ ...insertArgs, bypassNewSkillRateLimit: true });
   });
 
   it("releases the staged publish finalization claim when insertion fails", async () => {

--- a/convex/lib/skillPublish.ts
+++ b/convex/lib/skillPublish.ts
@@ -49,6 +49,8 @@ const QUALITY_WINDOW_MS = 24 * 60 * 60 * 1000;
 const QUALITY_ACTIVITY_LIMIT = 60;
 const PLATFORM_SKILL_LICENSE = "MIT-0" as const;
 const SECURITY_SCAN_ENQUEUE_BACKUP_DELAY_MS = 15_000;
+// Frozen after the CLAW-480 rollback snapshot. Remove after the incident cohort is drained.
+const CLAW_480_RECOVERY_ATTEMPT_CUTOFF_MS = Date.parse("2026-07-07T15:27:09Z");
 const MAX_PUBLISH_SUMMARY_LENGTH = 300;
 
 type FingerprintFile = { path: string; sha256: string };
@@ -548,6 +550,7 @@ export async function finalizeSkillPublishAttempt(
     | {
         status: "claimed";
         attemptId: Id<"publishAttempts">;
+        createdAt: number;
         skillInsertArgs: unknown;
         followup: SkillPublishFollowup;
       }
@@ -564,7 +567,10 @@ export async function finalizeSkillPublishAttempt(
 
   let publishResult: PublishResult;
   try {
-    const skillInsertArgs = await prepareSkillInsertArgsForFinalization(ctx, claim.skillInsertArgs);
+    const skillInsertArgs = withStagedFinalizationRateLimitBypass(
+      await prepareSkillInsertArgsForFinalization(ctx, claim.skillInsertArgs),
+      claim.createdAt,
+    );
     publishResult = (await ctx.runMutation(
       internal.skills.insertVersion,
       skillInsertArgs as never,
@@ -595,6 +601,22 @@ export async function finalizeSkillPublishAttempt(
   }
 
   return publishResult;
+}
+
+function withStagedFinalizationRateLimitBypass(rawInsertArgs: unknown, attemptCreatedAt: number) {
+  if (!rawInsertArgs || typeof rawInsertArgs !== "object" || Array.isArray(rawInsertArgs)) {
+    return rawInsertArgs;
+  }
+  if (
+    attemptCreatedAt > CLAW_480_RECOVERY_ATTEMPT_CUTOFF_MS &&
+    (rawInsertArgs as Record<string, unknown>).bypassNewSkillRateLimit !== true
+  ) {
+    return rawInsertArgs;
+  }
+  return {
+    ...rawInsertArgs,
+    bypassNewSkillRateLimit: true,
+  };
 }
 
 async function prepareSkillInsertArgsForFinalization(
@@ -821,6 +843,7 @@ export const __test = {
   toStructuralFingerprint,
   derivePublishFilesFromStorage,
   buildSkillPublishAttemptIdempotencyKey,
+  withStagedFinalizationRateLimitBypass,
 };
 
 export async function queueHighlightedWebhook(ctx: MutationCtx, skillId: Id<"skills">) {

--- a/convex/publishAttempts.ts
+++ b/convex/publishAttempts.ts
@@ -657,6 +657,7 @@ export const claimSkillPublishAttemptForFinalizationInternal = internalMutation(
     return {
       status: "claimed" as const,
       attemptId: attempt._id,
+      createdAt: attempt.createdAt,
       skillInsertArgs: attempt.skillInsertArgs,
       followup: buildSkillPublishFollowup(attempt),
     };
@@ -1057,6 +1058,7 @@ async function requireSkillPublishAttempt(
     version: string;
     displayName: string;
     artifactFingerprint: string;
+    createdAt: number;
     finalizationClaimId?: string;
     finalizationClaimExpiresAt?: number;
     result?: {


### PR DESCRIPTION
## Summary
- carry staged attempt creation time into skill finalization claims
- bypass new-skill rate limits only for the frozen CLAW-480 incident cohort created before the rollback snapshot
- preserve normal limits for future staged attempts and existing explicit bypass intent

## Production evidence
The bounded recovery run surfaced 20+ retryable finalization failures with `Rate limit: max 5 new skills per hour`. These attempts were already admitted while staged publishing was enabled, so applying the ordinary new-skill creation limit again prevents the historical queue from draining.

The recovery cutoff is `2026-07-07T15:27:09Z`, after the newest row in the redacted rollback snapshot. Staged publishing remains disabled. The temporary cutoff is marked for removal after the incident cohort is drained.

## Validation
- `bunx vitest run convex/lib/skillPublish.test.ts convex/publishAttempts.test.ts` (34 passed)
- `bun run ci:static`
- `VITE_CONVEX_URL=https://example.invalid bun run ci:unit` (4,446 passed, 1 skipped)
- `bun run ci:types-build`
- `bunx tsc -p tsconfig.json --noEmit`
- `$autoreview` clean
