### PR TITLE
fix: normalize skill version tags

### DIFF
--- a/convex/lib/skillPublish.test.ts
+++ b/convex/lib/skillPublish.test.ts
@@ -754,7 +754,7 @@ description: Security scanner smoke fixture.
               version: "1.0.0",
               changelog: "Initial release",
               changelogSource: "user",
-              tags: ["latest"],
+              tags: ["latest", "tax", "个体工商户", "_private"],
               files: [],
               parsed: { frontmatter: {}, license: "MIT-0" },
               staticScan: {
@@ -782,12 +782,15 @@ description: Security scanner smoke fixture.
       versionId: "skillVersions:pending",
       embeddingId: "skillEmbeddings:demo",
     });
-    expect(runMutation).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        versionId: "skillVersions:pending",
-      }),
+    const publishPendingCall = runMutation.mock.calls.find(
+      ([, args]) => args.versionId === "skillVersions:pending" && "publishArgs" in args,
     );
+    expect(publishPendingCall?.[1]).toMatchObject({
+      versionId: "skillVersions:pending",
+      publishArgs: {
+        tags: ["latest", "tax"],
+      },
+    });
     expect(runMutation).not.toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({

--- a/convex/lib/skillPublish.ts
+++ b/convex/lib/skillPublish.ts
@@ -41,6 +41,7 @@ import {
 } from "./skills";
 import { assertValidSkillSlug, normalizeSkillSlug } from "./skillSlugValidator";
 import { generateSkillSummary } from "./skillSummary";
+import { normalizeSkillTags } from "./skillTags";
 import { runStaticPublishScan } from "./staticPublishScan";
 import { getWebhookConfig, type WebhookSkillPayload } from "./webhooks";
 
@@ -435,7 +436,7 @@ async function publishVersionForUserInternal(
     changelog: changelogText,
     changelogSource,
     sourceProvenance: options.sourceProvenance,
-    tags: args.tags?.map((tag) => tag.trim()).filter(Boolean),
+    tags: normalizeSkillTags(args.tags),
     categories,
     topics: topics.length ? topics : undefined,
     fingerprint,
@@ -667,8 +668,16 @@ async function prepareSkillInsertArgsForFinalization(
     return rawInsertArgs;
   }
   const insertArgs = rawInsertArgs as Record<string, unknown>;
+  const tags = Array.isArray(insertArgs.tags)
+    ? normalizeSkillTags(insertArgs.tags.filter((tag): tag is string => typeof tag === "string"))
+    : undefined;
   const deferred = insertArgs.deferredAiEnrichment as DeferredAiEnrichment | undefined;
-  if (!deferred) return rawInsertArgs;
+  if (!deferred) {
+    return {
+      ...insertArgs,
+      ...(insertArgs.tags !== undefined ? { tags } : {}),
+    };
+  }
 
   const { deferredAiEnrichment: _deferredAiEnrichment, ...prepared } = insertArgs;
   const files = Array.isArray(prepared.files)
@@ -737,6 +746,7 @@ async function prepareSkillInsertArgsForFinalization(
 
   return {
     ...prepared,
+    ...(prepared.tags !== undefined ? { tags } : {}),
     summary,
     changelog,
     embedding,

--- a/convex/lib/skillTags.test.ts
+++ b/convex/lib/skillTags.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSkillTags } from "./skillTags";
+
+describe("normalizeSkillTags", () => {
+  it("keeps unique Convex-safe tags and drops invalid object keys", () => {
+    expect(
+      normalizeSkillTags([
+        " latest ",
+        "tax",
+        "tax",
+        "个体工商户",
+        "_private",
+        "$system",
+        "line\nbreak",
+        "",
+      ]),
+    ).toEqual(["latest", "tax"]);
+  });
+
+  it("preserves an omitted tag list", () => {
+    expect(normalizeSkillTags(undefined)).toBeUndefined();
+  });
+});

--- a/convex/lib/skillTags.ts
+++ b/convex/lib/skillTags.ts
@@ -1,0 +1,19 @@
+const CONVEX_FIELD_NAME = /^[\x20-\x7e]+$/;
+
+export function normalizeSkillTags(tags: readonly string[] | undefined): string[] | undefined {
+  if (!tags) return undefined;
+
+  return Array.from(
+    new Set(
+      tags
+        .map((tag) => tag.trim())
+        .filter(
+          (tag) =>
+            tag.length > 0 &&
+            !tag.startsWith("$") &&
+            !tag.startsWith("_") &&
+            CONVEX_FIELD_NAME.test(tag),
+        ),
+    ),
+  );
+}

--- a/convex/skills.ts
+++ b/convex/skills.ts
@@ -170,6 +170,7 @@ import {
 } from "./lib/skillSearchDigest";
 import { assertValidSkillSlug, normalizeSkillSlug } from "./lib/skillSlugValidator";
 import { readCanonicalStat } from "./lib/skillStats";
+import { normalizeSkillTags } from "./lib/skillTags";
 import { runStaticPublishScan } from "./lib/staticPublishScan";
 import { adjustUserSkillStatsForSkillChange } from "./lib/userSkillStats";
 import schema from "./schema";
@@ -12672,7 +12673,7 @@ export const insertVersion = internalMutation({
     // comparison above so that backport publishes cannot clobber the latest
     // pointer. Silently drop it (case-insensitively) from caller-provided tags
     // to prevent a trivial bypass via args.tags: ["latest"].
-    for (const tag of args.tags ?? []) {
+    for (const tag of normalizeSkillTags(args.tags) ?? []) {
       if (tag.toLowerCase() === "latest") continue;
       nextTags[tag] = versionId;
     }
@@ -12943,7 +12944,7 @@ export const publishPendingVersionInternal = internalMutation({
     if (isNewLatest) {
       nextTags.latest = version._id;
     }
-    for (const tag of publishArgs.tags ?? []) {
+    for (const tag of normalizeSkillTags(publishArgs.tags) ?? []) {
       if (tag.toLowerCase() === "latest") continue;
       nextTags[tag] = version._id;
     }


### PR DESCRIPTION
## Summary
- normalize user-supplied skill version tags before they become Convex record keys
- drop non-ASCII and reserved-prefix tags while preserving valid ASCII tags
- apply the same boundary to immediate and staged prepublication finalization paths

## Production issue
Scheduled prepublication scans completed successfully, but finalization failed for versions containing tags such as `个体工商户` because Convex record keys must be ASCII and cannot start with `$` or `_`.

## Validation
- `bunx vitest run convex/lib/skillTags.test.ts convex/lib/skillPublish.test.ts`
- `bunx vitest run convex/skills.backportLatest.test.ts convex/lib/skills.test.ts`
- `bun run ci:static`
- `bun run ci:unit`
- `bun run ci:types-build`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
