### PR TITLE
fix: cache approved public skill versions

### DIFF
--- a/convex/functions.ts
+++ b/convex/functions.ts
@@ -425,6 +425,22 @@ triggers.register("skills", async (ctx, change) => {
   }
 });
 
+triggers.register("skillVersions", async (ctx, change) => {
+  if (change.operation === "insert") return;
+  if (
+    change.operation === "update" &&
+    change.oldDoc.softDeletedAt === change.newDoc.softDeletedAt &&
+    change.oldDoc.vtAnalysis?.status === change.newDoc.vtAnalysis?.status &&
+    (change.oldDoc.llmAnalysis?.verdict ?? change.oldDoc.llmAnalysis?.status) ===
+      (change.newDoc.llmAnalysis?.verdict ?? change.newDoc.llmAnalysis?.status) &&
+    change.oldDoc.staticScan?.status === change.newDoc.staticScan?.status
+  ) {
+    return;
+  }
+  const skillId = change.operation === "delete" ? change.oldDoc.skillId : change.newDoc.skillId;
+  await syncSkillSearchDigestForSkill(ctx, await ctx.db.get(skillId));
+});
+
 triggers.register("packages", async (ctx, change) => {
   await adjustPublisherStatsForPackageChange(
     ctx,

--- a/convex/lib/publicBrowse.test.ts
+++ b/convex/lib/publicBrowse.test.ts
@@ -5,6 +5,7 @@ import {
   isHostedSkillPendingFirstPublicRelease,
   isPubliclyListableSkillVersion,
   isSkillPendingPublicReview,
+  resolvePublicBrowseVersionState,
   resolvePublicBrowseVersionForSkill,
   shouldExcludeSkillFromPublicBrowse,
 } from "./publicBrowse";
@@ -201,6 +202,74 @@ describe("publicBrowse", () => {
 
     expect(version?._id).toBe("skillVersions:approved");
     expect(version?.version).toBe("1.0.0");
+  });
+
+  it("projects the exact approved fallback version for digest readers", async () => {
+    const pendingVersion = {
+      _id: "skillVersions:pending" as never,
+      skillId: "skills:1" as never,
+      softDeletedAt: undefined,
+      version: "2.0.0",
+      createdAt: 2,
+      changelog: "pending",
+      changelogSource: "user" as const,
+      parsed: { frontmatter: {}, license: "MIT-0" as const },
+      vtAnalysis: { status: "pending" as const, checkedAt: 2 },
+    };
+    const approvedVersion = {
+      ...pendingVersion,
+      _id: "skillVersions:approved" as never,
+      version: "1.0.0",
+      createdAt: 1,
+      vtAnalysis: { status: "clean" as const, checkedAt: 1 },
+    };
+
+    const state = await resolvePublicBrowseVersionState(
+      {
+        db: {
+          get: async () => pendingVersion,
+          query: () => ({
+            withIndex: () => ({
+              order: () => ({
+                take: async () => [pendingVersion, approvedVersion],
+              }),
+            }),
+          }),
+        },
+      } as never,
+      {
+        _id: "skills:1" as never,
+        latestVersionId: pendingVersion._id,
+        moderationSourceVersionId: pendingVersion._id,
+        moderationStatus: "active",
+        moderationReason: "pending.scan",
+        moderationFlags: undefined,
+        stats: { ...emptyStats, versions: 2 },
+        softDeletedAt: undefined,
+        moderationVerdict: "clean",
+        githubScanStatus: "clean",
+      },
+      { latestVersion: pendingVersion as never },
+    );
+
+    expect(state).toEqual({
+      status: "available",
+      versionId: "skillVersions:approved",
+    });
+  });
+
+  it("projects an explicit unavailable state for hidden skills", async () => {
+    const get = async () => {
+      throw new Error("hidden skills must not read versions");
+    };
+
+    const state = await resolvePublicBrowseVersionState({ db: { get } } as never, {
+      ...browseFields,
+      _id: "skills:1" as never,
+      moderationStatus: "hidden",
+    });
+
+    expect(state).toEqual({ status: "unavailable" });
   });
 
   it("does not skip past multiple pending hosted versions", async () => {

--- a/convex/lib/publicBrowse.ts
+++ b/convex/lib/publicBrowse.ts
@@ -36,6 +36,10 @@ type SkillVersionPublicBrowseFields = Pick<
   | "staticScan"
 >;
 
+export type PublicBrowseVersionState =
+  | { status: "available"; versionId: Id<"skillVersions"> }
+  | { status: "unavailable" };
+
 function isPendingSkillModerationReason(reason: string | null | undefined) {
   const normalized = reason?.trim().toLowerCase();
   return (
@@ -105,15 +109,37 @@ export async function hasResolvablePublicBrowseVersion(
   return (await resolvePublicBrowseVersionForSkill(ctx, skill)) !== null;
 }
 
+export async function hasResolvablePublicBrowseVersionFromState(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  skill: SkillPublicBrowseFields & { _id: Id<"skills"> },
+  state: PublicBrowseVersionState | undefined,
+) {
+  if (shouldExcludeSkillFromPublicBrowse(skill)) return false;
+  if (state?.status === "available") return true;
+  if (state?.status === "unavailable") return false;
+  return hasResolvablePublicBrowseVersion(ctx, skill);
+}
+
+export async function resolvePublicBrowseVersionState(
+  ctx: Pick<QueryCtx | MutationCtx, "db">,
+  skill: SkillPublicBrowseFields & { _id: Id<"skills"> },
+  options?: { latestVersion: Doc<"skillVersions"> | null },
+): Promise<PublicBrowseVersionState> {
+  if (shouldExcludeSkillFromPublicBrowse(skill)) return { status: "unavailable" };
+  const version = await resolvePublicBrowseVersionForSkill(ctx, skill, options);
+  return version ? { status: "available", versionId: version._id } : { status: "unavailable" };
+}
+
 export async function resolvePublicBrowseVersionForSkill(
   ctx: Pick<QueryCtx | MutationCtx, "db">,
   skill: SkillPublicBrowseFields & { _id: Id<"skills"> },
+  options?: { latestVersion: Doc<"skillVersions"> | null },
 ): Promise<Doc<"skillVersions"> | null> {
   const latestVersionId = skill.latestVersionId;
   if (!latestVersionId) return null;
 
   if (!isSkillPendingPublicReview(skill)) {
-    const latestVersion = await ctx.db.get(latestVersionId);
+    const latestVersion = options ? options.latestVersion : await ctx.db.get(latestVersionId);
     return latestVersion &&
       latestVersion.skillId === skill._id &&
       isPubliclyListableSkillVersion(latestVersion)

--- a/convex/lib/skillSearchDigest.test.ts
+++ b/convex/lib/skillSearchDigest.test.ts
@@ -247,7 +247,11 @@ describe("extractValidatedDigestFields", () => {
     const digest = await extractValidatedDigestFields(
       {
         db: {
-          get: async () => ({ skillId: "skills:abc", softDeletedAt: undefined }),
+          get: async () => ({
+            _id: "skillVersions:v1",
+            skillId: "skills:abc",
+            softDeletedAt: undefined,
+          }),
         },
       } as never,
       makeSkillDoc() as never,
@@ -256,6 +260,10 @@ describe("extractValidatedDigestFields", () => {
     expect(digest.latestVersionId).toBe("skillVersions:v1");
     expect(digest.latestVersionSkillId).toBe("skills:abc");
     expect(digest.latestVersionSummary).toMatchObject({ version: "1.0.0" });
+    expect(digest.publicVersion).toEqual({
+      status: "available",
+      versionId: "skillVersions:v1",
+    });
   });
 
   it("clears stale latest-version metadata when the version belongs to another skill", async () => {
@@ -271,6 +279,7 @@ describe("extractValidatedDigestFields", () => {
     expect(digest.latestVersionId).toBeUndefined();
     expect(digest.latestVersionSkillId).toBeUndefined();
     expect(digest.latestVersionSummary).toBeUndefined();
+    expect(digest.publicVersion).toEqual({ status: "unavailable" });
   });
 });
 

--- a/convex/lib/skillSearchDigest.ts
+++ b/convex/lib/skillSearchDigest.ts
@@ -6,6 +6,7 @@ import {
 import type { Doc, Id } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
 import type { HydratableSkill, PublicPublisher } from "./public";
+import { type PublicBrowseVersionState, resolvePublicBrowseVersionState } from "./publicBrowse";
 import { getOwnerPublisher } from "./publishers";
 import { computeRecommendationScore, RECOMMENDATION_SCORE_VERSION } from "./recommendationScore";
 import { tokenize } from "./searchText";
@@ -71,6 +72,7 @@ export type SkillSearchDigestFields = Pick<Doc<"skills">, (typeof SHARED_KEYS)[n
   ownerImage?: string;
   recommendedScore?: number;
   recommendedScoreVersion?: number;
+  publicVersion?: PublicBrowseVersionState;
 };
 
 /** Pick the subset of fields from a full skill doc needed for the digest. */
@@ -119,15 +121,19 @@ export async function extractValidatedDigestFields(
 ): Promise<SkillSearchDigestFields> {
   const fields = extractDigestFields(skill);
   const version = skill.latestVersionId ? await ctx.db.get(skill.latestVersionId) : null;
+  const publicVersion = await resolvePublicBrowseVersionState(ctx, skill, {
+    latestVersion: version,
+  });
   if (!version || version.softDeletedAt || version.skillId !== skill._id) {
     return {
       ...fields,
       latestVersionId: undefined,
       latestVersionSkillId: undefined,
       latestVersionSummary: undefined,
+      publicVersion,
     };
   }
-  return { ...fields, latestVersionSkillId: version.skillId };
+  return { ...fields, latestVersionSkillId: version.skillId, publicVersion };
 }
 
 export function normalizeSkillSearchText(value: string) {

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -26,7 +26,10 @@ import {
   INSTALL_BACKFILL_CLEAN_WINDOW_READY_CURSOR_CREATION_TIME,
   INSTALL_BACKFILL_DEFAULTS,
 } from "./lib/skillInstallBackfill";
-import { syncSkillSearchDigestForSkill } from "./lib/skillSearchDigest";
+import {
+  extractValidatedDigestFields,
+  syncSkillSearchDigestForSkill,
+} from "./lib/skillSearchDigest";
 import { readCanonicalStat } from "./lib/skillStats";
 import { adjustUserSkillStatsForSkillChange } from "./lib/userSkillStats";
 import schema from "./schema";
@@ -478,6 +481,25 @@ export const canonicalizePackageCatalogMetadata = migrations.define({
     };
     await ctx.db.patch(pkg._id, patch);
     await syncPackageSearchDigestForPackageId(ctx, pkg._id);
+  },
+});
+
+export const backfillSkillSearchDigestPublicVersions = migrations.define({
+  table: "skillSearchDigest",
+  batchSize: 25,
+  migrateOne: async (ctx, digest) => {
+    if (digest.publicVersion !== undefined) return;
+    const skill = await ctx.db.get(digest.skillId);
+    if (!skill) {
+      await ctx.db.patch(digest._id, {
+        publicVersion: { status: "unavailable" },
+      });
+      return;
+    }
+    const fields = await extractValidatedDigestFields(ctx, skill);
+    await ctx.db.patch(digest._id, {
+      publicVersion: fields.publicVersion ?? { status: "unavailable" },
+    });
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -448,6 +448,16 @@ const moderationStatusValidator = v.optional(
   v.union(v.literal("active"), v.literal("hidden"), v.literal("removed")),
 );
 
+const publicBrowseVersionStateValidator = v.union(
+  v.object({
+    status: v.literal("available"),
+    versionId: v.id("skillVersions"),
+  }),
+  v.object({
+    status: v.literal("unavailable"),
+  }),
+);
+
 const githubSkillScanStatusValidator = v.union(
   v.literal("clean"),
   v.literal("suspicious"),
@@ -1241,6 +1251,9 @@ const skillSearchDigest = defineTable({
   forkOf: forkOfValidator,
   latestVersionId: v.optional(v.id("skillVersions")),
   latestVersionSkillId: v.optional(v.id("skills")),
+  // Missing means the rollout backfill has not reached this row. New writes
+  // always store an explicit available or unavailable public-version state.
+  publicVersion: v.optional(publicBrowseVersionStateValidator),
   installKind: v.optional(v.literal("github")),
   githubHasSkillCard: v.optional(v.boolean()),
   githubCurrentStatus: v.optional(githubSkillCurrentStatusValidator),

--- a/convex/search.test.ts
+++ b/convex/search.test.ts
@@ -754,6 +754,61 @@ describe("search helpers", () => {
     expect(ctx.takeLimits).toEqual([25, 25]);
   });
 
+  it("uses the digest public version without reading version history", async () => {
+    const pending = makeSkillDoc({
+      id: "skills:pending-update",
+      slug: "pending-update",
+      displayName: "Pending Update",
+      moderationReason: "pending.scan",
+      moderationSourceVersionId: "skillVersions:pending",
+      latestVersionId: "skillVersions:pending",
+      statsVersions: 2,
+      publicVersion: {
+        status: "available",
+        versionId: "skillVersions:approved",
+      },
+    });
+    const ctx = makeLexicalCtx({
+      exactSlugSkill: null,
+      recentSkills: [pending],
+    });
+
+    const result = await lexicalFallbackSkillsHandler(ctx, {
+      query: "pending",
+      queryTokens: ["pending"],
+      limit: 10,
+    });
+
+    expect(result.map((entry) => entry.skill.slug)).toEqual(["pending-update"]);
+    expect(ctx.db.query).not.toHaveBeenCalledWith("skillVersions");
+  });
+
+  it("fails closed from the digest without reading version history", async () => {
+    const pending = makeSkillDoc({
+      id: "skills:unavailable-update",
+      slug: "unavailable-update",
+      displayName: "Unavailable Update",
+      moderationReason: "pending.scan",
+      moderationSourceVersionId: "skillVersions:pending",
+      latestVersionId: "skillVersions:pending",
+      statsVersions: 2,
+      publicVersion: { status: "unavailable" },
+    });
+    const ctx = makeLexicalCtx({
+      exactSlugSkill: null,
+      recentSkills: [pending],
+    });
+
+    const result = await lexicalFallbackSkillsHandler(ctx, {
+      query: "unavailable",
+      queryTokens: ["unavailable"],
+      limit: 10,
+    });
+
+    expect(result).toEqual([]);
+    expect(ctx.db.query).not.toHaveBeenCalledWith("skillVersions");
+  });
+
   it("includes exact slug match from by_slug even when recent scan is empty", async () => {
     const exactSlugSkill = makeSkillDoc({ id: "skills:orf", slug: "orf", displayName: "ORF" });
     const ctx = makeLexicalCtx({
@@ -2339,24 +2394,31 @@ function makeSkillDoc(params: {
   topics?: string[];
   inferredCategories?: string[];
   inferredFromVersionId?: string;
+  latestVersionId?: string;
+  moderationSourceVersionId?: string;
+  statsVersions?: number;
+  publicVersion?: { status: "available"; versionId: string } | { status: "unavailable" };
 }) {
   return {
     ...makePublicSkill(params),
+    latestVersionId: params.latestVersionId ?? "skillVersions:1",
     stats: {
       downloads: params.downloads ?? 0,
       installsCurrent: 0,
       installsAllTime: params.installs ?? 0,
       stars: params.stars ?? 0,
-      versions: 1,
+      versions: params.statsVersions ?? 1,
       comments: 0,
     },
     _creationTime: 1,
     moderationStatus: "active",
     moderationFlags: params.moderationFlags ?? [],
     moderationReason: params.moderationReason,
+    moderationSourceVersionId: params.moderationSourceVersionId,
     softDeletedAt: params.softDeletedAt as number | undefined,
     inferredCategories: params.inferredCategories,
     inferredFromVersionId: params.inferredFromVersionId,
+    publicVersion: params.publicVersion,
   };
 }
 

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -17,7 +17,7 @@ import { hasOfficialPublisherRow, toPublicPublisherWithOfficial } from "./lib/of
 import type { HydratableSkill, PublicPublisher } from "./lib/public";
 import { toPublicSkill } from "./lib/public";
 import {
-  hasResolvablePublicBrowseVersion,
+  hasResolvablePublicBrowseVersionFromState,
   shouldExcludeSkillFromPublicBrowse,
 } from "./lib/publicBrowse";
 import { getOwnerPublisher } from "./lib/publishers";
@@ -908,7 +908,14 @@ export const hydrateResults = internalQuery({
           ? await withOfficialOwnerInfo(ctx, preResolved)
           : await getOwnerInfo(skill.ownerUserId, skill.ownerPublisherId);
         if (!resolved.owner) return null;
-        if (!(await hasResolvablePublicBrowseVersion(ctx, { ...skill, _id: skillId }))) return null;
+        if (
+          !(await hasResolvablePublicBrowseVersionFromState(
+            ctx,
+            { ...skill, _id: skillId },
+            digest?.publicVersion,
+          ))
+        )
+          return null;
         const publicSkill = toPublicSearchSkill(skill);
         if (!publicSkill) return null;
         return {
@@ -951,6 +958,7 @@ export const lexicalFallbackSkills = internalQuery({
       Id<"skills">,
       { ownerHandle: string | null; owner: PublicPublisher | null }
     >();
+    const publicVersions = new Map<Id<"skills">, Doc<"skillSearchDigest">["publicVersion"]>();
 
     // Exact slug matches via the skills table. Slugs are unique per publisher,
     // so this read must tolerate multiple rows for the same global slug.
@@ -1047,6 +1055,7 @@ export const lexicalFallbackSkills = internalQuery({
         // Pre-resolve owner from digest to avoid users table reads.
         const ownerInfo = digestToOwnerInfo(digest);
         if (ownerInfo) preResolvedOwners.set(digest.skillId, ownerInfo);
+        publicVersions.set(digest.skillId, digest.publicVersion);
       }
     };
     addDigestCandidates(recentByUpdated);
@@ -1073,7 +1082,13 @@ export const lexicalFallbackSkills = internalQuery({
           ? await withOfficialOwnerInfo(ctx, preResolved)
           : await getOwnerInfo(skill.ownerUserId, skill.ownerPublisherId);
         if (!resolved.owner) return null;
-        if (!(await hasResolvablePublicBrowseVersion(ctx, { ...skill, _id: skill._id })))
+        if (
+          !(await hasResolvablePublicBrowseVersionFromState(
+            ctx,
+            { ...skill, _id: skill._id },
+            publicVersions.get(skill._id),
+          ))
+        )
           return null;
         const publicSkill = toPublicSearchSkill(skill);
         if (!publicSkill) return null;

--- a/convex/skills.backportLatest.test.ts
+++ b/convex/skills.backportLatest.test.ts
@@ -241,10 +241,36 @@ function buildDb(
       if (table === "skillVersions") {
         return {
           withIndex: (name: string) => {
-            if (name !== "by_skill_version") {
-              throw new Error(`unexpected skillVersions index ${name}`);
+            if (name === "by_skill_version") {
+              return { unique: async () => existingVersion ?? null };
             }
-            return { unique: async () => existingVersion ?? null };
+            if (name === "by_skill_active_created") {
+              return {
+                order: () => ({
+                  take: async (limit: number) => {
+                    const insertedVersion = captured.versionInserted
+                      ? {
+                          _id: NEW_VERSION_ID,
+                          skillId: SKILL_ID,
+                          softDeletedAt: undefined,
+                          ...captured.versionInserted,
+                        }
+                      : null;
+                    const previousVersion = {
+                      _id: PREV_LATEST_VERSION_ID,
+                      skillId: SKILL_ID,
+                      softDeletedAt: undefined,
+                      version: "2.0.0",
+                      vtAnalysis: { status: "clean" },
+                      llmAnalysis: { status: "clean" },
+                      staticScan: { status: "clean" },
+                    };
+                    return [insertedVersion, previousVersion].filter(Boolean).slice(0, limit);
+                  },
+                }),
+              };
+            }
+            throw new Error(`unexpected skillVersions index ${name}`);
           },
         };
       }

--- a/convex/skills.publicListCursor.test.ts
+++ b/convex/skills.publicListCursor.test.ts
@@ -1243,6 +1243,49 @@ describe("public skill list deterministic cursors", () => {
     });
   });
 
+  it("loads the approved digest version directly for a pending update", async () => {
+    const get = vi.fn(async (id: string) =>
+      id === "skillVersions:approved"
+        ? {
+            _id: id,
+            skillId: "skills:demo",
+            version: "1.0.0",
+            createdAt: 8,
+            changelog: "approved",
+            softDeletedAt: undefined,
+          }
+        : null,
+    );
+    getPageMock.mockResolvedValueOnce({
+      page: [
+        makeSearchDigest({
+          moderationReason: "pending.scan",
+          stats: { downloads: 0, stars: 0, versions: 2, comments: 0 },
+          latestVersionId: "skillVersions:pending",
+          publicVersion: {
+            status: "available",
+            versionId: "skillVersions:approved",
+          },
+        }),
+      ],
+      hasMore: false,
+      indexKeys: [],
+    });
+
+    const result = await listPublicApiPageV1Handler({ db: { get } } as never, {
+      numItems: 10,
+      sort: "updated",
+    });
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledWith("skillVersions:approved");
+    expect(result.items[0]).toMatchObject({
+      latestVersion: {
+        version: "1.0.0",
+      },
+    });
+  });
+
   it("carries topics through the public API list projection", async () => {
     getPageMock.mockResolvedValueOnce({
       page: [

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -6001,12 +6001,18 @@ async function loadPublicLatestVersionForDigest(
     | "skillId"
     | "latestVersionId"
     | "latestVersionSkillId"
+    | "publicVersion"
     | "moderationReason"
     | "moderationFlags"
     | "stats"
     | "installKind"
   >,
 ) {
+  if (digest.publicVersion?.status === "unavailable") return null;
+  if (digest.publicVersion?.status === "available") {
+    const version = await ctx.db.get(digest.publicVersion.versionId);
+    return isPublicSkillVersionAvailableForSkill(version, digest.skillId) ? version : null;
+  }
   if (!digest.latestVersionId) return null;
   if (digest.latestVersionSkillId !== undefined && digest.latestVersionSkillId !== digest.skillId) {
     return null;
@@ -6030,13 +6036,17 @@ async function resolveDigestLatestVersionForSkill(
   ctx: Pick<QueryCtx, "db">,
   digest: Doc<"skillSearchDigest">,
 ) {
+  if (digest.publicVersion?.status === "unavailable") return null;
+  const publicVersionId =
+    digest.publicVersion?.status === "available" ? digest.publicVersion.versionId : undefined;
   const needsApprovedSnapshot =
     isHostedSkillPendingPublicReview(digest) && hostedSkillMayHavePriorApprovedVersion(digest);
 
   if (
-    !needsApprovedSnapshot &&
+    (!needsApprovedSnapshot || publicVersionId === digest.latestVersionId) &&
     digest.latestVersionSummary &&
     digest.latestVersionId &&
+    (!publicVersionId || publicVersionId === digest.latestVersionId) &&
     (digest.latestVersionSkillId === undefined || digest.latestVersionSkillId === digest.skillId)
   ) {
     return toPublicSkillListVersionFromSummary(

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -288,6 +288,12 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   hold applies. Codex malicious verdicts block the candidate version. On updates,
   the previous clean/current public version remains live; on first versions,
   nothing public is promoted.
+- `skillSearchDigest.publicVersion` is a derived public-browse cache, not a
+  moderation source of truth. `available` points to the exact approved public
+  `skillVersions` row and `unavailable` fails closed; a missing value exists only
+  during rollout/backfill and uses the legacy resolver. Skill visibility changes
+  and version scan-status changes must refresh the cache so hot browse/search
+  queries never need to walk version history.
 - Plugins under `@openclaw/*` owned by the OpenClaw publisher are trusted by
   default. They may still be audited, but scanner telemetry alone must not
   downgrade them.


### PR DESCRIPTION
## Summary
- store an explicit approved public-version pointer on `skillSearchDigest`
- consume the pointer in hot search and public-list paths instead of scanning version history
- refresh the pointer on skill visibility and version scan-status changes
- add a component migration with rollout fallback for existing digest rows

## Validation
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bun run ci:packages`
- `GITHUB_TOKEN="$(gh auth token)" bun run ci:e2e-http`
- `bunx convex dev --once --typecheck=disable`
- local migration dry run and full apply: 1,006 rows, 0 missing afterward
- `.agents/skills/autoreview/scripts/autoreview --mode local`
