### PR TITLE
feat: forward package catalog metadata in publish workflow

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -67,10 +67,20 @@ on:
         description: Optional comma-separated plugin category slugs.
         required: false
         type: string
+      clear_categories:
+        description: Clear existing plugin categories. Cannot be combined with categories.
+        required: false
+        type: boolean
+        default: false
       topics:
         description: Optional comma-separated catalog topics.
         required: false
         type: string
+      clear_topics:
+        description: Clear existing catalog topics. Cannot be combined with topics.
+        required: false
+        type: boolean
+        default: false
       source_repo:
         description: Optional source repo override for local-folder publishes.
         required: false
@@ -326,7 +336,9 @@ jobs:
           INPUT_TAGS: ${{ inputs.tags }}
           INPUT_CHANGELOG: ${{ inputs.changelog }}
           INPUT_CATEGORIES: ${{ inputs.categories }}
+          INPUT_CLEAR_CATEGORIES: ${{ inputs.clear_categories }}
           INPUT_TOPICS: ${{ inputs.topics }}
+          INPUT_CLEAR_TOPICS: ${{ inputs.clear_topics }}
           INPUT_SOURCE_REPO: ${{ inputs.source_repo }}
           INPUT_SOURCE_COMMIT: ${{ inputs.source_commit }}
           INPUT_SOURCE_REF: ${{ inputs.source_ref }}
@@ -495,7 +507,13 @@ jobs:
           tags = os.environ["INPUT_TAGS"].strip()
           changelog = os.environ["INPUT_CHANGELOG"].strip()
           categories = os.environ["INPUT_CATEGORIES"].strip()
+          clear_categories = os.environ["INPUT_CLEAR_CATEGORIES"].strip().lower() == "true"
           topics = os.environ["INPUT_TOPICS"].strip()
+          clear_topics = os.environ["INPUT_CLEAR_TOPICS"].strip().lower() == "true"
+          if categories and clear_categories:
+              raise SystemExit("categories and clear_categories cannot be combined")
+          if topics and clear_topics:
+              raise SystemExit("topics and clear_topics cannot be combined")
           if owner:
               cmd += ["--owner", owner]
           if family:
@@ -513,8 +531,12 @@ jobs:
               cmd += ["--changelog", changelog]
           if categories:
               cmd += ["--categories", categories]
+          elif clear_categories:
+              cmd += ["--categories", ""]
           if topics:
               cmd += ["--topics", topics]
+          elif clear_topics:
+              cmd += ["--topics", ""]
           source_repo = os.environ["INPUT_SOURCE_REPO"].strip()
           source_commit = os.environ["INPUT_SOURCE_COMMIT"].strip()
           source_ref = os.environ["INPUT_SOURCE_REF"].strip()

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -59,6 +59,18 @@ on:
         required: false
         type: string
         default: latest
+      changelog:
+        description: Optional release changelog shown on ClawHub.
+        required: false
+        type: string
+      categories:
+        description: Optional comma-separated plugin category slugs.
+        required: false
+        type: string
+      topics:
+        description: Optional comma-separated catalog topics.
+        required: false
+        type: string
       source_repo:
         description: Optional source repo override for local-folder publishes.
         required: false
@@ -312,6 +324,9 @@ jobs:
           INPUT_FAMILY: ${{ inputs.family }}
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_TAGS: ${{ inputs.tags }}
+          INPUT_CHANGELOG: ${{ inputs.changelog }}
+          INPUT_CATEGORIES: ${{ inputs.categories }}
+          INPUT_TOPICS: ${{ inputs.topics }}
           INPUT_SOURCE_REPO: ${{ inputs.source_repo }}
           INPUT_SOURCE_COMMIT: ${{ inputs.source_commit }}
           INPUT_SOURCE_REF: ${{ inputs.source_ref }}
@@ -478,6 +493,9 @@ jobs:
           family = os.environ["INPUT_FAMILY"].strip()
           version = os.environ["INPUT_VERSION"].strip()
           tags = os.environ["INPUT_TAGS"].strip()
+          changelog = os.environ["INPUT_CHANGELOG"].strip()
+          categories = os.environ["INPUT_CATEGORIES"].strip()
+          topics = os.environ["INPUT_TOPICS"].strip()
           if owner:
               cmd += ["--owner", owner]
           if family:
@@ -491,6 +509,12 @@ jobs:
               cmd += ["--version", version]
           if tags:
               cmd += ["--tags", tags]
+          if changelog:
+              cmd += ["--changelog", changelog]
+          if categories:
+              cmd += ["--categories", categories]
+          if topics:
+              cmd += ["--topics", topics]
           source_repo = os.environ["INPUT_SOURCE_REPO"].strip()
           source_commit = os.environ["INPUT_SOURCE_COMMIT"].strip()
           source_ref = os.environ["INPUT_SOURCE_REF"].strip()

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -797,12 +797,12 @@ jobs:
       clawhub_token: ${{ secrets.CLAWHUB_TOKEN }}
 ```
 
-To attach release and catalog metadata, pass the matching CLI values to either
-job:
+To attach release and catalog metadata, add the matching CLI values to the
+job's existing `with` block. Keep `dry_run: true` on pull-request jobs; use
+`dry_run: false` only on the trusted publish job shown above.
 
 ```yaml
 with:
