### PR TITLE
feat: automate Test environment deployments

### DIFF
--- a/.agents/skills/clawhub-production-release/SKILL.md
+++ b/.agents/skills/clawhub-production-release/SKILL.md
@@ -12,6 +12,9 @@ the app or publish the CLI.
 
 - Run production workflows from `main`.
 - Re-read the workflow and exact `main` SHA immediately before dispatch.
+- Require a successful `Deploy Test` workflow for that exact SHA before
+  dispatching an app production deploy. This is an operator check until the
+  production workflow enforces the gate directly.
 - Do not treat a green workflow alone as proof. Record the workflow URL, exact
   deployed SHA, and live-surface verification.
 - Do not add one-off migrations or repairs to the deploy workflow. Run
@@ -25,8 +28,23 @@ the app or publish the CLI.
 The workflow is `.github/workflows/deploy.yml`.
 
 1. Confirm the selected commit is on `origin/main` and record its SHA.
-2. Run the required pre-merge or release validation for the changed surface.
-3. Dispatch one target:
+2. Find the successful Test deployment for that exact SHA and record its URL:
+
+```bash
+gh run list \
+  --repo openclaw/clawhub \
+  --workflow deploy-test.yml \
+  --branch main \
+  --commit <MAIN_SHA> \
+  --status success \
+  --limit 1
+```
+
+If no successful exact-SHA Test run exists, stop and fix or rerun Test before
+releasing production.
+
+3. Run the required pre-merge or release validation for the changed surface.
+4. Dispatch one target:
 
 ```bash
 gh workflow run deploy.yml \
@@ -48,11 +66,12 @@ Choose `full`, `backend`, or `frontend`:
 Set `allow_deleting_large_indexes=true` only after reviewing the Convex index
 deletion and explicitly accepting it.
 
-4. Capture the workflow run URL and wait for completion.
-5. Verify the run used the expected SHA.
-6. Verify the affected live route, API, or backend contract on
+5. Capture the workflow run URL and wait for completion.
+6. Verify the run used the expected SHA.
+7. Verify the affected live route, API, or backend contract on
    `https://clawhub.ai`.
