### PR TITLE
fix: avoid repeated dashboard pagination

### DIFF
--- a/convex/skills.dashboard.test.ts
+++ b/convex/skills.dashboard.test.ts
@@ -84,9 +84,14 @@ function isPaginatedIndexPage(
 
 function makeCtx(
   indexPages: Record<string, IndexPage>,
-  options: { membership?: Record<string, unknown> | null; legacyPersonalPublisher?: boolean } = {},
+  options: {
+    membership?: Record<string, unknown> | null;
+    legacyPersonalPublisher?: boolean;
+    rejectMultiplePaginateCalls?: boolean;
+  } = {},
 ) {
   const indexCalls: string[] = [];
+  let paginateCalls = 0;
   const ctx = {
     db: {
       get: vi.fn(async (id: string) => {
@@ -163,6 +168,14 @@ function makeCtx(
                 order: vi.fn(() => ({
                   take: vi.fn().mockResolvedValue(takeRows),
                   paginate: vi.fn((paginationOpts: { cursor: string | null }) => {
+                    paginateCalls += 1;
+                    if (options.rejectMultiplePaginateCalls && paginateCalls > 1) {
+                      return Promise.reject(
+                        new Error(
+                          "This query or mutation function ran multiple paginated queries.",
+                        ),
+                      );
+                    }
                     if (isPaginatedIndexPage(indexPage)) {
                       const pageIndex = paginationOpts.cursor
                         ? Number(paginationOpts.cursor.replace("cursor:", ""))
@@ -280,27 +293,30 @@ describe("skills.listDashboardPaginated", () => {
     ]);
   });
 
-  it("continues personal dashboard pagination past other publisher-owned rows", async () => {
+  it("returns a filtered personal dashboard page without paginating twice", async () => {
     vi.mocked(getAuthUserId).mockResolvedValue("users:owner" as never);
-    const { ctx } = makeCtx({
-      by_owner_active_updated: [
-        {
-          page: [
-            makeSkill("team-hidden", {
-              ownerPublisherId: "publishers:org",
-              moderationStatus: "hidden",
-            }),
-          ],
-          isDone: false,
-          continueCursor: "cursor:1",
-        },
-        {
-          page: [makeSkill("legacy-skill")],
-          isDone: true,
-          continueCursor: "",
-        },
-      ],
-    });
+    const { ctx } = makeCtx(
+      {
+        by_owner_active_updated: [
+          {
+            page: [
+              makeSkill("team-hidden", {
+                ownerPublisherId: "publishers:org",
+                moderationStatus: "hidden",
+              }),
+            ],
+            isDone: false,
+            continueCursor: "cursor:1",
+          },
+          {
+            page: [makeSkill("legacy-skill")],
+            isDone: true,
+            continueCursor: "",
+          },
+        ],
+      },
+      { rejectMultiplePaginateCalls: true },
+    );
 
     const result = await handler(
       ctx as never,
@@ -310,36 +326,39 @@ describe("skills.listDashboardPaginated", () => {
       } as never,
     );
 
-    expect(result.page).toEqual([expect.objectContaining({ slug: "legacy-skill" })]);
-    expect(result.isDone).toBe(true);
-    expect(result.continueCursor).toBe("");
+    expect(result.page).toEqual([]);
+    expect(result.isDone).toBe(false);
+    expect(result.continueCursor).toBe("cursor:1");
   });
 
-  it("continues owner-user dashboard pagination past stale publisher-owned rows", async () => {
+  it("returns a filtered owner-user dashboard page without paginating twice", async () => {
     vi.mocked(getAuthUserId).mockResolvedValue("users:owner" as never);
-    const { ctx } = makeCtx({
-      by_owner_active_updated: [
-        {
-          page: [
-            makeSkill("other-personal-hidden", {
-              ownerPublisherId: "publishers:other-personal",
-              moderationStatus: "hidden",
-            }),
-            makeSkill("org-hidden", {
-              ownerPublisherId: "publishers:org",
-              moderationStatus: "hidden",
-            }),
-          ],
-          isDone: false,
-          continueCursor: "cursor:1",
-        },
-        {
-          page: [makeSkill("legacy-skill", { moderationStatus: "hidden" })],
-          isDone: true,
-          continueCursor: "",
-        },
-      ],
-    });
+    const { ctx } = makeCtx(
+      {
+        by_owner_active_updated: [
+          {
+            page: [
+              makeSkill("other-personal-hidden", {
+                ownerPublisherId: "publishers:other-personal",
+                moderationStatus: "hidden",
+              }),
+              makeSkill("org-hidden", {
+                ownerPublisherId: "publishers:org",
+                moderationStatus: "hidden",
+              }),
+            ],
+            isDone: false,
+            continueCursor: "cursor:1",
+          },
+          {
+            page: [makeSkill("legacy-skill", { moderationStatus: "hidden" })],
+            isDone: true,
+            continueCursor: "",
+          },
+        ],
+      },
+      { rejectMultiplePaginateCalls: true },
+    );
 
     const result = await handler(
       ctx as never,
@@ -349,9 +368,9 @@ describe("skills.listDashboardPaginated", () => {
       } as never,
     );
 
-    expect(result.page).toEqual([expect.objectContaining({ slug: "legacy-skill" })]);
-    expect(result.isDone).toBe(true);
-    expect(result.continueCursor).toBe("");
+    expect(result.page).toEqual([]);
+    expect(result.isDone).toBe(false);
+    expect(result.continueCursor).toBe("cursor:1");
   });
 
   it("includes linked-user legacy skills in non-owner personal publisher reads", async () => {

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -3893,40 +3893,26 @@ export const listDashboardPaginated = query({
           ? (ownerPublisher.linkedUserId ?? (isOwnDashboard ? userId : undefined))
           : undefined;
       const shouldIncludeLegacyPersonalSkills = Boolean(legacyPersonalOwnerUserId);
-      const paginateOwnerSkills = async (paginationOpts: typeof args.paginationOpts) =>
-        shouldIncludeLegacyPersonalSkills
-          ? await ctx.db
-              .query("skills")
-              .withIndex("by_owner_active_updated", (q) =>
-                q.eq("ownerUserId", legacyPersonalOwnerUserId!).eq("softDeletedAt", undefined),
-              )
-              .order("desc")
-              .paginate(paginationOpts)
-          : await ctx.db
-              .query("skills")
-              .withIndex("by_owner_publisher_active_updated", (q) =>
-                q.eq("ownerPublisherId", ownerPublisherId).eq("softDeletedAt", undefined),
-              )
-              .order("desc")
-              .paginate(paginationOpts);
-      let result = await paginateOwnerSkills(args.paginationOpts);
-      const scopePersonalDashboardPage = (page: Doc<"skills">[]) =>
-        shouldIncludeLegacyPersonalSkills
-          ? page.filter(
-              (skill) => !skill.ownerPublisherId || skill.ownerPublisherId === ownerPublisherId,
+      const result = shouldIncludeLegacyPersonalSkills
+        ? await ctx.db
+            .query("skills")
+            .withIndex("by_owner_active_updated", (q) =>
+              q.eq("ownerUserId", legacyPersonalOwnerUserId!).eq("softDeletedAt", undefined),
             )
-          : page;
-      const scopedPage = scopePersonalDashboardPage(result.page);
-      if (shouldIncludeLegacyPersonalSkills) {
-        while (!result.isDone && scopedPage.length < args.paginationOpts.numItems) {
-          result = await paginateOwnerSkills({
-            ...args.paginationOpts,
-            cursor: result.continueCursor,
-            numItems: args.paginationOpts.numItems - scopedPage.length,
-          });
-          scopedPage.push(...scopePersonalDashboardPage(result.page));
-        }
-      }
+            .order("desc")
+            .paginate(args.paginationOpts)
+        : await ctx.db
+            .query("skills")
+            .withIndex("by_owner_publisher_active_updated", (q) =>
+              q.eq("ownerPublisherId", ownerPublisherId).eq("softDeletedAt", undefined),
+            )
+            .order("desc")
+            .paginate(args.paginationOpts);
+      const scopedPage = shouldIncludeLegacyPersonalSkills
+        ? result.page.filter(
+            (skill) => !skill.ownerPublisherId || skill.ownerPublisherId === ownerPublisherId,
+          )
+        : result.page;
       const page = await mapDashboardSkillPage(ctx, scopedPage, isOwnDashboard);
       return { ...result, page };
     }
@@ -3935,26 +3921,14 @@ export const listDashboardPaginated = query({
     if (ownerUserId) {
       const userId = await getOptionalActiveAuthUserId(ctx);
       const isOwnDashboard = Boolean(userId && userId === ownerUserId);
-      const paginateOwnerSkills = async (paginationOpts: typeof args.paginationOpts) =>
-        await ctx.db
-          .query("skills")
-          .withIndex("by_owner_active_updated", (q) =>
-            q.eq("ownerUserId", ownerUserId).eq("softDeletedAt", undefined),
-          )
-          .order("desc")
-          .paginate(paginationOpts);
-      let result = await paginateOwnerSkills(args.paginationOpts);
+      const result = await ctx.db
+        .query("skills")
+        .withIndex("by_owner_active_updated", (q) =>
+          q.eq("ownerUserId", ownerUserId).eq("softDeletedAt", undefined),
+        )
+        .order("desc")
+        .paginate(args.paginationOpts);
       const scopedPage = await filterSkillsForOwnerUserDashboard(ctx, result.page, ownerUserId);
-      while (!result.isDone && scopedPage.length < args.paginationOpts.numItems) {
-        result = await paginateOwnerSkills({
-          ...args.paginationOpts,
-          cursor: result.continueCursor,
-          numItems: args.paginationOpts.numItems - scopedPage.length,
-        });
-        scopedPage.push(
-          ...(await filterSkillsForOwnerUserDashboard(ctx, result.page, ownerUserId)),
-        );
-      }
       const page = await mapDashboardSkillPage(ctx, scopedPage, isOwnDashboard);
       return { ...result, page };
     }

--- a/src/routes/-dashboard.test.tsx
+++ b/src/routes/-dashboard.test.tsx
@@ -378,6 +378,53 @@ describe("Dashboard rows", () => {
     });
   });
 
+  it("waits for the publisher scope before loading dashboard skills", () => {
+    mocks.useQuery.mockImplementation((query: unknown, args: unknown) => {
+      if (args === "skip") return undefined;
+      const name = getFunctionName(query as never);
+      if (name === "publishers:listMine") return undefined;
+      return [];
+    });
+
+    renderDashboard();
+
+    expect(mocks.usePaginatedQuery).toHaveBeenCalledWith(expect.anything(), "skip", {
+      initialNumItems: 50,
+    });
+  });
+
+  it("loads personal dashboard skills by publisher scope", () => {
+    arrangeDashboard({});
+
+    renderDashboard();
+
+    expect(mocks.usePaginatedQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      { ownerPublisherId: "publishers:local" },
+      { initialNumItems: 50 },
+    );
+  });
+
+  it("advances past an empty filtered skill page", async () => {
+    const loadMore = vi.fn();
+    mocks.usePaginatedQuery.mockReturnValue({
+      results: [],
+      status: "CanLoadMore",
+      loadMore,
+    });
+    mocks.useQuery.mockImplementation((query: unknown, args: unknown) => {
+      if (args === "skip") return undefined;
+      const name = getFunctionName(query as never);
+      if (name === "publishers:listMine") return publishers;
+      if (name === "dashboard:getDownloadMetrics") return downloadMetrics;
+      return [];
+    });
+
+    renderDashboard();
+
+    await waitFor(() => expect(loadMore).toHaveBeenCalledWith(50));
+  });
+
   it("filters catalog items by kind", () => {
     arrangeDashboard({
       skills: [

--- a/src/routes/dashboard.tsx
+++ b/src/routes/dashboard.tsx
@@ -94,13 +94,9 @@ export function Dashboard() {
   const canManage = selectedPublisher?.role !== "publisher";
 
   const skillsQueryArgs =
-    selectedPublisher?.publisher?.kind === "user" && me?._id
-      ? { ownerUserId: me._id }
-      : activePublisherId
-        ? { ownerPublisherId: activePublisherId as Doc<"publishers">["_id"] }
-        : me?._id
-          ? { ownerUserId: me._id }
-          : "skip";
+    publishers === undefined || !activePublisherId
+      ? "skip"
+      : { ownerPublisherId: activePublisherId as Doc<"publishers">["_id"] };
   const {
     results: paginatedSkills,
     status: skillsStatus,
@@ -188,6 +184,12 @@ export function Dashboard() {
     const timer = window.setTimeout(() => setLoadTimedOut(true), DASHBOARD_LOAD_TIMEOUT_MS);
     return () => window.clearTimeout(timer);
   }, [isLoading]);
+
+  useEffect(() => {
+    if (!skillsQuerySkipped && skills.length === 0 && skillsStatus === "CanLoadMore") {
+      loadMore(50);
+    }
+  }, [loadMore, skills.length, skillsQuerySkipped, skillsStatus]);
 
   if (isAuthLoading) {
     return <DashboardSkeleton />;


### PR DESCRIPTION
## Summary
- keep `skills:listDashboardPaginated` to one Convex paginated query per invocation
- wait for publisher scope before loading dashboard skills and advance empty filtered pages client-side
- add backend and route regressions for legacy/publisher-owned rows

## Validation
- `bunx vitest run convex/skills.dashboard.test.ts`
- `bunx vitest run src/routes/-dashboard.test.tsx`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- local Convex runtime proof with an org-owned row preceding a legacy personal row: first page returned empty with a cursor, second transaction returned the legacy row without the multiple-pagination server error

## Production evidence
Axiom recorded production failures for `skills:listDashboardPaginated` with: `This query or mutation function ran multiple paginated queries. Convex only supports a single paginated query in each function.`