### PR TITLE
fix: terminalize legacy publish conflicts

### DIFF
--- a/convex/publishAttempts.test.ts
+++ b/convex/publishAttempts.test.ts
@@ -491,6 +491,60 @@ describe("publishAttempts", () => {
     );
   });
 
+  it.each([
+    [
+      "redirected legacy slugs",
+      "Uncaught ConvexError: Slug redirects to an existing skill. Choose a different slug. Existing skill: /orchune/personal-finance",
+    ],
+    ["deleted fork sources", "Uncaught ConvexError: Upstream skill not found"],
+  ])("terminalizes %s instead of retrying finalization", async (_caseName, error) => {
+    const ctx = {
+      db: {
+        delete: vi.fn(),
+        get: vi.fn(async () => ({
+          _id: "publishAttempts:legacy-fork",
+          kind: "skill",
+          status: "finalizing",
+          skillInsertArgs: {
+            slug: "demo-skill",
+            version: "1.0.0",
+            forkOf: { slug: "legacy-upstream" },
+          },
+          followup: {},
+          finalizationClaimId: "finalize:claim",
+        })),
+        insert: vi.fn(),
+        normalizeId: vi.fn(),
+        patch: vi.fn(),
+        query: vi.fn(),
+        replace: vi.fn(),
+        system: {},
+      },
+    };
+
+    await expect(
+      releaseSkillFinalizationHandler(ctx, {
+        attemptId: "publishAttempts:legacy-fork",
+        claimId: "finalize:claim",
+        error,
+      }),
+    ).resolves.toEqual({
+      attemptId: "publishAttempts:legacy-fork",
+      status: "failed",
+    });
+
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "publishAttempts:legacy-fork",
+      expect.objectContaining({
+        status: "failed",
+        checkClaimId: undefined,
+        finalizationClaimId: undefined,
+        finalizationLastError: error,
+        failedAt: expect.any(Number),
+      }),
+    );
+  });
+
   it("terminalizes duplicate package versions while preserving transient retries", async () => {
     const duplicateCtx = {
       db: {

--- a/convex/publishAttempts.ts
+++ b/convex/publishAttempts.ts
@@ -86,7 +86,9 @@ function isTerminalFinalizationConflict(error: string | undefined) {
   return (
     typeof error === "string" &&
     (/Version .+ already exists\. Increment the version number and try again\./.test(error) ||
-      error.includes("Slug is used by multiple publishers. Use an owner-qualified skill URL."))
+      error.includes("Slug is used by multiple publishers. Use an owner-qualified skill URL.") ||
+      error.includes("Slug redirects to an existing skill. Choose a different slug.") ||
+      error.includes("Upstream skill not found"))
   );
 }
 


### PR DESCRIPTION
## Summary

- terminalize staged publish finalization when a legacy slug redirects to an existing skill
- terminalize staged fork finalization when the upstream skill no longer exists
- preserve retryability for transient scanner and rate-limit failures

## Production evidence

- `orchune-finance@2.0.0`: `Slug redirects to an existing skill...`
- `bookforge-data-visualization-selector@1.0.0`: `Upstream skill not found`
- both remained `ready_to_finalize` before this classifier update

## Validation

- `bunx vitest run convex/publishAttempts.test.ts`
- `bunx vitest run convex/publishAttempts.test.ts scripts/security/run-prepublication-worker.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- repo-local autoreview: clean
