### PR TITLE
fix: prevent prepublication scan starvation

### DIFF
--- a/.github/workflows/prepublication-publish-checks.yml
+++ b/.github/workflows/prepublication-publish-checks.yml
@@ -15,6 +15,18 @@ on:
         description: "Stop claiming new attempts after this many minutes"
         required: true
         default: "8"
+      kind:
+        description: "Optional targeted recovery kind: skill or package"
+        required: false
+        default: ""
+      slug:
+        description: "Optional targeted recovery slug"
+        required: false
+        default: ""
+      version:
+        description: "Optional targeted recovery version"
+        required: false
+        default: ""
       runner:
         description: "Runner label for manual recovery dispatches"
         required: true
@@ -49,6 +61,9 @@ jobs:
       PREPUBLICATION_CHECK_LIMIT: ${{ inputs['batch-limit'] || '2' }}
       PREPUBLICATION_CHECK_MAX_JOBS: ${{ inputs['max-jobs'] || '' }}
       PREPUBLICATION_CHECK_MAX_RUNTIME_MINUTES: ${{ inputs['max-runtime-minutes'] || '8' }}
+      PREPUBLICATION_CHECK_KIND: ${{ inputs.kind || '' }}
+      PREPUBLICATION_CHECK_SLUG: ${{ inputs.slug || '' }}
+      PREPUBLICATION_CHECK_VERSION: ${{ inputs.version || '' }}
       PREPUBLICATION_CLAWSCAN_TIMEOUT_MS: ${{ vars.PREPUBLICATION_CLAWSCAN_TIMEOUT_MS || '240000' }}
       PREPUBLICATION_TRUFFLEHOG_IMAGE: ${{ vars.PREPUBLICATION_TRUFFLEHOG_IMAGE || 'ghcr.io/trufflesecurity/trufflehog:3.95.6@sha256:96f8429082cb2d4ae73b1096dcdb2f5aa139881d97042b0c5e5fa226a392e056' }}
       PREPUBLICATION_WORKER_ID: "github-actions:${{ github.run_id }}:${{ github.run_attempt }}:${{ matrix.shard }}"
@@ -60,7 +75,7 @@ jobs:
       - name: Install ClawScan CLI
         run: |
           set -euo pipefail
-          npm install -g @openclaw/clawscan@0.1.2
+          npm install -g @openclaw/clawscan@0.1.4
           clawscan --version
 
       - name: Run pre-publication publish worker
@@ -72,4 +87,7 @@ jobs:
           bun run publish:prepublication-worker -- \
             --batch-limit "$PREPUBLICATION_CHECK_LIMIT" \
             --max-jobs "$PREPUBLICATION_CHECK_MAX_JOBS" \
-            --max-runtime-minutes "$PREPUBLICATION_CHECK_MAX_RUNTIME_MINUTES"
+            --max-runtime-minutes "$PREPUBLICATION_CHECK_MAX_RUNTIME_MINUTES" \
+            --kind "$PREPUBLICATION_CHECK_KIND" \
+            --slug "$PREPUBLICATION_CHECK_SLUG" \
+            --version "$PREPUBLICATION_CHECK_VERSION"

--- a/convex/publishAttempts.test.ts
+++ b/convex/publishAttempts.test.ts
@@ -104,6 +104,67 @@ describe("publishAttempts", () => {
     expect(patch.checkClaimExpiresAt - patch.checkClaimedAt).toBeGreaterThanOrEqual(30 * 60 * 1000);
   });
 
