### PR TITLE
feat: show browse categories in desktop sidebars

### DIFF
--- a/src/__tests__/packages-route.test.tsx
+++ b/src/__tests__/packages-route.test.tsx
@@ -618,6 +618,18 @@ describe("plugins route", () => {
     expect(fetchPluginCatalogMock).not.toHaveBeenCalled();
   });
 
+  it("renders desktop category navigation and keeps the responsive category dropdown", async () => {
+    const route = await loadRoute();
+    const Component = route.__config.component as ComponentType;
+
+    render(<Component />);
+
+    const categorySidebar = screen.getByLabelText("Plugin categories");
+    expect(categorySidebar.querySelectorAll("button")).toHaveLength(13);
+    expect(categorySidebar.textContent).toContain("Channels");
+    expect(screen.getByRole("combobox", { name: "Category" })).toBeTruthy();
+  });
+
   it("uses recommendation ranking as the plugin browse default", async () => {
     fetchPluginCatalogMock.mockResolvedValue({ items: [], nextCursor: null });
     const { loadPluginsPageData } = await import("../routes/plugins/index");

--- a/src/__tests__/skills-index.test.tsx
+++ b/src/__tests__/skills-index.test.tsx
@@ -118,6 +118,22 @@ describe("SkillsIndex", () => {
     expect(screen.queryByRole("radio", { name: "Most downloaded" })).toBeNull();
   });
 
+  it("renders desktop category navigation and keeps the responsive category dropdown", async () => {
+    render(<SkillsIndex />);
+    await act(async () => {});
+
+    const categorySidebar = screen.getByLabelText("Skill categories");
+    expect(categorySidebar.querySelectorAll("button")).toHaveLength(15);
+    expect(categorySidebar.textContent).toContain("Development");
+    expect(screen.getByRole("combobox", { name: "Category" })).toBeTruthy();
+
+    fireEvent.click(
+      categorySidebar.querySelector('button[aria-pressed="false"]') as HTMLButtonElement,
+    );
+
+    expect(navigateMock).toHaveBeenCalled();
+  });
+
   it("separates primary views from secondary sort options", async () => {
     render(<SkillsIndex />);
     await act(async () => {});

--- a/src/components/BrowseControls.test.tsx
+++ b/src/components/BrowseControls.test.tsx
@@ -1,0 +1,39 @@
+/* @vitest-environment jsdom */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PLUGIN_CATEGORIES } from "../lib/categories";
+import { BrowseCategorySelect, BrowseCategorySidebar, BrowseTopicChips } from "./BrowseControls";
+
+describe("BrowseControls", () => {
+  it("renders chip-shaped placeholders while topics load", () => {
+    const { container } = render(<BrowseTopicChips topics={[]} loading onChange={() => {}} />);
+
+    expect(screen.getByRole("status", { name: "Loading topics" })).toBeTruthy();
+    expect(container.querySelectorAll(".browse-topic-chip-skeleton")).toHaveLength(8);
+  });
+
+  it("keeps the category dropdown responsive and exposes desktop category buttons", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <>
+        <BrowseCategorySelect
+          categories={PLUGIN_CATEGORIES}
+          value="channels"
+          onChange={onChange}
+          responsive
+        />
+        <BrowseCategorySidebar
+          ariaLabel="Plugin categories"
+          categories={PLUGIN_CATEGORIES}
+          value="channels"
+          onChange={onChange}
+        />
+      </>,
+    );
+
+    expect(container.querySelector(".browse-category-select-responsive")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Models" }));
+    expect(onChange).toHaveBeenCalledWith("models");
+  });
+});

--- a/src/components/BrowseControls.tsx
+++ b/src/components/BrowseControls.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 import { BrowseCategoryIcon } from "../lib/browseCategoryIcons";
 import type { BrowseCategory } from "../lib/categories";
+import { Skeleton } from "./ui/skeleton";
 
 type BrowseChoice = {
   value: string | undefined;
@@ -404,9 +405,15 @@ type BrowseCategorySelectProps = {
   categories: readonly BrowseCategory[];
   value: string | undefined;
   onChange: (value: string | undefined) => void;
+  responsive?: boolean;
 };
 
-export function BrowseCategorySelect({ categories, value, onChange }: BrowseCategorySelectProps) {
+export function BrowseCategorySelect({
+  categories,
+  value,
+  onChange,
+  responsive = false,
+}: BrowseCategorySelectProps) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const rootRef = useRef<HTMLDivElement>(null);
@@ -457,7 +464,10 @@ export function BrowseCategorySelect({ categories, value, onChange }: BrowseCate
   };
 
   return (
-    <div className="browse-category-select" ref={rootRef}>
+    <div
+      className={`browse-category-select${responsive ? " browse-category-select-responsive" : ""}`}
+      ref={rootRef}
+    >
       <button
         type="button"
         className="browse-category-trigger"
@@ -563,18 +573,93 @@ export function BrowseCategorySelect({ categories, value, onChange }: BrowseCate
   );
 }
 
+type BrowseCategorySidebarProps = {
+  ariaLabel: string;
+  categories: readonly BrowseCategory[];
+  value: string | undefined;
+  onChange: (value: string | undefined) => void;
+  disabled?: boolean;
+};
+
+export function BrowseCategorySidebar({
+  ariaLabel,
+  categories,
+  value,
+  onChange,
+  disabled = false,
+}: BrowseCategorySidebarProps) {
+  return (
+    <aside className="browse-sidebar browse-category-sidebar" aria-label={ariaLabel}>
+      <fieldset className="sidebar-section">
+        <legend className="sidebar-title">Categories</legend>
+        <button
+          className={`sidebar-option${!value ? " is-active" : ""}`}
+          type="button"
+          aria-pressed={!value}
+          onClick={() => onChange(undefined)}
+          disabled={disabled}
+        >
+          <BrowseCategoryIcon slug={null} size={16} className="sidebar-option-icon" />
+          <span>All categories</span>
+        </button>
+        {categories.map((category) => {
+          const active = category.slug === value;
+          return (
+            <button
+              key={category.slug}
+              className={`sidebar-option${active ? " is-active" : ""}`}
+              type="button"
+              aria-pressed={active}
+              onClick={() => onChange(category.slug)}
+              disabled={disabled}
+            >
+              <BrowseCategoryIcon
+                slug={category.slug}
+                icon={category.icon}
+                size={16}
+                className="sidebar-option-icon"
+              />
+              <span>{category.label}</span>
+            </button>
+          );
+        })}
+      </fieldset>
+    </aside>
+  );
+}
+
 type BrowseTopicChipsProps = {
   topics: readonly string[];
   activeTopic?: string;
   onChange: (topic: string | undefined) => void;
+  loading?: boolean;
 };
 
-export function BrowseTopicChips({ topics, activeTopic, onChange }: BrowseTopicChipsProps) {
+export function BrowseTopicChips({
+  topics,
+  activeTopic,
+  onChange,
+  loading = false,
+}: BrowseTopicChipsProps) {
   const displayTopics = useMemo(() => {
     const safeTopics = Array.isArray(topics) ? topics.filter(Boolean) : [];
     if (!activeTopic || safeTopics.includes(activeTopic)) return safeTopics;
     return [activeTopic, ...safeTopics];
   }, [activeTopic, topics]);
+
+  if (loading && !activeTopic) {
+    return (
+      <div className="browse-topic-chips" role="status" aria-label="Loading topics">
+        {Array.from({ length: 8 }, (_, index) => (
+          <Skeleton
+            // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton placeholder count
+            key={index}
+            className="browse-topic-chip-skeleton"
+          />
+        ))}
+      </div>
+    );
+  }
 
   if (displayTopics.length === 0) return null;
 

--- a/src/components/skeletons/BrowseResultsSkeleton.tsx
+++ b/src/components/skeletons/BrowseResultsSkeleton.tsx
@@ -62,7 +62,7 @@ export function BrowseResultsSkeleton({
             key={i}
             className="skill-list-item skill-list-item-has-creator browse-results-skeleton-row"
           >
-            <Skeleton className="browse-results-skeleton-icon h-9 w-9 shrink-0 rounded-[var(--oc-radius-inset)]" />
+            <Skeleton className="browse-results-skeleton-icon h-[27px] w-[27px] shrink-0 rounded-[var(--oc-radius-inset)]" />
             <div className="skill-list-item-body">
               <div className="skill-list-item-main">
                 <Skeleton className="h-5 w-32 max-w-[45%]" />

--- a/src/routes/plugins/index.tsx
+++ b/src/routes/plugins/index.tsx
@@ -7,6 +7,7 @@ import { api } from "../../../convex/_generated/api";
 import {
   BrowseActions,
   BrowseCategorySelect,
+  BrowseCategorySidebar,
   BrowseControls,
   BrowseControlsRow,
   BrowseSearchInput,
@@ -351,12 +352,20 @@ function PluginsIndexPending() {
               categories={PLUGIN_CATEGORIES}
               value={undefined}
               onChange={() => {}}
+              responsive
             />
             <BrowseViewToggle view="list" onToggle={() => {}} />
           </BrowseActions>
         </BrowseControlsRow>
       </BrowseControls>
-      <div className="browse-layout">
+      <div className="browse-layout browse-layout-with-sidebar">
+        <BrowseCategorySidebar
+          ariaLabel="Plugin categories"
+          categories={PLUGIN_CATEGORIES}
+          value={undefined}
+          onChange={() => {}}
+          disabled
+        />
         <div className="browse-results">
           <div className="browse-results-toolbar">
             <span className="browse-results-count">Loading results</span>
@@ -699,6 +708,7 @@ function PluginsIndex() {
               categories={PLUGIN_CATEGORIES}
               value={activeCategory}
               onChange={handleCategoryChange}
+              responsive
             />
             <BrowseViewToggle view={view} onToggle={handleToggleView} />
           </BrowseActions>
@@ -719,9 +729,16 @@ function PluginsIndex() {
           topics={categoryTopics ?? []}
           activeTopic={activeTopic}
           onChange={handleTopicChange}
+          loading={Boolean(activeCategory && categoryTopics === undefined)}
         />
       </BrowseControls>
-      <div className="browse-layout">
+      <div className="browse-layout browse-layout-with-sidebar">
+        <BrowseCategorySidebar
+          ariaLabel="Plugin categories"
+          categories={PLUGIN_CATEGORIES}
+          value={activeCategory}
+          onChange={handleCategoryChange}
+        />
         <div className="browse-results">
           {isLoading ? (
             <BrowseResultsSkeleton label="Plugin" variant={effectiveView} />

--- a/src/routes/skills/index.tsx
+++ b/src/routes/skills/index.tsx
@@ -5,6 +5,7 @@ import { api } from "../../../convex/_generated/api";
 import {
   BrowseActions,
   BrowseCategorySelect,
+  BrowseCategorySidebar,
   BrowseControls,
   BrowseControlsDivider,
   BrowseControlsRow,
@@ -303,6 +304,7 @@ export function SkillsIndex() {
               categories={SKILL_CATEGORIES}
               value={model.activeCategory}
               onChange={handleCategoryChange}
+              responsive
             />
             <BrowseViewToggle view={model.view} onToggle={model.onToggleView} />
           </BrowseActions>
@@ -322,9 +324,16 @@ export function SkillsIndex() {
           topics={categoryTopics ?? []}
           activeTopic={activeTopic}
           onChange={handleTopicChange}
+          loading={Boolean(model.activeCategory && categoryTopics === undefined)}
         />
       </BrowseControls>
-      <div className="browse-layout">
+      <div className="browse-layout browse-layout-with-sidebar">
+        <BrowseCategorySidebar
+          ariaLabel="Skill categories"
+          categories={SKILL_CATEGORIES}
+          value={model.activeCategory}
+          onChange={handleCategoryChange}
+        />
         <div className="browse-results">
           <SkillsResults
             isLoadingSkills={model.isLoadingSkills}

--- a/src/styles.css
+++ b/src/styles.css
@@ -7862,6 +7862,11 @@ code {
   height: 18px;
 }
 
+.browse-page .skill-list-item .official-badge svg {
+  width: 14px;
+  height: 14px;
+}
+
 .skill-hero-scan-row {
   display: grid;
   gap: 6px;
@@ -16736,7 +16741,7 @@ a.agentic-risk-finding-title:focus-visible {
 }
 
 .browse-list-head-icon-spacer {
-  width: 36px;
+  width: 27px;
 }
 
 .browse-list-head-actions-spacer {
@@ -16833,8 +16838,9 @@ a.agentic-risk-finding-title:focus-visible {
 .browse-page .skill-list-item > .marketplace-icon {
   --marketplace-icon-accent: var(--ink-soft) !important;
   --marketplace-icon-wash: transparent !important;
-  width: 36px;
-  height: 36px;
+  width: 27px;
+  height: 27px;
+  border-radius: 7px;
   border-color: color-mix(in srgb, var(--line) 78%, transparent);
   background: color-mix(in srgb, var(--surface) 72%, transparent);
   color: color-mix(in srgb, var(--ink-soft) 88%, transparent);
@@ -16842,8 +16848,8 @@ a.agentic-risk-finding-title:focus-visible {
 }
 
 .browse-page .skill-list-item > .marketplace-icon .marketplace-icon-glyph {
-  width: 18px;
-  height: 18px;
+  width: 14px;
+  height: 14px;
 }
 
 .skill-list-item-main {
@@ -18639,6 +18645,21 @@ body:has(.browse-page-borderless-header) .navbar {
   display: none;
 }
 
+.browse-topic-chip-skeleton {
+  width: 86px;
+  height: 30px;
+  flex: 0 0 auto;
+  border-radius: var(--r-pill);
+}
+
+.browse-topic-chip-skeleton:nth-child(3n + 1) {
+  width: 104px;
+}
+
+.browse-topic-chip-skeleton:nth-child(3n) {
+  width: 72px;
+}
+
 .browse-topic-chip {
   display: inline-flex;
   align-items: center;
@@ -19133,6 +19154,11 @@ body:has(.browse-page-borderless-header) .navbar {
   align-items: start;
 }
 
+.browse-layout-with-sidebar {
+  grid-template-columns: minmax(168px, 188px) minmax(0, 1fr);
+  gap: 28px;
+}
+
 .browse-sidebar {
   position: sticky;
   top: var(--browse-sticky-top);
@@ -19186,6 +19212,17 @@ body:has(.browse-page-borderless-header) .navbar {
 
 .sidebar-option:hover {
   color: var(--ink);
+}
+
+.sidebar-option:focus-visible {
+  color: var(--ink);
+  outline: 2px solid color-mix(in srgb, var(--ink) 35%, transparent);
+  outline-offset: 2px;
+}
+
+.sidebar-option:disabled {
+  cursor: default;
+  opacity: 0.62;
 }
 
 .sidebar-option.is-active {
@@ -19265,6 +19302,23 @@ body:has(.browse-page-borderless-header) .navbar {
 
 .sidebar-checkbox input[type="checkbox"] {
   accent-color: var(--accent);
+}
+
+@media (min-width: 1081px) {
+  .browse-category-select-responsive {
+    display: none;
+  }
+}
+
+@media (max-width: 1080px) {
+  .browse-layout-with-sidebar {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0;
+  }
+
+  .browse-category-sidebar {
+    display: none;
+  }
 }
 
 .browse-results {


### PR DESCRIPTION
## Summary
- render skill and plugin categories in a persistent left sidebar on desktop
- retain the category dropdown on tablet/mobile layouts
- add topic chip skeleton loaders while category topics resolve
- reduce list-row package icons and verified marks by 25%, including row skeletons

## UI proof
Verified in the Codex app browser against `http://localhost:3001`:
- desktop `1280x720`: category sidebar visible, category dropdown hidden, 8 topic skeletons rendered
- mobile `390x844`: category sidebar hidden, category dropdown visible
- list icon CSS resolves to `27px`; verified icon CSS resolves to `14px`

## Validation
- `bunx vitest run src/components/BrowseControls.test.tsx src/__tests__/skills-index.test.tsx src/__tests__/packages-route.test.tsx src/components/SkillListItem.test.tsx src/components/PluginListItem.test.tsx`
- `bun run ci:unit`
- `bun run ci:static`
- `bun run ci:types-build`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
