### PR TITLE
fix(moderation): restore from current scan verdict

### DIFF
--- a/convex/skills.moderationHold.test.ts
+++ b/convex/skills.moderationHold.test.ts
@@ -107,12 +107,20 @@ describe("skills moderation holds", () => {
     );
   });
 
-  it("restores clean hold-hidden skills but keeps unscanned skills hidden pending scan", async () => {
+  it("restores from current scanner verdicts but keeps unscanned skills pending", async () => {
     vi.spyOn(Date, "now").mockReturnValue(2_000);
     const { ctx, patch } = makeCtx({
       user: { _id: "users:owner", requiresModerationAt: undefined },
       versions: {
         "versions:clean": { _id: "versions:clean", vtAnalysis: { status: "clean" } },
+        "versions:clawscan-clean": {
+          _id: "versions:clawscan-clean",
+          llmAnalysis: { status: "clean" },
+        },
+        "versions:malicious": {
+          _id: "versions:malicious",
+          llmAnalysis: { status: "malicious" },
+        },
         "versions:pending": { _id: "versions:pending" },
       },
       skills: [
@@ -120,6 +128,26 @@ describe("skills moderation holds", () => {
           _id: "skills:clean",
           ownerUserId: "users:owner",
           latestVersionId: "versions:clean",
+          moderationStatus: "hidden",
+          moderationReason: "user.moderation",
+          moderationFlags: undefined,
+          softDeletedAt: undefined,
+          hiddenAt: 1_000,
+        },
+        {
+          _id: "skills:clawscan-clean",
+          ownerUserId: "users:owner",
+          latestVersionId: "versions:clawscan-clean",
+          moderationStatus: "hidden",
+          moderationReason: "user.moderation",
+          moderationFlags: undefined,
+          softDeletedAt: undefined,
+          hiddenAt: 1_000,
+        },
+        {
+          _id: "skills:malicious",
+          ownerUserId: "users:owner",
+          latestVersionId: "versions:malicious",
           moderationStatus: "hidden",
           moderationReason: "user.moderation",
           moderationFlags: undefined,
@@ -144,13 +172,28 @@ describe("skills moderation holds", () => {
       holdPlacedAt: 1_000,
     });
 
-    expect(result.restoredCount).toBe(2);
+    expect(result.restoredCount).toBe(4);
     expect(patch).toHaveBeenCalledWith(
       "skills:clean",
       expect.objectContaining({
         moderationStatus: "active",
-        moderationReason: "restored.moderation_lift",
+        moderationReason: "scanner.vt.clean",
         hiddenAt: undefined,
+      }),
+    );
+    expect(patch).toHaveBeenCalledWith(
+      "skills:clawscan-clean",
+      expect.objectContaining({
+        moderationStatus: "active",
+        moderationReason: "scanner.llm.clean",
+        hiddenAt: undefined,
+      }),
+    );
+    expect(patch).toHaveBeenCalledWith(
+      "skills:malicious",
+      expect.objectContaining({
+        moderationStatus: "hidden",
+        moderationReason: "scanner.llm.malicious",
       }),
     );
     expect(patch).toHaveBeenCalledWith(

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -321,6 +321,18 @@ function normalizeAnalysisStatus(status: string | undefined) {
   return status?.trim().toLowerCase();
 }
 
+function hasCompletedScannerResult(
+  version: Pick<Doc<"skillVersions">, "staticScan" | "vtAnalysis" | "llmAnalysis">,
+) {
+  const completedStatuses = new Set(["clean", "benign", "safe", "suspicious", "malicious"]);
+  return [
+    version.staticScan?.status,
+    version.vtAnalysis?.status,
+    version.llmAnalysis?.status,
+    version.llmAnalysis?.verdict,
+  ].some((status) => completedStatuses.has(normalizeAnalysisStatus(status) ?? ""));
+}
+
 function hasReviewReasonCode(codes: readonly string[] | undefined) {
   return (codes ?? []).some((code) => code.startsWith("review."));
 }
@@ -8974,27 +8986,36 @@ export const restoreOwnedSkillsForModerationLiftBatchInternal = internalMutation
 
       const latestVersion = skill.latestVersionId ? await ctx.db.get(skill.latestVersionId) : null;
 
-      // If the skill was never scanned (or was pending scan when the hold
-      // was placed), re-queue it into the VT pipeline instead of marking it
-      // as restored. The VT queue selector only picks up "pending.scan",
-      // "pending.scan.stale", and "scanner.*" reasons, so
-      // "restored.moderation_lift" would leave these skills permanently
-      // unscanned.
-      const vtStatus = latestVersion?.vtAnalysis?.status;
-      const needsScan = !vtStatus || vtStatus === "pending" || vtStatus === "loading";
-      const nextReason = needsScan ? "pending.scan" : "restored.moderation_lift";
-      const patch: Partial<Doc<"skills">> = {
-        moderationStatus: needsScan ? "hidden" : "active",
-        moderationReason: nextReason,
-        isSuspicious: computeIsSuspicious({
-          moderationFlags: skill.moderationFlags,
-          moderationReason: nextReason,
-        }),
-        hiddenAt: undefined,
-        hiddenBy: undefined,
-        lastReviewedAt: now,
-        updatedAt: now,
-      };
+      // Restore from the current structured scanner result. VirusTotal is no
+      // longer guaranteed to run, so checking only vtAnalysis would leave
+      // clean ClawScan versions hidden as pending forever.
+      const patch: Partial<Doc<"skills">> =
+        latestVersion && hasCompletedScannerResult(latestVersion)
+          ? {
+              ...applySkillManualOverrideToSkillPatch({
+                skill,
+                basePatch: buildScannerModerationPatchFromVersion({
+                  owner: user,
+                  version: latestVersion,
+                  now,
+                }),
+                now,
+                stripUpdatedAt: true,
+              }),
+              updatedAt: now,
+            }
+          : {
+              moderationStatus: "hidden",
+              moderationReason: "pending.scan",
+              isSuspicious: computeIsSuspicious({
+                moderationFlags: skill.moderationFlags,
+                moderationReason: "pending.scan",
+              }),
+              hiddenAt: undefined,
+              hiddenBy: undefined,
+              lastReviewedAt: now,
+              updatedAt: now,
+            };
       const nextSkill = { ...skill, ...patch };
       await ctx.db.patch(skill._id, patch);
       await adjustGlobalPublicCountForSkillChange(ctx, skill, nextSkill);


### PR DESCRIPTION
## Summary
- restore moderation-held skills from the latest structured scanner verdict
- stop treating missing legacy VirusTotal data as an unscanned version
- keep malicious results hidden and truly unscanned versions pending

Follow-up to #3128 and #3008.

## Validation
- `bun run ci:static`
- `bun run ci:unit`
- `bunx tsc --noEmit`
- `bunx vitest run convex/skills.moderationHold.test.ts`
- autoreview: clean
