### PR TITLE
fix: settings page fails to load when the deployed backend predates the listMine args change

### DIFF
--- a/src/routes/-settings.test.tsx
+++ b/src/routes/-settings.test.tsx
@@ -365,7 +365,7 @@ describe("Settings", () => {
     render(<Settings />);
 
     expect(getLastQueryArgs("tokens:listMine")).toEqual({});
-    expect(getLastQueryArgs("publishers:listMine")).toEqual({ includePublishedItems: false });
+    expect(getLastQueryArgs("publishers:listMine")).toEqual({});
     expect(getLastQueryArgs("publishers:getDeletionInventory")).toBe("skip");
     useQueryMock.mockClear();
     fireEvent.click(screen.getByRole("button", { name: "Delete account" }));

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -265,9 +265,13 @@ export function Settings() {
     | undefined;
   const createToken = useMutation(api.tokens.create);
   const revokeToken = useMutation(api.tokens.revoke);
+  // Deploy-skew safety: `includePublishedItems` only exists on newer backend
+  // deployments, and Convex rejects unknown args — sending it while an older
+  // backend is live breaks all of /settings ("Server Error"). Omit it until
+  // the arg has been in production long enough to be assumed everywhere.
   const publisherMemberships = useQuery(
     api.publishers.listMine,
-    shouldLoadAccountScopedQueries ? { includePublishedItems: false } : "skip",
+    shouldLoadAccountScopedQueries ? {} : "skip",
   ) as Array<PublisherMembership> | undefined;
   const createOrg = useMutation(api.publishers.createOrg);
   const deleteOrg = useMutation(api.publishers.deleteOrg);


### PR DESCRIPTION
## What Problem This Solves

Signed-in users currently get the global error boundary on `/settings`:

```
Something went wrong
[CONVEX Q(publishers:listMine)] Server Error Called by client
```

#3073 made the settings route pass `{ includePublishedItems: false }` to `publishers:listMine`, but Convex validators reject unknown arguments. Whenever the deployed web app is newer than the deployed Convex backend — true in production right now — the whole settings route error-boundaries for every signed-in user.

Verifiable from anywhere (unauthenticated):

```bash
# what the settings route sends today → error on the live backend
curl -s -X POST https://wry-manatee-359.convex.cloud/api/query \
  -H 'Content-Type: application/json' \
  -d '{"path":"publishers:listMine","args":{"includePublishedItems":false},"format":"json"}'
# → {"status":"error","errorMessage":"[Request ID: …] Server Error"}

# legacy args → success (deployed validator still has args: {})
curl -s -X POST https://wry-manatee-359.convex.cloud/api/query \
  -H 'Content-Type: application/json' \
  -d '{"path":"publishers:listMine","args":{},"format":"json"}'
# → {"status":"success","value":[]}
```

## What This Changes

The settings route omits the argument and passes `{}`, which both backend generations accept — the new backend defaults `includePublishedItems` to `true`, so rendering is unchanged and the page works regardless of deploy order. A brief comment marks the rollout hazard. The lightweight-list optimization from #3073 can be reintroduced once the new validator is verifiably live in production.

Even after the backend catches up, this keeps `/settings` resilient to the frontend-ahead-of-backend deploy window that any future arg addition reopens.

Tests: `src/routes/-settings.test.tsx` updated (24/24 passing); biome clean.

Related: #3064