### PR TITLE
fix: install prepublication judge runtime

### DIFF
--- a/.github/workflows/prepublication-publish-checks.yml
+++ b/.github/workflows/prepublication-publish-checks.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        shard: [0, 1]
+        shard: ${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs['attempt-id'] != '' && '[0]' || '[0,1]') }}
     env:
       CONVEX_URL: ${{ vars.CONVEX_URL || vars.VITE_CONVEX_URL || 'https://wry-manatee-359.convex.cloud' }}
       PREPUBLICATION_CHECK_LIMIT: ${{ inputs['batch-limit'] || '2' }}
@@ -76,6 +76,12 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: ./.github/actions/setup-bun
+
+      - name: Install Codex CLI
+        run: |
+          set -euo pipefail
+          npm install -g @openai/codex@0.142.3
+          codex --version
 
       - name: Install ClawScan CLI
         run: |

--- a/scripts/security/prepublication-worker-workflow.test.ts
+++ b/scripts/security/prepublication-worker-workflow.test.ts
@@ -95,7 +95,9 @@ describe("pre-publication publish worker workflow", () => {
     expect(job.environment).toBe("Production");
     expect(job["runs-on"]).toBe("${{ inputs.runner || 'blacksmith-8vcpu-ubuntu-2404' }}");
     expect(job["timeout-minutes"]).toBe(20);
-    expect(job.strategy?.matrix?.shard).toEqual([0, 1]);
+    expect(job.strategy?.matrix?.shard).toBe(
+      "${{ fromJSON(github.event_name == 'workflow_dispatch' && inputs['attempt-id'] != '' && '[0]' || '[0,1]') }}",
+    );
     expect(job.strategy?.["max-parallel"]).toBe(2);
     expect(job.env).toMatchObject({
       CONVEX_URL:
@@ -124,7 +126,9 @@ describe("pre-publication publish worker workflow", () => {
     expect(steps.find((step) => step.name === "Install ClawScan CLI")?.run).toContain(
       "npm install -g @openclaw/clawscan@0.1.4",
     );
-    expect(steps.find((step) => step.name === "Install Codex CLI")).toBeUndefined();
+    expect(steps.find((step) => step.name === "Install Codex CLI")?.run).toContain(
+      "npm install -g @openai/codex@0.142.3",
+    );
     expect(steps.find((step) => step.name === "Authenticate Codex CLI")).toBeUndefined();
     expect(steps.find((step) => step.name === "Install SkillSpector")).toBeUndefined();
     expect(JSON.stringify(job)).not.toContain("CODEX_SECURITY_SCAN_SHADOW_CLAWSCAN");


### PR DESCRIPTION
## Summary
- install the pinned Codex CLI required by the built-in `clawhub` judge profile
- run exact-attempt recovery on one shard to avoid duplicate claim races

## Production proof
The targeted `driver@0.8.3` recovery claimed the exact attempt, then recorded `ClawScan judge status was failed`. The canonical security worker installs `@openai/codex@0.142.3`; the pre-publication worker did not install any Codex CLI.

## Validation
- `bun test scripts/security/prepublication-worker-workflow.test.ts`
- `bun run ci:static`
