### PR TITLE
fix(security): classify SkillSpector findings exits correctly

### DIFF
--- a/scripts/security/run-codex-scan-worker.test.ts
+++ b/scripts/security/run-codex-scan-worker.test.ts
@@ -81,7 +81,13 @@ describe("run-codex-scan-worker diagnostics", () => {
             status: "suspicious",
             score: 93,
             issueCount: 1,
-            issues: [],
+            issues: [
+              {
+                issueId: "SDI-1",
+                severity: "HIGH",
+                explanation: "Detected suspicious behavior.",
+              },
+            ],
             checkedAt: 1,
           },
         }),
@@ -100,7 +106,13 @@ describe("run-codex-scan-worker diagnostics", () => {
             rawResult: JSON.stringify({
               status: "suspicious",
               issue_count: 1,
-              issues: [],
+              issues: [
+                {
+                  id: "SDI-1",
+                  severity: "HIGH",
+                  explanation: "Detected suspicious behavior.",
+                },
+              ],
             }),
           },
         }),
@@ -136,6 +148,22 @@ describe("run-codex-scan-worker diagnostics", () => {
             ...baseInput.skillSpector,
             exitCode: 2,
           },
+          skillSpectorAnalysis: {
+            status: "suspicious",
+            issueCount: 1,
+            issues: [],
+            checkedAt: 1,
+          },
+        }),
+      ).toMatchObject({
+        scannerStageFailed: true,
+      });
+    });
+
+    it("treats a positive issue count without parsed findings as a scanner failure", () => {
+      expect(
+        scanHealthClassification({
+          ...baseInput,
           skillSpectorAnalysis: {
             status: "suspicious",
             issueCount: 1,

--- a/scripts/security/run-codex-scan-worker.test.ts
+++ b/scripts/security/run-codex-scan-worker.test.ts
@@ -164,6 +164,25 @@ describe("run-codex-scan-worker diagnostics", () => {
       });
     });
 
+    it("treats a missing process exit status as a scanner failure", () => {
+      expect(
+        scanHealthClassification({
+          ...baseInput,
+          skillSpector: {
+            ...baseInput.skillSpector,
+            exitCode: undefined,
+            rawResult: JSON.stringify({
+              status: "suspicious",
+              issue_count: 1,
+              issues: [],
+            }),
+          },
+        }),
+      ).toMatchObject({
+        scannerStageFailed: true,
+      });
+    });
+
     it.each([undefined, "{malformed"])(
       "treats a nonzero exit with %s captured output as a scanner failure",
       (rawResult) => {

--- a/scripts/security/run-codex-scan-worker.test.ts
+++ b/scripts/security/run-codex-scan-worker.test.ts
@@ -148,6 +148,22 @@ describe("run-codex-scan-worker diagnostics", () => {
       });
     });
 
+    it("treats exit 1 with a clean zero-findings report as a scanner failure", () => {
+      expect(
+        scanHealthClassification({
+          ...baseInput,
+          skillSpectorAnalysis: {
+            status: "clean",
+            issueCount: 0,
+            issues: [],
+            checkedAt: 1,
+          },
+        }),
+      ).toMatchObject({
+        scannerStageFailed: true,
+      });
+    });
+
     it.each([undefined, "{malformed"])(
       "treats a nonzero exit with %s captured output as a scanner failure",
       (rawResult) => {

--- a/scripts/security/run-codex-scan-worker.test.ts
+++ b/scripts/security/run-codex-scan-worker.test.ts
@@ -17,6 +17,7 @@ import {
   resolveSkillSpectorScanInput,
   resolveSkillSpectorScanInputs,
   runContinuouslyRefilledWorkerPool,
+  scanHealthClassification,
   writeArtifactWorkspace,
   writeJobDiagnostic,
 } from "./run-codex-scan-worker";
@@ -60,6 +61,126 @@ function unsafeFixtureLabels() {
 }
 
 describe("run-codex-scan-worker diagnostics", () => {
+  describe("legacy SkillSpector health classification", () => {
+    const baseInput = {
+      clawscan: {},
+      codex: {},
+      implementation: "legacy" as const,
+      skillSpector: {
+        args: ["scan", "./artifact", "--format", "json"],
+        exitCode: 1,
+      },
+      status: "completed" as const,
+    };
+
+    it("does not treat exit 1 with a valid suspicious report as a scanner failure", () => {
+      expect(
+        scanHealthClassification({
+          ...baseInput,
+          skillSpectorAnalysis: {
+            status: "suspicious",
+            score: 93,
+            issueCount: 1,
+            issues: [],
+            checkedAt: 1,
+          },
+        }),
+      ).toMatchObject({
+        scannerStageFailed: false,
+        timedOut: false,
+      });
+    });
+
+    it("recognizes a valid captured report when a later stage prevents returning the analysis", () => {
+      expect(
+        scanHealthClassification({
+          ...baseInput,
+          skillSpector: {
+            ...baseInput.skillSpector,
+            rawResult: JSON.stringify({
+              status: "suspicious",
+              issue_count: 1,
+              issues: [],
+            }),
+          },
+        }),
+      ).toMatchObject({
+        scannerStageFailed: false,
+      });
+    });
+
+    it.each(["error", "failed"] as const)(
+      "treats a parsed %s report as a scanner failure",
+      (status) => {
+        expect(
+          scanHealthClassification({
+            ...baseInput,
+            skillSpectorAnalysis: {
+              status,
+              issueCount: 0,
+              issues: [],
+              checkedAt: 1,
+            },
+          }),
+        ).toMatchObject({
+          scannerStageFailed: true,
+        });
+      },
+    );
+
+    it("treats other nonzero exits as failures even with a parseable report", () => {
+      expect(
+        scanHealthClassification({
+          ...baseInput,
+          skillSpector: {
+            ...baseInput.skillSpector,
+            exitCode: 2,
+          },
+          skillSpectorAnalysis: {
+            status: "suspicious",
+            issueCount: 1,
+            issues: [],
+            checkedAt: 1,
+          },
+        }),
+      ).toMatchObject({
+        scannerStageFailed: true,
+      });
+    });
+
+    it.each([undefined, "{malformed"])(
+      "treats a nonzero exit with %s captured output as a scanner failure",
+      (rawResult) => {
+        expect(
+          scanHealthClassification({
+            ...baseInput,
+            skillSpector: {
+              ...baseInput.skillSpector,
+              rawResult,
+            },
+          }),
+        ).toMatchObject({
+          scannerStageFailed: true,
+        });
+      },
+    );
+
+    it("treats a SkillSpector timeout as a scanner failure", () => {
+      expect(
+        scanHealthClassification({
+          ...baseInput,
+          skillSpector: {
+            ...baseInput.skillSpector,
+            timedOut: true,
+          },
+        }),
+      ).toMatchObject({
+        scannerStageFailed: true,
+        timedOut: true,
+      });
+    });
+  });
+
   it("publishes the worker report to the Actions summary and diagnostics artifact", async () => {
     const diagnosticsRoot = await tempDir();
     const stepSummaryPath = join(await tempDir(), "step-summary.md");

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -1907,22 +1907,25 @@ export function scanHealthClassification(input: {
 
   if (input.implementation === "legacy") {
     let skillSpectorStatus = input.skillSpectorAnalysis?.status;
+    let skillSpectorIssueCount = input.skillSpectorAnalysis?.issueCount;
     if (skillSpectorStatus === undefined && input.skillSpector.rawResult !== undefined) {
       try {
-        skillSpectorStatus = normalizeSkillSpectorAnalysis(input.skillSpector.rawResult).status;
+        const parsedReport = normalizeSkillSpectorAnalysis(input.skillSpector.rawResult);
+        skillSpectorStatus = parsedReport.status;
+        skillSpectorIssueCount = parsedReport.issueCount;
       } catch {
         skillSpectorStatus = "error";
+        skillSpectorIssueCount = 0;
       }
     }
     const skillSpectorRan =
       input.skillSpector.args !== undefined ||
       input.skillSpector.exitCode !== undefined ||
       input.skillSpector.timedOut === true;
-    const validParsedReport =
-      skillSpectorStatus !== undefined &&
-      skillSpectorStatus !== "error" &&
-      skillSpectorStatus !== "failed";
-    const validFindingsExit = input.skillSpector.exitCode === 1 && validParsedReport;
+    const validFindingsExit =
+      input.skillSpector.exitCode === 1 &&
+      (skillSpectorStatus === "suspicious" || skillSpectorStatus === "malicious") &&
+      (skillSpectorIssueCount ?? 0) > 0;
     const unexpectedExit =
       input.skillSpector.exitCode !== undefined &&
       input.skillSpector.exitCode !== 0 &&

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -1890,7 +1890,7 @@ async function runLegacyScan(
   return { llmAnalysis, skillSpectorAnalysis };
 }
 
-function scanHealthClassification(input: {
+export function scanHealthClassification(input: {
   clawscan: ClawScanCommandDiagnostic;
   codex: CodexCommandDiagnostic;
   errorMessage?: string;
@@ -1906,11 +1906,33 @@ function scanHealthClassification(input: {
   let judgeStageFailed = false;
 
   if (input.implementation === "legacy") {
+    let skillSpectorStatus = input.skillSpectorAnalysis?.status;
+    if (skillSpectorStatus === undefined && input.skillSpector.rawResult !== undefined) {
+      try {
+        skillSpectorStatus = normalizeSkillSpectorAnalysis(input.skillSpector.rawResult).status;
+      } catch {
+        skillSpectorStatus = "error";
+      }
+    }
+    const skillSpectorRan =
+      input.skillSpector.args !== undefined ||
+      input.skillSpector.exitCode !== undefined ||
+      input.skillSpector.timedOut === true;
+    const validParsedReport =
+      skillSpectorStatus !== undefined &&
+      skillSpectorStatus !== "error" &&
+      skillSpectorStatus !== "failed";
+    const validFindingsExit = input.skillSpector.exitCode === 1 && validParsedReport;
+    const unexpectedExit =
+      input.skillSpector.exitCode !== undefined &&
+      input.skillSpector.exitCode !== 0 &&
+      !validFindingsExit;
     scannerStageFailed =
       input.skillSpector.timedOut === true ||
-      (input.skillSpector.exitCode !== undefined && input.skillSpector.exitCode !== 0) ||
-      input.skillSpectorAnalysis?.status === "error" ||
-      input.skillSpectorAnalysis?.status === "failed";
+      (skillSpectorRan && skillSpectorStatus === undefined) ||
+      unexpectedExit ||
+      skillSpectorStatus === "error" ||
+      skillSpectorStatus === "failed";
     judgeStageFailed =
       input.status === "failed" &&
       (input.codex.args !== undefined ||

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -1926,6 +1926,7 @@ export function scanHealthClassification(input: {
       input.skillSpector.exitCode === 1 &&
       (skillSpectorStatus === "suspicious" || skillSpectorStatus === "malicious") &&
       (skillSpectorIssueCount ?? 0) > 0;
+    const missingExitStatus = skillSpectorRan && input.skillSpector.exitCode === undefined;
     const unexpectedExit =
       input.skillSpector.exitCode !== undefined &&
       input.skillSpector.exitCode !== 0 &&
@@ -1933,6 +1934,7 @@ export function scanHealthClassification(input: {
     scannerStageFailed =
       input.skillSpector.timedOut === true ||
       (skillSpectorRan && skillSpectorStatus === undefined) ||
+      missingExitStatus ||
       unexpectedExit ||
       skillSpectorStatus === "error" ||
       skillSpectorStatus === "failed";

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -1908,14 +1908,17 @@ export function scanHealthClassification(input: {
   if (input.implementation === "legacy") {
     let skillSpectorStatus = input.skillSpectorAnalysis?.status;
     let skillSpectorIssueCount = input.skillSpectorAnalysis?.issueCount;
+    let skillSpectorParsedIssueCount = input.skillSpectorAnalysis?.issues.length;
     if (skillSpectorStatus === undefined && input.skillSpector.rawResult !== undefined) {
       try {
         const parsedReport = normalizeSkillSpectorAnalysis(input.skillSpector.rawResult);
         skillSpectorStatus = parsedReport.status;
         skillSpectorIssueCount = parsedReport.issueCount;
+        skillSpectorParsedIssueCount = parsedReport.issues.length;
       } catch {
         skillSpectorStatus = "error";
         skillSpectorIssueCount = 0;
+        skillSpectorParsedIssueCount = 0;
       }
     }
     const skillSpectorRan =
@@ -1925,7 +1928,8 @@ export function scanHealthClassification(input: {
     const validFindingsExit =
       input.skillSpector.exitCode === 1 &&
       (skillSpectorStatus === "suspicious" || skillSpectorStatus === "malicious") &&
-      (skillSpectorIssueCount ?? 0) > 0;
+      (skillSpectorIssueCount ?? 0) > 0 &&
+      (skillSpectorParsedIssueCount ?? 0) > 0;
     const missingExitStatus = skillSpectorRan && input.skillSpector.exitCode === undefined;
     const unexpectedExit =
       input.skillSpector.exitCode !== undefined &&

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -298,7 +298,11 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   `clawscan` additionally report authoritative/secondary verdict pairs, exact
   matches, secondary failures, and disagreement direction. Queue-health lookup
   failures are diagnostic-only and must not change authoritative persistence,
-  retries, or the worker exit result.
+  retries, or the worker exit result. A valid parsed scanner report with
+  findings is a completed scanner stage when SkillSpector uses exit code `1`
+  with a valid parsed non-error report. Other nonzero exits remain failures.
+  Scanner-stage failures also include a timeout, missing or unparseable report,
+  or parsed `error`/`failed` status.
 - Retained worker diagnostics preserve every redacted Codex/legacy output
   record plus complete redacted ClawScan artifacts, per-scanner outputs, and
   comparison records without per-file or aggregate-size truncation. Bounded

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -300,9 +300,9 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   failures are diagnostic-only and must not change authoritative persistence,
   retries, or the worker exit result. A valid parsed scanner report with
   findings is a completed scanner stage when SkillSpector uses exit code `1`
-  with a valid parsed non-error report. Other nonzero exits remain failures.
-  Scanner-stage failures also include a timeout, missing or unparseable report,
-  or parsed `error`/`failed` status.
+  with a `suspicious` or `malicious` report containing at least one finding.
+  Other nonzero exits remain failures. Scanner-stage failures also include a
+  timeout, missing or unparseable report, or parsed `error`/`failed` status.
 - Retained worker diagnostics preserve every redacted Codex/legacy output
   record plus complete redacted ClawScan artifacts, per-scanner outputs, and
   comparison records without per-file or aggregate-size truncation. Bounded

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -302,7 +302,8 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   findings is a completed scanner stage when SkillSpector uses exit code `1`
   with a `suspicious` or `malicious` report containing at least one finding.
   Other nonzero exits remain failures. Scanner-stage failures also include a
-  timeout, missing or unparseable report, or parsed `error`/`failed` status.
+  timeout, missing process exit status, missing or unparseable report, or
+  parsed `error`/`failed` status.
 - Retained worker diagnostics preserve every redacted Codex/legacy output
   record plus complete redacted ClawScan artifacts, per-scanner outputs, and
   comparison records without per-file or aggregate-size truncation. Bounded

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -300,10 +300,10 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   failures are diagnostic-only and must not change authoritative persistence,
   retries, or the worker exit result. A valid parsed scanner report with
   findings is a completed scanner stage when SkillSpector uses exit code `1`
-  with a `suspicious` or `malicious` report containing at least one finding.
-  Other nonzero exits remain failures. Scanner-stage failures also include a
-  timeout, missing process exit status, missing or unparseable report, or
-  parsed `error`/`failed` status.
+  with a `suspicious` or `malicious` report containing a positive normalized
+  issue count and at least one parsed finding. Other nonzero exits remain
+  failures. Scanner-stage failures also include a timeout, missing process exit
+  status, missing or unparseable report, or parsed `error`/`failed` status.
 - Retained worker diagnostics preserve every redacted Codex/legacy output
   record plus complete redacted ClawScan artifacts, per-scanner outputs, and
   comparison records without per-file or aggregate-size truncation. Bounded


### PR DESCRIPTION
## Summary

- treat SkillSpector exit code `1` as healthy only for a parsed `suspicious`/`malicious` report with a positive issue count and at least one parsed finding
- keep timeouts, missing exit status, malformed or missing reports, `error`/`failed` reports, inconsistent findings, and other nonzero exits classified as scanner-stage failures
- document the production monitoring invariant for the ClawScan cutover

Linear: [CLAW-548 Fix SkillSpector exit-1 health false positives before ClawScan cutover](https://linear.app/my-openclaw/issue/CLAW-548/fix-skillspector-exit-1-health-false-positives-before-clawscan-cutover)

## Validation

- `bunx vitest run scripts/security/run-codex-scan-worker.test.ts scripts/security/run-codex-scan-worker-modes.test.ts` (48 passed)
- `bun run ci:static`
- `bun run ci:unit` (4681 passed, 1 skipped)
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- branch autoreview: clean, no accepted/actionable findings
