### PR TITLE
fix: polish browse loading and view controls

### DIFF
--- a/src/__tests__/packages-route.test.tsx
+++ b/src/__tests__/packages-route.test.tsx
@@ -922,6 +922,7 @@ describe("plugins route", () => {
 
     expect(screen.getByRole("heading", { name: "Plugins" })).toBeTruthy();
     expect(screen.getByRole("status", { name: "Loading results" })).toBeTruthy();
+    expect(screen.queryByText("Loading results")).toBeNull();
   });
 
   it("keeps plugin count copy hidden on non-first browse pages", async () => {
@@ -1131,6 +1132,7 @@ describe("plugins route", () => {
     render(<PendingComponent />);
 
     expect(screen.getByRole("status", { name: "Loading results" })).toBeTruthy();
+    expect(screen.queryByText("Loading results")).toBeNull();
     expect(screen.queryByText("Unable to load plugins")).toBeNull();
   });
 

--- a/src/__tests__/ui-design-contract.test.ts
+++ b/src/__tests__/ui-design-contract.test.ts
@@ -168,6 +168,13 @@ describe("restored UI design contract", () => {
     expect(cssRule(css, ".clawhub-segmented")).toContain(
       "border: 1px solid var(--clawhub-segmented-border)",
     );
+    expect(cssRule(css, ".clawhub-segmented")).toContain("border-radius: var(--oc-radius-control)");
+    expect(
+      cssRule(
+        css,
+        ".clawhub-segmented-btn,\n.home-v2-listing-kind-btn,\n.home-v2-listing-view-btn,\n.browse-view-btn",
+      ),
+    ).toContain("border-radius: var(--oc-radius-inset)");
     expect(cssRule(css, ".clawhub-segmented-btn.browse-view-btn")).toContain(
       "width: var(--clawhub-segmented-seg-h)",
     );

--- a/src/routes/plugins/index.tsx
+++ b/src/routes/plugins/index.tsx
@@ -367,9 +367,6 @@ function PluginsIndexPending() {
           disabled
         />
         <div className="browse-results">
-          <div className="browse-results-toolbar">
-            <span className="browse-results-count">Loading results</span>
-          </div>
           <BrowseResultsSkeleton label="Plugin" />
         </div>
       </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -21860,7 +21860,7 @@ a.search-empty-action {
   height: var(--clawhub-segmented-h);
   padding: 3px;
   border: 1px solid var(--clawhub-segmented-border);
-  border-radius: 10px;
+  border-radius: var(--oc-radius-control);
   background: var(--clawhub-segmented-bg);
   transition:
     border-color 0.15s ease,
@@ -21876,7 +21876,7 @@ a.search-empty-action {
   justify-content: center;
   height: var(--clawhub-segmented-seg-h);
   border: none;
-  border-radius: 7px;
+  border-radius: var(--oc-radius-inset);
   background: transparent;
   color: var(--clawhub-segmented-fg);
   font-size: 14px;
@@ -29120,7 +29120,7 @@ a[class*="rounded-full"] {
   height: var(--clawhub-segmented-h);
   padding: 3px;
   border: 1px solid var(--clawhub-segmented-border);
-  border-radius: 10px;
+  border-radius: var(--oc-radius-control);
   background: var(--clawhub-segmented-bg);
 }
 
@@ -29132,7 +29132,7 @@ a[class*="rounded-full"] {
   height: var(--clawhub-segmented-seg-h);
   padding: 0 12px;
   border: none;
-  border-radius: 7px;
+  border-radius: var(--oc-radius-inset);
   background: transparent;
   color: var(--clawhub-segmented-fg);
   font-size: 14px;


### PR DESCRIPTION
## Summary
- use the shared design-system radius tokens for browse segmented controls
- remove the visible `Loading results` copy during skill/plugin tab transitions while preserving the accessible loading status
- add regression coverage for both behaviors

## Validation
- `bun run ci:static`
- `bun run ci:types-build`
- focused Vitest: 86 tests passed
- `CI=1 bun run ci:unit` on Blacksmith Testbox: 368 files passed, 4,726 tests passed, coverage gate passed
- `$autoreview`: clean on two passes

## UI proof
Verified on the real local ClawHub app at `http://localhost:3000` with the local public corpus:
- populated skills and plugins browse pages render category sidebars on desktop
- mobile `390x844` layouts keep categories in the top toolbar and hide the sidebar
- no horizontal overflow or visible `Loading results` copy
- segmented controls resolve to the shared design-system radius tokens

Screenshots are published in the ClawHub UI Proof comment below.
