### PR TITLE
fix(ci): increase security scan runner memory

### DIFF
--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   codex-security-scan:
     name: Codex security scan ${{ matrix.lane }} shard ${{ matrix.shard }}
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 40
     environment: Production
     strategy:


### PR DESCRIPTION
## Summary

- run the security scan worker on Blacksmith's 16 vCPU runner
- increase available memory for concurrent SkillSpector/ClawScan work after confirmed OOM failures on the previous runner

## Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/security-scan-codex.yml`
- `bun run ci:static`
- `git diff --check`
