### PR TITLE
ci: cut local-auth e2e critical path below five minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 8
       matrix:
         include:
           - name: account-cleanup
@@ -163,10 +163,10 @@ jobs:
             specs: |
               e2e/local-auth/header-profile-link.pw.test.ts
               e2e/local-auth/manage-context-proof.pw.test.ts
-          - name: moderation-star
-            specs: |
-              e2e/local-auth/malicious-skill-ban-flow.pw.test.ts
-              e2e/local-auth/skill-star-sync.pw.test.ts
+          - name: moderation-malicious
+            specs: e2e/local-auth/malicious-skill-ban-flow.pw.test.ts
+          - name: star-sync
+            specs: e2e/local-auth/skill-star-sync.pw.test.ts
           - name: inspector-version
             specs: |
               e2e/local-auth/plugin-inspector-findings.pw.test.ts

--- a/e2e/local-auth/helpers.ts
+++ b/e2e/local-auth/helpers.ts
@@ -571,7 +571,11 @@ export async function publishSkillVersion(
   type PublishState = "duplicate" | "pending" | "private-detail" | "published" | "staged" | "";
   const readPublishState = async (): Promise<PublishState> => {
     if (await hasDuplicateVersionAlert(page, args.version)) return "duplicate";
-    if (detailUrlPattern.test(new URL(page.url()).pathname)) {
+    const pathname = new URL(page.url()).pathname;
+    // Staged publishes redirect to the dashboard as soon as Convex accepts the
+    // upload. Treat that navigation as success instead of waiting and retrying.
+    if (pathname === "/dashboard") return "staged";
+    if (detailUrlPattern.test(pathname)) {
       if (await isPublishedDetailCurrentVersionVisible(page, args)) {
         return "published";
       }

--- a/e2e/local-auth/malicious-skill-ban-flow.pw.test.ts
+++ b/e2e/local-auth/malicious-skill-ban-flow.pw.test.ts
@@ -91,11 +91,6 @@ function withoutExpectedPublishFlowErrors(errors: string[]) {
         error.includes("Function execution timed out (maximum duration: 1s)") &&
         recoverableTimeouts.some((functionName) => error.includes(functionName))
       ) &&
-      !(
-        error.includes("CONVEX A(skills:publishVersion)") &&
-        error.includes("Version ") &&
-        error.includes(" already exists")
-      ) &&
       !(error.includes("CONVEX A(skills:publishVersion)") && error.includes("Unauthorized")) &&
       !(
         error.includes("CONVEX A(skills:publishVersion)") &&

--- a/e2e/local-auth/publish-skill-lifecycle.pw.test.ts
+++ b/e2e/local-auth/publish-skill-lifecycle.pw.test.ts
@@ -159,11 +159,6 @@ async function expectHealthyPublishPage(page: Page, errors: string[]) {
         !(
           error.includes("Function execution timed out (maximum duration: 1s)") &&
           expectedTransientTimeouts.some((functionName) => error.includes(functionName))
-        ) &&
-        !(
-          error.includes("CONVEX A(skills:publishVersion)") &&
-          error.includes("Version ") &&
-          error.includes(" already exists")
         ),
     ),
   );

--- a/scripts/playwright-local-auth-workflow.test.ts
+++ b/scripts/playwright-local-auth-workflow.test.ts
@@ -9,20 +9,33 @@ type WorkflowStep = {
 };
 
 describe("playwright local-auth workflow", () => {
-  it("provides enough CPU for local Convex and reports runner pressure", async () => {
+  it("runs isolated local-auth shards concurrently and reports runner pressure", async () => {
     const workflow = parseYaml(await readFile(".github/workflows/ci.yml", "utf8")) as {
       jobs: {
         "playwright-local-auth-shard": {
           "runs-on": string;
           steps: WorkflowStep[];
-          strategy?: { "max-parallel"?: number };
+          strategy?: {
+            "max-parallel"?: number;
+            matrix?: { include?: Array<{ name?: string; specs?: string }> };
+          };
         };
       };
     };
     const job = workflow.jobs["playwright-local-auth-shard"];
 
     expect(job["runs-on"]).toBe("blacksmith-16vcpu-ubuntu-2404");
-    expect(job.strategy?.["max-parallel"]).toBe(1);
+    expect(job.strategy?.["max-parallel"]).toBe(8);
+    expect(job.strategy?.matrix?.include?.map((entry) => entry.name)).toEqual(
+      expect.arrayContaining(["moderation-malicious", "star-sync"]),
+    );
+    expect(
+      job.strategy?.matrix?.include?.some(
+        (entry) =>
+          entry.specs?.includes("malicious-skill-ban-flow.pw.test.ts") &&
+          entry.specs.includes("skill-star-sync.pw.test.ts"),
+      ),
+    ).toBe(false);
 
     const localAuthStep = job.steps.find((step) => step.name === "Local-auth browser e2e");
     expect(localAuthStep?.run).toContain("/sys/fs/cgroup/cpu.stat");


### PR DESCRIPTION
## Summary
- recognize the staged-publish `/dashboard` redirect immediately instead of waiting 60 seconds and resubmitting
- fail the affected browser flows if duplicate publish errors return
- run the eight isolated local-auth shards concurrently and separate the malicious and star-sync critical paths

## Result
Exact-head CI run: https://github.com/openclaw/clawhub/actions/runs/29557420317

- previous 20-run average: **24m22s**
- exact-head attempt 1: **3m14s** from workflow creation to aggregate completion
- exact-head attempt 2: **2m24s** from rerun start to aggregate completion
- two-run average: **2m49s**
- slowest shard: **3m00s** (`inspector-version`)
- malicious flow: **1m54s** job wall, **51.0s** Playwright test
- star-sync: **1m12s** job wall
- publish-new-version: **1m14s** job wall, **24.4s** Playwright test
- no duplicate-version errors in the affected exact-head job logs

## Validation
- `bunx vitest run scripts/playwright-local-auth-workflow.test.ts scripts/playwright-local-auth-config.test.ts src/__tests__/skills-publish-route.test.tsx`
- `bun run format:check -- .github/workflows/ci.yml e2e/local-auth/helpers.ts e2e/local-auth/malicious-skill-ban-flow.pw.test.ts e2e/local-auth/publish-skill-lifecycle.pw.test.ts scripts/playwright-local-auth-workflow.test.ts`
- `bun run ci:static`
- autoreview: clean, no accepted/actionable findings
- AWS Crabbox `c7a.xlarge` probes confirmed the clean image needs explicit Node/Bun/browser bootstrap; exact Blacksmith CI supplied the authoritative runtime proof

## Unrelated main failure
`pr-gates` currently fails after 4,722 passing tests because Vitest collects `.github/scripts/catalog-feed-schema-version-guard.test.cjs`, which uses the Node test runner and reports `No test suite found`. The same failure reproduces locally from current `main`; it is not caused by this diff.
