### PR TITLE
perf(publishers): reduce profile and catalog read amplification (#3064 / #2925)

### DIFF
--- a/convex/publishers.test.ts
+++ b/convex/publishers.test.ts
@@ -13,6 +13,7 @@ import {
   listPublicPage,
   listPublic,
   listMine,
+  getDeletionInventory,
   getMyProfileHandle,
   getHomePublisherSummaries,
   getProfileByHandle,
@@ -212,7 +213,17 @@ const recoverPersonalPublisherInternalHandler = (
 )._handler;
 
 const listMineHandler = (
-  listMine as unknown as WrappedHandler<Record<string, never>, Array<unknown>>
+  listMine as unknown as WrappedHandler<{ includePublishedItems?: boolean }, Array<unknown>>
+)._handler;
+
+const getDeletionInventoryHandler = (
+  getDeletionInventory as unknown as WrappedHandler<
+    { publisherId?: string },
+    Array<{
+      handle: string;
+      publishedItems: Array<{ displayName: string }>;
+    }>
+  >
 )._handler;
 
 const getMyProfileHandleHandler = (
@@ -270,7 +281,7 @@ const listPublishedPageHandler = (
       paginationOpts: { cursor: string | null; numItems: number };
     },
     {
-      page: Array<{ displayName: string; href: string }>;
+      page: Array<{ displayName: string; href: string; kind: "skill" | "plugin" }>;
       continueCursor: string;
       isDone: boolean;
     }
@@ -493,6 +504,7 @@ function indexedRows(rows: unknown[]) {
       for (const row of rows) yield row;
     },
     collect: vi.fn(async () => rows),
+    first: vi.fn(async (): Promise<unknown> => null),
     take: vi.fn(async (limit: number) => rows.slice(0, limit)),
     paginate,
     order: vi.fn(() => ({
@@ -2885,6 +2897,37 @@ describe("publishers membership controls", () => {
       createdAt: 1,
       updatedAt: 1,
     };
+    const packageRows = [
+      {
+        _id: "packages:high-download-plugin",
+        _creationTime: 2,
+        ownerPublisherId: "publishers:openclaw",
+        softDeletedAt: undefined,
+        family: "code-plugin",
+        name: "@openclaw/high-download-plugin",
+        displayName: "High Download Plugin",
+        summary: "Scoped plugin",
+        stats: { downloads: 70, installs: 3, stars: 1, versions: 1 },
+        updatedAt: 5,
+      },
+      {
+        _id: "packages:low-download-plugin",
+        _creationTime: 1,
+        ownerPublisherId: "publishers:openclaw",
+        softDeletedAt: undefined,
+        family: "code-plugin",
+        name: "@openclaw/low-download-plugin",
+        displayName: "Low Download Plugin",
+        summary: "Scoped plugin",
+        stats: { downloads: 7, installs: 300, stars: 1, versions: 1 },
+        updatedAt: 6,
+      },
+    ];
+    const packagePage = indexedRows(packageRows);
+    const legacyPackageRows = indexedRows(packageRows);
+    packagePage.collect.mockImplementation(async () => {
+      throw new Error("catalog pagination must not collect the package table");
+    });
     const ctx = {
       db: {
         get: vi.fn(async (id: string) => (id === "publishers:openclaw" ? publisher : null)),
@@ -2903,34 +2946,11 @@ describe("publishers membership controls", () => {
                 unique: vi.fn(async () => (fields.handle === "openclaw" ? publisher : null)),
               };
             }
-            if (table === "skills" && indexName === "by_owner_publisher_active_updated") {
-              return indexedRows([]);
+            if (table === "packages" && indexName === "by_owner_publisher_active_downloads") {
+              return packagePage;
             }
             if (table === "packages" && indexName === "by_owner_publisher_active_updated") {
-              return indexedRows([
-                {
-                  _id: "packages:low-download-plugin",
-                  ownerPublisherId: "publishers:openclaw",
-                  softDeletedAt: undefined,
-                  family: "code-plugin",
-                  name: "@openclaw/low-download-plugin",
-                  displayName: "Low Download Plugin",
-                  summary: "Scoped plugin",
-                  stats: { downloads: 7, installs: 300, stars: 1, versions: 1 },
-                  updatedAt: 6,
-                },
-                {
-                  _id: "packages:high-download-plugin",
-                  ownerPublisherId: "publishers:openclaw",
-                  softDeletedAt: undefined,
-                  family: "code-plugin",
-                  name: "@openclaw/high-download-plugin",
-                  displayName: "High Download Plugin",
-                  summary: "Scoped plugin",
-                  stats: { downloads: 70, installs: 3, stars: 1, versions: 1 },
-                  updatedAt: 5,
-                },
-              ]);
+              return legacyPackageRows;
             }
             if (table === "officialPublishers" && indexName === "by_publisher") {
               return { unique: vi.fn(async () => null) };
@@ -2941,13 +2961,26 @@ describe("publishers membership controls", () => {
       },
     };
 
-    const result = await listPublishedPageHandler(ctx as never, {
+    const firstPage = await listPublishedPageHandler(ctx as never, {
       handle: "openclaw",
+      kind: "plugin",
       sort: "downloads",
-      paginationOpts: { cursor: null, numItems: 12 },
+      paginationOpts: { cursor: null, numItems: 1 },
+    });
+    const secondPage = await listPublishedPageHandler(ctx as never, {
+      handle: "openclaw",
+      kind: "plugin",
+      sort: "downloads",
+      paginationOpts: { cursor: firstPage.continueCursor, numItems: 1 },
+    });
+    const resumedLegacyPage = await listPublishedPageHandler(ctx as never, {
+      handle: "openclaw",
+      kind: "plugin",
+      sort: "downloads",
+      paginationOpts: { cursor: "1", numItems: 1 },
     });
 
-    expect(result.page).toMatchObject([
+    expect([...firstPage.page, ...secondPage.page]).toMatchObject([
       {
         displayName: "High Download Plugin",
         downloads: 70,
@@ -2961,6 +2994,342 @@ describe("publishers membership controls", () => {
         installs: 300,
       },
     ]);
+    expect(packagePage.order).toHaveBeenCalledWith("desc");
+    expect(packagePage.paginate).toHaveBeenNthCalledWith(1, { cursor: null, numItems: 1 });
+    expect(packagePage.paginate).toHaveBeenNthCalledWith(2, { cursor: "1", numItems: 1 });
+    expect(firstPage.continueCursor).toBe("indexed:1");
+    expect(firstPage.isDone).toBe(false);
+    expect(secondPage.isDone).toBe(true);
+    expect(resumedLegacyPage.page.map((item) => item.displayName)).toEqual(["Low Download Plugin"]);
+    expect(resumedLegacyPage.isDone).toBe(true);
+  });
+
+  it("preserves mixed catalog pagination when kind is omitted", async () => {
+    const publisher = {
+      _id: "publishers:openclaw",
+      _creationTime: 1,
+      kind: "org",
+      handle: "openclaw",
+      displayName: "OpenClaw",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const skill = {
+      _id: "skills:demo",
+      _creationTime: 2,
+      ownerPublisherId: publisher._id,
+      ownerUserId: "users:owner",
+      softDeletedAt: undefined,
+      slug: "demo",
+      displayName: "Demo Skill",
+      moderationStatus: "active",
+      stats: { downloads: 10, stars: 1, installsCurrent: 1, installsAllTime: 2 },
+      updatedAt: 5,
+    };
+    const pkg = {
+      _id: "packages:demo",
+      _creationTime: 3,
+      ownerPublisherId: publisher._id,
+      softDeletedAt: undefined,
+      family: "code-plugin",
+      name: "@openclaw/demo",
+      displayName: "Demo Plugin",
+      stats: { downloads: 5, installs: 1, stars: 0, versions: 1 },
+      updatedAt: 4,
+    };
+    const ctx = {
+      db: {
+        get: vi.fn(async () => null),
+        query: vi.fn((table: string) => ({
+          withIndex: vi.fn((indexName: string) => {
+            if (table === "publishers" && indexName === "by_handle") {
+              return { unique: vi.fn(async () => publisher) };
+            }
+            if (table === "skills" && indexName === "by_owner_publisher_active_updated") {
+              return indexedRows([skill]);
+            }
+            if (table === "packages" && indexName === "by_owner_publisher_active_updated") {
+              return indexedRows([pkg]);
+            }
+            if (table === "officialPublishers" && indexName === "by_publisher") {
+              return { unique: vi.fn(async () => null) };
+            }
+            throw new Error(`unexpected ${table} index ${indexName}`);
+          }),
+        })),
+      },
+    };
+
+    const firstPage = await listPublishedPageHandler(ctx as never, {
+      handle: "openclaw",
+      sort: "downloads",
+      paginationOpts: { cursor: null, numItems: 1 },
+    });
+    const secondPage = await listPublishedPageHandler(ctx as never, {
+      handle: "openclaw",
+      sort: "downloads",
+      paginationOpts: { cursor: firstPage.continueCursor, numItems: 1 },
+    });
+
+    expect(firstPage.page.map((item) => item.kind)).toEqual(["skill"]);
+    expect(firstPage.continueCursor).toBe("1");
+    expect(firstPage.isDone).toBe(false);
+    expect(secondPage.page.map((item) => item.kind)).toEqual(["plugin"]);
+    expect(secondPage.isDone).toBe(true);
+  });
+
+  it("preserves canonical download order for legacy skills across pages", async () => {
+    const publisher = {
+      _id: "publishers:legacy",
+      _creationTime: 1,
+      kind: "org",
+      handle: "legacy",
+      displayName: "Legacy",
+      publishedSkills: 2,
+      publishedPackages: 0,
+      totalInstalls: 4,
+      totalDownloads: 77,
+      totalStars: 2,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const highDownloadLegacySkill = {
+      _id: "skills:legacy-high",
+      _creationTime: 1,
+      ownerPublisherId: publisher._id,
+      ownerUserId: "users:legacy",
+      softDeletedAt: undefined,
+      slug: "legacy-high",
+      displayName: "Legacy High",
+      moderationStatus: "active",
+      stats: { downloads: 70, stars: 1, installsCurrent: 1, installsAllTime: 2 },
+      updatedAt: 5,
+    };
+    const lowDownloadSkill = {
+      _id: "skills:modern-low",
+      _creationTime: 2,
+      ownerPublisherId: publisher._id,
+      ownerUserId: "users:legacy",
+      softDeletedAt: undefined,
+      slug: "modern-low",
+      displayName: "Modern Low",
+      moderationStatus: "active",
+      statsDownloads: 7,
+      stats: { downloads: 7, stars: 1, installsCurrent: 1, installsAllTime: 2 },
+      updatedAt: 6,
+    };
+    const legacyLookup = indexedRows([]);
+    legacyLookup.first.mockResolvedValue(highDownloadLegacySkill);
+    const legacyRows = indexedRows([lowDownloadSkill, highDownloadLegacySkill]);
+    const queriedTables: string[] = [];
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => (id === publisher._id ? publisher : null)),
+        query: vi.fn((table: string) => {
+          queriedTables.push(table);
+          return {
+            withIndex: vi.fn((indexName: string, buildQuery: (q: unknown) => unknown) => {
+              const fields: Record<string, unknown> = {};
+              const q = {
+                eq: (field: string, value: unknown) => {
+                  fields[field] = value;
+                  return q;
+                },
+              };
+              buildQuery(q);
+              if (table === "publishers" && indexName === "by_handle") {
+                return { unique: vi.fn(async () => publisher) };
+              }
+              if (table === "officialPublishers" && indexName === "by_publisher") {
+                return { unique: vi.fn(async () => null) };
+              }
+              if (
+                table === "skills" &&
+                indexName === "by_owner_publisher_active_downloads" &&
+                "statsDownloads" in fields
+              ) {
+                return legacyLookup;
+              }
+              if (table === "skills" && indexName === "by_owner_publisher_active_updated") {
+                return legacyRows;
+              }
+              throw new Error(`unexpected ${table} index ${indexName}`);
+            }),
+          };
+        }),
+      },
+    };
+
+    const firstPage = await listPublishedPageHandler(ctx as never, {
+      handle: "legacy",
+      kind: "skill",
+      sort: "downloads",
+      paginationOpts: { cursor: null, numItems: 1 },
+    });
+    legacyLookup.first.mockResolvedValue(null);
+    const secondPage = await listPublishedPageHandler(ctx as never, {
+      handle: "legacy",
+      kind: "skill",
+      sort: "downloads",
+      paginationOpts: { cursor: firstPage.continueCursor, numItems: 1 },
+    });
+
+    expect([...firstPage.page, ...secondPage.page].map((item) => item.displayName)).toEqual([
+      "Legacy High",
+      "Modern Low",
+    ]);
+    expect(firstPage.continueCursor).toBe("legacy:1");
+    expect(secondPage.isDone).toBe(true);
+    expect(legacyLookup.first).toHaveBeenCalledTimes(1);
+    expect(legacyRows.collect).toHaveBeenCalledTimes(2);
+    expect(queriedTables).not.toContain("packages");
+  });
+
+  it("resumes untagged pre-index cursors with the original comparator across backfill", async () => {
+    const publisher = {
+      _id: "publishers:preindex",
+      _creationTime: 1,
+      kind: "org",
+      handle: "preindex",
+      displayName: "Pre-index",
+      publishedSkills: 3,
+      publishedPackages: 0,
+      totalInstalls: 3,
+      totalDownloads: 30,
+      totalStars: 6,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const originalRows = [
+      {
+        _id: "skills:old-a",
+        _creationTime: 1,
+        ownerPublisherId: publisher._id,
+        ownerUserId: "users:preindex",
+        softDeletedAt: undefined,
+        slug: "old-a",
+        displayName: "Old A",
+        moderationStatus: "active",
+        stats: { downloads: 10, stars: 3, installsCurrent: 1, installsAllTime: 1 },
+        updatedAt: 1,
+      },
+      {
+        _id: "skills:old-b",
+        _creationTime: 3,
+        ownerPublisherId: publisher._id,
+        ownerUserId: "users:preindex",
+        softDeletedAt: undefined,
+        slug: "old-b",
+        displayName: "Old B",
+        moderationStatus: "active",
+        stats: { downloads: 10, stars: 2, installsCurrent: 1, installsAllTime: 1 },
+        updatedAt: 3,
+      },
+      {
+        _id: "skills:old-c",
+        _creationTime: 2,
+        ownerPublisherId: publisher._id,
+        ownerUserId: "users:preindex",
+        softDeletedAt: undefined,
+        slug: "old-c",
+        displayName: "Old C",
+        moderationStatus: "active",
+        stats: { downloads: 10, stars: 1, installsCurrent: 1, installsAllTime: 1 },
+        updatedAt: 2,
+      },
+    ];
+    let rows = originalRows;
+    const collect = vi.fn(async () => rows);
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => (id === publisher._id ? publisher : null)),
+        query: vi.fn((table: string) => ({
+          withIndex: vi.fn((indexName: string) => {
+            if (table === "publishers" && indexName === "by_handle") {
+              return { unique: vi.fn(async () => publisher) };
+            }
+            if (table === "officialPublishers" && indexName === "by_publisher") {
+              return { unique: vi.fn(async () => null) };
+            }
+            if (table === "skills" && indexName === "by_owner_publisher_active_updated") {
+              return { collect };
+            }
+            throw new Error(`unexpected ${table} index ${indexName}`);
+          }),
+        })),
+      },
+    };
+
+    const resumedPage = await listPublishedPageHandler(ctx as never, {
+      handle: "preindex",
+      kind: "skill",
+      sort: "downloads",
+      paginationOpts: { cursor: "1", numItems: 1 },
+    });
+    rows = originalRows.map((row) => ({ ...row, statsDownloads: row.stats.downloads }));
+    const pageAfterBackfill = await listPublishedPageHandler(ctx as never, {
+      handle: "preindex",
+      kind: "skill",
+      sort: "downloads",
+      paginationOpts: { cursor: resumedPage.continueCursor, numItems: 1 },
+    });
+
+    expect(resumedPage.continueCursor).toBe("preindex:2");
+    expect([
+      "Old A",
+      ...resumedPage.page.map((item) => item.displayName),
+      ...pageAfterBackfill.page.map((item) => item.displayName),
+    ]).toEqual(["Old A", "Old B", "Old C"]);
+    expect(pageAfterBackfill.isDone).toBe(true);
+    expect(collect).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses complete profile counters without reading resource or star tables", async () => {
+    const publisher = {
+      _id: "publishers:openclaw",
+      _creationTime: 1,
+      kind: "org",
+      handle: "openclaw",
+      displayName: "OpenClaw",
+      publishedSkills: 3,
+      publishedPackages: 2,
+      totalInstalls: 50,
+      totalDownloads: 80,
+      totalStars: 7,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const queriedTables: string[] = [];
+    const ctx = {
+      db: {
+        query: vi.fn((table: string) => {
+          queriedTables.push(table);
+          return {
+            withIndex: vi.fn((indexName: string) => {
+              if (table === "publishers" && indexName === "by_handle") {
+                return { unique: vi.fn(async () => publisher) };
+              }
+              if (table === "officialPublishers" && indexName === "by_publisher") {
+                return { unique: vi.fn(async () => null) };
+              }
+              throw new Error(`unexpected ${table} index ${indexName}`);
+            }),
+          };
+        }),
+      },
+    };
+
+    const result = await getProfileByHandleHandler(ctx as never, { handle: "openclaw" });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        stats: { skills: 3, packages: 2, installs: 50, downloads: 80, stars: 7 },
+      }),
+    );
+    expect(result).not.toHaveProperty("publishedItems");
+    expect(queriedTables).not.toContain("skills");
+    expect(queriedTables).not.toContain("packages");
+    expect(queriedTables).not.toContain("stars");
   });
 
   it("computes OG metadata stats when publisher denormalized stats are missing", async () => {
@@ -3309,7 +3678,7 @@ describe("publishers membership controls", () => {
                 unique: vi.fn(async () => (fields.handle === "nvidia" ? publisher : null)),
               };
             }
-            if (table === "skills" && indexName === "by_owner_publisher_active_updated") {
+            if (table === "skills" && indexName === "by_owner_publisher_active_downloads") {
               return indexedRows(skillRows);
             }
             if (table === "packages" && indexName === "by_owner_publisher_active_updated") {
@@ -3326,6 +3695,7 @@ describe("publishers membership controls", () => {
 
     const result = await listPublishedPageHandler(ctx as never, {
       handle: "nvidia",
+      kind: "skill",
       paginationOpts: { cursor: null, numItems: 12 },
     });
 
@@ -3365,7 +3735,7 @@ describe("publishers membership controls", () => {
                 unique: vi.fn(async () => (fields.handle === "openclaw" ? publisher : null)),
               };
             }
-            if (table === "skills" && indexName === "by_owner_publisher_active_updated") {
+            if (table === "skills" && indexName === "by_owner_publisher_active_downloads") {
               return indexedRows([
                 {
                   _id: "skills:icon-skill",
@@ -3403,7 +3773,7 @@ describe("publishers membership controls", () => {
                 },
               ]);
             }
-            if (table === "packages" && indexName === "by_owner_publisher_active_updated") {
+            if (table === "packages" && indexName === "by_owner_publisher_active_downloads") {
               return indexedRows([
                 {
                   _id: "packages:plugin",
@@ -3458,10 +3828,19 @@ describe("publishers membership controls", () => {
       },
     };
 
-    const result = (await listPublishedPageHandler(ctx as never, {
+    const skillResult = await listPublishedPageHandler(ctx as never, {
       handle: "openclaw",
+      kind: "skill",
       paginationOpts: { cursor: null, numItems: 12 },
-    })) as unknown as {
+    });
+    const pluginResult = await listPublishedPageHandler(ctx as never, {
+      handle: "openclaw",
+      kind: "plugin",
+      paginationOpts: { cursor: null, numItems: 12 },
+    });
+    const result = {
+      page: [...skillResult.page, ...pluginResult.page],
+    } as unknown as {
       page: Array<{
         displayName: string;
         kind: "skill" | "plugin";
@@ -3737,7 +4116,7 @@ describe("publishers membership controls", () => {
     });
 
     expect(profile).toEqual(expect.objectContaining({ handle: "proof-banned-builder" }));
-    expect(profile).toEqual(expect.objectContaining({ starredCount: 1 }));
+    expect(profile).not.toHaveProperty("starredCount");
   });
 
   it("hides published items for a user publisher whose linked user is deleted", async () => {
@@ -3748,6 +4127,7 @@ describe("publishers membership controls", () => {
     await expect(
       listPublishedPageHandler(ctx as never, {
         handle: "proof-banned-builder",
+        kind: "skill",
         paginationOpts: { cursor: null, numItems: 12 },
       }),
     ).resolves.toEqual({ page: [], continueCursor: "", isDone: true });
@@ -3762,6 +4142,7 @@ describe("publishers membership controls", () => {
     await expect(
       listPublishedPageHandler(ctx as never, {
         handle: "proof-banned-builder",
+        kind: "skill",
         paginationOpts: { cursor: null, numItems: 12 },
       }),
     ).resolves.toEqual({ page: [], continueCursor: "", isDone: true });
@@ -6953,7 +7334,176 @@ describe("publisher bootstrap", () => {
     ]);
   });
 
-  it("returns every published item for mine listings so deletion confirmations are complete", async () => {
+  it("uses complete counters for mine summaries without reading resource tables", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:alice" as never);
+    const publisher = {
+      _id: "publishers:alice",
+      _creationTime: 1,
+      kind: "user",
+      handle: "alice",
+      displayName: "Alice",
+      linkedUserId: "users:alice",
+      publishedSkills: 4,
+      publishedPackages: 1,
+      totalInstalls: 14,
+      totalDownloads: 14,
+      totalStars: 0,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "users:alice") {
+            return {
+              _id: id,
+              personalPublisherId: publisher._id,
+              createdAt: 1,
+              updatedAt: 1,
+            };
+          }
+          return id === publisher._id ? publisher : null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table === "publisherMembers") {
+            return {
+              withIndex: vi.fn(() =>
+                indexedRows([
+                  {
+                    _id: "publisherMembers:alice",
+                    publisherId: publisher._id,
+                    userId: "users:alice",
+                    role: "owner",
+                  },
+                ]),
+              ),
+            };
+          }
+          if (table === "publishers") {
+            return {
+              withIndex: vi.fn(() => ({ unique: vi.fn(async () => publisher) })),
+            };
+          }
+          if (table === "officialPublishers") return emptyOfficialPublishersQuery();
+          throw new Error(`mine summary must not query ${table}`);
+        }),
+      },
+    };
+
+    const result = (await listMineHandler(ctx as never, {
+      includePublishedItems: false,
+    })) as Array<{
+      publisher: Record<string, unknown>;
+    }>;
+
+    expect(result[0]?.publisher).toEqual(
+      expect.objectContaining({
+        stats: { skills: 4, packages: 1, installs: 14, downloads: 14, stars: 0 },
+      }),
+    );
+    expect(result[0]?.publisher).not.toHaveProperty("publishedItems");
+  });
+
+  it("keeps complete published items for listMine callers without the lightweight opt-out", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:alice" as never);
+    const publisher = {
+      _id: "publishers:alice",
+      _creationTime: 1,
+      kind: "user",
+      handle: "alice",
+      displayName: "Alice",
+      linkedUserId: "users:alice",
+      publishedSkills: 1,
+      publishedPackages: 1,
+      totalInstalls: 3,
+      totalDownloads: 5,
+      totalStars: 0,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "users:alice") {
+            return { _id: id, personalPublisherId: publisher._id, createdAt: 1, updatedAt: 1 };
+          }
+          return id === publisher._id ? publisher : null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table === "publisherMembers") {
+            return {
+              withIndex: vi.fn(() =>
+                indexedRows([
+                  {
+                    _id: "publisherMembers:alice",
+                    publisherId: publisher._id,
+                    userId: "users:alice",
+                    role: "owner",
+                  },
+                ]),
+              ),
+            };
+          }
+          if (table === "publishers") {
+            return { withIndex: vi.fn(() => ({ unique: vi.fn(async () => publisher) })) };
+          }
+          if (table === "skills") {
+            return {
+              withIndex: vi.fn(() =>
+                indexedRows([
+                  {
+                    _id: "skills:alice-tool",
+                    _creationTime: 1,
+                    ownerPublisherId: publisher._id,
+                    softDeletedAt: undefined,
+                    moderationStatus: "active",
+                    displayName: "Alice Tool",
+                    updatedAt: 1,
+                    stats: {
+                      downloads: 3,
+                      stars: 0,
+                      installsCurrent: 1,
+                      installsAllTime: 1,
+                    },
+                  },
+                ]),
+              ),
+            };
+          }
+          if (table === "packages") {
+            return {
+              withIndex: vi.fn(() =>
+                indexedRows([
+                  {
+                    _id: "packages:alice-plugin",
+                    _creationTime: 2,
+                    ownerPublisherId: publisher._id,
+                    family: "code-plugin",
+                    softDeletedAt: undefined,
+                    displayName: "Alice Plugin",
+                    stats: { downloads: 2, stars: 0, installs: 2, versions: 1 },
+                  },
+                ]),
+              ),
+            };
+          }
+          if (table === "officialPublishers") return emptyOfficialPublishersQuery();
+          throw new Error(`unexpected table ${table}`);
+        }),
+      },
+    };
+
+    const result = (await listMineHandler(ctx as never, {})) as Array<{
+      publisher: { publishedItems: Array<{ displayName: string }> };
+    }>;
+
+    expect(result[0]?.publisher.publishedItems.map((item) => item.displayName)).toEqual([
+      "Alice Tool",
+      "Alice Plugin",
+    ]);
+  });
+
+  it("loads every published item only from deletion inventory", async () => {
     vi.mocked(getAuthUserId).mockResolvedValue("users:alice" as never);
     const publisher = {
       _id: "publishers:alice",
@@ -7056,17 +7606,58 @@ describe("publisher bootstrap", () => {
       },
     };
 
-    const result = (await listMineHandler(ctx as never, {} as never)) as Array<{
-      publisher: { publishedItems: Array<{ displayName: string }> };
-    }>;
+    const result = await getDeletionInventoryHandler(ctx as never, {});
 
-    expect(result[0]?.publisher.publishedItems.map((item) => item.displayName)).toEqual([
+    expect(result[0]?.publishedItems.map((item) => item.displayName)).toEqual([
       "Plugin 1",
       "Skill 4",
       "Skill 3",
       "Skill 2",
       "Skill 1",
     ]);
+  });
+
+  it("rejects organization deletion inventory for non-owners", async () => {
+    vi.mocked(getAuthUserId).mockResolvedValue("users:alice" as never);
+    const publisher = {
+      _id: "publishers:team",
+      kind: "org",
+      handle: "team",
+      displayName: "Team",
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const ctx = {
+      db: {
+        get: vi.fn(async (id: string) => {
+          if (id === "users:alice") return { _id: id, createdAt: 1, updatedAt: 1 };
+          return id === publisher._id ? publisher : null;
+        }),
+        query: vi.fn((table: string) => {
+          if (table !== "publisherMembers") {
+            throw new Error(`inventory authorization must not query ${table}`);
+          }
+          return {
+            withIndex: vi.fn((indexName: string) => {
+              if (indexName !== "by_publisher_user") {
+                throw new Error(`unexpected membership index ${indexName}`);
+              }
+              return {
+                unique: vi.fn(async () => ({
+                  publisherId: publisher._id,
+                  userId: "users:alice",
+                  role: "admin",
+                })),
+              };
+            }),
+          };
+        }),
+      },
+    };
+
+    await expect(
+      getDeletionInventoryHandler(ctx as never, { publisherId: publisher._id }),
+    ).rejects.toThrow("Forbidden");
   });
 });
 

--- a/convex/publishers.ts
+++ b/convex/publishers.ts
@@ -476,6 +476,110 @@ function normalizePublisherCatalogSort(sort?: PublisherCatalogSortArg): Publishe
   return sort === "recent" ? "recent" : "downloads";
 }
 
+type PublisherPageCursorMode = "indexed" | "legacy" | "preindex";
+
+function parsePublisherPageCursor(cursor: string | null): {
+  mode: PublisherPageCursorMode | null;
+  cursor: string | null;
+} {
+  if (!cursor) return { mode: null, cursor: null };
+  if (cursor.startsWith("indexed:")) {
+    return { mode: "indexed", cursor: cursor.slice("indexed:".length) };
+  }
+  if (cursor.startsWith("legacy:")) {
+    return { mode: "legacy", cursor: cursor.slice("legacy:".length) };
+  }
+  if (cursor.startsWith("preindex:")) {
+    return { mode: "preindex", cursor: cursor.slice("preindex:".length) };
+  }
+  return { mode: "preindex", cursor };
+}
+
+function encodePublisherPageCursor(mode: PublisherPageCursorMode, cursor: string, isDone: boolean) {
+  return isDone ? "" : `${mode}:${cursor}`;
+}
+
+function paginatePublisherItems(
+  items: PublisherCatalogItem[],
+  paginationOpts: { cursor: string | null; numItems: number },
+  mode: Exclude<PublisherPageCursorMode, "indexed">,
+) {
+  const offset = paginationOpts.cursor ? Number(paginationOpts.cursor) : 0;
+  const safeOffset = Number.isFinite(offset) && offset > 0 ? Math.trunc(offset) : 0;
+  const nextOffset = safeOffset + paginationOpts.numItems;
+  const isDone = nextOffset >= items.length;
+  return {
+    page: items.slice(safeOffset, nextOffset),
+    continueCursor: encodePublisherPageCursor(mode, String(nextOffset), isDone),
+    isDone,
+  };
+}
+
+function comparePublisherIndexOrder<T extends { _creationTime: number; updatedAt: number }>(
+  sort: PublisherCatalogSort,
+  readDownloads: (row: T) => number,
+) {
+  return (a: T, b: T) =>
+    sort === "recent"
+      ? b.updatedAt - a.updatedAt || b._creationTime - a._creationTime
+      : readDownloads(b) - readDownloads(a) ||
+        b.updatedAt - a.updatedAt ||
+        b._creationTime - a._creationTime;
+}
+
+function toPublisherSkillCatalogItem(
+  publisher: Doc<"publishers">,
+  skill: Doc<"skills">,
+  publisherOfficial: boolean,
+): PublisherCatalogItem {
+  return {
+    _id: skill._id,
+    kind: "skill",
+    slug: skill.slug,
+    displayName: skill.displayName,
+    summary: skill.summary ?? null,
+    topics: skill.topics,
+    categories: skill.categories,
+    inferredCategories: skill.inferredCategories,
+    latestVersionId: skill.latestVersionId,
+    inferredFromVersionId: skill.inferredFromVersionId,
+    icon: skill.icon ?? null,
+    href: `/${encodeURIComponent(publisher.handle)}/${encodeURIComponent(skill.slug)}`,
+    installs: readCanonicalStat(skill, "installsAllTime"),
+    downloads: readCanonicalStat(skill, "downloads"),
+    stars: readCanonicalStat(skill, "stars"),
+    isOfficial: publisherOfficial || Boolean(skill.badges?.official),
+    updatedAt: skill.updatedAt,
+    sourceBacked: skill.installKind === "github",
+    sourceId: skill.githubSourceId ?? null,
+    sourceRepo: null,
+    sourcePath: skill.githubPath ?? null,
+  };
+}
+
+function toPublisherPackageCatalogItem(
+  pkg: Doc<"packages">,
+  publisherOfficial: boolean,
+): PublisherCatalogItem {
+  return {
+    _id: pkg._id,
+    kind: "plugin",
+    displayName: pkg.displayName,
+    summary: pkg.summary ?? null,
+    topics: pkg.topics,
+    icon:
+      pkg.channel === "private" || isPackageBlockedFromPublic(pkg.scanStatus)
+        ? null
+        : (pkg.icon ?? null),
+    href: buildPluginDetailHref(pkg.name),
+    installs: pkg.stats.installs,
+    downloads: pkg.stats.downloads,
+    stars: pkg.stats.stars,
+    isOfficial: publisherOfficial || pkg.isOfficial,
+    updatedAt: pkg.updatedAt,
+  };
+}
+
 function getPublisherCatalogItems(
   publisher: Doc<"publishers">,
   rows: PublisherPublishedRows,
@@ -483,46 +587,8 @@ function getPublisherCatalogItems(
   sort: PublisherCatalogSort = "downloads",
 ): PublisherCatalogItem[] {
   return [
-    ...rows.skills.map((skill) => ({
-      _id: skill._id,
-      kind: "skill" as const,
-      slug: skill.slug,
-      displayName: skill.displayName,
-      summary: skill.summary ?? null,
-      topics: skill.topics,
-      categories: skill.categories,
-      inferredCategories: skill.inferredCategories,
-      latestVersionId: skill.latestVersionId,
-      inferredFromVersionId: skill.inferredFromVersionId,
-      icon: skill.icon ?? null,
-      href: `/${encodeURIComponent(publisher.handle)}/${encodeURIComponent(skill.slug)}`,
-      installs: readCanonicalStat(skill, "installsAllTime"),
-      downloads: readCanonicalStat(skill, "downloads"),
-      stars: readCanonicalStat(skill, "stars"),
-      isOfficial: publisherOfficial || Boolean(skill.badges?.official),
-      updatedAt: skill.updatedAt,
-      sourceBacked: skill.installKind === "github",
-      sourceId: skill.githubSourceId ?? null,
-      sourceRepo: null,
-      sourcePath: skill.githubPath ?? null,
-    })),
-    ...rows.packages.map((pkg) => ({
-      _id: pkg._id,
-      kind: "plugin" as const,
-      displayName: pkg.displayName,
-      summary: pkg.summary ?? null,
-      topics: pkg.topics,
-      icon:
-        pkg.channel === "private" || isPackageBlockedFromPublic(pkg.scanStatus)
-          ? null
-          : (pkg.icon ?? null),
-      href: buildPluginDetailHref(pkg.name),
-      installs: pkg.stats.installs,
-      downloads: pkg.stats.downloads,
-      stars: pkg.stats.stars,
-      isOfficial: publisherOfficial || pkg.isOfficial,
-      updatedAt: pkg.updatedAt,
-    })),
+    ...rows.skills.map((skill) => toPublisherSkillCatalogItem(publisher, skill, publisherOfficial)),
+    ...rows.packages.map((pkg) => toPublisherPackageCatalogItem(pkg, publisherOfficial)),
   ].sort(comparePublisherCatalogItems(sort));
 }
 
@@ -620,6 +686,11 @@ async function toPublisherListItem(
     ...(starredCount !== undefined ? { starredCount } : {}),
     ...(affiliations ? { affiliations } : {}),
   };
+}
+
+function withoutPublishedItems(item: PublisherListItem) {
+  const { publishedItems: _publishedItems, ...summary } = item;
+  return summary;
 }
 
 function toPublisherListSummary(publisher: Doc<"publishers">): PublisherListSummary | null {
@@ -2167,12 +2238,13 @@ export const resolvePublishTargetForUserInternal = internalMutation({
 });
 
 export const listMine = query({
-  args: {},
-  handler: async (ctx) => {
+  args: { includePublishedItems: v.optional(v.boolean()) },
+  handler: async (ctx, args) => {
     const userId = await getOptionalActiveAuthUserId(ctx);
     if (!userId) return [];
     const user = await ctx.db.get(userId);
     if (!user || user.deletedAt || user.deactivatedAt) return [];
+    const includePublishedItems = args.includePublishedItems !== false;
     const memberships = await ctx.db
       .query("publisherMembers")
       .withIndex("by_user", (q) => q.eq("userId", userId))
@@ -2188,14 +2260,14 @@ export const listMine = query({
         }
         const publicPublisher = publisher
           ? await toPublisherListItem(ctx, publisher, {
-              includePublishedItems: true,
-              includeAllPublishedItems: true,
+              includePublishedItems,
+              includeAllPublishedItems: includePublishedItems,
             })
           : null;
         if (!publicPublisher) return null;
         return {
           publisher: {
-            ...publicPublisher,
+            ...(includePublishedItems ? publicPublisher : withoutPublishedItems(publicPublisher)),
             imageStorageId: publisher?.imageStorageId,
           },
           role: publisher?.kind === "user" ? "owner" : membership.role,
@@ -2208,8 +2280,8 @@ export const listMine = query({
     const personalPublisherDoc = await getPersonalPublisherForUserOrFallback(ctx, user);
     const personalPublisher = personalPublisherDoc
       ? await toPublisherListItem(ctx, personalPublisherDoc, {
-          includePublishedItems: true,
-          includeAllPublishedItems: true,
+          includePublishedItems,
+          includeAllPublishedItems: includePublishedItems,
         })
       : null;
     if (
@@ -2218,13 +2290,68 @@ export const listMine = query({
     ) {
       visiblePublishers.unshift({
         publisher: {
-          ...personalPublisher,
+          ...(includePublishedItems ? personalPublisher : withoutPublishedItems(personalPublisher)),
           imageStorageId: personalPublisherDoc?.imageStorageId,
         },
         role: "owner",
       });
     }
     return visiblePublishers;
+  },
+});
+
+async function toPublisherDeletionInventory(
+  ctx: Pick<QueryCtx, "db">,
+  publisher: Doc<"publishers">,
+) {
+  if (!(await getPublicPublisherVisibility(ctx, publisher))) return null;
+  const rows = await getPublisherPublishedRows(ctx, publisher._id);
+  const stats = getIndexedPublisherStatsFromRows(rows);
+  return {
+    handle: publisher.handle,
+    stats: { skills: stats.skills, packages: stats.packages },
+    publishedItems: getPublisherPublishedItems(rows, Number.POSITIVE_INFINITY),
+  };
+}
+
+export const getDeletionInventory = query({
+  args: { publisherId: v.optional(v.id("publishers")) },
+  handler: async (ctx, args) => {
+    const userId = await getOptionalActiveAuthUserId(ctx);
+    if (!userId) return [];
+    const user = await ctx.db.get(userId);
+    if (!user || user.deletedAt || user.deactivatedAt) return [];
+
+    if (args.publisherId) {
+      const publisher = await ctx.db.get(args.publisherId);
+      if (!publisher || publisher.kind !== "org") throw new ConvexError("Publisher not found");
+      const membership = await getPublisherMembership(ctx, publisher._id, userId);
+      if (!membership || membership.role !== "owner") throw new ConvexError("Forbidden");
+      const inventory = await toPublisherDeletionInventory(ctx, publisher);
+      return inventory ? [inventory] : [];
+    }
+
+    const memberships = await ctx.db
+      .query("publisherMembers")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .collect();
+    const publishersById = new Map<Id<"publishers">, Doc<"publishers">>();
+    const personalPublisher = await getPersonalPublisherForUserOrFallback(ctx, user);
+    if (personalPublisher) publishersById.set(personalPublisher._id, personalPublisher);
+    for (const membership of memberships) {
+      if (membership.role !== "owner") continue;
+      const publisher = await ctx.db.get(membership.publisherId);
+      if (publisher?.kind === "org" && !publisher.deletedAt && !publisher.deactivatedAt) {
+        publishersById.set(publisher._id, publisher);
+      }
+    }
+
+    const inventories = await Promise.all(
+      [...publishersById.values()].map((publisher) => toPublisherDeletionInventory(ctx, publisher)),
+    );
+    return inventories.filter((inventory): inventory is NonNullable<(typeof inventories)[number]> =>
+      Boolean(inventory),
+    );
   },
 });
 
@@ -2270,12 +2397,11 @@ export const getProfileByHandle = query({
   handler: async (ctx, args) => {
     const publisher = await getPublisherByHandle(ctx, args.handle);
     if (!publisher || publisher.deletedAt || publisher.deactivatedAt) return null;
-    return await toPublisherListItem(ctx, publisher, {
-      forceComputedStats: true,
+    const item = await toPublisherListItem(ctx, publisher, {
       includeAffiliations: true,
-      includePublishedItems: true,
-      includeStarredCount: true,
     });
+    if (!item) return null;
+    return withoutPublishedItems(item);
   },
 });
 
@@ -2415,22 +2541,140 @@ export const listPublishedPage = query({
     }
     const visiblePublisher = visible.publisher;
 
-    const numItems = clampInt(args.paginationOpts.numItems, 1, 24);
-    const offset = args.paginationOpts.cursor ? Number(args.paginationOpts.cursor) : 0;
-    const safeOffset = Number.isFinite(offset) && offset > 0 ? Math.trunc(offset) : 0;
-    const items = getPublisherCatalogItems(
-      visiblePublisher,
-      await getPublisherPublishedRows(ctx, visiblePublisher._id),
-      await isOfficialPublisher(ctx, visiblePublisher),
-      normalizePublisherCatalogSort(args.sort),
-    ).filter((item) => !args.kind || item.kind === args.kind);
-    const nextOffset = safeOffset + numItems;
-    const page = items.slice(safeOffset, nextOffset);
+    const paginationOpts = {
+      ...args.paginationOpts,
+      numItems: clampInt(args.paginationOpts.numItems, 1, 24),
+    };
+    const sort = normalizePublisherCatalogSort(args.sort);
+    const publisherOfficial = await isOfficialPublisher(ctx, visiblePublisher);
 
+    if (!args.kind) {
+      const offset = args.paginationOpts.cursor ? Number(args.paginationOpts.cursor) : 0;
+      const safeOffset = Number.isFinite(offset) && offset > 0 ? Math.trunc(offset) : 0;
+      const items = getPublisherCatalogItems(
+        visiblePublisher,
+        await getPublisherPublishedRows(ctx, visiblePublisher._id),
+        publisherOfficial,
+        sort,
+      );
+      const nextOffset = safeOffset + paginationOpts.numItems;
+      return {
+        page: items.slice(safeOffset, nextOffset),
+        continueCursor: nextOffset < items.length ? String(nextOffset) : "",
+        isDone: nextOffset >= items.length,
+      };
+    }
+
+    const index =
+      sort === "recent"
+        ? "by_owner_publisher_active_updated"
+        : "by_owner_publisher_active_downloads";
+
+    if (args.kind === "skill") {
+      const cursorState = parsePublisherPageCursor(paginationOpts.cursor);
+      let cursorMode: PublisherPageCursorMode = cursorState.mode ?? "indexed";
+      if (sort === "downloads" && cursorState.mode === null) {
+        // Legacy rows can lack the indexed field while retaining canonical nested downloads.
+        const legacySkill = await ctx.db
+          .query("skills")
+          .withIndex("by_owner_publisher_active_downloads", (q) =>
+            q
+              .eq("ownerPublisherId", visiblePublisher._id)
+              .eq("softDeletedAt", undefined)
+              .eq("statsDownloads", undefined),
+          )
+          .first();
+        if (legacySkill) cursorMode = "legacy";
+      }
+
+      if (cursorMode !== "indexed") {
+        const skills = (
+          await ctx.db
+            .query("skills")
+            .withIndex("by_owner_publisher_active_updated", (q) =>
+              q.eq("ownerPublisherId", visiblePublisher._id).eq("softDeletedAt", undefined),
+            )
+            .collect()
+        ).filter(isPublicPublishedSkill);
+        const items =
+          cursorMode === "preindex"
+            ? skills
+                .map((skill) =>
+                  toPublisherSkillCatalogItem(visiblePublisher, skill, publisherOfficial),
+                )
+                .sort(comparePublisherCatalogItems(sort))
+            : skills
+                .sort(
+                  comparePublisherIndexOrder(sort, (skill) =>
+                    readCanonicalStat(skill, "downloads"),
+                  ),
+                )
+                .map((skill) =>
+                  toPublisherSkillCatalogItem(visiblePublisher, skill, publisherOfficial),
+                );
+        return paginatePublisherItems(
+          items,
+          {
+            cursor: cursorState.cursor,
+            numItems: paginationOpts.numItems,
+          },
+          cursorMode,
+        );
+      }
+
+      const result = await ctx.db
+        .query("skills")
+        .withIndex(index, (q) =>
+          q.eq("ownerPublisherId", visiblePublisher._id).eq("softDeletedAt", undefined),
+        )
+        .order("desc")
+        .paginate({ ...paginationOpts, cursor: cursorState.cursor });
+      return {
+        ...result,
+        continueCursor: encodePublisherPageCursor("indexed", result.continueCursor, result.isDone),
+        page: result.page
+          .filter(isPublicPublishedSkill)
+          .map((skill) => toPublisherSkillCatalogItem(visiblePublisher, skill, publisherOfficial)),
+      };
+    }
+
+    const cursorState = parsePublisherPageCursor(paginationOpts.cursor);
+    if (cursorState.mode === "legacy" || cursorState.mode === "preindex") {
+      const packages = await ctx.db
+        .query("packages")
+        .withIndex("by_owner_publisher_active_updated", (q) =>
+          q.eq("ownerPublisherId", visiblePublisher._id).eq("softDeletedAt", undefined),
+        )
+        .collect();
+      const items =
+        cursorState.mode === "preindex"
+          ? packages
+              .map((pkg) => toPublisherPackageCatalogItem(pkg, publisherOfficial))
+              .sort(comparePublisherCatalogItems(sort))
+          : packages
+              .sort(comparePublisherIndexOrder(sort, (pkg) => pkg.stats.downloads))
+              .map((pkg) => toPublisherPackageCatalogItem(pkg, publisherOfficial));
+      return paginatePublisherItems(
+        items,
+        {
+          cursor: cursorState.cursor,
+          numItems: paginationOpts.numItems,
+        },
+        cursorState.mode,
+      );
+    }
+
+    const result = await ctx.db
+      .query("packages")
+      .withIndex(index, (q) =>
+        q.eq("ownerPublisherId", visiblePublisher._id).eq("softDeletedAt", undefined),
+      )
+      .order("desc")
+      .paginate({ ...paginationOpts, cursor: cursorState.cursor });
     return {
-      page,
-      continueCursor: nextOffset < items.length ? String(nextOffset) : "",
-      isDone: nextOffset >= items.length,
+      ...result,
+      continueCursor: encodePublisherPageCursor("indexed", result.continueCursor, result.isDone),
+      page: result.page.map((pkg) => toPublisherPackageCatalogItem(pkg, publisherOfficial)),
     };
   },
 });

--- a/src/__tests__/user-profile-route.test.tsx
+++ b/src/__tests__/user-profile-route.test.tsx
@@ -253,6 +253,18 @@ describe("user profile route", () => {
     expect(args).toContainEqual(expect.objectContaining({ handle: "nvidia", sort: "downloads" }));
   });
 
+  it("keeps later indexed pages reachable when a page has no visible items", async () => {
+    const loadMore = vi.fn();
+    paginatedQueryMock.mockReturnValue({ loadMore, results: [], status: "CanLoadMore" });
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Load more" }));
+    expect(loadMore).toHaveBeenCalledWith(12);
+  });
+
   it("groups published items by topic and labels empty topics as uncategorized", async () => {
     paginatedQueryMock.mockReturnValue({
       loadMore: vi.fn(),

--- a/src/lib/publicUser.ts
+++ b/src/lib/publicUser.ts
@@ -44,6 +44,8 @@ export type PublicPublisherListItem = PublicPublisherSummary & {
   }>;
 };
 
+export type PublicPublisherProfileItem = Omit<PublicPublisherListItem, "publishedItems">;
+
 export type PublicPublisherCatalogItem = {
   _id: string;
   kind: "skill" | "plugin";

--- a/src/lib/slugRoute.ts
+++ b/src/lib/slugRoute.ts
@@ -2,7 +2,7 @@ import { api } from "../../convex/_generated/api";
 import { convexHttp } from "../convex/client";
 import { getOpenClawExtensionPackageName } from "./openClawExtensionSlugs";
 import { buildPluginDetailHref } from "./pluginRoutes";
-import type { PublicPublisherListItem } from "./publicUser";
+import type { PublicPublisherProfileItem } from "./publicUser";
 
 const OPENCLAW_HANDLE = "openclaw";
 
@@ -15,7 +15,7 @@ type PluginSlugRouteTarget = {
 type TopLevelSlugRouteTarget = {
   kind: "publisher";
   handle: string;
-  publisher: PublicPublisherListItem;
+  publisher: PublicPublisherProfileItem;
 };
 
 function normalizeSlug(slug: string) {
@@ -63,7 +63,7 @@ async function resolvePublisherHandle(handle: string) {
   try {
     return (await convexHttp.query(api.publishers.getProfileByHandle, {
       handle: normalized,
-    })) as PublicPublisherListItem | null;
+    })) as PublicPublisherProfileItem | null;
   } catch {
     return null;
   }

--- a/src/routes/-settings.test.tsx
+++ b/src/routes/-settings.test.tsx
@@ -137,11 +137,13 @@ function mockSignedInSettings({
   pendingInvites = [],
   myInvites = [],
   membersLoading = false,
+  deletionInventoryLoading = false,
 }: {
   search?: Record<string, unknown>;
   memberships?: Array<typeof orgMembership | typeof personalMembership>;
   members?: typeof orgMembers;
   membersLoading?: boolean;
+  deletionInventoryLoading?: boolean;
   pendingInvites?: PublisherInviteFixture[];
   myInvites?: PublisherInviteFixture[];
   githubSources?: Array<{
@@ -196,6 +198,9 @@ function mockSignedInSettings({
     if (args === "skip") return undefined;
     if (queryName === "tokens:listMine") return [];
     if (queryName === "publishers:listMine") return memberships;
+    if (queryName === "publishers:getDeletionInventory") {
+      return deletionInventoryLoading ? undefined : [];
+    }
     if (queryName === "publishers:listMembers" && membersLoading) return undefined;
     if (queryName === "publishers:listMembers") return members;
     if (queryName === "publishers:listInvitesForPublisher") return pendingInvites;
@@ -321,11 +326,30 @@ describe("Settings", () => {
     fireEvent.click(screen.getByRole("button", { name: "Delete organization" }));
 
     expect(await screen.findByText(/Permanently delete @openclaw/)).toBeTruthy();
+    expect(getLastQueryArgs("publishers:getDeletionInventory")).toEqual({
+      publisherId: "publisher_openclaw",
+    });
     fireEvent.click(screen.getByRole("button", { name: "Permanently delete organization" }));
 
     await waitFor(() =>
       expect(deleteOrg).toHaveBeenCalledWith({ publisherId: "publisher_openclaw" }),
     );
+  });
+
+  it("blocks organization deletion until its inventory loads", async () => {
+    mockSignedInSettings({
+      search: { view: "organizations" },
+      deletionInventoryLoading: true,
+    });
+
+    render(<Settings />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete organization" }));
+
+    expect(
+      (await screen.findByRole("button", { name: "Permanently delete organization" })).hasAttribute(
+        "disabled",
+      ),
+    ).toBe(true);
   });
 
   it("stops account-scoped queries before deleting the signed-in account", async () => {
@@ -341,9 +365,11 @@ describe("Settings", () => {
     render(<Settings />);
 
     expect(getLastQueryArgs("tokens:listMine")).toEqual({});
-    expect(getLastQueryArgs("publishers:listMine")).toEqual({});
+    expect(getLastQueryArgs("publishers:listMine")).toEqual({ includePublishedItems: false });
+    expect(getLastQueryArgs("publishers:getDeletionInventory")).toBe("skip");
     useQueryMock.mockClear();
     fireEvent.click(screen.getByRole("button", { name: "Delete account" }));
+    expect(getLastQueryArgs("publishers:getDeletionInventory")).toEqual({});
     fireEvent.click(await screen.findByRole("button", { name: "Permanently delete account" }));
 
     await waitFor(() => expect(deleteAccount).toHaveBeenCalled());
@@ -351,6 +377,23 @@ describe("Settings", () => {
       expect(getLastQueryArgs("tokens:listMine")).toBe("skip");
       expect(getLastQueryArgs("publishers:listMine")).toBe("skip");
     });
+  });
+
+  it("blocks account deletion until its inventory loads", async () => {
+    mockSignedInSettings({
+      search: { view: "danger" },
+      memberships: [personalMembership],
+      deletionInventoryLoading: true,
+    });
+
+    render(<Settings />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete account" }));
+
+    expect(
+      (await screen.findByRole("button", { name: "Permanently delete account" })).hasAttribute(
+        "disabled",
+      ),
+    ).toBe(true);
   });
 
   it("clears auth state and leaves settings after account deletion succeeds", async () => {

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -121,13 +121,20 @@ type PublisherMembership = {
       downloads: number;
       stars: number;
     };
-    publishedItems?: Array<{
-      kind: "skill" | "plugin";
-      displayName: string;
-      downloads: number;
-    }>;
   };
   role: "owner" | "admin" | "publisher";
+};
+
+type PublisherDeletionInventory = {
+  handle: string;
+  stats: {
+    skills: number;
+    packages: number;
+  };
+  publishedItems: Array<{
+    kind: "skill" | "plugin";
+    displayName: string;
+  }>;
 };
 
 type OrgMembersResult = {
@@ -260,7 +267,7 @@ export function Settings() {
   const revokeToken = useMutation(api.tokens.revoke);
   const publisherMemberships = useQuery(
     api.publishers.listMine,
-    shouldLoadAccountScopedQueries ? {} : "skip",
+    shouldLoadAccountScopedQueries ? { includePublishedItems: false } : "skip",
   ) as Array<PublisherMembership> | undefined;
   const createOrg = useMutation(api.publishers.createOrg);
   const deleteOrg = useMutation(api.publishers.deleteOrg);
@@ -368,9 +375,14 @@ export function Settings() {
       ? {}
       : "skip",
   ) as GitHubSkillSource[] | undefined;
-  const deletionPublishers = (publisherMemberships ?? []).filter(
-    (entry) => entry.publisher.kind === "user" || entry.role === "owner",
-  );
+  const deletionInventory = useQuery(
+    api.publishers.getDeletionInventory,
+    shouldLoadAccountScopedQueries && deleteOrgDialogOpen && selectedOrg
+      ? { publisherId: selectedOrg.publisher._id }
+      : shouldLoadAccountScopedQueries && deleteDialogOpen
+        ? {}
+        : "skip",
+  ) as PublisherDeletionInventory[] | undefined;
 
   useEffect(() => {
     if (!me) return;
@@ -1339,7 +1351,7 @@ export function Settings() {
                                     </DialogDescription>
                                   </DialogHeader>
                                   <DeletionResourceSummary
-                                    publishers={[selectedOrg]}
+                                    inventory={deletionInventory}
                                     emptyLabel="This organization has no published skills or plugins."
                                   />
                                   <DialogFooter>
@@ -1351,6 +1363,7 @@ export function Settings() {
                                     </Button>
                                     <Button
                                       variant="destructive"
+                                      disabled={deletionInventory === undefined}
                                       onClick={() => void onDeleteOrg()}
                                     >
                                       Permanently delete organization
@@ -1693,14 +1706,18 @@ export function Settings() {
                           </DialogDescription>
                         </DialogHeader>
                         <DeletionResourceSummary
-                          publishers={deletionPublishers}
+                          inventory={deletionInventory}
                           emptyLabel="No published skills or plugins are attached to your account."
                         />
                         <DialogFooter>
                           <Button variant="ghost" onClick={() => setDeleteDialogOpen(false)}>
                             Cancel
                           </Button>
-                          <Button variant="destructive" onClick={() => void onDelete()}>
+                          <Button
+                            variant="destructive"
+                            disabled={deletionInventory === undefined}
+                            onClick={() => void onDelete()}
+                          >
                             Permanently delete account
                           </Button>
                         </DialogFooter>
@@ -1756,24 +1773,32 @@ function formatGitHubSourceSyncToast(
 }
 
 function DeletionResourceSummary({
-  publishers,
+  inventory,
   emptyLabel,
 }: {
-  publishers: PublisherMembership[];
+  inventory: PublisherDeletionInventory[] | undefined;
   emptyLabel: string;
 }) {
-  const totals = publishers.reduce(
+  if (inventory === undefined) {
+    return (
+      <div className="rounded-[var(--oc-radius-control)] border border-status-error-fg/30 bg-status-error-bg px-3 py-3 text-sm text-[color:var(--ink-soft)]">
+        Loading published resources...
+      </div>
+    );
+  }
+
+  const totals = inventory.reduce(
     (acc, entry) => {
-      acc.skills += entry.publisher.stats?.skills ?? 0;
-      acc.plugins += entry.publisher.stats?.packages ?? 0;
+      acc.skills += entry.stats.skills;
+      acc.plugins += entry.stats.packages;
       return acc;
     },
     { skills: 0, plugins: 0 },
   );
-  const resources = publishers.flatMap((entry) =>
-    (entry.publisher.publishedItems ?? []).map((item) => ({
+  const resources = inventory.flatMap((entry) =>
+    entry.publishedItems.map((item) => ({
       ...item,
-      publisherHandle: entry.publisher.handle,
+      publisherHandle: entry.handle,
     })),
   );
   const totalResources = totals.skills + totals.plugins;

--- a/src/routes/user/$handle.tsx
+++ b/src/routes/user/$handle.tsx
@@ -72,7 +72,7 @@ import type {
   PublicPublisher,
   PublicPublisherCatalogDisplay,
   PublicPublisherCatalogItem,
-  PublicPublisherListItem,
+  PublicPublisherProfileItem,
   PublicSkill,
 } from "../../lib/publicUser";
 import { readPublicDownloadCount } from "../../lib/publicUser";
@@ -92,7 +92,7 @@ export const Route = createFileRoute("/user/$handle")({
     const { convexHttp } = await import("../../convex/client");
     const publisher = (await convexHttp.query(api.publishers.getProfileByHandle, {
       handle: params.handle,
-    })) as PublicPublisherListItem | null;
+    })) as PublicPublisherProfileItem | null;
     if (!publisher) throw notFound();
     return { publisher };
   },
@@ -166,15 +166,19 @@ function formatCatalogTabCount(value: number) {
 }
 
 export function resolveDefaultCatalogTab(
-  publisher: Pick<PublicPublisherListItem, "stats">,
+  publisher: Pick<PublicPublisherProfileItem, "stats">,
 ): Extract<ProfileCatalogTab, "skills" | "plugins"> {
   if (publisher.stats.skills > 0) return "skills";
   if (publisher.stats.packages > 0) return "plugins";
   return "skills";
 }
 
-function buildCatalogTabOptions(publisher: PublicPublisherListItem) {
-  const options = [
+function buildCatalogTabOptions(publisher: PublicPublisherProfileItem) {
+  const options: Array<{
+    value: ProfileCatalogTab;
+    label: string;
+    count?: string;
+  }> = [
     {
       value: "skills",
       label: "Skills",
@@ -190,7 +194,10 @@ function buildCatalogTabOptions(publisher: PublicPublisherListItem) {
     options.push({
       value: "stars",
       label: "Starred",
-      count: formatCatalogTabCount(publisher.starredCount ?? 0),
+      count:
+        publisher.starredCount === undefined
+          ? undefined
+          : formatCatalogTabCount(publisher.starredCount),
     });
   }
   return options;
@@ -265,7 +272,9 @@ type PublisherStatCard = {
   icon: LucideIcon;
 };
 
-export function buildPublisherStatCards(publisher: PublicPublisherListItem): PublisherStatCard[] {
+export function buildPublisherStatCards(
+  publisher: PublicPublisherProfileItem,
+): PublisherStatCard[] {
   return [
     {
       key: "downloads",
@@ -396,7 +405,7 @@ function PublisherProfileMembers({
 function PublisherProfile() {
   const { handle } = Route.useParams();
   const { publisher: loaderPublisher } = Route.useLoaderData() as {
-    publisher: PublicPublisherListItem;
+    publisher: PublicPublisherProfileItem;
   };
   return <PublisherProfilePage handle={handle} loaderPublisher={loaderPublisher} />;
 }
@@ -462,7 +471,7 @@ function PublisherProfileChromeActions({
   );
 }
 
-function PublisherProfileChromeIdentity({ publisher }: { publisher: PublicPublisherListItem }) {
+function PublisherProfileChromeIdentity({ publisher }: { publisher: PublicPublisherProfileItem }) {
   return (
     <div className="publisher-profile-chrome-identity">
       <div className="publisher-profile-avatar">
@@ -498,7 +507,7 @@ export function PublisherProfilePage({
   loaderPublisher,
 }: {
   handle: string;
-  loaderPublisher: PublicPublisherListItem;
+  loaderPublisher: PublicPublisherProfileItem;
 }) {
   const { isAuthenticated, me } = useAuthStatus();
   const { signIn } = useAuthActions();
@@ -534,7 +543,7 @@ export function PublisherProfilePage({
   }, [handle, catalogTab, apiSort]);
 
   const queriedPublisher = useQuery(api.publishers.getProfileByHandle, { handle }) as
-    | PublicPublisherListItem
+    | PublicPublisherProfileItem
     | null
     | undefined;
   const publisher = queriedPublisher === undefined ? loaderPublisher : queriedPublisher;
@@ -641,7 +650,7 @@ export function PublisherProfilePage({
     setIsReportDialogOpen(true);
   };
 
-  const submitPublisherReport = async (reportedPublisher: PublicPublisherListItem) => {
+  const submitPublisherReport = async (reportedPublisher: PublicPublisherProfileItem) => {
     const trimmedReason = reportReason.trim();
     if (!trimmedReason) {
       setReportError("Report reason required.");
@@ -937,13 +946,20 @@ export function PublisherProfilePage({
                 <EmptyState
                   icon={catalogSearch.trim().length > 0 ? Search : undefined}
                   title={
-                    catalogSearch.trim().length > 0
-                      ? "No matching items"
-                      : catalogTab === "stars"
-                        ? "No starred items yet"
-                        : catalogTab === "plugins"
-                          ? "No published plugins yet"
-                          : "No published skills yet"
+                    showCatalogLoadMore
+                      ? "No visible items on this page"
+                      : catalogSearch.trim().length > 0
+                        ? "No matching items"
+                        : catalogTab === "stars"
+                          ? "No starred items yet"
+                          : catalogTab === "plugins"
+                            ? "No published plugins yet"
+                            : "No published skills yet"
+                  }
+                  action={
+                    showCatalogLoadMore
+                      ? { label: "Load more", onClick: () => activeLoadMore(12) }
+                      : undefined
                   }
                 />
               )}


### PR DESCRIPTION
## Summary

- In this PR, publisher profiles and settings use denormalized counters when they are complete, with the existing table reads retained as a fallback for legacy rows.
- Publisher memberships return lightweight summaries, while the exact deletion inventory is loaded only after the destructive dialog opens.
- Publisher catalog pagination selects one resource kind per request, uses the matching index, and keeps legacy numeric cursors resumable without mixing cursor modes.
- This is a partial step for #3064: `getPublishedDisplayManifest` remains unbounded, and this PR does not add a `starredCount` migration or a mixed skill/plugin cursor.

## Linked Issue

- Refs #3064
- Related #2925

## Screenshots

- [x] Real ClawHub profile/catalog and account-deletion inventory proof attached in the PR proof comment.

## Behavioural Proof

- [x] In the proposed candidate, a seeded publisher profile rendered 12 of 14 skills on the first page, then all 14 after pagination, without duplicate or missing items.
- [x] As the seeded `@local` owner, Settings → Account deletion loaded the exact 2-skill/3-plugin inventory only after the dialog opened; the dialog was cancelled and no deletion was confirmed.

## Security / Trust Impact

- [x] No security/trust impact. Existing publisher visibility, ownership authorization, and deletion mutations are unchanged.

## Data / Deploy Impact

- [x] No data migration or production deploy. Legacy rows continue through the fallback path.

## Verification

- [x] `bun run ci:static`
- [x] Focused tests: `bun run test -- convex/publishers.test.ts src/routes/-settings.test.tsx src/__tests__/user-profile-route.test.tsx src/components/PublisherListItem.test.tsx src/__tests__/home-popular-publishers-section.test.tsx src/lib/slugRoute.test.ts`
- [x] `bun run ci:unit`
- [x] `bun run ci:types-build`
- [x] `bunx convex codegen`
- [x] `git diff --check`
