### PR TITLE
fix(security): require ClawScan artifact inspection

### DIFF
--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Install ClawScan CLI
         run: |
           set -euo pipefail
-          npm install -g @openclaw/clawscan@0.1.3
+          npm install -g @openclaw/clawscan@0.1.4
           clawscan --version
 
       - name: Install SkillSpector

--- a/scripts/security/run-codex-scan-worker-clawscan.test.ts
+++ b/scripts/security/run-codex-scan-worker-clawscan.test.ts
@@ -187,6 +187,12 @@ function completeJudgeResult(verdict: ClawScanVerdict) {
     dimensions: completeJudgeDimensions(),
     scan_findings_in_context: [],
     user_guidance: "guidance",
+    artifact_inspection: {
+      status: "completed",
+      challenge: "inspection-challenge",
+      required_file_sha256: "a".repeat(64),
+      files_inspected: ["artifact/SKILL.md"],
+    },
   };
 }
 
@@ -718,6 +724,63 @@ echo "not json" > "$out"`,
     }
   });
 
+  it("fails the job when the ClawScan judge omits artifact inspection proof", async () => {
+    const workspace = await tempDir();
+    const fakeClawScan = join(workspace, "fake-clawscan");
+    const { artifact_inspection: _inspection, ...judgeResult } = completeJudgeResult("benign");
+    const artifactJson = clawScanArtifactJson({ judgeResult });
+    await writeFakeClawScanCommand(
+      fakeClawScan,
+      `out=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output)
+      out="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+mkdir -p "$(dirname "$out")"
+cat > "$out" <<'JSON'
+${artifactJson}
+JSON`,
+    );
+
+    const previousCommand = process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND;
+    process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND = fakeClawScan;
+    try {
+      const client = {
+        action: vi.fn(async (...args: unknown[]) => {
+          const payload = args[1] as { error?: string } | undefined;
+          return payload?.error ? { retry: false } : {};
+        }),
+      };
+      const result = await processJob(
+        client,
+        "worker-auth",
+        skillVersionJob("securityScanJobs:judge-no-inspection"),
+        undefined,
+        "clawscan",
+      );
+
+      expect(result).toEqual({
+        completed: false,
+        hardFailed: true,
+        retryableFailed: false,
+      });
+      expect(client.action).toHaveBeenCalledTimes(1);
+      expect(client.action.mock.calls[0]?.[1]).toMatchObject({
+        error: "ClawScan judge result missing required field(s): artifact_inspection",
+      });
+    } finally {
+      if (previousCommand === undefined) delete process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND;
+      else process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND = previousCommand;
+    }
+  });
+
   it("fails the job when the ClawScan judge result is missing required dimensions", async () => {
     const workspace = await tempDir();
     const fakeClawScan = join(workspace, "fake-clawscan");
@@ -734,6 +797,12 @@ echo "not json" > "$out"`,
         },
         scan_findings_in_context: [],
         user_guidance: "guidance",
+        artifact_inspection: {
+          status: "completed",
+          challenge: "inspection-challenge",
+          required_file_sha256: "a".repeat(64),
+          files_inspected: ["artifact/SKILL.md"],
+        },
       },
     });
     await writeFakeClawScanCommand(

--- a/scripts/security/run-codex-scan-worker-modes.test.ts
+++ b/scripts/security/run-codex-scan-worker-modes.test.ts
@@ -92,6 +92,12 @@ function completeClawScanArtifact(verdict: "benign" | "suspicious" | "malicious"
         },
         scan_findings_in_context: [],
         user_guidance: "guidance",
+        artifact_inspection: {
+          status: "completed",
+          challenge: "inspection-challenge",
+          required_file_sha256: "a".repeat(64),
+          files_inspected: ["artifact/SKILL.md"],
+        },
       },
     },
   });

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -1557,11 +1557,20 @@ function clawScanTimeoutMs() {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_CLAWSCAN_TIMEOUT_MS;
 }
 
-const REQUIRED_CLAWHUB_RESULT_KEYS = CLAWHUB_OUTPUT_SCHEMA_CONTRACT.requiredResultKeys;
+const REQUIRED_CLAWHUB_RESULT_KEYS = [
+  ...CLAWHUB_OUTPUT_SCHEMA_CONTRACT.requiredResultKeys,
+  "artifact_inspection",
+];
 const REQUIRED_CLAWHUB_DIMENSION_KEYS = CLAWHUB_OUTPUT_SCHEMA_CONTRACT.requiredDimensionKeys;
 const REQUIRED_CLAWHUB_DIMENSION_FIELD_KEYS =
   CLAWHUB_OUTPUT_SCHEMA_CONTRACT.requiredDimensionFieldKeys;
 const REQUIRED_CLAWHUB_FINDING_KEYS = CLAWHUB_OUTPUT_SCHEMA_CONTRACT.requiredFindingKeys;
