### PR TITLE
fix(search): bound pending version fallback reads

### DIFF
--- a/convex/lib/publicBrowse.test.ts
+++ b/convex/lib/publicBrowse.test.ts
@@ -176,7 +176,10 @@ describe("publicBrowse", () => {
           query: () => ({
             withIndex: () => ({
               order: () => ({
-                take: async () => [pendingVersion, approvedVersion],
+                take: async (limit: number) => {
+                  expect(limit).toBe(2);
+                  return [pendingVersion, approvedVersion];
+                },
               }),
             }),
           }),
@@ -200,7 +203,7 @@ describe("publicBrowse", () => {
     expect(version?.version).toBe("1.0.0");
   });
 
-  it("returns null when every hosted version is still pending review", async () => {
+  it("does not skip past multiple pending hosted versions", async () => {
     const pendingV2 = {
       _id: "skillVersions:pending-2" as never,
       skillId: "skills:1" as never,
@@ -218,6 +221,13 @@ describe("publicBrowse", () => {
       version: "1.0.0",
       createdAt: 1,
     };
+    const olderApproved = {
+      ...pendingV2,
+      _id: "skillVersions:approved" as never,
+      version: "0.9.0",
+      createdAt: 0,
+      vtAnalysis: { status: "clean" as const, checkedAt: 0 },
+    };
 
     const version = await resolvePublicBrowseVersionForSkill(
       {
@@ -226,7 +236,8 @@ describe("publicBrowse", () => {
           query: () => ({
             withIndex: () => ({
               order: () => ({
-                take: async () => [pendingV2, pendingV1],
+                take: async (limit: number) =>
+                  [pendingV2, pendingV1, olderApproved].slice(0, limit),
               }),
             }),
           }),

--- a/convex/lib/publicBrowse.ts
+++ b/convex/lib/publicBrowse.ts
@@ -129,7 +129,9 @@ export async function resolvePublicBrowseVersionForSkill(
       q.eq("skillId", skill._id).eq("softDeletedAt", undefined),
     )
     .order("desc")
-    .take(24);
+    // A hosted skill can only have its latest version pending review. Read that
+    // version plus the immediately preceding public fallback, then fail closed.
+    .take(2);
 
   for (const version of versions) {
     if (version._id === skill.moderationSourceVersionId) continue;


### PR DESCRIPTION
## Summary

- limit hosted pending-review fallback resolution to the latest two versions
- fail closed instead of walking past multiple pending versions
- add regression coverage for the read bound and fallback behavior

## Production reproduction

Before this fix, the following read-only production query hit Convex's 16 MiB read limit:

```sh
bunx convex run --deployment wry-manatee-359 search:lexicalFallbackSkills '{"query":"other","queryTokens":["other"],"limit":200,"skipExactSlugLookup":true,"categorySlug":"other"}'
```

Request ID: `6295d549ee6c12aa`. Insights showed 2,206 `skillVersions` documents read (~12.58 MB), plus the 2,000-row search digest (~4.54 MB).

## Validation

- `bunx vitest run convex/lib/publicBrowse.test.ts convex/search.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `bunx convex dev --once --typecheck=disable`
- `$autoreview --mode local` (clean)

Tracks Sentry issue `CLAWHUB-CONVEX-13`.
