### PR TITLE
perf: add ninth security scan worker

### DIFF
--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -36,7 +36,7 @@ jobs:
     environment: Production
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: 9
       matrix:
         include:
           - lane: priority
@@ -55,6 +55,8 @@ jobs:
             shard: shared-5
           - lane: shared
             shard: shared-6
+          - lane: shared
+            shard: shared-7
     env:
       CONVEX_URL: ${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}
       CODEX_SECURITY_SCAN_LIMIT: ${{ github.event.client_payload.batch_limit || inputs.limit || inputs['batch-limit'] || '4' }}

--- a/scripts/security/security-scan-worker-workflow.test.ts
+++ b/scripts/security/security-scan-worker-workflow.test.ts
@@ -75,7 +75,7 @@ describe("security-scan-codex workflow", () => {
     expect(workflow.on?.workflow_dispatch).toBeDefined();
     expect(workflow.on?.repository_dispatch?.types).toEqual(["clawhub-security-scan"]);
     expect(workflow.on?.schedule).toBeUndefined();
-    expect(workflow.jobs["codex-security-scan"].strategy?.["max-parallel"]).toBe(8);
+    expect(workflow.jobs["codex-security-scan"].strategy?.["max-parallel"]).toBe(9);
     expect(workflow.jobs["codex-security-scan"].strategy?.matrix?.include).toEqual([
       { lane: "priority", shard: "priority-0" },
       { lane: "shared", shard: "shared-0" },
@@ -85,6 +85,7 @@ describe("security-scan-codex workflow", () => {
       { lane: "shared", shard: "shared-4" },
       { lane: "shared", shard: "shared-5" },
       { lane: "shared", shard: "shared-6" },
+      { lane: "shared", shard: "shared-7" },
     ]);
     expect(jobEnv.CODEX_SECURITY_SCAN_LANE).toBe("${{ matrix.lane }}");
     expect(jobEnv.CODEX_SECURITY_SCAN_LIMIT).toBe(


### PR DESCRIPTION
## Summary
- add one shared security-scan shard and raise workflow fanout to nine total jobs
- keep the dedicated publish-priority lane and all lease/dispatch behavior unchanged
- update the workflow contract test for the expanded matrix

## Production evidence
- eight-job stage: 411 completions in the first full 15-minute window (1,644/hour)
- target: 435 completions per 15 minutes (1,740/hour)
- adding one shared worker is the smallest measured increase with projected headroom above target

## Validation
- `bunx vitest run scripts/security/security-scan-worker-workflow.test.ts`
- `bun run format:check -- .github/workflows/security-scan-codex.yml scripts/security/security-scan-worker-workflow.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
