### PR TITLE
fix: reuse exact prepublication scan verdicts

### DIFF
--- a/convex/publishAttempts.test.ts
+++ b/convex/publishAttempts.test.ts
@@ -165,6 +165,61 @@ describe("publishAttempts", () => {
     );
   });
 
+  it("reuses a completed ClawScan verdict only for the exact staged artifact", async () => {
+    const attempt = {
+      _id: "publishAttempts:reusable",
+      kind: "skill",
+      status: "pending_checks",
+      userId: "users:publisher",
+      skillVersionId: "skillVersions:reusable",
+      slug: "reusable-skill",
+      displayName: "Reusable Skill",
+      version: "1.0.0",
+      artifactFingerprint: "exact-fingerprint",
+      files: [{ path: "SKILL.md", storageId: "_storage:skill", size: 10, sha256: "sha" }],
+      skillInsertArgs: {
+        staticScan: { status: "clean" },
+      },
+      createdAt: Date.now(),
+    };
+    const analysis = {
+      checkedAt: Date.now(),
+      confidence: "high",
+      status: "suspicious",
+      summary: "Completed exact-artifact review.",
+      verdict: "suspicious",
+    };
+    const ctx = {
+      db: {
+        delete: vi.fn(),
+        get: vi.fn(async (id: string) =>
+          id === "skillVersions:reusable"
+            ? { fingerprint: "exact-fingerprint", llmAnalysis: analysis }
+            : null,
+        ),
+        insert: vi.fn(),
+        normalizeId: vi.fn(),
+        patch: vi.fn(),
+        query: vi.fn(() => ({
+          withIndex: vi.fn(() => ({
+            order: vi.fn(() => ({
+              take: vi.fn(async () => [attempt]),
+            })),
+          })),
+        })),
+        replace: vi.fn(),
+        system: {},
+      },
+    };
+
+    await expect(
+      claimPendingChecksHandler(ctx, { claimId: "checks:claim" }),
+    ).resolves.toMatchObject({
+      attemptId: "publishAttempts:reusable",
+      existingClawscanAnalysis: analysis,
+    });
+  });
+
   it("hydrates staged package attempts with ClawPack URL and review context", async () => {
     const previousToken = process.env.SECURITY_SCAN_WORKER_TOKEN;
     process.env.SECURITY_SCAN_WORKER_TOKEN = "worker-token";

--- a/convex/publishAttempts.ts
+++ b/convex/publishAttempts.ts
@@ -83,6 +83,16 @@ function withClawscanAnalysis(insertArgs: unknown, clawscanAnalysis: unknown) {
   };
 }
 
+function reusableClawscanAnalysis(value: unknown) {
+  const analysis = asRecord(value);
+  const status = typeof analysis.status === "string" ? analysis.status.trim().toLowerCase() : "";
+  const verdict = typeof analysis.verdict === "string" ? analysis.verdict.trim().toLowerCase() : "";
+  const completed = new Set(["benign", "clean", "suspicious", "malicious"]);
+  if (typeof analysis.checkedAt !== "number") return undefined;
+  if (!completed.has(status) && !completed.has(verdict)) return undefined;
+  return value;
+}
+
 function scannerFailureSummary(args: {
   trufflehog: { status: string; summary?: string };
   clawscan: { status: string; summary?: string };
@@ -706,6 +716,19 @@ export const claimPendingPublishAttemptChecksInternal = internalMutation({
       updatedAt: now,
     });
 
+    let existingClawscanAnalysis: unknown;
+    if (attempt.kind === "skill" && attempt.skillVersionId) {
+      const version = await ctx.db.get(attempt.skillVersionId);
+      if (version?.fingerprint === attempt.artifactFingerprint) {
+        existingClawscanAnalysis = reusableClawscanAnalysis(version.llmAnalysis);
+      }
+    } else if (attempt.kind === "package" && attempt.packageReleaseId) {
+      const release = await ctx.db.get(attempt.packageReleaseId);
+      if (release?.integritySha256 === attempt.artifactFingerprint) {
+        existingClawscanAnalysis = reusableClawscanAnalysis(release.llmAnalysis);
+      }
+    }
+
     return {
       attemptId: attempt._id,
       status: attempt.status,
@@ -732,6 +755,7 @@ export const claimPendingPublishAttemptChecksInternal = internalMutation({
             clawpackStorageId: publishAttemptClawpackStorageId(attempt),
             scanContext: buildPackageAttemptScanContext(attempt),
           }),
+      ...(existingClawscanAnalysis ? { existingClawscanAnalysis } : {}),
       checkClaimExpiresAt,
       createdAt: attempt.createdAt,
     };

--- a/scripts/security/run-prepublication-worker.test.ts
+++ b/scripts/security/run-prepublication-worker.test.ts
@@ -132,6 +132,48 @@ describe("pre-publication worker", () => {
     expect(client.action.mock.calls[0]?.[1].trufflehog).not.toHaveProperty("exitCode");
   });
 
+  it("reuses a completed ClawScan verdict from the exact staged artifact", async () => {
+    const client = {
+      action: vi.fn().mockResolvedValue({ status: "finalized" }),
+    };
+    const runTruffleHog = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      status: "clean",
+      summary: "TruffleHog found no verified secrets.",
+    });
+    const runClawScan = vi.fn();
+    const existingClawscanAnalysis = {
+      checkedAt: 123,
+      confidence: "high",
+      status: "suspicious",
+      summary: "Exact-artifact ClawScan review.",
+      verdict: "suspicious",
+    };
+
+    await expect(
+      processPrePublicationAttempt(
+        client,
+        "worker-token",
+        { ...attempt, existingClawscanAnalysis },
+        {
+          runClawScan,
+          runTruffleHog,
+          writeWorkspace: vi.fn().mockResolvedValue(undefined),
+        },
+      ),
+    ).resolves.toMatchObject({ completed: true });
+
+    expect(runTruffleHog).toHaveBeenCalledTimes(1);
+    expect(runClawScan).not.toHaveBeenCalled();
+    expect(client.action).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        clawscan: expect.objectContaining({ status: "clean" }),
+        clawscanAnalysis: existingClawscanAnalysis,
+      }),
+    );
+  });
+
   it("publishes suspicious staged artifacts without treating them as malicious", async () => {
     const client = {
       action: vi.fn().mockResolvedValue({ status: "finalized" }),

--- a/scripts/security/run-prepublication-worker.ts
+++ b/scripts/security/run-prepublication-worker.ts
@@ -42,6 +42,7 @@ type ClaimedPrePublicationAttempt = {
     package?: Record<string, unknown>;
     release?: Record<string, unknown>;
   };
+  existingClawscanAnalysis?: StoredLlmAnalysis;
   checkClaimExpiresAt: number;
   createdAt: number;
 };
@@ -630,15 +631,28 @@ export async function processPrePublicationAttempt(
 
     let clawscan: WorkerCheckResult;
     let clawscanAnalysis: StoredLlmAnalysis | undefined;
-    try {
-      const review = await runClawScan(job, workspace);
-      clawscanAnalysis = review.analysis;
-      clawscan = review.check;
-    } catch (error) {
-      clawscan = {
-        status: "failed",
-        summary: publicText(error instanceof Error ? error.message : String(error)),
-      };
+    if (attempt.existingClawscanAnalysis) {
+      clawscanAnalysis = attempt.existingClawscanAnalysis;
+      clawscan = clawScanCheckResult(clawscanAnalysis);
+      logger.info(
+        {
+          attemptId: attempt.attemptId,
+          event: "prepublication_clawscan_result_reused",
+          kind: attempt.kind,
+        },
+        "pre-publication ClawScan result reused for exact artifact",
+      );
+    } else {
+      try {
+        const review = await runClawScan(job, workspace);
+        clawscanAnalysis = review.analysis;
+        clawscan = review.check;
+      } catch (error) {
+        clawscan = {
+          status: "failed",
+          summary: publicText(error instanceof Error ? error.message : String(error)),
+        };
+      }
     }
 
     completionStarted = true;


### PR DESCRIPTION
## Summary
- reuse a completed canonical ClawScan verdict when the staged skill/package artifact fingerprint is an exact match
- continue running TruffleHog fresh for every staged publish
- fall back to a fresh ClawScan run when no exact terminal verdict exists

## Why
The `driver` staged publish already had a successful canonical ClawScan verdict for the exact artifact, but duplicate prepublication judge runs failed nondeterministically on receipt formatting. Reusing only the exact persisted terminal verdict removes that duplicate failure mode without weakening artifact identity or secret scanning.

## Validation
- `bun test convex/publishAttempts.test.ts scripts/security/run-prepublication-worker.test.ts scripts/security/prepublication-worker-workflow.test.ts`
- `bun run ci:static`
- `bun run ci:unit` (4,715 passed, 1 skipped)
- `bun run ci:types-build`
- `codex review --base origin/main` (clean; no actionable defects)
