### PR TITLE
perf(web): defer offscreen home images (#3066 / #2925)

### DIFF
--- a/src/__tests__/home-route.test.tsx
+++ b/src/__tests__/home-route.test.tsx
@@ -86,6 +86,16 @@ describe("home route", () => {
     return (Route as unknown as { __config: { loader: () => Promise<unknown> } }).__config.loader;
   }
 
+  async function getRouteHeadLinks() {
+    const { Route } = await import("../routes/index");
+    const head = (
+      Route as unknown as {
+        __config: { head?: () => { links?: Array<{ rel?: string; as?: string; href?: string }> } };
+      }
+    ).__config.head?.();
+    return head?.links ?? [];
+  }
+
   function clickHeroHeadlineTriple() {
     const headline = screen.getByRole("button", { name: /Equip/ });
     act(() => {
@@ -135,6 +145,15 @@ describe("home route", () => {
 
     await expect(loader()).resolves.toBe(initialListingFixture);
     expect(fetchInitialHomeListingMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not prioritize offscreen app icons in the route head", async () => {
+    const links = await getRouteHeadLinks();
+
+    expect(links.some((link) => link.rel === "preload" && link.as === "image")).toBe(false);
+    expect(links.some((link) => link.rel === "preconnect" && link.href?.includes("jsdelivr"))).toBe(
+      false,
+    );
   });
 
   it("falls back to client loading when the default listing loader fails", async () => {

--- a/src/components/Footer.test.tsx
+++ b/src/components/Footer.test.tsx
@@ -87,6 +87,23 @@ describe("Footer", () => {
     );
   });
 
+  it("keeps offscreen imagery lazy and dimensioned", () => {
+    const { container } = render(<Footer />);
+    const images = Array.from(container.querySelectorAll("img"));
+
+    expect(images.length).toBeGreaterThan(0);
+    for (const image of images) {
+      expect(image.getAttribute("loading")).toBe("lazy");
+      expect(image.getAttribute("decoding")).toBe("async");
+      expect(image.width).toBeGreaterThan(0);
+      expect(image.height).toBeGreaterThan(0);
+    }
+    expect(container.querySelector(".footer-v2-brand-mark")?.getAttribute("src")).toBe(
+      "/logo-transparent.png",
+    );
+    expect(container.querySelector('img[src="/og-clawhub-watermark.png"]')).toBeNull();
+  });
+
   it("collapses footer sections by heading until toggled open", async () => {
     mockMatchMedia(true);
     render(<Footer />);

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -13,7 +13,7 @@ import {
   OPENCLAW_SITE_URL,
 } from "../lib/nav-items";
 
-const FOOTER_BRAND_MARK_SRC = "/og-clawhub-watermark.png";
+const FOOTER_BRAND_MARK_SRC = "/logo-transparent.png";
 const FOOTER_EASTER_ASCII = [
   "....:: clawhub/openclaw ::....  skills plugins publishers trust signals",
   ">>> install scan publish verify    @@ gateway @@ registry @@ agents @@",
@@ -74,7 +74,7 @@ function FooterEcoMark({
   const content = (
     <>
       <span className="footer-v2-eco-mark-logo" aria-hidden="true">
-        <img src={project.logoUrl} alt="" width={28} height={28} decoding="async" />
+        <img src={project.logoUrl} alt="" width={28} height={28} loading="lazy" decoding="async" />
       </span>
       <span className="footer-v2-eco-mark-label">{project.label}</span>
     </>
@@ -216,6 +216,7 @@ export function Footer() {
                 alt=""
                 width={22}
                 height={22}
+                loading="lazy"
                 decoding="async"
               />
               <span className="footer-v2-brand-name">ClawHub</span>
@@ -303,7 +304,14 @@ export function Footer() {
           <p className="footer-v2-eco-label">
             Built alongside{" "}
             <span className="footer-v2-eco-label-accent">
-              <img src={OPENCLAW_LOGO_URL} alt="" width={14} height={14} decoding="async" />
+              <img
+                src={OPENCLAW_LOGO_URL}
+                alt=""
+                width={14}
+                height={14}
+                loading="lazy"
+                decoding="async"
+              />
               the OpenClaw ecosystem
             </span>
           </p>

--- a/src/lib/homeApps.ts
+++ b/src/lib/homeApps.ts
@@ -528,26 +528,6 @@ export function simpleIconUrl(slug: string) {
   return `${SIMPLE_ICON_BASE_URL}/${slug}.svg`;
 }
 
-const HOME_APP_POPULAR_SIMPLE_ICON_IDS = [
-  "github",
-  "vscode",
-  "notion",
-  "slack",
-  "gmail",
-  "google-drive",
-  "google-sheets",
-  "google-calendar",
-  "linear",
-  "figma",
-  "trello",
-  "whatsapp",
-] as const satisfies readonly (keyof typeof HOME_APP_SIMPLE_ICONS)[];
-
-export const HOME_APP_ICON_PRELOAD_HREFS = [
-  ...HOME_APP_POPULAR_SIMPLE_ICON_IDS.map((id) => simpleIconUrl(HOME_APP_SIMPLE_ICONS[id])),
-  ...Object.values(HOME_APP_IMAGE_ICONS),
-];
-
 function homeAppIcon({ id, iconDomain }: { id: string; iconDomain?: string }): HomeAppIcon {
   if (id in HOME_APP_IMAGE_ICONS) {
     return {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -6,40 +6,9 @@ import { HomeListingSection } from "../components/HomeListingSection";
 import { HomePopularPublishersSection } from "../components/HomePopularPublishersSection";
 import { HomePromotionsSection } from "../components/HomePromotionsSection";
 import { HomeV2FoldBottomFade } from "../components/HomeV2FoldBottomFade";
-import { HOME_APP_ICON_PRELOAD_HREFS } from "../lib/homeApps";
 import { fetchInitialHomeListing, type HomeListingInitialData } from "../lib/homeListingData";
 
-type HomeRouteHeadLink =
-  | {
-      rel: "preconnect";
-      href: string;
-    }
-  | {
-      rel: "preload";
-      as: "image";
-      href: string;
-    };
-
-function imagePreloadLink(href: string): HomeRouteHeadLink {
-  return {
-    rel: "preload",
-    as: "image",
-    href,
-  };
-}
-
-const HOME_ROUTE_HEAD_LINKS = [
-  {
-    rel: "preconnect",
-    href: "https://cdn.jsdelivr.net",
-  },
-  ...HOME_APP_ICON_PRELOAD_HREFS.map(imagePreloadLink),
-] satisfies HomeRouteHeadLink[];
-
 export const Route = createFileRoute("/")({
-  head: () => ({
-    links: HOME_ROUTE_HEAD_LINKS,
-  }),
   loader: loadInitialHomeListing,
   component: SkillsHome,
 });


### PR DESCRIPTION
## Summary

- What changed: This PR removes explicit home-route preloads for below-fold app icons and the jsDelivr preconnect, keeps footer imagery lazy and dimensioned, and reuses the canonical local ClawHub logo in the footer.
- Why: The home route was scheduling offscreen images before the first viewport needed them, increasing initial requests and transferred bytes without improving LCP.

## Linked Issue

- Closes #3066
- Related umbrella: #2925

## Screenshots

Real 1280 x 720 before/after captures of the Apps section and footer are embedded in the ClawHub UI Proof comment.

- [x] Screenshots/recordings attached, or `N/A`

## Behavioural Proof

At a 720 px viewport height, the initial document changed from 49 image preload links to 1, while the jsDelivr preconnect changed from 1 to 0. An uncached development reload observed 71 to 15 initial image requests and 3,330,822 to 354,926 encoded image bytes.

The remaining preload is the first-viewport ClawHub logo. The LCP element remained the `Install` headline, and that logo retained its 123 x 128 natural dimensions and low request priority. After scrolling, all 3 Apps images and all 52 Footer images had non-zero natural dimensions. Category switching, marquee content, links, and labels remained functional.

The candidate still requested 12 jsDelivr icon masks at low priority when the Apps section entered the browser's native loading threshold. This proves removal of eager scheduling rather than removal of the underlying visible resources.

- [x] Behavioural proof included, or `N/A`

## Security / Trust Impact

- [x] No security/trust impact
- [ ] Security/trust impact explained

## Data / Deploy Impact

- [x] No data/deploy impact
- [ ] Data/deploy impact explained

## Verification

- [x] `bun run ci:static`
- [x] Focused tests for touched behavior: `bun run test -- src/__tests__/home-route.test.tsx src/components/Footer.test.tsx`
- [x] `bun run ci:unit` or `N/A` for docs/config-only: `bun run ci:unit`
- [x] Broader gate when required (`ci:types-build`, `ci:packages`, `ci:e2e-http`, `ci:playwright-smoke`, `test:pw:local-auth`, `proof:ui`): `bun run ci:types-build`; real-browser before/after proof
- [x] Other: `git diff --check`; autoreview against `upstream/main`
