### PR TITLE
feat: add featured catalog moderation commands

### DIFF
--- a/convex/httpApiV1.handlers.test.ts
+++ b/convex/httpApiV1.handlers.test.ts
@@ -7412,6 +7412,68 @@ describe("httpApiV1 handlers", () => {
     );
   });
 
+  it("sets featured status for an owner-qualified skill through the moderator mutation", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:moderator",
+      user: { _id: "users:moderator", role: "moderator" },
+    } as never);
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      return {
+        ok: true,
+        featured: true,
+        skillId: "skills:1",
+        slug: "demo",
+        ownerHandle: "openclaw",
+      };
+    });
+
+    const response = await __handlers.skillsPostRouterV1Handler(
+      makeCtx({ runMutation }),
+      new Request("https://example.com/api/v1/skills/demo/featured", {
+        method: "POST",
+        headers: { Authorization: "Bearer clh_test" },
+        body: JSON.stringify({ featured: true, ownerHandle: "openclaw" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ ok: true, featured: true });
+    expect(runMutation).toHaveBeenCalledWith(
+      (internal as unknown as { skills: Record<string, unknown> }).skills
+        .setSkillFeaturedForUserInternal,
+      {
+        actorUserId: "users:moderator",
+        slug: "demo",
+        ownerHandle: "openclaw",
+        featured: true,
+      },
+    );
+  });
+
+  it("maps forbidden featured-skill mutations to a 403 response", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:user",
+      user: { _id: "users:user", role: "user" },
+    } as never);
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      throw new Error("Forbidden");
+    });
+
+    const response = await __handlers.skillsPostRouterV1Handler(
+      makeCtx({ runMutation }),
+      new Request("https://example.com/api/v1/skills/demo/featured", {
+        method: "POST",
+        headers: { Authorization: "Bearer clh_test" },
+        body: JSON.stringify({ featured: true }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.text()).resolves.toBe("Forbidden");
+  });
+
   it("skill rescan rejects malformed JSON", async () => {
     vi.mocked(requireApiTokenUser).mockResolvedValue({
       userId: "users:moderator",
@@ -7667,6 +7729,66 @@ describe("httpApiV1 handlers", () => {
         version: "1.2.3",
       },
     );
+  });
+
+  it("sets featured status for a plugin through the moderator mutation", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:moderator",
+      user: { _id: "users:moderator", role: "moderator" },
+    } as never);
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      return {
+        ok: true,
+        featured: false,
+        packageId: "packages:1",
+        name: "@openclaw/demo-plugin",
+      };
+    });
+
+    const response = await __handlers.packagesPostRouterV1Handler(
+      makeCtx({ runMutation }),
+      new Request("https://example.com/api/v1/packages/%40openclaw%2Fdemo-plugin/featured", {
+        method: "POST",
+        headers: { Authorization: "Bearer clh_test" },
+        body: JSON.stringify({ featured: false }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ ok: true, featured: false });
+    expect(runMutation).toHaveBeenCalledWith(
+      (internal as unknown as { packages: Record<string, unknown> }).packages
+        .setPackageFeaturedForUserInternal,
+      {
+        actorUserId: "users:moderator",
+        name: "@openclaw/demo-plugin",
+        featured: false,
+      },
+    );
+  });
+
+  it("maps forbidden featured-plugin mutations to a 403 response", async () => {
+    vi.mocked(requireApiTokenUser).mockResolvedValue({
+      userId: "users:user",
+      user: { _id: "users:user", role: "user" },
+    } as never);
+    const runMutation = vi.fn(async (_mutation: unknown, args: Record<string, unknown>) => {
+      if (isRateLimitArgs(args)) return okRate();
+      throw new Error("Forbidden");
+    });
+
+    const response = await __handlers.packagesPostRouterV1Handler(
+      makeCtx({ runMutation }),
+      new Request("https://example.com/api/v1/packages/%40openclaw%2Fdemo-plugin/featured", {
+        method: "POST",
+        headers: { Authorization: "Bearer clh_test" },
+        body: JSON.stringify({ featured: true }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.text()).resolves.toBe("Forbidden");
   });
 
   it("package rescan rejects malformed JSON", async () => {

--- a/convex/httpApiV1/packagesV1.ts
+++ b/convex/httpApiV1/packagesV1.ts
@@ -143,6 +143,7 @@ const internalRefs = internal as unknown as {
     listOfficialPluginMigrationsInternal: unknown;
     upsertOfficialPluginMigrationForUserInternal: unknown;
     listPackageModerationQueueInternal: unknown;
+    setPackageFeaturedForUserInternal: unknown;
   };
   downloadMetrics: {
     recordDownloadMetricInternal: unknown;
@@ -2913,6 +2914,37 @@ export async function packagesPostRouterV1Handler(ctx: ActionCtx, request: Reque
         400,
         rate.headers,
       );
+    }
+  }
+
+  if (packageSegments[0] === "featured" && packageSegments.length === 1) {
+    const rate = await applyRateLimit(ctx, request, "write");
+    if (!rate.ok) return rate.response;
+    const auth = await requireApiTokenUserOrResponse(ctx, request, rate.headers);
+    if (!auth.ok) return auth.response;
+
+    try {
+      const body = await readOptionalJson(request);
+      const featured =
+        body && typeof body === "object" && !Array.isArray(body)
+          ? (body as Record<string, unknown>).featured
+          : undefined;
+      if (typeof featured !== "boolean") {
+        return text("featured must be a boolean", 400, rate.headers);
+      }
+      const result = await runMutationRef(
+        ctx,
+        internalRefs.packages.setPackageFeaturedForUserInternal,
+        {
+          actorUserId: auth.userId,
+          name: packageName,
+          featured,
+        },
+      );
+      return json(result, 200, rate.headers);
+    } catch (error) {
+      if (error instanceof SyntaxError) return text("Invalid JSON", 400, rate.headers);
+      return packageOperationErrorToResponse(error, rate.headers, "Package feature update failed");
     }
   }
 

--- a/convex/httpApiV1/skillsV1.ts
+++ b/convex/httpApiV1/skillsV1.ts
@@ -359,6 +359,7 @@ const internalRefs = internal as unknown as {
     submitSkillAppealForUserInternal: unknown;
     listSkillAppealsInternal: unknown;
     resolveSkillAppealForUserInternal: unknown;
+    setSkillFeaturedForUserInternal: unknown;
   };
 };
 
@@ -3144,6 +3145,39 @@ export async function skillsPostRouterV1Handler(ctx: ActionCtx, request: Request
         400,
         rate.headers,
       );
+    }
+  }
+
+  if (segments.length === 2 && action === "featured") {
+    if (!slug) return text("Slug required", 400, rate.headers);
+    const auth = await requireApiTokenUserOrResponse(ctx, request, rate.headers);
+    if (!auth.ok) return auth.response;
+
+    try {
+      const body = await readOptionalJson(request);
+      const featured =
+        body && typeof body === "object" && !Array.isArray(body)
+          ? (body as Record<string, unknown>).featured
+          : undefined;
+      if (typeof featured !== "boolean") {
+        return text("featured must be a boolean", 400, rate.headers);
+      }
+      const ownerHandle =
+        optionalStringField(body, "ownerHandle") ?? getOwnerHandleParam(new URL(request.url));
+      const result = await runMutationRef(
+        ctx,
+        internalRefs.skills.setSkillFeaturedForUserInternal,
+        {
+          actorUserId: auth.userId,
+          slug,
+          ...(ownerHandle ? { ownerHandle } : {}),
+          featured,
+        },
+      );
+      return json(result, 200, rate.headers);
+    } catch (error) {
+      if (error instanceof SyntaxError) return text("Invalid JSON", 400, rate.headers);
+      return skillRescanErrorToResponse(error, rate.headers);
     }
   }
 

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -10272,23 +10272,52 @@ export const setBatch = mutation({
       throw new ConvexError("Plugin not found");
     }
     const nextBatch = args.batch?.trim() || undefined;
-    const nextHighlighted = nextBatch === "highlighted";
-    const now = Date.now();
+    await setPackageFeaturedForActor(ctx, user, pkg, nextBatch === "highlighted");
+  },
+});
 
