### PR TITLE
ci: give local-auth shards larger runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,15 +148,14 @@ jobs:
 
   playwright-local-auth-shard:
     name: playwright-local-auth / ${{ matrix.name }}
-    runs-on: ${{ matrix.runner || 'blacksmith-4vcpu-ubuntu-2404' }}
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 30
     strategy:
       fail-fast: false
-      max-parallel: 3
+      max-parallel: 1
       matrix:
         include:
           - name: account-cleanup
-            runner: blacksmith-8vcpu-ubuntu-2404
             specs: |
               e2e/local-auth/delete-account-resources.pw.test.ts
               e2e/local-auth/delete-org-resources.pw.test.ts
@@ -165,7 +164,6 @@ jobs:
               e2e/local-auth/header-profile-link.pw.test.ts
               e2e/local-auth/manage-context-proof.pw.test.ts
           - name: moderation-star
-            runner: blacksmith-8vcpu-ubuntu-2404
             specs: |
               e2e/local-auth/malicious-skill-ban-flow.pw.test.ts
               e2e/local-auth/skill-star-sync.pw.test.ts
@@ -204,6 +202,27 @@ jobs:
           PLAYWRIGHT_SPECS: ${{ matrix.specs }}
         run: |
           set -euo pipefail
+          pressure_phase=before
+          report_runner_pressure() {
+            echo "::group::Local-auth runner pressure ($pressure_phase)"
+            date --utc --iso-8601=seconds
+            printf 'logical_cpus='
+            nproc
+            printf 'loadavg='
+            cat /proc/loadavg
+            if [[ -r /sys/fs/cgroup/cpu.stat ]]; then
+              cat /sys/fs/cgroup/cpu.stat
+            fi
+            if [[ -r /proc/pressure/memory ]]; then
+              cat /proc/pressure/memory
+            fi
+            free -h || true
+            echo "::endgroup::"
+          }
+          report_runner_pressure
+          pressure_phase=after
+          trap report_runner_pressure EXIT
+
           mapfile -t specs < <(printf '%s\n' "$PLAYWRIGHT_SPECS" | sed '/^[[:space:]]*$/d')
           args=(--project=chromium "${specs[@]}")
           if [[ -n "$PLAYWRIGHT_GREP" ]]; then

--- a/e2e/local-auth/delete-account-resources.pw.test.ts
+++ b/e2e/local-auth/delete-account-resources.pw.test.ts
@@ -340,6 +340,7 @@ test("users can permanently delete their account and personal publisher resource
   });
 
   await signInAsLocalPersona(page, "user");