-  dry_run: false
   changelog: "Describe the changes in this release."
   categories: "tools"
   topics: "automation,productivity"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -797,11 +797,26 @@ jobs:
       clawhub_token: ${{ secrets.CLAWHUB_TOKEN }}
 ```
 
+To attach release and catalog metadata, pass the matching CLI values to either
+job:
+
+```yaml
+with:
+  dry_run: false
+  changelog: "Describe the changes in this release."
+  categories: "tools"
+  topics: "automation,productivity"
+```
+
 Notes:
 
 - The reusable workflow defaults `source` to the caller repo.
 - For monorepos, pass `source_path` so the workflow publishes the plugin
   package folder, for example `source_path: extensions/codex`.
+- `changelog`, `categories`, and `topics` are optional. When present, the
+  workflow forwards them to the matching package publish CLI flags. Categories
+  and topics use comma-separated values; omitting them preserves the existing
+  workflow behavior.
 - Pin the reusable workflow to a stable tag or full commit SHA. Do not run release publishing from `@main`.
 - `pull_request` should use `dry_run: true` so CI stays non-polluting.
 - Real publishes should be limited to trusted events such as `workflow_dispatch` or tag pushes.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -817,6 +817,9 @@ Notes:
   workflow forwards them to the matching package publish CLI flags. Categories
   and topics use comma-separated values; omitting them preserves the existing
   workflow behavior.
+- To remove previously declared metadata, set `clear_categories: true` or
+  `clear_topics: true`. A clear input cannot be combined with its matching
+  value input.
 - Pin the reusable workflow to a stable tag or full commit SHA. Do not run release publishing from `@main`.
 - `pull_request` should use `dry_run: true` so CI stays non-polluting.
 - Real publishes should be limited to trusted events such as `workflow_dispatch` or tag pushes.

--- a/src/__tests__/package-publish-workflow.test.ts
+++ b/src/__tests__/package-publish-workflow.test.ts
@@ -186,4 +186,32 @@ describe("package publish workflow", () => {
     expect(workflow).not.toContain("Prebuilt artifact mode does not accept source_path");
     expect(workflow).toContain('cmd += ["--source-path", source_path]');
   });
+
+  it("forwards optional catalog metadata and changelog inputs", () => {
+    const workflowText = readFileSync(resolve(".github/workflows/package-publish.yml"), "utf8");
+    const workflow = parseYaml(workflowText) as {
+      on?: {
+        workflow_call?: {
+          inputs?: Record<string, { required?: boolean; type?: string }>;
+        };
+      };
+      jobs?: {
+        publish?: {
+          steps?: Array<{ name?: string; env?: Record<string, string>; run?: string }>;
+        };
+      };
+    };
+    const inputs = workflow.on?.workflow_call?.inputs;
+    const resolveStep = workflow.jobs?.publish?.steps?.find(
+      (step) => step.name === "Resolve publish command",
+    );
+
+    for (const name of ["changelog", "categories", "topics"]) {
+      const envName = `INPUT_${name.toUpperCase()}`;
+      expect(inputs?.[name]).toMatchObject({ required: false, type: "string" });
+      expect(resolveStep?.env?.[envName]).toBe(`\${{ inputs.${name} }}`);
+      expect(resolveStep?.run).toContain(`${name} = os.environ["${envName}"].strip()`);
+      expect(resolveStep?.run).toContain(`if ${name}:\n    cmd += ["--${name}", ${name}]`);
+    }
+  });
 });

--- a/src/__tests__/package-publish-workflow.test.ts
+++ b/src/__tests__/package-publish-workflow.test.ts
@@ -213,5 +213,23 @@ describe("package publish workflow", () => {
       expect(resolveStep?.run).toContain(`${name} = os.environ["${envName}"].strip()`);
       expect(resolveStep?.run).toContain(`if ${name}:\n    cmd += ["--${name}", ${name}]`);
     }
+
+    for (const name of ["categories", "topics"]) {
+      const clearName = `clear_${name}`;
+      const envName = `INPUT_CLEAR_${name.toUpperCase()}`;
+      expect(inputs?.[clearName]).toMatchObject({
+        required: false,
+        type: "boolean",
+        default: false,
+      });
+      expect(resolveStep?.env?.[envName]).toBe(`\${{ inputs.${clearName} }}`);
+      expect(resolveStep?.run).toContain(
+        `${clearName} = os.environ["${envName}"].strip().lower() == "true"`,
+      );
+      expect(resolveStep?.run).toContain(
+        `if ${name} and ${clearName}:\n    raise SystemExit("${name} and ${clearName} cannot be combined")`,
+      );
+      expect(resolveStep?.run).toContain(`elif ${clearName}:\n    cmd += ["--${name}", ""]`);
+    }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The ClawHub CLI already accepts `--changelog`, `--categories`, and `--topics` for package publishes, but the official reusable GitHub Actions workflow does not expose them. Trusted OIDC callers therefore cannot set release/catalog metadata without replacing the supported workflow or falling back to a long-lived token.

This surfaced in [`sergiopesch/raspberry-pi-maker#4`](https://github.com/sergiopesch/raspberry-pi-maker/pull/4): a direct CLI workflow could carry the fields, but ClawHub's trusted-publisher verifier rejected that route. [`sergiopesch/raspberry-pi-maker#5`](https://github.com/sergiopesch/raspberry-pi-maker/pull/5) restored the official reusable workflow and left the catalog metadata gap unresolved.

