### PR TITLE
perf: raise security scan worker fanout

### DIFF
--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -36,7 +36,7 @@ jobs:
     environment: Production
     strategy:
       fail-fast: false
-      max-parallel: 6
+      max-parallel: 8
       matrix:
         include:
           - lane: priority
@@ -51,6 +51,10 @@ jobs:
             shard: shared-3
           - lane: shared
             shard: shared-4
+          - lane: shared
+            shard: shared-5
+          - lane: shared
+            shard: shared-6
     env:
       CONVEX_URL: ${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}
       CODEX_SECURITY_SCAN_LIMIT: ${{ github.event.client_payload.batch_limit || inputs.limit || inputs['batch-limit'] || '4' }}

--- a/scripts/security/security-scan-worker-workflow.test.ts
+++ b/scripts/security/security-scan-worker-workflow.test.ts
@@ -75,7 +75,7 @@ describe("security-scan-codex workflow", () => {
     expect(workflow.on?.workflow_dispatch).toBeDefined();
     expect(workflow.on?.repository_dispatch?.types).toEqual(["clawhub-security-scan"]);
     expect(workflow.on?.schedule).toBeUndefined();
-    expect(workflow.jobs["codex-security-scan"].strategy?.["max-parallel"]).toBe(6);
+    expect(workflow.jobs["codex-security-scan"].strategy?.["max-parallel"]).toBe(8);
     expect(workflow.jobs["codex-security-scan"].strategy?.matrix?.include).toEqual([
       { lane: "priority", shard: "priority-0" },
       { lane: "shared", shard: "shared-0" },
@@ -83,6 +83,8 @@ describe("security-scan-codex workflow", () => {
       { lane: "shared", shard: "shared-2" },
       { lane: "shared", shard: "shared-3" },
       { lane: "shared", shard: "shared-4" },
+      { lane: "shared", shard: "shared-5" },
+      { lane: "shared", shard: "shared-6" },
     ]);
     expect(jobEnv.CODEX_SECURITY_SCAN_LANE).toBe("${{ matrix.lane }}");
     expect(jobEnv.CODEX_SECURITY_SCAN_LIMIT).toBe(


### PR DESCRIPTION
## Summary

- increase the security scan workflow from 6 to 8 parallel shards
- preserve one priority shard for publish work and add two low-priority shared shards
- update the workflow contract test for the 8-shard matrix

## Why

The stable 2x baseline has produced 792-1,044 completions/hour in full 15-minute windows, while the 5x target is 870/hour. The current six-shard pool reaches roughly 900/hour while fully active but loses sustained throughput to wave boundaries and transient runner loss. Two additional shared shards provide the next conservative ramp stage without changing batch size, queue priority, leases, or dispatch semantics.

## Validation

- `bunx vitest run scripts/security/security-scan-worker-workflow.test.ts`
- `bun run ci:static`
- `bun run ci:unit` (4,548 passed, 1 skipped)
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean)

## Rollout gate

Do not merge until the current six-shard production campaign completes a clean runner-stability check. After merge, require two consecutive 15-minute windows at or above 870 completions/hour with the existing failure and publish-priority guardrails.
