### PR TITLE
perf: add tenth security scan worker

### DIFF
--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -36,7 +36,7 @@ jobs:
     environment: Production
     strategy:
       fail-fast: false
-      max-parallel: 9
+      max-parallel: 10
       matrix:
         include:
           - lane: priority
@@ -57,6 +57,8 @@ jobs:
             shard: shared-6
           - lane: shared
             shard: shared-7
+          - lane: shared
+            shard: shared-8
     env:
       CONVEX_URL: ${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}
       CODEX_SECURITY_SCAN_LIMIT: ${{ github.event.client_payload.batch_limit || inputs.limit || inputs['batch-limit'] || '4' }}

--- a/scripts/security/security-scan-worker-workflow.test.ts
+++ b/scripts/security/security-scan-worker-workflow.test.ts
@@ -75,7 +75,7 @@ describe("security-scan-codex workflow", () => {
     expect(workflow.on?.workflow_dispatch).toBeDefined();
     expect(workflow.on?.repository_dispatch?.types).toEqual(["clawhub-security-scan"]);
     expect(workflow.on?.schedule).toBeUndefined();
-    expect(workflow.jobs["codex-security-scan"].strategy?.["max-parallel"]).toBe(9);
+    expect(workflow.jobs["codex-security-scan"].strategy?.["max-parallel"]).toBe(10);
     expect(workflow.jobs["codex-security-scan"].strategy?.matrix?.include).toEqual([
       { lane: "priority", shard: "priority-0" },
       { lane: "shared", shard: "shared-0" },
@@ -86,6 +86,7 @@ describe("security-scan-codex workflow", () => {
       { lane: "shared", shard: "shared-5" },
       { lane: "shared", shard: "shared-6" },
       { lane: "shared", shard: "shared-7" },
+      { lane: "shared", shard: "shared-8" },
     ]);
     expect(jobEnv.CODEX_SECURITY_SCAN_LANE).toBe("${{ matrix.lane }}");
     expect(jobEnv.CODEX_SECURITY_SCAN_LIMIT).toBe(


### PR DESCRIPTION
## Summary

- add one shared ClawScan shard, increasing the production workflow from 9 to 10 jobs
- keep the reserved publish-priority lane unchanged
- update the workflow contract test for the exact matrix

Production evidence: the first representative nine-job 15-minute bin completed 393 scans (1,572/hour), below the 1,740/hour 10x target. The additional shard is the smallest capacity increase that covers the measured shortfall.

## Validation

- `bunx vitest run scripts/security/security-scan-worker-workflow.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
