### PR TITLE
Route org publisher abuse nominations to org review

### DIFF
--- a/convex/publisherAbuse.test.ts
+++ b/convex/publisherAbuse.test.ts
@@ -423,6 +423,18 @@ const markPublisherAbuseNominationReviewedHandler = (
   >
 )._handler;
 
+const markOrgPublisherAbuseNominationForFutureActionHandler = (
+  publisherAbuse.markOrgPublisherAbuseNominationForFutureAction as unknown as Wrapped<
+    {
+      nominationId: string;
+      expectedLatestScoreId: string;
+      expectedUpdatedAt: number;
+      note?: string;
+    },
+    { ok: true; status: "candidate_for_future_action" }
+  >
+)._handler;
+
 const autoBanPublisherAbuseCandidatesPageHandler = (
   publisherAbuse.autoBanPublisherAbuseCandidatesPageInternal as unknown as Wrapped<
     { batchSize?: number; cursor?: string },
@@ -2334,6 +2346,132 @@ describe("publisher abuse dry-run persistence", () => {
     expect(insert).not.toHaveBeenCalled();
   });
 
+  it("rejects direct user-ban actions for org publisher nominations", async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:moderator",
+      user: { _id: "users:moderator", role: "moderator" },
+    } as never);
+    const runMutation = vi.fn(async () => ({ ok: true }));
+    const patch = vi.fn(async () => null);
+    const insert = vi.fn(async (table: string) => `${table}:new`);
+    const ctx = {
+      runMutation,
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "publisherAbuseReviewNominations:nomination") {
+            return makeNomination({
+              _id: "publisherAbuseReviewNominations:nomination",
+              ownerKey: "publisher:org",
+              ownerPublisherId: "publishers:org",
+              ownerUserId: undefined,
+              label: "potential_ban_candidate",
+              status: "pending",
+              latestScoreId: "publisherAbuseScores:score",
+              updatedAt: 1,
+            });
+          }
+          if (id === "publishers:org") {
+            return {
+              _id: "publishers:org",
+              kind: "org",
+              handle: "org",
+              displayName: "Org",
+            };
+          }
+          return null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table === "officialPublishers") return makeEmptyOfficialPublishersQuery();
+          if (table === "publisherMembers") return makeEmptyPublisherMembersQuery();
+          throw new Error(`unexpected table ${table}`);
+        }),
+        insert,
+        patch,
+      },
+    };
+
+    await expect(
+      banPublisherAbuseOwnerHandler(ctx, {
+        nominationId: "publisherAbuseReviewNominations:nomination",
+        expectedLatestScoreId: "publisherAbuseScores:score",
+        expectedUpdatedAt: 1,
+        reason: "confirmed spam",
+      }),
+    ).rejects.toThrow(/org publisher/i);
+
+    expect(runMutation).not.toHaveBeenCalled();
+    expect(patch).not.toHaveBeenCalled();
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it("tracks org publisher abuse nominations for future org-level action", async () => {
+    vi.mocked(requireUser).mockResolvedValue({
+      userId: "users:moderator",
+      user: { _id: "users:moderator", role: "moderator" },
+    } as never);
+    const patch = vi.fn(async () => null);
+    const insert = vi.fn(async (table: string) => `${table}:new`);
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "publisherAbuseReviewNominations:nomination") {
+            return makeNomination({
+              _id: "publisherAbuseReviewNominations:nomination",
+              ownerKey: "publisher:org",
+              ownerPublisherId: "publishers:org",
+              ownerUserId: undefined,
+              label: "review",
+              status: "pending",
+              latestScoreId: "publisherAbuseScores:score",
+              updatedAt: 1,
+            });
+          }
+          if (id === "publishers:org") {
+            return {
+              _id: "publishers:org",
+              kind: "org",
+              handle: "org",
+              displayName: "Org",
+            };
+          }
+          return null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table === "officialPublishers") return makeEmptyOfficialPublishersQuery();
+          if (table === "publisherMembers") return makeEmptyPublisherMembersQuery();
+          throw new Error(`unexpected table ${table}`);
+        }),
+        insert,
+        patch,
+      },
+    };
+
+    await expect(
+      markOrgPublisherAbuseNominationForFutureActionHandler(ctx, {
+        nominationId: "publisherAbuseReviewNominations:nomination",
+        expectedLatestScoreId: "publisherAbuseScores:score",
+        expectedUpdatedAt: 1,
+        note: "review org suspension options",
+      }),
+    ).resolves.toEqual({ ok: true, status: "candidate_for_future_action" });
+
+    expect(patch).toHaveBeenCalledWith(
+      "publisherAbuseReviewNominations:nomination",
+      expect.objectContaining({
+        status: "candidate_for_future_action",
+        notes: "review org suspension options",
+        reviewedByUserId: "users:moderator",
+      }),
+    );
+    expect(insert).toHaveBeenCalledWith(
+      "publisherAbuseReviewEvents",
+      expect.objectContaining({
+        nominationId: "publisherAbuseReviewNominations:nomination",
+        nextStatus: "candidate_for_future_action",
+      }),
+    );
+  });
+
   it.each([
     {
       name: "official publisher nominations",
@@ -3413,6 +3551,89 @@ describe("publisher abuse dry-run persistence", () => {
       }),
     );
     expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
+  });
+
+  it("tracks org publisher autoban candidates for future org-level action", async () => {
+    const nomination = makeNomination({
+      _id: "publisherAbuseReviewNominations:org",
+      ownerKey: "publisher:publishers:org",
+      ownerPublisherId: "publishers:org",
+      ownerUserId: undefined,
+      latestScoreId: "publisherAbuseScores:org",
+      label: "potential_ban_candidate",
+      status: "pending",
+    });
+    const score = makeScore({
+      _id: "publisherAbuseScores:org",
+      ownerKey: nomination.ownerKey,
+      ownerPublisherId: "publishers:org",
+    });
+    const patch = vi.fn(async () => null);
+    const insert = vi.fn(async (table: string) => `${table}:new`);
+    const runMutation = vi.fn(async () => ({ ok: true }));
+    const ctx = {
+      scheduler: { runAfter: vi.fn(async () => null) },
+      runMutation,
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "publisherAbuseScores:org") return score;
+          if (id === score.runId) return makeCompletedPressureScoreRun();
+          if (id === "publishers:org") {
+            return {
+              _id: "publishers:org",
+              kind: "org",
+              handle: "org",
+              displayName: "Org",
+            };
+          }
+          return null;
+        }),
+        patch,
+        insert,
+        query: vi.fn((table: string) => {
+          if (table === "publisherAbuseReviewNominations") {
+            return makeAutoBanNominationQuery([nomination]);
+          }
+          if (table === "systemSettings") {
+            return makePublisherAbuseAutobanSettingQuery({
+              key: "publisherAbuseAutobanEnabled",
+              enabled: true,
+              updatedAt: 1,
+              updatedByUserId: "users:admin",
+            });
+          }
+          if (table === "officialPublishers") return makeEmptyOfficialPublishersQuery();
+          if (table === "publisherMembers") return makeEmptyPublisherMembersQuery();
+          throw new Error(`unexpected table ${table}`);
+        }),
+      },
+    };
+
+    await expect(autoBanPublisherAbuseCandidatesPageHandler(ctx, {})).resolves.toEqual({
+      ok: true,
+      processed: 1,
+      warned: 0,
+      banned: 0,
+      alreadyBanned: 0,
+      skipped: 1,
+      isDone: true,
+    });
+
+    expect(runMutation).not.toHaveBeenCalled();
+    expect(patch).toHaveBeenCalledWith(
+      "publisherAbuseReviewNominations:org",
+      expect.objectContaining({
+        status: "candidate_for_future_action",
+        notes: "Autoban skipped: org publisher nominations require org-level review.",
+      }),
+    );
+    expect(insert).toHaveBeenCalledWith(
+      "publisherAbuseReviewEvents",
+      expect.objectContaining({
+        nominationId: "publisherAbuseReviewNominations:org",
+        nextStatus: "candidate_for_future_action",
+      }),
+    );
   });
 
   it.each([

--- a/convex/publisherAbuse.ts
+++ b/convex/publisherAbuse.ts
@@ -93,6 +93,8 @@ const MISSING_PUBLISHER_AUTOBAN_SKIP_NOTE =
 const INACTIVE_PUBLISHER_AUTOBAN_SKIP_NOTE = "Autoban skipped: publisher is inactive.";
 const STALE_PUBLISHER_LINK_AUTOBAN_SKIP_NOTE =
   "Autoban skipped: publisher is not linked to the nominated user account; manual review required.";
+const ORG_PUBLISHER_AUTOBAN_SKIP_NOTE =
+  "Autoban skipped: org publisher nominations require org-level review.";
 const MISSING_WARNING_EMAIL_AUTOBAN_SKIP_NOTE =
   "Autoban warning skipped: linked user has no email address; manual review required.";
 const FAILED_SCORE_RUN_AUTOBAN_SKIP_NOTE =
@@ -685,6 +687,13 @@ export const banPublisherAbuseOwner = mutation({
     if (!nomination) throw new Error("Publisher abuse nomination not found");
     requireFreshPublisherAbuseReviewNomination(nomination, args);
     requireActionablePublisherAbuseReviewNomination(nomination);
+    await requirePublisherAbuseNominationNotExcluded(ctx, nomination);
+    const targetPublisher = await getPublisherAbuseNominationPublisher(ctx, nomination);
+    if (targetPublisher?.kind === "org") {
+      throw new Error(
+        "Org publisher nominations require org-level review; user bans must target a specific member.",
+      );
+    }
     if (!nomination.ownerUserId) {
       throw new Error("Cannot ban publisher abuse nomination without a linked user");
     }
@@ -693,7 +702,6 @@ export const banPublisherAbuseOwner = mutation({
     if (ownerUser.role === "admin" || ownerUser.role === "moderator") {
       throw new Error("Cannot ban staff accounts through publisher abuse workflow");
     }
-    await requirePublisherAbuseNominationNotExcluded(ctx, nomination);
     await requirePublisherAbuseNominationStillTargetsLinkedUser(ctx, nomination);
 
     const reason = normalizeBanReason(args.reason);
@@ -713,6 +721,47 @@ export const banPublisherAbuseOwner = mutation({
     });
 
     return { ok: true, status: "banned" as const };
+  },
+});
+
+export const markOrgPublisherAbuseNominationForFutureAction = mutation({
+  args: {
+    nominationId: v.id("publisherAbuseReviewNominations"),
+    expectedLatestScoreId: v.id("publisherAbuseScores"),
+    expectedUpdatedAt: v.number(),
+    note: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const { user } = await requireUser(ctx);
+    assertModerator(user);
+
+    const nomination = await ctx.db.get(args.nominationId);
+    if (!nomination) throw new Error("Publisher abuse nomination not found");
+    requireFreshPublisherAbuseReviewNomination(nomination, args);
+    if (nomination.label === "pass") {
+      throw new Error(
+        "Only flagged org publisher abuse nominations can be tracked for future action.",
+      );
+    }
+    if (nomination.status !== "pending") {
+      throw new Error(
+        "Only pending org publisher abuse nominations can be tracked for future action.",
+      );
+    }
+    await requirePublisherAbuseNominationNotExcluded(ctx, nomination);
+    await requireOrgPublisherAbuseNominationTarget(ctx, nomination);
+
+    const now = Date.now();
+    const notes = normalizePublisherAbuseReviewNote(args.note);
+    await setPublisherAbuseReviewStatusWithActor(ctx, {
+      nomination,
+      status: "candidate_for_future_action",
+      notes,
+      actorUserId: user._id,
+      now,
+    });
+
+    return { ok: true, status: "candidate_for_future_action" as const };
   },
 });
 
@@ -1214,6 +1263,17 @@ export async function autoBanPublisherAbuseCandidatesPageInternalHandler(
         nomination,
         status: "reviewed_no_action",
         notes: "Autoban skipped: publisher is excluded from publisher abuse enforcement.",
+        now,
+      });
+      skipped += 1;
+      continue;
+    }
+
+    if (publisher.kind === "org") {
+      await setPublisherAbuseReviewStatusWithActor(ctx, {
+        nomination,
+        status: "candidate_for_future_action",
+        notes: ORG_PUBLISHER_AUTOBAN_SKIP_NOTE,
         now,
       });
       skipped += 1;
@@ -3582,6 +3642,28 @@ async function requirePublisherAbuseNominationNotExcluded(
   const publisher = await ctx.db.get(nomination.ownerPublisherId);
   if (!(await isPublisherExcludedFromPublisherAbuse(ctx, publisher))) return;
   throw new Error("Excluded publisher abuse nominations cannot be acted on.");
+}
+
+async function getPublisherAbuseNominationPublisher(
+  ctx: Pick<MutationCtx, "db">,
+  nomination: Doc<"publisherAbuseReviewNominations">,
+) {
+  if (!nomination.ownerPublisherId) return null;
+  return await ctx.db.get(nomination.ownerPublisherId);
+}
+
+async function requireOrgPublisherAbuseNominationTarget(
+  ctx: Pick<MutationCtx, "db">,
+  nomination: Doc<"publisherAbuseReviewNominations">,
+) {
+  const publisher = await getPublisherAbuseNominationPublisher(ctx, nomination);
+  if (!publisher || publisher.deletedAt || publisher.deactivatedAt) {
+    throw new Error("Org publisher abuse nomination target is inactive.");
+  }
+  if (publisher.kind !== "org") {
+    throw new Error("Only org publisher abuse nominations can be tracked for org-level action.");
+  }
+  return publisher;
 }
 
 async function requirePublisherAbuseNominationStillTargetsLinkedUser(

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -59,10 +59,12 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   `potential_ban_candidate` pressure nominations without waiting for the score
   run to finish. It must not warn or autoban `review` nominations, historical
   backfill temporal nominations, partial current temporal nominations,
-  nominations without a linked user account, or candidates whose linked user has
-  no email address. Skipped pending nominations must be moved out of pending
-  status with an explanatory review event so the cron does not retry them
-  forever.
+  org publisher nominations, non-org nominations without a linked user account,
+  or candidates whose linked user has no email address. Skipped pending
+  nominations must be moved out of pending status with an explanatory review
+  event so the cron does not retry them forever. Org publisher nominations are
+  tracked as `candidate_for_future_action` so staff can review org suspension or
+  member-specific account action separately from the user-ban flow.
 - Publisher abuse automatic bans must still use the account ban flow, including
   token revocation, owned listing hiding, audit logging, and the normal
   suspension/appeal email.

--- a/src/routes/-management.test.tsx
+++ b/src/routes/-management.test.tsx
@@ -22,6 +22,8 @@ function makePublisherAbuseItem({
   id = "1",
   label = "potential_ban_candidate",
   ownerKey = "user:spammy",
+  ownerPublisherId,
+  ownerPublisherKind = "user",
   ownerRole = "user",
   ownerUserId = "users:spammy",
   openedByRun = null,
@@ -30,12 +32,27 @@ function makePublisherAbuseItem({
   scoreRunId = "publisherAbuseScoreRuns:1",
   status = "pending",
   zScore = 3.1,
+}: {
+  handle?: string;
+  id?: string;
+  label?: "potential_ban_candidate" | "review" | "pass";
+  ownerKey?: string;
+  ownerPublisherId?: string;
+  ownerPublisherKind?: "user" | "org";
+  ownerRole?: "admin" | "moderator" | "user";
+  ownerUserId?: string;
+  openedByRun?: unknown;
+  rank?: number;
+  scoreOverrides?: Record<string, unknown>;
+  scoreRunId?: string;
+  status?: string;
+  zScore?: number;
 } = {}) {
   const score = {
     _id: `publisherAbuseScores:${id}`,
     runId: scoreRunId,
     ownerKey,
-    ownerPublisherId: undefined,
+    ownerPublisherId,
     ownerUserId,
     handleSnapshot: handle,
     modelVersion: "v1",
@@ -76,14 +93,34 @@ function makePublisherAbuseItem({
   return {
     nomination,
     latestScore: score,
-    publisher: null,
-    ownerUser: {
-      _id: ownerUserId,
-      handle: ownerUserId.split(":").at(-1) ?? "spammy",
-      name: handle,
-      displayName: null,
-      role: ownerRole,
-    },
+    publisher: ownerPublisherId
+      ? {
+          _id: ownerPublisherId,
+          handle,
+          displayName: handle,
+          kind: ownerPublisherKind,
+          linkedUserId: ownerPublisherKind === "user" ? ownerUserId : null,
+          publishedSkills: score.publishedSkills,
+          publishedPackages: 0,
+          totalInstalls: score.totalInstalls,
+          totalStars: score.totalStars,
+          totalDownloads: score.totalDownloads,
+          skillTotalInstalls: score.totalInstalls,
+          skillTotalStars: score.totalStars,
+          skillTotalDownloads: score.totalDownloads,
+          deletedAt: null,
+          deactivatedAt: null,
+        }
+      : null,
+    ownerUser: ownerUserId
+      ? {
+          _id: ownerUserId,
+          handle: ownerUserId.split(":").at(-1) ?? "spammy",
+          name: handle,
+          displayName: null,
+          role: ownerRole,
+        }
+      : null,
     openedByRun,
   };
 }
@@ -1618,6 +1655,73 @@ describe("Management", () => {
     const banButton = screen.getByRole("button", { name: "Ban user" }) as HTMLButtonElement;
     expect(banButton.disabled).toBe(true);
     fireEvent.click(banButton);
+    expect(banPublisherAbuseOwner).not.toHaveBeenCalled();
+  });
+
+  it("does not offer user bans for org publisher abuse nominations", async () => {
+    const banPublisherAbuseOwner = vi.fn(async () => ({ ok: true }));
+    const markOrgFutureAction = vi.fn(async () => ({
+      ok: true,
+      status: "candidate_for_future_action",
+    }));
+    const item = makePublisherAbuseItem({
+      handle: "oomol",
+      ownerKey: "publisher:oomol",
+      ownerPublisherId: "publishers:oomol",
+      ownerPublisherKind: "org",
+      ownerUserId: undefined,
+    });
+    useMutationMock.mockImplementation((mutation) => {
+      const name = getFunctionName(mutation);
+      if (name === "publisherAbuse:banPublisherAbuseOwner") {
+        return banPublisherAbuseOwner;
+      }
+      if (name === "publisherAbuse:markOrgPublisherAbuseNominationForFutureAction") {
+        return markOrgFutureAction;
+      }
+      return vi.fn(async () => ({ ok: true }));
+    });
+    useQueryMock.mockImplementation((query, args) => {
+      if (args === "skip") return undefined;
+      const name = getFunctionName(query);
+      if (name === "skills:listRecentVersions") return [];
+      if (name === "skills:listReportedSkills") return [];
+      if (name === "skills:listDuplicateCandidates") return [];
+      if (name === "publisherAbuse:listReviewDashboard") {
+        return {
+          latestRun: null,
+          pendingItems: [],
+          pendingPotentialBanCandidateItems: [item],
+          pendingReviewItems: [],
+          recentResolvedItems: [],
+        };
+      }
+      if (name === "users:list") return { items: [], total: 0 };
+      return undefined;
+    });
+
+    render(<Management />);
+
+    fireEvent.click(screen.getByText("oomol"));
+
+    expect(screen.queryByRole("button", { name: "Ban user" })).toBeNull();
+    expect(screen.getByText(/Org publisher nominations need org-level review/i)).toBeTruthy();
+    fireEvent.change(screen.getByPlaceholderText("What should staff review next? (optional)"), {
+      target: { value: "consider org suspension" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Track org action" }));
+    expect(screen.getByRole("heading", { name: "Track oomol for org action?" })).toBeTruthy();
+    const trackButtons = screen.getAllByRole("button", { name: "Track org action" });
+    fireEvent.click(trackButtons[trackButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(markOrgFutureAction).toHaveBeenCalledWith({
+        nominationId: item.nomination._id,
+        expectedLatestScoreId: item.nomination.latestScoreId,
+        expectedUpdatedAt: item.nomination.updatedAt,
+        note: "consider org suspension",
+      });
+    });
     expect(banPublisherAbuseOwner).not.toHaveBeenCalled();
   });
 });

--- a/src/routes/-management/AbusePage.tsx
+++ b/src/routes/-management/AbusePage.tsx
@@ -66,6 +66,7 @@ export function AbusePage({
   onChangeTab,
   onClose,
   onDismissSignal,
+  onMarkOrgFutureAction,
   onMarkReviewed,
   onLoadMore,
   onRefresh,
@@ -103,6 +104,7 @@ export function AbusePage({
   onChangeTab: (value: PublisherAbuseTab) => void;
   onClose: () => void;
   onDismissSignal: (item: PublisherAbuseSignalEntry) => void;
+  onMarkOrgFutureAction: (item: PublisherAbuseReviewItem) => void;
   onMarkReviewed: (item: PublisherAbuseReviewItem) => void;
   onLoadMore: () => void;
   onRefresh: () => void;
@@ -133,6 +135,7 @@ export function AbusePage({
   const latestRun = dashboard?.latestRun ?? null;
   const selectedScore = selectedItem?.latestScore ?? null;
   const selectedPublisher = selectedItem?.publisher ?? null;
+  const selectedIsOrgPublisher = selectedPublisher?.kind === "org";
   const canBanSelectedUser = canBanPublisherAbuseOwner(selectedItem, currentUserId);
   const visiblePending = dashboard ? getPublisherAbuseVisiblePendingItems(dashboard) : [];
   const visiblePotentialBan = visiblePending.filter(
@@ -665,6 +668,31 @@ export function AbusePage({
                       {selectedItem.nomination.notes?.trim() ||
                         "This nomination is no longer in the pending queue."}
                     </p>
+                  </section>
+                ) : selectedIsOrgPublisher ? (
+                  <section className="pa-zone pa-review">
+                    <div className="pa-section-label">Org review</div>
+                    <p className="pa-hint">
+                      Org publisher nominations need org-level review. Track this for future
+                      org-publisher action or review the responsible members separately.
+                    </p>
+                    <Textarea
+                      maxLength={USER_BAN_REASON_MAX_LENGTH}
+                      placeholder="What should staff review next? (optional)"
+                      value={notes}
+                      onChange={(event) => onChangeNotes(event.target.value)}
+                    />
+                    <div className="pa-actions">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => onMarkOrgFutureAction(selectedItem)}
+                      >
+                        <Clock3 size={14} />
+                        Track org action
+                      </Button>
+                    </div>
                   </section>
                 ) : selectedItem.nomination.label === "potential_ban_candidate" ? (
                   <section className="pa-zone pa-review">
@@ -1301,6 +1329,7 @@ export function canBanPublisherAbuseOwner(
   item: PublisherAbuseReviewItem | null,
   currentUserId: Id<"users"> | null,
 ) {
+  if (item?.publisher?.kind === "org") return false;
   const ownerUser = item?.ownerUser;
   if (!ownerUser?._id) return false;
   if (ownerUser._id === currentUserId) return false;

--- a/src/routes/management.tsx
+++ b/src/routes/management.tsx
@@ -280,6 +280,9 @@ export function Management() {
   const markPublisherAbuseNominationReviewed = useMutation(
     api.publisherAbuse.markPublisherAbuseNominationReviewed,
   );
+  const markOrgPublisherAbuseNominationForFutureAction = useMutation(
+    api.publisherAbuse.markOrgPublisherAbuseNominationForFutureAction,
+  );
   const setPublisherAbuseAutobanEnabled = useMutation(
     api.publisherAbuse.setPublisherAbuseAutobanEnabled,
   );
@@ -703,6 +706,32 @@ export function Management() {
     });
   };
 
+  const requestMarkOrgPublisherAbuseNominationForFutureAction = (
+    item: PublisherAbuseReviewItem,
+  ) => {
+    const label = item.nomination.handleSnapshot;
+    const note = publisherAbuseNotes.trim() || undefined;
+    setConfirmRequest({
+      title: `Track ${label} for org action?`,
+      body: "Moves this org publisher nomination out of the active queue without banning a user. Staff can review org suspension or member-level action separately.",
+      confirmLabel: "Track org action",
+      onConfirm: () => {
+        void markOrgPublisherAbuseNominationForFutureAction({
+          nominationId: item.nomination._id,
+          expectedLatestScoreId: item.nomination.latestScoreId,
+          expectedUpdatedAt: item.nomination.updatedAt,
+          note,
+        })
+          .then(() => {
+            toast.success("Org nomination tracked for future action.");
+            setPublisherAbuseNotes("");
+            setSelectedPublisherAbuseNominationId(null);
+          })
+          .catch((error) => toast.error(formatMutationError(error)));
+      },
+    });
+  };
+
   const requestDismissPublisherAbuseSignal = (item: PublisherAbuseSignalEntry) => {
     setConfirmRequest({
       title: `Dismiss ${item.signal.skillDisplayName}?`,
@@ -860,6 +889,7 @@ export function Management() {
             }}
             onToggleAutoban={requestTogglePublisherAbuseAutoban}
             onDismissSignal={requestDismissPublisherAbuseSignal}
+            onMarkOrgFutureAction={requestMarkOrgPublisherAbuseNominationForFutureAction}
             onMarkReviewed={requestMarkPublisherAbuseNominationReviewed}
             onLoadMore={() => {
               if (publisherAbuseTab === "signals") {


### PR DESCRIPTION
## Summary

Org publisher abuse nominations now stay in the publisher-abuse scoring workflow, but they no longer route through user-ban enforcement. Manual staff actions and scheduled autoban both move org publisher nominations into `candidate_for_future_action` so staff can review org suspension or member-specific account action separately.

## What Changed

- User-ban guard: `banPublisherAbuseOwner` now rejects org publisher nominations before invoking the account-ban mutation.
- Org review action: staff can mark pending flagged org publisher nominations for future org-level action with an audit event and optional note.
- Scheduled autoban: active non-excluded org publishers are skipped from warning/ban enforcement and moved out of the pending queue with an org-level review note.
- Management UI: org publisher nominations hide `Ban user` and show an `Org review` lane with `Track org action` instead.
- Moderation spec: documents that org publisher abuse is scored normally but handled through org/member review rather than automatic user bans.

## Proof

Behavioral proof:

- Backend tests cover direct user-ban rejection for org publishers, manual org future-action tracking, and scheduled autoban moving org publisher candidates to `candidate_for_future_action` instead of warning or banning.
- Management tests render an org publisher nomination, verify `Ban user` is hidden, and confirm `Track org action` calls `publisherAbuse.markOrgPublisherAbuseNominationForFutureAction` with the expected freshness guards and note.
- Independent cold review mapped the backend, scheduler, UI wiring, and spec changes and reported no actionable findings.

Screenshots:

- Not attached: this harness does not expose the GitHub PR attachment upload flow required for reviewer-visible screenshots, and the local seeded publisher-abuse dashboard has user-publisher rows but no org publisher nomination to capture. The org UI state is covered by `src/routes/-management.test.tsx`.

## Verification

Passed locally:

- `bunx vitest run convex/publisherAbuse.test.ts` (130 tests)
- `bunx --bun vitest run src/routes/-management.test.tsx` (31 tests)
- `bun run format:check convex/publisherAbuse.ts convex/publisherAbuse.test.ts src/routes/management.tsx src/routes/-management/AbusePage.tsx src/routes/-management.test.tsx specs/security-moderation.md`
- `bun run lint`
- `bunx tsc --noEmit --pretty false`
- `bunx convex dev --once --typecheck=disable` against dev deployment `admired-dodo-615`
- `git diff --check origin/main...HEAD`

Partial or blocked:

- `NPM_CONFIG_REGISTRY=https://registry.npmjs.org npm_config_registry=https://registry.npmjs.org bun run ci:static` passed peer checks, audit, llms check, formatting, and lint, then failed in `deadcode:files` because `knip@6.8.0` hit a Node/Bun `ERR_REQUIRE_ESM` loading `oxc-parser/src-js/generated/visit/walk.js`.
- `VITE_CONVEX_URL=https://example.invalid bun run ci:unit` ran the suite but failed the repo global coverage threshold: lines 38.32%, functions 26.54%, statements 37.07%, branches 26.71% versus the 70% threshold.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --base origin/main --output .local-autoreview.md --json-output .local-autoreview.json` could not run because the nested Codex CLI review engine returned `401 Unauthorized: Missing bearer or basic authentication`.
