### PR TITLE
Make promotional banner dismissible

### DIFF
--- a/src/components/PromotionsBar.test.tsx
+++ b/src/components/PromotionsBar.test.tsx
@@ -1,5 +1,5 @@
 /* @vitest-environment jsdom */
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PromotionsBar } from "./PromotionsBar";
 
@@ -44,10 +44,12 @@ describe("PromotionsBar", () => {
     publicApiUrlMock.mockReset();
     publicApiUrlMock.mockReturnValue(new URL("https://clawhub.test/api/v1/promotions"));
     vi.stubGlobal("fetch", fetchMock);
+    window.localStorage.clear();
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -110,5 +112,83 @@ describe("PromotionsBar", () => {
     expect(screen.getByText("Tencent's latest model, free until July 21")).toBeTruthy();
     expect(screen.queryByText(/days left/)).toBeNull();
     expect(container.querySelector('img[src="/tencent-hy-favicon.png"]')).toBeTruthy();
+  });
+
+  it("keeps a dismissed promotion hidden for the same campaign window", async () => {
+    const activePromotion = { ...promotion, endsAt: 200_000 };
+    fetchMock.mockResolvedValue(promotionsResponse([activePromotion]));
+
+    const { unmount } = render(<PromotionsBar />);
+    await flushPromises();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: `Dismiss ${activePromotion.title} promotion`,
+      }),
+    );
+
+    expect(screen.queryByText(activePromotion.title)).toBeNull();
+    expect(
+      window.localStorage.getItem(
+        `clawhub.promotion.dismissed.${activePromotion.slug}.${activePromotion.endsAt}`,
+      ),
+    ).toBe("1");
+
+    unmount();
+    render(<PromotionsBar />);
+    await flushPromises();
+
+    expect(screen.queryByText(activePromotion.title)).toBeNull();
+  });
+
+  it("shows a later campaign window after an earlier one was dismissed", async () => {
+    const earlierPromotion = { ...promotion, endsAt: 200_000 };
+    window.localStorage.setItem(
+      `clawhub.promotion.dismissed.${earlierPromotion.slug}.${earlierPromotion.endsAt}`,
+      "1",
+    );
+    fetchMock.mockResolvedValue(promotionsResponse([{ ...earlierPromotion, endsAt: 300_000 }]));
+
+    render(<PromotionsBar />);
+    await flushPromises();
+
+    expect(screen.getByText(earlierPromotion.title)).toBeTruthy();
+  });
+
+  it("renders promotions when storage reads are unavailable", async () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new DOMException("Storage blocked", "SecurityError");
+    });
+    fetchMock.mockResolvedValue(promotionsResponse([{ ...promotion, endsAt: 200_000 }]));
+
+    render(<PromotionsBar />);
+    await flushPromises();
+
+    expect(screen.getByText(promotion.title)).toBeTruthy();
+  });
+
+  it("dismisses the current promotion when storage writes are unavailable", async () => {
+    const activePromotion = { ...promotion, endsAt: 200_000 };
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("Storage full", "QuotaExceededError");
+    });
+    fetchMock.mockResolvedValue(promotionsResponse([activePromotion]));
+
+    render(<PromotionsBar />);
+    await flushPromises();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: `Dismiss ${activePromotion.title} promotion`,
+      }),
+    );
+
+    expect(screen.queryByText(activePromotion.title)).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(screen.queryByText(activePromotion.title)).toBeNull();
   });
 });

