### PR TITLE
fix(api): decouple rate-limit retention writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- API: keep successful rate-limit checks available when retention metadata writes contend, while preserving fail-closed enforcement for authoritative counter conflicts.
 - CLI: accept npm 12's package-keyed `npm pack --json` output when building ClawPacks while retaining compatibility with earlier npm array output.
 - Web/API: preserve JSON, SSR, and OG responses through the Convex proxy after the H3 response-wrapper update.
 

--- a/convex/http.test.ts
+++ b/convex/http.test.ts
@@ -21,6 +21,9 @@ function makeDeniedRateLimitCtx() {
       const config = args.config as { period: number };
       return { ok: false, retryAfter: config.period };
     }
+    if ("name" in args && "key" in args && "ttlMs" in args) {
+      return { action: "retained" };
+    }
     throw new Error(`Unexpected runMutation args: ${JSON.stringify(args)}`);
   });
   return {
@@ -40,6 +43,9 @@ function makeAllowedRateLimitCtx() {
   const runMutation = vi.fn(async (_fn: unknown, args: Record<string, unknown>) => {
     if ("name" in args && "config" in args) {
       return { ok: true };
+    }
+    if ("name" in args && "key" in args && "ttlMs" in args) {
+      return { action: "retained" };
     }
     throw new Error(`Unexpected runMutation args: ${JSON.stringify(args)}`);
   });
@@ -198,7 +204,7 @@ describe("HTTP route rate limit defaults", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(runMutation).toHaveBeenCalledTimes(1);
+    expect(runMutation).toHaveBeenCalledTimes(2);
     expect(runMutation).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({

--- a/convex/httpApi.handlers.test.ts
+++ b/convex/httpApi.handlers.test.ts
@@ -18,7 +18,22 @@ const { __handlers } = await import("./httpApi");
 const { hashSkillFiles } = await import("./lib/skills");
 
 function makeCtx(partial: Record<string, unknown>) {
-  return partial as unknown as import("./_generated/server").ActionCtx;
+  const partialRunMutation =
+    typeof partial.runMutation === "function"
+      ? (partial.runMutation as (mutation: unknown, args: Record<string, unknown>) => unknown)
+      : null;
+  const runMutation = vi.fn(async (mutation: unknown, args: Record<string, unknown>) => {
+    if (
+      typeof args.name === "string" &&
+      typeof args.key === "string" &&
+      typeof args.ttlMs === "number" &&
+      !("config" in args)
+    ) {
+      return { action: "retained" };
+    }
+    return partialRunMutation ? await partialRunMutation(mutation, args) : null;
+  });
+  return { ...partial, runMutation } as unknown as import("./_generated/server").ActionCtx;
 }
 
 describe("httpApi handlers", () => {

--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -57,6 +57,17 @@ function isRateLimitArgs(args: unknown): args is RateLimitArgs {
   );
 }
 
+function isRateLimitMetadataArgs(args: unknown) {
+  if (!args || typeof args !== "object") return false;
+  const value = args as Record<string, unknown>;
+  return (
+    typeof value.name === "string" &&
+    typeof value.key === "string" &&
+    typeof value.ttlMs === "number" &&
+    !("config" in value)
+  );
+}
+
 function hasSlugArgs(args: unknown): args is { slug: string } {
   if (!args || typeof args !== "object") return false;
   const value = args as Record<string, unknown>;
@@ -235,13 +246,16 @@ function makeCtx(partial: Record<string, unknown>) {
   const runQuery = vi.fn(async (query: unknown, args: Record<string, unknown>) => {
     return partialRunQuery ? await partialRunQuery(query, args) : null;
   });
-  const runMutation =
+  const partialRunMutation =
     typeof partial.runMutation === "function"
-      ? partial.runMutation
-      : vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
-          if (isRateLimitArgs(args)) return rateLimitStatus?.(args) ?? okRate();
-          return okRate();
-        });
+      ? (partial.runMutation as (mutation: unknown, args: Record<string, unknown>) => unknown)
+      : null;
+  const runMutation = vi.fn(async (mutation: unknown, args: Record<string, unknown>) => {
+    if (isRateLimitMetadataArgs(args)) return { action: "retained" };
+    if (partialRunMutation) return await partialRunMutation(mutation, args);
+    if (isRateLimitArgs(args)) return rateLimitStatus?.(args) ?? okRate();
+    return okRate();
+  });
 
   return { ...partial, runQuery, runMutation } as unknown as ActionCtx;
 }

--- a/convex/lib/httpRateLimit.test.ts
+++ b/convex/lib/httpRateLimit.test.ts
@@ -64,6 +64,12 @@ function componentRateLimitCalls(runMutation: ReturnType<typeof vi.fn>) {
   }) as [unknown, Record<string, unknown>][];
 }
 
+function metadataTouchCalls(runMutation: ReturnType<typeof vi.fn>) {
+  return runMutation.mock.calls.filter(([, args]) => {
+    return Boolean(args && typeof args === "object" && "ttlMs" in args && !("config" in args));
+  }) as [unknown, Record<string, unknown>][];
+}
+
 describe("getClientIp", () => {
   let prev: string | undefined;
   beforeEach(() => {
@@ -223,7 +229,8 @@ describe("applyRateLimit headers", () => {
     const ctx = {
       runMutation: vi
         .fn()
-        .mockRejectedValue(
+        .mockResolvedValueOnce({ action: "updated", expiresAt: 88_900_000 })
+        .mockRejectedValueOnce(
           new Error('Document in table "rateLimits" changed while this mutation was being run'),
         ),
     } as unknown as Parameters<typeof applyRateLimit>[0];
@@ -240,16 +247,19 @@ describe("applyRateLimit headers", () => {
     await expect(result.response.text()).resolves.toBe("Rate limit temporarily unavailable");
   });
 
-  it("returns retryable unavailable response when metadata key writes conflict", async () => {
+  it("keeps successful checks available when metadata key writes conflict", async () => {
     vi.spyOn(Date, "now").mockReturnValue(2_550_000);
-    const ctx = {
-      runMutation: vi
-        .fn()
-        .mockRejectedValue(
-          new Error(
-            'Document in table "httpRateLimitKeys" changed while this mutation was being run',
-          ),
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const runMutation = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error(
+          'Document in table "httpRateLimitKeys" changed while this mutation was being run',
         ),
+      )
+      .mockResolvedValueOnce({ ok: true });
+    const ctx = {
+      runMutation,
     } as unknown as Parameters<typeof applyRateLimit>[0];
 
     const result = await applyRateLimit(
@@ -258,11 +268,14 @@ describe("applyRateLimit headers", () => {
       "read",
     );
 
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.response.status).toBe(503);
-    expect(result.response.headers.get("Retry-After")).toBe("1");
-    await expect(result.response.text()).resolves.toBe("Rate limit temporarily unavailable");
+    expect(result.ok).toBe(true);
+    expect(runMutation).toHaveBeenCalledTimes(2);
+    expect(
+      runMutation.mock.calls.map(([, args]) => ("config" in args ? "counter" : "metadata")),
+    ).toEqual(["metadata", "counter"]);
+    expect(warn).toHaveBeenCalledWith("rate_limit_metadata_write_contention", {
+      name: "readIp",
+    });
   });
 
   it("configures component-backed HTTP limits with 16 shards", async () => {
@@ -297,7 +310,7 @@ describe("applyRateLimit headers", () => {
     });
   });
 
-  it("passes component key metadata after an allowed limiter check", async () => {
+  it("records component key metadata before an allowed limiter check", async () => {
     vi.spyOn(Date, "now").mockReturnValue(2_650_000);
     const ctx = makeRateLimitCtx({
       ip: {
@@ -316,9 +329,11 @@ describe("applyRateLimit headers", () => {
 
     expect(result.ok).toBe(true);
     const runMutation = (ctx as unknown as { runMutation: ReturnType<typeof vi.fn> }).runMutation;
-    expect(componentRateLimitCalls(runMutation).map(([, args]) => args)).toContainEqual(
+    expect(
+      runMutation.mock.calls.map(([, args]) => ("config" in args ? "counter" : "metadata")),
+    ).toEqual(["metadata", "counter"]);
+    expect(metadataTouchCalls(runMutation).map(([, args]) => args)).toContainEqual(
       expect.objectContaining({
-        config: expect.any(Object),
         name: "downloadIp",
         key: "ip:unknown:download",
         now: 2_650_000,
@@ -327,7 +342,7 @@ describe("applyRateLimit headers", () => {
     );
   });
 
-  it("passes component key metadata after a denied limiter check", async () => {
+  it("records component key metadata before a denied limiter check", async () => {
     vi.spyOn(Date, "now").mockReturnValue(2_660_000);
     const ctx = makeRateLimitCtx({
       ip: {
@@ -346,9 +361,11 @@ describe("applyRateLimit headers", () => {
 
     expect(result.ok).toBe(false);
     const runMutation = (ctx as unknown as { runMutation: ReturnType<typeof vi.fn> }).runMutation;
-    expect(componentRateLimitCalls(runMutation).map(([, args]) => args)).toContainEqual(
+    expect(
+      runMutation.mock.calls.map(([, args]) => ("config" in args ? "counter" : "metadata")),
+    ).toEqual(["metadata", "counter"]);
+    expect(metadataTouchCalls(runMutation).map(([, args]) => args)).toContainEqual(
       expect.objectContaining({
-        config: expect.any(Object),
         name: "downloadIp",
         key: "ip:unknown:download",
         now: 2_660_000,

--- a/convex/lib/httpRateLimit.ts
+++ b/convex/lib/httpRateLimit.ts
@@ -214,12 +214,11 @@ async function checkRateLimit(
 ): Promise<RateLimitResult> {
   const now = Date.now();
   try {
+    await touchRateLimitKeyMetadata(ctx, { name, key, now });
     const status = await ctx.runMutation(internal.rateLimits.consumeHttpRateLimitKeyInternal, {
       name,
       key,
       config: HTTP_RATE_LIMIT_CONFIGS[name],
-      now,
-      ttlMs: HTTP_RATE_LIMIT_KEY_TTL_MS,
     });
     if (!status.ok) {
       return {
@@ -236,7 +235,7 @@ async function checkRateLimit(
       resetAt: getCurrentWindowResetAt(now),
     };
   } catch (error) {
-    if (!isRateLimitWriteConflict(error)) throw error;
+    if (!isRateLimitCounterWriteConflict(error)) throw error;
     return {
       allowed: false,
       remaining: 0,
@@ -244,6 +243,26 @@ async function checkRateLimit(
       resetAt: now + 1000,
       unavailable: true,
     };
+  }
+}
+
+async function touchRateLimitKeyMetadata(
+  ctx: ActionCtx,
+  args: { name: HttpRateLimitName; key: string; now: number },
+) {
+  try {
+    await ctx.runMutation(internal.rateLimits.touchHttpRateLimitKeyInternal, {
+      ...args,
+      ttlMs: HTTP_RATE_LIMIT_KEY_TTL_MS,
+    });
+  } catch (error) {
+    if (!isRateLimitMetadataWriteConflict(error)) throw error;
+    // Metadata must be attempted before quota consumption so cleanup cannot
+    // reset a bucket after it is consumed. A conflict means cleanup or another
+    // refresh committed first, so the later counter mutation remains ordered.
+    console.warn("rate_limit_metadata_write_contention", {
+      name: args.name,
+    });
   }
 }
 
@@ -320,10 +339,18 @@ function shouldTrustClientIpHeaders() {
   return false;
 }
 
-function isRateLimitWriteConflict(error: unknown) {
+function isRateLimitCounterWriteConflict(error: unknown) {
   if (!(error instanceof Error)) return false;
   return (
-    (error.message.includes("rateLimits") || error.message.includes("httpRateLimitKeys")) &&
+    error.message.includes("rateLimits") &&
+    error.message.includes("changed while this mutation was being run")
+  );
+}
+
+function isRateLimitMetadataWriteConflict(error: unknown) {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.message.includes("httpRateLimitKeys") &&
     error.message.includes("changed while this mutation was being run")
   );
 }

--- a/convex/lib/httpRouteRateLimit.test.ts
+++ b/convex/lib/httpRouteRateLimit.test.ts
@@ -23,6 +23,9 @@ function makeCtx({
       const config = args.config as { period: number };
       return allowed ? { ok: true } : { ok: false, retryAfter: config.period };
     }
+    if ("name" in args && "key" in args && "ttlMs" in args) {
+      return { action: "retained" };
+    }
     throw new Error(`Unexpected runMutation args: ${JSON.stringify(args)}`);
   });
   return { ctx: { runQuery, runMutation } as unknown as ActionCtx, runQuery, runMutation };
@@ -131,7 +134,7 @@ describe("rateLimitedHttpAction", () => {
     const response = await wrapped._handler(ctx, new Request("https://example.com/api/v1/search"));
 
     expect(response.status).toBe(200);
-    expect(runMutation).toHaveBeenCalledTimes(1);
+    expect(runMutation).toHaveBeenCalledTimes(2);
     expect(runMutation).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({

--- a/convex/rateLimits.test.ts
+++ b/convex/rateLimits.test.ts
@@ -14,7 +14,7 @@ type WrappedHandler<TArgs, TResult> = {
 const touchHttpKeyHandler = (
   touchHttpRateLimitKeyInternal as unknown as WrappedHandler<
     { name: string; key: string; shard?: number; now?: number; ttlMs?: number },
-    { action: "inserted" | "updated"; expiresAt: number; shard: number }
+    { action: "inserted" | "retained" | "updated"; expiresAt: number; shard: number }
   >
 )._handler;
 const consumeHttpKeyHandler = (
@@ -29,9 +29,6 @@ const consumeHttpKeyHandler = (
         start?: number;
         shards?: number;
       };
-      now?: number;
-      ttlMs?: number;
-      shard?: number;
     },
     { ok: true; retryAfter?: number } | { ok: false; retryAfter: number }
   >
@@ -60,38 +57,23 @@ function makeDb(overrides: { query: ReturnType<typeof vi.fn>; delete: ReturnType
 }
 
 describe("component HTTP rate limit key metadata", () => {
-  it("consumes a component bucket and refreshes sharded metadata in one mutation", async () => {
-    const take = vi.fn(async () => []);
-    const insert = vi.fn();
+  it("consumes a component bucket without coupling retention metadata writes", async () => {
     const runMutation = vi.fn(async () => ({ ok: true }));
-    const eqShard = vi.fn();
-    const eqKey = vi.fn(() => ({ eq: eqShard }));
-    const eqName = vi.fn(() => ({ eq: eqKey }));
-    const withIndex = vi.fn((_index, builder) => {
-      builder({ eq: eqName });
-      return { take };
-    });
     const ctx = {
       runMutation,
       db: makeDb({
-        query: vi.fn(() => ({
-          withIndex,
-        })),
+        query: vi.fn(),
         delete: vi.fn(),
       }),
       scheduler: {
         runAfter: vi.fn(),
       },
     };
-    ctx.db.insert = insert;
 
     const result = await consumeHttpKeyHandler(ctx, {
       name: "downloadIp",
       key: "ip:203.0.113.1:download",
       config: { kind: "fixed window", rate: 1200, period: 60_000, start: 0, shards: 16 },
-      now: 10_000,
-      ttlMs: 60_000,
-      shard: 7,
     });
 
     expect(result).toEqual({ ok: true });
@@ -100,17 +82,7 @@ describe("component HTTP rate limit key metadata", () => {
       key: "ip:203.0.113.1:download",
       config: { kind: "fixed window", rate: 1200, period: 60_000, start: 0, shards: 16 },
     });
-    expect(withIndex).toHaveBeenCalledWith("by_name_and_key_and_shard", expect.any(Function));
-    expect(eqName).toHaveBeenCalledWith("name", "downloadIp");
-    expect(eqKey).toHaveBeenCalledWith("key", "ip:203.0.113.1:download");
-    expect(eqShard).toHaveBeenCalledWith("shard", 7);
-    expect(insert).toHaveBeenCalledWith("httpRateLimitKeys", {
-      name: "downloadIp",
-      key: "ip:203.0.113.1:download",
-      shard: 7,
-      lastTouchedAt: 10_000,
-      expiresAt: 70_000,
-    });
+    expect(ctx.db.query).not.toHaveBeenCalled();
   });
 
   it("inserts sharded metadata for a newly observed component key", async () => {
@@ -164,7 +136,7 @@ describe("component HTTP rate limit key metadata", () => {
       key: "user:users_123:read",
       shard: 11,
       lastTouchedAt: 1_000,
-      expiresAt: 61_000,
+      expiresAt: 49_000,
     };
     const ctx = {
       db: makeDb({
@@ -192,6 +164,41 @@ describe("component HTTP rate limit key metadata", () => {
       expiresAt: 80_000,
     });
     expect(ctx.db.insert).not.toHaveBeenCalled();
+  });
+
+  it("retains fresh metadata without another write", async () => {
+    const existing = {
+      _id: "httpRateLimitKeys:1",
+      name: "readKey",
+      key: "user:users_123:read",
+      shard: 11,
+      lastTouchedAt: 10_000,
+      expiresAt: 70_000,
+    };
+    const ctx = {
+      db: makeDb({
+        query: vi.fn(() => ({
+          withIndex: vi.fn(() => ({ take: vi.fn(async () => [existing]) })),
+        })),
+        delete: vi.fn(),
+      }),
+      scheduler: {
+        runAfter: vi.fn(),
+      },
+    };
+
+    const result = await touchHttpKeyHandler(ctx, {
+      name: "readKey",
+      key: "user:users_123:read",
+      shard: 11,
+      now: 20_000,
+      ttlMs: 60_000,
+    });
+
+    expect(result).toEqual({ action: "retained", expiresAt: 70_000, shard: 11 });
+    expect(ctx.db.patch).not.toHaveBeenCalled();
+    expect(ctx.db.insert).not.toHaveBeenCalled();
+    expect(ctx.db.delete).not.toHaveBeenCalled();
   });
 
   it("repairs duplicate metadata rows while refreshing a component key shard", async () => {

--- a/convex/rateLimits.ts
+++ b/convex/rateLimits.ts
@@ -8,6 +8,7 @@ const DEFAULT_HTTP_RATE_LIMIT_KEY_TTL_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_PRUNE_HTTP_RATE_LIMIT_KEYS_BATCH_SIZE = RETENTION_STANDARD_BATCH_SIZE;
 const MAX_PRUNE_HTTP_RATE_LIMIT_KEYS_BATCH_SIZE = 1_000;
 const HTTP_RATE_LIMIT_KEY_METADATA_SHARDS = 64;
+const HTTP_RATE_LIMIT_KEY_METADATA_REFRESH_FRACTION = 0.5;
 const MAX_EXPIRED_HTTP_RATE_LIMIT_KEY_ROWS_PER_KEY = HTTP_RATE_LIMIT_KEY_METADATA_SHARDS * 2;
 const fixedWindowRateLimitConfigValidator = v.object({
   kind: v.literal("fixed window"),
@@ -78,6 +79,10 @@ async function touchHttpRateLimitKey(
   const [existing, ...duplicates] = matches;
 
   if (existing) {
+    const refreshAfter = now + Math.floor(ttlMs * HTTP_RATE_LIMIT_KEY_METADATA_REFRESH_FRACTION);
+    if (duplicates.length === 0 && existing.expiresAt > refreshAfter) {
+      return { action: "retained" as const, expiresAt: existing.expiresAt, shard };
+    }
     await ctx.db.patch(existing._id, { lastTouchedAt: now, expiresAt });
     for (const duplicate of duplicates) {
       await ctx.db.delete(duplicate._id);
@@ -100,19 +105,14 @@ export const consumeHttpRateLimitKeyInternal = internalMutation({
     name: v.string(),
     key: v.string(),
     config: fixedWindowRateLimitConfigValidator,
-    now: v.optional(v.number()),
-    ttlMs: v.optional(v.number()),
-    shard: v.optional(v.number()),
   },
   returns: rateLimitStatusValidator,
   handler: async (ctx, args) => {
-    const status = await ctx.runMutation(components.rateLimiter.lib.rateLimit, {
+    return await ctx.runMutation(components.rateLimiter.lib.rateLimit, {
       name: args.name,
       key: args.key,
       config: args.config,
     });
-    await touchHttpRateLimitKey(ctx, args);
-    return status;
   },
 });
 


### PR DESCRIPTION
## Summary

- What changed:
  - split authoritative component counter consumption from `httpRateLimitKeys` retention metadata writes
  - refresh retention metadata before consuming quota, preserving cleanup ordering at expiry
  - tolerate only metadata-table OCC conflicts while keeping component counter conflicts fail-closed with `503 Retry-After: 1`
  - suppress fresh metadata rewrites until half of the 24-hour TTL has elapsed
- Why:
  - ClawHub release traffic was receiving retryable 503s when high-concurrency metadata writes contended, even though that table is only used to discover component keys for cleanup

## Linked Issue

- Closes N/A
- Related N/A

## Screenshots

- [x] Screenshots/recordings attached, or `N/A`

N/A: backend/API behavior only.

## Behavioural Proof

- [x] Behavioural proof included, or `N/A`

On Blacksmith Testbox `tbx_01kxb789cttnp2vvkwen43584y`:

- affected HTTP/rate-limit suites: 6 files, 487 tests passed
- full `bun run ci:unit`: 359 files passed, 1 skipped; 4,597 tests passed, 1 skipped
- metadata OCC test proves the request proceeds to the authoritative counter after the metadata conflict
- counter OCC test proves the API still returns a retryable 503
- ordering tests prove metadata refresh happens before allowed and denied counter checks

## Security / Trust Impact

- [ ] No security/trust impact
- [x] Security/trust impact explained

Rate-limit enforcement remains owned by the component counter and remains fail-closed on counter write conflicts. Only retention metadata conflicts are tolerated, after a pre-consumption refresh attempt establishes safe ordering with cleanup.

## Data / Deploy Impact

- [ ] No data/deploy impact
- [x] Data/deploy impact explained

No schema or data migration. The behavior takes effect through the normal Convex deployment after merge; merging alone does not deploy production.

## Verification

- [ ] `bun run ci:static`
- [x] Focused tests for touched behavior: `bunx vitest run convex/lib/httpRateLimit.test.ts convex/rateLimits.test.ts convex/lib/httpRouteRateLimit.test.ts convex/http.test.ts convex/httpApi.handlers.test.ts convex/httpApiV1.handlers.test.ts`
- [x] `bun run ci:unit` or `N/A` for docs/config-only: `bun run ci:unit`
- [ ] Broader gate when required (`ci:types-build`, `ci:packages`, `ci:e2e-http`, `ci:playwright-smoke`, `test:pw:local-auth`, `proof:ui`): hosted PR CI pending
- [x] Other: `bun run format:check`, `bun run lint`, root/schema/CLI TypeScript checks, clean Codex autoreview

AI-assisted implementation and review. The change was source-audited against `@convex-dev/rate-limiter@0.3.2`, exercised with focused and full tests, and is maintainable by the submitting maintainer.