### PR TITLE
fix: retry transient security scan claims

### DIFF
--- a/scripts/security/run-codex-scan-worker.test.ts
+++ b/scripts/security/run-codex-scan-worker.test.ts
@@ -133,10 +133,12 @@ describe("run-codex-scan-worker diagnostics", () => {
     expect(processClaimedJob).toHaveBeenCalledTimes(2);
   });
 
-  it("counts one failed batch lease request without multiplying it by slot count", async () => {
-    const claimJobs = vi.fn(async () => {
-      throw new Error("claim outage");
-    });
+  it("retries a transient failed batch lease request without multiplying it by slot count", async () => {
+    const claimJobs = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("claim outage"))
+      .mockResolvedValueOnce({ claimedCount: 0, jobs: [] });
+    const sleep = vi.fn(async () => {});
 
     await expect(
       runContinuouslyRefilledWorkerPool({
@@ -145,13 +147,41 @@ describe("run-codex-scan-worker diagnostics", () => {
         canClaim: () => true,
         claimJobs,
         processClaimedJob: vi.fn(),
+        claimRetryMs: 25,
+        sleep,
+      }),
+    ).resolves.toMatchObject({
+      totalClaimed: 0,
+      totalClaimFailures: 1,
+      totalFailed: 0,
+    });
+    expect(claimJobs).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(25);
+  });
+
+  it("fails when the claim window closes during retry backoff", async () => {
+    let canClaim = true;
+    const sleep = vi.fn(async () => {
+      canClaim = false;
+    });
+
+    await expect(
+      runContinuouslyRefilledWorkerPool({
+        concurrency: 4,
+        maxJobs: undefined,
+        canClaim: () => canClaim,
+        claimJobs: vi.fn(async () => {
+          throw new Error("claim outage");
+        }),
+        processClaimedJob: vi.fn(),
+        claimRetryMs: 25,
+        sleep,
       }),
     ).resolves.toMatchObject({
       totalClaimed: 0,
       totalClaimFailures: 1,
       totalFailed: 1,
     });
-    expect(claimJobs).toHaveBeenCalledTimes(1);
   });
 
   it("keeps the priority lane alive after processing a partial batch", async () => {

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -1586,6 +1586,7 @@ export async function runContinuouslyRefilledWorkerPool<TJob>(options: {
   canClaim: (totalClaimed: number) => boolean;
   claimJobs: (limit: number) => Promise<{ claimedCount: number; jobs: TJob[] }>;
   processClaimedJob: (job: TJob) => Promise<ProcessJobResult>;
+  claimRetryMs?: number;
   idlePollMs?: number;
   sleep?: (ms: number) => Promise<unknown>;
 }) {
@@ -1618,8 +1619,6 @@ export async function runContinuouslyRefilledWorkerPool<TJob>(options: {
         ({ claimedCount, jobs } = await options.claimJobs(remainingJobs));
       } catch (error) {
         totalClaimFailures += 1;
-        totalFailed += 1;
-        queueDrained = true;
         const message = error instanceof Error ? error.message : String(error);
         logger.error(
           {
@@ -1630,7 +1629,18 @@ export async function runContinuouslyRefilledWorkerPool<TJob>(options: {
           },
           "failed to claim security scan jobs",
         );
-        break;
+        if (!options.canClaim(totalClaimed)) {
+          totalFailed += 1;
+          queueDrained = true;
+          break;
+        }
+        await sleepImpl(options.claimRetryMs ?? 1_000);
+        if (!options.canClaim(totalClaimed)) {
+          totalFailed += 1;
+          queueDrained = true;
+          break;
+        }
+        continue;
       }
 
       totalClaimed += claimedCount;
@@ -1783,6 +1793,7 @@ async function main() {
       return { claimedCount: leases.length, jobs };
     },
     processClaimedJob: (job) => processJob(client, token, job, diagnosticsRoot),
+    claimRetryMs: 1_000,
     idlePollMs: lane === "priority" ? 15_000 : undefined,
   });
 


### PR DESCRIPTION
Retries transient claim OCC failures with bounded backoff while preserving a failed outcome when the claim window closes.\n\nValidation: focused worker tests, ci:static, ci:unit, ci:types-build, autoreview.