### PR TITLE
fix: keep scan workers refilling after hydration skips

### DIFF
--- a/scripts/security/run-codex-scan-worker.test.ts
+++ b/scripts/security/run-codex-scan-worker.test.ts
@@ -67,7 +67,10 @@ describe("run-codex-scan-worker diagnostics", () => {
       releaseSlowJob = resolve;
     });
     const jobs = ["slow", "fast", "next"];
-    const claimJobs = vi.fn(async (limit: number) => jobs.splice(0, limit).map((id) => ({ id })));
+    const claimJobs = vi.fn(async (limit: number) => {
+      const claimedJobs = jobs.splice(0, limit).map((id) => ({ id }));
+      return { claimedCount: claimedJobs.length, jobs: claimedJobs };
+    });
     const processClaimedJob = vi.fn(async (job: { id: string }) => {
       started.push(job.id);
       if (job.id === "slow") await slowJob;
@@ -96,6 +99,38 @@ describe("run-codex-scan-worker diagnostics", () => {
       totalClaimFailures: 0,
     });
     expect(claimJobs.mock.calls.map(([limit]) => limit)).toEqual([2, 1, 1]);
+  });
+
+  it("keeps refilling after a full lease batch has no hydratable jobs", async () => {
+    const claimJobs = vi
+      .fn()
+      .mockResolvedValueOnce({ claimedCount: 2, jobs: [] })
+      .mockResolvedValueOnce({
+        claimedCount: 2,
+        jobs: [{ id: "next-1" }, { id: "next-2" }],
+      })
+      .mockResolvedValue({ claimedCount: 0, jobs: [] });
+    const processClaimedJob = vi.fn(async () => ({
+      completed: true,
+      hardFailed: false,
+      retryableFailed: false,
+    }));
+
+    await expect(
+      runContinuouslyRefilledWorkerPool({
+        concurrency: 2,
+        maxJobs: undefined,
+        canClaim: () => true,
+        claimJobs,
+        processClaimedJob,
+      }),
+    ).resolves.toMatchObject({
+      totalClaimed: 4,
+      totalCompleted: 2,
+      totalClaimFailures: 0,
+    });
+    expect(claimJobs.mock.calls.map(([limit]) => limit)).toEqual([2, 2, 1]);
+    expect(processClaimedJob).toHaveBeenCalledTimes(2);
   });
 
   it("counts one failed batch lease request without multiplying it by slot count", async () => {
@@ -130,7 +165,10 @@ describe("run-codex-scan-worker diagnostics", () => {
         concurrency: 4,
         maxJobs: undefined,
         canClaim: () => canClaim,
-        claimJobs: vi.fn(async () => [{ id: "publish" }]),
+        claimJobs: vi.fn(async () => ({
+          claimedCount: 1,
+          jobs: [{ id: "publish" }],
+        })),
         processClaimedJob: vi.fn(async () => ({
           completed: true,
           hardFailed: false,
@@ -154,7 +192,10 @@ describe("run-codex-scan-worker diagnostics", () => {
         concurrency: 4,
         maxJobs: 1,
         canClaim: () => true,
-        claimJobs: vi.fn(async () => [{ id: "publish" }]),
+        claimJobs: vi.fn(async () => ({
+          claimedCount: 1,
+          jobs: [{ id: "publish" }],
+        })),
         processClaimedJob: vi.fn(async () => ({
           completed: true,
           hardFailed: false,

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -1584,7 +1584,7 @@ export async function runContinuouslyRefilledWorkerPool<TJob>(options: {
   concurrency: number;
   maxJobs: number | undefined;
   canClaim: (totalClaimed: number) => boolean;
-  claimJobs: (limit: number) => Promise<TJob[]>;
+  claimJobs: (limit: number) => Promise<{ claimedCount: number; jobs: TJob[] }>;
   processClaimedJob: (job: TJob) => Promise<ProcessJobResult>;
   idlePollMs?: number;
   sleep?: (ms: number) => Promise<unknown>;
@@ -1612,9 +1612,10 @@ export async function runContinuouslyRefilledWorkerPool<TJob>(options: {
         break;
       }
 
+      let claimedCount: number;
       let jobs: TJob[];
       try {
-        jobs = await options.claimJobs(remainingJobs);
+        ({ claimedCount, jobs } = await options.claimJobs(remainingJobs));
       } catch (error) {
         totalClaimFailures += 1;
         totalFailed += 1;
@@ -1632,11 +1633,10 @@ export async function runContinuouslyRefilledWorkerPool<TJob>(options: {
         break;
       }
 
-      if (jobs.length === 0) {
+      totalClaimed += claimedCount;
+      if (claimedCount < remainingJobs) {
         queueDrained = true;
-        break;
       }
-      totalClaimed += jobs.length;
       for (const job of jobs) {
         const task = options.processClaimedJob(job).catch((error) => {
           const message = error instanceof Error ? error.message : String(error);
@@ -1656,7 +1656,7 @@ export async function runContinuouslyRefilledWorkerPool<TJob>(options: {
         });
         active.add(task);
       }
-      if (jobs.length < remainingJobs) queueDrained = true;
+      if (jobs.length === 0 && queueDrained) break;
     }
 
     if (active.size > 0) {
@@ -1767,9 +1767,6 @@ async function main() {
         .map((outcome) => outcome.job)
         .filter((job): job is ClaimedJob => job !== null);
       const requeued = hydrated.filter((outcome) => outcome.requeued).length;
-      if (requeued > 0 && jobs.length === 0) {
-        throw new Error("All claimed security scan jobs failed hydration and were requeued");
-      }
       logger.info(
         {
           claimed: leases.length,
@@ -1783,7 +1780,7 @@ async function main() {
         },
         "claimed security scan jobs",
       );
-      return jobs;
+      return { claimedCount: leases.length, jobs };
     },
     processClaimedJob: (job) => processJob(client, token, job, diagnosticsRoot),
     idlePollMs: lane === "priority" ? 15_000 : undefined,


### PR DESCRIPTION
## Summary

- Track claimed lease count separately from hydratable jobs in the continuously refilled worker pool.
- Keep shared shards claiming when a full lease batch contains stale or temporarily unhydratable jobs.
- Preserve genuine queue-drained behavior when Convex returns fewer leases than requested.
- Add a regression for a full lease batch with zero hydratable jobs.

## Production evidence

The first shadow-disabled production wave reached roughly 718 completions/hour, but one shared shard exited after logging `claimed: 1, hydrated: 0` despite more than 3,000 claimable jobs. The old pool compared hydrated jobs to requested capacity, so stale missing-artifact rows falsely marked the whole lane drained.

## Validation

- `bunx vitest run scripts/security/run-codex-scan-worker.test.ts` (31 passed)
- `bun run ci:static`
- `bun run ci:unit` (350 files passed, 1 skipped; 4524 tests passed, 1 skipped)
- `bun run ci:types-build`
- `$autoreview` clean after addressing one accepted finding
