### PR TITLE
Remove account shortcuts from mobile menu

### DIFF
--- a/src/__tests__/header.test.tsx
+++ b/src/__tests__/header.test.tsx
@@ -663,6 +663,30 @@ describe("Header", () => {
     ).toBeTruthy();
   });
 
+  it("keeps signed-in account links out of the mobile menu", () => {
+    authStatusMock.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      me: {
+        displayName: "Patrick",
+        email: "patrick@example.com",
+        handle: "patrick",
+        image: null,
+        name: "Patrick",
+      },
+    });
+
+    render(<Header />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open menu" }));
+
+    const labels = Array.from(document.querySelectorAll(".mobile-nav-section .mobile-nav-link"))
+      .map((element) => element.textContent?.trim())
+      .filter((label): label is string => Boolean(label));
+
+    expect(labels).toEqual(["Home", "Skills", "Plugins", "Creators", "Docs"]);
+  });
+
   it("links profile and starred skills from the signed-in avatar menu", () => {
     profileHandleMock.mockReturnValue("patrick-profile");
     authStatusMock.mockReturnValue({

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -436,38 +436,6 @@ export default function Header() {
                         </Link>
                       </SheetClose>
                     ))}
-                    {isAuthenticated && me ? (
-                      <>
-                        <SheetClose asChild>
-                          <Link to="/dashboard" className="mobile-nav-link">
-                            <LayoutDashboard size={16} aria-hidden="true" />
-                            Dashboard
-                          </Link>
-                        </SheetClose>
-                        <SheetClose asChild>
-                          <Link
-                            to="/add"
-                            search={{ kind: "skill", ownerHandle: undefined, method: undefined }}
-                            className="mobile-nav-link"
-                          >
-                            <Plus size={16} aria-hidden="true" />
-                            Add to ClawHub
-                          </Link>
-                        </SheetClose>
-                        <SheetClose asChild>
-                          <Link to="/stars" className="mobile-nav-link">
-                            <Star size={16} aria-hidden="true" />
-                            Stars
-                          </Link>
-                        </SheetClose>
-                        <SheetClose asChild>
-                          <Link to="/settings" className="mobile-nav-link">
-                            <Settings size={16} aria-hidden="true" />
-                            Settings
-                          </Link>
-                        </SheetClose>
-                      </>
-                    ) : null}
                     {SECONDARY_NAV_ITEMS.map((item) => (
                       <SheetClose key={(item.href ?? item.to ?? "") + item.label} asChild>
                         {item.href ? (


### PR DESCRIPTION
## Summary

- Remove the signed-in account shortcuts from the mobile sheet menu.
- Keep those destinations available through the user avatar menu.
- Add a Header test covering the proposed signed-in mobile menu contents.

## Validation

- `bun run test -- src/__tests__/header.test.tsx`
- `bun run format:check -- src/components/Header.tsx src/__tests__/header.test.tsx`
- `bun run ci:static`
- Local Chrome check at `http://localhost:3000/`, 390x844 viewport: opened the mobile menu and verified the rendered links are `Home`, `Skills`, `Plugins`, `Creators`, and `Docs`.
