### PR TITLE
fix(security): reuse cached VirusTotal evidence

### DIFF
--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -116,7 +116,6 @@ jobs:
           CODEX_API_KEY: ${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           SECURITY_SCAN_WORKER_TOKEN: ${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}
-          VIRUSTOTAL_API_KEY: ${{ secrets.VT_API_KEY }}
         run: |
           bun scripts/security/run-codex-scan-worker.ts \
             --batch-limit "$CODEX_SECURITY_SCAN_LIMIT" \

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1857,6 +1857,7 @@ const securityScanJobs = defineTable({
   updatedAt: v.number(),
 })
   .index("by_status_and_next_run_at", ["status", "nextRunAt"])
+  .index("by_status_and_updated_at", ["status", "updatedAt"])
   .index("by_status_source_created_at", ["status", "source", "createdAt"])
   .index("by_status_source_next_run_at", ["status", "source", "nextRunAt"])
   .index("by_status_source_target_kind_created_at", ["status", "source", "targetKind", "createdAt"])

--- a/convex/securityScan.test.ts
+++ b/convex/securityScan.test.ts
@@ -90,7 +90,7 @@ const requeueExpiredCodexScanJobsInternalHandler = (
 
 const requeueFailedSecurityScanJobsInternalHandler = (
   requeueFailedSecurityScanJobsInternal as unknown as WrappedHandler<
-    { failedAfter: number; dryRun: boolean; limit?: number },
+    { failedAfter: number; failedBefore: number; dryRun: boolean; limit?: number },
     {
       dryRun: boolean;
       matched: number;
@@ -628,8 +628,12 @@ function makeQueueHealthCtx(jobs: ScanJob[]) {
   return { db: { query } };
 }
 
-function makeFailedScanRecoveryCtx(jobs: ScanJob[]) {
+function makeFailedScanRecoveryCtx(
+  jobs: ScanJob[],
+  docs: Record<string, Record<string, unknown>> = {},
+) {
   const patches: Array<{ id: string; patch: Record<string, unknown> }> = [];
+  const inserts: Array<{ table: string; doc: Record<string, unknown> }> = [];
   const patch = vi.fn(
     async (
       tableOrId: string,
@@ -639,10 +643,20 @@ function makeFailedScanRecoveryCtx(jobs: ScanJob[]) {
       const id = maybeValue ? (idOrValue as string) : tableOrId;
       const value = maybeValue ?? (idOrValue as Record<string, unknown>);
       patches.push({ id, patch: value });
+      docs[id] = { ...docs[id], ...value };
     },
   );
   const query = vi.fn((table: string) => {
-    expect(table).toBe("securityScanJobs");
+    if (table !== "securityScanJobs") {
+      return {
+        withIndex: vi.fn(() => ({
+          collect: vi.fn(async () => []),
+          order: vi.fn(() => ({ take: vi.fn(async () => []) })),
+          take: vi.fn(async () => []),
+          unique: vi.fn(async () => null),
+        })),
+      };
+    }
     return {
       withIndex: vi.fn(
         (
@@ -650,11 +664,13 @@ function makeFailedScanRecoveryCtx(jobs: ScanJob[]) {
           buildRange: (q: {
             eq: (field: string, value: unknown) => unknown;
             gte: (field: string, value: number) => unknown;
+            lt: (field: string, value: number) => unknown;
           }) => unknown,
         ) => {
           expect(indexName).toBe("by_status_and_updated_at");
           const equals = new Map<string, unknown>();
           let updatedAfter = Number.NEGATIVE_INFINITY;
+          let updatedBefore = Number.POSITIVE_INFINITY;
           const range = {
             eq(field: string, value: unknown) {
               equals.set(field, value);
@@ -665,6 +681,11 @@ function makeFailedScanRecoveryCtx(jobs: ScanJob[]) {
               updatedAfter = value;
               return range;
             },
+            lt(field: string, value: number) {
+              expect(field).toBe("updatedAt");
+              updatedBefore = value;
+              return range;
+            },
           };
           buildRange(range);
           const matched = jobs
@@ -672,7 +693,9 @@ function makeFailedScanRecoveryCtx(jobs: ScanJob[]) {
               (job) =>
                 Array.from(equals.entries()).every(
                   ([field, value]) => job[field as keyof ScanJob] === value,
-                ) && job.updatedAt >= updatedAfter,
+                ) &&
+                job.updatedAt >= updatedAfter &&
+                job.updatedAt < updatedBefore,
             )
             .sort((a, b) => a.updatedAt - b.updatedAt || a._id.localeCompare(b._id));
           return {
@@ -691,8 +714,11 @@ function makeFailedScanRecoveryCtx(jobs: ScanJob[]) {
     ctx: {
       db: {
         delete: vi.fn(),
-        get: vi.fn(),
-        insert: vi.fn(),
+        get: vi.fn(async (id: string) => docs[id] ?? null),
+        insert: vi.fn(async (table: string, doc: Record<string, unknown>) => {
+          inserts.push({ table, doc });
+          return `${table}:inserted`;
+        }),
         normalizeId: vi.fn((_table: string, id: string) => id),
         patch,
         query,
@@ -701,6 +727,7 @@ function makeFailedScanRecoveryCtx(jobs: ScanJob[]) {
       },
     },
     patches,
+    inserts,
   };
 }
 
@@ -2417,11 +2444,17 @@ describe("securityScan", () => {
         status: "succeeded",
         updatedAt: 102,
       }),
+      makeScanJob({
+        _id: "securityScanJobs:after-window",
+        status: "failed",
+        updatedAt: 103,
+      }),
     ]);
 
     const result = await requeueFailedSecurityScanJobsInternalHandler(ctx, {
       dryRun: true,
       failedAfter: 100,
+      failedBefore: 103,
       limit: 10,
     });
 
@@ -2461,6 +2494,7 @@ describe("securityScan", () => {
     const result = await requeueFailedSecurityScanJobsInternalHandler(firstCtx.ctx, {
       dryRun: false,
       failedAfter: 100,
+      failedBefore: 200,
       limit: 1,
     });
 
@@ -2497,6 +2531,7 @@ describe("securityScan", () => {
     const second = await requeueFailedSecurityScanJobsInternalHandler(secondCtx.ctx, {
       dryRun: false,
       failedAfter: 100,
+      failedBefore: 200,
     });
 
     expect(second).toMatchObject({ matched: 1, requeued: 1, hasMore: false });
@@ -2517,6 +2552,87 @@ describe("securityScan", () => {
             status: "queued",
             lastError: undefined,
             completedAt: undefined,
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it("restores failed GitHub-backed scans to pending while requeueing", async () => {
+    const ctx = makeFailedScanRecoveryCtx(
+      [
+        makeScanJob({
+          _id: "securityScanJobs:github-failed",
+          status: "failed",
+          source: "github",
+          targetKind: "skillScanRequest",
+          skillVersionId: undefined,
+          skillScanRequestId: "skillScanRequests:github",
+          attempts: 3,
+          updatedAt: 150,
+        }),
+      ],
+      {
+        "skillScanRequests:github": {
+          _id: "skillScanRequests:github",
+          githubSkillScanId: "githubSkillScans:github",
+          status: "failed",
+        },
+        "githubSkillScans:github": {
+          _id: "githubSkillScans:github",
+          skillId: "skills:github",
+          contentHash: "content-hash",
+          status: "failed",
+        },
+        "skills:github": {
+          _id: "skills:github",
+          installKind: "github",
+          githubCurrentStatus: "present",
+          githubCurrentCommit: "a".repeat(40),
+          githubCurrentContentHash: "content-hash",
+          slug: "github-skill",
+          displayName: "GitHub Skill",
+          stats: {
+            downloads: 0,
+            stars: 0,
+            installsCurrent: 0,
+            installsAllTime: 0,
+            comments: 0,
+            versions: 0,
+          },
+          moderationStatus: "hidden",
+          moderationReason: "scanner.failed",
+          moderationFlags: [],
+          isSuspicious: false,
+          createdAt: 1,
+          updatedAt: 150,
+        },
+      },
+    );
+
+    const result = await requeueFailedSecurityScanJobsInternalHandler(ctx.ctx, {
+      dryRun: false,
+      failedAfter: 100,
+      failedBefore: 200,
+    });
+
+    expect(result).toMatchObject({ matched: 1, requeued: 1, hasMore: false });
+    expect(ctx.patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "githubSkillScans:github",
+          patch: expect.objectContaining({
+            status: "pending",
+            lastError: undefined,
+            completedAt: undefined,
+          }),
+        }),
+        expect.objectContaining({
+          id: "skills:github",
+          patch: expect.objectContaining({
+            githubScanStatus: "pending",
+            moderationStatus: "active",
+            moderationReason: "pending.scan",
           }),
         }),
       ]),

--- a/convex/securityScan.test.ts
+++ b/convex/securityScan.test.ts
@@ -25,6 +25,7 @@ import {
   pruneExpiredSkillScanRequestsInternal,
   requeueCodexScanJobLease,
   requeueExpiredCodexScanJobsInternal,
+  requeueFailedSecurityScanJobsInternal,
   requeueJobLeaseInternal,
   recordGitHubSkillScanResultInternal,
   recordSkillScanRequestFailedInternal,
@@ -84,6 +85,21 @@ const requeueExpiredCodexScanJobsInternalHandler = (
   requeueExpiredCodexScanJobsInternal as unknown as WrappedHandler<
     { limit?: number },
     { requeued: number }
+  >
+)._handler;
+
+const requeueFailedSecurityScanJobsInternalHandler = (
+  requeueFailedSecurityScanJobsInternal as unknown as WrappedHandler<
+    { failedAfter: number; dryRun: boolean; limit?: number },
+    {
+      dryRun: boolean;
+      matched: number;
+      requeued: number;
+      hasMore: boolean;
+      bySource: Record<string, number>;
+      byTargetKind: Record<string, number>;
+      sampleJobIds: string[];
+    }
   >
 )._handler;
 
@@ -610,6 +626,82 @@ function makeQueueHealthCtx(jobs: ScanJob[]) {
   });
 
   return { db: { query } };
+}
+
+function makeFailedScanRecoveryCtx(jobs: ScanJob[]) {
+  const patches: Array<{ id: string; patch: Record<string, unknown> }> = [];
+  const patch = vi.fn(
+    async (
+      tableOrId: string,
+      idOrValue: string | Record<string, unknown>,
+      maybeValue?: Record<string, unknown>,
+    ) => {
+      const id = maybeValue ? (idOrValue as string) : tableOrId;
+      const value = maybeValue ?? (idOrValue as Record<string, unknown>);
+      patches.push({ id, patch: value });
+    },
+  );
+  const query = vi.fn((table: string) => {
+    expect(table).toBe("securityScanJobs");
+    return {
+      withIndex: vi.fn(
+        (
+          indexName: string,
+          buildRange: (q: {
+            eq: (field: string, value: unknown) => unknown;
+            gte: (field: string, value: number) => unknown;
+          }) => unknown,
+        ) => {
+          expect(indexName).toBe("by_status_and_updated_at");
+          const equals = new Map<string, unknown>();
+          let updatedAfter = Number.NEGATIVE_INFINITY;
+          const range = {
+            eq(field: string, value: unknown) {
+              equals.set(field, value);
+              return range;
+            },
+            gte(field: string, value: number) {
+              expect(field).toBe("updatedAt");
+              updatedAfter = value;
+              return range;
+            },
+          };
+          buildRange(range);
+          const matched = jobs
+            .filter(
+              (job) =>
+                Array.from(equals.entries()).every(
+                  ([field, value]) => job[field as keyof ScanJob] === value,
+                ) && job.updatedAt >= updatedAfter,
+            )
+            .sort((a, b) => a.updatedAt - b.updatedAt || a._id.localeCompare(b._id));
+          return {
+            order: vi.fn((direction: string) => {
+              expect(direction).toBe("asc");
+              return {
+                take: vi.fn(async (limit: number) => matched.slice(0, limit)),
+              };
+            }),
+          };
+        },
+      ),
+    };
+  });
+  return {
+    ctx: {
+      db: {
+        delete: vi.fn(),
+        get: vi.fn(),
+        insert: vi.fn(),
+        normalizeId: vi.fn((_table: string, id: string) => id),
+        patch,
+        query,
+        replace: vi.fn(),
+        system: {},
+      },
+    },
+    patches,
+  };
 }
 
 function makeTarget(llmStatus?: string) {
@@ -2296,6 +2388,139 @@ describe("securityScan", () => {
       done: false,
       failedJobIds: ["securityScanJobs:failed"],
     });
+  });
+
+  it("dry-runs failed security scan recovery without changing jobs", async () => {
+    const { ctx, patches } = makeFailedScanRecoveryCtx([
+      makeScanJob({
+        _id: "securityScanJobs:before-window",
+        status: "failed",
+        updatedAt: 99,
+      }),
+      makeScanJob({
+        _id: "securityScanJobs:publish-failed",
+        status: "failed",
+        source: "publish",
+        updatedAt: 100,
+      }),
+      makeScanJob({
+        _id: "securityScanJobs:manual-failed",
+        status: "failed",
+        source: "manual",
+        targetKind: "skillScanRequest",
+        skillVersionId: undefined,
+        skillScanRequestId: "skillScanRequests:manual",
+        updatedAt: 101,
+      }),
+      makeScanJob({
+        _id: "securityScanJobs:succeeded",
+        status: "succeeded",
+        updatedAt: 102,
+      }),
+    ]);
+
+    const result = await requeueFailedSecurityScanJobsInternalHandler(ctx, {
+      dryRun: true,
+      failedAfter: 100,
+      limit: 10,
+    });
+
+    expect(result).toEqual({
+      dryRun: true,
+      matched: 2,
+      requeued: 0,
+      hasMore: false,
+      bySource: { manual: 1, publish: 1 },
+      byTargetKind: { skillScanRequest: 1, skillVersion: 1 },
+      sampleJobIds: ["securityScanJobs:publish-failed", "securityScanJobs:manual-failed"],
+    });
+    expect(patches).toEqual([]);
+  });
+
+  it("requeues failed jobs and resets uploaded scan-request state", async () => {
+    const firstCtx = makeFailedScanRecoveryCtx([
+      makeScanJob({
+        _id: "securityScanJobs:publish-failed",
+        status: "failed",
+        source: "publish",
+        attempts: 3,
+        updatedAt: 100,
+      }),
+      makeScanJob({
+        _id: "securityScanJobs:manual-failed",
+        status: "failed",
+        source: "manual",
+        targetKind: "skillScanRequest",
+        skillVersionId: undefined,
+        skillScanRequestId: "skillScanRequests:manual",
+        attempts: 3,
+        updatedAt: 101,
+      }),
+    ]);
+
+    const result = await requeueFailedSecurityScanJobsInternalHandler(firstCtx.ctx, {
+      dryRun: false,
+      failedAfter: 100,
+      limit: 1,
+    });
+
+    expect(result).toMatchObject({
+      dryRun: false,
+      matched: 1,
+      requeued: 1,
+      hasMore: true,
+      sampleJobIds: ["securityScanJobs:publish-failed"],
+    });
+    expect(firstCtx.patches).toHaveLength(1);
+    expect(firstCtx.patches[0]).toMatchObject({
+      id: "securityScanJobs:publish-failed",
+      patch: {
+        status: "queued",
+        attempts: 0,
+        lastError: undefined,
+        completedAt: undefined,
+      },
+    });
+
+    const secondCtx = makeFailedScanRecoveryCtx([
+      makeScanJob({
+        _id: "securityScanJobs:manual-failed",
+        status: "failed",
+        source: "manual",
+        targetKind: "skillScanRequest",
+        skillVersionId: undefined,
+        skillScanRequestId: "skillScanRequests:manual",
+        attempts: 3,
+        updatedAt: 101,
+      }),
+    ]);
+    const second = await requeueFailedSecurityScanJobsInternalHandler(secondCtx.ctx, {
+      dryRun: false,
+      failedAfter: 100,
+    });
+
+    expect(second).toMatchObject({ matched: 1, requeued: 1, hasMore: false });
+    expect(secondCtx.patches).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "securityScanJobs:manual-failed",
+          patch: expect.objectContaining({
+            status: "queued",
+            attempts: 0,
+            lastError: undefined,
+            completedAt: undefined,
+          }),
+        }),
+        expect.objectContaining({
+          id: "skillScanRequests:manual",
+          patch: expect.objectContaining({
+            status: "queued",
+            lastError: undefined,
+            completedAt: undefined,
+          }),
+        }),
+      ]),
+    );
   });
 
   it("lets platform moderators request package rescans", async () => {

--- a/convex/securityScan.ts
+++ b/convex/securityScan.ts
@@ -30,6 +30,9 @@ const MAX_ATTEMPTS = 3;
 const DEFAULT_CODEX_SCAN_CLAIM_LIMIT = 64;
 const MAX_CODEX_SCAN_CLAIM_LIMIT = 512;
 const MAX_EXPIRED_CODEX_SCAN_LEASE_REQUEUES = 512;
+const DEFAULT_FAILED_SCAN_RECOVERY_LIMIT = 250;
+const MAX_FAILED_SCAN_RECOVERY_LIMIT = 1000;
+const FAILED_SCAN_RECOVERY_SAMPLE_LIMIT = 20;
 const DEFAULT_CANCEL_SCAN_LIMIT = 1000;
 const DEFAULT_CANCEL_DELETE_LIMIT = 500;
 const MAX_CANCEL_SCAN_LIMIT = 5000;
@@ -2468,6 +2471,72 @@ export const requeueExpiredCodexScanJobsInternal = internalMutation({
     }
     if (jobs.length > 0) await requestSecurityScanDispatch(ctx);
     return { requeued: jobs.length };
+  },
+});
+
+export const requeueFailedSecurityScanJobsInternal = internalMutation({
+  args: {
+    failedAfter: v.number(),
+    dryRun: v.boolean(),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const limit = Math.max(
+      1,
+      Math.min(
+        Math.floor(args.limit ?? DEFAULT_FAILED_SCAN_RECOVERY_LIMIT),
+        MAX_FAILED_SCAN_RECOVERY_LIMIT,
+      ),
+    );
+    const jobs = await ctx.db
+      .query("securityScanJobs")
+      .withIndex("by_status_and_updated_at", (q) =>
+        q.eq("status", "failed").gte("updatedAt", args.failedAfter),
+      )
+      .order("asc")
+      .take(limit + 1);
+    const matched = jobs.slice(0, limit);
+    const bySource: Partial<Record<SecurityScanJobSource, number>> = {};
+    const byTargetKind: Partial<Record<Doc<"securityScanJobs">["targetKind"], number>> = {};
+
+    for (const job of matched) {
+      bySource[job.source] = (bySource[job.source] ?? 0) + 1;
+      byTargetKind[job.targetKind] = (byTargetKind[job.targetKind] ?? 0) + 1;
+      if (args.dryRun) continue;
+
+      const now = Date.now();
+      await ctx.db.patch(job._id, {
+        status: "queued",
+        attempts: 0,
+        lastError: undefined,
+        runId: undefined,
+        completedAt: undefined,
+        leaseToken: undefined,
+        leaseExpiresAt: undefined,
+        workerId: undefined,
+        nextRunAt: now,
+        updatedAt: now,
+      });
+      if (job.targetKind === "skillScanRequest" && job.skillScanRequestId) {
+        await ctx.db.patch(job.skillScanRequestId, {
+          status: "queued",
+          lastError: undefined,
+          completedAt: undefined,
+          updatedAt: now,
+        });
+      }
+    }
+
+    if (!args.dryRun && matched.length > 0) await requestSecurityScanDispatch(ctx);
+    return {
+      dryRun: args.dryRun,
+      matched: matched.length,
+      requeued: args.dryRun ? 0 : matched.length,
+      hasMore: jobs.length > limit,
+      bySource,
+      byTargetKind,
+      sampleJobIds: matched.slice(0, FAILED_SCAN_RECOVERY_SAMPLE_LIMIT).map((job) => job._id),
+    };
   },
 });
 

--- a/convex/securityScan.ts
+++ b/convex/securityScan.ts
@@ -2477,10 +2477,14 @@ export const requeueExpiredCodexScanJobsInternal = internalMutation({
 export const requeueFailedSecurityScanJobsInternal = internalMutation({
   args: {
     failedAfter: v.number(),
+    failedBefore: v.number(),
     dryRun: v.boolean(),
     limit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
+    if (args.failedBefore <= args.failedAfter) {
+      throw new ConvexError("failedBefore must be greater than failedAfter");
+    }
     const limit = Math.max(
       1,
       Math.min(
@@ -2491,7 +2495,10 @@ export const requeueFailedSecurityScanJobsInternal = internalMutation({
     const jobs = await ctx.db
       .query("securityScanJobs")
       .withIndex("by_status_and_updated_at", (q) =>
-        q.eq("status", "failed").gte("updatedAt", args.failedAfter),
+        q
+          .eq("status", "failed")
+          .gte("updatedAt", args.failedAfter)
+          .lt("updatedAt", args.failedBefore),
       )
       .order("asc")
       .take(limit + 1);
@@ -2518,12 +2525,33 @@ export const requeueFailedSecurityScanJobsInternal = internalMutation({
         updatedAt: now,
       });
       if (job.targetKind === "skillScanRequest" && job.skillScanRequestId) {
+        const request = await ctx.db.get(job.skillScanRequestId);
         await ctx.db.patch(job.skillScanRequestId, {
           status: "queued",
           lastError: undefined,
           completedAt: undefined,
           updatedAt: now,
         });
+        if (request?.githubSkillScanId) {
+          const scan = await ctx.db.get(request.githubSkillScanId);
+          if (scan) {
+            await ctx.db.patch(scan._id, {
+              status: "pending",
+              skillSpectorAnalysis: undefined,
+              llmAnalysis: undefined,
+              lastError: undefined,
+              runId: undefined,
+              completedAt: undefined,
+              updatedAt: now,
+            });
+            await applyGitHubSkillVerificationResultHandler(ctx, {
+              skillId: scan.skillId,
+              contentHash: scan.contentHash,
+              scanStatus: "pending",
+              now,
+            });
+          }
+        }
       }
     }
 

--- a/scripts/security/run-codex-scan-worker-clawscan.test.ts
+++ b/scripts/security/run-codex-scan-worker-clawscan.test.ts
@@ -362,7 +362,11 @@ JSON`,
       const artifactJson = clawScanArtifactJson({ verdict });
       await writeFakeClawScanCommand(
         fakeClawScan,
-        `printf '%s\n' "$@" > ${JSON.stringify(argsLog)}
+        `if [[ -n "\${VIRUSTOTAL_API_KEY:-}" ]]; then
+  echo "VirusTotal key leaked into ClawScan" >&2
+  exit 86
+fi
+printf '%s\n' "$@" > ${JSON.stringify(argsLog)}
 out=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -386,7 +390,9 @@ JSON`,
       );
 
       const previousCommand = process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND;
+      const previousVirusTotalKey = process.env.VIRUSTOTAL_API_KEY;
       process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND = fakeClawScan;
+      process.env.VIRUSTOTAL_API_KEY = "vt-fixture-that-must-not-reach-clawscan";
       try {
         const client = {
           action: vi.fn(async (..._args: unknown[]) => ({})),
@@ -438,6 +444,8 @@ JSON`,
       } finally {
         if (previousCommand === undefined) delete process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND;
         else process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND = previousCommand;
+        if (previousVirusTotalKey === undefined) delete process.env.VIRUSTOTAL_API_KEY;
+        else process.env.VIRUSTOTAL_API_KEY = previousVirusTotalKey;
       }
     },
   );

--- a/scripts/security/run-codex-scan-worker-clawscan.test.ts
+++ b/scripts/security/run-codex-scan-worker-clawscan.test.ts
@@ -36,6 +36,12 @@ function skillVersionJob(jobId: string): ClaimedJob {
   return {
     job: baseJob,
     target: {
+      version: {
+        vtAnalysis: {
+          status: "completed",
+          source: "cached-skill-version",
+        },
+      },
       files: [
         {
           path: "SKILL.md",
@@ -53,6 +59,7 @@ function claimedJob(input: {
   source: string;
   target: ClaimedJob["target"];
   targetKind: ClaimedJob["job"]["targetKind"];
+  vtAnalysis?: unknown;
 }): ClaimedJob {
   const leaseField = `lease${"Token"}`;
   const job = {
@@ -65,7 +72,12 @@ function claimedJob(input: {
   } as ClaimedJob["job"];
   return {
     job,
-    target: input.target,
+    target: {
+      ...input.target,
+      ...(input.targetKind === "packageRelease"
+        ? { release: { vtAnalysis: input.vtAnalysis ?? null } }
+        : { version: { vtAnalysis: input.vtAnalysis ?? null } }),
+    },
   };
 }
 
@@ -346,6 +358,7 @@ JSON`,
       const workspace = await tempDir();
       const fakeClawScan = join(workspace, "fake-clawscan");
       const argsLog = join(workspace, "clawscan-args.log");
+      const virusTotalLog = join(workspace, "virustotal-input.json");
       const artifactJson = clawScanArtifactJson({ verdict });
       await writeFakeClawScanCommand(
         fakeClawScan,
@@ -353,6 +366,10 @@ JSON`,
 out=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --scanner-result)
+      cp "\${2#virustotal=}" ${JSON.stringify(virusTotalLog)}
+      shift 2
+      ;;
     --output)
       out="$2"
       shift 2
@@ -409,7 +426,15 @@ JSON`,
         expect(invocationArgs).toContain("--profile");
         expect(invocationArgs).toContain("clawhub");
         expect(invocationArgs).not.toContain("--context");
-        expect(invocationArgs).not.toContain("--scanner-result");
+        expect(invocationArgs).toContain("--scanner-result");
+        const invocationLines = invocationArgs.trim().split("\n");
+        const scannerResultIndex = invocationLines.indexOf("--scanner-result");
+        const scannerResult = invocationLines[scannerResultIndex + 1];
+        expect(scannerResult).toMatch(/^virustotal=/);
+        expect(JSON.parse(await readFile(virusTotalLog, "utf8"))).toEqual({
+          status: "completed",
+          source: "cached-skill-version",
+        });
       } finally {
         if (previousCommand === undefined) delete process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND;
         else process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND = previousCommand;
@@ -473,6 +498,7 @@ JSON`,
       const fakeClawScan = join(workspace, "fake-clawscan");
       const argsLog = join(workspace, "clawscan-args.log");
       const filesLog = join(workspace, "clawscan-files.log");
+      const virusTotalLog = join(workspace, "virustotal-input.json");
       await writeFakeClawScanCommand(
         fakeClawScan,
         `target="$1"
@@ -481,6 +507,10 @@ find "$target" -type f -print | sort > ${JSON.stringify(filesLog)}
 out=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --scanner-result)
+      cp "\${2#virustotal=}" ${JSON.stringify(virusTotalLog)}
+      shift 2
+      ;;
     --output)
       out="$2"
       shift 2
@@ -511,6 +541,10 @@ JSON`,
               source,
               target: await target(),
               targetKind,
+              vtAnalysis: {
+                status: "completed",
+                source: `${targetKind}-${source}`,
+              },
             }),
             undefined,
             "clawscan",
@@ -540,7 +574,14 @@ JSON`,
           expect.arrayContaining(["--profile", "clawhub", "--output"]),
         );
         expect(invocationArgs).not.toContain("--context");
-        expect(invocationArgs).not.toContain("--scanner-result");
+        const scannerResultIndex = invocationArgs.indexOf("--scanner-result");
+        expect(scannerResultIndex).toBeGreaterThan(-1);
+        const scannerResult = invocationArgs[scannerResultIndex + 1];
+        expect(scannerResult).toMatch(/^virustotal=/);
+        expect(JSON.parse(await readFile(virusTotalLog, "utf8"))).toEqual({
+          status: "completed",
+          source: `${targetKind}-${source}`,
+        });
         expect((await readFile(filesLog, "utf8")).trim().split("\n")).toContain(expectedFile);
       } finally {
         if (previousCommand === undefined) delete process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND;
@@ -548,6 +589,72 @@ JSON`,
       }
     },
   );
+
+  it("passes a completed null VirusTotal fixture when cached telemetry is unavailable", async () => {
+    const workspace = await tempDir();
+    const fakeClawScan = join(workspace, "fake-clawscan");
+    const argsLog = join(workspace, "clawscan-args.log");
+    const virusTotalLog = join(workspace, "virustotal-input.json");
+    await writeFakeClawScanCommand(
+      fakeClawScan,
+      `printf '%s\n' "$@" > ${JSON.stringify(argsLog)}
+out=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --scanner-result)
+      cp "\${2#virustotal=}" ${JSON.stringify(virusTotalLog)}
+      shift 2
+      ;;
+    --output)
+      out="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+mkdir -p "$(dirname "$out")"
+cat > "$out" <<'JSON'
+${clawScanArtifactJson()}
+JSON`,
+    );
+
+    const previousCommand = process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND;
+    process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND = fakeClawScan;
+    try {
+      const client = {
+        action: vi.fn(async (..._args: unknown[]) => ({})),
+      };
+      const result = await withFakeLegacySecondary(async () =>
+        processJob(
+          client,
+          "worker-auth",
+          claimedJob({
+            jobId: "securityScanJobs:no-cached-vt",
+            source: "manual",
+            target: fileTarget("SKILL.md", "# Uploaded skill\n"),
+            targetKind: "skillScanRequest",
+          }),
+          undefined,
+          "clawscan",
+        ),
+      );
+
+      expect(result).toEqual({
+        completed: true,
+        hardFailed: false,
+        retryableFailed: false,
+      });
+      const invocationArgs = (await readFile(argsLog, "utf8")).trim().split("\n");
+      const scannerResult = invocationArgs[invocationArgs.indexOf("--scanner-result") + 1];
+      expect(scannerResult).toMatch(/^virustotal=/);
+      expect(JSON.parse(await readFile(virusTotalLog, "utf8"))).toBeNull();
+    } finally {
+      if (previousCommand === undefined) delete process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND;
+      else process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND = previousCommand;
+    }
+  });
 
   it.each([
     {

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -1236,12 +1236,14 @@ class CommandFailure extends Error {
 async function runCommand(
   command: string,
   args: string[],
-  options: { cwd: string; input?: string; timeoutMs: number },
+  options: { cwd: string; input?: string; omitEnv?: string[]; timeoutMs: number },
 ) {
   return await new Promise<{ stdout: string; stderr: string }>((resolvePromise, reject) => {
+    const env = codexEnv();
+    for (const name of options.omitEnv ?? []) delete env[name];
     const child = spawn(command, args, {
       cwd: options.cwd,
-      env: codexEnv(),
+      env,
       stdio: ["pipe", "pipe", "pipe"],
     });
     let stdout = "";
@@ -1829,6 +1831,7 @@ export async function runClawScan(
   try {
     const output = await runCommand(command, args, {
       cwd: workspace,
+      omitEnv: ["VIRUSTOTAL_API_KEY"],
       timeoutMs: clawScanTimeoutMs(),
     });
     onDiagnostic({

--- a/scripts/security/run-codex-scan-worker.ts
+++ b/scripts/security/run-codex-scan-worker.ts
@@ -1186,6 +1186,14 @@ ${skillSpector}
 Return the required JSON object only.`;
 }
 
+function cachedVirusTotalAnalysis(job: ClaimedJob) {
+  return (
+    (job.target.version as Record<string, unknown> | undefined)?.vtAnalysis ??
+    (job.target.release as Record<string, unknown> | undefined)?.vtAnalysis ??
+    null
+  );
+}
+
 function codexEnv() {
   const env = { ...process.env };
   const codexHome = resolveCodexWorkerHome(process.env, LOCAL_CODEX_HOME);
@@ -1785,8 +1793,22 @@ export async function runClawScan(
 ) {
   const command = process.env.CODEX_SECURITY_SCAN_CLAWSCAN_COMMAND ?? "clawscan";
   const artifactPath = join(workspace, "clawscan-artifact.json");
+  const virusTotalResultPath = join(workspace, "clawscan-virustotal.json");
+  await writeFile(
+    virusTotalResultPath,
+    `${JSON.stringify(cachedVirusTotalAnalysis(job), null, 2)}\n`,
+    "utf8",
+  );
   const target = await resolveClawScanTarget(workspace, job);
-  const args = [target, "--profile", "clawhub", "--output", artifactPath];
+  const args = [
+    target,
+    "--profile",
+    "clawhub",
+    "--scanner-result",
+    `virustotal=${virusTotalResultPath}`,
+    "--output",
+    artifactPath,
+  ];
   onDiagnostic({ args: [command, ...args], artifactPath });
 
   const captureArtifact = async () => {

--- a/scripts/security/security-scan-worker-workflow.test.ts
+++ b/scripts/security/security-scan-worker-workflow.test.ts
@@ -123,7 +123,7 @@ describe("security-scan-codex workflow", () => {
       "Run Codex security worker",
     ]);
     expectSecretStepAllowlist(steps, "SECURITY_SCAN_WORKER_TOKEN", ["Run Codex security worker"]);
-    expectSecretStepAllowlist(steps, "VT_API_KEY", ["Run Codex security worker"]);
+    expectSecretStepAllowlist(steps, "VT_API_KEY", []);
     expect(scanStep?.env ?? {}).not.toHaveProperty("CODEX_API_KEY");
     expect(scanStep?.env ?? {}).not.toHaveProperty("OPENAI_API_KEY");
     expect(scanStep?.env ?? {}).not.toHaveProperty("SECURITY_SCAN_WORKER_TOKEN");
@@ -143,7 +143,6 @@ describe("security-scan-codex workflow", () => {
       CODEX_API_KEY: "${{ secrets.CODEX_API_KEY || secrets.OPENAI_API_KEY }}",
       OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}",
       SECURITY_SCAN_WORKER_TOKEN: "${{ secrets.SECURITY_SCAN_WORKER_TOKEN }}",
-      VIRUSTOTAL_API_KEY: "${{ secrets.VT_API_KEY }}",
     });
   });
 });

--- a/specs/security-moderation.md
+++ b/specs/security-moderation.md
@@ -276,6 +276,10 @@ See also: [acceptable-usage.md](./acceptable-usage.md) for the marketplace polic
   workspace with static and VT signals as context.
 - Current skill and plugin scans are queued through `securityScanJobs` and
   completed by the external Codex worker.
+- ClawHub owns the single live VirusTotal scan for a published artifact. The
+  worker passes the stored full `vtAnalysis` JSON into OSS ClawScan as the
+  `virustotal` scanner result; it must not give ClawScan a VT credential or
+  trigger a second live VT request.
 - The worker's explicit artifact-only OSS ClawScan route accepts every claimed
   target kind and source through the same completion/failure contract. Skill
   versions and scan requests use the isolated `artifact` root; extracted


### PR DESCRIPTION
## Summary

- reuse the canonical ClawHub VirusTotal analysis as ClawScan scanner evidence instead of making a second live VirusTotal request
- remove the VirusTotal credential from the worker workflow and explicitly strip it from the ClawScan child process
- add a bounded, dry-run-capable recovery mutation for incident-window failed scan jobs
- restore failed GitHub-backed scans and moderation state to pending while they retry

## Validation

- `bunx vitest run scripts/security/run-codex-scan-worker-clawscan.test.ts scripts/security/security-scan-worker-workflow.test.ts convex/securityScan.test.ts` (101 passed)
- `bun run ci:static`
- `bun run ci:unit` (4,730 passed; 1 skipped)
- `bun run ci:types-build`
- `bunx tsc --noEmit`

## Review

Initial structured review found three issues: GitHub-backed scans remained hidden during recovery, the ClawScan subprocess could inherit `VIRUSTOTAL_API_KEY`, and the recovery query lacked a fixed end bound. All three were fixed and covered by regression tests. Two post-fix structured review attempts were interrupted by the local Codex model stream after retries; they produced no additional findings.

Linear: CLAW-546
