### PR TITLE
fix: terminate prepublication process trees

### DIFF
--- a/scripts/security/run-prepublication-worker.test.ts
+++ b/scripts/security/run-prepublication-worker.test.ts
@@ -698,6 +698,64 @@ JSON
     }
   });
 
+  it("terminates the full ClawScan process tree on timeout", async () => {
+    const workspace = await tempDir();
+    await mkdir(join(workspace, "artifact"), { recursive: true });
+    await writeFile(join(workspace, "artifact", "SKILL.md"), "# Demo\n");
+    const fakeClawScan = join(workspace, "fake-clawscan");
+    await writeFile(
+      fakeClawScan,
+      `#!/usr/bin/env bash
+set -euo pipefail
+(
+  trap '' TERM
+  exec >/dev/null 2>&1
+  while true; do sleep 1; done
+) &
+child_pid=$!
+printf '%s' "$child_pid" > "${workspace}/descendant.pid"
+wait "$child_pid"
+`,
+    );
+    await chmod(fakeClawScan, 0o755);
+    const previousCommand = process.env.PREPUBLICATION_CLAWSCAN_COMMAND;
+    const previousTimeout = process.env.PREPUBLICATION_CLAWSCAN_TIMEOUT_MS;
+    process.env.PREPUBLICATION_CLAWSCAN_COMMAND = fakeClawScan;
+    process.env.PREPUBLICATION_CLAWSCAN_TIMEOUT_MS = "500";
+
+    try {
+      await expect(
+        runNativeClawScan(
+          {
+            job: {
+              targetKind: "skillVersion",
+            },
+            target: {},
+          } as Parameters<typeof runNativeClawScan>[0],
+          workspace,
+        ),
+      ).rejects.toThrow("timed out");
+
+      const descendantPid = Number(await readFile(join(workspace, "descendant.pid"), "utf8"));
+      let descendantRunning = true;
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        try {
+          process.kill(descendantPid, 0);
+          await new Promise((resolvePromise) => setTimeout(resolvePromise, 25));
+        } catch {
+          descendantRunning = false;
+          break;
+        }
+      }
+      expect(descendantRunning).toBe(false);
+    } finally {
+      if (previousCommand === undefined) delete process.env.PREPUBLICATION_CLAWSCAN_COMMAND;
+      else process.env.PREPUBLICATION_CLAWSCAN_COMMAND = previousCommand;
+      if (previousTimeout === undefined) delete process.env.PREPUBLICATION_CLAWSCAN_TIMEOUT_MS;
+      else process.env.PREPUBLICATION_CLAWSCAN_TIMEOUT_MS = previousTimeout;
+    }
+  });
+
   it("maps TruffleHog verified-secret exit code to a blocked result", async () => {
     const workspace = await tempDir();
     await mkdir(join(workspace, "artifact"), { recursive: true });

--- a/scripts/security/run-prepublication-worker.ts
+++ b/scripts/security/run-prepublication-worker.ts
@@ -257,6 +257,7 @@ async function runCommand(
     (resolvePromise, reject) => {
       const child = spawn(command, args, {
         cwd: options.cwd,
+        detached: process.platform !== "win32",
         env: {
           ...process.env,
           NO_COLOR: "1",
@@ -266,10 +267,23 @@ async function runCommand(
       let stdout = "";
       let stderr = "";
       let timedOut = false;
+      let forceKillTimeout: NodeJS.Timeout | undefined;
+      const killProcessTree = (signal: NodeJS.Signals) => {
+        if (process.platform !== "win32" && child.pid) {
+          try {
+            process.kill(-child.pid, signal);
+            return;
+          } catch {
+            // The process group may already have exited; fall back to the direct child.
+          }
+        }
+        child.kill(signal);
+      };
       const timeout = setTimeout(() => {
         timedOut = true;
-        child.kill("SIGTERM");
-        setTimeout(() => child.kill("SIGKILL"), 10_000).unref();
+        killProcessTree("SIGTERM");
+        forceKillTimeout = setTimeout(() => killProcessTree("SIGKILL"), 10_000);
+        forceKillTimeout.unref();
       }, options.timeoutMs);
       child.stdout.on("data", (chunk) => {
         stdout += String(chunk);
@@ -279,10 +293,14 @@ async function runCommand(
       });
       child.on("error", (error) => {
         clearTimeout(timeout);
+        if (timedOut) killProcessTree("SIGKILL");
+        if (forceKillTimeout) clearTimeout(forceKillTimeout);
         reject(error);
       });
       child.on("close", (code) => {
         clearTimeout(timeout);
+        if (timedOut) killProcessTree("SIGKILL");
+        if (forceKillTimeout) clearTimeout(forceKillTimeout);
         if (timedOut) {
           reject(new Error(`${command} timed out`));
           return;


### PR DESCRIPTION
## Summary
- launch pre-publication scanner commands in their own Unix process groups
- terminate the full process tree on timeout, including descendants that ignore SIGTERM
- add a regression test covering a detached descendant leak

## Validation
- `bun test scripts/security/run-prepublication-worker.test.ts`
- `bun run ci:static`
- `bunx tsc -p packages/schema/tsconfig.json --noEmit`
- `bunx tsc -p packages/clawhub/tsconfig.json --noEmit`
- `.agents/skills/autoreview/scripts/autoreview --mode local`