### PR TITLE
feat(feeds): add dormant catalog signing foundation

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -64,7 +64,7 @@ import {
   skillsShCatalogTestV1Http,
   skillsShCatalogPublicV1Http,
 } from "./httpApiV1";
-import { signedCatalogFeedV1Http } from "./httpApiV1/catalogFeedSigning";
+import { catalogFeedWithOptionalSigningV1Http } from "./httpApiV1/catalogFeedSigning";
 import { preflightHandler } from "./httpPreflight";
 import { installRateLimitedRoutes } from "./lib/httpRouteRateLimit";
 import {
@@ -190,7 +190,7 @@ http.route({
 http.route({
   path: ApiRoutes.catalogFeed,
   method: "GET",
-  handler: signedCatalogFeedV1Http,
+  handler: catalogFeedWithOptionalSigningV1Http,
 });
 
 http.route({

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -52,7 +52,6 @@ import {
   listPromotionsV1Http,
   promotionsGetRouterV1Http,
   promotionsPostRouterV1Http,
-  catalogFeedV1Http,
   catalogSkillsFeedV1Http,
   catalogClawsFeedV1Http,
   promotionsFeedV1Http,
@@ -65,6 +64,7 @@ import {
   skillsShCatalogTestV1Http,
   skillsShCatalogPublicV1Http,
 } from "./httpApiV1";
+import { signedCatalogFeedV1Http } from "./httpApiV1/catalogFeedSigning";
 import { preflightHandler } from "./httpPreflight";
 import { installRateLimitedRoutes } from "./lib/httpRouteRateLimit";
 import {
@@ -190,7 +190,7 @@ http.route({
 http.route({
   path: ApiRoutes.catalogFeed,
   method: "GET",
-  handler: catalogFeedV1Http,
+  handler: signedCatalogFeedV1Http,
 });
 
 http.route({

--- a/convex/httpApiV1.catalogFeedSigning.test.ts
+++ b/convex/httpApiV1.catalogFeedSigning.test.ts
@@ -95,6 +95,7 @@ describe("signed catalog feed", () => {
     const body = await first.text();
     const envelope = JSON.parse(body) as { payload: string };
     expect(Buffer.from(envelope.payload, "base64url").toString("utf8")).toBe(publication.payload);
+    expect(first.headers.get("content-type")).toBe("application/vnd.dsse+json; charset=utf-8");
     expect(first.headers.get("etag")).toMatch(/^"sha256:[a-f0-9]{64}"$/u);
     expect(first.headers.get("x-content-sha256")).toMatch(/^[a-f0-9]{64}$/u);
     expect(first.headers.get("x-catalog-payload-sha256")).toBe(publication.payloadSha256);
@@ -137,7 +138,11 @@ describe("signed catalog feed", () => {
     {},
     { CLAWHUB_FEED_SIGNING_CONFIG: "not-json" },
     { CLAWHUB_FEED_SIGNING_CONFIG: "[]" },
-    { CLAWHUB_FEED_SIGNING_CONFIG: JSON.stringify({ keyId: "clawhub-feed-2026-q3" }) },
+    {
+      CLAWHUB_FEED_SIGNING_CONFIG: JSON.stringify({
+        keyId: "clawhub-feed-2026-q3",
+      }),
+    },
     {
       CLAWHUB_FEED_SIGNING_CONFIG: JSON.stringify({
         keyId: "clawhub-feed-2026-q3",

--- a/convex/httpApiV1.catalogFeedSigning.test.ts
+++ b/convex/httpApiV1.catalogFeedSigning.test.ts
@@ -29,8 +29,10 @@ async function signingFixture() {
     publicKeyEncoding: { type: "spki", format: "pem" },
   });
   const env = {
-    CLAWHUB_FEED_SIGNING_KEY_ID: "clawhub-feed-2026-q3",
-    CLAWHUB_FEED_SIGNING_PRIVATE_KEY: privateKey,
+    CLAWHUB_FEED_SIGNING_CONFIG: JSON.stringify({
+      keyId: "clawhub-feed-2026-q3",
+      privateKey,
+    }),
   };
   const config = await resolveFeedSigningConfig(env);
   if (!config) throw new Error("expected signing config");
@@ -97,6 +99,7 @@ describe("signed catalog feed", () => {
     expect(first.headers.get("x-content-sha256")).toMatch(/^[a-f0-9]{64}$/u);
     expect(first.headers.get("x-catalog-payload-sha256")).toBe(publication.payloadSha256);
     expect(first.headers.get("x-openclaw-feed-signing-key-id")).toBe("clawhub-feed-2026-q3");
+    expect(first.headers.get("last-modified")).toBeNull();
     expect(ctx.runQuery).toHaveBeenCalledWith(internal.catalogFeed.getLatestPublication, {
       feedId: "clawhub-official",
     });
@@ -119,19 +122,34 @@ describe("signed catalog feed", () => {
     );
     expect(await repeated.text()).toBe(body);
     expect(repeated.headers.get("etag")).toBe(etag);
+
+    const ignoredLastModified = await signedCatalogFeedV1Handler(
+      ctx as never,
+      new Request("https://clawhub.ai/api/v1/feeds/plugins", {
+        headers: { "If-Modified-Since": "Wed, 31 Dec 2098 23:59:59 GMT" },
+      }),
+      env,
+    );
+    expect(ignoredLastModified.status).toBe(200);
   });
 
   it.each([
     {},
-    { CLAWHUB_FEED_SIGNING_KEY_ID: "clawhub-feed-2026-q3" },
-    { CLAWHUB_FEED_SIGNING_PRIVATE_KEY: "not-a-private-key" },
+    { CLAWHUB_FEED_SIGNING_CONFIG: "not-json" },
+    { CLAWHUB_FEED_SIGNING_CONFIG: "[]" },
+    { CLAWHUB_FEED_SIGNING_CONFIG: JSON.stringify({ keyId: "clawhub-feed-2026-q3" }) },
     {
-      CLAWHUB_FEED_SIGNING_KEY_ID: "clawhub-feed-2026-q3",
-      CLAWHUB_FEED_SIGNING_PRIVATE_KEY: "not-a-private-key",
+      CLAWHUB_FEED_SIGNING_CONFIG: JSON.stringify({
+        keyId: "clawhub-feed-2026-q3",
+        privateKey: "not-a-private-key",
+      }),
     },
     {
-      CLAWHUB_FEED_SIGNING_KEY_ID: "invalid key id\r\nheader",
-      CLAWHUB_FEED_SIGNING_PRIVATE_KEY: "not-a-private-key",
+      CLAWHUB_FEED_SIGNING_CONFIG: JSON.stringify({
+        keyId: "invalid key id\r\nheader",
+        privateKey: "not-a-private-key",
+        unexpected: true,
+      }),
     },
   ])("fails closed before reading a publication when signing config is invalid", async (env) => {
     const response = await signedCatalogFeedV1Handler(

--- a/convex/httpApiV1.catalogFeedSigning.test.ts
+++ b/convex/httpApiV1.catalogFeedSigning.test.ts
@@ -103,6 +103,21 @@ describe("signed catalog feed", () => {
     expect(signed.headers.get("cache-control")).toBe("no-store");
   });
 
+  it.each([{}, { CLAWHUB_FEED_SIGNING_CONFIG: "not-json" }])(
+    "keeps the existing unsigned route available while signing is dormant or invalid",
+    async (env) => {
+      const response = await negotiatedCatalogFeedV1Handler(
+        ctx as never,
+        new Request("https://clawhub.ai/api/v1/feeds/plugins"),
+        env,
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/json; charset=utf-8");
+      expect(await response.text()).toBe(publication.payload);
+    },
+  );
+
   it("signs the exact stored publication bytes with DSSE Ed25519", async () => {
     const { config, publicKey } = await signingFixture();
     const signed = await signCatalogFeedPayload(publication.payload, config);

--- a/convex/httpApiV1.catalogFeedSigning.test.ts
+++ b/convex/httpApiV1.catalogFeedSigning.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { internal } from "./_generated/api";
 import {
   OPENCLAW_CATALOG_FEED_PAYLOAD_TYPE,
+  negotiatedCatalogFeedV1Handler,
   resolveFeedSigningConfig,
   signCatalogFeedPayload,
   signedCatalogFeedV1Handler,
@@ -55,6 +56,51 @@ describe("signed catalog feed", () => {
 
   beforeEach(() => {
     ctx = { runQuery: vi.fn().mockResolvedValue(publication) };
+  });
+
+  it("preserves the unsigned representation unless a client opts into DSSE", async () => {
+    const unsigned = await negotiatedCatalogFeedV1Handler(
+      ctx as never,
+      new Request("https://clawhub.ai/api/v1/feeds/plugins"),
+      {},
+    );
+
+    expect(unsigned.status).toBe(200);
+    expect(unsigned.headers.get("content-type")).toBe("application/json; charset=utf-8");
+    expect(unsigned.headers.get("vary")).toContain("Accept");
+    expect(await unsigned.text()).toBe(publication.payload);
+
+    const { env } = await signingFixture();
+    const signed = await negotiatedCatalogFeedV1Handler(
+      ctx as never,
+      new Request("https://clawhub.ai/api/v1/feeds/plugins", {
+        headers: { Accept: "application/vnd.dsse+json" },
+      }),
+      env,
+    );
+
+    expect(signed.status).toBe(200);
+    expect(signed.headers.get("content-type")).toBe("application/vnd.dsse+json; charset=utf-8");
+    expect(signed.headers.get("vary")).toContain("Accept");
+  });
+
+  it("contains signing failures to clients that request the signed representation", async () => {
+    const unsigned = await negotiatedCatalogFeedV1Handler(
+      ctx as never,
+      new Request("https://clawhub.ai/api/v1/feeds/plugins"),
+      {},
+    );
+    const signed = await negotiatedCatalogFeedV1Handler(
+      ctx as never,
+      new Request("https://clawhub.ai/api/v1/feeds/plugins", {
+        headers: { Accept: "application/vnd.dsse+json" },
+      }),
+      {},
+    );
+
+    expect(unsigned.status).toBe(200);
+    expect(signed.status).toBe(503);
+    expect(signed.headers.get("cache-control")).toBe("no-store");
   });
 
   it("signs the exact stored publication bytes with DSSE Ed25519", async () => {

--- a/convex/httpApiV1.catalogFeedSigning.test.ts
+++ b/convex/httpApiV1.catalogFeedSigning.test.ts
@@ -1,0 +1,160 @@
+import { createPublicKey, generateKeyPairSync, verify as verifyDetached } from "node:crypto";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { internal } from "./_generated/api";
+import {
+  OPENCLAW_CATALOG_FEED_PAYLOAD_TYPE,
+  resolveFeedSigningConfig,
+  signCatalogFeedPayload,
+  signedCatalogFeedV1Handler,
+} from "./httpApiV1/catalogFeedSigning";
+
+type QueryCtx = {
+  runQuery: ReturnType<typeof vi.fn>;
+};
+
+const publication = {
+  feedId: "clawhub-official",
+  sequence: 4,
+  generatedAt: "2026-06-23T00:00:00.000Z",
+  expiresAt: "2026-06-30T00:00:00.000Z",
+  payload:
+    '{"schemaVersion":1,"id":"clawhub-official","generatedAt":"2026-06-23T00:00:00.000Z","sequence":4,"expiresAt":"2026-06-30T00:00:00.000Z","entries":[]}',
+  payloadSha256: "catalog-payload-sha256",
+  publishedAt: Date.parse("2026-06-23T00:00:00.000Z"),
+};
+
+async function signingFixture() {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519", {
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  const env = {
+    CLAWHUB_FEED_SIGNING_KEY_ID: "clawhub-feed-2026-q3",
+    CLAWHUB_FEED_SIGNING_PRIVATE_KEY: privateKey,
+  };
+  const config = await resolveFeedSigningConfig(env);
+  if (!config) throw new Error("expected signing config");
+  return { config, env, publicKey };
+}
+
+function dsseInput(payloadBytes: Buffer) {
+  const typeBytes = Buffer.from(OPENCLAW_CATALOG_FEED_PAYLOAD_TYPE, "utf8");
+  return Buffer.concat([
+    Buffer.from(
+      `DSSEv1 ${typeBytes.length} ${OPENCLAW_CATALOG_FEED_PAYLOAD_TYPE} ${payloadBytes.length} `,
+      "utf8",
+    ),
+    payloadBytes,
+  ]);
+}
+
+describe("signed catalog feed", () => {
+  let ctx: QueryCtx;
+
+  beforeEach(() => {
+    ctx = { runQuery: vi.fn().mockResolvedValue(publication) };
+  });
+
+  it("signs the exact stored publication bytes with DSSE Ed25519", async () => {
+    const { config, publicKey } = await signingFixture();
+    const signed = await signCatalogFeedPayload(publication.payload, config);
+    const payloadBytes = Buffer.from(signed.envelope.payload, "base64url");
+
+    expect(payloadBytes.toString("utf8")).toBe(publication.payload);
+    expect(signed.envelope).toMatchObject({
+      schemaVersion: 1,
+      payloadType: OPENCLAW_CATALOG_FEED_PAYLOAD_TYPE,
+      signatures: [
+        {
+          keyId: "clawhub-feed-2026-q3",
+          algorithm: "ed25519",
+        },
+      ],
+    });
+    expect(
+      verifyDetached(
+        null,
+        dsseInput(payloadBytes),
+        createPublicKey(publicKey),
+        Buffer.from(signed.envelope.signatures[0]?.signature ?? "", "base64url"),
+      ),
+    ).toBe(true);
+  });
+
+  it("serves a stable signed representation with envelope validators", async () => {
+    const { env } = await signingFixture();
+    const first = await signedCatalogFeedV1Handler(
+      ctx as never,
+      new Request("https://clawhub.ai/api/v1/feeds/plugins"),
+      env,
+    );
+
+    expect(first.status).toBe(200);
+    const body = await first.text();
+    const envelope = JSON.parse(body) as { payload: string };
+    expect(Buffer.from(envelope.payload, "base64url").toString("utf8")).toBe(publication.payload);
+    expect(first.headers.get("etag")).toMatch(/^"sha256:[a-f0-9]{64}"$/u);
+    expect(first.headers.get("x-content-sha256")).toMatch(/^[a-f0-9]{64}$/u);
+    expect(first.headers.get("x-catalog-payload-sha256")).toBe(publication.payloadSha256);
+    expect(first.headers.get("x-openclaw-feed-signing-key-id")).toBe("clawhub-feed-2026-q3");
+    expect(ctx.runQuery).toHaveBeenCalledWith(internal.catalogFeed.getLatestPublication, {
+      feedId: "clawhub-official",
+    });
+
+    const etag = first.headers.get("etag") ?? "";
+    const notModified = await signedCatalogFeedV1Handler(
+      ctx as never,
+      new Request("https://clawhub.ai/api/v1/feeds/plugins", {
+        headers: { "If-None-Match": etag },
+      }),
+      env,
+    );
+    expect(notModified.status).toBe(304);
+    expect(await notModified.text()).toBe("");
+
+    const repeated = await signedCatalogFeedV1Handler(
+      ctx as never,
+      new Request("https://clawhub.ai/api/v1/feeds/plugins"),
+      env,
+    );
+    expect(await repeated.text()).toBe(body);
+    expect(repeated.headers.get("etag")).toBe(etag);
+  });
+
+  it.each([
+    {},
+    { CLAWHUB_FEED_SIGNING_KEY_ID: "clawhub-feed-2026-q3" },
+    { CLAWHUB_FEED_SIGNING_PRIVATE_KEY: "not-a-private-key" },
+    {
+      CLAWHUB_FEED_SIGNING_KEY_ID: "clawhub-feed-2026-q3",
+      CLAWHUB_FEED_SIGNING_PRIVATE_KEY: "not-a-private-key",
+    },
+    {
+      CLAWHUB_FEED_SIGNING_KEY_ID: "invalid key id\r\nheader",
+      CLAWHUB_FEED_SIGNING_PRIVATE_KEY: "not-a-private-key",
+    },
+  ])("fails closed before reading a publication when signing config is invalid", async (env) => {
+    const response = await signedCatalogFeedV1Handler(
+      ctx as never,
+      new Request("https://clawhub.ai/api/v1/feeds/plugins"),
+      env,
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(ctx.runQuery).not.toHaveBeenCalled();
+  });
+
+  it("does not cache a missing stored publication", async () => {
+    const { env } = await signingFixture();
+    ctx.runQuery.mockResolvedValue(null);
+    const response = await signedCatalogFeedV1Handler(
+      ctx as never,
+      new Request("https://clawhub.ai/api/v1/feeds/plugins"),
+      env,
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+});

--- a/convex/httpApiV1.catalogFeedSigning.test.ts
+++ b/convex/httpApiV1.catalogFeedSigning.test.ts
@@ -63,22 +63,22 @@ describe("signed catalog feed", () => {
     const payloadBytes = Buffer.from(signed.envelope.payload, "base64url");
 
     expect(payloadBytes.toString("utf8")).toBe(publication.payload);
+    expect(Object.keys(signed.envelope).sort()).toEqual(["payload", "payloadType", "signatures"]);
     expect(signed.envelope).toMatchObject({
-      schemaVersion: 1,
       payloadType: OPENCLAW_CATALOG_FEED_PAYLOAD_TYPE,
       signatures: [
         {
-          keyId: "clawhub-feed-2026-q3",
-          algorithm: "ed25519",
+          keyid: "clawhub-feed-2026-q3",
         },
       ],
     });
+    expect(Object.keys(signed.envelope.signatures[0] ?? {}).sort()).toEqual(["keyid", "sig"]);
     expect(
       verifyDetached(
         null,
         dsseInput(payloadBytes),
         createPublicKey(publicKey),
-        Buffer.from(signed.envelope.signatures[0]?.signature ?? "", "base64url"),
+        Buffer.from(signed.envelope.signatures[0]?.sig ?? "", "base64url"),
       ),
     ).toBe(true);
   });

--- a/convex/httpApiV1.catalogFeedSigning.test.ts
+++ b/convex/httpApiV1.catalogFeedSigning.test.ts
@@ -84,6 +84,31 @@ describe("signed catalog feed", () => {
     expect(signed.headers.get("vary")).toContain("Accept");
   });
 
+  it.each([
+    ["application/json, application/vnd.dsse+json;q=0.1", "application/json; charset=utf-8"],
+    ["application/vnd.dsse+json;Q=0", "application/json; charset=utf-8"],
+    [
+      "application/json;q=0.5, application/vnd.dsse+json;q=0.9",
+      "application/vnd.dsse+json; charset=utf-8",
+    ],
+    [
+      "application/vnd.dsse+json;q=0.8, application/json;q=0.7, */*;q=1",
+      "application/vnd.dsse+json; charset=utf-8",
+    ],
+  ])("respects Accept quality preferences for %s", async (accept, expectedContentType) => {
+    const { env } = await signingFixture();
+    const response = await negotiatedCatalogFeedV1Handler(
+      ctx as never,
+      new Request("https://clawhub.ai/api/v1/feeds/plugins", {
+        headers: { Accept: accept },
+      }),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(expectedContentType);
+  });
+
   it("contains signing failures to clients that request the signed representation", async () => {
     const unsigned = await negotiatedCatalogFeedV1Handler(
       ctx as never,

--- a/convex/httpApiV1/catalogFeedSigning.ts
+++ b/convex/httpApiV1/catalogFeedSigning.ts
@@ -3,6 +3,7 @@ import { internal } from "../_generated/api";
 import type { ActionCtx } from "../_generated/server";
 import { httpAction } from "../functions";
 import {
+  catalogFeedV1Handler,
   catalogFeedResponseHeaders,
   catalogFeedUnavailableResponse,
   matchesEtag,
@@ -189,4 +190,41 @@ export async function signedCatalogFeedV1Handler(
   return new Response(signed.body, { status: 200, headers });
 }
 
-export const signedCatalogFeedV1Http = httpAction(signedCatalogFeedV1Handler);
+function acceptsSignedCatalogFeed(request: Request) {
+  return (request.headers.get("Accept") ?? "").split(",").some((value) => {
+    const [mediaType, ...parameters] = value.split(";").map((part) => part.trim());
+    const disabled = parameters.some((parameter) => /^q=0(?:\.0*)?$/u.test(parameter));
+    return mediaType?.toLowerCase() === "application/vnd.dsse+json" && !disabled;
+  });
+}
+
+function addAcceptVary(response: Response) {
+  const headers = new Headers(response.headers);
+  const vary = headers.get("Vary");
+  const values = new Set(
+    (vary ?? "")
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean),
+  );
+  values.add("Accept");
+  headers.set("Vary", [...values].join(", "));
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+export async function negotiatedCatalogFeedV1Handler(
+  ctx: ActionCtx,
+  request: Request,
+  env: Record<string, string | undefined> = process.env,
+) {
+  const response = acceptsSignedCatalogFeed(request)
+    ? await signedCatalogFeedV1Handler(ctx, request, env)
+    : await catalogFeedV1Handler(ctx, request);
+  return addAcceptVary(response);
+}
+
+export const signedCatalogFeedV1Http = httpAction(negotiatedCatalogFeedV1Handler);

--- a/convex/httpApiV1/catalogFeedSigning.ts
+++ b/convex/httpApiV1/catalogFeedSigning.ts
@@ -176,6 +176,7 @@ export async function signedCatalogFeedV1Handler(
     catalogFeedResponseHeaders(publication, {
       representationSha256: signed.sha256,
       additionalHeaders: {
+        "Content-Type": "application/vnd.dsse+json; charset=utf-8",
         "X-Catalog-Payload-SHA256": publication.payloadSha256,
         "X-OpenClaw-Feed-Signing-Key-ID": signingConfig.keyId,
       },

--- a/convex/httpApiV1/catalogFeedSigning.ts
+++ b/convex/httpApiV1/catalogFeedSigning.ts
@@ -11,14 +11,14 @@ import {
 export const OPENCLAW_CATALOG_FEED_PAYLOAD_TYPE =
   "openclaw.official-external-plugin-catalog-feed.v1";
 
-type FeedSigningConfig = {
+export type FeedSigningConfig = {
   keyId: string;
   privateKey: CryptoKey;
 };
 
 type SignedFeedEnvelope = {
   schemaVersion: 1;
-  payloadType: typeof OPENCLAW_CATALOG_FEED_PAYLOAD_TYPE;
+  payloadType: string;
   payload: string;
   signatures: readonly {
     keyId: string;
@@ -116,7 +116,8 @@ function toHex(bytes: Uint8Array) {
   return result;
 }
 
-export async function signCatalogFeedPayload(
+export async function signFeedPayload(
+  payloadType: string,
   payload: string,
   config: FeedSigningConfig,
 ): Promise<{ envelope: SignedFeedEnvelope; body: string; sha256: string }> {
@@ -125,12 +126,12 @@ export async function signCatalogFeedPayload(
     await crypto.subtle.sign(
       { name: "Ed25519" },
       config.privateKey,
-      dssePreAuthenticationEncoding(OPENCLAW_CATALOG_FEED_PAYLOAD_TYPE, payloadBytes),
+      dssePreAuthenticationEncoding(payloadType, payloadBytes),
     ),
   );
   const envelope: SignedFeedEnvelope = {
     schemaVersion: 1,
-    payloadType: OPENCLAW_CATALOG_FEED_PAYLOAD_TYPE,
+    payloadType,
     payload: base64UrlEncode(payloadBytes),
     signatures: [
       {
@@ -147,6 +148,10 @@ export async function signCatalogFeedPayload(
     body,
     sha256: toHex(new Uint8Array(digest)),
   };
+}
+
+export async function signCatalogFeedPayload(payload: string, config: FeedSigningConfig) {
+  return await signFeedPayload(OPENCLAW_CATALOG_FEED_PAYLOAD_TYPE, payload, config);
 }
 
 export async function signedCatalogFeedV1Handler(

--- a/convex/httpApiV1/catalogFeedSigning.ts
+++ b/convex/httpApiV1/catalogFeedSigning.ts
@@ -6,7 +6,6 @@ import {
   catalogFeedResponseHeaders,
   catalogFeedUnavailableResponse,
   matchesEtag,
-  matchesLastModified,
 } from "./catalogFeedV1";
 
 export const OPENCLAW_CATALOG_FEED_PAYLOAD_TYPE =
@@ -42,9 +41,31 @@ function decodePkcs8PrivateKey(raw: string) {
 export async function resolveFeedSigningConfig(
   env: Record<string, string | undefined>,
 ): Promise<FeedSigningConfig | null> {
-  const keyId = env.CLAWHUB_FEED_SIGNING_KEY_ID?.trim();
-  const privateKeyValue = env.CLAWHUB_FEED_SIGNING_PRIVATE_KEY?.trim();
-  if (!keyId || !privateKeyValue) return null;
+  const rawConfig = env.CLAWHUB_FEED_SIGNING_CONFIG?.trim();
+  if (!rawConfig) return null;
+  if (rawConfig.length > 32_768) throw new Error("ClawHub feed signing config is too large");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawConfig);
+  } catch {
+    throw new Error("ClawHub feed signing config must be valid JSON");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("ClawHub feed signing config must be an object");
+  }
+  const record = parsed as Record<string, unknown>;
+  if (
+    Object.keys(record).sort().join(",") !== "keyId,privateKey" ||
+    typeof record.keyId !== "string" ||
+    typeof record.privateKey !== "string"
+  ) {
+    throw new Error("ClawHub feed signing config must contain only keyId and privateKey");
+  }
+  const keyId = record.keyId.trim();
+  const privateKeyValue = record.privateKey.trim();
+  if (!keyId || !privateKeyValue) {
+    throw new Error("ClawHub feed signing config fields must not be empty");
+  }
   if (!/^[A-Za-z0-9._:-]{1,128}$/u.test(keyId)) {
     throw new Error("ClawHub feed signing key id is invalid");
   }
@@ -150,17 +171,17 @@ export async function signedCatalogFeedV1Handler(
 
   const signed = await signCatalogFeedPayload(publication.payload, signingConfig);
   const etag = `"sha256:${signed.sha256}"`;
-  const headers = catalogFeedResponseHeaders(publication, {
-    representationSha256: signed.sha256,
-    additionalHeaders: {
-      "X-Catalog-Payload-SHA256": publication.payloadSha256,
-      "X-OpenClaw-Feed-Signing-Key-ID": signingConfig.keyId,
-    },
-  });
-  if (
-    matchesEtag(request, etag) ||
-    (!request.headers.has("if-none-match") && matchesLastModified(request, publication.publishedAt))
-  ) {
+  const headers = new Headers(
+    catalogFeedResponseHeaders(publication, {
+      representationSha256: signed.sha256,
+      additionalHeaders: {
+        "X-Catalog-Payload-SHA256": publication.payloadSha256,
+        "X-OpenClaw-Feed-Signing-Key-ID": signingConfig.keyId,
+      },
+    }),
+  );
+  headers.delete("Last-Modified");
+  if (matchesEtag(request, etag)) {
     return new Response(null, { status: 304, headers });
   }
   return new Response(signed.body, { status: 200, headers });

--- a/convex/httpApiV1/catalogFeedSigning.ts
+++ b/convex/httpApiV1/catalogFeedSigning.ts
@@ -1,0 +1,169 @@
+import { CATALOG_FEED_ID } from "clawhub-schema";
+import { internal } from "../_generated/api";
+import type { ActionCtx } from "../_generated/server";
+import { httpAction } from "../functions";
+import {
+  catalogFeedResponseHeaders,
+  catalogFeedUnavailableResponse,
+  matchesEtag,
+  matchesLastModified,
+} from "./catalogFeedV1";
+
+export const OPENCLAW_CATALOG_FEED_PAYLOAD_TYPE =
+  "openclaw.official-external-plugin-catalog-feed.v1";
+
+type FeedSigningConfig = {
+  keyId: string;
+  privateKey: CryptoKey;
+};
+
+type SignedFeedEnvelope = {
+  schemaVersion: 1;
+  payloadType: typeof OPENCLAW_CATALOG_FEED_PAYLOAD_TYPE;
+  payload: string;
+  signatures: readonly {
+    keyId: string;
+    algorithm: "ed25519";
+    signature: string;
+  }[];
+};
+
+function decodePkcs8PrivateKey(raw: string) {
+  const normalized = raw.replaceAll("\\n", "\n").trim();
+  const match =
+    /^-----BEGIN PRIVATE KEY-----\s*([A-Za-z0-9+/=\s]+)\s*-----END PRIVATE KEY-----$/m.exec(
+      normalized,
+    );
+  if (!match?.[1]) throw new Error("ClawHub feed signing key must be PKCS#8 PEM");
+  const binary = atob(match[1].replaceAll(/\s/gu, ""));
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+}
+
+export async function resolveFeedSigningConfig(
+  env: Record<string, string | undefined>,
+): Promise<FeedSigningConfig | null> {
+  const keyId = env.CLAWHUB_FEED_SIGNING_KEY_ID?.trim();
+  const privateKeyValue = env.CLAWHUB_FEED_SIGNING_PRIVATE_KEY?.trim();
+  if (!keyId || !privateKeyValue) return null;
+  if (!/^[A-Za-z0-9._:-]{1,128}$/u.test(keyId)) {
+    throw new Error("ClawHub feed signing key id is invalid");
+  }
+  if (privateKeyValue.length > 16_384) {
+    throw new Error("ClawHub feed signing private key is too large");
+  }
+
+  const privateKey = await crypto.subtle.importKey(
+    "pkcs8",
+    decodePkcs8PrivateKey(privateKeyValue),
+    { name: "Ed25519" },
+    false,
+    ["sign"],
+  );
+  if (privateKey.algorithm.name !== "Ed25519") {
+    throw new Error("ClawHub feed signing key must be Ed25519");
+  }
+  return { keyId, privateKey };
+}
+
+function concatBytes(left: Uint8Array, right: Uint8Array) {
+  const result = new Uint8Array(left.length + right.length);
+  result.set(left);
+  result.set(right, left.length);
+  return result;
+}
+
+function dssePreAuthenticationEncoding(payloadType: string, payloadBytes: Uint8Array) {
+  const encoder = new TextEncoder();
+  const payloadTypeBytes = encoder.encode(payloadType);
+  const prefix = encoder.encode(
+    `DSSEv1 ${payloadTypeBytes.length} ${payloadType} ${payloadBytes.length} `,
+  );
+  return concatBytes(prefix, payloadBytes);
+}
+
+function base64UrlEncode(bytes: Uint8Array) {
+  let binary = "";
+  for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
+  }
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/u, "");
+}
+
+function toHex(bytes: Uint8Array) {
+  let result = "";
+  for (const byte of bytes) result += byte.toString(16).padStart(2, "0");
+  return result;
+}
+
+export async function signCatalogFeedPayload(
+  payload: string,
+  config: FeedSigningConfig,
+): Promise<{ envelope: SignedFeedEnvelope; body: string; sha256: string }> {
+  const payloadBytes = new TextEncoder().encode(payload);
+  const signature = new Uint8Array(
+    await crypto.subtle.sign(
+      { name: "Ed25519" },
+      config.privateKey,
+      dssePreAuthenticationEncoding(OPENCLAW_CATALOG_FEED_PAYLOAD_TYPE, payloadBytes),
+    ),
+  );
+  const envelope: SignedFeedEnvelope = {
+    schemaVersion: 1,
+    payloadType: OPENCLAW_CATALOG_FEED_PAYLOAD_TYPE,
+    payload: base64UrlEncode(payloadBytes),
+    signatures: [
+      {
+        keyId: config.keyId,
+        algorithm: "ed25519",
+        signature: base64UrlEncode(signature),
+      },
+    ],
+  };
+  const body = JSON.stringify(envelope);
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(body));
+  return {
+    envelope,
+    body,
+    sha256: toHex(new Uint8Array(digest)),
+  };
+}
+
+export async function signedCatalogFeedV1Handler(
+  ctx: ActionCtx,
+  request: Request,
+  env: Record<string, string | undefined> = process.env,
+) {
+  let signingConfig: FeedSigningConfig | null;
+  try {
+    signingConfig = await resolveFeedSigningConfig(env);
+  } catch {
+    return catalogFeedUnavailableResponse("Signed catalog feed is unavailable");
+  }
+  if (!signingConfig) {
+    return catalogFeedUnavailableResponse("Signed catalog feed is unavailable");
+  }
+
+  const publication = await ctx.runQuery(internal.catalogFeed.getLatestPublication, {
+    feedId: CATALOG_FEED_ID,
+  });
+  if (!publication) return catalogFeedUnavailableResponse();
+
+  const signed = await signCatalogFeedPayload(publication.payload, signingConfig);
+  const etag = `"sha256:${signed.sha256}"`;
+  const headers = catalogFeedResponseHeaders(publication, {
+    representationSha256: signed.sha256,
+    additionalHeaders: {
+      "X-Catalog-Payload-SHA256": publication.payloadSha256,
+      "X-OpenClaw-Feed-Signing-Key-ID": signingConfig.keyId,
+    },
+  });
+  if (
+    matchesEtag(request, etag) ||
+    (!request.headers.has("if-none-match") && matchesLastModified(request, publication.publishedAt))
+  ) {
+    return new Response(null, { status: 304, headers });
+  }
+  return new Response(signed.body, { status: 200, headers });
+}
+
+export const signedCatalogFeedV1Http = httpAction(signedCatalogFeedV1Handler);

--- a/convex/httpApiV1/catalogFeedSigning.ts
+++ b/convex/httpApiV1/catalogFeedSigning.ts
@@ -227,4 +227,7 @@ export async function negotiatedCatalogFeedV1Handler(
   return addAcceptVary(response);
 }
 
-export const signedCatalogFeedV1Http = httpAction(negotiatedCatalogFeedV1Handler);
+// Installing this handler does not activate signing. The unsigned representation
+// remains the default, and signing is reached only through explicit Accept
+// negotiation plus an active signing configuration.
+export const catalogFeedWithOptionalSigningV1Http = httpAction(negotiatedCatalogFeedV1Handler);

--- a/convex/httpApiV1/catalogFeedSigning.ts
+++ b/convex/httpApiV1/catalogFeedSigning.ts
@@ -17,13 +17,11 @@ export type FeedSigningConfig = {
 };
 
 type SignedFeedEnvelope = {
-  schemaVersion: 1;
   payloadType: string;
   payload: string;
   signatures: readonly {
-    keyId: string;
-    algorithm: "ed25519";
-    signature: string;
+    keyid: string;
+    sig: string;
   }[];
 };
 
@@ -130,14 +128,12 @@ export async function signFeedPayload(
     ),
   );
   const envelope: SignedFeedEnvelope = {
-    schemaVersion: 1,
     payloadType,
     payload: base64UrlEncode(payloadBytes),
     signatures: [
       {
-        keyId: config.keyId,
-        algorithm: "ed25519",
-        signature: base64UrlEncode(signature),
+        keyid: config.keyId,
+        sig: base64UrlEncode(signature),
       },
     ],
   };

--- a/convex/httpApiV1/catalogFeedSigning.ts
+++ b/convex/httpApiV1/catalogFeedSigning.ts
@@ -191,11 +191,30 @@ export async function signedCatalogFeedV1Handler(
 }
 
 function acceptsSignedCatalogFeed(request: Request) {
-  return (request.headers.get("Accept") ?? "").split(",").some((value) => {
-    const [mediaType, ...parameters] = value.split(";").map((part) => part.trim());
-    const disabled = parameters.some((parameter) => /^q=0(?:\.0*)?$/u.test(parameter));
-    return mediaType?.toLowerCase() === "application/vnd.dsse+json" && !disabled;
+  const ranges = (request.headers.get("Accept") ?? "").split(",").map((value) => {
+    const [rawMediaType, ...parameters] = value.split(";").map((part) => part.trim());
+    const qualityParameter = parameters.find((parameter) => /^q\s*=/iu.test(parameter));
+    const quality = qualityParameter
+      ? Number.parseFloat(qualityParameter.slice(qualityParameter.indexOf("=") + 1).trim())
+      : 1;
+    return {
+      mediaType: rawMediaType?.toLowerCase(),
+      quality: Number.isFinite(quality) && quality >= 0 && quality <= 1 ? quality : 0,
+    };
   });
+  const qualityFor = (...mediaTypesBySpecificity: string[]) => {
+    for (const mediaType of mediaTypesBySpecificity) {
+      const matchingQualities = ranges
+        .filter((range) => range.mediaType === mediaType)
+        .map((range) => range.quality);
+      if (matchingQualities.length > 0) return Math.max(...matchingQualities);
+    }
+    return 0;
+  };
+  const signedQuality = qualityFor("application/vnd.dsse+json");
+  if (!signedQuality) return false;
+  const unsignedQuality = qualityFor("application/json", "application/*", "*/*");
+  return signedQuality >= unsignedQuality;
 }
 
 function addAcceptVary(response: Response) {

--- a/convex/httpApiV1/catalogFeedV1.ts
+++ b/convex/httpApiV1/catalogFeedV1.ts
@@ -9,7 +9,7 @@ import type { ActionCtx } from "../_generated/server";
 import { experimentalClawsEnabled } from "../lib/experimentalClaws";
 import { corsHeaders, mergeHeaders } from "../lib/httpHeaders";
 
-function matchesEtag(request: Request, etag: string) {
+export function matchesEtag(request: Request, etag: string) {
   const header = request.headers.get("if-none-match");
   if (!header) return false;
   return header
@@ -22,12 +22,54 @@ function matchesEtag(request: Request, etag: string) {
     });
 }
 
-function matchesLastModified(request: Request, publishedAt: number) {
+export function matchesLastModified(request: Request, publishedAt: number) {
   const header = request.headers.get("if-modified-since");
   if (!header) return false;
   const since = Date.parse(header);
   if (!Number.isFinite(since)) return false;
   return Math.floor(publishedAt / 1000) * 1000 <= since;
+}
+
+export function catalogFeedUnavailableResponse(message = "Catalog feed is not published") {
+  return new Response(message, {
+    status: 503,
+    headers: mergeHeaders(
+      {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Cache-Control": "no-store",
+      },
+      corsHeaders(),
+    ),
+  });
+}
+
+export function catalogFeedResponseHeaders(
+  publication: {
+    sequence: number;
+    payloadSha256: string;
+    publishedAt: number;
+  },
+  options?: {
+    representationSha256?: string;
+    additionalHeaders?: Record<string, string>;
+  },
+) {
+  const representationSha256 = options?.representationSha256 ?? publication.payloadSha256;
+  return mergeHeaders(
+    {
+      "Content-Type": "application/json; charset=utf-8",
+      "Cache-Control": "public, max-age=60, s-maxage=300, stale-while-revalidate=86400",
+      "Surrogate-Control": "max-age=300, stale-while-revalidate=86400",
+      ETag: `"sha256:${representationSha256}"`,
+      "Last-Modified": new Date(publication.publishedAt).toUTCString(),
+      "X-Catalog-Feed-Sequence": String(publication.sequence),
+      "X-Content-SHA256": representationSha256,
+      "X-Content-Type-Options": "nosniff",
+      Vary: "Accept-Encoding",
+      ...options?.additionalHeaders,
+    },
+    corsHeaders(),
+  );
 }
 
 export async function catalogFeedV1Handler(
@@ -53,16 +95,7 @@ export async function catalogFeedV1Handler(
   }
   const publication = await ctx.runQuery(internal.catalogFeed.getLatestPublication, { feedId });
   if (!publication) {
-    return new Response("Catalog feed is not published", {
-      status: 503,
-      headers: mergeHeaders(
-        {
-          "Content-Type": "text/plain; charset=utf-8",
-          "Cache-Control": "no-store",
-        },
-        corsHeaders(),
-      ),
-    });
+    return catalogFeedUnavailableResponse();
   }
 
   const etag = `"sha256:${publication.payloadSha256}"`;

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "preview": "bun --bun vite preview",
     "proof:publish": "node scripts/ui-proof-publish.mjs",
     "proof:ui": "node scripts/ui-proof.mjs",
+    "provision:catalog-feed-key": "bun scripts/provision-catalog-feed-signing-key.ts",
     "publish:prepublication-worker": "bun scripts/security/run-prepublication-worker.ts",
     "release:clawhub:cli:changelog": "node scripts/extract-changelog-release.mjs",
     "release:clawhub:cli:npm:check": "node scripts/clawhub-cli-npm-release-check.mjs",

--- a/scripts/provision-catalog-feed-signing-key.test.ts
+++ b/scripts/provision-catalog-feed-signing-key.test.ts
@@ -1,0 +1,249 @@
+import { createPublicKey } from "node:crypto";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  activateSigningKey,
+  parseOptions,
+  prepareSigningKey,
+  type ConvexRunner,
+} from "./provision-catalog-feed-signing-key";
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryDirectory() {
+  const directory = await mkdtemp(join(tmpdir(), "clawhub-feed-key-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true })),
+  );
+});
+
+describe("catalog feed signing key provisioner", () => {
+  it("parses explicit prepare and activate phases", () => {
+    expect(
+      parseOptions([
+        "prepare",
+        "--key-id",
+        "clawhub-feed-2026-q4",
+        "--public-key-out",
+        "next.pem",
+        "--prod",
+      ]),
+    ).toMatchObject({ command: "prepare", keyId: "clawhub-feed-2026-q4", target: "prod" });
+    expect(
+      parseOptions([
+        "activate",
+        "--key-id",
+        "clawhub-feed-2026-q4",
+        "--public-key",
+        "next.pem",
+        "--deployment",
+        "staging",
+      ]),
+    ).toMatchObject({
+      command: "activate",
+      keyId: "clawhub-feed-2026-q4",
+      target: { deployment: "staging" },
+    });
+  });
+
+  it.each([
+    [[]],
+    [["prepare", "--key-id", "bad key", "--public-key-out", "next.pem", "--prod"]],
+    [["prepare", "--key-id", "next", "--public-key-out", "next.pem"]],
+    [
+      [
+        "activate",
+        "--key-id",
+        "next",
+        "--public-key",
+        "next.pem",
+        "--prod",
+        "--deployment",
+        "staging",
+      ],
+    ],
+  ])("rejects ambiguous or incomplete arguments: %j", (args) => {
+    expect(() => parseOptions(args)).toThrow("Usage:");
+  });
+
+  it("prepares a pending key without changing the active signer", async () => {
+    const directory = await temporaryDirectory();
+    const publicKeyOut = join(directory, "next.pem");
+    const runConvex = vi.fn<ConvexRunner>(() => "");
+
+    await prepareSigningKey(
+      { command: "prepare", keyId: "next", publicKeyOut, target: "prod" },
+      { runConvex },
+    );
+
+    const [[args, config]] = runConvex.mock.calls;
+    expect(args).toEqual(["env", "set", "CLAWHUB_FEED_SIGNING_PENDING_CONFIG", "--prod"]);
+    expect(args).not.toContain("CLAWHUB_FEED_SIGNING_CONFIG");
+    const parsed = JSON.parse(config ?? "") as { keyId: string; privateKey: string };
+    expect(parsed.keyId).toBe("next");
+    const writtenPublicKey = await readFile(publicKeyOut, "utf8");
+    expect(createPublicKey(parsed.privateKey).export({ type: "spki", format: "pem" })).toBe(
+      writtenPublicKey,
+    );
+  });
+
+  it("retains the public recovery material when pending-secret storage fails", async () => {
+    const directory = await temporaryDirectory();
+    const publicKeyOut = join(directory, "next.pem");
+
+    await expect(
+      prepareSigningKey(
+        { command: "prepare", keyId: "next", publicKeyOut, target: "prod" },
+        {
+          runConvex: () => {
+            throw new Error("storage failed");
+          },
+        },
+      ),
+    ).rejects.toThrow("Pending-secret storage was not confirmed");
+    expect(await readFile(publicKeyOut, "utf8")).toContain("BEGIN PUBLIC KEY");
+  });
+
+  it("activates only the pending key that matches the reviewed public key", async () => {
+    const directory = await temporaryDirectory();
+    const publicKey = join(directory, "next.pem");
+    let pendingConfig = "";
+    const prepareRunner: ConvexRunner = (_args, input) => {
+      pendingConfig = input ?? "";
+      return "";
+    };
+    await prepareSigningKey(
+      { command: "prepare", keyId: "next", publicKeyOut: publicKey, target: "prod" },
+      { runConvex: prepareRunner },
+    );
+    const calls: string[][] = [];
+    const activateRunner: ConvexRunner = (args, input) => {
+      calls.push(args);
+      if (args[1] === "get") return pendingConfig;
+      if (args[1] === "set") expect(input).toBe(pendingConfig);
+      return "";
+    };
+
+    await activateSigningKey(
+      { command: "activate", keyId: "next", publicKey, target: "prod" },
+      { runConvex: activateRunner },
+    );
+
+    expect(calls).toEqual([
+      ["env", "get", "CLAWHUB_FEED_SIGNING_PENDING_CONFIG", "--prod"],
+      ["env", "set", "CLAWHUB_FEED_SIGNING_CONFIG", "--prod"],
+      ["env", "remove", "CLAWHUB_FEED_SIGNING_PENDING_CONFIG", "--prod"],
+    ]);
+  });
+
+  it("refuses activation when the reviewed public key does not match", async () => {
+    const directory = await temporaryDirectory();
+    const firstPublicKey = join(directory, "first.pem");
+    const secondPublicKey = join(directory, "second.pem");
+    let pendingConfig = "";
+    await prepareSigningKey(
+      { command: "prepare", keyId: "first", publicKeyOut: firstPublicKey, target: "prod" },
+      { runConvex: (_args, input) => ((pendingConfig = input ?? ""), "") },
+    );
+    await prepareSigningKey(
+      { command: "prepare", keyId: "second", publicKeyOut: secondPublicKey, target: "prod" },
+      { runConvex: () => "" },
+    );
+    const runConvex = vi.fn<ConvexRunner>((args) => (args[1] === "get" ? pendingConfig : ""));
+
+    await expect(
+      activateSigningKey(
+        { command: "activate", keyId: "first", publicKey: secondPublicKey, target: "prod" },
+        { runConvex },
+      ),
+    ).rejects.toThrow("does not match the reviewed public key");
+    expect(runConvex).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not remove the pending key when active promotion fails", async () => {
+    const directory = await temporaryDirectory();
+    const publicKey = join(directory, "next.pem");
+    let pendingConfig = "";
+    await prepareSigningKey(
+      { command: "prepare", keyId: "next", publicKeyOut: publicKey, target: "prod" },
+      { runConvex: (_args, input) => ((pendingConfig = input ?? ""), "") },
+    );
+    const calls: string[][] = [];
+    const runConvex: ConvexRunner = (args) => {
+      calls.push(args);
+      if (args[1] === "get") return pendingConfig;
+      throw new Error("promotion failed");
+    };
+
+    await expect(
+      activateSigningKey(
+        { command: "activate", keyId: "next", publicKey, target: "prod" },
+        { runConvex },
+      ),
+    ).rejects.toThrow("promotion failed");
+    expect(calls.some((args) => args[1] === "remove")).toBe(false);
+  });
+
+  it("reports cleanup failure after activation without hiding the active write", async () => {
+    const directory = await temporaryDirectory();
+    const publicKey = join(directory, "next.pem");
+    let pendingConfig = "";
+    await prepareSigningKey(
+      { command: "prepare", keyId: "next", publicKeyOut: publicKey, target: "prod" },
+      { runConvex: (_args, input) => ((pendingConfig = input ?? ""), "") },
+    );
+    let activated = false;
+    const runConvex: ConvexRunner = (args) => {
+      if (args[1] === "get") return pendingConfig;
+      if (args[1] === "set") {
+        activated = true;
+        return "";
+      }
+      throw new Error("cleanup failed");
+    };
+
+    await expect(
+      activateSigningKey(
+        { command: "activate", keyId: "next", publicKey, target: "prod" },
+        { runConvex },
+      ),
+    ).rejects.toThrow("Signer activated, but pending-secret cleanup failed");
+    expect(activated).toBe(true);
+  });
+
+  it("reports endpoint failure as post-activation verification", async () => {
+    const directory = await temporaryDirectory();
+    const publicKey = join(directory, "next.pem");
+    let pendingConfig = "";
+    await prepareSigningKey(
+      { command: "prepare", keyId: "next", publicKeyOut: publicKey, target: "prod" },
+      { runConvex: (_args, input) => ((pendingConfig = input ?? ""), "") },
+    );
+    const runConvex: ConvexRunner = (args) => (args[1] === "get" ? pendingConfig : "");
+
+    await expect(
+      activateSigningKey(
+        {
+          command: "activate",
+          keyId: "next",
+          publicKey,
+          target: "prod",
+          verifyUrl: "https://clawhub.ai/api/v1/feeds/plugins",
+        },
+        {
+          runConvex,
+          verifyFeed: async () => {
+            throw new Error("HTTP 503");
+          },
+        },
+      ),
+    ).rejects.toThrow("Signer activated and pending secret removed");
+  });
+});

--- a/scripts/provision-catalog-feed-signing-key.test.ts
+++ b/scripts/provision-catalog-feed-signing-key.test.ts
@@ -8,6 +8,7 @@ import {
   parseOptions,
   prepareSigningKey,
   type ConvexRunner,
+  verifyEndpoint,
 } from "./provision-catalog-feed-signing-key";
 
 const temporaryDirectories: string[] = [];
@@ -19,6 +20,7 @@ async function temporaryDirectory() {
 }
 
 afterEach(async () => {
+  vi.unstubAllGlobals();
   await Promise.all(
     temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true })),
   );
@@ -138,9 +140,39 @@ describe("catalog feed signing key provisioner", () => {
 
     expect(calls).toEqual([
       ["env", "get", "CLAWHUB_FEED_SIGNING_PENDING_CONFIG", "--prod"],
+      ["env", "list", "--names-only", "--prod"],
       ["env", "set", "CLAWHUB_FEED_SIGNING_CONFIG", "--prod"],
       ["env", "remove", "CLAWHUB_FEED_SIGNING_PENDING_CONFIG", "--prod"],
     ]);
+  });
+
+  it("preserves the active signer before rotating to the pending key", async () => {
+    const directory = await temporaryDirectory();
+    const publicKey = join(directory, "next.pem");
+    let pendingConfig = "";
+    await prepareSigningKey(
+      { command: "prepare", keyId: "next", publicKeyOut: publicKey, target: "prod" },
+      { runConvex: (_args, input) => ((pendingConfig = input ?? ""), "") },
+    );
+    const activeConfig = JSON.stringify({ keyId: "current", privateKey: "current-private-key" });
+    const writes = new Map<string, string>();
+    const runConvex: ConvexRunner = (args, input) => {
+      const name = args[2] ?? "";
+      if (args[1] === "list") return "CLAWHUB_FEED_SIGNING_CONFIG\nOTHER_NAME\n";
+      if (args[1] === "get") {
+        return name === "CLAWHUB_FEED_SIGNING_PENDING_CONFIG" ? pendingConfig : activeConfig;
+      }
+      if (args[1] === "set") writes.set(name, input ?? "");
+      return "";
+    };
+
+    await activateSigningKey(
+      { command: "activate", keyId: "next", publicKey, target: "prod" },
+      { runConvex },
+    );
+
+    expect(writes.get("CLAWHUB_FEED_SIGNING_PREVIOUS_CONFIG")).toBe(activeConfig);
+    expect(writes.get("CLAWHUB_FEED_SIGNING_CONFIG")).toBe(pendingConfig);
   });
 
   it("refuses activation when the reviewed public key does not match", async () => {
@@ -179,6 +211,7 @@ describe("catalog feed signing key provisioner", () => {
     const runConvex: ConvexRunner = (args) => {
       calls.push(args);
       if (args[1] === "get") return pendingConfig;
+      if (args[1] === "list") return "";
       throw new Error("promotion failed");
     };
 
@@ -202,6 +235,7 @@ describe("catalog feed signing key provisioner", () => {
     let activated = false;
     const runConvex: ConvexRunner = (args) => {
       if (args[1] === "get") return pendingConfig;
+      if (args[1] === "list") return "";
       if (args[1] === "set") {
         activated = true;
         return "";
@@ -216,6 +250,42 @@ describe("catalog feed signing key provisioner", () => {
       ),
     ).rejects.toThrow("Signer activated, but pending-secret cleanup failed");
     expect(activated).toBe(true);
+  });
+
+  it("retries cleanup without overwriting the rollback signer", async () => {
+    const directory = await temporaryDirectory();
+    const publicKey = join(directory, "next.pem");
+    let pendingConfig = "";
+    await prepareSigningKey(
+      { command: "prepare", keyId: "next", publicKeyOut: publicKey, target: "prod" },
+      { runConvex: (_args, input) => ((pendingConfig = input ?? ""), "") },
+    );
+    const calls: string[][] = [];
+    const runConvex: ConvexRunner = (args) => {
+      calls.push(args);
+      if (args[1] === "list") return "CLAWHUB_FEED_SIGNING_CONFIG\n";
+      if (args[1] === "get") return pendingConfig;
+      return "";
+    };
+
+    await activateSigningKey(
+      { command: "activate", keyId: "next", publicKey, target: "prod" },
+      { runConvex },
+    );
+
+    expect(calls).not.toContainEqual([
+      "env",
+      "set",
+      "CLAWHUB_FEED_SIGNING_PREVIOUS_CONFIG",
+      "--prod",
+    ]);
+    expect(calls).not.toContainEqual(["env", "set", "CLAWHUB_FEED_SIGNING_CONFIG", "--prod"]);
+    expect(calls).toContainEqual([
+      "env",
+      "remove",
+      "CLAWHUB_FEED_SIGNING_PENDING_CONFIG",
+      "--prod",
+    ]);
   });
 
   it("reports endpoint failure as post-activation verification", async () => {
@@ -245,5 +315,22 @@ describe("catalog feed signing key provisioner", () => {
         },
       ),
     ).rejects.toThrow("Signer activated and pending secret removed");
+  });
+
+  it("bypasses shared caches during endpoint verification", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("unavailable", { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      verifyEndpoint("https://clawhub.ai/api/v1/feeds/plugins", "unused", "next"),
+    ).rejects.toThrow("HTTP 503");
+
+    const [requestUrl, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(requestUrl.searchParams.get("feed-signing-verification")).toBeTruthy();
+    expect(init.headers).toMatchObject({
+      Accept: "application/vnd.dsse+json",
+      "Cache-Control": "no-cache, no-store",
+      Pragma: "no-cache",
+    });
   });
 });

--- a/scripts/provision-catalog-feed-signing-key.ts
+++ b/scripts/provision-catalog-feed-signing-key.ts
@@ -1,0 +1,124 @@
+import { spawnSync } from "node:child_process";
+import {
+  createHash,
+  createPublicKey,
+  generateKeyPairSync,
+  verify as verifyDetached,
+} from "node:crypto";
+import { existsSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const PAYLOAD_TYPE = "openclaw.official-external-plugin-catalog-feed.v1";
+
+type Options = {
+  keyId: string;
+  publicKeyOut: string;
+  target: "prod" | { deployment: string };
+  verifyUrl?: string;
+};
+
+function usage(): never {
+  throw new Error(
+    "Usage: bun scripts/provision-catalog-feed-signing-key.ts --key-id <id> --public-key-out <path> (--prod | --deployment <name>) [--verify-url <url>]",
+  );
+}
+
+export function parseOptions(args: string[]): Options {
+  const values = new Map<string, string>();
+  const flags = new Set<string>();
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--prod") {
+      flags.add(arg);
+      continue;
+    }
+    if (!arg?.startsWith("--")) usage();
+    const value = args[index + 1];
+    if (!value || value.startsWith("--")) usage();
+    values.set(arg, value);
+    index += 1;
+  }
+  const keyId = values.get("--key-id")?.trim();
+  const publicKeyOut = values.get("--public-key-out")?.trim();
+  const deployment = values.get("--deployment")?.trim();
+  if (!keyId || !publicKeyOut || !/^[A-Za-z0-9._:-]{1,128}$/u.test(keyId)) usage();
+  if (flags.has("--prod") === Boolean(deployment)) usage();
+  return {
+    keyId,
+    publicKeyOut: resolve(publicKeyOut),
+    target: deployment ? { deployment } : "prod",
+    verifyUrl: values.get("--verify-url")?.trim(),
+  };
+}
+
+function dsseInput(payload: Buffer) {
+  const type = Buffer.from(PAYLOAD_TYPE, "utf8");
+  return Buffer.concat([
+    Buffer.from(`DSSEv1 ${type.length} ${PAYLOAD_TYPE} ${payload.length} `, "utf8"),
+    payload,
+  ]);
+}
+
+async function verifyEndpoint(url: string, publicKey: string, keyId: string) {
+  const response = await fetch(url, { headers: { Accept: "application/vnd.dsse+json" } });
+  if (!response.ok) throw new Error(`Signed feed verification failed with HTTP ${response.status}`);
+  const envelope = (await response.json()) as {
+    payloadType?: string;
+    payload?: string;
+    signatures?: { keyid?: string; sig?: string }[];
+  };
+  const signature = envelope.signatures?.find((candidate) => candidate.keyid === keyId);
+  if (envelope.payloadType !== PAYLOAD_TYPE || !envelope.payload || !signature?.sig) {
+    throw new Error("Signed feed returned an unexpected DSSE envelope");
+  }
+  const payload = Buffer.from(envelope.payload, "base64url");
+  if (
+    !verifyDetached(
+      null,
+      dsseInput(payload),
+      createPublicKey(publicKey),
+      Buffer.from(signature.sig, "base64url"),
+    )
+  ) {
+    throw new Error("Signed feed signature verification failed");
+  }
+}
+
+export async function main(args = process.argv.slice(2)) {
+  const options = parseOptions(args);
+  if (existsSync(options.publicKeyOut)) {
+    throw new Error(`Refusing to overwrite existing public key: ${options.publicKeyOut}`);
+  }
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519", {
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  const config = JSON.stringify({ keyId: options.keyId, privateKey });
+  const targetArgs =
+    options.target === "prod" ? ["--prod"] : ["--deployment", options.target.deployment];
+  // Persist the non-secret half first so a successful secret write can never
+  // activate a signer whose matching trust anchor was lost locally.
+  await writeFile(options.publicKeyOut, publicKey, { encoding: "utf8", flag: "wx" });
+  const child = spawnSync(
+    process.execPath,
+    ["x", "convex", "env", "set", "CLAWHUB_FEED_SIGNING_CONFIG", ...targetArgs],
+    { input: config, stdio: ["pipe", "inherit", "inherit"] },
+  );
+  if (child.error || child.status !== 0) {
+    throw new Error(
+      `Convex did not confirm the signing configuration${child.error ? `: ${child.error.message}` : ""}; public key retained at ${options.publicKeyOut} for recovery checks`,
+    );
+  }
+
+  const fingerprint = createHash("sha256")
+    .update(createPublicKey(publicKey).export({ type: "spki", format: "der" }))
+    .digest("hex");
+  console.log(`keyId=${options.keyId}`);
+  console.log(`publicKey=${options.publicKeyOut}`);
+  console.log(`spkiSha256=${fingerprint}`);
+  console.log("The private key was sent directly to Convex and was not written or printed.");
+  if (options.verifyUrl) await verifyEndpoint(options.verifyUrl, publicKey, options.keyId);
+}
+
+if (import.meta.main) await main();

--- a/scripts/provision-catalog-feed-signing-key.ts
+++ b/scripts/provision-catalog-feed-signing-key.ts
@@ -6,50 +6,140 @@ import {
   verify as verifyDetached,
 } from "node:crypto";
 import { existsSync } from "node:fs";
-import { writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 
+const ACTIVE_CONFIG_NAME = "CLAWHUB_FEED_SIGNING_CONFIG";
+const PENDING_CONFIG_NAME = "CLAWHUB_FEED_SIGNING_PENDING_CONFIG";
 const PAYLOAD_TYPE = "openclaw.official-external-plugin-catalog-feed.v1";
 
-type Options = {
+type Target = "prod" | { deployment: string };
+
+type PrepareOptions = {
+  command: "prepare";
   keyId: string;
   publicKeyOut: string;
-  target: "prod" | { deployment: string };
+  target: Target;
+};
+
+type ActivateOptions = {
+  command: "activate";
+  keyId: string;
+  publicKey: string;
+  target: Target;
   verifyUrl?: string;
+};
+
+export type Options = PrepareOptions | ActivateOptions;
+
+export type ConvexRunner = (args: string[], input?: string) => string;
+
+type Dependencies = {
+  runConvex?: ConvexRunner;
+  verifyFeed?: (url: string, publicKey: string, keyId: string) => Promise<void>;
 };
 
 function usage(): never {
   throw new Error(
-    "Usage: bun scripts/provision-catalog-feed-signing-key.ts --key-id <id> --public-key-out <path> (--prod | --deployment <name>) [--verify-url <url>]",
+    "Usage: ... prepare --key-id <id> --public-key-out <path> (--prod | --deployment <name>)\n" +
+      "   or: ... activate --key-id <id> --public-key <path> (--prod | --deployment <name>) [--verify-url <url>]",
   );
 }
 
+function parseTarget(values: Map<string, string>, flags: Set<string>): Target {
+  const deployment = values.get("--deployment")?.trim();
+  if (flags.has("--prod") === Boolean(deployment)) usage();
+  return deployment ? { deployment } : "prod";
+}
+
 export function parseOptions(args: string[]): Options {
+  const [command, ...optionArgs] = args;
+  if (command !== "prepare" && command !== "activate") usage();
   const values = new Map<string, string>();
   const flags = new Set<string>();
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
+  const allowedValues = new Set([
+    "--key-id",
+    "--public-key-out",
+    "--public-key",
+    "--deployment",
+    "--verify-url",
+  ]);
+  for (let index = 0; index < optionArgs.length; index += 1) {
+    const arg = optionArgs[index];
     if (arg === "--prod") {
       flags.add(arg);
       continue;
     }
-    if (!arg?.startsWith("--")) usage();
-    const value = args[index + 1];
+    if (!arg || !allowedValues.has(arg)) usage();
+    const value = optionArgs[index + 1];
     if (!value || value.startsWith("--")) usage();
     values.set(arg, value);
     index += 1;
   }
   const keyId = values.get("--key-id")?.trim();
-  const publicKeyOut = values.get("--public-key-out")?.trim();
-  const deployment = values.get("--deployment")?.trim();
-  if (!keyId || !publicKeyOut || !/^[A-Za-z0-9._:-]{1,128}$/u.test(keyId)) usage();
-  if (flags.has("--prod") === Boolean(deployment)) usage();
+  if (!keyId || !/^[A-Za-z0-9._:-]{1,128}$/u.test(keyId)) usage();
+  const target = parseTarget(values, flags);
+  if (command === "prepare") {
+    const publicKeyOut = values.get("--public-key-out")?.trim();
+    if (!publicKeyOut || values.has("--public-key") || values.has("--verify-url")) usage();
+    return { command, keyId, publicKeyOut: resolve(publicKeyOut), target };
+  }
+  const publicKey = values.get("--public-key")?.trim();
+  if (!publicKey || values.has("--public-key-out")) usage();
   return {
+    command,
     keyId,
-    publicKeyOut: resolve(publicKeyOut),
-    target: deployment ? { deployment } : "prod",
+    publicKey: resolve(publicKey),
+    target,
     verifyUrl: values.get("--verify-url")?.trim(),
   };
+}
+
+function targetArgs(target: Target) {
+  return target === "prod" ? ["--prod"] : ["--deployment", target.deployment];
+}
+
+function runConvex(args: string[], input?: string) {
+  const child = spawnSync(process.execPath, ["x", "convex", ...args], {
+    ...(input === undefined ? {} : { input }),
+    encoding: "utf8",
+    stdio: input === undefined ? ["ignore", "pipe", "inherit"] : ["pipe", "pipe", "inherit"],
+  });
+  if (child.error || child.status !== 0) {
+    throw new Error(
+      `Convex command did not complete${child.error ? `: ${child.error.message}` : ` (exit ${child.status ?? "unknown"})`}`,
+    );
+  }
+  return child.stdout ?? "";
+}
+
+function parseSigningConfig(raw: string) {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw.trim());
+  } catch {
+    throw new Error("Pending signing config is not valid JSON");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Pending signing config is not an object");
+  }
+  const record = parsed as Record<string, unknown>;
+  if (
+    Object.keys(record).sort().join(",") !== "keyId,privateKey" ||
+    typeof record.keyId !== "string" ||
+    typeof record.privateKey !== "string"
+  ) {
+    throw new Error("Pending signing config has an unexpected shape");
+  }
+  return { keyId: record.keyId, privateKey: record.privateKey };
+}
+
+function publicKeyDer(pem: string) {
+  return createPublicKey(pem).export({ type: "spki", format: "der" });
+}
+
+function publicKeyFingerprint(pem: string) {
+  return createHash("sha256").update(publicKeyDer(pem)).digest("hex");
 }
 
 function dsseInput(payload: Buffer) {
@@ -85,8 +175,7 @@ async function verifyEndpoint(url: string, publicKey: string, keyId: string) {
   }
 }
 
-export async function main(args = process.argv.slice(2)) {
-  const options = parseOptions(args);
+export async function prepareSigningKey(options: PrepareOptions, dependencies: Dependencies = {}) {
   if (existsSync(options.publicKeyOut)) {
     throw new Error(`Refusing to overwrite existing public key: ${options.publicKeyOut}`);
   }
@@ -94,31 +183,82 @@ export async function main(args = process.argv.slice(2)) {
     privateKeyEncoding: { type: "pkcs8", format: "pem" },
     publicKeyEncoding: { type: "spki", format: "pem" },
   });
-  const config = JSON.stringify({ keyId: options.keyId, privateKey });
-  const targetArgs =
-    options.target === "prod" ? ["--prod"] : ["--deployment", options.target.deployment];
-  // Persist the non-secret half first so a successful secret write can never
-  // activate a signer whose matching trust anchor was lost locally.
   await writeFile(options.publicKeyOut, publicKey, { encoding: "utf8", flag: "wx" });
-  const child = spawnSync(
-    process.execPath,
-    ["x", "convex", "env", "set", "CLAWHUB_FEED_SIGNING_CONFIG", ...targetArgs],
-    { input: config, stdio: ["pipe", "inherit", "inherit"] },
-  );
-  if (child.error || child.status !== 0) {
+  const config = JSON.stringify({ keyId: options.keyId, privateKey });
+  const runner = dependencies.runConvex ?? runConvex;
+  try {
+    runner(["env", "set", PENDING_CONFIG_NAME, ...targetArgs(options.target)], config);
+  } catch (error) {
     throw new Error(
-      `Convex did not confirm the signing configuration${child.error ? `: ${child.error.message}` : ""}; public key retained at ${options.publicKeyOut} for recovery checks`,
+      `Pending-secret storage was not confirmed; public key retained at ${options.publicKeyOut} for recovery checks: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
     );
   }
+  return { fingerprint: publicKeyFingerprint(publicKey), publicKey: options.publicKeyOut };
+}
 
-  const fingerprint = createHash("sha256")
-    .update(createPublicKey(publicKey).export({ type: "spki", format: "der" }))
-    .digest("hex");
+export async function activateSigningKey(
+  options: ActivateOptions,
+  dependencies: Dependencies = {},
+) {
+  const runner = dependencies.runConvex ?? runConvex;
+  const pendingRaw = runner(["env", "get", PENDING_CONFIG_NAME, ...targetArgs(options.target)]);
+  const pending = parseSigningConfig(pendingRaw);
+  if (pending.keyId !== options.keyId) {
+    throw new Error(`Pending signing key id is ${pending.keyId}, not ${options.keyId}`);
+  }
+  const reviewedPublicKey = await readFile(options.publicKey, "utf8");
+  const derivedPublicKey = createPublicKey(pending.privateKey).export({
+    type: "spki",
+    format: "pem",
+  });
+  if (!publicKeyDer(reviewedPublicKey).equals(publicKeyDer(derivedPublicKey))) {
+    throw new Error("Pending private key does not match the reviewed public key");
+  }
+
+  const config = JSON.stringify(pending);
+  runner(["env", "set", ACTIVE_CONFIG_NAME, ...targetArgs(options.target)], config);
+  try {
+    runner(["env", "remove", PENDING_CONFIG_NAME, ...targetArgs(options.target)]);
+  } catch (error) {
+    throw new Error(
+      `Signer activated, but pending-secret cleanup failed: ${error instanceof Error ? error.message : String(error)}`,
+      { cause: error },
+    );
+  }
+  const fingerprint = publicKeyFingerprint(reviewedPublicKey);
+  if (options.verifyUrl) {
+    try {
+      await (dependencies.verifyFeed ?? verifyEndpoint)(
+        options.verifyUrl,
+        reviewedPublicKey,
+        options.keyId,
+      );
+    } catch (error) {
+      throw new Error(
+        `Signer activated and pending secret removed, but endpoint verification failed: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
+    }
+  }
+  return { fingerprint, publicKey: options.publicKey };
+}
+
+export async function main(args = process.argv.slice(2)) {
+  const options = parseOptions(args);
+  const result =
+    options.command === "prepare"
+      ? await prepareSigningKey(options)
+      : await activateSigningKey(options);
+  console.log(`phase=${options.command}`);
   console.log(`keyId=${options.keyId}`);
-  console.log(`publicKey=${options.publicKeyOut}`);
-  console.log(`spkiSha256=${fingerprint}`);
-  console.log("The private key was sent directly to Convex and was not written or printed.");
-  if (options.verifyUrl) await verifyEndpoint(options.verifyUrl, publicKey, options.keyId);
+  console.log(`publicKey=${result.publicKey}`);
+  console.log(`spkiSha256=${result.fingerprint}`);
+  console.log(
+    options.command === "prepare"
+      ? "The private key is pending in Convex and is not active."
+      : "The reviewed pending key is active and the pending secret was removed.",
+  );
 }
 
 if (import.meta.main) await main();

--- a/scripts/provision-catalog-feed-signing-key.ts
+++ b/scripts/provision-catalog-feed-signing-key.ts
@@ -3,6 +3,7 @@ import {
   createHash,
   createPublicKey,
   generateKeyPairSync,
+  randomUUID,
   verify as verifyDetached,
 } from "node:crypto";
 import { existsSync } from "node:fs";
@@ -11,6 +12,7 @@ import { resolve } from "node:path";
 
 const ACTIVE_CONFIG_NAME = "CLAWHUB_FEED_SIGNING_CONFIG";
 const PENDING_CONFIG_NAME = "CLAWHUB_FEED_SIGNING_PENDING_CONFIG";
+const PREVIOUS_CONFIG_NAME = "CLAWHUB_FEED_SIGNING_PREVIOUS_CONFIG";
 const PAYLOAD_TYPE = "openclaw.official-external-plugin-catalog-feed.v1";
 
 type Target = "prod" | { deployment: string };
@@ -113,15 +115,15 @@ function runConvex(args: string[], input?: string) {
   return child.stdout ?? "";
 }
 
-function parseSigningConfig(raw: string) {
+function parseSigningConfig(raw: string, label = "Pending") {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw.trim());
   } catch {
-    throw new Error("Pending signing config is not valid JSON");
+    throw new Error(`${label} signing config is not valid JSON`);
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error("Pending signing config is not an object");
+    throw new Error(`${label} signing config is not an object`);
   }
   const record = parsed as Record<string, unknown>;
   if (
@@ -129,7 +131,7 @@ function parseSigningConfig(raw: string) {
     typeof record.keyId !== "string" ||
     typeof record.privateKey !== "string"
   ) {
-    throw new Error("Pending signing config has an unexpected shape");
+    throw new Error(`${label} signing config has an unexpected shape`);
   }
   return { keyId: record.keyId, privateKey: record.privateKey };
 }
@@ -150,8 +152,16 @@ function dsseInput(payload: Buffer) {
   ]);
 }
 
-async function verifyEndpoint(url: string, publicKey: string, keyId: string) {
-  const response = await fetch(url, { headers: { Accept: "application/vnd.dsse+json" } });
+export async function verifyEndpoint(url: string, publicKey: string, keyId: string) {
+  const verificationUrl = new URL(url);
+  verificationUrl.searchParams.set("feed-signing-verification", randomUUID());
+  const response = await fetch(verificationUrl, {
+    headers: {
+      Accept: "application/vnd.dsse+json",
+      "Cache-Control": "no-cache, no-store",
+      Pragma: "no-cache",
+    },
+  });
   if (!response.ok) throw new Error(`Signed feed verification failed with HTTP ${response.status}`);
   const envelope = (await response.json()) as {
     payloadType?: string;
@@ -216,8 +226,25 @@ export async function activateSigningKey(
     throw new Error("Pending private key does not match the reviewed public key");
   }
 
+  const environmentNames = runner(["env", "list", "--names-only", ...targetArgs(options.target)]);
+  let activeAlreadyPending = false;
+  if (environmentNames.split(/\r?\n/u).some((name) => name.trim() === ACTIVE_CONFIG_NAME)) {
+    const activeRaw = runner(["env", "get", ACTIVE_CONFIG_NAME, ...targetArgs(options.target)]);
+    const active = parseSigningConfig(activeRaw, "Active");
+    activeAlreadyPending =
+      active.keyId === pending.keyId && active.privateKey === pending.privateKey;
+    if (!activeAlreadyPending) {
+      runner(
+        ["env", "set", PREVIOUS_CONFIG_NAME, ...targetArgs(options.target)],
+        JSON.stringify(active),
+      );
+    }
+  }
+
   const config = JSON.stringify(pending);
-  runner(["env", "set", ACTIVE_CONFIG_NAME, ...targetArgs(options.target)], config);
+  if (!activeAlreadyPending) {
+    runner(["env", "set", ACTIVE_CONFIG_NAME, ...targetArgs(options.target)], config);
+  }
   try {
     runner(["env", "remove", PENDING_CONFIG_NAME, ...targetArgs(options.target)]);
   } catch (error) {

--- a/specs/hosted-catalog-feed.md
+++ b/specs/hosted-catalog-feed.md
@@ -182,50 +182,65 @@ bootstrap endpoint from the same origin as the feed.
 
 ### Initial provisioning
 
-1. On an approved operator machine with production Convex access, generate and
-   provision a dedicated Ed25519 key pair without writing or printing the
-   private key:
+1. Choose a stable, non-secret key id such as `clawhub-feed-2026-q3`. Record the
+   owner, creation time, intended deployment, and rotation contact in the
+   operator secret inventory.
+2. On an approved operator machine with production Convex access, prepare a
+   dedicated Ed25519 key pair without writing or printing the private key:
 
    ```powershell
-   bun scripts/provision-catalog-feed-signing-key.ts `
+   bun run provision:catalog-feed-key -- prepare `
      --key-id clawhub-feed-2026-q3 `
      --public-key-out .\clawhub-feed-public.pem `
      --prod
    ```
 
-2. Choose a stable, non-secret key id such as `clawhub-feed-2026-q3`. Record the
-   owner, creation time, intended deployment, and rotation contact in the
-   operator secret inventory.
-3. The helper stores the key id and private PEM as one atomic JSON value. Do not
-   create separate mutable variables for the pair: a partially rotated pair can
-   publish an unverifiable cacheable envelope. For a non-production deployment,
-   use `--deployment <name>` instead of `--prod`.
+   Preparation stores the key id and private PEM together in the non-active
+   `CLAWHUB_FEED_SIGNING_PENDING_CONFIG` secret and emits only the public key
+   and fingerprint. For a non-production deployment, use `--deployment <name>`
+   instead of `--prod`.
 
-4. Confirm only the variable names, not their values:
+3. Confirm only the variable names, not their values:
 
    ```bash
    bunx convex env list --names-only --prod
    ```
 
-5. Provide `clawhub-feed-public.pem` and the key id to the OpenClaw maintainer
+4. Provide `clawhub-feed-public.pem`, its reported fingerprint, and the key id
+   to the OpenClaw maintainer
    bundling the `clawhub-public` trust profile. The private PEM never leaves
    ClawHub's operator-controlled secret path.
-6. Deploy ClawHub, publish a fresh `clawhub-official` snapshot, and verify that
+5. After the matching OpenClaw trust anchor is released, activate the reviewed
+   public key:
+
+   ```powershell
+   bun run provision:catalog-feed-key -- activate `
+     --key-id clawhub-feed-2026-q3 `
+     --public-key .\clawhub-feed-public.pem `
+     --prod `
+     --verify-url https://clawhub.ai/api/v1/feeds/plugins
+   ```
+
+   Activation reads the pending secret into process memory, derives its public
+   key, and requires it to match the reviewed file before atomically replacing
+   `CLAWHUB_FEED_SIGNING_CONFIG`. It removes the pending secret only after the
+   active write succeeds.
+
+6. Publish a fresh `clawhub-official` snapshot and verify that
    an `Accept: application/vnd.dsse+json` request to `/api/v1/feeds/plugins`
    returns an envelope whose decoded payload bytes equal the stored publication
-   and whose signature verifies with the handed-off public key. The provisioning
-   helper can perform this check with `--verify-url` after the endpoint is
-   deployed.
-7. Land and release the matching OpenClaw bundled public key. Older unsigned
+   and whose signature verifies with the handed-off public key. Older unsigned
    clients continue receiving the unsigned representation during migration.
 
 ### Normal rotation
 
-1. Generate a new dedicated key and key id.
-2. Bundle the new public key in OpenClaw while the old key remains trusted.
-3. After that trust update is available, replace
-   `CLAWHUB_FEED_SIGNING_CONFIG` once with JSON containing the new matched pair,
-   then deploy. Never stage key id and private key separately.
+1. Run the `prepare` command with a new key id and public-key output path. This
+   changes only `CLAWHUB_FEED_SIGNING_PENDING_CONFIG`; the active signer remains
+   unchanged.
+2. Bundle the new public key and recorded fingerprint in OpenClaw while the old
+   key remains trusted.
+3. After that trust update is released, run `activate` with the same key id and
+   reviewed public-key file. Never activate before the trust overlap is live.
 4. Verify a higher-sequence publication under the new key before retiring the
    old private key.
 5. Remove the old public key in a later OpenClaw release after the supported
@@ -240,6 +255,6 @@ multi-key signer support before beginning that rotation.
 Remove `CLAWHUB_FEED_SIGNING_CONFIG` or replace it with a new matched pair in
 Convex immediately. An absent signing configuration makes opted-in signed
 requests return `503 no-store` while the unsigned compatibility representation
-remains available. Notify OpenClaw maintainers to remove the compromised public key
-through the authenticated release channel. Do not recover by advertising a new
-public key from a feed-adjacent endpoint.
+remains available. Notify OpenClaw maintainers to remove the compromised public
+key through the authenticated release channel. Do not recover by advertising a
+new public key from a feed-adjacent endpoint.

--- a/specs/hosted-catalog-feed.md
+++ b/specs/hosted-catalog-feed.md
@@ -117,6 +117,7 @@ matching public key is bundled in OpenClaw.
 The response uses the standard DSSE JSON envelope fields: `payloadType`,
 `payload`, and `signatures` containing `keyid` and `sig`. Ed25519 is selected by
 the trusted key profile rather than repeated as a nonstandard signature field.
+The signed representation uses the `application/vnd.dsse+json` media type.
 
 `convex/promotionsFeed.ts` builds the promotions snapshot from the bounded active
 set and stores it in the same publication table. Production backend deploys

--- a/specs/hosted-catalog-feed.md
+++ b/specs/hosted-catalog-feed.md
@@ -233,8 +233,14 @@ bootstrap endpoint from the same origin as the feed.
 
    Activation reads the pending secret into process memory, derives its public
    key, and requires it to match the reviewed file before atomically replacing
-   `CLAWHUB_FEED_SIGNING_CONFIG`. It removes the pending secret only after the
-   active write succeeds.
+   `CLAWHUB_FEED_SIGNING_CONFIG`. When an active signer already exists, the
+   script first copies it to `CLAWHUB_FEED_SIGNING_PREVIOUS_CONFIG` so operators
+   retain one rollback signer. It removes the pending secret only after the
+   previous and active writes succeed. Endpoint verification uses a unique query
+   value plus no-cache request directives so a CDN cannot satisfy it with the
+   prior signed envelope. If pending-secret cleanup fails after activation,
+   rerunning the same command detects that the pending signer is already active
+   and retries cleanup without replacing the rollback copy.
 
 6. Publish a fresh `clawhub-official` snapshot and verify that
    an `Accept: application/vnd.dsse+json` request to `/api/v1/feeds/plugins`
@@ -251,6 +257,9 @@ bootstrap endpoint from the same origin as the feed.
    key remains trusted.
 3. After that trust update is released, run `activate` with the same key id and
    reviewed public-key file. Never activate before the trust overlap is live.
+   Activation retains the displaced signer in
+   `CLAWHUB_FEED_SIGNING_PREVIOUS_CONFIG`; do not remove it until the new signer
+   has passed the publication proof.
 4. Verify a higher-sequence publication under the new key before retiring the
    old private key.
 5. Remove the old public key in a later OpenClaw release after the supported

--- a/specs/hosted-catalog-feed.md
+++ b/specs/hosted-catalog-feed.md
@@ -114,6 +114,10 @@ the plugin HTTP action wraps those exact bytes in a deterministic DSSE/Ed25519
 envelope. The private key stays in Convex environment secret storage and the
 matching public key is bundled in OpenClaw.
 
+The response uses the standard DSSE JSON envelope fields: `payloadType`,
+`payload`, and `signatures` containing `keyid` and `sig`. Ed25519 is selected by
+the trusted key profile rather than repeated as a nonstandard signature field.
+
 `convex/promotionsFeed.ts` builds the promotions snapshot from the bounded active
 set and stores it in the same publication table. Production backend deploys
 publish an initial snapshot before contract verification. Promotion updates and

--- a/specs/hosted-catalog-feed.md
+++ b/specs/hosted-catalog-feed.md
@@ -129,14 +129,18 @@ The stable HTTP endpoints are `/api/v1/feeds/plugins`, `/api/v1/feeds/skills`,
 and `/api/v1/feeds/promotions`. Each representation provides:
 
 - `ETag: "sha256:<payload hash>"`
-- `Last-Modified`
 - `Cache-Control: public, max-age=60, s-maxage=300, stale-while-revalidate=86400`
 - `Surrogate-Control: max-age=300, stale-while-revalidate=86400`
-- `304 Not Modified` for matching `If-None-Match` or `If-Modified-Since`
+- `304 Not Modified` for matching `If-None-Match`
 
-The plugin feed route requires `CLAWHUB_FEED_SIGNING_KEY_ID` and
-`CLAWHUB_FEED_SIGNING_PRIVATE_KEY`. It returns `503` with `Cache-Control:
-no-store` when either value is absent, incomplete, or invalid. Its ETag and
+Unsigned skills and promotions also expose `Last-Modified` and accept
+`If-Modified-Since`. The signed plugin representation intentionally does not:
+rotating its signer changes the envelope without changing the underlying
+publication time, so only its representation ETag is a valid cache validator.
+
+The plugin feed route requires one atomic `CLAWHUB_FEED_SIGNING_CONFIG` JSON
+secret containing exactly `keyId` and `privateKey`. It returns `503` with
+`Cache-Control: no-store` when the value is absent or invalid. Its ETag and
 `X-Content-SHA256` describe the signed envelope representation;
 `X-Catalog-Payload-SHA256` preserves the stored publication payload digest.
 Skills and promotions remain on their existing unsigned representations until
@@ -178,15 +182,18 @@ bootstrap endpoint from the same origin as the feed.
 2. Choose a stable, non-secret key id such as `clawhub-feed-2026-q3`. Record the
    owner, creation time, intended deployment, and rotation contact in the
    operator secret inventory.
-3. Store the private PEM in each intended Convex deployment without placing it
-   in shell history. For production, use the Convex dashboard or pipe the value
-   to the CLI:
+3. Store the key id and private PEM as one atomic JSON value in each intended
+   Convex deployment. Do not create separate mutable variables for the pair: a
+   partially rotated pair can publish an unverifiable cacheable envelope. For
+   production, use the Convex dashboard or pipe compact JSON to the CLI without
+   placing the private key in shell history:
 
    ```powershell
-   Get-Content -Raw .\clawhub-feed-private.pem |
-     bunx convex env set CLAWHUB_FEED_SIGNING_PRIVATE_KEY --prod
-   "clawhub-feed-2026-q3" |
-     bunx convex env set CLAWHUB_FEED_SIGNING_KEY_ID --prod
+   @{
+     keyId = "clawhub-feed-2026-q3"
+     privateKey = Get-Content -Raw .\clawhub-feed-private.pem
+   } | ConvertTo-Json -Compress |
+     bunx convex env set CLAWHUB_FEED_SIGNING_CONFIG --prod
    ```
 
 4. Confirm only the variable names, not their values:
@@ -212,8 +219,9 @@ bootstrap endpoint from the same origin as the feed.
 
 1. Generate a new dedicated key and key id.
 2. Bundle the new public key in OpenClaw while the old key remains trusted.
-3. After that trust update is available, update the two Convex signing variables
-   together and deploy.
+3. After that trust update is available, replace
+   `CLAWHUB_FEED_SIGNING_CONFIG` once with JSON containing the new matched pair,
+   then deploy. Never stage key id and private key separately.
 4. Verify a higher-sequence publication under the new key before retiring the
    old private key.
 5. Remove the old public key in a later OpenClaw release after the supported
@@ -225,8 +233,8 @@ multi-key signer support before beginning that rotation.
 
 ### Emergency revocation
 
-Remove or replace the compromised private key in Convex immediately. Leaving
-signing configuration incomplete intentionally makes the plugin feed return
+Remove `CLAWHUB_FEED_SIGNING_CONFIG` or replace it with a new matched pair in
+Convex immediately. An absent signing configuration makes the plugin feed return
 `503 no-store`. Notify OpenClaw maintainers to remove the compromised public key
 through the authenticated release channel. Do not recover by advertising a new
 public key from a feed-adjacent endpoint.

--- a/specs/hosted-catalog-feed.md
+++ b/specs/hosted-catalog-feed.md
@@ -117,7 +117,9 @@ matching public key is bundled in OpenClaw.
 The response uses the standard DSSE JSON envelope fields: `payloadType`,
 `payload`, and `signatures` containing `keyid` and `sig`. Ed25519 is selected by
 the trusted key profile rather than repeated as a nonstandard signature field.
-The signed representation uses the `application/vnd.dsse+json` media type.
+The signed representation uses the `application/vnd.dsse+json` media type and
+is selected only when the client sends that media type in `Accept`. Requests
+without that opt-in retain the existing unsigned JSON representation.
 
 `convex/promotionsFeed.ts` builds the promotions snapshot from the bounded active
 set and stores it in the same publication table. Production backend deploys
@@ -143,9 +145,12 @@ Unsigned skills and promotions also expose `Last-Modified` and accept
 rotating its signer changes the envelope without changing the underlying
 publication time, so only its representation ETag is a valid cache validator.
 
-The plugin feed route requires one atomic `CLAWHUB_FEED_SIGNING_CONFIG` JSON
-secret containing exactly `keyId` and `privateKey`. It returns `503` with
-`Cache-Control: no-store` when the value is absent or invalid. Its ETag and
+The signed plugin representation requires one atomic
+`CLAWHUB_FEED_SIGNING_CONFIG` JSON secret containing exactly `keyId` and
+`privateKey`. An opted-in signed request returns `503` with `Cache-Control:
+no-store` when the value is absent or invalid; unsigned requests remain
+available during rollout and signer incidents. Responses include `Vary:
+Accept`. The signed representation's ETag and
 `X-Content-SHA256` describe the signed envelope representation;
 `X-Catalog-Payload-SHA256` preserves the stored publication payload digest.
 Skills and promotions remain on their existing unsigned representations until
@@ -177,29 +182,24 @@ bootstrap endpoint from the same origin as the feed.
 
 ### Initial provisioning
 
-1. Generate a dedicated Ed25519 key pair on an approved operator machine:
+1. On an approved operator machine with production Convex access, generate and
+   provision a dedicated Ed25519 key pair without writing or printing the
+   private key:
 
-   ```bash
-   openssl genpkey -algorithm ED25519 -out clawhub-feed-private.pem
-   openssl pkey -in clawhub-feed-private.pem -pubout -out clawhub-feed-public.pem
+   ```powershell
+   bun scripts/provision-catalog-feed-signing-key.ts `
+     --key-id clawhub-feed-2026-q3 `
+     --public-key-out .\clawhub-feed-public.pem `
+     --prod
    ```
 
 2. Choose a stable, non-secret key id such as `clawhub-feed-2026-q3`. Record the
    owner, creation time, intended deployment, and rotation contact in the
    operator secret inventory.
-3. Store the key id and private PEM as one atomic JSON value in each intended
-   Convex deployment. Do not create separate mutable variables for the pair: a
-   partially rotated pair can publish an unverifiable cacheable envelope. For
-   production, use the Convex dashboard or pipe compact JSON to the CLI without
-   placing the private key in shell history:
-
-   ```powershell
-   @{
-     keyId = "clawhub-feed-2026-q3"
-     privateKey = Get-Content -Raw .\clawhub-feed-private.pem
-   } | ConvertTo-Json -Compress |
-     bunx convex env set CLAWHUB_FEED_SIGNING_CONFIG --prod
-   ```
+3. The helper stores the key id and private PEM as one atomic JSON value. Do not
+   create separate mutable variables for the pair: a partially rotated pair can
+   publish an unverifiable cacheable envelope. For a non-production deployment,
+   use `--deployment <name>` instead of `--prod`.
 
 4. Confirm only the variable names, not their values:
 
@@ -211,14 +211,13 @@ bootstrap endpoint from the same origin as the feed.
    bundling the `clawhub-public` trust profile. The private PEM never leaves
    ClawHub's operator-controlled secret path.
 6. Deploy ClawHub, publish a fresh `clawhub-official` snapshot, and verify that
-   `/api/v1/feeds/plugins` returns an envelope whose decoded payload bytes equal
-   the stored publication and whose signature verifies with the handed-off
-   public key.
+   an `Accept: application/vnd.dsse+json` request to `/api/v1/feeds/plugins`
+   returns an envelope whose decoded payload bytes equal the stored publication
+   and whose signature verifies with the handed-off public key. The provisioning
+   helper can perform this check with `--verify-url` after the endpoint is
+   deployed.
 7. Land and release the matching OpenClaw bundled public key. Older unsigned
-   clients may fall back to their bundled catalog when they first encounter the
-   envelope; they must not reinterpret it as unsigned feed content.
-8. Securely delete operator-machine private-key files after the approved secret
-   backup and recovery process is complete.
+   clients continue receiving the unsigned representation during migration.
 
 ### Normal rotation
 
@@ -239,7 +238,8 @@ multi-key signer support before beginning that rotation.
 ### Emergency revocation
 
 Remove `CLAWHUB_FEED_SIGNING_CONFIG` or replace it with a new matched pair in
-Convex immediately. An absent signing configuration makes the plugin feed return
-`503 no-store`. Notify OpenClaw maintainers to remove the compromised public key
+Convex immediately. An absent signing configuration makes opted-in signed
+requests return `503 no-store` while the unsigned compatibility representation
+remains available. Notify OpenClaw maintainers to remove the compromised public key
 through the authenticated release channel. Do not recover by advertising a new
 public key from a feed-adjacent endpoint.

--- a/specs/hosted-catalog-feed.md
+++ b/specs/hosted-catalog-feed.md
@@ -109,9 +109,10 @@ the sequence and exact payload needed for validators.
 
 The `Publish Hosted Catalog Feed` workflow refreshes the snapshot every six
 hours and can be run manually. It requires the existing `Production` environment
-`CONVEX_DEPLOY_KEY`. The workflow currently publishes an unsigned feed; signed
-envelopes require a separate production key-management decision and must not be
-advertised to OpenClaw clients until the signing key and trust root are deployed.
+`CONVEX_DEPLOY_KEY`. Publication stores the canonical unsigned payload bytes;
+the plugin HTTP action wraps those exact bytes in a deterministic DSSE/Ed25519
+envelope. The private key stays in Convex environment secret storage and the
+matching public key is bundled in OpenClaw.
 
 `convex/promotionsFeed.ts` builds the promotions snapshot from the bounded active
 set and stores it in the same publication table. Production backend deploys
@@ -125,14 +126,21 @@ snapshot inside its 24-hour `expiresAt` horizon.
 ## Edge delivery
 
 The stable HTTP endpoints are `/api/v1/feeds/plugins`, `/api/v1/feeds/skills`,
-and `/api/v1/feeds/promotions`. Each enabled endpoint
-returns its stored bytes unchanged and provides:
+and `/api/v1/feeds/promotions`. Each representation provides:
 
 - `ETag: "sha256:<payload hash>"`
 - `Last-Modified`
 - `Cache-Control: public, max-age=60, s-maxage=300, stale-while-revalidate=86400`
 - `Surrogate-Control: max-age=300, stale-while-revalidate=86400`
 - `304 Not Modified` for matching `If-None-Match` or `If-Modified-Since`
+
+The plugin feed route requires `CLAWHUB_FEED_SIGNING_KEY_ID` and
+`CLAWHUB_FEED_SIGNING_PRIVATE_KEY`. It returns `503` with `Cache-Control:
+no-store` when either value is absent, incomplete, or invalid. Its ETag and
+`X-Content-SHA256` describe the signed envelope representation;
+`X-Catalog-Payload-SHA256` preserves the stored publication payload digest.
+Skills and promotions remain on their existing unsigned representations until
+their payload types and matching OpenClaw consumers are specified.
 
 Nitro exposes `/v1/feeds/plugins`, `/v1/feeds/skills`, and
 `/v1/feeds/promotions` through the same environment-aware Convex proxy used for
@@ -150,3 +158,75 @@ schema version.
 
 Do not make the feed request-time dynamic. Refresh the stored publication first,
 then let Vercel or the configured CDN cache the immutable response by ETag.
+
+## Feed signing runbook
+
+ClawHub owns the private key and stable key id. OpenClaw owns distribution of
+the matching public trust anchor. Do not reuse release, package, TLS, account,
+or other platform signing keys for feed signing, and do not publish a trust
+bootstrap endpoint from the same origin as the feed.
+
+### Initial provisioning
+
+1. Generate a dedicated Ed25519 key pair on an approved operator machine:
+
+   ```bash
+   openssl genpkey -algorithm ED25519 -out clawhub-feed-private.pem
+   openssl pkey -in clawhub-feed-private.pem -pubout -out clawhub-feed-public.pem
+   ```
+
+2. Choose a stable, non-secret key id such as `clawhub-feed-2026-q3`. Record the
+   owner, creation time, intended deployment, and rotation contact in the
+   operator secret inventory.
+3. Store the private PEM in each intended Convex deployment without placing it
+   in shell history. For production, use the Convex dashboard or pipe the value
+   to the CLI:
+
+   ```powershell
+   Get-Content -Raw .\clawhub-feed-private.pem |
+     bunx convex env set CLAWHUB_FEED_SIGNING_PRIVATE_KEY --prod
+   "clawhub-feed-2026-q3" |
+     bunx convex env set CLAWHUB_FEED_SIGNING_KEY_ID --prod
+   ```
+
+4. Confirm only the variable names, not their values:
+
+   ```bash
+   bunx convex env list --names-only --prod
+   ```
+
+5. Provide `clawhub-feed-public.pem` and the key id to the OpenClaw maintainer
+   bundling the `clawhub-public` trust profile. The private PEM never leaves
+   ClawHub's operator-controlled secret path.
+6. Deploy ClawHub, publish a fresh `clawhub-official` snapshot, and verify that
+   `/api/v1/feeds/plugins` returns an envelope whose decoded payload bytes equal
+   the stored publication and whose signature verifies with the handed-off
+   public key.
+7. Land and release the matching OpenClaw bundled public key. Older unsigned
+   clients may fall back to their bundled catalog when they first encounter the
+   envelope; they must not reinterpret it as unsigned feed content.
+8. Securely delete operator-machine private-key files after the approved secret
+   backup and recovery process is complete.
+
+### Normal rotation
+
+1. Generate a new dedicated key and key id.
+2. Bundle the new public key in OpenClaw while the old key remains trusted.
+3. After that trust update is available, update the two Convex signing variables
+   together and deploy.
+4. Verify a higher-sequence publication under the new key before retiring the
+   old private key.
+5. Remove the old public key in a later OpenClaw release after the supported
+   client overlap window.
+
+The first signer emits one signature, so it cannot provide an old-and-new
+dual-sign overlap by itself. If operational policy requires dual signing, add
+multi-key signer support before beginning that rotation.
+
+### Emergency revocation
+
+Remove or replace the compromised private key in Convex immediately. Leaving
+signing configuration incomplete intentionally makes the plugin feed return
+`503 no-store`. Notify OpenClaw maintainers to remove the compromised public key
+through the authenticated release channel. Do not recover by advertising a new
+public key from a feed-adjacent endpoint.

--- a/specs/hosted-catalog-feed.md
+++ b/specs/hosted-catalog-feed.md
@@ -156,6 +156,16 @@ Accept`. The signed representation's ETag and
 Skills and promotions remain on their existing unsigned representations until
 their payload types and matching OpenClaw consumers are specified.
 
+### Activation boundary
+
+Deploying this code does not enable signing and does not require a production
+key. The existing unsigned response remains the default before and after this
+change, including when the signing configuration is absent or invalid. Signing
+is active only for clients that explicitly request `application/vnd.dsse+json`
+and only after `CLAWHUB_FEED_SIGNING_CONFIG` is installed. This lets the signing
+foundation and dependent feed transport changes merge and receive review before
+operators provision a key and OpenClaw ships the matching trust anchor.
+
 Nitro exposes `/v1/feeds/plugins`, `/v1/feeds/skills`, and
 `/v1/feeds/promotions` through the same environment-aware Convex proxy used for
 `/api/*`. Their unversioned `/feeds/*` paths permanently redirect to the


### PR DESCRIPTION
## Summary

- add an **optional** DSSE/Ed25519 representation for the stored `clawhub-official` catalog publication
- preserve the existing unsigned JSON representation as the default on `/api/v1/feeds/plugins`
- sign the exact immutable stored payload bytes and expose representation-specific validators
- provide a tested prepare/activate rotation script and operator runbook

## Merge and activation contract

**Merging this PR does not enable signing and does not require production keys.**

The route selects DSSE only when a client explicitly sends `Accept: application/vnd.dsse+json`. Without that opt-in, the existing unsigned response remains available even when `CLAWHUB_FEED_SIGNING_CONFIG` is missing or malformed. An opted-in signed request fails closed with `503 no-store` until a valid signer is installed.

This is the dormant signing foundation for the large-feed stack. Production activation is a later operator action after the matching OpenClaw trust anchor is released.

## Review order

1. **This PR — signing foundation and activation boundary**
2. openclaw/clawhub#3149 — durable revision/change history
3. openclaw/clawhub#3160 — signed paged query and delta transport
4. openclaw/clawhub#3163 — sharded full snapshots
5. openclaw/openclaw#110250 — verified sharded-feed consumer

OpenClaw trust-anchor work in openclaw/openclaw#101981 can be reviewed and landed in parallel, but must ship before production signing is activated.

## Signing configuration

ClawHub owns one atomic Convex secret:

- `CLAWHUB_FEED_SIGNING_CONFIG`: strict JSON containing exactly `keyId` and PKCS#8 Ed25519 `privateKey`

OpenClaw receives only the matching public PEM and key id. There is intentionally no feed-adjacent public-key bootstrap endpoint. The complete provisioning, activation, rotation, and emergency-revocation runbook is in `specs/hosted-catalog-feed.md`.

## Cache behavior

The signed representation uses its envelope ETag as the conditional validator and deliberately omits `Last-Modified`; signer rotation changes envelope bytes without changing the stored publication timestamp. The unsigned representation retains its existing validators. Responses include `Vary: Accept`.

## Validation

- `bun x vitest run convex/httpApiV1.catalogFeedSigning.test.ts scripts/provision-catalog-feed-signing-key.test.ts` — 25 tests passed
- regression coverage proves missing or malformed signer config cannot break ordinary unsigned requests
- exact stored bytes and DSSE Ed25519 signatures verified with generated key pairs
- matching ETag returns 304; signed responses omit `Last-Modified`
- `git diff --check origin/main...HEAD`
- direct `codex review --uncommitted` — no actionable findings

`bun run ci:static` now clears the dependency audit after upstream #3234; it currently stops on formatting errors in two files already present on `main` (`.agents/skills/autoreview/CLAUDE.md` and `CLAUDE.md`). Production key provisioning and public-endpoint proof are intentionally deferred to activation.