### PR TITLE
feat: link ClawHub status page from footer

### DIFF
--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -216,6 +216,7 @@ describe("restored UI design contract", () => {
     expect(navSource).toContain('label: "Publish Plugin"');
     expect(navSource).toContain('label: "GitHub"');
     expect(navSource).toContain('label: "OpenClaw"');
+    expect(navSource).toContain('label: "Status"');
     expect(navSource).toContain('label: "Deployed on Vercel"');
     expect(navSource).toContain('label: "Powered by Convex"');
 

--- a/src/components/Footer.test.tsx
+++ b/src/components/Footer.test.tsx
@@ -76,6 +76,9 @@ describe("Footer", () => {
         .getAttribute("href"),
     ).toBe("https://openclaw.ai");
     expect(within(community as HTMLElement).queryByRole("link", { name: "About" })).toBeNull();
+    expect(screen.getByRole("link", { name: "Status" }).getAttribute("href")).toBe(
+      "https://clawhub.betteruptime.com",
+    );
     expect(screen.getByRole("link", { name: "Deployed on Vercel" }).getAttribute("href")).toBe(
       "https://vercel.com",
     );

--- a/src/lib/nav-items.ts
+++ b/src/lib/nav-items.ts
@@ -185,6 +185,7 @@ export const FOOTER_NAV_SECTIONS: FooterNavSection[] = [
 ];
 
 export const FOOTER_PLATFORM_LINKS = [
+  { label: "Status", href: "https://clawhub.betteruptime.com" },
   { label: "Deployed on Vercel", href: "https://vercel.com" },
   { label: "Powered by Convex", href: "https://www.convex.dev" },
 ] as const;


### PR DESCRIPTION
## Summary
- add the ClawHub Better Stack status page to the global footer
- cover the link in the footer and UI design contract tests

## Validation
- `bun run vitest run src/components/Footer.test.tsx src/__tests__/ui-design-contract.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- Playwright desktop and mobile checks against `http://localhost:3002/` confirmed one visible Status link pointing to `https://clawhub.betteruptime.com`