### PR TITLE
fix: use platform percentiles for temporal abuse signals

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -143,6 +143,7 @@ import type * as promotionsFeed from "../promotionsFeed.js";
 import type * as publishAttempts from "../publishAttempts.js";
 import type * as publisherAbuse from "../publisherAbuse.js";
 import type * as publisherAbuseDevSeed from "../publisherAbuseDevSeed.js";
+import type * as publisherAbuseTemporalScan from "../publisherAbuseTemporalScan.js";
 import type * as publishers from "../publishers.js";
 import type * as rateLimits from "../rateLimits.js";
 import type * as retention from "../retention.js";
@@ -306,6 +307,7 @@ declare const fullApi: ApiFromModules<{
   publishAttempts: typeof publishAttempts;
   publisherAbuse: typeof publisherAbuse;
   publisherAbuseDevSeed: typeof publisherAbuseDevSeed;
+  publisherAbuseTemporalScan: typeof publisherAbuseTemporalScan;
   publishers: typeof publishers;
   rateLimits: typeof rateLimits;
   retention: typeof retention;

--- a/convex/crons.test.ts
+++ b/convex/crons.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => {
   const publisherAbuseSignalNotificationsRef = Symbol("publisher-abuse-signal-notifications");
   const publisherAbuseScoreRefreshRef = Symbol("publisher-abuse-score-refresh");
   const publisherTemporalAbuseScanRef = Symbol("publisher-temporal-abuse-scan");
+  const publisherTemporalAbuseScanPruneRef = Symbol("publisher-temporal-abuse-scan-prune");
   const httpRateLimitKeysPruneRef = Symbol("http-rate-limit-keys-prune");
   const skillStatEventPruneRef = Symbol("skill-stat-event-prune");
   const packageStatEventPruneRef = Symbol("package-stat-event-prune");
@@ -26,6 +27,7 @@ const mocks = vi.hoisted(() => {
     publisherAbuseSignalNotificationsRef,
     publisherAbuseScoreRefreshRef,
     publisherTemporalAbuseScanRef,
+    publisherTemporalAbuseScanPruneRef,
     httpRateLimitKeysPruneRef,
     skillStatEventPruneRef,
     packageStatEventPruneRef,
@@ -68,9 +70,12 @@ vi.mock("./_generated/api", () => ({
     },
     publisherAbuse: {
       runPublisherAbuseScoreRunInternal: mocks.publisherAbuseScoreRefreshRef,
-      runTemporalPublisherAbuseScanInternal: mocks.publisherTemporalAbuseScanRef,
       notifyPublisherAbuseSignalChangesInternal: mocks.publisherAbuseSignalNotificationsRef,
       processPublisherAbuseAutobansInternal: mocks.publisherAbuseAutobanRef,
+    },
+    publisherAbuseTemporalScan: {
+      runScheduledTemporalPublisherAbuseScanInternal: mocks.publisherTemporalAbuseScanRef,
+      pruneExpiredTemporalScanRowsInternal: mocks.publisherTemporalAbuseScanPruneRef,
     },
     promotionsFeed: {
       publishInternal: mocks.promotionsFeedPublishRef,
@@ -215,15 +220,13 @@ describe("crons", () => {
       "publisher-temporal-abuse-scan",
       { hours: 24 },
       mocks.publisherTemporalAbuseScanRef,
-      {
-        mode: "current",
-        dryRun: true,
-        archiveDryRunSignals: true,
-        candidateLimit: 1_000,
-        batchSize: 50,
-        maxPages: 20,
-        trigger: "cron",
-      },
+      {},
+    );
+    expect(mocks.interval).toHaveBeenCalledWith(
+      "publisher-temporal-abuse-scan-row-prune",
+      { hours: 24 },
+      mocks.publisherTemporalAbuseScanPruneRef,
+      { batchSize: 500 },
     );
     expect(mocks.interval).toHaveBeenCalledWith(
       "publisher-abuse-autobans",

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -114,16 +114,15 @@ if (process.env.CLAWHUB_DISABLE_CRONS !== "1" && process.env.CLAWHUB_PREVIEW !==
   crons.interval(
     "publisher-temporal-abuse-scan",
     { hours: 24 },
-    internal.publisherAbuse.runTemporalPublisherAbuseScanInternal,
-    {
-      mode: "current",
-      dryRun: true,
-      archiveDryRunSignals: true,
-      candidateLimit: 1_000,
-      batchSize: 50,
-      maxPages: 20,
-      trigger: "cron",
-    },
+    internal.publisherAbuseTemporalScan.runScheduledTemporalPublisherAbuseScanInternal,
+    {},
+  );
+
+  crons.interval(
+    "publisher-temporal-abuse-scan-row-prune",
+    { hours: 24 },
+    internal.publisherAbuseTemporalScan.pruneExpiredTemporalScanRowsInternal,
+    { batchSize: 500 },
   );
 
   crons.interval(

--- a/convex/lib/publisherAbuseScoring.test.ts
+++ b/convex/lib/publisherAbuseScoring.test.ts
@@ -435,17 +435,17 @@ describe("publisher abuse scoring", () => {
       }),
       dailyStats: [
         ...dailyRange(64, 30, { downloads: 5, installs: 0 }),
-        ...dailyRange(94, 7, { downloads: 200, installs: 0 }),
+        ...dailyRange(94, 7, { downloads: 400, installs: 0 }),
       ],
     });
 
     expect(score.spike).toBe(true);
     expect(score.sustained).toBe(false);
-    expect(score.recent7Downloads).toBe(1_400);
+    expect(score.recent7Downloads).toBe(2_800);
     expect(score.recent7Installs).toBe(0);
     expect(score.previous30Downloads).toBe(150);
-    expect(score.spikeMultiplier).toBeCloseTo(14);
-    expect(score.spikeMultiplierCohortBand).toBe("p95");
+    expect(score.spikeMultiplier).toBeCloseTo(28);
+    expect(score.spikeMultiplierCohortBand).toBe("p99");
     expect(score.reasonCodes).toContain("temporal_download_spike_flat_installs");
   });
 
@@ -455,7 +455,7 @@ describe("publisher abuse scoring", () => {
       todayDay,
       benchmark: temporalBenchmark({
         downloads30dP95: 3_000,
-        downloads30dP99: 6_000,
+        downloads30dP99: 3_000,
         spikeMultiplier7dP95: 20,
         spikeMultiplier7dP99: 50,
       }),
@@ -467,8 +467,38 @@ describe("publisher abuse scoring", () => {
     expect(score.recent30Downloads).toBe(3_600);
     expect(score.recent30Installs).toBe(0);
     expect(score.downloadInstallRatio30).toBe(3_600);
-    expect(score.downloads30dCohortBand).toBe("p95");
+    expect(score.downloads30dCohortBand).toBe("p99");
     expect(score.reasonCodes).toContain("temporal_sustained_downloads_flat_installs");
+  });
+
+  it("keeps P95-only sustained download traffic below review thresholds", () => {
+    const score = computeCurrentSkillTemporalAbuseScore({
+      todayDay: 100,
+      benchmark: temporalBenchmark({
+        downloads30dP95: 3_000,
+        downloads30dP99: 6_000,
+      }),
+      dailyStats: dailyRange(71, 30, { downloads: 120, installs: 0 }),
+    });
+
+    expect(score.recent30Downloads).toBe(3_600);
+    expect(score.sustained).toBe(false);
+    expect(score.downloads30dCohortBand).toBeUndefined();
+  });
+
+  it("keeps sub-3000 P99 download traffic below the absolute review floor", () => {
+    const score = computeCurrentSkillTemporalAbuseScore({
+      todayDay: 100,
+      benchmark: temporalBenchmark({
+        downloads30dP95: 1_000,
+        downloads30dP99: 2_000,
+      }),
+      dailyStats: dailyRange(71, 30, { downloads: 90, installs: 0 }),
+    });
+
+    expect(score.recent30Downloads).toBe(2_700);
+    expect(score.sustained).toBe(false);
+    expect(score.downloads30dCohortBand).toBeUndefined();
   });
 
   it("flags high-volume installs that track downloads too closely", () => {
@@ -588,8 +618,8 @@ describe("publisher abuse scoring", () => {
       }),
       dailyStats: [
         ...dailyRange(10, 30, { downloads: 3, installs: 0 }),
-        ...dailyRange(40, 7, { downloads: 220, installs: 0 }),
-        ...dailyRange(80, 30, { downloads: 150, installs: 0 }),
+        ...dailyRange(40, 7, { downloads: 400, installs: 0 }),
+        ...dailyRange(80, 30, { downloads: 400, installs: 0 }),
       ],
     });
 

--- a/convex/lib/publisherAbuseScoring.ts
+++ b/convex/lib/publisherAbuseScoring.ts
@@ -90,6 +90,7 @@ export type SkillTemporalAbuseScore = {
 };
 
 export type TemporalAbuseCohortBenchmark = {
+  scope?: "all_active_skills";
   sampleSize: number;
   downloads30dAverage: number;
   downloads30dMedian: number;
@@ -126,6 +127,8 @@ const TEMPORAL_SPIKE_BASELINE_DAYS = 30;
 const TEMPORAL_SUSTAINED_DAYS = 30;
 const TEMPORAL_MAX_SPIKE_INSTALLS = 2;
 const TEMPORAL_MAX_SUSTAINED_INSTALLS = 5;
+const TEMPORAL_MIN_SPIKE_7_DOWNLOADS = 2_000;
+const TEMPORAL_MIN_SUSTAINED_30_DOWNLOADS = 3_000;
 const TEMPORAL_MIN_BASELINE_7_DOWNLOADS = 100;
 const TEMPORAL_MIN_NEAR_CONVERSION_7_DOWNLOADS = 500;
 const TEMPORAL_MIN_NEAR_CONVERSION_30_DOWNLOADS = 1_000;
@@ -433,20 +436,14 @@ export function classifySkillTemporalAbuseScore(
   const spikeMultiplierVsPeerP95 =
     score.spikeMultiplier / Math.max(1, benchmark.spikeMultiplier7dP95);
   const downloads30dCohortBand =
-    score.recent30Installs <= TEMPORAL_MAX_SUSTAINED_INSTALLS
-      ? percentileBand({
-          value: score.recent30Downloads,
-          p95: benchmark.downloads30dP95,
-          p99: benchmark.downloads30dP99,
-        })
+    score.recent30Installs <= TEMPORAL_MAX_SUSTAINED_INSTALLS &&
+    score.recent30Downloads >= TEMPORAL_MIN_SUSTAINED_30_DOWNLOADS
+      ? p99Band({ value: score.recent30Downloads, p99: benchmark.downloads30dP99 })
       : undefined;
   const spikeMultiplierCohortBand =
-    score.recent7Installs <= TEMPORAL_MAX_SPIKE_INSTALLS && score.recent7Downloads > 0
-      ? percentileBand({
-          value: score.spikeMultiplier,
-          p95: benchmark.spikeMultiplier7dP95,
-          p99: benchmark.spikeMultiplier7dP99,
-        })
+    score.recent7Installs <= TEMPORAL_MAX_SPIKE_INSTALLS &&
+    score.recent7Downloads >= TEMPORAL_MIN_SPIKE_7_DOWNLOADS
+      ? p99Band({ value: score.spikeMultiplier, p99: benchmark.spikeMultiplier7dP99 })
       : undefined;
   const spike = Boolean(spikeMultiplierCohortBand);
   const sustained = Boolean(downloads30dCohortBand);
@@ -732,15 +729,9 @@ function percentile(values: number[], quantile: number) {
   return sorted[index] ?? 0;
 }
 
-function percentileBand(input: {
-  value: number;
-  p95: number;
-  p99: number;
-}): "p95" | "p99" | undefined {
+function p99Band(input: { value: number; p99: number }): "p99" | undefined {
   if (input.value <= 0) return undefined;
-  if (input.p99 > 0 && input.value > input.p99) return "p99";
-  if (input.p95 > 0 && input.value > input.p95) return "p95";
-  return undefined;
+  return input.value > input.p99 ? "p99" : undefined;
 }
 
 function standardDeviation(values: number[], mean: number) {

--- a/convex/lib/retentionPolicy.ts
+++ b/convex/lib/retentionPolicy.ts
@@ -212,6 +212,24 @@ export const RETENTION_POLICIES = {
   auditLogs: permanent("Audit logs are durable compliance/security history."),
   systemSettings: permanent("Durable operator-controlled system settings."),
   publisherAbuseScoreRuns: permanent("Abuse scoring run history."),
+  publisherAbuseTemporalScanSamples: ephemeral(
+    "Exact temporal percentile samples are temporary scan working state.",
+    {
+      expirationField: "expirationTime",
+      expirationIndex: "by_expiration_time",
+      prune: "publisherAbuseTemporalScan.pruneExpiredTemporalScanRowsInternal",
+      retention: "Seven days after the scan starts.",
+    },
+  ),
+  publisherAbuseTemporalScanCandidates: ephemeral(
+    "Temporal review candidates are temporary scan working state.",
+    {
+      expirationField: "expirationTime",
+      expirationIndex: "by_expiration_time",
+      prune: "publisherAbuseTemporalScan.pruneExpiredTemporalScanRowsInternal",
+      retention: "Seven days after the scan starts.",
+    },
+  ),
   publisherAbuseScores: permanent("Abuse score history used for review decisions."),
   publisherAbuseReviewNominations: permanent("Abuse review workflow state."),
   publisherAbuseReviewEvents: permanent("Abuse review event history."),

--- a/convex/publisherAbuse.test.ts
+++ b/convex/publisherAbuse.test.ts
@@ -8781,6 +8781,7 @@ describe("publisher abuse dry-run persistence", () => {
       nominations: 0,
       candidates: [],
       benchmark: {
+        scope: "all_active_skills",
         sampleSize: 1,
         downloads30dAverage: 2_000,
         downloads30dMedian: 2_000,
@@ -8793,6 +8794,145 @@ describe("publisher abuse dry-run persistence", () => {
 
     expect(ctx.runQuery).toHaveBeenCalledTimes(1);
     expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it("benchmarks review candidates against every scanned active skill", async () => {
+    const candidate = temporalCandidate("skills:anysearch", {
+      slug: "anysearch",
+      displayName: "AnySearch",
+    });
+    candidate.temporalScore.spike = false;
+    candidate.temporalScore.sustained = false;
+    candidate.temporalScore.recent30Downloads = 3_370;
+    candidate.temporalScore.recent30Installs = 4;
+    candidate.temporalScore.reasonCodes = [];
+    const ordinaryScore = {
+      ...candidate.temporalScore,
+      recent30Downloads: 100,
+      recent30Installs: 1,
+      spikeMultiplier: 1,
+    };
+    const ctx = {
+      runQuery: vi.fn(async () => ({
+        cursor: undefined,
+        isDone: true,
+        scannedSkills: 100,
+        benchmarkScores: [
+          ...Array.from({ length: 99 }, () => ({ ...ordinaryScore })),
+          candidate.temporalScore,
+        ],
+        candidates: [candidate],
+      })),
+      runMutation: vi.fn(),
+    };
+
+    await expect(
+      temporalRunHandler(ctx, {
+        mode: "current",
+        dryRun: true,
+        candidateLimit: 100,
+        batchSize: 100,
+        maxPages: 1,
+        todayDay: 100,
+      }),
+    ).resolves.toMatchObject({
+      scannedSkills: 100,
+      highTemporalSkills: 1,
+      benchmark: {
+        sampleSize: 100,
+        downloads30dP95: 100,
+        downloads30dP99: 100,
+      },
+      candidates: [
+        expect.objectContaining({
+          slug: "anysearch",
+          temporalScore: expect.objectContaining({
+            sustained: true,
+            downloads30dCohortBand: "p99",
+          }),
+        }),
+      ],
+    });
+  });
+
+  it("persists the full active-skill benchmark for completed current scans", async () => {
+    const candidate = temporalCandidate("skills:anysearch", {
+      slug: "anysearch",
+      displayName: "AnySearch",
+    });
+    candidate.temporalScore.spike = false;
+    candidate.temporalScore.sustained = false;
+    candidate.temporalScore.recent30Downloads = 3_370;
+    candidate.temporalScore.recent30Installs = 4;
+    candidate.temporalScore.reasonCodes = [];
+    const ordinaryScore = {
+      ...candidate.temporalScore,
+      recent30Downloads: 100,
+      recent30Installs: 1,
+      spikeMultiplier: 1,
+    };
+    const runMutation = vi
+      .fn()
+      .mockResolvedValueOnce({
+        runId: "publisherAbuseScoreRuns:temporal",
+        flaggedPublishers: 1,
+        nominations: 0,
+      })
+      .mockResolvedValueOnce({
+        archivedCandidates: 1,
+        archivedSignals: 1,
+        changedSignals: 1,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        processed: 0,
+        warned: 0,
+        banned: 0,
+        alreadyBanned: 0,
+        skipped: 0,
+        isDone: true,
+      });
+    const ctx = {
+      scheduler: { runAfter: vi.fn(async () => null) },
+      runQuery: vi.fn(async () => ({
+        cursor: undefined,
+        isDone: true,
+        scannedSkills: 100,
+        benchmarkScores: [
+          ...Array.from({ length: 99 }, () => ({ ...ordinaryScore })),
+          candidate.temporalScore,
+        ],
+        candidates: [candidate],
+      })),
+      runMutation,
+    };
+
+    await expect(
+      temporalRunHandler(ctx, {
+        mode: "current",
+        dryRun: false,
+        candidateLimit: 100,
+        batchSize: 100,
+        maxPages: 1,
+        todayDay: 100,
+      }),
+    ).resolves.toMatchObject({
+      scannedSkills: 100,
+      highTemporalSkills: 1,
+      flaggedPublishers: 1,
+    });
+
+    expect(runMutation).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({
+        benchmark: expect.objectContaining({
+          sampleSize: 100,
+          downloads30dP95: 100,
+          downloads30dP99: 100,
+        }),
+      }),
+    );
   });
 
   it("keeps current temporal dry-runs read-only unless archival is requested", async () => {
@@ -8911,7 +9051,7 @@ describe("publisher abuse dry-run persistence", () => {
     expect(ctx.scheduler.runAfter).toHaveBeenCalledWith(0, expect.any(Symbol), {});
   });
 
-  it("archives bounded current temporal dry-run signals before scan completion when requested", async () => {
+  it("does not archive temporal dry-run signals before the full benchmark scan completes", async () => {
     const candidate = temporalCandidate("skills:bounded-ratio", {
       slug: "bounded-ratio",
       displayName: "Bounded Ratio",
@@ -8963,24 +9103,62 @@ describe("publisher abuse dry-run persistence", () => {
       nominations: 0,
     });
 
-    expect(ctx.runMutation).toHaveBeenCalledTimes(1);
-    expect(ctx.runMutation).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        candidates: [expect.objectContaining({ skillId: "skills:bounded-ratio" })],
-      }),
-    );
-    expect(ctx.scheduler.runAfter).toHaveBeenCalledWith(0, expect.any(Symbol), {});
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
   });
 
-  it("caps temporal scan candidate limits below Convex array limits", async () => {
+  it("does not present percentile signals or a benchmark for partial dry runs", async () => {
+    const candidate = temporalCandidate("skills:partial-spike", {
+      slug: "partial-spike",
+      displayName: "Partial Spike",
+    });
     const ctx = {
-      runQuery: vi.fn(async (_query: unknown, args: { batchSize: number }) => ({
-        cursor: "next",
+      runQuery: vi.fn(async () => ({
+        cursor: "next-page",
         isDone: false,
-        scannedSkills: args.batchSize,
-        candidates: [],
+        scannedSkills: 1,
+        benchmarkScores: [candidate.temporalScore],
+        candidates: [candidate],
       })),
+      runMutation: vi.fn(),
+    };
+
+    const result = await temporalRunHandler(ctx, {
+      mode: "current",
+      dryRun: true,
+      candidateLimit: 1,
+      batchSize: 1,
+      maxPages: 1,
+      todayDay: 100,
+    });
+
+    expect(result).toMatchObject({
+      scannedSkills: 1,
+      highTemporalSkills: 0,
+      candidates: [],
+    });
+    expect(result).not.toHaveProperty("benchmark");
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it("keeps the legacy manual scan bounded and omits a partial benchmark", async () => {
+    const score = temporalCandidate("skills:benchmark", {
+      slug: "benchmark",
+      displayName: "Benchmark",
+    }).temporalScore;
+    let pageNumber = 0;
+    const ctx = {
+      runQuery: vi.fn(async (_query: unknown, args: { batchSize: number }) => {
+        pageNumber += 1;
+        const isDone = pageNumber === 81;
+        return {
+          cursor: isDone ? undefined : `page-${pageNumber + 1}`,
+          isDone,
+          scannedSkills: args.batchSize,
+          benchmarkScores: Array.from({ length: args.batchSize }, () => score),
+          candidates: [],
+        };
+      }),
       runMutation: vi.fn(),
     };
 
@@ -8988,9 +9166,7 @@ describe("publisher abuse dry-run persistence", () => {
       temporalRunHandler(ctx, {
         mode: "current",
         dryRun: true,
-        candidateLimit: 10_000,
         batchSize: 100,
-        maxPages: 100,
         todayDay: 100,
       }),
     ).resolves.toMatchObject({
@@ -9346,7 +9522,14 @@ describe("publisher abuse dry-run persistence", () => {
               },
             };
           }
-          if (table === "skillDailyStats") throw new Error("official publisher was scanned");
+          if (table === "skillDailyStats") {
+            return {
+              withIndex: (_indexName: string, callback: (q: typeof indexBuilder) => unknown) => {
+                callback(indexBuilder);
+                return { take: async () => [] };
+              },
+            };
+          }
           if (table === "officialPublishers") {
             return {
               withIndex: (indexName: string, callback: (q: typeof indexBuilder) => unknown) => {
@@ -9376,6 +9559,7 @@ describe("publisher abuse dry-run persistence", () => {
       cursor: undefined,
       isDone: true,
       scannedSkills: 1,
+      benchmarkScores: [expect.objectContaining({ recent30Downloads: 0 })],
       candidates: [],
     });
   });
@@ -9456,7 +9640,14 @@ describe("publisher abuse dry-run persistence", () => {
               },
             };
           }
-          if (table === "skillDailyStats") throw new Error("staff org publisher was scanned");
+          if (table === "skillDailyStats") {
+            return {
+              withIndex: (_indexName: string, callback: (q: typeof indexBuilder) => unknown) => {
+                callback(indexBuilder);
+                return { take: async () => [] };
+              },
+            };
+          }
           if (table === "officialPublishers") return makeEmptyOfficialPublishersQuery();
           throw new Error(`unexpected table ${table}`);
         }),
@@ -9473,6 +9664,7 @@ describe("publisher abuse dry-run persistence", () => {
       cursor: undefined,
       isDone: true,
       scannedSkills: 1,
+      benchmarkScores: [expect.objectContaining({ recent30Downloads: 0 })],
       candidates: [],
     });
   });

--- a/convex/publisherAbuse.ts
+++ b/convex/publisherAbuse.ts
@@ -52,11 +52,11 @@ const MAX_REVIEW_DASHBOARD_PAGE_SIZE = 25;
 const DASHBOARD_SIGNAL_COUNT_LIMIT = 25;
 const DASHBOARD_SIGNAL_COUNT_SCAN_LIMIT = 100;
 const MAX_BAN_REASON_LENGTH = 500;
-const DEFAULT_TEMPORAL_BATCH_SIZE = 50;
+const DEFAULT_TEMPORAL_BATCH_SIZE = 100;
 const MAX_TEMPORAL_BATCH_SIZE = 100;
-const DEFAULT_TEMPORAL_CANDIDATE_LIMIT = 1000;
+const DEFAULT_TEMPORAL_CANDIDATE_LIMIT = 8_000;
 const MAX_TEMPORAL_CANDIDATE_LIMIT = 8_000;
-const DEFAULT_TEMPORAL_MAX_PAGES = 20;
+const DEFAULT_TEMPORAL_MAX_PAGES = 100;
 const MAX_TEMPORAL_MAX_PAGES = 100;
 const CURRENT_TEMPORAL_LOOKBACK_DAYS = 37;
 const DEFAULT_BACKFILL_TEMPORAL_LOOKBACK_DAYS = 365;
@@ -172,7 +172,7 @@ type PublisherAbuseExclusionPublisher = Pick<Doc<"publishers">, "_id" | "kind"> 
   deactivatedAt?: number | null;
 };
 
-type TemporalSkillCandidate = {
+export type TemporalSkillCandidate = {
   ownerKey: string;
   ownerPublisherId?: Id<"publishers">;
   ownerUserId?: Id<"users">;
@@ -189,6 +189,7 @@ type TemporalSkillCandidatesPage = {
   cursor?: string;
   isDone: boolean;
   scannedSkills: number;
+  benchmarkScores?: SkillTemporalAbuseScore[];
   candidates: TemporalSkillCandidate[];
 };
 
@@ -258,6 +259,7 @@ type PublisherAbuseWarningTarget = Pick<Doc<"users">, "_id" | "email" | "handle"
 const temporalCohortBandValidator = v.union(v.literal("p95"), v.literal("p99"));
 
 const temporalAbuseCohortBenchmarkValidator = v.object({
+  scope: v.optional(v.literal("all_active_skills")),
   sampleSize: v.number(),
   downloads30dAverage: v.number(),
   downloads30dMedian: v.number(),
@@ -1562,6 +1564,7 @@ export const archiveTemporalPublisherAbuseSignalsPageInternal = internalMutation
   args: {
     runId: v.optional(v.id("publisherAbuseScoreRuns")),
     candidates: v.array(temporalCandidateValidator),
+    benchmark: v.optional(temporalAbuseCohortBenchmarkValidator),
     now: v.number(),
   },
   handler: archiveTemporalPublisherAbuseSignalsPageInternalHandler,
@@ -2339,17 +2342,9 @@ export async function collectTemporalPublisherAbuseSkillCandidatesPageInternalHa
     .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
 
   const candidates: TemporalSkillCandidate[] = [];
+  const benchmarkScores: SkillTemporalAbuseScore[] = [];
   const staffManagerExclusionBudget = createStaffPublisherManagerExclusionBudget();
   for (const skill of page.page) {
-    if (!skill.ownerPublisherId) continue;
-    const publisher = await ctx.db.get(skill.ownerPublisherId);
-    if (
-      !publisher ||
-      (await isPublisherExcludedFromPublisherAbuse(ctx, publisher, staffManagerExclusionBudget))
-    ) {
-      continue;
-    }
-
     const dailyStats = await ctx.db
       .query("skillDailyStats")
       .withIndex("by_skill_day", (q) =>
@@ -2360,6 +2355,16 @@ export async function collectTemporalPublisherAbuseSkillCandidatesPageInternalHa
       args.mode === "backfill"
         ? computeHistoricalSkillTemporalAbuseScore({ dailyStats })
         : computeCurrentSkillTemporalAbuseScore({ todayDay, dailyStats });
+    benchmarkScores.push(temporalScore);
+
+    if (!skill.ownerPublisherId) continue;
+    const publisher = await ctx.db.get(skill.ownerPublisherId);
+    if (
+      !publisher ||
+      (await isPublisherExcludedFromPublisherAbuse(ctx, publisher, staffManagerExclusionBudget))
+    ) {
+      continue;
+    }
 
     candidates.push({
       ownerKey: `publisher:${publisher._id}`,
@@ -2379,6 +2384,7 @@ export async function collectTemporalPublisherAbuseSkillCandidatesPageInternalHa
     cursor: page.isDone ? undefined : page.continueCursor,
     isDone: page.isDone,
     scannedSkills: page.page.length,
+    benchmarkScores,
     candidates,
   };
 }
@@ -2452,7 +2458,7 @@ export async function persistTemporalPublisherAbuseCandidatesInternalHandler(
     status: "completed",
     phase: "completed",
     temporalScanComplete: args.scanComplete,
-    temporalBenchmark: args.benchmark,
+    ...(args.benchmark ? { temporalBenchmark: args.benchmark } : {}),
     scannedPublishers,
     scoredPublishers,
     finalizedScores: finalizedCount,
@@ -2896,12 +2902,12 @@ export async function runTemporalPublisherAbuseScanInternalHandler(
   flaggedPublishers: number;
   nominations: number;
   candidates?: TemporalSkillCandidate[];
-  benchmark: TemporalAbuseCohortBenchmark;
+  benchmark?: TemporalAbuseCohortBenchmark;
 }> {
   const mode = args.mode ?? "current";
   const dryRun = args.dryRun ?? false;
   const archiveDryRunSignals = args.archiveDryRunSignals ?? false;
-  const requestedCandidateLimit = clampInt(
+  const candidateLimit = clampInt(
     args.candidateLimit ?? DEFAULT_TEMPORAL_CANDIDATE_LIMIT,
     1,
     MAX_TEMPORAL_CANDIDATE_LIMIT,
@@ -2911,13 +2917,7 @@ export async function runTemporalPublisherAbuseScanInternalHandler(
     1,
     MAX_TEMPORAL_BATCH_SIZE,
   );
-  const requestedMaxPages = clampInt(
-    args.maxPages ?? DEFAULT_TEMPORAL_MAX_PAGES,
-    1,
-    MAX_TEMPORAL_MAX_PAGES,
-  );
-  const candidateLimit = requestedCandidateLimit;
-  const maxPages = requestedMaxPages;
+  const maxPages = clampInt(args.maxPages ?? DEFAULT_TEMPORAL_MAX_PAGES, 1, MAX_TEMPORAL_MAX_PAGES);
   const todayDay = args.todayDay ?? toDayKey(Date.now());
 
   let cursor: string | undefined;
@@ -2925,19 +2925,24 @@ export async function runTemporalPublisherAbuseScanInternalHandler(
   let pages = 0;
   let scanComplete = false;
   const candidates: TemporalSkillCandidate[] = [];
+  const benchmarkScores: SkillTemporalAbuseScore[] = [];
   while (pages < maxPages && scannedSkills < candidateLimit) {
+    const remainingSkills = candidateLimit - scannedSkills;
     const result: TemporalSkillCandidatesPage = await ctx.runQuery(
       internal.publisherAbuse.collectTemporalPublisherAbuseSkillCandidatesPageInternal,
       {
         mode,
         cursor,
-        batchSize: Math.min(batchSize, candidateLimit - scannedSkills),
+        batchSize: Math.min(batchSize, remainingSkills),
         todayDay,
         lookbackDays: args.lookbackDays,
       },
     );
     pages += 1;
     scannedSkills += result.scannedSkills;
+    benchmarkScores.push(
+      ...(result.benchmarkScores ?? result.candidates.map((candidate) => candidate.temporalScore)),
+    );
     candidates.push(...result.candidates);
     cursor = result.cursor;
     if (result.isDone || !cursor) {
@@ -2946,13 +2951,18 @@ export async function runTemporalPublisherAbuseScanInternalHandler(
     }
   }
 
-  const benchmark = computeTemporalAbuseCohortBenchmark(
-    candidates.map((candidate) => candidate.temporalScore),
-  );
+  const benchmark = scanComplete
+    ? {
+        ...computeTemporalAbuseCohortBenchmark(benchmarkScores),
+        scope: "all_active_skills" as const,
+      }
+    : undefined;
   const highTemporalCandidates = candidates
     .map((candidate) => ({
       ...candidate,
-      temporalScore: classifySkillTemporalAbuseScore(candidate.temporalScore, benchmark),
+      temporalScore: benchmark
+        ? classifySkillTemporalAbuseScore(candidate.temporalScore, benchmark)
+        : withoutTemporalCohortClassification(candidate.temporalScore),
     }))
     .filter(
       (candidate) =>
@@ -2963,7 +2973,13 @@ export async function runTemporalPublisherAbuseScanInternalHandler(
 
   const flaggedPublishers = aggregateTemporalPublisherCandidates(highTemporalCandidates).length;
   if (dryRun || !scanComplete || (mode !== "current" && highTemporalCandidates.length === 0)) {
-    if (dryRun && archiveDryRunSignals && mode === "current" && highTemporalCandidates.length > 0) {
+    if (
+      dryRun &&
+      archiveDryRunSignals &&
+      mode === "current" &&
+      scanComplete &&
+      highTemporalCandidates.length > 0
+    ) {
       await archiveTemporalPublisherAbuseSignalPages(ctx, {
         candidates: highTemporalCandidates,
         now: Date.now(),
@@ -2978,22 +2994,49 @@ export async function runTemporalPublisherAbuseScanInternalHandler(
       highTemporalSkills: highTemporalCandidates.length,
       flaggedPublishers,
       nominations: 0,
-      benchmark,
+      ...(benchmark ? { benchmark } : {}),
       ...(dryRun
         ? { candidates: highTemporalCandidates.slice(0, MAX_TEMPORAL_DRY_RUN_CANDIDATES) }
         : {}),
     };
   }
 
+  if (!benchmark) {
+    throw new Error("Completed temporal scan is missing its platform benchmark");
+  }
+
   return await finishTemporalPublisherAbuseScan(ctx, {
     mode,
     dryRun,
     candidates,
+    benchmark,
     scannedSkills,
     scanComplete,
     trigger: args.trigger ?? "cron",
     actorUserId: args.actorUserId,
   });
+}
+
+function withoutTemporalCohortClassification(
+  score: SkillTemporalAbuseScore,
+): SkillTemporalAbuseScore {
+  return {
+    ...score,
+    spike: false,
+    sustained: false,
+    pressure: score.nearConversion
+      ? Math.max(score.installDownloadExcessZScore7, score.installDownloadExcessZScore30)
+      : 0,
+    downloads30dCohortBand: undefined,
+    spikeMultiplierCohortBand: undefined,
+    downloads30dVsPeerP95: undefined,
+    spikeMultiplierVsPeerP95: undefined,
+    spikeWindowStartDay: undefined,
+    spikeWindowEndDay: undefined,
+    sustainedWindowStartDay: undefined,
+    sustainedWindowEndDay: undefined,
+    reasonCodes: score.nearConversion ? ["temporal_installs_track_downloads"] : [],
+  };
 }
 
 async function finishTemporalPublisherAbuseScan(
@@ -3002,19 +3045,17 @@ async function finishTemporalPublisherAbuseScan(
     mode: TemporalAbuseMode;
     dryRun: boolean;
     candidates: TemporalSkillCandidate[];
+    benchmark: TemporalAbuseCohortBenchmark;
     scannedSkills: number;
     scanComplete: boolean;
     trigger: "cron" | "manual";
     actorUserId?: Id<"users">;
   },
 ) {
-  const benchmark = computeTemporalAbuseCohortBenchmark(
-    args.candidates.map((candidate) => candidate.temporalScore),
-  );
   const highTemporalCandidates = args.candidates
     .map((candidate) => ({
       ...candidate,
-      temporalScore: classifySkillTemporalAbuseScore(candidate.temporalScore, benchmark),
+      temporalScore: classifySkillTemporalAbuseScore(candidate.temporalScore, args.benchmark),
     }))
     .filter(
       (candidate) =>
@@ -3033,7 +3074,7 @@ async function finishTemporalPublisherAbuseScan(
       trigger: args.trigger,
       actorUserId: args.actorUserId,
       candidates: highTemporalCandidates,
-      benchmark,
+      benchmark: args.benchmark,
       scanComplete: args.scanComplete,
     },
   );
@@ -3054,7 +3095,7 @@ async function finishTemporalPublisherAbuseScan(
     highTemporalSkills: highTemporalCandidates.length,
     flaggedPublishers: saved.flaggedPublishers,
     nominations: saved.nominations,
-    benchmark,
+    benchmark: args.benchmark,
   };
 }
 
@@ -3291,11 +3332,12 @@ function temporalEvidenceFromCandidate(candidate: TemporalSkillCandidate) {
   };
 }
 
-async function archiveTemporalPublisherAbuseSignals(
+export async function archiveTemporalPublisherAbuseSignals(
   ctx: Pick<MutationCtx, "db">,
   args: {
     runId?: Id<"publisherAbuseScoreRuns">;
     candidates: TemporalSkillCandidate[];
+    benchmark?: TemporalAbuseCohortBenchmark;
     now: number;
   },
 ) {
@@ -3306,6 +3348,7 @@ async function archiveTemporalPublisherAbuseSignals(
       const changed = await upsertPublisherAbuseSignal(ctx, {
         runId: args.runId,
         candidate,
+        benchmark: args.benchmark,
         signalType,
         now: args.now,
       });
@@ -3321,6 +3364,7 @@ export async function archiveTemporalPublisherAbuseSignalsPageInternalHandler(
   args: {
     runId?: Id<"publisherAbuseScoreRuns">;
     candidates: TemporalSkillCandidate[];
+    benchmark?: TemporalAbuseCohortBenchmark;
     now: number;
   },
 ) {
@@ -3345,6 +3389,7 @@ async function upsertPublisherAbuseSignal(
   args: {
     runId?: Id<"publisherAbuseScoreRuns">;
     candidate: TemporalSkillCandidate;
+    benchmark?: TemporalAbuseCohortBenchmark;
     signalType: PublisherAbuseSignalType;
     now: number;
   },
@@ -3397,6 +3442,7 @@ async function upsertPublisherAbuseSignal(
 function publisherAbuseSignalSnapshot(args: {
   runId?: Id<"publisherAbuseScoreRuns">;
   candidate: TemporalSkillCandidate;
+  benchmark?: TemporalAbuseCohortBenchmark;
   signalType: PublisherAbuseSignalType;
 }) {
   const { candidate } = args;
@@ -3424,6 +3470,7 @@ function publisherAbuseSignalSnapshot(args: {
     }),
     allTimeDownloads: nonNegative(candidate.totalDownloads),
     allTimeInstalls: nonNegative(candidate.totalInstalls),
+    temporalBenchmark: args.benchmark,
     allTimeInstallDownloadRatio: installDownloadRatio({
       installs: candidate.totalInstalls,
       downloads: candidate.totalDownloads,

--- a/convex/publisherAbuseDevSeed.ts
+++ b/convex/publisherAbuseDevSeed.ts
@@ -398,6 +398,7 @@ async function seedTemporalCohortDemoRows(ctx: ClearSeedCtx, args: { now: number
   const now = args.now;
   const todayDay = Math.floor(now / DAY_MS);
   const temporalBenchmark = {
+    scope: "all_active_skills" as const,
     sampleSize: 1000,
     downloads30dAverage: 180,
     downloads30dMedian: 45,

--- a/convex/publisherAbuseTemporalScan.test.ts
+++ b/convex/publisherAbuseTemporalScan.test.ts
@@ -1,0 +1,314 @@
+/* @vitest-environment node */
+import { describe, expect, it, vi } from "vitest";
+import type { Doc, Id } from "./_generated/dataModel";
+import type { MutationCtx } from "./_generated/server";
+import {
+  DEFAULT_PUBLISHER_ABUSE_MODEL_CONFIG,
+  PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION,
+  type SkillTemporalAbuseScore,
+} from "./lib/publisherAbuseScoring";
+import type { TemporalSkillCandidate } from "./publisherAbuse";
+import {
+  advanceScheduledTemporalCandidatesInternalHandler,
+  percentileIndex,
+  pruneExpiredTemporalScanRowsInternalHandler,
+  runScheduledTemporalPublisherAbuseScanInternalHandler,
+  storeScheduledTemporalScanPageInternalHandler,
+  temporalBenchmarkFromRun,
+  valueAtGlobalIndex,
+} from "./publisherAbuseTemporalScan";
+
+function temporalScore(overrides: Partial<SkillTemporalAbuseScore> = {}): SkillTemporalAbuseScore {
+  return {
+    spike: false,
+    sustained: false,
+    nearConversion: false,
+    pressure: 0,
+    recent7Downloads: 100,
+    recent7Installs: 0,
+    previous30Downloads: 100,
+    baseline7Downloads: 100,
+    spikeMultiplier: 1,
+    recent30Downloads: 100,
+    recent30Installs: 0,
+    downloadInstallRatio30: 100,
+    installDownloadRatio7: 0,
+    installDownloadRatio30: 0,
+    installDownloadExcessZScore7: 0,
+    installDownloadExcessZScore30: 0,
+    reasonCodes: [],
+    ...overrides,
+  };
+}
+
+function temporalCandidate(
+  skillId: Id<"skills">,
+  score: SkillTemporalAbuseScore = temporalScore(),
+): TemporalSkillCandidate {
+  return {
+    ownerKey: "publisher:publishers:anysearch",
+    ownerPublisherId: "publishers:anysearch" as Id<"publishers">,
+    ownerUserId: "users:anysearch" as Id<"users">,
+    handleSnapshot: "anysearch",
+    skillId,
+    slug: "anysearch",
+    displayName: "AnySearch",
+    totalDownloads: 10_000,
+    totalInstalls: 4,
+    temporalScore: score,
+  };
+}
+
+function temporalRun(
+  overrides: Partial<Doc<"publisherAbuseScoreRuns">> = {},
+): Doc<"publisherAbuseScoreRuns"> {
+  const now = Date.now();
+  return {
+    _id: "publisherAbuseScoreRuns:scheduled" as Id<"publisherAbuseScoreRuns">,
+    _creationTime: 1,
+    modelVersion: PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION,
+    modelConfig: DEFAULT_PUBLISHER_ABUSE_MODEL_CONFIG,
+    trigger: "cron",
+    status: "running",
+    phase: "collecting",
+    startedAt: now,
+    updatedAt: now,
+    scannedPublishers: 0,
+    scoredPublishers: 0,
+    finalizedScores: 0,
+    nominatedPublishers: 0,
+    passCount: 0,
+    reviewCount: 0,
+    potentialBanCandidateCount: 0,
+    sumLogPressure: 0,
+    sumSquaredLogPressure: 0,
+    temporalMode: "current",
+    temporalScanComplete: false,
+    temporalPipelinePhase: "collecting",
+    temporalTodayDay: 100,
+    temporalSampleSize: 0,
+    temporalDownloadsSum: 0,
+    temporalDownloadsProcessed: 0,
+    temporalSpikeProcessed: 0,
+    ...overrides,
+  };
+}
+
+describe("scheduled temporal publisher abuse scan", () => {
+  it("uses nearest-rank percentile indexes across bounded pages", () => {
+    expect(percentileIndex(100, 0.5)).toBe(49);
+    expect(percentileIndex(100, 0.95)).toBe(94);
+    expect(percentileIndex(100, 0.99)).toBe(98);
+    expect(
+      valueAtGlobalIndex({ values: [90, 91, 92, 93, 94], pageStart: 90, targetIndex: 94 }),
+    ).toBe(94);
+    expect(
+      valueAtGlobalIndex({ values: [90, 91, 92, 93, 94], pageStart: 90, targetIndex: 89 }),
+    ).toBeUndefined();
+  });
+
+  it("builds the exact platform benchmark from persisted rank values", () => {
+    expect(
+      temporalBenchmarkFromRun(
+        temporalRun({
+          temporalSampleSize: 100,
+          temporalDownloadsSum: 18_000,
+          temporalDownloadsMedian: 45,
+          temporalDownloadsP95: 900,
+          temporalDownloadsP99: 3_000,
+          temporalSpikeP95: 4,
+          temporalSpikeP99: 12,
+        }),
+      ),
+    ).toEqual({
+      scope: "all_active_skills",
+      sampleSize: 100,
+      downloads30dAverage: 180,
+      downloads30dMedian: 45,
+      downloads30dP95: 900,
+      downloads30dP99: 3_000,
+      spikeMultiplier7dP95: 4,
+      spikeMultiplier7dP99: 12,
+    });
+  });
+
+  it("persists one bounded source page and advances its durable cursor", async () => {
+    const run = temporalRun();
+    const insert = vi.fn(async () => "inserted");
+    const patch = vi.fn(async () => null);
+    const ctx = {
+      db: {
+        get: vi.fn(async () => run),
+        insert,
+        patch,
+      },
+    };
+    const candidate = temporalCandidate("skills:anysearch" as Id<"skills">);
+
+    await expect(
+      storeScheduledTemporalScanPageInternalHandler(ctx as unknown as MutationCtx, {
+        runId: run._id,
+        expectedCursor: undefined,
+        nextCursor: "next-page",
+        isDone: false,
+        benchmarkScores: [
+          { recent30Downloads: 0, spikeMultiplier: 0 },
+          { recent30Downloads: 100, spikeMultiplier: 1 },
+        ],
+        candidates: [candidate],
+      }),
+    ).resolves.toEqual({ applied: true });
+
+    expect(insert).toHaveBeenCalledTimes(3);
+    expect(insert).toHaveBeenCalledWith(
+      "publisherAbuseTemporalScanSamples",
+      expect.objectContaining({ runId: run._id, recent30Downloads: 0 }),
+    );
+    expect(insert).toHaveBeenCalledWith(
+      "publisherAbuseTemporalScanCandidates",
+      expect.objectContaining({ runId: run._id, skillId: candidate.skillId }),
+    );
+    expect(patch).toHaveBeenCalledWith(
+      run._id,
+      expect.objectContaining({
+        temporalSourceCursor: "next-page",
+        temporalSampleSize: 2,
+        temporalDownloadsSum: 100,
+        temporalPipelinePhase: "collecting",
+      }),
+    );
+  });
+
+  it("archives classified candidates with the completed full-platform benchmark", async () => {
+    const benchmark = {
+      scope: "all_active_skills" as const,
+      sampleSize: 1_000,
+      downloads30dAverage: 180,
+      downloads30dMedian: 45,
+      downloads30dP95: 900,
+      downloads30dP99: 3_000,
+      spikeMultiplier7dP95: 4,
+      spikeMultiplier7dP99: 12,
+    };
+    const run = temporalRun({
+      phase: "finalizing",
+      temporalPipelinePhase: "classifying",
+      temporalBenchmark: benchmark,
+    });
+    const candidate = temporalCandidate(
+      "skills:anysearch" as Id<"skills">,
+      temporalScore({ recent30Downloads: 3_370, recent30Installs: 4 }),
+    );
+    const runQuery = vi
+      .fn()
+      .mockResolvedValueOnce(run)
+      .mockResolvedValueOnce({ candidates: [candidate], cursor: undefined, isDone: true });
+    const runMutation = vi.fn(async () => ({ applied: true }));
+    const scheduler = { runAfter: vi.fn(async () => null) };
+    const handler = runScheduledTemporalPublisherAbuseScanInternalHandler as unknown as (
+      ctx: {
+        runQuery: typeof runQuery;
+        runMutation: typeof runMutation;
+        scheduler: typeof scheduler;
+      },
+      args: { runId?: Id<"publisherAbuseScoreRuns"> },
+    ) => Promise<unknown>;
+
+    await expect(
+      handler({ runQuery, runMutation, scheduler }, { runId: run._id }),
+    ).resolves.toEqual({
+      ok: true,
+      runId: run._id,
+      completed: true,
+    });
+
+    expect(runMutation).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({
+        runId: run._id,
+        candidates: [
+          expect.objectContaining({
+            skillId: candidate.skillId,
+            temporalScore: expect.objectContaining({
+              sustained: true,
+              downloads30dCohortBand: "p99",
+            }),
+          }),
+        ],
+      }),
+    );
+    expect(scheduler.runAfter).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not archive or revive a scan that has already failed", async () => {
+    const run = temporalRun({
+      status: "failed",
+      phase: "finalizing",
+      temporalPipelinePhase: "classifying",
+      temporalBenchmark: {
+        scope: "all_active_skills",
+        sampleSize: 100,
+        downloads30dAverage: 10,
+        downloads30dMedian: 5,
+        downloads30dP95: 20,
+        downloads30dP99: 30,
+        spikeMultiplier7dP95: 2,
+        spikeMultiplier7dP99: 3,
+      },
+    });
+    const ctx = {
+      db: {
+        get: vi.fn(async () => run),
+        query: vi.fn(() => {
+          throw new Error("failed scans must not archive signals");
+        }),
+        insert: vi.fn(async () => {
+          throw new Error("failed scans must not archive signals");
+        }),
+        patch: vi.fn(async () => {
+          throw new Error("failed scans must not be revived");
+        }),
+      },
+    };
+
+    await expect(
+      advanceScheduledTemporalCandidatesInternalHandler(ctx as unknown as MutationCtx, {
+        runId: run._id,
+        expectedCursor: undefined,
+        nextCursor: undefined,
+        isDone: true,
+        candidates: [temporalCandidate("skills:anysearch" as Id<"skills">)],
+      }),
+    ).resolves.toEqual({ applied: false });
+  });
+
+  it("deletes expired working rows in bounded retention batches", async () => {
+    const expiredSample = {
+      _id: "publisherAbuseTemporalScanSamples:expired" as Id<"publisherAbuseTemporalScanSamples">,
+    };
+    const expiredCandidate = {
+      _id: "publisherAbuseTemporalScanCandidates:expired" as Id<"publisherAbuseTemporalScanCandidates">,
+    };
+    const take = vi
+      .fn()
+      .mockResolvedValueOnce([expiredSample])
+      .mockResolvedValueOnce([expiredCandidate]);
+    const scheduler = { runAfter: vi.fn(async () => null) };
+    const ctx = {
+      db: {
+        query: vi.fn(() => ({
+          withIndex: vi.fn(() => ({ take })),
+        })),
+        delete: vi.fn(async () => null),
+      },
+      scheduler,
+    };
+
+    await expect(
+      pruneExpiredTemporalScanRowsInternalHandler(ctx as unknown as MutationCtx, { batchSize: 2 }),
+    ).resolves.toEqual({ samplesDeleted: 1, candidatesDeleted: 1, hasMore: false });
+    expect(ctx.db.delete).toHaveBeenCalledTimes(2);
+    expect(scheduler.runAfter).not.toHaveBeenCalled();
+  });
+});

--- a/convex/publisherAbuseTemporalScan.ts
+++ b/convex/publisherAbuseTemporalScan.ts
@@ -1,0 +1,700 @@
+import { v } from "convex/values";
+import { internal } from "./_generated/api";
+import type { Doc, Id } from "./_generated/dataModel";
+import type { ActionCtx, MutationCtx, QueryCtx } from "./_generated/server";
+import { internalAction, internalMutation, internalQuery } from "./functions";
+import { toDayKey } from "./lib/leaderboards";
+import {
+  classifySkillTemporalAbuseScore,
+  DEFAULT_PUBLISHER_ABUSE_MODEL_CONFIG,
+  PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION,
+  type SkillTemporalAbuseScore,
+  type TemporalAbuseCohortBenchmark,
+} from "./lib/publisherAbuseScoring";
+import { RETENTION_STANDARD_BATCH_SIZE } from "./lib/retentionPolicy";
+import {
+  archiveTemporalPublisherAbuseSignals,
+  type TemporalSkillCandidate,
+} from "./publisherAbuse";
+
+const SOURCE_PAGE_SIZE = 100;
+const PERCENTILE_PAGE_SIZE = 500;
+const CANDIDATE_PAGE_SIZE = 100;
+const TEMPORAL_SCAN_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+
+const temporalCohortBandValidator = v.union(v.literal("p95"), v.literal("p99"));
+const temporalScoreValidator = v.object({
+  spike: v.boolean(),
+  sustained: v.boolean(),
+  nearConversion: v.boolean(),
+  pressure: v.number(),
+  recent7Downloads: v.number(),
+  recent7Installs: v.number(),
+  previous30Downloads: v.number(),
+  baseline7Downloads: v.number(),
+  spikeMultiplier: v.number(),
+  recent30Downloads: v.number(),
+  recent30Installs: v.number(),
+  downloadInstallRatio30: v.number(),
+  downloads30dCohortBand: v.optional(temporalCohortBandValidator),
+  spikeMultiplierCohortBand: v.optional(temporalCohortBandValidator),
+  downloads30dVsPeerP95: v.optional(v.number()),
+  spikeMultiplierVsPeerP95: v.optional(v.number()),
+  installDownloadRatio7: v.number(),
+  installDownloadRatio30: v.number(),
+  installDownloadExcessZScore7: v.number(),
+  installDownloadExcessZScore30: v.number(),
+  spikeWindowStartDay: v.optional(v.number()),
+  spikeWindowEndDay: v.optional(v.number()),
+  sustainedWindowStartDay: v.optional(v.number()),
+  sustainedWindowEndDay: v.optional(v.number()),
+  nearConversionWindowStartDay: v.optional(v.number()),
+  nearConversionWindowEndDay: v.optional(v.number()),
+  reasonCodes: v.array(v.string()),
+});
+
+const temporalCandidateValidator = v.object({
+  ownerKey: v.string(),
+  ownerPublisherId: v.optional(v.id("publishers")),
+  ownerUserId: v.optional(v.id("users")),
+  handleSnapshot: v.string(),
+  skillId: v.id("skills"),
+  slug: v.string(),
+  displayName: v.string(),
+  totalDownloads: v.number(),
+  totalInstalls: v.number(),
+  temporalScore: temporalScoreValidator,
+});
+
+const temporalBenchmarkValidator = v.object({
+  scope: v.optional(v.literal("all_active_skills")),
+  sampleSize: v.number(),
+  downloads30dAverage: v.number(),
+  downloads30dMedian: v.number(),
+  downloads30dP95: v.number(),
+  downloads30dP99: v.number(),
+  spikeMultiplier7dP95: v.number(),
+  spikeMultiplier7dP99: v.number(),
+});
+
+type TemporalScanRun = Doc<"publisherAbuseScoreRuns">;
+type PercentileMetric = "downloads" | "spike";
+
+function isActiveScheduledTemporalRun(run: TemporalScanRun, now: number) {
+  return run.status === "running" && now - run.startedAt < TEMPORAL_SCAN_RETENTION_MS;
+}
+
+export async function getOrStartScheduledTemporalScanInternalHandler(ctx: MutationCtx) {
+  const now = Date.now();
+  const existing = await ctx.db
+    .query("publisherAbuseScoreRuns")
+    .withIndex("by_model_version_and_status_and_trigger_and_updated_at", (q) =>
+      q
+        .eq("modelVersion", PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION)
+        .eq("status", "running")
+        .eq("trigger", "cron"),
+    )
+    .order("desc")
+    .first();
+  if (
+    existing?.temporalPipelinePhase &&
+    existing.temporalPipelinePhase !== "completed" &&
+    now - existing.startedAt < TEMPORAL_SCAN_RETENTION_MS
+  ) {
+    return { runId: existing._id, resumed: true as const };
+  }
+  if (existing) {
+    await ctx.db.patch(existing._id, {
+      status: "failed",
+      errorMessage: "Scheduled temporal scan exceeded its seven-day working-state retention.",
+      updatedAt: now,
+    });
+  }
+  const runId = await ctx.db.insert("publisherAbuseScoreRuns", {
+    modelVersion: PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION,
+    modelConfig: DEFAULT_PUBLISHER_ABUSE_MODEL_CONFIG,
+    trigger: "cron",
+    status: "running",
+    phase: "collecting",
+    startedAt: now,
+    updatedAt: now,
+    scannedPublishers: 0,
+    scoredPublishers: 0,
+    finalizedScores: 0,
+    nominatedPublishers: 0,
+    passCount: 0,
+    reviewCount: 0,
+    potentialBanCandidateCount: 0,
+    sumLogPressure: 0,
+    sumSquaredLogPressure: 0,
+    temporalMode: "current",
+    temporalScanComplete: false,
+    temporalPipelinePhase: "collecting",
+    temporalTodayDay: toDayKey(now),
+    temporalSampleSize: 0,
+    temporalDownloadsSum: 0,
+    temporalDownloadsProcessed: 0,
+    temporalSpikeProcessed: 0,
+  });
+  return { runId, resumed: false as const };
+}
+
+export const getOrStartScheduledTemporalScanInternal = internalMutation({
+  args: {},
+  handler: getOrStartScheduledTemporalScanInternalHandler,
+});
+
+export async function getScheduledTemporalScanStateInternalHandler(
+  ctx: Pick<QueryCtx, "db">,
+  args: { runId: Id<"publisherAbuseScoreRuns"> },
+) {
+  const run = await ctx.db.get(args.runId);
+  if (!run || run.modelVersion !== PUBLISHER_TEMPORAL_ABUSE_MODEL_VERSION) {
+    throw new Error("Scheduled temporal publisher abuse scan not found");
+  }
+  return run;
+}
+
+export const getScheduledTemporalScanStateInternal = internalQuery({
+  args: { runId: v.id("publisherAbuseScoreRuns") },
+  handler: getScheduledTemporalScanStateInternalHandler,
+});
+
+export async function storeScheduledTemporalScanPageInternalHandler(
+  ctx: MutationCtx,
+  args: {
+    runId: Id<"publisherAbuseScoreRuns">;
+    expectedCursor?: string;
+    nextCursor?: string;
+    isDone: boolean;
+    benchmarkScores: Pick<SkillTemporalAbuseScore, "recent30Downloads" | "spikeMultiplier">[];
+    candidates: TemporalSkillCandidate[];
+  },
+) {
+  const run = await getScheduledTemporalScanStateInternalHandler(ctx, { runId: args.runId });
+  const now = Date.now();
+  if (!isActiveScheduledTemporalRun(run, now) || run.temporalPipelinePhase !== "collecting") {
+    return { applied: false as const };
+  }
+  if ((run.temporalSourceCursor ?? null) !== (args.expectedCursor ?? null)) {
+    return { applied: false as const };
+  }
+  const expirationTime = run.startedAt + TEMPORAL_SCAN_RETENTION_MS;
+  for (const score of args.benchmarkScores) {
+    await ctx.db.insert("publisherAbuseTemporalScanSamples", {
+      runId: run._id,
+      recent30Downloads: Math.max(0, score.recent30Downloads),
+      spikeMultiplier: Math.max(0, score.spikeMultiplier),
+      expirationTime,
+    });
+  }
+  for (const candidate of args.candidates) {
+    await ctx.db.insert("publisherAbuseTemporalScanCandidates", {
+      runId: run._id,
+      ...candidate,
+      expirationTime,
+    });
+  }
+  await ctx.db.patch(run._id, {
+    temporalSourceCursor: args.isDone ? undefined : args.nextCursor,
+    temporalSampleSize: (run.temporalSampleSize ?? 0) + args.benchmarkScores.length,
+    temporalDownloadsSum:
+      (run.temporalDownloadsSum ?? 0) +
+      args.benchmarkScores.reduce((sum, score) => sum + Math.max(0, score.recent30Downloads), 0),
+    temporalPipelinePhase: args.isDone ? "downloads_percentiles" : "collecting",
+    updatedAt: now,
+  });
+  return { applied: true as const };
+}
+
+export const storeScheduledTemporalScanPageInternal = internalMutation({
+  args: {
+    runId: v.id("publisherAbuseScoreRuns"),
+    expectedCursor: v.optional(v.string()),
+    nextCursor: v.optional(v.string()),
+    isDone: v.boolean(),
+    benchmarkScores: v.array(
+      v.object({ recent30Downloads: v.number(), spikeMultiplier: v.number() }),
+    ),
+    candidates: v.array(temporalCandidateValidator),
+  },
+  handler: storeScheduledTemporalScanPageInternalHandler,
+});
+
+export async function readScheduledTemporalPercentilePageInternalHandler(
+  ctx: Pick<QueryCtx, "db">,
+  args: {
+    runId: Id<"publisherAbuseScoreRuns">;
+    metric: PercentileMetric;
+    cursor?: string;
+    batchSize?: number;
+  },
+) {
+  const batchSize = Math.max(1, Math.min(PERCENTILE_PAGE_SIZE, Math.trunc(args.batchSize ?? 500)));
+  const page =
+    args.metric === "downloads"
+      ? await ctx.db
+          .query("publisherAbuseTemporalScanSamples")
+          .withIndex("by_run_id_and_recent30_downloads", (q) => q.eq("runId", args.runId))
+          .order("asc")
+          .paginate({ cursor: args.cursor ?? null, numItems: batchSize })
+      : await ctx.db
+          .query("publisherAbuseTemporalScanSamples")
+          .withIndex("by_run_id_and_spike_multiplier", (q) => q.eq("runId", args.runId))
+          .order("asc")
+          .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
+  return {
+    values: page.page.map((sample) =>
+      args.metric === "downloads" ? sample.recent30Downloads : sample.spikeMultiplier,
+    ),
+    cursor: page.isDone ? undefined : page.continueCursor,
+    isDone: page.isDone,
+  };
+}
+
+export const readScheduledTemporalPercentilePageInternal = internalQuery({
+  args: {
+    runId: v.id("publisherAbuseScoreRuns"),
+    metric: v.union(v.literal("downloads"), v.literal("spike")),
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+  },
+  handler: readScheduledTemporalPercentilePageInternalHandler,
+});
+
+function percentileIndex(sampleSize: number, quantile: number) {
+  if (sampleSize <= 0) return 0;
+  return Math.max(0, Math.min(sampleSize - 1, Math.ceil(quantile * sampleSize) - 1));
+}
+
+function valueAtGlobalIndex(args: { values: number[]; pageStart: number; targetIndex: number }) {
+  const localIndex = args.targetIndex - args.pageStart;
+  return localIndex >= 0 && localIndex < args.values.length ? args.values[localIndex] : undefined;
+}
+
+export async function advanceScheduledTemporalPercentileInternalHandler(
+  ctx: MutationCtx,
+  args: {
+    runId: Id<"publisherAbuseScoreRuns">;
+    phase: "downloads_percentiles" | "spike_percentiles";
+    expectedCursor?: string;
+    nextCursor?: string;
+    isDone: boolean;
+    processed: number;
+    median?: number;
+    p95?: number;
+    p99?: number;
+  },
+) {
+  const run = await getScheduledTemporalScanStateInternalHandler(ctx, { runId: args.runId });
+  const now = Date.now();
+  if (!isActiveScheduledTemporalRun(run, now) || run.temporalPipelinePhase !== args.phase) {
+    return { applied: false as const };
+  }
+  const currentCursor =
+    args.phase === "downloads_percentiles" ? run.temporalDownloadsCursor : run.temporalSpikeCursor;
+  if ((currentCursor ?? null) !== (args.expectedCursor ?? null)) {
+    return { applied: false as const };
+  }
+  if (args.phase === "downloads_percentiles") {
+    await ctx.db.patch(run._id, {
+      temporalDownloadsCursor: args.isDone ? undefined : args.nextCursor,
+      temporalDownloadsProcessed: args.processed,
+      temporalDownloadsMedian: args.median ?? run.temporalDownloadsMedian,
+      temporalDownloadsP95: args.p95 ?? run.temporalDownloadsP95,
+      temporalDownloadsP99: args.p99 ?? run.temporalDownloadsP99,
+      temporalPipelinePhase: args.isDone ? "spike_percentiles" : args.phase,
+      updatedAt: now,
+    });
+    return { applied: true as const };
+  }
+  const spikeP95 = args.p95 ?? run.temporalSpikeP95;
+  const spikeP99 = args.p99 ?? run.temporalSpikeP99;
+  const benchmark = args.isDone
+    ? temporalBenchmarkFromRun({ ...run, temporalSpikeP95: spikeP95, temporalSpikeP99: spikeP99 })
+    : undefined;
+  await ctx.db.patch(run._id, {
+    temporalSpikeCursor: args.isDone ? undefined : args.nextCursor,
+    temporalSpikeProcessed: args.processed,
+    temporalSpikeP95: spikeP95,
+    temporalSpikeP99: spikeP99,
+    temporalBenchmark: benchmark,
+    temporalPipelinePhase: args.isDone ? "classifying" : args.phase,
+    updatedAt: now,
+  });
+  return { applied: true as const };
+}
+
+export const advanceScheduledTemporalPercentileInternal = internalMutation({
+  args: {
+    runId: v.id("publisherAbuseScoreRuns"),
+    phase: v.union(v.literal("downloads_percentiles"), v.literal("spike_percentiles")),
+    expectedCursor: v.optional(v.string()),
+    nextCursor: v.optional(v.string()),
+    isDone: v.boolean(),
+    processed: v.number(),
+    median: v.optional(v.number()),
+    p95: v.optional(v.number()),
+    p99: v.optional(v.number()),
+  },
+  handler: advanceScheduledTemporalPercentileInternalHandler,
+});
+
+function temporalBenchmarkFromRun(run: TemporalScanRun): TemporalAbuseCohortBenchmark {
+  const sampleSize = run.temporalSampleSize ?? 0;
+  return {
+    scope: "all_active_skills",
+    sampleSize,
+    downloads30dAverage: sampleSize > 0 ? (run.temporalDownloadsSum ?? 0) / sampleSize : 0,
+    downloads30dMedian: run.temporalDownloadsMedian ?? 0,
+    downloads30dP95: run.temporalDownloadsP95 ?? 0,
+    downloads30dP99: run.temporalDownloadsP99 ?? 0,
+    spikeMultiplier7dP95: run.temporalSpikeP95 ?? 0,
+    spikeMultiplier7dP99: run.temporalSpikeP99 ?? 0,
+  };
+}
+
+export async function readScheduledTemporalCandidatesPageInternalHandler(
+  ctx: Pick<QueryCtx, "db">,
+  args: { runId: Id<"publisherAbuseScoreRuns">; cursor?: string; batchSize?: number },
+) {
+  const batchSize = Math.max(1, Math.min(CANDIDATE_PAGE_SIZE, Math.trunc(args.batchSize ?? 100)));
+  const page = await ctx.db
+    .query("publisherAbuseTemporalScanCandidates")
+    .withIndex("by_run_id", (q) => q.eq("runId", args.runId))
+    .paginate({ cursor: args.cursor ?? null, numItems: batchSize });
+  return {
+    candidates: page.page.map(({ expirationTime: _expirationTime, runId: _runId, ...candidate }) =>
+      candidateFromScanRow(candidate),
+    ),
+    cursor: page.isDone ? undefined : page.continueCursor,
+    isDone: page.isDone,
+  };
+}
+
+function candidateFromScanRow(
+  row: Omit<Doc<"publisherAbuseTemporalScanCandidates">, "expirationTime" | "runId">,
+): TemporalSkillCandidate {
+  return {
+    ownerKey: row.ownerKey,
+    ownerPublisherId: row.ownerPublisherId,
+    ownerUserId: row.ownerUserId,
+    handleSnapshot: row.handleSnapshot,
+    skillId: row.skillId,
+    slug: row.slug,
+    displayName: row.displayName,
+    totalDownloads: row.totalDownloads,
+    totalInstalls: row.totalInstalls,
+    temporalScore: row.temporalScore,
+  };
+}
+
+export const readScheduledTemporalCandidatesPageInternal = internalQuery({
+  args: {
+    runId: v.id("publisherAbuseScoreRuns"),
+    cursor: v.optional(v.string()),
+    batchSize: v.optional(v.number()),
+  },
+  handler: readScheduledTemporalCandidatesPageInternalHandler,
+});
+
+export async function advanceScheduledTemporalCandidatesInternalHandler(
+  ctx: MutationCtx,
+  args: {
+    runId: Id<"publisherAbuseScoreRuns">;
+    expectedCursor?: string;
+    nextCursor?: string;
+    isDone: boolean;
+    candidates: TemporalSkillCandidate[];
+  },
+) {
+  const run = await getScheduledTemporalScanStateInternalHandler(ctx, { runId: args.runId });
+  const now = Date.now();
+  if (!isActiveScheduledTemporalRun(run, now) || run.temporalPipelinePhase !== "classifying") {
+    return { applied: false as const };
+  }
+  if ((run.temporalCandidateCursor ?? null) !== (args.expectedCursor ?? null)) {
+    return { applied: false as const };
+  }
+  if (!run.temporalBenchmark) throw new Error("Temporal scan benchmark is missing");
+  if (args.candidates.length > 0) {
+    await archiveTemporalPublisherAbuseSignals(ctx, {
+      runId: run._id,
+      candidates: args.candidates,
+      benchmark: run.temporalBenchmark,
+      now,
+    });
+  }
+  const finalizedScores = run.finalizedScores + args.candidates.length;
+  await ctx.db.patch(run._id, {
+    temporalCandidateCursor: args.isDone ? undefined : args.nextCursor,
+    temporalPipelinePhase: args.isDone ? "completed" : "classifying",
+    temporalScanComplete: args.isDone,
+    status: args.isDone ? "completed" : "running",
+    phase: args.isDone ? "completed" : "finalizing",
+    completedAt: args.isDone ? now : undefined,
+    finalizedScores,
+    reviewCount: finalizedScores,
+    updatedAt: now,
+  });
+  return { applied: true as const };
+}
+
+export const advanceScheduledTemporalCandidatesInternal = internalMutation({
+  args: {
+    runId: v.id("publisherAbuseScoreRuns"),
+    expectedCursor: v.optional(v.string()),
+    nextCursor: v.optional(v.string()),
+    isDone: v.boolean(),
+    candidates: v.array(temporalCandidateValidator),
+  },
+  handler: advanceScheduledTemporalCandidatesInternalHandler,
+});
+
+export async function failExpiredScheduledTemporalScanInternalHandler(
+  ctx: MutationCtx,
+  args: { runId: Id<"publisherAbuseScoreRuns"> },
+) {
+  const run = await getScheduledTemporalScanStateInternalHandler(ctx, { runId: args.runId });
+  const now = Date.now();
+  if (run.status !== "running" || now - run.startedAt < TEMPORAL_SCAN_RETENTION_MS) {
+    return { failed: false as const };
+  }
+  await ctx.db.patch(run._id, {
+    status: "failed",
+    temporalScanComplete: false,
+    errorMessage: "Scheduled temporal scan exceeded its seven-day working-state retention.",
+    updatedAt: now,
+  });
+  return { failed: true as const };
+}
+
+export const failExpiredScheduledTemporalScanInternal = internalMutation({
+  args: { runId: v.id("publisherAbuseScoreRuns") },
+  handler: failExpiredScheduledTemporalScanInternalHandler,
+});
+
+type TemporalSourcePage = {
+  cursor?: string;
+  isDone: boolean;
+  scannedSkills: number;
+  benchmarkScores?: SkillTemporalAbuseScore[];
+  candidates: TemporalSkillCandidate[];
+};
+
+type PercentilePage = { values: number[]; cursor?: string; isDone: boolean };
+type CandidatePage = { candidates: TemporalSkillCandidate[]; cursor?: string; isDone: boolean };
+
+export async function runScheduledTemporalPublisherAbuseScanInternalHandler(
+  ctx: ActionCtx,
+  args: { runId?: Id<"publisherAbuseScoreRuns"> },
+) {
+  const start = args.runId
+    ? { runId: args.runId }
+    : await ctx.runMutation(
+        internal.publisherAbuseTemporalScan.getOrStartScheduledTemporalScanInternal,
+        {},
+      );
+  const run: TemporalScanRun = await ctx.runQuery(
+    internal.publisherAbuseTemporalScan.getScheduledTemporalScanStateInternal,
+    { runId: start.runId },
+  );
+  if (run.status !== "running" || run.temporalPipelinePhase === "completed") {
+    return { ok: true as const, runId: run._id, completed: true as const };
+  }
+  if (!isActiveScheduledTemporalRun(run, Date.now())) {
+    await ctx.runMutation(
+      internal.publisherAbuseTemporalScan.failExpiredScheduledTemporalScanInternal,
+      { runId: run._id },
+    );
+    return {
+      ok: false as const,
+      runId: run._id,
+      completed: false as const,
+      expired: true as const,
+    };
+  }
+
+  if (run.temporalPipelinePhase === "collecting") {
+    const sourcePage: TemporalSourcePage = await ctx.runQuery(
+      internal.publisherAbuse.collectTemporalPublisherAbuseSkillCandidatesPageInternal,
+      {
+        mode: "current",
+        cursor: run.temporalSourceCursor,
+        batchSize: SOURCE_PAGE_SIZE,
+        todayDay: run.temporalTodayDay,
+      },
+    );
+    await ctx.runMutation(
+      internal.publisherAbuseTemporalScan.storeScheduledTemporalScanPageInternal,
+      {
+        runId: run._id,
+        expectedCursor: run.temporalSourceCursor,
+        nextCursor: sourcePage.cursor,
+        isDone: sourcePage.isDone,
+        benchmarkScores:
+          sourcePage.benchmarkScores ??
+          sourcePage.candidates.map(({ temporalScore }) => ({
+            recent30Downloads: temporalScore.recent30Downloads,
+            spikeMultiplier: temporalScore.spikeMultiplier,
+          })),
+        candidates: sourcePage.candidates,
+      },
+    );
+  } else if (
+    run.temporalPipelinePhase === "downloads_percentiles" ||
+    run.temporalPipelinePhase === "spike_percentiles"
+  ) {
+    const metric: PercentileMetric =
+      run.temporalPipelinePhase === "downloads_percentiles" ? "downloads" : "spike";
+    const cursor = metric === "downloads" ? run.temporalDownloadsCursor : run.temporalSpikeCursor;
+    const processed =
+      metric === "downloads"
+        ? (run.temporalDownloadsProcessed ?? 0)
+        : (run.temporalSpikeProcessed ?? 0);
+    const page: PercentilePage = await ctx.runQuery(
+      internal.publisherAbuseTemporalScan.readScheduledTemporalPercentilePageInternal,
+      { runId: run._id, metric, cursor, batchSize: PERCENTILE_PAGE_SIZE },
+    );
+    const sampleSize = run.temporalSampleSize ?? 0;
+    const p95 = valueAtGlobalIndex({
+      values: page.values,
+      pageStart: processed,
+      targetIndex: percentileIndex(sampleSize, 0.95),
+    });
+    const p99 = valueAtGlobalIndex({
+      values: page.values,
+      pageStart: processed,
+      targetIndex: percentileIndex(sampleSize, 0.99),
+    });
+    const median =
+      metric === "downloads"
+        ? valueAtGlobalIndex({
+            values: page.values,
+            pageStart: processed,
+            targetIndex: percentileIndex(sampleSize, 0.5),
+          })
+        : undefined;
+    await ctx.runMutation(
+      internal.publisherAbuseTemporalScan.advanceScheduledTemporalPercentileInternal,
+      {
+        runId: run._id,
+        phase: run.temporalPipelinePhase,
+        expectedCursor: cursor,
+        nextCursor: page.cursor,
+        isDone: page.isDone,
+        processed: processed + page.values.length,
+        median: sampleSize === 0 ? 0 : median,
+        p95: sampleSize === 0 ? 0 : p95,
+        p99: sampleSize === 0 ? 0 : p99,
+      },
+    );
+  } else if (run.temporalPipelinePhase === "classifying") {
+    if (!run.temporalBenchmark) throw new Error("Temporal scan benchmark is missing");
+    const page: CandidatePage = await ctx.runQuery(
+      internal.publisherAbuseTemporalScan.readScheduledTemporalCandidatesPageInternal,
+      {
+        runId: run._id,
+        cursor: run.temporalCandidateCursor,
+        batchSize: CANDIDATE_PAGE_SIZE,
+      },
+    );
+    const highCandidates = page.candidates
+      .map((candidate) => ({
+        ...candidate,
+        temporalScore: classifySkillTemporalAbuseScore(
+          candidate.temporalScore,
+          run.temporalBenchmark,
+        ),
+      }))
+      .filter(
+        ({ temporalScore }) =>
+          temporalScore.spike || temporalScore.sustained || temporalScore.nearConversion,
+      );
+    await ctx.runMutation(
+      internal.publisherAbuseTemporalScan.advanceScheduledTemporalCandidatesInternal,
+      {
+        runId: run._id,
+        expectedCursor: run.temporalCandidateCursor,
+        nextCursor: page.cursor,
+        isDone: page.isDone,
+        candidates: highCandidates,
+      },
+    );
+    if (page.isDone) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.publisherAbuse.notifyPublisherAbuseSignalChangesInternal,
+        {},
+      );
+      return { ok: true as const, runId: run._id, completed: true as const };
+    }
+  }
+
+  await ctx.scheduler.runAfter(
+    0,
+    internal.publisherAbuseTemporalScan.runScheduledTemporalPublisherAbuseScanInternal,
+    { runId: run._id },
+  );
+  return {
+    ok: true as const,
+    runId: run._id,
+    completed: false as const,
+    phase: run.temporalPipelinePhase,
+  };
+}
+
+export const runScheduledTemporalPublisherAbuseScanInternal = internalAction({
+  args: { runId: v.optional(v.id("publisherAbuseScoreRuns")) },
+  handler: runScheduledTemporalPublisherAbuseScanInternalHandler,
+});
+
+export async function pruneExpiredTemporalScanRowsInternalHandler(
+  ctx: MutationCtx,
+  args: { batchSize?: number },
+) {
+  const batchSize = Math.max(
+    1,
+    Math.min(
+      RETENTION_STANDARD_BATCH_SIZE,
+      Math.trunc(args.batchSize ?? RETENTION_STANDARD_BATCH_SIZE),
+    ),
+  );
+  const now = Date.now();
+  const [samples, candidates] = await Promise.all([
+    ctx.db
+      .query("publisherAbuseTemporalScanSamples")
+      .withIndex("by_expiration_time", (q) => q.lt("expirationTime", now))
+      .take(batchSize),
+    ctx.db
+      .query("publisherAbuseTemporalScanCandidates")
+      .withIndex("by_expiration_time", (q) => q.lt("expirationTime", now))
+      .take(batchSize),
+  ]);
+  for (const row of [...samples, ...candidates]) await ctx.db.delete(row._id);
+  const hasMore = samples.length === batchSize || candidates.length === batchSize;
+  if (hasMore) {
+    await ctx.scheduler.runAfter(
+      0,
+      internal.publisherAbuseTemporalScan.pruneExpiredTemporalScanRowsInternal,
+      { batchSize },
+    );
+  }
+  return { samplesDeleted: samples.length, candidatesDeleted: candidates.length, hasMore };
+}
+
+export const pruneExpiredTemporalScanRowsInternal = internalMutation({
+  args: { batchSize: v.optional(v.number()) },
+  handler: pruneExpiredTemporalScanRowsInternalHandler,
+});
+
+export const temporalBenchmarkForScheduledScanInternal = internalQuery({
+  args: { runId: v.id("publisherAbuseScoreRuns") },
+  returns: v.union(temporalBenchmarkValidator, v.null()),
+  handler: async (ctx, args) => {
+    const run = await ctx.db.get(args.runId);
+    return run?.temporalBenchmark ?? null;
+  },
+});
+
+export { percentileIndex, temporalBenchmarkFromRun, valueAtGlobalIndex };

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2735,8 +2735,32 @@ const publisherAbuseScoreRuns = defineTable({
   stdDevLogPressure: v.optional(v.number()),
   temporalMode: v.optional(v.union(v.literal("current"), v.literal("backfill"))),
   temporalScanComplete: v.optional(v.boolean()),
+  temporalPipelinePhase: v.optional(
+    v.union(
+      v.literal("collecting"),
+      v.literal("downloads_percentiles"),
+      v.literal("spike_percentiles"),
+      v.literal("classifying"),
+      v.literal("completed"),
+    ),
+  ),
+  temporalTodayDay: v.optional(v.number()),
+  temporalSourceCursor: v.optional(v.string()),
+  temporalDownloadsCursor: v.optional(v.string()),
+  temporalSpikeCursor: v.optional(v.string()),
+  temporalCandidateCursor: v.optional(v.string()),
+  temporalSampleSize: v.optional(v.number()),
+  temporalDownloadsSum: v.optional(v.number()),
+  temporalDownloadsProcessed: v.optional(v.number()),
+  temporalSpikeProcessed: v.optional(v.number()),
+  temporalDownloadsMedian: v.optional(v.number()),
+  temporalDownloadsP95: v.optional(v.number()),
+  temporalDownloadsP99: v.optional(v.number()),
+  temporalSpikeP95: v.optional(v.number()),
+  temporalSpikeP99: v.optional(v.number()),
   temporalBenchmark: v.optional(
     v.object({
+      scope: v.optional(v.literal("all_active_skills")),
       sampleSize: v.number(),
       downloads30dAverage: v.number(),
       downloads30dMedian: v.number(),
@@ -2755,6 +2779,12 @@ const publisherAbuseScoreRuns = defineTable({
   .index("by_status_and_updated_at", ["status", "updatedAt"])
   .index("by_model_version_and_started_at", ["modelVersion", "startedAt"])
   .index("by_model_version_and_status_and_updated_at", ["modelVersion", "status", "updatedAt"])
+  .index("by_model_version_and_status_and_trigger_and_updated_at", [
+    "modelVersion",
+    "status",
+    "trigger",
+    "updatedAt",
+  ])
   .index("by_model_status_phase_temporal_complete_started_at", [
     "modelVersion",
     "status",
@@ -2764,6 +2794,63 @@ const publisherAbuseScoreRuns = defineTable({
     "startedAt",
   ])
   .index("by_started_at", ["startedAt"]);
+
+const publisherAbuseTemporalScanSamples = defineTable({
+  runId: v.id("publisherAbuseScoreRuns"),
+  recent30Downloads: v.number(),
+  spikeMultiplier: v.number(),
+  expirationTime: v.number(),
+})
+  .index("by_run_id_and_recent30_downloads", ["runId", "recent30Downloads"])
+  .index("by_run_id_and_spike_multiplier", ["runId", "spikeMultiplier"])
+  .index("by_expiration_time", ["expirationTime"]);
+
+const publisherAbuseTemporalScanScoreValidator = v.object({
+  spike: v.boolean(),
+  sustained: v.boolean(),
+  nearConversion: v.boolean(),
+  pressure: v.number(),
+  recent7Downloads: v.number(),
+  recent7Installs: v.number(),
+  previous30Downloads: v.number(),
+  baseline7Downloads: v.number(),
+  spikeMultiplier: v.number(),
+  recent30Downloads: v.number(),
+  recent30Installs: v.number(),
+  downloadInstallRatio30: v.number(),
+  downloads30dCohortBand: v.optional(v.union(v.literal("p95"), v.literal("p99"))),
+  spikeMultiplierCohortBand: v.optional(v.union(v.literal("p95"), v.literal("p99"))),
+  downloads30dVsPeerP95: v.optional(v.number()),
+  spikeMultiplierVsPeerP95: v.optional(v.number()),
+  installDownloadRatio7: v.number(),
+  installDownloadRatio30: v.number(),
+  installDownloadExcessZScore7: v.number(),
+  installDownloadExcessZScore30: v.number(),
+  spikeWindowStartDay: v.optional(v.number()),
+  spikeWindowEndDay: v.optional(v.number()),
+  sustainedWindowStartDay: v.optional(v.number()),
+  sustainedWindowEndDay: v.optional(v.number()),
+  nearConversionWindowStartDay: v.optional(v.number()),
+  nearConversionWindowEndDay: v.optional(v.number()),
+  reasonCodes: v.array(v.string()),
+});
+
+const publisherAbuseTemporalScanCandidates = defineTable({
+  runId: v.id("publisherAbuseScoreRuns"),
+  ownerKey: v.string(),
+  ownerPublisherId: v.optional(v.id("publishers")),
+  ownerUserId: v.optional(v.id("users")),
+  handleSnapshot: v.string(),
+  skillId: v.id("skills"),
+  slug: v.string(),
+  displayName: v.string(),
+  totalDownloads: v.number(),
+  totalInstalls: v.number(),
+  temporalScore: publisherAbuseTemporalScanScoreValidator,
+  expirationTime: v.number(),
+})
+  .index("by_run_id", ["runId"])
+  .index("by_expiration_time", ["expirationTime"]);
 
 const publisherAbuseScores = defineTable({
   runId: v.id("publisherAbuseScoreRuns"),
@@ -2792,6 +2879,7 @@ const publisherAbuseScores = defineTable({
   temporalMaxPressure: v.optional(v.number()),
   temporalBenchmark: v.optional(
     v.object({
+      scope: v.optional(v.literal("all_active_skills")),
       sampleSize: v.number(),
       downloads30dAverage: v.number(),
       downloads30dMedian: v.number(),
@@ -2942,6 +3030,18 @@ const publisherAbuseSignals = defineTable({
   allTimeDownloads: v.number(),
   allTimeInstalls: v.number(),
   allTimeInstallDownloadRatio: v.number(),
+  temporalBenchmark: v.optional(
+    v.object({
+      scope: v.optional(v.literal("all_active_skills")),
+      sampleSize: v.number(),
+      downloads30dAverage: v.number(),
+      downloads30dMedian: v.number(),
+      downloads30dP95: v.number(),
+      downloads30dP99: v.number(),
+      spikeMultiplier7dP95: v.number(),
+      spikeMultiplier7dP99: v.number(),
+    }),
+  ),
   reviewStatus: publisherAbuseSignalReviewStatusValidator,
   snoozedUntil: v.optional(v.number()),
   reviewedByUserId: v.optional(v.id("users")),
@@ -3266,6 +3366,8 @@ export default defineSchema({
   auditLogs,
   systemSettings,
   publisherAbuseScoreRuns,
+  publisherAbuseTemporalScanSamples,
+  publisherAbuseTemporalScanCandidates,
   publisherAbuseScores,
   publisherAbuseReviewNominations,
   publisherAbuseReviewEvents,

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -64,15 +64,28 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
 - Publisher abuse scoring classifies bulk-publishing abuse for staff review and
   warning-first automatic enforcement. Scheduled pressure scoring runs daily.
   Plain temporal dry runs are read-only. The scheduled temporal scan explicitly
-  opts into archived dry-run signal rows for the staff Signals tab until it has
-  persisted aggregation/cursor state. The `review` label remains a
-  calibration/manual-review signal. The `potential_ban_candidate` label is an
+  opts into archived dry-run signal rows for the staff Signals tab. It persists
+  bounded source pages, exact percentile samples, and review candidates, then
+  resumes through percentile and classification phases. Temporary scan rows
+  expire after seven days. Explicitly bounded manual scans remain diagnostic-only.
+  The `review` label remains a calibration/manual-review signal. The
+  `potential_ban_candidate` label is an
   enforcement signal only for pressure-score nominations: the first eligible
   enforcement sweep must warn the linked non-staff user by email and persist the
   warning score/run/deadline on the nomination. A later sweep may automatically
   ban only after the warning deadline has passed and a newer pressure score
   still places the publisher in `potential_ban_candidate`. A stale warning by
   itself is not enough to ban.
+- Temporal download percentiles use the full active-skill population, including
+  zero-download, official, staff-owned, and personal skills. Publisher
+  exclusions apply only to review candidates, not to the platform benchmark.
+  Partial scans must not archive signals or present their top-download slice as
+  a platform percentile.
+- Flat-install temporal review signals are deliberately high-confidence:
+  sustained volume must exceed the platform P99, reach at least 3,000 downloads
+  in 30 days, and have at most 5 installs; a spike must exceed the platform P99,
+  reach at least 2,000 downloads in 7 days, and have at most 2 installs. These
+  signals indicate anomalous traffic for manual review, not publisher attribution.
 - Publisher abuse scoring must skip staff-linked and official publishers before
   nominations are created. Publisher abuse autoban must process pending
   `potential_ban_candidate` pressure nominations without waiting for the score

--- a/src/routes/-management.test.tsx
+++ b/src/routes/-management.test.tsx
@@ -114,6 +114,16 @@ function makePublisherAbuseSignal() {
       allTimeDownloads: 10_000,
       allTimeInstalls: 1_200,
       allTimeInstallDownloadRatio: 0.12,
+      temporalBenchmark: {
+        scope: "all_active_skills",
+        sampleSize: 1000,
+        downloads30dAverage: 180,
+        downloads30dMedian: 45,
+        downloads30dP95: 900,
+        downloads30dP99: 3000,
+        spikeMultiplier7dP95: 4,
+        spikeMultiplier7dP99: 12,
+      },
     },
     publisher: {
       _id: "publishers:ratio-owner",
@@ -539,6 +549,9 @@ describe("Management", () => {
     expect(screen.getByText("96 installs / 800 downloads")).toBeTruthy();
     expect(screen.getByText("288 installs / 2,400 downloads")).toBeTruthy();
     expect(screen.getByText("1,200 installs / 10,000 downloads")).toBeTruthy();
+    expect(
+      screen.getByText(/Platform 30d downloads across all 1,000 active skills: P95 900, P99 3,000/),
+    ).toBeTruthy();
     expect(screen.getByRole("button", { name: /^Snooze 14 days$/ })).toBeTruthy();
     expect(screen.getByRole("button", { name: /^Dismiss signal$/ })).toBeTruthy();
     expect(screen.queryByRole("columnheader", { name: "Z-score" })).toBeNull();
@@ -1398,9 +1411,54 @@ describe("Management", () => {
   });
 
   it("shows temporal download/install evidence in the abuse drawer", () => {
+    const temporalEvidence = [
+      {
+        skillId: "skills:burst",
+        slug: "download-burst",
+        displayName: "Download Burst",
+        spike: false,
+        sustained: true,
+        pressure: 18,
+        recent7Downloads: 5000,
+        recent7Installs: 0,
+        previous30Downloads: 120,
+        baseline7Downloads: 100,
+        spikeMultiplier: 8,
+        recent30Downloads: 16_200,
+        recent30Installs: 0,
+        downloadInstallRatio30: 16_200,
+        downloads30dCohortBand: "p99",
+        downloads30dVsPeerP95: 18,
+        spikeMultiplierVsPeerP95: 2,
+        sustainedWindowStartDay: 1,
+        sustainedWindowEndDay: 30,
+        reasonCodes: ["temporal_sustained_downloads_flat_installs"],
+      },
+    ];
     const item = makePublisherAbuseItem({
       handle: "temporal-pub",
       zScore: 2.65,
+      scoreOverrides: {
+        modelVersion: "publisher-abuse-temporal.v1",
+        pressure: 1101,
+        temporalMaxPressure: 1,
+        reasonCodes: ["temporal_sustained_downloads_flat_installs"],
+        temporalBenchmark: {
+          scope: "all_active_skills",
+          sampleSize: 1000,
+          downloads30dAverage: 180,
+          downloads30dMedian: 45,
+          downloads30dP95: 900,
+          downloads30dP99: 3000,
+          spikeMultiplier7dP95: 4,
+          spikeMultiplier7dP99: 12,
+        },
+        temporalEvidence,
+      },
+    });
+    const legacyItem = makePublisherAbuseItem({
+      handle: "legacy-temporal-pub",
+      id: "2",
       scoreOverrides: {
         modelVersion: "publisher-abuse-temporal.v1",
         pressure: 1101,
@@ -1415,30 +1473,7 @@ describe("Management", () => {
           spikeMultiplier7dP95: 4,
           spikeMultiplier7dP99: 12,
         },
-        temporalEvidence: [
-          {
-            skillId: "skills:burst",
-            slug: "download-burst",
-            displayName: "Download Burst",
-            spike: false,
-            sustained: true,
-            pressure: 18,
-            recent7Downloads: 5000,
-            recent7Installs: 0,
-            previous30Downloads: 120,
-            baseline7Downloads: 100,
-            spikeMultiplier: 8,
-            recent30Downloads: 16_200,
-            recent30Installs: 0,
-            downloadInstallRatio30: 16_200,
-            downloads30dCohortBand: "p99",
-            downloads30dVsPeerP95: 18,
-            spikeMultiplierVsPeerP95: 2,
-            sustainedWindowStartDay: 1,
-            sustainedWindowEndDay: 30,
-            reasonCodes: ["temporal_sustained_downloads_flat_installs"],
-          },
-        ],
+        temporalEvidence,
       },
     });
 
@@ -1452,7 +1487,7 @@ describe("Management", () => {
         return {
           latestRun: null,
           pendingItems: [],
-          pendingPotentialBanCandidateItems: [item],
+          pendingPotentialBanCandidateItems: [item, legacyItem],
           pendingReviewItems: [],
           recentResolvedItems: [],
         };
@@ -1468,10 +1503,15 @@ describe("Management", () => {
     expect(screen.getByText("Temporal signal")).toBeTruthy();
     expect(screen.getByText("Low (1)")).toBeTruthy();
     expect(screen.queryByText("Very High")).toBeNull();
-    expect(screen.getByText(/Compared with 1,000 scanned skills/)).toBeTruthy();
+    expect(screen.getByText(/Compared with all 1,000 active skills/)).toBeTruthy();
     expect(screen.getByText("Download Burst")).toBeTruthy();
     expect(screen.getByText("16,200")).toBeTruthy();
-    expect(screen.getByText("Peer 30d P95")).toBeTruthy();
+    expect(screen.getByText("Platform 30d P95")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("legacy-temporal-pub"));
+
+    expect(screen.getByText(/Compared with a legacy cohort of 1,000 active skills/)).toBeTruthy();
+    expect(screen.getByText("Legacy cohort 30d P95")).toBeTruthy();
   });
 
   it("bans potential-ban nominations through the publisher abuse flow", async () => {

--- a/src/routes/-management/AbusePage.tsx
+++ b/src/routes/-management/AbusePage.tsx
@@ -1022,6 +1022,14 @@ function PublisherAbuseSignalInspector({
               ratio={item.signal.allTimeInstallDownloadRatio}
             />
           </div>
+          {item.signal.temporalBenchmark?.scope === "all_active_skills" ? (
+            <p className="pa-hint">
+              Platform 30d downloads across all{" "}
+              {formatWholeNumber(item.signal.temporalBenchmark.sampleSize)} active skills: P95{" "}
+              {formatWholeNumber(item.signal.temporalBenchmark.downloads30dP95)}, P99{" "}
+              {formatWholeNumber(item.signal.temporalBenchmark.downloads30dP99)}.
+            </p>
+          ) : null}
         </section>
 
         <section className="pa-zone">
@@ -1222,12 +1230,14 @@ function PublisherTemporalEvidence({ score }: { score: PublisherAbuseReviewScore
   if (!evidence.length) return null;
 
   const benchmark = score?.temporalBenchmark;
+  const isPlatformBenchmark = benchmark?.scope === "all_active_skills";
   return (
     <div className="pa-activity-evidence">
       <div className="pa-subsection-label">Temporal signal</div>
       {benchmark ? (
         <p className="pa-hint">
-          Compared with {formatWholeNumber(benchmark.sampleSize)} scanned skills: 30d download P95{" "}
+          Compared with {isPlatformBenchmark ? "all" : "a legacy cohort of"}{" "}
+          {formatWholeNumber(benchmark.sampleSize)} active skills: 30d download P95{" "}
           {formatWholeNumber(benchmark.downloads30dP95)}, P99{" "}
           {formatWholeNumber(benchmark.downloads30dP99)}.
         </p>
@@ -1254,16 +1264,22 @@ function PublisherTemporalEvidence({ score }: { score: PublisherAbuseReviewScore
             <div className="pa-temporal-metrics">
               <PublisherAbuseMetric label="30d downloads" value={item.recent30Downloads} />
               {benchmark ? (
-                <PublisherAbuseMetric label="Peer 30d P95" value={benchmark.downloads30dP95} />
+                <PublisherAbuseMetric
+                  label={`${isPlatformBenchmark ? "Platform" : "Legacy cohort"} 30d P95`}
+                  value={benchmark.downloads30dP95}
+                />
               ) : null}
               {benchmark ? (
-                <PublisherAbuseMetric label="Peer 30d P99" value={benchmark.downloads30dP99} />
+                <PublisherAbuseMetric
+                  label={`${isPlatformBenchmark ? "Platform" : "Legacy cohort"} 30d P99`}
+                  value={benchmark.downloads30dP99}
+                />
               ) : null}
               <PublisherAbuseMetric label="30d vs P95" value={item.downloads30dVsPeerP95} ratio />
               <PublisherAbuseMetric label="7d spike multiple" value={item.spikeMultiplier} ratio />
               {benchmark ? (
                 <PublisherAbuseMetric
-                  label="Peer spike P95"
+                  label={`${isPlatformBenchmark ? "Platform" : "Legacy cohort"} spike P95`}
                   value={benchmark.spikeMultiplier7dP95}
                   ratio
                 />


### PR DESCRIPTION
## New behavior

Temporal abuse percentiles now describe the full active-skill population instead of the top downloaded cohort. Zero-download, personal, official, and staff-owned skills all contribute to the platform benchmark; protected publishers remain excluded only from review candidates.

The daily scan is bounded and resumable:

1. Persist 100-skill source pages into short-lived scan rows.
2. Read the persisted samples in indexed order to capture exact nearest-rank median/P95/P99 values.
3. Classify persisted review candidates against the completed benchmark.
4. Archive signals and the benchmark atomically, then expire temporary rows after seven days.

Partial or explicitly bounded manual scans cannot present or archive a platform percentile. Legacy unscoped benchmarks remain labeled as legacy cohorts.

## Review thresholds

| Signal | Required conditions |
| --- | --- |
| Sustained downloads with flat installs | Above platform P99, at least 3,000 downloads in 30 days, and at most 5 installs |
| Download spike with flat installs | Above platform P99, at least 2,000 downloads in 7 days, and at most 2 installs |

These remain anomalous-traffic signals for manual review; they do not attribute the traffic to the publisher.

## Dashboard

The Signals inspector now shows the all-active-skills sample size and platform 30-day P95/P99 stored with the signal. Older unscoped review evidence is not mislabeled as platform-wide.

Screenshot unavailable: no local checkout on this machine has matching `.env.local` and `.convex` state required to render the staff-only drawer in a real running ClawHub instance. The exact visible copy and both current/legacy states are covered by the management route test.

## How to verify

1. Start the scheduled temporal scan and confirm repeated continuations advance one persisted page at a time.
2. Confirm the completed benchmark sample size matches every active skill, including protected and zero-download skills.
3. Confirm an AnySearch-like score (3,370 downloads / 4 installs in 30 days) opens only when it exceeds platform P99.
4. Mark a scan failed/expired while classification is in flight and confirm it cannot archive or revive the run.

## Checks

- `bun run ci:static` — passed.
- `bun run ci:unit` — passed: 4,638 tests, 1 skipped; coverage thresholds satisfied.
- `bun run ci:types-build` — passed, including package typechecks and production build.
- Focused temporal/retention/management slice — passed: 216 tests.
- Structured branch review — clean; no accepted/actionable findings.
- Real Convex codegen/dev runtime validation not run: no checkout on this machine has a configured non-production deployment; production was not modified. The deterministic generated API module entry was updated with the new function module.
