### PR TITLE
fix: bound temporal scan source pages

### DIFF
--- a/convex/publisherAbuseTemporalScan.test.ts
+++ b/convex/publisherAbuseTemporalScan.test.ts
@@ -179,6 +179,35 @@ describe("scheduled temporal publisher abuse scan", () => {
     );
   });
 
+  it("keeps source pages below the dense daily-stat read budget", async () => {
+    const run = temporalRun();
+    const runQuery = vi.fn().mockResolvedValueOnce(run).mockResolvedValueOnce({
+      benchmarkScores: [],
+      candidates: [],
+      cursor: "next-page",
+      isDone: false,
+      scannedSkills: 0,
+    });
+    const runMutation = vi.fn(async () => ({ applied: true }));
+    const scheduler = { runAfter: vi.fn(async () => null) };
+    const handler = runScheduledTemporalPublisherAbuseScanInternalHandler as unknown as (
+      ctx: {
+        runQuery: typeof runQuery;
+        runMutation: typeof runMutation;
+        scheduler: typeof scheduler;
+      },
+      args: { runId?: Id<"publisherAbuseScoreRuns"> },
+    ) => Promise<unknown>;
+
+    await handler({ runQuery, runMutation, scheduler }, { runId: run._id });
+
+    expect(runQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      expect.objectContaining({ batchSize: 50 }),
+    );
+  });
+
   it("archives classified candidates with the completed full-platform benchmark", async () => {
     const benchmark = {
       scope: "all_active_skills" as const,

--- a/convex/publisherAbuseTemporalScan.ts
+++ b/convex/publisherAbuseTemporalScan.ts
@@ -17,7 +17,8 @@ import {
   type TemporalSkillCandidate,
 } from "./publisherAbuse";
 
-const SOURCE_PAGE_SIZE = 100;
+// Leave room for up to 37 daily-stat rows plus publisher exclusion reads per skill.
+const SOURCE_PAGE_SIZE = 50;
 const PERCENTILE_PAGE_SIZE = 500;
 const CANDIDATE_PAGE_SIZE = 100;
 const TEMPORAL_SCAN_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;


### PR DESCRIPTION
## New behavior

The scheduled publisher-abuse scan now reads at most 50 skills per source transaction, leaving enough Convex operation budget for each skill's 30-day daily-stat history and publisher-exclusion reads. Previously, a 100-skill page timed out on dense staging data before the all-skill percentile walk completed.

## Staging proof

A read-only full-population walk against Test completed with the new page size:

- 67,614 active skills across 1,353 pages
- downloads30d P95: 205
- downloads30d P99: 350
- sustained threshold matches: 2
- spike threshold matches: 0

The same walk at 100 skills per page failed with a Convex system-operation timeout.

## Checks

- Scheduled-scan regression test confirms `batchSize: 50` — passed.
- Full Vitest coverage suite — 4,621 tests passed; four worker-start omissions were rerun serially and passed 18/18.
- `bun run ci:static` — passed.
- `bun run ci:types-build` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings.

This is backend-only; there is no changed UI state to screenshot.