+  it("claims fresh staged publishes before older scanner retries", async () => {
+    const now = Date.now();
+    const freshAttempt = {
+      _id: "publishAttempts:fresh",
+      kind: "skill",
+      status: "pending_checks",
+      userId: "users:publisher",
+      slug: "fresh-skill",
+      displayName: "Fresh Skill",
+      version: "1.0.0",
+      artifactFingerprint: "fresh-fingerprint",
+      files: [{ path: "SKILL.md", storageId: "_storage:fresh", size: 10, sha256: "fresh-sha" }],
+      skillInsertArgs: {
+        staticScan: { status: "clean" },
+      },
+      createdAt: now,
+    };
+    const retryAttempt = {
+      ...freshAttempt,
+      _id: "publishAttempts:retry",
+      slug: "retry-skill",
+      artifactFingerprint: "retry-fingerprint",
+      checkClaimExpiresAt: now - 1,
+      checkClaimLastError: "ClawScan judge status was failed",
+      createdAt: now - 60_000,
+    };
+    const ctx = {
+      db: {
+        delete: vi.fn(),
+        get: vi.fn(),
+        insert: vi.fn(),
+        normalizeId: vi.fn(),
+        patch: vi.fn(),
+        query: vi.fn(() => ({
+          withIndex: vi.fn((indexName: string) => ({
+            order: vi.fn(() => ({
+              take: vi.fn(async () =>
+                indexName === "by_status_check_claim_expires_at_created"
+                  ? [freshAttempt, retryAttempt]
+                  : [retryAttempt, freshAttempt],
+              ),
+            })),
+          })),
+        })),
+        replace: vi.fn(),
+        system: {},
+      },
+    };
+
+    await expect(
+      claimPendingChecksHandler(ctx, { claimId: "checks:claim" }),
+    ).resolves.toMatchObject({
+      attemptId: "publishAttempts:fresh",
+      slug: "fresh-skill",
+    });
+    expect(ctx.db.patch).toHaveBeenCalledWith(
+      "publishAttempts:fresh",
+      expect.objectContaining({ checkClaimId: "checks:claim" }),
+    );
+  });
+
   it("hydrates staged package attempts with ClawPack URL and review context", async () => {
     const previousToken = process.env.SECURITY_SCAN_WORKER_TOKEN;
     process.env.SECURITY_SCAN_WORKER_TOKEN = "worker-token";

--- a/convex/publishAttempts.ts
+++ b/convex/publishAttempts.ts
@@ -667,7 +667,9 @@ export const claimPendingPublishAttemptChecksInternal = internalMutation({
       : (
           await ctx.db
             .query("publishAttempts")
-            .withIndex("by_status_and_created", (q) => q.eq("status", "pending_checks"))
+            .withIndex("by_status_check_claim_expires_at_created", (q) =>
+              q.eq("status", "pending_checks"),
+            )
             .order("asc")
             .take(25)
         ).find((candidate) => {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1175,6 +1175,7 @@ const publishAttempts = defineTable({
 })
   .index("by_idempotency_key", ["idempotencyKey"])
   .index("by_status_and_created", ["status", "createdAt"])
+  .index("by_status_check_claim_expires_at_created", ["status", "checkClaimExpiresAt", "createdAt"])
   .index("by_expires_at", ["expiresAt"])
   .index("by_kind_status_slug_version_created", ["kind", "status", "slug", "version", "createdAt"])
   .index("by_user_status_created", ["userId", "status", "createdAt"])

--- a/scripts/security/prepublication-worker-workflow.test.ts
+++ b/scripts/security/prepublication-worker-workflow.test.ts
@@ -39,10 +39,22 @@ describe("pre-publication publish worker workflow", () => {
         schedule?: Array<{ cron?: string }>;
         workflow_dispatch?: {
           inputs?: {
+            kind?: {
+              default?: string;
+              required?: boolean;
+            };
             runner?: {
               default?: string;
               options?: string[];
               type?: string;
+            };
+            slug?: {
+              default?: string;
+              required?: boolean;
+            };
+            version?: {
+              default?: string;
+              required?: boolean;
             };
           };
         };
@@ -60,6 +72,18 @@ describe("pre-publication publish worker workflow", () => {
       type: "choice",
       options: ["blacksmith-8vcpu-ubuntu-2404", "ubuntu-latest"],
     });
+    expect(workflow.on?.workflow_dispatch?.inputs?.kind).toMatchObject({
+      required: false,
+      default: "",
+    });
+    expect(workflow.on?.workflow_dispatch?.inputs?.slug).toMatchObject({
+      required: false,
+      default: "",
+    });
+    expect(workflow.on?.workflow_dispatch?.inputs?.version).toMatchObject({
+      required: false,
+      default: "",
+    });
     expect(job.environment).toBe("Production");
     expect(job["runs-on"]).toBe("${{ inputs.runner || 'blacksmith-8vcpu-ubuntu-2404' }}");
     expect(job["timeout-minutes"]).toBe(20);
@@ -71,6 +95,9 @@ describe("pre-publication publish worker workflow", () => {
       PREPUBLICATION_CLAWSCAN_TIMEOUT_MS:
         "${{ vars.PREPUBLICATION_CLAWSCAN_TIMEOUT_MS || '240000' }}",
       PREPUBLICATION_CHECK_LIMIT: "${{ inputs['batch-limit'] || '2' }}",
+      PREPUBLICATION_CHECK_KIND: "${{ inputs.kind || '' }}",
+      PREPUBLICATION_CHECK_SLUG: "${{ inputs.slug || '' }}",
+      PREPUBLICATION_CHECK_VERSION: "${{ inputs.version || '' }}",
       PREPUBLICATION_TRUFFLEHOG_IMAGE:
         "${{ vars.PREPUBLICATION_TRUFFLEHOG_IMAGE || 'ghcr.io/trufflesecurity/trufflehog:3.95.6@sha256:96f8429082cb2d4ae73b1096dcdb2f5aa139881d97042b0c5e5fa226a392e056' }}",
     });
@@ -81,8 +108,11 @@ describe("pre-publication publish worker workflow", () => {
 
     const runStep = steps.find((step) => step.name === "Run pre-publication publish worker");
     expect(runStep?.run).toContain("bun run publish:prepublication-worker");
+    expect(runStep?.run).toContain('--kind "$PREPUBLICATION_CHECK_KIND"');
+    expect(runStep?.run).toContain('--slug "$PREPUBLICATION_CHECK_SLUG"');
+    expect(runStep?.run).toContain('--version "$PREPUBLICATION_CHECK_VERSION"');
     expect(steps.find((step) => step.name === "Install ClawScan CLI")?.run).toContain(
-      "npm install -g @openclaw/clawscan@0.1.2",
+      "npm install -g @openclaw/clawscan@0.1.4",
     );
     expect(steps.find((step) => step.name === "Install Codex CLI")).toBeUndefined();
     expect(steps.find((step) => step.name === "Authenticate Codex CLI")).toBeUndefined();

--- a/scripts/security/run-prepublication-worker.test.ts
+++ b/scripts/security/run-prepublication-worker.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Id } from "../../convex/_generated/dataModel";
 import {
   claimBatchDrainedQueue,
+  claimPrePublicationAttempt,
   claimPrePublicationBatch,
   processPrePublicationBatch,
   processPrePublicationAttempt,
@@ -49,6 +50,27 @@ const attempt = {
 };
 
 describe("pre-publication worker", () => {
+  it("forwards targeted recovery filters when claiming an attempt", async () => {
+    const client = {
+      action: vi.fn().mockResolvedValue(attempt),
+    };
+
+    await expect(
+      claimPrePublicationAttempt(client, "fixture", {
+        kind: "skill",
+        slug: "driver",
+        version: "0.8.3",
+      }),
+    ).resolves.toEqual(attempt);
+
+    expect(client.action).toHaveBeenCalledWith(expect.anything(), {
+      token: "fixture",
+      kind: "skill",
+      slug: "driver",
+      version: "0.8.3",
+    });
+  });
+
   it("keeps claiming after partial transient claim failures", () => {
     expect(claimBatchDrainedQueue(0, 0, 6)).toBe(true);
     expect(claimBatchDrainedQueue(0, 5, 6)).toBe(true);

--- a/scripts/security/run-prepublication-worker.ts
+++ b/scripts/security/run-prepublication-worker.ts
@@ -59,6 +59,13 @@ type ProcessAttemptResult = {
 
 type PrePublicationWorkerClient = Pick<ConvexHttpClient, "action">;
 
+type PrePublicationClaimFilters = {
+  attemptId?: Id<"publishAttempts">;
+  kind?: "skill" | "package";
+  slug?: string;
+  version?: string;
+};
+
 type TruffleHogResult = WorkerCheckResult & {
   exitCode?: number | null;
 };
@@ -98,6 +105,11 @@ function parseArgs() {
     const parsed = Number(value);
     return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
   };
+  const optionalStringFrom = (value: string | undefined) => value?.trim() || undefined;
+  const kind = optionalStringFrom(get("--kind") ?? process.env.PREPUBLICATION_CHECK_KIND);
+  if (kind && kind !== "skill" && kind !== "package") {
+    throw new Error("--kind must be skill or package");
+  }
   return {
     batchLimit: numberFrom(
       get("--batch-limit") ?? process.env.PREPUBLICATION_CHECK_LIMIT,
@@ -109,6 +121,14 @@ function parseArgs() {
         get("--max-runtime-minutes") ?? process.env.PREPUBLICATION_CHECK_MAX_RUNTIME_MINUTES,
         DEFAULT_MAX_RUNTIME_MS / 60_000,
       ) * 60_000,
+    claimFilters: {
+      attemptId: optionalStringFrom(
+        get("--attempt-id") ?? process.env.PREPUBLICATION_CHECK_ATTEMPT_ID,
+      ) as Id<"publishAttempts"> | undefined,
+      kind: kind as "skill" | "package" | undefined,
+      slug: optionalStringFrom(get("--slug") ?? process.env.PREPUBLICATION_CHECK_SLUG),
+      version: optionalStringFrom(get("--version") ?? process.env.PREPUBLICATION_CHECK_VERSION),
+    } satisfies PrePublicationClaimFilters,
   };
 }
 
@@ -728,9 +748,11 @@ export async function processPrePublicationBatch(
 export async function claimPrePublicationAttempt(
   client: PrePublicationWorkerClient,
   token: string,
+  filters: PrePublicationClaimFilters = {},
 ) {
   return (await client.action(api.publishAttempts.claimPrePublicationChecks, {
     token,
+    ...filters,
   })) as ClaimedPrePublicationAttempt | null;
 }
 
@@ -738,9 +760,10 @@ export async function claimPrePublicationBatch(
   client: PrePublicationWorkerClient,
   token: string,
   limit: number,
+  filters: PrePublicationClaimFilters = {},
 ) {
   const claims = await Promise.allSettled(
-    Array.from({ length: limit }, () => claimPrePublicationAttempt(client, token)),
+    Array.from({ length: limit }, () => claimPrePublicationAttempt(client, token, filters)),
   );
   const attempts: ClaimedPrePublicationAttempt[] = [];
   const failures: unknown[] = [];
@@ -770,7 +793,7 @@ export function claimBatchDrainedQueue(
 }
 
 async function main() {
-  const { batchLimit, maxJobs, maxRuntimeMs } = parseArgs();
+  const { batchLimit, claimFilters, maxJobs, maxRuntimeMs } = parseArgs();
   maskKnownWorkerSecrets();
   const convexUrl = process.env.CONVEX_URL ?? process.env.VITE_CONVEX_URL;
   if (!convexUrl) throw new Error("CONVEX_URL or VITE_CONVEX_URL is required");
@@ -795,8 +818,14 @@ async function main() {
     if (totalClaimed > 0 && claimDeadline - Date.now() < CLAIM_WINDOW_SHUTDOWN_BUFFER_MS) break;
     const remainingJobs = maxJobs === undefined ? batchLimit : Math.max(0, maxJobs - totalClaimed);
     if (remainingJobs === 0) break;
-    const claimLimit = Math.min(batchLimit, remainingJobs);
-    const { attempts, claimFailures } = await claimPrePublicationBatch(client, token, claimLimit);
+    const targeted = Object.values(claimFilters).some(Boolean);
+    const claimLimit = Math.min(targeted ? 1 : batchLimit, remainingJobs);
+    const { attempts, claimFailures } = await claimPrePublicationBatch(
+      client,
+      token,
+      claimLimit,
+      claimFilters,
+    );
     if (attempts.length === 0) break;
     totalClaimed += attempts.length;
     const results = await processPrePublicationBatch(attempts, (attempt) =>


### PR DESCRIPTION
## Summary

- prioritize newly staged publish attempts over scanner retries by indexing the next eligible claim time
- update the pre-publication worker to the production ClawScan 0.1.4 package
- add targeted workflow recovery inputs for kind, slug, and version

## Validation

- `bun test convex/publishAttempts.test.ts scripts/security/run-prepublication-worker.test.ts scripts/security/prepublication-worker-workflow.test.ts`
- `bun run ci:static`
- `bun run ci:unit` (4,713 passed, 1 skipped)
- `bun run ci:types-build`
- autoreview clean on an equivalent fixture-sanitized branch diff
