### PR TITLE
fix(search): gate exact-match rank on trust and order tiers by adoption

### DIFF
--- a/convex/lib/searchRanking.test.ts
+++ b/convex/lib/searchRanking.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  adoptionBucket,
+  compareRankedSearchKeys,
+  hasStrongTrustSignal,
+  rankedSearchKey,
+  verificationRank,
+  type SearchTrustSignals,
+} from "./searchRanking";
+
+const community = (overrides: Partial<SearchTrustSignals> = {}): SearchTrustSignals => ({
+  isOfficial: false,
+  verificationTier: null,
+  downloads: 0,
+  installs: 0,
+  ...overrides,
+});
+
+describe("verificationRank", () => {
+  it("orders tiers from unverified to rebuild-verified", () => {
+    expect(verificationRank(null)).toBe(0);
+    expect(verificationRank(undefined)).toBe(0);
+    expect(verificationRank("structural")).toBe(1);
+    expect(verificationRank("source-linked")).toBe(2);
+    expect(verificationRank("provenance-verified")).toBe(3);
+    expect(verificationRank("rebuild-verified")).toBe(4);
+  });
+});
+
+describe("hasStrongTrustSignal", () => {
+  it("accepts official packages and strong verification", () => {
+    expect(hasStrongTrustSignal(community({ isOfficial: true }))).toBe(true);
+    expect(hasStrongTrustSignal(community({ verificationTier: "provenance-verified" }))).toBe(true);
+    expect(hasStrongTrustSignal(community({ verificationTier: "rebuild-verified" }))).toBe(true);
+  });
+
+  it("rejects self-serve tiers so they cannot open the squat gate", () => {
+    expect(hasStrongTrustSignal(community())).toBe(false);
+    expect(hasStrongTrustSignal(community({ verificationTier: "structural" }))).toBe(false);
+    expect(hasStrongTrustSignal(community({ verificationTier: "source-linked" }))).toBe(false);
+  });
+});
+
+describe("adoptionBucket", () => {
+  it("buckets combined downloads and installs on a log scale", () => {
+    expect(adoptionBucket(community())).toBe(0);
+    expect(adoptionBucket(community({ downloads: 9 }))).toBe(0);
+    expect(adoptionBucket(community({ downloads: 10 }))).toBe(1);
+    expect(adoptionBucket(community({ downloads: 60, installs: 40 }))).toBe(2);
+    expect(adoptionBucket(community({ downloads: 950, installs: 60 }))).toBe(3);
+    expect(adoptionBucket(community({ downloads: 5_000_000_000 }))).toBe(6);
+  });
+
+  it("ignores negative and missing stats", () => {
+    expect(adoptionBucket(community({ downloads: -5, installs: null }))).toBe(0);
+    expect(adoptionBucket({ isOfficial: false })).toBe(0);
+  });
+});
+
+describe("rankedSearchKey", () => {
+  it("demotes exact matches without trust or adoption to the prefix tier", () => {
+    const key = rankedSearchKey({ rankTier: 0, score: 200 }, community());
+    expect(key.tier).toBe(1);
+    expect(key.adoption).toBe(0);
+    expect(key.score).toBe(200);
+  });
+
+  it("keeps exact matches for official, verified, or adopted entries", () => {
+    expect(rankedSearchKey({ rankTier: 0, score: 200 }, community({ isOfficial: true })).tier).toBe(
+      0,
+    );
+    expect(
+      rankedSearchKey(
+        { rankTier: 0, score: 200 },
+        community({ verificationTier: "rebuild-verified" }),
+      ).tier,
+    ).toBe(0);
+    expect(rankedSearchKey({ rankTier: 0, score: 200 }, community({ installs: 25 })).tier).toBe(0);
+  });
+
+  it("leaves non-exact tiers untouched", () => {
+    expect(rankedSearchKey({ rankTier: 1, score: 80 }, community()).tier).toBe(1);
+    expect(rankedSearchKey({ rankTier: 3, score: 20 }, community()).tier).toBe(3);
+  });
+});
+
+describe("compareRankedSearchKeys", () => {
+  const sortKeys = (entries: Array<{ name: string; key: ReturnType<typeof rankedSearchKey> }>) =>
+    [...entries].sort((a, b) => compareRankedSearchKeys(a.key, b.key)).map((entry) => entry.name);
+
+  it("ranks adopted substring matches above fresh exact-name squats", () => {
+    // Regression for issue #3054: a zero-adoption, unverified package named
+    // exactly like the query must not headline over adopted alternatives.
+    const squat = rankedSearchKey({ rankTier: 0, score: 355 }, community());
+    const adopted = rankedSearchKey({ rankTier: 1, score: 120 }, community({ installs: 3_200 }));
+    expect(
+      sortKeys([
+        { name: "squat", key: squat },
+        { name: "adopted", key: adopted },
+      ]),
+    ).toEqual(["adopted", "squat"]);
+  });
+
+  it("keeps official exact matches on top", () => {
+    const official = rankedSearchKey(
+      { rankTier: 0, score: 200 },
+      community({ isOfficial: true, downloads: 50 }),
+    );
+    const adopted = rankedSearchKey({ rankTier: 1, score: 120 }, community({ installs: 90_000 }));
+    expect(
+      sortKeys([
+        { name: "adopted", key: adopted },
+        { name: "official", key: official },
+      ]),
+    ).toEqual(["official", "adopted"]);
+  });
+
+  it("prefers adoption magnitude before text score within a tier", () => {
+    const popular = rankedSearchKey({ rankTier: 1, score: 40 }, community({ downloads: 12_000 }));
+    const niche = rankedSearchKey({ rankTier: 1, score: 120 }, community({ downloads: 15 }));
+    expect(
+      sortKeys([
+        { name: "niche", key: niche },
+        { name: "popular", key: popular },
+      ]),
+    ).toEqual(["popular", "niche"]);
+  });
+
+  it("breaks adoption ties by text score", () => {
+    const better = rankedSearchKey({ rankTier: 1, score: 120 }, community({ downloads: 30 }));
+    const worse = rankedSearchKey({ rankTier: 1, score: 40 }, community({ downloads: 60 }));
+    expect(
+      sortKeys([
+        { name: "worse", key: worse },
+        { name: "better", key: better },
+      ]),
+    ).toEqual(["better", "worse"]);
+  });
+
+  it("returns zero for identical keys so caller tie-breakers apply", () => {
+    const key = rankedSearchKey({ rankTier: 1, score: 40 }, community({ downloads: 60 }));
+    expect(compareRankedSearchKeys(key, { ...key })).toBe(0);
+  });
+});