+const REQUIRED_CLAWHUB_ARTIFACT_INSPECTION_KEYS = [
+  "status",
+  "challenge",
+  "required_file_sha256",
+  "files_inspected",
+];
 const ALLOWED_CLAWHUB_DIMENSION_STATUSES = CLAWHUB_OUTPUT_SCHEMA_CONTRACT.allowedDimensionStatus;
 
 function assertExactObjectKeys(
@@ -1595,6 +1604,36 @@ function validateClawScanJudgeResultShape(result: Record<string, unknown>) {
   }
   if (typeof result.user_guidance !== "string") {
     throw new Error("ClawScan judge result user_guidance was missing");
+  }
+
+  const artifactInspection = asRecord(result.artifact_inspection);
+  if (!artifactInspection) {
+    throw new Error("ClawScan judge result artifact_inspection was missing");
+  }
+  assertExactObjectKeys(
+    artifactInspection,
+    REQUIRED_CLAWHUB_ARTIFACT_INSPECTION_KEYS,
+    "ClawScan artifact inspection",
+  );
+  const inspectionStatus = readString(artifactInspection, ["status"]);
+  if (inspectionStatus !== "completed") {
+    throw new Error(`ClawScan artifact inspection status was ${inspectionStatus ?? "missing"}`);
+  }
+  const inspectionChallenge = readString(artifactInspection, ["challenge"]);
+  if (!inspectionChallenge) {
+    throw new Error("ClawScan artifact inspection challenge was missing");
+  }
+  const requiredFileSha256 = readString(artifactInspection, ["required_file_sha256"]);
+  if (!requiredFileSha256 || !/^[a-f0-9]{64}$/.test(requiredFileSha256)) {
+    throw new Error("ClawScan artifact inspection required_file_sha256 was invalid");
+  }
+  const inspectedFiles = artifactInspection.files_inspected;
+  if (
+    !Array.isArray(inspectedFiles) ||
+    inspectedFiles.length === 0 ||
+    inspectedFiles.some((file) => typeof file !== "string" || !file.startsWith("artifact/"))
+  ) {
+    throw new Error("ClawScan artifact inspection files_inspected was invalid");
   }
 
   const dimensions = asRecord(result.dimensions);

--- a/scripts/security/security-scan-worker-workflow.test.ts
+++ b/scripts/security/security-scan-worker-workflow.test.ts
@@ -135,7 +135,7 @@ describe("security-scan-codex workflow", () => {
     const skillspectorInstall = steps.find((step) => step.name === "Install SkillSpector")?.run;
     expect(codexInstall).toContain("npm install -g @openai/codex@0.142.3");
     expect(codexInstall).not.toContain("@latest");
-    expect(clawScanInstall).toContain("npm install -g @openclaw/clawscan@0.1.3");
+    expect(clawScanInstall).toContain("npm install -g @openclaw/clawscan@0.1.4");
     expect(clawScanInstall).not.toContain("@latest");
     expect(skillspectorInstall).toContain("git+https://github.com/NVIDIA/skillspector.git@8f37cfa");
     expect(skillspectorInstall).not.toContain("git+https://github.com/NVIDIA/skillspector.git'");

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -291,6 +291,11 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   Authoritative ClawScan failures use the existing failure/retry lifecycle and
   never trigger per-job legacy fallback. Rollback is a manual whole-system mode
   change to `legacy`.
+- An authoritative ClawScan judge result is complete only when ClawScan verifies
+  a workspace-only inspection challenge and the SHA-256 of a required artifact
+  file. Missing or mismatched inspection receipts fail the judge and use the
+  normal scan failure/retry lifecycle; a low-confidence verdict cannot replace
+  successful artifact inspection.
 - Every worker run publishes a GitHub Actions summary and uploads a structured
   summary with its secret-scanned diagnostics. The summary reports authoritative
   completions, failures, timeouts, scanner-stage and judge-stage failures,


### PR DESCRIPTION
## Summary

- pin the production security worker to `@openclaw/clawscan@0.1.4`
- require the ClawScan-only artifact inspection receipt before accepting a verdict
- keep the legacy Codex output schema unchanged for manual rollback
- document the fail-closed artifact inspection invariant

## Validation

- `bunx vitest run scripts/security/run-codex-scan-worker-clawscan.test.ts scripts/security/security-scan-worker-workflow.test.ts scripts/security/run-codex-scan-worker-modes.test.ts scripts/security/run-codex-scan-worker.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local`
- live npm replay of `enterprise-file-writer@1.2.3` with `@openclaw/clawscan@0.1.4`

Linear: CLAW-549