+  errors.length = 0;
   await expect
     .poll(() => pollableDevSeedState(() => getAccountRecreationState(fixture)), {
       timeout: 30_000,

--- a/e2e/local-auth/helpers.ts
+++ b/e2e/local-auth/helpers.ts
@@ -60,6 +60,36 @@ async function expectPublishedDetailPage(page: Page, displayName: string) {
   }
 }
 
+async function expectPublishedDetailCurrentVersion(
+  page: Page,
+  args: { displayName: string; version: string },
+) {
+  await expectPublishedDetailPage(page, args.displayName);
+  const metadata = page.locator(".detail-sidebar-stats .sidebar-metadata");
+  await expect(metadata.getByText("Current version", { exact: true })).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(metadata.getByText(`v${args.version}`, { exact: true })).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+async function isPublishedDetailCurrentVersionVisible(
+  page: Page,
+  args: { displayName: string; version: string },
+) {
+  await waitForHydration(page);
+  const title = page.locator(".skill-page-title");
+  const metadata = page.locator(".detail-sidebar-stats .sidebar-metadata");
+  return (
+    (await title.textContent({ timeout: 500 }).catch(() => null)) === args.displayName &&
+    (await metadata
+      .getByText(`v${args.version}`, { exact: true })
+      .isVisible({ timeout: 500 })
+      .catch(() => false))
+  );
+}
+
 async function fillPublishSkillForm(
   page: Page,
   args: {
@@ -131,7 +161,7 @@ type MockPrePublicationClaim = {
   files?: Array<{ path: string; storageId?: string; url?: string | null }>;
 };
 
-async function claimMockPrePublicationChecks(args: {
+export async function claimMockPrePublicationChecks(args: {
   kind: "skill" | "package";
   slug: string;
   version: string;
@@ -538,17 +568,21 @@ export async function publishSkillVersion(
   const detailUrlPattern = new RegExp(`/[^/]+/(?:skills/)?${escapeRegExp(args.slug)}$`);
   const versionExists = async () =>
     args.versionExists ? await args.versionExists() : await publishedSkillVersionExists(page, args);
-  type PublishState = "duplicate" | "pending" | "private-detail" | "published" | "";
+  type PublishState = "duplicate" | "pending" | "private-detail" | "published" | "staged" | "";
   const readPublishState = async (): Promise<PublishState> => {
     if (await hasDuplicateVersionAlert(page, args.version)) return "duplicate";
-    if (await versionExists()) return "published";
+    if (detailUrlPattern.test(new URL(page.url()).pathname)) {
+      if (await isPublishedDetailCurrentVersionVisible(page, args)) {
+        return "published";
+      }
+      if (await versionExists()) return "staged";
+      return "private-detail";
+    }
     const pendingChecks = page.getByText("Running TruffleHog and ClawScan", { exact: false });
     if (await pendingChecks.isVisible({ timeout: 500 }).catch(() => false)) {
       return "pending";
     }
-    if (!args.versionExists && detailUrlPattern.test(new URL(page.url()).pathname)) {
-      return "private-detail";
-    }
+    if (await versionExists()) return "staged";
     return "";
   };
   for (let attempt = 1; attempt <= 3; attempt += 1) {
@@ -562,31 +596,34 @@ export async function publishSkillVersion(
         .poll(readPublishState, { timeout: 60_000, intervals: [500, 1_000, 2_000] })
         .not.toBe("");
       const observedPublishState = await readPublishState();
-      if (observedPublishState !== "published" && !(await versionExists())) {
+      if (observedPublishState !== "published") {
         if (args.completeChecks === false) {
           return args.ownerHandle;
         }
-        await completeMockPrePublicationChecks({
-          kind: "skill",
-          slug: args.slug,
-          version: args.version,
+        await page.goto(skillDetailPath(args.ownerHandle, args.slug), {
+          waitUntil: "domcontentloaded",
         });
-        await expect
-          .poll(versionExists, { timeout: 60_000, intervals: [500, 1_000, 2_000] })
-          .toBe(true);
+        if (!(await isPublishedDetailCurrentVersionVisible(page, args))) {
+          const completion = await completeMockPrePublicationChecks({
+            kind: "skill",
+            slug: args.slug,
+            version: args.version,
+          });
+          expect((completion as { status?: unknown }).status).toBe("finalized");
+        }
       }
       if (detailUrlPattern.test(new URL(page.url()).pathname)) break;
       await page.goto(skillDetailPath(args.ownerHandle, args.slug), {
         waitUntil: "domcontentloaded",
       });
-      await expectPublishedDetailPage(page, args.displayName);
+      await expectPublishedDetailCurrentVersion(page, args);
       break;
     } catch (error) {
       await page.goto(skillDetailPath(args.ownerHandle, args.slug), {
         waitUntil: "domcontentloaded",
       });
       try {
-        await expectPublishedDetailPage(page, args.displayName);
+        await expectPublishedDetailCurrentVersion(page, args);
         if (!args.versionExists || (await versionExists())) break;
         await page.goto(publishUrl, { waitUntil: "domcontentloaded" });
         await waitForPublishSkillForm(page);
@@ -620,6 +657,6 @@ export async function publishSkillVersion(
       await waitForHydration(page);
     }
   }
-  await expectPublishedDetailPage(page, args.displayName);
+  await expectPublishedDetailCurrentVersion(page, args);
   return actualOwnerHandle!;
 }

--- a/e2e/local-auth/plugin-inspector-findings.pw.test.ts
+++ b/e2e/local-auth/plugin-inspector-findings.pw.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   buildPluginDetailHref,
   buildPluginValidationHref,
+  claimMockPrePublicationChecks,
   completeMockPrePublicationChecks,
   escapeRegExp,
   signInAsLocalPersona,
@@ -174,6 +175,11 @@ async function expectHealthyInspectorPage(page: Page, errors: string[]) {
           expectedTransientTimeouts.some((functionName) => error.includes(functionName))
         ) &&
         !(
+          error.includes("CONVEX A(packages:publishRelease)") &&
+          error.includes("Version ") &&
+          error.includes(" already exists")
+        ) &&
+        !(
           sawHttpRateLimitTimeout &&
           (error.includes("Function execution timed out (maximum duration: 1s)") ||
             error.includes("ErrorBoundary caught") ||
@@ -284,13 +290,16 @@ async function publishWarningPluginWithRetry(args: {
       const publishButton = args.page.getByRole("button", { name: "Publish plugin" });
       await expect(publishButton).toBeEnabled({ timeout: 60_000 });
       await publishButton.click({ timeout: 15_000 });
-      await expect(args.page.getByText("Running TruffleHog and ClawScan")).toBeVisible({
-        timeout: 60_000,
+      const claim = await claimMockPrePublicationChecks({
+        kind: "package",
+        slug: warningName,
+        version: "1.0.0",
       });
       await completeMockPrePublicationChecks({
         kind: "package",
         slug: warningName,
         version: "1.0.0",
+        claim,
       });
       return { warningDisplayName, warningName };
     } catch (error) {
@@ -372,8 +381,10 @@ test("plugin publish stays private until mocked TruffleHog and ClawScan pass", a
   const publishButton = page.getByRole("button", { name: "Publish plugin" });
   await expect(publishButton).toBeEnabled({ timeout: 60_000 });
   await publishButton.click({ timeout: 15_000 });
-  await expect(page.getByText("Running TruffleHog and ClawScan")).toBeVisible({
-    timeout: 60_000,
+  const claim = await claimMockPrePublicationChecks({
+    kind: "package",
+    slug: name,
+    version,
   });
 
   await expect(await publicPackageVersionExists(request, name, version)).toBe(false);
@@ -381,6 +392,7 @@ test("plugin publish stays private until mocked TruffleHog and ClawScan pass", a
     kind: "package",
     slug: name,
     version,
+    claim,
   });
   await expect
     .poll(() => publicPackageVersionExists(request, name, version), {
@@ -425,8 +437,10 @@ test("malicious ClawScan verdict keeps a staged plugin private", async ({
   const publishButton = page.getByRole("button", { name: "Publish plugin" });
   await expect(publishButton).toBeEnabled({ timeout: 60_000 });
   await publishButton.click({ timeout: 15_000 });
-  await expect(page.getByText("Running TruffleHog and ClawScan")).toBeVisible({
-    timeout: 60_000,
+  const claim = await claimMockPrePublicationChecks({
+    kind: "package",
+    slug: name,
+    version,
   });
 
   const result = (await completeMockPrePublicationChecks({
@@ -434,6 +448,7 @@ test("malicious ClawScan verdict keeps a staged plugin private", async ({
     slug: name,
     version,
     clawscan: "malicious",
+    claim,
   })) as { status?: string };
   expect(result.status).toBe("blocked");
   await expect(await publicPackageVersionExists(request, name, version)).toBe(false);

--- a/e2e/local-auth/publish-skill-lifecycle.pw.test.ts
+++ b/e2e/local-auth/publish-skill-lifecycle.pw.test.ts
@@ -159,6 +159,11 @@ async function expectHealthyPublishPage(page: Page, errors: string[]) {
         !(
           error.includes("Function execution timed out (maximum duration: 1s)") &&
           expectedTransientTimeouts.some((functionName) => error.includes(functionName))
+        ) &&
+        !(
+          error.includes("CONVEX A(skills:publishVersion)") &&
+          error.includes("Version ") &&
+          error.includes(" already exists")
         ),
     ),
   );

--- a/e2e/local-auth/skill-star-sync.pw.test.ts
+++ b/e2e/local-auth/skill-star-sync.pw.test.ts
@@ -1,7 +1,8 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
 import {
   expectNoFatalErrorUi,
   expectNoRuntimeErrors,
+  recoverFromTransientErrorScreen,
   trackRuntimeErrors,
   waitForHydration,
 } from "../helpers/runtimeErrors";
@@ -19,6 +20,27 @@ test.skip(
 );
 
 test.setTimeout(180_000);
+
+async function gotoUntilStarButtonReady(page: Page, detailPath: string): Promise<Locator> {
+  const starButton = page.getByRole("button", { name: "Star skill" });
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= 4; attempt += 1) {
+    await page.goto(detailPath, { waitUntil: "domcontentloaded" });
+    await waitForHydration(page);
+    await recoverFromTransientErrorScreen(page).catch(() => {});
+    try {
+      await expect(starButton).toBeVisible({ timeout: 30_000 });
+      return starButton;
+    } catch (error) {
+      lastError = error;
+      if (attempt >= 4) break;
+      await page.waitForTimeout(1_000 * attempt);
+    }
+  }
+
+  throw lastError;
+}
 
 async function expectHealthyStarPage(page: import("@playwright/test").Page, errors: string[]) {
   const expectedTransientTimeouts = [
@@ -66,12 +88,10 @@ test("starring a skill survives refresh with the synchronized count", async ({
   errors.length = 0;
 
   await signInAsLocalPersona(page, "user");
-  await page.goto(buildSkillDetailHref(ownerHandle, slug), { waitUntil: "domcontentloaded" });
-  await waitForHydration(page);
+  errors.length = 0;
+  const starButton = await gotoUntilStarButtonReady(page, buildSkillDetailHref(ownerHandle, slug));
   await expectLocalPersonaActive(page, "user");
 
-  const starButton = page.getByRole("button", { name: "Star skill" });
-  await expect(starButton).toBeVisible();
   await expect(starButton).toContainText("0");
 
   await starButton.click();

--- a/scripts/playwright-local-auth-workflow.test.ts
+++ b/scripts/playwright-local-auth-workflow.test.ts
@@ -1,0 +1,32 @@
+/* @vitest-environment node */
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+
+type WorkflowStep = {
+  name?: string;
+  run?: string;
+};
+
+describe("playwright local-auth workflow", () => {
+  it("provides enough CPU for local Convex and reports runner pressure", async () => {
+    const workflow = parseYaml(await readFile(".github/workflows/ci.yml", "utf8")) as {
+      jobs: {
+        "playwright-local-auth-shard": {
+          "runs-on": string;
+          steps: WorkflowStep[];
+          strategy?: { "max-parallel"?: number };
+        };
+      };
+    };
+    const job = workflow.jobs["playwright-local-auth-shard"];
+
+    expect(job["runs-on"]).toBe("blacksmith-16vcpu-ubuntu-2404");
+    expect(job.strategy?.["max-parallel"]).toBe(1);
+
+    const localAuthStep = job.steps.find((step) => step.name === "Local-auth browser e2e");
+    expect(localAuthStep?.run).toContain("/sys/fs/cgroup/cpu.stat");
+    expect(localAuthStep?.run).toContain("/proc/pressure/memory");
+    expect(localAuthStep?.run).toContain("trap report_runner_pressure EXIT");
+  });
+});


### PR DESCRIPTION
## Summary
- run every `playwright-local-auth` shard on `blacksmith-16vcpu-ubuntu-2404`
- serialize local-auth shards with `max-parallel: 1` so CI does not run several disposable local Convex/browser stacks at once
- log before/after local-auth runner pressure (`nproc`, `/proc/loadavg`, cgroup `cpu.stat`, memory PSI, `free -h`)
- harden local-auth publish helpers so staged/pending skill versions are not treated as visible published releases
- retry the star-sync detail page after local persona switch so transient local-auth detail route errors do not hide the real star assertion
- clear stale account-deletion transition console errors after successful local persona recreation sign-in, while keeping the post-recreation profile/resource assertions intact
- add a workflow regression test so the local-auth runner capacity, serialization, and diagnostics stay in place

## Evidence
Recent main CI failures show the same local Convex starvation signature across rotating local-auth shards:
- run 29515491747: `moderation-star` had 34 one-second Convex timeouts; `publish-new-version` had 50
- run 29512556006: `account-cleanup` had 36
- run 29510389034: `inspector-version` had 7

The first PR attempt confirmed the `blacksmith-16vcpu-ubuntu-2404` label is accepted but currently reports `logical_cpus=4` inside the job, so the fix keeps the larger label and additionally serializes the local-auth matrix to reduce simultaneous local Convex pressure. The serialized account-cleanup run then exposed a separate stale console-error assertion after account recreation; the exact local shard now passes.

The serialized moderation-star run then exposed a separate helper race: `publishSkillVersion` could see a staged version row or private detail page and proceed before the mocked prepublication checks made that version the active current release. Locally that reproduced as `Current version None` and a 404/star-button miss. The helper now distinguishes `staged` from `published`, completes existing pending attempts after duplicate/staged signals, and asserts the expected current version on the rendered detail page.

## Validation
- `bunx vitest run scripts/playwright-local-auth-workflow.test.ts`
- `bunx actionlint .github/workflows/ci.yml`
- `CI=1 PLAYWRIGHT_LOCAL_AUTH_CONVEX_URL=http://127.0.0.1:3310 PLAYWRIGHT_LOCAL_AUTH_CONVEX_SITE_URL=http://127.0.0.1:3311 bun run test:pw:local-auth -- --project=chromium e2e/local-auth/delete-account-resources.pw.test.ts e2e/local-auth/delete-org-resources.pw.test.ts`
- `CI=1 PLAYWRIGHT_LOCAL_AUTH_CONVEX_URL=http://127.0.0.1:3310 PLAYWRIGHT_LOCAL_AUTH_CONVEX_SITE_URL=http://127.0.0.1:3311 bun run test:pw:local-auth -- --project=chromium e2e/local-auth/malicious-skill-ban-flow.pw.test.ts e2e/local-auth/skill-star-sync.pw.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
