### PR TITLE
fix: show edit profile on owned profile pages

### DIFF
--- a/src/__tests__/user-profile-route.test.tsx
+++ b/src/__tests__/user-profile-route.test.tsx
@@ -15,7 +15,8 @@ import {
   shouldShowPublisherCatalogLoadMore,
 } from "../routes/user/$handle";
 
-const { loaderDataMock, paginatedQueryMock, queryMock } = vi.hoisted(() => ({
+const { authStatusMock, loaderDataMock, paginatedQueryMock, queryMock } = vi.hoisted(() => ({
+  authStatusMock: vi.fn(),
   loaderDataMock: vi.fn(),
   paginatedQueryMock: vi.fn(),
   queryMock: vi.fn(),
@@ -31,7 +32,7 @@ vi.mock("@convex-dev/auth/react", () => ({
 }));
 
 vi.mock("../lib/useAuthStatus", () => ({
-  useAuthStatus: () => ({ isAuthenticated: false, isLoading: false, me: null }),
+  useAuthStatus: () => authStatusMock(),
 }));
 
 vi.mock("sonner", () => ({
@@ -85,6 +86,8 @@ describe("user profile route", () => {
     vi.resetModules();
     loaderDataMock.mockReset();
     loaderDataMock.mockReturnValue({ publisher });
+    authStatusMock.mockReset();
+    authStatusMock.mockReturnValue({ isAuthenticated: false, isLoading: false, me: null });
     paginatedQueryMock.mockReset();
     paginatedQueryMock.mockReturnValue({
       loadMore: vi.fn(),
@@ -122,6 +125,44 @@ describe("user profile route", () => {
     expect(screen.queryByRole("button", { name: "Follow" })).toBeNull();
     expect(screen.getByRole("button", { name: "Profile actions" })).toBeTruthy();
     expect(screen.getByRole("link", { name: /github/i })).toBeTruthy();
+  });
+
+  it("shows edit profile instead of report on the viewer's own publisher page", async () => {
+    const personalPublisher = {
+      ...publisher,
+      kind: "user" as const,
+    };
+    loaderDataMock.mockReturnValue({ publisher: personalPublisher });
+    authStatusMock.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      me: { handle: "nvidia" },
+    });
+    queryMock.mockImplementation((_query, args: Record<string, unknown> | "skip") => {
+      if (args === "skip") return undefined;
+      if ("publisherHandle" in args) return { publisher: personalPublisher, members: [] };
+      if ("kind" in args) return null;
+      if (Object.keys(args).length === 0) {
+        return [{ publisher: { handle: "nvidia", kind: "user" }, role: "owner" }];
+      }
+      return personalPublisher;
+    });
+
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    const editProfile = screen.getByRole("link", { name: "Edit profile" });
+    const add = screen.getByRole("link", { name: "Add" });
+
+    expect(
+      screen.getAllByRole("link", { name: /^(Edit profile|Add)$/ }).map((link) => link.textContent),
+    ).toEqual(["Edit profile", "Add"]);
+    expect(editProfile.getAttribute("href")).toBe("/settings");
+    expect(add.getAttribute("href")).toContain("/add");
+    expect(screen.queryByRole("button", { name: "Profile actions" })).toBeNull();
+    expect(screen.queryByText("Report profile")).toBeNull();
   });
 
   it("renders segmented catalog tabs and sort control", async () => {

--- a/src/routes/user/$handle.tsx
+++ b/src/routes/user/$handle.tsx
@@ -403,17 +403,24 @@ function PublisherProfile() {
 
 function PublisherProfileChromeActions({
   addHandle,
+  showEditProfile,
   isAuthenticated,
   onReport,
   requireSignIn,
 }: {
   addHandle?: string;
+  showEditProfile: boolean;
   isAuthenticated: boolean;
   onReport: () => void;
   requireSignIn: () => void;
 }) {
   return (
     <div className="publisher-profile-chrome-actions">
+      {showEditProfile ? (
+        <Button asChild size="sm" variant="outline">
+          <Link to="/settings">Edit profile</Link>
+        </Button>
+      ) : null}
       {addHandle ? (
         <Button asChild size="sm" variant="primary">
           <Link to="/add" search={{ kind: "skill", ownerHandle: addHandle, method: undefined }}>
@@ -422,33 +429,35 @@ function PublisherProfileChromeActions({
           </Link>
         </Button>
       ) : null}
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            type="button"
-            size="icon-sm"
-            variant="ghost"
-            aria-label="Profile actions"
-            className="publisher-profile-chrome-more-trigger rounded-full focus-visible:ring-0 focus-visible:ring-offset-0"
-          >
-            <MoreHorizontal size={16} aria-hidden="true" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="publisher-profile-chrome-more-menu">
-          <DropdownMenuItem
-            onSelect={() => {
-              if (!isAuthenticated) {
-                requireSignIn();
-                return;
-              }
-              onReport();
-            }}
-          >
-            <Flag size={14} aria-hidden="true" />
-            Report profile
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      {showEditProfile ? null : (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              size="icon-sm"
+              variant="ghost"
+              aria-label="Profile actions"
+              className="publisher-profile-chrome-more-trigger rounded-full focus-visible:ring-0 focus-visible:ring-offset-0"
+            >
+              <MoreHorizontal size={16} aria-hidden="true" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="publisher-profile-chrome-more-menu">
+            <DropdownMenuItem
+              onSelect={() => {
+                if (!isAuthenticated) {
+                  requireSignIn();
+                  return;
+                }
+                onReport();
+              }}
+            >
+              <Flag size={14} aria-hidden="true" />
+              Report profile
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
     </div>
   );
 }
@@ -558,6 +567,9 @@ export function PublisherProfilePage({
     () => Boolean(myPublisherMemberships?.some((entry) => entry.publisher.handle === handle)),
     [myPublisherMemberships, handle],
   );
+  const viewerOwnsPersonalPublisher =
+    publisher?.kind === "user" &&
+    (viewerCanAddToPublisher || (me?.handle != null && me.handle === handle));
   const viewerCanSeeOrgRoles = isAdmin(me) || (me?.handle != null && me.handle === handle);
 
   const {
@@ -731,6 +743,7 @@ export function PublisherProfilePage({
               <PublisherProfileChromeIdentity publisher={publisher} />
               <PublisherProfileChromeActions
                 addHandle={viewerCanAddToPublisher ? publisher.handle : undefined}
+                showEditProfile={viewerOwnsPersonalPublisher}
                 isAuthenticated={isAuthenticated}
                 onReport={openReportDialog}
                 requireSignIn={() => {


### PR DESCRIPTION
## Summary

- Proposes replacing the owner-visible profile actions menu with an `Edit profile` button on personal publisher pages.
- Keeps `Add` available for publishers the viewer can publish under.
- Adds route coverage so the owner's personal profile does not expose `Report profile`.

## Proof

- Local preview: `http://127.0.0.1:3017/local` with local Convex seed and `Use Owner` dev persona.

## Tests

- `bunx vitest run src/__tests__/user-profile-route.test.tsx`
- `bun run format:check -- 'src/routes/user/$handle.tsx' src/__tests__/user-profile-route.test.tsx`