## Why This Change Was Made

- Keep the official reusable workflow as the single supported OIDC publishing path.
- Expose the CLI's existing metadata contract without adding permissions, secrets, or a second publish implementation.
- Preserve every existing caller: all three inputs are optional and omitted values add no CLI flags.
- Keep parsing and validation in the CLI, which already owns category/topic semantics.

## User Impact

Plugin repositories can publish changelog text, category slugs, and topics through the supported secretless workflow. Existing callers that omit the inputs behave exactly as before.

## Summary

- Add optional string inputs for `changelog`, `categories`, and `topics`.
- Forward non-empty values through the existing environment-backed, `shlex`-quoted command builder.
- Strengthen the workflow contract test around the exact input → environment → conditional CLI flag path.
- Add a copy-ready documentation example and explicitly document omitted-input behavior.

## Behavioural Proof

Exact revision: `6f34a65f328f938326c7826463a2311edc325d72`

- [Secretless Raspberry Pi Maker proof run](https://github.com/sergiopesch/raspberry-pi-maker/actions/runs/29866192179)
  - Real reusable-workflow dry run with all three metadata inputs.
  - Real reusable-workflow dry run with all three inputs omitted.
  - Both calls pin the ClawHub PR and Raspberry Pi package by full commit SHA and hardcode `dry_run: true`.
  - The run logs show the supplied inputs and the generated package-publish command; the control omits the three flags.
- [Raspberry Pi Maker caller CI](https://github.com/sergiopesch/raspberry-pi-maker/actions/runs/29866191172)
- [Existing Raspberry Pi Maker package workflow](https://github.com/sergiopesch/raspberry-pi-maker/actions/runs/29866192661)

The temporary evidence harness was [`sergiopesch/raspberry-pi-maker#8`](https://github.com/sergiopesch/raspberry-pi-maker/pull/8). It used no repository secrets and is now closed with its remote branch removed; the immutable run evidence remains available.

## Security / Trust Impact

- [x] No security/trust impact

No permissions or secret handling changed. Inputs cross the workflow boundary as strings, enter the existing Python argument list through environment variables, and are shell-escaped by the existing `shlex.quote` path. The live proof uses only `actions: read`, `contents: read`, and the workflow's existing `id-token: write` permission.

## Data / Deploy Impact

- [x] No data/deploy impact

No schema, migration, configuration, or rollout change. The workflow remains additive and backward-compatible for callers that omit the new inputs.

## Evidence

- `bun run docs:list`
- `bunx vitest run src/__tests__/package-publish-workflow.test.ts` (5 passed)
- Deterministic `ci:static` components: peer checks, generated-doc check, formatting, lint, dead-code checks, and release-workflow action-pin checks
- `bun run ci:unit` (4,873 passed, 1 skipped)
- `bun run ci:packages` (468 passed across package suites)
- Clean structured autoreview of the full branch: no accepted/actionable findings
- [Fork secret scan for the exact PR revision](https://github.com/sergiopesch/clawhub/actions/runs/29865683102)

`bun run ci:static` currently stops at `bun audit` on two newly reported advisories in dependencies unchanged by this PR (`dompurify` GHSA-c2j3-45gr-mqc4 and `fast-uri` GHSA-4c8g-83qw-93j6). The proof run records that audit result and runs every deterministic static component separately.

## Verification

- [ ] `bun run ci:static` (dependency audit blocker documented above)
- [x] Focused tests for touched behavior
- [x] `bun run ci:unit`
- [x] Broader package gate: `bun run ci:packages`
- [x] Real reusable-workflow behavior proof
- [x] Screenshots/recordings: N/A (workflow-only change)

## AI Assistance

This contribution was AI-assisted. The implementation was manually traced through the reusable workflow, CLI option declarations, package payload builder, adjacent tests, GitHub reusable-workflow/OIDC contracts, and a real secretless Raspberry Pi Maker caller run. The author can maintain the resulting three-input workflow extension.
