### PR TITLE
fix(web): center homepage hero background

### DIFF
--- a/e2e/public-routes-smoke.pw.test.ts
+++ b/e2e/public-routes-smoke.pw.test.ts
@@ -43,6 +43,21 @@ async function getSeedFixture(request: APIRequestContext, path: string) {
   return lastResponse!;
 }
 
+async function expectHomeHeroBackgroundCentered(page: Page) {
+  const metrics = await page.locator(".home-v2-hero-bg").evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return {
+      backgroundCenter: rect.left + rect.width / 2,
+      backgroundWidth: rect.width,
+      viewportCenter: window.innerWidth / 2,
+      viewportWidth: window.innerWidth,
+    };
+  });
+
+  expect(metrics.backgroundWidth).toBeGreaterThanOrEqual(metrics.viewportWidth - 20);
+  expect(Math.abs(metrics.backgroundCenter - metrics.viewportCenter)).toBeLessThanOrEqual(10);
+}
+
 async function fetchSeedFixtures(request: APIRequestContext): Promise<SeedFixtures> {
   const skillPath = "/api/v1/skills/gifgrep";
   const skillResponse = await getSeedFixture(request, skillPath);
@@ -93,6 +108,7 @@ function publicRouteCases(): PublicRouteCase[] {
       path: () => "/",
       assert: async (page) => {
         await expect(page.locator("body")).toContainText("ClawHub");
+        await expectHomeHeroBackgroundCentered(page);
       },
     },
     {

--- a/src/styles.css
+++ b/src/styles.css
@@ -29247,6 +29247,8 @@ a[class*="rounded-full"] {
   left: 50%;
   width: 100vw;
   max-width: none;
+  /* This rule centers with transform; neutralize the legacy -50vw margin above. */
+  margin-left: 0;
   transform: translateX(-50%);
   -webkit-mask-image: linear-gradient(to bottom, #000 0%, #000 40%, transparent 100%);
   mask-image: linear-gradient(to bottom, #000 0%, #000 40%, transparent 100%);


### PR DESCRIPTION
## What this fixes

The homepage hero introduced in #3106 inherited two horizontal-centering mechanisms: the legacy `margin-left: -50vw` and the newer `left: 50%` plus `translateX(-50%)`. Together they shifted the full-viewport background left by half a viewport.

## Changes

- neutralize the legacy negative margin where the transform owns centering
- add a Playwright regression that measures the background center against the viewport center

## Regression proof

- production baseline: 647.5 px desktop offset and 202.5 px mobile offset
- proposed fix: 7.5 px offset in both viewports (the scrollbar gutter)
- baseline fails the new assertion; the proposed fix passes it

## Validation

- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- Chromium public-route smoke: 16/16 passed
- real-browser proof: desktop/mobile, dark/light

## Visual proof

| Production baseline | Proposed fix |
| --- | --- |
| <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3108/2026-07-16-home-hero-centering/baseline/desktop-dark.png" width="620" alt="Desktop production baseline with the hero background shifted left"> | <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3108/2026-07-16-home-hero-centering/candidate/desktop-dark.png" width="620" alt="Desktop proposed fix with the hero background centered"> |
| <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3108/2026-07-16-home-hero-centering/baseline/mobile-dark.png" width="300" alt="Mobile production baseline with the hero background shifted left"> | <img src="https://raw.githubusercontent.com/openclaw/clawhub/qa-artifacts/clawhub-ui-proof/pr-3108/2026-07-16-home-hero-centering/candidate/mobile-dark.png" width="300" alt="Mobile proposed fix with the hero background centered"> |

The proof comment also includes the light-theme captures and raw artifacts.