--- a/convex/lib/searchRanking.test.ts
+++ b/convex/lib/searchRanking.test.ts
@@ -3,6 +3,7 @@ import {
   adoptionBucket,
   compareRankedSearchKeys,
   hasStrongTrustSignal,
+  isDemotedExactMatch,
   rankedSearchKey,
   verificationRank,
   type SearchTrustSignals,
@@ -81,6 +82,22 @@ describe("rankedSearchKey", () => {
   it("leaves non-exact tiers untouched", () => {
     expect(rankedSearchKey({ rankTier: 1, score: 80 }, community()).tier).toBe(1);
     expect(rankedSearchKey({ rankTier: 3, score: 20 }, community()).tier).toBe(3);
+  });
+});
+
+describe("isDemotedExactMatch", () => {
+  it("flags untrusted zero-adoption exact matches so they cannot fill collection quotas", () => {
+    expect(isDemotedExactMatch({ rankTier: 0, score: 200 }, community())).toBe(true);
+  });
+
+  it("does not flag trusted, adopted, or non-exact matches", () => {
+    expect(isDemotedExactMatch({ rankTier: 0, score: 200 }, community({ isOfficial: true }))).toBe(
+      false,
+    );
+    expect(isDemotedExactMatch({ rankTier: 0, score: 200 }, community({ downloads: 40 }))).toBe(
+      false,
+    );
+    expect(isDemotedExactMatch({ rankTier: 1, score: 80 }, community())).toBe(false);
   });
 });
 

--- a/convex/lib/searchRanking.ts
+++ b/convex/lib/searchRanking.ts
@@ -1,0 +1,78 @@
+// Trust-aware ordering for catalog search results, shared by package and skill
+// search (convex/packages.ts, convex/skills.ts). See issue #3054: pure
+// text-match ranking let a fresh exact-name publish outrank adopted, verified
+// packages on generic queries (name-squat vector).
+
+/** Text-match result produced by the per-surface match functions. */
+type SearchTextMatch = {
+  /** 0 = exact name match, 1 = prefix/substring/token, 2 = taxonomy, 3 = summary. */
+  rankTier: number;
+  score: number;
+};
+
+export type SearchTrustSignals = {
+  isOfficial: boolean;
+  verificationTier?:
+    | "structural"
+    | "source-linked"
+    | "provenance-verified"
+    | "rebuild-verified"
+    | null;
+  downloads?: number | null;
+  installs?: number | null;
+};
+
+export function verificationRank(tier: SearchTrustSignals["verificationTier"]): number {
+  if (tier === "rebuild-verified") return 4;
+  if (tier === "provenance-verified") return 3;
+  if (tier === "source-linked") return 2;
+  if (tier === "structural") return 1;
+  return 0;
+}
+
+// Only signals that are expensive to fake count as strong trust: the official
+// flag is curated and provenance/rebuild verification require a reproducible
+// source chain. source-linked and structural are self-serve, so they must not
+// open the exact-match squat gate.
+export function hasStrongTrustSignal(signals: SearchTrustSignals): boolean {
+  return signals.isOfficial || verificationRank(signals.verificationTier) >= 3;
+}
+
+const ADOPTION_BUCKET_MAX = 6;
+
+// Log-scale adoption so ranking rewards magnitude, not vanity deltas.
+// Downloads/installs are identity-deduped upstream (convex/downloadMetrics.ts),
+// which keeps buckets costly to inflate compared to a one-publish name squat.
+export function adoptionBucket(signals: SearchTrustSignals): number {
+  const total = Math.max(0, signals.downloads ?? 0) + Math.max(0, signals.installs ?? 0);
+  if (total < 10) return 0;
+  return Math.min(ADOPTION_BUCKET_MAX, Math.floor(Math.log10(total)));
+}
+
+type RankedSearchKey = {
+  tier: number;
+  adoption: number;
+  score: number;
+};
+
+// Exact-name matches are only authoritative when backed by strong trust or
+// measurable adoption; otherwise a fresh publish with a popular name would
+// headline generic queries. Demoted entries still rank by text score inside
+// the prefix/substring tier, so new legitimate packages stay discoverable.
+export function rankedSearchKey(
+  match: SearchTextMatch,
+  signals: SearchTrustSignals,
+): RankedSearchKey {
+  const adoption = adoptionBucket(signals);
+  const demoteExact = match.rankTier === 0 && adoption === 0 && !hasStrongTrustSignal(signals);
+  return {
+    tier: demoteExact ? 1 : match.rankTier,
+    adoption,
+    score: match.score,
+  };
+}
+
+/** Ascending sort: better entries first. Callers append surface tie-breakers. */
+export function compareRankedSearchKeys(a: RankedSearchKey, b: RankedSearchKey): number {
+  return a.tier - b.tier || b.adoption - a.adoption || b.score - a.score;
+}

--- a/convex/lib/searchRanking.ts
+++ b/convex/lib/searchRanking.ts
@@ -76,3 +76,12 @@ export function rankedSearchKey(
 export function compareRankedSearchKeys(a: RankedSearchKey, b: RankedSearchKey): number {
   return a.tier - b.tier || b.adoption - a.adoption || b.score - a.score;
 }
+
+// Collection guard: a demoted exact match must not satisfy "enough results"
+// short-circuits while candidates are being gathered. The squat gate only
+// works when the fallback scan still runs to collect the adopted lexical
+// alternatives the demoted hit is compared against; otherwise a top-1 query
+// returns the squat unchallenged.
+export function isDemotedExactMatch(match: SearchTextMatch, signals: SearchTrustSignals): boolean {
+  return match.rankTier === 0 && rankedSearchKey(match, signals).tier !== 0;
+}

--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -3957,6 +3957,51 @@ describe("packages public queries", () => {
     expect(result.map((entry) => entry.package.name)).toEqual(["clean-demo"]);
   });
 
+  it("does not let a fresh exact-name package headline over adopted matches at limit 1", async () => {
+    // Regression for #3054: the untrusted exact hit fills the direct-match
+    // slot, but it must not satisfy the collection quota, or the fallback
+    // scan never gathers the adopted alternative it is ranked against.
+    const { ctx } = makeDigestCtx({
+      exactDigests: [makeDigest("youtube")],
+      pages: [
+        {
+          page: [
+            makeDigest("youtube-transcript", {
+              stats: { downloads: 4200, installs: 800, stars: 12, versions: 3 },
+            }),
+          ],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+    });
+
+    const result = await searchPublicHandler(ctx, { query: "youtube", limit: 1 });
+
+    expect(result.map((entry) => entry.package.name)).toEqual(["youtube-transcript"]);
+  });
+
+  it("keeps trusted exact-name matches on top at limit 1", async () => {
+    const { ctx } = makeDigestCtx({
+      exactDigests: [makeDigest("youtube", { isOfficial: true })],
+      pages: [
+        {
+          page: [
+            makeDigest("youtube-transcript", {
+              stats: { downloads: 4200, installs: 800, stars: 12, versions: 3 },
+            }),
+          ],
+          isDone: true,
+          continueCursor: "",
+        },
+      ],
+    });
+
+    const result = await searchPublicHandler(ctx, { query: "youtube", limit: 1 });
+
+    expect(result.map((entry) => entry.package.name)).toEqual(["youtube"]);
+  });
+
   it("allows owners to search their private packages", async () => {
     const { ctx } = makeDigestCtx({
       pages: [

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -114,6 +114,12 @@ import {
   RECOMMENDATION_SCORE_VERSION,
 } from "./lib/recommendationScore";
 import { MAX_ACTIVE_REPORTS_PER_USER, MAX_REPORT_REASON_LENGTH } from "./lib/reporting";
+import {
+  compareRankedSearchKeys,
+  rankedSearchKey,
+  verificationRank,
+  type SearchTrustSignals,
+} from "./lib/searchRanking";
 import { matchesAllTokens, matchesExploratoryTokenPrefixes, tokenize } from "./lib/searchText";
 import { hashSkillFiles } from "./lib/skills";
 import { buildDeterministicPackageZip } from "./lib/skillZip";
@@ -1738,16 +1744,14 @@ function comparePackageSearchMatches<
     };
   },
 >(a: T, b: T) {
-  const verificationRank = (tier: PackageDigestLike["verificationTier"] | null) => {
-    if (tier === "rebuild-verified") return 4;
-    if (tier === "provenance-verified") return 3;
-    if (tier === "source-linked") return 2;
-    if (tier === "structural") return 1;
-    return 0;
-  };
+  const signals = (entry: T): SearchTrustSignals => ({
+    isOfficial: entry.package.isOfficial,
+    verificationTier: entry.package.verificationTier,
+    downloads: entry.package.stats?.downloads,
+    installs: entry.package.stats?.installs,
+  });
   return (
-    a.rankTier - b.rankTier ||
-    b.score - a.score ||
+    compareRankedSearchKeys(rankedSearchKey(a, signals(a)), rankedSearchKey(b, signals(b))) ||
     Number(b.package.isOfficial) - Number(a.package.isOfficial) ||
     verificationRank(b.package.verificationTier) - verificationRank(a.package.verificationTier) ||
     (b.package.stats?.stars ?? 0) - (a.package.stats?.stars ?? 0) ||

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -116,6 +116,7 @@ import {
 import { MAX_ACTIVE_REPORTS_PER_USER, MAX_REPORT_REASON_LENGTH } from "./lib/reporting";
 import {
   compareRankedSearchKeys,
+  isDemotedExactMatch,
   rankedSearchKey,
   verificationRank,
   type SearchTrustSignals,
@@ -1734,6 +1735,19 @@ function packageSearchMatch(
   return { rankTier, score };
 }
 
+function packageTrustSignals(pkg: {
+  isOfficial: boolean;
+  verificationTier?: PackageDigestLike["verificationTier"] | null;
+  stats?: { downloads: number; installs: number; stars: number } | null;
+}): SearchTrustSignals {
+  return {
+    isOfficial: pkg.isOfficial,
+    verificationTier: pkg.verificationTier,
+    downloads: pkg.stats?.downloads,
+    installs: pkg.stats?.installs,
+  };
+}
+
 function comparePackageSearchMatches<
   T extends PackageSearchMatch & {
     package: {
@@ -1744,14 +1758,11 @@ function comparePackageSearchMatches<
     };
   },
 >(a: T, b: T) {
-  const signals = (entry: T): SearchTrustSignals => ({
-    isOfficial: entry.package.isOfficial,
-    verificationTier: entry.package.verificationTier,
-    downloads: entry.package.stats?.downloads,
-    installs: entry.package.stats?.installs,
-  });
   return (
-    compareRankedSearchKeys(rankedSearchKey(a, signals(a)), rankedSearchKey(b, signals(b))) ||
+    compareRankedSearchKeys(
+      rankedSearchKey(a, packageTrustSignals(a.package)),
+      rankedSearchKey(b, packageTrustSignals(b.package)),
+    ) ||
     Number(b.package.isOfficial) - Number(a.package.isOfficial) ||
     verificationRank(b.package.verificationTier) - verificationRank(a.package.verificationTier) ||
     (b.package.stats?.stars ?? 0) - (a.package.stats?.stars ?? 0) ||
@@ -4259,7 +4270,14 @@ async function searchPackagesImpl(
     });
   }
 
-  if (matches.length < targetCount) {
+  // Demoted exact hits never satisfy the collection quota: the fallback scan
+  // must still gather the adopted lexical alternatives they are ranked against
+  // (top-1 queries would otherwise return a name squat unchallenged).
+  const authoritativeMatchCount = () =>
+    matches.filter((entry) => !isDemotedExactMatch(entry, packageTrustSignals(entry.package)))
+      .length;
+
+  if (authoritativeMatchCount() < targetCount) {
     const scanLimit = Math.min(MAX_SEARCH_PAGE_SIZE, Math.max(targetCount * 5, 50));
     const collectDigestMatches = async (digests: PackageDigestLike[]) => {
       for (const digest of digests) {
@@ -4272,7 +4290,7 @@ async function searchPackagesImpl(
           ...match,
           package: await toPublicPackageListItem(ctx, digest),
         });
-        if (matches.length >= targetCount) break;
+        if (authoritativeMatchCount() >= targetCount) break;
       }
     };
 
@@ -4282,7 +4300,7 @@ async function searchPackagesImpl(
       let scanPages = 0;
       let remainingScanBudget = MAX_PUBLIC_LIST_FILTER_SCAN_DOCUMENTS;
       while (
-        matches.length < targetCount &&
+        authoritativeMatchCount() < targetCount &&
         !isDone &&
         scanPages < MAX_PUBLIC_LIST_FILTER_SCAN_PAGES &&
         remainingScanBudget > 0

--- a/convex/skills.packageCatalog.test.ts
+++ b/convex/skills.packageCatalog.test.ts
@@ -158,8 +158,23 @@ function makeCtx(
         }
 
         return {
-          withIndex: (indexName: string) => {
+          withIndex: (indexName: string, builder?: (q: unknown) => unknown) => {
             indexNames?.push(indexName);
+            // Capture eq constraints so by_skill unique lookups (the
+            // exact-slug direct-hit path) resolve against the seeded digests.
+            // Range operators are accepted but ignored, like before.
+            const constraints: Array<{ field: string; value: unknown }> = [];
+            const chain = {
+              eq: (field: string, value: unknown) => {
+                constraints.push({ field, value });
+                return chain;
+              },
+              gt: () => chain,
+              gte: () => chain,
+              lt: () => chain,
+              lte: () => chain,
+            };
+            builder?.(chain);
             return {
               order: () => ({
                 paginate: async ({ cursor: pageCursor }: { cursor: string | null }) =>
@@ -171,7 +186,12 @@ function makeCtx(
                 (missingRecommendedScores && indexName.startsWith("by_active_recommended_")
                   ? (allDigests[0] ?? {})
                   : null),
-              unique: async () => null,
+              unique: async () =>
+                table === "skillSearchDigest" && indexName === "by_skill" && constraints.length > 0
+                  ? (allDigests.find((digest) =>
+                      constraints.every((entry) => digest[entry.field] === entry.value),
+                    ) ?? null)
+                  : null,
             };
           },
         };
@@ -825,6 +845,32 @@ describe("skills package catalog queries", () => {
       },
     });
     expect(result[0]?.score).toBeGreaterThan(0);
+  });
+
+  it("does not let a fresh exact-slug skill headline over adopted matches at limit 1", async () => {
+    // Regression for #3054: the untrusted exact slug hit fills the direct
+    // slot, but it must not satisfy the collection quota, or the fallback
+    // scan never gathers the adopted alternative it is ranked against.
+    const squat = makeDigest("youtube");
+    const adopted = makeDigest("youtube-transcript", {
+      statsDownloads: 4200,
+      statsInstallsAllTime: 800,
+    });
+    const result = await searchPackageCatalogPublicHandler(
+      makeCtx([
+        {
+          page: [squat, adopted],
+          isDone: true,
+          continueCursor: "",
+        },
+      ]),
+      {
+        query: "youtube",
+        limit: 1,
+      },
+    );
+
+    expect(result.map((entry) => entry.package.name)).toEqual(["youtube-transcript"]);
   });
 
   it("uses stored categories as skill package search evidence", async () => {

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -126,6 +126,11 @@ import {
   reserveSlugForHardDeleteFinalize,
   upsertReservedSlugForRightfulOwner,
 } from "./lib/reservedSlugs";
+import {
+  compareRankedSearchKeys,
+  rankedSearchKey,
+  type SearchTrustSignals,
+} from "./lib/searchRanking";
 import { matchesAllTokens, matchesExploratoryTokenPrefixes, tokenize } from "./lib/searchText";
 import {
   selectGeneratedSkillCardFile,
@@ -6638,12 +6643,18 @@ function skillCatalogSearchMatch(
 
 function compareSkillCatalogSearchMatches<
   T extends SkillCatalogSearchMatch & {
-    package: Pick<PublicSkillCatalogItem, "isOfficial" | "updatedAt">;
+    package: Pick<PublicSkillCatalogItem, "isOfficial" | "updatedAt" | "stats">;
   },
 >(a: T, b: T) {
+  // Skills have no verification tiers, so official flag + adoption are the
+  // only trust signals feeding the shared squat gate.
+  const signals = (entry: T): SearchTrustSignals => ({
+    isOfficial: entry.package.isOfficial,
+    downloads: entry.package.stats.downloads,
+    installs: entry.package.stats.installs,
+  });
   return (
-    a.rankTier - b.rankTier ||
-    b.score - a.score ||
+    compareRankedSearchKeys(rankedSearchKey(a, signals(a)), rankedSearchKey(b, signals(b))) ||
     Number(b.package.isOfficial) - Number(a.package.isOfficial) ||
     b.package.updatedAt - a.package.updatedAt
   );

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -128,6 +128,7 @@ import {
 } from "./lib/reservedSlugs";
 import {
   compareRankedSearchKeys,
+  isDemotedExactMatch,
   rankedSearchKey,
   type SearchTrustSignals,
 } from "./lib/searchRanking";
@@ -6641,20 +6642,28 @@ function skillCatalogSearchMatch(
   return { rankTier, score };
 }
 
+// Skills have no verification tiers, so official flag + adoption are the
+// only trust signals feeding the shared squat gate.
+function skillTrustSignals(
+  pkg: Pick<PublicSkillCatalogItem, "isOfficial" | "stats">,
+): SearchTrustSignals {
+  return {
+    isOfficial: pkg.isOfficial,
+    downloads: pkg.stats.downloads,
+    installs: pkg.stats.installs,
+  };
+}
+
 function compareSkillCatalogSearchMatches<
   T extends SkillCatalogSearchMatch & {
     package: Pick<PublicSkillCatalogItem, "isOfficial" | "updatedAt" | "stats">;
   },
 >(a: T, b: T) {
-  // Skills have no verification tiers, so official flag + adoption are the
-  // only trust signals feeding the shared squat gate.
-  const signals = (entry: T): SearchTrustSignals => ({
-    isOfficial: entry.package.isOfficial,
-    downloads: entry.package.stats.downloads,
-    installs: entry.package.stats.installs,
-  });
   return (
-    compareRankedSearchKeys(rankedSearchKey(a, signals(a)), rankedSearchKey(b, signals(b))) ||
+    compareRankedSearchKeys(
+      rankedSearchKey(a, skillTrustSignals(a.package)),
+      rankedSearchKey(b, skillTrustSignals(b.package)),
+    ) ||
     Number(b.package.isOfficial) - Number(a.package.isOfficial) ||
     b.package.updatedAt - a.package.updatedAt
   );
@@ -6844,7 +6853,13 @@ async function searchPackageCatalogImpl(ctx: QueryCtx, args: SkillPackageCatalog
     }
   }
 
-  if (!topic && matches.length < targetCount) {
+  // Demoted exact hits never satisfy the collection quota: the fallback scans
+  // must still gather the adopted lexical alternatives they are ranked against
+  // (top-1 queries would otherwise return a slug squat unchallenged).
+  const authoritativeMatchCount = () =>
+    matches.filter((entry) => !isDemotedExactMatch(entry, skillTrustSignals(entry.package))).length;
+
+  if (!topic && authoritativeMatchCount() < targetCount) {
     const directTopic = normalizeCatalogTopic(queryText);
     if (directTopic) {
       const exactTopicDigests = await ctx.db
@@ -6886,12 +6901,12 @@ async function searchPackageCatalogImpl(ctx: QueryCtx, args: SkillPackageCatalog
           ...match,
           package: catalogItem,
         });
-        if (matches.length >= targetCount) break;
+        if (authoritativeMatchCount() >= targetCount) break;
       }
     }
   }
 
-  if (matches.length < targetCount) {
+  if (authoritativeMatchCount() < targetCount) {
     const pageSize = Math.min(MAX_SKILL_CATALOG_SEARCH_PAGE_SIZE, Math.max(targetCount * 5, 50));
     const candidateDigests: Doc<"skillSearchDigest">[] = [];
     if (topic) {

--- a/specs/search-relevance.md
+++ b/specs/search-relevance.md
@@ -17,7 +17,31 @@ Search ranking should be lexicographic before it is numeric:
 3. category or topic match;
 4. summary match;
 
-Numeric scores, trust state, popularity, and recency may order results inside those broad tiers, but must not move a weaker tier above a stronger tier.
+Numeric scores, trust state, popularity, and recency may order results inside those broad tiers, but must not make a weaker-evidence match eligible for a stronger tier.
+
+## Exact-Match Squat Gate
+
+The exact-match tier is authority, and authority must be earned (issue #3054). An exact full-field
+match claims tier 1 only when the item carries at least one signal that is expensive to fake:
+
+- the curated `official` flag,
+- provenance or rebuild verification (self-serve tiers such as structural or source-linked do not
+  qualify), or
+- measurable adoption (identity-deduped downloads plus installs).
+
+An exact match with none of those signals is ranked with the lexical tier instead. Without this
+gate, one unverified publish whose name equals a popular generic query headlines that query above
+long-adopted alternatives; display names are not even unique. Demoted items still rank by text
+score inside the lexical tier, so fresh legitimate packages stay discoverable while they earn
+signal.
+
+Within a tier, a log-scale adoption bucket orders results before the raw text-match score, then the
+existing tie-breakers apply (official, verification tier, stars, installs, downloads, recency).
+Log-scale bucketing rewards magnitude, not vanity deltas, and identity-deduped download metering
+(`specs/download-metering.md`) keeps buckets costly to inflate.
+
+The shared implementation lives in `convex/lib/searchRanking.ts` and must stay the single ranking
+seam for both package and skill-as-package catalog search.
 
 The same contract applies across `/search`, the header typeahead, package/plugin catalog search, and skill-as-package catalog search.
 


### PR DESCRIPTION
## Summary

- What changed: Added a shared trust-aware ranking seam (`convex/lib/searchRanking.ts`) and wired it into both package catalog search (`convex/packages.ts`) and skill-as-package catalog search (`convex/skills.ts`). Two behavior changes: (1) an exact-name match with no strong trust signal (not official, no provenance/rebuild verification) and no measurable adoption is ranked with the lexical tier instead of the exact tier; (2) within a tier, a log-scale adoption bucket (identity-deduped downloads + installs) orders results before the raw text-match score. Existing tie-breakers (official, verification tier, stars, installs, downloads, recency) are unchanged. `specs/search-relevance.md` is amended with the new "Exact-Match Squat Gate" contract.
- Why: One unverified publish whose name exactly equals a popular generic query used to headline that query above long-adopted, better-verified alternatives — display names are not even unique. A wrapper-plugin cluster was observed exploiting exactly this while connector suggestions were curated for the OpenClaw Control UI plugin store (openclaw/openclaw#103176). Adoption is a defensible counter-signal because download metering is identity-deduped, so inflating it costs many identities while a name squat costs one publish.

## Linked Issue

- Closes #3054

## Screenshots

- [x] `N/A` (backend ranking change; no UI surface altered)

## Behavioural Proof

- Collection quota guard: demoted exact hits do not count toward the "enough results" short-circuits, so the fallback scan still gathers the adopted alternatives they are ranked against — without this, a top-1 query returned the squat unchallenged (found by structured review, fixed with limit-1 regression tests on both surfaces: `convex/packages.public.test.ts`, `convex/skills.packageCatalog.test.ts`).
- New regression suite `convex/lib/searchRanking.test.ts` (15 tests), including the observed scenario: a zero-adoption, unverified exact-name match ("squat") now ranks below an adopted substring match, while official/verified/adopted exact matches keep today's top placement.
- Existing search behavior suites pass unchanged: `convex/packages.public.test.ts`, `convex/skills.packageCatalog.test.ts`, `convex/httpApiV1.handlers.test.ts`, `src/lib/packageApi.test.ts` (707 tests total in those files).

## Security / Trust Impact

- [x] Security/trust impact explained

This is abuse hardening for the search trust boundary: it removes the cheap top-slot path for name-squatting on generic queries and prices ranking influence in identity-deduped adoption or curated/provenance trust. Intended trade-off (documented in the spec): a brand-new package that exactly matches a query no longer outranks adopted related packages until it earns adoption or verification; it remains discoverable at the top of the unproven band by text relevance.

## Data / Deploy Impact

- [x] No data/deploy impact (pure query-time ranking; no schema or stored-data changes)

## Verification

- [x] `bun run ci:static`
- [x] Focused tests for touched behavior: `bunx vitest run convex/lib/searchRanking.test.ts convex/packages.public.test.ts convex/skills.packageCatalog.test.ts convex/httpApiV1.handlers.test.ts src/lib/packageApi.test.ts`
- [x] `bun run ci:unit` — the three isolated-pass/full-suite-timeout failures on this host (home hero, scan results, user badge; all unrelated React render tests) reproduce on a clean `main` baseline run as well (main shows 19 local failures), so they are a local-environment artifact; hosted CI is the arbiter
- [x] Broader gate when required: `bun run ci:types-build`
- [ ] Other: `N/A`
