### PR TITLE
fix: bound package release tag cleanup

### DIFF
--- a/convex/packages.public.test.ts
+++ b/convex/packages.public.test.ts
@@ -40,6 +40,7 @@ import {
   getVersionByName,
   getVersionSecurityByNameForViewerInternal,
   insertReleaseInternal,
+  cleanupReassignedPackageReleaseTagsInternal,
   publishPendingReleaseInternal,
   finalizePackagePublishAttemptInternal,
   findPackagePublishResultInternal,
@@ -280,6 +281,16 @@ const publishPendingReleaseInternalHandler = (
   publishPendingReleaseInternal as unknown as WrappedHandler<
     {
       releaseId: string;
+    },
+    unknown
+  >
+)._handler;
+const cleanupReassignedPackageReleaseTagsInternalHandler = (
+  cleanupReassignedPackageReleaseTagsInternal as unknown as WrappedHandler<
+    {
+      packageId: string;
+      assignments: Array<{ releaseId: string; tags: string[] }>;
+      offset?: number;
     },
     unknown
   >
@@ -1753,9 +1764,31 @@ function makeInsertReleaseCtx(
   recordsById: Record<string, Record<string, unknown>> = {},
   runtimePackages: Array<Record<string, unknown>> = [],
   finalPublisherMembershipRole?: "owner" | "admin" | "publisher" | null,
+  packageReleaseReadLimitBytes?: number,
 ) {
-  const patch = vi.fn();
   let insertedPackage: Record<string, unknown> | null = null;
+  const patch = vi.fn(async (id: string, value: Record<string, unknown>) => {
+    const target =
+      recordsById[id] ??
+      priorReleases.find((release) => release._id === id) ??
+      (existing?._id === id ? existing : null) ??
+      (insertedPackage?._id === id ? insertedPackage : null);
+    if (target) Object.assign(target, value);
+  });
+  const scheduler = {
+    runAfter: vi.fn(),
+  };
+  let packageReleaseBytesRead = 0;
+  const readPackageRelease = (record: Record<string, unknown> | null) => {
+    if (!record || packageReleaseReadLimitBytes === undefined) return record;
+    packageReleaseBytesRead += JSON.stringify(record).length;
+    if (packageReleaseBytesRead > packageReleaseReadLimitBytes) {
+      throw new Error(
+        `Too many bytes read in a single function execution (limit: ${packageReleaseReadLimitBytes} bytes).`,
+      );
+    }
+    return record;
+  };
   const insert = vi.fn(async (table: string, doc: Record<string, unknown>) => {
     if (table === "packages") {
       insertedPackage = makePackageDoc({
@@ -1774,11 +1807,22 @@ function makeInsertReleaseCtx(
   return {
     patch,
     insert,
+    scheduler,
+    resetPackageReleaseReadBudget: () => {
+      packageReleaseBytesRead = 0;
+    },
     db: {
       get: vi.fn(async (id: string) => {
-        if (id in recordsById) return recordsById[id];
+        if (id in recordsById) {
+          return id.startsWith("packageReleases:")
+            ? readPackageRelease(recordsById[id])
+            : recordsById[id];
+        }
         if (id === "packages:new") return insertedPackage;
+        if (existing?._id === id) return existing;
         if (id === "users:owner") return { _id: id, role: "user", trustedPublisher: false };
+        const priorRelease = priorReleases.find((release) => release._id === id);
+        if (priorRelease) return readPackageRelease(priorRelease);
         return null;
       }),
       query: vi.fn((table: string) => {
@@ -1821,7 +1865,17 @@ function makeInsertReleaseCtx(
               ) => {
                 if (indexName === "by_package") {
                   return {
-                    collect: vi.fn().mockResolvedValue(priorReleases),
+                    collect: vi.fn(async () => {
+                      if (
+                        packageReleaseReadLimitBytes !== undefined &&
+                        JSON.stringify(priorReleases).length > packageReleaseReadLimitBytes
+                      ) {
+                        throw new Error(
+                          `Too many bytes read in a single function execution (limit: ${packageReleaseReadLimitBytes} bytes).`,
+                        );
+                      }
+                      return priorReleases;
+                    }),
                   };
                 }
                 if (indexName === "by_package_version") {
@@ -1925,6 +1979,24 @@ function makeInsertReleaseCtx(
       normalizeId: vi.fn(),
     },
   };
+}
+
+async function flushScheduledPackageReleaseTagCleanup(
+  ctx: ReturnType<typeof makeInsertReleaseCtx>,
+) {
+  for (let callIndex = 0; callIndex < ctx.scheduler.runAfter.mock.calls.length; callIndex += 1) {
+    const [, , args] = ctx.scheduler.runAfter.mock.calls[callIndex] as [
+      number,
+      unknown,
+      {
+        packageId: string;
+        assignments: Array<{ releaseId: string; tags: string[] }>;
+        offset?: number;
+      },
+    ];
+    ctx.resetPackageReleaseReadBudget();
+    await cleanupReassignedPackageReleaseTagsInternalHandler(ctx, args);
+  }
 }
 
 function makeReservePackageNameCtx(options?: {
@@ -7176,6 +7248,7 @@ describe("packages public queries", () => {
       pendingPublication: undefined,
       verification: { scanStatus: "clean" },
     });
+    await flushScheduledPackageReleaseTagCleanup(ctx);
     expect(ctx.patch).toHaveBeenCalledWith("packageReleases:old", { distTags: [] });
     expect(ctx.patch).toHaveBeenCalledWith(
       "packages:demo",
@@ -7187,6 +7260,189 @@ describe("packages public queries", () => {
         scanStatus: "clean",
       }),
     );
+  });
+
+  it("publishes a pending release without reading its file-heavy release history", async () => {
+    const priorRelease = makeReleaseDoc({
+      _id: "packageReleases:old",
+      version: "1.0.0",
+      distTags: ["latest"],
+      publicationStatus: "published",
+      extractedPackageJson: {
+        description: "x".repeat(190_000),
+      },
+    });
+    const unrelatedReleases = Array.from({ length: 91 }, (_, index) =>
+      makeReleaseDoc({
+        _id: `packageReleases:history-${index}`,
+        version: `0.0.${index}`,
+        distTags: [],
+        publicationStatus: "published",
+        extractedPackageJson: {
+          description: "x".repeat(190_000),
+        },
+      }),
+    );
+    const pendingRelease = makeReleaseDoc({
+      _id: "packageReleases:pending",
+      version: "2.0.0",
+      publicationStatus: "pending",
+      pendingPublication: {
+        displayName: "Demo Plugin",
+        tags: ["latest"],
+        channel: "community",
+        isOfficial: false,
+      },
+      distTags: ["latest"],
+      summary: "pending summary",
+      changelog: "next",
+      integritySha256: "pending-sha",
+      verification: { scanStatus: "pending" },
+      llmAnalysis: {
+        status: "clean",
+        verdict: "clean",
+        checkedAt: 1_700_000_000_000,
+      },
+    });
+    const existingPackage = makePackageDoc({
+      latestReleaseId: "packageReleases:old",
+      latestVersionSummary: { version: "1.0.0" },
+      tags: { latest: "packageReleases:old" },
+      stats: { downloads: 0, installs: 0, stars: 0, versions: 92 },
+    });
+    const allReleases = [priorRelease, ...unrelatedReleases, pendingRelease];
+    const ctx = makeInsertReleaseCtx(
+      existingPackage,
+      allReleases,
+      {
+        "packageReleases:old": priorRelease,
+        "packageReleases:pending": pendingRelease,
+        "packages:demo": existingPackage,
+      },
+      [],
+      undefined,
+      16 * 1024 * 1024,
+    );
+
+    await expect(
+      publishPendingReleaseInternalHandler(ctx, {
+        releaseId: "packageReleases:pending",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      packageId: "packages:demo",
+      releaseId: "packageReleases:pending",
+    });
+
+    await flushScheduledPackageReleaseTagCleanup(ctx);
+    expect(ctx.patch).toHaveBeenCalledWith("packageReleases:old", { distTags: [] });
+    expect(ctx.patch).toHaveBeenCalledWith(
+      "packages:demo",
+      expect.objectContaining({
+        latestReleaseId: "packageReleases:pending",
+        tags: { latest: "packageReleases:pending" },
+        stats: { downloads: 0, installs: 0, stars: 0, versions: 93 },
+      }),
+    );
+  });
+
+  it("publishes a pending release without hydrating every file-heavy tag owner", async () => {
+    const tagNames = ["latest", ...Array.from({ length: 89 }, (_, index) => `tag-${index}`)];
+    const priorReleases = tagNames.map((tag, index) =>
+      makeReleaseDoc({
+        _id: `packageReleases:old-${index}`,
+        version: `1.0.${index}`,
+        distTags: [tag],
+        publicationStatus: "published",
+        extractedPackageJson: {
+          description: "x".repeat(190_000),
+        },
+      }),
+    );
+    const pendingRelease = makeReleaseDoc({
+      _id: "packageReleases:pending",
+      version: "2.0.0",
+      publicationStatus: "pending",
+      pendingPublication: {
+        displayName: "Demo Plugin",
+        tags: tagNames,
+        channel: "community",
+        isOfficial: false,
+      },
+      distTags: tagNames,
+      summary: "pending summary",
+      changelog: "next",
+      integritySha256: "pending-sha",
+      verification: { scanStatus: "pending" },
+      llmAnalysis: {
+        status: "clean",
+        verdict: "clean",
+        checkedAt: 1_700_000_000_000,
+      },
+    });
+    const packageTags = Object.fromEntries(
+      tagNames.map((tag, index) => [tag, `packageReleases:old-${index}`]),
+    );
+    const existingPackage = makePackageDoc({
+      latestReleaseId: "packageReleases:old-0",
+      latestVersionSummary: { version: "1.0.0" },
+      tags: packageTags,
+      stats: { downloads: 0, installs: 0, stars: 0, versions: priorReleases.length },
+    });
+    const recordsById: Record<string, Record<string, unknown>> = Object.fromEntries(
+      [...priorReleases, pendingRelease].map((release) => [release._id, release]),
+    );
+    recordsById["packages:demo"] = existingPackage;
+    const ctx = makeInsertReleaseCtx(
+      existingPackage,
+      [...priorReleases, pendingRelease],
+      recordsById,
+      [],
+      undefined,
+      16 * 1024 * 1024,
+    );
+
+    await expect(
+      publishPendingReleaseInternalHandler(ctx, {
+        releaseId: "packageReleases:pending",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      packageId: "packages:demo",
+      releaseId: "packageReleases:pending",
+    });
+
+    expect(ctx.scheduler.runAfter).toHaveBeenCalledOnce();
+    expect(ctx.patch).not.toHaveBeenCalledWith(
+      expect.stringMatching(/^packageReleases:old-/),
+      expect.anything(),
+    );
+    await flushScheduledPackageReleaseTagCleanup(ctx);
+    expect(ctx.scheduler.runAfter).toHaveBeenCalledTimes(23);
+    expect(
+      ctx.patch.mock.calls.filter(([id]) => id.startsWith("packageReleases:old-")),
+    ).toHaveLength(90);
+  });
+
+  it("keeps a dist-tag when a later publish moves it back before cleanup runs", async () => {
+    const priorRelease = makeReleaseDoc({
+      _id: "packageReleases:old",
+      distTags: ["latest"],
+      publicationStatus: "published",
+    });
+    const pkg = makePackageDoc({
+      latestReleaseId: "packageReleases:old",
+      tags: { latest: "packageReleases:old" },
+    });
+    const ctx = makeInsertReleaseCtx(pkg, [priorRelease]);
+
+    await cleanupReassignedPackageReleaseTagsInternalHandler(ctx, {
+      packageId: "packages:demo",
+      assignments: [{ releaseId: "packageReleases:old", tags: ["latest"] }],
+    });
+
+    expect(ctx.patch).not.toHaveBeenCalledWith("packageReleases:old", expect.anything());
+    expect(ctx.scheduler.runAfter).not.toHaveBeenCalled();
   });
 
   it("releases release-backed finalization claims when pending promotion fails", async () => {
@@ -8388,6 +8644,7 @@ describe("packages public queries", () => {
       integritySha256: "abc123",
     });
 
+    await flushScheduledPackageReleaseTagCleanup(ctx);
     expect(ctx.patch).toHaveBeenCalledWith("packageReleases:old", {
       distTags: ["stable"],
     });

--- a/convex/packages.ts
+++ b/convex/packages.ts
@@ -137,6 +137,8 @@ const MAX_DIRECT_PACKAGE_SEARCH_CANDIDATES = 20;
 const MAX_DIRECT_PACKAGE_FULL_TEXT_CANDIDATES = 40;
 const MAX_PACKAGE_VERSION_DELETE_LOOKUP_CANDIDATES = 4;
 const MAX_POINTERLESS_RELEASE_SURVIVOR_SCAN = 100;
+// Release rows can approach 1 MiB, and trigger-wrapped patches materialize full documents.
+const PACKAGE_RELEASE_TAG_CLEANUP_BATCH_SIZE = 4;
 const packageListScanStatusValidator = v.union(
   v.literal("clean"),
   v.literal("suspicious"),
@@ -498,6 +500,7 @@ const internalRefs = internal as unknown as {
     claimPackageInspectorScanBatchInternal: unknown;
     ingestPackageInspectorScanResultsInternal: unknown;
     discardPendingPackagePublicationInternal: unknown;
+    cleanupReassignedPackageReleaseTagsInternal: unknown;
     publishPendingReleaseInternal: unknown;
   };
   packageInspectorNode: {
@@ -9391,6 +9394,46 @@ function stringArrayPendingField(metadata: Record<string, unknown>, field: strin
     : undefined;
 }
 
+type PackageReleaseTagCleanupAssignment = {
+  releaseId: Id<"packageReleases">;
+  tags: string[];
+};
+
+function getPackageTagReleaseId(
+  pkg: Pick<Doc<"packages">, "_id" | "latestReleaseId" | "tags">,
+  tag: string,
+) {
+  return tag === "latest" ? (pkg.tags.latest ?? pkg.latestReleaseId) : pkg.tags[tag];
+}
+
+function planPackageReleaseTagReassignment(
+  pkg: Pick<Doc<"packages">, "_id" | "latestReleaseId" | "tags">,
+  releaseId: Id<"packageReleases">,
+  effectiveTags: string[],
+) {
+  const cleanupTagsByRelease = new Map<Id<"packageReleases">, string[]>();
+  const nextTags = { ...pkg.tags };
+
+  for (const tag of new Set(effectiveTags)) {
+    const priorReleaseId = getPackageTagReleaseId(pkg, tag);
+    nextTags[tag] = releaseId;
+    if (priorReleaseId && priorReleaseId !== releaseId) {
+      cleanupTagsByRelease.set(priorReleaseId, [
+        ...(cleanupTagsByRelease.get(priorReleaseId) ?? []),
+        tag,
+      ]);
+    }
+  }
+
+  return {
+    nextTags,
+    cleanupAssignments: [...cleanupTagsByRelease].map(([priorReleaseId, tags]) => ({
+      releaseId: priorReleaseId,
+      tags,
+    })),
+  };
+}
+
 export const discardPendingPackagePublicationInternal = internalMutation({
   args: {
     packageId: v.id("packages"),
@@ -9439,6 +9482,70 @@ export const discardPendingPackagePublicationInternal = internalMutation({
   },
 });
 
+export const cleanupReassignedPackageReleaseTagsInternal = internalMutation({
+  args: {
+    packageId: v.id("packages"),
+    assignments: v.array(
+      v.object({
+        releaseId: v.id("packageReleases"),
+        tags: v.array(v.string()),
+      }),
+    ),
+    offset: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const offset = Math.max(0, Math.floor(args.offset ?? 0));
+    const pkg = await ctx.db.get(args.packageId);
+    if (!pkg) return { cleaned: 0, scheduled: false };
+
+    const batch = args.assignments.slice(offset, offset + PACKAGE_RELEASE_TAG_CLEANUP_BATCH_SIZE);
+    let cleaned = 0;
+    for (const assignment of batch) {
+      const tagsToRemove = assignment.tags.filter(
+        (tag) => getPackageTagReleaseId(pkg, tag) !== assignment.releaseId,
+      );
+      if (tagsToRemove.length === 0) continue;
+
+      const priorRelease = await ctx.db.get(assignment.releaseId);
+      if (
+        !priorRelease ||
+        priorRelease.packageId !== pkg._id ||
+        !isPublishedPackageRelease(priorRelease)
+      ) {
+        continue;
+      }
+      const tagsToRemoveSet = new Set(tagsToRemove);
+      const nextDistTags = (priorRelease.distTags ?? []).filter((tag) => !tagsToRemoveSet.has(tag));
+      if (nextDistTags.length === (priorRelease.distTags ?? []).length) continue;
+      await ctx.db.patch(priorRelease._id, { distTags: nextDistTags });
+      cleaned += 1;
+    }
+
+    const nextOffset = offset + batch.length;
+    const scheduled = nextOffset < args.assignments.length;
+    if (scheduled) {
+      await runAfterRef(ctx, 0, internalRefs.packages.cleanupReassignedPackageReleaseTagsInternal, {
+        packageId: args.packageId,
+        assignments: args.assignments,
+        offset: nextOffset,
+      });
+    }
+    return { cleaned, scheduled };
+  },
+});
+
+async function schedulePackageReleaseTagCleanup(
+  ctx: Pick<MutationCtx, "scheduler">,
+  packageId: Id<"packages">,
+  assignments: PackageReleaseTagCleanupAssignment[],
+) {
+  if (assignments.length === 0) return;
+  await runAfterRef(ctx, 0, internalRefs.packages.cleanupReassignedPackageReleaseTagsInternal, {
+    packageId,
+    assignments,
+  });
+}
+
 export const publishPendingReleaseInternal = internalMutation({
   args: {
     releaseId: v.id("packageReleases"),
@@ -9479,21 +9586,11 @@ export const publishPendingReleaseInternal = internalMutation({
       verification: releaseVerification,
     } as Doc<"packageReleases">;
 
-    const priorReleases = await ctx.db
-      .query("packageReleases")
-      .withIndex("by_package", (q) => q.eq("packageId", pkg._id))
-      .collect();
-
-    const nextTags = { ...pkg.tags };
-    for (const tag of effectiveTags) nextTags[tag] = release._id;
-    for (const priorRelease of priorReleases) {
-      if (priorRelease._id === release._id || !isPublishedPackageRelease(priorRelease)) continue;
-      const nextDistTags = (priorRelease.distTags ?? []).filter(
-        (tag) => !effectiveTags.includes(tag),
-      );
-      if (nextDistTags.length === (priorRelease.distTags ?? []).length) continue;
-      await ctx.db.patch(priorRelease._id, { distTags: nextDistTags });
-    }
+    const { nextTags, cleanupAssignments } = planPackageReleaseTagReassignment(
+      pkg,
+      release._id,
+      effectiveTags,
+    );
 
     await ctx.db.patch(release._id, {
       publicationStatus: "published",
@@ -9541,6 +9638,7 @@ export const publishPendingReleaseInternal = internalMutation({
       stats: { ...pkg.stats, versions: (pkg.stats?.versions ?? 0) + 1 },
       updatedAt: now,
     });
+    await schedulePackageReleaseTagCleanup(ctx, pkg._id, cleanupAssignments);
 
     return {
       ok: true as const,
@@ -9805,13 +9903,6 @@ export const insertReleaseInternal = internalMutation({
         );
       }
     }
-    const priorReleases = existing
-      ? await ctx.db
-          .query("packageReleases")
-          .withIndex("by_package", (q) => q.eq("packageId", existing._id))
-          .collect()
-      : [];
-
     const shouldPromoteLatest = args.tags.includes("latest");
     const effectiveTags = shouldPromoteLatest
       ? Array.from(new Set([...args.tags, "latest"]))
@@ -9883,15 +9974,11 @@ export const insertReleaseInternal = internalMutation({
       };
     }
 
-    const nextTags = { ...pkg.tags };
-    for (const tag of effectiveTags) nextTags[tag] = releaseId;
-    for (const priorRelease of priorReleases) {
-      const nextDistTags = (priorRelease.distTags ?? []).filter(
-        (tag) => !effectiveTags.includes(tag),
-      );
-      if (nextDistTags.length === (priorRelease.distTags ?? []).length) continue;
-      await ctx.db.patch(priorRelease._id, { distTags: nextDistTags });
-    }
+    const { nextTags, cleanupAssignments } = planPackageReleaseTagReassignment(
+      pkg,
+      releaseId,
+      effectiveTags,
+    );
 
     await ctx.db.patch(pkgId, {
       displayName: args.displayName,
@@ -9939,6 +10026,7 @@ export const insertReleaseInternal = internalMutation({
       stats: { ...pkg.stats, versions: (pkg.stats?.versions ?? 0) + 1 },
       updatedAt: now,
     });
+    await schedulePackageReleaseTagCleanup(ctx, pkgId, cleanupAssignments);
 
     return {
       ok: true as const,


### PR DESCRIPTION
## Summary

- remove the unbounded `packageReleases.by_package.collect()` reads from pending package finalization and immediate package insertion
- derive prior dist-tag owners from the package's canonical `tags` map plus the legacy `latestReleaseId` fallback
- publish the release and update package pointers atomically, then clean old release `distTags` in durable batches of four
- recheck the current canonical tag owner before every cleanup so retries and concurrent tag moves cannot strip a tag from its active release

## Root cause

PR #3087 (`b23d10d9`) added full release-history scans while introducing staged package publication. In production, `packages:publishPendingReleaseInternal` hydrated 93 file-heavy release documents and read about 16.95 MB, crossing Convex's 16 MiB per-function limit before the pending release could become published.

The original history scan also existed before the pending early return in `insertReleaseInternal`, which explains the related insertion-limit events. This patch removes both scans.

Fixes #3146.

## Validation

- `bunx vitest run convex/packages.public.test.ts` (295 passed)
- `bunx convex dev --once` against local `anonymous-clawhub` on port 3210
- `bun run ci:static`
- `bun run ci:unit` (4,728 passed, 1 skipped)
- `bun run ci:types-build`
- `bun run ci:packages`
- autoreview clean: no accepted/actionable findings, task `019f713c-cecb-7592-bb03-ac79ffbf21ed`

## Scope

Changed only `convex/packages.ts` and directly related package publish tests. No production data, deployment, moderation state, security-scan implementation, or worker workflow was modified.
