### PR TITLE
feat: add continuously refilled security scan workers

### DIFF
--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -18,9 +18,9 @@ on:
         required: false
         default: ""
       max-runtime-minutes:
-        description: "Stop claiming new batches after this many minutes"
+        description: "Stop claiming new jobs after this many minutes"
         required: true
-        default: "8"
+        default: "12"
 permissions:
   contents: read
 
@@ -30,20 +30,33 @@ concurrency:
 
 jobs:
   codex-security-scan:
-    name: Codex security scan shard ${{ matrix.shard }}
+    name: Codex security scan ${{ matrix.lane }} shard ${{ matrix.shard }}
     runs-on: blacksmith-8vcpu-ubuntu-2404
-    timeout-minutes: 20
+    timeout-minutes: 40
     environment: Production
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 6
       matrix:
-        shard: [0, 1, 2, 3]
+        include:
+          - lane: priority
+            shard: priority-0
+          - lane: shared
+            shard: shared-0
+          - lane: shared
+            shard: shared-1
+          - lane: shared
+            shard: shared-2
+          - lane: shared
+            shard: shared-3
+          - lane: shared
+            shard: shared-4
     env:
       CONVEX_URL: ${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}
       CODEX_SECURITY_SCAN_LIMIT: ${{ github.event.client_payload.batch_limit || inputs.limit || inputs['batch-limit'] || '4' }}
       CODEX_SECURITY_SCAN_MAX_JOBS: ${{ github.event.client_payload.max_jobs || inputs['max-jobs'] || '' }}
-      CODEX_SECURITY_SCAN_MAX_RUNTIME_MINUTES: ${{ github.event.client_payload.max_runtime_minutes || inputs['max-runtime-minutes'] || '8' }}
+      CODEX_SECURITY_SCAN_MAX_RUNTIME_MINUTES: ${{ github.event.client_payload.max_runtime_minutes || inputs['max-runtime-minutes'] || '12' }}
+      CODEX_SECURITY_SCAN_LANE: ${{ matrix.lane }}
       CODEX_SECURITY_SCAN_TIMEOUT_MS: ${{ vars.CODEX_SECURITY_SCAN_TIMEOUT_MS || '240000' }}
       CODEX_SECURITY_SCAN_SHADOW_CLAWSCAN: "1"
       CODEX_SECURITY_SCAN_SHADOW_CLAWSCAN_SANDBOX: ${{ vars.CODEX_SECURITY_SCAN_SHADOW_CLAWSCAN_SANDBOX || 'docker' }}
@@ -100,6 +113,7 @@ jobs:
         run: |
           bun scripts/security/run-codex-scan-worker.ts \
             --batch-limit "$CODEX_SECURITY_SCAN_LIMIT" \
+            --lane "$CODEX_SECURITY_SCAN_LANE" \
             --max-jobs "$CODEX_SECURITY_SCAN_MAX_JOBS" \
             --max-runtime-minutes "$CODEX_SECURITY_SCAN_MAX_RUNTIME_MINUTES" \
             --lease-minutes "$CODEX_SECURITY_SCAN_LEASE_MINUTES"

