### PR TITLE
perf: restore SSR plugin catalog loading

### DIFF
--- a/src/__tests__/packages-route.test.tsx
+++ b/src/__tests__/packages-route.test.tsx
@@ -48,7 +48,13 @@ let loaderDataMock:
 
 vi.mock("@tanstack/react-router", () => ({
   createFileRoute:
-    () => (config: { loader?: unknown; component?: unknown; validateSearch?: unknown }) => ({
+    () =>
+    (config: {
+      loader?: unknown;
+      loaderDeps?: unknown;
+      component?: unknown;
+      validateSearch?: unknown;
+    }) => ({
       __config: config,
       useNavigate: () => navigateMock,
       useSearch: () => searchMock,
@@ -84,6 +90,7 @@ async function loadRoute() {
   return (await import("../routes/plugins/index")).Route as unknown as {
     __config: {
       loader?: unknown;
+      loaderDeps?: (args: { search: Record<string, unknown> }) => Record<string, unknown>;
       component?: ComponentType;
       pendingComponent?: ComponentType;
       validateSearch?: (search: Record<string, unknown>) => Record<string, unknown>;
@@ -416,6 +423,201 @@ describe("plugins route", () => {
     expect(fetchPluginCatalogMock.mock.calls[0]?.[0]).not.toHaveProperty("family");
   });
 
+  it("loads the initial catalog from route search and forwards navigation aborts", async () => {
+    const route = await loadRoute();
+    const loaderDeps = route.__config.loaderDeps as NonNullable<
+      (typeof route.__config)["loaderDeps"]
+    >;
+    const loader = route.__config.loader as (args: {
+      deps: Record<string, unknown>;
+      abortController: AbortController;
+    }) => Promise<unknown>;
+    const controller = new AbortController();
+    const deps = loaderDeps({
+      search: {
+        q: "security",
+        category: "tools",
+        topic: "oauth",
+        cursor: "ignored-for-search",
+        official: true,
+        sort: "updated",
+        view: "grid",
+      },
+    });
+
+    await loader({ deps, abortController: controller });
+
+    expect(deps).not.toHaveProperty("view");
+    expect(fetchPluginCatalogMock).toHaveBeenCalledTimes(1);
+    expect(fetchPluginCatalogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: "security",
+        category: "tools",
+        topic: "oauth",
+        cursor: undefined,
+        isOfficial: true,
+        signal: expect.any(AbortSignal),
+        viewerMode: "anonymous",
+      }),
+    );
+  });
+
+  it("does not invalidate search results for client-only cursor, sort, or view changes", async () => {
+    const route = await loadRoute();
+    const loaderDeps = route.__config.loaderDeps as NonNullable<
+      (typeof route.__config)["loaderDeps"]
+    >;
+
+    const initialDeps = loaderDeps({
+      search: {
+        q: "security",
+        cursor: "stale-cursor",
+        sort: "updated",
+        view: "list",
+      },
+    });
+    const clientOnlyChangeDeps = loaderDeps({
+      search: {
+        q: "security",
+        cursor: "another-stale-cursor",
+        sort: "downloads",
+        view: "grid",
+      },
+    });
+
+    expect(clientOnlyChangeDeps).toEqual(initialDeps);
+    expect(initialDeps).toEqual(
+      expect.objectContaining({
+        q: "security",
+        cursor: undefined,
+        sort: undefined,
+      }),
+    );
+  });
+
+  it("invalidates browse results for cursor and sort changes but not view changes", async () => {
+    const route = await loadRoute();
+    const loaderDeps = route.__config.loaderDeps as NonNullable<
+      (typeof route.__config)["loaderDeps"]
+    >;
+    const initialDeps = loaderDeps({
+      search: {
+        category: "security",
+        cursor: "cursor:first",
+        sort: "downloads",
+        view: "list",
+      },
+    });
+
+    expect(
+      loaderDeps({
+        search: {
+          category: "security",
+          cursor: "cursor:first",
+          sort: "downloads",
+          view: "grid",
+        },
+      }),
+    ).toEqual(initialDeps);
+    expect(
+      loaderDeps({
+        search: {
+          category: "security",
+          cursor: "cursor:second",
+          sort: "downloads",
+          view: "list",
+        },
+      }),
+    ).toEqual(expect.objectContaining({ cursor: "cursor:second", sort: "downloads" }));
+    expect(
+      loaderDeps({
+        search: {
+          category: "security",
+          cursor: "cursor:first",
+          sort: "updated",
+          view: "list",
+        },
+      }),
+    ).toEqual(expect.objectContaining({ cursor: "cursor:first", sort: "updated" }));
+  });
+
+  it("cancels a pending route loader request when navigation aborts", async () => {
+    fetchPluginCatalogMock.mockImplementation(
+      ({ signal }: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("The operation was aborted.", "AbortError")),
+            { once: true },
+          );
+        }),
+    );
+    const route = await loadRoute();
+    const loader = route.__config.loader as (args: {
+      deps: Record<string, unknown>;
+      abortController: AbortController;
+    }) => Promise<unknown>;
+    const controller = new AbortController();
+
+    const pendingLoader = loader({ deps: {}, abortController: controller });
+    controller.abort();
+
+    await expect(pendingLoader).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("returns an API error when the catalog request exceeds the loader timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      fetchPluginCatalogMock.mockImplementation(
+        ({ signal }: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+          }),
+      );
+      const { loadPluginsPageData } = await import("../routes/plugins/index");
+
+      const pendingLoader = loadPluginsPageData({});
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await expect(pendingLoader).resolves.toEqual(
+        expect.objectContaining({
+          items: [],
+          isLoading: false,
+          apiError: true,
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not refetch loader-backed catalog data after mount", async () => {
+    loaderDataMock = {
+      items: [
+        {
+          name: "server-plugin",
+          displayName: "Server Plugin",
+          family: "code-plugin",
+          channel: "community",
+          isOfficial: false,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      nextCursor: null,
+      rateLimited: false,
+      retryAfterSeconds: null,
+      isLoading: false,
+    };
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    expect(await screen.findByText("Server Plugin")).toBeTruthy();
+    expect(fetchPluginCatalogMock).not.toHaveBeenCalled();
+  });
+
   it("uses recommendation ranking as the plugin browse default", async () => {
     fetchPluginCatalogMock.mockResolvedValue({ items: [], nextCursor: null });
     const { loadPluginsPageData } = await import("../routes/plugins/index");
@@ -550,6 +752,94 @@ describe("plugins route", () => {
     expect(navigateMock).not.toHaveBeenCalled();
   });
 
+  it("aborts stale pagination when route loader data changes", async () => {
+    let paginationSignal: AbortSignal | undefined;
+    let resolvePagination: (value: {
+      items: Array<{
+        name: string;
+        displayName: string;
+        family: "code-plugin";
+        channel: "community";
+        isOfficial: false;
+        createdAt: number;
+        updatedAt: number;
+      }>;
+      nextCursor: null;
+    }) => void = () => {};
+    fetchPluginCatalogMock.mockImplementation(
+      ({ signal }: { signal?: AbortSignal }) =>
+        new Promise((resolve) => {
+          paginationSignal = signal;
+          resolvePagination = resolve;
+        }),
+    );
+    loaderDataMock = {
+      items: [
+        {
+          name: "old-plugin",
+          displayName: "Old Plugin",
+          family: "code-plugin",
+          channel: "community",
+          isOfficial: false,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      nextCursor: "cursor:old-next",
+      rateLimited: false,
+      retryAfterSeconds: null,
+    };
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+    const rendered = render(<Component />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+    expect(paginationSignal?.aborted).toBe(false);
+
+    searchMock = { category: "tools" };
+    loaderDataMock = {
+      items: [
+        {
+          name: "new-plugin",
+          displayName: "New Plugin",
+          family: "code-plugin",
+          channel: "community",
+          isOfficial: false,
+          createdAt: 2,
+          updatedAt: 2,
+        },
+      ],
+      nextCursor: null,
+      rateLimited: false,
+      retryAfterSeconds: null,
+    };
+
+    await act(async () => {
+      rendered.rerender(<Component />);
+    });
+
+    expect(paginationSignal?.aborted).toBe(true);
+    await act(async () => {
+      resolvePagination({
+        items: [
+          {
+            name: "stale-plugin",
+            displayName: "Stale Plugin",
+            family: "code-plugin",
+            channel: "community",
+            isOfficial: false,
+            createdAt: 3,
+            updatedAt: 3,
+          },
+        ],
+        nextCursor: null,
+      });
+    });
+    expect(screen.getByText("New Plugin")).toBeTruthy();
+    expect(screen.queryByText("Old Plugin")).toBeNull();
+    expect(screen.queryByText("Stale Plugin")).toBeNull();
+  });
+
   it("keeps downloads sort in filtered load-more requests", async () => {
     searchMock = { category: "security" };
     loaderDataMock = {
@@ -612,41 +902,19 @@ describe("plugins route", () => {
     expect(screen.getByText("1.2k")).toBeTruthy();
   });
 
-  it("renders the browse shell immediately while catalog data loads", async () => {
-    const item = {
-      name: "demo-plugin",
-      displayName: "Demo Plugin",
-      family: "code-plugin" as const,
-      channel: "community" as const,
-      isOfficial: false,
-      createdAt: 1,
-      updatedAt: 1,
-    };
-    let resolveCatalog: (value: {
-      items: (typeof item)[];
-      nextCursor: string | null;
-      totalCount: number;
-    }) => void = () => {};
-    fetchPluginCatalogMock.mockReturnValue(
-      new Promise((resolve) => {
-        resolveCatalog = resolve;
-      }),
-    );
+  it("renders the browse shell while the route loader is pending", async () => {
     const route = await loadRoute();
-    const Component = route.__config.component as ComponentType;
+    const PendingComponent = route.__config.pendingComponent as ComponentType;
 
-    render(<Component />);
+    render(<PendingComponent />);
 
     expect(screen.getByRole("heading", { name: "Plugins" })).toBeTruthy();
     expect(screen.getByRole("status", { name: "Loading results" })).toBeTruthy();
-    resolveCatalog({ items: [item], nextCursor: null, totalCount: 321 });
-
-    expect(await screen.findByText("Demo Plugin")).toBeTruthy();
-    expect(screen.getByRole("heading", { name: "Plugins 321" })).toBeTruthy();
   });
 
   it("keeps plugin count copy hidden on non-first browse pages", async () => {
     searchMock = { cursor: "cursor:current" };
+    convexReactMocks.useQuery.mockReturnValue(333);
     loaderDataMock = {
       items: [
         {
@@ -671,6 +939,8 @@ describe("plugins route", () => {
     expect(screen.getByRole("heading", { name: "Plugins" })).toBeTruthy();
     expect(screen.queryByText("1 shown")).toBeNull();
     expect(screen.queryByText("1 result shown")).toBeNull();
+    expect(screen.queryByText("333")).toBeNull();
+    expect(convexReactMocks.useQuery).toHaveBeenCalledWith("packages:countPublicPlugins", "skip");
   });
 
   it("renders the total plugin count in the unfiltered page title", async () => {
@@ -697,6 +967,7 @@ describe("plugins route", () => {
     render(<Component />);
 
     expect(screen.getByRole("heading", { name: "Plugins 321" })).toBeTruthy();
+    expect(convexReactMocks.useQuery).toHaveBeenCalledWith("packages:countPublicPlugins", "skip");
   });
 
   it("falls back to the Convex plugin count when catalog data has no total", async () => {

--- a/src/lib/packageApi.test.ts
+++ b/src/lib/packageApi.test.ts
@@ -306,6 +306,38 @@ describe("fetchPackages", () => {
     expect(url.searchParams.get("officialFirst")).toBe("true");
   });
 
+  it("omits viewer credentials from anonymous plugin catalog requests", async () => {
+    vi.stubEnv("VITE_CONVEX_SITE_URL", "https://app.example");
+    vi.stubEnv("VITE_CONVEX_URL", "https://registry.example");
+    getRequestHeadersMock.mockReturnValue(
+      new Headers({
+        authorization: "Bearer private-token",
+        cookie: "session=private",
+        "x-forwarded-for": "203.0.113.9",
+      }),
+    );
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ items: [], nextCursor: null }), { status: 200 }),
+      );
+
+    await fetchPluginCatalog({ limit: 12, viewerMode: "anonymous" });
+
+    const [, requestInit] = fetchMock.mock.calls[0] ?? [];
+    expect(requestInit).toEqual(
+      expect.objectContaining({
+        credentials: "omit",
+        headers: expect.objectContaining({
+          Accept: "application/json",
+          "x-forwarded-for": "203.0.113.9",
+        }),
+      }),
+    );
+    expect(requestInit?.headers).not.toHaveProperty("authorization");
+    expect(requestInit?.headers).not.toHaveProperty("cookie");
+  });
+
   it("uses the dedicated plugins search endpoint for mixed plugin search", async () => {
     vi.stubEnv("VITE_CONVEX_URL", "https://registry.example");
     const fetchMock = vi

--- a/src/lib/packageApi.ts
+++ b/src/lib/packageApi.ts
@@ -189,6 +189,8 @@ type PackageApiErrorOptions = {
   retryAfterSeconds?: number | null;
 };
 
+type PackageApiViewerMode = "request" | "anonymous";
+
 export class PackageApiError extends Error {
   status: number;
   retryAfterSeconds: number | null;
@@ -229,7 +231,7 @@ export function getPackageArtifactDownloadPath(name: string, version: string) {
   );
 }
 
-async function getForwardedHeaders() {
+async function getForwardedHeaders(viewerMode: PackageApiViewerMode) {
   if (typeof window !== "undefined" || !import.meta.env.SSR) return {};
   try {
     const serverRuntimeModule = "@tanstack/react-start/server";
@@ -246,8 +248,10 @@ async function getForwardedHeaders() {
       "x-real-ip",
       "fly-client-ip",
     ] as const;
-    if (cookie) headers.cookie = cookie;
-    if (authorization) headers.authorization = authorization;
+    if (viewerMode === "request") {
+      if (cookie) headers.cookie = cookie;
+      if (authorization) headers.authorization = authorization;
+    }
     for (const headerName of clientIpHeaders) {
       const value = requestHeaders.get(headerName);
       if (value) headers[headerName] = value;
@@ -258,8 +262,13 @@ async function getForwardedHeaders() {
   }
 }
 
-async function packageFetch(url: URL, accept: string, signal?: AbortSignal) {
-  const forwarded = await getForwardedHeaders();
+async function packageFetch(
+  url: URL,
+  accept: string,
+  signal?: AbortSignal,
+  viewerMode: PackageApiViewerMode = "request",
+) {
+  const forwarded = await getForwardedHeaders(viewerMode);
   const isSameOrigin = typeof window !== "undefined" && url.origin === window.location.origin;
   return await fetch(url.toString(), {
     method: "GET",
@@ -267,7 +276,7 @@ async function packageFetch(url: URL, accept: string, signal?: AbortSignal) {
     // rewrite). Cross-origin requests to the Convex site URL don't need
     // cookies, and `credentials: "include"` is rejected when the server
     // responds with `Access-Control-Allow-Origin: *`.
-    credentials: isSameOrigin ? "include" : "omit",
+    credentials: viewerMode === "request" && isSameOrigin ? "include" : "omit",
     headers: {
       Accept: accept,
       ...forwarded,
@@ -315,8 +324,12 @@ function normalizePackageApiErrorBody(status: number, body: string) {
   return body || `Request failed with status ${status}`;
 }
 
-async function fetchJson<T>(url: URL, signal?: AbortSignal): Promise<T> {
-  const response = await packageFetch(url, "application/json", signal);
+async function fetchJson<T>(
+  url: URL,
+  signal?: AbortSignal,
+  viewerMode?: PackageApiViewerMode,
+): Promise<T> {
+  const response = await packageFetch(url, "application/json", signal, viewerMode);
   if (!response.ok) throw await createPackageApiError(response);
   return (await response.json()) as T;
 }
@@ -334,6 +347,7 @@ export async function fetchPackages(params: {
   sort?: PackageCatalogSort;
   limit?: number;
   signal?: AbortSignal;
+  viewerMode?: PackageApiViewerMode;
 }) {
   if (params.q?.trim()) {
     const url = await packageApiUrl(`${ApiRoutes.packages}/search`);
@@ -352,7 +366,7 @@ export async function fetchPackages(params: {
         score: number;
         package: PackageListItem;
       }>;
-    }>(url, params.signal);
+    }>(url, params.signal, params.viewerMode);
   }
 
   const route =
@@ -379,6 +393,7 @@ export async function fetchPackages(params: {
   return await fetchJson<{ items: PackageListItem[]; nextCursor: string | null }>(
     url,
     params.signal,
+    params.viewerMode,
   );
 }
 
@@ -395,6 +410,7 @@ export async function fetchPluginCatalog(params: {
   sort?: PackageCatalogSort;
   limit?: number;
   signal?: AbortSignal;
+  viewerMode?: PackageApiViewerMode;
 }): Promise<PluginCatalogResult> {
   if (params.family) {
     const response = await fetchPackages({
@@ -410,6 +426,7 @@ export async function fetchPluginCatalog(params: {
       sort: params.sort,
       limit: params.limit,
       signal: params.signal,
+      viewerMode: params.viewerMode,
     });
     if (hasOwnProperty(response, "results") && Array.isArray(response.results)) {
       return {
@@ -444,7 +461,7 @@ export async function fetchPluginCatalog(params: {
         score: number;
         package: PackageListItem;
       }>;
-    }>(url, params.signal);
+    }>(url, params.signal, params.viewerMode);
     return {
       items: (response?.results ?? []).map((entry) => entry?.package).filter(Boolean),
       nextCursor: null,
@@ -465,7 +482,7 @@ export async function fetchPluginCatalog(params: {
     url.searchParams.set("excludeScanStatus", params.excludedScanStatuses.join(","));
   }
   if (params.sort) url.searchParams.set("sort", params.sort);
-  const result = await fetchJson<PluginCatalogResult>(url, params.signal);
+  const result = await fetchJson<PluginCatalogResult>(url, params.signal, params.viewerMode);
   return {
     items: result?.items ?? [],
     nextCursor: result?.nextCursor ?? null,

--- a/src/routes/plugins/index.tsx
+++ b/src/routes/plugins/index.tsx
@@ -40,6 +40,7 @@ type LegacyPluginSort = PluginSort | "newest" | "name" | "installs";
 type PluginBrowseTab = VisiblePluginSort | "official";
 
 const PLUGINS_PAGE_SIZE = 25;
+const PLUGIN_CATALOG_REQUEST_TIMEOUT_MS = 5_000;
 
 type PluginSearchState = {
   q?: string;
@@ -166,14 +167,25 @@ function hasPersistentPluginBrowseFilter(
 ) {
   return Boolean(args.category || args.featured || args.official);
 }
-function isNavigationAbortError(err: unknown, signal?: AbortSignal) {
-  if (signal?.aborted) return true;
-  return err instanceof Error && err.name === "AbortError";
+
+function isNavigationAbortError(signal?: AbortSignal) {
+  return Boolean(signal?.aborted);
 }
 
 export async function loadPluginsPageData(
   args: PluginsPageDataRequest,
 ): Promise<PluginsLoaderData> {
+  const requestController = new AbortController();
+  const abortFromNavigation = () => requestController.abort(args.signal?.reason);
+  if (args.signal?.aborted) {
+    abortFromNavigation();
+  } else {
+    args.signal?.addEventListener("abort", abortFromNavigation, { once: true });
+  }
+  const timeoutId = setTimeout(() => {
+    requestController.abort(new DOMException("Plugin catalog request timed out", "TimeoutError"));
+  }, PLUGIN_CATALOG_REQUEST_TIMEOUT_MS);
+
   try {
     const data = await fetchPluginCatalog({
       q: args.q,
@@ -192,7 +204,9 @@ export async function loadPluginsPageData(
         ? { sort: args.sort ?? getDefaultPluginBrowseSort(args) }
         : {}),
       limit: PLUGINS_PAGE_SIZE,
-      signal: args.signal,
+      signal: requestController.signal,
+      // Public browse SSR must not serialize request-scoped private package visibility.
+      viewerMode: "anonymous",
     });
 
     return {
@@ -205,7 +219,7 @@ export async function loadPluginsPageData(
       apiError: false,
     };
   } catch (error) {
-    if (isNavigationAbortError(error, args.signal)) throw error;
+    if (isNavigationAbortError(args.signal)) throw error;
     if (isRateLimitedPackageApiError(error)) {
       return {
         items: [],
@@ -227,6 +241,9 @@ export async function loadPluginsPageData(
       isLoading: false,
       apiError: true,
     };
+  } finally {
+    clearTimeout(timeoutId);
+    args.signal?.removeEventListener("abort", abortFromNavigation);
   }
 }
 
@@ -294,7 +311,23 @@ export const Route = createFileRoute("/plugins/")({
       });
     }
   },
-  loader: (): PluginsLoaderData => createPluginsLoadingData(),
+  loaderDeps: ({ search }) => {
+    const hasQuery = Boolean(search.q);
+    return {
+      q: search.q,
+      category: search.category,
+      topic: search.topic,
+      cursor: hasQuery ? undefined : search.cursor,
+      featured: search.featured,
+      official: search.official,
+      sort: hasQuery ? undefined : normalizeActivePluginSort(search.sort),
+    };
+  },
+  loader: async ({ deps, abortController }): Promise<PluginsLoaderData> =>
+    await loadPluginsPageData({
+      ...deps,
+      signal: abortController.signal,
+    }),
   component: PluginsIndex,
 });
 
@@ -340,20 +373,20 @@ function PluginsIndex() {
   const navigate = Route.useNavigate();
   const { search, activeTopic } = useBrowseTopicSearch(routeSearch, navigate);
   const initialLoaderData = Route.useLoaderData() as PluginsLoaderData | undefined;
-  const [catalogData, setCatalogData] = useState<PluginsLoaderData>(
-    () => initialLoaderData ?? createPluginsLoadingData(),
-  );
-  const shouldKeepInitialDataRef = useRef(
-    Boolean(initialLoaderData && !initialLoaderData.isLoading),
-  );
+  const [catalogState, setCatalogState] = useState(() => ({
+    loaderData: initialLoaderData,
+    data: initialLoaderData ?? createPluginsLoadingData(),
+  }));
+  const catalogData =
+    catalogState.loaderData === initialLoaderData
+      ? catalogState.data
+      : (initialLoaderData ?? catalogState.data);
 
   // Defensive handling for when loader data is unavailable (SSR errors, etc.)
   const items = catalogData.items;
   const nextCursor = catalogData.nextCursor;
   const rateLimited = catalogData.rateLimited;
   const retryAfterSeconds = catalogData.retryAfterSeconds;
-  const totalPluginsCount = useQuery(api.packages.countPublicPlugins, {});
-  const totalCount = catalogData.totalCount ?? totalPluginsCount ?? null;
   const isLoading = catalogData.isLoading ?? false;
   const apiError = catalogData.apiError ?? false;
   const view = normalizePluginView(search.view) ?? "list";
@@ -365,6 +398,7 @@ function PluginsIndex() {
   const searchInputRef = useRef<HTMLInputElement>(null);
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
   const loadMoreInFlightRef = useRef(false);
+  const loadMoreAbortControllerRef = useRef<AbortController | null>(null);
   const searchNavigateTimer = useRef<number>(0);
 
   useEffect(() => {
@@ -378,50 +412,25 @@ function PluginsIndex() {
     Boolean(activeTopic) ||
     Boolean(search.official) ||
     Boolean(search.featured);
-  const formattedCount = !hasActiveFilters ? formatBrowseCount(totalCount) : null;
+  const shouldResolveTotalCount =
+    !hasActiveFilters && !search.cursor && catalogData.totalCount == null;
+  const totalPluginsCount = useQuery(
+    api.packages.countPublicPlugins,
+    shouldResolveTotalCount ? {} : "skip",
+  );
+  const totalCount = catalogData.totalCount ?? totalPluginsCount ?? null;
+  const formattedCount = !hasActiveFilters && !search.cursor ? formatBrowseCount(totalCount) : null;
 
   useEffect(() => {
-    if (shouldKeepInitialDataRef.current) {
-      shouldKeepInitialDataRef.current = false;
-      return () => {};
+    if (initialLoaderData) {
+      loadMoreAbortControllerRef.current?.abort();
+      loadMoreAbortControllerRef.current = null;
+      setIsLoadingMore(false);
+      loadMoreInFlightRef.current = false;
+      setCatalogState({ loaderData: initialLoaderData, data: initialLoaderData });
     }
-    const controller = new AbortController();
-    setIsLoadingMore(false);
-    loadMoreInFlightRef.current = false;
-    setCatalogData(createPluginsLoadingData());
-    void loadPluginsPageData({
-      q: search.q,
-      category: search.category,
-      topic: search.topic,
-      cursor: search.cursor,
-      featured: search.featured,
-      official: search.official,
-      sort: normalizeActivePluginSort(search.sort),
-      signal: controller.signal,
-    })
-      .then((data) => setCatalogData(data))
-      .catch((error) => {
-        if (isNavigationAbortError(error, controller.signal)) return;
-        setCatalogData({
-          items: [],
-          nextCursor: null,
-          rateLimited: false,
-          retryAfterSeconds: null,
-          totalCount: null,
-          isLoading: false,
-          apiError: true,
-        });
-      });
-    return () => controller.abort();
-  }, [
-    search.category,
-    search.cursor,
-    search.featured,
-    search.official,
-    search.q,
-    search.sort,
-    search.topic,
-  ]);
+    return () => loadMoreAbortControllerRef.current?.abort();
+  }, [initialLoaderData]);
 
   const activeCategory = search.category;
   const categoryTopics = useQuery(
@@ -594,6 +603,8 @@ function PluginsIndex() {
 
   const loadMore = useCallback(async () => {
     if (!nextCursor || loadMoreInFlightRef.current) return;
+    const controller = new AbortController();
+    loadMoreAbortControllerRef.current = controller;
     loadMoreInFlightRef.current = true;
     setIsLoadingMore(true);
     try {
@@ -605,16 +616,30 @@ function PluginsIndex() {
         featured: search.featured,
         official: search.official,
         sort: normalizeActivePluginSort(search.sort),
+        signal: controller.signal,
       });
-      setCatalogData((previous) => ({
-        ...data,
-        items: [...previous.items, ...data.items],
-      }));
+      if (controller.signal.aborted) return;
+      setCatalogState((previous) => {
+        if (previous.loaderData !== initialLoaderData) return previous;
+        return {
+          ...previous,
+          data: {
+            ...data,
+            items: [...previous.data.items, ...data.items],
+          },
+        };
+      });
+    } catch (error) {
+      if (!isNavigationAbortError(controller.signal)) throw error;
     } finally {
-      setIsLoadingMore(false);
-      loadMoreInFlightRef.current = false;
+      if (loadMoreAbortControllerRef.current === controller) {
+        loadMoreAbortControllerRef.current = null;
+        setIsLoadingMore(false);
+        loadMoreInFlightRef.current = false;
+      }
     }
   }, [
+    initialLoaderData,
     nextCursor,
     search.category,
     search.featured,


### PR DESCRIPTION
## Summary

- restore the proposed `/plugins/` catalog request to the real TanStack route loader after #2586 moved it behind hydration
- key loader invalidation to request-affecting search state, while keeping view changes and search-only client sorting out of the cache key
- forward navigation cancellation and cap catalog loading at five seconds so a stalled backend cannot block SSR indefinitely
- keep this public browse surface explicitly anonymous so request-scoped private package visibility is never serialized into HTML or mixed into pagination
- anchor load-more state to the active loader result, abort stale pagination, and skip the redundant public-count subscription when loader data already has the total

This closes the confirmed `/plugins/` loader item from #2925. The broader SSR auth, skill README, and Markdown rendering work remain explicitly out of scope.

## Validation

- `bunx vitest run src/__tests__/packages-route.test.tsx src/lib/packageApi.test.ts` (100 passed)
- red/green regressions: effective search loader deps and stale pagination both fail against the previous implementation and pass in this PR
- `bun run ci:static`
- `bun run ci:unit` (4,605 passed, 1 skipped; coverage 85.59% statements / 75.35% branches / 86.79% functions / 88.51% lines)
- `bun run ci:types-build`
- `git diff --check`
- real browser proof at `http://localhost:3000/plugins` with the seeded local public corpus: SSR HTML contained all 3 fixture plugins; warm local TTFB was 0.28s; Chromium observed 0 catalog requests after hydration, 1 request for a category navigation, and 0 requests for a list/grid-only navigation
