### PR TITLE
chore: pin clawscan 0.1.5

### DIFF
--- a/.github/workflows/prepublication-publish-checks.yml
+++ b/.github/workflows/prepublication-publish-checks.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Install ClawScan CLI
         run: |
           set -euo pipefail
-          npm install -g @openclaw/clawscan@0.1.4
+          npm install -g @openclaw/clawscan@0.1.5
           clawscan --version
 
       - name: Run pre-publication publish worker

--- a/.github/workflows/security-scan-codex.yml
+++ b/.github/workflows/security-scan-codex.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Install ClawScan CLI
         run: |
           set -euo pipefail
-          npm install -g @openclaw/clawscan@0.1.4
+          npm install -g @openclaw/clawscan@0.1.5
           clawscan --version
 
       - name: Install SkillSpector

--- a/scripts/security/prepublication-worker-workflow.test.ts
+++ b/scripts/security/prepublication-worker-workflow.test.ts
@@ -126,7 +126,7 @@ describe("pre-publication publish worker workflow", () => {
     expect(runStep?.run).not.toContain("--version");
     expect(runStep?.run).not.toContain("--max-jobs");
     expect(steps.find((step) => step.name === "Install ClawScan CLI")?.run).toContain(
-      "npm install -g @openclaw/clawscan@0.1.4",
+      "npm install -g @openclaw/clawscan@0.1.5",
     );
     expect(steps.find((step) => step.name === "Install Codex CLI")?.run).toContain(
       "npm install -g @openai/codex@0.142.3",

--- a/scripts/security/security-scan-worker-workflow.test.ts
+++ b/scripts/security/security-scan-worker-workflow.test.ts
@@ -131,7 +131,7 @@ describe("security-scan-codex workflow", () => {
     const skillspectorInstall = steps.find((step) => step.name === "Install SkillSpector")?.run;
     expect(codexInstall).toContain("npm install -g @openai/codex@0.142.3");
     expect(codexInstall).not.toContain("@latest");
-    expect(clawScanInstall).toContain("npm install -g @openclaw/clawscan@0.1.4");
+    expect(clawScanInstall).toContain("npm install -g @openclaw/clawscan@0.1.5");
     expect(clawScanInstall).not.toContain("@latest");
     expect(skillspectorInstall).toContain("git+https://github.com/NVIDIA/skillspector.git@8f37cfa");
     expect(skillspectorInstall).not.toContain("git+https://github.com/NVIDIA/skillspector.git'");


### PR DESCRIPTION
## Summary
- pin both production ClawScan workflows to `@openclaw/clawscan@0.1.5`
- update workflow contract tests to require the same version

This release tolerates unverifiable extra artifact-inspection path claims while still requiring the exact challenged file, challenge, and SHA-256.

## Validation
- `bun test scripts/security/prepublication-worker-workflow.test.ts scripts/security/security-scan-worker-workflow.test.ts`
- `bun run ci:static`
- autoreview clean