-7. Report the workflow URL, deployed SHA, target, and live proof.
+8. Report the Test workflow URL, production workflow URL, deployed SHA, target,
+   and live proof.
 
 The workflow uses the GitHub `Production` environment. Backend deploys require
 the environment secret `CONVEX_DEPLOY_KEY`. The optional

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -1,0 +1,231 @@
+name: Deploy Test
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-test
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-test:
+    if: >-
+      (github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main') ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push')
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment:
+      name: Test
+      url: ${{ vars.SITE_URL }}
+    outputs:
+      deployment_url: ${{ steps.vercel.outputs.deployment_url }}
+      deploy_sha: ${{ steps.revision.outputs.deploy_sha }}
+      fixture_version: ${{ steps.revision.outputs.fixture_version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
+
+      - name: Resolve deployment revision
+        id: revision
+        run: |
+          set -euo pipefail
+          deploy_sha="$(git rev-parse HEAD)"
+          git fetch --no-tags origin main
+          main_sha="$(git rev-parse origin/main)"
+          if [[ "$deploy_sha" != "$main_sha" ]]; then
+            echo "::error::Refusing stale Test deploy: $deploy_sha is not current main $main_sha"
+            exit 1
+          fi
+          fixture_version="$(
+            git hash-object convex/devSeed.ts convex/lib/testSeed.ts |
+              sha256sum |
+              cut -c1-12
+          )"
+          echo "deploy_sha=$deploy_sha" >> "$GITHUB_OUTPUT"
+          echo "fixture_version=$fixture_version" >> "$GITHUB_OUTPUT"
+
+      - name: Check Test configuration
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+          VERCEL_SCOPE: ${{ vars.VERCEL_SCOPE }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          TEST_SITE_URL: ${{ vars.SITE_URL }}
+          VITE_CONVEX_SITE_URL: ${{ vars.VITE_CONVEX_SITE_URL }}
+          VITE_CONVEX_URL: ${{ vars.VITE_CONVEX_URL }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in \
+            CONVEX_DEPLOY_KEY \
+            VERCEL_AUTOMATION_BYPASS_SECRET \
+            VERCEL_ORG_ID \
+            VERCEL_PROJECT_ID \
+            VERCEL_SCOPE \
+            VERCEL_TOKEN \
+            TEST_SITE_URL \
+            VITE_CONVEX_SITE_URL \
+            VITE_CONVEX_URL
+          do
+            if [[ -z "${!name}" ]]; then
+              missing+=("$name")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            echo "::error::Missing Test environment configuration: ${missing[*]}"
+            exit 1
+          fi
+          if [[ "$CONVEX_DEPLOY_KEY" != prod:academic-chihuahua-392\|* ]]; then
+            echo "::error::CONVEX_DEPLOY_KEY must target academic-chihuahua-392"
+            exit 1
+          fi
+
+      - uses: ./.github/actions/setup-bun
+
+      - name: Stamp Convex build SHA
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+        run: bunx convex env set APP_BUILD_SHA "${{ steps.revision.outputs.deploy_sha }}" --prod
+
+      - name: Stamp Convex deploy time
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+        run: bunx convex env set APP_DEPLOYED_AT "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" --prod
+
+      - name: Deploy Convex Test
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+        run: bun run convex:deploy
+
+      - name: Verify Convex contract
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+        run: bun run verify:convex-contract -- --prod
+
+      - name: Apply additive Test fixtures
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+          CONVEX_DEPLOYMENT: ${{ vars.CONVEX_DEPLOYMENT }}
+        run: bun run seed:test
+
+      - name: Deploy unpromoted Vercel Test candidate
+        id: vercel
+        env:
+          TEST_SITE_URL: ${{ vars.SITE_URL }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+          VERCEL_SCOPE: ${{ vars.VERCEL_SCOPE }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VITE_CONVEX_SITE_URL: ${{ vars.VITE_CONVEX_SITE_URL }}
+          VITE_CONVEX_URL: ${{ vars.VITE_CONVEX_URL }}
+        run: |
+          set -euo pipefail
+          deployment_json="$(
+            bunx --bun vercel@50.44.0 deploy \
+              --target=preview \
+              --yes \
+              --scope "$VERCEL_SCOPE" \
+              --token "$VERCEL_TOKEN" \
+              --meta githubSha="${{ steps.revision.outputs.deploy_sha }}" \
+              --meta clawhubEnvironment=test \
+              --build-env CONVEX_DEPLOY_KEY= \
+              --build-env VERCEL_ENV=test \
+              --build-env VERCEL_TARGET_ENV=test \
+              --build-env CLAWHUB_ENV=test \
+              --build-env SITE_URL="$TEST_SITE_URL" \
+              --build-env VITE_CLAWHUB_DEPLOY_ENV=test \
+              --build-env VITE_CONVEX_URL="$VITE_CONVEX_URL" \
+              --build-env VITE_CONVEX_SITE_URL="$VITE_CONVEX_SITE_URL" \
+              --build-env VITE_SITE_URL="$TEST_SITE_URL" \
+              --env CONVEX_DEPLOY_KEY= \
+              --env CLAWHUB_ENV=test \
+              --env SITE_URL="$TEST_SITE_URL" \
+              --env VITE_CLAWHUB_DEPLOY_ENV=test \
+              --env VITE_CONVEX_URL="$VITE_CONVEX_URL" \
+              --env VITE_CONVEX_SITE_URL="$VITE_CONVEX_SITE_URL" \
+              --env VITE_SITE_URL="$TEST_SITE_URL" \
+              --format=json
+          )"
+          deployment_url="$(jq -r '.url // .deployment.url // empty' <<< "$deployment_json")"
+          if [[ -z "$deployment_url" ]]; then
+            echo "::error::Vercel did not return a candidate deployment URL"
+            exit 1
+          fi
+          if [[ "$deployment_url" != http* ]]; then
+            deployment_url="https://$deployment_url"
+          fi
+          echo "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"
+
+      - name: Install Playwright browser
+        run: bunx playwright install --with-deps chromium
+
+      - name: Smoke Test candidate HTTP
+        env:
+          CLAWHUB_E2E_CANONICAL_SITE: ${{ vars.SITE_URL }}
+          CLAWHUB_E2E_EXPECT_TEST_BACKEND: academic-chihuahua-392
+          CLAWHUB_E2E_SITE: ${{ steps.vercel.outputs.deployment_url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+        run: bun run test:e2e:prod-http
+
+      - name: Smoke Test candidate UI
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ steps.vercel.outputs.deployment_url }}
+          PLAYWRIGHT_WORKERS: "1"
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+        run: bunx playwright test --project=chromium e2e/ci-smoke.pw.test.ts
+
+      - name: Assign stable Test alias
+        env:
+          TEST_SITE_URL: ${{ vars.SITE_URL }}
+          VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
+          VERCEL_SCOPE: ${{ vars.VERCEL_SCOPE }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+          alias="${TEST_SITE_URL#https://}"
+          bunx --bun vercel@50.44.0 alias set \
+            "${{ steps.vercel.outputs.deployment_url }}" \
+            "$alias" \
+            --scope "$VERCEL_SCOPE" \
+            --token "$VERCEL_TOKEN"
+
+      - name: Verify stable Test URL
+        env:
+          CLAWHUB_E2E_CANONICAL_SITE: ${{ vars.SITE_URL }}
+          CLAWHUB_E2E_EXPECT_TEST_BACKEND: academic-chihuahua-392
+          CLAWHUB_E2E_SITE: ${{ vars.SITE_URL }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+        run: bun run test:e2e:prod-http
+
+      - name: Write deployment summary
+        if: always()
+        env:
+          CANDIDATE_URL: ${{ steps.vercel.outputs.deployment_url }}
+          DEPLOY_SHA: ${{ steps.revision.outputs.deploy_sha }}
+          FIXTURE_VERSION: ${{ steps.revision.outputs.fixture_version }}
+          STABLE_URL: ${{ vars.SITE_URL }}
+        run: |
+          {
+            echo "## ClawHub Test deployment"
+            echo
+            echo "- Git SHA: \`${DEPLOY_SHA:-unresolved}\`"
+            echo "- Convex deployment: \`academic-chihuahua-392\`"
+            echo "- Vercel candidate: ${CANDIDATE_URL:-not created}"
+            echo "- Stable Test URL: ${STABLE_URL:-not configured}"
+            echo "- Fixture version: \`${FIXTURE_VERSION:-unresolved}\`"
+            echo "- Result: \`${{ job.status }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -189,6 +189,7 @@ jobs:
 
       - name: Assign stable Test alias
         env:
+          DEPLOYMENT_URL: ${{ steps.vercel.outputs.deployment_url }}
           TEST_SITE_URL: ${{ vars.SITE_URL }}
           VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
@@ -198,7 +199,7 @@ jobs:
           set -euo pipefail
           alias="${TEST_SITE_URL#https://}"
           bunx --bun vercel@50.44.0 alias set \
-            "${{ steps.vercel.outputs.deployment_url }}" \
+            "$DEPLOYMENT_URL" \
             "$alias" \
             --scope "$VERCEL_SCOPE" \
             --token "$VERCEL_TOKEN"

--- a/e2e/ci-smoke.pw.test.ts
+++ b/e2e/ci-smoke.pw.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { stubExternalMediaInVitePreview } from "./helpers/externalMedia";
 import { expectHealthyPage, trackRuntimeErrors } from "./helpers/runtimeErrors";
+import { routeVercelProtectionBypass } from "./helpers/vercelProtection";
 
 test("public navigation routes render without runtime errors", async ({ browser }) => {
   const routes = [
@@ -10,6 +11,7 @@ test("public navigation routes render without runtime errors", async ({ browser 
 
   for (const route of routes) {
     const page = await browser.newPage();
+    await routeVercelProtectionBypass(page);
     await stubExternalMediaInVitePreview(page);
     const errors = trackRuntimeErrors(page);
 
@@ -21,6 +23,7 @@ test("public navigation routes render without runtime errors", async ({ browser 
 });
 
 test("signed-out publish entry renders", async ({ page }) => {
+  await routeVercelProtectionBypass(page);
   await stubExternalMediaInVitePreview(page);
   const errors = trackRuntimeErrors(page);
 

--- a/e2e/helpers/runtimeErrors.ts
+++ b/e2e/helpers/runtimeErrors.ts
@@ -5,6 +5,7 @@ const EXTERNAL_RESOURCE_DNS_ERROR = "Failed to load resource: net::ERR_NAME_NOT_
 const TRANSIENT_CHROMIUM_RESOURCE_ERRORS = new Set([
   "Failed to load resource: net::ERR_NETWORK_CHANGED",
 ]);
+const VERCEL_TOOLBAR_SCRIPT_URL = "https://vercel.live/_next-live/feedback/feedback.js";
 
 function isIgnoredExternalResourceDnsError(message: ConsoleMessage) {
   if (message.text() !== EXTERNAL_RESOURCE_DNS_ERROR) return false;
@@ -13,6 +14,15 @@ function isIgnoredExternalResourceDnsError(message: ConsoleMessage) {
 
 function isIgnoredTransientResourceError(message: ConsoleMessage) {
   return TRANSIENT_CHROMIUM_RESOURCE_ERRORS.has(message.text());
+}
+
+function isIgnoredVercelToolbarCspError(message: ConsoleMessage) {
+  const text = message.text();
+  return (
+    Boolean(process.env.VERCEL_AUTOMATION_BYPASS_SECRET?.trim()) &&
+    text.includes(`Loading the script '${VERCEL_TOOLBAR_SCRIPT_URL}' violates`) &&
+    text.includes("Content Security Policy")
+  );
 }
 
 export function trackRuntimeErrors(page: Page) {
@@ -26,6 +36,7 @@ export function trackRuntimeErrors(page: Page) {
     if (message.type() !== "error") return;
     if (isIgnoredExternalResourceDnsError(message)) return;
     if (isIgnoredTransientResourceError(message)) return;
+    if (isIgnoredVercelToolbarCspError(message)) return;
     errors.push(`console:${message.text()}`);
   });
 

--- a/e2e/helpers/vercelProtection.ts
+++ b/e2e/helpers/vercelProtection.ts
@@ -1,0 +1,17 @@
+import type { Page } from "@playwright/test";
+
+export async function routeVercelProtectionBypass(page: Page) {
+  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET?.trim();
+  const baseURL = process.env.PLAYWRIGHT_BASE_URL?.trim();
+  if (!bypassSecret || !baseURL) return;
+
+  const origin = new URL(baseURL).origin;
+  await page.route(`${origin}/**`, async (route) => {
+    await route.continue({
+      headers: {
+        ...route.request().headers(),
+        "x-vercel-protection-bypass": bypassSecret,
+      },
+    });
+  });
+}

--- a/e2e/prod-http-smoke.e2e.test.ts
+++ b/e2e/prod-http-smoke.e2e.test.ts
@@ -25,12 +25,25 @@ function getSiteBase() {
   );
 }
 
+function getCanonicalSiteBase() {
+  return process.env.CLAWHUB_E2E_CANONICAL_SITE?.trim() || getSiteBase();
+}
+
 function getSkillSlug() {
   return process.env.CLAWHUB_E2E_SKILL_SLUG?.trim() || "gifgrep";
 }
 
 function getSkillOwner() {
   return process.env.CLAWHUB_E2E_SKILL_OWNER?.trim() || "steipete";
+}
+
+function withDeploymentProtection(init?: RequestInit): RequestInit {
+  const headers = new Headers(init?.headers);
+  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET?.trim();
+  if (bypassSecret) {
+    headers.set("x-vercel-protection-bypass", bypassSecret);
+  }
+  return { ...init, headers };
 }
 
 async function fetchWithTimeout(
@@ -41,7 +54,10 @@ async function fetchWithTimeout(
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(new Error("Timeout")), timeoutMs);
   try {
-    return await fetch(input, { ...init, signal: controller.signal });
+    return await fetch(input, {
+      ...withDeploymentProtection(init),
+      signal: controller.signal,
+    });
   } finally {
     clearTimeout(timeout);
   }
@@ -140,6 +156,10 @@ async function fetchSkillDetail() {
         },
       );
       expect(response.ok).toBe(true);
+      const expectedTestBackend = process.env.CLAWHUB_E2E_EXPECT_TEST_BACKEND?.trim();
+      if (expectedTestBackend) {
+        expect(response.headers.get("x-clawhub-test-backend")).toBe(expectedTestBackend);
+      }
       return (await response.json()) as SkillDetailResponse;
     })();
   }
@@ -166,7 +186,7 @@ describe("prod http smoke", () => {
     expectLinkWithRelAndHref(
       html,
       "canonical",
-      `${getSiteBase()}/${owner}/skills/${detail.skill.slug}`,
+      `${getCanonicalSiteBase()}/${owner}/skills/${detail.skill.slug}`,
     );
     if (detail.skill.summary) {
       expect(html).toContain(detail.skill.summary);
@@ -196,5 +216,18 @@ describe("prod http smoke", () => {
     if (detail.latestVersion?.version) {
       expect(response.headers.get("cache-control")).toContain("immutable");
     }
+  });
+
+  it("serves the published SKILL.md file", async () => {
+    const detail = await fetchSkillDetail();
+    const response = await fetchWithRetry(
+      new URL(`/api/v1/skills/${detail.skill.slug}/file?path=SKILL.md`, getSiteBase()),
+      {
+        headers: { Accept: "text/plain" },
+      },
+    );
+
+    expect(response.ok).toBe(true);
+    expect((await response.text()).trim().length).toBeGreaterThan(0);
   });
 });

--- a/scripts/seed-test.test.ts
+++ b/scripts/seed-test.test.ts
@@ -33,6 +33,30 @@ describe("seed:test", () => {
     ]);
   });
 
+  it("uses a deployment-scoped CI key without combining auth target formats", () => {
+    expect(
+      buildSeedTestCommands(
+        CLAWHUB_TEST_DEPLOYMENT,
+        `prod:${CLAWHUB_TEST_DEPLOYMENT}|deployment-key`,
+      ),
+    ).toEqual([
+      {
+        command: "bunx",
+        args: ["convex", "run", "--no-push", "devSeed:seedTestFixtures"],
+      },
+      {
+        command: "bunx",
+        args: ["convex", "run", "--no-push", "statsMaintenance:updateGlobalStatsAction"],
+      },
+    ]);
+  });
+
+  it("rejects a deploy key for any other deployment", () => {
+    expect(() =>
+      buildSeedTestCommands(CLAWHUB_TEST_DEPLOYMENT, "prod:wry-manatee-359|deployment-key"),
+    ).toThrow(`seed:test deploy key must target ${CLAWHUB_TEST_DEPLOYMENT}`);
+  });
+
   it("rejects every other deployment", () => {
     expect(() => buildSeedTestCommands("wry-manatee-359")).toThrow(
       `seed:test may only target ${CLAWHUB_TEST_DEPLOYMENT}`,

--- a/scripts/seed-test.ts
+++ b/scripts/seed-test.ts
@@ -25,9 +25,15 @@ export function assertSeedTestTarget(deployment: string) {
   }
 }
 
-export function buildSeedTestCommands(deployment: string) {
+export function buildSeedTestCommands(deployment: string, deployKey?: string) {
   assertSeedTestTarget(deployment);
-  const target = ["convex", "run", "--deployment", deployment, "--no-push"];
+  const expectedDeployKeyPrefix = `prod:${deployment}|`;
+  if (deployKey && !deployKey.startsWith(expectedDeployKeyPrefix)) {
+    throw new Error(`seed:test deploy key must target ${deployment}`);
+  }
+  const target = deployKey
+    ? ["convex", "run", "--no-push"]
+    : ["convex", "run", "--deployment", deployment, "--no-push"];
   return [
     {
       command: "bunx",
@@ -42,7 +48,7 @@ export function buildSeedTestCommands(deployment: string) {
 
 async function main() {
   const options = parseSeedTestArgs(process.argv.slice(2));
-  for (const step of buildSeedTestCommands(options.deployment)) {
+  for (const step of buildSeedTestCommands(options.deployment, process.env.CONVEX_DEPLOY_KEY)) {
     const result = spawnSync(step.command, step.args, {
       cwd: process.cwd(),
       env: process.env,

--- a/server/convexProxy.test.ts
+++ b/server/convexProxy.test.ts
@@ -92,6 +92,23 @@ describe("Convex HTTP proxy", () => {
     expect(response.headers.get("X-ClawHub-Preview-Backend")).toBe("preview-branch-123");
   });
 
+  it("exposes the permanent Test backend name for deployment proof", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ ok: true }))),
+    );
+    const event = mockEvent("https://test.example/api/v1/skills/demo");
+
+    const response = await proxyConvexRequest(event, {
+      VERCEL_TARGET_ENV: "preview",
+      VITE_CLAWHUB_DEPLOY_ENV: "test",
+      VITE_CONVEX_URL: "https://academic-chihuahua-392.convex.cloud",
+    });
+
+    expect(response.headers.get("X-ClawHub-Test-Backend")).toBe("academic-chihuahua-392");
+    expect(response.headers.get("X-ClawHub-Preview-Backend")).toBeNull();
+  });
+
   it("rejects preview writes without contacting Convex", async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);

--- a/server/convexProxy.ts
+++ b/server/convexProxy.ts
@@ -34,8 +34,14 @@ export function resolveConvexProxyEnv(
 
 function isPreviewFrontend(env: ProxyEnv) {
   const targetEnvironment =
-    env.VERCEL_TARGET_ENV?.trim() || env.VITE_CLAWHUB_DEPLOY_ENV?.trim() || env.VERCEL_ENV?.trim();
+    env.VITE_CLAWHUB_DEPLOY_ENV?.trim() || env.VERCEL_TARGET_ENV?.trim() || env.VERCEL_ENV?.trim();
   return targetEnvironment === "preview";
+}
+
+function isTestFrontend(env: ProxyEnv) {
+  const targetEnvironment =
+    env.VITE_CLAWHUB_DEPLOY_ENV?.trim() || env.VERCEL_TARGET_ENV?.trim() || env.VERCEL_ENV?.trim();
+  return targetEnvironment === "test";
 }
 
 export function isConvexProxyMethodAllowed(method: string, env: ProxyEnv) {
@@ -78,9 +84,14 @@ export async function proxyConvexRequest(
     statusText: proxied.statusText,
     headers: proxied.headers,
   });
-  if (isPreviewFrontend(env)) {
+  if (isPreviewFrontend(env) || isTestFrontend(env)) {
     const deployment = convexDeploymentName(target);
-    if (deployment) response.headers.set("X-ClawHub-Preview-Backend", deployment);
+    if (deployment) {
+      response.headers.set(
+        isTestFrontend(env) ? "X-ClawHub-Test-Backend" : "X-ClawHub-Preview-Backend",
+        deployment,
+      );
+    }
   }
   return response;
 }

--- a/src/__tests__/deploy-test-workflow.test.ts
+++ b/src/__tests__/deploy-test-workflow.test.ts
@@ -1,0 +1,118 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+
+type WorkflowStep = {
+  env?: Record<string, string>;
+  id?: string;
+  if?: string;
+  name?: string;
+  run?: string;
+};
+
+type WorkflowJob = {
+  environment?: { name?: string; url?: string };
+  if?: string;
+  steps?: WorkflowStep[];
+};
+
+async function readWorkflow() {
+  return parseYaml(await readFile(".github/workflows/deploy-test.yml", "utf8")) as {
+    concurrency?: {
+      group?: string;
+      "cancel-in-progress"?: boolean;
+    };
+    jobs?: Record<string, WorkflowJob>;
+    on?: {
+      workflow_dispatch?: unknown;
+      workflow_run?: {
+        branches?: string[];
+        types?: string[];
+        workflows?: string[];
+      };
+    };
+    permissions?: Record<string, string>;
+  };
+}
+
+describe("Test deploy workflow", () => {
+  it("runs only after successful main CI or a manual dispatch", async () => {
+    const workflow = await readWorkflow();
+    const job = workflow.jobs?.["deploy-test"];
+    const steps = job?.steps ?? [];
+
+    expect(workflow.on?.workflow_run).toEqual({
+      workflows: ["CI"],
+      types: ["completed"],
+      branches: ["main"],
+    });
+    expect(workflow.on?.workflow_dispatch).toBeDefined();
+    expect(workflow.concurrency).toEqual({
+      group: "deploy-test",
+      "cancel-in-progress": false,
+    });
+    expect(job?.if).toContain("github.event.workflow_run.conclusion == 'success'");
+    expect(job?.if).toContain("github.event.workflow_run.event == 'push'");
+    expect(job?.if).toContain("github.ref == 'refs/heads/main'");
+    expect(steps.find((step) => step.name === "Resolve deployment revision")?.run).toContain(
+      'deploy_sha" != "$main_sha',
+    );
+  });
+
+  it("uses only the Test environment and narrowly scoped secrets", async () => {
+    const workflow = await readWorkflow();
+    const job = workflow.jobs?.["deploy-test"];
+    const steps = job?.steps ?? [];
+
+    expect(workflow.permissions).toEqual({ contents: "read" });
+    expect(job?.environment).toEqual({
+      name: "Test",
+      url: "${{ vars.SITE_URL }}",
+    });
+    expect(steps.filter((step) => step.env?.CONVEX_DEPLOY_KEY).map((step) => step.name)).toEqual([
+      "Check Test configuration",
+      "Stamp Convex build SHA",
+      "Stamp Convex deploy time",
+      "Deploy Convex Test",
+      "Verify Convex contract",
+      "Apply additive Test fixtures",
+    ]);
+    expect(steps.filter((step) => step.env?.VERCEL_TOKEN).map((step) => step.name)).toEqual([
+      "Check Test configuration",
+      "Deploy unpromoted Vercel Test candidate",
+      "Assign stable Test alias",
+    ]);
+    expect(steps.find((step) => step.name === "Check Test configuration")?.run).toContain(
+      "prod:academic-chihuahua-392\\|*",
+    );
+  });
+
+  it("smokes the candidate before assigning the stable alias and verifies it afterward", async () => {
+    const workflow = await readWorkflow();
+    const steps = workflow.jobs?.["deploy-test"]?.steps ?? [];
+    const indexOf = (name: string) => steps.findIndex((step) => step.name === name);
+    const deployStep = steps.find(
+      (step) => step.name === "Deploy unpromoted Vercel Test candidate",
+    );
+    const aliasStep = steps.find((step) => step.name === "Assign stable Test alias");
+
+    expect(indexOf("Deploy Convex Test")).toBeGreaterThanOrEqual(0);
+    expect(indexOf("Apply additive Test fixtures")).toBeGreaterThan(indexOf("Deploy Convex Test"));
+    expect(indexOf("Deploy unpromoted Vercel Test candidate")).toBeGreaterThan(
+      indexOf("Apply additive Test fixtures"),
+    );
+    expect(indexOf("Smoke Test candidate HTTP")).toBeGreaterThan(
+      indexOf("Deploy unpromoted Vercel Test candidate"),
+    );
+    expect(indexOf("Smoke Test candidate UI")).toBeGreaterThan(
+      indexOf("Smoke Test candidate HTTP"),
+    );
+    expect(indexOf("Assign stable Test alias")).toBeGreaterThan(indexOf("Smoke Test candidate UI"));
+    expect(indexOf("Verify stable Test URL")).toBeGreaterThan(indexOf("Assign stable Test alias"));
+    expect(deployStep?.run).toContain("--target=preview");
+    expect(deployStep?.run).toContain('--scope "$VERCEL_SCOPE"');
+    expect(deployStep?.run).toContain("--build-env CONVEX_DEPLOY_KEY=");
+    expect(aliasStep?.run).toContain("vercel@50.44.0 alias set");
+    expect(aliasStep?.run).toContain('--scope "$VERCEL_SCOPE"');
+  });
+});

--- a/src/__tests__/deploy-test-workflow.test.ts
+++ b/src/__tests__/deploy-test-workflow.test.ts
@@ -113,6 +113,8 @@ describe("Test deploy workflow", () => {
     expect(deployStep?.run).toContain('--scope "$VERCEL_SCOPE"');
     expect(deployStep?.run).toContain("--build-env CONVEX_DEPLOY_KEY=");
     expect(aliasStep?.run).toContain("vercel@50.44.0 alias set");
+    expect(aliasStep?.run).toContain('"$DEPLOYMENT_URL"');
+    expect(aliasStep?.run).not.toContain("${{ steps.vercel.outputs.deployment_url }}");
     expect(aliasStep?.run).toContain('--scope "$VERCEL_SCOPE"');
   });
 });


### PR DESCRIPTION
## Summary

- deploy every successful current-`main` CI revision to the permanent Convex Test backend
- apply additive `seed:test` fixtures, deploy an unpromoted Vercel candidate, smoke it, then move the stable Test alias
- guard Test credentials by branch, exact SHA, Convex deployment-key target, and origin-scoped Vercel protection bypass
- update the production release skill to require an exact-SHA successful Test deployment before manual production dispatch

## Validation

- `bun run ci:static`
- `bun run ci:unit` (4,554 passed, 1 skipped; coverage gate passed)
- `bun run ci:types-build`
- `actionlint .github/workflows/deploy-test.yml`
- `bunx vitest run scripts/seed-test.test.ts src/__tests__/deploy-test-workflow.test.ts server/convexProxy.test.ts`
- `bun run convex:deploy` against `academic-chihuahua-392`
- `bun run verify:convex-contract -- --prod` (664 identifiers matched)
- deployment-key `bun run seed:test` against `academic-chihuahua-392`
- candidate HTTP smoke: 4 passed
- candidate Playwright smoke: 2 passed
- stable alias HTTP smoke: 4 passed
- `$autoreview`: clean, no accepted/actionable findings

## Live proof

- Stable Test URL: https://clawhub-env-test-openclaw-foundation.vercel.app
- Validated candidate: https://clawhub-3rknzz0c2-openclaw-foundation.vercel.app
- Convex Test: `academic-chihuahua-392`

Linear: https://linear.app/my-openclaw/issue/CLAW-494/04-automatically-deploy-main-to-clawhub-test-and-run-smoke-checks
