### PR TITLE
Polish ClawHub design-system migration surfaces

### DIFF
--- a/convex/devSeed.localFixtures.test.ts
+++ b/convex/devSeed.localFixtures.test.ts
@@ -1254,7 +1254,11 @@ describe("devSeed local fixtures", () => {
     expect(tables.users?.[0]).toEqual(expect.objectContaining({ handle: "fuller-stack-dev" }));
     expect(
       tables.skills?.map((skill) => String(skill.slug)).sort((a, b) => a.localeCompare(b)),
-    ).toEqual([scannedSkillSlug, flaggedSkillSlug]);
+    ).toEqual([
+      scannedSkillSlug,
+      flaggedSkillSlug,
+      "local-truncation-plugin-runtime-integration-skill",
+    ]);
     expect(tables.skills?.every((skill) => skill.ownerUserId === userId)).toBe(true);
     expect(
       tables.packages?.map((pkg) => String(pkg.name)).sort((a, b) => a.localeCompare(b)),
@@ -1262,6 +1266,7 @@ describe("devSeed local fixtures", () => {
       flaggedPluginName,
       currentUserSeedPackageName(userId, "local-merge-notes-plugin"),
       scannedPluginName,
+      "local-truncation-runtime-plugin",
     ]);
     expect(tables.packages?.every((pkg) => pkg.ownerUserId === userId)).toBe(true);
     expect(tables.packages).toEqual(

--- a/convex/devSeed.ts
+++ b/convex/devSeed.ts
@@ -274,6 +274,10 @@ const FLAGGED_SKILL_SLUG = "local-flagged-wallet-sync";
 const SCANNED_SKILL_SLUG = "local-agentic-risk-demo";
 const FLAGGED_PLUGIN_NAME = "local-flagged-runtime-plugin";
 const SCANNED_PLUGIN_NAME = "local-scanned-runtime-plugin";
+const TRUNCATION_SKILL_SLUG = "local-truncation-plugin-runtime-integration-skill";
+const TRUNCATION_PLUGIN_NAME = "local-truncation-runtime-plugin";
+const TRUNCATION_FIXTURE_DISPLAY_NAME =
+  "[120] Plugin Runtime Integration ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHI";
 const SCANNED_SKILL_SUMMARY =
   "Seeded fixture for previewing ClawHub security buckets with a deliberately long explanation that should wrap for two lines in the skill header, then truncate before the metadata column.";
 const FLAGGED_SKILL_MD = `---
@@ -2590,17 +2594,21 @@ export async function seedLocalModerationFixturesHandler(
   const existingScannedSkill = await findScannedSkillFixture(ctx, scannedSkillSlug);
   const existingPlugin = await findSeedPluginFixture(ctx, flaggedPluginName);
   const existingScannedPlugin = await findScannedPluginFixture(ctx, scannedPluginName);
+  const existingTruncationSkill = await findSeedSkillFixture(ctx, TRUNCATION_SKILL_SLUG);
+  const existingTruncationPlugin = await findSeedPluginFixtureByName(ctx, TRUNCATION_PLUGIN_NAME);
   if (
     existingSkill &&
     existingScannedSkill &&
     existingPlugin &&
     existingScannedPlugin &&
+    existingTruncationSkill &&
+    existingTruncationPlugin &&
     !args.reset
   ) {
     const { userId, publisherId } = owner;
     const storageIdsToDelete: Id<"_storage">[] = [];
     const ownerPatch = { ownerUserId: userId, ownerPublisherId: publisherId, updatedAt: now };
-    for (const skill of [existingSkill, existingScannedSkill]) {
+    for (const skill of [existingSkill, existingScannedSkill, existingTruncationSkill]) {
       if (skill.ownerUserId !== userId || skill.ownerPublisherId !== publisherId) {
         await ctx.db.patch(skill._id, ownerPatch);
       }
@@ -2614,7 +2622,7 @@ export async function seedLocalModerationFixturesHandler(
       updatedAt: now,
     });
     await ensureSkillBadge(ctx, existingScannedSkill._id, userId, now, "official");
-    for (const pkg of [existingPlugin, existingScannedPlugin]) {
+    for (const pkg of [existingPlugin, existingScannedPlugin, existingTruncationPlugin]) {
       if (pkg.ownerUserId !== userId || pkg.ownerPublisherId !== publisherId) {
         await ctx.db.patch(pkg._id, ownerPatch);
       }
@@ -2746,18 +2754,24 @@ export async function seedLocalModerationFixturesHandler(
       flaggedSkillVersionId: existingSkill.latestVersionId,
       scannedSkillId: existingScannedSkill._id,
       scannedSkillVersionId: existingScannedSkill.latestVersionId,
+      truncationSkillId: existingTruncationSkill._id,
+      truncationSkillVersionId: existingTruncationSkill.latestVersionId,
       flaggedPluginId: existingPlugin._id,
       flaggedPluginReleaseId: existingPlugin.latestReleaseId,
       scannedPluginId: existingScannedPlugin._id,
       scannedPluginReleaseId: existingScannedPlugin.latestReleaseId,
+      truncationPluginId: existingTruncationPlugin._id,
+      truncationPluginReleaseId: existingTruncationPlugin.latestReleaseId,
       storageIdsToDelete,
     };
   }
 
   await deleteSeedSkillFixture(ctx, flaggedSkillSlug);
   await deleteScannedSkillFixture(ctx, scannedSkillSlug);
+  await deleteSeedSkillFixture(ctx, TRUNCATION_SKILL_SLUG);
   await deleteSeedPluginFixture(ctx, flaggedPluginName);
   await deleteScannedPluginFixture(ctx, scannedPluginName);
+  await deleteSeedPluginFixtureByName(ctx, TRUNCATION_PLUGIN_NAME);
 
   const { userId, publisherId } = owner;
   const staticScan = staticMaliciousScan(now);
@@ -2942,6 +2956,87 @@ export async function seedLocalModerationFixturesHandler(
       installsCurrent: 1,
       installsAllTime: 3,
       stars: 2,
+      versions: 1,
+      comments: 0,
+    },
+    updatedAt: now,
+  });
+
+  const truncationSkillId = await ctx.db.insert("skills", {
+    slug: TRUNCATION_SKILL_SLUG,
+    displayName: TRUNCATION_FIXTURE_DISPLAY_NAME,
+    summary: "Long local owner skill fixture for dashboard truncation checks.",
+    ownerUserId: userId,
+    ownerPublisherId: publisherId,
+    latestVersionId: undefined,
+    tags: {},
+    softDeletedAt: undefined,
+    badges: { redactionApproved: undefined },
+    moderationStatus: "active",
+    moderationReason: undefined,
+    moderationVerdict: "clean",
+    moderationReasonCodes: [],
+    moderationEvidence: undefined,
+    moderationSummary: undefined,
+    moderationEngineVersion: undefined,
+    moderationEvaluatedAt: now,
+    moderationFlags: [],
+    isSuspicious: false,
+    statsDownloads: 7,
+    statsStars: 1,
+    statsInstallsCurrent: 1,
+    statsInstallsAllTime: 2,
+    stats: {
+      downloads: 7,
+      installsCurrent: 1,
+      installsAllTime: 2,
+      stars: 1,
+      versions: 0,
+      comments: 0,
+    },
+    createdAt: now,
+    updatedAt: now,
+  });
+  const truncationSkillVersionId = await ctx.db.insert("skillVersions", {
+    skillId: truncationSkillId,
+    version: "0.1.0",
+    changelog: "Seeded local long-name version for dashboard truncation checks.",
+    files: [
+      {
+        path: "SKILL.md",
+        size: args.scannedSkillMd.length,
+        storageId: args.scannedSkillStorageId,
+        sha256: "seeded-truncation-skill",
+        contentType: "text/markdown",
+      },
+    ],
+    parsed: {
+      frontmatter: {
+        name: TRUNCATION_SKILL_SLUG,
+        description: "Long local owner skill fixture for dashboard truncation checks.",
+      },
+    },
+    createdBy: userId,
+    createdAt: now,
+    softDeletedAt: undefined,
+    sha256hash: "seeded-truncation-skill-hash",
+    vtAnalysis: {
+      status: "clean",
+      verdict: "clean",
+      analysis: "Local truncation fixture scanned clean.",
+      source: "local-dev-seed",
+      checkedAt: now,
+    },
+  });
+  await ctx.db.patch(truncationSkillId, {
+    latestVersionId: truncationSkillVersionId,
+    moderationSourceVersionId: truncationSkillVersionId,
+    tags: { latest: truncationSkillVersionId },
+    stats: {
+      downloads: 7,
+      installsCurrent: 1,
+      installsAllTime: 2,
+      stars: 1,
       versions: 1,
       comments: 0,
     },
@@ -3161,6 +3256,106 @@ export async function seedLocalModerationFixturesHandler(
     installs: 1,
     now,
   });
+  const truncationPackageId = await ctx.db.insert("packages", {
+    name: TRUNCATION_PLUGIN_NAME,
+    normalizedName: normalizePackageName(TRUNCATION_PLUGIN_NAME),
+    displayName: TRUNCATION_FIXTURE_DISPLAY_NAME,
+    summary: "Long local owner plugin fixture for dashboard truncation checks.",
+    ownerUserId: userId,
+    ownerPublisherId: publisherId,
+    family: "code-plugin",
+    channel: "community",
+    isOfficial: false,
+    runtimeId: "local.truncation.runtime",
+    sourceRepo: "openclaw/local-dev-fixture",
+    latestReleaseId: undefined,
+    latestVersionSummary: undefined,
+    tags: {},
+    compatibility: { pluginApiRange: ">=0.1.0" },
+    verification: {
+      tier: "structural",
+      scope: "artifact-only",
+      summary: "Local dev fixture for long-name layout checks.",
+      sourceRepo: "openclaw/local-dev-fixture",
+      scanStatus: "clean",
+    },
+    scanStatus: "clean",
+    stats: { downloads: 5, installs: 1, stars: 1, versions: 0 },
+    ...seededPackageRecommendationPatch({ downloads: 5, installs: 1, stars: 1 }),
+    softDeletedAt: undefined,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const truncationPackageReleaseId = await ctx.db.insert("packageReleases", {
+    packageId: truncationPackageId,
+    version: "0.1.0",
+    changelog: "Seeded local long-name release for dashboard truncation checks.",
+    summary: "Long local owner plugin fixture for dashboard truncation checks.",
+    distTags: ["latest"],
+    files: [
+      {
+        path: "README.md",
+        size: args.scannedPluginReadme.length,
+        storageId: args.scannedPluginStorageId,
+        sha256: "seeded-truncation-plugin",
+        contentType: "text/markdown",
+      },
+    ],
+    integritySha256: "seeded-truncation-plugin-integrity",
+    extractedPackageJson: {
+      name: TRUNCATION_PLUGIN_NAME,
+      version: "0.1.0",
+      description: "Long local owner plugin fixture for dashboard truncation checks.",
+    },
+    compatibility: { pluginApiRange: ">=0.1.0" },
+    verification: {
+      tier: "structural",
+      scope: "artifact-only",
+      summary: "Local dev fixture for long-name layout checks.",
+      sourceRepo: "openclaw/local-dev-fixture",
+      scanStatus: "clean",
+    },
+    sha256hash: "seeded-truncation-plugin-hash",
+    vtAnalysis: {
+      status: "clean",
+      verdict: "clean",
+      analysis: "Local truncation fixture scanned clean.",
+      source: "local-dev-seed",
+      checkedAt: now,
+    },
+    source: { kind: "github", repo: "openclaw/local-dev-fixture", path: "." },
+    createdBy: userId,
+    publishActor: { kind: "user", userId },
+    createdAt: now,
+    softDeletedAt: undefined,
+  });
+  await ctx.db.patch(truncationPackageId, {
+    latestReleaseId: truncationPackageReleaseId,
+    latestVersionSummary: {
+      version: "0.1.0",
+      createdAt: now,
+      changelog: "Seeded local long-name release for dashboard truncation checks.",
+      compatibility: { pluginApiRange: ">=0.1.0" },
+      verification: {
+        tier: "structural",
+        scope: "artifact-only",
+        summary: "Local dev fixture for long-name layout checks.",
+        sourceRepo: "openclaw/local-dev-fixture",
+        scanStatus: "clean",
+      },
+    },
+    tags: { latest: truncationPackageReleaseId },
+    stats: { downloads: 5, installs: 1, stars: 1, versions: 1 },
+    ...seededPackageRecommendationPatch({ downloads: 5, installs: 1, stars: 1 }),
+    updatedAt: now,
+  });
+  await ensurePublicCorpusPackageDailyStats(ctx, {
+    packageId: truncationPackageId,
+    key: TRUNCATION_PLUGIN_NAME,
+    downloads: 5,
+    installs: 1,
+    now,
+  });
   await ctx.db.insert("packageInspectorWarnings", {
     packageId: scannedPackageId,
     releaseId: scannedPackageReleaseId,
@@ -3205,8 +3400,8 @@ export async function seedLocalModerationFixturesHandler(
   });
   await ctx.db.patch(userId, {
     publishedSkills: 6,
-    totalStars: 3,
-    totalDownloads: 13,
+    totalStars: 4,
+    totalDownloads: 20,
     updatedAt: now,
   });
 
@@ -3218,10 +3413,14 @@ export async function seedLocalModerationFixturesHandler(
     flaggedSkillVersionId: skillVersionId,
     scannedSkillId,
     scannedSkillVersionId,
+    truncationSkillId,
+    truncationSkillVersionId,
     flaggedPluginId: packageId,
     flaggedPluginReleaseId: packageReleaseId,
     scannedPluginId: scannedPackageId,
     scannedPluginReleaseId: scannedPackageReleaseId,
+    truncationPluginId: truncationPackageId,
+    truncationPluginReleaseId: truncationPackageReleaseId,
   };
 }
 

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -155,6 +155,20 @@ describe("restored UI design contract", () => {
     expect(cliBand).toContain("max-width: none");
   });
 
+  it("keeps browse segmented labels stable across active state changes", () => {
+    const css = styles();
+
+    expect(cssRule(css, ".browse-tab")).toContain("font-weight: 600");
+    expect(cssRule(css, ".browse-tab.is-active")).not.toContain("font-weight");
+  });
+
+  it("makes global toasts dismissible", () => {
+    const rootSource = rootRoute();
+
+    expect(rootSource).toContain("<Toaster");
+    expect(rootSource).toContain("closeButton");
+  });
+
   it("keeps migrated application surfaces on canonical semantic tokens", () => {
     const css = styles();
     const sharedCss = designSystemStyles();

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -162,11 +162,34 @@ describe("restored UI design contract", () => {
     expect(cssRule(css, ".browse-tab.is-active")).not.toContain("font-weight");
   });
 
+  it("keeps shared segmented controls visually quiet across homepage variants", () => {
+    const css = styles();
+
+    expect(css).toContain("--clawhub-segmented-border: color-mix(in srgb, var(--line) 58%");
+    expect(css).toContain("--clawhub-segmented-border: color-mix(in srgb, var(--hv2-border) 72%");
+    expect(css).not.toContain("--clawhub-segmented-border: var(--hv2-border-strong)");
+    expect(cssRule(css, ".clawhub-segmented")).toContain(
+      "border: 1px solid var(--clawhub-segmented-border)",
+    );
+    expect(cssRule(css, ".clawhub-segmented-btn.browse-view-btn")).toContain(
+      "width: var(--clawhub-segmented-seg-h)",
+    );
+  });
+
   it("makes global toasts dismissible", () => {
     const rootSource = rootRoute();
+    const css = styles();
 
     expect(rootSource).toContain("<Toaster");
     expect(rootSource).toContain("closeButton");
+    expect(rootSource).toContain('closeButton: "clawhub-toast-close"');
+    expect(rootSource).toContain('paddingRight: "48px"');
+    expect(cssRule(css, '[data-sonner-toast][data-styled="true"] .clawhub-toast-close')).toContain(
+      "right: 14px !important",
+    );
+    expect(cssRule(css, '[data-sonner-toast][data-styled="true"] .clawhub-toast-close')).toContain(
+      "background: transparent !important",
+    );
   });
 
   it("keeps migrated application surfaces on canonical semantic tokens", () => {

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -291,7 +291,7 @@ describe("restored UI design contract", () => {
     expect(homeSource).toContain('className="home-v2-main oc-app-surface"');
     expect(homeSource).toContain("home-v2-headline oc-hero-title");
     expect(listingSource).toContain("home-v2-listing-card oc-card oc-card-interactive");
-    expect(listingSource).toContain("home-v2-listing-kind oc-segmented");
+    expect(listingSource).toContain("home-v2-listing-kind clawhub-segmented");
     expect(appsSource).toContain("home-v2-apps-tile oc-card oc-card-interactive");
     expect(appsSource).toContain('className="home-v2-apps-workflow-header"');
     expect(appsSource).not.toContain('className="home-v2-apps-workflow-header oc-card"');

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -136,6 +136,17 @@ describe("restored UI design contract", () => {
     );
   });
 
+  it("keeps dashboard package names inside their rows and attention cards", () => {
+    const css = styles();
+
+    expect(cssRule(css, ".dashboard-catalog-row .skill-list-item-name")).toContain(
+      "max-width: min(48ch, 100%)",
+    );
+    expect(
+      cssRule(css, ".dashboard-final .dashboard-attention-row .skill-list-item-name"),
+    ).toContain("max-width: 100%");
+  });
+
   it("keeps migrated application surfaces on canonical semantic tokens", () => {
     const css = styles();
     const sharedCss = designSystemStyles();

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -147,6 +147,14 @@ describe("restored UI design contract", () => {
     ).toContain("max-width: 100%");
   });
 
+  it("keeps the homepage CLI band full bleed after design-system styles load", () => {
+    const css = styles();
+    const cliBand = cssRule(css, ".home-v2-byos.oc-section");
+
+    expect(cliBand).toContain("width: 100vw");
+    expect(cliBand).toContain("max-width: none");
+  });
+
   it("keeps migrated application surfaces on canonical semantic tokens", () => {
     const css = styles();
     const sharedCss = designSystemStyles();

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -292,7 +292,7 @@ describe("restored UI design contract", () => {
     expect(homeSource).toContain("home-v2-headline oc-hero-title");
     expect(listingSource).toContain("home-v2-listing-card oc-card oc-card-interactive");
     expect(listingSource).toContain("home-v2-listing-kind clawhub-segmented");
-    expect(appsSource).toContain("home-v2-apps-tile oc-card oc-card-interactive");
+    expect(appsSource).toContain('className="home-v2-apps-tile"');
     expect(appsSource).toContain('className="home-v2-apps-workflow-header"');
     expect(appsSource).not.toContain('className="home-v2-apps-workflow-header oc-card"');
     expect(publishersSource).toContain(

--- a/src/components/HomeAppsSection.tsx
+++ b/src/components/HomeAppsSection.tsx
@@ -60,7 +60,7 @@ function HomeAppsCompactSkill({ app }: { app: HomeSkillApp }) {
     <Link
       to="/skills"
       search={{ ...SKILLS_BROWSE_SEARCH, q: app.browseQuery }}
-      className="home-v2-apps-tile oc-card oc-card-interactive"
+      className="home-v2-apps-tile"
       title={app.description}
     >
       <span className="home-v2-apps-tile-icon" aria-hidden="true">
@@ -79,7 +79,7 @@ function HomeAppsCompactPlugin({ plugin: shortcut }: { plugin: HomePluginShortcu
   return (
     <Link
       to={buildPluginDetailHref(shortcut.packageName)}
-      className="home-v2-apps-tile oc-card oc-card-interactive"
+      className="home-v2-apps-tile"
       title={shortcut.description}
     >
       <span className="home-v2-apps-tile-icon" aria-hidden="true">
@@ -277,11 +277,7 @@ export function HomeAppsSection() {
           </div>
         </div>
 
-        <div
-          className="home-v2-apps-categories oc-segmented"
-          role="tablist"
-          aria-label="App categories"
-        >
+        <div className="home-v2-apps-categories" role="tablist" aria-label="App categories">
           {appCategories.map((category) => {
             const Icon = category.icon;
             return (
@@ -290,7 +286,7 @@ export function HomeAppsSection() {
                 type="button"
                 role="tab"
                 aria-selected={category.id === activeCategoryId}
-                className="home-v2-apps-category-tab oc-segmented-item"
+                className="home-v2-apps-category-tab"
                 onClick={() => setActiveCategoryId(category.id)}
               >
                 <Icon className="home-v2-apps-category-tab-icon" size={14} aria-hidden="true" />

--- a/src/components/HomeListingSection.tsx
+++ b/src/components/HomeListingSection.tsx
@@ -677,10 +677,14 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
     >
       <div className="home-v2-listing-controls">
         <div className="home-v2-listing-toolbar">
-          <div className="home-v2-listing-kind oc-segmented" role="group" aria-label="Content type">
+          <div
+            className="home-v2-listing-kind clawhub-segmented"
+            role="group"
+            aria-label="Content type"
+          >
             <button
               type="button"
-              className={`home-v2-listing-kind-btn oc-segmented-item${
+              className={`home-v2-listing-kind-btn clawhub-segmented-btn${
                 kind === "skills" ? " is-active" : ""
               }`}
               aria-pressed={kind === "skills"}
@@ -690,7 +694,7 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
             </button>
             <button
               type="button"
-              className={`home-v2-listing-kind-btn oc-segmented-item${
+              className={`home-v2-listing-kind-btn clawhub-segmented-btn${
                 kind === "plugins" ? " is-active" : ""
               }`}
               aria-pressed={kind === "plugins"}
@@ -749,10 +753,14 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
                 onChange={setCategorySlugs}
               />
 
-              <div className="home-v2-listing-view oc-segmented" role="group" aria-label="Layout">
+              <div
+                className="home-v2-listing-view clawhub-segmented"
+                role="group"
+                aria-label="Layout"
+              >
                 <button
                   type="button"
-                  className={`home-v2-listing-view-btn oc-segmented-item${
+                  className={`home-v2-listing-view-btn clawhub-segmented-btn${
                     view === "list" ? " is-active" : ""
                   }`}
                   aria-pressed={view === "list"}
@@ -763,7 +771,7 @@ export function HomeListingSection({ initialListing = null }: HomeListingSection
                 </button>
                 <button
                   type="button"
-                  className={`home-v2-listing-view-btn oc-segmented-item${
+                  className={`home-v2-listing-view-btn clawhub-segmented-btn${
                     view === "grid" ? " is-active" : ""
                   }`}
                   aria-pressed={view === "grid"}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -202,6 +202,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
             <Footer />
           </div>
           <Toaster
+            closeButton
             position="bottom-right"
             toastOptions={{
               style: {

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -205,12 +205,16 @@ function RootDocument({ children }: { children: React.ReactNode }) {
             closeButton
             position="bottom-right"
             toastOptions={{
+              classNames: {
+                closeButton: "clawhub-toast-close",
+              },
               style: {
                 background: "var(--oc-bg-elevated)",
                 color: "var(--oc-text-primary)",
                 border: "1px solid var(--oc-border-subtle)",
                 borderRadius: "var(--oc-radius-control)",
                 fontFamily: "var(--oc-font-body)",
+                paddingRight: "48px",
               },
             }}
           />

--- a/src/styles.css
+++ b/src/styles.css
@@ -31208,7 +31208,14 @@ a[class*="rounded-full"] {
 }
 
 .dashboard-catalog-row .skill-list-item-main {
+  min-width: 0;
   gap: 8px;
+  flex-wrap: nowrap;
+}
+
+.dashboard-catalog-row .skill-list-item-name {
+  flex: 0 1 auto;
+  max-width: min(48ch, 100%);
 }
 
 .dashboard-catalog-version {
@@ -32807,8 +32814,16 @@ a[class*="rounded-full"] {
 
 .dashboard-final .dashboard-attention-row .skill-list-item-main {
   display: grid;
+  width: 100%;
+  min-width: 0;
   justify-items: start;
   gap: 7px;
+}
+
+.dashboard-final .dashboard-attention-row .skill-list-item-name {
+  display: block;
+  width: 100%;
+  max-width: 100%;
 }
 
 .dashboard-final .dashboard-attention-visibility {

--- a/src/styles.css
+++ b/src/styles.css
@@ -361,6 +361,30 @@ html {
   scrollbar-gutter: stable;
 }
 
+[data-sonner-toast][data-styled="true"] .clawhub-toast-close {
+  top: 50% !important;
+  right: 14px !important;
+  left: auto !important;
+  width: 24px !important;
+  height: 24px !important;
+  border: 0 !important;
+  border-radius: var(--oc-radius-control) !important;
+  background: transparent !important;
+  color: var(--oc-text-muted) !important;
+  transform: translateY(-50%) !important;
+}
+
+[data-sonner-toast][data-styled="true"] .clawhub-toast-close:hover {
+  background: var(--oc-surface-interactive) !important;
+  color: var(--oc-text-primary) !important;
+}
+
+[data-sonner-toast][data-styled="true"] .clawhub-toast-close:focus-visible {
+  background: var(--oc-surface-interactive) !important;
+  box-shadow: 0 0 0 2px var(--oc-focus-ring) !important;
+  color: var(--oc-text-primary) !important;
+}
+
 /*
  * Radix UI (react-remove-scroll) locks body scroll when a dropdown/dialog/popover
  * opens and, to prevent the scrollbar from disappearing visibly, injects a
@@ -21841,7 +21865,7 @@ a.search-empty-action {
   --clawhub-segmented-h: calc(var(--clawhub-segmented-seg-h) + 8px);
   --home-v2-listing-control-h: var(--clawhub-segmented-h);
   --home-v2-listing-control-seg-h: var(--clawhub-segmented-seg-h);
-  --clawhub-segmented-border: var(--line);
+  --clawhub-segmented-border: color-mix(in srgb, var(--line) 58%, transparent);
   --clawhub-segmented-bg: color-mix(in srgb, var(--surface) 95%, transparent);
   --clawhub-segmented-fg: var(--ink-soft);
   --clawhub-segmented-fg-hover: var(--ink);
@@ -21944,7 +21968,7 @@ a.search-empty-action {
 .app-shell:has(.home-v2-main) .home-v2-listing-kind,
 .app-shell:has(.home-v2-main) .home-v2-listing-view,
 .app-shell:has(.home-v2-main) .browse-view-toggle {
-  --clawhub-segmented-border: var(--hv2-border-strong);
+  --clawhub-segmented-border: color-mix(in srgb, var(--hv2-border) 72%, transparent);
   --clawhub-segmented-bg: color-mix(in srgb, var(--hv2-surface) 95%, transparent);
   --clawhub-segmented-fg: var(--hv2-text-tertiary);
   --clawhub-segmented-fg-hover: var(--hv2-text-secondary);
@@ -29253,7 +29277,7 @@ a[class*="rounded-full"] {
 .clawhub-segmented {
   --clawhub-segmented-seg-h: 30px;
   --clawhub-segmented-h: calc(var(--clawhub-segmented-seg-h) + 8px);
-  --clawhub-segmented-border: var(--line);
+  --clawhub-segmented-border: color-mix(in srgb, var(--line) 58%, transparent);
   --clawhub-segmented-bg: color-mix(in srgb, var(--surface) 95%, transparent);
   --clawhub-segmented-fg: var(--ink-soft);
   --clawhub-segmented-fg-hover: var(--ink);
@@ -29320,7 +29344,7 @@ a[class*="rounded-full"] {
 }
 
 .app-shell:has(.home-v2-main) .clawhub-segmented {
-  --clawhub-segmented-border: var(--hv2-border-strong);
+  --clawhub-segmented-border: color-mix(in srgb, var(--hv2-border) 72%, transparent);
   --clawhub-segmented-bg: color-mix(in srgb, var(--hv2-surface) 95%, transparent);
   --clawhub-segmented-fg: var(--hv2-text-tertiary);
   --clawhub-segmented-fg-hover: var(--hv2-text-secondary);

--- a/src/styles.css
+++ b/src/styles.css
@@ -27554,7 +27554,7 @@ a.home-v2-apps-see-all:focus-visible svg {
 
 /* ===== Home v2 — Bring your skills (CLI) ===== */
 
-.home-v2-byos {
+.home-v2-byos.oc-section {
   --byos-x: 50%;
   --byos-y: 42%;
   --byos-intensity: 0;

--- a/src/styles.css
+++ b/src/styles.css
@@ -17483,8 +17483,21 @@ a.agentic-risk-finding-title:focus-visible {
 }
 
 .publisher-published-rail-item {
+  position: relative;
   display: inline-flex;
   margin-left: -10px;
+}
+
+.publisher-published-rail-item:nth-child(1) {
+  z-index: 3;
+}
+
+.publisher-published-rail-item:nth-child(2) {
+  z-index: 2;
+}
+
+.publisher-published-rail-item:nth-child(3) {
+  z-index: 1;
 }
 
 .publisher-published-rail .marketplace-icon {
@@ -17517,6 +17530,21 @@ a.agentic-risk-finding-title:focus-visible {
 
 .browse-page .publisher-directory-list .publisher-card-list .publisher-card-copy {
   gap: 3px;
+}
+
+.browse-page .publisher-directory-list .publisher-card-list .publisher-card-identity {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.browse-page .publisher-directory-list .publisher-card-list .publisher-card-title-row {
+  flex: 0 1 auto;
+  overflow: hidden;
+}
+
+.browse-page .publisher-directory-list .publisher-card-list .publisher-card-handle {
+  min-width: 0;
 }
 
 .browse-page .publisher-directory-list .publisher-card-list .publisher-card-name {
@@ -17573,6 +17601,11 @@ a.agentic-risk-finding-title:focus-visible {
   border-radius: 0;
   background: transparent;
   box-shadow: none;
+}
+
+.browse-page .publisher-published-rail .marketplace-icon {
+  background: var(--surface);
+  box-shadow: 0 0 0 2px var(--surface);
 }
 
 .browse-page .publisher-directory-list .publisher-card .marketplace-icon {

--- a/src/styles.css
+++ b/src/styles.css
@@ -26635,6 +26635,7 @@ a.search-empty-action {
   position: relative;
   z-index: 2;
   display: flex;
+  width: fit-content;
   gap: 8px;
   flex-wrap: wrap;
   margin-top: 2px;
@@ -26683,14 +26684,14 @@ a.search-empty-action {
 }
 
 .home-v2-apps-category-tab[aria-selected="true"] {
-  border-color: color-mix(in srgb, var(--hv2-text) 18%, transparent);
-  background: var(--hv2-text);
-  color: var(--hv2-bg);
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.16);
+  border-color: var(--hv2-border-hover);
+  background: var(--hv2-surface-hover);
+  color: var(--hv2-text);
+  box-shadow: none;
 }
 
 .home-v2-apps-category-tab[aria-selected="true"] .home-v2-apps-category-tab-icon {
-  color: var(--hv2-bg);
+  color: var(--hv2-text);
 }
 
 .home-v2-apps-tile-grid {
@@ -27574,7 +27575,7 @@ a.home-v2-apps-see-all:focus-visible svg {
   inset: 0;
   background-position: var(--byos-art-x, 50%) var(--byos-art-y, 50%);
   background-repeat: no-repeat;
-  background-size: var(--byos-art-size, 112%) auto;
+  background-size: cover;
   pointer-events: none;
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -18092,7 +18092,7 @@ body:has(.browse-page-borderless-header) .navbar {
   cursor: pointer;
   font: inherit;
   font-size: 14px;
-  font-weight: 400;
+  font-weight: 600;
   line-height: 1;
   white-space: nowrap;
   transition:
@@ -18114,7 +18114,6 @@ body:has(.browse-page-borderless-header) .navbar {
 .browse-tab.is-active {
   border-bottom-color: var(--ink);
   color: var(--ink);
-  font-weight: 600;
 }
 
 .browse-tab-count {

--- a/src/styles.css
+++ b/src/styles.css
@@ -18059,7 +18059,7 @@ body:has(.browse-page-borderless-header) .navbar {
   cursor: pointer;
   font: inherit;
   font-size: 14px;
-  font-weight: 560;
+  font-weight: 400;
   line-height: 1;
   white-space: nowrap;
   transition:
@@ -18081,6 +18081,7 @@ body:has(.browse-page-borderless-header) .navbar {
 .browse-tab.is-active {
   border-bottom-color: var(--ink);
   color: var(--ink);
+  font-weight: 600;
 }
 
 .browse-tab-count {
@@ -18145,7 +18146,7 @@ body:has(.browse-page-borderless-header) .navbar {
 .browse-sort-label {
   min-width: 0;
   overflow: hidden;
-  font-size: 13px;
+  font-size: 14px;
   text-align: left;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -22185,7 +22186,7 @@ a.search-empty-action {
   background: none;
   padding: 0 2px;
   font-size: 14px;
-  font-weight: 560;
+  font-weight: 400;
   line-height: 1;
   color: var(--hv2-text-tertiary);
   cursor: pointer;
@@ -22212,6 +22213,7 @@ a.search-empty-action {
 .home-v2-listing-tab.is-active {
   color: var(--hv2-text);
   border-bottom-color: var(--hv2-text);
+  font-weight: 600;
 }
 
 .home-v2-listing-tab.is-active .home-v2-listing-tab-icon {


### PR DESCRIPTION
## Summary

- Aligns home browse/list controls, app category tabs, app cards, creator rows, publisher activity rails, and the BYOS CLI band with the migrated design-system styling.
- Stabilizes dashboard long-name rendering and adds Owner local truncation fixtures so dashboard regressions are easy to verify.
- Makes global toasts dismissible with a neutral close affordance inside the toast.
- Softens shared segmented-control borders site-wide and keeps browse tab weight stable.

## Validation

- `bun run test -- convex/devSeed.localFixtures.test.ts src/__tests__/ui-design-contract.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- Browser validation on local ClawHub with dev auth/Owner fixtures:
  - `/dashboard` showed `Packages 6` with two `[120] Plugin Runtime Integration...` fixtures.
  - Long dashboard names measured with `overflow: hidden`, `text-overflow: ellipsis`, and `white-space: nowrap`.
  - Toast close button measured inside the toast, neutral, right-aligned.

Note: autoreview was not run because the local guardrail blocked sending this private branch diff to an external model service without explicit approval.
