### PR TITLE
feat(security): publish cutover health summaries

### DIFF
--- a/convex/securityScan.test.ts
+++ b/convex/securityScan.test.ts
@@ -14,6 +14,7 @@ import {
   failCodexScanJob,
   failJobInternal,
   finalizeGitHubSkillScanRequestInternal,
+  getCodexScanQueueHealth,
   getCodexScanQueueHealthInternal,
   getJobTargetInternal,
   getBulkSkillRescanBatchStatusForAdminInternal,
@@ -117,6 +118,21 @@ const failJobInternalHandler = (
 const getCodexScanQueueHealthInternalHandler = (
   getCodexScanQueueHealthInternal as unknown as WrappedHandler<
     Record<string, never>,
+    {
+      snapshotAt: number;
+      queueDepth: number;
+      queueDepthIsEstimate: boolean;
+      readyQueueDepth: number;
+      readyQueueDepthIsEstimate: boolean;
+      oldestReadyJobAgeSeconds: number;
+      oldestReadyJobNextRunAt: number | null;
+    }
+  >
+)._handler;
+
+const getCodexScanQueueHealthHandler = (
+  getCodexScanQueueHealth as unknown as WrappedHandler<
+    { token: string },
     {
       snapshotAt: number;
       queueDepth: number;
@@ -1249,6 +1265,30 @@ describe("securityScan", () => {
       }),
     );
     log.mockRestore();
+  });
+
+  it("exposes queue health to the authenticated security worker", async () => {
+    const workerAuth = "fixture";
+    const rejectedAuth = "rejected-fixture";
+    vi.stubEnv("SECURITY_SCAN_WORKER_TOKEN", workerAuth);
+    const snapshot = {
+      snapshotAt: 1_000_000,
+      queueDepth: 4,
+      queueDepthIsEstimate: false,
+      readyQueueDepth: 2,
+      readyQueueDepthIsEstimate: false,
+      oldestReadyJobAgeSeconds: 901,
+      oldestReadyJobNextRunAt: 99_000,
+    };
+    const runQuery = vi.fn(async () => snapshot);
+
+    await expect(
+      getCodexScanQueueHealthHandler({ runQuery }, { token: workerAuth }),
+    ).resolves.toEqual(snapshot);
+    expect(runQuery).toHaveBeenCalledWith(expect.anything(), {});
+    await expect(
+      getCodexScanQueueHealthHandler({ runQuery }, { ["token"]: rejectedAuth }),
+    ).rejects.toThrow("Unauthorized");
   });
 
   it("does not enqueue a duplicate publish scan after the backup delay if the first scan already finished", async () => {

--- a/convex/securityScan.ts
+++ b/convex/securityScan.ts
@@ -1125,6 +1125,20 @@ export const logCodexScanQueueHealthInternal = internalAction({
   },
 });
 
+export const getCodexScanQueueHealth = action({
+  args: {
+    token: v.string(),
+  },
+  handler: async (ctx, args): Promise<CodexScanQueueHealth> => {
+    assertWorkerToken(args.token);
+    return await runQueryRef<CodexScanQueueHealth>(
+      ctx,
+      internalRefs.securityScan.getCodexScanQueueHealthInternal,
+      {},
+    );
+  },
+});
+
 function compareQueuedScanClaimOrder(a: Doc<"securityScanJobs">, b: Doc<"securityScanJobs">) {
   if (a.nextRunAt !== b.nextRunAt) return a.nextRunAt - b.nextRunAt;
   if (a._creationTime !== b._creationTime) return a._creationTime - b._creationTime;

--- a/scripts/security/run-codex-scan-worker-clawscan.test.ts
+++ b/scripts/security/run-codex-scan-worker-clawscan.test.ts
@@ -692,6 +692,7 @@ echo "not json" > "$out"`,
           return payload?.error ? { retry: false } : {};
         }),
       };
+      const onHealth = vi.fn();
 
       const result = await processJob(
         client,
@@ -699,6 +700,7 @@ echo "not json" > "$out"`,
         skillVersionJob("securityScanJobs:malformed"),
         undefined,
         "clawscan",
+        onHealth,
       );
 
       expect(result).toEqual({
@@ -763,6 +765,7 @@ JSON`,
           return payload?.error ? { retry: false } : {};
         }),
       };
+      const onHealth = vi.fn();
 
       const result = await processJob(
         client,
@@ -770,6 +773,7 @@ JSON`,
         skillVersionJob("securityScanJobs:judge-incomplete"),
         undefined,
         "clawscan",
+        onHealth,
       );
 
       expect(result).toEqual({
@@ -780,6 +784,13 @@ JSON`,
       expect(client.action).toHaveBeenCalledTimes(1);
       const payload = client.action.mock.calls[0]?.[1] as { error?: string } | undefined;
       expect(payload?.error).toContain("ClawScan judge dimensions missing required field(s)");
+      expect(onHealth).toHaveBeenCalledWith(
+        expect.objectContaining({
+          completed: false,
+          failureStage: "judge",
+          judgeStageFailed: true,
+        }),
+      );
     } finally {
       if (previousCommand === undefined) delete process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND;
       else process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND = previousCommand;
@@ -891,6 +902,7 @@ JSON`,
           return payload?.error ? { retry: false } : {};
         }),
       };
+      const onHealth = vi.fn();
 
       const result = await processJob(
         client,
@@ -898,6 +910,7 @@ JSON`,
         skillVersionJob("securityScanJobs:scanner-failed"),
         undefined,
         "clawscan",
+        onHealth,
       );
 
       expect(result).toEqual({
@@ -909,6 +922,13 @@ JSON`,
       expect(client.action.mock.calls[0]?.[1]).toMatchObject({
         error: "ClawScan scanner skillspector status was failed",
       });
+      expect(onHealth).toHaveBeenCalledWith(
+        expect.objectContaining({
+          completed: false,
+          failureStage: "scanner",
+          scannerStageFailed: true,
+        }),
+      );
     } finally {
       if (previousCommand === undefined) delete process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND;
       else process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND = previousCommand;
@@ -935,6 +955,7 @@ echo "this should never complete"`,
           return payload?.error ? { retry: true } : {};
         }),
       };
+      const onHealth = vi.fn();
 
       const result = await processJob(
         client,
@@ -942,6 +963,7 @@ echo "this should never complete"`,
         skillVersionJob("securityScanJobs:timeout"),
         undefined,
         "clawscan",
+        onHealth,
       );
 
       expect(result).toEqual({
@@ -952,6 +974,13 @@ echo "this should never complete"`,
       expect(client.action).toHaveBeenCalledTimes(1);
       const payload = client.action.mock.calls[0]?.[1] as { error?: string } | undefined;
       expect(payload?.error).toContain("timed out");
+      expect(onHealth).toHaveBeenCalledWith(
+        expect.objectContaining({
+          completed: false,
+          failureStage: "unclassified",
+          timedOut: true,
+        }),
+      );
     } finally {
       if (previousCommand === undefined) delete process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND;
       else process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND = previousCommand;

--- a/scripts/security/run-codex-scan-worker-modes.test.ts
+++ b/scripts/security/run-codex-scan-worker-modes.test.ts
@@ -342,6 +342,7 @@ describe("security scan rollout modes", () => {
       const client = {
         action: vi.fn(async (..._args: unknown[]) => ({})),
       };
+      const onHealth = vi.fn();
 
       const result = await withCommands(commands, () =>
         processJob(
@@ -350,6 +351,7 @@ describe("security scan rollout modes", () => {
           claimedJob(`${mode}-secondary-failed`),
           diagnosticsRoot,
           mode,
+          onHealth,
         ),
       );
 
@@ -374,6 +376,15 @@ describe("security scan rollout modes", () => {
         status: "failed",
         error: expect.stringContaining(mode === "shadow" ? "exited 17" : "exited 19"),
       });
+      expect(onHealth).toHaveBeenCalledWith(
+        expect.objectContaining({
+          completed: true,
+          comparison: expect.objectContaining({
+            secondaryFailureStage: mode === "shadow" ? "unclassified" : "judge",
+            secondaryStatus: "failed",
+          }),
+        }),
+      );
     },
   );
 

--- a/scripts/security/run-codex-scan-worker.test.ts
+++ b/scripts/security/run-codex-scan-worker.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   buildPrompt,
   normalizeSkillSpectorAnalysis,
+  publishWorkerHealthSummary,
   processJob,
   resolveSkillSpectorScanInput,
   resolveSkillSpectorScanInputs,
@@ -59,6 +60,63 @@ function unsafeFixtureLabels() {
 }
 
 describe("run-codex-scan-worker diagnostics", () => {
+  it("publishes the worker report to the Actions summary and diagnostics artifact", async () => {
+    const diagnosticsRoot = await tempDir();
+    const stepSummaryPath = join(await tempDir(), "step-summary.md");
+    await writeFile(stepSummaryPath, "");
+    const previousStepSummary = process.env.GITHUB_STEP_SUMMARY;
+    process.env.GITHUB_STEP_SUMMARY = stepSummaryPath;
+    try {
+      await publishWorkerHealthSummary(diagnosticsRoot, {
+        authoritative: {
+          averageDurationMs: 30_000,
+          completed: 1,
+          failed: 0,
+          judgeStageFailures: 0,
+          scannerStageFailures: 0,
+          timedOut: 0,
+          unclassifiedFailures: 0,
+          verdicts: {
+            benign: 1,
+            malicious: 0,
+            suspicious: 0,
+            unknown: 0,
+          },
+        },
+        claimFailures: 0,
+        durationMs: 30_000,
+        mode: "clawscan",
+        queueHealth: {
+          snapshotAt: 1,
+          queueDepth: 2,
+          queueDepthIsEstimate: false,
+          readyQueueDepth: 1,
+          readyQueueDepthIsEstimate: false,
+          oldestReadyJobAgeSeconds: 60,
+          oldestReadyJobNextRunAt: 0,
+        },
+        throughputPerMinute: 2,
+        totalClaimed: 1,
+        workerId: "fixture-worker",
+      });
+    } finally {
+      if (previousStepSummary === undefined) delete process.env.GITHUB_STEP_SUMMARY;
+      else process.env.GITHUB_STEP_SUMMARY = previousStepSummary;
+    }
+
+    const markdown = await readFile(stepSummaryPath, "utf8");
+    expect(markdown).toContain("## Security scan worker health");
+    expect(markdown).toContain("| Completed | 1 |");
+    const artifact = JSON.parse(
+      await readFile(join(diagnosticsRoot, "worker-summary.json"), "utf8"),
+    );
+    expect(artifact).toMatchObject({
+      mode: "clawscan",
+      workerId: "fixture-worker",
+      queueHealth: { queueDepth: 2 },
+    });
+  });
+
   it("refills a free slot without waiting for the slowest active job", async () => {
     const started: string[] = [];
     let releaseSlowJob: (() => void) | undefined;
@@ -927,6 +985,8 @@ describe("run-codex-scan-worker diagnostics", () => {
           status: "clean",
           verdict: "benign",
         },
+        judgeStageFailed: false,
+        scannerStageFailed: false,
         secondary: {
           confidence: "high",
           implementation: "clawscan",
@@ -934,6 +994,7 @@ describe("run-codex-scan-worker diagnostics", () => {
           verdict: "benign",
         },
         status: "completed",
+        timedOut: false,
       },
       skillSpectorAnalysis: {
         status: "suspicious",
@@ -1054,6 +1115,56 @@ describe("run-codex-scan-worker diagnostics", () => {
       status: "completed",
     });
     expect(await readdir(jobDir)).not.toContain("artifact");
+  });
+
+  it("retains complete redacted legacy diagnostics beyond the former file and bundle caps", async () => {
+    const diagnosticsRoot = await tempDir();
+    const jsonl = Array.from({ length: 4_000 }, (_, index) =>
+      JSON.stringify({
+        item: { id: `item-${index}`, type: "agent_message" },
+        status: "completed",
+        type: "item.completed",
+      }),
+    ).join("\n");
+    const stderr = `STDERR-BEGIN-${"a".repeat(70_000)}-STDERR-END`;
+
+    await writeJobDiagnostic({
+      codex: {
+        exitCode: 0,
+        stderr,
+        stdout: jsonl,
+      },
+      completedAt: 2,
+      diagnosticsRoot,
+      job: {
+        job: {
+          _id: "job-complete-legacy-diagnostics",
+          hasMaliciousSignal: false,
+          leaseToken: "fixture",
+          source: "publish",
+          targetKind: "skillVersion",
+          waitForVtUntil: 0,
+        },
+        target: {},
+      },
+      startedAt: 1,
+      status: "completed",
+    });
+
+    const jobDir = join(diagnosticsRoot, "job-complete-legacy-diagnostics");
+    const stdout = await readFile(join(jobDir, "codex.stdout.redacted.jsonl"), "utf8");
+    const retainedLines = stdout.trim().split("\n");
+    expect(Buffer.byteLength(stdout)).toBeGreaterThan(256 * 1_024);
+    expect(retainedLines).toHaveLength(4_000);
+    expect(retainedLines[0]).toContain("item-0");
+    expect(retainedLines.at(-1)).toContain("item-3999");
+    expect(stdout).not.toContain("...[truncated ");
+
+    const retainedStderr = await readFile(join(jobDir, "codex.stderr.redacted.log"), "utf8");
+    expect(Buffer.byteLength(retainedStderr)).toBeGreaterThan(64 * 1_024);
+    expect(retainedStderr).toContain("STDERR-BEGIN");
+    expect(retainedStderr).toContain("STDERR-END");
+    expect(retainedStderr).not.toContain("...[truncated ");
   });
 
   it("retains full ClawScan artifact and scanner outputs with secret-safe redaction", async () => {
@@ -1267,10 +1378,14 @@ describe("run-codex-scan-worker diagnostics", () => {
           verdict: "benign",
         },
         error: `clawscan timed out with api_key=${redactionFixture}`,
+        failureStage: "unclassified",
+        judgeStageFailed: false,
+        scannerStageFailed: false,
         secondary: {
           implementation: "clawscan",
         },
         status: "failed",
+        timedOut: true,
       },
       startedAt: 1,
       status: "completed",

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { mkdirSync, readFileSync } from "node:fs";
-import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -22,6 +22,16 @@ import {
   redactWorkerPublicText,
   safeWorkerArtifactPathLabel,
 } from "../lib/workerRedaction";
+import {
+  calculateSecurityScanWorkerHealthSummary,
+  renderSecurityScanWorkerSummaryMarkdown,
+  type SecurityScanComparisonOutcome,
+  type SecurityScanJobHealth,
+  type SecurityScanMode,
+  type SecurityScanQueueHealth,
+} from "./security-scan-worker-summary";
+
+export type { SecurityScanMode } from "./security-scan-worker-summary";
 
 export type ClaimedJob = {
   job: {
@@ -93,6 +103,7 @@ type CodexCommandDiagnostic = {
   rawResult?: string;
   stderr?: string;
   stdout?: string;
+  timedOut?: boolean;
 };
 
 type ClawScanCommandDiagnostic = {
@@ -102,6 +113,7 @@ type ClawScanCommandDiagnostic = {
   rawArtifact?: string;
   stderr?: string;
   stdout?: string;
+  timedOut?: boolean;
   mapping?: {
     judge?: {
       outputSchemaSha256?: string;
@@ -119,8 +131,6 @@ type ClawScanCommandDiagnostic = {
 
 type ScanImplementation = "legacy" | "clawscan";
 
-export type SecurityScanMode = "legacy" | "shadow" | "clawscan";
-
 type SecondaryScanDiagnostic = {
   authoritative: {
     confidence?: string;
@@ -131,6 +141,9 @@ type SecondaryScanDiagnostic = {
   completedAt?: number;
   durationMs?: number;
   error?: string;
+  failureStage?: "scanner" | "judge" | "unclassified";
+  judgeStageFailed: boolean;
+  scannerStageFailed: boolean;
   secondary: {
     confidence?: string;
     implementation: ScanImplementation;
@@ -139,6 +152,7 @@ type SecondaryScanDiagnostic = {
   };
   startedAt?: number;
   status: "completed" | "failed";
+  timedOut: boolean;
 };
 
 type JobDiagnosticInput = {
@@ -500,13 +514,13 @@ function redactDiagnosticValue(value: unknown, path: string[] = []): unknown {
   );
 }
 
-function redactStructuredDiagnosticText(value: string, rootKey: string) {
+function redactCompleteDiagnosticText(value: string, rootKey: string) {
   const trimmed = value.trim();
   if (!trimmed) return "";
   try {
     return JSON.stringify(redactDiagnosticValue(JSON.parse(trimmed), [rootKey]), null, 2);
   } catch {
-    // Codex --json writes JSONL. Redact parseable lines structurally, then fall back to text redaction.
+    // Codex --json writes JSONL. Preserve every line while applying the same secret redaction.
     const lines = value.split("\n");
     if (lines.some((line) => line.trim().startsWith("{"))) {
       return lines
@@ -515,12 +529,12 @@ function redactStructuredDiagnosticText(value: string, rootKey: string) {
           try {
             return JSON.stringify(redactDiagnosticValue(JSON.parse(line), [rootKey]));
           } catch {
-            return redactDiagnosticText(line, 2_000);
+            return redactDiagnosticTextUncapped(line);
           }
         })
         .join("\n");
     }
-    return redactDiagnosticText(value);
+    return redactDiagnosticTextUncapped(value);
   }
 }
 
@@ -690,7 +704,7 @@ async function writeDiagnosticText(
       ? value
       : options?.structured === false
         ? redactDiagnosticText(value, options.maxChars)
-        : redactStructuredDiagnosticText(value, rootKey);
+        : redactCompleteDiagnosticText(value, rootKey);
   await writeFile(join(jobDir, fileName), redacted.endsWith("\n") ? redacted : `${redacted}\n`);
   return fileName;
 }
@@ -1091,6 +1105,7 @@ export async function runSkillSpector(
           rawResult,
           stderr: error.stderr,
           stdout: error.stdout,
+          timedOut: error.timedOut,
         });
         if (rawResult) {
           try {
@@ -1192,13 +1207,21 @@ class CommandFailure extends Error {
   exitCode: number | null;
   stderr: string;
   stdout: string;
+  timedOut: boolean;
 
-  constructor(message: string, exitCode: number | null, stdout: string, stderr: string) {
+  constructor(
+    message: string,
+    exitCode: number | null,
+    stdout: string,
+    stderr: string,
+    timedOut: boolean,
+  ) {
     super(message);
     this.name = "CommandFailure";
     this.exitCode = exitCode;
     this.stdout = stdout;
     this.stderr = stderr;
+    this.timedOut = timedOut;
   }
 }
 
@@ -1241,6 +1264,7 @@ async function runCommand(
             code,
             stdout,
             stderr,
+            timedOut,
           ),
         );
       }
@@ -1640,6 +1664,25 @@ function readClawScanScannerStatuses(
   return scannerStatuses;
 }
 
+function clawScanDiagnosticMapping(artifact: Record<string, unknown>) {
+  const judge = asRecord(artifact.judge);
+  const result = asRecord(judge?.result);
+  const scannerStatuses = readClawScanScannerStatuses(artifact);
+  return {
+    judge: {
+      outputSchemaSha256: readString(judge ?? {}, ["outputSchemaSha256", "outputSchemaSHA"]),
+      promptSha256: readString(judge ?? {}, ["promptSha256", "promptSHA"]),
+      status: readString(judge ?? {}, ["status"]),
+      verdict: readString(result ?? {}, ["verdict"]),
+    },
+    scanners: {
+      skillspectorStatus: scannerStatuses.skillspector,
+      staticStatus: scannerStatuses["clawscan-static"],
+      virustotalStatus: scannerStatuses.virustotal,
+    },
+  };
+}
+
 function validateClawScanArtifactForClawHubProfile(artifact: Record<string, unknown>) {
   const schemaVersion = readString(artifact, ["schemaVersion"]);
   if (schemaVersion !== "clawscan-run-v1") {
@@ -1648,6 +1691,19 @@ function validateClawScanArtifactForClawHubProfile(artifact: Record<string, unkn
   const profile = readString(artifact, ["profile"]);
   if (profile !== "clawhub") {
     throw new Error(`ClawScan artifact profile was ${profile ?? "missing"}`);
+  }
+
+  const scannerStatuses = readClawScanScannerStatuses(artifact);
+  const allowedScannerStatuses: Record<string, Set<string>> = {
+    "clawscan-static": new Set(["completed"]),
+    skillspector: new Set(["completed"]),
+    virustotal: new Set(["completed"]),
+  };
+  for (const [scanner, status] of Object.entries(scannerStatuses)) {
+    const allowed = allowedScannerStatuses[scanner] ?? new Set(["completed"]);
+    if (!allowed.has(status)) {
+      throw new Error(`ClawScan scanner ${scanner} status was ${status}`);
+    }
   }
 
   const judge = asRecord(artifact.judge);
@@ -1666,19 +1722,6 @@ function validateClawScanArtifactForClawHubProfile(artifact: Record<string, unkn
     throw new Error("ClawScan judge result did not match the ClawHub output schema");
   }
 
-  const scannerStatuses = readClawScanScannerStatuses(artifact);
-  const allowedScannerStatuses: Record<string, Set<string>> = {
-    "clawscan-static": new Set(["completed"]),
-    skillspector: new Set(["completed"]),
-    virustotal: new Set(["completed"]),
-  };
-  for (const [scanner, status] of Object.entries(scannerStatuses)) {
-    const allowed = allowedScannerStatuses[scanner] ?? new Set(["completed"]);
-    if (!allowed.has(status)) {
-      throw new Error(`ClawScan scanner ${scanner} status was ${status}`);
-    }
-  }
-
   const scanners = asRecord(artifact.scanners);
   const skillSpector = asRecord(scanners?.skillspector);
   if (!skillSpector || skillSpector.raw === undefined) {
@@ -1691,19 +1734,7 @@ function validateClawScanArtifactForClawHubProfile(artifact: Record<string, unkn
 
   return {
     llmAnalysis: toStoredLlmAnalysis(parsed, { checkedAt, omitModel: true }),
-    mapping: {
-      judge: {
-        outputSchemaSha256: readString(judge, ["outputSchemaSha256", "outputSchemaSHA"]),
-        promptSha256: readString(judge, ["promptSha256", "promptSHA"]),
-        status: judgeStatus ?? undefined,
-        verdict: parsed.verdict,
-      },
-      scanners: {
-        skillspectorStatus: scannerStatuses.skillspector,
-        staticStatus: scannerStatuses["clawscan-static"],
-        virustotalStatus: scannerStatuses.virustotal,
-      },
-    },
+    mapping: clawScanDiagnosticMapping(artifact),
     skillSpectorAnalysis: normalizeSkillSpectorAnalysis(rawSkillSpector, checkedAt),
   };
 }
@@ -1718,6 +1749,21 @@ export async function runClawScan(
   const target = await resolveClawScanTarget(workspace, job);
   const args = [target, "--profile", "clawhub", "--output", artifactPath];
   onDiagnostic({ args: [command, ...args], artifactPath });
+
+  const captureArtifact = async () => {
+    if (!(await fileExists(artifactPath))) return undefined;
+    const rawArtifact = await readFile(artifactPath, "utf8");
+    onDiagnostic({ rawArtifact });
+    let parsedArtifact: unknown;
+    try {
+      parsedArtifact = JSON.parse(rawArtifact);
+    } catch {
+      return undefined;
+    }
+    const artifact = asRecord(parsedArtifact);
+    if (artifact) onDiagnostic({ mapping: clawScanDiagnosticMapping(artifact) });
+    return artifact;
+  };
 
   try {
     const output = await runCommand(command, args, {
@@ -1735,24 +1781,15 @@ export async function runClawScan(
         exitCode: error.exitCode,
         stderr: error.stderr,
         stdout: error.stdout,
+        timedOut: error.timedOut,
       });
     }
+    await captureArtifact();
     throw error;
   }
 
-  const rawArtifact = await readFile(artifactPath, "utf8");
-  onDiagnostic({ rawArtifact });
-
-  let parsedArtifact: unknown;
-  try {
-    parsedArtifact = JSON.parse(rawArtifact);
-  } catch {
-    throw new Error("ClawScan did not emit a valid JSON artifact");
-  }
-  const artifact = asRecord(parsedArtifact);
-  if (!artifact) {
-    throw new Error("ClawScan artifact root must be a JSON object");
-  }
+  const artifact = await captureArtifact();
+  if (!artifact) throw new Error("ClawScan did not emit a valid JSON artifact");
 
   const mapped = validateClawScanArtifactForClawHubProfile(artifact);
   onDiagnostic({ mapping: mapped.mapping });
@@ -1811,6 +1848,7 @@ export async function runCodex(
         exitCode: error.exitCode,
         stderr: error.stderr,
         stdout: error.stdout,
+        timedOut: error.timedOut,
       });
     }
     throw error;
@@ -1852,6 +1890,61 @@ async function runLegacyScan(
   return { llmAnalysis, skillSpectorAnalysis };
 }
 
+function scanHealthClassification(input: {
+  clawscan: ClawScanCommandDiagnostic;
+  codex: CodexCommandDiagnostic;
+  errorMessage?: string;
+  implementation: ScanImplementation;
+  skillSpector: CodexCommandDiagnostic;
+  skillSpectorAnalysis?: SkillSpectorAnalysis;
+  status: "completed" | "failed";
+}) {
+  const timedOut = Boolean(
+    input.clawscan.timedOut || input.codex.timedOut || input.skillSpector.timedOut,
+  );
+  let scannerStageFailed = false;
+  let judgeStageFailed = false;
+
+  if (input.implementation === "legacy") {
+    scannerStageFailed =
+      input.skillSpector.timedOut === true ||
+      (input.skillSpector.exitCode !== undefined && input.skillSpector.exitCode !== 0) ||
+      input.skillSpectorAnalysis?.status === "error" ||
+      input.skillSpectorAnalysis?.status === "failed";
+    judgeStageFailed =
+      input.status === "failed" &&
+      (input.codex.args !== undefined ||
+        input.codex.exitCode !== undefined ||
+        input.codex.timedOut === true);
+  } else {
+    const scannerStatuses = Object.values(input.clawscan.mapping?.scanners ?? {}).filter(
+      (status): status is string => Boolean(status),
+    );
+    scannerStageFailed = scannerStatuses.some(
+      (status) => status !== "completed" && status !== "missing",
+    );
+    const judgeStatus = input.clawscan.mapping?.judge?.status;
+    judgeStageFailed = Boolean(judgeStatus && judgeStatus !== "completed");
+    scannerStageFailed ||= /ClawScan scanner/i.test(input.errorMessage ?? "");
+    judgeStageFailed ||= /ClawScan (artifact )?judge|output schema/i.test(input.errorMessage ?? "");
+  }
+
+  const failureStage =
+    input.status === "failed"
+      ? scannerStageFailed
+        ? "scanner"
+        : judgeStageFailed
+          ? "judge"
+          : "unclassified"
+      : undefined;
+  return {
+    failureStage,
+    judgeStageFailed,
+    scannerStageFailed,
+    timedOut,
+  } as const;
+}
+
 async function runSecondaryScan(input: {
   authoritativeAnalysis: StoredLlmAnalysis;
   authoritativeImplementation: ScanImplementation;
@@ -1870,11 +1963,14 @@ async function runSecondaryScan(input: {
       status: input.authoritativeAnalysis.status,
       verdict: input.authoritativeAnalysis.verdict,
     },
+    judgeStageFailed: false,
+    scannerStageFailed: false,
     secondary: {
       implementation: input.secondaryImplementation,
     },
     startedAt,
     status: "failed",
+    timedOut: false,
   };
 
   try {
@@ -1890,10 +1986,19 @@ async function runSecondaryScan(input: {
             input.skillSpectorDiagnostic,
           );
     const completedAt = Date.now();
+    const health = scanHealthClassification({
+      clawscan: input.clawscanDiagnostic,
+      codex: input.codexDiagnostic,
+      implementation: input.secondaryImplementation,
+      skillSpector: input.skillSpectorDiagnostic,
+      skillSpectorAnalysis: result.skillSpectorAnalysis,
+      status: "completed",
+    });
     return {
       ...diagnostic,
       completedAt,
       durationMs: completedAt - startedAt,
+      ...health,
       secondary: {
         confidence: result.llmAnalysis.confidence,
         implementation: input.secondaryImplementation,
@@ -1904,14 +2009,41 @@ async function runSecondaryScan(input: {
     };
   } catch (error) {
     const completedAt = Date.now();
+    const errorMessage = sanitizeWorkerErrorMessage(
+      error instanceof Error ? error.message : String(error),
+    );
+    const health = scanHealthClassification({
+      clawscan: input.clawscanDiagnostic,
+      codex: input.codexDiagnostic,
+      errorMessage,
+      implementation: input.secondaryImplementation,
+      skillSpector: input.skillSpectorDiagnostic,
+      status: "failed",
+    });
     return {
       ...diagnostic,
       completedAt,
       durationMs: completedAt - startedAt,
-      error: sanitizeWorkerErrorMessage(error instanceof Error ? error.message : String(error)),
+      error: errorMessage,
+      ...health,
       status: "failed",
     };
   }
+}
+
+function comparisonHealth(
+  secondaryScan: SecondaryScanDiagnostic | undefined,
+): SecurityScanComparisonOutcome | undefined {
+  if (!secondaryScan) return undefined;
+  return {
+    authoritativeVerdict: secondaryScan.authoritative.verdict,
+    secondaryFailureStage: secondaryScan.failureStage,
+    secondaryJudgeStageFailed: secondaryScan.judgeStageFailed,
+    secondaryScannerStageFailed: secondaryScan.scannerStageFailed,
+    secondaryStatus: secondaryScan.status,
+    secondaryTimedOut: secondaryScan.timedOut,
+    secondaryVerdict: secondaryScan.secondary.verdict,
+  };
 }
 
 export async function processJob(
@@ -1920,6 +2052,7 @@ export async function processJob(
   job: ClaimedJob,
   diagnosticsRoot: string | undefined,
   mode: SecurityScanMode = "legacy",
+  onHealth?: (health: SecurityScanJobHealth) => void,
 ): Promise<ProcessJobResult> {
   const workspace = await mkdtemp(join(tmpdir(), `clawhub-codex-scan-${basename(job.job._id)}-`));
   const startedAt = Date.now();
@@ -1933,6 +2066,7 @@ export async function processJob(
   const codex: CodexCommandDiagnostic = {};
   const skillSpector: CodexCommandDiagnostic = {};
   let errorMessage: string | undefined;
+  let authoritativeCompletedAt: number | undefined;
   let llmAnalysis: StoredLlmAnalysis | undefined;
   let skillSpectorAnalysis: SkillSpectorAnalysis | undefined;
   let secondaryScan: SecondaryScanDiagnostic | undefined;
@@ -1962,6 +2096,7 @@ export async function processJob(
       skillSpectorAnalysis,
       runId: process.env.GITHUB_RUN_ID,
     });
+    authoritativeCompletedAt = Date.now();
     status = "completed";
     if (secondaryImplementation) {
       secondaryScan = await runSecondaryScan({
@@ -2005,6 +2140,21 @@ export async function processJob(
       },
       "security scan job completed",
     );
+    const health = scanHealthClassification({
+      clawscan,
+      codex,
+      implementation: authoritativeImplementation,
+      skillSpector,
+      skillSpectorAnalysis,
+      status: "completed",
+    });
+    onHealth?.({
+      authoritativeVerdict: llmAnalysis.verdict,
+      comparison: comparisonHealth(secondaryScan),
+      completed: true,
+      durationMs: (authoritativeCompletedAt ?? Date.now()) - startedAt,
+      ...health,
+    });
     return { completed: true, hardFailed: false, retryableFailed: false };
   } catch (error) {
     errorMessage = sanitizeWorkerErrorMessage(
@@ -2028,6 +2178,22 @@ export async function processJob(
       },
       "security scan job failed",
     );
+    const completedAt = Date.now();
+    const health = scanHealthClassification({
+      clawscan,
+      codex,
+      errorMessage,
+      implementation: authoritativeImplementation,
+      skillSpector,
+      skillSpectorAnalysis,
+      status: "failed",
+    });
+    onHealth?.({
+      comparison: comparisonHealth(secondaryScan),
+      completed: false,
+      durationMs: completedAt - startedAt,
+      ...health,
+    });
     return {
       completed: false,
       hardFailed: !failResult?.retry,
@@ -2175,6 +2341,21 @@ export async function runContinuouslyRefilledWorkerPool<TJob>(options: {
   };
 }
 
+export async function publishWorkerHealthSummary(
+  diagnosticsRoot: string,
+  summary: ReturnType<typeof calculateSecurityScanWorkerHealthSummary>,
+) {
+  await mkdir(diagnosticsRoot, { recursive: true });
+  await writeFile(
+    join(diagnosticsRoot, "worker-summary.json"),
+    `${JSON.stringify(summary, null, 2)}\n`,
+  );
+  const stepSummaryPath = process.env.GITHUB_STEP_SUMMARY?.trim();
+  if (stepSummaryPath) {
+    await appendFile(stepSummaryPath, renderSecurityScanWorkerSummaryMarkdown(summary));
+  }
+}
+
 async function main() {
   const { batchLimit, maxJobs, maxRuntimeMs, leaseMs, lane, diagnosticsRoot } = parseArgs();
   const mode = resolveSecurityScanMode();
@@ -2191,6 +2372,7 @@ async function main() {
     }:${process.env.CODEX_SECURITY_SCAN_SHARD ?? process.env.GITHUB_JOB ?? "0"}`;
   const startedAt = Date.now();
   const claimDeadline = startedAt + maxRuntimeMs;
+  const outcomes: SecurityScanJobHealth[] = [];
 
   logger.info(
     { diagnosticsRoot, event: "security_scan_diagnostics_directory", lane, mode, workerId },
@@ -2270,9 +2452,61 @@ async function main() {
       );
       return { claimedCount: leases.length, jobs };
     },
-    processClaimedJob: (job) => processJob(client, token, job, diagnosticsRoot, mode),
+    processClaimedJob: async (job) => {
+      const processStartedAt = Date.now();
+      let reported = false;
+      try {
+        const result = await processJob(client, token, job, diagnosticsRoot, mode, (health) => {
+          reported = true;
+          outcomes.push(health);
+        });
+        if (!reported) {
+          outcomes.push({
+            completed: result.completed,
+            durationMs: Date.now() - processStartedAt,
+            failureStage: result.completed ? undefined : "unclassified",
+            judgeStageFailed: false,
+            scannerStageFailed: false,
+            timedOut: false,
+          });
+        }
+        return result;
+      } catch (error) {
+        if (!reported) {
+          outcomes.push({
+            completed: false,
+            durationMs: Date.now() - processStartedAt,
+            failureStage: "unclassified",
+            judgeStageFailed: false,
+            scannerStageFailed: false,
+            timedOut: false,
+          });
+        }
+        throw error;
+      }
+    },
     idlePollMs: lane === "priority" ? 15_000 : undefined,
   });
+
+  let queueHealth: SecurityScanQueueHealth | undefined;
+  let queueHealthError: string | undefined;
+  try {
+    queueHealth = (await client.action(api.securityScan.getCodexScanQueueHealth, {
+      token,
+    })) as SecurityScanQueueHealth;
+  } catch (error) {
+    queueHealthError = sanitizeWorkerErrorMessage(
+      error instanceof Error ? error.message : String(error),
+    );
+    logger.error(
+      {
+        event: "security_scan_queue_health_failed",
+        publicReason: queueHealthError,
+        workerId,
+      },
+      "failed to read security scan queue health",
+    );
+  }
 
   const remainingRuntimeMs = claimDeadline - Date.now();
   if (remainingRuntimeMs <= 0) {
@@ -2296,6 +2530,16 @@ async function main() {
     },
     "security scan worker summary",
   );
+  const summary = calculateSecurityScanWorkerHealthSummary({
+    durationMs: Date.now() - startedAt,
+    mode,
+    outcomes,
+    pool: stats,
+    queueHealth,
+    queueHealthError,
+    workerId,
+  });
+  await publishWorkerHealthSummary(diagnosticsRoot, summary);
   if (stats.totalFailed > 0) {
     process.exitCode = 1;
   }

--- a/scripts/security/security-scan-worker-summary.test.ts
+++ b/scripts/security/security-scan-worker-summary.test.ts
@@ -1,0 +1,190 @@
+/* @vitest-environment node */
+import { describe, expect, it } from "vitest";
+import {
+  calculateSecurityScanWorkerHealthSummary,
+  renderSecurityScanWorkerSummaryMarkdown,
+  type SecurityScanJobHealth,
+} from "./security-scan-worker-summary";
+
+function outcome(overrides: Partial<SecurityScanJobHealth> = {}): SecurityScanJobHealth {
+  return {
+    authoritativeVerdict: "benign",
+    completed: true,
+    durationMs: 30_000,
+    judgeStageFailed: false,
+    scannerStageFailed: false,
+    timedOut: false,
+    ...overrides,
+  };
+}
+
+describe("security scan worker summary", () => {
+  it("calculates authoritative health, throughput, queue age, and verdict totals", () => {
+    const summary = calculateSecurityScanWorkerHealthSummary({
+      durationMs: 120_000,
+      mode: "legacy",
+      outcomes: [
+        outcome(),
+        outcome({
+          authoritativeVerdict: "suspicious",
+          durationMs: 60_000,
+          scannerStageFailed: true,
+        }),
+        outcome({
+          authoritativeVerdict: undefined,
+          completed: false,
+          durationMs: 90_000,
+          failureStage: "judge",
+          judgeStageFailed: true,
+          timedOut: true,
+        }),
+      ],
+      pool: {
+        totalClaimed: 3,
+        totalClaimFailures: 1,
+        totalCompleted: 2,
+        totalFailed: 0,
+        totalRetryableFailed: 1,
+      },
+      queueHealth: {
+        snapshotAt: 1_000_000,
+        queueDepth: 512,
+        queueDepthIsEstimate: true,
+        readyQueueDepth: 7,
+        readyQueueDepthIsEstimate: false,
+        oldestReadyJobAgeSeconds: 900,
+        oldestReadyJobNextRunAt: 100_000,
+      },
+      workerId: "fixture-worker",
+    });
+
+    expect(summary).toMatchObject({
+      authoritative: {
+        averageDurationMs: 60_000,
+        completed: 2,
+        failed: 1,
+        judgeStageFailures: 1,
+        scannerStageFailures: 1,
+        timedOut: 1,
+        verdicts: {
+          benign: 1,
+          suspicious: 1,
+          malicious: 0,
+          unknown: 0,
+        },
+      },
+      claimFailures: 1,
+      throughputPerMinute: 1.5,
+    });
+    const markdown = renderSecurityScanWorkerSummaryMarkdown(summary);
+    expect(markdown).toContain("| Completed | 2 |");
+    expect(markdown).toContain("| Timed out | 1 |");
+    expect(markdown).toContain("- Queued: >=512");
+    expect(markdown).toContain("- Oldest ready job age: 15.0 min");
+  });
+
+  it("calculates verdict pairs, exact match rate, failures, and disagreement direction", () => {
+    const summary = calculateSecurityScanWorkerHealthSummary({
+      durationMs: 60_000,
+      mode: "clawscan",
+      outcomes: [
+        outcome({
+          authoritativeVerdict: "benign",
+          comparison: {
+            authoritativeVerdict: "benign",
+            secondaryJudgeStageFailed: false,
+            secondaryScannerStageFailed: false,
+            secondaryStatus: "completed",
+            secondaryTimedOut: false,
+            secondaryVerdict: "benign",
+          },
+        }),
+        outcome({
+          authoritativeVerdict: "malicious",
+          comparison: {
+            authoritativeVerdict: "malicious",
+            secondaryJudgeStageFailed: false,
+            secondaryScannerStageFailed: false,
+            secondaryStatus: "completed",
+            secondaryTimedOut: false,
+            secondaryVerdict: "suspicious",
+          },
+        }),
+        outcome({
+          authoritativeVerdict: "suspicious",
+          comparison: {
+            authoritativeVerdict: "suspicious",
+            secondaryJudgeStageFailed: false,
+            secondaryScannerStageFailed: false,
+            secondaryStatus: "completed",
+            secondaryTimedOut: false,
+            secondaryVerdict: "malicious",
+          },
+        }),
+        outcome({
+          authoritativeVerdict: "benign",
+          comparison: {
+            authoritativeVerdict: "benign",
+            secondaryFailureStage: "scanner",
+            secondaryJudgeStageFailed: false,
+            secondaryScannerStageFailed: true,
+            secondaryStatus: "failed",
+            secondaryTimedOut: true,
+          },
+        }),
+      ],
+      pool: {
+        totalClaimed: 4,
+        totalClaimFailures: 0,
+        totalCompleted: 4,
+        totalFailed: 0,
+        totalRetryableFailed: 0,
+      },
+      workerId: "fixture-worker",
+    });
+
+    expect(summary.comparison).toEqual({
+      authoritativeMoreSevere: 1,
+      completedPairs: 3,
+      exactMatchRate: 33.33,
+      exactMatches: 1,
+      pairs: {
+        "benign -> benign": 1,
+        "malicious -> suspicious": 1,
+        "suspicious -> malicious": 1,
+      },
+      secondaryFailures: 1,
+      secondaryJudgeStageFailures: 0,
+      secondaryMoreSevere: 1,
+      secondaryScannerStageFailures: 1,
+      secondaryTimedOut: 1,
+      unknownDirection: 0,
+    });
+    const markdown = renderSecurityScanWorkerSummaryMarkdown(summary);
+    expect(markdown).toContain("Exact matches: 1 (33.33%)");
+    expect(markdown).toContain("| `malicious -> suspicious` | 1 |");
+    expect(markdown).toContain("Secondary scanner-stage failures: 1");
+  });
+
+  it("reports unavailable queue diagnostics without changing scan health", () => {
+    const summary = calculateSecurityScanWorkerHealthSummary({
+      durationMs: 60_000,
+      mode: "clawscan",
+      outcomes: [outcome()],
+      pool: {
+        totalClaimed: 1,
+        totalClaimFailures: 0,
+        totalCompleted: 1,
+        totalFailed: 0,
+        totalRetryableFailed: 0,
+      },
+      queueHealthError: "queue health request failed",
+      workerId: "fixture-worker",
+    });
+
+    expect(summary.authoritative).toMatchObject({ completed: 1, failed: 0 });
+    expect(renderSecurityScanWorkerSummaryMarkdown(summary)).toContain(
+      "- Unavailable: queue health request failed",
+    );
+  });
+});

--- a/scripts/security/security-scan-worker-summary.ts
+++ b/scripts/security/security-scan-worker-summary.ts
@@ -1,0 +1,297 @@
+export type SecurityScanMode = "legacy" | "shadow" | "clawscan";
+
+export type SecurityScanQueueHealth = {
+  snapshotAt: number;
+  queueDepth: number;
+  queueDepthIsEstimate: boolean;
+  readyQueueDepth: number;
+  readyQueueDepthIsEstimate: boolean;
+  oldestReadyJobAgeSeconds: number;
+  oldestReadyJobNextRunAt: number | null;
+};
+
+export type SecurityScanComparisonOutcome = {
+  authoritativeVerdict?: string;
+  secondaryFailureStage?: "scanner" | "judge" | "unclassified";
+  secondaryScannerStageFailed: boolean;
+  secondaryJudgeStageFailed: boolean;
+  secondaryStatus: "completed" | "failed";
+  secondaryTimedOut: boolean;
+  secondaryVerdict?: string;
+};
+
+export type SecurityScanJobHealth = {
+  authoritativeVerdict?: string;
+  comparison?: SecurityScanComparisonOutcome;
+  completed: boolean;
+  durationMs: number;
+  failureStage?: "scanner" | "judge" | "unclassified";
+  judgeStageFailed: boolean;
+  scannerStageFailed: boolean;
+  timedOut: boolean;
+};
+
+export type SecurityScanWorkerPoolStats = {
+  totalClaimed: number;
+  totalClaimFailures: number;
+  totalCompleted: number;
+  totalFailed: number;
+  totalRetryableFailed: number;
+};
+
+type VerdictTotals = {
+  benign: number;
+  suspicious: number;
+  malicious: number;
+  unknown: number;
+};
+
+export type SecurityScanWorkerHealthSummary = {
+  authoritative: {
+    averageDurationMs: number;
+    completed: number;
+    failed: number;
+    judgeStageFailures: number;
+    scannerStageFailures: number;
+    timedOut: number;
+    unclassifiedFailures: number;
+    verdicts: VerdictTotals;
+  };
+  claimFailures: number;
+  comparison?: {
+    authoritativeMoreSevere: number;
+    completedPairs: number;
+    exactMatchRate: number | null;
+    exactMatches: number;
+    pairs: Record<string, number>;
+    secondaryFailures: number;
+    secondaryJudgeStageFailures: number;
+    secondaryMoreSevere: number;
+    secondaryScannerStageFailures: number;
+    secondaryTimedOut: number;
+    unknownDirection: number;
+  };
+  durationMs: number;
+  mode: SecurityScanMode;
+  queueHealth?: SecurityScanQueueHealth;
+  queueHealthError?: string;
+  throughputPerMinute: number;
+  totalClaimed: number;
+  workerId: string;
+};
+
+function normalizedVerdict(verdict: string | undefined) {
+  const normalized = verdict?.trim().toLowerCase();
+  return normalized === "clean" ? "benign" : normalized;
+}
+
+function incrementVerdict(totals: VerdictTotals, verdict: string | undefined) {
+  const normalized = normalizedVerdict(verdict);
+  if (normalized === "benign" || normalized === "suspicious" || normalized === "malicious") {
+    totals[normalized] += 1;
+  } else {
+    totals.unknown += 1;
+  }
+}
+
+function verdictSeverity(verdict: string | undefined) {
+  const normalized = normalizedVerdict(verdict);
+  if (normalized === "benign") return 0;
+  if (normalized === "suspicious") return 1;
+  if (normalized === "malicious") return 2;
+  return undefined;
+}
+
+export function calculateSecurityScanWorkerHealthSummary(input: {
+  durationMs: number;
+  mode: SecurityScanMode;
+  outcomes: SecurityScanJobHealth[];
+  pool: SecurityScanWorkerPoolStats;
+  queueHealth?: SecurityScanQueueHealth;
+  queueHealthError?: string;
+  workerId: string;
+}): SecurityScanWorkerHealthSummary {
+  const failed = input.outcomes.filter((outcome) => !outcome.completed).length;
+  const completed = input.outcomes.length - failed;
+  const durationTotal = input.outcomes.reduce((total, outcome) => total + outcome.durationMs, 0);
+  const verdicts: VerdictTotals = {
+    benign: 0,
+    suspicious: 0,
+    malicious: 0,
+    unknown: 0,
+  };
+  for (const outcome of input.outcomes) {
+    if (outcome.completed) incrementVerdict(verdicts, outcome.authoritativeVerdict);
+  }
+
+  const summary: SecurityScanWorkerHealthSummary = {
+    authoritative: {
+      averageDurationMs:
+        input.outcomes.length > 0 ? Math.round(durationTotal / input.outcomes.length) : 0,
+      completed,
+      failed,
+      judgeStageFailures: input.outcomes.filter((outcome) => outcome.judgeStageFailed).length,
+      scannerStageFailures: input.outcomes.filter((outcome) => outcome.scannerStageFailed).length,
+      timedOut: input.outcomes.filter((outcome) => outcome.timedOut).length,
+      unclassifiedFailures: input.outcomes.filter(
+        (outcome) => !outcome.completed && outcome.failureStage === "unclassified",
+      ).length,
+      verdicts,
+    },
+    claimFailures: input.pool.totalClaimFailures,
+    durationMs: input.durationMs,
+    mode: input.mode,
+    queueHealth: input.queueHealth,
+    queueHealthError: input.queueHealthError,
+    throughputPerMinute:
+      input.durationMs > 0 ? (input.outcomes.length * 60_000) / input.durationMs : 0,
+    totalClaimed: input.pool.totalClaimed,
+    workerId: input.workerId,
+  };
+
+  if (input.mode === "legacy") return summary;
+
+  const comparisons = input.outcomes
+    .map((outcome) => outcome.comparison)
+    .filter((comparison): comparison is SecurityScanComparisonOutcome => Boolean(comparison));
+  const pairs: Record<string, number> = {};
+  let exactMatches = 0;
+  let authoritativeMoreSevere = 0;
+  let secondaryMoreSevere = 0;
+  let unknownDirection = 0;
+  const completedPairs = comparisons.filter(
+    (comparison) =>
+      comparison.secondaryStatus === "completed" &&
+      Boolean(normalizedVerdict(comparison.authoritativeVerdict)) &&
+      Boolean(normalizedVerdict(comparison.secondaryVerdict)),
+  );
+
+  for (const comparison of completedPairs) {
+    const authoritative = normalizedVerdict(comparison.authoritativeVerdict) ?? "unknown";
+    const secondary = normalizedVerdict(comparison.secondaryVerdict) ?? "unknown";
+    const pair = `${authoritative} -> ${secondary}`;
+    pairs[pair] = (pairs[pair] ?? 0) + 1;
+    if (authoritative === secondary) {
+      exactMatches += 1;
+      continue;
+    }
+    const authoritativeSeverity = verdictSeverity(authoritative);
+    const secondarySeverity = verdictSeverity(secondary);
+    if (authoritativeSeverity === undefined || secondarySeverity === undefined) {
+      unknownDirection += 1;
+    } else if (authoritativeSeverity > secondarySeverity) {
+      authoritativeMoreSevere += 1;
+    } else {
+      secondaryMoreSevere += 1;
+    }
+  }
+
+  summary.comparison = {
+    authoritativeMoreSevere,
+    completedPairs: completedPairs.length,
+    exactMatchRate:
+      completedPairs.length > 0
+        ? Math.round((exactMatches / completedPairs.length) * 10_000) / 100
+        : null,
+    exactMatches,
+    pairs,
+    secondaryFailures: comparisons.filter((comparison) => comparison.secondaryStatus === "failed")
+      .length,
+    secondaryJudgeStageFailures: comparisons.filter(
+      (comparison) => comparison.secondaryJudgeStageFailed,
+    ).length,
+    secondaryMoreSevere,
+    secondaryScannerStageFailures: comparisons.filter(
+      (comparison) => comparison.secondaryScannerStageFailed,
+    ).length,
+    secondaryTimedOut: comparisons.filter((comparison) => comparison.secondaryTimedOut).length,
+    unknownDirection,
+  };
+  return summary;
+}
+
+function formatDuration(durationMs: number) {
+  if (durationMs < 1_000) return `${durationMs} ms`;
+  if (durationMs < 60_000) return `${(durationMs / 1_000).toFixed(1)} s`;
+  return `${(durationMs / 60_000).toFixed(1)} min`;
+}
+
+function estimatePrefix(isEstimate: boolean) {
+  return isEstimate ? ">=" : "";
+}
+
+export function renderSecurityScanWorkerSummaryMarkdown(summary: SecurityScanWorkerHealthSummary) {
+  const lines = [
+    "## Security scan worker health",
+    "",
+    `**Mode:** \`${summary.mode}\`  `,
+    `**Worker:** \`${summary.workerId}\`  `,
+    `**Run duration:** ${formatDuration(summary.durationMs)}  `,
+    `**Throughput:** ${summary.throughputPerMinute.toFixed(2)} scans/min`,
+    "",
+    "| Authoritative scans | Count |",
+    "| --- | ---: |",
+    `| Completed | ${summary.authoritative.completed} |`,
+    `| Failed | ${summary.authoritative.failed} |`,
+    `| Timed out | ${summary.authoritative.timedOut} |`,
+    `| Scanner-stage failures | ${summary.authoritative.scannerStageFailures} |`,
+    `| Judge-stage failures | ${summary.authoritative.judgeStageFailures} |`,
+    `| Unclassified failures | ${summary.authoritative.unclassifiedFailures} |`,
+    `| Average duration | ${formatDuration(summary.authoritative.averageDurationMs)} |`,
+    `| Claim failures | ${summary.claimFailures} |`,
+    "",
+    "| Authoritative verdict | Count |",
+    "| --- | ---: |",
+    `| Benign | ${summary.authoritative.verdicts.benign} |`,
+    `| Suspicious | ${summary.authoritative.verdicts.suspicious} |`,
+    `| Malicious | ${summary.authoritative.verdicts.malicious} |`,
+    `| Unknown | ${summary.authoritative.verdicts.unknown} |`,
+  ];
+
+  if (summary.queueHealth) {
+    lines.push(
+      "",
+      "### Queue health",
+      "",
+      `- Queued: ${estimatePrefix(summary.queueHealth.queueDepthIsEstimate)}${summary.queueHealth.queueDepth}`,
+      `- Ready now: ${estimatePrefix(summary.queueHealth.readyQueueDepthIsEstimate)}${summary.queueHealth.readyQueueDepth}`,
+      `- Oldest ready job age: ${formatDuration(summary.queueHealth.oldestReadyJobAgeSeconds * 1_000)}`,
+    );
+  } else if (summary.queueHealthError) {
+    lines.push("", "### Queue health", "", `- Unavailable: ${summary.queueHealthError}`);
+  }
+
+  if (summary.comparison) {
+    const rate =
+      summary.comparison.exactMatchRate === null
+        ? "n/a"
+        : `${summary.comparison.exactMatchRate.toFixed(2)}%`;
+    lines.push(
+      "",
+      "### Authoritative vs secondary",
+      "",
+      `- Completed pairs: ${summary.comparison.completedPairs}`,
+      `- Exact matches: ${summary.comparison.exactMatches} (${rate})`,
+      `- Secondary failures: ${summary.comparison.secondaryFailures}`,
+      `- Secondary timeouts: ${summary.comparison.secondaryTimedOut}`,
+      `- Secondary scanner-stage failures: ${summary.comparison.secondaryScannerStageFailures}`,
+      `- Secondary judge-stage failures: ${summary.comparison.secondaryJudgeStageFailures}`,
+      `- Authoritative more severe: ${summary.comparison.authoritativeMoreSevere}`,
+      `- Secondary more severe: ${summary.comparison.secondaryMoreSevere}`,
+      `- Unknown disagreement direction: ${summary.comparison.unknownDirection}`,
+      "",
+      "| Verdict pair | Count |",
+      "| --- | ---: |",
+    );
+    const pairs = Object.entries(summary.comparison.pairs).sort(([left], [right]) =>
+      left.localeCompare(right),
+    );
+    if (pairs.length === 0) {
+      lines.push("| No completed pairs | 0 |");
+    } else {
+      for (const [pair, count] of pairs) lines.push(`| \`${pair}\` | ${count} |`);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}

--- a/scripts/security/security-scan-worker-workflow.test.ts
+++ b/scripts/security/security-scan-worker-workflow.test.ts
@@ -53,6 +53,9 @@ describe("security-scan-codex workflow", () => {
     const jobEnv = workflow.jobs["codex-security-scan"].env ?? {};
     const scanIndex = steps.findIndex((step) => step.id === "diagnostics_secret_scan");
     const uploadIndex = steps.findIndex((step) => step.uses === "actions/upload-artifact@v7");
+    const prepareStep = steps.find(
+      (step) => step.name === "Prepare Codex security diagnostics scan",
+    );
     const scanStep = steps[scanIndex];
     const uploadStep = steps[uploadIndex];
 
@@ -67,10 +70,13 @@ describe("security-scan-codex workflow", () => {
     expect(scanStep?.run).toContain("--only-verified");
     expect(scanStep?.run).toContain("--fail");
     expect(scanStep?.run).not.toContain("--debug");
+    expect(prepareStep?.if).toBe("${{ !cancelled() }}");
+    expect(scanStep?.if).toBe("${{ !cancelled() }}");
     expect(uploadStep?.if).toBe(
       "${{ !cancelled() && steps.diagnostics_secret_scan.outcome == 'success' }}",
     );
     expect(uploadStep?.with?.path).toBe("${{ env.CODEX_SECURITY_SCAN_DIAGNOSTICS_DIR }}");
+    expect(uploadStep?.with?.["if-no-files-found"]).toBe("ignore");
     expect(workflow.jobs["codex-security-scan"]["timeout-minutes"]).toBe(40);
     expect(workflow.on?.workflow_dispatch).toBeDefined();
     expect(workflow.on?.repository_dispatch?.types).toEqual(["clawhub-security-scan"]);

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -291,6 +291,19 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   Authoritative ClawScan failures use the existing failure/retry lifecycle and
   never trigger per-job legacy fallback. Rollback is a manual whole-system mode
   change to `legacy`.
+- Every worker run publishes a GitHub Actions summary and uploads a structured
+  summary with its secret-scanned diagnostics. The summary reports authoritative
+  completions, failures, timeouts, scanner-stage and judge-stage failures,
+  duration, throughput, queue health, and verdict totals. `shadow` and
+  `clawscan` additionally report authoritative/secondary verdict pairs, exact
+  matches, secondary failures, and disagreement direction. Queue-health lookup
+  failures are diagnostic-only and must not change authoritative persistence,
+  retries, or the worker exit result.
+- Retained worker diagnostics preserve every redacted Codex/legacy output
+  record plus complete redacted ClawScan artifacts, per-scanner outputs, and
+  comparison records without per-file or aggregate-size truncation. Bounded
+  metadata/error fields may remain capped. Artifact upload still requires the
+  existing verified-secret scan to pass.
 - Claimable queue work edge-triggers a coalesced GitHub Actions worker dispatch.
   Successful completion requests another dispatch while queued work remains; a
   five-minute Convex cron is only a recovery watchdog for lost dispatch signals.


### PR DESCRIPTION
## Summary
- publish a concise GitHub Actions health summary and structured worker summary artifact for every security worker run
- report authoritative scan outcomes, stage failures, timing, throughput, queue health, verdict totals, and comparison-mode agreement
- retain complete secret-redacted ClawScan, scanner, comparison, and legacy diagnostic outputs without arbitrary size caps
- keep queue-health lookup and secondary scan failures diagnostic-only, preserving authoritative persistence and retry semantics

## Validation
- `bun run test -- scripts/security/security-scan-worker-summary.test.ts scripts/security/run-codex-scan-worker.test.ts scripts/security/run-codex-scan-worker-clawscan.test.ts scripts/security/run-codex-scan-worker-modes.test.ts convex/securityScan.test.ts scripts/security/security-scan-worker-workflow.test.ts` (136 tests passed)
- `bun run ci:static`
- `bun run ci:unit` (4,670 tests passed, 1 skipped)
- `bun run ci:types-build`
- `bun run ci:packages`
- `bun run ci:e2e-http`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` (clean)

Linear: CLAW-544
