### PR TITLE
fix(web): official creators fail to load on homepage

### DIFF
--- a/src/__tests__/home-popular-publishers-section.test.tsx
+++ b/src/__tests__/home-popular-publishers-section.test.tsx
@@ -3,16 +3,16 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const convexActionMock = vi.fn();
+const convexQueryMock = vi.fn();
 
 vi.mock("../convex/client", () => ({
-  convexHttp: { action: (...args: unknown[]) => convexActionMock(...args) },
+  convexHttp: { query: (...args: unknown[]) => convexQueryMock(...args) },
 }));
 
 vi.mock("../../convex/_generated/api", () => ({
   api: {
     publishers: {
-      getHomeOfficialCreatorSummaries: "publishers:getHomeOfficialCreatorSummaries",
+      listPublicPage: "publishers:listPublicPage",
     },
   },
 }));
@@ -52,8 +52,8 @@ describe("HomePopularPublishersSection", () => {
   let intersectionCallback: IntersectionObserverCallback;
 
   beforeEach(() => {
-    convexActionMock.mockReset();
-    convexActionMock.mockResolvedValue([]);
+    convexQueryMock.mockReset();
+    convexQueryMock.mockResolvedValue({ page: [] });
     vi.stubGlobal(
       "IntersectionObserver",
       class {
@@ -83,8 +83,8 @@ describe("HomePopularPublishersSection", () => {
   };
 
   it("loads the top twelve official creators once when the section nears the viewport", async () => {
-    convexActionMock.mockResolvedValue(
-      Array.from({ length: 12 }, (_, index) => ({
+    convexQueryMock.mockResolvedValue({
+      page: Array.from({ length: 12 }, (_, index) => ({
         _id: `publishers:org-${index}`,
         _creationTime: index,
         handle: `org-${index}`,
@@ -94,15 +94,15 @@ describe("HomePopularPublishersSection", () => {
           skills: 2,
           packages: 1,
           installs: 12 - index,
-          downloads: 4,
+          downloads: 12 - index,
           stars: 5,
         },
       })),
-    );
+    });
 
     render(<HomePopularPublishersSection />);
 
-    expect(convexActionMock).not.toHaveBeenCalled();
+    expect(convexQueryMock).not.toHaveBeenCalled();
     expect(screen.getByRole("heading", { name: "Official creators" })).toBeTruthy();
     expect(screen.getByText("Explore skills and plugins from official creators.")).toBeTruthy();
     expect(screen.getByRole("link", { name: "Browse creators" }).dataset.search).toBe(
@@ -110,13 +110,15 @@ describe("HomePopularPublishersSection", () => {
     );
 
     await enterPublisherSection();
-    await waitFor(() => expect(convexActionMock).toHaveBeenCalledTimes(1));
-    expect(convexActionMock).toHaveBeenCalledWith("publishers:getHomeOfficialCreatorSummaries", {
-      limit: 12,
+    await waitFor(() => expect(convexQueryMock).toHaveBeenCalledTimes(1));
+    expect(convexQueryMock).toHaveBeenCalledWith("publishers:listPublicPage", {
+      kind: "org",
+      official: true,
+      paginationOpts: { cursor: null, numItems: 12 },
     });
     expect(screen.getAllByRole("link", { name: /Official Org/ })).toHaveLength(12);
-    expect(screen.getByText("12 installs")).toBeTruthy();
-    expect(screen.getByText("1 install")).toBeTruthy();
+    expect(screen.getByText("12 downloads")).toBeTruthy();
+    expect(screen.getByText("1 download")).toBeTruthy();
     expect(document.querySelectorAll(".home-v2-popular-publisher-card")).toHaveLength(12);
     expect(
       Array.from(document.querySelectorAll(".home-v2-popular-publisher-card"), (card) =>
@@ -125,44 +127,48 @@ describe("HomePopularPublishersSection", () => {
     ).toEqual(Array.from({ length: 12 }, (_, index) => `Official Org ${index}, @org-${index}`));
 
     await enterPublisherSection();
-    expect(convexActionMock).toHaveBeenCalledTimes(1);
+    expect(convexQueryMock).toHaveBeenCalledTimes(1);
   });
 
   it("retries a failed official creator request", async () => {
-    convexActionMock.mockRejectedValueOnce(new Error("offline")).mockResolvedValueOnce([
-      {
-        _id: "publishers:openclaw",
-        _creationTime: 1,
-        handle: "openclaw",
-        displayName: "OpenClaw",
-        kind: "org",
-        stats: { skills: 2, packages: 1, installs: 3, downloads: 4, stars: 5 },
-      },
-    ]);
+    convexQueryMock.mockRejectedValueOnce(new Error("offline")).mockResolvedValueOnce({
+      page: [
+        {
+          _id: "publishers:openclaw",
+          _creationTime: 1,
+          handle: "openclaw",
+          displayName: "OpenClaw",
+          kind: "org",
+          stats: { skills: 2, packages: 1, installs: 3, downloads: 4, stars: 5 },
+        },
+      ],
+    });
 
     render(<HomePopularPublishersSection />);
     await enterPublisherSection();
 
-    await waitFor(() => expect(convexActionMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(convexQueryMock).toHaveBeenCalledTimes(1));
     expect(document.querySelectorAll(".home-v2-popular-publisher-card")).toHaveLength(0);
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
 
-    await waitFor(() => expect(convexActionMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(convexQueryMock).toHaveBeenCalledTimes(2));
     expect(await screen.findByRole("link", { name: "OpenClaw, @openclaw" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
   });
 
   it("keeps creator cards clickable until the pointer actually drags", async () => {
-    convexActionMock.mockResolvedValue([
-      {
-        _id: "publishers:openclaw",
-        _creationTime: 1,
-        handle: "openclaw",
-        displayName: "OpenClaw",
-        kind: "org",
-        stats: { skills: 2, packages: 1, installs: 3, downloads: 4, stars: 5 },
-      },
-    ]);
+    convexQueryMock.mockResolvedValue({
+      page: [
+        {
+          _id: "publishers:openclaw",
+          _creationTime: 1,
+          handle: "openclaw",
+          displayName: "OpenClaw",
+          kind: "org",
+          stats: { skills: 2, packages: 1, installs: 3, downloads: 4, stars: 5 },
+        },
+      ],
+    });
     const setPointerCapture = vi.fn();
     const hasPointerCapture = vi.fn(() => false);
     const releasePointerCapture = vi.fn();

--- a/src/components/HomePopularPublishersSection.tsx
+++ b/src/components/HomePopularPublishersSection.tsx
@@ -12,7 +12,7 @@ const HOME_OFFICIAL_CREATOR_LIMIT = 12;
 function OfficialCreatorCard({ publisher }: { publisher: PublicPublisherSummary }) {
   const name = publisher.displayName.trim() || publisher.handle;
   const bio = publisher.bio?.trim() || "Official creator on ClawHub.";
-  const installs = publisher.stats.installs;
+  const downloads = publisher.stats.downloads;
 
   return (
     <Link
@@ -34,7 +34,7 @@ function OfficialCreatorCard({ publisher }: { publisher: PublicPublisherSummary 
       <div className="home-v2-popular-publisher-copy">
         <p className="home-v2-popular-publisher-bio">{bio}</p>
         <span className="home-v2-popular-publisher-stats">
-          {formatCompactStat(installs)} {installs === 1 ? "install" : "installs"}
+          {formatCompactStat(downloads)} {downloads === 1 ? "download" : "downloads"}
           <ArrowRight size={13} aria-hidden="true" />
         </span>
       </div>
@@ -63,11 +63,13 @@ export function HomePopularPublishersSection() {
     requestedPublishersRef.current = true;
     setLoadFailed(false);
     try {
-      const result = (await convexHttp.action(api.publishers.getHomeOfficialCreatorSummaries, {
-        limit: HOME_OFFICIAL_CREATOR_LIMIT,
-      })) as PublicPublisherSummary[];
+      const result = (await convexHttp.query(api.publishers.listPublicPage, {
+        kind: "org",
+        official: true,
+        paginationOpts: { cursor: null, numItems: HOME_OFFICIAL_CREATOR_LIMIT },
+      })) as { page: PublicPublisherSummary[] };
       if (!mountedRef.current) return;
-      setPublishers(result);
+      setPublishers(result.page);
     } catch {
       requestedPublishersRef.current = false;
       if (!mountedRef.current) return;


### PR DESCRIPTION
Closes #3105

## What Problem This Solves

Fixes an issue where homepage visitors would see an empty Official creators section with a Retry control when the section's data request failed.

## Why This Change Was Made

This PR loads the shelf through the existing public creators query, filtered to official organizations and limited to 12 results. It preserves lazy loading and retry behavior, and shows download totals so the displayed metric matches the query's download-based ordering.

## User Impact

Visitors can see and open the 12 leading official creator cards from the homepage, with download totals and the existing Browse creators link.

## Evidence

- `bun run test -- src/__tests__/home-popular-publishers-section.test.tsx` — 3 tests passed.
- `bun run ci:static` — audit, formatting, lint, dead-code, and workflow pin checks passed.
- `bun run ci:unit` — 4,697 tests passed, 1 skipped; coverage thresholds passed.
- `bun run ci:types-build` — TypeScript and production build passed.
- Local ClawHub at `http://127.0.0.1:4175/` using the public read backend: 12 cards, 12 download labels, no install labels, and no Retry control at desktop and 375px mobile widths.

Proposed fixed state in this PR:

![Official creators rendered with download totals](https://raw.githubusercontent.com/vyctorbrzezowski/clawhub/qa-artifacts/clawhub-ui-proof/issue-3105/official-creators-fixed.png)