-    if (nextHighlighted) {
-      await upsertPackageBadge(ctx, pkg._id, "highlighted", user._id, now);
-    } else {
-      await removePackageBadge(ctx, pkg._id, "highlighted");
+async function setPackageFeaturedForActor(
+  ctx: MutationCtx,
+  actor: Doc<"users">,
+  pkg: Doc<"packages">,
+  featured: boolean,
+) {
+  const now = Date.now();
+  if (featured) {
+    await upsertPackageBadge(ctx, pkg._id, "highlighted", actor._id, now);
+  } else {
+    await removePackageBadge(ctx, pkg._id, "highlighted");
+  }
+
+  await ctx.db.insert("auditLogs", {
+    actorUserId: actor._id,
+    action: "package.badge.highlighted",
+    targetType: "package",
+    targetId: pkg._id,
+    metadata: { highlighted: featured },
+    createdAt: now,
+  });
+
+  return { ok: true as const, featured, packageId: pkg._id, name: pkg.name };
+}
+
+export const setPackageFeaturedForUserInternal = internalMutation({
+  args: {
+    actorUserId: v.id("users"),
+    name: v.string(),
+    featured: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const actor = await ctx.db.get(args.actorUserId);
+    if (!actor || actor.deletedAt || actor.deactivatedAt) throw new ConvexError("Unauthorized");
+    assertModerator(actor);
+
+    const pkg = await getPackageByNormalizedName(ctx, normalizePackageName(args.name));
+    if (!pkg || pkg.softDeletedAt || pkg.family === "skill") {
+      throw new ConvexError("Plugin not found");
     }
 
-    await ctx.db.insert("auditLogs", {
-      actorUserId: user._id,
-      action: "package.badge.highlighted",
-      targetType: "package",
-      targetId: pkg._id,
-      metadata: { highlighted: nextHighlighted },
-      createdAt: now,
-    });
+    return await setPackageFeaturedForActor(ctx, actor, pkg, args.featured);
   },
 });
 

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -10498,34 +10498,78 @@ export const setBatch = mutation({
     assertModerator(user);
     const skill = await ctx.db.get(args.skillId);
     if (!skill) throw new Error("Skill not found");
-    const existingBadges = await getSkillBadgeMap(ctx, skill._id);
-    const previousHighlighted = isSkillHighlighted({ badges: existingBadges });
     const nextBatch = args.batch?.trim() || undefined;
-    const nextHighlighted = nextBatch === "highlighted";
-    const now = Date.now();
+    await setSkillFeaturedForActor(ctx, user, skill, nextBatch);
+  },
+});
 
