### PR TITLE
chore: remove CLAW-480 recovery bypass

### DIFF
--- a/convex/lib/skillPublish.test.ts
+++ b/convex/lib/skillPublish.test.ts
@@ -556,10 +556,7 @@ description: Security scanner smoke fixture.
       versionId: "skillVersions:demo",
       embeddingId: "skillEmbeddings:demo",
     });
-    expect(runMutation).toHaveBeenCalledWith(expect.anything(), {
-      ...insertArgs,
-      bypassNewSkillRateLimit: true,
-    });
+    expect(runMutation).toHaveBeenCalledWith(expect.anything(), insertArgs);
     expect(scheduler.runAfter).toHaveBeenCalledWith(0, expect.anything(), {
       versionId: "skillVersions:demo",
     });
@@ -573,24 +570,6 @@ description: Security scanner smoke fixture.
       preserveActiveJob: true,
       preserveExistingJob: true,
     });
-  });
-
-  it("does not bypass new-skill limits for attempts created after the recovery cutoff", () => {
-    const insertArgs = {
-      userId: "users:1",
-      slug: "future-staged-skill",
-      version: "1.0.0",
-    };
-
-    expect(
-      __test.withStagedFinalizationRateLimitBypass(insertArgs, Date.parse("2026-07-07T15:27:10Z")),
-    ).toBe(insertArgs);
-    expect(
-      __test.withStagedFinalizationRateLimitBypass(
-        { ...insertArgs, bypassNewSkillRateLimit: true },
-        Date.parse("2026-07-07T15:27:10Z"),
-      ),
-    ).toEqual({ ...insertArgs, bypassNewSkillRateLimit: true });
   });
 
   it("releases the staged publish finalization claim when insertion fails", async () => {

--- a/convex/lib/skillPublish.ts
+++ b/convex/lib/skillPublish.ts
@@ -49,8 +49,6 @@ const QUALITY_WINDOW_MS = 24 * 60 * 60 * 1000;
 const QUALITY_ACTIVITY_LIMIT = 60;
 const PLATFORM_SKILL_LICENSE = "MIT-0" as const;
 const SECURITY_SCAN_ENQUEUE_BACKUP_DELAY_MS = 15_000;
-// Frozen after the CLAW-480 rollback snapshot. Remove after the incident cohort is drained.
-const CLAW_480_RECOVERY_ATTEMPT_CUTOFF_MS = Date.parse("2026-07-07T15:27:09Z");
 const MAX_PUBLISH_SUMMARY_LENGTH = 300;
 
 type FingerprintFile = { path: string; sha256: string };
@@ -567,10 +565,7 @@ export async function finalizeSkillPublishAttempt(
 
   let publishResult: PublishResult;
   try {
-    const skillInsertArgs = withStagedFinalizationRateLimitBypass(
-      await prepareSkillInsertArgsForFinalization(ctx, claim.skillInsertArgs),
-      claim.createdAt,
-    );
+    const skillInsertArgs = await prepareSkillInsertArgsForFinalization(ctx, claim.skillInsertArgs);
     publishResult = (await ctx.runMutation(
       internal.skills.insertVersion,
       skillInsertArgs as never,
@@ -601,22 +596,6 @@ export async function finalizeSkillPublishAttempt(
   }
 
   return publishResult;
-}
-
-function withStagedFinalizationRateLimitBypass(rawInsertArgs: unknown, attemptCreatedAt: number) {
-  if (!rawInsertArgs || typeof rawInsertArgs !== "object" || Array.isArray(rawInsertArgs)) {
-    return rawInsertArgs;
-  }
-  if (
-    attemptCreatedAt > CLAW_480_RECOVERY_ATTEMPT_CUTOFF_MS &&
-    (rawInsertArgs as Record<string, unknown>).bypassNewSkillRateLimit !== true
-  ) {
-    return rawInsertArgs;
-  }
-  return {
-    ...rawInsertArgs,
-    bypassNewSkillRateLimit: true,
-  };
 }
 
 async function prepareSkillInsertArgsForFinalization(
@@ -843,7 +822,6 @@ export const __test = {
   toStructuralFingerprint,
   derivePublishFilesFromStorage,
   buildSkillPublishAttemptIdempotencyKey,
-  withStagedFinalizationRateLimitBypass,
 };
 
 export async function queueHighlightedWebhook(ctx: MutationCtx, skillId: Id<"skills">) {


### PR DESCRIPTION
## Summary
- remove the temporary CLAW-480 pre-cutoff staged-finalization rate-limit override
- restore normal finalization behavior after the production recovery cohort reached a terminal state
- remove the incident-only helper and cutoff test

Production precondition verified before removal:
- pending: 0
- ready_to_finalize: 0
- finalizing: 0
- no-op worker canary claimed: 0
- staged publishing remains disabled

## Validation
- `bunx vitest run convex/lib/skillPublish.test.ts convex/publishAttempts.test.ts scripts/security/run-prepublication-worker.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- repo-local autoreview: clean

Linear: https://linear.app/my-openclaw/issue/CLAW-480/recover-staged-publishing-and-harden-the-async-prepublication-rollout