--- a/src/components/PromotionsBar.tsx
+++ b/src/components/PromotionsBar.tsx
@@ -75,43 +75,43 @@ function PromotionBarItem({
 
   return (
     <article className="promotion-bar-item">
-      <div className="promotion-bar-copy">
-        <h3 className="promotion-bar-title">
-          {isTencentPromotion ? (
-            <img
-              src="/tencent-hy-favicon.png"
-              alt=""
-              aria-hidden="true"
-              className="promotion-bar-icon"
-            />
-          ) : (
-            <Gift
-              size={14}
-              aria-hidden="true"
-              className="promotion-bar-icon promotion-bar-icon-fallback"
-            />
-          )}
-          <span className="promotion-bar-title-copy">{promotion.title}</span>
-        </h3>
-        <span className="promotion-bar-separator" aria-hidden="true" />
-        <span className="promotion-bar-meta">{promotionMetaCopy(promotion)}</span>
-      </div>
-      <div className="promotion-bar-actions">
+      <div className="promotion-bar-content">
+        <div className="promotion-bar-copy">
+          <h3 className="promotion-bar-title">
+            {isTencentPromotion ? (
+              <img
+                src="/tencent-hy-favicon.png"
+                alt=""
+                aria-hidden="true"
+                className="promotion-bar-icon"
+              />
+            ) : (
+              <Gift
+                size={14}
+                aria-hidden="true"
+                className="promotion-bar-icon promotion-bar-icon-fallback"
+              />
+            )}
+            <span className="promotion-bar-title-copy">{promotion.title}</span>
+          </h3>
+          <span className="promotion-bar-separator" aria-hidden="true" />
+          <span className="promotion-bar-meta">{promotionMetaCopy(promotion)}</span>
+        </div>
         {ctaUrl ? (
           <a className="promotion-bar-link" href={ctaUrl} target="_blank" rel="noopener noreferrer">
             Try it free <ArrowUpRight size={15} aria-hidden="true" />
           </a>
         ) : null}
-        <button
-          type="button"
-          className="promotion-bar-dismiss"
-          aria-label={`Dismiss ${promotion.title} promotion`}
-          title="Dismiss promotion"
-          onClick={() => onDismiss(promotion)}
-        >
-          <X size={14} aria-hidden="true" />
-        </button>
       </div>
+      <button
+        type="button"
+        className="promotion-bar-dismiss"
+        aria-label={`Dismiss ${promotion.title} promotion`}
+        title="Dismiss promotion"
+        onClick={() => onDismiss(promotion)}
+      >
+        <X size={14} aria-hidden="true" />
+      </button>
     </article>
   );
 }

--- a/src/components/PromotionsBar.tsx
+++ b/src/components/PromotionsBar.tsx
@@ -1,6 +1,6 @@
 import { ApiRoutes } from "clawhub-schema/routes";
-import { ArrowUpRight, Gift } from "lucide-react";
-import { useEffect, useState } from "react";
+import { ArrowUpRight, Gift, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { publicApiUrl } from "../lib/publicApiUrl";
 
 type PublicPromotion = {
@@ -14,6 +14,22 @@ type PublicPromotion = {
 };
 
 const PROMOTIONS_POLL_INTERVAL_MS = 60_000;
+const PROMOTION_DISMISSED_KEY_PREFIX = "clawhub.promotion.dismissed";
+
+function promotionDismissedKey(promotion: PublicPromotion) {
+  return `${PROMOTION_DISMISSED_KEY_PREFIX}.${promotion.slug}.${promotion.endsAt}`;
+}
+
+function isPromotionDismissed(promotion: PublicPromotion, dismissedKeys: ReadonlySet<string>) {
+  const key = promotionDismissedKey(promotion);
+  if (dismissedKeys.has(key)) return true;
+
+  try {
+    return window.localStorage.getItem(key) === "1";
+  } catch {
+    return false;
+  }
+}
 
 function nextPromotionsRefreshDelay(promotions: PublicPromotion[], now: number) {
   return promotions.reduce(
@@ -47,7 +63,13 @@ function promotionMetaCopy(promotion: PublicPromotion) {
   return promotion.blurb;
 }
 
-function PromotionBarItem({ promotion }: { promotion: PublicPromotion }) {
+function PromotionBarItem({
+  promotion,
+  onDismiss,
+}: {
+  promotion: PublicPromotion;
+  onDismiss: (promotion: PublicPromotion) => void;
+}) {
   const ctaUrl = promotionCtaUrl(promotion);
   const isTencentPromotion = isTencentHyPromotion(promotion.title);
 
@@ -74,17 +96,40 @@ function PromotionBarItem({ promotion }: { promotion: PublicPromotion }) {
         <span className="promotion-bar-separator" aria-hidden="true" />
         <span className="promotion-bar-meta">{promotionMetaCopy(promotion)}</span>
       </div>
-      {ctaUrl ? (
-        <a className="promotion-bar-link" href={ctaUrl} target="_blank" rel="noopener noreferrer">
-          Try it free <ArrowUpRight size={15} aria-hidden="true" />
-        </a>
-      ) : null}
+      <div className="promotion-bar-actions">
+        {ctaUrl ? (
+          <a className="promotion-bar-link" href={ctaUrl} target="_blank" rel="noopener noreferrer">
+            Try it free <ArrowUpRight size={15} aria-hidden="true" />
+          </a>
+        ) : null}
+        <button
+          type="button"
+          className="promotion-bar-dismiss"
+          aria-label={`Dismiss ${promotion.title} promotion`}
+          title="Dismiss promotion"
+          onClick={() => onDismiss(promotion)}
+        >
+          <X size={14} aria-hidden="true" />
+        </button>
+      </div>
     </article>
   );
 }
 
 export function PromotionsBar() {
   const [promotions, setPromotions] = useState<PublicPromotion[]>([]);
+  const dismissedKeys = useRef(new Set<string>());
+
+  function dismissPromotion(promotion: PublicPromotion) {
+    const key = promotionDismissedKey(promotion);
+    dismissedKeys.current.add(key);
+    try {
+      window.localStorage.setItem(key, "1");
+    } catch {
+      // Persistence is optional; the current banner should still close.
+    }
+    setPromotions((current) => current.filter((item) => promotionDismissedKey(item) !== key));
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -108,7 +153,9 @@ export function PromotionsBar() {
         if (!response.ok) throw new Error(`Promotions request failed: ${response.status}`);
         const payload = (await response.json()) as { promotions?: PublicPromotion[] };
         if (!Array.isArray(payload.promotions)) throw new Error("Invalid promotions response");
-        const active = payload.promotions;
+        const active = payload.promotions.filter(
+          (promotion) => !isPromotionDismissed(promotion, dismissedKeys.current),
+        );
         if (cancelled) return;
         setPromotions(active);
         scheduleRefresh(active);
@@ -134,7 +181,11 @@ export function PromotionsBar() {
       </h2>
       <div className="promotion-bar-track">
         {promotions.map((promotion) => (
-          <PromotionBarItem key={promotion.slug} promotion={promotion} />
+          <PromotionBarItem
+            key={`${promotion.slug}.${promotion.endsAt}`}
+            promotion={promotion}
+            onDismiss={dismissPromotion}
+          />
         ))}
       </div>
     </section>

--- a/src/styles.css
+++ b/src/styles.css
@@ -25675,6 +25675,13 @@ a.search-empty-action {
   text-overflow: ellipsis;
 }
 
+.promotion-bar-actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 6px;
+}
+
 .promotion-bar-link {
   display: inline-flex;
   align-items: center;
@@ -25702,6 +25709,26 @@ a.search-empty-action {
   height: 12px;
 }
 
+.promotion-bar-dismiss {
+  display: inline-grid;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 auto;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: var(--oc-radius-control);
+  background: transparent;
+  color: var(--ink-soft);
+  cursor: pointer;
+}
+
+.promotion-bar-dismiss:hover,
+.promotion-bar-dismiss:focus-visible {
+  background: color-mix(in srgb, var(--ink) 8%, transparent);
+  color: var(--ink);
+}
+
 @media (max-width: 760px) {
   .promotion-bar-track {
     padding: 0;
@@ -25717,6 +25744,10 @@ a.search-empty-action {
 
   .promotion-bar-copy {
     gap: 0;
+  }
+
+  .promotion-bar-actions {
+    gap: 4px;
   }
 
   .promotion-bar-separator,

--- a/src/styles.css
+++ b/src/styles.css
@@ -25607,13 +25607,13 @@ a.search-empty-action {
 }
 
 .promotion-bar-item {
+  position: relative;
   display: flex;
   flex: 1 0 auto;
   align-items: center;
   justify-content: center;
-  gap: 18px;
   min-width: min(100%, 520px);
-  padding: 6px 0;
+  padding: 6px 32px;
   scroll-snap-align: start;
 }
 
@@ -25675,11 +25675,12 @@ a.search-empty-action {
   text-overflow: ellipsis;
 }
 
-.promotion-bar-actions {
+.promotion-bar-content {
   display: flex;
-  flex: 0 0 auto;
   align-items: center;
-  gap: 6px;
+  justify-content: center;
+  gap: 18px;
+  min-width: 0;
 }
 
 .promotion-bar-link {
@@ -25710,10 +25711,12 @@ a.search-empty-action {
 }
 
 .promotion-bar-dismiss {
+  position: absolute;
+  top: 50%;
+  right: 0;
   display: inline-grid;
   width: 24px;
   height: 24px;
-  flex: 0 0 auto;
   place-items: center;
   padding: 0;
   border: 0;
@@ -25721,6 +25724,7 @@ a.search-empty-action {
   background: transparent;
   color: var(--ink-soft);
   cursor: pointer;
+  transform: translateY(-50%);
 }
 
 .promotion-bar-dismiss:hover,
@@ -25735,19 +25739,23 @@ a.search-empty-action {
   }
 
   .promotion-bar-item {
+    min-width: 100%;
+    padding: 7px 44px 7px 12px;
+    border-left: 0;
+  }
+
+  .promotion-bar-content {
+    width: 100%;
     justify-content: space-between;
     gap: 12px;
-    min-width: 100%;
-    padding: 7px 12px;
-    border-left: 0;
   }
 
   .promotion-bar-copy {
     gap: 0;
   }
 
-  .promotion-bar-actions {
-    gap: 4px;
+  .promotion-bar-dismiss {
+    right: 12px;
   }
 
   .promotion-bar-separator,


### PR DESCRIPTION
## Summary

- add an accessible close control to active promotional banners
- align the dismiss control to the far-right edge on desktop and mobile
- persist dismissal per promotion slug and campaign end time so later campaigns can appear again
- keep dismissed promotions hidden during polling even when localStorage is unavailable

## Validation

- `bun run test -- src/components/PromotionsBar.test.tsx` (7 passed)
- `bun run ci:static`
- `bun run ci:unit` (4,730 passed, 1 skipped; 85.42% coverage)
- `bun run ci:types-build`
- `$autoreview` (clean)
- in-app browser verification at desktop and mobile widths, including right-edge alignment and persistence after reload