### PR TITLE
docs: symlink Claude instructions to AGENTS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,1 @@
-# ClawHub Project Rules
-
-Follow `AGENTS.md` as the canonical repository instructions.
-
-- For Convex work, also read `.agents/skills/clawhub-convex/SKILL.md`.
-- For production app deploys or stable CLI npm releases, also read
-  `.agents/skills/clawhub-production-release/SKILL.md`.
+AGENTS.md


### PR DESCRIPTION
## Summary

- replace `CLAUDE.md` with a relative symlink to canonical `AGENTS.md`

## Validation

- `bun run ci:static`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `git diff --check`