-    if (nextHighlighted) {
-      await upsertSkillBadge(ctx, skill._id, "highlighted", user._id, now);
-    } else {
-      await removeSkillBadge(ctx, skill._id, "highlighted");
+async function setSkillFeaturedForActor(
+  ctx: MutationCtx,
+  actor: Doc<"users">,
+  skill: Doc<"skills">,
+  nextBatch: string | undefined,
+) {
+  const existingBadges = await getSkillBadgeMap(ctx, skill._id);
+  const previousHighlighted = isSkillHighlighted({ badges: existingBadges });
+  const featured = nextBatch === "highlighted";
+  const now = Date.now();
+
+  if (featured) {
+    await upsertSkillBadge(ctx, skill._id, "highlighted", actor._id, now);
+  } else {
+    await removeSkillBadge(ctx, skill._id, "highlighted");
+  }
+
+  await ctx.db.patch(skill._id, {
+    batch: nextBatch,
+    updatedAt: now,
+  });
+  await ctx.db.insert("auditLogs", {
+    actorUserId: actor._id,
+    action: "badge.highlighted",
+    targetType: "skill",
+    targetId: skill._id,
+    metadata: { highlighted: featured },
+    createdAt: now,
+  });
+
+  if (featured && !previousHighlighted) {
+    void queueHighlightedWebhook(ctx, skill._id);
+  }
+
+  return { ok: true as const, featured, skillId: skill._id, slug: skill.slug };
+}
+
+export const setSkillFeaturedForUserInternal = internalMutation({
+  args: {
+    actorUserId: v.id("users"),
+    slug: v.string(),
+    ownerHandle: v.optional(v.string()),
+    featured: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const actor = await ctx.db.get(args.actorUserId);
+    if (!actor || actor.deletedAt || actor.deactivatedAt) throw new ConvexError("Unauthorized");
+    assertModerator(actor);
+
+    const resolved = await resolveSkillBySlugOrAliasForOwner(ctx, args.slug, args.ownerHandle);
+    if (resolved.ambiguous) {
+      throw new ConvexError(
+        "Slug is used by multiple publishers. Use an owner-qualified skill URL.",
+      );
+    }
+    const skill = resolved.skill;
+    if (!skill || skill.softDeletedAt || skill.moderationStatus === "removed") {
+      throw new ConvexError("Skill not found");
     }
 
-    await ctx.db.patch(skill._id, {
-      batch: nextBatch,
-      updatedAt: now,
-    });
-    await ctx.db.insert("auditLogs", {
-      actorUserId: user._id,
-      action: "badge.highlighted",
-      targetType: "skill",
-      targetId: skill._id,
-      metadata: { highlighted: nextHighlighted },
-      createdAt: now,
-    });
-
-    if (nextHighlighted && !previousHighlighted) {
-      void queueHighlightedWebhook(ctx, skill._id);
-    }
+    const result = await setSkillFeaturedForActor(
+      ctx,
+      actor,
+      skill,
+      args.featured ? "highlighted" : undefined,
+    );
+    return { ...result, ownerHandle: args.ownerHandle ?? null };
   },
 });
 

--- a/packages/clawhub-admin/README.md
+++ b/packages/clawhub-admin/README.md
@@ -113,11 +113,15 @@ Package moderation and operations:
 
 ```bash
 bun run admin -- skills reports [--status open|confirmed|dismissed|all]
+bun run admin -- skills feature <slug|@owner/slug> [--json]
+bun run admin -- skills unfeature <slug|@owner/slug> [--json]
 bun run admin -- skills rescan <slug> [--version <version>] [--yes] [--json]
 bun run admin -- skills unhide <slug> --reason <text> [--yes]
 bun run admin -- skills triage-report <report-id> --status open|confirmed|dismissed [--note <text>] [--action none|hide] [--yes]
 
 bun run admin -- plugins moderate <name> --version <version> --state approved|quarantined|revoked --reason <text>
+bun run admin -- plugins feature <name> [--json]
+bun run admin -- plugins unfeature <name> [--json]
 bun run admin -- plugins status <name>
 bun run admin -- plugins queue [--status open|blocked|manual|all]
 bun run admin -- plugins reports [--status open|confirmed|dismissed|all]

--- a/packages/clawhub-admin/src/cli.ts
+++ b/packages/clawhub-admin/src/cli.ts
@@ -27,6 +27,7 @@ import {
   cmdRecordContentRightsCorrespondence,
 } from "./commands/contentRights.js";
 import { cmdSendStaffEmail } from "./commands/email.js";
+import { cmdSetPackageFeatured, cmdSetSkillFeatured } from "./commands/featured.js";
 import {
   cmdBanUser,
   cmdRecoverPersonalPublisher,
@@ -702,6 +703,8 @@ function registerPluginGovernanceCommands(command: Command) {
 }
 
 function registerPluginModerationCommands(command: Command) {
+  registerFeaturedCommands(command, "plugin");
+
   command
     .command("reports")
     .description("List plugin reports for moderator review")
@@ -773,6 +776,8 @@ function registerPluginOperations(command: Command) {
 }
 
 function registerSkillModerationCommands(command: Command) {
+  registerFeaturedCommands(command, "skill");
+
   command
     .command("revoke-version")
     .description("Permanently remove one skill version from public access")
@@ -891,6 +896,30 @@ function registerSkillModerationCommands(command: Command) {
       const opts = await resolveGlobalOpts();
       await cmdTriageSkillReport(opts, reportId, options);
     });
+}
+
+function registerFeaturedCommands(command: Command, kind: "plugin" | "skill") {
+  const label = kind === "plugin" ? "plugin" : "skill";
+  const argument = kind === "plugin" ? "Plugin package name" : "Skill ref, optionally @owner/slug";
+
+  for (const [name, featured] of [
+    ["feature", true],
+    ["unfeature", false],
+  ] as const) {
+    command
+      .command(name)
+      .description(`${featured ? "Add" : "Remove"} a ${label} from the Featured catalog`)
+      .argument(`<${kind}>`, argument)
+      .option("--json", "Output JSON")
+      .action(async (value, options) => {
+        const opts = await resolveGlobalOpts();
+        if (kind === "plugin") {
+          await cmdSetPackageFeatured(opts, value, featured, options);
+        } else {
+          await cmdSetSkillFeatured(opts, value, featured, options);
+        }
+      });
+  }
 }
 
 program.action(() => {

--- a/packages/clawhub-admin/src/commands/featured.test.ts
+++ b/packages/clawhub-admin/src/commands/featured.test.ts
@@ -1,0 +1,81 @@
+/* @vitest-environment node */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createAuthTokenModuleMocks,
+  createHttpModuleMocks,
+  createRegistryModuleMocks,
+  createUiModuleMocks,
+  makeGlobalOpts,
+} from "../../../clawhub/test/cliCommandTestKit.js";
+
+const authTokenMocks = createAuthTokenModuleMocks();
+const registryMocks = createRegistryModuleMocks();
+const httpMocks = createHttpModuleMocks();
+const uiMocks = createUiModuleMocks();
+
+vi.mock("../../../clawhub/src/cli/authToken.js", () => authTokenMocks.moduleFactory());
+vi.mock("../../../clawhub/src/cli/registry.js", () => registryMocks.moduleFactory());
+vi.mock("../../../clawhub/src/http.js", () => httpMocks.moduleFactory());
+vi.mock("../../../clawhub/src/cli/ui.js", () => uiMocks.moduleFactory());
+
+const { cmdSetPackageFeatured, cmdSetSkillFeatured } = await import("./featured");
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("featured catalog commands", () => {
+  it("features a plugin through the moderator API", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      ok: true,
+      featured: true,
+      packageId: "packages:1",
+      name: "@openclaw/demo-plugin",
+    });
+
+    await cmdSetPackageFeatured(makeGlobalOpts(), "@openclaw/demo-plugin", true);
+
+    expect(authTokenMocks.requireAuthToken).toHaveBeenCalled();
+    expect(httpMocks.apiRequest).toHaveBeenCalledWith(
+      "https://clawhub.ai",
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/v1/packages/%40openclaw%2Fdemo-plugin/featured",
+        token: "tkn",
+        body: { featured: true },
+      }),
+      undefined,
+    );
+  });
+
+  it("unfeatures an owner-qualified skill through the moderator API", async () => {
+    httpMocks.apiRequest.mockResolvedValueOnce({
+      ok: true,
+      featured: false,
+      skillId: "skills:1",
+      slug: "weather",
+      ownerHandle: "openclaw",
+    });
+
+    await cmdSetSkillFeatured(makeGlobalOpts(), "@openclaw/weather", false);
+
+    expect(httpMocks.apiRequest).toHaveBeenCalledWith(
+      "https://clawhub.ai",
+      expect.objectContaining({
+        method: "POST",
+        path: "/api/v1/skills/weather/featured",
+        token: "tkn",
+        body: { featured: false, ownerHandle: "openclaw" },
+      }),
+      undefined,
+    );
+  });
+
+  it("rejects malformed skill refs before making a request", async () => {
+    await expect(cmdSetSkillFeatured(makeGlobalOpts(), "a/b/c", true)).rejects.toThrow(
+      /invalid skill ref/i,
+    );
+    expect(httpMocks.apiRequest).not.toHaveBeenCalled();
+  });
+});

--- a/packages/clawhub-admin/src/commands/featured.ts
+++ b/packages/clawhub-admin/src/commands/featured.ts
@@ -1,0 +1,117 @@
+import { requireAuthToken } from "../../../clawhub/src/cli/authToken.js";
+import { getRegistry } from "../../../clawhub/src/cli/registry.js";
+import type { GlobalOpts } from "../../../clawhub/src/cli/types.js";
+import { fail } from "../../../clawhub/src/cli/ui.js";
+import { apiRequest } from "../../../clawhub/src/http.js";
+import { ApiRoutes } from "../../../clawhub/src/schema/index.js";
+
+type FeaturedOptions = {
+  json?: boolean;
+};
+
+type FeaturedPackageResult = {
+  ok: true;
+  featured: boolean;
+  packageId: string;
+  name: string;
+};
+
+type FeaturedSkillResult = {
+  ok: true;
+  featured: boolean;
+  skillId: string;
+  slug: string;
+  ownerHandle: string | null;
+};
+
+type SkillRef = {
+  slug: string;
+  ownerHandle?: string;
+};
+
+function normalizePackageNameOrFail(value: string) {
+  const name = value.trim();
+  if (!name) fail("Package name required");
+  return name;
+}
+
+function parseSkillRefOrFail(value: string): SkillRef {
+  const ref = value.trim();
+  if (!ref) fail("Skill ref required");
+
+  const slashIndex = ref.indexOf("/");
+  if (slashIndex < 0) {
+    if (ref.includes("\\") || ref.includes("..")) fail(`Invalid skill ref: ${value}`);
+    return { slug: ref.toLowerCase() };
+  }
+  if (ref.indexOf("/", slashIndex + 1) >= 0) fail(`Invalid skill ref: ${value}`);
+
+  const ownerHandle = ref.slice(0, slashIndex).trim().replace(/^@+/, "").toLowerCase();
+  const slug = ref
+    .slice(slashIndex + 1)
+    .trim()
+    .toLowerCase();
+  if (
+    !ownerHandle ||
+    !slug ||
+    ownerHandle.includes("\\") ||
+    ownerHandle.includes("..") ||
+    slug.includes("\\") ||
+    slug.includes("..")
+  ) {
+    fail(`Invalid skill ref: ${value}`);
+  }
+  return { slug, ownerHandle };
+}
+
+export async function cmdSetPackageFeatured(
+  opts: GlobalOpts,
+  packageName: string,
+  featured: boolean,
+  options: FeaturedOptions = {},
+) {
+  const name = normalizePackageNameOrFail(packageName);
+  const token = await requireAuthToken();
+  const registry = await getRegistry(opts, { cache: true });
+  const result = await apiRequest<FeaturedPackageResult>(registry, {
+    method: "POST",
+    path: `${ApiRoutes.packages}/${encodeURIComponent(name)}/featured`,
+    token,
+    body: { featured },
+  });
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return result;
+  }
+  console.log(`OK. ${featured ? "Featured" : "Unfeatured"} plugin ${result.name}.`);
+  return result;
+}
+
+export async function cmdSetSkillFeatured(
+  opts: GlobalOpts,
+  skillRef: string,
+  featured: boolean,
+  options: FeaturedOptions = {},
+) {
+  const ref = parseSkillRefOrFail(skillRef);
+  const token = await requireAuthToken();
+  const registry = await getRegistry(opts, { cache: true });
+  const result = await apiRequest<FeaturedSkillResult>(registry, {
+    method: "POST",
+    path: `${ApiRoutes.skills}/${encodeURIComponent(ref.slug)}/featured`,
+    token,
+    body: {
+      featured,
+      ...(ref.ownerHandle ? { ownerHandle: ref.ownerHandle } : {}),
+    },
+  });
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return result;
+  }
+  const label = result.ownerHandle ? `@${result.ownerHandle}/${result.slug}` : result.slug;
+  console.log(`OK. ${featured ? "Featured" : "Unfeatured"} skill ${label}.`);
+  return result;
+}


### PR DESCRIPTION
## Summary
- add moderator-only plugin and skill Featured mutations
- expose guarded Featured endpoints through the v1 API
- add `admin packages feature|unfeature` and `admin skills feature|unfeature`

## Why now
The Featured-first homepage shipped, but this curation slice did not. Production currently has the wrong manually curated plugin set and needs an auditable admin path to correct it.

## Validation
- 695 focused API/package/skill/CLI tests passed
- `bun run ci:static`
- Convex and admin CLI TypeScript checks
- autoreview clean
- full coverage reached 4701 passing tests; four unrelated UI tests timed out under concurrent load, then all affected files passed serially (76/76)