--- a/convex/crons.test.ts
+++ b/convex/crons.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => {
   const authRefreshTokensPruneRef = Symbol("auth-refresh-tokens-prune");
   const publisherInvitesPruneRef = Symbol("publisher-invites-prune");
   const promotionsFeedPublishRef = Symbol("promotions-feed-publish");
+  const securityScanExpiredLeaseRecoveryRef = Symbol("security-scan-expired-lease-recovery");
   const securityScanDispatchWatchdogRef = Symbol("security-scan-dispatch-watchdog");
   return {
     interval,
@@ -32,6 +33,7 @@ const mocks = vi.hoisted(() => {
     authRefreshTokensPruneRef,
     publisherInvitesPruneRef,
     promotionsFeedPublishRef,
+    securityScanExpiredLeaseRecoveryRef,
     securityScanDispatchWatchdogRef,
   };
 });
@@ -79,6 +81,7 @@ vi.mock("./_generated/api", () => ({
     },
     securityScan: {
       pruneExpiredSkillScanRequestsInternal: Symbol("skill-scan-request-prune"),
+      requeueExpiredCodexScanJobsInternal: mocks.securityScanExpiredLeaseRecoveryRef,
     },
     securityScanDispatch: {
       requestSecurityScanDispatchInternal: mocks.securityScanDispatchWatchdogRef,
@@ -169,6 +172,17 @@ describe("crons", () => {
       "codex-scan-dispatch-watchdog",
       { minutes: 5 },
       mocks.securityScanDispatchWatchdogRef,
+      {},
+    );
+  });
+
+  it("recovers expired security scan leases outside the claim hot path", async () => {
+    await import("./crons");
+
+    expect(mocks.interval).toHaveBeenCalledWith(
+      "codex-scan-expired-lease-recovery",
+      { minutes: 5 },
+      mocks.securityScanExpiredLeaseRecoveryRef,
       {},
     );
   });

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -170,6 +170,13 @@ if (process.env.CLAWHUB_DISABLE_CRONS !== "1" && process.env.CLAWHUB_PREVIEW !==
   );
 
   crons.interval(
+    "codex-scan-expired-lease-recovery",
+    { minutes: 5 },
+    internal.securityScan.requeueExpiredCodexScanJobsInternal,
+    {},
+  );
+
+  crons.interval(
     "codex-scan-dispatch-watchdog",
     { minutes: 5 },
     internal.securityScanDispatch.requestSecurityScanDispatchInternal,

--- a/convex/securityScan.test.ts
+++ b/convex/securityScan.test.ts
@@ -4,6 +4,7 @@ import {
   appendGitHubSkillScanRequestFilesInternal,
   cancelQueuedVtUpdateJobsInternal,
   claimCodexScanJobs,
+  claimCodexScanJobLeases,
   clearQueuedBackfillJobsForLocalDev,
   claimQueuedJobsInternal,
   completeCodexScanJob,
@@ -21,12 +22,16 @@ import {
   logCodexScanQueueHealthInternal,
   prepareGitHubSkillScanRequestInternal,
   pruneExpiredSkillScanRequestsInternal,
+  requeueCodexScanJobLease,
+  requeueExpiredCodexScanJobsInternal,
+  requeueJobLeaseInternal,
   recordGitHubSkillScanResultInternal,
   recordSkillScanRequestFailedInternal,
   requestPackageRescanForUserInternal,
   requestPackageRescan,
   requestSkillRescanForUserInternal,
   requestSkillRescan,
+  hydrateCodexScanJob,
 } from "./securityScan";
 
 vi.mock("@convex-dev/auth/server", () => ({
@@ -45,10 +50,53 @@ const claimCodexScanJobsHandler = (
   >
 )._handler;
 
+const claimCodexScanJobLeasesHandler = (
+  claimCodexScanJobLeases as unknown as WrappedHandler<
+    {
+      token: string;
+      workerId: string;
+      lane?: "priority" | "shared";
+      limit?: number;
+      leaseMs?: number;
+    },
+    Array<ScanJob & { leaseToken: string; workerId: string }>
+  >
+)._handler;
+
+const hydrateCodexScanJobHandler = (
+  hydrateCodexScanJob as unknown as WrappedHandler<{
+    token: string;
+    workerId: string;
+    jobId: string;
+    leaseToken: string;
+  }>
+)._handler;
+
 const claimQueuedJobsInternalHandler = (
   claimQueuedJobsInternal as unknown as WrappedHandler<
-    { workerId: string; limit: number; leaseMs?: number },
+    { workerId: string; lane?: "priority" | "shared"; limit: number; leaseMs?: number },
     Array<ScanJob & { leaseToken: string; workerId: string }>
+  >
+)._handler;
+
+const requeueExpiredCodexScanJobsInternalHandler = (
+  requeueExpiredCodexScanJobsInternal as unknown as WrappedHandler<
+    { limit?: number },
+    { requeued: number }
+  >
+)._handler;
+
+const requeueJobLeaseInternalHandler = (
+  requeueJobLeaseInternal as unknown as WrappedHandler<
+    { jobId: string; leaseToken: string; workerId: string },
+    { ok: true; nextRunAt: number }
+  >
+)._handler;
+
+const requeueCodexScanJobLeaseHandler = (
+  requeueCodexScanJobLease as unknown as WrappedHandler<
+    { token: string; jobId: string; leaseToken: string; workerId: string },
+    { ok: true; nextRunAt: number }
   >
 )._handler;
 
@@ -2534,19 +2582,84 @@ describe("securityScan", () => {
     expect(getUrl).toHaveBeenCalledWith("storage:skill");
   });
 
-  it("claims one hydrated scan job at a time to bound signed URL response size", async () => {
+  it("claims several lightweight leases in one mutation without hydrating signed URLs", async () => {
     vi.stubEnv("SECURITY_SCAN_WORKER_TOKEN", "worker-secret");
-    const runMutation = vi.fn(async () => []);
+    const leases = Array.from({ length: 4 }, (_, index) => ({
+      ...claimedJob,
+      _id: `securityScanJobs:${index}`,
+      leaseToken: `lease-${index}`,
+    }));
+    const runMutation = vi.fn(async () => leases);
+    const runQuery = vi.fn();
+    const getUrl = vi.fn();
 
-    await claimCodexScanJobsHandler(
-      { runMutation, runQuery: vi.fn(), storage: { getUrl: vi.fn() } },
-      { token: "worker-secret", workerId: "worker-1", limit: 10 },
+    const result = await claimCodexScanJobLeasesHandler(
+      { runMutation, runQuery, storage: { getUrl } },
+      {
+        token: "worker-secret",
+        workerId: "worker-1",
+        lane: "shared",
+        limit: 4,
+      },
     );
 
     expect(runMutation).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ workerId: "worker-1", limit: 1 }),
+      expect.objectContaining({
+        workerId: "worker-1",
+        lane: "shared",
+        limit: 4,
+      }),
     );
+    expect(result).toEqual(leases);
+    expect(runQuery).not.toHaveBeenCalled();
+    expect(getUrl).not.toHaveBeenCalled();
+  });
+
+  it("refuses to hydrate a lease owned by a different worker", async () => {
+    vi.stubEnv("SECURITY_SCAN_WORKER_TOKEN", "worker-secret");
+    const runQuery = vi.fn(async () => ({
+      job: {
+        ...claimedJob,
+        workerId: "worker-2",
+      },
+    }));
+    const getUrl = vi.fn();
+
+    await expect(
+      hydrateCodexScanJobHandler(
+        { runMutation: vi.fn(), runQuery, storage: { getUrl } },
+        {
+          token: "worker-secret",
+          workerId: "worker-1",
+          jobId: "securityScanJobs:1",
+          leaseToken: "lease-token",
+        },
+      ),
+    ).rejects.toThrow("Lease mismatch");
+    expect(getUrl).not.toHaveBeenCalled();
+  });
+
+  it("exposes a worker-authenticated retry-safe lease requeue action", async () => {
+    vi.stubEnv("SECURITY_SCAN_WORKER_TOKEN", "worker-secret");
+    const runMutation = vi.fn(async () => ({ ok: true, nextRunAt: 1234 }));
+
+    await expect(
+      requeueCodexScanJobLeaseHandler(
+        { runMutation },
+        {
+          token: "worker-secret",
+          workerId: "worker-1",
+          jobId: "securityScanJobs:1",
+          leaseToken: "lease-token",
+        },
+      ),
+    ).resolves.toEqual({ ok: true, nextRunAt: 1234 });
+    expect(runMutation).toHaveBeenCalledWith(expect.anything(), {
+      workerId: "worker-1",
+      jobId: "securityScanJobs:1",
+      leaseToken: "lease-token",
+    });
   });
 
   it("hydrates only the declared bounded GitHub file chunks", async () => {
@@ -2969,8 +3082,8 @@ describe("securityScan", () => {
     expect(claimed.map((job) => job._id)).toEqual([
       "securityScanJobs:manual",
       "securityScanJobs:malicious-publish",
-      "securityScanJobs:backfill",
       "securityScanJobs:old-publish",
+      "securityScanJobs:backfill",
     ]);
     expect(patches.map((entry) => entry.id)).toEqual(claimed.map((job) => job._id));
   });
@@ -3018,11 +3131,72 @@ describe("securityScan", () => {
 
     expect(claimed.map((job) => job._id)).toEqual([
       "securityScanJobs:manual",
-      "securityScanJobs:backfill",
       "securityScanJobs:publish",
+      "securityScanJobs:backfill",
       "securityScanJobs:vt-update",
       "securityScanJobs:bulk-rescan",
     ]);
+  });
+
+  it("reserves the priority lane for manual, malicious, and publish work", async () => {
+    const { ctx } = makeClaimCtx([
+      makeScanJob({
+        _id: "securityScanJobs:vt-update",
+        source: "vt-update",
+        createdAt: 1,
+        nextRunAt: 1,
+      }),
+      makeScanJob({
+        _id: "securityScanJobs:publish",
+        source: "publish",
+        createdAt: 2,
+        nextRunAt: 2,
+      }),
+      makeScanJob({
+        _id: "securityScanJobs:manual",
+        source: "manual",
+        createdAt: 3,
+        nextRunAt: 3,
+      }),
+    ]);
+
+    const claimed = await claimQueuedJobsInternalHandler(ctx, {
+      workerId: "priority-worker",
+      lane: "priority",
+      limit: 4,
+      leaseMs: 60_000,
+    });
+
+    expect(claimed.map((job) => job._id)).toEqual([
+      "securityScanJobs:manual",
+      "securityScanJobs:publish",
+    ]);
+  });
+
+  it("lets shared workers help priority work before consuming bulk backlog", async () => {
+    const { ctx } = makeClaimCtx([
+      makeScanJob({
+        _id: "securityScanJobs:vt-update",
+        source: "vt-update",
+        createdAt: 1,
+        nextRunAt: 1,
+      }),
+      makeScanJob({
+        _id: "securityScanJobs:publish",
+        source: "publish",
+        createdAt: 2,
+        nextRunAt: 2,
+      }),
+    ]);
+
+    const claimed = await claimQueuedJobsInternalHandler(ctx, {
+      workerId: "shared-worker",
+      lane: "shared",
+      limit: 1,
+      leaseMs: 60_000,
+    });
+
+    expect(claimed.map((job) => job._id)).toEqual(["securityScanJobs:publish"]);
   });
 
   it("caps each Codex scan claim request", async () => {
@@ -3078,6 +3252,82 @@ describe("securityScan", () => {
       "securityScanJobs:manual-1",
       "securityScanJobs:manual-2",
     ]);
+  });
+
+  it("recovers expired leases separately from normal claim transactions", async () => {
+    const { ctx, patches } = makeClaimCtx([
+      makeScanJob({
+        _id: "securityScanJobs:expired",
+        status: "running",
+        leaseToken: "expired-lease",
+        leaseExpiresAt: Date.now() - 1,
+        workerId: "stale-worker",
+      }),
+      makeScanJob({
+        _id: "securityScanJobs:active",
+        status: "running",
+        leaseToken: "active-lease",
+        leaseExpiresAt: Date.now() + 60_000,
+        workerId: "active-worker",
+      }),
+    ]);
+
+    await expect(requeueExpiredCodexScanJobsInternalHandler(ctx, {})).resolves.toEqual({
+      requeued: 1,
+    });
+    expect(patches).toEqual([
+      expect.objectContaining({
+        id: "securityScanJobs:expired",
+        patch: expect.objectContaining({
+          status: "queued",
+          leaseToken: undefined,
+          workerId: undefined,
+        }),
+      }),
+    ]);
+  });
+
+  it("requeues hydration failures without consuming a scanner attempt", async () => {
+    vi.stubEnv("SECURITY_SCAN_EVENT_DISPATCH_ENABLED", "0");
+    const { ctx, patches } = makeFailurePersistenceCtx({
+      "securityScanJobs:1": {
+        ...claimedJob,
+        workerId: "worker-1",
+        targetKind: "skillScanRequest",
+        skillVersionId: undefined,
+        skillScanRequestId: "skillScanRequests:1",
+        attempts: 2,
+      },
+      "skillScanRequests:1": {
+        _id: "skillScanRequests:1",
+        status: "running",
+      },
+    });
+
+    await expect(
+      requeueJobLeaseInternalHandler(ctx, {
+        jobId: "securityScanJobs:1",
+        leaseToken: "lease-token",
+        workerId: "worker-1",
+      }),
+    ).resolves.toMatchObject({ ok: true });
+    expect(patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "securityScanJobs:1",
+          patch: expect.objectContaining({
+            status: "queued",
+            attempts: 1,
+            leaseToken: undefined,
+            workerId: undefined,
+          }),
+        }),
+        expect.objectContaining({
+          id: "skillScanRequests:1",
+          patch: expect.objectContaining({ status: "queued" }),
+        }),
+      ]),
+    );
   });
 
   it("reports queued scan position for manual scan requests", async () => {

--- a/convex/securityScan.ts
+++ b/convex/securityScan.ts
@@ -138,6 +138,7 @@ const jobSourceValidator = v.union(
 );
 
 type SecurityScanJobSource = "publish" | "vt-update" | "backfill" | "bulk-rescan" | "manual";
+const codexScanWorkerLaneValidator = v.union(v.literal("priority"), v.literal("shared"));
 
 type CodexScanQueueHealth = {
   snapshotAt: number;
@@ -150,16 +151,16 @@ type CodexScanQueueHealth = {
 };
 
 const CLAIM_SOURCE_ORDER: SecurityScanJobSource[] = [
-  "backfill",
   "publish",
+  "backfill",
   "vt-update",
   "bulk-rescan",
 ];
 
 const SOURCE_PRIORITY: Record<SecurityScanJobSource, number> = {
   manual: 5,
-  backfill: 4,
-  publish: 3,
+  publish: 4,
+  backfill: 3,
   "vt-update": 2,
   "bulk-rescan": 1,
 };
@@ -327,6 +328,7 @@ const internalRefs = internal as unknown as {
     recordGitHubSkillScanResultInternal: unknown;
     recordSkillScanRequestFailedInternal: unknown;
     recordSkillScanRequestSucceededInternal: unknown;
+    requeueJobLeaseInternal: unknown;
     succeedJobInternal: unknown;
   };
   securityScanDispatch: {
@@ -2337,6 +2339,7 @@ export const clearQueuedBackfillJobsForLocalDev = internalMutation({
 export const claimQueuedJobsInternal = internalMutation({
   args: {
     workerId: v.string(),
+    lane: v.optional(codexScanWorkerLaneValidator),
     limit: v.number(),
     leaseMs: v.optional(v.number()),
   },
@@ -2344,23 +2347,6 @@ export const claimQueuedJobsInternal = internalMutation({
     const now = Date.now();
     const limit = normalizeLimit(args.limit);
     const leaseMs = Math.max(60_000, Math.min(args.leaseMs ?? DEFAULT_LEASE_MS, 60 * 60 * 1000));
-
-    const expiredRunning = await ctx.db
-      .query("securityScanJobs")
-      .withIndex("by_status_and_lease_expires_at", (q) =>
-        q.eq("status", "running").lte("leaseExpiresAt", now),
-      )
-      .take(MAX_EXPIRED_CODEX_SCAN_LEASE_REQUEUES);
-    for (const job of expiredRunning) {
-      await ctx.db.patch(job._id, {
-        status: "queued",
-        leaseToken: undefined,
-        leaseExpiresAt: undefined,
-        workerId: undefined,
-        nextRunAt: now,
-        updatedAt: now,
-      });
-    }
     const capacity = limit;
 
     const ready: Doc<"securityScanJobs">[] = [];
@@ -2399,9 +2385,12 @@ export const claimQueuedJobsInternal = internalMutation({
       );
     }
 
+    // Shared workers remain work-conserving and may help priority work. The dedicated
+    // priority lane never claims bulk sources, which guarantees reserved fast-path capacity.
     for (const source of CLAIM_SOURCE_ORDER) {
       addReadyJobs(await takeReadySourceJobs(source));
       if (remainingCapacity() === 0) break;
+      if (args.lane === "priority" && source === "publish") break;
     }
 
     const claimed = [];
@@ -2433,6 +2422,38 @@ export const claimQueuedJobsInternal = internalMutation({
       });
     }
     return claimed;
+  },
+});
+
+export const requeueExpiredCodexScanJobsInternal = internalMutation({
+  args: {
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const jobs = await ctx.db
+      .query("securityScanJobs")
+      .withIndex("by_status_and_lease_expires_at", (q) =>
+        q.eq("status", "running").lte("leaseExpiresAt", now),
+      )
+      .take(
+        Math.max(
+          1,
+          Math.min(args.limit ?? MAX_EXPIRED_CODEX_SCAN_LEASE_REQUEUES, MAX_CODEX_SCAN_CLAIM_LIMIT),
+        ),
+      );
+    for (const job of jobs) {
+      await ctx.db.patch(job._id, {
+        status: "queued",
+        leaseToken: undefined,
+        leaseExpiresAt: undefined,
+        workerId: undefined,
+        nextRunAt: now,
+        updatedAt: now,
+      });
+    }
+    if (jobs.length > 0) await requestSecurityScanDispatch(ctx);
+    return { requeued: jobs.length };
   },
 });
 
@@ -2563,6 +2584,134 @@ export const failJobInternal = internalMutation({
   },
 });
 
+export const requeueJobLeaseInternal = internalMutation({
+  args: {
+    jobId: v.id("securityScanJobs"),
+    leaseToken: v.string(),
+    workerId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const job = await ctx.db.get(args.jobId);
+    if (
+      !job ||
+      job.status !== "running" ||
+      job.leaseToken !== args.leaseToken ||
+      job.workerId !== args.workerId
+    ) {
+      throw new ConvexError("Lease mismatch");
+    }
+    const now = Date.now();
+    await ctx.db.patch(job._id, {
+      status: "queued",
+      attempts: Math.max(0, job.attempts - 1),
+      leaseToken: undefined,
+      leaseExpiresAt: undefined,
+      workerId: undefined,
+      nextRunAt: now + 60_000,
+      updatedAt: now,
+    });
+    if (job.targetKind === "skillScanRequest" && job.skillScanRequestId) {
+      await ctx.db.patch(job.skillScanRequestId, {
+        status: "queued",
+        updatedAt: now,
+      });
+    }
+    await requestSecurityScanDispatch(ctx);
+    return { ok: true as const, nextRunAt: now + 60_000 };
+  },
+});
+
+type CodexScanHydrationCtx = {
+  runMutation: (ref: never, args: never) => Promise<unknown>;
+  runQuery: (ref: never, args: never) => Promise<unknown>;
+  storage: {
+    getUrl: (storageId: Id<"_storage">) => Promise<string | null>;
+  };
+};
+
+async function hydrateClaimedCodexScanJob(
+  ctx: CodexScanHydrationCtx,
+  job: Doc<"securityScanJobs"> & { leaseToken: string },
+  target: Record<string, unknown> | null,
+) {
+  if (!target || target.missing) {
+    await runMutationRef(ctx, internalRefs.securityScan.failJobInternal, {
+      jobId: job._id,
+      leaseToken: job.leaseToken,
+      error: "Target artifact missing",
+    });
+    return null;
+  }
+
+  const scanRequest = target.scanRequest as Doc<"skillScanRequests"> | undefined;
+  const version = target.version as Doc<"skillVersions"> | undefined;
+  const release = target.release as Doc<"packageReleases"> | undefined;
+  let files: Array<{
+    path: string;
+    size: number;
+    sha256: string;
+    storageId: Id<"_storage">;
+    contentType?: string;
+  }> = [];
+  if (scanRequest) {
+    files =
+      (target.scanRequestFiles as Doc<"skillScanRequests">["files"] | undefined) ??
+      scanRequest.files;
+  } else if (version) {
+    const fingerprintEntries = await runQueryRef<
+      Array<{ fingerprint: string; kind?: "source" | "generated-bundle" }>
+    >(ctx, internalRefs.skills.listVersionFingerprintsInternal, {
+      skillVersionId: version._id,
+    });
+    files = sourceSkillVersionFiles(version.files, {
+      generatedBundleFingerprints: fingerprintEntries
+        .filter((entry) => entry.kind === "generated-bundle")
+        .map((entry) => entry.fingerprint),
+    });
+  } else if (release) {
+    files = release.files;
+  }
+  const fileUrls = [];
+  for (const file of files) {
+    const url = await ctx.storage.getUrl(file.storageId);
+    if (!url) {
+      await runMutationRef(ctx, internalRefs.securityScan.failJobInternal, {
+        jobId: job._id,
+        leaseToken: job.leaseToken,
+        error: `Artifact file unavailable: ${file.path}`,
+      });
+      return null;
+    }
+    fileUrls.push({
+      path: file.path,
+      size: file.size,
+      sha256: file.sha256,
+      contentType: file.contentType,
+      url,
+    });
+  }
+
+  const clawpackUrl = release?.clawpackStorageId
+    ? await ctx.storage.getUrl(release.clawpackStorageId)
+    : null;
+  if (release?.clawpackStorageId && !clawpackUrl) {
+    await runMutationRef(ctx, internalRefs.securityScan.failJobInternal, {
+      jobId: job._id,
+      leaseToken: job.leaseToken,
+      error: "ClawPack artifact unavailable",
+    });
+    return null;
+  }
+  return {
+    job,
+    target: {
+      ...target,
+      files: fileUrls,
+      clawpackUrl,
+    },
+  };
+}
+
 export const claimCodexScanJobs = action({
   args: {
     token: v.string(),
@@ -2590,89 +2739,85 @@ export const claimCodexScanJobs = action({
         internalRefs.securityScan.getJobTargetInternal,
         { jobId: job._id },
       );
-      if (!target || target.missing) {
-        await runMutationRef(ctx, internalRefs.securityScan.failJobInternal, {
-          jobId: job._id,
-          leaseToken: job.leaseToken,
-          error: "Target artifact missing",
-        });
-        continue;
-      }
-
-      const scanRequest = target.scanRequest as Doc<"skillScanRequests"> | undefined;
-      const version = target.version as Doc<"skillVersions"> | undefined;
-      const release = target.release as Doc<"packageReleases"> | undefined;
-      let files: Array<{
-        path: string;
-        size: number;
-        sha256: string;
-        storageId: Id<"_storage">;
-        contentType?: string;
-      }> = [];
-      if (scanRequest) {
-        files =
-          (target.scanRequestFiles as Doc<"skillScanRequests">["files"] | undefined) ??
-          scanRequest.files;
-      } else if (version) {
-        const fingerprintEntries = await runQueryRef<
-          Array<{ fingerprint: string; kind?: "source" | "generated-bundle" }>
-        >(ctx, internalRefs.skills.listVersionFingerprintsInternal, {
-          skillVersionId: version._id,
-        });
-        files = sourceSkillVersionFiles(version.files, {
-          generatedBundleFingerprints: fingerprintEntries
-            .filter((entry) => entry.kind === "generated-bundle")
-            .map((entry) => entry.fingerprint),
-        });
-      } else if (release) {
-        files = release.files;
-      }
-      const fileUrls = [];
-      let missingStoragePath: string | null = null;
-      for (const file of files) {
-        const url = await ctx.storage.getUrl(file.storageId);
-        if (!url) {
-          missingStoragePath = file.path;
-          break;
-        }
-        fileUrls.push({
-          path: file.path,
-          size: file.size,
-          sha256: file.sha256,
-          contentType: file.contentType,
-          url,
-        });
-      }
-      if (missingStoragePath) {
-        await runMutationRef(ctx, internalRefs.securityScan.failJobInternal, {
-          jobId: job._id,
-          leaseToken: job.leaseToken,
-          error: `Artifact file unavailable: ${missingStoragePath}`,
-        });
-        continue;
-      }
-
-      const clawpackUrl = release?.clawpackStorageId
-        ? await ctx.storage.getUrl(release.clawpackStorageId)
-        : null;
-      if (release?.clawpackStorageId && !clawpackUrl) {
-        await runMutationRef(ctx, internalRefs.securityScan.failJobInternal, {
-          jobId: job._id,
-          leaseToken: job.leaseToken,
-          error: "ClawPack artifact unavailable",
-        });
-        continue;
-      }
-      hydrated.push({
-        job,
-        target: {
-          ...target,
-          files: fileUrls,
-          clawpackUrl,
-        },
-      });
+      const claimedJob = await hydrateClaimedCodexScanJob(ctx, job, target);
+      if (claimedJob) hydrated.push(claimedJob);
     }
     return hydrated;
+  },
+});
+
+export const claimCodexScanJobLeases = action({
+  args: {
+    token: v.string(),
+    workerId: v.string(),
+    lane: v.optional(codexScanWorkerLaneValidator),
+    limit: v.optional(v.number()),
+    leaseMs: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    assertWorkerToken(args.token);
+    return await runMutationRef<Array<Doc<"securityScanJobs"> & { leaseToken: string }>>(
+      ctx,
+      internalRefs.securityScan.claimQueuedJobsInternal,
+      {
+        workerId: args.workerId,
+        lane: args.lane ?? "shared",
+        limit: normalizeLimit(args.limit),
+        leaseMs: args.leaseMs,
+      },
+    );
+  },
+});
+
+export const hydrateCodexScanJob = action({
+  args: {
+    token: v.string(),
+    workerId: v.string(),
+    jobId: v.id("securityScanJobs"),
+    leaseToken: v.string(),
+  },
+  handler: async (ctx, args) => {
+    assertWorkerToken(args.token);
+    const target = await runQueryRef<Record<string, unknown> | null>(
+      ctx,
+      internalRefs.securityScan.getJobTargetInternal,
+      { jobId: args.jobId },
+    );
+    const job = target?.job as Doc<"securityScanJobs"> | undefined;
+    if (
+      !job ||
+      job.status !== "running" ||
+      job.leaseToken !== args.leaseToken ||
+      job.workerId !== args.workerId
+    ) {
+      throw new ConvexError("Lease mismatch");
+    }
+    return hydrateClaimedCodexScanJob(
+      ctx,
+      job as Doc<"securityScanJobs"> & { leaseToken: string },
+      target,
+    );
+  },
+});
+
+export const requeueCodexScanJobLease = action({
+  args: {
+    token: v.string(),
+    workerId: v.string(),
+    jobId: v.id("securityScanJobs"),
+    leaseToken: v.string(),
+  },
+  handler: async (ctx, args) => {
+    assertWorkerToken(args.token);
+    return await runMutationRef<{ ok: true; nextRunAt: number }>(
+      ctx,
+      internalRefs.securityScan.requeueJobLeaseInternal,
+      {
+        workerId: args.workerId,
+        jobId: args.jobId,
+        leaseToken: args.leaseToken,
+      },
+    );
   },
 });
 

--- a/convex/securityScanDispatch.test.ts
+++ b/convex/securityScanDispatch.test.ts
@@ -348,7 +348,7 @@ describe("securityScanDispatch", () => {
         scheduledToken: undefined,
         scheduledAt: undefined,
         leaseToken: result.leaseToken,
-        leaseExpiresAt: 1_300_000,
+        leaseExpiresAt: 1_900_000,
       }),
     );
   });
@@ -406,7 +406,7 @@ describe("securityScanDispatch", () => {
           event_type: "clawhub-security-scan",
           client_payload: {
             batch_limit: "4",
-            max_runtime_minutes: "8",
+            max_runtime_minutes: "12",
           },
         }),
       }),

--- a/convex/securityScanDispatch.ts
+++ b/convex/securityScanDispatch.ts
@@ -5,7 +5,7 @@ import { internalAction, internalMutation } from "./functions";
 import { createGitHubAppInstallationToken, isGitHubAppConfigured } from "./lib/githubAuth";
 
 const DISPATCH_STATE_KEY = "codex-worker";
-const DISPATCH_LEASE_MS = 5 * 60 * 1000;
+const DISPATCH_LEASE_MS = 15 * 60 * 1000;
 const SCHEDULE_STALE_MS = 60 * 1000;
 const GITHUB_REPOSITORY_DISPATCH_URL = "https://api.github.com/repos/openclaw/clawhub/dispatches";
 
@@ -69,7 +69,7 @@ export async function dispatchSecurityScanWorkflow(
       event_type: "clawhub-security-scan",
       client_payload: {
         batch_limit: "4",
-        max_runtime_minutes: "8",
+        max_runtime_minutes: "12",
       },
     }),
   });

--- a/scripts/security/run-codex-scan-worker.test.ts
+++ b/scripts/security/run-codex-scan-worker.test.ts
@@ -9,18 +9,14 @@ import {
   LOCAL_CODEX_WORKER_OPT_IN,
   resolveCodexWorkerHome,
 } from "../codex-worker-guard";
-import * as codexScanWorker from "./run-codex-scan-worker";
 import {
   buildPrompt,
-  claimBatchDrainedQueue,
-  claimFailuresAreFatal,
-  minimumClaimWindowMs,
   normalizeSkillSpectorAnalysis,
   processJob,
   resolveSkillSpectorScanInput,
   resolveSkillSpectorScanInputs,
+  runContinuouslyRefilledWorkerPool,
   runClawScanShadow,
-  shouldClaimSecurityScanBatch,
   writeArtifactWorkspace,
   writeJobDiagnostic,
 } from "./run-codex-scan-worker";
@@ -64,115 +60,114 @@ function unsafeFixtureLabels() {
 }
 
 describe("run-codex-scan-worker diagnostics", () => {
-  it("treats transient claim failures as fatal only when no jobs were claimed", () => {
-    expect(claimFailuresAreFatal(0, 0)).toBe(false);
-    expect(claimFailuresAreFatal(1, 0)).toBe(true);
-    expect(claimFailuresAreFatal(1, 3)).toBe(false);
-  });
-
-  it("keeps claiming after partial transient claim failures", () => {
-    expect(claimBatchDrainedQueue(0, 0, 4)).toBe(true);
-    expect(claimBatchDrainedQueue(0, 3, 4)).toBe(true);
-    expect(claimBatchDrainedQueue(1, 3, 4)).toBe(false);
-    expect(claimBatchDrainedQueue(0, 4, 4)).toBe(false);
-  });
-
-  it("keeps enough wall-clock room for one Codex scan plus cleanup before claiming", () => {
-    expect(minimumClaimWindowMs(8 * 60_000, 4 * 60_000)).toBe(7 * 60_000);
-    expect(minimumClaimWindowMs(5 * 60_000, 4 * 60_000)).toBe(5 * 60_000);
-  });
-
-  it("always allows the first claim even when the configured runtime is short", () => {
-    expect(shouldClaimSecurityScanBatch(0, 1, 5 * 60_000)).toBe(true);
-    expect(shouldClaimSecurityScanBatch(1, 1, 5 * 60_000)).toBe(false);
-    expect(shouldClaimSecurityScanBatch(1, 5 * 60_000, 5 * 60_000)).toBe(true);
-  });
-
-  it("keeps successful claims when a parallel claim request fails", async () => {
-    const claimCodexScanJobBatch = (
-      codexScanWorker as typeof codexScanWorker & {
-        claimCodexScanJobBatch?: (
-          claimLimit: number,
-          claimOne: () => Promise<
-            Array<{
-              job: {
-                _id: string;
-                leaseToken: string;
-                targetKind: "skillVersion";
-                source: string;
-                hasMaliciousSignal: boolean;
-                waitForVtUntil: number;
-              };
-              target: Record<string, unknown>;
-            }>
-          >,
-        ) => Promise<{ claimFailures: number; jobs: Array<{ job: { _id: string } }> }>;
-      }
-    ).claimCodexScanJobBatch;
-    expect(claimCodexScanJobBatch).toBeTypeOf("function");
-    if (!claimCodexScanJobBatch) return;
-
-    const claimOne = vi
-      .fn()
-      .mockResolvedValueOnce([
-        {
-          job: {
-            _id: "securityScanJobs:1",
-            leaseToken: "lease",
-            targetKind: "skillVersion",
-            source: "publish",
-            hasMaliciousSignal: false,
-            waitForVtUntil: 0,
-          },
-          target: {},
-        },
-      ])
-      .mockRejectedValueOnce(
-        new Error(
-          "temporary claim failure https://signed.example.invalid/file?token=claim-secret OPENAI_API_KEY=claim-process-secret",
-        ),
-      )
-      .mockResolvedValueOnce([]);
-    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    await expect(claimCodexScanJobBatch(3, claimOne)).resolves.toMatchObject({
-      claimFailures: 1,
-      jobs: [{ job: { _id: "securityScanJobs:1" } }],
+  it("refills a free slot without waiting for the slowest active job", async () => {
+    const started: string[] = [];
+    let releaseSlowJob: (() => void) | undefined;
+    const slowJob = new Promise<void>((resolve) => {
+      releaseSlowJob = resolve;
     });
-    expect(claimOne).toHaveBeenCalledTimes(3);
-    const logged = stdoutWrite.mock.calls.map((call) => String(call[0])).join("");
-    expect(logged).toContain("security_scan_claim_failed");
-    expect(logged).toContain("temporary claim failure");
-    expect(logged).not.toContain("https://signed.example.invalid");
-    expect(logged).not.toContain("claim-secret");
-    expect(logged).not.toContain("claim-process-secret");
-    stdoutWrite.mockRestore();
+    const jobs = ["slow", "fast", "next"];
+    const claimJobs = vi.fn(async (limit: number) => jobs.splice(0, limit).map((id) => ({ id })));
+    const processClaimedJob = vi.fn(async (job: { id: string }) => {
+      started.push(job.id);
+      if (job.id === "slow") await slowJob;
+      return {
+        completed: true,
+        hardFailed: false,
+        retryableFailed: false,
+      };
+    });
+
+    const run = runContinuouslyRefilledWorkerPool({
+      concurrency: 2,
+      maxJobs: undefined,
+      canClaim: () => true,
+      claimJobs,
+      processClaimedJob,
+    });
+
+    await vi.waitFor(() => expect(started).toEqual(["slow", "fast", "next"]));
+    expect(releaseSlowJob).toBeTypeOf("function");
+    releaseSlowJob?.();
+
+    await expect(run).resolves.toMatchObject({
+      totalClaimed: 3,
+      totalCompleted: 3,
+      totalClaimFailures: 0,
+    });
+    expect(claimJobs.mock.calls.map(([limit]) => limit)).toEqual([2, 1, 1]);
   });
 
-  it("counts total claim failures even when no jobs are claimed", async () => {
-    const claimCodexScanJobBatch = (
-      codexScanWorker as typeof codexScanWorker & {
-        claimCodexScanJobBatch?: (
-          claimLimit: number,
-          claimOne: () => Promise<never[]>,
-        ) => Promise<{ claimFailures: number; jobs: Array<{ job: { _id: string } }> }>;
-      }
-    ).claimCodexScanJobBatch;
-    expect(claimCodexScanJobBatch).toBeTypeOf("function");
-    if (!claimCodexScanJobBatch) return;
-
-    const claimOne = vi.fn().mockRejectedValue(new Error("claim outage"));
-    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    await expect(claimCodexScanJobBatch(2, claimOne)).resolves.toMatchObject({
-      claimFailures: 2,
-      jobs: [],
+  it("counts one failed batch lease request without multiplying it by slot count", async () => {
+    const claimJobs = vi.fn(async () => {
+      throw new Error("claim outage");
     });
-    expect(claimOne).toHaveBeenCalledTimes(2);
-    const logged = stdoutWrite.mock.calls.map((call) => String(call[0])).join("");
-    expect(logged).toContain("security_scan_claim_failed");
-    expect(logged).toContain("claim outage");
-    stdoutWrite.mockRestore();
+
+    await expect(
+      runContinuouslyRefilledWorkerPool({
+        concurrency: 4,
+        maxJobs: undefined,
+        canClaim: () => true,
+        claimJobs,
+        processClaimedJob: vi.fn(),
+      }),
+    ).resolves.toMatchObject({
+      totalClaimed: 0,
+      totalClaimFailures: 1,
+      totalFailed: 1,
+    });
+    expect(claimJobs).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the priority lane alive after processing a partial batch", async () => {
+    let canClaim = true;
+    const sleep = vi.fn(async () => {
+      canClaim = false;
+    });
+
+    await expect(
+      runContinuouslyRefilledWorkerPool({
+        concurrency: 4,
+        maxJobs: undefined,
+        canClaim: () => canClaim,
+        claimJobs: vi.fn(async () => [{ id: "publish" }]),
+        processClaimedJob: vi.fn(async () => ({
+          completed: true,
+          hardFailed: false,
+          retryableFailed: false,
+        })),
+        idlePollMs: 15_000,
+        sleep,
+      }),
+    ).resolves.toMatchObject({
+      totalClaimed: 1,
+      totalCompleted: 1,
+    });
+    expect(sleep).toHaveBeenCalledWith(15_000);
+  });
+
+  it("exits a priority worker after reaching its explicit max-jobs cap", async () => {
+    const sleep = vi.fn();
+
+    await expect(
+      runContinuouslyRefilledWorkerPool({
+        concurrency: 4,
+        maxJobs: 1,
+        canClaim: () => true,
+        claimJobs: vi.fn(async () => [{ id: "publish" }]),
+        processClaimedJob: vi.fn(async () => ({
+          completed: true,
+          hardFailed: false,
+          retryableFailed: false,
+        })),
+        idlePollMs: 15_000,
+        sleep,
+      }),
+    ).resolves.toMatchObject({
+      totalClaimed: 1,
+      totalCompleted: 1,
+    });
+    expect(sleep).not.toHaveBeenCalled();
   });
 
   it("blocks direct local Codex security worker runs without opt-in", () => {

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -45,6 +45,8 @@ export type ClaimedJob = {
   };
 };
 
+type ClaimedJobLease = ClaimedJob["job"];
+
 export type StoredLlmAnalysis = {
   status: string;
   verdict?: string;
@@ -147,7 +149,6 @@ type ProcessJobResult = {
 const DEFAULT_BATCH_LIMIT = 4;
 const DEFAULT_MAX_RUNTIME_MS = 40 * 60 * 1000;
 const DEFAULT_CODEX_SCAN_TIMEOUT_MS = 20 * 60 * 1000;
-const CLAIM_WINDOW_SHUTDOWN_BUFFER_MS = 3 * 60 * 1000;
 const DEFAULT_CLAWSCAN_SHADOW_TIMEOUT_MS = 20 * 60 * 1000;
 const DEFAULT_CLAWSCAN_SHADOW_SANDBOX_IMAGE =
   "ghcr.io/openclaw/clawscan-runtime@sha256:d85bfe671fe597edc6802f9d6a07dd91b59c69cec4faa6e8f89778037507dc3b";
@@ -200,6 +201,8 @@ function parseArgs() {
     const parsed = Number(value);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
   };
+  const laneValue = get("--lane") ?? process.env.CODEX_SECURITY_SCAN_LANE;
+  const lane: "priority" | "shared" = laneValue === "priority" ? "priority" : "shared";
   return {
     batchLimit: numberFrom(
       get("--batch-limit") ?? get("--limit") ?? process.env.CODEX_SECURITY_SCAN_LIMIT,
@@ -216,11 +219,16 @@ function parseArgs() {
         get("--lease-minutes") ?? process.env.CODEX_SECURITY_SCAN_LEASE_MINUTES,
         DEFAULT_LEASE_MS / 60_000,
       ) * 60_000,
+    lane,
     diagnosticsRoot:
       get("--diagnostics-dir") ??
       process.env.CODEX_SECURITY_SCAN_DIAGNOSTICS_DIR ??
       DEFAULT_DIAGNOSTICS_ROOT,
   };
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function requireEnv(name: string) {
@@ -1207,18 +1215,6 @@ function clawScanShadowEnabled() {
   return value === "1" || value === "true" || value === "yes";
 }
 
-export function minimumClaimWindowMs(maxRuntimeMs: number, scanTimeoutMs: number) {
-  return Math.min(maxRuntimeMs, scanTimeoutMs + CLAIM_WINDOW_SHUTDOWN_BUFFER_MS);
-}
-
-export function shouldClaimSecurityScanBatch(
-  totalClaimed: number,
-  remainingRuntimeMs: number,
-  minClaimWindowMs: number,
-) {
-  return totalClaimed === 0 || remainingRuntimeMs >= minClaimWindowMs;
-}
-
 export async function runCodex(
   job: ClaimedJob,
   workspace: string,
@@ -1584,43 +1580,116 @@ export async function processJob(
   }
 }
 
-export async function claimCodexScanJobBatch(
-  claimLimit: number,
-  claimOne: () => Promise<ClaimedJob[]>,
-) {
-  const results = await Promise.allSettled(Array.from({ length: claimLimit }, () => claimOne()));
-  let claimFailures = 0;
-  const jobs = results.flatMap((result) => {
-    if (result.status === "fulfilled") return result.value;
-    claimFailures += 1;
-    const message = result.reason instanceof Error ? result.reason.message : String(result.reason);
-    logger.error(
-      {
-        event: "security_scan_claim_failed",
-        publicReason: sanitizeWorkerErrorMessage(message),
-        scannerPhase: "claim",
-      },
-      "failed to claim security scan job",
-    );
-    return [];
-  });
-  return { claimFailures, jobs };
-}
+export async function runContinuouslyRefilledWorkerPool<TJob>(options: {
+  concurrency: number;
+  maxJobs: number | undefined;
+  canClaim: (totalClaimed: number) => boolean;
+  claimJobs: (limit: number) => Promise<TJob[]>;
+  processClaimedJob: (job: TJob) => Promise<ProcessJobResult>;
+  idlePollMs?: number;
+  sleep?: (ms: number) => Promise<unknown>;
+}) {
+  const active = new Set<Promise<ProcessJobResult>>();
+  const sleepImpl = options.sleep ?? sleep;
+  let queueDrained = false;
+  let totalClaimed = 0;
+  let totalCompleted = 0;
+  let totalFailed = 0;
+  let totalRetryableFailed = 0;
+  let totalClaimFailures = 0;
 
-export function claimFailuresAreFatal(claimFailures: number, claimedJobs: number) {
-  return claimFailures > 0 && claimedJobs === 0;
-}
+  while (active.size > 0 || (!queueDrained && options.canClaim(totalClaimed))) {
+    while (active.size < options.concurrency && !queueDrained && options.canClaim(totalClaimed)) {
+      const remainingJobs =
+        options.maxJobs === undefined
+          ? options.concurrency - active.size
+          : Math.min(
+              options.concurrency - active.size,
+              Math.max(0, options.maxJobs - totalClaimed),
+            );
+      if (remainingJobs === 0) {
+        queueDrained = true;
+        break;
+      }
 
-export function claimBatchDrainedQueue(
-  claimFailures: number,
-  claimedJobs: number,
-  claimLimit: number,
-) {
-  return claimFailures === 0 && claimedJobs < claimLimit;
+      let jobs: TJob[];
+      try {
+        jobs = await options.claimJobs(remainingJobs);
+      } catch (error) {
+        totalClaimFailures += 1;
+        totalFailed += 1;
+        queueDrained = true;
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error(
+          {
+            event: "security_scan_claim_failed",
+            publicReason: sanitizeWorkerErrorMessage(message),
+            requested: remainingJobs,
+            scannerPhase: "claim",
+          },
+          "failed to claim security scan jobs",
+        );
+        break;
+      }
+
+      if (jobs.length === 0) {
+        queueDrained = true;
+        break;
+      }
+      totalClaimed += jobs.length;
+      for (const job of jobs) {
+        const task = options.processClaimedJob(job).catch((error) => {
+          const message = error instanceof Error ? error.message : String(error);
+          logger.error(
+            {
+              event: "security_scan_unhandled_process_failure",
+              publicReason: sanitizeWorkerErrorMessage(message),
+              scannerPhase: "process",
+            },
+            "security scan job escaped worker error handling",
+          );
+          return {
+            completed: false,
+            hardFailed: true,
+            retryableFailed: false,
+          };
+        });
+        active.add(task);
+      }
+      if (jobs.length < remainingJobs) queueDrained = true;
+    }
+
+    if (active.size > 0) {
+      const settled = await Promise.race(
+        [...active].map(async (task) => ({ result: await task, task })),
+      );
+      active.delete(settled.task);
+      if (settled.result.completed) totalCompleted += 1;
+      if (settled.result.hardFailed) totalFailed += 1;
+      if (settled.result.retryableFailed) totalRetryableFailed += 1;
+      if (active.size > 0 || !queueDrained) continue;
+    }
+
+    const maxJobsReached = options.maxJobs !== undefined && totalClaimed >= options.maxJobs;
+    if (queueDrained && !maxJobsReached && options.idlePollMs && options.canClaim(totalClaimed)) {
+      await sleepImpl(options.idlePollMs);
+      queueDrained = false;
+      continue;
+    }
+    break;
+  }
+
+  return {
+    totalClaimed,
+    totalClaimFailures,
+    totalCompleted,
+    totalFailed,
+    totalRetryableFailed,
+  };
 }
 
 async function main() {
-  const { batchLimit, maxJobs, maxRuntimeMs, leaseMs, diagnosticsRoot } = parseArgs();
+  const { batchLimit, maxJobs, maxRuntimeMs, leaseMs, lane, diagnosticsRoot } = parseArgs();
   assertCodexWorkerExecutionAllowed(process.env);
   maskKnownWorkerSecrets();
   const convexUrl = process.env.CONVEX_URL ?? process.env.VITE_CONVEX_URL;
@@ -1634,88 +1703,115 @@ async function main() {
     }:${process.env.CODEX_SECURITY_SCAN_SHARD ?? process.env.GITHUB_JOB ?? "0"}`;
   const startedAt = Date.now();
   const claimDeadline = startedAt + maxRuntimeMs;
-  const minClaimWindowMs = minimumClaimWindowMs(maxRuntimeMs, codexScanTimeoutMs());
-  let totalClaimed = 0;
-  let totalCompleted = 0;
-  let totalFailed = 0;
-  let totalRetryableFailed = 0;
-  let totalClaimFailures = 0;
 
   logger.info(
-    { diagnosticsRoot, event: "security_scan_diagnostics_directory", workerId },
+    { diagnosticsRoot, event: "security_scan_diagnostics_directory", lane, workerId },
     "security scan diagnostics directory",
   );
 
-  while (Date.now() < claimDeadline) {
-    const remainingRuntimeMs = claimDeadline - Date.now();
-    if (!shouldClaimSecurityScanBatch(totalClaimed, remainingRuntimeMs, minClaimWindowMs)) {
+  const sharedShardIndex = Number(
+    process.env.CODEX_SECURITY_SCAN_SHARD?.match(/shared-(\d+)/)?.[1] ?? 0,
+  );
+  if (lane === "shared" && sharedShardIndex > 0) {
+    await sleep(sharedShardIndex * 250);
+  }
+
+  const stats = await runContinuouslyRefilledWorkerPool({
+    concurrency: batchLimit,
+    maxJobs,
+    canClaim: () => Date.now() < claimDeadline,
+    claimJobs: async (limit) => {
+      const leases = (await client.action(api.securityScan.claimCodexScanJobLeases, {
+        token,
+        workerId,
+        lane,
+        limit,
+        leaseMs,
+      })) as ClaimedJobLease[];
+      const hydrated = await Promise.all(
+        leases.map(async (lease) => {
+          try {
+            return {
+              job: (await client.action(api.securityScan.hydrateCodexScanJob, {
+                token,
+                workerId,
+                jobId: lease._id as Id<"securityScanJobs">,
+                leaseToken: lease.leaseToken,
+              })) as ClaimedJob | null,
+              requeued: false,
+            };
+          } catch (error) {
+            const message = sanitizeWorkerErrorMessage(
+              error instanceof Error ? error.message : String(error),
+            );
+            await client.action(api.securityScan.requeueCodexScanJobLease, {
+              token,
+              workerId,
+              jobId: lease._id as Id<"securityScanJobs">,
+              leaseToken: lease.leaseToken,
+            });
+            logger.error(
+              {
+                event: "security_scan_hydration_failed",
+                jobId: lease._id,
+                publicReason: message,
+                scannerPhase: "hydrate",
+              },
+              "failed to hydrate security scan job",
+            );
+            return { job: null, requeued: true };
+          }
+        }),
+      );
+      const jobs = hydrated
+        .map((outcome) => outcome.job)
+        .filter((job): job is ClaimedJob => job !== null);
+      const requeued = hydrated.filter((outcome) => outcome.requeued).length;
+      if (requeued > 0 && jobs.length === 0) {
+        throw new Error("All claimed security scan jobs failed hydration and were requeued");
+      }
       logger.info(
         {
-          event: "security_scan_claim_window_closed",
-          minClaimWindowMs,
-          remainingRuntimeMs,
+          claimed: leases.length,
+          event: "security_scan_jobs_claimed",
+          hydrated: jobs.length,
+          lane,
+          leaseMs,
+          requeued,
+          requested: limit,
           workerId,
         },
-        "stopping before claiming another security scan batch",
+        "claimed security scan jobs",
       );
-      break;
-    }
-    const remainingJobs = maxJobs === undefined ? batchLimit : Math.max(0, maxJobs - totalClaimed);
-    if (remainingJobs === 0) break;
-    const claimLimit = Math.min(batchLimit, remainingJobs);
-    const claimBatch = await claimCodexScanJobBatch(
-      claimLimit,
-      async () =>
-        (await client.action(api.securityScan.claimCodexScanJobs, {
-          token,
-          workerId,
-          limit: 1,
-          leaseMs,
-        })) as ClaimedJob[],
-    );
-    const { claimFailures, jobs } = claimBatch;
-    totalClaimFailures += claimFailures;
-    if (claimFailuresAreFatal(claimFailures, jobs.length)) {
-      totalFailed += claimFailures;
-    }
+      return jobs;
+    },
+    processClaimedJob: (job) => processJob(client, token, job, diagnosticsRoot),
+    idlePollMs: lane === "priority" ? 15_000 : undefined,
+  });
+
+  const remainingRuntimeMs = claimDeadline - Date.now();
+  if (remainingRuntimeMs <= 0) {
     logger.info(
       {
-        claimed: jobs.length,
-        claimFailures,
-        claimLimit,
-        event: "security_scan_jobs_claimed",
-        leaseMs,
+        event: "security_scan_claim_window_closed",
+        remainingRuntimeMs,
         workerId,
       },
-      "claimed security scan jobs",
+      "stopping before claiming another security scan job",
     );
-    if (jobs.length === 0) break;
-
-    totalClaimed += jobs.length;
-    const results = await Promise.all(
-      jobs.map((job) => processJob(client, token, job, diagnosticsRoot)),
-    );
-    totalCompleted += results.filter((result) => result.completed).length;
-    totalFailed += results.filter((result) => result.hardFailed).length;
-    totalRetryableFailed += results.filter((result) => result.retryableFailed).length;
-
-    if (claimBatchDrainedQueue(claimFailures, jobs.length, claimLimit)) break;
   }
 
   logger.info(
     {
       elapsedMs: Date.now() - startedAt,
       event: "security_scan_worker_summary",
-      totalClaimed,
-      totalClaimFailures,
-      totalCompleted,
-      totalFailed,
-      totalRetryableFailed,
+      lane,
+      ...stats,
       workerId,
     },
     "security scan worker summary",
   );
-  if (totalFailed > 0) {
+  if (stats.totalFailed > 0) {
     process.exitCode = 1;
   }
 }

--- a/scripts/security/security-scan-worker-workflow.test.ts
+++ b/scripts/security/security-scan-worker-workflow.test.ts
@@ -36,7 +36,10 @@ describe("security-scan-codex workflow", () => {
         "codex-security-scan": {
           env?: Record<string, unknown>;
           steps: WorkflowStep[];
-          strategy?: { "max-parallel"?: number; matrix?: { shard?: number[] } };
+          strategy?: {
+            "max-parallel"?: number;
+            matrix?: { include?: Array<{ lane?: string; shard?: string }> };
+          };
           "timeout-minutes"?: number;
         };
       };
@@ -68,12 +71,20 @@ describe("security-scan-codex workflow", () => {
       "${{ !cancelled() && steps.diagnostics_secret_scan.outcome == 'success' }}",
     );
     expect(uploadStep?.with?.path).toBe("${{ env.CODEX_SECURITY_SCAN_DIAGNOSTICS_DIR }}");
-    expect(workflow.jobs["codex-security-scan"]["timeout-minutes"]).toBe(20);
+    expect(workflow.jobs["codex-security-scan"]["timeout-minutes"]).toBe(40);
     expect(workflow.on?.workflow_dispatch).toBeDefined();
     expect(workflow.on?.repository_dispatch?.types).toEqual(["clawhub-security-scan"]);
     expect(workflow.on?.schedule).toBeUndefined();
-    expect(workflow.jobs["codex-security-scan"].strategy?.["max-parallel"]).toBe(4);
-    expect(workflow.jobs["codex-security-scan"].strategy?.matrix?.shard).toEqual([0, 1, 2, 3]);
+    expect(workflow.jobs["codex-security-scan"].strategy?.["max-parallel"]).toBe(6);
+    expect(workflow.jobs["codex-security-scan"].strategy?.matrix?.include).toEqual([
+      { lane: "priority", shard: "priority-0" },
+      { lane: "shared", shard: "shared-0" },
+      { lane: "shared", shard: "shared-1" },
+      { lane: "shared", shard: "shared-2" },
+      { lane: "shared", shard: "shared-3" },
+      { lane: "shared", shard: "shared-4" },
+    ]);
+    expect(jobEnv.CODEX_SECURITY_SCAN_LANE).toBe("${{ matrix.lane }}");
     expect(jobEnv.CODEX_SECURITY_SCAN_LIMIT).toBe(
       "${{ github.event.client_payload.batch_limit || inputs.limit || inputs['batch-limit'] || '4' }}",
     );
@@ -81,7 +92,7 @@ describe("security-scan-codex workflow", () => {
       "${{ github.event.client_payload.max_jobs || inputs['max-jobs'] || '' }}",
     );
     expect(jobEnv.CODEX_SECURITY_SCAN_MAX_RUNTIME_MINUTES).toBe(
-      "${{ github.event.client_payload.max_runtime_minutes || inputs['max-runtime-minutes'] || '8' }}",
+      "${{ github.event.client_payload.max_runtime_minutes || inputs['max-runtime-minutes'] || '12' }}",
     );
     expect(jobEnv.CODEX_SECURITY_SCAN_TIMEOUT_MS).toBe(
       "${{ vars.CODEX_SECURITY_SCAN_TIMEOUT_MS || '240000' }}",


### PR DESCRIPTION
## Summary
- replace batch-barrier scan waves with continuously refilled worker slots
- reserve one priority lane for publish/manual work while shared workers drain backlog work-conservingly
- split lightweight lease claims from artifact hydration to reduce Convex OCC contention
- recover expired and transiently unhydratable leases safely
- raise the initial production stage to 6 runners x 4 slots (24 concurrent jobs) with 12-minute waves

## Validation
- `bunx vitest run convex/securityScan.test.ts convex/securityScanDispatch.test.ts convex/crons.test.ts scripts/security/run-codex-scan-worker.test.ts scripts/security/security-scan-worker-workflow.test.ts`
- `bunx tsc --noEmit`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `$autoreview --mode local` (clean)

## Rollout
After merge, manually deploy from `main`, verify queue depth and publish priority, then hold this 24-slot stage until two consecutive 15-minute windows meet the 2x throughput and error guardrails before considering a 5x stage.
