### PR TITLE
chore: remove completed public version backfill

### DIFF
--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -26,10 +26,7 @@ import {
   INSTALL_BACKFILL_CLEAN_WINDOW_READY_CURSOR_CREATION_TIME,
   INSTALL_BACKFILL_DEFAULTS,
 } from "./lib/skillInstallBackfill";
-import {
-  extractValidatedDigestFields,
-  syncSkillSearchDigestForSkill,
-} from "./lib/skillSearchDigest";
+import { syncSkillSearchDigestForSkill } from "./lib/skillSearchDigest";
 import { readCanonicalStat } from "./lib/skillStats";
 import { adjustUserSkillStatsForSkillChange } from "./lib/userSkillStats";
 import schema from "./schema";
@@ -481,25 +478,6 @@ export const canonicalizePackageCatalogMetadata = migrations.define({
     };
     await ctx.db.patch(pkg._id, patch);
     await syncPackageSearchDigestForPackageId(ctx, pkg._id);
-  },
-});
-
-export const backfillSkillSearchDigestPublicVersions = migrations.define({
-  table: "skillSearchDigest",
-  batchSize: 25,
-  migrateOne: async (ctx, digest) => {
-    if (digest.publicVersion !== undefined) return;
-    const skill = await ctx.db.get(digest.skillId);
-    if (!skill) {
-      await ctx.db.patch(digest._id, {
-        publicVersion: { status: "unavailable" },
-      });
-      return;
-    }
-    const fields = await extractValidatedDigestFields(ctx, skill);
-    await ctx.db.patch(digest._id, {
-      publicVersion: fields.publicVersion ?? { status: "unavailable" },
-    });
   },
 });
 


### PR DESCRIPTION
## Summary
- remove the completed `backfillSkillSearchDigestPublicVersions` migration
- keep the durable `publicVersion` schema, write synchronization, and search/read behavior unchanged

## Production migration proof
- deployment: `wry-manatee-359`
- processed: `92,800` rows
- final state: `success`, `isDone: true`, cursor cleared
- newest 10,000 digest rows after apply: `0` missing `publicVersion` pointers
- post-backfill observation: 28,377 lexical fallback executions with 0 bytes-read-limit failures

## Validation
- `bunx convex dev --once` (local `anonymous:anonymous-clawhub`)
- `bun run ci:static`
- `bun run ci:unit` (4,548 passed, 1 skipped)
- `bun run ci:types-build`
- `bun run ci:packages`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean)
